### PR TITLE
test(build): prove the completion transaction and the status-guard bypass

### DIFF
--- a/packages/lib/src/builds/__tests__/build-status-guard-wiring.int.test.ts
+++ b/packages/lib/src/builds/__tests__/build-status-guard-wiring.int.test.ts
@@ -1,0 +1,243 @@
+// packages/lib/src/builds/__tests__/build-status-guard-wiring.int.test.ts
+//
+// DB-backed tests (vitest.integration.config.ts -> auxx_test) for the half of
+// the `build_status` lifecycle guard that no unit test can reach: the WIRING.
+//
+// `pre/build-status-guard.test.ts` proves the handler's matching logic — that it
+// refuses the coerced `{ type: 'option', optionId }` envelope the field chain
+// actually delivers, and leaves `planned` alone.
+// `__tests__/build-status-guard-registration.test.ts` proves it is registered
+// under `builds` and has no system twin. Neither can see past its own double of
+// `UnifiedCrudHandler`, and so neither can answer the question that actually
+// decides whether this feature works:
+//
+//   🛑 **Does `bypassFieldGuards: ['build_status']` reach `fireFieldPreHooks`?**
+//
+// If a bypass were missing from any of the five sanctioned writers, the guard
+// would refuse the very button it exists to protect — Complete would simply stop
+// working — and every existing test would still be green, because they all stub
+// the handler that carries the set. That is the "half a fix" failure mode: a
+// wall that keeps out the owner and nobody else.
+//
+// So every writer below runs for real, through the real
+// `UnifiedCrudHandler` -> `FieldValueService` -> `fireFieldPreHooks` chain,
+// against a real organization whose `build` def and fields came from the
+// registry. And the other direction is exercised on the SAME record through the
+// door an interactive drawer edit takes — `fieldValue.set`'s
+// `FieldValueService.setValueWithBuiltIn`, constructed with no bypass at all.
+//
+// `reverseBuild` gets its own case: it writes `completed` on a **CREATE**, and
+// the field pre-hook chain has no `operation === 'create'` exemption.
+
+import type { Database } from '@auxx/database'
+import { getTestDb } from '@auxx/test-utils'
+import type { FieldId } from '@auxx/types/field'
+import type { RecordId } from '@auxx/types/resource'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getOrgCache } from '../../cache'
+import { guardManualBuildLifecycleStatus } from '../../field-hooks/pre/build-status-guard'
+import { getFieldPreHooks, hasFieldPreHooks } from '../../field-hooks/registry'
+import { FieldValueService } from '../../field-values'
+import {
+  BUILD_ACTION_STATUS_MESSAGE,
+  BUILD_ACTION_STATUSES,
+} from '../../resources/hooks/lifecycle-status-guard'
+import { BuildStatus } from '../../resources/registry/enum-values'
+import { toRecordId } from '../../resources/resource-id'
+import { cancelBuild, createBuild, startBuild } from '../build-mutations'
+import { getBuild } from '../build-queries'
+import { completeBuild } from '../complete-build'
+import { reverseBuild } from '../reverse-build'
+import { type BuildFixture, seedBuildOrg } from './support/build-fixture'
+
+// ── The two queue-backed externals, mocked OFF ───────────────────────────────
+//
+// ⚠️ Not decoration — without these the suite hangs forever rather than failing.
+// `publisher.publishLater` and `enqueueDuplicateScan` are BullMQ writes, and
+// BullMQ's default `maxRetriesPerRequest: null` means a command issued against
+// an unreachable Redis never settles. `publishLater` is AWAITED on the
+// interactive write lane, which is the lane `createBuild` / `startBuild` /
+// `cancelBuild` take. Nothing in the guard chain goes near either one.
+
+vi.mock('../../events/publisher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, publisher: { publish: async () => {}, publishLater: async () => {} } }
+})
+
+vi.mock('../../dedup/enqueue-scan', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../dedup/enqueue-scan')>()
+  return { ...actual, enqueueDuplicateScan: async () => {} }
+})
+
+const db = () => getTestDb() as unknown as Database
+
+const QUANTITY = 4
+
+let f: BuildFixture
+
+beforeEach(async () => {
+  f = await seedBuildOrg()
+})
+
+/** Raise a build through the sanctioned door. */
+async function raise(): Promise<string> {
+  const created = await createBuild(db(), f.organizationId, f.userId, {
+    partId: f.producedPartId,
+    quantityPlanned: QUANTITY,
+  })
+  if (created.isErr()) throw created.error
+  return created.value.buildId
+}
+
+async function statusOf(buildId: string): Promise<string | null> {
+  const result = await getBuild(db(), f.organizationId, buildId)
+  if (result.isErr()) throw result.error
+  return result.value?.status ?? null
+}
+
+/** The `build_status` `CustomField.id` for this org. */
+async function buildStatusFieldId(): Promise<FieldId> {
+  const fields = await getOrgCache()
+    .from(f.organizationId, 'customFields')
+    .bySystemAttributes(['build_status'] as const)
+  const field = fields.build_status
+  if (!field) throw new Error('build_status was not seeded')
+  return field.id as FieldId
+}
+
+/**
+ * The write an interactive drawer edit makes: `fieldValue.set` builds a
+ * `FieldValueService` with no `bypassFieldGuards` at all, and that is the ONLY
+ * difference between this and what `startBuild` does two lines above.
+ */
+async function unsanctionedStatusWrite(buildId: string, value: unknown): Promise<void> {
+  const service = new FieldValueService(f.organizationId, f.userId, db())
+  await service.setValueWithBuiltIn({
+    recordId: toRecordId(f.buildDefId, buildId) as RecordId,
+    fieldId: await buildStatusFieldId(),
+    value,
+  })
+}
+
+// ── Anti-vacuity ─────────────────────────────────────────────────────────────
+
+describe('the guard is registered and armed in this process', () => {
+  // 🛑 Without this, every "the sanctioned writer still works" case below would
+  // pass just as happily against a guard that was never registered — which is
+  // precisely the state PR #1949 was written to leave behind, and precisely what
+  // a wiring test must not be blind to.
+  it('is on the field pre-hook chain for builds', () => {
+    expect(hasFieldPreHooks('builds', 'build_status')).toBe(true)
+    expect(getFieldPreHooks('builds', 'build_status')).toContain(guardManualBuildLifecycleStatus)
+  })
+
+  it('guards exactly the three action statuses', () => {
+    expect([...BUILD_ACTION_STATUSES]).toEqual(['in_progress', 'completed', 'canceled'])
+  })
+})
+
+// ── The five sanctioned writers ──────────────────────────────────────────────
+
+describe('every sanctioned writer still gets through', () => {
+  it('createBuild lands planned', async () => {
+    const buildId = await raise()
+    expect(await statusOf(buildId)).toBe(BuildStatus.PLANNED)
+  })
+
+  it('startBuild lands in_progress', async () => {
+    const buildId = await raise()
+    const started = await startBuild(db(), f.organizationId, f.userId, { buildId })
+    if (started.isErr()) throw started.error
+    expect(await statusOf(buildId)).toBe(BuildStatus.IN_PROGRESS)
+  })
+
+  it('cancelBuild lands canceled', async () => {
+    const buildId = await raise()
+    const canceled = await cancelBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      reason: 'floor stopped the run',
+    })
+    if (canceled.isErr()) throw canceled.error
+    expect(await statusOf(buildId)).toBe(BuildStatus.CANCELED)
+  })
+
+  it('completeBuild lands completed', async () => {
+    const buildId = await raise()
+    const started = await startBuild(db(), f.organizationId, f.userId, { buildId })
+    if (started.isErr()) throw started.error
+
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY,
+    })
+    if (done.isErr()) throw done.error
+    expect(await statusOf(buildId)).toBe(BuildStatus.COMPLETED)
+  })
+
+  // 🛑 The asymmetric one. `reverseBuild` writes `completed` on a CREATE, and
+  // `applyDefaults` + `fireFieldPreHooks` treat a create carrying a guarded value
+  // exactly like an update. A missing bypass here would break B6's only
+  // correction for a posted run while leaving Start / Complete / Cancel working,
+  // so it cannot be inferred from the other four passing.
+  it('reverseBuild creates its reversing build AT completed', async () => {
+    const buildId = await raise()
+    const started = await startBuild(db(), f.organizationId, f.userId, { buildId })
+    if (started.isErr()) throw started.error
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY,
+    })
+    if (done.isErr()) throw done.error
+
+    const reversed = await reverseBuild(db(), f.organizationId, f.userId, { buildId })
+    if (reversed.isErr()) throw reversed.error
+
+    expect(await statusOf(reversed.value.buildId)).toBe(BuildStatus.COMPLETED)
+    expect(reversed.value.buildId).not.toBe(buildId)
+  })
+})
+
+// ── The door the guard exists to close ───────────────────────────────────────
+
+describe('an unsanctioned write of a guarded value is refused', () => {
+  it.each([...BUILD_ACTION_STATUSES])('refuses a raw fieldValue.set of %s', async (status) => {
+    const buildId = await raise()
+    await expect(unsanctionedStatusWrite(buildId, status)).rejects.toThrow(
+      BUILD_ACTION_STATUS_MESSAGE
+    )
+  })
+
+  it('leaves the stored status untouched when it refuses', async () => {
+    const buildId = await raise()
+    await expect(unsanctionedStatusWrite(buildId, BuildStatus.COMPLETED)).rejects.toThrow()
+    expect(await statusOf(buildId)).toBe(BuildStatus.PLANNED)
+  })
+
+  // 🛑 The defect this whole guard was built for: a build reading `completed`
+  // with no consume rows, no produce row and no costs behind it.
+  it('writes no stock movements on the refused path — the ledger stays empty', async () => {
+    const buildId = await raise()
+    await expect(unsanctionedStatusWrite(buildId, BuildStatus.COMPLETED)).rejects.toThrow()
+
+    const build = await getBuild(db(), f.organizationId, buildId)
+    if (build.isErr()) throw build.error
+    expect(build.value?.status).toBe(BuildStatus.PLANNED)
+    expect(build.value?.materialCost).toBeFalsy()
+    expect(build.value?.producedValue).toBeFalsy()
+  })
+
+  // The other side of the same wall. `planned` is `build_status`'s defaultValue
+  // and every create carries it, so guarding it would refuse every build create
+  // through the generic door. A refusal here would mean the guard had become a
+  // FIELD wall rather than a VALUE wall.
+  it('still allows an unsanctioned write of planned', async () => {
+    const buildId = await raise()
+    const started = await startBuild(db(), f.organizationId, f.userId, { buildId })
+    if (started.isErr()) throw started.error
+
+    // Not `rejects` — a throw here fails the test, and the stored value is the
+    // claim: the write went all the way through.
+    await unsanctionedStatusWrite(buildId, BuildStatus.PLANNED)
+    expect(await statusOf(buildId)).toBe(BuildStatus.PLANNED)
+  })
+})

--- a/packages/lib/src/builds/__tests__/complete-build-transaction.int.test.ts
+++ b/packages/lib/src/builds/__tests__/complete-build-transaction.int.test.ts
@@ -1,0 +1,465 @@
+// packages/lib/src/builds/__tests__/complete-build-transaction.int.test.ts
+//
+// DB-backed tests (vitest.integration.config.ts -> auxx_test) for the ONE claim
+// `complete-build.test.ts` structurally cannot make: that every write inside
+// `db.transaction()` actually lands on `tx`, and that they all land or none of
+// them do.
+//
+// The unit tests double `db.transaction`, so they observe the calls a fake
+// handler received. That proves the ORDER of the steps and nothing about the
+// connection they ran on — a `completeBuild` that wrote its movements through
+// the module-level pool instead of `tx` would satisfy every one of them, and
+// would leave a half-posted build behind the first time anything threw. A
+// partial build is a corrupt ledger: consume rows with no produce row value
+// inventory out of existence, and no reversal can describe a run that never
+// finished.
+//
+// Three things are asserted here that nothing else can see:
+//
+//   1. **Commit.** After a completion, all N consume rows and the single
+//      produce row are in the database, priced from the frozen standard.
+//   2. **Rollback.** A failure raised between the consume writes and the produce
+//      write leaves NOTHING behind — no movement instances, no movement field
+//      values, and a build still reading `in_progress`.
+//   3. **The post-commit recalculation sees committed rows.** `batchRecalculateQoH`
+//      runs on the module-level pool after the transaction returns (trap 1), so
+//      the quantity on hand it writes is the proof the rows were visible to a
+//      different connection by then.
+//
+// It also pins the known wrinkle rather than trusting the reasoning about it:
+// `createEntity`'s post-write `getEntityInstance` re-read uses the module-level
+// pool and therefore CANNOT see the row it just created inside `tx`. That is
+// observed directly below (`freshReadOutcomes`) and shown to be harmless,
+// because the re-read falls back to the in-transaction instance and the quiet
+// lane suppresses its only other consumer, the realtime frame.
+
+import { type Database, schema } from '@auxx/database'
+import { getTestDb } from '@auxx/test-utils'
+import { and, eq, inArray } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getOrgCache } from '../../cache'
+import { createBuild, startBuild } from '../build-mutations'
+import { getBuild } from '../build-queries'
+import { completeBuild } from '../complete-build'
+import { type BuildFixture, seedBuildOrg } from './support/build-fixture'
+
+const db = () => getTestDb() as unknown as Database
+
+// ── The two queue-backed externals, mocked OFF ───────────────────────────────
+//
+// ⚠️ Not decoration — without these the suite hangs forever rather than failing.
+// `publisher.publishLater` and `enqueueDuplicateScan` are BullMQ writes, and
+// BullMQ's default `maxRetriesPerRequest: null` means a command issued against
+// an unreachable Redis never settles. `publishLater` is AWAITED on the
+// interactive write lane (`publishFieldTriggerEvents` ->
+// `setValuesForEntity`), so a single `startBuild` blocks the process. Neither
+// is part of any claim below: the field pre-hook chain, the transaction and
+// `batchRecalculateQoH` all run for real.
+
+vi.mock('../../events/publisher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, publisher: { publish: async () => {}, publishLater: async () => {} } }
+})
+
+vi.mock('../../dedup/enqueue-scan', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../dedup/enqueue-scan')>()
+  return { ...actual, enqueueDuplicateScan: async () => {} }
+})
+
+// ── The two seams the tests steer, both partial mocks ────────────────────────
+
+const h = vi.hoisted(() => ({
+  /**
+   * Armed only around the call under test. `resolveGlAccountForPartKind` is
+   * called once per component line while the plan is PRICED (outside any write)
+   * and then once more for the produce row — after every consume movement has
+   * been written and before the build's own status/cost update. Throwing on the
+   * `finished_good` call is therefore a failure exactly partway through the
+   * transaction, which is the shape a real defect takes.
+   */
+  failOnFinishedGoodGlAccount: false,
+  /** Every `getEntityInstance` re-read `createEntity` made, and whether it found the row. */
+  freshReadOutcomes: [] as Array<{ id: string; found: boolean }>,
+}))
+
+vi.mock('../../receiving/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../receiving/client')>()
+  return {
+    ...actual,
+    resolveGlAccountForPartKind: (
+      kind: Parameters<typeof actual.resolveGlAccountForPartKind>[0]
+    ) => {
+      if (h.failOnFinishedGoodGlAccount && kind === 'finished_good') {
+        throw new Error('injected failure between the consume rows and the produce row')
+      }
+      return actual.resolveGlAccountForPartKind(kind)
+    },
+  }
+})
+
+vi.mock('../../entity-instances', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../entity-instances')>()
+  return {
+    ...actual,
+    getEntityInstance: async (params: Parameters<typeof actual.getEntityInstance>[0]) => {
+      const result = await actual.getEntityInstance(params)
+      h.freshReadOutcomes.push({ id: params.id, found: result.isOk() })
+      return result
+    },
+  }
+})
+
+// ── Fixture ──────────────────────────────────────────────────────────────────
+
+const QUANTITY_PRODUCED = 10
+
+let f: BuildFixture
+
+/** Raise a build and start it, so `completeBuild` has something legal to finish. */
+async function anInProgressBuild(): Promise<string> {
+  const created = await createBuild(db(), f.organizationId, f.userId, {
+    partId: f.producedPartId,
+    quantityPlanned: QUANTITY_PRODUCED,
+  })
+  if (created.isErr()) throw created.error
+  const buildId = created.value.buildId
+
+  const started = await startBuild(db(), f.organizationId, f.userId, { buildId })
+  if (started.isErr()) throw started.error
+  return buildId
+}
+
+/** Every `stock_movement` instance id in the org. */
+async function movementInstanceIds(): Promise<string[]> {
+  const rows = await db()
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, f.organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, f.movementDefId)
+      )
+    )
+  return rows.map((row) => row.id)
+}
+
+/** `systemAttribute` -> `CustomField.id`, straight off the org cache. */
+async function fieldId(attribute: string): Promise<string> {
+  const fields = await getOrgCache()
+    .from(f.organizationId, 'customFields')
+    .bySystemAttributes([attribute] as never)
+  const field = (fields as Record<string, { id: string } | null>)[attribute]
+  if (!field) throw new Error(`no CustomField for ${attribute}`)
+  return field.id
+}
+
+/** The stored numeric value of `attribute` on each of `entityIds`. */
+async function numbersByEntity(
+  attribute: string,
+  entityIds: string[]
+): Promise<Map<string, number>> {
+  if (entityIds.length === 0) return new Map()
+  const id = await fieldId(attribute)
+  const rows = await db()
+    .select({
+      entityId: schema.FieldValue.entityId,
+      valueNumber: schema.FieldValue.valueNumber,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, f.organizationId),
+        eq(schema.FieldValue.fieldId, id),
+        inArray(schema.FieldValue.entityId, entityIds)
+      )
+    )
+  const out = new Map<string, number>()
+  for (const row of rows) {
+    if (row.valueNumber != null) out.set(row.entityId, Number(row.valueNumber))
+  }
+  return out
+}
+
+/** The related-record target of `attribute` on each of `entityIds`. */
+async function relatedByEntity(
+  attribute: string,
+  entityIds: string[]
+): Promise<Map<string, string>> {
+  const id = await fieldId(attribute)
+  const rows = await db()
+    .select({
+      entityId: schema.FieldValue.entityId,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, f.organizationId),
+        eq(schema.FieldValue.fieldId, id),
+        inArray(schema.FieldValue.entityId, entityIds)
+      )
+    )
+  const out = new Map<string, string>()
+  for (const row of rows) {
+    if (row.relatedEntityId) out.set(row.entityId, row.relatedEntityId)
+  }
+  return out
+}
+
+/** The stored option id of `attribute` on each of `entityIds`. */
+async function optionsByEntity(
+  attribute: string,
+  entityIds: string[]
+): Promise<Map<string, string>> {
+  const id = await fieldId(attribute)
+  const rows = await db()
+    .select({
+      entityId: schema.FieldValue.entityId,
+      optionId: schema.FieldValue.optionId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, f.organizationId),
+        eq(schema.FieldValue.fieldId, id),
+        inArray(schema.FieldValue.entityId, entityIds)
+      )
+    )
+  const out = new Map<string, string>()
+  for (const row of rows) {
+    if (row.optionId) out.set(row.entityId, row.optionId)
+  }
+  return out
+}
+
+beforeEach(async () => {
+  h.failOnFinishedGoodGlAccount = false
+  h.freshReadOutcomes = []
+  f = await seedBuildOrg()
+})
+
+describe('completeBuild commits its whole ledger', () => {
+  it('writes one consume movement per component and one produce movement, priced from the standard', async () => {
+    const buildId = await anInProgressBuild()
+
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+    if (done.isErr()) throw done.error
+
+    const stored = await movementInstanceIds()
+    expect(stored.sort()).toEqual([...done.value.movementIds].sort())
+    expect(stored).toHaveLength(f.componentPartIds.length + 1)
+
+    const quantities = await numbersByEntity('stock_movement_quantity', stored)
+    const unitCosts = await numbersByEntity('stock_movement_unit_cost', stored)
+    const extended = await numbersByEntity('stock_movement_extended_cost', stored)
+    const parts = await relatedByEntity('stock_movement_part', stored)
+    const types = await optionsByEntity('stock_movement_type', stored)
+
+    // One row per consumed part, at the NEGATED BOM quantity and the frozen cost.
+    for (const partId of f.componentPartIds) {
+      const movementId = stored.find((id) => parts.get(id) === partId)
+      expect(movementId, `no consume movement for ${partId}`).toBeTruthy()
+      const consumed = (f.qtyPerUnit.get(partId) as number) * QUANTITY_PRODUCED
+      const unitCost = f.standardCosts.get(partId) as number
+      expect(types.get(movementId as string)).toBe('build_consume')
+      expect(quantities.get(movementId as string)).toBe(-consumed)
+      expect(unitCosts.get(movementId as string)).toBe(unitCost)
+      expect(extended.get(movementId as string)).toBe(-(unitCost * consumed))
+    }
+
+    // ...and exactly one produce row, at the POSITIVE produced quantity.
+    const produceIds = stored.filter((id) => types.get(id) === 'build_produce')
+    expect(produceIds).toHaveLength(1)
+    const produceId = produceIds[0] as string
+    expect(parts.get(produceId)).toBe(f.producedPartId)
+    expect(quantities.get(produceId)).toBe(QUANTITY_PRODUCED)
+    expect(unitCosts.get(produceId)).toBe(f.standardCosts.get(f.producedPartId))
+  })
+
+  it('stamps the build itself completed, with the costs the same commit wrote', async () => {
+    const buildId = await anInProgressBuild()
+
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+    if (done.isErr()) throw done.error
+
+    const reread = await getBuild(db(), f.organizationId, buildId)
+    if (reread.isErr()) throw reread.error
+    const build = reread.value
+    expect(build?.status).toBe('completed')
+    expect(build?.quantityProduced).toBe(QUANTITY_PRODUCED)
+    expect(build?.materialCost).toBe(done.value.materialCost)
+    expect(build?.producedValue).toBe(done.value.producedValue)
+    expect(build?.varianceAmount).toBe(done.value.varianceAmount)
+  })
+
+  // 🛑 The wrinkle `complete-build.ts` reasons about but no unit test can see:
+  // `createEntity` re-reads the instance it just created through the MODULE-LEVEL
+  // pool, which is a different connection from `tx`. If the movement writes were
+  // (wrongly) on the pool, this read would find them.
+  it('cannot see its own uncommitted rows from the module-level pool — which is how we know they are on tx', async () => {
+    const buildId = await anInProgressBuild()
+    h.freshReadOutcomes = []
+
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+    if (done.isErr()) throw done.error
+
+    const movementReads = h.freshReadOutcomes.filter((read) =>
+      done.value.movementIds.includes(read.id)
+    )
+    expect(movementReads).toHaveLength(done.value.movementIds.length)
+    // NOT `.every(...) === false`, which one miss would satisfy: every single
+    // re-read must have missed, because every single write was on `tx`.
+    expect(movementReads.filter((read) => read.found)).toEqual([])
+
+    // ...and harmless: the ids the caller got back are the real committed rows.
+    const stored = await movementInstanceIds()
+    expect(stored.sort()).toEqual([...done.value.movementIds].sort())
+  })
+})
+
+describe('a failure partway through rolls the whole completion back', () => {
+  it('leaves no movement instances behind', async () => {
+    const buildId = await anInProgressBuild()
+    expect(await movementInstanceIds()).toHaveLength(0)
+    h.freshReadOutcomes = []
+
+    h.failOnFinishedGoodGlAccount = true
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+
+    expect(done.isErr()).toBe(true)
+
+    // 🛑 The premise, made explicit rather than assumed: `createEntity` ran once
+    // per component before the failure fired, so there really were rows in
+    // flight for the rollback to undo. Without this the assertion below would
+    // pass just as happily against a `completeBuild` that failed before writing
+    // anything at all, and would be proving nothing.
+    expect(h.freshReadOutcomes.length).toBeGreaterThanOrEqual(f.componentPartIds.length)
+
+    // If any of those writes were on the pool rather than on `tx`, they would
+    // still be here.
+    expect(await movementInstanceIds()).toHaveLength(0)
+  })
+
+  it('leaves no movement field values behind', async () => {
+    const buildId = await anInProgressBuild()
+
+    h.failOnFinishedGoodGlAccount = true
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+    expect(done.isErr()).toBe(true)
+
+    const orphans = await db()
+      .select({ id: schema.FieldValue.id })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, f.organizationId),
+          eq(schema.FieldValue.entityDefinitionId, f.movementDefId)
+        )
+      )
+    expect(orphans).toEqual([])
+  })
+
+  // 🛑 The one that matters most. A build left reading `completed` with no
+  // ledger behind it is exactly the state `build-status-guard.ts` exists to
+  // prevent a human from creating by hand.
+  it('does not leave the build reading completed', async () => {
+    const buildId = await anInProgressBuild()
+
+    h.failOnFinishedGoodGlAccount = true
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+    expect(done.isErr()).toBe(true)
+
+    const reread = await getBuild(db(), f.organizationId, buildId)
+    if (reread.isErr()) throw reread.error
+    expect(reread.value?.status).toBe('in_progress')
+    expect(reread.value?.quantityProduced).toBeFalsy()
+    expect(reread.value?.materialCost).toBeFalsy()
+  })
+
+  it('leaves the build completable on a second, unfailed attempt', async () => {
+    const buildId = await anInProgressBuild()
+
+    h.failOnFinishedGoodGlAccount = true
+    expect(
+      (
+        await completeBuild(db(), f.organizationId, f.userId, {
+          buildId,
+          quantityProduced: QUANTITY_PRODUCED,
+        })
+      ).isErr()
+    ).toBe(true)
+
+    h.failOnFinishedGoodGlAccount = false
+    const retry = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+    if (retry.isErr()) throw retry.error
+
+    // Exactly one ledger, not two. B8's "one completion per build" would be
+    // meaningless if a rolled-back attempt still counted as one.
+    expect(await movementInstanceIds()).toHaveLength(f.componentPartIds.length + 1)
+  })
+})
+
+describe('the post-commit recalculation sees the committed rows', () => {
+  it('sets quantity on hand for the produced part and every consumed part', async () => {
+    const buildId = await anInProgressBuild()
+
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+    if (done.isErr()) throw done.error
+
+    const partIds = [f.producedPartId, ...f.componentPartIds]
+    const qoh = await numbersByEntity('part_quantity_on_hand', partIds)
+
+    // 🛑 `batchRecalculateQoH` runs AFTER the transaction returns, on the
+    // module-level pool. A non-zero number here is only possible if the movement
+    // rows were committed and visible to that other connection by then — which
+    // is trap 1 discharged, observed rather than reasoned about.
+    expect(qoh.get(f.producedPartId)).toBe(QUANTITY_PRODUCED)
+    for (const partId of f.componentPartIds) {
+      const consumed = (f.qtyPerUnit.get(partId) as number) * QUANTITY_PRODUCED
+      expect(qoh.get(partId)).toBe(-consumed)
+    }
+  })
+
+  it('recalculates nothing when the completion rolled back', async () => {
+    const buildId = await anInProgressBuild()
+
+    h.failOnFinishedGoodGlAccount = true
+    const done = await completeBuild(db(), f.organizationId, f.userId, {
+      buildId,
+      quantityProduced: QUANTITY_PRODUCED,
+    })
+    expect(done.isErr()).toBe(true)
+
+    const partIds = [f.producedPartId, ...f.componentPartIds]
+    const qoh = await numbersByEntity('part_quantity_on_hand', partIds)
+    for (const partId of partIds) {
+      // Either untouched, or recomputed to the honest zero — never a number
+      // sourced from rows that no longer exist.
+      expect(qoh.get(partId) ?? 0).toBe(0)
+    }
+  })
+})

--- a/packages/lib/src/builds/__tests__/support/build-fixture.ts
+++ b/packages/lib/src/builds/__tests__/support/build-fixture.ts
@@ -1,0 +1,239 @@
+// packages/lib/src/builds/__tests__/support/build-fixture.ts
+//
+// A real, DB-backed organization that the build write paths can run against
+// end to end, for the two `*.int.test.ts` files next door.
+//
+// Everything here is REAL: the entity definitions and their `CustomField` rows
+// come from the same two seeder passes `EntitySeeder` runs
+// (`createEntityDefinitions` + `createAllFields`, then the relationship and
+// display links), the parts and subparts are written through
+// `UnifiedCrudHandler`, and the org cache is the production one falling back to
+// its in-memory layer. That is the point — both gaps these fixtures serve are
+// about WIRING (does a write land on `tx`; does a bypass reach the guard), and
+// wiring is precisely what a double cannot answer.
+//
+// The one thing written as raw `FieldValue` rows is the frozen standard cost.
+// `part_standard_cost` and its three components are `creatable: false,
+// updatable: false` — `rollStandardCost` is their only writer — so there is no
+// CRUD door to write them through. They are an INPUT to every test here, never
+// the thing under test.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, createTestUser, getTestDb } from '@auxx/test-utils'
+import { and, eq } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import { UnifiedCrudHandler } from '../../../resources/crud/unified-handler'
+import { PartKind } from '../../../resources/registry/enum-values'
+import { toRecordId } from '../../../resources/resource-id'
+import { createEntityDefinitions } from '../../../seed/entity-seeder/create-entity-defs'
+import { createAllFields } from '../../../seed/entity-seeder/create-fields'
+import { linkDisplayFields } from '../../../seed/entity-seeder/link-display-fields'
+import { linkRelationships } from '../../../seed/entity-seeder/link-relationships'
+import type { EntityDefMap } from '../../../seed/entity-seeder/types'
+
+const db = () => getTestDb() as unknown as Database
+
+/** The only defs whose registry fields a build path ever reads or writes. */
+const BUILD_ENTITY_TYPES = ['build', 'part', 'subpart', 'stock_movement'] as const
+
+/** Everything the build tests need to address the seeded org. */
+export interface BuildFixture {
+  organizationId: string
+  userId: string
+  buildDefId: string
+  partDefId: string
+  subpartDefId: string
+  movementDefId: string
+  /** The finished good the build produces. */
+  producedPartId: string
+  /** The BOM components, in BOM order. */
+  componentPartIds: string[]
+  /** `partId` -> the frozen `part_standard_cost` in minor units. */
+  standardCosts: Map<string, number>
+  /** `partId` -> qty per produced unit, for the BOM edges. */
+  qtyPerUnit: Map<string, number>
+}
+
+export interface SeedBuildOrgOptions {
+  /** How many BOM components the produced part gets. Default 3. */
+  components?: number
+}
+
+/**
+ * Seed an organization whose `build`, `part`, `subpart` and `stock_movement`
+ * definitions and fields are the registry's own, then give it one buildable
+ * finished good with a priced bill of materials.
+ */
+export async function seedBuildOrg(options: SeedBuildOrgOptions = {}): Promise<BuildFixture> {
+  const componentCount = options.components ?? 3
+
+  const org = await createTestOrganization()
+  const user = await createTestUser({ name: 'Build Operator' })
+  await db()
+    .update(schema.Organization)
+    .set({ systemUserId: user.id })
+    .where(eq(schema.Organization.id, org.id))
+
+  // The two passes that materialise defs + fields, plus the two link passes the
+  // relationship writes below need. Views and dashboards are not read by any
+  // build path, so passes 6 to 8 are skipped.
+  //
+  // EVERY definition — `getCachedEntityDefId` and the resource cache read the
+  // whole org, and defs are one cheap insert each.
+  const entityDefMap = await createEntityDefinitions(db(), org.id)
+
+  // ...but only the four defs a build actually touches get their ~1,000
+  // registry fields materialised. `createAllFields` keys off the map it is
+  // handed, so narrowing it here is the difference between a ~1.2s fixture and
+  // a ~12s one, repeated once per test because `per-test-setup` truncates every
+  // table after each one. Nothing below reads a field on any other def.
+  const buildDefMap: EntityDefMap = new Map()
+  for (const entityType of BUILD_ENTITY_TYPES) {
+    const def = entityDefMap.get(entityType)
+    if (!def) throw new Error(`fixture: no ${entityType} entity definition was seeded`)
+    buildDefMap.set(entityType, def)
+  }
+
+  const fieldMap = await createAllFields(db(), org.id, buildDefMap)
+  await linkRelationships(db(), buildDefMap, fieldMap)
+  await linkDisplayFields(db(), buildDefMap, fieldMap)
+
+  const defId = (entityType: string): string => {
+    const def = buildDefMap.get(entityType)
+    if (!def) throw new Error(`fixture: no ${entityType} entity definition was seeded`)
+    return def.id
+  }
+
+  const buildDefId = defId('build')
+  const partDefId = defId('part')
+  const subpartDefId = defId('subpart')
+  const movementDefId = defId('stock_movement')
+
+  const crud = new UnifiedCrudHandler(org.id, user.id, db())
+
+  const createPart = async (title: string, kind: string): Promise<string> => {
+    const created = await crud.create(partDefId, {
+      part_title: title,
+      part_sku: `SKU-${title.replace(/\s+/g, '-').toUpperCase()}`,
+      part_kind: kind,
+    })
+    return created.instance.id
+  }
+
+  const producedPartId = await createPart('Auxx Lift 400lbs 4x8', PartKind.FINISHED_GOOD)
+
+  const componentPartIds: string[] = []
+  const qtyPerUnit = new Map<string, number>()
+  for (let index = 0; index < componentCount; index += 1) {
+    const partId = await createPart(`Component ${index + 1}`, PartKind.COMPONENT)
+    componentPartIds.push(partId)
+    // Distinct quantities, so a test that mixed two lines up would show it.
+    qtyPerUnit.set(partId, index + 1)
+    await crud.create(subpartDefId, {
+      subpart_parent_part: toRecordId(partDefId, producedPartId),
+      subpart_child_part: toRecordId(partDefId, partId),
+      subpart_quantity: index + 1,
+    })
+  }
+
+  // Frozen standards, in minor units. Distinct per part for the same reason the
+  // quantities are.
+  const standardCosts = new Map<string, number>()
+  standardCosts.set(producedPartId, 12_500)
+  componentPartIds.forEach((partId, index) => {
+    standardCosts.set(partId, 1_000 * (index + 1))
+  })
+  for (const [partId, standardCost] of standardCosts) {
+    await freezeStandardCost(org.id, partId, standardCost)
+  }
+
+  return {
+    organizationId: org.id,
+    userId: user.id,
+    buildDefId,
+    partDefId,
+    subpartDefId,
+    movementDefId,
+    producedPartId,
+    componentPartIds,
+    standardCosts,
+    qtyPerUnit,
+  }
+}
+
+/**
+ * Write the four `part_standard_*` numbers and the effective date directly.
+ *
+ * `readStandardCost` omits a part with no `part_standard_cost` rather than
+ * defaulting it to zero, and `completeBuild` refuses a plan with any such part,
+ * so a fixture that skipped this would abort before writing anything and every
+ * assertion below it would be vacuous.
+ */
+export async function freezeStandardCost(
+  organizationId: string,
+  partId: string,
+  standardCost: number
+): Promise<void> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([
+      'part_standard_material_cost',
+      'part_standard_labor_cost',
+      'part_standard_overhead_cost',
+      'part_standard_cost',
+      'part_standard_cost_effective_at',
+    ] as const)
+
+  const partDefId = fields.part_standard_cost?.entityDefinitionId
+  if (!fields.part_standard_cost || !partDefId) {
+    throw new Error('fixture: part_standard_cost was not seeded')
+  }
+
+  const now = new Date()
+  const numeric: Array<[{ id: string } | null, number]> = [
+    [fields.part_standard_material_cost, standardCost],
+    [fields.part_standard_labor_cost, 0],
+    [fields.part_standard_overhead_cost, 0],
+    [fields.part_standard_cost, standardCost],
+  ]
+
+  for (const [field, value] of numeric) {
+    if (!field) continue
+    await db().insert(schema.FieldValue).values({
+      organizationId,
+      entityId: partId,
+      entityDefinitionId: partDefId,
+      fieldId: field.id,
+      valueNumber: value,
+      updatedAt: now,
+    })
+  }
+
+  if (fields.part_standard_cost_effective_at) {
+    await db().insert(schema.FieldValue).values({
+      organizationId,
+      entityId: partId,
+      entityDefinitionId: partDefId,
+      fieldId: fields.part_standard_cost_effective_at.id,
+      valueDate: now.toISOString(),
+      updatedAt: now,
+    })
+  }
+}
+
+/** Every `stock_movement` instance in the org — archived rows included, on purpose. */
+export async function listMovementInstanceIds(
+  organizationId: string,
+  movementDefId: string
+): Promise<string[]> {
+  const rows = await db()
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, movementDefId)
+      )
+    )
+  return rows.map((row) => row.id)
+}


### PR DESCRIPTION
Closes the two verification gaps [#1946](https://github.com/Auxx-Ai/auxx-ai/pull/1946) and [#1949](https://github.com/Auxx-Ai/auxx-ai/pull/1949) shipped with — both flagged in those PRs as things unit tests structurally cannot see. **No production code changed.**

3 new files. Follows the existing `.int.test.ts` convention exactly (`vitest.integration.config.ts` → `auxx_test`, `@auxx/test-utils` fixtures); the org's `build` / `part` / `subpart` / `stock_movement` defs come from the real seeder passes, and every record is written through the real `UnifiedCrudHandler`.

## Gap 1 — writes land on `tx`, and the rollback is clean

`completeBuild` writes ~51 movements plus five cost fields inside one `db.transaction()`. Its unit tests use a **double** for `db.transaction`, so *"every write inside the transaction lands on `tx`, and rolls back together"* was unverified against a real database. Every unit test would pass identically if a write escaped the transaction and committed on its own connection.

**It holds. There is no bug here.** 9 tests:

- **Commit** — N consume rows at `-(qtyPerUnit × unitsStarted)` and one produce row at `+quantityProduced`, each priced from the frozen `part_standard_cost`, `extendedCost` negated from the positive extended term; build stamped `completed` with the costs the call returned.
- **Rollback** — a failure injected between the consume writes and the produce row (a partial mock of `resolveGlAccountForPartKind` throwing only on the `finished_good` call) leaves **zero** movement instances, **zero** movement `FieldValue` rows, status still `in_progress`, and the build still completable on a second attempt with exactly one ledger.
- **Post-commit recalc** — `part_quantity_on_hand` is `+10` on the produced part and `-(qty × 10)` on each component after commit, `0`/absent after a rollback. Since `batchRecalculateQoH` runs on the **module-level pool** after the transaction returns, a correct number there is direct evidence the rows committed and were visible to another connection.
- **The known wrinkle, verified both ways** — during a completion **every** post-write `getEntityInstance` re-read misses (`ENTITY_INSTANCE_NOT_FOUND`), which is exactly what *"the write went to `tx`, the re-read went to the pool"* looks like. Harmless: the returned `movementIds` are precisely the committed rows.

## Gap 2 — the bypass wiring

#1949 gave five writers `bypassFieldGuards: ['build_status']`. 🛑 **If a bypass were missing, the guard would refuse the very button it protects** — Complete would simply stop working — and every existing test would still pass, because they all double `UnifiedCrudHandler`.

13 tests:

- **Anti-vacuity first:** `hasFieldPreHooks('builds', 'build_status')` is `true` and the chain contains `guardManualBuildLifecycleStatus` in-process, so the "writer still works" cases cannot pass against an unregistered guard.
- `createBuild` → `planned`, `startBuild` → `in_progress`, `cancelBuild` → `canceled`, `completeBuild` → `completed`, and **`reverseBuild` → a new build created AT `completed`** — the CREATE case, which the field chain has no exemption for.
- **The unsanctioned door**, reproduced exactly as `fieldValue.set` builds it (`new FieldValueService(org, user, db)`, no bypass, then `setValueWithBuiltIn`): all three guarded values refused with `BUILD_ACTION_STATUS_MESSAGE`, stored status untouched, ledger still empty. `planned` still writes through — proving it is a **value** wall, not a field wall.

## Both mutation-verified

Neither test is trusted on its own say-so:

| mutation | result |
| --- | --- |
| `writeCompletion(tx, …)` → writes on the pool inside an empty transaction | **4 failed** — the tx test and all three rollback tests |
| all four `bypassFieldGuards: BUILD_STATUS_BYPASS` sites removed | **exactly 4 failed** — `startBuild`, `cancelBuild`, `completeBuild`, `reverseBuild` |

`createBuild` correctly still passed under the second mutation, because `planned` is not in the guarded set — which is the documented reason its bypass is defensive rather than load-bearing today. Both mutations reverted; `git diff` on the production files is empty.

## Verification

```
lib typecheck ratchet:   no new type errors (29 total, baseline 29)
vitest src/builds src/field-hooks src/resources/crud:
                         51 files, 574 passed | 10 skipped, exit 0
new integration tests:   RAN (did not skip) — 2 files, 22 passed, 28.9s, exit 0
whole integration suite: 40 files, 469 passed, 294s, exit 0
biome:                   3 files, clean
```

## ⚠️ An unrelated production finding, surfaced while getting these to run

**There is a hard Redis dependency on the interactive write lane.** With Redis unreachable, `setValuesForEntity({ publishEvents: true })` **never returns** — it hangs rather than erroring. The awaited enqueue is `publisher.publishLater` at `field-hooks/post/publish-field-change-event.ts:49`, and BullMQ's `maxRetriesPerRequest: null` retries forever instead of rejecting.

In production a Redis outage would leave **every drawer edit spinning** rather than failing with a 500. Nothing to do with builds — it is on the shared interactive write path, and it deserves its own look.

Both test files therefore mock `../../events/publisher` and `../../dedup/enqueue-scan` off, with a comment saying why. Nothing either test claims goes near them: the field pre-hook chain, the transaction and `batchRecalculateQoH` all run for real. (`completeBuild`'s own writes take the quiet lane and are unaffected — it is `createBuild`/`startBuild`/`cancelBuild` that need it.)

## Reviewer notes

- The fixture materialises registry fields for only the four defs a build touches (all ~40 defs are still created). Seeding all ~1,000 fields per test made the suite ~10× slower, and `per-test-setup` truncates every table after each test so the seed cannot be hoisted.
- `__tests__/support/` is already excluded from default collection by the unit config, so the fixture does not run as a test.
- **Not covered:** the browser half — that the Complete/Start/Cancel/Reverse buttons call these functions rather than `fieldValue.set`. That is a rung above lib and belongs in `apps/web` if it should be pinned.
