### PR TITLE
feat(purchasing): send a purchase order from its page, and default its contact

### DIFF
--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-lines-tab.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-lines-tab.tsx
@@ -12,6 +12,13 @@
 // phantom-draft rows and one-round-trip creates for free — every one of which
 // the bespoke dialog either reimplemented or simply did not have.
 //
+// It also owns the document actions cluster — Send/Resend plus the secondary
+// dropdown — teleported into the wrapping <Section> header by
+// `DocumentSectionActions`, exactly as quote and invoice do
+// (plans/purchasing/07-purchase-order-send-and-status.md §5 step 6). A purchase
+// order is the THIRD consumer of `useDocumentSendActions`, which needed no
+// changes to take it.
+//
 // Rendered in both places a PO is opened, the `order`/`quote` relation:
 //   PurchaseOrderLinesTab  -> the detail page's "Lines" section
 //                             (DETAIL_VIEW_TAB_COMPONENTS, sections layout)
@@ -23,30 +30,57 @@
 // accumulates on the draft instead of firing a create the server must reject.
 // That guard lives in `createDraft`, so it holds for any cell added later.
 
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import { parseRecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
+import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
+import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
+import { Ban, Check, Download, Send } from 'lucide-react'
+import Link from 'next/link'
 import { useCallback } from 'react'
 import type { DetailViewTabProps } from '~/components/detail-view'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
-import { DocumentSectionActions } from '~/components/money/ui/document-actions-cluster'
+import {
+  DocumentActionsCluster,
+  DocumentSectionActions,
+} from '~/components/money/ui/document-actions-cluster'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
 import type { PartPrefillLookup } from '~/components/money/ui/line-builder/line-rows'
-import { useSystemValues } from '~/components/resources/hooks'
+import { useDocumentSendActions } from '~/components/money/ui/use-document-send-actions'
+import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
+import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 
 const PO_STATUS_ATTRS = [
   'purchase_order_status',
   'purchase_order_receipt_status',
   'purchase_order_billing_status',
+  'purchase_order_contact',
 ] as const
+
+/**
+ * Statuses a purchase order can still be (re)sent from. `closed` and `canceled` are the
+ * two terminal decisions, so they drop the Send segment entirely and the cluster falls
+ * back to a standalone "Actions" button — Download PDF is still reachable.
+ */
+const SENDABLE_STATUSES = new Set(['draft', 'issued'])
+
+/**
+ * Statuses a human can still close or cancel from — the `draft`/`issued` -> terminal
+ * transitions of §3.3's action axis. Both are plain `saveSystemValues` writes because
+ * neither is guarded: only `issued` has a sanctioned writer
+ * (`field-hooks/pre/purchase-order-status-guard.ts`).
+ */
+const OPEN_STATUSES = new Set(['draft', 'issued'])
 
 type BadgeSpec = { label: string; variant: 'green' | 'amber' | 'red' }
 
 /**
  * The ACTION axis — what a person decided. `draft` is the default and `issued` is
  * the ordinary working state, so neither earns a badge; only the two terminal
- * decisions do.
+ * decisions do. (`issued` is legible from the cluster anyway — the Send segment
+ * reads "Resend".)
  *
  * 🛑 `partially_received` / `received` used to live here. They are no longer values
  * of this field at all — receiving and billing are independent axes and moved to
@@ -75,20 +109,79 @@ const BILLING_BADGE: Record<string, BadgeSpec> = {
 }
 
 export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
-  const { values } = useSystemValues(recordId, [...PO_STATUS_ATTRS], { autoFetch: true })
+  const [closeConfirm, CloseConfirmDialog] = useConfirm()
+  const [cancelConfirm, CancelConfirmDialog] = useConfirm()
+
+  const { values, isLoading } = useSystemValues(recordId, [...PO_STATUS_ATTRS], { autoFetch: true })
+  const { save: saveSystemValues } = useSaveSystemValues(recordId)
 
   // SINGLE_SELECT values arrive as arrays — take the first (see the
   // `use_system_values_single_select_arrays` convention).
-  const status = firstValue(values.purchase_order_status)
+  const status = firstValue(values.purchase_order_status) ?? 'draft'
   const receiptStatus = firstValue(values.purchase_order_receipt_status)
   const billingStatus = firstValue(values.purchase_order_billing_status)
   // Order matters: the decision first, then what actually arrived, then what was
   // invoiced — the same left-to-right reading as the document's own lifecycle.
   const badges = [
-    status ? STATUS_BADGE[status] : undefined,
+    STATUS_BADGE[status],
     receiptStatus ? RECEIPT_BADGE[receiptStatus] : undefined,
     billingStatus ? BILLING_BADGE[billingStatus] : undefined,
   ].filter((b): b is BadgeSpec => !!b)
+
+  // ⚠️ The addressee is the CONTACT, never the vendor: `purchase_order_vendor` targets a
+  // `company` and a company carries no email field at all (§7.2). `purchase_order_contact`
+  // is nullable and nothing prefills it, so "no contact" is the COMMON case — surfacing it
+  // as a disabled reason beats letting `prepareDocumentEmail` reject the round trip.
+  const hasContact = extractRelationshipRecordIds(values.purchase_order_contact).length > 0
+
+  // Shared send/download flow (compose + PDF + no-channel guard) — the same hook quote
+  // and invoice use, unmodified.
+  const { hasEmailChannel, handleSend, handleDownload, isSending } = useDocumentSendActions(
+    recordId,
+    'purchase order'
+  )
+
+  const markSent = api.purchasing.markPurchaseOrderSent.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Error marking purchase order as sent', description: error.message }),
+  })
+
+  const handleClose = async () => {
+    const confirmed = await closeConfirm({
+      title: 'Close this purchase order?',
+      description:
+        'Closing says nothing further is expected against this order, even if some lines were never fully received or billed.',
+      confirmText: 'Close order',
+      cancelText: 'Cancel',
+    })
+    if (!confirmed) return
+    const ok = await saveSystemValues({ purchase_order_status: 'closed' })
+    if (!ok) {
+      toastError({
+        title: 'Error closing purchase order',
+        description: 'Could not update the purchase order status',
+      })
+    }
+  }
+
+  const handleCancel = async () => {
+    const confirmed = await cancelConfirm({
+      title: 'Cancel this purchase order?',
+      description:
+        'The order stays on file with its lines and any receipts intact — cancelling only records that it will not be fulfilled.',
+      confirmText: 'Cancel order',
+      cancelText: 'Keep open',
+      destructive: true,
+    })
+    if (!confirmed) return
+    const ok = await saveSystemValues({ purchase_order_status: 'canceled' })
+    if (!ok) {
+      toastError({
+        title: 'Error canceling purchase order',
+        description: 'Could not update the purchase order status',
+      })
+    }
+  }
 
   // `variant='section'`: rendered inside a DetailViewSections <Section> on an
   // outer-owned scroll column instead of a `TabsContent` that grants `h-full`, so
@@ -129,11 +222,37 @@ export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewT
     [utils]
   )
 
+  // The channel guard comes first because it blocks every document; the contact guard
+  // only applies once there IS somewhere to send from. `isLoading` suppresses the
+  // contact reason until the field has actually been read, mirroring how the hook
+  // treats "channels still loading" as available — neither may flash a disabled Send.
+  const sendDisabledReason = !hasEmailChannel ? (
+    <div className='flex flex-col gap-1 text-xs'>
+      <span>Connect an email channel to send purchase orders.</span>
+      <Link href='/app/settings/channels' className='underline'>
+        Go to channel settings
+      </Link>
+    </div>
+  ) : !isLoading && !hasContact ? (
+    <div className='flex flex-col gap-1 text-xs'>
+      <span>Set the Contact field to the person at the vendor who should receive this order.</span>
+    </div>
+  ) : undefined
+
+  const sendSlot = SENDABLE_STATUSES.has(status)
+    ? {
+        label: status === 'draft' ? 'Send' : 'Resend',
+        onClick: handleSend,
+        isPending: isSending,
+        disabledReason: sendDisabledReason,
+      }
+    : undefined
+
   return (
     <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
-      {badges.length > 0 && (
-        <DocumentSectionActions
-          badge={
+      <DocumentSectionActions
+        badge={
+          badges.length > 0 ? (
             <span className='flex items-center gap-1.5'>
               {badges.map((b) => (
                 <Badge key={b.label} variant={b.variant} size='sm'>
@@ -141,10 +260,57 @@ export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewT
                 </Badge>
               ))}
             </span>
-          }
-        />
-      )}
+          ) : undefined
+        }>
+        <DocumentActionsCluster send={sendSlot} menuLabel='Purchase order actions'>
+          <DropdownMenuItem onClick={handleDownload}>
+            <Download /> Download PDF
+          </DropdownMenuItem>
 
+          {/*
+            The only writer of `issued` reachable without composing an email. Sending from
+            the composer flips the status on a CONFIRMED send (thread.ts), so this is the
+            "the order went out by phone/fax/portal" door — the same role "Mark as sent"
+            plays for quote and invoice.
+          */}
+          {status === 'draft' && (
+            <DropdownMenuItem
+              onClick={() =>
+                markSent.mutate({ purchaseOrderId: parseRecordId(recordId).entityInstanceId })
+              }>
+              <Send /> Mark as sent
+            </DropdownMenuItem>
+          )}
+
+          {OPEN_STATUSES.has(status) && (
+            <>
+              <DropdownMenuSeparator />
+              {/*
+                `closed` is deliberately NOT derived (§3.6): an order whose short-shipped
+                remainder has been forgiven must still be closeable, and no roll-up rule can
+                decide that. So it is a human decision with a confirm, not a rollup.
+              */}
+              <DropdownMenuItem onClick={handleClose}>
+                <Check /> Close order
+              </DropdownMenuItem>
+              <DropdownMenuItem variant='destructive' onClick={handleCancel}>
+                <Ban /> Cancel order
+              </DropdownMenuItem>
+            </>
+          )}
+        </DocumentActionsCluster>
+      </DocumentSectionActions>
+
+      {/*
+        🛑 No `readOnly` prop, and that is the rule rather than an omission (§6.5). Status is
+        the wrong predicate in BOTH directions: an `issued` order nobody has shipped against
+        is perfectly safe to edit (real orders get amended when a vendor substitutes a part),
+        while a `draft` order that already carries receipts — legal since §6.1's pull-forward
+        — is not. The lock is per-LINE and evidence-based, enforced server-side by
+        `field-hooks/pre/purchase-order-line-evidence-lock.ts`: a line freezes its
+        `quantity_ordered` and `expected_unit_price` once a `stock_movement` or
+        `vendor_bill_line` points at it. Adding new lines stays open at any status.
+      */}
       <div className={cn(isSection ? 'max-h-[60vh] overflow-auto ps-3 pe-3' : 'min-h-0 flex-1')}>
         <LineBuilder
           documentRecordId={recordId}
@@ -152,6 +318,9 @@ export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewT
           resolvePartPrefill={resolvePartPrefill}
         />
       </div>
+
+      <CloseConfirmDialog />
+      <CancelConfirmDialog />
     </div>
   )
 }

--- a/apps/web/src/server/api/routers/thread.ts
+++ b/apps/web/src/server/api/routers/thread.ts
@@ -17,7 +17,12 @@ import {
   updateScheduledMessageStatus,
 } from '@auxx/lib/mail-schedule'
 import { MessageSenderService } from '@auxx/lib/messages'
-import { markInvoiceSent, markQuoteSent, recordDocumentSendSignal } from '@auxx/lib/money'
+import {
+  markInvoiceSent,
+  markPurchaseOrderSent,
+  markQuoteSent,
+  recordDocumentSendSignal,
+} from '@auxx/lib/money'
 import { PermissionKey } from '@auxx/lib/permissions'
 import { satisfiesRung } from '@auxx/lib/permissions/capabilities/rung'
 import { getThreadLens, type UserInstanceGrants } from '@auxx/lib/permissions/visibility'
@@ -549,8 +554,48 @@ export const threadRouter = createTRPCRouter({
                   })
                 }
               }
+
+              // Purchase order (plans/purchasing/07-purchase-order-send-and-status.md §3.4).
+              // `issued` IS "sent to the vendor" — one event, no separate `sent` value — so
+              // the confirmed-send flip writes `issued` where the two branches above write
+              // `sent`. `recordDocumentSendSignal`'s own header already names this branch.
+              const purchaseOrderDefId = await getCachedEntityDefId(
+                organizationId,
+                'purchase_order'
+              )
+              if (
+                linkedInstance &&
+                purchaseOrderDefId &&
+                linkedInstance.entityDefinitionId === purchaseOrderDefId
+              ) {
+                try {
+                  await markPurchaseOrderSent({
+                    organizationId,
+                    userId,
+                    purchaseOrderInstanceId: input.linkTicketId,
+                  })
+                } catch (flipError) {
+                  // markPurchaseOrderSent asserts status === 'draft' — a BadRequestError
+                  // here means the order was already issued (resend) or is closed/canceled;
+                  // that's the expected idempotent no-op, not a failure.
+                  if (!(flipError instanceof BadRequestError)) throw flipError
+                }
+
+                // Communications-view signal — see the quote branch above for rationale.
+                if (sentMessage.sendStatus === 'SENT') {
+                  await recordDocumentSendSignal({
+                    organizationId,
+                    userId,
+                    documentType: 'purchase_order',
+                    documentInstanceId: input.linkTicketId,
+                    messageId: sentMessage.id,
+                    threadId: sentMessage.threadId,
+                    subject: input.subject ?? 'Purchase order sent',
+                  })
+                }
+              }
             } catch (statusFlipError) {
-              logger.error('Failed to flip quote/invoice status to sent after send', {
+              logger.error('Failed to flip document status to sent after send', {
                 threadId: sentMessage.threadId,
                 ticketId: input.linkTicketId,
                 error:

--- a/packages/lib/src/field-hooks/post/purchase-order-contact-prefill.test.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-contact-prefill.test.ts
@@ -1,0 +1,196 @@
+// packages/lib/src/field-hooks/post/purchase-order-contact-prefill.test.ts
+//
+// The SECOND door for the vendor -> contact default (purchasing plan 07). The
+// `purchase_order_vendor` system hook covers `UnifiedCrudHandler` writes — how an
+// order is first drafted against a supplier. Re-pointing an existing order at a
+// different supplier goes through `fieldValue.set`, which never reads the
+// system-hook registry, so it reaches only this handler.
+//
+// The rule this pins is the one that separates a prefill from a stamp: replace this
+// hook's own prefill, never a human's pick.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityFieldChangeEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  resolveCompanyPrimaryContact: vi.fn(),
+  setValueWithType: vi.fn(),
+  createFieldValueContext: vi.fn(),
+  getValues: vi.fn(),
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../resources/hooks/purchasing-hooks', () => ({
+  resolveCompanyPrimaryContact: h.resolveCompanyPrimaryContact,
+}))
+vi.mock('../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    getValues = h.getValues
+  },
+}))
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: h.createFieldValueContext,
+}))
+vi.mock('../../field-values/stored-field-type', () => ({ toFieldType: () => 'RELATIONSHIP' }))
+
+import { prefillContactOnVendorChange } from './purchase-order-contact-prefill'
+
+const PO = 'podef:po-1'
+const OLD_VENDOR = 'codef:co-old'
+const NEW_VENDOR = 'codef:co-new'
+const OLD_PRIMARY = 'ctdef:ct-old'
+const NEW_PRIMARY = 'ctdef:ct-new'
+const HUMAN_PICK = 'ctdef:ct-human'
+
+function event(overrides: Partial<EntityFieldChangeEvent> = {}): EntityFieldChangeEvent {
+  return {
+    recordId: PO,
+    entityDefinitionId: 'podef',
+    entityType: 'purchase_order',
+    entitySlug: 'purchase-orders',
+    field: { id: 'fld-vendor', systemAttribute: 'purchase_order_vendor', type: 'RELATIONSHIP' },
+    oldValue: [{ type: 'relationship', recordId: OLD_VENDOR }],
+    newValue: [{ type: 'relationship', recordId: NEW_VENDOR }],
+    oldDisplay: null,
+    newDisplay: null,
+    organizationId: 'org_1',
+    userId: 'usr_1',
+    ...overrides,
+  } as unknown as EntityFieldChangeEvent
+}
+
+/** The current `purchase_order_contact` on the order, as `getValues` returns it. */
+function currentContact(recordId: string | null) {
+  h.getValues.mockResolvedValue(
+    new Map(recordId ? [['fld-contact', [{ type: 'relationship', recordId }]]] : [])
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.bySystemAttributes.mockResolvedValue({
+    purchase_order_contact: { id: 'fld-contact', type: 'RELATIONSHIP' },
+  })
+  h.createFieldValueContext.mockResolvedValue({})
+  currentContact(null)
+})
+
+describe('prefillContactOnVendorChange', () => {
+  it('fills an empty contact from the new vendor', async () => {
+    h.resolveCompanyPrimaryContact.mockResolvedValue(NEW_PRIMARY)
+
+    await prefillContactOnVendorChange(event())
+
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        recordId: PO,
+        fieldId: 'fld-contact',
+        value: { type: 'relationship', recordId: NEW_PRIMARY },
+      })
+    )
+  })
+
+  // The whole reason this is a prefill and not a stamp.
+  it('leaves a human’s pick alone', async () => {
+    currentContact(HUMAN_PICK)
+    h.resolveCompanyPrimaryContact.mockImplementation(async ({ companyRecordId }) =>
+      companyRecordId === NEW_VENDOR ? NEW_PRIMARY : OLD_PRIMARY
+    )
+
+    await prefillContactOnVendorChange(event())
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('re-derives a contact that was its own earlier prefill', async () => {
+    currentContact(OLD_PRIMARY)
+    h.resolveCompanyPrimaryContact.mockImplementation(async ({ companyRecordId }) =>
+      companyRecordId === NEW_VENDOR ? NEW_PRIMARY : OLD_PRIMARY
+    )
+
+    await prefillContactOnVendorChange(event())
+
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ value: { type: 'relationship', recordId: NEW_PRIMARY } })
+    )
+  })
+
+  // A prefilled contact names somebody at the PREVIOUS supplier, and this field's only
+  // consumer is the address line on an email to the new one.
+  it('clears its own prefill when the new vendor names nobody', async () => {
+    currentContact(OLD_PRIMARY)
+    h.resolveCompanyPrimaryContact.mockImplementation(async ({ companyRecordId }) =>
+      companyRecordId === NEW_VENDOR ? null : OLD_PRIMARY
+    )
+
+    await prefillContactOnVendorChange(event())
+
+    expect(h.setValueWithType).toHaveBeenCalledWith({}, expect.objectContaining({ value: null }))
+  })
+
+  // `undefined` is "could not resolve" — never clear a good contact on a blip.
+  it('writes nothing when the new vendor cannot be resolved', async () => {
+    h.resolveCompanyPrimaryContact.mockResolvedValue(undefined)
+
+    await prefillContactOnVendorChange(event())
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('writes nothing when the OLD vendor cannot be resolved', async () => {
+    currentContact(OLD_PRIMARY)
+    h.resolveCompanyPrimaryContact.mockImplementation(async ({ companyRecordId }) =>
+      companyRecordId === NEW_VENDOR ? NEW_PRIMARY : undefined
+    )
+
+    await prefillContactOnVendorChange(event())
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('does not touch the contact when the vendor is detached', async () => {
+    await prefillContactOnVendorChange(event({ newValue: null }))
+
+    expect(h.resolveCompanyPrimaryContact).not.toHaveBeenCalled()
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when the derived contact is already the current one', async () => {
+    currentContact(NEW_PRIMARY)
+    h.resolveCompanyPrimaryContact.mockResolvedValue(NEW_PRIMARY)
+
+    await prefillContactOnVendorChange(event())
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('ignores every field but the vendor', async () => {
+    await prefillContactOnVendorChange(
+      event({
+        field: {
+          id: 'fld-status',
+          systemAttribute: 'purchase_order_status',
+          type: 'SINGLE_SELECT',
+        },
+      } as unknown as Partial<EntityFieldChangeEvent>)
+    )
+
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+  })
+
+  // A default must never fail the vendor write it rides on.
+  it('swallows a write failure', async () => {
+    h.resolveCompanyPrimaryContact.mockResolvedValue(NEW_PRIMARY)
+    h.setValueWithType.mockRejectedValue(new Error('boom'))
+
+    await expect(prefillContactOnVendorChange(event())).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/field-hooks/post/purchase-order-contact-prefill.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-contact-prefill.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/field-hooks/post/purchase-order-contact-prefill.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { TypedFieldValue } from '@auxx/types'
+import type { RecordId } from '@auxx/types/resource'
+import { getOrgCache } from '../../cache'
+import { createFieldValueContext } from '../../field-values/field-value-helpers'
+import { setValueWithType } from '../../field-values/field-value-mutations'
+import { FieldValueService } from '../../field-values/field-value-service'
+import { toFieldType } from '../../field-values/stored-field-type'
+import { resolveCompanyPrimaryContact } from '../../resources/hooks/purchasing-hooks'
+import type { EntityFieldChangeHandler } from '../types'
+
+const logger = createScopedLogger('field-hooks:purchase-order-contact-prefill')
+
+/**
+ * Read a `RecordId` out of a post-write relationship value. RELATIONSHIP fields
+ * report the FULL array the write produced, and `null` when the write cleared the
+ * only row.
+ */
+function readRelationshipRecordId(raw: unknown): RecordId | null {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (typeof value === 'string') return value as RecordId
+  const typed = value as TypedFieldValue | undefined
+  if (typed?.type === 'relationship' && typed.recordId) return typed.recordId
+  return null
+}
+
+/**
+ * Default `purchase_order_contact` from the vendor's `company_primary_contact`
+ * (purchasing plan 07; the intent was recorded on the field itself in
+ * `purchase-order-fields.ts` and shipped without a writer).
+ *
+ * ⚠️ **This is the SECOND door, and it is the one the UI actually uses.** The
+ * `purchase_order_vendor` system hook in `resources/hooks/purchasing-hooks.ts`
+ * covers writes through `UnifiedCrudHandler` (`record.create`, the importer, the
+ * SDK) — that is how an order is first drafted against a supplier. But every EDIT
+ * to an existing order goes through `useSaveFieldValue` -> `fieldValue.set` ->
+ * `FieldValueService`, which consults only `getFieldPreHooks` /
+ * `getEntityFieldChangeHooks` and never reads the system-hook registry at all.
+ * Re-pointing an order at a different supplier reaches ONLY this handler. The same
+ * split is recorded on `line-item-part-stamp.ts` and on the two
+ * `purchase_order_status` guards.
+ *
+ * ⚠️ **Registered under `purchase_order_vendor`, not `purchase_order_contact`.**
+ * `runPreHooks` skips a system hook on UPDATE unless its own registered
+ * systemAttribute is present in `values`, so the twin keyed on the contact would
+ * fire on create only. Both doors are keyed on the vendor so the two stay
+ * symmetrical.
+ *
+ * ## This is a PREFILL, not a stamp
+ *
+ * `line_item_part` is a provenance STAMP and always overwrites. A contact is a
+ * person somebody chose, so the rule is narrower — **replace our own prefill,
+ * never a human's pick**:
+ *
+ * - no contact yet -> fill from the new vendor
+ * - the contact equals the OLD vendor's primary contact -> it was this hook's own
+ *   prefill, so re-derive it from the new vendor
+ * - anything else -> a human picked that person; leave it alone
+ *
+ * `oldValue` is what makes that test cheap: the alternative is reading the
+ * contact's `contact_employer` / `contact_company`, which are two DIFFERENT edges
+ * (`company_primary_contact` inverts to `contact:company`, `company_employees` to
+ * `contact:employer`) and answer a subtly different question.
+ *
+ * When the new vendor has no primary contact, a prefilled contact is CLEARED
+ * rather than left: it names a person at the previous supplier, and this field's
+ * only consumer is the address line on an email to the new one.
+ *
+ * `undefined` from the resolver means "could not resolve" and always leaves the
+ * field untouched — collapsing it into `null` would clear a good contact on a
+ * transient failure.
+ *
+ * No recursion: this fires only for `purchase_order_vendor` and writes only
+ * `purchase_order_contact`.
+ */
+export const prefillContactOnVendorChange: EntityFieldChangeHandler = async (event) => {
+  if (event.field.systemAttribute !== 'purchase_order_vendor') return
+
+  const { organizationId, userId, recordId } = event
+
+  try {
+    const cf = await getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttributes(['purchase_order_contact'] as const)
+    const contactField = cf.purchase_order_contact
+    if (!contactField) return
+
+    const newVendor = readRelationshipRecordId(event.newValue)
+    // Detaching the vendor is not a re-point. Whoever the order is addressed to is
+    // still the last thing anybody decided, and there is no new supplier to derive
+    // a better answer from.
+    if (!newVendor) return
+
+    const next = await resolveCompanyPrimaryContact({
+      organizationId,
+      userId,
+      companyRecordId: newVendor,
+    })
+    if (next === undefined) return
+
+    const values = await new FieldValueService(organizationId, userId).getValues({
+      recordId,
+      fieldIds: [contactField.id],
+    })
+    const entry = values.get(contactField.id)
+    const typed: TypedFieldValue | undefined = Array.isArray(entry) ? entry[0] : entry
+    const current = typed?.type === 'relationship' ? (typed.recordId ?? null) : null
+
+    if (current) {
+      const oldVendor = readRelationshipRecordId(event.oldValue)
+      if (!oldVendor) return
+
+      const prior = await resolveCompanyPrimaryContact({
+        organizationId,
+        userId,
+        companyRecordId: oldVendor,
+      })
+      // `undefined` here is the dangerous one: it cannot tell a human's pick from
+      // this hook's own prefill, and guessing wrong discards a deliberate choice.
+      if (prior === undefined || prior !== current) return
+    }
+
+    if (current === next) return
+
+    const ctx = await createFieldValueContext(organizationId, userId)
+    await setValueWithType(ctx, {
+      recordId,
+      fieldId: contactField.id,
+      fieldType: toFieldType(contactField.type),
+      value: next ? { type: 'relationship', recordId: next } : null,
+    })
+  } catch (error) {
+    // A default must never fail the vendor write it rides on.
+    logger.warn('could not prefill purchase_order_contact from the vendor', {
+      organizationId,
+      recordId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -52,6 +52,7 @@ import {
 import { invalidateInboxCacheOnFieldChange } from './post/inbox-cache-invalidation'
 import { stampPartOnCatalogItemChange } from './post/line-item-part-stamp'
 import { publishFieldChangeEvent } from './post/publish-field-change-event'
+import { prefillContactOnVendorChange } from './post/purchase-order-contact-prefill'
 import { touchActivityOnFieldChange } from './post/touch-activity-on-field-change'
 import { guardInboxOwnerField } from './pre/inbox-owner-guard'
 import { guardInvoiceDelete } from './pre/invoice-delete-guard'
@@ -184,7 +185,17 @@ export function registerAllHooks(): void {
   // supplier's document (01 §5.4b). Recomputing them would silently correct the vendor's
   // arithmetic — the exact discrepancy the three-way match exists to surface.
   registerEntityFieldChangeHooks('purchase-order-lines', [recomputeOnPurchaseOrderLineChange])
-  registerEntityFieldChangeHooks('purchase-orders', [recomputeOnPurchaseOrderBillingChange])
+  // ⚠️ `prefillContactOnVendorChange` is the SECOND door for the vendor -> contact default
+  // (purchasing plan 07). The `purchase_order_vendor` system hook in
+  // `resources/hooks/purchasing-hooks.ts` fires only for writes through
+  // `UnifiedCrudHandler`, which is how an order is first drafted; re-pointing an existing
+  // order at a different supplier goes through `fieldValue.set` and reaches only this
+  // handler. It is also the only one of the two given `oldValue`, so it owns the rule that
+  // replaces this hook's own prefill without ever discarding a human's pick.
+  registerEntityFieldChangeHooks('purchase-orders', [
+    recomputeOnPurchaseOrderBillingChange,
+    prefillContactOnVendorChange,
+  ])
 
   // The three-way match (plans/purchasing/01-build-plan.md §6.2). `vendor_bill_status`,
   // `_match_variance` and `_match_notes` all declare the match hook as their only writer,

--- a/packages/lib/src/resources/hooks/__tests__/purchasing-hooks.test.ts
+++ b/packages/lib/src/resources/hooks/__tests__/purchasing-hooks.test.ts
@@ -14,6 +14,17 @@ vi.mock('../../../records/record-numbering', () => ({
   recordNumbering: { create: vi.fn() },
 }))
 
+const h = vi.hoisted(() => ({ bySystemAttributes: vi.fn(), getValues: vi.fn() }))
+
+vi.mock('../../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    getValues = h.getValues
+  },
+}))
+
 const { recordNumbering } = await import('../../../records/record-numbering')
 const createMock = vi.mocked(recordNumbering.create)
 
@@ -93,6 +104,93 @@ describe('vendor_bill_internal_number issuance', () => {
   })
 })
 
+const CONTACT_FIELD = { id: 'fld-contact', systemAttribute: 'purchase_order_contact' }
+const VENDOR_FIELD = { id: 'fld-vendor', systemAttribute: 'purchase_order_vendor' }
+const VENDOR = 'codef:co-1'
+const PRIMARY = 'ctdef:ct-1'
+
+/** What `company_primary_contact` resolves to for the vendor in the write. */
+function primaryContactIs(recordId: string | null) {
+  h.bySystemAttributes.mockResolvedValue({ company_primary_contact: { id: 'fld-cpc' } })
+  h.getValues.mockResolvedValue(
+    new Map(recordId ? [['fld-cpc', [{ type: 'relationship', recordId }]]] : [])
+  )
+}
+
+function vendorContext(overrides: Record<string, unknown> = {}): SystemHookContext {
+  return buildContext('purchase_order', 'purchase_order_vendor', VENDOR_FIELD.id, {
+    values: { [VENDOR_FIELD.id]: VENDOR },
+    allFields: [CONTACT_FIELD, VENDOR_FIELD],
+    ...overrides,
+  } as unknown as Partial<SystemHookContext>)
+}
+
+/** The CRUD door for the vendor -> contact default (purchasing plan 07). */
+describe('purchase_order_contact default', () => {
+  const hook = () => PURCHASE_ORDER_HOOKS.purchase_order_vendor![0]!
+
+  it('defaults the contact from the vendor\u2019s primary contact on create', async () => {
+    primaryContactIs(PRIMARY)
+
+    const values = await hook()(vendorContext())
+
+    expect(values[CONTACT_FIELD.id]).toBe(PRIMARY)
+  })
+
+  // A caller that named a person is not asking for a default. `values` is accepted keyed by
+  // field id OR by systemAttribute, so both keys have to be honoured.
+  it('never overwrites a contact named in the same write', async () => {
+    primaryContactIs(PRIMARY)
+
+    const byId = await hook()(
+      vendorContext({ values: { [VENDOR_FIELD.id]: VENDOR, [CONTACT_FIELD.id]: 'ctdef:mine' } })
+    )
+    const byAttribute = await hook()(
+      vendorContext({
+        values: { [VENDOR_FIELD.id]: VENDOR, purchase_order_contact: 'ctdef:mine' },
+      })
+    )
+
+    expect(byId[CONTACT_FIELD.id]).toBe('ctdef:mine')
+    expect(byAttribute[CONTACT_FIELD.id]).toBeUndefined()
+  })
+
+  // Re-pointing an existing order is the field-change twin's job \u2014 it is the only one of
+  // the two given `oldValue`, which is what tells this hook's own prefill from a human's pick.
+  it('does nothing on update', async () => {
+    primaryContactIs(PRIMARY)
+
+    const values = await hook()(vendorContext({ operation: 'update' }))
+
+    expect(values[CONTACT_FIELD.id]).toBeUndefined()
+  })
+
+  it('leaves the contact unset when the vendor names nobody', async () => {
+    primaryContactIs(null)
+
+    const values = await hook()(vendorContext())
+
+    expect(values[CONTACT_FIELD.id]).toBeUndefined()
+  })
+
+  it('leaves the contact unset when the write carries no vendor', async () => {
+    primaryContactIs(PRIMARY)
+
+    const values = await hook()(vendorContext({ values: {} }))
+
+    expect(values[CONTACT_FIELD.id]).toBeUndefined()
+  })
+
+  // An org that has not run migration 108's contact half has no field to write.
+  it('is inert on an org with no contact field', async () => {
+    primaryContactIs(PRIMARY)
+
+    const values = await hook()(vendorContext({ allFields: [VENDOR_FIELD] }))
+
+    expect(values).toEqual({ [VENDOR_FIELD.id]: VENDOR })
+  })
+})
+
 describe('purchasing hook registration', () => {
   // The miss that made native-order phase 1 ship numberless orders.
   it('is reachable through the entity-type registry, not just the module export', () => {
@@ -120,8 +218,17 @@ describe('purchasing hook registration', () => {
     expect(Object.keys(PURCHASE_ORDER_HOOKS).sort()).toEqual([
       'purchase_order_number',
       'purchase_order_status',
+      'purchase_order_vendor',
     ])
     expect(getHooksForAttribute('purchase_order', 'purchase_order_status')).toHaveLength(1)
+  })
+
+  // The contact default is keyed on the VENDOR, never on the contact: `runPreHooks` skips a
+  // hook on update unless its own systemAttribute is in `values`, so keyed on the contact it
+  // could never see which supplier the order was placed with.
+  it('keys the contact default on the vendor, not the contact', () => {
+    expect(getHooksForAttribute('purchase_order', 'purchase_order_vendor')).toHaveLength(1)
+    expect(getHooksForAttribute('purchase_order', 'purchase_order_contact')).toHaveLength(0)
   })
 
   // `vendor_bill_status` is recomputed by the match hook on every create/update, so a manual

--- a/packages/lib/src/resources/hooks/purchasing-hooks.ts
+++ b/packages/lib/src/resources/hooks/purchasing-hooks.ts
@@ -1,12 +1,19 @@
 // packages/lib/src/resources/hooks/purchasing-hooks.ts
 
+import { createScopedLogger } from '@auxx/logger'
+import type { TypedFieldValue } from '@auxx/types'
+import { getOrgCache } from '../../cache'
+import { FieldValueService } from '../../field-values/field-value-service'
 import { recordNumbering } from '../../records/record-numbering'
+import { isRecordId, type RecordId } from '../resource-id'
 import {
   createLifecycleStatusGuard,
   PURCHASE_ORDER_ACTION_STATUS_MESSAGE,
   PURCHASE_ORDER_ACTION_STATUSES,
 } from './lifecycle-status-guard'
 import type { SystemHook, SystemHookRegistry } from './types'
+
+const logger = createScopedLogger('resources:purchasing-hooks')
 
 /**
  * Auto-generate the purchase order number on create. Mirrors autoGenerateOrderNumber.
@@ -42,6 +49,119 @@ const autoGenerateVendorBillInternalNumber: SystemHook = async ({
   if (operation !== 'create') return values
   const { recordNumber } = await recordNumbering.create(organizationId, 'vendor_bill')
   return { ...values, [field.id]: recordNumber }
+}
+
+/**
+ * Unwrap a write-time value that may be scalar or a single-element array, then read a
+ * `RecordId` out of it. Relationship values reach a pre-hook as the `"<defId>:<instanceId>"`
+ * string, but some writers wrap the value in an array or in a `{ recordId }` object.
+ */
+function readRecordId(raw: unknown): RecordId | null {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (typeof value === 'string') return isRecordId(value) ? value : null
+  if (value && typeof value === 'object' && 'recordId' in value) {
+    const inner = (value as { recordId?: unknown }).recordId
+    return typeof inner === 'string' && isRecordId(inner) ? inner : null
+  }
+  return null
+}
+
+/**
+ * Read `company_primary_contact` off a company.
+ *
+ * Three-state on purpose, mirroring `resolveCatalogItemPart`:
+ * - a `RecordId` — the company names that person as its primary contact
+ * - `null` — the company resolved and names NOBODY
+ * - `undefined` — the primary contact could not be resolved at all (the org has no
+ *   `company_primary_contact` field, or the read failed). The caller must leave any
+ *   existing value alone in that case; collapsing it into `null` would clear a good
+ *   contact on a transient failure.
+ *
+ * ⚠️ A contact reaches a company through TWO different edges and this is only one of
+ * them: `company_primary_contact` inverts to `contact:company`, while
+ * `company_employees` inverts to `contact:employer`. A primary contact is not
+ * automatically an employee, and vice versa.
+ */
+export async function resolveCompanyPrimaryContact(params: {
+  organizationId: string
+  userId: string
+  companyRecordId: RecordId
+}): Promise<RecordId | null | undefined> {
+  const { organizationId, userId, companyRecordId } = params
+
+  try {
+    const cf = await getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttributes(['company_primary_contact'] as const)
+    if (!cf.company_primary_contact) return undefined
+
+    const values = await new FieldValueService(organizationId, userId).getValues({
+      recordId: companyRecordId,
+      fieldIds: [cf.company_primary_contact.id],
+    })
+    const entry = values.get(cf.company_primary_contact.id)
+    const typed: TypedFieldValue | undefined = Array.isArray(entry) ? entry[0] : entry
+    if (typed?.type === 'relationship' && typed.recordId) return typed.recordId
+    return null
+  } catch (error) {
+    logger.warn('could not resolve company_primary_contact', {
+      organizationId,
+      companyRecordId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
+}
+
+/**
+ * Default `purchase_order_contact` from the vendor's primary contact on CREATE
+ * (purchasing plan 07). `purchase_order_vendor` targets a `company`, and a company
+ * carries no email of its own, so without a contact a drafted order has nobody to
+ * send it to — the field was declared with this intent and shipped without a writer.
+ *
+ * ⚠️ **Registered under `purchase_order_vendor`, not `purchase_order_contact`.**
+ * `runPreHooks` skips a hook on UPDATE unless its own registered systemAttribute is
+ * present in `values`; keyed on the contact this would never see a vendor at all.
+ *
+ * ⚠️ **Create only.** This is the CRUD door — `record.create`, the importer, the SDK.
+ * Every interactive vendor change goes through `fieldValue.set`, which never reads
+ * this registry, and is handled by the field-change twin in
+ * `field-hooks/post/purchase-order-contact-prefill.ts`. That twin owns the re-point
+ * case because it is the only one of the two given `oldValue`, which is what tells
+ * this hook's own prefill apart from a human's pick.
+ *
+ * An explicit contact in the SAME write always wins — a caller that named a person
+ * is not asking for a default.
+ */
+const prefillContactFromVendor: SystemHook = async ({
+  operation,
+  values,
+  organizationId,
+  userId,
+  allFields,
+}) => {
+  if (operation !== 'create') return values
+
+  const contactField = allFields.find((f) => f.systemAttribute === 'purchase_order_contact')
+  if (!contactField) return values
+  // `values` is accepted keyed by field id OR by systemAttribute, so an explicit
+  // contact can arrive under either.
+  if (values[contactField.id] != null || values.purchase_order_contact != null) return values
+
+  const vendorField = allFields.find((f) => f.systemAttribute === 'purchase_order_vendor')
+  const vendor = readRecordId(
+    (vendorField ? values[vendorField.id] : undefined) ?? values.purchase_order_vendor
+  )
+  if (!vendor) return values
+
+  const contact = await resolveCompanyPrimaryContact({
+    organizationId,
+    userId,
+    companyRecordId: vendor,
+  })
+  if (!contact) return values
+
+  return { ...values, [contactField.id]: contact }
 }
 
 /**
@@ -83,12 +203,14 @@ const rejectManualLifecycleStatus: SystemHook = createLifecycleStatusGuard({
 })
 
 /**
- * `purchase_order` system hooks: the RecordSequence number on create, and the lifecycle
- * guard that keeps `issued` an action rather than a dropdown value.
+ * `purchase_order` system hooks: the RecordSequence number on create, the lifecycle guard
+ * that keeps `issued` an action rather than a dropdown value, and the contact default
+ * derived from the vendor.
  */
 export const PURCHASE_ORDER_HOOKS: SystemHookRegistry = {
   purchase_order_number: [autoGeneratePurchaseOrderNumber],
   purchase_order_status: [rejectManualLifecycleStatus],
+  purchase_order_vendor: [prefillContactFromVendor],
 }
 
 /**


### PR DESCRIPTION
Completes [`plans/purchasing/07-purchase-order-send-and-status.md`](plans/purchasing/07-purchase-order-send-and-status.md). #1939 split the status into three axes and gave `markPurchaseOrderSent` a caller in the API; this adds the surfaces that actually reach it.

## Send from the purchase order's own page

The lines tab takes the Send/Resend cluster plus the secondary dropdown, teleported into the wrapping `<Section>` header by `DocumentSectionActions` — exactly as quote and invoice do. A purchase order is the **third** consumer of `useDocumentSendActions`, and that hook needed no changes to take it.

`closed` and `canceled` are the two terminal decisions, so they drop the Send segment entirely and the cluster falls back.

## `issued` IS "sent to the vendor"

The confirmed-send flip in the thread router writes `issued` where the quote and invoice branches write `sent` — one event, no separate `sent` value on this document.

A `BadRequestError` out of `markPurchaseOrderSent` means the order was already issued (a resend) or is closed/canceled, so it is caught rather than failing a send that has already physically happened.

## The contact prefill has two doors, and the second is the one the UI uses

`purchase_order_contact` now defaults from the vendor's `company_primary_contact` — intent that was recorded on the field itself long ago and shipped without a writer.

| door | covers | when it fires |
| --- | --- | --- |
| `purchase_order_vendor` **system** hook | `record.create`, the importer, the SDK | how an order is first drafted against a supplier |
| `prefillContactOnVendorChange` **field-change** hook | `useSaveFieldValue` → `fieldValue.set` → `FieldValueService` | **every edit to an existing order** |

The second is load-bearing: `FieldValueService` consults only the field-hook registries and **never reads the system-hook registry at all**. Re-pointing an existing order at a different supplier reaches only that handler. The same split is already recorded on `line-item-part-stamp.ts` and on the two `purchase_order_status` guards.

**Both doors are keyed on `purchase_order_vendor`, not on the contact.** `runPreHooks` skips a system hook on UPDATE unless its own `systemAttribute` is present in `values`, so a twin keyed on the contact would fire on create only.

## It is a prefill, not a stamp

`line_item_part` is provenance and always overwrites. A contact is a *person somebody chose*, so the rule is narrower — **replace our own prefill, never a human's pick**:

- no contact yet → fill from the new vendor
- the contact equals the **old** vendor's primary contact → it was this hook's own prefill, so re-derive from the new vendor
- anything else → a human picked that person; leave it alone

Which is why the field-change door owns the rule: it is the only one of the two given `oldValue`.

`resolveCompanyPrimaryContact` is **three-state on purpose**, mirroring `resolveCatalogItemPart`:

- a `RecordId` — the company names that person
- `null` — the company resolved and names **nobody**
- `undefined` — the primary contact could not be resolved at all (no `company_primary_contact` field in the org, or the read failed)

Collapsing `undefined` into `null` would clear a good contact on a transient failure.

⚠️ Noted in the code: a contact reaches a company through **two** different edges and this is only one of them — `company_primary_contact` inverts to `contact:company`, while `company_employees` inverts to `contact:employer`. A primary contact is not automatically an employee, or vice versa.
