### PR TITLE
fix(dynamic-table): close the bulk action bar when the selected rows are deleted

### DIFF
--- a/apps/web/src/components/drawers/cards/part-costing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-costing-card.tsx
@@ -145,7 +145,7 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
             {!isLoadingSubparts && (
               <span className='text-xs text-muted-foreground'>
                 {hasSubparts
-                  ? 'The bill of materials has unpriced components — the Subparts tab lists them.'
+                  ? 'The bill of materials has unpriced components, the Subparts tab lists them.'
                   : 'No supplier price and no bill of materials.'}
               </span>
             )}

--- a/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
@@ -34,6 +34,7 @@ import { DynamicTableFooter } from './components/dynamic-table-footer'
 import { getIconForFieldType } from './custom-field-column-factory'
 import { DynamicView } from './dynamic-view'
 import { useDefaultTablePersistence } from './hooks/use-default-table-persistence'
+import { useSelectionStore } from './stores/selection-store'
 import {
   useActiveView,
   useActiveViewId,
@@ -63,6 +64,11 @@ const PAGE_SIZE = 100
 export interface DynamicResourceViewHandle {
   refresh: () => void
   getValue: (recordId: RecordId, fieldRef: FieldReference) => StoredFieldValue | undefined
+  /**
+   * Drop rows from the table's selection. For rows that no longer exist —
+   * deleted or archived — so the bulk action bar stops counting them.
+   */
+  deselect: (rowIds: string[]) => void
 }
 
 export interface DynamicResourceViewProps<TRow extends RecordMeta = RecordMeta> {
@@ -276,13 +282,18 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
     enabled: !!entityDefinitionId && columnIds.length > 0 && isConfigReady,
   })
 
+  const deselect = useCallback(
+    (rowIds: string[]) => useSelectionStore.getState().deselectRows(tableId, rowIds),
+    [tableId]
+  )
+
   useEffect(() => {
     if (!viewRef) return
-    viewRef.current = { refresh, getValue }
+    viewRef.current = { refresh, getValue, deselect }
     return () => {
       if (viewRef.current?.refresh === refresh) viewRef.current = null
     }
-  }, [viewRef, refresh, getValue])
+  }, [viewRef, refresh, getValue, deselect])
 
   const createEntityFieldColumn = useCallback(
     (field: ResourceField & { id: string }): ExtendedColumnDef<TRow> => {

--- a/apps/web/src/components/dynamic-table/dynamic-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-view.tsx
@@ -160,13 +160,13 @@ function DynamicViewInner<TData extends object>({
   // Check if calendar view is valid (needs a configured date axis)
   const isCalendarView = viewType === 'calendar' && !!calendarConfig?.dateFieldId
 
-  // Table-selected rows (for table view)
-  const tableState = table.getState()
-  // biome-ignore lint/correctness/useExhaustiveDependencies: tableState properties trigger recalculation when filters/selection change
-  const tableSelectedRows = useMemo(
-    () => table.getFilteredSelectedRowModel().rows,
-    [table, tableState.columnFilters, tableState.globalFilter, tableState.rowSelection]
-  )
+  // Table-selected rows (for table view).
+  // Deliberately NOT wrapped in useMemo: table-core already memoizes this on
+  // [rowSelection, getFilteredRowModel()], so the call is cached — and unlike a
+  // hand-rolled dep list it invalidates when rows are added or removed. A useMemo
+  // here previously omitted the row data, so deleting the selected rows left a
+  // stale array behind and the bulk action bar kept reporting the old count.
+  const tableSelectedRows = table.getFilteredSelectedRowModel().rows
 
   // Kanban-selected data
   const kanbanSelectedData = useMemo(() => {

--- a/apps/web/src/components/dynamic-table/stores/selection-store.ts
+++ b/apps/web/src/components/dynamic-table/stores/selection-store.ts
@@ -91,6 +91,14 @@ interface SelectionStore {
     allRowIds?: string[]
   ) => void
   resetRowSelection: (tableId: string) => void
+  /**
+   * Drop specific ids from the selection, leaving the rest intact.
+   *
+   * For rows that are GONE — deleted, archived — not for rows that merely
+   * scrolled or filtered out of view. Deselecting on any row-set change would
+   * wipe the selection every time server-side search re-runs.
+   */
+  deselectRows: (tableId: string, rowIds: string[]) => void
   getRowSelection: (tableId: string) => RowSelectionState
   setLastClickedRowId: (tableId: string, rowId: string | null) => void
   setLastSelectedIndex: (tableId: string, index: number | null) => void
@@ -217,6 +225,23 @@ export const useSelectionStore = create<SelectionStore>()(
           t.rowSelection = EMPTY_ROW_SELECTION
           t.lastClickedRowId = null
           t.lastSelectedIndex = null
+        })
+      )
+    },
+
+    deselectRows: (tableId, rowIds) => {
+      if (rowIds.length === 0) return
+      set((state) =>
+        produce(state, (draft) => {
+          const t = draft.tables[tableId]
+          if (!t) return
+          for (const id of rowIds) {
+            delete t.rowSelection[id]
+          }
+          if (t.lastClickedRowId && rowIds.includes(t.lastClickedRowId)) {
+            t.lastClickedRowId = null
+            t.lastSelectedIndex = null
+          }
         })
       )
     },

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -267,6 +267,14 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
     viewRef.current?.refresh()
   }, [])
 
+  // Deleted/archived rows are gone — drop them from the table's selection so the
+  // bulk action bar stops counting them. Note this is the dynamic-table selection
+  // store, which `handleOperationsClearSelection` above does NOT touch: that one
+  // clears the frozen selection this view pins dialog scope to.
+  const handleRowsRemoved = useCallback((rowIds: string[]) => {
+    viewRef.current?.deselect(rowIds)
+  }, [])
+
   const {
     handleDrawerDelete,
     handleBulkDelete,
@@ -279,6 +287,7 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
     resourcePlural: resource?.plural,
     onDrawerClose: handleOperationsDrawerClose,
     onClearSelection: handleOperationsClearSelection,
+    onRowsRemoved: handleRowsRemoved,
     onRefetch: refresh,
   })
 

--- a/apps/web/src/hooks/use-entity-instance-operations.tsx
+++ b/apps/web/src/hooks/use-entity-instance-operations.tsx
@@ -24,6 +24,13 @@ interface UseEntityInstanceOperationsOptions {
   onDrawerClose?: () => void
   /** Callback when row selection should be cleared */
   onClearSelection?: () => void
+  /**
+   * Callback with the ids of rows that are GONE after a bulk mutation — deleted
+   * or archived. Callers use it to drop those ids from the table's selection so
+   * the bulk action bar stops counting rows that no longer exist. Rows that
+   * failed to delete are omitted, so they stay selected for a retry.
+   */
+  onRowsRemoved?: (rowIds: string[]) => void
   /** Callback to refresh data after mutations */
   onRefetch?: () => void
 }
@@ -46,6 +53,7 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
     resourcePlural,
     onDrawerClose,
     onClearSelection,
+    onRowsRemoved,
     onRefetch,
   } = options
 
@@ -189,11 +197,18 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         const failedIds = new Set(
           result.errors.map((e) => parseRecordId(e.recordId).entityInstanceId)
         )
+        const removedIds: string[] = []
         for (const row of rows) {
-          if (!failedIds.has(row.id) && entityDefinitionId) {
-            useRecordStore.getState().removeRecord(entityDefinitionId, row.id)
+          if (!failedIds.has(row.id)) {
+            removedIds.push(row.id)
+            if (entityDefinitionId) {
+              useRecordStore.getState().removeRecord(entityDefinitionId, row.id)
+            }
           }
         }
+        // Drop the deleted ids from the table selection. Rows that failed keep
+        // their selection so the user can retry them.
+        onRowsRemoved?.(removedIds)
         onRefetch?.()
 
         if (result.errors.length > 0) {
@@ -211,6 +226,7 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
       bulkDeleteMutateAsync,
       buildRecordId,
       entityDefinitionId,
+      onRowsRemoved,
       onRefetch,
     ]
   )
@@ -230,9 +246,19 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         await bulkArchiveMutateAsync({
           recordIds: rows.map((r) => buildRecordId(r.id)),
         })
+        // bulkArchive is all-or-nothing ({ count }, no per-row errors), so on
+        // success every row passed in is gone from the default view.
+        onRowsRemoved?.(rows.map((r) => r.id))
       }
     },
-    [confirmArchive, resourceLabel, resourcePlural, bulkArchiveMutateAsync, buildRecordId]
+    [
+      confirmArchive,
+      resourceLabel,
+      resourcePlural,
+      bulkArchiveMutateAsync,
+      buildRecordId,
+      onRowsRemoved,
+    ]
   )
 
   /** Handle delete from drawer with confirmation */


### PR DESCRIPTION
## The bug

Select rows in a record view, run the **Delete** bulk action, confirm. The records are deleted and leave the table, but the floating bulk action bar stays open, still reporting the pre-delete count.

**Archive** had the identical symptom, and it affected every table on `dynamic-table` (records, recordings, documents, workflow executions), not just the record view.

## Root cause

`dynamic-view.tsx` computed the selection through a hand-rolled memo:

```ts
const tableState = table.getState()
// biome-ignore lint/correctness/useExhaustiveDependencies: ...
const tableSelectedRows = useMemo(
  () => table.getFilteredSelectedRowModel().rows,
  [table, tableState.columnFilters, tableState.globalFilter, tableState.rowSelection]
)
```

The row data is not a dependency, and the `useReactTable` instance is stable across renders, so it never invalidates. When the delete removed rows and the query refetched, **none of the four deps changed** — the memo handed back the pre-delete `Row[]`, which fed `selectedData` → `FloatingBulkActionBar` → `selectedCount`.

The tell: `getFilteredSelectedRowModel()` intersects `rowSelection` with the *current* row model. If it had actually re-run, the deleted rows would already be absent and the bar would have closed on its own.

## Fix

**Drop the memo.** `table-core@8.21.3` already memoizes this on exactly the right deps (`RowSelection.js:146`):

```js
table.getFilteredSelectedRowModel = utils.memo(
  () => [table.getState().rowSelection, table.getFilteredRowModel()],
  ...
)
```

`[rowSelection, filteredRowModel]` — the row model **is** in there, which is precisely what the hand-rolled list omitted, and `memo()` returns the cached object by identity when deps are unchanged. So the `useMemo` was never providing caching; it was overriding table-core's correct invalidation with a narrower, wrong one. The `biome-ignore` goes with it — the rule was flagging this correctly and had been suppressed.

**Prune the deleted ids from the selection store**, which nothing did before — `handleBulkDelete` removed records from `useRecordStore` and refetched but left the ids in `rowSelection`, so a row that ever reappeared came back pre-selected.

New `deselectRows(tableId, ids)` targets **specific ids** rather than reacting to row-set changes. That distinction matters: records search is server-side, so pruning on any row-set change would wipe the selection on every keystroke. `getFilteredSelectedRowModel` already excludes filtered-out rows from the count without discarding them; deletion is the only case where dropping the selection is unambiguously correct. Rows that fail to delete are omitted from the prune, so they stay selected for a retry.

Note `onClearSelection` could not be reused for this: in `records-view` it clears that view's own frozen selection (used to pin dialog scope), not the dynamic-table selection store the bar reads from.

## Performance

Removing a `useMemo` invites the question, so I measured `select all` on `/app/contacts` — interleaved A/B (B→A→A→B) to cancel ambient machine load, medians of 8-10 toggles each:

| | select-all | deselect |
|---|---|---|
| original `useMemo` | 282.2ms | 139.0ms |
| **this PR** | **273.2ms** | **135.2ms** |

No regression — identical within noise, marginally faster. Per render the call costs a two-element identity comparison and a cached return, and `dynamic-view` already calls `table.getRowModel()` unmemoized twice.

## Testing

- Delete and archive verified end-to-end in the app; the bar now closes.
- `pnpm --filter @auxx/web typecheck` — no new errors (ratchet: 0 total, baseline 0).
- Biome clean on all touched files.

## Also included

A one-line reword of the part costing card empty-state hint (em-dash → comma), carried along at the author's request.
