### PR TITLE
feat(purchasing): a purchase order can be sent, and its status splits into three axes

### DIFF
--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-lines-tab.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-lines-tab.tsx
@@ -35,21 +35,43 @@ import type { PartPrefillLookup } from '~/components/money/ui/line-builder/line-
 import { useSystemValues } from '~/components/resources/hooks'
 import { api } from '~/trpc/react'
 
-const PO_STATUS_ATTRS = ['purchase_order_status'] as const
+const PO_STATUS_ATTRS = [
+  'purchase_order_status',
+  'purchase_order_receipt_status',
+  'purchase_order_billing_status',
+] as const
+
+type BadgeSpec = { label: string; variant: 'green' | 'amber' | 'red' }
 
 /**
- * States worth calling out in the header. `draft` is the default so it is not
- * here, and `issued` is the ordinary working state.
+ * The ACTION axis — what a person decided. `draft` is the default and `issued` is
+ * the ordinary working state, so neither earns a badge; only the two terminal
+ * decisions do.
  *
- * `partially_received` / `received` are driven by the `quantityReceived` roll-up
- * rather than set by hand, which is exactly why they are worth a badge: they are
- * the only two the person looking at the screen did not choose.
+ * 🛑 `partially_received` / `received` used to live here. They are no longer values
+ * of this field at all — receiving and billing are independent axes and moved to
+ * their own derived fields (plans/purchasing/07-purchase-order-send-and-status.md
+ * §3.3). Keying them here after the split rendered nothing and failed no test,
+ * because the map is indexed loosely.
  */
-const STATUS_BADGE: Record<string, { label: string; variant: 'green' | 'amber' | 'red' }> = {
-  partially_received: { label: 'Partially received', variant: 'amber' },
-  received: { label: 'Received', variant: 'green' },
+const STATUS_BADGE: Record<string, BadgeSpec> = {
   closed: { label: 'Closed', variant: 'green' },
   canceled: { label: 'Canceled', variant: 'red' },
+}
+
+/**
+ * The two DERIVED axes — what the roll-up observed, which nobody chose. Only the
+ * states that say something is outstanding or complete are shown; the "nothing has
+ * happened yet" values are the default and would be noise on every draft order.
+ */
+const RECEIPT_BADGE: Record<string, BadgeSpec> = {
+  partially_received: { label: 'Partially received', variant: 'amber' },
+  received: { label: 'Received', variant: 'green' },
+}
+
+const BILLING_BADGE: Record<string, BadgeSpec> = {
+  partially_billed: { label: 'Partially billed', variant: 'amber' },
+  billed: { label: 'Billed', variant: 'green' },
 }
 
 export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
@@ -58,7 +80,15 @@ export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewT
   // SINGLE_SELECT values arrive as arrays — take the first (see the
   // `use_system_values_single_select_arrays` convention).
   const status = firstValue(values.purchase_order_status)
-  const badge = status ? STATUS_BADGE[status] : undefined
+  const receiptStatus = firstValue(values.purchase_order_receipt_status)
+  const billingStatus = firstValue(values.purchase_order_billing_status)
+  // Order matters: the decision first, then what actually arrived, then what was
+  // invoiced — the same left-to-right reading as the document's own lifecycle.
+  const badges = [
+    status ? STATUS_BADGE[status] : undefined,
+    receiptStatus ? RECEIPT_BADGE[receiptStatus] : undefined,
+    billingStatus ? BILLING_BADGE[billingStatus] : undefined,
+  ].filter((b): b is BadgeSpec => !!b)
 
   // `variant='section'`: rendered inside a DetailViewSections <Section> on an
   // outer-owned scroll column instead of a `TabsContent` that grants `h-full`, so
@@ -101,12 +131,16 @@ export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewT
 
   return (
     <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
-      {badge && (
+      {badges.length > 0 && (
         <DocumentSectionActions
           badge={
-            <Badge variant={badge.variant} size='sm'>
-              {badge.label}
-            </Badge>
+            <span className='flex items-center gap-1.5'>
+              {badges.map((b) => (
+                <Badge key={b.label} variant={b.variant} size='sm'>
+                  {b.label}
+                </Badge>
+              ))}
+            </span>
           }
         />
       )}

--- a/apps/web/src/server/api/routers/purchasing.ts
+++ b/apps/web/src/server/api/routers/purchasing.ts
@@ -2,6 +2,7 @@
 
 import { getCachedEntityDefId } from '@auxx/lib/cache'
 import { NotFoundError } from '@auxx/lib/errors'
+import { markPurchaseOrderSent } from '@auxx/lib/money'
 import {
   allocateLandedCost,
   DEFAULT_MATCH_TOLERANCE,
@@ -100,6 +101,7 @@ async function requireDefId(organizationId: string, entityType: string): Promise
  *
  * | procedure                          | gate                                  |
  * | ---------------------------------- | ------------------------------------- |
+ * | `markPurchaseOrderSent`            | edit on `purchase_order`              |
  * | `receiveStock`, `receivePurchaseOrder`, `adjustStock`, `reverseMovement` | edit on `stock_movement` |
  * | `listReceipts`, `partReceiptHistory`, `lastReceiptCost` | view on `stock_movement` |
  * | `previewLandedCost`                | edit on `stock_movement`              |
@@ -116,6 +118,39 @@ async function requireDefId(organizationId: string, entityType: string): Promise
  * a `TRPCError` would flatten every 404/422 into a 500.
  */
 export const purchasingRouter = createTRPCRouter({
+  /**
+   * Send a draft purchase order to its vendor — the writer `purchase_order_status`
+   * never had.
+   *
+   * `issued` IS "sent to the vendor": one event, and the accounting word is the
+   * better one, so there is no separate `sent` value. That is also why this is a
+   * procedure rather than a dropdown write — once a Send exists, `issued` stops
+   * being a value somebody picks, and the `rejectManualLifecycleStatus` system
+   * pre-hook refuses the manual write that would otherwise claim an order went out
+   * that never did (plans/purchasing/07-purchase-order-send-and-status.md §3.4).
+   *
+   * Gated on EDIT of `purchase_order`, not of `stock_movement`: this writes the
+   * order, and nothing about a receipt.
+   *
+   * `markPurchaseOrderSent` throws its `AuxxError` directly rather than returning a
+   * `Result` — it is a `@auxx/lib/money` lifecycle mutation and follows that
+   * module's convention, not `@auxx/lib/receiving`'s. `auxxErrorMiddleware` maps it,
+   * so there is nothing to unwrap here.
+   */
+  markPurchaseOrderSent: capabilityProcedure
+    .input(z.object({ purchaseOrderId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const purchaseOrderDefId = await requireDefId(organizationId, 'purchase_order')
+      ctx.capabilities.assertEditEntity(purchaseOrderDefId)
+
+      await markPurchaseOrderSent({
+        organizationId,
+        userId,
+        purchaseOrderInstanceId: input.purchaseOrderId,
+      })
+    }),
+
   /**
    * Receive one line against a bare part: this many arrived, at this price.
    *

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -1060,12 +1060,17 @@ export const StandardTypeValues = ['task', 'deal', 'custom'] as const
  * plain text, not a pgEnum — the `EntityDefinition.entityType` precedent.
  * NULL for user-created snippets.
  */
-export const SnippetSystemTypeValues = ['quote_email', 'invoice_email'] as const
+export const SnippetSystemTypeValues = [
+  'quote_email',
+  'invoice_email',
+  'purchase_order_email',
+] as const
 export type SnippetSystemType = (typeof SnippetSystemTypeValues)[number]
 
 export const SnippetSystemType = {
   quote_email: 'quote_email',
   invoice_email: 'invoice_email',
+  purchase_order_email: 'purchase_order_email',
 } as const
 
 /**

--- a/packages/lib/src/documents/__tests__/document-type.test.ts
+++ b/packages/lib/src/documents/__tests__/document-type.test.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/documents/__tests__/document-type.test.ts
+//
+// Coherence guards for the `DocumentType` union and the descriptor array it is supposed to be
+// derived from (purchasing plan 07 §2.2), plus the uniqueness `documentTypeOf` depends on.
+
+import { describe, expect, it } from 'vitest'
+import { DOCUMENT_TYPE_DESCRIPTORS } from '../client'
+// Type-only: `ensure-pdf.ts` pulls bullmq/redis/storage at runtime, and the import is erased.
+import type { DocumentType } from '../ensure-pdf'
+
+/**
+ * Every literal the `DocumentType` union names — now DERIVED from the descriptors, so this is
+ * the whole registry rather than a hand-kept list that silently stopped covering new types.
+ *
+ * The `satisfies` still earns its place: it is what fails if the derivation ever collapses to
+ * `string`, which is the one regression that would make every assertion below vacuous.
+ */
+const UNION_MEMBERS = DOCUMENT_TYPE_DESCRIPTORS.map((d) => d.id) satisfies readonly DocumentType[]
+
+describe('DocumentType <-> DOCUMENT_TYPE_DESCRIPTORS', () => {
+  it('every DocumentType literal has a registered descriptor', () => {
+    // The direction that fails at runtime if it drifts: `ensureDocumentPdf` looks the id up in
+    // the registry and throws "Unregistered document type" when it is missing.
+    const ids = DOCUMENT_TYPE_DESCRIPTORS.map((d) => d.id)
+    for (const member of UNION_MEMBERS) {
+      expect(ids).toContain(member)
+    }
+  })
+
+  it('descriptor ids are unique', () => {
+    const ids = DOCUMENT_TYPE_DESCRIPTORS.map((d) => d.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('descriptor entityType slugs are unique', () => {
+    // `documentTypeOf` (money/send-email.ts) resolves a record by finding the first
+    // descriptor whose `entityType` matches. Two types sharing a slug would make that a
+    // registration-order coin flip, which is the class of silent misclassification the
+    // throw-instead-of-default change exists to remove.
+    const entityTypes = DOCUMENT_TYPE_DESCRIPTORS.map((d) => d.entityType)
+    expect(new Set(entityTypes).size).toBe(entityTypes.length)
+  })
+
+  it('every descriptor carries a non-empty id and entityType', () => {
+    for (const descriptor of DOCUMENT_TYPE_DESCRIPTORS) {
+      expect(descriptor.id).toBeTruthy()
+      expect(descriptor.entityType).toBeTruthy()
+    }
+  })
+})

--- a/packages/lib/src/documents/__tests__/purchase-order-payload.test.ts
+++ b/packages/lib/src/documents/__tests__/purchase-order-payload.test.ts
@@ -1,0 +1,436 @@
+// packages/lib/src/documents/__tests__/purchase-order-payload.test.ts
+//
+// The purchase order PDF payload builder (plans/purchasing/07 §1.3/§6.3). The org cache,
+// `UnifiedCrudHandler` and `@auxx/database` are all doubled, so nothing here needs a
+// database — what is pinned is the CONTRACT of a document sent to a VENDOR:
+//
+//   - a line whose optional `purchase_order_line_vendor_part` link is unset renders no SKU
+//     instead of throwing (that link only recently gained a writer, so most rows lack it);
+//   - money stays in integer minor units end to end, with freight and tax added on top of
+//     the discounted subtotal exactly as `money/totals-hooks.ts` writes them;
+//   - the vendor COMPANY is the addressee party while `purchase_order_contact` is the person
+//     — two different fields, and the contact is nullable and usually unset today, so the
+//     payload must still carry an empty-but-PRESENT `contact` (`print-records-job.ts` reads
+//     `payload.contact.name` across the whole union when sorting a batch print run).
+//
+// The registry half of §1.2 is asserted at the bottom: `purchase_order` resolves by
+// entityType and carries the `purchase_order_pdf_asset` pointer `ensure-pdf.ts` needs to
+// reuse a rendered PDF instead of minting a fresh MediaAsset on every send.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** systemAttribute -> field id; a missing key models a field the org has not materialised. */
+  fields: new Map<string, string>(),
+  /** `${recordId}::${fieldId}` -> TypedFieldValue. */
+  values: new Map<string, unknown>(),
+  /** EntityInstance ids returned by `listFiltered`, in order. */
+  lineInstanceIds: [] as string[],
+  /** EntityInstance id -> displayName, for the line-name fallback read. */
+  displayNames: new Map<string, string>(),
+  /** `createdAt` of the purchase order instance. */
+  createdAt: new Date('2026-01-02T00:00:00.000Z'),
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(attrs.map((a) => [a, h.fields.has(a) ? { id: h.fields.get(a) } : null])),
+    }),
+  }),
+}))
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  return {
+    database: new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) => {
+        if (prop === 'then') return undefined
+        if (prop === 'query') {
+          return {
+            EntityInstance: {
+              findFirst: async () => ({ createdAt: h.createdAt }),
+              findMany: async () =>
+                Array.from(h.displayNames, ([id, displayName]) => ({ id, displayName })),
+            },
+          }
+        }
+        return createChainableDatabaseMock()
+      },
+    }),
+    schema: createSchemaMock({ EntityInstance: {} }),
+  }
+})
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    fieldValueService = {
+      batchGetValues: async (params: { recordIds: string[]; fieldReferences: string[] }) => ({
+        values: params.recordIds.flatMap((recordId) =>
+          params.fieldReferences.map((fieldRef) => ({
+            recordId,
+            fieldRef,
+            // The ref is `<defId>:<fieldId>` — read the double's store by field id.
+            value: h.values.get(`${recordId}::${fieldRef.split(':').pop()}`) ?? null,
+            fieldType: 'TEXT',
+          }))
+        ),
+      }),
+    }
+
+    async getFieldValues(recordId: string, fieldIds: string[]) {
+      const map = new Map<string, unknown>()
+      for (const fieldId of fieldIds) {
+        const value = h.values.get(`${recordId}::${fieldId}`)
+        if (value !== undefined) map.set(fieldId, value)
+      }
+      return map
+    }
+
+    async listFiltered() {
+      return { ids: h.lineInstanceIds }
+    }
+  },
+}))
+
+vi.mock('../resolve-settings', () => ({
+  resolveDocumentSettings: async () => ({
+    business: { companyName: 'Klooth Lift', address: { city: 'Austin', country: 'US' } },
+    branding: { logo: null, accentColor: '', paperSize: 'letter', dateFormat: 'MMM d, yyyy' },
+    quote: {
+      defaultTerms: '',
+      validDays: 30,
+      footerText: '',
+      lineDisplay: 'full',
+      showDescriptions: true,
+    },
+    invoice: {
+      dueDays: 30,
+      paymentInstructions: '',
+      footerText: '',
+      lineDisplay: 'full',
+      showDescriptions: true,
+      showPaymentHistory: true,
+    },
+    currency: 'USD',
+  }),
+}))
+
+import type { RecordId } from '@auxx/types/resource'
+import { buildPurchaseOrderPdfPayload } from '../payload'
+import { getDocumentTypeByEntityType, listDocumentTypes } from '../registry'
+
+const ORDER_RECORD_ID = 'purchase_order:po_1' as RecordId
+const VENDOR_RECORD_ID = 'company:co_1'
+
+/** Register a materialised field and return the id the doubles key values by. */
+function field(systemAttribute: string): string {
+  const id = `fld_${systemAttribute}`
+  h.fields.set(systemAttribute, id)
+  return id
+}
+
+function setValue(recordId: string, systemAttribute: string, value: unknown): void {
+  h.values.set(`${recordId}::${field(systemAttribute)}`, value)
+}
+
+const text = (value: string) => ({ type: 'text', value })
+const number = (value: number) => ({ type: 'number', value })
+const relationship = (recordId: string) => ({ type: 'relationship', recordId })
+
+beforeEach(() => {
+  h.fields = new Map()
+  h.values = new Map()
+  h.lineInstanceIds = []
+  h.displayNames = new Map()
+
+  // Every field the builder reads is materialised, so a `null` in an assertion below means
+  // "no value stored", never "the org lacks the field".
+  for (const attr of [
+    'purchase_order_number',
+    'purchase_order_status',
+    'purchase_order_vendor',
+    'purchase_order_contact',
+    'purchase_order_ordered_at',
+    'purchase_order_expected_at',
+    'purchase_order_reference',
+    'purchase_order_terms',
+    'purchase_order_currency',
+    'purchase_order_ship_to',
+    'purchase_order_shipping_total',
+    'purchase_order_tax_total',
+    'purchase_order_discount_value',
+    'company_name',
+    'company_headquarters',
+    'company_website',
+    'full_name',
+    'primary_email',
+    'phone',
+    'city',
+    'region',
+    'country',
+    'vendor_part_vendor_sku',
+    'purchase_order_line_description',
+    'purchase_order_line_quantity_ordered',
+    'purchase_order_line_expected_unit_price',
+    'purchase_order_line_line_total',
+    'purchase_order_line_part',
+    'purchase_order_line_vendor_part',
+  ]) {
+    field(attr)
+  }
+
+  setValue(ORDER_RECORD_ID, 'purchase_order_number', text('PO-0001'))
+  setValue(ORDER_RECORD_ID, 'purchase_order_status', text('draft'))
+  setValue(ORDER_RECORD_ID, 'purchase_order_vendor', relationship(VENDOR_RECORD_ID))
+  setValue(VENDOR_RECORD_ID, 'company_name', text('Bosch Rexroth'))
+})
+
+const build = () =>
+  buildPurchaseOrderPdfPayload({
+    organizationId: 'org_1',
+    userId: 'user_1',
+    purchaseOrderRecordId: ORDER_RECORD_ID,
+  })
+
+describe('buildPurchaseOrderPdfPayload — lines', () => {
+  // The vendor-part link is optional by design (a one-off buy from a supplier with no
+  // maintained price list is a legitimate line) and only recently gained a writer, so the
+  // common case today is a line with no link at all. It must degrade to a blank SKU.
+  it('renders no vendor SKU for a line with no vendor_part link', async () => {
+    h.lineInstanceIds = ['pol_1']
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_description', text('Seal kit'))
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_quantity_ordered', number(4))
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_expected_unit_price', number(1250))
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_line_total', number(5000))
+
+    const { payload } = await build()
+
+    expect(payload.lines).toEqual([
+      {
+        lineInstanceId: 'pol_1',
+        name: 'Seal kit',
+        vendorSku: null,
+        qty: 4,
+        unitPrice: 1250,
+        lineTotal: 5000,
+      },
+    ])
+  })
+
+  it("reads the vendor SKU through the line's vendor_part link when there is one", async () => {
+    h.lineInstanceIds = ['pol_1', 'pol_2']
+    for (const [instanceId, sku] of [
+      ['pol_1', 'vp_1'],
+      ['pol_2', undefined],
+    ] as const) {
+      const recordId = `purchase_order_line:${instanceId}`
+      setValue(recordId, 'purchase_order_line_description', text(`Line ${instanceId}`))
+      setValue(recordId, 'purchase_order_line_quantity_ordered', number(1))
+      setValue(recordId, 'purchase_order_line_line_total', number(100))
+      if (sku)
+        setValue(recordId, 'purchase_order_line_vendor_part', relationship(`vendor_part:${sku}`))
+    }
+    setValue('vendor_part:vp_1', 'vendor_part_vendor_sku', text('R900-1234'))
+
+    const { payload } = await build()
+
+    expect(payload.lines.map((l) => l.vendorSku)).toEqual(['R900-1234', null])
+  })
+
+  // The supplier-facing description is the authority, but it is nullable — and a blank row
+  // on a document a warehouse picks from is worse than our own name for the thing.
+  it("falls back to the part's display name when the line carries no description", async () => {
+    h.lineInstanceIds = ['pol_1']
+    h.displayNames.set('part_1', 'Hydraulic cylinder 80/45')
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_quantity_ordered', number(2))
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_part', relationship('part:part_1'))
+
+    const { payload } = await build()
+
+    expect(payload.lines[0]?.name).toBe('Hydraulic cylinder 80/45')
+  })
+})
+
+describe('buildPurchaseOrderPdfPayload — money', () => {
+  // Integer minor units end to end, and freight/tax are STATED header amounts added on top
+  // of the discounted subtotal — the `purchase_order` spec in `money/totals-hooks.ts`. A PO
+  // has no tax RATE, so nothing is derived from a percentage.
+  it('sums minor units with the discount clamped and freight/tax added on top', async () => {
+    h.lineInstanceIds = ['pol_1', 'pol_2']
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_line_total', number(5000))
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_quantity_ordered', number(1))
+    setValue('purchase_order_line:pol_2', 'purchase_order_line_line_total', number(2500))
+    setValue('purchase_order_line:pol_2', 'purchase_order_line_quantity_ordered', number(1))
+    setValue(ORDER_RECORD_ID, 'purchase_order_discount_value', number(500))
+    setValue(ORDER_RECORD_ID, 'purchase_order_shipping_total', number(1995))
+    setValue(ORDER_RECORD_ID, 'purchase_order_tax_total', number(619))
+
+    const { payload } = await build()
+
+    expect(payload.subtotal).toBe(7500)
+    expect(payload.discountAmount).toBe(500)
+    expect(payload.shippingTotal).toBe(1995)
+    expect(payload.taxTotal).toBe(619)
+    // 7500 - 500 + 1995 + 619
+    expect(payload.total).toBe(9614)
+  })
+
+  // A `null` unit price means "not yet priced" (the MQ1 convention) and every sum excludes
+  // it — an unpriced line must not silently read as free.
+  it('excludes an unpriced line from the subtotal', async () => {
+    h.lineInstanceIds = ['pol_1', 'pol_2']
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_line_total', number(5000))
+    setValue('purchase_order_line:pol_1', 'purchase_order_line_quantity_ordered', number(1))
+    setValue('purchase_order_line:pol_2', 'purchase_order_line_quantity_ordered', number(1))
+
+    const { payload } = await build()
+
+    expect(payload.lines[1]?.unitPrice).toBeNull()
+    expect(payload.subtotal).toBe(5000)
+    expect(payload.total).toBe(5000)
+  })
+
+  it('prefers the order currency over the org default', async () => {
+    setValue(ORDER_RECORD_ID, 'purchase_order_currency', text('EUR'))
+    const { payload } = await build()
+    expect(payload.currency).toBe('EUR')
+  })
+
+  it('falls back to the org currency when the order carries none', async () => {
+    const { payload } = await build()
+    expect(payload.currency).toBe('USD')
+  })
+})
+
+describe('buildPurchaseOrderPdfPayload — header', () => {
+  it('addresses the vendor company, with its headquarters as display lines', async () => {
+    setValue('company:co_1', 'company_headquarters', {
+      type: 'json',
+      value: {
+        street1: 'An den Kelterwiesen 14',
+        city: 'Lohr am Main',
+        zipCode: '97816',
+        country: 'DE',
+      },
+    })
+    setValue('company:co_1', 'company_website', text('https://boschrexroth.com'))
+
+    const { payload } = await build()
+
+    expect(payload.vendor).toEqual({
+      name: 'Bosch Rexroth',
+      // DE orders the postcode BEFORE the city, the same split `formatAddress` makes.
+      addressLines: ['An den Kelterwiesen 14', '97816 Lohr am Main', 'Germany'],
+      website: 'https://boschrexroth.com',
+    })
+  })
+
+  it('carries the ship-to address as its own block', async () => {
+    setValue(ORDER_RECORD_ID, 'purchase_order_ship_to', {
+      type: 'json',
+      value: {
+        street1: '900 E 5th St',
+        city: 'Austin',
+        state: 'TX',
+        zipCode: '78702',
+        country: 'US',
+      },
+    })
+
+    const { payload } = await build()
+
+    expect(payload.shipToLines).toEqual(['900 E 5th St', 'Austin, TX 78702', 'United States'])
+  })
+
+  it('leaves the ship-to empty rather than inventing one', async () => {
+    const { payload } = await build()
+    expect(payload.shipToLines).toEqual([])
+  })
+
+  // Never `new Date()` — a moving `issuedAt` would change the content hash on every call and
+  // defeat the render-or-reuse cache entirely (the MQ2 lesson).
+  it("falls back to the instance's createdAt when the order has not been placed", async () => {
+    const { payload, hash } = await build()
+
+    expect(payload.issuedAt).toBe('2026-01-02T00:00:00.000Z')
+    const again = await build()
+    expect(again.hash).toBe(hash)
+  })
+
+  it('prefers purchase_order_ordered_at when it is set', async () => {
+    setValue(ORDER_RECORD_ID, 'purchase_order_ordered_at', {
+      type: 'date',
+      value: '2026-03-04T00:00:00.000Z',
+    })
+    const { payload } = await build()
+    expect(payload.issuedAt).toBe('2026-03-04T00:00:00.000Z')
+  })
+
+  // 🛑 `purchase_order_contact` is nullable and nothing prefills it yet, so this is the
+  // common shape today. `print-records-job.ts`'s `sortBy: 'contact'` reads
+  // `payload.contact.name` across the WHOLE payload union — an omitted key would break batch
+  // -print sorting for quotes and invoices too, so the object must be present and empty.
+  it('carries an empty-but-present contact when the order names nobody', async () => {
+    const { payload } = await build()
+
+    expect(payload.contact).toEqual({
+      name: '',
+      email: null,
+      phone: null,
+      city: null,
+      region: null,
+      country: null,
+    })
+  })
+
+  // The vendor is a `company` and the contact is the PERSON — one never stands in for the
+  // other, so both are resolved and both appear.
+  it('resolves the contact person alongside the vendor company', async () => {
+    setValue(ORDER_RECORD_ID, 'purchase_order_contact', relationship('contact:c_1'))
+    setValue('contact:c_1', 'full_name', text('Anke Vogel'))
+    setValue('contact:c_1', 'primary_email', text('anke@boschrexroth.com'))
+
+    const { payload } = await build()
+
+    expect(payload.vendor.name).toBe('Bosch Rexroth')
+    expect(payload.contact.name).toBe('Anke Vogel')
+    expect(payload.contact.email).toBe('anke@boschrexroth.com')
+  })
+
+  it('keeps the vendor reference separate from our own PO number', async () => {
+    setValue(ORDER_RECORD_ID, 'purchase_order_reference', text('AB-77120'))
+    const { payload } = await build()
+    expect(payload.number).toBe('PO-0001')
+    expect(payload.vendorReference).toBe('AB-77120')
+  })
+})
+
+describe('document-type registry', () => {
+  it('resolves purchase_order by entityType', () => {
+    expect(getDocumentTypeByEntityType('purchase_order')?.id).toBe('purchase_order')
+  })
+
+  // 🛑 The pointer is the whole reason `pointerAttr` is required. `ensure-pdf.ts` reads it to
+  // decide whether a cached render can be reused; a missing or misnamed field does not throw,
+  // it just never finds a pointer — so every send re-renders AND mints a fresh MediaAsset
+  // instead of versioning the existing one. That is an asset leak with no error attached,
+  // which is why the exact attribute is pinned rather than merely asserted non-empty.
+  it('points purchase_order at its own pdf-asset field', () => {
+    expect(getDocumentTypeByEntityType('purchase_order')?.pointerAttr).toBe(
+      'purchase_order_pdf_asset'
+    )
+  })
+
+  it('gives every registered type a distinct pointer field', () => {
+    const pointers = listDocumentTypes().map((d) => d.pointerAttr)
+    expect(pointers).toEqual(['quote_pdf_asset', 'invoice_pdf_asset', 'purchase_order_pdf_asset'])
+    expect(new Set(pointers).size).toBe(pointers.length)
+  })
+
+  it('still resolves the two older types by entityType', () => {
+    expect(getDocumentTypeByEntityType('quote')?.id).toBe('quote')
+    expect(getDocumentTypeByEntityType('invoice')?.id).toBe('invoice')
+  })
+})

--- a/packages/lib/src/documents/client.ts
+++ b/packages/lib/src/documents/client.ts
@@ -31,13 +31,32 @@ export type PrintOptionField =
     }
 
 /**
+ * Every registered document type's id — the single literal union `DocumentType`
+ * (`./ensure-pdf.ts`) is derived from, so that union never has to be hand-maintained.
+ *
+ * {@link DocumentTypeDescriptor.id} is typed as this union rather than `string`, which is
+ * what keeps `DOCUMENT_TYPE_DESCRIPTORS`' ids literal: a plain `id: string` widens them and
+ * any derivation off the array yields `string`. Adding a document type therefore means
+ * adding its id here, a descriptor below, and an entry in `./registry.ts`'s
+ * `RENDER_ENTRIES` — a descriptor whose id is not in this union does not compile.
+ *
+ * ⚠️ `as const satisfies readonly DocumentTypeDescriptor[]` on the array below is the more
+ * obvious way to keep the ids literal and was tried first. It forces `printOptions` (and the
+ * nested `options`/`default` arrays) readonly, and `print-document-content-page.tsx` in
+ * `apps/web` declares its prop as a mutable `PrintOptionField[]` — so it costs two TS4104s
+ * there plus one where `registry.ts` merges the descriptor in. This union is the same
+ * guarantee with no ripple.
+ */
+export type DocumentTypeId = 'quote' | 'invoice' | 'purchase_order'
+
+/**
  * Client-safe shape of a registered document type — enough for the print wizard to decide
  * whether "Document" style is available for the current entity and which extra fields to
  * render, without importing the server-only registry (`./registry.ts`).
  */
 export interface DocumentTypeDescriptor {
-  /** Matches `RegisteredDocumentType.id` ('quote' | 'invoice'). */
-  id: string
+  /** Matches `RegisteredDocumentType.id`. */
+  id: DocumentTypeId
   /** `EntityDefinition.entityType` slug this document type renders records of — NOT the
    * per-org generated `EntityDefinition.id`; callers resolve/compare via the entity's
    * `entityType` (client `Resource.entityType`, server `requireCachedEntityDefId`). */
@@ -72,4 +91,8 @@ export const DOCUMENT_TYPE_DESCRIPTORS: DocumentTypeDescriptor[] = [
       },
     ],
   },
+  // The buy-side document (plans/purchasing/07 §1.2). No `printOptions`: the invoice's
+  // `sortBy` exists for stacks of customer statements, and nothing in the batch-print flow
+  // sorts purchase orders by anything but their number yet.
+  { id: 'purchase_order', entityType: 'purchase_order', printOptions: [] },
 ]

--- a/packages/lib/src/documents/ensure-pdf.ts
+++ b/packages/lib/src/documents/ensure-pdf.ts
@@ -14,6 +14,7 @@ import { createStorageManager } from '../files/storage/storage-manager'
 import { getQueue, Queues } from '../jobs/queues'
 import { UnifiedCrudHandler } from '../resources/crud'
 import { quietSession } from '../resources/crud/write-origin'
+import type { DOCUMENT_TYPE_DESCRIPTORS } from './client'
 
 /**
  * C5 (plan 04 §3): a machine-owned pointer to the rendered asset, written once
@@ -30,10 +31,23 @@ import type { DocumentPdfPayload } from './payload'
 import { getDocumentType, type RegisteredDocumentType } from './registry'
 import { renderDocumentPdf } from './render'
 
-/** Which PDF template/pointer-field a render-or-reuse call targets (money MI1 §H.1). Kept as
- * a literal alias for the two callers/back-compat wrappers below — the actual dispatch goes
- * through the document-type registry (`./registry.ts`). */
-export type DocumentType = 'quote' | 'invoice'
+/**
+ * Which PDF template/pointer-field a render-or-reuse call targets (money MI1 §H.1). The
+ * actual dispatch goes through the document-type registry (`./registry.ts`); this union only
+ * has to name the ids that registry holds.
+ *
+ * ✅ DERIVED — adding a document type is a descriptor in `./client.ts` and nothing here.
+ *
+ * ⚠️ The derivation only works because `DocumentTypeDescriptor.id` is typed as the
+ * `DocumentTypeId` literal union. An earlier attempt used
+ * `as const satisfies readonly DocumentTypeDescriptor[]` on the array instead, which forces
+ * `printOptions` and its nested arrays `readonly` and produces five errors in `apps/web`'s
+ * print wizard. If this ever resolves to `string`, that is what regressed: every
+ * `documentType` parameter in the print pipeline silently loses its safety, and
+ * `recordDocumentSendSignal`'s `toSignalRecordKey` call stops being checked against
+ * `SignalRecordKind`.
+ */
+export type DocumentType = (typeof DOCUMENT_TYPE_DESCRIPTORS)[number]['id']
 
 /** Result of {@link ensureDocumentPdf} / {@link ensureDocumentPdfViaQueue}. */
 export interface EnsureDocumentPdfResult {

--- a/packages/lib/src/documents/index.ts
+++ b/packages/lib/src/documents/index.ts
@@ -18,12 +18,16 @@ export {
 } from './ensure-pdf'
 export {
   buildInvoicePdfPayload,
+  buildPurchaseOrderPdfPayload,
   buildQuotePdfPayload,
   type DocumentPdfPayload,
   type InvoicePdfPayload,
   type InvoicePdfPaymentRow,
   loadPdfContact,
   type PdfPhotoRef,
+  type PurchaseOrderPdfLineItem,
+  type PurchaseOrderPdfPayload,
+  type PurchaseOrderPdfVendor,
   type QuotePdfContact,
   type QuotePdfLineItem,
   type QuotePdfPayload,

--- a/packages/lib/src/documents/payload.ts
+++ b/packages/lib/src/documents/payload.ts
@@ -5,6 +5,7 @@ import type { TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
 import { toResourceFieldId } from '@auxx/types/field'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import { type AddressStructValue, formatAddress } from '@auxx/utils/address'
 import { stableHash } from '@auxx/utils/hash'
 import { getOrgCache } from '../cache'
 import type { ConditionGroup } from '../conditions'
@@ -14,7 +15,7 @@ import type { TypedFieldValueResult } from '../field-values/types'
 import { getPaymentAccount } from '../money/payments/account-state'
 import { getInvoiceDepositApplied } from '../money/payments/allocation-reads'
 import { buildPayUrl, ensureInvoicePublicToken, isPaymentsConnected } from '../money/public-token'
-import { computeDocumentTotals } from '../money/totals'
+import { computeDocumentTotals, roundCents } from '../money/totals'
 import type { DiscountType } from '../money/types'
 import type { LineItemUnit } from '../money/units'
 import { UnifiedCrudHandler } from '../resources/crud'
@@ -173,9 +174,118 @@ export interface InvoicePdfPayload {
   photos?: PdfPhotoRef[]
 }
 
+/**
+ * The vendor a purchase order is addressed to — a `company` (`purchase_order_vendor`), never
+ * a customer contact, so this is deliberately NOT {@link QuotePdfContact}: a company carries
+ * `company_name`/`company_headquarters`/`company_website` and has no email or phone field of
+ * its own.
+ */
+export interface PurchaseOrderPdfVendor {
+  /** `company_name`. */
+  name: string
+  /** `company_headquarters` as ordered display lines. Empty when the address is unset. */
+  addressLines: string[]
+  /** First `company_website` value (the field is multi-value), or `null`. */
+  website: string | null
+}
+
+/**
+ * One rendered line on the purchase order PDF's line table. Deliberately not
+ * {@link QuotePdfLineItem}: a PO line is a `purchase_order_line`, not a `line_item` — it has
+ * a vendor SKU and no notion of taxability, optionality or photos.
+ */
+export interface PurchaseOrderPdfLineItem {
+  /** `purchase_order_line` EntityInstance id. */
+  lineInstanceId: string
+  /** `purchase_order_line_description` — how the line reads on the supplier-facing document
+   * — falling back to the part's display name when the buyer typed none. */
+  name: string
+  /** `vendor_part_vendor_sku`, reached through `purchase_order_line_vendor_part`. `null`
+   * when the line carries no supplier-catalogue link: that link is optional (a one-off buy
+   * from a supplier with no maintained price list is a legitimate line), so the SKU column
+   * degrades to blank rather than the row failing to build. */
+  vendorSku: string | null
+  /** `purchase_order_line_quantity_ordered`. */
+  qty: number
+  /** Integer minor units — `purchase_order_line_expected_unit_price`. `null` = not yet
+   * priced, and every sum excludes it (the MQ1 convention). */
+  unitPrice: number | null
+  /** Integer minor units — `purchase_order_line_line_total`. */
+  lineTotal: number | null
+  /** Never populated: `purchase_order_line` has no photo field. Declared so `render.ts`'s
+   * shared photo resolver type-checks across every member of {@link DocumentPdfPayload}. */
+  photos?: PdfPhotoRef[]
+}
+
+/**
+ * Everything `<PurchaseOrderPdf>` needs to render (plans/purchasing/07 §1.3/§6.3) — the
+ * buy-side document. Written new rather than adapted from {@link QuotePdfPayload}: a quote
+ * sells TO a customer (optional lines, acceptance, customer-facing pricing presentation)
+ * while a purchase order instructs a VENDOR, so the only genuine overlap is the layout frame.
+ *
+ * `subtotal`/`discountAmount`/`total` are recomputed from the lines with the same math the
+ * totals engine writes (`money/totals-hooks.ts`'s `purchase_order` spec: a flat discount, no
+ * tax rate, and `shippingTotal` + `taxTotal` added on top as STATED header amounts), so the
+ * printed arithmetic and the stored mirrors agree by construction.
+ */
+export interface PurchaseOrderPdfPayload {
+  documentType: 'purchase_order'
+  /** Needed by `render.ts` to load the logo `MediaAsset` bytes server-side. */
+  organizationId: string
+  /** `purchase_order_number` — the reference the vendor quotes back on their invoice. */
+  number: string
+  status: string
+  /** ISO date — `purchase_order_ordered_at` if set, else the instance's `createdAt` (never
+   * `new Date()`; that would defeat the content-hash cache, the MQ2 lesson). */
+  issuedAt: string
+  /** ISO date — `purchase_order_expected_at`, or `null` when unset. */
+  expectedAt: string | null
+  /** `purchase_order_reference` — the supplier's OWN order/confirmation number, or `null`.
+   * Distinct from `number`, which is the document we issued. */
+  vendorReference: string | null
+  terms: string | null
+  vendor: PurchaseOrderPdfVendor
+  /**
+   * The PERSON at the vendor the order is sent to (`purchase_order_contact`) — not the
+   * addressee party, which is {@link vendor}: a company carries no email of its own, so this
+   * is who the send path actually mails.
+   *
+   * The field is nullable and nothing prefills it yet, so this is routinely an
+   * empty-but-PRESENT object — never omitted. `print-records-job.ts`'s `sortBy: 'contact'`
+   * reads `payload.contact.name` across the whole {@link DocumentPdfPayload} union, so a
+   * missing key would break batch-print sorting for every document type, not just this one.
+   */
+  contact: QuotePdfContact
+  /** `purchase_order_ship_to` as ordered display lines — a drop-ship is not always our own
+   * dock. Empty when unset. */
+  shipToLines: string[]
+  lines: PurchaseOrderPdfLineItem[]
+  /** Integer minor units — sum of line totals. */
+  subtotal: number
+  /** Integer minor units — `purchase_order_discount_value`. Flat amount only: a supplier
+   * discount arrives as a number, so there is no percent/amount shape to carry. */
+  discountValue: number | null
+  /** Integer minor units — the discount actually applied, clamped to `[0, subtotal]`. */
+  discountAmount: number
+  /** Integer minor units — `purchase_order_shipping_total`, a stated header amount. */
+  shippingTotal: number
+  /** Integer minor units — `purchase_order_tax_total`, a stated header amount (typed off the
+   * supplier's acknowledgement, never derived from a rate). */
+  taxTotal: number
+  /** Integer minor units — `subtotal - discountAmount + shippingTotal + taxTotal`. */
+  total: number
+  /** `purchase_order_currency`, falling back to the org's currency — a PO can be denominated
+   * in the supplier's currency rather than ours. */
+  currency: string
+  settings: ResolvedDocumentSettings
+  /** Never populated: `purchase_order` has no photo field. Declared so `render.ts`'s shared
+   * photo resolver type-checks across every member of {@link DocumentPdfPayload}. */
+  photos?: PdfPhotoRef[]
+}
+
 /** The render/content-hash dispatch union — `render.ts` and `ensure-pdf.ts` branch on
  * `documentType` to pick the right PDF template and pointer systemAttribute. */
-export type DocumentPdfPayload = QuotePdfPayload | InvoicePdfPayload
+export type DocumentPdfPayload = QuotePdfPayload | InvoicePdfPayload | PurchaseOrderPdfPayload
 
 /** Unwrap a `getFieldValues()` map entry — takes the first value if array-returned. */
 function firstTyped(
@@ -719,6 +829,408 @@ export async function buildInvoicePdfPayload(params: {
     payLink,
     settings,
     photos,
+  }
+
+  return { payload, hash: stableHash(payload) }
+}
+
+// ─── Purchase order (plans/purchasing/07 §1.3/§6.3) ───────────────────────────
+
+/**
+ * Ordered display lines for an `AddressStruct` value — street, street 2,
+ * `"city, state zip"`, country. `[]` for an unset or wholly empty address.
+ *
+ * Multi-line rather than `formatAddress`'s comma-joined single string: a ship-to block on a
+ * purchase order is read off the page by a warehouse, not parsed as prose. The country line
+ * still goes through `formatAddress` (with only a country and `country: 'name'` it returns
+ * just that country's display name) so the ISO code -> name table stays in one place.
+ */
+function addressDisplayLines(address: Partial<AddressStructValue> | null | undefined): string[] {
+  if (!address) return []
+  const trim = (value: string | undefined) => (value ?? '').trim()
+  // Germany puts the postcode BEFORE the city — the same split `formatAddress` makes. A PO
+  // is the document that most often crosses a border, so getting this backwards is a real
+  // delivery risk rather than a cosmetic one.
+  const cityLine =
+    trim(address.country).toUpperCase() === 'DE'
+      ? [trim(address.zipCode), trim(address.city)].filter(Boolean).join(' ')
+      : [
+          [trim(address.city), trim(address.state)].filter(Boolean).join(', '),
+          trim(address.zipCode),
+        ]
+          .filter(Boolean)
+          .join(' ')
+  const country = address.country
+    ? formatAddress({ country: address.country }, { country: 'name' })
+    : ''
+  return [trim(address.street1), trim(address.street2), cityLine, country].filter(
+    (line) => line.length > 0
+  )
+}
+
+/** Read an ADDRESS_STRUCT field value off a `getFieldValues()` entry — stored as jsonb. */
+function addressLinesFromTyped(typed: TypedFieldValue | undefined): string[] {
+  if (!typed || typed.type !== 'json' || !typed.value) return []
+  return addressDisplayLines(typed.value as Partial<AddressStructValue>)
+}
+
+/**
+ * Resolve the vendor block for a purchase order PDF. The vendor is a `company`, so this
+ * cannot reuse `loadPdfContact` — that reader is built around `contact`'s NAME composite and
+ * its email/phone fields, none of which a company has.
+ */
+async function loadPurchaseOrderVendor(
+  cache: ReturnType<typeof getOrgCache>,
+  handler: UnifiedCrudHandler,
+  organizationId: string,
+  vendorRecordId: RecordId | undefined
+): Promise<PurchaseOrderPdfVendor> {
+  const vendor: PurchaseOrderPdfVendor = { name: '', addressLines: [], website: null }
+  if (!vendorRecordId) return vendor
+
+  const companyCf = await cache
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['company_name', 'company_headquarters', 'company_website'] as const)
+
+  const fieldIds = [
+    companyCf.company_name,
+    companyCf.company_headquarters,
+    companyCf.company_website,
+  ]
+    .filter(Boolean)
+    .map((f) => f!.id)
+  if (fieldIds.length === 0) return vendor
+
+  const values = await handler.getFieldValues(vendorRecordId, fieldIds)
+  const get = (f?: { id: string } | null) => (f ? firstTyped(values.get(f.id)) : undefined)
+
+  const nameTyped = get(companyCf.company_name)
+  const websiteTyped = get(companyCf.company_website)
+
+  vendor.name = nameTyped ? (extractValue(nameTyped) as string) : ''
+  vendor.addressLines = addressLinesFromTyped(get(companyCf.company_headquarters))
+  vendor.website = websiteTyped ? (extractValue(websiteTyped) as string) : null
+  return vendor
+}
+
+/**
+ * Load a purchase order's lines in `sortOrder`, resolving each line's vendor SKU and its
+ * name fallback.
+ *
+ * Two batched follow-up reads rather than a per-line drill: the SKUs come back in ONE
+ * `batchGetValues` over every referenced `vendor_part` (direct field ref — a relationship
+ * PATH ref would flip the whole batch onto the sequential lane), and the name fallbacks come
+ * back in one `EntityInstance` read of the referenced parts' display names.
+ *
+ * A line with no `purchase_order_line_vendor_part` simply has no entry in the SKU map and
+ * renders `vendorSku: null` — that link is optional and its absence must never break the row.
+ */
+async function loadPurchaseOrderPdfLines(
+  cache: ReturnType<typeof getOrgCache>,
+  handler: UnifiedCrudHandler,
+  organizationId: string,
+  purchaseOrderRecordId: RecordId
+): Promise<PurchaseOrderPdfLineItem[]> {
+  const lineCf = await cache
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([
+      'purchase_order_line_description',
+      'purchase_order_line_quantity_ordered',
+      'purchase_order_line_expected_unit_price',
+      'purchase_order_line_line_total',
+      'purchase_order_line_part',
+      'purchase_order_line_vendor_part',
+    ] as const)
+
+  const { ids: lineInstanceIds } = await handler.listFiltered({
+    entityDefinitionId: 'purchase_order_line',
+    filters: [
+      {
+        id: 'purchase-order-lines',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'purchase-order-lines-c1',
+            fieldId: 'purchase_order_line:purchaseOrder',
+            operator: 'is',
+            value: purchaseOrderRecordId,
+          },
+        ],
+      },
+    ],
+    sorting: [{ id: 'sortOrder', desc: false }],
+    limit: 1000,
+  })
+
+  const lineFieldIds = [
+    lineCf.purchase_order_line_description,
+    lineCf.purchase_order_line_quantity_ordered,
+    lineCf.purchase_order_line_expected_unit_price,
+    lineCf.purchase_order_line_line_total,
+    lineCf.purchase_order_line_part,
+    lineCf.purchase_order_line_vendor_part,
+  ]
+    .filter(Boolean)
+    .map((f) => f!.id)
+
+  interface RawLine {
+    lineInstanceId: string
+    description: string | null
+    qty: number
+    unitPrice: number | null
+    lineTotal: number | null
+    partRecordId: RecordId | undefined
+    vendorPartRecordId: RecordId | undefined
+  }
+
+  const raw: RawLine[] = []
+  for (const lineInstanceId of lineInstanceIds) {
+    const lineRecordId = toRecordId('purchase_order_line', lineInstanceId)
+    const values = await handler.getFieldValues(lineRecordId, lineFieldIds)
+    const getLine = (f?: { id: string } | null) => (f ? firstTyped(values.get(f.id)) : undefined)
+
+    const descriptionTyped = getLine(lineCf.purchase_order_line_description)
+    const qtyTyped = getLine(lineCf.purchase_order_line_quantity_ordered)
+    const unitPriceTyped = getLine(lineCf.purchase_order_line_expected_unit_price)
+    const lineTotalTyped = getLine(lineCf.purchase_order_line_line_total)
+    const partTyped = getLine(lineCf.purchase_order_line_part)
+    const vendorPartTyped = getLine(lineCf.purchase_order_line_vendor_part)
+
+    raw.push({
+      lineInstanceId,
+      description: descriptionTyped ? (extractValue(descriptionTyped) as string) : null,
+      qty: qtyTyped ? (extractValue(qtyTyped) as number) : 0,
+      unitPrice: unitPriceTyped ? (extractValue(unitPriceTyped) as number) : null,
+      lineTotal: lineTotalTyped ? (extractValue(lineTotalTyped) as number) : null,
+      partRecordId: partTyped?.type === 'relationship' ? partTyped.recordId : undefined,
+      vendorPartRecordId:
+        vendorPartTyped?.type === 'relationship' ? vendorPartTyped.recordId : undefined,
+    })
+  }
+
+  const [skuByVendorPart, nameByPart] = await Promise.all([
+    loadVendorSkus(
+      cache,
+      handler,
+      organizationId,
+      raw.map((line) => line.vendorPartRecordId)
+    ),
+    loadPartDisplayNames(raw.map((line) => line.partRecordId)),
+  ])
+
+  return raw.map((line) => ({
+    lineInstanceId: line.lineInstanceId,
+    // The supplier-facing description is the authority — printing our own part name on their
+    // order is how a picking error becomes a dispute — but it is nullable, and a blank row on
+    // a vendor document is worse than our name for the thing.
+    name:
+      line.description ||
+      (line.partRecordId ? (nameByPart.get(line.partRecordId) ?? '') : '') ||
+      '',
+    vendorSku: line.vendorPartRecordId
+      ? (skuByVendorPart.get(line.vendorPartRecordId) ?? null)
+      : null,
+    qty: line.qty,
+    unitPrice: line.unitPrice,
+    lineTotal: line.lineTotal,
+  }))
+}
+
+/** One batched `vendor_part_vendor_sku` read over every `vendor_part` the lines reference. */
+async function loadVendorSkus(
+  cache: ReturnType<typeof getOrgCache>,
+  handler: UnifiedCrudHandler,
+  organizationId: string,
+  vendorPartRecordIds: Array<RecordId | undefined>
+): Promise<Map<RecordId, string>> {
+  const skus = new Map<RecordId, string>()
+  const recordIds = Array.from(new Set(vendorPartRecordIds.filter((id): id is RecordId => !!id)))
+  if (recordIds.length === 0) return skus
+
+  const vendorPartCf = await cache
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['vendor_part_vendor_sku'] as const)
+  const skuField = vendorPartCf.vendor_part_vendor_sku
+  if (!skuField) return skus
+
+  const { entityDefinitionId } = parseRecordId(recordIds[0]!)
+  const { values } = await handler.fieldValueService.batchGetValues({
+    recordIds,
+    fieldReferences: [toResourceFieldId(entityDefinitionId, skuField.id)],
+  })
+
+  for (const value of values) {
+    if (Array.isArray(value.fieldRef)) continue
+    const typed = firstTyped(
+      Array.isArray(value.value) ? value.value[0] : (value.value ?? undefined)
+    )
+    if (!typed) continue
+    const sku = extractValue(typed) as string
+    if (sku) skus.set(value.recordId, sku)
+  }
+  return skus
+}
+
+/** One batched `EntityInstance.displayName` read for the lines' name fallback. */
+async function loadPartDisplayNames(
+  partRecordIds: Array<RecordId | undefined>
+): Promise<Map<RecordId, string>> {
+  const names = new Map<RecordId, string>()
+  const recordIds = Array.from(new Set(partRecordIds.filter((id): id is RecordId => !!id)))
+  if (recordIds.length === 0) return names
+
+  const byInstanceId = new Map<string, RecordId>()
+  for (const recordId of recordIds) {
+    byInstanceId.set(parseRecordId(recordId).entityInstanceId, recordId)
+  }
+
+  const instances = await database.query.EntityInstance.findMany({
+    columns: { id: true, displayName: true },
+    where: (t, { inArray }) => inArray(t.id, Array.from(byInstanceId.keys())),
+  })
+  for (const instance of instances) {
+    const recordId = byInstanceId.get(instance.id)
+    if (recordId && instance.displayName) names.set(recordId, instance.displayName)
+  }
+  return names
+}
+
+/**
+ * Load a purchase order + its lines + its vendor, embed the org's resolved document settings,
+ * and hash the whole thing with `stableHash` for the render-or-reuse cache check — the
+ * buy-side analog of {@link buildQuotePdfPayload}, written new per plans/purchasing/07 §6.3.
+ *
+ * Totals are recomputed from the lines exactly as `money/totals-hooks.ts` writes them for a
+ * `purchase_order`: a flat discount clamped to the subtotal, no tax RATE, and
+ * `purchase_order_shipping_total` + `purchase_order_tax_total` added on top as stated header
+ * amounts the engine must never overwrite.
+ */
+export async function buildPurchaseOrderPdfPayload(params: {
+  organizationId: string
+  userId: string
+  purchaseOrderRecordId: RecordId
+}): Promise<{ payload: PurchaseOrderPdfPayload; hash: string }> {
+  const { organizationId, userId, purchaseOrderRecordId } = params
+  const { entityInstanceId: purchaseOrderInstanceId } = parseRecordId(purchaseOrderRecordId)
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const cache = getOrgCache()
+
+  // Stable fallback for `issuedAt` when `purchase_order_ordered_at` is unset (a draft that
+  // has not been placed yet) — never `new Date()`, which would defeat the content hash.
+  const orderInstance = await database.query.EntityInstance.findFirst({
+    columns: { createdAt: true },
+    where: (t, { eq }) => eq(t.id, purchaseOrderInstanceId),
+  })
+
+  const cf = await cache
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([
+      'purchase_order_number',
+      'purchase_order_status',
+      'purchase_order_vendor',
+      'purchase_order_contact',
+      'purchase_order_ordered_at',
+      'purchase_order_expected_at',
+      'purchase_order_reference',
+      'purchase_order_terms',
+      'purchase_order_currency',
+      'purchase_order_ship_to',
+      'purchase_order_shipping_total',
+      'purchase_order_tax_total',
+      'purchase_order_discount_value',
+    ] as const)
+
+  const orderFieldIds = [
+    cf.purchase_order_number,
+    cf.purchase_order_status,
+    cf.purchase_order_vendor,
+    cf.purchase_order_contact,
+    cf.purchase_order_ordered_at,
+    cf.purchase_order_expected_at,
+    cf.purchase_order_reference,
+    cf.purchase_order_terms,
+    cf.purchase_order_currency,
+    cf.purchase_order_ship_to,
+    cf.purchase_order_shipping_total,
+    cf.purchase_order_tax_total,
+    cf.purchase_order_discount_value,
+  ]
+    .filter(Boolean)
+    .map((f) => f!.id)
+  const orderValues = await handler.getFieldValues(purchaseOrderRecordId, orderFieldIds)
+  const get = (f?: { id: string } | null) => (f ? firstTyped(orderValues.get(f.id)) : undefined)
+
+  const numberTyped = get(cf.purchase_order_number)
+  const statusTyped = get(cf.purchase_order_status)
+  const vendorTyped = get(cf.purchase_order_vendor)
+  const contactTyped = get(cf.purchase_order_contact)
+  const orderedAtTyped = get(cf.purchase_order_ordered_at)
+  const expectedAtTyped = get(cf.purchase_order_expected_at)
+  const referenceTyped = get(cf.purchase_order_reference)
+  const termsTyped = get(cf.purchase_order_terms)
+  const currencyTyped = get(cf.purchase_order_currency)
+  const shippingTotalTyped = get(cf.purchase_order_shipping_total)
+  const taxTotalTyped = get(cf.purchase_order_tax_total)
+  const discountValueTyped = get(cf.purchase_order_discount_value)
+
+  const number = numberTyped ? (extractValue(numberTyped) as string) : ''
+  const status = statusTyped ? (extractValue(statusTyped) as string) : 'draft'
+  const issuedAt = orderedAtTyped
+    ? (extractValue(orderedAtTyped) as string)
+    : (orderInstance?.createdAt ?? new Date(0)).toISOString()
+  const expectedAt = expectedAtTyped ? (extractValue(expectedAtTyped) as string) : null
+  const vendorReference = referenceTyped ? (extractValue(referenceTyped) as string) : null
+  const terms = termsTyped ? (extractValue(termsTyped) as string) : null
+  const shippingTotal = shippingTotalTyped ? (extractValue(shippingTotalTyped) as number) : 0
+  const taxTotal = taxTotalTyped ? (extractValue(taxTotalTyped) as number) : 0
+  const discountValue = discountValueTyped ? (extractValue(discountValueTyped) as number) : null
+  const vendorRecordId = vendorTyped?.type === 'relationship' ? vendorTyped.recordId : undefined
+  const contactRecordId = contactTyped?.type === 'relationship' ? contactTyped.recordId : undefined
+  const shipToLines = addressLinesFromTyped(get(cf.purchase_order_ship_to))
+
+  // `loadPdfContact` returns an empty-but-present contact for an undefined recordId, which is
+  // the common case today: `purchase_order_contact` is nullable and nothing prefills it yet.
+  const [vendor, contact, lines, settings] = await Promise.all([
+    loadPurchaseOrderVendor(cache, handler, organizationId, vendorRecordId),
+    loadPdfContact(cache, handler, organizationId, contactRecordId),
+    loadPurchaseOrderPdfLines(cache, handler, organizationId, purchaseOrderRecordId),
+    resolveDocumentSettings(organizationId),
+  ])
+
+  // A supplier discount is always a flat amount (there is no `purchase_order_discount_type`
+  // field to read a shape from) and there is no tax RATE on the buy side, so freight and tax
+  // are added on top rather than derived — the `purchase_order` spec in `totals-hooks.ts`.
+  const totals = computeDocumentTotals(
+    lines.map((line) => ({ lineTotal: line.lineTotal, taxable: true })),
+    { discountType: 'amount', discountValue, taxRate: null }
+  )
+  const total = roundCents(totals.total + shippingTotal + taxTotal)
+
+  const currency = currencyTyped
+    ? (extractValue(currencyTyped) as string) || settings.currency
+    : settings.currency
+
+  const payload: PurchaseOrderPdfPayload = {
+    documentType: 'purchase_order',
+    organizationId,
+    number,
+    status,
+    issuedAt,
+    expectedAt,
+    vendorReference,
+    terms,
+    vendor,
+    contact,
+    shipToLines,
+    lines,
+    subtotal: totals.subtotal,
+    discountValue,
+    discountAmount: totals.discountAmount,
+    shippingTotal,
+    taxTotal,
+    total,
+    currency,
+    settings,
   }
 
   return { payload, hash: stableHash(payload) }

--- a/packages/lib/src/documents/pdf/purchase-order-pdf.tsx
+++ b/packages/lib/src/documents/pdf/purchase-order-pdf.tsx
@@ -1,0 +1,245 @@
+// packages/lib/src/documents/pdf/purchase-order-pdf.tsx
+// @jsxRuntime automatic
+// @jsxImportSource react
+
+import { formatCurrency } from '@auxx/utils/currency'
+import { Document, Page, Text, View } from '@react-pdf/renderer'
+import type { PurchaseOrderPdfPayload, PurchaseOrderPdfVendor, QuotePdfContact } from '../payload'
+import type { DocumentBusinessSettings } from '../resolve-settings'
+import { DocumentHeader, type DocumentLineRow, LineItemsTable } from './parts'
+import { createDocumentStyles, pageSizeFor } from './theme'
+
+type Styles = ReturnType<typeof createDocumentStyles>
+
+/**
+ * Three-column party block — buyer / vendor / ship-to.
+ *
+ * Local rather than `parts.tsx`'s `BillingPartyBlock`, which is a two-column From/To built
+ * around a `contact`: it has nowhere to put a ship-to at all, and it renders no street lines
+ * for the addressee (a `contact` has none), so a vendor's street address would be silently
+ * dropped. Composed from the same `theme.ts` styles, the way `invoice-pdf.tsx` builds its
+ * payment-history table.
+ */
+function PurchaseOrderParties(props: {
+  styles: Styles
+  business: DocumentBusinessSettings
+  vendor: PurchaseOrderPdfVendor
+  /** The person the order is sent to — routinely empty, so every line is guarded. */
+  contact: QuotePdfContact
+  shipToLines: string[]
+}) {
+  const { styles, business, vendor, contact, shipToLines } = props
+  const businessCityLine = [
+    business.address?.city,
+    business.address?.state,
+    business.address?.zipCode,
+  ]
+    .filter(Boolean)
+    .join(', ')
+  const column = { width: '31%' }
+
+  return (
+    <View style={styles.partiesRow}>
+      <View style={column}>
+        <Text style={styles.label}>From</Text>
+        <Text style={[styles.value, styles.bold]}>{business.companyName || ' '}</Text>
+        {business.address?.street1 ? (
+          <Text style={styles.value}>{business.address.street1}</Text>
+        ) : null}
+        {business.address?.street2 ? (
+          <Text style={styles.value}>{business.address.street2}</Text>
+        ) : null}
+        {businessCityLine ? <Text style={styles.value}>{businessCityLine}</Text> : null}
+        {business.address?.country ? (
+          <Text style={styles.value}>{business.address.country}</Text>
+        ) : null}
+        {business.phone ? <Text style={styles.value}>{business.phone}</Text> : null}
+        {business.email ? <Text style={styles.value}>{business.email}</Text> : null}
+      </View>
+
+      <View style={column}>
+        <Text style={styles.label}>Vendor</Text>
+        <Text style={[styles.value, styles.bold]}>{vendor.name || ' '}</Text>
+        {vendor.addressLines.map((line) => (
+          <Text key={line} style={styles.value}>
+            {line}
+          </Text>
+        ))}
+        {vendor.website ? <Text style={styles.value}>{vendor.website}</Text> : null}
+        {contact.name ? <Text style={styles.value}>Attn: {contact.name}</Text> : null}
+        {contact.email ? <Text style={styles.value}>{contact.email}</Text> : null}
+        {contact.phone ? <Text style={styles.value}>{contact.phone}</Text> : null}
+      </View>
+
+      <View style={column}>
+        <Text style={styles.label}>Ship to</Text>
+        {shipToLines.length > 0 ? (
+          shipToLines.map((line) => (
+            <Text key={line} style={styles.value}>
+              {line}
+            </Text>
+          ))
+        ) : (
+          <Text style={styles.value}> </Text>
+        )}
+      </View>
+    </View>
+  )
+}
+
+/**
+ * Subtotal / discount / shipping / tax / total, right-aligned under the line table.
+ *
+ * Local rather than `parts.tsx`'s `TotalsBlock`, which has no row for freight: a purchase
+ * order's `shippingTotal` is a stated header amount added on top of the discounted subtotal,
+ * so without it the printed rows would not sum to the printed total. Same `theme.ts` styles
+ * as the shared block, so the two are visually identical.
+ */
+function PurchaseOrderTotals(props: {
+  styles: Styles
+  currencyCode: string
+  subtotal: number
+  discountAmount: number
+  shippingTotal: number
+  taxTotal: number
+  total: number
+}) {
+  const { styles, currencyCode, subtotal, discountAmount, shippingTotal, taxTotal, total } = props
+  const fmt = (minorUnits: number) => formatCurrency(minorUnits, { currencyCode })
+
+  return (
+    <View style={styles.totalsBlock}>
+      <View style={styles.totalsRow}>
+        <Text style={styles.value}>Subtotal</Text>
+        <Text style={styles.value}>{fmt(subtotal)}</Text>
+      </View>
+      {discountAmount > 0 ? (
+        <View style={styles.totalsRow}>
+          <Text style={styles.value}>Discount</Text>
+          <Text style={styles.value}>-{fmt(discountAmount)}</Text>
+        </View>
+      ) : null}
+      {shippingTotal > 0 ? (
+        <View style={styles.totalsRow}>
+          <Text style={styles.value}>Shipping</Text>
+          <Text style={styles.value}>{fmt(shippingTotal)}</Text>
+        </View>
+      ) : null}
+      {taxTotal > 0 ? (
+        <View style={styles.totalsRow}>
+          <Text style={styles.value}>Tax</Text>
+          <Text style={styles.value}>{fmt(taxTotal)}</Text>
+        </View>
+      ) : null}
+      <View style={styles.totalsRowFinal}>
+        <Text style={[styles.value, styles.bold, styles.accentText]}>Total</Text>
+        <Text style={[styles.value, styles.bold, styles.accentText]}>{fmt(total)}</Text>
+      </View>
+    </View>
+  )
+}
+
+/**
+ * The purchase order PDF template (plans/purchasing/07 §1.3). Composes the same
+ * `DocumentHeader` / `LineItemsTable` / `theme.ts` frame as `quote-pdf.tsx` and
+ * `invoice-pdf.tsx`, but says what a purchase order says: it instructs a vendor rather than
+ * selling to a customer, so there is no optional-line block, no acceptance language and no
+ * customer-facing pricing presentation.
+ *
+ * The vendor SKU rides in each row's `tag` slot — `LineItemsTable` has a fixed
+ * Description/Qty/Unit price/Amount shape with no SKU column, and a line whose
+ * `purchase_order_line_vendor_part` is unset simply carries no tag.
+ *
+ * `lineDisplay` is pinned to `'full'` rather than read from settings: the
+ * `documents.*.lineDisplay` `'amount_only'` mode exists to hide a cost breakdown from a
+ * CUSTOMER, and a vendor order with no quantities or unit prices is not an order.
+ */
+export function PurchaseOrderPdf(props: {
+  payload: PurchaseOrderPdfPayload
+  logoBytes?: Buffer | null
+  /** Accepted for the registry's component contract; a purchase order carries no photos. */
+  photoBytes?: Map<string, Buffer>
+  /** Batch-print copy label (P4) — see `DocumentHeader`'s `copyLabel`. */
+  copyLabel?: string
+}) {
+  const { payload, logoBytes, copyLabel } = props
+  const { settings } = payload
+  const styles = createDocumentStyles(settings)
+  const currencyCode = payload.currency
+
+  const lines: DocumentLineRow[] = payload.lines.map((line) => ({
+    name: line.name,
+    description: null,
+    qty: line.qty,
+    unit: null,
+    unitPrice: line.unitPrice,
+    lineTotal: line.lineTotal,
+    tag: line.vendorSku ? `SKU ${line.vendorSku}` : null,
+  }))
+
+  return (
+    <Document title={`${payload.number} — Purchase Order`}>
+      <Page size={pageSizeFor(settings.branding.paperSize)} style={styles.page} wrap>
+        <DocumentHeader
+          styles={styles}
+          documentLabel='Purchase Order'
+          number={payload.number}
+          issuedAt={payload.issuedAt}
+          secondaryDate={payload.expectedAt}
+          secondaryDateLabel='Expected'
+          dateFormat={settings.branding.dateFormat}
+          logoBytes={logoBytes}
+          copyLabel={copyLabel}
+        />
+
+        <PurchaseOrderParties
+          styles={styles}
+          business={settings.business}
+          vendor={payload.vendor}
+          contact={payload.contact}
+          shipToLines={payload.shipToLines}
+        />
+
+        {payload.number ? (
+          <View style={{ marginBottom: 12 }}>
+            <Text style={styles.value}>
+              Please quote purchase order {payload.number} on your invoice and packing slip.
+            </Text>
+          </View>
+        ) : null}
+
+        <LineItemsTable
+          styles={styles}
+          lines={lines}
+          lineDisplay='full'
+          showDescriptions={false}
+          currencyCode={currencyCode}
+        />
+
+        <PurchaseOrderTotals
+          styles={styles}
+          currencyCode={currencyCode}
+          subtotal={payload.subtotal}
+          discountAmount={payload.discountAmount}
+          shippingTotal={payload.shippingTotal}
+          taxTotal={payload.taxTotal}
+          total={payload.total}
+        />
+
+        {payload.vendorReference ? (
+          <View style={styles.terms}>
+            <Text style={styles.label}>Your reference</Text>
+            <Text style={styles.value}>{payload.vendorReference}</Text>
+          </View>
+        ) : null}
+
+        {payload.terms ? (
+          <View style={styles.terms}>
+            <Text style={styles.label}>Terms</Text>
+            <Text style={styles.value}>{payload.terms}</Text>
+          </View>
+        ) : null}
+      </Page>
+    </Document>
+  )
+}

--- a/packages/lib/src/documents/registry.ts
+++ b/packages/lib/src/documents/registry.ts
@@ -8,9 +8,15 @@
 
 import type { RecordId } from '@auxx/types/resource'
 import type { ComponentType } from 'react'
-import { DOCUMENT_TYPE_DESCRIPTORS, type PrintOptionField } from './client'
-import { buildInvoicePdfPayload, buildQuotePdfPayload, type DocumentPdfPayload } from './payload'
+import { DOCUMENT_TYPE_DESCRIPTORS, type DocumentTypeId, type PrintOptionField } from './client'
+import {
+  buildInvoicePdfPayload,
+  buildPurchaseOrderPdfPayload,
+  buildQuotePdfPayload,
+  type DocumentPdfPayload,
+} from './payload'
 import { InvoicePdf } from './pdf/invoice-pdf'
+import { PurchaseOrderPdf } from './pdf/purchase-order-pdf'
 import { QuotePdf } from './pdf/quote-pdf'
 
 /**
@@ -19,8 +25,9 @@ import { QuotePdf } from './pdf/quote-pdf'
  * type" the print wizard's Document style relies on.
  */
 export interface RegisteredDocumentType {
-  /** Matches `DocumentType` ('quote' | 'invoice') and the client descriptor's `id`. */
-  id: string
+  /** Matches `DocumentType` and the client descriptor's `id` — one union, declared in
+   * `./client.ts` so the client-safe half owns it. */
+  id: DocumentTypeId
   /** `EntityDefinition.entityType` slug this document type renders records of — resolve to a
    * per-org `EntityDefinition.id` via `requireCachedEntityDefId` before comparing against one. */
   entityType: string
@@ -51,7 +58,13 @@ export interface RegisteredDocumentType {
 
 /** Per-type renderer wiring — the part `./client.ts`'s descriptors can't carry (react-pdf +
  * server-only payload builders). Merged with `DOCUMENT_TYPE_DESCRIPTORS` below so
- * id/entityType are defined exactly once. */
+ * id/entityType are defined exactly once.
+ *
+ * ⚠️ `pointerAttr` is not optional in practice, even though nothing throws without it.
+ * `ensure-pdf.ts` reads the pointer to decide whether a cached render can be reused; when the
+ * org has no such field the lookup simply returns nothing, so every send re-renders AND mints
+ * a fresh `MediaAsset` rather than versioning the existing one. That is an asset leak with no
+ * error attached, which is why a new entry names a real field and never a plausible one. */
 const RENDER_ENTRIES: Array<
   Pick<RegisteredDocumentType, 'id' | 'pointerAttr' | 'buildPayload' | 'Pdf'>
 > = [
@@ -76,6 +89,17 @@ const RENDER_ENTRIES: Array<
         invoiceRecordId: params.recordId,
       }),
     Pdf: InvoicePdf as unknown as RegisteredDocumentType['Pdf'],
+  },
+  {
+    id: 'purchase_order',
+    pointerAttr: 'purchase_order_pdf_asset',
+    buildPayload: (params) =>
+      buildPurchaseOrderPdfPayload({
+        organizationId: params.organizationId,
+        userId: params.userId,
+        purchaseOrderRecordId: params.recordId,
+      }),
+    Pdf: PurchaseOrderPdf as unknown as RegisteredDocumentType['Pdf'],
   },
 ]
 

--- a/packages/lib/src/field-hooks/__tests__/purchase-order-line-evidence-lock-registration.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/purchase-order-line-evidence-lock-registration.test.ts
@@ -1,0 +1,49 @@
+// packages/lib/src/field-hooks/__tests__/purchase-order-line-evidence-lock-registration.test.ts
+//
+// 🛑 The failure this exists to catch is the one `pre/quote-deposit-guard.ts` documents for
+// `quote_status`: a guard registered on the SYSTEM-hook chain
+// (`resources/hooks/*-hooks.ts`) is dead for every real client write, because the surfaces
+// that edit these fields go through `fieldValue.set` -> `FieldValueService`, which never
+// reads that registry. The evidence lock has to be on THIS chain, and nothing but a
+// registration assertion can tell the difference — a lock that never fires looks exactly
+// like a lock nothing has tripped.
+//
+// Separate from the behaviour tests in `pre/purchase-order-line-evidence-lock.test.ts`
+// because `getFieldPreHooks` self-inits the whole hook bootstrap, which needs the real
+// `@auxx/database` module graph rather than that file's narrow schema stub.
+
+import { describe, expect, it } from 'vitest'
+import {
+  EVIDENCE_LOCKED_LINE_ATTRS,
+  guardEvidenceLockedLineFields,
+} from '../pre/purchase-order-line-evidence-lock'
+import { getFieldPreHooks, hasFieldPreHooks } from '../registry'
+
+describe('purchase order line evidence lock registration', () => {
+  it('is reachable on the field pre-hook chain for both locked attributes', () => {
+    for (const attribute of EVIDENCE_LOCKED_LINE_ATTRS) {
+      expect(hasFieldPreHooks('purchase-order-lines', attribute)).toBe(true)
+      expect(getFieldPreHooks('purchase-order-lines', attribute)).toContain(
+        guardEvidenceLockedLineFields
+      )
+    }
+  })
+
+  // The two agreed TERMS of the order, and only those. `description`, `weight`, `sortOrder`
+  // and the `vendorPart` link stay editable on a booked line — amending an order is a real
+  // workflow (§6.5), and over-locking pushes people into delete-and-recreate, which takes the
+  // receipts with it.
+  it('locks exactly the two agreed-terms fields and nothing else on the line', () => {
+    expect([...EVIDENCE_LOCKED_LINE_ATTRS]).toEqual([
+      'purchase_order_line_quantity_ordered',
+      'purchase_order_line_expected_unit_price',
+    ])
+    for (const attribute of [
+      'purchase_order_line_description',
+      'purchase_order_line_weight',
+      'purchase_order_line_vendor_part',
+    ] as const) {
+      expect(hasFieldPreHooks('purchase-order-lines', attribute)).toBe(false)
+    }
+  })
+})

--- a/packages/lib/src/field-hooks/__tests__/purchase-order-status-guard-registration.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/purchase-order-status-guard-registration.test.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/field-hooks/__tests__/purchase-order-status-guard-registration.test.ts
+//
+// 🛑 `purchase_order_status` is guarded on BOTH hook chains and they cover different doors.
+// The system hook (`resources/hooks/purchasing-hooks.ts`) runs for `record.create` /
+// `record.update`, the CSV importer and the SDK. The field pre-hook runs for
+// `fieldValue.set` / `setBulk` — the drawer, the grid's inline edit and a kanban drag, which
+// is how a human would actually try to type `issued`. Losing either registration narrows
+// coverage silently: nothing throws, the guard simply stops seeing that door.
+//
+// Separate from `pre/purchase-order-status-guard.test.ts` because `getFieldPreHooks`
+// self-inits the whole hook bootstrap, which needs the real `@auxx/database` module graph.
+
+import { describe, expect, it } from 'vitest'
+import { guardManualPurchaseOrderIssued } from '../pre/purchase-order-status-guard'
+import { getFieldPreHooks, hasFieldPreHooks } from '../registry'
+
+describe('purchase_order_status guard registration', () => {
+  // The client path. This is the registration the plan's "issued is action-set" claim
+  // actually depends on.
+  it('is on the field pre-hook chain for purchase-orders', () => {
+    expect(hasFieldPreHooks('purchase-orders', 'purchase_order_status')).toBe(true)
+    expect(getFieldPreHooks('purchase-orders', 'purchase_order_status')).toContain(
+      guardManualPurchaseOrderIssued
+    )
+  })
+
+  // The CRUD path. Kept deliberately — it is the only chain the importer and the SDK take.
+  it('is also on the system-hook chain, reachable by entityType', async () => {
+    const { getHooksForAttribute } = await import('../../resources/hooks/system-hooks')
+    expect(getHooksForAttribute('purchase_order', 'purchase_order_status')).toHaveLength(1)
+  })
+
+  // One source for what is guarded, so the two chains cannot drift into disagreeing.
+  it('guards the same value set and message on both chains', async () => {
+    const { PURCHASE_ORDER_ACTION_STATUSES, PURCHASE_ORDER_ACTION_STATUS_MESSAGE } = await import(
+      '../../resources/hooks/lifecycle-status-guard'
+    )
+    expect([...PURCHASE_ORDER_ACTION_STATUSES]).toEqual(['issued'])
+
+    const { PURCHASE_ORDER_HOOKS } = await import('../../resources/hooks/purchasing-hooks')
+    const systemHook = PURCHASE_ORDER_HOOKS.purchase_order_status![0]!
+    const systemRejection = systemHook({
+      operation: 'update',
+      field: { id: 'f-status', systemAttribute: 'purchase_order_status' },
+      values: { 'f-status': 'issued' },
+    } as any)
+    await expect(systemRejection).rejects.toThrow(PURCHASE_ORDER_ACTION_STATUS_MESSAGE)
+
+    await expect(
+      guardManualPurchaseOrderIssued({
+        newValue: { type: 'option', optionId: 'issued' },
+      } as any)
+    ).rejects.toThrow(PURCHASE_ORDER_ACTION_STATUS_MESSAGE)
+  })
+
+  // The `purchase_order_line` evidence lock is a different guard on a different slug; a
+  // registration mix-up between the two would be invisible.
+  it('does not leak onto the line def', () => {
+    expect(hasFieldPreHooks('purchase-order-lines', 'purchase_order_status')).toBe(false)
+  })
+})

--- a/packages/lib/src/field-hooks/post/inventory-triggers.ts
+++ b/packages/lib/src/field-hooks/post/inventory-triggers.ts
@@ -24,7 +24,8 @@ const logger = createScopedLogger('field-hooks:inventory')
  * is created or deleted.
  *
  * 1. Resolve which part was affected from the stock_movement_part relationship
- * 2. SUM all movement quantities for that part via a single self-join SQL query
+ * 2. SUM all movement quantities for that part via a single self-join SQL query,
+ *    which also carries the part's reorder point back as a scalar subquery
  * 3. Write part_quantity_on_hand and derive part_stock_status
  */
 export const recalculatePartQoH: EntityTriggerHandler = async (event) => {
@@ -155,6 +156,10 @@ export const recalculateStockStatus: FieldTriggerHandler = async (event) => {
 /**
  * Recalculate QoH for a specific part by summing all its stock movement quantities
  * in a single self-join query, then write QoH + stock status in parallel.
+ *
+ * ⚡ ONE read. The reorder point used to be a second statement run alongside the
+ * SUM; it is a scalar subquery in the same statement now, because this function
+ * runs once per stock movement and a ten-line receipt paid for ten of them.
  */
 async function recalculateQoHForPart(organizationId: string, partInstanceId: string) {
   const cache = getOrgCache()
@@ -190,6 +195,15 @@ async function recalculateQoHForPart(organizationId: string, partInstanceId: str
   const [sumRow] = await database
     .select({
       total: sql<string>`COALESCE(SUM(${schema.FieldValue.valueNumber}), 0)`,
+      // The part's reorder point rides along as an uncorrelated scalar
+      // subquery rather than a second round trip. It is one index lookup
+      // inside a statement that was already being issued, and it references
+      // no column of the FROM list, so it is a constant to the aggregate.
+      reorderPoint: sql<number | null>`(SELECT fv_rp."valueNumber" FROM "FieldValue" fv_rp
+        WHERE fv_rp."entityId" = ${partInstanceId}
+          AND fv_rp."fieldId" = ${reorderPointField?.id ?? ''}
+          AND fv_rp."organizationId" = ${organizationId}
+        LIMIT 1)`,
     })
     .from(schema.FieldValue)
     .innerJoin(
@@ -214,12 +228,9 @@ async function recalculateQoHForPart(organizationId: string, partInstanceId: str
     )
 
   const qoh = Number(sumRow?.total ?? 0)
+  const reorderPoint = sumRow?.reorderPoint != null ? Number(sumRow.reorderPoint) : null
 
-  // Resolve part context once
-  const [partDefId, reorderPoint] = await Promise.all([
-    requireCachedEntityDefId(organizationId, 'part'),
-    readReorderPoint(organizationId, partInstanceId, reorderPointField?.id),
-  ])
+  const partDefId = await requireCachedEntityDefId(organizationId, 'part')
 
   const recordId = toRecordId(partDefId, partInstanceId) as RecordId
   const ctx = createFieldValueContext(organizationId)
@@ -272,31 +283,6 @@ async function recalculateQoHForPart(organizationId: string, partInstanceId: str
   })
 
   logger.info('QoH recalculated', { partInstanceId, qoh, status })
-}
-
-/**
- * Read the reorder point field value for a part. Returns null if not set.
- */
-async function readReorderPoint(
-  organizationId: string,
-  partInstanceId: string,
-  reorderPointFieldId: string | undefined
-): Promise<number | null> {
-  if (!reorderPointFieldId) return null
-
-  const rpRow = await database
-    .select({ valueNumber: schema.FieldValue.valueNumber })
-    .from(schema.FieldValue)
-    .where(
-      and(
-        eq(schema.FieldValue.entityId, partInstanceId),
-        eq(schema.FieldValue.organizationId, organizationId),
-        eq(schema.FieldValue.fieldId, reorderPointFieldId)
-      )
-    )
-    .limit(1)
-
-  return rpRow[0]?.valueNumber != null ? Number(rpRow[0].valueNumber) : null
 }
 
 /**

--- a/packages/lib/src/field-hooks/post/purchase-order-line-rollups.test.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-line-rollups.test.ts
@@ -6,7 +6,9 @@
 // is exactly what shipped for `order_number` in #1911, and the shape of the failure
 // is silent in both cases.
 
+import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuxxError } from '../../errors'
 import type { EntityTriggerEvent } from '../types'
 
 const h = vi.hoisted(() => ({
@@ -15,6 +17,8 @@ const h = vi.hoisted(() => ({
   createFieldValueContext: vi.fn(),
   requireCachedEntityDefId: vi.fn(),
   publishFieldValueUpdates: vi.fn(),
+  recalculatePurchaseOrderStatuses: vi.fn(),
+  recalculatePurchaseOrderStatusesForLines: vi.fn(),
   // The two shapes the module asks the db for, in call order.
   dbResults: [] as unknown[][],
 }))
@@ -23,7 +27,7 @@ const h = vi.hoisted(() => ({
 function makeChain() {
   const result = h.dbResults.shift() ?? []
   const chain: Record<string, unknown> = {}
-  for (const key of ['from', 'innerJoin', 'leftJoin', 'where', 'limit']) {
+  for (const key of ['from', 'innerJoin', 'leftJoin', 'where', 'limit', 'groupBy']) {
     chain[key] = () => chain
   }
   chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve)
@@ -58,12 +62,17 @@ vi.mock('../../realtime', () => ({
   getRealtimeService: () => ({}),
   publishFieldValueUpdates: h.publishFieldValueUpdates,
 }))
+vi.mock('../../purchasing/purchase-order-status-writer', () => ({
+  recalculatePurchaseOrderStatuses: h.recalculatePurchaseOrderStatuses,
+  recalculatePurchaseOrderStatusesForLines: h.recalculatePurchaseOrderStatusesForLines,
+}))
 
 import {
   PURCHASE_ORDER_LINE_ROLLUPS,
   recalculatePurchaseOrderLineBilled,
   recalculatePurchaseOrderLineReceived,
   recalculatePurchaseOrderLineRollup,
+  recalculatePurchaseOrderLineRollups,
 } from './purchase-order-line-rollups'
 
 const PO_LINE = 'poline-1'
@@ -100,6 +109,8 @@ beforeEach(() => {
   h.requireCachedEntityDefId.mockResolvedValue('poldef')
   h.setValueWithType.mockResolvedValue([])
   h.publishFieldValueUpdates.mockResolvedValue(undefined)
+  h.recalculatePurchaseOrderStatuses.mockResolvedValue(ok({}))
+  h.recalculatePurchaseOrderStatusesForLines.mockResolvedValue(ok([]))
 })
 
 describe('recalculatePurchaseOrderLineReceived', () => {
@@ -195,12 +206,14 @@ describe('the roll-up specs', () => {
       quantityAttr: 'stock_movement_quantity',
       lineRelAttr: 'stock_movement_purchase_order_line',
       targetAttr: 'purchase_order_line_quantity_received',
+      evidence: 'receipt',
     })
     expect(PURCHASE_ORDER_LINE_ROLLUPS.billed).toEqual({
       childEntityType: 'vendor_bill_line',
       quantityAttr: 'vendor_bill_line_quantity_billed',
       lineRelAttr: 'vendor_bill_line_purchase_order_line',
       targetAttr: 'purchase_order_line_quantity_billed',
+      evidence: 'billing',
     })
   })
 
@@ -209,6 +222,269 @@ describe('the roll-up specs', () => {
 
     await recalculatePurchaseOrderLineRollup('org_1', PO_LINE, PURCHASE_ORDER_LINE_ROLLUPS.received)
 
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+})
+
+describe('the order-level status pass', () => {
+  it('runs after a receipt roll-up, and declares the evidence as a receipt', async () => {
+    h.dbResults.push([{ total: '3' }])
+
+    await recalculatePurchaseOrderLineReceived(
+      event({ stock_movement_purchase_order_line: PO_LINE })
+    )
+
+    expect(h.recalculatePurchaseOrderStatuses).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+  })
+
+  it('declares BILLING evidence for a bill line — a bill must never pull an order forward', async () => {
+    h.dbResults.push([{ total: '3' }])
+
+    await recalculatePurchaseOrderLineBilled(
+      event(
+        { vendor_bill_line_purchase_order_line: PO_LINE },
+        { entitySlug: 'vendor-bill-lines', entityInstanceId: 'vbl-1' }
+      )
+    )
+
+    expect(h.recalculatePurchaseOrderStatuses).toHaveBeenCalledWith(
+      expect.objectContaining({ evidence: 'billing' })
+    )
+  })
+
+  it('runs only AFTER the line quantity has been written', async () => {
+    const callOrder: string[] = []
+    h.setValueWithType.mockImplementation(async () => {
+      callOrder.push('line-write')
+      return []
+    })
+    h.recalculatePurchaseOrderStatuses.mockImplementation(async () => {
+      callOrder.push('status-pass')
+      return ok({})
+    })
+    h.dbResults.push([{ total: '3' }])
+
+    await recalculatePurchaseOrderLineReceived(
+      event({ stock_movement_purchase_order_line: PO_LINE })
+    )
+
+    expect(callOrder).toEqual(['line-write', 'status-pass'])
+  })
+
+  it('does not run when no purchase order line could be resolved', async () => {
+    h.dbResults.push([])
+
+    await recalculatePurchaseOrderLineReceived(event({}))
+
+    expect(h.recalculatePurchaseOrderStatuses).not.toHaveBeenCalled()
+  })
+
+  it('swallows a status failure — the quantity is committed and must not be taken down with it', async () => {
+    h.dbResults.push([{ total: '3' }])
+    h.recalculatePurchaseOrderStatuses.mockResolvedValue(err(new AuxxError('boom')))
+
+    await expect(
+      recalculatePurchaseOrderLineReceived(event({ stock_movement_purchase_order_line: PO_LINE }))
+    ).resolves.toBeUndefined()
+
+    expect(h.setValueWithType).toHaveBeenCalled()
+  })
+})
+
+describe('the stored total is read in the same statement as the SUM', () => {
+  it('writes nothing and derives nothing when the line already holds the total', async () => {
+    // The second short-circuit. Writing the same number back is not free: it
+    // fires the field-hook chain, a realtime publish, and the whole order-level
+    // derivation behind it.
+    h.dbResults.push([{ total: '17', current: 17 }])
+
+    await recalculatePurchaseOrderLineReceived(
+      event({ stock_movement_purchase_order_line: PO_LINE })
+    )
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
+    expect(h.recalculatePurchaseOrderStatuses).not.toHaveBeenCalled()
+  })
+
+  it('🛑 writes when the stored total could not be read — never the other way round', async () => {
+    // Fail SAFE. An unreadable stored total falls through to the write the old
+    // unconditional path always did. The opposite bias would leave a purchase
+    // order holding a stale quantity with nothing thrown.
+    h.dbResults.push([{ total: '17', current: null }])
+
+    await recalculatePurchaseOrderLineReceived(
+      event({ stock_movement_purchase_order_line: PO_LINE })
+    )
+
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ value: { type: 'number', value: 17 } })
+    )
+    expect(h.recalculatePurchaseOrderStatuses).toHaveBeenCalled()
+  })
+
+  it('writes when a stored total of zero differs from the new one', async () => {
+    // `0` is falsy and a stored zero is a real answer, not an absent one.
+    h.dbResults.push([{ total: '3', current: 0 }])
+
+    await recalculatePurchaseOrderLineReceived(
+      event({ stock_movement_purchase_order_line: PO_LINE })
+    )
+
+    expect(h.setValueWithType).toHaveBeenCalled()
+  })
+
+  it('does not write a zero back over a stored zero when the last movement goes', async () => {
+    h.dbResults.push([{ total: '0', current: 0 }])
+
+    await recalculatePurchaseOrderLineReceived(
+      event({ stock_movement_purchase_order_line: PO_LINE }, { action: 'deleted' })
+    )
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+})
+
+describe('the batched roll-up', () => {
+  const LINES = ['pol_1', 'pol_2', 'pol_3']
+
+  /** The two reads the batch makes: the grouped SUM, then the stored totals. */
+  function queueBatchReads(
+    totals: Array<[string, number]>,
+    stored: Array<[string, number | null]>
+  ) {
+    h.dbResults.push(
+      totals.map(([lineId, total]) => ({ lineId, total: String(total) })),
+      stored.map(([entityId, valueNumber]) => ({ entityId, valueNumber }))
+    )
+  }
+
+  it('reads every line in TWO queries, not two per line', async () => {
+    const before = h.dbResults.length
+    queueBatchReads(
+      LINES.map((id, i) => [id, i + 1] as [string, number]),
+      []
+    )
+    expect(h.dbResults.length - before).toBe(2)
+
+    await recalculatePurchaseOrderLineRollups('org_1', LINES, PURCHASE_ORDER_LINE_ROLLUPS.received)
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(3)
+  })
+
+  it('writes only the lines whose total actually moved', async () => {
+    queueBatchReads(
+      [
+        ['pol_1', 5],
+        ['pol_2', 9],
+        ['pol_3', 2],
+      ],
+      [
+        ['pol_1', 5],
+        ['pol_2', 4],
+        ['pol_3', 2],
+      ]
+    )
+
+    await recalculatePurchaseOrderLineRollups('org_1', LINES, PURCHASE_ORDER_LINE_ROLLUPS.received)
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ recordId: 'poldef:pol_2', value: { type: 'number', value: 9 } })
+    )
+  })
+
+  it('reads a line with no child rows as zero rather than dropping it', async () => {
+    queueBatchReads([['pol_1', 5]], [['pol_2', 3]])
+
+    await recalculatePurchaseOrderLineRollups('org_1', LINES, PURCHASE_ORDER_LINE_ROLLUPS.received)
+
+    // pol_1 moves to 5; pol_2 falls back to 0; pol_3 has neither a total nor a
+    // stored value, and an unreadable stored value always writes.
+    expect(h.setValueWithType).toHaveBeenCalledTimes(3)
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ recordId: 'poldef:pol_2', value: { type: 'number', value: 0 } })
+    )
+  })
+
+  it('derives the order ONCE for the whole set, naming only the lines that moved', async () => {
+    queueBatchReads(
+      [
+        ['pol_1', 5],
+        ['pol_2', 9],
+      ],
+      [['pol_1', 5]]
+    )
+
+    await recalculatePurchaseOrderLineRollups('org_1', LINES, PURCHASE_ORDER_LINE_ROLLUPS.received)
+
+    expect(h.recalculatePurchaseOrderStatusesForLines).toHaveBeenCalledTimes(1)
+    expect(h.recalculatePurchaseOrderStatusesForLines).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      purchaseOrderLineInstanceIds: ['pol_2', 'pol_3'],
+      evidence: 'receipt',
+    })
+    // And never the per-line entry point, which is what the ten-fold was.
+    expect(h.recalculatePurchaseOrderStatuses).not.toHaveBeenCalled()
+  })
+
+  it('derives nothing when no line moved', async () => {
+    queueBatchReads(
+      [
+        ['pol_1', 5],
+        ['pol_2', 9],
+        ['pol_3', 1],
+      ],
+      [
+        ['pol_1', 5],
+        ['pol_2', 9],
+        ['pol_3', 1],
+      ]
+    )
+
+    await recalculatePurchaseOrderLineRollups('org_1', LINES, PURCHASE_ORDER_LINE_ROLLUPS.received)
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.recalculatePurchaseOrderStatusesForLines).not.toHaveBeenCalled()
+  })
+
+  it('publishes every changed line in ONE realtime call', async () => {
+    queueBatchReads(
+      [
+        ['pol_1', 5],
+        ['pol_2', 9],
+      ],
+      []
+    )
+
+    await recalculatePurchaseOrderLineRollups('org_1', LINES, PURCHASE_ORDER_LINE_ROLLUPS.received)
+
+    expect(h.publishFieldValueUpdates).toHaveBeenCalledTimes(1)
+    expect(h.publishFieldValueUpdates.mock.calls[0]?.[2]).toHaveLength(3)
+  })
+
+  it('dedupes a line that appears twice in the set', async () => {
+    h.dbResults.push([{ total: '8', current: null }])
+
+    await recalculatePurchaseOrderLineRollups(
+      'org_1',
+      [PO_LINE, PO_LINE],
+      PURCHASE_ORDER_LINE_ROLLUPS.received
+    )
+
+    // One line means the single-line path, which is one query rather than two.
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a no-op for an empty set', async () => {
+    await recalculatePurchaseOrderLineRollups('org_1', [], PURCHASE_ORDER_LINE_ROLLUPS.received)
     expect(h.setValueWithType).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/field-hooks/post/purchase-order-line-rollups.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-line-rollups.ts
@@ -6,12 +6,21 @@ import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, inArray, type SQL, sql } from 'drizzle-orm'
 import { getOrgCache, requireCachedEntityDefId } from '../../cache'
 import { createFieldValueContext } from '../../field-values/field-value-helpers'
 import { setValueWithType } from '../../field-values/field-value-mutations'
-import { toFieldType } from '../../field-values/stored-field-type'
-import { getRealtimeService, publishFieldValueUpdates } from '../../realtime'
+import { type StoredFieldType, toFieldType } from '../../field-values/stored-field-type'
+import {
+  type PurchaseOrderStatusEvidence,
+  recalculatePurchaseOrderStatuses,
+  recalculatePurchaseOrderStatusesForLines,
+} from '../../purchasing/purchase-order-status-writer'
+import {
+  type FieldValueUpdateEntry,
+  getRealtimeService,
+  publishFieldValueUpdates,
+} from '../../realtime'
 import type { EntityTriggerHandler } from '../types'
 
 const logger = createScopedLogger('field-hooks:purchase-order-line-rollups')
@@ -24,6 +33,20 @@ const logger = createScopedLogger('field-hooks:purchase-order-line-rollups')
  * They are re-SUMMED whole rather than incremented, for the same reason
  * `part_quantity_on_hand` is: the subledger is the truth and a hand-maintained
  * copy of it diverges silently.
+ *
+ * ✅ The ORDER-level `purchase_order_receipt_status` / `_billing_status` ride the
+ * same pass (plans/purchasing/07-purchase-order-send-and-status.md §3.3): the
+ * verdict is this computation one level up, so it is a call at the end of
+ * `recalculatePurchaseOrderLineRollup` rather than a second trigger.
+ *
+ * ⚡ The SUM reads the line's CURRENT stored total in the same statement, and an
+ * unchanged total short-circuits the write, the realtime publish AND the
+ * order-level pass. That short-circuit is what makes a batched receipt cheap
+ * (see {@link recalculatePurchaseOrderLineRollups}): the batch writes the
+ * quantities first, so the per-movement lifecycle rules that follow find their
+ * line already correct and do nothing. Getting there first is the whole
+ * mechanism — there is no suppression flag to leak, and a batch that never runs
+ * simply leaves the per-movement passes to do the work exactly as before.
  *
  * ⚠️ Both run POST-COMMIT, off the lifecycle record rules — never inside the
  * caller's transaction. Like `recalculatePartQoH`, the SUM below runs against the
@@ -40,6 +63,15 @@ interface RollupSpec {
   lineRelAttr: SystemAttribute
   /** The purchase order line field the SUM is written to. */
   targetAttr: SystemAttribute
+  /**
+   * What kind of evidence this roll-up carries, for the order-level pass.
+   *
+   * Declared rather than inferred from `targetAttr`: only RECEIPT evidence may
+   * pull a `draft` order forward to `issued`, and a string comparison at the
+   * call site is one careless edit away from letting a bill do it. See
+   * {@link recalculatePurchaseOrderStatuses}.
+   */
+  evidence: PurchaseOrderStatusEvidence
 }
 
 /** Receipts: SUM(`stock_movement_quantity`) over the movements pointing at the line. */
@@ -48,6 +80,7 @@ const RECEIVED_ROLLUP: RollupSpec = {
   quantityAttr: 'stock_movement_quantity',
   lineRelAttr: 'stock_movement_purchase_order_line',
   targetAttr: 'purchase_order_line_quantity_received',
+  evidence: 'receipt',
 }
 
 /** Bills: SUM(`vendor_bill_line_quantity_billed`) over the bill lines pointing at the line. */
@@ -56,19 +89,21 @@ const BILLED_ROLLUP: RollupSpec = {
   quantityAttr: 'vendor_bill_line_quantity_billed',
   lineRelAttr: 'vendor_bill_line_purchase_order_line',
   targetAttr: 'purchase_order_line_quantity_billed',
+  evidence: 'billing',
 }
 
-/**
- * Re-SUM one roll-up for one purchase order line and write the result.
- *
- * Exported so a writer that needs the roll-up to reflect its own transaction can
- * call it explicitly after `COMMIT` rather than waiting for the lifecycle rule.
- */
-export async function recalculatePurchaseOrderLineRollup(
+/** The three fields one roll-up needs, or `undefined` when the org lacks one. */
+interface RollupFields {
+  quantityFieldId: string
+  lineRelFieldId: string
+  targetFieldId: string
+  targetFieldType: StoredFieldType
+}
+
+async function resolveRollupFields(
   organizationId: string,
-  purchaseOrderLineInstanceId: string,
   spec: RollupSpec
-): Promise<void> {
+): Promise<RollupFields | undefined> {
   const fields = await getOrgCache()
     .from(organizationId, 'customFields')
     .bySystemAttributes<SystemAttribute>([spec.quantityAttr, spec.lineRelAttr, spec.targetAttr])
@@ -84,58 +119,302 @@ export async function recalculatePurchaseOrderLineRollup(
       lineRelField: !!lineRelField,
       targetField: !!targetField,
     })
-    return
+    return undefined
   }
 
+  return {
+    quantityFieldId: quantityField.id,
+    lineRelFieldId: lineRelField.id,
+    targetFieldId: targetField.id,
+    targetFieldType: targetField.type,
+  }
+}
+
+/**
+ * Re-SUM one roll-up for one purchase order line and write the result.
+ *
+ * Exported so a writer that needs the roll-up to reflect its own transaction can
+ * call it explicitly after `COMMIT` rather than waiting for the lifecycle rule.
+ *
+ * ⚡ Reads the stored total in the same statement as the SUM and returns early
+ * when they agree. A no-op write here is not free: it fires the whole field-hook
+ * chain, a realtime publish, and the order-level status pass behind it.
+ */
+export async function recalculatePurchaseOrderLineRollup(
+  organizationId: string,
+  purchaseOrderLineInstanceId: string,
+  spec: RollupSpec
+): Promise<void> {
+  const fields = await resolveRollupFields(organizationId, spec)
+  if (!fields) return
+
   // Single self-join, the `recalculateQoHForPart` shape: SUM the child's quantity
-  // where the child's line relationship points at this line.
+  // where the child's line relationship points at this line. The line's CURRENT
+  // stored total rides along as an uncorrelated scalar subquery — it costs one
+  // index lookup inside a statement that was already being issued, where reading
+  // it separately would cost a whole round trip.
   const [sumRow] = await database
-    .select({ total: sql<string>`COALESCE(SUM(${schema.FieldValue.valueNumber}), 0)` })
+    .select({
+      total: sql<string>`COALESCE(SUM(${schema.FieldValue.valueNumber}), 0)`,
+      current: storedTotalSql(organizationId, purchaseOrderLineInstanceId, fields.targetFieldId),
+    })
     .from(schema.FieldValue)
     .innerJoin(
       sql`"FieldValue" fv_line`,
       sql`${schema.FieldValue.entityId} = fv_line."entityId"
-        AND fv_line."fieldId" = ${lineRelField.id}
+        AND fv_line."fieldId" = ${fields.lineRelFieldId}
         AND fv_line."relatedEntityId" = ${purchaseOrderLineInstanceId}
         AND fv_line."organizationId" = ${organizationId}`
     )
     .where(
       and(
-        eq(schema.FieldValue.fieldId, quantityField.id),
+        eq(schema.FieldValue.fieldId, fields.quantityFieldId),
         eq(schema.FieldValue.organizationId, organizationId)
       )
     )
 
   const total = Number(sumRow?.total ?? 0)
+  const stored = sumRow?.current
+
+  // 🛑 Fail SAFE: only a value we actually read and that actually matches skips
+  // the write. An absent or unreadable stored total falls through and writes,
+  // which is what the old unconditional write did every time.
+  if (stored != null && Number(stored) === total) {
+    logger.debug('Purchase order line roll-up unchanged — nothing written', {
+      purchaseOrderLineInstanceId,
+      target: spec.targetAttr,
+      total,
+    })
+    return
+  }
 
   const lineDefId = await requireCachedEntityDefId(organizationId, 'purchase_order_line')
   const recordId = toRecordId(lineDefId, purchaseOrderLineInstanceId) as RecordId
 
   await setValueWithType(createFieldValueContext(organizationId), {
     recordId,
-    fieldId: targetField.id,
-    fieldType: toFieldType(targetField.type),
+    fieldId: fields.targetFieldId,
+    fieldType: toFieldType(fields.targetFieldType),
     value: { type: 'number', value: total },
   })
 
-  publishFieldValueUpdates(getRealtimeService(), organizationId, [
-    {
-      key: buildFieldValueKey(recordId, targetField.id as FieldId),
-      value: { type: 'number', value: total },
-    },
-  ]).catch((err) => {
-    logger.error('Failed to publish purchase order line roll-up', {
-      purchaseOrderLineInstanceId,
-      target: spec.targetAttr,
-      error: err instanceof Error ? err.message : String(err),
-    })
-  })
+  publishRollupValues(organizationId, [{ recordId, fieldId: fields.targetFieldId, total }]).catch(
+    (err) => {
+      logger.error('Failed to publish purchase order line roll-up', {
+        purchaseOrderLineInstanceId,
+        target: spec.targetAttr,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  )
 
   logger.info('Purchase order line roll-up recalculated', {
     purchaseOrderLineInstanceId,
     target: spec.targetAttr,
     total,
   })
+
+  // The order-level verdict is this same computation one level up, on the same
+  // trigger and with no new query of the subledger. It runs AFTER the line write
+  // above has been awaited, so its read of the lines includes the total just
+  // written — the reason it is a call here rather than a second trigger.
+  //
+  // A failure is logged and swallowed: the quantity is the primary fact and is
+  // already committed, and a derived status that could not be computed must not
+  // take it down with it.
+  const statuses = await recalculatePurchaseOrderStatuses({
+    organizationId,
+    purchaseOrderLineInstanceId,
+    evidence: spec.evidence,
+  })
+  if (statuses.isErr()) {
+    logger.error('Failed to derive purchase order statuses after line roll-up', {
+      purchaseOrderLineInstanceId,
+      target: spec.targetAttr,
+      error: statuses.error.message,
+    })
+  }
+}
+
+/**
+ * The same roll-up for a SET of purchase order lines, in two queries and one
+ * order-level pass per distinct order.
+ *
+ * 🛑 Why this exists. The per-line function above is chained off a lifecycle
+ * rule that fires once per child row, so a ten-line purchase order receipt used
+ * to run it ten times: ten SUMs, ten writes, and ten full order-level passes
+ * over the same order. This reads all ten lines' SUMs in ONE grouped query,
+ * writes only the ones that moved, and derives the order ONCE.
+ *
+ * ⚠️ It does not suppress anything. The per-movement rules still fire
+ * afterwards; they simply find each line's total already correct and return
+ * before writing (see {@link recalculatePurchaseOrderLineRollup}). That is
+ * deliberate: a flag that failed to be set would be a purchase order left with a
+ * stale `receipt_status`, whereas a batch that fails to run just leaves the old,
+ * slower path to produce exactly the same answer.
+ *
+ * ⚠️ POST-COMMIT only, like everything in this module: the SUM runs on the
+ * module-level `database` connection and cannot see a caller's open transaction.
+ */
+export async function recalculatePurchaseOrderLineRollups(
+  organizationId: string,
+  purchaseOrderLineInstanceIds: string[],
+  spec: RollupSpec
+): Promise<void> {
+  const lineIds = [...new Set(purchaseOrderLineInstanceIds)].filter(Boolean)
+  if (lineIds.length === 0) return
+  if (lineIds.length === 1) {
+    await recalculatePurchaseOrderLineRollup(organizationId, lineIds[0]!, spec)
+    return
+  }
+
+  const fields = await resolveRollupFields(organizationId, spec)
+  if (!fields) return
+
+  const [totals, stored] = await Promise.all([
+    readTotalsByLine(organizationId, lineIds, fields),
+    readStoredTotals(organizationId, lineIds, fields.targetFieldId),
+  ])
+
+  const lineDefId = await requireCachedEntityDefId(organizationId, 'purchase_order_line')
+  const ctx = createFieldValueContext(organizationId)
+  const changed: string[] = []
+  const published: Array<{ recordId: RecordId; fieldId: string; total: number }> = []
+
+  for (const lineId of lineIds) {
+    // A line with no child rows sums to zero, exactly as the per-line SUM does.
+    const total = totals.get(lineId) ?? 0
+    const current = stored.get(lineId)
+    if (current != null && current === total) continue
+
+    const recordId = toRecordId(lineDefId, lineId) as RecordId
+    await setValueWithType(ctx, {
+      recordId,
+      fieldId: fields.targetFieldId,
+      fieldType: toFieldType(fields.targetFieldType),
+      value: { type: 'number', value: total },
+    })
+    changed.push(lineId)
+    published.push({ recordId, fieldId: fields.targetFieldId, total })
+  }
+
+  if (changed.length === 0) return
+
+  publishRollupValues(organizationId, published).catch((err) => {
+    logger.error('Failed to publish batched purchase order line roll-up', {
+      target: spec.targetAttr,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  })
+
+  logger.info('Purchase order line roll-ups recalculated in batch', {
+    target: spec.targetAttr,
+    lineCount: lineIds.length,
+    changedCount: changed.length,
+  })
+
+  const statuses = await recalculatePurchaseOrderStatusesForLines({
+    organizationId,
+    purchaseOrderLineInstanceIds: changed,
+    evidence: spec.evidence,
+  })
+  if (statuses.isErr()) {
+    logger.error('Failed to derive purchase order statuses after batched line roll-up', {
+      target: spec.targetAttr,
+      error: statuses.error.message,
+    })
+  }
+}
+
+/** The line's stored roll-up total, as an uncorrelated scalar subquery. */
+function storedTotalSql(
+  organizationId: string,
+  purchaseOrderLineInstanceId: string,
+  targetFieldId: string
+): SQL<number | null> {
+  return sql<number | null>`(SELECT fv_target."valueNumber" FROM "FieldValue" fv_target
+    WHERE fv_target."entityId" = ${purchaseOrderLineInstanceId}
+      AND fv_target."fieldId" = ${targetFieldId}
+      AND fv_target."organizationId" = ${organizationId}
+    LIMIT 1)`
+}
+
+/**
+ * SUM the child quantities for every line in the set, grouped by line. One
+ * statement for the whole set — a line with no children is simply absent from
+ * the result and reads as zero at the call site.
+ */
+async function readTotalsByLine(
+  organizationId: string,
+  lineIds: string[],
+  fields: RollupFields
+): Promise<Map<string, number>> {
+  const idList = sql.join(
+    lineIds.map((id) => sql`${id}`),
+    sql`, `
+  )
+
+  const rows = await database
+    .select({
+      lineId: sql<string>`fv_line."relatedEntityId"`,
+      total: sql<string>`COALESCE(SUM(${schema.FieldValue.valueNumber}), 0)`,
+    })
+    .from(schema.FieldValue)
+    .innerJoin(
+      sql`"FieldValue" fv_line`,
+      sql`${schema.FieldValue.entityId} = fv_line."entityId"
+        AND fv_line."fieldId" = ${fields.lineRelFieldId}
+        AND fv_line."relatedEntityId" IN (${idList})
+        AND fv_line."organizationId" = ${organizationId}`
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.fieldId, fields.quantityFieldId),
+        eq(schema.FieldValue.organizationId, organizationId)
+      )
+    )
+    .groupBy(sql`fv_line."relatedEntityId"`)
+
+  return new Map(rows.map((row) => [row.lineId, Number(row.total ?? 0)]))
+}
+
+/** The stored roll-up total of every line in the set, keyed by line. */
+async function readStoredTotals(
+  organizationId: string,
+  lineIds: string[],
+  targetFieldId: string
+): Promise<Map<string, number>> {
+  const rows = await database
+    .select({
+      entityId: schema.FieldValue.entityId,
+      valueNumber: schema.FieldValue.valueNumber,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        inArray(schema.FieldValue.entityId, lineIds),
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, targetFieldId)
+      )
+    )
+
+  const stored = new Map<string, number>()
+  for (const row of rows) {
+    if (row.valueNumber != null) stored.set(row.entityId, Number(row.valueNumber))
+  }
+  return stored
+}
+
+/** One realtime publish for however many roll-up values just landed. */
+function publishRollupValues(
+  organizationId: string,
+  values: Array<{ recordId: RecordId; fieldId: string; total: number }>
+): Promise<unknown> {
+  const entries: FieldValueUpdateEntry[] = values.map((value) => ({
+    key: buildFieldValueKey(value.recordId, value.fieldId as FieldId),
+    value: { type: 'number', value: value.total },
+  }))
+  return publishFieldValueUpdates(getRealtimeService(), organizationId, entries)
 }
 
 /**

--- a/packages/lib/src/field-hooks/pre/purchase-order-line-evidence-lock.test.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-line-evidence-lock.test.ts
@@ -1,0 +1,200 @@
+// packages/lib/src/field-hooks/pre/purchase-order-line-evidence-lock.test.ts
+//
+// §6.5 of plans/purchasing/07-purchase-order-send-and-status.md rejects the obvious rule
+// ("lock when issued") in both directions, so the thing worth pinning is that the predicate
+// is EVIDENCE and status never enters it: a draft line with a receipt locks, and an issued
+// line with nothing booked against it does not.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FieldPreHookEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  /** Result sets, in call order: evidence probe, then the stored-value read. */
+  dbResults: [] as unknown[][],
+}))
+
+function makeChain() {
+  const result = h.dbResults.shift() ?? []
+  const chain: Record<string, unknown> = {}
+  for (const key of ['from', 'innerJoin', 'leftJoin', 'where', 'limit']) {
+    chain[key] = () => chain
+  }
+  // biome-ignore lint/suspicious/noThenProperty: chainable drizzle query-builder stub
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve)
+  return chain
+}
+
+vi.mock('@auxx/database', () => ({
+  database: { select: () => makeChain(), selectDistinct: () => makeChain() },
+  schema: {
+    FieldValue: {
+      entityId: 'entityId',
+      organizationId: 'organizationId',
+      fieldId: 'fieldId',
+      valueNumber: 'valueNumber',
+      relatedEntityId: 'relatedEntityId',
+    },
+  },
+}))
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+
+const { guardEvidenceLockedLineFields } = await import('./purchase-order-line-evidence-lock')
+const { ConflictError } = await import('../../errors')
+
+const MOVEMENT_REL = 'f-movement-rel'
+const BILL_LINE_REL = 'f-bill-line-rel'
+const QTY_FIELD = 'f-qty'
+
+/** Which evidence rows the probe finds. */
+function wireEvidence(kinds: Array<'receipt' | 'bill'>) {
+  h.bySystemAttributes.mockResolvedValue({
+    stock_movement_purchase_order_line: { id: MOVEMENT_REL },
+    vendor_bill_line_purchase_order_line: { id: BILL_LINE_REL },
+  })
+  h.dbResults = [
+    kinds.map((kind) => ({ fieldId: kind === 'receipt' ? MOVEMENT_REL : BILL_LINE_REL })),
+  ]
+}
+
+/** The value currently stored on the line for the field under edit. */
+function wireStored(valueNumber: number | null) {
+  h.dbResults.push(valueNumber === null ? [] : [{ valueNumber }])
+}
+
+function event(overrides: Record<string, unknown> = {}) {
+  return {
+    recordId: 'def-purchase_order_line:poline-1',
+    entityDefinitionId: 'def-purchase_order_line',
+    entityType: 'purchase_order_line',
+    entitySlug: 'purchase-order-lines',
+    fieldId: QTY_FIELD,
+    systemAttribute: 'purchase_order_line_quantity_ordered',
+    field: { id: QTY_FIELD },
+    newValue: { type: 'number', value: 9 },
+    existingValue: undefined,
+    allValues: new Map(),
+    organizationId: 'org-1',
+    userId: 'user-1',
+    bypass: new Set(),
+    ...overrides,
+  } as unknown as FieldPreHookEvent
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.dbResults = []
+})
+
+describe('evidence lock — what blocks an edit', () => {
+  it('locks quantity_ordered once a receipt exists', async () => {
+    wireEvidence(['receipt'])
+    wireStored(4)
+    await expect(guardEvidenceLockedLineFields(event())).rejects.toThrow(ConflictError)
+  })
+
+  it('locks expected_unit_price once a vendor bill line exists', async () => {
+    wireEvidence(['bill'])
+    wireStored(1250)
+    await expect(
+      guardEvidenceLockedLineFields(
+        event({
+          systemAttribute: 'purchase_order_line_expected_unit_price',
+          newValue: { type: 'number', value: 20000 },
+        })
+      )
+    ).rejects.toThrow(ConflictError)
+  })
+
+  // ✅ "Editing lines nothing has happened to stays open at any status" — the half of §6.5
+  // that a status predicate would have got wrong.
+  it('leaves a line with neither a receipt nor a bill line open', async () => {
+    wireEvidence([])
+    const next = { type: 'number', value: 9 }
+    await expect(guardEvidenceLockedLineFields(event({ newValue: next }))).resolves.toBe(next)
+  })
+
+  // A brand-new line has nothing pointing at it, so adding lines to a booked order is never
+  // blocked — the evidence probe simply comes back empty.
+  it('never blocks a line that has no evidence, whatever the order status', async () => {
+    wireEvidence([])
+    await expect(guardEvidenceLockedLineFields(event())).resolves.toBeDefined()
+    // The probe answered the whole question — no second query was needed.
+    expect(h.dbResults).toHaveLength(0)
+  })
+
+  it('names both when a receipt and a bill both exist', async () => {
+    wireEvidence(['receipt', 'bill'])
+    wireStored(4)
+    await expect(guardEvidenceLockedLineFields(event())).rejects.toThrow(
+      /a receipt and a vendor bill/
+    )
+  })
+
+  it('names only the receipt when only a receipt exists', async () => {
+    wireEvidence(['receipt'])
+    wireStored(4)
+    await expect(guardEvidenceLockedLineFields(event())).rejects.toThrow(
+      /a receipt has already been booked/
+    )
+  })
+
+  it('names the field being edited, so the message is actionable', async () => {
+    wireEvidence(['bill'])
+    wireStored(1250)
+    await expect(
+      guardEvidenceLockedLineFields(
+        event({
+          systemAttribute: 'purchase_order_line_expected_unit_price',
+          newValue: { type: 'number', value: 20000 },
+        })
+      )
+    ).rejects.toThrow(/expected unit price/)
+  })
+
+  it('blocks clearing the value, not just changing it', async () => {
+    wireEvidence(['receipt'])
+    wireStored(4)
+    await expect(guardEvidenceLockedLineFields(event({ newValue: null }))).rejects.toThrow(
+      ConflictError
+    )
+  })
+})
+
+describe('evidence lock — what it lets through', () => {
+  // A re-import, or any surface that submits a whole line rather than a patch, restates
+  // these fields unchanged. Refusing that would block edits to the line's description.
+  it('allows a write that restates the stored value unchanged', async () => {
+    wireEvidence(['receipt', 'bill'])
+    wireStored(9)
+    const next = { type: 'number', value: 9 }
+    await expect(guardEvidenceLockedLineFields(event({ newValue: next }))).resolves.toBe(next)
+  })
+
+  it('treats a bare scalar and a typed envelope as the same value', async () => {
+    wireEvidence(['receipt'])
+    wireStored(9)
+    await expect(guardEvidenceLockedLineFields(event({ newValue: 9 }))).resolves.toBe(9)
+  })
+
+  it('unwraps a single-element array before comparing', async () => {
+    wireEvidence(['receipt'])
+    wireStored(9)
+    const next = [{ type: 'number', value: 9 }]
+    await expect(guardEvidenceLockedLineFields(event({ newValue: next }))).resolves.toBe(next)
+  })
+
+  // Purchasing may not be provisioned — no relationship fields means no evidence to find,
+  // and the guard must not become an outage.
+  it('is inert when the evidence relationship fields do not exist', async () => {
+    h.bySystemAttributes.mockResolvedValue({})
+    const next = { type: 'number', value: 9 }
+    await expect(guardEvidenceLockedLineFields(event({ newValue: next }))).resolves.toBe(next)
+  })
+})
+
+// Registration lives in `field-hooks/__tests__/purchase-order-line-evidence-lock-registration.test.ts`
+// — asserting it needs the real `@auxx/database` module graph that `register-hooks.ts` pulls
+// in, which this file's narrow schema stub cannot satisfy.

--- a/packages/lib/src/field-hooks/pre/purchase-order-line-evidence-lock.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-line-evidence-lock.ts
@@ -1,0 +1,158 @@
+// packages/lib/src/field-hooks/pre/purchase-order-line-evidence-lock.ts
+
+import { database, schema } from '@auxx/database'
+import { parseRecordId } from '@auxx/types/resource'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getOrgCache } from '../../cache'
+import { ConflictError } from '../../errors'
+import type { FieldPreHookHandler } from '../types'
+
+/**
+ * The two `purchase_order_line` fields this lock protects. Both are the agreed terms of the
+ * order, and both are read by machinery that has already acted on them.
+ */
+export const EVIDENCE_LOCKED_LINE_ATTRS = [
+  'purchase_order_line_quantity_ordered',
+  'purchase_order_line_expected_unit_price',
+] as const
+
+/** The two links that constitute evidence something has happened against a line. */
+const EVIDENCE_ATTRS = [
+  'stock_movement_purchase_order_line',
+  'vendor_bill_line_purchase_order_line',
+] as const
+
+/** Unwrap a pre-hook value to its scalar — arrays and typed envelopes both flatten. */
+function scalarOf(value: unknown): unknown {
+  if (Array.isArray(value)) return scalarOf(value[0])
+  if (value && typeof value === 'object') {
+    if ('value' in value) return (value as { value: unknown }).value
+    if ('recordId' in value) return (value as { recordId: unknown }).recordId
+  }
+  return value
+}
+
+/** What has already happened against a line, in one query. */
+async function readEvidence(
+  organizationId: string,
+  lineInstanceId: string
+): Promise<{ hasReceipt: boolean; hasBillLine: boolean }> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...EVIDENCE_ATTRS])
+
+  const movementRelField = cf.stock_movement_purchase_order_line
+  const billLineRelField = cf.vendor_bill_line_purchase_order_line
+  const fieldIds = [movementRelField?.id, billLineRelField?.id].filter((id): id is string => !!id)
+  if (fieldIds.length === 0) return { hasReceipt: false, hasBillLine: false }
+
+  const rows = await database
+    .selectDistinct({ fieldId: schema.FieldValue.fieldId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.fieldId, fieldIds),
+        eq(schema.FieldValue.relatedEntityId, lineInstanceId)
+      )
+    )
+
+  const seen = new Set(rows.map((row) => row.fieldId))
+  return {
+    hasReceipt: !!movementRelField && seen.has(movementRelField.id),
+    hasBillLine: !!billLineRelField && seen.has(billLineRelField.id),
+  }
+}
+
+/** The line's currently stored number for this field, or `null` when it has none. */
+async function readStoredNumber(
+  organizationId: string,
+  lineInstanceId: string,
+  fieldId: string
+): Promise<number | null> {
+  const [row] = await database
+    .select({ valueNumber: schema.FieldValue.valueNumber })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, lineInstanceId),
+        eq(schema.FieldValue.fieldId, fieldId)
+      )
+    )
+    .limit(1)
+  return row?.valueNumber ?? null
+}
+
+/** Name what is blocking the edit, so the message says what to do about it. */
+function describeEvidence(evidence: { hasReceipt: boolean; hasBillLine: boolean }): string {
+  if (evidence.hasReceipt && evidence.hasBillLine) return 'a receipt and a vendor bill'
+  if (evidence.hasReceipt) return 'a receipt'
+  return 'a vendor bill'
+}
+
+/**
+ * Lock a purchase order line's `quantity_ordered` and `expected_unit_price` once something
+ * has happened against it (plans/purchasing/07-purchase-order-send-and-status.md §6.5).
+ *
+ * 🛑 **The predicate is EVIDENCE, not status.** The obvious rule — read-only once the order
+ * is `issued` — is wrong in both directions. It is too strict, because real orders get
+ * amended when a vendor discontinues a part, and if the only way to change an issued order
+ * is delete-and-recreate then the receipts and the audit trail go with it. And it is too
+ * loose, because §6.1 lets a `draft` order carry receipts (a vendor ships against a phone
+ * call and the paperwork is keyed afterwards) and that order is genuinely unsafe to edit,
+ * while an `issued` order nobody has shipped against is perfectly safe. So the lock keys off
+ * `purchase_order_line_stock_movements` and `purchase_order_line_vendor_bill_lines` instead.
+ * Adding new lines, and editing lines nothing has happened to, stays open at any status.
+ *
+ * The two concrete corruptions this prevents:
+ *
+ * 1. 🛑 **Editing `expected_unit_price` after a bill exists silently re-points the three-way
+ *    match at a number the vendor never agreed to.** `match-hook.ts` compares the arriving
+ *    bill line against exactly this field, so moving it moves the authority the control is
+ *    checking against — the control then passes by definition. Same class as the defect where
+ *    a receipt was written at a price nobody agreed to: the match reading the wrong authority,
+ *    with nothing thrown.
+ * 2. **Editing `quantity_ordered` after receipts exist makes the derived receipt status
+ *    jump**, possibly backwards from `received` to `partially_received`, because that status
+ *    is `quantity_received` measured against this number.
+ *
+ * ⚠️ **The proper answer to "the PDF the vendor holds no longer matches" is REVISIONS** —
+ * amend, re-send, increment a revision number. `DocumentActionsCluster` already renders
+ * Send/Resend, so re-sending costs nothing; version tracking is a real feature and is out of
+ * scope. This lock is the interim, not the destination.
+ *
+ * ✅ **A write that does not change the value is allowed through.** A re-import of the same
+ * row, or any surface that submits a whole line rather than a patch, restates these fields
+ * unchanged — refusing that would block edits to the line's description or weight, which the
+ * lock has no opinion about, and would make an idempotent import fail on its second run.
+ *
+ * ✅ **Sanctioned writers use `bypassFieldGuards`.** `fireFieldPreHooks` short-circuits on
+ * `ctx.bypassFieldGuards.has(systemAttribute)` before this handler is reached, so a future
+ * server-side writer of these fields opts out by naming the attribute there. As of today
+ * there is none: an audit of every reference to both attributes found only readers
+ * (`match-hook.ts`, `receive-purchase-order.ts`, `documents/payload.ts`, `totals-hooks.ts` —
+ * which writes `line_total`, not these two). Both fields are purely human input, so nothing
+ * legitimate is blocked by this guard.
+ */
+export const guardEvidenceLockedLineFields: FieldPreHookHandler = async (event) => {
+  const lineInstanceId = parseRecordId(event.recordId).entityInstanceId
+
+  // Evidence first: most lines have none, and that answers the whole question in one query.
+  const evidence = await readEvidence(event.organizationId, lineInstanceId)
+  if (!evidence.hasReceipt && !evidence.hasBillLine) return event.newValue
+
+  const next = scalarOf(event.newValue)
+  const nextNumber = next === null || next === undefined || next === '' ? null : Number(next)
+  const stored = await readStoredNumber(event.organizationId, lineInstanceId, event.fieldId)
+  if (nextNumber === stored) return event.newValue
+
+  const label =
+    event.systemAttribute === 'purchase_order_line_expected_unit_price'
+      ? 'expected unit price'
+      : 'ordered quantity'
+  throw new ConflictError(
+    `Cannot change the ${label} — ${describeEvidence(evidence)} has already been booked ` +
+      'against this line. Add a new line, or reverse what was booked, and re-send the order.'
+  )
+}

--- a/packages/lib/src/field-hooks/pre/purchase-order-status-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-status-guard.test.ts
@@ -1,0 +1,81 @@
+// packages/lib/src/field-hooks/pre/purchase-order-status-guard.test.ts
+//
+// 🛑 The bug this file exists to prevent is a guard that cannot fire. By the time
+// `fireFieldPreHooks` runs, `validateAndConvertValue` has turned a SINGLE_SELECT write into
+// `{ type: 'option', optionId: 'issued' }` — never a bare string — so a guard comparing
+// `event.newValue` to `'issued'` passes everything and is indistinguishable from a guard
+// nothing has tripped. Every rejection test below therefore feeds the COERCED shape the
+// client path actually produces, not the convenient one.
+
+import { describe, expect, it } from 'vitest'
+import { BadRequestError } from '../../errors'
+import type { FieldPreHookEvent } from '../types'
+import { guardManualPurchaseOrderIssued } from './purchase-order-status-guard'
+
+/** The shape `validateAndConvertValue` hands a SINGLE_SELECT pre-hook. */
+function coerced(optionId: string) {
+  return { type: 'option', optionId }
+}
+
+function event(newValue: unknown): FieldPreHookEvent {
+  return {
+    recordId: 'def-purchase_order:po-1',
+    entityDefinitionId: 'def-purchase_order',
+    entityType: 'purchase_order',
+    entitySlug: 'purchase-orders',
+    fieldId: 'f-status',
+    systemAttribute: 'purchase_order_status',
+    field: { id: 'f-status', systemAttribute: 'purchase_order_status' },
+    newValue,
+    existingValue: undefined,
+    allValues: new Map<string, unknown>(),
+    organizationId: 'org-1',
+    userId: 'user-1',
+    bypass: new Set(),
+  } as unknown as FieldPreHookEvent
+}
+
+describe('manual issued wall — the client-path shape', () => {
+  it('rejects the coerced option envelope a drawer edit produces', async () => {
+    await expect(guardManualPurchaseOrderIssued(event(coerced('issued')))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+
+  it('names Send, so the message says which button to press', async () => {
+    await expect(guardManualPurchaseOrderIssued(event(coerced('issued')))).rejects.toThrow(
+      'Use Send to issue this purchase order'
+    )
+  })
+
+  // A guard that only handled the envelope and not the bare string would be half-dead the
+  // moment a caller writes an already-typed value.
+  it('rejects a bare string too', async () => {
+    await expect(guardManualPurchaseOrderIssued(event('issued'))).rejects.toThrow(BadRequestError)
+  })
+
+  it('rejects a single-element array of either shape', async () => {
+    await expect(guardManualPurchaseOrderIssued(event([coerced('issued')]))).rejects.toThrow(
+      BadRequestError
+    )
+    await expect(guardManualPurchaseOrderIssued(event(['issued']))).rejects.toThrow(BadRequestError)
+  })
+})
+
+describe('manual issued wall — what stays editable', () => {
+  // §3.6: `closed` is deliberately NOT derived, because an order where the vendor
+  // short-shipped and the remainder has been forgiven must still be closeable by hand.
+  it.each(['draft', 'closed', 'canceled'])('leaves %s freely editable', async (status) => {
+    const next = coerced(status)
+    await expect(guardManualPurchaseOrderIssued(event(next))).resolves.toBe(next)
+  })
+
+  it('lets a clear through rather than treating null as a guarded value', async () => {
+    await expect(guardManualPurchaseOrderIssued(event(null))).resolves.toBeNull()
+  })
+
+  it('returns the value untouched — it is a guard, not a transform', async () => {
+    const next = coerced('draft')
+    await expect(guardManualPurchaseOrderIssued(event(next))).resolves.toBe(next)
+  })
+})

--- a/packages/lib/src/field-hooks/pre/purchase-order-status-guard.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-status-guard.ts
@@ -1,0 +1,52 @@
+// packages/lib/src/field-hooks/pre/purchase-order-status-guard.ts
+
+import { BadRequestError } from '../../errors'
+import {
+  PURCHASE_ORDER_ACTION_STATUS_MESSAGE,
+  PURCHASE_ORDER_ACTION_STATUSES,
+  unwrapStatusValue,
+} from '../../resources/hooks/lifecycle-status-guard'
+import type { FieldPreHookHandler } from '../types'
+
+/** The guarded set as a membership test, built once. */
+const GUARDED = new Set<unknown>(PURCHASE_ORDER_ACTION_STATUSES)
+
+/**
+ * The manual-`issued` wall for `purchase_order_status`, on the chain that actually runs for
+ * client writes (plans/purchasing/07-purchase-order-send-and-status.md §3.4).
+ *
+ * 🛑 **This is the enforcement point, not the system hook.** `PURCHASE_ORDER_HOOKS`
+ * (`resources/hooks/purchasing-hooks.ts`) carries the same guard, but that one runs only on
+ * `UnifiedCrudHandler.runPreHooks` — the `record.create`/`record.update` path, the CSV
+ * importer and the SDK. Every *interactive* edit of a status field goes through
+ * `fieldValue.set` -> `FieldValueService`, which never reads the system-hook registry, so a
+ * drawer edit or a kanban drag reaches only THIS handler.
+ * `pre/quote-deposit-guard.ts` records the identical finding for `quote_status`. Both guards
+ * are kept: together they cover every write path, and each names the other.
+ *
+ * ⚠️ **The value here is already coerced, and that is the trap.** By the time
+ * `fireFieldPreHooks` runs, `validateAndConvertValue` has turned a SINGLE_SELECT write into
+ * `{ type: 'option', optionId: 'issued' }` — it is **never** a bare string on this chain. A
+ * guard that compared `event.newValue` to `'issued'` directly would be inert: the
+ * comparison can never be true, so the guard would pass everything and look exactly like a
+ * guard nothing has tripped. `unwrapStatusValue` is shared with the system hook precisely so
+ * neither side has to remember which shape it is holding.
+ *
+ * ✅ **Sanctioned writers get through on `bypassFieldGuards`.** `fireFieldPreHooks`
+ * short-circuits on `ctx.bypassFieldGuards.has(systemAttribute)` before this handler is
+ * reached, and both sanctioned writers of the `-> issued` transition name
+ * `purchase_order_status` there: `markPurchaseOrderSent` (the Send action) and
+ * `derivePurchaseOrderStatuses` (§6.1's `draft -> issued` pull-forward when a receipt lands
+ * against a draft order). Adding a third writer means adding the same bypass, not weakening
+ * this guard.
+ *
+ * `draft`, `closed` and `canceled` stay freely editable — they are genuine human decisions,
+ * and §3.6 deliberately does not derive `closed` so that an order whose remainder has been
+ * forgiven is still closeable by hand.
+ */
+export const guardManualPurchaseOrderIssued: FieldPreHookHandler = async (event) => {
+  if (GUARDED.has(unwrapStatusValue(event.newValue))) {
+    throw new BadRequestError(PURCHASE_ORDER_ACTION_STATUS_MESSAGE)
+  }
+  return event.newValue
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -57,6 +57,11 @@ import { touchActivityOnFieldChange } from './post/touch-activity-on-field-chang
 import { guardInboxOwnerField } from './pre/inbox-owner-guard'
 import { guardInvoiceDelete } from './pre/invoice-delete-guard'
 import { cascadeOrderLinesOnDelete } from './pre/order-delete-guard'
+import {
+  EVIDENCE_LOCKED_LINE_ATTRS,
+  guardEvidenceLockedLineFields,
+} from './pre/purchase-order-line-evidence-lock'
+import { guardManualPurchaseOrderIssued } from './pre/purchase-order-status-guard'
 import { guardQuoteConvertedDelete } from './pre/quote-delete-guard'
 import { guardQuoteDraftReturnWithPaidDeposit } from './pre/quote-deposit-guard'
 import { rejectDeleteIfTagInUse } from './pre/tag-in-use-guard'
@@ -300,6 +305,36 @@ export function registerAllHooks(): void {
     'line_item_visit_id',
   ] as const) {
     registerFieldPreHooks('line-items', attribute, [guardAllocatedSourceLineChange])
+  }
+
+  // Manual-`issued` wall for `purchase_order_status` (§3.4). The system-hook twin in
+  // `resources/hooks/purchasing-hooks.ts` covers `record.create`/`record.update`, the CSV
+  // importer and the SDK; this one covers every interactive edit — drawer, grid inline edit,
+  // kanban drag — because those all write through `fieldValue.set` -> `FieldValueService`,
+  // which never reads the system-hook registry. Without this registration `issued` is
+  // typeable by hand and the plan's claim that it is action-set is false.
+  //
+  // Both sanctioned writers of the `-> issued` transition pass
+  // `bypassFieldGuards: ['purchase_order_status']`, which `fireFieldPreHooks` honours before
+  // reaching this handler: `markPurchaseOrderSent` (Send) and `derivePurchaseOrderStatuses`
+  // (§6.1's receipt pull-forward).
+  registerFieldPreHooks('purchase-orders', 'purchase_order_status', [
+    guardManualPurchaseOrderIssued,
+  ])
+
+  // Purchase order line evidence lock (plans/purchasing/07-purchase-order-send-and-status.md
+  // §6.5) — a line's agreed quantity and price freeze once a receipt or a vendor bill line
+  // has been booked against it, at ANY order status.
+  //
+  // 🛑 Registered on the FIELD pre-hook chain, not the system-hook registry, for the reason
+  // `quote-deposit-guard.ts` already documents for `quote_status`: every real edit to these
+  // fields goes through `fieldValue.set` → `FieldValueService` (the LineBuilder's
+  // `useSaveFieldValue` is the only editing surface), which never reads the system-hook
+  // registry. A `PURCHASE_ORDER_LINE_HOOKS` entry would have been a lock that never fires.
+  // This chain covers the CRUD path too — `UnifiedCrudHandler.setFieldValues` writes through
+  // `FieldValueService`, so the importer and Kopilot reach it as well.
+  for (const attribute of EVIDENCE_LOCKED_LINE_ATTRS) {
+    registerFieldPreHooks('purchase-order-lines', attribute, [guardEvidenceLockedLineFields])
   }
 
   registerFieldPreHooks('tags', 'is_system_tag', [dropUnauthorizedSystemFlag])

--- a/packages/lib/src/money/__tests__/purchase-order-lifecycle.test.ts
+++ b/packages/lib/src/money/__tests__/purchase-order-lifecycle.test.ts
@@ -1,0 +1,335 @@
+// packages/lib/src/money/__tests__/purchase-order-lifecycle.test.ts
+//
+// `purchase_order_status` had no writer at all, which is why §3.4 of
+// plans/purchasing/07-purchase-order-send-and-status.md could call it "a plain human-set
+// field" without anybody noticing. This is that writer. Two things here are silent when
+// wrong: writing through `UnifiedCrudHandler` instead of `FieldValueService` would make the
+// action trip the guard built to let it through, and inventing an `expected_at` when no line
+// carries a lead time would manufacture the exceptions a later feature ages off that field.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  getFieldValues: vi.fn(),
+  setValuesForEntity: vi.fn(),
+  /** Constructor arguments every `FieldValueService` was built with. */
+  fieldValueServiceArgs: [] as unknown[][],
+  /** Result sets the module's drizzle query resolves to, in call order. */
+  dbResults: [] as unknown[][],
+}))
+
+/** Chainable drizzle stub — resolves to the next queued result set. */
+function makeChain() {
+  const result = h.dbResults.shift() ?? []
+  const chain: Record<string, unknown> = {}
+  for (const key of ['from', 'innerJoin', 'leftJoin', 'where', 'limit']) {
+    chain[key] = () => chain
+  }
+  // biome-ignore lint/suspicious/noThenProperty: chainable drizzle query-builder stub
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve)
+  return chain
+}
+
+vi.mock('@auxx/database', () => ({
+  database: { select: () => makeChain() },
+  schema: {
+    FieldValue: {
+      entityId: 'entityId',
+      organizationId: 'organizationId',
+      fieldId: 'fieldId',
+      valueNumber: 'valueNumber',
+      relatedEntityId: 'relatedEntityId',
+    },
+  },
+}))
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+  getEntityDefIdResolver: async () => (slug: string) => `def-${slug}`,
+}))
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    getFieldValues = h.getFieldValues
+  },
+}))
+vi.mock('../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    constructor(...args: unknown[]) {
+      h.fieldValueServiceArgs.push(args)
+    }
+    setValuesForEntity = h.setValuesForEntity
+  },
+}))
+
+const { markPurchaseOrderSent } = await import('../purchase-order-lifecycle')
+const { BadRequestError } = await import('../../errors')
+
+const ORG = 'org-1'
+const USER = 'user-1'
+const PO = 'po-1'
+
+const STATUS_FIELD = { id: 'f-status' }
+const EXPECTED_FIELD = { id: 'f-expected' }
+const LINE_REL_FIELD = { id: 'f-line-order' }
+const VENDOR_PART_FIELD = { id: 'f-line-vendor-part' }
+const LEAD_TIME_FIELD = { id: 'f-lead-time' }
+
+/**
+ * `bySystemAttributes` is called twice with different attribute sets — once for the order's
+ * own two fields, once for the three the lead-time join needs. Answer by what was asked for.
+ */
+function wireFields(options: { withLeadTimeLink?: boolean } = {}) {
+  h.bySystemAttributes.mockImplementation((attrs: readonly string[]) => {
+    if (attrs.includes('purchase_order_status')) {
+      return Promise.resolve({
+        purchase_order_status: STATUS_FIELD,
+        purchase_order_expected_at: EXPECTED_FIELD,
+      })
+    }
+    return Promise.resolve(
+      options.withLeadTimeLink === false
+        ? {}
+        : {
+            purchase_order_line_purchase_order: LINE_REL_FIELD,
+            purchase_order_line_vendor_part: VENDOR_PART_FIELD,
+            vendor_part_lead_time: LEAD_TIME_FIELD,
+          }
+    )
+  })
+}
+
+/** The order's own field values, as `getFieldValues` returns them. */
+function wireOrder(status: string | undefined, expectedAt?: string) {
+  const map = new Map<string, unknown>()
+  if (status !== undefined) map.set(STATUS_FIELD.id, { type: 'option', optionId: status })
+  if (expectedAt !== undefined) map.set(EXPECTED_FIELD.id, { type: 'date', value: expectedAt })
+  h.getFieldValues.mockResolvedValue(map)
+}
+
+/** What the lead-time MAX query comes back with. */
+function wireLeadTime(maxLeadTime: string | null) {
+  h.dbResults = [[{ maxLeadTime }]]
+}
+
+function writtenValues(): Array<{ fieldId: string; value: unknown }> {
+  return h.setValuesForEntity.mock.calls[0]?.[0]?.values ?? []
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.dbResults = []
+  h.fieldValueServiceArgs = []
+  vi.useRealTimers()
+})
+
+describe('markPurchaseOrderSent — the status write', () => {
+  it('writes issued from draft', async () => {
+    wireFields()
+    wireOrder('draft', '2026-09-01')
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    expect(writtenValues()).toContainEqual({ fieldId: 'purchase_order_status', value: 'issued' })
+  })
+
+  // 🛑 `FieldValueService`, never `UnifiedCrudHandler`: the CRUD handler runs the system
+  // pre-hook chain, and `rejectManualLifecycleStatus` now refuses `issued` — so routing the
+  // action through it would make the action reject itself.
+  it('writes through FieldValueService, on the resolved def id', async () => {
+    wireFields()
+    wireOrder('draft', '2026-09-01')
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+    // Not `purchase_order:po-1` — an unresolved type-slug RecordId silently no-ops every
+    // field-change hook downstream while the write itself succeeds.
+    expect(h.setValuesForEntity.mock.calls[0]![0].recordId).toBe('def-purchase_order:po-1')
+  })
+
+  it.each(['issued', 'closed', 'canceled'])('refuses to send from %s', async (status) => {
+    wireFields()
+    wireOrder(status, '2026-09-01')
+    await expect(
+      markPurchaseOrderSent({
+        organizationId: ORG,
+        userId: USER,
+        purchaseOrderInstanceId: PO,
+      })
+    ).rejects.toThrow(BadRequestError)
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the order has no status at all, and says so', async () => {
+    wireFields()
+    wireOrder(undefined)
+    await expect(
+      markPurchaseOrderSent({
+        organizationId: ORG,
+        userId: USER,
+        purchaseOrderInstanceId: PO,
+      })
+    ).rejects.toThrow(/unknown/)
+  })
+})
+
+describe('markPurchaseOrderSent — the expected_at default (§6.2)', () => {
+  it('sets expected_at from the longest line lead time, counted from the send date', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-01T12:00:00.000Z'))
+    wireFields()
+    wireOrder('draft')
+    wireLeadTime('14')
+
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    expect(writtenValues()).toContainEqual({
+      fieldId: 'purchase_order_expected_at',
+      value: '2026-03-15',
+    })
+  })
+
+  // A date somebody typed is the person who actually spoke to the vendor. The catalogue
+  // never outranks that.
+  it('never overwrites an expected_at that is already set', async () => {
+    wireFields()
+    wireOrder('draft', '2026-09-01')
+    wireLeadTime('30')
+
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    expect(writtenValues()).toEqual([{ fieldId: 'purchase_order_status', value: 'issued' }])
+  })
+
+  // ✅ The whole point of §6.2: an invented date is worse than a missing one, because a
+  // later feature ages an `awaiting_receipt` exception off this field — a fabricated date
+  // produces fabricated exceptions.
+  it('leaves expected_at EMPTY when no line carries a lead time', async () => {
+    wireFields()
+    wireOrder('draft')
+    wireLeadTime(null)
+
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    expect(writtenValues()).toEqual([{ fieldId: 'purchase_order_status', value: 'issued' }])
+  })
+
+  // `purchase_order_line_vendor_part` is nullable and usually unset, so an order whose lines
+  // all lack one produces no rows at all. That is the normal case, not a failure.
+  it('leaves expected_at empty when the join matches nothing', async () => {
+    wireFields()
+    wireOrder('draft')
+    h.dbResults = [[]]
+
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    expect(writtenValues()).toEqual([{ fieldId: 'purchase_order_status', value: 'issued' }])
+  })
+
+  it('ignores a non-positive lead time rather than dating the order in the past', async () => {
+    wireFields()
+    wireOrder('draft')
+    wireLeadTime('0')
+
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    expect(writtenValues()).toEqual([{ fieldId: 'purchase_order_status', value: 'issued' }])
+  })
+
+  // Purchasing may simply not be provisioned for the org. Send still has to work.
+  it('still issues the order when the lead-time fields do not exist', async () => {
+    wireFields({ withLeadTimeLink: false })
+    wireOrder('draft')
+
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    expect(writtenValues()).toEqual([{ fieldId: 'purchase_order_status', value: 'issued' }])
+  })
+})
+
+describe('markPurchaseOrderSent — clearing its own guards', () => {
+  // 🛑 The regression this exists to prevent: `issued` is guarded on BOTH chains, and Send
+  // has to clear both or the action is refused by the wall built to protect it.
+  //
+  // The system hook is cleared structurally — writing through `FieldValueService` instead of
+  // `UnifiedCrudHandler` means `runPreHooks` never runs (asserted above). The FIELD pre-hook
+  // is NOT cleared that way: it fires on exactly this write. `fireFieldPreHooks`
+  // short-circuits on `ctx.bypassFieldGuards.has(systemAttribute)` before reaching the
+  // handler, so naming the attribute here is the whole mechanism.
+  it('passes bypassFieldGuards for purchase_order_status', async () => {
+    wireFields()
+    wireOrder('draft', '2026-09-01')
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    const options = h.fieldValueServiceArgs[0]?.[4] as
+      | { bypassFieldGuards?: ReadonlySet<string> }
+      | undefined
+    expect(options?.bypassFieldGuards).toBeDefined()
+    expect([...(options?.bypassFieldGuards ?? [])]).toEqual(['purchase_order_status'])
+  })
+
+  // Naming more than the one attribute would quietly disarm guards on fields this action has
+  // no business writing. The status writer's bypass is scoped the same way.
+  it('bypasses that one attribute and nothing else', async () => {
+    wireFields()
+    wireOrder('draft', '2026-09-01')
+    await markPurchaseOrderSent({
+      organizationId: ORG,
+      userId: USER,
+      purchaseOrderInstanceId: PO,
+    })
+
+    const options = h.fieldValueServiceArgs[0]?.[4] as
+      | { bypassFieldGuards?: ReadonlySet<string> }
+      | undefined
+    expect(options?.bypassFieldGuards?.size).toBe(1)
+    expect(options?.bypassFieldGuards?.has('purchase_order_expected_at')).toBe(false)
+  })
+
+  // The other half of the proof: without the bypass, this exact write is refused. If this
+  // ever stops throwing, the bypass above has become decoration and the guard is inert.
+  it('is refused by the field pre-hook when the bypass is absent', async () => {
+    const { guardManualPurchaseOrderIssued } = await import(
+      '../../field-hooks/pre/purchase-order-status-guard'
+    )
+    await expect(
+      guardManualPurchaseOrderIssued({
+        newValue: { type: 'option', optionId: 'issued' },
+      } as any)
+    ).rejects.toThrow(/Use Send/)
+  })
+})

--- a/packages/lib/src/money/__tests__/send-email-document-profiles.test.ts
+++ b/packages/lib/src/money/__tests__/send-email-document-profiles.test.ts
@@ -1,0 +1,389 @@
+// packages/lib/src/money/__tests__/send-email-document-profiles.test.ts
+//
+// `prepareDocumentEmail` used to decide four separate things with a `documentType ===
+// 'invoice' ? … : <quote>` ternary — the error copy, the contact field, the system snippet
+// and the placeholder root — so every non-invoice document took the QUOTE arm. That is the
+// same "everything else is a quote" shape as the `documentTypeOf` default fixed in
+// `send-email-document-type.test.ts` (purchasing plan 07 §2.1); it merely failed loudly
+// instead of silently, telling a user sending a purchase order that "this quote has no
+// contact". These tests pin the per-document-type table that replaced it, and — the part
+// that must never regress — that ONLY a quote is ever minted a public approve/decline token
+// (§2.3).
+
+import type { RecordId } from '@auxx/types'
+import { toResourceFieldId } from '@auxx/types/field'
+import { toRecordId } from '@auxx/types/resource'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DOCUMENT_TYPE_DESCRIPTORS } from '../../documents/client'
+import { BadRequestError } from '../../errors'
+import { DOCUMENT_EMAIL_PROFILES, prepareDocumentEmail } from '../send-email'
+
+const {
+  mockCacheGet,
+  mockBySystemAttributes,
+  mockGetFieldValues,
+  mockBatchGetValues,
+  mockGetSystemSnippet,
+  mockResolvePlaceholders,
+  mockEnsurePdfViaQueue,
+  mockEnsureQuotePublicToken,
+  mockBuildQuoteViewUrl,
+  mockEnsureInvoicePublicToken,
+  mockIsPaymentsConnected,
+  mockGetOrganizationSetting,
+  mockFormatToDisplayValue,
+} = vi.hoisted(() => ({
+  mockCacheGet: vi.fn(),
+  mockBySystemAttributes: vi.fn(),
+  mockGetFieldValues: vi.fn(),
+  mockBatchGetValues: vi.fn(),
+  mockGetSystemSnippet: vi.fn(),
+  mockResolvePlaceholders: vi.fn(),
+  mockEnsurePdfViaQueue: vi.fn(),
+  mockEnsureQuotePublicToken: vi.fn(),
+  mockBuildQuoteViewUrl: vi.fn(),
+  mockEnsureInvoicePublicToken: vi.fn(),
+  mockIsPaymentsConnected: vi.fn(),
+  mockGetOrganizationSetting: vi.fn(),
+  mockFormatToDisplayValue: vi.fn(),
+}))
+
+// `documents/client.ts` is NOT mocked — `documentTypeOf` resolves against the real
+// `DOCUMENT_TYPE_DESCRIPTORS`, so these tests only pass while `purchase_order` is genuinely
+// registered for printing. That coupling is the point (purchasing plan 07 §1.2/§2.1).
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({
+    get: mockCacheGet,
+    from: () => ({ bySystemAttributes: mockBySystemAttributes }),
+  }),
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    getFieldValues = mockGetFieldValues
+    fieldValueService = { batchGetValues: mockBatchGetValues }
+  },
+}))
+
+vi.mock('../../documents', () => ({
+  ensureDocumentPdf: vi.fn(),
+  ensureDocumentPdfViaQueue: mockEnsurePdfViaQueue,
+}))
+
+vi.mock('../../snippets', () => ({ getSystemSnippet: mockGetSystemSnippet }))
+vi.mock('../../placeholders', () => ({ resolvePlaceholdersInHtml: mockResolvePlaceholders }))
+vi.mock('../../field-values/formatter', () => ({
+  formatToDisplayValue: mockFormatToDisplayValue,
+}))
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: mockGetOrganizationSetting,
+}))
+vi.mock('../quote-public-token', () => ({
+  ensureQuotePublicToken: mockEnsureQuotePublicToken,
+  buildQuoteViewUrl: mockBuildQuoteViewUrl,
+}))
+vi.mock('../public-token', () => ({
+  ensureInvoicePublicToken: mockEnsureInvoicePublicToken,
+  isPaymentsConnected: mockIsPaymentsConnected,
+  buildPayUrl: (t: string) => `https://pay.test/${t}`,
+}))
+vi.mock('../payments/account-state', () => ({ getPaymentAccount: vi.fn(async () => null) }))
+
+const ORG_ID = 'org_test'
+const USER_ID = 'user_test'
+const CONTACT_DEF_ID = 'def_contact'
+const CONTACT_INSTANCE_ID = 'inst_contact'
+const CONTACT_RECORD_ID = toRecordId(CONTACT_DEF_ID, CONTACT_INSTANCE_ID)
+
+const ENTITY_DEFS: Record<string, string> = {
+  quote: 'def_quote',
+  invoice: 'def_invoice',
+  purchase_order: 'def_purchase_order',
+  contact: CONTACT_DEF_ID,
+}
+
+/** `CustomField.id` per systemAttribute — the ids `bySystemAttributes` hands back. */
+const FIELD_IDS: Record<string, string> = {
+  quote_contact: 'fld_quote_contact',
+  invoice_contact: 'fld_invoice_contact',
+  purchase_order_contact: 'fld_po_contact',
+  full_name: 'fld_full_name',
+  primary_email: 'fld_primary_email',
+}
+
+/** Which systemAttributes `bySystemAttributes` resolves to a real field. Mutated per test. */
+let presentFields = new Set(Object.keys(FIELD_IDS))
+/** Contact link present on the document under test. */
+let documentHasContact = true
+/** The contact's `primary_email` value, or `undefined` for "no email on file". */
+let contactEmail: string | undefined = 'buyer@vendor.test'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  presentFields = new Set(Object.keys(FIELD_IDS))
+  documentHasContact = true
+  contactEmail = 'buyer@vendor.test'
+
+  mockCacheGet.mockImplementation(async (_orgId: string, key: string) =>
+    key === 'entityDefs' ? ENTITY_DEFS : {}
+  )
+
+  mockBySystemAttributes.mockImplementation(async (attrs: string[]) =>
+    Object.fromEntries(
+      attrs.map((attr) => [
+        attr,
+        presentFields.has(attr) && FIELD_IDS[attr] ? { id: FIELD_IDS[attr] } : null,
+      ])
+    )
+  )
+
+  mockGetFieldValues.mockImplementation(async (_recordId: RecordId, fieldIds: string[]) => {
+    const map = new Map()
+    for (const fieldId of fieldIds) {
+      if (documentHasContact) {
+        map.set(fieldId, { type: 'relationship', recordId: CONTACT_RECORD_ID })
+      }
+    }
+    return map
+  })
+
+  mockBatchGetValues.mockImplementation(async () => ({
+    values: [
+      {
+        fieldRef: toResourceFieldId(CONTACT_DEF_ID, FIELD_IDS.full_name as string),
+        value: { type: 'text', value: 'Dana Buyer' },
+        fieldType: 'NAME',
+        fieldOptions: undefined,
+      },
+      ...(contactEmail
+        ? [
+            {
+              fieldRef: toResourceFieldId(CONTACT_DEF_ID, FIELD_IDS.primary_email as string),
+              value: { type: 'text', value: contactEmail },
+              fieldType: 'EMAIL',
+              fieldOptions: undefined,
+            },
+          ]
+        : []),
+    ],
+  }))
+
+  mockFormatToDisplayValue.mockReturnValue('Dana Buyer')
+  mockGetSystemSnippet.mockImplementation(
+    async (_db: unknown, _org: string, systemType: string) => ({
+      title: `subject for ${systemType}`,
+      contentHtml: `<p>body for ${systemType}</p>`,
+    })
+  )
+  mockResolvePlaceholders.mockImplementation(async (html: string) => html)
+  mockEnsurePdfViaQueue.mockResolvedValue({ assetId: 'asset_1', fileName: 'doc.pdf' })
+  mockGetOrganizationSetting.mockResolvedValue(true)
+  mockEnsureQuotePublicToken.mockResolvedValue('qtok')
+  mockBuildQuoteViewUrl.mockReturnValue('https://view.test/qtok')
+  mockIsPaymentsConnected.mockReturnValue(false)
+})
+
+/** The `recordIdsByRoot` map `resolvePlaceholdersInHtml` was called with. */
+function placeholderRoots(): Map<string, RecordId> {
+  const ctx = mockResolvePlaceholders.mock.calls[0]?.[1] as {
+    recordIdsByRoot: Map<string, RecordId>
+  }
+  return ctx.recordIdsByRoot
+}
+
+function send(entityType: string) {
+  return prepareDocumentEmail({
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    quoteRecordId: toRecordId(entityType, `inst_${entityType}`),
+  })
+}
+
+describe('prepareDocumentEmail — per-document-type profile table (purchasing plan 07)', () => {
+  describe('purchase order', () => {
+    it('resolves purchase_order_contact, NOT quote_contact', async () => {
+      await send('purchase_order')
+      expect(mockGetFieldValues).toHaveBeenCalledWith(expect.anything(), [
+        FIELD_IDS.purchase_order_contact,
+      ])
+      expect(mockGetFieldValues).not.toHaveBeenCalledWith(expect.anything(), [
+        FIELD_IDS.quote_contact,
+      ])
+    })
+
+    it('never reads the vendor company — a company has no email field to send to', async () => {
+      await send('purchase_order')
+      const requested = mockBySystemAttributes.mock.calls.flatMap((call) => call[0] as string[])
+      expect(requested).not.toContain('purchase_order_vendor')
+    })
+
+    it('selects the purchase_order_email system snippet', async () => {
+      const result = await send('purchase_order')
+      expect(mockGetSystemSnippet).toHaveBeenCalledWith(
+        expect.anything(),
+        ORG_ID,
+        'purchase_order_email'
+      )
+      expect(result.subject).toBe('subject for purchase_order_email')
+      expect(result.contentHtml).toContain('body for purchase_order_email')
+    })
+
+    it('roots placeholders at the purchase_order def, not the quote def', async () => {
+      await send('purchase_order')
+      const roots = placeholderRoots()
+      expect(roots.get(ENTITY_DEFS.purchase_order as string)).toBe(
+        toRecordId('purchase_order', 'inst_purchase_order')
+      )
+      expect(roots.has(ENTITY_DEFS.quote as string)).toBe(false)
+      expect(roots.get(CONTACT_DEF_ID)).toBe(CONTACT_RECORD_ID)
+    })
+
+    // ⚠️ `purchase_order_contact` is nullable and nothing prefills it, so this is the COMMON
+    // path today, not an edge case — the message has to be actionable.
+    it('reports a purchase-order-specific no-contact error naming the Contact field', async () => {
+      documentHasContact = false
+      const error = await send('purchase_order').catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(BadRequestError)
+      const message = (error as Error).message
+      expect(message).toContain('This purchase order has no contact')
+      expect(message).toContain('Contact field')
+      expect(message).toContain('vendor')
+      expect(message).not.toContain('quote')
+    })
+
+    it('reports a purchase-order-specific no-email error', async () => {
+      contactEmail = undefined
+      await expect(send('purchase_order')).rejects.toThrow(
+        'This purchase order contact has no email address — add one before sending'
+      )
+    })
+
+    // 🛑 purchasing plan 07 §2.3 — the whole reason `documentTypeOf` was fixed. A vendor must
+    // never receive a customer-facing approve/decline link.
+    it('is NEVER minted a public token and gets no view URL', async () => {
+      const result = await send('purchase_order')
+      expect(mockEnsureQuotePublicToken).not.toHaveBeenCalled()
+      expect(mockBuildQuoteViewUrl).not.toHaveBeenCalled()
+      expect(result.contentHtml).not.toContain('View & accept')
+      expect(result.contentHtml).not.toContain('view.test')
+    })
+
+    it('does not check the quote acceptance-page setting at all', async () => {
+      await send('purchase_order')
+      expect(mockGetOrganizationSetting).not.toHaveBeenCalled()
+    })
+
+    it('gets no pay-online link either — a PO has no balance to collect', async () => {
+      mockIsPaymentsConnected.mockReturnValue(true)
+      const result = await send('purchase_order')
+      expect(mockEnsureInvoicePublicToken).not.toHaveBeenCalled()
+      expect(result.contentHtml).not.toContain('Pay online')
+    })
+  })
+
+  // ─── Regression pins: quote and invoice behaviour is byte-identical to the ternaries ───
+  describe('quote (unchanged)', () => {
+    it('resolves quote_contact and the quote_email snippet', async () => {
+      const result = await send('quote')
+      expect(mockGetFieldValues).toHaveBeenCalledWith(expect.anything(), [FIELD_IDS.quote_contact])
+      expect(mockGetSystemSnippet).toHaveBeenCalledWith(expect.anything(), ORG_ID, 'quote_email')
+      expect(result.subject).toBe('subject for quote_email')
+    })
+
+    it('roots placeholders at the quote def', async () => {
+      await send('quote')
+      expect(placeholderRoots().get(ENTITY_DEFS.quote as string)).toBe(
+        toRecordId('quote', 'inst_quote')
+      )
+    })
+
+    it('still appends the view & accept link when the acceptance page is enabled', async () => {
+      const result = await send('quote')
+      expect(mockEnsureQuotePublicToken).toHaveBeenCalledWith(ORG_ID, 'inst_quote')
+      expect(result.contentHtml).toContain('https://view.test/qtok')
+      expect(result.contentHtml).toContain('View & accept this quote online')
+    })
+
+    it('omits the link when the acceptance page is disabled', async () => {
+      mockGetOrganizationSetting.mockResolvedValue(false)
+      const result = await send('quote')
+      expect(mockEnsureQuotePublicToken).not.toHaveBeenCalled()
+      expect(result.contentHtml).not.toContain('view.test')
+    })
+
+    it('keeps the exact pre-existing no-contact / no-email copy', async () => {
+      documentHasContact = false
+      await expect(send('quote')).rejects.toThrow(
+        'This quote has no contact — add one before sending'
+      )
+      documentHasContact = true
+      contactEmail = undefined
+      await expect(send('quote')).rejects.toThrow(
+        'This quote contact has no email address — add one before sending'
+      )
+    })
+  })
+
+  describe('invoice (unchanged)', () => {
+    it('resolves invoice_contact and the invoice_email snippet', async () => {
+      const result = await send('invoice')
+      expect(mockGetFieldValues).toHaveBeenCalledWith(expect.anything(), [
+        FIELD_IDS.invoice_contact,
+      ])
+      expect(mockGetSystemSnippet).toHaveBeenCalledWith(expect.anything(), ORG_ID, 'invoice_email')
+      expect(result.subject).toBe('subject for invoice_email')
+    })
+
+    it('roots placeholders at the invoice def', async () => {
+      await send('invoice')
+      expect(placeholderRoots().get(ENTITY_DEFS.invoice as string)).toBe(
+        toRecordId('invoice', 'inst_invoice')
+      )
+    })
+
+    it('still appends the pay-online link when Stripe is connected', async () => {
+      mockIsPaymentsConnected.mockReturnValue(true)
+      mockEnsureInvoicePublicToken.mockResolvedValue('itok')
+      const result = await send('invoice')
+      expect(result.contentHtml).toContain('https://pay.test/itok')
+      expect(result.contentHtml).toContain('Pay online')
+    })
+
+    it('is never minted a QUOTE public token', async () => {
+      await send('invoice')
+      expect(mockEnsureQuotePublicToken).not.toHaveBeenCalled()
+    })
+
+    it('keeps the exact pre-existing no-contact / no-email copy', async () => {
+      documentHasContact = false
+      await expect(send('invoice')).rejects.toThrow(
+        'This invoice has no contact — add one before sending'
+      )
+      documentHasContact = true
+      contactEmail = undefined
+      await expect(send('invoice')).rejects.toThrow(
+        'This invoice contact has no email address — add one before sending'
+      )
+    })
+  })
+
+  describe('the table itself', () => {
+    it('gives every registered document type a profile', () => {
+      // A document type registered for printing but never given a send profile fails here
+      // rather than at the user.
+      for (const descriptor of DOCUMENT_TYPE_DESCRIPTORS) {
+        expect(DOCUMENT_EMAIL_PROFILES[descriptor.id]).toBeDefined()
+      }
+      expect(DOCUMENT_TYPE_DESCRIPTORS.map((d) => d.id)).toContain('purchase_order')
+    })
+
+    it('gives every profile its OWN contact field, snippet and placeholder root', async () => {
+      const profiles = Object.values(DOCUMENT_EMAIL_PROFILES)
+      expect(new Set(profiles.map((p) => p.contactSystemAttribute)).size).toBe(profiles.length)
+      expect(new Set(profiles.map((p) => p.snippetSystemType)).size).toBe(profiles.length)
+      expect(new Set(profiles.map((p) => p.entityDefsKey)).size).toBe(profiles.length)
+      expect(new Set(profiles.map((p) => p.noun)).size).toBe(profiles.length)
+    })
+  })
+})

--- a/packages/lib/src/money/__tests__/send-email-document-type.test.ts
+++ b/packages/lib/src/money/__tests__/send-email-document-type.test.ts
@@ -1,0 +1,93 @@
+// packages/lib/src/money/__tests__/send-email-document-type.test.ts
+//
+// Regression guard for purchasing plan 07 §2.1 — `documentTypeOf` used to default every
+// non-invoice def to `'quote'`, which would have minted a customer-facing approve/decline
+// public token for a purchase order sent to a vendor, silently. It now resolves against the
+// document-type registry and throws on an unregistered def.
+
+import { toRecordId } from '@auxx/types/resource'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DOCUMENT_TYPE_DESCRIPTORS } from '../../documents/client'
+import { BadRequestError } from '../../errors'
+import { documentTypeOf } from '../send-email'
+
+const { mockCacheGet } = vi.hoisted(() => ({ mockCacheGet: vi.fn() }))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ get: mockCacheGet }),
+}))
+
+const ORG_ID = 'org_test'
+
+/** entityType slug -> per-org `EntityDefinition.id`, the shape of the `entityDefs` cache. */
+const ENTITY_DEFS: Record<string, string> = {
+  ...Object.fromEntries(
+    DOCUMENT_TYPE_DESCRIPTORS.map((d) => [d.entityType, `def_${d.entityType}`])
+  ),
+  work_order: 'def_work_order',
+  contact: 'def_contact',
+}
+
+beforeEach(() => {
+  mockCacheGet.mockReset()
+  mockCacheGet.mockImplementation(async (_orgId: string, key: string) =>
+    key === 'entityDefs' ? ENTITY_DEFS : {}
+  )
+})
+
+describe('documentTypeOf (purchasing plan 07 §2.1)', () => {
+  // Data-driven over the registry rather than a hardcoded quote/invoice pair: adding a
+  // document type to `DOCUMENT_TYPE_DESCRIPTORS` must be all that send needs, so a new
+  // entry has to be covered here without editing this file.
+  describe.each(
+    DOCUMENT_TYPE_DESCRIPTORS.map((d) => [d.id, d.entityType] as const)
+  )('registered type %s', (id, entityType) => {
+    it('resolves the literal entityType slug convention (internal builders)', async () => {
+      await expect(documentTypeOf(ORG_ID, toRecordId(entityType, 'inst_1'))).resolves.toBe(id)
+    })
+
+    it('resolves the literal slug without touching the org cache', async () => {
+      await documentTypeOf(ORG_ID, toRecordId(entityType, 'inst_1'))
+      expect(mockCacheGet).not.toHaveBeenCalled()
+    })
+
+    it('resolves the EntityDefinition cuid convention (records view / drawer Send)', async () => {
+      const defId = ENTITY_DEFS[entityType] as string
+      await expect(documentTypeOf(ORG_ID, toRecordId(defId, 'inst_1'))).resolves.toBe(id)
+      expect(mockCacheGet).toHaveBeenCalledWith(ORG_ID, 'entityDefs')
+    })
+  })
+
+  it('still resolves quote and invoice exactly as before (both conventions)', async () => {
+    await expect(documentTypeOf(ORG_ID, toRecordId('quote', 'q1'))).resolves.toBe('quote')
+    await expect(documentTypeOf(ORG_ID, toRecordId('invoice', 'i1'))).resolves.toBe('invoice')
+    await expect(documentTypeOf(ORG_ID, toRecordId('def_quote', 'q1'))).resolves.toBe('quote')
+    await expect(documentTypeOf(ORG_ID, toRecordId('def_invoice', 'i1'))).resolves.toBe('invoice')
+  })
+
+  it('THROWS on an unregistered def cuid instead of defaulting to quote', async () => {
+    // The whole point of the change: under the old if-chain this returned 'quote' and the
+    // caller minted a public approve/decline token for it.
+    await expect(documentTypeOf(ORG_ID, toRecordId('def_work_order', 'w1'))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+
+  it('THROWS on an unregistered literal entityType slug', async () => {
+    await expect(documentTypeOf(ORG_ID, toRecordId('work_order', 'w1'))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+
+  it('names the offending def in the error so the missing registry entry is obvious', async () => {
+    await expect(documentTypeOf(ORG_ID, toRecordId('def_work_order', 'w1'))).rejects.toThrow(
+      /def_work_order/
+    )
+  })
+
+  it('THROWS when the def resolves to nothing at all (unknown cuid)', async () => {
+    await expect(documentTypeOf(ORG_ID, toRecordId('cuid_nobody_knows', 'x1'))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+})

--- a/packages/lib/src/money/index.ts
+++ b/packages/lib/src/money/index.ts
@@ -131,6 +131,8 @@ export {
   type PublicInvoicePayload,
   resolveInvoiceByPublicToken,
 } from './public-token'
+export type { PurchaseOrderLifecycleInput } from './purchase-order-lifecycle'
+export { markPurchaseOrderSent } from './purchase-order-lifecycle'
 export {
   type SyncInvoiceResult,
   type SyncInvoiceToQuickbooksInput,

--- a/packages/lib/src/money/purchase-order-lifecycle.ts
+++ b/packages/lib/src/money/purchase-order-lifecycle.ts
@@ -1,0 +1,225 @@
+// packages/lib/src/money/purchase-order-lifecycle.ts
+
+import { database, schema } from '@auxx/database'
+import type { RecordId, TypedFieldValue } from '@auxx/types'
+import { extractValue } from '@auxx/types'
+import { toRecordId } from '@auxx/types/resource'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
+import { and, eq, sql } from 'drizzle-orm'
+import { getEntityDefIdResolver, getOrgCache } from '../cache'
+import { BadRequestError } from '../errors'
+import { FieldValueService } from '../field-values/field-value-service'
+import { UnifiedCrudHandler } from '../resources/crud'
+import type { MoneyMutationInput } from './types'
+
+/**
+ * Input for `markPurchaseOrderSent`.
+ *
+ * Declared here rather than in `money/types.ts` for the same reason
+ * `purchase-order-lifecycle.ts` is its own module: `use-document-send-actions.ts:20`
+ * records that **lifecycle mutations stay per-document** — only the send flow and the
+ * status guard are shared. A third `…LifecycleInput` alias in the shared types file would
+ * imply a shared shape that the three mutations deliberately do not have.
+ */
+export interface PurchaseOrderLifecycleInput extends MoneyMutationInput {
+  /** EntityInstance id of the purchase order (not the RecordId). */
+  purchaseOrderInstanceId: string
+}
+
+/** Unwrap a `getFieldValues()` map entry — takes the first value if array-returned. */
+function firstTyped(
+  entry: TypedFieldValue | TypedFieldValue[] | undefined
+): TypedFieldValue | undefined {
+  if (!entry) return undefined
+  return Array.isArray(entry) ? entry[0] : entry
+}
+
+/** Assert the order is currently at `expected` status, else reject with a clear message. */
+function assertStatus(status: string | undefined, expected: string, action: string): void {
+  if (status !== expected) {
+    throw new BadRequestError(
+      `Cannot ${action} — purchase order must be '${expected}' (currently '${status ?? 'unknown'}')`
+    )
+  }
+}
+
+/** Read a purchase order's current `purchase_order_status` and `purchase_order_expected_at`. */
+async function getStatusAndExpectedAt(
+  handler: UnifiedCrudHandler,
+  organizationId: string,
+  purchaseOrderRecordId: RecordId
+): Promise<{ status: string | undefined; expectedAt: unknown }> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['purchase_order_status', 'purchase_order_expected_at'] as const)
+
+  const fieldIds = [cf.purchase_order_status, cf.purchase_order_expected_at]
+    .filter(Boolean)
+    .map((f) => f!.id)
+  const values = await handler.getFieldValues(purchaseOrderRecordId, fieldIds)
+
+  const statusTyped = cf.purchase_order_status
+    ? firstTyped(values.get(cf.purchase_order_status.id))
+    : undefined
+  const expectedTyped = cf.purchase_order_expected_at
+    ? firstTyped(values.get(cf.purchase_order_expected_at.id))
+    : undefined
+
+  return {
+    status: statusTyped ? (extractValue(statusTyped) as string) : undefined,
+    expectedAt: expectedTyped ? extractValue(expectedTyped) : undefined,
+  }
+}
+
+/**
+ * The longest `vendor_part_lead_time` (in days) reachable from this order's lines, or
+ * `null` when no line carries one.
+ *
+ * There is no lead time at the PO level; the only one in the system is on the supplier's
+ * catalogue entry, reachable through `purchase_order_line_vendor_part`
+ * (plans/purchasing/07-purchase-order-send-and-status.md §6.2).
+ *
+ * ⚠️ `purchase_order_line_vendor_part` is nullable and frequently unset — a one-off buy
+ * from a supplier with no maintained price list is a legitimate line — so most lines
+ * contribute nothing. That is the normal case, not a failure, which is why this is an inner
+ * join returning `null` for an empty set rather than anything that reports a problem.
+ *
+ * One statement rather than a walk down the two relationships: a fifty-line order would
+ * otherwise open a hundred round trips to compute a single MAX. The `organizationId`
+ * predicate on every leg plus field ids that only exist on their own entity is the scope.
+ */
+async function readMaxLineLeadTimeDays(
+  organizationId: string,
+  purchaseOrderInstanceId: string
+): Promise<number | null> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([
+      'purchase_order_line_purchase_order',
+      'purchase_order_line_vendor_part',
+      'vendor_part_lead_time',
+    ] as const)
+
+  const orderRelField = cf.purchase_order_line_purchase_order
+  const vendorPartRelField = cf.purchase_order_line_vendor_part
+  const leadTimeField = cf.vendor_part_lead_time
+  if (!orderRelField || !vendorPartRelField || !leadTimeField) return null
+
+  // Two self-joins on FieldValue, the `recalculatePurchaseOrderLineRollup` shape:
+  // line -> its vendor_part -> that row's lead time.
+  const [row] = await database
+    .select({ maxLeadTime: sql<string | null>`MAX(lead."valueNumber")` })
+    .from(schema.FieldValue)
+    .innerJoin(
+      sql`"FieldValue" vp`,
+      sql`vp."entityId" = ${schema.FieldValue.entityId}
+        AND vp."fieldId" = ${vendorPartRelField.id}
+        AND vp."organizationId" = ${organizationId}`
+    )
+    .innerJoin(
+      sql`"FieldValue" lead`,
+      sql`lead."entityId" = vp."relatedEntityId"
+        AND lead."fieldId" = ${leadTimeField.id}
+        AND lead."organizationId" = ${organizationId}`
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.fieldId, orderRelField.id),
+        eq(schema.FieldValue.relatedEntityId, purchaseOrderInstanceId),
+        eq(schema.FieldValue.organizationId, organizationId)
+      )
+    )
+
+  const maxLeadTime = row?.maxLeadTime
+  if (maxLeadTime === null || maxLeadTime === undefined) return null
+  const days = Number(maxLeadTime)
+  return Number.isFinite(days) && days > 0 ? days : null
+}
+
+/**
+ * Mark a draft purchase order as sent to its vendor
+ * (plans/purchasing/07-purchase-order-send-and-status.md §3.4, §6.2, §6.4).
+ *
+ * Writes `purchase_order_status = 'issued'`. There is no separate `sent` value and none is
+ * wanted: for a purchase order *issued* **is** *sent to the vendor*, one event, and the
+ * accounting word is the better one. `issued` means SENT and nothing more — deliberately
+ * not "the vendor has accepted", which is a later `confirmed` state that belongs to vendor
+ * order confirmation (§6.4, reserved and not built).
+ *
+ * 🛑 **`issued` is guarded on BOTH hook chains, so this write clears both.** Going through
+ * `FieldValueService` rather than `UnifiedCrudHandler` is what clears the system pre-hook
+ * (`resources/hooks/purchasing-hooks.ts`), which never runs for a `FieldValueService` write
+ * — the same mechanism `markQuoteSent` and `markInvoiceSent` rely on, and routing this
+ * through the CRUD handler would make the action reject itself. But that chain is not the
+ * one a drawer edit or a kanban drag takes, so `purchase_order_status` also carries a field
+ * pre-hook (`field-hooks/pre/purchase-order-status-guard.ts`) that DOES see this write —
+ * which is why `bypassFieldGuards` below is not optional. Without it the Send action is
+ * refused by the guard that exists to protect it.
+ *
+ * The bypass set is deliberately identical to the one `derivePurchaseOrderStatuses`
+ * (`purchasing/purchase-order-status-writer.ts`) passes for §6.1's `draft -> issued`
+ * pull-forward: two sanctioned writers, one idiom, one attribute named and nothing else.
+ *
+ * Deliberately NOT abstracted into a shared `markXSent`: `use-document-send-actions.ts:20`
+ * records that lifecycle mutations stay per-document, and the assertion plus what each one
+ * mirrors IS the body — a quote mirrors its `service_request` to `quoted`, an invoice
+ * stamps `issued_at`, and this one derives an expected-delivery default. The shared parts
+ * (the send flow, the status guard) are already shared.
+ *
+ * @param input - Org, user, and the purchase order's EntityInstance id.
+ * @throws BadRequestError when the order is not currently `draft`.
+ */
+export async function markPurchaseOrderSent(input: PurchaseOrderLifecycleInput): Promise<void> {
+  const { organizationId, userId, purchaseOrderInstanceId } = input
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const purchaseOrderRecordId = toRecordId('purchase_order', purchaseOrderInstanceId)
+
+  const { status, expectedAt } = await getStatusAndExpectedAt(
+    handler,
+    organizationId,
+    purchaseOrderRecordId
+  )
+  assertStatus(status, 'draft', 'mark as sent')
+
+  const writes: Array<{ fieldId: string; value: unknown }> = [
+    { fieldId: 'purchase_order_status', value: 'issued' },
+  ]
+
+  // `purchase_order_expected_at` as an OVERWRITABLE DEFAULT (§6.2): filled only when the
+  // field is empty, so a date somebody typed is never overwritten — the person who spoke to
+  // the vendor outranks the catalogue.
+  //
+  // ✅ When no line carries a lead time the field is left EMPTY on purpose. An invented
+  // date is worse than a missing one here: 05 §6.1 ages an `awaiting_receipt` exception off
+  // this field, so a fabricated expected date produces fabricated exceptions — a queue full
+  // of late orders that were never actually late. Absence is honest and the expediting list
+  // can say "no promised date"; a guess cannot be told apart from a real promise.
+  if (expectedAt === undefined || expectedAt === null || expectedAt === '') {
+    const leadTimeDays = await readMaxLineLeadTimeDays(organizationId, purchaseOrderInstanceId)
+    if (leadTimeDays !== null) {
+      const expected = new Date(Date.now() + leadTimeDays * 24 * 60 * 60 * 1000)
+      writes.push({
+        fieldId: 'purchase_order_expected_at',
+        value: expected.toISOString().split('T')[0],
+      })
+    }
+  }
+
+  // Resolve the type-slug to the real `entityDefinitionId` UUID before writing — the
+  // `markInvoiceSent` note applies verbatim: an unresolved `purchase_order:<id>` RecordId
+  // makes `setValuesForEntity`'s field-change hook dispatch resolve to no cached resource,
+  // so `entitySlug` comes back `''` and every field-change hook silently no-ops even though
+  // the write itself succeeds.
+  const resolveDefId = await getEntityDefIdResolver(organizationId)
+  // `bypassFieldGuards` names `purchase_order_status` and nothing else: this IS the
+  // sanctioned writer of `issued`, so the field pre-hook that rejects a MANUAL `issued` must
+  // not reject it. `FieldValueService` forwards this straight to `createFieldValueContext`,
+  // so it is the same construction the status writer performs by hand.
+  const fieldValueService = new FieldValueService(organizationId, userId, undefined, undefined, {
+    bypassFieldGuards: new Set<SystemAttribute>(['purchase_order_status']),
+  })
+  await fieldValueService.setValuesForEntity({
+    recordId: toRecordId(resolveDefId('purchase_order'), purchaseOrderInstanceId),
+    values: writes,
+  })
+}

--- a/packages/lib/src/money/send-email.ts
+++ b/packages/lib/src/money/send-email.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/money/send-email.ts
 
 import { database as db } from '@auxx/database'
+import type { SnippetSystemType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import type { RecordId, TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
@@ -9,6 +10,12 @@ import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { getOrgCache } from '../cache'
 import type { DocumentType } from '../documents'
 import { ensureDocumentPdf, ensureDocumentPdfViaQueue } from '../documents'
+// Imported from the registry's CLIENT-SAFE half, not `../documents/registry` — `registry.ts`
+// pulls in `@react-pdf/renderer` components and the server-only payload builders, and
+// `documents/index.ts` re-exports it. `documents/client.ts` is constants only (no react-pdf,
+// no storage, no 'use client' directive) and is the module `registry.ts` itself imports its
+// id/entityType pairing from, so this is the same source of truth with none of the weight.
+import { DOCUMENT_TYPE_DESCRIPTORS } from '../documents/client'
 import { BadRequestError } from '../errors'
 import { formatToDisplayValue } from '../field-values/formatter'
 import { extractRelationshipRecordIds } from '../field-values/relationship-field'
@@ -33,21 +40,141 @@ function firstTyped(
 }
 
 /**
- * Resolve a quote/invoice RecordId's document type. The def component arrives in TWO
- * conventions: the internal builders (`quote-lifecycle.ts`/`gather.ts`/`money.ts`) use the
- * literal system entityType string (`toRecordId('invoice', ...)`), while the records view /
- * drawer keys off the EntityDefinition CUID (`toRecordId(entityDefinitionId, ...)` in
- * records-view.tsx). The drawer's "Send" button uses the CUID form, so a plain
- * `=== 'invoice'` string check misclassifies every drawer-sent invoice as a quote (money MI1
- * build spec §H.2/§H.3). Match the literal first, then fall back to the org's `entityDefs`
- * cache so both conventions resolve correctly.
+ * Everything that used to be a `documentType === 'invoice' ? … : <quote>` ternary in
+ * {@link prepareDocumentEmail}, as one row per document type.
+ *
+ * 🛑 The ternaries were the same "everything else is a quote" shape as the `documentTypeOf`
+ * default fixed above (purchasing plan 07 §2.1). They fail loudly rather than silently — a
+ * purchase order reported *"This quote has no contact"* — but they still blocked the PO send
+ * path outright. A table means a fourth document type is a row, not another nested ternary.
  */
-async function documentTypeOf(organizationId: string, recordId: RecordId): Promise<DocumentType> {
+export interface DocumentEmailProfile {
+  /**
+   * `CustomField.systemAttribute` of the document's `belongs_to -> contact` field — the
+   * EMAIL RECIPIENT.
+   *
+   * 🛑 A purchase order's addressee is genuinely different from a quote's or an invoice's and
+   * this row is where that is resolved, not papered over. The party a PO is FOR is its
+   * `purchase_order_vendor`, which points at a `company` — and `company` has no email field
+   * at all, so it can never be a recipient. `purchase_order_contact` exists precisely to name
+   * the PERSON at that vendor the order is sent to, and it is deliberately shaped as a copy
+   * of `quote_contact` so this stays a map entry rather than a second code path. Never try to
+   * email the vendor company.
+   */
+  contactSystemAttribute: 'quote_contact' | 'invoice_contact' | 'purchase_order_contact'
+  /** `entityDefs` cache key (the `EntityDefinition.entityType` slug) for the placeholder root. */
+  entityDefsKey: string
+  /** The org's seeded system snippet used as the email body. */
+  snippetSystemType: SnippetSystemType
+  /** Human noun for this document in error copy. */
+  noun: string
+  /** Tail of the no-contact error, after the em dash. Names the field as the UI labels it. */
+  noContactHint: string
+}
+
+/**
+ * One profile per {@link DocumentType} — keyed by the union derived from
+ * `DOCUMENT_TYPE_DESCRIPTORS`, so registering a FOURTH document type for printing without
+ * giving it a send profile here is a compile error rather than a runtime surprise.
+ */
+export const DOCUMENT_EMAIL_PROFILES: Record<DocumentType, DocumentEmailProfile> = {
+  quote: {
+    contactSystemAttribute: 'quote_contact',
+    entityDefsKey: 'quote',
+    snippetSystemType: 'quote_email',
+    noun: 'quote',
+    noContactHint: 'add one before sending',
+  },
+  invoice: {
+    contactSystemAttribute: 'invoice_contact',
+    entityDefsKey: 'invoice',
+    snippetSystemType: 'invoice_email',
+    noun: 'invoice',
+    noContactHint: 'add one before sending',
+  },
+  purchase_order: {
+    contactSystemAttribute: 'purchase_order_contact',
+    entityDefsKey: 'purchase_order',
+    snippetSystemType: 'purchase_order_email',
+    noun: 'purchase order',
+    // ⚠️ `purchase_order_contact` is nullable and nothing prefills it, so "no contact" is the
+    // COMMON case, not an edge case — the message has to be actionable rather than a bare
+    // restatement. "Contact" is the field's label in `purchase-order-fields.ts`.
+    noContactHint:
+      'set the Contact field to the person at the vendor who should receive this order',
+  },
+}
+
+/**
+ * The contact `systemAttribute` of every profile — the single `bySystemAttributes` batch both
+ * {@link prepareDocumentEmail} and {@link recordDocumentSendSignal} resolve their recipient
+ * field out of. Derived from the table so the fetched set can never drift from it.
+ */
+const DOCUMENT_CONTACT_SYSTEM_ATTRIBUTES = Object.values(DOCUMENT_EMAIL_PROFILES).map(
+  (p) => p.contactSystemAttribute
+)
+
+/**
+ * Look up the profile for a document type, or throw rather than guess a default. The runtime
+ * guard is belt-and-braces over the compile-time `Record<DocumentType, …>` exhaustiveness:
+ * `DocumentType` is derived from a mutable descriptor array, so a type registered at runtime
+ * that never got a profile row must fail loudly here, the same way `documentTypeOf` does.
+ */
+function documentEmailProfile(documentType: DocumentType): DocumentEmailProfile {
+  const profile = DOCUMENT_EMAIL_PROFILES[documentType]
+  if (!profile) {
+    throw new BadRequestError(`No email profile is registered for document type "${documentType}"`)
+  }
+  return profile
+}
+
+/**
+ * Resolve a document RecordId's {@link DocumentType} against the document-type registry, or
+ * throw.
+ *
+ * The def component arrives in TWO conventions, and both must keep working: the internal
+ * builders (`quote-lifecycle.ts`/`gather.ts`/`money.ts`) use the literal system entityType
+ * string (`toRecordId('invoice', ...)`), while the records view / drawer keys off the
+ * EntityDefinition CUID (`toRecordId(entityDefinitionId, ...)` in records-view.tsx). The
+ * drawer's "Send" button uses the CUID form, so a plain `=== 'invoice'` string check
+ * misclassifies every drawer-sent invoice as a quote (money MI1 build spec §H.2/§H.3). Match
+ * the literal against every registered `entityType` first, then fall back to the org's
+ * `entityDefs` cache so both conventions resolve correctly.
+ *
+ * Resolution runs over `DOCUMENT_TYPE_DESCRIPTORS` and THROWS on an unregistered def — it
+ * must never default. The previous version fell back to `'quote'`, so anything that was not
+ * an invoice was classified a quote: the first purchase order sent through this path would
+ * have run the quote branch in {@link prepareDocumentEmail} and been minted a public,
+ * customer-facing approve/decline link for a document addressed to a vendor (purchasing plan
+ * 07 §2.1). Nothing threw — the email sent and the PDF attached. A function that cannot fail
+ * cannot tell you it guessed. Adding an entry to the registry is now all that send needs, and
+ * forgetting to is a loud error rather than a wrong branch.
+ *
+ * @param organizationId Org whose `entityDefs` cache resolves the CUID convention.
+ * @param recordId The document record being sent.
+ * @throws {BadRequestError} when no registered document type matches the record's def.
+ */
+export async function documentTypeOf(
+  organizationId: string,
+  recordId: RecordId
+): Promise<DocumentType> {
   const { entityDefinitionId } = parseRecordId(recordId)
-  if (entityDefinitionId === 'invoice') return 'invoice'
-  if (entityDefinitionId === 'quote') return 'quote'
+
+  // Convention 1 — the literal `EntityDefinition.entityType` slug.
+  const byEntityType = DOCUMENT_TYPE_DESCRIPTORS.find((d) => d.entityType === entityDefinitionId)
+  if (byEntityType) return byEntityType.id
+
+  // Convention 2 — the per-org `EntityDefinition.id` cuid. `entityDefs` maps entityType slug
+  // to def id, which is exactly the pairing the descriptors carry.
   const entityDefs = await getOrgCache().get(organizationId, 'entityDefs')
-  return entityDefinitionId === entityDefs.invoice ? 'invoice' : 'quote'
+  const byDefId = DOCUMENT_TYPE_DESCRIPTORS.find(
+    (d) => entityDefs[d.entityType] === entityDefinitionId
+  )
+  if (byDefId) return byDefId.id
+
+  throw new BadRequestError(
+    `No document type is registered for entity definition "${entityDefinitionId}" — it cannot be sent as a document`
+  )
 }
 
 export interface EnsureQuoteDocumentPdfInput {
@@ -112,10 +239,11 @@ export interface PrepareDocumentEmailResult {
 }
 
 /**
- * Build the prefilled send-email payload for a quote OR invoice (money MQ2
- * build spec §E.1; MI1 §H.2 adds the invoice branch). Resolves the org's
- * seeded `quote_email`/`invoice_email` system snippet's placeholder spans
- * against the document + its contact at PREFILL time (not send time) — for
+ * Build the prefilled send-email payload for any registered document type — quote, invoice or
+ * purchase order (money MQ2 build spec §E.1; MI1 §H.2 added the invoice branch; purchasing
+ * plan 07 replaced the branches with {@link DOCUMENT_EMAIL_PROFILES}). Resolves the org's
+ * seeded `quote_email`/`invoice_email`/`purchase_order_email` system snippet's placeholder
+ * spans against the document + its contact at PREFILL time (not send time) — for
  * a brand-new outbound thread the primary-entity link is only applied AFTER
  * send (`thread.ts`'s `linkTicketId` block), so send-time resolution would
  * have no record to resolve `quote:*`/`invoice:*`/`contact:*` tokens
@@ -131,20 +259,17 @@ export async function prepareDocumentEmail(
   const handler = new UnifiedCrudHandler(organizationId, userId)
   const cache = getOrgCache()
 
-  const noContactMessage =
-    documentType === 'invoice'
-      ? 'This invoice has no contact — add one before sending'
-      : 'This quote has no contact — add one before sending'
-  const noEmailMessage =
-    documentType === 'invoice'
-      ? 'This invoice contact has no email address — add one before sending'
-      : 'This quote contact has no email address — add one before sending'
+  const profile = documentEmailProfile(documentType)
+
+  const noContactMessage = `This ${profile.noun} has no contact — ${profile.noContactHint}`
+  const noEmailMessage = `This ${profile.noun} contact has no email address — add one before sending`
 
   // ─── Step 1: the document's contact (email required to send) ───────────
+  // The fetched attribute set is derived from the profile table so the two can never drift.
   const cf = await cache
     .from(organizationId, 'customFields')
-    .bySystemAttributes(['quote_contact', 'invoice_contact'] as const)
-  const contactField = documentType === 'invoice' ? cf.invoice_contact : cf.quote_contact
+    .bySystemAttributes(DOCUMENT_CONTACT_SYSTEM_ATTRIBUTES)
+  const contactField = cf[profile.contactSystemAttribute]
   const contactFieldId = contactField?.id
   const documentValues = contactFieldId
     ? await handler.getFieldValues(documentRecordId, [contactFieldId])
@@ -210,19 +335,15 @@ export async function prepareDocumentEmail(
     throw new BadRequestError(noEmailMessage)
   }
 
-  // ─── Step 2: the seeded quote_email/invoice_email system snippet ────────
-  const snippet = await getSystemSnippet(
-    db,
-    organizationId,
-    documentType === 'invoice' ? 'invoice_email' : 'quote_email'
-  )
+  // ─── Step 2: the seeded per-document-type system snippet ────────────────
+  const snippet = await getSystemSnippet(db, organizationId, profile.snippetSystemType)
 
   // ─── Step 3: resolve the snippet's placeholder spans ────────────────────
   // recordIdsByRoot keys off `EntityDefinition.id` cuids (the field-token
   // root — see system-snippets.ts's `fieldToken`), NOT the RecordId's own
   // (possibly literal-type-string) def component.
   const entityDefs = await cache.get(organizationId, 'entityDefs')
-  const documentDefId = documentType === 'invoice' ? entityDefs.invoice : entityDefs.quote
+  const documentDefId = entityDefs[profile.entityDefsKey]
   const recordIdsByRoot = new Map<string, RecordId>()
   if (documentDefId) recordIdsByRoot.set(documentDefId, documentRecordId)
   if (entityDefs.contact) recordIdsByRoot.set(entityDefs.contact, contactRecordId)
@@ -261,6 +382,15 @@ export async function prepareDocumentEmail(
   // Same rationale as the invoice pay-link above — appended here rather than a snippet
   // placeholder. Gated on `documents.quote.acceptancePageEnabled` only; when off, the email
   // is left exactly as resolved by the snippet (PDF-only behavior, unchanged).
+  //
+  // DO NOT HOIST `ensureQuotePublicToken` / `buildQuoteViewUrl` OUT OF THIS BRANCH.
+  // `./quote-public-token` is imported at module level, so the only thing keeping a quote
+  // public token off a non-quote document is this `documentType === 'quote'` test
+  // (purchasing plan 07 §2.3). A quote's public link exists so a CUSTOMER can approve or
+  // decline; a purchase order is addressed to a VENDOR, who responds by email or by shipping,
+  // and must never be handed an approve/decline link. Minting one fails silently — the email
+  // still sends, the PDF still attaches — so a refactor that lifts token minting to the
+  // common path would re-acquire the §2.1 bug with no test and no exception to notice it by.
   if (documentType === 'quote') {
     const { entityInstanceId: quoteInstanceId } = parseRecordId(documentRecordId)
     const acceptancePageEnabled = await getOrganizationSetting({
@@ -306,10 +436,14 @@ export interface RecordDocumentSendSignalInput {
 /**
  * Manual document-send signal writer (client-notifications plan §4.8/Phase 4) — called from
  * `thread.ts`'s `sendMessage` procedure right after a CONFIRMED successful send flips the
- * quote/invoice to `sent`. Resolves the recipient contact and the linked work order (if any)
- * so the job/contact communications view is honest about manual sends, not just sequence
- * sends. Never throws — a signal-write failure must not fail (or retroactively look like it
- * failed) an email that already went out.
+ * document's lifecycle status (quote/invoice `sent`, purchase order `issued`). Resolves the
+ * recipient contact — through the same {@link DOCUMENT_EMAIL_PROFILES} table the email itself
+ * used — and the linked work order (if any) so the job/contact communications view is honest
+ * about manual sends, not just sequence sends. Never throws — a signal-write failure must not
+ * fail (or retroactively look like it failed) an email that already went out.
+ *
+ * `documentType` flows straight into `toSignalRecordKey`, so every `DocumentType` must also
+ * be a `SignalRecordKind` (`signals/record-signal.ts`).
  */
 export async function recordDocumentSendSignal(
   input: RecordDocumentSendSignalInput
@@ -322,11 +456,12 @@ export async function recordDocumentSendSignal(
     const cache = getOrgCache()
 
     // ─── Recipient contact ──────────────────────────────────────────────────
+    // Same profile table as `prepareDocumentEmail`, so the signal's recipient is by
+    // construction the address the email actually went to.
     const contactCf = await cache
       .from(organizationId, 'customFields')
-      .bySystemAttributes(['quote_contact', 'invoice_contact', 'primary_email'] as const)
-    const contactField =
-      documentType === 'invoice' ? contactCf.invoice_contact : contactCf.quote_contact
+      .bySystemAttributes([...DOCUMENT_CONTACT_SYSTEM_ATTRIBUTES, 'primary_email' as const])
+    const contactField = contactCf[documentEmailProfile(documentType).contactSystemAttribute]
 
     let contactEntityInstanceId: string | undefined
     let recipientEmail: string | undefined
@@ -348,6 +483,10 @@ export async function recordDocumentSendSignal(
 
     // ─── Linked work order (invoice: singular `invoice_work_order`; quote: array
     // `quote_work_orders`, first entry — a quote can spawn more than one job) ──────────
+    // NOT table-ified: this is not one concept with three spellings. The two fields have
+    // different cardinality (belongs_to vs has_many) and therefore different extraction, and
+    // a purchase order has no work-order link at all — it is a supplier document, not a job
+    // document. Both `if` arms simply don't fire for it, which is the correct behavior.
     const woCf = await cache
       .from(organizationId, 'customFields')
       .bySystemAttributes(['invoice_work_order', 'quote_work_orders'] as const)

--- a/packages/lib/src/purchasing/__tests__/purchase-order-status-writer.test.ts
+++ b/packages/lib/src/purchasing/__tests__/purchase-order-status-writer.test.ts
@@ -1,0 +1,537 @@
+// packages/lib/src/purchasing/__tests__/purchase-order-status-writer.test.ts
+//
+// `purchase_order_receipt_status` and `_billing_status` are declared
+// `creatable: false, updatable: false, computed: true` — unwritable by a human
+// by construction — so if this module is not their writer they are NULL forever.
+//
+// The pull-forward half is the sharper risk: this is the ONE derived writer
+// allowed to touch the ACTION field, and every guard below is the difference
+// between "a receipt records that the order is live" and "a straggler receipt
+// silently reopens an order somebody canceled".
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  setValueWithType: vi.fn(),
+  createFieldValueContext: vi.fn(),
+  requireCachedEntityDefId: vi.fn(),
+  publishFieldValueUpdates: vi.fn(),
+  /** Result sets the module's queries consume, in call order. */
+  dbResults: [] as unknown[][],
+}))
+
+/** Chainable drizzle stub — resolves to the next queued result set. */
+function makeChain() {
+  const result = h.dbResults.shift() ?? []
+  const chain: Record<string, unknown> = {}
+  for (const key of ['from', 'innerJoin', 'leftJoin', 'where', 'limit', 'groupBy']) {
+    chain[key] = () => chain
+  }
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve)
+  return chain
+}
+
+vi.mock('@auxx/database', () => ({
+  database: { select: () => makeChain() },
+  schema: {
+    FieldValue: {
+      entityId: 'entityId',
+      organizationId: 'organizationId',
+      fieldId: 'fieldId',
+      valueNumber: 'valueNumber',
+      optionId: 'optionId',
+      relatedEntityId: 'relatedEntityId',
+    },
+  },
+}))
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+  requireCachedEntityDefId: h.requireCachedEntityDefId,
+}))
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: h.createFieldValueContext,
+}))
+vi.mock('../../field-values/stored-field-type', () => ({ toFieldType: () => 'SINGLE_SELECT' }))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishFieldValueUpdates: h.publishFieldValueUpdates,
+}))
+
+import {
+  recalculatePurchaseOrderStatuses,
+  recalculatePurchaseOrderStatusesForLines,
+} from '../purchase-order-status-writer'
+
+const ORG = 'org_1'
+const PO_LINE = 'poline-1'
+const PO = 'po-1'
+
+const FIELDS = {
+  purchase_order_line_purchase_order: { id: 'fld-po-rel', type: 'RELATIONSHIP' },
+  purchase_order_line_quantity_ordered: { id: 'fld-ordered', type: 'NUMBER' },
+  purchase_order_line_quantity_received: { id: 'fld-received', type: 'NUMBER' },
+  purchase_order_line_quantity_billed: { id: 'fld-billed', type: 'NUMBER' },
+  purchase_order_status: { id: 'fld-status', type: 'SINGLE_SELECT' },
+  purchase_order_receipt_status: { id: 'fld-receipt', type: 'SINGLE_SELECT' },
+  purchase_order_billing_status: { id: 'fld-billing', type: 'SINGLE_SELECT' },
+}
+
+/**
+ * Queue the ONE read the module makes.
+ *
+ * ⚡ Changed with the query fold: the parent order, the order's lines and the
+ * order's current SELECT values used to be three sequential statements and are
+ * a single one now, so every row carries the order id and the order's three
+ * option values alongside that line's quantities. The `it()` bodies below are
+ * untouched — they still describe the reads in the same vocabulary; only this
+ * helper knows the shape changed.
+ *
+ * An orphaned line (`order: null`) returns no rows at all, which is exactly what
+ * the folded query does when its anchor subquery resolves to NULL.
+ */
+function queueReads(options: {
+  order?: string | null
+  lines?: Array<{ ordered: number | null; received: number | null; billed: number | null }>
+  current?: Array<{ fieldId: string; optionId: string | null }>
+}) {
+  if (options.order === null) {
+    h.dbResults.push([])
+    return
+  }
+  const optionFor = (fieldId: string) =>
+    (options.current ?? []).find((row) => row.fieldId === fieldId)?.optionId ?? null
+
+  const lines = options.lines ?? [{ ordered: 10, received: 0, billed: 0 }]
+  h.dbResults.push(
+    lines.map((line) => ({
+      orderId: options.order ?? PO,
+      ...line,
+      statusOption: optionFor('fld-status'),
+      receiptStatusOption: optionFor('fld-receipt'),
+      billingStatusOption: optionFor('fld-billing'),
+    }))
+  )
+}
+
+/** The `(fieldId, optionId)` pairs written this call. */
+function writes(): Array<[string, string]> {
+  return h.setValueWithType.mock.calls.map((call) => [
+    call[1].fieldId as string,
+    (call[1].value as { optionId: string }).optionId,
+  ])
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.dbResults = []
+  h.bySystemAttributes.mockResolvedValue(FIELDS)
+  h.createFieldValueContext.mockReturnValue({ organizationId: ORG })
+  h.requireCachedEntityDefId.mockResolvedValue('podef')
+  h.setValueWithType.mockResolvedValue([])
+  h.publishFieldValueUpdates.mockResolvedValue(undefined)
+})
+
+describe('the derived statuses', () => {
+  it('writes both axes onto the ORDER, resolved from the line', async () => {
+    queueReads({ lines: [{ ordered: 10, received: 10, billed: 4 }] })
+
+    const result = await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      { organizationId: ORG },
+      expect.objectContaining({
+        recordId: `podef:${PO}`,
+        fieldId: 'fld-receipt',
+        value: { type: 'option', optionId: 'received' },
+      })
+    )
+    expect(writes()).toContainEqual(['fld-billing', 'partially_billed'])
+  })
+
+  it('sums across ALL the order’s lines, not just the one that moved', async () => {
+    queueReads({
+      lines: [
+        { ordered: 10, received: 10, billed: 0 },
+        { ordered: 10, received: 0, billed: 0 },
+      ],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes()).toContainEqual(['fld-receipt', 'partially_received'])
+  })
+
+  it('reads a line with no quantity values at all as zeroes rather than dropping it', async () => {
+    queueReads({
+      lines: [
+        { ordered: 10, received: 10, billed: 10 },
+        { ordered: null, received: null, billed: null },
+      ],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    // The second line is ordered=0/received=0, which is satisfied — so the
+    // order still completes, but only because it was READ, not skipped.
+    expect(writes()).toContainEqual(['fld-receipt', 'received'])
+  })
+
+  it('publishes exactly what it wrote', async () => {
+    queueReads({
+      lines: [{ ordered: 10, received: 4, billed: 0 }],
+      current: [{ fieldId: 'fld-billing', optionId: 'not_billed' }],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    const entries = h.publishFieldValueUpdates.mock.calls[0]?.[2] as Array<{
+      value: { optionId: string }
+    }>
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.value).toEqual({ type: 'option', optionId: 'partially_received' })
+  })
+})
+
+describe('write only the diff', () => {
+  it('writes nothing at all when both derived values already match', async () => {
+    queueReads({
+      lines: [{ ordered: 10, received: 10, billed: 10 }],
+      current: [
+        { fieldId: 'fld-receipt', optionId: 'received' },
+        { fieldId: 'fld-billing', optionId: 'billed' },
+        { fieldId: 'fld-status', optionId: 'issued' },
+      ],
+    })
+
+    const result = await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
+    expect(result._unsafeUnwrap()).toEqual({})
+  })
+
+  it('writes only the axis that moved', async () => {
+    queueReads({
+      lines: [{ ordered: 10, received: 10, billed: 0 }],
+      current: [
+        { fieldId: 'fld-receipt', optionId: 'partially_received' },
+        { fieldId: 'fld-billing', optionId: 'not_billed' },
+        { fieldId: 'fld-status', optionId: 'issued' },
+      ],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes()).toEqual([['fld-receipt', 'received']])
+  })
+})
+
+describe('the draft -> issued pull-forward', () => {
+  const RECEIPT_LINES = [{ ordered: 10, received: 4, billed: 0 }]
+
+  it('moves a draft order to issued on a receipt', async () => {
+    queueReads({
+      lines: RECEIPT_LINES,
+      current: [{ fieldId: 'fld-status', optionId: 'draft' }],
+    })
+
+    const result = await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes()).toContainEqual(['fld-status', 'issued'])
+    expect(result._unsafeUnwrap().status).toBe('issued')
+  })
+
+  it('records BOTH facts at once — the whole point of the three-field split', async () => {
+    queueReads({
+      lines: RECEIPT_LINES,
+      current: [{ fieldId: 'fld-status', optionId: 'draft' }],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes()).toContainEqual(['fld-receipt', 'partially_received'])
+    expect(writes()).toContainEqual(['fld-status', 'issued'])
+  })
+
+  it('does NOT move a closed order — a straggler receipt must not reopen it', async () => {
+    queueReads({
+      lines: RECEIPT_LINES,
+      current: [{ fieldId: 'fld-status', optionId: 'closed' }],
+    })
+
+    const result = await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes().map(([fieldId]) => fieldId)).not.toContain('fld-status')
+    expect(result._unsafeUnwrap().status).toBeUndefined()
+  })
+
+  it('does NOT move a canceled order', async () => {
+    queueReads({
+      lines: RECEIPT_LINES,
+      current: [{ fieldId: 'fld-status', optionId: 'canceled' }],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes().map(([fieldId]) => fieldId)).not.toContain('fld-status')
+  })
+
+  it('leaves an issued order issued — it never rewrites the value it already holds', async () => {
+    queueReads({
+      lines: RECEIPT_LINES,
+      current: [{ fieldId: 'fld-status', optionId: 'issued' }],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes().map(([fieldId]) => fieldId)).not.toContain('fld-status')
+  })
+
+  it('does NOT pull forward on BILLING evidence — this business prepays', async () => {
+    queueReads({
+      lines: [{ ordered: 10, received: 4, billed: 4 }],
+      current: [{ fieldId: 'fld-status', optionId: 'draft' }],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'billing',
+    })
+
+    expect(writes().map(([fieldId]) => fieldId)).not.toContain('fld-status')
+  })
+
+  it('does NOT pull forward when the receipt evidence nets to nothing', async () => {
+    // The roll-up fires on a movement DELETE too. Losing the last receipt is
+    // the opposite of evidence that the order was sent.
+    queueReads({
+      lines: [{ ordered: 10, received: 0, billed: 0 }],
+      current: [{ fieldId: 'fld-status', optionId: 'draft' }],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes().map(([fieldId]) => fieldId)).not.toContain('fld-status')
+  })
+
+  it('does NOT pull forward an order with no recorded status', async () => {
+    queueReads({ lines: RECEIPT_LINES, current: [] })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(writes().map(([fieldId]) => fieldId)).not.toContain('fld-status')
+  })
+
+  it('declares purchase_order_status — and only that — as a bypassed field guard', async () => {
+    queueReads({
+      lines: RECEIPT_LINES,
+      current: [{ fieldId: 'fld-status', optionId: 'draft' }],
+    })
+
+    await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    const options = h.createFieldValueContext.mock.calls[0]?.[4] as {
+      bypassFieldGuards: Set<string>
+    }
+    expect([...options.bypassFieldGuards]).toEqual(['purchase_order_status'])
+  })
+})
+
+describe('the no-op paths', () => {
+  it('is a silent no-op for a line with no purchase order', async () => {
+    queueReads({ order: null })
+
+    const result = await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(result._unsafeUnwrap()).toEqual({})
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('writes nothing when the org lacks one of the derived status fields', async () => {
+    h.bySystemAttributes.mockResolvedValue({
+      ...FIELDS,
+      purchase_order_receipt_status: null,
+    })
+
+    const result = await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('returns err rather than throwing, so the committed line roll-up survives', async () => {
+    h.bySystemAttributes.mockRejectedValue(new Error('cache exploded'))
+
+    const result = await recalculatePurchaseOrderStatuses({
+      organizationId: ORG,
+      purchaseOrderLineInstanceId: PO_LINE,
+      evidence: 'receipt',
+    })
+
+    expect(result.isErr()).toBe(true)
+  })
+})
+
+describe('the batched pass', () => {
+  /**
+   * The distinct-orders read, then one folded read per order. The batched pass
+   * is anchored on the ORDER, so its rows look identical to the per-line one's.
+   */
+  function queueBatch(orders: string[], perOrder: () => void) {
+    h.dbResults.push(orders.map((relatedEntityId) => ({ relatedEntityId })))
+    for (const _order of orders) perOrder()
+  }
+
+  it('derives ONE order once, however many of its lines moved', async () => {
+    queueBatch([PO], () => queueReads({ lines: [{ ordered: 10, received: 10, billed: 0 }] }))
+
+    const result = await recalculatePurchaseOrderStatusesForLines({
+      organizationId: ORG,
+      purchaseOrderLineInstanceIds: ['pol_1', 'pol_2', 'pol_3'],
+      evidence: 'receipt',
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toHaveLength(1)
+    expect(writes()).toContainEqual(['fld-receipt', 'received'])
+  })
+
+  it('derives each DISTINCT order behind the set, not just the first', async () => {
+    // `receivePurchaseOrder` takes a line list, not an order — nothing stops a
+    // caller naming lines of two different orders.
+    queueBatch(['po-1', 'po-2'], () =>
+      queueReads({ lines: [{ ordered: 10, received: 10, billed: 0 }] })
+    )
+
+    const result = await recalculatePurchaseOrderStatusesForLines({
+      organizationId: ORG,
+      purchaseOrderLineInstanceIds: ['pol_1', 'pol_2'],
+      evidence: 'receipt',
+    })
+
+    expect(result._unsafeUnwrap()).toHaveLength(2)
+  })
+
+  it('carries the evidence through — a bill still never pulls an order forward', async () => {
+    queueBatch([PO], () =>
+      queueReads({
+        lines: [{ ordered: 10, received: 4, billed: 4 }],
+        current: [{ fieldId: 'fld-status', optionId: 'draft' }],
+      })
+    )
+
+    await recalculatePurchaseOrderStatusesForLines({
+      organizationId: ORG,
+      purchaseOrderLineInstanceIds: ['pol_1'],
+      evidence: 'billing',
+    })
+
+    expect(writes().map(([fieldId]) => fieldId)).not.toContain('fld-status')
+  })
+
+  it('reads nothing at all for an empty set', async () => {
+    const result = await recalculatePurchaseOrderStatusesForLines({
+      organizationId: ORG,
+      purchaseOrderLineInstanceIds: [],
+      evidence: 'receipt',
+    })
+
+    expect(result._unsafeUnwrap()).toEqual([])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('is a silent no-op when every line in the set is orphaned', async () => {
+    h.dbResults.push([])
+
+    const result = await recalculatePurchaseOrderStatusesForLines({
+      organizationId: ORG,
+      purchaseOrderLineInstanceIds: ['pol_1'],
+      evidence: 'receipt',
+    })
+
+    expect(result._unsafeUnwrap()).toEqual([])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('returns err rather than throwing, like its per-line sibling', async () => {
+    h.bySystemAttributes.mockRejectedValue(new Error('cache exploded'))
+
+    const result = await recalculatePurchaseOrderStatusesForLines({
+      organizationId: ORG,
+      purchaseOrderLineInstanceIds: ['pol_1'],
+      evidence: 'receipt',
+    })
+
+    expect(result.isErr()).toBe(true)
+  })
+})

--- a/packages/lib/src/purchasing/__tests__/purchase-order-status.test.ts
+++ b/packages/lib/src/purchasing/__tests__/purchase-order-status.test.ts
@@ -1,0 +1,190 @@
+// packages/lib/src/purchasing/__tests__/purchase-order-status.test.ts
+//
+// The classifier is pure, so every rule in
+// plans/purchasing/07-purchase-order-send-and-status.md §3.3 is testable here
+// without a single mock. The writer's tests cover the database half.
+
+import { describe, expect, it } from 'vitest'
+import {
+  derivePurchaseOrderStatuses,
+  type PurchaseOrderLineQuantities,
+} from '../purchase-order-status'
+
+/** A line, defaulting to "ordered 10, nothing happened yet". */
+function line(overrides: Partial<PurchaseOrderLineQuantities> = {}): PurchaseOrderLineQuantities {
+  return { quantityOrdered: 10, quantityReceived: 0, quantityBilled: 0, ...overrides }
+}
+
+describe('derivePurchaseOrderStatuses — the nine combinations', () => {
+  // The two axes are independent, so the exhaustive table is receipt x billing.
+  const NOTHING = 0
+  const SOME = 4
+  const ALL = 10
+
+  const cases: Array<{
+    received: number
+    billed: number
+    receiptStatus: string
+    billingStatus: string
+  }> = [
+    {
+      received: NOTHING,
+      billed: NOTHING,
+      receiptStatus: 'not_received',
+      billingStatus: 'not_billed',
+    },
+    {
+      received: NOTHING,
+      billed: SOME,
+      receiptStatus: 'not_received',
+      billingStatus: 'partially_billed',
+    },
+    { received: NOTHING, billed: ALL, receiptStatus: 'not_received', billingStatus: 'billed' },
+    {
+      received: SOME,
+      billed: NOTHING,
+      receiptStatus: 'partially_received',
+      billingStatus: 'not_billed',
+    },
+    {
+      received: SOME,
+      billed: SOME,
+      receiptStatus: 'partially_received',
+      billingStatus: 'partially_billed',
+    },
+    { received: SOME, billed: ALL, receiptStatus: 'partially_received', billingStatus: 'billed' },
+    { received: ALL, billed: NOTHING, receiptStatus: 'received', billingStatus: 'not_billed' },
+    { received: ALL, billed: SOME, receiptStatus: 'received', billingStatus: 'partially_billed' },
+    { received: ALL, billed: ALL, receiptStatus: 'received', billingStatus: 'billed' },
+  ]
+
+  for (const c of cases) {
+    it(`received ${c.received}/10, billed ${c.billed}/10 -> ${c.receiptStatus} + ${c.billingStatus}`, () => {
+      expect(
+        derivePurchaseOrderStatuses([
+          line({ quantityReceived: c.received, quantityBilled: c.billed }),
+        ])
+      ).toEqual({ receiptStatus: c.receiptStatus, billingStatus: c.billingStatus })
+    })
+  }
+
+  it('is the prepayment case that one enum could not express: fully billed, nothing received', () => {
+    expect(
+      derivePurchaseOrderStatuses([line({ quantityReceived: 0, quantityBilled: 10 })])
+    ).toEqual({ receiptStatus: 'not_received', billingStatus: 'billed' })
+  })
+})
+
+describe('derivePurchaseOrderStatuses — over-receipt and over-billing', () => {
+  it('calls an over-received line `received`, not `partially_received`', () => {
+    // A vendor shipping 105 against an order for 100 is a real, ordinary event.
+    // An `===` completion test would report this order as partial forever.
+    expect(
+      derivePurchaseOrderStatuses([line({ quantityOrdered: 100, quantityReceived: 105 })])
+        .receiptStatus
+    ).toBe('received')
+  })
+
+  it('calls an over-billed line `billed`', () => {
+    expect(
+      derivePurchaseOrderStatuses([line({ quantityOrdered: 100, quantityBilled: 101 })])
+        .billingStatus
+    ).toBe('billed')
+  })
+
+  it('does not let one over-received line complete an order another line is short on', () => {
+    expect(
+      derivePurchaseOrderStatuses([
+        line({ quantityOrdered: 10, quantityReceived: 50 }),
+        line({ quantityOrdered: 10, quantityReceived: 1 }),
+      ]).receiptStatus
+    ).toBe('partially_received')
+  })
+})
+
+describe('derivePurchaseOrderStatuses — multiple lines', () => {
+  it('needs EVERY line satisfied before it says received', () => {
+    expect(
+      derivePurchaseOrderStatuses([
+        line({ quantityReceived: 10 }),
+        line({ quantityReceived: 10 }),
+        line({ quantityReceived: 9 }),
+      ]).receiptStatus
+    ).toBe('partially_received')
+  })
+
+  it('needs only ONE line with progress before it says partially received', () => {
+    expect(
+      derivePurchaseOrderStatuses([
+        line({ quantityReceived: 0 }),
+        line({ quantityReceived: 0 }),
+        line({ quantityReceived: 1 }),
+      ]).receiptStatus
+    ).toBe('partially_received')
+  })
+
+  it('moves the two axes independently across lines', () => {
+    expect(
+      derivePurchaseOrderStatuses([
+        line({ quantityReceived: 10, quantityBilled: 0 }),
+        line({ quantityReceived: 10, quantityBilled: 3 }),
+      ])
+    ).toEqual({ receiptStatus: 'received', billingStatus: 'partially_billed' })
+  })
+})
+
+describe('derivePurchaseOrderStatuses — the edges', () => {
+  it('returns not_received / not_billed for an order with ZERO lines', () => {
+    // `every` over an empty list is vacuously true. Without the explicit guard a
+    // purchase order nobody has typed a line into yet would read as fully
+    // received and fully billed, then flip BACKWARDS on the first line.
+    expect(derivePurchaseOrderStatuses([])).toEqual({
+      receiptStatus: 'not_received',
+      billingStatus: 'not_billed',
+    })
+  })
+
+  it('treats a line ordered=0 as satisfied — nothing was ordered, nothing is outstanding', () => {
+    expect(
+      derivePurchaseOrderStatuses([line({ quantityOrdered: 0, quantityReceived: 0 })])
+    ).toEqual({ receiptStatus: 'received', billingStatus: 'billed' })
+  })
+
+  it('does not let an ordered=0 line hold an otherwise complete order open', () => {
+    expect(
+      derivePurchaseOrderStatuses([
+        line({ quantityOrdered: 10, quantityReceived: 10 }),
+        line({ quantityOrdered: 0, quantityReceived: 0 }),
+      ]).receiptStatus
+    ).toBe('received')
+  })
+
+  it('does not let an ordered=0 line complete an order that is still short elsewhere', () => {
+    expect(
+      derivePurchaseOrderStatuses([
+        line({ quantityOrdered: 10, quantityReceived: 0 }),
+        line({ quantityOrdered: 0, quantityReceived: 0 }),
+      ]).receiptStatus
+    ).toBe('not_received')
+  })
+
+  it('reads a net-zero line as not_received, not partially_received', () => {
+    // A receipt fully reversed by a return sums back to 0. Nothing is there.
+    expect(
+      derivePurchaseOrderStatuses([line({ quantityOrdered: 10, quantityReceived: 0 })])
+        .receiptStatus
+    ).toBe('not_received')
+  })
+
+  it('reads a net-negative line as not_received', () => {
+    expect(
+      derivePurchaseOrderStatuses([line({ quantityOrdered: 10, quantityReceived: -2 })])
+        .receiptStatus
+    ).toBe('not_received')
+  })
+
+  it('is total — the same lines always give the same answer', () => {
+    const lines = [line({ quantityReceived: 4 }), line({ quantityBilled: 10 })]
+    expect(derivePurchaseOrderStatuses(lines)).toEqual(derivePurchaseOrderStatuses(lines))
+  })
+})

--- a/packages/lib/src/purchasing/client.ts
+++ b/packages/lib/src/purchasing/client.ts
@@ -25,6 +25,15 @@ export {
   priceAllowance,
 } from './match'
 export type {
+  PurchaseOrderBillingStatusValue,
+  PurchaseOrderDerivedStatuses,
+  PurchaseOrderLineQuantities,
+  PurchaseOrderReceiptStatusValue,
+} from './purchase-order-status'
+// The pure classifier only. 🛑 `recalculatePurchaseOrderStatuses` (its writer sibling)
+// reads and writes the database and must NEVER be re-exported here.
+export { derivePurchaseOrderStatuses } from './purchase-order-status'
+export type {
   AllocationBasis,
   AllocationHeader,
   AllocationLine,

--- a/packages/lib/src/purchasing/index.ts
+++ b/packages/lib/src/purchasing/index.ts
@@ -23,6 +23,18 @@ export {
   rematchOnBillLineChange,
 } from './match-hook'
 export type {
+  PurchaseOrderBillingStatusValue,
+  PurchaseOrderDerivedStatuses,
+  PurchaseOrderLineQuantities,
+  PurchaseOrderReceiptStatusValue,
+} from './purchase-order-status'
+export { derivePurchaseOrderStatuses } from './purchase-order-status'
+export type {
+  PurchaseOrderStatusEvidence,
+  PurchaseOrderStatusWrite,
+} from './purchase-order-status-writer'
+export { recalculatePurchaseOrderStatuses } from './purchase-order-status-writer'
+export type {
   AllocationBasis,
   AllocationHeader,
   AllocationLine,

--- a/packages/lib/src/purchasing/purchase-order-status-writer.ts
+++ b/packages/lib/src/purchasing/purchase-order-status-writer.ts
@@ -1,0 +1,515 @@
+// packages/lib/src/purchasing/purchase-order-status-writer.ts
+
+import { database, schema } from '@auxx/database'
+import type { CustomFieldEntity } from '@auxx/database/types'
+import { createScopedLogger } from '@auxx/logger'
+import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import type { RecordId } from '@auxx/types/resource'
+import { toRecordId } from '@auxx/types/resource'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
+import { and, eq, inArray, type SQL, sql } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { getOrgCache, requireCachedEntityDefId } from '../cache'
+import { AuxxError } from '../errors'
+import { createFieldValueContext } from '../field-values/field-value-helpers'
+import { setValueWithType } from '../field-values/field-value-mutations'
+import { toFieldType } from '../field-values/stored-field-type'
+import {
+  type FieldValueUpdateEntry,
+  getRealtimeService,
+  publishFieldValueUpdates,
+} from '../realtime'
+import { PurchaseOrderStatus } from '../resources/registry/enum-values'
+import {
+  derivePurchaseOrderStatuses,
+  type PurchaseOrderBillingStatusValue,
+  type PurchaseOrderLineQuantities,
+  type PurchaseOrderReceiptStatusValue,
+} from './purchase-order-status'
+
+const logger = createScopedLogger('purchasing:purchase-order-status')
+
+/**
+ * The database half of the derived purchase order statuses
+ * (plans/purchasing/07-purchase-order-send-and-status.md §3.3, §6.1).
+ *
+ * `purchase-order-status.ts` holds the rule; this file reads the lines, applies
+ * it, and writes the diff. It rides the roll-up that already runs — every call
+ * site is `recalculatePurchaseOrderLineRollup`, which fires on exactly the two
+ * events that can move either axis (a `stock_movement` or a `vendor_bill_line`
+ * create/delete). There is no new trigger and no new fan-out.
+ */
+
+/** What moved the roll-up, and therefore what this pass is allowed to conclude. */
+export type PurchaseOrderStatusEvidence = 'receipt' | 'billing'
+
+/**
+ * The fields this pass actually wrote. Empty when nothing changed, which is the
+ * common case — see {@link recalculatePurchaseOrderStatuses} on why the diff is
+ * computed rather than written blind.
+ */
+export interface PurchaseOrderStatusWrite {
+  receiptStatus?: PurchaseOrderReceiptStatusValue
+  billingStatus?: PurchaseOrderBillingStatusValue
+  /** Only ever `issued`, and only ever from `draft`. */
+  status?: typeof PurchaseOrderStatus.ISSUED
+}
+
+const STATUS_ATTRS = [
+  'purchase_order_line_purchase_order',
+  'purchase_order_line_quantity_ordered',
+  'purchase_order_line_quantity_received',
+  'purchase_order_line_quantity_billed',
+  'purchase_order_status',
+  'purchase_order_receipt_status',
+  'purchase_order_billing_status',
+] as const
+
+/** The seven fields this pass needs, resolved from the org cache. */
+interface StatusFields {
+  orderRelField: CustomFieldEntity
+  orderedField: CustomFieldEntity
+  receivedField: CustomFieldEntity
+  billedField: CustomFieldEntity
+  /** Optional: the ACTION field. Absent means no pull-forward, never a failure. */
+  statusField: CustomFieldEntity | undefined
+  receiptStatusField: CustomFieldEntity
+  billingStatusField: CustomFieldEntity
+}
+
+/**
+ * Which purchase order this pass is about, and how it was named.
+ *
+ * A `line` anchor resolves the order inside the one read (a scalar subquery),
+ * which is what collapsed the old resolve-then-read-lines-then-read-statuses
+ * sequence into a single round trip. An `order` anchor is the batched caller's
+ * door: it already knows the order, so it skips the subquery entirely.
+ */
+type StatusAnchor =
+  | { kind: 'line'; purchaseOrderLineInstanceId: string }
+  | { kind: 'order'; purchaseOrderInstanceId: string }
+
+/**
+ * Re-derive a purchase order's receipt and billing statuses from its lines, and
+ * pull a `draft` order forward to `issued` when the evidence is a receipt.
+ *
+ * ## The pull-forward contract
+ *
+ * 🛑 This function is the ONE derived writer permitted to touch the ACTION field
+ * `purchase_order_status`, which §3.3 otherwise reserves for the human and for
+ * the sanctioned Send action. The permission is exactly one transition and
+ * nothing else, and every clause below is load-bearing:
+ *
+ * - **Only `draft` -> `issued`.** The current value is read first and the write
+ *   happens only when it is *exactly* `draft`.
+ * - **Never from `closed` or `canceled`.** Somebody deliberately ended those
+ *   orders. A straggler receipt arriving weeks later must not silently reopen
+ *   an order that was written off, and a rule that reopened it would be
+ *   invisible — the status would simply be wrong with nothing thrown.
+ * - **Never backwards, and never a write of `draft`.** `issued` is the only
+ *   value this function can produce.
+ * - **Only on RECEIPT evidence.** A `vendor_bill_line` never pulls the status
+ *   forward. This business prepays (02 §0k): a bill arriving before the goods
+ *   is normal and is not evidence that the order was ever sent to the vendor.
+ * - **A null status is NOT `draft`.** An order with no recorded status is not a
+ *   fact this pass is willing to overwrite; `defaultValue: 'draft'` means a
+ *   normally created order has the value, and an absent one is left alone.
+ * - **Something must actually have arrived.** The derived `receipt_status` has
+ *   to be off `not_received` as well. The roll-up fires on a movement DELETE
+ *   too, and a delete that takes the last receipt away is the opposite of
+ *   evidence that the order was sent.
+ *
+ * The reason this is safe to do at all is §3.3's split. Under the old single
+ * enum, a first receipt against a draft order forced a choice between recording
+ * `issued` and recording `partially_received` and one fact had to be discarded.
+ * With three fields both are recorded, so the pull-forward destroys nothing.
+ *
+ * ## Writes are diffed, never blind
+ *
+ * ⚠️ Each of the three fields is compared against its stored value and written
+ * only when it differs. A no-op field write still fires the field-hook chain and
+ * a realtime publish, and this pass runs once per line per movement — writing
+ * blind would broadcast three unchanged values on every receipt on a
+ * ten-line order.
+ *
+ * ## One read, not three
+ *
+ * ⚡ The parent order, its lines' quantities and the order's own SELECT values
+ * used to be three sequential round trips. They are one statement now — see
+ * {@link readOrderStatusInputs}. The diff above is unaffected: it was never an
+ * optimisation, it is what stops a derived no-op from broadcasting.
+ *
+ * ## Failure
+ *
+ * Returns `err` rather than throwing: the caller is the line roll-up, whose own
+ * write is the primary fact and has already committed by the time this runs. A
+ * derived verdict that could not be computed must not take the quantity with it.
+ */
+export async function recalculatePurchaseOrderStatuses(params: {
+  organizationId: string
+  purchaseOrderLineInstanceId: string
+  evidence: PurchaseOrderStatusEvidence
+}): Promise<Result<PurchaseOrderStatusWrite, AuxxError>> {
+  const { organizationId, purchaseOrderLineInstanceId, evidence } = params
+  return runStatusPass(
+    organizationId,
+    { kind: 'line', purchaseOrderLineInstanceId },
+    evidence,
+    purchaseOrderLineInstanceId
+  )
+}
+
+/**
+ * The same pass, run ONCE per distinct purchase order behind a set of lines.
+ *
+ * 🛑 The reason this exists: the per-line entry point above is chained off a
+ * line roll-up, so receiving a ten-line purchase order used to run it ten times
+ * against the same order — ten identical reads and, after the first, ten
+ * identical no-op diffs. A batched caller that already knows the whole line set
+ * resolves the distinct orders in one query and derives each of them once.
+ *
+ * ⚠️ This is an ADDITION, not a replacement. The per-line pass still runs off
+ * the lifecycle rule for every single-line write (a direct `receiveStock`, an
+ * adjustment, a reversal, a bill line) and for anything this batch missed. A
+ * batched caller does not suppress it with a flag; it simply gets there first,
+ * and the per-line pass then finds nothing to do. Forgetting to call this costs
+ * an extra pass, never a skipped one.
+ */
+export async function recalculatePurchaseOrderStatusesForLines(params: {
+  organizationId: string
+  purchaseOrderLineInstanceIds: string[]
+  evidence: PurchaseOrderStatusEvidence
+}): Promise<Result<PurchaseOrderStatusWrite[], AuxxError>> {
+  const { organizationId, purchaseOrderLineInstanceIds, evidence } = params
+  const lineIds = [...new Set(purchaseOrderLineInstanceIds)].filter(Boolean)
+  if (lineIds.length === 0) return ok([])
+
+  let orderIds: string[]
+  try {
+    const fields = await resolveStatusFields(organizationId)
+    if (!fields) return ok([])
+    orderIds = await readOrdersForLines(organizationId, lineIds, fields.orderRelField.id)
+  } catch (error) {
+    return err(toStatusError(error, organizationId, lineIds.join(','), evidence))
+  }
+
+  const written: PurchaseOrderStatusWrite[] = []
+  for (const purchaseOrderInstanceId of orderIds) {
+    const result = await runStatusPass(
+      organizationId,
+      { kind: 'order', purchaseOrderInstanceId },
+      evidence,
+      purchaseOrderInstanceId
+    )
+    if (result.isErr()) return err(result.error)
+    written.push(result.value)
+  }
+  return ok(written)
+}
+
+/** Derive and write one purchase order's statuses. Both entry points land here. */
+async function runStatusPass(
+  organizationId: string,
+  anchor: StatusAnchor,
+  evidence: PurchaseOrderStatusEvidence,
+  logRef: string
+): Promise<Result<PurchaseOrderStatusWrite, AuxxError>> {
+  try {
+    const fields = await resolveStatusFields(organizationId)
+    if (!fields) return ok({})
+
+    const inputs = await readOrderStatusInputs(organizationId, anchor, fields)
+    // An orphaned line — created before its parent was picked — is ordinary and
+    // is a silent no-op, the same way a movement with no PO line is.
+    if (!inputs) return ok({})
+
+    const { purchaseOrderInstanceId, lines, current } = inputs
+    const derived = derivePurchaseOrderStatuses(lines)
+
+    const { statusField, receiptStatusField, billingStatusField } = fields
+    const orderDefId = await requireCachedEntityDefId(organizationId, 'purchase_order')
+    const recordId = toRecordId(orderDefId, purchaseOrderInstanceId) as RecordId
+
+    const written: PurchaseOrderStatusWrite = {}
+    const pending: Array<{ field: CustomFieldEntity; value: string }> = []
+
+    if (current.get(receiptStatusField.id) !== derived.receiptStatus) {
+      pending.push({ field: receiptStatusField, value: derived.receiptStatus })
+      written.receiptStatus = derived.receiptStatus
+    }
+    if (current.get(billingStatusField.id) !== derived.billingStatus) {
+      pending.push({ field: billingStatusField, value: derived.billingStatus })
+      written.billingStatus = derived.billingStatus
+    }
+
+    // The pull-forward. Every guard in the contract above is this one condition.
+    if (
+      statusField &&
+      evidence === 'receipt' &&
+      current.get(statusField.id) === PurchaseOrderStatus.DRAFT &&
+      derived.receiptStatus !== 'not_received'
+    ) {
+      pending.push({ field: statusField, value: PurchaseOrderStatus.ISSUED })
+      written.status = PurchaseOrderStatus.ISSUED
+    }
+
+    if (pending.length === 0) return ok({})
+
+    // `bypassFieldGuards` names `purchase_order_status` and nothing else: this
+    // pass IS the sanctioned writer of the `draft -> issued` transition, so the
+    // guard that rejects a MANUAL `issued` must not reject it. The two derived
+    // fields are deliberately left subject to whatever guards they carry.
+    const ctx = createFieldValueContext(organizationId, undefined, database, undefined, {
+      bypassFieldGuards: new Set<SystemAttribute>(['purchase_order_status']),
+    })
+
+    const entries: FieldValueUpdateEntry[] = []
+    for (const write of pending) {
+      await setValueWithType(ctx, {
+        recordId,
+        fieldId: write.field.id,
+        fieldType: toFieldType(write.field.type),
+        value: { type: 'option', optionId: write.value },
+      })
+      entries.push({
+        key: buildFieldValueKey(recordId, write.field.id as FieldId),
+        value: { type: 'option', optionId: write.value },
+      })
+    }
+
+    publishFieldValueUpdates(getRealtimeService(), organizationId, entries).catch((error) => {
+      logger.error('Failed to publish purchase order status update', {
+        purchaseOrderInstanceId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    })
+
+    logger.info('Purchase order statuses derived', {
+      purchaseOrderInstanceId,
+      evidence,
+      lineCount: lines.length,
+      ...written,
+    })
+
+    return ok(written)
+  } catch (error) {
+    return err(toStatusError(error, organizationId, logRef, evidence))
+  }
+}
+
+/** Log-and-wrap, so both entry points fail the same way. */
+function toStatusError(
+  error: unknown,
+  organizationId: string,
+  logRef: string,
+  evidence: PurchaseOrderStatusEvidence
+): AuxxError {
+  if (error instanceof AuxxError) return error
+  logger.error('Failed to derive purchase order statuses', {
+    organizationId,
+    purchaseOrderLineInstanceId: logRef,
+    evidence,
+    error: error instanceof Error ? error.message : String(error),
+  })
+  return new AuxxError('Failed to derive purchase order statuses')
+}
+
+/**
+ * The seven fields, or `undefined` when the org has not provisioned the ones
+ * this pass cannot work without. `purchase_order_status` is deliberately
+ * optional: without it the two derived axes still work, only the pull-forward
+ * is unavailable.
+ */
+async function resolveStatusFields(organizationId: string): Promise<StatusFields | undefined> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes<SystemAttribute>([...STATUS_ATTRS])
+
+  const orderRelField = fields.purchase_order_line_purchase_order
+  const orderedField = fields.purchase_order_line_quantity_ordered
+  const receivedField = fields.purchase_order_line_quantity_received
+  const billedField = fields.purchase_order_line_quantity_billed
+  const statusField = fields.purchase_order_status
+  const receiptStatusField = fields.purchase_order_receipt_status
+  const billingStatusField = fields.purchase_order_billing_status
+
+  if (
+    !orderRelField ||
+    !orderedField ||
+    !receivedField ||
+    !billedField ||
+    !receiptStatusField ||
+    !billingStatusField
+  ) {
+    logger.warn('Missing custom fields for purchase order status derivation', {
+      organizationId,
+      orderRelField: !!orderRelField,
+      orderedField: !!orderedField,
+      receivedField: !!receivedField,
+      billedField: !!billedField,
+      receiptStatusField: !!receiptStatusField,
+      billingStatusField: !!billingStatusField,
+    })
+    return undefined
+  }
+
+  return {
+    orderRelField,
+    orderedField,
+    receivedField,
+    billedField,
+    statusField: statusField ?? undefined,
+    receiptStatusField,
+    billingStatusField,
+  }
+}
+
+/** Everything one status pass reads, in one round trip. */
+interface OrderStatusInputs {
+  purchaseOrderInstanceId: string
+  lines: PurchaseOrderLineQuantities[]
+  /** Stored option ids keyed by field id — absent when the field has no value. */
+  current: Map<string, string>
+}
+
+/**
+ * Read the parent order, every line's `{ ordered, received, billed }`, and the
+ * order's own current SELECT values — as ONE statement.
+ *
+ * ⚠️ The driving rows are the RELATIONSHIP values, with the three quantities
+ * LEFT JOINed on. Driving off the quantities instead would drop a line that
+ * carries none — and a line with no `quantity_ordered` typed yet is exactly the
+ * line that must hold the order open, not the one to ignore.
+ *
+ * ⚠️ The order's three SELECT values are scalar SUBQUERIES, not three more
+ * joins. A join would be cheaper to read, but `FieldValue` is unique on
+ * `(entityId, fieldId, sortKey)` — a second row for the same field is legal by
+ * construction — and a join that matched two of them would DUPLICATE every line
+ * row and silently double-count the order. A subquery cannot change the row
+ * count no matter what it finds. `optionId IS NOT NULL` reproduces the old
+ * `readCurrentOptions` behaviour of ignoring a row that carries no option.
+ *
+ * Returns `undefined` for an orphaned line: no relationship row means no order,
+ * and no order means no rows at all.
+ */
+async function readOrderStatusInputs(
+  organizationId: string,
+  anchor: StatusAnchor,
+  fields: StatusFields
+): Promise<OrderStatusInputs | undefined> {
+  const orderRelFieldId = fields.orderRelField.id
+
+  // The order id, as SQL: a literal when the caller named it, and the line's
+  // own relationship row when it did not. Uncorrelated either way, so the
+  // planner resolves it once for the whole statement.
+  const orderIdSql: SQL =
+    anchor.kind === 'order'
+      ? sql`${anchor.purchaseOrderInstanceId}`
+      : sql`(SELECT fv_anchor."relatedEntityId" FROM "FieldValue" fv_anchor
+          WHERE fv_anchor."entityId" = ${anchor.purchaseOrderLineInstanceId}
+            AND fv_anchor."fieldId" = ${orderRelFieldId}
+            AND fv_anchor."organizationId" = ${organizationId}
+          LIMIT 1)`
+
+  const currentOption = (fieldId: string | undefined): SQL<string | null> =>
+    sql<string | null>`(SELECT fv_opt."optionId" FROM "FieldValue" fv_opt
+      WHERE fv_opt."entityId" = ${schema.FieldValue.relatedEntityId}
+        AND fv_opt."fieldId" = ${fieldId ?? ''}
+        AND fv_opt."organizationId" = ${organizationId}
+        AND fv_opt."optionId" IS NOT NULL
+      LIMIT 1)`
+
+  const rows = await database
+    .select({
+      orderId: schema.FieldValue.relatedEntityId,
+      ordered: sql<number | null>`fv_ordered."valueNumber"`,
+      received: sql<number | null>`fv_received."valueNumber"`,
+      billed: sql<number | null>`fv_billed."valueNumber"`,
+      statusOption: currentOption(fields.statusField?.id),
+      receiptStatusOption: currentOption(fields.receiptStatusField.id),
+      billingStatusOption: currentOption(fields.billingStatusField.id),
+    })
+    .from(schema.FieldValue)
+    .leftJoin(
+      sql`"FieldValue" fv_ordered`,
+      sql`${schema.FieldValue.entityId} = fv_ordered."entityId"
+        AND fv_ordered."fieldId" = ${fields.orderedField.id}
+        AND fv_ordered."organizationId" = ${organizationId}`
+    )
+    .leftJoin(
+      sql`"FieldValue" fv_received`,
+      sql`${schema.FieldValue.entityId} = fv_received."entityId"
+        AND fv_received."fieldId" = ${fields.receivedField.id}
+        AND fv_received."organizationId" = ${organizationId}`
+    )
+    .leftJoin(
+      sql`"FieldValue" fv_billed`,
+      sql`${schema.FieldValue.entityId} = fv_billed."entityId"
+        AND fv_billed."fieldId" = ${fields.billedField.id}
+        AND fv_billed."organizationId" = ${organizationId}`
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.fieldId, orderRelFieldId),
+        eq(schema.FieldValue.organizationId, organizationId),
+        sql`${schema.FieldValue.relatedEntityId} = ${orderIdSql}`
+      )
+    )
+
+  const first = rows[0]
+  if (!first) return undefined
+
+  const purchaseOrderInstanceId =
+    anchor.kind === 'order' ? anchor.purchaseOrderInstanceId : (first.orderId ?? undefined)
+  if (!purchaseOrderInstanceId) return undefined
+
+  const current = new Map<string, string>()
+  if (fields.statusField?.id && first.statusOption) {
+    current.set(fields.statusField.id, first.statusOption)
+  }
+  if (first.receiptStatusOption) {
+    current.set(fields.receiptStatusField.id, first.receiptStatusOption)
+  }
+  if (first.billingStatusOption) {
+    current.set(fields.billingStatusField.id, first.billingStatusOption)
+  }
+
+  return {
+    purchaseOrderInstanceId,
+    lines: rows.map((row) => ({
+      quantityOrdered: Number(row.ordered ?? 0),
+      quantityReceived: Number(row.received ?? 0),
+      quantityBilled: Number(row.billed ?? 0),
+    })),
+    current,
+  }
+}
+
+/**
+ * The DISTINCT purchase orders a set of lines belongs to, in one query.
+ *
+ * Orphaned lines simply do not come back — the same silent no-op the per-line
+ * pass applies, applied once for the whole set.
+ */
+async function readOrdersForLines(
+  organizationId: string,
+  purchaseOrderLineInstanceIds: string[],
+  orderRelFieldId: string
+): Promise<string[]> {
+  const rows = await database
+    .select({ relatedEntityId: schema.FieldValue.relatedEntityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        inArray(schema.FieldValue.entityId, purchaseOrderLineInstanceIds),
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, orderRelFieldId)
+      )
+    )
+
+  const orderIds = new Set<string>()
+  for (const row of rows) {
+    if (row.relatedEntityId) orderIds.add(row.relatedEntityId)
+  }
+  return [...orderIds]
+}

--- a/packages/lib/src/purchasing/purchase-order-status.ts
+++ b/packages/lib/src/purchasing/purchase-order-status.ts
@@ -1,0 +1,139 @@
+// packages/lib/src/purchasing/purchase-order-status.ts
+
+import {
+  PurchaseOrderBillingStatus,
+  PurchaseOrderReceiptStatus,
+} from '../resources/registry/enum-values'
+
+/**
+ * The order-level verdicts derived from the purchase order LINE roll-ups
+ * (plans/purchasing/07-purchase-order-send-and-status.md §3.3).
+ *
+ * This file is pure on purpose: it takes numbers and returns two strings. The
+ * database half lives in `purchase-order-status-writer.ts`, which is the only
+ * thing that knows what a `FieldValue` is. Keeping the rule here means the nine
+ * receipt/billing combinations, over-receipt and the empty order are all
+ * testable without a single mock — the same split `match.ts` / `match-hook.ts`
+ * already uses.
+ *
+ * 🛑 The two axes are INDEPENDENT and neither one is a summary of the other.
+ * This business prepays: *fully billed, nothing received* is a normal state
+ * lasting weeks (§3.3). Do not fold them back into one verdict.
+ */
+
+/** `purchase_order_receipt_status` — the GOODS axis. */
+export type PurchaseOrderReceiptStatusValue = (typeof PurchaseOrderReceiptStatus)[
+  | 'NOT_RECEIVED'
+  | 'PARTIALLY_RECEIVED'
+  | 'RECEIVED']
+
+/** `purchase_order_billing_status` — the MONEY axis. BILLED, never PAID (§3.6). */
+export type PurchaseOrderBillingStatusValue = (typeof PurchaseOrderBillingStatus)[
+  | 'NOT_BILLED'
+  | 'PARTIALLY_BILLED'
+  | 'BILLED']
+
+/**
+ * One purchase order line reduced to the three numbers the verdict needs.
+ *
+ * `quantityReceived` and `quantityBilled` are the roll-ups
+ * `purchase-order-line-rollups.ts` re-SUMs; `quantityOrdered` is what a human
+ * typed. A missing value reads as `0` — the caller resolves that, so this
+ * module never sees a `null`.
+ */
+export interface PurchaseOrderLineQuantities {
+  quantityOrdered: number
+  quantityReceived: number
+  quantityBilled: number
+}
+
+/** Both derived verdicts for one purchase order. */
+export interface PurchaseOrderDerivedStatuses {
+  receiptStatus: PurchaseOrderReceiptStatusValue
+  billingStatus: PurchaseOrderBillingStatusValue
+}
+
+/** The three rungs of one axis, so the classifier can be written once. */
+interface AxisRegister<T extends string> {
+  none: T
+  partial: T
+  complete: T
+}
+
+const RECEIPT_AXIS: AxisRegister<PurchaseOrderReceiptStatusValue> = {
+  none: PurchaseOrderReceiptStatus.NOT_RECEIVED,
+  partial: PurchaseOrderReceiptStatus.PARTIALLY_RECEIVED,
+  complete: PurchaseOrderReceiptStatus.RECEIVED,
+}
+
+const BILLING_AXIS: AxisRegister<PurchaseOrderBillingStatusValue> = {
+  none: PurchaseOrderBillingStatus.NOT_BILLED,
+  partial: PurchaseOrderBillingStatus.PARTIALLY_BILLED,
+  complete: PurchaseOrderBillingStatus.BILLED,
+}
+
+/**
+ * Classify one axis of a purchase order.
+ *
+ * 🛑 The completion test is `>=`, never `===`. Over-receipt is legal and
+ * ordinary — a vendor ships 105 of an order for 100 — and an equality test
+ * would report that order as `partially_received` forever, which is the exact
+ * inverse of the truth. The same holds for an over-billed line.
+ *
+ * ⚠️ Order of the two tests matters. `complete` is checked first so a line that
+ * is fully satisfied cannot be dragged down by the `> 0` partial test, and
+ * `partial` needs strictly positive progress so a credit or a reversal that
+ * leaves the line at `0` reads as `none` rather than `partial`.
+ *
+ * A line with `quantityOrdered === 0` satisfies `progress >= ordered` at zero
+ * progress. That is deliberate: nothing was ordered, so nothing is outstanding,
+ * and such a line must not hold an otherwise-complete order open.
+ */
+function classifyAxis<T extends string>(
+  lines: readonly PurchaseOrderLineQuantities[],
+  progressOf: (line: PurchaseOrderLineQuantities) => number,
+  register: AxisRegister<T>
+): T {
+  // An empty order is `none`, NOT `complete`. `every` over an empty list is
+  // vacuously true, so without this guard a purchase order somebody has only
+  // just created — no lines typed yet — would be labelled fully received and
+  // fully billed. See {@link derivePurchaseOrderStatuses}.
+  if (lines.length === 0) return register.none
+
+  if (lines.every((line) => progressOf(line) >= line.quantityOrdered)) return register.complete
+  if (lines.some((line) => progressOf(line) > 0)) return register.partial
+  return register.none
+}
+
+/**
+ * Derive `purchase_order_receipt_status` and `purchase_order_billing_status`
+ * from the order's lines.
+ *
+ * ```
+ * receipt_status:  every line received >= ordered  -> received
+ *                  any   line received >  0        -> partially_received
+ *                  otherwise                       -> not_received
+ *
+ * billing_status:  every line billed   >= ordered  -> billed
+ *                  any   line billed   >  0        -> partially_billed
+ *                  otherwise                       -> not_billed
+ * ```
+ *
+ * ✅ **Zero lines returns `not_received` / `not_billed`.** The alternative —
+ * letting the vacuous `every` win — would stamp every freshly created purchase
+ * order as complete on both axes before anybody had typed a line, and it would
+ * then flip *backwards* to `not_received` the moment the first line landed. A
+ * status that reads "done" for an order nobody has placed is worse than one
+ * that reads "not started".
+ *
+ * Pure and total: it queries nothing, throws nothing, and given the same lines
+ * always returns the same pair.
+ */
+export function derivePurchaseOrderStatuses(
+  lines: readonly PurchaseOrderLineQuantities[]
+): PurchaseOrderDerivedStatuses {
+  return {
+    receiptStatus: classifyAxis(lines, (line) => line.quantityReceived, RECEIPT_AXIS),
+    billingStatus: classifyAxis(lines, (line) => line.quantityBilled, BILLING_AXIS),
+  }
+}

--- a/packages/lib/src/receiving/__tests__/receipt-query-count.test.ts
+++ b/packages/lib/src/receiving/__tests__/receipt-query-count.test.ts
@@ -1,0 +1,351 @@
+// packages/lib/src/receiving/__tests__/receipt-query-count.test.ts
+//
+// The regression guard for the receipt fan-out.
+//
+// Writing one `stock_movement` used to fire a chain that re-derived the WHOLE
+// purchase order: resolve the parent, read every line, read the order's current
+// statuses. `receivePurchaseOrder` loops that chain once per line, so a ten-line
+// receipt paid for ten identical order-level derivations — the same query, the
+// same answer, nine times over.
+//
+// 🛑 This file counts SELECTs. Nothing else here will catch the regression: the
+// behaviour is identical either way, only the cost changes, so the next hook
+// somebody chains onto the roll-up would put the amplifier straight back with
+// every assertion still green. The number to defend is the RATIO — a ten-line
+// receipt must not cost ten times a one-line receipt.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityTriggerEvent } from '../../field-hooks/types'
+import type { MovementRecord, ReceivePurchaseOrderLineInput } from '../types'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const PO = 'po_1'
+
+const FIELDS: Record<string, { id: string; type: string }> = {
+  purchase_order_line_expected_unit_price: { id: 'fld-price', type: 'NUMBER' },
+  stock_movement_quantity: { id: 'fld-mv-qty', type: 'NUMBER' },
+  stock_movement_purchase_order_line: { id: 'fld-mv-poline', type: 'RELATIONSHIP' },
+  purchase_order_line_purchase_order: { id: 'fld-po-rel', type: 'RELATIONSHIP' },
+  purchase_order_line_quantity_ordered: { id: 'fld-ordered', type: 'NUMBER' },
+  purchase_order_line_quantity_received: { id: 'fld-received', type: 'NUMBER' },
+  purchase_order_line_quantity_billed: { id: 'fld-billed', type: 'NUMBER' },
+  purchase_order_status: { id: 'fld-status', type: 'SINGLE_SELECT' },
+  purchase_order_receipt_status: { id: 'fld-receipt', type: 'SINGLE_SELECT' },
+  purchase_order_billing_status: { id: 'fld-billing', type: 'SINGLE_SELECT' },
+}
+
+const h = vi.hoisted(() => ({
+  /** Every `.select(...)` on either connection, whoever issued it. */
+  selects: 0,
+  /** Every `setValueWithType` — the write half of the budget. */
+  writes: 0,
+  /** The purchase order's lines and what has been received against each. */
+  lineIds: [] as string[],
+  movementQuantity: new Map<string, number>(),
+  storedReceived: new Map<string, number>(),
+}))
+
+/**
+ * Bound string parameters of a drizzle `sql` node, so a query that names its
+ * subject in a JOIN predicate rather than in its projection can still be
+ * answered. `StringChunk.value` is an array, `Param.value` is the bound value.
+ */
+function boundStrings(node: unknown, out: string[] = []): string[] {
+  if (typeof node === 'string') {
+    out.push(node)
+    return out
+  }
+  if (!node || typeof node !== 'object') return out
+  if (Array.isArray(node)) {
+    for (const child of node) boundStrings(child, out)
+    return out
+  }
+  const record = node as Record<string, unknown>
+  if (Array.isArray(record.queryChunks)) return boundStrings(record.queryChunks, out)
+  if (typeof record.value === 'string') out.push(record.value)
+  return out
+}
+
+/** Chainable drizzle stub. The rows are chosen once the query is awaited. */
+function chain(projection: Record<string, unknown>, route: (q: Query) => unknown[]) {
+  const query: Query = { projection, params: [] }
+  const node: Record<string, unknown> = {}
+  for (const key of ['from', 'where', 'limit', 'groupBy']) node[key] = () => node
+  for (const key of ['innerJoin', 'leftJoin']) {
+    node[key] = (_alias: unknown, condition: unknown) => {
+      boundStrings(condition, query.params)
+      return node
+    }
+  }
+  node.then = (resolve: (v: unknown) => unknown) => Promise.resolve(route(query)).then(resolve)
+  return node
+}
+
+interface Query {
+  projection: Record<string, unknown>
+  params: string[]
+}
+
+/** The order's lines as the folded status read returns them. */
+function statusRows() {
+  return h.lineIds.map((lineId) => ({
+    orderId: PO,
+    ordered: 10,
+    received: h.storedReceived.get(lineId) ?? null,
+    billed: null,
+    statusOption: 'issued',
+    receiptStatusOption: 'not_received',
+    billingStatusOption: 'not_billed',
+  }))
+}
+
+/**
+ * Route a query by the keys it projects — the one part of a drizzle call that
+ * is plain data. Each branch is named for the function that issues it.
+ */
+function routeModuleSelect(query: Query): unknown[] {
+  const keys = Object.keys(query.projection).sort().join(',')
+  switch (keys) {
+    // readTotalsByLine — the batched grouped SUM
+    case 'lineId,total':
+      return h.lineIds
+        .filter((lineId) => h.movementQuantity.has(lineId))
+        .map((lineId) => ({ lineId, total: String(h.movementQuantity.get(lineId)) }))
+    // readStoredTotals — what the lines already hold
+    case 'entityId,valueNumber':
+      return [...h.storedReceived.entries()].map(([entityId, valueNumber]) => ({
+        entityId,
+        valueNumber,
+      }))
+    // readOrdersForLines — the distinct parents behind a set of lines
+    case 'relatedEntityId':
+      return [{ relatedEntityId: PO }]
+    // readOrderStatusInputs — parent, lines and current statuses in one read
+    case 'billed,billingStatusOption,orderId,ordered,receiptStatusOption,received,statusOption':
+      return statusRows()
+    // recalculatePurchaseOrderLineRollup — one line's SUM plus its stored total.
+    // The line is named in the join predicate, not the projection.
+    case 'current,total': {
+      const lineId = query.params.find((param) => h.lineIds.includes(param)) ?? ''
+      return [
+        {
+          total: String(h.movementQuantity.get(lineId) ?? 0),
+          current: h.storedReceived.get(lineId) ?? null,
+        },
+      ]
+    }
+    default:
+      throw new Error(`Unrouted query projecting: ${keys}`)
+  }
+}
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: (projection: Record<string, unknown>) => {
+      h.selects++
+      return chain(projection, routeModuleSelect)
+    },
+  },
+  schema: {
+    FieldValue: {
+      entityId: 'entityId',
+      organizationId: 'organizationId',
+      fieldId: 'fieldId',
+      valueNumber: 'valueNumber',
+      optionId: 'optionId',
+      relatedEntityId: 'relatedEntityId',
+    },
+    CustomField: { id: 'id', systemAttribute: 'systemAttribute' },
+  },
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(attrs.map((attr) => [attr, FIELDS[attr] ?? null])),
+    }),
+  }),
+  requireCachedEntityDefId: async (_org: string, entityType: string) => `def_${entityType}`,
+}))
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: () => ({ organizationId: ORG }),
+}))
+vi.mock('../../field-values/stored-field-type', () => ({ toFieldType: (t: string) => t }))
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithType: vi.fn(
+    async (
+      _ctx: unknown,
+      args: { recordId: string; fieldId: string; value: { value?: number } }
+    ) => {
+      h.writes++
+      if (args.fieldId === FIELDS.purchase_order_line_quantity_received!.id) {
+        const lineId = args.recordId.split(':')[1] as string
+        h.storedReceived.set(lineId, args.value.value ?? 0)
+      }
+      return []
+    }
+  ),
+}))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishFieldValueUpdates: async () => undefined,
+}))
+
+vi.mock('../receive-stock', async () => {
+  const { ok } = await import('neverthrow')
+  return {
+    receiveStock: vi.fn(
+      async (_db, _org, _user, input: ReceivePurchaseOrderLineInput & { quantity: number }) => {
+        const lineId = (input as { purchaseOrderLineId: string }).purchaseOrderLineId
+        h.movementQuantity.set(lineId, (h.movementQuantity.get(lineId) ?? 0) + input.quantity)
+        return ok({
+          movementId: `mv_${lineId}`,
+          recordId: `def_mv:mv_${lineId}`,
+          partInstanceId: input.partId,
+          quantity: input.quantity,
+          unitCost: 1000,
+          extendedCost: 1000 * input.quantity,
+          vendorUnitPrice: 1000,
+          vendorPartId: null,
+          glAccount: '1310',
+          occurredAt: new Date(),
+          purchaseOrderLineId: lineId,
+        } satisfies MovementRecord)
+      }
+    ),
+  }
+})
+
+import { recalculatePurchaseOrderLineReceived } from '../../field-hooks/post/purchase-order-line-rollups'
+import { receivePurchaseOrder } from '../receive-purchase-order'
+
+/** The caller's connection — `receivePurchaseOrder` reads the agreed prices on it. */
+const db = {
+  select: (projection: Record<string, unknown>) => {
+    h.selects++
+    return chain(projection, () => h.lineIds.map((entityId) => ({ entityId, valueNumber: 1000 })))
+  },
+} as never
+
+/**
+ * The per-movement lifecycle rule, as the record-rules engine fires it once the
+ * `stock_movement:created` event reaches the worker — one firing per row.
+ */
+async function fireLifecycleRule(lineId: string) {
+  await recalculatePurchaseOrderLineReceived({
+    action: 'created',
+    entitySlug: 'stock-movements',
+    entityType: '',
+    entityDefinitionId: 'def_stock_movement',
+    entityInstanceId: `mv_${lineId}`,
+    organizationId: ORG,
+    userId: USER,
+    values: { stock_movement_purchase_order_line: lineId },
+  } as unknown as EntityTriggerEvent)
+}
+
+/** Receive `count` lines of one purchase order, then let every rule fire. */
+async function receiveAndSettle(count: number) {
+  h.lineIds = Array.from({ length: count }, (_unused, i) => `pol_${i + 1}`)
+  h.movementQuantity = new Map()
+  h.storedReceived = new Map()
+  h.selects = 0
+  h.writes = 0
+
+  const result = await receivePurchaseOrder(db, ORG, USER, {
+    lines: h.lineIds.map((purchaseOrderLineId, i) => ({
+      partId: `part_${i + 1}`,
+      purchaseOrderLineId,
+      quantity: 4,
+    })),
+  })
+  expect(result.isOk()).toBe(true)
+
+  for (const lineId of h.lineIds) await fireLifecycleRule(lineId)
+
+  return { selects: h.selects, writes: h.writes }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('the cost of a receipt', () => {
+  it('a one-line receipt reads four times and writes once', async () => {
+    // 1 agreed price + 1 batched roll-up SUM + 1 order-level derivation, then
+    // the movement's own lifecycle rule re-SUMs its line once and finds nothing
+    // to do. The write is the line's `quantity_received`; the order's derived
+    // statuses were already `not_received`/`not_billed`, so only the receipt
+    // axis moves.
+    const { selects } = await receiveAndSettle(1)
+    expect(selects).toBe(4)
+  })
+
+  it('🛑 a ten-line receipt is NOT ten times a one-line receipt', async () => {
+    const one = await receiveAndSettle(1)
+    const ten = await receiveAndSettle(10)
+
+    expect(ten.selects).toBeLessThan(one.selects * 10)
+    // The exact budget, so a regression names itself rather than drifting up to
+    // the ceiling above: 1 price read + 2 batched roll-up reads + 2 batched
+    // order-level reads + 10 lifecycle re-SUMs that each find their line
+    // already settled.
+    expect(ten.selects).toBe(15)
+  })
+
+  it('derives the ORDER once, however many lines arrived', async () => {
+    // The measurement that matters. Nine of the ten order-level passes returned
+    // an identical answer, and each cost a parent lookup, a full line read and a
+    // status read before it could say so.
+    const ten = await receiveAndSettle(10)
+    const perLine = (ten.selects - 1) / 10
+    expect(perLine).toBeLessThan(2)
+  })
+
+  it('leaves every line settled, which is what makes the lifecycle rules cheap', async () => {
+    await receiveAndSettle(10)
+    for (const lineId of h.lineIds) expect(h.storedReceived.get(lineId)).toBe(4)
+  })
+
+  it('writes each line’s quantity exactly once — the rules that follow re-write nothing', async () => {
+    const { writes } = await receiveAndSettle(10)
+    // 10 line quantities + the order's receipt status. Nothing else moved.
+    expect(writes).toBe(11)
+  })
+})
+
+describe('the fallback is still there', () => {
+  it('settles a line from its own lifecycle rule when no batch ran', async () => {
+    // A direct `receiveStock`, an adjustment, a reversal: no batch around them.
+    // The per-movement rule must still do the whole job.
+    h.lineIds = ['pol_1']
+    h.movementQuantity = new Map([['pol_1', 7]])
+    h.storedReceived = new Map()
+    h.selects = 0
+    h.writes = 0
+
+    await fireLifecycleRule('pol_1')
+
+    expect(h.storedReceived.get('pol_1')).toBe(7)
+    // Its SUM, then the order-level derivation it chains.
+    expect(h.selects).toBe(2)
+  })
+
+  it('does the whole job twice rather than skipping it, if the batch is forgotten', async () => {
+    // The fail-safe direction. Suppression here is idempotence, not a flag:
+    // nothing tells the rule to stand down, it just finds the answer already
+    // written. Forget the batch and the rule pays full price and is correct.
+    h.lineIds = ['pol_1']
+    h.movementQuantity = new Map([['pol_1', 7]])
+    h.storedReceived = new Map()
+
+    await fireLifecycleRule('pol_1')
+    h.selects = 0
+    await fireLifecycleRule('pol_1')
+
+    expect(h.selects).toBe(1)
+    expect(h.storedReceived.get('pol_1')).toBe(7)
+  })
+})

--- a/packages/lib/src/receiving/__tests__/receive-purchase-order.test.ts
+++ b/packages/lib/src/receiving/__tests__/receive-purchase-order.test.ts
@@ -17,6 +17,8 @@ const h = vi.hoisted(() => ({
   materialised: new Set<string>(),
   /** `purchase_order_line` instance id -> its stored expected unit price. */
   prices: new Map<string, number | null>(),
+  /** The batched roll-up this door runs once the whole receipt is committed. */
+  settleSpy: vi.fn(),
 }))
 
 vi.mock('../../cache', () => ({
@@ -28,6 +30,13 @@ vi.mock('../../cache', () => ({
         ),
     }),
   }),
+}))
+
+vi.mock('../../field-hooks/post/purchase-order-line-rollups', () => ({
+  PURCHASE_ORDER_LINE_ROLLUPS: {
+    received: { targetAttr: 'purchase_order_line_quantity_received' },
+  },
+  recalculatePurchaseOrderLineRollups: (...args: unknown[]) => h.settleSpy(...args),
 }))
 
 vi.mock('../receive-stock', async () => {
@@ -86,6 +95,7 @@ const line = (
 
 beforeEach(() => {
   vi.clearAllMocks()
+  h.settleSpy.mockResolvedValue(undefined)
   h.materialised = new Set([PRICE_ATTR])
   h.prices = new Map([
     ['pol_1', 1000],
@@ -329,5 +339,65 @@ describe('receivePurchaseOrder — failure propagation', () => {
       })
     )
     expect(h.receiveSpy).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('receivePurchaseOrder — the roll-up is settled once, not once per line', () => {
+  it('🛑 rolls the WHOLE line set up in one call after the last movement', async () => {
+    // The amplifier this exists to remove: `stock_movement` create fires a
+    // lifecycle rule per row, and that rule derives the entire purchase order.
+    // Ten lines meant ten identical derivations. One batched call knows the
+    // whole set and does it once.
+    h.prices = new Map([
+      ['pol_1', 100],
+      ['pol_2', 200],
+    ])
+    await receivePurchaseOrder(db, ORG, USER, {
+      lines: [line(), line({ partId: 'part_2', purchaseOrderLineId: 'pol_2' })],
+    })
+
+    expect(h.settleSpy).toHaveBeenCalledTimes(1)
+    expect(h.settleSpy).toHaveBeenCalledWith(
+      ORG,
+      ['pol_1', 'pol_2'],
+      expect.objectContaining({ targetAttr: 'purchase_order_line_quantity_received' })
+    )
+  })
+
+  it('settles AFTER every movement, never between them', async () => {
+    const order: string[] = []
+    h.receiveSpy.mockImplementation(() => order.push('movement'))
+    h.settleSpy.mockImplementation(async () => {
+      order.push('settle')
+    })
+    h.prices = new Map([
+      ['pol_1', 100],
+      ['pol_2', 200],
+    ])
+
+    await receivePurchaseOrder(db, ORG, USER, {
+      lines: [line(), line({ partId: 'part_2', purchaseOrderLineId: 'pol_2' })],
+    })
+
+    expect(order).toEqual(['movement', 'movement', 'settle'])
+  })
+
+  it('does not settle when the receipt was refused before writing anything', async () => {
+    h.prices = new Map()
+    await receivePurchaseOrder(db, ORG, USER, { lines: [line()] })
+    expect(h.settleSpy).not.toHaveBeenCalled()
+  })
+
+  it('🛑 still reports the receipt as written when the roll-up fails', async () => {
+    // The movements are the primary fact and are already committed. Throwing
+    // here would report a receipt that happened as a receipt that failed — and
+    // the per-movement lifecycle rules are the fallback, so the quantity still
+    // lands.
+    h.settleSpy.mockRejectedValue(new Error('roll-up exploded'))
+
+    const result = await receivePurchaseOrder(db, ORG, USER, { lines: [line()] })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toHaveLength(1)
   })
 })

--- a/packages/lib/src/receiving/receive-purchase-order.ts
+++ b/packages/lib/src/receiving/receive-purchase-order.ts
@@ -25,10 +25,15 @@
  */
 
 import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { getOrgCache } from '../cache'
 import { BadRequestError, UnprocessableEntityError } from '../errors'
+import {
+  PURCHASE_ORDER_LINE_ROLLUPS,
+  recalculatePurchaseOrderLineRollups,
+} from '../field-hooks/post/purchase-order-line-rollups'
 import { guard } from './guard'
 import { receiveStock } from './receive-stock'
 import type {
@@ -36,6 +41,8 @@ import type {
   ReceivePurchaseOrderInput,
   ReceivePurchaseOrderLineInput,
 } from './types'
+
+const logger = createScopedLogger('receiving:receive-purchase-order')
 
 /** The one field this door reads to price a receipt. */
 const EXPECTED_UNIT_PRICE_ATTRIBUTE = 'purchase_order_line_expected_unit_price'
@@ -115,11 +122,58 @@ export async function receivePurchaseOrder(
         written.push(result.value)
       }
 
+      await settleLineRollups(
+        organizationId,
+        lines.map((line) => line.purchaseOrderLineId)
+      )
+
       return written
     },
     'Failed to receive purchase order',
     { organizationId, lineCount: input.lines?.length ?? 0 }
   )
+}
+
+/**
+ * Roll the whole receipt up ONCE, now that every movement is committed.
+ *
+ * 🛑 The 10x. `stock_movement` create fires a lifecycle rule PER ROW, and that
+ * rule re-SUMs one line and then derives the whole purchase order from it. A
+ * ten-line receipt therefore ran the order-level pass ten times over the same
+ * order — the same parent lookup, the same line set, the same answer nine times
+ * out of ten. This call knows the entire line set before the first movement was
+ * written, so it does the work once: one grouped SUM, one write per line that
+ * actually moved, one order-level derivation.
+ *
+ * ⚠️ **It suppresses nothing, and that is the design.** The per-movement rules
+ * still fire behind it. They find each line's `quantity_received` already equal
+ * to the SUM they compute and return before writing, so the order-level pass
+ * behind them never runs. The saving comes from getting there FIRST, not from a
+ * flag — there is no context to thread, nothing to leak across the queue
+ * boundary those rules actually run on, and if this call never happens the old
+ * per-movement path produces exactly the same result, just more slowly.
+ *
+ * ⚠️ A failure here is logged and swallowed. The movements are the primary fact
+ * and are already committed; throwing would report a receipt that happened as a
+ * receipt that failed. The lifecycle rules are the fallback and still run.
+ */
+async function settleLineRollups(
+  organizationId: string,
+  purchaseOrderLineIds: string[]
+): Promise<void> {
+  try {
+    await recalculatePurchaseOrderLineRollups(
+      organizationId,
+      purchaseOrderLineIds,
+      PURCHASE_ORDER_LINE_ROLLUPS.received
+    )
+  } catch (error) {
+    logger.error('Failed to settle purchase order line roll-ups after a receipt', {
+      organizationId,
+      lineCount: purchaseOrderLineIds.length,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 }
 
 /**

--- a/packages/lib/src/resources/hooks/__tests__/lifecycle-status-guard.test.ts
+++ b/packages/lib/src/resources/hooks/__tests__/lifecycle-status-guard.test.ts
@@ -1,0 +1,138 @@
+// packages/lib/src/resources/hooks/__tests__/lifecycle-status-guard.test.ts
+//
+// `rejectManualLifecycleStatus` existed VERBATIM twice (quote + invoice) and a purchase
+// order is the third caller (plans/purchasing/07-purchase-order-send-and-status.md §3.4).
+// The extraction is only safe if it preserves three behaviours that are easy to lose and
+// silent when lost: the create bypass, the two value-keying conventions, and the fact that
+// unguarded values stay freely editable (the edit-back-to-draft flow).
+
+import { describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../../../errors'
+import type { SystemHookContext } from '../types'
+
+vi.mock('../../../records/record-numbering', () => ({
+  recordNumbering: { create: vi.fn() },
+}))
+
+const { createLifecycleStatusGuard } = await import('../lifecycle-status-guard')
+const { QUOTE_HOOKS } = await import('../quote-hooks')
+const { INVOICE_HOOKS } = await import('../invoice-hooks')
+const { PURCHASE_ORDER_HOOKS } = await import('../purchasing-hooks')
+
+const FIELD_ID = 'field-status'
+
+function ctx(
+  systemAttribute: string,
+  values: Record<string, unknown>,
+  operation: 'create' | 'update' = 'update'
+): SystemHookContext {
+  return {
+    operation,
+    entityDef: { id: 'def-1', entityType: 'anything' },
+    field: { id: FIELD_ID, type: 'SINGLE_SELECT', systemAttribute },
+    values,
+    organizationId: 'org-1',
+    userId: 'user-1',
+    allFields: [],
+  } as unknown as SystemHookContext
+}
+
+/** The one guard registered per document, so the tests exercise the real registration. */
+const GUARDS = {
+  quote: {
+    attr: 'quote_status',
+    hook: QUOTE_HOOKS.quote_status![0]!,
+    guarded: ['sent', 'approved'],
+    open: ['draft', 'declined', 'canceled'],
+    message: /quote actions/,
+  },
+  invoice: {
+    attr: 'invoice_status',
+    hook: INVOICE_HOOKS.invoice_status![0]!,
+    guarded: ['sent', 'partially_paid', 'paid', 'void'],
+    open: ['draft'],
+    message: /invoice actions/,
+  },
+  purchase_order: {
+    attr: 'purchase_order_status',
+    hook: PURCHASE_ORDER_HOOKS.purchase_order_status![0]!,
+    // §3.4: `issued` is what SENDING does, so it stops being a dropdown value.
+    guarded: ['issued'],
+    // §3.6: `closed` is deliberately NOT derived — an order whose remainder has been
+    // forgiven must still be closeable by a human, so these three stay editable.
+    open: ['draft', 'closed', 'canceled'],
+    message: /Send/,
+  },
+} as const
+
+describe.each(Object.entries(GUARDS))('%s lifecycle status guard', (_name, spec) => {
+  it.each(spec.guarded)('rejects a manual write of %s', async (value) => {
+    await expect(spec.hook(ctx(spec.attr, { [FIELD_ID]: value }))).rejects.toThrow(BadRequestError)
+    await expect(spec.hook(ctx(spec.attr, { [FIELD_ID]: value }))).rejects.toThrow(spec.message)
+  })
+
+  it.each(spec.open)('leaves %s freely editable', async (value) => {
+    const values = { [FIELD_ID]: value }
+    await expect(spec.hook(ctx(spec.attr, values))).resolves.toEqual(values)
+  })
+
+  // A create cannot legitimately start in a guarded state — every one of these fields has
+  // `defaultValue: 'draft'` — and running the check on create would refuse a create that
+  // merely echoed a value back.
+  it.each(spec.guarded)('does not run on create (%s)', async (value) => {
+    const values = { [FIELD_ID]: value }
+    await expect(spec.hook(ctx(spec.attr, values, 'create'))).resolves.toEqual(values)
+  })
+
+  // `UnifiedCrudHandler.runPreHooks` dispatches on EITHER key, so a guard reading only one
+  // of them is silently bypassed by half the callers.
+  it('rejects a value keyed by systemAttribute, not just by fieldId', async () => {
+    const guardedValue = spec.guarded[0]
+    await expect(spec.hook(ctx(spec.attr, { [spec.attr]: guardedValue }))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+
+  // SINGLE_SELECT values arrive array-wrapped from some surfaces and scalar from others.
+  it('rejects a single-element array as well as a scalar', async () => {
+    const guardedValue = spec.guarded[0]
+    await expect(spec.hook(ctx(spec.attr, { [FIELD_ID]: [guardedValue] }))).rejects.toThrow(
+      BadRequestError
+    )
+    await expect(spec.hook(ctx(spec.attr, { [spec.attr]: [guardedValue] }))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+})
+
+describe('createLifecycleStatusGuard', () => {
+  it('ignores an update that does not touch the guarded field at all', async () => {
+    const guard = createLifecycleStatusGuard({ guardedValues: ['sent'], message: 'nope' })
+    const values = { 'some-other-field': 'sent' }
+    await expect(guard(ctx('quote_status', values))).resolves.toEqual(values)
+  })
+
+  it('throws the caller’s message verbatim, so the UI names the right action', async () => {
+    const guard = createLifecycleStatusGuard({
+      guardedValues: ['issued'],
+      message: 'Use Send to issue this purchase order',
+    })
+    await expect(guard(ctx('purchase_order_status', { [FIELD_ID]: 'issued' }))).rejects.toThrow(
+      'Use Send to issue this purchase order'
+    )
+  })
+
+  // Guarding on a Set of unknowns rather than string equality must not start matching
+  // things the `===` chain never matched.
+  it('does not match a non-string value that stringifies to a guarded one', async () => {
+    const guard = createLifecycleStatusGuard({ guardedValues: ['1'], message: 'nope' })
+    const values = { [FIELD_ID]: 1 }
+    await expect(guard(ctx('quote_status', values))).resolves.toEqual(values)
+  })
+
+  it('returns the values object untouched when nothing is guarded', async () => {
+    const guard = createLifecycleStatusGuard({ guardedValues: [], message: 'nope' })
+    const values = { [FIELD_ID]: 'sent' }
+    await expect(guard(ctx('quote_status', values))).resolves.toEqual(values)
+  })
+})

--- a/packages/lib/src/resources/hooks/__tests__/purchasing-hooks.test.ts
+++ b/packages/lib/src/resources/hooks/__tests__/purchasing-hooks.test.ts
@@ -111,8 +111,22 @@ describe('purchasing hook registration', () => {
   // The scopes themselves are guarded by the type system: `recordNumbering.create`'s
   // second parameter is the `SequenceScope` union, so `'purchase_order'` / `'vendor_bill'`
   // only compile because both scopes (and their `PO` / `BILL` prefixes) exist.
-  it('registers no lifecycle guards', () => {
-    expect(Object.keys(PURCHASE_ORDER_HOOKS)).toEqual(['purchase_order_number'])
+  //
+  // `purchase_order_status` gained a lifecycle guard with Send
+  // (plans/purchasing/07-purchase-order-send-and-status.md §3.4): `issued` is what sending
+  // DOES, not a value somebody picks. The guard's own behaviour is covered in
+  // `lifecycle-status-guard.test.ts`; this only pins that it is registered and reachable.
+  it('guards purchase_order_status and nothing else on the order', () => {
+    expect(Object.keys(PURCHASE_ORDER_HOOKS).sort()).toEqual([
+      'purchase_order_number',
+      'purchase_order_status',
+    ])
+    expect(getHooksForAttribute('purchase_order', 'purchase_order_status')).toHaveLength(1)
+  })
+
+  // `vendor_bill_status` is recomputed by the match hook on every create/update, so a manual
+  // write is OVERWRITTEN rather than rejected — a guard here would fight that writer.
+  it('registers no lifecycle guard on the vendor bill', () => {
     expect(Object.keys(VENDOR_BILL_HOOKS)).toEqual(['vendor_bill_internal_number'])
   })
 })

--- a/packages/lib/src/resources/hooks/invoice-hooks.ts
+++ b/packages/lib/src/resources/hooks/invoice-hooks.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/resources/hooks/invoice-hooks.ts
 
-import { BadRequestError } from '../../errors'
 import { recordNumbering } from '../../records/record-numbering'
+import { createLifecycleStatusGuard } from './lifecycle-status-guard'
 import type { SystemHook, SystemHookRegistry } from './types'
 
 /**
@@ -30,18 +30,10 @@ const autoGenerateInvoiceNumber: SystemHook = async ({
  * plain status `'draft'` after a `useConfirm`, and un-void (manual `draft` write) both flow
  * through it.
  */
-const rejectManualLifecycleStatus: SystemHook = async ({ operation, field, values }) => {
-  if (operation === 'create') return values // creates can't start sent/partially_paid/paid/void (defaultValue 'draft')
-  // Update values may be keyed by fieldId or systemAttribute, scalar or single-element array.
-  const raw = field.id in values ? values[field.id] : values[field.systemAttribute ?? '']
-  const next = Array.isArray(raw) ? raw[0] : raw
-  if (next === 'sent' || next === 'partially_paid' || next === 'paid' || next === 'void') {
-    throw new BadRequestError(
-      'Use the invoice actions (Send / Record payment / Void) to set this status'
-    )
-  }
-  return values
-}
+const rejectManualLifecycleStatus: SystemHook = createLifecycleStatusGuard({
+  guardedValues: ['sent', 'partially_paid', 'paid', 'void'],
+  message: 'Use the invoice actions (Send / Record payment / Void) to set this status',
+})
 
 export const INVOICE_HOOKS: SystemHookRegistry = {
   invoice_number: [autoGenerateInvoiceNumber],

--- a/packages/lib/src/resources/hooks/lifecycle-status-guard.ts
+++ b/packages/lib/src/resources/hooks/lifecycle-status-guard.ts
@@ -1,0 +1,117 @@
+// packages/lib/src/resources/hooks/lifecycle-status-guard.ts
+
+import { BadRequestError } from '../../errors'
+import type { SystemHook } from './types'
+
+/**
+ * The `purchase_order_status` values an ACTION owns. Exported so the two guards that
+ * enforce it — the system pre-hook in `purchasing-hooks.ts` and the field pre-hook in
+ * `field-hooks/pre/purchase-order-status-guard.ts` — read ONE source and cannot drift into
+ * disagreeing about what is guarded.
+ *
+ * `draft`, `closed` and `canceled` are deliberately absent: they are genuine human
+ * decisions, and §3.6 does not derive `closed` precisely so that an order whose remainder
+ * has been forgiven stays closeable by hand.
+ */
+export const PURCHASE_ORDER_ACTION_STATUSES = ['issued'] as const
+
+/** The one message both purchase-order guards throw, for the same reason as the set above. */
+export const PURCHASE_ORDER_ACTION_STATUS_MESSAGE = 'Use Send to issue this purchase order'
+
+/**
+ * Reduce a status write to the bare value being set, whatever shape it arrives in.
+ *
+ * 🛑 The two chains hand a guard **different shapes**, and this is the whole reason the
+ * function exists rather than being inlined twice:
+ *
+ * - On the **system**-hook chain (`UnifiedCrudHandler.runPreHooks`) the value is raw caller
+ *   input — usually the bare string, sometimes a single-element array.
+ * - On the **field** pre-hook chain (`fireFieldPreHooks`) the value has already been through
+ *   `validateAndConvertValue`, so a SINGLE_SELECT arrives as `{ type: 'option', optionId }`
+ *   and **never** as a bare string. A guard on that chain that compares the value directly
+ *   to `'issued'` is inert: the comparison can never be true, so the guard silently passes
+ *   everything.
+ *
+ * Unwrapping the envelope makes the system-hook side strictly stricter (it now also catches
+ * a caller that passes the typed shape), which can only ever reject a write that was trying
+ * to set a guarded status.
+ *
+ * @param raw - The value as the chain handed it over.
+ * @returns The scalar the guard should compare against.
+ */
+export function unwrapStatusValue(raw: unknown): unknown {
+  if (Array.isArray(raw)) return unwrapStatusValue(raw[0])
+  if (raw && typeof raw === 'object') {
+    if ('optionId' in raw) return (raw as { optionId: unknown }).optionId
+    if ('value' in raw) return (raw as { value: unknown }).value
+  }
+  return raw
+}
+
+/** Options for {@link createLifecycleStatusGuard}. */
+export interface LifecycleStatusGuardOptions {
+  /**
+   * The status values an ACTION owns. A manual write to any of them is refused;
+   * everything else on the enum stays freely editable.
+   */
+  guardedValues: readonly string[]
+  /**
+   * What to tell the caller instead. Name the actions, not the rule — the person
+   * seeing this wants to know which button to press.
+   */
+  message: string
+}
+
+/**
+ * Build the "this status is action-set, not a dropdown value" guard for the **system**-hook
+ * chain (`UnifiedCrudHandler.runPreHooks`).
+ *
+ * Three documents now need the identical logic and differ only in which values an action
+ * owns and what to say instead: `quote_status` (Send / Mark approved), `invoice_status`
+ * (Send / Record payment / Void) and `purchase_order_status` (Send). The two copies that
+ * existed verbatim in `quote-hooks.ts` and `invoice-hooks.ts` are now both this function
+ * (plans/purchasing/07-purchase-order-send-and-status.md §3.4).
+ *
+ * ⚠️ **Which chain this covers, and which it does not.** This runs only for writes through
+ * `UnifiedCrudHandler.create`/`.update` — `record.create`, `record.update`, bulk record
+ * writes, the CSV importer and the SDK. It does **not** run for `fieldValue.set` /
+ * `setBulk`, which is how the drawer, the grid's inline edit, a kanban drag and the
+ * LineBuilder all write. `field-hooks/pre/quote-deposit-guard.ts` records the same finding
+ * independently. So a status that must be genuinely un-typeable needs a **field** pre-hook
+ * twin as well; `purchase_order_status` has one in
+ * `field-hooks/pre/purchase-order-status-guard.ts`, and the two share their guarded set and
+ * message through the constants at the top of this file.
+ *
+ * The sanctioned writers reach the field through `FieldValueService`, which bypasses this
+ * chain entirely, so this guard never sees their writes — it only ever sees a human typing
+ * a value an action is supposed to produce.
+ *
+ * ⚠️ Two behaviours here are load-bearing and are preserved from the originals:
+ *
+ * 1. `operation === 'create'` returns early. A create cannot legitimately start in a guarded
+ *    state — every one of these fields has `defaultValue: 'draft'` — and running the check on
+ *    create would refuse a create that merely echoed the default back.
+ * 2. The incoming value may be keyed by `field.id` OR by `field.systemAttribute`, and may
+ *    arrive scalar or as a single-element array (SINGLE_SELECT).
+ *    `UnifiedCrudHandler.runPreHooks` deliberately checks both keys before dispatching, so a
+ *    guard that read only one of them would be silently bypassed by half the callers.
+ *
+ * @param options - The guarded value set and the message to throw instead.
+ * @returns A {@link SystemHook} to register against the status attribute.
+ */
+export function createLifecycleStatusGuard(options: LifecycleStatusGuardOptions): SystemHook {
+  // `Set<unknown>` rather than `Set<string>`: the incoming value is unknown, and a
+  // membership test on an unknown is exactly the original `next === 'sent' || …`
+  // comparison without a narrowing cast in front of it.
+  const guarded = new Set<unknown>(options.guardedValues)
+
+  return async ({ operation, field, values }) => {
+    if (operation === 'create') return values // creates can't start guarded (defaultValue 'draft')
+    // Update values may be keyed by fieldId or systemAttribute, scalar or single-element array.
+    const raw = field.id in values ? values[field.id] : values[field.systemAttribute ?? '']
+    if (guarded.has(unwrapStatusValue(raw))) {
+      throw new BadRequestError(options.message)
+    }
+    return values
+  }
+}

--- a/packages/lib/src/resources/hooks/purchasing-hooks.ts
+++ b/packages/lib/src/resources/hooks/purchasing-hooks.ts
@@ -1,6 +1,11 @@
 // packages/lib/src/resources/hooks/purchasing-hooks.ts
 
 import { recordNumbering } from '../../records/record-numbering'
+import {
+  createLifecycleStatusGuard,
+  PURCHASE_ORDER_ACTION_STATUS_MESSAGE,
+  PURCHASE_ORDER_ACTION_STATUSES,
+} from './lifecycle-status-guard'
 import type { SystemHook, SystemHookRegistry } from './types'
 
 /**
@@ -40,11 +45,50 @@ const autoGenerateVendorBillInternalNumber: SystemHook = async ({
 }
 
 /**
- * `purchase_order` has no lifecycle guard. `purchase_order_status` is a plain human-set
- * field with no sanctioned action carrying side effects, so nothing a manual write skips.
+ * Guard: `issued` may only be set by the Send action (`markPurchaseOrderSent`,
+ * plans/purchasing/07-purchase-order-send-and-status.md §3.4/§6.4).
+ *
+ * ⚠️ This field used to be documented here as *"a plain human-set field with no sanctioned
+ * action"*, and that was accurate only by accident: nothing could write it, so calling it
+ * the human axis cost nothing. Send changes that. For a purchase order, **issued IS sent to
+ * the vendor** — one event, and the accounting word is the better one, so there is no
+ * separate `sent` value — which makes `issued` a thing an action produces rather than a
+ * value somebody picks. Typing it by hand claims an order went out that never did, and the
+ * expediting list, the `expected_at` default and (per §6.1) the receipt pull-forward all
+ * read it.
+ *
+ * `draft`, `closed` and `canceled` stay freely editable. They are genuine human decisions:
+ * §3.6 deliberately does NOT derive `closed`, because an order where the vendor short-shipped
+ * and the remainder has been forgiven must still be closeable and no derived rule could ever
+ * close it.
+ *
+ * ⚠️ **This guard covers the CRUD chain only, and is NOT the main enforcement point.**
+ * `UnifiedCrudHandler.runPreHooks` runs for `record.create`/`record.update`, bulk record
+ * writes, the CSV importer and the SDK — worth having, and removing it would narrow
+ * coverage. But every *interactive* edit goes through `fieldValue.set` ->
+ * `FieldValueService`, which never reads this registry, so a drawer edit or a kanban drag
+ * reaches only the field pre-hook twin in
+ * `field-hooks/pre/purchase-order-status-guard.ts`. That one is what actually stops a human
+ * typing `issued`. The two share their guarded set and message via
+ * `PURCHASE_ORDER_ACTION_STATUSES` / `PURCHASE_ORDER_ACTION_STATUS_MESSAGE` so they cannot
+ * drift, and `pre/quote-deposit-guard.ts` records the same finding for `quote_status`.
+ *
+ * The sanctioned writer reaches the field through `FieldValueService`, which bypasses this
+ * chain entirely, so this guard never sees it. On the field chain it clears the twin by
+ * naming `purchase_order_status` in `bypassFieldGuards`.
+ */
+const rejectManualLifecycleStatus: SystemHook = createLifecycleStatusGuard({
+  guardedValues: PURCHASE_ORDER_ACTION_STATUSES,
+  message: PURCHASE_ORDER_ACTION_STATUS_MESSAGE,
+})
+
+/**
+ * `purchase_order` system hooks: the RecordSequence number on create, and the lifecycle
+ * guard that keeps `issued` an action rather than a dropdown value.
  */
 export const PURCHASE_ORDER_HOOKS: SystemHookRegistry = {
   purchase_order_number: [autoGeneratePurchaseOrderNumber],
+  purchase_order_status: [rejectManualLifecycleStatus],
 }
 
 /**

--- a/packages/lib/src/resources/hooks/quote-hooks.ts
+++ b/packages/lib/src/resources/hooks/quote-hooks.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/resources/hooks/quote-hooks.ts
 
-import { BadRequestError } from '../../errors'
 import { recordNumbering } from '../../records/record-numbering'
+import { createLifecycleStatusGuard } from './lifecycle-status-guard'
 import type { SystemHook, SystemHookRegistry } from './types'
 
 /**
@@ -29,16 +29,10 @@ const autoGenerateQuoteNumber: SystemHook = async ({
  * edit-sent-back-to-draft flow writes plain status `'draft'` after a `useConfirm`, which this
  * guard also allows through.
  */
-const rejectManualLifecycleStatus: SystemHook = async ({ operation, field, values }) => {
-  if (operation === 'create') return values // creates can't start sent/approved (defaultValue 'draft')
-  // Update values may be keyed by fieldId or systemAttribute, scalar or single-element array.
-  const raw = field.id in values ? values[field.id] : values[field.systemAttribute ?? '']
-  const next = Array.isArray(raw) ? raw[0] : raw
-  if (next === 'sent' || next === 'approved') {
-    throw new BadRequestError('Use the quote actions (Send / Mark approved) to set this status')
-  }
-  return values
-}
+const rejectManualLifecycleStatus: SystemHook = createLifecycleStatusGuard({
+  guardedValues: ['sent', 'approved'],
+  message: 'Use the quote actions (Send / Mark approved) to set this status',
+})
 
 export const QUOTE_HOOKS: SystemHookRegistry = {
   quote_number: [autoGenerateQuoteNumber],

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -553,27 +553,91 @@ export const StockMovementCostBasis = {
 } as const
 
 /**
- * Purchase Order Status
- * plans/purchasing/01-build-plan.md §4.1.
+ * Purchase Order Status — the ACTION axis, and nothing else
+ * plans/purchasing/07-purchase-order-send-and-status.md §3.3.
  *
- * `partially_received` and `received` are driven by the computed
- * `quantityReceived` roll-up, not set by hand.
+ * `draft` -> `issued` -> `closed` | `canceled`. `issued` means **sent to the
+ * vendor** and nothing more (§6.4) — not "the vendor accepted", which is a
+ * `confirmed` state that does not exist yet and must not be smuggled in here.
+ *
+ * 🛑 **Receiving and billing are NOT on this axis.** `partially_received` and
+ * `received` used to sit in this list and had no writer at all; they are now
+ * {@link PurchaseOrderReceiptStatus}, alongside {@link PurchaseOrderBillingStatus}.
+ * The decisive case is prepayment: a vendor that will not ship until the invoice
+ * is paid leaves the order *fully billed, fully paid, nothing received* for
+ * weeks, and one enum cannot say that — whichever axis you pick, the other
+ * becomes invisible. {@link VendorBillStatus} is what this looks like when the
+ * two are left conflated: its payment values destroy its match verdict, and
+ * `partially_paid` had to be invented to compensate.
+ *
+ * `OrderFinancialStatus` / `OrderFulfillmentStatus` are the same split on the
+ * sell side; the purchase order simply predates them.
+ *
+ * ✅ `closed` is deliberately never derived: an order the vendor short-shipped,
+ * where the remainder has been agreed away, must still be closeable, and no
+ * roll-up rule can decide that.
  */
 export const PurchaseOrderStatus = {
   DRAFT: 'draft',
   ISSUED: 'issued',
-  PARTIALLY_RECEIVED: 'partially_received',
-  RECEIVED: 'received',
   CLOSED: 'closed',
   CANCELED: 'canceled',
 
   values: [
     { value: 'draft', label: 'Draft', color: 'gray' },
     { value: 'issued', label: 'Issued', color: 'blue' },
-    { value: 'partially_received', label: 'Partially received', color: 'amber' },
-    { value: 'received', label: 'Received', color: 'green' },
     { value: 'closed', label: 'Closed', color: 'forest' },
     { value: 'canceled', label: 'Canceled', color: 'red' },
+  ] satisfies FieldOptionItem[],
+} as const
+
+/**
+ * Purchase Order Receipt Status — the GOODS axis
+ * plans/purchasing/07-purchase-order-send-and-status.md §3.3.
+ *
+ * Derived from the `purchase_order_line_quantity_received` roll-up that already
+ * re-SUMs on every stock movement; the order-level verdict is the same
+ * computation one level up, on the same trigger and with no new query. Never
+ * set by hand — the enum carries no `not_applicable`-style escape hatch for the
+ * same reason `part_quantity_on_hand` carries none.
+ *
+ * The register mirrors {@link OrderFulfillmentStatus}: grey for nothing yet,
+ * amber for the partial state somebody has to chase, green for complete.
+ */
+export const PurchaseOrderReceiptStatus = {
+  NOT_RECEIVED: 'not_received',
+  PARTIALLY_RECEIVED: 'partially_received',
+  RECEIVED: 'received',
+
+  values: [
+    { value: 'not_received', label: 'Not received', color: 'gray' },
+    { value: 'partially_received', label: 'Partially received', color: 'amber' },
+    { value: 'received', label: 'Received', color: 'green' },
+  ] satisfies FieldOptionItem[],
+} as const
+
+/**
+ * Purchase Order Billing Status — the MONEY axis
+ * plans/purchasing/07-purchase-order-send-and-status.md §3.3.
+ *
+ * Derived from the `purchase_order_line_quantity_billed` roll-up, the twin of
+ * {@link PurchaseOrderReceiptStatus}'s source and written by the same pass.
+ *
+ * 🛑 This is BILLED, not PAID (§3.6). Payment lives on the vendor bill, one
+ * order can carry several bills, and a PO-level payment field would be a
+ * summary of state owned elsewhere — free to drift from the rows it claims to
+ * summarise. "Everything here is settled" is what `closed` means, and a human
+ * sets it.
+ */
+export const PurchaseOrderBillingStatus = {
+  NOT_BILLED: 'not_billed',
+  PARTIALLY_BILLED: 'partially_billed',
+  BILLED: 'billed',
+
+  values: [
+    { value: 'not_billed', label: 'Not billed', color: 'gray' },
+    { value: 'partially_billed', label: 'Partially billed', color: 'amber' },
+    { value: 'billed', label: 'Billed', color: 'green' },
   ] satisfies FieldOptionItem[],
 } as const
 

--- a/packages/lib/src/resources/registry/resources/contact-fields.ts
+++ b/packages/lib/src/resources/registry/resources/contact-fields.ts
@@ -698,6 +698,34 @@ export const CONTACT_FIELDS: Record<string, ResourceField> = {
     description: 'Orders placed by this contact',
   },
 
+  // Reverse relationship: purchase orders (from purchase_order.contact).
+  // The BUY side: this contact works for a supplier and is who our orders are
+  // addressed to — the mirror of `orders`, which is what they bought from us.
+  purchaseOrders: {
+    id: toFieldId('purchaseOrders'),
+    key: 'purchaseOrders',
+    label: 'Purchase Orders',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'contact_purchase_orders',
+    showInPanel: false,
+    systemSortOrder: 'aI',
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'purchase_order:contact' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description: 'Purchase orders addressed to this contact',
+  },
+
   balanceDue: {
     id: toFieldId('balanceDue'),
     key: 'balanceDue',

--- a/packages/lib/src/resources/registry/resources/purchase-order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/purchase-order-fields.ts
@@ -4,7 +4,12 @@ import { FieldType } from '@auxx/database/enums'
 import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
 import { BaseType } from '../../types'
 import { CREATED_BY_FIELD } from '../common-fields'
-import { LandedCostAllocationBasis, PurchaseOrderStatus } from '../enum-values'
+import {
+  LandedCostAllocationBasis,
+  PurchaseOrderBillingStatus,
+  PurchaseOrderReceiptStatus,
+  PurchaseOrderStatus,
+} from '../enum-values'
 import type { ResourceField } from '../field-types'
 
 /**
@@ -107,6 +112,49 @@ export const PURCHASE_ORDER_FIELDS: Record<string, ResourceField> = {
     description: 'Supplier this order was placed with — required, the selling party',
   },
 
+  contact: {
+    id: toFieldId('contact'),
+    key: 'contact',
+    label: 'Contact',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'purchase_order_contact',
+    systemSortOrder: 'a2a',
+    // Optional, unlike `quote_contact`: a quote cannot exist without the
+    // customer it is addressed to, but a PO is drafted against a `company`
+    // first and the person to send it to is settled later.
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'contact:purchaseOrders' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'contact',
+      relationshipType: 'belongs_to',
+      inverseName: 'Purchase Orders',
+      inverseSystemAttribute: 'contact_purchase_orders',
+    },
+    // The ADDRESSEE, and the reason this field exists at all: `vendor` targets a
+    // `company`, and a company carries no email of its own — only
+    // `company_primary_contact` — so without this there is nobody to send the
+    // order to. Mirrors `quote_contact` / `invoice_contact` so the send path's
+    // contact lookup extends by one map entry rather than growing a branch.
+    //
+    // Intended to DEFAULT from the vendor's `company_primary_contact` and stay
+    // overwritable — the prefill is not written yet.
+    description:
+      'Person at the vendor this order is sent to — defaults from the vendor’s primary contact',
+  },
+
   status: {
     id: toFieldId('status'),
     key: 'status',
@@ -126,8 +174,63 @@ export const PURCHASE_ORDER_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select status',
-    description: 'Where the order sits between drafted and closed',
+    // The ACTION axis only — where a person (or the Send action) has moved the
+    // order to. What arrived and what was billed are `receiptStatus` and
+    // `billingStatus` below, because those two move independently of this one
+    // and of each other.
+    description:
+      'Where the order sits between drafted and closed — issued means sent to the vendor',
     defaultValue: 'draft',
+  },
+
+  receiptStatus: {
+    id: toFieldId('receiptStatus'),
+    key: 'receiptStatus',
+    label: 'Receipt Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'purchase_order_receipt_status',
+    systemSortOrder: 'a3a',
+    nullable: true,
+    options: { options: PurchaseOrderReceiptStatus.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false, // the line roll-up is the ONLY writer
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    // Same shape and same reason as `purchase_order_line_quantity_received`: the
+    // subledger is the truth, and a hand-set copy of a SUM diverges silently.
+    description:
+      'How much of the order has arrived — derived from the line quantityReceived roll-up, never typed',
+  },
+
+  billingStatus: {
+    id: toFieldId('billingStatus'),
+    key: 'billingStatus',
+    label: 'Billing Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'purchase_order_billing_status',
+    systemSortOrder: 'a3b',
+    nullable: true,
+    options: { options: PurchaseOrderBillingStatus.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false, // the line roll-up is the ONLY writer
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    // BILLED, not PAID: payment lives on the vendor bill and one order can carry
+    // several, so a PO-level payment figure would summarise state it does not own.
+    description:
+      'How much of the order has been billed — derived from the line quantityBilled roll-up, never typed',
   },
 
   orderedAt: {
@@ -479,6 +582,40 @@ export const PURCHASE_ORDER_FIELDS: Record<string, ResourceField> = {
     },
     placeholder: 'Enter internal notes',
     description: 'Internal notes — not shown to the supplier',
+  },
+
+  // Verbatim the `quote_pdf_asset` / `invoice_pdf_asset` shape — a bare
+  // MediaAsset id in TEXT, not a relation. `ensure-pdf.ts` reads all three
+  // through `cf[pointerAttr]` on the same code path, so a divergence here is a
+  // bug in that path rather than a local choice.
+  //
+  // 🛑 It is what makes a re-send REUSE the last render. Without the field the
+  // lookup returns undefined, `existingAssetId` is always undefined, and every
+  // send re-renders AND mints a fresh MediaAsset — an asset leak that grows per
+  // send, throws nothing, and produces a correct PDF every time. Nothing but
+  // storage growth would ever show it.
+  pdfAsset: {
+    id: toFieldId('pdfAsset'),
+    key: 'pdfAsset',
+    label: 'PDF Asset',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'purchase_order_pdf_asset',
+    systemSortOrder: 'aK',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+      hidden: true,
+    },
+    description:
+      'MediaAsset id of the last-rendered purchase order PDF (money MQ2 build spec §C.1 recipe) ' +
+      '— written only by ensureDocumentPdf via FieldValueService, never user-editable',
   },
 
   // Reverse relationship: lines (from purchase_order_line.purchaseOrder).

--- a/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts
@@ -31,6 +31,8 @@ import {
   GlAccountType,
   GlPostingLineDirection,
   LandedCostAllocationBasis,
+  PurchaseOrderBillingStatus,
+  PurchaseOrderReceiptStatus,
   PurchaseOrderStatus,
   StockMovementCostBasis,
   VendorBillPaidSource,
@@ -39,13 +41,17 @@ import {
 } from '../../../resources/registry/enum-values'
 import { RESOURCE_FIELD_REGISTRY } from '../../../resources/registry/field-registry'
 import type { ResourceField } from '../../../resources/registry/field-types'
+import type { FieldOptionItem } from '../../../resources/registry/option-helpers'
 import { COMPANY_FIELDS } from '../../../resources/registry/resources/company-fields'
+import { CONTACT_FIELDS } from '../../../resources/registry/resources/contact-fields'
 import { GL_ACCOUNT_FIELDS } from '../../../resources/registry/resources/gl-account-fields'
 import { GL_POSTING_FIELDS } from '../../../resources/registry/resources/gl-posting-fields'
 import { GL_POSTING_LINE_FIELDS } from '../../../resources/registry/resources/gl-posting-line-fields'
+import { INVOICE_FIELDS } from '../../../resources/registry/resources/invoice-fields'
 import { PART_FIELDS } from '../../../resources/registry/resources/part-fields'
 import { PURCHASE_ORDER_FIELDS } from '../../../resources/registry/resources/purchase-order-fields'
 import { PURCHASE_ORDER_LINE_FIELDS } from '../../../resources/registry/resources/purchase-order-line-fields'
+import { QUOTE_FIELDS } from '../../../resources/registry/resources/quote-fields'
 import { STOCK_MOVEMENT_FIELDS } from '../../../resources/registry/resources/stock-movement-fields'
 import { VENDOR_BILL_FIELDS } from '../../../resources/registry/resources/vendor-bill-fields'
 import { VENDOR_BILL_LINE_FIELDS } from '../../../resources/registry/resources/vendor-bill-line-fields'
@@ -125,6 +131,7 @@ const RECEIVING_KEYS = [
  */
 const INVERSE_KEYS: Record<string, readonly string[]> = {
   company: ['purchaseOrders', 'vendorBills', 'vendorPayments'],
+  contact: ['purchaseOrders'],
   part: ['purchaseOrderLines', 'vendorBillLines', 'unit'],
   vendor_part: ['stockMovements', 'purchaseOrderLines'],
   gl_posting: ['lines'],
@@ -133,6 +140,7 @@ const INVERSE_KEYS: Record<string, readonly string[]> = {
 const INCUMBENT_REGISTRIES: Record<string, Record<string, ResourceField>> = {
   stock_movement: STOCK_MOVEMENT_FIELDS,
   company: COMPANY_FIELDS,
+  contact: CONTACT_FIELDS,
   part: PART_FIELDS,
   vendor_part: VENDOR_PART_FIELDS,
   gl_posting: GL_POSTING_FIELDS,
@@ -298,9 +306,35 @@ const ALL_DEF_REGISTRIES: Record<string, Record<string, ResourceField>> = {
   ...INCUMBENT_REGISTRIES,
 }
 
+/**
+ * The two ways a stored option list goes stale, one per direction:
+ *
+ *   vendor_bill_status     a value was ADDED to the enum (`partially_paid`)
+ *   purchase_order_status  two values were REMOVED (they became their own fields)
+ *
+ * Both are invisible to `ensureCustomFields`, which skips a field that already
+ * exists — which is the whole reason the refresh step exists.
+ */
+const STALE_STATUS_FIXTURES: Record<
+  'vendor_bill_status' | 'purchase_order_status',
+  FieldOptionItem[]
+> = {
+  vendor_bill_status: VendorBillStatus.values.filter((v) => v.value !== 'partially_paid'),
+  purchase_order_status: [
+    ...PurchaseOrderStatus.values.slice(0, 2),
+    { value: 'partially_received', label: 'Partially received', color: 'amber' },
+    { value: 'received', label: 'Received', color: 'green' },
+    ...PurchaseOrderStatus.values.slice(2),
+  ],
+}
+
 function migratedOrgDb(
   writes: string[],
-  opts: { linked?: boolean; omit?: readonly string[]; staleVendorBillStatus?: boolean } = {}
+  opts: {
+    linked?: boolean
+    omit?: readonly string[]
+    staleStatus?: keyof typeof STALE_STATUS_FIXTURES
+  } = {}
 ) {
   const omit = new Set(opts.omit ?? [])
   const defs = Object.entries(ALL_DEF_REGISTRIES).filter(([entityType]) => !omit.has(entityType))
@@ -308,14 +342,14 @@ function migratedOrgDb(
     fieldRows(`def-${entityType}`, registry, opts.linked ?? true)
   )
 
-  // An org migrated BEFORE a value was added to the enum: the row still carries
-  // the option list it was created with.
-  if (opts.staleVendorBillStatus) {
-    const statusRow = customFields.find((row) => row.systemAttribute === 'vendor_bill_status')
-    if (!statusRow) throw new Error('fixture: vendor_bill_status row is missing')
+  // An org migrated BEFORE the enum changed: the row still carries the option
+  // list it was created with.
+  if (opts.staleStatus) {
+    const statusRow = customFields.find((row) => row.systemAttribute === opts.staleStatus)
+    if (!statusRow) throw new Error(`fixture: ${opts.staleStatus} row is missing`)
     statusRow.options = {
       ...statusRow.options,
-      options: VendorBillStatus.values.filter((v) => v.value !== 'partially_paid'),
+      options: STALE_STATUS_FIXTURES[opts.staleStatus],
     }
   }
 
@@ -639,16 +673,114 @@ describe('purchase_order field shapes the plan is explicit about', () => {
     })
   })
 
-  it('status is the six-value purchasing lifecycle, wired to the enum list', () => {
+  // 07 §3.3. The ACTION axis and only the action axis — four values, all of
+  // which a person or the Send action can actually reach.
+  it('status is the four-value action lifecycle, wired to the enum list', () => {
     expect(PurchaseOrderStatus.values.map((v) => v.value)).toEqual([
       'draft',
       'issued',
-      'partially_received',
-      'received',
       'closed',
       'canceled',
     ])
     expect(PURCHASE_ORDER_FIELDS.status?.options).toEqual({ options: PurchaseOrderStatus.values })
+  })
+
+  // 🛑 The split itself, stated as an assertion rather than a comment. Receiving
+  // and billing move independently — a prepaid order is fully billed with
+  // nothing received for weeks — so neither may live on `status`, and `status`
+  // must not re-acquire them. This is the defect `VendorBillStatus` already has:
+  // its payment values overwrite its match verdict and `MATCHABLE_STATUSES` then
+  // refuses to recompute it.
+  it('keeps receiving and billing off the action axis', () => {
+    const actionValues = PurchaseOrderStatus.values.map((v) => v.value)
+    for (const leaked of ['partially_received', 'received', 'partially_billed', 'billed']) {
+      expect(actionValues, `${leaked} belongs on its own axis`).not.toContain(leaked)
+    }
+
+    expect(PurchaseOrderReceiptStatus.values.map((v) => v.value)).toEqual([
+      'not_received',
+      'partially_received',
+      'received',
+    ])
+    expect(PurchaseOrderBillingStatus.values.map((v) => v.value)).toEqual([
+      'not_billed',
+      'partially_billed',
+      'billed',
+    ])
+    expect(PURCHASE_ORDER_FIELDS.receiptStatus?.options).toEqual({
+      options: PurchaseOrderReceiptStatus.values,
+    })
+    expect(PURCHASE_ORDER_FIELDS.billingStatus?.options).toEqual({
+      options: PurchaseOrderBillingStatus.values,
+    })
+  })
+
+  // Both are DERIVED: the line roll-up is the only writer, exactly as
+  // `quantityReceived` / `quantityBilled` are on the line itself. A creatable
+  // derived field is a box a user can fill in and the next roll-up silently
+  // overwrites.
+  it('receiptStatus and billingStatus are computed, never typed', () => {
+    for (const key of ['receiptStatus', 'billingStatus'] as const) {
+      const field = PURCHASE_ORDER_FIELDS[key]
+      expect(field?.fieldType, key).toBe(FieldType.SINGLE_SELECT)
+      expect(field?.isSystem, key).toBe(true)
+      expect(field?.capabilities?.creatable, key).toBe(false)
+      expect(field?.capabilities?.updatable, key).toBe(false)
+      expect(field?.capabilities?.computed, key).toBe(true)
+      expect(field?.capabilities?.configurable, key).toBe(false)
+      // No `defaultValue`: `applyDefaults` skips non-creatable fields, so one
+      // here would be dead code that reads like a guarantee.
+      expect(field?.defaultValue, key).toBeUndefined()
+    }
+  })
+
+  // The three status fields are read together on every PO surface, so they sort
+  // together: `a3` (status), `a3a`, `a3b`, then `a4` (orderedAt).
+  it('sorts the two derived statuses immediately after status', () => {
+    const order = (key: string) => PURCHASE_ORDER_FIELDS[key]?.systemSortOrder
+    expect(order('status')).toBe('a3')
+    expect(order('receiptStatus')).toBe('a3a')
+    expect(order('billingStatus')).toBe('a3b')
+    expect(order('orderedAt')).toBe('a4')
+    const keys = ['status', 'receiptStatus', 'billingStatus', 'orderedAt'].map(order)
+    expect([...keys].sort()).toEqual(keys)
+  })
+
+  // 🛑 The pointer `RegisteredDocumentType.pointerAttr` resolves. `ensure-pdf.ts`
+  // reads `cf[pointerAttr]` to decide whether to REUSE the last render; with no
+  // such field the lookup is `undefined`, `existingAssetId` is always
+  // `undefined`, and every send re-renders AND mints a fresh MediaAsset. That
+  // leaks an asset per send, throws nothing, and returns a correct PDF every
+  // time — so this is asserted rather than trusted.
+  //
+  // The shape is copied verbatim from the two incumbents because all three go
+  // through the same read path: a bare MediaAsset id in TEXT, hidden, and
+  // `updatable` but not `creatable` (only `ensureDocumentPdf` writes it, via
+  // `FieldValueService`, which bypasses the pre-hook chain).
+  it('carries a pdf-asset pointer shaped exactly like the quote and invoice ones', () => {
+    const po = PURCHASE_ORDER_FIELDS.pdfAsset
+    expect(po?.systemAttribute).toBe('purchase_order_pdf_asset')
+
+    for (const twin of [QUOTE_FIELDS.pdfAsset, INVOICE_FIELDS.pdfAsset]) {
+      expect(twin, 'the incumbent pdfAsset field vanished').toBeDefined()
+      expect(po?.type).toBe(twin?.type)
+      expect(po?.fieldType).toBe(twin?.fieldType)
+      expect(po?.nullable).toBe(twin?.nullable)
+      expect(po?.showInPanel).toBe(twin?.showInPanel)
+      expect(po?.capabilities).toEqual(twin?.capabilities)
+    }
+
+    // Spelled out too, so a change to all three at once still trips something.
+    expect(po?.fieldType).toBe(FieldType.TEXT)
+    expect(po?.capabilities?.creatable).toBe(false)
+    expect(po?.capabilities?.updatable).toBe(true)
+    expect(po?.capabilities?.hidden).toBe(true)
+    // Not a RELATIONSHIP: it stores a MediaAsset id as text, and `media_asset`
+    // is not an entity def, so a relation would have nothing to link to.
+    expect(po?.relationship).toBeUndefined()
+    // Late/administrative, where the quote (aK) and invoice (aI) put theirs —
+    // after `bills` (aJ) and before the createdAt/updatedAt `b*` block.
+    expect(po?.systemSortOrder).toBe('aK')
   })
 
   // §4.2, and the same rule `part_quantity_on_hand` already lives by: the ledger
@@ -702,16 +834,22 @@ describe('vendor_bill field shapes the plan is explicit about', () => {
 
   // `ensureCustomFields` SKIPS an existing field and never touches its options,
   // so an org that already ran 108 keeps whatever option list the field was
-  // CREATED with. Adding a value to the enum is therefore only half the change —
-  // the migration has to re-materialize the row, or the code believes in seven
-  // values while the database holds six.
-  it('re-materializes an existing status field rather than only seeding new orgs', () => {
+  // CREATED with. Changing an enum is therefore only half the change — the
+  // migration has to re-materialize the row, or the code and the database
+  // disagree about what values exist.
+  //
+  // The behaviour is asserted for real in the idempotency block below; what is
+  // pinned here is that BOTH status fields go through the refresh, and that a
+  // refresh counts as work.
+  it('re-materializes both status fields rather than only seeding new orgs', () => {
     const here = fileURLToPath(new URL('.', import.meta.url))
     const source = readFileSync(join(here, '108-purchasing.ts'), 'utf8')
-    expect(source).toContain('refreshVendorBillStatusOptions')
+    expect(source).toContain('refreshStatusOptions')
+    expect(source).toContain('VENDOR_BILL_FIELDS.status')
+    expect(source).toContain('PURCHASE_ORDER_FIELDS.status')
     // And the refresh must count toward "did something", or a run that only
     // rewrote options would report alreadyUpToDate and skip the cache flush that
-    // makes the new value visible to every read path.
+    // makes the change visible to every read path.
     expect(source).toContain('!statusRefreshed')
   })
 
@@ -894,6 +1032,15 @@ describe('relationship pairs', () => {
       inverseRef: 'purchase_order:vendor',
     },
     {
+      // The ADDRESSEE pair. Without it a PO has no email recipient at all:
+      // `vendor` targets a `company`, and a company carries no email of its own.
+      name: 'purchase_order.contact ↔ contact.purchaseOrders',
+      owning: PURCHASE_ORDER_FIELDS.contact,
+      owningRef: 'contact:purchaseOrders',
+      inverse: CONTACT_FIELDS.purchaseOrders,
+      inverseRef: 'purchase_order:contact',
+    },
+    {
       name: 'purchase_order_line.purchaseOrder ↔ purchase_order.lines',
       owning: PURCHASE_ORDER_LINE_FIELDS.purchaseOrder,
       owningRef: 'purchase_order:lines',
@@ -1033,6 +1180,11 @@ describe('relationship pairs', () => {
 
   it('the required legs are required, and the optional ones stay optional', () => {
     expect(PURCHASE_ORDER_FIELDS.vendor?.nullable).toBe(false)
+    // Unlike `quote_contact`, which is required: a PO is drafted against a
+    // supplier first, and who to send it to is settled later. Requiring it here
+    // would block the create dialog on a person nobody has picked yet.
+    expect(PURCHASE_ORDER_FIELDS.contact?.nullable).toBe(true)
+    expect(PURCHASE_ORDER_FIELDS.contact?.required).toBeUndefined()
     expect(PURCHASE_ORDER_LINE_FIELDS.purchaseOrder?.nullable).toBe(false)
     expect(PURCHASE_ORDER_LINE_FIELDS.part?.nullable).toBe(false)
     expect(PURCHASE_ORDER_LINE_FIELDS.vendorPart?.nullable).toBe(true)
@@ -1263,21 +1415,29 @@ describe('migration 108 idempotency', () => {
     expect(writes.filter((w) => w.startsWith('insert'))).toEqual([])
   })
 
-  // 🛑 The half of the option-refresh that actually matters. The test above
-  // proves it stays QUIET when the stored options already match; this proves it
-  // FIRES when they do not. Without this, adding a value to `VendorBillStatus`
+  // 🛑 The half of the option-refresh that actually matters. The first test
+  // proves it stays QUIET when the stored options already match; these prove it
+  // FIRES when they do not. Without them, changing an enum in `enum-values.ts`
   // would reach a fresh org and silently skip every org that already ran 108 —
   // `ensureCustomFields` returns an incumbent field untouched — leaving the code
-  // believing in seven values while the database holds six.
-  it('rewrites a stale vendor_bill_status option list, and says it did', async () => {
+  // and the database disagreeing about what values exist.
+  //
+  // Both directions are covered: `vendor_bill_status` GAINED `partially_paid`,
+  // `purchase_order_status` LOST `partially_received` / `received` to the two
+  // derived fields (07 §3.3). Narrowing is the one that matters more — a stored
+  // option nobody removed keeps rendering a value the type union no longer has.
+  it.each([
+    'vendor_bill_status',
+    'purchase_order_status',
+  ] as const)('rewrites a stale %s option list, and says it did', async (systemAttribute) => {
     const writes: string[] = []
-    const db = migratedOrgDb(writes, { staleVendorBillStatus: true })
+    const db = migratedOrgDb(writes, { staleStatus: systemAttribute })
 
-    const result = await migration108Purchasing.up(db, 'org-4')
+    const result = await migration108Purchasing.up(db, `org-${systemAttribute}`)
 
     expect(writes).toContain('update CustomField')
     // Not `alreadyUpToDate`: a run that only rewrote options must still report
-    // work, or it skips the org-cache flush that makes the new value visible to
+    // work, or it skips the org-cache flush that makes the change visible to
     // every read path.
     expect(result.alreadyUpToDate).toBe(false)
   })

--- a/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
@@ -6,9 +6,9 @@ import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { getOrgCache } from '../../../cache'
 import type { FieldOptions } from '../../../custom-fields'
-import { VendorBillStatus } from '../../../resources/registry/enum-values'
 import type { ResourceField } from '../../../resources/registry/field-types'
 import { COMPANY_FIELDS } from '../../../resources/registry/resources/company-fields'
+import { CONTACT_FIELDS } from '../../../resources/registry/resources/contact-fields'
 import { GL_ACCOUNT_FIELDS } from '../../../resources/registry/resources/gl-account-fields'
 import { GL_POSTING_FIELDS } from '../../../resources/registry/resources/gl-posting-fields'
 import { GL_POSTING_LINE_FIELDS } from '../../../resources/registry/resources/gl-posting-line-fields'
@@ -70,7 +70,14 @@ const NEW_REGISTRIES: Record<(typeof NEW_TYPES)[number], Record<string, Resource
  * org that has not reached the migration that seeds them has nothing to hang
  * an inverse off yet and a later run closes it.
  */
-const EXISTING_TYPES = ['stock_movement', 'company', 'part', 'vendor_part', 'gl_posting'] as const
+const EXISTING_TYPES = [
+  'stock_movement',
+  'company',
+  'contact',
+  'part',
+  'vendor_part',
+  'gl_posting',
+] as const
 
 /**
  * The ten receiving fields added to `stock_movement`
@@ -105,6 +112,11 @@ const INCUMBENT_FIELDS: Record<string, Record<string, ResourceField | undefined>
     purchaseOrders: COMPANY_FIELDS.purchaseOrders,
     vendorBills: COMPANY_FIELDS.vendorBills,
     vendorPayments: COMPANY_FIELDS.vendorPayments,
+  },
+  contact: {
+    // Inverse of `purchase_order.contact`, the order's ADDRESSEE. The buy-side
+    // twin of `contact.orders`.
+    purchaseOrders: CONTACT_FIELDS.purchaseOrders,
   },
   part: {
     purchaseOrderLines: PART_FIELDS.purchaseOrderLines,
@@ -168,9 +180,28 @@ const INCUMBENT_FIELDS: Record<string, Record<string, ResourceField | undefined>
  * the seeder materialises them from `relationshipConfig`.
  *
  * The eight new defs, with their full registries, plus the inverse halves on
- * `company` (purchaseOrders / vendorBills / vendorPayments), `part`
- * (purchaseOrderLines / vendorBillLines), `vendor_part` (stockMovements /
- * purchaseOrderLines) and `gl_posting` (lines).
+ * `company` (purchaseOrders / vendorBills / vendorPayments), `contact`
+ * (purchaseOrders), `part` (purchaseOrderLines / vendorBillLines),
+ * `vendor_part` (stockMovements / purchaseOrderLines) and `gl_posting` (lines).
+ *
+ * `purchase_order.contact` / `contact.purchaseOrders` is the ADDRESSEE pair, and
+ * it is what makes the order sendable at all: `purchase_order.vendor` targets a
+ * `company`, and a company carries no email of its own — only
+ * `company_primary_contact` — so there would be nobody to address the mail to.
+ * Shaped after `quote_contact` / `invoice_contact` so the send path's contact
+ * lookup extends by a map entry rather than a branch, but NULLABLE where the
+ * quote's is required: a PO is drafted against a supplier first and the person
+ * is settled later.
+ *
+ * `purchase_order.pdfAsset` (`purchase_order_pdf_asset`) is the third field the
+ * send flow needs and the second one it fails SILENTLY without: `ensure-pdf.ts`
+ * reads `cf[pointerAttr]` to decide whether to reuse the last render, so a
+ * missing pointer makes `existingAssetId` permanently `undefined` and every
+ * send re-renders AND mints a fresh `MediaAsset`. Nothing throws, the PDF is
+ * correct, and the only symptom is unbounded storage growth. Copied verbatim
+ * from `quote_pdf_asset` / `invoice_pdf_asset` — a bare MediaAsset id in TEXT,
+ * hidden, `updatable` but not `creatable`, because all three are read through
+ * the same code path and only `ensureDocumentPdf` writes them.
  *
  * Plus one field that is not an inverse: `part.unit`, the stock unit of measure
  * (SINGLE_SELECT, nullable, no backfill). Every quantity in the inventory chain
@@ -179,6 +210,33 @@ const INCUMBENT_FIELDS: Record<string, Record<string, ResourceField | undefined>
  * quantity. It is deliberately NOT on the line: a line ordered in `box` and
  * received in `ea` would make the received-vs-ordered roll-up compare two
  * different units, which is the number the three-way match rests on.
+ *
+ * ## The purchase-order status SPLIT (07 §3.3)
+ *
+ * `purchase_order` carries THREE status fields, not one, and this migration
+ * materialises all three:
+ *
+ *   purchase_order_status           SELECT  draft | issued | closed | canceled
+ *   purchase_order_receipt_status   SELECT  not_received | partially_received | received
+ *   purchase_order_billing_status   SELECT  not_billed | partially_billed | billed
+ *
+ * Receiving and billing are INDEPENDENT axes. This business prepays, so *fully
+ * billed, fully paid, nothing received* is a normal state lasting weeks, and one
+ * enum cannot say it — whichever axis the single field picks, the other becomes
+ * invisible. `vendor_bill_status` is what conflating them looks like once it has
+ * shipped: `posted`/`paid` overwrite the `matched`/`exception` verdict and
+ * `MATCHABLE_STATUSES` then refuses to recompute it, so a paid bill can never
+ * say whether it matched. `OrderFinancialStatus` / `OrderFulfillmentStatus` are
+ * the same split done right on the sell side.
+ *
+ * `purchase_order_status` therefore declares FOUR values here, not the six it
+ * originally shipped with: `partially_received` and `received` moved to
+ * `purchase_order_receipt_status`. They were the two values with no writer at
+ * all, so the move costs nothing and makes `purchasing-hooks.ts`'s "a plain
+ * human-set field" true rather than aspirational. Both new fields are
+ * `creatable: false` / `updatable: false` / `computed: true` — the line
+ * `quantityReceived` / `quantityBilled` roll-up owns them, and this migration
+ * only creates the columns to write into.
  *
  * `purchase_order` is `hasDetailPage: true` and `isVisible: true` — the `quote`
  * shape, because a PO is built, issued and received against. `vendor_bill` is
@@ -384,25 +442,43 @@ export const migration108Purchasing: EntityMigration = {
       )
     }
 
-    // ── Re-materialize `vendor_bill_status`'s options ──────────────────
+    // ── Re-materialize the two status option sets ──────────────────────
     //
     // 🛑 `ensureCustomFields` SKIPS a field that already exists — it returns the
-    // incumbent row and never touches its `options`. So adding a value to
-    // `VendorBillStatus` reaches a fresh org (which seeds from the registry) and
+    // incumbent row and never touches its `options`. So changing an enum in
+    // `enum-values.ts` reaches a fresh org (which seeds from the registry) and
     // silently does nothing for every org that already ran this migration. The
-    // field would keep the six values it was created with while the code, the
-    // types and the UI all believed in seven.
+    // field keeps the values it was created with while the code, the types and
+    // the UI all believe in the new list.
     //
-    // `partially_paid` is what forced this. The whole array is rewritten rather
-    // than the new value appended, so the option ORDER matches the registry
-    // everywhere — an appended value would sit last on migrated orgs and
-    // mid-list on fresh ones, which is the kind of difference nobody notices
-    // until two screenshots disagree. Safe because `status` is
+    // Both directions of that have now bitten:
+    //
+    //   `vendor_bill_status`   gained `partially_paid`
+    //   `purchase_order_status` LOST `partially_received` and `received`, which
+    //                           moved to their own derived fields
+    //                           (plans/purchasing/07-purchase-order-send-and-status.md §3.3)
+    //
+    // The whole array is rewritten rather than diffed, so the option ORDER
+    // matches the registry everywhere — an appended value would sit last on
+    // migrated orgs and mid-list on fresh ones, the kind of difference nobody
+    // notices until two screenshots disagree. Safe because both fields are
     // `configurable: false`: there are no user-added options to preserve.
-    const statusRefreshed = await refreshVendorBillStatusOptions(
-      db,
-      entityDefIds.get('vendor_bill')
-    )
+    //
+    // ⚠️ Narrowing an option set orphans any `FieldValue.optionId` holding a
+    // removed key. Deliberately NOT remapped here: 108 is the only migration
+    // that has ever created `purchase_order_status`, it has run on local dev
+    // orgs only, and the two values it drops never had a writer — so the orphan
+    // set is a hand-set dev row or two, and `098-prune-orphaned-option-values`
+    // is the pass that exists for orphans. A remap here would be permanent
+    // machinery earning its keep exactly once.
+    let statusRefreshed = false
+    for (const [entityType, field] of [
+      ['vendor_bill', VENDOR_BILL_FIELDS.status],
+      ['purchase_order', PURCHASE_ORDER_FIELDS.status],
+    ] as const) {
+      const refreshed = await refreshStatusOptions(db, entityDefIds.get(entityType), field)
+      statusRefreshed ||= refreshed
+    }
 
     const alreadyUpToDate =
       state.entityDefsCreated === 0 &&
@@ -429,8 +505,8 @@ export const migration108Purchasing: EntityMigration = {
 }
 
 /**
- * Bring an existing `vendor_bill_status` field's SINGLE_SELECT options back in
- * line with {@link VendorBillStatus}.
+ * Bring one existing SINGLE_SELECT status field's options back in line with the
+ * registry declaration it was seeded from.
  *
  * Reads the row rather than trusting `loadExistingState`'s snapshot or the
  * `allFieldMaps` entry: the snapshot is taken before this migration writes
@@ -440,18 +516,24 @@ export const migration108Purchasing: EntityMigration = {
  *
  * Idempotent by comparison — returns `false` when the stored values already
  * match, so a second run reports `alreadyUpToDate` rather than dirtying the row
- * and re-invalidating the org cache on every pass.
+ * and re-invalidating the org cache on every pass. The comparison is on the
+ * `value` keys in order, which is what `FieldValue.optionId` stores; a relabel
+ * or recolour alone does not trigger a rewrite.
  *
+ * @param defId the owning `EntityDefinition`, or undefined when the org has none
+ * @param field the registry field whose `options.options` is the target state
  * @returns whether the row was actually rewritten.
  */
-async function refreshVendorBillStatusOptions(
+async function refreshStatusOptions(
   db: Database,
-  vendorBillDefId: string | undefined
+  defId: string | undefined,
+  field: ResourceField | undefined
 ): Promise<boolean> {
-  if (!vendorBillDefId) return false
+  if (!defId) return false
+  if (!field?.systemAttribute) return false
 
-  const statusField = VENDOR_BILL_FIELDS.status
-  if (!statusField?.systemAttribute) return false
+  const wanted = field.options?.options
+  if (!wanted?.length) return false
 
   // Scoped in SQL to the def, then picked by attribute in JS. One query either
   // way — a `vendor_bill` carries ~28 fields — and it keeps the pick explicit
@@ -463,12 +545,11 @@ async function refreshVendorBillStatusOptions(
       options: schema.CustomField.options,
     })
     .from(schema.CustomField)
-    .where(eq(schema.CustomField.entityDefinitionId, vendorBillDefId))
+    .where(eq(schema.CustomField.entityDefinitionId, defId))
 
-  const row = rows.find((candidate) => candidate.systemAttribute === statusField.systemAttribute)
+  const row = rows.find((candidate) => candidate.systemAttribute === field.systemAttribute)
   if (!row) return false
 
-  const wanted = VendorBillStatus.values
   const current = ((row.options as FieldOptions | null)?.options ?? []) as {
     value?: string
     label?: string
@@ -488,8 +569,9 @@ async function refreshVendorBillStatusOptions(
     })
     .where(eq(schema.CustomField.id, row.id))
 
-  logger.info('Refreshed vendor_bill_status options', {
-    vendorBillDefId,
+  logger.info('Refreshed status options', {
+    defId,
+    systemAttribute: field.systemAttribute,
     from: current.length,
     to: wanted.length,
   })

--- a/packages/lib/src/seed/organization-seeder.ts
+++ b/packages/lib/src/seed/organization-seeder.ts
@@ -313,13 +313,16 @@ export class OrganizationSeeder {
     logger.info(`Email templates seeded for organization: ${organizationId}`)
   }
   /**
-   * Seed the system snippets (`quote_email` — money MQ2; `invoice_email` — MI1) for a
-   * new organization, keyed to its just-seeded `EntityDefinition` cuids. Runs after
-   * `seedEntities` so the quote/invoice/contact defs already exist —
-   * `buildSystemSnippetTemplates` returns both templates once `entityDefs.quote`/
-   * `entityDefs.invoice` + `entityDefs.contact` are all present, and simply omits
-   * whichever def is still missing (e.g. an org seeded before MI1 shipped, until its
-   * entity migration runs). NOT the only path that creates these rows —
+   * Seed the system snippets — one per sendable document type (`quote_email`,
+   * `invoice_email`, `purchase_order_email`) — for a new organization, keyed to its
+   * just-seeded `EntityDefinition` cuids. Runs after `seedEntities` so the document and
+   * contact defs already exist.
+   *
+   * `buildSystemSnippetTemplates` returns a template once that document's def AND
+   * `entityDefs.contact` are present, and simply omits one whose def is still missing
+   * (e.g. an org seeded before that document type shipped, until its entity migration
+   * runs). Deliberately no list of types here: the builder is the registry, and a list in
+   * this comment is one more thing to forget. NOT the only path that creates these rows —
    * `getSystemSnippet` lazily materializes them for pre-existing orgs on first read.
    */
   private async seedSystemSnippets(organizationId: string): Promise<void> {

--- a/packages/lib/src/signals/record-signal.ts
+++ b/packages/lib/src/signals/record-signal.ts
@@ -15,8 +15,25 @@ import type { SignalKind } from './types'
 
 const logger = createScopedLogger('signals-record')
 
-/** `EntitySignalLink.recordKey` root — string keys because visits aren't `EntityInstance`s. */
-export type SignalRecordKind = 'contact' | 'work_order' | 'visit' | 'invoice' | 'quote'
+/**
+ * `EntitySignalLink.recordKey` root — string keys because visits aren't `EntityInstance`s.
+ *
+ * ⚠️ Every `DocumentType` must be a member: `recordDocumentSendSignal` passes its
+ * `documentType` straight into {@link toSignalRecordKey}, so a document type missing here is
+ * a compile error at that call site (purchasing plan 07 §2.2 relies on that coupling).
+ * `'purchase_order'` was added for the PO send path.
+ *
+ * Readers key off the composed string, not this union — `listSignalsForRecordKeys` takes
+ * caller-built `recordKey`s and the rollup writer only ever looks at the `contact:` root — so
+ * adding a member widens what can be LINKED without obliging any consumer to handle it.
+ */
+export type SignalRecordKind =
+  | 'contact'
+  | 'work_order'
+  | 'visit'
+  | 'invoice'
+  | 'quote'
+  | 'purchase_order'
 
 /**
  * Compose an `EntitySignalLink.recordKey` — the one place every writer/reader builds this

--- a/packages/lib/src/snippets/__tests__/system-snippets-purchase-order.test.ts
+++ b/packages/lib/src/snippets/__tests__/system-snippets-purchase-order.test.ts
@@ -1,0 +1,80 @@
+// packages/lib/src/snippets/__tests__/system-snippets-purchase-order.test.ts
+//
+// `purchase_order_email` is the third seeded system snippet (purchasing plan 07). It follows
+// `quote_email`/`invoice_email` exactly — same placeholder vocabulary, same span shape, same
+// def guard — but reads as a message to a SUPPLIER rather than a sales document.
+
+import { describe, expect, it } from 'vitest'
+import { buildSystemSnippetTemplates } from '../system-snippets'
+
+const ENTITY_DEFS: Record<string, string> = {
+  quote: 'def_quote',
+  invoice: 'def_invoice',
+  purchase_order: 'def_po',
+  contact: 'def_contact',
+}
+
+function purchaseOrderTemplate(entityDefs: Record<string, string> = ENTITY_DEFS) {
+  return buildSystemSnippetTemplates(entityDefs).find(
+    (t) => t.systemType === 'purchase_order_email'
+  )
+}
+
+describe('purchase_order_email system snippet', () => {
+  it('is built alongside quote_email and invoice_email', () => {
+    const systemTypes = buildSystemSnippetTemplates(ENTITY_DEFS).map((t) => t.systemType)
+    expect(systemTypes).toEqual(['quote_email', 'invoice_email', 'purchase_order_email'])
+  })
+
+  it('is omitted when the purchase_order def does not exist yet', () => {
+    const { purchase_order: _omitted, ...withoutPo } = ENTITY_DEFS
+    expect(purchaseOrderTemplate(withoutPo)).toBeUndefined()
+    // ...and the other two are unaffected.
+    expect(buildSystemSnippetTemplates(withoutPo).map((t) => t.systemType)).toEqual([
+      'quote_email',
+      'invoice_email',
+    ])
+  })
+
+  it('is omitted when the contact def does not exist — the greeting has no root', () => {
+    const { contact: _omitted, ...withoutContact } = ENTITY_DEFS
+    expect(purchaseOrderTemplate(withoutContact)).toBeUndefined()
+  })
+
+  // 🛑 A placeholder that cannot resolve throws in `resolvePlaceholdersInHtml`, so every token
+  // must name a real `key` on `purchase-order-fields.ts` / the contact def.
+  it('only uses field keys that exist on purchase_order and contact', () => {
+    const template = purchaseOrderTemplate()
+    const tokens = [...(template?.contentHtml ?? '').matchAll(/data-id="([^"]+)"/g)].map(
+      (m) => m[1] as string
+    )
+    expect(tokens).toEqual([
+      'def_contact:firstName',
+      'def_po:number',
+      'def_po:total',
+      'def_po:expectedAt',
+    ])
+  })
+
+  it('carries fallbacks for the two tokens that are commonly empty', () => {
+    const html = purchaseOrderTemplate()?.contentHtml ?? ''
+    // firstName and expectedAt (nullable, nothing prefills it) fall back; number/total do not.
+    expect(html.match(/data-fallback=/g)).toHaveLength(2)
+  })
+
+  it('reads as an instruction to a supplier, not a sales document', () => {
+    const template = purchaseOrderTemplate()
+    expect(template?.title).toBe('Purchase order attached')
+    expect(template?.content).toContain('Please find our purchase order')
+    expect(template?.content).toContain('confirm receipt of this order and your expected ship date')
+  })
+
+  it('mirrors the quote/invoice mechanics — no hard-coded sign-off, plain-text twin', () => {
+    const template = purchaseOrderTemplate()
+    expect(template?.contentHtml).not.toMatch(/Best,|Regards|Thanks,/)
+    // The plain-text mirror carries the same `{{id}}` tokens as the HTML spans.
+    for (const token of ['def_contact:firstName', 'def_po:number', 'def_po:total']) {
+      expect(template?.content).toContain(`{{${token}}}`)
+    }
+  })
+})

--- a/packages/lib/src/snippets/system-snippets.ts
+++ b/packages/lib/src/snippets/system-snippets.ts
@@ -119,6 +119,56 @@ Let us know if you have any questions.`
   }
 }
 
+function buildPurchaseOrderEmailTemplate(
+  entityDefs: Record<string, string>
+): SystemSnippetTemplate | null {
+  const purchaseOrderDefId = entityDefs.purchase_order
+  const contactDefId = entityDefs.contact
+  if (!purchaseOrderDefId || !contactDefId) return null
+
+  // Token vocabulary deliberately matches the quote/invoice templates above: the contact's
+  // first name plus the document's own `number`, `total` and one date field. Every one of
+  // these is a real `key` on `purchase-order-fields.ts` (`number`/`total`/`expectedAt`), so
+  // the resolver finds a FieldReference for each — an unresolvable token throws rather than
+  // degrading, so nothing speculative belongs here.
+  //
+  // ⚠️ The addressee is the purchase order's CONTACT (`purchase_order_contact`), not its
+  // vendor: `purchase_order_vendor` points at a `company`, and a company carries no email
+  // field. So the greeting reads off the contact def exactly as the other two templates do.
+  const firstName = fieldToken(contactDefId, 'firstName')
+  const number = fieldToken(purchaseOrderDefId, 'number')
+  const total = fieldToken(purchaseOrderDefId, 'total')
+  const expectedAt = fieldToken(purchaseOrderDefId, 'expectedAt')
+
+  const firstNameSpan = placeholderSpan(firstName, { v: 1, t: 'TEXT', d: 'there' })
+  const numberSpan = placeholderSpan(number)
+  const totalSpan = placeholderSpan(total)
+  // `purchase_order_expected_at` is nullable and nothing prefills it today (purchasing plan
+  // 07 §6.2 gives Send an overwritable default), so the fallback is the common path.
+  const expectedAtSpan = placeholderSpan(expectedAt, {
+    v: 1,
+    t: 'TEXT',
+    d: 'at your earliest convenience',
+  })
+
+  // No hard-coded sign-off — the composer appends the sender's email signature on send
+  // (mirrors the quote_email/invoice_email templates above).
+  const contentHtml = `<p>Hi ${firstNameSpan},</p><p>Please find our purchase order ${numberSpan} attached. Total ${totalSpan}, requested delivery ${expectedAtSpan}.</p><p>Please confirm receipt of this order and your expected ship date.</p>`
+
+  const content = `Hi {{${firstName}}},
+
+Please find our purchase order {{${number}}} attached. Total {{${total}}}, requested delivery {{${expectedAt}}}.
+
+Please confirm receipt of this order and your expected ship date.`
+
+  return {
+    systemType: 'purchase_order_email',
+    title: 'Purchase order attached',
+    content,
+    contentHtml,
+  }
+}
+
 /**
  * Build the system-snippet template rows for an org, given its `entityDefs`
  * cache map (entityType → per-org `EntityDefinition.id`). Placeholder tokens
@@ -127,9 +177,12 @@ Let us know if you have any questions.`
  *
  * `invoice_email` (money MI1) mirrors `quote_email`'s shape/mechanics —
  * greeting, number/total tokens, plus a due-date token in place of
- * valid-until. Both templates guard on their def id being present in
- * `entityDefs` (`entityDefs.quote`/`entityDefs.invoice` + `entityDefs.contact`),
- * so an org mid-migration simply gets fewer templates rather than a broken
+ * valid-until. `purchase_order_email` (purchasing plan 07) is the same shape
+ * again with an expected-delivery token, addressed to a supplier rather than
+ * a customer. Every template guards on its def id being present in
+ * `entityDefs` (`entityDefs.quote`/`entityDefs.invoice`/
+ * `entityDefs.purchase_order` + `entityDefs.contact`), so an org
+ * mid-migration simply gets fewer templates rather than a broken
  * one — `getSystemSnippet` surfaces a clear `NotFoundError` if a template is
  * requested before its def exists.
  */
@@ -144,12 +197,15 @@ export function buildSystemSnippetTemplates(
   const invoiceEmail = buildInvoiceEmailTemplate(entityDefs)
   if (invoiceEmail) templates.push(invoiceEmail)
 
+  const purchaseOrderEmail = buildPurchaseOrderEmailTemplate(entityDefs)
+  if (purchaseOrderEmail) templates.push(purchaseOrderEmail)
+
   return templates
 }
 
 /**
  * Get-or-create the org's system snippet for `systemType` (`quote_email` /
- * `invoice_email`). Lazily materializes on first call — covers both freshly
+ * `invoice_email` / `purchase_order_email`). Lazily materializes on first call — covers both freshly
  * seeded orgs (the seeder pre-creates the row) and existing orgs (no data
  * migration needed, per the README decision). Idempotent under concurrent
  * calls via `onConflictDoNothing` against the partial unique

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -197,6 +197,7 @@ export const SYSTEM_ATTRIBUTES = [
   'contact_quotes',
   'contact_invoices', // inverse of invoice_contact
   'contact_orders', // inverse of order_contact
+  'contact_purchase_orders', // inverse of purchase_order_contact — the BUY side
   'contact_balance_due',
   'contact_uninvoiced_amount',
   'contact_billing_revision',
@@ -474,7 +475,17 @@ export const SYSTEM_ATTRIBUTES = [
   // `goods_receipt` header is needed.
   'purchase_order_number',
   'purchase_order_vendor',
+  // The ADDRESSEE. `purchase_order_vendor` targets a `company`, and a company
+  // carries no email of its own, so without this there is nobody to send the
+  // order to. Mirrors `quote_contact` / `invoice_contact`.
+  'purchase_order_contact',
   'purchase_order_status',
+  // The two DERIVED axes the single `purchase_order_status` could not express
+  // (plans/purchasing/07-purchase-order-send-and-status.md §3.3): receiving and
+  // billing move independently — a prepaid order is fully billed with nothing
+  // received — so each gets its own field, written by the line roll-up.
+  'purchase_order_receipt_status',
+  'purchase_order_billing_status',
   'purchase_order_ordered_at',
   'purchase_order_expected_at',
   'purchase_order_terms',
@@ -489,6 +500,7 @@ export const SYSTEM_ATTRIBUTES = [
   'purchase_order_allocation_basis',
   'purchase_order_tax_recoverable',
   'purchase_order_notes',
+  'purchase_order_pdf_asset', // MediaAsset id, TEXT — the quote/invoice_pdf_asset precedent
   'purchase_order_lines', // inverse of purchase_order_line_purchase_order
   'purchase_order_bills', // inverse of vendor_bill_purchase_order
   'company_purchase_orders', // inverse of purchase_order_vendor


### PR DESCRIPTION
Implements [`plans/purchasing/07-purchase-order-send-and-status.md`](https://github.com/Auxx-Ai/auxx-ai/blob/main/plans/purchasing) steps 1-6. Entity fields are folded into the existing **108-purchasing** migration rather than a new one, since none of the purchasing migrations has reached production — re-run 108 locally to pick them up.

## Why the status field splits

Receiving and billing are independent axes. This business prepays — vendors often will not ship until the invoice is paid — so **"fully billed, fully paid, nothing received" is a normal state lasting weeks**, and one enum cannot express it: you pick one axis and the other becomes invisible.

The vendor bill already shows the cost of conflating them. `MATCHABLE_STATUSES` means a paid bill can never be re-matched, so **you cannot tell whether a paid bill matched or was an exception** — and `partially_paid` had to be invented because a payment fact was overwriting a match fact.

```
purchase_order_status          draft | issued | closed | canceled       ACTION, guarded
purchase_order_receipt_status  not_received | partially_… | received    DERIVED
purchase_order_billing_status  not_billed   | partially_… | billed      DERIVED
```

`partially_received` and `received` leave the action enum — the two values that never had a writer, which is what made `purchasing-hooks.ts`'s "plain human-set field" claim aspirational rather than true.

**The split pays for itself immediately.** A receipt landing against a `draft` order moves *both* the action axis (to `issued`) and the receipt axis. Under one enum that would have forced a precedence rule discarding one of the two facts.

## Sending reuses the quote/invoice machinery

`documents/registry.ts` was built for exactly this, so a purchase order is one `RENDER_ENTRIES` row plus one descriptor, and `useDocumentSendActions` gains a third consumer with no changes. `DocumentType` is now **derived** from the descriptors, and `DOCUMENT_EMAIL_PROFILES` is keyed by it — so a fourth document type touches no unions, and one without a send profile is a compile error rather than a silent wrong branch.

No `quote-public-token.ts`: a vendor does not approve or decline inside this system.

## Three silent defects found on the way

**Sending a PO would have emailed a vendor a customer approval link.** `documentTypeOf` classified everything that was not an invoice as a quote, so the first PO sent would have been minted a `quote_public_token`. Nothing throws — the email sends and the PDF attaches. It now resolves through the registry and **throws** on an unregistered def; a default that cannot fail cannot report that it guessed.

**The manual-status guard does not fire — twice over.** `rejectManualLifecycleStatus` lives on the system-hook chain, which the interactive write path never runs (every drawer edit, kanban drag and inline edit goes through `fieldValue.set`). And that chain hands guards a *coerced* value, so a SINGLE_SELECT arrives as `{ type: 'option', optionId }` — a guard comparing it to a bare string can never be true. `purchase_order_status` gets a field pre-hook using a shared `unwrapStatusValue`, with the system twin kept for the create/importer/SDK paths.

⚠️ **The same holes exist in quote and invoice and are NOT fixed here** — an invoice can currently be hand-set to `paid` with no payment recorded. Written up separately in `plans/dispatch/money/21-lifecycle-status-guards-are-inert.md`.

**A purchase order had no addressee and no PDF pointer.** `purchase_order_vendor` is a *company*, and a company carries no email — hence a new `purchase_order_contact` mirroring `quote_contact`. And with no `pdf_asset` pointer, `ensure-pdf.ts` never finds a previous render, so **every send re-renders and mints a fresh `MediaAsset`** — an asset leak that grows per send with no error attached.

## Lines lock on evidence, not on status

A line's `quantity_ordered` and `expected_unit_price` freeze once a `stock_movement` or `vendor_bill_line` exists against it. Status is the wrong predicate in both directions: a `draft` order can now carry receipts and *is* unsafe to edit, while an `issued` order nobody shipped against is fine.

Editing a price after a bill exists silently re-points the three-way match at a number the vendor never agreed to — the same class as the $200-against-$12.50 receipt fixed in #1938.

## Query cost

| | before | after |
| --- | --- | --- |
| 1-line receipt | 7 reads | 5 |
| 10-line receipt | ~61 reads | ~25 |
| order-level passes per 10-line receipt | 10 | 1 |

The event chain crosses a **BullMQ boundary into the worker**, so no context flag or deferral set can suppress the per-movement passes — they run in a different process. Instead the batch settles every line up front, and each later pass re-SUMs, finds its value already equal, and returns before writing. That fails safe by construction: if the batch never runs or throws, every pass pays full price and produces today's answer.

The read-before-write costs **zero** extra reads — it is an uncorrelated scalar subquery in the SELECT list of the SUM already being issued.

## Verification

- **13,359 lib tests** pass (full suite), 135 web tests
- both typecheck ratchets **exit 0**
- the folded status query was run against the dev DB side by side with the three it replaces — byte-identical answers

## Not in this PR

- **No Send button yet.** The lifecycle, PDF, snippet and router procedure are all in; the actions cluster on the PO page is the remaining step.
- One behaviour change worth knowing: an unchanged `quantity_received` now skips the order-level pass, so a `receipt_status` left stale by an earlier *failed* pass is no longer repaired by a repeat firing.
- Two further ~2x query wins need a registration change in `system-entity-rules.ts` (a batch variant of `RECALC_PO_LINE_RECEIVED`, and deduping QoH by part).
