### PR TITLE
fix(purchasing): read a PO's lines from the list lane, not the inverse mirror

### DIFF
--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -123,6 +123,9 @@ import {
 import {
   type DocumentType,
   diffLineValues,
+  documentLineFilters,
+  LINE_PAGE_SIZE,
+  LINE_SORT,
   type LinePatch,
   type LineValues,
   lineAttributesFor,
@@ -160,10 +163,7 @@ export interface LineBuilderProps {
   renderMatchKeyEditor?: MatchKeyEditorRenderer
 }
 
-const PAGE_SIZE = 100
 const INITIAL_DRAFT_COUNT = 3
-/** Stable sort ref — `useRecordList` keys its cache off this object. */
-const LINE_SORT = [{ id: 'sortOrder', desc: false }]
 /** Every fixed line-builder field is visible to the shared syncer. */
 const LINE_FIELD_VISIBILITY = {}
 
@@ -313,52 +313,15 @@ export function LineBuilder({
   // race two `record.create` calls for the same draft before React re-renders.
   const creatingDraftIdsRef = useRef<Set<string>>(new Set())
 
-  // Baseline filter: lines belonging to this document, via the belongs_to rel
-  // (`contact-tickets-tab.tsx` precedent — `operator: 'is'` + the RecordId;
-  // the server strips the def prefix). Invoice mode ALSO excludes work-order source
-  // lines stamped with `line_item_invoice` (the gather "invoiced by" pointer, money
-  // MI1 build spec §B.3/§J.2) — only the invoice's own copies (workOrder empty) show.
-  // work_order mode ALSO splits on `line_item_visitId` (plain-text bridge, dispatch lock):
-  // a `visitId` prop → only that visit's occurrence extras; no prop → only the job's
-  // per-cycle set (visitId empty), so extras never leak into the job Line-items tab.
-  const filters = useMemo<ConditionGroup[]>(() => {
-    const conditions: ConditionGroup['conditions'] = [
-      {
-        id: 'line-builder-document',
-        // The order and purchasing arms are the plainest: no work-order exclusion
-        // (that invariant is about an invoice's own lines) and no visit split.
-        fieldId: schema.relFieldId,
-        operator: 'is',
-        value: documentRecordId,
-      },
-    ]
-    if (schema.capabilities.excludeWorkOrderSourceLines) {
-      conditions.push({
-        id: 'line-builder-invoice-workorder',
-        fieldId: 'line_item:workOrder',
-        operator: 'empty',
-        value: null,
-      })
-    }
-    if (schema.capabilities.visitScoped) {
-      conditions.push(
-        visitId
-          ? {
-              id: 'line-builder-visit',
-              fieldId: 'line_item:visitId',
-              operator: 'is',
-              value: visitId,
-            }
-          : {
-              id: 'line-builder-visit',
-              fieldId: 'line_item:visitId',
-              operator: 'empty',
-              value: null,
-            }
-      )
-    }
-    return [{ id: 'line-builder-baseline', logicalOperator: 'AND', conditions }]
-  }, [schema, documentRecordId, visitId])
+  // The baseline filter is built by `documentLineFilters` in `line-values.ts`,
+  // NOT inline here: the condition ids are part of `createListKey`'s hash, so a
+  // second reader of these same rows must construct them identically or it lands
+  // on a private list cache that no optimistic append ever reaches. See that
+  // function's own note.
+  const filters = useMemo<ConditionGroup[]>(
+    () => documentLineFilters(schema, documentRecordId, visitId),
+    [schema, documentRecordId, visitId]
+  )
 
   const {
     records,
@@ -374,7 +337,7 @@ export function LineBuilder({
     entityDefinitionId: entityDefinitionId ?? '',
     filters,
     sorting: LINE_SORT,
-    limit: PAGE_SIZE,
+    limit: LINE_PAGE_SIZE,
     enabled: !!entityDefinitionId,
   })
 

--- a/apps/web/src/components/money/ui/line-builder/line-values.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-values.ts
@@ -2,6 +2,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeValue } from '@auxx/database/types'
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { computeLineTotal, type LineItemUnit, roundCents } from '@auxx/lib/money/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 
@@ -484,6 +485,78 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
 }
 
 /** The schema for one document type. */
+/**
+ * The baseline filter selecting one document's lines — the SINGLE construction
+ * site, used by both `LineBuilder` and any card that lists the same rows.
+ *
+ * Lines belonging to this document, via the belongs_to rel
+ * (`contact-tickets-tab.tsx` precedent — `operator: 'is'` + the RecordId; the
+ * server strips the def prefix). Invoice mode ALSO excludes work-order source
+ * lines stamped with `line_item_invoice` (the gather "invoiced by" pointer, money
+ * MI1 build spec §B.3/§J.2) — only the invoice's own copies (workOrder empty) show.
+ * work_order mode ALSO splits on `line_item_visitId` (plain-text bridge, dispatch
+ * lock): a `visitId` → only that visit's occurrence extras; none → only the job's
+ * per-cycle set (visitId empty), so extras never leak into the job Line-items tab.
+ *
+ * 🛑 It is a shared FUNCTION and not a per-caller literal for a reason that is
+ * invisible at the call site: `createListKey` hashes `JSON.stringify(filters)`,
+ * so the condition `id` STRINGS are part of the cache key. Two components asking
+ * for the same rows with different ids land on two different `lists[...]` entries
+ * — and `appendCreatedRecord(key, id)` patches only the ONE key that created the
+ * record, while the acting tab is excluded from its own `record:created` frame.
+ * The second list then never learns about the new row until a reload. Hand-rolling
+ * this literal per caller is exactly how that happens, so don't.
+ */
+export function documentLineFilters(
+  schema: LineSchema,
+  documentRecordId: string,
+  visitId?: string | null
+): ConditionGroup[] {
+  const conditions: ConditionGroup['conditions'] = [
+    {
+      id: 'line-builder-document',
+      // The order and purchasing arms are the plainest: no work-order exclusion
+      // (that invariant is about an invoice's own lines) and no visit split.
+      fieldId: schema.relFieldId,
+      operator: 'is',
+      value: documentRecordId,
+    },
+  ]
+  if (schema.capabilities.excludeWorkOrderSourceLines) {
+    conditions.push({
+      id: 'line-builder-invoice-workorder',
+      fieldId: 'line_item:workOrder',
+      operator: 'empty',
+      value: null,
+    })
+  }
+  if (schema.capabilities.visitScoped) {
+    conditions.push(
+      visitId
+        ? { id: 'line-builder-visit', fieldId: 'line_item:visitId', operator: 'is', value: visitId }
+        : {
+            id: 'line-builder-visit',
+            fieldId: 'line_item:visitId',
+            operator: 'empty',
+            value: null,
+          }
+    )
+  }
+  return [{ id: 'line-builder-baseline', logicalOperator: 'AND', conditions }]
+}
+
+/**
+ * Page size every caller of {@link documentLineFilters} must share.
+ *
+ * `limit` rides on `useRecordList`'s tRPC query input, so a second reader that
+ * pages differently gets a different React Query entry even when the store
+ * `listKey` matches — half-shared, which is worse than either.
+ */
+export const LINE_PAGE_SIZE = 100
+
+/** Stable sort ref shared by every line reader — see {@link LINE_PAGE_SIZE}. */
+export const LINE_SORT = [{ id: 'sortOrder', desc: false }]
+
 export function lineSchemaFor(documentType: DocumentType): LineSchema {
   return LINE_SCHEMAS[documentType]
 }

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
@@ -11,14 +11,19 @@
 // over `stock_movement` (`purchasing-hooks.ts`), so it is already maintained; nothing
 // had ever read it back.
 //
+// 🛑 The line set comes from `usePurchaseOrderLines`, the shared read the picker
+// and the bill-lines action already use. It used to be a second, hand-rolled copy
+// of that read off the PO's `purchase_order_lines` inverse — which is the mirror
+// lane, and the mirror is never published (see the hook's own note, and B-9/D-11
+// in `plans/events/`). A line added from the Lines card in this same drawer
+// therefore never appeared here until the page was reloaded.
+//
 // The card's header action is the **Receive** dialog — the whole order in one pass,
 // everything prefilled as if it all arrived. That is deliberately the door here
 // rather than the part-first popover: a part-first receipt sets no
 // `purchaseOrderLineId`, so it moves quantity on hand without ever moving the
 // numbers this card renders.
 
-import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
-import type { RecordId } from '@auxx/types/resource'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { TreeRow } from '@auxx/ui/components/tree-row'
@@ -34,60 +39,16 @@ import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { useOpenRecord } from '~/components/records/record-drill-panels'
 import { useRecord } from '~/components/resources'
-import { useSystemValues } from '~/components/resources/hooks/use-system-values'
-import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
-import {
-  formatQuantity,
-  numberValue,
-  PurchasingSummaryStrip,
-  unwrapValue,
-} from '../purchasing-summary-strip'
+import { formatQuantity, PurchasingSummaryStrip } from '../purchasing-summary-strip'
 import { ReceivePurchaseOrderDialog } from './receive-purchase-order-dialog'
-
-const PO_ATTRS = ['purchase_order_lines'] as const
-
-const LINE_ATTRS = [
-  'purchase_order_line_part',
-  'purchase_order_line_description',
-  'purchase_order_line_quantity_ordered',
-  'purchase_order_line_quantity_received',
-] as const
+import { type PurchaseOrderLineRow, usePurchaseOrderLines } from './use-purchase-order-lines'
 
 /** How many lines render before the inline "Show more" row collapses the rest. */
 const LINE_PREVIEW_LIMIT = 6
 
-interface ReceivingLine {
-  lineRecordId: RecordId
-  partRecordId: RecordId | undefined
-  description: string | null
-  ordered: number
-  received: number
-}
-
 export function PurchaseOrderReceivingCard({ recordId }: DrawerTabProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
-  const { values, isLoading: linesLoading } = useSystemValues(recordId, [...PO_ATTRS], {
-    autoFetch: true,
-  })
-  const lineRecordIds = extractRelationshipRecordIds(values.purchase_order_lines)
-
-  const { valuesById, isLoading: valuesLoading } = useSystemValuesForRecords(
-    lineRecordIds,
-    LINE_ATTRS,
-    { autoFetch: true, enabled: lineRecordIds.length > 0 }
-  )
-
-  const lines: ReceivingLine[] = lineRecordIds.map((lineRecordId) => {
-    const lineValues = valuesById[lineRecordId] ?? ({} as Record<string, unknown>)
-    const description = unwrapValue(lineValues.purchase_order_line_description)
-    return {
-      lineRecordId,
-      partRecordId: extractRelationshipRecordIds(lineValues.purchase_order_line_part)[0],
-      description: typeof description === 'string' && description ? description : null,
-      ordered: numberValue(lineValues.purchase_order_line_quantity_ordered),
-      received: numberValue(lineValues.purchase_order_line_quantity_received),
-    }
-  })
+  const { lines, isLoading: loading } = usePurchaseOrderLines(recordId)
 
   const ordered = lines.reduce((sum, line) => sum + line.ordered, 0)
   const received = lines.reduce((sum, line) => sum + line.received, 0)
@@ -98,9 +59,8 @@ export function PurchaseOrderReceivingCard({ recordId }: DrawerTabProps) {
     0
   )
 
-  const loading = linesLoading || (lineRecordIds.length > 0 && valuesLoading)
   if (loading) return <RowSkeleton />
-  if (lineRecordIds.length === 0) return <EmptyRow label='No lines yet' />
+  if (lines.length === 0) return <EmptyRow label='No lines yet' />
 
   return (
     <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
@@ -140,7 +100,7 @@ export function PurchaseOrderReceivingCard({ recordId }: DrawerTabProps) {
   )
 }
 
-function ReceivingLineRow({ line }: { line: ReceivingLine }) {
+function ReceivingLineRow({ line }: { line: PurchaseOrderLineRow }) {
   const openRecord = useOpenRecord()
   const { record } = useRecord({ recordId: line.partRecordId!, enabled: !!line.partRecordId })
 
@@ -171,7 +131,7 @@ function ReceivingLineRow({ line }: { line: ReceivingLine }) {
  * a real condition on the floor (a vendor shipped more than was ordered) and the
  * three-way match will raise it, so hiding it here would contradict the match card.
  */
-function receivingProgress(line: ReceivingLine): { label: string; variant: Variant } {
+function receivingProgress(line: PurchaseOrderLineRow): { label: string; variant: Variant } {
   const qty = `${formatQuantity(line.received)} / ${formatQuantity(line.ordered)}`
   if (line.received > line.ordered) return { label: `${qty} over`, variant: 'amber' }
   if (line.ordered > 0 && line.received >= line.ordered) return { label: qty, variant: 'green' }

--- a/apps/web/src/components/purchasing/purchase-order/receive-purchase-order-dialog.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/receive-purchase-order-dialog.tsx
@@ -15,9 +15,18 @@
 // Everything here is prefilled on the assumption the whole order arrived: each
 // row's quantity is what is OUTSTANDING and each price is what was agreed. The
 // common case is therefore Receive, with no typing at all.
+//
+// 🛑 The line set comes from `usePurchaseOrderLines` — the LIST lane — and here
+// that is a correctness requirement, not a freshness nicety. This dialog does not
+// merely display the lines: `buildReceivePoInput` turns them into the write. Read
+// off the PO's `purchase_order_lines` inverse (as this did), a line added earlier
+// in the same session is simply absent from the mirror — the fetch queue skips a
+// key already in the store, so not even reopening the dialog repairs it — and the
+// receipt is then built from a short line set. Nothing throws: the order reports
+// received and the missing line silently sits at `0 / n`. See the hook's own note
+// and B-9/D-11 in `plans/events/`.
 
 import { FieldType } from '@auxx/database/enums'
-import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import type { RecordId } from '@auxx/types/resource'
 import { getInstanceId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
@@ -42,7 +51,6 @@ import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapte
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useRecord } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
-import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 import { BaseType } from '~/components/workflow/types'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
@@ -63,25 +71,18 @@ import {
   type ReceivablePoLine,
   receiptSubtotal,
 } from './receive-po-lines'
+import { usePurchaseOrderLines } from './use-purchase-order-lines'
 
+// The PO's OWN fields — written on the PO and published normally, so
+// `useSystemValues` is the right read for them. `purchase_order_lines` is not
+// here on purpose; see the note above.
 const PO_ATTRS = [
-  'purchase_order_lines',
   'purchase_order_shipping_total',
   'purchase_order_tax_total',
   'purchase_order_discount_value',
   'purchase_order_tax_recoverable',
   'purchase_order_allocation_basis',
   'purchase_order_currency',
-] as const
-
-const LINE_ATTRS = [
-  'purchase_order_line_part',
-  'purchase_order_line_description',
-  'purchase_order_line_quantity_ordered',
-  'purchase_order_line_quantity_received',
-  'purchase_order_line_expected_unit_price',
-  'purchase_order_line_vendor_part',
-  'purchase_order_line_weight',
 ] as const
 
 interface ReceivePurchaseOrderDialogProps {
@@ -102,12 +103,10 @@ export function ReceivePurchaseOrderDialog({
   const { values, isLoading: poLoading } = useSystemValues(purchaseOrderRecordId, [...PO_ATTRS], {
     autoFetch: true,
   })
-  const lineRecordIds = extractRelationshipRecordIds(values.purchase_order_lines)
-  const { valuesById, isLoading: linesLoading } = useSystemValuesForRecords(
-    lineRecordIds,
-    LINE_ATTRS,
-    { autoFetch: true, enabled: open && lineRecordIds.length > 0 }
-  )
+  // Same hook the Receiving card behind this dialog uses, so both resolve one
+  // line set from one fetch — the card and the receipt can never disagree about
+  // what is on the order.
+  const { lines: poLines, isLoading: linesLoading } = usePurchaseOrderLines(purchaseOrderRecordId)
 
   const currencyValue = unwrapValue(values.purchase_order_currency)
   const currencyCode =
@@ -122,29 +121,26 @@ export function ReceivePurchaseOrderDialog({
   // rather than as a UI-only field bolted onto the payload type.
   const { lines, partRecordIds } = useMemo(() => {
     const partRecordIds: Record<string, RecordId | undefined> = {}
-    const lines: ReceivablePoLine[] = lineRecordIds.map((lineRecordId) => {
-      const line = valuesById[lineRecordId] ?? ({} as Record<string, unknown>)
-      const partRecordId = extractRelationshipRecordIds(line.purchase_order_line_part)[0]
-      const vendorPartRecordId = extractRelationshipRecordIds(
-        line.purchase_order_line_vendor_part
-      )[0]
-      const description = unwrapValue(line.purchase_order_line_description)
-      const weight = numberValue(line.purchase_order_line_weight)
-      const purchaseOrderLineId = getInstanceId(lineRecordId)
-      partRecordIds[purchaseOrderLineId] = partRecordId
+    const lines: ReceivablePoLine[] = poLines.map((line) => {
+      const purchaseOrderLineId = getInstanceId(line.lineRecordId)
+      partRecordIds[purchaseOrderLineId] = line.partRecordId ?? undefined
       return {
         purchaseOrderLineId,
-        partId: partRecordId ? getInstanceId(partRecordId) : '',
-        description: typeof description === 'string' && description ? description : null,
-        quantityOrdered: numberValue(line.purchase_order_line_quantity_ordered),
-        quantityReceived: numberValue(line.purchase_order_line_quantity_received),
-        expectedUnitPrice: numberValue(line.purchase_order_line_expected_unit_price),
-        ...(vendorPartRecordId ? { vendorPartId: getInstanceId(vendorPartRecordId) } : {}),
-        ...(weight > 0 ? { weight } : {}),
+        partId: line.partRecordId ? getInstanceId(line.partRecordId) : '',
+        description: line.description,
+        quantityOrdered: line.ordered,
+        quantityReceived: line.received,
+        expectedUnitPrice: line.expectedUnitPrice,
+        // Spread-or-omit, not `undefined`: both are optional on the server
+        // payload and an explicit `undefined` is a different shape.
+        ...(line.vendorPartRecordId
+          ? { vendorPartId: getInstanceId(line.vendorPartRecordId) }
+          : {}),
+        ...(line.weight > 0 ? { weight: line.weight } : {}),
       }
     })
     return { lines, partRecordIds }
-  }, [lineRecordIds, valuesById])
+  }, [poLines])
 
   const basisValue = unwrapValue(values.purchase_order_allocation_basis)
   const header: ReceiptHeader = {
@@ -206,7 +202,7 @@ export function ReceivePurchaseOrderDialog({
     }
   }
 
-  const isLoading = poLoading || (lineRecordIds.length > 0 && linesLoading)
+  const isLoading = poLoading || linesLoading
   const receivingCount = payload?.lines.length ?? 0
 
   // The header amounts are the freight-allocation inputs (§4.3) — shown so the

--- a/apps/web/src/components/purchasing/purchase-order/use-purchase-order-lines.ts
+++ b/apps/web/src/components/purchasing/purchase-order/use-purchase-order-lines.ts
@@ -8,21 +8,48 @@
 // "Add lines from the order" on the bill (plans/purchasing/02-handoff.md §4 item
 // 3c). The two readings must agree: the picker offers a line and the button
 // creates one, and a line that is billable by one rule and not the other is a
-// contradiction the user sees as a bug.
+// contradiction the user sees as a bug. The Receiving card is the third caller,
+// and folding it in here is what retired its own hand-rolled copy of this read.
 //
-// 🛑 No query, by design. `purchase_order_lines` is the PO's own inverse
-// relationship, so scoping is a FIELD READ off the order — the same reasoning
-// that kept the picker off `record.search`, whose input schema takes no
-// conditions and would offer every purchase order line in the org.
+// 🛑 Membership comes from `useRecordList`, NOT from the PO's
+// `purchase_order_lines` inverse. Those are two lanes over the same rows and
+// only one of them is live:
+//
+//   - the LIST lane (here) is the server's answer to a filtered query, kept
+//     current by optimistic membership writes (`appendCreated` / `removeFromList`
+//     on the acting tab) and by the `record:created` → `invalidateLists` frame
+//     everywhere else;
+//   - the INVERSE MIRROR lane reads a second copy of the relationship, written
+//     on the PARENT by raw SQL in `field-values/relationship-sync.ts` — which
+//     publishes nothing at all. A line added while a card is mounted never
+//     reaches it, and `field-value-fetch-queue` skips any key already in the
+//     store, so not even a remount repairs it: only a page reload does. That is
+//     B-9/D-11 in `plans/events/`, an open defect, and it is why this hook used
+//     to go stale.
+//
+// `LineBuilder` has been on the list lane since #1918 with the identical filter,
+// so a PO drawer mixing the two showed its Lines card updating live and its
+// Receiving card frozen — same rows, same drawer, two answers.
+//
+// The filter reuses `LINE_SCHEMAS`' own `relFieldId` rather than restating
+// `'purchase_order_line:purchaseOrder'` here. That table is the single place a
+// document's line wiring is declared, and its own warning says why: "three
+// hand-copied copies is how the read prefix and the write prefix drift apart."
 
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
-import type { RecordId } from '@auxx/types/resource'
-import { useMemo } from 'react'
-import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useEffect, useMemo } from 'react'
+import {
+  documentLineFilters,
+  LINE_PAGE_SIZE,
+  LINE_SORT,
+  lineSchemaFor,
+} from '~/components/money/ui/line-builder/line-values'
+import { type RecordId, toRecordId, useRecordList, useResource } from '~/components/resources'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 import { numberValue, unwrapValue } from '../purchasing-summary-strip'
 
-const PO_ATTRS = ['purchase_order_lines'] as const
+const PO_LINE_SCHEMA = lineSchemaFor('purchase_order')
 
 const LINE_ATTRS = [
   'purchase_order_line_part',
@@ -31,9 +58,15 @@ const LINE_ATTRS = [
   'purchase_order_line_quantity_received',
   'purchase_order_line_quantity_billed',
   'purchase_order_line_expected_unit_price',
+  // Read for the receipt dialog's landed-cost allocation. Carried on the shared
+  // row rather than fetched separately so the dialog and the cards resolve one
+  // line set — the dialog BUILDS A WRITE from these rows, so a second read that
+  // could disagree is worse here than anywhere else.
+  'purchase_order_line_vendor_part',
+  'purchase_order_line_weight',
 ] as const
 
-/** One purchase order line, as both the picker and the bill-lines action read it. */
+/** One purchase order line, as all three callers read it. */
 export interface PurchaseOrderLineRow {
   lineRecordId: RecordId
   /** `null` on a line whose part was never set — legal on a draft, not on a create. */
@@ -46,6 +79,10 @@ export interface PurchaseOrderLineRow {
   billed: number
   /** Integer minor units — the agreed price, and the price arm of the match. */
   expectedUnitPrice: number
+  /** `null` unless the line was priced off a specific vendor part. */
+  vendorPartRecordId: RecordId | null
+  /** Shipping weight for the whole line; read only by the `weight` basis. */
+  weight: number
 }
 
 /**
@@ -59,12 +96,44 @@ export function usePurchaseOrderLines(purchaseOrderRecordId: RecordId | null): {
   lines: PurchaseOrderLineRow[]
   isLoading: boolean
 } {
-  const { values, isLoading: linesLoading } = useSystemValues(
-    purchaseOrderRecordId,
-    [...PO_ATTRS],
-    { autoFetch: true, enabled: !!purchaseOrderRecordId }
+  const { resource } = useResource(PO_LINE_SCHEMA.slug)
+  const entityDefinitionId = resource?.id
+
+  // 🛑 Built by `documentLineFilters`, the same call the line builder makes, and
+  // that sharing is load-bearing rather than tidy. `createListKey` hashes
+  // `JSON.stringify(filters)`, so the condition ID STRINGS decide which
+  // `lists[...]` entry this read subscribes to. An equivalent filter written by
+  // hand here — same field, same operator, different ids — produces a DIFFERENT
+  // key, and `appendCreatedRecord(key, id)` only ever patches the one key that
+  // created the record while the acting tab is excluded from its own
+  // `record:created` frame. The card would then be just as stale as it was on the
+  // inverse mirror, for a completely different reason. Identical filters +
+  // identical sorting + identical limit is what puts this card on the builder's
+  // cache entry, which is the entry that gets the optimistic append.
+  const filters = useMemo<ConditionGroup[]>(
+    () => documentLineFilters(PO_LINE_SCHEMA, purchaseOrderRecordId ?? ''),
+    [purchaseOrderRecordId]
   )
-  const lineRecordIds = extractRelationshipRecordIds(values.purchase_order_lines)
+
+  const { recordIds, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } = useRecordList({
+    entityDefinitionId: entityDefinitionId ?? '',
+    filters,
+    sorting: LINE_SORT,
+    limit: LINE_PAGE_SIZE,
+    enabled: !!entityDefinitionId && !!purchaseOrderRecordId,
+  })
+
+  // Load every page rather than the first. A silently truncated set here would
+  // read as "the order has 100 lines" to the picker and to the receiving totals,
+  // which is worse than slow — same reasoning (and same shape) as the builder's.
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage && !isLoading) fetchNextPage()
+  }, [hasNextPage, isFetchingNextPage, isLoading, fetchNextPage])
+
+  const lineRecordIds = useMemo(
+    () => (entityDefinitionId ? recordIds.map((id) => toRecordId(entityDefinitionId, id)) : []),
+    [entityDefinitionId, recordIds]
+  )
 
   const { valuesById, isLoading: valuesLoading } = useSystemValuesForRecords(
     lineRecordIds,
@@ -85,10 +154,13 @@ export function usePurchaseOrderLines(purchaseOrderRecordId: RecordId | null): {
           received: numberValue(v.purchase_order_line_quantity_received),
           billed: numberValue(v.purchase_order_line_quantity_billed),
           expectedUnitPrice: numberValue(v.purchase_order_line_expected_unit_price),
+          vendorPartRecordId:
+            extractRelationshipRecordIds(v.purchase_order_line_vendor_part)[0] ?? null,
+          weight: numberValue(v.purchase_order_line_weight),
         }
       }),
     [lineRecordIds, valuesById]
   )
 
-  return { lines, isLoading: linesLoading || (lineRecordIds.length > 0 && valuesLoading) }
+  return { lines, isLoading: isLoading || (lineRecordIds.length > 0 && valuesLoading) }
 }


### PR DESCRIPTION
The Receiving card never showed a line added from the Lines card in the same drawer. Only a page reload brought it in, while the Bills card updated instantly — which is what made it look like a purchasing bug.

## What it actually is

A relationship is stored **twice**: once on the child (`purchase_order_line.purchase_order`) and once as a mirror on the parent (`purchase_order_lines`). The parent's copy is written by raw SQL in `field-values/relationship-sync.ts`, which **publishes nothing** — it computes the exact `{removedFrom, addedTo}` diff and no caller anywhere consumes it (grep returns zero non-test hits). The client's cached copy of that array is stale from the moment a child is created, and `field-value-fetch-queue.ts:241` skips a key already in the store, so not even a remount repairs it.

This is already filed: **B-9 / D-11** in `plans/events/`, with a door-matrix row (`inverseRelationshipVisibility`, `interactive: 'per-record'`) that `door-conformance.test.ts` classifies `unverifiable` — *"no seam to observe until then"*.

Bills looked fine only by accident: `totals-hooks.ts` builds `new FieldValueService(organizationId, userId, db)` with **no socketId**, so the acting tab isn't excluded from its own `purchase_order_total` frame.

`LineBuilder` has read the same rows through `useRecordList` since #1918. The drawer shipped with its Lines card live and its Receiving card frozen — same rows, same drawer, two answers.

## The change

Both purchasing readers move onto that same list query. Sharing the filter is **load-bearing, not tidy**: `createListKey` hashes `JSON.stringify(filters)`, so the condition ID *strings* decide which `lists[...]` entry a read subscribes to, and `appendCreatedRecord(key, id)` patches only the key that created the record while the acting tab is excluded from its own `record:created` frame. An equivalent filter written by hand lands on a private cache entry nothing updates — which is exactly what a first attempt at this fix did (`l2w0sp` vs `kck2nr`). So the filter now has one construction site:

- `line-values.ts` — new `documentLineFilters()`, `LINE_SORT`, `LINE_PAGE_SIZE`
- `line-builder.tsx` — uses them instead of its inline literal (same keys as before, so its behaviour is unchanged)
- `use-purchase-order-lines.ts` — list lane; also gains `vendorPartRecordId` and `weight`
- `purchase-order-receiving-card.tsx` — drops its duplicate read, −55 lines
- `receive-purchase-order-dialog.tsx` — same hook

### The dialog is the one that mattered

There this was never a display bug. `buildReceivePoInput` builds the receipt **payload** from these rows, so a line added earlier in the session was absent from the write: the order reported received and the missing line sat at `0 / n`, nothing thrown, nothing logged. Its `PO_ATTRS` keeps the header amounts, which are the PO's own fields and publish normally.

No extra requests — the dialog is always mounted inside the Receiving card, so it resolves the same listKey and the same value keys, deduped.

Also retires a comment in `use-purchase-order-lines.ts` that said there was no query for this, citing `record.search` (which indeed takes no conditions). `record.listFiltered` does take `ConditionGroup[]`, and `entity-condition-builder.ts:630` compiles a RELATIONSHIP `is` to `FieldValue.relatedEntityId = <id>`.

## Test plan

Driven in a browser on PO-0007, no reload between steps:

- 4-line PO → added a 5th line from the Lines card
- Receiving card: Ordered **4 → 5**, Outstanding **4 → 5**, new row `0 / 1`
- Opened **Receive**: all 5 rows prefilled, button read **"Receive 5 lines"** (cancelled, no receipt written)

Also: `apps/web` typecheck clean; biome clean; 155 tests pass across `components/purchasing`, `components/money`, `components/drawers`.

## Follow-ups (not in this PR)

1. **D-11** — publish the inverse diff from `relationship-sync.ts`, buffered through `getAmbientTxWriteScope` when a tx is open and inline otherwise, **without** `excludeSocketId`. Fixes the nine remaining mirror-reading surfaces at once, plus the record rules that currently don't fire on the parent side. Nine hand-migrations is the wrong trade.
2. **Sibling-list invalidation** — `appendCreatedRecord` is key-scoped while `removeRecord` is def-wide, so two lists over the same def in one tab leave the non-acting one stale. A blind def-wide *append* would be wrong (creates aren't monotone — the row may fail the other filter); the right shape is to *invalidate* siblings, coalesced, mirroring what every remote tab already does. Currently masked only by copy-paste-identical filter literals (`part-inventory-card` / `part-inventory-tab`) and liberal manual `refresh()`.
