### PR TITLE
feat(build): freeze a part's standard cost, separately from its live cost

### DIFF
--- a/apps/web/src/components/drawers/cards/part-costing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-costing-card.tsx
@@ -1,28 +1,46 @@
 // apps/web/src/components/drawers/cards/part-costing-card.tsx
 'use client'
 
+import { standardCostDrift } from '@auxx/lib/builds/client'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { CostSource, parseRecordId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
 import { formatCurrency } from '@auxx/utils/currency'
 import { useMemo } from 'react'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { Tooltip } from '~/components/global/tooltip'
+import { RollStandardCostPopover } from '~/components/manufacturing/parts/roll-standard-cost-popover'
 import { useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
 /**
  * The three provenance fields migration 100 added under `part_cost`, plus the
- * cost itself. All computed by the cost calculator — this card is read-only.
+ * cost itself — and the frozen standard migration 109 added beside it.
+ *
+ * All six are computed; this card is read-only and the roll is the only writer
+ * of the standard. The five `part_standard_*` fields are declared
+ * `showInPanel: false` / `showInDialogs: false` precisely so they surface HERE
+ * rather than burying the part's Details panel under five uneditable cost rows
+ * (plans/products/build/01-build-plan.md §1.6, §2.5).
  */
 const PART_COSTING_ATTRIBUTES = [
   'part_cost',
   'part_purchase_cost',
   'part_rollup_cost',
   'part_cost_source',
+  'part_standard_cost',
+  'part_standard_cost_effective_at',
 ] as const
+
+/** "12 Aug 2026" — the day the current standard took effect. */
+function formatEffectiveDate(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
 
 /** `CostSource.values` keyed by option value, for badge label + color. */
 const COST_SOURCE_BY_VALUE = Object.fromEntries(CostSource.values.map((v) => [v.value, v]))
@@ -75,9 +93,18 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
   const purchaseCost = values.part_purchase_cost as number | null | undefined
   const rollupCost = values.part_rollup_cost as number | null | undefined
   const costSource = values.part_cost_source as string | undefined
+  const liveCost = values.part_cost as number | null | undefined
+  const standardCost = values.part_standard_cost as number | null | undefined
+  const standardEffectiveAt = values.part_standard_cost_effective_at as string | undefined
 
   const hasComparison = purchaseCost != null && rollupCost != null
   const isUncosted = costSource === CostSource.NONE
+  // The standard block shows as soon as there is anything to say about it —
+  // including "not rolled yet", which is the state that needs the action most.
+  const hasStandardBlock = standardCost != null || liveCost != null
+  // How far the standard has drifted from reality since it was last rolled.
+  // Genuinely useful on its own: it is the number that tells you a roll is due.
+  const drift = standardCostDrift(liveCost, standardCost)
 
   // Whether the part has a bill of materials at all — decides which "why" the
   // uncosted state shows. Same filter shape as PartInventoryCard's hasSubparts
@@ -108,7 +135,7 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
   })
   const hasSubparts = subpartRecords.length > 0
 
-  if (!hasComparison && !isUncosted) return null
+  if (!hasComparison && !isUncosted && !hasStandardBlock) return null
 
   const noneMeta = COST_SOURCE_BY_VALUE[CostSource.NONE]
 
@@ -134,7 +161,7 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
             </div>
           </FieldPanelRow>
         </>
-      ) : (
+      ) : isUncosted ? (
         <FieldPanelRow title='Cost'>
           <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm'>
             <Badge variant={(noneMeta?.color ?? 'amber') as Variant} size='xs'>
@@ -151,6 +178,48 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
             )}
           </div>
         </FieldPanelRow>
+      ) : null}
+
+      {hasStandardBlock && (
+        <>
+          <FieldPanelRow
+            title='Standard'
+            description='The frozen value every stock movement is stamped with'>
+            <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm tabular-nums'>
+              {standardCost == null ? (
+                <Badge variant='amber' size='xs'>
+                  Not rolled
+                </Badge>
+              ) : (
+                <>
+                  {formatCurrency(standardCost)}
+                  {standardEffectiveAt && (
+                    <span className='text-muted-foreground text-xs'>
+                      set {formatEffectiveDate(standardEffectiveAt)}
+                    </span>
+                  )}
+                </>
+              )}
+              <RollStandardCostPopover partId={partId}>
+                <Button variant='outline' size='xs' className='ms-auto'>
+                  Roll
+                </Button>
+              </RollStandardCostPopover>
+            </div>
+          </FieldPanelRow>
+
+          {drift != null && (
+            <FieldPanelRow
+              title='Drift'
+              description="Today's cost minus the standard — how stale the standard is">
+              <div className='flex min-h-8 items-center text-sm text-muted-foreground tabular-nums'>
+                {drift === 0
+                  ? 'None — the standard matches today\u2019s cost'
+                  : `${drift > 0 ? '+' : ''}${formatCurrency(drift)}`}
+              </div>
+            </FieldPanelRow>
+          )}
+        </>
       )}
     </FieldPanel>
   )

--- a/apps/web/src/components/manufacturing/parts/roll-standard-cost-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/roll-standard-cost-popover.tsx
@@ -1,0 +1,229 @@
+// apps/web/src/components/manufacturing/parts/roll-standard-cost-popover.tsx
+'use client'
+
+// The standard-cost roll (plans/products/build/01-build-plan.md §2.4).
+//
+// 🛑 **A roll restates the balance sheet, so this is never a button that just
+// fires.** The whole component is the preview: `builds.previewRoll` runs the
+// same plan the mutation will run and reports the revaluation delta per part
+// and summed, plus every part that cannot be valued at all. Confirming is the
+// second step, and it is deliberately below the numbers rather than beside the
+// trigger.
+//
+// Scoped to one part, and **widened server-side to every ancestor of it** — a
+// finished good whose subassembly's standard just moved is carrying a standard
+// built from the old number, so rolling the child alone would leave the two
+// disagreeing. That is why the preview usually lists more parts than the one
+// this popover was opened from.
+
+import { FieldType } from '@auxx/database/enums'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
+import { useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { api } from '~/trpc/react'
+
+/** Why a part could not be valued, in words a person can act on. */
+const SKIP_REASON_LABEL: Record<string, string> = {
+  'no-live-cost': 'no supplier price and no priced bill of materials',
+  'no-bill-of-materials': 'classified as buildable but has no bill of materials',
+}
+
+interface RollStandardCostPopoverProps {
+  /** The part's entityInstanceId. */
+  partId: string
+  onSuccess?: () => void
+  children: React.ReactNode
+}
+
+export function RollStandardCostPopover({
+  partId,
+  onSuccess,
+  children,
+}: RollStandardCostPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const [effectiveAt, setEffectiveAt] = useState<string>(() => new Date().toISOString())
+
+  // A fresh effective date every time it opens — a stale one left over from a
+  // popover somebody abandoned yesterday would silently backdate the roll.
+  useEffect(() => {
+    if (open) setEffectiveAt(new Date().toISOString())
+  }, [open])
+
+  const preview = api.builds.previewRoll.useQuery(
+    { partIds: [partId], effectiveAt: new Date(effectiveAt) },
+    { enabled: open, retry: false, refetchOnWindowFocus: false }
+  )
+
+  const utils = api.useUtils()
+  const roll = api.builds.roll.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Failed to roll standard cost', description: error.message }),
+  })
+
+  const handleRoll = async () => {
+    try {
+      await roll.mutateAsync({ partIds: [partId], effectiveAt: new Date(effectiveAt) })
+      await utils.builds.previewRoll.invalidate()
+      onSuccess?.()
+      setOpen(false)
+    } catch {
+      // onError above already surfaced the toast.
+    }
+  }
+
+  const plan = preview.data
+  const changed = plan?.lines.filter((line) => line.changed) ?? []
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className='w-[26rem]' align='end'>
+        <div className='space-y-3'>
+          <div>
+            <h4 className='font-semibold text-sm'>Roll standard cost</h4>
+            <p className='mt-0.5 text-muted-foreground text-xs'>
+              Freezes today&apos;s cost as the value every stock movement will be stamped with. This
+              part and everything built from it.
+            </p>
+          </div>
+
+          <FieldPanel className='p-0'>
+            <FieldPanelRow
+              title='Effective'
+              type={BaseType.DATE}
+              showIcon
+              description='When the new standard takes effect'>
+              <FieldInputAdapter
+                fieldType={FieldType.DATETIME}
+                value={effectiveAt}
+                onChange={(val) => setEffectiveAt((val as string) ?? new Date().toISOString())}
+                disabled={roll.isPending}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+
+          {preview.isPending ? (
+            <div className='space-y-2'>
+              <Skeleton className='h-5 w-full' />
+              <Skeleton className='h-5 w-full' />
+            </div>
+          ) : preview.error ? (
+            // An unpriced component surfaces HERE rather than half-way through a
+            // write: the server refuses to value a parent whose child has no
+            // standard, because treating it as zero understates the finished good.
+            <p className='rounded-md bg-destructive/10 p-2 text-destructive text-xs'>
+              {preview.error.message}
+            </p>
+          ) : plan ? (
+            <div className='space-y-2'>
+              {changed.length === 0 ? (
+                <p className='text-muted-foreground text-xs'>
+                  Nothing to roll — the standard already matches today&apos;s cost.
+                </p>
+              ) : (
+                <ScrollArea className='max-h-48' allowScrollChaining>
+                  <div className='divide-y divide-border/50'>
+                    {changed.map((line) => (
+                      <div
+                        key={line.partId}
+                        className='flex items-baseline gap-2 py-1.5 text-xs tabular-nums'>
+                        <span className='flex-1 truncate'>{line.partName ?? line.partId}</span>
+                        <span className='text-muted-foreground'>
+                          {line.previousStandardCost == null
+                            ? '—'
+                            : formatCurrency(line.previousStandardCost)}
+                        </span>
+                        <span className='text-muted-foreground'>&rarr;</span>
+                        <span className='font-medium'>{formatCurrency(line.standardCost)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+              )}
+
+              {/* The number this whole preview exists for. */}
+              <div className='space-y-1 border-t border-border/50 pt-2 text-xs tabular-nums'>
+                <Summary
+                  label='Inventory revaluation'
+                  hint='(new standard − old) × qty on hand'
+                  value={plan.revaluationDelta}
+                  signed
+                />
+                {plan.initialValue !== 0 && (
+                  <Summary
+                    label='First valuation'
+                    hint='parts that had no standard before — not a revaluation'
+                    value={plan.initialValue}
+                  />
+                )}
+              </div>
+
+              {plan.skipped.length > 0 && (
+                <div className='border-t border-border/50 pt-2 text-xs'>
+                  <p className='text-muted-foreground'>
+                    Not valued ({plan.skipped.length}) — left untouched, never written as zero:
+                  </p>
+                  <ul className='mt-1 space-y-0.5'>
+                    {plan.skipped.slice(0, 5).map((skip) => (
+                      <li key={skip.partId} className='truncate text-muted-foreground'>
+                        {skip.partName ?? skip.partId} —{' '}
+                        {SKIP_REASON_LABEL[skip.reason] ?? skip.reason}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : null}
+
+          <div className='flex justify-end gap-2'>
+            <Button variant='ghost' size='sm' onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              size='sm'
+              loading={roll.isPending}
+              loadingText='Rolling...'
+              disabled={!plan || changed.length === 0 || roll.isPending}
+              onClick={handleRoll}>
+              Roll standard cost
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/** One summed number with the arithmetic that produced it spelled out. */
+function Summary({
+  label,
+  hint,
+  value,
+  signed,
+}: {
+  label: string
+  hint: string
+  value: number
+  signed?: boolean
+}) {
+  const sign = signed && value > 0 ? '+' : ''
+  return (
+    <div className='flex items-baseline justify-between gap-2'>
+      <span className='text-muted-foreground'>
+        {label} <span className='text-[10px]'>{hint}</span>
+      </span>
+      <span className='font-medium'>
+        {sign}
+        {formatCurrency(value)}
+      </span>
+    </div>
+  )
+}

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -18,6 +18,7 @@ import { auditLogRouter } from './routers/audit-log'
 import { authRouter } from './routers/auth'
 import { availabilityRouter } from './routers/availability'
 import { billingRouter } from './routers/billing'
+import { buildsRouter } from './routers/builds'
 import { calendarRouter } from './routers/calendar'
 import { channelRouter } from './routers/channel'
 import { channelReauthRouter } from './routers/channel-reauth'
@@ -123,6 +124,7 @@ export const appRouter = createTRPCRouter({
   auth: authRouter,
   availability: availabilityRouter,
   billing: billingRouter,
+  builds: buildsRouter,
   calendar: calendarRouter,
   chat: chatRouter,
   chatDuty: chatDutyRouter,

--- a/apps/web/src/server/api/routers/builds.ts
+++ b/apps/web/src/server/api/routers/builds.ts
@@ -1,0 +1,103 @@
+// apps/web/src/server/api/routers/builds.ts
+
+import { previewStandardCostRoll, rollStandardCost } from '@auxx/lib/builds'
+import { getCachedEntityDefId } from '@auxx/lib/cache'
+import { NotFoundError } from '@auxx/lib/errors'
+import { z } from 'zod'
+import { capabilityProcedure, createTRPCRouter } from '~/server/api/trpc'
+
+/**
+ * A roll may be scoped to a handful of parts, or run across the org.
+ *
+ * The cap is generous rather than meaningful — the widening step adds every
+ * ancestor anyway, and an unscoped roll covers everything. It exists only so a
+ * malformed client cannot send an unbounded array.
+ */
+const rollInput = z.object({
+  partIds: z.array(z.string().min(1)).max(500).optional(),
+  /** When the new standards take effect. Defaults to now. */
+  effectiveAt: z.coerce.date().optional(),
+})
+
+/**
+ * Standard cost — phase 1 of plans/products/build/01-build-plan.md.
+ *
+ * **Both procedures here are the permission gate for the lib call underneath.**
+ * `@auxx/lib/builds` contains no access checks by design, so if a gate is
+ * missing here it is missing everywhere.
+ *
+ * | procedure          | gate                |
+ * | ------------------ | ------------------- |
+ * | `previewRoll`      | edit on `part`      |
+ * | `roll`             | edit on `part`      |
+ *
+ * `assertEditEntity` on `part` on BOTH, not view on the preview: the preview
+ * exists solely to be the first half of a write, it discloses the balance-sheet
+ * effect of that write, and a reader who cannot roll has no use for it. Gating
+ * it the same way is what makes the button the UI hides and the door the server
+ * closes the same door.
+ *
+ * Lib returns neverthrow `Result`s carrying `AuxxError`s; those are rethrown
+ * as-is so `auxxErrorMiddleware` maps them. Wrapping one in a `TRPCError` would
+ * flatten the 422 an unpriced component produces into a 500.
+ */
+export const buildsRouter = createTRPCRouter({
+  /**
+   * What a roll WOULD do to the balance sheet.
+   *
+   * 🛑 **This is the point of the whole action** (section 2.4). A roll restates
+   * inventory value, so it must never be a button that just fires: this returns
+   * the revaluation delta per part and summed, plus the parts that cannot be
+   * valued at all, before anything is committed.
+   *
+   * A `.query()` because it writes nothing — not even the `part_cost` refresh
+   * the roll performs. In practice `part_cost` is already current;
+   * `recalculateAffectedParts` rewrites it on every vendor-price and
+   * bill-of-materials change.
+   */
+  previewRoll: capabilityProcedure.input(rollInput).query(async ({ ctx, input }) => {
+    const { organizationId } = ctx.session
+    ctx.capabilities.assertEditEntity(await requirePartDefId(organizationId))
+
+    const result = await previewStandardCostRoll(ctx.db, organizationId, {
+      partIds: input.partIds,
+      effectiveAt: input.effectiveAt ?? new Date(),
+    })
+    if (result.isErr()) throw result.error
+    return result.value
+  }),
+
+  /**
+   * Freeze a new standard cost onto every part in scope.
+   *
+   * The revaluation delta comes back on the result and is **not posted** — GL
+   * posting is out of scope for this directory (README B9). Nothing here
+   * touches an existing `stock_movement`: a mid-period standard change revalues
+   * on-hand inventory, it never restates history.
+   */
+  roll: capabilityProcedure.input(rollInput).mutation(async ({ ctx, input }) => {
+    const { organizationId, userId } = ctx.session
+    ctx.capabilities.assertEditEntity(await requirePartDefId(organizationId))
+
+    const result = await rollStandardCost(ctx.db, organizationId, userId, {
+      partIds: input.partIds,
+      effectiveAt: input.effectiveAt ?? new Date(),
+    })
+    if (result.isErr()) throw result.error
+    return result.value
+  }),
+})
+
+/**
+ * Resolve the `part` definition from the org cache, or refuse.
+ *
+ * A missing def is a 404 rather than a 403: the member is not being denied
+ * anything, the organization simply has no parts yet.
+ */
+async function requirePartDefId(organizationId: string): Promise<string> {
+  const defId = await getCachedEntityDefId(organizationId, 'part')
+  if (!defId) {
+    throw new NotFoundError('This organization has no part records yet.')
+  }
+  return defId
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -202,6 +202,18 @@
       "import": "./dist/bom/client.mjs",
       "default": "./src/bom/client.ts"
     },
+    "./builds": {
+      "types": "./src/builds/index.ts",
+      "source": "./src/builds/index.ts",
+      "import": "./dist/builds/index.mjs",
+      "default": "./src/builds/index.ts"
+    },
+    "./builds/client": {
+      "types": "./src/builds/client.ts",
+      "source": "./src/builds/client.ts",
+      "import": "./dist/builds/client.mjs",
+      "default": "./src/builds/client.ts"
+    },
     "./cache": {
       "types": "./src/cache/index.ts",
       "source": "./src/cache/index.ts",

--- a/packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
+++ b/packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
@@ -1,0 +1,392 @@
+// packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
+//
+// Cover for plans/products/build/01-build-plan.md section 2.2a and README B11 —
+// the two rules that keep account 5090 meaningful. Every case here is pure
+// arithmetic over an in-memory graph, so it needs no `vi.mock` at all.
+
+import { describe, expect, it } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import type { PartKindValue } from '../client'
+import {
+  computeStandardCosts,
+  type StandardCostRollInputs,
+  type SubpartEdge,
+  widenToAncestors,
+} from '../standard-cost-roll'
+import type { AbsorptionRates } from '../types'
+
+const MOTOR = 'part_motor'
+const TUBE = 'part_tube'
+const ASSEMBLY = 'part_assembly'
+const LIFT = 'part_lift'
+
+/** $5.00 direct labour and $2.00 overhead per assembled unit, in minor units. */
+const RATES: AbsorptionRates = { laborCostPerUnit: 500, overheadCostPerUnit: 200 }
+
+function inputs(overrides: Partial<StandardCostRollInputs> = {}): StandardCostRollInputs {
+  return {
+    scope: new Set<string>(),
+    partKinds: new Map<string, PartKindValue>(),
+    liveCosts: new Map<string, number>(),
+    subpartGraph: new Map<string, SubpartEdge[]>(),
+    storedStandardCosts: new Map<string, number>(),
+    rates: RATES,
+    ...overrides,
+  }
+}
+
+describe('computeStandardCosts', () => {
+  // The real lift, from section 2.2a's table. A purchased motor at $20.098 and a
+  // purchased tube at $9.510 make a $29.608 assembly; two of those plus $7.00 of
+  // conversion at each of the two levels make the lift.
+  const liftGraph = () =>
+    inputs({
+      scope: new Set([MOTOR, TUBE, ASSEMBLY, LIFT]),
+      partKinds: new Map<string, PartKindValue>([
+        [MOTOR, 'component'],
+        [TUBE, 'component'],
+        [ASSEMBLY, 'subassembly'],
+        [LIFT, 'finished_good'],
+      ]),
+      liveCosts: new Map([
+        [MOTOR, 2009.8],
+        [TUBE, 951],
+        // `part_cost` on a built part is the pure MATERIAL chain, and the roll
+        // must ignore it entirely. Present here so the test would catch a
+        // regression that read it.
+        [ASSEMBLY, 2960.8],
+        [LIFT, 5921.6],
+      ]),
+      subpartGraph: new Map<string, SubpartEdge[]>([
+        [
+          ASSEMBLY,
+          [
+            { childId: MOTOR, qty: 1 },
+            { childId: TUBE, qty: 1 },
+          ],
+        ],
+        [LIFT, [{ childId: ASSEMBLY, qty: 2 }]],
+      ]),
+    })
+
+  it("rolls children's standardCost, so a subassembly's conversion cost survives to the parent", () => {
+    const { costs } = computeStandardCosts(liftGraph())
+
+    expect(costs.get(ASSEMBLY)).toEqual({
+      standardMaterialCost: 2961, // round(2009.8) + round(951)
+      standardLaborCost: 500,
+      standardOverheadCost: 200,
+      standardCost: 3661,
+    })
+
+    // 2 x 3661 = 7322, NOT 2 x 2961 = 5922. The $14.00 difference is exactly the
+    // two assemblies' conversion cost, and rolling `part_cost` would drop it.
+    expect(costs.get(LIFT)).toEqual({
+      standardMaterialCost: 7322,
+      standardLaborCost: 500,
+      standardOverheadCost: 200,
+      standardCost: 8022,
+    })
+
+    const naiveMaterial = Math.round(2960.8) * 2
+    expect(costs.get(LIFT)!.standardMaterialCost - naiveMaterial).toBe(1400)
+  })
+
+  it('gives a purchased component zero labour and zero overhead', () => {
+    const { costs } = computeStandardCosts(liftGraph())
+
+    // Zero, not null: we know we did not assemble it. Adding $7.00 of assembly
+    // labour to a motor capitalises cost never spent and overstates 1310.
+    expect(costs.get(MOTOR)).toEqual({
+      standardMaterialCost: 2010,
+      standardLaborCost: 0,
+      standardOverheadCost: 0,
+      standardCost: 2010,
+    })
+  })
+
+  it('treats a NULL partKind as a component, so an unclassified part absorbs nothing', () => {
+    const { costs } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR]),
+        // No entry at all for MOTOR — `part_kind` is set on 5 of 218 parts.
+        partKinds: new Map(),
+        liveCosts: new Map([[MOTOR, 2009.8]]),
+        subpartGraph: new Map([[MOTOR, [{ childId: TUBE, qty: 1 }]]]),
+      })
+    )
+
+    expect(costs.get(MOTOR)).toEqual({
+      standardMaterialCost: 2010,
+      standardLaborCost: 0,
+      standardOverheadCost: 0,
+      standardCost: 2010,
+    })
+  })
+
+  it('gates conversion cost on partKind, not on which number part_cost took', () => {
+    // A part with BOTH a vendor price and a bill of materials: `part_cost_source`
+    // would flip to 'vendor' here, and gating on it would silently strip the
+    // subassembly's conversion cost.
+    const { costs } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, ASSEMBLY]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [ASSEMBLY, 'subassembly'],
+        ]),
+        liveCosts: new Map([
+          [MOTOR, 1000],
+          [ASSEMBLY, 900],
+        ]),
+        subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 1 }]]]),
+      })
+    )
+
+    expect(costs.get(ASSEMBLY)).toEqual({
+      standardMaterialCost: 1000,
+      standardLaborCost: 500,
+      standardOverheadCost: 200,
+      standardCost: 1700,
+    })
+  })
+
+  it('aborts the parent with UnprocessableEntityError when a child has no standard cost', () => {
+    const naming = inputs({
+      scope: new Set([MOTOR, ASSEMBLY]),
+      partKinds: new Map<string, PartKindValue>([
+        [MOTOR, 'component'],
+        [ASSEMBLY, 'subassembly'],
+      ]),
+      // MOTOR has no `part_cost`, so it has no standard to contribute.
+      liveCosts: new Map(),
+      subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 1 }]]]),
+      partNames: new Map([
+        [MOTOR, '400Lbs Motor'],
+        [ASSEMBLY, '400Lbs motor Assembly'],
+      ]),
+    })
+
+    expect(() => computeStandardCosts(naming)).toThrow(UnprocessableEntityError)
+    // Naming both parts is the point: silently valuing the assembly at $0 for
+    // the motor understates it and dumps the difference into 5090.
+    expect(() => computeStandardCosts(naming)).toThrow(/400Lbs motor Assembly/)
+    expect(() => computeStandardCosts(naming)).toThrow(/400Lbs Motor/)
+  })
+
+  it('aborts on a circular bill of materials rather than contributing zero', () => {
+    const cyclic = inputs({
+      scope: new Set([ASSEMBLY, LIFT]),
+      partKinds: new Map<string, PartKindValue>([
+        [ASSEMBLY, 'subassembly'],
+        [LIFT, 'finished_good'],
+      ]),
+      subpartGraph: new Map<string, SubpartEdge[]>([
+        [LIFT, [{ childId: ASSEMBLY, qty: 1 }]],
+        [ASSEMBLY, [{ childId: LIFT, qty: 1 }]],
+      ]),
+      partNames: new Map([[LIFT, 'Auxx Lift 400lbs 4x8']]),
+    })
+
+    // `calculateAllCosts` contains a cycle by contributing 0 to the parent. A
+    // standard must not: that 0 would be frozen onto every movement.
+    expect(() => computeStandardCosts(cyclic)).toThrow(UnprocessableEntityError)
+    expect(() => computeStandardCosts(cyclic)).toThrow(/circular/i)
+  })
+
+  it('reads an out-of-scope child at its STORED standard, never a recomputed one', () => {
+    // Scoped roll of the lift only. The assembly keeps the standard already
+    // agreed for it — which is the number `completeBuild` will value the consume
+    // rows at, so the parent has to be built from the same one.
+    const { costs } = computeStandardCosts(
+      inputs({
+        scope: new Set([LIFT]),
+        partKinds: new Map<string, PartKindValue>([
+          [ASSEMBLY, 'subassembly'],
+          [LIFT, 'finished_good'],
+        ]),
+        liveCosts: new Map([[ASSEMBLY, 9999]]),
+        subpartGraph: new Map<string, SubpartEdge[]>([
+          [LIFT, [{ childId: ASSEMBLY, qty: 2 }]],
+          [ASSEMBLY, [{ childId: MOTOR, qty: 1 }]],
+        ]),
+        storedStandardCosts: new Map([[ASSEMBLY, 3661]]),
+      })
+    )
+
+    expect(costs.get(LIFT)!.standardMaterialCost).toBe(7322)
+    expect(costs.has(ASSEMBLY)).toBe(false)
+  })
+
+  it('aborts when an out-of-scope child has never been rolled', () => {
+    expect(() =>
+      computeStandardCosts(
+        inputs({
+          scope: new Set([LIFT]),
+          partKinds: new Map<string, PartKindValue>([[LIFT, 'finished_good']]),
+          subpartGraph: new Map([[LIFT, [{ childId: ASSEMBLY, qty: 2 }]]]),
+          storedStandardCosts: new Map(),
+        })
+      )
+    ).toThrow(UnprocessableEntityError)
+  })
+
+  it('stores NULL, not zero, for an absorption rate that has not been declared', () => {
+    const { costs } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, ASSEMBLY]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [ASSEMBLY, 'subassembly'],
+        ]),
+        liveCosts: new Map([[MOTOR, 1000]]),
+        subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 1 }]]]),
+        rates: { laborCostPerUnit: null, overheadCostPerUnit: null },
+      })
+    )
+
+    // "No absorption declared" and "a declared rate of zero" are numerically
+    // identical once summed, so the distinction survives in storage.
+    expect(costs.get(ASSEMBLY)).toEqual({
+      standardMaterialCost: 1000,
+      standardLaborCost: null,
+      standardOverheadCost: null,
+      standardCost: 1000,
+    })
+    // A component still stores 0 — its conversion cost is a fact, not an absence.
+    expect(costs.get(MOTOR)!.standardLaborCost).toBe(0)
+  })
+
+  it('distinguishes a declared zero rate from an undeclared one', () => {
+    const { costs } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, ASSEMBLY]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [ASSEMBLY, 'subassembly'],
+        ]),
+        liveCosts: new Map([[MOTOR, 1000]]),
+        subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 1 }]]]),
+        rates: { laborCostPerUnit: 0, overheadCostPerUnit: null },
+      })
+    )
+
+    expect(costs.get(ASSEMBLY)!.standardLaborCost).toBe(0)
+    expect(costs.get(ASSEMBLY)!.standardOverheadCost).toBeNull()
+  })
+
+  it('rounds before freezing, because CURRENCY is integer minor units', () => {
+    const { costs } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, ASSEMBLY]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [ASSEMBLY, 'subassembly'],
+        ]),
+        // A landed cost carrying a fractional-cent tariff term.
+        liveCosts: new Map([[MOTOR, 4442.975]]),
+        // Fractional quantities are legal — `subpart_quantity` is doublePrecision.
+        subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 2.5 }]]]),
+        rates: { laborCostPerUnit: 500.4, overheadCostPerUnit: null },
+      })
+    )
+
+    expect(costs.get(MOTOR)!.standardCost).toBe(4443)
+    expect(costs.get(ASSEMBLY)!.standardMaterialCost).toBe(11108) // round(4443 x 2.5)
+    expect(costs.get(ASSEMBLY)!.standardLaborCost).toBe(500)
+    expect(Number.isInteger(costs.get(ASSEMBLY)!.standardCost)).toBe(true)
+  })
+
+  it('skips an unpriced component instead of writing it as zero', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, TUBE]),
+        partKinds: new Map<string, PartKindValue>([[TUBE, 'component']]),
+        liveCosts: new Map([[TUBE, 951]]),
+      })
+    )
+
+    expect(costs.has(MOTOR)).toBe(false)
+    expect(skipped).toEqual([{ partId: MOTOR, reason: 'no-live-cost', partName: null }])
+    expect(costs.get(TUBE)!.standardCost).toBe(951)
+  })
+
+  it('skips a buildable part that has no bill of materials yet', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([ASSEMBLY]),
+        partKinds: new Map<string, PartKindValue>([[ASSEMBLY, 'subassembly']]),
+      })
+    )
+
+    // Not an abort: nothing is being understated, because there are no inputs at
+    // all. It is reported so it stays visible.
+    expect(costs.has(ASSEMBLY)).toBe(false)
+    expect(skipped).toEqual([{ partId: ASSEMBLY, reason: 'no-bill-of-materials', partName: null }])
+  })
+
+  it('walks bottom-up, so every child settles before the parent that reads it', () => {
+    const { order } = computeStandardCosts(liftGraph())
+
+    expect(order.indexOf(MOTOR)).toBeLessThan(order.indexOf(ASSEMBLY))
+    expect(order.indexOf(TUBE)).toBeLessThan(order.indexOf(ASSEMBLY))
+    expect(order.indexOf(ASSEMBLY)).toBeLessThan(order.indexOf(LIFT))
+  })
+
+  it('memoizes a shared child rather than re-rolling it per parent', () => {
+    const shared = inputs({
+      scope: new Set([MOTOR, ASSEMBLY, LIFT]),
+      partKinds: new Map<string, PartKindValue>([
+        [MOTOR, 'component'],
+        [ASSEMBLY, 'subassembly'],
+        [LIFT, 'finished_good'],
+      ]),
+      liveCosts: new Map([[MOTOR, 1000]]),
+      subpartGraph: new Map<string, SubpartEdge[]>([
+        [ASSEMBLY, [{ childId: MOTOR, qty: 1 }]],
+        [
+          LIFT,
+          [
+            { childId: MOTOR, qty: 1 },
+            { childId: ASSEMBLY, qty: 1 },
+          ],
+        ],
+      ]),
+    })
+
+    const { order } = computeStandardCosts(shared)
+    expect(order.filter((id) => id === MOTOR)).toHaveLength(1)
+  })
+})
+
+describe('widenToAncestors', () => {
+  // parent graph: child -> [parents]
+  const parentGraph = new Map<string, string[]>([
+    [MOTOR, [ASSEMBLY]],
+    [TUBE, [ASSEMBLY]],
+    [ASSEMBLY, [LIFT]],
+  ])
+
+  it('pulls in every ancestor of a named part', () => {
+    // The same widening `recalculateAffectedParts` performs: a finished good
+    // whose subassembly just moved is carrying a standard built from the old
+    // number.
+    expect([...widenToAncestors([MOTOR], parentGraph)].sort()).toEqual(
+      [MOTOR, ASSEMBLY, LIFT].sort()
+    )
+  })
+
+  it('pulls in no descendants', () => {
+    // Rolling a finished good values it at its subassemblies' already-agreed
+    // standards. Widening downward would re-value what the caller did not ask to.
+    expect([...widenToAncestors([LIFT], parentGraph)]).toEqual([LIFT])
+  })
+
+  it('terminates on a cycle in the parent graph', () => {
+    const cyclic = new Map<string, string[]>([
+      [ASSEMBLY, [LIFT]],
+      [LIFT, [ASSEMBLY]],
+    ])
+    expect([...widenToAncestors([ASSEMBLY], cyclic)].sort()).toEqual([ASSEMBLY, LIFT].sort())
+  })
+})

--- a/packages/lib/src/builds/__tests__/standard-cost.test.ts
+++ b/packages/lib/src/builds/__tests__/standard-cost.test.ts
@@ -1,0 +1,500 @@
+// packages/lib/src/builds/__tests__/standard-cost.test.ts
+//
+// The IO half of the roll: ancestor widening against real data, the revaluation
+// delta the preview exists to show, and what actually gets written.
+// Harness style follows `bom/cost-calculator.test.ts` — mock `@auxx/database`'s
+// schema, hand the functions a fake `db`, and assert on the writer's calls.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  queryQueue: [] as unknown[][],
+  setValueWithType: vi.fn(async (_ctx: unknown, _params: unknown) => [] as unknown[]),
+  publishFieldValueUpdates: vi.fn(async () => {}),
+  recalculateAllPartCosts: vi.fn(async (_orgId: string) => [] as string[]),
+  subparts: [] as { parentPartId: string; childPartId: string; quantity: number }[],
+  settings: {} as Record<string, unknown>,
+  callOrder: [] as string[],
+}))
+
+function nextRows(): unknown[] {
+  return h.queryQueue.shift() ?? []
+}
+
+/** Minimal drizzle-shaped stub: `select().from().where()` resolves the next queued rows. */
+const db = {
+  select: () => ({
+    from: () => ({
+      where: () => Promise.resolve(nextRows()),
+    }),
+  }),
+} as never
+
+vi.mock('@auxx/database', () => ({
+  schema: {
+    EntityInstance: {
+      id: 'id',
+      displayName: 'displayName',
+      organizationId: 'organizationId',
+      entityDefinitionId: 'entityDefinitionId',
+      archivedAt: 'archivedAt',
+    },
+    FieldValue: {
+      entityId: 'entityId',
+      fieldId: 'fieldId',
+      organizationId: 'organizationId',
+      valueNumber: 'valueNumber',
+      valueDate: 'valueDate',
+      optionId: 'optionId',
+    },
+  },
+}))
+
+const FIELD: Record<string, { id: string; type: string }> = {
+  part_kind: { id: 'f_kind', type: 'SINGLE_SELECT' },
+  part_cost: { id: 'f_cost', type: 'CURRENCY' },
+  part_quantity_on_hand: { id: 'f_qoh', type: 'NUMBER' },
+  part_standard_material_cost: { id: 'f_std_mat', type: 'CURRENCY' },
+  part_standard_labor_cost: { id: 'f_std_lab', type: 'CURRENCY' },
+  part_standard_overhead_cost: { id: 'f_std_ovh', type: 'CURRENCY' },
+  part_standard_cost: { id: 'f_std', type: 'CURRENCY' },
+  part_standard_cost_effective_at: { id: 'f_std_at', type: 'DATETIME' },
+}
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(attrs.map((a) => [a, FIELD[a] ?? null])),
+    }),
+  }),
+  requireCachedEntityDefId: async () => 'part_def',
+}))
+
+vi.mock('../../bom/cost-calculator', () => ({
+  recalculateAllPartCosts: async (orgId: string) => {
+    h.callOrder.push('recalculateAllPartCosts')
+    return h.recalculateAllPartCosts(orgId)
+  },
+  loadOrgPricingData: async () => {
+    h.callOrder.push('loadOrgPricingData')
+    return { vendorPrices: [], subparts: h.subparts }
+  },
+  buildSubpartGraph: (rows: typeof h.subparts) => {
+    const map = new Map<string, { childId: string; qty: number }[]>()
+    for (const row of rows) {
+      const children = map.get(row.parentPartId) ?? []
+      children.push({ childId: row.childPartId, qty: row.quantity })
+      map.set(row.parentPartId, children)
+    }
+    return map
+  },
+  buildParentGraph: (rows: typeof h.subparts) => {
+    const map = new Map<string, string[]>()
+    for (const row of rows) {
+      const parents = map.get(row.childPartId) ?? []
+      parents.push(row.parentPartId)
+      map.set(row.childPartId, parents)
+    }
+    return map
+  },
+}))
+
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: async ({ key }: { key: string }) => h.settings[key] ?? null,
+}))
+
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: (organizationId: string, userId?: string) => ({
+    organizationId,
+    userId,
+  }),
+}))
+
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+
+vi.mock('../../field-values/stored-field-type', () => ({
+  toFieldType: (stored: string) => stored,
+}))
+
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishFieldValueUpdates: h.publishFieldValueUpdates,
+}))
+
+import { rollStandardCost } from '../standard-cost'
+import { previewStandardCostRoll, readStandardCost } from '../standard-cost-queries'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const MOTOR = 'part_motor'
+const ASSEMBLY = 'part_assembly'
+const LIFT = 'part_lift'
+const EFFECTIVE_AT = new Date('2026-08-27T00:00:00.000Z')
+
+/** A `FieldValue` row as the loader reads it. */
+function fv(
+  entityId: string,
+  fieldId: string,
+  value: { number?: number; date?: string; option?: string }
+) {
+  return {
+    entityId,
+    fieldId,
+    valueNumber: value.number ?? null,
+    valueDate: value.date ?? null,
+    optionId: value.option ?? null,
+  }
+}
+
+/**
+ * Queue the two reads `planStandardCostRoll` makes, in the order it makes them:
+ * every part instance, then every stored field value.
+ */
+function queueOrg(
+  parts: { id: string; displayName: string | null }[],
+  fieldValues: ReturnType<typeof fv>[]
+) {
+  h.queryQueue = [parts, fieldValues]
+}
+
+/** The lift graph: motor -> assembly -> lift, one of each. */
+function liftSubparts() {
+  return [
+    { parentPartId: ASSEMBLY, childPartId: MOTOR, quantity: 1 },
+    { parentPartId: LIFT, childPartId: ASSEMBLY, quantity: 2 },
+  ]
+}
+
+const PARTS = [
+  { id: MOTOR, displayName: '400Lbs Motor' },
+  { id: ASSEMBLY, displayName: '400Lbs motor Assembly' },
+  { id: LIFT, displayName: 'Auxx Lift 400lbs 4x8' },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // `clearAllMocks` clears calls but keeps implementations, so a test that made
+  // a write fail would leak that failure into every test after it.
+  h.setValueWithType.mockImplementation(async () => [])
+  h.queryQueue = []
+  h.subparts = []
+  h.settings = {}
+  h.callOrder = []
+})
+
+describe('previewStandardCostRoll', () => {
+  it('reports the revaluation delta per part and summed, without writing', async () => {
+    h.subparts = liftSubparts()
+    queueOrg(PARTS, [
+      fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+      fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+      fv(MOTOR, FIELD.part_quantity_on_hand!.id, { number: 10 }),
+      // Previously rolled at $20.10; the new standard is $22.00.
+      fv(MOTOR, FIELD.part_standard_cost!.id, { number: 2010 }),
+      fv(MOTOR, FIELD.part_standard_material_cost!.id, { number: 2010 }),
+      fv(MOTOR, FIELD.part_standard_cost_effective_at!.id, { date: '2026-01-01T00:00:00.000Z' }),
+    ])
+
+    const result = await previewStandardCostRoll(db, ORG, {
+      partIds: [MOTOR],
+      effectiveAt: EFFECTIVE_AT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    const plan = result._unsafeUnwrap()
+    const motor = plan.lines.find((line) => line.partId === MOTOR)!
+    expect(motor.previousStandardCost).toBe(2010)
+    expect(motor.standardCost).toBe(2200)
+    expect(motor.quantityOnHand).toBe(10)
+    expect(motor.revaluationDelta).toBe(1900) // (2200 - 2010) x 10
+    expect(motor.isInitial).toBe(false)
+    expect(plan.revaluationDelta).toBe(1900)
+
+    // A preview restates nothing. Nothing is written and `part_cost` is not
+    // even refreshed, so a `.query()` procedure can call it.
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.callOrder).not.toContain('recalculateAllPartCosts')
+  })
+
+  it('reports a first roll as an initial valuation, not as a revaluation', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+        fv(MOTOR, FIELD.part_quantity_on_hand!.id, { number: 10 }),
+      ]
+    )
+
+    const plan = (
+      await previewStandardCostRoll(db, ORG, { partIds: [MOTOR], effectiveAt: EFFECTIVE_AT })
+    )._unsafeUnwrap()
+
+    const motor = plan.lines[0]!
+    expect(motor.isInitial).toBe(true)
+    // Folding this into the delta would report the whole on-hand inventory value
+    // as a variance on the very first roll.
+    expect(motor.revaluationDelta).toBe(0)
+    expect(motor.initialValue).toBe(22000)
+    expect(plan.revaluationDelta).toBe(0)
+    expect(plan.initialValue).toBe(22000)
+  })
+
+  it('widens a scoped roll to every ancestor of the parts named', async () => {
+    h.subparts = liftSubparts()
+    queueOrg(PARTS, [
+      fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+      fv(MOTOR, FIELD.part_cost!.id, { number: 2010 }),
+      fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      fv(LIFT, FIELD.part_kind!.id, { option: 'finished_good' }),
+    ])
+    h.settings = {
+      'manufacturing.assemblyLaborCostPerUnit': 500,
+      'manufacturing.overheadCostPerUnit': 200,
+    }
+
+    // Only the motor is named — the assembly and the lift are carrying standards
+    // built from the old number and must be rolled with it.
+    const plan = (
+      await previewStandardCostRoll(db, ORG, { partIds: [MOTOR], effectiveAt: EFFECTIVE_AT })
+    )._unsafeUnwrap()
+
+    expect(plan.lines.map((line) => line.partId)).toEqual([MOTOR, ASSEMBLY, LIFT])
+    expect(plan.lines.find((l) => l.partId === ASSEMBLY)!.standardCost).toBe(2710)
+    expect(plan.lines.find((l) => l.partId === LIFT)!.standardCost).toBe(6120)
+  })
+
+  it('surfaces an unpriced component as UnprocessableEntityError before anything commits', async () => {
+    h.subparts = liftSubparts()
+    queueOrg(PARTS, [
+      fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      fv(LIFT, FIELD.part_kind!.id, { option: 'finished_good' }),
+    ])
+
+    const result = await previewStandardCostRoll(db, ORG, { effectiveAt: EFFECTIVE_AT })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toMatch(/400Lbs Motor/)
+  })
+
+  it('refuses when the part_standard_* fields have not been provisioned', async () => {
+    const saved = FIELD.part_standard_cost!
+    delete FIELD.part_standard_cost
+    try {
+      const result = await previewStandardCostRoll(db, ORG, { effectiveAt: EFFECTIVE_AT })
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr().message).toMatch(/not available/i)
+    } finally {
+      FIELD.part_standard_cost = saved
+    }
+  })
+})
+
+describe('rollStandardCost', () => {
+  /** Every `setValueWithType` call, flattened to `fieldId -> value`. */
+  function writesFor(partId: string) {
+    return h.setValueWithType.mock.calls
+      .map(([, params]) => params as { recordId: string; fieldId: string; value: unknown })
+      .filter((params) => params.recordId.includes(partId))
+      .map((params) => [params.fieldId, params.value] as const)
+  }
+
+  it('refreshes part_cost before planning, so the roll never freezes a stale price', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+      ]
+    )
+
+    await rollStandardCost(db, ORG, USER, { partIds: [MOTOR], effectiveAt: EFFECTIVE_AT })
+
+    expect(h.callOrder[0]).toBe('recalculateAllPartCosts')
+    expect(h.callOrder).toContain('loadOrgPricingData')
+  })
+
+  it('writes all five fields and stamps the effective date', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+        fv(MOTOR, FIELD.part_quantity_on_hand!.id, { number: 4 }),
+      ]
+    )
+
+    const result = await rollStandardCost(db, ORG, USER, {
+      partIds: [MOTOR],
+      effectiveAt: EFFECTIVE_AT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([MOTOR])
+    expect(writesFor(MOTOR)).toEqual([
+      [FIELD.part_standard_material_cost!.id, { type: 'number', value: 2200 }],
+      // A component's conversion cost is zero as a FACT, not as an absence.
+      [FIELD.part_standard_labor_cost!.id, { type: 'number', value: 0 }],
+      [FIELD.part_standard_overhead_cost!.id, { type: 'number', value: 0 }],
+      [FIELD.part_standard_cost!.id, { type: 'number', value: 2200 }],
+      [
+        FIELD.part_standard_cost_effective_at!.id,
+        { type: 'date', value: '2026-08-27T00:00:00.000Z' },
+      ],
+    ])
+  })
+
+  it('clears the absorption components when no rate is declared, rather than leaving a stale one', async () => {
+    h.subparts = [{ parentPartId: ASSEMBLY, childPartId: MOTOR, quantity: 1 }]
+    queueOrg(
+      [PARTS[0]!, PARTS[1]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+        fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+        // A rate that WAS declared when this part was last rolled.
+        fv(ASSEMBLY, FIELD.part_standard_labor_cost!.id, { number: 500 }),
+      ]
+    )
+    // ...and is not declared now.
+    h.settings = {}
+
+    await rollStandardCost(db, ORG, USER, { effectiveAt: EFFECTIVE_AT })
+
+    const writes = new Map(writesFor(ASSEMBLY))
+    expect(writes.get(FIELD.part_standard_labor_cost!.id)).toBeNull()
+    expect(writes.get(FIELD.part_standard_overhead_cost!.id)).toBeNull()
+    expect(writes.get(FIELD.part_standard_cost!.id)).toEqual({ type: 'number', value: 2200 })
+  })
+
+  it('writes nothing, and does not move the effective date, when the standard has not changed', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+        fv(MOTOR, FIELD.part_standard_material_cost!.id, { number: 2200 }),
+        fv(MOTOR, FIELD.part_standard_labor_cost!.id, { number: 0 }),
+        fv(MOTOR, FIELD.part_standard_overhead_cost!.id, { number: 0 }),
+        fv(MOTOR, FIELD.part_standard_cost!.id, { number: 2200 }),
+        fv(MOTOR, FIELD.part_standard_cost_effective_at!.id, { date: '2026-01-01T00:00:00.000Z' }),
+      ]
+    )
+
+    const result = await rollStandardCost(db, ORG, USER, { effectiveAt: EFFECTIVE_AT })
+
+    // A standard that did not move took effect earlier. Restamping it would
+    // erase the one signal that says how stale it is.
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
+  })
+
+  it('touches only the five part_standard_* fields — never a stock movement', async () => {
+    h.subparts = liftSubparts()
+    queueOrg(PARTS, [
+      fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+      fv(MOTOR, FIELD.part_cost!.id, { number: 2010 }),
+      fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      fv(LIFT, FIELD.part_kind!.id, { option: 'finished_good' }),
+    ])
+
+    await rollStandardCost(db, ORG, USER, { effectiveAt: EFFECTIVE_AT })
+
+    const owned = new Set([
+      FIELD.part_standard_material_cost!.id,
+      FIELD.part_standard_labor_cost!.id,
+      FIELD.part_standard_overhead_cost!.id,
+      FIELD.part_standard_cost!.id,
+      FIELD.part_standard_cost_effective_at!.id,
+    ])
+    const touched = h.setValueWithType.mock.calls.map(
+      ([, params]) => (params as { fieldId: string }).fieldId
+    )
+    expect(touched.length).toBeGreaterThan(0)
+    // A mid-period standard change is a one-time revaluation of ON-HAND stock,
+    // never a restatement of history.
+    expect(touched.every((fieldId) => owned.has(fieldId))).toBe(true)
+  })
+
+  it('aborts the roll when a write fails, rather than reporting a partial success', async () => {
+    h.subparts = liftSubparts()
+    queueOrg(PARTS, [
+      fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+      fv(MOTOR, FIELD.part_cost!.id, { number: 2010 }),
+      fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      fv(LIFT, FIELD.part_kind!.id, { option: 'finished_good' }),
+    ])
+    // The last part in the bottom-up order fails; the two beneath it land.
+    h.setValueWithType.mockImplementation(async (_ctx, params) => {
+      const { recordId } = params as { recordId: string }
+      if (recordId.includes(LIFT)) throw new Error('connection lost')
+      return []
+    })
+
+    const result = await rollStandardCost(db, ORG, USER, { effectiveAt: EFFECTIVE_AT })
+
+    // A half-applied roll reported as a success would leave a parent frozen
+    // against children that never moved.
+    expect(result.isErr()).toBe(true)
+    // What did land is still published, so open clients are not left rendering a
+    // stale number that no reload explains.
+    expect(h.publishFieldValueUpdates).toHaveBeenCalled()
+  })
+
+  it('returns the revaluation delta rather than posting it', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+        fv(MOTOR, FIELD.part_quantity_on_hand!.id, { number: 10 }),
+        fv(MOTOR, FIELD.part_standard_cost!.id, { number: 2010 }),
+        fv(MOTOR, FIELD.part_standard_cost_effective_at!.id, { date: '2026-01-01T00:00:00.000Z' }),
+      ]
+    )
+
+    const result = await rollStandardCost(db, ORG, USER, { effectiveAt: EFFECTIVE_AT })
+
+    // GL posting is out of scope for this directory (README B9) — the number is
+    // computed and handed back, and nothing writes a journal entry.
+    expect(result._unsafeUnwrap().revaluationDelta).toBe(1900)
+  })
+})
+
+describe('readStandardCost', () => {
+  it('omits a part that has never been rolled, so absence can never read as zero', async () => {
+    h.queryQueue = [
+      [
+        fv(MOTOR, FIELD.part_standard_cost!.id, { number: 2200 }),
+        fv(MOTOR, FIELD.part_standard_material_cost!.id, { number: 2200 }),
+        fv(MOTOR, FIELD.part_standard_cost_effective_at!.id, { date: '2026-08-27T00:00:00.000Z' }),
+        // The assembly has a material component but no standard — a half-written
+        // row is still not a standard.
+        fv(ASSEMBLY, FIELD.part_standard_material_cost!.id, { number: 5000 }),
+      ],
+    ]
+
+    const result = await readStandardCost(db, ORG, [MOTOR, ASSEMBLY, LIFT])
+
+    const map = result._unsafeUnwrap()
+    expect(map.get(MOTOR)).toEqual({
+      partId: MOTOR,
+      standardMaterialCost: 2200,
+      standardLaborCost: null,
+      standardOverheadCost: null,
+      standardCost: 2200,
+      effectiveAt: new Date('2026-08-27T00:00:00.000Z'),
+    })
+    expect(map.has(ASSEMBLY)).toBe(false)
+    expect(map.has(LIFT)).toBe(false)
+  })
+
+  it('short-circuits on an empty part list without querying', async () => {
+    const result = await readStandardCost(db, ORG, [])
+    expect(result._unsafeUnwrap().size).toBe(0)
+  })
+})

--- a/packages/lib/src/builds/client.ts
+++ b/packages/lib/src/builds/client.ts
@@ -1,0 +1,99 @@
+// packages/lib/src/builds/client.ts
+
+/**
+ * Client-safe half of the builds module: the part-kind vocabulary the standard
+ * cost roll is gated on, and the pure arithmetic both the browser preview and
+ * the server roll run.
+ *
+ * No `'use client'` directive — server code imports this file too, and the
+ * directive would turn every export into a client-reference proxy there
+ * (`docs/lib-module-guide.md` section 7).
+ */
+
+/** The three values `part_kind` can hold. Mirrors `PartKind` in the registry. */
+export type PartKindValue = 'component' | 'subassembly' | 'finished_good'
+
+/** The two kinds a build can produce, and the only two that absorb conversion cost. */
+const BUILT_PART_KINDS: ReadonlySet<PartKindValue> = new Set<PartKindValue>([
+  'subassembly',
+  'finished_good',
+])
+
+/**
+ * Read a stored `part_kind` option value as a {@link PartKindValue}.
+ *
+ * 🛑 **NULL reads as `component`** (Gap C section 3.3), which is the conservative
+ * direction: an unclassified part gets no labour and no overhead, so nothing is
+ * capitalised that was never spent. It is also the *wrong* default for a part
+ * that is genuinely built — `part_kind` is set on 5 of 218 parts in the dev org
+ * — so classifying the built parts is a prerequisite of the first roll, not an
+ * afterthought.
+ *
+ * An unrecognised string falls to the same default rather than throwing, exactly
+ * as `resolveGlAccountForPartKind` does: a roll is not the place to discover
+ * that somebody added a fourth part kind.
+ */
+export function resolvePartKind(raw: string | null | undefined): PartKindValue {
+  if (raw === 'subassembly' || raw === 'finished_good') return raw
+  return 'component'
+}
+
+/**
+ * Does this part kind absorb direct labour and overhead?
+ *
+ * 🛑 Gate on `partKind`, **never** on `part_cost_source`. `source` is itself
+ * computed and flips the moment somebody adds a vendor price to a part that
+ * also has a bill of materials, so a part gated on it would silently change its
+ * costing basis. `partKind` is the stored, auditable classification (README
+ * B11, Gap C section 3.2).
+ */
+export function absorbsConversionCost(partKind: PartKindValue): boolean {
+  return BUILT_PART_KINDS.has(partKind)
+}
+
+/**
+ * Round a money value to whole minor units.
+ *
+ * 🛑 Not optional. `CURRENCY` is cents in a `doublePrecision` column and
+ * `computeLandedCost` can emit a fractional-cent tariff term (Gap C section 1.7,
+ * R11). Round before freezing, or every downstream balance check holds by luck
+ * instead of by construction — and `setValueWithType` rejects a fractional
+ * CURRENCY write outright (`assertCurrencyIntegerMinorUnits`).
+ */
+export function roundMinorUnits(value: number): number {
+  return Math.round(value)
+}
+
+/**
+ * The absorbed amount for one rate, in whole minor units, or `null`.
+ *
+ * 🛑 **A NULL rate means "no absorption declared" and must never read as zero.**
+ * The two are numerically indistinguishable once summed, so the distinction is
+ * kept in the TYPE and carried all the way into storage: a built part rolled
+ * while `manufacturing.assemblyLaborCostPerUnit` is unset stores
+ * `part_standard_labor_cost = NULL`, not `0`. A stored `0` then means somebody
+ * deliberately declared a zero rate, which is a different (and checkable) claim.
+ *
+ * A `component` is the one case that legitimately stores `0`: we did not
+ * assemble it, so its labour is zero as a fact rather than as an absence.
+ */
+export function absorbedRate(rate: number | null | undefined): number | null {
+  if (rate == null) return null
+  if (!Number.isFinite(rate)) return null
+  return roundMinorUnits(rate)
+}
+
+/**
+ * The drift between a part's live cost and its frozen standard, in minor units.
+ *
+ * *How far the standard has moved away from reality since it was last rolled* —
+ * which is the number that tells you a roll is due (section 2.4). `null` when
+ * either half is missing, because a drift against nothing is not zero drift.
+ */
+export function standardCostDrift(
+  liveCost: number | null | undefined,
+  standardCost: number | null | undefined
+): number | null {
+  if (liveCost == null || standardCost == null) return null
+  return liveCost - standardCost
+}

--- a/packages/lib/src/builds/guard.ts
+++ b/packages/lib/src/builds/guard.ts
@@ -1,0 +1,32 @@
+// packages/lib/src/builds/guard.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError } from '../errors'
+
+const logger = createScopedLogger('builds')
+
+/**
+ * Run an imperative body that may `throw` an {@link AuxxError} for known
+ * business-rule failures, and convert the outcome into a neverthrow `Result`.
+ *
+ * Copied from `snippets/guard.ts` per `docs/lib-module-guide.md` section 3 — it
+ * is small enough that duplicating it beats a shared abstraction, and
+ * duplicating it is what lets this module bind its own `createScopedLogger`
+ * scope so a failed roll is greppable as `scope='builds'`.
+ */
+export async function guard<T>(
+  fn: () => Promise<T>,
+  logMessage: string,
+  meta: Record<string, unknown> = {}
+): Promise<Result<T, AuxxError>> {
+  try {
+    return ok(await fn())
+  } catch (error) {
+    if (error instanceof AuxxError) {
+      return err(error)
+    }
+    logger.error(logMessage, { error, ...meta })
+    return err(new AuxxError('Internal error'))
+  }
+}

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -1,0 +1,43 @@
+// packages/lib/src/builds/index.ts
+
+/**
+ * Builds — phase 1: standard cost.
+ *
+ * plans/products/build/01-build-plan.md section 2. The `build` entity,
+ * `completeBuild` and `reverseBuild` are phase 2 and land in this same folder.
+ */
+
+export {
+  absorbedRate,
+  absorbsConversionCost,
+  type PartKindValue,
+  resolvePartKind,
+  roundMinorUnits,
+  standardCostDrift,
+} from './client'
+export { rollStandardCost } from './standard-cost'
+export {
+  loadAbsorptionRates,
+  loadStandardCostFields,
+  previewStandardCostRoll,
+  readStandardCost,
+  type StandardCostFields,
+} from './standard-cost-queries'
+export {
+  computeStandardCosts,
+  type StandardCostRollComputation,
+  type StandardCostRollInputs,
+  type SubpartEdge,
+  widenToAncestors,
+} from './standard-cost-roll'
+export type {
+  AbsorptionRates,
+  PartStandardCost,
+  RollStandardCostInput,
+  SkippedPart,
+  SkipReason,
+  StandardCostComponents,
+  StandardCostRollLine,
+  StandardCostRollPlan,
+  StandardCostRollResult,
+} from './types'

--- a/packages/lib/src/builds/standard-cost-queries.ts
+++ b/packages/lib/src/builds/standard-cost-queries.ts
@@ -1,0 +1,437 @@
+// packages/lib/src/builds/standard-cost-queries.ts
+
+/**
+ * Every READ the standard-cost roll needs, plus the two read-only public
+ * surfaces: {@link previewStandardCostRoll} and {@link readStandardCost}.
+ *
+ * Split from `standard-cost.ts` because that file writes — a module where one
+ * file both queries and mutates is the first step back toward a service class
+ * (`docs/lib-module-guide.md` section 5).
+ *
+ * No permission checks anywhere in this file. The router asserts
+ * (`docs/lib-module-guide.md` section 6).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import type { CustomFieldEntity } from '@auxx/database/types'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { buildParentGraph, buildSubpartGraph, loadOrgPricingData } from '../bom/cost-calculator'
+import { getOrgCache, requireCachedEntityDefId } from '../cache'
+import { UnprocessableEntityError } from '../errors'
+import { getOrganizationSetting } from '../settings/settings-service'
+import { type PartKindValue, resolvePartKind } from './client'
+import { guard } from './guard'
+import {
+  computeStandardCosts,
+  type StandardCostRollComputation,
+  type SubpartEdge,
+  widenToAncestors,
+} from './standard-cost-roll'
+import type {
+  AbsorptionRates,
+  PartStandardCost,
+  RollStandardCostInput,
+  StandardCostRollLine,
+  StandardCostRollPlan,
+} from './types'
+
+/** The five fields entity migration 109 added, plus the three the roll reads. */
+const ROLL_ATTRIBUTES = [
+  'part_kind',
+  'part_cost',
+  'part_quantity_on_hand',
+  'part_standard_material_cost',
+  'part_standard_labor_cost',
+  'part_standard_overhead_cost',
+  'part_standard_cost',
+  'part_standard_cost_effective_at',
+] as const
+
+/** The five `part_standard_*` fields the roll owns. `rollStandardCost` is their only writer. */
+export interface StandardCostFields {
+  material: CustomFieldEntity
+  labor: CustomFieldEntity
+  overhead: CustomFieldEntity
+  standard: CustomFieldEntity
+  effectiveAt: CustomFieldEntity
+  /** Read-only inputs. Absent on an org whose earlier migrations have not run. */
+  partKind: CustomFieldEntity | null
+  liveCost: CustomFieldEntity | null
+  quantityOnHand: CustomFieldEntity | null
+}
+
+/**
+ * Resolve the fields the roll reads and writes, or refuse.
+ *
+ * The five `part_standard_*` fields are REQUIRED: without them the roll would
+ * appear to succeed and freeze nothing, which is worse than a clear refusal.
+ * The three inputs are optional — an org missing `part_kind` simply reads every
+ * part as a `component`, which is the documented NULL behaviour anyway.
+ */
+export async function loadStandardCostFields(organizationId: string): Promise<StandardCostFields> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...ROLL_ATTRIBUTES])
+
+  const material = fields.part_standard_material_cost
+  const labor = fields.part_standard_labor_cost
+  const overhead = fields.part_standard_overhead_cost
+  const standard = fields.part_standard_cost
+  const effectiveAt = fields.part_standard_cost_effective_at
+
+  if (!material || !labor || !overhead || !standard || !effectiveAt) {
+    throw new UnprocessableEntityError(
+      'Standard cost is not available until the part standard cost fields are provisioned'
+    )
+  }
+
+  return {
+    material,
+    labor,
+    overhead,
+    standard,
+    effectiveAt,
+    partKind: fields.part_kind,
+    liveCost: fields.part_cost,
+    quantityOnHand: fields.part_quantity_on_hand,
+  }
+}
+
+/**
+ * The two `manufacturing.*` absorption rates.
+ *
+ * 🛑 They ship unset, and a `null` here must never collapse to `0` — the two are
+ * numerically indistinguishable once summed, so the distinction is kept in the
+ * type and carried into storage. See {@link absorbedRate}.
+ */
+export async function loadAbsorptionRates(organizationId: string): Promise<AbsorptionRates> {
+  const [labor, overhead] = await Promise.all([
+    getOrganizationSetting({ organizationId, key: 'manufacturing.assemblyLaborCostPerUnit' }),
+    getOrganizationSetting({ organizationId, key: 'manufacturing.overheadCostPerUnit' }),
+  ])
+  return {
+    laborCostPerUnit: typeof labor === 'number' ? labor : null,
+    overheadCostPerUnit: typeof overhead === 'number' ? overhead : null,
+  }
+}
+
+/** Every non-archived `part` in the org, with the name error messages use. */
+async function loadPartRows(
+  db: Database,
+  organizationId: string,
+  partDefId: string
+): Promise<{ id: string; displayName: string | null }[]> {
+  return db
+    .select({ id: schema.EntityInstance.id, displayName: schema.EntityInstance.displayName })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, partDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+}
+
+/** Every stored value of every field the roll touches, in one query. */
+export interface StoredPartValues {
+  partKinds: Map<string, PartKindValue>
+  liveCosts: Map<string, number>
+  quantitiesOnHand: Map<string, number>
+  standardMaterialCosts: Map<string, number>
+  standardLaborCosts: Map<string, number>
+  standardOverheadCosts: Map<string, number>
+  standardCosts: Map<string, number>
+  effectiveDates: Map<string, string>
+}
+
+async function loadStoredPartValues(
+  db: Database,
+  organizationId: string,
+  fields: StandardCostFields
+): Promise<StoredPartValues> {
+  const values: StoredPartValues = {
+    partKinds: new Map(),
+    liveCosts: new Map(),
+    quantitiesOnHand: new Map(),
+    standardMaterialCosts: new Map(),
+    standardLaborCosts: new Map(),
+    standardOverheadCosts: new Map(),
+    standardCosts: new Map(),
+    effectiveDates: new Map(),
+  }
+
+  const fieldIds = [
+    fields.partKind?.id,
+    fields.liveCost?.id,
+    fields.quantityOnHand?.id,
+    fields.material.id,
+    fields.labor.id,
+    fields.overhead.id,
+    fields.standard.id,
+    fields.effectiveAt.id,
+  ].filter((id): id is string => Boolean(id))
+
+  const rows = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueNumber: schema.FieldValue.valueNumber,
+      valueDate: schema.FieldValue.valueDate,
+      optionId: schema.FieldValue.optionId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        inArray(schema.FieldValue.fieldId, fieldIds),
+        eq(schema.FieldValue.organizationId, organizationId)
+      )
+    )
+
+  for (const row of rows) {
+    if (fields.partKind && row.fieldId === fields.partKind.id) {
+      // A SINGLE_SELECT lives in `optionId` — the registry's option rows carry
+      // no id, so the stored key is the raw option value.
+      values.partKinds.set(row.entityId, resolvePartKind(row.optionId))
+    } else if (fields.liveCost && row.fieldId === fields.liveCost.id) {
+      if (row.valueNumber != null) values.liveCosts.set(row.entityId, row.valueNumber)
+    } else if (fields.quantityOnHand && row.fieldId === fields.quantityOnHand.id) {
+      if (row.valueNumber != null) values.quantitiesOnHand.set(row.entityId, row.valueNumber)
+    } else if (row.fieldId === fields.material.id) {
+      if (row.valueNumber != null) values.standardMaterialCosts.set(row.entityId, row.valueNumber)
+    } else if (row.fieldId === fields.labor.id) {
+      if (row.valueNumber != null) values.standardLaborCosts.set(row.entityId, row.valueNumber)
+    } else if (row.fieldId === fields.overhead.id) {
+      if (row.valueNumber != null) values.standardOverheadCosts.set(row.entityId, row.valueNumber)
+    } else if (row.fieldId === fields.standard.id) {
+      if (row.valueNumber != null) values.standardCosts.set(row.entityId, row.valueNumber)
+    } else if (row.fieldId === fields.effectiveAt.id) {
+      if (row.valueDate != null) values.effectiveDates.set(row.entityId, row.valueDate)
+    }
+  }
+
+  return values
+}
+
+/** Everything `rollStandardCost` needs to turn a plan into writes. */
+export interface StandardCostRollContext {
+  partDefId: string
+  fields: StandardCostFields
+  plan: StandardCostRollPlan
+  stored: StoredPartValues
+  computation: StandardCostRollComputation
+}
+
+/**
+ * Build the plan: what a roll WOULD write, and what it would do to the balance
+ * sheet.
+ *
+ * 🛑 **Reads only.** `rollStandardCost` refreshes `part_cost` before calling
+ * this; the preview deliberately does not, so a preview never writes. In
+ * practice `part_cost` is already current — `recalculateAffectedParts` rewrites
+ * it on every vendor-price and bill-of-materials change — and the refresh in the
+ * roll is a repair step, not the source of the number.
+ */
+export async function planStandardCostRoll(
+  db: Database,
+  organizationId: string,
+  input: RollStandardCostInput
+): Promise<StandardCostRollContext> {
+  const partDefId = await requireCachedEntityDefId(organizationId, 'part')
+  const fields = await loadStandardCostFields(organizationId)
+  const [rates, partRows, stored, pricing] = await Promise.all([
+    loadAbsorptionRates(organizationId),
+    loadPartRows(db, organizationId, partDefId),
+    loadStoredPartValues(db, organizationId, fields),
+    loadOrgPricingData(organizationId),
+  ])
+
+  const allPartIds = new Set(partRows.map((row) => row.id))
+  // Only real names go in: `computeStandardCosts` falls back to the id for an
+  // error message, and a report would rather say "unnamed" than echo a cuid.
+  const partNames = new Map<string, string>()
+  for (const row of partRows) {
+    if (row.displayName) partNames.set(row.id, row.displayName)
+  }
+
+  const subpartGraph: ReadonlyMap<string, SubpartEdge[]> = buildSubpartGraph(pricing.subparts)
+  const parentGraph = buildParentGraph(pricing.subparts)
+
+  // Scoped -> widen to every ancestor, then intersect with the parts that
+  // actually exist, so a stale id from the caller cannot invent a write target.
+  const requested = input.partIds?.filter((id) => allPartIds.has(id)) ?? []
+  const scope =
+    input.partIds && input.partIds.length > 0
+      ? new Set([...widenToAncestors(requested, parentGraph)].filter((id) => allPartIds.has(id)))
+      : allPartIds
+
+  const computation = computeStandardCosts({
+    scope,
+    partKinds: stored.partKinds,
+    liveCosts: stored.liveCosts,
+    subpartGraph,
+    storedStandardCosts: stored.standardCosts,
+    rates,
+    partNames,
+  })
+
+  const effectiveAtIso = input.effectiveAt.toISOString()
+  const lines: StandardCostRollLine[] = []
+  let revaluationDelta = 0
+  let initialValue = 0
+
+  // `computation.order` is the bottom-up walk order, so a caller rendering the
+  // plan sees components before the assemblies built from them.
+  for (const partId of computation.order) {
+    const next = computation.costs.get(partId)
+    if (!next) continue
+
+    const previousStandardCost = stored.standardCosts.get(partId) ?? null
+    const quantityOnHand = stored.quantitiesOnHand.get(partId) ?? 0
+    const isInitial = previousStandardCost == null
+    const lineDelta = isInitial ? 0 : (next.standardCost - previousStandardCost) * quantityOnHand
+    const lineInitial = isInitial ? next.standardCost * quantityOnHand : 0
+
+    revaluationDelta += lineDelta
+    initialValue += lineInitial
+
+    lines.push({
+      partId,
+      partName: partNames.get(partId) ?? null,
+      partKind: stored.partKinds.get(partId) ?? 'component',
+      ...next,
+      previousStandardCost,
+      quantityOnHand,
+      revaluationDelta: lineDelta,
+      isInitial,
+      initialValue: lineInitial,
+      changed:
+        next.standardMaterialCost !== (stored.standardMaterialCosts.get(partId) ?? null) ||
+        next.standardLaborCost !== (stored.standardLaborCosts.get(partId) ?? null) ||
+        next.standardOverheadCost !== (stored.standardOverheadCosts.get(partId) ?? null) ||
+        next.standardCost !== previousStandardCost ||
+        stored.effectiveDates.get(partId) == null,
+    })
+  }
+
+  return {
+    partDefId,
+    fields,
+    stored,
+    computation,
+    plan: {
+      effectiveAt: new Date(effectiveAtIso),
+      rates,
+      lines,
+      revaluationDelta,
+      initialValue,
+      skipped: computation.skipped,
+    },
+  }
+}
+
+/**
+ * What a roll would do, without doing it.
+ *
+ * 🛑 **The preview is the point** (section 2.4). A roll restates the balance
+ * sheet, so it must never be a button that just fires: this returns the
+ * revaluation delta per part and summed, so a person can see the effect before
+ * committing to it.
+ *
+ * It fails with the same `UnprocessableEntityError` the roll would, so an
+ * unpriced component surfaces here rather than half-way through a write.
+ */
+export async function previewStandardCostRoll(
+  db: Database,
+  organizationId: string,
+  input: RollStandardCostInput
+): Promise<Result<StandardCostRollPlan, Error>> {
+  return guard(
+    async () => (await planStandardCostRoll(db, organizationId, input)).plan,
+    'Failed to preview standard cost roll',
+    { organizationId, partIds: input.partIds?.length ?? 'all' }
+  )
+}
+
+/**
+ * The batch read `completeBuild` uses: the frozen standard for these parts.
+ *
+ * Returns an entry ONLY for a part that has a `part_standard_cost`. A part
+ * missing from the map has never been rolled, and the caller must treat that as
+ * a refusal — never as a zero. `completeBuild`'s "never post a zero cost" rule
+ * is the same rule stated from the other side.
+ */
+export async function readStandardCost(
+  db: Database,
+  organizationId: string,
+  partIds: string[]
+): Promise<Result<Map<string, PartStandardCost>, Error>> {
+  return guard(
+    async () => {
+      const result = new Map<string, PartStandardCost>()
+      if (partIds.length === 0) return result
+
+      const fields = await loadStandardCostFields(organizationId)
+      type NumericKey =
+        | 'standardMaterialCost'
+        | 'standardLaborCost'
+        | 'standardOverheadCost'
+        | 'standardCost'
+      const byField = new Map<string, NumericKey | 'effectiveAt'>([
+        [fields.material.id, 'standardMaterialCost'],
+        [fields.labor.id, 'standardLaborCost'],
+        [fields.overhead.id, 'standardOverheadCost'],
+        [fields.standard.id, 'standardCost'],
+        [fields.effectiveAt.id, 'effectiveAt'],
+      ])
+
+      const rows = await db
+        .select({
+          entityId: schema.FieldValue.entityId,
+          fieldId: schema.FieldValue.fieldId,
+          valueNumber: schema.FieldValue.valueNumber,
+          valueDate: schema.FieldValue.valueDate,
+        })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            inArray(schema.FieldValue.entityId, partIds),
+            inArray(schema.FieldValue.fieldId, [...byField.keys()])
+          )
+        )
+
+      const draft = new Map<string, Partial<PartStandardCost>>()
+      for (const row of rows) {
+        const key = byField.get(row.fieldId)
+        if (!key) continue
+        const entry = draft.get(row.entityId) ?? {}
+        if (key === 'effectiveAt') {
+          entry.effectiveAt = row.valueDate ? new Date(row.valueDate) : null
+        } else if (row.valueNumber != null) {
+          entry[key] = row.valueNumber
+        }
+        draft.set(row.entityId, entry)
+      }
+
+      for (const [partId, entry] of draft) {
+        // No `standardCost` means the part has never been rolled. It is omitted
+        // rather than defaulted, so a caller cannot mistake absence for zero.
+        if (entry.standardCost == null) continue
+        result.set(partId, {
+          partId,
+          standardMaterialCost: entry.standardMaterialCost ?? entry.standardCost,
+          standardLaborCost: entry.standardLaborCost ?? null,
+          standardOverheadCost: entry.standardOverheadCost ?? null,
+          standardCost: entry.standardCost,
+          effectiveAt: entry.effectiveAt ?? null,
+        })
+      }
+
+      return result
+    },
+    'Failed to read standard costs',
+    { organizationId, partCount: partIds.length }
+  )
+}

--- a/packages/lib/src/builds/standard-cost-roll.ts
+++ b/packages/lib/src/builds/standard-cost-roll.ts
@@ -1,0 +1,220 @@
+// packages/lib/src/builds/standard-cost-roll.ts
+
+/**
+ * The standard-cost roll itself — pure arithmetic over an already-loaded graph.
+ *
+ * Split from `standard-cost.ts` so the two rules that make this subsystem
+ * correct (plans/products/build/01-build-plan.md section 2.2a, README B11) can
+ * be tested without a database:
+ *
+ *  1. **Roll children's `standardCost`, not children's `part_cost`.**
+ *     `part_cost` is a PURE MATERIAL CHAIN — `bom/cost-calculator.ts:466` reads
+ *     `rollupCost = SUM(child.cost x qty)` where a child's `cost` is its vendor
+ *     price or its own rollup, and labour and overhead appear nowhere at any
+ *     level. Rolling it drops every subassembly's own conversion cost on the way
+ *     up: $14.00 per unit on the real lift. And it does not vanish quietly —
+ *     `completeBuild` values consumed rows at the child's standard and
+ *     `producedValue` at the parent's, so the gap lands in `varianceAmount` ->
+ *     account 5090 on EVERY build, destroying that account's meaning.
+ *
+ *  2. **Conversion cost is gated on `partKind`.** A purchased `component` gets
+ *     zero labour and zero overhead; capitalising assembly labour onto a motor
+ *     we never assembled overstates 1310 Raw Materials.
+ *
+ * The walk is a memoized DFS with `inProgress` cycle detection, copying the
+ * ordering discipline of `calculateAllCosts` in `bom/cost-calculator.ts`. That
+ * ordering is not a performance detail: a parent read before its children have
+ * their new standard picks up the old one.
+ */
+
+import { UnprocessableEntityError } from '../errors'
+import { absorbedRate, absorbsConversionCost, type PartKindValue, roundMinorUnits } from './client'
+import type { AbsorptionRates, SkippedPart, StandardCostComponents } from './types'
+
+/** One edge of the bill of materials. Matches `bom/cost-calculator.ts`'s shape. */
+export interface SubpartEdge {
+  childId: string
+  qty: number
+}
+
+/** Everything {@link computeStandardCosts} needs, already loaded. */
+export interface StandardCostRollInputs {
+  /**
+   * Every part the roll will write, after ancestor widening.
+   *
+   * A part OUTSIDE this set contributes its **stored** standard to its parent,
+   * never a freshly computed one. That is deliberate and it is what keeps
+   * `completeBuild` balanced: the consume rows are valued at the child's stored
+   * standard, so the parent's `producedValue` has to be built from the same
+   * number. Computing a child in memory and writing only the parent would
+   * recreate the exact 5090 gap this module exists to close.
+   */
+  scope: ReadonlySet<string>
+  /** `part_kind`, already resolved (a NULL appears as `component`). */
+  partKinds: ReadonlyMap<string, PartKindValue>
+  /** Live `part_cost`, exact and unrounded, for the parts that have one. */
+  liveCosts: ReadonlyMap<string, number>
+  /** Bill of materials: parent -> children. */
+  subpartGraph: ReadonlyMap<string, SubpartEdge[]>
+  /** `part_standard_cost` as currently stored, for parts outside {@link scope}. */
+  storedStandardCosts: ReadonlyMap<string, number>
+  /** The org's absorption rates. A `null` is "not declared", never zero. */
+  rates: AbsorptionRates
+  /** `EntityInstance.displayName` per part, for error messages only. */
+  partNames?: ReadonlyMap<string, string>
+}
+
+/** What {@link computeStandardCosts} produced. */
+export interface StandardCostRollComputation {
+  /** Keyed by part id. Only parts in scope that could be valued appear. */
+  costs: Map<string, StandardCostComponents>
+  /** In-scope parts that could not be valued at all. Never written. */
+  skipped: SkippedPart[]
+  /** Bottom-up: every part appears after every in-scope part it depends on. */
+  order: string[]
+}
+
+/**
+ * Roll every in-scope part, bottom-up.
+ *
+ * @throws UnprocessableEntityError when a built part's component has no standard
+ * cost, or when the bill of materials contains a cycle. Both abort the roll
+ * rather than valuing the parent short: silently treating a missing child as
+ * zero understates the finished good and dumps the difference into 5090, which
+ * is the precise failure section 2.2a exists to prevent.
+ */
+export function computeStandardCosts(inputs: StandardCostRollInputs): StandardCostRollComputation {
+  const costs = new Map<string, StandardCostComponents>()
+  const skipped: SkippedPart[] = []
+  const order: string[] = []
+
+  /** Parts already settled — a `null` entry means "in scope but unvaluable". */
+  const memo = new Map<string, StandardCostComponents | null>()
+  /** The current DFS stack, which is what makes a back edge detectable. */
+  const inProgress = new Set<string>()
+
+  /** The name for an error message: an id is a poor thing to hand a person. */
+  const name = (partId: string) => inputs.partNames?.get(partId) ?? partId
+  /** The name for a REPORT, where a missing one should read as absent, not as an id. */
+  const partName = (partId: string) => inputs.partNames?.get(partId) ?? null
+
+  /**
+   * The standard a PARENT should multiply by its quantity.
+   *
+   * In scope -> the freshly rolled number. Out of scope -> the stored one, which
+   * is the value already agreed for that subassembly.
+   */
+  function contributionOf(partId: string): number | null {
+    if (!inputs.scope.has(partId)) {
+      return inputs.storedStandardCosts.get(partId) ?? null
+    }
+    return roll(partId)?.standardCost ?? null
+  }
+
+  function roll(partId: string): StandardCostComponents | null {
+    const memoized = memo.get(partId)
+    if (memoized !== undefined) return memoized
+
+    if (inProgress.has(partId)) {
+      // A cycle cannot be costed at any node on it, and a cycle that reaches a
+      // BUILT part is a parent whose inputs include itself. `calculateAllCosts`
+      // contains a cycle by contributing 0; a standard cost must not, because
+      // that 0 would be frozen onto every movement.
+      throw new UnprocessableEntityError(
+        `Cannot roll standard cost: the bill of materials for "${name(partId)}" contains a circular reference.`
+      )
+    }
+    inProgress.add(partId)
+    try {
+      const result = computeOne(partId)
+      memo.set(partId, result)
+      order.push(partId)
+      if (result) costs.set(partId, result)
+      return result
+    } finally {
+      inProgress.delete(partId)
+    }
+  }
+
+  function computeOne(partId: string): StandardCostComponents | null {
+    const partKind = inputs.partKinds.get(partId) ?? 'component'
+
+    // ── A purchased part: its landed cost, and nothing else ──
+    if (!absorbsConversionCost(partKind)) {
+      const live = inputs.liveCosts.get(partId)
+      if (live == null || !Number.isFinite(live)) {
+        skipped.push({ partId, reason: 'no-live-cost', partName: partName(partId) })
+        return null
+      }
+      const material = roundMinorUnits(live)
+      // Zero, not null: we know we did not assemble it, so its conversion cost
+      // is a fact rather than an absence.
+      return {
+        standardMaterialCost: material,
+        standardLaborCost: 0,
+        standardOverheadCost: 0,
+        standardCost: material,
+      }
+    }
+
+    // ── A built part: the sum of what goes into it, plus conversion ──
+    const children = inputs.subpartGraph.get(partId) ?? []
+    if (children.length === 0) {
+      // Nothing to roll. Not an abort: a part classified as buildable before its
+      // bill of materials was entered has no inputs at all, so no number is
+      // being understated. It is reported so it is visible, not written.
+      skipped.push({ partId, reason: 'no-bill-of-materials', partName: partName(partId) })
+      return null
+    }
+
+    let material = 0
+    for (const child of children) {
+      const childStandard = contributionOf(child.childId)
+      if (childStandard == null) {
+        throw new UnprocessableEntityError(
+          `Cannot roll standard cost for "${name(partId)}": its component "${name(child.childId)}" has no standard cost. Give it a price or roll it first.`
+        )
+      }
+      material += childStandard * child.qty
+    }
+
+    // Quantities are `doublePrecision`, so the sum can carry a fractional cent
+    // even though every child standard is a whole one.
+    const standardMaterialCost = roundMinorUnits(material)
+    const standardLaborCost = absorbedRate(inputs.rates.laborCostPerUnit)
+    const standardOverheadCost = absorbedRate(inputs.rates.overheadCostPerUnit)
+
+    return {
+      standardMaterialCost,
+      standardLaborCost,
+      standardOverheadCost,
+      standardCost: standardMaterialCost + (standardLaborCost ?? 0) + (standardOverheadCost ?? 0),
+    }
+  }
+
+  for (const partId of inputs.scope) roll(partId)
+
+  return { costs, skipped, order }
+}
+
+/**
+ * Widen a set of part ids to include every ancestor.
+ *
+ * The same widening `recalculateAffectedParts` performs, and for the same
+ * reason: a finished good whose subassembly's standard just moved is carrying a
+ * standard built from the old number. Ancestors only — pulling descendants in
+ * would re-value the subassemblies the caller did not ask to re-value.
+ */
+export function widenToAncestors(
+  partIds: Iterable<string>,
+  parentGraph: ReadonlyMap<string, string[]>
+): Set<string> {
+  const widened = new Set<string>()
+  const walk = (partId: string) => {
+    if (widened.has(partId)) return
+    widened.add(partId)
+    for (const parent of parentGraph.get(partId) ?? []) walk(parent)
+  }
+  for (const partId of partIds) walk(partId)
+  return widened
+}

--- a/packages/lib/src/builds/standard-cost.ts
+++ b/packages/lib/src/builds/standard-cost.ts
@@ -1,0 +1,255 @@
+// packages/lib/src/builds/standard-cost.ts
+
+/**
+ * `rollStandardCost` — the ONLY writer of the five `part_standard_*` fields.
+ *
+ * plans/products/build/01-build-plan.md sections 2.2 and 2.2a, README B11.
+ *
+ * A part carries two costs and they answer different questions:
+ *
+ * | | `part_cost` | `part_standard_cost` |
+ * | --- | --- | --- |
+ * | written by | `recalculateAffectedParts`, on every vendor-price or BOM change | this function, only when a person runs it |
+ * | answers | "what would this cost to build today" | "what we have agreed to value it at" |
+ * | stamped onto movements | never | every one |
+ *
+ * If the standard were recalculated automatically it would just BE `part_cost`,
+ * and every movement's frozen `unitCost` would drift with vendor prices — the
+ * defect this whole subsystem exists to avoid.
+ *
+ * 🛑 **This function touches no existing `stock_movement`. Ever.** A mid-period
+ * standard change is a one-time revaluation of ON-HAND inventory, never a
+ * restatement of history. The revaluation delta is computed and RETURNED; it is
+ * not posted, because GL posting is out of scope for this directory (README B9).
+ *
+ * No permission checks: the router asserts before calling
+ * (`docs/lib-module-guide.md` section 6).
+ */
+
+import type { Database } from '@auxx/database'
+import type { CustomFieldEntity } from '@auxx/database/types'
+import { createScopedLogger } from '@auxx/logger'
+import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
+import type { Result } from 'neverthrow'
+import { recalculateAllPartCosts } from '../bom/cost-calculator'
+import { createFieldValueContext } from '../field-values/field-value-helpers'
+import { setValueWithType } from '../field-values/field-value-mutations'
+import { toFieldType } from '../field-values/stored-field-type'
+import {
+  type FieldValueUpdateEntry,
+  getRealtimeService,
+  publishFieldValueUpdates,
+} from '../realtime'
+import { guard } from './guard'
+import { planStandardCostRoll, type StandardCostFields } from './standard-cost-queries'
+import type { RollStandardCostInput, StandardCostRollLine, StandardCostRollResult } from './types'
+
+const logger = createScopedLogger('builds:standard-cost')
+
+/** How many parts are written concurrently. Mirrors `persistCosts`. */
+const WRITE_BATCH_SIZE = 20
+
+/** One field of one part, already reduced to the value that will be stored. */
+type StandardFieldValue = { type: 'number'; value: number } | { type: 'date'; value: string } | null
+
+interface PendingWrite {
+  field: CustomFieldEntity
+  value: StandardFieldValue
+}
+
+/**
+ * Freeze a new standard cost onto every part in scope.
+ *
+ * The order of the steps is the contract:
+ *
+ * 1. `recalculateAllPartCosts` so `part_cost` is current — the roll's material
+ *    input for a purchased component is that number, and a stale one freezes a
+ *    price nobody is paying.
+ * 2. Plan the roll. **Bottom-up**, because a parent read before its children
+ *    have their new standard picks up the old one; and when `partIds` is scoped,
+ *    **widened to every ancestor**, because a finished good whose subassembly
+ *    just moved is carrying a standard built from the old number.
+ * 3. Write only what changed, and stamp `standardCostEffectiveAt` on those parts
+ *    only — a standard that did not move took effect earlier, and moving its
+ *    date forward would erase the one signal that says how stale it is. The
+ *    writes follow the same bottom-up order and stop at the first failure, so a
+ *    roll can never freeze a parent and then fail before the children under it.
+ * 4. Return the revaluation delta. Never post it.
+ *
+ * @returns the plan that was executed plus `writtenPartIds`.
+ */
+export async function rollStandardCost(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: RollStandardCostInput
+): Promise<Result<StandardCostRollResult, Error>> {
+  return guard(
+    async () => {
+      // Step 1. Uses the module-level pool by design — it is a full-org sweep
+      // with its own batching, not a participant in any caller's transaction.
+      await recalculateAllPartCosts(organizationId)
+
+      // Step 2.
+      const { partDefId, fields, plan } = await planStandardCostRoll(db, organizationId, input)
+
+      // Step 3.
+      const writtenPartIds = await persistStandardCosts(db, organizationId, userId, {
+        partDefId,
+        fields,
+        effectiveAt: plan.effectiveAt,
+        lines: plan.lines,
+      })
+
+      logger.info('Rolled standard cost', {
+        organizationId,
+        scopedPartIds: input.partIds?.length ?? 'all',
+        planned: plan.lines.length,
+        written: writtenPartIds.length,
+        skipped: plan.skipped.length,
+        revaluationDelta: plan.revaluationDelta,
+        initialValue: plan.initialValue,
+        laborRateDeclared: plan.rates.laborCostPerUnit != null,
+        overheadRateDeclared: plan.rates.overheadCostPerUnit != null,
+      })
+
+      // Step 4. Computed and returned, never posted (README B9).
+      return { ...plan, writtenPartIds }
+    },
+    'Failed to roll standard cost',
+    { organizationId, partIds: input.partIds?.length ?? 'all' }
+  )
+}
+
+/**
+ * Write the changed lines through `setValueWithType`, the same writer
+ * `persistCosts` uses for the other computed `part` cost fields.
+ *
+ * The five fields are `updatable: false` + `computed: true`, which makes their
+ * inputs read-only and keeps every form, import and connector out — it does not
+ * stop this path, because the CRUD layer is where that flag is enforced. Going
+ * through `setValueWithType` rather than a raw insert is what keeps the display
+ * value, the search text and the realtime store consistent.
+ */
+async function persistStandardCosts(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  args: {
+    partDefId: string
+    fields: StandardCostFields
+    effectiveAt: Date
+    lines: StandardCostRollLine[]
+  }
+): Promise<string[]> {
+  const { partDefId, fields, effectiveAt, lines } = args
+  const effectiveAtIso = effectiveAt.toISOString()
+
+  const pending = lines
+    .filter((line) => line.changed)
+    .map((line) => ({
+      partId: line.partId,
+      writes: [
+        { field: fields.material, value: numberValue(line.standardMaterialCost) },
+        // A `null` here is the stored form of "no absorption declared" and is
+        // written as a CLEAR, not skipped: leaving a previous rate in place
+        // would make an undeclared rate indistinguishable from a stale one.
+        { field: fields.labor, value: numberValue(line.standardLaborCost) },
+        { field: fields.overhead, value: numberValue(line.standardOverheadCost) },
+        { field: fields.standard, value: numberValue(line.standardCost) },
+        { field: fields.effectiveAt, value: { type: 'date', value: effectiveAtIso } },
+      ] satisfies PendingWrite[],
+    }))
+
+  if (pending.length === 0) return []
+
+  const ctx = createFieldValueContext(organizationId, userId, db)
+  const written = new Set<string>()
+
+  // 🛑 `pending` is in the roll's BOTTOM-UP order and the batches are walked in
+  // that order, so whatever gets written is a PREFIX of it. Combined with the
+  // abort below, that is the consistency guarantee this loop gives without
+  // holding one transaction open across ~1000 field-value writes: a roll never
+  // freezes a parent and then fails before the children beneath it.
+  //
+  // A roll is idempotent — the `changed` diff skips what is already correct — so
+  // the recovery from a failure is to run it again, never to unpick it.
+  for (let i = 0; i < pending.length; i += WRITE_BATCH_SIZE) {
+    const batch = pending.slice(i, i + WRITE_BATCH_SIZE)
+    const settled = await Promise.allSettled(
+      batch.map(async (entry) => {
+        const recordId = toRecordId(partDefId, entry.partId) as RecordId
+        // Sequential per part: the five values belong to one record and
+        // `setValueWithType` stamps the instance on each write.
+        for (const write of entry.writes) {
+          await setValueWithType(ctx, {
+            recordId,
+            fieldId: write.field.id,
+            fieldType: toFieldType(write.field.type),
+            value: write.value,
+          })
+        }
+        return entry.partId
+      })
+    )
+
+    for (const outcome of settled) {
+      if (outcome.status === 'fulfilled') written.add(outcome.value)
+    }
+
+    const failure = settled.find((outcome) => outcome.status === 'rejected')
+    if (failure) {
+      // Publish what DID land before surfacing the failure, so open clients show
+      // the parts that moved rather than a stale number no reload explains.
+      publishStandardCostUpdates(organizationId, partDefId, pending, written)
+      logger.error('Failed to freeze standard cost, aborting the roll', {
+        organizationId,
+        written: written.size,
+        planned: pending.length,
+        error: failure.reason instanceof Error ? failure.reason.message : String(failure.reason),
+      })
+      throw failure.reason instanceof Error
+        ? failure.reason
+        : new Error('Failed to freeze standard cost')
+    }
+  }
+
+  publishStandardCostUpdates(organizationId, partDefId, pending, written)
+
+  return [...written]
+}
+
+/**
+ * Push the frozen numbers to every open client.
+ *
+ * A cleared cell publishes as `value: null`, not as an omitted entry — on
+ * `FieldValueUpdateEntry` an absent `value` means "don't touch the store", so
+ * skipping it would leave the part drawer's Costing card rendering the previous
+ * labour absorption until a reload.
+ */
+function publishStandardCostUpdates(
+  organizationId: string,
+  partDefId: string,
+  pending: { partId: string; writes: PendingWrite[] }[],
+  written: ReadonlySet<string>
+): void {
+  if (written.size === 0) return
+  const entries: FieldValueUpdateEntry[] = []
+  for (const entry of pending) {
+    if (!written.has(entry.partId)) continue
+    const recordId = toRecordId(partDefId, entry.partId) as RecordId
+    for (const write of entry.writes) {
+      entries.push({
+        key: buildFieldValueKey(recordId, write.field.id as FieldId),
+        value: write.value,
+      })
+    }
+  }
+  publishFieldValueUpdates(getRealtimeService(), organizationId, entries).catch(() => {})
+}
+
+/** `null` is a real answer — it clears the stored value. */
+function numberValue(value: number | null): StandardFieldValue {
+  return value == null ? null : { type: 'number', value }
+}

--- a/packages/lib/src/builds/types.ts
+++ b/packages/lib/src/builds/types.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/builds/types.ts
+
+/**
+ * Shapes the standard-cost roll reads and returns.
+ *
+ * plans/products/build/01-build-plan.md sections 2.2 and 2.2a.
+ */
+
+import type { PartKindValue } from './client'
+
+/**
+ * The two `manufacturing.*` org settings, per assembled unit, in minor units.
+ *
+ * Both are `number | null` and the `null` is load-bearing — see
+ * {@link absorbedRate}. They ship unset, and a roll run before they are filled
+ * in stores NULL components rather than a confident zero.
+ */
+export interface AbsorptionRates {
+  laborCostPerUnit: number | null
+  overheadCostPerUnit: number | null
+}
+
+/**
+ * The four numbers a roll freezes onto a part, all in whole minor units.
+ *
+ * The three components are split because it is load-bearing, not tidiness: the
+ * fulfillment COGS entry has to land across 5000 Materials / 5010 Direct Labor /
+ * 5020 Applied Overhead, and it can only do that if the finished good's standard
+ * remembers its composition (Gap C section 6.1).
+ */
+export interface StandardCostComponents {
+  /**
+   * For a `component`: `round(part_cost)`, its landed purchase cost.
+   * For a built part: the sum of its children's `standardCost` x quantity —
+   * **not** `round(part_cost)`, which is a pure material chain and drops every
+   * subassembly's own conversion cost on the way up (README B11).
+   */
+  standardMaterialCost: number
+  /** `0` for a component; the declared rate for a built part; `null` when no rate is declared. */
+  standardLaborCost: number | null
+  /** Gated on `partKind` exactly as {@link standardLaborCost} is. */
+  standardOverheadCost: number | null
+  /** Material + labour + overhead. THE value every stock movement stamps. */
+  standardCost: number
+}
+
+/** One part's frozen standard, as {@link readStandardCost} returns it. */
+export interface PartStandardCost extends StandardCostComponents {
+  partId: string
+  /** When this standard took effect. `null` on a part whose roll predates the stamp. */
+  effectiveAt: Date | null
+}
+
+/** Why a part could not be rolled. Never written, and never written as zero. */
+export type SkipReason =
+  /** A `component` (or an unclassified part) with no `part_cost` at all. */
+  | 'no-live-cost'
+  /** A `subassembly` / `finished_good` with no bill of materials to roll. */
+  | 'no-bill-of-materials'
+
+/** One part the roll declined to value, with the reason a person can act on. */
+export interface SkippedPart {
+  partId: string
+  reason: SkipReason
+  /** `EntityInstance.displayName`, so a preview can name the part to go fix. */
+  partName: string | null
+}
+
+/** One part the roll will write, with the balance-sheet effect of writing it. */
+export interface StandardCostRollLine extends StandardCostComponents {
+  partId: string
+  /** `EntityInstance.displayName`. The preview lists parts, not ids. */
+  partName: string | null
+  /** Resolved, never raw: a NULL `part_kind` appears here as `component`. */
+  partKind: PartKindValue
+  /** The standard this part carried before the roll. `null` = never rolled. */
+  previousStandardCost: number | null
+  /** `part_quantity_on_hand`, or 0 when the part has never been counted. */
+  quantityOnHand: number
+  /**
+   * `(newStandard - previousStandardCost) x quantityOnHand`, in minor units.
+   *
+   * **Zero when there is no previous standard** — see {@link isInitial}. A first
+   * roll is not a revaluation of anything.
+   */
+  revaluationDelta: number
+  /**
+   * This part had no standard before, so the roll VALUES its on-hand stock for
+   * the first time rather than revaluing it.
+   *
+   * Kept separate because folding it into {@link revaluationDelta} would report
+   * the entire on-hand inventory value as a variance on the very first roll,
+   * which is both alarming and wrong.
+   */
+  isInitial: boolean
+  /** `newStandard x quantityOnHand`. Only meaningful when {@link isInitial}. */
+  initialValue: number
+  /** `false` when every component and the effective date already match — nothing is written. */
+  changed: boolean
+}
+
+/**
+ * What a roll WOULD do. Returned by the preview and, extended, by the roll.
+ *
+ * 🛑 The preview is the point (section 2.4): a roll restates the balance sheet,
+ * so it must never be a button that just fires.
+ */
+export interface StandardCostRollPlan {
+  /** The date the new standards take effect. Stamped onto every changed part. */
+  effectiveAt: Date
+  /** The rates in force. A `null` here is visible as "no absorption declared". */
+  rates: AbsorptionRates
+  /** Every part in the write scope after ancestor widening, in bottom-up order. */
+  lines: StandardCostRollLine[]
+  /** Sum of {@link StandardCostRollLine.revaluationDelta} over the non-initial lines. */
+  revaluationDelta: number
+  /** Sum of {@link StandardCostRollLine.initialValue} over the initial lines. */
+  initialValue: number
+  /** Parts in scope that cannot be valued at all. */
+  skipped: SkippedPart[]
+}
+
+/** What a roll DID. */
+export interface StandardCostRollResult extends StandardCostRollPlan {
+  /** The parts whose field values were actually written. */
+  writtenPartIds: string[]
+}
+
+/** Input to {@link rollStandardCost} and {@link previewStandardCostRoll}. */
+export interface RollStandardCostInput {
+  /**
+   * Restrict the roll to these parts **and every ancestor of them**.
+   *
+   * Omitted (or empty) rolls every non-archived part in the org. Descendants are
+   * deliberately NOT pulled in: rolling a finished good values it at its
+   * subassemblies' already-agreed standards, which is what a standard cost roll
+   * is for.
+   */
+  partIds?: string[]
+  /** When the new standards take effect. */
+  effectiveAt: Date
+}


### PR DESCRIPTION
Phase 1 of [`plans/products/build/01-build-plan.md`](plans/products/build/01-build-plan.md) §2. Ships alone; **nothing reads these fields yet**. No schema — migration 109 already landed them.

## Why a second cost number

A part already has `part_cost`. It answers a different question.

| | `part_cost` | `part_standard_cost` |
| --- | --- | --- |
| Written by | `recalculateAffectedParts`, on **every** vendor-price or BOM change, propagating to every ancestor | `rollStandardCost` **only**, when a person runs it |
| Answers | *what would this cost to build today* | *what we have agreed to value it at* |
| Changes | constantly, silently | on an explicit roll, with a stamped `effectiveAt` |
| Stamped onto movements | never | **every one** |

The whole chain today is a live mirror, so a motor price change in March silently restates January's COGS. If the standard were recalculated automatically it would just *be* `part_cost`, which is the defect this directory exists to avoid.

## 🛑 The roll corrects Gap C §6.1

The design reference says `standardMaterialCost = round(part_cost)` for every in-scope part. That is wrong twice, and both errors are silent.

**1. `part_cost` is a pure material chain.** `bom/cost-calculator.ts:466` computes `rollupCost = Σ contribution(child) × qty`, where a child contributes its vendor landed cost or its own rollup. Labour and overhead appear nowhere, at any level. So rolling it drops every subassembly's own conversion cost on the way up:

| part | material | labour + ovh | standard |
| --- | --- | --- | --- |
| Motor | $20.098 (purchased) | — | $20.098 |
| Tube | $9.510 (purchased) | — | $9.510 |
| 400Lbs motor Assembly | $29.608 | $5 + $2 | **$36.608** |
| Auxx Lift 4x8 (2× assembly) | $59.216 | $5 + $2 | $66.216 ← as Gap C writes it |
| | *should be* 2 × $36.608 = $73.216 | $5 + $2 | **$80.216** |

**$14.00 short — exactly 2 × ($5 + $2).** And it does not vanish quietly: `completeBuild` values consumed rows at the child's frozen standard and `producedValue` at the parent's, so the gap lands in `varianceAmount` → **account 5090 on every single build, forever**. A structural variance in the account that is supposed to mean "something went wrong on this run" drowns the real yield and scrap signals.

**2. A purchased component would get assembly labour.** We did not assemble the motor; adding $7 to it capitalises labour never spent and overstates **1310 Raw Materials**.

**The fix:** roll children's `standardCost` bottom-up, and gate conversion cost on `partKind` — `component` gets none, `subassembly`/`finished_good` get the org rates. Gated on `partKind` and **not** `part_cost_source`, because `source` is itself computed and flips the moment someone adds a vendor price to a part that also has a BOM, silently changing its costing basis.

**The load-bearing detail:** an out-of-scope child contributes its **stored** standard, never one computed in memory but not written. A child computed and not persisted recreates the same 5090 gap, because `completeBuild` reads the stored number.

## Judgement calls worth reviewing

These are the places §2 read more than one way.

1. **Abort vs skip.** A built part whose child has no standard **throws** `UnprocessableEntityError` naming both — rolling it would understate the parent. A part with **no inputs at all** (an unpriced `component`, a buildable part with no BOM yet) is **skipped** and reported in `skipped[]`, never written and never zeroed. Without the split, a full-org roll aborts on the first of ~200 unpriced parts and the feature is unusable.
2. **A cycle throws**, diverging from `calculateAllCosts`, which contains one by contributing `0`. A standard must not — the `0` would be frozen onto every movement.
3. **First roll ≠ revaluation.** `(new − old) × QoH` with a NULL `old` reports the entire on-hand inventory value as variance on the very first roll. Split into `revaluationDelta` and `initialValue`, summed separately.
4. **A NULL rate is not zero.** Undeclared → stores NULL, written as an *explicit clear* so a stale rate cannot masquerade as undeclared. A `component` → stores `0`, because its conversion cost is a fact rather than an absence. A declared `0` → stores `0` and stays distinguishable from both.
5. **`effectiveAt` is stamped only on parts that changed.** Restamping an unmoved standard erases the drift signal that tells you a roll is due.
6. **The preview does not run `recalculateAllPartCosts`** — that would make a `.query()` write. `part_cost` is already maintained on every vendor-price/BOM change, so the refresh in the roll is a repair step, not the source of the number.
7. **Preview is gated on `edit` of `part`, not `view`** — it exists only as the first half of a write and discloses the balance-sheet effect of one.

## ⚠️ No wrapping transaction — the main thing to review

A full-org roll is ~1090 field-value writes; one transaction around them is a long lock, and `persistCosts` sets the precedent of batched non-transactional writes.

Instead the writes follow the bottom-up order and **abort at the first failure**, so whatever was written is always a *prefix* — a roll can never freeze a parent and fail before its children. A roll is idempotent (it diffs `changed`), so recovery is to re-run it. There is a residual window inside a single 20-part batch, documented in the file.

The trade: a partial roll leaves children on new standards and parents on old, which is temporarily the same understatement this PR exists to prevent — until the re-run. Reviewers who would rather pay the lock should say so.

## UI

Three read-only rows on the part drawer's **Costing card**, which already renders this exact shape — two candidate numbers with a badge on the winner — for buy-vs-build:

```
Cost (live)   $155.00   [Rollup]
Standard      $150.00   set 12 Aug 2026     [Roll]
Δ              +$5.00   ← unrolled drift
```

**The preview is the point.** A roll restates the balance sheet, so it is never a button that just fires: `builds.previewRoll` returns the per-part before→after table, the summed inventory revaluation, the separately-summed first valuation, and the "Not valued (n)" list with reasons. It fails with the same error the roll would, so an unpriced component surfaces *before* anything commits. Confirm is disabled unless a plan came back with changes.

Nothing went into the Details panel — §1.6 declared all five fields `showInPanel: false` precisely so they surface here.

## Verification

```
lib typecheck ratchet:   no new type errors (29 total, baseline 29)
web typecheck ratchet:   no new type errors (0 total, baseline 0)
vitest src/builds src/bom:  5 files, 76 tests passed
biome:                   13 files, clean
```

32 new tests. The roll's are pure with **zero mocks** — including one that asserts the $14.00 gap explicitly, one that a NULL `partKind` is treated as `component`, one that gates on `partKind` rather than `part_cost_source`, and one that an out-of-scope child is read at its *stored* standard while a never-rolled one aborts.

## Known, pre-existing

`planStandardCostRoll` calls `loadOrgPricingData(orgId)`, which binds the module-level `database` rather than the passed `db`. That is an existing property of `bom/cost-calculator.ts`, not introduced here — the same class of thing flagged in #1944.
