### PR TITLE
feat(orders): stamp line_item_part from the line's catalog item

### DIFF
--- a/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
+++ b/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
@@ -23,6 +23,7 @@ import {
   CommandSeparator,
 } from '@auxx/ui/components/command'
 import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatCurrency } from '@auxx/utils/currency'
 import { Boxes, Package, Plus, Settings2 } from 'lucide-react'
@@ -214,7 +215,16 @@ export function CatalogPicker({
                         title={item.name}
                         secondary={
                           item.partRecordId ? (
-                            <span className='text-muted-foreground text-xs'>Linked part</span>
+                            // Icon, not the words "Linked part": the row already carries a
+                            // name and a price, and the label competed with both for a fact
+                            // that only matters on hover. `line_item_part` is stamped from
+                            // this link at write time (08 §6.2), so it is provenance the
+                            // picker should surface quietly.
+                            <SimpleTooltip content='Linked to a part' side='top'>
+                              <span className='inline-flex text-muted-foreground'>
+                                <Package className='size-3.5' aria-label='Linked to a part' />
+                              </span>
+                            </SimpleTooltip>
                           ) : undefined
                         }
                         trailing={

--- a/packages/lib/scripts/backfill-line-item-part.ts
+++ b/packages/lib/scripts/backfill-line-item-part.ts
@@ -1,0 +1,360 @@
+// packages/lib/scripts/backfill-line-item-part.ts
+//
+// One-off backfill for plans/products/08-order-build.md phase 4 (§6.2).
+//
+// `line_item_part` is STAMPED, not hand-set: when a line carries a
+// `catalogItem` whose `catalog_item_part` is set, that part is copied onto the
+// line so revenue-by-part is ONE join instead of the three-hop
+// line -> catalog_item -> part -> product chain, and so the grouping key is
+// auditable rather than re-derived from a field a user can re-point later
+// (§6.2 — re-pointing `catalog_item.part` today silently re-attributes every
+// historical sale that ever went through that catalog item).
+//
+// A write-time hook does this going forward. This repairs history: every line
+// written before the hook existed.
+//
+// WHAT IT DELIBERATELY DOES NOT DO
+//
+//   - It never OVERWRITES. A line that already holds a `line_item_part` — set
+//     by a human, or by an earlier run of this script — is left exactly as it
+//     is. Only an absent value is filled. That is the whole point of a stamp:
+//     the field stays writable, and a human override outranks the derivation.
+//
+//   - It never invents a part. A line whose catalog item has no
+//     `catalog_item_part` is NOT a failure and is NOT guessed at — it is the
+//     population that explains why this backfill is small, so it is counted and
+//     reported separately rather than silently omitted (§6.1: `catalog_item ->
+//     part` is 2 of 9 on dev; everything past `line_item -> catalog_item`
+//     collapses).
+//
+//   - It never touches `line_item_qty`, `line_item_unit_price` or any other
+//     money field, and `line_item_part` is deliberately NOT in
+//     `LINE_TRIGGER_ATTRS` (money/totals-hooks.ts; asserted by
+//     `107-order.test.ts`). A stamp is provenance, never a pricing input, so it
+//     must not recompute a document's totals. Do not add it to that set.
+//
+// THE WRITER — and why it is not raw SQL
+//
+//   A relation is TWO mirror `FieldValue` rows, one on each end, and
+//   `FieldValue.relatedEntityId` is a bare `text()` column with no foreign key.
+//   Writing only the line's half is the exact defect
+//   `field-values/sweep-entity-references.ts` was written to clean up (1,619
+//   half-relations, 15.5% of all relation values in dev).
+//
+//   So every write here goes through `UnifiedCrudHandler.update`, the same door
+//   the record UI uses. `setValuesForEntity` -> `syncInverseRelationships`
+//   writes the `part_line_items` mirror on the part
+//   (`registry/resources/part-fields.ts:571`) and keeps `searchText` and the
+//   display projections in step. Hand-inserting the `FieldValue` row would
+//   produce a line that looks stamped and a part whose Line Items list is empty.
+//
+//   The handler runs under `seedSession` — a reshape, silent forever: no
+//   realtime, no timeline entry, no per-write field triggers. Backfilling
+//   history must not read as 100 live edits.
+//
+// SKIPPED, AND REPORTED RATHER THAN SWALLOWED
+//
+//   - Dangling references. `relatedEntityId` has no FK, so a line may point at a
+//     catalog item, or a catalog item at a part, that no longer resolves to an
+//     `EntityInstance` in the same org. Stamping one of those would mint a fresh
+//     half-relation pointing at nothing. Counted, never written.
+//
+//   - Ambiguous chains. `catalog_item_part` is a `belongs_to` and should hold at
+//     most one value; if the data disagrees (or a line holds two catalog items
+//     resolving to different parts) there is no defensible winner, so the line is
+//     listed and left alone.
+//
+// Idempotent and re-runnable: a second run finds nothing and changes nothing,
+// because the lines it stamped now hold a `line_item_part` and are excluded by
+// the same NOT EXISTS that selects candidates.
+//
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/backfill-line-item-part.ts [--dry-run]
+
+import { database as db } from '@auxx/database'
+import { toRecordId } from '@auxx/types/resource'
+import { sql } from 'drizzle-orm'
+import { getOrgCache } from '../src/cache'
+import { seedSession, UnifiedCrudHandler } from '../src/resources/crud'
+import { SystemUserService } from '../src/users/system-user-service'
+
+const DRY_RUN = process.argv.includes('--dry-run')
+
+const SESSION_REASON = 'backfill line_item_part (plans/products/08-order-build.md §6.2)'
+
+/** One line -> catalog item -> part chain that resolves end to end. */
+interface CandidateRow extends Record<string, unknown> {
+  organizationId: string
+  lineId: string
+  lineDefId: string
+  lineName: string | null
+  catalogItemId: string
+  catalogItemName: string | null
+  partId: string
+  partDefId: string
+  partName: string | null
+}
+
+/** Per-org population counts — the context that makes the stamp count readable. */
+interface OrgCountRow extends Record<string, unknown> {
+  organizationId: string
+  organizationName: string | null
+  lines: number
+  noCatalogItem: number
+  catalogItemWithoutPart: number
+  catalogItemWithPart: number
+  alreadyStamped: number
+}
+
+/** A reference whose target no longer exists. Never stamped, always reported. */
+interface DanglingRow extends Record<string, unknown> {
+  organizationId: string
+  kind: string
+  count: number
+}
+
+/**
+ * The three joins this script is built on, org-scoped at every hop.
+ *
+ * `CustomField` is joined on `organizationId` as well as `id` — the same
+ * `systemAttribute` exists once per org (28 rows for each of these four), and an
+ * unscoped join is a cross-org read waiting to happen.
+ */
+const CHAIN_CTES = sql`
+  line_item AS (
+    SELECT ei.id, ei."organizationId", ei."entityDefinitionId", ei."displayName"
+    FROM "EntityInstance" ei
+    JOIN "EntityDefinition" ed
+      ON ed.id = ei."entityDefinitionId"
+     AND ed."organizationId" = ei."organizationId"
+     AND ed."entityType" = 'line_item'
+  ),
+  line_catalog_item AS (
+    SELECT fv."entityId" AS "lineId", fv."organizationId", fv."relatedEntityId" AS "catalogItemId"
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf
+      ON cf.id = fv."fieldId"
+     AND cf."organizationId" = fv."organizationId"
+     AND cf."systemAttribute" = 'line_item_catalog_item'
+    WHERE fv."relatedEntityId" IS NOT NULL
+  ),
+  catalog_item_part AS (
+    SELECT fv."entityId" AS "catalogItemId", fv."organizationId", fv."relatedEntityId" AS "partId"
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf
+      ON cf.id = fv."fieldId"
+     AND cf."organizationId" = fv."organizationId"
+     AND cf."systemAttribute" = 'catalog_item_part'
+    WHERE fv."relatedEntityId" IS NOT NULL
+  ),
+  stamped AS (
+    SELECT DISTINCT fv."entityId" AS "lineId", fv."organizationId"
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf
+      ON cf.id = fv."fieldId"
+     AND cf."organizationId" = fv."organizationId"
+     AND cf."systemAttribute" = 'line_item_part'
+    WHERE fv."relatedEntityId" IS NOT NULL
+  )
+`
+
+/**
+ * Lines whose catalog item has a part, that hold no `line_item_part` yet, and
+ * whose whole chain resolves to live records in the same org.
+ */
+async function findCandidates(): Promise<CandidateRow[]> {
+  const { rows } = await db.execute<CandidateRow>(sql`
+    WITH ${CHAIN_CTES}
+    SELECT li."organizationId",
+           li.id                  AS "lineId",
+           li."entityDefinitionId" AS "lineDefId",
+           li."displayName"       AS "lineName",
+           ci.id                  AS "catalogItemId",
+           ci."displayName"       AS "catalogItemName",
+           p.id                   AS "partId",
+           p."entityDefinitionId" AS "partDefId",
+           p."displayName"        AS "partName"
+    FROM line_item li
+    JOIN line_catalog_item lci
+      ON lci."lineId" = li.id AND lci."organizationId" = li."organizationId"
+    JOIN "EntityInstance" ci
+      ON ci.id = lci."catalogItemId" AND ci."organizationId" = li."organizationId"
+    JOIN catalog_item_part cip
+      ON cip."catalogItemId" = ci.id AND cip."organizationId" = li."organizationId"
+    JOIN "EntityInstance" p
+      ON p.id = cip."partId" AND p."organizationId" = li."organizationId"
+    WHERE NOT EXISTS (
+      SELECT 1 FROM stamped s
+      WHERE s."lineId" = li.id AND s."organizationId" = li."organizationId"
+    )
+    ORDER BY li."organizationId", li.id, p.id
+  `)
+  return rows
+}
+
+/** Every line, bucketed by how far along the chain it gets. */
+async function countByOrg(): Promise<OrgCountRow[]> {
+  const { rows } = await db.execute<OrgCountRow>(sql`
+    WITH ${CHAIN_CTES}
+    SELECT li."organizationId",
+           o.name AS "organizationName",
+           count(DISTINCT li.id)::int AS lines,
+           count(DISTINCT li.id) FILTER (WHERE lci."lineId" IS NULL)::int AS "noCatalogItem",
+           count(DISTINCT li.id) FILTER (
+             WHERE lci."lineId" IS NOT NULL AND cip."partId" IS NULL
+           )::int AS "catalogItemWithoutPart",
+           count(DISTINCT li.id) FILTER (WHERE cip."partId" IS NOT NULL)::int
+             AS "catalogItemWithPart",
+           count(DISTINCT li.id) FILTER (WHERE s."lineId" IS NOT NULL)::int AS "alreadyStamped"
+    FROM line_item li
+    LEFT JOIN "Organization" o ON o.id = li."organizationId"
+    LEFT JOIN line_catalog_item lci
+      ON lci."lineId" = li.id AND lci."organizationId" = li."organizationId"
+    LEFT JOIN catalog_item_part cip
+      ON cip."catalogItemId" = lci."catalogItemId" AND cip."organizationId" = li."organizationId"
+    LEFT JOIN stamped s
+      ON s."lineId" = li.id AND s."organizationId" = li."organizationId"
+    GROUP BY 1, 2
+    ORDER BY 1
+  `)
+  return rows
+}
+
+/** References with no surviving target. `relatedEntityId` carries no FK. */
+async function countDangling(): Promise<DanglingRow[]> {
+  const { rows } = await db.execute<DanglingRow>(sql`
+    WITH ${CHAIN_CTES},
+    dangling AS (
+      SELECT li."organizationId", 'line -> catalog_item' AS kind, li.id AS "lineId"
+      FROM line_item li
+      JOIN line_catalog_item lci
+        ON lci."lineId" = li.id AND lci."organizationId" = li."organizationId"
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "EntityInstance" ci
+        WHERE ci.id = lci."catalogItemId" AND ci."organizationId" = li."organizationId"
+      )
+      UNION ALL
+      SELECT li."organizationId", 'catalog_item -> part' AS kind, li.id
+      FROM line_item li
+      JOIN line_catalog_item lci
+        ON lci."lineId" = li.id AND lci."organizationId" = li."organizationId"
+      JOIN catalog_item_part cip
+        ON cip."catalogItemId" = lci."catalogItemId" AND cip."organizationId" = li."organizationId"
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "EntityInstance" p
+        WHERE p.id = cip."partId" AND p."organizationId" = li."organizationId"
+      )
+    )
+    SELECT "organizationId", kind, count(DISTINCT "lineId")::int AS count
+    FROM dangling
+    GROUP BY 1, 2
+    ORDER BY 1, 2
+  `)
+  return rows
+}
+
+/** Group candidates by line, so a line resolving to two different parts is visible. */
+function groupByLine(rows: CandidateRow[]): Map<string, CandidateRow[]> {
+  const byLine = new Map<string, CandidateRow[]>()
+  for (const row of rows) {
+    const existing = byLine.get(row.lineId)
+    if (existing) existing.push(row)
+    else byLine.set(row.lineId, [row])
+  }
+  return byLine
+}
+
+async function main() {
+  console.log(DRY_RUN ? '── DRY RUN — nothing is written ──\n' : '── APPLYING ──\n')
+
+  const counts = await countByOrg()
+  const candidates = await findCandidates()
+  const dangling = await countDangling()
+
+  const byLine = groupByLine(candidates)
+  const stampable: CandidateRow[] = []
+  const ambiguous: Array<{ line: CandidateRow; partIds: string[] }> = []
+  for (const rows of byLine.values()) {
+    const partIds = [...new Set(rows.map((r) => r.partId))]
+    if (partIds.length > 1) ambiguous.push({ line: rows[0]!, partIds })
+    else stampable.push(rows[0]!)
+  }
+
+  console.log('Line items by how far the catalog-item chain gets:\n')
+  for (const org of counts) {
+    console.log(`  ${org.organizationName ?? '(unnamed)'}  [${org.organizationId}]`)
+    console.log(`    line items                                     ${org.lines}`)
+    console.log(`    ├─ no catalog item at all                      ${org.noCatalogItem}`)
+    console.log(`    ├─ catalog item has NO part (§6.1)             ${org.catalogItemWithoutPart}`)
+    console.log(`    └─ catalog item HAS a part                     ${org.catalogItemWithPart}`)
+    console.log(`    already carry line_item_part (left alone)      ${org.alreadyStamped}`)
+    for (const d of dangling.filter((row) => row.organizationId === org.organizationId)) {
+      console.log(`    ⚠ dangling ${d.kind}: ${d.count} (skipped — target no longer exists)`)
+    }
+    console.log('')
+  }
+
+  const stampableByOrg = new Map<string, CandidateRow[]>()
+  for (const row of stampable) {
+    const list = stampableByOrg.get(row.organizationId)
+    if (list) list.push(row)
+    else stampableByOrg.set(row.organizationId, [row])
+  }
+
+  console.log(`Lines to stamp: ${stampable.length}\n`)
+  for (const [organizationId, rows] of stampableByOrg) {
+    const name = counts.find((c) => c.organizationId === organizationId)?.organizationName
+    console.log(`  ${name ?? '(unnamed)'}  [${organizationId}]  ${rows.length}`)
+    for (const row of rows) {
+      console.log(
+        `    ${row.lineId}  ${row.lineName ?? '(no name)'}` +
+          `  ←  ${row.catalogItemName ?? row.catalogItemId}` +
+          `  ⇒  part ${row.partName ?? row.partId} (${row.partId})`
+      )
+    }
+  }
+
+  if (ambiguous.length > 0) {
+    console.log(`\n⚠ Ambiguous chains left alone: ${ambiguous.length}`)
+    for (const { line, partIds } of ambiguous) {
+      console.log(`    ${line.lineId}  org=${line.organizationId}  parts=[${partIds.join(', ')}]`)
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log('\nDry run complete. Nothing was written.')
+    process.exit(0)
+  }
+
+  let stamped = 0
+  let failed = 0
+  for (const [organizationId, rows] of stampableByOrg) {
+    // 107 added `line_item_part`; an org cache warmed before it would hand the
+    // handler a field map without the field, and the write would be dropped.
+    await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+    const userId = await SystemUserService.getSystemUserForActions(organizationId)
+    const handler = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+      session: seedSession(SESSION_REASON),
+    })
+
+    for (const row of rows) {
+      try {
+        await handler.update(toRecordId(row.lineDefId, row.lineId), {
+          line_item_part: toRecordId(row.partDefId, row.partId),
+        })
+        stamped++
+      } catch (error) {
+        failed++
+        console.error(`  FAILED ${row.lineId}: ${(error as Error).message}`)
+      }
+    }
+  }
+
+  console.log(`\nStamped ${stamped} line items, ${failed} failed.`)
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/lib/src/field-hooks/post/line-item-part-stamp.test.ts
+++ b/packages/lib/src/field-hooks/post/line-item-part-stamp.test.ts
@@ -1,0 +1,145 @@
+// packages/lib/src/field-hooks/post/line-item-part-stamp.test.ts
+//
+// The SECOND door for the 08 §6.2 stamp. The system hook in
+// `resources/hooks/line-item-hooks.ts` covers `UnifiedCrudHandler` writes — how the
+// LineBuilder ADDS a line. Every EDIT goes through `fieldValue.set` →
+// `FieldValueService`, which never reads the system-hook registry, so a re-point
+// reaches only this handler.
+//
+// Verified against the running app before this file existed: re-pointing a line at a
+// catalog item with a part left `line_item_part` NULL.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityFieldChangeEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  resolveCatalogItemPart: vi.fn(),
+  setValueWithType: vi.fn(),
+  createFieldValueContext: vi.fn(),
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../resources/hooks/line-item-hooks', () => ({
+  resolveCatalogItemPart: h.resolveCatalogItemPart,
+}))
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: h.createFieldValueContext,
+}))
+vi.mock('../../field-values/stored-field-type', () => ({ toFieldType: () => 'RELATIONSHIP' }))
+
+import { stampPartOnCatalogItemChange } from './line-item-part-stamp'
+
+const LINE = 'linedef:line-1'
+const CATALOG_ITEM = 'cidef:ci-1'
+const PART = 'partdef:part-1'
+
+function event(overrides: Partial<EntityFieldChangeEvent> = {}): EntityFieldChangeEvent {
+  return {
+    recordId: LINE,
+    entityDefinitionId: 'linedef',
+    entityType: 'line_item',
+    entitySlug: 'line-items',
+    field: { id: 'fld-ci', systemAttribute: 'line_item_catalog_item', type: 'RELATIONSHIP' },
+    oldValue: null,
+    newValue: [{ type: 'relationship', recordId: CATALOG_ITEM }],
+    oldDisplay: null,
+    newDisplay: null,
+    organizationId: 'org_1',
+    userId: 'usr_1',
+    ...overrides,
+  } as unknown as EntityFieldChangeEvent
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.bySystemAttributes.mockResolvedValue({
+    line_item_part: { id: 'fld-part', type: 'RELATIONSHIP' },
+  })
+  h.createFieldValueContext.mockResolvedValue({ organizationId: 'org_1' })
+  h.setValueWithType.mockResolvedValue([])
+})
+
+describe('stampPartOnCatalogItemChange', () => {
+  it('stamps the part when a line is re-pointed at a catalog item that has one', async () => {
+    h.resolveCatalogItemPart.mockResolvedValue(PART)
+
+    await stampPartOnCatalogItemChange(event())
+
+    expect(h.setValueWithType).toHaveBeenCalledWith(expect.anything(), {
+      recordId: LINE,
+      fieldId: 'fld-part',
+      fieldType: 'RELATIONSHIP',
+      value: { type: 'relationship', recordId: PART },
+    })
+  })
+
+  it('clears the stamp when the new catalog item has no part', async () => {
+    h.resolveCatalogItemPart.mockResolvedValue(null)
+
+    await stampPartOnCatalogItemChange(event())
+
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fieldId: 'fld-part', value: null })
+    )
+  })
+
+  it('clears the stamp when the catalog item is detached entirely', async () => {
+    await stampPartOnCatalogItemChange(event({ newValue: null }))
+
+    expect(h.resolveCatalogItemPart).not.toHaveBeenCalled()
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ value: null })
+    )
+  })
+
+  it('leaves an existing stamp alone when the part cannot be resolved', async () => {
+    // `undefined` = unmigrated org or a transient read failure. Clearing here would
+    // wipe good provenance on a Redis blip.
+    h.resolveCatalogItemPart.mockResolvedValue(undefined)
+
+    await stampPartOnCatalogItemChange(event())
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('ignores every field except the catalog item — no recursion on its own write', async () => {
+    await stampPartOnCatalogItemChange(
+      event({
+        field: {
+          id: 'fld-part',
+          systemAttribute: 'line_item_part',
+          type: 'RELATIONSHIP',
+        } as never,
+      })
+    )
+    await stampPartOnCatalogItemChange(
+      event({
+        field: { id: 'fld-qty', systemAttribute: 'line_item_qty', type: 'NUMBER' } as never,
+      })
+    )
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when the org has no line_item_part field', async () => {
+    h.bySystemAttributes.mockResolvedValue({})
+
+    await stampPartOnCatalogItemChange(event())
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('never fails the line edit that triggered it', async () => {
+    h.resolveCatalogItemPart.mockRejectedValue(new Error('redis down'))
+
+    await expect(stampPartOnCatalogItemChange(event())).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/field-hooks/post/line-item-part-stamp.ts
+++ b/packages/lib/src/field-hooks/post/line-item-part-stamp.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/field-hooks/post/line-item-part-stamp.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { TypedFieldValue } from '@auxx/types'
+import type { RecordId } from '@auxx/types/resource'
+import { getOrgCache } from '../../cache'
+import { createFieldValueContext } from '../../field-values/field-value-helpers'
+import { setValueWithType } from '../../field-values/field-value-mutations'
+import { toFieldType } from '../../field-values/stored-field-type'
+import { resolveCatalogItemPart } from '../../resources/hooks/line-item-hooks'
+import type { EntityFieldChangeHandler } from '../types'
+
+const logger = createScopedLogger('field-hooks:line-item-part-stamp')
+
+/**
+ * Read the catalog item `RecordId` out of a post-write relationship value.
+ * RELATIONSHIP fields report the FULL array the write produced, and `null` when
+ * the write cleared the only row.
+ */
+function readRelationshipRecordId(raw: unknown): RecordId | null {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (typeof value === 'string') return value as RecordId
+  const typed = value as TypedFieldValue | undefined
+  if (typed?.type === 'relationship' && typed.recordId) return typed.recordId
+  return null
+}
+
+/**
+ * Stamp `line_item_part` when a line's catalog item changes (08 §6.2, §7.5).
+ *
+ * ⚠️ **This is the SECOND door, and it is the one the UI actually uses.** The
+ * `LINE_ITEM_HOOKS` system hook in `resources/hooks/line-item-hooks.ts` covers
+ * writes that go through `UnifiedCrudHandler` (`record.create` / `createMany` /
+ * `record.update`) — that is how the `LineBuilder` ADDS a line. But every EDIT to
+ * an existing line goes through `useSaveFieldValue` → `fieldValue.set` /
+ * `setBulk` → `FieldValueService`, and that path consults only
+ * `getFieldPreHooks` / `getEntityFieldChangeHooks`. It never reads the system-hook
+ * registry at all (the same bypass `invoice-hooks.ts` records for money's
+ * lifecycle writers).
+ *
+ * Found by testing the real app: re-pointing a line at a catalog item that has a
+ * part left `line_item_part` NULL, because re-pointing never reaches
+ * `runPreHooks`. Without this handler the system hook's whole reason for being
+ * keyed on `line_item_catalog_item` — so a re-point re-stamps — is unreachable
+ * in the product.
+ *
+ * A field PRE-hook cannot do this: it may only transform the value of its own
+ * field. Writing a different field is a post-write concern, which is why this is
+ * an `EntityFieldChangeHandler`, registered beside `recomputeOnLineChange`.
+ *
+ * Semantics are identical to the system hook, deliberately — both call the same
+ * `resolveCatalogItemPart`:
+ * - catalog item with a part → stamp it (a re-point re-stamps; the chain is live,
+ *   so the stamp is frozen against LATER edits to `catalog_item.part`, never
+ *   against a change of which catalog item the line sells)
+ * - catalog item with no part, or detached → clear the stamp
+ * - could not resolve (unmigrated org, transient failure) → leave it alone
+ *
+ * No recursion: this fires only for `line_item_catalog_item`, and the value it
+ * writes is `line_item_part`. That attribute is deliberately absent from
+ * `LINE_TRIGGER_ATTRS`, so the write cannot move a document total either.
+ */
+export const stampPartOnCatalogItemChange: EntityFieldChangeHandler = async (event) => {
+  if (event.field.systemAttribute !== 'line_item_catalog_item') return
+
+  const { organizationId, userId, recordId } = event
+
+  try {
+    const cf = await getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttributes(['line_item_part'] as const)
+    const partField = cf.line_item_part
+    if (!partField) return
+
+    const catalogItemRecordId = readRelationshipRecordId(event.newValue)
+    const part = catalogItemRecordId
+      ? await resolveCatalogItemPart({ organizationId, userId, catalogItemRecordId })
+      : null
+
+    // `undefined` is "could not resolve" — never clear a good stamp on a blip.
+    if (part === undefined) return
+
+    const ctx = await createFieldValueContext(organizationId, userId)
+    await setValueWithType(ctx, {
+      recordId,
+      fieldId: partField.id,
+      fieldType: toFieldType(partField.type),
+      value: part ? { type: 'relationship', recordId: part } : null,
+    })
+  } catch (error) {
+    // Provenance must never fail the line edit that triggered it.
+    logger.warn('could not stamp line_item_part from the catalog item', {
+      organizationId,
+      recordId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -44,6 +44,7 @@ import {
   reanchorInvoiceOnDueDateChange,
 } from '../sequences/field-change-hooks'
 import { invalidateInboxCacheOnFieldChange } from './post/inbox-cache-invalidation'
+import { stampPartOnCatalogItemChange } from './post/line-item-part-stamp'
 import { publishFieldChangeEvent } from './post/publish-field-change-event'
 import { touchActivityOnFieldChange } from './post/touch-activity-on-field-change'
 import { guardInboxOwnerField } from './pre/inbox-owner-guard'
@@ -150,7 +151,17 @@ export function registerAllHooks(): void {
   // the quote's or invoice's own billing fields (discount type/value, tax rate) change.
   // Keyed by apiSlug — line_item's is 'line-items', quote's is 'quotes', invoice's is
   // 'invoices'.
-  registerEntityFieldChangeHooks('line-items', [recomputeOnLineChange, syncBillingOnLineChange])
+  // ⚠️ `stampPartOnCatalogItemChange` is the SECOND door for the 08 §6.2 stamp. The system
+  // hook in `resources/hooks/line-item-hooks.ts` only fires for writes through
+  // `UnifiedCrudHandler` — how the LineBuilder ADDS a line. Every EDIT goes through
+  // `fieldValue.set` → `FieldValueService`, which never reads the system-hook registry, so
+  // re-pointing a line at another catalog item reaches only this handler. Verified against
+  // the running app: without it, a re-point left `line_item_part` NULL.
+  registerEntityFieldChangeHooks('line-items', [
+    recomputeOnLineChange,
+    syncBillingOnLineChange,
+    stampPartOnCatalogItemChange,
+  ])
   registerEntityFieldChangeHooks('quotes', [recomputeOnQuoteBillingChange])
   registerEntityFieldChangeHooks('orders', [recomputeOnOrderBillingChange])
   //

--- a/packages/lib/src/resources/hooks/__tests__/line-item-hooks.test.ts
+++ b/packages/lib/src/resources/hooks/__tests__/line-item-hooks.test.ts
@@ -1,0 +1,280 @@
+// packages/lib/src/resources/hooks/__tests__/line-item-hooks.test.ts
+//
+// The `line_item_part` stamp (08 §6.2 / §8 "Linking (phase 4)"). The field shipped in
+// phase 2 with NOTHING writing it, so these tests pin the four things that made it a
+// no-op or a wrong-answer generator:
+//
+//  1. the hook is reachable through HOOKS_BY_ENTITY_TYPE — an unregistered entity type
+//     returns {} silently, which is how `order_number` stayed NULL for three PRs;
+//  2. it is keyed on `line_item_catalog_item`, not `line_item_part` — `runPreHooks`
+//     skips an update whose registered attribute is absent from `values`, so the wrong
+//     key means the stamp never follows a re-point;
+//  3. a write that does NOT touch the catalog item leaves the stamp alone — the frozen
+//     -stamp assertion that is the whole point of §6.2;
+//  4. an explicit part in the same write is the human override and survives.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SystemHookContext } from '../types'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  getValues: vi.fn(),
+}))
+
+vi.mock('../../../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({ bySystemAttributes: h.bySystemAttributes }),
+  }),
+}))
+
+vi.mock('../../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    getValues = h.getValues
+  },
+}))
+
+const { LINE_ITEM_HOOKS } = await import('../line-item-hooks')
+const { getSystemHooks, getHooksForAttribute } = await import('../system-hooks')
+
+const CATALOG_FIELD_ID = 'fld-line-catalog-item'
+const PART_FIELD_ID = 'fld-line-part'
+const CATALOG_PART_FIELD_ID = 'fld-catalog-part'
+
+const CATALOG_ITEM = 'defcatalog:instcatalog1'
+const PART_A = 'defpart:instparta'
+const PART_B = 'defpart:instpartb'
+
+const stamp = LINE_ITEM_HOOKS.line_item_catalog_item![0]!
+
+beforeEach(() => vi.clearAllMocks())
+
+type ContextOverrides = Partial<Record<keyof SystemHookContext, unknown>>
+
+function buildContext(overrides: ContextOverrides = {}): SystemHookContext {
+  return {
+    operation: 'create',
+    entityDef: { id: 'def-line-item', entityType: 'line_item', apiSlug: 'line-items' },
+    field: {
+      id: CATALOG_FIELD_ID,
+      type: 'RELATIONSHIP',
+      systemAttribute: 'line_item_catalog_item',
+    },
+    values: {},
+    organizationId: 'org-1',
+    userId: 'user-1',
+    allFields: [
+      { id: CATALOG_FIELD_ID, systemAttribute: 'line_item_catalog_item' },
+      { id: PART_FIELD_ID, systemAttribute: 'line_item_part' },
+    ],
+    ...overrides,
+  } as unknown as SystemHookContext
+}
+
+/** The catalog item resolves, and carries `part` (or no part when `part` is null). */
+function catalogItemHasPart(part: string | null) {
+  h.bySystemAttributes.mockResolvedValue({
+    catalog_item_part: { id: CATALOG_PART_FIELD_ID, type: 'RELATIONSHIP' },
+  })
+  h.getValues.mockResolvedValue(
+    new Map(part ? [[CATALOG_PART_FIELD_ID, { type: 'relationship', recordId: part }]] : [])
+  )
+}
+
+describe('line_item_part stamp', () => {
+  it('stamps the catalog item’s part on create', async () => {
+    catalogItemHasPart(PART_A)
+
+    const values = await stamp(buildContext({ values: { [CATALOG_FIELD_ID]: CATALOG_ITEM } }))
+
+    expect(values[PART_FIELD_ID]).toBe(PART_A)
+    expect(h.getValues).toHaveBeenCalledWith({
+      recordId: CATALOG_ITEM,
+      fieldIds: [CATALOG_PART_FIELD_ID],
+    })
+  })
+
+  it('reads a systemAttribute-keyed catalog item too', async () => {
+    catalogItemHasPart(PART_A)
+
+    const values = await stamp(buildContext({ values: { line_item_catalog_item: CATALOG_ITEM } }))
+
+    expect(values[PART_FIELD_ID]).toBe(PART_A)
+  })
+
+  it('unwraps a single-element array relationship value', async () => {
+    catalogItemHasPart(PART_A)
+
+    const values = await stamp(buildContext({ values: { [CATALOG_FIELD_ID]: [CATALOG_ITEM] } }))
+
+    expect(values[PART_FIELD_ID]).toBe(PART_A)
+  })
+
+  it('stamps nothing on create when the catalog item has no part', async () => {
+    catalogItemHasPart(null)
+
+    const values = await stamp(buildContext({ values: { [CATALOG_FIELD_ID]: CATALOG_ITEM } }))
+
+    expect(PART_FIELD_ID in values).toBe(false)
+    expect(values).toEqual({ [CATALOG_FIELD_ID]: CATALOG_ITEM })
+  })
+
+  it('re-stamps when an update re-points the line at another catalog item', async () => {
+    // ⚠️ This only ever runs because the hook is registered under
+    // `line_item_catalog_item` — see the registration test below.
+    catalogItemHasPart(PART_B)
+
+    const values = await stamp(
+      buildContext({
+        operation: 'update',
+        values: { [CATALOG_FIELD_ID]: CATALOG_ITEM },
+        existingInstance: { id: 'inst-line-1' },
+      })
+    )
+
+    expect(values[PART_FIELD_ID]).toBe(PART_B)
+  })
+
+  it('CLEARS the stamp when an update re-points at a catalog item with no part', async () => {
+    catalogItemHasPart(null)
+
+    const values = await stamp(
+      buildContext({
+        operation: 'update',
+        values: { [CATALOG_FIELD_ID]: CATALOG_ITEM },
+        existingInstance: { id: 'inst-line-1' },
+      })
+    )
+
+    expect(values[PART_FIELD_ID]).toBeNull()
+  })
+
+  it('CLEARS the stamp when an update detaches the catalog item entirely', async () => {
+    catalogItemHasPart(PART_A)
+
+    const values = await stamp(
+      buildContext({
+        operation: 'update',
+        values: { [CATALOG_FIELD_ID]: null },
+        existingInstance: { id: 'inst-line-1' },
+      })
+    )
+
+    expect(values[PART_FIELD_ID]).toBeNull()
+    expect(h.getValues).not.toHaveBeenCalled()
+  })
+
+  it('never overwrites an explicit part set in the same write — the human override', async () => {
+    catalogItemHasPart(PART_A)
+
+    const byId = await stamp(
+      buildContext({ values: { [CATALOG_FIELD_ID]: CATALOG_ITEM, [PART_FIELD_ID]: PART_B } })
+    )
+    expect(byId[PART_FIELD_ID]).toBe(PART_B)
+
+    const byAttr = await stamp(
+      buildContext({ values: { [CATALOG_FIELD_ID]: CATALOG_ITEM, line_item_part: PART_B } })
+    )
+    expect(byAttr.line_item_part).toBe(PART_B)
+    expect(PART_FIELD_ID in byAttr).toBe(false)
+
+    expect(h.getValues).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the org has no `line_item_part` field yet', async () => {
+    catalogItemHasPart(PART_A)
+
+    const values = await stamp(
+      buildContext({
+        values: { [CATALOG_FIELD_ID]: CATALOG_ITEM },
+        allFields: [{ id: CATALOG_FIELD_ID, systemAttribute: 'line_item_catalog_item' }],
+      })
+    )
+
+    expect(values).toEqual({ [CATALOG_FIELD_ID]: CATALOG_ITEM })
+  })
+
+  it('leaves the stamp alone when the catalog item’s part cannot be resolved', async () => {
+    // Unmigrated org — `catalog_item_part` does not exist. Collapsing this into "no
+    // part" would CLEAR a good stamp.
+    h.bySystemAttributes.mockResolvedValue({ catalog_item_part: null })
+
+    const values = await stamp(
+      buildContext({
+        operation: 'update',
+        values: { [CATALOG_FIELD_ID]: CATALOG_ITEM },
+        existingInstance: { id: 'inst-line-1' },
+      })
+    )
+
+    expect(PART_FIELD_ID in values).toBe(false)
+  })
+
+  it('does not block the line write when the catalog-item read throws', async () => {
+    h.bySystemAttributes.mockRejectedValue(new Error('redis down'))
+
+    const values = await stamp(buildContext({ values: { [CATALOG_FIELD_ID]: CATALOG_ITEM } }))
+
+    expect(values).toEqual({ [CATALOG_FIELD_ID]: CATALOG_ITEM })
+  })
+})
+
+describe('the stamp is FROZEN (08 §6.2 / §8)', () => {
+  // The assertion the whole feature exists for: the three-hop
+  // line_item → catalog_item → part chain is LIVE, so re-pointing `catalog_item.part`
+  // later must NOT re-attribute an already-stamped historical sale. The hook only ever
+  // fires on a `line_item_catalog_item` write, so the observable form of that claim is:
+  // a write that does not touch the catalog item leaves `line_item_part` untouched.
+  it('a write that does not touch the catalog item leaves line_item_part alone', async () => {
+    catalogItemHasPart(PART_B) // catalog_item.part has since moved to PART_B
+
+    const values = await stamp(
+      buildContext({
+        operation: 'update',
+        values: { 'fld-line-qty': 3 },
+        existingInstance: { id: 'inst-line-1' },
+      })
+    )
+
+    expect(values).toEqual({ 'fld-line-qty': 3 })
+    expect(h.getValues).not.toHaveBeenCalled()
+  })
+
+  it('nothing is written on a create that carries no catalog item at all', async () => {
+    catalogItemHasPart(PART_A)
+
+    const values = await stamp(buildContext({ values: { 'fld-line-description': 'labour' } }))
+
+    expect(values).toEqual({ 'fld-line-description': 'labour' })
+    expect(h.getValues).not.toHaveBeenCalled()
+  })
+})
+
+describe('line_item hook registration', () => {
+  it('is reachable through the entity-type registry, not just the module export', () => {
+    // HOOKS_BY_ENTITY_TYPE returns {} for an unregistered entityType rather than
+    // failing — forgetting this entry is a silent no-op (08 status block).
+    expect(getSystemHooks('line_item')).toBe(LINE_ITEM_HOOKS)
+    expect(Object.keys(getSystemHooks('line_item')).length).toBeGreaterThan(0)
+  })
+
+  it('⚠️ is keyed on `line_item_catalog_item`, NOT `line_item_part`', () => {
+    // `runPreHooks` skips a hook on UPDATE unless its own registered systemAttribute is
+    // present in `values`. Keyed on `line_item_part` this would fire on create only and
+    // never follow a re-point, which is half the feature.
+    expect(Object.keys(LINE_ITEM_HOOKS)).toEqual(['line_item_catalog_item'])
+    expect(getHooksForAttribute('line_item', 'line_item_catalog_item')).toHaveLength(1)
+    expect(getHooksForAttribute('line_item', 'line_item_part')).toHaveLength(0)
+  })
+})
+
+describe('the stamp never moves a total', () => {
+  it('line_item_part is not a total trigger', async () => {
+    // 08 §2 ⚠️ / §7.2 correction 1: the part is provenance and grouping, never a pricing
+    // input. In LINE_TRIGGER_ATTRS it would fire a full document recompute per stamped
+    // line for a number that provably did not change — and that set is also the
+    // vocabulary the finalize integrity passes match on.
+    const { LINE_TRIGGER_ATTRS } = await import('../../../money/totals-hooks')
+    expect(LINE_TRIGGER_ATTRS.has('line_item_part')).toBe(false)
+    expect(LINE_TRIGGER_ATTRS.has('line_item_catalog_item')).toBe(false)
+  })
+})

--- a/packages/lib/src/resources/hooks/index.ts
+++ b/packages/lib/src/resources/hooks/index.ts
@@ -3,6 +3,7 @@
 export { autoSetCreatedBy, COMMON_HOOKS } from './common-hooks'
 export { CONTACT_HOOKS } from './contact-hooks'
 export { INVOICE_HOOKS } from './invoice-hooks'
+export { LINE_ITEM_HOOKS } from './line-item-hooks'
 export { ORDER_HOOKS } from './order-hooks'
 export { PAYMENT_HOOKS } from './payment-hooks'
 export { QUOTE_HOOKS } from './quote-hooks'

--- a/packages/lib/src/resources/hooks/line-item-hooks.ts
+++ b/packages/lib/src/resources/hooks/line-item-hooks.ts
@@ -1,0 +1,135 @@
+// packages/lib/src/resources/hooks/line-item-hooks.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { TypedFieldValue } from '@auxx/types'
+import { getOrgCache } from '../../cache'
+import { FieldValueService } from '../../field-values/field-value-service'
+import { isRecordId, type RecordId } from '../resource-id'
+import type { SystemHook, SystemHookRegistry } from './types'
+
+const logger = createScopedLogger('resources:line-item-hooks')
+
+/**
+ * Unwrap a write-time value that may be scalar or a single-element array, then read a
+ * `RecordId` out of it. Relationship values reach a pre-hook as the `"<defId>:<instanceId>"`
+ * string, but `values` is also accepted keyed by `field.id` OR by `systemAttribute`, and
+ * some writers wrap the value in an array or in a `{ recordId }` object.
+ */
+function readRecordId(raw: unknown): RecordId | null {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (typeof value === 'string') return isRecordId(value) ? value : null
+  if (value && typeof value === 'object' && 'recordId' in value) {
+    const inner = (value as { recordId?: unknown }).recordId
+    return typeof inner === 'string' && isRecordId(inner) ? inner : null
+  }
+  return null
+}
+
+/**
+ * Read `catalog_item_part` off a catalog item.
+ *
+ * Three-state on purpose:
+ * - a `RecordId` — the catalog item is backed by that part
+ * - `null` — the catalog item resolved and is backed by NO part
+ * - `undefined` — the part could not be resolved at all (the org has no
+ *   `catalog_item_part` field, or the read failed). The caller must leave any existing
+ *   stamp alone in that case; collapsing it into `null` would clear a good stamp on a
+ *   transient failure.
+ */
+export async function resolveCatalogItemPart(params: {
+  organizationId: string
+  userId: string
+  catalogItemRecordId: RecordId
+}): Promise<RecordId | null | undefined> {
+  const { organizationId, userId, catalogItemRecordId } = params
+
+  try {
+    const cf = await getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttributes(['catalog_item_part'] as const)
+    if (!cf.catalog_item_part) return undefined
+
+    const values = await new FieldValueService(organizationId, userId).getValues({
+      recordId: catalogItemRecordId,
+      fieldIds: [cf.catalog_item_part.id],
+    })
+    const entry = values.get(cf.catalog_item_part.id)
+    const typed: TypedFieldValue | undefined = Array.isArray(entry) ? entry[0] : entry
+    if (typed?.type === 'relationship' && typed.recordId) return typed.recordId
+    return null
+  } catch (error) {
+    // A provenance stamp must never block the line write it rides on.
+    logger.warn('could not resolve catalog_item_part — leaving line_item_part untouched', {
+      organizationId,
+      catalogItemRecordId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
+}
+
+/**
+ * Stamp `line_item_part` from the line's catalog item (08 §6.2).
+ *
+ * ⚠️ **Registered under `line_item_catalog_item`, NOT `line_item_part`.** `runPreHooks`
+ * skips a hook on UPDATE unless its own registered systemAttribute is present in `values`
+ * (`resources/crud/unified-handler.ts`). Keyed on `line_item_part` the stamp would fire on
+ * create only and never when a line is re-pointed at a different catalog item — half the
+ * feature. Keyed on the catalog item it fires on create and on every catalog-item change,
+ * and on nothing else.
+ *
+ * That "nothing else" is the whole point. The `line_item → catalog_item → part` chain is
+ * LIVE: re-pointing `catalog_item.part` later would silently re-attribute every historical
+ * sale that ever went through that catalog item. This stamp is therefore FROZEN — it is
+ * written when the line's catalog item is written and never re-derived, which is the same
+ * answer Gap C §3.2 reached for `partKind`.
+ *
+ * Rules:
+ * - The field stays writable. An explicit `line_item_part` in the SAME write wins — that is
+ *   the human override, and a line that sells a part directly sets it itself.
+ * - A catalog item with no part CLEARS the stamp on update. The line now sells something
+ *   with no part behind it, and a stale stamp pointing at the previous catalog item's part
+ *   is worse than no stamp: it is wrong, and it is wrong in the reporting join this field
+ *   exists to serve. On create there is nothing to clear, so nothing is written.
+ * - `line_item_part` is deliberately NOT in `LINE_TRIGGER_ATTRS` (`money/totals-hooks.ts`),
+ *   so this stamp never fires a document total recompute. The part is provenance and
+ *   grouping, never a pricing input (08 §7.2 correction 1).
+ */
+const stampPartFromCatalogItem: SystemHook = async ({
+  operation,
+  field,
+  values,
+  organizationId,
+  userId,
+  allFields,
+}) => {
+  const partField = allFields.find((f) => f.systemAttribute === 'line_item_part')
+  if (!partField) return values
+
+  // The human override: the caller is setting the part itself in this operation.
+  if (partField.id in values || 'line_item_part' in values) return values
+
+  const catalogKey = field.id in values ? field.id : (field.systemAttribute ?? '')
+  if (!(catalogKey in values)) return values
+
+  const catalogItemRecordId = readRecordId(values[catalogKey])
+  const part = catalogItemRecordId
+    ? await resolveCatalogItemPart({ organizationId, userId, catalogItemRecordId })
+    : null
+
+  if (part === undefined) return values
+  if (part === null && operation === 'create') return values
+
+  return { ...values, [partField.id]: part }
+}
+
+/**
+ * System hooks for `line_item`.
+ *
+ * ⚠️ Registering the file is not enough — `HOOKS_BY_ENTITY_TYPE` in `system-hooks.ts`
+ * returns `{}` for an unregistered entity type rather than failing, which is exactly how
+ * `order_number` stayed NULL for three PRs (08 status block).
+ */
+export const LINE_ITEM_HOOKS: SystemHookRegistry = {
+  line_item_catalog_item: [stampPartFromCatalogItem],
+}

--- a/packages/lib/src/resources/hooks/system-hooks.ts
+++ b/packages/lib/src/resources/hooks/system-hooks.ts
@@ -3,6 +3,7 @@
 import { COMMON_HOOKS } from './common-hooks'
 import { CONTACT_HOOKS } from './contact-hooks'
 import { INVOICE_HOOKS } from './invoice-hooks'
+import { LINE_ITEM_HOOKS } from './line-item-hooks'
 import { ORDER_HOOKS } from './order-hooks'
 import { PAYMENT_HOOKS } from './payment-hooks'
 import { QUOTE_HOOKS } from './quote-hooks'
@@ -29,6 +30,7 @@ const HOOKS_BY_ENTITY_TYPE: Record<string, SystemHookRegistry> = {
   invoice: INVOICE_HOOKS,
   payment: PAYMENT_HOOKS,
   order: ORDER_HOOKS,
+  line_item: LINE_ITEM_HOOKS,
 }
 
 /**


### PR DESCRIPTION
Phase 4 of [`plans/products/08-order-build.md`](../blob/main/plans/products/08-order-build.md). `line_item.part` has existed since migration 107 and **nothing wrote it**. It is now stamped at write time from the line's catalog item, so revenue by product is one join instead of three.

## Why a stamp and not a lookup

The `line_item → catalog_item → part` chain is **live**. Re-pointing `catalog_item.part` today silently re-attributes every historical sale that ever went through that catalog item — the same objection Gap C §3.2 raised for `partKind` (*"unlink a variant and every historical posting that relieved 1330 becomes unexplainable"*), and it was accepted there. A grouping key that feeds accounting is stamped and auditable, never re-derived from fields a user can edit later.

08 §6.2 also settles the open question from OUTSTANDING §3b: **`catalogItem` wins for pricing, `part` is not a pricing input.** The line already carries its own `unitPrice`/`lineTotal`; the relations are provenance and grouping.

## Two doors, because a line has two write paths

This is the part worth reviewing. The two paths run **different hook systems**:

| action | tRPC | dispatcher | reads system hooks? |
| --- | --- | --- | --- |
| add a line | `record.create` / `createMany` | `runPreHooks` | ✅ |
| **edit an existing line** | `fieldValue.set` → `setValueWithBuiltIn` | `getEntityFieldChangeHooks` | ❌ **never** |

- `LINE_ITEM_HOOKS` (`resources/hooks/line-item-hooks.ts`) covers the `UnifiedCrudHandler` writes — how the LineBuilder **adds** a line, and how the money layer copies one at quote conversion (`convert-quote.ts:355`).
- `stampPartOnCatalogItemChange` (`field-hooks/post/`) covers every **edit**, which goes through `useSaveFieldValue` → `FieldValueService` and consults only `getEntityFieldChangeHooks`. That path never reads the system-hook registry — the same bypass `invoice-hooks.ts` records for money's lifecycle writers.

**The second door was found by testing the running app**, not by reading code: re-pointing a line at a catalog item that has a part left `line_item_part` NULL, because re-pointing never reaches `runPreHooks`. Without it, the system hook's whole reason for being keyed on `line_item_catalog_item` — so a re-point re-stamps — is unreachable in the product.

Both doors call the same `resolveCatalogItemPart`, so the semantics cannot drift. A field **pre**-hook could not do this: it may only transform its own field's value, and this writes a different field.

## Registration traps

- **Keyed under `line_item_catalog_item`, never `line_item_part`.** `runPreHooks` skips a hook on *update* unless its own systemAttribute is in `values`; keyed on the part it would fire on create only. Pinned by a test asserting `getHooksForAttribute('line_item', 'line_item_part')` is empty.
- **`HOOKS_BY_ENTITY_TYPE` had no `line_item` key at all**, and returns `{}` for an unregistered type rather than failing — the same silence that left `order_number` NULL for three PRs (#1911→#1914).
- **`line_item_part` stays out of `LINE_TRIGGER_ATTRS`.** The stamp must not fire a document total recompute. Pinned here, and `107-order.test.ts:368` already asserted it.

## Three behaviours, identical on both doors

- catalog item **with** a part → stamp it (a re-point re-stamps; frozen against later edits to `catalog_item.part`, never against a change of *which* catalog item the line sells)
- catalog item with **no** part, or detached → **clear** the stamp. A stamp pointing at the *previous* catalog item's part is wrong precisely in the reporting join this field exists for.
- **unresolvable** (unmigrated org, transient read failure) → leave any existing stamp alone. This third state is deliberately distinct from "no part"; collapsing them would wipe good provenance on a Redis blip.

## Verified on the live dev database

Through the real doors, not mocks:

```
RESULT after re-point to partless catalog item : []                             ← cleared
RESULT after re-point to Auxx-Lift Gray        : [ 'ocmdutjip9hwtquet080yju5' ]  ← stamped
```

Both `line_item_part` and its `part_line_items` mirror are written.

## 🔴 The backfill stamps ZERO rows, and that is the finding

`scripts/backfill-line-item-part.ts` — dry-run by default, writes through `UnifiedCrudHandler.update` (so both halves of the relation and `searchText` are maintained), never overwrites an existing stamp, idempotent.

08 §6.1 measured `catalog_item → part` at 2 of 9 and predicted a small repair. It is not small, it is **empty**: the two catalog items that carry a part (`Auxx-Lift Gray 4x8 400`, `Auxx-Lift White 4x8 400`) are referenced by **no line item**. All 105 catalog-item-bearing lines point at one of six others, every one with `part_id NULL`.

The script still earns its place — it covers orgs where the chain is populated, and [02](../blob/main/plans/products/02-shopify-mapping.md)'s contribute mode closes `catalog_item.part` as a side effect (§6.3) — but it repairs nothing today. **Not applied.**

## Also

The catalog picker's `Linked part` text label is now a `Package` icon with a tooltip — the row already carries a name and a price, and the label competed with both for a fact that only matters on hover.

## Tests

- `line-item-hooks.test.ts` — 16, including the §8 frozen-stamp assertion in its strongest form: a write that does not touch the catalog item leaves `line_item_part` alone **and never reads the catalog item**, even after `catalog_item.part` has moved.
- `line-item-part-stamp.test.ts` — 7 for the edit door.

400 tests green across field-hooks/hooks/money; typecheck ratchet clean (29, baseline 29); web typecheck clean.

⚠️ **Worth noting for review:** the unit tests could not have caught the missing second door — they mock the write path, so they prove the hook's logic, not that anything calls it. Only driving the real app did. A DB-backed integration test over `setValueWithBuiltIn` would close that gap; happy to add it here or as a follow-up.