### PR TITLE
fix(money): the lifecycle status guards actually fire

### DIFF
--- a/packages/lib/src/field-hooks/__tests__/lifecycle-status-guard-registration.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/lifecycle-status-guard-registration.test.ts
@@ -1,0 +1,119 @@
+// packages/lib/src/field-hooks/__tests__/lifecycle-status-guard-registration.test.ts
+//
+// 🛑 `quote_status` and `invoice_status` are guarded on BOTH hook chains and they cover
+// different doors. The system hook (`resources/hooks/quote-hooks.ts` /
+// `invoice-hooks.ts`) runs for `record.create` / `record.update`, the CSV importer and the
+// SDK. The field pre-hook runs for `fieldValue.set` / `setBulk` — the drawer, the grid's
+// inline edit and a kanban drag, which is how a human would actually type `paid`.
+//
+// For most of these fields' life only the system half existed, so the guards were on a door
+// nobody uses and an invoice could be hand-set to `paid` with no payment behind it
+// (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §1). Losing either
+// registration narrows coverage silently: nothing throws, the guard simply stops seeing that
+// door — which is precisely how the gap survived unnoticed.
+//
+// Separate from `pre/lifecycle-status-guard.test.ts` because `getFieldPreHooks` self-inits
+// the whole hook bootstrap, which needs the real `@auxx/database` module graph.
+
+import { describe, expect, it } from 'vitest'
+import {
+  guardManualInvoiceLifecycleStatus,
+  guardManualQuoteLifecycleStatus,
+} from '../pre/lifecycle-status-guard'
+import { guardQuoteDraftReturnWithPaidDeposit } from '../pre/quote-deposit-guard'
+import { getFieldPreHooks, hasFieldPreHooks } from '../registry'
+
+describe('quote_status guard registration', () => {
+  it('is on the field pre-hook chain for quotes', () => {
+    expect(hasFieldPreHooks('quotes', 'quote_status')).toBe(true)
+    expect(getFieldPreHooks('quotes', 'quote_status')).toContain(guardManualQuoteLifecycleStatus)
+  })
+
+  // The deposit wall was here alone and inert. It stays — it walls the opposite transition
+  // (`-> draft`), which the action wall does not touch.
+  it('keeps the deposit wall alongside it', () => {
+    expect(getFieldPreHooks('quotes', 'quote_status')).toContain(
+      guardQuoteDraftReturnWithPaidDeposit
+    )
+  })
+
+  // ORDER IS COST, not semantics: the two are disjoint by value, so this only keeps the
+  // deposit wall's query off writes that could never trip it.
+  it('runs the in-memory wall before the one that costs a query', () => {
+    const hooks = getFieldPreHooks('quotes', 'quote_status')
+    expect(hooks.indexOf(guardManualQuoteLifecycleStatus)).toBeLessThan(
+      hooks.indexOf(guardQuoteDraftReturnWithPaidDeposit)
+    )
+  })
+
+  it('is also on the system-hook chain, reachable by entityType', async () => {
+    const { getHooksForAttribute } = await import('../../resources/hooks/system-hooks')
+    expect(getHooksForAttribute('quote', 'quote_status')).toHaveLength(1)
+  })
+})
+
+describe('invoice_status guard registration', () => {
+  // 🛑 This chain had NO registration at all — not an inert guard, none. It is the one that
+  // made `paid` typeable from the drawer.
+  it('is on the field pre-hook chain for invoices', () => {
+    expect(hasFieldPreHooks('invoices', 'invoice_status')).toBe(true)
+    expect(getFieldPreHooks('invoices', 'invoice_status')).toContain(
+      guardManualInvoiceLifecycleStatus
+    )
+  })
+
+  it('is also on the system-hook chain, reachable by entityType', async () => {
+    const { getHooksForAttribute } = await import('../../resources/hooks/system-hooks')
+    expect(getHooksForAttribute('invoice', 'invoice_status')).toHaveLength(1)
+  })
+})
+
+describe('one source for what is guarded', () => {
+  // The two chains hand guards different shapes, so they cannot share an implementation —
+  // only the value set and the message. If those drift, a status is walled on the importer
+  // and typeable in the drawer (or the reverse) and nothing says so.
+  it.each([
+    {
+      document: 'quote',
+      attr: 'quote_status',
+      fieldGuard: guardManualQuoteLifecycleStatus,
+      values: ['sent', 'approved'],
+      hooks: () => import('../../resources/hooks/quote-hooks').then((m) => m.QUOTE_HOOKS),
+      constants: 'QUOTE_ACTION_STATUSES',
+      messageKey: 'QUOTE_ACTION_STATUS_MESSAGE',
+    },
+    {
+      document: 'invoice',
+      attr: 'invoice_status',
+      fieldGuard: guardManualInvoiceLifecycleStatus,
+      values: ['sent', 'partially_paid', 'paid', 'void'],
+      hooks: () => import('../../resources/hooks/invoice-hooks').then((m) => m.INVOICE_HOOKS),
+      constants: 'INVOICE_ACTION_STATUSES',
+      messageKey: 'INVOICE_ACTION_STATUS_MESSAGE',
+    },
+  ])('$document guards the same value set and message on both chains', async (spec) => {
+    const lifecycle = (await import('../../resources/hooks/lifecycle-status-guard')) as Record<
+      string,
+      unknown
+    >
+    expect([...(lifecycle[spec.constants] as readonly string[])]).toEqual(spec.values)
+    const message = lifecycle[spec.messageKey] as string
+
+    const registry = await spec.hooks()
+    const systemHook = registry[spec.attr]![0]!
+    await expect(
+      systemHook({
+        operation: 'update',
+        field: { id: 'f-status', systemAttribute: spec.attr },
+        values: { 'f-status': spec.values[0] },
+        // biome-ignore lint/suspicious/noExplicitAny: partial SystemHookContext for the guard
+      } as any)
+    ).rejects.toThrow(message)
+
+    // The SAME value, in the shape the field chain actually delivers.
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: partial FieldPreHookEvent for the guard
+      spec.fieldGuard({ newValue: { type: 'option', optionId: spec.values[0] } } as any)
+    ).rejects.toThrow(message)
+  })
+})

--- a/packages/lib/src/field-hooks/__tests__/registry.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/registry.test.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/field-hooks/__tests__/registry.test.ts
 
 import type { FieldType } from '@auxx/database/types'
+import type { TypedFieldValueInput } from '@auxx/types'
 import type { RecordId } from '@auxx/types/resource'
 import { describe, expect, it, vi } from 'vitest'
 import type { CachedField } from '../../field-values/types'
@@ -20,6 +21,14 @@ import type { EntityFieldChangeEvent, FieldPreHookEvent } from '../types'
 
 const TEST_RECORD: RecordId = 'fhk-test-record:abc' as RecordId
 
+/**
+ * A pre-hook's `newValue` is post-coercion, so the sentinels these tests pass down the chain
+ * have to be real typed envelopes rather than bare strings — the type says so, and the reason
+ * it says so is that three shipped guards compared this value to a string literal and were
+ * inert (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §5b).
+ */
+const typed = (value: string): TypedFieldValueInput => ({ type: 'text', value })
+
 function buildEvent(overrides: Partial<FieldPreHookEvent> = {}): FieldPreHookEvent {
   return {
     recordId: TEST_RECORD,
@@ -29,9 +38,9 @@ function buildEvent(overrides: Partial<FieldPreHookEvent> = {}): FieldPreHookEve
     fieldId: 'fld_1',
     systemAttribute: 'title',
     field: { id: 'fld_1', systemAttribute: 'title' } as unknown as CachedField,
-    newValue: 'before',
+    newValue: typed('before'),
     existingValue: undefined,
-    allValues: new Map<string, unknown>([['fld_1', 'before']]),
+    allValues: new Map<string, unknown>([['fld_1', typed('before')]]),
     organizationId: 'org_1',
     userId: 'user_1',
     bypass: new Set(),
@@ -48,8 +57,8 @@ describe('field-hooks registry — pre-hooks', () => {
   it('keys hooks by (entitySlug, systemAttribute) — different slugs do not collide', () => {
     const slugA = 'fhk-slug-a'
     const slugB = 'fhk-slug-b'
-    const handlerA = vi.fn(async () => 'A')
-    const handlerB = vi.fn(async () => 'B')
+    const handlerA = vi.fn(async () => typed('A'))
+    const handlerB = vi.fn(async () => typed('B'))
     registerFieldPreHooks(slugA, 'tag_parent', [handlerA])
     registerFieldPreHooks(slugB, 'tag_parent', [handlerB])
 
@@ -62,11 +71,11 @@ describe('field-hooks registry — pre-hooks', () => {
     const calls: string[] = []
     const scoped = async () => {
       calls.push('scoped')
-      return 'mid'
+      return typed('mid')
     }
     const global = async () => {
       calls.push('global')
-      return 'last'
+      return typed('last')
     }
     registerFieldPreHooks(slug, 'tag_parent', [scoped])
     registerFieldPreHooks('*', 'tag_parent', [global])
@@ -74,18 +83,18 @@ describe('field-hooks registry — pre-hooks', () => {
     const chain = getFieldPreHooks(slug, 'tag_parent')
     expect(chain).toEqual([scoped, global])
 
-    let value: unknown = 'first'
+    let value: TypedFieldValueInput | TypedFieldValueInput[] | null = typed('first')
     for (const fn of chain) {
-      value = await fn(buildEvent({ newValue: value }))
+      value = (await fn(buildEvent({ newValue: value }))) ?? null
     }
     expect(calls).toEqual(['scoped', 'global'])
-    expect(value).toBe('last')
+    expect(value).toEqual(typed('last'))
   })
 
   it('registers multiple hooks under one (slug, attribute) and preserves order', () => {
     const slug = 'fhk-multi-slug'
-    const a = vi.fn(async () => 'A')
-    const b = vi.fn(async () => 'B')
+    const a = vi.fn(async () => typed('A'))
+    const b = vi.fn(async () => typed('B'))
     registerFieldPreHooks(slug, 'title', [a])
     registerFieldPreHooks(slug, 'title', [b])
 
@@ -96,10 +105,10 @@ describe('field-hooks registry — pre-hooks', () => {
     const slug = 'fhk-has-slug'
     expect(hasFieldPreHooks(slug, 'title')).toBe(false)
 
-    registerFieldPreHooks(slug, 'title', [async () => 'x'])
+    registerFieldPreHooks(slug, 'title', [async () => typed('x')])
     expect(hasFieldPreHooks(slug, 'title')).toBe(true)
 
-    registerFieldPreHooks('*', 'tag_parent', [async () => 'y'])
+    registerFieldPreHooks('*', 'tag_parent', [async () => typed('y')])
     expect(hasFieldPreHooks('any-other-slug', 'tag_parent')).toBe(true)
   })
 })

--- a/packages/lib/src/field-hooks/pre/lifecycle-status-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/lifecycle-status-guard.test.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/field-hooks/pre/lifecycle-status-guard.test.ts
+//
+// 🛑 The bug this file exists to prevent is a guard that cannot fire. By the time
+// `fireFieldPreHooks` runs, `validateAndConvertValue` has turned a SINGLE_SELECT write into
+// `{ type: 'option', optionId: 'paid' }` — never a bare string — so a guard comparing
+// `event.newValue` to `'paid'` passes everything and is indistinguishable from a guard
+// nothing has tripped. That is exactly what `guardQuoteDraftReturnWithPaidDeposit` did from
+// the day it shipped (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §2), and
+// it passed review and its own unit test because both fed it a bare string.
+//
+// So: every rejection test below feeds the COERCED shape the client path actually produces.
+// A version of these guards that only understood bare strings would pass the `it('rejects a
+// bare string')` cases and fail every `coerced(...)` one, which is the whole point.
+
+import { describe, expect, it } from 'vitest'
+import { BadRequestError } from '../../errors'
+import {
+  INVOICE_ACTION_STATUS_MESSAGE,
+  QUOTE_ACTION_STATUS_MESSAGE,
+} from '../../resources/hooks/lifecycle-status-guard'
+import type { FieldPreHookEvent, FieldPreHookHandler } from '../types'
+import {
+  guardManualInvoiceLifecycleStatus,
+  guardManualQuoteLifecycleStatus,
+} from './lifecycle-status-guard'
+
+/** The shape `validateAndConvertValue` hands a SINGLE_SELECT pre-hook. */
+function coerced(optionId: string) {
+  return { type: 'option', optionId }
+}
+
+function event(newValue: unknown): FieldPreHookEvent {
+  return {
+    recordId: 'def-invoice:inv-1',
+    entityDefinitionId: 'def-invoice',
+    entityType: 'invoice',
+    entitySlug: 'invoices',
+    fieldId: 'f-status',
+    systemAttribute: 'invoice_status',
+    field: { id: 'f-status', systemAttribute: 'invoice_status' },
+    newValue,
+    existingValue: undefined,
+    allValues: new Map<string, unknown>(),
+    organizationId: 'org-1',
+    userId: 'user-1',
+    bypass: new Set(),
+  } as unknown as FieldPreHookEvent
+}
+
+const CASES: Array<{
+  name: string
+  guard: FieldPreHookHandler
+  guarded: string[]
+  open: string[]
+  message: string
+}> = [
+  {
+    name: 'quote_status',
+    guard: guardManualQuoteLifecycleStatus,
+    // Both mirror the linked `service_request`; a typed status skips the mirror and leaves
+    // the request in the pipeline for a quote that has already been answered.
+    guarded: ['sent', 'approved'],
+    // `declined` has a sanctioned writer but no side effect a manual write would skip, and
+    // `draft` is the edit-a-sent-quote flow — walled separately, and only when a deposit
+    // has been paid, by `quote-deposit-guard.ts`.
+    open: ['draft', 'declined', 'canceled'],
+    message: QUOTE_ACTION_STATUS_MESSAGE,
+  },
+  {
+    name: 'invoice_status',
+    guard: guardManualInvoiceLifecycleStatus,
+    // 🛑 `paid` is the one that corrupts money: hand-set, the bill reads settled with no
+    // `PaymentTransaction`, no allocation and no `invoice_amount_paid` behind it.
+    guarded: ['sent', 'partially_paid', 'paid', 'void'],
+    // Both the edit-a-sent-invoice flow and un-voiding write `draft` directly.
+    open: ['draft'],
+    message: INVOICE_ACTION_STATUS_MESSAGE,
+  },
+]
+
+describe.each(CASES)('$name manual-write wall', (spec) => {
+  it.each(spec.guarded)('rejects the coerced option envelope for %s', async (status) => {
+    await expect(spec.guard(event(coerced(status)))).rejects.toThrow(BadRequestError)
+  })
+
+  it('names the actions, so the message says which button to press', async () => {
+    await expect(spec.guard(event(coerced(spec.guarded[0]!)))).rejects.toThrow(spec.message)
+  })
+
+  // A guard that only handled the envelope would be half-dead the moment a caller writes an
+  // already-typed value — and the system-hook twin passes exactly that shape.
+  it.each(spec.guarded)('rejects a bare string %s too', async (status) => {
+    await expect(spec.guard(event(status))).rejects.toThrow(BadRequestError)
+  })
+
+  it('rejects a single-element array of either shape', async () => {
+    const status = spec.guarded[0]!
+    await expect(spec.guard(event([coerced(status)]))).rejects.toThrow(BadRequestError)
+    await expect(spec.guard(event([status]))).rejects.toThrow(BadRequestError)
+  })
+
+  it.each(spec.open)('leaves %s freely editable', async (status) => {
+    const next = coerced(status)
+    await expect(spec.guard(event(next))).resolves.toBe(next)
+  })
+
+  it('lets a clear through rather than treating null as a guarded value', async () => {
+    await expect(spec.guard(event(null))).resolves.toBeNull()
+  })
+
+  it('returns the value untouched — it is a guard, not a transform', async () => {
+    const next = coerced(spec.open[0]!)
+    await expect(spec.guard(event(next))).resolves.toBe(next)
+  })
+})
+
+describe('the guarded sets do not leak into each other', () => {
+  // `approved` is a quote word and `paid` an invoice one. Building both guards from one
+  // factory makes swapping the two constant arrays a one-character mistake that nothing else
+  // would catch — each document would then guard the other's values and none of its own.
+  it('does not let the quote guard reject an invoice-only status', async () => {
+    const next = coerced('paid')
+    await expect(guardManualQuoteLifecycleStatus(event(next))).resolves.toBe(next)
+  })
+
+  it('does not let the invoice guard reject a quote-only status', async () => {
+    const next = coerced('approved')
+    await expect(guardManualInvoiceLifecycleStatus(event(next))).resolves.toBe(next)
+  })
+})

--- a/packages/lib/src/field-hooks/pre/lifecycle-status-guard.ts
+++ b/packages/lib/src/field-hooks/pre/lifecycle-status-guard.ts
@@ -1,0 +1,108 @@
+// packages/lib/src/field-hooks/pre/lifecycle-status-guard.ts
+
+import { BadRequestError } from '../../errors'
+import {
+  INVOICE_ACTION_STATUS_MESSAGE,
+  INVOICE_ACTION_STATUSES,
+  type LifecycleStatusGuardOptions,
+  QUOTE_ACTION_STATUS_MESSAGE,
+  QUOTE_ACTION_STATUSES,
+  unwrapStatusValue,
+} from '../../resources/hooks/lifecycle-status-guard'
+import type { FieldPreHookHandler } from '../types'
+
+/**
+ * Build the "this status is action-set, not a dropdown value" guard for the **field**
+ * pre-hook chain (`fireFieldPreHooks`) — the twin of `createLifecycleStatusGuard`, which
+ * builds the same rule for the system-hook chain.
+ *
+ * 🛑 **This chain is the enforcement point; the system one is coverage.** Every *interactive*
+ * edit of a status field — the drawer, the grid's inline edit, a kanban drag, a Kopilot
+ * record tool — goes through `fieldValue.set` -> `FieldValueService`, which never reads the
+ * system-hook registry. A document whose status is guarded only there is guarded on a door
+ * nobody uses (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §1). Both are
+ * kept: `record.create`/`record.update`, the CSV importer and the SDK take the other one.
+ *
+ * ⚠️ **The value here is already coerced, and that is the trap this factory exists to close.**
+ * By the time this runs, `validateAndConvertValue` has turned a SINGLE_SELECT write into
+ * `{ type: 'option', optionId: 'paid' }` — it is **never** a bare string on this chain. A
+ * guard comparing `event.newValue` to `'paid'` directly is inert: the comparison can never be
+ * true, so it passes everything and is indistinguishable from a guard nothing has tripped. It
+ * also reads correctly in review and passes any unit test that feeds it a bare string (§2).
+ * `unwrapStatusValue` is shared with the system hook precisely so neither side has to remember
+ * which shape it is holding.
+ *
+ * ✅ **Sanctioned writers get through on `bypassFieldGuards`.** `fireFieldPreHooks`
+ * short-circuits on `ctx.bypassFieldGuards.has(systemAttribute)` before any handler is
+ * reached, so every action that legitimately produces a guarded value names its attribute
+ * there. 🛑 That half is not optional: the moment one of these guards starts working, a
+ * sanctioned writer without the bypass is refused by the wall built to protect it, and Send
+ * simply stops working (§4).
+ *
+ * @param options - The guarded value set and the message to throw instead.
+ * @returns A {@link FieldPreHookHandler} to register against the status attribute.
+ */
+export function createFieldLifecycleStatusGuard(
+  options: LifecycleStatusGuardOptions
+): FieldPreHookHandler {
+  // `Set<unknown>`: the incoming value is unknown, and a membership test on an unknown is
+  // the `next === 'sent' || …` comparison without a narrowing cast in front of it.
+  const guarded = new Set<unknown>(options.guardedValues)
+
+  return async (event) => {
+    if (guarded.has(unwrapStatusValue(event.newValue))) {
+      throw new BadRequestError(options.message)
+    }
+    return event.newValue
+  }
+}
+
+/**
+ * The manual-`sent`/`approved` wall for `quote_status` on the chain that actually runs for
+ * client writes.
+ *
+ * Both transitions mirror onto the linked `service_request` — `markQuoteSent` sets it to
+ * `quoted`, `approveQuote` to `approved` — and a typed status skips the mirror, leaving the
+ * request sitting in the pipeline for a quote that has already been answered.
+ *
+ * Sanctioned writers, all in `money/quote-lifecycle.ts` and all naming `quote_status` in
+ * `bypassFieldGuards`: `markQuoteSent`, `approveQuote` and `declineQuote` (which writes an
+ * unguarded value today, and carries the bypass so that stays true of the writer rather than
+ * of the value). `acceptQuoteByToken` / `declineQuoteByToken` reach the field through those
+ * same two functions.
+ *
+ * Registered alongside `guardQuoteDraftReturnWithPaidDeposit`, which walls the opposite
+ * transition (`-> draft`) and only when a deposit has been paid. The two are disjoint by
+ * value; this one runs first because it decides in memory and the deposit wall costs a query.
+ */
+export const guardManualQuoteLifecycleStatus: FieldPreHookHandler = createFieldLifecycleStatusGuard(
+  {
+    guardedValues: QUOTE_ACTION_STATUSES,
+    message: QUOTE_ACTION_STATUS_MESSAGE,
+  }
+)
+
+/**
+ * The manual-`sent`/`partially_paid`/`paid`/`void` wall for `invoice_status`.
+ *
+ * 🛑 **This is the one that was corrupting money.** `invoice_status` had no field pre-hook at
+ * all — not an inert one, none — so it could be typed to `paid` from the drawer with no
+ * `PaymentTransaction`, no allocation and no `invoice_amount_paid`, and the bill read settled
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §3). `sent` skips
+ * `markInvoiceSent`'s side effects: `invoice_issued_at` is never stamped and the
+ * `WorkOrderBillingInstallment` never flips to `invoiced`.
+ *
+ * Sanctioned writers, all naming `invoice_status` in `bypassFieldGuards`: `markInvoiceSent`
+ * and `voidInvoice` (`money/invoice-lifecycle.ts`), and `syncInvoicePaymentState`
+ * (`money/payments/ledger.ts`) — the ledger projection, which is the ONLY writer of `paid`,
+ * `partially_paid` and the payment-reversal `-> sent`.
+ *
+ * ⚠️ Marking an invoice paid by hand is deliberately not possible, and §6.1 of the plan
+ * leaves that open: an org reconciling historic invoices may legitimately need it, but the
+ * answer there is an action with its own ledger side effects, not an editable dropdown.
+ */
+export const guardManualInvoiceLifecycleStatus: FieldPreHookHandler =
+  createFieldLifecycleStatusGuard({
+    guardedValues: INVOICE_ACTION_STATUSES,
+    message: INVOICE_ACTION_STATUS_MESSAGE,
+  })

--- a/packages/lib/src/field-hooks/pre/purchase-order-status-guard.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-status-guard.ts
@@ -1,15 +1,11 @@
 // packages/lib/src/field-hooks/pre/purchase-order-status-guard.ts
 
-import { BadRequestError } from '../../errors'
 import {
   PURCHASE_ORDER_ACTION_STATUS_MESSAGE,
   PURCHASE_ORDER_ACTION_STATUSES,
-  unwrapStatusValue,
 } from '../../resources/hooks/lifecycle-status-guard'
 import type { FieldPreHookHandler } from '../types'
-
-/** The guarded set as a membership test, built once. */
-const GUARDED = new Set<unknown>(PURCHASE_ORDER_ACTION_STATUSES)
+import { createFieldLifecycleStatusGuard } from './lifecycle-status-guard'
 
 /**
  * The manual-`issued` wall for `purchase_order_status`, on the chain that actually runs for
@@ -21,8 +17,9 @@ const GUARDED = new Set<unknown>(PURCHASE_ORDER_ACTION_STATUSES)
  * importer and the SDK. Every *interactive* edit of a status field goes through
  * `fieldValue.set` -> `FieldValueService`, which never reads the system-hook registry, so a
  * drawer edit or a kanban drag reaches only THIS handler.
- * `pre/quote-deposit-guard.ts` records the identical finding for `quote_status`. Both guards
- * are kept: together they cover every write path, and each names the other.
+ * `quote_status` and `invoice_status` now carry the same pair (`pre/lifecycle-status-guard.ts`),
+ * built from the same factory this one uses. Both chains are kept for each: together they
+ * cover every write path, and each names the other.
  *
  * ⚠️ **The value here is already coerced, and that is the trap.** By the time
  * `fireFieldPreHooks` runs, `validateAndConvertValue` has turned a SINGLE_SELECT write into
@@ -44,9 +41,7 @@ const GUARDED = new Set<unknown>(PURCHASE_ORDER_ACTION_STATUSES)
  * and §3.6 deliberately does not derive `closed` so that an order whose remainder has been
  * forgiven is still closeable by hand.
  */
-export const guardManualPurchaseOrderIssued: FieldPreHookHandler = async (event) => {
-  if (GUARDED.has(unwrapStatusValue(event.newValue))) {
-    throw new BadRequestError(PURCHASE_ORDER_ACTION_STATUS_MESSAGE)
-  }
-  return event.newValue
-}
+export const guardManualPurchaseOrderIssued: FieldPreHookHandler = createFieldLifecycleStatusGuard({
+  guardedValues: PURCHASE_ORDER_ACTION_STATUSES,
+  message: PURCHASE_ORDER_ACTION_STATUS_MESSAGE,
+})

--- a/packages/lib/src/field-hooks/pre/quote-deposit-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/quote-deposit-guard.test.ts
@@ -1,0 +1,115 @@
+// packages/lib/src/field-hooks/pre/quote-deposit-guard.test.ts
+//
+// 🛑 This guard shipped inert and had never fired
+// (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §2). It unwrapped the ARRAY
+// case and compared the result to `'draft'` — but on the field pre-hook chain
+// `validateAndConvertValue` has already run, so a SINGLE_SELECT arrives as
+// `{ type: 'option', optionId: 'draft' }` and never as a bare string. The comparison could
+// not be true, so it returned early on every write and a paid quote could be edited back to
+// draft, orphaning the deposit charge it was built to protect.
+//
+// The trap is that a unit test feeding a bare string passes against BOTH the broken and the
+// fixed version. So the rejection case here feeds the coerced envelope, and the bare-string
+// case exists only to prove the fix did not trade one shape for the other.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ findFirst: vi.fn() }))
+
+vi.mock('@auxx/database', () => ({
+  database: { query: { PaymentTransaction: { findFirst: h.findFirst } } },
+  schema: {
+    PaymentTransaction: {
+      organizationId: 'organizationId',
+      quoteInstanceId: 'quoteInstanceId',
+      kind: 'kind',
+      status: 'status',
+    },
+  },
+}))
+
+const { BadRequestError } = await import('../../errors')
+const { guardQuoteDraftReturnWithPaidDeposit } = await import('./quote-deposit-guard')
+
+import type { FieldPreHookEvent } from '../types'
+
+/** The shape `validateAndConvertValue` hands a SINGLE_SELECT pre-hook. */
+function coerced(optionId: string) {
+  return { type: 'option', optionId }
+}
+
+function event(newValue: unknown): FieldPreHookEvent {
+  return {
+    recordId: 'def-quote:quote-1',
+    entityDefinitionId: 'def-quote',
+    entityType: 'quote',
+    entitySlug: 'quotes',
+    fieldId: 'f-status',
+    systemAttribute: 'quote_status',
+    field: { id: 'f-status', systemAttribute: 'quote_status' },
+    newValue,
+    existingValue: undefined,
+    allValues: new Map<string, unknown>(),
+    organizationId: 'org-1',
+    userId: 'user-1',
+    bypass: new Set(),
+  } as unknown as FieldPreHookEvent
+}
+
+beforeEach(() => {
+  h.findFirst.mockReset()
+})
+
+describe('return-to-draft wall with a paid deposit', () => {
+  // The case the guard exists for, in the shape production delivers. This is the assertion
+  // that fails against the version that shipped.
+  it('rejects the coerced option envelope a drawer edit produces', async () => {
+    h.findFirst.mockResolvedValue({ id: 'txn-1' })
+    await expect(guardQuoteDraftReturnWithPaidDeposit(event(coerced('draft')))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+
+  it('says why, naming the deposit rather than the rule', async () => {
+    h.findFirst.mockResolvedValue({ id: 'txn-1' })
+    await expect(guardQuoteDraftReturnWithPaidDeposit(event(coerced('draft')))).rejects.toThrow(
+      'a deposit has been paid against it'
+    )
+  })
+
+  it('rejects the array-wrapped and bare shapes too', async () => {
+    h.findFirst.mockResolvedValue({ id: 'txn-1' })
+    await expect(guardQuoteDraftReturnWithPaidDeposit(event([coerced('draft')]))).rejects.toThrow(
+      BadRequestError
+    )
+    await expect(guardQuoteDraftReturnWithPaidDeposit(event('draft'))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+})
+
+describe('what still gets through', () => {
+  it('allows the return to draft when no deposit was ever paid', async () => {
+    h.findFirst.mockResolvedValue(undefined)
+    const next = coerced('draft')
+    await expect(guardQuoteDraftReturnWithPaidDeposit(event(next))).resolves.toBe(next)
+  })
+
+  // The wall is about ONE transition. Every other status write must skip the query entirely —
+  // this guard sits on `quote_status`, so it sees every write to the field.
+  it.each([
+    'sent',
+    'approved',
+    'declined',
+    'canceled',
+  ])('leaves %s alone without touching the ledger', async (status) => {
+    const next = coerced(status)
+    await expect(guardQuoteDraftReturnWithPaidDeposit(event(next))).resolves.toBe(next)
+    expect(h.findFirst).not.toHaveBeenCalled()
+  })
+
+  it('lets a clear through rather than treating null as a return to draft', async () => {
+    await expect(guardQuoteDraftReturnWithPaidDeposit(event(null))).resolves.toBeNull()
+    expect(h.findFirst).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/field-hooks/pre/quote-deposit-guard.ts
+++ b/packages/lib/src/field-hooks/pre/quote-deposit-guard.ts
@@ -4,26 +4,34 @@ import { database, schema } from '@auxx/database'
 import { parseRecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
 import { BadRequestError } from '../../errors'
+import { unwrapStatusValue } from '../../resources/hooks/lifecycle-status-guard'
 import type { FieldPreHookHandler } from '../types'
 
 /**
  * The return-to-draft wall for `quote_status` (money MP2 build spec §B.10). The system-hook
- * chain's `rejectManualLifecycleStatus` (`resources/hooks/quote-hooks.ts`) is dead for real
- * client writes to this field — the generic records path (form edits, Kopilot record tools)
- * runs `fireFieldPreHooks` (this **field**-pre-hook chain), never
+ * chain's lifecycle guard (`resources/hooks/quote-hooks.ts`) is dead for real client writes to
+ * this field — the generic records path (form edits, Kopilot record tools) runs
+ * `fireFieldPreHooks` (this **field**-pre-hook chain), never
  * `UnifiedCrudHandler.runPreHooks` (the **system**-hook chain). So this guard, not that one, is
  * the actual enforcement point.
  *
  * Rejects a manual `quote_status → 'draft'` write when a succeeded deposit charge is already
  * held against the quote — editing a paid quote back to draft would orphan the deposit with no
  * document to reconcile it against.
+ *
+ * 🛑 **This guard shipped inert and had never once fired**
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §2). It unwrapped the array
+ * case and compared the result to `'draft'` — but on THIS chain `validateAndConvertValue` has
+ * already run, so a SINGLE_SELECT arrives as `{ type: 'option', optionId: 'draft' }` and never
+ * as a bare string. The comparison could not be true, so every write returned early. The
+ * array-unwrap idiom it copied is correct for the SYSTEM chain, which passes raw caller input;
+ * carrying it across is what broke it. `unwrapStatusValue` handles both shapes and is what the
+ * two sibling status guards use.
  */
 export const guardQuoteDraftReturnWithPaidDeposit: FieldPreHookHandler = async (event) => {
-  // SINGLE_SELECT values can arrive array-wrapped (`['draft']`) or as a bare scalar — normalize
-  // before comparing, matching the `Array.isArray(raw) ? raw[0] : raw` idiom used elsewhere for
-  // status fields (e.g. `resources/hooks/quote-hooks.ts`'s `rejectManualLifecycleStatus`).
-  const next = Array.isArray(event.newValue) ? event.newValue[0] : event.newValue
-  if (next !== 'draft') return event.newValue
+  // The coerced envelope, the array wrapper and the bare string all reduce here — see the
+  // note above on why unwrapping only the array was a guard that could never fire.
+  if (unwrapStatusValue(event.newValue) !== 'draft') return event.newValue
 
   const quoteInstanceId = parseRecordId(event.recordId).entityInstanceId
   const deposit = await database.query.PaymentTransaction.findFirst({

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -56,6 +56,10 @@ import { publishFieldChangeEvent } from './post/publish-field-change-event'
 import { touchActivityOnFieldChange } from './post/touch-activity-on-field-change'
 import { guardInboxOwnerField } from './pre/inbox-owner-guard'
 import { guardInvoiceDelete } from './pre/invoice-delete-guard'
+import {
+  guardManualInvoiceLifecycleStatus,
+  guardManualQuoteLifecycleStatus,
+} from './pre/lifecycle-status-guard'
 import { cascadeOrderLinesOnDelete } from './pre/order-delete-guard'
 import {
   EVIDENCE_LOCKED_LINE_ATTRS,
@@ -280,12 +284,34 @@ export function registerAllHooks(): void {
   registerFieldPreHooks('inboxes', 'inbox_owner_user_id', [guardInboxOwnerField])
   registerFieldPreHooks('personal-inboxes', 'inbox_owner_user_id', [guardInboxOwnerField])
 
-  // Return-to-draft wall (money MP2 §B.10) — `rejectManualLifecycleStatus`
-  // (`resources/hooks/quote-hooks.ts`) is dead for real client writes to
-  // `quote_status` (the generic records path never runs the system-hook
-  // chain), so the deposit guard lives here instead, on the field-pre-hook
-  // chain that actually runs.
-  registerFieldPreHooks('quotes', 'quote_status', [guardQuoteDraftReturnWithPaidDeposit])
+  // Lifecycle status walls for `quote_status` and `invoice_status`
+  // (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4). The system-hook twins
+  // in `resources/hooks/quote-hooks.ts` / `invoice-hooks.ts` cover `record.create` /
+  // `record.update`, the CSV importer and the SDK; these cover every interactive edit —
+  // drawer, grid inline edit, kanban drag, Kopilot record tools — because those all write
+  // through `fieldValue.set` -> `FieldValueService`, which never reads the system-hook
+  // registry. Until these two registrations existed, an invoice could be typed to `paid` with
+  // no payment behind it and a quote to `sent` without its request ever being mirrored.
+  //
+  // Every sanctioned writer names its attribute in `bypassFieldGuards`, which
+  // `fireFieldPreHooks` honours before reaching these handlers: `markQuoteSent` /
+  // `approveQuote` / `declineQuote` for the quote, and `markInvoiceSent` / `voidInvoice` /
+  // `syncInvoicePaymentState` (the ledger projection — the only writer of `paid`) for the
+  // invoice. 🛑 A new sanctioned writer means a new bypass, not a weaker guard.
+  //
+  // ⚠️ ORDER IS COST, not semantics. The two quote guards are disjoint by value — this one
+  // walls `sent`/`approved`, the deposit wall walls `-> draft` — so either order behaves the
+  // same; the in-memory membership test runs first so the deposit wall's query is only spent
+  // on a write that could actually trip it.
+  //
+  // Return-to-draft wall (money MP2 §B.10): the deposit guard is here for the same reason,
+  // and had been here alone — inert, because it compared the coerced option envelope to a
+  // bare string (21 §2).
+  registerFieldPreHooks('quotes', 'quote_status', [
+    guardManualQuoteLifecycleStatus,
+    guardQuoteDraftReturnWithPaidDeposit,
+  ])
+  registerFieldPreHooks('invoices', 'invoice_status', [guardManualInvoiceLifecycleStatus])
 
   for (const attribute of BILLING_PROJECTION_ATTRS) {
     const entitySlug = attribute.startsWith('work_order_')

--- a/packages/lib/src/field-hooks/types.ts
+++ b/packages/lib/src/field-hooks/types.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/field-hooks/types.ts
 
+import type { TypedFieldValueInput } from '@auxx/types'
 import type { RecordId } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import type { CachedField } from '../field-values/types'
@@ -63,8 +64,25 @@ export interface FieldPreHookEvent {
   /**
    * Post-coercion value the caller is about to write. May be `null` to
    * signal a delete intent — guards that forbid clearing must handle `null`.
+   *
+   * 🛑 **Typed, not `unknown`, and that is load-bearing**
+   * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §5b).
+   * `fireFieldPreHooks` runs AFTER `validateAndConvertValue`, so what arrives here is the
+   * COERCED envelope — a SINGLE_SELECT is `{ type: 'option', optionId }`, never the bare
+   * string the caller typed. Three guards were written comparing this directly to a string
+   * literal; every one of them was inert, read correctly in review, and passed a unit test
+   * that fed it a bare string. Because `TypedFieldValueInput` is a union of OBJECT types,
+   * that comparison is now `error TS2367: This comparison appears to be unintentional […]
+   * have no overlap` — the mistake is unwriteable rather than merely discouraged.
+   *
+   * ⚠️ Unwrap deliberately, per field type. There is no framework-level normalisation on
+   * purpose: it would be lossy (a relationship guard needs `relatedEntityId`, an actor guard
+   * the actor envelope) and it would make the mistake invisible rather than impossible — a
+   * guard comparing a normalised value to the wrong literal still fails silently.
+   * `unwrapStatusValue` (`resources/hooks/lifecycle-status-guard.ts`) is the SINGLE_SELECT
+   * one.
    */
-  newValue: unknown
+  newValue: TypedFieldValueInput | TypedFieldValueInput[] | null
   /**
    * Existing value on the record for this field. Pre-fetched on the bulk
    * path; `undefined` on the single-field path (hooks that need it can
@@ -90,9 +108,13 @@ export interface FieldPreHookEvent {
  * write for this field, or throws to reject the operation.
  *
  * Multiple hooks for the same (entitySlug, systemAttribute) compose
- * left-to-right; entity-scoped run before global (`'*'`-scoped) hooks.
+ * left-to-right; entity-scoped run before global (`'*'`-scoped) hooks — so a
+ * handler's return value is the next handler's `newValue`, which is why it is
+ * typed the same way rather than `unknown`.
  */
-export type FieldPreHookHandler = (event: FieldPreHookEvent) => Promise<unknown>
+export type FieldPreHookHandler = (
+  event: FieldPreHookEvent
+) => Promise<TypedFieldValueInput | TypedFieldValueInput[] | null | undefined>
 
 /**
  * Pre-delete entity hook — fired before an entity is permanently deleted.

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -441,15 +441,18 @@ async function fireFieldPreHooks(
     bypass: ctx.bypassFieldGuards,
   }
 
-  let value: unknown = args.typedValue
+  // Typed, not `unknown`: `args.typedValue` already carries the coerced shape, and widening
+  // it here is what let three guards ship comparing an option envelope to a bare string
+  // (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §5b). Keeping the type is
+  // what turns that mistake into `error TS2367` in the guard's own file. The `undefined`
+  // check narrows the drop case out, so no cast is needed on the way back either.
+  let value: TypedFieldValueInput | TypedFieldValueInput[] | null = args.typedValue
   for (const hook of hooks) {
-    value = await hook({ ...event, newValue: value })
-    if (value === undefined) return { kind: 'drop' }
+    const next = await hook({ ...event, newValue: value })
+    if (next === undefined) return { kind: 'drop' }
+    value = next
   }
-  return {
-    kind: 'continue',
-    value: value as TypedFieldValueInput | TypedFieldValueInput[] | null,
-  }
+  return { kind: 'continue', value }
 }
 
 // =============================================================================

--- a/packages/lib/src/money/__tests__/invoice-lifecycle.test.ts
+++ b/packages/lib/src/money/__tests__/invoice-lifecycle.test.ts
@@ -1,0 +1,218 @@
+// packages/lib/src/money/__tests__/invoice-lifecycle.test.ts
+//
+// 🛑 The regression this file exists to prevent: `invoice_status` is guarded on BOTH hook
+// chains and the two are cleared by DIFFERENT mechanisms. Writing through
+// `FieldValueService` instead of `UnifiedCrudHandler` clears the system pre-hook
+// structurally — `runPreHooks` never runs. It does NOT clear the field pre-hook, which fires
+// on exactly these writes; only `bypassFieldGuards` does
+// (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4).
+//
+// `invoice_status` is the sharpest case in that plan: it had no field pre-hook at all, so
+// `paid` was typeable from the drawer with no payment behind it. Adding the wall is what
+// makes these bypasses load-bearing — without them Send and Void stop working, and nothing
+// says so until somebody presses the button.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  getFieldValues: vi.fn(),
+  setValuesForEntity: vi.fn(),
+  hasSucceededCharges: vi.fn(),
+  listInvoiceAllocations: vi.fn(),
+  /** Constructor arguments every `FieldValueService` was built with. */
+  fieldValueServiceArgs: [] as unknown[][],
+  /** `WorkOrderBillingInstallment` rows the update statement claimed to touch. */
+  installmentUpdates: [] as unknown[],
+}))
+
+vi.mock('@auxx/database', () => {
+  const chain = {
+    set: (values: unknown) => {
+      h.installmentUpdates.push(values)
+      return chain
+    },
+    where: () => Promise.resolve(),
+  }
+  return {
+    database: { update: () => chain },
+    schema: {
+      WorkOrderBillingInstallment: {
+        organizationId: 'organizationId',
+        invoiceId: 'invoiceId',
+        status: 'status',
+      },
+    },
+  }
+})
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+  getEntityDefIdResolver: async () => (slug: string) => `def-${slug}`,
+}))
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    getFieldValues = h.getFieldValues
+  },
+}))
+vi.mock('../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    constructor(...args: unknown[]) {
+      h.fieldValueServiceArgs.push(args)
+    }
+    setValuesForEntity = h.setValuesForEntity
+  },
+}))
+vi.mock('../billing-allocations', () => ({
+  listInvoiceAllocations: h.listInvoiceAllocations,
+  releaseInvoiceAllocations: vi.fn(),
+}))
+vi.mock('../billing-projection', () => ({
+  syncInvoiceBillingProjection: vi.fn(),
+  syncWorkOrderBillingProjection: vi.fn(),
+}))
+vi.mock('../payments/ledger', () => ({ hasSucceededCharges: h.hasSucceededCharges }))
+
+const { markInvoiceSent, voidInvoice } = await import('../invoice-lifecycle')
+const { BadRequestError } = await import('../../errors')
+
+const ORG = 'org-1'
+const USER = 'user-1'
+const INVOICE = 'inv-1'
+
+const STATUS_FIELD = { id: 'f-invoice-status' }
+const ISSUED_FIELD = { id: 'f-invoice-issued-at' }
+
+/**
+ * `bySystemAttributes` is called for the status read and again for `invoice_issued_at`.
+ * Answer by what was asked for. `issuedAt: undefined` means the stamp is still empty.
+ */
+function wireInvoice(status: string, options: { issuedAt?: string } = {}) {
+  h.bySystemAttributes.mockImplementation((attrs: readonly string[]) =>
+    Promise.resolve(
+      attrs.includes('invoice_status')
+        ? { invoice_status: STATUS_FIELD }
+        : { invoice_issued_at: ISSUED_FIELD }
+    )
+  )
+  h.getFieldValues.mockImplementation((_recordId: string, fieldIds: string[]) => {
+    const map = new Map<string, unknown>()
+    if (fieldIds.includes(STATUS_FIELD.id)) {
+      map.set(STATUS_FIELD.id, { type: 'option', optionId: status })
+    }
+    if (fieldIds.includes(ISSUED_FIELD.id) && options.issuedAt) {
+      map.set(ISSUED_FIELD.id, { type: 'date', value: options.issuedAt })
+    }
+    return Promise.resolve(map)
+  })
+}
+
+function writtenValues(): Array<{ fieldId: string; value: unknown }> {
+  return h.setValuesForEntity.mock.calls[0]?.[0]?.values ?? []
+}
+
+/** The bypass set the first `FieldValueService` was constructed with. */
+function bypass(): ReadonlySet<string> | undefined {
+  const options = h.fieldValueServiceArgs[0]?.[4] as
+    | { bypassFieldGuards?: ReadonlySet<string> }
+    | undefined
+  return options?.bypassFieldGuards
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.fieldValueServiceArgs = []
+  h.installmentUpdates = []
+  h.hasSucceededCharges.mockResolvedValue(false)
+  h.listInvoiceAllocations.mockResolvedValue({
+    lineAllocations: [],
+    visitAllocations: [],
+    scheduleAllocations: [],
+  })
+})
+
+describe('markInvoiceSent', () => {
+  it('writes sent from draft', async () => {
+    wireInvoice('draft')
+    await markInvoiceSent({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(writtenValues()).toContainEqual({ fieldId: 'invoice_status', value: 'sent' })
+  })
+
+  it('refuses to run from any status but draft', async () => {
+    wireInvoice('sent')
+    await expect(
+      markInvoiceSent({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    ).rejects.toThrow(BadRequestError)
+  })
+
+  // The side effects a typed `sent` would skip — the reason the value is guarded at all.
+  it('stamps invoice_issued_at when it is still empty', async () => {
+    wireInvoice('draft')
+    await markInvoiceSent({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(writtenValues().map((w) => w.fieldId)).toContain('invoice_issued_at')
+  })
+
+  it('leaves a stamp that is already there alone', async () => {
+    wireInvoice('draft', { issuedAt: '2026-01-01' })
+    await markInvoiceSent({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(writtenValues().map((w) => w.fieldId)).not.toContain('invoice_issued_at')
+  })
+
+  it('flips the drafted installment to invoiced', async () => {
+    wireInvoice('draft')
+    await markInvoiceSent({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(h.installmentUpdates).toEqual([{ status: 'invoiced' }])
+  })
+})
+
+describe('voidInvoice', () => {
+  it('writes void', async () => {
+    wireInvoice('sent')
+    await voidInvoice({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(writtenValues()).toEqual([{ fieldId: 'invoice_status', value: 'void' }])
+  })
+
+  it('refuses while a succeeded payment exists', async () => {
+    wireInvoice('sent')
+    h.hasSucceededCharges.mockResolvedValue(true)
+    await expect(
+      voidInvoice({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    ).rejects.toThrow(BadRequestError)
+  })
+})
+
+describe('clearing their own guards', () => {
+  const ACTIONS = [
+    { name: 'markInvoiceSent', run: markInvoiceSent, from: 'draft' },
+    { name: 'voidInvoice', run: voidInvoice, from: 'sent' },
+  ] as const
+
+  // The whole mechanism. `fireFieldPreHooks` short-circuits on
+  // `ctx.bypassFieldGuards.has(systemAttribute)` before any handler runs.
+  it.each(ACTIONS)('$name passes bypassFieldGuards for invoice_status', async (action) => {
+    wireInvoice(action.from)
+    await action.run({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect([...(bypass() ?? [])]).toEqual(['invoice_status'])
+  })
+
+  // 🛑 `markInvoiceSent` writes `invoice_issued_at` on the same service. Naming it here too
+  // would be the easy mistake: that field carries no guard today, and exempting a field a
+  // bypass does not need is how a projection-owned field quietly becomes writable later.
+  it.each(ACTIONS)('$name bypasses that one attribute and nothing else', async (action) => {
+    wireInvoice(action.from)
+    await action.run({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(bypass()?.size).toBe(1)
+    expect(bypass()?.has('invoice_issued_at')).toBe(false)
+  })
+
+  // The other half of the proof: without the bypass, this exact write is refused. If this
+  // ever stops throwing, the bypasses above have become decoration and the wall is inert.
+  it.each(['sent', 'void'])('is refused by the field pre-hook without a bypass (%s)', async (v) => {
+    const { guardManualInvoiceLifecycleStatus } = await import(
+      '../../field-hooks/pre/lifecycle-status-guard'
+    )
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: partial FieldPreHookEvent for the guard
+      guardManualInvoiceLifecycleStatus({ newValue: { type: 'option', optionId: v } } as any)
+    ).rejects.toThrow(BadRequestError)
+  })
+})

--- a/packages/lib/src/money/__tests__/quote-lifecycle.test.ts
+++ b/packages/lib/src/money/__tests__/quote-lifecycle.test.ts
@@ -1,0 +1,153 @@
+// packages/lib/src/money/__tests__/quote-lifecycle.test.ts
+//
+// 🛑 The regression this file exists to prevent: `quote_status` is guarded on BOTH hook
+// chains and the two are cleared by DIFFERENT mechanisms. Writing through
+// `FieldValueService` instead of `UnifiedCrudHandler` clears the system pre-hook
+// structurally — `runPreHooks` never runs. It does NOT clear the field pre-hook, which fires
+// on exactly these writes; only `bypassFieldGuards` does
+// (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4).
+//
+// Drop the bypass and Send stops working: the wall built to protect the action refuses it.
+// Nothing about that is visible until somebody presses the button, which is why the two
+// halves of that plan had to land in one commit and why they are asserted together here.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  getFieldValues: vi.fn(),
+  listFiltered: vi.fn(),
+  setValuesForEntity: vi.fn(),
+  /** Constructor arguments every `FieldValueService` was built with. */
+  fieldValueServiceArgs: [] as unknown[][],
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    getFieldValues = h.getFieldValues
+    listFiltered = h.listFiltered
+  },
+}))
+vi.mock('../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    constructor(...args: unknown[]) {
+      h.fieldValueServiceArgs.push(args)
+    }
+    setValuesForEntity = h.setValuesForEntity
+  },
+}))
+
+const { approveQuote, declineQuote, markQuoteSent } = await import('../quote-lifecycle')
+const { BadRequestError } = await import('../../errors')
+
+const ORG = 'org-1'
+const USER = 'user-1'
+const QUOTE = 'quote-1'
+
+const STATUS_FIELD = { id: 'f-quote-status' }
+const REQUEST_FIELD = { id: 'f-quote-request' }
+
+/** The quote's own field values, as `getFieldValues` returns them (coerced shapes). */
+function wireQuote(status: string, requestInstanceId?: string) {
+  h.bySystemAttributes.mockResolvedValue({
+    quote_status: STATUS_FIELD,
+    quote_request: REQUEST_FIELD,
+  })
+  const map = new Map<string, unknown>()
+  map.set(STATUS_FIELD.id, { type: 'option', optionId: status })
+  if (requestInstanceId) {
+    map.set(REQUEST_FIELD.id, {
+      type: 'relationship',
+      recordId: `service_request:${requestInstanceId}`,
+    })
+  }
+  h.getFieldValues.mockResolvedValue(map)
+}
+
+/** The bypass set the Nth `FieldValueService` was constructed with. */
+function bypassOf(index = 0): ReadonlySet<string> | undefined {
+  const options = h.fieldValueServiceArgs[index]?.[4] as
+    | { bypassFieldGuards?: ReadonlySet<string> }
+    | undefined
+  return options?.bypassFieldGuards
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.fieldValueServiceArgs = []
+})
+
+const ACTIONS = [
+  { name: 'markQuoteSent', run: markQuoteSent, from: 'draft', writes: 'sent' },
+  { name: 'approveQuote', run: approveQuote, from: 'sent', writes: 'approved' },
+  { name: 'declineQuote', run: declineQuote, from: 'sent', writes: 'declined' },
+] as const
+
+describe.each(ACTIONS)('$name — the status write', (action) => {
+  it(`writes ${action.writes} from ${action.from}`, async () => {
+    wireQuote(action.from)
+    await action.run({ organizationId: ORG, userId: USER, quoteInstanceId: QUOTE })
+    expect(h.setValuesForEntity.mock.calls[0]?.[0]?.values).toEqual([
+      { fieldId: 'quote_status', value: action.writes },
+    ])
+  })
+
+  it('refuses to run from the wrong status', async () => {
+    wireQuote('canceled')
+    await expect(
+      action.run({ organizationId: ORG, userId: USER, quoteInstanceId: QUOTE })
+    ).rejects.toThrow(BadRequestError)
+  })
+})
+
+describe.each(ACTIONS)('$name — clearing its own guards', (action) => {
+  // The whole mechanism. `fireFieldPreHooks` short-circuits on
+  // `ctx.bypassFieldGuards.has(systemAttribute)` before any handler runs, so naming the
+  // attribute here is what lets the sanctioned writer past its own wall.
+  it('passes bypassFieldGuards for quote_status', async () => {
+    wireQuote(action.from)
+    await action.run({ organizationId: ORG, userId: USER, quoteInstanceId: QUOTE })
+    expect([...(bypassOf() ?? [])]).toEqual(['quote_status'])
+  })
+
+  // Naming more than the one attribute would quietly disarm guards on fields these actions
+  // have no business writing — `markPurchaseOrderSent`'s bypass is scoped the same way.
+  it('bypasses that one attribute and nothing else', async () => {
+    wireQuote(action.from)
+    await action.run({ organizationId: ORG, userId: USER, quoteInstanceId: QUOTE })
+    expect(bypassOf()?.size).toBe(1)
+  })
+})
+
+describe('the request mirror', () => {
+  // The reason `sent` and `approved` are guarded at all: a typed status skips this write and
+  // leaves the request sitting in the pipeline for a quote that has already been answered.
+  it.each([
+    { name: 'markQuoteSent', run: markQuoteSent, from: 'draft', mirrors: 'quoted' },
+    { name: 'approveQuote', run: approveQuote, from: 'sent', mirrors: 'approved' },
+  ])('$name mirrors the linked request to $mirrors', async (spec) => {
+    wireQuote(spec.from, 'req-1')
+    await spec.run({ organizationId: ORG, userId: USER, quoteInstanceId: QUOTE })
+    expect(h.setValuesForEntity.mock.calls[1]?.[0]?.values).toEqual([
+      { fieldId: 'service_request_status', value: spec.mirrors },
+    ])
+  })
+
+  // 🛑 The mirror rides the SAME service, so it inherits the bypass. That is only safe
+  // because the set names `quote_status` — an attribute the request does not have. A wider
+  // set would silently exempt this second write from whatever guards the request carries.
+  it('cannot disarm a guard on the request, because the set names a quote attribute', async () => {
+    wireQuote('draft', 'req-1')
+    await markQuoteSent({ organizationId: ORG, userId: USER, quoteInstanceId: QUOTE })
+    expect(bypassOf()?.has('service_request_status')).toBe(false)
+  })
+
+  it('declineQuote deliberately mirrors nothing', async () => {
+    wireQuote('sent', 'req-1')
+    await declineQuote({ organizationId: ORG, userId: USER, quoteInstanceId: QUOTE })
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/money/invoice-lifecycle.ts
+++ b/packages/lib/src/money/invoice-lifecycle.ts
@@ -4,6 +4,7 @@ import { database, schema } from '@auxx/database'
 import type { RecordId, TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { and, eq } from 'drizzle-orm'
 import { getEntityDefIdResolver, getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
@@ -55,12 +56,37 @@ export async function unstampSourceLines(
 }
 
 /**
+ * The bypass both invoice lifecycle actions carry
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4).
+ *
+ * 🛑 **Two chains guard `invoice_status`, and only ONE of them is cleared structurally.**
+ * Writing through `FieldValueService` rather than `UnifiedCrudHandler` clears the system
+ * pre-hook (`resources/hooks/invoice-hooks.ts`), which never runs for a `FieldValueService`
+ * write. But that is not the chain a drawer edit or a kanban drag takes, so `invoice_status`
+ * also carries a FIELD pre-hook (`field-hooks/pre/lifecycle-status-guard.ts`) that DOES see
+ * these writes. `fireFieldPreHooks` short-circuits on
+ * `ctx.bypassFieldGuards.has(systemAttribute)` before any handler runs, so naming the
+ * attribute here is the whole mechanism — without it Send and Void are refused by the wall
+ * built to protect them.
+ *
+ * It names `invoice_status` and nothing else. `markInvoiceSent` also writes
+ * `invoice_issued_at`, which is deliberately NOT in here: that field is not in
+ * `BILLING_PROJECTION_ATTRS` and carries no guard, and naming a field a bypass does not need
+ * is how a projection-owned field quietly becomes writable later.
+ *
+ * The third sanctioned writer, `syncInvoicePaymentState` (`payments/ledger.ts`), builds the
+ * identical one-attribute set — it is the only writer of `paid` / `partially_paid`.
+ */
+const INVOICE_STATUS_BYPASS = new Set<SystemAttribute>(['invoice_status'])
+
+/**
  * Mark a draft invoice as sent (money MI1 build spec §G.2) — send is issuance, so
  * `invoice_issued_at` is stamped to today if it's still empty. No `markPaid` mutation exists
  * on purpose: "Mark as paid" in the UI records a full-balance payment through
  * `recordManualPayment` (decision 4, one code path). Writes go through `FieldValueService` —
- * the sanctioned-writer path the `rejectManualLifecycleStatus` system pre-hook
- * (resources/hooks/invoice-hooks.ts) is built to let through.
+ * the sanctioned-writer path both `invoice_status` guards are built to let through: the
+ * system pre-hook (resources/hooks/invoice-hooks.ts) structurally, and the field pre-hook via
+ * {@link INVOICE_STATUS_BYPASS}.
  */
 export async function markInvoiceSent(input: InvoiceLifecycleInput): Promise<void> {
   const { organizationId, userId, invoiceInstanceId } = input
@@ -100,7 +126,9 @@ export async function markInvoiceSent(input: InvoiceLifecycleInput): Promise<voi
   // precedent for the identical gap. Mirrors `UnifiedCrudHandler.update`'s own
   // recordId-resolution step (unified-handler-mutations.ts:452).
   const resolveDefId = await getEntityDefIdResolver(organizationId)
-  const fieldValueService = new FieldValueService(organizationId, userId)
+  const fieldValueService = new FieldValueService(organizationId, userId, undefined, undefined, {
+    bypassFieldGuards: INVOICE_STATUS_BYPASS,
+  })
   await fieldValueService.setValuesForEntity({
     recordId: toRecordId(resolveDefId('invoice'), invoiceInstanceId),
     values: writes,
@@ -122,8 +150,8 @@ export async function markInvoiceSent(input: InvoiceLifecycleInput): Promise<voi
  * (decision 6 — delete manual payments first; MP1 extends the message to refunds). Unstamps
  * every source line so the job can be re-gathered later (decision 5) — the invoice's own
  * copies stay, so the void document remains readable history. Un-void is the manual `draft`
- * write escape hatch, deliberately unguarded (`rejectManualLifecycleStatus` only blocks the
- * ledger-derived/send statuses).
+ * write escape hatch, deliberately unguarded — neither `invoice_status` guard blocks `draft`,
+ * only the ledger-derived and send statuses.
  */
 export async function voidInvoice(input: InvoiceLifecycleInput): Promise<void> {
   const { organizationId, userId, invoiceInstanceId } = input
@@ -142,7 +170,9 @@ export async function voidInvoice(input: InvoiceLifecycleInput): Promise<void> {
   // identical note in `markInvoiceSent` above (unresolved `invoice:<id>` RecordId silently
   // no-ops every field-change hook, including this plan's invoice-reminders subject guard).
   const resolveDefId = await getEntityDefIdResolver(organizationId)
-  const fieldValueService = new FieldValueService(organizationId, userId)
+  const fieldValueService = new FieldValueService(organizationId, userId, undefined, undefined, {
+    bypassFieldGuards: INVOICE_STATUS_BYPASS,
+  })
   await fieldValueService.setValuesForEntity({
     recordId: toRecordId(resolveDefId('invoice'), invoiceInstanceId),
     values: [{ fieldId: 'invoice_status', value: 'void' }],

--- a/packages/lib/src/money/payments/ledger-payment-state.test.ts
+++ b/packages/lib/src/money/payments/ledger-payment-state.test.ts
@@ -1,0 +1,181 @@
+// packages/lib/src/money/payments/ledger-payment-state.test.ts
+//
+// 🛑 `syncInvoicePaymentState` is the ONLY writer of `invoice_status = paid` /
+// `partially_paid`, and of the payment-reversal `-> sent`. That is exactly why the field
+// pre-hook wall on `invoice_status` exists — a hand-set `paid` records a settled bill with no
+// `PaymentTransaction` behind it — and exactly why this call has to be exempt from it
+// (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4).
+//
+// Writing through `FieldValueService` clears the SYSTEM pre-hook structurally. It does not
+// clear the FIELD pre-hook, which fires on this write. Drop `bypassFieldGuards` and recording
+// a payment starts failing — the ledger can no longer say what the ledger is for.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  getFieldValues: vi.fn(),
+  setValuesForEntity: vi.fn(),
+  /** Constructor arguments every `FieldValueService` was built with. */
+  fieldValueServiceArgs: [] as unknown[][],
+  /** Allocation rows `computeAmountPaid` sums — `{ amount, kind }`, kind from the transaction. */
+  allocations: [] as Array<{ kind: string; amount: number }>,
+}))
+
+/** Chainable drizzle stub — `computeAmountPaid` sums the rows it resolves to. */
+function makeChain() {
+  const chain: Record<string, unknown> = {}
+  for (const key of ['from', 'innerJoin', 'leftJoin', 'where', 'limit', 'groupBy']) {
+    chain[key] = () => chain
+  }
+  // biome-ignore lint/suspicious/noThenProperty: chainable drizzle query-builder stub
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(h.allocations).then(resolve)
+  return chain
+}
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => makeChain(),
+  },
+  schema: new Proxy(
+    {},
+    { get: (_t, table) => new Proxy({}, { get: (_c, col) => `${String(table)}.${String(col)}` }) }
+  ),
+}))
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    getFieldValues = h.getFieldValues
+  },
+}))
+vi.mock('../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    constructor(...args: unknown[]) {
+      h.fieldValueServiceArgs.push(args)
+    }
+    setValuesForEntity = h.setValuesForEntity
+  },
+}))
+
+const { syncInvoicePaymentState } = await import('./ledger')
+
+const ORG = 'org-1'
+const USER = 'user-1'
+const INVOICE = 'inv-1'
+
+const FIELDS = {
+  invoice_status: { id: 'f-status' },
+  invoice_total: { id: 'f-total' },
+  invoice_amount_paid: { id: 'f-paid' },
+  invoice_balance: { id: 'f-balance' },
+}
+
+/** The invoice as the ledger finds it, plus the succeeded charges held against it. */
+function wireInvoice(params: {
+  status: string
+  total: number
+  amountPaid?: number
+  charges?: number[]
+}) {
+  h.bySystemAttributes.mockResolvedValue(FIELDS)
+  const map = new Map<string, unknown>()
+  map.set(FIELDS.invoice_status.id, { type: 'option', optionId: params.status })
+  map.set(FIELDS.invoice_total.id, { type: 'number', value: params.total })
+  map.set(FIELDS.invoice_amount_paid.id, { type: 'number', value: params.amountPaid ?? 0 })
+  h.getFieldValues.mockResolvedValue(map)
+  h.allocations = (params.charges ?? []).map((amount) => ({ kind: 'charge', amount }))
+}
+
+function writtenValues(): Array<{ fieldId: string; value: unknown }> {
+  return h.setValuesForEntity.mock.calls[0]?.[0]?.values ?? []
+}
+
+/** The bypass set the projection's `FieldValueService` was constructed with. */
+function bypass(): ReadonlySet<string> | undefined {
+  const options = h.fieldValueServiceArgs[0]?.[4] as
+    | { bypassFieldGuards?: ReadonlySet<string> }
+    | undefined
+  return options?.bypassFieldGuards
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.fieldValueServiceArgs = []
+  h.allocations = []
+})
+
+describe('syncInvoicePaymentState — clearing the wall it justifies', () => {
+  it('passes bypassFieldGuards for invoice_status', async () => {
+    wireInvoice({ status: 'sent', total: 100, charges: [100] })
+    await syncInvoicePaymentState({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect([...(bypass() ?? [])]).toEqual(['invoice_status'])
+  })
+
+  // The other two fields it writes need no exemption: `BILLING_PROJECTION_ATTRS` deliberately
+  // excludes `invoice_amount_paid`, and neither it nor `invoice_balance` carries a field
+  // pre-hook. Naming them would exempt writes that were never guarded, which is how a
+  // projection-owned field quietly becomes writable later.
+  it('bypasses that one attribute and nothing else', async () => {
+    wireInvoice({ status: 'sent', total: 100, charges: [100] })
+    await syncInvoicePaymentState({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(bypass()?.size).toBe(1)
+    expect(bypass()?.has('invoice_amount_paid')).toBe(false)
+    expect(bypass()?.has('invoice_balance')).toBe(false)
+  })
+
+  // 🛑 The write the bypass is for. If the guard set ever stops covering `paid`, the wall
+  // this test's subject exists behind has gone away.
+  it('is the write the wall would otherwise refuse', async () => {
+    wireInvoice({ status: 'sent', total: 100, charges: [100] })
+    await syncInvoicePaymentState({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(writtenValues()).toContainEqual({ fieldId: 'invoice_status', value: 'paid' })
+
+    const { guardManualInvoiceLifecycleStatus } = await import(
+      '../../field-hooks/pre/lifecycle-status-guard'
+    )
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: partial FieldPreHookEvent for the guard
+      guardManualInvoiceLifecycleStatus({ newValue: { type: 'option', optionId: 'paid' } } as any)
+    ).rejects.toThrow()
+  })
+})
+
+describe('syncInvoicePaymentState — what it derives', () => {
+  it('lands on partially_paid when the ledger is short of the total', async () => {
+    wireInvoice({ status: 'sent', total: 100, charges: [40] })
+    await syncInvoicePaymentState({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(writtenValues()).toContainEqual({ fieldId: 'invoice_status', value: 'partially_paid' })
+  })
+
+  // Removing the last payment reverses the status — a `paid` invoice with an empty ledger
+  // would be exactly the corruption the wall exists to prevent, arrived at legitimately.
+  it('reverses paid back to sent when the ledger empties', async () => {
+    wireInvoice({ status: 'paid', total: 100, amountPaid: 100, charges: [] })
+    await syncInvoicePaymentState({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(writtenValues()).toContainEqual({ fieldId: 'invoice_status', value: 'sent' })
+  })
+
+  it('never touches a void invoice', async () => {
+    wireInvoice({ status: 'void', total: 100, charges: [100] })
+    await syncInvoicePaymentState({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+
+  // No write at all means no service, and therefore no bypass to assert — the guard is only
+  // ever consulted for a write that actually changes something.
+  it('writes nothing when the projection already agrees', async () => {
+    wireInvoice({ status: 'paid', total: 100, amountPaid: 100, charges: [100] })
+    h.getFieldValues.mockResolvedValue(
+      new Map<string, unknown>([
+        [FIELDS.invoice_status.id, { type: 'option', optionId: 'paid' }],
+        [FIELDS.invoice_total.id, { type: 'number', value: 100 }],
+        [FIELDS.invoice_amount_paid.id, { type: 'number', value: 100 }],
+        [FIELDS.invoice_balance.id, { type: 'number', value: 0 }],
+      ])
+    )
+    await syncInvoicePaymentState({ organizationId: ORG, userId: USER, invoiceInstanceId: INVOICE })
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/money/payments/ledger.ts
+++ b/packages/lib/src/money/payments/ledger.ts
@@ -6,6 +6,7 @@ import { createScopedLogger } from '@auxx/logger'
 import type { TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { and, asc, eq, inArray, isNotNull, or, sql } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
 import { BadRequestError, ForbiddenError, NotFoundError } from '../../errors'
@@ -165,11 +166,28 @@ export async function listWorkOrderPayments(
 }
 
 /**
+ * The bypass the ledger projection carries
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4).
+ *
+ * 🛑 `invoice_status` is guarded on the FIELD pre-hook chain
+ * (`field-hooks/pre/lifecycle-status-guard.ts`), which `FieldValueService` writes DO reach —
+ * unlike the system pre-hook, which they clear structurally. This function is the ONLY writer
+ * of `paid` and `partially_paid` and of the payment-reversal `-> sent`, which is exactly why
+ * the wall exists and exactly why this call has to be exempt from it.
+ *
+ * It names `invoice_status` and nothing else. The other two fields written here —
+ * `invoice_amount_paid` and `invoice_balance` — need no exemption: `BILLING_PROJECTION_ATTRS`
+ * deliberately excludes `invoice_amount_paid`, and neither carries a field pre-hook.
+ */
+const INVOICE_STATUS_BYPASS = new Set<SystemAttribute>(['invoice_status'])
+
+/**
  * Project the ledger onto an invoice's mirrored `amountPaid`/`balance`/`status` fields
  * (money MI1 build spec §E.4) — the one function where ledger truth becomes invoice state.
  * Writes go through `FieldValueService` (the sanctioned-writer path that structurally
- * bypasses the `rejectManualLifecycleStatus` system pre-hook — the convert-quote.ts:206-210
- * precedent). Only writes fields that actually changed, to avoid no-op event churn.
+ * bypasses the system pre-hook — the convert-quote.ts:206-210 precedent) plus
+ * {@link INVOICE_STATUS_BYPASS} for the field pre-hook, which that path does NOT clear on its
+ * own. Only writes fields that actually changed, to avoid no-op event churn.
  */
 export async function syncInvoicePaymentState(
   input: SyncInvoicePaymentStateInput & { db?: Database }
@@ -230,7 +248,9 @@ export async function syncInvoicePaymentState(
   if (nextStatus !== status) writes.push({ fieldId: 'invoice_status', value: nextStatus })
   if (writes.length === 0) return
 
-  const fieldValueService = new FieldValueService(organizationId, userId, db)
+  const fieldValueService = new FieldValueService(organizationId, userId, db, undefined, {
+    bypassFieldGuards: INVOICE_STATUS_BYPASS,
+  })
   // No `publishEvents` (plan 04 §7.3): the ambient write session decides. On the
   // four Stripe rails these writes are and stay loud; reached from
   // `recomputeInvoiceTotals` during a buffered billing composition they are

--- a/packages/lib/src/money/quote-lifecycle.ts
+++ b/packages/lib/src/money/quote-lifecycle.ts
@@ -3,6 +3,7 @@
 import type { RecordId, TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
 import { toRecordId } from '@auxx/types/resource'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import { FieldValueService } from '../field-values/field-value-service'
@@ -53,13 +54,37 @@ async function getQuoteStatusAndRequest(
 }
 
 /**
+ * The bypass every quote lifecycle action carries
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4).
+ *
+ * 🛑 **Two chains guard `quote_status`, and only ONE of them is cleared structurally.**
+ * Writing through `FieldValueService` rather than `UnifiedCrudHandler` is what clears the
+ * system pre-hook (`resources/hooks/quote-hooks.ts`), which never runs for a
+ * `FieldValueService` write. But that is not the chain a drawer edit or a kanban drag takes,
+ * so `quote_status` also carries a FIELD pre-hook
+ * (`field-hooks/pre/lifecycle-status-guard.ts`) that DOES see these writes.
+ * `fireFieldPreHooks` short-circuits on `ctx.bypassFieldGuards.has(systemAttribute)` before
+ * any handler runs, so naming the attribute here is the whole mechanism — without it Send and
+ * Mark approved are refused by the wall built to protect them.
+ *
+ * It names `quote_status` and nothing else, matching `markPurchaseOrderSent`'s scoping:
+ * naming more would quietly disarm guards on fields these actions have no business writing.
+ *
+ * `declineQuote` carries it too, though `declined` is not currently a guarded value — the
+ * exemption belongs to the sanctioned WRITER rather than to today's value set, so adding
+ * `declined` to the wall later cannot silently break the action that produces it.
+ */
+const QUOTE_STATUS_BYPASS = new Set<SystemAttribute>(['quote_status'])
+
+/**
  * Mark a quote as sent (money MQ1 build spec §F.3). Bare status flip until MQ2 wraps
  * it with the real PDF/email send. Mirrors the linked request to `quoted` if present.
  *
- * Writes go through `FieldValueService` directly — this is the sanctioned writer the
- * `rejectManualLifecycleStatus` system pre-hook (resources/hooks/quote-hooks.ts) is
- * built to let through, since `FieldValueService` bypasses `UnifiedCrudHandler`'s
- * system pre-hook chain entirely (the M1 `converted`-mirror precedent).
+ * Writes go through `FieldValueService` directly — this is the sanctioned writer both
+ * `quote_status` guards are built to let through. `FieldValueService` bypasses
+ * `UnifiedCrudHandler`'s system pre-hook chain entirely (the M1 `converted`-mirror
+ * precedent), and {@link QUOTE_STATUS_BYPASS} clears the field pre-hook, which this write
+ * does reach.
  */
 export async function markQuoteSent(input: QuoteLifecycleInput): Promise<void> {
   const { organizationId, userId, quoteInstanceId } = input
@@ -73,7 +98,9 @@ export async function markQuoteSent(input: QuoteLifecycleInput): Promise<void> {
   )
   assertStatus(status, 'draft', 'mark as sent')
 
-  const fieldValueService = new FieldValueService(organizationId, userId)
+  const fieldValueService = new FieldValueService(organizationId, userId, undefined, undefined, {
+    bypassFieldGuards: QUOTE_STATUS_BYPASS,
+  })
   await fieldValueService.setValuesForEntity({
     recordId: quoteRecordId,
     values: [{ fieldId: 'quote_status', value: 'sent' }],
@@ -103,7 +130,9 @@ export async function approveQuote(input: QuoteLifecycleInput): Promise<void> {
   )
   assertStatus(status, 'sent', 'approve')
 
-  const fieldValueService = new FieldValueService(organizationId, userId)
+  const fieldValueService = new FieldValueService(organizationId, userId, undefined, undefined, {
+    bypassFieldGuards: QUOTE_STATUS_BYPASS,
+  })
   await fieldValueService.setValuesForEntity({
     recordId: quoteRecordId,
     values: [{ fieldId: 'quote_status', value: 'approved' }],
@@ -129,7 +158,9 @@ export async function declineQuote(input: QuoteLifecycleInput): Promise<void> {
   const { status } = await getQuoteStatusAndRequest(handler, organizationId, quoteRecordId)
   assertStatus(status, 'sent', 'decline')
 
-  const fieldValueService = new FieldValueService(organizationId, userId)
+  const fieldValueService = new FieldValueService(organizationId, userId, undefined, undefined, {
+    bypassFieldGuards: QUOTE_STATUS_BYPASS,
+  })
   await fieldValueService.setValuesForEntity({
     recordId: quoteRecordId,
     values: [{ fieldId: 'quote_status', value: 'declined' }],

--- a/packages/lib/src/resources/hooks/invoice-hooks.ts
+++ b/packages/lib/src/resources/hooks/invoice-hooks.ts
@@ -1,7 +1,11 @@
 // packages/lib/src/resources/hooks/invoice-hooks.ts
 
 import { recordNumbering } from '../../records/record-numbering'
-import { createLifecycleStatusGuard } from './lifecycle-status-guard'
+import {
+  createLifecycleStatusGuard,
+  INVOICE_ACTION_STATUS_MESSAGE,
+  INVOICE_ACTION_STATUSES,
+} from './lifecycle-status-guard'
 import type { SystemHook, SystemHookRegistry } from './types'
 
 /**
@@ -29,10 +33,17 @@ const autoGenerateInvoiceNumber: SystemHook = async ({
  * sanctioned writes. `draft` stays freely editable — the edit-sent-back-to-draft flow writes
  * plain status `'draft'` after a `useConfirm`, and un-void (manual `draft` write) both flow
  * through it.
+ *
+ * ⚠️ **This chain is coverage, not enforcement.** It runs for `record.create`/`record.update`,
+ * the CSV importer and the SDK — NOT for `fieldValue.set`, which is how the drawer, the grid's
+ * inline edit and a kanban drag write. Its field-chain twin
+ * (`field-hooks/pre/lifecycle-status-guard.ts`) is what stops a human typing `paid` with no
+ * payment behind it, and the two share their value set and message through the constants they
+ * both import.
  */
 const rejectManualLifecycleStatus: SystemHook = createLifecycleStatusGuard({
-  guardedValues: ['sent', 'partially_paid', 'paid', 'void'],
-  message: 'Use the invoice actions (Send / Record payment / Void) to set this status',
+  guardedValues: INVOICE_ACTION_STATUSES,
+  message: INVOICE_ACTION_STATUS_MESSAGE,
 })
 
 export const INVOICE_HOOKS: SystemHookRegistry = {

--- a/packages/lib/src/resources/hooks/lifecycle-status-guard.ts
+++ b/packages/lib/src/resources/hooks/lifecycle-status-guard.ts
@@ -19,6 +19,43 @@ export const PURCHASE_ORDER_ACTION_STATUSES = ['issued'] as const
 export const PURCHASE_ORDER_ACTION_STATUS_MESSAGE = 'Use Send to issue this purchase order'
 
 /**
+ * The `quote_status` values an ACTION owns (money MQ1 build spec §F.3). Same one-source rule
+ * as the purchase order's set above: the system pre-hook in `quote-hooks.ts` and the field
+ * pre-hook in `field-hooks/pre/lifecycle-status-guard.ts` both read this, so the two chains
+ * cannot drift into guarding different values.
+ *
+ * `draft`, `declined` and `canceled` stay freely editable. `declined` has a sanctioned writer
+ * (`declineQuote`) but no side effects a manual write would skip, and the edit-a-sent-quote
+ * flow writes plain `draft` after a `useConfirm` — that transition is walled separately, and
+ * only when money is at stake, by `pre/quote-deposit-guard.ts`.
+ */
+export const QUOTE_ACTION_STATUSES = ['sent', 'approved'] as const
+
+/** The one message both quote lifecycle guards throw. */
+export const QUOTE_ACTION_STATUS_MESSAGE =
+  'Use the quote actions (Send / Mark approved) to set this status'
+
+/**
+ * The `invoice_status` values an ACTION owns (money MI1 build spec §F.2).
+ *
+ * 🛑 `paid` and `partially_paid` are in here for a different and sharper reason than `sent`.
+ * They are LEDGER-DERIVED: `syncInvoicePaymentState` computes them from the
+ * `PaymentTransaction` rows and nothing else. A hand-set `paid` therefore records a settled
+ * bill with no payment behind it — no transaction, no allocation, no `invoice_amount_paid` —
+ * and every downstream read believes it. That is the one case in this file where an inert
+ * guard silently corrupts money rather than merely skipping a mirror
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §3).
+ *
+ * `draft` stays editable: both the edit-a-sent-invoice flow and un-voiding write it directly
+ * after a confirmation.
+ */
+export const INVOICE_ACTION_STATUSES = ['sent', 'partially_paid', 'paid', 'void'] as const
+
+/** The one message both invoice lifecycle guards throw. */
+export const INVOICE_ACTION_STATUS_MESSAGE =
+  'Use the invoice actions (Send / Record payment / Void) to set this status'
+
+/**
  * Reduce a status write to the bare value being set, whatever shape it arrives in.
  *
  * 🛑 The two chains hand a guard **different shapes**, and this is the whole reason the

--- a/packages/lib/src/resources/hooks/quote-hooks.ts
+++ b/packages/lib/src/resources/hooks/quote-hooks.ts
@@ -1,7 +1,11 @@
 // packages/lib/src/resources/hooks/quote-hooks.ts
 
 import { recordNumbering } from '../../records/record-numbering'
-import { createLifecycleStatusGuard } from './lifecycle-status-guard'
+import {
+  createLifecycleStatusGuard,
+  QUOTE_ACTION_STATUS_MESSAGE,
+  QUOTE_ACTION_STATUSES,
+} from './lifecycle-status-guard'
 import type { SystemHook, SystemHookRegistry } from './types'
 
 /**
@@ -28,10 +32,16 @@ const autoGenerateQuoteNumber: SystemHook = async ({
  * never sees the sanctioned write. `draft`/`declined`/`canceled` stay freely editable — the
  * edit-sent-back-to-draft flow writes plain status `'draft'` after a `useConfirm`, which this
  * guard also allows through.
+ *
+ * ⚠️ **This chain is coverage, not enforcement.** It runs for `record.create`/`record.update`,
+ * the CSV importer and the SDK — NOT for `fieldValue.set`, which is how the drawer, the grid's
+ * inline edit and a kanban drag write. Its field-chain twin
+ * (`field-hooks/pre/lifecycle-status-guard.ts`) is what stops a human typing `sent`, and the
+ * two share their value set and message through the constants they both import.
  */
 const rejectManualLifecycleStatus: SystemHook = createLifecycleStatusGuard({
-  guardedValues: ['sent', 'approved'],
-  message: 'Use the quote actions (Send / Mark approved) to set this status',
+  guardedValues: QUOTE_ACTION_STATUSES,
+  message: QUOTE_ACTION_STATUS_MESSAGE,
 })
 
 export const QUOTE_HOOKS: SystemHookRegistry = {


### PR DESCRIPTION
`quote_status` and `invoice_status` could be set by hand from the drawer, a kanban drag or any generic record edit. Every guard meant to stop that was inert, for **two independent reasons**.

Written up in `plans/dispatch/money/21-lifecycle-status-guards-are-inert.md` (untracked). The purchase-order half was fixed first in #1939; this generalises it.

## The two defects

**A — wrong chain.** The guards were `SystemHookRegistry` entries, which only `UnifiedCrudHandler.runPreHooks` executes. The interactive path is `fieldValue.set` → `FieldValueService` → `fireFieldPreHooks` and never touches it. This was already written down in `quote-deposit-guard.ts` for one field; the conclusion — *every* lifecycle guard on that chain is decorative for client writes — was never drawn.

**B — wrong shape.** The field chain runs after `validateAndConvertValue`, so a SINGLE_SELECT arrives as `{ type: 'option', optionId }`, never a bare string. `guardQuoteDraftReturnWithPaidDeposit` compared it to `'draft'`, so the condition could not be true: **it returned early on every write and had never fired.** It looks correct, reads correctly in review, and passes a unit test that feeds it a bare string.

Net effect: an invoice could be typed to `paid` with no `PaymentTransaction`, no allocation and no `amount_paid` behind it, and the bill read settled. A paid quote could be edited back to `draft`, orphaning its deposit — the exact thing the file named `quote-deposit-guard.ts` exists to stop.

## What this does

🛑 **Both halves land together, because half of this fix is worse than none.** The moment a guard starts working, a sanctioned writer without a bypass is refused by the wall built to protect it — Send stops working, with nothing to see until somebody presses the button.

- **Field pre-hooks** for `quote_status` (`sent`, `approved`) and `invoice_status` (`sent`, `partially_paid`, `paid`, `void`), built from one factory shared with `purchase_order_status`. Value sets and messages are exported constants both chains read, so the two cannot drift into guarding different things.
- **`bypassFieldGuards` on all six sanctioned writers**, each naming exactly one attribute: `markQuoteSent` / `approveQuote` / `declineQuote`, `markInvoiceSent` / `voidInvoice`, and `syncInvoicePaymentState` — the ledger projection, the only writer of `paid` / `partially_paid`.
- **The deposit guard unwraps the envelope.** One line.
- System-chain guards **kept**: `record.create`/`record.update`, the importer and the SDK are the only door they cover, and removing them narrows coverage.

## The durable half is the type

`FieldPreHookEvent.newValue` was `unknown`, which is what permitted a comparison that can never be true. It is now `TypedFieldValueInput | TypedFieldValueInput[] | null`, so that comparison is `error TS2367: … have no overlap`. `fireFieldPreHooks` stopped widening and its trailing cast is gone.

✅ The widening was gratuitous: **11 errors across 2 files, none of them a production guard.** Ten were in `field-hooks/__tests__/registry.test.ts`, passing bare strings as chain sentinels — precisely the test shape that proves nothing, caught the first time the type could see it. That is the audit of every other field pre-hook, answered by construction rather than by reading.

## Two things to look at

⚠️ **A create can no longer start in a guarded state.** The system chain exempts `operation === 'create'`; the field chain has no such notion. So `record.create` with `invoice_status: 'paid'` is now refused. Correct for this defect — a created-paid invoice is the same corruption — and it is what `purchase_order_status` already shipped. But it means **the importer can no longer bring in historic invoices carrying a non-draft status**. If that matters, the answer is an explicit action with its own ledger side effects, not a create carve-out.

⚠️ **`declineQuote` carries a bypass for a value that is not guarded.** Deliberate: the exemption belongs to the sanctioned *writer*, not to today's value set, so guarding `declined` later cannot silently break the action that produces it. This does not extend to naming extra attributes — every bypass here is a one-element set, asserted as such.

## Verification

- `pnpm exec vitest run` in `packages/lib` — green (full suite).
- `node scripts/ci/typecheck-ratchet.js --package lib` and `--package web` — no new errors.
- 44 new tests. **Every rejection case feeds the coerced envelope**, because a test that feeds a bare string passes against both the broken and the fixed version — that is how defect B survived. The deposit-guard test is mutation-checked against the shipped implementation.
- Bypass presence, scope (`size === 1`) and the "refused without it" counterpart are asserted per writer.

🛑 **Not driven in a browser.** Nobody has typed `paid` into a drawer and watched it refused, or pressed Send and watched it still work. The second is the one that would break loudly, and no unit test can see past its own mock of `FieldValueService`.