### PR TITLE
feat(table): sort from the toolbar, not only from a column header

### DIFF
--- a/apps/web/src/components/dynamic-table/components/table-toolbar/index.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/index.tsx
@@ -39,7 +39,7 @@ import { useTableConfig } from '../../context/table-config-context'
 import { useTableInstance } from '../../context/table-instance-context'
 import { useViewMetadata } from '../../context/view-metadata-context'
 import { useDynamicTableStore } from '../../stores/dynamic-table-store'
-import { useSetFilters } from '../../stores/store-actions'
+import { useSetFilters, useSetSorting } from '../../stores/store-actions'
 import {
   useActiveView,
   useActiveViewId,
@@ -53,6 +53,7 @@ import { ColumnManager } from './column-manager'
 import { KanbanViewSettings } from './kanban-view-settings'
 import { RecordsGuideDialog } from './records-guide-dialog'
 import { TableFilterBuilder } from './table-filter-builder'
+import { TableSortBuilder } from './table-sort-builder'
 import { ViewSelector } from './view-selector'
 
 interface TableToolbarProps {
@@ -90,6 +91,7 @@ export function TableToolbar<TData = any>({
     tableId,
     entityDefinitionId,
     enableFiltering = true,
+    enableSorting = true,
     enableSearch = true,
     renderSearch,
     enableImport = false,
@@ -108,10 +110,11 @@ export function TableToolbar<TData = any>({
   const currentView = useActiveView(tableId)
   const filters = useTableFilters(tableId)
   const setFilters = useSetFilters(tableId)
+  const setSorting = useSetSorting(tableId)
   const setActiveView = useDynamicTableStore((state) => state.setActiveView)
 
-  // Get filterable fields from resource system
-  const { filterableFields } = useResourceFields(entityDefinitionId ?? null)
+  // Get filterable + sortable fields from resource system
+  const { filterableFields, sortableFields } = useResourceFields(entityDefinitionId ?? null)
 
   // Determine view type
   const viewType: ViewType = (currentView?.config as ViewConfig)?.viewType ?? 'table'
@@ -133,7 +136,7 @@ export function TableToolbar<TData = any>({
   // Records help guide
   const [guideOpen, setGuideOpen] = useState(false)
 
-  // CSV export
+  // CSV export — `sorting` is also what the Sort control reads and writes.
   const activeViewId = useActiveViewId(tableId)
   const sorting = useTableSorting(tableId)
   const { viewColumns, allColumns } = useExportColumns(tableId, entityDefinitionId)
@@ -232,6 +235,25 @@ export function TableToolbar<TData = any>({
             filters={filters}
             onFiltersChange={setFilters}
             filterableFields={filterableFields}
+            resourceType={entityDefinitionId}
+          />
+        </div>
+      )}
+
+      {/* Sort Button — deliberately its own control rather than a section of the
+          filter popover: that one is a buffered draft that commits on close,
+          while sorting applies immediately (as the column header does).
+
+          Shown for kanban and calendar too. `DynamicResourceView` passes the
+          view's sorting to `useRecordList` whatever the view type, so a sort set
+          on the table keeps applying there — and those two render no column
+          headers at all, which would leave it invisible and unclearable. */}
+      {enableSorting && entityDefinitionId && (
+        <div className='group-data-[search-expanded]/toolbar:hidden'>
+          <TableSortBuilder
+            sorting={sorting}
+            onSortingChange={setSorting}
+            sortableFields={sortableFields}
             resourceType={entityDefinitionId}
           />
         </div>

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/table-sort-builder.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/table-sort-builder.tsx
@@ -1,0 +1,196 @@
+// apps/web/src/components/dynamic-table/components/table-toolbar/table-sort-builder.tsx
+
+'use client'
+
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { toFieldId, toResourceFieldId } from '@auxx/types/field'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { cn } from '@auxx/ui/lib/utils'
+import type { SortingState } from '@tanstack/react-table'
+import { ArrowDown, ArrowDownUp, ArrowUp, TriangleAlert } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { type FieldDefinition, ResourceFieldSelector } from '~/components/conditions'
+import { Tooltip } from '~/components/global/tooltip'
+import { getSortOptionsForFieldType } from '../../utils/constants'
+
+interface TableSortBuilderProps {
+  /** Current sorting from the view/session config. */
+  sorting: SortingState
+  onSortingChange: (sorting: SortingState) => void
+  /** The resource's sortable fields, before this component's own eligibility pass. */
+  sortableFields: ResourceField[]
+  /** entityDefinitionId — used to build the ResourceFieldId a sort is keyed by. */
+  resourceType: string
+  disabled?: boolean
+}
+
+/**
+ * The toolbar's Sort control.
+ *
+ * Exists because the column header was the ONLY way to sort — `header-cell.tsx`
+ * holds the sole `toggleSorting` call site — which coupled sorting to column
+ * visibility in two bad ways: you could not sort by a field without also
+ * putting it on screen as a column, and a sort whose column you later hid kept
+ * applying server-side with no way to see or clear it.
+ *
+ * Single sort by design. The whole stack carries `sorting` as an array, but both
+ * query lanes read `sorting[0]` and drop the rest, so offering more here would
+ * only make an existing silent truncation visible.
+ *
+ * Applies IMMEDIATELY, unlike the sibling filter popover's buffered draft —
+ * the column header applies instantly, and two sort entry points that commit at
+ * different moments would be worse than either behaviour on its own.
+ */
+export function TableSortBuilder({
+  sorting,
+  onSortingChange,
+  sortableFields,
+  resourceType,
+  disabled = false,
+}: TableSortBuilderProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  // Only offer what the server will actually apply. `buildOrderBySql` returns
+  // `undefined` for a non-sortable or hidden field, and the list then falls back
+  // to its default order — so an ineligible option here would look like it did
+  // nothing. Mirrors the column factory's `enableSorting` plus the `hidden`
+  // rule, which the shared `sortableFields` selector does not apply.
+  const eligibleFields = useMemo(
+    () =>
+      sortableFields.filter(
+        (field) =>
+          field.active !== false &&
+          !field.capabilities?.hidden &&
+          field.fieldType !== 'RELATIONSHIP'
+      ),
+    [sortableFields]
+  )
+
+  /** A sort is keyed by the column id, which is always a ResourceFieldId. */
+  const fieldSortId = useCallback(
+    (field: ResourceField): string =>
+      field.resourceFieldId ?? toResourceFieldId(resourceType, toFieldId(field.id as string)),
+    [resourceType]
+  )
+
+  const fieldDefinitions: FieldDefinition[] = useMemo(
+    () =>
+      eligibleFields.map((field) => ({
+        id: fieldSortId(field),
+        label: field.label,
+        type: field.type,
+        fieldType: field.fieldType,
+        fieldKey: field.key,
+      })),
+    [eligibleFields, fieldSortId]
+  )
+
+  const active = sorting[0]
+  const activeField = active
+    ? eligibleFields.find((field) => fieldSortId(field) === active.id)
+    : undefined
+
+  // A sort naming a field that is gone, hidden, or no longer sortable. It is
+  // still being sent, and the list silently falls back to its default order —
+  // so say so and offer the way out rather than rendering a blank picker.
+  const isOrphanedSort = !!active && !activeField
+
+  const directionOptions = getSortOptionsForFieldType(activeField?.fieldType)
+
+  const TriggerIcon = activeField ? (active!.desc ? ArrowDown : ArrowUp) : ArrowDownUp
+
+  const handleFieldChange = useCallback(
+    (fieldId: string) => {
+      // Keep the current direction when swapping fields; default to ascending.
+      onSortingChange([{ id: fieldId, desc: active?.desc ?? false }])
+    },
+    [onSortingChange, active?.desc]
+  )
+
+  const handleDirection = useCallback(
+    (desc: boolean) => {
+      if (!active) return
+      onSortingChange([{ id: active.id, desc }])
+    },
+    [onSortingChange, active]
+  )
+
+  const handleClear = useCallback(() => {
+    onSortingChange([])
+    setIsOpen(false)
+  }, [onSortingChange])
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <div>
+          <Tooltip content={activeField ? `Sorted by ${activeField.label}` : 'Sort rows'}>
+            <Button variant='ghost' size='sm' disabled={disabled}>
+              {/* The label stays 'Sort' at every width — a field name in the
+                  toolbar gets long fast. The active sort shows as the direction
+                  arrow (zero extra width) with the field named in the tooltip;
+                  without some indicator, a sort set here and then left behind is
+                  exactly the invisible state this control exists to end. */}
+              <TriggerIcon />
+              <span className='hidden @lg/controls:block'>Sort</span>
+            </Button>
+          </Tooltip>
+        </div>
+      </PopoverTrigger>
+
+      <PopoverContent className='w-[260px] p-2' align='start'>
+        <div className='space-y-2'>
+          {isOrphanedSort && (
+            <div className='flex items-start gap-1.5 rounded-md bg-muted px-2 py-1.5 text-xs text-muted-foreground'>
+              <TriangleAlert className='mt-0.5 size-3.5 shrink-0' />
+              <span>
+                This view sorts by a field that is no longer available, so it is not being applied.
+              </span>
+            </div>
+          )}
+
+          <div className='px-1'>
+            <ResourceFieldSelector
+              value={activeField ? active!.id : ''}
+              onChange={handleFieldChange}
+              availableFields={fieldDefinitions}
+              placeholder='Select a field to sort by'
+              disabled={disabled}
+            />
+          </div>
+
+          {activeField && (
+            <div className='flex flex-col'>
+              {directionOptions.map((option) => {
+                const OptionIcon = option.icon
+                const isActive = active!.desc === (option.value === 'desc')
+                return (
+                  <Button
+                    key={option.value}
+                    variant='ghost'
+                    size='sm'
+                    className={cn('justify-start', isActive && 'bg-accent')}
+                    onClick={() => handleDirection(option.value === 'desc')}>
+                    <OptionIcon />
+                    {option.label}
+                  </Button>
+                )
+              })}
+            </div>
+          )}
+
+          {active && (
+            <Button
+              variant='ghost'
+              size='sm'
+              className='w-full justify-start'
+              onClick={handleClear}>
+              Clear sort
+            </Button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}


### PR DESCRIPTION
`header-cell.tsx` held the **only** `toggleSorting` call site in the codebase. That coupled sorting to column visibility in two ways:

- You could not sort by a field without also putting it on screen as a column. Sorting by created date meant showing a Created column.
- A sort whose column you later hid **kept applying server-side** — sorting lives in the view config, independent of `columnVisibility` — with the header gone and no other way to see or clear it. Silent, sticky, invisible.

Kanban and calendar had it worse. `DynamicResourceView` passes the view's sorting to `useRecordList` whatever the view type, and neither renders a column header at all, so a sort set on the table kept applying there with no affordance anywhere. The control is shown for all three view types for that reason.

## What it is

A `Sort` button beside `Filter`, opening a popover with:

- the **existing field picker** — `ResourceFieldSelector`, the same component the filter builder's condition rows use, so a field looks and searches the same wherever you pick one
- a direction toggle whose labels come from `getSortOptionsForFieldType`, so they read identically to the column header's menu ("A → Z" for text, "Oldest → Newest" for dates)
- Clear sort

**Single sort.** The stack carries `sorting` as an array, but both query lanes read `sorting[0]` and drop the rest, so offering more here would only make an existing silent truncation visible. Left a note at the call site so nobody builds multi-sort on top of `[0]` by accident.

**Applies immediately**, unlike the sibling filter popover's buffered draft. The column header applies instantly, and two sort entry points committing at different moments is worse than either behaviour on its own. Both write through `useSetSorting`, which is the same state `useDynamicTable` feeds to TanStack — so the header's sort indicator stays in sync with the popover.

## Two things not obvious from the diff

**Eligibility is stricter than the shared `sortableFields` selector**, which checks only `capabilities.sortable`. Hidden, inactive and `RELATIONSHIP` fields are also excluded, because `buildOrderBySql` returns `undefined` for those and the list falls back to its default order — offering them would look like the option did nothing.

**An orphaned sort is now named and clearable.** A sort pointing at a field that is gone, hidden, or no longer sortable says *"this view sorts by a field that is no longer available, so it is not being applied"* and offers Clear. That state was previously unreachable — you could neither see it nor fix it.

## UI notes

The trigger reads `Sort` at every width (a field name in the toolbar gets long fast). An active sort shows as the direction arrow — zero extra width — with the field named in the tooltip.

## Verification

- `@auxx/web` typecheck clean, Biome clean
- 109 tests pass across `src/components/dynamic-table` and `src/components/records`
- Not visually reviewed in a browser yet — popover spacing is the part worth a look

## Follow-up not in this PR

The remaining half of the silent-sort problem: when a sort cannot compile, the list falls back to its default order with no signal *on the list itself*. This PR surfaces it in the Sort popover, which is where someone would go looking, but a list-level notice (the way `DroppedFiltersNotice` reports dropped filters) is still unwritten. Note that `unified-handler-queries.ts` currently argues the opposite — *"There is deliberately no drop reporting for sorts: an unsorted list is visibly odd, unlike a widened one"* — which was truer when the fallback was random cuid order than it is now that it is `createdAt DESC`.