### PR TITLE
fix(pickers): stop re-filtering server search results by label

### DIFF
--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -300,6 +300,7 @@ export function FieldInputAdapter({
             onCreate={canInlineCreate ? handleOpenCreate : undefined}
             excludeIds={fieldOptions?.excludeIds}
             showDefinitionIcon={fieldOptions?.showDefinitionIcon}
+            showSecondary={fieldOptions?.showSecondary}
             triggerProps={triggerProps}
             open={open}
             onOpenChange={onOpenChange}

--- a/apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
@@ -366,6 +366,9 @@ export function SubpartDialog({
                         relationship: CHILD_PART_RELATIONSHIP,
                         excludeIds: excludedForRow(row.key),
                         showDefinitionIcon: true,
+                        // Components are looked up by SKU, so show it — otherwise a hit on
+                        // a SKU query renders a name that looks unrelated to what was typed.
+                        showSecondary: true,
                       }}
                     />
                   </FieldPanelRow>

--- a/apps/web/src/components/pickers/async-option-picker.tsx
+++ b/apps/web/src/components/pickers/async-option-picker.tsx
@@ -212,7 +212,11 @@ export function AsyncOptionPicker({
           value={normalizedValue}
           onChange={handleChange}
           isLoading={isLoading}
-          onSearchChange={setSearchQuery}
+          // Async mode only: handing the picker `onSearchChange` declares the search
+          // server-side, so it stops filtering locally. In static mode `staticOptions` is
+          // the whole list and the picker's own filter is the only one there is (the
+          // resolve effect bails on `isStatic`, so nothing consumes `searchQuery` there).
+          onSearchChange={isStatic ? undefined : setSearchQuery}
           canManage={false}
           canAdd={false}
           multi={multi}

--- a/apps/web/src/components/pickers/multi-select-picker.tsx
+++ b/apps/web/src/components/pickers/multi-select-picker.tsx
@@ -8,11 +8,11 @@ import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
   CommandList,
+  CommandPlaceholder,
 } from '@auxx/ui/components/command'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { toastError } from '@auxx/ui/components/toast'
@@ -279,12 +279,19 @@ export function MultiSelectPicker({
     }
   }, [usageError])
 
+  // A caller that takes `onSearchChange` is running the search itself (server-side) and
+  // hands back only the rows that already matched. Re-filtering those locally would
+  // discard every hit the server matched on something other than the label — a record
+  // found by SKU or email never contains the query in its display name, so the list
+  // came back empty. Local filtering stays the only filter for static option lists.
+  const isServerFiltered = !!onSearchChange
+
   // Filter options by search value
   const filteredOptions = useMemo(() => {
-    if (!searchValue.trim()) return localOptions
+    if (isServerFiltered || !searchValue.trim()) return localOptions
     const search = searchValue.toLowerCase()
     return localOptions.filter((opt) => opt.label.toLowerCase().includes(search))
-  }, [localOptions, searchValue])
+  }, [localOptions, searchValue, isServerFiltered])
 
   // Partition filtered options into ordered, headed sections when `groupBy` is
   // set; `null` keeps the single ungrouped list. Group order follows `groups`,
@@ -586,8 +593,8 @@ export function MultiSelectPicker({
           isManageMode && 'py-0 pe-1',
           editingOptionId === opt.value && 'bg-primary-200'
         )}>
-        <div className='flex items-center justify-between w-full'>
-          <div className='flex items-center gap-2'>
+        <div className='flex items-center justify-between w-full gap-2 min-w-0'>
+          <div className='flex items-center gap-2 min-w-0'>
             {/* Selection indicator (checkbox/radio) or manage icon */}
 
             {/* Avatar + icon fallback (record pickers carry avatarUrl) */}
@@ -623,8 +630,14 @@ export function MultiSelectPicker({
               </>
             )}
 
-            {/* Option label */}
+            {/* Option label, plus the muted secondary line the search may have matched on
+                (a record's SKU or email) — without it a hit looks unrelated to the query. */}
             <span className='truncate'>{opt.label}</span>
+            {opt.secondary && (
+              <span className='truncate min-w-0 text-xs text-muted-foreground [flex-shrink:9999]'>
+                {opt.secondary}
+              </span>
+            )}
           </div>
           <div className='flex items-center gap-1 shrink-0'>
             {/* Per-row secondary action (e.g., favorite star) */}
@@ -760,9 +773,14 @@ export function MultiSelectPicker({
                 </>
               )}
 
-              {/* Options List */}
-              {filteredOptions.length === 0 && !searchValue.trim() && (
-                <CommandEmpty>No options yet. Type to create one.</CommandEmpty>
+              {/* Options List. CommandPlaceholder, not CommandEmpty: cmdk's Empty renders on
+                  its own registered-item count, which the pinned Create/Manage/Browse rows
+                  below keep above zero — so CommandEmpty stayed invisible and a search with
+                  no hits rendered a blank popover. */}
+              {filteredOptions.length === 0 && (
+                <CommandPlaceholder>
+                  {searchValue.trim() ? 'No results found' : 'No options yet. Type to create one.'}
+                </CommandPlaceholder>
               )}
               {filteredOptions.length > 0 &&
                 (groupedOptions ? (

--- a/apps/web/src/components/shared/multi-relation-input.tsx
+++ b/apps/web/src/components/shared/multi-relation-input.tsx
@@ -7,10 +7,12 @@ import type { SelectOptionColor } from '@auxx/types/custom-field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
+import { keepPreviousData } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
 import { useResource } from '~/components/resources/hooks/use-resource'
 import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
+import { useDebouncedValue } from '~/hooks/use-debounced-value'
 import { api } from '~/trpc/react'
 import { RecordBadge } from '../resources/ui'
 
@@ -55,6 +57,13 @@ export interface MultiRelationInputProps {
    */
   showDefinitionIcon?: boolean
 
+  /**
+   * When true, rows show the record's secondary display value (SKU, email, …) muted
+   * beside the label. Default: false — worth the row width only where that value is
+   * what people search by.
+   */
+  showSecondary?: boolean
+
   /** Callback when "Create new" is clicked (for complex creation flows via dialog) */
   onCreate?: () => void
 
@@ -91,6 +100,7 @@ export function MultiRelationInput({
   multi = true,
   excludeIds = [],
   showDefinitionIcon = false,
+  showSecondary = false,
   onCreate,
   createLabel,
   triggerProps,
@@ -103,6 +113,9 @@ export function MultiRelationInput({
 
   const [internalOpen, setInternalOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  // Search is server-side, so it is the query that gets debounced — feeding every
+  // keystroke straight to `record.search` fired one request per character.
+  const [debouncedSearch] = useDebouncedValue(searchQuery, 300)
 
   // Use controlled or uncontrolled state
   const open = controlledOpen ?? internalOpen
@@ -126,11 +139,12 @@ export function MultiRelationInput({
   const { data: searchResults, isLoading: isSearching } = api.record.search.useQuery(
     {
       entityDefinitionId: tableId!,
-      query: searchQuery,
+      query: debouncedSearch,
       limit: 20,
     },
     {
       enabled: open && !!tableId,
+      placeholderData: keepPreviousData,
     }
   )
 
@@ -143,12 +157,22 @@ export function MultiRelationInput({
         label: item.displayName,
         value: item.recordId,
         avatarUrl: item.avatarUrl,
+        // Opt-in: the field the search often matched on (SKU, email). Withholding it is
+        // what hides the line — the picker renders `secondary` on its presence alone.
+        ...(showSecondary ? { secondary: item.secondaryInfo ?? undefined } : {}),
         // Fall back to the EntityDefinition's icon/color when the record has no avatar
         ...(showDefinitionIcon
           ? { icon: resource?.icon, color: resource?.color as SelectOptionColor | undefined }
           : {}),
       }))
-  }, [searchResults, excludeIds, showDefinitionIcon, resource?.icon, resource?.color])
+  }, [
+    searchResults,
+    excludeIds,
+    showDefinitionIcon,
+    showSecondary,
+    resource?.icon,
+    resource?.color,
+  ])
 
   /**
    * Handle selection change from MultiSelectPicker

--- a/packages/lib/src/custom-fields/field-options.ts
+++ b/packages/lib/src/custom-fields/field-options.ts
@@ -137,6 +137,13 @@ export interface FieldOptions {
    * Runtime-only UI flag passed by the caller — never persisted to CustomField.options.
    */
   showDefinitionIcon?: boolean
+  /**
+   * When true, RELATIONSHIP picker rows show the record's secondary display value
+   * (SKU, email, …) muted beside the label. Off by default: it is only worth the row
+   * width where that value is what people search by.
+   * Runtime-only UI flag passed by the caller — never persisted to CustomField.options.
+   */
+  showSecondary?: boolean
 
   // ─────────────────────────────────────────────────────────────
   // ACTOR (nested - uses ActorOptions from @auxx/types/custom-field)

--- a/packages/types/custom-field/index.ts
+++ b/packages/types/custom-field/index.ts
@@ -70,6 +70,8 @@ export const selectOptionSchema = z.object({
   icon: z.string().optional(),
   /** URL or encoded visual ref (see `EntityInstance.avatarUrl`) — used by record/relation pickers; not persisted on field options */
   avatarUrl: z.string().optional(),
+  /** Muted second line beside the label (e.g. a record's SKU / email) — used by record/relation pickers; not persisted on field options */
+  secondary: z.string().optional(),
   /** Target time for items to remain in this status (kanban) */
   targetTimeInStatus: targetTimeInStatusSchema.optional(),
   /** Trigger celebration animation when cards move to this column (kanban) */


### PR DESCRIPTION
## The bug

Typing a SKU into a relationship picker found nothing — reported on **Add Subparts** (`/app/parts?tab=subparts`), but it affected every relation picker.

The server was fine. `record.search` matched the record (SKU is in `EntityInstance.searchText`) and returned it:

```json
{"displayName":"Auxx-Lift Gray 4x8 400","secondaryInfo":"AX48G400","combined_score":0.414}
```

`MultiSelectPicker` then threw it away. It re-filtered the server's rows locally:

```ts
return localOptions.filter((opt) => opt.label.toLowerCase().includes(search))
```

`"auxx-lift gray 4x8 400".includes("ax48g400")` is false, so the one real hit was dropped. Name search worked only because there the substring happens to match.

## The fix

Taking `onSearchChange` declares the search server-side and bypasses the local filter. Static option lists (select fields) keep filtering locally — that is the only filter they have — so `AsyncOptionPicker` passes the handler in async mode only.

Two defects in the same code fell out of it:

- **Blank popover instead of an empty state.** `CommandEmpty` renders off cmdk's own registered-item count, and the pinned Create/Manage/Browse rows keep that above zero, so it was never going to show. Now `CommandPlaceholder` (manual control, as `record-picker-content` already uses) with the un-inverted condition.
- **No debounce.** `MultiRelationInput` fed every keystroke straight to `record.search` — eight requests to type `AX48G400`. Now debounced 300ms with `keepPreviousData`, so the list doesn't blank between keystrokes.

## Secondary value

Pickers can now show a record's secondary display value (SKU, email) muted beside the label, via `SelectOption.secondary` — same runtime-only, never-persisted contract as the neighbouring `avatarUrl`.

**Off by default**, behind `fieldOptions.showSecondary`. Opted into on the subpart dialog only, where components are looked up by SKU and a hit otherwise renders a name that looks unrelated to what was typed.

Note `record-picker-content`/`record-item` already have a `showSecondary` prop but default it to `true`; this path defaults to `false`, so the two aren't consistent on the default.

## Verification

Driven in a real browser against dev:

| Surface | `AX48G400` |
| --- | --- |
| Subpart dialog (opted in) | finds it, shows `Auxx-Lift Gray 4×8 400  AX48G400` |
| PO line picker (not opted in) | finds it, shows `Auxx-Lift Gray 4×8 400` — no SKU |
| `zzzznotathing` | "No results found" instead of a blank box |

Debounce confirmed in the network panel: one `record.search` for the full query, down from eight.

`pnpm --filter @auxx/web typecheck` exits 0. lib ratchet flat (29 total, baseline 29). Biome clean on all 7 files. `custom-fields` suite 90/90.