### PR TITLE
fix(build): a build cannot be marked completed by hand

### DIFF
--- a/apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
@@ -99,7 +99,7 @@ export function BuildLedgerCard({ entityInstanceId }: DrawerTabProps) {
   if (records.length === 0) {
     // Not an error and not a gap: a `planned` build writes no movements at all
     // (B2), which is the safety property the whole phasing rests on.
-    return <EmptyRow label='Nothing posted yet — a build writes its ledger when it completes' />
+    return <EmptyRow label='Nothing posted yet (A build writes its ledger when it completes)' />
   }
 
   return (

--- a/packages/lib/src/builds/__tests__/build-event.test.ts
+++ b/packages/lib/src/builds/__tests__/build-event.test.ts
@@ -159,7 +159,7 @@ vi.mock('../../resources/crud/unified-handler', () => ({
   },
 }))
 
-import { createBuild } from '../build-mutations'
+import { cancelBuild, createBuild, startBuild } from '../build-mutations'
 import { completeBuild } from '../complete-build'
 import { reverseBuild } from '../reverse-build'
 
@@ -766,5 +766,98 @@ describe('reverseBuild', () => {
     const error = await expectErr(reverseBuild(db, ORG, USER, { buildId: BUILD }))
     expect(error).toBeInstanceOf(ConflictError)
     expect(h.created).toEqual([])
+  })
+})
+
+// ─── the build_status lifecycle wall ────────────────────────────────────
+
+/**
+ * 🛑 `field-hooks/pre/build-status-guard.ts` refuses a manual write of `in_progress`,
+ * `completed` or `canceled`. `fireFieldPreHooks` short-circuits on
+ * `ctx.bypassFieldGuards.has(systemAttribute)` BEFORE that handler runs, and
+ * `UnifiedCrudHandler` forwards the set it was constructed with to the `FieldValueService`
+ * it owns — so these assertions are the only thing standing between the guard and Start /
+ * Complete / Cancel / Reverse silently ceasing to work
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4: half of this fix is
+ * worse than none).
+ *
+ * Nothing in this file's doubles enforces the guard, which is precisely why the bypass has
+ * to be asserted rather than inferred from a green test.
+ */
+describe('every sanctioned build_status writer carries its bypass', () => {
+  /** The bypass set of the handler that performed the Nth construction. */
+  function bypasses(index = 0): string[] {
+    const options = h.constructions[index]
+    const set = options?.bypassFieldGuards as ReadonlySet<string> | undefined
+    return set ? [...set] : []
+  }
+
+  it('createBuild bypasses, even though planned is not guarded', async () => {
+    // The exemption belongs to the WRITER, not to today's value set — widening the guard
+    // later must not break the action that raises a build.
+    await createBuild(db, ORG, USER, { partId: PART_LIFT, quantityPlanned: 10 })
+    expect(bypasses()).toEqual(['build_status'])
+  })
+
+  it('startBuild bypasses — it writes the guarded in_progress', async () => {
+    const result = await startBuild(db, ORG, USER, { buildId: BUILD })
+    expect(result.isOk()).toBe(true)
+    expect(h.updated[0]?.values).toMatchObject({ build_status: 'in_progress' })
+    expect(bypasses()).toEqual(['build_status'])
+  })
+
+  it('cancelBuild bypasses — it writes the guarded canceled', async () => {
+    const result = await cancelBuild(db, ORG, USER, { buildId: BUILD })
+    expect(result.isOk()).toBe(true)
+    expect(h.updated[0]?.values).toMatchObject({ build_status: 'canceled' })
+    expect(bypasses()).toEqual(['build_status'])
+  })
+
+  it('completeBuild bypasses — without it the ledger writer is refused by its own wall', async () => {
+    const result = await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    expect(result.isOk()).toBe(true)
+    expect(bypasses()).toEqual(['build_status'])
+  })
+
+  it('reverseBuild bypasses — the reversing build is CREATED at completed', async () => {
+    // 🛑 The field chain has no `operation === 'create'` exemption, so a create carrying a
+    // guarded value is refused exactly like an update. B6's only correction for a posted run
+    // depends on this.
+    h.valueRows = [...completedBuildRows(), ...completedMovementRows(), ...partKindRows()]
+    h.movementInstances = [{ id: 'mv_1' }, { id: 'mv_2' }]
+
+    const result = await reverseBuild(db, ORG, USER, { buildId: BUILD })
+    expect(result.isOk()).toBe(true)
+    expect(buildWrites()[0]).toMatchObject({ build_status: 'completed' })
+    expect(bypasses()).toEqual(['build_status'])
+  })
+
+  // 🛑 ONE element. `completeBuild` and `reverseBuild` write their stock movements through
+  // the SAME handler and so inherit this set; a second attribute would silently disarm a
+  // guard on the movement rows and nothing would say so — the same narrowness that keeps
+  // `markQuoteSent`'s mirror write safe (21 §7.1).
+  it('names build_status and nothing else, on every handler it constructs', async () => {
+    h.valueRows = [...completedBuildRows(), ...completedMovementRows(), ...partKindRows()]
+    h.movementInstances = [{ id: 'mv_1' }, { id: 'mv_2' }]
+    await reverseBuild(db, ORG, USER, { buildId: BUILD })
+
+    expect(h.constructions.length).toBeGreaterThan(0)
+    for (const options of h.constructions) {
+      const set = options?.bypassFieldGuards as ReadonlySet<string> | undefined
+      expect(set).toBeDefined()
+      expect(set?.size).toBe(1)
+      expect(set?.has('build_status')).toBe(true)
+      expect(set?.has('stock_movement_type')).toBe(false)
+      expect(set?.has('stock_movement_unit_cost')).toBe(false)
+    }
+  })
+
+  it('keeps the quiet lane and the bypass on the same handler', async () => {
+    await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+    const ledgerHandlers = h.constructions.filter((options) => options?.session)
+    expect(ledgerHandlers).toHaveLength(1)
+    expect([...(ledgerHandlers[0]?.bypassFieldGuards as ReadonlySet<string>)]).toEqual([
+      'build_status',
+    ])
   })
 })

--- a/packages/lib/src/builds/build-mutations.ts
+++ b/packages/lib/src/builds/build-mutations.ts
@@ -19,6 +19,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { and, eq, isNull } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { loadDirectSubparts } from '../bom/subpart-graph'
@@ -39,6 +40,27 @@ import { guard } from './guard'
 import type { BuildRecord, CancelBuildInput, CreateBuildInput, StartBuildInput } from './types'
 
 const logger = createScopedLogger('builds:mutations')
+
+/**
+ * The exemption every sanctioned writer of `build_status` carries.
+ *
+ * `field-hooks/pre/build-status-guard.ts` refuses a manual write of `in_progress`,
+ * `completed` or `canceled`, and `fireFieldPreHooks` short-circuits on
+ * `ctx.bypassFieldGuards.has(systemAttribute)` before that handler runs.
+ * `UnifiedCrudHandler` forwards this set to the `FieldValueService` it owns, so passing it at
+ * construction is what lets these functions produce the values the wall exists to protect.
+ *
+ * 🛑 **Without it the guard refuses the actions it was built for** — Start, Complete and
+ * Cancel simply stop working, which is the half-a-fix failure mode
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4).
+ *
+ * 🛑 **ONE element, asserted by a test.** `completeBuild` and `reverseBuild` write their stock
+ * movements through the same handler and so inherit this set; naming a second attribute would
+ * silently disarm a guard on the movement rows, and nothing would say so.
+ */
+export const BUILD_STATUS_BYPASS: ReadonlySet<SystemAttribute> = new Set<SystemAttribute>([
+  'build_status',
+])
 
 /**
  * Raise a build. Always lands `planned`.
@@ -108,7 +130,12 @@ export async function createBuild(
       // that write stock movements take the quiet lane (`write-lane.ts`); a
       // planned build writes nothing a record rule can act on, and silencing it
       // would cost the list its realtime update for no benefit.
-      const crud = new UnifiedCrudHandler(organizationId, userId, db)
+      // `planned` is not in the guarded set, but the bypass is here anyway: the exemption
+      // belongs to the sanctioned WRITER rather than to today's value set, so widening the
+      // guard later cannot silently break the action that raises a build.
+      const crud = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+        bypassFieldGuards: BUILD_STATUS_BYPASS,
+      })
       const created = await crud.create(ctx.buildDefId, values)
 
       logger.info('Raised build', {
@@ -204,7 +231,11 @@ async function updateBuild(
   buildId: string,
   values: Record<string, unknown>
 ): Promise<void> {
-  const crud = new UnifiedCrudHandler(organizationId, userId, db)
+  const crud = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+    // Both callers write a GUARDED value — `startBuild` sets `in_progress`, `cancelBuild`
+    // sets `canceled` — so this is what keeps the two actions working.
+    bypassFieldGuards: BUILD_STATUS_BYPASS,
+  })
   await crud.update(toRecordId(ctx.buildDefId, buildId) as RecordId, values)
 }
 

--- a/packages/lib/src/builds/complete-build.ts
+++ b/packages/lib/src/builds/complete-build.ts
@@ -62,6 +62,7 @@ import {
   StockMovementType,
 } from '../resources/registry/enum-values'
 import { type RecordId, toRecordId } from '../resources/resource-id'
+import { BUILD_STATUS_BYPASS } from './build-mutations'
 import {
   assertBuildStatus,
   type BuildFieldContext,
@@ -251,6 +252,13 @@ async function writeCompletion(
   const crud = new UnifiedCrudHandler(organizationId, userId, txDb, undefined, {
     // The one construction site for the quiet lane. See `write-lane.ts`.
     session: buildWriteSession(),
+    // 🛑 Step 6 writes `build_status: 'completed'`, which
+    // `field-hooks/pre/build-status-guard.ts` refuses on a manual write. Without this the
+    // wall built to protect the ledger would refuse the only function that writes it.
+    // ⚠️ The movement `create`s below share this handler and so inherit the set; that is
+    // safe only because it names `build_status` alone and `stock_movement` has no such
+    // attribute.
+    bypassFieldGuards: BUILD_STATUS_BYPASS,
   })
 
   const buildRecordId = toRecordId(ctx.buildDefId, build.buildId)

--- a/packages/lib/src/builds/reverse-build.ts
+++ b/packages/lib/src/builds/reverse-build.ts
@@ -54,7 +54,7 @@ import { computeExtendedCost } from '../receiving/client'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { BuildStatus, StockMovementCostBasis } from '../resources/registry/enum-values'
 import { toRecordId } from '../resources/resource-id'
-import { requireDefId } from './build-mutations'
+import { BUILD_STATUS_BYPASS, requireDefId } from './build-mutations'
 import {
   assertBuildStatus,
   type BuildFieldContext,
@@ -185,6 +185,11 @@ async function writeReversal(
     // The same quiet lane the completion takes, for the same reasons — see
     // `write-lane.ts` and `complete-build.ts`'s header.
     session: buildWriteSession(),
+    // 🛑 The reversing build is CREATED at `completed` (there is no planned reversal), and
+    // the field pre-hook chain has no `operation === 'create'` exemption — a create carrying
+    // a guarded value is refused exactly like an update. Without this, B6's only correction
+    // for a posted run stops working.
+    bypassFieldGuards: BUILD_STATUS_BYPASS,
   })
 
   // Resolved only when the original names one, so an org with no orders is

--- a/packages/lib/src/field-hooks/__tests__/build-status-guard-registration.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/build-status-guard-registration.test.ts
@@ -1,0 +1,85 @@
+// packages/lib/src/field-hooks/__tests__/build-status-guard-registration.test.ts
+//
+// 🛑 `build_status` is guarded on the FIELD pre-hook chain and deliberately NOT on the
+// system-hook chain, which is a departure from `quote_status` / `invoice_status` /
+// `purchase_order_status`. The reason is mechanical and this file is what keeps it from
+// being "fixed" by someone restoring symmetry:
+//
+//   - `UnifiedCrudHandler.runPreHooks` consults no equivalent of `bypassFieldGuards`.
+//   - `startBuild`, `cancelBuild` and `completeBuild` all write `build_status` through
+//     `UnifiedCrudHandler.update`, so a system twin would refuse the three actions it exists
+//     to protect — trap 2 of plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4
+//     arriving on a chain with no way to answer it.
+//   - It would add no coverage either: `record.create` / `record.update`, the CSV importer
+//     and the SDK all reach field values through `setFieldValues` -> `FieldValueService` ->
+//     `fireFieldPreHooks`, so the field guard already sees them.
+//
+// Separate from `pre/build-status-guard.test.ts` because `getFieldPreHooks` self-inits the
+// whole hook bootstrap, which needs the real `@auxx/database` module graph.
+
+import { describe, expect, it } from 'vitest'
+import { guardManualBuildLifecycleStatus } from '../pre/build-status-guard'
+import { getFieldPreHooks, hasFieldPreHooks } from '../registry'
+import type { FieldPreHookEvent } from '../types'
+
+describe('build_status guard registration', () => {
+  // The slug, not the entityType: `fireFieldPreHooks` keys off `resource.apiSlug`, which is
+  // `builds`. Registering under `build` would be a silent no-op.
+  it('is on the field pre-hook chain for builds', () => {
+    expect(hasFieldPreHooks('builds', 'build_status')).toBe(true)
+    expect(getFieldPreHooks('builds', 'build_status')).toContain(guardManualBuildLifecycleStatus)
+  })
+
+  it('is registered under the apiSlug, not the entityType', () => {
+    expect(hasFieldPreHooks('build', 'build_status')).toBe(false)
+  })
+
+  // 🛑 Not an oversight. See the header — a system twin would break Start, Complete and
+  // Cancel, because system hooks cannot be bypassed and those three write through
+  // `UnifiedCrudHandler.update`.
+  it('has NO system-hook twin, on purpose', async () => {
+    const { getHooksForAttribute } = await import('../../resources/hooks/system-hooks')
+    expect(getHooksForAttribute('build', 'build_status')).toHaveLength(0)
+  })
+
+  it('leaves the build number hook alone on the system chain', async () => {
+    const { getHooksForAttribute } = await import('../../resources/hooks/system-hooks')
+    expect(getHooksForAttribute('build', 'build_number')).toHaveLength(1)
+  })
+})
+
+describe('one source for what build_status guards', () => {
+  it('reads its set and message from the shared lifecycle module', async () => {
+    const { BUILD_ACTION_STATUSES, BUILD_ACTION_STATUS_MESSAGE } = await import(
+      '../../resources/hooks/lifecycle-status-guard'
+    )
+    expect([...BUILD_ACTION_STATUSES]).toEqual(['in_progress', 'completed', 'canceled'])
+
+    // The SAME value, in the shape the field chain actually delivers — never a bare string.
+    await expect(
+      guardManualBuildLifecycleStatus({
+        newValue: { type: 'option', optionId: 'completed' },
+      } as unknown as FieldPreHookEvent)
+    ).rejects.toThrow(BUILD_ACTION_STATUS_MESSAGE)
+  })
+
+  // The three money sets are untouched by this change. If one of them grows a build value
+  // (or the build set grows a money one) the factory would guard the wrong document.
+  it('does not overlap the quote, invoice or purchase-order sets', async () => {
+    const {
+      BUILD_ACTION_STATUSES,
+      INVOICE_ACTION_STATUSES,
+      PURCHASE_ORDER_ACTION_STATUSES,
+      QUOTE_ACTION_STATUSES,
+    } = await import('../../resources/hooks/lifecycle-status-guard')
+
+    const build = new Set<string>(BUILD_ACTION_STATUSES)
+    for (const other of [
+      QUOTE_ACTION_STATUSES,
+      INVOICE_ACTION_STATUSES,
+      PURCHASE_ORDER_ACTION_STATUSES,
+    ]) {
+      for (const value of other) expect(build.has(value)).toBe(false)
+    }
+  })
+})

--- a/packages/lib/src/field-hooks/pre/build-status-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/build-status-guard.test.ts
@@ -1,0 +1,122 @@
+// packages/lib/src/field-hooks/pre/build-status-guard.test.ts
+//
+// 🛑 The bug this file exists to prevent is a guard that cannot fire. By the time
+// `fireFieldPreHooks` runs, `validateAndConvertValue` has turned a SINGLE_SELECT write into
+// `{ type: 'option', optionId: 'completed' }` — never the bare string `'completed'` — so a
+// guard comparing `event.newValue` to `'completed'` passes everything and is
+// indistinguishable from a guard nothing has tripped. It reads correctly in review and
+// passes any unit test that only feeds it a bare string
+// (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §2).
+//
+// So every rejection case below feeds the COERCED envelope the client path actually
+// produces. A version of `guardManualBuildLifecycleStatus` that only understood bare strings
+// would pass `rejects a bare string` and fail every `coerced(...)` case — which is exactly
+// the discrimination this file is for.
+
+import { describe, expect, it } from 'vitest'
+import { BadRequestError } from '../../errors'
+import {
+  BUILD_ACTION_STATUS_MESSAGE,
+  BUILD_ACTION_STATUSES,
+} from '../../resources/hooks/lifecycle-status-guard'
+import type { FieldPreHookEvent } from '../types'
+import { guardManualBuildLifecycleStatus } from './build-status-guard'
+
+/** The shape `validateAndConvertValue` hands a SINGLE_SELECT pre-hook. */
+function coerced(optionId: string) {
+  return { type: 'option', optionId }
+}
+
+function event(newValue: unknown): FieldPreHookEvent {
+  return {
+    recordId: 'def-build:bld-1',
+    entityDefinitionId: 'def-build',
+    entityType: 'build',
+    entitySlug: 'builds',
+    fieldId: 'f-status',
+    systemAttribute: 'build_status',
+    field: { id: 'f-status', systemAttribute: 'build_status' },
+    newValue,
+    // Deliberately `undefined`, because that is what `fireFieldPreHooks` passes on the
+    // single-field path. It is also why this guard is a VALUE wall rather than a transition
+    // wall: a guard that tried to read the previous status here would never fire.
+    existingValue: undefined,
+    allValues: new Map<string, unknown>(),
+    organizationId: 'org-1',
+    userId: 'user-1',
+    bypass: new Set(),
+  } as unknown as FieldPreHookEvent
+}
+
+describe('build_status manual-write wall', () => {
+  it('guards exactly in_progress, completed and canceled', () => {
+    expect([...BUILD_ACTION_STATUSES]).toEqual(['in_progress', 'completed', 'canceled'])
+  })
+
+  it.each([
+    ...BUILD_ACTION_STATUSES,
+  ])('rejects the coerced option envelope for %s', async (status) => {
+    await expect(guardManualBuildLifecycleStatus(event(coerced(status)))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+
+  // 🛑 The one that matters most. `completeBuild` writes the consume/produce movements,
+  // stamps five cost fields and computes the variance; a hand-set `completed` records a
+  // finished production run with none of it, and every downstream read believes it.
+  it('rejects a hand-set completed — a build with no ledger behind it', async () => {
+    await expect(guardManualBuildLifecycleStatus(event(coerced('completed')))).rejects.toThrow(
+      BUILD_ACTION_STATUS_MESSAGE
+    )
+  })
+
+  it('names the actions, so the message says which button to press', async () => {
+    await expect(guardManualBuildLifecycleStatus(event(coerced('canceled')))).rejects.toThrow(
+      'Use the build actions (Start / Complete / Cancel / Reverse) to set this status'
+    )
+  })
+
+  // A guard that only handled the envelope would be half-dead the moment a caller writes an
+  // already-typed value.
+  it.each([...BUILD_ACTION_STATUSES])('rejects a bare string %s too', async (status) => {
+    await expect(guardManualBuildLifecycleStatus(event(status))).rejects.toThrow(BadRequestError)
+  })
+
+  it('rejects a single-element array of either shape', async () => {
+    await expect(guardManualBuildLifecycleStatus(event([coerced('completed')]))).rejects.toThrow(
+      BadRequestError
+    )
+    await expect(guardManualBuildLifecycleStatus(event(['completed']))).rejects.toThrow(
+      BadRequestError
+    )
+  })
+
+  // 🛑 `planned` is `build_status`'s `defaultValue`, and `applyDefaults` injects a creatable
+  // field's default into EVERY create before the write reaches this chain — which, unlike
+  // the system-hook chain, has no `operation === 'create'` exemption. Guarding it would
+  // refuse every build create through the generic door, not merely one carrying an unusual
+  // status. Same structural reason `draft` is absent from the quote and invoice sets.
+  it('leaves planned freely editable — it is the defaultValue every create carries', async () => {
+    const next = coerced('planned')
+    await expect(guardManualBuildLifecycleStatus(event(next))).resolves.toBe(next)
+    await expect(guardManualBuildLifecycleStatus(event(['planned']))).resolves.toEqual(['planned'])
+  })
+
+  it('lets a clear through rather than treating null as a guarded value', async () => {
+    await expect(guardManualBuildLifecycleStatus(event(null))).resolves.toBeNull()
+  })
+
+  it('returns the value untouched — it is a guard, not a transform', async () => {
+    const next = coerced('planned')
+    await expect(guardManualBuildLifecycleStatus(event(next))).resolves.toBe(next)
+  })
+
+  // The build guard is built from the same factory as the quote and invoice ones, so
+  // swapping the constant arrays is a one-character mistake nothing else would catch.
+  it('does not reject another document status that happens to share the field', async () => {
+    for (const foreign of ['sent', 'approved', 'paid', 'void', 'issued', 'closed']) {
+      const next = coerced(foreign)
+      await expect(guardManualBuildLifecycleStatus(event(next))).resolves.toBe(next)
+    }
+  })
+})

--- a/packages/lib/src/field-hooks/pre/build-status-guard.ts
+++ b/packages/lib/src/field-hooks/pre/build-status-guard.ts
@@ -1,0 +1,70 @@
+// packages/lib/src/field-hooks/pre/build-status-guard.ts
+
+import {
+  BUILD_ACTION_STATUS_MESSAGE,
+  BUILD_ACTION_STATUSES,
+} from '../../resources/hooks/lifecycle-status-guard'
+import type { FieldPreHookHandler } from '../types'
+import { createFieldLifecycleStatusGuard } from './lifecycle-status-guard'
+
+/**
+ * The manual-`in_progress`/`completed`/`canceled` wall for `build_status`.
+ *
+ * 🛑 **The build subsystem already enforced its transitions, on a door nobody interactive
+ * uses.** `startBuild` / `completeBuild` / `cancelBuild` / `reverseBuild` all call
+ * `assertBuildStatus` (`builds/build-queries.ts`) against the `canStartBuild` /
+ * `canCompleteBuild` / `canCancelBuild` / `canReverseBuild` predicates, so the transition
+ * matrix is correct *inside those functions*. `fieldValue.set` never reaches them. Every
+ * drawer edit, grid inline edit, kanban drag and Kopilot record tool goes
+ * `useSaveFieldValue -> api.fieldValue.set -> FieldValueService -> fireFieldPreHooks`, so
+ * until this handler existed a raw write could set `build_status: 'completed'` directly and
+ * record a finished production run with no movements, no costs and no variance behind it —
+ * the same defect `quote_status` / `invoice_status` / `purchase_order_status` had
+ * (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §1), and sharper, because a
+ * build is the thing that writes the ledger.
+ *
+ * ⚠️ **The value here is already coerced, and that is the trap this guard is built to avoid.**
+ * By the time `fireFieldPreHooks` runs, `validateAndConvertValue` has turned a SINGLE_SELECT
+ * write into `{ type: 'option', optionId: 'completed' }` — it is **never** a bare string on
+ * this chain. A guard comparing `event.newValue` to `'completed'` directly is inert: the
+ * comparison can never be true, so it passes everything, reads correctly in review and passes
+ * any unit test that feeds it a bare string (§2). `unwrapStatusValue`, shared with the
+ * system-hook factory, is what makes that unnecessary to remember.
+ *
+ * ✅ **The five sanctioned writers get through on `bypassFieldGuards`,** which
+ * `fireFieldPreHooks` honours before any handler runs. All five write `build_status` through
+ * `UnifiedCrudHandler`, whose constructor forwards the set to its internal
+ * `FieldValueService`:
+ *
+ * | writer | file | value |
+ * | --- | --- | --- |
+ * | `createBuild` | `builds/build-mutations.ts` | `planned` |
+ * | `startBuild` | `builds/build-mutations.ts` | `in_progress` |
+ * | `cancelBuild` | `builds/build-mutations.ts` | `canceled` |
+ * | `completeBuild` | `builds/complete-build.ts` | `completed` |
+ * | `reverseBuild` | `builds/reverse-build.ts` | `completed` (on the reversing build's CREATE) |
+ *
+ * 🛑 That half is not optional. `createBuild` is in the table even though `planned` is not in
+ * the guarded set, and `reverseBuild` is in it because the field chain has no
+ * `operation === 'create'` exemption — a create carrying a guarded value is refused exactly
+ * like an update. Both carry the bypass so the exemption belongs to the sanctioned WRITER
+ * rather than to today's value set, the same reasoning that put one on `declineQuote`.
+ *
+ * ⚠️ **`completeBuild` and `reverseBuild` share their handler with the stock-movement
+ * writes,** so those inherit the bypass too. That is safe only because the set names
+ * `build_status` and nothing else, and `stock_movement` has no such attribute — the same
+ * narrowness that keeps `markQuoteSent`'s mirror write onto `service_request` safe (§7.1).
+ * Pinned by a test.
+ *
+ * 🛑 **There is deliberately no system-hook twin, unlike the other three.** See
+ * `resources/hooks/build-hooks.ts` for the argument: `SystemHook`s do not consult
+ * `bypassFieldGuards`, and all three build UPDATE writers go through
+ * `UnifiedCrudHandler.runPreHooks`, so registering one would refuse Start, Complete and
+ * Cancel. It would also add no coverage — those callers write on through to this chain.
+ */
+export const guardManualBuildLifecycleStatus: FieldPreHookHandler = createFieldLifecycleStatusGuard(
+  {
+    guardedValues: BUILD_ACTION_STATUSES,
+    message: BUILD_ACTION_STATUS_MESSAGE,
+  }
+)

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -54,6 +54,7 @@ import { stampPartOnCatalogItemChange } from './post/line-item-part-stamp'
 import { publishFieldChangeEvent } from './post/publish-field-change-event'
 import { prefillContactOnVendorChange } from './post/purchase-order-contact-prefill'
 import { touchActivityOnFieldChange } from './post/touch-activity-on-field-change'
+import { guardManualBuildLifecycleStatus } from './pre/build-status-guard'
 import { guardInboxOwnerField } from './pre/inbox-owner-guard'
 import { guardInvoiceDelete } from './pre/invoice-delete-guard'
 import {
@@ -352,6 +353,26 @@ export function registerAllHooks(): void {
   registerFieldPreHooks('purchase-orders', 'purchase_order_status', [
     guardManualPurchaseOrderIssued,
   ])
+
+  // Manual-`in_progress`/`completed`/`canceled` wall for `build_status`. The build subsystem
+  // enforced its transitions inside `startBuild` / `completeBuild` / `cancelBuild` /
+  // `reverseBuild` via `assertBuildStatus`, which is a DIFFERENT door: a drawer edit, a grid
+  // inline edit, a kanban drag or a Kopilot record tool writes through `fieldValue.set` ->
+  // `FieldValueService` and reaches none of them. Until this registration existed,
+  // `build_status: 'completed'` was typeable by hand — a finished production run with no
+  // movements, no costs and no variance, believed by every downstream read.
+  //
+  // All five sanctioned writers pass `bypassFieldGuards: ['build_status']` through their
+  // `UnifiedCrudHandler`, which forwards it to the `FieldValueService` it owns: `createBuild`,
+  // `startBuild`, `cancelBuild` (`builds/build-mutations.ts`), `completeBuild`
+  // (`builds/complete-build.ts`) and `reverseBuild` (`builds/reverse-build.ts`).
+  // 🛑 A new sanctioned writer means a new bypass, not a weaker guard.
+  //
+  // 🛑 NO system-hook twin, unlike the other three — see `resources/hooks/build-hooks.ts`.
+  // System hooks do not consult `bypassFieldGuards`, and the three build writers that write
+  // status on an UPDATE go through `UnifiedCrudHandler.runPreHooks`, so a twin would refuse
+  // Start, Complete and Cancel while adding no coverage this registration lacks.
+  registerFieldPreHooks('builds', 'build_status', [guardManualBuildLifecycleStatus])
 
   // Purchase order line evidence lock (plans/purchasing/07-purchase-order-send-and-status.md
   // §6.5) — a line's agreed quantity and price freeze once a receipt or a vendor bill line

--- a/packages/lib/src/resources/hooks/build-hooks.ts
+++ b/packages/lib/src/resources/hooks/build-hooks.ts
@@ -36,12 +36,32 @@ const autoGenerateBuildNumber: SystemHook = async ({
 /**
  * `build` system hooks: the RecordSequence number on create, and nothing else.
  *
- * No lifecycle guard for `build_status`. Unlike `quote_status` / `invoice_status` /
- * `purchase_order_status`, the build lifecycle is enforced inside the commands that own
- * it — `startBuild` / `completeBuild` / `cancelBuild` all go through `assertBuildStatus`
- * in `builds/build-queries.ts`. That is a different door from this registry, so a raw
- * `record.update` is not walled the way those three attributes are; putting that wall up
- * is its own change, not a side effect of giving the number a writer.
+ * 🛑 **`build_status` IS walled now, and deliberately NOT here.** Its guard lives on the
+ * FIELD pre-hook chain only — `field-hooks/pre/build-status-guard.ts`, registered against
+ * `('builds', 'build_status')`. That is a departure from `quote_status` / `invoice_status` /
+ * `purchase_order_status`, which carry the guard on both chains, and the reason is
+ * mechanical rather than a matter of taste:
+ *
+ * 1. **A system hook cannot be bypassed.** `UnifiedCrudHandler.runPreHooks` consults no
+ *    equivalent of `bypassFieldGuards` — the exemption exists only on the field chain
+ *    (`fireFieldPreHooks`). The money writers never collide with that because they write
+ *    status through `FieldValueService` directly and so never enter this registry at all.
+ *    **The build writers do not**: `startBuild`, `cancelBuild` and `completeBuild` each write
+ *    `build_status` through `UnifiedCrudHandler.update`, which runs every hook registered
+ *    here. A twin would therefore refuse the three actions it was built to protect — trap 2
+ *    of plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4, arriving through a
+ *    chain that has no way to answer it.
+ * 2. **It would add no coverage.** The doors a system hook is kept for — `record.create` /
+ *    `record.update`, the CSV importer, the SDK — all reach the field values through
+ *    `UnifiedCrudHandler.setFieldValues` -> `FieldValueService` -> `fireFieldPreHooks` with
+ *    an empty bypass set, so the field guard already sees them. The system twin's one
+ *    distinguishing behaviour is its `operation === 'create'` exemption, which makes it
+ *    strictly weaker, not additive.
+ *
+ * The transition MATRIX still lives where it always did — `assertBuildStatus` in
+ * `builds/build-queries.ts`, against `canStartBuild` / `canCompleteBuild` / `canCancelBuild`
+ * / `canReverseBuild`. The field guard does not duplicate it; it only stops a manual write
+ * from routing around it.
  */
 export const BUILD_HOOKS: SystemHookRegistry = {
   build_number: [autoGenerateBuildNumber],

--- a/packages/lib/src/resources/hooks/lifecycle-status-guard.ts
+++ b/packages/lib/src/resources/hooks/lifecycle-status-guard.ts
@@ -56,6 +56,49 @@ export const INVOICE_ACTION_STATUS_MESSAGE =
   'Use the invoice actions (Send / Record payment / Void) to set this status'
 
 /**
+ * The `build_status` values an ACTION owns. The enum is
+ * `planned | in_progress | completed | canceled`, and this set is three of the four.
+ *
+ * 🛑 **`completed` is ledger-derived, and more strongly than any status above it.**
+ * `completeBuild` writes one `build_consume` movement per component plus one
+ * `build_produce`, stamps five cost fields and computes the variance — all of it frozen onto
+ * `updatable: false` rows in an append-only ledger. A hand-set `completed` therefore records
+ * a finished production run with **no movements, no costs and no variance**, and every
+ * downstream read — quantity on hand, COGS, margin, account 5090 — believes it. This is the
+ * build's analogue of invoice `paid` "silently corrupting money rather than merely skipping a
+ * mirror" (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §3), except that a
+ * build IS the thing that writes the ledger.
+ *
+ * ✅ **`in_progress` and `canceled` are guarded for a second, independent reason: they are
+ * two of the three ways to LEAVE `completed`.** B6 says a completed build is never edited or
+ * deleted, only reversed — a status flip out of `completed` leaves its movements in the
+ * ledger valuing inventory against a run the system now says never happened, which is the
+ * same corruption seen from the other side. `cancelBuild` refuses exactly that transition
+ * ("A completed build is reversed, never cancelled"); a drawer edit or a kanban drag onto
+ * Canceled does it anyway. Their own side effects reinforce it — `startBuild` stamps
+ * `build_started_at`, `cancelBuild` appends the reason to the notes — but the stranded ledger
+ * is what makes them worth guarding rather than leaving editable the way `declined` is on a
+ * quote.
+ *
+ * 🛑 **`planned` is deliberately absent, and it is NOT a judgement call.** It is
+ * `build_status`'s `defaultValue`, and `applyDefaults` injects a `creatable` field's default
+ * into every create before the write reaches the field chain — which, unlike the system
+ * chain, has no `operation === 'create'` exemption (21 §7.3). Guarding `planned` would
+ * therefore refuse *every* build create through the generic door, not merely one carrying an
+ * unusual status. That is the same structural reason `draft` is absent from all three sets
+ * above, and it is why the exit door cannot be closed completely: `completed -> planned` by
+ * hand stays reachable. Closing it needs a transition guard, and the field chain cannot
+ * express one — `existingValue` is `undefined` on the single-field path
+ * (`field-value-mutations.ts`), so a guard reading it would be inert in exactly the way §2
+ * describes. Shipping that would be the bug, not the fix.
+ */
+export const BUILD_ACTION_STATUSES = ['in_progress', 'completed', 'canceled'] as const
+
+/** The one message the build lifecycle guard throws, for the same reason as the set above. */
+export const BUILD_ACTION_STATUS_MESSAGE =
+  'Use the build actions (Start / Complete / Cancel / Reverse) to set this status'
+
+/**
  * Reduce a status write to the bare value being set, whatever shape it arrives in.
  *
  * 🛑 The two chains hand a guard **different shapes**, and this is the whole reason the


### PR DESCRIPTION
`build_status` had no lifecycle guard. This is the last correctness gap in the build subsystem shipped today (#1943–#1947).

## The hole

The build subsystem enforces its transitions inside `startBuild` / `completeBuild` / `cancelBuild` / `reverseBuild` via `assertBuildStatus`. **That is a different door.** Every *interactive* edit of a status field — the drawer, the grid's inline edit, a kanban drag, a Kopilot record tool — goes through `fieldValue.set` → `FieldValueService`, which reaches none of them.

So `build_status: 'completed'` was typeable by hand: **a finished production run with no movements, no costs and no variance**, believed by every downstream read. Same defect #1940 fixed for quote, invoice and purchase order — and sharper here, because a build is the thing that *writes* the ledger.

```
PURCHASE_ORDER_ACTION_STATUSES = ['issued']
QUOTE_ACTION_STATUSES          = ['sent', 'approved']
INVOICE_ACTION_STATUSES        = ['sent', 'partially_paid', 'paid', 'void']
BUILD_ACTION_STATUSES          = ['in_progress', 'completed', 'canceled']   ← new
```

## Why those three

**`completed`** is the essential one, for the reason above.

**`in_progress` and `canceled` are guarded for a second, independent reason: they are two of the three ways to *leave* `completed`.** B6 says a completed build is never edited, only reversed. A status flip out of `completed` strands its movements, valuing inventory against a run the system now says never happened. `cancelBuild` refuses exactly that transition — *"A completed build is reversed, never cancelled"* — but a kanban drag onto Canceled did it anyway.

**`planned` is excluded, and that is structural, not taste.** It is `build_status`'s `defaultValue`, and `applyDefaults` injects a creatable field's default into **every** create before the write reaches the field chain — which, unlike the system chain, has no `operation === 'create'` exemption. Guarding it would refuse *every* build create through the generic door. Same reason `draft` is absent from all three existing sets.

**Residual, written into the file:** `completed → planned` by hand stays reachable, so the one-way door is closed on two of three exits. Closing it needs a *transition* guard, and the field chain cannot express one — `existingValue` is hardcoded `undefined` on the single-field path (`field-value-mutations.ts:2927`), so a guard reading it would be inert in exactly the way #1940 §2 describes. Shipping that would be the bug, not the fix.

## 🛑 One chain, not two — deliberately unlike the other three

The other three guards register on both the field and system chains. This one registers on the **field chain only**.

`UnifiedCrudHandler.runPreHooks` consults **no equivalent of `bypassFieldGuards`** — that exemption exists only in `fireFieldPreHooks`. The money writers never collide with this because `markInvoiceSent` and its siblings write status through `FieldValueService` directly and never enter the system registry. **The build writers do the opposite:** `startBuild`, `cancelBuild` and `completeBuild` each write `build_status` through `UnifiedCrudHandler.update`, which runs every hook registered there. A system twin would refuse Start, Complete and Cancel.

It would also add **zero coverage**: `record.create` / `record.update`, the CSV importer and the SDK all reach field values through `setFieldValues → FieldValueService → fireFieldPreHooks` with an empty bypass set, so the field guard already sees them. The twin's only distinguishing behaviour is its create exemption — strictly weaker, not additive.

Pinned by a test named `has NO system-hook twin, on purpose`, so a future contributor "fixing the inconsistency" trips it.

## Five bypasses

| writer | value | note |
| --- | --- | --- |
| `createBuild` | `planned` | not guarded today; carries it so widening later can't silently break Raise |
| `startBuild` | `in_progress` | |
| `cancelBuild` | `canceled` | |
| `completeBuild` | `completed` | |
| `reverseBuild` | `completed` | **on a CREATE** — the field chain has no create exemption |

`reverseBuild` is the one easy to miss: the reversing build is *created* at `completed`, and a create carrying a guarded value is refused exactly like an update.

⚠️ `completeBuild` and `reverseBuild` share their handler with the stock-movement writes, which therefore inherit the bypass set. Safe only because it names `build_status` alone and `stock_movement` has no such attribute — asserted as `size === 1` on **every** handler construction.

## The coerced-shape test, proven by mutation

#1940's central lesson is that a guard comparing `event.newValue` to `'completed'` is **inert**: by the time it runs, `validateAndConvertValue` has turned a SINGLE_SELECT write into `{ type: 'option', optionId: 'completed' }`. The comparison can never be true, so it passes everything — and it reads correctly in review and passes any unit test fed a bare string.

So the guard was mutated to that naive form and the suite re-run:

```
× rejects the coerced option envelope for in_progress
× rejects the coerced option envelope for completed
× rejects the coerced option envelope for canceled
× rejects a hand-set completed — a build with no ledger behind it
× names the actions, so the message says which button to press
× rejects a single-element array of either shape
 Tests  6 failed | 8 passed (14)
```

**The 8 that passed under the mutation are the bare-string cases.** That is the lesson demonstrated rather than asserted. The existing three guards are untouched — `git diff` on `pre/lifecycle-status-guard.ts` is empty.

## Verification

```
lib typecheck ratchet:  no new type errors (29 total, baseline 29)
vitest src/builds src/field-hooks src/resources/hooks:
                        29 files, 341 tests passed
biome:                  11 files, clean
```

## ⚠️ Still owed, same as #1940 §7.4

Nobody has typed `completed` into a build drawer and watched it be refused, or pressed Complete and watched the bypass work. **The bypass half is the one no unit test can see past its own double of `UnifiedCrudHandler`** — if a bypass were missing, the guard would refuse the button built to protect it, and only a real click would show it.

Also included: a one-line copy tweak to `build-ledger-card.tsx`'s empty state, made by hand during review.
