### PR TITLE
fix(records): write optimistic list membership to both caches, not just the store

### DIFF
--- a/apps/web/src/components/drawers/cards/part-pricing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-pricing-card.tsx
@@ -65,7 +65,7 @@ const CATALOG_SETTINGS_HREF = '/app/dispatch/settings/products'
  * item fields via the batched `useSystemValuesForRecords`, `part_kind` via
  * `useSystemValues`. Writes: `useSaveSystemValues` on the ITEM's record for
  * active/price, `useCreateRecord` (the unified record-create, seeding this
- * card's own list via `listKey`) for the inline create.
+ * card's own list via `appendCreated`) for the inline create.
  *
  * Registered as the `part:pricing` overview card (`drawer-config.ts` +
  * `drawer-tab-registry.tsx`) — `TabCardSection` owns the "Pricing" section
@@ -100,7 +100,7 @@ export function PartPricingCard({ recordId }: DrawerTabProps) {
     records,
     isLoading: isLoadingList,
     isLoadingRecords,
-    listKey,
+    appendCreated,
   } = useRecordList({
     entityDefinitionId: catalogDefId ?? '',
     filters: itemFilters,
@@ -155,12 +155,13 @@ export function PartPricingCard({ recordId }: DrawerTabProps) {
 
   // Inline create for the finished-good offer state — the unified record
   // creation path (same `api.record.create` seam the catalog settings' phantom
-  // draft uses). `listKey` seeds the new item straight into this card's own
-  // list, so the derived toggle flips to checked with zero refetch.
+  // draft uses). `appendCreated` seeds the new item straight into this card's
+  // own list — both caches it is served from — so the derived toggle flips to
+  // checked with zero refetch, and stays checked across a remount.
   const { record: partRecord } = useRecord({ recordId })
   const { create, isPending: isCreating } = useCreateRecord({
     entityDefinitionId: catalogDefId ?? '',
-    listKey,
+    appendCreated,
   })
   const [armed, setArmed] = useState(false)
   const [draftPriceCents, setDraftPriceCents] = useState<number | null>(null)

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -337,7 +337,8 @@ export function LineBuilder({
     isFetchingNextPage,
     fetchNextPage,
     refresh,
-    listKey,
+    appendCreated,
+    removeFromList,
   } = useRecordList<RecordMeta>({
     entityDefinitionId: entityDefinitionId ?? '',
     filters,
@@ -559,12 +560,16 @@ export function LineBuilder({
   const deleteLine = useCallback(
     (lineId: string) => {
       if (!entityDefinitionId) return
-      // Optimistic: drop the record from the store (and every cached list —
+      // Optimistic: drop the record from BOTH caches this list is served from —
       // `lineRecordIds` shrinks, so the row AND the totals footer repaint in
-      // this frame), then fire the delete without awaiting. No `refresh()` on
-      // success — the store is already correct, and the refetch is what made
+      // this frame — then fire the delete without awaiting. No `refresh()` on
+      // success — the caches are already correct, and the refetch is what made
       // deletes feel slow.
-      useRecordStore.getState().removeRecord(entityDefinitionId, lineId)
+      //
+      // 🛑 `removeFromList`, not a bare `removeRecord`: the acting tab is
+      // excluded from its own `record:deleted` frame, so nothing else evicts the
+      // id from the tRPC pages and the row would come back on the next remount.
+      removeFromList(lineId)
       const restoreOnError = (error: unknown) => {
         // `removeRecord` marked the id not-found, which `requestRecord` would
         // skip — clear that marker first so the refetched list can resurrect
@@ -603,6 +608,7 @@ export function LineBuilder({
       deleteMutateAsync,
       deleteInvoiceLineMutateAsync,
       recomputeMutate,
+      removeFromList,
       refresh,
     ]
   )
@@ -720,10 +726,10 @@ export function LineBuilder({
         seedCreatedRecord({
           entityDefinitionId,
           recordId: result.recordId,
-          listKey,
           instance: result.instance,
           values: linePatchToFieldValues(snapshot, schema),
         })
+        appendCreated(result.instance.id)
 
         // Diff whatever landed locally while the create was in flight, and
         // flush just the changed fields against the now-real record.
@@ -753,7 +759,7 @@ export function LineBuilder({
       createMutateAsync,
       saveMultipleAsync,
       seedCreatedRecord,
-      listKey,
+      appendCreated,
     ]
   )
 
@@ -813,10 +819,10 @@ export function LineBuilder({
           seedCreatedRecord({
             entityDefinitionId,
             recordId: result.recordId,
-            listKey,
             instance: result.instance,
             values: linePatchToFieldValues(snapshot, schema),
           })
+          appendCreated(result.instance.id)
           const latest = draftsRef.current.find((d) => d.draftId === draft.draftId) ?? snapshot
           const changed = linePatchToFieldValues(diffLineValues(snapshot, latest), schema)
           if (changed.length > 0) flushes.push(saveMultipleAsync(result.recordId, changed))
@@ -872,7 +878,7 @@ export function LineBuilder({
       saveMultipleAsync,
       seedCreatedRecord,
       reorderMutate,
-      listKey,
+      appendCreated,
     ]
   )
 

--- a/apps/web/src/components/resources/hooks/use-create-record.ts
+++ b/apps/web/src/components/resources/hooks/use-create-record.ts
@@ -31,9 +31,15 @@ export interface CreatedRecordResult {
 
 export interface UseCreateRecordOptions {
   entityDefinitionId: string
-  /** record-store list to append the new id into (from `useRecordList().listKey`).
-   *  Omit for catalog/standalone surfaces (seeds row data only, no list membership). */
-  listKey?: string
+  /**
+   * Add each created row to a list's caches — pass `useRecordList().appendCreated`.
+   * Omit for catalog/standalone surfaces (seeds row data only, no list membership).
+   *
+   * ⚠️ It must be the hook's own `appendCreated`, not a bare store write: a list
+   * is served from EITHER the record store or the tRPC query pages, and writing
+   * only one makes the row revert on the next remount.
+   */
+  appendCreated?: (instanceId: string) => void
   /** Surface-specific extras the hook can't know about: navigation, relationship
    *  hydration, standalone-query (`['calendar-record-ids']`) invalidation, or the
    *  `record.listAll` catalog push. Fires once per created row, after it's seeded. */
@@ -57,7 +63,7 @@ export function useCreateRecord(opts: UseCreateRecordOptions): {
   createMany: (inputs: CreateRecordInput[]) => Promise<CreatedRecordResult[]>
   isPending: boolean
 } {
-  const { entityDefinitionId, listKey, onCreated } = opts
+  const { entityDefinitionId, appendCreated, onCreated } = opts
   const { seedCreatedRecord } = useSeedCreatedRecord()
   const createMutation = api.record.create.useMutation()
   const createManyMutation = api.record.createMany.useMutation()
@@ -96,10 +102,10 @@ export function useCreateRecord(opts: UseCreateRecordOptions): {
         seedCreatedRecord({
           entityDefinitionId,
           recordId: result.recordId,
-          listKey,
           instance: result.instance,
           values: toSeedValues(input.values),
         })
+        appendCreated?.(result.instance.id)
         const created: CreatedRecordResult = {
           recordId: result.recordId,
           instanceId: result.instance.id,
@@ -115,7 +121,7 @@ export function useCreateRecord(opts: UseCreateRecordOptions): {
         throw error
       }
     },
-    [entityDefinitionId, listKey, onCreated, seedCreatedRecord, toSeedValues, createMutation]
+    [entityDefinitionId, appendCreated, onCreated, seedCreatedRecord, toSeedValues, createMutation]
   )
 
   const createMany = useCallback(
@@ -131,10 +137,10 @@ export function useCreateRecord(opts: UseCreateRecordOptions): {
           seedCreatedRecord({
             entityDefinitionId,
             recordId: result.recordId,
-            listKey,
             instance: result.instance,
             values: toSeedValues(inputs[i]?.values ?? {}),
           })
+          appendCreated?.(result.instance.id)
           const created: CreatedRecordResult = {
             recordId: result.recordId,
             instanceId: result.instance.id,
@@ -151,7 +157,14 @@ export function useCreateRecord(opts: UseCreateRecordOptions): {
         throw error
       }
     },
-    [entityDefinitionId, listKey, onCreated, seedCreatedRecord, toSeedValues, createManyMutation]
+    [
+      entityDefinitionId,
+      appendCreated,
+      onCreated,
+      seedCreatedRecord,
+      toSeedValues,
+      createManyMutation,
+    ]
   )
 
   return {

--- a/apps/web/src/components/resources/hooks/use-record-list.test.ts
+++ b/apps/web/src/components/resources/hooks/use-record-list.test.ts
@@ -1,0 +1,273 @@
+// apps/web/src/components/resources/hooks/use-record-list.test.ts
+//
+// `useRecordList` is served from TWO caches — the zustand record-store list and
+// the tRPC infinite-query pages — and either one can be the display source. The
+// bug these tests pin (plans/entity/record-list-cache-divergence-plan.md) is
+// what happens when they disagree:
+//
+//   - the store cache DISABLES the query, so a stale store list is served
+//     instead of refetching;
+//   - the sync effect used to copy the query's (frequently cached, minutes-old)
+//     pages back over the store list stamped `Date.now()`, which both clobbered
+//     optimistic appends and re-armed the 5-minute TTL — so a list that went
+//     empty stayed empty until a full page reload;
+//   - `record.create` / `record.delete` exclude the acting socket from their
+//     realtime frames, so the acting tab's optimistic write is its ONLY update,
+//     and writing just one cache reverts on the next remount.
+//
+// Nothing here talks to a server: the query hook is faked so each test can set
+// `data` / `dataUpdatedAt` exactly.
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Pages the faked `useInfiniteQuery` hands back (undefined = never fetched). */
+  data: undefined as { pages: Array<Record<string, unknown>>; pageParams: unknown[] } | undefined,
+  /** When those pages were fetched, per React Query. */
+  dataUpdatedAt: 0,
+  /** Every `enabled` the hook asked for, in order. */
+  enabledSeen: [] as boolean[],
+  /** Stand-in for the tRPC infinite-query cache `setInfiniteData` mutates. */
+  cache: undefined as { pages: Array<Record<string, unknown>>; pageParams: unknown[] } | undefined,
+  refetch: vi.fn(),
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    record: {
+      listFiltered: {
+        useInfiniteQuery: (_input: unknown, opts: { enabled: boolean }) => {
+          h.enabledSeen.push(opts.enabled)
+          return {
+            data: h.data,
+            dataUpdatedAt: h.dataUpdatedAt,
+            isLoading: false,
+            isFetchingNextPage: false,
+            hasNextPage: false,
+            fetchNextPage: vi.fn(),
+            refetch: h.refetch,
+          }
+        },
+      },
+    },
+    useUtils: () => ({
+      record: {
+        listFiltered: {
+          setInfiniteData: (_input: unknown, updater: (prev: typeof h.cache) => typeof h.cache) => {
+            h.cache = updater(h.cache)
+          },
+        },
+      },
+    }),
+  },
+}))
+
+import { createListKey, EMPTY_FILTERS, EMPTY_SORTING, useRecordStore } from '../store/record-store'
+import { useRecordList } from './use-record-list'
+
+const DEF = 'def_purchase_order_line'
+const NOW = 1_700_000_000_000
+
+/** The key `useRecordList` derives for the default (no filters/sort) call. */
+const LIST_KEY = createListKey(DEF, EMPTY_FILTERS, EMPTY_SORTING, undefined)
+
+/** One `record.listFiltered` page. `total` rides on the first page only. */
+function page(ids: string[], opts: { total?: number; hasMore?: boolean } = {}) {
+  return { ids, total: opts.total, hasMore: opts.hasMore ?? false }
+}
+
+function pages(...list: Array<ReturnType<typeof page>>) {
+  return { pages: list, pageParams: [undefined] }
+}
+
+function render() {
+  return renderHook(() => useRecordList({ entityDefinitionId: DEF }))
+}
+
+beforeEach(() => {
+  h.data = undefined
+  h.dataUpdatedAt = 0
+  h.enabledSeen = []
+  h.cache = undefined
+  h.refetch = vi.fn()
+  useRecordStore.setState({
+    records: {},
+    lists: {},
+    pendingFetchIds: new Set(),
+    loadingIds: new Set(),
+    notFoundIds: new Set(),
+    attemptedIds: new Set(),
+  })
+  vi.useRealTimers()
+})
+
+describe('store cache vs query', () => {
+  it('serves a warm store cache without enabling the query', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    useRecordStore.getState().setList(LIST_KEY, {
+      ids: ['a', 'b'],
+      total: 2,
+      fetchedAt: NOW,
+      nextCursor: null,
+    })
+
+    const { result } = render()
+
+    expect(result.current.recordIds).toEqual(['a', 'b'])
+    expect(result.current.isCached).toBe(true)
+    expect(h.enabledSeen.at(-1)).toBe(false)
+  })
+
+  it('re-enables the query once the store cache passes its TTL', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    useRecordStore.getState().setList(LIST_KEY, {
+      ids: ['a'],
+      total: 1,
+      fetchedAt: NOW,
+      nextCursor: null,
+    })
+    const warm = render()
+    expect(warm.result.current.isCached).toBe(true)
+    expect(h.enabledSeen.at(-1)).toBe(false)
+
+    // 6 minutes later the cache is stale — the query must come back on.
+    vi.setSystemTime(NOW + 6 * 60_000)
+    h.enabledSeen = []
+    render()
+    expect(h.enabledSeen.at(-1)).toBe(true)
+  })
+})
+
+describe('sync effect', () => {
+  it('stamps fetchedAt with the query timestamp, not Date.now()', () => {
+    vi.useFakeTimers()
+    // Pages fetched 6 minutes ago, served from React Query's cache on this mount.
+    vi.setSystemTime(NOW + 6 * 60_000)
+    h.data = pages(page(['a'], { total: 1 }))
+    h.dataUpdatedAt = NOW
+
+    render()
+
+    const cached = useRecordStore.getState().lists[LIST_KEY]
+    expect(cached?.fetchedAt).toBe(NOW)
+    // …and because that timestamp is honest, the entry is already stale, so the
+    // next mount refetches instead of serving it for another five minutes.
+    expect(cached && NOW + 6 * 60_000 - cached.fetchedAt).toBeGreaterThan(5 * 60_000)
+  })
+
+  it('does not overwrite a store list built from the same snapshot', () => {
+    vi.setSystemTime(NOW)
+    // The store list already reflects `dataUpdatedAt` AND has taken an
+    // optimistic append since — equal timestamps are the normal case, which is
+    // why the guard is `>=` and not `>`.
+    useRecordStore.getState().setList(LIST_KEY, {
+      ids: ['a', 'optimistic'],
+      total: 2,
+      fetchedAt: NOW,
+      nextCursor: null,
+    })
+    h.data = pages(page(['a'], { total: 1 }))
+    h.dataUpdatedAt = NOW
+
+    render()
+
+    expect(useRecordStore.getState().lists[LIST_KEY]?.ids).toEqual(['a', 'optimistic'])
+  })
+
+  it('does write when the query snapshot is newer than the store list', () => {
+    useRecordStore.getState().setList(LIST_KEY, {
+      ids: ['a'],
+      total: 1,
+      fetchedAt: NOW,
+      nextCursor: null,
+    })
+    h.data = pages(page(['a', 'b'], { total: 2 }))
+    h.dataUpdatedAt = NOW + 1_000
+
+    render()
+
+    expect(useRecordStore.getState().lists[LIST_KEY]?.ids).toEqual(['a', 'b'])
+  })
+})
+
+describe('appendCreated', () => {
+  it('writes both caches', () => {
+    h.data = pages(page(['a'], { total: 1 }))
+    h.dataUpdatedAt = NOW
+    h.cache = pages(page(['a'], { total: 1 }))
+
+    const { result } = render()
+    act(() => result.current.appendCreated('b'))
+
+    expect(useRecordStore.getState().lists[LIST_KEY]?.ids).toEqual(['a', 'b'])
+    expect(h.cache?.pages[0]?.ids).toEqual(['a', 'b'])
+    expect(h.cache?.pages[0]?.total).toBe(2)
+  })
+
+  it('never fabricates a page when the list has never been fetched', () => {
+    // 🛑 Inventing a page here would read as loaded data and suppress the first
+    // real fetch forever — strictly worse than the bug this fixes.
+    h.cache = undefined
+    const { result } = render()
+    act(() => result.current.appendCreated('b'))
+    expect(h.cache).toBeUndefined()
+  })
+
+  it('is idempotent', () => {
+    h.data = pages(page(['a'], { total: 1 }))
+    h.dataUpdatedAt = NOW
+    h.cache = pages(page(['a'], { total: 1 }))
+
+    const { result } = render()
+    act(() => {
+      result.current.appendCreated('b')
+      result.current.appendCreated('b')
+    })
+
+    expect(h.cache?.pages[0]?.ids).toEqual(['a', 'b'])
+    expect(h.cache?.pages[0]?.total).toBe(2)
+  })
+
+  it('bumps total on the first page only', () => {
+    h.cache = pages(page(['a'], { total: 3, hasMore: true }), page(['b']))
+    const { result } = render()
+    act(() => result.current.appendCreated('c'))
+
+    expect(h.cache?.pages[0]?.total).toBe(4)
+    expect(h.cache?.pages[1]?.total).toBeUndefined()
+    // Appends land on the LAST page, where the next fetch would have put them.
+    expect(h.cache?.pages[1]?.ids).toEqual(['b', 'c'])
+  })
+
+  it('preserves pageParams', () => {
+    h.cache = { pages: [page(['a'], { total: 1 })], pageParams: [undefined, { offset: 100 }] }
+    const { result } = render()
+    act(() => result.current.appendCreated('b'))
+    expect(h.cache?.pageParams).toEqual([undefined, { offset: 100 }])
+  })
+})
+
+describe('removeFromList', () => {
+  it('drops the id from both caches and decrements total once', () => {
+    h.data = pages(page(['a', 'b'], { total: 2 }))
+    h.dataUpdatedAt = NOW
+    h.cache = pages(page(['a', 'b'], { total: 2 }))
+
+    const { result } = render()
+    act(() => result.current.removeFromList('b'))
+
+    expect(useRecordStore.getState().lists[LIST_KEY]?.ids).toEqual(['a'])
+    expect(h.cache?.pages[0]?.ids).toEqual(['a'])
+    expect(h.cache?.pages[0]?.total).toBe(1)
+  })
+
+  it('no-ops on an id the list does not hold', () => {
+    h.cache = pages(page(['a'], { total: 1 }))
+    const { result } = render()
+    act(() => result.current.removeFromList('zzz'))
+    expect(h.cache?.pages[0]?.total).toBe(1)
+  })
+})

--- a/apps/web/src/components/resources/hooks/use-record-list.ts
+++ b/apps/web/src/components/resources/hooks/use-record-list.ts
@@ -72,6 +72,19 @@ interface UseRecordListResult<T = RecordMeta> {
   fetchNextPage: () => void
   /** Force refresh */
   refresh: () => void
+  /**
+   * Add a freshly-created record to this list's caches — BOTH the record store
+   * and the tRPC query pages. The acting tab is excluded from its own
+   * `record:created` realtime frame, so this is its only path; writing just one
+   * cache makes the row revert on the next remount.
+   */
+  appendCreated: (instanceId: string) => void
+  /**
+   * Optimistically drop a record from this list's caches. Does the full store
+   * eviction (`removeRecord`) as well — do not pair it with a separate
+   * `removeRecord` call.
+   */
+  removeFromList: (instanceId: string) => void
   /** Data came from cache */
   isCached: boolean
 }
@@ -139,6 +152,7 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
 
   const {
     data,
+    dataUpdatedAt,
     isLoading,
     isFetchingNextPage,
     hasNextPage,
@@ -158,9 +172,28 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
   // Get request action for batch fetching
   const requestRecord = useRecordStore((s) => s.requestRecord)
 
-  // ─── SYNC TO STORE + QUEUE RECORD FETCHES ────────────────────────
+  const utils = api.useUtils()
+
+  // ─── SYNC QUERY PAGES TO STORE ───────────────────────────────────
+  //
+  // 🛑 `data` is frequently React Query's CACHE, not a fresh response — this
+  // query is DISABLED whenever the store cache is warm (`shouldFetch` above), so
+  // an already-mounted observer keeps handing back the pages it fetched minutes
+  // ago. Two rules follow, and the list stops self-healing without either:
+  //
+  //   1. stamp `fetchedAt` with the query's real `dataUpdatedAt`, never
+  //      `Date.now()`. Stamping "now" re-arms the 5-minute TTL on a stale
+  //      snapshot, so `shouldFetch` never flips back to true and the only repair
+  //      left is a full page reload.
+  //   2. never overwrite a store list that already reflects this same server
+  //      snapshot. Equal timestamps are the NORMAL case (the store list was
+  //      written FROM these pages and has since taken optimistic appends /
+  //      removals), which is why the guard is `>=` and not `>`.
   useEffect(() => {
     if (!data?.pages?.length) return
+
+    const existing = useRecordStore.getState().lists[listKey]
+    if (existing && existing.fetchedAt >= dataUpdatedAt) return
 
     // Flatten all pages into IDs with deduplication (preserves order)
     const seenIds = new Set<string>()
@@ -186,22 +219,14 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
       ids: allIds,
       // `total` rides on the first page only — later pages omit the COUNT.
       total: data.pages[0]?.total ?? allIds.length,
-      fetchedAt: Date.now(),
+      fetchedAt: dataUpdatedAt,
       nextCursor,
       // Same story as `total`: every page carries the identical drop diagnostics
       // (they come from the same filter build), so the first page is the source.
       droppedConditions: data.pages[0]?.droppedConditions,
       droppedConditionCount: data.pages[0]?.droppedConditionCount,
     })
-
-    // Queue record fetches for IDs not in cache
-    const recordCache = useRecordStore.getState().records[entityDefinitionId]
-    for (const id of allIds) {
-      if (!recordCache?.has(id)) {
-        requestRecord(toRecordId(entityDefinitionId, id))
-      }
-    }
-  }, [data, listKey, setList, entityDefinitionId, requestRecord])
+  }, [data, dataUpdatedAt, listKey, setList])
 
   // ─── FETCH NEXT PAGE ────────────────────────────────────────────────
 
@@ -217,6 +242,75 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
     useRecordStore.getState().invalidateList(listKey)
     refetch()
   }, [listKey, refetch])
+
+  // ─── OPTIMISTIC MEMBERSHIP (BOTH CACHES) ───────────────────────────
+  //
+  // 🛑 `record.create` / `record.delete` deliberately exclude the originating
+  // socket from their realtime events (`unified-handler-mutations.ts`), so the
+  // acting tab never receives the `record:created` / `record:deleted` frame that
+  // makes every OTHER tab invalidate. Seeding is the actor's only instant path —
+  // and it has to reach BOTH caches, because either one can be the display
+  // source (see `recordIds` below). Writing only the store means the row is
+  // visible until the next remount and then silently reverts to the query's
+  // pre-write pages.
+  //
+  // This hook is the only place that holds both halves — the `listKey` (store)
+  // and the `queryInput` (React Query) — which is why the mutation lives here
+  // rather than in `useSeedCreatedRecord`, whose `listKey` is an opaque hash.
+
+  /** Add a freshly-created record to both caches for this list. */
+  const appendCreated = useCallback(
+    (instanceId: string) => {
+      useRecordStore.getState().appendCreatedRecord(listKey, instanceId)
+      utils.record.listFiltered.setInfiniteData(queryInput, (prev) => {
+        // 🛑 Never fabricate a page. `undefined` means "never fetched"; inventing
+        // one here reads as loaded data and would suppress the first real fetch
+        // forever — strictly worse than the bug this exists to fix.
+        if (!prev?.pages.length) return prev
+        if (prev.pages.some((page) => page.ids.includes(instanceId))) return prev
+        const lastIndex = prev.pages.length - 1
+        return {
+          ...prev,
+          pages: prev.pages.map((page, i) => ({
+            ...page,
+            ids: i === lastIndex ? [...page.ids, instanceId] : page.ids,
+            // `total` rides on the first page only — bumping it on every page
+            // would drift the count by the number of pages loaded. An absent
+            // total stays absent rather than being invented as 1.
+            total: i === 0 && page.total !== undefined ? page.total + 1 : page.total,
+          })),
+        }
+      })
+    },
+    [listKey, queryInput, utils]
+  )
+
+  /**
+   * Drop a record from both caches (optimistic delete).
+   *
+   * The store half is `removeRecord`, which does the full job — evicts the
+   * `RecordMeta`, marks the id not-found so `requestRecord` will not resurrect
+   * it, and splices it out of every cached list for this definition. Call sites
+   * should NOT also call `removeRecord` themselves.
+   */
+  const removeFromList = useCallback(
+    (instanceId: string) => {
+      useRecordStore.getState().removeRecord(entityDefinitionId, instanceId)
+      utils.record.listFiltered.setInfiniteData(queryInput, (prev) => {
+        if (!prev?.pages.length) return prev
+        if (!prev.pages.some((page) => page.ids.includes(instanceId))) return prev
+        return {
+          ...prev,
+          pages: prev.pages.map((page, i) => ({
+            ...page,
+            ids: page.ids.filter((id) => id !== instanceId),
+            total: i === 0 && page.total !== undefined ? Math.max(0, page.total - 1) : page.total,
+          })),
+        }
+      })
+    },
+    [entityDefinitionId, listKey, queryInput, utils]
+  )
 
   // ─── RETURN ────────────────────────────────────────────────────────
   // Return IDs and resolved items from record store
@@ -243,6 +337,22 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
   const droppedConditionCount =
     (cachedList ? cachedList.droppedConditionCount : data?.pages?.[0]?.droppedConditionCount) ??
     droppedConditions.length
+
+  // ─── QUEUE RECORD FETCHES ──────────────────────────────────────────
+  //
+  // Keyed on the DISPLAYED ids, not on `data`. The store cache is served instead
+  // of the query for 5 minutes, so queueing from the query response alone means a
+  // list served from cache queues nothing at all — a row whose `RecordMeta` was
+  // evicted (or was never fetched, e.g. an optimistically appended id) renders as
+  // a hole with no repair path short of a reload. `requestRecord` dedupes against
+  // records / pending / loading / notFound, so this is cheap and idempotent.
+  useEffect(() => {
+    if (!recordIds.length) return
+    const cache = useRecordStore.getState().records[entityDefinitionId]
+    for (const id of recordIds) {
+      if (!cache?.has(id)) requestRecord(toRecordId(entityDefinitionId, id))
+    }
+  }, [recordIds, entityDefinitionId, requestRecord])
 
   // ─── RESOLVE RECORDS FROM RECORD STORE ─────────────────────────────────
   // Subscribe to record cache for this entity definition
@@ -285,6 +395,8 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
     hasNextPage: hasNextPage ?? cachedList?.nextCursor !== null,
     fetchNextPage,
     refresh,
+    appendCreated,
+    removeFromList,
     isCached: !!cachedList,
   }
 }

--- a/apps/web/src/components/resources/hooks/use-seed-created-record.ts
+++ b/apps/web/src/components/resources/hooks/use-seed-created-record.ts
@@ -54,19 +54,22 @@ export interface SeedFieldValue {
  * `resolveFieldRef` + `formatToTypedInput` pairing `use-save-field-value.ts`
  * uses for the field-value store, so the freshly-seeded row renders
  * identically to one hydrated from a list refetch — zero extra network calls.
+ *
+ * ⚠️ This seeds the new row's DATA only — it does not add it to any list.
+ * List MEMBERSHIP is `useRecordList`'s `appendCreated`, which is the only place
+ * that can reach both caches a list is served from (the record store AND the
+ * tRPC query pages). Appending to just one of them makes the row revert on the
+ * next remount, which is exactly what this hook used to do with its `listKey`.
  */
 export function useSeedCreatedRecord() {
   const seedCreatedRecord = useCallback(
     (params: {
       entityDefinitionId: string
       recordId: RecordId
-      /** record-store list to append the new id into. Omit for catalog/standalone
-       *  surfaces whose lists live outside record-store (seeds row data only). */
-      listKey?: string
       instance: CreatedRecordInstance
       values: SeedFieldValue[]
     }) => {
-      const { entityDefinitionId, listKey, instance, values } = params
+      const { entityDefinitionId, instance, values } = params
       // Guard: canonicalize the prefix so seeded keys match subscriber keys.
       const recordId = getNormalizedRecordId(params.recordId)
 
@@ -86,11 +89,7 @@ export function useSeedCreatedRecord() {
             : instance.updatedAt,
       }
 
-      const recordStore = useRecordStore.getState()
-      recordStore.setRecords(entityDefinitionId, [meta])
-      // Catalog/standalone surfaces omit `listKey`; their lists live in the
-      // `record.listAll` tRPC cache, pushed separately by the caller.
-      if (listKey) recordStore.appendCreatedRecord(listKey, instance.id)
+      useRecordStore.getState().setRecords(entityDefinitionId, [meta])
 
       const resourceState = useResourceStore.getState()
       const entries = values.map(({ fieldId, value, fieldType, fieldOptions }) => {


### PR DESCRIPTION
Create a purchase order, add lines, switch to another PO and switch back: the Lines grid is empty. Only a full page reload brings the lines back. Deletes have the mirror bug — a deleted line reappears.

Not purchasing-specific. `useRecordList` is the generic record-list hook; the line builder is just the surface that creates rows fastest and remounts most often, so it is where this surfaced first. `part-pricing-card` had it too.

## Cause

A record list is served from **two** caches — the zustand record-store list and the tRPC infinite-query pages — and either one can be the display source. Four facts compose:

1. `record.create` / `record.delete` deliberately exclude the acting socket from their realtime frames (`unified-handler-mutations.ts:450`), so the acting tab never runs the `invalidateLists` + `listFiltered.invalidate` pair that every *other* tab runs. Seeding is its only update.
2. That seed (`useSeedCreatedRecord`) only wrote the **store**. React Query's pages never learned about the new id.
3. `shouldFetch = enabled && !cachedList` — the store cache *disables* the query; and when the store cache is missing or past its 5-minute TTL, the display source silently becomes React Query's last fetched pages.
4. The sync effect copied those pages back into the store stamped `Date.now()` — clobbering optimistic appends and re-arming the TTL on a snapshot that was often minutes old, so `shouldFetch` never flipped back and the stale answer was re-blessed on every visit.

Measured on the running app: the query sat at `enabled:true, isStale:true, isActive:true, fetchStatus:"idle"` with `dataUpdatedAt` frozen and 1 of 4 ids, and no `record.listFiltered` request was made on the way back.

## Fix

**One writer owns both caches.** `useRecordList` gains `appendCreated` / `removeFromList` — it is the only place holding both the `listKey` (store) and the `queryInput` (React Query), which is why this moves out of `useSeedCreatedRecord`, whose `listKey` is an opaque hash. Both no-op on an unfetched list rather than fabricating a page (a synthesized page reads as loaded data and would suppress the first real fetch), and `total` is adjusted on page 0 only.

**`fetchedAt` means "when the server answered".** The sync effect uses the query's `dataUpdatedAt`, and skips the write when the store list already reflects that snapshot — `>=`, not `>`, because equal timestamps are the normal case for a list carrying optimistic writes. This is what makes the cache self-healing: a remount served an old React Query page writes an old `fetchedAt`, `isListStale` rejects it, and the list refetches.

**Record fetching is queued from the displayed ids**, not from the query response. Previously a list served from the store cache queued nothing at all, so an evicted `RecordMeta` rendered as a hole with no repair path.

## Verification

Browser, cross-checked against Postgres rather than against the screen:

- add a 5th line to a PO → switch away → switch back: all 5 present
- delete a line → switch away → switch back: stays deleted; DB agrees exactly
- create still costs zero list refetches (the phantom-draft property #1918 introduced is preserved)

New `use-record-list.test.ts` (12 tests): warm-cache serve without enabling the query, TTL re-enable, honest `fetchedAt`, the `>=` guard, `appendCreated` idempotence / never-fabricate / page-0 total / `pageParams` preservation, `removeFromList`.

`apps/web` typecheck ratchet: no new type errors (0 total, baseline 0).

## Not in this PR

The purchase order's **own** header values — the Bills card's `Order total` and the Receiving card's `purchase_order_lines` — are a *different* cache and are still stale in the acting tab until reload. They read field values a server-side hook rewrites after the line write. Pre-existing, tracked separately.

Plan: `plans/entity/record-list-cache-divergence-plan.md`
