### PR TITLE
refactor(kanban): name the column key `value`, since that is what it is

### DIFF
--- a/apps/web/src/components/dynamic-table/types.ts
+++ b/apps/web/src/components/dynamic-table/types.ts
@@ -269,9 +269,18 @@ export interface KanbanRow {
   [key: string]: unknown
 }
 
-/** Normalized option for kanban columns (with id instead of value) */
+/**
+ * A kanban column derived from one select option.
+ *
+ * `value` is the option's stored value — the same string a record's
+ * `FieldValue` holds — and it is what identifies the column everywhere:
+ * `columnOrder`, `columnSettings`, `collapsedColumns`, the dnd ids, and
+ * `KanbanColumn`'s `columnId` prop (whose other inhabitant is the synthetic
+ * {@link NO_STATUS_COLUMN_ID}). Options carry no `id` — see
+ * `resource-registry-service`'s projection, which never emits one.
+ */
 export interface KanbanSelectOption {
-  id: string
+  value: string
   label: string
   color?: string
   /** Target time for items to remain in this status */

--- a/apps/web/src/components/kanban/kanban-view.tsx
+++ b/apps/web/src/components/kanban/kanban-view.tsx
@@ -280,12 +280,14 @@ export function KanbanView<TData extends KanbanRow>({
     })
   }, [])
 
-  // Get options from the groupBy field - normalize value -> id
+  // Get the columns from the groupBy field's options
   const allColumns: KanbanSelectOption[] = useMemo(() => {
     const rawOptions: RawSelectOption[] = groupByField.options?.options ?? []
-    // Normalize: map 'value' to 'id' for consistent usage
+    // Narrow to the column shape. This drops `id`/`icon`/`avatarUrl`
+    // deliberately: `id` is never populated on a stored option, so nothing
+    // downstream should be able to reach for one.
     const normalizedOptions: KanbanSelectOption[] = rawOptions.map((o) => ({
-      id: o.value,
+      value: o.value,
       label: o.label,
       color: o.color,
       targetTimeInStatus: o.targetTimeInStatus,
@@ -298,10 +300,10 @@ export function KanbanView<TData extends KanbanRow>({
     // Use column order for ordering, but include ALL options
     // Options in columnOrder appear first (in that order), then any new options are appended
     const orderedColumns = config.columnOrder
-      .map((id) => normalizedOptions.find((o) => o.id === id))
+      .map((value) => normalizedOptions.find((o) => o.value === value))
       .filter(Boolean) as KanbanSelectOption[]
-    const orderedIds = new Set(config.columnOrder)
-    const unorderedColumns = normalizedOptions.filter((o) => !orderedIds.has(o.id))
+    const orderedValues = new Set(config.columnOrder)
+    const unorderedColumns = normalizedOptions.filter((o) => !orderedValues.has(o.value))
     return [...orderedColumns, ...unorderedColumns]
   }, [groupByField.options, config.columnOrder])
 
@@ -319,13 +321,13 @@ export function KanbanView<TData extends KanbanRow>({
   // Filter columns by visibility settings
   const columns = useMemo(() => {
     return allColumns.filter((col) => {
-      const settings = config.columnSettings?.[col.id]
+      const settings = config.columnSettings?.[col.value]
       return settings?.isVisible !== false
     })
   }, [allColumns, config.columnSettings])
 
   // Column IDs for sortable context
-  const columnIds = useMemo(() => [NO_STATUS_COLUMN_ID, ...columns.map((c) => c.id)], [columns])
+  const columnIds = useMemo(() => [NO_STATUS_COLUMN_ID, ...columns.map((c) => c.value)], [columns])
 
   // Group data by column
   const columnData = useMemo(() => {
@@ -334,7 +336,7 @@ export function KanbanView<TData extends KanbanRow>({
     // Initialize ALL columns (including hidden ones)
     // This ensures items keep their correct grouping even when column is hidden
     allColumns.forEach((col) => {
-      grouped[col.id] = []
+      grouped[col.value] = []
     })
 
     // Add "No Status" column for items without a value
@@ -375,7 +377,7 @@ export function KanbanView<TData extends KanbanRow>({
       const dragWidth = cardElement?.offsetWidth
 
       if (type === 'column') {
-        const column = columns.find((c) => c.id === active.id)
+        const column = columns.find((c) => c.value === active.id)
         if (column) {
           setActiveItem({ type: 'column', id: String(active.id), data: column })
         }
@@ -462,7 +464,7 @@ export function KanbanView<TData extends KanbanRow>({
         if (cardsToMove.length === 0) return
 
         // Show celebration once (not per card)
-        const targetColumn = columns.find((c) => c.id === targetColumnId)
+        const targetColumn = columns.find((c) => c.value === targetColumnId)
         if (targetColumn?.celebration) {
           showCelebrationConfetti()
         }
@@ -596,17 +598,17 @@ export function KanbanView<TData extends KanbanRow>({
               {/* Regular columns (sortable) - each subscribes to its own data via hooks */}
               {columns.map((column) => (
                 <KanbanColumn
-                  key={column.id}
-                  columnId={column.id}
+                  key={column.value}
+                  columnId={column.value}
                   resourceFieldId={resourceFieldId}
                   tableId={tableId}
-                  count={columnData[column.id]?.length ?? 0}
-                  isOver={overId === column.id}
-                  isSourceColumn={activeItem?.sourceColumnId === column.id}
+                  count={columnData[column.value]?.length ?? 0}
+                  isOver={overId === column.value}
+                  isSourceColumn={activeItem?.sourceColumnId === column.value}
                   isDraggingColumn={activeItem?.type === 'column'}
-                  onAddCard={onAddCard ? () => onAddCard(column.id) : undefined}
+                  onAddCard={onAddCard ? () => onAddCard(column.value) : undefined}
                   isSortable>
-                  {(columnData[column.id] ?? []).map((card) => (
+                  {(columnData[column.value] ?? []).map((card) => (
                     <KanbanCard
                       key={card.id}
                       id={card.id}


### PR DESCRIPTION
Follow-up to #1926, which fixed the bug this name caused.

## The misnomer

`KanbanSelectOption.id` never held an id. `kanban-view.tsx` built it as `id: o.value`, and it had to: a card's column is resolved from the **stored field value** —

```typescript
const columnId = rawValue ? String(rawValue) : NO_STATUS_COLUMN_ID
```

— so the option's `value` is necessarily the column key. Correct behaviour, wrong name.

That name is what made #1485 believe options have ids and rekey the visible-columns switches to a property nothing ever populates. Every other layer already says `value`:

| site | signature |
|---|---|
| `use-field.ts:220` | `useFieldSelectOption(resourceFieldId, optionValue)` → `o.value === optionValue` |
| `use-custom-field-mutations.tsx:625` | `updateOption(optionValue, changes)` |
| `:668` | `deleteOption(optionValue)` |
| `:686` | `reorderOptions` — keyed by `o.value` |

This makes the kanban layer agree with all of them.

## Scope

Pure rename, no behaviour change. The type is used in exactly one file (`kanban-view.tsx`); `types.ts` carries the declaration.

Two things deliberately **not** changed:

- **`KanbanColumn`'s `columnId` prop keeps its name.** A column id is genuinely an option value *or* the synthetic `NO_STATUS_COLUMN_ID` sentinel, so `columnId` is the honest name for that union.
- **The narrowing map stays** rather than passing `SelectOption` straight through. Dropping `id`/`icon`/`avatarUrl` is precisely what stops anything downstream reaching for an `id` again — it earns its keep now.

## Verification

- `pnpm --filter @auxx/web typecheck` — exit 0, zero `error TS` lines.
- Biome clean.
- No behavioural surface to migrate: `columnOrder`, `columnSettings` and `collapsedColumns` were already keyed by option value on both the read and write side, so stored view configs are unaffected.

## Noted while in here, not addressed

Option `value` is minted two different ways into the same array:

```
use-custom-field-mutations.tsx:654   value: data.value ?? data.label   // kanban "add column" → value IS the label
options-editor.tsx:327               value: generateId()               // field editor → value is a cuid (since #1791)
```

Consequences: a mixed keyspace within one field; kanban-created values freeze the *original* label forever (`updateOption` never touches `value`, so renaming a column leaves the stored value reading the old name); and two kanban columns created with the same label yield duplicate values, since `createOption` appends with no uniqueness check.

Currently latent, not active — across all 8,370 stored options: 0 cuid-shaped values, 253 where `value == label`, **0 duplicates**. The `generateId` path is new enough that it hasn't produced a row yet, which makes now the cheap moment to pick a convention. Separate PR.
