### PR TITLE
perf(money): rebuild a billing projection once per write, not once per changed field

### DIFF
--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -24,6 +24,7 @@ import {
   syncBillingOnWorkOrderChange,
   syncContactAfterWorkOrderDelete,
 } from '../money/billing-hooks'
+import { registerBillingReconcilers } from '../money/billing-reconciler'
 import {
   pauseMarkupOnPriceEdit,
   recomputePriceOnMarkupChange,
@@ -126,6 +127,10 @@ export function registerAllHooks(): void {
   // The three-way match's two drains. Same rule as above: the bill and bill-line
   // hooks only MARK, so without this nothing re-matches.
   registerMatchReconcilers()
+
+  // The billing projectors' four drains. Same rule again: the six billing hooks
+  // below only MARK, so without this nothing rebuilds a projection.
+  registerBillingReconcilers()
 
   // Field-change post-hook — fires `<prefix>:field:updated` after every field
   // write. Registered globally so contacts, tickets, companies, and custom

--- a/packages/lib/src/money/billing-coalescing.test.ts
+++ b/packages/lib/src/money/billing-coalescing.test.ts
@@ -1,0 +1,280 @@
+// packages/lib/src/money/billing-coalescing.test.ts
+//
+// Plan 08 phase 2c, through the real hooks.
+//
+// The billing projectors arrived with two of their three legs already right — a
+// batched child read and a no-op write guard — so the only thing this pins is the
+// third: that N hook fires produce ONE rebuild. Nothing in the existing suite
+// could see that, because these six hooks had no test coverage at all before this
+// file, and every projection assertion would pass identically at 30 rebuilds and
+// at one.
+//
+// The witness is `syncWorkOrderBillingProjection` itself, mocked and counted.
+// The money and purchasing coalescing tests had to proxy through `listFiltered`
+// because their rebuild function lived in the module under test; here the
+// projectors live in `./billing-projection`, a separate module the reconciler
+// lazy-imports, so it can be intercepted and counted directly. That is a truer
+// witness — it counts rebuilds, not a query that happens to accompany one.
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityFieldChangeEvent, EntityPostDeleteEvent } from '../field-hooks/types'
+import { runWithDirtyParents } from '../reconcilers/dirty-parents'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  syncWorkOrder: vi.fn(),
+  syncInvoice: vi.fn(),
+  syncContact: vi.fn(),
+  recomputeTotals: vi.fn(),
+  /** `FieldValue` rows for `readFieldRelations`' set-based read. */
+  relationRows: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('./billing-projection', () => ({
+  syncWorkOrderBillingProjection: h.syncWorkOrder,
+  syncInvoiceBillingProjection: h.syncInvoice,
+  syncContactBillingProjection: h.syncContact,
+}))
+vi.mock('./totals-hooks', () => ({ recomputeTotals: h.recomputeTotals }))
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../database/src/db/schema/index')
+  return {
+    schema,
+    database: { select: () => ({ from: () => ({ where: () => h.relationRows() }) }) },
+  }
+})
+
+import {
+  syncBillingAfterInvoiceDelete,
+  syncBillingAfterLineDelete,
+  syncBillingOnInvoiceChange,
+  syncBillingOnLineChange,
+  syncBillingOnWorkOrderChange,
+  syncContactAfterWorkOrderDelete,
+} from './billing-hooks'
+import { registerBillingReconcilers } from './billing-reconciler'
+
+const FIELDS: Record<string, { id: string; type: string }> = {
+  line_item_work_order: { id: 'f-li-wo', type: 'RELATIONSHIP' },
+}
+
+const ORG = 'org_1'
+const USER = 'usr_1'
+
+/** A source line pointing at `wo-1`, as the set-based relation read sees it. */
+const lineOnWorkOrder = (lineId: string, workOrderId = 'wo-1') => ({
+  entityId: lineId,
+  fieldId: 'f-li-wo',
+  relatedEntityId: workOrderId,
+})
+
+const lineEvent = (lineId: string, systemAttribute: string) =>
+  ({
+    recordId: `line_item:${lineId}`,
+    organizationId: ORG,
+    userId: USER,
+    field: { id: 'f', systemAttribute, type: 'CURRENCY' },
+  }) as unknown as EntityFieldChangeEvent
+
+const recordEvent = (recordId: string, systemAttribute: string) =>
+  ({
+    recordId,
+    organizationId: ORG,
+    userId: USER,
+    field: { id: 'f', systemAttribute, type: 'TEXT' },
+  }) as unknown as EntityFieldChangeEvent
+
+const deleteEvent = (values: Record<string, unknown>) =>
+  ({ organizationId: ORG, userId: USER, values }) as unknown as EntityPostDeleteEvent
+
+/** Work-order projection rebuilds. */
+const rebuilds = () => h.syncWorkOrder.mock.calls.length
+
+beforeAll(() => {
+  registerBillingReconcilers()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.bySystemAttributes.mockImplementation(async (attrs: string[]) =>
+    Object.fromEntries(attrs.filter((a) => FIELDS[a]).map((a) => [a, FIELDS[a]]))
+  )
+  h.syncWorkOrder.mockResolvedValue(undefined)
+  h.syncInvoice.mockResolvedValue(undefined)
+  h.syncContact.mockResolvedValue(undefined)
+  h.recomputeTotals.mockResolvedValue(undefined)
+  h.relationRows.mockResolvedValue([])
+})
+
+describe('a write rebuilds a projection once', () => {
+  it('collapses 30 line fires on one work order into ONE rebuild', async () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `li-${i}`)
+    h.relationRows.mockResolvedValue(lines.map((id) => lineOnWorkOrder(id)))
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (const id of lines) {
+        // The three trigger attributes one line write moves.
+        await syncBillingOnLineChange(lineEvent(id, 'line_item_qty'))
+        await syncBillingOnLineChange(lineEvent(id, 'line_item_unit_price'))
+        await syncBillingOnLineChange(lineEvent(id, 'line_item_work_order'))
+      }
+    })
+
+    expect(rebuilds()).toBe(1)
+    expect(h.syncWorkOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ workOrderInstanceId: 'wo-1' })
+    )
+  })
+
+  it('resolves every line parent in ONE relation query, not one per fire', async () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `li-${i}`)
+    h.relationRows.mockResolvedValue(lines.map((id) => lineOnWorkOrder(id)))
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (const id of lines) await syncBillingOnLineChange(lineEvent(id, 'line_item_qty'))
+    })
+
+    expect(h.relationRows).toHaveBeenCalledTimes(1)
+  })
+
+  it('still rebuilds each distinct work order', async () => {
+    h.relationRows.mockResolvedValue([
+      lineOnWorkOrder('li-1', 'wo-1'),
+      lineOnWorkOrder('li-2', 'wo-2'),
+    ])
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await syncBillingOnLineChange(lineEvent('li-1', 'line_item_qty'))
+      await syncBillingOnLineChange(lineEvent('li-2', 'line_item_qty'))
+    })
+
+    expect(rebuilds()).toBe(2)
+  })
+
+  it('collapses several work-order attribute fires into one rebuild', async () => {
+    await runWithDirtyParents(ORG, USER, async () => {
+      await syncBillingOnWorkOrderChange(recordEvent('work_order:wo-1', 'work_order_status'))
+      await syncBillingOnWorkOrderChange(recordEvent('work_order:wo-1', 'work_order_pricing_model'))
+    })
+
+    expect(rebuilds()).toBe(1)
+  })
+
+  it('rebuilds nothing for a line that hangs off no work order', async () => {
+    h.relationRows.mockResolvedValue([])
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await syncBillingOnLineChange(lineEvent('li-1', 'line_item_qty'))
+    })
+
+    expect(rebuilds()).toBe(0)
+  })
+
+  it('ignores an attribute outside the trigger set', async () => {
+    await runWithDirtyParents(ORG, USER, async () => {
+      await syncBillingOnLineChange(lineEvent('li-1', 'line_item_description'))
+    })
+
+    expect(h.relationRows).not.toHaveBeenCalled()
+    expect(rebuilds()).toBe(0)
+  })
+
+  it('still refuses to re-enter on a field the projector itself writes', async () => {
+    await runWithDirtyParents(ORG, USER, async () => {
+      await syncBillingOnWorkOrderChange(
+        recordEvent('work_order:wo-1', 'work_order_uninvoiced_amount')
+      )
+    })
+
+    expect(rebuilds()).toBe(0)
+  })
+})
+
+describe('the unscoped fallback', () => {
+  it('rebuilds inline when no write method opened a scope', async () => {
+    h.relationRows.mockResolvedValue([lineOnWorkOrder('li-1')])
+
+    // No `runWithDirtyParents` — the shape of a caller that reached the hook chain
+    // through an exported `field-value-mutations` function.
+    await syncBillingOnLineChange(lineEvent('li-1', 'line_item_qty'))
+
+    expect(rebuilds()).toBe(1)
+  })
+
+  it('rebuilds a work-order change inline too', async () => {
+    await syncBillingOnWorkOrderChange(recordEvent('work_order:wo-1', 'work_order_status'))
+    expect(rebuilds()).toBe(1)
+  })
+
+  it('rebuilds an invoice change inline too', async () => {
+    await syncBillingOnInvoiceChange(recordEvent('invoice:inv-1', 'invoice_status'))
+    expect(h.syncInvoice).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the delete paths', () => {
+  it('coalesces a bulk work-order delete onto one contact aggregate', async () => {
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (const id of ['wo-1', 'wo-2', 'wo-3']) {
+        await syncContactAfterWorkOrderDelete(
+          deleteEvent({ work_order_contact: `contact:c-1`, id })
+        )
+      }
+    })
+
+    expect(h.syncContact).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces several invoice deletes onto one work order', async () => {
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (const _ of [1, 2, 3]) {
+        await syncBillingAfterInvoiceDelete(deleteEvent({ invoice_work_order: 'work_order:wo-1' }))
+      }
+    })
+
+    expect(rebuilds()).toBe(1)
+  })
+
+  it('rebuilds nothing when the delete captured no parent', async () => {
+    await runWithDirtyParents(ORG, USER, async () => {
+      await syncBillingAfterInvoiceDelete(deleteEvent({}))
+      await syncContactAfterWorkOrderDelete(deleteEvent({}))
+    })
+
+    expect(rebuilds()).toBe(0)
+    expect(h.syncContact).not.toHaveBeenCalled()
+  })
+
+  it('a deleted work-order source line rebuilds its work order', async () => {
+    await runWithDirtyParents(ORG, USER, async () => {
+      await syncBillingAfterLineDelete(deleteEvent({ line_item_work_order: 'work_order:wo-1' }))
+    })
+
+    expect(rebuilds()).toBe(1)
+    expect(h.recomputeTotals).not.toHaveBeenCalled()
+  })
+
+  it('keeps the invoice totals recompute INLINE and ahead of the projection', async () => {
+    // The invoice projector cascades to the work order, whose projection reads
+    // `invoice_total` — so the totals must land before the projection runs. If
+    // both were marked, that dependency would ride on key insertion order.
+    const order: string[] = []
+    h.recomputeTotals.mockImplementation(async () => {
+      order.push('totals')
+    })
+    h.syncInvoice.mockImplementation(async () => {
+      order.push('projection')
+    })
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await syncBillingAfterLineDelete(deleteEvent({ line_item_invoice: 'invoice:inv-1' }))
+      // The totals recompute has already happened, inside the write.
+      expect(order).toEqual(['totals'])
+    })
+
+    expect(order).toEqual(['totals', 'projection'])
+  })
+})

--- a/packages/lib/src/money/billing-hooks.ts
+++ b/packages/lib/src/money/billing-hooks.ts
@@ -15,11 +15,15 @@ import type {
 } from '../field-hooks'
 import { UnifiedCrudHandler } from '../resources/crud'
 import { assertBillingConfigurationCompatible } from './billing-config'
+// Only the (never-registered) `syncBillingOnContactChange` still calls a projector
+// directly; every live hook marks instead, and the drain imports them lazily.
+import { syncContactBillingProjection } from './billing-projection'
 import {
-  syncContactBillingProjection,
-  syncInvoiceBillingProjection,
-  syncWorkOrderBillingProjection,
-} from './billing-projection'
+  markOrSyncContact,
+  markOrSyncInvoice,
+  markOrSyncLine,
+  markOrSyncWorkOrder,
+} from './billing-reconciler'
 import { recomputeTotals } from './totals-hooks'
 import type { WorkOrderBillingBasis, WorkOrderInvoiceTiming } from './types'
 
@@ -339,20 +343,11 @@ export const syncBillingOnLineChange: EntityFieldChangeHandler = async (event) =
   const attribute = event.field.systemAttribute ?? ''
   if ((BILLING_PROJECTION_ATTRS as readonly string[]).includes(attribute)) return
   if (!LINE_ITEM_BILLING_TRIGGER_ATTRS.has(attribute)) return
-  const cache = getOrgCache()
-  const fields = await cache
-    .from(event.organizationId, 'customFields')
-    .bySystemAttributes(['line_item_work_order'] as const)
-  if (!fields.line_item_work_order) return
-  const handler = new UnifiedCrudHandler(event.organizationId, event.userId)
-  const values = await handler.getFieldValues(event.recordId, [fields.line_item_work_order.id])
-  const typed = firstTyped(values.get(fields.line_item_work_order.id))
-  if (typed?.type !== 'relationship' || !typed.recordId) return
-  await syncWorkOrderBillingProjection({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    workOrderInstanceId: typed.recordId.split(':').at(-1)!,
-  })
+  // The work order is resolved in the DRAIN, not here: this used to be a
+  // `getFieldValues` on every one of the trigger attributes, asking the same
+  // question of the same line several times per write (plan 08 phase 2c).
+  const { entityInstanceId } = parseRecordId(event.recordId)
+  await markOrSyncLine(event.organizationId, event.userId, entityInstanceId)
 }
 
 /** Recompute work-order billing after relevant work-order fields change. */
@@ -360,11 +355,7 @@ export const syncBillingOnWorkOrderChange: EntityFieldChangeHandler = async (eve
   const attribute = event.field.systemAttribute ?? ''
   if ((BILLING_PROJECTION_ATTRS as readonly string[]).includes(attribute)) return
   if (!WORK_ORDER_BILLING_TRIGGER_ATTRS.has(attribute)) return
-  await syncWorkOrderBillingProjection({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    workOrderInstanceId: event.recordId.split(':').at(-1)!,
-  })
+  await markOrSyncWorkOrder(event.organizationId, event.userId, event.recordId.split(':').at(-1)!)
 }
 
 /** Recompute invoice context and its linked work order after lifecycle/payment changes. */
@@ -372,11 +363,7 @@ export const syncBillingOnInvoiceChange: EntityFieldChangeHandler = async (event
   const attribute = event.field.systemAttribute ?? ''
   if ((BILLING_PROJECTION_ATTRS as readonly string[]).includes(attribute)) return
   if (!INVOICE_BILLING_TRIGGER_ATTRS.has(attribute)) return
-  await syncInvoiceBillingProjection({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    invoiceInstanceId: event.recordId.split(':').at(-1)!,
-  })
+  await markOrSyncInvoice(event.organizationId, event.userId, event.recordId.split(':').at(-1)!)
 }
 
 /** Recompute a contact aggregate when its billing relationships change. */
@@ -408,11 +395,7 @@ function capturedRelationInstanceId(value: unknown): string | null {
 export const syncBillingAfterInvoiceDelete: EntityPostDeleteHandler = async (event) => {
   const workOrderInstanceId = capturedRelationInstanceId(event.values.invoice_work_order)
   if (!workOrderInstanceId) return
-  await syncWorkOrderBillingProjection({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    workOrderInstanceId,
-  })
+  await markOrSyncWorkOrder(event.organizationId, event.userId, workOrderInstanceId)
 }
 
 /**
@@ -427,26 +410,22 @@ export const syncBillingAfterLineDelete: EntityPostDeleteHandler = async (event)
   if (workOrderInstanceId) {
     // Work orders have no document-totals record — the billing projector reads source lines
     // directly, so the projection sync alone restores contract/uninvoiced amounts.
-    await syncWorkOrderBillingProjection({
-      organizationId: event.organizationId,
-      userId: event.userId,
-      workOrderInstanceId,
-    })
+    await markOrSyncWorkOrder(event.organizationId, event.userId, workOrderInstanceId)
     return
   }
   const invoiceInstanceId = capturedRelationInstanceId(event.values.line_item_invoice)
   if (invoiceInstanceId) {
+    // 🛑 `recomputeTotals` stays INLINE and stays first. The invoice projector
+    // cascades to the work order, whose projection reads `invoice_total` — so the
+    // totals have to be on the row before the projection runs. Marking both would
+    // put that dependency at the mercy of key insertion order in the drain.
     await recomputeTotals({
       organizationId: event.organizationId,
       userId: event.userId,
       documentType: 'invoice',
       documentInstanceId: invoiceInstanceId,
     })
-    await syncInvoiceBillingProjection({
-      organizationId: event.organizationId,
-      userId: event.userId,
-      invoiceInstanceId,
-    })
+    await markOrSyncInvoice(event.organizationId, event.userId, invoiceInstanceId)
   }
 }
 
@@ -457,9 +436,5 @@ export const syncBillingAfterLineDelete: EntityPostDeleteHandler = async (event)
 export const syncContactAfterWorkOrderDelete: EntityPostDeleteHandler = async (event) => {
   const contactInstanceId = capturedRelationInstanceId(event.values.work_order_contact)
   if (!contactInstanceId) return
-  await syncContactBillingProjection({
-    organizationId: event.organizationId,
-    userId: event.userId,
-    contactInstanceId,
-  })
+  await markOrSyncContact(event.organizationId, event.userId, contactInstanceId)
 }

--- a/packages/lib/src/money/billing-reconciler.ts
+++ b/packages/lib/src/money/billing-reconciler.ts
@@ -1,0 +1,189 @@
+// packages/lib/src/money/billing-reconciler.ts
+
+/**
+ * The work-order billing projection as a dirty-parent reconciler
+ * (`plans/events/08-derived-parent-reconciler-plan.md` phase 2c) — the fourth and
+ * last instance of the pattern, and the mildest.
+ *
+ * Unlike the totals engine and the three-way match, this one arrived with two of
+ * its three legs already right (plan 08 §1.0 row 3):
+ *
+ * - its child read is already batched — `computeWorkOrderBillingProjection` hands
+ *   `readSystemValues` an `entityInstanceIds` list;
+ * - it already refuses a no-op write — `projectionHasChanges` /
+ *   `writeChangedProjection`, *"a projection repair that finds no changes does not
+ *   create event churn"*.
+ *
+ * **Neither is touched here.** The only gap was coalescing:
+ * `syncBillingOnLineChange` fired once per changed FIELD, resolved
+ * `line_item_work_order` with a `getFieldValues` on every one of them, and rebuilt
+ * the whole projection each time.
+ *
+ * ## Four keys, because there are three projectors
+ *
+ * | key | marked with | drain |
+ * | --- | --- | --- |
+ * | `billing:line_item` | a source LINE id | batch-resolve line -> work order, then project |
+ * | `billing:work_order` | a WORK ORDER id | project it |
+ * | `billing:invoice` | an INVOICE id | project it (which cascades to its work order) |
+ * | `billing:contact` | a CONTACT id | project the customer aggregate |
+ *
+ * ## Why drain order does not matter
+ *
+ * The three projectors cascade **invoice -> work order -> contact**
+ * (`billing-projection.ts`: the invoice projector ends by syncing its work order,
+ * and the work-order projector ends by syncing its contact *"only when the
+ * work-order projection actually changed"*). So whichever key drains first, a
+ * downstream projection that went stale is re-run by the cascade above it — and
+ * every drain reads current database truth, after all of the write's own values
+ * have landed. Two keys naming the same document is wasteful, never wrong, and
+ * the no-op guard already makes the second pass write nothing.
+ */
+
+import { getOrgCache } from '../cache'
+import { readFieldRelations } from '../field-values/read-field-scalars'
+import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
+
+export const BILLING_LINE_ITEM = 'billing:line_item'
+export const BILLING_WORK_ORDER = 'billing:work_order'
+export const BILLING_INVOICE = 'billing:invoice'
+export const BILLING_CONTACT = 'billing:contact'
+
+let registered = false
+
+/** Register the four drains. Called from `registerAllHooks()`, idempotent. */
+export function registerBillingReconcilers(): void {
+  if (registered) return
+  registered = true
+
+  registerReconciler(BILLING_LINE_ITEM, async ({ organizationId, userId, parentInstanceIds }) => {
+    const workOrders = await resolveWorkOrdersForLines(organizationId, parentInstanceIds)
+    await syncEach(organizationId, userId, workOrders, 'work_order')
+  })
+
+  registerReconciler(BILLING_WORK_ORDER, async ({ organizationId, userId, parentInstanceIds }) => {
+    await syncEach(organizationId, userId, parentInstanceIds, 'work_order')
+  })
+
+  registerReconciler(BILLING_INVOICE, async ({ organizationId, userId, parentInstanceIds }) => {
+    await syncEach(organizationId, userId, parentInstanceIds, 'invoice')
+  })
+
+  registerReconciler(BILLING_CONTACT, async ({ organizationId, userId, parentInstanceIds }) => {
+    await syncEach(organizationId, userId, parentInstanceIds, 'contact')
+  })
+}
+
+/** Which projector a batch belongs to. */
+type Projector = 'work_order' | 'invoice' | 'contact'
+
+/**
+ * Project each distinct record once, isolating failures.
+ *
+ * One record failing must not lose the rest — a drain batch is several unrelated
+ * documents, not one unit of work, the same rule `rematchEach` applies. The three
+ * projectors are lazy-imported so this module carries no runtime edge back to
+ * `billing-hooks`, which imports it.
+ */
+async function syncEach(
+  organizationId: string,
+  userId: string,
+  instanceIds: string[],
+  projector: Projector
+): Promise<void> {
+  if (instanceIds.length === 0) return
+  const {
+    syncContactBillingProjection,
+    syncInvoiceBillingProjection,
+    syncWorkOrderBillingProjection,
+  } = await import('./billing-projection')
+
+  for (const instanceId of new Set(instanceIds)) {
+    if (projector === 'work_order') {
+      await syncWorkOrderBillingProjection({
+        organizationId,
+        userId,
+        workOrderInstanceId: instanceId,
+      })
+    } else if (projector === 'invoice') {
+      await syncInvoiceBillingProjection({ organizationId, userId, invoiceInstanceId: instanceId })
+    } else {
+      await syncContactBillingProjection({ organizationId, userId, contactInstanceId: instanceId })
+    }
+  }
+}
+
+/**
+ * The work order each source line hangs off, in ONE query.
+ *
+ * The per-line version was a `getFieldValues` per line, called once per changed
+ * attribute — so a line whose quantity, price and description all moved in one
+ * write cost three round trips to answer the same question three times.
+ */
+async function resolveWorkOrdersForLines(
+  organizationId: string,
+  lineInstanceIds: string[]
+): Promise<string[]> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['line_item_work_order'] as const)
+  const relField = cf.line_item_work_order
+  if (!relField) return []
+
+  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [relField.id])
+
+  const workOrders: string[] = []
+  for (const lineInstanceId of lineInstanceIds) {
+    const workOrder = rels.get(lineInstanceId)?.get(relField.id)
+    if (workOrder) workOrders.push(workOrder)
+  }
+  return workOrders
+}
+
+/**
+ * Mark a work order for projection, or project it now when nothing will drain.
+ *
+ * The inline fallback is load-bearing — see `markParentDirty`: a caller that
+ * reached the hook chain through an exported `field-value-mutations` function
+ * rather than a public service method has no scope, and without this the
+ * work order's contract and uninvoiced amounts would silently stop updating.
+ */
+export async function markOrSyncWorkOrder(
+  organizationId: string,
+  userId: string,
+  workOrderInstanceId: string
+): Promise<void> {
+  if (markParentDirty(BILLING_WORK_ORDER, workOrderInstanceId)) return
+  await syncEach(organizationId, userId, [workOrderInstanceId], 'work_order')
+}
+
+/** {@link markOrSyncWorkOrder}'s line-side twin — the parent is resolved in the drain. */
+export async function markOrSyncLine(
+  organizationId: string,
+  userId: string,
+  lineInstanceId: string
+): Promise<void> {
+  if (markParentDirty(BILLING_LINE_ITEM, lineInstanceId)) return
+  const workOrders = await resolveWorkOrdersForLines(organizationId, [lineInstanceId])
+  await syncEach(organizationId, userId, workOrders, 'work_order')
+}
+
+/** {@link markOrSyncWorkOrder} for the invoice projector. */
+export async function markOrSyncInvoice(
+  organizationId: string,
+  userId: string,
+  invoiceInstanceId: string
+): Promise<void> {
+  if (markParentDirty(BILLING_INVOICE, invoiceInstanceId)) return
+  await syncEach(organizationId, userId, [invoiceInstanceId], 'invoice')
+}
+
+/** {@link markOrSyncWorkOrder} for the customer aggregate. */
+export async function markOrSyncContact(
+  organizationId: string,
+  userId: string,
+  contactInstanceId: string
+): Promise<void> {
+  if (markParentDirty(BILLING_CONTACT, contactInstanceId)) return
+  await syncEach(organizationId, userId, [contactInstanceId], 'contact')
+}


### PR DESCRIPTION
Phase 2c of `plans/events/08-derived-parent-reconciler-plan.md` — the fourth and last instance of the parent-from-children pattern, after #1953, #1955 and #1956.

## The defect

This one is the mildest, because it arrived with two of its three legs already right (plan 08 §1.0 row 3):

- ✅ its child read is already batched — `computeWorkOrderBillingProjection` hands `readSystemValues` an `entityInstanceIds` list
- ✅ it already refuses a no-op write — `projectionHasChanges` / `writeChangedProjection`, *"a projection repair that finds no changes does not create event churn"*

**Neither is touched here.** The gap was coalescing:

```
syncBillingOnLineChange                    x once per changed field
  |- getOrgCache -> line_item_work_order
  |- getFieldValues(line, [rel])           <- resolves the SAME parent, per fire
  '- syncWorkOrderBillingProjection        <- rebuilds the WHOLE projection, per fire
```

Editing 10 source lines with three trigger attributes each: **30 parent resolves + 30 rebuilds → 1 relation query + 1 rebuild.**

## Four keys, because there are three projectors

The directive for this work assumed one projector and two keys. There are three, and the delete paths resolve their parent from captured `event.values` rather than a read:

| key | marked with | drain |
| --- | --- | --- |
| `billing:line_item` | a source LINE id | batch-resolve line → work order, then project |
| `billing:work_order` | a WORK ORDER id | project it |
| `billing:invoice` | an INVOICE id | project it (cascades to its work order) |
| `billing:contact` | a CONTACT id | project the customer aggregate |

Six hooks now mark: `syncBillingOnLineChange`, `syncBillingOnWorkOrderChange`, `syncBillingOnInvoiceChange`, `syncBillingAfterInvoiceDelete`, `syncBillingAfterLineDelete`, `syncContactAfterWorkOrderDelete`. The three delete hooks gain coalescing for bulk deletes — deleting 10 work orders for one customer was 10 contact aggregates, now 1.

**Drain order does not matter.** The projectors cascade **invoice → work order → contact** (`billing-projection.ts`: the invoice projector ends by syncing its work order; the work-order projector ends by syncing its contact *"only when the work-order projection actually changed"*). So a projection another key left stale is re-run by the cascade above it, and every drain reads current truth after all of the write's values have landed. Two keys naming the same document is wasteful, never wrong, and the existing no-op guard makes the second pass write nothing.

## One call deliberately NOT deferred

In `syncBillingAfterLineDelete`'s invoice arm, `recomputeTotals` stays **inline and first**. The invoice projector cascades to the work order, whose projection reads `invoice_total` — so the totals must be on the row before the projection runs. Marking both would put that dependency at the mercy of key insertion order in the drain. There is a test that pins the ordering, and a comment at the call site saying why.

## Left alone

`syncBillingOnContactChange` is exported but **registered nowhere and called from nowhere** — a repo-wide search finds only its own declaration. Coalescing a handler nothing invokes would be speculation, and deleting half-wired code is not this PR's job. It keeps its direct projector call, which is why one import of `syncContactBillingProjection` remains.

## Tests

These six hooks had **no test coverage at all** before this — so there was no mechanism-asserting test to rewrite, and `billing-coalescing.test.ts` (15 tests) is their first.

The witness is `syncWorkOrderBillingProjection` itself, mocked and counted. The money and purchasing coalescing tests had to proxy through `listFiltered` because their rebuild function lived in the module under test; here the projectors live in `./billing-projection`, a separate module the reconciler lazy-imports, so it can be intercepted and counted directly — a truer witness, counting rebuilds rather than a query that accompanies one.

Covered: 30 line fires → 1 rebuild; one relation query for the whole batch; distinct work orders still each rebuild; several work-order attributes → 1 rebuild; orphaned line rebuilds nothing; non-trigger attribute ignored; the `BILLING_PROJECTION_ATTRS` re-entry guard still holds; three unscoped-fallback cases; bulk delete coalescing on both the contact and work-order paths; no parent captured rebuilds nothing; and the totals-before-projection ordering above.

Two of these are structurally impossible to pass on the old code — it never called `readFieldRelations` at all.

## Verified

- `pnpm exec vitest run` in `packages/lib` — **1024 files, 13,744 tests, 0 failures**, exit 0 on the first run (the known `resolve-resource-trigger-match` flake did not bite)
- `node scripts/ci/typecheck-ratchet.js --package lib` — no new type errors (29 total, baseline 29)
- biome clean on all four files
