### PR TITLE
feat(receiving): the receipt form, and the first caller of the purchasing router

### DIFF
--- a/apps/web/src/components/drawers/cards/part-inventory-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-inventory-card.tsx
@@ -13,12 +13,15 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatRelativeTime } from '@auxx/utils'
+import { formatCurrency } from '@auxx/utils/currency'
 import { ChevronRight } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import { useMemo, useState } from 'react'
+import { ReceiveStockPopover } from '~/components/manufacturing/parts/receive-stock-popover'
 import { StockAdjustmentPopover } from '~/components/manufacturing/parts/stock-adjustment-popover'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSettings } from '~/hooks/use-settings'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import { PartLinkedInventorySection } from './part-linked-inventory-card'
 
@@ -53,19 +56,35 @@ const MOVEMENT_ATTRIBUTES = [
   'stock_movement_quantity',
   'stock_movement_reason',
   'stock_movement_reference',
+  // plans/purchasing/01-build-plan.md §3.5 — the frozen cost, and the ACCOUNTING
+  // date, which is when the goods arrived rather than when they were keyed.
+  'stock_movement_unit_cost',
+  'stock_movement_occurred_at',
 ] as const
 
 // ─────────────────────────────────────────────────────────────────
 // Movement Row
 // ─────────────────────────────────────────────────────────────────
 
-function MovementRow({ recordId, createdAt }: { recordId: RecordId; createdAt?: string | Date }) {
+function MovementRow({
+  recordId,
+  createdAt,
+  currencyCode,
+}: {
+  recordId: RecordId
+  createdAt?: string | Date
+  currencyCode: string
+}) {
   const { values } = useSystemValues(recordId, MOVEMENT_ATTRIBUTES, { autoFetch: true })
 
   const type = values.stock_movement_type as string | undefined
   const quantity = values.stock_movement_quantity as number | undefined
   const reason = values.stock_movement_reason as string | undefined
   const reference = values.stock_movement_reference as string | undefined
+  const unitCost = values.stock_movement_unit_cost as number | null | undefined
+  const occurredAt = values.stock_movement_occurred_at as string | undefined
+  // COALESCE(occurredAt, createdAt): only a receipt carries an accounting date.
+  const shownAt = occurredAt ?? createdAt
 
   const isPositive = quantity != null && quantity > 0
   const label = type ? (TYPE_LABEL_MAP[type] ?? type) : '—'
@@ -80,12 +99,17 @@ function MovementRow({ recordId, createdAt }: { recordId: RecordId; createdAt?: 
         className={`font-mono text-xs font-medium tabular-nums ${isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
         {quantity != null ? `${isPositive ? '+' : ''}${quantity}` : '—'}
       </span>
+      {unitCost != null && (
+        <span className='shrink-0 font-mono text-muted-foreground text-xs tabular-nums'>
+          {formatCurrency(unitCost, { currencyCode })}
+        </span>
+      )}
       <span className='flex-1 truncate text-xs text-muted-foreground'>
         {reason || reference || ''}
       </span>
-      {createdAt && (
+      {shownAt && (
         <span className='shrink-0 text-xs text-muted-foreground'>
-          {formatRelativeTime(createdAt, true)}
+          {formatRelativeTime(shownAt, true)}
         </span>
       )}
     </div>
@@ -99,15 +123,15 @@ function MovementRow({ recordId, createdAt }: { recordId: RecordId; createdAt?: 
 function MovementsList({
   partId,
   currentQoH,
-  hasSubparts,
   onAdjustSuccess,
 }: {
   partId: string
   currentQoH: number
-  hasSubparts: boolean
   onAdjustSuccess: () => void
 }) {
   const stockMovementDefId = useResourceProperty('stock_movement', 'id')
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
 
   const filters: ConditionGroup[] = useMemo(
     () => [
@@ -146,15 +170,21 @@ function MovementsList({
     <div className='border-t border-border/50 pt-2 mt-1'>
       <div className='flex items-center justify-between mb-2'>
         <h4 className='text-xs font-semibold text-muted-foreground'>Stock Movements</h4>
-        <StockAdjustmentPopover
-          partId={partId}
-          currentQoH={currentQoH}
-          hasSubparts={hasSubparts}
-          onSuccess={handleAdjustSuccess}>
-          <Button variant='outline' size='xs'>
-            Adjust
-          </Button>
-        </StockAdjustmentPopover>
+        <div className='flex items-center gap-1'>
+          <ReceiveStockPopover partId={partId} onSuccess={handleAdjustSuccess}>
+            <Button variant='outline' size='xs'>
+              Receive
+            </Button>
+          </ReceiveStockPopover>
+          <StockAdjustmentPopover
+            partId={partId}
+            currentQoH={currentQoH}
+            onSuccess={handleAdjustSuccess}>
+            <Button variant='outline' size='xs'>
+              Adjust
+            </Button>
+          </StockAdjustmentPopover>
+        </div>
       </div>
 
       {isLoading || isLoadingRecords ? (
@@ -173,6 +203,7 @@ function MovementsList({
                 key={record.id}
                 recordId={toRecordId(stockMovementDefId!, record.id)}
                 createdAt={record.createdAt}
+                currencyCode={currencyCode}
               />
             ))}
           </div>
@@ -191,35 +222,6 @@ export function PartInventoryCard({ recordId, entityInstanceId }: DrawerTabProps
   const partId = entityInstanceId
   const { values, isLoading } = useSystemValues(recordId, [...PART_ATTRIBUTES], { autoFetch: true })
   const [isOpen, setIsOpen] = useState(false)
-  const subpartDefId = useResourceProperty('subpart', 'id')
-
-  // Check if part has subparts (for "Adjust subparts" toggle)
-  const subpartFilters: ConditionGroup[] = useMemo(
-    () => [
-      {
-        id: 'parent-filter',
-        logicalOperator: 'AND' as const,
-        conditions: [
-          {
-            id: 'parent-match',
-            fieldId: 'subpart:parentPart' as ResourceFieldId,
-            operator: 'is' as const,
-            value: partId,
-          },
-        ],
-      },
-    ],
-    [partId]
-  )
-
-  const { records: subpartRecords } = useRecordList({
-    entityDefinitionId: subpartDefId ?? '',
-    filters: subpartFilters,
-    limit: 1,
-    enabled: !!partId && !!subpartDefId,
-  })
-
-  const hasSubparts = subpartRecords.length > 0
 
   const qoh = (values.part_quantity_on_hand as number) ?? 0
   const stockStatus =
@@ -298,12 +300,7 @@ export function PartInventoryCard({ recordId, entityInstanceId }: DrawerTabProps
               }}
               exit={{ height: 0, opacity: 0, filter: 'blur(3px)', overflow: 'hidden' }}
               transition={{ type: 'spring', stiffness: 300, damping: 30 }}>
-              <MovementsList
-                partId={partId}
-                currentQoH={qoh}
-                hasSubparts={hasSubparts}
-                onAdjustSuccess={() => {}}
-              />
+              <MovementsList partId={partId} currentQoH={qoh} onAdjustSuccess={() => {}} />
             </motion.div>
           )}
         </AnimatePresence>

--- a/apps/web/src/components/drawers/tabs/part-inventory-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-inventory-tab.tsx
@@ -20,12 +20,15 @@ import {
   TableRow,
 } from '@auxx/ui/components/table'
 import { formatRelativeTime } from '@auxx/utils'
-import { Package } from 'lucide-react'
+import { formatCurrency } from '@auxx/utils/currency'
+import { Package, PackagePlus } from 'lucide-react'
 import { useMemo } from 'react'
+import { ReceiveStockPopover } from '~/components/manufacturing/parts/receive-stock-popover'
 import { StockAdjustmentPopover } from '~/components/manufacturing/parts/stock-adjustment-popover'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useFieldValueStore } from '~/components/resources/store/field-value-store'
+import { useSettings } from '~/hooks/use-settings'
 import { useAccess } from '~/providers/capabilities-provider'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
@@ -60,6 +63,11 @@ const MOVEMENT_ATTRIBUTES = [
   'stock_movement_quantity',
   'stock_movement_reason',
   'stock_movement_reference',
+  // plans/purchasing/01-build-plan.md §3.5. A receipt's whole point is the cost
+  // it froze, and `occurredAt` is the ACCOUNTING date — when the goods actually
+  // arrived, which is not when somebody got round to keying them.
+  'stock_movement_unit_cost',
+  'stock_movement_occurred_at',
 ] as const
 
 /** Inventory tab for the part detail view */
@@ -72,43 +80,16 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
   // its `autoFetch` re-pulls the recalculated on-hand quantity.
   const invalidateResource = useFieldValueStore((s) => s.invalidateResource)
   const stockMovementDefId = useResourceProperty('stock_movement', 'id')
-  const subpartDefId = useResourceProperty('subpart', 'id')
   // The tab itself is NOT `recordResource`-gated — it leads with the part's own
   // on-hand quantity — so the stock_movement gate sits on the write action.
   const { canEditEntity } = useAccess()
   const canAdjustStock = !!stockMovementDefId && canEditEntity(stockMovementDefId)
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
 
   const qoh = (values.part_quantity_on_hand as number) ?? 0
   const stockStatus =
     (values.part_stock_status as string | undefined) ?? (qoh <= 0 ? 'out_of_stock' : 'in_stock')
-
-  // Check if part has subparts (for "Adjust subparts" toggle)
-  const subpartFilters: ConditionGroup[] = useMemo(
-    () => [
-      {
-        id: 'parent-filter',
-        logicalOperator: 'AND' as const,
-        conditions: [
-          {
-            id: 'parent-match',
-            fieldId: 'subpart:parentPart' as ResourceFieldId,
-            operator: 'is' as const,
-            value: partId,
-          },
-        ],
-      },
-    ],
-    [partId]
-  )
-
-  const { records: subpartRecords } = useRecordList({
-    entityDefinitionId: subpartDefId ?? '',
-    filters: subpartFilters,
-    limit: 1,
-    enabled: !!partId && !!subpartDefId,
-  })
-
-  const hasSubparts = subpartRecords.length > 0
 
   const filters: ConditionGroup[] = useMemo(
     () => [
@@ -179,16 +160,25 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
         initialOpen
         actions={
           canAdjustStock ? (
-            <StockAdjustmentPopover
-              partId={partId}
-              currentQoH={qoh}
-              hasSubparts={hasSubparts}
-              onSuccess={handleAdjustSuccess}>
-              <Button variant='ghost' size='xs'>
-                <Package />
-                Adjust Stock
-              </Button>
-            </StockAdjustmentPopover>
+            <div className='flex items-center gap-1'>
+              {/* Receive leads: it is the movement that VALUES stock, and the one
+                  a purchase produces. Adjust is the correction beside it. */}
+              <ReceiveStockPopover partId={partId} onSuccess={handleAdjustSuccess}>
+                <Button variant='ghost' size='xs'>
+                  <PackagePlus />
+                  Receive
+                </Button>
+              </ReceiveStockPopover>
+              <StockAdjustmentPopover
+                partId={partId}
+                currentQoH={qoh}
+                onSuccess={handleAdjustSuccess}>
+                <Button variant='ghost' size='xs'>
+                  <Package />
+                  Adjust Stock
+                </Button>
+              </StockAdjustmentPopover>
+            </div>
           ) : undefined
         }>
         {records.length === 0 ? (
@@ -206,6 +196,7 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
                 <TableRow>
                   <TableHead>Type</TableHead>
                   <TableHead className='text-right'>Qty</TableHead>
+                  <TableHead className='text-right'>Unit cost</TableHead>
                   <TableHead>Reason</TableHead>
                   <TableHead className='text-right'>Date</TableHead>
                 </TableRow>
@@ -216,6 +207,7 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
                     key={record.id}
                     recordId={toRecordId(stockMovementDefId!, record.id)}
                     createdAt={record.createdAt}
+                    currencyCode={currencyCode}
                   />
                 ))}
               </TableBody>
@@ -229,13 +221,26 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
 
 // ─── Row Component ──────────────────────────────────────────────────────
 
-function MovementRow({ recordId, createdAt }: { recordId: RecordId; createdAt?: string | Date }) {
+function MovementRow({
+  recordId,
+  createdAt,
+  currencyCode,
+}: {
+  recordId: RecordId
+  createdAt?: string | Date
+  currencyCode: string
+}) {
   const { values } = useSystemValues(recordId, MOVEMENT_ATTRIBUTES, { autoFetch: true })
 
   const type = values.stock_movement_type as string | undefined
   const quantity = values.stock_movement_quantity as number | undefined
   const reason = values.stock_movement_reason as string | undefined
   const reference = values.stock_movement_reference as string | undefined
+  const unitCost = values.stock_movement_unit_cost as number | null | undefined
+  const occurredAt = values.stock_movement_occurred_at as string | undefined
+  // COALESCE(occurredAt, createdAt) — an adjustment carries no accounting date, so
+  // it falls back to when it was written. A receipt has one and it is the truth.
+  const shownAt = occurredAt ?? createdAt
 
   const isPositive = quantity != null && quantity > 0
   const label = type ? (TYPE_LABEL_MAP[type] ?? type) : '—'
@@ -254,12 +259,17 @@ function MovementRow({ recordId, createdAt }: { recordId: RecordId; createdAt?: 
           {quantity != null ? `${isPositive ? '+' : ''}${quantity}` : '—'}
         </span>
       </TableCell>
+      <TableCell className='text-right'>
+        <span className='font-mono text-muted-foreground text-xs tabular-nums'>
+          {unitCost != null ? formatCurrency(unitCost, { currencyCode }) : '—'}
+        </span>
+      </TableCell>
       <TableCell>
         <span className='truncate text-sm text-muted-foreground'>{reason || reference || '—'}</span>
       </TableCell>
       <TableCell className='text-right'>
         <span className='text-xs text-muted-foreground'>
-          {createdAt ? formatRelativeTime(createdAt, true) : '—'}
+          {shownAt ? formatRelativeTime(shownAt, true) : '—'}
         </span>
       </TableCell>
     </TableRow>

--- a/apps/web/src/components/manufacturing/parts/receipt-input.test.ts
+++ b/apps/web/src/components/manufacturing/parts/receipt-input.test.ts
@@ -1,0 +1,123 @@
+// apps/web/src/components/manufacturing/parts/receipt-input.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { buildReceiptInput, type ReceiptFormState, receiptBreakdown } from './receipt-input'
+
+/** A priced supplier row: $1.20 freight, 4.3% tariff, no other cost. */
+const TERMS = { shippingCost: 120, tariffRate: 4.3, otherCost: null }
+
+function formState(overrides: Partial<ReceiptFormState> = {}): ReceiptFormState {
+  return {
+    partId: 'part_1',
+    quantity: 10,
+    vendorPartId: 'vp_1',
+    terms: TERMS,
+    unitPrice: 4400,
+    occurredAt: '2026-08-26T00:00:00.000Z',
+    reference: '',
+    reason: '',
+    ...overrides,
+  }
+}
+
+describe('receiptBreakdown', () => {
+  it('applies the supplier adders to the price on screen', () => {
+    const parts = receiptBreakdown(formState())
+    // $44.00 + $1.20 freight + $1.89 tariff (4.3% of 4400 = 189.2 → 189)
+    expect(parts).toEqual({
+      base: 4400,
+      freight: 120,
+      tariff: 189,
+      tariffRate: 4.3,
+      other: 0,
+      landed: 4709,
+    })
+  })
+
+  it('keeps the adders when the price is edited', () => {
+    // Freight and tariff still apply to a price the vendor actually charged, so
+    // an edit is a new base under the same terms — not a reason to drop them.
+    const parts = receiptBreakdown(formState({ unitPrice: 5000 }))
+    expect(parts?.base).toBe(5000)
+    expect(parts?.freight).toBe(120)
+    expect(parts?.landed).toBe(5000 + 120 + 215)
+  })
+
+  it('is the bare price when the part has no supplier row', () => {
+    const parts = receiptBreakdown(formState({ vendorPartId: null, terms: null, unitPrice: 4400 }))
+    expect(parts).toMatchObject({ base: 4400, freight: 0, tariff: 0, other: 0, landed: 4400 })
+  })
+
+  it('has no answer without a price', () => {
+    expect(receiptBreakdown(formState({ unitPrice: null }))).toBeNull()
+  })
+
+  it('parts always sum to the landed total', () => {
+    for (const unitPrice of [1, 333, 4133, 99999]) {
+      for (const tariffRate of [0, 4.3, 7.5, 10]) {
+        const parts = receiptBreakdown(formState({ unitPrice, terms: { ...TERMS, tariffRate } }))
+        expect(parts).not.toBeNull()
+        const sum = parts!.base + parts!.freight + parts!.tariff + parts!.other
+        // A breakdown whose lines do not visibly add up to its own total is worse
+        // than no breakdown, and this one is shown to the person keying the cost.
+        expect(sum).toBe(parts!.landed)
+      }
+    }
+  })
+})
+
+describe('buildReceiptInput', () => {
+  it('always sends unitCost alongside vendorUnitPrice', () => {
+    // 🛑 The whole reason this module exists. `receiveStock` derives landed from
+    // the supplier row's OWN unitPrice when `unitCost` is absent, so sending only
+    // the edited base would freeze a cost computed from the replaced price —
+    // silently, with no error and a row that looks correct.
+    const input = buildReceiptInput(formState({ unitPrice: 5000 }))
+    expect(input?.vendorUnitPrice).toBe(5000)
+    expect(input?.unitCost).toBe(5335)
+  })
+
+  it('sends the exact number the breakdown displayed', () => {
+    const state = formState()
+    expect(buildReceiptInput(state)?.unitCost).toBe(receiptBreakdown(state)?.landed)
+  })
+
+  it('omits the supplier when the part has no row, and still prices the receipt', () => {
+    const input = buildReceiptInput(formState({ vendorPartId: null, terms: null }))
+    expect(input).not.toBeNull()
+    expect(input).not.toHaveProperty('vendorPartId')
+    expect(input?.unitCost).toBe(4400)
+  })
+
+  it('refuses a non-positive quantity', () => {
+    expect(buildReceiptInput(formState({ quantity: 0 }))).toBeNull()
+    expect(buildReceiptInput(formState({ quantity: -3 }))).toBeNull()
+    expect(buildReceiptInput(formState({ quantity: null }))).toBeNull()
+    expect(buildReceiptInput(formState({ quantity: Number.NaN }))).toBeNull()
+  })
+
+  it('refuses a receipt that would land at zero cost', () => {
+    // Mirrors `receiveStock`'s hard failure: a zero-cost receipt is worse than a
+    // missing one because it looks like data. The server check is the real guard;
+    // this one only keeps the button honest.
+    expect(buildReceiptInput(formState({ unitPrice: null }))).toBeNull()
+    expect(buildReceiptInput(formState({ unitPrice: 0, terms: null }))).toBeNull()
+  })
+
+  it('drops blank reference and reason rather than sending empty strings', () => {
+    const input = buildReceiptInput(formState({ reference: '   ', reason: '' }))
+    expect(input).not.toHaveProperty('reference')
+    expect(input).not.toHaveProperty('reason')
+  })
+
+  it('trims a reference that was typed with padding', () => {
+    expect(buildReceiptInput(formState({ reference: '  slip 88213 ' }))?.reference).toBe(
+      'slip 88213'
+    )
+  })
+
+  it('sends the accounting date the form was given, not today', () => {
+    const input = buildReceiptInput(formState({ occurredAt: '2026-01-04T09:30:00.000Z' }))
+    expect(input?.occurredAt.toISOString()).toBe('2026-01-04T09:30:00.000Z')
+  })
+})

--- a/apps/web/src/components/manufacturing/parts/receipt-input.ts
+++ b/apps/web/src/components/manufacturing/parts/receipt-input.ts
@@ -1,0 +1,94 @@
+// apps/web/src/components/manufacturing/parts/receipt-input.ts
+
+// What the Receive form actually sends, as a pure function of what is on screen.
+//
+// Extracted from `receive-stock-popover.tsx` because ONE detail here is both
+// load-bearing and invisible: `receiveStock` derives the landed cost from the
+// supplier row's OWN `unitPrice` whenever `unitCost` is absent
+// (`receive-stock.ts` → `resolveReceiptPrice`). So a form that sends only the
+// edited `vendorUnitPrice` stores a cost computed from the price the user just
+// replaced — the edit appears to work, the row looks right, and the frozen cost
+// is wrong forever. Nothing throws.
+//
+// The rule is therefore: whenever the form can price a receipt at all, it sends
+// BOTH figures, and the landed one is the same number the breakdown showed.
+
+import type { ReceiptCostInputs, ReceiptCostParts } from '@auxx/lib/receiving/client'
+import { computeReceiptLandedBreakdown } from '@auxx/lib/receiving/client'
+
+/** The `purchasing.receiveStock` input, as this form builds it. */
+export interface ReceiptInput {
+  partId: string
+  quantity: number
+  vendorPartId?: string
+  vendorUnitPrice: number
+  unitCost: number
+  occurredAt: Date
+  reference?: string
+  reason?: string
+}
+
+/** Everything on the form that decides the payload. */
+export interface ReceiptFormState {
+  partId: string
+  quantity: number | null
+  /** The selected supplier row, or null when the part has none. */
+  vendorPartId: string | null
+  /** The selected row's freight/tariff/other terms. */
+  terms: Pick<ReceiptCostInputs, 'shippingCost' | 'tariffRate' | 'otherCost'> | null
+  /** The base price as it stands in the input — prefilled, possibly edited. */
+  unitPrice: number | null
+  /** ISO string from the date input. */
+  occurredAt: string
+  reference: string
+  reason: string
+}
+
+/**
+ * The landed breakdown for the price currently on screen.
+ *
+ * The adders come from the selected supplier row and the base comes from the
+ * INPUT, not the row: freight and tariff terms still apply to a price the vendor
+ * actually charged, so an edited price is a new base under the same terms rather
+ * than a reason to drop them.
+ */
+export function receiptBreakdown(state: ReceiptFormState): ReceiptCostParts | null {
+  if (state.unitPrice == null) return null
+  return computeReceiptLandedBreakdown({
+    unitPrice: state.unitPrice,
+    shippingCost: state.terms?.shippingCost ?? null,
+    tariffRate: state.terms?.tariffRate ?? null,
+    otherCost: state.terms?.otherCost ?? null,
+  })
+}
+
+/**
+ * Build the mutation input, or `null` when the form is not submittable.
+ *
+ * Not submittable means: no positive quantity, no price at all, or a price that
+ * lands at or below zero. The last one is refused here as well as on the server
+ * (`receiveStock` throws `UnprocessableEntityError`) because a disabled button is
+ * a better answer than a toast — but the server check is the real guard, and this
+ * one must never be the only one.
+ */
+export function buildReceiptInput(state: ReceiptFormState): ReceiptInput | null {
+  if (state.quantity == null || !Number.isFinite(state.quantity) || state.quantity <= 0) return null
+
+  const breakdown = receiptBreakdown(state)
+  if (!breakdown || breakdown.landed <= 0) return null
+
+  const reference = state.reference.trim()
+  const reason = state.reason.trim()
+
+  return {
+    partId: state.partId,
+    quantity: state.quantity,
+    ...(state.vendorPartId ? { vendorPartId: state.vendorPartId } : {}),
+    // Both, always — see the note at the top of this file.
+    vendorUnitPrice: breakdown.base,
+    unitCost: breakdown.landed,
+    occurredAt: new Date(state.occurredAt),
+    ...(reference ? { reference } : {}),
+    ...(reason ? { reason } : {}),
+  }
+}

--- a/apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
@@ -1,0 +1,338 @@
+// apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
+'use client'
+
+// The receipt form (plans/purchasing/01-build-plan.md §3.5) — a sibling of
+// `stock-adjustment-popover.tsx`, deliberately not a mode of it.
+//
+// 🛑 Do NOT merge the two behind a type selector. `adjust` is a count correction
+// and `receive` is a purchase: a merged form has a supplier, a price and a landed
+// breakdown that are all irrelevant on half its inputs, and a Direction control
+// that is meaningless on the other half.
+//
+// The price input is PREFILLED FROM THE SUPPLIER ROW AND EDITABLE, and that is the
+// point of the whole form: the standing terms are a guess, the vendor's actual
+// invoice is the fact, and freezing the guess is how inventory value drifts away
+// from what was really paid.
+//
+// The landed cost is shown broken out beneath it — `$47.10 = $44.00 + $1.20
+// freight + $1.90 tariff (4.3%)` — because that total is what gets frozen onto the
+// movement forever, and a number nobody can check is a number nobody catches.
+// Client and server compute it with the SAME `computeReceiptLandedCost`, so the
+// figure on screen is the figure stored.
+
+import { FieldType } from '@auxx/database/enums'
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { formatLandedCostSummary, type ReceiptCostInputs } from '@auxx/lib/receiving/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
+import { useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { BaseType } from '~/components/workflow/types'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import { buildReceiptInput, type ReceiptFormState, receiptBreakdown } from './receipt-input'
+
+/** Everything the landed-cost formula needs, plus what the option label shows. */
+const VENDOR_PART_ATTRIBUTES = [
+  'vendor_part_vendor_sku',
+  'vendor_part_unit_price',
+  'vendor_part_shipping_cost',
+  'vendor_part_tariff_rate',
+  'vendor_part_other_cost',
+  'vendor_part_is_preferred',
+] as const
+
+interface SupplierOption {
+  id: string
+  label: string
+  isPreferred: boolean
+  terms: ReceiptCostInputs
+}
+
+interface ReceiveStockPopoverProps {
+  /** The part's entityInstanceId. */
+  partId: string
+  onSuccess?: () => void
+  children: React.ReactNode
+}
+
+export function ReceiveStockPopover({ partId, onSuccess, children }: ReceiveStockPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const [vendorPartId, setVendorPartId] = useState<string | null>(null)
+  const [quantity, setQuantity] = useState<number | null>(null)
+  const [unitPrice, setUnitPrice] = useState<number | null>(null)
+  // Whether the price shown is the person's own number rather than the prefill.
+  // Without this, re-running the prefill effect would quietly overwrite a typed
+  // price — the one value on this form that must never be overwritten.
+  const [priceEdited, setPriceEdited] = useState(false)
+  const [occurredAt, setOccurredAt] = useState<string>(() => new Date().toISOString())
+  const [reference, setReference] = useState('')
+  const [reason, setReason] = useState('')
+
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+
+  const suppliers = usePartSuppliers(partId, open)
+  const selected = suppliers.find((option) => option.id === vendorPartId) ?? null
+
+  // Reset to a fresh form every time the popover opens, defaulting to the
+  // preferred supplier (§3.5) — the row the buyer already chose.
+  useEffect(() => {
+    if (!open) return
+    setQuantity(null)
+    setUnitPrice(null)
+    setPriceEdited(false)
+    setOccurredAt(new Date().toISOString())
+    setReference('')
+    setReason('')
+    setVendorPartId(null)
+  }, [open])
+
+  // Prefill the supplier once the rows land, then the price from that supplier.
+  // Split from the reset above because the rows arrive asynchronously, after it.
+  useEffect(() => {
+    if (!open || vendorPartId || suppliers.length === 0) return
+    const preferred = suppliers.find((option) => option.isPreferred) ?? suppliers[0]
+    if (preferred) setVendorPartId(preferred.id)
+  }, [open, vendorPartId, suppliers])
+
+  useEffect(() => {
+    if (!open || priceEdited) return
+    setUnitPrice(selected?.terms.unitPrice ?? null)
+  }, [open, priceEdited, selected])
+
+  // Everything that decides the payload, in one value — so what the breakdown
+  // below renders and what the mutation sends are computed from the same state
+  // by the same module (`receipt-input.ts`), not by two expressions that agree
+  // today.
+  const formState: ReceiptFormState = {
+    partId,
+    quantity,
+    vendorPartId,
+    terms: selected?.terms ?? null,
+    unitPrice,
+    occurredAt,
+    reference,
+    reason,
+  }
+  const breakdown = receiptBreakdown(formState)
+  const payload = buildReceiptInput(formState)
+
+  const receiveStock = api.purchasing.receiveStock.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Failed to receive stock', description: error.message }),
+  })
+
+  const isPending = receiveStock.isPending
+
+  const handleSubmit = async () => {
+    if (!payload) return
+    try {
+      await receiveStock.mutateAsync(payload)
+      onSuccess?.()
+      setOpen(false)
+    } catch {
+      // onError above already surfaced the toast.
+    }
+  }
+
+  const supplierOptions = useMemo(
+    () => ({ options: suppliers.map((option) => ({ label: option.label, value: option.id })) }),
+    [suppliers]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className='w-96' align='end'>
+        <div className='space-y-3'>
+          <h4 className='font-semibold text-sm'>Receive Stock</h4>
+
+          <FieldPanel className='p-0'>
+            <FieldPanelRow
+              title='Supplier part'
+              type={BaseType.ENUM}
+              showIcon
+              description='Sets the price and the freight and tariff terms'>
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
+                value={vendorPartId}
+                onChange={(val) => {
+                  setVendorPartId((val as string[])[0] ?? null)
+                  // A different supplier means different terms, so the prefill is
+                  // live again — the typed price belonged to the old row.
+                  setPriceEdited(false)
+                }}
+                fieldOptions={supplierOptions}
+                disabled={isPending || suppliers.length === 0}
+              />
+            </FieldPanelRow>
+
+            <FieldPanelRow title='Quantity' type={BaseType.NUMBER} showIcon isRequired>
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
+                value={quantity}
+                onChange={(val) => setQuantity((val as number) ?? null)}
+                placeholder='0'
+                disabled={isPending}
+              />
+            </FieldPanelRow>
+
+            <FieldPanelRow
+              title='Unit price'
+              type={BaseType.CURRENCY}
+              showIcon
+              isRequired
+              description='What the vendor actually charged'>
+              <FieldInputAdapter
+                fieldType={FieldType.CURRENCY}
+                fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+                value={unitPrice}
+                onChange={(val) => {
+                  setUnitPrice((val as number) ?? null)
+                  setPriceEdited(true)
+                }}
+                disabled={isPending}
+              />
+              {breakdown && (
+                <p className='mt-1 text-muted-foreground text-xs tabular-nums'>
+                  {formatLandedCostSummary(breakdown, (minorUnits) =>
+                    formatCurrency(minorUnits, { currencyCode })
+                  )}
+                  {' landed'}
+                </p>
+              )}
+            </FieldPanelRow>
+
+            <FieldPanelRow
+              title='Received on'
+              type={BaseType.DATE}
+              showIcon
+              isRequired
+              description='The accounting date, which is not when it was keyed'>
+              <FieldInputAdapter
+                fieldType={FieldType.DATETIME}
+                value={occurredAt}
+                onChange={(val) => setOccurredAt(val as string)}
+                disabled={isPending}
+              />
+            </FieldPanelRow>
+
+            <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.TEXT}
+                value={reference}
+                onChange={(val) => setReference((val as string) ?? '')}
+                placeholder='e.g. Packing slip 88213'
+                disabled={isPending}
+              />
+            </FieldPanelRow>
+
+            <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.TEXT}
+                value={reason}
+                onChange={(val) => setReason((val as string) ?? '')}
+                placeholder='e.g. Partial delivery'
+                disabled={isPending}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+
+          {suppliers.length === 0 && (
+            <p className='text-muted-foreground text-xs'>
+              This part has no supplier rows. Enter the price paid to receive it anyway.
+            </p>
+          )}
+
+          <div className='flex justify-end gap-2'>
+            <Button variant='ghost' size='xs' onClick={() => setOpen(false)} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant='outline'
+              size='xs'
+              onClick={handleSubmit}
+              loading={isPending}
+              loadingText='Receiving...'
+              disabled={!payload}>
+              Receive
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/**
+ * The part's supplier rows with their priced terms, in the shape the form needs.
+ *
+ * The Suppliers tab's read (`part-vendors-tab.tsx`), narrowed: this form ranks
+ * nothing, it only prefills, so it wants the terms and a label and not the
+ * lead-time/contact columns that tab renders.
+ */
+function usePartSuppliers(partId: string, enabled: boolean): SupplierOption[] {
+  const vendorPartDefId = useResourceProperty('vendor_part', 'id')
+
+  const filters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'part-filter',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'part-match',
+            fieldId: 'vendor_part:part' as ResourceFieldId,
+            operator: 'is' as const,
+            value: partId,
+          },
+        ],
+      },
+    ],
+    [partId]
+  )
+
+  const { records } = useRecordList({
+    entityDefinitionId: vendorPartDefId ?? '',
+    filters,
+    limit: 50,
+    enabled: enabled && !!partId && !!vendorPartDefId,
+  })
+
+  const recordIds = useMemo(
+    () => (vendorPartDefId ? records.map((record) => toRecordId(vendorPartDefId, record.id)) : []),
+    [records, vendorPartDefId]
+  )
+
+  const { valuesById } = useSystemValuesForRecords(recordIds, VENDOR_PART_ATTRIBUTES, {
+    autoFetch: true,
+    enabled: enabled && recordIds.length > 0,
+  })
+
+  return useMemo(
+    () =>
+      records.map((record, index) => {
+        const values = valuesById[recordIds[index] ?? ''] ?? ({} as Record<string, unknown>)
+        const sku = values.vendor_part_vendor_sku as string | undefined
+        return {
+          id: record.id,
+          label: record.displayName || sku || 'Supplier part',
+          isPreferred: (values.vendor_part_is_preferred as boolean | undefined) ?? false,
+          terms: {
+            unitPrice: (values.vendor_part_unit_price as number | null | undefined) ?? null,
+            shippingCost: (values.vendor_part_shipping_cost as number | null | undefined) ?? null,
+            tariffRate: (values.vendor_part_tariff_rate as number | null | undefined) ?? null,
+            otherCost: (values.vendor_part_other_cost as number | null | undefined) ?? null,
+          },
+        }
+      }),
+    [records, recordIds, valuesById]
+  )
+}

--- a/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
@@ -30,17 +30,34 @@ interface StockAdjustmentPopoverProps {
   partId: string
   /** Current quantity on hand (needed for "Set to" mode) */
   currentQoH: number
-  /** Whether this part has subparts (BOM) — enables "Adjust subparts" toggle */
-  hasSubparts?: boolean
   onSuccess?: () => void
   children: React.ReactNode
 }
 
-/** Popover for creating manual stock movements */
+/**
+ * Popover for creating manual stock movements — `type: 'adjust'` only.
+ *
+ * 🛑 There is deliberately no "Adjust subparts" control and no BOM cascade.
+ * The toggle that used to live here exploded the bill of materials WITHOUT
+ * negating, so "Add 10" of a finished good increased every component's stock
+ * as well — the assembly and the parts it consumed both went up, which is the
+ * opposite of what building one does
+ * (plans/products/11-costing-and-stock-improvements.md §5.3).
+ *
+ * An adjustment is a count correction and must never cascade: explosion belongs
+ * to a movement that knows its own direction.
+ *
+ * ⚠️ The `stock_movement_adjust_subparts` FIELD and the BOM explosion behind it
+ * are deliberately untouched — only this control is gone. The inventory bridge
+ * still sets the flag on `sale` movements
+ * (`data-connectors/inventory-bridge-pass.ts`), and that use is CORRECT: selling
+ * a finished good does consume its components, and a sale is negative, so the
+ * explosion negates. It was only ever the arbitrary direction of an `adjust`
+ * that made the cascade wrong. Do not remove the field.
+ */
 export function StockAdjustmentPopover({
   partId,
   currentQoH,
-  hasSubparts = false,
   onSuccess,
   children,
 }: StockAdjustmentPopoverProps) {
@@ -50,7 +67,6 @@ export function StockAdjustmentPopover({
   const [quantity, setQuantity] = useState<number | null>(null)
   const [reason, setReason] = useState('')
   const [reference, setReference] = useState('')
-  const [adjustSubparts, setAdjustSubparts] = useState(false)
 
   const stockMovementDefId = useResourceProperty('stock_movement', 'id')
   const partDefId = useResourceProperty('part', 'id')
@@ -63,7 +79,6 @@ export function StockAdjustmentPopover({
       setQuantity(null)
       setReason('')
       setReference('')
-      setAdjustSubparts(false)
     }
   }, [open])
 
@@ -92,7 +107,6 @@ export function StockAdjustmentPopover({
         stock_movement_part: toRecordId(partDefId, partId),
         stock_movement_type: 'adjust',
         stock_movement_quantity: finalQuantity,
-        ...(adjustSubparts && { stock_movement_adjust_subparts: true }),
         ...(reason && { stock_movement_reason: reason }),
         ...(reference && { stock_movement_reference: reference }),
       },
@@ -108,7 +122,6 @@ export function StockAdjustmentPopover({
     quantityMode,
     direction,
     currentQoH,
-    adjustSubparts,
     reason,
     reference,
     createRecord,
@@ -139,11 +152,9 @@ export function StockAdjustmentPopover({
               <FieldInputAdapter
                 fieldType={FieldType.SINGLE_SELECT}
                 value={quantityMode}
-                onChange={(val) => {
-                  const mode = ((val as string[])[0] as QuantityMode) ?? 'adjust_by'
-                  setQuantityMode(mode)
-                  if (mode === 'set_to') setAdjustSubparts(false)
-                }}
+                onChange={(val) =>
+                  setQuantityMode(((val as string[])[0] as QuantityMode) ?? 'adjust_by')
+                }
                 fieldOptions={quantityModeFieldOptions}
                 disabled={isPending}
               />
@@ -205,31 +216,7 @@ export function StockAdjustmentPopover({
                 disabled={isPending}
               />
             </FieldPanelRow>
-
-            {/* Adjust subparts toggle — only shown when part has subparts and in "Adjust by" mode */}
-            {hasSubparts && !isSetToMode && (
-              <FieldPanelRow
-                title='Adjust subparts'
-                type={BaseType.BOOLEAN}
-                showIcon
-                description='Cascade this adjustment to all leaf component parts based on the bill of materials'>
-                <FieldInputAdapter
-                  fieldType={FieldType.CHECKBOX}
-                  value={adjustSubparts}
-                  onChange={(val) => setAdjustSubparts((val as boolean) ?? false)}
-                  fieldOptions={{ variant: 'switch' }}
-                  disabled={isPending}
-                />
-              </FieldPanelRow>
-            )}
           </FieldPanel>
-
-          {/* Info hint when adjust subparts is enabled */}
-          {adjustSubparts && (
-            <p className='text-xs text-muted-foreground'>
-              Adjustment will be applied to all component parts based on the bill of materials.
-            </p>
-          )}
 
           {/* Actions */}
           <div className='flex justify-end gap-2'>

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1162,6 +1162,12 @@
       "import": "./dist/receiving/index.mjs",
       "default": "./src/receiving/index.ts"
     },
+    "./receiving/client": {
+      "types": "./src/receiving/client.ts",
+      "source": "./src/receiving/client.ts",
+      "import": "./dist/receiving/client.mjs",
+      "default": "./src/receiving/client.ts"
+    },
     "./record-rules": {
       "types": "./src/record-rules/index.ts",
       "source": "./src/record-rules/index.ts",


### PR DESCRIPTION
Phase 2's UI ([01 §3.5](../blob/main/plans/purchasing/01-build-plan.md)), which is [02-handoff.md §4.1](../blob/main/plans/purchasing/02-handoff.md) — the top-ranked missing item.

**Until this, nothing in the app called the purchasing router.** `grep 'api.purchasing' apps/web/src` returned zero hits across #1918 and #1920, so every procedure on `purchasingRouter` was unreachable, there was no way to receive stock at all, and `receipt-queries.ts` had no caller to exercise it once. That is now one hit and rising.

| | |
| --- | --- |
| `ReceiveStockPopover` | supplier part · quantity · an **editable** price · the accounting date · reference · reason |
| **Receive** button | beside Adjust, on both inventory surfaces |
| Unit cost column | the frozen landed cost, per movement |
| Date column | `COALESCE(occurredAt, createdAt)` |

Both surfaces, because `part:inventory` resolves to two different components — `drawers/tabs/part-inventory-tab.tsx` for the detail page and `drawers/cards/part-inventory-card.tsx` for the drawer.

## The price is editable, and that is the point

Standing supplier terms are a guess; the vendor's actual invoice is the fact, and freezing the guess is how inventory value drifts from what was really paid. The landed cost is shown broken out under the input — `$47.09 = $44.00 + $1.20 freight + $1.89 tariff (4.3%)` — because that total is frozen onto the movement forever, and a number nobody can check is a number nobody catches.

Client and server compute it through the same `computeReceiptLandedCost`, so the figure on screen is the figure stored. No third copy of the landed formula.

## ⚠️ Why `receipt-input.ts` is a separate module

One detail here is load-bearing and completely invisible. `receiveStock` derives the landed cost from **the supplier row's own `unitPrice`** whenever `unitCost` is absent (`receive-stock.ts` → `resolveReceiptPrice`). So a form that sends only the edited `vendorUnitPrice` stores a cost computed from the price the user just replaced:

- nothing throws
- the movement is created
- the row looks correct
- the frozen cost is wrong forever

Extracting the payload builder makes that rule testable instead of a comment. It always sends **both** figures, and the landed one is always the exact number the breakdown displayed.

13 tests, including that the breakdown's parts sum to its own total across a price × tariff-rate grid — a breakdown whose lines don't visibly add up is worse than no breakdown, and this one is shown to the person keying the cost.

## Removes the Adjust subparts toggle

[products/11 §5.3](../blob/main/plans/products/11-costing-and-stock-improvements.md), the "while in there" of §3.5. It exploded the BOM **without negating**, so "Add 10" of a finished good raised every component's stock as well — the assembly and the parts it consumes both went up. The now-dead subpart probe that fed it is removed from both surfaces too.

**The field and the explosion behind it stay.** The inventory bridge sets the same flag on `sale` movements (`data-connectors/inventory-bridge-pass.ts:200`) and **that use is correct** — selling a finished good does consume its components, and a sale is negative, so the explosion negates. It was only ever the arbitrary direction of an `adjust` that made the cascade wrong. There is a note in the file saying so, because "unused field" is the wrong conclusion to reach here.

## Note

`packages/lib/package.json` is in the diff. It is codegen (`generate-exports.ts`, CI runs it with `--check`) — this is the first consumer of `@auxx/lib/receiving/client`.

## Verification

```
node scripts/ci/typecheck-ratchet.js --package web   # 0, baseline 0
node scripts/ci/typecheck-ratchet.js --package lib   # 29, baseline 29 — no new
cd apps/web && pnpm exec vitest run src/components/manufacturing src/components/drawers
                                                     # 59 passed (7 files)
pnpm -F @auxx/lib check:exports                      # up to date (265 entries)
biome check                                          # clean
```

Not verified in a browser. The receiving card from #1920 should start showing non-zero received quantities once a receipt is keyed against a PO line — but this popover receives against a **part**, not a PO line, so it does not set `purchaseOrderLineId`. Receiving against a PO (`receivePurchaseOrder`, which does set it) is the next piece, and it is what will make that card move.
