### PR TITLE
feat(build): an order raises the builds needed to fulfil it

### DIFF
--- a/apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
+++ b/apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
@@ -229,7 +229,7 @@ export function CompleteBuildDialog({
           <DialogTitle>Complete {number ?? 'build'}</DialogTitle>
           <DialogDescription>
             Consumes the components and puts the finished units into stock at their standard cost. A
-            completed build is never edited or deleted — it is corrected by a reversing build.
+            completed build is never edited or deleted (it is corrected by a reversing build).
           </DialogDescription>
         </DialogHeader>
 
@@ -628,7 +628,7 @@ function UnpricedWarning({
   }
   return (
     <div className='rounded-md bg-destructive/10 p-2 text-destructive text-xs'>
-      <p className='font-medium'>Cannot post — these parts have no standard cost:</p>
+      <p className='font-medium'>Cannot post: these parts have no standard cost:</p>
       <ul className='mt-1 space-y-0.5'>
         {partIds.map((id) => (
           <li key={id} className='truncate'>
@@ -737,7 +737,7 @@ function SummaryLine({
  * and set the rate.
  */
 function absorptionHint(rate: number | null | undefined, currencyCode: string): string {
-  if (rate == null) return 'No rate declared — absorbs nothing unless you enter an amount'
+  if (rate == null) return 'No rate declared: absorbs nothing unless you enter an amount'
   return `${formatCurrency(rate, { currencyCode })} per unit started`
 }
 

--- a/packages/lib/src/builds/__tests__/auto-build-cancel.test.ts
+++ b/packages/lib/src/builds/__tests__/auto-build-cancel.test.ts
@@ -1,0 +1,381 @@
+// packages/lib/src/builds/__tests__/auto-build-cancel.test.ts
+//
+// Phase 3b — a cancelled order cancels a `planned` build and REVERSES a
+// `completed` one, and never deletes anything
+// (plans/products/12-order-triggered-build.md §6, AB6).
+//
+// Same doubling reasoning as `auto-build.test.ts`: `cancelBuild` and
+// `reverseBuild` have their own suite in `build-event.test.ts`; what is under
+// test here is which of them is chosen, for which build, and which builds are
+// left alone.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConflictError } from '../../errors'
+import type { BuildRecord } from '../types'
+
+const ORG = 'org_1'
+const SYSTEM_USER = 'user_system'
+const ORDER = 'ord_1'
+const OTHER_ORDER = 'ord_2'
+const LIFT = 'part_lift'
+
+interface FixtureOrder {
+  orderId: string
+  placedAt: Date
+  cancelledAt: Date | null
+  lines: { partId: string; quantity: number }[]
+}
+
+const h = vi.hoisted(() => ({
+  orders: [] as FixtureOrder[],
+  builds: [] as BuildRecord[],
+  /** Set to make the read report a page-shaped list, for the pagination test. */
+  pageSize: 100,
+  listCalls: [] as Record<string, unknown>[],
+  cancelCalls: [] as string[],
+  reverseCalls: [] as string[],
+  /** buildIds `reverseBuild` must refuse. */
+  reverseFailures: new Map<string, Error>(),
+  nextReversal: 0,
+}))
+
+vi.mock('../auto-build-queries', () => ({
+  loadAutoBuildOrders: vi.fn(async (_db: unknown, _org: string, orderIds: string[]) =>
+    h.orders.filter((order) => orderIds.includes(order.orderId))
+  ),
+  readPartQuantitiesOnHand: vi.fn(async () => new Map<string, number>()),
+}))
+
+vi.mock('../build-queries', () => ({
+  listBuilds: vi.fn(async (_db: unknown, _org: string, filters: Record<string, unknown>) => {
+    h.listCalls.push(filters)
+    const { ok } = await import('neverthrow')
+    // A faithful stand-in for the real filters, so a test that removes the
+    // `source` filter from the call sees manual builds arrive.
+    const matched = h.builds.filter((build) => {
+      if (filters.orderId && build.orderId !== filters.orderId) return false
+      if (filters.source && build.source !== filters.source) return false
+      return true
+    })
+    const offset = (filters.offset as number) ?? 0
+    const limit = (filters.limit as number) ?? 50
+    return ok(matched.slice(offset, offset + limit))
+  }),
+}))
+
+vi.mock('../build-mutations', () => ({
+  cancelBuild: vi.fn(
+    async (_db: unknown, _org: string, _user: string, input: { buildId: string }) => {
+      h.cancelCalls.push(input.buildId)
+      const { ok } = await import('neverthrow')
+      return ok({ buildId: input.buildId })
+    }
+  ),
+}))
+
+vi.mock('../reverse-build', () => ({
+  reverseBuild: vi.fn(
+    async (_db: unknown, _org: string, _user: string, input: { buildId: string }) => {
+      h.reverseCalls.push(input.buildId)
+      const { err, ok } = await import('neverthrow')
+      const failure = h.reverseFailures.get(input.buildId)
+      if (failure) return err(failure)
+      h.nextReversal += 1
+      return ok({ buildId: `rev_${h.nextReversal}`, reversalOfBuildId: input.buildId })
+    }
+  ),
+}))
+
+vi.mock('../../users/system-user-service', () => ({
+  SystemUserService: { getSystemUserForActions: vi.fn(async () => SYSTEM_USER) },
+}))
+
+import { cancelAutoBuildsForOrders } from '../auto-build-cancel'
+
+function build(overrides: Partial<BuildRecord> & { buildId: string }): BuildRecord {
+  return {
+    recordId: `def_build:${overrides.buildId}`,
+    number: null,
+    partId: LIFT,
+    status: 'planned',
+    quantityPlanned: 1,
+    quantityProduced: null,
+    quantityScrapped: null,
+    startedAt: null,
+    completedAt: null,
+    materialCost: null,
+    laborCost: null,
+    overheadCost: null,
+    producedValue: null,
+    varianceAmount: null,
+    postedAt: null,
+    notes: null,
+    orderId: ORDER,
+    source: 'order',
+    reversalOfBuildId: null,
+    createdAt: new Date('2026-08-27T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function cancelledOrder(orderId = ORDER): FixtureOrder {
+  return {
+    orderId,
+    placedAt: new Date('2026-08-27T00:00:00.000Z'),
+    cancelledAt: new Date('2026-08-28T00:00:00.000Z'),
+    lines: [],
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.orders = []
+  h.builds = []
+  h.listCalls = []
+  h.cancelCalls = []
+  h.reverseCalls = []
+  h.reverseFailures = new Map()
+  h.nextReversal = 0
+})
+
+async function run(orderIds: string[] = [ORDER]) {
+  const result = await cancelAutoBuildsForOrders({} as never, ORG, orderIds)
+  expect(result.isOk()).toBe(true)
+  return result._unsafeUnwrap()
+}
+
+describe('AB6 — cancel a planned run, REVERSE a completed one', () => {
+  it('cancels a `planned` build', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [build({ buildId: 'bld_1', status: 'planned' })]
+
+    const summary = await run()
+
+    expect(h.cancelCalls).toEqual(['bld_1'])
+    expect(h.reverseCalls).toEqual([])
+    expect(summary.outcomes).toEqual([
+      { orderId: ORDER, buildId: 'bld_1', action: 'cancelled', reversalBuildId: null },
+    ])
+  })
+
+  it('cancels an `in_progress` build — no movements exist yet', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [build({ buildId: 'bld_1', status: 'in_progress' })]
+
+    await run()
+
+    expect(h.cancelCalls).toEqual(['bld_1'])
+    expect(h.reverseCalls).toEqual([])
+  })
+
+  it('🛑 REVERSES a `completed` build, and never cancels it', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [build({ buildId: 'bld_1', status: 'completed' })]
+
+    const summary = await run()
+
+    expect(h.reverseCalls).toEqual(['bld_1'])
+    expect(h.cancelCalls).toEqual([])
+    expect(summary.outcomes).toEqual([
+      { orderId: ORDER, buildId: 'bld_1', action: 'reversed', reversalBuildId: 'rev_1' },
+    ])
+  })
+
+  it('skips a build that is already `canceled`', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [build({ buildId: 'bld_1', status: 'canceled' })]
+
+    const summary = await run()
+
+    expect(h.cancelCalls).toEqual([])
+    expect(h.reverseCalls).toEqual([])
+    expect(summary.outcomes[0]?.action).toBe('skipped')
+  })
+
+  it('skips a row whose status is missing entirely', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [build({ buildId: 'bld_1', status: null })]
+
+    const summary = await run()
+
+    expect(summary.outcomes[0]?.action).toBe('skipped')
+    expect(h.cancelCalls).toEqual([])
+    expect(h.reverseCalls).toEqual([])
+  })
+
+  it('handles a mixed order: one planned cancelled, one completed reversed', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [
+      build({ buildId: 'bld_planned', status: 'planned' }),
+      build({ buildId: 'bld_done', status: 'completed' }),
+    ]
+
+    await run()
+
+    expect(h.cancelCalls).toEqual(['bld_planned'])
+    expect(h.reverseCalls).toEqual(['bld_done'])
+  })
+})
+
+describe('🛑 nothing is ever deleted', () => {
+  it('reports a deleted count of zero, for every shape of build', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [
+      build({ buildId: 'bld_planned', status: 'planned' }),
+      build({ buildId: 'bld_running', status: 'in_progress' }),
+      build({ buildId: 'bld_done', status: 'completed' }),
+      build({ buildId: 'bld_dead', status: 'canceled' }),
+    ]
+
+    const summary = await run()
+
+    expect(summary.deleted).toBe(0)
+    expect(summary.outcomes).toHaveLength(4)
+  })
+
+  it('calls only `cancelBuild` and `reverseBuild` — there is no delete path', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [build({ buildId: 'bld_done', status: 'completed' })]
+
+    await run()
+
+    const mutations = await import('../build-mutations')
+    const reversal = await import('../reverse-build')
+    expect(Object.keys(mutations)).toEqual(['cancelBuild'])
+    expect(vi.mocked(reversal.reverseBuild)).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('a hand-raised build is never touched (§6.2)', () => {
+  it('asks the read for `source: order` only', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [
+      build({ buildId: 'bld_auto', status: 'planned', source: 'order' }),
+      build({ buildId: 'bld_hand', status: 'planned', source: 'manual' }),
+    ]
+
+    await run()
+
+    expect(h.listCalls[0]).toMatchObject({ orderId: ORDER, source: 'order' })
+    expect(h.cancelCalls).toEqual(['bld_auto'])
+  })
+
+  it('🛑 re-checks `source` in memory, because `listBuilds` drops an unmaterialised filter', async () => {
+    // Simulate an org where `build_source` is not materialised: the real
+    // `listBuilds` silently ignores the filter and hands back everything.
+    const { listBuilds } = await import('../build-queries')
+    vi.mocked(listBuilds).mockImplementationOnce(async () => {
+      const { ok } = await import('neverthrow')
+      return ok(h.builds)
+    })
+    h.orders = [cancelledOrder()]
+    h.builds = [
+      build({ buildId: 'bld_auto', status: 'planned', source: 'order' }),
+      build({ buildId: 'bld_hand', status: 'planned', source: 'manual' }),
+    ]
+
+    await run()
+
+    expect(h.cancelCalls).toEqual(['bld_auto'])
+  })
+
+  it('🛑 re-checks `orderId` in memory too', async () => {
+    const { listBuilds } = await import('../build-queries')
+    vi.mocked(listBuilds).mockImplementationOnce(async () => {
+      const { ok } = await import('neverthrow')
+      return ok(h.builds)
+    })
+    h.orders = [cancelledOrder()]
+    h.builds = [
+      build({ buildId: 'bld_mine', status: 'planned' }),
+      build({ buildId: 'bld_theirs', status: 'planned', orderId: OTHER_ORDER }),
+    ]
+
+    await run()
+
+    expect(h.cancelCalls).toEqual(['bld_mine'])
+  })
+})
+
+describe('idempotence', () => {
+  it('never reverses a build that already carries a reversal', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [
+      build({ buildId: 'bld_done', status: 'completed' }),
+      // The reversal itself: same order, same source, carried by `reverseBuild`.
+      build({ buildId: 'rev_1', status: 'completed', reversalOfBuildId: 'bld_done' }),
+    ]
+
+    const summary = await run()
+
+    expect(h.reverseCalls).toEqual([])
+    expect(summary.outcomes.map((o) => o.action)).toEqual(['skipped', 'skipped'])
+  })
+
+  it('never undoes a reversing build — that would re-apply what it removed', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = [build({ buildId: 'rev_1', status: 'completed', reversalOfBuildId: 'bld_gone' })]
+
+    await run()
+
+    expect(h.reverseCalls).toEqual([])
+    expect(h.cancelCalls).toEqual([])
+  })
+})
+
+describe('the cancellation stamp is re-read, not trusted', () => {
+  it('does nothing for an order whose `order_cancelled_at` is empty', async () => {
+    // The interactive native-field door fires `on: set` for ANY write of the
+    // field, so this is the case that stops a cleared value undoing production.
+    h.orders = [{ ...cancelledOrder(), cancelledAt: null }]
+    h.builds = [build({ buildId: 'bld_1', status: 'planned' })]
+
+    const summary = await run()
+
+    expect(summary.ordersCancelled).toBe(0)
+    expect(h.cancelCalls).toEqual([])
+    expect(h.listCalls).toEqual([])
+  })
+})
+
+describe('🛑 never throw', () => {
+  it('a build that refuses to reverse leaves the rest of the order undone anyway', async () => {
+    h.orders = [cancelledOrder()]
+    h.reverseFailures.set('bld_done', new ConflictError('already reversed'))
+    h.builds = [
+      build({ buildId: 'bld_done', status: 'completed' }),
+      build({ buildId: 'bld_planned', status: 'planned' }),
+    ]
+
+    const summary = await run()
+
+    expect(h.cancelCalls).toEqual(['bld_planned'])
+    expect(summary.failed).toEqual([
+      { orderId: ORDER, buildId: 'bld_done', message: 'already reversed' },
+    ])
+  })
+
+  it('returns an err rather than throwing when the order read fails', async () => {
+    const queries = await import('../auto-build-queries')
+    vi.mocked(queries.loadAutoBuildOrders).mockRejectedValueOnce(new Error('db is on fire'))
+
+    const result = await cancelAutoBuildsForOrders({} as never, ORG, [ORDER])
+
+    expect(result.isErr()).toBe(true)
+  })
+})
+
+describe('paging', () => {
+  it('walks past the first page, and stops on the first short one', async () => {
+    h.orders = [cancelledOrder()]
+    h.builds = Array.from({ length: 150 }, (_, i) =>
+      build({ buildId: `bld_${i}`, status: 'planned' })
+    )
+
+    const summary = await run()
+
+    expect(summary.outcomes).toHaveLength(150)
+    expect(h.cancelCalls).toHaveLength(150)
+    expect(h.listCalls.map((c) => c.offset)).toEqual([0, 100])
+  })
+})

--- a/packages/lib/src/builds/__tests__/auto-build-policy.test.ts
+++ b/packages/lib/src/builds/__tests__/auto-build-policy.test.ts
@@ -1,0 +1,126 @@
+// packages/lib/src/builds/__tests__/auto-build-policy.test.ts
+//
+// The four decisions the order-triggered auto-build makes without a database
+// (plans/products/12-order-triggered-build.md §5.3, AB4, AB8). Pure — no
+// doubles, no mocks, nothing to set up.
+
+import { describe, expect, it } from 'vitest'
+import {
+  isCoveredByStock,
+  isWithinEnablementWindow,
+  parseAutoBuildEnabledAt,
+  resolveAutoBuildStatus,
+  resolveAutoBuildStockRule,
+  sumQuantityByPart,
+} from '../auto-build-policy'
+
+const LIFT = 'part_lift'
+const HOIST = 'part_hoist'
+
+describe('sumQuantityByPart — one build per PART, not per line (§5.3 step 6)', () => {
+  it('collapses two lines of the SAME part into one entry for the sum', () => {
+    const totals = sumQuantityByPart([
+      { partId: LIFT, quantity: 2 },
+      { partId: LIFT, quantity: 3 },
+    ])
+    expect(totals.size).toBe(1)
+    expect(totals.get(LIFT)).toBe(5)
+  })
+
+  it('keeps different parts apart', () => {
+    const totals = sumQuantityByPart([
+      { partId: LIFT, quantity: 2 },
+      { partId: HOIST, quantity: 1 },
+      { partId: LIFT, quantity: 4 },
+    ])
+    expect([...totals.entries()].sort()).toEqual([
+      [HOIST, 1],
+      [LIFT, 6],
+    ])
+  })
+
+  it('drops a line with no quantity, and a part whose lines sum to nothing', () => {
+    const totals = sumQuantityByPart([
+      { partId: LIFT, quantity: 0 },
+      { partId: HOIST, quantity: Number.NaN },
+      { partId: HOIST, quantity: -3 },
+    ])
+    expect(totals.size).toBe(0)
+  })
+})
+
+describe('isCoveredByStock — AB4', () => {
+  it('out_of_stock_only skips a part the shelf already covers', () => {
+    expect(isCoveredByStock('out_of_stock_only', 10, 4)).toBe(true)
+    expect(isCoveredByStock('out_of_stock_only', 4, 4)).toBe(true)
+  })
+
+  it('out_of_stock_only fires for a part the shelf does not cover', () => {
+    expect(isCoveredByStock('out_of_stock_only', 3, 4)).toBe(false)
+    expect(isCoveredByStock('out_of_stock_only', 0, 1)).toBe(false)
+    expect(isCoveredByStock('out_of_stock_only', -2, 1)).toBe(false)
+  })
+
+  it('all_stock_levels never treats anything as covered — that is what it means', () => {
+    expect(isCoveredByStock('all_stock_levels', 1000, 1)).toBe(false)
+  })
+})
+
+describe('resolveAutoBuildStockRule — the SAFE value is the default (AB4)', () => {
+  it('defaults an unset, unknown or malformed value to out_of_stock_only', () => {
+    expect(resolveAutoBuildStockRule(undefined)).toBe('out_of_stock_only')
+    expect(resolveAutoBuildStockRule(null)).toBe('out_of_stock_only')
+    expect(resolveAutoBuildStockRule('everything')).toBe('out_of_stock_only')
+    expect(resolveAutoBuildStockRule(7)).toBe('out_of_stock_only')
+  })
+
+  it('honours an explicit all_stock_levels', () => {
+    expect(resolveAutoBuildStockRule('all_stock_levels')).toBe('all_stock_levels')
+  })
+})
+
+describe('resolveAutoBuildStatus — AB5', () => {
+  it('is planned, and stays planned even when the stored value says otherwise', () => {
+    // `completed` becomes selectable in phase 4, once `part_kind` is set on the
+    // parts that are built. Until then an auto-complete aborts on every order.
+    expect(resolveAutoBuildStatus('planned')).toBe('planned')
+    expect(resolveAutoBuildStatus('completed')).toBe('planned')
+    expect(resolveAutoBuildStatus(null)).toBe('planned')
+  })
+})
+
+describe('parseAutoBuildEnabledAt', () => {
+  it('reads an ISO string and a Date, and refuses anything else', () => {
+    expect(parseAutoBuildEnabledAt('2026-08-27T10:00:00.000Z')?.toISOString()).toBe(
+      '2026-08-27T10:00:00.000Z'
+    )
+    const date = new Date('2026-08-27T10:00:00.000Z')
+    expect(parseAutoBuildEnabledAt(date)).toBe(date)
+    expect(parseAutoBuildEnabledAt(null)).toBeNull()
+    expect(parseAutoBuildEnabledAt('')).toBeNull()
+    expect(parseAutoBuildEnabledAt('not a date')).toBeNull()
+    expect(parseAutoBuildEnabledAt(1756288800000)).toBeNull()
+  })
+})
+
+describe('isWithinEnablementWindow — AB8, the backlog cutoff', () => {
+  const enabledAt = new Date('2026-08-27T00:00:00.000Z')
+
+  it('accepts an order placed after the switch was turned on', () => {
+    expect(isWithinEnablementWindow(new Date('2026-08-28T00:00:00.000Z'), enabledAt)).toBe(true)
+  })
+
+  it('accepts an order placed at the exact moment it was turned on', () => {
+    expect(isWithinEnablementWindow(new Date(enabledAt), enabledAt)).toBe(true)
+  })
+
+  it('refuses an order placed before it — the whole point of the stamp', () => {
+    expect(isWithinEnablementWindow(new Date('2025-01-01T00:00:00.000Z'), enabledAt)).toBe(false)
+  })
+
+  it('🛑 refuses EVERY order when no stamp was recorded', () => {
+    // Guessing permissively here is what fires a build for every historical
+    // order the moment a Shopify back-fill lands.
+    expect(isWithinEnablementWindow(new Date('2030-01-01T00:00:00.000Z'), null)).toBe(false)
+  })
+})

--- a/packages/lib/src/builds/__tests__/auto-build-queries.test.ts
+++ b/packages/lib/src/builds/__tests__/auto-build-queries.test.ts
@@ -1,0 +1,247 @@
+// packages/lib/src/builds/__tests__/auto-build-queries.test.ts
+//
+// The reads behind the order-triggered build (§5.3 steps 1-2, 4). The org cache
+// is a double and `db` is a stand-in that routes by TABLE IDENTITY plus whether
+// the query joined — the same style as `build-event.test.ts`.
+//
+// ⚠️ `src/test/setup.ts` mocks `@auxx/database` wholesale, so `schema.Foo` is a
+// memoized `{}` whose COLUMNS are `undefined`: table identity is comparable by
+// reference, but the double cannot read a `WHERE`. The two unjoined
+// `FieldValue` reads are therefore told apart by ORDER — order values first,
+// line values second — which is exactly the order `loadAutoBuildOrders` issues
+// them in.
+
+import { schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG = 'org_1'
+const ORDER = 'ord_1'
+const LINE_A = 'line_a'
+const LINE_B = 'line_b'
+const LINE_C = 'line_c'
+const LIFT = 'part_lift'
+const PLACED_FIELD = 'fld_order_placed_at'
+const CANCELLED_FIELD = 'fld_order_cancelled_at'
+const LINE_ORDER_FIELD = 'fld_line_item_order'
+const LINE_PART_FIELD = 'fld_line_item_part'
+const LINE_QTY_FIELD = 'fld_line_item_qty'
+const QOH_FIELD = 'fld_part_quantity_on_hand'
+const CREATED_AT = new Date('2026-08-20T00:00:00.000Z')
+
+const h = vi.hoisted(() => ({
+  defs: new Map<string, string>(),
+  /** systemAttributes the org has materialised, mapped to a field row id. */
+  fields: new Map<string, string>(),
+  instanceRows: [] as { id: string; createdAt: Date }[],
+  /** `.from(FieldValue)` with NO join, in issue order. */
+  valueReads: [] as Record<string, unknown>[][],
+  /** `.from(FieldValue).innerJoin(EntityInstance)` — the line -> order edge. */
+  joinedRows: [] as Record<string, unknown>[],
+  valueReadIndex: 0,
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(
+          attrs.map((attr) => {
+            const id = h.fields.get(attr)
+            return [attr, id ? { id } : null]
+          })
+        ),
+    }),
+  }),
+}))
+
+import { loadAutoBuildOrders, readPartQuantitiesOnHand } from '../auto-build-queries'
+
+/** A promise carrying the chain methods, so `await` works anywhere along it. */
+function chain(rows: unknown[]): PromiseLike<unknown[]> & { where: () => unknown } {
+  const promise = Promise.resolve(rows) as unknown as PromiseLike<unknown[]> & {
+    where: () => unknown
+  }
+  promise.where = () => promise
+  return promise
+}
+
+const db = {
+  select: () => ({
+    from: (table: unknown) => {
+      if (table === schema.EntityInstance) return chain(h.instanceRows)
+      const joined = {
+        innerJoin: () => chain(h.joinedRows),
+        where: () => {
+          const rows = h.valueReads[h.valueReadIndex] ?? []
+          h.valueReadIndex += 1
+          return Promise.resolve(rows)
+        },
+      }
+      return joined
+    },
+  }),
+} as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.defs = new Map([
+    ['order', 'def_orders'],
+    ['line_item', 'def_lines'],
+  ])
+  h.fields = new Map([
+    ['order_placed_at', PLACED_FIELD],
+    ['order_cancelled_at', CANCELLED_FIELD],
+    ['line_item_order', LINE_ORDER_FIELD],
+    ['line_item_part', LINE_PART_FIELD],
+    ['line_item_qty', LINE_QTY_FIELD],
+    ['part_quantity_on_hand', QOH_FIELD],
+  ])
+  h.instanceRows = [{ id: ORDER, createdAt: CREATED_AT }]
+  h.valueReads = [[], []]
+  h.joinedRows = []
+  h.valueReadIndex = 0
+})
+
+describe('loadAutoBuildOrders', () => {
+  it('returns the order with its placed date and its lines', async () => {
+    h.valueReads = [
+      [{ entityId: ORDER, fieldId: PLACED_FIELD, valueDate: '2026-08-27T09:00:00.000Z' }],
+      [
+        { entityId: LINE_A, fieldId: LINE_PART_FIELD, relatedEntityId: LIFT, valueNumber: null },
+        { entityId: LINE_A, fieldId: LINE_QTY_FIELD, relatedEntityId: null, valueNumber: 2 },
+      ],
+    ]
+    h.joinedRows = [{ lineId: LINE_A, orderId: ORDER }]
+
+    const [order] = await loadAutoBuildOrders(db, ORG, [ORDER])
+
+    expect(order).toEqual({
+      orderId: ORDER,
+      placedAt: new Date('2026-08-27T09:00:00.000Z'),
+      cancelledAt: null,
+      lines: [{ partId: LIFT, quantity: 2 }],
+    })
+  })
+
+  it('falls back to the row createdAt when the order carries no placed date', async () => {
+    h.joinedRows = []
+
+    const [order] = await loadAutoBuildOrders(db, ORG, [ORDER])
+
+    expect(order?.placedAt).toEqual(CREATED_AT)
+  })
+
+  it('surfaces `order_cancelled_at`', async () => {
+    h.valueReads = [
+      [{ entityId: ORDER, fieldId: CANCELLED_FIELD, valueDate: '2026-08-28T00:00:00.000Z' }],
+      [],
+    ]
+
+    const [order] = await loadAutoBuildOrders(db, ORG, [ORDER])
+
+    expect(order?.cancelledAt).toEqual(new Date('2026-08-28T00:00:00.000Z'))
+  })
+
+  it('drops a line that reaches no part — §5.3 step 2', async () => {
+    h.valueReads = [
+      [],
+      [
+        { entityId: LINE_A, fieldId: LINE_PART_FIELD, relatedEntityId: LIFT, valueNumber: null },
+        { entityId: LINE_A, fieldId: LINE_QTY_FIELD, relatedEntityId: null, valueNumber: 1 },
+        // LINE_B carries a quantity but no `line_item_part`.
+        { entityId: LINE_B, fieldId: LINE_QTY_FIELD, relatedEntityId: null, valueNumber: 9 },
+      ],
+    ]
+    h.joinedRows = [
+      { lineId: LINE_A, orderId: ORDER },
+      { lineId: LINE_B, orderId: ORDER },
+    ]
+
+    const [order] = await loadAutoBuildOrders(db, ORG, [ORDER])
+
+    expect(order?.lines).toEqual([{ partId: LIFT, quantity: 1 }])
+  })
+
+  it('keeps two lines of the SAME part separate — the summing happens later', async () => {
+    // Collapsing here would hide the case `sumQuantityByPart` exists to handle.
+    h.valueReads = [
+      [],
+      [
+        { entityId: LINE_A, fieldId: LINE_PART_FIELD, relatedEntityId: LIFT, valueNumber: null },
+        { entityId: LINE_A, fieldId: LINE_QTY_FIELD, relatedEntityId: null, valueNumber: 2 },
+        { entityId: LINE_C, fieldId: LINE_PART_FIELD, relatedEntityId: LIFT, valueNumber: null },
+        { entityId: LINE_C, fieldId: LINE_QTY_FIELD, relatedEntityId: null, valueNumber: 3 },
+      ],
+    ]
+    h.joinedRows = [
+      { lineId: LINE_A, orderId: ORDER },
+      { lineId: LINE_C, orderId: ORDER },
+    ]
+
+    const [order] = await loadAutoBuildOrders(db, ORG, [ORDER])
+
+    expect(order?.lines).toEqual([
+      { partId: LIFT, quantity: 2 },
+      { partId: LIFT, quantity: 3 },
+    ])
+  })
+
+  it('reads a line with no stored quantity as zero, so the policy drops it', async () => {
+    h.valueReads = [
+      [],
+      [{ entityId: LINE_A, fieldId: LINE_PART_FIELD, relatedEntityId: LIFT, valueNumber: null }],
+    ]
+    h.joinedRows = [{ lineId: LINE_A, orderId: ORDER }]
+
+    const [order] = await loadAutoBuildOrders(db, ORG, [ORDER])
+
+    expect(order?.lines).toEqual([{ partId: LIFT, quantity: 0 }])
+  })
+
+  it('returns nothing at all for an empty input, without touching the cache', async () => {
+    const cache = await import('../../cache')
+    expect(await loadAutoBuildOrders(db, ORG, [])).toEqual([])
+    expect(cache.getCachedEntityDefId).not.toHaveBeenCalled()
+  })
+
+  it('returns nothing for an org with no `order` def', async () => {
+    h.defs.delete('order')
+    expect(await loadAutoBuildOrders(db, ORG, [ORDER])).toEqual([])
+  })
+
+  it('returns nothing for an org missing `line_item_part`', async () => {
+    // Nothing can reach a part, so there is nothing to build from — an empty
+    // list rather than a logged failure on every order create.
+    h.fields.delete('line_item_part')
+    expect(await loadAutoBuildOrders(db, ORG, [ORDER])).toEqual([])
+  })
+
+  it('returns nothing when the order id resolves to no live row', async () => {
+    h.instanceRows = []
+    expect(await loadAutoBuildOrders(db, ORG, [ORDER])).toEqual([])
+  })
+})
+
+describe('readPartQuantitiesOnHand', () => {
+  it('reads a stored quantity and defaults an uncounted part to zero', async () => {
+    h.valueReads = [[{ entityId: LIFT, valueNumber: 7 }]]
+
+    const quantities = await readPartQuantitiesOnHand(db, ORG, [LIFT, 'part_never_counted'])
+
+    expect(quantities.get(LIFT)).toBe(7)
+    expect(quantities.get('part_never_counted')).toBe(0)
+  })
+
+  it('defaults every part to zero when the org has no `part_quantity_on_hand`', async () => {
+    h.fields.delete('part_quantity_on_hand')
+
+    const quantities = await readPartQuantitiesOnHand(db, ORG, [LIFT])
+
+    expect(quantities.get(LIFT)).toBe(0)
+  })
+
+  it('is empty for an empty input', async () => {
+    expect((await readPartQuantitiesOnHand(db, ORG, [])).size).toBe(0)
+  })
+})

--- a/packages/lib/src/builds/__tests__/auto-build-rule.test.ts
+++ b/packages/lib/src/builds/__tests__/auto-build-rule.test.ts
@@ -1,0 +1,199 @@
+// packages/lib/src/builds/__tests__/auto-build-rule.test.ts
+//
+// The two system-rule declarations and their native handlers
+// (plans/products/12-order-triggered-build.md §5.1, §6.2). Asserts the shape
+// `assertSystemRuleShape` enforces, that they resolve against a real org's def
+// and field maps, and — the load-bearing one — that neither handler can throw.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG = 'org_1'
+const ORDER_DEF = 'def_orders'
+const CANCELLED_FIELD = 'fld_order_cancelled_at'
+
+const h = vi.hoisted(() => ({
+  autoBuildCalls: [] as { orgId: string; orderIds: string[] }[],
+  cancelCalls: [] as { orgId: string; orderIds: string[] }[],
+  autoBuildThrows: false,
+  autoBuildErrs: false,
+  cancelThrows: false,
+}))
+
+vi.mock('../auto-build', () => ({
+  runAutoBuildForOrders: vi.fn(async (_db: unknown, orgId: string, orderIds: string[]) => {
+    h.autoBuildCalls.push({ orgId, orderIds })
+    if (h.autoBuildThrows) throw new Error('handler blew up')
+    const { err, ok } = await import('neverthrow')
+    if (h.autoBuildErrs) return err(new Error('orchestrator refused'))
+    return ok({ ordersConsidered: orderIds.length, created: [], skipped: [], failed: [] })
+  }),
+}))
+
+vi.mock('../auto-build-cancel', () => ({
+  cancelAutoBuildsForOrders: vi.fn(async (_db: unknown, orgId: string, orderIds: string[]) => {
+    h.cancelCalls.push({ orgId, orderIds })
+    if (h.cancelThrows) throw new Error('cancel blew up')
+    const { ok } = await import('neverthrow')
+    return ok({ ordersCancelled: orderIds.length, outcomes: [], failed: [], deleted: 0 })
+  }),
+}))
+
+import { __clearNativeRuleHandlers, getNativeRuleHandler } from '../../record-rules/actions'
+import {
+  __clearSystemRules,
+  getSystemRuleDeclarations,
+  resolveSystemRules,
+} from '../../record-rules/system-rules'
+import {
+  __resetAutoBuildRulesLatch,
+  AUTO_BUILD_FROM_ORDER,
+  CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED,
+  registerAutoBuildRules,
+} from '../auto-build-rule'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.autoBuildCalls = []
+  h.cancelCalls = []
+  h.autoBuildThrows = false
+  h.autoBuildErrs = false
+  h.cancelThrows = false
+  __clearSystemRules()
+  __clearNativeRuleHandlers()
+  __resetAutoBuildRulesLatch()
+  registerAutoBuildRules()
+})
+
+afterEach(() => {
+  __clearSystemRules()
+  __clearNativeRuleHandlers()
+  __resetAutoBuildRulesLatch()
+})
+
+const decl = (key: string) => getSystemRuleDeclarations().find((d) => d.key === key)!
+
+describe('the declarations', () => {
+  it('declares exactly two rules, both all-native, both on the native order def', () => {
+    const decls = getSystemRuleDeclarations()
+    expect(decls).toHaveLength(2)
+    expect(decls.map((d) => d.key).sort()).toEqual([
+      'auto-build-cancel-on-order-cancelled',
+      'auto-build-from-order',
+    ])
+    // 🛑 AB3 — the native `order`, never `shopify_orders`. Only a native
+    // `line_item` carries `line_item_part`.
+    expect(decls.every((d) => d.defSlug === 'orders')).toBe(true)
+    expect(decls.every((d) => d.actions.every((a) => a.type === 'native'))).toBe(true)
+  })
+
+  it('the create rule is a LIFECYCLE rule with no fieldRef', () => {
+    const rule = decl('auto-build-from-order')
+    expect(rule.on).toBe('created')
+    expect(rule.fieldRef).toBeUndefined()
+    expect(rule.actions).toEqual([{ type: 'native', handler: AUTO_BUILD_FROM_ORDER }])
+  })
+
+  it('the cancellation rule watches `order_cancelled_at` being set (AB6/AB9)', () => {
+    const rule = decl('auto-build-cancel-on-order-cancelled')
+    expect(rule.on).toBe('set')
+    expect(rule.fieldRef).toEqual({ systemAttribute: 'order_cancelled_at' })
+    expect(rule.actions).toEqual([
+      { type: 'native', handler: CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED },
+    ])
+  })
+
+  it('is idempotent — a second registration does not duplicate anything', () => {
+    __resetAutoBuildRulesLatch()
+    registerAutoBuildRules()
+    expect(getSystemRuleDeclarations()).toHaveLength(2)
+  })
+
+  it('registers both native handlers under the keys the declarations name', () => {
+    expect(getNativeRuleHandler(AUTO_BUILD_FROM_ORDER)).toBeTypeOf('function')
+    expect(getNativeRuleHandler(CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED)).toBeTypeOf('function')
+  })
+})
+
+describe('resolution against an org', () => {
+  const lookup = {
+    defIdBySlug: (slug: string) => (slug === 'orders' ? ORDER_DEF : undefined),
+    fieldIdBySystemAttribute: (defId: string, attr: string) =>
+      defId === ORDER_DEF && attr === 'order_cancelled_at' ? CANCELLED_FIELD : undefined,
+  }
+
+  it('resolves both rules for an org that has the def and the field', () => {
+    const resolved = resolveSystemRules(ORG, getSystemRuleDeclarations(), lookup)
+    expect(resolved).toHaveLength(2)
+    expect(resolved.map((r) => r.id).sort()).toEqual([
+      'system:auto-build-cancel-on-order-cancelled',
+      'system:auto-build-from-order',
+    ])
+    expect(resolved.every((r) => r.entityDefinitionId === ORDER_DEF && r.isSystem)).toBe(true)
+    // The lifecycle rule keeps `fieldId: null`; the field rule resolves to a row id.
+    expect(resolved.find((r) => r.on === 'created')!.fieldId).toBeNull()
+    expect(resolved.find((r) => r.on === 'set')!.fieldId).toBe(CANCELLED_FIELD)
+  })
+
+  it('drops BOTH rules for an org with no orders def', () => {
+    const resolved = resolveSystemRules(ORG, getSystemRuleDeclarations(), {
+      ...lookup,
+      defIdBySlug: () => undefined,
+    })
+    expect(resolved).toEqual([])
+  })
+
+  it('drops only the cancellation rule for an org missing `order_cancelled_at`', () => {
+    const resolved = resolveSystemRules(ORG, getSystemRuleDeclarations(), {
+      ...lookup,
+      fieldIdBySystemAttribute: () => undefined,
+    })
+    expect(resolved.map((r) => r.on)).toEqual(['created'])
+  })
+})
+
+describe('the native handlers', () => {
+  const event = (recordIds: string[]) =>
+    ({ recordIds, organizationId: ORG, action: 'created' }) as never
+
+  it('turns record ids into instance ids and hands them to the orchestrator', async () => {
+    await getNativeRuleHandler(AUTO_BUILD_FROM_ORDER)!(
+      event([`${ORDER_DEF}:ord_1`, `${ORDER_DEF}:ord_2`])
+    )
+    expect(h.autoBuildCalls).toEqual([{ orgId: ORG, orderIds: ['ord_1', 'ord_2'] }])
+  })
+
+  it('ignores a firing that is not a create', async () => {
+    await getNativeRuleHandler(AUTO_BUILD_FROM_ORDER)!({
+      recordIds: [`${ORDER_DEF}:ord_1`],
+      organizationId: ORG,
+      action: 'deleted',
+    } as never)
+    expect(h.autoBuildCalls).toEqual([])
+  })
+
+  it('🛑 never throws when the orchestrator returns an err', async () => {
+    h.autoBuildErrs = true
+    await expect(
+      getNativeRuleHandler(AUTO_BUILD_FROM_ORDER)!(event([`${ORDER_DEF}:ord_1`]))
+    ).resolves.toBeUndefined()
+  })
+
+  it('🛑 never throws when the orchestrator throws outright', async () => {
+    h.autoBuildThrows = true
+    await expect(
+      getNativeRuleHandler(AUTO_BUILD_FROM_ORDER)!(event([`${ORDER_DEF}:ord_1`]))
+    ).resolves.toBeUndefined()
+  })
+
+  it('the cancellation handler forwards its instance ids, and never throws', async () => {
+    const handler = getNativeRuleHandler(CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED)!
+    // Field firings carry no `action`; the cancellation handler must not gate on one.
+    await handler({ recordIds: [`${ORDER_DEF}:ord_1`], organizationId: ORG } as never)
+    expect(h.cancelCalls).toEqual([{ orgId: ORG, orderIds: ['ord_1'] }])
+
+    h.cancelThrows = true
+    await expect(
+      handler({ recordIds: [`${ORDER_DEF}:ord_2`], organizationId: ORG } as never)
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/builds/__tests__/auto-build-settings.test.ts
+++ b/packages/lib/src/builds/__tests__/auto-build-settings.test.ts
@@ -1,0 +1,68 @@
+// packages/lib/src/builds/__tests__/auto-build-settings.test.ts
+//
+// The seam between the settings catalog and the auto-build policy: which four
+// keys are read, and how their stored shapes become the trigger's inputs
+// (plans/products/12-order-triggered-build.md §5.4).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG = 'org_1'
+
+const h = vi.hoisted(() => ({
+  values: new Map<string, unknown>(),
+  keysRead: [] as string[],
+}))
+
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: vi.fn(async ({ key }: { key: string }) => {
+    h.keysRead.push(key)
+    return h.values.has(key) ? h.values.get(key) : null
+  }),
+}))
+
+import { loadAutoBuildSettings } from '../auto-build-settings'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.values = new Map()
+  h.keysRead = []
+})
+
+describe('loadAutoBuildSettings', () => {
+  it('reads exactly the four `inventory.autoBuild*` keys', async () => {
+    await loadAutoBuildSettings(ORG)
+    expect(h.keysRead.sort()).toEqual([
+      'inventory.autoBuildEnabledAt',
+      'inventory.autoBuildFromOrders',
+      'inventory.autoBuildStatus',
+      'inventory.autoBuildStockRule',
+    ])
+  })
+
+  it('reads an unconfigured org as OFF, with the safe stock rule and no stamp', async () => {
+    expect(await loadAutoBuildSettings(ORG)).toEqual({
+      enabled: false,
+      enabledAt: null,
+      status: 'planned',
+      stockRule: 'out_of_stock_only',
+    })
+  })
+
+  it('turns the stored ISO stamp into a Date', async () => {
+    h.values.set('inventory.autoBuildFromOrders', true)
+    h.values.set('inventory.autoBuildEnabledAt', '2026-08-27T10:00:00.000Z')
+    h.values.set('inventory.autoBuildStockRule', 'all_stock_levels')
+
+    expect(await loadAutoBuildSettings(ORG)).toEqual({
+      enabled: true,
+      enabledAt: new Date('2026-08-27T10:00:00.000Z'),
+      status: 'planned',
+      stockRule: 'all_stock_levels',
+    })
+  })
+
+  it('treats a non-boolean stored switch as off', async () => {
+    h.values.set('inventory.autoBuildFromOrders', 'yes')
+    expect((await loadAutoBuildSettings(ORG)).enabled).toBe(false)
+  })
+})

--- a/packages/lib/src/builds/__tests__/auto-build.test.ts
+++ b/packages/lib/src/builds/__tests__/auto-build.test.ts
@@ -1,0 +1,479 @@
+// packages/lib/src/builds/__tests__/auto-build.test.ts
+//
+// Phase 3a — what `runAutoBuildForOrders` raises, what it declines, and what it
+// does when one part blows up (plans/products/12-order-triggered-build.md §5.3).
+//
+// The collaborators are doubles because every one of them is already covered by
+// its own suite: the order/line read (`auto-build-queries`), the settings read
+// (`auto-build-settings`), the part-kind read and `createBuild` itself
+// (`build-event.test.ts`). What is under test here is the DECISION SEQUENCE —
+// which is the whole of this phase, and the part a mocked db double would only
+// obscure.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+
+const ORG = 'org_1'
+const SYSTEM_USER = 'user_system'
+const ORDER = 'ord_1'
+const OTHER_ORDER = 'ord_2'
+const LIFT = 'part_lift'
+const HOIST = 'part_hoist'
+const MOTOR = 'part_motor'
+const ENABLED_AT = new Date('2026-08-01T00:00:00.000Z')
+
+interface FixtureOrder {
+  orderId: string
+  placedAt: Date
+  cancelledAt: Date | null
+  lines: { partId: string; quantity: number }[]
+}
+
+const h = vi.hoisted(() => ({
+  settings: {
+    enabled: true,
+    enabledAt: null as Date | null,
+    status: 'planned' as const,
+    stockRule: 'out_of_stock_only' as 'out_of_stock_only' | 'all_stock_levels',
+  },
+  orders: [] as FixtureOrder[],
+  /** partId -> stored `part_kind` option value. Absent reads as `component`. */
+  kinds: new Map<string, string>(),
+  /** partId -> `part_quantity_on_hand`. */
+  onHand: new Map<string, number>(),
+  /** partId -> direct subparts. An absent/empty entry is "no bill of materials". */
+  bom: new Map<string, { childId: string; qty: number }[]>(),
+  /** partIds `createBuild` must refuse, and with what. */
+  createFailures: new Map<string, Error>(),
+  /** partIds `createBuild` must THROW on, rather than returning an err. */
+  createThrows: new Set<string>(),
+  createCalls: [] as {
+    partId: string
+    quantityPlanned: number
+    orderId?: string
+    source?: string
+  }[],
+  systemUserCalls: 0,
+  nextBuild: 0,
+}))
+
+vi.mock('../auto-build-settings', () => ({
+  loadAutoBuildSettings: vi.fn(async () => h.settings),
+}))
+
+vi.mock('../auto-build-queries', () => ({
+  loadAutoBuildOrders: vi.fn(async (_db: unknown, _org: string, orderIds: string[]) =>
+    h.orders.filter((order) => orderIds.includes(order.orderId))
+  ),
+  readPartQuantitiesOnHand: vi.fn(async (_db: unknown, _org: string, partIds: string[]) => {
+    const map = new Map<string, number>()
+    for (const partId of partIds) map.set(partId, h.onHand.get(partId) ?? 0)
+    return map
+  }),
+}))
+
+vi.mock('../build-queries', () => ({
+  readPartKinds: vi.fn(async (_db: unknown, _org: string, partIds: string[]) => {
+    const map = new Map<string, string>()
+    for (const partId of partIds) {
+      const kind = h.kinds.get(partId)
+      if (kind) map.set(partId, kind)
+    }
+    return map
+  }),
+}))
+
+vi.mock('../../bom/subpart-graph', () => ({
+  loadDirectSubparts: vi.fn(async (_db: unknown, _org: string, partId: string) => {
+    return h.bom.get(partId) ?? []
+  }),
+}))
+
+vi.mock('../build-mutations', () => ({
+  createBuild: vi.fn(
+    async (
+      _db: unknown,
+      _org: string,
+      _userId: string,
+      input: { partId: string; quantityPlanned: number; orderId?: string; source?: string }
+    ) => {
+      h.createCalls.push(input)
+      if (h.createThrows.has(input.partId)) {
+        throw new Error(`boom for ${input.partId}`)
+      }
+      const failure = h.createFailures.get(input.partId)
+      const { err, ok } = await import('neverthrow')
+      if (failure) return err(failure)
+      h.nextBuild += 1
+      return ok({ buildId: `bld_${h.nextBuild}` })
+    }
+  ),
+}))
+
+vi.mock('../../users/system-user-service', () => ({
+  SystemUserService: {
+    getSystemUserForActions: vi.fn(async () => {
+      h.systemUserCalls += 1
+      return SYSTEM_USER
+    }),
+  },
+}))
+
+import { runAutoBuildForOrders } from '../auto-build'
+
+/** A buildable part: classified `finished_good`, with a bill of materials. */
+function makeBuildable(partId: string, kind = 'finished_good'): void {
+  h.kinds.set(partId, kind)
+  h.bom.set(partId, [{ childId: MOTOR, qty: 2 }])
+}
+
+function order(overrides: Partial<FixtureOrder> = {}): FixtureOrder {
+  return {
+    orderId: ORDER,
+    placedAt: new Date('2026-08-27T00:00:00.000Z'),
+    cancelledAt: null,
+    lines: [{ partId: LIFT, quantity: 1 }],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.settings = {
+    enabled: true,
+    enabledAt: ENABLED_AT,
+    status: 'planned',
+    stockRule: 'out_of_stock_only',
+  }
+  h.orders = []
+  h.kinds = new Map()
+  h.onHand = new Map()
+  h.bom = new Map()
+  h.createFailures = new Map()
+  h.createThrows = new Set()
+  h.createCalls = []
+  h.systemUserCalls = 0
+  h.nextBuild = 0
+})
+
+async function run(orderIds: string[] = [ORDER]) {
+  const result = await runAutoBuildForOrders({} as never, ORG, orderIds)
+  expect(result.isOk()).toBe(true)
+  return result._unsafeUnwrap()
+}
+
+function reasons(summary: Awaited<ReturnType<typeof run>>): string[] {
+  return summary.skipped.map((skip) => skip.reason)
+}
+
+describe('the switch', () => {
+  it('does nothing at all while `inventory.autoBuildFromOrders` is off', async () => {
+    h.settings.enabled = false
+    h.orders = [order()]
+    makeBuildable(LIFT)
+
+    const summary = await run()
+
+    expect(summary.created).toEqual([])
+    expect(reasons(summary)).toEqual(['disabled'])
+    expect(h.createCalls).toEqual([])
+    // Not even the system user is resolved — nothing is read that is not needed.
+    expect(h.systemUserCalls).toBe(0)
+  })
+})
+
+describe('one build per PART, not per line (§5.3 step 6)', () => {
+  it('two lines of the same lift yield ONE build for the SUM', async () => {
+    makeBuildable(LIFT)
+    h.orders = [
+      order({
+        lines: [
+          { partId: LIFT, quantity: 2 },
+          { partId: LIFT, quantity: 3 },
+        ],
+      }),
+    ]
+
+    const summary = await run()
+
+    expect(h.createCalls).toHaveLength(1)
+    expect(h.createCalls[0]).toMatchObject({ partId: LIFT, quantityPlanned: 5, orderId: ORDER })
+    expect(summary.created).toEqual([
+      { orderId: ORDER, partId: LIFT, buildId: 'bld_1', quantityPlanned: 5 },
+    ])
+  })
+
+  it('two DIFFERENT parts yield two builds', async () => {
+    makeBuildable(LIFT)
+    makeBuildable(HOIST, 'subassembly')
+    h.orders = [
+      order({
+        lines: [
+          { partId: LIFT, quantity: 1 },
+          { partId: HOIST, quantity: 4 },
+        ],
+      }),
+    ]
+
+    const summary = await run()
+
+    expect(summary.created.map((c) => [c.partId, c.quantityPlanned]).sort()).toEqual([
+      [HOIST, 4],
+      [LIFT, 1],
+    ])
+  })
+
+  it('stamps the order and `source: order` on every build it raises (AB7)', async () => {
+    makeBuildable(LIFT)
+    h.orders = [order()]
+
+    await run()
+
+    expect(h.createCalls[0]).toEqual({
+      partId: LIFT,
+      quantityPlanned: 1,
+      orderId: ORDER,
+      source: 'order',
+    })
+  })
+
+  it('writes as the org SYSTEM user — there is no human in the call stack', async () => {
+    makeBuildable(LIFT)
+    h.orders = [order()]
+
+    await run()
+
+    const { createBuild } = await import('../build-mutations')
+    expect(createBuild).toHaveBeenCalledWith({}, ORG, SYSTEM_USER, expect.anything())
+  })
+})
+
+describe('the filters (§5.3 steps 2-4)', () => {
+  it('skips a part with NO bill of materials', async () => {
+    h.kinds.set(LIFT, 'finished_good')
+    h.bom.set(LIFT, [])
+    h.orders = [order()]
+
+    const summary = await run()
+
+    expect(summary.created).toEqual([])
+    expect(reasons(summary)).toEqual(['no-bill-of-materials'])
+    expect(h.createCalls).toEqual([])
+  })
+
+  it('skips a `component` part — it is purchased, not assembled', async () => {
+    h.kinds.set(LIFT, 'component')
+    h.bom.set(LIFT, [{ childId: MOTOR, qty: 2 }])
+    h.orders = [order()]
+
+    const summary = await run()
+
+    expect(reasons(summary)).toEqual(['not-a-built-part'])
+    expect(h.createCalls).toEqual([])
+  })
+
+  it('skips an UNCLASSIFIED part, because a null `part_kind` reads as component', async () => {
+    h.bom.set(LIFT, [{ childId: MOTOR, qty: 2 }])
+    h.orders = [order()]
+
+    const summary = await run()
+
+    expect(reasons(summary)).toEqual(['not-a-built-part'])
+  })
+
+  it('skips an order whose lines reach no part at all', async () => {
+    h.orders = [order({ lines: [] })]
+
+    const summary = await run()
+
+    expect(reasons(summary)).toEqual(['no-parts-on-order'])
+  })
+
+  it('builds a `subassembly` as readily as a `finished_good`', async () => {
+    makeBuildable(HOIST, 'subassembly')
+    h.orders = [order({ lines: [{ partId: HOIST, quantity: 1 }] })]
+
+    const summary = await run()
+
+    expect(summary.created).toHaveLength(1)
+  })
+})
+
+describe('the stock rule (AB4)', () => {
+  it('out_of_stock_only SKIPS a part the shelf already covers', async () => {
+    makeBuildable(LIFT)
+    h.onHand.set(LIFT, 5)
+    h.orders = [order({ lines: [{ partId: LIFT, quantity: 3 }] })]
+
+    const summary = await run()
+
+    expect(summary.created).toEqual([])
+    expect(reasons(summary)).toEqual(['covered-by-stock'])
+  })
+
+  it('out_of_stock_only FIRES for a part the shelf does not cover', async () => {
+    makeBuildable(LIFT)
+    h.onHand.set(LIFT, 2)
+    h.orders = [order({ lines: [{ partId: LIFT, quantity: 3 }] })]
+
+    const summary = await run()
+
+    expect(summary.created).toHaveLength(1)
+    expect(h.createCalls[0]).toMatchObject({ quantityPlanned: 3 })
+  })
+
+  it('all_stock_levels builds regardless of what is on the shelf', async () => {
+    h.settings.stockRule = 'all_stock_levels'
+    makeBuildable(LIFT)
+    h.onHand.set(LIFT, 999)
+    h.orders = [order({ lines: [{ partId: LIFT, quantity: 3 }] })]
+
+    const summary = await run()
+
+    expect(summary.created).toHaveLength(1)
+  })
+
+  it('a part nobody has ever counted reads as zero on hand, and builds', async () => {
+    makeBuildable(LIFT)
+    h.orders = [order()]
+
+    const summary = await run()
+
+    expect(summary.created).toHaveLength(1)
+  })
+})
+
+describe('the enablement window (AB8)', () => {
+  it('skips an order PLACED before the switch was turned on', async () => {
+    makeBuildable(LIFT)
+    h.orders = [order({ placedAt: new Date('2025-06-01T00:00:00.000Z') })]
+
+    const summary = await run()
+
+    expect(summary.created).toEqual([])
+    expect(reasons(summary)).toEqual(['before-enablement'])
+    expect(h.createCalls).toEqual([])
+  })
+
+  it('🛑 skips EVERY order when no enablement stamp was ever recorded', async () => {
+    h.settings.enabledAt = null
+    makeBuildable(LIFT)
+    h.orders = [order(), order({ orderId: OTHER_ORDER })]
+
+    const summary = await run([ORDER, OTHER_ORDER])
+
+    expect(summary.created).toEqual([])
+    expect(reasons(summary)).toEqual(['before-enablement', 'before-enablement'])
+  })
+
+  it('skips an order that arrived already cancelled', async () => {
+    makeBuildable(LIFT)
+    h.orders = [order({ cancelledAt: new Date('2026-08-27T01:00:00.000Z') })]
+
+    const summary = await run()
+
+    expect(summary.created).toEqual([])
+    expect(reasons(summary)).toEqual(['order-cancelled'])
+  })
+})
+
+describe('🛑 never throw (§5.3 step 7)', () => {
+  it('a line that `createBuild` REFUSES still leaves the rest of the order built', async () => {
+    makeBuildable(LIFT)
+    makeBuildable(HOIST, 'subassembly')
+    h.createFailures.set(LIFT, new UnprocessableEntityError('no bill of materials'))
+    h.orders = [
+      order({
+        lines: [
+          { partId: LIFT, quantity: 1 },
+          { partId: HOIST, quantity: 2 },
+        ],
+      }),
+    ]
+
+    const summary = await run()
+
+    expect(summary.created.map((c) => c.partId)).toEqual([HOIST])
+    expect(summary.failed).toEqual([
+      { orderId: ORDER, partId: LIFT, message: 'no bill of materials' },
+    ])
+  })
+
+  it('a line that THROWS still leaves the rest of the order built', async () => {
+    makeBuildable(LIFT)
+    makeBuildable(HOIST, 'subassembly')
+    h.createThrows.add(LIFT)
+    h.orders = [
+      order({
+        lines: [
+          { partId: LIFT, quantity: 1 },
+          { partId: HOIST, quantity: 2 },
+        ],
+      }),
+    ]
+
+    const summary = await run()
+
+    expect(summary.created.map((c) => c.partId)).toEqual([HOIST])
+    expect(summary.failed).toEqual([
+      { orderId: ORDER, partId: LIFT, message: 'boom for part_lift' },
+    ])
+  })
+
+  it('a bad order does not lose the other orders in the batch', async () => {
+    makeBuildable(LIFT)
+    makeBuildable(HOIST, 'subassembly')
+    h.createThrows.add(LIFT)
+    h.orders = [
+      order({ lines: [{ partId: LIFT, quantity: 1 }] }),
+      order({ orderId: OTHER_ORDER, lines: [{ partId: HOIST, quantity: 1 }] }),
+    ]
+
+    const summary = await run([ORDER, OTHER_ORDER])
+
+    expect(summary.ordersConsidered).toBe(2)
+    expect(summary.created.map((c) => c.orderId)).toEqual([OTHER_ORDER])
+    expect(summary.failed.map((f) => f.orderId)).toEqual([ORDER])
+  })
+
+  it('returns an err rather than throwing when the whole read fails', async () => {
+    const queries = await import('../auto-build-queries')
+    vi.mocked(queries.loadAutoBuildOrders).mockRejectedValueOnce(new Error('db is on fire'))
+    h.orders = [order()]
+
+    const result = await runAutoBuildForOrders({} as never, ORG, [ORDER])
+
+    expect(result.isErr()).toBe(true)
+  })
+})
+
+describe('batching', () => {
+  it('reads the part kinds, quantities and BOM once per DISTINCT part', async () => {
+    makeBuildable(LIFT)
+    h.orders = [
+      order({ lines: [{ partId: LIFT, quantity: 1 }] }),
+      order({ orderId: OTHER_ORDER, lines: [{ partId: LIFT, quantity: 1 }] }),
+    ]
+
+    await run([ORDER, OTHER_ORDER])
+
+    const { readPartKinds } = await import('../build-queries')
+    const { loadDirectSubparts } = await import('../../bom/subpart-graph')
+    expect(readPartKinds).toHaveBeenCalledTimes(1)
+    expect(readPartKinds).toHaveBeenCalledWith({}, ORG, [LIFT])
+    expect(loadDirectSubparts).toHaveBeenCalledTimes(1)
+    // Two orders, one part each -> still two builds. Batching the READS never
+    // collapses the WRITES: these are two different orders.
+    expect(h.createCalls).toHaveLength(2)
+  })
+
+  it('never reads the bill of materials for a part it has already ruled out', async () => {
+    h.kinds.set(LIFT, 'component')
+    h.orders = [order()]
+
+    await run()
+
+    const { loadDirectSubparts } = await import('../../bom/subpart-graph')
+    expect(loadDirectSubparts).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/builds/auto-build-cancel.ts
+++ b/packages/lib/src/builds/auto-build-cancel.ts
@@ -1,0 +1,249 @@
+// packages/lib/src/builds/auto-build-cancel.ts
+
+/**
+ * Phase 3b — an order is cancelled, and the builds it caused are undone.
+ *
+ * plans/products/12-order-triggered-build.md section 6, decision AB6.
+ *
+ * 🛑 **Nothing is ever deleted.** The competitor setting this copies says to
+ * *delete* the auto-raised manufactures — and deleting a completed manufacture
+ * deletes ledger history and silently restates a closed period. Take the
+ * trigger, refuse the verb:
+ *
+ * | status | action |
+ * | --- | --- |
+ * | `planned` / `in_progress` | `cancelBuild` — no movements exist yet |
+ * | `completed` | `reverseBuild` — a second, opposite build carrying the ORIGINAL's frozen costs |
+ * | `canceled` | skip, already terminal |
+ *
+ * 🛑 **A build with `build_source = 'manual'` is never touched**, even when it
+ * points at the cancelled order. A person raised it deliberately, against this
+ * order, on purpose — that is the entire reason AB7 added `build_source`
+ * alongside `build_order`. The read filters on it in SQL AND this file
+ * re-checks it in memory, because `listBuilds` silently drops a filter whose
+ * field the org has not materialised, and a dropped `source` filter would turn
+ * "undo what the system raised" into "undo everything anyone raised".
+ *
+ * 🛑 **Never throws.** Same contract as `auto-build.ts`: one build that will not
+ * cancel must not strand the others.
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { Result } from 'neverthrow'
+import { SystemUserService } from '../users/system-user-service'
+import { loadAutoBuildOrders } from './auto-build-queries'
+import { cancelBuild } from './build-mutations'
+import { listBuilds } from './build-queries'
+import { canCancelBuild, canReverseBuild } from './client'
+import { guard } from './guard'
+import { reverseBuild } from './reverse-build'
+import type { BuildRecord } from './types'
+
+const logger = createScopedLogger('builds:auto-build-cancel')
+
+/** One page of the build read. Orders raise a handful of builds, not thousands. */
+const PAGE_SIZE = 100
+
+/**
+ * How many builds one order is allowed to have before the sweep stops walking.
+ *
+ * A cap rather than an unbounded loop: this runs inline on a field write, and a
+ * pathological order must degrade to "some builds were not undone, and it is in
+ * the log" rather than to a write that never returns.
+ */
+const MAX_BUILDS_PER_ORDER = 1000
+
+const CANCEL_REASON = 'Order cancelled'
+
+/** What happened to one build. */
+export type AutoBuildCancellationAction =
+  /** Was `planned` or `in_progress`; now `canceled`. */
+  | 'cancelled'
+  /** Was `completed`; a reversing build now negates it. */
+  | 'reversed'
+  /** Already `canceled`, already reversed, or itself a reversal. */
+  | 'skipped'
+
+export interface AutoBuildCancellationOutcome {
+  orderId: string
+  buildId: string
+  action: AutoBuildCancellationAction
+  /** The NEW build a reversal wrote. `null` for every other action. */
+  reversalBuildId: string | null
+}
+
+export interface AutoBuildCancellationFailure {
+  orderId: string
+  buildId: string
+  message: string
+}
+
+/** What one dispatch of the cancellation rule did. */
+export interface AutoBuildCancellationSummary {
+  /** Orders that were actually found carrying `order_cancelled_at`. */
+  ordersCancelled: number
+  outcomes: AutoBuildCancellationOutcome[]
+  failed: AutoBuildCancellationFailure[]
+  /**
+   * 🛑 Always `0`, asserted by a test.  and the
+   * counter exists so "nothing is ever deleted" is a property this module
+   * reports rather than a claim its comments make.
+   */
+  deleted: 0
+}
+
+function emptySummary(): AutoBuildCancellationSummary {
+  return { ordersCancelled: 0, outcomes: [], failed: [], deleted: 0 }
+}
+
+/**
+ * Undo the auto-raised builds behind a batch of cancelled orders.
+ *
+ * ⚠️ **The cancellation stamp is re-read, not trusted from the transition.** The
+ * interactive native-rule door dispatches with a sentinel new value rather than
+ * the real one (`field-hooks/field-hook-job.ts`), so `on: 'set'` there means
+ * "this field was written", not "this field went from empty to non-empty". Any
+ * order in the batch whose `order_cancelled_at` is actually empty is dropped
+ * here — which is also what makes a future un-cancel harmless rather than
+ * destructive.
+ *
+ * Deliberately NOT gated on `inventory.autoBuildFromOrders`. The builds already
+ * exist; switching the trigger off afterwards must not leave them stranded
+ * against an order that is gone. An org that never switched it on has no
+ * `source: 'order'` builds, so this is a no-op there by construction.
+ */
+export async function cancelAutoBuildsForOrders(
+  db: Database,
+  organizationId: string,
+  orderIds: string[]
+): Promise<Result<AutoBuildCancellationSummary, Error>> {
+  return guard(
+    async () => {
+      const summary = emptySummary()
+      if (orderIds.length === 0) return summary
+
+      const orders = await loadAutoBuildOrders(db, organizationId, orderIds)
+      const cancelled = orders.filter((order) => order.cancelledAt != null)
+      summary.ordersCancelled = cancelled.length
+      if (cancelled.length === 0) return summary
+
+      const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+
+      for (const order of cancelled) {
+        const builds = await readAutoBuilds(db, organizationId, order.orderId)
+        // A build that already carries a reversal must not be reversed twice —
+        // `reverseBuild` refuses it, but refusing is a logged failure and this
+        // rule can legitimately fire more than once on the same order.
+        const alreadyReversed = new Set(
+          builds
+            .map((build) => build.reversalOfBuildId)
+            .filter((id): id is string => id !== null && id !== undefined)
+        )
+
+        for (const build of builds) {
+          try {
+            const outcome = await undoBuild(db, organizationId, systemUserId, build, {
+              alreadyReversed,
+            })
+            summary.outcomes.push({ orderId: order.orderId, ...outcome })
+          } catch (error) {
+            summary.failed.push({
+              orderId: order.orderId,
+              buildId: build.buildId,
+              message: error instanceof Error ? error.message : String(error),
+            })
+          }
+        }
+      }
+
+      if (summary.outcomes.length > 0 || summary.failed.length > 0) {
+        logger.info('Cancelled order — undid its auto-raised builds', {
+          organizationId,
+          orders: summary.ordersCancelled,
+          cancelled: summary.outcomes.filter((o) => o.action === 'cancelled').length,
+          reversed: summary.outcomes.filter((o) => o.action === 'reversed').length,
+          skipped: summary.outcomes.filter((o) => o.action === 'skipped').length,
+          failed: summary.failed.length,
+        })
+      }
+      return summary
+    },
+    'Cancelling the builds for a cancelled order failed',
+    { organizationId, orders: orderIds.length }
+  )
+}
+
+/** Decide and perform the one correction this build's status allows. */
+async function undoBuild(
+  db: Database,
+  organizationId: string,
+  systemUserId: string,
+  build: BuildRecord,
+  ctx: { alreadyReversed: Set<string> }
+): Promise<Omit<AutoBuildCancellationOutcome, 'orderId'>> {
+  const skipped = { buildId: build.buildId, action: 'skipped' as const, reversalBuildId: null }
+
+  // A reversing build is a correction, not a run. Undoing it would re-apply the
+  // very movements the cancellation is trying to remove.
+  if (build.reversalOfBuildId) return skipped
+  if (ctx.alreadyReversed.has(build.buildId)) return skipped
+
+  if (canCancelBuild(build.status)) {
+    const result = await cancelBuild(db, organizationId, systemUserId, {
+      buildId: build.buildId,
+      reason: CANCEL_REASON,
+    })
+    if (result.isErr()) throw result.error
+    return { buildId: build.buildId, action: 'cancelled', reversalBuildId: null }
+  }
+
+  if (canReverseBuild(build.status)) {
+    const result = await reverseBuild(db, organizationId, systemUserId, {
+      buildId: build.buildId,
+      reason: CANCEL_REASON,
+    })
+    if (result.isErr()) throw result.error
+    return { buildId: build.buildId, action: 'reversed', reversalBuildId: result.value.buildId }
+  }
+
+  // `canceled`, or a row whose status is missing entirely. Terminal either way.
+  return skipped
+}
+
+/**
+ * Every `source: 'order'` build raised against one order.
+ *
+ * Paged, because `listBuilds` defaults to 50 and an order that raised 60 builds
+ * must not have 10 of them silently survive its cancellation.
+ */
+async function readAutoBuilds(
+  db: Database,
+  organizationId: string,
+  orderId: string
+): Promise<BuildRecord[]> {
+  const builds: BuildRecord[] = []
+  for (let offset = 0; offset < MAX_BUILDS_PER_ORDER; offset += PAGE_SIZE) {
+    const page = await listBuilds(db, organizationId, {
+      orderId,
+      source: 'order',
+      limit: PAGE_SIZE,
+      offset,
+    })
+    if (page.isErr()) throw page.error
+    // 🛑 Re-assert both filters in memory. `listBuilds` drops a filter whose
+    // field the org has not materialised, and a dropped `source` filter would
+    // hand a hand-raised build to the cancellation path.
+    builds.push(
+      ...page.value.filter((build) => build.orderId === orderId && build.source === 'order')
+    )
+    if (page.value.length < PAGE_SIZE) return builds
+  }
+
+  logger.warn('Order has more auto-raised builds than the cancellation sweep walks', {
+    organizationId,
+    orderId,
+    cap: MAX_BUILDS_PER_ORDER,
+  })
+  return builds
+}

--- a/packages/lib/src/builds/auto-build-policy.ts
+++ b/packages/lib/src/builds/auto-build-policy.ts
@@ -1,0 +1,151 @@
+// packages/lib/src/builds/auto-build-policy.ts
+
+/**
+ * Every decision the order-triggered auto-build makes that does not need a
+ * database: which stock rule is in force, whether a part is already covered,
+ * whether an order predates the switch being turned on, and how many units one
+ * order really wants of one part.
+ *
+ * plans/products/12-order-triggered-build.md sections 4 (AB4, AB5, AB8) and 5.3.
+ *
+ * Pure on purpose. The trigger runs with no human present and its interesting
+ * behaviour is entirely in these four answers, so they are testable without a
+ * db double, a cache double or a rule engine.
+ */
+
+/**
+ * Which stock levels an auto-build is raised for.
+ *
+ * 🛑 **`out_of_stock_only` is the default here and `all_stock_levels` is not**
+ * (AB4). Building a lift that is already crated on the shelf gives you two lifts
+ * and one order. The competitor this trigger is modelled on ships the unsafe
+ * value as the default and puts the safe one behind a paywall, which is
+ * backwards.
+ */
+export type AutoBuildStockRule = 'out_of_stock_only' | 'all_stock_levels'
+
+export const AUTO_BUILD_STOCK_RULES: readonly AutoBuildStockRule[] = [
+  'out_of_stock_only',
+  'all_stock_levels',
+]
+
+/**
+ * The status an auto-raised build lands in.
+ *
+ * 🛑 **`planned` is the only member today, and that is deliberate** (AB5). A
+ * `planned` build writes no movements (build README B2), which is the entire
+ * reason this trigger can ship before a single standard cost has been rolled.
+ * `completed` becomes selectable in phase 4, once `part_kind` is set on the
+ * parts that are actually built — until then an auto-complete would abort on
+ * its first run, on every order.
+ */
+export type AutoBuildStatus = 'planned'
+
+export const AUTO_BUILD_STATUSES: readonly AutoBuildStatus[] = ['planned']
+
+/**
+ * Read the stored `inventory.autoBuildStockRule` value.
+ *
+ * Anything unrecognised falls to `out_of_stock_only` rather than throwing: the
+ * safe direction, and a trigger is not the place to discover that somebody
+ * added a third stock rule.
+ */
+export function resolveAutoBuildStockRule(raw: unknown): AutoBuildStockRule {
+  return raw === 'all_stock_levels' ? 'all_stock_levels' : 'out_of_stock_only'
+}
+
+/** Read the stored `inventory.autoBuildStatus` value. See {@link AutoBuildStatus}. */
+export function resolveAutoBuildStatus(_raw: unknown): AutoBuildStatus {
+  return 'planned'
+}
+
+/** One order line, reduced to the only two things the trigger needs from it. */
+export interface AutoBuildLine {
+  /** `EntityInstance.id` of the `part` the line reaches through `line_item_part`. */
+  partId: string
+  /** `line_item_qty`. */
+  quantity: number
+}
+
+/**
+ * Collapse an order's lines to ONE entry per part, summing the quantities.
+ *
+ * 🛑 **This is section 5.3 step 6, and it is the whole of "one build per part,
+ * not one per line."** An order with the same lift on two lines must yield one
+ * build for the sum — two builds for the same part against the same order look
+ * like a duplicate to everyone downstream, and the floor would assemble the
+ * batch twice.
+ *
+ * Lines with a non-positive or non-finite quantity contribute nothing; a part
+ * whose lines sum to zero or less is dropped entirely rather than raising a
+ * build for nothing.
+ */
+export function sumQuantityByPart(lines: readonly AutoBuildLine[]): Map<string, number> {
+  const totals = new Map<string, number>()
+  for (const line of lines) {
+    if (!line.partId) continue
+    if (!Number.isFinite(line.quantity) || line.quantity <= 0) continue
+    totals.set(line.partId, (totals.get(line.partId) ?? 0) + line.quantity)
+  }
+  for (const [partId, quantity] of totals) {
+    if (quantity <= 0) totals.delete(partId)
+  }
+  return totals
+}
+
+/**
+ * Under the rule in force, is this part already covered by what is on the shelf?
+ *
+ * `all_stock_levels` never covers anything — that is what the option means.
+ * Under `out_of_stock_only` a part is covered when its quantity on hand already
+ * meets the whole ordered quantity.
+ *
+ * ⚠️ **On-hand, not available-to-promise.** Nothing here reserves stock against
+ * other open orders, so two same-day orders for three lifts each against five on
+ * the shelf are both read as covered. The rule this copies has the same shape; a
+ * real allocation model is a different feature and is not what AB4 asked for.
+ */
+export function isCoveredByStock(
+  rule: AutoBuildStockRule,
+  quantityOnHand: number,
+  quantityOrdered: number
+): boolean {
+  if (rule === 'all_stock_levels') return false
+  return quantityOnHand >= quantityOrdered
+}
+
+/**
+ * Coerce a stored `inventory.autoBuildEnabledAt` into a date.
+ *
+ * The catalog declares the key `DATETIME`, which `normalizeSettingValue` passes
+ * through unvalidated (no catalog entry used that field type before), so this
+ * has to be defensive about what is actually in the jsonb column.
+ */
+export function parseAutoBuildEnabledAt(raw: unknown): Date | null {
+  if (raw instanceof Date) return Number.isNaN(raw.getTime()) ? null : raw
+  if (typeof raw !== 'string' || raw.trim() === '') return null
+  const parsed = new Date(raw)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+/**
+ * AB8 — is this order inside the window the switch has been on for?
+ *
+ * 🛑 **A missing `enabledAt` reads as OUTSIDE the window, for every order.** The
+ * whole point of the stamp is that *a feature which reacts to records must not
+ * react to the backlog that existed when it was switched on*; with no recorded
+ * boundary there is no way to tell an order placed this morning from one
+ * back-filled out of five years of Shopify history, and guessing in the
+ * permissive direction fires a build for every historical order at once. The
+ * settings write path stamps the timestamp the instant the boolean flips on
+ * (`settings/settings-service.ts`), so the only way to reach this branch is an
+ * org whose row was written before that existed.
+ *
+ * The comparison is on the order's *business* date, not the row's creation
+ * date: a connector back-fill creates rows today carrying last year's
+ * `placedAt`, and that is exactly the case this exists to refuse.
+ */
+export function isWithinEnablementWindow(orderDate: Date, enabledAt: Date | null): boolean {
+  if (!enabledAt) return false
+  return orderDate.getTime() >= enabledAt.getTime()
+}

--- a/packages/lib/src/builds/auto-build-queries.ts
+++ b/packages/lib/src/builds/auto-build-queries.ts
@@ -1,0 +1,249 @@
+// packages/lib/src/builds/auto-build-queries.ts
+
+/**
+ * Every READ the order-triggered auto-build needs: an order's business date, its
+ * cancellation stamp, the parts its lines reach, and what is on the shelf.
+ *
+ * plans/products/12-order-triggered-build.md section 5.3 steps 1-4.
+ *
+ * Reads only — the writes live in `auto-build.ts`, because a file that both
+ * queries and mutates is the first step back toward a service class
+ * (`docs/lib-module-guide.md` section 5). No permission checks anywhere: this
+ * runs with no human present and the rule engine is not an authorization
+ * surface (section 6).
+ *
+ * 🛑 **AB3 — every read here is on the NATIVE `order` / `line_item`, never
+ * `shopify_orders`.** Only a native `line_item` carries `line_item_part`;
+ * `shopify_line_items` carries a `variant` reference, which is a different
+ * keyspace that reaches a part only through a hop that is 0 of 26 and stays
+ * that way (products/08 section 6.3).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import type { AutoBuildLine } from './auto-build-policy'
+
+/** The order fields the trigger reads. Both optional — migration 109 provisions them. */
+const ORDER_ATTRIBUTES = ['order_placed_at', 'order_cancelled_at'] as const
+
+/** The line fields the trigger reads. All three required for a line to be usable. */
+const LINE_ATTRIBUTES = ['line_item_order', 'line_item_part', 'line_item_qty'] as const
+
+/** One order, reduced to what section 5.3 actually decides on. */
+export interface AutoBuildOrder {
+  /** `EntityInstance.id` of the `order`. */
+  orderId: string
+  /**
+   * `order_placed_at`, falling back to the row's `createdAt`.
+   *
+   * The fallback matters: AB8 compares the order's BUSINESS date against the
+   * enablement stamp, and an order typed by hand in auxx may carry no placed
+   * date at all. Falling back to when the row was made keeps such an order
+   * inside the window rather than silently dropping it.
+   */
+  placedAt: Date
+  /** `order_cancelled_at`. Non-null means the order arrived (or is) cancelled. */
+  cancelledAt: Date | null
+  /** One entry per line that reaches a part. Lines with no part are already dropped. */
+  lines: AutoBuildLine[]
+}
+
+/**
+ * Load the orders in this batch, with their lines.
+ *
+ * Returns an entry per order that exists, is this org's, and is not archived —
+ * an id that resolves to nothing is simply absent rather than an error, because
+ * a lifecycle rule can be dispatched for a record a later write has since
+ * removed.
+ *
+ * Four queries regardless of batch size. An org missing the `order` def, the
+ * `line_item` def or any of the three line fields yields an empty list: there
+ * is nothing to build from, and refusing loudly would turn every order create
+ * in an unmigrated org into a logged failure.
+ */
+export async function loadAutoBuildOrders(
+  db: Database,
+  organizationId: string,
+  orderIds: string[]
+): Promise<AutoBuildOrder[]> {
+  if (orderIds.length === 0) return []
+
+  const [orderDefId, lineDefId] = await Promise.all([
+    getCachedEntityDefId(organizationId, 'order'),
+    getCachedEntityDefId(organizationId, 'line_item'),
+  ])
+  if (!orderDefId || !lineDefId) return []
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...ORDER_ATTRIBUTES, ...LINE_ATTRIBUTES])
+
+  const lineOrderField = fields.line_item_order
+  const linePartField = fields.line_item_part
+  const lineQtyField = fields.line_item_qty
+  if (!lineOrderField || !linePartField || !lineQtyField) return []
+
+  const orderRows = await db
+    .select({ id: schema.EntityInstance.id, createdAt: schema.EntityInstance.createdAt })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, orderDefId),
+        inArray(schema.EntityInstance.id, orderIds),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+  if (orderRows.length === 0) return []
+
+  const liveOrderIds = orderRows.map((row) => row.id)
+
+  const orderDateFieldIds = [fields.order_placed_at?.id, fields.order_cancelled_at?.id].filter(
+    (id): id is string => Boolean(id)
+  )
+  const orderValues = orderDateFieldIds.length
+    ? await db
+        .select({
+          entityId: schema.FieldValue.entityId,
+          fieldId: schema.FieldValue.fieldId,
+          valueDate: schema.FieldValue.valueDate,
+        })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            inArray(schema.FieldValue.entityId, liveOrderIds),
+            inArray(schema.FieldValue.fieldId, orderDateFieldIds)
+          )
+        )
+    : []
+
+  // The line -> order edge, with the line's own instance joined so an archived
+  // line is dropped at the source rather than contributing a phantom quantity.
+  const lineLinks = await db
+    .select({
+      lineId: schema.FieldValue.entityId,
+      orderId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .innerJoin(
+      schema.EntityInstance,
+      and(
+        eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, lineDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, lineOrderField.id),
+        inArray(schema.FieldValue.relatedEntityId, liveOrderIds)
+      )
+    )
+
+  const lineIds = [...new Set(lineLinks.map((row) => row.lineId))]
+  const lineValues = lineIds.length
+    ? await db
+        .select({
+          entityId: schema.FieldValue.entityId,
+          fieldId: schema.FieldValue.fieldId,
+          valueNumber: schema.FieldValue.valueNumber,
+          relatedEntityId: schema.FieldValue.relatedEntityId,
+        })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            inArray(schema.FieldValue.entityId, lineIds),
+            inArray(schema.FieldValue.fieldId, [linePartField.id, lineQtyField.id])
+          )
+        )
+    : []
+
+  const partByLine = new Map<string, string>()
+  const qtyByLine = new Map<string, number>()
+  for (const row of lineValues) {
+    if (row.fieldId === linePartField.id && row.relatedEntityId) {
+      partByLine.set(row.entityId, row.relatedEntityId)
+    } else if (row.fieldId === lineQtyField.id && row.valueNumber != null) {
+      qtyByLine.set(row.entityId, Number(row.valueNumber))
+    }
+  }
+
+  const linesByOrder = new Map<string, AutoBuildLine[]>()
+  for (const link of lineLinks) {
+    if (!link.orderId) continue
+    // Step 2: a line with no `line_item_part` reaches no part and is dropped.
+    const partId = partByLine.get(link.lineId)
+    if (!partId) continue
+    const bucket = linesByOrder.get(link.orderId)
+    const line: AutoBuildLine = { partId, quantity: qtyByLine.get(link.lineId) ?? 0 }
+    if (bucket) bucket.push(line)
+    else linesByOrder.set(link.orderId, [line])
+  }
+
+  const placedByOrder = new Map<string, Date>()
+  const cancelledByOrder = new Map<string, Date>()
+  for (const row of orderValues) {
+    const parsed = row.valueDate ? new Date(row.valueDate) : null
+    if (!parsed || Number.isNaN(parsed.getTime())) continue
+    if (row.fieldId === fields.order_placed_at?.id) placedByOrder.set(row.entityId, parsed)
+    else if (row.fieldId === fields.order_cancelled_at?.id) {
+      cancelledByOrder.set(row.entityId, parsed)
+    }
+  }
+
+  return orderRows.map((row) => ({
+    orderId: row.id,
+    placedAt: placedByOrder.get(row.id) ?? row.createdAt,
+    cancelledAt: cancelledByOrder.get(row.id) ?? null,
+    lines: linesByOrder.get(row.id) ?? [],
+  }))
+}
+
+/**
+ * `part_quantity_on_hand` for a set of parts.
+ *
+ * A part with no stored value reads **0**, not "unknown": a part nobody has ever
+ * counted has nothing on the shelf, and under `out_of_stock_only` that is the
+ * answer that raises the build.
+ */
+export async function readPartQuantitiesOnHand(
+  db: Database,
+  organizationId: string,
+  partIds: string[]
+): Promise<Map<string, number>> {
+  const quantities = new Map<string, number>()
+  if (partIds.length === 0) return quantities
+
+  const unique = [...new Set(partIds)]
+  for (const partId of unique) quantities.set(partId, 0)
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['part_quantity_on_hand'] as const)
+  const qohField = fields.part_quantity_on_hand
+  if (!qohField) return quantities
+
+  const rows = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      valueNumber: schema.FieldValue.valueNumber,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, qohField.id),
+        inArray(schema.FieldValue.entityId, unique)
+      )
+    )
+
+  for (const row of rows) {
+    if (row.valueNumber != null) quantities.set(row.entityId, Number(row.valueNumber))
+  }
+  return quantities
+}

--- a/packages/lib/src/builds/auto-build-rule.ts
+++ b/packages/lib/src/builds/auto-build-rule.ts
@@ -1,0 +1,158 @@
+// packages/lib/src/builds/auto-build-rule.ts
+
+/**
+ * The two system rules that make the build entity react to an order.
+ *
+ * plans/products/12-order-triggered-build.md sections 5.1 (AB2) and 6.2 (AB6).
+ *
+ * 🛑 **AB2 — code-declared system rules, not managed `RecordRule` rows.**
+ * Declarations are unioned into the org rule cache at compute time
+ * (`record-rules/system-rules.ts`), resolved per org, and dropped for an org
+ * that lacks the def or the field. The v9 inventory bridge needed a DB row per
+ * org, a provisioning step and a teardown path; this needs none of them.
+ *
+ * ⚠️ Contrary to plan 12 section 5.1, `declarations` was NOT empty when this was
+ * written — `field-hooks/system-entity-rules.ts` and
+ * `field-hooks/system-record-rules.ts` already declare nine lifecycle and seven
+ * field system rules between them, including the live
+ * `mfg-stock-movements-created`. These two follow that shipped shape exactly
+ * rather than inventing one.
+ *
+ * 🛑 **AB3 — `defSlug` is the NATIVE order, never `shopify_orders`.** Only a
+ * native `line_item` carries `line_item_part`. The slug used is the def's
+ * `apiSlug` (`'orders'`), matching every declaration already shipped: the
+ * resolver falls back to the entityType map, so `'order'` would also resolve —
+ * but only after `entityDefSlugs` had a chance to match a custom entity that
+ * happened to be api-slugged `order`.
+ *
+ * ⚠️ Section 5.2's door matrix is unchanged and must stay that way: `seed: off`
+ * for record rules is correct, because a seeded demo order must not manufacture
+ * anything.
+ *
+ * Top-level imports stay light — the two orchestrators pull `@auxx/database`,
+ * the CRUD handler and the BOM graph, so they are lazy-imported inside the
+ * wrappers. A static import here would drag all of that into
+ * `registerAllHooks()`'s module graph (same rule as `system-entity-rules.ts`).
+ */
+
+import { createScopedLogger } from '@auxx/logger'
+import { parseRecordId } from '@auxx/types/resource'
+import { registerNativeRuleHandler } from '../record-rules/actions'
+import type { SystemRuleDeclaration } from '../record-rules/system-rules'
+import { declareSystemRules } from '../record-rules/system-rules'
+
+const logger = createScopedLogger('builds:auto-build-rule')
+
+/** Native handler keys. Registered here, referenced by the declarations below. */
+export const AUTO_BUILD_FROM_ORDER = 'autoBuildFromOrder'
+export const CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED = 'cancelAutoBuildsOnOrderCancelled'
+
+let registered = false
+
+/**
+ * Declare the two auto-build system rules and register their native handlers.
+ * Called from `registerAllHooks()`. Idempotent — safe under repeated init.
+ */
+export function registerAutoBuildRules(): void {
+  if (registered) return
+  registered = true
+
+  registerNativeRuleHandler(AUTO_BUILD_FROM_ORDER, async (event) => {
+    // Lifecycle rule: `deleted` never reaches this declaration, but a native
+    // handler is keyed by name and could in principle be reused, so be explicit.
+    if (event.action !== 'created') return
+    await runQuietly('auto-build from order', event.organizationId, async () => {
+      const [{ database }, { runAutoBuildForOrders }] = await Promise.all([
+        import('@auxx/database'),
+        import('./auto-build'),
+      ])
+      const result = await runAutoBuildForOrders(
+        database,
+        event.organizationId,
+        toInstanceIds(event.recordIds)
+      )
+      if (result.isErr()) throw result.error
+    })
+  })
+
+  registerNativeRuleHandler(CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED, async (event) => {
+    await runQuietly('cancel auto-builds', event.organizationId, async () => {
+      const [{ database }, { cancelAutoBuildsForOrders }] = await Promise.all([
+        import('@auxx/database'),
+        import('./auto-build-cancel'),
+      ])
+      const result = await cancelAutoBuildsForOrders(
+        database,
+        event.organizationId,
+        toInstanceIds(event.recordIds)
+      )
+      if (result.isErr()) throw result.error
+    })
+  })
+
+  declareSystemRules(AUTO_BUILD_SYSTEM_RULES)
+}
+
+/** `<defId>:<instanceId>` -> `instanceId`, which is what the orchestrators take. */
+function toInstanceIds(recordIds: readonly string[]): string[] {
+  return recordIds.map((recordId) => parseRecordId(recordId as never).entityInstanceId)
+}
+
+/**
+ * 🛑 **Section 5.3 step 7 — never throw.**
+ *
+ * The engine already records a per-action failure and moves on, so a throw here
+ * would not lose the order; it would, however, mark the rule run failed for a
+ * reason nobody can act on, and it would put a dynamic-import failure on the
+ * same footing as a genuine business refusal. Both orchestrators already return
+ * a `Result` and isolate each order and each part internally; this is the last
+ * wall, and it catches the import itself.
+ */
+async function runQuietly(
+  what: string,
+  organizationId: string,
+  fn: () => Promise<void>
+): Promise<void> {
+  try {
+    await fn()
+  } catch (error) {
+    logger.error(`${what} failed`, {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * The two declarations.
+ *
+ * `assertSystemRuleShape` requires all-native actions, forbids a `fieldRef` on a
+ * lifecycle rule and requires one on a field rule — both of these satisfy it.
+ */
+const AUTO_BUILD_SYSTEM_RULES: SystemRuleDeclaration[] = [
+  {
+    key: 'auto-build-from-order',
+    name: 'Build finished goods when an order is created',
+    defSlug: 'orders',
+    on: 'created',
+    actions: [{ type: 'native', handler: AUTO_BUILD_FROM_ORDER }],
+  },
+  {
+    // ⚠️ `on: 'set'` is the intent, but it is not a guarantee. The interactive
+    // native-field door dispatches with `oldValue: undefined` and a sentinel new
+    // value (`field-hooks/field-hook-job.ts`), so every transition matches there
+    // — the handler re-reads `order_cancelled_at` and drops any order that is
+    // not actually cancelled.
+    key: 'auto-build-cancel-on-order-cancelled',
+    name: 'Cancel or reverse the auto-raised builds when an order is cancelled',
+    defSlug: 'orders',
+    fieldRef: { systemAttribute: 'order_cancelled_at' },
+    on: 'set',
+    actions: [{ type: 'native', handler: CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED }],
+  },
+]
+
+/** Test-only: reset the one-time registration latch. */
+export function __resetAutoBuildRulesLatch(): void {
+  registered = false
+}

--- a/packages/lib/src/builds/auto-build-settings.ts
+++ b/packages/lib/src/builds/auto-build-settings.ts
@@ -1,0 +1,57 @@
+// packages/lib/src/builds/auto-build-settings.ts
+
+/**
+ * The four `inventory.autoBuild*` org settings, resolved into the shape the
+ * trigger reads.
+ *
+ * plans/products/12-order-triggered-build.md section 5.4.
+ *
+ * No `db` parameter, matching {@link loadAbsorptionRates}: every one of these
+ * comes out of the `orgSettings` org cache (`getOrganizationSetting` merges the
+ * catalog defaults with the persisted rows behind a 100 ms L1 plus one Redis
+ * hash GET), so hitting the database here would defeat the invalidation the
+ * settings write path already performs.
+ */
+
+import { getOrganizationSetting } from '../settings/settings-service'
+import {
+  type AutoBuildStatus,
+  type AutoBuildStockRule,
+  parseAutoBuildEnabledAt,
+  resolveAutoBuildStatus,
+  resolveAutoBuildStockRule,
+} from './auto-build-policy'
+
+/** What the switch is set to right now, for one org. */
+export interface AutoBuildSettings {
+  /** `inventory.autoBuildFromOrders`. Off by default. */
+  enabled: boolean
+  /**
+   * `inventory.autoBuildEnabledAt` — when the switch was last turned on (AB8).
+   *
+   * `null` on an org whose row predates the stamp. The trigger treats that as
+   * "no order qualifies", never as "every order qualifies".
+   */
+  enabledAt: Date | null
+  /** `inventory.autoBuildStatus`. `planned` (AB5). */
+  status: AutoBuildStatus
+  /** `inventory.autoBuildStockRule`. `out_of_stock_only` by default (AB4). */
+  stockRule: AutoBuildStockRule
+}
+
+/** Read the four settings for one org, all four concurrently. */
+export async function loadAutoBuildSettings(organizationId: string): Promise<AutoBuildSettings> {
+  const [enabled, enabledAt, status, stockRule] = await Promise.all([
+    getOrganizationSetting({ organizationId, key: 'inventory.autoBuildFromOrders' }),
+    getOrganizationSetting({ organizationId, key: 'inventory.autoBuildEnabledAt' }),
+    getOrganizationSetting({ organizationId, key: 'inventory.autoBuildStatus' }),
+    getOrganizationSetting({ organizationId, key: 'inventory.autoBuildStockRule' }),
+  ])
+
+  return {
+    enabled: enabled === true,
+    enabledAt: parseAutoBuildEnabledAt(enabledAt),
+    status: resolveAutoBuildStatus(status),
+    stockRule: resolveAutoBuildStockRule(stockRule),
+  }
+}

--- a/packages/lib/src/builds/auto-build.ts
+++ b/packages/lib/src/builds/auto-build.ts
@@ -1,0 +1,265 @@
+// packages/lib/src/builds/auto-build.ts
+
+/**
+ * Phase 3a — an order arrives, and the system raises the builds needed to fulfil
+ * it.
+ *
+ * plans/products/12-order-triggered-build.md section 5.3. The trigger that calls
+ * this is declared in `auto-build-rule.ts`; this file is the whole of what it
+ * does, so it can be tested without a rule engine.
+ *
+ * 🛑 **AB1 — an order creates a `build`, not a movement.** The build is a
+ * visible, cancellable, costable record that a journal entry can point at. A
+ * hidden pair of offsetting movements is what the v9 inventory bridge did, and
+ * it is what made a lost movement undetectable.
+ *
+ * 🛑 **AB5 — every build this raises lands `planned`, and a planned build writes
+ * no stock movements** (build README B2). That is the safety property the whole
+ * phasing rests on: this can be switched on in an org where not one part has a
+ * frozen standard cost, and it still cannot produce a wrong number, because it
+ * does not produce a number at all.
+ *
+ * 🛑 **Never throws** (section 5.3 step 7). One bad line must not lose the rest
+ * of the order, and one bad order must not lose the rest of the batch — so every
+ * part is attempted inside its own `try`, every order inside its own `try`, and
+ * the whole thing is wrapped in the module `guard`. A caller that ignores the
+ * returned `Result` is behaving correctly.
+ *
+ * No permission checks. The rule engine is not an authorization surface, and
+ * there is no human in the call stack to check against
+ * (`docs/lib-module-guide.md` section 6).
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { Result } from 'neverthrow'
+import { loadDirectSubparts } from '../bom/subpart-graph'
+import { SystemUserService } from '../users/system-user-service'
+import { isCoveredByStock, isWithinEnablementWindow, sumQuantityByPart } from './auto-build-policy'
+import {
+  type AutoBuildOrder,
+  loadAutoBuildOrders,
+  readPartQuantitiesOnHand,
+} from './auto-build-queries'
+import { loadAutoBuildSettings } from './auto-build-settings'
+import { createBuild } from './build-mutations'
+import { readPartKinds } from './build-queries'
+import { resolvePartKind } from './client'
+import { guard } from './guard'
+
+const logger = createScopedLogger('builds:auto-build')
+
+/** Why a candidate did not become a build. Every one of these is normal. */
+export type AutoBuildSkipReason =
+  /** `inventory.autoBuildFromOrders` is off. */
+  | 'disabled'
+  /** AB8 — the order was placed before the switch was turned on. */
+  | 'before-enablement'
+  /** The order arrived already cancelled; phase 3b would only undo the work. */
+  | 'order-cancelled'
+  /** No line on the order reaches a part through `line_item_part`. */
+  | 'no-parts-on-order'
+  /** Section 5.3 step 3 — a `component` (or an unclassified part) is purchased, not built. */
+  | 'not-a-built-part'
+  /** Section 5.3 step 2 — no bill of materials, so a build would consume nothing. */
+  | 'no-bill-of-materials'
+  /** AB4 — quantity on hand already covers the ordered quantity. */
+  | 'covered-by-stock'
+
+/** One candidate the trigger declined, with the reason a person can act on. */
+export interface AutoBuildSkip {
+  orderId: string | null
+  /** `null` for an order-level skip. */
+  partId: string | null
+  reason: AutoBuildSkipReason
+}
+
+/** One build the trigger raised. */
+export interface AutoBuildCreation {
+  orderId: string
+  partId: string
+  buildId: string
+  quantityPlanned: number
+}
+
+/** One candidate that failed. Recorded and stepped over, never thrown. */
+export interface AutoBuildFailure {
+  orderId: string
+  partId: string | null
+  message: string
+}
+
+/** What one dispatch of the trigger did. */
+export interface AutoBuildSummary {
+  /** Orders that resolved to a live, non-archived row in this org. */
+  ordersConsidered: number
+  created: AutoBuildCreation[]
+  skipped: AutoBuildSkip[]
+  failed: AutoBuildFailure[]
+}
+
+function emptySummary(): AutoBuildSummary {
+  return { ordersConsidered: 0, created: [], skipped: [], failed: [] }
+}
+
+/**
+ * Raise the builds a batch of newly created orders needs.
+ *
+ * The pass, per section 5.3, with the order-level gates hoisted ahead of the
+ * per-part ones so a back-filled order costs one comparison instead of a BOM
+ * read per line:
+ *
+ * 1. The switch is on (5.4), or nothing happens at all.
+ * 2. The order is inside the enablement window (AB8) and is not itself already
+ *    cancelled.
+ * 3. Its lines are collapsed to ONE entry per part, quantities summed (step 6).
+ * 4. Parts that are not `finished_good` / `subassembly` are dropped (step 3).
+ * 5. Parts with no direct subparts are dropped (step 2).
+ * 6. Under `out_of_stock_only`, parts already covered by stock are dropped (step 4).
+ * 7. What survives becomes one `planned` build per part, stamped with the order
+ *    and `source: 'order'` (AB7).
+ */
+export async function runAutoBuildForOrders(
+  db: Database,
+  organizationId: string,
+  orderIds: string[]
+): Promise<Result<AutoBuildSummary, Error>> {
+  return guard(
+    async () => {
+      const summary = emptySummary()
+      if (orderIds.length === 0) return summary
+
+      const settings = await loadAutoBuildSettings(organizationId)
+      if (!settings.enabled) {
+        summary.skipped.push({ orderId: null, partId: null, reason: 'disabled' })
+        return summary
+      }
+
+      const orders = await loadAutoBuildOrders(db, organizationId, orderIds)
+      summary.ordersConsidered = orders.length
+      if (orders.length === 0) return summary
+
+      // Order-level gates first, so the batched part reads below only ever cover
+      // parts that could still become a build.
+      const candidates: { order: AutoBuildOrder; byPart: Map<string, number> }[] = []
+      for (const order of orders) {
+        if (order.cancelledAt) {
+          summary.skipped.push({ orderId: order.orderId, partId: null, reason: 'order-cancelled' })
+          continue
+        }
+        if (!isWithinEnablementWindow(order.placedAt, settings.enabledAt)) {
+          summary.skipped.push({
+            orderId: order.orderId,
+            partId: null,
+            reason: 'before-enablement',
+          })
+          continue
+        }
+        const byPart = sumQuantityByPart(order.lines)
+        if (byPart.size === 0) {
+          summary.skipped.push({
+            orderId: order.orderId,
+            partId: null,
+            reason: 'no-parts-on-order',
+          })
+          continue
+        }
+        candidates.push({ order, byPart })
+      }
+      if (candidates.length === 0) return summary
+
+      const partIds = [...new Set(candidates.flatMap(({ byPart }) => [...byPart.keys()]))]
+      const [kinds, quantitiesOnHand, systemUserId] = await Promise.all([
+        readPartKinds(db, organizationId, partIds),
+        readPartQuantitiesOnHand(db, organizationId, partIds),
+        // The trigger runs unattended, so it writes as the org's system user —
+        // the same actor the rule engine's own `set-field` executor uses.
+        SystemUserService.getSystemUserForActions(organizationId),
+      ])
+
+      // One BOM read per DISTINCT part across the whole batch, not per order.
+      const hasBom = new Map<string, boolean>()
+      for (const partId of partIds) {
+        // Step 3 before step 2: a `component` never needs its bill of materials read.
+        if (resolvePartKind(kinds.get(partId)) === 'component') continue
+        const subparts = await loadDirectSubparts(db, organizationId, partId)
+        hasBom.set(partId, subparts.length > 0)
+      }
+
+      for (const { order, byPart } of candidates) {
+        for (const [partId, quantityPlanned] of byPart) {
+          try {
+            if (resolvePartKind(kinds.get(partId)) === 'component') {
+              summary.skipped.push({
+                orderId: order.orderId,
+                partId,
+                reason: 'not-a-built-part',
+              })
+              continue
+            }
+            if (!hasBom.get(partId)) {
+              summary.skipped.push({
+                orderId: order.orderId,
+                partId,
+                reason: 'no-bill-of-materials',
+              })
+              continue
+            }
+            if (
+              isCoveredByStock(
+                settings.stockRule,
+                quantitiesOnHand.get(partId) ?? 0,
+                quantityPlanned
+              )
+            ) {
+              summary.skipped.push({ orderId: order.orderId, partId, reason: 'covered-by-stock' })
+              continue
+            }
+
+            const created = await createBuild(db, organizationId, systemUserId, {
+              partId,
+              quantityPlanned,
+              orderId: order.orderId,
+              source: 'order',
+            })
+            if (created.isErr()) {
+              summary.failed.push({
+                orderId: order.orderId,
+                partId,
+                message: created.error.message,
+              })
+              continue
+            }
+            summary.created.push({
+              orderId: order.orderId,
+              partId,
+              buildId: created.value.buildId,
+              quantityPlanned,
+            })
+          } catch (error) {
+            // 🛑 Step 7. A part that blows up is recorded and stepped over; the
+            // rest of the order, and every other order in the batch, still runs.
+            summary.failed.push({
+              orderId: order.orderId,
+              partId,
+              message: error instanceof Error ? error.message : String(error),
+            })
+          }
+        }
+      }
+
+      if (summary.created.length > 0 || summary.failed.length > 0) {
+        logger.info('Auto-build from orders', {
+          organizationId,
+          orders: summary.ordersConsidered,
+          created: summary.created.length,
+          skipped: summary.skipped.length,
+          failed: summary.failed.length,
+        })
+      }
+      return summary
+    },
+    'Auto-build from orders failed',
+    { organizationId, orders: orderIds.length }
+  )
+}

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -11,6 +11,45 @@
  * first standard has ever been rolled without producing a wrong number.
  */
 
+export {
+  type AutoBuildCreation,
+  type AutoBuildFailure,
+  type AutoBuildSkip,
+  type AutoBuildSkipReason,
+  type AutoBuildSummary,
+  runAutoBuildForOrders,
+} from './auto-build'
+export {
+  type AutoBuildCancellationAction,
+  type AutoBuildCancellationFailure,
+  type AutoBuildCancellationOutcome,
+  type AutoBuildCancellationSummary,
+  cancelAutoBuildsForOrders,
+} from './auto-build-cancel'
+export {
+  AUTO_BUILD_STATUSES,
+  AUTO_BUILD_STOCK_RULES,
+  type AutoBuildLine,
+  type AutoBuildStatus,
+  type AutoBuildStockRule,
+  isCoveredByStock,
+  isWithinEnablementWindow,
+  parseAutoBuildEnabledAt,
+  resolveAutoBuildStatus,
+  resolveAutoBuildStockRule,
+  sumQuantityByPart,
+} from './auto-build-policy'
+export {
+  type AutoBuildOrder,
+  loadAutoBuildOrders,
+  readPartQuantitiesOnHand,
+} from './auto-build-queries'
+export {
+  AUTO_BUILD_FROM_ORDER,
+  CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED,
+  registerAutoBuildRules,
+} from './auto-build-rule'
+export { type AutoBuildSettings, loadAutoBuildSettings } from './auto-build-settings'
 export { cancelBuild, createBuild, startBuild } from './build-mutations'
 export {
   type BuildComponentPlanInput,

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/field-hooks/register-hooks.ts
 
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
+import { registerAutoBuildRules } from '../builds/auto-build-rule'
 import {
   ensureVisitOnWorkOrderCreate,
   syncVisitPinsOnAddressNormalized,
@@ -106,6 +107,14 @@ export function registerAllHooks(): void {
   // dispatch through door 2 (`handleRecordRules`) + the manifest consumer, so they gain
   // sync/import visibility for free. Replaces the deleted ENTITY_TRIGGERS registry.
   registerEntitySystemRules()
+
+  // The order-triggered build (plans/products/12-order-triggered-build.md, AB2/AB6): two
+  // more code-declared system rules on the NATIVE `orders` def — one lifecycle rule that
+  // raises a `planned` build per ordered part on create, and one field rule that cancels or
+  // REVERSES those builds when `order_cancelled_at` is set. Nothing is ever deleted (AB6).
+  // Both handlers swallow their own failures; the module's top-level imports stay light and
+  // everything heavy is lazy-imported inside the wrappers.
+  registerAutoBuildRules()
 
   // Field-change post-hook — fires `<prefix>:field:updated` after every field
   // write. Registered globally so contacts, tickets, companies, and custom

--- a/packages/lib/src/seed/entity-migrations/migrations/109-build-and-standard-cost.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/109-build-and-standard-cost.ts
@@ -133,7 +133,7 @@ const INCUMBENT_FIELD_KEYS: Record<(typeof EXISTING_TYPES)[number], readonly str
  * **No backfill, anywhere** (§1.5). Every new field reads NULL on every
  * existing row and every future reader must handle that. There is nothing to
  * reconstruct: a past movement's cost is not recoverable from a later ledger
- * state, and pretending otherwise is the Stocksmith failure exactly.
+ * state, and pretending otherwise is the Others failure exactly.
  *
  * **No field views and no default table views.** 108 materialised
  * `dialog_create` views because a dialog is an allowlist the registry cannot

--- a/packages/lib/src/settings/__tests__/auto-build-enabled-stamp.test.ts
+++ b/packages/lib/src/settings/__tests__/auto-build-enabled-stamp.test.ts
@@ -1,0 +1,222 @@
+// packages/lib/src/settings/__tests__/auto-build-enabled-stamp.test.ts
+//
+// AB8's enablement stamp (plans/products/12-order-triggered-build.md §4):
+// flipping `inventory.autoBuildFromOrders` ON records the moment it happened in
+// `inventory.autoBuildEnabledAt`, and the order-triggered build refuses every
+// order placed before it.
+//
+// The db is a stand-in recording upserts. `src/test/setup.ts` mocks
+// `@auxx/database` wholesale, so `schema.OrganizationSetting`'s columns are
+// `undefined` and the double cannot read a `WHERE` — the fixture is one row, so
+// "the row this select would return" is unambiguous.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SETTINGS_CATALOG } from '../catalog'
+import { batchUpdateOrganizationSettings, updateOrganizationSetting } from '../settings-service'
+
+const ORG = 'org_1'
+
+interface Upsert {
+  key: string
+  value: unknown
+  scope: string
+}
+
+const h = vi.hoisted(() => ({
+  /** The one row a `select` returns, or `undefined` for "no row yet". */
+  storedValue: undefined as unknown,
+  upserts: [] as Upsert[],
+}))
+
+function chain(rows: unknown[]) {
+  const promise = Promise.resolve(rows) as Promise<unknown[]> & Record<string, unknown>
+  promise.where = () => promise
+  promise.limit = () => promise
+  return promise
+}
+
+const db = {
+  select: () => ({
+    from: () => chain(h.storedValue === undefined ? [] : [{ value: h.storedValue }]),
+  }),
+  insert: () => ({
+    values: (row: Upsert) => ({
+      onConflictDoUpdate: () => {
+        h.upserts.push({ key: row.key, value: row.value, scope: row.scope })
+        return Promise.resolve([])
+      },
+    }),
+  }),
+  transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(db),
+} as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.storedValue = undefined
+  h.upserts = []
+})
+
+const stamps = () => h.upserts.filter((u) => u.key === 'inventory.autoBuildEnabledAt')
+
+describe('the four catalog entries (§5.4)', () => {
+  it('declares all four keys, org-scoped', () => {
+    for (const key of [
+      'inventory.autoBuildFromOrders',
+      'inventory.autoBuildEnabledAt',
+      'inventory.autoBuildStatus',
+      'inventory.autoBuildStockRule',
+    ] as const) {
+      expect(SETTINGS_CATALOG[key].access).toBe('org')
+    }
+  })
+
+  it('🛑 defaults to OFF, `out_of_stock_only` and `planned` (AB4/AB5)', () => {
+    expect(SETTINGS_CATALOG['inventory.autoBuildFromOrders'].defaultValue).toBe(false)
+    expect(SETTINGS_CATALOG['inventory.autoBuildEnabledAt'].defaultValue).toBeNull()
+    expect(SETTINGS_CATALOG['inventory.autoBuildStockRule'].defaultValue).toBe('out_of_stock_only')
+    expect(SETTINGS_CATALOG['inventory.autoBuildStatus'].defaultValue).toBe('planned')
+  })
+
+  it('offers `planned` alone until phase 4, and both stock rules today', () => {
+    expect(SETTINGS_CATALOG['inventory.autoBuildStatus'].options?.options).toEqual([
+      { value: 'planned', label: 'Planned' },
+    ])
+    expect(
+      SETTINGS_CATALOG['inventory.autoBuildStockRule'].options?.options?.map((o) => o.value)
+    ).toEqual(['out_of_stock_only', 'all_stock_levels'])
+  })
+
+  it('reuses GENERAL rather than the dead INVENTORY_BRIDGE scope', () => {
+    // `INVENTORY_BRIDGE` is the scope of the v9 bridge deleted in #1941; naming
+    // the bridge's replacement after the bridge would be worse than generic.
+    for (const key of [
+      'inventory.autoBuildFromOrders',
+      'inventory.autoBuildEnabledAt',
+      'inventory.autoBuildStatus',
+      'inventory.autoBuildStockRule',
+    ] as const) {
+      expect(SETTINGS_CATALOG[key].scope).toBe('GENERAL')
+    }
+  })
+})
+
+describe('updateOrganizationSetting — the off→on stamp', () => {
+  it('stamps `autoBuildEnabledAt` when the switch goes from unset to on', async () => {
+    await updateOrganizationSetting({
+      organizationId: ORG,
+      key: 'inventory.autoBuildFromOrders',
+      value: true,
+      db,
+    })
+
+    expect(stamps()).toHaveLength(1)
+    expect(typeof stamps()[0]?.value).toBe('string')
+    expect(Number.isNaN(Date.parse(stamps()[0]?.value as string))).toBe(false)
+  })
+
+  it('stamps again when the switch is turned back on after being off', async () => {
+    h.storedValue = false
+
+    await updateOrganizationSetting({
+      organizationId: ORG,
+      key: 'inventory.autoBuildFromOrders',
+      value: true,
+      db,
+    })
+
+    // 🛑 A switch off for three months must not reopen those three months.
+    expect(stamps()).toHaveLength(1)
+  })
+
+  it('🛑 does NOT re-stamp when the switch was already on', async () => {
+    h.storedValue = true
+
+    await updateOrganizationSetting({
+      organizationId: ORG,
+      key: 'inventory.autoBuildFromOrders',
+      value: true,
+      db,
+    })
+
+    // Re-saving an unchanged settings form must not move the cutoff forward and
+    // silently skip every order placed since it was actually turned on.
+    expect(stamps()).toEqual([])
+  })
+
+  it('does not stamp when the switch is turned OFF', async () => {
+    h.storedValue = true
+
+    await updateOrganizationSetting({
+      organizationId: ORG,
+      key: 'inventory.autoBuildFromOrders',
+      value: false,
+      db,
+    })
+
+    // The stamp is only read while the boolean is true, so leaving it is right.
+    expect(stamps()).toEqual([])
+  })
+
+  it('never stamps for an unrelated key', async () => {
+    await updateOrganizationSetting({
+      organizationId: ORG,
+      key: 'inventory.autoBuildStockRule',
+      value: 'all_stock_levels',
+      db,
+    })
+
+    expect(stamps()).toEqual([])
+    expect(h.upserts.map((u) => u.key)).toEqual(['inventory.autoBuildStockRule'])
+  })
+})
+
+describe('batchUpdateOrganizationSettings — the same stamp, same transaction', () => {
+  it('stamps when the batch flips the switch on', async () => {
+    await batchUpdateOrganizationSettings({
+      organizationId: ORG,
+      settings: [
+        { key: 'inventory.autoBuildStockRule', value: 'out_of_stock_only' },
+        { key: 'inventory.autoBuildFromOrders', value: true },
+      ],
+      db,
+    })
+
+    expect(stamps()).toHaveLength(1)
+  })
+
+  it('does not stamp when the batch leaves an already-on switch on', async () => {
+    h.storedValue = true
+
+    await batchUpdateOrganizationSettings({
+      organizationId: ORG,
+      settings: [{ key: 'inventory.autoBuildFromOrders', value: true }],
+      db,
+    })
+
+    expect(stamps()).toEqual([])
+  })
+})
+
+describe('validation', () => {
+  it('refuses a stock rule the catalog does not offer', async () => {
+    await expect(
+      updateOrganizationSetting({
+        organizationId: ORG,
+        key: 'inventory.autoBuildStockRule',
+        value: 'whatever',
+        db,
+      })
+    ).rejects.toThrow(/expects one of/)
+  })
+
+  it('🛑 refuses `completed` as an auto-build status until phase 4 widens it', async () => {
+    await expect(
+      updateOrganizationSetting({
+        organizationId: ORG,
+        key: 'inventory.autoBuildStatus',
+        value: 'completed',
+        db,
+      })
+    ).rejects.toThrow(/expects one of/)
+  })
+})

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -872,6 +872,72 @@ export const SETTINGS_CATALOG = {
       'Applied overhead per assembled unit, integer minor units: total annual factory ' +
       'overhead / expected annual units. Unset = no overhead absorption.',
   },
+
+  // ── Order-triggered auto-build (plans/products/12-order-triggered-build.md §5.4) ────────
+  //
+  // Scoped GENERAL, following the `manufacturing.*` precedent directly above:
+  // there is no INVENTORY value in the `SettingScope` pg enum and adding one is
+  // a Drizzle migration this phase does not carry. The enum's existing
+  // `INVENTORY_BRIDGE` member is NOT reused — it is the dead scope of the v9
+  // bridge deleted in #1941, and naming the bridge's replacement after the
+  // bridge is worse than a generic scope.
+  'inventory.autoBuildFromOrders': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CHECKBOX',
+    options: { variant: 'switch' },
+    // Off by default. Turning it on starts production automatically, which is a
+    // business decision nobody should acquire by upgrading.
+    defaultValue: false,
+    description:
+      'When on, creating an order raises a planned build for each ordered part that has a ' +
+      'bill of materials.',
+  },
+  // 🛑 Written by the settings write path, not by a form: flipping
+  // `inventory.autoBuildFromOrders` on stamps this with the moment it happened
+  // (AB8). Orders placed before it are never built — without it, switching this
+  // on against a Shopify back-fill fires a build for every historical order at
+  // once. Re-stamped on every off->on transition, so a switch turned off for
+  // three months does not reopen those three months when it comes back.
+  'inventory.autoBuildEnabledAt': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'DATETIME',
+    defaultValue: null,
+    description:
+      'When auto-build was last switched on, ISO 8601. Orders placed before it are never ' +
+      'built. Stamped automatically; not a user-facing field.',
+  },
+  // ⚠️ ONE legal value today, on purpose (AB5). A planned build writes no stock
+  // movements, which is what lets this trigger ship before a single standard
+  // cost has been rolled. `completed` becomes selectable in phase 4, once
+  // `part_kind` is set on the parts that are actually built — offering it now
+  // would abort `completeBuild` on the first auto-run, on every order.
+  'inventory.autoBuildStatus': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'SINGLE_SELECT',
+    defaultValue: 'planned',
+    options: { options: [{ value: 'planned', label: 'Planned' }] },
+    description: 'The status an automatically raised build lands in.',
+  },
+  // 🛑 The DEFAULT is the safe value (AB4). `all_stock_levels` builds a lift that is already
+  // crated on the shelf, which gives you two lifts and one order.
+  'inventory.autoBuildStockRule': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'SINGLE_SELECT',
+    defaultValue: 'out_of_stock_only',
+    options: {
+      options: [
+        { value: 'out_of_stock_only', label: 'Out of stock only' },
+        { value: 'all_stock_levels', label: 'All stock levels' },
+      ],
+    },
+    description:
+      'Whether an auto-build is raised for a part whose quantity on hand already covers the ' +
+      'ordered quantity.',
+  },
 } satisfies Record<string, SettingConfig>
 
 /**

--- a/packages/lib/src/settings/settings-service.ts
+++ b/packages/lib/src/settings/settings-service.ts
@@ -85,6 +85,60 @@ async function applyInvoiceDefaultTimingWriteThrough(params: {
 }
 
 /**
+ * AB8's enablement stamp (plans/products/12-order-triggered-build.md §4).
+ *
+ * `inventory.autoBuildFromOrders` flipping ON records the moment it happened in
+ * `inventory.autoBuildEnabledAt`, and the order-triggered build refuses every
+ * order placed before it. Without the stamp the trigger has no way to tell an
+ * order placed this morning from one back-filled out of years of Shopify
+ * history, and switching the feature on would raise a build for every
+ * historical order at once — the same lesson the polling backfill cutoff
+ * already taught.
+ *
+ * Written here rather than in a form so that EVERY door that can flip the
+ * boolean — the settings router, a batch save, a future onboarding step —
+ * carries the stamp with it. Mirrors the `documents.invoice.defaultTiming`
+ * write-through directly below it.
+ *
+ * 🛑 **Re-stamped on every off→on transition, not only the first.** A switch
+ * turned off for three months must not reopen those three months when it comes
+ * back on. Turning it OFF leaves the stamp alone — the value is only ever read
+ * while the boolean is true.
+ *
+ * Returns `true` when it wrote, so the batch path can decide about cache busts.
+ */
+async function stampAutoBuildEnabledAt(params: {
+  organizationId: string
+  /** The stored value BEFORE this write. `undefined` when no row existed. */
+  previousValue: SettingValue | undefined
+  value: SettingValue
+  db: Database | Transaction
+}): Promise<boolean> {
+  const { organizationId, previousValue, value, db } = params
+  // 🛑 The TRANSITION, not the value. Stamping on every write of `true` would let
+  // a settings form re-saved unchanged move the cutoff forward, silently skipping
+  // every order placed since the switch was actually turned on.
+  if (value !== true || previousValue === true) return false
+
+  const stampedAt = new Date().toISOString()
+  await db
+    .insert(schema.OrganizationSetting)
+    .values({
+      organizationId,
+      key: 'inventory.autoBuildEnabledAt',
+      value: stampedAt,
+      scope: SETTINGS_CATALOG['inventory.autoBuildEnabledAt'].scope,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [schema.OrganizationSetting.organizationId, schema.OrganizationSetting.key],
+      set: { value: stampedAt, updatedAt: new Date() },
+    })
+
+  return true
+}
+
+/**
  * Get an organization setting, ignoring user overrides.
  */
 export async function getOrganizationSetting(params: {
@@ -303,6 +357,13 @@ export async function updateOrganizationSetting(params: {
 
   const normalizedValue = normalizeSettingValue(key, settingConfig, value)
 
+  // Read BEFORE the upsert — the off→on transition is what AB8's stamp keys on,
+  // and it is not observable from the row once the write has landed.
+  const previousValue =
+    key === 'inventory.autoBuildFromOrders'
+      ? await readOrganizationSettingValue({ organizationId, key, db })
+      : undefined
+
   await db
     .insert(schema.OrganizationSetting)
     .values({
@@ -320,6 +381,28 @@ export async function updateOrganizationSetting(params: {
   if (key === 'documents.invoice.defaultTiming') {
     await applyInvoiceDefaultTimingWriteThrough({ organizationId, value: normalizedValue, db })
   }
+  if (key === 'inventory.autoBuildFromOrders') {
+    await stampAutoBuildEnabledAt({ organizationId, previousValue, value: normalizedValue, db })
+  }
+}
+
+/** The raw stored value for one key, or `undefined` when the org has no row. */
+async function readOrganizationSettingValue(params: {
+  organizationId: string
+  key: SettingKey
+  db: Database | Transaction
+}): Promise<SettingValue | undefined> {
+  const [row] = await params.db
+    .select({ value: schema.OrganizationSetting.value })
+    .from(schema.OrganizationSetting)
+    .where(
+      and(
+        eq(schema.OrganizationSetting.organizationId, params.organizationId),
+        eq(schema.OrganizationSetting.key, params.key)
+      )
+    )
+    .limit(1)
+  return row ? (row.value as SettingValue) : undefined
 }
 
 /**
@@ -411,6 +494,13 @@ export async function batchUpdateOrganizationSettings(params: {
 
       const normalizedValue = normalizeSettingValue(key, settingConfig, value)
 
+      // See `updateOrganizationSetting` — read before the upsert, or the
+      // transition AB8's stamp keys on is already gone.
+      const previousValue =
+        key === 'inventory.autoBuildFromOrders'
+          ? await readOrganizationSettingValue({ organizationId, key, db: tx })
+          : undefined
+
       await tx
         .insert(schema.OrganizationSetting)
         .values({
@@ -432,6 +522,14 @@ export async function batchUpdateOrganizationSettings(params: {
           db: tx,
         })
         if (wrote) touchedInvoiceDefaultTiming = true
+      }
+      if (key === 'inventory.autoBuildFromOrders') {
+        await stampAutoBuildEnabledAt({
+          organizationId,
+          previousValue,
+          value: normalizedValue,
+          db: tx,
+        })
       }
     }
   })


### PR DESCRIPTION
Phases **3a and 3b** of [`plans/products/12-order-triggered-build.md`](plans/products/12-order-triggered-build.md). An order is created and the system raises a `planned` build per finished good on it; the order is cancelled and those builds are cancelled or reversed.

Two code-declared **system rules** — no managed `RecordRule` rows, no per-org provisioning, no post-sink pass. That is exactly the machinery the inventory bridge needed (deleted in #1941) and this does not. **No schema migration.**

## 🛑 Two claims in plan 12 were stale

**AB2 said `declarations` is empty, so this "would be the first system rule".** It initialises empty but is populated at bootstrap by two registrars — `system-entity-rules.ts` (9 lifecycle rules, including the live `mfg-stock-movements-created`) and `system-record-rules.ts` (7 field rules), both called from `registerAllHooks()`. **This is the 17th and 18th declaration**, so it copies that shipped shape exactly: latch-guarded registrar, handler keys as exported consts, heavy imports lazy inside the wrappers, `__reset*Latch` for tests.

**§5.4 recommended adding an `INVENTORY` `SettingScope`.** The four keys ship **`GENERAL`** instead, following the `manufacturing.*` precedent set two PRs ago: there is no such value in the pg enum, and adding one is a Drizzle migration this phase was told not to carry. ⚠️ `SettingScope` still carries **`INVENTORY_BRIDGE` with zero catalog entries** — dead since #1941 — and naming the bridge's *replacement* after the bridge would be worse than a generic scope. A test pins both facts.

## 🛑 `on: 'set'` is not a transition — the load-bearing detail

The interactive native-field door (`field-hooks/field-hook-job.ts`) dispatches `oldValue: undefined` plus a sentinel new value, so **every** write of the field matches. `set` means *"this field was written"*, not *"this field became non-null"*.

The cancellation handler therefore **re-reads `order_cancelled_at`** and drops any order that is not actually cancelled. Without that, editing anything near the field could reverse a completed build.

## A manual build is never touched — enforced twice

`listBuilds({ source: 'order' })` in SQL, **and** an in-memory re-check of both `source` and `orderId`.

`listBuilds` silently drops a filter whose field the org has not materialised — so a dropped `source` filter would turn *"undo what the system raised"* into *"undo everything anyone raised"*. Two tests simulate exactly that.

## Other decisions worth reviewing

- **One build per PART, not per line** — the same lift on two lines yields one build for the sum. `sumQuantityByPart` is the single place it happens, and the read deliberately does **not** collapse (a test asserts it returns both lines separately), so the collapse is testable in isolation rather than being an accident of the query.
- **Never throw, in three layers** — per-part `try/catch` collecting into `summary.failed`, order-level gates that cannot throw, and the module `guard()`. A failed line is recorded as `{orderId, partId, message}` and the loop continues; tested for both a returned `err` and a raw `throw`.
- **`defSlug: 'orders'`, not `'order'`** — the resolver is `slugMap[slug] ?? typeMap[slug]`, so `'order'` only resolves via the entityType fallback, *after* giving a custom entity api-slugged `order` a chance to win. All 16 existing declarations use apiSlug.
- **AB8's enablement stamp needed a writer**, or the key was dead config. The settings service now stamps `autoBuildEnabledAt` on the off→on transition (mirroring the existing `documents.invoice.defaultTiming` write-through), reading the previous value **before** the upsert — so re-saving an unchanged form does not move the cutoff forward.
- **`inventory.autoBuildStatus` offers only `planned`** today. `completeBuild` aborts on any component lacking a standard cost, and `part_kind` is set on 5 of 218 parts, so offering `completed` would abort on the first auto-run.
- **Cancellation is not gated on the feature flag.** The builds already exist; turning the trigger off must not strand them.
- **An order created already cancelled is skipped**, rather than built-then-reversed.
- **Stock rule granularity follows §5.3 literally**: skip a covered part, or build the *full* ordered quantity — never the shortfall. QoH 2 / ordered 3 builds 3. "Build the shortfall" is arguably better but is a product call, not a silent deviation — it is Q5 in plan 13.

## ⚠️ Known, and now written up

**An order created through the app has no line items yet** — the header is created first and lines are added afterwards through the LineBuilder — so `on: 'created'` fires on an empty order and records `no-parts-on-order`.

The **connector path is unaffected**, and the reason is worth recording because it corrects §5.2: record rules fire **once at run finalize**, after `resolveRelationships`, on **both** lanes. The `per-record` vs `batched` split in `door-matrix.ts:171` is about firing granularity *inside the engine*, not about when rules run.

That gap, and the larger question of what should happen when an order changes **after** its builds are raised, are now [`plans/products/13-order-build-reconciliation.md`](plans/products/13-order-build-reconciliation.md). Short version: the trigger fires once, there is no existing-build check, and an order stays editable by design — so a quantity edit silently diverges. Naive idempotency is *worse*, because the rule that stops duplicates also stops corrections.

**This PR does not attempt to solve that.** It ships the trigger as specified, behind a flag defaulting to `false`.

## Verification

```
lib typecheck ratchet:  no new type errors (29 total, baseline 29)
web typecheck ratchet:  no new type errors (0 total, baseline 0)
vitest src/builds src/record-rules src/field-hooks src/settings:
                        40 files, 489 tests passed
full packages/lib:      1018 files, 13,658 tests passed
biome:                  17 files, clean
```

Also included: two copy edits made by hand during review — em-dashes to colons in the completion dialog, and a competitor name removed from a comment in migration 109.
