### PR TITLE
feat(purchasing): add bills from the order, scope the PO-line picker

### DIFF
--- a/apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
@@ -1,0 +1,442 @@
+// apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
+'use client'
+
+// Enter a vendor's invoice against the order it belongs to — the Bills card's
+// header action, and the missing half of `purchase_order:bills`.
+//
+// Until this existed the card could PAY a bill and not create one: bills were
+// raised from the `vendor-bills` list route, where the purchase order is a field
+// somebody has to remember to set. That is not a cosmetic gap. A bill with no PO
+// cannot be matched — `PurchaseOrderLinePicker` disables itself, because with no
+// order there is nothing to match against — so a bill entered the long way is
+// only matchable if whoever typed it linked it by hand. Coming in from the order
+// makes the link a fact rather than a step.
+//
+// 🛑 Deliberately NOT the generic `RecordEditorDialog`. `vendor_bill` has no
+// custom editor, so it would fall through to `EntityInstanceForm`, whose field
+// pool is `creatable !== false && !hidden` — eighteen fields for this def,
+// including all five PAYMENT fields (`paidAt`, `amountPaid`, `paymentMethod`,
+// `paymentReference`, `paidSource`) and raw relationship pickers for `lines` and
+// `paymentAllocations`. Paying is `MarkBillPaidDialog`'s job and lines are added
+// on the bill's own card; offering them here invites a payment that never posts.
+//
+// **Total is prefilled to the order's unbilled amount, and that is a deliberate
+// exception to the transcription rule** — narrow enough to be safe and worth
+// stating, because the rule itself is not negotiable elsewhere.
+//
+// It is safe here because the header total is NOT a match input: `matchBill`
+// weighs `quantityBilled` and `unitPriceBilled` off the LINES. The header total
+// drives `vendor_bill_balance`, the Bills card's figures and the `canPay` gate —
+// so a wrong one records the wrong payable, which is an A/P accuracy problem, not
+// a corrupted match. And in the common case (one invoice for the whole order) the
+// unbilled amount IS the invoice total, so the prefill is right far more often
+// than not.
+//
+// What the prefill must not become is an ANCHOR — a number accepted without
+// checking it against the paper. Three things keep it honest:
+//   - it fills ONCE per opening, only while untouched, so it never overwrites
+//     typing (values arrive async, so this cannot be a plain initial state);
+//   - the field is marked prefilled until edited, and says so;
+//   - once edited, any difference from the unbilled amount is named under the
+//     field. A short-bill is normal (a partial delivery); an over-bill is the
+//     news. Neither is blocked — both are stated.
+//
+// The other three amounts are NOT prefilled. Subtotal/shipping/tax are pure
+// transcription with no order-side figure that is even a good guess.
+
+import { FieldType } from '@auxx/database/enums'
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
+import { useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useResourceProperty } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { RecordBadge } from '~/components/resources/ui/record-badge'
+import { BaseType } from '~/components/workflow/types'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import { numberValue, PurchasingSummaryStrip, unwrapValue } from '../purchasing-summary-strip'
+
+const PO_ATTRS = [
+  'purchase_order_vendor',
+  'purchase_order_currency',
+  'purchase_order_total',
+  'purchase_order_subtotal',
+  'purchase_order_shipping_total',
+  'purchase_order_tax_total',
+  'purchase_order_discount_value',
+  'purchase_order_bills',
+] as const
+
+/** Read off every bill already against the order, to subtract from the prefills. */
+const BILL_ATTRS = [
+  'vendor_bill_total',
+  'vendor_bill_subtotal',
+  'vendor_bill_shipping_total',
+  'vendor_bill_tax_total',
+] as const
+
+interface BillDraft {
+  /** The vendor's OWN invoice number. `internalNumber` is the sequence hook's. */
+  number: string
+  billedAt: string | null
+  dueAt: string | null
+  subtotal: number | null
+  shippingTotal: number | null
+  taxTotal: number | null
+  total: number | null
+}
+
+const EMPTY_DRAFT: BillDraft = {
+  number: '',
+  billedAt: null,
+  dueAt: null,
+  subtotal: null,
+  shippingTotal: null,
+  taxTotal: null,
+  total: null,
+}
+
+export interface CreateBillFromPurchaseOrderDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  purchaseOrderRecordId: RecordId
+  /** Opens the saved bill — the card peeks it. */
+  onCreated?: (billRecordId: RecordId) => void
+}
+
+export function CreateBillFromPurchaseOrderDialog({
+  open,
+  onOpenChange,
+  purchaseOrderRecordId,
+  onCreated,
+}: CreateBillFromPurchaseOrderDialogProps) {
+  const { getSetting } = useSettings({})
+  const [draft, setDraft] = useState<BillDraft>(EMPTY_DRAFT)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  // Distinguishes "we filled this" from "somebody typed this" — the difference
+  // between a suggestion and a transcription, which the row below states.
+  const [totalIsPrefilled, setTotalIsPrefilled] = useState(false)
+
+  const billDefId = useResourceProperty('vendor_bill', 'id')
+
+  const { values } = useSystemValues(purchaseOrderRecordId, [...PO_ATTRS], {
+    autoFetch: true,
+    enabled: open,
+  })
+
+  const vendorRecordId = extractRelationshipRecordIds(values.purchase_order_vendor)[0] ?? null
+  const billRecordIds = extractRelationshipRecordIds(values.purchase_order_bills)
+  const { valuesById } = useSystemValuesForRecords(billRecordIds, BILL_ATTRS, {
+    autoFetch: true,
+    enabled: open && billRecordIds.length > 0,
+  })
+
+  /** An order figure minus what every existing bill already charged for it. */
+  const remainder = (orderAttr: (typeof PO_ATTRS)[number], billAttr: (typeof BILL_ATTRS)[number]) =>
+    numberValue(values[orderAttr]) -
+    billRecordIds.reduce(
+      (sum, billRecordId) => sum + numberValue(valuesById[billRecordId]?.[billAttr]),
+      0
+    )
+
+  const currencyValue = unwrapValue(values.purchase_order_currency)
+  const currencyCode =
+    (typeof currencyValue === 'string' && currencyValue) ||
+    (getSetting('organization.currency') as string | null) ||
+    'USD'
+
+  const orderTotal = numberValue(values.purchase_order_total)
+  const billed = billRecordIds.reduce(
+    (sum, billRecordId) => sum + numberValue(valuesById[billRecordId]?.vendor_bill_total),
+    0
+  )
+  // Signed, like the Bills card's: an order already over-billed is the news, and
+  // clamping it to zero would hide exactly the case worth seeing before adding one more.
+  const unbilled = orderTotal - billed
+
+  // 🛑 The subtraction is what makes the component prefills safe on a SECOND
+  // bill, and freight is the case that proves it: an order's $50 shipping is
+  // normally charged in full on the first invoice, so prefilling the order's
+  // figure again would double it. Its remainder is 0 by then, which is correct.
+  //
+  // Skipped entirely when the order carries a discount. A bill has no discount
+  // field — `subtotal`/`shipping`/`tax`/`total` is the whole set — so on a
+  // discounted order the three components cannot reconcile with the total, and
+  // four prefilled numbers that visibly do not add up on a transcription form
+  // teach people to distrust all of them. Total still prefills: it carries the
+  // discount already and it is the figure that drives balance and payment.
+  const hasDiscount = numberValue(values.purchase_order_discount_value) !== 0
+  const unbilledSubtotal = remainder('purchase_order_subtotal', 'vendor_bill_subtotal')
+  const unbilledShipping = remainder('purchase_order_shipping_total', 'vendor_bill_shipping_total')
+  const unbilledTax = remainder('purchase_order_tax_total', 'vendor_bill_tax_total')
+
+  useEffect(() => {
+    if (!open) return
+    setDraft(EMPTY_DRAFT)
+    setErrors({})
+    setTotalIsPrefilled(false)
+  }, [open])
+
+  // The order's values arrive after the dialog opens, so the prefill cannot be
+  // initial state. Guarded on `total === null` rather than on a "has run" flag:
+  // that is what makes it unable to overwrite typing, including a total the user
+  // deliberately cleared to zero.
+  useEffect(() => {
+    if (!open) return
+    setDraft((prev) => {
+      const next = { ...prev }
+      if (prev.total === null && unbilled > 0) {
+        next.total = unbilled
+        setTotalIsPrefilled(true)
+      }
+      if (!hasDiscount) {
+        if (prev.subtotal === null && unbilledSubtotal > 0) next.subtotal = unbilledSubtotal
+        if (prev.shippingTotal === null && unbilledShipping > 0)
+          next.shippingTotal = unbilledShipping
+        if (prev.taxTotal === null && unbilledTax > 0) next.taxTotal = unbilledTax
+      }
+      return next
+    })
+  }, [open, unbilled, hasDiscount, unbilledSubtotal, unbilledShipping, unbilledTax])
+
+  const createRecord = api.record.create.useMutation({
+    onError: (error) => toastError({ title: 'Error adding bill', description: error.message }),
+  })
+
+  const change = <K extends keyof BillDraft>(key: K, value: BillDraft[K]) => {
+    if (key === 'total') setTotalIsPrefilled(false)
+    setDraft((prev) => ({ ...prev, [key]: value }))
+    setErrors((prev) => {
+      if (!prev[key]) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+  }
+
+  const handleSubmit = async () => {
+    const next: Record<string, string> = {}
+    if (!draft.number.trim()) next.number = "Enter the number on the supplier's invoice"
+    // Not pedantry: a bill with no total cannot be paid (`canPay` requires
+    // `total > 0`) and gives the match nothing to weigh, so it would land as a
+    // row that looks entered and does nothing.
+    if (draft.total === null) next.total = 'Enter the invoice total as billed'
+    setErrors(next)
+    if (Object.keys(next).length > 0) return
+
+    if (!billDefId || !vendorRecordId) return
+
+    // `status` is left unset on purpose — `vendor_bill_status` carries
+    // `defaultValue: VendorBillStatus.DRAFT` and create fills missing keys from
+    // field defaults, so the lifecycle starts where it should without this
+    // surface asserting a status of its own.
+    const created = await createRecord.mutateAsync({
+      entityDefinitionId: billDefId,
+      values: {
+        vendor_bill_vendor: vendorRecordId,
+        vendor_bill_purchase_order: purchaseOrderRecordId,
+        vendor_bill_number: draft.number.trim(),
+        vendor_bill_billed_at: draft.billedAt,
+        vendor_bill_due_at: draft.dueAt,
+        vendor_bill_currency: currencyCode,
+        vendor_bill_subtotal: draft.subtotal,
+        vendor_bill_shipping_total: draft.shippingTotal,
+        vendor_bill_tax_total: draft.taxTotal,
+        vendor_bill_total: draft.total,
+      },
+    })
+
+    onOpenChange(false)
+    if (created?.recordId) onCreated?.(created.recordId)
+  }
+
+  const isPending = createRecord.isPending
+
+  // What the Total row says about itself, in the three states it can be in. The
+  // point of the third is that a difference from the order is NORMAL as often as
+  // not — a partial delivery bills short — so it is named, never blocked.
+  const totalVariance = draft.total === null ? 0 : draft.total - unbilled
+  const totalDescription = totalIsPrefilled
+    ? 'Prefilled from the unbilled amount — check it against the invoice.'
+    : totalVariance === 0
+      ? 'As printed. Never summed from the lines.'
+      : totalVariance > 0
+        ? `As printed. ${formatCurrency(totalVariance, { currencyCode })} MORE than this order has unbilled.`
+        : `As printed. ${formatCurrency(-totalVariance, { currencyCode })} less than this order has unbilled.`
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent position='tc' size='lg'>
+        <DialogHeader>
+          <DialogTitle>Add bill</DialogTitle>
+          <DialogDescription>
+            Transcribe the supplier's invoice exactly as it reads. The amounts are not derived from
+            the order.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='space-y-4'>
+          <PurchasingSummaryStrip
+            className='rounded-2xl border px-3 py-2'
+            cells={[
+              { label: 'Order total', value: formatCurrency(orderTotal, { currencyCode }) },
+              { label: 'Already billed', value: formatCurrency(billed, { currencyCode }) },
+              {
+                label: 'Unbilled',
+                value: formatCurrency(unbilled, { currencyCode }),
+                tone: unbilled === 0 ? 'muted' : 'default',
+              },
+            ]}
+          />
+
+          {!vendorRecordId && (
+            <p className='text-destructive text-sm'>
+              This purchase order has no vendor, and a bill must have one. Set the vendor on the
+              order first.
+            </p>
+          )}
+
+          <FieldPanel
+            orientation='responsive'
+            breakpoint='md'
+            resizeId='create-bill-from-po'
+            defaultLabelWidth={110}
+            className='p-0'>
+            {/* Context, not questions: you pressed Add bill from this order. */}
+            <FieldPanelRow title='Vendor' type={BaseType.STRING} showIcon>
+              {vendorRecordId ? (
+                <RecordBadge recordId={vendorRecordId} className='mt-1.5' />
+              ) : (
+                <span className='text-muted-foreground text-sm'>—</span>
+              )}
+            </FieldPanelRow>
+            <FieldPanelRow title='Purchase order' type={BaseType.STRING} showIcon>
+              <RecordBadge recordId={purchaseOrderRecordId} className='mt-1.5' />
+            </FieldPanelRow>
+
+            <FieldPanelRow
+              title='Bill number'
+              type={BaseType.STRING}
+              showIcon
+              isRequired
+              description="The supplier's own invoice number, not the internal one"
+              validationError={errors.number}
+              validationType='error'>
+              <FieldInputAdapter
+                fieldType={FieldType.TEXT}
+                value={draft.number}
+                onChange={(val) => change('number', (val as string) ?? '')}
+                placeholder='e.g. INV-88213'
+                disabled={isPending}
+              />
+            </FieldPanelRow>
+
+            <FieldPanelRow title='Bill date' type={BaseType.DATE} showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.DATETIME}
+                value={draft.billedAt}
+                onChange={(val) => change('billedAt', (val as string) ?? null)}
+                disabled={isPending}
+                triggerProps={{ className: 'ps-0' }}
+              />
+            </FieldPanelRow>
+            <FieldPanelRow title='Due date' type={BaseType.DATE} showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.DATETIME}
+                value={draft.dueAt}
+                onChange={(val) => change('dueAt', (val as string) ?? null)}
+                disabled={isPending}
+                triggerProps={{ className: 'ps-0' }}
+              />
+            </FieldPanelRow>
+
+            <FieldPanelRow title='Subtotal' type={BaseType.NUMBER} showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.CURRENCY}
+                fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+                value={draft.subtotal}
+                onChange={(val) => change('subtotal', val as number | null)}
+                disabled={isPending}
+                triggerProps={{ className: 'ps-0' }}
+              />
+            </FieldPanelRow>
+            <FieldPanelRow title='Shipping' type={BaseType.NUMBER} showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.CURRENCY}
+                fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+                value={draft.shippingTotal}
+                onChange={(val) => change('shippingTotal', val as number | null)}
+                disabled={isPending}
+                triggerProps={{ className: 'ps-0' }}
+              />
+            </FieldPanelRow>
+            <FieldPanelRow title='Tax' type={BaseType.NUMBER} showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.CURRENCY}
+                fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+                value={draft.taxTotal}
+                onChange={(val) => change('taxTotal', val as number | null)}
+                disabled={isPending}
+                triggerProps={{ className: 'ps-0' }}
+              />
+            </FieldPanelRow>
+            <FieldPanelRow
+              title='Total'
+              type={BaseType.NUMBER}
+              showIcon
+              isRequired
+              description={totalDescription}
+              validationError={errors.total}
+              validationType='error'>
+              <FieldInputAdapter
+                fieldType={FieldType.CURRENCY}
+                fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+                value={draft.total}
+                onChange={(val) => change('total', val as number | null)}
+                disabled={isPending}
+                triggerProps={{ className: 'ps-0' }}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant='outline'
+            size='sm'
+            loading={isPending}
+            loadingText='Adding...'
+            disabled={!billDefId || !vendorRecordId}
+            data-dialog-submit>
+            Add bill
+            <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
@@ -20,15 +20,17 @@
 import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import { getDefinitionId, type RecordId } from '@auxx/types/resource'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { formatCurrency } from '@auxx/utils/currency'
-import { Banknote } from 'lucide-react'
+import { Banknote, Plus } from 'lucide-react'
 import { useState } from 'react'
 import {
   EmptyRow,
   RowSkeleton,
   TREE_SECONDARY_NOTRUNCATE,
 } from '~/components/drawers/cards/related-record-row'
+import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { useOpenRecord } from '~/components/records/record-drill-panels'
 import { useRecord, useResource } from '~/components/resources'
@@ -40,6 +42,7 @@ import { RecordIcon } from '~/components/resources/ui/record-icon'
 import { useSettings } from '~/hooks/use-settings'
 import { numberValue, PurchasingSummaryStrip, unwrapValue } from '../purchasing-summary-strip'
 import { MarkBillPaidDialog } from '../vendor-bill/mark-bill-paid-dialog'
+import { CreateBillFromPurchaseOrderDialog } from './create-bill-from-purchase-order-dialog'
 
 const PO_ATTRS = [
   'purchase_order_bills',
@@ -64,6 +67,8 @@ interface PayTarget {
 export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
   const { getSetting } = useSettings({})
   const [payTarget, setPayTarget] = useState<PayTarget | null>(null)
+  const [addOpen, setAddOpen] = useState(false)
+  const openRecord = useOpenRecord()
   const invalidateResource = useFieldValueStore((state) => state.invalidateResource)
   const { values, isLoading } = useSystemValues(recordId, [...PO_ATTRS], { autoFetch: true })
 
@@ -102,6 +107,23 @@ export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
 
   return (
     <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+      <DrawerCardActions>
+        <Button variant='ghost' size='xs' onClick={() => setAddOpen(true)}>
+          <Plus />
+          Add bill
+        </Button>
+      </DrawerCardActions>
+      <CreateBillFromPurchaseOrderDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        purchaseOrderRecordId={recordId}
+        onCreated={(billRecordId) => {
+          // The card lists the PO's `purchase_order_bills` inverse, so it is the
+          // ORDER whose values went stale, not the new bill.
+          invalidateResource(recordId)
+          openRecord?.(billRecordId)
+        }}
+      />
       <PurchasingSummaryStrip
         className='pb-2'
         cells={[

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-line-picker.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-line-picker.tsx
@@ -1,0 +1,239 @@
+// apps/web/src/components/purchasing/purchase-order/purchase-order-line-picker.tsx
+'use client'
+
+// The scoped replacement for the relationship picker on a bill line's
+// `purchaseOrderLine` field (plans/purchasing/02-handoff.md item 2).
+//
+// That field is the THREE-WAY MATCH KEY: `matchBill` reads the agreed price and
+// the received quantity from whichever line is pointed at, and the post-commit
+// re-SUM adds the billed quantity onto that line's `quantity_billed` roll-up.
+// Pick the wrong line and both land on another vendor's order, silently — the
+// price check can even come back clean, because the tolerance floor ($5.00 or
+// 2%, whichever is larger) swallows a small per-unit difference whole.
+//
+// The generic `FieldInputAdapter` RELATIONSHIP branch cannot do this job, for
+// two independent reasons:
+//
+//   1. It has no scope. `MultiRelationInput` calls `api.record.search`, whose
+//      input schema takes `entityDefinitionId`/`query`/`limit` and nothing else,
+//      so every purchase order line in the ORG is offered. `excludeIds` is not a
+//      way out — it post-filters the 20 rows already returned.
+//   2. A purchase order line has no name. There is no title field in
+//      `purchase-order-line-fields.ts`; the part IS the line's identity, exactly
+//      as `purchase-order-receiving-card.tsx` documents. A generic picker renders
+//      `displayName` and cannot reach through to the part, so the list reads as a
+//      wall of near-blank rows.
+//
+// Which is what makes the ordered/received/price detail on each row part of the
+// fix rather than decoration: two lines for the same part are told apart by
+// their numbers or not at all.
+//
+// The line set needs no query. `purchase_order_lines` is the PO's own inverse
+// relationship, already on the read path the Receiving card uses, so scoping
+// here is a matter of reading the order the bill points at.
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import type { SelectOption } from '@auxx/types/custom-field'
+import type { RecordId } from '@auxx/types/resource'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { formatCurrency } from '@auxx/utils/currency'
+import { useCallback, useMemo, useState } from 'react'
+import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
+import { useRecords } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { PickerTrigger } from '~/components/ui/picker-trigger'
+import { formatQuantity, numberValue, unwrapValue } from '../purchasing-summary-strip'
+
+const PO_ATTRS = ['purchase_order_lines'] as const
+
+const LINE_ATTRS = [
+  'purchase_order_line_part',
+  'purchase_order_line_description',
+  'purchase_order_line_quantity_ordered',
+  'purchase_order_line_quantity_received',
+  'purchase_order_line_expected_unit_price',
+] as const
+
+interface PickableLine {
+  lineRecordId: RecordId
+  label: string
+  ordered: number
+  received: number
+  expectedUnitPrice: number
+}
+
+export interface PurchaseOrderLinePickerProps {
+  /** The order whose lines are offered. Null ⇒ the bill has no PO; see below. */
+  purchaseOrderRecordId: RecordId | null
+  value: RecordId | null
+  onChange: (next: RecordId | null) => void
+  currencyCode: string
+  disabled?: boolean
+}
+
+/**
+ * Single-select picker over one purchase order's lines.
+ *
+ * With no `purchaseOrderRecordId` the picker is disabled rather than falling back
+ * to an unscoped list: a bill with no order has nothing to match against, so every
+ * line it could offer belongs to somebody else's order. Link the bill to its PO
+ * first and the picker fills.
+ */
+export function PurchaseOrderLinePicker({
+  purchaseOrderRecordId,
+  value,
+  onChange,
+  currencyCode,
+  disabled = false,
+}: PurchaseOrderLinePickerProps) {
+  const [open, setOpen] = useState(false)
+
+  const { values, isLoading: linesLoading } = useSystemValues(
+    purchaseOrderRecordId,
+    [...PO_ATTRS],
+    {
+      autoFetch: true,
+      enabled: !!purchaseOrderRecordId,
+    }
+  )
+  const lineRecordIds = extractRelationshipRecordIds(values.purchase_order_lines)
+
+  const { valuesById, isLoading: valuesLoading } = useSystemValuesForRecords(
+    lineRecordIds,
+    LINE_ATTRS,
+    { autoFetch: true, enabled: lineRecordIds.length > 0 }
+  )
+
+  // The part carries the line's label, so its metadata is fetched in one batch
+  // rather than a `useRecord` per row — the rows are options here, not components.
+  const partRecordIds = useMemo(
+    () =>
+      lineRecordIds
+        .map(
+          (lineRecordId) =>
+            extractRelationshipRecordIds(valuesById[lineRecordId]?.purchase_order_line_part)[0]
+        )
+        .filter((partRecordId): partRecordId is RecordId => !!partRecordId),
+    [lineRecordIds, valuesById]
+  )
+  const { recordsByKey, isLoading: partsLoading } = useRecords({
+    recordIds: partRecordIds,
+    enabled: partRecordIds.length > 0,
+  })
+
+  const lines: PickableLine[] = useMemo(
+    () =>
+      lineRecordIds.map((lineRecordId) => {
+        const lineValues = valuesById[lineRecordId] ?? ({} as Record<string, unknown>)
+        const partRecordId = extractRelationshipRecordIds(lineValues.purchase_order_line_part)[0]
+        const description = unwrapValue(lineValues.purchase_order_line_description)
+        // Same precedence as the Receiving card: part, then the typed
+        // description, then an admission that the line has no identity yet.
+        const label =
+          (partRecordId && recordsByKey.get(partRecordId)?.displayName) ||
+          (typeof description === 'string' && description ? description : '') ||
+          'Untitled line'
+        return {
+          lineRecordId,
+          label,
+          ordered: numberValue(lineValues.purchase_order_line_quantity_ordered),
+          received: numberValue(lineValues.purchase_order_line_quantity_received),
+          expectedUnitPrice: numberValue(lineValues.purchase_order_line_expected_unit_price),
+        }
+      }),
+    [lineRecordIds, valuesById, recordsByKey]
+  )
+
+  const options: SelectOption[] = useMemo(
+    () => lines.map((line) => ({ label: line.label, value: line.lineRecordId })),
+    [lines]
+  )
+
+  const isLoading = linesLoading || valuesLoading || partsLoading
+  const selectedLine = lines.find((line) => line.lineRecordId === value)
+  // A stored value that is not among this order's lines is the exact corruption
+  // the unscoped picker used to produce, so it must not render as an empty
+  // trigger — that reads as "nothing picked" while the mis-match is still on the
+  // row and still driving `matchBill`. Say what it is and leave Clear reachable.
+  const isForeignLine = !!value && !selectedLine && !isLoading
+
+  const handleChange = useCallback(
+    (selected: string[]) => {
+      onChange((selected[0] as RecordId | undefined) ?? null)
+    },
+    [onChange]
+  )
+
+  // A bill with no order is the one case where an empty picker is correct rather
+  // than a symptom, so it says which of the two it is.
+  const placeholder = purchaseOrderRecordId
+    ? 'Select purchase order line...'
+    : 'Link the bill to a purchase order first'
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <PickerTrigger
+          open={open}
+          disabled={disabled || !purchaseOrderRecordId}
+          variant='transparent'
+          hasValue={!!selectedLine || isForeignLine}
+          placeholder={placeholder}
+          showClear={!!selectedLine || isForeignLine}
+          onClear={(e) => {
+            e.stopPropagation()
+            onChange(null)
+          }}
+          asCombobox
+          className='h-auto min-h-8 w-full ps-0 pe-1'>
+          {selectedLine && (
+            <span className='flex flex-1 items-center gap-1.5 py-0.5 text-sm'>
+              <span className='truncate'>{selectedLine.label}</span>
+              <LineDetail line={selectedLine} currencyCode={currencyCode} />
+            </span>
+          )}
+          {isForeignLine && (
+            <span className='flex-1 truncate py-0.5 text-destructive text-sm'>
+              Line from another purchase order — clear it and pick again
+            </span>
+          )}
+        </PickerTrigger>
+      </PopoverTrigger>
+      <PopoverContent
+        className='min-w-[max(var(--radix-popover-trigger-width),22rem)] p-0'
+        align='start'>
+        <MultiSelectPicker
+          options={options}
+          value={value ? [value] : []}
+          onChange={handleChange}
+          isLoading={isLoading}
+          canManage={false}
+          canAdd={false}
+          multi={false}
+          placeholder='Search lines...'
+          onSelectSingle={() => setOpen(false)}
+          disabled={disabled}
+          renderItemAction={(option) => {
+            const line = lines.find((candidate) => candidate.lineRecordId === option.value)
+            return line ? <LineDetail line={line} currencyCode={currencyCode} /> : null
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/**
+ * The received/ordered and agreed-price pair — what actually distinguishes two
+ * lines for the same part, and the two numbers the match will be run against.
+ */
+function LineDetail({ line, currencyCode }: { line: PickableLine; currencyCode: string }) {
+  return (
+    <span className='shrink-0 text-muted-foreground text-xs tabular-nums'>
+      {formatQuantity(line.received)}/{formatQuantity(line.ordered)}
+      {' · '}
+      {formatCurrency(line.expectedUnitPrice, { currencyCode })}
+    </span>
+  )
+}

--- a/apps/web/src/components/purchasing/vendor-bill/vendor-bill-lines-card.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/vendor-bill-lines-card.tsx
@@ -24,6 +24,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
@@ -69,6 +70,7 @@ import { RecordBadge } from '~/components/resources/ui/record-badge'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
+import { PurchaseOrderLinePicker } from '../purchase-order/purchase-order-line-picker'
 
 /** Header values the lines card needs: the currency and the transcribed totals. */
 const BILL_HEADER_ATTRIBUTES = [
@@ -459,14 +461,19 @@ function VendorBillLineDialog({
   const lineDefId = useResourceProperty('vendor_bill_line', 'id')
   const billDefId = useResourceProperty('vendor_bill', 'id')
 
-  // TODO(phase-3-router): this picker offers EVERY purchase order line in the
-  // org. Narrowing it to the lines of the bill's own purchase order needs a
-  // scoped read — `purchasing.listOpenPurchaseOrderLines({ purchaseOrderId })`
-  // or the equivalent relation-picker filter — neither of which exists yet.
-  // Picking the wrong line silently mis-matches the bill, so this is the first
-  // thing to tighten once a purchasing router lands.
-  const purchaseOrderLineField = useSystemField('vendor_bill_line_purchase_order_line')
   const partField = useSystemField('vendor_bill_line_part')
+
+  // The match key is picked from THIS bill's order and no other, through
+  // `PurchaseOrderLinePicker` rather than the generic relationship input — which
+  // offers every purchase order line in the org and can only label them by a
+  // `displayName` a line does not have. See that file's header.
+  const billRecordId = billDefId ? toRecordId(billDefId, billId) : null
+  const { values: billValues } = useSystemValues(billRecordId, ['vendor_bill_purchase_order'], {
+    autoFetch: true,
+    enabled: open && !!billRecordId,
+  })
+  const purchaseOrderRecordId =
+    extractRelationshipRecordIds(billValues.vendor_bill_purchase_order)[0] ?? null
 
   const { values: systemValues } = useSystemValues(lineRecordId, [...VENDOR_BILL_LINE_ATTRIBUTES], {
     autoFetch: true,
@@ -600,16 +607,11 @@ function VendorBillLineDialog({
           <FieldPanelRow
             title='Purchase order line'
             description='The match key. Leave empty for a bill with no purchase order.'>
-            <FieldInputAdapter
-              fieldType={purchaseOrderLineField?.fieldType ?? FieldType.RELATIONSHIP}
-              fieldOptions={purchaseOrderLineField?.options}
-              triggerProps={{ className: 'w-full ps-0 pe-1' }}
-              value={values.purchaseOrderLineRecordId ? [values.purchaseOrderLineRecordId] : []}
-              onChange={(next) => {
-                const ids = next as RecordId[]
-                handleChange('purchaseOrderLineRecordId', ids[0] ?? null)
-              }}
-              placeholder='Select purchase order line...'
+            <PurchaseOrderLinePicker
+              purchaseOrderRecordId={purchaseOrderRecordId}
+              value={values.purchaseOrderLineRecordId ?? null}
+              onChange={(next) => handleChange('purchaseOrderLineRecordId', next)}
+              currencyCode={currencyCode}
               disabled={isPending}
             />
           </FieldPanelRow>


### PR DESCRIPTION
Two halves of entering a vendor bill against a purchase order. Closes item 2 of the purchasing handoff — *"the sharpest correctness edge on `main`"*.

## 1. The PO-line picker is scoped

`vendor_bill_line.purchaseOrderLine` is the **three-way match key**. `matchBill` reads the agreed price and the received quantity from whichever line is pointed at, and the post-commit re-SUM adds the billed quantity onto that line's `quantity_billed` roll-up.

It offered **every purchase order line in the org**. Two hex-bolt lines from two vendors look identical in that list, and picking the wrong one lands both the comparison and the roll-up on another vendor's order — **silently**. The price check can even come back `matched`, because the `max(2%, $5.00)` allowance swallows a small per-unit difference whole.

**The generic relationship input could not be filtered into place**, and this is the durable part:

- **No scope.** `MultiRelationInput` calls `record.search`, whose `globalSearchInputSchema` takes `entityDefinitionId` / `query` / `limit` / `cursor` and **no conditions at all**. `excludeIds` is not a way out — it post-filters the 20 rows already returned.
- **No label.** A PO line has **no name field**. The part is its identity, exactly as `purchase-order-receiving-card.tsx:147` documents. A generic picker renders `displayName` and cannot reach through to the part.

`PurchaseOrderLinePicker` reads the order's own `purchase_order_lines` inverse — already on the read path the Receiving card uses, so **no new query and no router procedure**. The `listOpenPurchaseOrderLines` the TODO asked for was the wrong shape to reach for. Each row carries **received/ordered and the agreed price**, which is what tells two lines for the same part apart.

Edge cases:
- **No PO on the bill** → picker disabled, not unscoped. Nothing to match against, so every line it could offer belongs to someone else's order.
- **A stored value that is not one of this order's lines** (i.e. data the old picker produced) → renders `Line from another purchase order — clear it and pick again` in destructive red, with Clear reachable. An empty trigger would read as "nothing picked" while the mis-match still drives `matchBill`.

## 2. Bills can be created from the order

The Bills card could **pay** a bill and not **raise** one, so bills came from the `vendor-bills` list route where the purchase order is a field somebody has to remember to set — and a bill with no PO is unmatchable. Coming in from the order makes the link a fact rather than a step, which also means the picker above is live immediately.

**Deliberately not `RecordEditorDialog`.** `vendor_bill` has no custom editor, so it falls through to `EntityInstanceForm`, whose pool is `creatable !== false && !hidden` — **18 fields** for this def, including all five payment fields (`paidAt`, `amountPaid`, `paymentMethod`, `paymentReference`, `paidSource`) and raw relationship pickers for `lines` and `paymentAllocations`. Paying is `MarkBillPaidDialog`'s job; lines are added on the bill's own card.

`status` is left unset on purpose — `vendor_bill_status` carries `defaultValue: VendorBillStatus.DRAFT` and create fills missing keys from field defaults.

### Prefills

Amounts prefill from what the order has left **unbilled**, per component: the order's figure minus what every existing bill already charged for *that* component.

**The subtraction is what makes this safe on a second bill, and freight is the case that proves it.** An order's $50 shipping is normally charged in full on the first invoice. Prefilling the raw order figure again would double it — the remainder is $0 by then, which is correct.

Guards against the prefill becoming a blind anchor:
- fills **once per opening, only while a field is still null**, so it can never overwrite typing (the order's values arrive after the dialog opens, so this cannot be initial state)
- the total says *"Prefilled from the unbilled amount — check it against the invoice"* until edited
- once edited, any difference is named: *"$40.00 less than this order has unbilled"* / *"…MORE than…"*

Nothing is clamped and nothing is blocked. Billing short is normal (a partial delivery); over-billing is the news — a negative unbilled figure shows, same as the Bills card.

**The three components are skipped when the order carries a discount.** A bill has no discount field — `subtotal`/`shipping`/`tax`/`total` is the whole set — so on a discounted order they cannot reconcile with the total, and four prefilled numbers that visibly do not add up on a transcription form teach people to distrust all of them. Total still prefills; it carries the discount already.

## Checks

- `apps/web` typecheck ratchet: **no new type errors** (0 total, baseline 0)
- Biome clean
- 65 tests pass across `components/purchasing` and `components/drawers`, including `drawer-card-parity`

## Not covered

**No test coverage, and not yet driven in a browser.** Both surfaces are presentational over hooks and there is no harness for that in this area — the existing purchasing tests are pure modules (`receive-po-lines.test.ts`). Given #1923's record — three defects, all in exactly this gap, all passing CI — this wants a real click-through before merge. The prefill effect racing the async value load is the specific thing to watch.