### PR TITLE
perf(money): read a document's lines in one query, and skip a write that changes nothing

### DIFF
--- a/packages/lib/src/money/purchase-order-totals.test.ts
+++ b/packages/lib/src/money/purchase-order-totals.test.ts
@@ -18,7 +18,25 @@ const h = vi.hoisted(() => ({
   listFiltered: vi.fn(),
   setValuesForEntity: vi.fn(),
   syncInvoicePaymentState: vi.fn(),
+  /**
+   * The LINE read. It is a set-based select over `FieldValue` rather than a
+   * `getFieldValues` per line — one query per 200 ids instead of one per line
+   * (`plans/events/08-derived-parent-reconciler-plan.md` §1), so the line half of
+   * these fixtures is raw rows while the HEADER half stays `getFieldValues`.
+   */
+  fieldValueRows: vi.fn(),
 }))
+
+// Real schema (so `eq`/`inArray` get real columns), stubbed connection.
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../database/src/db/schema/index')
+  return {
+    schema,
+    database: {
+      select: () => ({ from: () => ({ where: () => h.fieldValueRows() }) }),
+    },
+  }
+})
 
 vi.mock('../cache', () => ({
   getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
@@ -81,7 +99,15 @@ beforeEach(() => {
   h.setValuesForEntity.mockResolvedValue(undefined)
   h.listFiltered.mockResolvedValue({ ids: [] })
   h.getFieldValues.mockResolvedValue(new Map())
+  h.fieldValueRows.mockResolvedValue([])
 })
+
+/** One `FieldValue` row as the set-based line read sees it. */
+function row(entityId: string, fieldId: string, value: number | boolean) {
+  return typeof value === 'boolean'
+    ? { entityId, fieldId, valueBoolean: value }
+    : { entityId, fieldId, valueNumber: value }
+}
 
 describe('purchase order totals', () => {
   it('sums PURCHASE ORDER LINES, not line_items', async () => {
@@ -121,17 +147,17 @@ describe('purchase order totals', () => {
   it('adds the STATED shipping and tax on top and subtracts the flat discount', async () => {
     // Two lines at $50.00 and $30.00; $10.00 discount, $5.00 freight, $6.40 stated tax.
     h.listFiltered.mockResolvedValue({ ids: ['pol-1', 'pol-2'] })
-    h.getFieldValues.mockImplementation(async (recordId: string) => {
-      if (recordId === 'purchase_order:po-1') {
-        return new Map<string, unknown>([
-          ['f-po-discount', { type: 'number', value: 1000 }],
-          ['f-po-shipping', { type: 'number', value: 500 }],
-          ['f-po-tax', { type: 'number', value: 640 }],
-        ])
-      }
-      const lineTotal = recordId === 'purchase_order_line:pol-1' ? 5000 : 3000
-      return new Map<string, unknown>([['f-pol-total', { type: 'number', value: lineTotal }]])
-    })
+    h.getFieldValues.mockResolvedValue(
+      new Map<string, unknown>([
+        ['f-po-discount', { type: 'number', value: 1000 }],
+        ['f-po-shipping', { type: 'number', value: 500 }],
+        ['f-po-tax', { type: 'number', value: 640 }],
+      ])
+    )
+    h.fieldValueRows.mockResolvedValue([
+      row('pol-1', 'f-pol-total', 5000),
+      row('pol-2', 'f-pol-total', 3000),
+    ])
 
     await recomputeTotals({
       organizationId: 'org_1',
@@ -158,13 +184,11 @@ describe('purchase order totals', () => {
 
   it('treats the flat discount as an AMOUNT with no discount-type field to read', async () => {
     h.listFiltered.mockResolvedValue({ ids: ['pol-1'] })
-    h.getFieldValues.mockImplementation(async (recordId: string) => {
-      if (recordId === 'purchase_order:po-1') {
-        // A `percent` reading of 25 would give 7500, not 9975.
-        return new Map<string, unknown>([['f-po-discount', { type: 'number', value: 25 }]])
-      }
-      return new Map<string, unknown>([['f-pol-total', { type: 'number', value: 10000 }]])
-    })
+    // A `percent` reading of 25 would give 7500, not 9975.
+    h.getFieldValues.mockResolvedValue(
+      new Map<string, unknown>([['f-po-discount', { type: 'number', value: 25 }]])
+    )
+    h.fieldValueRows.mockResolvedValue([row('pol-1', 'f-pol-total', 10000)])
 
     await recomputeTotals({
       organizationId: 'org_1',
@@ -180,19 +204,17 @@ describe('purchase order totals', () => {
 describe('the sell side is byte-for-byte unchanged', () => {
   it('still sums line_items and still writes all three quote mirrors', async () => {
     h.listFiltered.mockResolvedValue({ ids: ['li-1'] })
-    h.getFieldValues.mockImplementation(async (recordId: string) => {
-      if (recordId === 'quote:q-1') {
-        return new Map<string, unknown>([
-          ['f-q-dtype', { type: 'option', optionId: 'percent' }],
-          ['f-q-dvalue', { type: 'number', value: 10 }],
-          ['f-q-rate', { type: 'number', value: 10 }],
-        ])
-      }
-      return new Map<string, unknown>([
-        ['f-li-total', { type: 'number', value: 10000 }],
-        ['f-li-taxable', { type: 'boolean', value: true }],
+    h.getFieldValues.mockResolvedValue(
+      new Map<string, unknown>([
+        ['f-q-dtype', { type: 'option', optionId: 'percent' }],
+        ['f-q-dvalue', { type: 'number', value: 10 }],
+        ['f-q-rate', { type: 'number', value: 10 }],
       ])
-    })
+    )
+    h.fieldValueRows.mockResolvedValue([
+      row('li-1', 'f-li-total', 10000),
+      row('li-1', 'f-li-taxable', true),
+    ])
 
     await recomputeTotals({
       organizationId: 'org_1',

--- a/packages/lib/src/money/totals-hooks.ts
+++ b/packages/lib/src/money/totals-hooks.ts
@@ -1,13 +1,16 @@
 // packages/lib/src/money/totals-hooks.ts
 
 import type { Database } from '@auxx/database'
+import { database, schema } from '@auxx/database'
 import type { TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
+import { and, eq, inArray } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import type { EntityFieldChangeHandler } from '../field-hooks/types'
+import { extractFieldValueScalar } from '../field-values/field-value-scalar'
 import { FieldValueService } from '../field-values/field-value-service'
 import { UnifiedCrudHandler } from '../resources/crud'
 import { syncInvoicePaymentState } from './payments/ledger'
@@ -344,6 +347,22 @@ async function recomputeDocumentTotals(params: {
     ...spec.billing.statedAdditionAttrs,
   ].filter((a): a is SystemAttribute => a !== null)
 
+  /**
+   * The mirrors this engine writes. Read in the SAME `getFieldValues` call as the
+   * billing inputs — same query, more ids, no extra round trip — so the write can be
+   * skipped when nothing moved (`purchase-order-line-rollups.ts:288` does the same for
+   * its single roll-up value).
+   *
+   * `_tax_total` is listed only when the engine OWNS it: a PO's is a human input
+   * (`writesTaxTotal: false`), and reading it here to compare against a number we never
+   * write would refuse every no-op.
+   */
+  const mirrorAttrs: SystemAttribute[] = [
+    `${spec.attrPrefix}_subtotal` as SystemAttribute,
+    `${spec.attrPrefix}_total` as SystemAttribute,
+    ...(spec.billing.writesTaxTotal ? [`${spec.attrPrefix}_tax_total` as SystemAttribute] : []),
+  ]
+
   const lineAttrs = [
     spec.line.lineTotalAttr,
     spec.line.taxableAttr,
@@ -353,7 +372,7 @@ async function recomputeDocumentTotals(params: {
 
   const cf = await cache
     .from(organizationId, 'customFields')
-    .bySystemAttributes<SystemAttribute>([...headerAttrs, ...lineAttrs])
+    .bySystemAttributes<SystemAttribute>([...headerAttrs, ...mirrorAttrs, ...lineAttrs])
 
   const discountTypeField = spec.billing.discountTypeAttr
     ? cf[spec.billing.discountTypeAttr]
@@ -361,7 +380,9 @@ async function recomputeDocumentTotals(params: {
   const discountValueField = cf[spec.billing.discountValueAttr]
   const taxRateField = spec.billing.taxRateAttr ? cf[spec.billing.taxRateAttr] : undefined
 
-  const headerFieldIds = headerAttrs.map((a) => cf[a]?.id).filter((id): id is string => !!id)
+  const headerFieldIds = [...headerAttrs, ...mirrorAttrs]
+    .map((a) => cf[a]?.id)
+    .filter((id): id is string => !!id)
   const headerValues = await handler.getFieldValues(documentRecordId, headerFieldIds)
 
   const readNumber = (fieldId: string | undefined): number | null => {
@@ -411,44 +432,10 @@ async function recomputeDocumentTotals(params: {
     limit: 1000,
   })
 
-  const lines: LineForTotals[] = []
   const lineTotalField = cf[spec.line.lineTotalAttr]
-  if (lineTotalField) {
-    const taxableFieldId = spec.line.taxableAttr ? cf[spec.line.taxableAttr]?.id : undefined
-    const optionalFieldId = spec.line.optionalAttr ? cf[spec.line.optionalAttr]?.id : undefined
-    const optionalSelectedFieldId = spec.line.optionalSelectedAttr
-      ? cf[spec.line.optionalSelectedAttr]?.id
-      : undefined
-    const fieldIds = [
-      lineTotalField.id,
-      taxableFieldId,
-      optionalFieldId,
-      optionalSelectedFieldId,
-    ].filter((id): id is string => !!id)
-
-    for (const lineInstanceId of lineInstanceIds) {
-      const lineRecordId = toRecordId(spec.line.lineEntityType, lineInstanceId)
-      const lineValues = await handler.getFieldValues(lineRecordId, fieldIds)
-      const lineTotalTyped = firstTyped(lineValues.get(lineTotalField.id))
-      const taxableTyped = taxableFieldId ? firstTyped(lineValues.get(taxableFieldId)) : undefined
-      const optionalTyped = optionalFieldId
-        ? firstTyped(lineValues.get(optionalFieldId))
-        : undefined
-      const optionalSelectedTyped = optionalSelectedFieldId
-        ? firstTyped(lineValues.get(optionalSelectedFieldId))
-        : undefined
-      lines.push({
-        lineTotal: lineTotalTyped ? (extractValue(lineTotalTyped) as number) : null,
-        // A line entity with no `taxable` field is wholly taxable as far as the math is
-        // concerned — with `taxRate` null (the buy side) that distinction never surfaces.
-        taxable: taxableTyped ? (extractValue(taxableTyped) as boolean) : true,
-        optional: optionalTyped ? (extractValue(optionalTyped) as boolean) : undefined,
-        optionalSelected: optionalSelectedTyped
-          ? (extractValue(optionalSelectedTyped) as boolean)
-          : undefined,
-      })
-    }
-  }
+  const lines: LineForTotals[] = lineTotalField
+    ? await readLinesForTotals(db, organizationId, spec, cf, lineInstanceIds)
+    : []
 
   const totals = computeDocumentTotals(lines, billing)
 
@@ -463,14 +450,146 @@ async function recomputeDocumentTotals(params: {
     values.push({ fieldId: `${spec.attrPrefix}_tax_total`, value: totals.taxTotal })
   }
 
-  const fieldValueService = new FieldValueService(organizationId, userId, db)
-  await fieldValueService.setValuesForEntity({
-    recordId: documentRecordId,
-    values,
-    publishEvents: spec.publishEvents,
+  /**
+   * Skip a write that would store what is already stored.
+   *
+   * The hook fires once per changed FIELD, and several of its triggers move no total at
+   * all — `line_item_taxable` on a document with no tax rate, a rel write that re-links a
+   * line to the parent it already had, the second of two attributes set in one line write.
+   * Each of those previously re-entered the field-value layer, the realtime publisher and
+   * the sync manifest to store an identical number.
+   *
+   * Conservative by construction: unless EVERY value is already present and equal, the
+   * write happens. A mirror the org has not materialised has no field id, so `readNumber`
+   * returns null, nothing matches, and the write proceeds exactly as before.
+   *
+   * 🛑 `afterWrite` still runs. `syncInvoicePaymentState` reads more than these three
+   * numbers — a payment recorded elsewhere moves `balance` and can flip
+   * `paid` <-> `partially_paid` with the totals unchanged — and `money.recomputeTotals`
+   * is documented as the manual drift escape, so it must stay a real refresh.
+   */
+  const unchanged = values.every((v) => {
+    const current = readNumber(cf[v.fieldId as SystemAttribute]?.id)
+    return current !== null && current === v.value
   })
 
+  if (!unchanged) {
+    const fieldValueService = new FieldValueService(organizationId, userId, db)
+    await fieldValueService.setValuesForEntity({
+      recordId: documentRecordId,
+      values,
+      publishEvents: spec.publishEvents,
+    })
+  }
+
   await spec.afterWrite?.({ organizationId, userId, documentInstanceId, db })
+}
+
+/**
+ * Every line's contribution to its document, in ONE query per 200-id chunk.
+ *
+ * ⚠️ This replaced a serial `getFieldValues` per line — `await` inside a `for`
+ * over an id list capped at 1000 — which made a 20-line document cost ~20
+ * round trips per hook fire, and the hook fires once per changed FIELD. A
+ * 20-line bulk paste therefore issued 40 recomputes, each re-reading every
+ * line that existed so far. See `plans/events/08-derived-parent-reconciler-plan.md` §1.
+ *
+ * The read is deliberately raw + {@link extractFieldValueScalar} rather than
+ * `FieldValueService.batchGetValues`, for the same two reasons
+ * `purchase-order-line-rollups.ts` and `builds/auto-build-queries.ts` are
+ * written this way: the field ids in hand are CustomField ids, where
+ * `batchGetValues` validates `ResourceFieldId`s (`entity:key`) and would need a
+ * key translation this has no reason to risk; and enforcement is unchanged
+ * either way, because the handler this used to go through is constructed
+ * without a `CapabilityView` and the line ids were already scoped by the
+ * `listFiltered` above.
+ *
+ * One entry per id in `lineInstanceIds`, in that order, INCLUDING a line with no
+ * stored values at all — the previous loop pushed an entry per id unconditionally
+ * and `computeDocumentTotals` counts a null `lineTotal` as a zero contribution.
+ */
+async function readLinesForTotals(
+  db: Database | undefined,
+  organizationId: string,
+  spec: DocumentTotalsSpec,
+  cf: Partial<Record<SystemAttribute, { id: string } | null>>,
+  lineInstanceIds: string[]
+): Promise<LineForTotals[]> {
+  if (lineInstanceIds.length === 0) return []
+
+  const idFor = (attr: SystemAttribute | undefined): string | undefined =>
+    attr ? (cf[attr]?.id ?? undefined) : undefined
+
+  const lineTotalFieldId = idFor(spec.line.lineTotalAttr)
+  const taxableFieldId = idFor(spec.line.taxableAttr)
+  const optionalFieldId = idFor(spec.line.optionalAttr)
+  const optionalSelectedFieldId = idFor(spec.line.optionalSelectedAttr)
+
+  const fieldIds = [
+    lineTotalFieldId,
+    taxableFieldId,
+    optionalFieldId,
+    optionalSelectedFieldId,
+  ].filter((id): id is string => !!id)
+  if (fieldIds.length === 0) return lineInstanceIds.map(() => emptyLineForTotals())
+
+  const conn = db ?? database
+  // `fieldId -> value` per line. A line absent from the map stored nothing.
+  const byLine = new Map<string, Map<string, unknown>>()
+
+  // Bounded IN-list, same 200 as `record-rules/snapshot-fetcher.ts`. A document
+  // is capped at 1000 lines by the `listFiltered` above, so this is <= 5 queries
+  // for the largest document that can exist, against 1000 before.
+  const CHUNK = 200
+  for (let i = 0; i < lineInstanceIds.length; i += CHUNK) {
+    const chunk = lineInstanceIds.slice(i, i + CHUNK)
+    const rows = await conn
+      .select()
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          inArray(schema.FieldValue.entityId, chunk),
+          inArray(schema.FieldValue.fieldId, fieldIds)
+        )
+      )
+
+    for (const row of rows) {
+      let values = byLine.get(row.entityId)
+      if (!values) {
+        values = new Map()
+        byLine.set(row.entityId, values)
+      }
+      values.set(row.fieldId, extractFieldValueScalar(row as unknown as Record<string, unknown>))
+    }
+  }
+
+  return lineInstanceIds.map((lineInstanceId) => {
+    const values = byLine.get(lineInstanceId)
+    if (!values) return emptyLineForTotals()
+
+    const read = (fieldId: string | undefined): unknown =>
+      fieldId && values.has(fieldId) ? values.get(fieldId) : undefined
+
+    const lineTotal = read(lineTotalFieldId)
+    const taxable = read(taxableFieldId)
+    const optional = read(optionalFieldId)
+    const optionalSelected = read(optionalSelectedFieldId)
+
+    return {
+      lineTotal: lineTotal == null ? null : (lineTotal as number),
+      // A line entity with no `taxable` field is wholly taxable as far as the math is
+      // concerned — with `taxRate` null (the buy side) that distinction never surfaces.
+      taxable: taxable == null ? true : (taxable as boolean),
+      optional: optional == null ? undefined : (optional as boolean),
+      optionalSelected: optionalSelected == null ? undefined : (optionalSelected as boolean),
+    }
+  })
+}
+
+/** A line the query returned nothing for — the previous loop's all-absent case. */
+function emptyLineForTotals(): LineForTotals {
+  return { lineTotal: null, taxable: true, optional: undefined, optionalSelected: undefined }
 }
 
 /**

--- a/packages/lib/src/money/totals-line-read.test.ts
+++ b/packages/lib/src/money/totals-line-read.test.ts
@@ -1,0 +1,231 @@
+// packages/lib/src/money/totals-line-read.test.ts
+//
+// The line read and the no-op guard, both added by
+// `plans/events/08-derived-parent-reconciler-plan.md` phase 1.
+//
+// What these pin is COST, which no other test in this module can see: the engine used to
+// issue one `getFieldValues` per line, inside a `for await`, against an id list capped at
+// 1000 — and the hook that calls it fires once per changed FIELD, so a 20-line bulk paste
+// ran 40 recomputes each re-reading every line that existed so far. A regression here is
+// silent: every totals assertion in the suite passes just as well at 20 queries as at one.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  getFieldValues: vi.fn(),
+  listFiltered: vi.fn(),
+  setValuesForEntity: vi.fn(),
+  syncInvoicePaymentState: vi.fn(),
+  fieldValueRows: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    getFieldValues = h.getFieldValues
+    listFiltered = h.listFiltered
+  },
+}))
+vi.mock('../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    setValuesForEntity = h.setValuesForEntity
+  },
+}))
+vi.mock('./payments/ledger', () => ({ syncInvoicePaymentState: h.syncInvoicePaymentState }))
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../database/src/db/schema/index')
+  return {
+    schema,
+    database: { select: () => ({ from: () => ({ where: () => h.fieldValueRows() }) }) },
+  }
+})
+
+import { recomputeTotals } from './totals-hooks'
+
+const FIELDS: Record<string, { id: string; type: string }> = {
+  quote_discount_type: { id: 'f-q-dtype', type: 'SINGLE_SELECT' },
+  quote_discount_value: { id: 'f-q-dvalue', type: 'CURRENCY' },
+  quote_tax_rate: { id: 'f-q-rate', type: 'NUMBER' },
+  quote_subtotal: { id: 'f-q-subtotal', type: 'CURRENCY' },
+  quote_tax_total: { id: 'f-q-taxtotal', type: 'CURRENCY' },
+  quote_total: { id: 'f-q-total', type: 'CURRENCY' },
+  invoice_discount_type: { id: 'f-i-dtype', type: 'SINGLE_SELECT' },
+  invoice_discount_value: { id: 'f-i-dvalue', type: 'CURRENCY' },
+  invoice_tax_rate: { id: 'f-i-rate', type: 'NUMBER' },
+  invoice_subtotal: { id: 'f-i-subtotal', type: 'CURRENCY' },
+  invoice_tax_total: { id: 'f-i-taxtotal', type: 'CURRENCY' },
+  invoice_total: { id: 'f-i-total', type: 'CURRENCY' },
+  line_item_line_total: { id: 'f-li-total', type: 'CURRENCY' },
+  line_item_taxable: { id: 'f-li-taxable', type: 'BOOLEAN' },
+  line_item_optional: { id: 'f-li-optional', type: 'BOOLEAN' },
+  line_item_optional_selected: { id: 'f-li-optsel', type: 'BOOLEAN' },
+}
+
+function row(entityId: string, fieldId: string, value: number | boolean) {
+  return typeof value === 'boolean'
+    ? { entityId, fieldId, valueBoolean: value }
+    : { entityId, fieldId, valueNumber: value }
+}
+
+function written(fieldId: string): number | undefined {
+  const call = h.setValuesForEntity.mock.calls.at(-1)?.[0] as
+    | { values: Array<{ fieldId: string; value: number }> }
+    | undefined
+  return call?.values.find((v) => v.fieldId === fieldId)?.value
+}
+
+const quote = { organizationId: 'org_1', userId: 'usr_1', documentInstanceId: 'q-1' } as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.bySystemAttributes.mockImplementation(async (attrs: string[]) =>
+    Object.fromEntries(attrs.filter((a) => FIELDS[a]).map((a) => [a, FIELDS[a]]))
+  )
+  h.setValuesForEntity.mockResolvedValue(undefined)
+  h.syncInvoicePaymentState.mockResolvedValue(undefined)
+  h.listFiltered.mockResolvedValue({ ids: [] })
+  h.getFieldValues.mockResolvedValue(new Map())
+  h.fieldValueRows.mockResolvedValue([])
+})
+
+describe('the line read is set-based', () => {
+  it('issues ONE query for many lines, not one per line', async () => {
+    const ids = Array.from({ length: 25 }, (_, i) => `li-${i}`)
+    h.listFiltered.mockResolvedValue({ ids })
+    h.fieldValueRows.mockResolvedValue(ids.map((id) => row(id, 'f-li-total', 100)))
+
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+
+    expect(h.fieldValueRows).toHaveBeenCalledTimes(1)
+    expect(written('quote_subtotal')).toBe(2500)
+  })
+
+  it('chunks a document past 200 lines rather than sending one unbounded IN-list', async () => {
+    const ids = Array.from({ length: 201 }, (_, i) => `li-${i}`)
+    h.listFiltered.mockResolvedValue({ ids })
+    h.fieldValueRows.mockResolvedValue([])
+
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+
+    expect(h.fieldValueRows).toHaveBeenCalledTimes(2)
+  })
+
+  it('never queries at all when the document has no lines', async () => {
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+    expect(h.fieldValueRows).not.toHaveBeenCalled()
+    expect(written('quote_subtotal')).toBe(0)
+  })
+})
+
+describe('per-line value semantics are unchanged', () => {
+  it('counts a line with NO stored values as a zero contribution, not as absent', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['li-1', 'li-2'] })
+    // Only li-1 has a row. li-2 must still produce a line, exactly as the old
+    // per-line loop did — it pushed an entry per id regardless of what came back.
+    h.fieldValueRows.mockResolvedValue([row('li-1', 'f-li-total', 5000)])
+
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+
+    expect(written('quote_subtotal')).toBe(5000)
+  })
+
+  it('treats an absent `taxable` as taxable and a stored `false` as not', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['li-1', 'li-2'] })
+    h.getFieldValues.mockResolvedValue(
+      new Map<string, unknown>([['f-q-rate', { type: 'number', value: 10 }]])
+    )
+    h.fieldValueRows.mockResolvedValue([
+      row('li-1', 'f-li-total', 10000), // no taxable row -> taxable
+      row('li-2', 'f-li-total', 10000),
+      row('li-2', 'f-li-taxable', false), // stored false -> not taxable
+    ])
+
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+
+    expect(written('quote_subtotal')).toBe(20000)
+    expect(written('quote_tax_total')).toBe(1000) // 10% of li-1 only
+  })
+
+  it('drops an unselected optional line from the total', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['li-1', 'li-2'] })
+    h.fieldValueRows.mockResolvedValue([
+      row('li-1', 'f-li-total', 10000),
+      row('li-2', 'f-li-total', 9900),
+      row('li-2', 'f-li-optional', true),
+      row('li-2', 'f-li-optsel', false),
+    ])
+
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+
+    expect(written('quote_subtotal')).toBe(10000)
+  })
+})
+
+describe('the no-op guard', () => {
+  it('skips the write when every mirror already holds the computed value', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['li-1'] })
+    h.fieldValueRows.mockResolvedValue([row('li-1', 'f-li-total', 10000)])
+    h.getFieldValues.mockResolvedValue(
+      new Map<string, unknown>([
+        ['f-q-subtotal', { type: 'number', value: 10000 }],
+        ['f-q-taxtotal', { type: 'number', value: 0 }],
+        ['f-q-total', { type: 'number', value: 10000 }],
+      ])
+    )
+
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+
+  it('writes when ANY mirror differs, even by a cent', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['li-1'] })
+    h.fieldValueRows.mockResolvedValue([row('li-1', 'f-li-total', 10000)])
+    h.getFieldValues.mockResolvedValue(
+      new Map<string, unknown>([
+        ['f-q-subtotal', { type: 'number', value: 10000 }],
+        ['f-q-taxtotal', { type: 'number', value: 0 }],
+        ['f-q-total', { type: 'number', value: 9999 }],
+      ])
+    )
+
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes when a mirror is UNSET — null is not a match', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['li-1'] })
+    h.fieldValueRows.mockResolvedValue([row('li-1', 'f-li-total', 10000)])
+    h.getFieldValues.mockResolvedValue(new Map())
+
+    await recomputeTotals({ ...quote, documentType: 'quote' })
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+  })
+
+  it('still runs afterWrite on a no-op — a payment moves `balance` with totals unchanged', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['li-1'] })
+    h.fieldValueRows.mockResolvedValue([row('li-1', 'f-li-total', 10000)])
+    h.getFieldValues.mockResolvedValue(
+      new Map<string, unknown>([
+        ['f-i-subtotal', { type: 'number', value: 10000 }],
+        ['f-i-taxtotal', { type: 'number', value: 0 }],
+        ['f-i-total', { type: 'number', value: 10000 }],
+      ])
+    )
+
+    await recomputeTotals({
+      organizationId: 'org_1',
+      userId: 'usr_1',
+      documentType: 'invoice',
+      documentInstanceId: 'inv-1',
+    })
+
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+    expect(h.syncInvoicePaymentState).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Phase 1 of `plans/events/08-derived-parent-reconciler-plan.md`.

## The defect

`recomputeDocumentTotals` read its lines with one `getFieldValues` **per line**, inside a `for await` over an id list capped at 1000 — and the hook that calls it is an `EntityFieldChangeHandler`, so it fires once per changed **field**, not per record write.

```
recomputeOnLineChange                      x once per changed field
  |- recomputeLineTotal                    -> 1 read + 1 write
  |- resolveLineParentDocument             -> up to 3 serial getFieldValues
  '- recomputeDocumentTotals
       |- 1 header getFieldValues
       |- 1 listFiltered                   (limit 1000)
       |- N serial getFieldValues          <- ONE PER LINE
       '- 1 setValuesForEntity             <- unconditional; no compare
```

A 20-line document cost ~28 round trips per fire. A 20-line bulk paste (`line-builder.tsx:957` -> `createManyMutateAsync`) issued 40 recomputes, each re-reading every line that existed so far.

This is the same concept two other subsystems already implement correctly:

| subsystem | trigger | child read | no-op check |
| --- | --- | --- | --- |
| `money/totals-hooks.ts` (before) | per field-value change | N serial `getFieldValues` | none |
| `field-hooks/post/purchase-order-line-rollups.ts` | batched id list | one `SUM ... GROUP BY` | yes (`:288`) |
| `builds/auto-build-queries.ts` | batched id list | *"four queries regardless of batch size"* | n/a |

## What changed

**1. The line read is set-based.** One select per 200-id chunk (same bound as `record-rules/snapshot-fetcher.ts`), so the largest document that can exist costs 5 queries instead of 1000.

**2. The write is skipped when nothing moved.** The mirrors the engine owns are read in the *same* `getFieldValues` call as the billing inputs — same query, more ids, no extra round trip — and compared before writing. Several triggers move no total at all (`line_item_taxable` on a document with no tax rate; a rel write re-linking a line to the parent it already had; the second of two attributes set in one line write), and each of those previously re-entered the field-value layer, the realtime publisher and the sync manifest to store an identical number.

Conservative by construction: unless **every** value is already present and equal, the write happens. A mirror the org has not materialised has no field id, so nothing matches and the write proceeds as before.

🛑 **`afterWrite` still runs on a no-op.** `syncInvoicePaymentState` reads more than these three numbers — a payment recorded elsewhere moves `balance` and can flip `paid` <-> `partially_paid` with the totals unchanged — and `money.recomputeTotals` is the documented manual drift escape, so it has to stay a real refresh.

## Why raw drizzle and not `batchGetValues`

`FieldValueService.batchGetValues` is the natural fit and has a genuine fast path (all-direct refs collapse to a single query), but it validates `ResourceFieldId`s (`entity:key`) while the ids in hand here are CustomField ids — a key translation with no upside. Enforcement is unchanged either way: the handler this read used to go through is constructed without a `CapabilityView`, and the line ids were already scoped by the `listFiltered` above.

## Behaviour

Per-line value semantics are preserved exactly, including the two that are easy to lose in this refactor and are now pinned:

- a line with **no stored values at all** still contributes (as zero) — the old loop pushed an entry per id unconditionally;
- an **absent** `taxable` still reads as taxable, and a stored `false` still reads as not.

## Tests

`money/totals-line-read.test.ts` (new, 10 tests) pins the **cost**, which nothing else could see — every totals assertion in the suite passes just as well at 20 queries as at one: one query for 25 lines, two for 201, none for zero lines, plus the four value-semantics cases and the four no-op-guard cases.

`purchase-order-totals.test.ts` keeps its assertions; only its line fixtures move from `getFieldValues` stubs to `FieldValue` rows, since that half of the read changed shape.

- `pnpm exec vitest run` in `packages/lib` — **1020 files, 13,680 tests, 0 failures**
- `node scripts/ci/typecheck-ratchet.js --package lib` — no new type errors (29 total, baseline 29)
- `pnpm lint` clean on the three files

## Not in this PR

The remaining win is coalescing — 40 fires still become 40 drains, they are just ~9 round trips each instead of ~28. That is phase 2 of the plan, and it moves *when* the write happens, so it is deliberately separate from this one.