### PR TITLE
perf(money): rebuild a document once per write, not once per changed field

### DIFF
--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -37,6 +37,7 @@ import {
   recomputeOnPurchaseOrderLineChange,
   recomputeOnQuoteBillingChange,
 } from '../money/totals-hooks'
+import { registerMoneyTotalsReconcilers } from '../money/totals-reconciler'
 import { derivePhoneGeoOnChange, warmPhoneGeo } from '../phone-geo'
 import {
   rematchAfterBillLineDelete,
@@ -115,6 +116,11 @@ export function registerAllHooks(): void {
   // Both handlers swallow their own failures; the module's top-level imports stay light and
   // everything heavy is lazy-imported inside the wrappers.
   registerAutoBuildRules()
+
+  // The totals engine's six drains (plan 08 phase 2). The hooks registered below
+  // only MARK; without this nothing recomputes a document, so these two must stay
+  // in the same bootstrap.
+  registerMoneyTotalsReconcilers()
 
   // Field-change post-hook — fires `<prefix>:field:updated` after every field
   // write. Registered globally so contacts, tickets, companies, and custom

--- a/packages/lib/src/field-values/field-value-service.ts
+++ b/packages/lib/src/field-values/field-value-service.ts
@@ -6,6 +6,7 @@ import type { RecordId } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { getCachedResourceFields } from '../cache'
 import type { CapabilityView } from '../permissions/capabilities/capability-view'
+import { runWithDirtyParents } from '../reconcilers/dirty-parents'
 import type { WriteSession } from '../resources/crud/write-origin'
 import {
   type CachedField,
@@ -83,6 +84,21 @@ export class FieldValueService {
   /** Internal context shared across mutations and queries */
   readonly ctx: FieldValueContext
 
+  /**
+   * Every public write on this service runs inside a dirty-parent scope, so a
+   * hook it fires can mark its parent and the reconciler drains ONCE when the
+   * write is done (plan 08 §5, `reconcilers/dirty-parents.ts`).
+   *
+   * This service is the SECOND door and it has to be wrapped too: an EDIT goes
+   * through `fieldValue.set` -> `FieldValueService` and never touches
+   * `UnifiedCrudHandler`, which is the same asymmetry `register-hooks.ts`
+   * records for `stampPartOnCatalogItemChange`. Nesting joins, so a write that
+   * came through the handler still produces one drain, not two.
+   */
+  private inReconcileScope<T>(fn: () => Promise<T>): Promise<T> {
+    return runWithDirtyParents(this.organizationId, this.userId ?? '', fn)
+  }
+
   constructor(
     private readonly organizationId: string,
     private readonly userId?: string,
@@ -116,7 +132,7 @@ export class FieldValueService {
    * @returns Array of TypedFieldValue objects after the operation.
    */
   setValue(params: SetValueInput): Promise<TypedFieldValue[]> {
-    return mutations.setValue(this.ctx, params)
+    return this.inReconcileScope(() => mutations.setValue(this.ctx, params))
   }
 
   /**
@@ -129,7 +145,7 @@ export class FieldValueService {
    * @returns Array of TypedFieldValue objects after the operation.
    */
   setValueWithType(params: SetValueWithTypeInput): Promise<TypedFieldValue[]> {
-    return mutations.setValueWithType(this.ctx, params)
+    return this.inReconcileScope(() => mutations.setValueWithType(this.ctx, params))
   }
 
   /**
@@ -158,7 +174,7 @@ export class FieldValueService {
    * @param params - Delete value input
    */
   deleteValue(params: DeleteValueInput): Promise<void> {
-    return mutations.deleteValue(this.ctx, params)
+    return this.inReconcileScope(() => mutations.deleteValue(this.ctx, params))
   }
 
   /**
@@ -264,7 +280,7 @@ export class FieldValueService {
    * @returns SetValueResult with state, performedAt, and values array
    */
   setValueWithBuiltIn(params: SetValueWithBuiltInInput): Promise<SetValueResult> {
-    return mutations.setValueWithBuiltIn(this.ctx, params)
+    return this.inReconcileScope(() => mutations.setValueWithBuiltIn(this.ctx, params))
   }
 
   /**
@@ -275,7 +291,7 @@ export class FieldValueService {
    * @returns Array of SetValuesResult (one per field)
    */
   setValuesForEntity(params: SetValuesForEntityInput): Promise<SetValuesResult[]> {
-    return mutations.setValuesForEntity(this.ctx, params)
+    return this.inReconcileScope(() => mutations.setValuesForEntity(this.ctx, params))
   }
 
   /**
@@ -286,7 +302,7 @@ export class FieldValueService {
    * @returns Object with count of successfully updated entities
    */
   setBulkValues(params: SetBulkValuesInput): Promise<{ count: number }> {
-    return mutations.setBulkValues(this.ctx, params)
+    return this.inReconcileScope(() => mutations.setBulkValues(this.ctx, params))
   }
 
   /**

--- a/packages/lib/src/money/totals-coalescing.test.ts
+++ b/packages/lib/src/money/totals-coalescing.test.ts
@@ -1,0 +1,281 @@
+// packages/lib/src/money/totals-coalescing.test.ts
+//
+// Plan 08 phase 2, end to end through the real hooks.
+//
+// The post-write hook chain is dispatched per `(record, field)`, so before this
+// a 20-line paste recomputed the same quote 40 times. Nothing in the money suite
+// could see that: every totals assertion passes identically at 40 recomputes and
+// at one. `listFiltered` is the witness — `recomputeDocumentTotals` calls it
+// exactly once per document rebuild, so counting it counts rebuilds.
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityFieldChangeEvent } from '../field-hooks/types'
+import { runWithDirtyParents } from '../reconcilers/dirty-parents'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  getFieldValues: vi.fn(),
+  listFiltered: vi.fn(),
+  setValuesForEntity: vi.fn(),
+  syncInvoicePaymentState: vi.fn(),
+  /** `select()` with no projection — the LINE VALUE read in `totals-hooks`. */
+  fieldValueRows: vi.fn(),
+  /** `select({...})` — the RELATION read in `totals-reconciler`. */
+  relationRows: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    getFieldValues = h.getFieldValues
+    listFiltered = h.listFiltered
+  },
+}))
+vi.mock('../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    setValuesForEntity = h.setValuesForEntity
+  },
+}))
+vi.mock('./payments/ledger', () => ({ syncInvoicePaymentState: h.syncInvoicePaymentState }))
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../database/src/db/schema/index')
+  return {
+    schema,
+    database: {
+      // The two set-based reads are told apart by their projection: the line
+      // VALUE read takes no argument, the relation read names three columns.
+      select: (projection?: unknown) => ({
+        from: () => ({ where: () => (projection ? h.relationRows() : h.fieldValueRows()) }),
+      }),
+    },
+  }
+})
+
+import {
+  recomputeOnLineChange,
+  recomputeOnPurchaseOrderLineChange,
+  recomputeOnQuoteBillingChange,
+} from './totals-hooks'
+import { registerMoneyTotalsReconcilers } from './totals-reconciler'
+
+const FIELDS: Record<string, { id: string; type: string }> = {
+  quote_discount_type: { id: 'f-q-dtype', type: 'SINGLE_SELECT' },
+  quote_discount_value: { id: 'f-q-dvalue', type: 'CURRENCY' },
+  quote_tax_rate: { id: 'f-q-rate', type: 'NUMBER' },
+  quote_subtotal: { id: 'f-q-subtotal', type: 'CURRENCY' },
+  quote_tax_total: { id: 'f-q-taxtotal', type: 'CURRENCY' },
+  quote_total: { id: 'f-q-total', type: 'CURRENCY' },
+  line_item_line_total: { id: 'f-li-total', type: 'CURRENCY' },
+  line_item_taxable: { id: 'f-li-taxable', type: 'BOOLEAN' },
+  line_item_quote: { id: 'f-li-quote', type: 'RELATIONSHIP' },
+  line_item_invoice: { id: 'f-li-invoice', type: 'RELATIONSHIP' },
+  line_item_order: { id: 'f-li-order', type: 'RELATIONSHIP' },
+  line_item_work_order: { id: 'f-li-wo', type: 'RELATIONSHIP' },
+  purchase_order_discount_value: { id: 'f-po-discount', type: 'CURRENCY' },
+  purchase_order_shipping_total: { id: 'f-po-shipping', type: 'CURRENCY' },
+  purchase_order_tax_total: { id: 'f-po-tax', type: 'CURRENCY' },
+  purchase_order_subtotal: { id: 'f-po-subtotal', type: 'CURRENCY' },
+  purchase_order_total: { id: 'f-po-total', type: 'CURRENCY' },
+  purchase_order_line_line_total: { id: 'f-pol-total', type: 'CURRENCY' },
+  purchase_order_line_purchase_order: { id: 'f-pol-po', type: 'RELATIONSHIP' },
+}
+
+function lineEvent(lineInstanceId: string, systemAttribute: string): EntityFieldChangeEvent {
+  return {
+    recordId: `line_item:${lineInstanceId}`,
+    organizationId: 'org_1',
+    userId: 'usr_1',
+    field: { id: 'f', systemAttribute, type: 'CURRENCY' },
+  } as unknown as EntityFieldChangeEvent
+}
+
+/** How many times a whole document was rebuilt. */
+const rebuilds = () => h.listFiltered.mock.calls.length
+
+beforeAll(() => {
+  registerMoneyTotalsReconcilers()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.bySystemAttributes.mockImplementation(async (attrs: string[]) =>
+    Object.fromEntries(attrs.filter((a) => FIELDS[a]).map((a) => [a, FIELDS[a]]))
+  )
+  h.setValuesForEntity.mockResolvedValue(undefined)
+  h.syncInvoicePaymentState.mockResolvedValue(undefined)
+  h.listFiltered.mockResolvedValue({ ids: [] })
+  h.getFieldValues.mockResolvedValue(new Map())
+  h.fieldValueRows.mockResolvedValue([])
+  h.relationRows.mockResolvedValue([])
+})
+
+describe('a paste rebuilds the document once', () => {
+  it('collapses 40 line fires on one quote into ONE rebuild', async () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `li-${i}`)
+    h.relationRows.mockResolvedValue(
+      lines.map((id) => ({ entityId: id, fieldId: 'f-li-quote', relatedEntityId: 'q-1' }))
+    )
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      for (const id of lines) {
+        // The two attributes one line write sets — two dispatches, as in production.
+        await recomputeOnLineChange(lineEvent(id, 'line_item_qty'))
+        await recomputeOnLineChange(lineEvent(id, 'line_item_unit_price'))
+      }
+    })
+
+    expect(rebuilds()).toBe(1)
+  })
+
+  it('resolves every line parent in ONE relation query, not one ladder per line', async () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `li-${i}`)
+    h.relationRows.mockResolvedValue(
+      lines.map((id) => ({ entityId: id, fieldId: 'f-li-quote', relatedEntityId: 'q-1' }))
+    )
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      for (const id of lines) await recomputeOnLineChange(lineEvent(id, 'line_item_taxable'))
+    })
+
+    expect(h.relationRows).toHaveBeenCalledTimes(1)
+  })
+
+  it('still rebuilds each distinct document', async () => {
+    h.relationRows.mockResolvedValue([
+      { entityId: 'li-1', fieldId: 'f-li-quote', relatedEntityId: 'q-1' },
+      { entityId: 'li-2', fieldId: 'f-li-quote', relatedEntityId: 'q-2' },
+    ])
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await recomputeOnLineChange(lineEvent('li-1', 'line_item_taxable'))
+      await recomputeOnLineChange(lineEvent('li-2', 'line_item_taxable'))
+    })
+
+    expect(rebuilds()).toBe(2)
+  })
+
+  it('does not rebuild anything for an attribute outside the trigger set', async () => {
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await recomputeOnLineChange(lineEvent('li-1', 'line_item_description'))
+    })
+
+    expect(h.relationRows).not.toHaveBeenCalled()
+    expect(rebuilds()).toBe(0)
+  })
+})
+
+describe('the parent ladder is preserved when batched', () => {
+  it('prefers the quote over an invoice on the same line', async () => {
+    h.relationRows.mockResolvedValue([
+      { entityId: 'li-1', fieldId: 'f-li-invoice', relatedEntityId: 'inv-1' },
+      { entityId: 'li-1', fieldId: 'f-li-quote', relatedEntityId: 'q-1' },
+    ])
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await recomputeOnLineChange(lineEvent('li-1', 'line_item_taxable'))
+    })
+
+    expect(
+      (
+        h.listFiltered.mock.calls[0]![0] as {
+          filters: Array<{ conditions: Array<{ value: string }> }>
+        }
+      ).filters[0]!.conditions[0]!.value
+    ).toBe('quote:q-1')
+  })
+
+  it('refuses the invoice when the line carries a work order — a WO copy must not count twice', async () => {
+    h.relationRows.mockResolvedValue([
+      { entityId: 'li-1', fieldId: 'f-li-invoice', relatedEntityId: 'inv-1' },
+      { entityId: 'li-1', fieldId: 'f-li-wo', relatedEntityId: 'wo-1' },
+    ])
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await recomputeOnLineChange(lineEvent('li-1', 'line_item_taxable'))
+    })
+
+    expect(rebuilds()).toBe(0)
+  })
+
+  it('falls through to the order when there is no quote and no invoice', async () => {
+    h.relationRows.mockResolvedValue([
+      { entityId: 'li-1', fieldId: 'f-li-order', relatedEntityId: 'ord-1' },
+    ])
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await recomputeOnLineChange(lineEvent('li-1', 'line_item_taxable'))
+    })
+
+    expect(
+      (
+        h.listFiltered.mock.calls[0]![0] as {
+          filters: Array<{ conditions: Array<{ value: string }> }>
+        }
+      ).filters[0]!.conditions[0]!.value
+    ).toBe('order:ord-1')
+  })
+
+  it('rebuilds nothing for an orphaned line', async () => {
+    h.relationRows.mockResolvedValue([])
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await recomputeOnLineChange(lineEvent('li-1', 'line_item_taxable'))
+    })
+
+    expect(rebuilds()).toBe(0)
+  })
+
+  it('resolves a purchase order line through its single relation', async () => {
+    h.relationRows.mockResolvedValue([
+      { entityId: 'pol-1', fieldId: 'f-pol-po', relatedEntityId: 'po-1' },
+      { entityId: 'pol-2', fieldId: 'f-pol-po', relatedEntityId: 'po-1' },
+    ])
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      for (const id of ['pol-1', 'pol-2']) {
+        await recomputeOnPurchaseOrderLineChange({
+          recordId: `purchase_order_line:${id}`,
+          organizationId: 'org_1',
+          userId: 'usr_1',
+          field: {
+            id: 'f',
+            systemAttribute: 'purchase_order_line_quantity_ordered',
+            type: 'NUMBER',
+          },
+        } as unknown as EntityFieldChangeEvent)
+      }
+    })
+
+    expect(rebuilds()).toBe(1)
+    expect(
+      (h.listFiltered.mock.calls[0]![0] as { entityDefinitionId: string }).entityDefinitionId
+    ).toBe('purchase_order_line')
+  })
+})
+
+describe('the unscoped fallback', () => {
+  it('rebuilds inline when no write method opened a scope', async () => {
+    h.relationRows.mockResolvedValue([
+      { entityId: 'li-1', fieldId: 'f-li-quote', relatedEntityId: 'q-1' },
+    ])
+
+    // No `runWithDirtyParents` — this is the shape of a caller that reached the
+    // hook chain through an exported `field-value-mutations` function.
+    await recomputeOnLineChange(lineEvent('li-1', 'line_item_taxable'))
+
+    expect(rebuilds()).toBe(1)
+  })
+
+  it('rebuilds a header change inline too', async () => {
+    await recomputeOnQuoteBillingChange({
+      recordId: 'quote:q-1',
+      organizationId: 'org_1',
+      userId: 'usr_1',
+      field: { id: 'f', systemAttribute: 'quote_tax_rate', type: 'NUMBER' },
+    } as unknown as EntityFieldChangeEvent)
+
+    expect(rebuilds()).toBe(1)
+  })
+})

--- a/packages/lib/src/money/totals-hooks.ts
+++ b/packages/lib/src/money/totals-hooks.ts
@@ -15,6 +15,12 @@ import { FieldValueService } from '../field-values/field-value-service'
 import { UnifiedCrudHandler } from '../resources/crud'
 import { syncInvoicePaymentState } from './payments/ledger'
 import { computeDocumentTotals, computeLineTotal, roundCents } from './totals'
+import {
+  MONEY_TOTALS_LINE_ITEM,
+  MONEY_TOTALS_PURCHASE_ORDER_LINE,
+  markOrRecomputeDocument,
+  markOrRecomputeLine,
+} from './totals-reconciler'
 import type {
   DiscountType,
   DocumentBillingInputs,
@@ -720,19 +726,17 @@ export const recomputeOnLineChange: EntityFieldChangeHandler = async (event) => 
   const { organizationId, userId } = event
   const { entityInstanceId: lineInstanceId } = parseRecordId(event.recordId)
 
+  // Stays INLINE, and must: the parent recompute reads `line_item_line_total`,
+  // so the line's own total has to be written before the drain runs.
   if (LINE_TOTAL_TRIGGER_ATTRS.has(attr)) {
     await recomputeLineTotal({ organizationId, userId, lineInstanceId })
   }
 
-  const parent = await resolveLineParentDocument({ organizationId, userId, lineInstanceId })
-  if (parent) {
-    await recomputeTotals({
-      organizationId,
-      userId,
-      documentType: parent.documentType,
-      documentInstanceId: parent.documentInstanceId,
-    })
-  }
+  // The parent is resolved in the DRAIN, not here (plan 08 phase 2). Walking the
+  // quote -> invoice -> order ladder per fire cost up to three round trips, and
+  // the hook fires once per changed field; the batched resolver walks it for the
+  // whole paste in one query.
+  await markOrRecomputeLine(organizationId, userId, MONEY_TOTALS_LINE_ITEM, lineInstanceId)
 }
 
 /**
@@ -745,12 +749,7 @@ export const recomputeOnQuoteBillingChange: EntityFieldChangeHandler = async (ev
   if (!attr || !QUOTE_TRIGGER_ATTRS.has(attr)) return
 
   const { entityInstanceId: quoteInstanceId } = parseRecordId(event.recordId)
-  await recomputeTotals({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    documentType: 'quote',
-    documentInstanceId: quoteInstanceId,
-  })
+  await markOrRecomputeDocument(event.organizationId, event.userId, 'quote', quoteInstanceId)
 }
 
 /**
@@ -763,12 +762,7 @@ export const recomputeOnInvoiceBillingChange: EntityFieldChangeHandler = async (
   if (!attr || !INVOICE_TRIGGER_ATTRS.has(attr)) return
 
   const { entityInstanceId: invoiceInstanceId } = parseRecordId(event.recordId)
-  await recomputeTotals({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    documentType: 'invoice',
-    documentInstanceId: invoiceInstanceId,
-  })
+  await markOrRecomputeDocument(event.organizationId, event.userId, 'invoice', invoiceInstanceId)
 }
 
 /**
@@ -781,12 +775,7 @@ export const recomputeOnOrderBillingChange: EntityFieldChangeHandler = async (ev
   if (!attr || !ORDER_TRIGGER_ATTRS.has(attr)) return
 
   const { entityInstanceId: orderInstanceId } = parseRecordId(event.recordId)
-  await recomputeTotals({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    documentType: 'order',
-    documentInstanceId: orderInstanceId,
-  })
+  await markOrRecomputeDocument(event.organizationId, event.userId, 'order', orderInstanceId)
 }
 
 /**
@@ -818,40 +807,12 @@ export const recomputeOnPurchaseOrderLineChange: EntityFieldChangeHandler = asyn
     })
   }
 
-  const purchaseOrderInstanceId = await resolvePurchaseOrderForLine({
+  await markOrRecomputeLine(
     organizationId,
     userId,
-    lineInstanceId,
-  })
-  if (purchaseOrderInstanceId) {
-    await recomputeTotals({
-      organizationId,
-      userId,
-      documentType: 'purchase_order',
-      documentInstanceId: purchaseOrderInstanceId,
-    })
-  }
-}
-
-/** Resolve the purchase order a PO line belongs to. Null when the line is orphaned. */
-async function resolvePurchaseOrderForLine(params: {
-  organizationId: string
-  userId: string
-  lineInstanceId: string
-}): Promise<string | null> {
-  const { organizationId, userId, lineInstanceId } = params
-  const cf = await getOrgCache()
-    .from(organizationId, 'customFields')
-    .bySystemAttributes(['purchase_order_line_purchase_order'] as const)
-  const relField = cf.purchase_order_line_purchase_order
-  if (!relField) return null
-
-  const handler = new UnifiedCrudHandler(organizationId, userId)
-  const lineRecordId = toRecordId(PURCHASE_ORDER_LINE_TOTALS_SPEC.lineEntityType, lineInstanceId)
-  const values = await handler.getFieldValues(lineRecordId, [relField.id])
-  const typed = firstTyped(values.get(relField.id))
-  if (typed?.type !== 'relationship' || !typed.recordId) return null
-  return parseRecordId(typed.recordId).entityInstanceId
+    MONEY_TOTALS_PURCHASE_ORDER_LINE,
+    lineInstanceId
+  )
 }
 
 /**
@@ -864,10 +825,10 @@ export const recomputeOnPurchaseOrderBillingChange: EntityFieldChangeHandler = a
   if (!attr || !PURCHASE_ORDER_TRIGGER_ATTRS.has(attr)) return
 
   const { entityInstanceId: purchaseOrderInstanceId } = parseRecordId(event.recordId)
-  await recomputeTotals({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    documentType: 'purchase_order',
-    documentInstanceId: purchaseOrderInstanceId,
-  })
+  await markOrRecomputeDocument(
+    event.organizationId,
+    event.userId,
+    'purchase_order',
+    purchaseOrderInstanceId
+  )
 }

--- a/packages/lib/src/money/totals-reconciler.ts
+++ b/packages/lib/src/money/totals-reconciler.ts
@@ -1,0 +1,277 @@
+// packages/lib/src/money/totals-reconciler.ts
+
+/**
+ * The totals engine as a dirty-parent reconciler (plan 08 phase 2).
+ *
+ * Before this, `recomputeOnLineChange` recomputed the whole document inline, and
+ * the hook chain is dispatched per `(record, field)` — so pasting 20 lines fired
+ * it 40 times and rebuilt the same quote 40 times. Now each fire marks, and the
+ * drain rebuilds it once.
+ *
+ * Six keys, not one, because the drain needs to know what it was handed:
+ *
+ * | key | marked with | drain |
+ * | --- | --- | --- |
+ * | `money-totals:line_item` | a LINE instance id | batch-resolve parents, then recompute |
+ * | `money-totals:purchase_order_line` | a PO LINE instance id | same, single-parent ladder |
+ * | `money-totals:quote` / `:invoice` / `:order` / `:purchase_order` | a DOCUMENT instance id | recompute directly |
+ *
+ * A write that dirties both a line and its document recomputes twice. That is
+ * accepted rather than merged: it is rare (a header field and a line body in one
+ * operation), and #1953's compare-before-write makes the second pass write
+ * nothing.
+ */
+
+import { database, schema } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
+import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
+import type { TotalledDocumentType } from './totals-hooks'
+
+/** Key per marked entity. See the table above. */
+export const MONEY_TOTALS_LINE_ITEM = 'money-totals:line_item'
+export const MONEY_TOTALS_PURCHASE_ORDER_LINE = 'money-totals:purchase_order_line'
+export const moneyTotalsDocumentKey = (documentType: TotalledDocumentType): string =>
+  `money-totals:${documentType}`
+
+const DOCUMENT_TYPES: TotalledDocumentType[] = ['quote', 'invoice', 'order', 'purchase_order']
+
+/** A resolved parent, deduped by both halves. */
+interface ParentDocument {
+  documentType: TotalledDocumentType
+  documentInstanceId: string
+}
+
+let registered = false
+
+/**
+ * Register the six drains. Called from `registerAllHooks()`, idempotent under a
+ * repeated bootstrap the same way `registerAutoBuildRules()` is.
+ */
+export function registerMoneyTotalsReconcilers(): void {
+  if (registered) return
+  registered = true
+
+  registerReconciler(
+    MONEY_TOTALS_LINE_ITEM,
+    async ({ organizationId, userId, parentInstanceIds }) => {
+      const parents = await resolveLineParents(organizationId, parentInstanceIds)
+      await recomputeEach(organizationId, userId, parents)
+    }
+  )
+
+  registerReconciler(
+    MONEY_TOTALS_PURCHASE_ORDER_LINE,
+    async ({ organizationId, userId, parentInstanceIds }) => {
+      const parents = await resolvePurchaseOrderLineParents(organizationId, parentInstanceIds)
+      await recomputeEach(organizationId, userId, parents)
+    }
+  )
+
+  for (const documentType of DOCUMENT_TYPES) {
+    registerReconciler(
+      moneyTotalsDocumentKey(documentType),
+      async ({ organizationId, userId, parentInstanceIds }) => {
+        await recomputeEach(
+          organizationId,
+          userId,
+          parentInstanceIds.map((documentInstanceId) => ({ documentType, documentInstanceId }))
+        )
+      }
+    )
+  }
+}
+
+/**
+ * Recompute each distinct document once, isolating failures.
+ *
+ * One document failing must not lose the rest of the batch — the same rule the
+ * drain applies across keys, applied again within one key, because here a batch
+ * is several unrelated user documents rather than one unit of work.
+ */
+async function recomputeEach(
+  organizationId: string,
+  userId: string,
+  parents: ParentDocument[]
+): Promise<void> {
+  if (parents.length === 0) return
+  // Lazy, so this module carries no RUNTIME edge back to `totals-hooks` — which
+  // imports this one. The type import above is erased, so the cycle is
+  // type-only, and the same dodge `builds/auto-build-rule.ts` uses for its
+  // orchestrators keeps it that way.
+  const { recomputeTotals } = await import('./totals-hooks')
+
+  const seen = new Set<string>()
+  for (const parent of parents) {
+    const dedupeKey = `${parent.documentType}:${parent.documentInstanceId}`
+    if (seen.has(dedupeKey)) continue
+    seen.add(dedupeKey)
+    await recomputeTotals({
+      organizationId,
+      userId,
+      documentType: parent.documentType,
+      documentInstanceId: parent.documentInstanceId,
+    })
+  }
+}
+
+/**
+ * Resolve every line's parent document in ONE query, applying the same
+ * precedence ladder `resolveLineParentDocument` applies per line: quote first,
+ * then invoice but ONLY when the line carries no work order (§B.3/§G.1 — a WO
+ * source line stamped with `line_item_invoice` must never recompute the
+ * invoice), then order.
+ *
+ * Reading `relatedEntityId` directly is what makes the batch possible; the
+ * per-line version issued up to three `getFieldValues` calls to walk the same
+ * ladder, so 20 lines cost up to 60 round trips before this.
+ */
+async function resolveLineParents(
+  organizationId: string,
+  lineInstanceIds: string[]
+): Promise<ParentDocument[]> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([
+      'line_item_quote',
+      'line_item_invoice',
+      'line_item_order',
+      'line_item_work_order',
+    ] as const)
+
+  const byField = new Map<string, 'quote' | 'invoice' | 'order' | 'work_order'>()
+  if (cf.line_item_quote) byField.set(cf.line_item_quote.id, 'quote')
+  if (cf.line_item_invoice) byField.set(cf.line_item_invoice.id, 'invoice')
+  if (cf.line_item_order) byField.set(cf.line_item_order.id, 'order')
+  if (cf.line_item_work_order) byField.set(cf.line_item_work_order.id, 'work_order')
+  if (byField.size === 0) return []
+
+  const rels = await readRelations(organizationId, lineInstanceIds, [...byField.keys()])
+
+  const parents: ParentDocument[] = []
+  for (const lineInstanceId of lineInstanceIds) {
+    const row = rels.get(lineInstanceId)
+    if (!row) continue
+
+    const slot = (which: 'quote' | 'invoice' | 'order' | 'work_order'): string | undefined => {
+      for (const [fieldId, role] of byField) if (role === which) return row.get(fieldId)
+      return undefined
+    }
+
+    const quote = slot('quote')
+    if (quote) {
+      parents.push({ documentType: 'quote', documentInstanceId: quote })
+      continue
+    }
+    // Only when BOTH fields exist, matching the per-line ladder's own guard: an
+    // org without `line_item_work_order` cannot prove the line is not a WO copy.
+    const invoice = cf.line_item_invoice && cf.line_item_work_order ? slot('invoice') : undefined
+    if (invoice && !slot('work_order')) {
+      parents.push({ documentType: 'invoice', documentInstanceId: invoice })
+      continue
+    }
+    const order = slot('order')
+    if (order) parents.push({ documentType: 'order', documentInstanceId: order })
+  }
+  return parents
+}
+
+/** A `purchase_order_line` has exactly one possible parent — no ladder. */
+async function resolvePurchaseOrderLineParents(
+  organizationId: string,
+  lineInstanceIds: string[]
+): Promise<ParentDocument[]> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['purchase_order_line_purchase_order'] as const)
+  const relField = cf.purchase_order_line_purchase_order
+  if (!relField) return []
+
+  const rels = await readRelations(organizationId, lineInstanceIds, [relField.id])
+
+  const parents: ParentDocument[] = []
+  for (const lineInstanceId of lineInstanceIds) {
+    const purchaseOrder = rels.get(lineInstanceId)?.get(relField.id)
+    if (purchaseOrder) {
+      parents.push({ documentType: 'purchase_order', documentInstanceId: purchaseOrder })
+    }
+  }
+  return parents
+}
+
+/**
+ * `lineInstanceId -> fieldId -> relatedEntityId`, one query per 200-id chunk —
+ * the same bound `totals-hooks.ts`'s line read and `record-rules/snapshot-fetcher.ts`
+ * use.
+ */
+async function readRelations(
+  organizationId: string,
+  instanceIds: string[],
+  fieldIds: string[]
+): Promise<Map<string, Map<string, string>>> {
+  const out = new Map<string, Map<string, string>>()
+  if (instanceIds.length === 0 || fieldIds.length === 0) return out
+
+  const CHUNK = 200
+  for (let i = 0; i < instanceIds.length; i += CHUNK) {
+    const chunk = instanceIds.slice(i, i + CHUNK)
+    const rows = await database
+      .select({
+        entityId: schema.FieldValue.entityId,
+        fieldId: schema.FieldValue.fieldId,
+        relatedEntityId: schema.FieldValue.relatedEntityId,
+      })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          inArray(schema.FieldValue.entityId, chunk),
+          inArray(schema.FieldValue.fieldId, fieldIds)
+        )
+      )
+
+    for (const row of rows) {
+      if (!row.relatedEntityId) continue
+      let values = out.get(row.entityId)
+      if (!values) {
+        values = new Map()
+        out.set(row.entityId, values)
+      }
+      values.set(row.fieldId, row.relatedEntityId)
+    }
+  }
+  return out
+}
+
+/**
+ * Mark a document for recompute, or recompute it now when nothing will drain.
+ *
+ * The inline fallback is load-bearing — see {@link markParentDirty}: a caller
+ * that reached the hook chain through an exported `field-value-mutations`
+ * function rather than a public service method has no scope, and without this
+ * its totals would silently stop updating.
+ */
+export async function markOrRecomputeDocument(
+  organizationId: string,
+  userId: string,
+  documentType: TotalledDocumentType,
+  documentInstanceId: string
+): Promise<void> {
+  if (markParentDirty(moneyTotalsDocumentKey(documentType), documentInstanceId)) return
+  await recomputeEach(organizationId, userId, [{ documentType, documentInstanceId }])
+}
+
+/** {@link markOrRecomputeDocument}'s line-side twin. */
+export async function markOrRecomputeLine(
+  organizationId: string,
+  userId: string,
+  key: typeof MONEY_TOTALS_LINE_ITEM | typeof MONEY_TOTALS_PURCHASE_ORDER_LINE,
+  lineInstanceId: string
+): Promise<void> {
+  if (markParentDirty(key, lineInstanceId)) return
+  const parents =
+    key === MONEY_TOTALS_LINE_ITEM
+      ? await resolveLineParents(organizationId, [lineInstanceId])
+      : await resolvePurchaseOrderLineParents(organizationId, [lineInstanceId])
+  await recomputeEach(organizationId, userId, parents)
+}

--- a/packages/lib/src/reconcilers/__tests__/dirty-parents.test.ts
+++ b/packages/lib/src/reconcilers/__tests__/dirty-parents.test.ts
@@ -1,0 +1,284 @@
+// packages/lib/src/reconcilers/__tests__/dirty-parents.test.ts
+//
+// Plan 08 phase 2. What these pin is COALESCING and the two exits — behaviour no
+// consumer's own tests can see, because a consumer passes just as well when its
+// reconciler runs 40 times as when it runs once.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createTxWriteScope } from '../../resources/crud/tx-write-scope'
+import type { WriteSession } from '../../resources/crud/write-origin'
+import { runWithWriteSession } from '../../resources/crud/write-session-als'
+import {
+  __resetReconcilersForTest,
+  drainDeferredDirtyParents,
+  MAX_DIRTY_PARENTS_PER_KEY,
+  markParentDirty,
+  registerReconciler,
+  runWithDirtyParents,
+} from '../dirty-parents'
+
+const ORG = 'org_1'
+const USER = 'usr_1'
+
+/** Ids handed to the drain for `key`, per call. */
+function spyReconciler(key: string) {
+  const calls: string[][] = []
+  registerReconciler(key, async ({ parentInstanceIds }) => {
+    calls.push(parentInstanceIds)
+  })
+  return calls
+}
+
+beforeEach(() => {
+  __resetReconcilersForTest()
+})
+
+describe('coalescing', () => {
+  it('collapses many marks of one parent into a single drain', async () => {
+    const calls = spyReconciler('k')
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      // The shape of a 20-line paste: two trigger attributes per line, every one
+      // of them resolving to the same document.
+      for (let i = 0; i < 40; i++) markParentDirty('k', 'doc-1')
+    })
+
+    expect(calls).toEqual([['doc-1']])
+  })
+
+  it('keeps distinct parents, in first-marked order', async () => {
+    const calls = spyReconciler('k')
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      markParentDirty('k', 'b')
+      markParentDirty('k', 'a')
+      markParentDirty('k', 'b')
+    })
+
+    expect(calls).toEqual([['b', 'a']])
+  })
+
+  it('drains each key with its own batch', async () => {
+    const lines = spyReconciler('lines')
+    const docs = spyReconciler('docs')
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      markParentDirty('lines', 'li-1')
+      markParentDirty('docs', 'q-1')
+      markParentDirty('lines', 'li-2')
+    })
+
+    expect(lines).toEqual([['li-1', 'li-2']])
+    expect(docs).toEqual([['q-1']])
+  })
+
+  it('does not drain a key nothing marked', async () => {
+    const calls = spyReconciler('k')
+    await runWithDirtyParents(ORG, USER, async () => {})
+    expect(calls).toEqual([])
+  })
+})
+
+describe('nesting joins', () => {
+  it('produces ONE drain however deep the writes nest', async () => {
+    const calls = spyReconciler('k')
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      markParentDirty('k', 'doc-1')
+      // A hook that constructs its own handler mid-write.
+      await runWithDirtyParents(ORG, USER, async () => {
+        markParentDirty('k', 'doc-1')
+        await runWithDirtyParents(ORG, USER, async () => markParentDirty('k', 'doc-2'))
+      })
+    })
+
+    expect(calls).toEqual([['doc-1', 'doc-2']])
+  })
+
+  it('an inner scope does not drain on its own way out', async () => {
+    const seen: number[] = []
+    registerReconciler('k', async ({ parentInstanceIds }) => {
+      seen.push(parentInstanceIds.length)
+    })
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await runWithDirtyParents(ORG, USER, async () => markParentDirty('k', 'a'))
+      // If the inner scope had drained, this mark would land in a second batch.
+      markParentDirty('k', 'b')
+    })
+
+    expect(seen).toEqual([2])
+  })
+})
+
+describe('the unscoped fallback', () => {
+  it('reports false with no ambient scope, so the caller does the work inline', () => {
+    spyReconciler('k')
+    expect(markParentDirty('k', 'doc-1')).toBe(false)
+  })
+
+  it('reports true inside a scope', async () => {
+    spyReconciler('k')
+    await runWithDirtyParents(ORG, USER, async () => {
+      expect(markParentDirty('k', 'doc-1')).toBe(true)
+    })
+  })
+
+  it('reports true for an empty id rather than sending the caller off to recompute nothing', () => {
+    expect(markParentDirty('k', '')).toBe(true)
+  })
+})
+
+describe('failure isolation', () => {
+  it('does not drain at all when the write threw', async () => {
+    const calls = spyReconciler('k')
+
+    await expect(
+      runWithDirtyParents(ORG, USER, async () => {
+        markParentDirty('k', 'doc-1')
+        throw new Error('write failed')
+      })
+    ).rejects.toThrow('write failed')
+
+    expect(calls).toEqual([])
+  })
+
+  it('one reconciler throwing does not lose another reconciler batch', async () => {
+    registerReconciler('bad', async () => {
+      throw new Error('boom')
+    })
+    const good = spyReconciler('good')
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      markParentDirty('bad', 'x')
+      markParentDirty('good', 'y')
+    })
+
+    expect(good).toEqual([['y']])
+  })
+
+  it('never surfaces a reconciler failure to the writer', async () => {
+    registerReconciler('bad', async () => {
+      throw new Error('boom')
+    })
+
+    await expect(
+      runWithDirtyParents(ORG, USER, async () => {
+        markParentDirty('bad', 'x')
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('a key with no registered reconciler is logged, not thrown', async () => {
+    await expect(
+      runWithDirtyParents(ORG, USER, async () => {
+        markParentDirty('nobody', 'x')
+      })
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('one pass, ever', () => {
+  it('drops a mark made BY the drain, and reports it handled', async () => {
+    const calls: string[][] = []
+    registerReconciler('k', async ({ parentInstanceIds }) => {
+      calls.push(parentInstanceIds)
+      // A reconciler that writes; its write re-enters the hook chain.
+      expect(markParentDirty('k', 'doc-1')).toBe(true)
+    })
+
+    await runWithDirtyParents(ORG, USER, async () => markParentDirty('k', 'doc-1'))
+
+    expect(calls).toEqual([['doc-1']])
+  })
+})
+
+describe('the cap', () => {
+  it('buffers up to the cap and drops beyond it, still reporting handled', async () => {
+    const calls = spyReconciler('k')
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (let i = 0; i < MAX_DIRTY_PARENTS_PER_KEY + 5; i++) {
+        expect(markParentDirty('k', `doc-${i}`)).toBe(true)
+      }
+    })
+
+    expect(calls[0]).toHaveLength(MAX_DIRTY_PARENTS_PER_KEY)
+  })
+
+  it('still accepts a parent already buffered once the cap is reached', async () => {
+    const calls = spyReconciler('k')
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (let i = 0; i < MAX_DIRTY_PARENTS_PER_KEY; i++) markParentDirty('k', `doc-${i}`)
+      markParentDirty('k', 'doc-0')
+    })
+
+    expect(calls[0]).toHaveLength(MAX_DIRTY_PARENTS_PER_KEY)
+  })
+})
+
+describe('the transaction exit', () => {
+  function buffered(scope: ReturnType<typeof createTxWriteScope>): WriteSession {
+    return {
+      origin: { kind: 'interactive', userId: USER },
+      depth: 0,
+      mode: { kind: 'buffered', scope },
+    } as WriteSession
+  }
+
+  it('hands the batch to the TxWriteScope instead of draining mid-transaction', async () => {
+    const calls = spyReconciler('k')
+    const tx = createTxWriteScope(ORG, USER)
+
+    await runWithWriteSession(buffered(tx), () =>
+      runWithDirtyParents(ORG, USER, async () => {
+        markParentDirty('k', 'doc-1')
+        markParentDirty('k', 'doc-2')
+      })
+    )
+
+    // Nothing ran yet — the transaction has not committed.
+    expect(calls).toEqual([])
+    expect([...(tx.dirtyParents.get('k') ?? [])]).toEqual(['doc-1', 'doc-2'])
+  })
+
+  it('drains what the transaction carried, once it commits', async () => {
+    const calls = spyReconciler('k')
+    const tx = createTxWriteScope(ORG, USER)
+
+    await runWithWriteSession(buffered(tx), () =>
+      runWithDirtyParents(ORG, USER, async () => markParentDirty('k', 'doc-1'))
+    )
+    await drainDeferredDirtyParents({
+      organizationId: ORG,
+      userId: USER,
+      dirty: tx.dirtyParents,
+    })
+
+    expect(calls).toEqual([['doc-1']])
+  })
+
+  it('unions two write methods inside one transaction into a single batch', async () => {
+    const calls = spyReconciler('k')
+    const tx = createTxWriteScope(ORG, USER)
+
+    await runWithWriteSession(buffered(tx), async () => {
+      await runWithDirtyParents(ORG, USER, async () => markParentDirty('k', 'doc-1'))
+      await runWithDirtyParents(ORG, USER, async () => markParentDirty('k', 'doc-2'))
+    })
+    await drainDeferredDirtyParents({
+      organizationId: ORG,
+      userId: USER,
+      dirty: tx.dirtyParents,
+    })
+
+    expect(calls).toEqual([['doc-1', 'doc-2']])
+  })
+
+  it('the buffer it carries is still structured-cloneable — T-4 holds', () => {
+    const tx = createTxWriteScope(ORG, USER)
+    tx.dirtyParents.set('k', new Set(['doc-1']))
+    expect(() => structuredClone(tx)).not.toThrow()
+  })
+})

--- a/packages/lib/src/reconcilers/dirty-parents.ts
+++ b/packages/lib/src/reconcilers/dirty-parents.ts
@@ -1,0 +1,286 @@
+// packages/lib/src/reconcilers/dirty-parents.ts
+
+/**
+ * Phase 2 of `plans/events/08-derived-parent-reconciler-plan.md`: collect the
+ * parents a write dirtied, drain them ONCE after the write, instead of doing the
+ * parent-level work again on every field.
+ *
+ * The problem this exists for (§1): the post-write hook chain is dispatched per
+ * `(record, field)` — `field-value-mutations.ts:3032` on the single path, `:4086`
+ * on the bulk path — so a hook that recomputes a whole document runs once per
+ * changed ATTRIBUTE. Pasting 20 lines into a quote fires it 40 times, and each
+ * fire re-derives the same document. #1953 made one fire cheap; this makes 40
+ * fires into one.
+ *
+ * ## The contract
+ *
+ * A hook does exactly one thing: {@link markParentDirty}. It performs no reads
+ * and no writes of its own. The registered {@link ReconcilerDrain} then receives
+ * the whole batch, once, and is expected to read current database truth — never
+ * to reconstruct state from what the hooks saw.
+ *
+ * ## Why an ALS of its own, and not a field on `WriteSession`
+ *
+ * A `UnifiedCrudHandler` constructed once and used for two sequential writes
+ * carries ONE `WriteSession` object across both (`unified-handler.ts:198`), so a
+ * buffer hung off the session would leak the first write's parents into the
+ * second write's drain. The scope has to track the async activation, not the
+ * session object.
+ *
+ * ## Where it drains (plan 08 §8 Q1)
+ *
+ * Two exits, because the two write shapes conflict:
+ *
+ * - **Not in a transaction** — drain on the way out of the outermost write
+ *   method. This is the interactive path, which does not always open one.
+ * - **Inside `runInTxWrite`** — hand the buffer to the ambient `TxWriteScope` and
+ *   let `flushTxWriteScope` drain it after COMMIT. Draining in place would run a
+ *   reconciler against uncommitted state on a different connection, which is the
+ *   silent failure plan 04's T-4 exists to prevent.
+ *
+ * Nesting JOINS, exactly as `runInTxWrite` does it: an inner write that finds an
+ * ambient scope contributes to it and does not drain, so the outermost owner
+ * drains once for everyone.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { createScopedLogger } from '@auxx/logger'
+
+const logger = createScopedLogger('reconcilers:dirty-parents')
+
+/**
+ * Cap on distinct parents buffered per reconciler, per scope.
+ *
+ * Beyond it the scope is {@link DirtyParentScope.truncated} and further parents
+ * are DROPPED — which for a derived value means it stays stale until something
+ * recomputes it. That is tolerable only because every consumer has a second
+ * door: money's is `money.recomputeTotals` (the documented manual drift escape)
+ * plus `events/handlers/finalize-integrity-passes.ts`, which recomputes a
+ * synced/imported run's parents off the manifest. A consumer WITHOUT such a door
+ * must not rely on this buffer alone.
+ *
+ * One interactive write touches one document, so this is a guard against a
+ * runaway bulk operation, not a working limit.
+ */
+export const MAX_DIRTY_PARENTS_PER_KEY = 500
+
+/** Drains one reconciler's whole batch. Reads current truth; never throws. */
+export type ReconcilerDrain = (params: {
+  organizationId: string
+  userId: string
+  /** Distinct, in first-marked order. Never empty. */
+  parentInstanceIds: string[]
+}) => Promise<void>
+
+/** The buffer for ONE write scope. Plain values only — see {@link DirtyParentScope}. */
+export interface DirtyParentScope {
+  organizationId: string
+  userId: string
+  /** reconciler key -> parent entity-instance ids. Insertion-ordered. */
+  readonly dirty: Map<string, Set<string>>
+  /** One pass, ever. See {@link drainDirtyParents}. */
+  drained: boolean
+  /** Some parent was dropped at {@link MAX_DIRTY_PARENTS_PER_KEY}. */
+  truncated: boolean
+}
+
+const als = new AsyncLocalStorage<DirtyParentScope>()
+
+const reconcilers = new Map<string, ReconcilerDrain>()
+
+/**
+ * Register the drain for a reconciler key. Called from `registerAllHooks()`.
+ * Idempotent per key — a second registration of the same key is ignored, so a
+ * double bootstrap cannot install two drains that both write.
+ */
+export function registerReconciler(key: string, drain: ReconcilerDrain): void {
+  if (reconcilers.has(key)) return
+  reconcilers.set(key, drain)
+}
+
+/** Test seam. Never call from production code. */
+export function __resetReconcilersForTest(): void {
+  reconcilers.clear()
+}
+
+/**
+ * Note that `parentInstanceId` needs `key`'s reconciler to run.
+ *
+ * @returns `false` ONLY when there is no ambient scope — meaning nothing will
+ * drain this and **the caller must do the work inline**. That fallback is not
+ * defensive tidiness: `field-value-mutations`' functions are exported and called
+ * directly (`field-hooks/post/purchase-order-line-rollups.ts` calls
+ * `setValueWithType(ctx, …)`), so a write can fire hooks without ever passing a
+ * public service method. Without the fallback those writes would silently stop
+ * updating derived values — a regression with no error anywhere.
+ *
+ * `true` means "handled, do nothing", which covers both the buffered case and
+ * the two deliberate drops below.
+ *
+ * ⚠️ Takes an entity INSTANCE id, never a `RecordId`. RecordIds reach this layer
+ * in two keyspaces — `handler.create` builds them from the canonical
+ * `EntityDefinition.id`, money's own writers from the type slug — and the two
+ * never compare equal for the same record, so a Set of them would not dedupe.
+ * Same argument `tx-write-flush.ts`'s `instanceIdOf` records.
+ */
+export function markParentDirty(key: string, parentInstanceId: string): boolean {
+  if (!parentInstanceId) return true
+  const scope = als.getStore()
+  if (!scope) return false
+  if (scope.drained) {
+    // A write issued BY a drain. Dropping is deliberate: re-marking would make
+    // the pass re-entrant, and a reconciler that dirties its own parent is a
+    // loop, not a missed update. Reported as handled so the caller does NOT
+    // fall back to doing it inline, which is the same loop by another route.
+    logger.debug('markParentDirty after drain, ignored', { key, parentInstanceId })
+    return true
+  }
+
+  let ids = scope.dirty.get(key)
+  if (!ids) {
+    ids = new Set()
+    scope.dirty.set(key, ids)
+  }
+  if (ids.size >= MAX_DIRTY_PARENTS_PER_KEY && !ids.has(parentInstanceId)) {
+    if (!scope.truncated) {
+      scope.truncated = true
+      logger.error('dirty-parent buffer truncated; some derived values will stay stale', {
+        key,
+        cap: MAX_DIRTY_PARENTS_PER_KEY,
+        organizationId: scope.organizationId,
+      })
+    }
+    // Handled, not unscoped: falling back inline here would do the very work the
+    // cap exists to bound, one synchronous recompute at a time.
+    return true
+  }
+  ids.add(parentInstanceId)
+  return true
+}
+
+/**
+ * Run `fn` with a dirty-parent scope, draining on the way out when this call
+ * OWNS the scope.
+ *
+ * Joined calls (an ambient scope already exists) simply run `fn` — they
+ * contribute to the outer buffer and the outer owner drains for everyone. This
+ * is what makes it safe to wrap every public write method: a
+ * `UnifiedCrudHandler.create` whose hooks construct their own handler nests
+ * freely and still produces one drain.
+ */
+export async function runWithDirtyParents<T>(
+  organizationId: string,
+  userId: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  if (als.getStore()) return fn()
+
+  const scope: DirtyParentScope = {
+    organizationId,
+    userId,
+    dirty: new Map(),
+    drained: false,
+    truncated: false,
+  }
+
+  const result = await als.run(scope, fn)
+
+  // Resolving path only. A throw takes the scope with it: the write failed, so
+  // there is nothing to reconcile, and draining a rolled-back attempt is exactly
+  // the failure `runInTxWrite`'s per-attempt contract (T-5) exists to prevent.
+  const deferred = await handOffToTransaction(scope)
+  if (!deferred) await drainDirtyParents(scope)
+  return result
+}
+
+/**
+ * Give a buffered composition's parents to its `TxWriteScope` so
+ * `flushTxWriteScope` drains them after COMMIT. Returns whether it took them.
+ *
+ * Lazy-imported for the reason `tx-write-flush.ts` records about its own
+ * imports: the crud barrel's module evaluation order is load-bearing for the
+ * cycle that runs through `@auxx/lib/cache`, and this module is reached FROM
+ * that barrel.
+ */
+async function handOffToTransaction(scope: DirtyParentScope): Promise<boolean> {
+  if (scope.dirty.size === 0) return true // nothing to drain, either way
+  try {
+    const { getAmbientTxWriteScope } = await import('../resources/crud/tx-write-scope')
+    const tx = getAmbientTxWriteScope()
+    if (!tx) return false
+    for (const [key, ids] of scope.dirty) {
+      let target = tx.dirtyParents.get(key)
+      if (!target) {
+        target = new Set()
+        tx.dirtyParents.set(key, target)
+      }
+      for (const id of ids) target.add(id)
+    }
+    scope.dirty.clear()
+    return true
+  } catch (error) {
+    // Never let the handoff itself lose the work — drain in place instead.
+    logger.error('dirty-parent handoff to transaction failed; draining in place', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+
+/**
+ * Run every registered reconciler over what the scope collected, once.
+ *
+ * BEST-EFFORT, per key. The write has already happened and a caller has nothing
+ * useful to do with a reconciler failure, so a throw here must never surface as
+ * a command failure — and one reconciler failing must not lose another's batch.
+ * Same rule as `flushTxWriteScope` (plan 04 T-6).
+ */
+export async function drainDirtyParents(scope: DirtyParentScope): Promise<void> {
+  if (scope.drained) return
+  scope.drained = true
+  if (scope.dirty.size === 0) return
+
+  for (const [key, ids] of scope.dirty) {
+    if (ids.size === 0) continue
+    const drain = reconcilers.get(key)
+    if (!drain) {
+      logger.error('no reconciler registered for a dirtied key', { key, count: ids.size })
+      continue
+    }
+    try {
+      await drain({
+        organizationId: scope.organizationId,
+        userId: scope.userId,
+        parentInstanceIds: [...ids],
+      })
+    } catch (error) {
+      logger.error('reconciler drain failed', {
+        key,
+        count: ids.size,
+        organizationId: scope.organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  scope.dirty.clear()
+}
+
+/**
+ * Drain a set collected inside a transaction, after it committed. The
+ * `TxWriteScope` carries plain `Map<string, Set<string>>`, not a scope, so this
+ * rebuilds the shape {@link drainDirtyParents} takes.
+ */
+export async function drainDeferredDirtyParents(params: {
+  organizationId: string
+  userId: string
+  dirty: Map<string, Set<string>>
+}): Promise<void> {
+  if (params.dirty.size === 0) return
+  await drainDirtyParents({
+    organizationId: params.organizationId,
+    userId: params.userId,
+    dirty: params.dirty,
+    drained: false,
+    truncated: false,
+  })
+}

--- a/packages/lib/src/resources/crud/tx-write-flush.ts
+++ b/packages/lib/src/resources/crud/tx-write-flush.ts
@@ -71,6 +71,21 @@ export async function flushTxWriteScope(scope: TxWriteScope): Promise<void> {
   } catch (error) {
     logFailure('flush', scope.attemptId, error)
   }
+  // AFTER the doors, and inside its own guard: a reconciler reads current truth,
+  // so it must not run before the realtime/timeline replay that tells the rest of
+  // the system the transaction landed — and its failure must not swallow theirs.
+  try {
+    if (scope.dirtyParents.size > 0) {
+      const { drainDeferredDirtyParents } = await import('../../reconcilers/dirty-parents')
+      await drainDeferredDirtyParents({
+        organizationId: scope.organizationId,
+        userId: scope.actorUserId,
+        dirty: scope.dirtyParents,
+      })
+    }
+  } catch (error) {
+    logFailure('dirty-parents', scope.attemptId, error)
+  }
 }
 
 async function replayTxWriteScope(scope: TxWriteScope): Promise<void> {

--- a/packages/lib/src/resources/crud/tx-write-scope.ts
+++ b/packages/lib/src/resources/crud/tx-write-scope.ts
@@ -87,6 +87,15 @@ export interface TxWriteScope {
    */
   readonly realtime: Record<RecordId, FieldValueUpdateEntry[]>
   readonly archived: TxWriteArchive[]
+  /**
+   * Parents a reconciler owes work on, handed over by
+   * `reconcilers/dirty-parents.ts` so the drain lands AFTER commit rather than
+   * against uncommitted state on another connection (plan 08 §8 Q1).
+   *
+   * `Map<reconcilerKey, Set<entityInstanceId>>` — plain strings, so it clones,
+   * so {@link assertTxWriteScopePure} still holds.
+   */
+  readonly dirtyParents: Map<string, Set<string>>
   truncated: boolean
 }
 
@@ -105,6 +114,7 @@ export function createTxWriteScope(organizationId: string, actorUserId: string):
     changes: {},
     realtime: {},
     archived: [],
+    dirtyParents: new Map(),
     truncated: false,
   }
 }

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -27,6 +27,7 @@ import {
   resolveRecordVisibilityScope,
 } from '../../permissions/capabilities/record-visibility-scope'
 import { buildDefIdToSlug } from '../../permissions/capabilities/resolve-capability-inputs'
+import { runWithDirtyParents } from '../../reconcilers/dirty-parents'
 import { resolveResourceAccessGrantees } from '../../resource-access/grantee-resolution'
 import { getCommonHooks, getSystemHooks } from '../hooks'
 import {
@@ -247,7 +248,13 @@ export class UnifiedCrudHandler {
    * signature change. Read methods stay unwrapped.
    */
   private inWriteSession<T>(fn: () => Promise<T>): Promise<T> {
-    return runWithWriteSession(this.session, fn)
+    // The dirty-parent scope wraps the session, not the other way round: hooks
+    // fired inside the write mark their parents, and the drain runs once the
+    // write method is done (plan 08 §5). Nesting joins, so a hook that builds
+    // its own handler still produces ONE drain.
+    return runWithDirtyParents(this.organizationId, this.userId, () =>
+      runWithWriteSession(this.session, fn)
+    )
   }
 
   /**


### PR DESCRIPTION
Phase 2 of `plans/events/08-derived-parent-reconciler-plan.md`. Follows #1953.

## The defect

The post-write hook chain is dispatched per `(record, field)` — `field-value-mutations.ts:3032` on the single path, `:4086` on the bulk path. So `recomputeOnLineChange` ran once per changed **attribute** and rebuilt the whole document each time.

Pasting 20 lines into a quote is 40 dispatches, and fire *k* rebuilt the document from the *k* lines that existed so far. #1953 made one rebuild cheap (~28 → ~9 round trips). This makes 40 rebuilds into one.

## The reusable half

`reconcilers/dirty-parents.ts`. A hook calls `markParentDirty(key, parentInstanceId)` and does nothing else — no reads, no writes. The registered drain then gets the whole batch, once, and reads current database truth rather than reconstructing state from what the hooks saw.

**Two exits**, because the two write shapes conflict (plan 08 §8 Q1):

- **not in a transaction** — drain on the way out of the outermost write method. This is the interactive path, which does not always open one.
- **inside `runInTxWrite`** — hand the batch to the ambient `TxWriteScope` and let `flushTxWriteScope` drain it after **COMMIT**. Draining in place would run a reconciler against uncommitted state on a different connection, which is the silent failure plan 04's T-4 exists to prevent.

`TxWriteScope.dirtyParents` is `Map<string, Set<string>>` — plain strings, so `assertTxWriteScopePure`'s `structuredClone` still holds. There's a test for exactly that.

**Nesting joins** the way `runInTxWrite:162` does, which is what makes it safe to wrap every public write method. `UnifiedCrudHandler.inWriteSession` already funnels all 15 of its writes, so that's a one-line change; `FieldValueService` gets the same funnel for its six. It has to — an EDIT goes through `fieldValue.set` → `FieldValueService` and never touches the handler, the same asymmetry `register-hooks.ts` records for `stampPartOnCatalogItemChange`.

**It also has its own ALS**, not a field on `WriteSession`: a handler constructed once and used for two sequential writes carries one session object across both (`unified-handler.ts:198`), so a buffer hung off it would leak the first write's parents into the second write's drain.

## Two things the plan did not call for

**1. The unscoped fallback.** `markParentDirty` returns `false` when there is no ambient scope, and the caller recomputes inline. This is load-bearing, not defensive tidiness: `field-value-mutations`' functions are exported and called directly — `field-hooks/post/purchase-order-line-rollups.ts` calls `setValueWithType(ctx, …)` — so a write can fire the hook chain without ever passing a public service method. Without the fallback those writes would have silently stopped updating totals, with no error anywhere.

**2. Batched parent resolution.** Deferring only the recompute would still walk `resolveLineParentDocument`'s ladder per fire — quote miss → invoice+workOrder miss → order hit, up to three round trips, 40 times. The drain now resolves the whole batch in one query over `FieldValue.relatedEntityId`, preserving the ladder exactly, including the rule that an invoice is refused when the line carries a work order (§B.3/§G.1 — a WO source line must not recompute the invoice).

## Cost

For a 20-line paste:

| | before #1953 | after #1953 | this PR |
| --- | --- | --- | --- |
| document rebuilds | 40 | 40 | **1** |
| ladder queries | ~120 | ~120 | **1** |
| per-rebuild round trips | ~28 | ~9 | ~9 |

## Accepted behaviour

A write that dirties both a line **and** its document rebuilds twice — the line key and the document key drain separately. Rare (a header field and a line body in one operation), and #1953's compare-before-write makes the second pass write nothing. Merging them is phase 3, when the registry is extracted and both become one `ParentReconciler`.

The 500-parent cap drops beyond it and logs an error. That is tolerable only because money has a second door — `money.recomputeTotals` (the documented manual drift escape) and `events/handlers/finalize-integrity-passes.ts`, which recomputes a synced/imported run's parents off the manifest. A future consumer without such a door must not rely on this buffer alone; that's written on the constant.

## Tests

**`reconcilers/__tests__/dirty-parents.test.ts`** (20) — coalescing, first-marked ordering, per-key batches, nesting joins to one drain, no drain when the write threw, one reconciler's failure not losing another's batch, failures never surfacing to the writer, the one-pass rule (a mark made *by* a drain is dropped and reported handled), the cap, and both transaction exits including the `structuredClone` check.

**`money/totals-coalescing.test.ts`** (11) — through the real hooks. `listFiltered` is the witness: `recomputeDocumentTotals` calls it exactly once per rebuild, so counting it counts rebuilds. 40 fires → 1 rebuild; 20 lines → 1 relation query; distinct documents still each rebuild; the ladder's precedence and the work-order refusal survive batching; and both unscoped fallbacks recompute inline.

Neither could be seen by the existing suite — every totals assertion passes identically at 40 rebuilds and at one.

- `pnpm exec vitest run` in `packages/lib` — **1022 files, 13,711 tests, 0 failures**
- `node scripts/ci/typecheck-ratchet.js --package lib` — no new type errors (29 total, baseline 29)
- biome clean on all ten files

⚠️ One flake worth knowing about, unrelated to this change: `events/handlers/resolve-resource-trigger-match.test.ts` timed out at 10s on one full run. It took **8905ms** on the #1953 run before any of this and passes alone in 6.1s — it is sitting on the limit and will tip again. Worth its own timeout bump.