### PR TITLE
fix(line-builder): render the part, restore units, make a PO's stated amounts editable

### DIFF
--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -526,6 +526,25 @@ export function LineBuilder({
     [hasBilling, saveMultipleAsync, docRecordId, billingPrefix]
   )
 
+  /**
+   * Write one of a `stated` document's own amount mirrors (`shipping_total`,
+   * `tax_total`, `discount_value`).
+   *
+   * 🛑 These are INPUTS, not derived figures — `purchase_order_shipping_total` is
+   * described in the registry as *"typed by hand from the freight invoice"* and is
+   * what `allocateLandedCost` spreads across the lines on receipt. All three are
+   * `creatable: true, updatable: true` and `showInPanel: false`, so this footer is
+   * the ONLY place in the app they can be entered. Rendering them read-only (which
+   * is what `stated` did at first) leaves landed cost permanently unreachable.
+   */
+  const updateStatedAmount = useCallback(
+    (attribute: string, cents: number | null) => {
+      if (schema.totalsMode !== 'stated') return
+      saveFieldValue(docRecordId, `${billingPrefix}_${attribute}`, cents, FieldType.CURRENCY)
+    },
+    [schema.totalsMode, saveFieldValue, docRecordId, billingPrefix]
+  )
+
   const updateTax = useCallback(
     (name: string | null, rate: number | null) => {
       if (!hasBilling) return
@@ -1101,7 +1120,7 @@ export function LineBuilder({
           className='sticky top-0 z-10 grid rounded-t-lg border-primary-200/50 border-b bg-primary-50 px-1 py-2 text-muted-foreground text-sm dark:border-[#1e2227] dark:bg-background'
           style={{ gridTemplateColumns: LINE_COLS }}>
           <div className='flex items-center gap-1 pl-2'>
-            Description
+            {schema.primaryColumnLabel}
             {!readOnly && (
               <SimpleTooltip content='Add line item' side='right'>
                 <Button
@@ -1203,6 +1222,7 @@ export function LineBuilder({
         taxRates={taxRates}
         onUpdateDiscount={updateDiscount}
         onUpdateTax={updateTax}
+        onUpdateStatedAmount={updateStatedAmount}
       />
     </div>
   )

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -883,11 +883,24 @@ function formatQtyDisplay(qty: number, unit: LineItemUnit | null): string {
 function QuantityCellView({
   quantity,
   unit,
+  unitEditable,
   readOnly,
   onCommit,
 }: {
   quantity: number
   unit: LineItemUnit | null
+  /**
+   * Whether the unit is this row's to change — `schema.capabilities.unit`.
+   *
+   * 🛑 On a purchasing line it is FALSE, and the unit shown comes from the PART
+   * (`part_unit`), not the line: `purchase_order_line` has no unit attribute, so
+   * a pick here would go through `linePatchToFieldValues`, which drops the key,
+   * and appear to work while changing nothing. It is on the part by design — a
+   * line ordered in `box` and received in `ea` would make the received-vs-ordered
+   * roll-up compare two different units. A PO does not get to choose the unit its
+   * part is stocked in, so the cell renders it without a dropdown.
+   */
+  unitEditable: boolean
   readOnly: boolean
   onCommit: (next: { quantity: number; unit: LineItemUnit | null }) => void
 }) {
@@ -913,7 +926,9 @@ function QuantityCellView({
       return
     }
     const nextQuantity = parsed.quantity ?? quantity
-    const nextUnit = parsed.unit
+    // Where the unit is not this row's to change, a typed `5 ea` still commits the
+    // 5 — the parsed unit is discarded rather than flashing the cell invalid.
+    const nextUnit = unitEditable ? parsed.unit : unit
     if (nextQuantity === quantity && nextUnit === unit) return
     onCommit({ quantity: nextQuantity, unit: nextUnit })
   }
@@ -943,26 +958,28 @@ function QuantityCellView({
           invalid && 'bg-destructive/10 ring-1 ring-destructive/60'
         )}
       />
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type='button'
-            tabIndex={-1}
-            onMouseDown={(e) => e.preventDefault()}
-            className='-translate-y-1/2 absolute top-1/2 right-0.5 rounded-sm p-0.5 text-muted-foreground opacity-0 outline-none hover:bg-primary-100 focus:opacity-100 group-hover/qty:opacity-100'>
-            <ChevronsUpDown className='size-3' />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align='end' className='max-h-64 overflow-y-auto'>
-          <DropdownMenuItem onSelect={() => pickUnitOnly(null)}>No unit</DropdownMenuItem>
-          <DropdownMenuSeparator />
-          {LINE_ITEM_UNIT_OPTIONS.map((option) => (
-            <DropdownMenuItem key={option.value} onSelect={() => pickUnitOnly(option.value)}>
-              {option.label}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      {unitEditable && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type='button'
+              tabIndex={-1}
+              onMouseDown={(e) => e.preventDefault()}
+              className='-translate-y-1/2 absolute top-1/2 right-0.5 rounded-sm p-0.5 text-muted-foreground opacity-0 outline-none hover:bg-primary-100 focus:opacity-100 group-hover/qty:opacity-100'>
+              <ChevronsUpDown className='size-3' />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end' className='max-h-64 overflow-y-auto'>
+            <DropdownMenuItem onSelect={() => pickUnitOnly(null)}>No unit</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {LINE_ITEM_UNIT_OPTIONS.map((option) => (
+              <DropdownMenuItem key={option.value} onSelect={() => pickUnitOnly(option.value)}>
+                {option.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   )
 }
@@ -1012,6 +1029,8 @@ function LineRowMenu({
   taxable,
   optional,
   showOptionalToggle,
+  showCategory = true,
+  showTaxable = true,
   hasDescription,
   hasCategory,
   hasPhotos,
@@ -1025,6 +1044,13 @@ function LineRowMenu({
   taxable: boolean
   optional: boolean
   showOptionalToggle: boolean
+  /**
+   * `schema.capabilities.category` / `.taxable`. A purchasing line has neither
+   * field, so the item would write through `linePatchToFieldValues`, which drops
+   * the key — the click would appear to work and change nothing.
+   */
+  showCategory?: boolean
+  showTaxable?: boolean
   hasDescription: boolean
   hasCategory: boolean
   hasPhotos: boolean
@@ -1061,11 +1087,13 @@ function LineRowMenu({
           {hasDescription ? 'Edit description' : 'Add description'}
           <MenuShortcut keys={['⇧', 'D']} />
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onSetCategory}>
-          <Tags />
-          {hasCategory ? 'Change category' : 'Add category'}
-          <MenuShortcut keys={['⇧', 'L']} />
-        </DropdownMenuItem>
+        {showCategory && (
+          <DropdownMenuItem onSelect={onSetCategory}>
+            <Tags />
+            {hasCategory ? 'Change category' : 'Add category'}
+            <MenuShortcut keys={['⇧', 'L']} />
+          </DropdownMenuItem>
+        )}
         {onOpenPhotos && (
           <DropdownMenuItem onSelect={onOpenPhotos}>
             <Camera />
@@ -1080,11 +1108,13 @@ function LineRowMenu({
             <MenuShortcut keys={['⇧', 'O']} />
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem onSelect={() => onToggleTaxable(!taxable)}>
-          {taxable ? <CircleX /> : <CircleCheck />}
-          {taxable ? 'Mark tax exempt' : 'Mark taxable'}
-          <MenuShortcut keys={['⇧', 'X']} />
-        </DropdownMenuItem>
+        {showTaxable && (
+          <DropdownMenuItem onSelect={() => onToggleTaxable(!taxable)}>
+            {taxable ? <CircleX /> : <CircleCheck />}
+            {taxable ? 'Mark tax exempt' : 'Mark taxable'}
+            <MenuShortcut keys={['⇧', 'X']} />
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem variant='destructive' onSelect={onDelete}>
           <Trash2 />
@@ -1105,8 +1135,8 @@ function LineRowMenu({
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * The leading cell for a purchasing line: a `part` relation picker over a free-text
- * description, in place of the sell-side name + catalog picker.
+ * The leading cell for a purchasing line: a `part` relation picker where the
+ * sell-side cell puts its free-text name + catalog picker.
  *
  * 🛑 This is not a styling variant of {@link LineNameCellView}. A purchasing line's
  * identity IS its part — `purchase_order_line.part` is `required: true` and leg 2
@@ -1115,6 +1145,15 @@ function LineRowMenu({
  * as the catalog pick does on the sell side; a description typed first accumulates
  * on the draft and is written with the part in one create. Committing on the
  * description instead would send a create the server must reject.
+ *
+ * ⚠️ Its ANATOMY, though, is deliberately the sell-side one, and the first cut got
+ * that wrong: it stacked a permanently-visible description input under the picker,
+ * which is precisely what {@link LineNameCellView} documents itself as avoiding —
+ * *"the line never grows a permanent second row"*. Purchasing rows rendered at
+ * double height beside every other document's, and the cell had no `⋯` menu at
+ * all, so a purchasing line could not be deleted from the grid and none of the
+ * row shortcuts reached it. Now: description is a standing button only once set,
+ * adding one lives in the `⋯` menu, and editing swaps the cell in place.
  *
  * The field definition is sourced live rather than stubbed so the picker gets a
  * real `RelationshipConfig` — and with it "create new part" — the same way the
@@ -1127,6 +1166,7 @@ function LinePartCellView({
   readOnly,
   onPickPart,
   onCommitDescription,
+  onDelete,
 }: {
   /** `purchase_order_line_part` / `vendor_bill_line_part`, from the schema. */
   partAttribute: string
@@ -1135,56 +1175,168 @@ function LinePartCellView({
   readOnly: boolean
   onPickPart: (recordId: RecordId | null) => void
   onCommitDescription: (value: string | null) => void
+  /** Delete this line (real record or draft). */
+  onDelete: () => void
 }) {
   const partField = useSystemField(partAttribute)
+  // `null` = not editing description; any string (incl. '') = in-progress text.
   const [descriptionDraft, setDescriptionDraft] = useState<string | null>(null)
-  const value = descriptionDraft ?? description ?? ''
 
-  const commitDescription = () => {
+  const confirmDescription = () => {
     if (descriptionDraft === null) return
-    const next = descriptionDraft.trim()
+    onCommitDescription(descriptionDraft.trim() || null)
     setDescriptionDraft(null)
-    if ((next || null) !== (description || null)) onCommitDescription(next || null)
   }
 
-  return (
-    <div className='flex min-w-0 flex-1 flex-col justify-center gap-0.5 py-0.5'>
-      {readOnly ? (
+  // Row-action shortcuts (use-line-hotkeys.ts) arrive as CustomEvents on the
+  // enclosing name cell — same contract as LineNameCellView. Only the two
+  // actions a purchasing line actually has are handled; the rest are no-ops
+  // rather than writes to fields the entity does not carry.
+  const rootRef = useRef<HTMLDivElement>(null)
+  const actionRef = useRef<(action: LineRowAction) => void>(() => {})
+  actionRef.current = (action) => {
+    if (action === 'description') {
+      if (descriptionDraft === null) setDescriptionDraft(description ?? '')
+      return
+    }
+    if (action === 'delete') onDelete()
+  }
+  useEffect(() => {
+    const cell = rootRef.current?.closest('[data-line-col]')
+    if (!cell) return
+    const onAction = (e: Event) => actionRef.current((e as CustomEvent<LineRowAction>).detail)
+    cell.addEventListener(LINE_ROW_ACTION_EVENT, onAction)
+    return () => cell.removeEventListener(LINE_ROW_ACTION_EVENT, onAction)
+  }, [])
+
+  // Description edit mode — replaces the cell with an autosize textarea in the
+  // same slot, exactly as the sell-side cell does.
+  if (descriptionDraft !== null) {
+    return (
+      <div ref={rootRef} className='flex min-w-0 flex-1 items-center gap-1 py-1'>
+        <AutosizeTextarea
+          value={descriptionDraft}
+          onChange={(e) => setDescriptionDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              confirmDescription()
+            }
+            if (e.key === 'Escape') setDescriptionDraft(null)
+          }}
+          autoFocus
+          minHeight={28}
+          maxHeight={160}
+          placeholder='What the supplier calls it'
+          className='min-w-0 flex-1 resize-none rounded-sm border-primary-200/60 bg-transparent px-2 py-1 text-muted-foreground text-xs'
+        />
+        <TreeRowButton persistent tooltipText='Save description' onClick={confirmDescription}>
+          <Check />
+        </TreeRowButton>
+        <TreeRowButton
+          persistent
+          variant='destructive'
+          tooltipText='Cancel'
+          onClick={() => setDescriptionDraft(null)}>
+          <X />
+        </TreeRowButton>
+      </div>
+    )
+  }
+
+  if (readOnly) {
+    return (
+      <div className='flex min-w-0 flex-1 items-center gap-1.5 py-1'>
         <span className='min-w-0 truncate px-1 text-sm'>
           {partField?.label ?? 'Part'}
           {partRecordId ? '' : ' —'}
         </span>
-      ) : (
-        <FieldInputAdapter
-          fieldType={partField?.fieldType ?? FieldType.RELATIONSHIP}
-          fieldOptions={partField?.options}
-          triggerProps={{ className: 'h-7 w-full border-none bg-transparent px-1 shadow-none' }}
-          value={partRecordId ? [partRecordId] : []}
-          onChange={(next) => {
-            const ids = next as RecordId[]
-            onPickPart(ids[0] ?? null)
-          }}
-          placeholder='Select part...'
-        />
+        {description && <TooltipExplanation text={description} />}
+      </div>
+    )
+  }
+
+  return (
+    <div ref={rootRef} className='flex min-w-0 flex-1 items-center gap-1.5 py-1'>
+      <FieldInputAdapter
+        fieldType={partField?.fieldType ?? FieldType.RELATIONSHIP}
+        fieldOptions={partField?.options}
+        // `PickerTrigger` takes no data attributes, so the grid's nav hook matches
+        // this trigger on `[role="combobox"]` instead — see use-line-nav.ts.
+        triggerProps={{
+          className: 'h-7 min-w-0 flex-1 border-none bg-transparent px-1 shadow-none',
+        }}
+        value={partRecordId ? [partRecordId] : []}
+        onChange={(next) => {
+          const ids = next as RecordId[]
+          onPickPart(ids[0] ?? null)
+        }}
+        placeholder='Select part...'
+      />
+
+      {/* Description button — a standing control, but only when the line HAS a
+          description; ADDING one lives in the `⋯` menu. Mirrors the sell side. */}
+      {description && (
+        <TreeRowButton
+          persistent
+          tabIndex={-1}
+          tooltipText={description}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => setDescriptionDraft(description)}>
+          <AlignLeft />
+        </TreeRowButton>
       )}
-      {readOnly ? (
-        description && (
-          <span className='min-w-0 truncate px-1 text-muted-foreground text-xs'>{description}</span>
-        )
-      ) : (
-        <input
-          data-cell-focusable
-          value={value}
-          onChange={(e) => setDescriptionDraft(e.target.value)}
-          onFocus={() => setDescriptionDraft(description ?? '')}
-          onBlur={commitDescription}
-          placeholder='What the supplier calls it'
-          className='h-6 min-w-0 rounded-sm border-none bg-transparent px-1 text-muted-foreground text-xs outline-none placeholder:text-muted-foreground/50'
-        />
-      )}
+
+      {/* Always the cell's LAST flex child, so its slot is stable across the
+          rest ↔ description-editor swap. Category / taxable / images / optional
+          are all off: a purchasing line carries none of those fields. */}
+      <LineRowMenu
+        taxable={false}
+        optional={false}
+        showOptionalToggle={false}
+        showCategory={false}
+        showTaxable={false}
+        hasDescription={!!description}
+        hasCategory={false}
+        hasPhotos={false}
+        onEditDescription={() => setDescriptionDraft(description ?? '')}
+        onSetCategory={() => {}}
+        onToggleTaxable={() => {}}
+        onToggleOptional={() => {}}
+        onDelete={onDelete}
+      />
     </div>
   )
 }
+
+/**
+ * The stock unit of measure to show beside a purchasing line's quantity, read
+ * from the line's PART rather than the line (`part_unit` — see `PART_FIELDS.unit`).
+ *
+ * Falls back to `each` when the part carries no unit. That is not a guess: every
+ * quantity in the inventory chain — `part_quantity_on_hand`, `stock_movement_quantity`,
+ * BOM quantities, ordered/received — is already a bare count of discrete units, so
+ * `each` is the semantics those numbers ALREADY have, simply made visible. The
+ * field ships `defaultValue: 'each'` and there is no backfill, so existing parts
+ * read through this fallback until someone sets one.
+ *
+ * `null` (no part picked yet) skips the fetch and still yields `each`, which is
+ * what keeps a draft row and the persisted row it becomes reading identically —
+ * the mismatch that `1 ea` vs `1` used to be.
+ */
+function usePartUnit(partRecordId: RecordId | null): LineItemUnit {
+  const { values } = useSystemValues(partRecordId ?? ('' as RecordId), PART_UNIT_ATTRS, {
+    autoFetch: !!partRecordId,
+    enabled: !!partRecordId,
+  })
+  // SINGLE_SELECT reads back as a single-element array in some paths and a scalar
+  // in others (`useSystemValues` collapses it) — tolerate both.
+  const raw = values.part_unit
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return (typeof value === 'string' ? (value as LineItemUnit) : null) ?? 'each'
+}
+
+const PART_UNIT_ATTRS = ['part_unit'] as const
 
 /** One sortable line row — a grid row whose leading slot is the drag grip. */
 export function LineRow({
@@ -1227,6 +1379,7 @@ export function LineRow({
   const showOptional = schema.capabilities.optional
   const { values } = useSystemValues(recordId, lineAttributesFor(schema), { autoFetch: false })
   const line = lineValuesFromSystemValues(values, schema)
+  const partUnit = usePartUnit(schema.capabilities.partPicker ? line.partRecordId : null)
   // FILE is array-return (plan 37b §3) — the photos attribute reads back as an array
   // of `{ ref, caption?, internal? }` envelopes (or is absent/empty when there are
   // none). A document whose lines carry no photos field has no attribute to read.
@@ -1258,6 +1411,7 @@ export function LineRow({
               readOnly={readOnly}
               onPickPart={(partRecordId) => onUpdateLine(recordId, { partRecordId })}
               onCommitDescription={(description) => onUpdateLine(recordId, { description })}
+              onDelete={() => deleteLine(record.id)}
             />
           ) : (
             <LineNameCellView
@@ -1306,7 +1460,10 @@ export function LineRow({
         qty={
           <QuantityCellView
             quantity={line.qty}
-            unit={line.unit}
+            // A purchasing line's unit is the PART's; the schema's own `unit`
+            // attribute is `null` there, so `line.unit` is always null too.
+            unit={schema.capabilities.partPicker ? partUnit : line.unit}
+            unitEditable={schema.capabilities.unit}
             readOnly={readOnly}
             onCommit={(next) => {
               const patch: LinePatch = {}
@@ -1375,6 +1532,7 @@ export function DraftLineRow({
 }) {
   const schema = lineSchemaFor(documentType)
   const showOptional = schema.capabilities.optional
+  const partUnit = usePartUnit(schema.capabilities.partPicker ? draft.partRecordId : null)
 
   return (
     <LineGridRow
@@ -1396,6 +1554,7 @@ export function DraftLineRow({
             // creating while the part is still unset — every draft-state write
             // goes through `mutateDrafts`, never a direct mutation.
             onCommitDescription={(description) => void createDraft(draft.draftId, { description })}
+            onDelete={() => deleteDraft(draft.draftId)}
           />
         ) : (
           <LineNameCellView
@@ -1433,7 +1592,8 @@ export function DraftLineRow({
       qty={
         <QuantityCellView
           quantity={draft.qty}
-          unit={draft.unit}
+          unit={schema.capabilities.partPicker ? partUnit : draft.unit}
+          unitEditable={schema.capabilities.unit}
           readOnly={false}
           onCommit={(next) =>
             void createDraft(draft.draftId, { qty: next.quantity, unit: next.unit })

--- a/apps/web/src/components/money/ui/line-builder/line-schemas.test.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-schemas.test.ts
@@ -244,6 +244,53 @@ describe('reading back a line whose entity lacks the sell-side fields', () => {
   })
 })
 
+describe('reading values back from the store', () => {
+  // 🛑 The defect this pins shipped: `useSystemValues` collapses SINGLE_SELECT to a
+  // scalar but leaves RELATIONSHIP as an ARRAY, and `lineValuesFromSystemValues`
+  // read `partRecordId` as if it were a scalar. The one-element array then flowed
+  // into `LinePartCellView`, which wraps it a second time, so `RecordBadge` got an
+  // array where it expects an id and rendered a permanent loading skeleton. Every
+  // purchase-order line showed a grey pill instead of its part, and nothing threw.
+  it('collapses the RELATIONSHIP array a part reads back as', () => {
+    const line = lineValuesFromSystemValues(
+      { purchase_order_line_part: ['part_def:part_instance'] },
+      LINE_SCHEMAS.purchase_order
+    )
+    expect(line.partRecordId).toBe('part_def:part_instance')
+  })
+
+  it('reads a bare relationship id unchanged, and an empty one as null', () => {
+    const scalar = lineValuesFromSystemValues(
+      { vendor_bill_line_part: 'part_def:part_instance' },
+      LINE_SCHEMAS.vendor_bill
+    )
+    expect(scalar.partRecordId).toBe('part_def:part_instance')
+    expect(
+      lineValuesFromSystemValues({ vendor_bill_line_part: [] }, LINE_SCHEMAS.vendor_bill)
+        .partRecordId
+    ).toBeNull()
+    expect(lineValuesFromSystemValues({}, LINE_SCHEMAS.vendor_bill).partRecordId).toBeNull()
+  })
+
+  // A document whose lines carry no unit field must not render the unit control —
+  // `linePatchToFieldValues` drops the key, so the pick would silently do nothing.
+  it('every document that shows a unit has a unit attribute to write it to', () => {
+    for (const documentType of ALL) {
+      const { capabilities, attrs } = lineSchemaFor(documentType)
+      expect(capabilities.unit).toBe(attrs.unit !== null)
+    }
+  })
+
+  // The leading cell of a buy-side row is a part picker; heading it "Description"
+  // names the wrong one of the two controls stacked in it.
+  it('labels the leading column for what it actually picks', () => {
+    for (const documentType of ALL) {
+      const { capabilities, primaryColumnLabel } = lineSchemaFor(documentType)
+      expect(primaryColumnLabel).toBe(capabilities.partPicker ? 'Part' : 'Description')
+    }
+  })
+})
+
 describe('capabilities match the vocabulary', () => {
   // The defect a flag/vocabulary mismatch produces is a rendered cell that writes
   // to a field the entity does not have.

--- a/apps/web/src/components/money/ui/line-builder/line-values.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-values.ts
@@ -136,6 +136,14 @@ export interface LineSchema {
   sortAttr: string
   /** Which text column leads the row. A PO line has no `name`, so it leads with description. */
   primaryTextKey: 'name' | 'description'
+  /**
+   * Header for the leading column. A lookup rather than a derivation: the sell-side
+   * cell leads with `name` and is headed "Description", so the label cannot be read
+   * off {@link primaryTextKey}, and a buy-side row's leading control is a PART
+   * picker — heading it "Description" names the wrong one of the two things stacked
+   * in that cell.
+   */
+  primaryColumnLabel: string
   totalsMode: TotalsMode
   /** systemAttribute prefix for the parent's own billing mirrors (`quote_discount_type`). */
   billingPrefix: string
@@ -245,6 +253,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     relFieldId: 'line_item:quote',
     sortAttr: 'line_item_sort_order',
     primaryTextKey: 'name',
+    primaryColumnLabel: 'Description',
     totalsMode: 'computed',
     billingPrefix: 'quote',
     billingAttrs: billingAttrsFor('quote'),
@@ -259,6 +268,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     relFieldId: 'line_item:invoice',
     sortAttr: 'line_item_sort_order',
     primaryTextKey: 'name',
+    primaryColumnLabel: 'Description',
     totalsMode: 'computed',
     billingPrefix: 'invoice',
     billingAttrs: [
@@ -283,6 +293,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     relFieldId: 'line_item:order',
     sortAttr: 'line_item_sort_order',
     primaryTextKey: 'name',
+    primaryColumnLabel: 'Description',
     totalsMode: 'computed',
     billingPrefix: 'order',
     billingAttrs: billingAttrsFor('order'),
@@ -297,6 +308,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     relFieldId: 'line_item:workOrder',
     sortAttr: 'line_item_sort_order',
     primaryTextKey: 'name',
+    primaryColumnLabel: 'Description',
     // The M2 job view stores no totals at all, so `billingPrefix` is never read —
     // every use is gated on `totalsMode`. It is still a real prefix rather than an
     // empty string so a missed gate fails loudly instead of building `_tax_rate`.
@@ -314,6 +326,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     relFieldId: 'purchase_order_line:purchaseOrder',
     sortAttr: 'purchase_order_line_sort_order',
     primaryTextKey: 'description',
+    primaryColumnLabel: 'Part',
     // The PO IS our document and its subtotal is ours to compute
     // (plans/purchasing/01-build-plan.md §4.1 — `subtotal`/`total` are
     // `creatable: false`) — but shipping and tax are stated amounts, not rates.
@@ -347,6 +360,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     relFieldId: 'vendor_bill_line:vendorBill',
     sortAttr: 'vendor_bill_line_sort_order',
     primaryTextKey: 'description',
+    primaryColumnLabel: 'Part',
     // 🛑 See TotalsMode. The bill is THEIRS; its totals are transcribed.
     totalsMode: 'stored',
     billingPrefix: 'vendor_bill',
@@ -460,6 +474,23 @@ export function diffLineValues(before: LineValues, after: LineValues): LinePatch
 }
 
 /**
+ * Collapse a RELATIONSHIP read to the single prefixed record id a line cell wants.
+ *
+ * 🛑 `useSystemValues` collapses SINGLE_SELECT and single-value ACTOR to a scalar
+ * but deliberately leaves the genuinely multi-value types — MULTI_SELECT, TAGS,
+ * FILE and **RELATIONSHIP** — as arrays. A line's `part` is single-valued, so
+ * reading it as a scalar hands a one-element ARRAY to everything downstream: the
+ * cell wraps it again (`value={[partRecordId]}`), `RecordBadge` receives an array
+ * where it expects an id, and the badge renders a permanent loading skeleton
+ * instead of the part's name. Nothing throws and nothing logs — the part is
+ * simply never visible on any purchasing line.
+ */
+function firstRecordId(raw: unknown): RecordId | null {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return typeof value === 'string' ? (value as RecordId) : null
+}
+
+/**
  * Normalize one passive `useSystemValues` result into the row's value shape.
  *
  * An attribute the schema maps to `null` falls back to its default rather than
@@ -476,6 +507,7 @@ export function lineValuesFromSystemValues(
     const attr = schema.attrs[key]
     return attr ? (values[attr] as T | undefined) : undefined
   }
+  const readRecordId = (key: keyof LineValues): RecordId | null => firstRecordId(read<unknown>(key))
   const { optional: supportsOptional } = schema.capabilities
   return {
     name: read<string | null>('name') ?? '',
@@ -488,6 +520,6 @@ export function lineValuesFromSystemValues(
     optional: supportsOptional && read<boolean>('optional') === true,
     optionalSelected: !supportsOptional || read<boolean>('optionalSelected') !== false,
     catalogItemRecordId: null,
-    partRecordId: read<RecordId | null>('partRecordId') ?? null,
+    partRecordId: readRecordId('partRecordId'),
   }
 }

--- a/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
+++ b/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
@@ -173,6 +173,7 @@ export function TotalsFooter({
   taxRates,
   onUpdateDiscount,
   onUpdateTax,
+  onUpdateStatedAmount,
 }: {
   documentType: DocumentType
   readOnly: boolean
@@ -185,6 +186,13 @@ export function TotalsFooter({
   taxRates: TaxRatePreset[]
   onUpdateDiscount: (type: DiscountType | null, value: number | null) => void
   onUpdateTax: (name: string | null, rate: number | null) => void
+  /**
+   * `stated` only — writes one of the document's own amount mirrors by attribute
+   * suffix (`discount_value` / `shipping_total` / `tax_total`), in integer minor
+   * units. See `updateStatedAmount` in `line-builder.tsx` for why these must be
+   * writable at all.
+   */
+  onUpdateStatedAmount: (attribute: string, cents: number | null) => void
 }) {
   const schema = lineSchemaFor(documentType)
   const { totalsMode, billingPrefix: prefix } = schema
@@ -401,27 +409,35 @@ export function TotalsFooter({
             </div>
           )}
 
-          {/* `stated` (purchase order): amounts the document carries, not rates —
-              read-only here. Shipping and tax are the freight-allocation inputs
-              (plans/purchasing/01-build-plan.md §4.1), keyed on the PO header. */}
+          {/* `stated` (purchase order): amounts the document carries, not rates.
+              🛑 EDITABLE — shipping and tax are the freight-allocation INPUTS
+              (plans/purchasing/01-build-plan.md §4.1), typed by hand off the
+              freight invoice, and `showInPanel: false` makes this footer the only
+              place they can be entered at all. */}
           {totalsMode === 'stated' && (
             <>
-              {statedDiscount > 0 && (
-                <div className='flex items-center justify-between'>
-                  <span className='text-muted-foreground'>Discount</span>
-                  <span className='tabular-nums'>
-                    -{formatCurrency(statedDiscount, currencyCode)}
-                  </span>
-                </div>
-              )}
-              <div className='flex items-center justify-between'>
-                <span className='text-muted-foreground'>Shipping</span>
-                <span className='tabular-nums'>{formatCurrency(statedShipping, currencyCode)}</span>
-              </div>
-              <div className='flex items-center justify-between'>
-                <span className='text-muted-foreground'>Tax</span>
-                <span className='tabular-nums'>{formatCurrency(statedTax, currencyCode)}</span>
-              </div>
+              <StatedAmountRow
+                label='Discount'
+                cents={statedDiscount}
+                negative
+                readOnly={readOnly}
+                currencyCode={currencyCode}
+                onCommit={(next) => onUpdateStatedAmount('discount_value', next)}
+              />
+              <StatedAmountRow
+                label='Shipping'
+                cents={statedShipping}
+                readOnly={readOnly}
+                currencyCode={currencyCode}
+                onCommit={(next) => onUpdateStatedAmount('shipping_total', next)}
+              />
+              <StatedAmountRow
+                label='Tax'
+                cents={statedTax}
+                readOnly={readOnly}
+                currencyCode={currencyCode}
+                onCommit={(next) => onUpdateStatedAmount('tax_total', next)}
+              />
             </>
           )}
 
@@ -445,6 +461,87 @@ export function TotalsFooter({
             </>
           )}
         </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * One editable amount row in a `stated` footer — the document's own
+ * discount / shipping / tax mirror.
+ *
+ * Currency convention: the value is stored in integer minor units and the input
+ * shows and accepts DOLLARS, matching the `amount` discount input above and
+ * `PriceCellView` in the row grid. An unparseable entry restores the last
+ * committed display rather than writing NaN; an empty one clears the field to
+ * `null` (which the totals read back as 0).
+ */
+function StatedAmountRow({
+  label,
+  cents,
+  negative = false,
+  readOnly,
+  currencyCode,
+  onCommit,
+}: {
+  label: string
+  cents: number
+  /** Discount is subtracted, so it displays with a leading minus at rest. */
+  negative?: boolean
+  readOnly: boolean
+  currencyCode: string
+  onCommit: (cents: number | null) => void
+}) {
+  const [draft, setDraft] = useState<string | null>(null)
+  const display = cents === 0 ? '' : String(cents / 100)
+
+  const commit = () => {
+    if (draft === null) return
+    const trimmed = draft.trim()
+    setDraft(null)
+    if (!trimmed) {
+      if (cents !== 0) onCommit(null)
+      return
+    }
+    const parsed = Number(trimmed.replace(/[$,]/g, ''))
+    if (!Number.isFinite(parsed)) return
+    const next = Math.round(parsed * 100)
+    if (next === cents) return
+    onCommit(next)
+  }
+
+  const formatted = `${negative && cents > 0 ? '-' : ''}${formatCurrency(cents, currencyCode)}`
+
+  if (readOnly) {
+    return (
+      <div className='flex items-center justify-between'>
+        <span className='text-muted-foreground'>{label}</span>
+        <span className='tabular-nums'>{formatted}</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex items-center justify-between gap-2'>
+      <span className='text-muted-foreground'>{label}</span>
+      <div className='flex items-center gap-1'>
+        <input
+          value={draft ?? display}
+          onChange={(e) => setDraft(e.target.value)}
+          onFocus={() => setDraft(display)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.currentTarget.blur()
+            if (e.key === 'Escape') setDraft(null)
+          }}
+          inputMode='decimal'
+          placeholder='0'
+          aria-label={label}
+          className='w-14 rounded-sm border-none bg-transparent px-1 text-right text-sm tabular-nums outline-none hover:bg-primary-100/60 focus:bg-primary-100/80'
+        />
+        <span className='w-20 text-right text-muted-foreground text-xs tabular-nums'>
+          {cents === 0 ? '' : formatted}
+        </span>
       </div>
     </div>
   )

--- a/apps/web/src/components/money/ui/line-builder/use-line-nav.ts
+++ b/apps/web/src/components/money/ui/line-builder/use-line-nav.ts
@@ -63,8 +63,13 @@ export function useLineNav({
       if (!target) return
       // `[data-cell-focusable]` covers the name cell's at-rest text button (which
       // swaps to an <input> on focus); qty/unit-cost cells match on `input`.
+      // `[role="combobox"]` is the buy-side leading cell's part picker — its
+      // trigger is a button rendered by `PickerTrigger`, which takes no data
+      // attributes, and it is the ONLY combobox inside the grid (the category and
+      // unit menus are `aria-haspopup="menu"` dropdowns, not comboboxes). Without
+      // it, arrow-nav into column 0 of a purchasing row finds nothing to focus.
       const focusable = target.querySelector(
-        'input, textarea, [data-cell-focusable]'
+        'input, textarea, [data-cell-focusable], [role="combobox"]'
       ) as HTMLElement | null
       if (focusable) {
         focusable.focus()

--- a/packages/lib/src/resources/registry/resources/part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/part-fields.ts
@@ -2,6 +2,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { LINE_ITEM_UNIT_OPTIONS } from '../../../money/units'
 import { BaseType } from '../../types'
 import { CREATED_BY_FIELD } from '../common-fields'
 import { CostSource, PartKind, StockStatus } from '../enum-values'
@@ -269,6 +270,49 @@ export const PART_FIELDS: Record<string, ResourceField> = {
     },
     placeholder: 'Enter HS code',
     description: 'Harmonized System code for customs',
+  },
+
+  /**
+   * The part's stock unit of measure — the unit EVERY quantity in the inventory
+   * chain is already denominated in, finally named.
+   *
+   * 🛑 It lives on the part, not on the line, and that is the whole design.
+   * `part_quantity_on_hand`, `stock_movement_quantity`, `subpart` BOM quantities,
+   * `purchase_order_line_quantity_ordered` and `_quantity_received` are all bare
+   * numbers that only reconcile because they share one implied unit. Putting a
+   * unit on the purchasing LINE instead (the `line_item` shape) would let a line
+   * be ordered in `box` and received in `ea`, and the received-vs-ordered roll-up
+   * — the thing the three-way match is built on — would silently compare two
+   * different units. A per-vendor pack size belongs on `vendor_part` with a real
+   * conversion factor, and is a separate feature.
+   *
+   * Purchasing rows render it read-only beside the quantity: a PO does not get to
+   * choose the unit its part is stocked in.
+   *
+   * Nullable with no backfill — an unset unit reads as unitless and displays a
+   * bare number, which is exactly today's behaviour for every existing part.
+   */
+  unit: {
+    id: toFieldId('unit'),
+    key: 'unit',
+    label: 'Unit',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'part_unit',
+    systemSortOrder: 'a4',
+    nullable: true,
+    options: { options: [...LINE_ITEM_UNIT_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select unit',
+    defaultValue: 'each',
+    description: 'Stock unit of measure — every quantity recorded for this part is in this unit',
   },
 
   // Ships the FIELD only. `readPartKind` / `shouldExplodeOnSale` and the

--- a/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts
@@ -117,12 +117,15 @@ const RECEIVING_KEYS = [
 ] as const
 
 /**
- * The inverse halves the migration hangs off defs it does not create. Declared
- * again here on purpose: the two lists have to agree, and this is what says so.
+ * The fields the migration hangs off defs it does not create. Declared again
+ * here on purpose: the two lists have to agree, and this is what says so.
+ *
+ * All are inverse halves except `part.unit` — the stock unit of measure, added
+ * here because the purchasing lines are the first surface that renders one.
  */
 const INVERSE_KEYS: Record<string, readonly string[]> = {
   company: ['purchaseOrders', 'vendorBills', 'vendorPayments'],
-  part: ['purchaseOrderLines', 'vendorBillLines'],
+  part: ['purchaseOrderLines', 'vendorBillLines', 'unit'],
   vendor_part: ['stockMovements', 'purchaseOrderLines'],
   gl_posting: ['lines'],
 }

--- a/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
@@ -89,11 +89,15 @@ const RECEIVING_FIELD_KEYS = [
 ] as const
 
 /**
- * The inverse halves this migration adds to defs it does not create. Each is a
- * `has_many` on an incumbent def whose owning `belongs_to` lives on one of the
- * eight new ones.
+ * Fields this migration adds to defs it does not create.
+ *
+ * Almost all are the inverse halves of edges owned by the eight new defs — a
+ * `has_many` on an incumbent whose owning `belongs_to` lives on a new one.
+ * `part.unit` is the exception: a plain SINGLE_SELECT, added here because the
+ * purchasing lines are the first surface that needs to render a unit and the
+ * part is where the stock UOM belongs (see its registry comment).
  */
-const INVERSE_FIELDS: Record<string, Record<string, ResourceField | undefined>> = {
+const INCUMBENT_FIELDS: Record<string, Record<string, ResourceField | undefined>> = {
   company: {
     purchaseOrders: COMPANY_FIELDS.purchaseOrders,
     vendorBills: COMPANY_FIELDS.vendorBills,
@@ -102,6 +106,8 @@ const INVERSE_FIELDS: Record<string, Record<string, ResourceField | undefined>> 
   part: {
     purchaseOrderLines: PART_FIELDS.purchaseOrderLines,
     vendorBillLines: PART_FIELDS.vendorBillLines,
+    // Not an inverse — the stock unit of measure every part quantity is in.
+    unit: PART_FIELDS.unit,
   },
   vendor_part: {
     stockMovements: VENDOR_PART_FIELDS.stockMovements,
@@ -162,6 +168,14 @@ const INVERSE_FIELDS: Record<string, Record<string, ResourceField | undefined>> 
  * `company` (purchaseOrders / vendorBills / vendorPayments), `part`
  * (purchaseOrderLines / vendorBillLines), `vendor_part` (stockMovements /
  * purchaseOrderLines) and `gl_posting` (lines).
+ *
+ * Plus one field that is not an inverse: `part.unit`, the stock unit of measure
+ * (SINGLE_SELECT, nullable, no backfill). Every quantity in the inventory chain
+ * — on-hand, movements, BOM, ordered/received — is already a bare number in one
+ * implied unit; this names it, and purchasing rows render it read-only beside the
+ * quantity. It is deliberately NOT on the line: a line ordered in `box` and
+ * received in `ea` would make the received-vs-ordered roll-up compare two
+ * different units, which is the number the three-way match rests on.
  *
  * `purchase_order` is `hasDetailPage: true` and `isVisible: true` — the `quote`
  * shape, because a PO is built, issued and received against. `vendor_bill` is
@@ -278,8 +292,8 @@ export const migration108Purchasing: EntityMigration = {
       )
     )
 
-    // ── The inverse halves on incumbent defs ───────────────────────────
-    for (const [entityType, fields] of Object.entries(INVERSE_FIELDS)) {
+    // ── The added fields on incumbent defs ─────────────────────────────
+    for (const [entityType, fields] of Object.entries(INCUMBENT_FIELDS)) {
       const defId = entityDefIds.get(entityType)
       if (!defId) continue
       const present: Record<string, ResourceField> = {}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -130,6 +130,10 @@ export const SYSTEM_ATTRIBUTES = [
   'part_sku',
   'category',
   'part_kind',
+  // The stock unit of measure every quantity recorded for the part is in
+  // (on-hand, movements, BOM, ordered/received). Deliberately on the part and
+  // not on a purchasing line — see `PART_FIELDS.unit`.
+  'part_unit',
   // Cost provenance. `part_cost` keeps its meaning (replacement cost — the
   // current landed cost from live vendor prices); the two below name the
   // numbers it chooses BETWEEN, and `part_cost_source` says which one won.


### PR DESCRIPTION
Found by driving `/app/purchase-orders?id=…` in a real browser. Every defect here passed the existing 36-assertion suite, threw nothing and logged nothing.

## The headline: no purchasing line ever showed its part

Every PO line rendered a permanent grey skeleton where the part name belongs — on first paint and forever after. Since the part **is** a buy-side line's identity, the Lines table was a column of anonymous pills.

```ts
partRecordId: read<RecordId | null>('partRecordId') ?? null,   // ← a type lie
```

`useSystemValues` collapses SINGLE_SELECT and single-value ACTOR to a scalar but **deliberately leaves the genuinely multi-value types — MULTI_SELECT, TAGS, FILE and RELATIONSHIP — as arrays** (`use-system-values.ts:118`). `read<T>` is a bare cast, so TypeScript could not see that `partRecordId` was a one-element *array*. The cell wraps it again (`value={partRecordId ? [partRecordId] : []}`) and `RecordBadge` received `["def:instance"]` where it expects `"def:instance"`.

This is the RELATIONSHIP twin of the SINGLE_SELECT-arrays convention, and worse: SINGLE_SELECT collapses and RELATIONSHIP does not, so the two read sites look identical and behave oppositely.

## Four more divergences from the four sell-side builders

**1. The row grew a permanent second line, and had no `⋯` menu.** `LinePartCellView` stacked an always-visible description input under the picker, so purchasing rows rendered at double the height of every other document's — exactly what `LineNameCellView` documents itself as avoiding (*"the line never grows a permanent second row"*). With no row menu, a PO line **could not be deleted from the grid** and no row shortcut (⇧D, ⌫) reached it. Rebuilt on the sell-side anatomy: description is a standing button only once set, adding one lives in the `⋯` menu, editing swaps the cell in place.

**2. Shipping and tax were read-only, which blocked landed cost entirely.** `stated` mode rendered all three amounts as plain `<span>`s. But `purchase_order_shipping_total`, `_tax_total` and `_discount_value` are all `creatable: true, updatable: true` with `showInPanel: false` — the registry comment on `shippingTotal` reads *"Typed by hand from the freight invoice: this is an INPUT to `allocateLandedCost`, not a derived figure."* The footer is the **only** place in the app they can be entered, and it did not let you. `stated` had conflated *amounts rather than rates* with *read-only*.

**3. The unit disappeared on persist — because no unit field existed anywhere.** Not on `purchase_order_line`, `vendor_bill_line`, `part`, `vendor_part` **or** `stock_movement`. Only `line_item` (sell side) has one. The `1 ea` on a draft row was `DEFAULT_LINE_VALUES.unit = 'each'` living in React state; it wrote nowhere and evaporated when the row persisted, which is why a draft read `1 ea` and the row it became read `1`.

Adds `part_unit` to **migration 108 in place** (it had only ever run on one machine; re-run with the existing `run-migration-108.ts`).

> 🛑 **On the part, not the line.** `part_quantity_on_hand`, `stock_movement_quantity`, BOM quantities and `purchase_order_line_quantity_ordered` / `_quantity_received` are all bare numbers that only reconcile because they share one implied unit. A unit on the LINE would let a line be ordered in `box` and received in `ea`, and the received-vs-ordered roll-up — the number the three-way match rests on — would silently compare two different units. A per-vendor pack size belongs on `vendor_part` with a real conversion factor, and is a separate feature.

Rendered read-only beside the quantity, falling back to `each` — the semantics those bare numbers already have, not a guess. `defaultValue: 'each'`, no backfill.

**4. Five descriptor members were read only by their own test file.** `capabilities.unit` / `.taxable` / `.category` / `.photos` and `primaryTextKey` gated nothing in production, so the unit dropdown rendered on documents with no unit field (a dead control) and the leading column was headed **"Description" over a part picker**. Adds `primaryColumnLabel` as a lookup — it cannot be derived from `primaryTextKey`, which is `'name'` on the sell side where the header says "Description" — and gates the row menu's category/taxable items.

## One side effect worth flagging

`PickerTrigger` accepts no data attributes, so the part picker cannot carry `data-cell-focusable`. With the description `<input>` gone, column 0 of a purchasing row had nothing for `useLineNav` to focus. Its selector now also matches `[role="combobox"]` — the only combobox inside the grid (the category and unit menus are `aria-haspopup="menu"` dropdowns).

## Verification

Verified **in the browser**, not just by the suite — which is the point, since the suite was green throughout:

- both lines render their part badge; qty reads `1 ea` on both
- typing a rate persists, and the line total, subtotal and the list's Total column all repaint
- typing `40` into Shipping wrote `4000` to `purchase_order_shipping_total`, and the server's totals hook recomputed `purchase_order_total` to `5250` against a `1250` subtotal — the footer's `subtotal − discount + shipping + tax` matches the server exactly
- `part_unit` present in all 28 orgs after re-running 108

```
apps/web typecheck                     0 errors, baseline 0
packages/lib typecheck                 29, baseline 29
apps/web  vitest src/components/money  41 passed  (was 36; +5 new guards)
packages/lib registry + entity-migrations  286 passed (20 files)
biome check                            clean
```

The five new assertions in `line-schemas.test.ts` pin the array collapse, `capabilities.unit === (attrs.unit !== null)`, and the column label following `capabilities.partPicker`.

## Not in this PR

Two orphaned `purchase_order_line` rows exist in the dev DB (`gr59pz…`, `ukp3xv…`) carrying a part and quantity but **no parent PO**, so they belong to no order and appear on no screen. Not reproducible through the current create path — a line driven through `LineBuilder` during this work linked correctly, and `draftCreateValues` sets `[schema.relKey]` unconditionally. One also carries `purchase_order_line_weight`, which the shared builder never writes, so it predates the cutover. Left in place as evidence rather than deleted: a PO line with no parent is invisible to every read path, so a leak here is silent.