### PR TITLE
perf(purchasing): match a vendor bill once per write, in four queries not two per line

### DIFF
--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -44,6 +44,7 @@ import {
   rematchOnBillChange,
   rematchOnBillLineChange,
 } from '../purchasing/match-hook'
+import { registerMatchReconcilers } from '../purchasing/match-reconciler'
 import { handleRecordRulesOnFieldChange } from '../record-rules/hook-handler'
 import {
   enqueueQuickbooksInvoiceSyncOnSent,
@@ -121,6 +122,10 @@ export function registerAllHooks(): void {
   // only MARK; without this nothing recomputes a document, so these two must stay
   // in the same bootstrap.
   registerMoneyTotalsReconcilers()
+
+  // The three-way match's two drains. Same rule as above: the bill and bill-line
+  // hooks only MARK, so without this nothing re-matches.
+  registerMatchReconcilers()
 
   // Field-change post-hook — fires `<prefix>:field:updated` after every field
   // write. Registered globally so contacts, tickets, companies, and custom

--- a/packages/lib/src/field-values/__tests__/read-field-scalars.test.ts
+++ b/packages/lib/src/field-values/__tests__/read-field-scalars.test.ts
@@ -1,0 +1,134 @@
+// packages/lib/src/field-values/__tests__/read-field-scalars.test.ts
+//
+// The set-based read behind every parent-level recompute. Its three callers each
+// replaced an `await` in a loop, so what matters here is the query SHAPE — the
+// chunk bound, and the absent-vs-null distinction every caller branches on.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ rows: vi.fn(), where: vi.fn() }))
+
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../../database/src/db/schema/index')
+  return {
+    schema,
+    database: {
+      select: () => ({
+        from: () => ({
+          where: (predicate: unknown) => {
+            h.where(predicate)
+            return h.rows()
+          },
+        }),
+      }),
+    },
+  }
+})
+
+import { readFieldRelations, readFieldScalars } from '../read-field-scalars'
+
+const ORG = 'org_1'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.rows.mockResolvedValue([])
+})
+
+describe('readFieldScalars', () => {
+  it('reads many records in ONE query', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'a', fieldId: 'f1', valueNumber: 10 },
+      { entityId: 'b', fieldId: 'f1', valueNumber: 20 },
+    ])
+
+    const out = await readFieldScalars(undefined, ORG, ['a', 'b'], ['f1'])
+
+    expect(h.rows).toHaveBeenCalledTimes(1)
+    expect(out.get('a')?.get('f1')).toBe(10)
+    expect(out.get('b')?.get('f1')).toBe(20)
+  })
+
+  it('chunks past 200 ids rather than sending one unbounded IN-list', async () => {
+    const ids = Array.from({ length: 201 }, (_, i) => `r-${i}`)
+    await readFieldScalars(undefined, ORG, ids, ['f1'])
+    expect(h.rows).toHaveBeenCalledTimes(2)
+  })
+
+  it('dedupes ids so a repeated parent does not widen the query', async () => {
+    const ids = Array.from({ length: 400 }, (_, i) => `r-${i % 100}`)
+    await readFieldScalars(undefined, ORG, ids, ['f1'])
+    expect(h.rows).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves a record with no rows ABSENT, not present-and-empty', async () => {
+    h.rows.mockResolvedValue([{ entityId: 'a', fieldId: 'f1', valueNumber: 1 }])
+
+    const out = await readFieldScalars(undefined, ORG, ['a', 'b'], ['f1'])
+
+    expect(out.has('a')).toBe(true)
+    // Callers branch on this: an absent `taxable` defaults to taxable, a stored
+    // `false` does not, and collapsing the two flips a total.
+    expect(out.has('b')).toBe(false)
+  })
+
+  it('keeps a stored false, which is not the same as no row', async () => {
+    h.rows.mockResolvedValue([{ entityId: 'a', fieldId: 'f1', valueBoolean: false }])
+    const out = await readFieldScalars(undefined, ORG, ['a'], ['f1'])
+    expect(out.get('a')?.get('f1')).toBe(false)
+  })
+
+  it('keeps a stored zero', async () => {
+    h.rows.mockResolvedValue([{ entityId: 'a', fieldId: 'f1', valueNumber: 0 }])
+    const out = await readFieldScalars(undefined, ORG, ['a'], ['f1'])
+    expect(out.get('a')?.get('f1')).toBe(0)
+  })
+
+  it('issues no query at all for an empty id or field set', async () => {
+    expect((await readFieldScalars(undefined, ORG, [], ['f1'])).size).toBe(0)
+    expect((await readFieldScalars(undefined, ORG, ['a'], [])).size).toBe(0)
+    expect(h.rows).not.toHaveBeenCalled()
+  })
+})
+
+describe('readFieldRelations', () => {
+  it('returns the related instance id, keyed by record and field', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'li-1', fieldId: 'f-quote', relatedEntityId: 'q-1' },
+      { entityId: 'li-2', fieldId: 'f-quote', relatedEntityId: 'q-1' },
+    ])
+
+    const out = await readFieldRelations(undefined, ORG, ['li-1', 'li-2'], ['f-quote'])
+
+    expect(h.rows).toHaveBeenCalledTimes(1)
+    expect(out.get('li-1')?.get('f-quote')).toBe('q-1')
+    expect(out.get('li-2')?.get('f-quote')).toBe('q-1')
+  })
+
+  it('drops a row whose relation is empty rather than storing null', async () => {
+    h.rows.mockResolvedValue([{ entityId: 'li-1', fieldId: 'f-quote', relatedEntityId: null }])
+    const out = await readFieldRelations(undefined, ORG, ['li-1'], ['f-quote'])
+    expect(out.has('li-1')).toBe(false)
+  })
+
+  it('separates two relation fields on one record — the parent ladder depends on it', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'li-1', fieldId: 'f-invoice', relatedEntityId: 'inv-1' },
+      { entityId: 'li-1', fieldId: 'f-wo', relatedEntityId: 'wo-1' },
+    ])
+
+    const out = await readFieldRelations(undefined, ORG, ['li-1'], ['f-invoice', 'f-wo'])
+
+    expect(out.get('li-1')?.get('f-invoice')).toBe('inv-1')
+    expect(out.get('li-1')?.get('f-wo')).toBe('wo-1')
+  })
+
+  it('uses the given connection when one is passed', async () => {
+    const rows = vi.fn().mockResolvedValue([])
+    const tx = { select: () => ({ from: () => ({ where: rows }) }) }
+
+    await readFieldRelations(tx as never, ORG, ['li-1'], ['f-quote'])
+
+    expect(rows).toHaveBeenCalledTimes(1)
+    expect(h.rows).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/field-values/read-field-scalars.ts
+++ b/packages/lib/src/field-values/read-field-scalars.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/field-values/read-field-scalars.ts
+
+/**
+ * Read NAMED fields for MANY records, in one query per chunk.
+ *
+ * The read every parent-level recompute needs and nothing in this repo had: a
+ * caller with a set of instance ids and a handful of field ids wanted
+ * `getFieldValues` per record, which is an `await` in a loop
+ * (`plans/events/08-derived-parent-reconciler-plan.md` §1). Three call sites paid
+ * that before this existed — the money totals engine, its parent-relation
+ * resolver, and the three-way match, which paid it TWICE per line.
+ *
+ * ## Why not `FieldValueService.batchGetValues`
+ *
+ * It is the natural fit and does collapse to a single query when every reference
+ * is direct — but it validates `ResourceFieldId`s (`entity:key`), while a caller
+ * holding fields from the org cache has CustomField ids. Translating one to the
+ * other means going through the field key/id/systemAttribute triad for no gain.
+ *
+ * ## Why not `record-rules/snapshot-fetcher.ts`
+ *
+ * It fetches EVERY value on a record, deliberately — a rule's conditions can name
+ * anything. A recompute names three fields out of forty, so it would read an
+ * order of magnitude more than it uses. It also includes soft-archived rows on
+ * purpose (a `deleted` rule evaluates against last-known values), which is the
+ * opposite of what a recompute wants.
+ *
+ * ## Enforcement
+ *
+ * There is none here, deliberately. Every caller is a post-write recompute
+ * running as the system over ids it already scoped, and the `UnifiedCrudHandler`
+ * the loop used to go through was itself constructed without a `CapabilityView`.
+ * A caller that needs read enforcement wants `batchGetValues`, not this.
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import { database, schema } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+import { extractFieldValueScalar } from './field-value-scalar'
+
+/**
+ * Bounded IN-list. Same 200 as `record-rules/snapshot-fetcher.ts`, and the same
+ * reason: one predictable query shape rather than an id list that grows with the
+ * document.
+ */
+const CHUNK = 200
+
+/** `instanceId -> fieldId -> value`. A record with no stored rows is absent. */
+export type FieldScalars = Map<string, Map<string, unknown>>
+
+/**
+ * Scalar values of `fieldIds` for `instanceIds`.
+ *
+ * A field with no row is ABSENT from the inner map rather than present as null,
+ * because the two mean different things to every caller: an absent `taxable`
+ * defaults to taxable, a stored `false` does not.
+ */
+export async function readFieldScalars(
+  db: Database | Transaction | undefined,
+  organizationId: string,
+  instanceIds: readonly string[],
+  fieldIds: readonly string[]
+): Promise<FieldScalars> {
+  const out: FieldScalars = new Map()
+  if (instanceIds.length === 0 || fieldIds.length === 0) return out
+  const conn = db ?? database
+
+  // Whole rows, because `extractFieldValueScalar` dispatches across every value
+  // column and the caller does not know which one its field uses.
+  for (const chunk of chunks(instanceIds)) {
+    const rows = await conn
+      .select()
+      .from(schema.FieldValue)
+      .where(scope(organizationId, chunk, fieldIds))
+    for (const row of rows) {
+      put(out, row.entityId, row.fieldId, extractFieldValueScalar(row as Record<string, unknown>))
+    }
+  }
+  return out
+}
+
+/**
+ * Related instance ids of `fieldIds` for `instanceIds` — the relationship twin of
+ * {@link readFieldScalars}.
+ *
+ * Reading `relatedEntityId` off the row is what lets a parent-resolution ladder
+ * be walked for a whole batch at once; the per-record version issued one
+ * `getFieldValues` per rung.
+ */
+export async function readFieldRelations(
+  db: Database | Transaction | undefined,
+  organizationId: string,
+  instanceIds: readonly string[],
+  fieldIds: readonly string[]
+): Promise<Map<string, Map<string, string>>> {
+  const out = new Map<string, Map<string, string>>()
+  if (instanceIds.length === 0 || fieldIds.length === 0) return out
+  const conn = db ?? database
+
+  // Three columns, not the row: a relationship's whole payload is one id, and
+  // this is called with every line of a document at once.
+  for (const chunk of chunks(instanceIds)) {
+    const rows = await conn
+      .select({
+        entityId: schema.FieldValue.entityId,
+        fieldId: schema.FieldValue.fieldId,
+        relatedEntityId: schema.FieldValue.relatedEntityId,
+      })
+      .from(schema.FieldValue)
+      .where(scope(organizationId, chunk, fieldIds))
+    for (const row of rows) {
+      if (row.relatedEntityId) put(out, row.entityId, row.fieldId, row.relatedEntityId)
+    }
+  }
+  return out
+}
+
+/** Id chunks, deduped. One predictable query shape per chunk. */
+function chunks(instanceIds: readonly string[]): string[][] {
+  const ids = [...new Set(instanceIds)]
+  const out: string[][] = []
+  for (let i = 0; i < ids.length; i += CHUNK) out.push(ids.slice(i, i + CHUNK))
+  return out
+}
+
+/** Org + these records + these fields. The whole predicate, in one place. */
+function scope(organizationId: string, chunk: string[], fieldIds: readonly string[]) {
+  return and(
+    eq(schema.FieldValue.organizationId, organizationId),
+    inArray(schema.FieldValue.entityId, chunk),
+    inArray(schema.FieldValue.fieldId, [...fieldIds])
+  )
+}
+
+function put<T>(out: Map<string, Map<string, T>>, entityId: string, fieldId: string, value: T) {
+  let values = out.get(entityId)
+  if (!values) {
+    values = new Map()
+    out.set(entityId, values)
+  }
+  values.set(fieldId, value)
+}

--- a/packages/lib/src/money/totals-hooks.ts
+++ b/packages/lib/src/money/totals-hooks.ts
@@ -1,17 +1,15 @@
 // packages/lib/src/money/totals-hooks.ts
 
 import type { Database } from '@auxx/database'
-import { database, schema } from '@auxx/database'
 import type { TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
-import { and, eq, inArray } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import type { EntityFieldChangeHandler } from '../field-hooks/types'
-import { extractFieldValueScalar } from '../field-values/field-value-scalar'
 import { FieldValueService } from '../field-values/field-value-service'
+import { readFieldScalars } from '../field-values/read-field-scalars'
 import { UnifiedCrudHandler } from '../resources/crud'
 import { syncInvoicePaymentState } from './payments/ledger'
 import { computeDocumentTotals, computeLineTotal, roundCents } from './totals'
@@ -500,15 +498,9 @@ async function recomputeDocumentTotals(params: {
  * 20-line bulk paste therefore issued 40 recomputes, each re-reading every
  * line that existed so far. See `plans/events/08-derived-parent-reconciler-plan.md` §1.
  *
- * The read is deliberately raw + {@link extractFieldValueScalar} rather than
- * `FieldValueService.batchGetValues`, for the same two reasons
- * `purchase-order-line-rollups.ts` and `builds/auto-build-queries.ts` are
- * written this way: the field ids in hand are CustomField ids, where
- * `batchGetValues` validates `ResourceFieldId`s (`entity:key`) and would need a
- * key translation this has no reason to risk; and enforcement is unchanged
- * either way, because the handler this used to go through is constructed
- * without a `CapabilityView` and the line ids were already scoped by the
- * `listFiltered` above.
+ * The set-based read itself lives in {@link readFieldScalars} — why it is raw
+ * rather than `batchGetValues` or `fetchResourceSnapshots` is recorded there, and
+ * it now has three callers.
  *
  * One entry per id in `lineInstanceIds`, in that order, INCLUDING a line with no
  * stored values at all — the previous loop pushed an entry per id unconditionally
@@ -539,36 +531,7 @@ async function readLinesForTotals(
   ].filter((id): id is string => !!id)
   if (fieldIds.length === 0) return lineInstanceIds.map(() => emptyLineForTotals())
 
-  const conn = db ?? database
-  // `fieldId -> value` per line. A line absent from the map stored nothing.
-  const byLine = new Map<string, Map<string, unknown>>()
-
-  // Bounded IN-list, same 200 as `record-rules/snapshot-fetcher.ts`. A document
-  // is capped at 1000 lines by the `listFiltered` above, so this is <= 5 queries
-  // for the largest document that can exist, against 1000 before.
-  const CHUNK = 200
-  for (let i = 0; i < lineInstanceIds.length; i += CHUNK) {
-    const chunk = lineInstanceIds.slice(i, i + CHUNK)
-    const rows = await conn
-      .select()
-      .from(schema.FieldValue)
-      .where(
-        and(
-          eq(schema.FieldValue.organizationId, organizationId),
-          inArray(schema.FieldValue.entityId, chunk),
-          inArray(schema.FieldValue.fieldId, fieldIds)
-        )
-      )
-
-    for (const row of rows) {
-      let values = byLine.get(row.entityId)
-      if (!values) {
-        values = new Map()
-        byLine.set(row.entityId, values)
-      }
-      values.set(row.fieldId, extractFieldValueScalar(row as unknown as Record<string, unknown>))
-    }
-  }
+  const byLine = await readFieldScalars(db, organizationId, lineInstanceIds, fieldIds)
 
   return lineInstanceIds.map((lineInstanceId) => {
     const values = byLine.get(lineInstanceId)

--- a/packages/lib/src/money/totals-reconciler.ts
+++ b/packages/lib/src/money/totals-reconciler.ts
@@ -22,9 +22,8 @@
  * nothing.
  */
 
-import { database, schema } from '@auxx/database'
-import { and, eq, inArray } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
+import { readFieldRelations } from '../field-values/read-field-scalars'
 import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
 import type { TotalledDocumentType } from './totals-hooks'
 
@@ -146,7 +145,9 @@ async function resolveLineParents(
   if (cf.line_item_work_order) byField.set(cf.line_item_work_order.id, 'work_order')
   if (byField.size === 0) return []
 
-  const rels = await readRelations(organizationId, lineInstanceIds, [...byField.keys()])
+  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [
+    ...byField.keys(),
+  ])
 
   const parents: ParentDocument[] = []
   for (const lineInstanceId of lineInstanceIds) {
@@ -187,7 +188,7 @@ async function resolvePurchaseOrderLineParents(
   const relField = cf.purchase_order_line_purchase_order
   if (!relField) return []
 
-  const rels = await readRelations(organizationId, lineInstanceIds, [relField.id])
+  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [relField.id])
 
   const parents: ParentDocument[] = []
   for (const lineInstanceId of lineInstanceIds) {
@@ -197,50 +198,6 @@ async function resolvePurchaseOrderLineParents(
     }
   }
   return parents
-}
-
-/**
- * `lineInstanceId -> fieldId -> relatedEntityId`, one query per 200-id chunk —
- * the same bound `totals-hooks.ts`'s line read and `record-rules/snapshot-fetcher.ts`
- * use.
- */
-async function readRelations(
-  organizationId: string,
-  instanceIds: string[],
-  fieldIds: string[]
-): Promise<Map<string, Map<string, string>>> {
-  const out = new Map<string, Map<string, string>>()
-  if (instanceIds.length === 0 || fieldIds.length === 0) return out
-
-  const CHUNK = 200
-  for (let i = 0; i < instanceIds.length; i += CHUNK) {
-    const chunk = instanceIds.slice(i, i + CHUNK)
-    const rows = await database
-      .select({
-        entityId: schema.FieldValue.entityId,
-        fieldId: schema.FieldValue.fieldId,
-        relatedEntityId: schema.FieldValue.relatedEntityId,
-      })
-      .from(schema.FieldValue)
-      .where(
-        and(
-          eq(schema.FieldValue.organizationId, organizationId),
-          inArray(schema.FieldValue.entityId, chunk),
-          inArray(schema.FieldValue.fieldId, fieldIds)
-        )
-      )
-
-    for (const row of rows) {
-      if (!row.relatedEntityId) continue
-      let values = out.get(row.entityId)
-      if (!values) {
-        values = new Map()
-        out.set(row.entityId, values)
-      }
-      values.set(row.fieldId, row.relatedEntityId)
-    }
-  }
-  return out
 }
 
 /**

--- a/packages/lib/src/purchasing/__tests__/match-hook.test.ts
+++ b/packages/lib/src/purchasing/__tests__/match-hook.test.ts
@@ -6,7 +6,7 @@
 // and the exception queue rendered stored values that were never stored. These tests pin
 // the wiring rather than the math.
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EntityFieldChangeEvent, EntityPostDeleteEvent } from '../../field-hooks/types'
 
 const h = vi.hoisted(() => ({
@@ -30,7 +30,24 @@ vi.mock('../../field-values/field-value-service', () => ({
     setValuesForEntity = h.setValuesForEntity
   },
 }))
+/**
+ * The bill LINES and their PO lines are read set-based now, not with a
+ * `getFieldValues` per line — so that half of every fixture arrives as
+ * `FieldValue` rows. `recordValues` still feeds both: {@link rowsFromRecordValues}
+ * flattens it, and every consumer looks its record up by instance id, so handing
+ * each query the whole set is equivalent to filtering it.
+ */
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../../database/src/db/schema/index')
+  return {
+    schema,
+    database: {
+      select: () => ({ from: () => ({ where: () => rowsFromRecordValues() }) }),
+    },
+  }
+})
 
+import { runWithDirtyParents } from '../../reconcilers/dirty-parents'
 import {
   BILL_LINE_MATCH_TRIGGER_ATTRS,
   BILL_MATCH_TRIGGER_ATTRS,
@@ -38,6 +55,7 @@ import {
   rematchBill,
   rematchOnBillLineChange,
 } from '../match-hook'
+import { registerMatchReconcilers } from '../match-reconciler'
 
 const FIELDS: Record<string, { id: string; type: string }> = {
   vendor_bill_status: { id: 'f-status', type: 'SINGLE_SELECT' },
@@ -54,6 +72,25 @@ const FIELDS: Record<string, { id: string; type: string }> = {
 
 /** Field values keyed by recordId, assembled per test. */
 let recordValues: Record<string, Record<string, unknown>> = {}
+
+/** `recordValues` as `FieldValue` rows, for the set-based reads. */
+function rowsFromRecordValues() {
+  const rows: Array<Record<string, unknown>> = []
+  for (const [recordId, values] of Object.entries(recordValues)) {
+    const entityId = recordId.split(':')[1]
+    for (const [fieldId, typed] of Object.entries(values)) {
+      const v = typed as { type: string; value?: unknown; optionId?: string; recordId?: string }
+      const row: Record<string, unknown> = { entityId, fieldId }
+      if (v.type === 'number') row.valueNumber = v.value
+      else if (v.type === 'boolean') row.valueBoolean = v.value
+      else if (v.type === 'option') row.optionId = v.optionId
+      else if (v.type === 'relationship') row.relatedEntityId = v.recordId?.split(':')[1]
+      else row.valueText = v.value
+      rows.push(row)
+    }
+  }
+  return rows
+}
 
 function written(fieldId: string): unknown {
   const call = h.setValuesForEntity.mock.calls.at(-1)?.[0] as
@@ -229,14 +266,54 @@ describe('rematchBill', () => {
   it('reads the received quantity from the PO LINE, not from the bill line', async () => {
     billIsDraft()
     h.listFiltered.mockResolvedValue({ ids: ['bl-1'] })
-    line('bl-1', 'pol-1', 5, 100, 5, 100)
+    // Billed 5, received 2. Reading `received` off the BILL line would find the
+    // billed 5 there and call this matched.
+    line('bl-1', 'pol-1', 5, 100, 2, 100)
 
     await rematch()
 
-    expect(h.getFieldValues).toHaveBeenCalledWith(
-      'purchase_order_line:pol-1',
-      expect.arrayContaining(['f-pol-recv', 'f-pol-price'])
-    )
+    expect(written('f-status')).toBe('exception')
+    expect(written('f-variance')).toBe(300)
+  })
+
+  it('reads the expected unit price from the PO LINE, not from the bill line', async () => {
+    billIsDraft()
+    h.listFiltered.mockResolvedValue({ ids: ['bl-1'] })
+    // Billed at 1500, the PO expected 100 — past both arms of
+    // `DEFAULT_MATCH_TOLERANCE` (2% and 500 minor units). Reading `expected` off
+    // the bill line would compare 1500 against itself and call this matched.
+    line('bl-1', 'pol-1', 5, 1500, 5, 100)
+
+    await rematch()
+
+    expect(written('f-status')).toBe('exception')
+    expect(written('f-variance')).toBe(7000)
+  })
+
+  it('skips the write when the bill already carries this verdict', async () => {
+    recordValues['vendor_bill:bill-1'] = {
+      'f-status': { type: 'option', optionId: 'matched' },
+      'f-variance': { type: 'number', value: 0 },
+    }
+    h.listFiltered.mockResolvedValue({ ids: ['bl-1'] })
+    line('bl-1', 'pol-1', 10, 500, 10, 500)
+
+    await rematch()
+
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+
+  it('writes when the stored verdict differs by any one field', async () => {
+    recordValues['vendor_bill:bill-1'] = {
+      'f-status': { type: 'option', optionId: 'matched' },
+      'f-variance': { type: 'number', value: 1 },
+    }
+    h.listFiltered.mockResolvedValue({ ids: ['bl-1'] })
+    line('bl-1', 'pol-1', 10, 500, 10, 500)
+
+    await rematch()
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -314,5 +391,78 @@ describe('rematchAfterBillLineDelete', () => {
     } as unknown as EntityPostDeleteEvent)
 
     expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+})
+
+describe('coalescing (plan 08 phase 2)', () => {
+  beforeAll(() => {
+    registerMatchReconcilers()
+  })
+
+  /** A bill line that knows its parent, for the batched resolver. */
+  function lineOnBill(id: string, poLineId: string) {
+    line(id, poLineId, 10, 500, 10, 500)
+    Object.assign(recordValues[`vendor_bill_line:${id}`]!, {
+      'f-bl-bill': { type: 'relationship', recordId: 'vendor_bill:bill-1' },
+    })
+  }
+
+  const lineEvent = (id: string, systemAttribute: string) =>
+    ({
+      recordId: `vendor_bill_line:${id}`,
+      organizationId: 'org_1',
+      userId: 'usr_1',
+      field: { id: 'f', systemAttribute, type: 'NUMBER' },
+    }) as unknown as EntityFieldChangeEvent
+
+  /** One `listFiltered` per `rematchBill`, so this counts matches. */
+  const matches = () => h.listFiltered.mock.calls.length
+
+  it('collapses 30 line fires on one bill into ONE match', async () => {
+    billIsDraft()
+    const ids = Array.from({ length: 10 }, (_, i) => `bl-${i}`)
+    for (const [i, id] of ids.entries()) lineOnBill(id, `pol-${i}`)
+    h.listFiltered.mockResolvedValue({ ids })
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      for (const id of ids) {
+        // The three attributes one line write moves.
+        await rematchOnBillLineChange(lineEvent(id, 'vendor_bill_line_quantity_billed'))
+        await rematchOnBillLineChange(lineEvent(id, 'vendor_bill_line_unit_price'))
+        await rematchOnBillLineChange(lineEvent(id, 'vendor_bill_line_purchase_order_line'))
+      }
+    })
+
+    expect(matches()).toBe(1)
+  })
+
+  it('matches inline when no write method opened a scope', async () => {
+    billIsDraft()
+    lineOnBill('bl-1', 'pol-1')
+    h.listFiltered.mockResolvedValue({ ids: ['bl-1'] })
+
+    await rematchOnBillLineChange(lineEvent('bl-1', 'vendor_bill_line_quantity_billed'))
+
+    expect(matches()).toBe(1)
+  })
+
+  it('matches nothing for an orphaned line', async () => {
+    billIsDraft()
+    line('bl-1', 'pol-1', 10, 500, 10, 500) // no `f-bl-bill`
+    h.listFiltered.mockResolvedValue({ ids: ['bl-1'] })
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await rematchOnBillLineChange(lineEvent('bl-1', 'vendor_bill_line_quantity_billed'))
+    })
+
+    expect(matches()).toBe(0)
+  })
+
+  it('ignores an attribute outside the trigger set', async () => {
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await rematchOnBillLineChange(lineEvent('bl-1', 'vendor_bill_line_description'))
+    })
+
+    expect(matches()).toBe(0)
   })
 })

--- a/packages/lib/src/purchasing/match-hook.ts
+++ b/packages/lib/src/purchasing/match-hook.ts
@@ -9,8 +9,10 @@ import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { getOrgCache } from '../cache'
 import type { EntityFieldChangeHandler, EntityPostDeleteHandler } from '../field-hooks/types'
 import { FieldValueService } from '../field-values/field-value-service'
+import { readFieldRelations, readFieldScalars } from '../field-values/read-field-scalars'
 import { UnifiedCrudHandler } from '../resources/crud'
 import { DEFAULT_MATCH_TOLERANCE, describeMatchReasons, matchBill, matchVariance } from './match'
+import { markOrRematchBill, markOrRematchBillLine } from './match-reconciler'
 import type { MatchLine } from './types'
 
 const logger = createScopedLogger('purchasing:match-hook')
@@ -67,15 +69,6 @@ function firstTyped(
   return Array.isArray(entry) ? entry[0] : entry
 }
 
-function readNumber(
-  values: Map<string, TypedFieldValue | TypedFieldValue[]>,
-  fieldId: string | undefined
-): number | null {
-  if (!fieldId) return null
-  const typed = firstTyped(values.get(fieldId))
-  return typed ? (extractValue(typed) as number) : null
-}
-
 function readString(
   values: Map<string, TypedFieldValue | TypedFieldValue[]>,
   fieldId: string | undefined
@@ -86,14 +79,11 @@ function readString(
   return typeof value === 'string' && value ? value : null
 }
 
-function readRelatedInstanceId(
-  values: Map<string, TypedFieldValue | TypedFieldValue[]>,
-  fieldId: string | undefined
-): string | null {
-  if (!fieldId) return null
-  const typed = firstTyped(values.get(fieldId))
-  if (typed?.type !== 'relationship' || !typed.recordId) return null
-  return parseRecordId(typed.recordId).entityInstanceId
+/** A number out of {@link readFieldScalars}' scalar map. */
+function num(values: Map<string, unknown> | undefined, fieldId: string | undefined): number | null {
+  if (!values || !fieldId) return null
+  const value = values.get(fieldId)
+  return typeof value === 'number' ? value : null
 }
 
 const MATCH_ATTRS = [
@@ -191,36 +181,50 @@ export async function rematchBill(params: {
     cf.purchase_order_line_expected_unit_price?.id,
   ].filter((id): id is string => !!id)
 
+  /**
+   * Two set-based reads, not two per line.
+   *
+   * This loop used to issue a `getFieldValues` for the bill line AND another for
+   * its purchase-order line, serially, per line — so a 10-line bill cost 20 round
+   * trips per match, and the hook that calls it fires once per changed FIELD.
+   * Entering that bill was ~30 matches, ~690 round trips. The same defect #1953
+   * fixed in the totals engine, doubled.
+   */
+  const poLineRelId = cf.vendor_bill_line_purchase_order_line?.id
+  const [billLineValues, billLineRels] = await Promise.all([
+    readFieldScalars(db, organizationId, lineInstanceIds, billLineFieldIds),
+    poLineRelId
+      ? readFieldRelations(db, organizationId, lineInstanceIds, [poLineRelId])
+      : Promise.resolve(new Map<string, Map<string, string>>()),
+  ])
+
+  const poLineIds = lineInstanceIds
+    .map((id) => (poLineRelId ? billLineRels.get(id)?.get(poLineRelId) : undefined))
+    .filter((id): id is string => !!id)
+  const poLineValues = await readFieldScalars(db, organizationId, poLineIds, poLineFieldIds)
+
   const matchLines: MatchLine[] = []
   let unmatchableLines = 0
 
   for (const lineInstanceId of lineInstanceIds) {
-    const lineValues = await handler.getFieldValues(
-      toRecordId('vendor_bill_line', lineInstanceId),
-      billLineFieldIds
-    )
-    const purchaseOrderLineId = readRelatedInstanceId(
-      lineValues,
-      cf.vendor_bill_line_purchase_order_line?.id
-    )
+    const purchaseOrderLineId = poLineRelId
+      ? billLineRels.get(lineInstanceId)?.get(poLineRelId)
+      : undefined
     if (!purchaseOrderLineId) {
       unmatchableLines += 1
       continue
     }
 
-    const poLineValues = await handler.getFieldValues(
-      toRecordId('purchase_order_line', purchaseOrderLineId),
-      poLineFieldIds
-    )
+    const line = billLineValues.get(lineInstanceId)
+    const poLine = poLineValues.get(purchaseOrderLineId)
 
     matchLines.push({
-      quantityBilled: readNumber(lineValues, cf.vendor_bill_line_quantity_billed?.id) ?? 0,
+      quantityBilled: num(line, cf.vendor_bill_line_quantity_billed?.id) ?? 0,
       // Nothing received yet reads as 0, which over-bills every billed unit — correct:
       // that IS "paying for what never arrived".
-      quantityReceived: readNumber(poLineValues, cf.purchase_order_line_quantity_received?.id) ?? 0,
-      unitPriceBilled: readNumber(lineValues, cf.vendor_bill_line_unit_price?.id) ?? 0,
-      unitPriceExpected:
-        readNumber(poLineValues, cf.purchase_order_line_expected_unit_price?.id) ?? 0,
+      quantityReceived: num(poLine, cf.purchase_order_line_quantity_received?.id) ?? 0,
+      unitPriceBilled: num(line, cf.vendor_bill_line_unit_price?.id) ?? 0,
+      unitPriceExpected: num(poLine, cf.purchase_order_line_expected_unit_price?.id) ?? 0,
     })
   }
 
@@ -253,14 +257,32 @@ export async function rematchBill(params: {
     )
   }
 
-  await fieldValueService.setValuesForEntity({
-    recordId: billRecordId,
-    values: [
-      { fieldId: statusField.id, value: result.outcome === 'matched' ? 'matched' : 'exception' },
-      { fieldId: varianceField.id, value: variance },
-      { fieldId: notesField.id, value: noteParts.length > 0 ? noteParts.join('; ') : null },
-    ],
-  })
+  const verdict = [
+    { fieldId: statusField.id, value: result.outcome === 'matched' ? 'matched' : 'exception' },
+    { fieldId: varianceField.id, value: variance },
+    { fieldId: notesField.id, value: noteParts.length > 0 ? noteParts.join('; ') : null },
+  ]
+
+  /**
+   * Skip a write that would store the verdict already on the bill.
+   *
+   * Most re-matches reach the same answer — the second of two attributes set in
+   * one line write, a quantity edited back to what it was — and each one
+   * previously re-entered the field-value layer, the realtime publisher and the
+   * sync manifest to store an identical status. Conservative the same way
+   * `totals-hooks.ts` is: unless EVERY value is already present and equal, the
+   * write happens.
+   */
+  const stored = await readFieldScalars(
+    db,
+    organizationId,
+    [vendorBillInstanceId],
+    [statusField.id, varianceField.id, notesField.id]
+  )
+  const current = stored.get(vendorBillInstanceId)
+  if (verdict.every((v) => (current?.get(v.fieldId) ?? null) === v.value)) return
+
+  await fieldValueService.setValuesForEntity({ recordId: billRecordId, values: verdict })
 
   logger.info('Vendor bill matched', {
     vendorBillInstanceId,
@@ -277,11 +299,7 @@ export const rematchOnBillChange: EntityFieldChangeHandler = async (event) => {
   if (!attr || !BILL_MATCH_TRIGGER_ATTRS.has(attr)) return
 
   const { entityInstanceId } = parseRecordId(event.recordId)
-  await rematchBill({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    vendorBillInstanceId: entityInstanceId,
-  })
+  await markOrRematchBill(event.organizationId, event.userId, entityInstanceId)
 }
 
 /** Re-run the parent bill's match when one of its lines changes (§6.2). */
@@ -289,19 +307,11 @@ export const rematchOnBillLineChange: EntityFieldChangeHandler = async (event) =
   const attr = event.field.systemAttribute as SystemAttribute | undefined
   if (!attr || !BILL_LINE_MATCH_TRIGGER_ATTRS.has(attr)) return
 
+  // The bill is resolved in the DRAIN, not here: the per-line lookup cost a round
+  // trip on every one of the four trigger attributes, and the batched resolver
+  // does the whole bill in one query.
   const { entityInstanceId: lineInstanceId } = parseRecordId(event.recordId)
-  const vendorBillInstanceId = await resolveBillForLine(
-    event.organizationId,
-    event.userId,
-    lineInstanceId
-  )
-  if (!vendorBillInstanceId) return
-
-  await rematchBill({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    vendorBillInstanceId,
-  })
+  await markOrRematchBillLine(event.organizationId, event.userId, lineInstanceId)
 }
 
 /**
@@ -316,28 +326,5 @@ export const rematchAfterBillLineDelete: EntityPostDeleteHandler = async (event)
     ? parseRecordId(raw as RecordId).entityInstanceId
     : raw
 
-  await rematchBill({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    vendorBillInstanceId,
-  })
-}
-
-/** Resolve the bill a line belongs to. Null when the line is orphaned. */
-async function resolveBillForLine(
-  organizationId: string,
-  userId: string,
-  lineInstanceId: string
-): Promise<string | null> {
-  const cf = await getOrgCache()
-    .from(organizationId, 'customFields')
-    .bySystemAttributes(['vendor_bill_line_vendor_bill'] as const)
-  const relField = cf.vendor_bill_line_vendor_bill
-  if (!relField) return null
-
-  const handler = new UnifiedCrudHandler(organizationId, userId)
-  const values = await handler.getFieldValues(toRecordId('vendor_bill_line', lineInstanceId), [
-    relField.id,
-  ])
-  return readRelatedInstanceId(values, relField.id)
+  await markOrRematchBill(event.organizationId, event.userId, vendorBillInstanceId)
 }

--- a/packages/lib/src/purchasing/match-reconciler.ts
+++ b/packages/lib/src/purchasing/match-reconciler.ts
@@ -1,0 +1,115 @@
+// packages/lib/src/purchasing/match-reconciler.ts
+
+/**
+ * The three-way match as a dirty-parent reconciler
+ * (`plans/events/08-derived-parent-reconciler-plan.md`, the money engine's twin).
+ *
+ * `rematchOnBillLineChange` fires on four attributes, once per changed field, and
+ * each fire re-matched the whole bill. Entering a 10-line bill was ~30 matches.
+ * Now each fire marks and the drain matches once.
+ *
+ * Two keys, for the same reason the money reconciler has six: the drain has to
+ * know whether it was handed a bill or one of its lines.
+ */
+
+import { getOrgCache } from '../cache'
+import { readFieldRelations } from '../field-values/read-field-scalars'
+import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
+
+export const MATCH_VENDOR_BILL = 'three-way-match:vendor_bill'
+export const MATCH_VENDOR_BILL_LINE = 'three-way-match:vendor_bill_line'
+
+let registered = false
+
+/** Register both drains. Called from `registerAllHooks()`, idempotent. */
+export function registerMatchReconcilers(): void {
+  if (registered) return
+  registered = true
+
+  registerReconciler(MATCH_VENDOR_BILL, async ({ organizationId, userId, parentInstanceIds }) => {
+    await rematchEach(organizationId, userId, parentInstanceIds)
+  })
+
+  registerReconciler(
+    MATCH_VENDOR_BILL_LINE,
+    async ({ organizationId, userId, parentInstanceIds }) => {
+      const bills = await resolveBillsForLines(organizationId, parentInstanceIds)
+      await rematchEach(organizationId, userId, bills)
+    }
+  )
+}
+
+/**
+ * Match each distinct bill once, isolating failures.
+ *
+ * One bill failing must not lose the rest: a drain batch is several unrelated
+ * documents, not one unit of work. `rematchBill` is lazy-imported so this module
+ * carries no runtime edge back to `match-hook`, which imports it.
+ */
+async function rematchEach(
+  organizationId: string,
+  userId: string,
+  vendorBillInstanceIds: string[]
+): Promise<void> {
+  if (vendorBillInstanceIds.length === 0) return
+  const { rematchBill } = await import('./match-hook')
+
+  for (const vendorBillInstanceId of new Set(vendorBillInstanceIds)) {
+    await rematchBill({ organizationId, userId, vendorBillInstanceId })
+  }
+}
+
+/**
+ * The bill each line hangs off, in ONE query.
+ *
+ * The per-line version was a `getFieldValues` per line, called once per changed
+ * attribute — four round trips for one line whose quantity, price and PO link all
+ * moved in the same write.
+ */
+async function resolveBillsForLines(
+  organizationId: string,
+  lineInstanceIds: string[]
+): Promise<string[]> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['vendor_bill_line_vendor_bill'] as const)
+  const relField = cf.vendor_bill_line_vendor_bill
+  if (!relField) return []
+
+  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [relField.id])
+
+  const bills: string[] = []
+  for (const lineInstanceId of lineInstanceIds) {
+    const bill = rels.get(lineInstanceId)?.get(relField.id)
+    if (bill) bills.push(bill)
+  }
+  return bills
+}
+
+/**
+ * Mark a bill for rematch, or rematch it now when nothing will drain.
+ *
+ * The inline fallback is load-bearing — see `markParentDirty`: a caller that
+ * reached the hook chain through an exported `field-value-mutations` function
+ * rather than a public service method has no scope, and without this the bill
+ * would silently stop leaving the exception queue.
+ */
+export async function markOrRematchBill(
+  organizationId: string,
+  userId: string,
+  vendorBillInstanceId: string
+): Promise<void> {
+  if (markParentDirty(MATCH_VENDOR_BILL, vendorBillInstanceId)) return
+  await rematchEach(organizationId, userId, [vendorBillInstanceId])
+}
+
+/** {@link markOrRematchBill}'s line-side twin. */
+export async function markOrRematchBillLine(
+  organizationId: string,
+  userId: string,
+  lineInstanceId: string
+): Promise<void> {
+  if (markParentDirty(MATCH_VENDOR_BILL_LINE, lineInstanceId)) return
+  const bills = await resolveBillsForLines(organizationId, [lineInstanceId])
+  await rematchEach(organizationId, userId, bills)
+}


### PR DESCRIPTION
The third instance of the pattern #1953 and #1955 fixed — and the worst of them. Follows those two; phase 2 of `plans/events/08-derived-parent-reconciler-plan.md` applied to its second consumer.

## The defect

`rematchBill` read **each bill line and its purchase-order line** with a serial `getFieldValues`:

```
rematchOnBillLineChange                    x once per changed field (4 trigger attrs)
  |- resolveBillForLine                    -> 1 getFieldValues
  '- rematchBill
       |- 1 bill getFieldValues
       |- 1 listFiltered                   (limit 1000)
       |- per line: 2 SERIAL getFieldValues  <- bill line, then its PO line
       '- 1 setValuesForEntity             <- unconditional; no compare
```

A 10-line bill is ~22 round trips per match. Entering that bill — 10 lines, three moved attributes each — is ~30 matches, **roughly 690 round trips**, ending in an unconditional write of a verdict that is usually the one already stored.

This is the money defect with a 2× multiplier on the N+1. It was never visible in tests: every match assertion passes identically at 30 matches and at one.

## What changed

**1. Two set-based reads, not two per line.** Bill-line values and bill-line→PO-line relations in parallel, then one read for the PO lines those resolved to.

**2. Compare before write.** The verdict — status, variance, notes — is read back in one query and the write is skipped when all three already match. Conservative the same way `totals-hooks.ts` is: unless *every* value is present and equal, the write happens.

**3. Coalesced.** The bill, bill-line and post-delete hooks now `markParentDirty` and one drain matches. Line→bill resolution moves into the drain, where it is one query for the batch instead of a lookup per fire.

Entering a 10-line bill: **~690 round trips → ~5.**

## The extraction

`field-values/read-field-scalars.ts`. Three call sites now need "read these fields for these records in one query" — money's line values, money's parent-relation ladder, and both halves of the match — so the raw read #1953 inlined moves out, with `readFieldRelations` as its relationship twin selecting three columns rather than the whole row.

Why raw, recorded on the module: `FieldValueService.batchGetValues` is the natural fit and does collapse to a single query for all-direct refs, but it validates `ResourceFieldId`s (`entity:key`) while callers hold CustomField ids from the org cache — a trip through the field key/id/systemAttribute triad for no gain. `record-rules/snapshot-fetcher.ts` reads *every* field on a record (a rule's conditions can name anything) and deliberately includes soft-archived rows, both of which are wrong for a recompute.

`readNumber`, `readRelatedInstanceId` and `resolveBillForLine` are deleted — the batched reads replaced all three.

## One test changed shape, not intent

`reads the received quantity from the PO LINE, not from the bill line` asserted that `getFieldValues` was called with `purchase_order_line:pol-1` — the mechanism that just changed. It now asserts the behaviour: bill 5, receive 2, expect an exception with variance 300. It gained a sibling for the expected unit price (billed 1500 against an expected 100, past both arms of `DEFAULT_MATCH_TOLERANCE`). Both would fail on a version that read those numbers off the wrong record, which the old assertion could not claim.

## Tests

- **`read-field-scalars.test.ts`** (11, new) — one query for many records, the 200 chunk bound, id dedupe, and the absent-vs-null distinction every caller branches on (a record with no rows stays *absent*; a stored `false` and a stored `0` survive).
- **`match-hook.test.ts`** (+7) — 30 line fires on one bill → **1** match; inline fallback with no scope; orphaned line matches nothing; non-trigger attribute ignored; the two PO-line behaviour tests above; and both halves of the no-op guard.

Verified:

- `pnpm exec vitest run` in `packages/lib` — **1023 files, 13,729 tests, 0 failures**
- `node scripts/ci/typecheck-ratchet.js --package lib` — no new type errors (29 total, baseline 29)
- biome clean on all eight files (the four warnings left in these directories are pre-existing, in files this PR does not touch)

## Why this and not the plan's phase 3

Plan 08 has "extract the registry" next. I went looking for the *other similar locations* first, because the registry is only worth extracting over consumers that actually exist — and found this one, which is a larger win than #1953 and #1955 combined and needs no product decision. It also makes phase 3 honest: there are now two real consumers with genuinely different shapes (a three-rung parent ladder, a single relation) to generalise over, instead of one.