### PR TITLE
feat(field-values): announce the inverse side of a relationship write (D-11)

### DIFF
--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
@@ -118,9 +118,16 @@ export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
         onOpenChange={setAddOpen}
         purchaseOrderRecordId={recordId}
         onCreated={(billRecordId) => {
-          // The card lists the PO's `purchase_order_bills` inverse, so it is the
-          // ORDER whose values went stale, not the new bill.
-          invalidateResource(recordId)
+          // No invalidation. The card lists the PO's `purchase_order_bills`
+          // inverse, and since D-11 that mirror announces its own rewrite
+          // (`field-values/relationship-sync.ts`), so the new bill arrives as a
+          // `fieldValues:updated` frame and merges through `setValues` —
+          // non-destructively, and for every viewer rather than only this tab.
+          //
+          // 🛑 Do not reinstate `invalidateResource(recordId)`. It DELETES every
+          // cached field value on the order, which is what made the drawer's line
+          // builder visibly reset itself; it was only ever here because the
+          // inverse write was silent.
           openRecord?.(billRecordId)
         }}
       />

--- a/packages/lib/src/field-values/__tests__/inverse-announcement.test.ts
+++ b/packages/lib/src/field-values/__tests__/inverse-announcement.test.ts
@@ -1,0 +1,230 @@
+// packages/lib/src/field-values/__tests__/inverse-announcement.test.ts
+//
+// Decision D-11 / defect B-9: the inverse side of a relationship write is a real
+// write to a real record and must be announced like one.
+//
+// Before this, `relationship-sync` rewrote the mirror array in raw SQL and told
+// nobody — every screen holding the parent kept rendering its load-time list
+// (the client never re-requests a key it already holds, so not even a remount
+// repaired it), and record rules subscribing to a relationship field never fired
+// on the inverse side at all. The diff was already computed and thrown away.
+//
+// These drive `syncInverseRelationships` through the same scripted fake db
+// `inverse-repoint-fallback.test.ts` uses, and assert on the frame that comes
+// out the other side.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const publishFieldValueUpdates = vi.fn(async () => {})
+const getRealtimeService = vi.fn(() => ({}) as never)
+const getAmbientTxWriteScope = vi.fn<() => unknown>(() => undefined)
+const recordTxWriteChange = vi.fn()
+
+vi.mock('../../realtime', () => ({
+  publishFieldValueUpdates: (...args: unknown[]) => publishFieldValueUpdates(...(args as [])),
+  getRealtimeService: () => getRealtimeService(),
+}))
+
+vi.mock('../../resources/crud/tx-write-scope', () => ({
+  getAmbientTxWriteScope: () => getAmbientTxWriteScope(),
+  recordTxWriteChange: (...args: unknown[]) => recordTxWriteChange(...args),
+}))
+
+import { syncInverseRelationships } from '../relationship-sync'
+
+/** Thenable statement-builder stub: every method chains, awaiting resolves `result`. */
+function chain(result: unknown): Record<string, unknown> {
+  const c: Record<string, unknown> = {}
+  for (const m of ['from', 'where', 'orderBy', 'groupBy', 'limit', 'set', 'returning']) {
+    c[m] = () => c
+  }
+  c.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown): Promise<unknown> =>
+    Promise.resolve(result).then(resolve, reject)
+  return c
+}
+
+/**
+ * A db whose `select` answers a scripted sequence. The multi-value add path
+ * runs two selects (existing links, then max sortKeys) before the D-11 re-read,
+ * so the third scripted answer is the array being announced.
+ */
+function fakeDb(selectResults: unknown[][]) {
+  let call = 0
+  return {
+    select: () => chain(selectResults[call++] ?? []),
+    delete: () => chain([]),
+    insert: () => ({ values: () => Promise.resolve() }),
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) => await fn(undefined),
+  } as never
+}
+
+/** A stored FieldValue row as `rowToTypedValue` expects to receive it. */
+function row(id: string, entityId: string, relatedEntityId: string, sortKey: string) {
+  return {
+    id,
+    entityId,
+    fieldId: 'field-inv',
+    relatedEntityId,
+    relatedEntityDefinitionId: 'def-line',
+    sortKey,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  }
+}
+
+/** An order gaining a line: the LINE is written, the ORDER's array is the mirror. */
+const HAS_MANY_INVERSE = {
+  inverseFieldId: 'field-inv',
+  inverseRelationshipType: 'has_many' as const,
+  sourceEntityDefinitionId: 'def-line',
+  targetEntityDefinitionId: 'def-order',
+  sourceFieldId: 'field-src',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getAmbientTxWriteScope.mockReturnValue(undefined)
+  publishFieldValueUpdates.mockResolvedValue(undefined)
+})
+
+describe('D-11 — the inverse write announces itself', () => {
+  it('publishes the parent’s new array when a child is linked to it', async () => {
+    await syncInverseRelationships(
+      {
+        db: fakeDb([
+          [],
+          [],
+          [row('r1', 'order-1', 'line-A', 'a0'), row('r2', 'order-1', 'line-B', 'a1')],
+        ]),
+        organizationId: 'org-1',
+      },
+      {
+        entityId: 'line-B',
+        oldRelatedIds: [],
+        newRelatedIds: ['order-1'],
+        inverseInfo: HAS_MANY_INVERSE,
+      }
+    )
+
+    expect(publishFieldValueUpdates).toHaveBeenCalledTimes(1)
+    const [, organizationId, entries] = publishFieldValueUpdates.mock.calls[0] as unknown as [
+      unknown,
+      string,
+      Array<{ key: string; value: unknown }>,
+    ]
+    expect(organizationId).toBe('org-1')
+    expect(entries).toHaveLength(1)
+    // Keyed on the ORDER — the record at the other end of the link, whose array
+    // moved. The line's own field was published by whoever wrote it.
+    expect(entries[0]!.key).toBe('def-order:order-1:def-order:field-inv')
+    expect(entries[0]!.value).toEqual([
+      expect.objectContaining({ type: 'relationship', recordId: 'def-line:line-A' }),
+      expect.objectContaining({ type: 'relationship', recordId: 'def-line:line-B' }),
+    ])
+  })
+
+  it('does NOT exclude the acting socket', async () => {
+    // 🛑 The load-bearing assertion. Every ordinary publish suppresses the echo
+    // to the tab that made the change. Here the announced record is a DIFFERENT
+    // record from the one the user edited, so to that tab it is news — and
+    // excluding it reinstates the original bug for the person most likely to be
+    // looking at the screen.
+    await syncInverseRelationships(
+      { db: fakeDb([[], [], [row('r1', 'order-1', 'line-A', 'a0')]]), organizationId: 'org-1' },
+      {
+        entityId: 'line-A',
+        oldRelatedIds: [],
+        newRelatedIds: ['order-1'],
+        inverseInfo: HAS_MANY_INVERSE,
+      }
+    )
+
+    const call = publishFieldValueUpdates.mock.calls[0] as unknown as unknown[]
+    expect(call[3]).toBeUndefined()
+  })
+
+  it('publishes an EMPTY array when the last link is removed', async () => {
+    // "This list is now empty" is the news. Skipping the frame leaves the last
+    // non-empty answer on screen forever.
+    await syncInverseRelationships(
+      { db: fakeDb([[]]), organizationId: 'org-1' },
+      {
+        entityId: 'line-A',
+        oldRelatedIds: ['order-1'],
+        newRelatedIds: [],
+        inverseInfo: HAS_MANY_INVERSE,
+      }
+    )
+
+    const [, , entries] = publishFieldValueUpdates.mock.calls[0] as unknown as [
+      unknown,
+      string,
+      Array<{ key: string; value: unknown }>,
+    ]
+    expect(entries).toEqual([{ key: 'def-order:order-1:def-order:field-inv', value: [] }])
+  })
+
+  it('buffers instead of publishing while a write scope is open', async () => {
+    // Announcing before COMMIT is worse than silence: the subscriber re-reads on
+    // another connection, cannot see uncommitted rows, and caches the PRE-write
+    // value as fresh.
+    const scope = { marker: 'buffered' }
+    getAmbientTxWriteScope.mockReturnValue(scope)
+
+    await syncInverseRelationships(
+      { db: fakeDb([[], [], [row('r1', 'order-1', 'line-A', 'a0')]]), organizationId: 'org-1' },
+      {
+        entityId: 'line-A',
+        oldRelatedIds: [],
+        newRelatedIds: ['order-1'],
+        inverseInfo: HAS_MANY_INVERSE,
+      }
+    )
+
+    expect(publishFieldValueUpdates).not.toHaveBeenCalled()
+    expect(recordTxWriteChange).toHaveBeenCalledTimes(1)
+    const [passedScope, args] = recordTxWriteChange.mock.calls[0] as [
+      unknown,
+      { recordId: string; outputKey: string; entry: { key: string } },
+    ]
+    expect(passedScope).toBe(scope)
+    expect(args.recordId).toBe('def-order:order-1')
+    expect(args.outputKey).toBe('field-inv')
+    // The buffered frame must be the one the inline lane would have sent, or the
+    // flush replays something the client has never seen the shape of.
+    expect(args.entry.key).toBe('def-order:order-1:def-order:field-inv')
+  })
+
+  it('a failed publish never fails the write', async () => {
+    // The rows are already durable by the time we get here. A realtime hiccup
+    // leaves the client exactly as stale as it was before D-11, never worse.
+    publishFieldValueUpdates.mockRejectedValue(new Error('pusher down'))
+
+    await expect(
+      syncInverseRelationships(
+        { db: fakeDb([[], [], [row('r1', 'order-1', 'line-A', 'a0')]]), organizationId: 'org-1' },
+        {
+          entityId: 'line-A',
+          oldRelatedIds: [],
+          newRelatedIds: ['order-1'],
+          inverseInfo: HAS_MANY_INVERSE,
+        }
+      )
+    ).resolves.toEqual({ removedFrom: [], addedTo: ['order-1'] })
+  })
+
+  it('says nothing when nothing changed', async () => {
+    await syncInverseRelationships(
+      { db: fakeDb([]), organizationId: 'org-1' },
+      {
+        entityId: 'line-A',
+        oldRelatedIds: ['order-1'],
+        newRelatedIds: ['order-1'],
+        inverseInfo: HAS_MANY_INVERSE,
+      }
+    )
+
+    expect(publishFieldValueUpdates).not.toHaveBeenCalled()
+    expect(recordTxWriteChange).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/field-values/relationship-sync.ts
+++ b/packages/lib/src/field-values/relationship-sync.ts
@@ -1,9 +1,16 @@
 // packages/lib/src/field-values/relationship-sync.ts
 
 import { type Database, schema, type Transaction } from '@auxx/database'
+import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { RelationshipType } from '@auxx/types/custom-field'
+import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import type { TypedFieldValue } from '@auxx/types/field-value'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
 import { generateKeyBetween, nextKeyAfter } from '@auxx/utils/fractional-indexing'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
+import type { FieldValueUpdateEntry } from '../realtime/events'
+import { rowToTypedValue } from './field-value-helpers'
+import type { FieldValueRow } from './types'
 
 // ============================================================================
 // TYPES
@@ -60,6 +67,169 @@ export interface BulkRelationshipUpdate {
 export interface BulkSyncInput {
   updates: BulkRelationshipUpdate[]
   inverseInfo: InverseFieldInfo
+}
+
+// ============================================================================
+// ANNOUNCING THE INVERSE WRITE  (decision D-11 / defect B-9)
+// ============================================================================
+
+/**
+ * One record whose relationship array this module just rewrote, and which
+ * therefore owes the rest of the system an announcement.
+ *
+ * 🛑 **Why this exists at all.** A relationship is stored TWICE — once on the
+ * record you edited and once as a mirror on the record at the other end — and
+ * until this was added, only the first write was ever published. The mirror was
+ * rewritten in raw SQL right here and nobody was told, so:
+ *
+ *   - every screen holding the parent kept rendering the list it had at load
+ *     time (the client's fetch queue never re-requests a key it already holds,
+ *     so not even a remount repaired it — only a full page reload);
+ *   - record rules that subscribe to a relationship field never fired on the
+ *     inverse side at all. Not intermittently. Never.
+ *
+ * The diff was already being computed — it is the value `syncInverseRelationships`
+ * returns — and simply thrown away by every caller. See
+ * `plans/events/03-write-context-and-batch-lane-plan.md` §D-11 and the
+ * `inverseRelationshipVisibility` row of `resources/crud/door-matrix.ts`.
+ */
+interface InverseAnnouncement {
+  /** Definition of the records named in {@link entityIds}. */
+  entityDefinitionId: string
+  /** The field on those records whose array changed. */
+  fieldId: string
+  /** Instance ids whose `fieldId` array changed. */
+  entityIds: string[]
+  /** `belongs_to`/`has_one` publish a scalar (or `null`); the rest publish the array. */
+  single: boolean
+}
+
+function isSingleValued(relationshipType: RelationshipType): boolean {
+  return relationshipType === 'belongs_to' || relationshipType === 'has_one'
+}
+
+/**
+ * Re-read each affected record's relationship array and publish it.
+ *
+ * Three deliberate choices, each of which is a bug if reversed:
+ *
+ * 1. **No `excludeSocketId`.** Every ordinary publish suppresses the echo to the
+ *    tab that made the change, because that tab already knows. Here it does not:
+ *    the record being announced is the one at the OTHER end of the link, not the
+ *    one the user edited. To the acting tab this is news, and suppressing it
+ *    leaves exactly the bug this function exists to fix, for the person most
+ *    likely to be looking at it.
+ *
+ * 2. **Buffered when a write scope is open.** Announcing before `COMMIT` is
+ *    worse than silence: the subscriber re-reads on a different connection,
+ *    cannot see uncommitted rows, and caches the PRE-write value as fresh.
+ *    `recordTxWriteChange` holds the frame until `flushTxWriteScope` replays it
+ *    after the transaction lands. (Writing the `changes` bucket is not optional
+ *    bookkeeping — the flush iterates `scope.changes` to decide what to replay,
+ *    so an entry with no bucket would be buffered and never sent.)
+ *
+ * 3. **Best-effort.** A realtime hiccup must never fail the write that caused
+ *    it; the rows are already durable by the time we get here. Same contract as
+ *    every other publish in this package.
+ *
+ * Records whose list was emptied are published as an empty array rather than
+ * skipped — "this list is now empty" is the news, and omitting it leaves the
+ * last non-empty answer on screen.
+ *
+ * Realtime and the write scope are LAZY-imported for the reason `tx-write-flush`
+ * documents: this module sits under the field-value write path, and pulling
+ * `realtime` into its static graph re-orders module evaluation across a cycle
+ * that runs through `@auxx/lib/cache`.
+ */
+async function announceInverseChanges(
+  ctx: RelationshipSyncContext,
+  announcements: InverseAnnouncement[]
+): Promise<void> {
+  const wanted = announcements.filter((a) => a.entityIds.length > 0)
+  if (wanted.length === 0) return
+
+  try {
+    // The record id and the raw field id are carried alongside the frame rather
+    // than re-derived from `entry.key`: `buildFieldValueKey` normalizes a bare
+    // field id into a `ResourceFieldId`, so the key is
+    // `<def>:<instance>:<def>:<field>` and slicing it back apart yields the
+    // qualified ref, not the plain field id the manifest's `outputKey` wants.
+    const pending: Array<{
+      recordId: RecordId
+      fieldId: string
+      entry: FieldValueUpdateEntry
+    }> = []
+
+    for (const announcement of wanted) {
+      const { entityDefinitionId, fieldId, entityIds, single } = announcement
+
+      const rows = await ctx.db
+        .select()
+        .from(schema.FieldValue)
+        .where(
+          and(
+            inArray(schema.FieldValue.entityId, entityIds),
+            eq(schema.FieldValue.fieldId, fieldId),
+            eq(schema.FieldValue.organizationId, ctx.organizationId)
+          )
+        )
+        .orderBy(asc(schema.FieldValue.entityId), asc(schema.FieldValue.sortKey))
+
+      // Seed every affected id with an empty list FIRST, so a record whose
+      // links were all removed still gets a frame (see the note above).
+      const byEntity = new Map<string, TypedFieldValue[]>(entityIds.map((id) => [id, []]))
+      for (const row of rows) {
+        byEntity
+          .get(row.entityId)
+          ?.push(rowToTypedValue(row as unknown as FieldValueRow, FieldTypeEnum.RELATIONSHIP))
+      }
+
+      for (const [entityId, values] of byEntity) {
+        const recordId = toRecordId(entityDefinitionId, entityId)
+        pending.push({
+          recordId,
+          fieldId,
+          entry: {
+            key: buildFieldValueKey(recordId, fieldId as FieldId),
+            value: single ? (values[0] ?? null) : values,
+          },
+        })
+      }
+    }
+
+    if (pending.length === 0) return
+
+    const { getAmbientTxWriteScope, recordTxWriteChange } = await import(
+      '../resources/crud/tx-write-scope'
+    )
+    const scope = getAmbientTxWriteScope()
+
+    if (scope) {
+      for (const { recordId, fieldId, entry } of pending) {
+        recordTxWriteChange(scope, {
+          recordId,
+          // The raw field id, matching the owning side's `systemAttribute ?? fieldId`
+          // fallback. No `systemAttribute` is resolvable from here.
+          outputKey: fieldId,
+          // No `o`: the pre-write array is gone by the time the rows are
+          // rewritten, and `recordTxWriteChange` treats `o` as optional.
+          change: { n: entry.value ?? null },
+          entry,
+        })
+      }
+      return
+    }
+
+    const realtime = await import('../realtime')
+    await realtime.publishFieldValueUpdates(
+      realtime.getRealtimeService(),
+      ctx.organizationId,
+      pending.map((p) => p.entry)
+    )
+  } catch {
+    // Best-effort by contract (3). The write is already durable; a client that
+    // misses this frame is exactly as stale as it was before D-11, no worse.
+  }
 }
 
 // ============================================================================
@@ -178,8 +348,9 @@ export async function syncInverseRelationships(
   }
 
   // Add inverse relationships for entities that were linked (2-3 queries)
+  let cascadeOwnerIds: string[] = []
   if (addedIds.length > 0) {
-    await batchAddToInverse(ctx, {
+    cascadeOwnerIds = await batchAddToInverse(ctx, {
       inverseFieldId: inverseInfo.inverseFieldId,
       inverseRelationshipType: inverseInfo.inverseRelationshipType,
       sourceEntityDefinitionId: inverseInfo.sourceEntityDefinitionId,
@@ -188,6 +359,26 @@ export async function syncInverseRelationships(
       sourceFieldId: inverseInfo.sourceFieldId,
     })
   }
+
+  // D-11: the records whose arrays actually moved, announced. `removedIds` and
+  // `addedIds` are TARGET ids (the other end of the link) — the source's own
+  // field was published by the caller that wrote it.
+  await announceInverseChanges(ctx, [
+    {
+      entityDefinitionId: inverseInfo.targetEntityDefinitionId,
+      fieldId: inverseInfo.inverseFieldId,
+      entityIds: [...new Set([...removedIds, ...addedIds])],
+      single: isSingleValued(inverseInfo.inverseRelationshipType),
+    },
+    // Re-parenting: moving a target from owner A to owner B also shortens A's
+    // list, on the SOURCE side's own field. That write is just as silent.
+    {
+      entityDefinitionId: inverseInfo.sourceEntityDefinitionId,
+      fieldId: inverseInfo.sourceFieldId,
+      entityIds: cascadeOwnerIds,
+      single: false,
+    },
+  ])
 
   return {
     removedFrom: removedIds,
@@ -252,8 +443,9 @@ export async function syncInverseRelationshipsBulk(
   }
 
   // ═══ Execute batched additions ═══
+  let cascadeOwnerIds: string[] = []
   if (additions.size > 0) {
-    await batchAddToInverse(ctx, {
+    cascadeOwnerIds = await batchAddToInverse(ctx, {
       inverseFieldId,
       inverseRelationshipType,
       sourceEntityDefinitionId,
@@ -262,6 +454,23 @@ export async function syncInverseRelationshipsBulk(
       sourceFieldId: inverseInfo.sourceFieldId,
     })
   }
+
+  // D-11, same contract as the single-entity path. Both maps are keyed by the
+  // TARGET id, so their union is exactly the set of records whose array moved.
+  await announceInverseChanges(ctx, [
+    {
+      entityDefinitionId: inverseInfo.targetEntityDefinitionId,
+      fieldId: inverseFieldId,
+      entityIds: [...new Set([...removals.keys(), ...additions.keys()])],
+      single: isSingleValued(inverseRelationshipType),
+    },
+    {
+      entityDefinitionId: sourceEntityDefinitionId,
+      fieldId: inverseInfo.sourceFieldId,
+      entityIds: cascadeOwnerIds,
+      single: false,
+    },
+  ])
 }
 
 // ============================================================================
@@ -343,11 +552,15 @@ interface BatchAddParams {
  * - 1 query to check existing links (dedupe)
  * - 1 query to get max sortKeys
  * - 1 batch INSERT for all new values
+ *
+ * @returns the ids of PREVIOUS owners whose own list was shortened by a
+ * re-parent (single-value branch only; empty otherwise). They are a second set
+ * of silently-rewritten records and D-11 announces them too.
  */
 async function batchAddToInverse(
   ctx: RelationshipSyncContext,
   params: BatchAddParams
-): Promise<void> {
+): Promise<string[]> {
   const {
     inverseFieldId,
     inverseRelationshipType,
@@ -357,7 +570,7 @@ async function batchAddToInverse(
     sourceFieldId,
   } = params
 
-  if (additions.size === 0) return
+  if (additions.size === 0) return []
 
   const isSingleValue =
     inverseRelationshipType === 'belongs_to' || inverseRelationshipType === 'has_one'
@@ -370,8 +583,10 @@ async function batchAddToInverse(
     }
   }
 
-  if (pairs.length === 0) return
+  if (pairs.length === 0) return []
 
+  /** Previous owners a re-parent shortened; single-value branch only. */
+  let cascadeOwnerIds: string[] = []
   const allTargetIds = [...additions.keys()]
 
   if (isSingleValue) {
@@ -418,6 +633,9 @@ async function batchAddToInverse(
     }
 
     // ═══ CASCADE DELETE: Remove targets from old owners' has_many fields ═══
+    // Reported back to the caller so D-11 can announce these owners too — their
+    // list just got shorter and, until D-11, nothing said so.
+    cascadeOwnerIds = [...cascadeRemovals.keys()]
     for (const [oldOwnerId, targetIds] of cascadeRemovals) {
       await ctx.db
         .delete(schema.FieldValue)
@@ -575,7 +793,7 @@ async function batchAddToInverse(
       ({ targetId, sourceId }) => !existingLinks.has(`${targetId}:${sourceId}`)
     )
 
-    if (toInsert.length === 0) return
+    if (toInsert.length === 0) return cascadeOwnerIds
 
     const targetIdsNeedingInsert = [...new Set(toInsert.map((p) => p.targetId))]
 
@@ -621,4 +839,6 @@ async function batchAddToInverse(
     // 1 batch INSERT
     await ctx.db.insert(schema.FieldValue).values(insertValues)
   }
+
+  return cascadeOwnerIds
 }

--- a/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
@@ -356,10 +356,14 @@ const DOOR_CONFORMANCE: Record<DoorId, DoorConformance> = {
   },
   inverseRelationshipVisibility: {
     kind: 'deferred',
-    status: 'unverifiable',
+    status: 'verified-elsewhere',
     where:
-      'relationship-sync diff is raw-SQL silent today; D-11 routes it through the session ' +
-      'collector in Phase 4/5 — no seam to observe until then',
+      'field-values/relationship-sync.ts `announceInverseChanges` — D-11 REALTIME arm landed: ' +
+      'the diff is published on the inverse record (inline, or buffered via ' +
+      'getAmbientTxWriteScope and replayed after COMMIT) and covered by ' +
+      'field-values/__tests__/inverse-announcement.test.ts. ⚠️ The timeline and record-rule arms ' +
+      'of this row are still unimplemented — the entry is no longer `unverifiable` because a ' +
+      'seam now exists, not because the row is fully satisfied',
   },
   integrityHooks: {
     kind: 'deferred',


### PR DESCRIPTION
Closes the write half of the bug #1934 patched at the read half.

## The defect

A relationship is stored **twice** — once on the record you edited (`purchase_order_line.purchase_order`) and once as a mirror on the record at the other end (`purchase_order_lines`). Only the first write was ever announced.

The mirror is rewritten in raw SQL by `field-values/relationship-sync.ts`, which **publishes nothing at all**. It computes the exact diff — `{removedFrom, addedTo}` — and every caller discards it; grep for those names outside that file returns zero non-test hits. A correct answer computed and dropped on the floor.

Two consequences:

- **Every screen holding the parent kept rendering its load-time list.** `field-value-fetch-queue.ts:241` skips a key already in the store, so not even a remount repaired it — only a full page reload, or a websocket reconnect whose `runCatchUp` refetches cached fields.
- **Record rules subscribing to a relationship field never fired on the inverse side.** Not intermittently — never. And a rule that doesn't run is indistinguishable from one whose condition wasn't met, so nobody could report it.

This was already decided and written down: **D-11** in `plans/events/03-write-context-and-batch-lane-plan.md`, defect **B-9**, with a `door-matrix.ts` row (`inverseRelationshipVisibility`, `interactive: 'per-record'`) that `door-conformance.test.ts` classified `unverifiable` — *"no seam to observe until then"*. This adds the seam.

## The change

`announceInverseChanges()` re-reads each affected record's array and publishes it, called from both `syncInverseRelationships` and `syncInverseRelationshipsBulk`. Three decisions, each documented at the site because each is a bug if reversed:

1. **No `excludeSocketId`.** Every ordinary publish suppresses the echo to the tab that made the change. Here the announced record is a *different* record from the one the user edited — to that tab it's news. Excluding it would leave the original bug in place for the person most likely to be looking at the screen. Pinned by a test.
2. **Buffered when a write scope is open** (`getAmbientTxWriteScope` → `recordTxWriteChange`, replayed by `flushTxWriteScope` after COMMIT). Announcing early is worse than silence: the subscriber re-reads on another connection, can't see uncommitted rows, and caches the *pre*-write value as fresh. Writing the `changes` bucket isn't bookkeeping — the flush iterates it to decide what to replay, so an entry without one would buffer and never send.
3. **Best-effort.** The rows are durable before we get here.

Two details that are easy to get wrong:

- A record whose list was **emptied publishes an empty array** rather than being skipped. "This list is now empty" is the news; omitting it leaves the last non-empty answer on screen.
- **Re-parenting is covered.** Moving a child from owner A to owner B also shortens A's list on the source-side field — an equally silent write — so `batchAddToInverse` now returns those owners.

Realtime and the write scope are lazy-imported, the dodge `tx-write-flush` documents for the `@auxx/lib/cache` evaluation cycle.

### The bills-card hand-patch is gone

`invalidateResource(recordId)` in `purchase-order-bills-card.tsx` existed *only* because the inverse write was silent. It's the cache-wiping call the codebase warns about (it's what made the line builder reset itself on every receipt), and it only ever helped the acting tab. Removing it is also what made the browser check decisive — see below.

## Test plan

**Driven in a browser**, which is the only check that settles this class. With the hand-patch removed, nothing but the D-11 frame could refresh the card: the PO's `purchase_order_bills` key was cached as empty and the fetch queue never re-requests a key it holds.

Added a bill on PO-0007 → **Billed $0.00 → $30.00**, "Unbilled" → "Still owed", and the `INV-D11-TEST` row appeared. No reload.

**6 new tests** in `inverse-announcement.test.ts`, driven through the same scripted fake db `inverse-repoint-fallback.test.ts` uses:
- publishes the parent's new array, keyed on the record at the other end
- **does not** pass `excludeSocketId`
- publishes an empty array when the last link is removed
- buffers via `recordTxWriteChange` while a write scope is open, and the buffered frame is byte-identical to the inline one
- a failed publish never fails the write
- says nothing when nothing changed

**Full `packages/lib` suite: 979 files / 13,050 tests pass.** Two files fail with `Test timed out in 10000ms`:
- `workflows/__tests__/workflow-draft-cas.test.ts` — **pre-existing**, A/B'd against `origin/main`'s `relationship-sync.ts` in a temp worktree: identical failure (2 failed / 3 passed) without D-11 present.
- `events/handlers/resolve-resource-trigger-match.test.ts` — passes 8/8 in isolation; a load flake.

Also: lib ratchet no new type errors (29, baseline 29); `apps/web` typecheck clean; biome clean; 305 web tests pass across `purchasing`/`money`/`drawers`/`resources`.

## Ledger

`inverseRelationshipVisibility` moves from `unverifiable` to `verified-elsewhere`, and the entry says plainly that **only the realtime arm landed** — the timeline and record-rule arms of that row are still unimplemented. It changed because a seam now exists, not because the row is satisfied.

## What this unblocks

Nine display-only surfaces still reading the mirror go live with no per-card work: `work_order_invoices`, `service_request_work_orders`/`_quotes`, `quote_work_orders` (×2), `purchase_order_bills` (×2), `order_work_orders`, `ticket_child_tickets`. Migrating them by hand was the alternative — nine new filters, each another chance to split a `createListKey` cache key, and none of it fixing the record-rules half.

## Still open (not in this PR)

**Sibling-list invalidation.** `appendCreatedRecord(key, id)` is key-scoped while `removeRecord(defId, id)` is def-wide, so two lists over the same def in one tab leave the non-acting one stale. A blind def-wide *append* would be wrong — deletes are monotone, creates aren't, so the row may fail the sibling's filter. The right shape is to *invalidate* siblings, coalesced, mirroring what remote tabs already do. Currently masked only by copy-paste-identical filter literals and manual `refresh()` calls.
