### PR TITLE
feat(purchasing): vendor, receiving, bills and payment cards

### DIFF
--- a/apps/web/src/components/drawers/drawer-card-parity.test.ts
+++ b/apps/web/src/components/drawers/drawer-card-parity.test.ts
@@ -1,0 +1,82 @@
+// apps/web/src/components/drawers/drawer-card-parity.test.ts
+
+// Pins the silent-failure trap plans/purchasing/02-handoff.md §6 names twice: a card
+// declared in `drawer-config.ts` / `detail-view-config.ts` with no component in
+// `DRAWER_TAB_CARD_COMPONENTS` renders NOTHING — `base-entity-drawer.tsx` is
+// `if (!componentLoader) return null`, with no error, no placeholder and no warning.
+// Six cards were declared ahead of their components during the purchasing build and
+// had to be trimmed back out; this is that review step, automated.
+//
+// Key-set only: the registry's values are dynamic `import()`s of .tsx modules and
+// this never calls them, so the assertion costs nothing and pulls in no components.
+
+import { DETAIL_VIEW_CONFIG_REGISTRY, DRAWER_CONFIG_REGISTRY } from '@auxx/lib/resources/client'
+import { describe, expect, it } from 'vitest'
+import { DRAWER_TAB_CARD_COMPONENTS, DRAWER_TAB_COMPONENTS } from './drawer-tab-registry'
+
+/** Every `entityType:cardValue` a drawer's tabCards declare. */
+function declaredDrawerCardKeys(): string[] {
+  const keys: string[] = []
+  for (const config of Object.values(DRAWER_CONFIG_REGISTRY)) {
+    for (const [, cards] of Object.entries(config.tabCards ?? {})) {
+      for (const card of cards ?? []) keys.push(`${config.entityType}:${card.value}`)
+    }
+  }
+  return keys
+}
+
+/** Every `entityType:cardValue` a detail view's sidebar declares. */
+function declaredSidebarCardKeys(): string[] {
+  const keys: string[] = []
+  for (const config of Object.values(DETAIL_VIEW_CONFIG_REGISTRY)) {
+    for (const card of config.sidebarCards ?? []) keys.push(`${config.entityType}:${card.value}`)
+  }
+  return keys
+}
+
+describe('drawer card declarations', () => {
+  // Non-vacuity guard: both walks read a nested config shape, so a shape change that
+  // silently yielded zero keys would make every assertion below pass while checking
+  // nothing. These floors are well under the current counts, not a snapshot.
+  it('actually walks the configs', () => {
+    expect(declaredDrawerCardKeys().length).toBeGreaterThan(10)
+    expect(declaredSidebarCardKeys().length).toBeGreaterThan(5)
+  })
+
+  it('every drawer tabCard has a registered component', () => {
+    const missing = declaredDrawerCardKeys().filter((key) => !DRAWER_TAB_CARD_COMPONENTS[key])
+    expect(missing).toEqual([])
+  })
+
+  it('every detail-view sidebarCard has a registered component', () => {
+    // The sidebar reads the SAME card registry as the drawer (detail-view-sidebar.tsx),
+    // so a card declared for a detail page resolves against these keys too.
+    const missing = declaredSidebarCardKeys().filter((key) => !DRAWER_TAB_CARD_COMPONENTS[key])
+    expect(missing).toEqual([])
+  })
+
+  it('every drawer additionalTab has a registered component', () => {
+    const missing: string[] = []
+    for (const config of Object.values(DRAWER_CONFIG_REGISTRY)) {
+      for (const tab of config.additionalTabs ?? []) {
+        const key = `${config.entityType}:${tab.value}`
+        if (!DRAWER_TAB_COMPONENTS[key]) missing.push(key)
+      }
+    }
+    expect(missing).toEqual([])
+  })
+
+  it('declares the purchasing cards that close the unreachable-field gaps', () => {
+    // `purchase_order_bills` and the quantityReceived roll-up are both
+    // `showInPanel: false` / computed, so these cards are their only surface.
+    for (const key of [
+      'purchase_order:vendor',
+      'purchase_order:receiving',
+      'purchase_order:bills',
+      'vendor_bill:vendor',
+      'vendor_bill:payment',
+    ]) {
+      expect(DRAWER_TAB_CARD_COMPONENTS[key], key).toBeDefined()
+    }
+  })
+})

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -245,6 +245,28 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     import('../purchasing/vendor-bill/vendor-bill-match-card').then((m) => ({
       default: m.VendorBillMatchCard,
     })),
+  // `receiving` is the ONLY read-back of `purchase_order_line_quantity_received`,
+  // and `bills` the only surface for `purchase_order_bills` (`showInPanel: false`).
+  'purchase_order:receiving': () =>
+    import('../purchasing/purchase-order/purchase-order-receiving-card').then((m) => ({
+      default: m.PurchaseOrderReceivingCard,
+    })),
+  'purchase_order:bills': () =>
+    import('../purchasing/purchase-order/purchase-order-bills-card').then((m) => ({
+      default: m.PurchaseOrderBillsCard,
+    })),
+  // One component behind both vendor keys — a PO and a bill each link exactly one
+  // company and ask the same question of it.
+  'purchase_order:vendor': () =>
+    import('../purchasing/vendor-card').then((m) => ({ default: m.PurchaseOrderVendorCard })),
+  'vendor_bill:vendor': () =>
+    import('../purchasing/vendor-card').then((m) => ({ default: m.VendorBillVendorCard })),
+  // The bill's six P12 payment fields. NOT the AR-side `invoice:payments` shape:
+  // `vendor_payment` is inert under P13, so there are no payment records to list.
+  'vendor_bill:payment': () =>
+    import('../purchasing/vendor-bill/vendor-bill-payment-card').then((m) => ({
+      default: m.VendorBillPaymentCard,
+    })),
 
   // ─────────────────────────────────────────────────────────────────
   // WORK ORDER (job view) SIDEBAR CARDS — dispatch M2 build spec §F.2, shared

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
@@ -1,0 +1,93 @@
+// apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
+'use client'
+
+// `purchase_order:bills` — the vendor bills charged against this PO
+// (plans/purchasing/01-build-plan.md §4.4).
+//
+// `purchase_order_bills` is `showInPanel: false` in `purchase-order-fields.ts`, so
+// without this card the inverse edge has NO surface at all: a bill knows its PO and
+// the PO could not show its bills. That asymmetry is what the card exists to close.
+//
+// The work-order Billing card's shape — summary strip, then one row per related
+// record — with `RelatedRecordRow` for the rows themselves, the same primitive the
+// order's work-orders block uses. A bill is `hasDetailPage: false`, so its row opens
+// as a drill panel rather than navigating.
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import { formatCurrency } from '@auxx/utils/currency'
+import {
+  EmptyRow,
+  RelatedRecordRow,
+  RowSkeleton,
+  TREE_SECONDARY_NOTRUNCATE,
+} from '~/components/drawers/cards/related-record-row'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { useSettings } from '~/hooks/use-settings'
+import { numberValue, PurchasingSummaryStrip, unwrapValue } from '../purchasing-summary-strip'
+
+const PO_ATTRS = [
+  'purchase_order_bills',
+  'purchase_order_total',
+  'purchase_order_currency',
+] as const
+
+const BILL_ATTRS = ['vendor_bill_total'] as const
+
+export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
+  const { getSetting } = useSettings({})
+  const { values, isLoading } = useSystemValues(recordId, [...PO_ATTRS], { autoFetch: true })
+
+  const billRecordIds = extractRelationshipRecordIds(values.purchase_order_bills)
+  const { valuesById, isLoading: billsLoading } = useSystemValuesForRecords(
+    billRecordIds,
+    BILL_ATTRS,
+    { autoFetch: true, enabled: billRecordIds.length > 0 }
+  )
+
+  const currencyValue = unwrapValue(values.purchase_order_currency)
+  const currencyCode =
+    (typeof currencyValue === 'string' && currencyValue) ||
+    (getSetting('organization.currency') as string | null) ||
+    'USD'
+
+  const orderTotal = numberValue(values.purchase_order_total)
+  const billed = billRecordIds.reduce(
+    (sum, billRecordId) => sum + numberValue(valuesById[billRecordId]?.vendor_bill_total),
+    0
+  )
+  // Signed, not clamped: over-billing against a PO is exactly the condition the
+  // three-way match exists to surface, so a negative unbilled figure is the news.
+  const unbilled = orderTotal - billed
+
+  if (isLoading || (billRecordIds.length > 0 && billsLoading)) return <RowSkeleton />
+
+  return (
+    <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+      <PurchasingSummaryStrip
+        className='pb-2'
+        cells={[
+          { label: 'Order total', value: formatCurrency(orderTotal, { currencyCode }) },
+          { label: 'Billed', value: formatCurrency(billed, { currencyCode }) },
+          {
+            label: 'Unbilled',
+            value: formatCurrency(unbilled, { currencyCode }),
+            tone: unbilled === 0 ? 'muted' : 'default',
+          },
+        ]}
+      />
+      {billRecordIds.length === 0 ? (
+        <EmptyRow label='No bills yet' />
+      ) : (
+        billRecordIds.map((billRecordId) => (
+          <RelatedRecordRow
+            key={billRecordId}
+            recordId={billRecordId}
+            statusAttr='vendor_bill_status'
+          />
+        ))
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
@@ -1,0 +1,161 @@
+// apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
+'use client'
+
+// `purchase_order:receiving` — how much of this PO has actually arrived
+// (plans/purchasing/01-build-plan.md §4.4, listed as wanted-and-unbuilt on
+// `purchase_order.sidebarCards`).
+//
+// The work-order Billing card's shape: a summary strip of figures, then one TreeRow
+// per line. It is the only surface anywhere that answers "what is still outstanding
+// on this order" — `purchase_order_line_quantity_received` is a post-commit re-SUM
+// over `stock_movement` (`purchasing-hooks.ts`), so it is already maintained; nothing
+// had ever read it back.
+//
+// 🛑 The received figures are only ever as good as the receipts behind them, and
+// nothing writes a receipt yet — plans/purchasing/02-handoff.md §4.1's
+// `ReceiveStockPopover` is unbuilt. Until it lands every line here reads 0 received.
+// That is honest (nothing HAS been received through the app) rather than broken.
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/types/resource'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
+import { Package } from 'lucide-react'
+import {
+  EmptyRow,
+  RowSkeleton,
+  TREE_SECONDARY_NOTRUNCATE,
+} from '~/components/drawers/cards/related-record-row'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { useOpenRecord } from '~/components/records/record-drill-panels'
+import { useRecord } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import {
+  formatQuantity,
+  numberValue,
+  PurchasingSummaryStrip,
+  unwrapValue,
+} from '../purchasing-summary-strip'
+
+const PO_ATTRS = ['purchase_order_lines'] as const
+
+const LINE_ATTRS = [
+  'purchase_order_line_part',
+  'purchase_order_line_description',
+  'purchase_order_line_quantity_ordered',
+  'purchase_order_line_quantity_received',
+] as const
+
+/** How many lines render before the inline "Show more" row collapses the rest. */
+const LINE_PREVIEW_LIMIT = 6
+
+interface ReceivingLine {
+  lineRecordId: RecordId
+  partRecordId: RecordId | undefined
+  description: string | null
+  ordered: number
+  received: number
+}
+
+export function PurchaseOrderReceivingCard({ recordId }: DrawerTabProps) {
+  const { values, isLoading: linesLoading } = useSystemValues(recordId, [...PO_ATTRS], {
+    autoFetch: true,
+  })
+  const lineRecordIds = extractRelationshipRecordIds(values.purchase_order_lines)
+
+  const { valuesById, isLoading: valuesLoading } = useSystemValuesForRecords(
+    lineRecordIds,
+    LINE_ATTRS,
+    { autoFetch: true, enabled: lineRecordIds.length > 0 }
+  )
+
+  const lines: ReceivingLine[] = lineRecordIds.map((lineRecordId) => {
+    const lineValues = valuesById[lineRecordId] ?? ({} as Record<string, unknown>)
+    const description = unwrapValue(lineValues.purchase_order_line_description)
+    return {
+      lineRecordId,
+      partRecordId: extractRelationshipRecordIds(lineValues.purchase_order_line_part)[0],
+      description: typeof description === 'string' && description ? description : null,
+      ordered: numberValue(lineValues.purchase_order_line_quantity_ordered),
+      received: numberValue(lineValues.purchase_order_line_quantity_received),
+    }
+  })
+
+  const ordered = lines.reduce((sum, line) => sum + line.ordered, 0)
+  const received = lines.reduce((sum, line) => sum + line.received, 0)
+  // Per line rather than on the totals: an over-receipt on one line must not
+  // cancel an under-receipt on another and report the order complete.
+  const outstanding = lines.reduce(
+    (sum, line) => sum + Math.max(0, line.ordered - line.received),
+    0
+  )
+
+  const loading = linesLoading || (lineRecordIds.length > 0 && valuesLoading)
+  if (loading) return <RowSkeleton />
+  if (lineRecordIds.length === 0) return <EmptyRow label='No lines yet' />
+
+  return (
+    <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+      <PurchasingSummaryStrip
+        className='pb-2'
+        cells={[
+          { label: 'Ordered', value: formatQuantity(ordered) },
+          { label: 'Received', value: formatQuantity(received) },
+          {
+            label: 'Outstanding',
+            value: formatQuantity(outstanding),
+            tone: outstanding === 0 ? 'muted' : 'default',
+          },
+        ]}
+      />
+      <TreeRowList
+        items={lines}
+        loading={false}
+        getKey={(line) => line.lineRecordId}
+        visibleLimit={LINE_PREVIEW_LIMIT}
+        renderRow={(line) => <ReceivingLineRow line={line} />}
+      />
+    </div>
+  )
+}
+
+function ReceivingLineRow({ line }: { line: ReceivingLine }) {
+  const openRecord = useOpenRecord()
+  const { record } = useRecord({ recordId: line.partRecordId!, enabled: !!line.partRecordId })
+
+  // The part IS a buy-side line's identity (03-line-builder-reuse.md), so it leads;
+  // `description` is the fallback for a line whose part has not resolved yet.
+  const title = record?.displayName ?? line.description ?? 'Untitled line'
+  const progress = receivingProgress(line)
+
+  return (
+    <TreeRow
+      rowClassName='hover:bg-primary-100'
+      icon={<Package className='size-4' />}
+      title={<span className='truncate text-sm'>{title}</span>}
+      secondary={
+        <Badge variant={progress.variant} size='xs'>
+          {progress.label}
+        </Badge>
+      }
+      onDrill={line.partRecordId ? () => openRecord?.(line.partRecordId!) : undefined}
+    />
+  )
+}
+
+/**
+ * The line's receiving state as a badge.
+ *
+ * Over-receipt gets its own colour rather than being folded into "received": it is
+ * a real condition on the floor (a vendor shipped more than was ordered) and the
+ * three-way match will raise it, so hiding it here would contradict the match card.
+ */
+function receivingProgress(line: ReceivingLine): { label: string; variant: Variant } {
+  const qty = `${formatQuantity(line.received)} / ${formatQuantity(line.ordered)}`
+  if (line.received > line.ordered) return { label: `${qty} over`, variant: 'amber' }
+  if (line.ordered > 0 && line.received >= line.ordered) return { label: qty, variant: 'green' }
+  if (line.received > 0) return { label: qty, variant: 'amber' }
+  return { label: qty, variant: 'secondary' }
+}

--- a/apps/web/src/components/purchasing/purchasing-summary-strip.tsx
+++ b/apps/web/src/components/purchasing/purchasing-summary-strip.tsx
@@ -1,0 +1,73 @@
+// apps/web/src/components/purchasing/purchasing-summary-strip.tsx
+'use client'
+
+// The purchasing cards' summary strip — the same three-cell header the work-order
+// drawer's Billing card puts above its rows (`billing-summary-strip.tsx`), with the
+// currency formatting lifted out so a strip can carry quantities too.
+//
+// Deliberately NOT a reuse of `BillingSummaryStrip`: that one is typed against
+// `WorkOrderBillingView` and formats every cell as currency, so a receiving strip
+// (three quantities) cannot use it without either widening its prop to a union or
+// pushing quantities through a currency formatter. The shared thing here was only
+// ever the markup, so that is what is shared.
+
+import { cn } from '@auxx/ui/lib/utils'
+
+/** One labelled figure. `value` arrives pre-formatted — the strip never formats. */
+export interface SummaryCell {
+  label: string
+  value: string
+  /** Muted renders the figure in the label's colour — for a zero that is not news. */
+  tone?: 'default' | 'muted'
+}
+
+/**
+ * A row of labelled figures above a card's rows.
+ *
+ * Column count is fixed to the cell count rather than container-queried: these
+ * cards carry three cells, which fits the drawer's ~400px min width without the
+ * reveal-as-it-widens treatment the six-cell billing strip needs.
+ */
+export function PurchasingSummaryStrip({
+  cells,
+  className,
+}: {
+  cells: SummaryCell[]
+  className?: string
+}) {
+  return (
+    <div
+      className={cn('grid gap-3', className)}
+      style={{ gridTemplateColumns: `repeat(${cells.length}, minmax(0, 1fr))` }}>
+      {cells.map((cell) => (
+        <div key={cell.label} className='flex flex-col gap-0.5'>
+          <span className='text-muted-foreground text-xs'>{cell.label}</span>
+          <span
+            className={cn(
+              'font-medium text-sm tabular-nums',
+              cell.tone === 'muted' && 'text-muted-foreground'
+            )}>
+            {cell.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** SINGLE_SELECT and RELATIONSHIP reads come back as arrays; everything else scalar. */
+export function unwrapValue(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value
+}
+
+/** Coerce a NUMBER system value to a number, treating absence as zero. */
+export function numberValue(value: unknown): number {
+  const raw = unwrapValue(value)
+  const parsed = typeof raw === 'string' ? Number(raw) : raw
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : 0
+}
+
+/** Trim a quantity's trailing zeros — `10` not `10.00`, `2.5` kept. */
+export function formatQuantity(value: number): string {
+  return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)))
+}

--- a/apps/web/src/components/purchasing/vendor-bill/mark-bill-paid-dialog.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/mark-bill-paid-dialog.tsx
@@ -1,0 +1,192 @@
+// apps/web/src/components/purchasing/vendor-bill/mark-bill-paid-dialog.tsx
+'use client'
+
+// Mark-a-vendor-bill-paid dialog — the `record-payment-dialog.tsx` FieldPanel recipe
+// applied to the bill's own six payment fields (plans/purchasing/01-build-plan.md
+// §5.3, decision P12).
+//
+// 🛑 It writes FIELDS, it does not create a payment record. `vendor_payment` and
+// `vendor_payment_allocation` ship inert under P13 and `108-purchasing.test.ts` fails
+// if any file in packages/lib so much as names them, so a payment object is not
+// available to write and must not be improvised here.
+//
+// 🛑 It also does not POST. P12 says a ledger-mode org (no accounting provider)
+// relieves A/P with `Dr 2000 / Cr 1000` when a bill is marked paid — but
+// `post-entry.ts` is phase 7 and does not exist, so nothing here can fire it. The
+// six fields are `creatable: true` and a human can already type them in the Details
+// panel today; this dialog is that same write made convenient, and carries the same
+// gap. See plans/purchasing/02-handoff.md §4.7.
+
+import { FieldType } from '@auxx/database/enums'
+import type { RecordId } from '@auxx/lib/resources/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError } from '@auxx/ui/components/toast'
+import { useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useSaveSystemValues } from '~/components/resources/hooks'
+import { BaseType } from '~/components/workflow/types'
+
+interface MarkBillPaidDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  billRecordId: RecordId
+  /** Bill total, integer minor units — the ceiling a payment settles against. */
+  total: number
+  /** Already settled before this payment, integer minor units. */
+  amountPaid: number
+  currencyCode: string
+  onSaved?: () => void
+}
+
+function todayIso(): string {
+  return new Date().toISOString()
+}
+
+export function MarkBillPaidDialog({
+  open,
+  onOpenChange,
+  billRecordId,
+  total,
+  amountPaid,
+  currencyCode,
+  onSaved,
+}: MarkBillPaidDialogProps) {
+  const balance = total - amountPaid
+  const [amount, setAmount] = useState<number | null>(balance)
+  const [date, setDate] = useState<string>(todayIso())
+  const [method, setMethod] = useState('')
+  const [reference, setReference] = useState('')
+
+  const { save, isPending } = useSaveSystemValues(billRecordId)
+
+  // Reset to a fresh prefill every time the dialog opens.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-init only when the dialog opens.
+  useEffect(() => {
+    if (!open) return
+    setAmount(balance)
+    setDate(todayIso())
+    setMethod('')
+    setReference('')
+  }, [open])
+
+  const canSave = !!amount && amount > 0
+
+  const handleSubmit = async () => {
+    if (!canSave || !amount) return
+    const nextAmountPaid = amountPaid + amount
+    const ok = await save({
+      vendor_bill_paid_at: date,
+      vendor_bill_amount_paid: nextAmountPaid,
+      vendor_bill_payment_method: method.trim() || null,
+      vendor_bill_payment_reference: reference.trim() || null,
+      // P12: `manual` is a HUMAN confirming the payment. Never `rule` — that value
+      // is reserved for a presumption, and the two must stay distinguishable.
+      vendor_bill_paid_source: 'manual',
+      // Only a fully settled bill becomes `paid`. A partial payment leaves the
+      // status where the match put it, because a bill that still owes money is
+      // not paid and a status that says otherwise is how it goes quiet.
+      ...(nextAmountPaid >= total && total > 0 ? { vendor_bill_status: 'paid' } : {}),
+    })
+    if (!ok) {
+      toastError({
+        title: 'Error recording payment',
+        description: 'The bill could not be updated.',
+      })
+      return
+    }
+    onSaved?.()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent position='tc'>
+        <DialogHeader>
+          <DialogTitle>Mark paid</DialogTitle>
+          <DialogDescription>
+            Record what was paid against this bill. This does not post to the ledger.
+          </DialogDescription>
+        </DialogHeader>
+
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='mark-bill-paid-form'
+          defaultLabelWidth={110}
+          className='p-0'>
+          <FieldPanelRow title='Amount' type={BaseType.CURRENCY} showIcon isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.CURRENCY}
+              fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+              value={amount}
+              onChange={(val) => setAmount(val as number | null)}
+              disabled={isPending}
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Paid on' type={BaseType.DATE} showIcon isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.DATETIME}
+              value={date}
+              onChange={(val) => setDate(val as string)}
+              disabled={isPending}
+            />
+          </FieldPanelRow>
+
+          {/* Free text, not a select: `vendor_bill_payment_method` is FieldType.TEXT
+              because the values have not settled yet (see the field's own note). */}
+          <FieldPanelRow title='Method' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={method}
+              onChange={(val) => setMethod(val as string)}
+              placeholder='Check, ACH, card'
+              disabled={isPending}
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={reference}
+              onChange={(val) => setReference(val as string)}
+              placeholder='Check no. / ACH trace'
+              disabled={isPending}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant='outline'
+            size='sm'
+            loading={isPending}
+            loadingText='Saving...'
+            disabled={!canSave}
+            data-dialog-submit>
+            Mark paid <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/purchasing/vendor-bill/vendor-bill-payment-card.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/vendor-bill-payment-card.tsx
@@ -1,0 +1,156 @@
+// apps/web/src/components/purchasing/vendor-bill/vendor-bill-payment-card.tsx
+'use client'
+
+// `vendor_bill:payment` — what this bill still owes, and what settled it
+// (plans/purchasing/01-build-plan.md §5.3, decision P12).
+//
+// The work-order Billing card's shape: a summary strip, a header action, then rows.
+// The AR-side twin (`invoice-payments-card.tsx`) lists `payment` RECORDS; this one
+// cannot, because `vendor_payment` is inert under P13 — the bill's own six fields
+// are the whole ledger, so the card renders those.
+//
+// 🛑 `vendor_bill_balance` is declared `creatable: false` "computed from total and
+// amountPaid" and NOTHING WRITES IT — there is no balance hook in
+// `purchasing-hooks.ts`, which registers only the two numbering hooks. That is the
+// same shape as the latent defect 02-handoff.md §1 documents (a field unwritable by
+// a hook that does not exist and unwritable by a human), so every row's stored
+// balance is NULL. This card therefore computes `total − amountPaid` for display and
+// never reads the stored field. See 02-handoff.md §4.
+
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { formatCurrency } from '@auxx/utils/currency'
+import { Banknote, CircleCheck, Plus } from 'lucide-react'
+import { useState } from 'react'
+import {
+  RowSkeleton,
+  TREE_SECONDARY_NOTRUNCATE,
+} from '~/components/drawers/cards/related-record-row'
+import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSettings } from '~/hooks/use-settings'
+import { numberValue, PurchasingSummaryStrip, unwrapValue } from '../purchasing-summary-strip'
+import { MarkBillPaidDialog } from './mark-bill-paid-dialog'
+
+const BILL_ATTRS = [
+  'vendor_bill_total',
+  'vendor_bill_amount_paid',
+  'vendor_bill_paid_at',
+  'vendor_bill_payment_method',
+  'vendor_bill_payment_reference',
+  'vendor_bill_paid_source',
+  'vendor_bill_status',
+  'vendor_bill_currency',
+] as const
+
+/** How the payment was established — P12's "not decoration" distinction, surfaced. */
+const PAID_SOURCE_BADGE: Record<string, { label: string; variant: Variant }> = {
+  manual: { label: 'Confirmed', variant: 'green' },
+  provider: { label: 'From accounting', variant: 'blue' },
+  bank_import: { label: 'From bank', variant: 'blue' },
+  rule: { label: 'Presumed', variant: 'amber' },
+}
+
+export function VendorBillPaymentCard({ recordId }: DrawerTabProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const { getSetting } = useSettings({})
+  const { values, isLoading } = useSystemValues(recordId, [...BILL_ATTRS], { autoFetch: true })
+
+  const currencyValue = unwrapValue(values.vendor_bill_currency)
+  const currencyCode =
+    (typeof currencyValue === 'string' && currencyValue) ||
+    (getSetting('organization.currency') as string | null) ||
+    'USD'
+
+  const total = numberValue(values.vendor_bill_total)
+  const amountPaid = numberValue(values.vendor_bill_amount_paid)
+  const balance = total - amountPaid
+
+  const status = stringValue(values.vendor_bill_status)
+  const paidAt = stringValue(values.vendor_bill_paid_at)
+  const method = stringValue(values.vendor_bill_payment_method)
+  const reference = stringValue(values.vendor_bill_payment_reference)
+  const paidSource = stringValue(values.vendor_bill_paid_source)
+  const sourceBadge = paidSource ? PAID_SOURCE_BADGE[paidSource] : undefined
+
+  // A void bill owes nothing by definition; a zero-total bill has nothing to settle
+  // and would otherwise offer a payment against an amount nobody has entered yet.
+  const canMarkPaid = status !== 'void' && total > 0 && balance > 0
+
+  if (isLoading) return <RowSkeleton />
+
+  return (
+    <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+      {canMarkPaid && (
+        <DrawerCardActions>
+          <Button variant='ghost' size='xs' onClick={() => setDialogOpen(true)}>
+            <Plus /> Mark paid
+          </Button>
+        </DrawerCardActions>
+      )}
+
+      <PurchasingSummaryStrip
+        className='pb-2'
+        cells={[
+          { label: 'Bill total', value: formatCurrency(total, { currencyCode }) },
+          { label: 'Paid', value: formatCurrency(amountPaid, { currencyCode }) },
+          {
+            label: 'Balance',
+            value: formatCurrency(balance, { currencyCode }),
+            tone: balance === 0 ? 'muted' : 'default',
+          },
+        ]}
+      />
+
+      {paidAt ? (
+        <TreeRow
+          rowClassName='hover:bg-primary-100'
+          icon={<Banknote className='size-4' />}
+          title={<span className='truncate text-sm'>{method || 'Payment'}</span>}
+          secondary={
+            <span className='flex items-center gap-1.5 text-xs'>
+              <span className='text-muted-foreground'>{formatDate(paidAt)}</span>
+              {reference && <span className='truncate text-muted-foreground'>· {reference}</span>}
+              {sourceBadge && (
+                <Badge variant={sourceBadge.variant} size='xs'>
+                  {sourceBadge.label}
+                </Badge>
+              )}
+            </span>
+          }
+        />
+      ) : (
+        <TreeRow
+          rowClassName='hover:bg-primary-100'
+          icon={<CircleCheck className='size-4' />}
+          title={<span className='text-muted-foreground text-sm'>Unpaid</span>}
+          secondary={
+            <span className='text-xs'>
+              {total > 0 ? `${formatCurrency(balance, { currencyCode })} owed` : 'No total entered'}
+            </span>
+          }
+        />
+      )}
+
+      <MarkBillPaidDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        billRecordId={recordId}
+        total={total}
+        amountPaid={amountPaid}
+        currencyCode={currencyCode}
+      />
+    </div>
+  )
+}
+
+function stringValue(value: unknown): string | null {
+  const raw = unwrapValue(value)
+  return typeof raw === 'string' && raw ? raw : null
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value))
+}

--- a/apps/web/src/components/purchasing/vendor-card.tsx
+++ b/apps/web/src/components/purchasing/vendor-card.tsx
@@ -1,0 +1,153 @@
+// apps/web/src/components/purchasing/vendor-card.tsx
+'use client'
+
+// The vendor block for both purchasing documents — `purchase_order:vendor` and
+// `vendor_bill:vendor` (plans/purchasing/01-build-plan.md §4.4 / §5.1).
+//
+// The `work-order-customer-site-card.tsx` recipe, pointed at a COMPANY rather than a
+// contact: identity block + an address strip beneath it. One component for both
+// documents because the only thing that differs is which relation attribute holds
+// the company — a PO and a bill each link exactly one vendor, and the card is the
+// same question on both.
+//
+// ⚠️ `company` carries no email or phone of its own (see `company-fields.ts` — the
+// people live on `company_employees` / `company_primary_contact`), so this block
+// leads with website + headquarters rather than the contact card's mail/phone rows.
+
+import { extractRelationshipRecordIds, primaryValue } from '@auxx/lib/field-values/client'
+import { getDefinitionId, type RecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { type AddressStructValue, formatAddress } from '@auxx/utils/address'
+import { ExternalLink, Globe, MapPin } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { useOpenRecord } from '~/components/records/record-drill-panels'
+import { useRecord, useResource } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { RecordIcon } from '~/components/resources/ui/record-icon'
+import { useRecordLink } from '~/components/resources/utils/get-record-link'
+import { useSettings } from '~/hooks/use-settings'
+
+const COMPANY_ATTRS = ['company_website', 'company_domain', 'company_headquarters'] as const
+
+/** `purchase_order:vendor` — the company this PO was placed with. */
+export function PurchaseOrderVendorCard({ recordId }: DrawerTabProps) {
+  return <VendorBlock recordId={recordId} vendorAttr='purchase_order_vendor' />
+}
+
+/** `vendor_bill:vendor` — the company that billed us. */
+export function VendorBillVendorCard({ recordId }: DrawerTabProps) {
+  return <VendorBlock recordId={recordId} vendorAttr='vendor_bill_vendor' />
+}
+
+function VendorBlock({ recordId, vendorAttr }: { recordId: RecordId; vendorAttr: string }) {
+  const { values, isLoading } = useSystemValues(recordId, [vendorAttr], { autoFetch: true })
+  const vendorRecordId = extractRelationshipRecordIds(values[vendorAttr])[0]
+
+  if (isLoading) return <Skeleton className='h-12 w-full rounded-2xl' />
+
+  // `vendor` is required on both defs, so an empty one is a half-written draft
+  // rather than a legitimate state — say so instead of rendering nothing.
+  if (!vendorRecordId) {
+    return (
+      <div className='rounded-2xl border border-dashed px-3 py-3 text-center text-muted-foreground text-xs'>
+        No vendor linked
+      </div>
+    )
+  }
+
+  return <VendorDetails vendorRecordId={vendorRecordId} />
+}
+
+/** Inner component — only rendered once the vendor relation has resolved. */
+function VendorDetails({ vendorRecordId }: { vendorRecordId: RecordId }) {
+  const router = useRouter()
+  const openRecord = useOpenRecord()
+  const { record } = useRecord({ recordId: vendorRecordId, enabled: true })
+  const { resource } = useResource(getDefinitionId(vendorRecordId))
+  const { values, isLoading } = useSystemValues(vendorRecordId, [...COMPANY_ATTRS], {
+    autoFetch: true,
+  })
+  const href = useRecordLink(vendorRecordId)
+
+  const { getSetting } = useSettings({})
+  const business = getSetting('documents.business') as { address?: { country?: string } } | null
+
+  // `company_website` is multi-value (`options.multi`), so this is the primary of
+  // several; `company_domain` is the plain-text fallback for a vendor recorded by
+  // domain alone.
+  const websiteValue = primaryValue(values.company_website)
+  const domainValue = primaryValue(values.company_domain)
+  const site =
+    typeof websiteValue === 'string' && websiteValue
+      ? websiteValue
+      : typeof domainValue === 'string' && domainValue
+        ? domainValue
+        : null
+
+  const headquarters = primaryValue(values.company_headquarters) as
+    | Partial<AddressStructValue>
+    | null
+    | undefined
+  const addressLine = headquarters
+    ? formatAddress(headquarters, { domesticCountry: business?.address?.country }) || null
+    : null
+
+  const handleOpen = openRecord
+    ? () => openRecord(vendorRecordId)
+    : href
+      ? () => router.push(href)
+      : undefined
+
+  return (
+    <div className='space-y-2'>
+      <div className='group flex items-center justify-between rounded-2xl border bg-primary-100/50 px-3 py-2 transition-colors duration-200 hover:bg-muted'>
+        <div className='flex flex-row items-start gap-4'>
+          <div className='flex size-8 shrink-0 items-center justify-center rounded-lg border bg-muted transition-colors group-hover:bg-secondary'>
+            <RecordIcon
+              avatarUrl={record?.avatarUrl}
+              iconId={resource?.icon || 'building-2'}
+              color={resource?.color || 'gray'}
+              size='xs'
+            />
+          </div>
+          <div className='flex min-w-0 flex-col'>
+            <div className='flex flex-row items-center gap-1 font-medium text-sm'>
+              {record ? (
+                <span className='truncate'>{record.displayName ?? 'Unnamed vendor'}</span>
+              ) : (
+                <Skeleton className='h-4 w-24' />
+              )}
+            </div>
+            <div className='text-muted-foreground text-xs'>
+              {isLoading ? (
+                <Skeleton className='mt-0.5 h-3 w-40' />
+              ) : (
+                site && (
+                  <div className='flex items-center gap-1.5'>
+                    <Globe className='size-3 shrink-0' />
+                    <span className='truncate'>{site}</span>
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+        </div>
+
+        {handleOpen && (
+          <Button variant='ghost' size='icon-sm' onClick={handleOpen}>
+            <ExternalLink />
+          </Button>
+        )}
+      </div>
+
+      {addressLine && (
+        <div className='flex items-start gap-2 rounded-2xl border bg-primary-100/50 px-3 py-2 text-muted-foreground text-xs'>
+          <MapPin className='mt-0.5 size-3.5 shrink-0' />
+          <span>{addressLine}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -203,14 +203,18 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     sidebarTabs: DEFAULT_SIDEBAR_TABS,
     defaultTab: 'line-items',
     defaultSidebarTab: 'overview',
-    // Deliberately empty for now. `vendor`, `receiving` (the computed
-    // quantityReceived roll-up) and `bills` are all wanted and none is built -
-    // and a card declared here with no component in
-    // `DRAWER_TAB_CARD_COMPONENTS` renders NOTHING at all, silently
-    // (`base-entity-drawer.tsx`: `if (!componentLoader) return null`). A
-    // phantom card is worse than an absent one, so they land with their
-    // components, not before.
-    sidebarCards: [],
+    // The sidebar and the drawer read the SAME `DRAWER_TAB_CARD_COMPONENTS`
+    // registry, so each value here is the card key and must match the
+    // `purchase_order:*` entries there and in the PO's drawer block.
+    //
+    // No `totals` card: the five total fields are `showInPanel: false` because
+    // the LineBuilder's TotalsFooter already renders them under the lines, so a
+    // totals card would compete with it — the same call `order` made.
+    sidebarCards: [
+      { value: 'vendor', label: 'Vendor' },
+      { value: 'receiving', label: 'Receiving' },
+      { value: 'bills', label: 'Bills', recordResource: 'vendor_bill' },
+    ],
   },
 
   work_order: {

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -243,10 +243,16 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     entityType: 'purchase_order',
     additionalTabs: [],
     tabCards: {
-      // `vendor` and `totals` are wanted and unbuilt - see the note on
-      // `purchase_order.sidebarCards` in detail-view-config.ts for why an
-      // unbacked card key is not declared here in advance.
-      overview: [{ value: 'lines', label: 'Lines', fullBleed: true }],
+      // No `totals` card, for the same reason `order` has none: the PO's five
+      // total fields are `showInPanel: false` BECAUSE the LineBuilder's own
+      // TotalsFooter renders them at the foot of the lines card. A totals card
+      // would be a second, competing rendering of the same five mirrors.
+      overview: [
+        { value: 'lines', label: 'Lines', fullBleed: true },
+        { value: 'vendor', label: 'Vendor' },
+        { value: 'receiving', label: 'Receiving' },
+        { value: 'bills', label: 'Bills', recordResource: 'vendor_bill' },
+      ],
     },
   },
 
@@ -257,10 +263,11 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     // The exception queue is a filtered list view, not a page per bill.
     additionalTabs: [],
     tabCards: {
-      // `vendor` and `payment` are wanted and unbuilt, as above.
       overview: [
         { value: 'lines', label: 'Lines', fullBleed: true },
         { value: 'match', label: 'Match' },
+        { value: 'vendor', label: 'Vendor' },
+        { value: 'payment', label: 'Payment' },
       ],
     },
   },


### PR DESCRIPTION
Five drawer/sidebar cards for the purchasing documents, built to the work-order drawer's shape: a summary strip of figures, then `TreeRow`s, with header actions portalled through `DrawerCardActions`.

| card | shows |
| --- | --- |
| `purchase_order:vendor` | the company, plus its headquarters |
| `purchase_order:receiving` | ordered / received / outstanding, then a badged row per line |
| `purchase_order:bills` | order total / billed / unbilled, then a row per bill |
| `vendor_bill:vendor` | the same component, the bill's side |
| `vendor_bill:payment` | bill total / paid / balance, the payment row, and **Mark paid** |

Closes [02-handoff.md](../blob/main/plans/purchasing/02-handoff.md) §4.5. The PO's `sidebarCards` was `[]` before this.

## Two of these were the only surface a field had

- **`purchase_order_bills` is `showInPanel: false`** — so a bill knew its PO and the PO could not show its bills. The inverse edge had no rendering anywhere.
- **`purchase_order_line_quantity_received`** is a maintained post-commit re-SUM over `stock_movement` (`purchasing-hooks.ts`) that nothing had ever read back.

## No totals card

`subtotal` / `shippingTotal` / `taxTotal` / `discountValue` / `total` are all `showInPanel: false` **because** the LineBuilder's `TotalsFooter` renders them under the lines. A totals card would be a second competing rendering of the same five mirrors — the call `order` already made (`drawer-config.ts`, the `order` block). The comment asking for one predates the LineBuilder cutover in #1918.

## Mark paid writes fields, and does not post

- **Not records.** `vendor_payment` is inert under P13 and `108-purchasing.test.ts` fails if any file in `packages/lib` so much as names it, so a payment object is not available to write and is not improvised.
- **Not a posting.** P12 relieves A/P with `Dr 2000 / Cr 1000` in ledger mode, but `post-entry.ts` is phase 7 and does not exist. The six fields are `creatable: true` and typeable in the Details panel today; this is that write made convenient, and carries the same gap. Documented at the top of the dialog.
- `paidSource` is written `manual` (a human confirming), never `rule` — P12's "not decoration" distinction. Status only flips to `paid` when the payment fully settles the bill; a partial payment leaves it where the match put it.

## ⚠️ `vendor_bill_balance` has no writer

It is declared `creatable: false` — *"computed from total and amountPaid"* — but `purchasing-hooks.ts` registers only the two numbering hooks. Nothing computes it, so **every bill's stored balance is NULL**. That is the same shape as the latent defect [02-handoff.md §1](../blob/main/plans/purchasing/02-handoff.md) documents, and the shape that shipped NULL order numbers twice.

This PR does not fix it — the card computes `total − amountPaid` for display and never reads the stored field, so the screen is right. The field itself is still dead, and a filter or sort on Balance returns nothing useful. Worth its own change.

## Test

`drawer-card-parity.test.ts` pins the trap [02-handoff.md §6](../blob/main/plans/purchasing/02-handoff.md) names twice: a card declared with no registered component renders **nothing**, silently — `base-entity-drawer.tsx` is `if (!componentLoader) return null`, no error, no placeholder, no warning. Six cards were declared ahead of their components during the original build and had to be trimmed back out; this is that review step, automated.

Key-set only — the registry's values are dynamic `import()`s and the test never calls them. It carries a non-vacuity guard so a config shape change cannot make the walk yield zero keys and pass while checking nothing.

## Not covered

`vendor_bill_document` (the vendor's scanned PDF) is `showInPanel: false` with no card, so it is still unreachable in the UI. Left out because `FileRefDetail` carries only name/mimeType/size — no URL — so an openable link needs plumbing beyond a card.

## Verification

```
node scripts/ci/typecheck-ratchet.js --package web   # 0, baseline 0
node scripts/ci/typecheck-ratchet.js --package lib   # 29, baseline 29 — no new
cd apps/web    && pnpm exec vitest run src/components/drawers/drawer-card-parity.test.ts   # 5 passed
cd packages/lib && pnpm exec vitest run src/resources/registry                             # 101 passed (8 files)
pnpm -F @auxx/lib check:exports                      # up to date (264 entries)
biome check                                          # clean on all 10 files
```

All re-run on this branch's base (main at `4d8721496`), not only on the tree it was written against.
