### PR TITLE
fix(shopify): stop looping merchants back to plan selection after they approve

### DIFF
--- a/apps/web/src/app/(public)/billing/subscription/activated/page.tsx
+++ b/apps/web/src/app/(public)/billing/subscription/activated/page.tsx
@@ -1,4 +1,4 @@
-// apps/web/src/app/(protected)/billing/subscription/activated/page.tsx
+// apps/web/src/app/(public)/billing/subscription/activated/page.tsx
 
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
@@ -21,6 +21,17 @@ interface PageProps {
  * confirm + sync the live contract onto the PlanSubscription row (shared
  * `confirmAndSyncShopifySubscription`). If the contract hasn't propagated within the window,
  * the 15-minute worker poll backstops it.
+ *
+ * **Deliberately `(public)`, not `(protected)`.** The URL is unchanged — route groups aren't URL
+ * segments — but the auth gate is gone on purpose. `(protected)`'s layout bounces an
+ * unauthenticated visitor to `/login` and drops `?plan_handle=&shop=` with it, so an approval
+ * made without a live Auxx session never reconciled at all. Nothing here needs a session: the
+ * whole confirm is server-side and `?shop=` identifies the org on its own. Only the final
+ * destination cares, and that is handled below.
+ *
+ * It also needs `billing` in `proxy.ts`'s `KNOWN_ROUTE_PREFIXES` — without it the proxy reads
+ * `billing` as an org handle and 307s this to a 404 before routing ever happens. See
+ * `plans/billing/v3/06-approval-loops-back-to-plan-selection.md` §3a-2.
  */
 export default async function ShopifySubscriptionActivatedPage({ searchParams }: PageProps) {
   const { plan_handle: planHandle, shop, org } = await searchParams
@@ -28,7 +39,7 @@ export default async function ShopifySubscriptionActivatedPage({ searchParams }:
   const orgRow = await resolveOrgForLanding({ shop, org })
   if (!orgRow?.shopifyShopDomain) {
     logger.warn('Activated landing could not resolve a Shopify org', { shop, org })
-    redirect('/app/settings/plans?billing=pending')
+    redirect(await destination('/app/settings/plans?billing=pending'))
   }
 
   const confirmed = await confirmAndSyncShopifySubscription({
@@ -42,11 +53,21 @@ export default async function ShopifySubscriptionActivatedPage({ searchParams }:
       organizationId: orgRow.organizationId,
       planHandle: planHandle ?? null,
     })
-    redirect('/app')
+    redirect(await destination('/app'))
   }
 
   // Contract not propagated yet — worker poll will catch up within 15 minutes.
-  redirect('/app/settings/plans?billing=pending')
+  redirect(await destination('/app/settings/plans?billing=pending'))
+}
+
+/**
+ * Where to send the merchant once the sync has run. Signed-in: straight there. Signed-out: to
+ * login carrying the destination, rather than letting `(protected)` bounce them to a bare
+ * `/login` that forgets where they were going.
+ */
+async function destination(path: string): Promise<string> {
+  const session = await getSession()
+  return session?.user ? path : `/login?callbackUrl=${encodeURIComponent(path)}`
 }
 
 /** Resolves the Shopify-billed org for the landing redirect, preferring the `?shop=` param. */

--- a/apps/web/src/components/subscriptions/plan-change-card.tsx
+++ b/apps/web/src/components/subscriptions/plan-change-card.tsx
@@ -17,6 +17,7 @@ import { useDemo } from '~/hooks/use-demo'
 import { useUser } from '~/hooks/use-user'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
+import { ShopifyPlanCard } from './shopify-plan-card'
 
 const PlanChangeSummary = dynamic(
   () =>
@@ -44,6 +45,14 @@ export function PlanChangeCard() {
 
   const { data: subscription, isLoading: subscriptionLoading } =
     api.billing.getCurrentSubscription.useQuery()
+
+  // Shopify App Pricing owns plan selection, proration, trials and cancellation. Mirroring any
+  // of it in-app can only drift from Shopify (App Store rejection 1.2.2, three rounds running),
+  // so these orgs get a read-only row + a link out instead of the grid, the change-summary
+  // dialog, and the Stripe-only restore/scheduled-change alerts below — every one of which
+  // either lies to them or calls a provider method that throws OPERATION_NOT_SUPPORTED.
+  // See plans/billing/v3/06-approval-loops-back-to-plan-selection.md §6.
+  const isShopify = subscription?.billingProvider === 'shopify'
 
   const cancelScheduledChange = api.billing.cancelScheduledChange.useMutation({
     onSuccess: () => {
@@ -106,6 +115,8 @@ export function PlanChangeCard() {
               <Skeleton className='h-9 w-28' />
             </div>
           </div>
+        ) : isShopify && subscription ? (
+          <ShopifyPlanCard subscription={subscription} />
         ) : (
           <div className='group flex items-center justify-between rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
             <div className='flex flex-row items-center gap-2'>
@@ -143,8 +154,10 @@ export function PlanChangeCard() {
           </div>
         )}
 
-        {/* Alerts - Priority: Cancellation > Scheduled Downgrade */}
-        {subscription?.cancelAtPeriodEnd && subscription.periodEnd ? (
+        {/* Alerts - Priority: Cancellation > Scheduled Downgrade. Stripe-only: both CTAs call
+            provider methods Shopify throws OPERATION_NOT_SUPPORTED for; ShopifyPlanCard renders
+            its own cancellation alert pointing at Shopify instead. */}
+        {isShopify ? null : subscription?.cancelAtPeriodEnd && subscription.periodEnd ? (
           // Cancellation Alert (highest priority)
           <Alert variant='destructive'>
             <AlertDescription className='flex items-center justify-between'>
@@ -189,7 +202,9 @@ export function PlanChangeCard() {
         ) : null}
       </SettingsSection>
 
-      {dialogOpen ? <PlanChangeSummary open={dialogOpen} onOpenChange={setDialogOpen} /> : null}
+      {dialogOpen && !isShopify ? (
+        <PlanChangeSummary open={dialogOpen} onOpenChange={setDialogOpen} />
+      ) : null}
     </>
   )
 }

--- a/apps/web/src/components/subscriptions/shopify-admin-billing-banner.tsx
+++ b/apps/web/src/components/subscriptions/shopify-admin-billing-banner.tsx
@@ -11,10 +11,11 @@ interface ShopifyAdminBillingBannerProps {
 }
 
 /**
- * Banner shown above Billing Details for Shopify-billed orgs. Clarifies that only
- * payment method + invoice history live in Shopify Admin — plan changes and
- * cancellation still work from this page. "Open Shopify Admin" deep-links to the app's
- * own page (Settings → Apps → Auxx). Mirrors the plan-change-card row design.
+ * Banner shown above Billing Details for Shopify-billed orgs. Shopify App Pricing owns the
+ * payment method, invoice history, plan changes and cancellation alike — the in-app plan grid
+ * and cancel dialog are both hidden for these orgs (see `ShopifyPlanCard`), so this says so
+ * rather than implying either works here. "Open Shopify Admin" deep-links to the app's own page
+ * (Settings → Apps → Auxx). Mirrors the plan-change-card row design.
  */
 export function ShopifyAdminBillingBanner({ shopDomain }: ShopifyAdminBillingBannerProps) {
   const { shopifyAppHandle } = useEnv()
@@ -30,8 +31,7 @@ export function ShopifyAdminBillingBanner({ shopDomain }: ShopifyAdminBillingBan
         <div className='flex flex-col'>
           <span className='text-sm'>Billing is managed in Shopify</span>
           <span className='text-xs text-muted-foreground'>
-            Your payment method and subscription are handled by Shopify Admin. Plan changes and
-            cancellation work from this page.
+            Your payment method, plan changes and cancellation are all handled by Shopify Admin.
           </span>
         </div>
       </div>

--- a/apps/web/src/components/subscriptions/shopify-plan-card.tsx
+++ b/apps/web/src/components/subscriptions/shopify-plan-card.tsx
@@ -1,0 +1,117 @@
+// apps/web/src/components/subscriptions/shopify-plan-card.tsx
+'use client'
+
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { format } from 'date-fns'
+import { CreditCard, ExternalLink } from 'lucide-react'
+import { api, type RouterOutputs } from '~/trpc/react'
+
+type Subscription = NonNullable<RouterOutputs['billing']['getCurrentSubscription']>
+
+interface ShopifyPlanCardProps {
+  subscription: Subscription
+}
+
+/**
+ * Read-only plan row for Shopify-billed orgs, in place of the in-app plan grid.
+ *
+ * Shopify App Pricing owns plan selection, pricing, proration, trials and cancellation, so
+ * mirroring any of that here can only drift from it — and every round of App Store rejection
+ * 1.2.2 has been a drift bug: a stale plan (round 2), a plan choice we collected and then
+ * discarded, and totals that disagreed with Shopify's own approval screen (round 3, assessment
+ * 2404984). See `plans/billing/v3/06-approval-loops-back-to-plan-selection.md` §6.
+ *
+ * So this shows only what we read back from the Admin API contract and hands off with one
+ * link. Requirement 1.2.3 (self-serve upgrade *and* downgrade, no support contact, no
+ * reinstall) is satisfied by that link — Shopify's picker offers both directions.
+ */
+export function ShopifyPlanCard({ subscription }: ShopifyPlanCardProps) {
+  // Where a plan change can actually go depends on whether the shop still has the app
+  // installed — the hosted pricing page 404s once it doesn't, and App Store rule 2.1.1
+  // counts a web error reached from our UI against us. Probes the Admin API.
+  const { data: planAction, isPending: planActionPending } =
+    api.billing.getShopifyPlanAction.useQuery()
+
+  const isCanceled = subscription.status === 'canceled' || subscription.cancelAtPeriodEnd
+  const isUninstalled = planAction?.kind === 'uninstalled'
+
+  return (
+    <>
+      <div className='group flex items-center justify-between rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
+        <div className='flex flex-row items-center gap-2'>
+          <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors shrink-0'>
+            <CreditCard className='size-4 shrink-0' />
+          </div>
+          <div className='flex flex-col'>
+            <div className='flex items-center gap-2'>
+              <span className='text-sm'>{subscription.plan?.name || 'No plan selected'}</span>
+              {subscription.billingCycle && (
+                <Badge size='xs' variant='user'>
+                  {subscription.billingCycle === 'MONTHLY' ? 'Monthly' : 'Annual'}
+                </Badge>
+              )}
+              {subscription.status === 'trialing' && (
+                <Badge size='xs' variant='secondary'>
+                  Trial
+                </Badge>
+              )}
+            </div>
+            <span className='text-xs text-muted-foreground'>{planSummary(subscription)}</span>
+          </div>
+        </div>
+        {/* Only offer the link when we know it leads somewhere. Reinstalling happens in the
+            Shopify admin, which has no deep link, so `uninstalled` (and a failed probe) falls
+            through to the alert below instead of rendering a dead link. */}
+        {planActionPending ? (
+          <Button variant='outline' size='sm' loading loadingText='Checking...'>
+            Manage plan in Shopify
+          </Button>
+        ) : planAction?.kind === 'plans' ? (
+          <Button variant='outline' size='sm' asChild>
+            <a href={planAction.url} target='_blank' rel='noopener noreferrer'>
+              Manage plan in Shopify
+              <ExternalLink />
+            </a>
+          </Button>
+        ) : null}
+      </div>
+
+      {isUninstalled ? (
+        <Alert variant='destructive'>
+          <AlertDescription>
+            <span className='text-sm'>
+              Auxx was removed from <strong>{planAction.shopDomain}</strong>. Reinstall it from your
+              Shopify admin — Settings → Apps → Uninstalled apps — to pick a plan again.
+            </span>
+          </AlertDescription>
+        </Alert>
+      ) : isCanceled && subscription.periodEnd ? (
+        <Alert variant='destructive'>
+          <AlertDescription>
+            <span className='text-sm'>
+              Your Shopify subscription has been canceled and access ends on{' '}
+              <strong>{format(new Date(subscription.periodEnd), 'MMMM d, yyyy')}</strong>. Choose a
+              plan in Shopify to keep using Auxx.
+            </span>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+    </>
+  )
+}
+
+/** One line of contract state, all of it read back from Shopify — never computed here. */
+function planSummary(subscription: Subscription): string {
+  if (subscription.status === 'trialing' && subscription.trialEnd) {
+    return `Trial ends ${format(new Date(subscription.trialEnd), 'MMMM d, yyyy')}`
+  }
+  if (subscription.status === 'past_due') return 'Payment overdue — resolve it in Shopify Admin'
+  if (subscription.status === 'incomplete') return 'Waiting for plan approval in Shopify'
+  if (subscription.status === 'canceled') return 'Canceled'
+  if (subscription.periodEnd) {
+    return `Renews ${format(new Date(subscription.periodEnd), 'MMMM d, yyyy')}`
+  }
+  return 'Billed through Shopify'
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -14,7 +14,13 @@ import { NextResponse } from 'next/server'
  */
 const KNOWN_ROUTE_PREFIXES = new Set([
   // (protected) routes
+  'access-denied',
   'app',
+  // Shopify App Pricing's post-approval Redirect URL is
+  // `/billing/subscription/activated`. Without this entry the segment reads as an org handle
+  // and 307s to `/subscription/activated`, which does not exist — every plan approval landed
+  // on a 404. See plans/billing/v3/06-approval-loops-back-to-plan-selection.md §3a-2.
+  'billing',
   'onboarding',
   'organizations',
   'preview',

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -21,9 +21,17 @@ import { and, eq, ne, sql } from 'drizzle-orm'
 import { cookies } from 'next/headers'
 import { z } from 'zod'
 import { setUserDefaultOrganization } from '~/server/auth/set-default-organization'
+import { confirmAndSyncShopifySubscription } from '~/server/billing/confirm-shopify-subscription'
 import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
 
 const CLAIM_COOKIE_NAME = 'shopify_claim_token'
+
+/**
+ * Propagation-lag budget for the post-install contract read. One retry (~1.5s) — the merchant
+ * is mid-redirect, and a shop that genuinely has no subscription must not pay a long wait
+ * before reaching the plan picker.
+ */
+const POST_INSTALL_CONFIRM_ATTEMPTS = 2
 
 /**
  * Block handle of the theme app embed, i.e. the filename of
@@ -34,6 +42,48 @@ const CLAIM_COOKIE_NAME = 'shopify_claim_token'
 const APP_EMBED_BLOCK_HANDLE = 'embed'
 
 const logger = createScopedLogger('shopify-router')
+
+/**
+ * Last gate before we send a merchant to Shopify's hosted plan picker: check whether they
+ * already have a live contract, and open the workspace instead if they do.
+ *
+ * A merchant can land in `finalizeAppStoreInstall` moments *after* approving a charge — App
+ * Pricing's post-approval redirect goes to the app URL, which re-runs install → OAuth → claim.
+ * Offering "pick a plan" there is App Store rejection 2404984: *"the app looped back to the plan
+ * selection after already approving the plan"* (see
+ * `plans/billing/v3/06-approval-loops-back-to-plan-selection.md` §3).
+ *
+ * The claim page's own confirm cannot cover this. It runs *before* `saveAppConnection`, so it
+ * queries the Admin API with the access token Shopify rotated away during this very install's
+ * OAuth round-trip. Call this only after the fresh credential is stored **and** flipped to
+ * primary — `getActiveSubscription` reads the org's primary connection.
+ *
+ * @returns `'/app'` when a live contract was confirmed and mirrored onto the row, else `null`
+ *   (caller falls back to the plan picker).
+ */
+async function openWorkspaceIfAlreadySubscribed(input: {
+  organizationId: string
+  shopDomain: string
+  userId: string
+  currentDefaultOrganizationId?: string | null
+}): Promise<string | null> {
+  const confirmed = await confirmAndSyncShopifySubscription({
+    organizationId: input.organizationId,
+    shopDomain: input.shopDomain,
+    maxAttempts: POST_INSTALL_CONFIRM_ATTEMPTS,
+  })
+  if (!confirmed) return null
+
+  logger.info('Live Shopify contract found on install — skipping the plan picker', {
+    organizationId: input.organizationId,
+    shop: input.shopDomain,
+  })
+  // Activate the picked workspace so `/app` opens it rather than the user's current default.
+  if (input.currentDefaultOrganizationId !== input.organizationId) {
+    await setUserDefaultOrganization(db, input.userId, input.organizationId)
+  }
+  return '/app'
+}
 
 export const shopifyRouter = createTRPCRouter({
   /**
@@ -328,6 +378,16 @@ export const shopifyRouter = createTRPCRouter({
         // selection. Any live status (active/trialing/past_due/paused) just opens the workspace.
         await registerBillingWebhooks(organizationId, claim.shop)
         if (existing.status === 'incomplete') {
+          // `incomplete` means *we* never observed an approval — not that there isn't one.
+          // Re-read the contract with the token this install just stored before asking again.
+          const openWorkspace = await openWorkspaceIfAlreadySubscribed({
+            organizationId,
+            shopDomain: claim.shop,
+            userId,
+            currentDefaultOrganizationId: ctx.session.user.defaultOrganizationId,
+          })
+          if (openWorkspace) return { redirectUrl: openWorkspace, shop: claim.shop }
+
           const provider = getProvider('shopify') as ShopifyBillingProvider
           const redirectUrl = await provider.getPlanSelectionUrl(organizationId)
           return { redirectUrl, shop: claim.shop }
@@ -392,6 +452,17 @@ export const shopifyRouter = createTRPCRouter({
       // legacy install flow forbids toml-declared subscriptions, so registration happens
       // here, per shop, with the token just linked.
       await registerBillingWebhooks(organizationId, claim.shop)
+
+      // The row above was just stamped `incomplete`, but a reinstall or a re-approval after
+      // cancel can arrive here with a live contract already approved on Shopify's page — and an
+      // App Store install can carry one from the listing's plan picker. Check before asking.
+      const openWorkspace = await openWorkspaceIfAlreadySubscribed({
+        organizationId,
+        shopDomain: claim.shop,
+        userId,
+        currentDefaultOrganizationId: ctx.session.user.defaultOrganizationId,
+      })
+      if (openWorkspace) return { redirectUrl: openWorkspace, shop: claim.shop }
 
       // Hand back the Shopify hosted pricing-page URL. The merchant picks the plan +
       // interval there, approves, and is redirected to /billing/subscription/activated.


### PR DESCRIPTION
App Store review assessment 2404984, rule 1.2.2:

> Upon reviewing the app we encountered an issue where the app looped back to the plan selection after already approving the plan.

Four independent defects sat between approving a charge and landing back in the app. The reviewer hit three of them in 30 seconds. Full frame-by-frame analysis and the retest recipe are in `plans/billing/v3/06-approval-loops-back-to-plan-selection.md`.

## What the reviewer saw

| t | URL | Screen |
|---|---|---|
| 7–15s | `app.auxx.ai/app/settings/plans` | Growth · Trial. Change Plan → picks **Starter** → Approve in Shopify |
| 16–18s | `…/charges/auxxai-1/pricing_plans` | **"Select a plan"** — his choice was discarded |
| 19–20s | `…/plans/starter?interval=EVERY_30_DAYS` | Approves Starter |
| 21s | `app.auxx.ai/shopify/claim?token=…` | Lands in the *install* flow |
| 22–25s | `…/charges/auxxai-1/pricing_plans` | **"Select a plan" again** ← the rejection |

## Changes

**1. `proxy.ts` — the landing URL 404s.** Any unknown first path segment is treated as an org handle, so `/billing/subscription/activated` 307'd to `/subscription/activated`, which does not exist. That route has therefore **never worked in any environment**. Adds `billing`, plus `access-denied` which was missing with the same effect (`/access-denied` currently redirects to `/login` and can never render — flag if you'd rather I split that out).

**2. `shopify.ts` — we offered plan selection to merchants who had just approved.** Shopify's post-approval redirect re-runs install → OAuth → claim, and both picker exits (`status: 'incomplete'`, and the `canceled` fall-through) returned `getPlanSelectionUrl()` without re-reading the contract. The claim page's own confirm can't cover this: it runs *before* `saveAppConnection`, so it queries with the token Shopify rotated away during that very round-trip. New `openWorkspaceIfAlreadySubscribed()` runs after the fresh credential is stored **and** flipped to primary — `getActiveSubscription` reads the org's primary connection.

**3. Plan grid removed for Shopify orgs.** Shopify App Pricing owns plan selection, pricing, proration, trials and cancellation; mirroring any of it can only drift, and every round of this rejection has been a drift bug — a stale plan (round 2), a discarded plan choice, and totals that disagreed with Shopify's own approval screen. Shopify orgs now get a read-only row plus one **Manage plan in Shopify** link, gated on `getShopifyPlanAction` so an uninstalled shop gets a reinstall notice rather than a dead link (rule 2.1.1). Also drops the **Restore Subscription** / **Cancel Change** CTAs, which called provider methods Shopify throws `OPERATION_NOT_SUPPORTED` for.

**4. Landing route no longer auth-gated.** Under `(protected)` an unauthenticated merchant was bounced to `/login` and lost `?plan_handle=&shop=` with it, so the approval never reconciled. Moved to `(public)` — route groups aren't URL segments, so **the URL is unchanged** and no further Partner Dashboard edit is needed.

## Paired config change (already made)

The per-plan Redirect URL was the relative path `/billing/subscription/activated`. A non-embedded app has no App Home to resolve that against, so Shopify fell back to `application_url`. Now absolute: `https://app.auxx.ai/billing/subscription/activated`.

Both halves were broken independently, which is why round 2's fix appeared to change nothing — and why deploying this is now urgent: with the config fixed and the proxy not, **every approval currently lands on a 404**.

## Testing

`pnpm --filter @auxx/web typecheck` clean (ratchet: 0 new errors). Biome clean. No unit tests — none of these files had coverage, and the behaviour is redirect-chain shaped.

**Must be retested from a cancelled row**, not a live one. A live subscription short-circuits the claim page and hides every symptom here — which is exactly why round 2's retests passed three days before this rejection.

1. Cancel the app subscription in Shopify Admin; wait for the row to reach `canceled`
2. Open the app from Shopify → approve a plan on the hosted page
3. Expect: browser hits `/billing/subscription/activated?plan_handle=…&shop=…`, then lands **in the app on the approved plan** — no second plan selection
4. Check the plans page shows the read-only Shopify row with **Manage plan in Shopify**