### PR TITLE
feat(build): raise, complete and reverse a build from the app

### DIFF
--- a/apps/web/src/app/(protected)/app/builds/[buildId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/builds/[buildId]/page.tsx
@@ -1,0 +1,22 @@
+// apps/web/src/app/(protected)/app/builds/[buildId]/page.tsx
+
+import { DetailView } from '~/components/detail-view'
+
+type Props = { params: Promise<{ buildId: string }> }
+
+/**
+ * Build detail page using the universal DetailView component
+ * (plans/products/build/01-build-plan.md §3.6, the purchase-orders recipe).
+ *
+ * `build` is `hasDetailPage: true`: a run is raised, started and completed
+ * against, which is page-shaped. Its two sidebar cards — Run and Ledger — are
+ * declared in `detail-view-config.ts` and resolved from the shared
+ * `DRAWER_TAB_CARD_COMPONENTS` registry, so the page and the drawer offer the
+ * same actions rather than the drawer being a read-only half.
+ */
+async function BuildDetailPage({ params }: Props) {
+  const { buildId } = await params
+  return <DetailView apiSlug='build' instanceId={buildId} backUrl='/app/builds' />
+}
+
+export default BuildDetailPage

--- a/apps/web/src/app/(protected)/app/builds/layout.tsx
+++ b/apps/web/src/app/(protected)/app/builds/layout.tsx
@@ -1,0 +1,51 @@
+// apps/web/src/app/(protected)/app/builds/layout.tsx
+
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { usePathname } from 'next/navigation'
+import { RecordRouteGuard } from '~/components/records'
+import { useResource } from '~/components/resources'
+
+type Props = { children: React.ReactNode }
+
+const BASE_PATH = '/app/builds'
+
+/**
+ * Builds layout — the purchase-orders/orders recipe
+ * (plans/products/build/01-build-plan.md §3.6): a plain breadcrumb shell for the
+ * list route only. `RecordsView` (mounted by `builds/page.tsx`) renders its own
+ * MainPageContent and contributes the Create button via `MainPageAction`; the
+ * detail route (`[buildId]`) owns its own `MainPage` and bypasses the shell.
+ *
+ * There is no catch-all route for system entities, and the Records sidebar links
+ * a system def as `/app/${apiSlug}`. This folder IS what makes entity migration
+ * 110's `isVisible: true` lead somewhere instead of 404ing.
+ */
+export default function BuildsLayout({ children }: Props) {
+  const pathname = usePathname()
+  const { resource } = useResource('builds')
+  const isDetailOrSpecialPage = pathname !== BASE_PATH
+
+  return (
+    <RecordRouteGuard slug='builds'>
+      {isDetailOrSpecialPage ? (
+        <>{children}</>
+      ) : (
+        <MainPage>
+          <MainPageHeader>
+            <MainPageBreadcrumb>
+              <MainPageBreadcrumbItem title={resource?.plural ?? 'Builds'} href={BASE_PATH} />
+            </MainPageBreadcrumb>
+          </MainPageHeader>
+          {children}
+        </MainPage>
+      )}
+    </RecordRouteGuard>
+  )
+}

--- a/apps/web/src/app/(protected)/app/builds/loading.tsx
+++ b/apps/web/src/app/(protected)/app/builds/loading.tsx
@@ -1,0 +1,7 @@
+// apps/web/src/app/(protected)/app/builds/loading.tsx
+
+import { LoadingSpinner } from '~/components/global/loading-content'
+
+export default function Loading() {
+  return <LoadingSpinner />
+}

--- a/apps/web/src/app/(protected)/app/builds/page.tsx
+++ b/apps/web/src/app/(protected)/app/builds/page.tsx
@@ -1,0 +1,26 @@
+// apps/web/src/app/(protected)/app/builds/page.tsx
+
+'use client'
+
+import { RecordsView } from '~/components/records'
+
+/**
+ * Builds list — the shared `RecordsView` for the `builds` resource
+ * (plans/products/build/01-build-plan.md §3.6).
+ *
+ * The columns are driven entirely by the field registry, not by this file:
+ * `primaryDisplayField: 'number'` pins `B-0001` as the first column and
+ * `secondaryDisplayField: 'part'` supplies the subtitle, both from
+ * `DISPLAY_FIELD_CONFIG`. `build_source` is the one field declared
+ * `showInTable: true` while `showInPanel: false` (§1.6), so the default table
+ * carries a Source column and an auto-build raised by the order trigger is
+ * distinguishable at a glance from one a person raised deliberately.
+ *
+ * ⚠️ `number` is NULL on every build created before the numbering hook landed,
+ * so the primary cell falls back to the record's own display name. Nothing here
+ * needs to know that; it is why no surface in this feature formats a number
+ * without a fallback.
+ */
+export default function BuildsPage() {
+  return <RecordsView slug='builds' basePath='/app/builds' />
+}

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -197,6 +197,22 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     })),
 
   // ─────────────────────────────────────────────────────────────────
+  // BUILD OVERVIEW CARDS (plans/products/build/01-build-plan.md §3.6) — shared
+  // with the build detail-view sidebar, which reads this same registry.
+  // ─────────────────────────────────────────────────────────────────
+  // The run's numbers plus the ONLY surface for Start / Cancel / Complete /
+  // Reverse. `build_status` is `showInDialogs: false` and each transition is a
+  // procedure with its own preconditions, so there is no status dropdown.
+  'build:run': () =>
+    import('../manufacturing/builds/build-run-card').then((m) => ({ default: m.BuildRunCard })),
+  // The consume/produce rows the completion wrote. `build_movements` is
+  // `showInPanel: false`, so this card is its only surface.
+  'build:ledger': () =>
+    import('../manufacturing/builds/build-ledger-card').then((m) => ({
+      default: m.BuildLedgerCard,
+    })),
+
+  // ─────────────────────────────────────────────────────────────────
   // INVOICE OVERVIEW CARDS (money MI1 build spec §J.1 — drawer-only entity,
   // hasDetailPage: false, so these are the invoice's ONLY UI surface)
   // ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
@@ -1,0 +1,195 @@
+// apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
+'use client'
+
+// `build:ledger` — the stock movements this build wrote
+// (plans/products/build/01-build-plan.md §1.6: "`build_movements` — has_many; a
+// card lists them").
+//
+// `build_movements` is declared `showInPanel: false`, so this card is its only
+// surface. `stock_movement_qty_per_unit` is `showInPanel: false` too, and
+// deliberately so — §1.6: "exposing it invites someone to 'correct' the as-built
+// snapshot, which destroys its only purpose". This card therefore renders what
+// that snapshot MEANS, not the number: a consume row with no per-unit quantity
+// is an off-BOM substitution, and it says so.
+//
+// The rows are read through the generic record list rather than through a lib
+// query, because they are ordinary `stock_movement` records and the mail/record
+// scope predicates that apply to every other movement list must apply here too.
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { StockMovementType } from '@auxx/lib/resources/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import type { RecordId } from '@auxx/types/resource'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { formatCurrency } from '@auxx/utils/currency'
+import { useMemo } from 'react'
+import { EmptyRow, RowSkeleton } from '~/components/drawers/cards/related-record-row'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { toRecordId, useRecord, useRecordList, useResourceProperty } from '~/components/resources'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { useSettings } from '~/hooks/use-settings'
+
+/** Movement type value → badge colour, straight from the registry's own enum. */
+const TYPE_VARIANT: Record<string, Variant> = Object.fromEntries(
+  StockMovementType.values.map((value) => [value.value, value.color as Variant])
+)
+
+const TYPE_LABEL: Record<string, string> = Object.fromEntries(
+  StockMovementType.values.map((value) => [value.value, value.label])
+)
+
+const MOVEMENT_ATTRIBUTES = [
+  // The part IS a movement row's identity here — a build's ledger is read as
+  // "what went in and what came out", not as a list of movement ids.
+  'stock_movement_part',
+  'stock_movement_type',
+  'stock_movement_quantity',
+  'stock_movement_unit_cost',
+  'stock_movement_extended_cost',
+  'stock_movement_gl_account',
+  // Read to detect the OFF-BOM case, never rendered as a number — see the header.
+  'stock_movement_qty_per_unit',
+] as const
+
+/** How many movements render before the list stops. A build writes one row per component. */
+const MOVEMENT_LIMIT = 200
+
+export function BuildLedgerCard({ entityInstanceId }: DrawerTabProps) {
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+
+  const movementDefId = useResourceProperty('stock_movement', 'id')
+
+  const filters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'build-filter',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'build-match',
+            fieldId: 'stock_movement:build' as ResourceFieldId,
+            operator: 'is' as const,
+            value: entityInstanceId,
+          },
+        ],
+      },
+    ],
+    [entityInstanceId]
+  )
+
+  const { records, isLoading } = useRecordList({
+    entityDefinitionId: movementDefId ?? '',
+    filters,
+    limit: MOVEMENT_LIMIT,
+    enabled: !!entityInstanceId && !!movementDefId,
+  })
+
+  const recordIds = useMemo(
+    () => (movementDefId ? records.map((record) => toRecordId(movementDefId, record.id)) : []),
+    [records, movementDefId]
+  )
+
+  const { valuesById } = useSystemValuesForRecords(recordIds, MOVEMENT_ATTRIBUTES, {
+    autoFetch: true,
+    enabled: recordIds.length > 0,
+  })
+
+  if (isLoading) return <RowSkeleton />
+  if (records.length === 0) {
+    // Not an error and not a gap: a `planned` build writes no movements at all
+    // (B2), which is the safety property the whole phasing rests on.
+    return <EmptyRow label='Nothing posted yet — a build writes its ledger when it completes' />
+  }
+
+  return (
+    <div className='divide-y divide-border/50'>
+      {records.map((record, index) => (
+        <MovementRow
+          key={record.id}
+          fallbackLabel={record.displayName}
+          values={valuesById[recordIds[index] ?? ''] ?? {}}
+          currencyCode={currencyCode}
+        />
+      ))}
+    </div>
+  )
+}
+
+function MovementRow({
+  fallbackLabel,
+  values,
+  currencyCode,
+}: {
+  fallbackLabel: string | null | undefined
+  values: Record<string, unknown>
+  currencyCode: string
+}) {
+  const partRecordId = unwrap(values.stock_movement_part) as RecordId | undefined
+  const { record: part } = useRecord({ recordId: partRecordId!, enabled: !!partRecordId })
+  const label = part?.displayName ?? fallbackLabel
+
+  const type = unwrap(values.stock_movement_type) as string | undefined
+  const quantity = numberOrNull(values.stock_movement_quantity)
+  const unitCost = numberOrNull(values.stock_movement_unit_cost)
+  const extendedCost = numberOrNull(values.stock_movement_extended_cost)
+  const glAccount = unwrap(values.stock_movement_gl_account) as string | undefined
+  const qtyPerUnit = numberOrNull(values.stock_movement_qty_per_unit)
+
+  // 🛑 The off-BOM marker, read as the marker it is. NULL `qtyPerUnit` on a
+  // CONSUME row means the component was not on the bill of materials — a floor
+  // substitution, made visible instead of silent (Gap C §4.1). It is NULL on
+  // every other movement type by definition, so the produce row must not be
+  // labelled a substitution.
+  const isConsume = type === 'build_consume'
+  const offBom = isConsume && qtyPerUnit == null
+
+  return (
+    <div className='flex items-center gap-2 py-1.5'>
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center gap-1.5'>
+          <span className='truncate text-sm'>{label || 'Movement'}</span>
+          {type && (
+            <Badge variant={TYPE_VARIANT[type] ?? 'secondary'} size='xs'>
+              {TYPE_LABEL[type] ?? type}
+            </Badge>
+          )}
+          {offBom && (
+            <Badge variant='amber' size='xs'>
+              Off BOM
+            </Badge>
+          )}
+        </div>
+        <span className='text-muted-foreground text-xs tabular-nums'>
+          {unitCost == null ? 'no cost' : `${formatCurrency(unitCost, { currencyCode })} each`}
+          {glAccount && ` · ${glAccount}`}
+        </span>
+      </div>
+
+      <span className='shrink-0 text-sm tabular-nums'>
+        {quantity == null ? '—' : formatSignedQuantity(quantity)}
+      </span>
+      <span className='w-24 shrink-0 text-right text-sm tabular-nums'>
+        {extendedCost == null ? '—' : formatCurrency(extendedCost, { currencyCode })}
+      </span>
+    </div>
+  )
+}
+
+/** SINGLE_SELECT and RELATIONSHIP reads come back as arrays; everything else scalar. */
+function unwrap(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value
+}
+
+/** A NUMBER system value, with absence kept distinct from zero. */
+function numberOrNull(value: unknown): number | null {
+  const raw = unwrap(value)
+  const parsed = typeof raw === 'string' ? Number(raw) : raw
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : null
+}
+
+/** A movement quantity keeps its sign — consume is negative, produce is positive. */
+function formatSignedQuantity(value: number): string {
+  const trimmed = Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)))
+  return value > 0 ? `+${trimmed}` : trimmed
+}

--- a/apps/web/src/components/manufacturing/builds/build-run-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-run-card.tsx
@@ -1,0 +1,372 @@
+// apps/web/src/components/manufacturing/builds/build-run-card.tsx
+'use client'
+
+// `build:run` — the run's numbers and its whole lifecycle, in one card
+// (plans/products/build/01-build-plan.md §3.6, §1.6).
+//
+// This is the ONLY surface for the four lifecycle transitions, and that is by
+// design rather than by omission. `build_status` is declared
+// `showInDialogs: false` and every one of Start / Cancel / Complete / Reverse is
+// a procedure with its own preconditions — `completeBuild` refuses a second
+// completion (B8), `reverseBuild` refuses a second reversal and refuses to
+// reverse a reversal (B6). A status dropdown would let a person claim a
+// transition the server would then have to unpick, and would claim a completed
+// build's movements exist when they do not.
+//
+// It is also the only place the five cost fields are read together. They ARE in
+// the Details panel (§1.6 keeps them there — the variance is the number a person
+// actually reads on a build), but a panel row per figure does not show the
+// arithmetic, and the arithmetic is the point.
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
+import { Undo2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { EmptyRow, RowSkeleton } from '~/components/drawers/cards/related-record-row'
+import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { PurchasingSummaryStrip } from '~/components/purchasing/purchasing-summary-strip'
+import { useOpenRecord } from '~/components/records/record-drill-panels'
+import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useSettings } from '~/hooks/use-settings'
+import { useAccess } from '~/providers/capabilities-provider'
+import { api } from '~/trpc/react'
+import { CompleteBuildDialog } from './complete-build-dialog'
+
+/** `build_status` → badge colour. Mirrors the `BuildStatus` enum's own colours. */
+const STATUS_VARIANT: Record<string, Variant> = {
+  planned: 'secondary',
+  in_progress: 'blue',
+  completed: 'green',
+  canceled: 'red',
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  planned: 'Planned',
+  in_progress: 'In progress',
+  completed: 'Completed',
+  canceled: 'Canceled',
+}
+
+export function BuildRunCard({ entityInstanceId }: DrawerTabProps) {
+  const [completeOpen, setCompleteOpen] = useState(false)
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+
+  const buildDefId = useResourceProperty('build', 'id')
+  const movementDefId = useResourceProperty('stock_movement', 'id')
+  const utils = api.useUtils()
+
+  // The client mirror of what `builds.ts` asserts, so the button the UI hides and
+  // the door the server closes are the same door. Raising and abandoning a run
+  // needs `build` alone (B2: a planned build writes no movements); completing and
+  // reversing also need `stock_movement`, because that is where the rest of
+  // manufacturing puts the authority to move stock.
+  const { canEditEntity } = useAccess()
+  const canManageRun = !!buildDefId && canEditEntity(buildDefId)
+  const canPostLedger = canManageRun && !!movementDefId && canEditEntity(movementDefId)
+  const build = api.builds.get.useQuery(
+    { buildId: entityInstanceId },
+    { enabled: !!entityInstanceId, retry: false }
+  )
+
+  const reversal = useBuildReversal(entityInstanceId, build.data?.status === 'completed')
+  const openRecord = useOpenRecord()
+
+  /**
+   * Every read this feature owns, plus the generic record list.
+   *
+   * 🛑 `reverseBuild` writes its new build on the quiet lane, so it emits **no**
+   * `record:created` frame and no open list learns about it. `startBuild` and
+   * `cancelBuild` do publish, but the acting tab is deliberately excluded from
+   * its own realtime events. Either way the tab that pressed the button is the
+   * one that has to invalidate — which is what this does, in the one place all
+   * four mutations funnel through.
+   */
+  const refresh = async () => {
+    await Promise.all([
+      utils.builds.get.invalidate(),
+      utils.builds.list.invalidate(),
+      buildDefId
+        ? utils.record.listFiltered.invalidate({ entityDefinitionId: buildDefId })
+        : Promise.resolve(),
+    ])
+  }
+
+  const startBuild = api.builds.start.useMutation({
+    onError: (error) => toastError({ title: 'Failed to start build', description: error.message }),
+    onSuccess: refresh,
+  })
+
+  const cancelBuild = api.builds.cancel.useMutation({
+    onError: (error) => toastError({ title: 'Failed to cancel build', description: error.message }),
+    onSuccess: refresh,
+  })
+
+  const reverseBuild = api.builds.reverse.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Failed to reverse build', description: error.message }),
+    onSuccess: refresh,
+  })
+
+  if (build.isPending) return <RowSkeleton />
+  if (!build.data) return <EmptyRow label='This build could not be read' />
+
+  const run = build.data
+  const status = run.status
+  const isCompleted = status === 'completed'
+  const isReversal = !!run.reversalOfBuildId
+  const alreadyReversed = reversal.reversedByBuildId != null
+  const pending = startBuild.isPending || cancelBuild.isPending || reverseBuild.isPending
+
+  const handleCancel = async () => {
+    const confirmed = await confirm({
+      title: 'Cancel this build?',
+      description:
+        'The run is abandoned. Nothing has been consumed or produced, so no stock movement is written or removed.',
+      confirmText: 'Cancel build',
+      cancelText: 'Keep it',
+      destructive: true,
+    })
+    if (confirmed) cancelBuild.mutate({ buildId: entityInstanceId })
+  }
+
+  const handleReverse = async () => {
+    const confirmed = await confirm({
+      title: 'Reverse this build?',
+      description:
+        'Writes a second build that negates every movement this one wrote, at the costs frozen on the originals. This build is left exactly as it is — a completed build is never edited or deleted.',
+      confirmText: 'Reverse build',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) reverseBuild.mutate({ buildId: entityInstanceId })
+  }
+
+  return (
+    <div className='space-y-2'>
+      <ConfirmDialog />
+
+      <DrawerCardActions>
+        <div className='flex items-center gap-1'>
+          {status === 'planned' && canManageRun && (
+            <Button
+              variant='ghost'
+              size='xs'
+              disabled={pending}
+              onClick={() => startBuild.mutate({ buildId: entityInstanceId })}>
+              Start
+            </Button>
+          )}
+          {(status === 'planned' || status === 'in_progress') && canManageRun && (
+            <>
+              <Button
+                variant='outline'
+                size='xs'
+                disabled={pending || !run.partId || !canPostLedger}
+                onClick={() => setCompleteOpen(true)}>
+                Complete
+              </Button>
+              <Button variant='ghost' size='xs' disabled={pending} onClick={handleCancel}>
+                Cancel
+              </Button>
+            </>
+          )}
+          {/* 🛑 Not offered on a reversal, and not offered twice. `reverseBuild`
+              refuses both, but a button that exists only to fail is a worse
+              answer than a button that is not there. */}
+          {isCompleted && !isReversal && !alreadyReversed && canPostLedger && (
+            <Button variant='ghost' size='xs' disabled={pending} onClick={handleReverse}>
+              <Undo2 />
+              Reverse
+            </Button>
+          )}
+        </div>
+      </DrawerCardActions>
+
+      <div className='flex items-center gap-1.5'>
+        <Badge variant={STATUS_VARIANT[status ?? ''] ?? 'secondary'} size='xs'>
+          {STATUS_LABEL[status ?? ''] ?? 'Unknown'}
+        </Badge>
+        {run.source === 'order' && (
+          <Badge variant='blue' size='xs'>
+            From order
+          </Badge>
+        )}
+        {isReversal && (
+          <Badge variant='amber' size='xs'>
+            Reversal
+          </Badge>
+        )}
+        {alreadyReversed && (
+          <Badge variant='amber' size='xs'>
+            Reversed
+          </Badge>
+        )}
+      </div>
+
+      {/* §1.6: the two reversal relations are `showInPanel: false` on purpose —
+          "surfaced as a banner/badge on a reversed build, not as two relationship
+          rows". This is that banner. */}
+      {isReversal && run.reversalOfBuildId && (
+        <ReversalBanner
+          label='Undoes an earlier build'
+          onOpen={
+            buildDefId && openRecord
+              ? () => openRecord(toRecordId(buildDefId, run.reversalOfBuildId as string))
+              : undefined
+          }
+        />
+      )}
+      {alreadyReversed && reversal.reversedByBuildId && (
+        <ReversalBanner
+          label='This build has been reversed'
+          onOpen={
+            buildDefId && openRecord
+              ? () => openRecord(toRecordId(buildDefId, reversal.reversedByBuildId as string))
+              : undefined
+          }
+        />
+      )}
+
+      <PurchasingSummaryStrip
+        className='pt-1'
+        cells={[
+          { label: 'Planned', value: formatQuantity(run.quantityPlanned) },
+          {
+            label: 'Produced',
+            value: formatQuantity(run.quantityProduced),
+            tone: run.quantityProduced ? 'default' : 'muted',
+          },
+          {
+            label: 'Scrapped',
+            value: formatQuantity(run.quantityScrapped),
+            tone: run.quantityScrapped ? 'default' : 'muted',
+          },
+        ]}
+      />
+
+      {isCompleted && (
+        <div className='space-y-1 border-border/50 border-t pt-2 text-xs tabular-nums'>
+          <CostLine label='Material' value={run.materialCost} currencyCode={currencyCode} />
+          <CostLine label='Labour' value={run.laborCost} currencyCode={currencyCode} />
+          <CostLine label='Overhead' value={run.overheadCost} currencyCode={currencyCode} />
+          <CostLine
+            label='Produced value'
+            value={run.producedValue}
+            currencyCode={currencyCode}
+            className='border-border/50 border-t pt-1'
+          />
+          <CostLine
+            label='Variance → 5090'
+            value={run.varianceAmount}
+            currencyCode={currencyCode}
+            signed
+            className='border-border/50 border-t pt-1 font-medium'
+          />
+        </div>
+      )}
+
+      {run.partId && (
+        <CompleteBuildDialog
+          open={completeOpen}
+          onOpenChange={setCompleteOpen}
+          buildId={entityInstanceId}
+          partId={run.partId}
+          quantityPlanned={run.quantityPlanned}
+          number={run.number}
+          onCompleted={refresh}
+        />
+      )}
+    </div>
+  )
+}
+
+/** The reversal pair, as a line a person can follow rather than two relation rows. */
+function ReversalBanner({ label, onOpen }: { label: string; onOpen?: () => void }) {
+  return (
+    <div className='flex items-center justify-between gap-2 rounded-md bg-amber-500/10 px-2 py-1.5 text-amber-700 text-xs dark:text-amber-500'>
+      <span>{label}</span>
+      {onOpen && (
+        <Button variant='ghost' size='xs' onClick={onOpen}>
+          Open
+        </Button>
+      )}
+    </div>
+  )
+}
+
+function CostLine({
+  label,
+  value,
+  currencyCode,
+  signed,
+  className,
+}: {
+  label: string
+  value: number | null
+  currencyCode: string
+  signed?: boolean
+  className?: string
+}) {
+  const sign = signed && value != null && value > 0 ? '+' : ''
+  return (
+    <div className={`flex items-baseline justify-between gap-2 ${className ?? ''}`}>
+      <span className='text-muted-foreground'>{label}</span>
+      <span>{value == null ? '—' : `${sign}${formatCurrency(value, { currencyCode })}`}</span>
+    </div>
+  )
+}
+
+/**
+ * The reversing build that points at this one, if there is one.
+ *
+ * `BuildRecord` carries `reversalOf` but not its inverse, so this reads the
+ * `build_reversed_by` side through the generic record list rather than adding a
+ * second shape to the lib. Enabled only for a completed build — nothing else can
+ * have been reversed, and a `planned` build that was cancelled is corrected by
+ * the cancellation, not by a negation.
+ */
+function useBuildReversal(buildId: string, enabled: boolean): { reversedByBuildId: string | null } {
+  const buildDefId = useResourceProperty('build', 'id')
+
+  const filters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'reversal-of',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'reversal-of-match',
+            fieldId: 'build:reversalOf' as ResourceFieldId,
+            operator: 'is' as const,
+            value: buildId,
+          },
+        ],
+      },
+    ],
+    [buildId]
+  )
+
+  const { records } = useRecordList({
+    entityDefinitionId: buildDefId ?? '',
+    filters,
+    limit: 1,
+    enabled: enabled && !!buildId && !!buildDefId,
+  })
+
+  return { reversedByBuildId: records[0]?.id ?? null }
+}
+
+/** Trim a quantity's trailing zeros, and read absence as a dash rather than zero. */
+function formatQuantity(value: number | null): string {
+  if (value == null) return '—'
+  return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)))
+}

--- a/apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
+++ b/apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
@@ -1,0 +1,747 @@
+// apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
+'use client'
+
+// The completion form (plans/products/build/01-build-plan.md §3.6) — the run's
+// only irreversible action, and the reason this whole phase is UI rather than a
+// procedure somebody calls.
+//
+// 🛑 **This is never a save.** `completeBuild` writes one `build_consume` per
+// component and one `build_produce`, all onto `updatable: false` rows, and the
+// only correction is a second build that negates them (B6). It also refuses a
+// second attempt outright — one completion per build (B8), so a run finished in
+// tranches is a different build, not a second press of this button. So the form
+// shows what it will write, at what cost, and what the variance will be, and it
+// says all three before the button is reachable.
+//
+// ## The three things it carries that a report would not
+//
+// 1. **Per-component quantity overrides.** The floor does not always follow the
+//    bill of materials. An untouched line is derived server-side from the BOM at
+//    the current produced/scrapped quantities and moves when they move; a line
+//    somebody typed is an absolute quantity for the WHOLE run and stays put.
+//    Zero is a legal answer — the line is dropped, not written at zero.
+// 2. **Off-BOM additions.** A part that is not on the bill of materials at all
+//    can be added, and its movement carries `stock_movement_qty_per_unit = NULL`
+//    — the documented marker for a floor substitution, so the usage cross-check
+//    can see it later instead of it being silent. The rows say so on screen too.
+// 3. **Scrap, priced.** B7: scrapped units consume material and produce no
+//    movement. Their whole standard cost falls out in `varianceAmount` and lands
+//    in account 5090. A person typing `2` into Scrapped is booking a variance,
+//    and the form says so at the input AND under the number.
+//
+// ## Why the numbers here are the numbers that get stored
+//
+// `builds.previewCompletion` runs the SAME `explodeBuildComponents` the write
+// runs, over the same overrides, and re-runs on every edit. The five cost
+// figures come from `summarizeBuildCompletion` in `@auxx/lib/builds/client`,
+// which is literally the function `completeBuild` calls. There is no second
+// implementation of the variance to drift.
+
+import { FieldType } from '@auxx/database/enums'
+import { summarizeBuildCompletion } from '@auxx/lib/builds/client'
+import { getInstanceId, type RecordId } from '@auxx/lib/resources/client'
+import type { RelationshipConfig } from '@auxx/types/custom-field'
+import { toResourceFieldId } from '@auxx/types/field'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
+import { RotateCcw, TriangleAlert } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { toRecordId, useResourceProperty } from '~/components/resources'
+import { BaseType } from '~/components/workflow/types'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import {
+  buildComponentOverrides,
+  type ComponentRow,
+  type KnownComponent,
+  mergeComponentRows,
+  rememberComponents,
+} from './completion-input'
+
+/** Synthetic relationship config for the ad-hoc off-BOM part picker (no backing field). */
+const OFF_BOM_PART_RELATIONSHIP: RelationshipConfig = {
+  inverseResourceFieldId: toResourceFieldId('part', 'id'),
+  relationshipType: 'belongs_to',
+  isInverse: false,
+}
+
+interface CompleteBuildDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** `EntityInstance.id` of the build being completed. */
+  buildId: string
+  /** `EntityInstance.id` of the part it produces. Drives the component explosion. */
+  partId: string
+  /** Prefills "Produced" — most runs make what they planned to make. */
+  quantityPlanned: number | null
+  /** `B-0001`, or null on a build raised before the numbering hook. */
+  number: string | null
+  onCompleted?: () => void
+}
+
+export function CompleteBuildDialog({
+  open,
+  onOpenChange,
+  buildId,
+  partId,
+  quantityPlanned,
+  number,
+  onCompleted,
+}: CompleteBuildDialogProps) {
+  const [quantityProduced, setQuantityProduced] = useState<number | null>(null)
+  const [quantityScrapped, setQuantityScrapped] = useState<number>(0)
+  const [overrides, setOverrides] = useState<Record<string, number>>({})
+  // Every component the form has ever seen for this run — see `rememberComponents`.
+  const [known, setKnown] = useState<KnownComponent[]>([])
+  // `null` means "take the org rate"; a number is what this run actually absorbed.
+  const [laborCost, setLaborCost] = useState<number | null>(null)
+  const [overheadCost, setOverheadCost] = useState<number | null>(null)
+  const [completedAt, setCompletedAt] = useState<string>(() => new Date().toISOString())
+  const [notes, setNotes] = useState('')
+
+  const partDefId = useResourceProperty('part', 'id')
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+
+  // A fresh form on every open. A stale completion date left over from a dialog
+  // somebody abandoned yesterday would silently backdate the whole ledger, and
+  // stale overrides would apply one run's substitutions to the next.
+  useEffect(() => {
+    if (!open) return
+    setQuantityProduced(quantityPlanned ?? null)
+    setQuantityScrapped(0)
+    setOverrides({})
+    setKnown([])
+    setLaborCost(null)
+    setOverheadCost(null)
+    setCompletedAt(new Date().toISOString())
+    setNotes('')
+  }, [open, quantityPlanned])
+
+  const produced = quantityProduced ?? 0
+  const scrapped = quantityScrapped ?? 0
+  const componentOverrides = useMemo(() => buildComponentOverrides(overrides), [overrides])
+
+  // The preview IS the form. It re-runs on every quantity and every override, so
+  // what is on screen is always what the write would freeze.
+  const preview = api.builds.previewCompletion.useQuery(
+    { partId, quantityProduced: produced, quantityScrapped: scrapped, componentOverrides },
+    { enabled: open && produced > 0, retry: false, refetchOnWindowFocus: false }
+  )
+
+  const plan = preview.data?.plan
+  const rates = preview.data?.rates
+
+  // Accumulate rather than replace: a line overridden to zero is not in the
+  // plan's `components`, and dropping it from the row list would take the input
+  // that produced it off screen.
+  useEffect(() => {
+    if (!plan) return
+    setKnown((current) => rememberComponents(current, plan.components))
+  }, [plan])
+
+  const rows = useMemo(
+    () => mergeComponentRows(known, plan?.components ?? [], overrides),
+    [known, plan, overrides]
+  )
+
+  // The five numbers, from the same function the server runs. `producedUnitCost`
+  // is null until the produced part has a standard, and there is deliberately no
+  // fallback: a completion at zero cost is what this whole subsystem exists to
+  // prevent, so the summary shows nothing rather than a confident zero.
+  const summary = useMemo(() => {
+    if (!plan || plan.producedUnitCost == null || !rates) return null
+    return summarizeBuildCompletion({
+      components: plan.components,
+      producedUnitCost: plan.producedUnitCost,
+      quantityProduced: produced,
+      quantityScrapped: scrapped,
+      laborCost,
+      overheadCost,
+      rates,
+    })
+  }, [plan, rates, produced, scrapped, laborCost, overheadCost])
+
+  const utils = api.useUtils()
+  const buildDefId = useResourceProperty('build', 'id')
+
+  const completeBuild = api.builds.complete.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Failed to complete build', description: error.message }),
+  })
+
+  const handleComplete = async () => {
+    if (!summary || produced <= 0) return
+    try {
+      await completeBuild.mutateAsync({
+        buildId,
+        quantityProduced: produced,
+        quantityScrapped: scrapped,
+        componentOverrides,
+        laborCost: laborCost ?? undefined,
+        overheadCost: overheadCost ?? undefined,
+        completedAt: new Date(completedAt),
+        notes: notes || undefined,
+      })
+      // `completeBuild` publishes its own field-value frame for the build row, so
+      // OTHER tabs repaint on their own. The acting tab is excluded from its own
+      // realtime events, and the movements were written on the quiet lane and
+      // announce nothing anywhere — so the ledger card's list has to be told.
+      await Promise.all([
+        utils.builds.get.invalidate({ buildId }),
+        utils.builds.list.invalidate(),
+        buildDefId
+          ? utils.record.listFiltered.invalidate({ entityDefinitionId: buildDefId })
+          : Promise.resolve(),
+      ])
+      onCompleted?.()
+      onOpenChange(false)
+    } catch {
+      // onError above already surfaced the toast.
+    }
+  }
+
+  const unpriced = plan?.missingStandardPartIds ?? []
+  const blocked = unpriced.length > 0 || rows.every((row) => row.dropped)
+  const canSubmit = !!summary && produced > 0 && !blocked && !completeBuild.isPending
+
+  const writtenRows = rows.filter((row) => !row.dropped).length
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !completeBuild.isPending && onOpenChange(next)}>
+      <DialogContent size='xl'>
+        <DialogHeader>
+          <DialogTitle>Complete {number ?? 'build'}</DialogTitle>
+          <DialogDescription>
+            Consumes the components and puts the finished units into stock at their standard cost. A
+            completed build is never edited or deleted — it is corrected by a reversing build.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className='max-h-[60vh]' allowScrollChaining>
+          <div className='space-y-4 pe-2'>
+            <FieldPanel className='p-0' breakpoint='md' resizeId='complete-build'>
+              <FieldPanelRow
+                title='Produced'
+                type={BaseType.NUMBER}
+                showIcon
+                isRequired
+                description='Good units that enter stock'>
+                <FieldInputAdapter
+                  fieldType={FieldType.NUMBER}
+                  value={quantityProduced}
+                  onChange={(val) => setQuantityProduced((val as number) ?? null)}
+                  placeholder='0'
+                  disabled={completeBuild.isPending}
+                />
+              </FieldPanelRow>
+
+              <FieldPanelRow
+                title='Scrapped'
+                type={BaseType.NUMBER}
+                showIcon
+                description='Started and lost'>
+                <FieldInputAdapter
+                  fieldType={FieldType.NUMBER}
+                  value={quantityScrapped}
+                  onChange={(val) => setQuantityScrapped((val as number) ?? 0)}
+                  placeholder='0'
+                  disabled={completeBuild.isPending}
+                />
+                {/* B7, said where the number is typed rather than only in a
+                    footnote: scrap is not free, and somebody entering 2 here is
+                    booking a variance, not recording a rounding detail. */}
+                {scrapped > 0 && (
+                  <p className='mt-1 flex items-start gap-1.5 text-amber-600 text-xs dark:text-amber-500'>
+                    <TriangleAlert className='mt-0.5 size-3 shrink-0' />
+                    <span>
+                      These {formatQuantity(scrapped)} units still consume components and produce no
+                      stock. Their whole cost is booked as a variance to account 5090.
+                    </span>
+                  </p>
+                )}
+              </FieldPanelRow>
+
+              <FieldPanelRow
+                title='Completed on'
+                type={BaseType.DATE}
+                showIcon
+                isRequired
+                description='The accounting date, which is not when it was keyed'>
+                <FieldInputAdapter
+                  fieldType={FieldType.DATETIME}
+                  value={completedAt}
+                  onChange={(val) => setCompletedAt((val as string) ?? new Date().toISOString())}
+                  disabled={completeBuild.isPending}
+                />
+              </FieldPanelRow>
+
+              <FieldPanelRow
+                title='Labour'
+                type={BaseType.CURRENCY}
+                showIcon
+                description={absorptionHint(rates?.laborCostPerUnit, currencyCode)}
+                onClear={laborCost == null ? undefined : () => setLaborCost(null)}>
+                <FieldInputAdapter
+                  fieldType={FieldType.CURRENCY}
+                  fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+                  value={laborCost ?? summary?.laborCost ?? null}
+                  onChange={(val) => setLaborCost((val as number) ?? null)}
+                  disabled={completeBuild.isPending}
+                />
+              </FieldPanelRow>
+
+              <FieldPanelRow
+                title='Overhead'
+                type={BaseType.CURRENCY}
+                showIcon
+                description={absorptionHint(rates?.overheadCostPerUnit, currencyCode)}
+                onClear={overheadCost == null ? undefined : () => setOverheadCost(null)}>
+                <FieldInputAdapter
+                  fieldType={FieldType.CURRENCY}
+                  fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+                  value={overheadCost ?? summary?.overheadCost ?? null}
+                  onChange={(val) => setOverheadCost((val as number) ?? null)}
+                  disabled={completeBuild.isPending}
+                />
+              </FieldPanelRow>
+
+              <FieldPanelRow title='Notes' type={BaseType.STRING} showIcon>
+                <FieldInputAdapter
+                  fieldType={FieldType.TEXT}
+                  value={notes}
+                  onChange={(val) => setNotes((val as string) ?? '')}
+                  placeholder='e.g. Substituted the 12V motor, none in stock'
+                  disabled={completeBuild.isPending}
+                />
+              </FieldPanelRow>
+            </FieldPanel>
+
+            <ComponentsSection
+              rows={rows}
+              hasPlan={!!plan}
+              loading={preview.isPending && produced > 0}
+              error={preview.error?.message ?? null}
+              currencyCode={currencyCode}
+              disabled={completeBuild.isPending}
+              unitsStarted={produced + scrapped}
+              onOverride={(rowPartId, quantity) =>
+                setOverrides((current) => ({ ...current, [rowPartId]: quantity }))
+              }
+              onResetOverride={(rowPartId) =>
+                setOverrides((current) => {
+                  const next = { ...current }
+                  delete next[rowPartId]
+                  return next
+                })
+              }
+              onAddOffBom={(rowPartId) =>
+                setOverrides((current) =>
+                  // Seed at one unit per started unit — a substitution usually
+                  // stands in for something, so zero would be a worse guess than
+                  // one and would drop the line the person just added.
+                  rowPartId in current
+                    ? current
+                    : { ...current, [rowPartId]: Math.max(1, produced + scrapped) }
+                )
+              }
+              partDefId={partDefId}
+              knownPartIds={rows.map((row) => row.partId)}
+            />
+
+            {unpriced.length > 0 && (
+              <UnpricedWarning partIds={unpriced} rows={rows} producedPartId={partId} />
+            )}
+
+            {summary && (
+              <CostSummary
+                summary={summary}
+                currencyCode={currencyCode}
+                quantityProduced={produced}
+                quantityScrapped={scrapped}
+                producedUnitCost={plan?.producedUnitCost ?? null}
+              />
+            )}
+          </div>
+        </ScrollArea>
+
+        {/* Said once, plainly, immediately above the button: what will be written
+            and that it cannot be taken back by editing. */}
+        {canSubmit && (
+          <p className='text-muted-foreground text-xs'>
+            Writes {writtenRows} consume {writtenRows === 1 ? 'movement' : 'movements'} and 1
+            produce movement, dated {new Date(completedAt).toLocaleDateString()}. This build cannot
+            be completed a second time.
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={completeBuild.isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={handleComplete}
+            loading={completeBuild.isPending}
+            loadingText='Posting...'
+            disabled={!canSubmit}
+            data-dialog-submit>
+            Complete and post <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Components ────────────────────────────────────────────────────────
+
+interface ComponentsSectionProps {
+  rows: ComponentRow[]
+  /** The explosion has arrived. Until it has there is nothing honest to render. */
+  hasPlan: boolean
+  loading: boolean
+  error: string | null
+  currencyCode: string
+  disabled: boolean
+  unitsStarted: number
+  onOverride: (partId: string, quantity: number) => void
+  onResetOverride: (partId: string) => void
+  onAddOffBom: (partId: string) => void
+  partDefId: string | undefined
+  knownPartIds: string[]
+}
+
+/**
+ * The per-component override table, and the off-BOM picker beneath it.
+ *
+ * Quantities are for the WHOLE run, not per unit — that is what the header says
+ * and what the server stores. Per-unit would have to be re-derived every time
+ * "produced" moved, and the floor counts what it pulled from the shelf, not what
+ * it pulled per unit.
+ */
+function ComponentsSection({
+  rows,
+  hasPlan,
+  loading,
+  error,
+  currencyCode,
+  disabled,
+  unitsStarted,
+  onOverride,
+  onResetOverride,
+  onAddOffBom,
+  partDefId,
+  knownPartIds,
+}: ComponentsSectionProps) {
+  if (error) {
+    return <p className='rounded-md bg-destructive/10 p-2 text-destructive text-xs'>{error}</p>
+  }
+
+  if (loading && rows.length === 0) {
+    return (
+      <div className='space-y-2'>
+        <Skeleton className='h-6 w-full' />
+        <Skeleton className='h-6 w-full' />
+        <Skeleton className='h-6 w-full' />
+      </div>
+    )
+  }
+
+  if (!hasPlan) return null
+
+  return (
+    <div className='space-y-2'>
+      <div className='flex items-baseline justify-between gap-2'>
+        <h4 className='font-semibold text-sm'>Components consumed</h4>
+        <span className='text-muted-foreground text-xs'>
+          for {formatQuantity(unitsStarted)} units started
+        </span>
+      </div>
+
+      <div className='divide-y divide-border/50 rounded-md border'>
+        {rows.map((row) => (
+          <ComponentRowInput
+            key={row.partId}
+            row={row}
+            currencyCode={currencyCode}
+            disabled={disabled}
+            onOverride={onOverride}
+            onResetOverride={onResetOverride}
+          />
+        ))}
+        {rows.length === 0 && (
+          <p className='px-3 py-2 text-muted-foreground text-xs'>
+            This part has no bill of materials, so there is nothing to consume.
+          </p>
+        )}
+      </div>
+
+      <div className='flex items-center gap-2'>
+        <span className='shrink-0 text-muted-foreground text-xs'>Add off-BOM part</span>
+        <div className='flex-1'>
+          <FieldInputAdapter
+            fieldType={FieldType.RELATIONSHIP}
+            value={[]}
+            onChange={(value) => {
+              const first = (value as RecordId[])[0]
+              if (first) onAddOffBom(getInstanceId(first))
+            }}
+            triggerProps={{ className: 'w-full' }}
+            placeholder='Search parts...'
+            disabled={disabled || !partDefId}
+            fieldOptions={{
+              relationship: OFF_BOM_PART_RELATIONSHIP,
+              excludeIds: partDefId
+                ? knownPartIds.map((id) => toRecordId(partDefId, id))
+                : undefined,
+              showDefinitionIcon: true,
+              showSecondary: true,
+            }}
+          />
+        </div>
+      </div>
+      <p className='text-muted-foreground text-xs'>
+        A part that is not on the bill of materials is recorded as a substitution — its movement
+        carries no per-unit quantity, so the swap stays visible instead of looking like the recipe.
+      </p>
+    </div>
+  )
+}
+
+/** One component line: what it is, how much of it, and what that costs. */
+function ComponentRowInput({
+  row,
+  currencyCode,
+  disabled,
+  onOverride,
+  onResetOverride,
+}: {
+  row: ComponentRow
+  currencyCode: string
+  disabled: boolean
+  onOverride: (partId: string, quantity: number) => void
+  onResetOverride: (partId: string) => void
+}) {
+  return (
+    <div className='flex items-center gap-2 px-3 py-2'>
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center gap-1.5'>
+          <span className='truncate text-sm'>{row.partName ?? row.partId}</span>
+          {/* The off-BOM marker, said in the UI exactly as it is stored: this
+              line carries no `qtyPerUnit`, which is what makes it findable later
+              as a substitution rather than as part of the recipe. */}
+          {row.offBom && (
+            <Badge variant='amber' size='xs'>
+              Off BOM
+            </Badge>
+          )}
+          {row.dropped && (
+            <Badge variant='secondary' size='xs'>
+              Not used
+            </Badge>
+          )}
+        </div>
+        <span className='text-muted-foreground text-xs tabular-nums'>
+          {row.qtyPerUnit == null ? 'substitution' : `${formatQuantity(row.qtyPerUnit)} per unit`}
+          {row.unitCost != null && ` · ${formatCurrency(row.unitCost, { currencyCode })} each`}
+        </span>
+      </div>
+
+      <div className='w-24 shrink-0'>
+        <FieldInputAdapter
+          fieldType={FieldType.NUMBER}
+          value={row.quantityConsumed}
+          onChange={(val) => onOverride(row.partId, (val as number) ?? 0)}
+          placeholder='0'
+          disabled={disabled}
+        />
+      </div>
+
+      <div className='w-24 shrink-0 text-right text-sm tabular-nums'>
+        {row.extendedCost == null ? (
+          <span className='text-destructive text-xs'>no standard</span>
+        ) : (
+          formatCurrency(row.extendedCost, { currencyCode })
+        )}
+      </div>
+
+      {/* Only for a line somebody typed — going back to the bill of materials is
+          otherwise not an available idea, and a reset on an untouched line would
+          suggest the BOM quantity is itself an override. */}
+      <Button
+        variant='ghost'
+        size='xs'
+        title='Use the bill of materials quantity'
+        className={row.overridden && !row.offBom ? undefined : 'invisible'}
+        disabled={disabled || !row.overridden || row.offBom}
+        onClick={() => onResetOverride(row.partId)}>
+        <RotateCcw />
+      </Button>
+    </div>
+  )
+}
+
+/**
+ * The parts that block the write.
+ *
+ * `completeBuild` refuses rather than posting these at zero: a zero-cost consume
+ * row understates COGS, drags every downstream average toward zero, and is
+ * frozen onto an `updatable: false` row forever. Naming them here is what makes
+ * that refusal actionable instead of a wall.
+ */
+function UnpricedWarning({
+  partIds,
+  rows,
+  producedPartId,
+}: {
+  partIds: string[]
+  rows: ComponentRow[]
+  producedPartId: string
+}) {
+  // The produced part is never one of the component rows, so it has no name to
+  // look up here — naming it by its role is more use than printing its id.
+  const nameFor = (id: string) => {
+    if (id === producedPartId) return 'the finished part this build produces'
+    return rows.find((row) => row.partId === id)?.partName ?? id
+  }
+  return (
+    <div className='rounded-md bg-destructive/10 p-2 text-destructive text-xs'>
+      <p className='font-medium'>Cannot post — these parts have no standard cost:</p>
+      <ul className='mt-1 space-y-0.5'>
+        {partIds.map((id) => (
+          <li key={id} className='truncate'>
+            {nameFor(id)}
+          </li>
+        ))}
+      </ul>
+      <p className='mt-1'>
+        Roll the standard cost from the part&apos;s Costing card first. A build is never posted at
+        zero cost.
+      </p>
+    </div>
+  )
+}
+
+/**
+ * The five numbers, with the arithmetic that produced them spelled out.
+ *
+ * The variance is the one a person actually reads on a build, and it is the last
+ * line for that reason. With no scrap and a standard that agrees with the bill
+ * of materials it comes out at zero exactly; anything else is the run telling
+ * you something.
+ */
+function CostSummary({
+  summary,
+  currencyCode,
+  quantityProduced,
+  quantityScrapped,
+  producedUnitCost,
+}: {
+  summary: {
+    materialCost: number
+    laborCost: number
+    overheadCost: number
+    producedValue: number
+    varianceAmount: number
+  }
+  currencyCode: string
+  quantityProduced: number
+  quantityScrapped: number
+  producedUnitCost: number | null
+}) {
+  const money = (value: number) => formatCurrency(value, { currencyCode })
+
+  return (
+    <div className='space-y-1 rounded-md border p-3 text-xs tabular-nums'>
+      <SummaryLine label='Material' value={money(summary.materialCost)} />
+      <SummaryLine label='Labour' value={money(summary.laborCost)} />
+      <SummaryLine label='Overhead' value={money(summary.overheadCost)} />
+      <SummaryLine
+        label='Produced value'
+        hint={
+          producedUnitCost == null
+            ? undefined
+            : `${formatQuantity(quantityProduced)} × ${money(producedUnitCost)}`
+        }
+        value={money(summary.producedValue)}
+        className='border-border/50 border-t pt-1'
+      />
+      <SummaryLine
+        label='Variance → 5090'
+        value={`${summary.varianceAmount > 0 ? '+' : ''}${money(summary.varianceAmount)}`}
+        className='border-border/50 border-t pt-1 font-medium'
+      />
+      {quantityScrapped > 0 && (
+        <p className='text-muted-foreground'>
+          Includes the whole standard cost of {formatQuantity(quantityScrapped)} scrapped{' '}
+          {quantityScrapped === 1 ? 'unit' : 'units'}, which is not absorbed into the units that
+          survived.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function SummaryLine({
+  label,
+  hint,
+  value,
+  className,
+}: {
+  label: string
+  hint?: string
+  value: string
+  className?: string
+}) {
+  return (
+    <div className={`flex items-baseline justify-between gap-2 ${className ?? ''}`}>
+      <span className='text-muted-foreground'>
+        {label}
+        {hint && <span className='ms-1 text-[10px]'>{hint}</span>}
+      </span>
+      <span>{value}</span>
+    </div>
+  )
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * What the field's placeholder says about where the default comes from.
+ *
+ * 🛑 A NULL rate absorbs zero on a completion, and the hint says "none declared"
+ * rather than "$0.00" — the two are numerically identical here but they are
+ * different claims, and a person who sees a confident zero has no reason to go
+ * and set the rate.
+ */
+function absorptionHint(rate: number | null | undefined, currencyCode: string): string {
+  if (rate == null) return 'No rate declared — absorbs nothing unless you enter an amount'
+  return `${formatCurrency(rate, { currencyCode })} per unit started`
+}
+
+/** Trim a quantity's trailing zeros — `10` not `10.00`, `2.5` kept. */
+function formatQuantity(value: number): string {
+  return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)))
+}

--- a/apps/web/src/components/manufacturing/builds/completion-input.test.ts
+++ b/apps/web/src/components/manufacturing/builds/completion-input.test.ts
@@ -1,0 +1,117 @@
+// apps/web/src/components/manufacturing/builds/completion-input.test.ts
+//
+// The completion form's pure half. Three things can go silently wrong here and
+// each has a test:
+//
+//  - a line overridden to ZERO is dropped by the server, so rebuilding the row
+//    list from the plan alone would take the row (and the input that produced
+//    it) off screen mid-edit with no way back;
+//  - an untouched line must send NOTHING, so it keeps tracking the bill of
+//    materials as the produced/scrapped quantities move;
+//  - an off-BOM row must stay distinguishable from a BOM row, because
+//    `qtyPerUnit: null` is what makes a floor substitution findable later.
+
+import type { BuildComponentLine } from '@auxx/lib/builds/client'
+import { describe, expect, it } from 'vitest'
+import { buildComponentOverrides, mergeComponentRows, rememberComponents } from './completion-input'
+
+function line(overrides: Partial<BuildComponentLine> & { partId: string }): BuildComponentLine {
+  return {
+    partName: `Part ${overrides.partId}`,
+    qtyPerUnit: 2,
+    quantityConsumed: 20,
+    unitCost: 500,
+    extendedCost: 10_000,
+    glAccount: '1310',
+    offBom: false,
+    ...overrides,
+  }
+}
+
+describe('rememberComponents', () => {
+  it('accumulates rather than replaces, so a zeroed line stays known', () => {
+    const first = rememberComponents([], [line({ partId: 'motor' }), line({ partId: 'tube' })])
+    // The next plan drops `tube` because it was overridden to zero.
+    const second = rememberComponents(first, [line({ partId: 'motor' })])
+
+    expect(second.map((entry) => entry.partId).sort()).toEqual(['motor', 'tube'])
+  })
+
+  it('refreshes what it already knows rather than duplicating it', () => {
+    const first = rememberComponents([], [line({ partId: 'motor', partName: 'Old name' })])
+    const second = rememberComponents(first, [line({ partId: 'motor', partName: 'Motor' })])
+
+    expect(second).toHaveLength(1)
+    expect(second[0]?.partName).toBe('Motor')
+  })
+})
+
+describe('mergeComponentRows', () => {
+  const known = rememberComponents(
+    [],
+    [
+      line({ partId: 'motor' }),
+      line({ partId: 'tube' }),
+      line({ partId: 'glue', offBom: true, qtyPerUnit: null }),
+    ]
+  )
+
+  it('keeps a dropped line visible, marked, and at the quantity that dropped it', () => {
+    const rows = mergeComponentRows(known, [line({ partId: 'motor' })], { tube: 0 })
+    const tube = rows.find((row) => row.partId === 'tube')
+
+    expect(tube?.dropped).toBe(true)
+    expect(tube?.quantityConsumed).toBe(0)
+    expect(tube?.extendedCost).toBeNull()
+    // Still overridden — the reset affordance has to stay reachable.
+    expect(tube?.overridden).toBe(true)
+  })
+
+  it('marks a typed line as overridden and an untouched one as not', () => {
+    const rows = mergeComponentRows(
+      known,
+      [line({ partId: 'motor', quantityConsumed: 17 }), line({ partId: 'tube' })],
+      { motor: 17 }
+    )
+
+    expect(rows.find((row) => row.partId === 'motor')?.overridden).toBe(true)
+    expect(rows.find((row) => row.partId === 'tube')?.overridden).toBe(false)
+  })
+
+  it('sorts bill-of-materials lines before off-BOM substitutions', () => {
+    const rows = mergeComponentRows(
+      known,
+      [
+        line({ partId: 'glue', offBom: true, qtyPerUnit: null }),
+        line({ partId: 'motor' }),
+        line({ partId: 'tube' }),
+      ],
+      {}
+    )
+
+    expect(rows.at(-1)?.partId).toBe('glue')
+    // 🛑 `qtyPerUnit: null` is the off-BOM marker, not missing data.
+    expect(rows.at(-1)?.qtyPerUnit).toBeNull()
+    expect(rows.at(-1)?.offBom).toBe(true)
+  })
+})
+
+describe('buildComponentOverrides', () => {
+  it('sends nothing at all when nothing was typed', () => {
+    // The server then derives every line from the bill of materials at the
+    // current quantities, which is what keeps the lines moving with "produced".
+    expect(buildComponentOverrides({})).toEqual([])
+  })
+
+  it('keeps a zero — it is how somebody says the part was not used', () => {
+    expect(buildComponentOverrides({ tube: 0 })).toEqual([{ partId: 'tube', quantityConsumed: 0 }])
+  })
+
+  it('drops a negative, which would silently reduce consumption below the BOM', () => {
+    expect(buildComponentOverrides({ tube: -4 })).toEqual([])
+  })
+
+  it('drops a non-finite quantity rather than sending NaN to the pricer', () => {
+    expect(buildComponentOverrides({ tube: Number.NaN })).toEqual([])
+  })
+})

--- a/apps/web/src/components/manufacturing/builds/completion-input.ts
+++ b/apps/web/src/components/manufacturing/builds/completion-input.ts
@@ -1,0 +1,138 @@
+// apps/web/src/components/manufacturing/builds/completion-input.ts
+
+// The completion form's pure half: what the browser sends, and what it renders.
+//
+// Split out of `complete-build-dialog.tsx` for the same reason `receipt-input.ts`
+// is split out of the receive popover — the preview under the form and the
+// payload the mutation sends must be derived from ONE description of the form's
+// state, not by two expressions that happen to agree today.
+//
+// 🛑 Nothing here computes money. The five cost numbers come from
+// `summarizeBuildCompletion` in `@auxx/lib/builds/client`, which is the same
+// function `completeBuild` runs on the server, so the variance on screen is the
+// variance that gets frozen.
+
+import type { BuildComponentLine } from '@auxx/lib/builds/client'
+
+/** One override the person actually typed, keyed by the consumed part. */
+export type OverrideMap = Readonly<Record<string, number>>
+
+/**
+ * A component row as the form renders it.
+ *
+ * Assembled by {@link mergeComponentRows} rather than read straight off the
+ * plan, because a line the person overrode to **zero** is dropped by the server
+ * (a zero-quantity movement is not written) and would otherwise vanish from the
+ * form mid-edit with no way to put it back.
+ */
+export interface ComponentRow {
+  partId: string
+  partName: string | null
+  /**
+   * The as-built bill-of-materials snapshot, per produced unit.
+   *
+   * 🛑 `null` is the **off-BOM marker**, not missing data: this part is not on
+   * the bill of materials at all, so its movement will carry
+   * `stock_movement_qty_per_unit = NULL` — a floor substitution made visible
+   * instead of silent (Gap C §4.1, §8.3).
+   */
+  qtyPerUnit: number | null
+  /** True when this row exists only because somebody added it. */
+  offBom: boolean
+  /** What the run will consume. `0` means the person zeroed it and no row is written. */
+  quantityConsumed: number
+  /** `round(unitCost x quantityConsumed)`, positive. `null` when the part has no standard. */
+  extendedCost: number | null
+  /** The component's frozen `part_standard_cost`. `null` = never rolled. */
+  unitCost: number | null
+  /** True when the person typed this quantity rather than taking the bill of materials'. */
+  overridden: boolean
+  /** True when the server dropped the line — a zeroed row, kept visible so it can be restored. */
+  dropped: boolean
+}
+
+/** What {@link mergeComponentRows} needs to keep a zeroed row on screen. */
+export interface KnownComponent {
+  partId: string
+  partName: string | null
+  qtyPerUnit: number | null
+  offBom: boolean
+}
+
+/**
+ * Every part the form has ever seen for this run, so a zeroed line stays visible.
+ *
+ * Accumulating rather than replacing is the whole point: `explodeBuildComponents`
+ * returns the lines it would WRITE, and a line overridden to zero is not one of
+ * them. Rebuilding the row list from each response alone would make the row
+ * disappear the moment somebody typed `0`, taking the input that produced it
+ * with it.
+ */
+export function rememberComponents(
+  known: readonly KnownComponent[],
+  lines: readonly BuildComponentLine[]
+): KnownComponent[] {
+  const merged = new Map(known.map((entry) => [entry.partId, entry]))
+  for (const line of lines) {
+    merged.set(line.partId, {
+      partId: line.partId,
+      partName: line.partName,
+      qtyPerUnit: line.qtyPerUnit,
+      offBom: line.offBom,
+    })
+  }
+  return [...merged.values()]
+}
+
+/**
+ * The rows to render: every remembered component, priced from the current plan.
+ *
+ * Bill-of-materials lines come first and off-BOM additions after, so a
+ * substitution reads as an addition to the recipe rather than as a peer of it.
+ */
+export function mergeComponentRows(
+  known: readonly KnownComponent[],
+  lines: readonly BuildComponentLine[],
+  overrides: OverrideMap
+): ComponentRow[] {
+  const byPart = new Map(lines.map((line) => [line.partId, line]))
+
+  const rows = known.map((entry): ComponentRow => {
+    const line = byPart.get(entry.partId)
+    const override = overrides[entry.partId]
+    return {
+      partId: entry.partId,
+      partName: line?.partName ?? entry.partName,
+      qtyPerUnit: line?.qtyPerUnit ?? entry.qtyPerUnit,
+      offBom: line?.offBom ?? entry.offBom,
+      quantityConsumed: line?.quantityConsumed ?? override ?? 0,
+      extendedCost: line?.extendedCost ?? null,
+      unitCost: line?.unitCost ?? null,
+      overridden: override != null,
+      dropped: !line,
+    }
+  })
+
+  return rows.sort((a, b) => Number(a.offBom) - Number(b.offBom))
+}
+
+/**
+ * The `componentOverrides` payload — one entry per quantity the person stated.
+ *
+ * 🛑 An untouched line sends **nothing**, and that is deliberate: the server then
+ * derives it from the bill of materials at the current produced/scrapped
+ * quantities, so editing "produced" still moves every line the floor did not
+ * comment on. An override is an absolute quantity for the WHOLE run, which is
+ * why it does not move with them.
+ *
+ * A zero is kept, not filtered: it is how somebody says "we did not use this at
+ * all", and the server drops the line rather than writing a zero-quantity
+ * movement.
+ */
+export function buildComponentOverrides(
+  overrides: OverrideMap
+): { partId: string; quantityConsumed: number }[] {
+  return Object.entries(overrides)
+    .filter(([, quantity]) => Number.isFinite(quantity) && quantity >= 0)
+    .map(([partId, quantityConsumed]) => ({ partId, quantityConsumed }))
+}

--- a/apps/web/src/components/manufacturing/builds/index.ts
+++ b/apps/web/src/components/manufacturing/builds/index.ts
@@ -1,0 +1,5 @@
+// apps/web/src/components/manufacturing/builds/index.ts
+
+export { BuildLedgerCard } from './build-ledger-card'
+export { BuildRunCard } from './build-run-card'
+export { CompleteBuildDialog } from './complete-build-dialog'

--- a/apps/web/src/server/api/routers/builds.ts
+++ b/apps/web/src/server/api/routers/builds.ts
@@ -1,6 +1,18 @@
 // apps/web/src/server/api/routers/builds.ts
 
-import { previewStandardCostRoll, rollStandardCost } from '@auxx/lib/builds'
+import {
+  cancelBuild,
+  completeBuild,
+  createBuild,
+  explodeBuildComponents,
+  getBuild,
+  listBuilds,
+  loadAbsorptionRates,
+  previewStandardCostRoll,
+  reverseBuild,
+  rollStandardCost,
+  startBuild,
+} from '@auxx/lib/builds'
 import { getCachedEntityDefId } from '@auxx/lib/cache'
 import { NotFoundError } from '@auxx/lib/errors'
 import { z } from 'zod'
@@ -19,23 +31,79 @@ const rollInput = z.object({
   effectiveAt: z.coerce.date().optional(),
 })
 
+/** Money is stored in integer minor units (cents) everywhere in this subsystem. */
+const minorUnits = z.number().int()
+
 /**
- * Standard cost — phase 1 of plans/products/build/01-build-plan.md.
+ * A completion quantity. `doublePrecision` columns, so fractions are legal.
  *
- * **Both procedures here are the permission gate for the lib call underneath.**
- * `@auxx/lib/builds` contains no access checks by design, so if a gate is
- * missing here it is missing everywhere.
+ * Bounded rather than merely positive: `quantityConsumed` multiplies into an
+ * extended cost and the movement rows are append-only, so an unbounded number
+ * here is a number nobody can take back. The cap is far above any real run.
+ */
+const runQuantity = z.number().finite().positive().max(1_000_000)
+
+/**
+ * What the floor actually consumed, where it differs from the bill of materials.
  *
- * | procedure          | gate                |
- * | ------------------ | ------------------- |
- * | `previewRoll`      | edit on `part`      |
- * | `roll`             | edit on `part`      |
+ * 🛑 **The one input that makes this a tool rather than a report.** Zero is
+ * allowed and means "we did not use this at all" — `planBuildComponents` drops
+ * the line rather than writing a zero-quantity movement. A part that is NOT on
+ * the bill of materials is an off-BOM substitution and its movement carries
+ * `qtyPerUnit: null`, which is the marker `stock_movement_qty_per_unit` exists
+ * to make visible instead of silent.
+ */
+const componentOverride = z.object({
+  partId: z.string().min(1),
+  /** Units consumed by the WHOLE run, not per produced unit. */
+  quantityConsumed: z.number().finite().nonnegative().max(1_000_000),
+})
+
+/** The two quantities and the overrides — everything that prices a run. */
+const completionShape = {
+  quantityProduced: runQuantity,
+  /**
+   * Units started and lost (B7). They consume material and produce NO movement:
+   * their whole standard cost lands in `varianceAmount` -> account 5090.
+   */
+  quantityScrapped: z.number().finite().nonnegative().max(1_000_000).optional(),
+  componentOverrides: z.array(componentOverride).max(500).optional(),
+}
+
+/**
+ * Builds — phase 1's standard cost and phase 2's build event
+ * (plans/products/build/01-build-plan.md).
  *
- * `assertEditEntity` on `part` on BOTH, not view on the preview: the preview
- * exists solely to be the first half of a write, it discloses the balance-sheet
- * effect of that write, and a reader who cannot roll has no use for it. Gating
- * it the same way is what makes the button the UI hides and the door the server
- * closes the same door.
+ * **Every procedure here is the permission gate for the lib call underneath.**
+ * `@auxx/lib/builds` contains no access checks by design — its module headers
+ * say so explicitly — so if a gate is missing here it is missing everywhere.
+ * The authority is per-definition, resolved from the org cache and asserted
+ * against the request's `CapabilitySet`:
+ *
+ * | procedure                              | gate                                      |
+ * | -------------------------------------- | ----------------------------------------- |
+ * | `previewRoll`, `roll`                  | edit on `part`                            |
+ * | `list`, `get`                          | view on `build`                           |
+ * | `create`, `start`, `cancel`            | edit on `build`                           |
+ * | `previewCompletion`, `complete`, `reverse` | edit on `build` AND edit on `stock_movement` |
+ *
+ * Three notes on why those, and not something coarser:
+ *
+ * 1. **`assertEditEntity`, never the coarser `assertWriteEntity`.** It is the
+ *    server mirror of the `canEditEntity(defId)` the cards run to decide whether
+ *    to render a button, so the button the UI hides and the door the server
+ *    closes are the same door.
+ * 2. **`complete` and `reverse` assert BOTH.** They are the only two paths in
+ *    this router that write a `stock_movement`, and `stock_movement` is where
+ *    the rest of manufacturing puts that authority — `purchasing.receiveStock`,
+ *    `adjustStock` and `reverseMovement` all gate on exactly that def. A person
+ *    who may raise a build but may not move stock must not be able to post a
+ *    ledger entry through the completion form, and gating on `build` alone would
+ *    let them.
+ * 3. **`previewCompletion` is gated as the write, not as a read.** Same argument
+ *    as `previewRoll`: the preview exists solely to be the first half of a
+ *    write, it discloses the standard costs that write will freeze, and a reader
+ *    who cannot complete has no use for it.
  *
  * Lib returns neverthrow `Result`s carrying `AuxxError`s; those are rethrown
  * as-is so `auxxErrorMiddleware` maps them. Wrapping one in a `TRPCError` would
@@ -57,7 +125,7 @@ export const buildsRouter = createTRPCRouter({
    */
   previewRoll: capabilityProcedure.input(rollInput).query(async ({ ctx, input }) => {
     const { organizationId } = ctx.session
-    ctx.capabilities.assertEditEntity(await requirePartDefId(organizationId))
+    ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'part'))
 
     const result = await previewStandardCostRoll(ctx.db, organizationId, {
       partIds: input.partIds,
@@ -77,7 +145,7 @@ export const buildsRouter = createTRPCRouter({
    */
   roll: capabilityProcedure.input(rollInput).mutation(async ({ ctx, input }) => {
     const { organizationId, userId } = ctx.session
-    ctx.capabilities.assertEditEntity(await requirePartDefId(organizationId))
+    ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'part'))
 
     const result = await rollStandardCost(ctx.db, organizationId, userId, {
       partIds: input.partIds,
@@ -86,18 +154,262 @@ export const buildsRouter = createTRPCRouter({
     if (result.isErr()) throw result.error
     return result.value
   }),
+
+  // ─── The build event (phase 2) ──────────────────────────────────────
+
+  /**
+   * Builds, newest first, with every cost already resolved.
+   *
+   * The generic record list is what the `/app/builds` page renders; this exists
+   * for the surfaces that need a build's NUMBERS rather than its field values —
+   * a part's builds, an order's builds, the run card's sibling lookups — without
+   * one field-value read per row.
+   */
+  list: capabilityProcedure
+    .input(
+      z.object({
+        status: z.enum(['planned', 'in_progress', 'completed', 'canceled']).optional(),
+        partId: z.string().min(1).optional(),
+        orderId: z.string().min(1).optional(),
+        source: z.enum(['manual', 'order']).optional(),
+        limit: z.number().int().min(1).max(200).optional(),
+        offset: z.number().int().min(0).optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      ctx.capabilities.assertViewEntity(await requireDefId(organizationId, 'build'))
+
+      const result = await listBuilds(ctx.db, organizationId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * One build, fully priced.
+   *
+   * `null` for a build that does not exist, is archived, or belongs to another
+   * org — the same three cases, deliberately indistinguishable, so this cannot
+   * be used to probe for ids.
+   */
+  get: capabilityProcedure
+    .input(z.object({ buildId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      ctx.capabilities.assertViewEntity(await requireDefId(organizationId, 'build'))
+
+      const result = await getBuild(ctx.db, organizationId, input.buildId)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Raise a run. Always lands `planned`, and writes NO stock movements (B2).
+   *
+   * Gated on `build` alone, not on `stock_movement`: that is the whole point of
+   * B2 — planning a run is not moving stock, so planning must not require the
+   * authority to move it.
+   */
+  create: capabilityProcedure
+    .input(
+      z.object({
+        partId: z.string().min(1),
+        quantityPlanned: runQuantity,
+        notes: z.string().max(2000).optional(),
+        orderId: z.string().min(1).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'build'))
+
+      // 🛑 `source` is NOT accepted from the browser. It is the discriminator
+      // that says whether a person raised this run or the order trigger did
+      // (products/12 AB7), and a browser claiming `order` would make an
+      // auto-build indistinguishable from a deliberate one. `createBuild`
+      // defaults it to `manual`; the trigger passes `order` server-side.
+      const result = await createBuild(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /** Move a `planned` run to `in_progress`. Writes no movements. */
+  start: capabilityProcedure
+    .input(
+      z.object({
+        buildId: z.string().min(1),
+        /** When work actually began, which is not when it was keyed. Defaults to now. */
+        startedAt: z.coerce.date().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'build'))
+
+      const result = await startBuild(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Abandon a run that has not been completed. Writes no movements.
+   *
+   * The correction for a run that never happened. A run that DID happen and was
+   * wrong is corrected by `reverse`, never by cancelling — a completed build has
+   * an append-only ledger behind it and cancelling would leave it standing.
+   */
+  cancel: capabilityProcedure
+    .input(
+      z.object({
+        buildId: z.string().min(1),
+        reason: z.string().max(2000).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'build'))
+
+      const result = await cancelBuild(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * What a completion WOULD consume, at what cost, without consuming it.
+   *
+   * 🛑 **The completion form is this query.** `completeBuild` is irreversible
+   * except by a reversing build (B6) and refuses a second attempt (B8), so it
+   * must never be a button that just fires: this returns the priced component
+   * lines the run will consume, the produced part's frozen standard, and every
+   * part that has no standard at all — before anything is written.
+   *
+   * It re-runs on every override edit, so the numbers under the form are always
+   * the numbers the write will freeze. The two absorption rates ride along
+   * because the form has to PREFILL the labour and overhead defaults, and a
+   * second round trip for two org settings would leave the prefill arriving
+   * after the person had already typed over it.
+   *
+   * A `.query()` because it writes nothing at all.
+   */
+  previewCompletion: capabilityProcedure
+    .input(z.object({ partId: z.string().min(1), ...completionShape }))
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await assertCanPostBuildLedger(ctx)
+
+      const [plan, rates] = await Promise.all([
+        explodeBuildComponents(ctx.db, organizationId, input),
+        loadAbsorptionRates(organizationId),
+      ])
+      if (plan.isErr()) throw plan.error
+      return { plan: plan.value, rates }
+    }),
+
+  /**
+   * Finish a run and write the ledger — the ONE procedure here that writes a
+   * stock movement.
+   *
+   * One `build_consume` per component at its frozen `part_standard_cost`, one
+   * `build_produce` for the good units, and the five cost fields stamped onto
+   * the build. It refuses outright if any component has no standard: a
+   * zero-cost consume row understates COGS forever on an `updatable: false` row.
+   *
+   * `laborCost` / `overheadCost` are OPTIONAL and the browser may state them.
+   * Omitted, the server absorbs `rate x unitsStarted` from the two
+   * `manufacturing.*` settings. There is no other authority for what a specific
+   * run absorbed, so the form is entitled to override the default — the same
+   * call `adjustStock` makes about a unit cost nobody else can supply.
+   */
+  complete: capabilityProcedure
+    .input(
+      z.object({
+        buildId: z.string().min(1),
+        ...completionShape,
+        /** Absorbed direct labour for the WHOLE run, minor units. */
+        laborCost: minorUnits.nonnegative().optional(),
+        /** Applied overhead for the whole run, minor units. */
+        overheadCost: minorUnits.nonnegative().optional(),
+        /** THE accounting date, stamped on the build and every movement. Defaults to now. */
+        completedAt: z.coerce.date().optional(),
+        notes: z.string().max(2000).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      await assertCanPostBuildLedger(ctx)
+
+      const result = await completeBuild(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Undo a completed build by writing its negation (B6).
+   *
+   * Not an edit and not a delete. A completed build is never edited: every
+   * `stock_movement` field is `updatable: false` on purpose, so a correction is
+   * a second build whose movements carry the ORIGINAL's frozen costs. Re-pricing
+   * a reversal at today's standard nets a build and its undo to a non-zero
+   * amount of inventory value out of nothing.
+   *
+   * 🛑 **The reversing build is written on the quiet lane, so it emits no
+   * `record:created` frame** and no open list learns about it on its own. The
+   * caller invalidates — see `build-run-card.tsx`.
+   */
+  reverse: capabilityProcedure
+    .input(
+      z.object({
+        buildId: z.string().min(1),
+        /** Why it is being undone. Stamped on the reversing build; the original is never touched. */
+        reason: z.string().max(2000).optional(),
+        /** The reversal's accounting date. Defaults to now. */
+        occurredAt: z.coerce.date().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      await assertCanPostBuildLedger(ctx)
+
+      const result = await reverseBuild(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
 })
 
 /**
- * Resolve the `part` definition from the org cache, or refuse.
+ * The gate on every path that writes a build's ledger.
+ *
+ * Both halves, in one place so the three procedures cannot drift: EDIT on
+ * `build` because the run's own status and cost fields are rewritten, and EDIT
+ * on `stock_movement` because consume and produce rows are appended. The rest of
+ * manufacturing puts movement authority on `stock_movement` — `receiveStock`,
+ * `adjustStock` and `reverseMovement` all assert exactly that def — and a build
+ * completion is a stock movement by any other name.
+ */
+async function assertCanPostBuildLedger(ctx: {
+  session: { organizationId: string }
+  capabilities: { assertEditEntity: (defId: string) => void }
+}): Promise<void> {
+  const { organizationId } = ctx.session
+  const [buildDefId, movementDefId] = await Promise.all([
+    requireDefId(organizationId, 'build'),
+    requireDefId(organizationId, 'stock_movement'),
+  ])
+  ctx.capabilities.assertEditEntity(buildDefId)
+  ctx.capabilities.assertEditEntity(movementDefId)
+}
+
+/**
+ * Resolve an entity definition id from the org cache, or refuse.
  *
  * A missing def is a 404 rather than a 403: the member is not being denied
- * anything, the organization simply has no parts yet.
+ * anything, the organization simply has no such records yet (entity migration
+ * 109 has not run for it).
  */
-async function requirePartDefId(organizationId: string): Promise<string> {
-  const defId = await getCachedEntityDefId(organizationId, 'part')
+async function requireDefId(organizationId: string, entityType: string): Promise<string> {
+  const defId = await getCachedEntityDefId(organizationId, entityType)
   if (!defId) {
-    throw new NotFoundError('This organization has no part records yet.')
+    throw new NotFoundError(`This organization has no ${entityType} records yet.`)
   }
   return defId
 }

--- a/apps/web/src/server/api/routers/ticketSequence.ts
+++ b/apps/web/src/server/api/routers/ticketSequence.ts
@@ -16,6 +16,7 @@ const scopeSchema = z
     'order',
     'purchase_order',
     'vendor_bill',
+    'build',
   ])
   .default('ticket')
 

--- a/packages/lib/src/builds/__tests__/build-client.test.ts
+++ b/packages/lib/src/builds/__tests__/build-client.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  absorbedRunCost,
   buildVariance,
   canCancelBuild,
   canCompleteBuild,
@@ -14,6 +15,7 @@ import {
   canStartBuild,
   componentConsumption,
   resolveBuildStatus,
+  summarizeBuildCompletion,
   unitsStarted,
 } from '../client'
 
@@ -99,5 +101,78 @@ describe('the run arithmetic', () => {
         })
       ).toBe(scrapped * standardCost)
     }
+  })
+})
+
+describe('absorbedRunCost', () => {
+  it('prefers what the completion form stated over the org rate', () => {
+    expect(absorbedRunCost(4200, 500, 12)).toBe(4200)
+  })
+
+  it('absorbs the rate over the units STARTED, not the units produced', () => {
+    // The choice that makes the variance identity above close.
+    expect(absorbedRunCost(undefined, 500, 12)).toBe(6000)
+  })
+
+  it('absorbs nothing when no rate is declared', () => {
+    // 🛑 Not the same decision `absorbedRate` makes for the part standard, where
+    // NULL must survive into storage. Here the field records what a specific run
+    // absorbed, and a run under no declared rate absorbed nothing — a fact.
+    expect(absorbedRunCost(undefined, null, 12)).toBe(0)
+    expect(absorbedRunCost(null, Number.NaN, 12)).toBe(0)
+  })
+
+  it('rounds to whole minor units', () => {
+    expect(absorbedRunCost(undefined, 33.4, 3)).toBe(100)
+    expect(absorbedRunCost(12.6, null, 3)).toBe(13)
+  })
+})
+
+describe('summarizeBuildCompletion', () => {
+  const rates = { laborCostPerUnit: 500, overheadCostPerUnit: 200 }
+
+  it('sums the component lines and values the output at its own standard', () => {
+    const summary = summarizeBuildCompletion({
+      components: [{ extendedCost: 40_196 }, { extendedCost: 19_020 }],
+      producedUnitCost: 6622,
+      quantityProduced: 10,
+      quantityScrapped: 0,
+      rates,
+    })
+
+    expect(summary.materialCost).toBe(59_216)
+    expect(summary.laborCost).toBe(5_000)
+    expect(summary.overheadCost).toBe(2_000)
+    expect(summary.producedValue).toBe(66_220)
+    expect(summary.varianceAmount).toBe(59_216 + 5_000 + 2_000 - 66_220)
+  })
+
+  it('books the scrapped units whole standard cost to the variance (B7)', () => {
+    // 10 good + 2 scrapped, a bill of materials that agrees with the standard.
+    const materialPerUnit = 7_322
+    const standardCost = 8_022
+    const summary = summarizeBuildCompletion({
+      components: [{ extendedCost: materialPerUnit * 12 }],
+      producedUnitCost: standardCost,
+      quantityProduced: 10,
+      quantityScrapped: 2,
+      rates,
+    })
+
+    expect(summary.varianceAmount).toBe(2 * standardCost)
+  })
+
+  it('treats a null extended cost as contributing nothing, never as a guess', () => {
+    const summary = summarizeBuildCompletion({
+      components: [{ extendedCost: 1_000 }, { extendedCost: null }],
+      producedUnitCost: 1_000,
+      quantityProduced: 1,
+      quantityScrapped: 0,
+      rates: { laborCostPerUnit: null, overheadCostPerUnit: null },
+    })
+
+    // The caller refuses to post such a plan anyway — `missingStandardPartIds`
+    // is non-empty — so this only pins that the preview does not invent a cost.
+    expect(summary.materialCost).toBe(1_000)
   })
 })

--- a/packages/lib/src/builds/client.ts
+++ b/packages/lib/src/builds/client.ts
@@ -210,3 +210,120 @@ export function buildVariance(parts: {
  * carried so the number and its destination stay in one place.
  */
 export const BUILD_VARIANCE_ACCOUNT = '5090'
+
+/**
+ * The absorbed amount for one rate over the WHOLE run, in whole minor units.
+ *
+ * An explicit input from the completion form wins. Otherwise it is the declared
+ * rate times the units STARTED — not the units produced.
+ *
+ * 🛑 The choice of `unitsStarted` is what makes the variance arithmetic close.
+ * With `s` units scrapped, material, labour and overhead are all absorbed on
+ * `produced + s` while `producedValue` values only `produced`, so the variance
+ * comes out at exactly `s x standardCost`: the scrapped units' whole standard
+ * cost, to 5090, which is what B7 asks for. Absorbing labour on the survivors
+ * instead would net the scrap loss down to material alone and understate it.
+ *
+ * An UNDECLARED rate absorbs `0` here, and that is not the same decision
+ * {@link absorbedRate} makes for the part standard. There, a NULL must survive
+ * into storage because it is the difference between "no rate declared" and "a
+ * declared rate of zero" on a number that gets rolled up and frozen forever.
+ * Here the field records what a specific run actually absorbed, and a run under
+ * no declared rate absorbed nothing — which is a fact, not an absence. It also
+ * keeps the arithmetic consistent: with no rate the part's standard carries no
+ * labour either, so both sides of the variance stay zero.
+ */
+export function absorbedRunCost(
+  explicit: number | null | undefined,
+  rate: number | null | undefined,
+  started: number
+): number {
+  if (explicit != null && Number.isFinite(explicit)) return roundMinorUnits(explicit)
+  if (rate == null || !Number.isFinite(rate)) return 0
+  return roundMinorUnits(rate * started)
+}
+
+/** The five numbers a completion freezes onto the build, all in whole minor units. */
+export interface BuildCompletionSummary {
+  /** Sum of the consumed lines' extended standard cost, POSITIVE. */
+  materialCost: number
+  laborCost: number
+  overheadCost: number
+  /** `round(quantityProduced x the produced part's standard cost)`. */
+  producedValue: number
+  /** `(material + labour + overhead) - producedValue` -> account 5090. */
+  varianceAmount: number
+}
+
+/** Everything {@link summarizeBuildCompletion} needs, and nothing that touches a database. */
+export interface BuildCompletionInputs {
+  /** The priced component lines, exactly as `explodeBuildComponents` returns them. */
+  components: readonly { extendedCost: number | null }[]
+  /** The produced part's frozen standard cost. */
+  producedUnitCost: number
+  quantityProduced: number
+  quantityScrapped: number
+  /** An explicit absorbed amount for the whole run, or absent to use the rate. */
+  laborCost?: number | null
+  overheadCost?: number | null
+  /** The two `manufacturing.*` org rates, per assembled unit. `null` absorbs nothing. */
+  rates: { laborCostPerUnit: number | null; overheadCostPerUnit: number | null }
+}
+
+/**
+ * What a completion costs, from inputs a browser already holds.
+ *
+ * 🛑 **This is the ONE definition of the arithmetic, and `completeBuild` calls
+ * it too.** The completion form has to show the variance before the write —
+ * `completeBuild` is irreversible except by a reversing build (B6) and refuses a
+ * second completion (B8), so a person must see the number they are committing
+ * to. Two implementations of that number, one for the preview and one for the
+ * write, is exactly the drift this codebase pays for elsewhere; the preview is
+ * trustworthy only because it is literally the same function.
+ *
+ * Every input is already rounded to whole minor units by the reads that produced
+ * it, and the two derived terms round again on the way out.
+ */
+export function summarizeBuildCompletion(inputs: BuildCompletionInputs): BuildCompletionSummary {
+  const started = unitsStarted(inputs.quantityProduced, inputs.quantityScrapped)
+
+  let materialCost = 0
+  for (const line of inputs.components) materialCost += line.extendedCost ?? 0
+
+  const laborCost = absorbedRunCost(inputs.laborCost, inputs.rates.laborCostPerUnit, started)
+  const overheadCost = absorbedRunCost(
+    inputs.overheadCost,
+    inputs.rates.overheadCostPerUnit,
+    started
+  )
+  // `round(unitCost x quantity)`, never a sum of rounded units — the same rule,
+  // and the same reason, as `computeExtendedCost` in the receiving module.
+  const producedValue = roundMinorUnits(inputs.producedUnitCost * inputs.quantityProduced)
+
+  return {
+    materialCost,
+    laborCost,
+    overheadCost,
+    producedValue,
+    varianceAmount: buildVariance({ materialCost, laborCost, overheadCost, producedValue }),
+  }
+}
+
+// ─── Client-safe re-exports of the build event's data shapes ───────────
+
+/**
+ * The four shapes a browser needs to render a completion form, re-exported so
+ * `@auxx/lib/builds/client` is the one door client code goes through.
+ *
+ * 🛑 Client code must NEVER import from `@auxx/lib/builds` — that barrel pulls in
+ * the Drizzle handlers, the realtime service and the crud stack, and a browser
+ * bundle that reaches any of them fails the build. These are pure data
+ * interfaces, `types.ts` imports nothing but this file, and `export type` is
+ * erased entirely at build time, so this costs a browser bundle nothing at all.
+ */
+export type {
+  AbsorptionRates,
+  BuildComponentLine,
+  BuildComponentOverride,
+  BuildComponentPlan,
+} from './types'

--- a/packages/lib/src/builds/complete-build.ts
+++ b/packages/lib/src/builds/complete-build.ts
@@ -54,7 +54,7 @@ import {
   getRealtimeService,
   publishFieldValueUpdates,
 } from '../realtime'
-import { computeExtendedCost, resolveGlAccountForPartKind } from '../receiving/client'
+import { resolveGlAccountForPartKind } from '../receiving/client'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import {
   BuildStatus,
@@ -72,7 +72,7 @@ import {
   requireBuildFieldContext,
   requireBuildMovementFieldContext,
 } from './build-queries'
-import { buildVariance, canCompleteBuild, roundMinorUnits, unitsStarted } from './client'
+import { canCompleteBuild, summarizeBuildCompletion } from './client'
 import { guard } from './guard'
 import { loadAbsorptionRates } from './standard-cost-queries'
 import type {
@@ -220,9 +220,6 @@ async function writeCompletion(
   })
   assertPlanIsPostable(plan)
 
-  const started = unitsStarted(quantityProduced, quantityScrapped)
-  const laborCost = absorbed(input.laborCost, rates.laborCostPerUnit, started)
-  const overheadCost = absorbed(input.overheadCost, rates.overheadCostPerUnit, started)
   // Non-null by construction: `assertPlanIsPostable` refuses a plan whose
   // produced part has no standard, which is the same "never post a zero cost"
   // rule seen from the other side. Re-checked rather than cast, because a cast
@@ -233,17 +230,22 @@ async function writeCompletion(
       'Refusing to complete a build at zero cost: roll the standard cost for the produced part first'
     )
   }
-  const producedValue = computeExtendedCost(producedUnitCost, quantityProduced)
 
-  let materialCost = 0
-  for (const line of plan.components) materialCost += line.extendedCost ?? 0
-
-  const varianceAmount = buildVariance({
-    materialCost,
-    laborCost,
-    overheadCost,
-    producedValue,
-  })
+  // 🛑 The SAME function the completion form runs to preview these five numbers
+  // (`client.ts`). The form has to show the variance before the write, because a
+  // completion is irreversible except by a reversing build (B6) and refuses a
+  // second attempt (B8) — and a preview computed by a second implementation is
+  // only accidentally the number that gets stored.
+  const { materialCost, laborCost, overheadCost, producedValue, varianceAmount } =
+    summarizeBuildCompletion({
+      components: plan.components,
+      producedUnitCost,
+      quantityProduced,
+      quantityScrapped,
+      laborCost: input.laborCost,
+      overheadCost: input.overheadCost,
+      rates,
+    })
 
   const producedKinds = await readPartKinds(txDb, organizationId, [build.partId])
   const crud = new UnifiedCrudHandler(organizationId, userId, txDb, undefined, {
@@ -380,34 +382,6 @@ function assertPlanIsPostable(plan: BuildComponentPlan): void {
       { partIds: plan.missingStandardPartIds }
     )
   }
-}
-
-/**
- * The absorbed amount for one rate over the whole run, in whole minor units.
- *
- * An explicit input from the completion form wins. Otherwise it is the declared
- * rate times the units STARTED — not the units produced.
- *
- * 🛑 The choice of `unitsStarted` is what makes the variance arithmetic close.
- * With `s` units scrapped, material, labour and overhead are all absorbed on
- * `produced + s` while `producedValue` values only `produced`, so the variance
- * comes out at exactly `s x standardCost`: the scrapped units' whole standard
- * cost, to 5090, which is what B7 asks for. Absorbing labour on the survivors
- * instead would net the scrap loss down to material alone and understate it.
- *
- * An UNDECLARED rate absorbs `0` here, and that is not the same decision
- * {@link absorbedRate} makes for the part standard. There, a NULL must survive
- * into storage because it is the difference between "no rate declared" and "a
- * declared rate of zero" on a number that gets rolled up and frozen forever.
- * Here the field records what a specific run actually absorbed, and a run under
- * no declared rate absorbed nothing — which is a fact, not an absence. It also
- * keeps the arithmetic consistent: with no rate the part's standard carries no
- * labour either, so both sides of the variance stay zero.
- */
-function absorbed(explicit: number | undefined, rate: number | null, started: number): number {
-  if (explicit != null && Number.isFinite(explicit)) return roundMinorUnits(explicit)
-  if (rate == null || !Number.isFinite(rate)) return 0
-  return roundMinorUnits(rate * started)
 }
 
 /**

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -23,9 +23,12 @@ export {
 } from './build-queries'
 export {
   absorbedRate,
+  absorbedRunCost,
   absorbsConversionCost,
   BUILD_STATUS_LABELS,
   BUILD_VARIANCE_ACCOUNT,
+  type BuildCompletionInputs,
+  type BuildCompletionSummary,
   type BuildStatusValue,
   buildVariance,
   canCancelBuild,
@@ -38,6 +41,7 @@ export {
   resolvePartKind,
   roundMinorUnits,
   standardCostDrift,
+  summarizeBuildCompletion,
   unitsStarted,
 } from './client'
 export { completeBuild } from './complete-build'

--- a/packages/lib/src/records/__tests__/record-numbering.test.ts
+++ b/packages/lib/src/records/__tests__/record-numbering.test.ts
@@ -1,0 +1,101 @@
+// packages/lib/src/records/__tests__/record-numbering.test.ts
+//
+// `SCOPE_DEFAULTS` is where a record kind's number FORMAT is decided, and the
+// hook tests above it can only ever assert the scope string they were handed —
+// they mock `recordNumbering` wholesale. So the claim "a build is numbered
+// `B-0001`" (plans/products/build/01-build-plan.md section 1.1) is only actually
+// pinned here: the prefix comes from this table, the `-` and the four digits come
+// from the RecordSequence column defaults, and nothing asserts the three compose
+// unless something exercises the real function.
+
+import { describe, expect, it, vi } from 'vitest'
+
+interface FakeRow {
+  organizationId: string
+  scope: string
+  currentNumber: number
+  prefix: string | null
+  paddingLength: number
+  usePrefix: boolean
+  useDateInPrefix: boolean
+  useSuffix: boolean
+  suffix: string | null
+  separator: string
+}
+
+const h = vi.hoisted(() => ({
+  rows: new Map<string, Record<string, unknown>>(),
+  // The key the INSERT named. `recordNumbering.create` always issues its UPDATE
+  // against the same organization+scope as the INSERT immediately before it in the
+  // same call, so pairing them this way lets the fake answer `where(...)` without
+  // interpreting a Drizzle condition tree.
+  target: { key: '' },
+}))
+
+vi.mock('@auxx/database', () => ({
+  schema: {
+    RecordSequence: {
+      organizationId: 'organizationId',
+      scope: 'scope',
+      currentNumber: 'currentNumber',
+    },
+  },
+  database: {
+    insert: () => ({
+      values: (row: { organizationId: string; scope: string }) => ({
+        onConflictDoNothing: async () => {
+          const key = `${row.organizationId}:${row.scope}`
+          h.target.key = key
+          if (h.rows.has(key)) return
+          // The columns `create` does NOT name, filled from the table defaults in
+          // packages/database/src/db/schema/record-sequence.ts — `separator` defaults
+          // to '-', which is what makes the number `B-0001` rather than `B0001`.
+          h.rows.set(key, {
+            useDateInPrefix: false,
+            useSuffix: false,
+            suffix: null,
+            separator: '-',
+            ...row,
+          })
+        },
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => ({
+          returning: async () => {
+            const row = h.rows.get(h.target.key) as FakeRow | undefined
+            if (!row) return []
+            row.currentNumber += 1
+            return [row]
+          },
+        }),
+      }),
+    }),
+  },
+}))
+
+const { recordNumbering } = await import('../record-numbering')
+
+describe('recordNumbering — the `build` scope', () => {
+  it('numbers the first build B-0001 and the next B-0002', async () => {
+    const first = await recordNumbering.create('org-1', 'build')
+    expect(first).toEqual({ recordNumber: 'B-0001', sequenceNumber: 1 })
+
+    const second = await recordNumbering.create('org-1', 'build')
+    expect(second).toEqual({ recordNumber: 'B-0002', sequenceNumber: 2 })
+  })
+
+  it('counts separately from the vendor bill, whose prefix it would otherwise be read as', async () => {
+    const bill = await recordNumbering.create('org-1', 'vendor_bill')
+    expect(bill.recordNumber).toBe('BILL-0001')
+
+    const build = await recordNumbering.create('org-1', 'build')
+    expect(build.recordNumber).toBe('B-0003')
+  })
+
+  it('counts separately per organization', async () => {
+    const other = await recordNumbering.create('org-2', 'build')
+    expect(other).toEqual({ recordNumber: 'B-0001', sequenceNumber: 1 })
+  })
+})

--- a/packages/lib/src/records/record-numbering.ts
+++ b/packages/lib/src/records/record-numbering.ts
@@ -14,6 +14,7 @@ export type SequenceScope =
   | 'order'
   | 'purchase_order'
   | 'vendor_bill'
+  | 'build'
 
 const SCOPE_DEFAULTS: Record<SequenceScope, { prefix: string }> = {
   ticket: { prefix: 'TKT' },
@@ -25,6 +26,11 @@ const SCOPE_DEFAULTS: Record<SequenceScope, { prefix: string }> = {
   purchase_order: { prefix: 'PO' },
   // Ours, beside the vendor's own invoice number - two different documents.
   vendor_bill: { prefix: 'BILL' },
+  // One letter, unlike every other scope here: the build plan fixes the format at
+  // `B-0001` (plans/products/build/01-build-plan.md section 1.1). Anything longer
+  // starting with a B would read as the vendor bill's `BILL-0001` at a glance, and
+  // these two numbers sit side by side on the same cost trail.
+  build: { prefix: 'B' },
 }
 
 /** Format a record number from a sequence record */

--- a/packages/lib/src/resources/hooks/__tests__/build-hooks.test.ts
+++ b/packages/lib/src/resources/hooks/__tests__/build-hooks.test.ts
@@ -1,0 +1,93 @@
+// packages/lib/src/resources/hooks/__tests__/build-hooks.test.ts
+//
+// The same failure `order-hooks.test.ts` and `purchasing-hooks.test.ts` pin, one
+// entity later: `build_number` was declared creatable:false / updatable:false with
+// "the hook is the ONLY writer" in its field registry, and no hook and no scope
+// existed — so every build was created with a NULL number that no human could fill,
+// and `build` declares `primaryDisplayField: 'number'`, so it rendered nameless.
+// `HOOKS_BY_ENTITY_TYPE` returns `{}` for an unregistered entityType rather than
+// throwing, so only a registration assertion catches it.
+
+import { describe, expect, it, vi } from 'vitest'
+import type { SystemHookContext } from '../types'
+
+vi.mock('../../../records/record-numbering', () => ({
+  recordNumbering: { create: vi.fn() },
+}))
+
+const { recordNumbering } = await import('../../../records/record-numbering')
+const createMock = vi.mocked(recordNumbering.create)
+
+const { BUILD_HOOKS } = await import('../build-hooks')
+const { getSystemHooks, getHooksForAttribute } = await import('../system-hooks')
+
+const FIELD_ID = 'field-build-number-1'
+
+function buildContext(overrides: Partial<SystemHookContext> = {}): SystemHookContext {
+  return {
+    operation: 'create',
+    entityDef: { id: 'def-build', entityType: 'build' },
+    field: { id: FIELD_ID, type: 'TEXT', systemAttribute: 'build_number' },
+    values: {},
+    organizationId: 'org-1',
+    userId: 'user-1',
+    allFields: [],
+    ...overrides,
+  } as unknown as SystemHookContext
+}
+
+describe('build_number issuance', () => {
+  it('stamps a RecordSequence number on create, on the `build` scope', async () => {
+    createMock.mockClear()
+    createMock.mockResolvedValue({ recordNumber: 'B-0001', sequenceNumber: 1 })
+
+    const values = await BUILD_HOOKS.build_number![0]!(buildContext())
+
+    expect(createMock).toHaveBeenCalledWith('org-1', 'build')
+    expect(values[FIELD_ID]).toBe('B-0001')
+  })
+
+  it('gives the next build the next number', async () => {
+    createMock.mockClear()
+    createMock.mockResolvedValue({ recordNumber: 'B-0002', sequenceNumber: 2 })
+
+    const values = await BUILD_HOOKS.build_number![0]!(buildContext())
+
+    expect(values[FIELD_ID]).toBe('B-0002')
+  })
+
+  it('does not re-issue on update — the number is stable for the record’s life', async () => {
+    createMock.mockClear()
+
+    const values = await BUILD_HOOKS.build_number![0]!(
+      buildContext({ operation: 'update', values: { other: 1 } })
+    )
+
+    expect(createMock).not.toHaveBeenCalled()
+    expect(values).toEqual({ other: 1 })
+  })
+
+  it('leaves the rest of the write untouched', async () => {
+    createMock.mockClear()
+    createMock.mockResolvedValue({ recordNumber: 'B-0003', sequenceNumber: 3 })
+
+    const values = await BUILD_HOOKS.build_number![0]!(
+      buildContext({ values: { build_quantity_planned: 5 } })
+    )
+
+    expect(values).toEqual({ build_quantity_planned: 5, [FIELD_ID]: 'B-0003' })
+  })
+})
+
+describe('build hook registration', () => {
+  // The miss that would ship numberless builds: HOOKS_BY_ENTITY_TYPE is keyed by
+  // EntityDefinition.entityType, and an absent key returns {} silently.
+  it('is reachable through the entity-type registry, not just the module export', () => {
+    expect(getSystemHooks('build')).toBe(BUILD_HOOKS)
+    expect(getHooksForAttribute('build', 'build_number')).toHaveLength(1)
+  })
+
+  it('registers the number hook and nothing else', () => {
+    expect(Object.keys(BUILD_HOOKS)).toEqual(['build_number'])
+  })
+})

--- a/packages/lib/src/resources/hooks/build-hooks.ts
+++ b/packages/lib/src/resources/hooks/build-hooks.ts
@@ -1,0 +1,48 @@
+// packages/lib/src/resources/hooks/build-hooks.ts
+
+import { recordNumbering } from '../../records/record-numbering'
+import type { SystemHook, SystemHookRegistry } from './types'
+
+/**
+ * Auto-generate the build number on create. Mirrors autoGenerateOrderNumber /
+ * autoGeneratePurchaseOrderNumber.
+ *
+ * `build_number` has creatable:false/updatable:false and `build` declares
+ * `primaryDisplayField: 'number'`, so this hook is the ONLY writer and without it
+ * every build renders nameless (plans/products/build/01-build-plan.md section 1.1 —
+ * `B-0001`, RecordSequence scope `build`).
+ *
+ * 🛑 Issued exactly once per build, and that rests on three things together:
+ * - `operation !== 'create'` returns early, so an update never re-enters the counter.
+ *   `UnifiedCrudHandler.runPreHooks` runs every registered hook on CREATE regardless of
+ *   whether the attribute is in `values`, but on UPDATE only when it is — this guard is
+ *   what covers the create-then-update case where a caller does pass the attribute.
+ * - `createBuild` performs exactly one `UnifiedCrudHandler.create` per build, so the
+ *   create door is entered once.
+ * - `recordNumbering.create` increments and reads back in a single UPDATE ... RETURNING,
+ *   so two concurrent creates cannot be handed the same number.
+ */
+const autoGenerateBuildNumber: SystemHook = async ({
+  operation,
+  field,
+  values,
+  organizationId,
+}) => {
+  if (operation !== 'create') return values
+  const { recordNumber } = await recordNumbering.create(organizationId, 'build')
+  return { ...values, [field.id]: recordNumber }
+}
+
+/**
+ * `build` system hooks: the RecordSequence number on create, and nothing else.
+ *
+ * No lifecycle guard for `build_status`. Unlike `quote_status` / `invoice_status` /
+ * `purchase_order_status`, the build lifecycle is enforced inside the commands that own
+ * it — `startBuild` / `completeBuild` / `cancelBuild` all go through `assertBuildStatus`
+ * in `builds/build-queries.ts`. That is a different door from this registry, so a raw
+ * `record.update` is not walled the way those three attributes are; putting that wall up
+ * is its own change, not a side effect of giving the number a writer.
+ */
+export const BUILD_HOOKS: SystemHookRegistry = {
+  build_number: [autoGenerateBuildNumber],
+}

--- a/packages/lib/src/resources/hooks/index.ts
+++ b/packages/lib/src/resources/hooks/index.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/resources/hooks/index.ts
 
+export { BUILD_HOOKS } from './build-hooks'
 export { autoSetCreatedBy, COMMON_HOOKS } from './common-hooks'
 export { CONTACT_HOOKS } from './contact-hooks'
 export { INVOICE_HOOKS } from './invoice-hooks'

--- a/packages/lib/src/resources/hooks/system-hooks.ts
+++ b/packages/lib/src/resources/hooks/system-hooks.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/resources/hooks/system-hooks.ts
 
+import { BUILD_HOOKS } from './build-hooks'
 import { COMMON_HOOKS } from './common-hooks'
 import { CONTACT_HOOKS } from './contact-hooks'
 import { INVOICE_HOOKS } from './invoice-hooks'
@@ -34,6 +35,7 @@ const HOOKS_BY_ENTITY_TYPE: Record<string, SystemHookRegistry> = {
   line_item: LINE_ITEM_HOOKS,
   purchase_order: PURCHASE_ORDER_HOOKS,
   vendor_bill: VENDOR_BILL_HOOKS,
+  build: BUILD_HOOKS,
 }
 
 /**

--- a/packages/lib/src/resources/registry/detail-view-config-types.ts
+++ b/packages/lib/src/resources/registry/detail-view-config-types.ts
@@ -90,6 +90,7 @@ export type DetailViewEntityType =
   | 'work_order'
   | 'order'
   | 'purchase_order'
+  | 'build'
 
 /** Registry type mapping entity types to their configurations */
 export type DetailViewConfigRegistry = Record<DetailViewEntityType, DetailViewConfig>

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -269,6 +269,34 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     ],
   },
 
+  build: {
+    entityType: 'build',
+    // No entity-specific main tab. A build is not a document with lines you
+    // edit — it is raised, worked, and completed once (B8), so everything worth
+    // reading about a run fits the two sidebar cards below. The two universal
+    // tabs are the whole main area, exactly as the generic `entity` config.
+    mainTabs: [
+      { value: 'timeline', label: 'Timeline', icon: 'clock' },
+      { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
+    ],
+    sidebarTabs: DEFAULT_SIDEBAR_TABS,
+    defaultTab: 'timeline',
+    defaultSidebarTab: 'overview',
+    // The sidebar and the drawer read the SAME `DRAWER_TAB_CARD_COMPONENTS`
+    // registry, so each value here is the card key and must match the `build:*`
+    // entries there and in the build's drawer block.
+    //
+    // `run` is the only place the lifecycle actions live — Start, Cancel,
+    // Complete, Reverse — because `build_status` is `showInDialogs: false` and
+    // `completeBuild` is a procedure, not a status somebody picks.
+    // `ledger` is the only surface for `build_movements`, whose field is
+    // `showInPanel: false` (section 1.6: "has_many; a card lists them").
+    sidebarCards: [
+      { value: 'run', label: 'Run' },
+      { value: 'ledger', label: 'Ledger', recordResource: 'stock_movement' },
+    ],
+  },
+
   /** Generic entities (custom entityDefinitions with entityType='entity') */
   entity: {
     entityType: 'entity',

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -256,6 +256,22 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     },
   },
 
+  build: {
+    entityType: 'build',
+    // Drawer parity with the detail page (detail-view-config.ts): the same two
+    // cards, from the same `DRAWER_TAB_CARD_COMPONENTS` keys. A build opened
+    // from the parts list or an order must offer the same Complete button the
+    // page does, or the drawer becomes a read-only view of a run somebody then
+    // has to navigate away to finish.
+    additionalTabs: [],
+    tabCards: {
+      overview: [
+        { value: 'run', label: 'Run' },
+        { value: 'ledger', label: 'Ledger', recordResource: 'stock_movement' },
+      ],
+    },
+  },
+
   vendor_bill: {
     entityType: 'vendor_bill',
     // Drawer-only, no detail page: a bill RECORDS something already settled, so

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -72,6 +72,7 @@ import { migration106SupplierPricingRelabel } from './migrations/106-supplier-pr
 import { migration107Order } from './migrations/107-order'
 import { migration108Purchasing } from './migrations/108-purchasing'
 import { migration109BuildAndStandardCost } from './migrations/109-build-and-standard-cost'
+import { migration110BuildVisible } from './migrations/110-build-visible'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -189,6 +190,9 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration107Order,
   migration108Purchasing,
   migration109BuildAndStandardCost,
+  // MUST sort after 109 — it flips the def 109 creates. See the migration itself
+  // for why the `SYSTEM_ENTITIES` edit alone reaches no existing org.
+  migration110BuildVisible,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/109-build-and-standard-cost.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/109-build-and-standard-cost.ts
@@ -182,7 +182,12 @@ export const migration109BuildAndStandardCost: EntityMigration = {
     const smDef = existing.entityDefs.get('stock_movement')
     if (!smDef) return { ...state, alreadyUpToDate: true }
 
-    // ── Step 1: the `build` EntityDefinition, isVisible: false ─────────
+    // ── Step 1: the `build` EntityDefinition ───────────────────────────
+    // Visibility comes from `SYSTEM_ENTITIES`, which carried `isVisible: false`
+    // when this shipped and carries `true` since phase 2 landed the UI. An org
+    // that ran this migration before then keeps the `false` it was seeded with
+    // — `ensureEntityDefinitions` never revisits an existing row — which is what
+    // migration 110-build-visible exists to correct.
     const entityDefIds = await ensureEntityDefinitions(
       db,
       organizationId,

--- a/packages/lib/src/seed/entity-migrations/migrations/110-build-visible.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/110-build-visible.test.ts
@@ -1,0 +1,67 @@
+// packages/lib/src/seed/entity-migrations/migrations/110-build-visible.test.ts
+//
+// Migration 110 is a one-column UPDATE, so what can silently go wrong is the
+// wiring around it rather than the write:
+//
+//  - the migration must run AFTER 109, which creates the row it flips;
+//  - `SYSTEM_ENTITIES` must carry the same `isVisible` the migration writes, or
+//    an org signed up before the deploy and one signed up after it disagree
+//    about whether builds appear in the sidebar;
+//  - the sidebar builds a system entity's href as `/app/${apiSlug}`, so the
+//    apiSlug must stay `builds` — the route folder is `app/builds`, and there is
+//    no catch-all for system entities, so a drifted slug is a 404 in the nav.
+//
+// These pin all three.
+
+import { ModelTypeMeta } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import {
+  BUILD_ENTITY_TYPE,
+  migration110BuildVisible,
+  resolveBuildVisibility,
+} from './110-build-visible'
+
+describe('migration 110 registration', () => {
+  it('is registered exactly once, after 109, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '110-build-visible')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf('110-build-visible')).toBe(ids.indexOf('109-build-and-standard-cost') + 1)
+    expect(migration110BuildVisible.id).toBe('110-build-visible')
+  })
+})
+
+describe('the seeder agrees with the migration', () => {
+  const build = SYSTEM_ENTITIES.find((e) => e.entityType === BUILD_ENTITY_TYPE)
+
+  it('SYSTEM_ENTITIES seeds a fresh org with the visibility this migration writes', () => {
+    // 🛑 The migration reaches EXISTING orgs and this constant reaches fresh
+    // ones — `ensureEntityDefinitions` reads `isVisible` at creation time only.
+    // Flipping one without the other is exactly the half-migration this pair
+    // exists to prevent.
+    expect(build, 'build missing from SYSTEM_ENTITIES').toBeDefined()
+    expect(build?.isVisible).toBe(true)
+  })
+
+  it('keeps the apiSlug the sidebar href and the route folder both assume', () => {
+    expect(build?.apiSlug).toBe('builds')
+    expect(ModelTypeMeta.build.apiSlug).toBe('builds')
+  })
+
+  it('keeps the detail page the [buildId] route provides', () => {
+    expect(ModelTypeMeta.build.hasDetailPage).toBe(true)
+  })
+})
+
+describe('resolveBuildVisibility', () => {
+  it('flips a def still carrying the seeded false', () => {
+    expect(resolveBuildVisibility(false)).toBe('update')
+  })
+
+  it('is a no-op on a def that is already visible', () => {
+    // Both a re-run and a fresh org seeded after the SYSTEM_ENTITIES flip.
+    expect(resolveBuildVisibility(true)).toBe('up-to-date')
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/110-build-visible.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/110-build-visible.ts
@@ -1,0 +1,108 @@
+// packages/lib/src/seed/entity-migrations/migrations/110-build-visible.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:110')
+
+/** The one def this migration reveals. */
+export const BUILD_ENTITY_TYPE = 'build'
+
+/**
+ * Decide what to do with one org's `build` def row.
+ *
+ * - `update`     — the row still carries the seeded `false`.
+ * - `up-to-date` — already visible; a re-run, or a fresh org seeded after the
+ *   `SYSTEM_ENTITIES` flip that ships alongside this file.
+ *
+ * There is no `skip` arm, and that is the difference from
+ * {@link resolveRelabel} in migration 102. A label is something an organization
+ * can legitimately have customized, so 102 has to tell "still seeded" from
+ * "theirs". `EntityDefinition.isVisible` has exactly one writer in the whole
+ * codebase — `ensureEntityDefinitions`, at creation time — and the sidebar's
+ * own hide/show toggle persists to the `sidebar.entities.visibility` **org
+ * setting** instead (`use-entity-sidebar.tsx`). So a `false` here is always the
+ * seeded value and never somebody's choice, and this migration cannot overrule
+ * a preference that has no way to be expressed on this column.
+ */
+export function resolveBuildVisibility(isVisible: boolean): 'update' | 'up-to-date' {
+  return isVisible ? 'up-to-date' : 'update'
+}
+
+/**
+ * Migration 110: make the `build` entity visible now that it has a UI
+ * (plans/products/build/01-build-plan.md §3.3, §3.6).
+ *
+ * ## Why this is a migration and not one line
+ *
+ * §3.3 says phase 2's schema work is "one line: flip the def to
+ * `isVisible: true`". That is wrong, and silently so.
+ * `ensureEntityDefinitions` (`../helpers.ts`) is a plain `insert` that
+ * `continue`s past any org already holding the def — `isVisible: entity.isVisible
+ * ?? true` is only ever evaluated when the row is CREATED. Migration 109 already
+ * created the `build` def in every org at `isVisible: false`, so editing
+ * `SYSTEM_ENTITIES` alone reaches no existing organization at all: it would flip
+ * the flag for orgs created after the deploy and leave every current one with a
+ * complete, working builds UI that has no way into it.
+ *
+ * The `SYSTEM_ENTITIES` edit still ships — it is what a fresh org seeds from,
+ * and leaving the two disagreeing is how a def ends up meaning one thing on old
+ * orgs and another on new ones. This migration is the other half.
+ *
+ * ## What `isVisible: true` actually turns on
+ *
+ * The Records sidebar group (`use-entity-sidebar.tsx` filters
+ * `resource.isVisible !== false`) and the kbar search / create pages. Nothing is
+ * registered by hand: the sidebar builds the href as `/app/${apiSlug}` for a
+ * system entity, which is `/app/builds`, and that route folder lands with this
+ * change. ⚠️ **The nav entry 404s without it** — which is the other half of why
+ * 109 shipped the def hidden.
+ *
+ * Idempotent, and no field, relationship or view work: 109 created all 24
+ * `BUILD_FIELDS` and linked every edge. This touches exactly one boolean column.
+ * Cache invalidation is the runner's: any org whose result is not
+ * `alreadyUpToDate` gets `entityDefs` / `entityDefSlugs` / `customFields` /
+ * `resources` recomputed.
+ */
+export const migration110BuildVisible: EntityMigration = {
+  id: '110-build-visible',
+  description: 'Make the build entity visible in the sidebar now that the builds UI has landed',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    const [def] = await db
+      .select({
+        id: schema.EntityDefinition.id,
+        isVisible: schema.EntityDefinition.isVisible,
+      })
+      .from(schema.EntityDefinition)
+      .where(
+        and(
+          eq(schema.EntityDefinition.organizationId, organizationId),
+          eq(schema.EntityDefinition.entityType, BUILD_ENTITY_TYPE),
+          isNull(schema.EntityDefinition.archivedAt)
+        )
+      )
+      .limit(1)
+
+    // The org predates the def entirely. Not an error and not something to fix
+    // here: 109 runs before this in the same ordered registry, so an absent row
+    // means 109 could not create it either, and 109 is where that is diagnosed.
+    if (!def) return { ...state, alreadyUpToDate: true }
+
+    if (resolveBuildVisibility(def.isVisible) === 'up-to-date') {
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    await db
+      .update(schema.EntityDefinition)
+      .set({ isVisible: true })
+      .where(eq(schema.EntityDefinition.id, def.id))
+
+    logger.info('Migration 110 applied', { organizationId, entityDefinitionId: def.id })
+    return { ...state, alreadyUpToDate: false }
+  },
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -331,17 +331,22 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     // writes them until `packages/lib/src/builds/` lands in phase 2. An entity
     // with zero rows can be reshaped for free; the first row ends that.
     //
-    // ⚠️ `isVisible: false` is NOT permanent — phase 2 flips it to true when the
-    // list, the detail page and the completion form land. Straight from the
-    // `vendor_payment` precedent: a visible nav entry for an empty list with no
-    // way to create a row is a worse first impression than no entry at all.
+    // ✅ Flipped to `isVisible: true` with phase 2 — the list, the detail page
+    // and the completion form landed, so the nav entry now leads somewhere.
+    //
+    // 🛑 This line reaches FRESH orgs only. `ensureEntityDefinitions` is a plain
+    // insert that skips an org already holding the def, so `isVisible` is read
+    // once at creation and never again; every org that ran 109 keeps the `false`
+    // it was seeded with. Entity migration **110-build-visible** is the other
+    // half, and the two must agree or the def means one thing on an old org and
+    // another on a new one.
     entityType: 'build',
     apiSlug: 'builds',
     singular: 'Build',
     plural: 'Builds',
     icon: 'hammer',
     color: 'orange',
-    isVisible: false,
+    isVisible: true,
   },
 ]
 


### PR DESCRIPTION
Phase 2's UI half ([§3.6](plans/products/build/01-build-plan.md)), the router serving it, the `build_number` writer, and the visibility flip. With this, the build subsystem is usable end to end.

## 🛑 Two things the plan said were free, and weren't

**1. The visibility flip is not "one line".** §3.3 says this phase's schema work is *"one line: flip the def to `isVisible: true`"*.

`ensureEntityDefinitions` (`seed/entity-migrations/helpers.ts:181-195`) is a plain `INSERT` that skips orgs already holding the def — `isVisible: entity.isVisible ?? true` is only ever evaluated at **creation**. All 28 orgs already hold `build` at `false`. So editing `SYSTEM_ENTITIES` alone reaches **no existing org**, and it would have read as correct in review because the constant would say `true`.

Hence **migration 110**, which UPDATEs existing rows, alongside the constant for future orgs. It deliberately has **no skip arm**: `EntityDefinition.isVisible` has exactly one writer in the repo, and the sidebar's own hide/show toggle persists to the `sidebar.entities.visibility` **org setting** instead (verified at `use-entity-sidebar.tsx:201-206`) — so a `false` on that column is always the seeded value and never someone's choice.

**2. `build_number` had no writer.** `build-fields.ts` documented it as RecordSequence-issued and stated *"the hook is the ONLY writer"* — but `SequenceScope` had no `build` member and no hook existed. Every build was created with `number: null`, under a def whose `primaryDisplayField` **is** `number`.

Added, copying `order_number` / `purchase_order_number` in shape. Prefix `B` rather than anything longer, because a longer B-prefix reads as `BILL-0001` at a glance and builds and vendor bills sit on the same cost trail (there's a test asserting the two counters stay independent). Once-only issuance rests on three things: a create-only guard (`runPreHooks` fires every hook on CREATE regardless of whether the attribute is in `values`, but on UPDATE only when present), one `crud.create` per build, and `recordNumbering`'s single incrementing `UPDATE … RETURNING` behind an `onConflictDoNothing` seed. Backstop: the field is `creatable: false` / `updatable: false`.

## The completion form

This is what §3.6 calls the difference between a usable tool and a report.

**Per-component overrides** are whole-run quantities, not per-unit. An untouched line keeps tracking the BOM as produced/scrapped change; a typed line becomes absolute and offers a reset-to-BOM. A line zeroed to `0` is dropped server-side — but the row **stays on screen** with a "Not used" badge and its input intact, so the edit is visible rather than vanishing.

**Off-BOM additions** get a badge, read "substitution" instead of "N per unit", sort after the BOM lines, and write `qtyPerUnit: null` — the field's documented marker. The ledger card reads that same NULL back from the other side as "Off BOM", and only on a consume row, since it's NULL on every other type by definition.

**Scrap is called out twice**, because B7 makes it expensive and nothing else in the UI would say so: an amber warning at the input the moment it exceeds zero (*"these units still consume components and produce no stock — their whole cost is booked as a variance to account 5090"*), and a line under the variance saying it is not absorbed into the survivors.

**The five cost figures preview live** on every quantity and override edit — Material / Labour / Overhead / Produced value / **Variance → 5090** — with the produced-value arithmetic spelled out beside it (`10 × $66.22`). The footer states how many movements will be written, the date, and that a build cannot be completed twice. The button reads **Complete and post**, not Save. No second confirm dialog: the form's own numbers are the deliberation, matching phase 1's roll popover. `useConfirm` is used for Cancel and Reverse.

Parts with no standard cost block the write and are **named** — including the produced part, labelled by role since it never appears as a component row.

## ⚠️ Why `complete-build.ts` changed

I had told the agent not to touch it. It did, and I think correctly.

That file held a private `absorbed()` and four inline expressions computing exactly the numbers the form must preview. A second implementation in the browser is the drift bug this codebase pays for elsewhere, so the arithmetic moved into `builds/client.ts` as `summarizeBuildCompletion`, and `writeCompletion` now calls it. Behaviour-identical, the 25 existing build tests pass untouched, and **the preview is trustworthy because it is the same function**, not a copy that agrees today.

Flagging it because it's a scope departure, not because I doubt it.

## What the router asserts

| procedure | gate |
| --- | --- |
| `list`, `get` | view on `build` |
| `create`, `start`, `cancel` | edit on `build` |
| `previewCompletion`, `complete`, `reverse` | edit on `build` **and** edit on `stock_movement` |

The `stock_movement` half comes from `purchasing.adjustStock` / `receiveStock` / `reverseMovement`, which all assert exactly that def. `assertEditEntity`, never `assertWriteEntity`, per that router's own note. `create` deliberately does **not** require `stock_movement` — that's B2, a planned build writes nothing. `source` is not accepted from the browser, or an auto-build would be indistinguishable from a deliberate one. The run card mirrors both gates with `canEditEntity`, so a hidden button and a closed door always agree.

## Realtime

`reverseBuild` has no `publish*` call at all — it creates its build row on the quiet lane. Every mutation funnels through one `refresh()` invalidating `builds.get`, `builds.list` and `record.listFiltered` for the build def, following `billing-action-dialog.tsx:127`. The completion dialog does the same: `completeBuild` publishes field-value frames for its own row, but the acting tab is excluded from its own events and the movements went out silently.

## Choices where §3.6 was silent

- **Lifecycle actions live on a `build:run` card**, not a status dropdown — `build_status` is `showInDialogs: false` and every transition has server preconditions.
- **A `build:ledger` card** wasn't asked for, but §1.6 says `build_movements` is `showInPanel: false` *"because a card lists them"* — without one the field is unreachable, which is the trap `drawer-card-parity.test.ts` exists to catch.
- **No main tab.** A build isn't a document with editable lines; both cards are declared in `drawer-config` *and* `detail-view-config` so the drawer isn't a read-only half.
- **The browser may override labour/overhead.** There's no other authority for what a *specific run* absorbed — the same call `adjustStock` makes about a unit cost. Clearing returns to the rate; a NULL rate reads "No rate declared — absorbs nothing", never `$0.00`.
- **`previewCompletion` takes `partId`, not `buildId`**, matching `explodeBuildComponents`. It discloses nothing `complete` wouldn't since the gate is identical, but resolving the part server-side from `buildId` would be tighter if you want it.

## Verification

```
lib typecheck ratchet:  no new type errors (29 total, baseline 29)
web typecheck ratchet:  no new type errors (0 total, baseline 0)
vitest lib src/builds src/seed src/records src/resources/hooks:
                        26 files, 393 tests passed
web components + routers:  68 and 1464 passed
biome:                  clean
```

Phases 1 and 2's existing tests pass untouched, including `purchasing-hooks.test.ts`, which was concurrently modified by unrelated work and not touched here.

## Known gap, next PR

**`build_status` has no lifecycle guard.** Transitions are enforced inside `startBuild` / `completeBuild` / `cancelBuild`, but a raw `record.update` — drawer, inline grid edit, kanban drag, Kopilot record tool — can still set `build_status: 'completed'` directly, recording a finished build with no movements, no costs and no variance. That's the same defect #1940 just fixed for `quote` / `invoice` / `purchase_order`, and the machinery now exists to fix it cheaply.
