### PR TITLE
fix(purchasing): make the three-way match readable

### DIFF
--- a/apps/web/src/components/purchasing/purchasing-summary-strip.tsx
+++ b/apps/web/src/components/purchasing/purchasing-summary-strip.tsx
@@ -17,8 +17,13 @@ import { cn } from '@auxx/ui/lib/utils'
 export interface SummaryCell {
   label: string
   value: string
-  /** Muted renders the figure in the label's colour — for a zero that is not news. */
-  tone?: 'default' | 'muted'
+  /**
+   * `muted` renders the figure in the label's colour — for a zero that is not
+   * news. `warning` is for the one figure on a card that is the reason a human
+   * opened it (a non-zero match variance), so it does not read as flat as the
+   * two figures it was derived from.
+   */
+  tone?: 'default' | 'muted' | 'warning'
 }
 
 /**
@@ -45,7 +50,8 @@ export function PurchasingSummaryStrip({
           <span
             className={cn(
               'font-medium text-sm tabular-nums',
-              cell.tone === 'muted' && 'text-muted-foreground'
+              cell.tone === 'muted' && 'text-muted-foreground',
+              cell.tone === 'warning' && 'text-amber-600'
             )}>
             {cell.value}
           </span>

--- a/apps/web/src/components/purchasing/vendor-bill/vendor-bill-match-card.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/vendor-bill-match-card.tsx
@@ -14,11 +14,22 @@
 // A human reading one row can name the failure — paid for what never arrived, or
 // a price nobody agreed — which is the point of the three-way match.
 //
+// LAYOUT. The three legs are rendered as three PAIRS, not six columns. Six
+// right-aligned money columns do not fit the drawer's ~400px min width without
+// the headers colliding, and the pair is the unit of meaning anyway: `1 / 1` and
+// `— / 100.00` are read as comparisons, where `Billed | Received | Billed price |
+// Expected price` is read as a spreadsheet. Above them sits the same
+// `PurchasingSummaryStrip` the Payment card uses, so the two cards in this drawer
+// share one rhythm.
+//
 // What this card deliberately does NOT do is decide the outcome. Tolerances live
 // in `matchBill` (phase 5) and are settings, not code; the verdict this card
 // shows is the STORED `vendor_bill_status` / `matchVariance` / `matchNotes` the
 // hook wrote. Re-deriving pass/fail on the client with guessed tolerances would
-// produce a second, disagreeing answer on the same screen.
+// produce a second, disagreeing answer on the same screen. The amber cell
+// highlight is not that second answer — it marks two numbers that DIFFER, which
+// is an observation about the row and true regardless of where the tolerance
+// sits. The ruling is the badge and the reason list, and both come from the hook.
 //
 // The "Match" section title is rendered by the drawer's `TabCardSection` wrapper,
 // so this card must not draw one.
@@ -37,12 +48,14 @@ import {
 } from '@auxx/ui/components/table'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatCurrency } from '@auxx/utils/currency'
-import { ScanSearch } from 'lucide-react'
+import { History, ScanSearch, TriangleAlert } from 'lucide-react'
 import { useMemo } from 'react'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
+import { useSettings } from '~/hooks/use-settings'
+import { PurchasingSummaryStrip, unwrapValue } from '../purchasing-summary-strip'
 import { useVendorBillLines, type VendorBillLineValues } from './use-vendor-bill-lines'
 
 /** The bill-level verdict, written by the match hook. */
@@ -68,10 +81,9 @@ const STATUS_BADGE: Record<string, { label: string; variant: 'green' | 'amber' |
   void: { label: 'Void', variant: 'amber' },
 }
 
-/** SINGLE_SELECT reads come back as arrays; everything else as a scalar. */
-function firstValue(raw: unknown): string | undefined {
-  const value = Array.isArray(raw) ? raw[0] : raw
-  return typeof value === 'string' ? value : undefined
+function firstString(raw: unknown): string | undefined {
+  const value = unwrapValue(raw)
+  return typeof value === 'string' && value ? value : undefined
 }
 
 function toNumber(raw: unknown): number | null {
@@ -102,23 +114,38 @@ interface MatchRow {
   quantityReceived: number | null
   /** Integer minor units. Null for the same reason. */
   expectedUnitPrice: number | null
-  /**
-   * Billed amount less what the agreed price would have made it, integer minor
-   * units. Null when either side is missing — an unknown variance is not zero.
-   */
-  variance: number | null
+  /** What the vendor is asking for on this line, integer minor units. */
+  billedAmount: number
+  /** What the receipt justifies at the agreed price, integer minor units. */
+  expectedAmount: number
+  /** `billedAmount - expectedAmount`, integer minor units. */
+  variance: number
 }
 
 export function VendorBillMatchCard({ recordId }: DrawerTabProps) {
   const { rows, isLoading } = useVendorBillLines(recordId)
+  const { getSetting } = useSettings({})
 
   const { values: header } = useSystemValues(recordId, [...BILL_MATCH_ATTRIBUTES], {
     autoFetch: true,
   })
-  const currencyCode = (header.vendor_bill_currency as string | undefined) || 'USD'
-  const status = firstValue(header.vendor_bill_status) ?? 'draft'
+  const currencyCode =
+    firstString(header.vendor_bill_currency) ||
+    (getSetting('organization.currency') as string | null) ||
+    'USD'
+  const status = firstString(header.vendor_bill_status) ?? 'draft'
   const storedVariance = toNumber(header.vendor_bill_match_variance)
-  const matchNotes = (header.vendor_bill_match_notes as string | undefined) ?? ''
+
+  // `describeMatchReasons` joins with `; `, so splitting on it recovers the list
+  // the hook rolled up. One reason per row beats one wrapping paragraph wedged
+  // between the badge and the variance, which is what this used to be.
+  const reasons = useMemo(() => {
+    const notes = firstString(header.vendor_bill_match_notes) ?? ''
+    return notes
+      .split('; ')
+      .map((part) => part.trim())
+      .filter(Boolean)
+  }, [header.vendor_bill_match_notes])
 
   // The purchase order lines this bill points at. One batched read across
   // whatever definitions the ids belong to — the hook resolves each attribute
@@ -144,38 +171,60 @@ export function VendorBillMatchCard({ recordId }: DrawerTabProps) {
         const quantityReceived = toNumber(poLine?.purchase_order_line_quantity_received)
         const expectedUnitPrice = toNumber(poLine?.purchase_order_line_expected_unit_price)
 
-        // Billed less expected, at the quantity the vendor billed. Rounded once,
-        // on the product — `CURRENCY` is minor units in a double column, so an
-        // unrounded product leaks a fraction of a cent into the variance.
-        const variance =
-          values.lineTotal === null || expectedUnitPrice === null || values.quantityBilled === null
-            ? null
-            : values.lineTotal - Math.round(values.quantityBilled * expectedUnitPrice)
+        // Both sides mirror `matchVariance` EXACTLY, including its two choices
+        // that look like bugs and are not:
+        //
+        //  - a missing number counts as 0, because that is what the hook rules
+        //    on (`match-hook.ts` reads every leg with `?? 0`). Rendering `—` in
+        //    the cell but treating it as unknown in the arithmetic is how this
+        //    card used to show a dash on every row while the header said
+        //    -$200.00.
+        //  - expected is `quantityRECEIVED x expectedUnitPrice`, never
+        //    `quantityBilled x ...`. Using the billed quantity nets an
+        //    over-billed line out of its own variance, which is the exact
+        //    failure the match exists to catch (see `matchVariance`).
+        //
+        // Rounded on the product: `CURRENCY` is minor units in a double column,
+        // so an unrounded product leaks a fraction of a cent into the sum.
+        const billedAmount = Math.round((values.quantityBilled ?? 0) * (values.unitPrice ?? 0))
+        const expectedAmount = Math.round((quantityReceived ?? 0) * (expectedUnitPrice ?? 0))
 
-        return { lineRecordId, line: values, quantityReceived, expectedUnitPrice, variance }
+        return {
+          lineRecordId,
+          line: values,
+          quantityReceived,
+          expectedUnitPrice,
+          billedAmount,
+          expectedAmount,
+          variance: billedAmount - expectedAmount,
+        }
       }),
     [rows, poLineValues]
   )
 
-  /**
-   * The line variances, summed — shown only when the hook has not written a
-   * bill-level figure yet.
-   *
-   * TODO(phase-3-router): `vendor_bill_match_variance` and
-   * `vendor_bill_match_notes` are written by the match hook of §6.2, which does
-   * not exist yet. `matchBill` / `matchVariance` DO exist
-   * (`packages/lib/src/purchasing/match.ts`, re-exported from that module's
-   * `client.ts`), but `packages/lib/package.json` carries no `./purchasing/client`
-   * export subpath yet, so this card cannot reach them. Once that subpath is
-   * generated, replace this sum with `matchVariance(...)` and read the outcome
-   * from `matchBill(...)` rather than colouring cells by raw inequality — the
-   * tolerances are settings, and this arithmetic is a read of them, not a ruling.
-   */
-  const derivedVariance = useMemo(
-    () => matchRows.reduce((sum, row) => sum + (row.variance ?? 0), 0),
+  const totals = useMemo(
+    () =>
+      matchRows.reduce(
+        (sum, row) => ({
+          billed: sum.billed + row.billedAmount,
+          expected: sum.expected + row.expectedAmount,
+        }),
+        { billed: 0, expected: 0 }
+      ),
     [matchRows]
   )
-  const variance = storedVariance ?? derivedVariance
+
+  // The strip shows the LIVE figure — the one the rows directly below it add up
+  // to. A three-cell strip whose third cell is not the difference of the first
+  // two is the worst thing this card can do, and that is what showing the stored
+  // variance here produced: `-$30.00` above rows summing to `-$60.00`.
+  //
+  // The stored figure is not discarded. When it disagrees the verdict below was
+  // computed against line data that has since changed, and saying so is more
+  // useful than silently preferring either number — the badge and the reasons
+  // are that stale verdict, so a reader needs to know how far to trust them.
+  const variance = totals.billed - totals.expected
+  const staleVariance = storedVariance !== null && storedVariance !== variance
 
   const statusBadge = STATUS_BADGE[status]
 
@@ -199,33 +248,44 @@ export function VendorBillMatchCard({ recordId }: DrawerTabProps) {
   }
 
   return (
-    <div className='flex flex-col gap-3'>
-      <div className='flex items-center justify-between gap-2 pe-3'>
-        <div className='flex items-center gap-2'>
-          {statusBadge && (
-            <Badge variant={statusBadge.variant} size='sm'>
-              {statusBadge.label}
-            </Badge>
-          )}
-          {matchNotes && <span className='text-xs text-muted-foreground'>{matchNotes}</span>}
+    <div className='flex flex-col gap-3 pe-3'>
+      {statusBadge && (
+        <div>
+          <Badge variant={statusBadge.variant} size='sm'>
+            {statusBadge.label}
+          </Badge>
         </div>
-        <div className='text-sm'>
-          <span className='text-muted-foreground'>Variance </span>
-          <span className={cn('tabular-nums', variance !== 0 && 'font-medium text-amber-600')}>
-            {formatSignedMoney(variance, currencyCode)}
-          </span>
-        </div>
-      </div>
+      )}
 
-      <div className='max-h-[24rem] overflow-auto border-y'>
+      <PurchasingSummaryStrip
+        cells={[
+          { label: 'Billed', value: formatCurrency(totals.billed, { currencyCode }) },
+          { label: 'Expected', value: formatCurrency(totals.expected, { currencyCode }) },
+          {
+            label: 'Variance',
+            value: formatSignedMoney(variance, currencyCode),
+            tone: variance === 0 ? 'muted' : 'warning',
+          },
+        ]}
+      />
+
+      <div className='max-h-[24rem] overflow-auto border-t'>
         <Table>
           <TableHeader>
-            <TableRow>
+            <TableRow className='hover:bg-transparent'>
               <TableHead>Line</TableHead>
-              <TableHead className='text-right'>Billed</TableHead>
-              <TableHead className='text-right'>Received</TableHead>
-              <TableHead className='text-right'>Billed price</TableHead>
-              <TableHead className='text-right'>Expected price</TableHead>
+              <TableHead className='text-right'>
+                Qty
+                <span className='block font-normal text-[0.6875rem] text-muted-foreground'>
+                  billed / recv
+                </span>
+              </TableHead>
+              <TableHead className='text-right'>
+                Unit price
+                <span className='block font-normal text-[0.6875rem] text-muted-foreground'>
+                  billed / agreed
+                </span>
+              </TableHead>
               <TableHead className='text-right'>Variance</TableHead>
             </TableRow>
           </TableHeader>
@@ -238,13 +298,11 @@ export function VendorBillMatchCard({ recordId }: DrawerTabProps) {
                 row.line.quantityBilled !== null &&
                 row.line.quantityBilled !== row.quantityReceived
               const priceDiffers =
-                row.expectedUnitPrice !== null &&
-                row.line.unitPrice !== null &&
-                row.line.unitPrice !== row.expectedUnitPrice
+                row.expectedUnitPrice !== null && row.line.unitPrice !== row.expectedUnitPrice
 
               return (
-                <TableRow key={row.lineRecordId}>
-                  <TableCell className='max-w-[12rem]'>
+                <TableRow key={row.lineRecordId} className='border-0 hover:bg-transparent'>
+                  <TableCell className='max-w-[10rem] align-top'>
                     {row.line.partRecordId ? (
                       <RecordBadge recordId={row.line.partRecordId} size='sm' link />
                     ) : (
@@ -258,38 +316,20 @@ export function VendorBillMatchCard({ recordId }: DrawerTabProps) {
                       <div className='text-xs text-muted-foreground'>Not linked to a PO line</div>
                     )}
                   </TableCell>
+                  <ComparisonCell
+                    differs={quantityDiffers}
+                    billed={formatQuantity(row.line.quantityBilled)}
+                    expected={formatQuantity(row.quantityReceived)}
+                  />
+                  <ComparisonCell
+                    differs={priceDiffers}
+                    billed={formatMoney(row.line.unitPrice, currencyCode)}
+                    expected={formatMoney(row.expectedUnitPrice, currencyCode)}
+                  />
                   <TableCell
                     className={cn(
-                      'text-right tabular-nums',
-                      quantityDiffers && 'font-medium text-amber-600'
-                    )}>
-                    {formatQuantity(row.line.quantityBilled)}
-                  </TableCell>
-                  <TableCell
-                    className={cn(
-                      'text-right tabular-nums',
-                      quantityDiffers ? 'font-medium text-amber-600' : 'text-muted-foreground'
-                    )}>
-                    {formatQuantity(row.quantityReceived)}
-                  </TableCell>
-                  <TableCell
-                    className={cn(
-                      'text-right tabular-nums',
-                      priceDiffers && 'font-medium text-amber-600'
-                    )}>
-                    {formatMoney(row.line.unitPrice, currencyCode)}
-                  </TableCell>
-                  <TableCell
-                    className={cn(
-                      'text-right tabular-nums',
-                      priceDiffers ? 'font-medium text-amber-600' : 'text-muted-foreground'
-                    )}>
-                    {formatMoney(row.expectedUnitPrice, currencyCode)}
-                  </TableCell>
-                  <TableCell
-                    className={cn(
-                      'text-right tabular-nums',
-                      row.variance !== null && row.variance !== 0 && 'font-medium text-amber-600'
+                      'text-right align-top tabular-nums',
+                      row.variance === 0 ? 'text-muted-foreground' : 'font-medium text-amber-600'
                     )}>
                     {formatSignedMoney(row.variance, currencyCode)}
                   </TableCell>
@@ -299,6 +339,51 @@ export function VendorBillMatchCard({ recordId }: DrawerTabProps) {
           </TableBody>
         </Table>
       </div>
+
+      {(reasons.length > 0 || staleVariance) && (
+        <ul className='flex flex-col gap-1'>
+          {staleVariance && (
+            <li className='flex items-start gap-1.5 text-muted-foreground text-xs'>
+              <History className='mt-0.5 size-3 shrink-0' />
+              <span>
+                Last checked at {formatSignedMoney(storedVariance, currencyCode)}, before the lines
+                above changed. Editing a line re-runs the match.
+              </span>
+            </li>
+          )}
+          {reasons.map((reason) => (
+            <li key={reason} className='flex items-start gap-1.5 text-muted-foreground text-xs'>
+              <TriangleAlert className='mt-0.5 size-3 shrink-0 text-amber-600' />
+              <span>{reason}</span>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
+  )
+}
+
+/**
+ * One leg of the match as a pair — what the vendor billed over what the receipt
+ * or the purchase order says. Both halves go amber together: the failure is the
+ * disagreement, not either number on its own.
+ */
+function ComparisonCell({
+  billed,
+  expected,
+  differs,
+}: {
+  billed: string
+  expected: string
+  differs: boolean
+}) {
+  return (
+    <TableCell className='whitespace-nowrap text-right align-top tabular-nums'>
+      <span className={cn(differs && 'font-medium text-amber-600')}>{billed}</span>
+      <span className='px-1 text-muted-foreground'>/</span>
+      <span className={cn(differs ? 'font-medium text-amber-600' : 'text-muted-foreground')}>
+        {expected}
+      </span>
+    </TableCell>
   )
 }

--- a/packages/lib/src/purchasing/__tests__/match-hook.test.ts
+++ b/packages/lib/src/purchasing/__tests__/match-hook.test.ts
@@ -41,6 +41,7 @@ import {
 
 const FIELDS: Record<string, { id: string; type: string }> = {
   vendor_bill_status: { id: 'f-status', type: 'SINGLE_SELECT' },
+  vendor_bill_currency: { id: 'f-currency', type: 'STRING' },
   vendor_bill_match_variance: { id: 'f-variance', type: 'CURRENCY' },
   vendor_bill_match_notes: { id: 'f-notes', type: 'TEXT' },
   vendor_bill_line_quantity_billed: { id: 'f-bl-qty', type: 'NUMBER' },
@@ -134,6 +135,31 @@ describe('rematchBill', () => {
     // expected side, so over-billing cannot net itself out.
     expect(written('f-variance')).toBe(3000)
     expect(written('f-notes')).toContain('billed 10 but only 4 received')
+  })
+
+  it("renders the notes in the bill's own currency scale", async () => {
+    // The prose the queue reads is written once, here — so the exponent has to
+    // come off the bill rather than be assumed to be 2. 1000 yen is 1000.
+    recordValues['vendor_bill:bill-1'] = {
+      'f-status': { type: 'option', optionId: 'draft' },
+      'f-currency': { type: 'text', value: 'JPY' },
+    }
+    h.listFiltered.mockResolvedValue({ ids: ['bl-1'] })
+    line('bl-1', 'pol-1', 1, 0, 1, 1000)
+
+    await rematch()
+
+    expect(written('f-notes')).toContain('an agreed 1000 ')
+  })
+
+  it('falls back to a 2-decimal scale when the bill carries no currency', async () => {
+    billIsDraft()
+    h.listFiltered.mockResolvedValue({ ids: ['bl-1'] })
+    line('bl-1', 'pol-1', 1, 0, 1, 1000)
+
+    await rematch()
+
+    expect(written('f-notes')).toContain('an agreed 10.00 ')
   })
 
   it('never un-posts a settled bill', async () => {

--- a/packages/lib/src/purchasing/__tests__/match.test.ts
+++ b/packages/lib/src/purchasing/__tests__/match.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest'
 import { BadRequestError } from '../../errors'
 import {
   DEFAULT_MATCH_TOLERANCE,
+  describeMatchReason,
+  describeMatchReasons,
   matchBill,
   matchBillLine,
   matchVariance,
@@ -351,5 +353,100 @@ describe('matchBillLine - invalid input', () => {
     expect(result.outcome).toBe('exception')
     if (result.outcome !== 'exception') throw new Error('unreachable')
     expect(result.reasons[0]?.lineIndex).toBe(2)
+  })
+})
+
+describe('describeMatchReason', () => {
+  it('renders money in major units, not the stored minor ones', () => {
+    // The whole point: `10000` on the exception queue is a number nobody reads
+    // as $100.00.
+    const [reason] = matchBillLine(
+      line({ unitPriceBilled: 0, unitPriceExpected: 10_000 }),
+      DEFAULT_MATCH_TOLERANCE,
+      0
+    )
+
+    expect(describeMatchReason(reason!)).toBe(
+      'Line 1: unit price 0.00 billed against an agreed 100.00 (off by -100.00)'
+    )
+  })
+
+  it('names the price leg, so a price failure cannot read as a quantity one', () => {
+    const [price] = matchBillLine(
+      line({ unitPriceBilled: 12_000, unitPriceExpected: 10_000 }),
+      DEFAULT_MATCH_TOLERANCE,
+      0
+    )
+    const [quantity] = matchBillLine(
+      line({ quantityBilled: 3, quantityReceived: 2 }),
+      DEFAULT_MATCH_TOLERANCE,
+      0
+    )
+
+    expect(describeMatchReason(price!)).toContain('unit price')
+    expect(describeMatchReason(quantity!)).not.toContain('unit price')
+  })
+
+  it('scales by the currency exponent rather than assuming cents', () => {
+    const [reason] = matchBillLine(
+      line({ unitPriceBilled: 1000, unitPriceExpected: 2000 }),
+      DEFAULT_MATCH_TOLERANCE,
+      0
+    )
+
+    // JPY has no minor unit — 1000 yen is 1000, not 10.00.
+    expect(describeMatchReason(reason!, 'JPY')).toBe(
+      'Line 1: unit price 1000 billed against an agreed 2000 (off by -1000)'
+    )
+  })
+
+  it('carries no currency symbol — the string is stored, the symbol is not', () => {
+    const [reason] = matchBillLine(
+      line({ unitPriceBilled: 0, unitPriceExpected: 10_000 }),
+      DEFAULT_MATCH_TOLERANCE,
+      0
+    )
+
+    expect(describeMatchReason(reason!, 'EUR')).not.toMatch(/[$€¥£]/)
+  })
+
+  it('keeps the quantity wording the exception queue already reads', () => {
+    const [over] = matchBillLine(
+      line({ quantityBilled: 10, quantityReceived: 4 }),
+      DEFAULT_MATCH_TOLERANCE,
+      0
+    )
+
+    expect(describeMatchReason(over!)).toBe('Line 1: billed 10 but only 4 received')
+  })
+
+  it('numbers lines from 1, because the human is holding the paper invoice', () => {
+    const result = matchBill([line(), line({ quantityBilled: 3, quantityReceived: 2 })])
+
+    if (result.outcome !== 'exception') throw new Error('unreachable')
+    expect(describeMatchReason(result.reasons[0]!)).toContain('Line 2:')
+  })
+})
+
+describe('describeMatchReasons', () => {
+  it('joins with the `; ` the Match card splits on', () => {
+    const result = matchBill([line({ quantityBilled: 3, quantityReceived: 2, unitPriceBilled: 0 })])
+
+    if (result.outcome !== 'exception') throw new Error('unreachable')
+    const notes = describeMatchReasons(result.reasons)
+
+    expect(notes.split('; ')).toHaveLength(2)
+    expect(notes.split('; ')).toEqual(result.reasons.map((r) => describeMatchReason(r)))
+  })
+
+  it('is the empty string for a clean bill, never a sentence claiming success', () => {
+    expect(describeMatchReasons([])).toBe('')
+  })
+
+  it('passes the currency through to every reason', () => {
+    const result = matchBill([line({ unitPriceBilled: 0, unitPriceExpected: 10_000 })])
+
+    if (result.outcome !== 'exception') throw new Error('unreachable')
+    expect(describeMatchReasons(result.reasons, 'JPY')).toContain('an agreed 10000')
   })
 })

--- a/packages/lib/src/purchasing/match-hook.ts
+++ b/packages/lib/src/purchasing/match-hook.ts
@@ -76,6 +76,16 @@ function readNumber(
   return typed ? (extractValue(typed) as number) : null
 }
 
+function readString(
+  values: Map<string, TypedFieldValue | TypedFieldValue[]>,
+  fieldId: string | undefined
+): string | null {
+  if (!fieldId) return null
+  const typed = firstTyped(values.get(fieldId))
+  const value = typed ? extractValue(typed) : null
+  return typeof value === 'string' && value ? value : null
+}
+
 function readRelatedInstanceId(
   values: Map<string, TypedFieldValue | TypedFieldValue[]>,
   fieldId: string | undefined
@@ -88,6 +98,7 @@ function readRelatedInstanceId(
 
 const MATCH_ATTRS = [
   'vendor_bill_status',
+  'vendor_bill_currency',
   'vendor_bill_match_variance',
   'vendor_bill_match_notes',
   'vendor_bill_line_quantity_billed',
@@ -135,9 +146,18 @@ export async function rematchBill(params: {
     return
   }
 
-  const billValues = await handler.getFieldValues(billRecordId, [statusField.id])
+  // The bill's own currency, read for one reason: `describeMatchReasons` renders
+  // money in major units and needs the exponent (2 for USD, 0 for JPY). It is a
+  // field on the bill rather than the org default because that is what the
+  // amounts on this document are denominated in.
+  const currencyField = cf.vendor_bill_currency
+  const billValues = await handler.getFieldValues(
+    billRecordId,
+    [statusField.id, currencyField?.id].filter((id): id is string => !!id)
+  )
   const statusTyped = firstTyped(billValues.get(statusField.id))
   const currentStatus = statusTyped ? (extractValue(statusTyped) as string) : null
+  const currencyCode = readString(billValues, currencyField?.id) ?? 'USD'
   // A bill with no status yet is a freshly created draft.
   if (currentStatus !== null && !MATCHABLE_STATUSES.has(currentStatus)) return
 
@@ -225,7 +245,8 @@ export async function rematchBill(params: {
   const variance = matchVariance(matchLines)
 
   const noteParts: string[] = []
-  if (result.outcome === 'exception') noteParts.push(describeMatchReasons(result.reasons))
+  if (result.outcome === 'exception')
+    noteParts.push(describeMatchReasons(result.reasons, currencyCode))
   if (unmatchableLines > 0) {
     noteParts.push(
       `${unmatchableLines} line${unmatchableLines === 1 ? '' : 's'} not matched to a purchase order line`

--- a/packages/lib/src/purchasing/match.ts
+++ b/packages/lib/src/purchasing/match.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/purchasing/match.ts
 
+import { minorToMajorString } from '@auxx/utils/currency'
 import { BadRequestError } from '../errors'
 import { roundCents } from '../money/totals'
 import type { MatchLine, MatchReason, MatchResult, MatchTolerance } from './types'
@@ -187,19 +188,33 @@ export function matchBill(
  * 1-based here and 0-based in `MatchReason.lineIndex` — the queue is read by
  * someone holding the paper invoice, where the first line is line 1.
  *
- * Money is rendered in whole minor units rather than formatted, because this
- * string is stored on the record and a currency symbol baked in at write time
- * would be wrong the moment the org's currency changes.
+ * Money is rendered in MAJOR units and carries no currency symbol. The symbol is
+ * still deliberately absent — this string is stored on the record, and a symbol
+ * baked in at write time would be wrong the moment the bill's currency changes.
+ * The scale is not: `10000` on screen is a number nobody reads as $100.00, so
+ * the exponent comes from the bill's own `currencyCode` (2 for USD, 0 for JPY,
+ * 3 for KWD) via the same `minorToMajorString` every other read path uses. A
+ * bill's currency is a fact about that document and does not drift the way an
+ * org default does, so pinning the scale at write time is safe in a way that
+ * pinning the symbol is not.
+ *
+ * `price_variance` names the leg explicitly ("unit price"). It used to share the
+ * `billed X against Y` shape with `quantity_under_billed`, which made a price
+ * failure read as a quantity one on the very screen that exists to tell them
+ * apart.
  */
-export function describeMatchReason(reason: MatchReason): string {
+export function describeMatchReason(reason: MatchReason, currencyCode = 'USD'): string {
   const line = reason.lineIndex + 1
+  // `allowed` may be a fractional minor unit (2% of 12345), and `difference` is
+  // signed — round once here so the string never shows a fraction of a cent.
+  const money = (value: number) => minorToMajorString(Math.round(value), currencyCode)
   switch (reason.code) {
     case 'quantity_over_billed':
       return `Line ${line}: billed ${reason.quantityBilled} but only ${reason.quantityReceived} received`
     case 'quantity_under_billed':
       return `Line ${line}: billed ${reason.quantityBilled} against ${reason.quantityReceived} received`
     case 'price_variance':
-      return `Line ${line}: billed ${reason.unitPriceBilled} against an agreed ${reason.unitPriceExpected} (off by ${reason.difference})`
+      return `Line ${line}: unit price ${money(reason.unitPriceBilled)} billed against an agreed ${money(reason.unitPriceExpected)} (off by ${money(reason.difference)})`
   }
 }
 
@@ -207,7 +222,10 @@ export function describeMatchReason(reason: MatchReason): string {
  * Every reason on one line of prose, for `vendor_bill_match_notes`. Empty string
  * for a clean bill — the field is what the queue renders, and "no reasons" must
  * read as blank rather than as a sentence claiming success.
+ *
+ * `; ` is the separator the drawer's Match card splits on to render one reason
+ * per row, so it is a shape contract and not just punctuation.
  */
-export function describeMatchReasons(reasons: MatchReason[]): string {
-  return reasons.map(describeMatchReason).join('; ')
+export function describeMatchReasons(reasons: MatchReason[], currencyCode = 'USD'): string {
+  return reasons.map((reason) => describeMatchReason(reason, currencyCode)).join('; ')
 }


### PR DESCRIPTION
The vendor bill drawer's Match card put a badge, a wrapping raw-prose blob and the variance on one line, then six right-aligned columns under them in a ~400px drawer.


## Layout

- The verdict is a badge on its own line above the same `PurchasingSummaryStrip` the Payment card uses, so the two cards in this drawer share one rhythm.
- The three legs render as **pairs** (`1 / 2`, `— / $10.00`) rather than six columns. The pair is the unit of meaning, and `Billed | Received | Billed price | Expected price | Variance` collides at the drawer's min width.
- The stored notes render **one reason per row** instead of one paragraph wedged between the badge and the variance.

## Prose

`describeMatchReason` wrote money in minor units, so the exception queue read `an agreed 10000` for $100.00. It now renders major units via `minorToMajorString`, scaled by the bill's own `vendor_bill_currency` (2 for USD, 0 for JPY, 3 for KWD). The **symbol** stays out for the reason the original docblock gives — the string is stored, and a symbol baked in at write time goes stale the moment the currency changes. The scale is not in that category: a bill's currency is a fact about that document.

`price_variance` also names its leg now. It shared the `billed X against Y` shape with `quantity_under_billed`, so a price failure read as a quantity one on the very screen that exists to tell them apart.

## Two arithmetic fixes in the card

Both make it agree with the hook whose verdict it reports:

- **A missing number counts as 0**, because that is what `matchBill` rules on (`match-hook.ts` reads every leg with `?? 0`). The card treated it as unknown, which is why every row showed `—` for variance while the header showed `-$200.00`.
- **Expected is `quantityReceived × expectedUnitPrice`**, never `quantityBilled × …`. The card used the billed quantity — which nets an over-billed line out of its own variance, the exact failure the match exists to catch, and the reason the column could never sum to the bill-level figure. `matchVariance`'s docblock warns against this explicitly.

## Stale verdicts

The strip's variance is now the **live** figure, so the three cells add up. Showing the stored one produced `-$30.00` above rows summing to `-$60.00`.

The stored figure is not dropped: when it disagrees, the verdict below it was computed against line data that has since changed, and the card says so — *"Last checked at -$30.00, before the lines above changed. Editing a line re-runs the match."* — rather than silently preferring either number. `INV-D11-TEST` in dev is in exactly this state.

## Not in scope, but noted

`rematchBill` is exported with the comment *"so the router can re-run a match on demand"* and **nothing calls it**. Only the field-change hooks fire it, so a stale verdict clears itself only when someone happens to edit a line. A `purchasing.rematchBill` procedure plus a button on this card would close that.

## Tests

9 new — 7 in `match.test.ts` pinning the prose, the currency scale, the absent symbol and the `; ` separator the card splits on; 2 in `match-hook.test.ts` pinning the currency threading and the USD fallback. 152 pass in `src/purchasing`. No new typecheck errors in `@auxx/lib` or `@auxx/web`.

`SummaryCell` gains an additive `tone: 'warning'`.

