### PR TITLE
fix(purchasing): the server prices a receipt, not the browser

### DIFF
--- a/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
+++ b/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
@@ -31,6 +31,12 @@ export const DETAIL_VIEW_TAB_COMPONENTS: Record<
     import('../drawers/tabs/contact-tickets-tab').then((m) => ({ default: m.ContactTicketsTab })),
 
   // ─────────────────────────────────────────────────────────────────
+  // COMPANY TABS
+  // ─────────────────────────────────────────────────────────────────
+  'company:parts': () =>
+    import('../drawers/tabs/company-parts-tab').then((m) => ({ default: m.CompanyPartsTab })),
+
+  // ─────────────────────────────────────────────────────────────────
   // TICKET TABS
   // ─────────────────────────────────────────────────────────────────
   'ticket:conversation': () =>

--- a/apps/web/src/components/drawers/tabs/part-inventory-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-inventory-tab.tsx
@@ -19,17 +19,20 @@ import {
   TableHeader,
   TableRow,
 } from '@auxx/ui/components/table'
+import { toastError } from '@auxx/ui/components/toast'
 import { formatRelativeTime } from '@auxx/utils'
 import { formatCurrency } from '@auxx/utils/currency'
-import { Package, PackagePlus } from 'lucide-react'
+import { Package, PackagePlus, Undo2 } from 'lucide-react'
 import { useMemo } from 'react'
 import { ReceiveStockPopover } from '~/components/manufacturing/parts/receive-stock-popover'
 import { StockAdjustmentPopover } from '~/components/manufacturing/parts/stock-adjustment-popover'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useFieldValueStore } from '~/components/resources/store/field-value-store'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useSettings } from '~/hooks/use-settings'
 import { useAccess } from '~/providers/capabilities-provider'
+import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
 /** Map movement type values to badge color variants */
@@ -68,6 +71,11 @@ const MOVEMENT_ATTRIBUTES = [
   // arrived, which is not when somebody got round to keying them.
   'stock_movement_unit_cost',
   'stock_movement_occurred_at',
+  // The two halves of the reversal link (entity migration 108). A row that already
+  // has a reversal must not get a second one, and a row that IS a reversal is not
+  // itself reversible — the correction for a bad correction is a fresh movement.
+  'stock_movement_reverses_movement',
+  'stock_movement_reversed_by_movements',
 ] as const
 
 /** Inventory tab for the part detail view */
@@ -199,6 +207,7 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
                   <TableHead className='text-right'>Unit cost</TableHead>
                   <TableHead>Reason</TableHead>
                   <TableHead className='text-right'>Date</TableHead>
+                  <TableHead className='w-10' />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -208,6 +217,8 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
                     recordId={toRecordId(stockMovementDefId!, record.id)}
                     createdAt={record.createdAt}
                     currencyCode={currencyCode}
+                    canReverse={canAdjustStock}
+                    onReversed={handleAdjustSuccess}
                   />
                 ))}
               </TableBody>
@@ -225,11 +236,21 @@ function MovementRow({
   recordId,
   createdAt,
   currencyCode,
+  canReverse,
+  onReversed,
 }: {
   recordId: RecordId
   createdAt?: string | Date
   currencyCode: string
+  canReverse: boolean
+  onReversed: () => void
 }) {
+  const [confirm, ConfirmDialog] = useConfirm()
+  const reverseMovement = api.purchasing.reverseMovement.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Could not reverse movement', description: error.message })
+    },
+  })
   const { values } = useSystemValues(recordId, MOVEMENT_ATTRIBUTES, { autoFetch: true })
 
   const type = values.stock_movement_type as string | undefined
@@ -241,6 +262,30 @@ function MovementRow({
   // COALESCE(occurredAt, createdAt) — an adjustment carries no accounting date, so
   // it falls back to when it was written. A receipt has one and it is the truth.
   const shownAt = occurredAt ?? createdAt
+
+  // A movement with no frozen cost cannot be reversed: the negation would be the
+  // zero-cost row `receiveStock` refuses to write in the first place. A row that
+  // already has a reversal, or that IS one, is equally out — the server enforces
+  // all three, this only keeps the menu honest.
+  const alreadyReversed =
+    ((values.stock_movement_reversed_by_movements as unknown[]) ?? []).length > 0
+  const isReversal = values.stock_movement_reverses_movement != null
+  const canReverseThis = canReverse && unitCost != null && !alreadyReversed && !isReversal
+
+  const handleReverse = async () => {
+    const confirmed = await confirm({
+      title: 'Reverse this movement?',
+      description:
+        'A cancelling movement is written at the original frozen cost. The original stays in the ledger.',
+      confirmText: 'Reverse',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    const { entityInstanceId } = parseRecordId(recordId)
+    await reverseMovement.mutateAsync({ movementId: entityInstanceId })
+    onReversed()
+  }
 
   const isPositive = quantity != null && quantity > 0
   const label = type ? (TYPE_LABEL_MAP[type] ?? type) : '—'
@@ -271,6 +316,19 @@ function MovementRow({
         <span className='text-xs text-muted-foreground'>
           {shownAt ? formatRelativeTime(shownAt, true) : '—'}
         </span>
+      </TableCell>
+      <TableCell className='text-right'>
+        <ConfirmDialog />
+        {canReverseThis ? (
+          <Button
+            variant='ghost'
+            size='xs'
+            loading={reverseMovement.isPending}
+            onClick={handleReverse}
+            aria-label='Reverse this movement'>
+            <Undo2 />
+          </Button>
+        ) : null}
       </TableCell>
     </TableRow>
   )

--- a/apps/web/src/components/manufacturing/parts/receipt-input.test.ts
+++ b/apps/web/src/components/manufacturing/parts/receipt-input.test.ts
@@ -67,26 +67,27 @@ describe('receiptBreakdown', () => {
 })
 
 describe('buildReceiptInput', () => {
-  it('always sends unitCost alongside vendorUnitPrice', () => {
-    // 🛑 The whole reason this module exists. `receiveStock` derives landed from
-    // the supplier row's OWN unitPrice when `unitCost` is absent, so sending only
-    // the edited base would freeze a cost computed from the replaced price —
-    // silently, with no error and a row that looks correct.
+  it('🛑 sends the BASE price and never a cost', () => {
+    // The whole reason this module exists. The landed figure is the server's to
+    // resolve — `purchasing.receiveStock` does not accept a `unitCost` at all —
+    // so what goes on the wire is the price off the packing slip, edits included.
     const input = buildReceiptInput(formState({ unitPrice: 5000 }))
     expect(input?.vendorUnitPrice).toBe(5000)
-    expect(input?.unitCost).toBe(5335)
+    expect(input).not.toHaveProperty('unitCost')
   })
 
-  it('sends the exact number the breakdown displayed', () => {
+  it('sends the base the breakdown was computed from, not the landed total', () => {
     const state = formState()
-    expect(buildReceiptInput(state)?.unitCost).toBe(receiptBreakdown(state)?.landed)
+    const breakdown = receiptBreakdown(state)
+    expect(buildReceiptInput(state)?.vendorUnitPrice).toBe(breakdown?.base)
+    expect(breakdown?.landed).not.toBe(breakdown?.base)
   })
 
   it('omits the supplier when the part has no row, and still prices the receipt', () => {
     const input = buildReceiptInput(formState({ vendorPartId: null, terms: null }))
     expect(input).not.toBeNull()
     expect(input).not.toHaveProperty('vendorPartId')
-    expect(input?.unitCost).toBe(4400)
+    expect(input?.vendorUnitPrice).toBe(4400)
   })
 
   it('refuses a non-positive quantity', () => {

--- a/apps/web/src/components/manufacturing/parts/receipt-input.ts
+++ b/apps/web/src/components/manufacturing/parts/receipt-input.ts
@@ -2,16 +2,20 @@
 
 // What the Receive form actually sends, as a pure function of what is on screen.
 //
-// Extracted from `receive-stock-popover.tsx` because ONE detail here is both
-// load-bearing and invisible: `receiveStock` derives the landed cost from the
-// supplier row's OWN `unitPrice` whenever `unitCost` is absent
-// (`receive-stock.ts` → `resolveReceiptPrice`). So a form that sends only the
-// edited `vendorUnitPrice` stores a cost computed from the price the user just
-// replaced — the edit appears to work, the row looks right, and the frozen cost
-// is wrong forever. Nothing throws.
+// Extracted from `receive-stock-popover.tsx` because the one rule here is
+// invisible in a rendered form: THE FORM SENDS A PRICE, NEVER A COST. The price
+// it sends is the base — what the packing slip says the vendor charged — and the
+// server applies the supplier row's freight, tariff and other terms on top of it
+// and owns the landed figure that gets frozen onto the movement. There is no
+// `unitCost` on the wire, and `purchasing.receiveStock`'s input schema does not
+// accept one, which is what makes "the browser cannot assert an inventory cost"
+// a fact rather than a convention
+// (plans/purchasing/05-receiving-cost-and-corrections.md §4.1).
 //
-// The rule is therefore: whenever the form can price a receipt at all, it sends
-// BOTH figures, and the landed one is the same number the breakdown showed.
+// The breakdown this module computes is DISPLAY ONLY — the same arithmetic the
+// server runs, shown so the person keying the receipt can see what it will cost
+// before committing. It is a preview of a server-computed number, not the number
+// being submitted.
 
 import type { ReceiptCostInputs, ReceiptCostParts } from '@auxx/lib/receiving/client'
 import { computeReceiptLandedBreakdown } from '@auxx/lib/receiving/client'
@@ -21,8 +25,8 @@ export interface ReceiptInput {
   partId: string
   quantity: number
   vendorPartId?: string
+  /** The BASE price per unit, minor units — never the landed cost. */
   vendorUnitPrice: number
-  unitCost: number
   occurredAt: Date
   reference?: string
   reason?: string
@@ -45,12 +49,13 @@ export interface ReceiptFormState {
 }
 
 /**
- * The landed breakdown for the price currently on screen.
+ * The landed breakdown for the price currently on screen — for display.
  *
  * The adders come from the selected supplier row and the base comes from the
  * INPUT, not the row: freight and tariff terms still apply to a price the vendor
  * actually charged, so an edited price is a new base under the same terms rather
- * than a reason to drop them.
+ * than a reason to drop them. That is the same rule `resolveReceiptPrice` applies
+ * server-side, which is why the figure shown here is the figure stored.
  */
 export function receiptBreakdown(state: ReceiptFormState): ReceiptCostParts | null {
   if (state.unitPrice == null) return null
@@ -84,9 +89,9 @@ export function buildReceiptInput(state: ReceiptFormState): ReceiptInput | null 
     partId: state.partId,
     quantity: state.quantity,
     ...(state.vendorPartId ? { vendorPartId: state.vendorPartId } : {}),
-    // Both, always — see the note at the top of this file.
+    // The base only. The server reads the supplier row for the adders and
+    // resolves the landed cost itself — see the note at the top of this file.
     vendorUnitPrice: breakdown.base,
-    unitCost: breakdown.landed,
     occurredAt: new Date(state.occurredAt),
     ...(reference ? { reference } : {}),
     ...(reason ? { reason } : {}),

--- a/apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
@@ -14,11 +14,16 @@
 // invoice is the fact, and freezing the guess is how inventory value drifts away
 // from what was really paid.
 //
-// The landed cost is shown broken out beneath it — `$47.10 = $44.00 + $1.20
-// freight + $1.90 tariff (4.3%)` — because that total is what gets frozen onto the
-// movement forever, and a number nobody can check is a number nobody catches.
-// Client and server compute it with the SAME `computeReceiptLandedCost`, so the
-// figure on screen is the figure stored.
+// 🛑 That price is the ONLY money this form sends. The landed cost is resolved
+// server-side from the price it was handed plus the supplier row's adders, and
+// `purchasing.receiveStock` does not accept a cost from the browser at all.
+//
+// The landed figure is still shown broken out beneath the input — `$47.10 =
+// $44.00 + $1.20 freight + $1.90 tariff (4.3%)` — because that total is what gets
+// frozen onto the movement forever, and a number nobody can check is a number
+// nobody catches. It is a PREVIEW: client and server run the same
+// `computeReceiptLandedCost` over the same inputs, so the figure on screen is the
+// figure stored, but the server is the one that computes the stored one.
 
 import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'

--- a/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
@@ -8,8 +8,8 @@ import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
-import { toRecordId, useResourceProperty } from '~/components/resources'
 import { BaseType } from '~/components/workflow/types'
+import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
 
 type Direction = 'add' | 'remove'
@@ -54,6 +54,20 @@ interface StockAdjustmentPopoverProps {
  * a finished good does consume its components, and a sale is negative, so the
  * explosion negates. It was only ever the arbitrary direction of an `adjust`
  * that made the cascade wrong. Do not remove the field.
+ *
+ * 🛑 **This form calls `purchasing.adjustStock`, never the generic
+ * `record.create`.** It used to write a `stock_movement` directly, which made it
+ * a third movement writer that bypassed the zero-cost guard entirely: no
+ * `unit_cost`, no `extended_cost`, no `gl_account`, no `cost_basis`. A positive
+ * adjustment therefore added stock valued at nothing, which understates COGS and
+ * drags the part's average cost toward zero
+ * (plans/purchasing/05-receiving-cost-and-corrections.md §1.5).
+ *
+ * That is why the Unit cost input below appears only when the adjustment ADDS
+ * stock. Adding creates inventory value and something has to say what it is
+ * worth; removing consumes value the ledger already carries, and valuing a
+ * removal properly needs a costing method this system does not have yet. So a
+ * removal is exactly as unencumbered as it has always been.
  */
 export function StockAdjustmentPopover({
   partId,
@@ -65,11 +79,16 @@ export function StockAdjustmentPopover({
   const [direction, setDirection] = useState<Direction>('add')
   const [quantityMode, setQuantityMode] = useState<QuantityMode>('adjust_by')
   const [quantity, setQuantity] = useState<number | null>(null)
+  const [unitCost, setUnitCost] = useState<number | null>(null)
+  // Whether the cost shown is the person's own number rather than the prefill.
+  // Without this, the prefill effect would quietly overwrite a typed cost once
+  // the query resolved.
+  const [costEdited, setCostEdited] = useState(false)
   const [reason, setReason] = useState('')
   const [reference, setReference] = useState('')
 
-  const stockMovementDefId = useResourceProperty('stock_movement', 'id')
-  const partDefId = useResourceProperty('part', 'id')
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
 
   // Reset form when popover opens
   useEffect(() => {
@@ -77,62 +96,83 @@ export function StockAdjustmentPopover({
       setDirection('add')
       setQuantityMode('adjust_by')
       setQuantity(null)
+      setUnitCost(null)
+      setCostEdited(false)
       setReason('')
       setReference('')
     }
   }, [open])
 
-  const createRecord = api.record.create.useMutation({
+  /**
+   * The signed delta this form will send — the one number both the cost input's
+   * visibility and the submit guard are derived from, so they can never disagree
+   * about which direction the adjustment goes.
+   */
+  const delta = useMemo(() => {
+    const qty = quantity ?? 0
+    if (quantityMode === 'set_to') return qty - currentQoH
+    return direction === 'remove' ? -Math.abs(qty) : Math.abs(qty)
+  }, [quantity, quantityMode, direction, currentQoH])
+
+  const isAdding = delta > 0
+
+  // What we last actually paid for this part — the honest default for "what are
+  // the added units worth". Absent history simply leaves the field empty; it is
+  // a prefill and never a floor.
+  const lastCost = api.purchasing.lastReceiptCost.useQuery(
+    { partInstanceId: partId },
+    { enabled: open }
+  )
+
+  useEffect(() => {
+    if (!open || costEdited) return
+    setUnitCost(lastCost.data ?? null)
+  }, [open, costEdited, lastCost.data])
+
+  const adjustStock = api.purchasing.adjustStock.useMutation({
     onError: (error) => {
       toastError({ title: 'Failed to adjust stock', description: error.message })
     },
   })
 
+  const isPending = adjustStock.isPending
+
+  /**
+   * The friendly duplicate of the server guard, not the guard itself.
+   *
+   * `adjustStock` refuses a zero delta and refuses an addition that does not
+   * round to a positive cost; both are real `AuxxError`s. Disabling the button
+   * is a better answer than a toast, but it must never be the only check —
+   * `receipt-input.ts` states the same rule for the receive form.
+   */
+  const missingCost = isAdding && (unitCost == null || unitCost <= 0)
+  const canSubmit = delta !== 0 && !missingCost
+
   const handleSubmit = useCallback(async () => {
-    if (!stockMovementDefId || !partDefId) return
-    const qty = quantity ?? 0
-    if (qty === 0 && quantityMode === 'adjust_by') return
-
-    let finalQuantity: number
-
-    if (quantityMode === 'set_to') {
-      finalQuantity = qty - currentQoH
-    } else {
-      finalQuantity = direction === 'remove' ? -Math.abs(qty) : Math.abs(qty)
+    if (!canSubmit) return
+    try {
+      await adjustStock.mutateAsync({
+        partId,
+        quantity: delta,
+        ...(delta > 0 && unitCost != null ? { unitCost } : {}),
+        ...(reason ? { reason } : {}),
+        ...(reference ? { reference } : {}),
+      })
+      onSuccess?.()
+      setOpen(false)
+    } catch {
+      // onError above already surfaced the toast.
     }
-
-    await createRecord.mutateAsync({
-      entityDefinitionId: stockMovementDefId,
-      values: {
-        stock_movement_part: toRecordId(partDefId, partId),
-        stock_movement_type: 'adjust',
-        stock_movement_quantity: finalQuantity,
-        ...(reason && { stock_movement_reason: reason }),
-        ...(reference && { stock_movement_reference: reference }),
-      },
-    })
-
-    onSuccess?.()
-    setOpen(false)
-  }, [
-    stockMovementDefId,
-    partDefId,
-    partId,
-    quantity,
-    quantityMode,
-    direction,
-    currentQoH,
-    reason,
-    reference,
-    createRecord,
-    onSuccess,
-  ])
+  }, [canSubmit, adjustStock, partId, delta, unitCost, reason, reference, onSuccess])
 
   const isSetToMode = quantityMode === 'set_to'
-  const isPending = createRecord.isPending
 
   const directionFieldOptions = useMemo(() => ({ options: DIRECTION_OPTIONS }), [])
   const quantityModeFieldOptions = useMemo(() => ({ options: QUANTITY_MODE_OPTIONS }), [])
+  const currencyFieldOptions = useMemo(
+    () => ({ currencyCode, decimals: 2, useGrouping: true }),
+    [currencyCode]
+  )
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -189,11 +229,37 @@ export function StockAdjustmentPopover({
               />
               {isSetToMode && quantity !== null && (
                 <p className='text-xs text-muted-foreground mt-1'>
-                  Delta: {quantity - currentQoH >= 0 ? '+' : ''}
-                  {quantity - currentQoH}
+                  Delta: {delta >= 0 ? '+' : ''}
+                  {delta}
                 </p>
               )}
             </FieldPanelRow>
+
+            {/* Unit cost — additions only. See the note on this component. */}
+            {isAdding && (
+              <FieldPanelRow
+                title='Unit cost'
+                type={BaseType.CURRENCY}
+                showIcon
+                isRequired
+                description='What one added unit is worth'>
+                <FieldInputAdapter
+                  fieldType={FieldType.CURRENCY}
+                  fieldOptions={currencyFieldOptions}
+                  value={unitCost}
+                  onChange={(val) => {
+                    setUnitCost((val as number) ?? null)
+                    setCostEdited(true)
+                  }}
+                  disabled={isPending}
+                />
+                <p className='text-xs text-muted-foreground mt-1'>
+                  {missingCost
+                    ? 'Adding stock creates inventory value, so it cannot be added at no cost.'
+                    : 'Prefilled from the last receipt of this part. Overwrite it with what these units are worth.'}
+                </p>
+              </FieldPanelRow>
+            )}
 
             {/* Reason */}
             <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
@@ -228,7 +294,8 @@ export function StockAdjustmentPopover({
               size='xs'
               onClick={handleSubmit}
               loading={isPending}
-              loadingText='Saving...'>
+              loadingText='Saving...'
+              disabled={!canSubmit}>
               Save
             </Button>
           </div>

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -310,6 +310,9 @@ export function LineBuilder({
   // a keyboard-driven or button-driven "add row" lands the caret ready to type.
   const [lastAddedDraftId, setLastAddedDraftId] = useState<string | null>(null)
   const draftsRef = useRef<DraftLine[]>([])
+  // draftId -> the record its create produced. Kept because a prefill that
+  // resolves on its own clock needs a target after the draft is gone.
+  const draftRecordIdsRef = useRef<Map<string, RecordId>>(new Map())
   /**
    * Single draft-state writer: applies the update to `draftsRef` synchronously
    * and mirrors the result into state, so two writers in one tick can never
@@ -840,6 +843,7 @@ export function LineBuilder({
         }
 
         creatingDraftIdsRef.current.delete(draftId)
+        draftRecordIdsRef.current.set(draftId, result.recordId)
         mutateDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
       } catch (error) {
         creatingDraftIdsRef.current.delete(draftId)
@@ -861,6 +865,50 @@ export function LineBuilder({
       seedCreatedRecord,
       appendCreated,
     ]
+  )
+
+  /**
+   * Land a patch that resolved on its OWN clock — the supplier price prefill
+   * (plans/purchasing/05-receiving-cost-and-corrections.md section 5.2).
+   *
+   * 🛑 Deliberately NOT `createDraft`, which was the first implementation and
+   * carried two defects, both of which need this function to stay separate:
+   *
+   * 1. `createDraft` opens with `initialDraftIdsRef.current.clear()`. A second
+   *    call arriving just after the first create dropped its draft can land in
+   *    the frame where the "never render zero rows" effect has re-seeded a
+   *    placeholder. Clearing the set orphans that placeholder from the cleanup
+   *    that would have removed it, and the row visibly flickers in and out.
+   * 2. A prefill patch carries no `partRecordId`, so it fails the
+   *    `draftRequiresPart` guard and accumulates onto a draft that no longer
+   *    exists — a silent no-op. Whenever the lookup finished after the create,
+   *    the price was simply dropped, with nothing thrown and nothing logged.
+   *
+   * The caller sequences this AFTER the create rather than racing it, so the
+   * common path is the record write below. The draft branch is the retry case:
+   * `createDraft` toasts and leaves the draft in place when the create fails,
+   * and the patch should survive to be carried by the next attempt.
+   */
+  const applyPrefillPatch = useCallback(
+    async (draftId: string, patch: LinePatch) => {
+      const recordId = draftRecordIdsRef.current.get(draftId)
+      if (!recordId) {
+        mutateDrafts((prev) => prev.map((d) => (d.draftId === draftId ? { ...d, ...patch } : d)))
+        return
+      }
+      const changed = linePatchToFieldValues(patch, schema)
+      if (changed.length === 0) return
+      try {
+        await saveMultipleAsync(recordId, changed)
+      } catch (error) {
+        toastError({
+          title: 'Error applying the supplier price',
+          description:
+            error instanceof Error ? error.message : 'Could not apply the supplier price',
+        })
+      }
+    },
+    [mutateDrafts, saveMultipleAsync, schema]
   )
 
   /**
@@ -1321,6 +1369,7 @@ export function LineBuilder({
                       onRevealWeight={revealWeight}
                       deleteDraft={deleteDraft}
                       createDraft={createDraft}
+                      applyPrefillPatch={applyPrefillPatch}
                       onSelectGroup={handleGroupPickDraft}
                     />
                   )

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -106,6 +106,7 @@ import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-valu
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSeedCreatedRecord } from '~/components/resources/hooks/use-seed-created-record'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
@@ -118,6 +119,8 @@ import {
   LINE_COLS,
   LineRow,
   type MatchKeyEditorRenderer,
+  type PartPrefillLookup,
+  type PartPrefillResolver,
   relKeyForDocumentType,
 } from './line-rows'
 import {
@@ -131,6 +134,7 @@ import {
   lineAttributesFor,
   linePatchToFieldValues,
   lineSchemaFor,
+  numberOrNull,
 } from './line-values'
 import { TotalsFooter } from './totals-footer'
 import { useLineHotkeys } from './use-line-hotkeys'
@@ -161,6 +165,17 @@ export interface LineBuilderProps {
    * so `money` never depends on `purchasing`; see {@link MatchKeyEditorRenderer}.
    */
   renderMatchKeyEditor?: MatchKeyEditorRenderer
+  /**
+   * Look up the supplier's price for a part just picked on a line
+   * (plans/purchasing/05-receiving-cost-and-corrections.md §5.2).
+   *
+   * Only ever called on a document whose schema names a {@link LineSchema.vendorAttr}
+   * AND whose parent record actually carries a vendor — so a purchase order with
+   * no supplier yet simply never prefills, rather than the resolver having to
+   * decide that for itself. Absent → picking a part writes the part and nothing
+   * else, which is the behaviour every document had before this existed.
+   */
+  resolvePartPrefill?: PartPrefillLookup
 }
 
 const INITIAL_DRAFT_COUNT = 3
@@ -191,6 +206,7 @@ export function LineBuilder({
   visitId,
   className,
   renderMatchKeyEditor,
+  resolvePartPrefill,
 }: LineBuilderProps) {
   const docRecordId = documentRecordId as RecordId
   // Everything document-shaped is one lookup. See the warning on `LINE_SCHEMAS`.
@@ -259,6 +275,25 @@ export function LineBuilder({
   )
   const matchScopeRecordId = schema.matchScopeAttr
     ? (extractRelationshipRecordIds(matchScopeValues[schema.matchScopeAttr])[0] ?? null)
+    : null
+
+  /**
+   * The supplier this document is placed with (`schema.vendorAttr`), read once
+   * per builder for the same reason {@link matchScopeRecordId} is: the answer is
+   * identical for every row, and the price prefill needs it on every part pick.
+   *
+   * `null` on a purchase order with no vendor yet, which is a legitimate state —
+   * a person can start typing lines before deciding who to buy from. The prefill
+   * simply does not run, exactly as it does not for a part the supplier has no
+   * catalogue entry for.
+   */
+  const { values: vendorValues } = useSystemValues(
+    docRecordId,
+    schema.vendorAttr ? [schema.vendorAttr] : [],
+    { autoFetch: !!schema.vendorAttr, enabled: !!schema.vendorAttr }
+  )
+  const vendorRecordId = schema.vendorAttr
+    ? (extractRelationshipRecordIds(vendorValues[schema.vendorAttr])[0] ?? null)
     : null
 
   const taxRates = useMemo(
@@ -469,6 +504,57 @@ export function LineBuilder({
     enabled: lineRecordIds.length > 0 && lineFieldIds.length > 0,
   })
 
+  /**
+   * The consumer's vendor-part lookup with this document's vendor bound in — or
+   * `undefined`, which is what every row reads as "picking a part writes the part
+   * and nothing else".
+   *
+   * Binding here rather than passing both halves down is what keeps the "no
+   * vendor ⇒ no prefill" rule in ONE place instead of in every row's pick handler.
+   */
+  const boundResolvePartPrefill = useMemo<PartPrefillResolver | undefined>(() => {
+    if (!resolvePartPrefill || !vendorRecordId) return undefined
+    return (partRecordId) => resolvePartPrefill({ partRecordId, vendorRecordId })
+  }, [resolvePartPrefill, vendorRecordId])
+
+  /**
+   * Whether the weight cell is showing on EVERY line of this document
+   * (plans/purchasing/05-receiving-cost-and-corrections.md §5.3).
+   *
+   * 🛑 The one line-level concept resolved at DOCUMENT level, and deliberately so.
+   * `allocateLandedCost` spreads freight by each line's share of the total weight,
+   * so a set where some lines are weighed and others are not is not partly
+   * configured — the weighed lines silently absorb all of the freight. A per-row
+   * reveal (which is how the match key and the GL account behave) would make that
+   * the likely state, so instead: one line's menu declares it, and the cell
+   * appears on all of them, blanks included.
+   *
+   * Two sources, either of which is enough. `weightDeclared` is this session's
+   * intent — somebody opened the editor from a row menu, and the siblings must
+   * show their blanks immediately, before anything is saved. The store read is the
+   * persisted answer, so a reopened order that already has weights comes back
+   * revealed. Drafts are checked too: an unsaved row is part of the same set.
+   */
+  const weightAttr = schema.attrs.weight
+  const weightAttrs = useMemo(() => (weightAttr ? [weightAttr] : []), [weightAttr])
+  // A passive subscription over the keys the syncer above already queued — this
+  // is one shallow read across N lines, not N reads (see the hook's own note),
+  // and it is the only way the builder can see an answer that lives across rows.
+  const { valuesById: lineWeightValues } = useSystemValuesForRecords(lineRecordIds, weightAttrs, {
+    autoFetch: false,
+    enabled: !!weightAttr && lineRecordIds.length > 0,
+  })
+  const [weightDeclared, setWeightDeclared] = useState(false)
+  const revealWeight = useCallback(() => setWeightDeclared(true), [])
+  const weightRevealed = useMemo(() => {
+    if (!weightAttr) return false
+    if (weightDeclared) return true
+    if (visibleDrafts.some((draft) => draft.weight !== null)) return true
+    return lineRecordIds.some(
+      (recordId) => numberOrNull(lineWeightValues[recordId]?.[weightAttr]) !== null
+    )
+  }, [weightAttr, weightDeclared, visibleDrafts, lineRecordIds, lineWeightValues])
+
   // Mutations (stable fns destructured — the wrapper objects churn per render).
   const reorderLines = api.money.reorderLines.useMutation()
   const recomputeTotals = api.money.recomputeTotals.useMutation()
@@ -660,6 +746,13 @@ export function LineBuilder({
         set('purchaseOrderLineRecordId', snapshot.purchaseOrderLineRecordId)
       }
       if (snapshot.glAccount) set('glAccount', snapshot.glAccount)
+      // Both are purchase-order-only and dropped by `set` everywhere else. The
+      // vendor part is provenance stamped by the price prefill; the weight is the
+      // freight allocation's basis input. Sent on the create rather than as a
+      // follow-up write so a row picked-and-prefilled before it materializes
+      // lands complete in one round trip.
+      if (snapshot.vendorPartRecordId) set('vendorPartRecordId', snapshot.vendorPartRecordId)
+      if (snapshot.weight !== null) set('weight', snapshot.weight)
       return values
     },
     [schema, documentRecordId, visitId]
@@ -1201,6 +1294,9 @@ export function LineBuilder({
                       catalogLoading={catalogLoading}
                       matchScopeRecordId={matchScopeRecordId}
                       renderMatchKeyEditor={renderMatchKeyEditor}
+                      weightRevealed={weightRevealed}
+                      resolvePartPrefill={boundResolvePartPrefill}
+                      onRevealWeight={revealWeight}
                       onUpdateLine={updateLine}
                       deleteLine={deleteLine}
                       onSelectGroup={handleGroupPick}
@@ -1220,6 +1316,9 @@ export function LineBuilder({
                       catalogLoading={catalogLoading}
                       matchScopeRecordId={matchScopeRecordId}
                       renderMatchKeyEditor={renderMatchKeyEditor}
+                      weightRevealed={weightRevealed}
+                      resolvePartPrefill={boundResolvePartPrefill}
+                      onRevealWeight={revealWeight}
                       deleteDraft={deleteDraft}
                       createDraft={createDraft}
                       onSelectGroup={handleGroupPickDraft}

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -2167,6 +2167,7 @@ export function DraftLineRow({
   onRevealWeight,
   deleteDraft,
   createDraft,
+  applyPrefillPatch,
   onSelectGroup,
 }: {
   draft: DraftLine
@@ -2187,6 +2188,7 @@ export function DraftLineRow({
   onRevealWeight: () => void
   deleteDraft: (draftId: string) => void
   createDraft: (draftId: string, overrides?: LinePatch) => Promise<void>
+  applyPrefillPatch: (draftId: string, patch: LinePatch) => Promise<void>
   onSelectGroup: (draftId: string, group: CatalogGroup) => void
 }) {
   const schema = lineSchemaFor(documentType)
@@ -2222,17 +2224,18 @@ export function DraftLineRow({
             // (`capabilities.draftRequiresPart`), and any of these commits can
             // materialize the row. See LinePartCellView and `createDraft`.
             //
-            // The prefill follows as a second `createDraft` call rather than
-            // being awaited into the first: the row must appear the instant the
-            // part is picked, and `createDraft` already accumulates anything that
-            // lands while its own create is in flight, then diff-flushes it.
+            // The create fires immediately, so the row still appears the instant
+            // the part is picked. The PREFILL is then sequenced after it rather
+            // than racing it: `applyPrefillPatch` needs a settled target, and a
+            // patch that lands mid-create used to either flicker a placeholder
+            // row or be silently dropped. See `applyPrefillPatch` for both.
             onPickPart={(partRecordId) => {
-              void createDraft(draft.draftId, { partRecordId })
+              const created = createDraft(draft.draftId, { partRecordId })
               void applyPartPrefill({
                 partRecordId,
                 resolve: resolvePartPrefill,
                 currentPriceRef: priceRef,
-                apply: (patch) => void createDraft(draft.draftId, patch),
+                apply: (patch) => void created.then(() => applyPrefillPatch(draft.draftId, patch)),
               })
             }}
             // Also routed through `createDraft`, which accumulates rather than

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -66,6 +66,7 @@ import {
   Tags,
   Trash2,
   TriangleAlert,
+  Weight,
   X,
 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
@@ -160,6 +161,51 @@ export type MatchKeyEditorRenderer = (props: {
   scopeRecordId: RecordId | null
   currencyCode: string
 }) => ReactNode
+
+/**
+ * What the `(part, supplier)` vendor-part lookup found
+ * (plans/purchasing/05-receiving-cost-and-corrections.md §5.2).
+ *
+ * Three distinct answers, and the caller must keep them apart:
+ *
+ * - `null` (the whole result) — the lookup could not run: this document does not
+ *   prefill, the order names no vendor, the request failed. **Write nothing.**
+ * - `vendorPartRecordId: null` — it ran and this supplier has no catalogue entry
+ *   for this part. The link is CLEARED, because whatever it pointed at belonged
+ *   to the part that was there before; no price is written.
+ * - both set — the supplier row, and the price to seed the cell with **if the
+ *   cell is still empty**.
+ *
+ * 🛑 The price half is a prefill and only a prefill. Nothing may re-derive a
+ * line's price through the link once it is set — see `LineValues.vendorPartRecordId`.
+ */
+export interface PartPrefill {
+  vendorPartRecordId: RecordId | null
+  /** Integer minor units, matching `expected_unit_price`. */
+  unitPriceCents: number | null
+}
+
+/**
+ * Look up the supplier's catalogue entry for a part — supplied by the CONSUMER.
+ *
+ * 🛑 A prop rather than a call to `api.purchasing.*` from here, for the same
+ * reason {@link MatchKeyEditorRenderer} is a render prop: this is the `money`
+ * module, and the only document that prefills is a PURCHASE ORDER. Reaching into
+ * the purchasing router from a document-agnostic builder makes every quote and
+ * invoice carry a purchasing dependency to use a feature they do not have.
+ *
+ * `vendorRecordId` is resolved by the builder from {@link LineSchema.vendorAttr},
+ * exactly as `scopeRecordId` is for the match key, so the consumer never re-fetches
+ * the parent it is already rendered inside — and so this is never called at all
+ * for an order with no vendor on it.
+ */
+export type PartPrefillLookup = (params: {
+  partRecordId: RecordId
+  vendorRecordId: RecordId
+}) => Promise<PartPrefill | null>
+
+/** {@link PartPrefillLookup} with the document's vendor already bound, as a row sees it. */
+export type PartPrefillResolver = (partRecordId: RecordId) => Promise<PartPrefill | null>
 
 /**
  * A phantom line row that exists only in local state until its first real
@@ -1138,6 +1184,26 @@ function MenuShortcut({ keys }: { keys: string[] }) {
  * account are the two newest members of that set — neither earns a grid column,
  * and adding one would have widened `LINE_COLS` for every document
  * (plans/purchasing/04-vendor-bill-lines-and-the-amount-cell.md §2).
+ *
+ * 🛑 **A purchase order line's WEIGHT joins that set with one deliberate
+ * deviation: setting it from one row's menu reveals the control on EVERY line of
+ * the document, not just that row.** The difference is arithmetic, not taste.
+ *
+ * A GL account is a property of one line and means something on its own — a line
+ * with one and a line without are both fully described. A weight is a **basis
+ * input that only means anything across the whole set**: `allocateLandedCost`
+ * spreads freight by each line's share of the total weight, so one line carrying
+ * a weight while its siblings do not is not "partly configured", it is a broken
+ * allocation — the weighed lines absorb all of the freight and the rest absorb
+ * none, silently, and it looks deliberate. A per-row toggle would make that the
+ * LIKELY state rather than the edge case, which is why the reveal is
+ * document-level (`weightRevealed`, resolved once in `LineBuilder`).
+ *
+ * ⚠️ Revealing is not filling: a shown-everywhere cell can still be left blank.
+ * `allocateCapitalisedCost` refuses a partial weight set outright, so a
+ * half-weighed document hard-fails at allocation; this menu's job is to make that
+ * state hard to reach, not to be the guard
+ * (plans/purchasing/05-receiving-cost-and-corrections.md §5.3).
  */
 function LineRowMenu({
   taxable,
@@ -1147,11 +1213,13 @@ function LineRowMenu({
   showTaxable = true,
   showMatchKey = false,
   showGlAccount = false,
+  showWeight = false,
   hasDescription,
   hasCategory,
   hasPhotos,
   hasMatchKey = false,
   hasGlAccount = false,
+  hasWeight = false,
   onEditDescription,
   onSetCategory,
   onOpenPhotos,
@@ -1159,6 +1227,7 @@ function LineRowMenu({
   onToggleOptional,
   onSetMatchKey,
   onSetGlAccount,
+  onSetWeight,
   onDelete,
 }: {
   taxable: boolean
@@ -1175,11 +1244,21 @@ function LineRowMenu({
   showMatchKey?: boolean
   /** `schema.attrs.glAccount !== null`. */
   showGlAccount?: boolean
+  /** `schema.attrs.weight !== null` — a purchase order line's allocation basis. */
+  showWeight?: boolean
   hasDescription: boolean
   hasCategory: boolean
   hasPhotos: boolean
   hasMatchKey?: boolean
   hasGlAccount?: boolean
+  /**
+   * Whether THIS row already carries a weight — the item's label only.
+   *
+   * ⚠️ Not what decides the standing control: that is `weightRevealed`, which is
+   * true for every line as soon as ANY line of the document has one. See the
+   * deviation note above.
+   */
+  hasWeight?: boolean
   onEditDescription: () => void
   onSetCategory: () => void
   /** `undefined` hides the images item (draft rows, missing registry field). */
@@ -1188,6 +1267,7 @@ function LineRowMenu({
   onToggleOptional: (next: boolean) => void
   onSetMatchKey?: () => void
   onSetGlAccount?: () => void
+  onSetWeight?: () => void
   onDelete: () => void
 }) {
   return (
@@ -1257,6 +1337,15 @@ function LineRowMenu({
             <MenuShortcut keys={['⇧', 'G']} />
           </DropdownMenuItem>
         )}
+        {/* No shortcut, and the omission is deliberate: `Mod+Shift+W` closes the
+            window in Chrome, Firefox AND Safari, so there is no letter left for
+            "weight" that is safe to take (see use-line-hotkeys.ts). */}
+        {showWeight && onSetWeight && (
+          <DropdownMenuItem onSelect={onSetWeight}>
+            <Weight />
+            {hasWeight ? 'Change weight' : 'Set weight'}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem variant='destructive' onSelect={onDelete}>
           <Trash2 />
@@ -1319,11 +1408,16 @@ function LinePartCellView({
   currencyCode,
   glAccountAttribute,
   glAccount,
+  weightAttribute,
+  weight,
+  weightRevealed = false,
   readOnly,
   onPickPart,
   onCommitDescription,
   onPickMatchKey,
   onCommitGlAccount,
+  onCommitWeight,
+  onRevealWeight,
   onDelete,
 }: {
   /** `purchase_order_line_part` / `vendor_bill_line_part`, from the schema. */
@@ -1340,11 +1434,34 @@ function LinePartCellView({
   /** `schema.attrs.glAccount` — `null` on a line with no GL account. */
   glAccountAttribute: string | null
   glAccount: string | null
+  /** `schema.attrs.weight` — `null` on every document but the purchase order. */
+  weightAttribute: string | null
+  weight: number | null
+  /**
+   * Whether the weight cell is a STANDING control on this row.
+   *
+   * 🛑 Document-level, resolved once by `LineBuilder`: true as soon as any line of
+   * the document carries a weight, or as soon as anybody opens the weight editor
+   * from any row's menu. Deliberately not `weight !== null` — see the deviation
+   * note on {@link LineRowMenu} for why a per-row weight is a broken allocation.
+   */
+  weightRevealed?: boolean
   readOnly: boolean
   onPickPart: (recordId: RecordId | null) => void
   onCommitDescription: (value: string | null) => void
   onPickMatchKey: (recordId: RecordId | null) => void
   onCommitGlAccount: (value: string | null) => void
+  onCommitWeight: (value: number | null) => void
+  /**
+   * Tell the document that it allocates by weight — fired when this row's menu
+   * OPENS the weight editor, before anything is typed.
+   *
+   * 🛑 This is the deviation, made concrete. Choosing "Set weight" on one line is
+   * a statement about the whole document, so the cell appears on every sibling in
+   * the same frame — including the blank ones, which is the point: a person who
+   * weighs three lines of five can SEE the two they have not weighed.
+   */
+  onRevealWeight: () => void
   /** Delete this line (real record or draft). */
   onDelete: () => void
 }) {
@@ -1358,20 +1475,28 @@ function LinePartCellView({
    * match key has none — its picker writes through on select.
    */
   const [edit, setEdit] = useState<
-    { field: 'description' | 'glAccount'; value: string } | { field: 'matchKey' } | null
+    { field: 'description' | 'glAccount' | 'weight'; value: string } | { field: 'matchKey' } | null
   >(null)
 
   // The match key is only editable where the consumer supplied an editor for it;
   // see MatchKeyEditorRenderer for why this is a render prop and not an import.
   const showMatchKey = !!matchKeyAttribute && !!renderMatchKeyEditor && !readOnly
   const showGlAccount = !!glAccountAttribute && !readOnly
+  const showWeight = !!weightAttribute && !readOnly
 
   const confirmText = () => {
     if (!edit || edit.field === 'matchKey') return
-    const trimmed = edit.value.trim() || null
+    const trimmed = edit.value.trim()
     setEdit(null)
-    if (edit.field === 'description') onCommitDescription(trimmed)
-    else onCommitGlAccount(trimmed)
+    if (edit.field === 'description') return onCommitDescription(trimmed || null)
+    if (edit.field === 'glAccount') return onCommitGlAccount(trimmed || null)
+    // Weight: empty CLEARS (a person removing a weight has to be able to), but
+    // unparseable or negative text writes nothing at all rather than clearing.
+    // Silently turning a typo into "this line has no weight" is the shape that
+    // produces the partial weight set §5.3 exists to prevent.
+    if (trimmed === '') return onCommitWeight(null)
+    const parsed = Number(trimmed)
+    if (Number.isFinite(parsed) && parsed >= 0) onCommitWeight(parsed)
   }
 
   // Row-action shortcuts (use-line-hotkeys.ts) arrive as CustomEvents on the
@@ -1476,6 +1601,43 @@ function LinePartCellView({
     )
   }
 
+  // Weight edit mode — a plain numeric input, matching the GL account's shape.
+  // `inputMode='decimal'` rather than `type='number'`: the spinner and the
+  // scroll-to-change behaviour of a number input are both hazards on a value the
+  // freight allocation divides by.
+  if (edit?.field === 'weight') {
+    return (
+      <div ref={rootRef} className='flex min-w-0 flex-1 items-center gap-1 py-1'>
+        <input
+          aria-label='Line weight'
+          inputMode='decimal'
+          value={edit.value}
+          onChange={(e) => setEdit({ field: 'weight', value: e.target.value })}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              confirmText()
+            }
+            if (e.key === 'Escape') setEdit(null)
+          }}
+          autoFocus
+          placeholder='Weight'
+          className='h-7 min-w-0 flex-1 rounded-sm border border-primary-200/60 bg-transparent px-2 text-sm tabular-nums outline-none'
+        />
+        <TreeRowButton persistent tooltipText='Save weight' onClick={confirmText}>
+          <Check />
+        </TreeRowButton>
+        <TreeRowButton
+          persistent
+          variant='destructive'
+          tooltipText='Cancel'
+          onClick={() => setEdit(null)}>
+          <X />
+        </TreeRowButton>
+      </div>
+    )
+  }
+
   // Match-key edit mode — the consumer's picker fills the cell, and writes
   // through on select rather than on a Save button, so there is nothing to
   // cancel: the ✓ only closes the slot.
@@ -1511,6 +1673,7 @@ function LinePartCellView({
           </SimpleTooltip>
         )}
         {glAccount && <GlAccountChip code={glAccount} />}
+        {weight !== null && <WeightChip weight={weight} />}
       </div>
     )
   }
@@ -1570,6 +1733,18 @@ function LinePartCellView({
         />
       )}
 
+      {/* 🛑 Gated on `weightRevealed`, NOT on `weight !== null` — the one place
+          this row deviates from the standing-control-once-set rule the chips
+          above follow. Once the document has any weight at all, every line shows
+          the cell INCLUDING the blank ones, because a blank line in a weighed
+          document is the thing a person needs to see. See {@link LineRowMenu}. */}
+      {showWeight && weightRevealed && (
+        <WeightChip
+          weight={weight}
+          onClick={() => setEdit({ field: 'weight', value: weight === null ? '' : String(weight) })}
+        />
+      )}
+
       {/* Always the cell's LAST flex child, so its slot is stable across the
           rest ↔ editor swaps. Category / taxable / images / optional are all off:
           a purchasing line carries none of those fields. */}
@@ -1581,11 +1756,13 @@ function LinePartCellView({
         showTaxable={false}
         showMatchKey={showMatchKey}
         showGlAccount={showGlAccount}
+        showWeight={showWeight}
         hasDescription={!!description}
         hasCategory={false}
         hasPhotos={false}
         hasMatchKey={!!matchKeyRecordId}
         hasGlAccount={!!glAccount}
+        hasWeight={weight !== null}
         onEditDescription={() => setEdit({ field: 'description', value: description ?? '' })}
         onSetCategory={() => {}}
         onToggleTaxable={() => {}}
@@ -1594,9 +1771,54 @@ function LinePartCellView({
         onSetGlAccount={
           showGlAccount ? () => setEdit({ field: 'glAccount', value: glAccount ?? '' }) : undefined
         }
+        onSetWeight={
+          showWeight
+            ? () => {
+                onRevealWeight()
+                setEdit({ field: 'weight', value: weight === null ? '' : String(weight) })
+              }
+            : undefined
+        }
         onDelete={onDelete}
       />
     </div>
+  )
+}
+
+/**
+ * The line's weight as a standing chip.
+ *
+ * ⚠️ Unlike {@link GlAccountChip} it renders when the value is ABSENT too, as a
+ * dash. That is not an oversight: the chip is shown document-wide once the
+ * document allocates by weight, and an unweighed line inside such a document is
+ * precisely the state a person has to be able to spot — `allocateCapitalisedCost`
+ * refuses a partial set, so a blank here is a document that will not allocate.
+ */
+function WeightChip({ weight, onClick }: { weight: number | null; onClick?: () => void }) {
+  const label = weight === null ? '—' : String(weight)
+  const content = (
+    <span className='flex shrink-0 items-center gap-0.5 rounded-sm bg-primary-100 px-1.5 py-0.5 text-[10px] text-muted-foreground leading-none tabular-nums dark:bg-primary-100/60'>
+      <Weight className='size-2.5' />
+      {label}
+    </span>
+  )
+  if (!onClick) return <SimpleTooltip content='Line weight'>{content}</SimpleTooltip>
+  return (
+    <SimpleTooltip
+      content={
+        weight === null
+          ? 'No weight on this line — freight cannot be allocated by weight until every line has one'
+          : 'Line weight — click to change'
+      }>
+      <button
+        type='button'
+        tabIndex={-1}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onClick}
+        className='shrink-0 rounded-sm hover:brightness-95'>
+        {content}
+      </button>
+    </SimpleTooltip>
   )
 }
 
@@ -1651,6 +1873,64 @@ function usePartUnit(partRecordId: RecordId | null): LineItemUnit {
 
 const PART_UNIT_ATTRS = ['part_unit'] as const
 
+/**
+ * A ref that always holds the value from the latest render.
+ *
+ * Exists for exactly one job: the vendor-part prefill is asynchronous, and the
+ * question it has to answer on completion — *is the price cell still empty?* —
+ * must be asked about the row as it is NOW, not as it was when the part was
+ * picked. A captured closure would answer with a value that is a round trip old.
+ */
+function useLatestRef<T>(value: T): { current: T } {
+  const ref = useRef(value)
+  ref.current = value
+  return ref
+}
+
+/**
+ * Apply the vendor-part prefill for a part that was just picked
+ * (plans/purchasing/05-receiving-cost-and-corrections.md §5.2).
+ *
+ * Two writes with two different rules, and keeping them apart is the whole
+ * function:
+ *
+ * - **The link is written whenever the lookup ran.** It is provenance — which
+ *   supplier row this line's part corresponds to on this order — and it is
+ *   written even when there is no row (as `null`), because a link left over from
+ *   the previously picked part names a `vendor_part` for a different part.
+ * - **The price is written only into an EMPTY cell.** A price a person typed is
+ *   never overwritten, and the check is made against {@link useLatestRef} at
+ *   completion rather than at pick time, so a price typed while the lookup was in
+ *   flight wins over the prefill.
+ *
+ * 🛑 It runs once, on the pick. Nothing re-reads the supplier's price afterwards:
+ * `vendor_part_unit_price` moves, and `expected_unit_price` is the price the
+ * order froze. See `LineValues.vendorPartRecordId`.
+ */
+async function applyPartPrefill({
+  partRecordId,
+  resolve,
+  currentPriceRef,
+  apply,
+}: {
+  partRecordId: RecordId | null
+  resolve: PartPrefillResolver | undefined
+  currentPriceRef: { current: number | null }
+  apply: (patch: LinePatch) => void
+}): Promise<void> {
+  if (!resolve || !partRecordId) return
+  const prefill = await resolve(partRecordId)
+  // `null` means the lookup could not run at all — no vendor on the order, a
+  // document that does not prefill, a failed request. Writing a cleared link on
+  // that would erase provenance nobody asked to erase.
+  if (!prefill) return
+  const patch: LinePatch = { vendorPartRecordId: prefill.vendorPartRecordId }
+  if (prefill.unitPriceCents !== null && currentPriceRef.current === null) {
+    patch.unitPriceCents = prefill.unitPriceCents
+  }
+  apply(patch)
+}
+
 /** One sortable line row — a grid row whose leading slot is the drag grip. */
 export function LineRow({
   record,
@@ -1667,6 +1947,9 @@ export function LineRow({
   catalogLoading,
   matchScopeRecordId,
   renderMatchKeyEditor,
+  weightRevealed = false,
+  resolvePartPrefill,
+  onRevealWeight,
   onUpdateLine,
   deleteLine,
   onSelectGroup,
@@ -1688,6 +1971,10 @@ export function LineRow({
   /** Resolved from `schema.matchScopeAttr` by the builder; scopes the match picker. */
   matchScopeRecordId: RecordId | null
   renderMatchKeyEditor?: MatchKeyEditorRenderer
+  /** Document-level: any line carries a weight, or somebody opened the editor. */
+  weightRevealed?: boolean
+  resolvePartPrefill?: PartPrefillResolver
+  onRevealWeight: () => void
   onUpdateLine: (recordId: RecordId, patch: LinePatch) => void
   deleteLine: (lineId: string) => void
   onSelectGroup: (recordId: RecordId, group: CatalogGroup) => void
@@ -1698,6 +1985,8 @@ export function LineRow({
   const { values } = useSystemValues(recordId, lineAttributesFor(schema), { autoFetch: false })
   const line = lineValuesFromSystemValues(values, schema)
   const partUnit = usePartUnit(schema.capabilities.partPicker ? line.partRecordId : null)
+  // Read at prefill-completion time, never at pick time — see `applyPartPrefill`.
+  const priceRef = useLatestRef(line.unitPriceCents)
   // FILE is array-return (plan 37b §3) — the photos attribute reads back as an array
   // of `{ ref, caption?, internal? }` envelopes (or is absent/empty when there are
   // none). A document whose lines carry no photos field has no attribute to read.
@@ -1733,13 +2022,30 @@ export function LineRow({
               currencyCode={currencyCode}
               glAccountAttribute={schema.attrs.glAccount}
               glAccount={line.glAccount}
+              weightAttribute={schema.attrs.weight}
+              weight={line.weight}
+              weightRevealed={weightRevealed}
               readOnly={readOnly}
-              onPickPart={(partRecordId) => onUpdateLine(recordId, { partRecordId })}
+              // The part write and the prefill are two separate patches on
+              // purpose: the pick must land in this frame (it is what the person
+              // just did, and on a draft it is what materializes the row), while
+              // the supplier lookup is a round trip that may resolve to nothing.
+              onPickPart={(partRecordId) => {
+                onUpdateLine(recordId, { partRecordId })
+                void applyPartPrefill({
+                  partRecordId,
+                  resolve: resolvePartPrefill,
+                  currentPriceRef: priceRef,
+                  apply: (patch) => onUpdateLine(recordId, patch),
+                })
+              }}
               onCommitDescription={(description) => onUpdateLine(recordId, { description })}
               onPickMatchKey={(purchaseOrderLineRecordId) =>
                 onUpdateLine(recordId, { purchaseOrderLineRecordId })
               }
               onCommitGlAccount={(glAccount) => onUpdateLine(recordId, { glAccount })}
+              onCommitWeight={(weight) => onUpdateLine(recordId, { weight })}
+              onRevealWeight={onRevealWeight}
               onDelete={() => deleteLine(record.id)}
             />
           ) : (
@@ -1856,6 +2162,9 @@ export function DraftLineRow({
   catalogLoading,
   matchScopeRecordId,
   renderMatchKeyEditor,
+  weightRevealed = false,
+  resolvePartPrefill,
+  onRevealWeight,
   deleteDraft,
   createDraft,
   onSelectGroup,
@@ -1873,6 +2182,9 @@ export function DraftLineRow({
   catalogLoading: boolean
   matchScopeRecordId: RecordId | null
   renderMatchKeyEditor?: MatchKeyEditorRenderer
+  weightRevealed?: boolean
+  resolvePartPrefill?: PartPrefillResolver
+  onRevealWeight: () => void
   deleteDraft: (draftId: string) => void
   createDraft: (draftId: string, overrides?: LinePatch) => Promise<void>
   onSelectGroup: (draftId: string, group: CatalogGroup) => void
@@ -1880,6 +2192,7 @@ export function DraftLineRow({
   const schema = lineSchemaFor(documentType)
   const showOptional = schema.capabilities.optional
   const partUnit = usePartUnit(schema.capabilities.partPicker ? draft.partRecordId : null)
+  const priceRef = useLatestRef(draft.unitPriceCents)
 
   return (
     <LineGridRow
@@ -1899,13 +2212,29 @@ export function DraftLineRow({
             currencyCode={currencyCode}
             glAccountAttribute={schema.attrs.glAccount}
             glAccount={draft.glAccount}
+            weightAttribute={schema.attrs.weight}
+            weight={draft.weight}
+            weightRevealed={weightRevealed}
             readOnly={false}
             // On a PURCHASE ORDER the part IS the line's identity, so picking one
             // is what fires the draft's first `record.create` — carrying any
             // description already typed. On a bill it is not
             // (`capabilities.draftRequiresPart`), and any of these commits can
             // materialize the row. See LinePartCellView and `createDraft`.
-            onPickPart={(partRecordId) => void createDraft(draft.draftId, { partRecordId })}
+            //
+            // The prefill follows as a second `createDraft` call rather than
+            // being awaited into the first: the row must appear the instant the
+            // part is picked, and `createDraft` already accumulates anything that
+            // lands while its own create is in flight, then diff-flushes it.
+            onPickPart={(partRecordId) => {
+              void createDraft(draft.draftId, { partRecordId })
+              void applyPartPrefill({
+                partRecordId,
+                resolve: resolvePartPrefill,
+                currentPriceRef: priceRef,
+                apply: (patch) => void createDraft(draft.draftId, patch),
+              })
+            }}
             // Also routed through `createDraft`, which accumulates rather than
             // creating while a required part is still unset — every draft-state
             // write goes through `mutateDrafts`, never a direct mutation.
@@ -1914,6 +2243,8 @@ export function DraftLineRow({
               void createDraft(draft.draftId, { purchaseOrderLineRecordId })
             }
             onCommitGlAccount={(glAccount) => void createDraft(draft.draftId, { glAccount })}
+            onCommitWeight={(weight) => void createDraft(draft.draftId, { weight })}
+            onRevealWeight={onRevealWeight}
             onDelete={() => deleteDraft(draft.draftId)}
           />
         ) : (

--- a/apps/web/src/components/money/ui/line-builder/line-schemas.test.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-schemas.test.ts
@@ -17,7 +17,7 @@
 // prefix to the line vocabulary itself, so these assertions widened with it.
 
 import { describe, expect, it } from 'vitest'
-import { relKeyForDocumentType } from './line-rows'
+import { LINE_COLS, relKeyForDocumentType } from './line-rows'
 import {
   crossFillAmount,
   DEFAULT_LINE_VALUES,
@@ -542,5 +542,114 @@ describe('the GL account', () => {
   it('belongs to the vendor bill alone', () => {
     expect(ALL.filter((d) => lineSchemaFor(d).attrs.glAccount !== null)).toEqual(['vendor_bill'])
     expect(LINE_SCHEMAS.vendor_bill.attrs.glAccount).toBe('vendor_bill_line_gl_account')
+  })
+})
+
+// plans/purchasing/05-receiving-cost-and-corrections.md §5.2/§5.3. Both fields
+// were DECLARED in the registry and written by nothing at all — read by
+// `use-purchase-order-lines.ts`, set by no surface anywhere. Mapping them into
+// `attrs` is what gave them a writer, so these assertions pin the mapping.
+describe('the supplier link', () => {
+  it('belongs to the purchase order alone', () => {
+    expect(ALL.filter((d) => lineSchemaFor(d).attrs.vendorPartRecordId !== null)).toEqual([
+      'purchase_order',
+    ])
+    expect(LINE_SCHEMAS.purchase_order.attrs.vendorPartRecordId).toBe(
+      'purchase_order_line_vendor_part'
+    )
+  })
+
+  // 🛑 The link and the lookup that produces it are one feature. The prefill
+  // resolves `vendor_part` on the natural key `(part, supplier)`, so a document
+  // that can stamp the link but names no vendor attribute has no second leg to
+  // match on — and the only way to produce a link without one is the preferred-
+  // vendor fallback §5.2 forbids, which would put another supplier's price on
+  // this supplier's order.
+  it.each(
+    ALL
+  )('%s: the link never travels without the vendor it resolves against', (documentType) => {
+    const { attrs, vendorAttr } = lineSchemaFor(documentType)
+    expect(vendorAttr !== null).toBe(attrs.vendorPartRecordId !== null)
+  })
+
+  // Read off the PARENT document, not the line — a line-entity attribute here
+  // would resolve to nothing on the record the builder fetches, exactly as it
+  // would for the match key's scope.
+  it('reads the vendor off a parent attribute, not a line one', () => {
+    for (const documentType of ALL) {
+      const { vendorAttr, lineEntityType } = lineSchemaFor(documentType)
+      if (!vendorAttr) continue
+      expect(vendorAttr.startsWith(`${lineEntityType}_`)).toBe(false)
+      expect(vendorAttr.startsWith(`${documentType}_`)).toBe(true)
+    }
+    expect(LINE_SCHEMAS.purchase_order.vendorAttr).toBe('purchase_order_vendor')
+  })
+
+  // A vendor bill HAS a vendor, and must still never prefill: its prices are
+  // transcribed from the supplier's own paper, and overwriting one with our
+  // catalogue price erases the disagreement the three-way match exists to find.
+  it('the vendor bill never prefills, though it has a vendor', () => {
+    expect(LINE_SCHEMAS.vendor_bill.vendorAttr).toBeNull()
+    expect(LINE_SCHEMAS.vendor_bill.attrs.vendorPartRecordId).toBeNull()
+  })
+
+  it('every other document drops a stray supplier link rather than writing it', () => {
+    for (const documentType of ALL) {
+      const schema = lineSchemaFor(documentType)
+      if (schema.attrs.vendorPartRecordId !== null) continue
+      const updates = linePatchToFieldValues(
+        { vendorPartRecordId: 'vendor_part_def:vp_instance' as LineValues['vendorPartRecordId'] },
+        schema
+      )
+      expect(updates, `${documentType} wrote a supplier link`).toEqual([])
+    }
+  })
+
+  it('reads the link back as a single record id, never a one-element array', () => {
+    const values = lineValuesFromSystemValues(
+      { purchase_order_line_vendor_part: ['vp_def:vp_instance'] },
+      LINE_SCHEMAS.purchase_order
+    )
+    expect(values.vendorPartRecordId).toBe('vp_def:vp_instance')
+    expect(
+      lineValuesFromSystemValues({}, LINE_SCHEMAS.purchase_order).vendorPartRecordId
+    ).toBeNull()
+  })
+})
+
+describe('the line weight', () => {
+  it('belongs to the purchase order alone', () => {
+    expect(ALL.filter((d) => lineSchemaFor(d).attrs.weight !== null)).toEqual(['purchase_order'])
+    expect(LINE_SCHEMAS.purchase_order.attrs.weight).toBe('purchase_order_line_weight')
+  })
+
+  it('every other document drops a stray weight rather than writing it', () => {
+    for (const documentType of ALL) {
+      const schema = lineSchemaFor(documentType)
+      if (schema.attrs.weight !== null) continue
+      const updates = linePatchToFieldValues({ weight: 12 }, schema)
+      expect(updates, `${documentType} wrote a weight`).toEqual([])
+    }
+  })
+
+  // 🛑 The distinction the whole §5.3 guard rests on. `allocateLandedCost`
+  // divides by the SUM of the set, so an unweighed line reported as `0` is
+  // indistinguishable from a line genuinely weighing nothing — and a document
+  // where some lines are weighed and others read `0` allocates all of the freight
+  // onto the weighed ones, silently. Absence has to survive the read as `null`.
+  it('keeps absence and zero apart', () => {
+    const po = LINE_SCHEMAS.purchase_order
+    expect(lineValuesFromSystemValues({}, po).weight).toBeNull()
+    expect(lineValuesFromSystemValues({ purchase_order_line_weight: null }, po).weight).toBeNull()
+    expect(lineValuesFromSystemValues({ purchase_order_line_weight: 0 }, po).weight).toBe(0)
+    expect(lineValuesFromSystemValues({ purchase_order_line_weight: 2.5 }, po).weight).toBe(2.5)
+    // NUMBER values arrive as a numeric string on some read paths.
+    expect(lineValuesFromSystemValues({ purchase_order_line_weight: '2.5' }, po).weight).toBe(2.5)
+  })
+
+  // The reason the menu convention exists at all: an optional concept must never
+  // cost every document a column (04-vendor-bill-lines-and-the-amount-cell.md §2).
+  it('costs no grid column', () => {
+    expect(LINE_COLS).toBe('minmax(10rem, 1fr) 5.5rem 5.5rem 6.5rem')
   })
 })

--- a/apps/web/src/components/money/ui/line-builder/line-values.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-values.ts
@@ -161,6 +161,29 @@ export interface LineValues {
   purchaseOrderLineRecordId: RecordId | null
   /** Buy-side only: the account CODE this line posts to ('2160', '5090'). */
   glAccount: string | null
+  /**
+   * Purchase order only: the supplier's catalogue entry this line was priced
+   * from — PROVENANCE, never a live price read.
+   *
+   * 🛑 Stamped once, when the part is picked, alongside the price it prefilled
+   * (`resolvePartPrefill` in line-builder.tsx). `vendor_part_unit_price` is
+   * `updatable: true` and `bom-cost-triggers.ts` recalculates part costs whenever
+   * it moves, while {@link unitPriceCents} on a purchase order is the price the
+   * order FROZE — the price arm of the three-way match. Re-deriving the line's
+   * price through this link would make the agreed price stop being agreed. It
+   * says where the number came from; it never says what the number is.
+   * (plans/purchasing/05-receiving-cost-and-corrections.md §5.2.)
+   */
+  vendorPartRecordId: RecordId | null
+  /**
+   * Purchase order only: the line's total shipped weight — the `weight`
+   * allocation basis's only input.
+   *
+   * ⚠️ Document-level in the UI even though it is stored per line; see
+   * `LineSchema.attrs.weight` and `LineRowMenu` for why a per-row optional weight
+   * is a broken allocation rather than a partly-configured one.
+   */
+  weight: number | null
 }
 
 /**
@@ -211,6 +234,21 @@ export interface LineSchema {
    * a mistake, and the footer would have to learn to skip it.
    */
   matchScopeAttr: string | null
+  /**
+   * Parent attribute naming the SUPPLIER this document is placed with — the one
+   * input, besides the part, that the vendor-part price prefill needs
+   * (plans/purchasing/05-receiving-cost-and-corrections.md §5.2).
+   *
+   * `null` on every document that does not prefill. Read off the parent once per
+   * builder for the same reason {@link matchScopeAttr} is: the answer is the same
+   * for every row, and a per-row read would be one fetch per line to learn it.
+   *
+   * ⚠️ Set on `purchase_order` and NOT on `vendor_bill`, which also has a vendor.
+   * A bill transcribes prices the supplier already charged; prefilling one would
+   * overwrite the vendor's own paper with our catalogue, which is the exact
+   * disagreement the three-way match exists to surface.
+   */
+  vendorAttr: string | null
   /** systemAttribute prefix for the parent's own billing mirrors (`quote_discount_type`). */
   billingPrefix: string
   /** Parent attributes fetched once by the builder and read by the footer. */
@@ -236,6 +274,8 @@ const NO_LINE_ATTRS: LineAttrMap = {
   lineTotal: null,
   purchaseOrderLineRecordId: null,
   glAccount: null,
+  vendorPartRecordId: null,
+  weight: null,
 }
 
 /** Every sell-side line is a `line_item`, so the four money documents share one map. */
@@ -259,6 +299,10 @@ const LINE_ITEM_ATTRS: LineAttrMap = {
   lineTotal: null,
   purchaseOrderLineRecordId: null,
   glAccount: null,
+  // Both are purchasing vocabulary. A sell-side line has no supplier and no
+  // freight basis, so neither field exists on `line_item` to write to.
+  vendorPartRecordId: null,
+  weight: null,
 }
 
 const SELL_SIDE_CAPABILITIES: LineCapabilities = {
@@ -330,6 +374,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     lineEntityType: 'line_item',
     amountMode: 'derived',
     matchScopeAttr: null,
+    vendorAttr: null,
     relKey: 'line_item_quote',
     relFieldId: 'line_item:quote',
     sortAttr: 'line_item_sort_order',
@@ -347,6 +392,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     lineEntityType: 'line_item',
     amountMode: 'derived',
     matchScopeAttr: null,
+    vendorAttr: null,
     relKey: 'line_item_invoice',
     relFieldId: 'line_item:invoice',
     sortAttr: 'line_item_sort_order',
@@ -374,6 +420,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     lineEntityType: 'line_item',
     amountMode: 'derived',
     matchScopeAttr: null,
+    vendorAttr: null,
     relKey: 'line_item_order',
     relFieldId: 'line_item:order',
     sortAttr: 'line_item_sort_order',
@@ -391,6 +438,7 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     lineEntityType: 'line_item',
     amountMode: 'derived',
     matchScopeAttr: null,
+    vendorAttr: null,
     relKey: 'line_item_work_order',
     relFieldId: 'line_item:workOrder',
     sortAttr: 'line_item_sort_order',
@@ -411,6 +459,9 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     lineEntityType: 'purchase_order_line',
     amountMode: 'derived',
     matchScopeAttr: null,
+    // The supplier the order is placed with, and the second half of the
+    // `(part, supplier)` natural key the price prefill resolves on (§5.2).
+    vendorAttr: 'purchase_order_vendor',
     relKey: 'purchase_order_line_purchase_order',
     relFieldId: 'purchase_order_line:purchaseOrder',
     sortAttr: 'purchase_order_line_sort_order',
@@ -438,6 +489,13 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
       qty: 'purchase_order_line_quantity_ordered',
       unitPriceCents: 'purchase_order_line_expected_unit_price',
       partRecordId: 'purchase_order_line_part',
+      // 🛑 Both fields were declared and had NO writer at all until
+      // plans/purchasing/05-receiving-cost-and-corrections.md §5.2/§5.3 — read by
+      // `use-purchase-order-lines.ts`, set by nothing. Mapping them here is what
+      // gives them one: `vendorPart` is stamped by the price prefill on part
+      // pick, `weight` by the row menu's weight control.
+      vendorPartRecordId: 'purchase_order_line_vendor_part',
+      weight: 'purchase_order_line_weight',
     },
     photosAttr: null,
     // `purchase_order_line.part` is `required: true` — a create without it is
@@ -455,6 +513,8 @@ export const LINE_SCHEMAS: Record<DocumentType, LineSchema> = {
     // (plans/purchasing/01-build-plan.md §5.4b).
     amountMode: 'stored',
     matchScopeAttr: 'vendor_bill_purchase_order',
+    // A bill's vendor is transcribed, never prefilled — see `vendorAttr`.
+    vendorAttr: null,
     relKey: 'vendor_bill_line_vendor_bill',
     relFieldId: 'vendor_bill_line:vendorBill',
     sortAttr: 'vendor_bill_line_sort_order',
@@ -601,6 +661,8 @@ export const DEFAULT_LINE_VALUES: LineValues = {
   lineTotal: null,
   purchaseOrderLineRecordId: null,
   glAccount: null,
+  vendorPartRecordId: null,
+  weight: null,
 }
 
 /** Semantic update emitted by a row; absent keys are not written. */
@@ -621,6 +683,8 @@ const LINE_FIELD_TYPES: Record<keyof LineValues, FieldTypeValue> = {
   lineTotal: FieldType.CURRENCY,
   purchaseOrderLineRecordId: FieldType.RELATIONSHIP,
   glAccount: FieldType.TEXT,
+  vendorPartRecordId: FieldType.RELATIONSHIP,
+  weight: FieldType.NUMBER,
 }
 
 const LINE_VALUE_KEYS = Object.keys(LINE_FIELD_TYPES) as Array<keyof LineValues>
@@ -670,6 +734,25 @@ export function diffLineValues(before: LineValues, after: LineValues): LinePatch
  * instead of the part's name. Nothing throws and nothing logs — the part is
  * simply never visible on any purchasing line.
  */
+/**
+ * Read a NUMBER system value as a number, keeping the empty/zero distinction.
+ *
+ * 🛑 Absence must not be encoded as zero. The `weight` allocation basis divides
+ * by the SUM of the set, so an unweighed line reported as `0` reads as a
+ * deliberate weighs-nothing — the "some lines weighed, some not" state
+ * `allocateCapitalisedCost` refuses. `null` means nobody has said yet, and it is
+ * what lets the cell render its blank rather than a confident `0`.
+ *
+ * Numeric strings are accepted because `useSystemValues` returns one on some
+ * paths and a bare number on others; a raw cast would put a string into the
+ * arithmetic.
+ */
+export function numberOrNull(raw: unknown): number | null {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  const parsed = typeof value === 'string' ? Number(value) : value
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : null
+}
+
 function firstRecordId(raw: unknown): RecordId | null {
   const value = Array.isArray(raw) ? raw[0] : raw
   return typeof value === 'string' ? (value as RecordId) : null
@@ -709,6 +792,12 @@ export function lineValuesFromSystemValues(
     lineTotal: read<number | null>('lineTotal') ?? null,
     purchaseOrderLineRecordId: readRecordId('purchaseOrderLineRecordId'),
     glAccount: read<string | null>('glAccount') ?? null,
+    vendorPartRecordId: readRecordId('vendorPartRecordId'),
+    // Coerced rather than cast: a NUMBER value reads back as a bare number on
+    // most paths and as a numeric STRING on others, and `0` is a legitimate
+    // weight — so `?? null` on a raw read would keep a string in a field the
+    // allocation sums.
+    weight: numberOrNull(read<unknown>('weight')),
   }
 }
 

--- a/apps/web/src/components/money/ui/line-builder/use-line-hotkeys.ts
+++ b/apps/web/src/components/money/ui/line-builder/use-line-hotkeys.ts
@@ -60,6 +60,13 @@ type UseLineHotkeysOptions = {
  * obvious letter for "match" and is NOT usable: Chrome binds it to profile
  * switching and Firefox to responsive-design mode.
  *
+ * 🛑 A purchase order line's WEIGHT is the one row-menu action with no shortcut,
+ * and the omission is deliberate rather than an oversight: `Mod+Shift+W` closes
+ * the window in Chrome, Firefox AND Safari, and every other letter that reads as
+ * "weight" is already taken here. A binding that shuts the browser mid-order is
+ * worse than no binding, so the menu item stands alone
+ * (plans/purchasing/05-receiving-cost-and-corrections.md §5.3).
+ *
  * Registered once on the rows container (TanStack `target`), so they only
  * fire while focus is inside the grid — the catalog picker portals outside
  * it, so its keys are never hijacked. The acting row is resolved from the

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-lines-tab.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-lines-tab.tsx
@@ -23,13 +23,17 @@
 // accumulates on the draft instead of firing a create the server must reject.
 // That guard lives in `createDraft`, so it holds for any cell added later.
 
+import { parseRecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { cn } from '@auxx/ui/lib/utils'
+import { useCallback } from 'react'
 import type { DetailViewTabProps } from '~/components/detail-view'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { DocumentSectionActions } from '~/components/money/ui/document-actions-cluster'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
+import type { PartPrefillLookup } from '~/components/money/ui/line-builder/line-rows'
 import { useSystemValues } from '~/components/resources/hooks'
+import { api } from '~/trpc/react'
 
 const PO_STATUS_ATTRS = ['purchase_order_status'] as const
 
@@ -62,6 +66,39 @@ export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewT
   // treatment to avoid fighting the outer page.
   const isSection = variant === 'section'
 
+  const utils = api.useUtils()
+
+  // Picking a part prefills the agreed price from what THIS order's vendor charges
+  // (plans/purchasing/05-receiving-cost-and-corrections.md 5.2).
+  //
+  // Supplied as a prop rather than called from inside `LineBuilder` because that
+  // module is document-agnostic and only a purchase order prefills — see
+  // `PartPrefillLookup`.
+  //
+  // The two failure shapes are NOT the same and the builder treats them
+  // differently. A successful lookup that finds no row returns a CLEARED link:
+  // the line may still carry a `vendor_part` naming the PREVIOUSLY picked part's
+  // supplier row, and leaving that in place would attach provenance to a price
+  // it did not produce. A thrown lookup returns `null`, which changes nothing —
+  // a network failure is not evidence that no catalogue entry exists.
+  const resolvePartPrefill = useCallback<PartPrefillLookup>(
+    async ({ partRecordId, vendorRecordId }) => {
+      try {
+        const found = await utils.purchasing.vendorPartForLine.fetch({
+          partInstanceId: parseRecordId(partRecordId).entityInstanceId,
+          vendorInstanceId: parseRecordId(vendorRecordId).entityInstanceId,
+        })
+        return {
+          vendorPartRecordId: found?.vendorPartRecordId ?? null,
+          unitPriceCents: found?.unitPrice ?? null,
+        }
+      } catch {
+        return null
+      }
+    },
+    [utils]
+  )
+
   return (
     <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
       {badge && (
@@ -75,7 +112,11 @@ export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewT
       )}
 
       <div className={cn(isSection ? 'max-h-[60vh] overflow-auto ps-3 pe-3' : 'min-h-0 flex-1')}>
-        <LineBuilder documentRecordId={recordId} documentType='purchase_order' />
+        <LineBuilder
+          documentRecordId={recordId}
+          documentType='purchase_order'
+          resolvePartPrefill={resolvePartPrefill}
+        />
       </div>
     </div>
   )

--- a/apps/web/src/components/purchasing/purchase-order/receive-po-lines.test.ts
+++ b/apps/web/src/components/purchasing/purchase-order/receive-po-lines.test.ts
@@ -3,13 +3,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   activeLines,
-  allocatedUnitCosts,
   buildReceivePoInput,
   outstandingQuantity,
   prefillDraft,
-  type ReceiptHeader,
   type ReceivablePoLine,
-  receiptSubtotal,
 } from './receive-po-lines'
 
 function line(overrides: Partial<ReceivablePoLine> = {}): ReceivablePoLine {
@@ -19,17 +16,8 @@ function line(overrides: Partial<ReceivablePoLine> = {}): ReceivablePoLine {
     description: null,
     quantityOrdered: 10,
     quantityReceived: 0,
-    expectedUnitPrice: 4400,
     ...overrides,
   }
-}
-
-const NO_HEADER: ReceiptHeader = {
-  shipping: 0,
-  tax: 0,
-  discount: 0,
-  taxRecoverable: false,
-  basis: 'value',
 }
 
 const META = { occurredAt: '2026-08-26T00:00:00.000Z', reference: '', reason: '' }
@@ -47,9 +35,9 @@ describe('outstandingQuantity', () => {
 })
 
 describe('prefillDraft', () => {
-  it('assumes the whole order arrived, at the agreed price', () => {
+  it('assumes the whole order arrived', () => {
     const draft = prefillDraft([line()])
-    expect(draft.pol_1).toEqual({ quantity: 10, unitPrice: 4400 })
+    expect(draft.pol_1).toEqual({ quantity: 10 })
   })
 
   it('prefills the OUTSTANDING amount, not the ordered amount', () => {
@@ -62,136 +50,81 @@ describe('prefillDraft', () => {
     const draft = prefillDraft([line({ quantityReceived: 10 })])
     expect(draft.pol_1?.quantity).toBe(0)
   })
+
+  it('carries no price — a draft row is a quantity and nothing else', () => {
+    // The agreed price never round-trips through the browser: the server reads
+    // `purchase_order_line_expected_unit_price` itself.
+    expect(Object.keys(prefillDraft([line()]).pol_1 ?? {})).toEqual(['quantity'])
+  })
 })
 
 describe('activeLines', () => {
   const lines = [line({ purchaseOrderLineId: 'a' }), line({ purchaseOrderLineId: 'b' })]
 
   it('excludes a line receiving nothing', () => {
-    const draft = { a: { quantity: 10, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
+    const draft = { a: { quantity: 10 }, b: { quantity: 0 } }
     expect(activeLines(lines, draft).map((row) => row.line.purchaseOrderLineId)).toEqual(['a'])
   })
 
   it('excludes a negative or non-finite quantity', () => {
-    const draft = {
-      a: { quantity: -1, unitPrice: 4400 },
-      b: { quantity: Number.NaN, unitPrice: 4400 },
-    }
+    const draft = { a: { quantity: -1 }, b: { quantity: Number.NaN } }
     expect(activeLines(lines, draft)).toEqual([])
   })
 })
 
-describe('allocatedUnitCosts', () => {
-  const lines = [
-    line({ purchaseOrderLineId: 'a', partId: 'p1' }),
-    line({ purchaseOrderLineId: 'b', partId: 'p2' }),
-  ]
-
-  it('is the bare price when the header states no amounts', () => {
-    const draft = { a: { quantity: 10, unitPrice: 4400 }, b: { quantity: 10, unitPrice: 4400 } }
-    expect(allocatedUnitCosts(lines, draft, NO_HEADER)).toEqual({ a: 4400, b: 4400 })
-  })
-
-  it('🛑 spreads freight over ONLY the lines being received', () => {
-    // The load-bearing rule. $100 freight across one received line is $100 on
-    // that line; including the untouched line would halve it and understate the
-    // cost of the goods that actually arrived.
-    const draft = { a: { quantity: 10, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
-    const costs = allocatedUnitCosts(lines, draft, { ...NO_HEADER, shipping: 10000 })
-    expect(costs.a).toBe(4400 + 1000)
-    expect(costs.b).toBeUndefined()
-
-    const bothReceived = {
-      a: { quantity: 10, unitPrice: 4400 },
-      b: { quantity: 10, unitPrice: 4400 },
-    }
-    const shared = allocatedUnitCosts(lines, bothReceived, { ...NO_HEADER, shipping: 10000 })
-    expect(shared.a).toBe(4400 + 500)
-    expect(shared.b).toBe(4400 + 500)
-  })
-
-  it('has nothing to allocate when no line is being received', () => {
-    const draft = { a: { quantity: 0, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
-    expect(allocatedUnitCosts(lines, draft, { ...NO_HEADER, shipping: 10000 })).toEqual({})
-  })
-})
-
-describe('receiptSubtotal', () => {
-  it('counts only the lines being received', () => {
-    const lines = [line({ purchaseOrderLineId: 'a' }), line({ purchaseOrderLineId: 'b' })]
-    const draft = { a: { quantity: 2, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
-    expect(receiptSubtotal(lines, draft)).toBe(8800)
-  })
-})
-
 describe('buildReceivePoInput', () => {
-  it('sends one entry per received line, and nothing for the rest', () => {
+  it('🛑 sends only the lines being received', () => {
+    // Rule 1. `receivePurchaseOrder` refuses a line at zero and refuses the whole
+    // receipt with it, so an untouched row must never reach the wire — otherwise
+    // a partly-received order could not be received at all.
     const lines = [line({ purchaseOrderLineId: 'a' }), line({ purchaseOrderLineId: 'b' })]
-    const draft = { a: { quantity: 10, unitPrice: 4400 }, b: { quantity: 0, unitPrice: 4400 } }
-    const input = buildReceivePoInput(lines, draft, NO_HEADER, META)
+    const draft = { a: { quantity: 10 }, b: { quantity: 0 } }
+    const input = buildReceivePoInput(lines, draft, META)
     expect(input?.lines).toHaveLength(1)
-    expect(input?.lines[0]).toMatchObject({
+    expect(input?.lines[0]).toEqual({
       partId: 'part_1',
       purchaseOrderLineId: 'a',
       quantity: 10,
-      unitPrice: 4400,
     })
+  })
+
+  it('🛑 states no price and no header amounts', () => {
+    // The whole point of the change: the browser cannot assert what stock cost.
+    const input = buildReceivePoInput([line()], prefillDraft([line()]), META)
+    expect(input?.lines[0]).not.toHaveProperty('unitPrice')
+    expect(input?.lines[0]).not.toHaveProperty('weight')
+    expect(input).not.toHaveProperty('shipping')
+    expect(input).not.toHaveProperty('tax')
+    expect(input).not.toHaveProperty('discount')
+    expect(input).not.toHaveProperty('taxRecoverable')
+    expect(input).not.toHaveProperty('basis')
   })
 
   it('is null when nothing is being received, so the button stays disabled', () => {
-    const input = buildReceivePoInput(
-      [line()],
-      { pol_1: { quantity: 0, unitPrice: 4400 } },
-      NO_HEADER,
-      META
-    )
+    const input = buildReceivePoInput([line()], { pol_1: { quantity: 0 } }, META)
     expect(input).toBeNull()
   })
 
-  it('carries the header amounts and the basis through unchanged', () => {
-    const header: ReceiptHeader = {
-      shipping: 10000,
-      tax: 500,
-      discount: 250,
-      taxRecoverable: true,
-      basis: 'weight',
-    }
-    const input = buildReceivePoInput([line()], prefillDraft([line()]), header, META)
-    expect(input).toMatchObject({
-      shipping: 10000,
-      tax: 500,
-      discount: 250,
-      taxRecoverable: true,
-      basis: 'weight',
-    })
-  })
-
-  it('omits vendorPartId and weight when the line carries neither', () => {
-    const input = buildReceivePoInput([line()], prefillDraft([line()]), NO_HEADER, META)
+  it('omits vendorPartId when the line names none', () => {
+    const input = buildReceivePoInput([line()], prefillDraft([line()]), META)
     expect(input?.lines[0]).not.toHaveProperty('vendorPartId')
-    expect(input?.lines[0]).not.toHaveProperty('weight')
   })
 
-  it('passes vendorPartId and weight when it does', () => {
-    const withTerms = line({ vendorPartId: 'vp_1', weight: 12.5 })
-    const input = buildReceivePoInput([withTerms], prefillDraft([withTerms]), NO_HEADER, META)
-    expect(input?.lines[0]).toMatchObject({ vendorPartId: 'vp_1', weight: 12.5 })
+  it('passes vendorPartId when it does', () => {
+    const withVendor = line({ vendorPartId: 'vp_1' })
+    const input = buildReceivePoInput([withVendor], prefillDraft([withVendor]), META)
+    expect(input?.lines[0]).toMatchObject({ vendorPartId: 'vp_1' })
   })
 
   it('allows an over-receipt rather than clamping it to the outstanding amount', () => {
     // The vendor shipped 12 against an order for 10. Capping it here would hide
     // the discrepancy at the one moment somebody can see the packing slip.
-    const input = buildReceivePoInput(
-      [line()],
-      { pol_1: { quantity: 12, unitPrice: 4400 } },
-      NO_HEADER,
-      META
-    )
+    const input = buildReceivePoInput([line()], { pol_1: { quantity: 12 } }, META)
     expect(input?.lines[0]?.quantity).toBe(12)
   })
 
   it('drops a blank reference and reason', () => {
-    const input = buildReceivePoInput([line()], prefillDraft([line()]), NO_HEADER, {
+    const input = buildReceivePoInput([line()], prefillDraft([line()]), {
       ...META,
       reference: '  ',
     })
@@ -200,7 +133,7 @@ describe('buildReceivePoInput', () => {
   })
 
   it('sends the accounting date it was given', () => {
-    const input = buildReceivePoInput([line()], prefillDraft([line()]), NO_HEADER, {
+    const input = buildReceivePoInput([line()], prefillDraft([line()]), {
       ...META,
       occurredAt: '2026-01-04T09:30:00.000Z',
     })

--- a/apps/web/src/components/purchasing/purchase-order/receive-po-lines.ts
+++ b/apps/web/src/components/purchasing/purchase-order/receive-po-lines.ts
@@ -1,26 +1,32 @@
 // apps/web/src/components/purchasing/purchase-order/receive-po-lines.ts
 
-// The receive-against-a-PO dialog's arithmetic, as a pure function of what is on
+// The receive-against-a-PO dialog's payload, as a pure function of what is on
 // screen (plans/purchasing/01-build-plan.md §3.1 / §4.3).
 //
 // Separate from the dialog for the same reason `receipt-input.ts` is separate from
 // the popover: the rules below are invisible in a rendered table and each one is a
 // silently-wrong number if it is missed.
 //
-//   1. A line receiving ZERO must not take part in the allocation. Freight is
-//      spread across what was on the truck; including a line that did not arrive
-//      dilutes every other line's share and understates the cost of the goods that
-//      did. It is also not merely display — `receivePurchaseOrder` allocates over
-//      exactly the lines it is sent.
+//   1. A line receiving ZERO must not be sent. `receivePurchaseOrder` refuses any
+//      line whose quantity is not greater than zero and refuses the WHOLE receipt
+//      when it finds one — validation runs over the entire set before the first
+//      movement, because half a shipment received is worse than a rejection. So a
+//      row nobody touched has to be filtered out here, or a partly-received order
+//      cannot be received at all.
 //   2. The default is "everything on the order arrived", so a quantity prefills to
 //      the OUTSTANDING amount, not the ordered amount. Re-receiving a fully
 //      received PO must default to zero, not to a second full delivery.
 //   3. Over-receipt is allowed and not clamped. A vendor shipping more than was
 //      ordered is a real event the three-way match exists to surface; silently
 //      capping it would hide the discrepancy at the one moment it is knowable.
-
-import { allocateLandedCost } from '@auxx/lib/purchasing/client'
-import { roundMinorUnits } from '@auxx/lib/receiving/client'
+//
+// 🛑 There is no price here, and no header amounts. The agreed price is already
+// frozen on the `purchase_order_line` and the server reads it there; the PO's
+// shipping, tax and discount are ORDER-level amounts that were being spread at
+// every SHIPMENT-level receipt, which capitalised the same freight once per
+// delivery (§1.1 and §3.2 of
+// plans/purchasing/05-receiving-cost-and-corrections.md). This door states two
+// facts per line and nothing else: which line arrived, and how many.
 
 /** One purchase-order line as the dialog knows it. */
 export interface ReceivablePoLine {
@@ -30,26 +36,12 @@ export interface ReceivablePoLine {
   description: string | null
   quantityOrdered: number
   quantityReceived: number
-  /** The agreed buy price, minor units — the prefill for the price input. */
-  expectedUnitPrice: number
   vendorPartId?: string
-  /** Shipping weight for the whole line. Read only by the `weight` basis. */
-  weight?: number
 }
 
 /** What the person keyed into one row. */
 export interface ReceiptDraftLine {
   quantity: number
-  unitPrice: number
-}
-
-/** The PO header's stated amounts — the freight-allocation inputs. */
-export interface ReceiptHeader {
-  shipping: number
-  tax: number
-  discount: number
-  taxRecoverable: boolean
-  basis: 'value' | 'quantity' | 'weight'
 }
 
 /** The `purchasing.receivePurchaseOrder` input, as this dialog builds it. */
@@ -58,15 +50,8 @@ export interface ReceivePoInput {
     partId: string
     purchaseOrderLineId: string
     quantity: number
-    unitPrice: number
     vendorPartId?: string
-    weight?: number
   }[]
-  shipping?: number
-  tax?: number
-  discount?: number
-  taxRecoverable?: boolean
-  basis?: 'value' | 'quantity' | 'weight'
   occurredAt: Date
   reference?: string
   reason?: string
@@ -82,14 +67,11 @@ export function outstandingQuantity(line: ReceivablePoLine): number {
   return Math.max(0, line.quantityOrdered - line.quantityReceived)
 }
 
-/** Prefill the whole table: outstanding quantity at the agreed price. */
+/** Prefill the whole table with the outstanding quantity on every line. */
 export function prefillDraft(lines: ReceivablePoLine[]): Record<string, ReceiptDraftLine> {
   const draft: Record<string, ReceiptDraftLine> = {}
   for (const line of lines) {
-    draft[line.purchaseOrderLineId] = {
-      quantity: outstandingQuantity(line),
-      unitPrice: line.expectedUnitPrice,
-    }
+    draft[line.purchaseOrderLineId] = { quantity: outstandingQuantity(line) }
   }
   return draft
 }
@@ -107,67 +89,10 @@ export function activeLines(
     )
 }
 
-/**
- * Allocated landed unit cost per active line, keyed by PO line id.
- *
- * The same `allocateLandedCost` the server runs, over the same set of lines, so
- * the column the person reads before committing is the number that gets frozen.
- */
-export function allocatedUnitCosts(
-  lines: ReceivablePoLine[],
-  draft: Record<string, ReceiptDraftLine>,
-  header: ReceiptHeader
-): Record<string, number> {
-  const active = activeLines(lines, draft)
-  if (active.length === 0) return {}
-
-  const unitCosts = allocateLandedCost(
-    active.map(({ line, draft: row }) => ({
-      lineTotal: roundMinorUnits(row.unitPrice * row.quantity),
-      quantity: row.quantity,
-      weight: line.weight,
-    })),
-    {
-      shipping: header.shipping,
-      tax: header.tax,
-      discount: header.discount,
-      taxRecoverable: header.taxRecoverable,
-    },
-    header.basis
-  )
-
-  const byLine: Record<string, number> = {}
-  active.forEach(({ line }, index) => {
-    const cost = unitCosts[index]
-    if (cost != null) byLine[line.purchaseOrderLineId] = cost
-  })
-  return byLine
-}
-
-/** Goods value before the header amounts are spread onto it. */
-export function receiptSubtotal(
-  lines: ReceivablePoLine[],
-  draft: Record<string, ReceiptDraftLine>
-): number {
-  return activeLines(lines, draft).reduce(
-    (sum, { draft: row }) => sum + roundMinorUnits(row.unitPrice * row.quantity),
-    0
-  )
-}
-
-/**
- * Build the mutation input, or `null` when nothing is being received.
- *
- * Header amounts are sent whole. They are the PO's stated totals and the server
- * spreads them over exactly the lines it is given — so receiving half an order
- * capitalises the full freight onto that half, which is correct: the truck came
- * once. Receiving the rest later with the freight already consumed is a real
- * question this does not answer; see the note in the dialog.
- */
+/** Build the mutation input, or `null` when nothing is being received. */
 export function buildReceivePoInput(
   lines: ReceivablePoLine[],
   draft: Record<string, ReceiptDraftLine>,
-  header: ReceiptHeader,
   meta: { occurredAt: string; reference: string; reason: string }
 ): ReceivePoInput | null {
   const active = activeLines(lines, draft)
@@ -181,15 +106,8 @@ export function buildReceivePoInput(
       partId: line.partId,
       purchaseOrderLineId: line.purchaseOrderLineId,
       quantity: row.quantity,
-      unitPrice: roundMinorUnits(row.unitPrice),
       ...(line.vendorPartId ? { vendorPartId: line.vendorPartId } : {}),
-      ...(line.weight != null ? { weight: line.weight } : {}),
     })),
-    shipping: header.shipping,
-    tax: header.tax,
-    discount: header.discount,
-    taxRecoverable: header.taxRecoverable,
-    basis: header.basis,
     occurredAt: new Date(meta.occurredAt),
     ...(reference ? { reference } : {}),
     ...(reason ? { reason } : {}),

--- a/apps/web/src/components/purchasing/purchase-order/receive-purchase-order-dialog.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/receive-purchase-order-dialog.tsx
@@ -13,8 +13,16 @@
 // one-off, a freight-only delivery — and it should stay small.
 //
 // Everything here is prefilled on the assumption the whole order arrived: each
-// row's quantity is what is OUTSTANDING and each price is what was agreed. The
-// common case is therefore Receive, with no typing at all.
+// row's quantity is what is OUTSTANDING. The common case is therefore Receive,
+// with no typing at all.
+//
+// 🛑 The only question this door asks is HOW MANY ARRIVED. It used to ask for a
+// unit price too, and to spread the order's shipping, tax and discount across
+// whatever was on this receipt — both wrong for the same reason: a purchase order
+// is an ORDER-level document and a receipt is a SHIPMENT-level event. The price
+// is already frozen on the line and the server reads it there; the freight is the
+// bill's to state, and allocating it here capitalised the same charge once per
+// delivery. See plans/purchasing/05-receiving-cost-and-corrections.md §3.2/§4.1.
 //
 // 🛑 The line set comes from `usePurchaseOrderLines` — the LIST lane — and here
 // that is a correctness requirement, not a freshness nicety. This dialog does not
@@ -44,46 +52,30 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { TableBody, TableCell, TableHead, TableHeader, TableRow } from '@auxx/ui/components/table'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
-import { formatCurrency } from '@auxx/utils/currency'
 import { Package } from 'lucide-react'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useRecord } from '~/components/resources'
-import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { BaseType } from '~/components/workflow/types'
-import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
+import { formatQuantity } from '../purchasing-summary-strip'
 import {
-  formatQuantity,
-  numberValue,
-  PurchasingSummaryStrip,
-  type SummaryCell,
-  unwrapValue,
-} from '../purchasing-summary-strip'
-import {
-  allocatedUnitCosts,
   buildReceivePoInput,
   outstandingQuantity,
   prefillDraft,
   type ReceiptDraftLine,
-  type ReceiptHeader,
   type ReceivablePoLine,
-  receiptSubtotal,
 } from './receive-po-lines'
 import { usePurchaseOrderLines } from './use-purchase-order-lines'
 
-// The PO's OWN fields — written on the PO and published normally, so
-// `useSystemValues` is the right read for them. `purchase_order_lines` is not
-// here on purpose; see the note above.
-const PO_ATTRS = [
-  'purchase_order_shipping_total',
-  'purchase_order_tax_total',
-  'purchase_order_discount_value',
-  'purchase_order_tax_recoverable',
-  'purchase_order_allocation_basis',
-  'purchase_order_currency',
-] as const
+// 🛑 This dialog reads NO field off the purchase order header any more. It used
+// to read `shipping_total` / `tax_total` / `discount_value` /
+// `tax_recoverable` / `allocation_basis` to spread freight across the receipt,
+// and `currency` to render the money columns that spread produced. All of that
+// left with the allocation. Those fields are still declared on the PO and still
+// reachable through the generic field panel — nothing was retired, this surface
+// simply stopped being one of their readers.
 
 interface ReceivePurchaseOrderDialogProps {
   open: boolean
@@ -98,21 +90,10 @@ export function ReceivePurchaseOrderDialog({
   purchaseOrderRecordId,
   onReceived,
 }: ReceivePurchaseOrderDialogProps) {
-  const { getSetting } = useSettings({})
-
-  const { values, isLoading: poLoading } = useSystemValues(purchaseOrderRecordId, [...PO_ATTRS], {
-    autoFetch: true,
-  })
   // Same hook the Receiving card behind this dialog uses, so both resolve one
   // line set from one fetch — the card and the receipt can never disagree about
   // what is on the order.
-  const { lines: poLines, isLoading: linesLoading } = usePurchaseOrderLines(purchaseOrderRecordId)
-
-  const currencyValue = unwrapValue(values.purchase_order_currency)
-  const currencyCode =
-    (typeof currencyValue === 'string' && currencyValue) ||
-    (getSetting('organization.currency') as string | null) ||
-    'USD'
+  const { lines: poLines, isLoading } = usePurchaseOrderLines(purchaseOrderRecordId)
 
   // Two shapes out of one pass over the lines. `ReceivablePoLine[]` is the SERVER
   // payload's shape, so its `partId` is a bare instance id — which cannot address
@@ -130,29 +111,15 @@ export function ReceivePurchaseOrderDialog({
         description: line.description,
         quantityOrdered: line.ordered,
         quantityReceived: line.received,
-        expectedUnitPrice: line.expectedUnitPrice,
-        // Spread-or-omit, not `undefined`: both are optional on the server
-        // payload and an explicit `undefined` is a different shape.
+        // Spread-or-omit, not `undefined`: it is optional on the server payload
+        // and an explicit `undefined` is a different shape.
         ...(line.vendorPartRecordId
           ? { vendorPartId: getInstanceId(line.vendorPartRecordId) }
           : {}),
-        ...(line.weight > 0 ? { weight: line.weight } : {}),
       }
     })
     return { lines, partRecordIds }
   }, [poLines])
-
-  const basisValue = unwrapValue(values.purchase_order_allocation_basis)
-  const header: ReceiptHeader = {
-    shipping: numberValue(values.purchase_order_shipping_total),
-    tax: numberValue(values.purchase_order_tax_total),
-    discount: numberValue(values.purchase_order_discount_value),
-    taxRecoverable: unwrapValue(values.purchase_order_tax_recoverable) === true,
-    basis:
-      basisValue === 'quantity' || basisValue === 'weight'
-        ? basisValue
-        : ('value' as ReceiptHeader['basis']),
-  }
 
   const [draft, setDraft] = useState<Record<string, ReceiptDraftLine>>({})
   const [occurredAt, setOccurredAt] = useState(() => new Date().toISOString())
@@ -172,9 +139,7 @@ export function ReceivePurchaseOrderDialog({
     setReason('')
   }, [open, linesKey])
 
-  const unitCosts = allocatedUnitCosts(lines, draft, header)
-  const subtotal = receiptSubtotal(lines, draft)
-  const payload = buildReceivePoInput(lines, draft, header, { occurredAt, reference, reason })
+  const payload = buildReceivePoInput(lines, draft, { occurredAt, reference, reason })
 
   const receive = api.purchasing.receivePurchaseOrder.useMutation({
     onError: (error) => toastError({ title: 'Failed to receive', description: error.message }),
@@ -202,34 +167,11 @@ export function ReceivePurchaseOrderDialog({
     }
   }
 
-  const isLoading = poLoading || linesLoading
   const receivingCount = payload?.lines.length ?? 0
-
-  // The header amounts are the freight-allocation inputs (§4.3) — shown so the
-  // landed column above is explicable rather than mysterious.
-  const landedCells: SummaryCell[] = [
-    { label: 'Goods', value: formatCurrency(subtotal, { currencyCode }) },
-    ...(header.shipping > 0
-      ? [{ label: 'Freight', value: `+ ${formatCurrency(header.shipping, { currencyCode })}` }]
-      : []),
-    ...(header.tax > 0
-      ? [
-          {
-            label: header.taxRecoverable ? 'Tax (recoverable)' : 'Tax',
-            value: `+ ${formatCurrency(header.tax, { currencyCode })}`,
-          },
-        ]
-      : []),
-    ...(header.discount > 0
-      ? [{ label: 'Discount', value: `− ${formatCurrency(header.discount, { currencyCode })}` }]
-      : []),
-    { label: 'Spread by', value: header.basis, tone: 'muted' },
-  ]
-  const showLandedCells = header.shipping > 0 || header.tax > 0 || header.discount > 0
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent position='tc' size='xxl'>
+      <DialogContent position='tc' size='lg'>
         <DialogHeader>
           <DialogTitle>Receive purchase order</DialogTitle>
           <DialogDescription>
@@ -237,9 +179,9 @@ export function ReceivePurchaseOrderDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {/* One rhythm for the three body blocks — the table, the allocation strip
-            and the receipt form. `DialogHeader` carries its own `mb-4` and
-            `DialogFooter` its own `pt-4`, so only the middle needs spacing. */}
+        {/* One rhythm for the two body blocks — the table and the receipt form.
+            `DialogHeader` carries its own `mb-4` and `DialogFooter` its own
+            `pt-4`, so only the middle needs spacing. */}
         <div className='space-y-4'>
           {isLoading ? (
             <div className='space-y-2 rounded-md border p-3'>
@@ -260,14 +202,12 @@ export function ReceivePurchaseOrderDialog({
                   div, which would become the sticky header's scrollport and pin the
                   header to a box that never scrolls. Same shape as `audit-table.tsx`.
                   `table-fixed` is what lets the part cell actually truncate. */}
-              <table className='w-full min-w-[36rem] table-fixed caption-bottom text-sm'>
+              <table className='w-full min-w-[24rem] table-fixed caption-bottom text-sm'>
                 <TableHeader className='sticky top-0 z-10 bg-muted'>
                   <TableRow className='hover:bg-muted'>
                     <TableHead>Part</TableHead>
                     <TableHead className='w-[7.5rem] text-right'>Outstanding</TableHead>
                     <TableHead className='w-[7rem] text-right'>Receive</TableHead>
-                    <TableHead className='w-[9rem] text-right'>Unit price</TableHead>
-                    <TableHead className='w-[7rem] text-right'>Landed</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -277,8 +217,6 @@ export function ReceivePurchaseOrderDialog({
                       line={line}
                       partRecordId={partRecordIds[line.purchaseOrderLineId]}
                       draft={draft[line.purchaseOrderLineId]}
-                      landedUnitCost={unitCosts[line.purchaseOrderLineId]}
-                      currencyCode={currencyCode}
                       disabled={receive.isPending}
                       onChange={(next) =>
                         setDraft((current) => ({ ...current, [line.purchaseOrderLineId]: next }))
@@ -288,10 +226,6 @@ export function ReceivePurchaseOrderDialog({
                 </TableBody>
               </table>
             </div>
-          )}
-
-          {showLandedCells && (
-            <PurchasingSummaryStrip className='rounded-md border px-3 py-2' cells={landedCells} />
           )}
 
           <FieldPanel
@@ -380,22 +314,17 @@ function ReceiveLineRow({
   line,
   partRecordId,
   draft,
-  landedUnitCost,
-  currencyCode,
   disabled,
   onChange,
 }: {
   line: ReceivablePoLine
   partRecordId: RecordId | undefined
   draft: ReceiptDraftLine | undefined
-  landedUnitCost: number | undefined
-  currencyCode: string
   disabled: boolean
   onChange: (next: ReceiptDraftLine) => void
 }) {
   const { record } = useRecord({ recordId: partRecordId!, enabled: !!partRecordId })
   const quantity = draft?.quantity ?? 0
-  const unitPrice = draft?.unitPrice ?? line.expectedUnitPrice
   const outstanding = outstandingQuantity(line)
 
   // The part IS a buy-side line's identity (03-line-builder-reuse.md), so it leads;
@@ -415,29 +344,15 @@ function ReceiveLineRow({
         {formatQuantity(outstanding)}
         <span className='ml-1 text-xs'>of {formatQuantity(line.quantityOrdered)}</span>
       </TableCell>
-      <TableCell className='px-1 py-1'>
+      <TableCell className='py-1 pr-2 pl-1'>
         <EditableNumberCell>
           <FieldInputAdapter
             fieldType={FieldType.NUMBER}
             value={quantity}
-            onChange={(val) => onChange({ quantity: (val as number) ?? 0, unitPrice })}
+            onChange={(val) => onChange({ quantity: (val as number) ?? 0 })}
             disabled={disabled}
           />
         </EditableNumberCell>
-      </TableCell>
-      <TableCell className='px-1 py-1'>
-        <EditableNumberCell>
-          <FieldInputAdapter
-            fieldType={FieldType.CURRENCY}
-            fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
-            value={unitPrice}
-            onChange={(val) => onChange({ quantity, unitPrice: (val as number) ?? 0 })}
-            disabled={disabled}
-          />
-        </EditableNumberCell>
-      </TableCell>
-      <TableCell className='py-1.5 pr-3 pl-2 text-right tabular-nums'>
-        {landedUnitCost != null ? formatCurrency(landedUnitCost, { currencyCode }) : '—'}
       </TableCell>
     </TableRow>
   )

--- a/apps/web/src/components/purchasing/purchase-order/use-purchase-order-lines.ts
+++ b/apps/web/src/components/purchasing/purchase-order/use-purchase-order-lines.ts
@@ -44,6 +44,7 @@ import {
   LINE_PAGE_SIZE,
   LINE_SORT,
   lineSchemaFor,
+  numberOrNull,
 } from '~/components/money/ui/line-builder/line-values'
 import { type RecordId, toRecordId, useRecordList, useResource } from '~/components/resources'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
@@ -62,6 +63,12 @@ const LINE_ATTRS = [
   // row rather than fetched separately so the dialog and the cards resolve one
   // line set — the dialog BUILDS A WRITE from these rows, so a second read that
   // could disagree is worse here than anywhere else.
+  //
+  // ✅ Both had NO WRITER at all until
+  // plans/purchasing/05-receiving-cost-and-corrections.md §5.2/§5.3: they were
+  // declared in the registry, read here, and set by no surface anywhere. The line
+  // builder writes them now — `vendorPart` from the price prefill on part pick,
+  // `weight` from the row menu's document-level weight control.
   'purchase_order_line_vendor_part',
   'purchase_order_line_weight',
 ] as const
@@ -79,10 +86,30 @@ export interface PurchaseOrderLineRow {
   billed: number
   /** Integer minor units — the agreed price, and the price arm of the match. */
   expectedUnitPrice: number
-  /** `null` unless the line was priced off a specific vendor part. */
+  /**
+   * The supplier catalogue entry this line's price was seeded from, or `null`.
+   *
+   * 🛑 PROVENANCE, not a price source. It is stamped once when the part is picked
+   * and the agreed price lives in {@link expectedUnitPrice} from then on —
+   * `vendor_part_unit_price` is `updatable: true`, so a caller that re-read the
+   * price through this link would stop reporting the price the order froze
+   * (plans/purchasing/05-receiving-cost-and-corrections.md §5.2).
+   */
   vendorPartRecordId: RecordId | null
-  /** Shipping weight for the whole line; read only by the `weight` basis. */
-  weight: number
+  /**
+   * Shipping weight for the whole line — the `weight` allocation basis's only
+   * input. `null` means nobody has recorded one.
+   *
+   * 🛑 `null`, never `0`, for an unrecorded weight. `numberValue` — which every
+   * other number on this row uses — folds absence into `0`, and that is right for
+   * a quantity or a price, where "none" and "zero" are the same fact. It is wrong
+   * here: `allocateLandedCost` spreads freight by each line's share of the total
+   * weight, so an unweighed line reported as `0` reads as a deliberate
+   * weighs-nothing. `allocateCapitalisedCost` rejects that shape either way (it
+   * treats zero as absent, for the same reason), but a caller that wants to WARN
+   * before it gets there needs the distinction this read preserves (§5.3).
+   */
+  weight: number | null
 }
 
 /**
@@ -156,7 +183,11 @@ export function usePurchaseOrderLines(purchaseOrderRecordId: RecordId | null): {
           expectedUnitPrice: numberValue(v.purchase_order_line_expected_unit_price),
           vendorPartRecordId:
             extractRelationshipRecordIds(v.purchase_order_line_vendor_part)[0] ?? null,
-          weight: numberValue(v.purchase_order_line_weight),
+          // 🛑 NOT `numberValue`, which folds absence into `0` — see the field's
+          // own note. Every other number on this row is a quantity or a price
+          // where "none" and "zero" mean the same thing; weight is the one where
+          // they do not.
+          weight: numberOrNull(v.purchase_order_line_weight),
         }
       }),
     [lineRecordIds, valuesById]

--- a/apps/web/src/server/api/routers/purchasing.ts
+++ b/apps/web/src/server/api/routers/purchasing.ts
@@ -2,13 +2,20 @@
 
 import { getCachedEntityDefId } from '@auxx/lib/cache'
 import { NotFoundError } from '@auxx/lib/errors'
-import { allocateLandedCost, DEFAULT_MATCH_TOLERANCE, matchBill } from '@auxx/lib/purchasing'
 import {
+  allocateLandedCost,
+  DEFAULT_MATCH_TOLERANCE,
+  findVendorPartForLine,
+  matchBill,
+} from '@auxx/lib/purchasing'
+import {
+  adjustStock,
   getLastReceiptCost,
   getPartReceiptHistory,
   listReceipts,
   receivePurchaseOrder,
   receiveStock,
+  reverseMovement,
   roundMinorUnits,
 } from '@auxx/lib/receiving'
 import { z } from 'zod'
@@ -22,17 +29,28 @@ const receiptQuantity = z.number().finite().positive()
 
 const allocationBasis = z.enum(['value', 'quantity', 'weight'])
 
+/**
+ * One line of a purchase-order receipt: which line arrived, and how many.
+ *
+ * No price, deliberately. The agreed price is already frozen on the
+ * `purchase_order_line` and `receivePurchaseOrder` reads it there, so there is
+ * nothing for a line to state about what the goods cost.
+ */
 const purchaseOrderLine = z.object({
   partId: z.string().min(1),
   purchaseOrderLineId: z.string().min(1),
   quantity: receiptQuantity,
-  /** Agreed buy price per unit, BEFORE header freight/tax is spread onto it. */
-  unitPrice: minorUnits,
   vendorPartId: z.string().min(1).optional(),
-  /** Shipping weight for the whole line. Read only by the `weight` basis. */
-  weight: z.number().finite().nonnegative().optional(),
 })
 
+/**
+ * A purchase order's stated freight, tax and discount, plus how to spread them.
+ *
+ * These are ORDER-level amounts and they no longer reach the receiving path —
+ * see `receivePurchaseOrder` below. The only procedure that still takes them is
+ * `previewLandedCost`, which is pure arithmetic over a set of lines a caller
+ * hands it and writes nothing.
+ */
 const purchaseOrderHeader = {
   shipping: minorUnits.optional(),
   tax: minorUnits.optional(),
@@ -82,7 +100,7 @@ async function requireDefId(organizationId: string, entityType: string): Promise
  *
  * | procedure                          | gate                                  |
  * | ---------------------------------- | ------------------------------------- |
- * | `receiveStock`, `receivePurchaseOrder` | edit on `stock_movement`          |
+ * | `receiveStock`, `receivePurchaseOrder`, `adjustStock`, `reverseMovement` | edit on `stock_movement` |
  * | `listReceipts`, `partReceiptHistory`, `lastReceiptCost` | view on `stock_movement` |
  * | `previewLandedCost`                | edit on `stock_movement`              |
  * | `previewMatch`                     | edit on `vendor_bill`                 |
@@ -99,11 +117,21 @@ async function requireDefId(organizationId: string, entityType: string): Promise
  */
 export const purchasingRouter = createTRPCRouter({
   /**
-   * Receive one line: this many of this part arrived, at this price.
+   * Receive one line against a bare part: this many arrived, at this price.
    *
-   * `unitCost` supplied here WINS over anything derivable from the `vendor_part`
-   * row — the vendor's actual invoice beats the standing terms. Leave it out to
-   * let the supplier row price the receipt.
+   * The no-purchase-order door. There is no agreed price anywhere in the system
+   * for a receipt with no `purchase_order_line`, so `vendorUnitPrice` is the one
+   * number the browser is entitled to state — and it states the BASE price off
+   * the packing slip, not the cost. The server reads the `vendor_part` row for
+   * the freight, tariff and other adders and derives the landed cost itself.
+   *
+   * 🛑 **There is no `unitCost` on this input, and there must never be one.**
+   * The cost frozen onto a movement is a fact the server holds; a client that
+   * could assert it could value inventory at any number it liked, and because
+   * every field on `stock_movement` is `updatable: false` the wrong figure would
+   * be frozen forever with nothing thrown. Dropping it from this schema is what
+   * makes that a fact rather than a convention
+   * (plans/purchasing/05-receiving-cost-and-corrections.md section 4.1).
    */
   receiveStock: capabilityProcedure
     .input(
@@ -111,10 +139,14 @@ export const purchasingRouter = createTRPCRouter({
         partId: z.string().min(1),
         quantity: receiptQuantity,
         vendorPartId: z.string().min(1).optional(),
-        /** Raw supplier price per unit, frozen as provenance for the three-way match. */
+        /**
+         * The BASE supplier price per unit, before the landed adders.
+         *
+         * Frozen on the movement as provenance for the three-way match as well,
+         * which is why it is one field and not two: the number the vendor
+         * invoiced is the number the landed cost is built on.
+         */
         vendorUnitPrice: minorUnits.optional(),
-        /** Landed cost per unit. */
-        unitCost: minorUnits.optional(),
         /** The ACCOUNTING date, which is not `createdAt`. Defaults to now. */
         occurredAt: z.coerce.date().optional(),
         reference: z.string().max(255).optional(),
@@ -133,17 +165,28 @@ export const purchasingRouter = createTRPCRouter({
     }),
 
   /**
-   * Receive a multi-line purchase order, spreading the header freight/tax/discount
-   * across the lines and freezing the resulting landed cost on each movement.
+   * Receive a multi-line purchase order: which lines arrived, and how many of
+   * each.
    *
-   * Every line must name a `purchase_order_line`: a movement carrying a share of a
-   * freight bill with no link back to the shipment cannot be audited later.
+   * Every line must name a `purchase_order_line`, which is both the link the
+   * roll-up and the three-way match need and — since the price left the wire —
+   * the only way the server can find out what the line cost. `receivePurchaseOrder`
+   * reads `purchase_order_line_expected_unit_price` per line and freezes that as
+   * the movement's cost; a price on the wire would be ignored, so there is none.
+   *
+   * 🛑 **Nothing is allocated here.** The header freight, tax and discount used
+   * to be spread across whatever was on this receipt. They are ORDER-level
+   * amounts and a receipt is a SHIPMENT-level event, so allocating them at every
+   * delivery capitalised the same freight once per delivery — $120.00 into
+   * inventory against a $40.00 freight charge on PO-0001. The double-count
+   * disappears by construction now that nothing allocates here; landed cost moves
+   * to the bill, which is the document that actually states what the freight was
+   * (plans/purchasing/05-receiving-cost-and-corrections.md sections 3.2 and 4.2).
    */
   receivePurchaseOrder: capabilityProcedure
     .input(
       z.object({
         lines: z.array(purchaseOrderLine).min(1).max(200),
-        ...purchaseOrderHeader,
         occurredAt: z.coerce.date().optional(),
         reference: z.string().max(255).optional(),
         reason: z.string().max(2000).optional(),
@@ -155,6 +198,114 @@ export const purchasingRouter = createTRPCRouter({
       ctx.capabilities.assertEditEntity(movementDefId)
 
       const result = await receivePurchaseOrder(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Correct a part's on-hand count by a signed delta.
+   *
+   * The THIRD movement door, and until now the only one that wrote a
+   * `stock_movement` through the generic `record.create` — which meant it
+   * bypassed the zero-cost guard entirely and could add stock valued at nothing
+   * (plans/purchasing/05-receiving-cost-and-corrections.md section 1.5).
+   *
+   * 🛑 **`unitCost` is required when `quantity` is positive and ignored when it
+   * is negative**, and unlike `receiveStock` the browser IS entitled to state it.
+   * There is no other authority: an adjustment has no supplier row, no purchase
+   * order and no packing slip, so the person keying the count is the only source
+   * for what the added units are worth. `adjustStock` still applies the real
+   * guard — a positive adjustment that does not round to a positive cost is
+   * refused there, and nothing is written.
+   */
+  adjustStock: capabilityProcedure
+    .input(
+      z.object({
+        partId: z.string().min(1),
+        /** The signed delta. Positive adds stock, negative removes it; zero is refused. */
+        quantity: z.number().finite(),
+        /** What one ADDED unit is worth, minor units. Required on a positive delta. */
+        unitCost: minorUnits.optional(),
+        /** The ACCOUNTING date, which is not `createdAt`. Defaults to now. */
+        occurredAt: z.coerce.date().optional(),
+        reason: z.string().max(2000).optional(),
+        reference: z.string().max(255).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const movementDefId = await requireDefId(organizationId, 'stock_movement')
+      ctx.capabilities.assertEditEntity(movementDefId)
+
+      const result = await adjustStock(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Undo a movement by writing its negation — the correction path that did not exist.
+   *
+   * Not an edit and not a delete. Every field on `stock_movement` is
+   * `updatable: false` on purpose, because a cost frozen onto a movement can only
+   * be trusted years later if nothing can rewrite it, so a correction is a second
+   * row that cancels the first (section 5.1).
+   *
+   * 🛑 **The reversal carries the ORIGINAL's frozen `unitCost`, never today's
+   * price.** Re-pricing a correction is the costing bug this whole subsystem
+   * exists to avoid. It also copies the original's `purchaseOrderLine`, which is
+   * what lets `quantity_received` roll back on its own — the roll-up re-SUMs every
+   * movement pointing at the line and has no opinion about sign.
+   *
+   * A movement carrying no cost cannot be reversed: the negation would be the
+   * zero-cost row `receiveStock` refuses to write in the first place.
+   */
+  reverseMovement: capabilityProcedure
+    .input(
+      z.object({
+        movementId: z.string().min(1),
+        /** Why it is being undone. Stamped on the reversing row, not the original. */
+        reason: z.string().max(2000).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const movementDefId = await requireDefId(organizationId, 'stock_movement')
+      ctx.capabilities.assertEditEntity(movementDefId)
+
+      const result = await reverseMovement(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * The one `vendor_part` row for a `(part, supplier)` pair — the PO line price prefill.
+   *
+   * Unambiguous by construction: `vendor_part_part` and `vendor_part_contact` are legs
+   * 1 and 2 of an enforced natural key, so this resolves to at most one row and needs no
+   * ambiguity handling.
+   *
+   * 🛑 `null` means this supplier has no catalogue entry for this part. That is NOT an
+   * error and must NEVER fall back to the preferred vendor: `is_preferred` answers
+   * "replacement cost for the part regardless of supplier", and using it here would put
+   * a different supplier's price on this supplier's order.
+   *
+   * What comes back is a PREFILL. The price is frozen onto the line at order time and
+   * nothing re-reads it through the link afterwards — `vendor_part_unit_price` is
+   * mutable, `expected_unit_price` is the agreed number (section 5.2).
+   */
+  vendorPartForLine: capabilityProcedure
+    .input(
+      z.object({
+        partInstanceId: z.string().min(1),
+        vendorInstanceId: z.string().min(1),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const vendorPartDefId = await requireDefId(organizationId, 'vendor_part')
+      ctx.capabilities.assertViewEntity(vendorPartDefId)
+
+      const result = await findVendorPartForLine(ctx.db, organizationId, input)
       if (result.isErr()) throw result.error
       return result.value
     }),

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1132,12 +1132,6 @@
       "import": "./dist/purchasing/index.mjs",
       "default": "./src/purchasing/index.ts"
     },
-    "./purchasing/client": {
-      "types": "./src/purchasing/client.ts",
-      "source": "./src/purchasing/client.ts",
-      "import": "./dist/purchasing/client.mjs",
-      "default": "./src/purchasing/client.ts"
-    },
     "./quick-actions": {
       "types": "./src/quick-actions/index.ts",
       "source": "./src/quick-actions/index.ts",

--- a/packages/lib/src/purchasing/__tests__/allocate-landed-cost.test.ts
+++ b/packages/lib/src/purchasing/__tests__/allocate-landed-cost.test.ts
@@ -174,14 +174,6 @@ describe('allocateLandedCost - bases', () => {
     ])
   })
 
-  it('treats a missing weight as zero', () => {
-    const mixed: AllocationLine[] = [
-      { lineTotal: 100, quantity: 1, weight: 10 },
-      { lineTotal: 100, quantity: 1 },
-    ]
-    expect(allocateCapitalisedCost(mixed, header({ shipping: 500 }), 'weight')).toEqual([500, 0])
-  })
-
   it('ignores a negative line total when weighting by value', () => {
     const withCredit: AllocationLine[] = [
       { lineTotal: -100, quantity: 1 },
@@ -190,6 +182,119 @@ describe('allocateLandedCost - bases', () => {
     expect(allocateCapitalisedCost(withCredit, header({ shipping: 500 }), 'value')).toEqual([
       0, 500,
     ])
+  })
+})
+
+describe('allocateCapitalisedCost - a partial weight set is refused', () => {
+  // Receiving plan section 5.3: all-absent carries no information and an equal
+  // split is honest; half-absent carries misleading information, because the
+  // unweighed lines land at exactly zero freight while looking deliberate.
+
+  it('refuses a set where only some lines carry a weight, naming the line', () => {
+    const mixed: AllocationLine[] = [
+      { lineTotal: 100, quantity: 1, weight: 10 },
+      { lineTotal: 100, quantity: 1 },
+    ]
+    expect(() => allocateCapitalisedCost(mixed, header({ shipping: 500 }), 'weight')).toThrow(
+      BadRequestError
+    )
+    expect(() => allocateCapitalisedCost(mixed, header({ shipping: 500 }), 'weight')).toThrow(
+      /Line 1 has no weight/
+    )
+  })
+
+  it('names the first unweighed line when several are missing', () => {
+    const mixed: AllocationLine[] = [
+      { lineTotal: 100, quantity: 1, weight: 10 },
+      { lineTotal: 100, quantity: 1, weight: 20 },
+      { lineTotal: 100, quantity: 1 },
+      { lineTotal: 100, quantity: 1 },
+    ]
+    expect(() => allocateCapitalisedCost(mixed, header({ shipping: 500 }), 'weight')).toThrow(
+      /Line 2 has no weight/
+    )
+  })
+
+  it('refuses an explicit zero weight among positive ones - same silent zero share', () => {
+    const mixed: AllocationLine[] = [
+      { lineTotal: 100, quantity: 1, weight: 10 },
+      { lineTotal: 100, quantity: 1, weight: 0 },
+      { lineTotal: 100, quantity: 1, weight: 30 },
+    ]
+    expect(() => allocateCapitalisedCost(mixed, header({ shipping: 500 }), 'weight')).toThrow(
+      /Line 1 has no weight/
+    )
+  })
+
+  it('refuses through allocateLandedCost too, not just the adder vector', () => {
+    const mixed: AllocationLine[] = [
+      { lineTotal: 100, quantity: 1, weight: 10 },
+      { lineTotal: 100, quantity: 1 },
+    ]
+    expect(() => allocateLandedCost(mixed, header({ shipping: 500 }), 'weight')).toThrow(
+      BadRequestError
+    )
+  })
+
+  it('allocates as before when every line carries a positive weight', () => {
+    const weighed: AllocationLine[] = [
+      { lineTotal: 100, quantity: 1, weight: 10 },
+      { lineTotal: 100, quantity: 1, weight: 40 },
+    ]
+    const purchase = header({ shipping: 500 })
+    const adders = allocateCapitalisedCost(weighed, purchase, 'weight')
+
+    expect(adders).toEqual([100, 400])
+    expect(sum(adders)).toBe(capitalisableAmount(purchase))
+  })
+
+  it('still equal-splits when no line is weighed, whether absent or explicitly zero', () => {
+    // The "weighed === 0" branch: a mix of absent and zero is still a set that
+    // carries no information, so the documented fallback stands.
+    const unweighed: AllocationLine[] = [
+      { lineTotal: 100, quantity: 1, weight: 0 },
+      { lineTotal: 100, quantity: 1 },
+      { lineTotal: 100, quantity: 1, weight: 0 },
+    ]
+    const purchase = header({ shipping: 100 })
+    const adders = allocateCapitalisedCost(unweighed, purchase, 'weight')
+
+    expect(adders).toEqual([34, 33, 33])
+    expect(sum(adders)).toBe(capitalisableAmount(purchase))
+  })
+
+  it('leaves the value and quantity bases untouched by unweighed lines', () => {
+    // A zero line total under 'value' is a legitimate free item, and neither
+    // basis reads `weight` at all - the guard must not reach them.
+    const mixed: AllocationLine[] = [
+      { lineTotal: 100, quantity: 1, weight: 10 },
+      { lineTotal: 0, quantity: 3 },
+    ]
+    const purchase = header({ shipping: 400 })
+
+    expect(allocateCapitalisedCost(mixed, purchase, 'value')).toEqual([400, 0])
+    expect(allocateCapitalisedCost(mixed, purchase, 'quantity')).toEqual([100, 300])
+    for (const basis of ['value', 'quantity'] as const) {
+      expect(sum(allocateCapitalisedCost(mixed, purchase, basis))).toBe(
+        capitalisableAmount(purchase)
+      )
+    }
+  })
+
+  it('reconciles exactly for every fully weighed set across awkward counts and freight', () => {
+    for (let lineCount = 1; lineCount <= 9; lineCount++) {
+      for (const shipping of [1, 7, 99, 100, 1001, 123_457]) {
+        const lines: AllocationLine[] = Array.from({ length: lineCount }, (_, index) => ({
+          lineTotal: 1000 + index * 37,
+          quantity: 1 + index,
+          weight: 1 + index * 3,
+        }))
+        const purchase = header({ shipping, tax: 13, discount: 7 })
+        expect(sum(allocateCapitalisedCost(lines, purchase, 'weight'))).toBe(
+          capitalisableAmount(purchase)
+        )
+      }
+    }
   })
 })
 
@@ -227,7 +332,11 @@ describe('allocateLandedCost - degenerate inputs', () => {
       { lineTotal: 100, quantity: 1, weight: 0 },
       { lineTotal: 100, quantity: 1, weight: 0 },
     ]
-    expect(allocateCapitalisedCost(lines, header({ shipping: 1000 }), 'weight')).toEqual([500, 500])
+    const purchase = header({ shipping: 1000 })
+    const adders = allocateCapitalisedCost(lines, purchase, 'weight')
+
+    expect(adders).toEqual([500, 500])
+    expect(sum(adders)).toBe(capitalisableAmount(purchase))
   })
 
   it('allocates nothing when the header is empty', () => {

--- a/packages/lib/src/purchasing/__tests__/vendor-part-lookup.test.ts
+++ b/packages/lib/src/purchasing/__tests__/vendor-part-lookup.test.ts
@@ -1,0 +1,151 @@
+// packages/lib/src/purchasing/__tests__/vendor-part-lookup.test.ts
+// The `(part, supplier)` lookup behind a purchase order line's price prefill.
+// The org cache is mocked and `db` is a chainable stub, so nothing here needs a
+// database — what is asserted is the CONTRACT: both legs of the natural key are
+// required (there is no preferred-vendor fallback), a missing row is `null`
+// rather than an error, and a row with no price still returns its link.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** systemAttributes the org has materialised. */
+  materialised: new Set<string>(),
+  /** entityType -> def id; a missing key models a def the org does not have. */
+  defs: new Map<string, string>(),
+  /** One result array per `db.select()` call, in order. */
+  results: [] as unknown[][],
+  /** How many statements the function actually issued. */
+  selectCalls: 0,
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(
+          attrs.map((a) => [a, h.materialised.has(a) ? { id: `fld_${a}` } : null])
+        ),
+    }),
+  }),
+}))
+
+import type { Database } from '@auxx/database'
+import { findVendorPartForLine } from '../vendor-part-lookup'
+
+/**
+ * A drizzle query builder that answers `rows` however it is chained.
+ *
+ * Every method returns the same proxy, so `.from().innerJoin().where().limit()`
+ * composes without the stub having to know the statement's shape — which is the
+ * point: this test pins the function's RULES, not its SQL.
+ */
+function chainReturning(rows: unknown[]): unknown {
+  const proxy: unknown = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'then') return (resolve: (value: unknown) => void) => resolve(rows)
+        return () => proxy
+      },
+    }
+  )
+  return proxy
+}
+
+const db = {
+  select: () => chainReturning(h.results[h.selectCalls++] ?? []),
+} as unknown as Database
+
+const PARAMS = { partInstanceId: 'part_1', vendorInstanceId: 'company_1' }
+
+beforeEach(() => {
+  h.defs = new Map([['vendor_part', 'def_vendor_part']])
+  h.materialised = new Set(['vendor_part_part', 'vendor_part_contact', 'vendor_part_unit_price'])
+  h.results = []
+  h.selectCalls = 0
+})
+
+describe('findVendorPartForLine', () => {
+  it('returns the supplier row and its price as a prefill', async () => {
+    h.results = [[{ id: 'vp_1' }], [{ valueNumber: 1250 }]]
+
+    const result = await findVendorPartForLine(db, 'org_1', PARAMS)
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual({
+      vendorPartRecordId: 'def_vendor_part:vp_1',
+      unitPrice: 1250,
+    })
+  })
+
+  // A supplier that stocks the part but has not priced it is a real row, and the
+  // link is still worth stamping — there is simply nothing to prefill with. The
+  // caller must not read this as "no supplier row".
+  it('returns the link with a null price when the row carries no price', async () => {
+    h.results = [[{ id: 'vp_1' }], []]
+
+    const result = await findVendorPartForLine(db, 'org_1', PARAMS)
+
+    expect(result._unsafeUnwrap()).toEqual({
+      vendorPartRecordId: 'def_vendor_part:vp_1',
+      unitPrice: null,
+    })
+  })
+
+  // 🛑 The rule §5.2 exists to state: no row for THIS pair means no prefill. There
+  // is no fall back to the part's preferred vendor — that would put a different
+  // supplier's price on this supplier's order.
+  it('is null when this supplier has no entry for this part', async () => {
+    h.results = [[]]
+
+    const result = await findVendorPartForLine(db, 'org_1', PARAMS)
+
+    expect(result._unsafeUnwrap()).toBeNull()
+    // And it does not go looking for a price it has no row to read one from.
+    expect(h.selectCalls).toBe(1)
+  })
+
+  it('is null, not an error, on an org with no vendor_part definition', async () => {
+    h.defs = new Map()
+
+    const result = await findVendorPartForLine(db, 'org_1', PARAMS)
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toBeNull()
+    expect(h.selectCalls).toBe(0)
+  })
+
+  // 🛑 Both legs of the natural key or nothing. Matching on the part alone would
+  // return "any vendor part for this part", which IS the preferred-vendor
+  // fallback wearing a different hat — and it would query, which is why the
+  // assertion is that no statement is issued at all.
+  it.each([
+    'vendor_part_part',
+    'vendor_part_contact',
+  ])('refuses to query when %s is not materialised', async (missing) => {
+    h.materialised.delete(missing)
+    h.results = [[{ id: 'vp_1' }], [{ valueNumber: 1250 }]]
+
+    const result = await findVendorPartForLine(db, 'org_1', PARAMS)
+
+    expect(result._unsafeUnwrap()).toBeNull()
+    expect(h.selectCalls).toBe(0)
+  })
+
+  // The price field is the only one that may be absent without sinking the
+  // lookup: provenance is still resolvable, and a mid-migration org should get
+  // the link rather than nothing.
+  it('still returns the link when the price field is not materialised', async () => {
+    h.materialised.delete('vendor_part_unit_price')
+    h.results = [[{ id: 'vp_1' }]]
+
+    const result = await findVendorPartForLine(db, 'org_1', PARAMS)
+
+    expect(result._unsafeUnwrap()).toEqual({
+      vendorPartRecordId: 'def_vendor_part:vp_1',
+      unitPrice: null,
+    })
+    expect(h.selectCalls).toBe(1)
+  })
+})

--- a/packages/lib/src/purchasing/allocate-landed-cost.ts
+++ b/packages/lib/src/purchasing/allocate-landed-cost.ts
@@ -39,6 +39,42 @@ function assertLine(line: AllocationLine, index: number): void {
   }
 }
 
+/**
+ * Refuse a PARTIAL weight set under basis 'weight' (receiving plan section 5.3).
+ *
+ * The asymmetry with the all-zero fallback below is deliberate, and it is a
+ * difference in what the input MEANS rather than in how hard it is to divide:
+ *
+ * - All weights zero or absent carries NO information. An equal split is the
+ *   only defensible answer, it reconciles to the header exactly, and nobody
+ *   reading it can mistake it for a considered allocation — there was nothing
+ *   to consider.
+ * - Some weights present and some not carries MISLEADING information. It
+ *   divides cleanly, so nothing throws; it produces a lopsided vector that
+ *   looks deliberate, so nothing reads as wrong; and the unweighed lines land
+ *   at exactly zero freight while the weighed ones carry all of it. A landed
+ *   cost that is silently wrong and looks right is the failure this whole
+ *   module exists to avoid.
+ *
+ * So: a weight is not a per-line property that means something on its own, the
+ * way a line total does. It is a basis input that only means anything across
+ * the whole set, and half a set is not a partly-configured allocation — it is a
+ * broken one. The guard lives here rather than only in the line builder because
+ * the bill-side caller (plan section 4.2) needs the same protection.
+ *
+ * Zero is treated as absent: a zero-weight line among weighed lines has the
+ * identical silent-zero-share problem, and there is no way to tell "weighs
+ * nothing" from "not weighed yet" in the stored value.
+ */
+function assertWeightBasis(lines: AllocationLine[]): void {
+  const weighed = lines.filter((line) => (line.weight ?? 0) > 0).length
+  if (weighed === 0 || weighed === lines.length) return
+  const index = lines.findIndex((line) => (line.weight ?? 0) <= 0)
+  throw new BadRequestError(
+    `Line ${index} has no weight; allocating by weight requires a weight on every line or none`
+  )
+}
+
 function assertHeader(header: AllocationHeader): void {
   assertMinorUnits(header.shipping, 'Header shipping')
   assertMinorUnits(header.tax, 'Header tax')
@@ -88,8 +124,15 @@ export function capitalisableAmount(header: AllocationHeader): number {
  *   "spread it evenly" is the only defensible answer when the basis carries no
  *   information, and it still reconciles to the header exactly.
  *
+ * A PARTIAL weight set under basis 'weight' is the one shape that is refused
+ * instead of absorbed — see `assertWeightBasis` for why all-absent is honest
+ * and half-absent is not. Only 'weight' is affected: a zero line total under
+ * 'value' is a legitimate free item and a zero quantity is already rejected
+ * outright.
+ *
  * @throws BadRequestError on a non-integer money amount, a quantity that is not
- *   greater than zero, a negative weight, or an unknown basis.
+ *   greater than zero, a negative weight, a weight on only some lines under
+ *   basis 'weight', or an unknown basis.
  */
 export function allocateCapitalisedCost(
   lines: AllocationLine[],
@@ -100,6 +143,7 @@ export function allocateCapitalisedCost(
     throw new BadRequestError(`Unknown allocation basis: ${String(basis)}`)
   }
   lines.forEach(assertLine)
+  if (basis === 'weight') assertWeightBasis(lines)
   const capitalisable = capitalisableAmount(header)
   if (lines.length === 0) return []
 
@@ -151,7 +195,8 @@ export function allocateCapitalisedCost(
  * rounded — and the two adders sum to the $10,000 freight bill to the cent.
  *
  * @throws BadRequestError on a non-integer money amount, a quantity that is not
- *   greater than zero, a negative weight, or an unknown basis.
+ *   greater than zero, a negative weight, a weight on only some lines under
+ *   basis 'weight', or an unknown basis.
  */
 export function allocateLandedCost(
   lines: AllocationLine[],

--- a/packages/lib/src/purchasing/index.ts
+++ b/packages/lib/src/purchasing/index.ts
@@ -31,3 +31,5 @@ export type {
   MatchResult,
   MatchTolerance,
 } from './types'
+export type { VendorPartLookupParams, VendorPartPrefill } from './vendor-part-lookup'
+export { findVendorPartForLine } from './vendor-part-lookup'

--- a/packages/lib/src/purchasing/vendor-part-lookup.ts
+++ b/packages/lib/src/purchasing/vendor-part-lookup.ts
@@ -1,0 +1,186 @@
+// packages/lib/src/purchasing/vendor-part-lookup.ts
+
+/**
+ * The `(part, supplier)` read behind a purchase order line's price prefill
+ * (plans/purchasing/05-receiving-cost-and-corrections.md section 5.2).
+ *
+ * Read only. There is nothing to write here: the caller stamps
+ * `purchase_order_line_vendor_part` and `purchase_order_line_expected_unit_price`
+ * through the ordinary field-value path, which is what keeps the prefill a
+ * PREFILL — a value a person can overwrite — rather than a derivation.
+ *
+ * No permission checks. The router asserts view access on the `vendor_part`
+ * definition and calls in (`docs/lib-module-guide.md` section 6).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
+import { and, eq, isNull } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import { err, ok, type Result } from 'neverthrow'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { AuxxError } from '../errors'
+
+const logger = createScopedLogger('purchasing:vendor-part-lookup')
+
+/**
+ * What one supplier's catalogue entry contributes to a purchase order line.
+ *
+ * 🛑 `unitPrice` is a **starting value, not an authority.** It is copied onto
+ * `purchase_order_line_expected_unit_price` once, at pick time, and then frozen:
+ * `vendor_part_unit_price` is `updatable: true` and `bom-cost-triggers.ts`
+ * recalculates part costs whenever it moves, so a line that re-read its price
+ * through this link would stop showing the price that was agreed. The agreed
+ * price is the frozen copy on the line; this is only where the first draft of it
+ * came from. See section 5.2 of the plan.
+ */
+export interface VendorPartPrefill {
+  /**
+   * The matched `vendor_part` row, as a `RecordId`.
+   *
+   * Returned already prefixed because this module has just resolved the
+   * `vendor_part` definition id to run the query — making the caller resolve it
+   * a second time to build the same string is a round trip for nothing.
+   */
+  vendorPartRecordId: RecordId
+  /**
+   * `vendor_part_unit_price` in integer minor units, or `null` when the supplier
+   * has a catalogue entry for this part but no price on it.
+   *
+   * The two are genuinely different answers and the caller must not collapse
+   * them: a `null` here still means "this IS the supplier row for this line", so
+   * the provenance link is still worth stamping — there is simply no number to
+   * prefill with.
+   */
+  unitPrice: number | null
+}
+
+/** Where the lookup reads from — one part, one supplier, both as instance ids. */
+export interface VendorPartLookupParams {
+  /** `EntityInstance.id` of the `part` just picked on the line. */
+  partInstanceId: string
+  /** `EntityInstance.id` of the purchase order's own vendor (`purchase_order_vendor`). */
+  vendorInstanceId: string
+}
+
+/**
+ * The one `vendor_part` row for a `(part, supplier)` pair, or `null`.
+ *
+ * ✅ **Unambiguous by schema.** `vendor_part` carries an enforced natural key
+ * `(part, supplier)` — `naturalKeyPosition: 1` on `vendor_part_part`,
+ * `2` on `vendor_part_contact` — so this resolves to at most one live row. That
+ * is why there is no `onAmbiguous` parameter here and no `ilike` anywhere in the
+ * query: the pair IS the identity, and matching it is an equality on two
+ * relationship values.
+ *
+ * ⚠️ **Never falls back to the preferred vendor.** `bom/cost-calculator.ts:141`
+ * uses `vendor_part_is_preferred` that way, but it is answering a different
+ * question — *replacement cost for this part, from whoever we would buy it from*.
+ * Here the supplier is already decided by the order, so a preferred-vendor
+ * fallback would put a DIFFERENT supplier's price on this supplier's purchase
+ * order and record a link that names a row the order has nothing to do with. No
+ * row for this pair means no prefill; the price is typed by hand.
+ *
+ * `null` is returned — rather than an error — for every "there is nothing to
+ * prefill from" shape: no `vendor_part` definition in this org yet, the
+ * relationship fields not materialised, or simply no catalogue entry for the
+ * pair. A missing prefill is not a failure of the pick.
+ *
+ * The `orderBy` exists only to make an unexpected duplicate deterministic. Under
+ * the natural key there is at most one row, so it never changes which row is
+ * returned; without it a violated key would return a different price per call.
+ */
+export async function findVendorPartForLine(
+  db: Database,
+  organizationId: string,
+  params: VendorPartLookupParams
+): Promise<Result<VendorPartPrefill | null, Error>> {
+  const { partInstanceId, vendorInstanceId } = params
+  try {
+    const vendorPartDefId = await getCachedEntityDefId(organizationId, 'vendor_part')
+    if (!vendorPartDefId) return ok(null)
+
+    const fields = await getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttributes([
+        'vendor_part_part',
+        'vendor_part_contact',
+        'vendor_part_unit_price',
+      ] as const)
+
+    const partField = fields.vendor_part_part
+    const supplierField = fields.vendor_part_contact
+    // Both legs of the natural key are required to identify a row. Matching on
+    // one alone would return "any vendor part for this part" — which is the
+    // preferred-vendor fallback this function exists to refuse.
+    if (!partField || !supplierField) return ok(null)
+
+    const partValue = alias(schema.FieldValue, 'vendor_part_part_value')
+    const supplierValue = alias(schema.FieldValue, 'vendor_part_supplier_value')
+
+    const [row] = await db
+      .select({ id: schema.EntityInstance.id })
+      .from(schema.EntityInstance)
+      .innerJoin(
+        partValue,
+        and(
+          eq(partValue.entityId, schema.EntityInstance.id),
+          eq(partValue.organizationId, schema.EntityInstance.organizationId),
+          eq(partValue.fieldId, partField.id),
+          eq(partValue.relatedEntityId, partInstanceId)
+        )
+      )
+      .innerJoin(
+        supplierValue,
+        and(
+          eq(supplierValue.entityId, schema.EntityInstance.id),
+          eq(supplierValue.organizationId, schema.EntityInstance.organizationId),
+          eq(supplierValue.fieldId, supplierField.id),
+          eq(supplierValue.relatedEntityId, vendorInstanceId)
+        )
+      )
+      .where(
+        and(
+          eq(schema.EntityInstance.organizationId, organizationId),
+          eq(schema.EntityInstance.entityDefinitionId, vendorPartDefId),
+          isNull(schema.EntityInstance.archivedAt)
+        )
+      )
+      .orderBy(schema.EntityInstance.createdAt)
+      .limit(1)
+
+    if (!row) return ok(null)
+
+    // Read as a second statement rather than a third join: the price is optional
+    // on the row AND its field may not be materialised on a mid-migration org, so
+    // a join would have to be conditional and the projection with it.
+    const priceField = fields.vendor_part_unit_price
+    let unitPrice: number | null = null
+    if (priceField) {
+      const [priceRow] = await db
+        .select({ valueNumber: schema.FieldValue.valueNumber })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            eq(schema.FieldValue.entityId, row.id),
+            eq(schema.FieldValue.fieldId, priceField.id)
+          )
+        )
+        .limit(1)
+      unitPrice = priceRow?.valueNumber ?? null
+    }
+
+    return ok({ vendorPartRecordId: toRecordId(vendorPartDefId, row.id), unitPrice })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to look up vendor part for a purchase order line', {
+      error,
+      organizationId,
+      partInstanceId,
+      vendorInstanceId,
+    })
+    return err(new AuxxError('Internal error'))
+  }
+}

--- a/packages/lib/src/receiving/__tests__/adjust-stock.test.ts
+++ b/packages/lib/src/receiving/__tests__/adjust-stock.test.ts
@@ -1,0 +1,362 @@
+// packages/lib/src/receiving/__tests__/adjust-stock.test.ts
+// The hand-keyed count correction — the third movement writer. The org cache,
+// the CRUD handler and the part-kind read are mocked, so nothing here needs a
+// database. What is asserted is the CONTRACT of section 1.5: a positive
+// adjustment carries a cost or nothing is written, and a negative one is exactly
+// as unencumbered as it was before this writer existed.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../../errors'
+
+const h = vi.hoisted(() => ({
+  createSpy: vi.fn(async (_defId: string, _values: Record<string, unknown>) => ({
+    instance: { id: 'mv_1' },
+  })),
+  /** systemAttributes the org has materialised. */
+  materialised: new Set<string>(),
+  /** entityType -> def id; a missing key models a def the org does not have. */
+  defs: new Map<string, string>(),
+  partKind: null as string | null,
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  requireCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => {
+    const id = h.defs.get(entityType)
+    if (!id) throw new Error(`EntityDefinition not found for entityType: ${entityType}`)
+    return id
+  }),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(
+          attrs.map((a) => [a, h.materialised.has(a) ? { id: `fld_${a}` } : null])
+        ),
+    }),
+  }),
+}))
+
+vi.mock('../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    create = h.createSpy
+  },
+}))
+
+vi.mock('../receipt-queries', async () => {
+  const { ok } = await import('neverthrow')
+  return {
+    readPartKind: vi.fn(async () => ok(h.partKind)),
+  }
+})
+
+import { adjustStock } from '../adjust-stock'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const db = {} as never
+
+/** Every systemAttribute a fully migrated org has for this write path. */
+const ALL_MOVEMENT_ATTRS = [
+  'stock_movement_unit_cost',
+  'stock_movement_cost_basis',
+  'stock_movement_extended_cost',
+  'stock_movement_gl_account',
+  'stock_movement_occurred_at',
+]
+
+/** The four fields a costed movement must stamp, per section 1.5. */
+const COST_FIELDS = [
+  'stock_movement_unit_cost',
+  'stock_movement_extended_cost',
+  'stock_movement_gl_account',
+  'stock_movement_cost_basis',
+] as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.materialised = new Set(ALL_MOVEMENT_ATTRS)
+  h.defs = new Map([
+    ['part', 'def_part'],
+    ['stock_movement', 'def_mv'],
+  ])
+  h.partKind = null
+  h.createSpy.mockResolvedValue({ instance: { id: 'mv_1' } })
+})
+
+/** The value bag handed to `UnifiedCrudHandler.create` on the single write. */
+function writtenValues(): Record<string, unknown> {
+  expect(h.createSpy).toHaveBeenCalledTimes(1)
+  return h.createSpy.mock.calls[0]![1]
+}
+
+async function expectErr(promise: ReturnType<typeof adjustStock>) {
+  const result = await promise
+  expect(result.isErr()).toBe(true)
+  return result._unsafeUnwrapErr()
+}
+
+async function adjustAndRead(
+  input: Parameters<typeof adjustStock>[3]
+): Promise<Record<string, unknown>> {
+  const result = await adjustStock(db, ORG, USER, input)
+  expect(result.isOk()).toBe(true)
+  return writtenValues()
+}
+
+describe('adjustStock — step 1, the quantity guard', () => {
+  it('refuses a zero adjustment rather than writing a row that changes nothing', async () => {
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 0, unitCost: 4400 })
+    )
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])('refuses a non-finite quantity (%s)', async (quantity) => {
+    // Infinity survives Math.round into the doublePrecision column and poisons
+    // every later SUM; NaN passes `=== 0` as false.
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, { partId: 'part_1', quantity, unitCost: 4400 })
+    )
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('runs the quantity guard before anything else', async () => {
+    // No defs at all: if the quantity check ran second this would surface as a
+    // NotFound and the caller would fix the wrong problem.
+    h.defs = new Map()
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 0, unitCost: 4400 })
+    )
+    expect(error).toBeInstanceOf(BadRequestError)
+  })
+
+  it('fails with NotFound when the org has no stock_movement definition', async () => {
+    h.defs.delete('stock_movement')
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 5, unitCost: 4400 })
+    )
+    expect(error).toBeInstanceOf(NotFoundError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('adjustStock — a POSITIVE adjustment must carry a cost', () => {
+  it('stamps all four cost fields', async () => {
+    // The defect in one assertion: this is what the popover's `record.create`
+    // wrote none of.
+    const values = await adjustAndRead({ partId: 'part_1', quantity: 5, unitCost: 4400 })
+    for (const field of COST_FIELDS) expect(values).toHaveProperty(field)
+    expect(values.stock_movement_unit_cost).toBe(4400)
+    expect(values.stock_movement_extended_cost).toBe(22000)
+    expect(values.stock_movement_gl_account).toBe('1310')
+    expect(values.stock_movement_cost_basis).toBe('actual')
+  })
+
+  it('🛑 refuses an addition with no cost at all, and writes nothing', async () => {
+    const error = await expectErr(adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 5 }))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses an explicit zero cost instead of defaulting it', async () => {
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 5, unitCost: 0 })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toMatch(/zero cost/i)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses a negative cost', async () => {
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 5, unitCost: -100 })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses a sub-half-cent cost rather than storing the zero it rounds to', async () => {
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 5, unitCost: 0.4 })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toMatch(/zero cost/i)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses a non-finite cost', async () => {
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, {
+        partId: 'part_1',
+        quantity: 5,
+        unitCost: Number.POSITIVE_INFINITY,
+      })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('rounds a fractional cost once, at the point of storage', async () => {
+    const values = await adjustAndRead({ partId: 'part_1', quantity: 10, unitCost: 4442.975 })
+    expect(values.stock_movement_unit_cost).toBe(4443)
+    // Rounded AFTER multiplying, never as a sum of rounded units.
+    expect(values.stock_movement_extended_cost).toBe(44430)
+  })
+
+  it('stamps the GL account resolved from the part kind', async () => {
+    h.partKind = 'finished_good'
+    const values = await adjustAndRead({ partId: 'part_1', quantity: 1, unitCost: 4400 })
+    expect(values.stock_movement_gl_account).toBe('1330')
+  })
+
+  it('refuses to write before the cost fields are provisioned', async () => {
+    h.materialised.delete('stock_movement_unit_cost')
+    const error = await expectErr(
+      adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 5, unitCost: 4400 })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('adjustStock — a NEGATIVE adjustment carries no cost', () => {
+  it('writes the removal with none of the four cost fields', async () => {
+    // Deliberate asymmetry: a removal consumes value the ledger already carries,
+    // and valuing it needs a costing method this system does not have.
+    const values = await adjustAndRead({ partId: 'part_1', quantity: -3 })
+    expect(values.stock_movement_quantity).toBe(-3)
+    for (const field of COST_FIELDS) expect(values).not.toHaveProperty(field)
+  })
+
+  it('ignores a cost supplied on a removal rather than freezing a guess', async () => {
+    const values = await adjustAndRead({ partId: 'part_1', quantity: -3, unitCost: 4400 })
+    for (const field of COST_FIELDS) expect(values).not.toHaveProperty(field)
+  })
+
+  it('writes even when the cost fields are not provisioned at all', async () => {
+    // A removal stamps none of them, so requiring them would block a correction
+    // that needs nothing they provide.
+    h.materialised = new Set()
+    const values = await adjustAndRead({ partId: 'part_1', quantity: -3 })
+    expect(values.stock_movement_quantity).toBe(-3)
+  })
+
+  it('reads no part kind, because it stamps no GL account', async () => {
+    const { readPartKind } = await import('../receipt-queries')
+    await adjustAndRead({ partId: 'part_1', quantity: -3 })
+    expect(vi.mocked(readPartKind)).not.toHaveBeenCalled()
+  })
+
+  it('returns nulls for the cost it did not write', async () => {
+    const result = await adjustStock(db, ORG, USER, { partId: 'part_1', quantity: -3 })
+    expect(result._unsafeUnwrap()).toMatchObject({
+      movementId: 'mv_1',
+      quantity: -3,
+      unitCost: null,
+      extendedCost: null,
+      glAccount: null,
+    })
+  })
+})
+
+describe('adjustStock — the movement it writes', () => {
+  it('writes ONE movement, on the stock_movement definition', async () => {
+    await adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 5, unitCost: 4400 })
+    expect(h.createSpy).toHaveBeenCalledTimes(1)
+    expect(h.createSpy.mock.calls[0]![0]).toBe('def_mv')
+  })
+
+  it('is an `adjust` against the part', async () => {
+    const values = await adjustAndRead({ partId: 'part_1', quantity: 5, unitCost: 4400 })
+    expect(values.stock_movement_type).toBe('adjust')
+    expect(values.stock_movement_part).toBe('def_part:part_1')
+  })
+
+  it.each([5, -5])('NEVER sets adjustSubparts (quantity %s)', async (quantity) => {
+    // Load-bearing. explodeBomMovement inherits the parent's type AND sign, so
+    // "add 10" of a finished good would raise every component's stock too.
+    const values = await adjustAndRead({
+      partId: 'part_1',
+      quantity,
+      ...(quantity > 0 ? { unitCost: 4400 } : {}),
+    })
+    expect(values.stock_movement_adjust_subparts).toBe(false)
+  })
+
+  it('carries the reason and the reference through', async () => {
+    const values = await adjustAndRead({
+      partId: 'part_1',
+      quantity: -2,
+      reason: 'Damaged goods',
+      reference: 'RMA-567',
+    })
+    expect(values.stock_movement_reason).toBe('Damaged goods')
+    expect(values.stock_movement_reference).toBe('RMA-567')
+  })
+
+  it('omits the reason and the reference when they are empty', async () => {
+    const values = await adjustAndRead({ partId: 'part_1', quantity: -2 })
+    expect(values).not.toHaveProperty('stock_movement_reason')
+    expect(values).not.toHaveProperty('stock_movement_reference')
+  })
+
+  it('never links a supplier part or a purchase order line', async () => {
+    // An adjustment is a count correction, not a purchase — which is exactly why
+    // it cannot be used to fix a PO mistake.
+    const result = await adjustStock(db, ORG, USER, {
+      partId: 'part_1',
+      quantity: 5,
+      unitCost: 4400,
+    })
+    const values = writtenValues()
+    expect(values).not.toHaveProperty('stock_movement_vendor_part')
+    expect(values).not.toHaveProperty('stock_movement_purchase_order_line')
+    expect(result._unsafeUnwrap()).toMatchObject({
+      vendorPartId: null,
+      vendorUnitPrice: null,
+      purchaseOrderLineId: null,
+    })
+  })
+
+  it('stamps the supplied accounting date, not the moment it was keyed', async () => {
+    const occurredAt = new Date('2026-01-04T09:30:00.000Z')
+    const values = await adjustAndRead({ partId: 'part_1', quantity: -1, occurredAt })
+    expect(values.stock_movement_occurred_at).toBe('2026-01-04T09:30:00.000Z')
+  })
+
+  it('defaults the accounting date to now when none is given', async () => {
+    const before = Date.now()
+    const values = await adjustAndRead({ partId: 'part_1', quantity: -1 })
+    const stamped = new Date(values.stock_movement_occurred_at as string).getTime()
+    expect(stamped).toBeGreaterThanOrEqual(before)
+    expect(stamped).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('returns exactly what it stored', async () => {
+    const result = await adjustStock(db, ORG, USER, {
+      partId: 'part_1',
+      quantity: 10,
+      unitCost: 4442.975,
+    })
+    expect(result._unsafeUnwrap()).toMatchObject({
+      movementId: 'mv_1',
+      recordId: 'def_mv:mv_1',
+      partInstanceId: 'part_1',
+      quantity: 10,
+      unitCost: 4443,
+      extendedCost: 44430,
+      glAccount: '1310',
+    })
+  })
+
+  it('adds no trigger of its own — QoH is left to the existing rule', async () => {
+    await adjustStock(db, ORG, USER, { partId: 'part_1', quantity: 5, unitCost: 4400 })
+    expect(h.createSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/receiving/__tests__/receive-purchase-order.test.ts
+++ b/packages/lib/src/receiving/__tests__/receive-purchase-order.test.ts
@@ -1,8 +1,9 @@
 // packages/lib/src/receiving/__tests__/receive-purchase-order.test.ts
 // The multi-line receipt. `receiveStock` is mocked (it has its own suite and its
-// own database dependencies); the allocation is the REAL `allocateLandedCost`,
-// because the thing worth asserting here is that the allocated unit cost is what
-// actually reaches the movement.
+// own database dependencies) and the org cache and the one field-value read are
+// faked, so nothing here needs a database — what is asserted is the CONTRACT:
+// the price comes from the purchase order line and nowhere else, the whole set
+// is validated before the first movement, and nothing is allocated any more.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BadRequestError, UnprocessableEntityError } from '../../errors'
@@ -10,6 +11,23 @@ import type { MovementRecord, ReceivePurchaseOrderLineInput } from '../types'
 
 const h = vi.hoisted(() => ({
   receiveSpy: vi.fn(),
+  /** One call per `db.select(...)`, so "one query for the whole set" is assertable. */
+  selectSpy: vi.fn(),
+  /** systemAttributes the org has materialised. */
+  materialised: new Set<string>(),
+  /** `purchase_order_line` instance id -> its stored expected unit price. */
+  prices: new Map<string, number | null>(),
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(
+          attrs.map((a) => [a, h.materialised.has(a) ? { id: `fld_${a}` } : null])
+        ),
+    }),
+  }),
 }))
 
 vi.mock('../receive-stock', async () => {
@@ -38,7 +56,24 @@ import { receivePurchaseOrder } from '../receive-purchase-order'
 
 const ORG = 'org_1'
 const USER = 'user_1'
-const db = {} as never
+
+/**
+ * The one read this module makes: `select({...}).from(FieldValue).where(...)`,
+ * resolving to whatever `h.prices` holds.
+ */
+const db = {
+  select: (projection: unknown) => {
+    h.selectSpy(projection)
+    return {
+      from: () => ({
+        where: async () =>
+          [...h.prices.entries()].map(([entityId, valueNumber]) => ({ entityId, valueNumber })),
+      }),
+    }
+  },
+} as never
+
+const PRICE_ATTR = 'purchase_order_line_expected_unit_price'
 
 const line = (
   overrides: Partial<ReceivePurchaseOrderLineInput> = {}
@@ -46,12 +81,16 @@ const line = (
   partId: 'part_1',
   purchaseOrderLineId: 'pol_1',
   quantity: 1,
-  unitPrice: 1000,
   ...overrides,
 })
 
 beforeEach(() => {
   vi.clearAllMocks()
+  h.materialised = new Set([PRICE_ATTR])
+  h.prices = new Map([
+    ['pol_1', 1000],
+    ['pol_2', 500],
+  ])
 })
 
 async function expectErr(promise: ReturnType<typeof receivePurchaseOrder>) {
@@ -80,8 +119,8 @@ describe('receivePurchaseOrder — validation', () => {
   })
 
   it('refuses a line with no purchase order line', async () => {
-    // An allocated cost is only defensible if the line it was allocated across
-    // can be pointed at.
+    // Since the price moved server-side this link is not merely provenance: it
+    // is the only way this door can find out what the line cost.
     const error = await expectErr(
       receivePurchaseOrder(db, ORG, USER, { lines: [line({ purchaseOrderLineId: '' })] })
     )
@@ -91,13 +130,6 @@ describe('receivePurchaseOrder — validation', () => {
   it.each([0, -1, Number.NaN])('refuses a line quantity of %s', async (quantity) => {
     const error = await expectErr(
       receivePurchaseOrder(db, ORG, USER, { lines: [line({ quantity })] })
-    )
-    expect(error).toBeInstanceOf(BadRequestError)
-  })
-
-  it('refuses a line with a non-finite unit price', async () => {
-    const error = await expectErr(
-      receivePurchaseOrder(db, ORG, USER, { lines: [line({ unitPrice: Number.NaN })] })
     )
     expect(error).toBeInstanceOf(BadRequestError)
   })
@@ -113,6 +145,127 @@ describe('receivePurchaseOrder — validation', () => {
     expect(error).toBeInstanceOf(BadRequestError)
     expect(h.receiveSpy).not.toHaveBeenCalled()
   })
+
+  it('refuses to write before the purchase order price field is provisioned', async () => {
+    h.materialised.delete(PRICE_ATTR)
+    const error = await expectErr(receivePurchaseOrder(db, ORG, USER, { lines: [line()] }))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.receiveSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('receivePurchaseOrder — the price comes from the purchase order line', () => {
+  it('values the movement at the stored expected unit price of its line', async () => {
+    h.prices = new Map([['pol_1', 1250]])
+    await receivePurchaseOrder(db, ORG, USER, { lines: [line({ quantity: 4 })] })
+    expect(receivedInput(0).unitCost).toBe(1250)
+    expect(receivedInput(0).vendorUnitPrice).toBe(1250)
+  })
+
+  it('🛑 ignores a price asserted by the client', async () => {
+    // The defect this change exists for: receipt 3 on PO-0001 is valued at
+    // $200.00 against an agreed $12.50, because somebody typed 200 into a box.
+    h.prices = new Map([['pol_1', 1250]])
+    await receivePurchaseOrder(db, ORG, USER, {
+      // A stale client still sending the old fields. The types no longer permit
+      // it; the runtime must not honour it either.
+      lines: [{ ...line(), unitPrice: 20_000, weight: 12 } as ReceivePurchaseOrderLineInput],
+    })
+    expect(receivedInput(0).unitCost).toBe(1250)
+    expect(receivedInput(0).vendorUnitPrice).toBe(1250)
+  })
+
+  it('prices each line from its OWN purchase order line', async () => {
+    h.prices = new Map([
+      ['pol_1', 1250],
+      ['pol_2', 99],
+    ])
+    await receivePurchaseOrder(db, ORG, USER, {
+      lines: [line(), line({ partId: 'part_2', purchaseOrderLineId: 'pol_2' })],
+    })
+    expect(receivedInput(0).unitCost).toBe(1250)
+    expect(receivedInput(1).unitCost).toBe(99)
+  })
+
+  it('reads every price in ONE query, not one per line', async () => {
+    h.prices = new Map([
+      ['pol_1', 100],
+      ['pol_2', 200],
+      ['pol_3', 300],
+    ])
+    await receivePurchaseOrder(db, ORG, USER, {
+      lines: [
+        line(),
+        line({ partId: 'part_2', purchaseOrderLineId: 'pol_2' }),
+        line({ partId: 'part_3', purchaseOrderLineId: 'pol_3' }),
+      ],
+    })
+    expect(h.selectSpy).toHaveBeenCalledTimes(1)
+    expect(h.receiveSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it.each([
+    ['missing entirely', undefined],
+    ['stored as null', null],
+    ['stored as zero', 0],
+    ['stored negative', -500],
+  ])('refuses a line whose agreed price is %s, writing NO movements', async (_label, stored) => {
+    h.prices = new Map([['pol_1', 1000]])
+    if (stored !== undefined) h.prices.set('pol_2', stored as number | null)
+
+    const error = await expectErr(
+      receivePurchaseOrder(db, ORG, USER, {
+        lines: [line(), line({ partId: 'part_2', purchaseOrderLineId: 'pol_2' })],
+      })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    // The whole set is priced before the first movement, so the GOOD line is not
+    // written either — a half-received shipment is worse than a rejected one.
+    expect(h.receiveSpy).not.toHaveBeenCalled()
+  })
+
+  it('names the offending line in the refusal', async () => {
+    h.prices = new Map([['pol_1', 1000]])
+    const error = await expectErr(
+      receivePurchaseOrder(db, ORG, USER, {
+        lines: [line(), line({ partId: 'part_2', purchaseOrderLineId: 'pol_2' })],
+      })
+    )
+    expect(error.message).toContain('Line 2')
+    expect(error.message).toContain('pol_2')
+  })
+
+  it('does not fall back to the vendor part when the line has no price', async () => {
+    // vendor_part holds standing terms that may be months newer than the order.
+    // A missing agreed price is a data problem on the order, not a price to guess.
+    h.prices = new Map()
+    const error = await expectErr(
+      receivePurchaseOrder(db, ORG, USER, { lines: [line({ vendorPartId: 'vp_1' })] })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.receiveSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('receivePurchaseOrder — nothing is allocated at receipt', () => {
+  it('capitalises nothing onto the unit cost: landed == agreed', async () => {
+    // The old behaviour spread the ORDER's shipping across every receipt, so the
+    // same $40.00 of freight was capitalised once per delivery. Freight is the
+    // bill's number now (section 4.2).
+    h.prices = new Map([['pol_1', 1000]])
+    await receivePurchaseOrder(db, ORG, USER, { lines: [line({ quantity: 10 })] })
+    expect(receivedInput(0).unitCost).toBe(1000)
+  })
+
+  it('values two receipts of the same line identically', async () => {
+    // The double-count in the plan (section 1.1) is exactly this asymmetry: four
+    // receipts of one line, three of them carrying the whole freight charge.
+    h.prices = new Map([['pol_1', 1250]])
+    await receivePurchaseOrder(db, ORG, USER, { lines: [line({ quantity: 99_997 })] })
+    await receivePurchaseOrder(db, ORG, USER, { lines: [line({ quantity: 1 })] })
+    expect(receivedInput(0).unitCost).toBe(1250)
+    expect(receivedInput(1).unitCost).toBe(1250)
+  })
 })
 
 describe('receivePurchaseOrder — one movement per line', () => {
@@ -120,20 +273,13 @@ describe('receivePurchaseOrder — one movement per line', () => {
     const result = await receivePurchaseOrder(db, ORG, USER, {
       lines: [
         line({ partId: 'part_1', purchaseOrderLineId: 'pol_1' }),
-        line({ partId: 'part_2', purchaseOrderLineId: 'pol_2', unitPrice: 500, quantity: 4 }),
+        line({ partId: 'part_2', purchaseOrderLineId: 'pol_2', quantity: 4 }),
       ],
     })
     expect(result.isOk()).toBe(true)
     expect(result._unsafeUnwrap()).toHaveLength(2)
     expect(receivedInput(0).purchaseOrderLineId).toBe('pol_1')
     expect(receivedInput(1).purchaseOrderLineId).toBe('pol_2')
-  })
-
-  it('freezes the agreed buy price as the vendor unit price', async () => {
-    // The allocated cost is what the stock is VALUED at; vendorUnitPrice is what
-    // the vendor charged, and the three-way match compares the bill against it.
-    await receivePurchaseOrder(db, ORG, USER, { lines: [line({ unitPrice: 999.6 })] })
-    expect(receivedInput(0).vendorUnitPrice).toBe(1000)
   })
 
   it('stamps one shared accounting date across every line', async () => {
@@ -162,94 +308,6 @@ describe('receivePurchaseOrder — one movement per line', () => {
   })
 })
 
-describe('receivePurchaseOrder — the allocated unit cost', () => {
-  it('capitalises freight into the unit cost, not just the header', async () => {
-    await receivePurchaseOrder(db, ORG, USER, {
-      lines: [line({ quantity: 10, unitPrice: 1000 })],
-      shipping: 5000,
-    })
-    // One line absorbs all of it: (10000 + 5000) / 10.
-    expect(receivedInput(0).unitCost).toBe(1500)
-  })
-
-  it('reproduces the worked example: a $1 line absorbing value-weighted freight', async () => {
-    // Costing plan section 4.2, purchase HZRA2W: $1,000 and $1 lines, one unit
-    // each, $10,000 shipping. The $1 line lands at 1 + 10000 x (1/1001).
-    await receivePurchaseOrder(db, ORG, USER, {
-      lines: [
-        line({ partId: 'part_big', purchaseOrderLineId: 'pol_big', unitPrice: 100000 }),
-        line({ partId: 'part_small', purchaseOrderLineId: 'pol_small', unitPrice: 100 }),
-      ],
-      shipping: 1000000,
-      basis: 'value',
-    })
-    expect(receivedInput(1).unitCost).toBe(1099)
-  })
-
-  it('defaults the basis to value', async () => {
-    const lines = [
-      line({ partId: 'a', purchaseOrderLineId: 'pol_a', unitPrice: 100000 }),
-      line({ partId: 'b', purchaseOrderLineId: 'pol_b', unitPrice: 100 }),
-    ]
-    await receivePurchaseOrder(db, ORG, USER, { lines, shipping: 1000000 })
-    const defaulted = receivedInput(1).unitCost
-    h.receiveSpy.mockClear()
-    await receivePurchaseOrder(db, ORG, USER, { lines, shipping: 1000000, basis: 'value' })
-    expect(receivedInput(1).unitCost).toBe(defaulted)
-  })
-
-  it('spreads by quantity when asked, so a cheap heavy line carries its share', async () => {
-    await receivePurchaseOrder(db, ORG, USER, {
-      lines: [
-        line({ partId: 'a', purchaseOrderLineId: 'pol_a', unitPrice: 100000, quantity: 1 }),
-        line({ partId: 'b', purchaseOrderLineId: 'pol_b', unitPrice: 100, quantity: 1 }),
-      ],
-      shipping: 1000000,
-      basis: 'quantity',
-    })
-    // Equal quantities, so an equal split: 500000 each.
-    expect(receivedInput(0).unitCost).toBe(600000)
-    expect(receivedInput(1).unitCost).toBe(500100)
-  })
-
-  it('capitalises tax by default and excludes it when it is recoverable', async () => {
-    await receivePurchaseOrder(db, ORG, USER, {
-      lines: [line({ quantity: 10, unitPrice: 1000 })],
-      tax: 1000,
-    })
-    expect(receivedInput(0).unitCost).toBe(1100)
-
-    h.receiveSpy.mockClear()
-    await receivePurchaseOrder(db, ORG, USER, {
-      lines: [line({ quantity: 10, unitPrice: 1000 })],
-      tax: 1000,
-      taxRecoverable: true,
-    })
-    // Reclaimable input tax is a receivable from the tax authority, not part of
-    // what the goods cost.
-    expect(receivedInput(0).unitCost).toBe(1000)
-  })
-
-  it('subtracts a header discount from what is capitalised', async () => {
-    await receivePurchaseOrder(db, ORG, USER, {
-      lines: [line({ quantity: 10, unitPrice: 1000 })],
-      shipping: 5000,
-      discount: 2000,
-    })
-    expect(receivedInput(0).unitCost).toBe(1300)
-  })
-
-  it('rounds the line total before allocating, so a fractional price cannot reach the math', async () => {
-    // allocateLandedCost rejects non-integer money amounts outright; a receipt
-    // keyed at 999.6 must still be allocatable.
-    const result = await receivePurchaseOrder(db, ORG, USER, {
-      lines: [line({ unitPrice: 999.6, quantity: 3 })],
-      shipping: 300,
-    })
-    expect(result.isOk()).toBe(true)
-  })
-})
-
 describe('receivePurchaseOrder — failure propagation', () => {
   it('surfaces a per-line failure with its own status, not as a generic 500', async () => {
     const { receiveStock } = await import('../receive-stock')
@@ -257,9 +315,7 @@ describe('receivePurchaseOrder — failure propagation', () => {
     vi.mocked(receiveStock).mockResolvedValueOnce(
       err(new UnprocessableEntityError('Refusing to write a receipt at zero cost.'))
     )
-    const error = await expectErr(
-      receivePurchaseOrder(db, ORG, USER, { lines: [line()], shipping: 0 })
-    )
+    const error = await expectErr(receivePurchaseOrder(db, ORG, USER, { lines: [line()] }))
     expect(error).toBeInstanceOf(UnprocessableEntityError)
   })
 

--- a/packages/lib/src/receiving/__tests__/receive-stock.test.ts
+++ b/packages/lib/src/receiving/__tests__/receive-stock.test.ts
@@ -194,9 +194,9 @@ describe('receiveStock — step 2, the zero-cost guard', () => {
 })
 
 describe('receiveStock — step 2, resolving the price', () => {
-  it('lets a supplied unit cost win over the supplier row', async () => {
-    // The editable price input on the Receive form is the whole point: the
-    // vendor's actual invoice beats their standing terms.
+  it('uses a supplied unit cost as-is, applying no vendor terms on top', async () => {
+    // `unitCost` is the internal seam receivePurchaseOrder passes an
+    // already-resolved cost through. It is not a browser field.
     h.vendorTerms = { unitPrice: 4000, shippingCost: 500 }
     const result = await receiveStock(db, ORG, USER, {
       partId: 'part_1',
@@ -244,6 +244,86 @@ describe('receiveStock — step 2, resolving the price', () => {
   it('omits the vendor unit price entirely when it is not known', async () => {
     const values = await receiveAndRead({ partId: 'part_1', quantity: 1, unitCost: 4400 })
     expect(values).not.toHaveProperty('stock_movement_vendor_unit_price')
+  })
+})
+
+describe('receiveStock — door 1, the SENT price is the base', () => {
+  it('🛑 uses the sent vendorUnitPrice as the base, NOT the stored supplier price', async () => {
+    // This is the regression the whole change exists for. The packing slip says
+    // $50.00; the supplier row still says $40.00 from months ago. Valuing the
+    // receipt from the stored price freezes a cost nobody typed onto a movement
+    // whose every field is `updatable: false`, and nothing throws.
+    h.vendorTerms = { unitPrice: 4000, shippingCost: 500, tariffRate: 10, otherCost: 100 }
+    await receiveStock(db, ORG, USER, {
+      partId: 'part_1',
+      quantity: 1,
+      vendorPartId: 'vp_1',
+      vendorUnitPrice: 5000,
+    })
+    const values = writtenValues()
+    // 5000 base + 500 freight + 10% of 5000 + 100 other.
+    expect(values.stock_movement_unit_cost).toBe(6100)
+    // What the OLD behaviour produced, from the price the user replaced.
+    expect(values.stock_movement_unit_cost).not.toBe(5000)
+    expect(values.stock_movement_vendor_unit_price).toBe(5000)
+  })
+
+  it('takes the adders from the supplier row while ignoring its price', async () => {
+    // Same row, same adders, two different sent bases: the landed costs differ
+    // by exactly the difference in the base.
+    h.vendorTerms = { unitPrice: 9999, shippingCost: 500, tariffRate: 10, otherCost: 100 }
+    await receiveStock(db, ORG, USER, {
+      partId: 'part_1',
+      quantity: 1,
+      vendorPartId: 'vp_1',
+      vendorUnitPrice: 1000,
+    })
+    // 1000 + 500 + 100 + 100 — the tariff is 10% of the SENT base, not of 9999.
+    expect(writtenValues().stock_movement_unit_cost).toBe(1700)
+  })
+
+  it('lands at exactly the sent base when no supplier row is named', async () => {
+    // A part with no supplier row at all: the terms resolve empty and there is
+    // nothing to capitalise.
+    h.vendorTerms = null
+    const values = await receiveAndRead({
+      partId: 'part_1',
+      quantity: 3,
+      vendorUnitPrice: 4400,
+    })
+    expect(values.stock_movement_unit_cost).toBe(4400)
+    expect(values.stock_movement_vendor_unit_price).toBe(4400)
+    expect(values.stock_movement_extended_cost).toBe(13200)
+  })
+
+  it('still refuses a sent base of zero rather than writing a free receipt', async () => {
+    h.vendorTerms = { unitPrice: 4000, shippingCost: 0 }
+    const error = await expectErr(
+      receiveStock(db, ORG, USER, {
+        partId: 'part_1',
+        quantity: 1,
+        vendorPartId: 'vp_1',
+        vendorUnitPrice: 0,
+      })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toMatch(/zero cost/i)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not read the supplier row when both the cost and the price are given', async () => {
+    const { readVendorPartCostInputs } = await import('../receipt-queries')
+    await receiveStock(db, ORG, USER, {
+      partId: 'part_1',
+      quantity: 1,
+      vendorPartId: 'vp_1',
+      vendorUnitPrice: 4123,
+      unitCost: 4500,
+    })
+    expect(vi.mocked(readVendorPartCostInputs)).not.toHaveBeenCalled()
+    const values = writtenValues()
+    expect(values.stock_movement_unit_cost).toBe(4500)
+    expect(values.stock_movement_vendor_unit_price).toBe(4123)
   })
 })
 

--- a/packages/lib/src/receiving/__tests__/reverse-movement.test.ts
+++ b/packages/lib/src/receiving/__tests__/reverse-movement.test.ts
@@ -1,0 +1,408 @@
+// packages/lib/src/receiving/__tests__/reverse-movement.test.ts
+// The correction path. The org cache and the CRUD handler are mocked with the
+// same doubles `receive-stock.test.ts` uses, and the three reads are served by a
+// db stand-in that routes on table identity — so nothing here needs a database.
+//
+// What is asserted is the CONTRACT: the quantity is negated, the ORIGINAL's
+// frozen unit cost is carried verbatim, the purchase order line is copied (which
+// is what rolls `quantityReceived` back), and the two refusals that keep the
+// ledger honest — a movement is reversed at most once, and a reversal is never
+// itself reversed.
+//
+// ⚠️ `src/test/setup.ts` mocks `@auxx/database` wholesale, so `schema.Foo` is a
+// memoized `{}` and its COLUMNS are `undefined`. Table identity therefore works
+// (`.from(schema.FieldValue)` is comparable by reference, which is how the db
+// double routes the three reads) but no assertion can name a column.
+
+import { schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from '../../errors'
+
+/** One stored `FieldValue`, in the projection `reverse-movement.ts` selects. */
+interface ValueRow {
+  fieldId: string
+  valueText: string | null
+  valueNumber: number | null
+  optionId: string | null
+  relatedEntityId: string | null
+}
+
+const h = vi.hoisted(() => ({
+  createSpy: vi.fn(async (_defId: string, _values: Record<string, unknown>) => ({
+    instance: { id: 'mv_rev' },
+  })),
+  /** systemAttributes the org has materialised. */
+  materialised: new Set<string>(),
+  /** entityType -> def id; a missing key models a def the org does not have. */
+  defs: new Map<string, string>(),
+  /** The `EntityInstance` existence probe. Empty models "no such movement". */
+  instanceRows: [] as { id: string }[],
+  /** The original movement's stored field values. */
+  valueRows: [] as ValueRow[],
+  /** The "is it already reversed?" probe. Non-empty models a standing reversal. */
+  reversalRows: [] as { id: string }[],
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  requireCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => {
+    const id = h.defs.get(entityType)
+    if (!id) throw new Error(`EntityDefinition not found for entityType: ${entityType}`)
+    return id
+  }),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(
+          attrs.map((a) => [a, h.materialised.has(a) ? { id: `fld_${a}` } : null])
+        ),
+    }),
+  }),
+}))
+
+vi.mock('../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    create = h.createSpy
+  },
+}))
+
+import { reverseMovement } from '../reverse-movement'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const MOVEMENT = 'mv_1'
+
+/** Every systemAttribute a fully migrated org has for this path. */
+const ALL_MOVEMENT_ATTRS = [
+  'stock_movement_part',
+  'stock_movement_type',
+  'stock_movement_quantity',
+  'stock_movement_cost_basis',
+  'stock_movement_unit_cost',
+  'stock_movement_gl_account',
+  'stock_movement_vendor_unit_price',
+  'stock_movement_vendor_part',
+  'stock_movement_purchase_order_line',
+  'stock_movement_reverses_movement',
+]
+
+/**
+ * A db stand-in for the three reads the module makes, routed by table identity:
+ * `.from(EntityInstance)` is the existence probe, `.from(FieldValue)` alone is
+ * the value read, and `.from(FieldValue).innerJoin(EntityInstance)` is the
+ * already-reversed probe.
+ */
+const db = {
+  select: () => {
+    const state = { table: null as unknown, joined: false }
+    const rows = () => {
+      if (state.table === schema.EntityInstance) return h.instanceRows
+      if (state.joined) return h.reversalRows
+      return h.valueRows
+    }
+    // `where()` returns a real Promise carrying a `limit`, rather than a hand-
+    // rolled thenable: one read is awaited straight off `where()` and two go on
+    // to `.limit(1)`, and an object with its own `then` is both a lint error and
+    // a trap the moment anything else awaits the chain.
+    const chain: Record<string, unknown> = {
+      from: (table: unknown) => {
+        state.table = table
+        return chain
+      },
+      innerJoin: () => {
+        state.joined = true
+        return chain
+      },
+      where: () => Object.assign(Promise.resolve(rows()), { limit: () => Promise.resolve(rows()) }),
+    }
+    return chain
+  },
+} as never
+
+function value(attr: string, over: Partial<ValueRow>): ValueRow {
+  return {
+    fieldId: `fld_${attr}`,
+    valueText: null,
+    valueNumber: null,
+    optionId: null,
+    relatedEntityId: null,
+    ...over,
+  }
+}
+
+/**
+ * A fully costed `receive` of 10 units at 4443c against `pol_1`, as
+ * `receiveStock` would have written it. Attributes named in `omit` are dropped,
+ * which models a movement that never carried them.
+ */
+function originalReceipt(
+  over: Partial<Record<string, ValueRow>> = {},
+  omit: string[] = []
+): ValueRow[] {
+  const rows: Record<string, ValueRow> = {
+    stock_movement_part: value('stock_movement_part', { relatedEntityId: 'part_1' }),
+    stock_movement_type: value('stock_movement_type', { optionId: 'receive' }),
+    stock_movement_quantity: value('stock_movement_quantity', { valueNumber: 10 }),
+    stock_movement_cost_basis: value('stock_movement_cost_basis', { optionId: 'actual' }),
+    stock_movement_unit_cost: value('stock_movement_unit_cost', { valueNumber: 4443 }),
+    stock_movement_gl_account: value('stock_movement_gl_account', { valueText: '1310' }),
+    stock_movement_vendor_unit_price: value('stock_movement_vendor_unit_price', {
+      valueNumber: 4133,
+    }),
+    stock_movement_vendor_part: value('stock_movement_vendor_part', { relatedEntityId: 'vp_1' }),
+    stock_movement_purchase_order_line: value('stock_movement_purchase_order_line', {
+      relatedEntityId: 'pol_1',
+    }),
+    ...over,
+  }
+  for (const attr of omit) delete rows[attr]
+  return Object.values(rows)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.materialised = new Set(ALL_MOVEMENT_ATTRS)
+  h.defs = new Map([
+    ['part', 'def_part'],
+    ['stock_movement', 'def_mv'],
+    ['vendor_part', 'def_vp'],
+    ['purchase_order_line', 'def_pol'],
+  ])
+  h.instanceRows = [{ id: MOVEMENT }]
+  h.valueRows = originalReceipt()
+  h.reversalRows = []
+  h.createSpy.mockResolvedValue({ instance: { id: 'mv_rev' } })
+})
+
+/** The value bag handed to `UnifiedCrudHandler.create` on the single write. */
+function writtenValues(): Record<string, unknown> {
+  expect(h.createSpy).toHaveBeenCalledTimes(1)
+  return h.createSpy.mock.calls[0]![1]
+}
+
+async function expectErr(promise: ReturnType<typeof reverseMovement>) {
+  const result = await promise
+  expect(result.isErr()).toBe(true)
+  return result._unsafeUnwrapErr()
+}
+
+async function reverseAndRead(
+  input: Parameters<typeof reverseMovement>[3] = { movementId: MOVEMENT }
+): Promise<Record<string, unknown>> {
+  const result = await reverseMovement(db, ORG, USER, input)
+  expect(result.isOk()).toBe(true)
+  return writtenValues()
+}
+
+describe('reverseMovement — the row it writes', () => {
+  it('writes ONE movement, on the stock_movement definition', async () => {
+    await reverseAndRead()
+    expect(h.createSpy).toHaveBeenCalledTimes(1)
+    expect(h.createSpy.mock.calls[0]![0]).toBe('def_mv')
+  })
+
+  it('negates the original quantity', async () => {
+    expect((await reverseAndRead()).stock_movement_quantity).toBe(-10)
+  })
+
+  it('🛑 carries the ORIGINAL frozen unit cost, never a fresh one', async () => {
+    // The whole point. A reversal valued at today's price nets a receipt and its
+    // undo to a non-zero amount of inventory value out of nothing.
+    expect((await reverseAndRead()).stock_movement_unit_cost).toBe(4443)
+  })
+
+  it('recomputes the extended cost so it is signed like the quantity', async () => {
+    // The subledger sums to the inventory balance because of that sign, not in
+    // spite of it.
+    expect((await reverseAndRead()).stock_movement_extended_cost).toBe(-44430)
+  })
+
+  it('copies the purchase order line, which is what rolls quantityReceived back', async () => {
+    expect((await reverseAndRead()).stock_movement_purchase_order_line).toBe('def_pol:pol_1')
+  })
+
+  it('points reversesMovement at the row it undoes', async () => {
+    expect((await reverseAndRead()).stock_movement_reverses_movement).toBe('def_mv:mv_1')
+  })
+
+  it('copies the GL account, the vendor price, the vendor part and the part', async () => {
+    const values = await reverseAndRead()
+    expect(values.stock_movement_gl_account).toBe('1310')
+    expect(values.stock_movement_vendor_unit_price).toBe(4133)
+    expect(values.stock_movement_vendor_part).toBe('def_vp:vp_1')
+    expect(values.stock_movement_part).toBe('def_part:part_1')
+  })
+
+  it("carries the original's cost basis rather than re-deciding it", async () => {
+    expect((await reverseAndRead()).stock_movement_cost_basis).toBe('actual')
+  })
+
+  it('NEVER sets adjustSubparts', async () => {
+    // Load-bearing. explodeBomMovement inherits the parent's type AND sign, so a
+    // reversal with the flag set would explode the negation across the BOM.
+    expect((await reverseAndRead()).stock_movement_adjust_subparts).toBe(false)
+  })
+
+  it('stamps the reason when one is given, and omits it otherwise', async () => {
+    const withReason = await reverseAndRead({ movementId: MOVEMENT, reason: 'Keyed twice' })
+    expect(withReason.stock_movement_reason).toBe('Keyed twice')
+
+    h.createSpy.mockClear()
+    expect(await reverseAndRead()).not.toHaveProperty('stock_movement_reason')
+  })
+
+  it('stamps the accounting date as now', async () => {
+    const before = Date.now()
+    const stamped = new Date(
+      (await reverseAndRead()).stock_movement_occurred_at as string
+    ).getTime()
+    expect(stamped).toBeGreaterThanOrEqual(before)
+    expect(stamped).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('omits the relations the original did not carry', async () => {
+    h.valueRows = originalReceipt({}, [
+      'stock_movement_vendor_part',
+      'stock_movement_purchase_order_line',
+      'stock_movement_vendor_unit_price',
+    ])
+    const values = await reverseAndRead()
+    expect(values).not.toHaveProperty('stock_movement_vendor_part')
+    expect(values).not.toHaveProperty('stock_movement_purchase_order_line')
+    expect(values).not.toHaveProperty('stock_movement_vendor_unit_price')
+  })
+
+  it('returns exactly what it stored', async () => {
+    const result = await reverseMovement(db, ORG, USER, { movementId: MOVEMENT })
+    expect(result._unsafeUnwrap()).toMatchObject({
+      movementId: 'mv_rev',
+      recordId: 'def_mv:mv_rev',
+      partInstanceId: 'part_1',
+      quantity: -10,
+      unitCost: 4443,
+      extendedCost: -44430,
+      vendorUnitPrice: 4133,
+      vendorPartId: 'vp_1',
+      glAccount: '1310',
+      purchaseOrderLineId: 'pol_1',
+    })
+  })
+})
+
+describe('reverseMovement — the type it writes', () => {
+  it('undoes a receipt as a return_out — the goods go back out the door', async () => {
+    expect((await reverseAndRead()).stock_movement_type).toBe('return_out')
+  })
+
+  it.each([
+    ['ship', 'return_in'],
+    ['sale', 'return_in'],
+    ['return_out', 'return_in'],
+    ['return_in', 'return_out'],
+  ])('mirrors a %s as a %s', async (original, expected) => {
+    h.valueRows = originalReceipt({
+      stock_movement_type: value('stock_movement_type', { optionId: original }),
+    })
+    expect((await reverseAndRead()).stock_movement_type).toBe(expected)
+  })
+
+  it.each([
+    'adjust',
+    'scrap',
+    'initial',
+    'build_consume',
+    'build_produce',
+  ])('labels the undo of a %s as an adjust rather than inventing an event', async (original) => {
+    // Undoing a build_consume is not a production run, and there is no
+    // "unscrap". `adjust` is the honest label — and unlike a hand-keyed
+    // adjustment this one carries the original's frozen cost.
+    h.valueRows = originalReceipt({
+      stock_movement_type: value('stock_movement_type', { optionId: original }),
+    })
+    expect((await reverseAndRead()).stock_movement_type).toBe('adjust')
+  })
+})
+
+describe('reverseMovement — the refusals', () => {
+  it('🛑 refuses a movement that has ALREADY been reversed', async () => {
+    // Double-reversal would decrement quantityReceived twice off one mistake,
+    // and because the roll-up re-SUMs rather than increments, the wrong number
+    // would look exactly as authoritative as the right one.
+    h.reversalRows = [{ id: 'mv_existing_reversal' }]
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: MOVEMENT }))
+    expect(error).toBeInstanceOf(ConflictError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses to reverse a reversal', async () => {
+    // The correction of an over-correction is a fresh receipt or adjustment, not
+    // a chain of undos.
+    h.valueRows = originalReceipt({
+      stock_movement_reverses_movement: value('stock_movement_reverses_movement', {
+        relatedEntityId: 'mv_original',
+      }),
+    })
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: MOVEMENT }))
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails with NotFound when the movement does not exist in this org', async () => {
+    h.instanceRows = []
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: 'mv_missing' }))
+    expect(error).toBeInstanceOf(NotFoundError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails with NotFound when the org has no stock_movement definition', async () => {
+    h.defs.delete('stock_movement')
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: MOVEMENT }))
+    expect(error).toBeInstanceOf(NotFoundError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses a movement carrying no frozen unit cost', async () => {
+    // A hand-keyed stock adjustment, or a pre-migration row. There is no cost to
+    // preserve and writing the negation at zero is worse than writing nothing.
+    h.valueRows = originalReceipt({}, ['stock_movement_unit_cost'])
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: MOVEMENT }))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses a movement carrying a cost but no GL account', async () => {
+    h.valueRows = originalReceipt({}, ['stock_movement_gl_account'])
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: MOVEMENT }))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses a movement with no quantity to reverse', async () => {
+    h.valueRows = originalReceipt({
+      stock_movement_quantity: value('stock_movement_quantity', { valueNumber: 0 }),
+    })
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: MOVEMENT }))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses before entity migration 108 has provisioned reversesMovement', async () => {
+    // Without it there is nothing to record WHAT the row undoes, and therefore
+    // no way to refuse the second reversal.
+    h.materialised.delete('stock_movement_reverses_movement')
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: MOVEMENT }))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails cleanly when the org has no purchase_order_line definition', async () => {
+    h.defs.delete('purchase_order_line')
+    const error = await expectErr(reverseMovement(db, ORG, USER, { movementId: MOVEMENT }))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+  })
+})

--- a/packages/lib/src/receiving/adjust-stock.ts
+++ b/packages/lib/src/receiving/adjust-stock.ts
@@ -1,0 +1,262 @@
+// packages/lib/src/receiving/adjust-stock.ts
+
+/**
+ * The hand-keyed count correction — the THIRD movement writer
+ * (plans/purchasing/05-receiving-cost-and-corrections.md section 1.5).
+ *
+ * Receiving was designed around two doors, both of which go through
+ * `receiveStock` and its zero-cost guard. The Adjust Stock popover was a third,
+ * and it went through the generic `record.create` instead: `type: 'adjust'`, a
+ * quantity, and nothing else. No `unit_cost`, no `extended_cost`, no
+ * `gl_account`, no `cost_basis`, and no guard — so a positive adjustment added
+ * stock valued at nothing, which understates COGS and drags the part's average
+ * cost toward zero.
+ *
+ * `receive-stock.ts` argues a zero-cost row is worse than a missing one
+ * "because it looks like data", and claims the rule "generalises to every
+ * movement writer". This file is what makes that claim true.
+ *
+ * Nothing else happens here — quantity on hand is maintained by the existing
+ * `mfg-stock-movements-created` rule (`recalculatePartQoH` in
+ * `field-hooks/post/inventory-triggers.ts`), and a second writer for it would
+ * give the same number two owners.
+ *
+ * No permission checks: `purchasing.adjustStock` asserts write access on the
+ * `stock_movement` def before calling, the same contract the sibling writers
+ * state.
+ */
+
+import type { Database } from '@auxx/database'
+import type { Result } from 'neverthrow'
+import { getCachedEntityDefId, requireCachedEntityDefId } from '../cache'
+import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../errors'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import { StockMovementCostBasis, StockMovementType } from '../resources/registry/enum-values'
+import { toRecordId } from '../resources/resource-id'
+import { computeExtendedCost, resolveGlAccountForPartKind, roundMinorUnits } from './client'
+import { assertCostFieldsMaterialized } from './cost-fields'
+import { guard } from './guard'
+import { readPartKind } from './receipt-queries'
+import type { AdjustStockInput, MovementRecord } from './types'
+
+/** What a costed adjustment stamps beyond the bare count change. */
+interface AdjustmentCost {
+  /** Whole minor units, strictly positive. */
+  unitCost: number
+  /** The inventory account CODE ('1310'), never a provider id. */
+  glAccount: string
+}
+
+/**
+ * Correct a part's on-hand count by a signed delta.
+ *
+ * The order of the steps is the contract, not an implementation detail:
+ *
+ * 1. `quantity` is a finite, non-zero number, or `BadRequestError`.
+ * 2. If it is POSITIVE, resolve and round a strictly positive `unitCost`, or
+ *    `UnprocessableEntityError`. Nothing is written when this fails.
+ * 3. Write one movement, `type: 'adjust'`, with the cost fields stamped only on
+ *    the positive branch.
+ *
+ * 🛑 **Positive adjustments must carry a cost; negative ones must not.** The
+ * asymmetry is deliberate and it is the whole design of this function:
+ *
+ * - A POSITIVE adjustment creates inventory value out of nothing. Something has
+ *   to say what the new units are worth, and the only honest source is the
+ *   person keying the count. Writing them at zero is the exact defect
+ *   `receiveStock` refuses — a row that sums into the inventory balance as
+ *   nothing and that nothing downstream can tell apart from a genuinely free
+ *   sample.
+ * - A NEGATIVE adjustment consumes value the ledger ALREADY carries. Answering
+ *   "at what cost" properly requires a costing method — FIFO, moving average,
+ *   specific identification — and this system does not have one yet: nothing
+ *   values inventory from the ledger today, and there is no layer table to draw
+ *   a consumption cost from. Inventing a method here would freeze a guess onto
+ *   a row whose every field is `updatable: false`, and a wrong cost that looks
+ *   considered is worse than a missing one that is visibly absent.
+ *
+ * ⚠️ **This is a known gap, not a finished answer.** When a costing method
+ * lands, the removal branch below is where it attaches, and the negative rows
+ * written before then will carry no cost that can be back-filled. Until then a
+ * removal is a count correction and explicitly not a valuation event.
+ */
+export async function adjustStock(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: AdjustStockInput
+): Promise<Result<MovementRecord, Error>> {
+  return guard(
+    async () => {
+      assertAdjustableQuantity(input.quantity)
+
+      const partDefId = await requireCachedEntityDefId(organizationId, 'part')
+      const movementDefId = await getCachedEntityDefId(organizationId, 'stock_movement')
+      if (!movementDefId) {
+        throw new NotFoundError('This organization has no stock_movement entity definition')
+      }
+
+      const cost =
+        input.quantity > 0 ? await resolveAdjustmentCost(db, organizationId, input) : null
+
+      return writeAdjustMovement(db, organizationId, userId, {
+        movementDefId,
+        partDefId,
+        input,
+        cost,
+        occurredAt: input.occurredAt ?? new Date(),
+      })
+    },
+    'Failed to adjust stock',
+    { organizationId, partId: input.partId, quantity: input.quantity }
+  )
+}
+
+/**
+ * Step 1: the delta must be a finite, non-zero number.
+ *
+ * `Number.isFinite` is checked as well as the sign for the same reason
+ * `assertReceivableQuantity` checks it: `NaN !== 0` is true, and an `Infinity`
+ * quantity multiplies into an `extendedCost` of `Infinity` that `Math.round`
+ * happily preserves — a value the `doublePrecision` column accepts and every
+ * later `SUM` is then poisoned by.
+ *
+ * Zero is refused rather than silently ignored. An adjustment of zero is a row
+ * in an append-only ledger that corrects nothing, and a caller that sent one is
+ * either mis-wired or asking a question ("set to the count it already has") the
+ * answer to which is "nothing to do" — which the caller, not the ledger, should
+ * record.
+ */
+function assertAdjustableQuantity(quantity: number): void {
+  if (!Number.isFinite(quantity)) {
+    throw new BadRequestError('Adjustment quantity must be a finite number')
+  }
+  if (quantity === 0) {
+    throw new BadRequestError(
+      'An adjustment of zero changes nothing. Enter the difference between the count and the system.'
+    )
+  }
+}
+
+/**
+ * Step 2: settle a strictly positive unit cost for an ADDITION, then round it.
+ *
+ * Only ever called on the positive branch — see the asymmetry note on
+ * {@link adjustStock}. The cost-field pre-flight runs here rather than at the
+ * top of the write for the same reason: a removal stamps no cost fields, so
+ * requiring them to be materialised would block a correction that does not need
+ * them.
+ *
+ * Rounding is applied BEFORE the positivity check so a sub-half-cent value is
+ * rejected here rather than stored as a zero the ledger cannot explain — the
+ * same ordering `resolveReceiptPrice` uses, and for the same reason.
+ */
+async function resolveAdjustmentCost(
+  db: Database,
+  organizationId: string,
+  input: AdjustStockInput
+): Promise<AdjustmentCost> {
+  await assertCostFieldsMaterialized(
+    organizationId,
+    'Adjusting stock is not available until the stock movement cost fields are provisioned'
+  )
+
+  const supplied = input.unitCost
+  if (supplied == null || !Number.isFinite(supplied)) {
+    throw new UnprocessableEntityError(
+      'Cannot add stock without a unit cost. Enter what the added units are worth.'
+    )
+  }
+
+  const unitCost = roundMinorUnits(supplied)
+  if (unitCost <= 0) {
+    throw new UnprocessableEntityError(
+      'Refusing to add stock at zero cost. Enter the price actually paid.'
+    )
+  }
+
+  const kind = await readPartKind(db, organizationId, input.partId)
+  if (kind.isErr()) throw kind.error
+
+  return { unitCost, glAccount: resolveGlAccountForPartKind(kind.value) }
+}
+
+interface WriteAdjustMovementArgs {
+  movementDefId: string
+  partDefId: string
+  input: AdjustStockInput
+  /** `null` on a removal — see the asymmetry note on {@link adjustStock}. */
+  cost: AdjustmentCost | null
+  occurredAt: Date
+}
+
+/**
+ * Step 3: write the one movement.
+ *
+ * Values are keyed by `systemAttribute` and go through `UnifiedCrudHandler`
+ * rather than a hand-built `EntityInstance` + `FieldValue` insert — the same
+ * mechanism `writeReceiveMovement` and `writeReversal` use, and what makes the
+ * post-commit triggers (QoH recalculation, timeline, realtime) fire at all. A
+ * direct insert writes rows the rest of the system never hears about, which is
+ * precisely how the popover this replaces got away with writing no cost.
+ *
+ * 🛑 **`adjustSubparts: false` is load-bearing, not a default.**
+ * `explodeBomMovement` inherits the parent movement's type AND its sign, so an
+ * adjustment with the flag set would cascade the correction through the bill of
+ * materials: "add 10" of a finished good would increase every component's stock
+ * as well, so the assembly and the parts it consumed both go up — the opposite
+ * of what building one does. An adjustment is a count correction and must never
+ * cascade; explosion belongs to a movement that knows its own direction
+ * (plans/products/11-costing-and-stock-improvements.md section 5.3).
+ */
+async function writeAdjustMovement(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  args: WriteAdjustMovementArgs
+): Promise<MovementRecord> {
+  const { movementDefId, partDefId, input, cost, occurredAt } = args
+  const quantity = input.quantity
+  const extendedCost = cost ? computeExtendedCost(cost.unitCost, quantity) : null
+
+  const values: Record<string, unknown> = {
+    stock_movement_part: toRecordId(partDefId, input.partId),
+    stock_movement_type: StockMovementType.ADJUST,
+    stock_movement_quantity: quantity,
+    // See the JSDoc above. Never true on an adjustment.
+    stock_movement_adjust_subparts: false,
+    stock_movement_occurred_at: occurredAt.toISOString(),
+  }
+
+  if (cost) {
+    // `actual`, not `standard`: this cost is what the person keying the count
+    // says the units are worth, not what a standard-cost roll-up expects.
+    values.stock_movement_cost_basis = StockMovementCostBasis.ACTUAL
+    values.stock_movement_unit_cost = cost.unitCost
+    values.stock_movement_extended_cost = extendedCost
+    values.stock_movement_gl_account = cost.glAccount
+  }
+
+  if (input.reason) values.stock_movement_reason = input.reason
+  if (input.reference) values.stock_movement_reference = input.reference
+
+  const crud = new UnifiedCrudHandler(organizationId, userId, db)
+  const created = await crud.create(movementDefId, values)
+
+  return {
+    movementId: created.instance.id,
+    recordId: toRecordId(movementDefId, created.instance.id),
+    partInstanceId: input.partId,
+    quantity,
+    unitCost: cost?.unitCost ?? null,
+    extendedCost,
+    // An adjustment has no supplier and no purchase order: it is a count
+    // correction, not a purchase. Nothing here is withheld — there is nothing
+    // to state.
+    vendorUnitPrice: null,
+    vendorPartId: null,
+    glAccount: cost?.glAccount ?? null,
+    occurredAt,
+    purchaseOrderLineId: null,
+  }
+}

--- a/packages/lib/src/receiving/cost-fields.ts
+++ b/packages/lib/src/receiving/cost-fields.ts
@@ -1,0 +1,42 @@
+// packages/lib/src/receiving/cost-fields.ts
+
+/**
+ * The one pre-flight every COSTED movement writer shares: are the cost fields
+ * entity migration 108 introduced actually materialised for this org?
+ *
+ * Extracted from `receive-stock.ts` when `adjust-stock.ts` needed the identical
+ * check (plans/purchasing/05-receiving-cost-and-corrections.md section 1.5).
+ * Copying it would have given the invariant two homes, and the whole point of
+ * that section is that a rule enforced on some writers and not others reads as
+ * enforced while it is not.
+ */
+
+import { getOrgCache } from '../cache'
+import { UnprocessableEntityError } from '../errors'
+
+/** The two attributes without which a cost cannot be expressed at all. */
+const REQUIRED_COST_ATTRIBUTES = ['stock_movement_unit_cost', 'stock_movement_cost_basis'] as const
+
+/**
+ * Fail early when entity migration 108 has not run for this org.
+ *
+ * Without `stock_movement_unit_cost` the write would still succeed and would
+ * produce exactly the thing the zero-cost rule forbids: a movement that claims
+ * to carry a cost and carries none. Refusing here means the org sees "this is
+ * not set up" instead of silently accumulating unpostable rows.
+ *
+ * The message is a parameter because the two callers are different doors and a
+ * person told "receiving is not available" while adjusting stock would look for
+ * the wrong thing. The default is `receiveStock`'s original wording, unchanged.
+ */
+export async function assertCostFieldsMaterialized(
+  organizationId: string,
+  message = 'Receiving is not available until the stock movement cost fields are provisioned'
+): Promise<void> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...REQUIRED_COST_ATTRIBUTES])
+  if (!fields.stock_movement_unit_cost || !fields.stock_movement_cost_basis) {
+    throw new UnprocessableEntityError(message)
+  }
+}

--- a/packages/lib/src/receiving/index.ts
+++ b/packages/lib/src/receiving/index.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/receiving/index.ts
 
+export { adjustStock } from './adjust-stock'
 export {
   computeExtendedCost,
   computeReceiptLandedBreakdown,
@@ -21,7 +22,10 @@ export {
 } from './receipt-queries'
 export { receivePurchaseOrder } from './receive-purchase-order'
 export { receiveStock } from './receive-stock'
+export type { ReverseMovementInput } from './reverse-movement'
+export { reverseMovement } from './reverse-movement'
 export type {
+  AdjustStockInput,
   ListReceiptsFilters,
   MovementRecord,
   ReceiptRow,

--- a/packages/lib/src/receiving/receive-purchase-order.ts
+++ b/packages/lib/src/receiving/receive-purchase-order.ts
@@ -1,26 +1,34 @@
 // packages/lib/src/receiving/receive-purchase-order.ts
 
 /**
- * The multi-line receipt: receive several purchase-order lines at once and
- * capitalise the header's freight, tax and discount into their unit costs
- * (plans/purchasing/01-build-plan.md sections 3.1 and 4.3).
+ * The multi-line receipt: receive several purchase-order lines at once, each
+ * valued at the price the purchase order already froze
+ * (plans/purchasing/05-receiving-cost-and-corrections.md sections 3.2 and 4.1).
  *
  * This exists as its own entry point rather than as an option on
- * {@link import('./receive-stock').receiveStock} because allocation is a
- * property of the SET of lines, not of any one of them: a line's landed cost
- * depends on what else was on the truck. Threading that through the single-line
- * signature would mean every caller passing the whole shipment to receive one
- * part of it. The single-line signature stays exactly as it is.
+ * {@link import('./receive-stock').receiveStock} because the price authority is
+ * different: this door has a `purchase_order_line` per line and reads
+ * `purchase_order_line_expected_unit_price` from it, while the single-line door
+ * receives against a bare part and has to be handed a price. The single-line
+ * signature stays exactly as it is.
+ *
+ * 🛑 **Nothing is allocated here any more.** A purchase order's shipping, tax
+ * and discount are ORDER-level amounts; a receipt is a SHIPMENT-level event.
+ * Spreading the first across the second capitalises the same freight once per
+ * delivery — on PO-0001 that put $120.00 into inventory against a $40.00 freight
+ * charge across four receipts. The double-count disappears by construction once
+ * nothing allocates at receipt. `allocateLandedCost` is kept, unchanged and
+ * untouched, for the bill side (section 4.2), where the freight is actually
+ * known.
  *
  * No permission checks. The router asserts (build plan section 3.3).
  */
 
-import type { Database } from '@auxx/database'
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
+import { getOrgCache } from '../cache'
 import { BadRequestError, UnprocessableEntityError } from '../errors'
-import { allocateLandedCost } from '../purchasing'
-import type { AllocationBasis } from '../purchasing/types'
-import { roundMinorUnits } from './client'
 import { guard } from './guard'
 import { receiveStock } from './receive-stock'
 import type {
@@ -29,23 +37,36 @@ import type {
   ReceivePurchaseOrderLineInput,
 } from './types'
 
+/** The one field this door reads to price a receipt. */
+const EXPECTED_UNIT_PRICE_ATTRIBUTE = 'purchase_order_line_expected_unit_price'
+
 /**
- * Receive a purchase order, spreading the header totals across its lines.
+ * Receive a purchase order, valuing every line at its agreed price.
  *
- * Each line becomes one `receive` movement with the ALLOCATED unit cost and its
- * `purchaseOrderLine` set — which is what lets `quantityReceived` roll up from
- * the ledger instead of being typed, and what gives the three-way match
- * something to compare the vendor's bill against.
+ * Each line becomes one `receive` movement with its `purchaseOrderLine` set —
+ * which is what lets `quantityReceived` roll up from the ledger instead of being
+ * typed, and what gives the three-way match something to compare the vendor's
+ * bill against.
  *
- * Validation runs over the whole set BEFORE the first movement is written. A
- * partial write here is worse than a rejection: half a shipment received is a
- * PO that reads `partially_received` for a reason nobody can reconstruct, and
- * there is no undo for a ledger entry — only a compensating one.
+ * 🛑 **The price is read here, not received here.** Any price on the wire is
+ * ignored; the value frozen onto the movement is
+ * `purchase_order_line_expected_unit_price`, read server-side from the line
+ * being received against. The PO's agreed price previously reached the ledger by
+ * round-tripping through an editable text box, so a browser could value stock at
+ * any number it asserted — receipt 3 on PO-0001 is stored at $200.00 against an
+ * agreed $12.50, and the three-way match cannot see it because the match reads
+ * the bill against the PO line and never reads the movement's price at all.
  *
- * ⚠️ The allocation itself is deliberately NOT implemented here. It lives in
- * `packages/lib/src/purchasing/` as a pure function so it can be tested to
- * exhaustion and so the PO form can preview a landed cost before anything is
- * committed. See that module for the residual-cent reconciliation rule.
+ * The `vendor_part` row is deliberately NOT a fallback. It holds standing terms
+ * that may be months newer than the order; the whole reason
+ * `expected_unit_price` exists is that the agreed price is frozen at order time.
+ * A line without one is a data problem to fix on the order, not a price to guess.
+ *
+ * Validation runs over the whole set BEFORE the first movement is written — the
+ * price read included. A partial write here is worse than a rejection: half a
+ * shipment received is a PO that reads `partially_received` for a reason nobody
+ * can reconstruct, and there is no undo for a ledger entry — only a compensating
+ * one.
  */
 export async function receivePurchaseOrder(
   db: Database,
@@ -58,51 +79,38 @@ export async function receivePurchaseOrder(
       const lines = input.lines ?? []
       assertReceivableLines(lines)
 
-      const basis: AllocationBasis = input.basis ?? 'value'
-      const unitCosts = allocateLandedCost(
-        lines.map((line) => ({
-          lineTotal: roundMinorUnits(line.unitPrice * line.quantity),
-          quantity: line.quantity,
-          weight: line.weight,
-        })),
-        {
-          shipping: input.shipping ?? 0,
-          tax: input.tax ?? 0,
-          discount: input.discount ?? 0,
-          taxRecoverable: input.taxRecoverable ?? false,
-        },
-        basis
+      const stored = await readExpectedUnitPrices(db, organizationId, lines)
+      const unitCosts = lines.map((line, index) =>
+        assertAgreedUnitPrice(stored.get(line.purchaseOrderLineId), line, index)
       )
-
-      if (unitCosts.length !== lines.length) {
-        throw new UnprocessableEntityError(
-          'Landed cost allocation returned a different number of lines than were received'
-        )
-      }
 
       const occurredAt = input.occurredAt ?? new Date()
       const written: MovementRecord[] = []
 
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i]!
+        const agreedUnitPrice = unitCosts[i]!
         const result = await receiveStock(db, organizationId, userId, {
           partId: line.partId,
           quantity: line.quantity,
           vendorPartId: line.vendorPartId,
-          // The agreed buy price, frozen as provenance. The allocated cost below
-          // is what the stock is VALUED at; this is what the vendor charged, and
-          // the match compares the bill against this one.
-          vendorUnitPrice: roundMinorUnits(line.unitPrice),
-          unitCost: unitCosts[i]!,
+          // The same number in both roles, and that is the point: with nothing
+          // capitalised at receipt the landed cost IS the agreed price, and
+          // `vendorUnitPrice` carries it as provenance for the three-way match.
+          // Passing `unitCost` explicitly is what stops `receiveStock` from
+          // applying the supplier row's adders on top of it — freight belongs to
+          // the bill.
+          vendorUnitPrice: agreedUnitPrice,
+          unitCost: agreedUnitPrice,
           occurredAt,
           reference: input.reference,
           reason: input.reason,
           purchaseOrderLineId: line.purchaseOrderLineId,
         })
         // `receiveStock` re-validates and applies the zero-cost guard per line,
-        // so an allocation that produced a zero or negative unit cost is refused
-        // here rather than stored. Rethrowing keeps that failure inside this
-        // function's own `guard()` and preserves the AuxxError's status.
+        // so a line priced at zero is refused here rather than stored.
+        // Rethrowing keeps that failure inside this function's own `guard()` and
+        // preserves the AuxxError's status.
         if (result.isErr()) throw result.error
         written.push(result.value)
       }
@@ -116,13 +124,12 @@ export async function receivePurchaseOrder(
 
 /**
  * Every line must name a part and a purchase-order line, and carry a positive
- * quantity and a finite price.
+ * quantity.
  *
  * The `purchaseOrderLineId` requirement is what separates this from
- * {@link import('./receive-stock').receiveStock}: an allocated cost is only
- * defensible if the line it was allocated across can be pointed at. A movement
- * carrying a share of a freight bill with no link back to the shipment is a
- * number nobody can audit three years later.
+ * {@link import('./receive-stock').receiveStock}: it is both the link the
+ * roll-up and the three-way match need, and — since section 4.1 — the only way
+ * this door can find out what the line cost.
  */
 function assertReceivableLines(lines: ReceivePurchaseOrderLineInput[]): void {
   if (lines.length === 0) {
@@ -138,8 +145,78 @@ function assertReceivableLines(lines: ReceivePurchaseOrderLineInput[]): void {
     if (!Number.isFinite(line.quantity) || line.quantity <= 0) {
       throw new BadRequestError(`Line ${index + 1} must receive a quantity greater than zero`)
     }
-    if (!Number.isFinite(line.unitPrice)) {
-      throw new BadRequestError(`Line ${index + 1} has no unit price`)
-    }
   }
+}
+
+/**
+ * The agreed unit price of every line being received, in ONE query.
+ *
+ * One statement for the whole set rather than one per line: a fifty-line
+ * container receipt would otherwise open fifty round trips before writing
+ * anything, and the read has to complete for the entire set before the first
+ * movement anyway (see the write path's validation contract).
+ *
+ * Keyed by `purchase_order_line` instance id. A line with no stored value is
+ * simply absent from the map, and {@link assertAgreedUnitPrice} turns that into
+ * the refusal — this function reports what is there, it does not judge it.
+ *
+ * The `organizationId` predicate plus a `fieldId` that only exists on
+ * `purchase_order_line` is the scope: a caller cannot read another org's prices,
+ * and an id that is not a purchase order line matches nothing.
+ */
+async function readExpectedUnitPrices(
+  db: Database,
+  organizationId: string,
+  lines: ReceivePurchaseOrderLineInput[]
+): Promise<Map<string, number | null>> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([EXPECTED_UNIT_PRICE_ATTRIBUTE])
+  const priceField = fields[EXPECTED_UNIT_PRICE_ATTRIBUTE]
+  if (!priceField) {
+    // Same shape as the receipt cost fields: "purchasing is not set up" beats
+    // silently receiving a shipment nobody can value.
+    throw new UnprocessableEntityError(
+      'Receiving is not available until the purchase order line price field is provisioned'
+    )
+  }
+
+  const lineIds = [...new Set(lines.map((line) => line.purchaseOrderLineId))]
+  const rows = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      valueNumber: schema.FieldValue.valueNumber,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.entityId, lineIds),
+        eq(schema.FieldValue.fieldId, priceField.id)
+      )
+    )
+
+  return new Map(rows.map((row) => [row.entityId, row.valueNumber]))
+}
+
+/**
+ * The stored price, or a refusal naming the line it is missing from.
+ *
+ * Zero is refused here rather than left to `receiveStock`'s zero-cost guard so
+ * the message names the purchase order line: "line 3 has no agreed price" is
+ * actionable on the order, while "refusing to write a receipt at zero cost" sends
+ * the reader to a form that no longer has a price box.
+ */
+function assertAgreedUnitPrice(
+  stored: number | null | undefined,
+  line: ReceivePurchaseOrderLineInput,
+  index: number
+): number {
+  if (stored == null || !Number.isFinite(stored) || stored <= 0) {
+    throw new UnprocessableEntityError(
+      `Line ${index + 1} (purchase order line ${line.purchaseOrderLineId}) has no agreed unit price. ` +
+        'Set the price on the purchase order line before receiving it.'
+    )
+  }
+  return stored
 }

--- a/packages/lib/src/receiving/receive-stock.ts
+++ b/packages/lib/src/receiving/receive-stock.ts
@@ -15,16 +15,18 @@
 
 import type { Database } from '@auxx/database'
 import type { Result } from 'neverthrow'
-import { getCachedEntityDefId, getOrgCache, requireCachedEntityDefId } from '../cache'
+import { getCachedEntityDefId, requireCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../errors'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { toRecordId } from '../resources/resource-id'
 import {
   computeExtendedCost,
   computeReceiptLandedCost,
+  type ReceiptCostInputs,
   resolveGlAccountForPartKind,
   roundMinorUnits,
 } from './client'
+import { assertCostFieldsMaterialized } from './cost-fields'
 import { guard } from './guard'
 import { readPartKind, readVendorPartCostInputs } from './receipt-queries'
 import type { MovementRecord, ReceiveStockInput } from './types'
@@ -37,9 +39,8 @@ import type { MovementRecord, ReceiveStockInput } from './types'
  * 1. `quantity > 0`, or `BadRequestError`. A negative receipt is a vendor return
  *    and has to carry the ORIGINAL receipt's cost, so it cannot be expressed
  *    here without silently valuing the return at today's price.
- * 2. Resolve the price. A supplied `unitCost` wins over the supplier row —
- *    the vendor's actual invoice beats their standing terms, which is why the
- *    Receive form's price input is editable at all.
+ * 2. Resolve the price. See {@link resolveReceiptPrice} — the base is the price
+ *    the caller sent, and the supplier row contributes only the landed adders.
  * 3. Round both money values ONCE, at the point of storage.
  * 4. Write one movement.
  *
@@ -107,25 +108,6 @@ function assertReceivableQuantity(quantity: number): void {
   }
 }
 
-/**
- * Fail early when entity migration 108 has not run for this org.
- *
- * Without `stock_movement_unit_cost` the write below would still succeed and
- * would produce exactly the thing step 2 forbids: a movement that looks like a
- * receipt and carries no cost. Refusing here means the org sees "receiving is not
- * set up" instead of silently accumulating unpostable rows.
- */
-async function assertCostFieldsMaterialized(organizationId: string): Promise<void> {
-  const fields = await getOrgCache()
-    .from(organizationId, 'customFields')
-    .bySystemAttributes(['stock_movement_unit_cost', 'stock_movement_cost_basis'])
-  if (!fields.stock_movement_unit_cost || !fields.stock_movement_cost_basis) {
-    throw new UnprocessableEntityError(
-      'Receiving is not available until the stock movement cost fields are provisioned'
-    )
-  }
-}
-
 interface ResolvedPrice {
   /** Whole minor units, strictly positive. */
   unitCost: number
@@ -136,16 +118,40 @@ interface ResolvedPrice {
 /**
  * Step 2 and step 3 of the contract: settle on a landed unit cost, then round it.
  *
- * The supplied `unitCost` wins outright. Only when it is absent is the
- * `vendor_part` row read and the EXISTING `computeLandedCost` run against it —
- * existing, not a local copy, because a receipt valued by a second implementation
- * of the landed formula could disagree with the part cost the same supplier row
- * produces, and reconciling two numbers that are both "the landed cost" is
- * exactly the confusion this subsystem is meant to remove.
+ * The precedence, in order:
+ *
+ * 1. **A supplied `unitCost` is used as-is.** This is the internal seam between
+ *    the two lib entry points, not a browser field:
+ *    {@link import('./receive-purchase-order').receivePurchaseOrder} reads the
+ *    purchase order line's agreed price server-side and passes the resolved cost
+ *    down. No vendor terms are applied on top of it.
+ * 2. **A supplied `vendorUnitPrice` is the BASE**, and the `vendor_part` row —
+ *    when one is named — contributes ONLY the adders (freight, tariff, other).
+ * 3. **`vendorPartId` alone** prices the whole receipt from the supplier row:
+ *    its `unitPrice` is the base and its adders sit on top.
+ * 4. Otherwise there is no price at all, and the receipt is refused.
+ *
+ * 🛑 **Why the SENT price is the base and the STORED one is not.** The Receive
+ * form shows the supplier's terms and lets the person keying the receipt replace
+ * the price with what the packing slip in front of them actually says. Reading
+ * `vendor_part.unitPrice` as the base after that would value the stock from the
+ * number the user just *replaced* — and because every field on `stock_movement`
+ * is `updatable: false`, the wrong cost is frozen forever with nothing thrown.
+ * `apps/web/src/components/manufacturing/parts/receipt-input.ts` documents that
+ * hazard, and compensated for it client-side by sending a pre-computed
+ * `unitCost`. That compensation existed because of this function; taking the
+ * sent price as the base removes the reason for it, and lets the router stop
+ * accepting a cost from the browser at all.
+ *
+ * The landed arithmetic itself is always the EXISTING `computeLandedCost`, never
+ * a local copy: a receipt valued by a second implementation of the formula could
+ * disagree with the part cost the same supplier row produces, and reconciling two
+ * numbers that are both "the landed cost" is exactly the confusion this subsystem
+ * exists to remove.
  *
  * `vendorUnitPrice` is resolved independently of `unitCost` and is allowed to
  * stay `null`: it is provenance for the three-way match, not an input to the
- * valuation, so a hand-keyed landed cost with no known invoice price is a
+ * valuation, so a resolved landed cost with no known invoice price is a
  * perfectly coherent receipt.
  */
 async function resolveReceiptPrice(
@@ -154,19 +160,34 @@ async function resolveReceiptPrice(
   input: ReceiveStockInput
 ): Promise<ResolvedPrice> {
   const supplied = input.unitCost
-  let vendorUnitPrice = input.vendorUnitPrice ?? null
+  const sentBase = input.vendorUnitPrice
+  let vendorUnitPrice = sentBase != null && Number.isFinite(sentBase) ? sentBase : null
 
   let landed: number | null = supplied != null && Number.isFinite(supplied) ? supplied : null
 
-  if (landed == null || vendorUnitPrice == null) {
-    if (input.vendorPartId) {
-      const terms = await unwrap(readVendorPartCostInputs(db, organizationId, input.vendorPartId))
-      if (!terms) {
-        throw new NotFoundError(`Vendor part ${input.vendorPartId} not found`)
-      }
-      if (vendorUnitPrice == null) vendorUnitPrice = terms.unitPrice
-      if (landed == null) landed = computeReceiptLandedCost(terms)
+  // The supplier row is read when it can still contribute something: the adders
+  // for an unresolved cost, or the raw price when none was sent. When both are
+  // already known it is not read at all.
+  let terms: ReceiptCostInputs | null = null
+  if ((landed == null || vendorUnitPrice == null) && input.vendorPartId) {
+    terms = await unwrap(readVendorPartCostInputs(db, organizationId, input.vendorPartId))
+    if (!terms) {
+      throw new NotFoundError(`Vendor part ${input.vendorPartId} not found`)
     }
+    if (vendorUnitPrice == null) vendorUnitPrice = terms.unitPrice
+  }
+
+  if (landed == null) {
+    // `vendorUnitPrice` is the base here whether it was sent or read: when it was
+    // sent, `terms.unitPrice` is deliberately discarded and only the adders are
+    // taken. With no supplier row the adders resolve empty and the landed cost is
+    // the sent base unchanged.
+    landed = computeReceiptLandedCost({
+      unitPrice: vendorUnitPrice,
+      shippingCost: terms?.shippingCost,
+      tariffRate: terms?.tariffRate,
+      otherCost: terms?.otherCost,
+    })
   }
 
   if (landed == null || !Number.isFinite(landed)) {

--- a/packages/lib/src/receiving/reverse-movement.ts
+++ b/packages/lib/src/receiving/reverse-movement.ts
@@ -1,0 +1,463 @@
+// packages/lib/src/receiving/reverse-movement.ts
+
+/**
+ * The correction path for a stock movement
+ * (plans/purchasing/05-receiving-cost-and-corrections.md section 5.1).
+ *
+ * Until this existed there was no way to undo a receipt at all: the ledger is
+ * append-only by construction, `receiveStock` refuses a non-positive quantity by
+ * design ("A negative receipt is a vendor return"), and Adjust Stock writes no
+ * `purchase_order_line` — so using it to fix a keying mistake moves the part's
+ * on-hand count and leaves `purchase_order_line_quantity_received` permanently
+ * wrong.
+ *
+ * A reversal is therefore a NEW, opposite row, never an edit — which is what
+ * `stock_movement_reverses_movement` was built for in entity migration 108 and
+ * never wired up. The roll-up needs no change: it re-SUMs every movement
+ * pointing at the line, so the negative row decrements `quantityReceived` for
+ * free, and `mfg-stock-movements-created` already fires on the create.
+ *
+ * No permission checks: the router asserts write access on the `stock_movement`
+ * def before calling, the same contract `receive-stock.ts` states.
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { BadRequestError, ConflictError, NotFoundError, UnprocessableEntityError } from '../errors'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import { StockMovementType } from '../resources/registry/enum-values'
+import { toRecordId } from '../resources/resource-id'
+import { computeExtendedCost } from './client'
+import { guard } from './guard'
+import type { MovementRecord } from './types'
+
+/** Which movement to undo, and why. */
+export interface ReverseMovementInput {
+  /** `EntityInstance.id` of the `stock_movement` being undone. */
+  movementId: string
+  /**
+   * Free text stamped onto the reversal only. The original is never touched —
+   * every field on `stock_movement` is `updatable: false`, which is the only
+   * reason a cost frozen onto a movement can be trusted years later.
+   */
+  reason?: string
+}
+
+/**
+ * Every attribute the reversal reads off the original.
+ *
+ * All of them are treated as optional below because they are only materialised
+ * once entity migration 108 has run for the org — but the four the write cannot
+ * be expressed without are asserted explicitly.
+ */
+const REVERSAL_ATTRIBUTES = [
+  'stock_movement_part',
+  'stock_movement_type',
+  'stock_movement_quantity',
+  'stock_movement_cost_basis',
+  'stock_movement_unit_cost',
+  'stock_movement_gl_account',
+  'stock_movement_vendor_unit_price',
+  'stock_movement_vendor_part',
+  'stock_movement_purchase_order_line',
+  'stock_movement_reverses_movement',
+] as const
+
+type ReversalAttribute = (typeof REVERSAL_ATTRIBUTES)[number]
+
+/** `systemAttribute` -> the materialised `CustomField`, or `null`. */
+type ReversalFields = Record<ReversalAttribute, { id: string } | null>
+
+/**
+ * What the reversal row is TYPED as, per the type of the row it undoes.
+ *
+ * The sign is what the arithmetic runs on — `recalculatePartQoH` and the
+ * purchase-order roll-up both plain-`SUM` `stock_movement_quantity` with no
+ * regard for the type — so this map is a LABEL, chosen to describe the direction
+ * the goods actually moved:
+ *
+ * - `receive` -> `return_out`: the goods go back out the door. This is the case
+ *   section 5.1 names, and the enum already had the value waiting for it.
+ * - `return_in` -> `return_out`, `return_out` -> `return_in`: the two return
+ *   directions undo each other exactly.
+ * - `ship` / `sale` -> `return_in`: goods that left come back.
+ * - everything else -> `adjust`. Deliberately NOT a per-type mirror: undoing a
+ *   `build_consume` is not a production run and calling it `build_produce` would
+ *   put a manufacturing event in the ledger that never happened, and there is no
+ *   "unscrap". `adjust` is the honest label for "the number on the shelf was
+ *   wrong", and unlike a hand-keyed adjustment this one carries the original's
+ *   frozen cost, so it is postable.
+ *
+ * An unrecognised type falls through to `adjust` for the same reason.
+ */
+const REVERSAL_TYPE_BY_ORIGINAL: Record<string, string> = {
+  [StockMovementType.RECEIVE]: StockMovementType.RETURN_OUT,
+  [StockMovementType.RETURN_IN]: StockMovementType.RETURN_OUT,
+  [StockMovementType.RETURN_OUT]: StockMovementType.RETURN_IN,
+  [StockMovementType.SHIP]: StockMovementType.RETURN_IN,
+  [StockMovementType.SALE]: StockMovementType.RETURN_IN,
+}
+
+/** The frozen facts a reversal is built from. */
+interface OriginalMovement {
+  partId: string
+  type: string
+  quantity: number
+  costBasis: string | null
+  unitCost: number
+  glAccount: string
+  vendorUnitPrice: number | null
+  vendorPartId: string | null
+  purchaseOrderLineId: string | null
+  /** Set when the original is ITSELF a reversal. */
+  reversesMovementId: string | null
+}
+
+/**
+ * Undo one stock movement by writing its negation.
+ *
+ * The order of the steps is the contract:
+ *
+ * 1. Read the original, or `NotFoundError`. Archived rows and rows belonging to
+ *    another org read as absent.
+ * 2. Refuse a movement that is ALREADY reversed, with `ConflictError`. This is
+ *    the sharpest correctness rule in the function: a second reversal would
+ *    decrement `purchase_order_line_quantity_received` twice off one mistake, and
+ *    because the roll-up re-SUMs rather than increments, the wrong number would
+ *    look exactly as authoritative as the right one.
+ * 3. Refuse to reverse a reversal, with `BadRequestError`. The correction of an
+ *    over-correction is a fresh receipt or adjustment, not a chain of undos —
+ *    a chain makes "is this movement live?" a graph walk instead of a lookup.
+ * 4. Write ONE new movement: the negated quantity, the ORIGINAL's frozen unit
+ *    cost verbatim, and the original's `purchaseOrderLine`, `glAccount`,
+ *    `vendorUnitPrice` and `vendorPart`.
+ *
+ * 🛑 **The reversal is never re-priced.** It carries the unit cost the original
+ * froze, whatever today's supplier terms say. A reversal valued at the current
+ * price nets a receipt and its undo to a non-zero amount of inventory value out
+ * of nothing, which is the exact costing bug this subsystem exists to avoid.
+ * `extendedCost` IS recomputed — from that same frozen unit cost against the
+ * negated quantity — so it stays signed like the quantity and the subledger
+ * still sums to the inventory balance.
+ *
+ * ⚠️ **Only a COSTED movement can be reversed here.** A movement with no frozen
+ * `unitCost` (a pre-migration row, or a hand-keyed stock adjustment — see
+ * section 1.5 of the plan) has no cost to preserve, and writing its negation at
+ * zero would be the thing `receive-stock.ts` refuses: a row that looks like data
+ * and values inventory at nothing. Those are corrected with a second adjustment;
+ * they carry no `purchaseOrderLine` either, so no roll-up is left wrong by that.
+ *
+ * ⚠️ Step 2 is a read-then-write check, not a database constraint — there is no
+ * unique index available on a `FieldValue` relationship — so two reversals
+ * issued concurrently for the same movement could both pass it. The window is a
+ * single request and the surface is one row action, so this is accepted rather
+ * than serialised.
+ */
+export async function reverseMovement(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: ReverseMovementInput
+): Promise<Result<MovementRecord, Error>> {
+  return guard(
+    async () => {
+      const movementDefId = await getCachedEntityDefId(organizationId, 'stock_movement')
+      if (!movementDefId) {
+        throw new NotFoundError('This organization has no stock_movement entity definition')
+      }
+
+      const fields = (await getOrgCache()
+        .from(organizationId, 'customFields')
+        .bySystemAttributes([...REVERSAL_ATTRIBUTES])) as ReversalFields
+
+      const reversesField = fields.stock_movement_reverses_movement
+      if (!reversesField || !fields.stock_movement_unit_cost || !fields.stock_movement_quantity) {
+        // Without `reversesMovement` there is no way to record WHAT this row
+        // undoes, and therefore no way to refuse the second reversal in step 2.
+        throw new UnprocessableEntityError(
+          'Reversing a movement is not available until the stock movement correction fields are provisioned'
+        )
+      }
+
+      const original = await readOriginalMovement(
+        db,
+        organizationId,
+        movementDefId,
+        fields,
+        input.movementId
+      )
+
+      if (await hasReversal(db, organizationId, reversesField.id, input.movementId)) {
+        throw new ConflictError(
+          'This movement has already been reversed. Reversing it again would decrement the received quantity twice.'
+        )
+      }
+
+      if (original.reversesMovementId) {
+        throw new BadRequestError(
+          'This movement is itself a reversal and cannot be reversed. Receive or adjust the stock again instead.'
+        )
+      }
+
+      return writeReversal(db, organizationId, userId, {
+        movementDefId,
+        originalMovementId: input.movementId,
+        original,
+        reason: input.reason,
+        occurredAt: new Date(),
+      })
+    },
+    'Failed to reverse stock movement',
+    { organizationId, movementId: input.movementId }
+  )
+}
+
+/**
+ * Step 1: the original's frozen facts, or `NotFoundError`.
+ *
+ * Two queries rather than one join: the instance probe is what distinguishes
+ * "no such movement" from "a movement with no values", and collapsing them would
+ * report a data problem as a missing row.
+ */
+async function readOriginalMovement(
+  db: Database,
+  organizationId: string,
+  movementDefId: string,
+  fields: ReversalFields,
+  movementId: string
+): Promise<OriginalMovement> {
+  const [instance] = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.id, movementId),
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, movementDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .limit(1)
+
+  if (!instance) {
+    throw new NotFoundError(`Stock movement ${movementId} not found`)
+  }
+
+  const fieldIds = REVERSAL_ATTRIBUTES.map((attr) => fields[attr]?.id).filter((id): id is string =>
+    Boolean(id)
+  )
+
+  const rows = await db
+    .select({
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+      valueNumber: schema.FieldValue.valueNumber,
+      optionId: schema.FieldValue.optionId,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, movementId),
+        inArray(schema.FieldValue.fieldId, fieldIds)
+      )
+    )
+
+  const byFieldId = new Map(rows.map((row) => [row.fieldId, row]))
+  const read = (attr: ReversalAttribute) => {
+    const id = fields[attr]?.id
+    return id ? (byFieldId.get(id) ?? null) : null
+  }
+
+  const partId = read('stock_movement_part')?.relatedEntityId ?? null
+  const type = read('stock_movement_type')?.optionId ?? null
+  const quantity = read('stock_movement_quantity')?.valueNumber ?? null
+  const unitCost = read('stock_movement_unit_cost')?.valueNumber ?? null
+  const glAccount = read('stock_movement_gl_account')?.valueText ?? null
+
+  if (!partId || !type) {
+    throw new UnprocessableEntityError(
+      `Stock movement ${movementId} has no part or no type and cannot be reversed`
+    )
+  }
+  if (quantity == null || !Number.isFinite(quantity) || quantity === 0) {
+    throw new UnprocessableEntityError(`Stock movement ${movementId} has no quantity to reverse`)
+  }
+  if (unitCost == null || !Number.isFinite(unitCost) || unitCost <= 0 || !glAccount) {
+    // See the JSDoc on `reverseMovement`: an uncosted movement has no frozen
+    // cost to carry, and the alternative — a reversal valued at zero — is worse
+    // than no row at all. `receiveStock` is the only writer of `unitCost` and it
+    // stamps `glAccount` in the same breath, so the two travel together.
+    throw new UnprocessableEntityError(
+      `Stock movement ${movementId} carries no frozen unit cost and cannot be reversed. Adjust the stock instead.`
+    )
+  }
+
+  return {
+    partId,
+    type,
+    quantity,
+    costBasis: read('stock_movement_cost_basis')?.optionId ?? null,
+    unitCost,
+    glAccount,
+    vendorUnitPrice: read('stock_movement_vendor_unit_price')?.valueNumber ?? null,
+    vendorPartId: read('stock_movement_vendor_part')?.relatedEntityId ?? null,
+    purchaseOrderLineId: read('stock_movement_purchase_order_line')?.relatedEntityId ?? null,
+    reversesMovementId: read('stock_movement_reverses_movement')?.relatedEntityId ?? null,
+  }
+}
+
+/**
+ * Step 2: does a live movement already point its `reversesMovement` at this one?
+ *
+ * Joins `EntityInstance` so an archived reversal does not block a legitimate
+ * second attempt — an archived row contributes nothing to either roll-up, so
+ * treating it as a standing reversal would leave the mistake uncorrectable.
+ */
+async function hasReversal(
+  db: Database,
+  organizationId: string,
+  reversesFieldId: string,
+  movementId: string
+): Promise<boolean> {
+  const [existing] = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.FieldValue)
+    .innerJoin(
+      schema.EntityInstance,
+      and(
+        eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+        eq(schema.EntityInstance.organizationId, schema.FieldValue.organizationId)
+      )
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, reversesFieldId),
+        eq(schema.FieldValue.relatedEntityId, movementId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .limit(1)
+
+  return Boolean(existing)
+}
+
+interface WriteReversalArgs {
+  movementDefId: string
+  originalMovementId: string
+  original: OriginalMovement
+  reason: string | undefined
+  occurredAt: Date
+}
+
+/**
+ * Step 4: write the one opposite movement.
+ *
+ * Values are keyed by `systemAttribute` and go through `UnifiedCrudHandler`, the
+ * same mechanism `writeReceiveMovement` uses and for the same reason: a direct
+ * `EntityInstance` + `FieldValue` insert writes rows the post-commit triggers
+ * (QoH recalculation, the purchase-order roll-up, timeline, realtime) never hear
+ * about — and the roll-up firing is the entire point of copying the
+ * `purchaseOrderLine` across.
+ *
+ * 🛑 **`adjustSubparts: false` is load-bearing, not a default.**
+ * `explodeBomMovement` inherits the parent movement's type AND its sign, so a
+ * reversal with the flag set would explode the negation across every descendant
+ * in the BOM — undoing one receipt of 10 motors would also move 10 of every
+ * screw inside them. Undoing a purchase moves the purchased item and nothing
+ * else, exactly as the receipt it undoes did.
+ */
+async function writeReversal(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  args: WriteReversalArgs
+): Promise<MovementRecord> {
+  const { movementDefId, originalMovementId, original, reason, occurredAt } = args
+
+  const partDefId = await requireDefId(organizationId, 'part')
+  const quantity = -original.quantity
+  const unitCost = original.unitCost
+  // Recomputed rather than negated from the stored total: `computeExtendedCost`
+  // rounds AFTER multiplying, so deriving it here keeps a reversal identical in
+  // magnitude to the receipt it undoes without depending on a stored number the
+  // original may never have carried.
+  const extendedCost = computeExtendedCost(unitCost, quantity)
+
+  const values: Record<string, unknown> = {
+    stock_movement_part: toRecordId(partDefId, original.partId),
+    stock_movement_type: reversalTypeFor(original.type),
+    stock_movement_quantity: quantity,
+    // See the JSDoc above. Never true on a reversal.
+    stock_movement_adjust_subparts: false,
+    stock_movement_unit_cost: unitCost,
+    stock_movement_extended_cost: extendedCost,
+    stock_movement_gl_account: original.glAccount,
+    stock_movement_occurred_at: occurredAt.toISOString(),
+    stock_movement_reverses_movement: toRecordId(movementDefId, originalMovementId),
+  }
+
+  // The basis follows the cost. A row carrying the original's frozen `actual`
+  // cost is still an `actual`, and re-deciding it here would let a reversal
+  // disagree with the movement it is a copy of.
+  if (original.costBasis) values.stock_movement_cost_basis = original.costBasis
+  if (original.vendorUnitPrice != null) {
+    values.stock_movement_vendor_unit_price = original.vendorUnitPrice
+  }
+  if (reason) values.stock_movement_reason = reason
+
+  if (original.vendorPartId) {
+    const vendorPartDefId = await requireDefId(organizationId, 'vendor_part')
+    values.stock_movement_vendor_part = toRecordId(vendorPartDefId, original.vendorPartId)
+  }
+
+  if (original.purchaseOrderLineId) {
+    // The copy that makes `purchase_order_line_quantity_received` roll back for
+    // free: the roll-up re-SUMs every movement pointing at the line, so the
+    // negative quantity decrements it with no change to the roll-up itself.
+    const lineDefId = await requireDefId(organizationId, 'purchase_order_line')
+    values.stock_movement_purchase_order_line = toRecordId(lineDefId, original.purchaseOrderLineId)
+  }
+
+  const crud = new UnifiedCrudHandler(organizationId, userId, db)
+  const created = await crud.create(movementDefId, values)
+
+  return {
+    movementId: created.instance.id,
+    recordId: toRecordId(movementDefId, created.instance.id),
+    partInstanceId: original.partId,
+    quantity,
+    unitCost,
+    extendedCost,
+    vendorUnitPrice: original.vendorUnitPrice,
+    vendorPartId: original.vendorPartId,
+    glAccount: original.glAccount,
+    occurredAt,
+    purchaseOrderLineId: original.purchaseOrderLineId,
+  }
+}
+
+/** See {@link REVERSAL_TYPE_BY_ORIGINAL} for why an unmapped type is an `adjust`. */
+function reversalTypeFor(originalType: string): string {
+  return REVERSAL_TYPE_BY_ORIGINAL[originalType] ?? StockMovementType.ADJUST
+}
+
+/**
+ * Resolve a def id the ORIGINAL movement already committed us to, as an
+ * `UnprocessableEntityError` rather than the bare `Error` the cache helper
+ * throws — "the movement you are undoing names a purchase order line and this
+ * org has no purchase orders" is a 422 the UI can act on, not a 500.
+ */
+async function requireDefId(organizationId: string, entityType: string): Promise<string> {
+  const defId = await getCachedEntityDefId(organizationId, entityType)
+  if (!defId) {
+    throw new UnprocessableEntityError(
+      `This organization has no ${entityType} entity definition yet`
+    )
+  }
+  return defId
+}

--- a/packages/lib/src/receiving/types.ts
+++ b/packages/lib/src/receiving/types.ts
@@ -10,8 +10,6 @@
  * reaches any field on these types.
  */
 
-import type { AllocationBasis } from '../purchasing/types'
-
 /** A single-line receipt: this many of this part arrived, at this price. */
 export interface ReceiveStockInput {
   /** `EntityInstance.id` of the `part` being received. */
@@ -29,18 +27,34 @@ export interface ReceiveStockInput {
   /** `EntityInstance.id` of the `vendor_part` row that priced this, if known. */
   vendorPartId?: string
   /**
-   * The raw supplier price per unit, minor units, before landed adders.
+   * The BASE price per unit, minor units, before landed adders.
    *
-   * Frozen onto the movement as provenance: the three-way match compares the
-   * vendor's bill against what was *invoiced*, not against the landed cost, so
-   * without this the match has nothing to compare to.
+   * Two jobs, and they are the same number: it is the base the `vendor_part`
+   * row's adders sit on top of, and it is frozen onto the movement as
+   * provenance for the three-way match, which compares the vendor's bill
+   * against what was *invoiced* rather than against the landed cost.
+   *
+   * 🛑 **Supplied here it is the base — the stored `vendor_part` price is
+   * not.** A receipt is keyed against the price on the packing slip in front of
+   * the person keying it; the supplier row holds standing terms that may be
+   * months old. Reading the stored price as the base while displaying the sent
+   * one is how a receipt ends up valued at a number nobody typed. The supplier
+   * row is still read, but only for the adders (freight, tariff, other).
    */
   vendorUnitPrice?: number
   /**
-   * The landed cost per unit, minor units. Supplied here it WINS over anything
-   * derivable from the `vendor_part` row — that is the point of the editable
-   * price input on the Receive form. The vendor's actual invoice beats the
-   * standing terms every time.
+   * The ALREADY-RESOLVED landed cost per unit, minor units.
+   *
+   * 🛑 **An internal seam, not a browser field.** The only caller that sets it
+   * is {@link ReceivePurchaseOrderInput}'s write path, which reads the purchase
+   * order line's agreed price server-side and hands it down rather than
+   * re-deriving it here. A client that could set this could value inventory at
+   * any number it asserted, which is why the router's input schema does not
+   * accept it.
+   *
+   * Supplied, it is used as-is: it has already been resolved from an authority
+   * the browser does not control. Absent, the price is resolved from
+   * {@link vendorUnitPrice} and the `vendor_part` adders.
    */
   unitCost?: number
   /**
@@ -74,22 +88,85 @@ export interface MovementRecord {
   /** `<entityDefinitionId>:<instanceId>`, ready for a drawer or a picker. */
   recordId: string
   partInstanceId: string
-  /** Positive for a receipt. */
+  /** Positive for a receipt; negative for a reversal or a removal. */
   quantity: number
-  /** Landed cost per unit, whole minor units. */
-  unitCost: number
-  /** `round(unitCost x quantity)`, signed like `quantity`. */
-  extendedCost: number
+  /**
+   * Landed cost per unit, whole minor units.
+   *
+   * `null` on exactly one shape of row: a NEGATIVE stock adjustment, which
+   * consumes value the ledger already carries rather than creating any. See
+   * {@link AdjustStockInput.unitCost} — every other writer in this module
+   * refuses to produce a row without a cost.
+   */
+  unitCost: number | null
+  /** `round(unitCost x quantity)`, signed like `quantity`; `null` with the cost. */
+  extendedCost: number | null
   /** Raw supplier price per unit, whole minor units; `null` when not known. */
   vendorUnitPrice: number | null
   vendorPartId: string | null
-  /** The inventory account CODE ('1310'), never a provider id. */
-  glAccount: string
+  /** The inventory account CODE ('1310'), never a provider id; `null` with the cost. */
+  glAccount: string | null
   occurredAt: Date
   purchaseOrderLineId: string | null
 }
 
-/** One line of a multi-line purchase-order receipt. */
+/**
+ * A hand-keyed count correction: the number on the shelf is not the number in
+ * the system, and this is the difference
+ * (plans/purchasing/05-receiving-cost-and-corrections.md section 1.5).
+ *
+ * 🛑 **This is not a receipt and it is not a reversal.** A receipt is a purchase
+ * with a supplier and a packing slip; a reversal undoes a specific movement and
+ * carries that movement's frozen cost. An adjustment has neither — it is the
+ * answer to "we counted, and there are three more than we thought".
+ */
+export interface AdjustStockInput {
+  /** `EntityInstance.id` of the `part` being adjusted. */
+  partId: string
+  /**
+   * The signed delta. Positive adds stock, negative removes it.
+   *
+   * Zero is refused rather than treated as a no-op: a movement of zero is a row
+   * in an append-only ledger that changes nothing and can never be removed.
+   */
+  quantity: number
+  /**
+   * What one added unit is worth, minor units. REQUIRED when {@link quantity}
+   * is positive, and ignored when it is negative.
+   *
+   * 🛑 **The asymmetry is the contract, not an oversight.** A positive
+   * adjustment CREATES inventory value out of nothing and something has to say
+   * what that value is; writing it at zero understates COGS and drags the
+   * part's average cost toward zero, which is the defect section 1.5 of the
+   * plan documents. A negative adjustment CONSUMES value the ledger already
+   * carries, and answering "at what cost" correctly needs a costing method
+   * (FIFO, moving average, specific identification) that this system does not
+   * have yet. Guessing one here would freeze the guess onto an `updatable:
+   * false` row forever, so a removal is written with no cost at all until that
+   * method exists.
+   */
+  unitCost?: number
+  /**
+   * The ACCOUNTING date. Defaults to now.
+   *
+   * Not `createdAt`: a stock count taken on Friday is routinely keyed on
+   * Monday, and without a separate date every period boundary falls on the
+   * wrong side.
+   */
+  occurredAt?: Date
+  /** Free text: 'Recount', 'Damaged goods'. */
+  reason?: string
+  /** An external document number, if the correction has one. */
+  reference?: string
+}
+
+/**
+ * One line of a multi-line purchase-order receipt.
+ *
+ * 🛑 **No price.** The agreed price is already on the `purchase_order_line`, and
+ * the write path reads it there. A line carries only the two facts the
+ * receiving door is entitled to state: which line arrived, and how many.
+ */
 export interface ReceivePurchaseOrderLineInput {
   /** `EntityInstance.id` of the `part` on this line. */
   partId: string
@@ -97,34 +174,22 @@ export interface ReceivePurchaseOrderLineInput {
   purchaseOrderLineId: string
   /** Units received on this line. Must be greater than zero. */
   quantity: number
-  /**
-   * The agreed buy price per unit, minor units, BEFORE any header freight/tax is
-   * spread onto it. This is what gets frozen as `vendorUnitPrice`; the allocation
-   * turns it into the landed `unitCost`.
-   */
-  unitPrice: number
   /** `EntityInstance.id` of the `vendor_part` row, if the line names one. */
   vendorPartId?: string
-  /** Shipping weight for the whole line — read only by the `weight` basis. */
-  weight?: number
 }
 
-/** The header totals a purchase-order receipt spreads across its lines. */
+/**
+ * A multi-line purchase-order receipt.
+ *
+ * 🛑 **No header freight, tax or discount.** Those are ORDER-level amounts and a
+ * receipt is a SHIPMENT-level event; spreading them at every receipt capitalises
+ * the same freight once per delivery. They stay on the purchase order, and the
+ * landed-cost allocation moves to the bill, which is the document that actually
+ * states what the freight was (plans/purchasing/05-receiving-cost-and-corrections.md
+ * sections 3.2 and 4.2).
+ */
 export interface ReceivePurchaseOrderInput {
   lines: ReceivePurchaseOrderLineInput[]
-  /** Freight charged on the purchase as a whole, minor units. */
-  shipping?: number
-  /** Tax charged on the purchase as a whole, minor units. */
-  tax?: number
-  /** Header-level discount, minor units. Subtracted from what is capitalised. */
-  discount?: number
-  /**
-   * True when the buyer reclaims input tax, in which case tax is NOT capitalised
-   * into inventory. Defaults to false, matching the header field's own default.
-   */
-  taxRecoverable?: boolean
-  /** What the header totals are spread in proportion to. Defaults to `value`. */
-  basis?: AllocationBasis
   /** The accounting date stamped on every movement in this receipt. */
   occurredAt?: Date
   /** Packing slip or vendor invoice number, stamped on every movement. */

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -55,6 +55,11 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
   company: {
     entityType: 'company',
     mainTabs: [
+      // Same supplied-parts list as the company drawer (drawer-config.ts) — a
+      // company is the supplier side of `vendor_part`, so the page must offer
+      // what the drawer already does. Gated on READ of vendor_part; most
+      // companies aren't suppliers, so Timeline stays the landing tab.
+      { value: 'parts', label: 'Parts', icon: 'package', recordResource: 'vendor_part' },
       { value: 'timeline', label: 'Timeline', icon: 'clock' },
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],

--- a/packages/lib/src/resources/registry/line-builder-contract.test.ts
+++ b/packages/lib/src/resources/registry/line-builder-contract.test.ts
@@ -67,6 +67,8 @@ const LINE_BUILDER_CONTRACT: Record<
       'purchase_order_tax_total',
       'purchase_order_subtotal',
       'purchase_order_total',
+      // Scopes the vendor-part price prefill (`LineSchema.vendorAttr`).
+      'purchase_order_vendor',
     ],
     line: [
       'purchase_order_line_purchase_order',
@@ -74,6 +76,10 @@ const LINE_BUILDER_CONTRACT: Record<
       'purchase_order_line_description',
       'purchase_order_line_quantity_ordered',
       'purchase_order_line_expected_unit_price',
+      // Provenance for the price prefill, and the weight basis's only input
+      // (plans/purchasing/05-receiving-cost-and-corrections.md 5.2, 5.3).
+      'purchase_order_line_vendor_part',
+      'purchase_order_line_weight',
       'purchase_order_line_sort_order',
     ],
   },


### PR DESCRIPTION
Implements items 1-5 of `plans/purchasing/05-receiving-cost-and-corrections.md` §8.

## The two defects, both reproducible in the dev DB

**A receipt could be written at any price a client asserted.** The PO line's agreed price was prefilled into an editable input, sent back, and taken because *"the supplied `unitCost` wins outright"*. PO-0001 carries a row valued at **$200/unit against an agreed $12.50**, and the three-way match cannot see it — `match-hook.ts:203` compares the bill against the PO line and never reads the movement's price.

**The receive dialog spread the order's shipping, tax and discount at every receipt.** An order-level amount allocated at a shipment-level event is a category error whenever there is more than one shipment: PO-0001 **capitalised $120 of freight against a $40 charge** across four receipts. Receipt 1 absorbed $0.00 only because $40 across 99,997 units rounds to zero — the rounding saved us, not the arithmetic.

## The change

`unitCost` is gone from **both** router input schemas. That single line is what makes "the browser cannot assert an inventory cost" a fact rather than a convention.

```
Door 2 (PO):     { purchaseOrderLineId }
                 -> server reads expected_unit_price, one query for the whole set
                 -> no vendor terms; freight is stated on a bill, never on a receipt

Door 1 (no-PO):  { vendorUnitPrice, vendorPartId? }
                 -> base = the SENT price, not the stored one
                 -> vendor_part read ONLY for shipping/tariff/other adders
```

Door 1's half fixes a hazard the code documented as permanent client policy. `receipt-input.ts:6` explained that the form must send a client-computed landed cost, because otherwise *"the frozen cost is wrong forever. Nothing throws."* That was a description of a **server** defect — `resolveReceiptPrice` used `terms.unitPrice` as the base instead of the price it was handed. Fixing the server removes the reason the client had to compensate.

The freight double-count dies by construction: nothing allocates at receipt. The dialog drops its price and Landed columns, shrinks 48rem -> 36rem, and now reads no PO header field at all.

## Also in here

**A reversal**, which did not exist. Migration 108 built `stock_movement_reverses_movement` and never wired it. `reverseMovement` writes the negation at the **original's frozen cost**, copies its `purchase_order_line` so `quantity_received` rolls back on its own, and refuses an uncosted movement, a double reversal, and a reversal of a reversal. UI lives on `MovementRow` — the Receiving card renders PO lines, not movements.

**The third movement writer.** Adjust Stock called `record.create` directly and bypassed the zero-cost guard entirely, so a positive adjustment added stock valued at nothing. It now goes through `adjustStock`, which requires a cost on a positive delta and prefills from `getLastReceiptCost` (zero callers until now). Negative adjustments are unchanged and the gap is documented: costing a removal needs FIFO or moving average, which does not exist yet, and guessing is worse than the gap.

**Two declared-but-unwritten fields get writers.** Picking a part on a PO line prefills the price from that vendor's catalogue entry and records which row it came from — prefill and provenance only, never re-read, because `vendor_part_unit_price` is mutable and `expected_unit_price` is the agreed number. Weight becomes editable from the row menu, revealed across **every** line at once: a weight is a basis input that only means something across the whole set, so a partial set is a broken allocation rather than partial configuration. `allocateCapitalisedCost` now refuses one.

**A prefill race** found while verifying in the browser. `onPickPart` fired two `createDraft` calls; the second cleared `initialDraftIdsRef` mid-flight (a placeholder row flickered in and out) and, carrying no `partRecordId`, failed the `draftRequiresPart` guard and accumulated onto a draft the completed create had already removed — so any lookup slower than the create **silently dropped the price**. Now sequenced after the create through a dedicated `applyPrefillPatch`.

## Verification

- 253 lib tests across `receiving`/`purchasing`, 135 web tests, full lib suite green
- typecheck ratchet: `lib` 29/29 baseline, `web` 0 errors
- Verified in the browser: picking a part on a jamali.net order fills `$5.00` from the vendor part row and rolls into the subtotal; a Google order correctly prefills nothing rather than borrowing another supplier's price

## Deliberately not here

- **§6.1 `awaiting_receipt`** — blocked on a decision, and it has a prerequisite the plan did not have: nothing on the receipt side re-triggers the match, so a bill's verdict never updates when goods arrive. That is a live bug today and the natural next PR.
- **§4.2 landed cost on the bill** — blocked on §6.2 (PPV), and the stock may already be consumed when the freight invoice lands, which is its own accounting design.
- `allocateLandedCost` keeps its tests and loses its caller; it is the function the bill side needs.
- `previewLandedCost` is now dead code. Kept deliberately rather than deleted.

Includes one unrelated commit: the company detail page gains the supplied-parts tab the drawer already had.
