### PR TITLE
feat(build): seed the build entity and standard-cost fields, inert

### DIFF
--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -151,6 +151,7 @@ export const ModelTypeValues = [
   'vendor_payment_allocation',
   'gl_account',
   'gl_posting_line',
+  'build',
 ] as const
 
 /**
@@ -203,6 +204,7 @@ export const ModelTypes = {
   VENDOR_PAYMENT_ALLOCATION: 'vendor_payment_allocation',
   GL_ACCOUNT: 'gl_account',
   GL_POSTING_LINE: 'gl_posting_line',
+  BUILD: 'build',
 } as const
 
 /**
@@ -583,6 +585,19 @@ export const ModelTypeMeta: Record<
     apiSlug: 'gl-posting-lines',
     dbTable: 'EntityInstance',
     hasDetailPage: false,
+  },
+  build: {
+    label: 'Build',
+    plural: 'Builds',
+    icon: 'hammer',
+    color: 'orange',
+    apiSlug: 'builds',
+    dbTable: 'EntityInstance',
+    // A build is raised, worked and completed against — the `quote` / `order`
+    // shape (plans/products/build/01-build-plan.md §1.1). Seeded
+    // `isVisible: false` by entity migration 109 and flipped in phase 2, when
+    // there is a UI and a way to create a row.
+    hasDetailPage: true,
   },
 }
 

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -773,3 +773,46 @@ export const GlPostingLineDirection = {
     { value: 'credit', label: 'Credit', color: 'purple' },
   ] satisfies FieldOptionItem[],
 } as const
+
+/**
+ * Build Status
+ * plans/products/build/01-build-plan.md §1.1.
+ *
+ * `planned` -> `in_progress` -> `completed` | `canceled`. A `planned` build
+ * writes NO stock movements (README B2) — that is the safety property the whole
+ * phasing rests on, and it is why `createBuild` can ship before
+ * `part_standard_cost` has a single writer. `completed` is terminal: a
+ * completed build is never edited or deleted, it is REVERSED by a second build
+ * carrying the original's frozen costs (B6).
+ */
+export const BuildStatus = {
+  PLANNED: 'planned',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+  CANCELED: 'canceled',
+
+  values: [
+    { value: 'planned', label: 'Planned', color: 'gray' },
+    { value: 'in_progress', label: 'In Progress', color: 'blue' },
+    { value: 'completed', label: 'Completed', color: 'green' },
+    { value: 'canceled', label: 'Canceled', color: 'red' },
+  ] satisfies FieldOptionItem[],
+} as const
+
+/**
+ * Build Source
+ * plans/products/build/01-build-plan.md §1.1, plans/products/12 AB7.
+ *
+ * An auto-raised build must be distinguishable from one a person raised against
+ * the same order deliberately — without that, "cancel the builds this order
+ * caused" cannot tell the two apart and would revoke a human decision.
+ */
+export const BuildSource = {
+  MANUAL: 'manual',
+  ORDER: 'order',
+
+  values: [
+    { value: 'manual', label: 'Manual', color: 'gray' },
+    { value: 'order', label: 'Order', color: 'blue' },
+  ] satisfies FieldOptionItem[],
+} as const

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -5,6 +5,7 @@ import type { FieldId } from '@auxx/types/field'
 import { ENTITY_DEFINITION_TYPES } from '@auxx/types/resource'
 import type { ResourceField, ResourceFieldRegistry, ResourceTableDefinition } from './field-types'
 import { ARTICLE_FIELDS } from './resources/article-fields'
+import { BUILD_FIELDS } from './resources/build-fields'
 import { CATALOG_GROUP_FIELDS } from './resources/catalog-group-fields'
 import { CATALOG_ITEM_FIELDS } from './resources/catalog-item-fields'
 import { COMPANY_FIELDS } from './resources/company-fields'
@@ -150,6 +151,7 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   vendor_payment_allocation: VENDOR_PAYMENT_ALLOCATION_FIELDS,
   gl_account: GL_ACCOUNT_FIELDS,
   gl_posting_line: GL_POSTING_LINE_FIELDS,
+  build: BUILD_FIELDS,
 }
 
 /**

--- a/packages/lib/src/resources/registry/resources/build-fields.ts
+++ b/packages/lib/src/resources/registry/resources/build-fields.ts
@@ -1,0 +1,681 @@
+// packages/lib/src/resources/registry/resources/build-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import { BuildSource, BuildStatus } from '../enum-values'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Build resource — the event that turns components
+ * into a finished good and writes down what it cost
+ * (plans/products/build/01-build-plan.md §1.1).
+ *
+ * The system has a costing calculator and no cost HISTORY. `part_cost` is a
+ * live mirror: a vendor raising the motor price in March silently restates
+ * January's COGS, because not one link in the chain is frozen. A build is what
+ * finally freezes one — it stamps each consumed component's
+ * `part_standard_cost` onto an append-only `stock_movement` row that is never
+ * recomputed.
+ *
+ * ## The three properties that make the rest of this file read correctly
+ *
+ * **A `planned` build writes no movements** (README B2). `completeBuild` is the
+ * only function that writes, and it is gated on a real standard cost. That is
+ * why this entity, its UI and the auto-build trigger can all ship and be used
+ * before `part_standard_cost` has a writer — nothing can produce a wrong number
+ * early.
+ *
+ * **A completed build is never edited or deleted — it is reversed** (B6) by a
+ * second build with sign-negated movements carrying the ORIGINAL's frozen
+ * costs. That is what `reversalOf` / `reversedBy` are for, and it is why every
+ * cost field here is `updatable: false`.
+ *
+ * **Scrapped units consume material and produce nothing** (B7). Their cost
+ * falls out in `varianceAmount` rather than being absorbed into the surviving
+ * units, because absorbing it would give the same variant a different unit cost
+ * on every run and destroy the point of a standard.
+ *
+ * Money is stored in **integer minor units** (`materialCost`, `laborCost`,
+ * `overheadCost`, `producedValue`, `varianceAmount`).
+ *
+ * ⚠️ Ships INERT with entity migration 109 (`isVisible: false`, B10): the def
+ * and every field below exist in each org and NOTHING writes them until
+ * `packages/lib/src/builds/` lands. A def with zero rows can be reshaped for
+ * free; the first row ends that.
+ *
+ * ## Visibility
+ *
+ * Declared at creation time on purpose (§1.6). `showInDialogs` on a
+ * materialized field lives in the `options` JSONB written when the field is
+ * created, so getting it wrong here costs a second migration — there are
+ * already two in the tree that exist only to do that. Exactly four fields reach
+ * the create dialog: `number`, `part`, `quantityPlanned`, `notes`, which is the
+ * whole of what raising a build should ask for.
+ */
+export const BUILD_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique build identifier',
+  },
+
+  number: {
+    id: toFieldId('number'),
+    key: 'number',
+    label: 'Number',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'build_number',
+    systemSortOrder: 'a1',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      // RecordSequence-issued, the `order` / `purchase_order` precedent — the
+      // hook is the ONLY writer. It seeds the QuickBooks `DocNumber` later.
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Auto-generated build number — RecordSequence scope `build`, prefix `B`',
+  },
+
+  part: {
+    id: toFieldId('part'),
+    key: 'part',
+    label: 'Part',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'build_part',
+    systemSortOrder: 'a2',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      // Not updatable: the finished good is what the whole costing run is
+      // computed against, so changing it after the fact would leave the frozen
+      // movements pointing at a different part than the build claims.
+      updatable: false,
+      required: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'part:builds' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'part',
+      relationshipType: 'belongs_to',
+      inverseName: 'Builds',
+      inverseSystemAttribute: 'part_builds',
+    },
+    placeholder: 'Select part',
+    description: 'The finished good this build produces',
+  },
+
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'build_status',
+    systemSortOrder: 'a3',
+    nullable: true,
+    // `createBuild` always starts at `planned` (B2) — the same reason
+    // `work_order_status` is hidden from the new-job dialog.
+    showInDialogs: false,
+    options: { options: BuildStatus.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select status',
+    defaultValue: 'planned',
+    description: 'Where the build sits — planned, in progress, completed or canceled',
+  },
+
+  quantityPlanned: {
+    id: toFieldId('quantityPlanned'),
+    key: 'quantityPlanned',
+    label: 'Quantity Planned',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'build_quantity_planned',
+    systemSortOrder: 'a4',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter quantity to build',
+    description: 'How many units this run intends to produce',
+  },
+
+  quantityProduced: {
+    id: toFieldId('quantityProduced'),
+    key: 'quantityProduced',
+    label: 'Quantity Produced',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'build_quantity_produced',
+    systemSortOrder: 'a5',
+    nullable: true,
+    showInDialogs: false, // set by the completion form, not at creation
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Good units that entered finished goods — the quantity of the produce movement',
+  },
+
+  quantityScrapped: {
+    id: toFieldId('quantityScrapped'),
+    key: 'quantityScrapped',
+    label: 'Quantity Scrapped',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'build_quantity_scrapped',
+    systemSortOrder: 'a6',
+    nullable: true,
+    showInDialogs: false, // set by the completion form, not at creation
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Units started but lost (B7). They consume material and produce NO movement — their ' +
+      'cost falls out in varianceAmount rather than being absorbed into the survivors',
+  },
+
+  startedAt: {
+    id: toFieldId('startedAt'),
+    key: 'startedAt',
+    label: 'Started',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'build_started_at',
+    systemSortOrder: 'a7',
+    nullable: true,
+    showInDialogs: false, // stamped by `startBuild`
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'When the run moved to in progress',
+  },
+
+  completedAt: {
+    id: toFieldId('completedAt'),
+    key: 'completedAt',
+    label: 'Completed',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'build_completed_at',
+    systemSortOrder: 'a8',
+    nullable: true,
+    showInDialogs: false, // stamped by `completeBuild`
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'THE accounting date — what every movement this build writes carries as its occurredAt, ' +
+      'and therefore which period the cost lands in',
+  },
+
+  materialCost: {
+    id: toFieldId('materialCost'),
+    key: 'materialCost',
+    label: 'Material Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'build_material_cost',
+    systemSortOrder: 'a9',
+    nullable: true,
+    showInDialogs: false, // computed at completion
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Sum of the consumed rows extended standard cost, integer minor units — written by ' +
+      'completeBuild and never recomputed',
+  },
+
+  laborCost: {
+    id: toFieldId('laborCost'),
+    key: 'laborCost',
+    label: 'Labor Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'build_labor_cost',
+    systemSortOrder: 'aA',
+    nullable: true,
+    showInDialogs: false, // computed at completion
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Absorbed direct labour for this run, integer minor units — the org rate ' +
+      '`manufacturing.assemblyLaborCostPerUnit` applied to the units started',
+  },
+
+  overheadCost: {
+    id: toFieldId('overheadCost'),
+    key: 'overheadCost',
+    label: 'Overhead Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'build_overhead_cost',
+    systemSortOrder: 'aB',
+    nullable: true,
+    showInDialogs: false, // computed at completion
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Applied overhead for this run, integer minor units — the org rate ' +
+      '`manufacturing.overheadCostPerUnit` applied to the units started',
+  },
+
+  producedValue: {
+    id: toFieldId('producedValue'),
+    key: 'producedValue',
+    label: 'Produced Value',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'build_produced_value',
+    systemSortOrder: 'aC',
+    nullable: true,
+    showInDialogs: false, // computed at completion
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'quantityProduced x the finished goods frozen part_standard_cost — what actually ' +
+      'entered inventory, integer minor units',
+  },
+
+  varianceAmount: {
+    id: toFieldId('varianceAmount'),
+    key: 'varianceAmount',
+    label: 'Variance',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'build_variance_amount',
+    systemSortOrder: 'aD',
+    nullable: true,
+    showInDialogs: false, // computed at completion
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    // Stays in the panel, unlike the part's five cost rows: the variance is the
+    // number a person actually reads on a build.
+    description:
+      '(material + labor + overhead) - producedValue, integer minor units. Account 5090. ' +
+      'This is what scrap and yield loss show up as — it is meaningless the moment a ' +
+      'structural roll-up error is booked to it (README B11)',
+  },
+
+  order: {
+    id: toFieldId('order'),
+    key: 'order',
+    label: 'Order',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'build_order',
+    systemSortOrder: 'aE',
+    nullable: true,
+    // Real provenance — WHICH order caused this build. Set by the trigger
+    // (plans/products/12 §5.3), never picked out of a create dialog.
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'order:builds' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'order',
+      relationshipType: 'belongs_to',
+      inverseName: 'Builds',
+      inverseSystemAttribute: 'order_builds',
+    },
+    description:
+      'The order this build was raised for. Without it, "cancel the builds for this order" ' +
+      'has nothing to look up (plans/products/12 AB7)',
+  },
+
+  source: {
+    id: toFieldId('source'),
+    key: 'source',
+    label: 'Source',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'build_source',
+    systemSortOrder: 'aF',
+    nullable: true,
+    // An internal discriminator, so it is out of the panel and the dialog — but
+    // it IS the one useful column here, so an auto-build is distinguishable at a
+    // glance in the list. This is the single field in migration 109 where the
+    // table default deliberately diverges from the panel default.
+    showInPanel: false,
+    showInTable: true,
+    showInDialogs: false,
+    options: { options: BuildSource.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    defaultValue: 'manual',
+    description:
+      'Who raised this build. An auto-build must be distinguishable from one a person raised ' +
+      'against the same order deliberately (plans/products/12 AB7)',
+  },
+
+  notes: {
+    id: toFieldId('notes'),
+    key: 'notes',
+    label: 'Notes',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'build_notes',
+    systemSortOrder: 'aG',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter notes',
+    description: 'Free text about this run',
+  },
+
+  postedAt: {
+    id: toFieldId('postedAt'),
+    key: 'postedAt',
+    label: 'Posted',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'build_posted_at',
+    systemSortOrder: 'aH',
+    nullable: true,
+    // 🛑 "Denormalized convenience only — never gate on it." A VISIBLE field
+    // invites exactly the gating that warning exists to prevent, so it is out of
+    // both the panel and the dialog. Not `capabilities.hidden` — it stays
+    // findable in the field picker for anyone who deliberately wants it.
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Denormalized convenience only — never gate on it. The gl_posting rows are the truth ' +
+      'about whether this build has been posted',
+  },
+
+  // ─── Relationship inverses and the reversal pair ───────────────────
+
+  movements: {
+    id: toFieldId('movements'),
+    key: 'movements',
+    label: 'Stock Movements',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'build_movements',
+    systemSortOrder: 'aI',
+    nullable: true,
+    showInPanel: false, // has_many; a card lists them
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'stock_movement:build' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description: 'The consume and produce rows this build wrote — the costed subledger entries',
+  },
+
+  reversalOf: {
+    id: toFieldId('reversalOf'),
+    key: 'reversalOf',
+    label: 'Reversal Of',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'build_reversal_of',
+    systemSortOrder: 'aJ',
+    nullable: true,
+    // Surfaced as a banner/badge on a reversed build, not as two relationship
+    // rows in the Details panel.
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    // Self-relation: carries `relationshipConfig` but NO
+    // `relationship.inverseResourceFieldId`, exactly like the
+    // `parentMovement` / `childMovements` and `reversesMovement` /
+    // `reversedByMovements` pairs. `linkNewRelationships` skips it by design and
+    // the seeder materialises it from `relationshipConfig`.
+    relationshipConfig: {
+      relatedEntityType: 'build',
+      relationshipType: 'belongs_to',
+      inverseName: 'Reversed By',
+      inverseSystemAttribute: 'build_reversed_by',
+    },
+    description:
+      'Set on the REVERSING build, pointing at the one it undoes (B6). A completed build is ' +
+      'never edited or deleted — a period that has been posted must not change shape',
+  },
+
+  reversedBy: {
+    id: toFieldId('reversedBy'),
+    key: 'reversedBy',
+    label: 'Reversed By',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'build_reversed_by',
+    systemSortOrder: 'aK',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'build',
+      relationshipType: 'has_many',
+      inverseName: 'Reversal Of',
+      inverseSystemAttribute: 'build_reversal_of',
+    },
+    description: 'Builds that undo this one',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the build is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the build is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/order-fields.ts
@@ -165,6 +165,36 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
     description: 'When the order was placed — the period key every revenue read groups on',
   },
 
+  cancelledAt: {
+    id: toFieldId('cancelledAt'),
+    key: 'cancelledAt',
+    label: 'Cancelled',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'order_cancelled_at',
+    systemSortOrder: 'a4a',
+    nullable: true,
+    // Meaningful when set, so it stays in the panel — but you do not cancel an
+    // order by typing a date into a create dialog
+    // (plans/products/build/01-build-plan.md §1.6).
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      // `creatable: true` on purpose: a Shopify order can arrive ALREADY
+      // cancelled, so the value has to be settable on the insert rather than
+      // requiring a second write (plans/products/12 §6.1a).
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select date cancelled',
+    description:
+      'When the order was cancelled. Set, never cleared — the cancellation rule reads it to ' +
+      'cancel or reverse the builds this order caused',
+  },
+
   financialStatus: {
     id: toFieldId('financialStatus'),
     key: 'financialStatus',
@@ -558,6 +588,36 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
       isInverse: true,
     },
     description: 'Work orders raised off this order — linked by hand (D4 defers the conversion)',
+  },
+
+  // Reverse relationship: builds (from build.order). The `build` side lands
+  // with entity migration 109; both halves are created in that one pass, so
+  // `linkNewRelationships` resolves this immediately.
+  builds: {
+    id: toFieldId('builds'),
+    key: 'builds',
+    label: 'Builds',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'order_builds',
+    systemSortOrder: 'aK',
+    showInPanel: false, // has_many inverse; surfaced from the build side
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'build:order' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description:
+      'Builds raised to satisfy this order — what "cancel the builds for this order" looks up',
   },
 
   createdAt: {

--- a/packages/lib/src/resources/registry/resources/part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/part-fields.ts
@@ -728,5 +728,207 @@ export const PART_FIELDS: Record<string, ResourceField> = {
     description: 'Bill lines charging for this part - what we were actually invoiced, per part',
   },
 
+  // ─── Standard cost — the FROZEN half of the two costs a part carries ──
+  // plans/products/build/01-build-plan.md §1.2, §2.4. Entity migration 109.
+  //
+  // `part_cost` answers "what would this cost to build today" and is rewritten
+  // by `recalculateAffectedParts` on every vendor-price or BOM change, silently
+  // and constantly. These answer "what we have agreed to value it at": written
+  // ONLY by `rollStandardCost`, only when a person runs it, with a stamped
+  // effective date. `part_standard_cost` is what every stock movement stamps —
+  // if it were recalculated automatically it would just BE `part_cost`, and
+  // every frozen unitCost would drift with vendor prices, which is the defect
+  // this whole subsystem exists to avoid.
+  //
+  // The three components are split because it is load-bearing, not for tidiness:
+  // the fulfillment COGS entry has to land across 5000 Materials / 5010 Direct
+  // Labor / 5020 Applied Overhead, and it can only do that if the finished
+  // good's standard remembers its composition.
+  //
+  // ⚠️ All five are hidden from the Details panel and the dialogs (§1.6). Five
+  // read-only cost rows would swamp the panel; they surface on the part drawer's
+  // Costing card, which already renders exactly this shape. Nobody types them.
+  // Deliberately NOT `capabilities.hidden` — they stay findable in the field
+  // picker, filterable, and addable to a view by anyone who wants them.
+
+  standardMaterialCost: {
+    id: toFieldId('standardMaterialCost'),
+    key: 'standardMaterialCost',
+    label: 'Standard Material Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'part_standard_material_cost',
+    systemSortOrder: 'a5e',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Frozen material roll-up, integer minor units. For a built part this is the sum of its ' +
+      "children's standardCost x quantity — NOT round(part_cost), which is a pure material " +
+      'chain and drops every subassembly conversion cost on the way up (README B11)',
+  },
+
+  standardLaborCost: {
+    id: toFieldId('standardLaborCost'),
+    key: 'standardLaborCost',
+    label: 'Standard Labor Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'part_standard_labor_cost',
+    systemSortOrder: 'a5f',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Absorbed direct labour per unit, integer minor units. Applies ONLY to a subassembly or ' +
+      'finished_good — a purchased component gets 0, because we did not assemble it and ' +
+      'capitalising labour never spent would overstate 1310 Raw Materials (README B11)',
+  },
+
+  standardOverheadCost: {
+    id: toFieldId('standardOverheadCost'),
+    key: 'standardOverheadCost',
+    label: 'Standard Overhead Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'part_standard_overhead_cost',
+    systemSortOrder: 'a5g',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Applied overhead per unit, integer minor units. Gated on partKind exactly as ' +
+      'standardLaborCost is',
+  },
+
+  standardCost: {
+    id: toFieldId('standardCost'),
+    key: 'standardCost',
+    label: 'Standard Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'part_standard_cost',
+    systemSortOrder: 'a5h',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Material + labour + overhead, integer minor units — THE value every stock movement ' +
+      'stamps. Rounded before freezing: computeLandedCost can emit a fractional-cent tariff ' +
+      'term, and an unrounded standard makes every downstream balance check hold by luck',
+  },
+
+  standardCostEffectiveAt: {
+    id: toFieldId('standardCostEffectiveAt'),
+    key: 'standardCostEffectiveAt',
+    label: 'Standard Cost Effective',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'part_standard_cost_effective_at',
+    systemSortOrder: 'a5i',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'When the current standard took effect. Stamped by rollStandardCost — the delta ' +
+      'between part_cost and part_standard_cost since this date is what tells you a roll is due',
+  },
+
+  // Reverse relationship: builds (from build.part)
+  builds: {
+    id: toFieldId('builds'),
+    key: 'builds',
+    label: 'Builds',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'part_builds',
+    systemSortOrder: 'c2',
+    showInPanel: false, // has_many inverse; a tab lists them
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'build:part' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description: 'Builds that produce this part',
+  },
+
   createdBy: CREATED_BY_FIELD,
 }

--- a/packages/lib/src/resources/registry/resources/stock-movement-fields.ts
+++ b/packages/lib/src/resources/registry/resources/stock-movement-fields.ts
@@ -546,5 +546,73 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
     description: 'Rows that undo this movement',
   },
 
+  // ─── Build provenance and the as-built BOM snapshot ────────────────
+  // plans/products/build/01-build-plan.md §1.2. Entity migration 109, inert:
+  // `packages/lib/src/builds/` does not exist yet, so both read NULL on every
+  // existing row and there is no backfill.
+
+  build: {
+    id: toFieldId('build'),
+    key: 'build',
+    label: 'Build',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'stock_movement_build',
+    systemSortOrder: 'c0',
+    nullable: true,
+    // Provenance read by the ledger UI, not a row a person fills in.
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'build:movements' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'build',
+      relationshipType: 'belongs_to',
+      inverseName: 'Stock Movements',
+      inverseSystemAttribute: 'build_movements',
+    },
+    description:
+      'The build that wrote this row. `reference` stays as-is - a free-text batch string is ' +
+      'not something a query can join on',
+  },
+
+  qtyPerUnit: {
+    id: toFieldId('qtyPerUnit'),
+    key: 'qtyPerUnit',
+    label: 'Qty Per Unit',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'stock_movement_qty_per_unit',
+    systemSortOrder: 'c1',
+    nullable: true,
+    // A diagnostic for the usage cross-check. Exposing it invites someone to
+    // "correct" the as-built snapshot, which destroys its only purpose.
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'The AS-BUILT BOM snapshot: on a build_consume row, the per-unit quantity in force at ' +
+      'build time. NULL on a consume row means the component was OFF-BOM - a floor ' +
+      'substitution, made visible instead of silent. NULL on every other movement type.',
+  },
+
   createdBy: CREATED_BY_FIELD,
 }

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -71,6 +71,7 @@ import { migration104VendorSkuOptional } from './migrations/104-vendor-sku-optio
 import { migration106SupplierPricingRelabel } from './migrations/106-supplier-pricing-relabel'
 import { migration107Order } from './migrations/107-order'
 import { migration108Purchasing } from './migrations/108-purchasing'
+import { migration109BuildAndStandardCost } from './migrations/109-build-and-standard-cost'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -187,6 +188,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration106SupplierPricingRelabel,
   migration107Order,
   migration108Purchasing,
+  migration109BuildAndStandardCost,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
@@ -63,8 +63,10 @@ describe('order entity registration wiring', () => {
     }
   })
 
-  it('carries exactly the 08 §2 field set', () => {
+  it('carries exactly the 08 §2 field set, plus what later migrations added', () => {
     expect(Object.keys(ORDER_FIELDS).sort()).toEqual([
+      'builds', // added by migration 109 — inverse of build_order (build §1.2)
+      'cancelledAt', // added by migration 109 — nullable, creatable, set never cleared
       'channel',
       'company',
       'contact',
@@ -83,7 +85,7 @@ describe('order entity registration wiring', () => {
       'shippingAddress',
       'subtotal',
       'tags',
-      'taxName', // added by migration 109 — the LineBuilder writes it with taxRate
+      'taxName', // folded into 108 (see the note below) — the LineBuilder writes it with taxRate
       'taxRate',
       'taxTotal',
       'total',

--- a/packages/lib/src/seed/entity-migrations/migrations/109-build-and-standard-cost.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/109-build-and-standard-cost.ts
@@ -1,0 +1,279 @@
+// packages/lib/src/seed/entity-migrations/migrations/109-build-and-standard-cost.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getOrgCache } from '../../../cache'
+import type { FieldOptions } from '../../../custom-fields'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { BUILD_FIELDS } from '../../../resources/registry/resources/build-fields'
+import { ORDER_FIELDS } from '../../../resources/registry/resources/order-fields'
+import { PART_FIELDS } from '../../../resources/registry/resources/part-fields'
+import { STOCK_MOVEMENT_FIELDS } from '../../../resources/registry/resources/stock-movement-fields'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import {
+  ensureCustomFields,
+  ensureEntityDefinitions,
+  linkDisplayFields,
+  linkNewRelationships,
+  loadExistingState,
+} from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:109')
+
+/** The one def this migration creates. */
+const NEW_TYPES = ['build'] as const
+
+/**
+ * Pre-existing defs that receive fields here. `stock_movement` is the hard
+ * dependency (checked separately, it is what a build actually writes); `part`
+ * and `order` are tolerated as absent, since an org short of the migration that
+ * seeds them has nothing to hang an inverse off yet and a later run closes it.
+ */
+const EXISTING_TYPES = ['stock_movement', 'part', 'order'] as const
+
+/**
+ * The fields added to defs this migration does not create, listed by REGISTRY
+ * KEY rather than taken as "everything new on that registry" — so a later,
+ * unrelated field does not silently join this migration's payload.
+ */
+const INCUMBENT_FIELD_KEYS: Record<(typeof EXISTING_TYPES)[number], readonly string[]> = {
+  // The frozen standard and its three components, plus the build inverse.
+  part: [
+    'standardMaterialCost',
+    'standardLaborCost',
+    'standardOverheadCost',
+    'standardCost',
+    'standardCostEffectiveAt',
+    'builds',
+  ],
+  // `stock_movement_unit_cost` / `_extended_cost` / `_cost_basis` /
+  // `_gl_account` are NOT here — they shipped with 108 and 19 rows already
+  // carry values. `stock_movement_gl_posting` is Gap B's, not this migration's.
+  stock_movement: ['build', 'qtyPerUnit'],
+  order: ['cancelledAt', 'builds'],
+}
+
+/**
+ * Migration 109: the `build` entity and the frozen standard cost, in ONE pass
+ * and completely INERT (plans/products/build/01-build-plan.md §1,
+ * plans/products/build/README.md B10).
+ *
+ * ## What "inert" means here, and why it is the whole point
+ *
+ * Every field this migration creates reads NULL and **has no writer**.
+ * `packages/lib/src/builds/` does not exist; `rollStandardCost` does not exist;
+ * nothing sets `order_cancelled_at`. A field with no writer does nothing at
+ * all, so this migration carries no behavioural risk whatsoever — and it clears
+ * the org-cache and def-exists gates for every phase after it.
+ *
+ * That is also what makes the phasing safe. A `planned` build writes no stock
+ * movements (README B2), and `completeBuild` — the only function that ever
+ * writes — is gated on a real `part_standard_cost`. So the entity, its UI and
+ * the auto-build trigger can all land and be used before the costing half
+ * exists, with no way to produce a wrong number early.
+ *
+ * The precedent is purchasing P13, which shipped its two payment defs seeded,
+ * hidden and inert in the same migration as the rest and recorded exactly why:
+ * it avoids a second trip through the ten-file registration set, no org-cache
+ * dance across every org, and no waiting on a def-exists gate. ⚠️ P13's
+ * condition applies here too — an entity with zero rows can be reshaped freely,
+ * and the freedom lasts only while nothing writes. `108-purchasing.test.ts`
+ * enforces that emptiness by scanning this source tree for the names, which is
+ * why they are not spelled out here.
+ *
+ * ## What it adds
+ *
+ * The `build` def with all 24 of `BUILD_FIELDS`, **`isVisible: false`**. Phase
+ * 2 flips that to true when the list, the detail page and the completion form
+ * land; a visible nav entry for an empty list with no way to create a row is a
+ * worse first impression than no entry at all.
+ *
+ * On `part` (§1.2), the frozen half of the two costs a part carries:
+ *
+ *   part.standardMaterialCost      CURRENCY   frozen material roll-up
+ *   part.standardLaborCost         CURRENCY   absorbed direct labour per unit
+ *   part.standardOverheadCost      CURRENCY   applied overhead per unit
+ *   part.standardCost              CURRENCY   the sum — what every movement stamps
+ *   part.standardCostEffectiveAt   DATETIME   when this standard took effect
+ *   part.builds                    has_many   -> build (inverse of build.part)
+ *
+ * Splitting the three components is load-bearing rather than tidy: the
+ * fulfillment COGS entry has to land across 5000 Materials / 5010 Direct Labor
+ * / 5020 Applied Overhead, and it can only do that if the finished good's
+ * standard remembers its composition.
+ *
+ * On `stock_movement`:
+ *
+ *   stock_movement.build           belongs_to -> build
+ *   stock_movement.qtyPerUnit      NUMBER      the as-built BOM snapshot
+ *
+ * On `order`:
+ *
+ *   order.cancelledAt              DATETIME   nullable, `creatable: true`
+ *   order.builds                   has_many   -> build (inverse of build.order)
+ *
+ * ⚠️ `order_cancelled_at` is `creatable: true` because a Shopify order can
+ * arrive ALREADY cancelled. Set, never cleared.
+ *
+ * ## Why this is ONE migration and not three
+ *
+ * Same argument as 108. `linkNewRelationships` links what is in the FIELD MAP
+ * it is handed, not what is in the database. Split across 109 -> 110 -> 111,
+ * `part.builds`, `stock_movement.build` and `order.builds` would each be
+ * materialised while `build` did not exist yet, the linker would skip all three
+ * with a debug line, and a later migration would have to re-read those rows out
+ * of `ExistingState` purely so the linker could see them. Every counterpart is
+ * in the same map before the single `linkNewRelationships` call below, so all
+ * of them resolve there. If a rehydration block is ever needed here, that means
+ * a def moved out of this migration and the fix is to move it back.
+ *
+ * ## Deliberately absent
+ *
+ * **No backfill, anywhere** (§1.5). Every new field reads NULL on every
+ * existing row and every future reader must handle that. There is nothing to
+ * reconstruct: a past movement's cost is not recoverable from a later ledger
+ * state, and pretending otherwise is the Stocksmith failure exactly.
+ *
+ * **No field views and no default table views.** 108 materialised
+ * `dialog_create` views because a dialog is an allowlist the registry cannot
+ * express per-field; here the registry CAN express it — `showInDialogs` is
+ * declared on all 24 build fields at creation time (§1.6), leaving exactly four
+ * in the dialog (number, part, quantityPlanned, notes). And a hidden def with
+ * zero rows has nothing to list, so a seeded table view would be the kind of
+ * thing that grows a "create" button.
+ *
+ * 🛑 `showInDialogs` on a materialised field lives in the `options` JSONB
+ * written HERE, at field-creation time — `ensureCustomFields` skips a field
+ * that already exists and never touches its options. Getting it wrong costs a
+ * second migration; `031-documents-field-hidden-in-dialogs` and
+ * `033-external-id-field-hidden-in-dialogs` are two that exist only to do that.
+ *
+ * **No DDL and no Drizzle migration.** `EntityDefinition.entityType` is a
+ * `text()` column, so a new entity type is this migration plus hand-edits to
+ * `enums.ts` (`ModelTypeValues` / `ModelTypes` / `ModelTypeMeta`),
+ * `enum-values.ts`, `field-registry.ts`, `create-fields.ts`, `constants.ts`,
+ * `types/resource/utils.ts` and the system-attribute union. If a `.sql` file
+ * appears under `packages/database/drizzle/` for this work, something is wrong.
+ *
+ * Note the id space is shared across `data-migrations/migrations/` and
+ * `seed/entity-migrations/migrations/` — 109 was the next free number counted
+ * across BOTH (it has already collided once, at 103).
+ *
+ * Idempotent — every helper is insert-only or skips existing rows, and
+ * `linkNewRelationships` only writes an `inverseResourceFieldId` that is null.
+ */
+export const migration109BuildAndStandardCost: EntityMigration = {
+  id: '109-build-and-standard-cost',
+  description:
+    'Add the inert build system entity, the five frozen part_standard_* cost fields, ' +
+    'stock_movement build provenance and qtyPerUnit, and order cancelledAt plus the build ' +
+    'inverses',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    // `stock_movement` is the core dependency: it is seeded by migration 002 and
+    // is what a build actually writes. An org that has not reached 002 is
+    // skipped rather than failed — 002 seeds the full registry, so it picks up
+    // the two new movement fields itself, and a later run of this migration
+    // adds the build def.
+    const smDef = existing.entityDefs.get('stock_movement')
+    if (!smDef) return { ...state, alreadyUpToDate: true }
+
+    // ── Step 1: the `build` EntityDefinition, isVisible: false ─────────
+    const entityDefIds = await ensureEntityDefinitions(
+      db,
+      organizationId,
+      SYSTEM_ENTITIES.filter((e) => (NEW_TYPES as readonly string[]).includes(e.entityType)),
+      existing,
+      state
+    )
+
+    // Pull the incumbent defs into the id map so `linkNewRelationships` can
+    // resolve BOTH directions of every pair in the single pass below. A def that
+    // is absent simply contributes nothing.
+    for (const entityType of EXISTING_TYPES) {
+      const def = existing.entityDefs.get(entityType)
+      if (def) entityDefIds.set(entityType, def.id)
+    }
+
+    const allFieldMaps = new Map<
+      string,
+      { id: string; systemAttribute: string; options: FieldOptions; _fieldDef: ResourceField }
+    >()
+    const merge = (m: typeof allFieldMaps) => {
+      for (const [k, v] of m) allFieldMaps.set(k, v)
+    }
+
+    // ── Step 2: the full BUILD_FIELDS registry ─────────────────────────
+    const buildDefId = entityDefIds.get('build')
+    if (buildDefId) {
+      merge(
+        await ensureCustomFields(
+          db,
+          organizationId,
+          'build',
+          buildDefId,
+          BUILD_FIELDS,
+          existing,
+          state
+        )
+      )
+    }
+
+    // ── Step 3: the added fields on part, stock_movement and order ─────
+    const registries: Record<(typeof EXISTING_TYPES)[number], Record<string, ResourceField>> = {
+      part: PART_FIELDS,
+      stock_movement: STOCK_MOVEMENT_FIELDS,
+      order: ORDER_FIELDS,
+    }
+
+    for (const entityType of EXISTING_TYPES) {
+      const defId = entityDefIds.get(entityType)
+      if (!defId) continue
+      const fields: Record<string, ResourceField> = {}
+      for (const key of INCUMBENT_FIELD_KEYS[entityType]) {
+        const field = registries[entityType][key]
+        // Loud rather than silent: a renamed registry key would otherwise make
+        // this migration quietly create one field fewer than it claims to.
+        if (!field) {
+          throw new Error(`${entityType} registry is missing the key "${key}" (migration 109)`)
+        }
+        fields[key] = field
+      }
+      merge(
+        await ensureCustomFields(db, organizationId, entityType, defId, fields, existing, state)
+      )
+    }
+
+    // ── Step 4: link relationships and display fields ──────────────────
+    // One call, and every edge resolves — see the "Why this is ONE migration"
+    // note above. `build.reversalOf` / `build.reversedBy` are a SELF-relation
+    // pair carrying no `relationship.inverseResourceFieldId`, exactly like
+    // `stock_movement.parentMovement` / `childMovements`, so the linker skips
+    // them by design and the seeder materialises them from `relationshipConfig`.
+    await linkNewRelationships(db, allFieldMaps, entityDefIds, state)
+    await linkDisplayFields(db, [...NEW_TYPES], entityDefIds, allFieldMaps)
+
+    const alreadyUpToDate =
+      state.entityDefsCreated === 0 && state.fieldsCreated === 0 && state.relationshipsLinked === 0
+
+    // New definitions and fields are invisible to every read path until the
+    // per-org caches that serve them are dropped. `runEntityMigrationsForOrg`
+    // does this after the whole batch, but `up()` can also be invoked directly,
+    // so it clears its own.
+    if (!alreadyUpToDate) {
+      await getOrgCache().invalidateAndRecompute(organizationId, [
+        'entityDefs',
+        'entityDefSlugs',
+        'customFields',
+        'resources',
+      ])
+      logger.info('Migration 109 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -325,6 +325,24 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     color: 'indigo',
     isVisible: false, // Written only by the poster, like gl_posting itself
   },
+  {
+    // Ships INERT with entity migration 109 (plans/products/build/README.md
+    // B10): the def and all 24 of its fields exist in every org, and NOTHING
+    // writes them until `packages/lib/src/builds/` lands in phase 2. An entity
+    // with zero rows can be reshaped for free; the first row ends that.
+    //
+    // ⚠️ `isVisible: false` is NOT permanent — phase 2 flips it to true when the
+    // list, the detail page and the completion form land. Straight from the
+    // `vendor_payment` precedent: a visible nav entry for an empty list with no
+    // way to create a row is a worse first impression than no entry at all.
+    entityType: 'build',
+    apiSlug: 'builds',
+    singular: 'Build',
+    plural: 'Builds',
+    icon: 'hammer',
+    color: 'orange',
+    isVisible: false,
+  },
 ]
 
 /**
@@ -469,6 +487,10 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
   gl_posting_line: {
     primaryDisplayField: 'accountCode',
     secondaryDisplayField: undefined,
+  },
+  build: {
+    primaryDisplayField: 'number',
+    secondaryDisplayField: 'part',
   },
 }
 

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -5,6 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import type { FieldOptions } from '../../custom-fields'
 import type { ResourceField } from '../../resources/registry/field-types'
 import { ARTICLE_FIELDS } from '../../resources/registry/resources/article-fields'
+import { BUILD_FIELDS } from '../../resources/registry/resources/build-fields'
 import { CATALOG_GROUP_FIELDS } from '../../resources/registry/resources/catalog-group-fields'
 import { CATALOG_ITEM_FIELDS } from '../../resources/registry/resources/catalog-item-fields'
 import { COMPANY_FIELDS } from '../../resources/registry/resources/company-fields'
@@ -85,6 +86,7 @@ export const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   vendor_payment_allocation: VENDOR_PAYMENT_ALLOCATION_FIELDS,
   gl_account: GL_ACCOUNT_FIELDS,
   gl_posting_line: GL_POSTING_LINE_FIELDS,
+  build: BUILD_FIELDS,
 }
 
 /**

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -824,6 +824,54 @@ export const SETTINGS_CATALOG = {
     description:
       'When on, accrual summaries are posted to the QuickBooks general ledger as journal entries.',
   },
+
+  // ── Manufacturing absorption rates (plans/products/build/01-build-plan.md §1.4) ─────────
+  //
+  // Per-UNIT, not per-hour: the merchant supplies a percentage split of a
+  // payroll total, not timesheets, so there are no routings, work centres or
+  // labour tickets behind these two numbers.
+  //
+  // 🛑 Both SHIP EMPTY (`null`). The actual figures are still open (build
+  // README §5 Q3), and nothing reads them until `rollStandardCost` lands in
+  // phase 1 — at which point a NULL rate must read as "no absorption", never as
+  // zero-by-accident. Scoped GENERAL like the other org-wide operational
+  // numbers; there is no MANUFACTURING value in the `SettingScope` pg enum and
+  // adding one would need a Drizzle migration this phase deliberately does not
+  // carry.
+  //
+  // ⚠️ Conversion cost applies only to a `subassembly` or `finished_good`
+  // (README B11). Applying these rates to a purchased `component` capitalises
+  // labour that was never spent and overstates 1310 Raw Materials.
+  'manufacturing.assemblyLaborCostPerUnit': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CURRENCY',
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    defaultValue: null,
+    description:
+      'Absorbed direct labour per assembled unit, integer minor units: ' +
+      '(annual payroll x assembly%) / expected annual units. Unset = no labour absorption.',
+  },
+  'manufacturing.overheadCostPerUnit': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CURRENCY',
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    defaultValue: null,
+    description:
+      'Applied overhead per assembled unit, integer minor units: total annual factory ' +
+      'overhead / expected annual units. Unset = no overhead absorption.',
+  },
 } satisfies Record<string, SettingConfig>
 
 /**

--- a/packages/types/resource/utils.ts
+++ b/packages/types/resource/utils.ts
@@ -166,6 +166,7 @@ export const ENTITY_DEFINITION_TYPES = [
   'vendor_payment_allocation',
   'gl_account',
   'gl_posting_line',
+  'build',
 ] as const
 
 /** Type for system entity types stored in EntityDefinition */

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -606,6 +606,44 @@ export const SYSTEM_ATTRIBUTES = [
   'gl_posting_line_sort_order',
   'gl_posting_lines', // inverse of gl_posting_line_gl_posting
 
+  // ─── Build / standard cost (plans/products/build/01-build-plan.md §1) ──
+  // Entity migration 109. Every one of these reads NULL until the code that
+  // writes it lands — there is no backfill anywhere in that migration.
+  'build_number',
+  'build_part',
+  'build_status',
+  'build_quantity_planned',
+  'build_quantity_produced', // good units that entered finished goods
+  'build_quantity_scrapped', // started but lost (B7) — falls out in the variance
+  'build_started_at',
+  'build_completed_at', // THE accounting date
+  'build_material_cost',
+  'build_labor_cost',
+  'build_overhead_cost',
+  'build_produced_value', // quantityProduced x part_standard_cost
+  'build_variance_amount', // (mat+lab+ovh) - producedValue -> account 5090
+  'build_movements', // inverse of stock_movement_build
+  'build_reversal_of', // set on the REVERSING build (B6)
+  'build_reversed_by', // inverse of build_reversal_of
+  'build_posted_at', // denormalized convenience ONLY — never gate on it
+  'build_notes',
+  'build_order', // which order caused this build (plans/products/12 AB7)
+  'build_source', // manual | order — an auto-build must be distinguishable
+  // The frozen standard, deliberately separate from the live `part_cost`. The
+  // three components are split because the fulfillment COGS entry has to land
+  // across 5000 / 5010 / 5020, which it can only do if the finished good's
+  // standard remembers its composition.
+  'part_standard_material_cost',
+  'part_standard_labor_cost',
+  'part_standard_overhead_cost',
+  'part_standard_cost', // the sum — the value every movement stamps
+  'part_standard_cost_effective_at',
+  'part_builds', // inverse of build_part
+  'stock_movement_build', // nullable; `reference` stays as-is
+  'stock_movement_qty_per_unit', // as-built BOM snapshot; NULL on a consume row = off-BOM
+  'order_cancelled_at', // set, never cleared — a Shopify order can arrive cancelled
+  'order_builds', // inverse of build_order
+
   // ─── Inbox fields ───────────────────────────────────────────────
   'inbox_name',
   'inbox_description',


### PR DESCRIPTION
Phase **S** of [`plans/products/build/01-build-plan.md`](plans/products/build/01-build-plan.md) §1 — every schema addition the build subsystem needs, in one entity migration, landing ahead of any code that reads it.

## This changes no behaviour

Nothing reads any of it. The `build` def is seeded `isVisible: false`, and a field with no writer does nothing at all.

That is also what makes decision B2 work. A `planned` build writes no stock movements, so the entity, the UI and the order-triggered build can all ship and be used before `part_standard_cost` exists — `completeBuild` is the only function that writes, and it is gated on a real standard cost. Nothing can produce a wrong number before phase 3.

## What migration 109 adds

| def | fields |
| --- | --- |
| **`build`** (new) | 20 — number, part, status, planned/produced/scrapped quantities, started/completed timestamps, the material/labor/overhead/produced-value/variance cost set, movements, reversal pair, postedAt, notes, order, source |
| `part` | 6 — `part_standard_{material,labor,overhead}_cost`, their `part_standard_cost` sum, `part_standard_cost_effective_at`, and the `part_builds` inverse |
| `stock_movement` | 2 — `build`, and `qty_per_unit` |
| `order` | 2 — `cancelled_at`, and the `builds` inverse |

Plus `BuildStatus` / `BuildSource` enums, and the two `manufacturing.*` absorption settings.

**Why the standard cost splits into three components rather than one number:** a fulfillment COGS entry has to break across 5000 Materials / 5010 Direct Labor / 5020 Applied Overhead, and it can only do that if the finished good's standard remembers its composition.

**Why `stock_movement_qty_per_unit` exists:** it is the as-built BOM snapshot. NULL on a `build_consume` row means the component was off-BOM — a floor substitution made visible instead of silent.

**Why the two settings ship empty:** the figures are still open (build README §5 Q3), and nothing reads them until `rollStandardCost` lands. A NULL rate must read as "no absorption", never as zero-by-accident.

## Why one migration instead of one per phase

The purchasing P13 precedent, which shipped `vendor_payment` inert in the shared migration for exactly this reason: it avoids a second trip through the ten-file registration set, an org-cache dance across every org, and waiting on a def-exists gate — and an entity with zero rows can still be reshaped freely, so the shape costs nothing to get slightly wrong. P13's condition applies here too: that freedom lasts only while nothing writes.

## Two corrections to the plan

Both are recorded in the plan itself, not just here.

**1. §1.5's "five hand-edits and no Drizzle migration" undercounts.** A new `entityType` also needs `SYSTEM_ATTRIBUTES`, `ENTITY_DEFINITION_TYPES`, `RESOURCE_FIELD_REGISTRY`, the entity→registry map in `create-fields.ts`, and `DISPLAY_FIELD_CONFIG`. `ResourceField.systemAttribute` is typed as `SystemAttribute`, so `build-fields.ts` does not compile without the first of those.

**2. `build` is deliberately NOT added to `EntityTypeValues` / `EntityType`,** against the plan's prose. Those two lists are **stale**: they are missing `order`, `purchase_order`, `vendor_bill`, `gl_account` and several more that `ModelTypeValues` — one screen up in the same file — has. Migrations 107 and 108 skipped them for the same reason. Their only real consumer is a `z.enum(EntityTypeValues)` in `entity-definitions/types.ts`, which system-seeded defs never pass through, which is how the drift went unnoticed. Adding one entry to a list missing a dozen would make it look maintained; the day that enum becomes load-bearing it fails on `order` before `build`.

So `enums.ts` gets three edits, not five: `ModelTypeValues`, `ModelTypes`, and the display map.

## Reviewer notes

- 🛑 **§1.6's visibility flags are the part that is expensive to get wrong.** `showInDialogs` on a materialized field lives in the `options` JSONB written at field-creation time, and there are already two migrations in the tree that exist only to correct this after the fact. All 30 declarations were checked field-by-field against the plan's table. Net result: exactly four fields reach the create dialog — number, part, quantityPlanned, notes.
- **Nothing uses `capabilities.hidden`.** Every field stays findable in the field picker, filterable and addable to a view; the defaults just do not put it there unasked.
- **No backfill anywhere.** Every new field reads NULL, and every future reader must handle that.
- **No Drizzle migration** — `EntityDefinition.entityType` is a `text()` column. If a `.sql` file appears in this diff, something is wrong.
- `107-order.test.ts`'s frozen `ORDER_FIELDS` key list gains `builds` and `cancelledAt` — intended maintenance for a migration that legitimately extends `order`, not a weakened assertion.
- The migration id space is shared between `data-migrations/` and `seed/entity-migrations/`; **109** was free in both at the time of writing. Whoever lands second renumbers.

## Verification

```
lib typecheck ratchet:      no new type errors (29 total, baseline 29)
@auxx/database typecheck:   clean, exit 0
packages/lib full suite:    999 files passed, 13407 tests passed, 0 failed
biome:                      clean across all 15 files
```

## Follow-up spotted, not fixed here

`107-order.test.ts:86` carried a comment claiming `order.taxName` was "added by migration 109" — no 109 existed until this one. A comment at :386 says it was folded into 108, but `108-purchasing.ts` has no `order` entry in `EXISTING_TYPES`/`INCUMBENT_FIELDS` at all. If that reading is right, **`order_tax_name` is materialized by nothing** for orgs that already ran 107. Only the misleading comment was corrected here; the substance deserves its own look.
