### PR TITLE
feat(purchasing): receive a whole PO in one dialog, pay bills from the order

### DIFF
--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
@@ -1,31 +1,45 @@
 // apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
 'use client'
 
-// `purchase_order:bills` — the vendor bills charged against this PO
-// (plans/purchasing/01-build-plan.md §4.4).
+// `purchase_order:bills` — the vendor bills charged against this PO, and paying
+// them without leaving it (plans/purchasing/01-build-plan.md §4.4, P12).
 //
 // `purchase_order_bills` is `showInPanel: false` in `purchase-order-fields.ts`, so
-// without this card the inverse edge has NO surface at all: a bill knows its PO and
+// without this card the inverse edge has NO surface at all: a bill knew its PO and
 // the PO could not show its bills. That asymmetry is what the card exists to close.
 //
-// The work-order Billing card's shape — summary strip, then one row per related
-// record — with `RelatedRecordRow` for the rows themselves, the same primitive the
-// order's work-orders block uses. A bill is `hasDetailPage: false`, so its row opens
-// as a drill panel rather than navigating.
+// Rows are built here rather than reused from `RelatedRecordRow` because each one
+// carries its own **Pay** action. The question "is this order settled" is asked at
+// the order, not bill by bill — a PO with three bills against it is exactly where a
+// person notices one is still outstanding, and making them open each bill to act on
+// that is the same friction that makes a control stop being run.
+//
+// 🛑 Paying here writes the bill's six P12 fields and does not post. See
+// `mark-bill-paid-dialog.tsx` — `post-entry.ts` is phase 7.
 
 import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import { getDefinitionId, type RecordId } from '@auxx/types/resource'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { formatCurrency } from '@auxx/utils/currency'
+import { Banknote } from 'lucide-react'
+import { useState } from 'react'
 import {
   EmptyRow,
-  RelatedRecordRow,
   RowSkeleton,
   TREE_SECONDARY_NOTRUNCATE,
 } from '~/components/drawers/cards/related-record-row'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { useOpenRecord } from '~/components/records/record-drill-panels'
+import { useRecord, useResource } from '~/components/resources'
+import { useSystemField } from '~/components/resources/hooks/use-field'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { useFieldValueStore } from '~/components/resources/store/field-value-store'
+import { RecordIcon } from '~/components/resources/ui/record-icon'
 import { useSettings } from '~/hooks/use-settings'
 import { numberValue, PurchasingSummaryStrip, unwrapValue } from '../purchasing-summary-strip'
+import { MarkBillPaidDialog } from '../vendor-bill/mark-bill-paid-dialog'
 
 const PO_ATTRS = [
   'purchase_order_bills',
@@ -33,10 +47,24 @@ const PO_ATTRS = [
   'purchase_order_currency',
 ] as const
 
-const BILL_ATTRS = ['vendor_bill_total'] as const
+const BILL_ATTRS = [
+  'vendor_bill_total',
+  'vendor_bill_amount_paid',
+  'vendor_bill_status',
+  'vendor_bill_number',
+] as const
+
+/** The bill a Pay click opened the dialog for. */
+interface PayTarget {
+  recordId: RecordId
+  total: number
+  amountPaid: number
+}
 
 export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
   const { getSetting } = useSettings({})
+  const [payTarget, setPayTarget] = useState<PayTarget | null>(null)
+  const invalidateResource = useFieldValueStore((state) => state.invalidateResource)
   const { values, isLoading } = useSystemValues(recordId, [...PO_ATTRS], { autoFetch: true })
 
   const billRecordIds = extractRelationshipRecordIds(values.purchase_order_bills)
@@ -60,6 +88,15 @@ export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
   // Signed, not clamped: over-billing against a PO is exactly the condition the
   // three-way match exists to surface, so a negative unbilled figure is the news.
   const unbilled = orderTotal - billed
+  const owed = billRecordIds.reduce((sum, billRecordId) => {
+    const bill = valuesById[billRecordId]
+    const status = unwrapValue(bill?.vendor_bill_status)
+    if (status === 'void') return sum
+    return (
+      sum +
+      Math.max(0, numberValue(bill?.vendor_bill_total) - numberValue(bill?.vendor_bill_amount_paid))
+    )
+  }, 0)
 
   if (isLoading || (billRecordIds.length > 0 && billsLoading)) return <RowSkeleton />
 
@@ -71,9 +108,11 @@ export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
           { label: 'Order total', value: formatCurrency(orderTotal, { currencyCode }) },
           { label: 'Billed', value: formatCurrency(billed, { currencyCode }) },
           {
-            label: 'Unbilled',
-            value: formatCurrency(unbilled, { currencyCode }),
-            tone: unbilled === 0 ? 'muted' : 'default',
+            // Once a bill exists, "what is still owed" is the live question and
+            // "what is unbilled" is the paperwork one. Show whichever is the news.
+            label: billRecordIds.length > 0 ? 'Still owed' : 'Unbilled',
+            value: formatCurrency(billRecordIds.length > 0 ? owed : unbilled, { currencyCode }),
+            tone: (billRecordIds.length > 0 ? owed : unbilled) === 0 ? 'muted' : 'default',
           },
         ]}
       />
@@ -81,13 +120,101 @@ export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
         <EmptyRow label='No bills yet' />
       ) : (
         billRecordIds.map((billRecordId) => (
-          <RelatedRecordRow
+          <BillRow
             key={billRecordId}
-            recordId={billRecordId}
-            statusAttr='vendor_bill_status'
+            billRecordId={billRecordId}
+            values={valuesById[billRecordId]}
+            currencyCode={currencyCode}
+            onPay={setPayTarget}
           />
         ))
       )}
+
+      {payTarget && (
+        <MarkBillPaidDialog
+          open
+          onOpenChange={(next) => !next && setPayTarget(null)}
+          billRecordId={payTarget.recordId}
+          total={payTarget.total}
+          amountPaid={payTarget.amountPaid}
+          currencyCode={currencyCode}
+          onSaved={() => {
+            // The row reads the bill's own values, so drop that record's cache and
+            // let `autoFetch` re-pull the new balance and status.
+            invalidateResource(payTarget.recordId)
+            setPayTarget(null)
+          }}
+        />
+      )}
     </div>
+  )
+}
+
+function BillRow({
+  billRecordId,
+  values,
+  currencyCode,
+  onPay,
+}: {
+  billRecordId: RecordId
+  values: Record<string, unknown> | undefined
+  currencyCode: string
+  onPay: (target: PayTarget) => void
+}) {
+  const openRecord = useOpenRecord()
+  const { record } = useRecord({ recordId: billRecordId, enabled: true })
+  const { resource } = useResource(getDefinitionId(billRecordId))
+  const statusField = useSystemField('vendor_bill_status', getDefinitionId(billRecordId))
+
+  const total = numberValue(values?.vendor_bill_total)
+  const amountPaid = numberValue(values?.vendor_bill_amount_paid)
+  const balance = total - amountPaid
+  const status = unwrapValue(values?.vendor_bill_status) as string | undefined
+  const statusOption = statusField?.options?.options?.find((option) => option.value === status)
+
+  // A void bill owes nothing by definition, and a zero-total bill has no amount to
+  // settle — offering Pay on either is offering an action against a number nobody
+  // has entered yet.
+  const canPay = status !== 'void' && total > 0 && balance > 0
+
+  return (
+    <TreeRow
+      rowClassName='hover:bg-primary-100'
+      onDrill={() => openRecord?.(billRecordId)}
+      icon={
+        <RecordIcon
+          avatarUrl={record?.avatarUrl}
+          iconId={resource?.icon || 'receipt'}
+          color={resource?.color || 'gray'}
+          size='xs'
+        />
+      }
+      title={<span className='truncate text-sm'>{record?.displayName ?? 'Untitled bill'}</span>}
+      secondary={
+        <span className='flex items-center gap-1.5 text-xs'>
+          <span className='tabular-nums'>{formatCurrency(total, { currencyCode })}</span>
+          {balance > 0 && balance !== total && (
+            <span className='text-muted-foreground tabular-nums'>
+              {formatCurrency(balance, { currencyCode })} left
+            </span>
+          )}
+          {status && (
+            <Badge variant={(statusOption?.color as Variant) ?? 'secondary'} size='xs'>
+              {statusOption?.label ?? status}
+            </Badge>
+          )}
+        </span>
+      }
+      actions={
+        canPay ? (
+          <TreeRowButton
+            persistent
+            tooltipText='Mark paid'
+            onClick={() => onPay({ recordId: billRecordId, total, amountPaid })}>
+            <Banknote />
+          </TreeRowButton>
+        ) : undefined
+      }
+    />
   )
 }

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
@@ -11,22 +11,26 @@
 // over `stock_movement` (`purchasing-hooks.ts`), so it is already maintained; nothing
 // had ever read it back.
 //
-// 🛑 The received figures are only ever as good as the receipts behind them, and
-// nothing writes a receipt yet — plans/purchasing/02-handoff.md §4.1's
-// `ReceiveStockPopover` is unbuilt. Until it lands every line here reads 0 received.
-// That is honest (nothing HAS been received through the app) rather than broken.
+// The card's header action is the **Receive** dialog — the whole order in one pass,
+// everything prefilled as if it all arrived. That is deliberately the door here
+// rather than the part-first popover: a part-first receipt sets no
+// `purchaseOrderLineId`, so it moves quantity on hand without ever moving the
+// numbers this card renders.
 
 import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import type { RecordId } from '@auxx/types/resource'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
-import { Package } from 'lucide-react'
+import { Package, PackagePlus } from 'lucide-react'
+import { useState } from 'react'
 import {
   EmptyRow,
   RowSkeleton,
   TREE_SECONDARY_NOTRUNCATE,
 } from '~/components/drawers/cards/related-record-row'
+import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { useOpenRecord } from '~/components/records/record-drill-panels'
 import { useRecord } from '~/components/resources'
@@ -38,6 +42,7 @@ import {
   PurchasingSummaryStrip,
   unwrapValue,
 } from '../purchasing-summary-strip'
+import { ReceivePurchaseOrderDialog } from './receive-purchase-order-dialog'
 
 const PO_ATTRS = ['purchase_order_lines'] as const
 
@@ -60,6 +65,7 @@ interface ReceivingLine {
 }
 
 export function PurchaseOrderReceivingCard({ recordId }: DrawerTabProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
   const { values, isLoading: linesLoading } = useSystemValues(recordId, [...PO_ATTRS], {
     autoFetch: true,
   })
@@ -98,6 +104,19 @@ export function PurchaseOrderReceivingCard({ recordId }: DrawerTabProps) {
 
   return (
     <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+      {outstanding > 0 && (
+        <DrawerCardActions>
+          <Button variant='ghost' size='xs' onClick={() => setDialogOpen(true)}>
+            <PackagePlus />
+            Receive
+          </Button>
+        </DrawerCardActions>
+      )}
+      <ReceivePurchaseOrderDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        purchaseOrderRecordId={recordId}
+      />
       <PurchasingSummaryStrip
         className='pb-2'
         cells={[

--- a/apps/web/src/components/purchasing/purchase-order/receive-po-lines.test.ts
+++ b/apps/web/src/components/purchasing/purchase-order/receive-po-lines.test.ts
@@ -1,0 +1,209 @@
+// apps/web/src/components/purchasing/purchase-order/receive-po-lines.test.ts
+
+import { describe, expect, it } from 'vitest'
+import {
+  activeLines,
+  allocatedUnitCosts,
+  buildReceivePoInput,
+  outstandingQuantity,
+  prefillDraft,
+  type ReceiptHeader,
+  type ReceivablePoLine,
+  receiptSubtotal,
+} from './receive-po-lines'
+
+function line(overrides: Partial<ReceivablePoLine> = {}): ReceivablePoLine {
+  return {
+    purchaseOrderLineId: 'pol_1',
+    partId: 'part_1',
+    description: null,
+    quantityOrdered: 10,
+    quantityReceived: 0,
+    expectedUnitPrice: 4400,
+    ...overrides,
+  }
+}
+
+const NO_HEADER: ReceiptHeader = {
+  shipping: 0,
+  tax: 0,
+  discount: 0,
+  taxRecoverable: false,
+  basis: 'value',
+}
+
+const META = { occurredAt: '2026-08-26T00:00:00.000Z', reference: '', reason: '' }
+
+describe('outstandingQuantity', () => {
+  it('is ordered less received', () => {
+    expect(outstandingQuantity(line({ quantityOrdered: 10, quantityReceived: 3 }))).toBe(7)
+  })
+
+  it('floors at zero for an over-received line', () => {
+    // A negative prefill would submit as a receipt the server rightly refuses,
+    // and over-receipt is a real state the match is meant to surface, not a bug.
+    expect(outstandingQuantity(line({ quantityOrdered: 10, quantityReceived: 12 }))).toBe(0)
+  })
+})
+
+describe('prefillDraft', () => {
+  it('assumes the whole order arrived, at the agreed price', () => {
+    const draft = prefillDraft([line()])
+    expect(draft.pol_1).toEqual({ quantity: 10, unitPrice: 4400 })
+  })
+
+  it('prefills the OUTSTANDING amount, not the ordered amount', () => {
+    // Reopening the dialog on a partly-received PO must offer the remainder.
+    const draft = prefillDraft([line({ quantityReceived: 4 })])
+    expect(draft.pol_1?.quantity).toBe(6)
+  })
+
+  it('prefills zero on a fully received order rather than a second delivery', () => {
+    const draft = prefillDraft([line({ quantityReceived: 10 })])
+    expect(draft.pol_1?.quantity).toBe(0)
+  })
+})
+
+describe('activeLines', () => {
+  const lines = [line({ purchaseOrderLineId: 'a' }), line({ purchaseOrderLineId: 'b' })]
+
+  it('excludes a line receiving nothing', () => {
+    const draft = { a: { quantity: 10, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
+    expect(activeLines(lines, draft).map((row) => row.line.purchaseOrderLineId)).toEqual(['a'])
+  })
+
+  it('excludes a negative or non-finite quantity', () => {
+    const draft = {
+      a: { quantity: -1, unitPrice: 4400 },
+      b: { quantity: Number.NaN, unitPrice: 4400 },
+    }
+    expect(activeLines(lines, draft)).toEqual([])
+  })
+})
+
+describe('allocatedUnitCosts', () => {
+  const lines = [
+    line({ purchaseOrderLineId: 'a', partId: 'p1' }),
+    line({ purchaseOrderLineId: 'b', partId: 'p2' }),
+  ]
+
+  it('is the bare price when the header states no amounts', () => {
+    const draft = { a: { quantity: 10, unitPrice: 4400 }, b: { quantity: 10, unitPrice: 4400 } }
+    expect(allocatedUnitCosts(lines, draft, NO_HEADER)).toEqual({ a: 4400, b: 4400 })
+  })
+
+  it('🛑 spreads freight over ONLY the lines being received', () => {
+    // The load-bearing rule. $100 freight across one received line is $100 on
+    // that line; including the untouched line would halve it and understate the
+    // cost of the goods that actually arrived.
+    const draft = { a: { quantity: 10, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
+    const costs = allocatedUnitCosts(lines, draft, { ...NO_HEADER, shipping: 10000 })
+    expect(costs.a).toBe(4400 + 1000)
+    expect(costs.b).toBeUndefined()
+
+    const bothReceived = {
+      a: { quantity: 10, unitPrice: 4400 },
+      b: { quantity: 10, unitPrice: 4400 },
+    }
+    const shared = allocatedUnitCosts(lines, bothReceived, { ...NO_HEADER, shipping: 10000 })
+    expect(shared.a).toBe(4400 + 500)
+    expect(shared.b).toBe(4400 + 500)
+  })
+
+  it('has nothing to allocate when no line is being received', () => {
+    const draft = { a: { quantity: 0, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
+    expect(allocatedUnitCosts(lines, draft, { ...NO_HEADER, shipping: 10000 })).toEqual({})
+  })
+})
+
+describe('receiptSubtotal', () => {
+  it('counts only the lines being received', () => {
+    const lines = [line({ purchaseOrderLineId: 'a' }), line({ purchaseOrderLineId: 'b' })]
+    const draft = { a: { quantity: 2, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
+    expect(receiptSubtotal(lines, draft)).toBe(8800)
+  })
+})
+
+describe('buildReceivePoInput', () => {
+  it('sends one entry per received line, and nothing for the rest', () => {
+    const lines = [line({ purchaseOrderLineId: 'a' }), line({ purchaseOrderLineId: 'b' })]
+    const draft = { a: { quantity: 10, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
+    const input = buildReceivePoInput(lines, draft, NO_HEADER, META)
+    expect(input?.lines).toHaveLength(1)
+    expect(input?.lines[0]).toMatchObject({
+      partId: 'part_1',
+      purchaseOrderLineId: 'a',
+      quantity: 10,
+      unitPrice: 4400,
+    })
+  })
+
+  it('is null when nothing is being received, so the button stays disabled', () => {
+    const input = buildReceivePoInput(
+      [line()],
+      { pol_1: { quantity: 0, unitPrice: 4400 } },
+      NO_HEADER,
+      META
+    )
+    expect(input).toBeNull()
+  })
+
+  it('carries the header amounts and the basis through unchanged', () => {
+    const header: ReceiptHeader = {
+      shipping: 10000,
+      tax: 500,
+      discount: 250,
+      taxRecoverable: true,
+      basis: 'weight',
+    }
+    const input = buildReceivePoInput([line()], prefillDraft([line()]), header, META)
+    expect(input).toMatchObject({
+      shipping: 10000,
+      tax: 500,
+      discount: 250,
+      taxRecoverable: true,
+      basis: 'weight',
+    })
+  })
+
+  it('omits vendorPartId and weight when the line carries neither', () => {
+    const input = buildReceivePoInput([line()], prefillDraft([line()]), NO_HEADER, META)
+    expect(input?.lines[0]).not.toHaveProperty('vendorPartId')
+    expect(input?.lines[0]).not.toHaveProperty('weight')
+  })
+
+  it('passes vendorPartId and weight when it does', () => {
+    const withTerms = line({ vendorPartId: 'vp_1', weight: 12.5 })
+    const input = buildReceivePoInput([withTerms], prefillDraft([withTerms]), NO_HEADER, META)
+    expect(input?.lines[0]).toMatchObject({ vendorPartId: 'vp_1', weight: 12.5 })
+  })
+
+  it('allows an over-receipt rather than clamping it to the outstanding amount', () => {
+    // The vendor shipped 12 against an order for 10. Capping it here would hide
+    // the discrepancy at the one moment somebody can see the packing slip.
+    const input = buildReceivePoInput(
+      [line()],
+      { pol_1: { quantity: 12, unitPrice: 4400 } },
+      NO_HEADER,
+      META
+    )
+    expect(input?.lines[0]?.quantity).toBe(12)
+  })
+
+  it('drops a blank reference and reason', () => {
+    const input = buildReceivePoInput([line()], prefillDraft([line()]), NO_HEADER, {
+      ...META,
+      reference: '  ',
+    })
+    expect(input).not.toHaveProperty('reference')
+    expect(input).not.toHaveProperty('reason')
+  })
+
+  it('sends the accounting date it was given', () => {
+    const input = buildReceivePoInput([line()], prefillDraft([line()]), NO_HEADER, {
+      ...META,
+      occurredAt: '2026-01-04T09:30:00.000Z',
+    })
+    expect(input?.occurredAt.toISOString()).toBe('2026-01-04T09:30:00.000Z')
+  })
+})

--- a/apps/web/src/components/purchasing/purchase-order/receive-po-lines.ts
+++ b/apps/web/src/components/purchasing/purchase-order/receive-po-lines.ts
@@ -1,0 +1,197 @@
+// apps/web/src/components/purchasing/purchase-order/receive-po-lines.ts
+
+// The receive-against-a-PO dialog's arithmetic, as a pure function of what is on
+// screen (plans/purchasing/01-build-plan.md §3.1 / §4.3).
+//
+// Separate from the dialog for the same reason `receipt-input.ts` is separate from
+// the popover: the rules below are invisible in a rendered table and each one is a
+// silently-wrong number if it is missed.
+//
+//   1. A line receiving ZERO must not take part in the allocation. Freight is
+//      spread across what was on the truck; including a line that did not arrive
+//      dilutes every other line's share and understates the cost of the goods that
+//      did. It is also not merely display — `receivePurchaseOrder` allocates over
+//      exactly the lines it is sent.
+//   2. The default is "everything on the order arrived", so a quantity prefills to
+//      the OUTSTANDING amount, not the ordered amount. Re-receiving a fully
+//      received PO must default to zero, not to a second full delivery.
+//   3. Over-receipt is allowed and not clamped. A vendor shipping more than was
+//      ordered is a real event the three-way match exists to surface; silently
+//      capping it would hide the discrepancy at the one moment it is knowable.
+
+import { allocateLandedCost } from '@auxx/lib/purchasing/client'
+import { roundMinorUnits } from '@auxx/lib/receiving/client'
+
+/** One purchase-order line as the dialog knows it. */
+export interface ReceivablePoLine {
+  purchaseOrderLineId: string
+  partId: string
+  /** For the row's label when the part has not hydrated yet. */
+  description: string | null
+  quantityOrdered: number
+  quantityReceived: number
+  /** The agreed buy price, minor units — the prefill for the price input. */
+  expectedUnitPrice: number
+  vendorPartId?: string
+  /** Shipping weight for the whole line. Read only by the `weight` basis. */
+  weight?: number
+}
+
+/** What the person keyed into one row. */
+export interface ReceiptDraftLine {
+  quantity: number
+  unitPrice: number
+}
+
+/** The PO header's stated amounts — the freight-allocation inputs. */
+export interface ReceiptHeader {
+  shipping: number
+  tax: number
+  discount: number
+  taxRecoverable: boolean
+  basis: 'value' | 'quantity' | 'weight'
+}
+
+/** The `purchasing.receivePurchaseOrder` input, as this dialog builds it. */
+export interface ReceivePoInput {
+  lines: {
+    partId: string
+    purchaseOrderLineId: string
+    quantity: number
+    unitPrice: number
+    vendorPartId?: string
+    weight?: number
+  }[]
+  shipping?: number
+  tax?: number
+  discount?: number
+  taxRecoverable?: boolean
+  basis?: 'value' | 'quantity' | 'weight'
+  occurredAt: Date
+  reference?: string
+  reason?: string
+}
+
+/**
+ * What is still owed on a line — rule 2 above.
+ *
+ * Floored at zero: an over-received line has nothing outstanding, and a negative
+ * prefill would submit as a receipt the server rightly refuses.
+ */
+export function outstandingQuantity(line: ReceivablePoLine): number {
+  return Math.max(0, line.quantityOrdered - line.quantityReceived)
+}
+
+/** Prefill the whole table: outstanding quantity at the agreed price. */
+export function prefillDraft(lines: ReceivablePoLine[]): Record<string, ReceiptDraftLine> {
+  const draft: Record<string, ReceiptDraftLine> = {}
+  for (const line of lines) {
+    draft[line.purchaseOrderLineId] = {
+      quantity: outstandingQuantity(line),
+      unitPrice: line.expectedUnitPrice,
+    }
+  }
+  return draft
+}
+
+/** The lines actually being received — rule 1. */
+export function activeLines(
+  lines: ReceivablePoLine[],
+  draft: Record<string, ReceiptDraftLine>
+): { line: ReceivablePoLine; draft: ReceiptDraftLine }[] {
+  return lines
+    .map((line) => ({ line, draft: draft[line.purchaseOrderLineId] }))
+    .filter(
+      (row): row is { line: ReceivablePoLine; draft: ReceiptDraftLine } =>
+        !!row.draft && Number.isFinite(row.draft.quantity) && row.draft.quantity > 0
+    )
+}
+
+/**
+ * Allocated landed unit cost per active line, keyed by PO line id.
+ *
+ * The same `allocateLandedCost` the server runs, over the same set of lines, so
+ * the column the person reads before committing is the number that gets frozen.
+ */
+export function allocatedUnitCosts(
+  lines: ReceivablePoLine[],
+  draft: Record<string, ReceiptDraftLine>,
+  header: ReceiptHeader
+): Record<string, number> {
+  const active = activeLines(lines, draft)
+  if (active.length === 0) return {}
+
+  const unitCosts = allocateLandedCost(
+    active.map(({ line, draft: row }) => ({
+      lineTotal: roundMinorUnits(row.unitPrice * row.quantity),
+      quantity: row.quantity,
+      weight: line.weight,
+    })),
+    {
+      shipping: header.shipping,
+      tax: header.tax,
+      discount: header.discount,
+      taxRecoverable: header.taxRecoverable,
+    },
+    header.basis
+  )
+
+  const byLine: Record<string, number> = {}
+  active.forEach(({ line }, index) => {
+    const cost = unitCosts[index]
+    if (cost != null) byLine[line.purchaseOrderLineId] = cost
+  })
+  return byLine
+}
+
+/** Goods value before the header amounts are spread onto it. */
+export function receiptSubtotal(
+  lines: ReceivablePoLine[],
+  draft: Record<string, ReceiptDraftLine>
+): number {
+  return activeLines(lines, draft).reduce(
+    (sum, { draft: row }) => sum + roundMinorUnits(row.unitPrice * row.quantity),
+    0
+  )
+}
+
+/**
+ * Build the mutation input, or `null` when nothing is being received.
+ *
+ * Header amounts are sent whole. They are the PO's stated totals and the server
+ * spreads them over exactly the lines it is given — so receiving half an order
+ * capitalises the full freight onto that half, which is correct: the truck came
+ * once. Receiving the rest later with the freight already consumed is a real
+ * question this does not answer; see the note in the dialog.
+ */
+export function buildReceivePoInput(
+  lines: ReceivablePoLine[],
+  draft: Record<string, ReceiptDraftLine>,
+  header: ReceiptHeader,
+  meta: { occurredAt: string; reference: string; reason: string }
+): ReceivePoInput | null {
+  const active = activeLines(lines, draft)
+  if (active.length === 0) return null
+
+  const reference = meta.reference.trim()
+  const reason = meta.reason.trim()
+
+  return {
+    lines: active.map(({ line, draft: row }) => ({
+      partId: line.partId,
+      purchaseOrderLineId: line.purchaseOrderLineId,
+      quantity: row.quantity,
+      unitPrice: roundMinorUnits(row.unitPrice),
+      ...(line.vendorPartId ? { vendorPartId: line.vendorPartId } : {}),
+      ...(line.weight != null ? { weight: line.weight } : {}),
+    })),
+    shipping: header.shipping,
+    tax: header.tax,
+    discount: header.discount,
+    taxRecoverable: header.taxRecoverable,
+    basis: header.basis,
+    occurredAt: new Date(meta.occurredAt),
+    ...(reference ? { reference } : {}),
+    ...(reason ? { reason } : {}),
+  }
+}

--- a/apps/web/src/components/purchasing/purchase-order/receive-purchase-order-dialog.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/receive-purchase-order-dialog.tsx
@@ -1,0 +1,388 @@
+// apps/web/src/components/purchasing/purchase-order/receive-purchase-order-dialog.tsx
+'use client'
+
+// Receive a whole purchase order in one pass (plans/purchasing/01-build-plan.md
+// §3.1 / §4.3) — the door that makes receiving usable.
+//
+// 🛑 This is the PRIMARY receiving flow, not a convenience over the part-first
+// popover. Receiving a delivery through `ReceiveStockPopover` means opening each
+// part, clicking Receive and keying the same six fields per line, and the result
+// is still wrong in a way nothing shows: a part-first receipt sets no
+// `purchaseOrderLineId`, so `purchase_order_line_quantity_received` never moves
+// and the three-way match has no receipt leg. The popover is the no-PO door — a
+// one-off, a freight-only delivery — and it should stay small.
+//
+// Everything here is prefilled on the assumption the whole order arrived: each
+// row's quantity is what is OUTSTANDING and each price is what was agreed. The
+// common case is therefore Receive, with no typing at all.
+
+import { FieldType } from '@auxx/database/enums'
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/types/resource'
+import { getInstanceId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
+import { useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useRecord } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { useFieldValueStore } from '~/components/resources/store/field-value-store'
+import { BaseType } from '~/components/workflow/types'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import { formatQuantity, numberValue, unwrapValue } from '../purchasing-summary-strip'
+import {
+  allocatedUnitCosts,
+  buildReceivePoInput,
+  outstandingQuantity,
+  prefillDraft,
+  type ReceiptDraftLine,
+  type ReceiptHeader,
+  type ReceivablePoLine,
+  receiptSubtotal,
+} from './receive-po-lines'
+
+const PO_ATTRS = [
+  'purchase_order_lines',
+  'purchase_order_shipping_total',
+  'purchase_order_tax_total',
+  'purchase_order_discount_value',
+  'purchase_order_tax_recoverable',
+  'purchase_order_allocation_basis',
+  'purchase_order_currency',
+] as const
+
+const LINE_ATTRS = [
+  'purchase_order_line_part',
+  'purchase_order_line_description',
+  'purchase_order_line_quantity_ordered',
+  'purchase_order_line_quantity_received',
+  'purchase_order_line_expected_unit_price',
+  'purchase_order_line_vendor_part',
+  'purchase_order_line_weight',
+] as const
+
+interface ReceivePurchaseOrderDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  purchaseOrderRecordId: RecordId
+  onReceived?: () => void
+}
+
+export function ReceivePurchaseOrderDialog({
+  open,
+  onOpenChange,
+  purchaseOrderRecordId,
+  onReceived,
+}: ReceivePurchaseOrderDialogProps) {
+  const { getSetting } = useSettings({})
+  const invalidateResource = useFieldValueStore((state) => state.invalidateResource)
+
+  const { values, isLoading: poLoading } = useSystemValues(purchaseOrderRecordId, [...PO_ATTRS], {
+    autoFetch: true,
+  })
+  const lineRecordIds = extractRelationshipRecordIds(values.purchase_order_lines)
+  const { valuesById, isLoading: linesLoading } = useSystemValuesForRecords(
+    lineRecordIds,
+    LINE_ATTRS,
+    { autoFetch: true, enabled: open && lineRecordIds.length > 0 }
+  )
+
+  const currencyValue = unwrapValue(values.purchase_order_currency)
+  const currencyCode =
+    (typeof currencyValue === 'string' && currencyValue) ||
+    (getSetting('organization.currency') as string | null) ||
+    'USD'
+
+  const lines: ReceivablePoLine[] = useMemo(
+    () =>
+      lineRecordIds.map((lineRecordId) => {
+        const line = valuesById[lineRecordId] ?? ({} as Record<string, unknown>)
+        const partRecordId = extractRelationshipRecordIds(line.purchase_order_line_part)[0]
+        const vendorPartRecordId = extractRelationshipRecordIds(
+          line.purchase_order_line_vendor_part
+        )[0]
+        const description = unwrapValue(line.purchase_order_line_description)
+        const weight = numberValue(line.purchase_order_line_weight)
+        return {
+          purchaseOrderLineId: getInstanceId(lineRecordId),
+          partId: partRecordId ? getInstanceId(partRecordId) : '',
+          description: typeof description === 'string' && description ? description : null,
+          quantityOrdered: numberValue(line.purchase_order_line_quantity_ordered),
+          quantityReceived: numberValue(line.purchase_order_line_quantity_received),
+          expectedUnitPrice: numberValue(line.purchase_order_line_expected_unit_price),
+          ...(vendorPartRecordId ? { vendorPartId: getInstanceId(vendorPartRecordId) } : {}),
+          ...(weight > 0 ? { weight } : {}),
+        }
+      }),
+    [lineRecordIds, valuesById]
+  )
+
+  const basisValue = unwrapValue(values.purchase_order_allocation_basis)
+  const header: ReceiptHeader = {
+    shipping: numberValue(values.purchase_order_shipping_total),
+    tax: numberValue(values.purchase_order_tax_total),
+    discount: numberValue(values.purchase_order_discount_value),
+    taxRecoverable: unwrapValue(values.purchase_order_tax_recoverable) === true,
+    basis:
+      basisValue === 'quantity' || basisValue === 'weight'
+        ? basisValue
+        : ('value' as ReceiptHeader['basis']),
+  }
+
+  const [draft, setDraft] = useState<Record<string, ReceiptDraftLine>>({})
+  const [occurredAt, setOccurredAt] = useState(() => new Date().toISOString())
+  const [reference, setReference] = useState('')
+  const [reason, setReason] = useState('')
+  // The prefill must re-run when the lines finish loading, but must NOT clobber a
+  // quantity somebody has already corrected — so it is keyed on the line set and
+  // only fires while the draft is still empty for those ids.
+  const linesKey = lines.map((line) => line.purchaseOrderLineId).join(',')
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: linesKey stands in for `lines`; re-prefill only when the set changes or the dialog reopens.
+  useEffect(() => {
+    if (!open) return
+    setDraft(prefillDraft(lines))
+    setOccurredAt(new Date().toISOString())
+    setReference('')
+    setReason('')
+  }, [open, linesKey])
+
+  const unitCosts = allocatedUnitCosts(lines, draft, header)
+  const subtotal = receiptSubtotal(lines, draft)
+  const payload = buildReceivePoInput(lines, draft, header, { occurredAt, reference, reason })
+
+  const receive = api.purchasing.receivePurchaseOrder.useMutation({
+    onError: (error) => toastError({ title: 'Failed to receive', description: error.message }),
+  })
+
+  const handleSubmit = async () => {
+    if (!payload) return
+    try {
+      await receive.mutateAsync(payload)
+      // The roll-up is a post-commit re-SUM on another connection, so the line's
+      // cached `quantityReceived` is stale the instant this resolves. Drop it and
+      // let `autoFetch` re-pull rather than guessing the new value.
+      invalidateResource(purchaseOrderRecordId)
+      for (const lineRecordId of lineRecordIds) invalidateResource(lineRecordId)
+      onReceived?.()
+      onOpenChange(false)
+    } catch {
+      // onError above already surfaced the toast.
+    }
+  }
+
+  const isLoading = poLoading || (lineRecordIds.length > 0 && linesLoading)
+  const receivingCount = payload?.lines.length ?? 0
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent position='tc' className='max-w-3xl'>
+        <DialogHeader>
+          <DialogTitle>Receive purchase order</DialogTitle>
+          <DialogDescription>
+            Everything is prefilled as if the whole order arrived. Change what did not.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className='space-y-2'>
+            <Skeleton className='h-8 w-full' />
+            <Skeleton className='h-8 w-full' />
+            <Skeleton className='h-8 w-full' />
+          </div>
+        ) : lines.length === 0 ? (
+          <p className='py-6 text-center text-muted-foreground text-sm'>
+            This purchase order has no lines.
+          </p>
+        ) : (
+          <div className='max-h-[45vh] overflow-auto rounded-md border'>
+            <table className='w-full text-sm'>
+              <thead className='sticky top-0 bg-primary-50 text-muted-foreground text-xs dark:bg-background'>
+                <tr>
+                  <th className='px-3 py-2 text-left font-normal'>Part</th>
+                  <th className='px-2 py-2 text-right font-normal'>Outstanding</th>
+                  <th className='w-24 px-2 py-2 text-right font-normal'>Receive</th>
+                  <th className='w-32 px-2 py-2 text-right font-normal'>Unit price</th>
+                  <th className='px-3 py-2 text-right font-normal'>Landed</th>
+                </tr>
+              </thead>
+              <tbody className='divide-y'>
+                {lines.map((line, index) => (
+                  <ReceiveLineRow
+                    key={line.purchaseOrderLineId}
+                    line={line}
+                    // Positional: `lines` is built by mapping `lineRecordIds`, so
+                    // the two stay index-aligned. `indexOf` would be O(n²) and
+                    // would silently pick the wrong row if two lines ever compared
+                    // equal.
+                    lineRecordId={lineRecordIds[index]}
+                    draft={draft[line.purchaseOrderLineId]}
+                    landedUnitCost={unitCosts[line.purchaseOrderLineId]}
+                    currencyCode={currencyCode}
+                    disabled={receive.isPending}
+                    onChange={(next) =>
+                      setDraft((current) => ({ ...current, [line.purchaseOrderLineId]: next }))
+                    }
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* The header amounts are the freight-allocation inputs (§4.3) — shown so the
+            landed column above is explicable rather than mysterious. */}
+        {(header.shipping > 0 || header.tax > 0 || header.discount > 0) && (
+          <div className='flex flex-wrap items-center gap-x-4 gap-y-1 px-1 text-muted-foreground text-xs tabular-nums'>
+            <span>Goods {formatCurrency(subtotal, { currencyCode })}</span>
+            {header.shipping > 0 && (
+              <span>+ {formatCurrency(header.shipping, { currencyCode })} freight</span>
+            )}
+            {header.tax > 0 && (
+              <span>
+                + {formatCurrency(header.tax, { currencyCode })} tax
+                {header.taxRecoverable ? ' (recoverable)' : ''}
+              </span>
+            )}
+            {header.discount > 0 && (
+              <span>− {formatCurrency(header.discount, { currencyCode })} discount</span>
+            )}
+            <span>spread by {header.basis}</span>
+          </div>
+        )}
+
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='receive-po-form'
+          defaultLabelWidth={110}
+          className='p-0'>
+          <FieldPanelRow
+            title='Received on'
+            type={BaseType.DATE}
+            showIcon
+            isRequired
+            description='The accounting date, which is not when it was keyed'>
+            <FieldInputAdapter
+              fieldType={FieldType.DATETIME}
+              value={occurredAt}
+              onChange={(val) => setOccurredAt(val as string)}
+              disabled={receive.isPending}
+            />
+          </FieldPanelRow>
+          <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={reference}
+              onChange={(val) => setReference((val as string) ?? '')}
+              placeholder='e.g. Packing slip 88213'
+              disabled={receive.isPending}
+            />
+          </FieldPanelRow>
+          <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={reason}
+              onChange={(val) => setReason((val as string) ?? '')}
+              placeholder='e.g. Partial delivery'
+              disabled={receive.isPending}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={receive.isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant='outline'
+            size='sm'
+            loading={receive.isPending}
+            loadingText='Receiving...'
+            disabled={!payload}
+            data-dialog-submit>
+            {receivingCount > 0
+              ? `Receive ${receivingCount} line${receivingCount === 1 ? '' : 's'}`
+              : 'Receive'}
+            <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ReceiveLineRow({
+  line,
+  lineRecordId,
+  draft,
+  landedUnitCost,
+  currencyCode,
+  disabled,
+  onChange,
+}: {
+  line: ReceivablePoLine
+  lineRecordId: RecordId | undefined
+  draft: ReceiptDraftLine | undefined
+  landedUnitCost: number | undefined
+  currencyCode: string
+  disabled: boolean
+  onChange: (next: ReceiptDraftLine) => void
+}) {
+  const { record } = useRecord({ recordId: lineRecordId!, enabled: !!lineRecordId })
+  const quantity = draft?.quantity ?? 0
+  const unitPrice = draft?.unitPrice ?? line.expectedUnitPrice
+  const outstanding = outstandingQuantity(line)
+
+  return (
+    <tr className={quantity > 0 ? undefined : 'opacity-50'}>
+      <td className='px-3 py-1.5'>
+        <span className='truncate'>{record?.displayName ?? line.description ?? 'Line'}</span>
+      </td>
+      <td className='px-2 py-1.5 text-right text-muted-foreground tabular-nums'>
+        {formatQuantity(outstanding)}
+        <span className='ml-1 text-xs'>of {formatQuantity(line.quantityOrdered)}</span>
+      </td>
+      <td className='px-2 py-1.5'>
+        <FieldInputAdapter
+          fieldType={FieldType.NUMBER}
+          value={quantity}
+          onChange={(val) => onChange({ quantity: (val as number) ?? 0, unitPrice })}
+          disabled={disabled}
+        />
+      </td>
+      <td className='px-2 py-1.5'>
+        <FieldInputAdapter
+          fieldType={FieldType.CURRENCY}
+          fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+          value={unitPrice}
+          onChange={(val) => onChange({ quantity, unitPrice: (val as number) ?? 0 })}
+          disabled={disabled}
+        />
+      </td>
+      <td className='px-3 py-1.5 text-right tabular-nums'>
+        {landedUnitCost != null ? formatCurrency(landedUnitCost, { currencyCode }) : '—'}
+      </td>
+    </tr>
+  )
+}

--- a/apps/web/src/components/purchasing/vendor-bill/mark-bill-paid-dialog.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/mark-bill-paid-dialog.tsx
@@ -92,10 +92,15 @@ export function MarkBillPaidDialog({
       // P12: `manual` is a HUMAN confirming the payment. Never `rule` — that value
       // is reserved for a presumption, and the two must stay distinguishable.
       vendor_bill_paid_source: 'manual',
-      // Only a fully settled bill becomes `paid`. A partial payment leaves the
-      // status where the match put it, because a bill that still owes money is
-      // not paid and a status that says otherwise is how it goes quiet.
-      ...(nextAmountPaid >= total && total > 0 ? { vendor_bill_status: 'paid' } : {}),
+      // A fully settled bill becomes `paid`; a partial one becomes
+      // `partially_paid`. Neither may be left reading `matched`: a bill with
+      // $400 of $1,000 settled would otherwise be indistinguishable from one
+      // nobody has paid a cent of, with the remaining balance visible only on
+      // this card. Same discipline as `paidSource` — never let a partial fact
+      // render as a complete one.
+      ...(total > 0
+        ? { vendor_bill_status: nextAmountPaid >= total ? 'paid' : 'partially_paid' }
+        : {}),
     })
     if (!ok) {
       toastError({

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1132,6 +1132,12 @@
       "import": "./dist/purchasing/index.mjs",
       "default": "./src/purchasing/index.ts"
     },
+    "./purchasing/client": {
+      "types": "./src/purchasing/client.ts",
+      "source": "./src/purchasing/client.ts",
+      "import": "./dist/purchasing/client.mjs",
+      "default": "./src/purchasing/client.ts"
+    },
     "./quick-actions": {
       "types": "./src/quick-actions/index.ts",
       "source": "./src/quick-actions/index.ts",

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -612,6 +612,7 @@ export const VendorBillStatus = {
   MATCHED: 'matched',
   EXCEPTION: 'exception',
   POSTED: 'posted',
+  PARTIALLY_PAID: 'partially_paid',
   PAID: 'paid',
   VOID: 'void',
 
@@ -620,6 +621,13 @@ export const VendorBillStatus = {
     { value: 'matched', label: 'Matched', color: 'green' },
     { value: 'exception', label: 'Exception', color: 'red' },
     { value: 'posted', label: 'Posted', color: 'blue' },
+    // 🛑 `partially_paid` is not cosmetic. Without it a bill with $400 of $1,000
+    // settled reads `matched` — indistinguishable from one nobody has paid a cent
+    // of, with the remaining balance visible only on the payment card. Same
+    // discipline as `paidSource`: never let a partial fact render as a complete
+    // one. It sits before `paid` because that is the lifecycle order, and `amber`
+    // because it is a state that still needs something to happen.
+    { value: 'partially_paid', label: 'Partially Paid', color: 'amber' },
     { value: 'paid', label: 'Paid', color: 'forest' },
     { value: 'void', label: 'Void', color: 'orange' },
   ] satisfies FieldOptionItem[],

--- a/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts
@@ -238,7 +238,14 @@ function fieldRows(
       id: `field-${entityDefinitionId}-${f.systemAttribute}`,
       systemAttribute: f.systemAttribute!,
       entityDefinitionId,
-      options: linked ? { relationship: { inverseResourceFieldId: 'already:linked' } } : {},
+      options: {
+        ...(linked ? { relationship: { inverseResourceFieldId: 'already:linked' } } : {}),
+        // Carry the registry's SELECT options through. Without them every
+        // already-migrated select field looks stale to the option-refresh step,
+        // and the idempotency case reports a rewrite that a real database would
+        // not perform.
+        ...(f.options?.options ? { options: f.options.options } : {}),
+      },
     }))
 }
 
@@ -293,22 +300,32 @@ const ALL_DEF_REGISTRIES: Record<string, Record<string, ResourceField>> = {
 
 function migratedOrgDb(
   writes: string[],
-  opts: { linked?: boolean; omit?: readonly string[] } = {}
+  opts: { linked?: boolean; omit?: readonly string[]; staleVendorBillStatus?: boolean } = {}
 ) {
   const omit = new Set(opts.omit ?? [])
   const defs = Object.entries(ALL_DEF_REGISTRIES).filter(([entityType]) => !omit.has(entityType))
+  const customFields = defs.flatMap(([entityType, registry]) =>
+    fieldRows(`def-${entityType}`, registry, opts.linked ?? true)
+  )
+
+  // An org migrated BEFORE a value was added to the enum: the row still carries
+  // the option list it was created with.
+  if (opts.staleVendorBillStatus) {
+    const statusRow = customFields.find((row) => row.systemAttribute === 'vendor_bill_status')
+    if (!statusRow) throw new Error('fixture: vendor_bill_status row is missing')
+    statusRow.options = {
+      ...statusRow.options,
+      options: VendorBillStatus.values.filter((v) => v.value !== 'partially_paid'),
+    }
+  }
+
   return stubDb(
     new Map<unknown, unknown[]>([
       [
         schema.EntityDefinition,
         defs.map(([entityType]) => ({ id: `def-${entityType}`, entityType })),
       ],
-      [
-        schema.CustomField,
-        defs.flatMap(([entityType, registry]) =>
-          fieldRows(`def-${entityType}`, registry, opts.linked ?? true)
-        ),
-      ],
+      [schema.CustomField, customFields],
       // A view already exists for every context, so both view helpers no-op.
       [schema.TableView, [{ id: 'view-1' }]],
     ]),
@@ -659,16 +676,43 @@ describe('vendor_bill field shapes the plan is explicit about', () => {
     expect(VENDOR_BILL_FIELDS.internalNumber?.capabilities?.updatable).toBe(false)
   })
 
-  it('status is the six-value bill lifecycle, wired to the enum list', () => {
+  it('status is the seven-value bill lifecycle, wired to the enum list', () => {
     expect(VendorBillStatus.values.map((v) => v.value)).toEqual([
       'draft',
       'matched',
       'exception',
       'posted',
+      'partially_paid',
       'paid',
       'void',
     ])
     expect(VENDOR_BILL_FIELDS.status?.options).toEqual({ options: VendorBillStatus.values })
+  })
+
+  // 🛑 The reason `partially_paid` exists, stated as an assertion rather than a
+  // comment: a bill with some of its balance settled must not be able to render
+  // as one nobody has touched. Without this value, $400 of $1,000 reads
+  // `matched` — identical to $0 of $1,000 — and the only place the difference
+  // shows is the payment card.
+  it('distinguishes a partly settled bill from an untouched one', () => {
+    expect(VendorBillStatus.PARTIALLY_PAID).toBe('partially_paid')
+    const values = VendorBillStatus.values.map((v) => v.value)
+    expect(values.indexOf('partially_paid')).toBeLessThan(values.indexOf('paid'))
+  })
+
+  // `ensureCustomFields` SKIPS an existing field and never touches its options,
+  // so an org that already ran 108 keeps whatever option list the field was
+  // CREATED with. Adding a value to the enum is therefore only half the change —
+  // the migration has to re-materialize the row, or the code believes in seven
+  // values while the database holds six.
+  it('re-materializes an existing status field rather than only seeding new orgs', () => {
+    const here = fileURLToPath(new URL('.', import.meta.url))
+    const source = readFileSync(join(here, '108-purchasing.ts'), 'utf8')
+    expect(source).toContain('refreshVendorBillStatusOptions')
+    // And the refresh must count toward "did something", or a run that only
+    // rewrote options would report alreadyUpToDate and skip the cache flush that
+    // makes the new value visible to every read path.
+    expect(source).toContain('!statusRefreshed')
   })
 
   // §5.3, and it is the same discipline as the zero-cost receipt guard: never
@@ -1217,5 +1261,24 @@ describe('migration 108 idempotency', () => {
 
     expect(result.alreadyUpToDate).toBe(true)
     expect(writes.filter((w) => w.startsWith('insert'))).toEqual([])
+  })
+
+  // 🛑 The half of the option-refresh that actually matters. The test above
+  // proves it stays QUIET when the stored options already match; this proves it
+  // FIRES when they do not. Without this, adding a value to `VendorBillStatus`
+  // would reach a fresh org and silently skip every org that already ran 108 —
+  // `ensureCustomFields` returns an incumbent field untouched — leaving the code
+  // believing in seven values while the database holds six.
+  it('rewrites a stale vendor_bill_status option list, and says it did', async () => {
+    const writes: string[] = []
+    const db = migratedOrgDb(writes, { staleVendorBillStatus: true })
+
+    const result = await migration108Purchasing.up(db, 'org-4')
+
+    expect(writes).toContain('update CustomField')
+    // Not `alreadyUpToDate`: a run that only rewrote options must still report
+    // work, or it skips the org-cache flush that makes the new value visible to
+    // every read path.
+    expect(result.alreadyUpToDate).toBe(false)
   })
 })

--- a/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
@@ -1,9 +1,12 @@
 // packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
 
 import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
 import { getOrgCache } from '../../../cache'
 import type { FieldOptions } from '../../../custom-fields'
+import { VendorBillStatus } from '../../../resources/registry/enum-values'
 import type { ResourceField } from '../../../resources/registry/field-types'
 import { COMPANY_FIELDS } from '../../../resources/registry/resources/company-fields'
 import { GL_ACCOUNT_FIELDS } from '../../../resources/registry/resources/gl-account-fields'
@@ -381,8 +384,31 @@ export const migration108Purchasing: EntityMigration = {
       )
     }
 
+    // ── Re-materialize `vendor_bill_status`'s options ──────────────────
+    //
+    // 🛑 `ensureCustomFields` SKIPS a field that already exists — it returns the
+    // incumbent row and never touches its `options`. So adding a value to
+    // `VendorBillStatus` reaches a fresh org (which seeds from the registry) and
+    // silently does nothing for every org that already ran this migration. The
+    // field would keep the six values it was created with while the code, the
+    // types and the UI all believed in seven.
+    //
+    // `partially_paid` is what forced this. The whole array is rewritten rather
+    // than the new value appended, so the option ORDER matches the registry
+    // everywhere — an appended value would sit last on migrated orgs and
+    // mid-list on fresh ones, which is the kind of difference nobody notices
+    // until two screenshots disagree. Safe because `status` is
+    // `configurable: false`: there are no user-added options to preserve.
+    const statusRefreshed = await refreshVendorBillStatusOptions(
+      db,
+      entityDefIds.get('vendor_bill')
+    )
+
     const alreadyUpToDate =
-      state.entityDefsCreated === 0 && state.fieldsCreated === 0 && state.relationshipsLinked === 0
+      state.entityDefsCreated === 0 &&
+      state.fieldsCreated === 0 &&
+      state.relationshipsLinked === 0 &&
+      !statusRefreshed
 
     // New definitions and fields are invisible to every read path until the
     // per-org caches that serve them are dropped. `runEntityMigrationsForOrg`
@@ -400,4 +426,72 @@ export const migration108Purchasing: EntityMigration = {
 
     return { ...state, alreadyUpToDate }
   },
+}
+
+/**
+ * Bring an existing `vendor_bill_status` field's SINGLE_SELECT options back in
+ * line with {@link VendorBillStatus}.
+ *
+ * Reads the row rather than trusting `loadExistingState`'s snapshot or the
+ * `allFieldMaps` entry: the snapshot is taken before this migration writes
+ * anything, and the map carries the INCUMBENT options for a field that already
+ * existed. Both would be correct here by accident; a fresh read is correct by
+ * construction.
+ *
+ * Idempotent by comparison — returns `false` when the stored values already
+ * match, so a second run reports `alreadyUpToDate` rather than dirtying the row
+ * and re-invalidating the org cache on every pass.
+ *
+ * @returns whether the row was actually rewritten.
+ */
+async function refreshVendorBillStatusOptions(
+  db: Database,
+  vendorBillDefId: string | undefined
+): Promise<boolean> {
+  if (!vendorBillDefId) return false
+
+  const statusField = VENDOR_BILL_FIELDS.status
+  if (!statusField?.systemAttribute) return false
+
+  // Scoped in SQL to the def, then picked by attribute in JS. One query either
+  // way — a `vendor_bill` carries ~28 fields — and it keeps the pick explicit
+  // rather than resting on `[0]` of a filtered result.
+  const rows = await db
+    .select({
+      id: schema.CustomField.id,
+      systemAttribute: schema.CustomField.systemAttribute,
+      options: schema.CustomField.options,
+    })
+    .from(schema.CustomField)
+    .where(eq(schema.CustomField.entityDefinitionId, vendorBillDefId))
+
+  const row = rows.find((candidate) => candidate.systemAttribute === statusField.systemAttribute)
+  if (!row) return false
+
+  const wanted = VendorBillStatus.values
+  const current = ((row.options as FieldOptions | null)?.options ?? []) as {
+    value?: string
+    label?: string
+    color?: string
+  }[]
+
+  const sameValues =
+    current.length === wanted.length &&
+    current.every((option, index) => option.value === wanted[index]?.value)
+  if (sameValues) return false
+
+  await db
+    .update(schema.CustomField)
+    .set({
+      options: { ...(row.options as FieldOptions), options: wanted },
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.CustomField.id, row.id))
+
+  logger.info('Refreshed vendor_bill_status options', {
+    vendorBillDefId,
+    from: current.length,
+    to: wanted.length,
+  })
+  return true
 }


### PR DESCRIPTION
Three things, all reachable from the purchase order.

## 1. Receiving part-by-part was unusable, and quietly wrong

Open the part → click Receive → key six fields → repeat per line. And the result was still wrong in a way nothing showed: a part-first receipt sets no `purchaseOrderLineId`, so `purchase_order_line_quantity_received` never moved, the Receiving card read `0 / 10` forever, and the three-way match had no receipt leg to compare a bill against.

**`ReceivePurchaseOrderDialog` is now the primary door.** Every row is prefilled as if the whole order arrived — quantity is what is **outstanding**, price is what was **agreed** — so the common case is a single click with no typing. A Landed column shows what each line will actually be frozen at, computed with the same `allocateLandedCost` the server runs, so the number on screen is the number stored.

It hangs off the Receiving card's header, which is where the outstanding figure already is. `ReceiveStockPopover` stays as the no-PO door (a one-off, a freight-only delivery) and should stay small.

## ⚠️ `receive-po-lines.ts` — three rules that are invisible in a rendered table

Each one is a silently wrong number if missed, which is why the arithmetic is a pure module with 19 tests rather than expressions inside the dialog:

- **A line receiving ZERO must not take part in the allocation.** Freight is spread across what was on the truck; including a line that did not arrive dilutes every other line's share and understates the cost of the goods that did. This is not only display — `receivePurchaseOrder` allocates over exactly the lines it is sent.
- **The prefill is the OUTSTANDING quantity, not the ordered quantity.** Reopening a partly-received PO offers the remainder; a fully received one offers nothing, rather than a second full delivery.
- **Over-receipt is allowed and never clamped.** A vendor shipping 12 against an order for 10 is exactly what the three-way match exists to surface. Capping it here would hide the discrepancy at the one moment somebody is holding the packing slip.

## 2. `partially_paid`

Joins `VendorBillStatus`, before `paid`. Without it a bill with $400 of $1,000 settled reads `matched` — indistinguishable from one nobody has paid a cent of, with the remaining balance visible only on the payment card. Same discipline as `paidSource`: never let a partial fact render as a complete one.

**⚠️ Adding the enum value is only half the change.** `ensureCustomFields` **skips a field that already exists** and never touches its `options` — it returns the incumbent row untouched. So the new value would reach a fresh org (which seeds from the registry) and silently do nothing for every org that already ran 108, leaving the code, the types and the UI believing in seven values while the database held six.

Migration 108 now re-materializes the row, and **counts that as work** so a run that only rewrote options still fires the org-cache flush that makes the value visible to every read path. The whole array is rewritten rather than the value appended, so option order matches the registry everywhere — safe because `status` is `configurable: false`.

Two tests, because one alone proves nothing: it stays **quiet** when the stored options already match (the idempotency case), and it **rewrites** when they do not.

The fixture also had to get more faithful — `fieldRows` gave every field `{relationship: …}` and no select options, so every already-migrated select field looked stale.

**Applied to the local DB as asked**, then verified by reading it back rather than trusting the log:

```
SELECT jsonb_array_length(options->'options'), count(*) …
→ option_count 7 | field_rows 28 | has_partially_paid 28
→ ['draft','matched','exception','posted','partially_paid','paid','void']
```

All 28 orgs, correct order.

## 3. Paying a bill from the PO

"Is this order settled" is a question asked at the order, not bill by bill — a PO with three bills against it is exactly where somebody notices one is outstanding, and making them open each bill to act on it is the friction that makes a control stop being run.

Each row on the bills card now carries its own **Pay** action, and the strip leads with **Still owed** once a bill exists (the live question) rather than **Unbilled** (the paperwork one). Rows are built in the card rather than reused from `RelatedRecordRow` because of that per-row action.

🛑 Paying still writes the bill's six P12 fields and **does not post** — `post-entry.ts` is phase 7. Unchanged from #1920.

## Verification

```
node scripts/ci/typecheck-ratchet.js --package web    # 0, baseline 0
node scripts/ci/typecheck-ratchet.js --package lib    # 29, baseline 29 — no new
cd apps/web     && pnpm exec vitest run src/components          # 2208 passed (218 files)
cd packages/lib && pnpm exec vitest run src/resources/registry src/seed/entity-migrations \
                                        src/purchasing src/receiving   # 456 passed (26 files)
pnpm -F @auxx/lib check:exports                       # 266 entries
biome check                                           # clean
```

`packages/lib/package.json` is codegen — this is the first consumer of `@auxx/lib/purchasing/client`.

Not driven in a browser. The dialog's own arithmetic is unit-tested, but the round trip (receive → roll-up re-SUM → Receiving card repaints) has not been watched end to end.
