### PR TITLE
feat(orders): line items, totals and the order number

### DIFF
--- a/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
+++ b/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
@@ -61,6 +61,15 @@ export const DETAIL_VIEW_TAB_COMPONENTS: Record<
     })),
 
   // ─────────────────────────────────────────────────────────────────
+  // ORDER TABS — plans/products/08-order-build.md §5.7 (D17: the order gets a
+  // full detail page, the quote shape, not the invoice's drawer-only one).
+  // ─────────────────────────────────────────────────────────────────
+  'order:line-items': () =>
+    import('../money/ui/order/order-line-items-tab').then((m) => ({
+      default: m.OrderLineItemsTab,
+    })),
+
+  // ─────────────────────────────────────────────────────────────────
   // WORK ORDER (job view) TABS — dispatch M2 build spec §F.2
   // ─────────────────────────────────────────────────────────────────
   'work_order:schedule': () =>

--- a/apps/web/src/components/drawers/cards/order-customer-card.tsx
+++ b/apps/web/src/components/drawers/cards/order-customer-card.tsx
@@ -1,0 +1,127 @@
+// apps/web/src/components/drawers/cards/order-customer-card.tsx
+'use client'
+
+import { extractRelationshipRecordIds, primaryValue } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/types/resource'
+import { getInstanceId } from '@auxx/types/resource'
+import { Avatar, AvatarFallback } from '@auxx/ui/components/avatar'
+import { Button } from '@auxx/ui/components/button'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { getFullName, getInitials } from '@auxx/utils'
+import { ExternalLink, Mail, Phone } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useOpenRecord } from '~/components/records/record-drill-panels'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+const CONTACT_ATTRS = ['first_name', 'last_name', 'primary_email', 'phone'] as const
+
+/**
+ * OrderCustomerCard — displays the order's linked contact (the
+ * `ticket-customer-card.tsx` recipe, plans/products/08-order-build.md §5.8). Resolves the
+ * contact via `order_contact`, then fetches individual contact fields via
+ * system attributes.
+ */
+export function OrderCustomerCard({ recordId }: DrawerTabProps) {
+  const { values: orderValues, isLoading: contactLoading } = useSystemValues(
+    recordId,
+    ['order_contact'],
+    { autoFetch: true }
+  )
+
+  const contactRecordIds = extractRelationshipRecordIds(orderValues.order_contact)
+  const contactRecordId = contactRecordIds[0]
+
+  if (contactLoading) {
+    return (
+      <div className='bg-primary-100/50 rounded-2xl border py-2 px-3'>
+        <div className='flex items-center gap-4'>
+          <Skeleton className='size-8 rounded-lg' />
+          <div className='flex flex-col gap-1'>
+            <Skeleton className='h-4 w-32' />
+            <Skeleton className='h-3 w-48' />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!contactRecordId) return null
+
+  return <ContactDetails contactRecordId={contactRecordId} />
+}
+
+/** Inner component — only rendered when contactRecordId is resolved. */
+function ContactDetails({ contactRecordId }: { contactRecordId: RecordId }) {
+  const router = useRouter()
+  const openRecord = useOpenRecord()
+  const { values, isLoading } = useSystemValues(contactRecordId, [...CONTACT_ATTRS], {
+    autoFetch: true,
+  })
+
+  const contactInstanceId = getInstanceId(contactRecordId)
+  const firstNameStr = (primaryValue(values.first_name) as string | null) ?? undefined
+  const lastNameStr = (primaryValue(values.last_name) as string | null) ?? undefined
+  const emailStr = (primaryValue(values.primary_email) as string | null) ?? undefined
+  const phoneStr = (primaryValue(values.phone) as string | null) ?? undefined
+
+  const contactName = {
+    firstName: firstNameStr ?? undefined,
+    lastName: lastNameStr ?? undefined,
+    email: emailStr ?? undefined,
+  }
+
+  return (
+    <div className='group flex items-center justify-between bg-primary-100/50 rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
+      <div className='flex flex-row items-start gap-4'>
+        <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors shrink-0'>
+          <Avatar className='h-7 w-7 rounded-none shadow-none'>
+            <AvatarFallback className='rounded-none bg-transparent'>
+              {isLoading ? '...' : getInitials(contactName)}
+            </AvatarFallback>
+          </Avatar>
+        </div>
+        <div className='flex flex-col'>
+          <div className='text-sm font-medium flex flex-row items-center gap-1'>
+            {isLoading ? (
+              <Skeleton className='h-4 w-24' />
+            ) : (
+              <span>{getFullName(contactName) || 'Unnamed Customer'}</span>
+            )}
+          </div>
+          <div className='text-muted-foreground text-xs'>
+            {isLoading ? (
+              <Skeleton className='h-3 w-40 mt-0.5' />
+            ) : (
+              <div className='flex flex-col gap-0.5'>
+                {emailStr && (
+                  <div className='flex items-center gap-1.5'>
+                    <Mail className='size-3' />
+                    <span>{emailStr}</span>
+                  </div>
+                )}
+                {phoneStr && (
+                  <div className='flex items-center gap-1.5'>
+                    <Phone className='size-3' />
+                    <span>{phoneStr}</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Button
+        variant='ghost'
+        size='icon-sm'
+        onClick={() =>
+          openRecord
+            ? openRecord(contactRecordId)
+            : router.push(`/app/contacts/${contactInstanceId}`)
+        }>
+        <ExternalLink />
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/components/drawers/cards/order-work-orders-card.tsx
+++ b/apps/web/src/components/drawers/cards/order-work-orders-card.tsx
@@ -1,0 +1,41 @@
+// apps/web/src/components/drawers/cards/order-work-orders-card.tsx
+'use client'
+
+// Order drawer overview block for the work orders linked to this order
+// (plans/products/08-order-build.md §5.8). The `order.workOrders` /
+// `work_order.order` pair is the MANUAL link standing in for D4's deferred
+// order → work-order conversion flow, so this block is read-only: there is no
+// "create job from order" action to mirror, unlike the request → quote block
+// this recipe comes from (`service-request-related-cards.tsx`).
+//
+// `order_work_orders` is hidden from the Details field panel
+// (`showInPanel: false`), so this card is where the relation surfaces.
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+import {
+  EmptyRow,
+  RelatedRecordRow,
+  RowSkeleton,
+  TREE_SECONDARY_NOTRUNCATE,
+} from './related-record-row'
+
+export function OrderWorkOrdersCard({ recordId }: DrawerTabProps) {
+  const { values, isLoading } = useSystemValues(recordId, ['order_work_orders'], {
+    autoFetch: true,
+  })
+
+  const workOrderRecordIds = extractRelationshipRecordIds(values.order_work_orders)
+
+  if (isLoading) return <RowSkeleton />
+  if (workOrderRecordIds.length === 0) return <EmptyRow label='No work orders yet' />
+
+  return (
+    <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+      {workOrderRecordIds.map((id) => (
+        <RelatedRecordRow key={id} recordId={id} statusAttr='work_order_status' />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -214,6 +214,20 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     })),
 
   // ─────────────────────────────────────────────────────────────────
+  // ORDER OVERVIEW CARDS (plans/products/08-order-build.md §5.8) — unlike the
+  // invoice, `order` also has a detail page (§5.7, D17); `order:lines` renders
+  // the same component the page's Line-items section does, in `section` variant.
+  // ─────────────────────────────────────────────────────────────────
+  'order:lines': () =>
+    import('../money/ui/order/order-line-items-tab').then((m) => ({
+      default: m.OrderLinesOverviewCard,
+    })),
+  'order:customer': () =>
+    import('./cards/order-customer-card').then((m) => ({ default: m.OrderCustomerCard })),
+  'order:work-orders': () =>
+    import('./cards/order-work-orders-card').then((m) => ({ default: m.OrderWorkOrdersCard })),
+
+  // ─────────────────────────────────────────────────────────────────
   // WORK ORDER (job view) SIDEBAR CARDS — dispatch M2 build spec §F.2, shared
   // with the job view's DetailView sidebar (DetailViewSidebar reads from this
   // same registry, see detail-view-sidebar.tsx).

--- a/apps/web/src/components/money/ui/document-actions-cluster.tsx
+++ b/apps/web/src/components/money/ui/document-actions-cluster.tsx
@@ -109,7 +109,13 @@ export function DocumentSectionActions({
   children,
 }: {
   badge?: ReactNode
-  children: ReactNode
+  /**
+   * Optional: an `order` has a status badge but NO actions cluster — its two
+   * status fields are plain human-set values with no sanctioned transition
+   * behind them, unlike quote's Send/Approve and invoice's Send/Void
+   * (plans/products/08-order-build.md §5.8).
+   */
+  children?: ReactNode
 }) {
   return (
     <>

--- a/apps/web/src/components/money/ui/line-builder/document-knobs.test.ts
+++ b/apps/web/src/components/money/ui/line-builder/document-knobs.test.ts
@@ -1,0 +1,94 @@
+// apps/web/src/components/money/ui/line-builder/document-knobs.test.ts
+//
+// plans/products/08-order-build.md §8: "with `documentType: 'order'`, lines write
+// `line_item_order` and the billing attributes resolve to the `order_*` prefix —
+// NOT `quote_*`. That is the billingPrefix trap, and it is the one UI assertion
+// worth writing before the code."
+//
+// The trap: `billingPrefix` was `documentType === 'invoice' ? 'invoice' : 'quote'`.
+// A two-way ternary has no fourth arm to forget — adding `order` to the union
+// compiles cleanly and silently reads and writes `quote_tax_rate` on every order.
+// Nothing throws; the order just shows another document's totals.
+
+import { describe, expect, it } from 'vitest'
+import { relKeyForDocumentType } from './line-rows'
+import { DOCUMENT_BILLING_ATTRS, DOCUMENT_KNOBS, type DocumentType } from './line-values'
+
+const ALL: DocumentType[] = ['quote', 'invoice', 'order', 'work_order']
+
+describe('the billingPrefix trap', () => {
+  it('order reads and writes order_*, never quote_*', () => {
+    expect(DOCUMENT_KNOBS.order.billingPrefix).toBe('order')
+    expect(DOCUMENT_KNOBS.order.billingPrefix).not.toBe('quote')
+    for (const attr of DOCUMENT_BILLING_ATTRS.order) {
+      expect(attr.startsWith('order_'), `${attr} is not an order_* attribute`).toBe(true)
+    }
+  })
+
+  it('every totalled document has its OWN prefix — no two share one', () => {
+    const totalled = ALL.filter((d) => DOCUMENT_KNOBS[d].hasBilling)
+    const prefixes = totalled.map((d) => DOCUMENT_KNOBS[d].billingPrefix)
+    expect(new Set(prefixes).size).toBe(totalled.length)
+    expect(totalled).toEqual(['quote', 'invoice', 'order'])
+  })
+
+  // Every attribute the builder fetches must belong to the document that fetched
+  // it — the single assertion that makes a mis-keyed row impossible to miss.
+  it.each([
+    'quote',
+    'invoice',
+    'order',
+  ] as const)('%s only ever fetches its own billing attributes', (documentType) => {
+    const prefix = DOCUMENT_KNOBS[documentType].billingPrefix
+    for (const attr of DOCUMENT_BILLING_ATTRS[documentType]) {
+      expect(attr.startsWith(`${prefix}_`)).toBe(true)
+    }
+  })
+
+  // `order_tax_name` was missing from ORDER_FIELDS until migration 109: the builder
+  // writes `${prefix}_tax_name` and `${prefix}_tax_rate` as a PAIR when a preset is
+  // picked, and TotalsFooter matches the stored pair back to decide the selection.
+  it('every totalled document fetches both halves of the tax snapshot', () => {
+    for (const documentType of ['quote', 'invoice', 'order'] as const) {
+      const attrs = DOCUMENT_BILLING_ATTRS[documentType]
+      const prefix = DOCUMENT_KNOBS[documentType].billingPrefix
+      expect(attrs).toContain(`${prefix}_tax_name`)
+      expect(attrs).toContain(`${prefix}_tax_rate`)
+    }
+  })
+
+  it('work_order has no billing at all — it stores no totals', () => {
+    expect(DOCUMENT_KNOBS.work_order.hasBilling).toBe(false)
+    expect(DOCUMENT_BILLING_ATTRS.work_order).toEqual([])
+  })
+})
+
+describe('line stamping', () => {
+  it('an order line is stamped line_item_order', () => {
+    expect(relKeyForDocumentType('order')).toBe('line_item_order')
+  })
+
+  it('every document stamps a DISTINCT relation — a shared one steals lines', () => {
+    const relKeys = ALL.map(relKeyForDocumentType)
+    expect(new Set(relKeys).size).toBe(ALL.length)
+    expect(relKeys).toEqual([
+      'line_item_quote',
+      'line_item_invoice',
+      'line_item_order',
+      'line_item_work_order',
+    ])
+  })
+
+  // The list filter's left side and the create payload's key are the same relation
+  // in two notations; a mismatch shows an empty builder that still saves rows.
+  it('the write key and the read field id name the same relation', () => {
+    for (const documentType of ALL) {
+      const { relKey, relFieldId } = DOCUMENT_KNOBS[documentType]
+      const fromFieldId = relFieldId.replace('line_item:', '')
+      const fromRelKey = relKey
+        .replace('line_item_', '')
+        .replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+      expect(fromRelKey).toBe(fromFieldId)
+    }
+  })
+})

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -120,6 +120,9 @@ import {
 } from './line-rows'
 import {
   BASE_LINE_SYSTEM_ATTRIBUTES,
+  DOCUMENT_BILLING_ATTRS,
+  DOCUMENT_KNOBS,
+  type DocumentType,
   diffLineValues,
   type LinePatch,
   type LineValues,
@@ -136,7 +139,7 @@ import { useLineNav } from './use-line-nav'
 
 export interface LineBuilderProps {
   documentRecordId: string
-  documentType: 'quote' | 'work_order' | 'invoice'
+  documentType: DocumentType
   readOnly?: boolean
   /**
    * Scope the builder to a single visit's occurrence extras (work_order only, money 01-ui #13):
@@ -155,23 +158,6 @@ const INITIAL_DRAFT_COUNT = 3
 const LINE_SORT = [{ id: 'sortOrder', desc: false }]
 /** Every fixed line-builder field is visible to the shared syncer. */
 const LINE_FIELD_VISIBILITY = {}
-
-// Document billing mirrors read once for group set-if-unset checks and `TotalsFooter`.
-// Invoice mode also carries its read-only paid/balance ledger mirrors.
-const QUOTE_BILLING_ATTRS = [
-  'quote_discount_type',
-  'quote_discount_value',
-  'quote_tax_name',
-  'quote_tax_rate',
-]
-const INVOICE_BILLING_ATTRS = [
-  'invoice_discount_type',
-  'invoice_discount_value',
-  'invoice_tax_name',
-  'invoice_tax_rate',
-  'invoice_amount_paid',
-  'invoice_balance',
-]
 
 /** Org tax rate preset (`documents.taxRates` setting, money MQ1 build spec §G.1). */
 interface TaxRatePreset {
@@ -235,12 +221,15 @@ export function LineBuilder({
 
   // work_order (M2 job view) has no billing fields (money MI1 build spec §J.2 precedent,
   // mirrored from TotalsFooter) — group discount/tax set-if-unset skips entirely there.
-  const hasBilling = documentType === 'quote' || documentType === 'invoice'
-  const billingPrefix = documentType === 'invoice' ? 'invoice' : 'quote'
+  // Everything else reads off DOCUMENT_KNOBS; see the warning on that table.
+  const { hasBilling, billingPrefix } = DOCUMENT_KNOBS[documentType]
   const { values: billingValues } = useSystemValues(
     docRecordId,
-    documentType === 'invoice' ? INVOICE_BILLING_ATTRS : QUOTE_BILLING_ATTRS,
-    { autoFetch: hasBilling, enabled: hasBilling }
+    DOCUMENT_BILLING_ATTRS[documentType],
+    {
+      autoFetch: hasBilling,
+      enabled: hasBilling,
+    }
   )
   const taxRates = useMemo(
     () =>
@@ -328,7 +317,9 @@ export function LineBuilder({
     const conditions: ConditionGroup['conditions'] = [
       {
         id: 'line-builder-document',
-        fieldId: documentType === 'quote' ? 'line_item:quote' : 'line_item:workOrder',
+        // The order arm is the plainest of the four: no work-order exclusion
+        // (that invariant is about an invoice's own lines) and no visit split.
+        fieldId: DOCUMENT_KNOBS[documentType].relFieldId,
         operator: 'is',
         value: documentRecordId,
       },
@@ -593,7 +584,12 @@ export function LineBuilder({
         deleteMutateAsync({ recordId: toRecordId(entityDefinitionId, lineId) })
           .then(() => {
             // Deletes don't fire field-change hooks — recompute explicitly (§F.2).
-            if (documentType === 'quote') recomputeMutate({ quoteRecordId: docRecordId })
+            // Every totalled document needs this; work_order stores no totals.
+            // `recordId` (not the legacy `quoteRecordId`) so the router derives
+            // the document type from the def component.
+            if (DOCUMENT_KNOBS[documentType].hasBilling) {
+              recomputeMutate({ recordId: docRecordId })
+            }
           })
           .catch(restoreOnError)
       }

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -75,6 +75,8 @@ import { LinePhotoPopover } from './line-photo-popover'
 import {
   BASE_LINE_SYSTEM_ATTRIBUTES,
   DEFAULT_LINE_VALUES,
+  DOCUMENT_KNOBS,
+  type DocumentType,
   type LinePatch,
   type LineValues,
   lineValuesFromSystemValues,
@@ -158,13 +160,15 @@ export function freshDraft(draftId: string): DraftLine {
   }
 }
 
-/** The document-relationship field a new line_item is stamped with, by document type. */
-export function relKeyForDocumentType(documentType: 'quote' | 'work_order' | 'invoice'): string {
-  return documentType === 'quote'
-    ? 'line_item_quote'
-    : documentType === 'invoice'
-      ? 'line_item_invoice'
-      : 'line_item_work_order'
+/**
+ * The document-relationship field a new line_item is stamped with, by document
+ * type. A lookup rather than a ternary chain: a missing arm here stamps the line
+ * onto the WRONG document instead of failing, and the fourth type
+ * (`order`, plans/products/08-order-build.md §5.6) is exactly the kind of
+ * addition a chain absorbs silently.
+ */
+export function relKeyForDocumentType(documentType: DocumentType): string {
+  return DOCUMENT_KNOBS[documentType].relKey
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1121,7 +1125,7 @@ export function LineRow({
   photosField: ResourceField | null
   readOnly: boolean
   currencyCode: string
-  documentType: 'quote' | 'work_order' | 'invoice'
+  documentType: DocumentType
   catalogItems: CatalogItem[]
   catalogGroups: CatalogGroup[]
   catalogItemMap: Map<string, CatalogItem>
@@ -1259,7 +1263,7 @@ export function DraftLineRow({
   autoFocus: boolean
   categoryOptions: CategoryOption[]
   currencyCode: string
-  documentType: 'quote' | 'work_order' | 'invoice'
+  documentType: DocumentType
   catalogItems: CatalogItem[]
   catalogGroups: CatalogGroup[]
   catalogItemMap: Map<string, CatalogItem>

--- a/apps/web/src/components/money/ui/line-builder/line-values.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-values.ts
@@ -5,6 +5,81 @@ import type { FieldType as FieldTypeValue } from '@auxx/database/types'
 import type { LineItemUnit } from '@auxx/lib/money/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 
+/**
+ * The documents that own line items. Three of them are **totalled**
+ * (`quote`, `invoice`, `order`); `work_order` owns lines but stores no totals
+ * at all, which is why `hasBilling` is a knob rather than a `!== 'work_order'`
+ * check. Declared here — the leaf of the line-builder module graph — so the
+ * builder, the rows and the totals footer share one definition instead of
+ * three hand-copied unions that can drift apart.
+ * See plans/products/08-order-build.md §5.4/§5.6.
+ */
+export type DocumentType = 'quote' | 'work_order' | 'invoice' | 'order'
+
+/**
+ * Per-document knobs, keyed on {@link DocumentType}
+ * (plans/products/08-order-build.md §5.6).
+ *
+ * ⚠️ These are LOOKUPS, not ternaries, and that is the whole point. `billingPrefix`
+ * used to be `documentType === 'invoice' ? 'invoice' : 'quote'` — a two-way
+ * expression that silently mapped `work_order`, and would have mapped `order`, to
+ * the QUOTE prefix. An order reading and writing `quote_tax_rate` is exactly what
+ * that shape produces, so a fourth document type must never be added to a
+ * boolean-shaped expression. `totals-hooks.ts` uses the same shape server-side.
+ *
+ * Defined here, in the leaf of the line-builder module graph, because the builder,
+ * the rows and the totals footer all need them — three hand-copied copies is how
+ * the read prefix and the write prefix drift apart.
+ *
+ * `work_order` (M2 job view) stores no totals at all: its `billingPrefix` is never
+ * read because every use is gated on `hasBilling`.
+ */
+export const DOCUMENT_KNOBS = {
+  quote: {
+    hasBilling: true,
+    billingPrefix: 'quote',
+    relKey: 'line_item_quote',
+    relFieldId: 'line_item:quote',
+  },
+  invoice: {
+    hasBilling: true,
+    billingPrefix: 'invoice',
+    relKey: 'line_item_invoice',
+    relFieldId: 'line_item:invoice',
+  },
+  order: {
+    hasBilling: true,
+    billingPrefix: 'order',
+    relKey: 'line_item_order',
+    relFieldId: 'line_item:order',
+  },
+  work_order: {
+    hasBilling: false,
+    billingPrefix: 'quote',
+    relKey: 'line_item_work_order',
+    relFieldId: 'line_item:workOrder',
+  },
+} as const satisfies Record<
+  DocumentType,
+  { hasBilling: boolean; billingPrefix: string; relKey: string; relFieldId: string }
+>
+
+/** The document billing mirrors read for group set-if-unset checks and `TotalsFooter`. */
+export const DOCUMENT_BILLING_ATTRS: Record<DocumentType, string[]> = {
+  quote: ['quote_discount_type', 'quote_discount_value', 'quote_tax_name', 'quote_tax_rate'],
+  invoice: [
+    'invoice_discount_type',
+    'invoice_discount_value',
+    'invoice_tax_name',
+    'invoice_tax_rate',
+    // Invoice-only: the ledger-sync mirrors (§E.4) — read-only here.
+    'invoice_amount_paid',
+    'invoice_balance',
+  ],
+  order: ['order_discount_type', 'order_discount_value', 'order_tax_name', 'order_tax_rate'],
+  work_order: [],
+}
+
 /** Persisted and draft values edited by one line-builder row. */
 export interface LineValues {
   name: string

--- a/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
+++ b/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
@@ -37,6 +37,7 @@ import {
 } from '~/components/resources/store/field-value-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import type { DraftLine } from './line-rows'
+import { DOCUMENT_KNOBS, type DocumentType } from './line-values'
 import { formatCurrency } from './shared'
 
 /** Org tax rate preset (`documents.taxRates` setting, §G.1). */
@@ -148,7 +149,7 @@ export function TotalsFooter({
   onUpdateDiscount,
   onUpdateTax,
 }: {
-  documentType: 'quote' | 'work_order' | 'invoice'
+  documentType: DocumentType
   readOnly: boolean
   currencyCode: string
   lineRecordIds: RecordId[]
@@ -162,10 +163,13 @@ export function TotalsFooter({
 }) {
   const isQuote = documentType === 'quote'
   const isInvoice = documentType === 'invoice'
-  // Both quote and invoice mirror the same billing shape (discount/tax) onto their own
-  // systemAttribute prefix (money MI1 build spec §J.2) — work_order (M2 job view) has none.
-  const hasBilling = isQuote || isInvoice
-  const prefix = isInvoice ? 'invoice' : 'quote'
+  // All THREE totalled documents mirror the same billing shape (discount/tax) onto their
+  // own systemAttribute prefix (money MI1 build spec §J.2, widened to `order` by
+  // plans/products/08-order-build.md §5.6) — work_order (M2 job view) has none.
+  // Keyed lookups, not `isInvoice ? 'invoice' : 'quote'`: that shape reads an order's
+  // totals off `quote_*` and shows the wrong numbers.
+  const hasBilling = DOCUMENT_KNOBS[documentType].hasBilling
+  const prefix = DOCUMENT_KNOBS[documentType].billingPrefix
   const lines = useLinesForTotals(lineRecordIds, draftLines)
   const [discountDraft, setDiscountDraft] = useState<string | null>(null)
 

--- a/apps/web/src/components/money/ui/order/order-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/order/order-line-items-tab.tsx
@@ -1,0 +1,111 @@
+// apps/web/src/components/money/ui/order/order-line-items-tab.tsx
+'use client'
+
+// The order's line-items surface, in both places an order is opened
+// (plans/products/08-order-build.md §5.7/§5.8). Follows `quote-line-items-tab.tsx`,
+// which is the precedent for an entity that has BOTH a detail page and a drawer:
+//
+//   OrderLineItemsTab      → the detail page's Line-items section
+//                            (DETAIL_VIEW_TAB_COMPONENTS, sections layout)
+//   OrderLinesOverviewCard → the drawer's Overview card, registered `order:lines`
+//
+// Kept in ONE file with two exports rather than the two files §5.8 lists, because
+// the drawer variant is a single prop away from the tab and the quote — the shape
+// §5.7 locked the order to — is written exactly this way.
+//
+// Deliberately thinner than quote and invoice: an order carries NO document
+// actions cluster. Quote has Send / Mark approved / Convert-to-job and invoice has
+// Send / Record payment / Void, and those exist because each has a lifecycle whose
+// transitions carry side effects. `order_financial_status` and
+// `order_fulfillment_status` are plain human-set fields with no sanctioned action
+// behind them (which is also why `order-hooks.ts` registers no lifecycle guard),
+// so there is nothing to teleport into the Section header and no read-only state:
+// an order records what was sold and stays editable.
+
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import type { DetailViewTabProps } from '~/components/detail-view'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { DocumentSectionActions } from '~/components/money/ui/document-actions-cluster'
+import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
+import { useSystemValues } from '~/components/resources/hooks'
+
+const ORDER_STATUS_ATTRS = ['order_financial_status', 'order_fulfillment_status'] as const
+
+/** Financial states worth calling out in the header — `pending` is the default, so it is not. */
+const FINANCIAL_BADGE: Record<string, { label: string; variant: 'green' | 'amber' | 'red' }> = {
+  paid: { label: 'Paid', variant: 'green' },
+  partially_refunded: { label: 'Partially refunded', variant: 'amber' },
+  refunded: { label: 'Refunded', variant: 'red' },
+  voided: { label: 'Voided', variant: 'red' },
+}
+
+/** Fulfillment states worth calling out — `unfulfilled` is the default, so it is not. */
+const FULFILLMENT_BADGE: Record<string, { label: string; variant: 'green' | 'amber' }> = {
+  partial: { label: 'Partially fulfilled', variant: 'amber' },
+  fulfilled: { label: 'Fulfilled', variant: 'green' },
+  restocked: { label: 'Restocked', variant: 'amber' },
+}
+
+export function OrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
+  const { values } = useSystemValues(recordId, [...ORDER_STATUS_ATTRS], { autoFetch: true })
+
+  // SINGLE_SELECT values arrive as arrays — take the first (see the
+  // `use_system_values_single_select_arrays` convention).
+  const financial = firstValue(values.order_financial_status)
+  const fulfillment = firstValue(values.order_fulfillment_status)
+
+  const financialBadge = financial ? FINANCIAL_BADGE[financial] : undefined
+  const fulfillmentBadge = fulfillment ? FULFILLMENT_BADGE[fulfillment] : undefined
+
+  // `variant='section'`: rendered inside a DetailViewSections <Section> on an
+  // outer-owned scroll column instead of a `TabsContent` that grants `h-full`, so
+  // the LineBuilder (a virtualized, scroll-owning table) needs the max-height +
+  // internal-scroll treatment to avoid fighting the outer page.
+  const isSection = variant === 'section'
+
+  return (
+    <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
+      {(financialBadge || fulfillmentBadge) && (
+        <DocumentSectionActions
+          badge={
+            <div className='flex items-center gap-1.5'>
+              {financialBadge && (
+                <Badge variant={financialBadge.variant} size='sm'>
+                  {financialBadge.label}
+                </Badge>
+              )}
+              {fulfillmentBadge && (
+                <Badge variant={fulfillmentBadge.variant} size='sm'>
+                  {fulfillmentBadge.label}
+                </Badge>
+              )}
+            </div>
+          }
+        />
+      )}
+
+      <div className={cn(isSection ? 'max-h-[60vh] overflow-auto ps-3 pe-3' : 'min-h-0 flex-1')}>
+        <LineBuilder documentRecordId={recordId} documentType='order' />
+      </div>
+    </div>
+  )
+}
+
+/** SINGLE_SELECT reads come back as arrays; everything else as a scalar. */
+function firstValue(raw: unknown): string | undefined {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * Drawer Overview card variant — registered as `order:lines` in
+ * `DRAWER_TAB_CARD_COMPONENTS` (the `quote:lines` / `invoice:lines` pattern: the
+ * drawer's Section wrapper renders the "Line items" title). Forces
+ * `variant='section'` so the builder is height-capped inside the Overview scroll
+ * column. The detail page is untouched — it renders {@link OrderLineItemsTab}
+ * through its own `DETAIL_VIEW_TAB_COMPONENTS` registry and sections layout.
+ */
+export function OrderLinesOverviewCard(props: DrawerTabProps) {
+  return <OrderLineItemsTab {...props} variant='section' />
+}

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -233,7 +233,8 @@ export const moneyRouter = createTRPCRouter({
         .object({
           /** @deprecated legacy shape — pass `recordId` instead (quote or invoice). */
           quoteRecordId: recordIdSchema.optional(),
-          /** Quote or invoice RecordId (money MI1 build spec §I.2) — `documentType` is derived
+          /** Quote, invoice or order RecordId (money MI1 build spec §I.2, widened to
+           * `order` by plans/products/08-order-build.md §5.6) — `documentType` is derived
            * from the def component, no separate flag needed. */
           recordId: recordIdSchema.optional(),
         })
@@ -244,7 +245,14 @@ export const moneyRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const targetRecordId = (input.recordId ?? input.quoteRecordId)!
       const { entityDefinitionId, entityInstanceId } = parseRecordId(targetRecordId)
-      const documentType = entityDefinitionId === 'invoice' ? 'invoice' : 'quote'
+      // Membership test, not a two-way ternary: the old
+      // `=== 'invoice' ? 'invoice' : 'quote'` shape would have silently
+      // recomputed an ORDER as a quote, writing quote_* totals onto it
+      // (plans/products/08-order-build.md §5.6, the billingPrefix trap).
+      const documentType =
+        entityDefinitionId === 'invoice' || entityDefinitionId === 'order'
+          ? entityDefinitionId
+          : 'quote'
       return recomputeTotals({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,

--- a/apps/web/src/server/api/routers/ticketSequence.ts
+++ b/apps/web/src/server/api/routers/ticketSequence.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
 
 const scopeSchema = z
-  .enum(['ticket', 'work_order', 'service_request', 'quote', 'invoice'])
+  .enum(['ticket', 'work_order', 'service_request', 'quote', 'invoice', 'order'])
   .default('ticket')
 
 export const ticketSequenceRouter = createTRPCRouter({

--- a/packages/lib/src/events/handlers/finalize-integrity-passes.ts
+++ b/packages/lib/src/events/handlers/finalize-integrity-passes.ts
@@ -273,9 +273,9 @@ async function totalsPass(
     const lineWork: Array<{ lineInstanceId: string; rewriteLineTotal: boolean }> = []
     const parents = new Map<
       string,
-      { documentType: 'quote' | 'invoice'; documentInstanceId: string }
+      { documentType: 'quote' | 'invoice' | 'order'; documentInstanceId: string }
     >()
-    const addParent = (documentType: 'quote' | 'invoice', documentInstanceId: string) =>
+    const addParent = (documentType: 'quote' | 'invoice' | 'order', documentInstanceId: string) =>
       parents.set(`${documentType}:${documentInstanceId}`, { documentType, documentInstanceId })
 
     for (const [rid, touched] of Object.entries(manifest.touched)) {
@@ -304,6 +304,9 @@ async function totalsPass(
           if (hasTrigger(totalsHooks.INVOICE_TRIGGER_ATTRS)) {
             addParent('invoice', entityInstanceId)
           }
+          break
+        case 'order':
+          if (hasTrigger(totalsHooks.ORDER_TRIGGER_ATTRS)) addParent('order', entityInstanceId)
           break
       }
     }

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -32,6 +32,7 @@ import {
 import {
   recomputeOnInvoiceBillingChange,
   recomputeOnLineChange,
+  recomputeOnOrderBillingChange,
   recomputeOnQuoteBillingChange,
 } from '../money/totals-hooks'
 import { derivePhoneGeoOnChange, warmPhoneGeo } from '../phone-geo'
@@ -150,6 +151,7 @@ export function registerAllHooks(): void {
   // 'invoices'.
   registerEntityFieldChangeHooks('line-items', [recomputeOnLineChange, syncBillingOnLineChange])
   registerEntityFieldChangeHooks('quotes', [recomputeOnQuoteBillingChange])
+  registerEntityFieldChangeHooks('orders', [recomputeOnOrderBillingChange])
   //
   // Client-notifications plan §4.3: enroll the seeded `invoice_reminders` sequence on the
   // draft→sent transition (`enrollInvoiceReminderOnSent` checks the PREVIOUS value so a

--- a/packages/lib/src/money/index.ts
+++ b/packages/lib/src/money/index.ts
@@ -177,6 +177,7 @@ export { computeDocumentTotals, computeLineTotal, roundCents } from './totals'
 export {
   recomputeOnInvoiceBillingChange,
   recomputeOnLineChange,
+  recomputeOnOrderBillingChange,
   recomputeOnQuoteBillingChange,
   recomputeTotals,
 } from './totals-hooks'

--- a/packages/lib/src/money/totals-hooks.ts
+++ b/packages/lib/src/money/totals-hooks.ts
@@ -45,6 +45,7 @@ export const LINE_TRIGGER_ATTRS = new Set<SystemAttribute>([
   'line_item_quote',
   'line_item_work_order',
   'line_item_invoice', // attach/detach recomputes the invoice (money MI1 build spec §G.1)
+  'line_item_order', // attach/detach recomputes the order (08 §5.4)
 ])
 
 /** Subset of {@link LINE_TRIGGER_ATTRS} that also requires rewriting `line_item_line_total`. */
@@ -67,14 +68,101 @@ export const INVOICE_TRIGGER_ATTRS = new Set<SystemAttribute>([
   'invoice_tax_rate',
 ])
 
+/** Fields on `orders` whose write should trigger a recompute (08 §5.4). */
+export const ORDER_TRIGGER_ATTRS = new Set<SystemAttribute>([
+  'order_discount_type',
+  'order_discount_value',
+  'order_tax_rate',
+])
+
+/** The three **totalled** money documents. `work_order` owns lines but stores no totals. */
+type TotalledDocumentType = 'quote' | 'invoice' | 'order'
+
 /**
- * Recompute a document's (quote or invoice) `subtotal`/`taxTotal`/`total` from its current
- * lines + billing fields and write the mirrors via `FieldValueService`. The single source of
- * truth for "what are this document's totals right now" — called by both field-change hooks
+ * Per-document knobs for {@link recomputeDocumentTotals} (08 §5.4). Everything else —
+ * the billing read, the line read, `computeDocumentTotals`, the mirror write — is shared,
+ * and the systemAttribute names are all derived from `attrPrefix`.
+ */
+interface DocumentTotalsSpec {
+  /** systemAttribute + field-id prefix: `quote_discount_type`, `quote_subtotal`, … */
+  attrPrefix: TotalledDocumentType
+  /** The line's owning relation, as a resource field id. */
+  lineRelFieldId: string
+  /** Extra conditions ANDed onto the line query. */
+  extraLineConditions: Array<{
+    id: string
+    fieldId: string
+    operator: 'is' | 'empty'
+    value: string | null
+  }>
+  /**
+   * Passed straight through to `setValuesForEntity`. `true` forces a publish (the
+   * builder's totals footer updates via realtime); **`undefined` is not the same as
+   * `false`** — undefined means "publish unless the session is declared silent"
+   * (`field-value-mutations.ts:2667`), which is what the invoice path has always done.
+   */
+  publishEvents?: boolean
+  /** Optional trailing side effect, run after the mirrors are written. */
+  afterWrite?: (params: {
+    organizationId: string
+    userId: string
+    documentInstanceId: string
+    db?: Database
+  }) => Promise<void>
+}
+
+const DOCUMENT_TOTALS_SPECS: Record<TotalledDocumentType, DocumentTotalsSpec> = {
+  quote: {
+    attrPrefix: 'quote',
+    lineRelFieldId: 'line_item:quote',
+    extraLineConditions: [],
+    publishEvents: true,
+  },
+  invoice: {
+    attrPrefix: 'invoice',
+    lineRelFieldId: 'line_item:invoice',
+    // The §B.3 invariant: an invoice's own lines never carry a work order, so a WO
+    // source line stamped with `line_item_invoice` must not contribute twice.
+    extraLineConditions: [
+      {
+        id: 'invoice-lines-workorder',
+        fieldId: 'line_item:workOrder',
+        operator: 'empty',
+        value: null,
+      },
+    ],
+    // Deliberately left undefined — see the field doc above.
+    // A total change can move `balance` and flip `paid` ↔ `partially_paid` even
+    // though no payment was recorded (§E.4).
+    afterWrite: ({ organizationId, userId, documentInstanceId, db }) =>
+      syncInvoicePaymentState({
+        organizationId,
+        userId,
+        invoiceInstanceId: documentInstanceId,
+        db,
+      }),
+  },
+  order: {
+    attrPrefix: 'order',
+    lineRelFieldId: 'line_item:order',
+    // The plainest of the three: no work-order exclusion (that invariant is about an
+    // invoice's own lines) and no payment ledger (08 §5.4).
+    extraLineConditions: [],
+    publishEvents: true,
+  },
+}
+
+/**
+ * Recompute a totalled document's `subtotal`/`taxTotal`/`total` from its current lines +
+ * billing fields and write the mirrors via `FieldValueService`. The single source of truth
+ * for "what are this document's totals right now" — called by both the field-change hooks
  * below and the `money.recomputeTotals` router mutation (delete path + drift escape,
- * §F.2/§G.2). Generalized across document types (money MI1 build spec §G.1) — the legacy
- * `{ quoteInstanceId }` shape (no `documentType`/`documentInstanceId`) is still accepted so
- * existing quote call sites keep compiling unchanged.
+ * §F.2/§G.2).
+ *
+ * Generalized across quote/invoice/order (08 §5.4): the quote and invoice branches were
+ * ~110-line near-duplicates differing in three places, which {@link DOCUMENT_TOTALS_SPECS}
+ * now names explicitly. The legacy `{ quoteInstanceId }` shape (no `documentType`/
+ * `documentInstanceId`) is still accepted so existing quote call sites keep compiling.
  */
 export async function recomputeTotals(
   input: RecomputeTotalsInput & { db?: Database }
@@ -88,171 +176,61 @@ export async function recomputeTotals(
     )
   }
 
-  if (documentType === 'invoice') {
-    await recomputeInvoiceTotals({
-      organizationId,
-      userId,
-      invoiceInstanceId: documentInstanceId,
-      db: input.db,
-    })
-    return
-  }
-
-  await recomputeQuoteTotals({ organizationId, userId, quoteInstanceId: documentInstanceId })
-}
-
-/** Quote branch of {@link recomputeTotals} — the original MQ1 engine, unchanged. */
-async function recomputeQuoteTotals(params: {
-  organizationId: string
-  userId: string
-  quoteInstanceId: string
-}): Promise<void> {
-  const { organizationId, userId, quoteInstanceId } = params
-  const quoteRecordId = toRecordId('quote', quoteInstanceId)
-  const handler = new UnifiedCrudHandler(organizationId, userId)
-  const cache = getOrgCache()
-
-  const cf = await cache
-    .from(organizationId, 'customFields')
-    .bySystemAttributes([
-      'quote_discount_type',
-      'quote_discount_value',
-      'quote_tax_rate',
-      'line_item_line_total',
-      'line_item_taxable',
-      'line_item_optional',
-      'line_item_optional_selected',
-    ] as const)
-
-  const billingFieldIds = [cf.quote_discount_type, cf.quote_discount_value, cf.quote_tax_rate]
-    .filter(Boolean)
-    .map((f) => f!.id)
-  const billingValues = await handler.getFieldValues(quoteRecordId, billingFieldIds)
-
-  const discountTypeTyped = cf.quote_discount_type
-    ? firstTyped(billingValues.get(cf.quote_discount_type.id))
-    : undefined
-  const discountValueTyped = cf.quote_discount_value
-    ? firstTyped(billingValues.get(cf.quote_discount_value.id))
-    : undefined
-  const taxRateTyped = cf.quote_tax_rate
-    ? firstTyped(billingValues.get(cf.quote_tax_rate.id))
-    : undefined
-
-  const billing: DocumentBillingInputs = {
-    discountType: discountTypeTyped ? (extractValue(discountTypeTyped) as DiscountType) : null,
-    discountValue: discountValueTyped ? (extractValue(discountValueTyped) as number) : null,
-    taxRate: taxRateTyped ? (extractValue(taxRateTyped) as number) : null,
-  }
-
-  const { ids: lineInstanceIds } = await handler.listFiltered({
-    entityDefinitionId: 'line_item',
-    filters: [
-      {
-        id: 'quote-lines',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: 'quote-lines-c1',
-            fieldId: 'line_item:quote',
-            operator: 'is',
-            value: quoteRecordId,
-          },
-        ],
-      },
-    ],
-    limit: 1000,
-  })
-
-  const lines: LineForTotals[] = []
-  if (cf.line_item_line_total && cf.line_item_taxable) {
-    const lineTotalFieldId = cf.line_item_line_total.id
-    const taxableFieldId = cf.line_item_taxable.id
-    const optionalFieldId = cf.line_item_optional?.id
-    const optionalSelectedFieldId = cf.line_item_optional_selected?.id
-    for (const lineInstanceId of lineInstanceIds) {
-      const lineRecordId = toRecordId('line_item', lineInstanceId)
-      const fieldIds = [lineTotalFieldId, taxableFieldId, optionalFieldId, optionalSelectedFieldId]
-        .filter(Boolean)
-        .map((id) => id!)
-      const lineValues = await handler.getFieldValues(lineRecordId, fieldIds)
-      const lineTotalTyped = firstTyped(lineValues.get(lineTotalFieldId))
-      const taxableTyped = firstTyped(lineValues.get(taxableFieldId))
-      const optionalTyped = optionalFieldId
-        ? firstTyped(lineValues.get(optionalFieldId))
-        : undefined
-      const optionalSelectedTyped = optionalSelectedFieldId
-        ? firstTyped(lineValues.get(optionalSelectedFieldId))
-        : undefined
-      lines.push({
-        lineTotal: lineTotalTyped ? (extractValue(lineTotalTyped) as number) : null,
-        taxable: taxableTyped ? (extractValue(taxableTyped) as boolean) : true,
-        optional: optionalTyped ? (extractValue(optionalTyped) as boolean) : undefined,
-        optionalSelected: optionalSelectedTyped
-          ? (extractValue(optionalSelectedTyped) as boolean)
-          : undefined,
-      })
-    }
-  }
-
-  const totals = computeDocumentTotals(lines, billing)
-
-  const fieldValueService = new FieldValueService(organizationId, userId)
-  await fieldValueService.setValuesForEntity({
-    recordId: quoteRecordId,
-    values: [
-      { fieldId: 'quote_subtotal', value: totals.subtotal },
-      { fieldId: 'quote_tax_total', value: totals.taxTotal },
-      { fieldId: 'quote_total', value: totals.total },
-    ],
-    publishEvents: true,
+  await recomputeDocumentTotals({
+    organizationId,
+    userId,
+    documentType,
+    documentInstanceId,
+    db: input.db,
   })
 }
 
-/**
- * Invoice branch of {@link recomputeTotals} (money MI1 build spec §G.1) — same shape as
- * {@link recomputeQuoteTotals} over `line_item:invoice is X AND line_item:workOrder is empty`
- * (the §B.3 invariant: an invoice's own lines never carry a work order). Ends by calling
- * `syncInvoicePaymentState` — a total change can move `balance` and flip
- * `paid` ↔ `partially_paid` even though no payment was recorded (§E.4).
- */
-async function recomputeInvoiceTotals(params: {
+/** The one parameterized recompute behind every document type. */
+async function recomputeDocumentTotals(params: {
   organizationId: string
   userId: string
-  invoiceInstanceId: string
+  documentType: TotalledDocumentType
+  documentInstanceId: string
   db?: Database
 }): Promise<void> {
-  const { organizationId, userId, invoiceInstanceId, db } = params
-  const invoiceRecordId = toRecordId('invoice', invoiceInstanceId)
+  const { organizationId, userId, documentType, documentInstanceId, db } = params
+  const spec = DOCUMENT_TOTALS_SPECS[documentType]
+  const documentRecordId = toRecordId(documentType, documentInstanceId)
   const handler = new UnifiedCrudHandler(organizationId, userId, db)
   const cache = getOrgCache()
 
+  const discountTypeAttr = `${spec.attrPrefix}_discount_type` as SystemAttribute
+  const discountValueAttr = `${spec.attrPrefix}_discount_value` as SystemAttribute
+  const taxRateAttr = `${spec.attrPrefix}_tax_rate` as SystemAttribute
+
   const cf = await cache
     .from(organizationId, 'customFields')
-    .bySystemAttributes([
-      'invoice_discount_type',
-      'invoice_discount_value',
-      'invoice_tax_rate',
+    .bySystemAttributes<SystemAttribute>([
+      discountTypeAttr,
+      discountValueAttr,
+      taxRateAttr,
       'line_item_line_total',
       'line_item_taxable',
       'line_item_optional',
       'line_item_optional_selected',
-    ] as const)
+    ])
 
-  const billingFieldIds = [cf.invoice_discount_type, cf.invoice_discount_value, cf.invoice_tax_rate]
+  const discountTypeField = cf[discountTypeAttr]
+  const discountValueField = cf[discountValueAttr]
+  const taxRateField = cf[taxRateAttr]
+
+  const billingFieldIds = [discountTypeField, discountValueField, taxRateField]
     .filter(Boolean)
     .map((f) => f!.id)
-  const billingValues = await handler.getFieldValues(invoiceRecordId, billingFieldIds)
+  const billingValues = await handler.getFieldValues(documentRecordId, billingFieldIds)
 
-  const discountTypeTyped = cf.invoice_discount_type
-    ? firstTyped(billingValues.get(cf.invoice_discount_type.id))
+  const discountTypeTyped = discountTypeField
+    ? firstTyped(billingValues.get(discountTypeField.id))
     : undefined
-  const discountValueTyped = cf.invoice_discount_value
-    ? firstTyped(billingValues.get(cf.invoice_discount_value.id))
+  const discountValueTyped = discountValueField
+    ? firstTyped(billingValues.get(discountValueField.id))
     : undefined
-  const taxRateTyped = cf.invoice_tax_rate
-    ? firstTyped(billingValues.get(cf.invoice_tax_rate.id))
-    : undefined
+  const taxRateTyped = taxRateField ? firstTyped(billingValues.get(taxRateField.id)) : undefined
 
   const billing: DocumentBillingInputs = {
     discountType: discountTypeTyped ? (extractValue(discountTypeTyped) as DiscountType) : null,
@@ -264,21 +242,16 @@ async function recomputeInvoiceTotals(params: {
     entityDefinitionId: 'line_item',
     filters: [
       {
-        id: 'invoice-lines',
+        id: `${documentType}-lines`,
         logicalOperator: 'AND',
         conditions: [
           {
-            id: 'invoice-lines-invoice',
-            fieldId: 'line_item:invoice',
+            id: `${documentType}-lines-parent`,
+            fieldId: spec.lineRelFieldId,
             operator: 'is',
-            value: invoiceRecordId,
+            value: documentRecordId,
           },
-          {
-            id: 'invoice-lines-workorder',
-            fieldId: 'line_item:workOrder',
-            operator: 'empty',
-            value: null,
-          },
+          ...spec.extraLineConditions,
         ],
       },
     ],
@@ -320,15 +293,16 @@ async function recomputeInvoiceTotals(params: {
 
   const fieldValueService = new FieldValueService(organizationId, userId, db)
   await fieldValueService.setValuesForEntity({
-    recordId: invoiceRecordId,
+    recordId: documentRecordId,
     values: [
-      { fieldId: 'invoice_subtotal', value: totals.subtotal },
-      { fieldId: 'invoice_tax_total', value: totals.taxTotal },
-      { fieldId: 'invoice_total', value: totals.total },
+      { fieldId: `${spec.attrPrefix}_subtotal`, value: totals.subtotal },
+      { fieldId: `${spec.attrPrefix}_tax_total`, value: totals.taxTotal },
+      { fieldId: `${spec.attrPrefix}_total`, value: totals.total },
     ],
+    publishEvents: spec.publishEvents,
   })
 
-  await syncInvoicePaymentState({ organizationId, userId, invoiceInstanceId, db })
+  await spec.afterWrite?.({ organizationId, userId, documentInstanceId, db })
 }
 
 /**
@@ -382,14 +356,19 @@ export async function resolveLineParentDocument(params: {
   organizationId: string
   userId: string
   lineInstanceId: string
-}): Promise<{ documentType: 'quote' | 'invoice'; documentInstanceId: string } | null> {
+}): Promise<{ documentType: TotalledDocumentType; documentInstanceId: string } | null> {
   const { organizationId, userId, lineInstanceId } = params
   const lineRecordId = toRecordId('line_item', lineInstanceId)
   const handler = new UnifiedCrudHandler(organizationId, userId)
 
   const cf = await getOrgCache()
     .from(organizationId, 'customFields')
-    .bySystemAttributes(['line_item_quote', 'line_item_invoice', 'line_item_work_order'] as const)
+    .bySystemAttributes([
+      'line_item_quote',
+      'line_item_invoice',
+      'line_item_order',
+      'line_item_work_order',
+    ] as const)
 
   // Resolve the parent quote — work_order lines have no stored totals in MQ1, skip.
   if (cf.line_item_quote) {
@@ -414,6 +393,18 @@ export async function resolveLineParentDocument(params: {
     if (!hasWorkOrder && invoiceTyped?.type === 'relationship' && invoiceTyped.recordId) {
       const { entityInstanceId: invoiceInstanceId } = parseRecordId(invoiceTyped.recordId)
       return { documentType: 'invoice', documentInstanceId: invoiceInstanceId }
+    }
+  }
+
+  // Resolve the parent order (08 §5.4). Last in precedence because it is the newest
+  // slot and the only one a line can hold alongside nothing else — an order line is
+  // never also a quote or invoice line.
+  if (cf.line_item_order) {
+    const orderValues = await handler.getFieldValues(lineRecordId, [cf.line_item_order.id])
+    const orderTyped = firstTyped(orderValues.get(cf.line_item_order.id))
+    if (orderTyped?.type === 'relationship' && orderTyped.recordId) {
+      const { entityInstanceId: orderInstanceId } = parseRecordId(orderTyped.recordId)
+      return { documentType: 'order', documentInstanceId: orderInstanceId }
     }
   }
 
@@ -488,5 +479,23 @@ export const recomputeOnInvoiceBillingChange: EntityFieldChangeHandler = async (
     userId: event.userId,
     documentType: 'invoice',
     documentInstanceId: invoiceInstanceId,
+  })
+}
+
+/**
+ * Recompute hook for `orders` (08 §5.4, registered under the `orders` apiSlug). Fires when
+ * the order's own billing fields change (discount type/value, tax rate) and recomputes +
+ * writes its mirrored totals.
+ */
+export const recomputeOnOrderBillingChange: EntityFieldChangeHandler = async (event) => {
+  const attr = event.field.systemAttribute as SystemAttribute | undefined
+  if (!attr || !ORDER_TRIGGER_ATTRS.has(attr)) return
+
+  const { entityInstanceId: orderInstanceId } = parseRecordId(event.recordId)
+  await recomputeTotals({
+    organizationId: event.organizationId,
+    userId: event.userId,
+    documentType: 'order',
+    documentInstanceId: orderInstanceId,
   })
 }

--- a/packages/lib/src/money/types.ts
+++ b/packages/lib/src/money/types.ts
@@ -76,8 +76,8 @@ export interface ReorderLinesInput extends MoneyMutationInput {
  * compiling unchanged — it's treated as `documentType: 'quote'`.
  */
 export interface RecomputeTotalsInput extends MoneyMutationInput {
-  documentType?: 'quote' | 'invoice'
-  /** EntityInstance id of the quote or invoice (not the RecordId). */
+  documentType?: 'quote' | 'invoice' | 'order'
+  /** EntityInstance id of the quote, invoice or order (not the RecordId). */
   documentInstanceId?: string
   /** @deprecated legacy shape — pass `documentInstanceId` + `documentType: 'quote'` instead. */
   quoteInstanceId?: string

--- a/packages/lib/src/records/record-numbering.ts
+++ b/packages/lib/src/records/record-numbering.ts
@@ -5,7 +5,13 @@ import { and, eq, sql } from 'drizzle-orm'
 import { NotFoundError } from '../errors'
 
 /** Which record kind a `RecordSequence` row counts. */
-export type SequenceScope = 'ticket' | 'work_order' | 'service_request' | 'quote' | 'invoice'
+export type SequenceScope =
+  | 'ticket'
+  | 'work_order'
+  | 'service_request'
+  | 'quote'
+  | 'invoice'
+  | 'order'
 
 const SCOPE_DEFAULTS: Record<SequenceScope, { prefix: string }> = {
   ticket: { prefix: 'TKT' },
@@ -13,6 +19,7 @@ const SCOPE_DEFAULTS: Record<SequenceScope, { prefix: string }> = {
   service_request: { prefix: 'REQ' },
   quote: { prefix: 'QUO' },
   invoice: { prefix: 'INV' },
+  order: { prefix: 'ORD' },
 }
 
 /** Format a record number from a sequence record */

--- a/packages/lib/src/resources/hooks/__tests__/order-hooks.test.ts
+++ b/packages/lib/src/resources/hooks/__tests__/order-hooks.test.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/resources/hooks/__tests__/order-hooks.test.ts
+//
+// The order number was declared in phase 1 (`order_number`, creatable:false /
+// updatable:false, "the hook is the ONLY writer") but the hook itself landed in
+// phase 2 — so for the whole of phase 1 every native order was created with no
+// number at all, and being non-creatable a human could not fill it either.
+// These tests pin the three halves that failure needed: the scope exists, the
+// hook is registered under the entity type, and it only fires on create.
+
+import { describe, expect, it, vi } from 'vitest'
+import type { SystemHookContext } from '../types'
+
+vi.mock('../../../records/record-numbering', () => ({
+  recordNumbering: { create: vi.fn() },
+}))
+
+const { recordNumbering } = await import('../../../records/record-numbering')
+const createMock = vi.mocked(recordNumbering.create)
+
+const { ORDER_HOOKS } = await import('../order-hooks')
+const { getSystemHooks, getHooksForAttribute } = await import('../system-hooks')
+
+const FIELD_ID = 'field-order-number-1'
+
+function buildContext(overrides: Partial<SystemHookContext> = {}): SystemHookContext {
+  return {
+    operation: 'create',
+    entityDef: { id: 'def-order', entityType: 'order' },
+    field: { id: FIELD_ID, type: 'TEXT', systemAttribute: 'order_number' },
+    values: {},
+    organizationId: 'org-1',
+    userId: 'user-1',
+    allFields: [],
+    ...overrides,
+  } as unknown as SystemHookContext
+}
+
+describe('order_number issuance', () => {
+  it('stamps a RecordSequence number on create', async () => {
+    createMock.mockResolvedValue({ recordNumber: 'ORD-0001', sequenceNumber: 1 })
+
+    const values = await ORDER_HOOKS.order_number![0]!(buildContext())
+
+    expect(createMock).toHaveBeenCalledWith('org-1', 'order')
+    expect(values[FIELD_ID]).toBe('ORD-0001')
+  })
+
+  it('does not re-issue on update — the number is stable for the record’s life', async () => {
+    createMock.mockClear()
+
+    const values = await ORDER_HOOKS.order_number![0]!(
+      buildContext({ operation: 'update', values: { other: 1 } })
+    )
+
+    expect(createMock).not.toHaveBeenCalled()
+    expect(values).toEqual({ other: 1 })
+  })
+})
+
+describe('order hook registration', () => {
+  // The miss that made phase 1 ship numberless orders: HOOKS_BY_ENTITY_TYPE is
+  // keyed by EntityDefinition.entityType, and an absent key returns {} silently.
+  it('is reachable through the entity-type registry, not just the module export', () => {
+    expect(getSystemHooks('order')).toBe(ORDER_HOOKS)
+    expect(getHooksForAttribute('order', 'order_number')).toHaveLength(1)
+  })
+
+  it('registers no lifecycle guard — order statuses have no sanctioned action', () => {
+    expect(Object.keys(ORDER_HOOKS)).toEqual(['order_number'])
+  })
+})

--- a/packages/lib/src/resources/hooks/index.ts
+++ b/packages/lib/src/resources/hooks/index.ts
@@ -3,6 +3,7 @@
 export { autoSetCreatedBy, COMMON_HOOKS } from './common-hooks'
 export { CONTACT_HOOKS } from './contact-hooks'
 export { INVOICE_HOOKS } from './invoice-hooks'
+export { ORDER_HOOKS } from './order-hooks'
 export { PAYMENT_HOOKS } from './payment-hooks'
 export { QUOTE_HOOKS } from './quote-hooks'
 export { SERVICE_REQUEST_HOOKS } from './service-request-hooks'

--- a/packages/lib/src/resources/hooks/order-hooks.ts
+++ b/packages/lib/src/resources/hooks/order-hooks.ts
@@ -1,0 +1,31 @@
+// packages/lib/src/resources/hooks/order-hooks.ts
+
+import { recordNumbering } from '../../records/record-numbering'
+import type { SystemHook, SystemHookRegistry } from './types'
+
+/**
+ * Auto-generate the order number on create. Mirrors autoGenerateInvoiceNumber.
+ * order_number has creatable:false/updatable:false, so this hook is the ONLY writer
+ * (plans/products/08-order-build.md §5.3/§5.5).
+ */
+const autoGenerateOrderNumber: SystemHook = async ({
+  operation,
+  field,
+  values,
+  organizationId,
+}) => {
+  if (operation !== 'create') return values
+  const { recordNumber } = await recordNumbering.create(organizationId, 'order')
+  return { ...values, [field.id]: recordNumber }
+}
+
+/**
+ * `order` has no lifecycle guard. Unlike quote and invoice, neither
+ * `order_financial_status` nor `order_fulfillment_status` has a sanctioned
+ * action that carries side effects — both are plain human-set fields on a
+ * document that records what already happened, so there is nothing a manual
+ * write would skip.
+ */
+export const ORDER_HOOKS: SystemHookRegistry = {
+  order_number: [autoGenerateOrderNumber],
+}

--- a/packages/lib/src/resources/hooks/system-hooks.ts
+++ b/packages/lib/src/resources/hooks/system-hooks.ts
@@ -3,6 +3,7 @@
 import { COMMON_HOOKS } from './common-hooks'
 import { CONTACT_HOOKS } from './contact-hooks'
 import { INVOICE_HOOKS } from './invoice-hooks'
+import { ORDER_HOOKS } from './order-hooks'
 import { PAYMENT_HOOKS } from './payment-hooks'
 import { QUOTE_HOOKS } from './quote-hooks'
 import { SERVICE_REQUEST_HOOKS } from './service-request-hooks'
@@ -27,6 +28,7 @@ const HOOKS_BY_ENTITY_TYPE: Record<string, SystemHookRegistry> = {
   quote: QUOTE_HOOKS,
   invoice: INVOICE_HOOKS,
   payment: PAYMENT_HOOKS,
+  order: ORDER_HOOKS,
 }
 
 /**

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -176,7 +176,11 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // link that stands in for the deferred order→work_order conversion.
     sidebarCards: [
       { value: 'customer', label: 'Customer' },
-      { value: 'jobs', label: 'Jobs', recordResource: 'work_order' },
+      // `work-orders`, not the quote's `jobs`: DetailViewSidebar and the drawer read
+      // the SAME `DRAWER_TAB_CARD_COMPONENTS` registry, so this value is the card key
+      // and must match `order:work-orders` there and in the order's drawer block.
+      // "Jobs" is dispatch vocabulary; an order links work orders (08 §5.8).
+      { value: 'work-orders', label: 'Work orders', recordResource: 'work_order' },
     ],
   },
 

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -211,6 +211,33 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       ],
     },
   },
+
+  // The third totalled money document (plans/products/08-order-build.md §5.8).
+  // Unlike invoice this is NOT a drawer-only entity — `order` has
+  // `hasDetailPage: true` (§5.7, D17), so these Overview cards and the detail
+  // page's own sections are independent lists rendering the same components.
+  //
+  // Two cards, not §5.8's three: there is no separate `totals` card because the
+  // LineBuilder's own `TotalsFooter` already renders subtotal/discount/tax/total
+  // at the foot of the lines card — exactly as it does for quote and invoice,
+  // neither of which carries a totals card either. A third card would be a
+  // second, competing rendering of the same three mirrored fields.
+  order: {
+    entityType: 'order',
+    additionalTabs: [],
+    tabCards: {
+      overview: [
+        {
+          value: 'lines',
+          label: 'Line items',
+          fullBleed: true,
+          permissionKey: 'dispatch.board.view',
+        },
+        { value: 'customer', label: 'Customer' },
+        { value: 'work-orders', label: 'Work orders', recordResource: 'work_order' },
+      ],
+    },
+  },
 }
 
 /**

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -469,6 +469,73 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     description: 'Parent invoice relation for invoice-owned snapshot lines only',
   },
 
+  // The fourth document slot (plans/products/08-order-build.md §2). Sort keys
+  // `b10`/`b11` sit between `invoice` (`b1`) and `photos` (`b1a`) so the four
+  // document relations stay adjacent in the panel.
+  order: {
+    id: toFieldId('order'),
+    key: 'order',
+    label: 'Order',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'line_item_order',
+    systemSortOrder: 'b10',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'order:lineItems' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'order',
+      relationshipType: 'belongs_to',
+      inverseName: 'Line Items',
+      inverseSystemAttribute: 'order_line_items',
+    },
+    description: 'Order this line belongs to',
+  },
+
+  part: {
+    id: toFieldId('part'),
+    key: 'part',
+    label: 'Part',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'line_item_part',
+    systemSortOrder: 'b11',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'part:lineItems' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'part',
+      relationshipType: 'belongs_to',
+      inverseName: 'Line Items',
+      inverseSystemAttribute: 'part_line_items',
+    },
+    description:
+      'Part this line sells — STAMPED at write from the line\u2019s catalog item, not hand-set (08 \u00a76.2). ' +
+      'Provenance and grouping only, never a pricing input: `catalogItem` wins for pricing.',
+  },
+
   photos: {
     id: toFieldId('photos'),
     key: 'photos',

--- a/packages/lib/src/resources/registry/resources/order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/order-fields.ts
@@ -400,6 +400,35 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
     },
   },
 
+  // The tax-preset snapshot's NAME, beside `taxRate`'s number. 08 §2's field
+  // table omitted it, but the shared `LineBuilder` writes `${prefix}_tax_name`
+  // and `${prefix}_tax_rate` together when a preset is picked
+  // (`line-builder.tsx` updateTax) and `TotalsFooter` matches the stored pair
+  // back to a preset to decide which option is selected — with only the rate,
+  // an order can never show a named tax and always reads as "Custom".
+  // `quote_tax_name` / `invoice_tax_name` are the precedent.
+  taxName: {
+    id: toFieldId('taxName'),
+    key: 'taxName',
+    label: 'Tax Name',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'order_tax_name',
+    systemSortOrder: 'aE1',
+    showInPanel: false, // shown in the line-items overview card
+    showInTable: false,
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: "Snapshot of the picked tax rate's name (documents.taxRates)",
+  },
+
   taxRate: {
     id: toFieldId('taxRate'),
     key: 'taxRate',

--- a/packages/lib/src/resources/registry/resources/part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/part-fields.ts
@@ -567,6 +567,36 @@ export const PART_FIELDS: Record<string, ResourceField> = {
     description: 'Catalog (product/service) entries backed by this part',
   },
 
+  // Reverse relationship: lineItems (one-to-many from line_item.part). The
+  // counterpart of the STAMPED `line_item_part`
+  // (plans/products/08-order-build.md §6.2) — this is what makes revenue by
+  // part a single join instead of the three-hop
+  // line -> catalog_item -> part -> product chain.
+  lineItems: {
+    id: toFieldId('lineItems'),
+    key: 'lineItems',
+    label: 'Line Items',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'part_line_items',
+    systemSortOrder: 'a9b',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'line_item:part' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description: 'Sold lines stamped with this part',
+  },
+
   // Optional place in a product family (plans/products/01-product-family.md §5).
   // The only family edge: connectors and humans write the same relation.
   product: {

--- a/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
@@ -19,6 +19,11 @@ import { FieldType, ModelTypeMeta, ModelTypeValues } from '@auxx/database/enums'
 import { isSystemAttribute } from '@auxx/types/system-attribute'
 import { describe, expect, it } from 'vitest'
 import {
+  LINE_TOTAL_TRIGGER_ATTRS,
+  LINE_TRIGGER_ATTRS,
+  ORDER_TRIGGER_ATTRS,
+} from '../../../money/totals-hooks'
+import {
   OrderChannel,
   OrderFinancialStatus,
   OrderFulfillmentStatus,
@@ -26,8 +31,11 @@ import {
 import { RESOURCE_FIELD_REGISTRY } from '../../../resources/registry/field-registry'
 import { COMPANY_FIELDS } from '../../../resources/registry/resources/company-fields'
 import { CONTACT_FIELDS } from '../../../resources/registry/resources/contact-fields'
+import { INVOICE_FIELDS } from '../../../resources/registry/resources/invoice-fields'
+import { LINE_ITEM_FIELDS } from '../../../resources/registry/resources/line-item-fields'
 import { ORDER_FIELDS } from '../../../resources/registry/resources/order-fields'
 import { PART_FIELDS } from '../../../resources/registry/resources/part-fields'
+import { QUOTE_FIELDS } from '../../../resources/registry/resources/quote-fields'
 import { WORK_ORDER_FIELDS } from '../../../resources/registry/resources/work-order-fields'
 import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
 import { DISPLAY_FIELD_CONFIG, SYSTEM_ENTITIES } from '../../entity-seeder/constants'
@@ -75,6 +83,7 @@ describe('order entity registration wiring', () => {
       'shippingAddress',
       'subtotal',
       'tags',
+      'taxName', // added by migration 109 — the LineBuilder writes it with taxRate
       'taxRate',
       'taxTotal',
       'total',
@@ -278,17 +287,146 @@ describe('relationship pairs', () => {
     expect(WORK_ORDER_FIELDS.order?.systemAttribute).toBe('work_order_order')
     expect(WORK_ORDER_FIELDS.order?.nullable).toBe(true)
   })
+})
 
-  // The counterpart `line_item.order` lands with the money phase (08 §7 phase 2).
-  // Declaring the reference now is deliberate: `linkNewRelationships` only writes
-  // `inverseResourceFieldId` when it is null, so that migration links both
-  // directions without re-work here.
-  it('order.lineItems names the phase-2 counterpart it will link against', () => {
-    expect(ORDER_FIELDS.lineItems?.relationship).toMatchObject({
-      inverseResourceFieldId: 'line_item:order',
+describe('the two new line_item slots', () => {
+  it('every new systemAttribute is in the SystemAttribute union', () => {
+    for (const attr of ['line_item_order', 'line_item_part', 'part_line_items']) {
+      expect(isSystemAttribute(attr), `'${attr}' missing from @auxx/types/system-attribute`).toBe(
+        true
+      )
+    }
+  })
+
+  it('line_item.order ↔ order.lineItems point at each other', () => {
+    expect(LINE_ITEM_FIELDS.order?.systemAttribute).toBe('line_item_order')
+    expect(LINE_ITEM_FIELDS.order?.fieldType).toBe(FieldType.RELATIONSHIP)
+    expect(LINE_ITEM_FIELDS.order?.relationship).toMatchObject({
+      inverseResourceFieldId: 'order:lineItems',
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    })
+    // This is the half 107 left dangling — it only links once the line above exists.
+    expect(ORDER_FIELDS.lineItems?.relationship?.inverseResourceFieldId).toBe('line_item:order')
+  })
+
+  it('line_item.part ↔ part.lineItems point at each other', () => {
+    expect(LINE_ITEM_FIELDS.part?.systemAttribute).toBe('line_item_part')
+    expect(LINE_ITEM_FIELDS.part?.relationship).toMatchObject({
+      inverseResourceFieldId: 'part:lineItems',
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    })
+    expect(PART_FIELDS.lineItems?.systemAttribute).toBe('part_line_items')
+    expect(PART_FIELDS.lineItems?.relationship).toMatchObject({
+      inverseResourceFieldId: 'line_item:part',
       relationshipType: 'has_many',
       isInverse: true,
     })
-    expect(ORDER_FIELDS.lineItems?.systemAttribute).toBe('order_line_items')
+  })
+
+  // `linkNewRelationships` splits the reference on ':' and looks the prefix up in
+  // the entityDefIds map, so the prefix must be an entityType, not an apiSlug.
+  it('names its counterparts by entityType, not apiSlug', () => {
+    const refs = [
+      LINE_ITEM_FIELDS.order!.relationship!.inverseResourceFieldId,
+      LINE_ITEM_FIELDS.part!.relationship!.inverseResourceFieldId,
+      PART_FIELDS.lineItems!.relationship!.inverseResourceFieldId,
+      ORDER_FIELDS.lineItems!.relationship!.inverseResourceFieldId,
+    ] as string[]
+    expect(refs.map((r) => r.split(':')[0])).toEqual(['order', 'part', 'line_item', 'line_item'])
+  })
+
+  it('the four document slots carry distinct, ordered sort keys', () => {
+    const keys = (['quote', 'workOrder', 'invoice', 'order'] as const).map(
+      (k) => LINE_ITEM_FIELDS[k]!.systemSortOrder!
+    )
+    expect(new Set(keys).size).toBe(4)
+    expect([...keys].sort()).toEqual(keys)
+  })
+})
+
+describe('totals trigger vocabulary', () => {
+  it('ORDER_TRIGGER_ATTRS is the order’s own billing fields', () => {
+    expect([...ORDER_TRIGGER_ATTRS].sort()).toEqual([
+      'order_discount_type',
+      'order_discount_value',
+      'order_tax_rate',
+    ])
+  })
+
+  it('attaching a line to an order recomputes that order', () => {
+    expect(LINE_TRIGGER_ATTRS.has('line_item_order')).toBe(true)
+  })
+
+  // 08 §2 said to add BOTH new rels here. `line_item_part` is deliberately left
+  // out: §6.2 is explicit that part is provenance and grouping, never a pricing
+  // input, so it cannot move a total. Including it would make phase 4’s stamp
+  // hook trigger a full document recompute on every line it touches, for a
+  // number that cannot have changed.
+  it('stamping a part does NOT recompute — part is not a pricing input', () => {
+    expect(LINE_TRIGGER_ATTRS.has('line_item_part')).toBe(false)
+  })
+
+  it('no trigger attr is one the engine itself writes — that would recurse', () => {
+    for (const written of [
+      'line_item_line_total',
+      'order_subtotal',
+      'order_tax_total',
+      'order_total',
+    ]) {
+      expect(LINE_TRIGGER_ATTRS.has(written as never)).toBe(false)
+      expect(ORDER_TRIGGER_ATTRS.has(written as never)).toBe(false)
+    }
+    // qty/unitPrice are the only two that also rewrite the line's own total.
+    expect([...LINE_TOTAL_TRIGGER_ATTRS].sort()).toEqual(['line_item_qty', 'line_item_unit_price'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// order.taxName — folded into 108 rather than given its own id. The "a change
+// needs a NEW migration id" rule in 08 §7.1 is about migration 107, which is
+// MERGED and already `applied` across 28 orgs: editing it would silently skip
+// every environment that already ran it. 108 is unmerged and has never reached
+// a deployed environment, so it is still free to change — `run-migration-108.ts`
+// re-applies it on dev, idempotently.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('order.taxName', () => {
+  it('is a TEXT field on the SystemAttribute union', () => {
+    expect(ORDER_FIELDS.taxName?.systemAttribute).toBe('order_tax_name')
+    expect(ORDER_FIELDS.taxName?.fieldType).toBe(FieldType.TEXT)
+    expect(isSystemAttribute('order_tax_name')).toBe(true)
+  })
+
+  it('is writable — the line builder sets it when a tax preset is picked', () => {
+    expect(ORDER_FIELDS.taxName?.capabilities?.creatable).toBe(true)
+    expect(ORDER_FIELDS.taxName?.capabilities?.updatable).toBe(true)
+  })
+
+  // The real invariant: the shared `LineBuilder.updateTax` writes
+  // `${prefix}_tax_name` AND `${prefix}_tax_rate` together, and `TotalsFooter`
+  // matches the stored pair back against `documents.taxRates` to decide which
+  // preset is selected. A document with the rate and no name always reads back
+  // as "Custom" and silently drops half of every write.
+  it('every totalled document carries BOTH halves of the tax snapshot', () => {
+    const documents = [
+      { name: 'quote', fields: QUOTE_FIELDS, prefix: 'quote' },
+      { name: 'invoice', fields: INVOICE_FIELDS, prefix: 'invoice' },
+      { name: 'order', fields: ORDER_FIELDS, prefix: 'order' },
+    ]
+    for (const { name, fields, prefix } of documents) {
+      const attrs = Object.values(fields).map((f) => f.systemAttribute)
+      expect(attrs, `${name} is missing ${prefix}_tax_name`).toContain(`${prefix}_tax_name`)
+      expect(attrs, `${name} is missing ${prefix}_tax_rate`).toContain(`${prefix}_tax_rate`)
+    }
+  })
+
+  it('sorts next to taxRate rather than at the end of the panel', () => {
+    const taxName = ORDER_FIELDS.taxName?.systemSortOrder ?? ''
+    const taxRate = ORDER_FIELDS.taxRate?.systemSortOrder ?? ''
+    const discountValue = ORDER_FIELDS.discountValue?.systemSortOrder ?? ''
+    expect(discountValue < taxName).toBe(true)
+    expect(taxName < taxRate).toBe(true)
   })
 })

--- a/packages/lib/src/seed/entity-migrations/migrations/107-order.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/107-order.ts
@@ -7,7 +7,9 @@ import type { FieldOptions } from '../../../custom-fields'
 import type { ResourceField } from '../../../resources/registry/field-types'
 import { COMPANY_FIELDS } from '../../../resources/registry/resources/company-fields'
 import { CONTACT_FIELDS } from '../../../resources/registry/resources/contact-fields'
+import { LINE_ITEM_FIELDS } from '../../../resources/registry/resources/line-item-fields'
 import { ORDER_FIELDS } from '../../../resources/registry/resources/order-fields'
+import { PART_FIELDS } from '../../../resources/registry/resources/part-fields'
 import { WORK_ORDER_FIELDS } from '../../../resources/registry/resources/work-order-fields'
 import { SystemUserService } from '../../../users/system-user-service'
 import { DEFAULT_VIEW_CONFIGS } from '../../default-view-configs'
@@ -154,10 +156,17 @@ async function renameIncumbentOrdersAside(
  *   order.workOrders    has_many   → work_order  (`order_work_orders`,  isInverse)
  *   work_order.order    belongs_to → order       (`work_order_order`,   nullable)
  *
- * `order.lineItems` (`order_line_items`) is created here but stays UNLINKED:
- * its counterpart `line_item.order` lands with the money phase (08 §7 phase 2).
- * `linkNewRelationships` only writes `inverseResourceFieldId` when it is null,
- * so the later migration links both directions without re-work.
+ *   line_item.order    belongs_to → order   (`line_item_order`)
+ *   order.lineItems     has_many   → line_item (`order_line_items`, isInverse)
+ *   line_item.part      belongs_to → part    (`line_item_part`)
+ *   part.lineItems      has_many   → line_item (`part_line_items`, isInverse)
+ *
+ * The last four landed with the money phase (08 §7 phase 2) and were folded back
+ * in here rather than given their own migration id: 107 has only ever run on one
+ * local dev database, so there is no environment holding a half-applied order.
+ * The "a change needs a NEW id" rule in 08 §7.1 applies once a migration has
+ * reached a deployed org — until then `run-migration-107.ts` re-applies it
+ * idempotently, which is what the local ledger's `applied` row requires.
  *
  * Step 0 renames an incumbent template-installed `orders` def aside — see
  * {@link renameIncumbentOrdersAside}. It runs BEFORE `loadExistingState`, and
@@ -201,7 +210,7 @@ export const migration107Order: EntityMigration = {
 
     // Pull the edge targets into the id map so linkNewRelationships can resolve
     // both directions of each pair.
-    for (const type of ['contact', 'company', 'work_order'] as const) {
+    for (const type of ['contact', 'company', 'work_order', 'line_item', 'part'] as const) {
       const def = existing.entityDefs.get(type)
       if (def) entityDefIds.set(type, def.id)
     }
@@ -271,6 +280,49 @@ export const migration107Order: EntityMigration = {
           'work_order',
           workOrderDefId,
           { order: WORK_ORDER_FIELDS.order! },
+          existing,
+          state
+        )
+      )
+    }
+
+    // The `line_item_order` / `line_item_part` owning halves and the
+    // `part_line_items` inverse. `order.lineItems` (`order_line_items`) is
+    // created by the ORDER_FIELDS pass above, and `linkNewRelationships` only
+    // writes `inverseResourceFieldId` when it is currently null — so both
+    // directions of both pairs resolve in the single pass below.
+    //
+    // `line_item_part` is STAMPED, not hand-set (08 §6.2): the
+    // resolve-from-catalog-item hook and the backfill over existing lines are
+    // phase 4, so the field is empty until then.
+    const lineItemDefId = entityDefIds.get('line_item')
+    const partDefId = entityDefIds.get('part')
+    if (lineItemDefId) {
+      // `part` is only offered when the org has a `part` def — creating it
+      // without one would leave a permanently dangling relationship field.
+      const lineItemFields: Record<string, ResourceField> = { order: LINE_ITEM_FIELDS.order! }
+      if (partDefId) lineItemFields.part = LINE_ITEM_FIELDS.part!
+      merge(
+        await ensureCustomFields(
+          db,
+          organizationId,
+          'line_item',
+          lineItemDefId,
+          lineItemFields,
+          existing,
+          state
+        )
+      )
+    }
+
+    if (partDefId && lineItemDefId) {
+      merge(
+        await ensureCustomFields(
+          db,
+          organizationId,
+          'part',
+          partDefId,
+          { lineItems: PART_FIELDS.lineItems! },
           existing,
           state
         )

--- a/packages/lib/src/seed/organization-seeder.ts
+++ b/packages/lib/src/seed/organization-seeder.ts
@@ -97,6 +97,17 @@ const defaultRecordSequences = [
     separator: '-',
     useSuffix: false,
   },
+  {
+    scope: 'order',
+    prefix: 'ORD',
+    currentNumber: 0,
+    paddingLength: 4,
+    usePrefix: true,
+    useDateInPrefix: false,
+    dateFormat: 'YYMM',
+    separator: '-',
+    useSuffix: false,
+  },
 ]
 // Default email templates for the organization
 const defaultEmailTemplates = [

--- a/packages/lib/src/workflows/__tests__/bundled-template-entity-refs.test.ts
+++ b/packages/lib/src/workflows/__tests__/bundled-template-entity-refs.test.ts
@@ -1,0 +1,107 @@
+// packages/lib/src/workflows/__tests__/bundled-template-entity-refs.test.ts
+//
+// The guard that was missing. `templates/order.json` was retired when the native
+// `order` system entity shipped (plans/products/08-order-build.md §3.5), and the
+// eight ENTITY templates that referenced it were rewritten in the same PR — but the
+// bundled WORKFLOW templates were never audited. `order-issue-triage` kept declaring
+// `entityTemplateId: "order"`, so `getEntityTemplateById('order')` returned undefined,
+// `resolveEntityRefsInGraph` never built a ref for it, and the template installed with
+// the literal string `@entity:orders` sitting in three nodes' `resourceType`.
+//
+// Nothing failed. That is the point: an unresolvable entity ref is silent — the
+// installer logs a debug line and moves on. These tests turn it into a red build.
+//
+// `entity-templates/template-registry.test.ts` is the same idea for the other half.
+
+import { describe, expect, it } from 'vitest'
+import { getTemplateById as getEntityTemplateById } from '../../entity-templates/template-registry'
+import type { WorkflowGraph } from '../template-graph-transformer'
+import { type RequiredEntity, resolveEntityRefsInGraph } from '../template-resolution'
+import { FILE_TEMPLATE_ID_PREFIX, FILE_TEMPLATES } from '../templates'
+
+/** Every bundled template paired with its declared entity requirements. */
+const TEMPLATES = FILE_TEMPLATES.map((t) => ({
+  slug: t.id.replace(FILE_TEMPLATE_ID_PREFIX, ''),
+  requiredEntities: (t.requiredEntities ?? []) as RequiredEntity[],
+  graph: t.graph as WorkflowGraph,
+}))
+
+/** Synthetic, deterministic ids — resolution only cares that a mapping exists. */
+function buildMaps(requiredEntities: RequiredEntity[]) {
+  const entityIdMap: Record<string, string> = {}
+  const fieldIdMap: Record<string, Record<string, string>> = {}
+  for (const req of requiredEntities) {
+    entityIdMap[req.entityTemplateId] = `def_${req.apiSlug}`
+    fieldIdMap[req.entityTemplateId] = Object.fromEntries(
+      Object.keys(req.fieldMapping).map((ref) => [ref, `fld_${req.apiSlug}_${ref}`])
+    )
+  }
+  return { entityIdMap, fieldIdMap }
+}
+
+describe('bundled workflow templates — declared entities', () => {
+  it.each(TEMPLATES)('$slug: every custom entityTemplateId resolves', ({ requiredEntities }) => {
+    const custom = requiredEntities.filter((r) => !r.entityTemplateId.startsWith('__system:'))
+    for (const req of custom) {
+      expect(
+        getEntityTemplateById(req.entityTemplateId),
+        `entityTemplateId '${req.entityTemplateId}' is not a registered entity template — ` +
+          'it was probably retired. A workflow template that names a dead template resolves ' +
+          'nothing and installs with its @entity: placeholders intact.'
+      ).toBeTruthy()
+    }
+  })
+
+  it.each(TEMPLATES)('$slug: a custom entity declares the apiSlug it actually has', ({
+    requiredEntities,
+  }) => {
+    for (const req of requiredEntities.filter((r) => !r.entityTemplateId.startsWith('__system:'))) {
+      const template = getEntityTemplateById(req.entityTemplateId)
+      expect(req.apiSlug).toBe(template?.entity.apiSlug)
+    }
+  })
+})
+
+describe('bundled workflow templates — graph refs resolve', () => {
+  // The end-to-end check: run the real resolver over each bundled graph and assert
+  // nothing is left behind. This is what would have caught @entity:orders.
+  it.each(TEMPLATES)('$slug: no @entity: placeholder survives resolution', ({
+    requiredEntities,
+    graph,
+  }) => {
+    const clone = structuredClone(graph)
+    const { entityIdMap, fieldIdMap } = buildMaps(requiredEntities)
+
+    const { unresolvedNodes } = resolveEntityRefsInGraph(
+      clone,
+      requiredEntities,
+      entityIdMap,
+      fieldIdMap
+    )
+
+    // `$comment` lives on the node wrapper, not inside `data`, and the resolver only
+    // walks `data` — so serializing just the data is what the installed graph sees.
+    const serialized = JSON.stringify(clone.nodes.map((n: { data: unknown }) => n.data))
+    expect(serialized).not.toContain('@entity:')
+    expect(unresolvedNodes).toEqual([])
+  })
+
+  it.each(TEMPLATES)('$slug: every @field: ref is declared in a fieldMapping', ({
+    requiredEntities,
+    graph,
+  }) => {
+    const declared = new Set(requiredEntities.flatMap((r) => Object.keys(r.fieldMapping)))
+    const refs = new Set(
+      Array.from(
+        JSON.stringify(graph.nodes.map((n: { data: unknown }) => n.data)).matchAll(
+          /@field:([A-Za-z_]\w*)/g
+        )
+      ).map((m) => m[1]!)
+    )
+    const undeclared = [...refs].filter((r) => !declared.has(r))
+    expect(
+      undeclared,
+      'a @field: ref with no fieldMapping entry is left verbatim in the installed graph'
+    ).toEqual([])
+  })
+})

--- a/packages/lib/src/workflows/__tests__/template-resolution.test.ts
+++ b/packages/lib/src/workflows/__tests__/template-resolution.test.ts
@@ -12,18 +12,34 @@ import {
   resolveEntityRefsInGraph,
 } from '../template-resolution'
 
-const ORDER_DEF_ID = 'ent_orders_cuid'
+const DEAL_DEF_ID = 'ent_deals_cuid'
+const DEAL_NAME_FIELD_ID = 'fld_deal_name_cuid'
+const ORDER_DEF_ID = 'ent_order_cuid'
 const ORDER_NUMBER_FIELD_ID = 'fld_order_number_cuid'
 const CONTACT_EMAIL_FIELD_ID = 'fld_primary_email_cuid'
 
-/** `order` is a real built-in entity template (apiSlug `orders`). */
+/**
+ * Two resolution branches, deliberately both represented.
+ *
+ * `deal` is a real built-in entity template (apiSlug `deals`) and carries the
+ * **custom** branch: `getEntityTemplateById` → `entity.apiSlug` builds the ref
+ * key, and the ref resolves to the entity-definition **CUID**.
+ *
+ * `contact` and `order` are **system** entities. `template-resolution.ts:393`
+ * resolves those to the bare entityType string, never a CUID — so a system
+ * entity cannot stand in for the custom branch. `order` used to be a custom
+ * template here (`templates/order.json`, apiSlug `orders`); that template was
+ * retired when the native order shipped
+ * (plans/products/08-order-build.md §3.5), so it moved to `__system:order`
+ * and `deal` took over the CUID coverage.
+ */
 const REQUIRED_ENTITIES: RequiredEntity[] = [
   {
-    entityTemplateId: 'order',
-    name: 'Order',
-    apiSlug: 'orders',
-    fieldMapping: { orderNumber: 'orderNumber' },
-    requiredFields: ['orderNumber'],
+    entityTemplateId: 'deal',
+    name: 'Deal',
+    apiSlug: 'deals',
+    fieldMapping: { dealName: 'dealName' },
+    requiredFields: ['dealName'],
     required: true,
   },
   {
@@ -34,16 +50,26 @@ const REQUIRED_ENTITIES: RequiredEntity[] = [
     requiredFields: ['primary_email'],
     required: true,
   },
+  {
+    entityTemplateId: '__system:order',
+    name: 'Order',
+    apiSlug: 'order',
+    fieldMapping: { order_number: 'order_number' },
+    requiredFields: ['order_number'],
+    required: true,
+  },
 ]
 
 const ENTITY_ID_MAP: Record<string, string> = {
-  order: ORDER_DEF_ID,
+  deal: DEAL_DEF_ID,
   '__system:contact': 'ent_contact_cuid',
+  '__system:order': ORDER_DEF_ID,
 }
 
 const FIELD_ID_MAP: Record<string, Record<string, string>> = {
-  order: { orderNumber: ORDER_NUMBER_FIELD_ID },
+  deal: { dealName: DEAL_NAME_FIELD_ID },
   '__system:contact': { primary_email: CONTACT_EMAIL_FIELD_ID },
+  '__system:order': { order_number: ORDER_NUMBER_FIELD_ID },
 }
 
 function resolve(graph: WorkflowGraph) {
@@ -55,16 +81,16 @@ function node(id: string, data: Record<string, any>): WorkflowGraph['nodes'][num
   return { id, type: 'standard', position: { x: 0, y: 0 }, data: { id, ...data } }
 }
 
-/** A find node on the `orders` entity, used as the referenced node in variable paths. */
-function findOrderNode(id = 'find-order') {
-  return node(id, { type: 'find', resourceType: '@entity:orders', findMode: 'findOne' })
+/** A find node on the `deals` entity, used as the referenced node in variable paths. */
+function findDealNode(id = 'find-deal') {
+  return node(id, { type: 'find', resourceType: '@entity:deals', findMode: 'findOne' })
 }
 
 describe('resolveEntityRefsInGraph — config pass (existing behaviour)', () => {
   it('rewrites resourceType for custom and system entities', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        node('crud-1', { type: 'crud', resourceType: '@entity:orders', mode: 'create' }),
+        node('crud-1', { type: 'crud', resourceType: '@entity:deals', mode: 'create' }),
         node('crud-2', { type: 'crud', resourceType: '@entity:contact', mode: 'create' }),
       ],
       edges: [],
@@ -72,9 +98,67 @@ describe('resolveEntityRefsInGraph — config pass (existing behaviour)', () => 
 
     const { unresolvedNodes } = resolve(graph)
 
-    expect(graph.nodes[0]?.data.resourceType).toBe(ORDER_DEF_ID)
+    expect(graph.nodes[0]?.data.resourceType).toBe(DEAL_DEF_ID)
     expect(graph.nodes[1]?.data.resourceType).toBe('contact')
     expect(unresolvedNodes).toEqual([])
+  })
+
+  // The binding `order-issue-triage.template.json` uses since the native order
+  // shipped. It is NOT the custom-entity path above: `template-resolution.ts:393`
+  // sends a `__system:` templateId to the bare entityType string, so an order node
+  // resolves to `'order'` and never to `ORDER_DEF_ID`. Pinned because the template
+  // previously bound to a retired entity template at apiSlug `orders`, which
+  // silently resolved to nothing and left `@entity:orders` in the installed graph.
+  it('sends a system order to its entityType, not to an entity-definition CUID', () => {
+    const graph: WorkflowGraph = {
+      nodes: [
+        node('find-order-009', {
+          type: 'find',
+          resourceType: '@entity:order',
+          findMode: 'findOne',
+          conditionGroups: [
+            {
+              id: 'g1',
+              conditions: [
+                { id: 'c1', fieldId: '@field:order_number', operator: 'is', value: 'x' },
+              ],
+            },
+          ],
+        }),
+      ],
+      edges: [],
+    }
+
+    const { unresolvedNodes } = resolve(graph)
+
+    expect(graph.nodes[0]?.data.resourceType).toBe('order')
+    expect(graph.nodes[0]?.data.resourceType).not.toBe(ORDER_DEF_ID)
+    expect(graph.nodes[0]?.data.conditionGroups[0].conditions[0].fieldId).toBe(
+      `${ORDER_DEF_ID}:${ORDER_NUMBER_FIELD_ID}`
+    )
+    expect(unresolvedNodes).toEqual([])
+  })
+
+  it('rewrites a system order @field: dictionary key to the field id', () => {
+    const graph: WorkflowGraph = {
+      nodes: [
+        node('create-order-011', {
+          type: 'crud',
+          resourceType: '@entity:order',
+          mode: 'create',
+          data: { '@field:order_number': 'x', '@field:order_contact': '{{find-contact.contact}}' },
+        }),
+      ],
+      edges: [],
+    }
+
+    resolve(graph)
+
+    const data = graph.nodes[0]?.data.data
+    // order_number is in the fixture's fieldMapping; order_contact is not, so it
+    // stays verbatim — an unmapped @field: is left alone rather than dropped.
+    expect(data[ORDER_NUMBER_FIELD_ID]).toBe('x')
+    expect(data['@field:order_contact']).toBe('{{find-contact.contact}}')
   })
 
   it('rewrites @field: dictionary keys and leaves values alone', () => {
@@ -82,12 +166,12 @@ describe('resolveEntityRefsInGraph — config pass (existing behaviour)', () => 
       nodes: [
         node('crud-1', {
           type: 'crud',
-          resourceType: '@entity:orders',
+          resourceType: '@entity:deals',
           mode: 'create',
-          data: { '@field:orderNumber': '{{extractor-1.extracted_data.orderNumber}}' },
-          fieldModes: { '@field:orderNumber': false },
-          fieldUpdateModes: { '@field:orderNumber': 'replace' },
-          fieldUpdateModeVars: { '@field:orderNumber': '{{env.MODE}}' },
+          data: { '@field:dealName': '{{extractor-1.extracted_data.orderNumber}}' },
+          fieldModes: { '@field:dealName': false },
+          fieldUpdateModes: { '@field:dealName': 'replace' },
+          fieldUpdateModeVars: { '@field:dealName': '{{env.MODE}}' },
         }),
       ],
       edges: [],
@@ -97,11 +181,11 @@ describe('resolveEntityRefsInGraph — config pass (existing behaviour)', () => 
     const data = graph.nodes[0]?.data as Record<string, any>
 
     expect(data.data).toEqual({
-      [ORDER_NUMBER_FIELD_ID]: '{{extractor-1.extracted_data.orderNumber}}',
+      [DEAL_NAME_FIELD_ID]: '{{extractor-1.extracted_data.orderNumber}}',
     })
-    expect(data.fieldModes).toEqual({ [ORDER_NUMBER_FIELD_ID]: false })
-    expect(data.fieldUpdateModes).toEqual({ [ORDER_NUMBER_FIELD_ID]: 'replace' })
-    expect(data.fieldUpdateModeVars).toEqual({ [ORDER_NUMBER_FIELD_ID]: '{{env.MODE}}' })
+    expect(data.fieldModes).toEqual({ [DEAL_NAME_FIELD_ID]: false })
+    expect(data.fieldUpdateModes).toEqual({ [DEAL_NAME_FIELD_ID]: 'replace' })
+    expect(data.fieldUpdateModeVars).toEqual({ [DEAL_NAME_FIELD_ID]: '{{env.MODE}}' })
   })
 
   it('rewrites find conditionGroups fieldId to the compound entityDefId:fieldId form', () => {
@@ -109,12 +193,12 @@ describe('resolveEntityRefsInGraph — config pass (existing behaviour)', () => 
       nodes: [
         node('find-1', {
           type: 'find',
-          resourceType: '@entity:orders',
+          resourceType: '@entity:deals',
           findMode: 'findOne',
           conditionGroups: [
             {
               id: 'g1',
-              conditions: [{ id: 'c1', fieldId: '@field:orderNumber', operator: 'is', value: 'x' }],
+              conditions: [{ id: 'c1', fieldId: '@field:dealName', operator: 'is', value: 'x' }],
             },
           ],
         }),
@@ -125,13 +209,13 @@ describe('resolveEntityRefsInGraph — config pass (existing behaviour)', () => 
     resolve(graph)
 
     expect(graph.nodes[0]?.data.conditionGroups[0].conditions[0].fieldId).toBe(
-      `${ORDER_DEF_ID}:${ORDER_NUMBER_FIELD_ID}`
+      `${DEAL_DEF_ID}:${DEAL_NAME_FIELD_ID}`
     )
   })
 
   it('blanks resourceType and reports the node when the entity is not installed', () => {
     const graph: WorkflowGraph = {
-      nodes: [node('crud-1', { type: 'crud', resourceType: '@entity:orders', mode: 'create' })],
+      nodes: [node('crud-1', { type: 'crud', resourceType: '@entity:deals', mode: 'create' })],
       edges: [],
     }
 
@@ -146,12 +230,12 @@ describe('resolveEntityRefsInGraph — @entity: inside {{…}}', () => {
   it('resolves the CUID a findOne on a custom entity keys its output by', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        findOrderNode(),
+        findDealNode(),
         node('crud-1', {
           type: 'crud',
-          resourceType: '@entity:orders',
+          resourceType: '@entity:deals',
           mode: 'update',
-          resourceId: '{{find-order.@entity:orders}}',
+          resourceId: '{{find-deal.@entity:deals}}',
         }),
       ],
       edges: [],
@@ -159,7 +243,7 @@ describe('resolveEntityRefsInGraph — @entity: inside {{…}}', () => {
 
     const { unresolvedNodes } = resolve(graph)
 
-    expect(graph.nodes[1]?.data.resourceId).toBe(`{{find-order.${ORDER_DEF_ID}}}`)
+    expect(graph.nodes[1]?.data.resourceId).toBe(`{{find-deal.${DEAL_DEF_ID}}}`)
     expect(unresolvedNodes).toEqual([])
   })
 
@@ -262,20 +346,20 @@ describe('resolveEntityRefsInGraph — @entity: inside {{…}}', () => {
     ],
   ])('resolves inside %s', (_label, _type, build) => {
     const graph: WorkflowGraph = {
-      nodes: [findOrderNode(), node('target', build('{{find-order.@entity:orders}}'))],
+      nodes: [findDealNode(), node('target', build('{{find-deal.@entity:deals}}'))],
       edges: [],
     }
 
     resolve(graph)
 
-    expect(JSON.stringify(graph.nodes[1]?.data)).toContain(`{{find-order.${ORDER_DEF_ID}}}`)
-    expect(JSON.stringify(graph.nodes[1]?.data)).not.toContain('@entity:orders')
+    expect(JSON.stringify(graph.nodes[1]?.data)).toContain(`{{find-deal.${DEAL_DEF_ID}}}`)
+    expect(JSON.stringify(graph.nodes[1]?.data)).not.toContain('@entity:deals')
   })
 
   it('resolves a bare Tiptap variable-node id inside an ai prompt', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        findOrderNode(),
+        findDealNode(),
         node('ai-1', {
           type: 'ai',
           prompt_template: [
@@ -290,7 +374,7 @@ describe('resolveEntityRefsInGraph — @entity: inside {{…}}', () => {
                       { type: 'text', text: 'Order record: ' },
                       {
                         type: 'variable-node',
-                        attrs: { variableId: 'find-order.@entity:orders.@field:orderNumber' },
+                        attrs: { variableId: 'find-deal.@entity:deals.@field:dealName' },
                       },
                     ],
                   },
@@ -306,14 +390,14 @@ describe('resolveEntityRefsInGraph — @entity: inside {{…}}', () => {
     const { unresolvedNodes } = resolve(graph)
     const chip = graph.nodes[1]?.data.prompt_template[0].json.content[0].content[1]
 
-    expect(chip.attrs.variableId).toBe(`find-order.${ORDER_DEF_ID}.${ORDER_NUMBER_FIELD_ID}`)
+    expect(chip.attrs.variableId).toBe(`find-deal.${DEAL_DEF_ID}.${DEAL_NAME_FIELD_ID}`)
     expect(unresolvedNodes).toEqual([])
   })
 
   it('resolves several placeholders in one string', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        findOrderNode(),
+        findDealNode(),
         node('find-contact', {
           type: 'find',
           resourceType: '@entity:contact',
@@ -321,7 +405,7 @@ describe('resolveEntityRefsInGraph — @entity: inside {{…}}', () => {
         }),
         node('answer-1', {
           type: 'answer',
-          text: 'Order {{find-order.@entity:orders}} for {{find-contact.@entity:contact}}',
+          text: 'Deal {{find-deal.@entity:deals}} for {{find-contact.@entity:contact}}',
         }),
       ],
       edges: [],
@@ -330,7 +414,7 @@ describe('resolveEntityRefsInGraph — @entity: inside {{…}}', () => {
     resolve(graph)
 
     expect(graph.nodes[2]?.data.text).toBe(
-      `Order {{find-order.${ORDER_DEF_ID}}} for {{find-contact.contact}}`
+      `Deal {{find-deal.${DEAL_DEF_ID}}} for {{find-contact.contact}}`
     )
   })
 })
@@ -339,10 +423,10 @@ describe('resolveEntityRefsInGraph — @field: inside {{…}}', () => {
   it('resolves against the preceding @entity: token in the same path', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        findOrderNode(),
+        findDealNode(),
         node('answer-1', {
           type: 'answer',
-          text: '{{find-order.@entity:orders.@field:orderNumber}}',
+          text: '{{find-deal.@entity:deals.@field:dealName}}',
         }),
       ],
       edges: [],
@@ -350,18 +434,16 @@ describe('resolveEntityRefsInGraph — @field: inside {{…}}', () => {
 
     resolve(graph)
 
-    expect(graph.nodes[1]?.data.text).toBe(
-      `{{find-order.${ORDER_DEF_ID}.${ORDER_NUMBER_FIELD_ID}}}`
-    )
+    expect(graph.nodes[1]?.data.text).toBe(`{{find-deal.${DEAL_DEF_ID}.${DEAL_NAME_FIELD_ID}}}`)
   })
 
   it('falls back to the entity of the node the path starts at (findMany plural form)', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        node('find-order', { type: 'find', resourceType: '@entity:orders', findMode: 'findMany' }),
+        node('find-deal', { type: 'find', resourceType: '@entity:deals', findMode: 'findMany' }),
         node('answer-1', {
           type: 'answer',
-          text: '{{find-order.orders[0].@field:orderNumber}}',
+          text: '{{find-deal.deals[0].@field:dealName}}',
         }),
       ],
       edges: [],
@@ -369,7 +451,7 @@ describe('resolveEntityRefsInGraph — @field: inside {{…}}', () => {
 
     const { unresolvedNodes } = resolve(graph)
 
-    expect(graph.nodes[1]?.data.text).toBe(`{{find-order.orders[0].${ORDER_NUMBER_FIELD_ID}}}`)
+    expect(graph.nodes[1]?.data.text).toBe(`{{find-deal.deals[0].${DEAL_NAME_FIELD_ID}}}`)
     expect(unresolvedNodes).toEqual([])
   })
 
@@ -377,14 +459,14 @@ describe('resolveEntityRefsInGraph — @field: inside {{…}}', () => {
     const graph: WorkflowGraph = {
       nodes: [
         node('extractor-1', { type: 'information-extractor', text: 'x' }),
-        node('answer-1', { type: 'answer', text: '{{extractor-1.@field:orderNumber}}' }),
+        node('answer-1', { type: 'answer', text: '{{extractor-1.@field:dealName}}' }),
       ],
       edges: [],
     }
 
     const { unresolvedNodes } = resolve(graph)
 
-    expect(graph.nodes[1]?.data.text).toBe('{{extractor-1.@field:orderNumber}}')
+    expect(graph.nodes[1]?.data.text).toBe('{{extractor-1.@field:dealName}}')
     expect(unresolvedNodes).toEqual(['answer-1'])
   })
 })
@@ -393,12 +475,12 @@ describe('resolveEntityRefsInGraph — unresolvable refs', () => {
   it('leaves an unknown entity slug verbatim and reports the node', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        findOrderNode(),
+        findDealNode(),
         node('crud-1', {
           type: 'crud',
           resourceType: '@entity:contact',
           mode: 'update',
-          resourceId: '{{find-order.@entity:widgets}}',
+          resourceId: '{{find-deal.@entity:widgets}}',
         }),
       ],
       edges: [],
@@ -406,22 +488,22 @@ describe('resolveEntityRefsInGraph — unresolvable refs', () => {
 
     const { unresolvedNodes } = resolve(graph)
 
-    expect(graph.nodes[1]?.data.resourceId).toBe('{{find-order.@entity:widgets}}')
+    expect(graph.nodes[1]?.data.resourceId).toBe('{{find-deal.@entity:widgets}}')
     expect(unresolvedNodes).toEqual(['crud-1'])
   })
 
   it('leaves an unknown field ref verbatim and reports the node', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        findOrderNode(),
-        node('answer-1', { type: 'answer', text: '{{find-order.@entity:orders.@field:nope}}' }),
+        findDealNode(),
+        node('answer-1', { type: 'answer', text: '{{find-deal.@entity:deals.@field:nope}}' }),
       ],
       edges: [],
     }
 
     const { unresolvedNodes } = resolve(graph)
 
-    expect(graph.nodes[1]?.data.text).toBe(`{{find-order.${ORDER_DEF_ID}.@field:nope}}`)
+    expect(graph.nodes[1]?.data.text).toBe(`{{find-deal.${DEAL_DEF_ID}.@field:nope}}`)
     expect(unresolvedNodes).toEqual(['answer-1'])
   })
 
@@ -462,9 +544,9 @@ describe('resolveEntityRefsInGraph — leaves ordinary text alone', () => {
   })
 
   it('does not touch a placeholder written outside a variable reference', () => {
-    const prose = 'Use the @entity:orders placeholder and the @field:orderNumber ref in CRUD nodes.'
+    const prose = 'Use the @entity:deals placeholder and the @field:dealName ref in CRUD nodes.'
     const graph: WorkflowGraph = {
-      nodes: [findOrderNode(), node('answer-1', { type: 'answer', text: prose })],
+      nodes: [findDealNode(), node('answer-1', { type: 'answer', text: prose })],
       edges: [],
     }
 
@@ -475,9 +557,9 @@ describe('resolveEntityRefsInGraph — leaves ordinary text alone', () => {
   })
 
   it('does not touch $comment authoring prose', () => {
-    const comment = 'TECHNIQUE 3: {{find-order.@entity:orders}} resolves to the entity id'
+    const comment = 'TECHNIQUE 3: {{find-deal.@entity:deals}} resolves to the entity id'
     const graph: WorkflowGraph = {
-      nodes: [findOrderNode(), node('answer-1', { type: 'answer', $comment: comment, text: 'hi' })],
+      nodes: [findDealNode(), node('answer-1', { type: 'answer', $comment: comment, text: 'hi' })],
       edges: [],
     }
 
@@ -489,12 +571,12 @@ describe('resolveEntityRefsInGraph — leaves ordinary text alone', () => {
   it('is idempotent — a second pass finds nothing left to rewrite', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        findOrderNode(),
+        findDealNode(),
         node('crud-1', {
           type: 'crud',
-          resourceType: '@entity:orders',
+          resourceType: '@entity:deals',
           mode: 'update',
-          resourceId: '{{find-order.@entity:orders}}',
+          resourceId: '{{find-deal.@entity:deals}}',
         }),
       ],
       edges: [],
@@ -513,55 +595,55 @@ describe('resolveEntityRefsInGraph — composes with node-id remapping', () => {
     const template: WorkflowGraph = {
       nodes: [
         {
-          id: 'find-order-009',
+          id: 'find-deal-009',
           type: 'standard',
           position: { x: 0, y: 0 },
           data: {
-            id: 'find-order-009',
+            id: 'find-deal-009',
             type: 'find',
-            resourceType: '@entity:orders',
+            resourceType: '@entity:deals',
             findMode: 'findOne',
           },
         },
         {
-          id: 'update-order-012',
+          id: 'update-deal-012',
           type: 'standard',
           position: { x: 100, y: 0 },
           data: {
-            id: 'update-order-012',
+            id: 'update-deal-012',
             type: 'crud',
-            resourceType: '@entity:orders',
+            resourceType: '@entity:deals',
             mode: 'update',
-            resourceId: '{{find-order-009.@entity:orders}}',
+            resourceId: '{{find-deal-009.@entity:deals}}',
             data: {
-              '@field:orderNumber': '{{find-order-009.@entity:orders.@field:orderNumber}}',
+              '@field:dealName': '{{find-deal-009.@entity:deals.@field:dealName}}',
             },
             prompt: [
               {
                 type: 'variable-node',
-                attrs: { variableId: 'find-order-009.@entity:orders.@field:orderNumber' },
+                attrs: { variableId: 'find-deal-009.@entity:deals.@field:dealName' },
               },
             ],
           },
         },
       ],
-      edges: [{ id: 'e1', source: 'find-order-009', target: 'update-order-012' }],
+      edges: [{ id: 'e1', source: 'find-deal-009', target: 'update-deal-012' }],
     }
 
     const transformer = new TemplateGraphTransformer()
     const { graph, idMapping } = transformer.cloneGraph(template)
-    const newFindId = idMapping.get('find-order-009')!
+    const newFindId = idMapping.get('find-deal-009')!
 
     const { unresolvedNodes } = resolve(graph)
     const crud = graph.nodes[1]?.data as Record<string, any>
 
-    expect(newFindId).not.toBe('find-order-009')
-    expect(crud.resourceId).toBe(`{{${newFindId}.${ORDER_DEF_ID}}}`)
-    expect(crud.data[ORDER_NUMBER_FIELD_ID]).toBe(
-      `{{${newFindId}.${ORDER_DEF_ID}.${ORDER_NUMBER_FIELD_ID}}}`
+    expect(newFindId).not.toBe('find-deal-009')
+    expect(crud.resourceId).toBe(`{{${newFindId}.${DEAL_DEF_ID}}}`)
+    expect(crud.data[DEAL_NAME_FIELD_ID]).toBe(
+      `{{${newFindId}.${DEAL_DEF_ID}.${DEAL_NAME_FIELD_ID}}}`
     )
     expect(crud.prompt[0].attrs.variableId).toBe(
-      `${newFindId}.${ORDER_DEF_ID}.${ORDER_NUMBER_FIELD_ID}`
+      `${newFindId}.${DEAL_DEF_ID}.${DEAL_NAME_FIELD_ID}`
     )
     expect(unresolvedNodes).toEqual([])
   })
@@ -573,8 +655,8 @@ describe('extractRequiredEntities', () => {
       nodes: [
         node('crud-1', {
           type: 'crud',
-          resourceType: '@entity:orders',
-          data: { '@field:orderNumber': 'x' },
+          resourceType: '@entity:deals',
+          data: { '@field:dealName': 'x' },
         }),
       ],
       edges: [],
@@ -583,14 +665,14 @@ describe('extractRequiredEntities', () => {
     const extracted = extractRequiredEntities(graph)
 
     expect(extracted).toHaveLength(1)
-    expect(extracted[0]?.requiredFields).toEqual(['orderNumber'])
+    expect(extracted[0]?.requiredFields).toEqual(['dealName'])
   })
 
   it('also collects refs that only appear inside variable references', () => {
     const graph: WorkflowGraph = {
       nodes: [
-        node('find-order', { type: 'find', resourceType: '@entity:orders', findMode: 'findMany' }),
-        node('answer-1', { type: 'answer', text: '{{find-order.orders[0].@field:trackingUrl}}' }),
+        node('find-deal', { type: 'find', resourceType: '@entity:deals', findMode: 'findMany' }),
+        node('answer-1', { type: 'answer', text: '{{find-deal.deals[0].@field:stage}}' }),
       ],
       edges: [],
     }
@@ -598,7 +680,7 @@ describe('extractRequiredEntities', () => {
     const extracted = extractRequiredEntities(graph)
 
     expect(extracted).toHaveLength(1)
-    expect(extracted[0]?.apiSlug).toBe('orders')
-    expect(extracted[0]?.requiredFields).toEqual(['trackingUrl'])
+    expect(extracted[0]?.apiSlug).toBe('deals')
+    expect(extracted[0]?.requiredFields).toEqual(['stage'])
   })
 })

--- a/packages/lib/src/workflows/templates/order-issue-triage.template.json
+++ b/packages/lib/src/workflows/templates/order-issue-triage.template.json
@@ -53,32 +53,25 @@
       "apiSlug": "ticket",
       "fieldMapping": {
         "ticket_status": "ticket_status",
-        "ticket_priority": "ticket_priority"
+        "ticket_priority": "ticket_priority",
+        "ticket_description": "ticket_description"
       },
       "requiredFields": ["ticket_status"],
       "required": true
     },
     {
-      "$comment": "TECHNIQUE 3: Custom entity from built-in template — requires installation if not present. All fields mapped 1:1 to templateFieldIds from order.json.",
-      "entityTemplateId": "order",
+      "$comment": "TECHNIQUE 3: System entity (order) — like contact, ticket and company above, `order` is a system entity definition, so it always exists and needs no installation. This WAS a custom entity from `templates/order.json`; that template was retired when the native order shipped (plans/products/08-order-build.md §3.5), so the binding moved to `__system:order` and the field keys became systemAttribute values from ORDER_FIELDS. The native order is a money document, not the CRM template — it has no priority, trackingUrl, itemsOrdered, requiresFollowUp or internalNotes, and it splits `status` into a financial and a fulfillment half.",
+      "entityTemplateId": "__system:order",
       "name": "Order",
-      "apiSlug": "orders",
-      "icon": "shopping-cart",
-      "color": "green",
+      "apiSlug": "order",
       "fieldMapping": {
-        "orderNumber": "orderNumber",
-        "orderTotal": "orderTotal",
-        "status": "status",
-        "priority": "priority",
-        "orderDate": "orderDate",
-        "shippingAddress": "shippingAddress",
-        "trackingUrl": "trackingUrl",
-        "itemsOrdered": "itemsOrdered",
-        "requiresFollowUp": "requiresFollowUp",
-        "internalNotes": "internalNotes",
-        "assignedTo": "assignedTo"
+        "order_number": "order_number",
+        "order_contact": "order_contact",
+        "order_placed_at": "order_placed_at",
+        "order_financial_status": "order_financial_status",
+        "order_fulfillment_status": "order_fulfillment_status"
       },
-      "requiredFields": ["orderNumber", "status"],
+      "requiredFields": ["order_number"],
       "companionTemplateIds": ["return-request", "shipment"],
       "required": true
     },
@@ -458,7 +451,7 @@
         "height": 100
       },
       {
-        "$comment": "── FIND NODE (custom entity: order) ── TECHNIQUE 3: @entity:orders resolves to entity definition ID via entityDefSlugs cache (apiSlug 'orders'). @field:orderNumber resolves via entity template's templateFieldId. findOne publishes its result under the entity-definition CUID (`<node>.<entityDefId>`), which a template addresses as `{{find-order-009.@entity:orders}}` — @entity: placeholders are rewritten inside {{…}} strings too, so the CUID never has to be known at authoring time.",
+        "$comment": "── FIND NODE (system entity: order) ── TECHNIQUE 3: @entity:order resolves to the entity definition ID straight from the org's entityDefs cache, keyed by entityType — no installation and no apiSlug lookup, unlike the custom-template path @entity:deals takes below. @field:order_number resolves by systemAttribute. findOne publishes its result under the entity-definition CUID (`<node>.<entityDefId>`), which a template addresses as `{{find-order-009.@entity:order}}` — @entity: placeholders are rewritten inside {{…}} strings too, so the CUID never has to be known at authoring time.",
         "id": "find-order-009",
         "type": "standard",
         "position": {
@@ -470,7 +463,7 @@
           "type": "find",
           "title": "Find Existing Order",
           "desc": "Search for an existing order record by order number",
-          "resourceType": "@entity:orders",
+          "resourceType": "@entity:order",
           "findMode": "findOne",
           "conditions": [],
           "conditionGroups": [
@@ -486,7 +479,7 @@
               "conditions": [
                 {
                   "id": "cond-order-number",
-                  "fieldId": "@field:orderNumber",
+                  "fieldId": "@field:order_number",
                   "operator": "is",
                   "value": "{{extractor-002.extracted_data.orderNumber}}",
                   "isConstant": false
@@ -549,7 +542,7 @@
         "height": 100
       },
       {
-        "$comment": "── CRUD CREATE (custom entity: order) ── TECHNIQUE 3 continued: Create order record from Shopify data. @entity:orders → entity definition ID. @field: refs → custom field IDs via templateFieldId matching after template installation.",
+        "$comment": "── CRUD CREATE (system entity: order) ── TECHNIQUE 3 continued: create a native order from the Shopify lookup. @field: refs resolve by systemAttribute. Only four fields are written, and the omissions are deliberate: `order_number` and `order_total` are BOTH `creatable: false` — the number is issued by the order_number system hook off the ORD RecordSequence, and the totals are owned by the totals engine, so a value written here would be discarded. `order_contact` is the one REQUIRED field (nullable: false); it takes the contact the parallel branch just resolved. The retired CRM template's priority / trackingUrl / itemsOrdered / requiresFollowUp / internalNotes have no native equivalent — the follow-up half of that now lives on the ticket in update-ticket-014. `order_shipping_address` is ADDRESS_STRUCT and the Shopify block's address shape does not match it, so it is left unset rather than seeded with a placeholder.",
         "id": "create-order-011",
         "type": "standard",
         "position": {
@@ -561,67 +554,19 @@
           "type": "crud",
           "title": "Create Order Record",
           "desc": "Create a new order record from Shopify data",
-          "resourceType": "@entity:orders",
+          "resourceType": "@entity:order",
           "mode": "create",
           "data": {
-            "@field:orderNumber": "{{shopify-order-003.order.name}}",
-            "@field:orderTotal": "{{shopify-order-003.order.totalPrice}}",
-            "@field:status": "Processing",
-            "@field:priority": "Normal",
-            "@field:orderDate": "{{shopify-order-003.order.createdAt}}",
-            "@field:shippingAddress": "",
-            "@field:trackingUrl": "{{shopify-order-003.order.orderStatusUrl}}",
-            "@field:itemsOrdered": "",
-            "@field:requiresFollowUp": true,
-            "@field:internalNotes": "Auto-created from customer support message"
+            "@field:order_contact": "{{find-contact-005.@entity:contact}}",
+            "@field:order_placed_at": "{{shopify-order-003.order.createdAt}}",
+            "@field:order_financial_status": "pending",
+            "@field:order_fulfillment_status": "unfulfilled"
           },
           "fieldModes": {
-            "@field:orderNumber": false,
-            "@field:orderTotal": false,
-            "@field:status": true,
-            "@field:priority": true,
-            "@field:orderDate": false,
-            "@field:shippingAddress": true,
-            "@field:trackingUrl": false,
-            "@field:itemsOrdered": true,
-            "@field:requiresFollowUp": true,
-            "@field:internalNotes": true
-          },
-          "error_strategy": "fail",
-          "default_values": [],
-          "errors": [],
-          "isValid": true,
-          "disabled": false
-        },
-        "width": 244,
-        "height": 100
-      },
-      {
-        "$comment": "── CRUD UPDATE (custom entity: order) ── TECHNIQUE 3 with update mode: Update existing order's follow-up flag and notes.",
-        "id": "update-order-012",
-        "type": "standard",
-        "position": {
-          "x": 1750,
-          "y": 150
-        },
-        "data": {
-          "id": "update-order-012",
-          "type": "crud",
-          "title": "Flag Order for Follow-Up",
-          "desc": "Update existing order with follow-up flag and priority",
-          "resourceType": "@entity:orders",
-          "mode": "update",
-          "resourceId": "{{find-order-009.@entity:orders}}",
-          "data": {
-            "@field:requiresFollowUp": true,
-            "@field:priority": "{{extractor-002.extracted_data.urgency}}",
-            "@field:internalNotes": "Customer reported issue: {{extractor-002.extracted_data.issueDescription}}"
-          },
-          "fieldModes": {
-            "resourceId": false,
-            "@field:requiresFollowUp": true,
-            "@field:priority": false,
-            "@field:internalNotes": false
+            "@field:order_contact": false,
+            "@field:order_placed_at": false,
+            "@field:order_financial_status": true,
+            "@field:order_fulfillment_status": true
           },
           "error_strategy": "fail",
           "default_values": [],
@@ -731,19 +676,21 @@
         "data": {
           "id": "update-ticket-014",
           "type": "crud",
-          "title": "Update Ticket Priority",
-          "desc": "Update the ticket with urgency and open status",
+          "title": "Update Ticket",
+          "desc": "Set urgency, reopen, and record the reported issue on the ticket",
           "resourceType": "@entity:ticket",
           "mode": "update",
           "resourceId": "{{trigger-001.ticket}}",
           "data": {
             "@field:ticket_priority": "{{extractor-002.extracted_data.urgency}}",
-            "@field:ticket_status": "open"
+            "@field:ticket_status": "open",
+            "@field:ticket_description": "Customer reported issue: {{extractor-002.extracted_data.issueDescription}}"
           },
           "fieldModes": {
             "resourceId": false,
             "@field:ticket_priority": false,
-            "@field:ticket_status": true
+            "@field:ticket_status": true,
+            "@field:ticket_description": false
           },
           "error_strategy": "fail",
           "default_values": [],
@@ -1217,10 +1164,10 @@
         "targetHandle": "target"
       },
       {
-        "$comment": "Order Exists? YES → Update Order",
+        "$comment": "Order Exists? YES → Update Ticket. The found arm used to pass through a 'Flag Order for Follow-Up' CRUD node; the native order has no requiresFollowUp / priority / internalNotes to flag (an order records a sale, it does not track a support conversation), so the arm now converges directly on update-ticket-014, which carries exactly those semantics natively.",
         "id": "edge-010",
         "source": "check-order-010",
-        "target": "update-order-012",
+        "target": "update-ticket-014",
         "sourceHandle": "case-order-found",
         "targetHandle": "target"
       },
@@ -1253,14 +1200,6 @@
         "id": "edge-014",
         "source": "create-order-011",
         "target": "create-company-015",
-        "sourceHandle": "source",
-        "targetHandle": "target"
-      },
-      {
-        "$comment": "Update Order → Update Ticket",
-        "id": "edge-015",
-        "source": "update-order-012",
-        "target": "update-ticket-014",
         "sourceHandle": "source",
         "targetHandle": "target"
       },

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -180,6 +180,7 @@ export const SYSTEM_ATTRIBUTES = [
   'part_stock_status',
   'part_reorder_point',
   'part_reorder_qty',
+  'part_line_items', // inverse of line_item_part
   'part_stock_movements',
 
   // ─── Contact inverse fields ────────────────────────────────────
@@ -330,6 +331,8 @@ export const SYSTEM_ATTRIBUTES = [
   'line_item_quote',
   'line_item_work_order',
   'line_item_invoice',
+  'line_item_order',
+  'line_item_part', // stamped from the line's catalog item, not hand-set (08 §6.2)
   'line_item_photos', // scouting/line-level photos (plan 37b §1)
 
   // ─── Catalog Item fields ────────────────────────────────────────
@@ -437,6 +440,7 @@ export const SYSTEM_ATTRIBUTES = [
   'order_subtotal',
   'order_discount_type',
   'order_discount_value',
+  'order_tax_name',
   'order_tax_rate',
   'order_tax_total',
   'order_total',


### PR DESCRIPTION
Phases 2 and 3 of `plans/products/08-order-build.md`, on top of the entity phase 1 shipped in #1911.

## The order number never worked

`order_number` shipped declaring `creatable: false` with the comment *"the hook is the ONLY writer"* — but the hook was never written and `SequenceScope` had no `'order'`. So the field was unwritable by the hook (absent) and unwritable by a human (not creatable), and every order created since #1911 has a NULL number. Verified on dev: the one order that existed had field values for channel/contact/statuses and **no `order_number` row at all**.

Adds the `ORD` scope, the issuing hook, and — the actual miss — the `order` key in `HOOKS_BY_ENTITY_TYPE`, where an absent key returns `{}` silently. Confirmed end-to-end on dev: a freshly created order came out as **`ORD-0001`** with the `RecordSequence` row self-seeding.

## Totals: generalized, not copied

`recomputeQuoteTotals` and `recomputeInvoiceTotals` were ~110-line near-duplicates differing in exactly three places. They collapse into one recompute keyed on `DOCUMENT_TOTALS_SPECS` — a net line reduction *while* adding a third document. The existing quote and invoice tests stay green **unchanged**, which is the whole safety argument.

One subtlety worth a reviewer's eye: `publishEvents: undefined` is not `publishEvents: false`. `field-value-mutations.ts:2667` reads `params.publishEvents ?? !isDeclaredSilent(...)`, so typing the knob as a plain `boolean` and giving invoice `false` would have silently stopped invoice totals broadcasting. The knob is optional and invoice deliberately omits it.

## The `billingPrefix` trap

`billingPrefix` was `documentType === 'invoice' ? 'invoice' : 'quote'` — a two-way ternary with no fourth arm to forget. Adding `order` to the union compiles cleanly and silently reads and writes `quote_tax_rate` on every order. `money.recomputeTotals` had the same shape server-side.

Both are now lookup tables (`DOCUMENT_KNOBS` in `line-values.ts`, a membership test in the router), and `document-knobs.test.ts` asserts every totalled document only ever touches its own prefix.

## Migration 107 is extended, not superseded

There is no 108 or 109. 107 has only ever run on one local dev database, so it was still free to change; the line-item slots, the `part.lineItems` inverse and `order.taxName` fold into it. The plan's "a change needs a new migration id" rule applies once a migration has reached a **deployed** org — until then `run-migration-107.ts` re-applies it idempotently.

Applied on dev, all 28 orgs: `line_item_order`, `line_item_part`, `part_line_items`, `order_line_items` all present and **linked**, plus `order_tax_name`.

## Two places the plan was wrong

- **§2 said to put both new line relations in `LINE_TRIGGER_ATTRS`.** Only `line_item_order` goes in. §6.2 is explicit that part is provenance and grouping, *never a pricing input*, so it cannot move a total — including it would make phase 4's stamp hook fire a full document recompute per line for a number that provably did not change, and that set is also what the finalize integrity passes match on. Pinned by a test.
- **§2's field table omits `taxName`.** The shared builder writes `${prefix}_tax_name` and `${prefix}_tax_rate` as a **pair** when a tax preset is picked, and `TotalsFooter` matches the stored pair back against `documents.taxRates` to decide the selection. With the rate alone the write drops half its payload and the picker always reads "Custom". `quote`/`invoice` are the precedent.

## Rides along: a phase-1 regression

#1911 retired `templates/order.json` and rewrote the eight *entity* templates that referenced it, but never audited the *workflow* templates. `order-issue-triage` still declared `entityTemplateId: "order"`, so `getEntityTemplateById('order')` returned undefined, `@entity:orders` was never mapped, and the template installed with that literal string as three nodes' `resourceType`. Silently — which is why 29 tests in `template-resolution.test.ts` were red on `main`.

It now binds to `__system:order`. That is not a mechanical repoint: the native order is a money document, not the CRM template — `order_number` and `order_total` are both `creatable: false`, `order_contact` is required and was never set, and 5 of the create node's 10 fields have no native equivalent. So the create node carries the native writable set, the follow-up/priority/notes semantics move onto the ticket (which already wrote `ticket_priority` from the *same* `urgency` expression), and the now-empty "Flag Order for Follow-Up" node is dropped with its arm converging directly on `update-ticket-014`.

`bundled-template-entity-refs.test.ts` turns that whole class of breakage into a red build — it runs the real resolver over all 12 bundled templates and asserts no `@entity:` placeholder survives. Verified by reintroducing the exact bug (3 red) and restoring.

## Test fixture note

`template-resolution.test.ts` retargets its custom-entity carrier to `deal` rather than following `order` to `__system:order`. System entities resolve to a **bare entityType string**, never a CUID (`template-resolution.ts:393`), so moving `order` there would have collapsed 25 of the 37 tests onto the path `contact` already covers and left the CUID branch untested. `deal` carries the custom branch; `order` gains its own system-branch coverage. 39 pass.

## Checks

- `packages/lib` full suite green; typecheck ratchet at baseline on both `lib` and `web`
- Drawer and detail page verified in the browser on dev (`ORD-0001`, line builder, totals footer)

## Not in scope

Phase 4 (the `line_item_part` stamp + backfill) and phase 5 (`EntityRefKind`). `line_item_part` exists but nothing writes it yet. Record-level permissions for `order` remain unaddressed, as the plan's §9 flags.
