### PR TITLE
fix(pickers): show the entity-definition icon on relationship rows by default

### DIFF
--- a/apps/web/src/components/pickers/multi-select-picker.tsx
+++ b/apps/web/src/components/pickers/multi-select-picker.tsx
@@ -604,17 +604,21 @@ export function MultiSelectPicker({
                 iconId={opt.icon || 'circle'}
                 color={opt.color ?? 'gray'}
                 size='sm'
+                inverse
               />
             ) : (
               <>
-                {/* Icon (if option has icon) */}
+                {/* Icon (if option has icon). `inverse` — solid tint, light glyph — is
+                    what `RecordItem` uses, so a record looks the same in this picker as
+                    in the record picker. A hex color drives the glyph directly and has
+                    no inverse pair, so it stays on the default treatment. */}
                 {opt.icon && (
                   <EntityIcon
                     iconId={opt.icon}
                     size='sm'
                     {...(opt.color?.startsWith('#')
                       ? { style: { color: opt.color } }
-                      : { color: opt.color ?? 'gray' })}
+                      : { color: opt.color ?? 'gray', inverse: true })}
                   />
                 )}
 

--- a/apps/web/src/components/shared/multi-relation-input.tsx
+++ b/apps/web/src/components/shared/multi-relation-input.tsx
@@ -52,8 +52,10 @@ export interface MultiRelationInputProps {
   excludeIds?: RecordId[]
 
   /**
-   * When true, picker rows with no avatar fall back to the related EntityDefinition's
-   * icon/color (matching the selected chips). Default: false.
+   * Picker rows with no avatar fall back to the related EntityDefinition's icon/color,
+   * matching the selected chips (`RecordBadge`) and the record picker (`RecordItem`),
+   * both of which fall back unconditionally. Default: true — pass `false` only where a
+   * bare label list is deliberate.
    */
   showDefinitionIcon?: boolean
 
@@ -99,7 +101,7 @@ export function MultiRelationInput({
   maxDisplayItems = 3,
   multi = true,
   excludeIds = [],
-  showDefinitionIcon = false,
+  showDefinitionIcon = true,
   showSecondary = false,
   onCreate,
   createLabel,
@@ -132,7 +134,7 @@ export function MultiRelationInput({
     return Array.isArray(entityDefinitionId) ? entityDefinitionId[0] : entityDefinitionId
   }, [entityDefinitionId])
 
-  // EntityDefinition icon/color fallback for records without an avatar (opt-in)
+  // EntityDefinition icon/color fallback for records without an avatar (on by default)
   const { resource } = useResource(showDefinitionIcon ? tableId : null)
 
   // Search for items when popover is open

--- a/packages/lib/src/custom-fields/field-options.ts
+++ b/packages/lib/src/custom-fields/field-options.ts
@@ -132,8 +132,9 @@ export interface FieldOptions {
    */
   excludeIds?: RecordId[]
   /**
-   * When true, RELATIONSHIP picker rows fall back to the related EntityDefinition's
-   * icon/color for records that have no avatar (selected chips already do this).
+   * RELATIONSHIP picker rows fall back to the related EntityDefinition's icon/color
+   * for records that have no avatar, like the selected chips do. On by default —
+   * set `false` only to opt a picker out.
    * Runtime-only UI flag passed by the caller — never persisted to CustomField.options.
    */
   showDefinitionIcon?: boolean


### PR DESCRIPTION
## What

A relationship picker row rendered a left icon only when the record carried its own `avatarUrl`. A list of companies came back as a ragged mix of logo rows and bare-label rows — with no left slot emitted at all, the labels did not even share a text baseline:

```html
<!-- has an avatar -->
<div class="flex items-center gap-2"><span data-slot="avatar" …></span><span class="truncate">GitHub</span></div>
<!-- does not -->
<div class="flex items-center gap-2"><span class="truncate">Motor Inc.</span></div>
```

## Why it happened

The fallback already existed — `MultiRelationInput`'s `showDefinitionIcon` — but it defaulted to `false` and was reachable only through `fieldOptions.showDefinitionIcon`, a runtime-only flag that is never persisted to `CustomField.options`. Five hand-written call sites pass it (parts, subpart, vendor-part, product-variant link, part-family). Every generic surface — the record create/edit dialog, bulk update, workflow node panels, kbar create — reaches the adapter through `field.options` read from the DB, where the flag is always absent, so it could never be true there.

Chain for the create dialog:

```
RecordEditorDialog → EntityInstanceDialog → EntityInstanceForm → FieldInputRow
  → FieldInputAdapter (case RELATIONSHIP) → MultiRelationInput → MultiSelectPicker rows
```

Meanwhile two other renderers of the same concept fall back unconditionally:

| surface | fallback | wrap |
| --- | --- | --- |
| `RecordBadge` — the selected chip in this very trigger | always | `RecordIcon`, non-inverse |
| `RecordItem` — the record picker | always | `RecordIcon`, `inverse` |
| `MultiSelectPicker` row | opt-in, default off | `EntityIcon`, non-inverse |

So one control disagreed with itself: the chip showed the definition icon, the dropdown row it came from did not.

## Change

- `MultiRelationInput`: `showDefinitionIcon` defaults to `true`. Callers can still pass `false`.
- `MultiSelectPicker`: row icons use `inverse` (solid tint, light glyph), matching `RecordItem`, so a record looks the same in both pickers. A hex color is passed as `style` and has no `inverseColor` pair in `ICON_COLORS`, so it stays on the default treatment rather than getting a solid background with no matching glyph.
- Doc comments in `MultiRelationInputProps` and `FieldOptions` updated to state the new default.

The five explicit `showDefinitionIcon: true` call sites are now redundant but harmless; left in place.

## Verified

Live in the New Purchase Order dialog: the Vendor field targets `company` (`icon: 'building-2'`, `color: 'blue'`), and every avatar-less row now renders that icon with the labels aligned.

## Not changed

`RecordBadge` is still non-inverse, so the chip and the dropdown row differ in treatment. It is used in every table cell and relationship card, so flipping it is a much wider blast radius than this PR.