### PR TITLE
feat(build): record what a build consumed and produced, at a cost that sticks

### DIFF
--- a/packages/lib/src/builds/__tests__/build-client.test.ts
+++ b/packages/lib/src/builds/__tests__/build-client.test.ts
@@ -1,0 +1,103 @@
+// packages/lib/src/builds/__tests__/build-client.test.ts
+//
+// The pure half of the build event: the status gates and the variance
+// arithmetic. No doubles of any kind — everything here is a total function of
+// its arguments, which is what lets the B7 identity below be asserted as an
+// identity rather than as one worked example.
+
+import { describe, expect, it } from 'vitest'
+import {
+  buildVariance,
+  canCancelBuild,
+  canCompleteBuild,
+  canReverseBuild,
+  canStartBuild,
+  componentConsumption,
+  resolveBuildStatus,
+  unitsStarted,
+} from '../client'
+
+describe('resolveBuildStatus', () => {
+  it('reads the four stored values', () => {
+    expect(resolveBuildStatus('planned')).toBe('planned')
+    expect(resolveBuildStatus('in_progress')).toBe('in_progress')
+    expect(resolveBuildStatus('completed')).toBe('completed')
+    expect(resolveBuildStatus('canceled')).toBe('canceled')
+  })
+
+  it('does NOT default an absent or unknown status', () => {
+    // Unlike `part_kind`, which reads NULL as `component`. A build with no
+    // status is a row whose lifecycle nobody can state, and defaulting it to
+    // `planned` would let a write path post an append-only ledger entry.
+    expect(resolveBuildStatus(null)).toBeNull()
+    expect(resolveBuildStatus(undefined)).toBeNull()
+    expect(resolveBuildStatus('shipped')).toBeNull()
+  })
+})
+
+describe('the status gates', () => {
+  it('refuses every action on a null status', () => {
+    expect(canStartBuild(null)).toBe(false)
+    expect(canCompleteBuild(null)).toBe(false)
+    expect(canCancelBuild(null)).toBe(false)
+    expect(canReverseBuild(null)).toBe(false)
+  })
+
+  it('allows exactly one completion (B8)', () => {
+    expect(canCompleteBuild('planned')).toBe(true)
+    expect(canCompleteBuild('in_progress')).toBe(true)
+    // A run finished in tranches is a second build.
+    expect(canCompleteBuild('completed')).toBe(false)
+    expect(canCompleteBuild('canceled')).toBe(false)
+  })
+
+  it('reverses only a completed build, and cancels only an open one (B6)', () => {
+    expect(canReverseBuild('completed')).toBe(true)
+    expect(canReverseBuild('planned')).toBe(false)
+    expect(canCancelBuild('planned')).toBe(true)
+    expect(canCancelBuild('in_progress')).toBe(true)
+    expect(canCancelBuild('completed')).toBe(false)
+  })
+})
+
+describe('the run arithmetic', () => {
+  it('counts scrap as started — scrapped units ate their components (B7)', () => {
+    expect(unitsStarted(10, 2)).toBe(12)
+    expect(componentConsumption(2, unitsStarted(10, 2))).toBe(24)
+  })
+
+  it('nets to zero when nothing is scrapped and the standard agrees with the BOM', () => {
+    expect(
+      buildVariance({
+        materialCost: 73220,
+        laborCost: 5000,
+        overheadCost: 2000,
+        producedValue: 80220,
+      })
+    ).toBe(0)
+  })
+
+  it('comes out at exactly the scrapped units x the standard cost', () => {
+    // The identity, over a range rather than one example. With `s` scrapped, all
+    // three absorbed terms scale on `produced + s` while `producedValue` values
+    // only `produced`, so the difference is always `s x standardCost` — which is
+    // what B7 sends to account 5090.
+    const standardCost = 8022
+    const materialPerUnit = 7322
+    const laborPerUnit = 500
+    const overheadPerUnit = 200
+    const produced = 10
+
+    for (const scrapped of [0, 1, 2, 5, 37]) {
+      const started = unitsStarted(produced, scrapped)
+      expect(
+        buildVariance({
+          materialCost: materialPerUnit * started,
+          laborCost: laborPerUnit * started,
+          overheadCost: overheadPerUnit * started,
+          producedValue: standardCost * produced,
+        })
+      ).toBe(scrapped * standardCost)
+    }
+  })
+})

--- a/packages/lib/src/builds/__tests__/build-event.test.ts
+++ b/packages/lib/src/builds/__tests__/build-event.test.ts
@@ -1,0 +1,770 @@
+// packages/lib/src/builds/__tests__/build-event.test.ts
+//
+// The build event: what `createBuild` does NOT write, what `completeBuild`
+// writes and at what cost, and what `reverseBuild` carries back.
+//
+// Harness style follows `receiving/__tests__/reverse-movement.test.ts` — the org
+// cache, the CRUD handler, the quantity-on-hand batch and the standard-cost read
+// are doubles, and a db stand-in routes the reads by table identity plus whether
+// the query joined. Nothing here needs a database.
+//
+// ⚠️ `src/test/setup.ts` mocks `@auxx/database` wholesale, so `schema.Foo` is a
+// memoized `{}` and its COLUMNS are `undefined`. Table identity therefore works
+// (`.from(schema.FieldValue)` is comparable by reference) but no assertion can
+// name a column, and the double ignores every `WHERE` — so a fixture must be
+// narrow enough that "the rows this table would return" is unambiguous.
+
+import { schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError, ConflictError, UnprocessableEntityError } from '../../errors'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const BUILD = 'bld_1'
+const PART_LIFT = 'part_lift'
+const PART_ASM = 'part_asm'
+const PART_MOTOR = 'part_motor'
+const CREATED_AT = new Date('2026-08-01T00:00:00.000Z')
+
+/** One stored `FieldValue`, in the widest projection any read here selects. */
+interface ValueRow {
+  entityId: string
+  fieldId: string
+  valueText: string | null
+  valueNumber: number | null
+  valueDate: string | null
+  optionId: string | null
+  relatedEntityId: string | null
+}
+
+/** One created record, as the CRUD double reports it back. */
+interface CreatedRecord {
+  defId: string
+  values: Record<string, unknown>
+}
+
+const h = vi.hoisted(() => ({
+  /** `.from(EntityInstance)` with no join. */
+  instanceRows: [] as { id: string; createdAt: Date; displayName: string | null }[],
+  /** `.from(EntityInstance).innerJoin(...)` — the build's own movements. */
+  movementInstances: [] as { id: string }[],
+  /** `.from(FieldValue)` with no join. One combined list; every reader buckets it. */
+  valueRows: [] as ValueRow[],
+  /** `.from(FieldValue).innerJoin(EntityInstance)` — the already-reversed probe. */
+  reversalRows: [] as { id: string }[],
+  /** systemAttributes the org has materialised. */
+  materialised: new Set<string>(),
+  /** entityType -> def id; a missing key models a def the org does not have. */
+  defs: new Map<string, string>(),
+  /** partId -> frozen standard cost, minor units. Absent = never rolled. */
+  standards: new Map<string, number>(),
+  /** The two `manufacturing.*` rates, per unit, minor units. */
+  rates: { laborCostPerUnit: null as number | null, overheadCostPerUnit: null as number | null },
+  /** parentPartId -> direct children, the real depth-1 semantics over a fixture. */
+  bom: new Map<string, { childId: string; qty: number }[]>(),
+  created: [] as CreatedRecord[],
+  updated: [] as { recordId: string; values: Record<string, unknown> }[],
+  /** Options every `UnifiedCrudHandler` was constructed with, in order. */
+  constructions: [] as (Record<string, unknown> | undefined)[],
+  recalcCalls: [] as string[][],
+  /** Interleaved trace: what ran, and on which side of the commit. */
+  trace: [] as string[],
+  publishedEntries: [] as unknown[],
+  getDeductionTargets: vi.fn(),
+  loadSubpartGraph: vi.fn(),
+  nextId: 0,
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  requireCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => {
+    const id = h.defs.get(entityType)
+    if (!id) throw new Error(`EntityDefinition not found for entityType: ${entityType}`)
+    return id
+  }),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(
+          attrs.map((attr) => [attr, h.materialised.has(attr) ? { id: `fld_${attr}` } : null])
+        ),
+    }),
+  }),
+}))
+
+vi.mock('../../bom/subpart-graph', () => ({
+  // The REAL depth-1 semantics over the fixture: asked for the lift it returns
+  // the assembly, asked for the assembly it would return the motor. That is what
+  // makes the direct-only assertion mean something — if the code walked a level
+  // deeper it would get an answer, and the motor would appear in the ledger.
+  loadDirectSubparts: vi.fn(async (_db: unknown, _org: string, partId: string) => {
+    h.trace.push(`loadDirectSubparts:${partId}`)
+    return h.bom.get(partId) ?? []
+  }),
+  loadSubpartGraph: h.loadSubpartGraph,
+  getDeductionTargets: h.getDeductionTargets,
+}))
+
+vi.mock('../standard-cost-queries', () => ({
+  readStandardCost: vi.fn(async (_db: unknown, _org: string, partIds: string[]) => {
+    const { ok } = await import('neverthrow')
+    const map = new Map<string, { partId: string; standardCost: number }>()
+    for (const partId of partIds) {
+      const standardCost = h.standards.get(partId)
+      if (standardCost != null) map.set(partId, { partId, standardCost })
+    }
+    return ok(map)
+  }),
+  loadAbsorptionRates: vi.fn(async () => h.rates),
+}))
+
+vi.mock('../../bom/qoh', () => ({
+  batchRecalculateQoH: vi.fn(async (_org: string, partIds: string[]) => {
+    h.trace.push('recalc')
+    h.recalcCalls.push(partIds)
+  }),
+}))
+
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishFieldValueUpdates: vi.fn(async (_svc: unknown, _org: string, entries: unknown[]) => {
+    h.trace.push('publish')
+    h.publishedEntries.push(...entries)
+  }),
+}))
+
+vi.mock('../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    constructor(
+      _org: string,
+      _user: string,
+      _db: unknown,
+      _socketId: unknown,
+      options?: Record<string, unknown>
+    ) {
+      h.constructions.push(options)
+    }
+    async create(defId: string, values: Record<string, unknown>) {
+      h.created.push({ defId, values })
+      h.nextId += 1
+      const id = defId === h.defs.get('build') ? `bld_new_${h.nextId}` : `mv_new_${h.nextId}`
+      h.trace.push(`create:${String(values.stock_movement_type ?? 'build')}`)
+      return { instance: { id }, recordId: `${defId}:${id}`, values }
+    }
+    async update(recordId: string, values: Record<string, unknown>) {
+      h.updated.push({ recordId, values })
+      h.trace.push('update')
+      return { id: recordId }
+    }
+  },
+}))
+
+import { createBuild } from '../build-mutations'
+import { completeBuild } from '../complete-build'
+import { reverseBuild } from '../reverse-build'
+
+// ─── The db double ──────────────────────────────────────────────────────
+
+/**
+ * A real Promise carrying the terminal chain methods, so `await` works anywhere
+ * along the chain. Deliberately a Promise with properties attached rather than a
+ * hand-rolled thenable: an object with its own `then` is a trap the moment
+ * anything else awaits it.
+ */
+interface RowsChain extends PromiseLike<unknown[]> {
+  limit(): RowsChain
+  offset(): RowsChain
+  orderBy(): RowsChain
+  for(): RowsChain
+}
+
+function rowsPromise(rows: unknown[]): RowsChain {
+  return Object.assign(Promise.resolve(rows), {
+    limit: () => rowsPromise(rows),
+    offset: () => rowsPromise(rows),
+    orderBy: () => rowsPromise(rows),
+    for: () => rowsPromise(rows),
+  })
+}
+
+function makeChain() {
+  const state = { table: null as unknown, joined: false }
+  const rows = () => {
+    if (state.table === schema.EntityInstance) {
+      return state.joined ? h.movementInstances : h.instanceRows
+    }
+    return state.joined ? h.reversalRows : h.valueRows
+  }
+  const chain: Record<string, unknown> = {
+    from: (table: unknown) => {
+      state.table = table
+      return chain
+    },
+    innerJoin: () => {
+      state.joined = true
+      return chain
+    },
+    leftJoin: () => chain,
+    $dynamic: () => chain,
+    where: () => rowsPromise(rows()),
+  }
+  return chain
+}
+
+const db = {
+  select: () => makeChain(),
+  transaction: async (fn: (tx: unknown) => Promise<unknown>) => {
+    h.trace.push('begin')
+    const result = await fn(db)
+    // Everything after this point in the trace ran AFTER the commit.
+    h.trace.push('commit')
+    return result
+  },
+} as never
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+const BUILD_ATTRS = [
+  'build_number',
+  'build_part',
+  'build_status',
+  'build_quantity_planned',
+  'build_quantity_produced',
+  'build_quantity_scrapped',
+  'build_started_at',
+  'build_completed_at',
+  'build_material_cost',
+  'build_labor_cost',
+  'build_overhead_cost',
+  'build_produced_value',
+  'build_variance_amount',
+  'build_posted_at',
+  'build_notes',
+  'build_order',
+  'build_source',
+  'build_reversal_of',
+]
+
+const MOVEMENT_ATTRS = [
+  'stock_movement_build',
+  'stock_movement_part',
+  'stock_movement_type',
+  'stock_movement_quantity',
+  'stock_movement_unit_cost',
+  'stock_movement_extended_cost',
+  'stock_movement_gl_account',
+  'stock_movement_qty_per_unit',
+  'stock_movement_cost_basis',
+]
+
+function value(entityId: string, attr: string, over: Partial<ValueRow>): ValueRow {
+  return {
+    entityId,
+    fieldId: `fld_${attr}`,
+    valueText: null,
+    valueNumber: null,
+    valueDate: null,
+    optionId: null,
+    relatedEntityId: null,
+    ...over,
+  }
+}
+
+/** The part classifications every fixture shares. */
+function partKindRows(): ValueRow[] {
+  return [
+    value(PART_LIFT, 'part_kind', { optionId: 'finished_good' }),
+    value(PART_ASM, 'part_kind', { optionId: 'subassembly' }),
+    value(PART_MOTOR, 'part_kind', { optionId: 'component' }),
+  ]
+}
+
+/** A `planned` build of 10 lifts. */
+function plannedBuildRows(): ValueRow[] {
+  return [
+    value(BUILD, 'build_status', { optionId: 'planned' }),
+    value(BUILD, 'build_part', { relatedEntityId: PART_LIFT }),
+    value(BUILD, 'build_quantity_planned', { valueNumber: 10 }),
+  ]
+}
+
+/**
+ * The SAME build after the completion in `completes a run with scrap` — 10 good,
+ * 2 scrapped, at the numbers that test asserts.
+ */
+function completedBuildRows(): ValueRow[] {
+  return [
+    value(BUILD, 'build_status', { optionId: 'completed' }),
+    value(BUILD, 'build_part', { relatedEntityId: PART_LIFT }),
+    value(BUILD, 'build_quantity_planned', { valueNumber: 10 }),
+    value(BUILD, 'build_quantity_produced', { valueNumber: 10 }),
+    value(BUILD, 'build_quantity_scrapped', { valueNumber: 2 }),
+    value(BUILD, 'build_material_cost', { valueNumber: 87864 }),
+    value(BUILD, 'build_labor_cost', { valueNumber: 6000 }),
+    value(BUILD, 'build_overhead_cost', { valueNumber: 2400 }),
+    value(BUILD, 'build_produced_value', { valueNumber: 80220 }),
+    value(BUILD, 'build_variance_amount', { valueNumber: 16044 }),
+    value(BUILD, 'build_completed_at', { valueDate: '2026-08-02T00:00:00.000Z' }),
+  ]
+}
+
+/** The two movements that completion wrote, with their FROZEN costs. */
+function completedMovementRows(): ValueRow[] {
+  return [
+    value('mv_1', 'stock_movement_part', { relatedEntityId: PART_ASM }),
+    value('mv_1', 'stock_movement_type', { optionId: 'build_consume' }),
+    value('mv_1', 'stock_movement_quantity', { valueNumber: -24 }),
+    value('mv_1', 'stock_movement_unit_cost', { valueNumber: 3661 }),
+    value('mv_1', 'stock_movement_extended_cost', { valueNumber: -87864 }),
+    value('mv_1', 'stock_movement_gl_account', { valueText: '1310' }),
+    value('mv_1', 'stock_movement_qty_per_unit', { valueNumber: 2 }),
+    value('mv_1', 'stock_movement_cost_basis', { optionId: 'standard' }),
+    value('mv_2', 'stock_movement_part', { relatedEntityId: PART_LIFT }),
+    value('mv_2', 'stock_movement_type', { optionId: 'build_produce' }),
+    value('mv_2', 'stock_movement_quantity', { valueNumber: 10 }),
+    value('mv_2', 'stock_movement_unit_cost', { valueNumber: 8022 }),
+    value('mv_2', 'stock_movement_extended_cost', { valueNumber: 80220 }),
+    value('mv_2', 'stock_movement_gl_account', { valueText: '1330' }),
+    value('mv_2', 'stock_movement_cost_basis', { optionId: 'standard' }),
+  ]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.materialised = new Set([...BUILD_ATTRS, ...MOVEMENT_ATTRS, 'part_kind'])
+  h.defs = new Map([
+    ['build', 'def_build'],
+    ['part', 'def_part'],
+    ['stock_movement', 'def_mv'],
+    ['order', 'def_order'],
+  ])
+  // The build row FIRST: the double ignores `WHERE`, and every detail read takes
+  // `[instance]`, so position is what identifies it.
+  h.instanceRows = [
+    { id: BUILD, createdAt: CREATED_AT, displayName: null },
+    { id: PART_LIFT, createdAt: CREATED_AT, displayName: 'Auxx Lift 400lbs 4x8' },
+    { id: PART_ASM, createdAt: CREATED_AT, displayName: '400Lbs motor Assembly' },
+  ]
+  h.movementInstances = []
+  h.reversalRows = []
+  h.valueRows = [...plannedBuildRows(), ...partKindRows()]
+  // 2 assemblies per lift; 1 motor per assembly. The motor is one level too deep
+  // for a build to touch (B4).
+  h.bom = new Map([
+    [PART_LIFT, [{ childId: PART_ASM, qty: 2 }]],
+    [PART_ASM, [{ childId: PART_MOTOR, qty: 1 }]],
+  ])
+  h.standards = new Map([
+    [PART_ASM, 3661],
+    [PART_LIFT, 8022],
+    [PART_MOTOR, 2010],
+  ])
+  h.rates = { laborCostPerUnit: 500, overheadCostPerUnit: 200 }
+  h.created = []
+  h.updated = []
+  h.constructions = []
+  h.recalcCalls = []
+  h.trace = []
+  h.publishedEntries = []
+  h.nextId = 0
+})
+
+/** Every `stock_movement` the CRUD double was asked to create. */
+function movementWrites(): Record<string, unknown>[] {
+  return h.created.filter((row) => row.defId === 'def_mv').map((row) => row.values)
+}
+
+/** Every `build` the CRUD double was asked to create. */
+function buildWrites(): Record<string, unknown>[] {
+  return h.created.filter((row) => row.defId === 'def_build').map((row) => row.values)
+}
+
+async function expectErr(promise: Promise<{ isErr(): boolean; _unsafeUnwrapErr(): Error }>) {
+  const result = await promise
+  expect(result.isErr()).toBe(true)
+  return result._unsafeUnwrapErr()
+}
+
+// ─── createBuild ────────────────────────────────────────────────────────
+
+describe('createBuild', () => {
+  it('writes ZERO stock movements — the safety property every later phase rests on (B2)', async () => {
+    const result = await createBuild(db, ORG, USER, { partId: PART_LIFT, quantityPlanned: 10 })
+
+    expect(result.isOk()).toBe(true)
+    expect(movementWrites()).toEqual([])
+    expect(buildWrites()).toHaveLength(1)
+    expect(buildWrites()[0]).toMatchObject({
+      build_status: 'planned',
+      build_quantity_planned: 10,
+      build_part: 'def_part:part_lift',
+      build_source: 'manual',
+    })
+  })
+
+  it('refuses a component — a purchased part is not assembled', async () => {
+    const error = await expectErr(
+      createBuild(db, ORG, USER, { partId: PART_MOTOR, quantityPlanned: 1 })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    // The kind check runs BEFORE the bill-of-materials check, and the motor has
+    // one — so this must fail on the classification, not on the BOM.
+    expect(error.message).toContain('part kind')
+    expect(h.created).toEqual([])
+  })
+
+  it('refuses a part with no bill of materials — a build would consume nothing', async () => {
+    h.bom.set(PART_LIFT, [])
+    const error = await expectErr(
+      createBuild(db, ORG, USER, { partId: PART_LIFT, quantityPlanned: 10 })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toContain('bill of materials')
+    expect(h.created).toEqual([])
+  })
+
+  it('refuses a run that plans to produce nothing', async () => {
+    const error = await expectErr(
+      createBuild(db, ORG, USER, { partId: PART_LIFT, quantityPlanned: 0 })
+    )
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.created).toEqual([])
+  })
+})
+
+// ─── completeBuild ──────────────────────────────────────────────────────
+
+describe('completeBuild', () => {
+  it('consumes the DIRECT subparts only — a subassembly is consumed as itself (B4)', async () => {
+    const result = await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    expect(result.isOk()).toBe(true)
+
+    const consumes = movementWrites().filter(
+      (values) => values.stock_movement_type === 'build_consume'
+    )
+    expect(consumes).toHaveLength(1)
+    expect(consumes[0]?.stock_movement_part).toBe('def_part:part_asm')
+    // The motor sits one level below the assembly and must never appear: the
+    // assembly carries its own on-hand balance and its own standard, so
+    // exploding through it would consume the same material twice.
+    expect(JSON.stringify(movementWrites())).not.toContain(PART_MOTOR)
+    // And the multi-level walk was not even reached for.
+    expect(h.getDeductionTargets).not.toHaveBeenCalled()
+    expect(h.loadSubpartGraph).not.toHaveBeenCalled()
+    expect(h.trace.filter((entry) => entry.startsWith('loadDirectSubparts'))).toEqual([
+      `loadDirectSubparts:${PART_LIFT}`,
+    ])
+  })
+
+  it('nets to zero variance when nothing is scrapped and the standard agrees with the BOM', async () => {
+    const result = await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+
+    // 2 assemblies per lift x 10 lifts = 20, at 3661 each.
+    expect(value.materialCost).toBe(73220)
+    expect(value.laborCost).toBe(5000)
+    expect(value.overheadCost).toBe(2000)
+    expect(value.producedValue).toBe(80220)
+    expect(value.varianceAmount).toBe(0)
+  })
+
+  it('scrap consumes material, produces no movement, and lands in the variance (B7)', async () => {
+    const result = await completeBuild(db, ORG, USER, {
+      buildId: BUILD,
+      quantityProduced: 10,
+      quantityScrapped: 2,
+    })
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+
+    // 12 units STARTED consume material: 2 x 12 = 24 assemblies.
+    expect(value.materialCost).toBe(87864)
+    expect(value.laborCost).toBe(6000)
+    expect(value.overheadCost).toBe(2400)
+    // Only the 10 SURVIVORS are valued into stock.
+    expect(value.producedValue).toBe(80220)
+    // 87864 + 6000 + 2400 - 80220 = 16044, which is exactly 2 x 8022: the
+    // scrapped units' whole standard cost, to account 5090.
+    expect(value.varianceAmount).toBe(16044)
+    expect(value.varianceAmount).toBe(2 * 8022)
+
+    const produces = movementWrites().filter(
+      (values) => values.stock_movement_type === 'build_produce'
+    )
+    expect(produces).toHaveLength(1)
+    // Not 12. Scrapped units produce nothing.
+    expect(produces[0]?.stock_movement_quantity).toBe(10)
+  })
+
+  it('aborts when a component has no standard cost — never posts a zero', async () => {
+    h.standards.delete(PART_ASM)
+    const error = await expectErr(
+      completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toContain('zero cost')
+    expect(h.created).toEqual([])
+    expect(h.updated).toEqual([])
+  })
+
+  it('aborts when the PRODUCED part has no standard cost', async () => {
+    h.standards.delete(PART_LIFT)
+    const error = await expectErr(
+      completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    )
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.created).toEqual([])
+  })
+
+  it('refuses a SECOND completion — one completion per build (B8)', async () => {
+    h.valueRows = [...completedBuildRows(), ...partKindRows()]
+    const error = await expectErr(
+      completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    )
+    expect(error).toBeInstanceOf(ConflictError)
+    expect(h.created).toEqual([])
+    expect(h.updated).toEqual([])
+  })
+
+  it('sets adjustSubparts: false on every row it writes', async () => {
+    await completeBuild(db, ORG, USER, {
+      buildId: BUILD,
+      quantityProduced: 10,
+      quantityScrapped: 2,
+    })
+    const rows = movementWrites()
+    expect(rows.length).toBeGreaterThan(0)
+    for (const values of rows) {
+      expect(values.stock_movement_adjust_subparts).toBe(false)
+    }
+  })
+
+  it('recalculates quantity on hand ONCE, batched, and only after the commit', async () => {
+    await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+
+    expect(h.recalcCalls).toHaveLength(1)
+    // The produced part and every consumed part, deduplicated. Under the quiet
+    // lane this call is the ONLY thing that recalculates them.
+    expect([...h.recalcCalls[0]!].sort()).toEqual([PART_ASM, PART_LIFT].sort())
+    // Ordering, not just presence: a recalc inside the transaction would re-SUM
+    // a ledger that does not yet contain the rows above.
+    expect(h.trace.indexOf('commit')).toBeGreaterThan(-1)
+    expect(h.trace.indexOf('recalc')).toBeGreaterThan(h.trace.indexOf('commit'))
+    for (const entry of h.trace.filter((step) => step.startsWith('create:'))) {
+      expect(h.trace.indexOf(entry)).toBeLessThan(h.trace.indexOf('commit'))
+    }
+  })
+
+  it('writes the ledger on the quiet lane, and never with the deprecated skipEvents alias', async () => {
+    await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+
+    const ledgerHandlers = h.constructions.filter((options) => options?.session)
+    expect(ledgerHandlers).toHaveLength(1)
+    const session = ledgerHandlers[0]?.session as {
+      mode?: { kind: string }
+      origin: { kind: string }
+    }
+    expect(session.mode?.kind).toBe('quiet')
+    // `automation`, not `seed`: a build completion is production automation, and
+    // a seed reason string would be a lie.
+    expect(session.origin.kind).toBe('automation')
+    for (const values of movementWrites()) {
+      expect(values).not.toHaveProperty('skipEvents')
+    }
+  })
+
+  it('freezes the standard onto every row, with the extended cost signed like the quantity', async () => {
+    await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    const [consume, produce] = movementWrites()
+
+    expect(consume).toMatchObject({
+      stock_movement_type: 'build_consume',
+      stock_movement_quantity: -20,
+      stock_movement_unit_cost: 3661,
+      stock_movement_extended_cost: -73220,
+      // A subassembly's stock sits in Raw Materials, not Finished Goods.
+      stock_movement_gl_account: '1310',
+      stock_movement_cost_basis: 'standard',
+      // The as-built BOM snapshot.
+      stock_movement_qty_per_unit: 2,
+      stock_movement_build: 'def_build:bld_1',
+    })
+    expect(produce).toMatchObject({
+      stock_movement_type: 'build_produce',
+      stock_movement_quantity: 10,
+      stock_movement_unit_cost: 8022,
+      stock_movement_extended_cost: 80220,
+      stock_movement_gl_account: '1330',
+      stock_movement_build: 'def_build:bld_1',
+    })
+    // NULL on the produce row, never a zero.
+    expect(produce).not.toHaveProperty('stock_movement_qty_per_unit')
+  })
+
+  it('stamps the build with the five costs and the completed status', async () => {
+    await completeBuild(db, ORG, USER, {
+      buildId: BUILD,
+      quantityProduced: 10,
+      quantityScrapped: 2,
+    })
+    expect(h.updated).toHaveLength(1)
+    expect(h.updated[0]?.values).toMatchObject({
+      build_status: 'completed',
+      build_quantity_produced: 10,
+      build_quantity_scrapped: 2,
+      build_material_cost: 87864,
+      build_labor_cost: 6000,
+      build_overhead_cost: 2400,
+      build_produced_value: 80220,
+      build_variance_amount: 16044,
+    })
+  })
+
+  it('takes a per-component override without losing the as-built BOM snapshot', async () => {
+    await completeBuild(db, ORG, USER, {
+      buildId: BUILD,
+      quantityProduced: 10,
+      componentOverrides: [{ partId: PART_ASM, quantityConsumed: 21 }],
+    })
+    const [consume] = movementWrites()
+    expect(consume?.stock_movement_quantity).toBe(-21)
+    // The floor used one more than the bill of materials called for. The bill
+    // still called for 2 per unit, and the snapshot says so.
+    expect(consume?.stock_movement_qty_per_unit).toBe(2)
+  })
+
+  it('marks an OFF-BOM substitution with a null qtyPerUnit rather than a zero', async () => {
+    await completeBuild(db, ORG, USER, {
+      buildId: BUILD,
+      quantityProduced: 10,
+      componentOverrides: [{ partId: PART_MOTOR, quantityConsumed: 5 }],
+    })
+    const substitution = movementWrites().find(
+      (values) => values.stock_movement_part === 'def_part:part_motor'
+    )
+    expect(substitution?.stock_movement_quantity).toBe(-5)
+    expect(substitution).not.toHaveProperty('stock_movement_qty_per_unit')
+    // A component's stock sits in Raw Materials.
+    expect(substitution?.stock_movement_gl_account).toBe('1310')
+  })
+
+  it('absorbs nothing when no rate is declared, and keeps the variance honest', async () => {
+    h.rates = { laborCostPerUnit: null, overheadCostPerUnit: null }
+    // A standard with no conversion cost: material only.
+    h.standards.set(PART_LIFT, 7322)
+    const result = await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    const value = result._unsafeUnwrap()
+
+    expect(value.laborCost).toBe(0)
+    expect(value.overheadCost).toBe(0)
+    expect(value.materialCost).toBe(73220)
+    expect(value.producedValue).toBe(73220)
+    expect(value.varianceAmount).toBe(0)
+  })
+
+  it('refuses a completion that produces nothing', async () => {
+    const error = await expectErr(
+      completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 0 })
+    )
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.created).toEqual([])
+  })
+})
+
+// ─── reverseBuild ───────────────────────────────────────────────────────
+
+describe('reverseBuild', () => {
+  beforeEach(() => {
+    h.valueRows = [...completedBuildRows(), ...completedMovementRows(), ...partKindRows()]
+    h.movementInstances = [{ id: 'mv_1' }, { id: 'mv_2' }]
+  })
+
+  it("carries the ORIGINAL's frozen costs, not today's", async () => {
+    // The standard has moved since. A reversal that re-priced would net the pair
+    // to a non-zero amount of inventory value out of nothing.
+    h.standards.set(PART_ASM, 9999)
+    h.standards.set(PART_LIFT, 12345)
+
+    const result = await reverseBuild(db, ORG, USER, { buildId: BUILD })
+    expect(result.isOk()).toBe(true)
+
+    const rows = movementWrites()
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      stock_movement_type: 'build_consume',
+      stock_movement_quantity: 24,
+      stock_movement_unit_cost: 3661,
+      stock_movement_extended_cost: 87864,
+      stock_movement_gl_account: '1310',
+      stock_movement_qty_per_unit: 2,
+      stock_movement_cost_basis: 'standard',
+      stock_movement_reverses_movement: 'def_mv:mv_1',
+      stock_movement_adjust_subparts: false,
+    })
+    expect(rows[1]).toMatchObject({
+      stock_movement_type: 'build_produce',
+      stock_movement_quantity: -10,
+      stock_movement_unit_cost: 8022,
+      stock_movement_extended_cost: -80220,
+      stock_movement_reverses_movement: 'def_mv:mv_2',
+    })
+    expect(JSON.stringify(rows)).not.toContain('9999')
+    expect(JSON.stringify(rows)).not.toContain('12345')
+  })
+
+  it('writes a second build carrying the negated quantities and costs', async () => {
+    await reverseBuild(db, ORG, USER, { buildId: BUILD })
+    const [reversal] = buildWrites()
+    expect(reversal).toMatchObject({
+      build_status: 'completed',
+      build_reversal_of: 'def_build:bld_1',
+      build_part: 'def_part:part_lift',
+      build_quantity_produced: -10,
+      build_quantity_scrapped: -2,
+      build_material_cost: -87864,
+      build_labor_cost: -6000,
+      build_overhead_cost: -2400,
+      build_produced_value: -80220,
+      build_variance_amount: -16044,
+    })
+    // Every reversing movement belongs to the NEW build, which is what
+    // `reverseMovement` could not express.
+    for (const values of movementWrites()) {
+      expect(values.stock_movement_build).toBe('def_build:bld_new_1')
+    }
+  })
+
+  it('recalculates quantity on hand once, after the commit', async () => {
+    await reverseBuild(db, ORG, USER, { buildId: BUILD })
+    expect(h.recalcCalls).toHaveLength(1)
+    expect([...h.recalcCalls[0]!].sort()).toEqual([PART_ASM, PART_LIFT].sort())
+    expect(h.trace.indexOf('recalc')).toBeGreaterThan(h.trace.indexOf('commit'))
+  })
+
+  it('refuses a build that is already reversed — a second negation is invisible', async () => {
+    h.reversalRows = [{ id: 'bld_rev' }]
+    const error = await expectErr(reverseBuild(db, ORG, USER, { buildId: BUILD }))
+    expect(error).toBeInstanceOf(ConflictError)
+    expect(h.created).toEqual([])
+  })
+
+  it('refuses to reverse a reversal — the correction of an over-correction is a fresh build', async () => {
+    h.valueRows = [
+      ...completedBuildRows(),
+      value(BUILD, 'build_reversal_of', { relatedEntityId: 'bld_original' }),
+      ...completedMovementRows(),
+      ...partKindRows(),
+    ]
+    const error = await expectErr(reverseBuild(db, ORG, USER, { buildId: BUILD }))
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.created).toEqual([])
+  })
+
+  it('refuses a build that was never completed — cancel it instead', async () => {
+    h.valueRows = [...plannedBuildRows(), ...partKindRows()]
+    const error = await expectErr(reverseBuild(db, ORG, USER, { buildId: BUILD }))
+    expect(error).toBeInstanceOf(ConflictError)
+    expect(h.created).toEqual([])
+  })
+})

--- a/packages/lib/src/builds/build-mutations.ts
+++ b/packages/lib/src/builds/build-mutations.ts
@@ -1,0 +1,265 @@
+// packages/lib/src/builds/build-mutations.ts
+
+/**
+ * The three build writes that touch NO stock movement: raise a run, start it,
+ * abandon it.
+ *
+ * plans/products/build/01-build-plan.md section 3.4.
+ *
+ * 🛑 **B2 is the safety property this whole file exists to state.** A `planned`
+ * build writes no movements, and `completeBuild` — in its own file — is the only
+ * function in this module that does. That is what let the `build` entity, its
+ * UI and the order-triggered auto-build all ship and be used before
+ * `part_standard_cost` had a writer: nothing here can produce a wrong number,
+ * because nothing here produces a number at all.
+ *
+ * No permission checks. The router asserts (`docs/lib-module-guide.md`
+ * section 6).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { loadDirectSubparts } from '../bom/subpart-graph'
+import { getCachedEntityDefId } from '../cache'
+import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../errors'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import { BuildStatus } from '../resources/registry/enum-values'
+import { type RecordId, toRecordId } from '../resources/resource-id'
+import {
+  assertBuildStatus,
+  type BuildFieldContext,
+  getBuild,
+  readPartKinds,
+  requireBuildFieldContext,
+} from './build-queries'
+import { canCancelBuild, canStartBuild, resolvePartKind } from './client'
+import { guard } from './guard'
+import type { BuildRecord, CancelBuildInput, CreateBuildInput, StartBuildInput } from './types'
+
+const logger = createScopedLogger('builds:mutations')
+
+/**
+ * Raise a build. Always lands `planned`.
+ *
+ * The two validations are the ones a wrong answer to is expensive later:
+ *
+ * 1. **`part_kind` must be `finished_good` or `subassembly`.** A `component` is
+ *    purchased, not assembled; a build against one would consume nothing and
+ *    produce inventory value out of thin air. NULL reads as `component`
+ *    ({@link resolvePartKind}), so an unclassified part is refused with a
+ *    message that says so — classifying the built parts is a prerequisite of
+ *    the first roll and of the first build alike.
+ * 2. **At least one direct subpart.** A run with no bill of materials has
+ *    nothing to consume, and completing it would write a lone `build_produce`
+ *    row: inventory created from nothing, at a standard cost that no consumed
+ *    material backs. Refusing here is the difference between a data problem
+ *    somebody fixes and a balance sheet nobody can explain.
+ *
+ * 🛑 **Writes no movements.** Asserted by a test, because it is the property
+ * every later phase leans on rather than a matter of what this happens to do.
+ */
+export async function createBuild(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: CreateBuildInput
+): Promise<Result<BuildRecord, Error>> {
+  return guard(
+    async () => {
+      const ctx = await requireBuildFieldContext(organizationId)
+
+      if (!Number.isFinite(input.quantityPlanned) || input.quantityPlanned <= 0) {
+        throw new BadRequestError('A build must plan to produce at least one unit')
+      }
+
+      const partDefId = await requireDefId(organizationId, 'part')
+      await assertPartExists(db, organizationId, partDefId, input.partId)
+
+      const kinds = await readPartKinds(db, organizationId, [input.partId])
+      const partKind = resolvePartKind(kinds.get(input.partId))
+      if (partKind === 'component') {
+        throw new UnprocessableEntityError(
+          'Only a finished good or a subassembly can be built. Set the part kind first.'
+        )
+      }
+
+      const subparts = await loadDirectSubparts(db, organizationId, input.partId)
+      if (subparts.length === 0) {
+        throw new UnprocessableEntityError(
+          'This part has no bill of materials, so a build would consume nothing'
+        )
+      }
+
+      const values: Record<string, unknown> = {
+        build_part: toRecordId(partDefId, input.partId),
+        build_status: BuildStatus.PLANNED,
+        build_quantity_planned: input.quantityPlanned,
+        build_source: input.source ?? 'manual',
+      }
+      if (input.notes) values.build_notes = input.notes
+      if (input.orderId) {
+        const orderDefId = await requireDefId(organizationId, 'order')
+        values.build_order = toRecordId(orderDefId, input.orderId)
+      }
+
+      // The DEFAULT (interactive) write session on purpose. Only the two paths
+      // that write stock movements take the quiet lane (`write-lane.ts`); a
+      // planned build writes nothing a record rule can act on, and silencing it
+      // would cost the list its realtime update for no benefit.
+      const crud = new UnifiedCrudHandler(organizationId, userId, db)
+      const created = await crud.create(ctx.buildDefId, values)
+
+      logger.info('Raised build', {
+        organizationId,
+        buildId: created.instance.id,
+        partId: input.partId,
+        quantityPlanned: input.quantityPlanned,
+        source: values.build_source,
+      })
+
+      return requireBuild(db, organizationId, created.instance.id)
+    },
+    'Failed to create build',
+    { organizationId, partId: input.partId }
+  )
+}
+
+/**
+ * Move a `planned` run to `in_progress` and stamp `startedAt`.
+ *
+ * Refused from any other status with a `ConflictError`: restarting a completed
+ * run would leave a build whose movements were written under a status that says
+ * they have not been.
+ */
+export async function startBuild(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: StartBuildInput
+): Promise<Result<BuildRecord, Error>> {
+  return guard(
+    async () => {
+      const ctx = await requireBuildFieldContext(organizationId)
+      const build = await requireBuild(db, organizationId, input.buildId)
+      assertBuildStatus(build, canStartBuild, 'Only a planned build can be started')
+
+      const startedAt = input.startedAt ?? new Date()
+      const values: Record<string, unknown> = { build_status: BuildStatus.IN_PROGRESS }
+      if (ctx.fields.build_started_at) values.build_started_at = startedAt.toISOString()
+
+      await updateBuild(db, organizationId, userId, ctx, input.buildId, values)
+      return requireBuild(db, organizationId, input.buildId)
+    },
+    'Failed to start build',
+    { organizationId, buildId: input.buildId }
+  )
+}
+
+/**
+ * Abandon a run that has not been completed.
+ *
+ * 🛑 **Cancelling is the whole of the correction for an unposted run, and
+ * reversal is the whole of it for a posted one** (B6). There is deliberately no
+ * path that cancels a `completed` build: its movements are in an append-only
+ * ledger and a status flip would leave them there, valuing inventory against a
+ * run the system says never happened.
+ */
+export async function cancelBuild(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: CancelBuildInput
+): Promise<Result<BuildRecord, Error>> {
+  return guard(
+    async () => {
+      const ctx = await requireBuildFieldContext(organizationId)
+      const build = await requireBuild(db, organizationId, input.buildId)
+      assertBuildStatus(
+        build,
+        canCancelBuild,
+        'A completed build is reversed, never cancelled. A cancelled build is already cancelled.'
+      )
+
+      const values: Record<string, unknown> = { build_status: BuildStatus.CANCELED }
+      if (input.reason && ctx.fields.build_notes) {
+        values.build_notes = appendNote(build.notes, input.reason)
+      }
+
+      await updateBuild(db, organizationId, userId, ctx, input.buildId, values)
+      return requireBuild(db, organizationId, input.buildId)
+    },
+    'Failed to cancel build',
+    { organizationId, buildId: input.buildId }
+  )
+}
+
+/** One `UnifiedCrudHandler.update` on the default lane, for a status-only write. */
+async function updateBuild(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  ctx: BuildFieldContext,
+  buildId: string,
+  values: Record<string, unknown>
+): Promise<void> {
+  const crud = new UnifiedCrudHandler(organizationId, userId, db)
+  await crud.update(toRecordId(ctx.buildDefId, buildId) as RecordId, values)
+}
+
+/** {@link getBuild}, as the `NotFoundError` a write path needs. */
+export async function requireBuild(
+  db: Database,
+  organizationId: string,
+  buildId: string
+): Promise<BuildRecord> {
+  const result = await getBuild(db, organizationId, buildId)
+  if (result.isErr()) throw result.error
+  if (!result.value) throw new NotFoundError(`Build ${buildId} not found`)
+  return result.value
+}
+
+/** The part must exist, in this org, unarchived — before anything else is read. */
+async function assertPartExists(
+  db: Database,
+  organizationId: string,
+  partDefId: string,
+  partId: string
+): Promise<void> {
+  const [instance] = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.id, partId),
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, partDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .limit(1)
+
+  if (!instance) throw new NotFoundError(`Part ${partId} not found`)
+}
+
+/** Free text is appended, never replaced — a cancellation reason is not the notes. */
+function appendNote(existing: string | null, addition: string): string {
+  return existing ? `${existing}\n${addition}` : addition
+}
+
+/**
+ * Resolve a def id the caller's input already committed us to, as an
+ * `UnprocessableEntityError` rather than the bare `Error` the cache helper
+ * throws — "you named an order and this org has no orders" is a 422 the UI can
+ * act on, not a 500.
+ */
+export async function requireDefId(organizationId: string, entityType: string): Promise<string> {
+  const defId = await getCachedEntityDefId(organizationId, entityType)
+  if (!defId) {
+    throw new UnprocessableEntityError(
+      `This organization has no ${entityType} entity definition yet`
+    )
+  }
+  return defId
+}

--- a/packages/lib/src/builds/build-queries.ts
+++ b/packages/lib/src/builds/build-queries.ts
@@ -1,0 +1,892 @@
+// packages/lib/src/builds/build-queries.ts
+
+/**
+ * Every READ over the build event: the list and detail surfaces, the
+ * transaction-only locking read the write paths open with, and
+ * {@link explodeBuildComponents} — the priced component plan a completion form
+ * shows before anything is written.
+ *
+ * plans/products/build/01-build-plan.md section 3.4.
+ *
+ * Reads only. The writes live in `build-mutations.ts`, `complete-build.ts` and
+ * `reverse-build.ts`, because a file that both queries and mutates is the first
+ * step back toward a service class (`docs/lib-module-guide.md` section 5).
+ *
+ * No permission checks anywhere in this file. The router asserts and hands the
+ * narrowed filters down (`docs/lib-module-guide.md` section 6).
+ */
+
+import type { Transaction } from '@auxx/database'
+import { type Database, schema } from '@auxx/database'
+import { and, desc, eq, inArray, isNotNull, isNull, type SQL } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import type { Result } from 'neverthrow'
+import { loadDirectSubparts } from '../bom/subpart-graph'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { ConflictError, NotFoundError, UnprocessableEntityError } from '../errors'
+import { computeExtendedCost, resolveGlAccountForPartKind } from '../receiving/client'
+import { toRecordId } from '../resources/resource-id'
+import {
+  type BuildStatusValue,
+  componentConsumption,
+  resolveBuildStatus,
+  unitsStarted,
+} from './client'
+import { guard } from './guard'
+import { readStandardCost } from './standard-cost-queries'
+import type {
+  BuildComponentLine,
+  BuildComponentOverride,
+  BuildComponentPlan,
+  BuildMovementRow,
+  BuildRecord,
+  ListBuildsFilters,
+  PartStandardCost,
+} from './types'
+
+/**
+ * Every attribute a {@link BuildRecord} is assembled from.
+ *
+ * All optional below: entity migration 109 provisions them, and an org that has
+ * not run it must read an empty list rather than 500.
+ */
+const BUILD_ATTRIBUTES = [
+  'build_number',
+  'build_part',
+  'build_status',
+  'build_quantity_planned',
+  'build_quantity_produced',
+  'build_quantity_scrapped',
+  'build_started_at',
+  'build_completed_at',
+  'build_material_cost',
+  'build_labor_cost',
+  'build_overhead_cost',
+  'build_produced_value',
+  'build_variance_amount',
+  'build_posted_at',
+  'build_notes',
+  'build_order',
+  'build_source',
+  'build_reversal_of',
+] as const
+
+type BuildAttribute = (typeof BUILD_ATTRIBUTES)[number]
+
+/** The movement attributes a build writes and a reversal reads back. */
+const BUILD_MOVEMENT_ATTRIBUTES = [
+  'stock_movement_build',
+  'stock_movement_part',
+  'stock_movement_type',
+  'stock_movement_quantity',
+  'stock_movement_unit_cost',
+  'stock_movement_extended_cost',
+  'stock_movement_gl_account',
+  'stock_movement_qty_per_unit',
+  'stock_movement_cost_basis',
+] as const
+
+type BuildMovementAttribute = (typeof BUILD_MOVEMENT_ATTRIBUTES)[number]
+
+const DEFAULT_LIMIT = 50
+
+/** `systemAttribute` -> the materialised `CustomField`, or `null`. */
+type BuildFields = Record<BuildAttribute, { id: string } | null>
+type BuildMovementFields = Record<BuildMovementAttribute, { id: string } | null>
+
+/** The resolved ids the build reads need. */
+export interface BuildFieldContext {
+  buildDefId: string
+  fields: BuildFields
+}
+
+/** The resolved ids the movement reads and writes need. */
+export interface BuildMovementFieldContext {
+  movementDefId: string
+  partDefId: string
+  fields: BuildMovementFields
+}
+
+/**
+ * Resolve the `build` def and its fields, or `null` when the org has no build
+ * entity yet.
+ *
+ * `null` rather than a throw so a list surface on an unmigrated org renders
+ * empty. The WRITE paths use {@link requireBuildFieldContext} instead, because
+ * a write that silently did nothing would be worse than a refusal.
+ */
+export async function loadBuildFieldContext(
+  organizationId: string
+): Promise<BuildFieldContext | null> {
+  const buildDefId = await getCachedEntityDefId(organizationId, 'build')
+  if (!buildDefId) return null
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...BUILD_ATTRIBUTES])) as BuildFields
+  // Without `status` there is no lifecycle at all, and every write gate below
+  // reduces to "yes". An org in that state must not be written to.
+  if (!fields.build_status || !fields.build_part) return null
+  return { buildDefId, fields }
+}
+
+/** {@link loadBuildFieldContext}, as the refusal a write path needs. */
+export async function requireBuildFieldContext(organizationId: string): Promise<BuildFieldContext> {
+  const ctx = await loadBuildFieldContext(organizationId)
+  if (!ctx) {
+    throw new UnprocessableEntityError(
+      'Builds are not available until the build entity and its fields are provisioned'
+    )
+  }
+  return ctx
+}
+
+/**
+ * Resolve the `stock_movement` def and the fields a build stamps onto its rows.
+ *
+ * The two migration-109 additions — `stock_movement_build` and
+ * `stock_movement_qty_per_unit` — are REQUIRED here rather than optional. A
+ * build whose movements cannot name the build that wrote them is a ledger with
+ * no provenance, and `reverseBuild` has nothing to read back.
+ */
+export async function requireBuildMovementFieldContext(
+  organizationId: string
+): Promise<BuildMovementFieldContext> {
+  const movementDefId = await getCachedEntityDefId(organizationId, 'stock_movement')
+  const partDefId = await getCachedEntityDefId(organizationId, 'part')
+  if (!movementDefId || !partDefId) {
+    throw new UnprocessableEntityError(
+      'This organization has no stock movement or part entity definition yet'
+    )
+  }
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...BUILD_MOVEMENT_ATTRIBUTES])) as BuildMovementFields
+
+  if (
+    !fields.stock_movement_build ||
+    !fields.stock_movement_part ||
+    !fields.stock_movement_type ||
+    !fields.stock_movement_quantity ||
+    !fields.stock_movement_unit_cost ||
+    !fields.stock_movement_qty_per_unit
+  ) {
+    throw new UnprocessableEntityError(
+      'Writing a build is not available until the stock movement build fields are provisioned'
+    )
+  }
+  return { movementDefId, partDefId, fields }
+}
+
+// ─── Detail and list ────────────────────────────────────────────────────
+
+/** One build, or `null` when it does not exist, is archived, or is another org's. */
+export async function getBuild(
+  db: Database,
+  organizationId: string,
+  buildId: string
+): Promise<Result<BuildRecord | null, Error>> {
+  return guard(
+    async () => {
+      const ctx = await loadBuildFieldContext(organizationId)
+      if (!ctx) return null
+
+      const [instance] = await db
+        .select({ id: schema.EntityInstance.id, createdAt: schema.EntityInstance.createdAt })
+        .from(schema.EntityInstance)
+        .where(
+          and(
+            eq(schema.EntityInstance.id, buildId),
+            eq(schema.EntityInstance.organizationId, organizationId),
+            eq(schema.EntityInstance.entityDefinitionId, ctx.buildDefId),
+            isNull(schema.EntityInstance.archivedAt)
+          )
+        )
+        .limit(1)
+
+      if (!instance) return null
+      const [record] = await hydrateBuilds(db, organizationId, ctx, [instance])
+      return record ?? null
+    },
+    'Failed to read build',
+    { organizationId, buildId }
+  )
+}
+
+/**
+ * List builds, newest first.
+ *
+ * Ordering is `createdAt` and not `completedAt`: a planned build has no
+ * completion date at all, and ordering on it would sort every open run to one
+ * end of the list — which is the half of the list a shop floor is looking at.
+ * Filters are applied in SQL, so a caller asking for page two gets page two of
+ * the filtered set.
+ */
+export async function listBuilds(
+  db: Database,
+  organizationId: string,
+  filters: ListBuildsFilters = {}
+): Promise<Result<BuildRecord[], Error>> {
+  return guard(
+    async () => {
+      const ctx = await loadBuildFieldContext(organizationId)
+      if (!ctx) return []
+      return queryBuilds(db, organizationId, ctx, filters, [])
+    },
+    'Failed to list builds',
+    { organizationId, filters }
+  )
+}
+
+/**
+ * Completed builds that carry no `postedAt` — what a GL export would pick up.
+ *
+ * ⚠️ **`postedAt` is a denormalized convenience, not the authority** (section
+ * 1.1). GL posting is out of scope for this directory (README B9), so nothing
+ * writes it yet and this returns every completed build. When the posting ledger
+ * lands, the authority becomes a `gl_posting` row referencing the build, and
+ * this function's predicate moves there — the shape of the answer does not
+ * change, so callers do not.
+ */
+export async function listUnpostedBuilds(
+  db: Database,
+  organizationId: string,
+  filters: Pick<ListBuildsFilters, 'limit' | 'offset'> = {}
+): Promise<Result<BuildRecord[], Error>> {
+  return guard(
+    async () => {
+      const ctx = await loadBuildFieldContext(organizationId)
+      if (!ctx) return []
+
+      // A LEFT JOIN plus `IS NULL` on the joined column, so a build with no
+      // `postedAt` ROW at all is included alongside one whose row is present and
+      // empty. An inner join would drop the first group, which today is every
+      // completed build there is.
+      const postedField = ctx.fields.build_posted_at
+      const unposted: AbsentValueJoin[] = postedField
+        ? [{ fieldId: postedField.id, name: 'build_unposted' }]
+        : []
+
+      return queryBuilds(db, organizationId, ctx, { ...filters, status: 'completed' }, unposted)
+    },
+    'Failed to list unposted builds',
+    { organizationId }
+  )
+}
+
+/** An aliased `FieldValue` table, as `alias()` returns it. */
+type FieldValueAlias = ReturnType<typeof alias<typeof schema.FieldValue, string>>
+
+/** A LEFT JOIN whose joined row must be absent or empty. See {@link listUnpostedBuilds}. */
+interface AbsentValueJoin {
+  fieldId: string
+  name: string
+}
+
+async function queryBuilds(
+  db: Database,
+  organizationId: string,
+  ctx: BuildFieldContext,
+  filters: ListBuildsFilters,
+  absent: AbsentValueJoin[]
+): Promise<BuildRecord[]> {
+  const limit = filters.limit ?? DEFAULT_LIMIT
+  const offset = filters.offset ?? 0
+
+  const where: SQL[] = [
+    eq(schema.EntityInstance.organizationId, organizationId),
+    eq(schema.EntityInstance.entityDefinitionId, ctx.buildDefId),
+    isNull(schema.EntityInstance.archivedAt),
+  ]
+
+  let query = db
+    .select({ id: schema.EntityInstance.id, createdAt: schema.EntityInstance.createdAt })
+    .from(schema.EntityInstance)
+    .$dynamic()
+
+  if (filters.status && ctx.fields.build_status) {
+    const statusValue = alias(schema.FieldValue, 'build_status_v')
+    query = query.innerJoin(
+      statusValue,
+      and(
+        valueJoin(statusValue, ctx.fields.build_status.id),
+        eq(statusValue.optionId, filters.status)
+      )
+    )
+  }
+
+  if (filters.source && ctx.fields.build_source) {
+    const sourceValue = alias(schema.FieldValue, 'build_source_v')
+    query = query.innerJoin(
+      sourceValue,
+      and(
+        valueJoin(sourceValue, ctx.fields.build_source.id),
+        eq(sourceValue.optionId, filters.source)
+      )
+    )
+  }
+
+  if (filters.partId && ctx.fields.build_part) {
+    const partValue = alias(schema.FieldValue, 'build_part_v')
+    query = query.innerJoin(
+      partValue,
+      and(
+        valueJoin(partValue, ctx.fields.build_part.id),
+        eq(partValue.relatedEntityId, filters.partId)
+      )
+    )
+  }
+
+  if (filters.orderId && ctx.fields.build_order) {
+    const orderValue = alias(schema.FieldValue, 'build_order_v')
+    query = query.innerJoin(
+      orderValue,
+      and(
+        valueJoin(orderValue, ctx.fields.build_order.id),
+        eq(orderValue.relatedEntityId, filters.orderId)
+      )
+    )
+  }
+
+  for (const join of absent) {
+    const absentValue = alias(schema.FieldValue, join.name)
+    query = query.leftJoin(absentValue, valueJoin(absentValue, join.fieldId))
+    where.push(isNull(absentValue.valueDate))
+  }
+
+  const rows = await query
+    .where(and(...where))
+    .orderBy(desc(schema.EntityInstance.createdAt))
+    .limit(limit)
+    .offset(offset)
+
+  if (rows.length === 0) return []
+  return hydrateBuilds(db, organizationId, ctx, rows)
+}
+
+/**
+ * Join predicate for "this instance's value of <field>".
+ *
+ * Takes the alias OBJECT and composes with `eq`, so drizzle emits the table as
+ * an identifier. A hand-written `sql` fragment interpolating a table binds it as
+ * a parameter instead, which is a mistake this codebase has already paid for.
+ */
+function valueJoin(table: FieldValueAlias, fieldId: string): SQL | undefined {
+  return and(
+    eq(table.entityId, schema.EntityInstance.id),
+    eq(table.organizationId, schema.EntityInstance.organizationId),
+    eq(table.fieldId, fieldId)
+  )
+}
+
+/**
+ * Turn a page of build ids into full rows with ONE additional query.
+ *
+ * The alternative — a join per attribute on the paging query — multiplies the
+ * row count and makes `LIMIT` mean something other than "this many builds".
+ */
+async function hydrateBuilds(
+  db: Database,
+  organizationId: string,
+  ctx: BuildFieldContext,
+  page: { id: string; createdAt: Date }[]
+): Promise<BuildRecord[]> {
+  const ids = page.map((row) => row.id)
+  const fieldIds = Object.values(ctx.fields)
+    .filter((field): field is { id: string } => field != null)
+    .map((field) => field.id)
+
+  const values = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+      valueNumber: schema.FieldValue.valueNumber,
+      valueDate: schema.FieldValue.valueDate,
+      optionId: schema.FieldValue.optionId,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.entityId, ids),
+        inArray(schema.FieldValue.fieldId, fieldIds)
+      )
+    )
+
+  const byInstance = new Map<string, Map<string, (typeof values)[number]>>()
+  for (const value of values) {
+    let bucket = byInstance.get(value.entityId)
+    if (!bucket) {
+      bucket = new Map()
+      byInstance.set(value.entityId, bucket)
+    }
+    bucket.set(value.fieldId, value)
+  }
+
+  return page.map((row) => toBuildRecord(ctx, row, byInstance.get(row.id)))
+}
+
+function toBuildRecord(
+  ctx: BuildFieldContext,
+  row: { id: string; createdAt: Date },
+  bucket:
+    | Map<
+        string,
+        {
+          valueText: string | null
+          valueNumber: number | null
+          valueDate: string | null
+          optionId: string | null
+          relatedEntityId: string | null
+        }
+      >
+    | undefined
+): BuildRecord {
+  const read = (attr: BuildAttribute) => {
+    const id = ctx.fields[attr]?.id
+    return id ? (bucket?.get(id) ?? null) : null
+  }
+  const date = (attr: BuildAttribute) => {
+    const raw = read(attr)?.valueDate
+    return raw ? new Date(raw) : null
+  }
+
+  return {
+    buildId: row.id,
+    recordId: toRecordId(ctx.buildDefId, row.id),
+    number: read('build_number')?.valueText ?? null,
+    partId: read('build_part')?.relatedEntityId ?? null,
+    status: resolveBuildStatus(read('build_status')?.optionId),
+    quantityPlanned: read('build_quantity_planned')?.valueNumber ?? null,
+    quantityProduced: read('build_quantity_produced')?.valueNumber ?? null,
+    quantityScrapped: read('build_quantity_scrapped')?.valueNumber ?? null,
+    startedAt: date('build_started_at'),
+    completedAt: date('build_completed_at'),
+    materialCost: read('build_material_cost')?.valueNumber ?? null,
+    laborCost: read('build_labor_cost')?.valueNumber ?? null,
+    overheadCost: read('build_overhead_cost')?.valueNumber ?? null,
+    producedValue: read('build_produced_value')?.valueNumber ?? null,
+    varianceAmount: read('build_variance_amount')?.valueNumber ?? null,
+    postedAt: date('build_posted_at'),
+    notes: read('build_notes')?.valueText ?? null,
+    orderId: read('build_order')?.relatedEntityId ?? null,
+    source: read('build_source')?.optionId ?? null,
+    reversalOfBuildId: read('build_reversal_of')?.relatedEntityId ?? null,
+    createdAt: row.createdAt,
+  }
+}
+
+// ─── The transaction-only reads ─────────────────────────────────────────
+
+/**
+ * Re-read a build `FOR UPDATE`, inside the caller's transaction.
+ *
+ * 🛑 **This is the whole of B8's enforcement.** Two concurrent completions both
+ * reach here; the row lock serialises them, the loser reads the status the
+ * winner committed, and `canCompleteBuild` refuses it. Reading the status
+ * BEFORE taking the lock — or taking no lock — makes "one completion per build"
+ * a race, and the losing side would write a second full set of movements that
+ * nothing downstream can tell from the first.
+ *
+ * `tx` is positional-first and typed as {@link Transaction}, not `Database`, so
+ * a connection pool cannot typecheck into the slot
+ * (`docs/lib-module-guide.md` section 4).
+ */
+export async function lockBuild(
+  tx: Transaction,
+  organizationId: string,
+  ctx: BuildFieldContext,
+  buildId: string
+): Promise<BuildRecord> {
+  const [instance] = await tx
+    .select({ id: schema.EntityInstance.id, createdAt: schema.EntityInstance.createdAt })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.id, buildId),
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, ctx.buildDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .for('update')
+
+  if (!instance) throw new NotFoundError(`Build ${buildId} not found`)
+
+  const [record] = await hydrateBuilds(tx as unknown as Database, organizationId, ctx, [instance])
+  if (!record) throw new NotFoundError(`Build ${buildId} not found`)
+  return record
+}
+
+/**
+ * Assert a build is in one of the statuses an action accepts.
+ *
+ * A `null` status is refused with the same `ConflictError`: see
+ * {@link resolveBuildStatus} for why an absent status is never defaulted on a
+ * path that writes.
+ */
+export function assertBuildStatus(
+  build: BuildRecord,
+  allowed: (status: BuildStatusValue | null) => boolean,
+  message: string
+): void {
+  if (!allowed(build.status)) throw new ConflictError(message)
+}
+
+/**
+ * Does a live build already point its `reversalOf` at this one?
+ *
+ * Joins `EntityInstance` so an ARCHIVED reversal does not block a legitimate
+ * second attempt — an archived build contributes nothing to any roll-up, so
+ * treating it as a standing reversal would leave the mistake uncorrectable.
+ * Same rule, and the same reason, as `reverse-movement.ts`'s `hasReversal`.
+ */
+export async function hasBuildReversal(
+  db: Database,
+  organizationId: string,
+  ctx: BuildFieldContext,
+  buildId: string
+): Promise<boolean> {
+  const reversalField = ctx.fields.build_reversal_of
+  if (!reversalField) return false
+
+  const [existing] = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.FieldValue)
+    .innerJoin(
+      schema.EntityInstance,
+      and(
+        eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+        eq(schema.EntityInstance.organizationId, schema.FieldValue.organizationId)
+      )
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, reversalField.id),
+        eq(schema.FieldValue.relatedEntityId, buildId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .limit(1)
+
+  return Boolean(existing)
+}
+
+/**
+ * Every live `stock_movement` this build wrote, with its FROZEN costs.
+ *
+ * 🛑 The costs come back verbatim and are never re-priced. A reversal valued at
+ * today's standard nets a build and its undo to a non-zero amount of inventory
+ * value out of nothing, which is the exact costing bug this subsystem exists to
+ * prevent (B6).
+ */
+export async function readBuildMovements(
+  db: Database,
+  organizationId: string,
+  movementCtx: BuildMovementFieldContext,
+  buildId: string
+): Promise<BuildMovementRow[]> {
+  const { fields } = movementCtx
+  const buildValue = alias(schema.FieldValue, 'mv_build')
+
+  const instances = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      buildValue,
+      and(
+        eq(buildValue.entityId, schema.EntityInstance.id),
+        eq(buildValue.organizationId, schema.EntityInstance.organizationId),
+        eq(buildValue.fieldId, fields.stock_movement_build!.id),
+        eq(buildValue.relatedEntityId, buildId)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, movementCtx.movementDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .orderBy(schema.EntityInstance.createdAt)
+
+  if (instances.length === 0) return []
+
+  const fieldIds = Object.values(fields)
+    .filter((field): field is { id: string } => field != null)
+    .map((field) => field.id)
+
+  const values = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+      valueNumber: schema.FieldValue.valueNumber,
+      optionId: schema.FieldValue.optionId,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(
+          schema.FieldValue.entityId,
+          instances.map((row) => row.id)
+        ),
+        inArray(schema.FieldValue.fieldId, fieldIds)
+      )
+    )
+
+  const byInstance = new Map<string, Map<string, (typeof values)[number]>>()
+  for (const value of values) {
+    let bucket = byInstance.get(value.entityId)
+    if (!bucket) {
+      bucket = new Map()
+      byInstance.set(value.entityId, bucket)
+    }
+    bucket.set(value.fieldId, value)
+  }
+
+  const rows: BuildMovementRow[] = []
+  for (const instance of instances) {
+    const bucket = byInstance.get(instance.id)
+    const read = (attr: BuildMovementAttribute) => {
+      const id = fields[attr]?.id
+      return id ? (bucket?.get(id) ?? null) : null
+    }
+    const partId = read('stock_movement_part')?.relatedEntityId ?? null
+    const type = read('stock_movement_type')?.optionId ?? null
+    const quantity = read('stock_movement_quantity')?.valueNumber ?? null
+    const unitCost = read('stock_movement_unit_cost')?.valueNumber ?? null
+
+    if (!partId || !type || quantity == null || quantity === 0 || unitCost == null) {
+      // Every row a build writes carries all four. One that does not was not
+      // written by `completeBuild`, and negating it would invent a cost.
+      throw new UnprocessableEntityError(
+        `Stock movement ${instance.id} on this build has no part, type, quantity or frozen cost and cannot be reversed`
+      )
+    }
+
+    rows.push({
+      movementId: instance.id,
+      partId,
+      type,
+      quantity,
+      unitCost,
+      extendedCost: read('stock_movement_extended_cost')?.valueNumber ?? null,
+      glAccount: read('stock_movement_gl_account')?.valueText ?? null,
+      qtyPerUnit: read('stock_movement_qty_per_unit')?.valueNumber ?? null,
+      costBasis: read('stock_movement_cost_basis')?.optionId ?? null,
+    })
+  }
+
+  return rows
+}
+
+// ─── The component plan ─────────────────────────────────────────────────
+
+/** What {@link planBuildComponents} needs to price a run. */
+export interface BuildComponentPlanInput {
+  /** `EntityInstance.id` of the `part` being produced. */
+  partId: string
+  quantityProduced: number
+  quantityScrapped?: number
+  componentOverrides?: BuildComponentOverride[]
+}
+
+/**
+ * The priced component plan, with the standards a completion would freeze.
+ *
+ * 🛑 **`loadDirectSubparts`, never `getDeductionTargets`** (B4). The multi-level
+ * walk deducts every descendant *including intermediates*, which is defensible
+ * for backflush-at-sale and wrong the moment a subassembly has its own on-hand
+ * balance — which is exactly what build-to-stock creates. A build consumes one
+ * level; the subassembly beneath it is produced by its own build and carries its
+ * own standard, so exploding through it would consume the same material twice
+ * and value the run at a number no ledger can reconcile.
+ *
+ * Reads, never writes. `completeBuild` calls this and then refuses if
+ * `missingStandardPartIds` is non-empty.
+ */
+export async function planBuildComponents(
+  db: Database,
+  organizationId: string,
+  input: BuildComponentPlanInput
+): Promise<BuildComponentPlan> {
+  const quantityProduced = input.quantityProduced
+  const quantityScrapped = input.quantityScrapped ?? 0
+  const started = unitsStarted(quantityProduced, quantityScrapped)
+
+  const edges = await loadDirectSubparts(db, organizationId, input.partId)
+  const overrides = new Map<string, number>()
+  for (const override of input.componentOverrides ?? []) {
+    overrides.set(override.partId, override.quantityConsumed)
+  }
+
+  // BOM order first, then any off-BOM substitution, so a form renders the bill
+  // of materials in its own order and the exceptions after it.
+  const bomPartIds = new Set(edges.map((edge) => edge.childId))
+  const planned: { partId: string; qtyPerUnit: number | null; quantityConsumed: number }[] = []
+
+  for (const edge of edges) {
+    const overridden = overrides.get(edge.childId)
+    planned.push({
+      partId: edge.childId,
+      // The BOM edge is the AS-BUILT snapshot and survives an override: the
+      // floor used a different quantity of a component that IS on the bill,
+      // which is not the same claim as "this component is off-BOM".
+      qtyPerUnit: edge.qty,
+      quantityConsumed: overridden ?? componentConsumption(edge.qty, started),
+    })
+  }
+
+  for (const [partId, quantityConsumed] of overrides) {
+    if (bomPartIds.has(partId)) continue
+    // NULL `qtyPerUnit` is the off-BOM marker the field exists for: a floor
+    // substitution, made visible instead of silent.
+    planned.push({ partId, qtyPerUnit: null, quantityConsumed })
+  }
+
+  // A zero-quantity line is dropped rather than written. A movement of zero is a
+  // row in an append-only ledger that changes nothing and can never be removed;
+  // `adjustStock` refuses one for the same reason.
+  const lines = planned.filter((line) => line.quantityConsumed !== 0)
+
+  const partIds = [input.partId, ...lines.map((line) => line.partId)]
+  const [standards, kinds, names] = await Promise.all([
+    readStandardCostMap(db, organizationId, partIds),
+    readPartKinds(
+      db,
+      organizationId,
+      lines.map((line) => line.partId)
+    ),
+    readPartNames(
+      db,
+      organizationId,
+      lines.map((line) => line.partId)
+    ),
+  ])
+
+  const missingStandardPartIds: string[] = []
+  if (!standards.has(input.partId)) missingStandardPartIds.push(input.partId)
+
+  const components: BuildComponentLine[] = lines.map((line) => {
+    const standard = standards.get(line.partId) ?? null
+    if (!standard) missingStandardPartIds.push(line.partId)
+    return {
+      partId: line.partId,
+      partName: names.get(line.partId) ?? null,
+      qtyPerUnit: line.qtyPerUnit,
+      quantityConsumed: line.quantityConsumed,
+      unitCost: standard?.standardCost ?? null,
+      // Rounded AFTER multiplying, never as a sum of rounded units: rounding
+      // first scales the error by the quantity.
+      extendedCost: standard
+        ? computeExtendedCost(standard.standardCost, line.quantityConsumed)
+        : null,
+      glAccount: resolveGlAccountForPartKind(kinds.get(line.partId) ?? null),
+      offBom: line.qtyPerUnit == null,
+    }
+  })
+
+  return {
+    partId: input.partId,
+    quantityProduced,
+    quantityScrapped,
+    unitsStarted: started,
+    producedUnitCost: standards.get(input.partId)?.standardCost ?? null,
+    components,
+    missingStandardPartIds,
+  }
+}
+
+/**
+ * What a completion would consume, and at what cost, without consuming it.
+ *
+ * The public read behind the completion form's per-component quantity
+ * overrides. It fails with nothing — a component with no standard comes back in
+ * `missingStandardPartIds` so the form can name the part to go roll, rather than
+ * surfacing at the moment of writing.
+ */
+export async function explodeBuildComponents(
+  db: Database,
+  organizationId: string,
+  input: BuildComponentPlanInput
+): Promise<Result<BuildComponentPlan, Error>> {
+  return guard(
+    async () => planBuildComponents(db, organizationId, input),
+    'Failed to explode build components',
+    { organizationId, partId: input.partId }
+  )
+}
+
+/** {@link readStandardCost}, unwrapped — the plan is already inside a `guard`. */
+async function readStandardCostMap(
+  db: Database,
+  organizationId: string,
+  partIds: string[]
+): Promise<Map<string, PartStandardCost>> {
+  const result = await readStandardCost(db, organizationId, [...new Set(partIds)])
+  if (result.isErr()) throw result.error
+  return result.value
+}
+
+/** `part_kind` for several parts in one query. A part with no row reads absent. */
+export async function readPartKinds(
+  db: Database,
+  organizationId: string,
+  partIds: string[]
+): Promise<Map<string, string>> {
+  const kinds = new Map<string, string>()
+  if (partIds.length === 0) return kinds
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['part_kind'] as const)
+  const kindField = fields.part_kind
+  if (!kindField) return kinds
+
+  const rows = await db
+    .select({ entityId: schema.FieldValue.entityId, optionId: schema.FieldValue.optionId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.entityId, [...new Set(partIds)]),
+        eq(schema.FieldValue.fieldId, kindField.id),
+        isNotNull(schema.FieldValue.optionId)
+      )
+    )
+
+  for (const row of rows) {
+    if (row.optionId) kinds.set(row.entityId, row.optionId)
+  }
+  return kinds
+}
+
+/** `EntityInstance.displayName` for several parts. A plan names parts, not cuids. */
+export async function readPartNames(
+  db: Database,
+  organizationId: string,
+  partIds: string[]
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>()
+  if (partIds.length === 0) return names
+
+  const rows = await db
+    .select({ id: schema.EntityInstance.id, displayName: schema.EntityInstance.displayName })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        inArray(schema.EntityInstance.id, [...new Set(partIds)])
+      )
+    )
+
+  for (const row of rows) {
+    if (row.displayName) names.set(row.id, row.displayName)
+  }
+  return names
+}

--- a/packages/lib/src/builds/client.ts
+++ b/packages/lib/src/builds/client.ts
@@ -97,3 +97,116 @@ export function standardCostDrift(
   if (liveCost == null || standardCost == null) return null
   return liveCost - standardCost
 }
+
+// ─── The build event (phase 2) ─────────────────────────────────────────
+//
+// plans/products/build/01-build-plan.md section 3, README B2/B6/B7/B8.
+
+/** The four values `build_status` can hold. Mirrors `BuildStatus` in the registry. */
+export type BuildStatusValue = 'planned' | 'in_progress' | 'completed' | 'canceled'
+
+/** Human labels, so a caller never has to re-derive them from the enum. */
+export const BUILD_STATUS_LABELS: Readonly<Record<BuildStatusValue, string>> = Object.freeze({
+  planned: 'Planned',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+  canceled: 'Canceled',
+})
+
+/**
+ * Read a stored `build_status` option value, or `null`.
+ *
+ * 🛑 **Unlike {@link resolvePartKind}, an absent status does NOT fall back.** A
+ * part with no `part_kind` is an unclassified part and reading it as a
+ * `component` is the conservative direction; a build with no status is a row
+ * whose lifecycle nobody can state, and defaulting it to `planned` would let
+ * `completeBuild` write an append-only ledger entry against it. `build_status`
+ * carries `defaultValue: 'planned'` and `createBuild` sets it explicitly, so
+ * `null` here is a data problem, and the write paths refuse it.
+ */
+export function resolveBuildStatus(raw: string | null | undefined): BuildStatusValue | null {
+  if (raw === 'planned' || raw === 'in_progress' || raw === 'completed' || raw === 'canceled') {
+    return raw
+  }
+  return null
+}
+
+/** `planned` is the only status a run can be started from. */
+export function canStartBuild(status: BuildStatusValue | null): boolean {
+  return status === 'planned'
+}
+
+/**
+ * The two statuses `completeBuild` accepts.
+ *
+ * 🛑 **B8 — one completion per build.** `completed` is deliberately absent: a
+ * run finished in tranches is a second build, not a second completion, because
+ * multi-completion needs per-tranche movement batches, a partial-consumption
+ * watermark and a variance per tranche. `canceled` is absent for the obvious
+ * reason.
+ */
+export function canCompleteBuild(status: BuildStatusValue | null): boolean {
+  return status === 'planned' || status === 'in_progress'
+}
+
+/** A run can be abandoned right up until it is completed. */
+export function canCancelBuild(status: BuildStatusValue | null): boolean {
+  return status === 'planned' || status === 'in_progress'
+}
+
+/**
+ * Only a completed build can be reversed.
+ *
+ * B6: a completed build is never edited or deleted — it is reversed by a second
+ * build carrying the ORIGINAL's frozen costs. A `planned` build has written
+ * nothing (B2), so there is nothing to reverse; cancelling it is the whole of
+ * the correction.
+ */
+export function canReverseBuild(status: BuildStatusValue | null): boolean {
+  return status === 'completed'
+}
+
+/**
+ * Units that entered the run: good units plus scrap.
+ *
+ * 🛑 **B7 — this, and not `quantityProduced`, is what consumes material.** A
+ * unit that was started and then lost still ate its components; pretending
+ * otherwise would leave the ledger holding material that is physically gone.
+ * Its cost falls out in `varianceAmount` (account 5090) rather than being
+ * absorbed into the survivors, because absorbing it would give the same variant
+ * a different unit cost on every run and destroy the point of a standard.
+ */
+export function unitsStarted(quantityProduced: number, quantityScrapped: number): number {
+  return quantityProduced + quantityScrapped
+}
+
+/** `qtyPer x unitsStarted` — the BOM quantity for one component of one run. */
+export function componentConsumption(qtyPerUnit: number, started: number): number {
+  return qtyPerUnit * started
+}
+
+/**
+ * `(material + labour + overhead) - producedValue`, in whole minor units.
+ *
+ * Positive means the run cost MORE than the standard says the output is worth,
+ * and the difference is a debit to **5090**. The three inputs are the absorbed
+ * amounts for the units STARTED; `producedValue` values only the units that
+ * survived. So with no scrap and a standard that agrees with the bill of
+ * materials the terms cancel exactly and the variance is zero, and with `s`
+ * units scrapped it comes out at `s x standardCost` — the scrapped units' whole
+ * standard cost, which is precisely what B7 says should land in 5090.
+ */
+export function buildVariance(parts: {
+  materialCost: number
+  laborCost: number
+  overheadCost: number
+  producedValue: number
+}): number {
+  return parts.materialCost + parts.laborCost + parts.overheadCost - parts.producedValue
+}
+
+/**
+ * The account a build's variance belongs to. Never posted here (README B9) —
+ * carried so the number and its destination stay in one place.
+ */
+export const BUILD_VARIANCE_ACCOUNT = '5090'

--- a/packages/lib/src/builds/complete-build.ts
+++ b/packages/lib/src/builds/complete-build.ts
@@ -1,0 +1,467 @@
+// packages/lib/src/builds/complete-build.ts
+
+/**
+ * `completeBuild` — the ONLY function in this module that writes a stock
+ * movement, and the one heavy write in the whole directory.
+ *
+ * plans/products/build/01-build-plan.md section 3.4, README B2/B4/B7/B8.
+ *
+ * ## What it produces
+ *
+ * ```
+ * -20  400Lbs motor Assembly   @ its frozen standard cost   (build_consume)
+ * +10  Auxx Lift 400lbs 4x8    @ its frozen standard cost   (build_produce)
+ * ```
+ *
+ * That pair is the event the system could not record before this file existed,
+ * and it is why margin was unavailable: not because parts had no cost, but
+ * because nothing ever wrote a cost DOWN. `part_cost` is a live mirror — a
+ * vendor raising the motor price in March silently restates January's COGS.
+ * Every number this function writes is read from `part_standard_cost`, frozen
+ * onto an append-only row, and never recomputed.
+ *
+ * ## The four traps, and where each is handled
+ *
+ * 1. **The transaction boundary.** Record-rule handlers use the module-level
+ *    `database` and `publishEvent` is not awaited, so a quantity-on-hand recalc
+ *    fired from inside `db.transaction()` reads a PRE-BUILD snapshot. The
+ *    recalc therefore runs {@link recalculateAfterCommit}, after the
+ *    transaction returns, never inside it.
+ * 2. **The write lane.** One quiet session, decided in `write-lane.ts` and
+ *    nowhere else. Read that file before changing it — `skipEvents: true` closes
+ *    only one of the two dispatch doors.
+ * 3. **Batch the recalc.** Quantity on hand is a full re-SUM per part on every
+ *    movement write; a build writing 51 movements would make that 51x worse in a
+ *    loop. ONE `batchRecalculateQoH` over the produced part and every consumed
+ *    part. Under the quiet lane this call is the only thing recalculating them
+ *    at all, so it is load-bearing rather than an optimisation.
+ * 4. **`adjustSubparts: false` on every row.** The build does its own explosion.
+ *    `explodeBomMovement` guards on this flag before any query, on every lane,
+ *    which makes it the belt that keeps this safe if the lane ever changes.
+ *
+ * No permission checks. The router asserts (`docs/lib-module-guide.md`
+ * section 6).
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import type { Result } from 'neverthrow'
+import { batchRecalculateQoH } from '../bom/qoh'
+import { BadRequestError, UnprocessableEntityError } from '../errors'
+import {
+  type FieldValueUpdateEntry,
+  getRealtimeService,
+  publishFieldValueUpdates,
+} from '../realtime'
+import { computeExtendedCost, resolveGlAccountForPartKind } from '../receiving/client'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import {
+  BuildStatus,
+  StockMovementCostBasis,
+  StockMovementType,
+} from '../resources/registry/enum-values'
+import { type RecordId, toRecordId } from '../resources/resource-id'
+import {
+  assertBuildStatus,
+  type BuildFieldContext,
+  type BuildMovementFieldContext,
+  lockBuild,
+  planBuildComponents,
+  readPartKinds,
+  requireBuildFieldContext,
+  requireBuildMovementFieldContext,
+} from './build-queries'
+import { buildVariance, canCompleteBuild, roundMinorUnits, unitsStarted } from './client'
+import { guard } from './guard'
+import { loadAbsorptionRates } from './standard-cost-queries'
+import type {
+  AbsorptionRates,
+  BuildComponentPlan,
+  BuildRecord,
+  CompleteBuildInput,
+  CompleteBuildResult,
+} from './types'
+import { buildWriteSession } from './write-lane'
+
+const logger = createScopedLogger('builds:complete')
+
+/**
+ * Finish a run: consume the components, produce the good units, and freeze what
+ * it cost.
+ *
+ * The order of the steps is the contract:
+ *
+ * 1. Re-read the build `FOR UPDATE` and refuse unless it is `planned` or
+ *    `in_progress`. **B8 — one completion per build.** The lock is what makes
+ *    that a rule rather than a race; a run finished in tranches is a second
+ *    build.
+ * 2. Resolve components with `loadDirectSubparts` — **direct only** (B4).
+ * 3. Value every line at its `part_standard_cost`. **If any component has none,
+ *    abort with `UnprocessableEntityError` naming the parts.** Never post a zero
+ *    cost: a zero-cost consume row understates COGS, drags every downstream
+ *    average toward zero, and is frozen onto an `updatable: false` row forever.
+ * 4. One `build_consume` per component, at `-consumed`.
+ * 5. One `build_produce` at `+quantityProduced`.
+ * 6. Stamp the five cost fields and `status: 'completed'`.
+ *
+ * Then, and only after the transaction has committed, one batched
+ * quantity-on-hand recalculation.
+ */
+export async function completeBuild(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: CompleteBuildInput
+): Promise<Result<CompleteBuildResult, Error>> {
+  return guard(
+    async () => {
+      const quantityProduced = input.quantityProduced
+      const quantityScrapped = input.quantityScrapped ?? 0
+      assertQuantities(quantityProduced, quantityScrapped)
+
+      const [ctx, movementCtx, rates] = await Promise.all([
+        requireBuildFieldContext(organizationId),
+        requireBuildMovementFieldContext(organizationId),
+        // Read OUTSIDE the transaction: the two absorption rates are org
+        // settings, they are not part of the invariant the row lock protects,
+        // and reading them inside would hold the lock across a settings round
+        // trip for nothing.
+        loadAbsorptionRates(organizationId),
+      ])
+
+      const completedAt = input.completedAt ?? new Date()
+
+      const written = await db.transaction(async (tx) =>
+        writeCompletion(tx, organizationId, userId, {
+          ctx,
+          movementCtx,
+          rates,
+          input,
+          quantityProduced,
+          quantityScrapped,
+          completedAt,
+        })
+      )
+
+      // 🛑 Trap 1 and trap 3, both discharged here and NOWHERE else. Inside the
+      // transaction this would re-SUM a ledger that does not yet contain the
+      // rows above; per movement it would be 51 full re-SUMs.
+      await recalculateAfterCommit(organizationId, written.result.recalculatedPartIds)
+      publishBuildUpdate(organizationId, ctx, written.result, completedAt)
+
+      logger.info('Completed build', {
+        organizationId,
+        buildId: written.result.buildId,
+        quantityProduced,
+        quantityScrapped,
+        movements: written.result.movementIds.length,
+        materialCost: written.result.materialCost,
+        producedValue: written.result.producedValue,
+        varianceAmount: written.result.varianceAmount,
+      })
+
+      return written.result
+    },
+    'Failed to complete build',
+    { organizationId, buildId: input.buildId }
+  )
+}
+
+interface WriteCompletionArgs {
+  ctx: BuildFieldContext
+  movementCtx: BuildMovementFieldContext
+  rates: AbsorptionRates
+  input: CompleteBuildInput
+  quantityProduced: number
+  quantityScrapped: number
+  completedAt: Date
+}
+
+/** Everything the post-commit work needs, plus the caller's answer. */
+interface WrittenCompletion {
+  build: BuildRecord
+  result: CompleteBuildResult
+}
+
+/**
+ * Steps 1 to 6, inside one transaction.
+ *
+ * `tx` is positional-first and typed as {@link Transaction} so a connection pool
+ * cannot typecheck into the slot: every write below must land or none of them
+ * must, and a pool here would write a half-build that no reversal can describe.
+ */
+async function writeCompletion(
+  tx: Transaction,
+  organizationId: string,
+  userId: string,
+  args: WriteCompletionArgs
+): Promise<WrittenCompletion> {
+  const { ctx, movementCtx, rates, input, quantityProduced, quantityScrapped, completedAt } = args
+  const txDb = tx as unknown as Database
+
+  // Step 1. The lock IS B8's enforcement — see `lockBuild`.
+  const build = await lockBuild(tx, organizationId, ctx, input.buildId)
+  assertBuildStatus(
+    build,
+    canCompleteBuild,
+    'This build has already been completed or cancelled. A run finished in tranches is a second build.'
+  )
+  if (!build.partId) {
+    throw new UnprocessableEntityError('This build names no part and cannot be completed')
+  }
+
+  // Steps 2 and 3.
+  const plan = await planBuildComponents(txDb, organizationId, {
+    partId: build.partId,
+    quantityProduced,
+    quantityScrapped,
+    componentOverrides: input.componentOverrides,
+  })
+  assertPlanIsPostable(plan)
+
+  const started = unitsStarted(quantityProduced, quantityScrapped)
+  const laborCost = absorbed(input.laborCost, rates.laborCostPerUnit, started)
+  const overheadCost = absorbed(input.overheadCost, rates.overheadCostPerUnit, started)
+  // Non-null by construction: `assertPlanIsPostable` refuses a plan whose
+  // produced part has no standard, which is the same "never post a zero cost"
+  // rule seen from the other side. Re-checked rather than cast, because a cast
+  // would silently survive somebody weakening that assertion.
+  const producedUnitCost = plan.producedUnitCost
+  if (producedUnitCost == null) {
+    throw new UnprocessableEntityError(
+      'Refusing to complete a build at zero cost: roll the standard cost for the produced part first'
+    )
+  }
+  const producedValue = computeExtendedCost(producedUnitCost, quantityProduced)
+
+  let materialCost = 0
+  for (const line of plan.components) materialCost += line.extendedCost ?? 0
+
+  const varianceAmount = buildVariance({
+    materialCost,
+    laborCost,
+    overheadCost,
+    producedValue,
+  })
+
+  const producedKinds = await readPartKinds(txDb, organizationId, [build.partId])
+  const crud = new UnifiedCrudHandler(organizationId, userId, txDb, undefined, {
+    // The one construction site for the quiet lane. See `write-lane.ts`.
+    session: buildWriteSession(),
+  })
+
+  const buildRecordId = toRecordId(ctx.buildDefId, build.buildId)
+  const movementIds: string[] = []
+
+  // Step 4: one `build_consume` per component, at the NEGATED quantity.
+  for (const line of plan.components) {
+    const values: Record<string, unknown> = {
+      stock_movement_part: toRecordId(movementCtx.partDefId, line.partId),
+      stock_movement_type: StockMovementType.BUILD_CONSUME,
+      stock_movement_quantity: -line.quantityConsumed,
+      // See the file header, trap 4. Never true on a build row.
+      stock_movement_adjust_subparts: false,
+      stock_movement_build: buildRecordId,
+      stock_movement_unit_cost: line.unitCost,
+      // Negated from the POSITIVE extended cost the plan computed, so the row
+      // and `materialCost` cannot disagree by a rounding step. Deriving it from
+      // `round(unitCost x -consumed)` instead would differ on a half-cent tail,
+      // because `Math.round` breaks ties toward positive infinity.
+      stock_movement_extended_cost: -(line.extendedCost ?? 0),
+      stock_movement_gl_account: line.glAccount,
+      stock_movement_cost_basis: StockMovementCostBasis.STANDARD,
+      stock_movement_occurred_at: completedAt.toISOString(),
+    }
+    // NULL is the OFF-BOM marker and is written as an absence, not a zero: a
+    // stamped `0` would claim the bill of materials calls for none of this
+    // component, which is a different and false statement.
+    if (line.qtyPerUnit != null) values.stock_movement_qty_per_unit = line.qtyPerUnit
+
+    const created = await crud.create(movementCtx.movementDefId, values)
+    movementIds.push(created.instance.id)
+  }
+
+  // Step 5: the single `build_produce`.
+  //
+  // ⚠️ The account is resolved from the produced part's OWN `part_kind`, not
+  // hard-coded to 1330. Section 3.4 names 1330 because the case it describes is
+  // a finished good, and for a finished good this resolves to exactly that. A
+  // SUBASSEMBLY build stamped 1330 would put raw-materials stock into Finished
+  // Goods, contradicting the part-kind account map that receiving already uses
+  // (products/01 section 4) and overstating 1330 on every subassembly run.
+  const produceValues: Record<string, unknown> = {
+    stock_movement_part: toRecordId(movementCtx.partDefId, build.partId),
+    stock_movement_type: StockMovementType.BUILD_PRODUCE,
+    // 🛑 `quantityProduced`, never `unitsStarted`. B7: scrapped units consume
+    // material and produce NO movement. Their cost falls out in
+    // `varianceAmount` instead of being absorbed into the survivors, because
+    // absorbing it would give the same variant a different unit cost on every
+    // run and destroy the point of a standard.
+    stock_movement_quantity: quantityProduced,
+    stock_movement_adjust_subparts: false,
+    stock_movement_build: buildRecordId,
+    stock_movement_unit_cost: producedUnitCost,
+    stock_movement_extended_cost: producedValue,
+    stock_movement_gl_account: resolveGlAccountForPartKind(producedKinds.get(build.partId) ?? null),
+    stock_movement_cost_basis: StockMovementCostBasis.STANDARD,
+    stock_movement_occurred_at: completedAt.toISOString(),
+  }
+  const produce = await crud.create(movementCtx.movementDefId, produceValues)
+  movementIds.push(produce.instance.id)
+
+  // Step 6.
+  const buildValues: Record<string, unknown> = {
+    build_status: BuildStatus.COMPLETED,
+    build_quantity_produced: quantityProduced,
+    build_quantity_scrapped: quantityScrapped,
+    build_material_cost: materialCost,
+    build_labor_cost: laborCost,
+    build_overhead_cost: overheadCost,
+    build_produced_value: producedValue,
+    build_variance_amount: varianceAmount,
+    build_completed_at: completedAt.toISOString(),
+  }
+  if (input.notes && ctx.fields.build_notes) {
+    buildValues.build_notes = build.notes ? `${build.notes}\n${input.notes}` : input.notes
+  }
+  await crud.update(buildRecordId as RecordId, buildValues)
+
+  return {
+    build,
+    result: {
+      buildId: build.buildId,
+      recordId: buildRecordId,
+      quantityProduced,
+      quantityScrapped,
+      materialCost,
+      laborCost,
+      overheadCost,
+      producedValue,
+      varianceAmount,
+      movementIds,
+      recalculatedPartIds: [build.partId, ...plan.components.map((line) => line.partId)],
+    },
+  }
+}
+
+/**
+ * ONE batched recalculation, after the commit.
+ *
+ * Extracted so the ordering is a named step a test can assert against rather
+ * than a line in the middle of a long function. See traps 1 and 3.
+ */
+export async function recalculateAfterCommit(
+  organizationId: string,
+  partIds: string[]
+): Promise<void> {
+  await batchRecalculateQoH(organizationId, [...new Set(partIds)])
+}
+
+/**
+ * Refuse a plan that cannot be valued, naming the parts.
+ *
+ * 🛑 **Never post a zero cost.** `readStandardCost` omits a part that has never
+ * been rolled rather than defaulting it, precisely so this check can exist: a
+ * missing standard is a refusal, not a zero. The two failure modes it prevents
+ * are the same failure seen from either end — an unvalued consume row
+ * understates COGS forever, and an unvalued produce row creates inventory at
+ * nothing.
+ */
+function assertPlanIsPostable(plan: BuildComponentPlan): void {
+  if (plan.components.length === 0) {
+    throw new UnprocessableEntityError(
+      'This build has no components to consume. Add a bill of materials, or record a stock adjustment instead.'
+    )
+  }
+  if (plan.missingStandardPartIds.length > 0) {
+    throw new UnprocessableEntityError(
+      'Refusing to complete a build at zero cost: roll the standard cost for these parts first',
+      { partIds: plan.missingStandardPartIds }
+    )
+  }
+}
+
+/**
+ * The absorbed amount for one rate over the whole run, in whole minor units.
+ *
+ * An explicit input from the completion form wins. Otherwise it is the declared
+ * rate times the units STARTED — not the units produced.
+ *
+ * 🛑 The choice of `unitsStarted` is what makes the variance arithmetic close.
+ * With `s` units scrapped, material, labour and overhead are all absorbed on
+ * `produced + s` while `producedValue` values only `produced`, so the variance
+ * comes out at exactly `s x standardCost`: the scrapped units' whole standard
+ * cost, to 5090, which is what B7 asks for. Absorbing labour on the survivors
+ * instead would net the scrap loss down to material alone and understate it.
+ *
+ * An UNDECLARED rate absorbs `0` here, and that is not the same decision
+ * {@link absorbedRate} makes for the part standard. There, a NULL must survive
+ * into storage because it is the difference between "no rate declared" and "a
+ * declared rate of zero" on a number that gets rolled up and frozen forever.
+ * Here the field records what a specific run actually absorbed, and a run under
+ * no declared rate absorbed nothing — which is a fact, not an absence. It also
+ * keeps the arithmetic consistent: with no rate the part's standard carries no
+ * labour either, so both sides of the variance stay zero.
+ */
+function absorbed(explicit: number | undefined, rate: number | null, started: number): number {
+  if (explicit != null && Number.isFinite(explicit)) return roundMinorUnits(explicit)
+  if (rate == null || !Number.isFinite(rate)) return 0
+  return roundMinorUnits(rate * started)
+}
+
+/**
+ * The two quantity rules, checked before anything is read.
+ *
+ * A zero-unit completion is refused rather than treated as a no-op: it would
+ * write a full set of consume rows against a produce row of nothing, which is a
+ * scrap event wearing a build's clothes. Negative scrap is refused because it
+ * would silently REDUCE the material consumed below what the bill of materials
+ * calls for.
+ */
+function assertQuantities(quantityProduced: number, quantityScrapped: number): void {
+  if (!Number.isFinite(quantityProduced) || quantityProduced <= 0) {
+    throw new BadRequestError('A completed build must produce at least one unit')
+  }
+  if (!Number.isFinite(quantityScrapped) || quantityScrapped < 0) {
+    throw new BadRequestError('Scrapped units cannot be negative')
+  }
+}
+
+/**
+ * Push the completed build's own numbers to every open client.
+ *
+ * The quiet lane deliberately suppresses the per-write realtime frame for
+ * everything this function writes, which is right for 51 movement rows and
+ * wrong for the build row itself: without this the list and the detail page
+ * would keep rendering `planned` with empty costs until a reload. Fire and
+ * forget, after the commit, exactly as the standard-cost roll publishes.
+ */
+function publishBuildUpdate(
+  organizationId: string,
+  ctx: BuildFieldContext,
+  result: CompleteBuildResult,
+  completedAt: Date
+): void {
+  const entries: FieldValueUpdateEntry[] = []
+  const push = (field: { id: string } | null, value: unknown) => {
+    if (!field) return
+    entries.push({
+      key: buildFieldValueKey(result.recordId as RecordId, field.id as FieldId),
+      value,
+    })
+  }
+
+  push(ctx.fields.build_status, { type: 'option', optionId: BuildStatus.COMPLETED })
+  push(ctx.fields.build_quantity_produced, { type: 'number', value: result.quantityProduced })
+  push(ctx.fields.build_quantity_scrapped, { type: 'number', value: result.quantityScrapped })
+  push(ctx.fields.build_material_cost, { type: 'number', value: result.materialCost })
+  push(ctx.fields.build_labor_cost, { type: 'number', value: result.laborCost })
+  push(ctx.fields.build_overhead_cost, { type: 'number', value: result.overheadCost })
+  push(ctx.fields.build_produced_value, { type: 'number', value: result.producedValue })
+  push(ctx.fields.build_variance_amount, { type: 'number', value: result.varianceAmount })
+  push(ctx.fields.build_completed_at, { type: 'date', value: completedAt.toISOString() })
+
+  if (entries.length === 0) return
+  publishFieldValueUpdates(getRealtimeService(), organizationId, entries).catch(() => {})
+}

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -1,20 +1,47 @@
 // packages/lib/src/builds/index.ts
 
 /**
- * Builds — phase 1: standard cost.
+ * Builds — the standard cost (phase 1) and the build event (phase 2).
  *
- * plans/products/build/01-build-plan.md section 2. The `build` entity,
- * `completeBuild` and `reverseBuild` are phase 2 and land in this same folder.
+ * plans/products/build/01-build-plan.md sections 2 and 3.
+ *
+ * `completeBuild` is the ONLY export here that writes a stock movement, and it
+ * is gated on a real `part_standard_cost` (README B2). Everything else — the
+ * entity, the list, the plan, the auto-build trigger — can be used before the
+ * first standard has ever been rolled without producing a wrong number.
  */
 
+export { cancelBuild, createBuild, startBuild } from './build-mutations'
+export {
+  type BuildComponentPlanInput,
+  type BuildFieldContext,
+  type BuildMovementFieldContext,
+  explodeBuildComponents,
+  getBuild,
+  listBuilds,
+  listUnpostedBuilds,
+} from './build-queries'
 export {
   absorbedRate,
   absorbsConversionCost,
+  BUILD_STATUS_LABELS,
+  BUILD_VARIANCE_ACCOUNT,
+  type BuildStatusValue,
+  buildVariance,
+  canCancelBuild,
+  canCompleteBuild,
+  canReverseBuild,
+  canStartBuild,
+  componentConsumption,
   type PartKindValue,
+  resolveBuildStatus,
   resolvePartKind,
   roundMinorUnits,
   standardCostDrift,
+  unitsStarted,
 } from './client'
+export { completeBuild } from './complete-build'
+export { reverseBuild } from './reverse-build'
 export { rollStandardCost } from './standard-cost'
 export {
   loadAbsorptionRates,
@@ -32,7 +59,19 @@ export {
 } from './standard-cost-roll'
 export type {
   AbsorptionRates,
+  BuildComponentLine,
+  BuildComponentOverride,
+  BuildComponentPlan,
+  BuildMovementRow,
+  BuildRecord,
+  CancelBuildInput,
+  CompleteBuildInput,
+  CompleteBuildResult,
+  CreateBuildInput,
+  ListBuildsFilters,
   PartStandardCost,
+  ReverseBuildInput,
+  ReverseBuildResult,
   RollStandardCostInput,
   SkippedPart,
   SkipReason,
@@ -40,4 +79,6 @@ export type {
   StandardCostRollLine,
   StandardCostRollPlan,
   StandardCostRollResult,
+  StartBuildInput,
 } from './types'
+export { BUILD_WRITE_LANE_REASON, buildWriteSession } from './write-lane'

--- a/packages/lib/src/builds/reverse-build.ts
+++ b/packages/lib/src/builds/reverse-build.ts
@@ -1,0 +1,302 @@
+// packages/lib/src/builds/reverse-build.ts
+
+/**
+ * `reverseBuild` — the inverse of {@link completeBuild}.
+ *
+ * plans/products/build/01-build-plan.md section 3.4, README B6.
+ *
+ * 🛑 **A completed build is never edited or deleted. It is reversed** by a
+ * second build whose movements are the originals' with the sign flipped,
+ * carrying the **ORIGINAL's** frozen costs and not today's. A period that has
+ * been posted must never change shape, and every field on `stock_movement` is
+ * `updatable: false` precisely so that a cost frozen years ago can still be
+ * trusted.
+ *
+ * ## Why this does not reuse `receiving/reverse-movement.ts`
+ *
+ * That function exists, it is good, and it is the wrong shape here — four ways,
+ * each of which would be a silent defect rather than a compile error:
+ *
+ * 1. **It re-types the row.** Its `REVERSAL_TYPE_BY_ORIGINAL` map deliberately
+ *    sends `build_consume` and `build_produce` to `adjust`, with the reasoning
+ *    written out in place: undoing a `build_consume` standalone is not a
+ *    production run, and labelling it `build_produce` would put a manufacturing
+ *    event in the ledger that never happened. That reasoning is right for one
+ *    movement corrected on its own and wrong for B6, where the negation belongs
+ *    to a reversing BUILD and the pair must be recognisable as one.
+ * 2. **It cannot set `stock_movement_build`.** The reversing rows would be
+ *    orphaned from the reversing build, `build_movements` would be empty, and
+ *    a second reversal would have nothing to read back.
+ * 3. **It does not copy `qty_per_unit`**, so the as-built BOM snapshot — the
+ *    whole point of that column — is lost on the negation.
+ * 4. **It is one movement, on the inline lane, outside any transaction.** A
+ *    51-row build would become 51 independently-refusable operations and 51 full
+ *    quantity-on-hand re-SUMs, and a failure half way through would leave a
+ *    ledger that is neither the build nor its reversal.
+ *
+ * What IS reused is its two refusals, verbatim in spirit — a build is reversed
+ * at most once, and a reversal is never itself reversed — plus
+ * `computeExtendedCost`, so a reversal is identical in magnitude to the run it
+ * undoes. Every reversing movement also points its
+ * `stock_movement_reverses_movement` at the row it negates, which is what makes
+ * `reverseMovement`'s own already-reversed guard refuse to correct a movement
+ * that this function has already undone.
+ *
+ * No permission checks. The router asserts (`docs/lib-module-guide.md`
+ * section 6).
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { Result } from 'neverthrow'
+import { BadRequestError, ConflictError, UnprocessableEntityError } from '../errors'
+import { computeExtendedCost } from '../receiving/client'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import { BuildStatus, StockMovementCostBasis } from '../resources/registry/enum-values'
+import { toRecordId } from '../resources/resource-id'
+import { requireDefId } from './build-mutations'
+import {
+  assertBuildStatus,
+  type BuildFieldContext,
+  type BuildMovementFieldContext,
+  hasBuildReversal,
+  lockBuild,
+  readBuildMovements,
+  requireBuildFieldContext,
+  requireBuildMovementFieldContext,
+} from './build-queries'
+import { canReverseBuild } from './client'
+import { recalculateAfterCommit } from './complete-build'
+import { guard } from './guard'
+import type { BuildRecord, ReverseBuildInput, ReverseBuildResult } from './types'
+import { buildWriteSession } from './write-lane'
+
+const logger = createScopedLogger('builds:reverse')
+
+/**
+ * Undo a completed build by writing its negation.
+ *
+ * The order of the steps is the contract:
+ *
+ * 1. Re-read the original `FOR UPDATE`; refuse unless it is `completed`. A
+ *    `planned` build has written nothing (B2) — cancel it instead.
+ * 2. Refuse a build that is ALREADY reversed (`ConflictError`). A second
+ *    reversal would double the negation, and because every roll-up downstream
+ *    re-SUMs rather than increments, the wrong number would look exactly as
+ *    authoritative as the right one.
+ * 3. Refuse to reverse a reversal (`BadRequestError`). The correction of an
+ *    over-correction is a fresh build, not a chain of undos — a chain makes "is
+ *    this build live?" a graph walk instead of a lookup.
+ * 4. Write ONE new build plus one negated movement per original movement, in a
+ *    single transaction, carrying the originals' frozen costs verbatim.
+ *
+ * Then, after the commit, one batched quantity-on-hand recalculation — the same
+ * rule, and the same reason, as `completeBuild`.
+ */
+export async function reverseBuild(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: ReverseBuildInput
+): Promise<Result<ReverseBuildResult, Error>> {
+  return guard(
+    async () => {
+      const [ctx, movementCtx] = await Promise.all([
+        requireBuildFieldContext(organizationId),
+        requireBuildMovementFieldContext(organizationId),
+      ])
+
+      if (!ctx.fields.build_reversal_of) {
+        // Without it there is no way to record WHAT this build undoes, and
+        // therefore no way to refuse the second reversal in step 2.
+        throw new UnprocessableEntityError(
+          'Reversing a build is not available until the build reversal fields are provisioned'
+        )
+      }
+
+      const occurredAt = input.occurredAt ?? new Date()
+      const result = await db.transaction(async (tx) =>
+        writeReversal(tx, organizationId, userId, { ctx, movementCtx, input, occurredAt })
+      )
+
+      await recalculateAfterCommit(organizationId, result.recalculatedPartIds)
+
+      logger.info('Reversed build', {
+        organizationId,
+        reversalOfBuildId: result.reversalOfBuildId,
+        buildId: result.buildId,
+        movements: result.movementIds.length,
+      })
+
+      return result
+    },
+    'Failed to reverse build',
+    { organizationId, buildId: input.buildId }
+  )
+}
+
+interface WriteReversalArgs {
+  ctx: BuildFieldContext
+  movementCtx: BuildMovementFieldContext
+  input: ReverseBuildInput
+  occurredAt: Date
+}
+
+async function writeReversal(
+  tx: Transaction,
+  organizationId: string,
+  userId: string,
+  args: WriteReversalArgs
+): Promise<ReverseBuildResult> {
+  const { ctx, movementCtx, input, occurredAt } = args
+  const txDb = tx as unknown as Database
+
+  // Step 1.
+  const original = await lockBuild(tx, organizationId, ctx, input.buildId)
+  assertBuildStatus(
+    original,
+    canReverseBuild,
+    'Only a completed build can be reversed. Cancel a planned or in-progress run instead.'
+  )
+
+  // Step 2.
+  if (await hasBuildReversal(txDb, organizationId, ctx, original.buildId)) {
+    throw new ConflictError(
+      'This build has already been reversed. Reversing it again would double the negation.'
+    )
+  }
+
+  // Step 3.
+  if (original.reversalOfBuildId) {
+    throw new BadRequestError(
+      'This build is itself a reversal and cannot be reversed. Raise a fresh build instead.'
+    )
+  }
+
+  const movements = await readBuildMovements(txDb, organizationId, movementCtx, original.buildId)
+  if (movements.length === 0) {
+    throw new UnprocessableEntityError(
+      'This build wrote no stock movements, so there is nothing to reverse'
+    )
+  }
+
+  // Step 4.
+  const crud = new UnifiedCrudHandler(organizationId, userId, txDb, undefined, {
+    // The same quiet lane the completion takes, for the same reasons — see
+    // `write-lane.ts` and `complete-build.ts`'s header.
+    session: buildWriteSession(),
+  })
+
+  // Resolved only when the original names one, so an org with no orders is
+  // never asked for an `order` def it does not have.
+  const orderDefId = original.orderId ? await requireDefId(organizationId, 'order') : null
+
+  const reversalBuild = await crud.create(
+    ctx.buildDefId,
+    reversalBuildValues(ctx, movementCtx, original, input, occurredAt, orderDefId)
+  )
+  const reversalRecordId = toRecordId(ctx.buildDefId, reversalBuild.instance.id)
+
+  const movementIds: string[] = []
+  for (const movement of movements) {
+    const quantity = -movement.quantity
+    const values: Record<string, unknown> = {
+      stock_movement_part: toRecordId(movementCtx.partDefId, movement.partId),
+      // 🛑 The TYPE is carried verbatim. A negated `build_consume` is still the
+      // consume leg of a build; re-labelling it would break the pairing that
+      // makes `SUM` over `build_consume` mean "material issued to production".
+      stock_movement_type: movement.type,
+      stock_movement_quantity: quantity,
+      // The build does its own explosion on the way out and on the way back.
+      stock_movement_adjust_subparts: false,
+      stock_movement_build: reversalRecordId,
+      // 🛑 The ORIGINAL's frozen cost, never today's. A reversal valued at the
+      // current standard nets a build and its undo to a non-zero amount of
+      // inventory value out of nothing.
+      stock_movement_unit_cost: movement.unitCost,
+      stock_movement_extended_cost:
+        movement.extendedCost != null
+          ? -movement.extendedCost
+          : computeExtendedCost(movement.unitCost, quantity),
+      // Points at the row it negates, so `reverseMovement`'s already-reversed
+      // guard refuses to correct a movement this build has already undone.
+      stock_movement_reverses_movement: toRecordId(movementCtx.movementDefId, movement.movementId),
+      stock_movement_occurred_at: occurredAt.toISOString(),
+    }
+    // The basis follows the cost: a row carrying the original's frozen
+    // `standard` cost is still a `standard`, and re-deciding it here would let a
+    // reversal disagree with the movement it is a copy of.
+    values.stock_movement_cost_basis = movement.costBasis ?? StockMovementCostBasis.STANDARD
+    if (movement.glAccount) values.stock_movement_gl_account = movement.glAccount
+    // Copied, not recomputed. The as-built snapshot describes the run that
+    // happened, and the reversal describes the same run.
+    if (movement.qtyPerUnit != null) values.stock_movement_qty_per_unit = movement.qtyPerUnit
+    if (input.reason) values.stock_movement_reason = input.reason
+
+    const created = await crud.create(movementCtx.movementDefId, values)
+    movementIds.push(created.instance.id)
+  }
+
+  return {
+    buildId: reversalBuild.instance.id,
+    recordId: reversalRecordId,
+    reversalOfBuildId: original.buildId,
+    movementIds,
+    recalculatedPartIds: [...new Set(movements.map((movement) => movement.partId))],
+  }
+}
+
+/**
+ * The reversing build's own row.
+ *
+ * Every quantity and every cost is the original's, negated. It lands
+ * `completed` because it IS complete the moment it is written — there is no
+ * planned reversal — and its `completedAt` is the reversal's accounting date,
+ * not the original's, so the correction falls in the period it was made rather
+ * than reopening the period being corrected.
+ *
+ * Negating the quantities as well as the costs is what makes any report that
+ * sums build output over a range net to zero across the pair. A reversal with a
+ * positive `quantityProduced` would double-count production while its movements
+ * cancelled out — two answers to "how many did we build", both from our own
+ * data.
+ */
+function reversalBuildValues(
+  ctx: BuildFieldContext,
+  movementCtx: BuildMovementFieldContext,
+  original: BuildRecord,
+  input: ReverseBuildInput,
+  occurredAt: Date,
+  orderDefId: string | null
+): Record<string, unknown> {
+  const values: Record<string, unknown> = {
+    build_status: BuildStatus.COMPLETED,
+    build_reversal_of: toRecordId(ctx.buildDefId, original.buildId),
+  }
+  if (original.partId) {
+    values.build_part = toRecordId(movementCtx.partDefId, original.partId)
+  }
+  const negate = (value: number | null): number | undefined => (value == null ? undefined : -value)
+
+  assign(values, 'build_quantity_produced', negate(original.quantityProduced))
+  assign(values, 'build_quantity_scrapped', negate(original.quantityScrapped))
+  assign(values, 'build_material_cost', negate(original.materialCost))
+  assign(values, 'build_labor_cost', negate(original.laborCost))
+  assign(values, 'build_overhead_cost', negate(original.overheadCost))
+  assign(values, 'build_produced_value', negate(original.producedValue))
+  assign(values, 'build_variance_amount', negate(original.varianceAmount))
+
+  if (ctx.fields.build_completed_at) values.build_completed_at = occurredAt.toISOString()
+  // Carried, so "the builds this order caused" finds the correction alongside
+  // the run it corrects rather than only the run (products/12 AB7).
+  if (orderDefId && original.orderId && ctx.fields.build_order) {
+    values.build_order = toRecordId(orderDefId, original.orderId)
+  }
+  if (original.source) values.build_source = original.source
+  if (input.reason && ctx.fields.build_notes) values.build_notes = input.reason
+  return values
+}
+
+function assign(values: Record<string, unknown>, key: string, value: number | undefined): void {
+  if (value !== undefined) values[key] = value
+}

--- a/packages/lib/src/builds/types.ts
+++ b/packages/lib/src/builds/types.ts
@@ -6,7 +6,7 @@
  * plans/products/build/01-build-plan.md sections 2.2 and 2.2a.
  */
 
-import type { PartKindValue } from './client'
+import type { BuildStatusValue, PartKindValue } from './client'
 
 /**
  * The two `manufacturing.*` org settings, per assembled unit, in minor units.
@@ -139,4 +139,242 @@ export interface RollStandardCostInput {
   partIds?: string[]
   /** When the new standards take effect. */
   effectiveAt: Date
+}
+
+// ─── The build event (phase 2) ─────────────────────────────────────────
+//
+// plans/products/build/01-build-plan.md section 3. Every money value below is
+// an INTEGER in whole minor units (cents), the platform `FieldType.CURRENCY`
+// convention.
+
+/**
+ * One `build` row as the read path returns it.
+ *
+ * Deliberately flat and fully resolved: a caller rendering a list must never
+ * have to issue a second read per row to learn what a build cost.
+ */
+export interface BuildRecord {
+  /** `EntityInstance.id` of the `build`. */
+  buildId: string
+  /** `<entityDefinitionId>:<instanceId>`, ready for a drawer or a picker. */
+  recordId: string
+  /** `B-0001`. `null` until a numbering hook exists — see the module README note. */
+  number: string | null
+  /** `EntityInstance.id` of the `part` this run produces. */
+  partId: string | null
+  /** `null` on a row whose status value is missing — see {@link resolveBuildStatus}. */
+  status: BuildStatusValue | null
+  quantityPlanned: number | null
+  /** Good units that entered stock. Negative on a reversing build. */
+  quantityProduced: number | null
+  /** Units started and lost (B7). Negative on a reversing build. */
+  quantityScrapped: number | null
+  startedAt: Date | null
+  /** THE accounting date. Every movement this build wrote carries it. */
+  completedAt: Date | null
+  materialCost: number | null
+  laborCost: number | null
+  overheadCost: number | null
+  producedValue: number | null
+  varianceAmount: number | null
+  /**
+   * Denormalized convenience only (section 1.1) — the GL posting ledger is the
+   * authority once it exists, and nothing gates a write on this.
+   */
+  postedAt: Date | null
+  notes: string | null
+  orderId: string | null
+  /** `manual` or `order`. `null` on a row written before the field existed. */
+  source: string | null
+  /** Set on a REVERSING build: the build it undoes (B6). */
+  reversalOfBuildId: string | null
+  createdAt: Date
+}
+
+/** Raise a run. Always lands `planned`, and writes no movements (B2). */
+export interface CreateBuildInput {
+  /** `EntityInstance.id` of the `part` to produce. */
+  partId: string
+  /** Units this run intends to produce. Must be greater than zero. */
+  quantityPlanned: number
+  notes?: string
+  /** `EntityInstance.id` of the `order` that caused this run, if any. */
+  orderId?: string
+  /**
+   * `manual` (a person raised it) or `order` (the auto-build trigger did).
+   * Defaults to `manual` — an auto-build must be distinguishable from one a
+   * person raised against the same order deliberately (products/12 AB7).
+   */
+  source?: 'manual' | 'order'
+}
+
+/** Move a `planned` run to `in_progress`. */
+export interface StartBuildInput {
+  buildId: string
+  /** Defaults to now. */
+  startedAt?: Date
+}
+
+/** Abandon a run that has not been completed. Writes no movements. */
+export interface CancelBuildInput {
+  buildId: string
+  /** Free text, appended to the build's notes. */
+  reason?: string
+}
+
+/**
+ * A per-component quantity the floor actually used, overriding the BOM.
+ *
+ * A part that IS on the bill of materials keeps its `qtyPerUnit` snapshot — the
+ * BOM was followed, just not to the letter. A part that is NOT on it is an
+ * off-BOM substitution and its movement carries `qtyPerUnit: null`, which is
+ * the marker `stock_movement_qty_per_unit` exists to make visible instead of
+ * silent.
+ */
+export interface BuildComponentOverride {
+  /** `EntityInstance.id` of the `part` consumed. */
+  partId: string
+  /** Units consumed by the WHOLE run, not per produced unit. Zero drops the line. */
+  quantityConsumed: number
+}
+
+/** Finish a run and write the ledger. The only input that produces movements. */
+export interface CompleteBuildInput {
+  buildId: string
+  /** Good units that entered stock. Must be greater than zero. */
+  quantityProduced: number
+  /** Units started and lost (B7). Defaults to zero; never negative. */
+  quantityScrapped?: number
+  /**
+   * Absorbed direct labour for the WHOLE run, minor units.
+   *
+   * Omitted, it is `round(manufacturing.assemblyLaborCostPerUnit x unitsStarted)`
+   * — the units STARTED, because labour was spent on the scrapped ones too, and
+   * because that is what makes the variance come out at exactly the scrapped
+   * units' standard cost. An undeclared rate absorbs zero.
+   */
+  laborCost?: number
+  /** Applied overhead for the whole run, minor units. Same defaulting rule. */
+  overheadCost?: number
+  /** What the floor actually consumed, where it differs from the BOM. */
+  componentOverrides?: BuildComponentOverride[]
+  /** THE accounting date stamped on the build and every movement. Defaults to now. */
+  completedAt?: Date
+  /** Free text, appended to the build's notes. */
+  notes?: string
+}
+
+/** One component line, as {@link explodeBuildComponents} previews it. */
+export interface BuildComponentLine {
+  partId: string
+  /** `EntityInstance.displayName`, so a form can name the part to go fix. */
+  partName: string | null
+  /**
+   * The per-unit quantity in force at build time — the as-built BOM snapshot.
+   * `null` means the component is OFF-BOM: a floor substitution.
+   */
+  qtyPerUnit: number | null
+  /** Units consumed by the whole run. */
+  quantityConsumed: number
+  /** The component's frozen `part_standard_cost`. `null` = never rolled. */
+  unitCost: number | null
+  /** `round(unitCost x quantityConsumed)`, POSITIVE. The movement stores its negation. */
+  extendedCost: number | null
+  /** Resolved from the component's `part_kind`, exactly as a receipt resolves it. */
+  glAccount: string
+  /** True when this line came from an override for a part with no BOM edge. */
+  offBom: boolean
+}
+
+/** What a completion WOULD consume, and what it cannot value. */
+export interface BuildComponentPlan {
+  /** The part being produced. */
+  partId: string
+  quantityProduced: number
+  quantityScrapped: number
+  /** `quantityProduced + quantityScrapped` — what consumes material (B7). */
+  unitsStarted: number
+  /**
+   * The produced part's frozen `part_standard_cost`, the value the
+   * `build_produce` row stamps. `null` when the part has never been rolled — in
+   * which case its id is also in {@link missingStandardPartIds}.
+   */
+  producedUnitCost: number | null
+  components: BuildComponentLine[]
+  /**
+   * Components with no `part_standard_cost`, and the produced part when IT has
+   * none. **A completion with any entry here is refused** — never posted at
+   * zero.
+   */
+  missingStandardPartIds: string[]
+}
+
+/** What a completion DID. Enough to render the result without a second read. */
+export interface CompleteBuildResult {
+  buildId: string
+  recordId: string
+  quantityProduced: number
+  quantityScrapped: number
+  /** Sum of the consumed lines' extended standard cost, positive. */
+  materialCost: number
+  laborCost: number
+  overheadCost: number
+  /** `round(quantityProduced x the produced part's standard cost)`. */
+  producedValue: number
+  /** `(material + labour + overhead) - producedValue` -> account 5090. */
+  varianceAmount: number
+  /** Every `stock_movement` written, consumes first then the single produce. */
+  movementIds: string[]
+  /** The parts whose quantity on hand was recalculated AFTER the commit. */
+  recalculatedPartIds: string[]
+}
+
+/** Undo a completed build by writing its negation (B6). */
+export interface ReverseBuildInput {
+  buildId: string
+  /** Free text stamped on the reversing build only. The original is never touched. */
+  reason?: string
+  /** The reversal's accounting date. Defaults to now. */
+  occurredAt?: Date
+}
+
+/** What a reversal DID. */
+export interface ReverseBuildResult {
+  /** The NEW build. */
+  buildId: string
+  recordId: string
+  /** The build it undoes. */
+  reversalOfBuildId: string
+  movementIds: string[]
+  recalculatedPartIds: string[]
+}
+
+/** Narrowing options for the build read path. */
+export interface ListBuildsFilters {
+  status?: BuildStatusValue
+  /** Only runs producing this `part` instance. */
+  partId?: string
+  /** Only runs raised against this `order` instance. */
+  orderId?: string
+  source?: 'manual' | 'order'
+  /** Defaults to 50. */
+  limit?: number
+  offset?: number
+}
+
+/** One `stock_movement` a build wrote, as the reversal reads it back. */
+export interface BuildMovementRow {
+  movementId: string
+  partId: string
+  /** `build_consume` or `build_produce`. Carried verbatim onto the negation. */
+  type: string
+  quantity: number
+  /** The ORIGINAL's frozen unit cost. Never re-priced (B6). */
+  unitCost: number
+  extendedCost: number | null
+  glAccount: string | null
+  /** The as-built snapshot; `null` on an off-BOM row and on the produce row. */
+  qtyPerUnit: number | null
+  /** `standard` on every row a build writes. Copied, never re-decided. */
+  costBasis: string | null
 }

--- a/packages/lib/src/builds/write-lane.ts
+++ b/packages/lib/src/builds/write-lane.ts
@@ -1,0 +1,68 @@
+// packages/lib/src/builds/write-lane.ts
+
+/**
+ * The ONE place that decides which write lane a build's ledger writes take.
+ *
+ * plans/products/build/01-build-plan.md section 3.5 trap 2.
+ *
+ * ## The choice
+ *
+ * `quietSession` — plan 04 section 3's C4/C5 mode: doors stay shut on purpose,
+ * and the reason is typed, greppable and checkable rather than a comment nobody
+ * can enforce. Its default origin is `automation`, so `sessionLane` resolves to
+ * `'silent'` (no bus event, no realtime frame, no dedup enqueue) and the session
+ * carries no `collector`, so neither dispatch door opens.
+ *
+ * ## Why not the three alternatives
+ *
+ * - **`skipEvents: true`** (what the plan originally said) is not merely
+ *   `@deprecated`, it is **insufficient**. There are two doors onto
+ *   `explodeBomMovement` and it closes only one. Door A is the per-write
+ *   fan-out, gated by `derivePublishEvents`. Door B is the sync manifest:
+ *   `createEntity` calls `syncCollectorOf(ctx.session)` and `recordCreated(...)`
+ *   in a block gated on **neither** `publishEvents`, `txScope`, nor
+ *   `skipEvents`. A `sync`-origin session with `skipEvents: true` is still
+ *   captured, and the manifest consumer dispatches the native rules from it.
+ * - **`seedSession`** reaches the same silent lane, but its reason string would
+ *   be a lie: a build completion is production automation, not a seeder or a
+ *   data migration. The door matrix justifies the seed column with "seeded data
+ *   is shaped by the seeder, not by rules", which is not why a build is silent.
+ * - **`absorbedSession`** requires a named aggregator that actually announces
+ *   the movements on their behalf, and there is none — claiming one that does
+ *   not exist is the B-16 defect `silent-write-conformance.test.ts` exists to
+ *   catch.
+ *
+ * ## 🛑 What this lane makes load-bearing
+ *
+ * Silencing the rule silences BOTH halves of `mfg-stock-movements-created`, and
+ * the second half is `recalculatePartQoH`, which fires regardless of the
+ * `adjustSubparts` flag. So the single post-commit `batchRecalculateQoH` is not
+ * an optimisation — it is the **only** thing that recalculates quantity on hand
+ * for a build's movements, and it must cover the produced part and every
+ * consumed part.
+ *
+ * ⚠️ `adjustSubparts: false` stays on every row regardless of the lane.
+ * `explodeBomMovement` guards on that flag as its third statement, before any
+ * query, and the create-time values are threaded rather than refetched, so a
+ * `false` reaches that guard on every lane. It is the belt that keeps this safe
+ * if the lane is ever changed.
+ */
+
+import { quietSession, type WriteSession } from '../resources/crud/write-origin'
+
+/** The prose recorded on every silent build write. Greppable, and the audit trail. */
+export const BUILD_WRITE_LANE_REASON =
+  'build completion posts its own consume/produce ledger and recalculates QoH after commit'
+
+/**
+ * The session every movement-writing build path constructs its
+ * `UnifiedCrudHandler` with.
+ *
+ * 🛑 Do NOT pass `skipEvents: true` alongside it. The deprecated alias still
+ * wins over the session-derived lane, which would move the decision back to the
+ * call site — the state this file exists to end — while closing only one of the
+ * two doors.
+ */
+export function buildWriteSession(): WriteSession {
+  return quietSession(BUILD_WRITE_LANE_REASON)
+}

--- a/packages/lib/src/resources/crud/__tests__/build-movement-explosion-lanes.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/build-movement-explosion-lanes.test.ts
@@ -1,0 +1,398 @@
+// packages/lib/src/resources/crud/__tests__/build-movement-explosion-lanes.test.ts
+//
+// plans/products/build/01-build-plan.md §3.5 trap 2, settled with a real test.
+//
+// The question: `completeBuild` writes ~51 `stock_movement` rows in one
+// transaction, every one carrying `adjustSubparts: false`, and must not
+// re-explode its own BOM. Suppression has TWO independent seams and the plan
+// treats them as one:
+//
+//   1. the per-write fan-out (`derivePublishEvents`) — the bus event that
+//      reaches `handleRecordRules` → `fireRecordRulesBatch` → the native
+//      `explodeBomMovement` handler;
+//   2. the sync-manifest collector (`syncCollectorOf`) — fed at the mutation
+//      seam INDEPENDENTLY of `publishEvents`, whose consumer
+//      (`handleSyncRecordRules`) dispatches the very same native rule.
+//
+// These tests pin both, per candidate lane, and pin the trigger's own
+// `adjustSubparts` guard so the flag's contribution can be told apart from the
+// lane's.
+//
+// @auxx/database is globally mocked in src/test/setup.ts; the mutation-seam
+// mocks mirror `sync-lifecycle-capture.test.ts` (spread-preserving where the
+// module has more exports).
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  // ── createEntity seam ──
+  deleteOpenPairsForRecord: vi.fn(async () => ok(0)),
+  enqueueDuplicateScan: vi.fn(async () => 'job_1'),
+  publish: vi.fn(async () => {}),
+  publishLater: vi.fn(() => {}),
+  deleteCommentsByRecordId: vi.fn(async () => {}),
+  // ── sync-manifest consumer seam ──
+  getRunManifest: vi.fn(async () => null as unknown),
+  claimRunManifestConsumed: vi.fn(async () => true),
+  getImportManifest: vi.fn(async () => null as unknown),
+  claimImportManifestConsumed: vi.fn(async () => true),
+  getCachedRecordRules: vi.fn(async () => [] as unknown[]),
+  fetchResourceSnapshots: vi.fn(async () => new Map()),
+  runSyncFinalize: vi.fn(async () => {}),
+  insertRecordRuleRuns: vi.fn(async () => {}),
+  insertRecordRuleRun: vi.fn(async () => {}),
+  // ── native rule handlers ──
+  explodeBomMovement: vi.fn(async (_event: unknown) => {}),
+  recalculatePartQoH: vi.fn(async () => {}),
+  recalculatePurchaseOrderLineReceived: vi.fn(async () => {}),
+  recalculatePurchaseOrderLineBilled: vi.fn(async () => {}),
+  loadSubpartGraph: vi.fn(async () => new Map()),
+}))
+
+vi.mock('../../../dedup/pairs', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteOpenPairsForRecord: h.deleteOpenPairsForRecord,
+}))
+vi.mock('../../../dedup/enqueue-scan', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  enqueueDuplicateScan: h.enqueueDuplicateScan,
+}))
+vi.mock('../../../entity-instances', () => ({
+  getEntityInstance: vi.fn(async () => ok({ id: 'sm_1', archivedAt: null })),
+  updateEntityInstance: vi.fn(async () => ok({ id: 'sm_1' })),
+  createEntityInstance: vi.fn(async () => ok({ id: 'sm_1' })),
+  deleteEntityInstance: vi.fn(async () => ok({ id: 'sm_1' })),
+}))
+vi.mock('../../../realtime', () => ({
+  getRealtimeService: () => ({ publish: h.publish }),
+  publishRecordsChanged: vi.fn(async () => {}),
+  rooms: { orgRecords: () => 'room' },
+}))
+vi.mock('../../../events/publisher', () => ({
+  publisher: { publishLater: h.publishLater, publish: h.publishLater },
+}))
+vi.mock('../../../comments', () => ({
+  CommentService: class {
+    deleteCommentsByRecordId = h.deleteCommentsByRecordId
+  },
+}))
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  findCachedResource: vi.fn(async () => undefined),
+  getCachedRecordRules: h.getCachedRecordRules,
+  getCachedResourceFields: vi.fn(async () => []),
+}))
+vi.mock('../../../data-connectors/service', () => ({
+  getRunManifest: h.getRunManifest,
+  claimRunManifestConsumed: h.claimRunManifestConsumed,
+}))
+vi.mock('../../../import', () => ({
+  getImportManifest: h.getImportManifest,
+  claimImportManifestConsumed: h.claimImportManifestConsumed,
+}))
+vi.mock('../../../events/handlers/sync-finalize', () => ({
+  runSyncFinalize: h.runSyncFinalize,
+}))
+vi.mock('../../../record-rules/store', () => ({
+  insertRecordRuleRun: h.insertRecordRuleRun,
+  insertRecordRuleRuns: h.insertRecordRuleRuns,
+}))
+vi.mock('../../../record-rules/snapshot-fetcher', () => ({
+  fetchResourceSnapshots: h.fetchResourceSnapshots,
+}))
+vi.mock('../../../field-hooks/post/bom-movement-triggers', () => ({
+  explodeBomMovement: h.explodeBomMovement,
+}))
+vi.mock('../../../field-hooks/post/inventory-triggers', () => ({
+  recalculatePartQoH: h.recalculatePartQoH,
+}))
+vi.mock('../../../field-hooks/post/purchase-order-line-rollups', () => ({
+  recalculatePurchaseOrderLineReceived: h.recalculatePurchaseOrderLineReceived,
+  recalculatePurchaseOrderLineBilled: h.recalculatePurchaseOrderLineBilled,
+}))
+vi.mock('../../../bom/subpart-graph', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  loadSubpartGraph: h.loadSubpartGraph,
+}))
+
+import { database } from '@auxx/database'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
+import { handleSyncRecordRules } from '../../../events/handlers/handle-sync-record-rules'
+import { registerEntitySystemRules } from '../../../field-hooks/system-entity-rules'
+import type { EntityTriggerEvent } from '../../../field-hooks/types'
+import { getSyncRuleSubscriptions } from '../../../record-rules/subscriptions'
+import {
+  createManifestCollector,
+  type ManifestCollector,
+} from '../../../record-rules/sync-manifest-collector'
+import type { SyncChangeManifest } from '../../../record-rules/sync-manifest-types'
+import { getSystemRuleDeclarations, resolveSystemRules } from '../../../record-rules/system-rules'
+import type { CachedRecordRule } from '../../../record-rules/types'
+import { createEntity, type MutationContext } from '../unified-handler-mutations'
+import { interactiveSession, quietSession, seedSession, type WriteSession } from '../write-origin'
+
+const ORG = 'org_1'
+const MOVEMENT_DEF = 'def_stock_movement'
+const PART_DEF = 'def_part'
+const MOVEMENT_RID = toRecordId(MOVEMENT_DEF, 'sm_1')
+
+/**
+ * One `build_consume` row exactly as §3.4 step 4 specifies it: the explosion
+ * flag is OFF, because the build does its own explosion.
+ */
+const BUILD_CONSUME_VALUES: Record<string, unknown> = {
+  stock_movement_part: toRecordId(PART_DEF, 'part_1'),
+  stock_movement_type: 'build_consume',
+  stock_movement_quantity: -4,
+  stock_movement_adjust_subparts: false,
+}
+
+/** Minimal CustomField-shaped rows for the create path's field plumbing. */
+const MOVEMENT_FIELDS = [
+  'stock_movement_part',
+  'stock_movement_type',
+  'stock_movement_quantity',
+  'stock_movement_adjust_subparts',
+].map((systemAttribute) => ({
+  id: `fld_${systemAttribute}`,
+  name: systemAttribute,
+  systemAttribute,
+  required: false,
+  isCreatable: true,
+}))
+
+/**
+ * The REAL `stock-movements` system rules, resolved for an org that has the def.
+ * Every other declaration drops out because its def slug is unknown here — so
+ * what these tests dispatch is the shipped `mfg-stock-movements-created`
+ * declaration, native actions and action order included, not a fixture of it.
+ */
+function stockMovementSystemRules(): CachedRecordRule[] {
+  registerEntitySystemRules()
+  return resolveSystemRules(ORG, getSystemRuleDeclarations(), {
+    defIdBySlug: (slug) => (slug === 'stock-movements' ? MOVEMENT_DEF : undefined),
+    fieldIdBySystemAttribute: () => undefined,
+  })
+}
+
+/** A sync session whose collector is built from the real rule subscriptions. */
+function syncSession(collector: ManifestCollector): WriteSession {
+  return { origin: { kind: 'sync', source: 'retro', ref: 'build_1', collector }, depth: 0 }
+}
+
+function collectorForStockMovements(): ManifestCollector {
+  return createManifestCollector(getSyncRuleSubscriptions(stockMovementSystemRules()))
+}
+
+function ctx(session: WriteSession): MutationContext {
+  return {
+    db: {} as never,
+    organizationId: ORG,
+    userId: 'user_1',
+    session,
+    fieldValueService: {} as never,
+    resolveEntityDefinition: async () => ({
+      id: MOVEMENT_DEF,
+      entityType: 'stock_movement',
+      apiSlug: 'stock-movements',
+    }),
+    getFields: async () => MOVEMENT_FIELDS as never,
+    runPreHooks: async (_o, _d, values) => values,
+    validateUniqueFields: async () => {},
+    setFieldValues: async () => {},
+  }
+}
+
+function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
+  return {
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched: {},
+    deltas: {},
+    createdRecordIds: [],
+    archivedRecordIds: [],
+    ...over,
+  } as SyncChangeManifest
+}
+
+function connectorEvent() {
+  return {
+    data: {
+      type: 'sync:records:changed',
+      data: { source: 'connector', organizationId: ORG, ref: 'run_1' },
+    },
+  } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.claimRunManifestConsumed.mockResolvedValue(true)
+  h.getCachedRecordRules.mockResolvedValue([])
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Seam 1: which lanes feed the sync-manifest collector
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('trap 2 seam 1 — does the write reach the sync-manifest collector?', () => {
+  it('interactive lane: no collector exists, but the per-write door DOES fire', async () => {
+    await createEntity(ctx(interactiveSession('user_1')), MOVEMENT_DEF, {
+      ...BUILD_CONSUME_VALUES,
+    })
+
+    // The inline door is the OTHER route to explodeBomMovement — the bus event
+    // this publishes is what `handleRecordRules` consumes.
+    expect(h.publishLater).toHaveBeenCalled()
+  })
+
+  it('sync lane: the create IS captured, with adjustSubparts:false in createdValues', async () => {
+    const collector = collectorForStockMovements()
+
+    await createEntity(ctx(syncSession(collector)), MOVEMENT_DEF, { ...BUILD_CONSUME_VALUES })
+
+    const captured = collector.toJson()
+    expect(captured?.createdRecordIds).toEqual([MOVEMENT_RID])
+    expect(captured?.createdValues?.[MOVEMENT_RID]).toMatchObject({
+      stock_movement_adjust_subparts: false,
+      stock_movement_type: 'build_consume',
+    })
+    // The per-write door is shut — but capture is not a door.
+    expect(h.publishLater).not.toHaveBeenCalled()
+    expect(h.publish).not.toHaveBeenCalled()
+  })
+
+  it('sync lane + skipEvents:true STILL captures — the deprecated alias does not reach the collector', async () => {
+    const collector = collectorForStockMovements()
+
+    await createEntity(
+      ctx(syncSession(collector)),
+      MOVEMENT_DEF,
+      { ...BUILD_CONSUME_VALUES },
+      { skipEvents: true }
+    )
+
+    // This is the trap: `skipEvents` gates `derivePublishEvents` only. The
+    // collector feed at the mutation seam is unconditional for a sync origin.
+    expect(collector.toJson()?.createdRecordIds).toEqual([MOVEMENT_RID])
+    expect(h.publishLater).not.toHaveBeenCalled()
+  })
+
+  it('seed lane: no door and no collector — a seed origin carries none by construction', async () => {
+    const session = seedSession('build completion posts its own ledger')
+
+    await createEntity(ctx(session), MOVEMENT_DEF, { ...BUILD_CONSUME_VALUES })
+
+    expect(session.origin.kind).toBe('seed')
+    expect('collector' in session.origin).toBe(false)
+    expect(h.publishLater).not.toHaveBeenCalled()
+    expect(h.publish).not.toHaveBeenCalled()
+  })
+
+  it('quiet automation lane: no door and no collector either', async () => {
+    const session = quietSession('build completion posts its own ledger')
+
+    await createEntity(ctx(session), MOVEMENT_DEF, { ...BUILD_CONSUME_VALUES })
+
+    expect(session.origin.kind).toBe('automation')
+    expect('collector' in session.origin).toBe(false)
+    expect(h.publishLater).not.toHaveBeenCalled()
+    expect(h.publish).not.toHaveBeenCalled()
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Seam 2: what the manifest consumer does with a captured create
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('trap 2 seam 2 — a captured create re-dispatches the native BOM rule', () => {
+  it('dispatches explodeBomMovement, with the raw adjustSubparts:false values threaded', async () => {
+    h.getCachedRecordRules.mockResolvedValue(stockMovementSystemRules())
+    h.getRunManifest.mockResolvedValue(
+      manifest({
+        createdRecordIds: [MOVEMENT_RID],
+        createdValues: { [MOVEMENT_RID]: { ...BUILD_CONSUME_VALUES } } as Record<
+          RecordId,
+          Record<string, unknown>
+        >,
+      })
+    )
+
+    await handleSyncRecordRules(connectorEvent())
+
+    // Reachable. The manifest lane is a full second door onto the trigger —
+    // suppressing the bus event does not close it.
+    expect(h.explodeBomMovement).toHaveBeenCalledTimes(1)
+    const event = h.explodeBomMovement.mock.calls[0]![0] as EntityTriggerEvent
+    expect(event.action).toBe('created')
+    expect(event.entityInstanceId).toBe('sm_1')
+    expect(event.values.stock_movement_adjust_subparts).toBe(false)
+    // Same firing carries the QoH recalc — the other half of trap 1.
+    expect(h.recalculatePartQoH).toHaveBeenCalledTimes(1)
+  })
+
+  it('captures nothing, dispatches nothing: an empty manifest never reaches the trigger', async () => {
+    h.getCachedRecordRules.mockResolvedValue(stockMovementSystemRules())
+    h.getRunManifest.mockResolvedValue(manifest())
+
+    await handleSyncRecordRules(connectorEvent())
+
+    expect(h.explodeBomMovement).not.toHaveBeenCalled()
+    expect(h.recalculatePartQoH).not.toHaveBeenCalled()
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// The belt: the trigger's own guard, independent of any lane
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('trap 4 — explodeBomMovement guards on adjustSubparts itself', () => {
+  async function realExplode() {
+    const actual = await vi.importActual<
+      typeof import('../../../field-hooks/post/bom-movement-triggers')
+    >('../../../field-hooks/post/bom-movement-triggers')
+    return actual.explodeBomMovement
+  }
+
+  function triggerEvent(values: Record<string, unknown>): EntityTriggerEvent {
+    return {
+      action: 'created',
+      entitySlug: 'stock-movements',
+      entityType: '',
+      entityDefinitionId: MOVEMENT_DEF,
+      entityInstanceId: 'sm_1',
+      organizationId: ORG,
+      userId: 'user_1',
+      values,
+    }
+  }
+
+  it('returns before touching the subpart graph or the DB when the flag is false', async () => {
+    const explode = await realExplode()
+
+    await explode(triggerEvent({ ...BUILD_CONSUME_VALUES }))
+
+    expect(h.loadSubpartGraph).not.toHaveBeenCalled()
+    expect(database.insert).not.toHaveBeenCalled()
+  })
+
+  it('returns the same way when the flag is absent entirely', async () => {
+    const explode = await realExplode()
+    const { stock_movement_adjust_subparts: _omitted, ...withoutFlag } = BUILD_CONSUME_VALUES
+
+    await explode(triggerEvent(withoutFlag))
+
+    expect(h.loadSubpartGraph).not.toHaveBeenCalled()
+    expect(database.insert).not.toHaveBeenCalled()
+  })
+
+  it('proceeds past the guard when the flag IS true (the guard is not a no-op)', async () => {
+    const explode = await realExplode()
+    h.loadSubpartGraph.mockRejectedValueOnce(new Error('reached loadSubpartGraph'))
+
+    await expect(
+      explode(triggerEvent({ ...BUILD_CONSUME_VALUES, stock_movement_adjust_subparts: true }))
+    ).rejects.toThrow('reached loadSubpartGraph')
+  })
+})


### PR DESCRIPTION
Phase 2 of [`plans/products/build/01-build-plan.md`](plans/products/build/01-build-plan.md) §3 — **lib core only**. No UI, no tRPC router, and the `build` def stays `isVisible: false` until there is a way to create a row. No schema; migration 109 already landed it.

## The event that was missing

The lift is 2 × *400Lbs motor Assembly*. Assembling 10 should record:

```
−20  400Lbs motor Assembly   @ its cost at that moment
+10  Auxx Lift 400lbs 4x8    @ the sum of what went in
```

Auxx could not record that. All three existing doors are wrong, and the worst — `Adjust stock → Add 10` with `Adjust subparts` ON — moves **every component upward**, the exact opposite of assembling.

Parts already *have* costs. What they could never answer is *"what did the one I shipped in January cost"*, because the whole chain is a live mirror: a vendor price change rewrites `part_cost` and propagates to every ancestor. This writes the cost **down** — consumed rows carry each component's frozen `part_standard_cost`, the produce row carries the parent's, and nothing later restates them.

## 🛑 The plan's answer on the write lane was wrong

§3.5 trap 2 says to write with `skipEvents: true`, and calls the outcome *unverified*. It's now verified, and the prescription would not have worked.

**`skipEvents` is not merely deprecated — it is insufficient.** There are two doors onto `explodeBomMovement` and it closes one:

| door | path | gated by `skipEvents`? |
| --- | --- | --- |
| A — per-write fan-out | `derivePublishEvents` → bus event → `handle-record-rules` → native dispatch | yes |
| B — sync manifest | `createEntity`'s `syncCollectorOf` + `recordCreated` block → manifest consumer → same native dispatch | **no** |

Door B is gated on **neither** `publishEvents`, `txScope`, nor `skipEvents`. A `sync`-origin session with `skipEvents: true` is still captured, and the consumer threads the raw values through without refetching. `resources/crud/__tests__/build-movement-explosion-lanes.test.ts` (10 tests, included here) proves it against the real system rule, the real `fireRecordRulesBatch` and the real consumer.

**Every movement-writing path takes `quietSession(...)`, constructed in exactly one place** (`builds/write-lane.ts`), so changing the lane is a one-line change. Not `seedSession`: same silent lane, but the reason string would be a lie — a build completion is production automation, not a seeder, and the door matrix justifies its seed column with *"seeded data is shaped by the seeder, not rules"*, which is not why a build is silent. Not `absorbedSession`: that needs a named aggregator actually announcing the movements, and claiming one that doesn't exist is exactly the defect `silent-write-conformance.test.ts` catches.

**⚠️ What this makes load-bearing:** silencing the rule silences *both* halves of `mfg-stock-movements-created`, and the second is `recalculatePartQoH`, which fires regardless of the `adjustSubparts` flag. So the single post-commit `batchRecalculateQoH` is **the only thing recalculating QoH** for these movements — not an optimisation.

**And §3.5's "two independent defences" framing is wrong.** `explodeBomMovement` guards on `adjustSubparts` as its *third statement*, before any query, and create-time values are threaded rather than refetched — so a `false` reaches that guard on every lane. The flag carries the anti-double-explosion safety; the lane closes traps 1 and 3.

## Variance arithmetic

```
unitsStarted  = produced + scrapped
material      = Σ round(childStandard_i × qtyPer_i × unitsStarted)
labour        = round(rate_L × unitsStarted)
overhead      = round(rate_O × unitsStarted)
producedValue = round(parentStandard × produced)        ← produced, NOT started
variance      = material + labour + overhead − producedValue    → 5090
```

Scrap absorbs on units **started** while `producedValue` values only survivors, so variance collapses to exactly `scrapped × standardCost` — the scrapped units' whole standard cost and nothing else (**B7**). Asserted as an identity over `s ∈ {0,1,2,5,37}`, and end-to-end: 10 good + 2 scrap → `87864 + 6000 + 2400 − 80220 = 16044 = 2 × 8022`, with the produce row at quantity **10**, not 12.

Absorbing scrap into the survivors instead would give the same variant a different unit cost on every build, destroying the point of a standard.

Movement `extendedCost` is the negation of the positive extended term, not a re-round of `unitCost × −consumed`, so a row and its total cannot disagree on a half-cent tie.

## 🛑 One deviation that needs your call

**§3.4 step 5 says `glAccount = 1330` flatly.** Taken literally that puts *subassembly* stock into **Finished Goods** on every subassembly build, contradicting the part-kind account map `receiveStock` already uses (products/01 §4: subassembly → 1310).

Implemented as: resolve the produce row's account from the produced part's own `part_kind` via the existing `resolveGlAccountForPartKind` — which yields exactly 1330 for the finished-good case §3.4 describes. Flagged in a code comment. **Say if you'd rather have the literal reading.**

## Other judgement calls

- **`receiving/reverse-movement.ts` was read and deliberately not reused** for B6: it maps `build_consume`/`build_produce` → `adjust` (right for a standalone correction, wrong for a build reversal), cannot set `stock_movement_build` (rows orphaned, `build_movements` empty), drops `qty_per_unit` (destroys the as-built snapshot), and is one inline-lane movement — 51 rows would be 51 independently-refusable ops and 51 QoH re-SUMs. Its `computeExtendedCost` and `resolveGlAccountForPartKind` **are** reused, and each reversing row sets `stock_movement_reverses_movement`, so that module's already-reversed guard still refuses to separately "correct" a movement a build reversal already undid.
- **A reversing build negates quantities and all five cost fields**, so any report summing build output nets to zero across the pair. B6 speaks only of movements; a positive `quantityProduced` would double-count production while the movements cancelled.
- **Labour/overhead multiply `unitsStarted`.** §3.6 says "the defaults from §2.3", but §2.3 defines per-unit rates and never says which quantity. Starting units is what makes the scrap identity close.
- **A null rate stores `0` on the build row**, unlike phase 1 where null ≠ 0 on the *part standard*. The build field records what a specific run absorbed, and a run under no declared rate absorbed nothing. The opposite choice is defensible.
- **`listUnpostedBuilds`** is `status = completed` + `postedAt IS NULL`, which today returns every completed build since B9 means nothing writes `postedAt`. Its predicate moves to the posting ledger when that lands.
- **Override semantics:** an override for a part *on* the BOM keeps `qtyPerUnit` (the bill still called for 2/unit); an override for a part *not* on it writes `qtyPerUnit: null`, the field's documented off-BOM marker. A zero-quantity line is dropped, not written.

## Two known gaps, both for the UI phase

1. **`build_number` has no writer.** `build-fields.ts` says it is RecordSequence-issued and "the hook is the ONLY writer", but `SequenceScope` in `records/record-numbering.ts` has no `'build'` entry and no hook exists. The hook belongs in `resources/hooks/`, which was out of scope here, and §3.4 doesn't list numbering. **`createBuild` currently produces `number: null`.**
2. **`reverseBuild`'s new build row is created on the quiet lane**, so it produces no `record:created` realtime frame — an open builds list won't show it until the router invalidates. `completeBuild` compensates for its own row by publishing changed field values post-commit; a create has no equivalent key.

## Verification

```
lib typecheck ratchet:  no new type errors (29 total, baseline 29)
vitest src/builds src/bom src/field-hooks src/receiving src/resources/crud:
                        52 files, 670 passed | 10 skipped
full packages/lib:      1006 files, 13504 passed | 79 skipped
biome:                  16 files, clean
```

Phase 1's 32 tests pass untouched. 33 new tests here plus the 10 lane tests.

**QoH ordering is proven, not asserted:** the harness pushes `commit` / `recalc` / `create:<type>` onto a shared trace, and the test asserts exactly one recalc, on the deduplicated `[produced, ...consumed]` set, with `indexOf('recalc') > indexOf('commit')` and every create before the commit. Same for `reverseBuild`.

## ⚠️ Caveat the unit tests cannot close

`db.transaction` is a double in this harness, so *"every `UnifiedCrudHandler` write inside `db.transaction()` actually lands on `tx`"* is unverified against a live database. `createEntity` threads `ctx.db` into `createEntityInstance` and `FieldValueService`, which is why it should hold — and its post-write `getEntityInstance` re-read uses the module-level pool and will miss the uncommitted row, which is harmless here because its only consumer is the realtime frame the quiet lane suppresses. **Worth one integration test before this touches production data.**
