### PR TITLE
feat(records): a related record opens in the drawer instead of navigating away

### DIFF
--- a/apps/web/src/components/drawers/cards/part-family-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-family-card.tsx
@@ -17,18 +17,13 @@ import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { pluralize } from '@auxx/utils'
 import { Package, Sparkles } from 'lucide-react'
-import Link from 'next/link'
 import { useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
-import {
-  toRecordId,
-  useRecordLink,
-  useRecordList,
-  useResourceProperty,
-} from '~/components/resources'
+import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveSystemValues } from '~/components/resources/hooks/use-save-system-values'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { RecordLink } from '~/components/resources/ui/record-link'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import {
   isPartKindUnset,
@@ -120,7 +115,6 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
   })
   const productTitle = productValues.product_title as string | undefined
   const productStatus = productValues.product_status as string | undefined
-  const productLink = useRecordLink(productRecordId)
 
   // Sibling variants: every part on the same family edge, this one included.
   const siblingFilters: ConditionGroup[] = useMemo(
@@ -237,13 +231,9 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
       <FieldPanel resizeId='part-family' defaultLabelWidth={130}>
         <FieldPanelRow title='Product'>
           <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm'>
-            {productLink ? (
-              <Link href={productLink} className='truncate font-medium hover:underline'>
-                {productTitle ?? 'Loading...'}
-              </Link>
-            ) : (
-              <span className='truncate font-medium'>{productTitle ?? 'Loading...'}</span>
-            )}
+            <RecordLink recordId={productRecordId} className='truncate font-medium' openInStack>
+              {productTitle ?? 'Loading...'}
+            </RecordLink>
             {statusMeta && (
               <Badge variant={(statusMeta.color ?? 'gray') as Variant} size='xs'>
                 {statusMeta.label}
@@ -272,11 +262,13 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
                       </span>
                     </span>
                   ) : (
-                    <SiblingLink
+                    <RecordLink
                       key={sibling.id}
                       recordId={toRecordId(partDefId ?? 'part', sibling.id)}
-                      label={sibling.displayName ?? 'Untitled'}
-                    />
+                      className='truncate'
+                      openInStack>
+                      {sibling.displayName ?? 'Untitled'}
+                    </RecordLink>
                   )
                 )}
                 {hiddenSiblingCount > 0 && !showAllSiblings && (
@@ -311,23 +303,5 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
         </div>
       )}
     </div>
-  )
-}
-
-/**
- * One sibling variant's link.
- *
- * A component rather than an inline `<Link>` because `useRecordLink` is a hook
- * and this renders in a loop. The href it builds resolves through
- * `resourceHasDetailPage`; the hand-written `/app/parts?id=` it replaced was a
- * path nothing would have flagged if part routing ever moved.
- */
-function SiblingLink({ recordId, label }: { recordId: RecordId; label: string }) {
-  const href = useRecordLink(recordId)
-  if (!href) return <span className='truncate'>{label}</span>
-  return (
-    <Link href={href} className='truncate hover:underline'>
-      {label}
-    </Link>
   )
 }

--- a/apps/web/src/components/drawers/cards/product-vendor-card.tsx
+++ b/apps/web/src/components/drawers/cards/product-vendor-card.tsx
@@ -43,7 +43,12 @@ export function ProductVendorCard({ recordId }: DrawerTabProps) {
     <FieldPanel resizeId='product-vendor' defaultLabelWidth={130}>
       <FieldPanelRow title='Vendor'>
         <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm'>
-          <RecordBadge recordId={vendorRecordId} variant='link' link={{ tab: 'overview' }} />
+          <RecordBadge
+            recordId={vendorRecordId}
+            variant='link'
+            link={{ tab: 'overview' }}
+            openInStack
+          />
         </div>
       </FieldPanelRow>
     </FieldPanel>

--- a/apps/web/src/components/drawers/cards/ticket-relationships-card.tsx
+++ b/apps/web/src/components/drawers/cards/ticket-relationships-card.tsx
@@ -55,7 +55,7 @@ export function TicketRelationshipsCard({ recordId }: DrawerTabProps) {
           </div>
           <div className='space-y-1'>
             {parentRecordIds.map((id) => (
-              <RecordBadge key={id} recordId={id} link />
+              <RecordBadge key={id} recordId={id} link openInStack />
             ))}
           </div>
         </div>
@@ -71,7 +71,7 @@ export function TicketRelationshipsCard({ recordId }: DrawerTabProps) {
           </div>
           <div className='space-y-1'>
             {childRecordIds.map((id) => (
-              <RecordBadge key={id} recordId={id} link />
+              <RecordBadge key={id} recordId={id} link openInStack />
             ))}
           </div>
         </div>

--- a/apps/web/src/components/drawers/tabs/contact-parts-tab-row.tsx
+++ b/apps/web/src/components/drawers/tabs/contact-parts-tab-row.tsx
@@ -59,7 +59,7 @@ export function ContactVendorPartRow({
       <TableCell className='font-medium'>
         <div className='flex items-center gap-2'>
           {partId ? (
-            <RecordBadge recordId={partId} variant='link' link={{ tab: 'vendors' }} />
+            <RecordBadge recordId={partId} variant='link' link={{ tab: 'vendors' }} openInStack />
           ) : (
             <span className='text-muted-foreground'>—</span>
           )}

--- a/apps/web/src/components/drawers/tabs/part-subparts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-subparts-tab.tsx
@@ -26,13 +26,13 @@ import { toastError } from '@auxx/ui/components/toast'
 import { pluralize } from '@auxx/utils'
 import { formatCurrency } from '@auxx/utils/currency'
 import { CircleAlert, Edit, MoreHorizontal, Package, PlusCircle, Trash2 } from 'lucide-react'
-import Link from 'next/link'
 import { useCallback, useMemo, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { SubpartDialog } from '~/components/manufacturing/parts/subpart-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { RecordLink } from '~/components/resources/ui/record-link'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
@@ -471,9 +471,13 @@ function PartNameCell({ partId, linkTab }: { partId: string; linkTab: string }) 
 
   return (
     <div className='flex flex-col'>
-      <Link href={`/app/parts?id=${partId}&tab=${linkTab}`} className='truncate hover:underline'>
+      <RecordLink
+        recordId={partRecordId || undefined}
+        link={{ tab: linkTab }}
+        className='truncate'
+        openInStack>
         {title ?? 'Loading...'}
-      </Link>
+      </RecordLink>
       {sku && <span className='text-xs text-muted-foreground'>{sku}</span>}
     </div>
   )

--- a/apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
+++ b/apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
@@ -112,7 +112,12 @@ export function VendorPartRow({
       <TableCell className='font-medium'>
         <div className='flex items-center gap-2'>
           {supplierRecordId ? (
-            <RecordBadge recordId={supplierRecordId} variant='link' link={{ tab: 'parts' }} />
+            <RecordBadge
+              recordId={supplierRecordId}
+              variant='link'
+              link={{ tab: 'parts' }}
+              openInStack
+            />
           ) : (
             <span className='text-muted-foreground'>—</span>
           )}

--- a/apps/web/src/components/drawers/tabs/product-parts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/product-parts-tab.tsx
@@ -28,13 +28,11 @@ import { toastError } from '@auxx/ui/components/toast'
 import { pluralize } from '@auxx/utils'
 import { formatCurrency } from '@auxx/utils/currency'
 import { Link2, MoreHorizontal, Package, Plus, Unlink } from 'lucide-react'
-import Link from 'next/link'
 import { useCallback, useMemo, useState } from 'react'
 import { PartFormDialog } from '~/components/manufacturing/parts/part-form-dialog'
 import {
   type RecordMeta,
   toRecordId,
-  useRecordLink,
   useRecordList,
   useResource,
   useResourceProperty,
@@ -42,6 +40,7 @@ import {
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 import { RecordIcon } from '~/components/resources/ui/record-icon'
+import { RecordLink } from '~/components/resources/ui/record-link'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useAccess } from '~/providers/capabilities-provider'
 import type { DrawerTabProps } from '../drawer-tab-registry'
@@ -412,7 +411,6 @@ function ProductPartRow({
   canEdit,
   onDetach,
 }: ProductPartRowProps) {
-  const href = useRecordLink(recordId)
   const { cost, quantityOnHand, kind, priceCents, catalogItemCount, priceLoaded } = values
   const kindMeta = kind ? PART_KIND_BY_VALUE[kind] : undefined
   const title = record.displayName ?? 'Untitled'
@@ -423,13 +421,9 @@ function ProductPartRow({
         <div className='flex items-center gap-2'>
           <RecordIcon avatarUrl={record.avatarUrl} iconId={iconId} color={color} size='sm' />
           <div className='flex min-w-0 flex-col'>
-            {href ? (
-              <Link href={href} className='truncate hover:underline'>
-                {title}
-              </Link>
-            ) : (
-              <span className='truncate'>{title}</span>
-            )}
+            <RecordLink recordId={recordId} className='truncate' openInStack>
+              {title}
+            </RecordLink>
             {record.secondaryInfo && (
               <span className='truncate text-xs text-muted-foreground'>{record.secondaryInfo}</span>
             )}

--- a/apps/web/src/components/records/record-drill-panels.tsx
+++ b/apps/web/src/components/records/record-drill-panels.tsx
@@ -329,3 +329,35 @@ export function useOpenRecord(): ((recordId: RecordId) => void) | null {
   const ctx = React.useContext(RecordStackContext)
   return ctx?.push ?? null
 }
+
+/**
+ * `onClick` for a record LINK (`RecordBadge`, `RecordLink`) that should push a
+ * peek frame instead of navigating — the opt-in half of `useOpenRecord`.
+ *
+ * Two gates, both required. `enabled` is the call site's explicit opt-in, so
+ * adopting this never changes a link the author did not convert; the
+ * `RecordStackProvider` check then keeps the same component honest on surfaces
+ * with no stack to push onto (the detail page's sidebar mounts several of the
+ * very same cards), where it degrades to the plain link it always was.
+ *
+ * Modifier and non-primary clicks always fall through to the browser, so the
+ * element stays a real `<a href>` and cmd-/middle-click still opens a tab.
+ */
+export function useOpenRecordLinkClick(
+  recordId: RecordId | null | undefined,
+  enabled: boolean | undefined
+): ((event: React.MouseEvent) => void) | undefined {
+  const openRecord = useOpenRecord()
+  const push = enabled ? openRecord : null
+
+  return React.useMemo(() => {
+    if (!push || !recordId) return undefined
+    return (event: React.MouseEvent) => {
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+        return
+      }
+      event.preventDefault()
+      push(recordId)
+    }
+  }, [push, recordId])
+}

--- a/apps/web/src/components/resources/ui/record-badge.tsx
+++ b/apps/web/src/components/resources/ui/record-badge.tsx
@@ -15,6 +15,7 @@ import { X } from 'lucide-react'
 import Link from 'next/link'
 
 // Hook imports
+import { useOpenRecordLinkClick } from '~/components/records/record-drill-panels'
 import { useRecord, useResource } from '~/components/resources'
 import { type GetRecordLinkOptions, useRecordLink } from '../utils/get-record-link'
 import { RecordHoverCard } from './record-hover-card'
@@ -84,6 +85,18 @@ interface RecordBadgeProps extends VariantProps<typeof recordBadgeVariants> {
   hoverCard?: boolean | RecordBadgeHoverCardConfig
   /** When set, renders a trailing X button that fires this handler on click. */
   onRemove?: () => void
+  /**
+   * Opt in to opening the record IN PLACE — a left-click pushes it onto the
+   * enclosing drawer's peek stack instead of navigating away.
+   *
+   * Off by default on purpose: most badges (timeline chips, table cells,
+   * field-panel values, Kopilot blocks) render inside a drawer too, and their
+   * navigation is deliberate. Only opt in where staying in the drawer is the
+   * point. Requires `link` — a badge with no href has nothing to intercept —
+   * and no-ops outside a `RecordStackProvider`, so the same component still
+   * navigates normally on a detail page.
+   */
+  openInStack?: boolean
 }
 
 /**
@@ -115,6 +128,10 @@ interface RecordBadgeProps extends VariantProps<typeof recordBadgeVariants> {
  * @example
  * // As a link with custom options
  * <RecordBadge recordId={recordId} variant="link" link={{ tab: 'activity', action: 'edit' }} />
+ *
+ * @example
+ * // Inside a drawer: open the record in place instead of navigating
+ * <RecordBadge recordId={recordId} variant="link" link openInStack />
  */
 export function RecordBadge({
   recordId,
@@ -125,6 +142,7 @@ export function RecordBadge({
   link,
   hoverCard = true,
   onRemove,
+  openInStack,
   ...props
 }: RecordBadgeProps) {
   // Fetch record data (displayName, avatarUrl)
@@ -143,6 +161,10 @@ export function RecordBadge({
   // Generate link if link prop is provided
   const linkOptions = typeof link === 'object' ? link : undefined
   const href = useRecordLink(link ? recordId : null, linkOptions)
+
+  // `undefined` unless the call site opted in AND a record stack is mounted, in
+  // which case a plain left-click pushes a peek frame instead of navigating.
+  const handleStackOpen = useOpenRecordLinkClick(recordId, openInStack)
 
   // Determine display name
   const displayName = isNotFound ? 'Unknown' : (record?.displayName ?? 'Unknown')
@@ -201,6 +223,7 @@ export function RecordBadge({
         aria-busy={isLoading}
         href={href}
         className={badgeClassName}
+        onClick={handleStackOpen}
         {...props}>
         {badgeContent}
       </Link>

--- a/apps/web/src/components/resources/ui/record-link.tsx
+++ b/apps/web/src/components/resources/ui/record-link.tsx
@@ -1,0 +1,46 @@
+// apps/web/src/components/resources/ui/record-link.tsx
+'use client'
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import { cn } from '@auxx/ui/lib/utils'
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { useOpenRecordLinkClick } from '~/components/records/record-drill-panels'
+import { type GetRecordLinkOptions, useRecordLink } from '../utils/get-record-link'
+
+interface RecordLinkProps {
+  recordId?: RecordId | null
+  /** Link text (or any inline content). */
+  children: ReactNode
+  /** Applied to both the anchor and the no-href fallback; the anchor also gets `hover:underline`. */
+  className?: string
+  /** Link-builder options, e.g. `{ tab: 'vendors' }`. */
+  link?: GetRecordLinkOptions
+  /** See `RecordBadge.openInStack` — opt in to opening in the drawer's peek stack. */
+  openInStack?: boolean
+}
+
+/**
+ * A record's display name as a link to its detail page.
+ *
+ * The text-only sibling of `RecordBadge` (no icon, no hover card), for table
+ * cells and field-panel rows where a badge would be too heavy. Exists as a
+ * component rather than an inline `<Link>` because both `useRecordLink` and
+ * `useOpenRecordLinkClick` are hooks and these render in loops.
+ *
+ * The href resolves through `resourceHasDetailPage`, so a definition with no
+ * detail page degrades to plain text instead of a 404 — which is why the
+ * hand-written `/app/parts?id=` paths this replaced were a hazard.
+ */
+export function RecordLink({ recordId, children, className, link, openInStack }: RecordLinkProps) {
+  const href = useRecordLink(recordId ?? null, link)
+  const handleStackOpen = useOpenRecordLinkClick(recordId, openInStack)
+
+  if (!href) return <span className={className}>{children}</span>
+
+  return (
+    <Link href={href} className={cn(className, 'hover:underline')} onClick={handleStackOpen}>
+      {children}
+    </Link>
+  )
+}


### PR DESCRIPTION
## What

The drawer already had two drill layers — the cross-record peek stack (`useOpenRecord`/`?peek=`) and the per-entityType drill panels (`?panel=`/`?item=`) — but only the work-order Schedule and Billing cards ever called them. Every part, product and supplier row still shipped a plain `<Link>`, so drilling from a part to its supplier, or from an assembly to a component, closed the drawer and did a full page nav.

This wires those rows through the peek stack, as an **opt-in**.

## How

**`useOpenRecordLinkClick(recordId, enabled)`** — sits next to `useOpenRecord` in `record-drill-panels.tsx`, returns an `onClick` or `undefined`. Two gates:

1. the call site's explicit opt-in, so adopting this never changes a link the author didn't convert;
2. the `RecordStackProvider` check, so a card shared with the detail-view sidebar (`product:vendor`, `product:summary`) degrades to the link it always was.

Modifier and non-primary clicks fall through to the browser, so the element stays a real `<a href>` and cmd-/middle-click still opens a tab.

**`RecordBadge.openInStack`** — off by default. Ambient behavior was the obvious implementation and the wrong one: `timeline/event-description.tsx`, `dynamic-table/utils/cell-renderers.tsx` and the Kopilot blocks all pass `link` and all render inside drawers, and their navigation is deliberate. Only intercepts when `link && href`, so badges without a link prop are untouched.

**`RecordLink`** (new) — the text-only sibling of `RecordBadge` for table cells and field-panel rows where a badge is too heavy. Absorbs three near-identical one-off components; `SiblingLink` in `part-family-card` collapsed into it exactly and is gone.

## Opt-ins

| Surface | Drills to |
| --- | --- |
| `part-vendors-tab-row` | supplier → `company` |
| `contact-parts-tab-row` | → `part` |
| `part-subparts-tab` (`PartNameCell`) | component / assembly → `part` |
| `product-parts-tab` (`ProductPartRow`) | variant → `part` |
| `part-family-card` (product + siblings) | → `product` / `part` |
| `product-vendor-card` | → `company` |
| `ticket-relationships-card` | parent / child → `ticket` |

Timeline chips, dynamic-table cells and Kopilot blocks keep navigating.

## Drive-by

`PartNameCell` was hardcoding \`/app/parts?id=\${partId}&tab=\${linkTab}\` — the list-drawer URL — for a definition with \`hasDetailPage: true\`. It routes through \`useRecordLink\` now. \`part-family-card\` had flagged that exact path shape as a hazard in a comment but hadn't fixed it here.

## Not in scope

A \`vendor_part\` drill panel for the landed-cost breakdown, which today only exists as a hover tooltip in \`part-vendors-tab-row\` (invisible on touch, not linkable). \`vendor_part\` and \`subpart\` are join records with no \`DRAWER_CONFIG_REGISTRY\` entry, so peeking one gives a bare generic frame — they want a registered drill panel instead, in the shape \`work_order\`'s \`invoices\` panel uses.

## Testing

- \`pnpm --filter @auxx/web typecheck\` — exit 0
- \`biome check\` clean on all 10 files
- \`vitest run src/components/drawers src/components/resources src/components/records\` — 31 files, 267 tests pass