### PR TITLE
fix(kanban): key column visibility by option value, not a nonexistent id

### DIFF
--- a/apps/web/src/components/dynamic-table/components/dialogs/create-view-dialog.tsx
+++ b/apps/web/src/components/dynamic-table/components/dialogs/create-view-dialog.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import type { SelectOption } from '@auxx/types/custom-field'
 import { Button } from '@auxx/ui/components/button'
 import { Combobox } from '@auxx/ui/components/combobox'
 import {
@@ -40,7 +41,7 @@ import type { TableView, ViewConfig } from '../../types'
 interface SelectField {
   id: string
   name: string
-  options?: { options?: Array<{ id: string; label: string; color?: string }> }
+  options?: { options?: SelectOption[] }
 }
 
 /** DATE/DATETIME field for the calendar view's date axis */

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/kanban-view-settings.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/kanban-view-settings.tsx
@@ -259,15 +259,17 @@ function VisibleColumnsStack() {
       <CommandSeparator />
       <CommandGroup>
         {stages.map((stage) => {
-          // Keyed by the option's `id` — that is what KanbanView/KanbanColumn
-          // read `columnSettings` with.
-          const isVisible = columnSettings[stage.id]?.isVisible !== false
+          // Keyed by the option's `value`. KanbanView normalizes options to
+          // `{ id: o.value }` (kanban-view.tsx), so `value` is what
+          // KanbanColumn reads `columnSettings` with. Stored options carry no
+          // `id` — the registry projection never emits one.
+          const isVisible = columnSettings[stage.value]?.isVisible !== false
           return (
             <CommandCheckboxItem
-              key={stage.id}
-              value={stage.id}
+              key={stage.value}
+              value={stage.value}
               checked={isVisible}
-              onCheckedChange={(checked) => handleToggleColumn(stage.id, checked)}
+              onCheckedChange={(checked) => handleToggleColumn(stage.value, checked)}
               variant='switch'>
               <div className='flex items-center gap-2'>
                 {stage.color && (

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/view-selector.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/view-selector.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import type { SelectOption } from '@auxx/types/custom-field'
 import { Button } from '@auxx/ui/components/button'
 import {
   Command,
@@ -58,7 +59,7 @@ import { CreateViewDialog, RenameViewDialog } from '../dialogs'
 interface SelectField {
   id: string
   name: string
-  options?: { options?: Array<{ id: string; label: string; color?: string }> }
+  options?: { options?: SelectOption[] }
 }
 
 /** DATE/DATETIME field for the calendar view's date axis */

--- a/apps/web/src/components/dynamic-table/context/view-metadata-context.tsx
+++ b/apps/web/src/components/dynamic-table/context/view-metadata-context.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/dynamic-table/context/view-metadata-context.tsx
 'use client'
 
+import type { SelectOption } from '@auxx/types/custom-field'
 import { createContext, type Dispatch, type SetStateAction, useContext } from 'react'
 import type { CustomField } from '../types'
 
@@ -14,7 +15,7 @@ export interface ViewMetadataContextValue<TData = any> {
   selectFields: Array<{
     id: string
     name: string
-    options: { options?: Array<{ id: string; label: string; color?: string }> }
+    options: { options?: SelectOption[] }
   }>
 
   /** Custom fields (for kanban cards) */

--- a/apps/web/src/components/dynamic-table/dynamic-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-view.tsx
@@ -348,7 +348,7 @@ export function DynamicView<TData extends object = object>(props: DynamicTablePr
       .map((f) => ({
         id: f.id,
         name: f.name ?? f.label,
-        options: f.options as { options?: Array<{ id: string; label: string; color?: string }> },
+        options: f.options ?? {},
       }))
   }, [fields])
 


### PR DESCRIPTION
## The bug

The **Visible columns** switches in kanban settings do nothing. Flipping one moves them all, and the board never hides a column.

## Cause

`2d7a8ce5d` — *"fix: clear 1671 type errors and the live defects they were hiding (#1485)"*, 2026-08-01 — changed `VisibleColumnsStack` from `columnSettings[stage.value]` to `columnSettings[stage.id]`, adding a comment asserting that `id` is what `KanbanView`/`KanbanColumn` read with. It isn't.

It made that change to satisfy the type in `view-metadata-context.tsx`, which declared the nested select options as `{ id: string; label; color? }` — `id` required, `value` absent. That is the inverse of the actual data.

**Select options have no `id`:**

- `selectOptionSchema` has carried `id: z.string().optional()` since 2026-01-02, and nothing ever populated it — **0 of 8,370** stored options across `SINGLE_SELECT`/`MULTI_SELECT`/`TAGS` have one.
- `resource-registry-service.ts:1075` — the client projection this screen reads through — whitelists `value, label, color, targetTimeInStatus, celebration`. I traced all 40 commits to that file back to January: `id` has **never** been in it.

So `stage.id` was `undefined` for every stage from the day #1485 landed. Every switch shared a single `columnSettings[undefined]` entry, and `KanbanView` — which normalizes options to `{ id: o.value }` (`kanban-view.tsx:287`) and reads `columnSettings[column.id]` — never saw the write.

> Note: `3ee3415ec` (#1791) did remove an option `id` recently, but that was the `OptionsEditor`'s UI-only dnd key (`"editor state (without internal id)"`), never persisted and never sent to the client. It is not related.

## The fix

Key by `value` again, and fix the three type declarations that made the wrong property look like the right one:

| file | change |
|---|---|
| `kanban-view-settings.tsx` | `stage.id` → `stage.value` (the actual fix); comment corrected |
| `view-metadata-context.tsx` | use canonical `SelectOption` from `@auxx/types/custom-field` instead of a hand-rolled inverted shape |
| `dynamic-view.tsx` | drop the `as` cast that stopped the projection from being typechecked |
| `view-selector.tsx`, `create-view-dialog.tsx` | two more private copies of the same wrong shape — neither reads the nested options, but both typed the same lie |

`stage.id` is now `string | undefined` at every one of those sites, so writing this again is a compile error rather than a silent no-op.

## Verification

- `pnpm --filter @auxx/web typecheck` — exit 0, zero `error TS` lines. (The type fix is what surfaced the two duplicate `SelectField` declarations.)
- Biome clean on all five files.
- **No data migration needed:** 64 views carry a `kanban` config and none have any `columnSettings` key, so there is nothing stale to clean up.

## Left open, deliberately

`KanbanSelectOption.id` (`dynamic-table/types.ts:274`) holds an option **value**, not an id — the misnomer that made #1485's comment look correct. Renaming it touches `columnId` plumbing including `NO_STATUS_COLUMN_ID` and belongs in its own PR.
