### PR TITLE
fix(purchasing): a bill can be raised before the goods arrive

### DIFF
--- a/apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
@@ -472,7 +472,7 @@ export function CreateBillFromPurchaseOrderDialog({
               />
               <span>
                 <span className='text-foreground'>
-                  Add {billableLines.length} received line
+                  Add {billableLines.length} line
                   {billableLines.length === 1 ? '' : 's'} from the order
                 </span>
                 <span className='block text-muted-foreground text-xs'>

--- a/apps/web/src/components/purchasing/vendor-bill/add-purchase-order-lines-button.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/add-purchase-order-lines-button.tsx
@@ -1,9 +1,13 @@
 // apps/web/src/components/purchasing/vendor-bill/add-purchase-order-lines-button.tsx
 'use client'
 
-// "Add lines from order" — the answer to entering a bill for an order that has
-// already been received and having to retype every line by hand
-// (plans/purchasing/02-handoff.md §4 item 3c).
+// "Add lines from order" — the answer to entering a bill against an order and
+// having to retype every line by hand (plans/purchasing/02-handoff.md §4 item 3c).
+//
+// Offered whether or not the goods have arrived: `selectBillableLines` gates on
+// what is still uninvoiced, not on what has been received. See that file for why
+// the receipt is the wrong gate — a vendor that will not ship until the invoice
+// is paid makes bill-before-receipt the normal case, not the edge one.
 //
 // What it removes is the STRUCTURE, not the transcription: the part, the
 // description, the GRNI account, and above all the `purchaseOrderLine` match key,

--- a/apps/web/src/components/purchasing/vendor-bill/bill-lines-from-purchase-order.test.ts
+++ b/apps/web/src/components/purchasing/vendor-bill/bill-lines-from-purchase-order.test.ts
@@ -39,21 +39,33 @@ describe('which lines are offered', () => {
     expect(selectBillableLines([poLine()], [])).toHaveLength(1)
   })
 
-  it('skips a line nothing has arrived against', () => {
-    expect(selectBillableLines([poLine({ received: 0 })], [])).toEqual([])
+  // 🛑 The gate is `billed < ordered`, NOT `received > billed`. A vendor that will
+  // not ship until the invoice is paid — full prepayment on Chinese supply, a
+  // deposit, a freight-forwarder invoice — bills before anything arrives, and
+  // under the old rule that bill offered zero lines and said nothing about why.
+  it('offers a line nothing has arrived against yet — the bill can precede the goods', () => {
+    expect(selectBillableLines([poLine({ received: 0, billed: 0 })], [])).toHaveLength(1)
   })
 
-  it('skips a line already fully billed elsewhere', () => {
+  it('skips a line already fully billed elsewhere, received or not', () => {
     expect(selectBillableLines([poLine({ received: 10, billed: 10 })], [])).toEqual([])
+    expect(selectBillableLines([poLine({ received: 0, billed: 10 })], [])).toEqual([])
   })
 
-  it('still offers a partially billed line — a delivery can be split across bills', () => {
+  it('skips an over-billed line', () => {
+    expect(selectBillableLines([poLine({ received: 10, billed: 12 })], [])).toEqual([])
+  })
+
+  it('still offers a partially billed line — an order can be split across bills', () => {
     expect(selectBillableLines([poLine({ received: 10, billed: 4 })], [])).toHaveLength(1)
+    // Same split, nothing received: a deposit invoice then a balance invoice.
+    expect(selectBillableLines([poLine({ received: 0, billed: 4 })], [])).toHaveLength(1)
   })
 
-  // 🛑 The regression this guard exists for. A line created by this action starts
-  // at the default quantity with no price, so `quantity_billed` barely moves and
-  // the received > billed filter keeps offering the same line back. Without the
+  // 🛑 The regression this guard exists for, and the new gate does NOT weaken it —
+  // if anything it leans harder on it. A line created by this action starts at the
+  // default quantity of 1 with no price, so against an ordered 10 the `billed <
+  // ordered` filter keeps offering the same line straight back. Without the
   // membership check, pressing the button twice duplicates every line.
   it('never offers a line already on this bill, however little was typed into it', () => {
     const line = poLine({ received: 10, billed: 0 })

--- a/apps/web/src/components/purchasing/vendor-bill/bill-lines-from-purchase-order.ts
+++ b/apps/web/src/components/purchasing/vendor-bill/bill-lines-from-purchase-order.ts
@@ -48,9 +48,8 @@ export const GRNI_ACCOUNT_CODE = '2160'
  *
  * Two independent filters, and both are needed:
  *
- * 1. **Something arrived that nobody has billed yet** — `received > billed`. Both
- *    are live roll-ups (`purchase-order-line-rollups.ts`), so this is the per-line
- *    GRNI residual and it is the right economic notion of "billable".
+ * 1. **Still uninvoiced** — `billed < ordered`. What is left to bill on the ORDER,
+ *    which is a fact about the order and not about the warehouse.
  * 2. **Not already on THIS bill.** 🛑 Without it the action duplicates every line
  *    on a second press, and it would do so *reliably*: a line created here starts
  *    at the default quantity with no price, so `quantity_billed` barely moves and
@@ -60,6 +59,32 @@ export const GRNI_ACCOUNT_CODE = '2160'
  *
  * A line still legitimately split across two bills stays offerable on the second
  * one, because filter (2) is scoped to the bill being filled.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🛑 THIS GATE USED TO BE `received > billed`, AND THAT WAS WRONG
+ *
+ * The old rule read as the per-line GRNI residual — "something arrived that
+ * nobody has billed yet" — which is impeccable double-entry and the wrong
+ * question to ask a person entering an invoice.
+ *
+ * **Vendors invoice ahead of delivery as a matter of course, and some will not
+ * ship at all until the invoice is paid.** Full prepayment before dispatch is
+ * the norm on Chinese supply, where the goods then sit on a boat for thirty to
+ * forty-five days. Deposits, freight-forwarder invoices and drop-ships land the
+ * same way. Under `received > billed` every one of those bills offered ZERO
+ * lines, so the one document that unblocks the shipment was the one document
+ * this dialog would not help you enter.
+ *
+ * It also failed silently: both callers render nothing at all when the count is
+ * zero, so the surface was indistinguishable from "not built".
+ *
+ * ⚠️ The receipt has NOT stopped mattering — it moved to where it belongs. Billed
+ * against received is the three-way match's quantity arm (`purchasing/match.ts`),
+ * which compares the two on every line and is the thing that catches paying for
+ * goods that never arrive. Answering that question twice, once as a silent filter
+ * on what you may type and once as a check on what you typed, only ever hid the
+ * check.
+ * ─────────────────────────────────────────────────────────────────────────────
  */
 export function selectBillableLines(
   purchaseOrderLines: PurchaseOrderLineRow[],
@@ -68,7 +93,7 @@ export function selectBillableLines(
 ): PurchaseOrderLineRow[] {
   const taken = new Set(alreadyOnThisBill.filter((id): id is RecordId => !!id))
   return purchaseOrderLines.filter(
-    (line) => line.received > line.billed && !taken.has(line.lineRecordId)
+    (line) => line.billed < line.ordered && !taken.has(line.lineRecordId)
   )
 }
 


### PR DESCRIPTION
`selectBillableLines` gated on `received > billed` — the per-line GRNI residual. Impeccable double-entry, and the wrong question to ask someone entering an invoice.

**Vendors invoice ahead of delivery routinely, and many will not ship at all until the invoice is paid.** Full prepayment is the norm on Chinese supply, where the goods then sit on a boat for 30–45 days. Deposits, freight-forwarder invoices and drop-ships land the same way. Under the old rule every one of those bills offered **zero** lines — the one document that unblocks the shipment was the one this dialog would not help you enter.

It also failed silently. Both callers render nothing when the count is zero:

- `create-bill-from-purchase-order-dialog.tsx:465` — the checkbox is inside `{billableLines.length > 0 && …}`
- `add-purchase-order-lines-button.tsx:66` — `if (!purchaseOrderRecordId || billable.length === 0) return null`

So the surface was indistinguishable from "not built", from "the order has no lines", and from "it is broken".

## The change

The gate is now `billed < ordered` — what is still uninvoiced on the **order**, which is a fact about the order rather than about the warehouse.

The receipt has not stopped mattering; it moved to where it belongs. Billed against received is the three-way match's quantity arm (`purchasing/match.ts`). Answering that question twice — once as a silent filter on what you may type, once as a check on what you typed — only ever hid the check.

Copy on both surfaces drops the word "received" ("Add 4 lines from the order"), and the retired rule is documented in place with the reasoning, so it does not get restored as an obvious GRNI fix.

**The duplicate-press guard is unchanged and now leans harder.** A line created by this action starts at the registry default quantity of `1` with no price, so against an ordered 10 the new filter re-offers it every time. Membership-of-this-bill is what stops that; its test comment now says so explicitly rather than citing the retired rule.

## Why this is safe to land now

**Nothing posts to the GL yet.** `packages/lib/src/postings/build-entry.ts` has zero callers outside its own tests and there is no `post-entry.ts` — phase 7 is unbuilt ([02-handoff §4 item 7](../blob/main/plans/purchasing/02-handoff.md)). The `2160` GRNI code stamped on a bill line is a field value and nothing more today, so changing which lines get one has no accounting consequence.

For the record, the accounting still nets out when posting arrives: bill-first is `DR GRNI / CR A/P`, receipt-later is `DR Inventory / CR GRNI`. GRNI carries a debit balance ("paid for, not arrived") instead of a credit balance, and self-clears. Whether that wants its own goods-in-transit account is a phase-7 decision, not this one.

## Tests

`bill-lines-from-purchase-order.test.ts`: the `skips a line nothing has arrived against` case asserted exactly the behaviour being removed, so it is inverted and named for the reason. Added the not-received-but-fully-billed arm, an over-billed arm, and a deposit-then-balance split with `received: 0`.

- 33 tests pass across `components/purchasing`
- `pnpm --filter @auxx/web typecheck` — exit 0
- biome clean

## 🛑 Follow-up, deliberately NOT in this PR

`matchBillLine` treats `quantityBilled > quantityReceived` as `quantity_over_billed` **unconditionally** — its comment calls it *"the 'paying for what never arrived' case and the reason the match exists."*

Now that prepaid bills can actually be entered, every one of them reads **"Line 1: billed 500 but only 0 received"** with the full bill value as `matchVariance`, for the entire 30–45 day transit. Every legitimate prepaid bill will sit in the exception queue looking like the worst thing the system can detect — which is precisely how an exception queue stops being read, and `match.ts`'s own tolerance comment already says as much: *"If the exception queue is usually empty these numbers are right; if it is never empty they are wrong."*

`MATCHABLE_STATUSES` excludes `paid`, so marking the bill paid freezes it out of recomputation — but that is a side effect of a payment action, not a design.

Wants an `awaiting_receipt` outcome distinct from `exception`, probably aged off an expected-delivery date so a bill for goods that never arrive still surfaces on its own. That is the mirror of the completeness check `match.ts` already scopes out (*"received-not-billed and aged, the GRNI residual"*) — same query shape, opposite direction. Needs a decision before it is built.
