### PR TITLE
feat(build): show when an order changed after its builds were raised

### DIFF
--- a/packages/lib/src/builds/__tests__/auto-build-cancel.test.ts
+++ b/packages/lib/src/builds/__tests__/auto-build-cancel.test.ts
@@ -113,6 +113,7 @@ function build(overrides: Partial<BuildRecord> & { buildId: string }): BuildReco
     orderId: ORDER,
     source: 'order',
     reversalOfBuildId: null,
+    orderRevision: null,
     createdAt: new Date('2026-08-27T00:00:00.000Z'),
     ...overrides,
   }

--- a/packages/lib/src/builds/__tests__/drift-hooks.test.ts
+++ b/packages/lib/src/builds/__tests__/drift-hooks.test.ts
@@ -1,0 +1,149 @@
+// packages/lib/src/builds/__tests__/drift-hooks.test.ts
+//
+// The trigger vocabulary is the whole of what this feature reacts to, and both
+// ways of getting it wrong are quiet: too narrow and an edit changes the demand
+// without moving the fingerprint (the defect plan 13 §0 is about, wearing a new
+// field); too wide and the fingerprint moves on an edit that asks the floor for
+// nothing different, so drift stops meaning anything.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityFieldChangeEvent, EntityPostDeleteEvent } from '../../field-hooks/types'
+
+const h = vi.hoisted(() => ({ markOrder: vi.fn(), markLine: vi.fn() }))
+
+vi.mock('../drift-reconciler', () => ({
+  markOrStampOrder: h.markOrder,
+  markOrStampOrderLine: h.markLine,
+}))
+
+import {
+  LINE_DEMAND_TRIGGER_ATTRS,
+  ORDER_DEMAND_TRIGGER_ATTRS,
+  stampOrderAfterLineDelete,
+  stampOrderOnLineChange,
+  stampOrderOnOrderChange,
+} from '../drift-hooks'
+
+const ORG = 'org_1'
+
+const lineEvent = (systemAttribute: string, oldValue: unknown = null) =>
+  ({
+    recordId: 'line_item:li-1',
+    organizationId: ORG,
+    userId: 'usr_1',
+    field: { id: 'f', systemAttribute, type: 'NUMBER' },
+    oldValue,
+  }) as unknown as EntityFieldChangeEvent
+
+const orderEvent = (systemAttribute: string) =>
+  ({
+    recordId: 'order:ord-1',
+    organizationId: ORG,
+    userId: 'usr_1',
+    field: { id: 'f', systemAttribute, type: 'DATETIME' },
+  }) as unknown as EntityFieldChangeEvent
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.markOrder.mockResolvedValue(undefined)
+  h.markLine.mockResolvedValue(undefined)
+})
+
+describe('the line trigger vocabulary', () => {
+  it('names exactly the three attributes that move DEMAND', () => {
+    expect([...LINE_DEMAND_TRIGGER_ATTRS].sort()).toEqual([
+      'line_item_order',
+      'line_item_part',
+      'line_item_qty',
+    ])
+  })
+
+  it('excludes the money vocabulary — a price change asks the floor for nothing new', () => {
+    for (const attr of ['line_item_unit_price', 'line_item_discount', 'line_item_taxable']) {
+      expect(LINE_DEMAND_TRIGGER_ATTRS.has(attr as never)).toBe(false)
+    }
+  })
+
+  it.each(['line_item_part', 'line_item_qty', 'line_item_order'])('marks on %s', async (attr) => {
+    await stampOrderOnLineChange(lineEvent(attr))
+    expect(h.markLine).toHaveBeenCalledWith(ORG, 'li-1')
+  })
+
+  it('ignores an attribute outside the set', async () => {
+    await stampOrderOnLineChange(lineEvent('line_item_unit_price'))
+    expect(h.markLine).not.toHaveBeenCalled()
+    expect(h.markOrder).not.toHaveBeenCalled()
+  })
+})
+
+describe('a reparented line changes TWO orders', () => {
+  it('marks the order it left as well as the one it joined', async () => {
+    await stampOrderOnLineChange(
+      lineEvent('line_item_order', { type: 'relationship', recordId: 'order:ord-old' })
+    )
+
+    // The new parent comes from the line itself; the old one is reachable only
+    // through `oldValue`, and without it the order it left keeps claiming demand
+    // that walked away.
+    expect(h.markLine).toHaveBeenCalledWith(ORG, 'li-1')
+    expect(h.markOrder).toHaveBeenCalledWith(ORG, 'ord-old')
+  })
+
+  it('marks only the line when it had no previous order', async () => {
+    await stampOrderOnLineChange(lineEvent('line_item_order', null))
+    expect(h.markLine).toHaveBeenCalledTimes(1)
+    expect(h.markOrder).not.toHaveBeenCalled()
+  })
+
+  it('does not look for a previous order on a part or quantity edit', async () => {
+    await stampOrderOnLineChange(
+      lineEvent('line_item_qty', { type: 'relationship', recordId: 'order:ord-old' })
+    )
+    expect(h.markOrder).not.toHaveBeenCalled()
+  })
+})
+
+describe('the order trigger vocabulary', () => {
+  it('is cancellation and nothing else', () => {
+    expect([...ORDER_DEMAND_TRIGGER_ATTRS]).toEqual(['order_cancelled_at'])
+  })
+
+  it('marks the order when it is cancelled', async () => {
+    await stampOrderOnOrderChange(orderEvent('order_cancelled_at'))
+    expect(h.markOrder).toHaveBeenCalledWith(ORG, 'ord-1')
+  })
+
+  it('ignores the money and status header fields', async () => {
+    for (const attr of ['order_tax_rate', 'order_financial_status', 'order_placed_at']) {
+      await stampOrderOnOrderChange(orderEvent(attr))
+    }
+    expect(h.markOrder).not.toHaveBeenCalled()
+  })
+})
+
+describe('a deleted line', () => {
+  const deleteEvent = (value: unknown) =>
+    ({
+      organizationId: ORG,
+      userId: 'usr_1',
+      values: { line_item_order: value },
+    }) as unknown as EntityPostDeleteEvent
+
+  it('marks the order the line hung off, read from the captured values', async () => {
+    // Deletes fire no field-change hook and the row is already gone, so the
+    // parent has to come off the event — the same way `rematchAfterBillLineDelete`
+    // reads its own.
+    await stampOrderAfterLineDelete(deleteEvent('order:ord-1'))
+    expect(h.markOrder).toHaveBeenCalledWith(ORG, 'ord-1')
+  })
+
+  it('accepts a bare instance id as well as a RecordId', async () => {
+    await stampOrderAfterLineDelete(deleteEvent('ord-1'))
+    expect(h.markOrder).toHaveBeenCalledWith(ORG, 'ord-1')
+  })
+
+  it('no-ops when the delete captured no parent', async () => {
+    await stampOrderAfterLineDelete(deleteEvent(undefined))
+    expect(h.markOrder).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/builds/__tests__/drift-queries.test.ts
+++ b/packages/lib/src/builds/__tests__/drift-queries.test.ts
@@ -1,0 +1,160 @@
+// packages/lib/src/builds/__tests__/drift-queries.test.ts
+//
+// The read side. Its one dangerous answer is a false positive: report drift for
+// a build that never claimed to follow an order and every historical build lights
+// up at once, which teaches people to ignore the signal — the opposite of what
+// Model A+ is for.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BuildRecord } from '../types'
+
+const h = vi.hoisted(() => ({ bySystemAttributes: vi.fn(), rows: vi.fn() }))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../../database/src/db/schema/index')
+  return { schema, database: { select: () => ({ from: () => ({ where: () => h.rows() }) }) } }
+})
+
+import { readBuildDrift } from '../drift-queries'
+
+const ORG = 'org_1'
+const REVISION_FIELD = 'f-order-build-revision'
+
+function build(overrides: Partial<BuildRecord> & { buildId: string }): BuildRecord {
+  return {
+    recordId: `def_build:${overrides.buildId}`,
+    number: null,
+    partId: 'p',
+    status: 'planned',
+    quantityPlanned: 1,
+    quantityProduced: null,
+    quantityScrapped: null,
+    startedAt: null,
+    completedAt: null,
+    materialCost: null,
+    laborCost: null,
+    overheadCost: null,
+    producedValue: null,
+    varianceAmount: null,
+    postedAt: null,
+    notes: null,
+    orderId: 'ord-1',
+    source: 'order',
+    reversalOfBuildId: null,
+    orderRevision: 'hash-at-raise',
+    createdAt: new Date('2026-08-28T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.bySystemAttributes.mockResolvedValue({ order_build_revision: { id: REVISION_FIELD } })
+  h.rows.mockResolvedValue([])
+})
+
+describe('readBuildDrift', () => {
+  it('reports drift when the order has moved on', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'ord-1', fieldId: REVISION_FIELD, valueText: 'hash-now' },
+    ])
+
+    const out = await readBuildDrift(undefined as never, ORG, [build({ buildId: 'b-1' })])
+
+    expect(out.get('b-1')?.drifted).toBe(true)
+  })
+
+  it('reports no drift when the order still matches', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'ord-1', fieldId: REVISION_FIELD, valueText: 'hash-at-raise' },
+    ])
+
+    const out = await readBuildDrift(undefined as never, ORG, [build({ buildId: 'b-1' })])
+
+    expect(out.get('b-1')?.drifted).toBe(false)
+  })
+
+  it('works identically for in_progress and completed — that is why it beat a status field', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'ord-1', fieldId: REVISION_FIELD, valueText: 'hash-now' },
+    ])
+
+    const out = await readBuildDrift(undefined as never, ORG, [
+      build({ buildId: 'b-planned', status: 'planned' }),
+      build({ buildId: 'b-running', status: 'in_progress' }),
+      build({ buildId: 'b-done', status: 'completed' }),
+    ])
+
+    // Plan 13 §1.5 forbids automation from AMENDING an in_progress or completed
+    // build. Nothing forbids being honest about one.
+    for (const id of ['b-planned', 'b-running', 'b-done']) {
+      expect(out.get(id)?.drifted).toBe(true)
+    }
+  })
+
+  it('never calls a hand-raised build drifted', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'ord-1', fieldId: REVISION_FIELD, valueText: 'hash-now' },
+    ])
+
+    const out = await readBuildDrift(undefined as never, ORG, [
+      build({ buildId: 'b-manual', source: 'manual', orderRevision: null }),
+    ])
+
+    expect(out.get('b-manual')?.drifted).toBe(false)
+  })
+
+  it('never calls a build with no order drifted', async () => {
+    const out = await readBuildDrift(undefined as never, ORG, [
+      build({ buildId: 'b-loose', orderId: null, orderRevision: null }),
+    ])
+
+    expect(out.get('b-loose')?.drifted).toBe(false)
+    // Nothing comparable, so nothing queried.
+    expect(h.rows).not.toHaveBeenCalled()
+  })
+
+  it('never calls a build drifted when the order carries no fingerprint yet', async () => {
+    h.rows.mockResolvedValue([])
+
+    const out = await readBuildDrift(undefined as never, ORG, [build({ buildId: 'b-1' })])
+
+    expect(out.get('b-1')?.drifted).toBe(false)
+  })
+
+  it('returns an entry for every build handed in, drifted or not', async () => {
+    const out = await readBuildDrift(undefined as never, ORG, [
+      build({ buildId: 'b-1' }),
+      build({ buildId: 'b-2', orderId: null, orderRevision: null }),
+    ])
+
+    expect([...out.keys()].sort()).toEqual(['b-1', 'b-2'])
+  })
+
+  it('reads every order in ONE query', async () => {
+    await readBuildDrift(undefined as never, ORG, [
+      build({ buildId: 'b-1', orderId: 'ord-1' }),
+      build({ buildId: 'b-2', orderId: 'ord-2' }),
+      build({ buildId: 'b-3', orderId: 'ord-3' }),
+    ])
+
+    expect(h.rows).toHaveBeenCalledTimes(1)
+  })
+
+  it('answers an empty batch without touching the cache or the database', async () => {
+    const out = await readBuildDrift(undefined as never, ORG, [])
+    expect(out.size).toBe(0)
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+  })
+
+  it('reports no drift when the org has not run migration 111', async () => {
+    h.bySystemAttributes.mockResolvedValue({ order_build_revision: null })
+
+    const out = await readBuildDrift(undefined as never, ORG, [build({ buildId: 'b-1' })])
+
+    expect(out.get('b-1')?.drifted).toBe(false)
+  })
+})

--- a/packages/lib/src/builds/__tests__/drift-reconciler.test.ts
+++ b/packages/lib/src/builds/__tests__/drift-reconciler.test.ts
@@ -1,0 +1,318 @@
+// packages/lib/src/builds/__tests__/drift-reconciler.test.ts
+//
+// Model A+ is defined as much by what it does NOT do as by what it does, and the
+// "does not" half is invisible to every other test in this package: a reconciler
+// that quietly cancelled a `planned` build would leave `order_build_revision`
+// looking perfectly correct. These pin the restraint, the feature gate and the
+// coalescing.
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runWithDirtyParents } from '../../reconcilers/dirty-parents'
+
+const h = vi.hoisted(() => ({
+  loadAutoBuildSettings: vi.fn(),
+  loadAutoBuildOrders: vi.fn(),
+  bySystemAttributes: vi.fn(),
+  getCachedEntityDefId: vi.fn(),
+  setValuesForEntity: vi.fn(),
+  rows: vi.fn(),
+  createBuild: vi.fn(),
+  cancelBuild: vi.fn(),
+}))
+
+vi.mock('../auto-build-settings', () => ({ loadAutoBuildSettings: h.loadAutoBuildSettings }))
+vi.mock('../auto-build-queries', () => ({ loadAutoBuildOrders: h.loadAutoBuildOrders }))
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+  getCachedEntityDefId: h.getCachedEntityDefId,
+}))
+vi.mock('../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    setValuesForEntity = h.setValuesForEntity
+  },
+}))
+// The two writers this must never reach. Spied, not stubbed away, so a call
+// would be recorded rather than silently succeeding.
+vi.mock('../build-mutations', () => ({
+  createBuild: h.createBuild,
+  cancelBuild: h.cancelBuild,
+}))
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../../database/src/db/schema/index')
+  return {
+    schema,
+    database: { select: () => ({ from: () => ({ where: () => h.rows() }) }) },
+  }
+})
+
+import {
+  markOrStampOrder,
+  markOrStampOrderLine,
+  ORDER_DRIFT_LINE,
+  ORDER_DRIFT_ORDER,
+  registerOrderDriftReconcilers,
+} from '../drift-reconciler'
+
+const ORG = 'org_1'
+const ORDER_DEF = 'def_order'
+const REVISION_FIELD = 'f-order-build-revision'
+const LINE_ORDER_FIELD = 'f-line-order'
+
+/** What was written to which order, on the last stamp. */
+function stamped(): Array<{ recordId: string; value: unknown }> {
+  return h.setValuesForEntity.mock.calls.map((call) => {
+    const arg = call[0] as { recordId: string; values: Array<{ value: unknown }> }
+    return { recordId: arg.recordId, value: arg.values[0]?.value }
+  })
+}
+
+beforeAll(() => {
+  registerOrderDriftReconcilers()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.loadAutoBuildSettings.mockResolvedValue({
+    enabled: true,
+    enabledAt: new Date('2026-01-01T00:00:00.000Z'),
+    status: 'planned',
+    stockRule: 'out_of_stock_only',
+  })
+  h.loadAutoBuildOrders.mockResolvedValue([
+    {
+      orderId: 'ord-1',
+      placedAt: new Date(),
+      cancelledAt: null,
+      lines: [{ partId: 'p', quantity: 3 }],
+    },
+  ])
+  h.bySystemAttributes.mockImplementation(async (attrs: readonly string[]) => {
+    const out: Record<string, { id: string } | null> = {}
+    for (const attr of attrs) {
+      if (attr === 'order_build_revision') out[attr] = { id: REVISION_FIELD }
+      else if (attr === 'line_item_order') out[attr] = { id: LINE_ORDER_FIELD }
+      else out[attr] = null
+    }
+    return out
+  })
+  h.getCachedEntityDefId.mockResolvedValue(ORDER_DEF)
+  h.setValuesForEntity.mockResolvedValue(undefined)
+  h.rows.mockResolvedValue([])
+})
+
+describe('it mutates no build, ever', () => {
+  it('stamps the ORDER and calls neither createBuild nor cancelBuild', async () => {
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+    })
+
+    expect(stamped()).toHaveLength(1)
+    expect(stamped()[0]?.recordId).toContain('ord-1')
+    // The whole point of Model A+ over Model B (plan 13 §3): the product
+    // decision stays open because nothing was decided on anyone's behalf.
+    expect(h.createBuild).not.toHaveBeenCalled()
+    expect(h.cancelBuild).not.toHaveBeenCalled()
+  })
+
+  it('writes exactly one field, and it is the revision', async () => {
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+    })
+
+    const call = h.setValuesForEntity.mock.calls[0]?.[0] as { values: Array<{ fieldId: string }> }
+    expect(call.values).toHaveLength(1)
+    expect(call.values[0]?.fieldId).toBe(REVISION_FIELD)
+  })
+})
+
+describe('the feature gate', () => {
+  it('stamps nothing when auto-build is switched off', async () => {
+    h.loadAutoBuildSettings.mockResolvedValue({
+      enabled: false,
+      enabledAt: null,
+      status: 'planned',
+      stockRule: 'out_of_stock_only',
+    })
+
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+    })
+
+    // Nothing can drift from a build that will never be raised, so a stamp here
+    // is a field write bought for nothing on every order edit in every org that
+    // does not manufacture. It also settles the seed lane: the setting is off by
+    // default, so a seeded demo org stamps nothing.
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+    expect(h.loadAutoBuildOrders).not.toHaveBeenCalled()
+  })
+
+  it('stamps an order placed BEFORE the enablement window — a position on plan 13 Q11', async () => {
+    h.loadAutoBuildOrders.mockResolvedValue([
+      {
+        orderId: 'ord-old',
+        placedAt: new Date('2020-01-01T00:00:00.000Z'),
+        cancelledAt: null,
+        lines: [{ partId: 'p', quantity: 1 }],
+      },
+    ])
+
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-old')
+    })
+
+    // AB8's window exists so switching auto-build on does not RAISE builds for
+    // the backlog. This raises nothing, and honouring the window here would
+    // leave every pre-enablement order permanently unable to show drift — the
+    // exact defect 13 §0 is about. Revisit before phase 5 turns `apply` on.
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+  })
+
+  it('stamps nothing when the org has not run migration 111', async () => {
+    h.bySystemAttributes.mockResolvedValue({ order_build_revision: null })
+
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+    })
+
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+})
+
+describe('the no-op guard', () => {
+  it('skips the write when the stored fingerprint already matches', async () => {
+    // Stamp once to learn the hash this demand produces...
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+    })
+    const fingerprint = stamped()[0]?.value
+    vi.clearAllMocks()
+    beforeEachState()
+
+    // ...then hand it back as what is already stored.
+    h.rows.mockResolvedValue([
+      { entityId: 'ord-1', fieldId: REVISION_FIELD, valueText: fingerprint },
+    ])
+
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+    })
+
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+
+  it('writes when the stored fingerprint is stale', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'ord-1', fieldId: REVISION_FIELD, valueText: 'a-stale-hash' },
+    ])
+
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+    })
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('coalescing', () => {
+  it('stamps once however many lines of one order moved', async () => {
+    h.rows.mockResolvedValue([
+      { entityId: 'li-1', fieldId: LINE_ORDER_FIELD, relatedEntityId: 'ord-1' },
+      { entityId: 'li-2', fieldId: LINE_ORDER_FIELD, relatedEntityId: 'ord-1' },
+    ])
+
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      for (const line of ['li-1', 'li-2']) {
+        await markOrStampOrderLine(ORG, line)
+        await markOrStampOrderLine(ORG, line)
+      }
+    })
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks rather than acting when a scope is open', async () => {
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+      // Still inside the write — the drain has not run.
+      expect(h.setValuesForEntity).not.toHaveBeenCalled()
+    })
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+  })
+
+  it('stamps inline when no write method opened a scope', async () => {
+    await markOrStampOrder(ORG, 'ord-1')
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes distinct keys for the order and line doors', () => {
+    expect(ORDER_DRIFT_ORDER).not.toBe(ORDER_DRIFT_LINE)
+  })
+})
+
+describe('failure isolation', () => {
+  it('does not throw out of the hook when the stamp write fails', async () => {
+    h.setValuesForEntity.mockRejectedValue(new Error('write failed'))
+
+    await expect(
+      runWithDirtyParents(ORG, 'usr_1', async () => {
+        await markOrStampOrder(ORG, 'ord-1')
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('stamps the rest of the batch when one order fails', async () => {
+    h.loadAutoBuildOrders.mockResolvedValue([
+      {
+        orderId: 'ord-1',
+        placedAt: new Date(),
+        cancelledAt: null,
+        lines: [{ partId: 'p', quantity: 1 }],
+      },
+      {
+        orderId: 'ord-2',
+        placedAt: new Date(),
+        cancelledAt: null,
+        lines: [{ partId: 'q', quantity: 2 }],
+      },
+    ])
+    h.setValuesForEntity.mockRejectedValueOnce(new Error('boom')).mockResolvedValue(undefined)
+
+    await runWithDirtyParents(ORG, 'usr_1', async () => {
+      await markOrStampOrder(ORG, 'ord-1')
+      await markOrStampOrder(ORG, 'ord-2')
+    })
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(2)
+  })
+})
+
+/** Re-apply the defaults `beforeEach` sets, after an in-test `clearAllMocks`. */
+function beforeEachState() {
+  h.loadAutoBuildSettings.mockResolvedValue({
+    enabled: true,
+    enabledAt: new Date('2026-01-01T00:00:00.000Z'),
+    status: 'planned',
+    stockRule: 'out_of_stock_only',
+  })
+  h.loadAutoBuildOrders.mockResolvedValue([
+    {
+      orderId: 'ord-1',
+      placedAt: new Date(),
+      cancelledAt: null,
+      lines: [{ partId: 'p', quantity: 3 }],
+    },
+  ])
+  h.bySystemAttributes.mockImplementation(async (attrs: readonly string[]) => {
+    const out: Record<string, { id: string } | null> = {}
+    for (const attr of attrs) {
+      if (attr === 'order_build_revision') out[attr] = { id: REVISION_FIELD }
+      else if (attr === 'line_item_order') out[attr] = { id: LINE_ORDER_FIELD }
+      else out[attr] = null
+    }
+    return out
+  })
+  h.getCachedEntityDefId.mockResolvedValue(ORDER_DEF)
+  h.setValuesForEntity.mockResolvedValue(undefined)
+  h.rows.mockResolvedValue([])
+}

--- a/packages/lib/src/builds/__tests__/order-fingerprint.test.ts
+++ b/packages/lib/src/builds/__tests__/order-fingerprint.test.ts
@@ -1,0 +1,143 @@
+// packages/lib/src/builds/__tests__/order-fingerprint.test.ts
+//
+// The whole of Model A+ rests on this function being STABLE for a change that is
+// not a change and DIFFERENT for one that is. Both failure modes are silent: a
+// hash that moves on a no-op makes every order look drifted until people stop
+// looking, and one that fails to move on a real edit is the defect plan 13 §0
+// exists to fix, reintroduced with a field to make it look handled.
+
+import { describe, expect, it } from 'vitest'
+import type { AutoBuildLine } from '../auto-build-policy'
+import { hasDrifted, orderDemandFingerprint } from '../order-fingerprint'
+
+const LIFT = 'part_lift'
+const MOTOR = 'part_motor'
+
+const fp = (lines: AutoBuildLine[], cancelledAt: Date | null = null) =>
+  orderDemandFingerprint({ cancelledAt, lines })
+
+describe('what does not change the fingerprint', () => {
+  it('is stable across runs for the same demand', () => {
+    expect(fp([{ partId: LIFT, quantity: 3 }])).toBe(fp([{ partId: LIFT, quantity: 3 }]))
+  })
+
+  it('ignores LINE ORDER — the same lines read back differently are the same demand', () => {
+    const a = fp([
+      { partId: LIFT, quantity: 3 },
+      { partId: MOTOR, quantity: 1 },
+    ])
+    const b = fp([
+      { partId: MOTOR, quantity: 1 },
+      { partId: LIFT, quantity: 3 },
+    ])
+    expect(a).toBe(b)
+  })
+
+  it('ignores a line SPLIT — 2 + 3 asks the floor for exactly what 5 did', () => {
+    const split = fp([
+      { partId: LIFT, quantity: 2 },
+      { partId: LIFT, quantity: 3 },
+    ])
+    expect(split).toBe(fp([{ partId: LIFT, quantity: 5 }]))
+  })
+
+  it('ignores a line whose quantity is zero or negative', () => {
+    const withNoise = fp([
+      { partId: LIFT, quantity: 3 },
+      { partId: MOTOR, quantity: 0 },
+      { partId: 'part_ghost', quantity: -2 },
+    ])
+    expect(withNoise).toBe(fp([{ partId: LIFT, quantity: 3 }]))
+  })
+
+  it('ignores a non-finite quantity rather than hashing NaN', () => {
+    expect(
+      fp([
+        { partId: LIFT, quantity: 3 },
+        { partId: MOTOR, quantity: Number.NaN },
+      ])
+    ).toBe(fp([{ partId: LIFT, quantity: 3 }]))
+  })
+
+  it('ignores WHEN an order was cancelled — only that it was', () => {
+    const lines = [{ partId: LIFT, quantity: 3 }]
+    expect(fp(lines, new Date('2026-01-01T00:00:00.000Z'))).toBe(
+      fp(lines, new Date('2026-08-28T12:34:56.000Z'))
+    )
+  })
+})
+
+describe('what does change the fingerprint', () => {
+  it('a quantity edit', () => {
+    expect(fp([{ partId: LIFT, quantity: 3 }])).not.toBe(fp([{ partId: LIFT, quantity: 5 }]))
+  })
+
+  it('a part swap', () => {
+    expect(fp([{ partId: LIFT, quantity: 3 }])).not.toBe(fp([{ partId: MOTOR, quantity: 3 }]))
+  })
+
+  it('an added line', () => {
+    expect(fp([{ partId: LIFT, quantity: 3 }])).not.toBe(
+      fp([
+        { partId: LIFT, quantity: 3 },
+        { partId: MOTOR, quantity: 1 },
+      ])
+    )
+  })
+
+  it('a deleted line', () => {
+    expect(
+      fp([
+        { partId: LIFT, quantity: 3 },
+        { partId: MOTOR, quantity: 1 },
+      ])
+    ).not.toBe(fp([{ partId: LIFT, quantity: 3 }]))
+  })
+
+  it('cancelling the order', () => {
+    const lines = [{ partId: LIFT, quantity: 3 }]
+    expect(fp(lines)).not.toBe(fp(lines, new Date('2026-08-28T00:00:00.000Z')))
+  })
+
+  it('distinguishes a CANCELLED order from one whose lines were all removed', () => {
+    // Both ask production for nothing, and they are not the same fact: one is a
+    // dead order, the other an empty one somebody is still typing.
+    expect(fp([], new Date('2026-08-28T00:00:00.000Z'))).not.toBe(fp([]))
+  })
+
+  it('distinguishes an empty order from one with a line', () => {
+    expect(fp([])).not.toBe(fp([{ partId: LIFT, quantity: 1 }]))
+  })
+
+  it('does not collide two parts whose ids share a prefix', () => {
+    expect(fp([{ partId: 'part_a', quantity: 1 }])).not.toBe(
+      fp([{ partId: 'part_ab', quantity: 1 }])
+    )
+  })
+
+  it('does not confuse a quantity with a part id', () => {
+    expect(fp([{ partId: '1', quantity: 2 }])).not.toBe(fp([{ partId: '2', quantity: 1 }]))
+  })
+})
+
+describe('hasDrifted', () => {
+  it('is true only when both stamps exist and differ', () => {
+    expect(hasDrifted('a', 'b')).toBe(true)
+  })
+
+  it('is false when they agree', () => {
+    expect(hasDrifted('a', 'a')).toBe(false)
+  })
+
+  it.each([
+    ['a build with no stamp', null, 'a'],
+    ['an order with no fingerprint', 'a', null],
+    ['neither side stamped', null, null],
+    ['an empty string, which is not a hash', '', 'a'],
+  ])('reads %s as UNKNOWN, never as drifted', (_label, build, order) => {
+    // A hand-raised build and a pre-migration order are both unknown. Calling
+    // them drifted would light up every historical build at once and teach
+    // everyone to ignore the signal.
+    expect(hasDrifted(build, order)).toBe(false)
+  })
+})

--- a/packages/lib/src/builds/build-mutations.ts
+++ b/packages/lib/src/builds/build-mutations.ts
@@ -124,6 +124,23 @@ export async function createBuild(
       if (input.orderId) {
         const orderDefId = await requireDefId(organizationId, 'order')
         values.build_order = toRecordId(orderDefId, input.orderId)
+
+        // Stamp what the order asked production for AT THIS MOMENT
+        // (plans/products/13 Model A+). Compared later against the order's own
+        // `order_build_revision` to show that the order has changed since.
+        //
+        // 🛑 Only for a build the ORDER raised. A person who raises a build
+        // against an order deliberately is not tracking it, and stamping them
+        // would report drift for a build that never claimed to follow anything
+        // — the same distinction `build_source` exists to make (12 AB7).
+        //
+        // Absent on failure rather than fatal: `hasDrifted` reads a missing
+        // stamp as *unknown*, not *drifted*, so the worst case is a build that
+        // cannot show drift — never a build that is not raised.
+        if ((input.source ?? 'manual') === 'order' && ctx.fields.build_order_revision) {
+          const stamp = await readOrderDemandFingerprint(db, organizationId, input.orderId)
+          if (stamp) values.build_order_revision = stamp
+        }
       }
 
       // The DEFAULT (interactive) write session on purpose. Only the two paths
@@ -237,6 +254,36 @@ async function updateBuild(
     bypassFieldGuards: BUILD_STATUS_BYPASS,
   })
   await crud.update(toRecordId(ctx.buildDefId, buildId) as RecordId, values)
+}
+
+/**
+ * The order's current demand fingerprint, or `null` when it cannot be computed.
+ *
+ * Never throws: a build must be raised whether or not its drift stamp can be
+ * taken. Lazy-imported so `build-mutations` keeps no static edge to the
+ * auto-build query layer.
+ */
+async function readOrderDemandFingerprint(
+  db: Database,
+  organizationId: string,
+  orderId: string
+): Promise<string | null> {
+  try {
+    const [{ loadAutoBuildOrders }, { orderDemandFingerprint }] = await Promise.all([
+      import('./auto-build-queries'),
+      import('./order-fingerprint'),
+    ])
+    const [order] = await loadAutoBuildOrders(db, organizationId, [orderId])
+    if (!order) return null
+    return orderDemandFingerprint({ cancelledAt: order.cancelledAt, lines: order.lines })
+  } catch (error) {
+    logger.warn('Could not stamp the build with its order revision', {
+      organizationId,
+      orderId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
 }
 
 /** {@link getBuild}, as the `NotFoundError` a write path needs. */

--- a/packages/lib/src/builds/build-queries.ts
+++ b/packages/lib/src/builds/build-queries.ts
@@ -69,6 +69,7 @@ const BUILD_ATTRIBUTES = [
   'build_order',
   'build_source',
   'build_reversal_of',
+  'build_order_revision',
 ] as const
 
 type BuildAttribute = (typeof BUILD_ATTRIBUTES)[number]
@@ -473,6 +474,7 @@ function toBuildRecord(
     orderId: read('build_order')?.relatedEntityId ?? null,
     source: read('build_source')?.optionId ?? null,
     reversalOfBuildId: read('build_reversal_of')?.relatedEntityId ?? null,
+    orderRevision: read('build_order_revision')?.valueText ?? null,
     createdAt: row.createdAt,
   }
 }

--- a/packages/lib/src/builds/drift-hooks.ts
+++ b/packages/lib/src/builds/drift-hooks.ts
@@ -1,0 +1,97 @@
+// packages/lib/src/builds/drift-hooks.ts
+
+/**
+ * The four seams that can change what an order asks production for
+ * (plans/products/13 Model A+).
+ *
+ * Every one of them does exactly one thing — mark the order dirty — and the
+ * drain in `drift-reconciler.ts` re-stamps it once. That is the contract
+ * `reconcilers/dirty-parents.ts` exists to enforce: a hook performs no reads and
+ * no writes of its own, so pasting twenty lines re-stamps the order once rather
+ * than forty times.
+ *
+ * 🛑 **None of these touches a build.**
+ */
+
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
+import type { EntityFieldChangeHandler, EntityPostDeleteHandler } from '../field-hooks/types'
+import { markOrStampOrder, markOrStampOrderLine } from './drift-reconciler'
+
+/**
+ * Line attributes that move the DEMAND, and only those.
+ *
+ * `line_item_order` is here for the same reason `money/totals-hooks.ts` carries
+ * its rel triggers: a line just attached to (or detached from) an order changes
+ * what that order asks for, and no other attribute fires when it happens.
+ *
+ * ⚠️ `line_item_unit_price` and the rest of the money vocabulary are deliberately
+ * ABSENT. A price change moves the totals, never the production demand, and
+ * including it would re-stamp — and so appear to make drift move — on an edit
+ * that asks the floor for nothing different.
+ */
+export const LINE_DEMAND_TRIGGER_ATTRS = new Set<SystemAttribute>([
+  'line_item_part',
+  'line_item_qty',
+  'line_item_order',
+])
+
+/**
+ * Order attributes that move the demand.
+ *
+ * Cancellation only. An order's own fields are otherwise a document header —
+ * dates, statuses, money — and none of them changes what is to be made.
+ */
+export const ORDER_DEMAND_TRIGGER_ATTRS = new Set<SystemAttribute>(['order_cancelled_at'])
+
+/** A line's part, quantity or parent order moved. */
+export const stampOrderOnLineChange: EntityFieldChangeHandler = async (event) => {
+  const attr = event.field.systemAttribute as SystemAttribute | undefined
+  if (!attr || !LINE_DEMAND_TRIGGER_ATTRS.has(attr)) return
+
+  const { entityInstanceId } = parseRecordId(event.recordId)
+  await markOrStampOrderLine(event.organizationId, entityInstanceId)
+
+  // A REPARENTED line changes two orders: the one it left now asks for less.
+  // The new parent is covered by the mark above, which resolves the line's
+  // CURRENT order; the old one is only reachable through `oldValue`.
+  if (attr === 'line_item_order') {
+    const previousOrderId = relatedInstanceId(event.oldValue)
+    if (previousOrderId) await markOrStampOrder(event.organizationId, previousOrderId)
+  }
+}
+
+/** The order was cancelled. It now asks production for nothing. */
+export const stampOrderOnOrderChange: EntityFieldChangeHandler = async (event) => {
+  const attr = event.field.systemAttribute as SystemAttribute | undefined
+  if (!attr || !ORDER_DEMAND_TRIGGER_ATTRS.has(attr)) return
+
+  const { entityInstanceId } = parseRecordId(event.recordId)
+  await markOrStampOrder(event.organizationId, entityInstanceId)
+}
+
+/**
+ * A line was deleted, so its order asks for less.
+ *
+ * Deletes fire no field-change hook, so without this a removed line leaves the
+ * order's fingerprint claiming demand that no longer exists — a drift signal
+ * that is wrong in the direction that matters. The parent comes off the delete
+ * event's captured values, the same way `rematchAfterBillLineDelete` reads its
+ * own; the row is gone by now and cannot be read back.
+ */
+export const stampOrderAfterLineDelete: EntityPostDeleteHandler = async (event) => {
+  const raw = event.values.line_item_order
+  if (typeof raw !== 'string' || raw.length === 0) return
+  const orderId = raw.includes(':') ? parseRecordId(raw as RecordId).entityInstanceId : raw
+
+  await markOrStampOrder(event.organizationId, orderId)
+}
+
+/** The instance id inside a relationship field value, or null. */
+function relatedInstanceId(value: unknown): string | null {
+  const typed = Array.isArray(value) ? value[0] : value
+  if (!typed || typeof typed !== 'object') return null
+  const rel = typed as { type?: string; recordId?: string }
+  if (rel.type !== 'relationship' || !rel.recordId) return null
+  return parseRecordId(rel.recordId as RecordId).entityInstanceId
+}

--- a/packages/lib/src/builds/drift-queries.ts
+++ b/packages/lib/src/builds/drift-queries.ts
@@ -1,0 +1,85 @@
+// packages/lib/src/builds/drift-queries.ts
+
+/**
+ * "Has this build drifted from the order that raised it?" — the read side of
+ * Model A+ (plans/products/13).
+ *
+ * 🛑 **No UI ships with this.** Plan 13 Q4 leaves the surface open — a badge, a
+ * field, or a signal — and that is a product call this does not make. What it
+ * provides is the answer, batched, so the surface is a rendering decision rather
+ * than another round of query design.
+ */
+
+import type { Database } from '@auxx/database'
+import { getOrgCache } from '../cache'
+import { readFieldScalars } from '../field-values/read-field-scalars'
+import { hasDrifted } from './order-fingerprint'
+import type { BuildRecord } from './types'
+
+/** One build's drift verdict. */
+export interface BuildDrift {
+  buildId: string
+  /** The order this build was raised from, or `null` for a hand-raised build. */
+  orderId: string | null
+  /**
+   * `true` only when BOTH stamps exist and differ. A missing stamp on either
+   * side is *unknown*, never *drifted* — see {@link hasDrifted}.
+   */
+  drifted: boolean
+}
+
+/**
+ * Which of these builds no longer match their order.
+ *
+ * Two queries regardless of batch size: the field lookup is cached, and every
+ * order's current fingerprint comes back in one read. A build with no order, or
+ * with no stamp, is reported `drifted: false` without costing anything.
+ *
+ * ⚠️ Deliberately takes {@link BuildRecord}s rather than ids. Every caller that
+ * wants drift is already listing builds, and re-reading them here would be the
+ * composed-read problem: a second query answering something the first already
+ * had in hand.
+ */
+export async function readBuildDrift(
+  db: Database,
+  organizationId: string,
+  builds: readonly BuildRecord[]
+): Promise<Map<string, BuildDrift>> {
+  const out = new Map<string, BuildDrift>()
+  for (const build of builds) {
+    out.set(build.buildId, {
+      buildId: build.buildId,
+      orderId: build.orderId,
+      drifted: false,
+    })
+  }
+  if (builds.length === 0) return out
+
+  // Only builds that carry BOTH an order and a stamp can drift; everything else
+  // is already answered above and must not widen the query.
+  const comparable = builds.filter((build) => build.orderId && build.orderRevision)
+  if (comparable.length === 0) return out
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['order_build_revision'] as const)
+  const revisionField = fields.order_build_revision
+  if (!revisionField) return out
+
+  const orderRevisions = await readFieldScalars(
+    db,
+    organizationId,
+    comparable.map((build) => build.orderId as string),
+    [revisionField.id]
+  )
+
+  for (const build of comparable) {
+    const current = orderRevisions.get(build.orderId as string)?.get(revisionField.id)
+    out.set(build.buildId, {
+      buildId: build.buildId,
+      orderId: build.orderId,
+      drifted: hasDrifted(build.orderRevision, typeof current === 'string' ? current : null),
+    })
+  }
+  return out
+}

--- a/packages/lib/src/builds/drift-reconciler.ts
+++ b/packages/lib/src/builds/drift-reconciler.ts
@@ -1,0 +1,192 @@
+// packages/lib/src/builds/drift-reconciler.ts
+
+/**
+ * Keep `order_build_revision` current, so a build raised from this order can be
+ * seen to have drifted from it (plans/products/13 Model A+).
+ *
+ * The third consumer of `reconcilers/dirty-parents.ts`, after the money totals
+ * engine and the three-way match, and by far the least ambitious:
+ *
+ * 🛑 **It writes exactly one field, on the ORDER, and never touches a build.**
+ * Not `createBuild`, not `cancelBuild`, not `quantityPlanned`. Plan 13 §1.5
+ * forbids automation from amending an `in_progress` build (material may already
+ * be cut) and B6/B8 forbid it absolutely for a `completed` one — but the reason
+ * this reconciler touches none of them is simpler than either rule: Model A+ was
+ * chosen precisely so that plan 13 Q1 stays open. Turning that into real
+ * reconciliation is phase 5, and it needs a product decision first.
+ *
+ * Two keys, for the same reason the other two reconcilers have several: the drain
+ * has to know whether it was handed an order or one of its lines.
+ */
+
+import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { FieldValueService } from '../field-values/field-value-service'
+import { readFieldRelations } from '../field-values/read-field-scalars'
+import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
+
+const logger = createScopedLogger('builds:drift-reconciler')
+
+export const ORDER_DRIFT_ORDER = 'order-build-drift:order'
+export const ORDER_DRIFT_LINE = 'order-build-drift:line_item'
+
+let registered = false
+
+/** Register both drains. Called from `registerAllHooks()`, idempotent. */
+export function registerOrderDriftReconcilers(): void {
+  if (registered) return
+  registered = true
+
+  registerReconciler(ORDER_DRIFT_ORDER, async ({ organizationId, parentInstanceIds }) => {
+    await stampOrders(organizationId, parentInstanceIds)
+  })
+
+  registerReconciler(ORDER_DRIFT_LINE, async ({ organizationId, parentInstanceIds }) => {
+    const orderIds = await resolveOrdersForLines(organizationId, parentInstanceIds)
+    await stampOrders(organizationId, orderIds)
+  })
+}
+
+/**
+ * Recompute and store each order's demand fingerprint.
+ *
+ * ⚠️ **Gated on `inventory.autoBuildFromOrders`.** With the feature off no order
+ * ever raises a build, so nothing can drift from anything and a stamp is a field
+ * write bought for nothing — on every order edit, in every org that does not
+ * manufacture. This also settles the seed lane by construction: the setting is
+ * off by default, so a seeded demo org stamps nothing.
+ *
+ * 🛑 **AB8's enablement window is deliberately NOT applied here, and that is a
+ * position on plan 13 Q11 rather than an oversight.** The window exists so that
+ * switching auto-build on does not RAISE builds for the entire historical
+ * backlog (12 AB8). This raises nothing — it writes one opaque token — and
+ * honouring the window here would instead leave every pre-enablement order
+ * permanently unable to show drift, which is the exact defect 13 §0 is about.
+ * The reasoning holds only while this reconciler mutates nothing; **phase 5 must
+ * revisit it before `apply` is turned on.** Q11 stays open.
+ *
+ * Lazy imports throughout, matching `auto-build-rule.ts`: the query layer pulls
+ * `@auxx/database` and the org cache, and this module is reached from
+ * `registerAllHooks()`.
+ */
+async function stampOrders(organizationId: string, orderIds: string[]): Promise<void> {
+  const ids = [...new Set(orderIds)].filter(Boolean)
+  if (ids.length === 0) return
+
+  const [{ loadAutoBuildSettings }, { database }] = await Promise.all([
+    import('./auto-build-settings'),
+    import('@auxx/database'),
+  ])
+  const settings = await loadAutoBuildSettings(organizationId)
+  if (!settings.enabled) return
+
+  const [{ loadAutoBuildOrders }, { orderDemandFingerprint }] = await Promise.all([
+    import('./auto-build-queries'),
+    import('./order-fingerprint'),
+  ])
+
+  const [orders, fields, orderDefId] = await Promise.all([
+    loadAutoBuildOrders(database, organizationId, ids),
+    getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttributes(['order_build_revision'] as const),
+    getCachedEntityDefId(organizationId, 'order'),
+  ])
+
+  const revisionField = fields.order_build_revision
+  // An org short of migration 111 has no field to stamp. Silent rather than
+  // loud: the migration closes it, and a logged failure per order edit until
+  // then would be noise about a state that fixes itself.
+  if (!revisionField || !orderDefId) return
+
+  const { readFieldScalars } = await import('../field-values/read-field-scalars')
+  const stored = await readFieldScalars(
+    database,
+    organizationId,
+    orders.map((order) => order.orderId),
+    [revisionField.id]
+  )
+
+  for (const order of orders) {
+    const fingerprint = orderDemandFingerprint({
+      cancelledAt: order.cancelledAt,
+      lines: order.lines,
+    })
+    // Compare before writing, the same guard #1953 and #1956 added to the other
+    // two reconcilers: most order edits move no line, and a re-stamp of an
+    // identical hash would re-enter the field-value layer, the realtime
+    // publisher and the sync manifest for nothing.
+    if (stored.get(order.orderId)?.get(revisionField.id) === fingerprint) continue
+
+    // One order failing must not lose the rest of the batch.
+    try {
+      const service = new FieldValueService(organizationId, SYSTEM_STAMP_USER, database)
+      await service.setValuesForEntity({
+        recordId: toRecordId(orderDefId, order.orderId),
+        values: [{ fieldId: revisionField.id, value: fingerprint }],
+      })
+    } catch (error) {
+      logger.error('Failed to stamp order demand fingerprint', {
+        organizationId,
+        orderId: order.orderId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+}
+
+/**
+ * `order_build_revision` is declared `updatable: false`, so it has no interactive
+ * writer and the reconciler is not acting for any particular person. The empty
+ * actor matches what `system-record-rules.ts` passes for the same reason — the
+ * wrapped writers never read it.
+ */
+const SYSTEM_STAMP_USER = ''
+
+/**
+ * The order each line hangs off, in ONE query — the pattern
+ * `purchasing/match-reconciler.ts` established.
+ */
+async function resolveOrdersForLines(
+  organizationId: string,
+  lineInstanceIds: string[]
+): Promise<string[]> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['line_item_order'] as const)
+  const relField = fields.line_item_order
+  if (!relField) return []
+
+  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [relField.id])
+
+  const orderIds: string[] = []
+  for (const lineInstanceId of lineInstanceIds) {
+    const orderId = rels.get(lineInstanceId)?.get(relField.id)
+    if (orderId) orderIds.push(orderId)
+  }
+  return orderIds
+}
+
+/**
+ * Mark an order for re-stamping, or re-stamp it now when nothing will drain.
+ *
+ * The inline fallback is load-bearing — see `markParentDirty`: a caller that
+ * reached the hook chain through an exported `field-value-mutations` function
+ * rather than a public service method has no scope, and without this the order's
+ * fingerprint would silently go stale, which is a drift signal that lies.
+ */
+export async function markOrStampOrder(organizationId: string, orderId: string): Promise<void> {
+  if (markParentDirty(ORDER_DRIFT_ORDER, orderId)) return
+  await stampOrders(organizationId, [orderId])
+}
+
+/** {@link markOrStampOrder}'s line-side twin. */
+export async function markOrStampOrderLine(
+  organizationId: string,
+  lineInstanceId: string
+): Promise<void> {
+  if (markParentDirty(ORDER_DRIFT_LINE, lineInstanceId)) return
+  const orderIds = await resolveOrdersForLines(organizationId, [lineInstanceId])
+  await stampOrders(organizationId, orderIds)
+}

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -84,6 +84,15 @@ export {
   unitsStarted,
 } from './client'
 export { completeBuild } from './complete-build'
+// Model A+ drift (plans/products/13). Read-only and stamp-only — nothing here
+// creates, amends or cancels a build.
+export { type BuildDrift, readBuildDrift } from './drift-queries'
+export {
+  markOrStampOrder,
+  markOrStampOrderLine,
+  registerOrderDriftReconcilers,
+} from './drift-reconciler'
+export { hasDrifted, type OrderDemand, orderDemandFingerprint } from './order-fingerprint'
 export { reverseBuild } from './reverse-build'
 export { rollStandardCost } from './standard-cost'
 export {

--- a/packages/lib/src/builds/order-fingerprint.ts
+++ b/packages/lib/src/builds/order-fingerprint.ts
@@ -1,0 +1,88 @@
+// packages/lib/src/builds/order-fingerprint.ts
+
+/**
+ * The order's production demand, reduced to one comparable string.
+ *
+ * `plans/products/13-order-build-reconciliation.md` Model A+. An order stays
+ * editable by design and the auto-build trigger fires once, on `created` — so a
+ * build says 3 forever while the order says 5 and no screen anywhere says they
+ * disagree (13 §0). This is what makes that disagreement visible: the order
+ * carries its CURRENT fingerprint, a build carries the one that was current when
+ * it was raised, and drift is simply the two differing.
+ *
+ * 🛑 **This decides nothing and changes nothing.** It does not create, amend or
+ * cancel a build. That is the point of A+ over Model B — plan 13 Q1 (snapshot or
+ * projection?) stays open, and whoever answers it inherits a convergence check
+ * that is already computed and stored.
+ *
+ * ## What goes in, and why it is the collapsed view
+ *
+ * The demand, not the document: {@link sumQuantityByPart}, which is the very
+ * function the trigger raises builds from (12 §5.3 step 6, *"one build per part,
+ * not one per line"*). Sharing it is deliberate — a fingerprint derived from a
+ * second, parallel reading of the order could disagree with what auto-build
+ * would actually raise, and a drift signal that lies is worse than none.
+ *
+ * Three consequences, all intended:
+ *
+ * - **Splitting one line of 5 into 2 + 3 is NOT drift.** Production is asked for
+ *   the same five units. The document changed; the demand did not.
+ * - **A line that reaches no part contributes nothing**, because it asks
+ *   production for nothing — `loadAutoBuildOrders` has already dropped it.
+ * - **A non-positive or non-finite quantity contributes nothing**, and a part
+ *   whose lines sum to zero drops out entirely, exactly as it does at raise time.
+ *
+ * ## Cancellation
+ *
+ * Carried as a BOOLEAN, not the timestamp. A cancelled order asks production for
+ * nothing, so its fingerprint must differ from its live self — but re-stamping
+ * `order_cancelled_at` with a different time is not a change in demand, and
+ * hashing the instant would report drift for it.
+ */
+
+import { stableHash } from '@auxx/utils/hash'
+import { type AutoBuildLine, sumQuantityByPart } from './auto-build-policy'
+
+/** Everything the fingerprint is allowed to see. No db, no clock. */
+export interface OrderDemand {
+  /** `order_cancelled_at`. Non-null means the order is cancelled. */
+  cancelledAt: Date | null
+  /** The order's live lines that reach a part. */
+  lines: readonly AutoBuildLine[]
+}
+
+/**
+ * The order's demand fingerprint — a hex SHA-256, stable across runs, processes
+ * and a Postgres `jsonb` round-trip.
+ *
+ * ⚠️ Sorted explicitly before hashing. {@link stableHash} is key-order
+ * independent but preserves ARRAY order on purpose (`packages/utils/src/json.ts`
+ * — array order is usually meaningful), and here it is not: the same two lines
+ * read back in a different order must produce the same fingerprint or every
+ * reconcile would report drift that does not exist.
+ */
+export function orderDemandFingerprint(demand: OrderDemand): string {
+  const totals = sumQuantityByPart(demand.lines)
+  const parts = [...totals.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+
+  return stableHash({
+    cancelled: demand.cancelledAt !== null,
+    parts,
+  })
+}
+
+/**
+ * Has this build drifted from the order that raised it?
+ *
+ * `false` whenever the comparison cannot be made — a build with no stamp (raised
+ * by hand, or before this shipped) and an order with no fingerprint yet are both
+ * *unknown*, not *drifted*. Reporting drift for an absent value would light up
+ * every historical build at once and teach everyone to ignore the signal.
+ */
+export function hasDrifted(
+  buildOrderRevision: string | null | undefined,
+  orderBuildRevision: string | null | undefined
+): boolean {
+  if (!buildOrderRevision || !orderBuildRevision) return false
+  return buildOrderRevision !== orderBuildRevision
+}

--- a/packages/lib/src/builds/types.ts
+++ b/packages/lib/src/builds/types.ts
@@ -188,6 +188,12 @@ export interface BuildRecord {
   source: string | null
   /** Set on a REVERSING build: the build it undoes (B6). */
   reversalOfBuildId: string | null
+  /**
+   * The order's demand fingerprint when this build was raised
+   * (plans/products/13 Model A+). `null` on a hand-raised build and on every
+   * row written before the field existed — both mean *unknown*, never *drifted*.
+   */
+  orderRevision: string | null
   createdAt: Date
 }
 

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -3,6 +3,12 @@
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import { registerAutoBuildRules } from '../builds/auto-build-rule'
 import {
+  stampOrderAfterLineDelete,
+  stampOrderOnLineChange,
+  stampOrderOnOrderChange,
+} from '../builds/drift-hooks'
+import { registerOrderDriftReconcilers } from '../builds/drift-reconciler'
+import {
   ensureVisitOnWorkOrderCreate,
   syncVisitPinsOnAddressNormalized,
 } from '../dispatch/visit-hooks'
@@ -127,6 +133,12 @@ export function registerAllHooks(): void {
   // hooks only MARK, so without this nothing re-matches.
   registerMatchReconcilers()
 
+  // The order-demand drift stamp's two drains (plans/products/13 Model A+). The
+  // hooks below only MARK, so without this an order's fingerprint goes stale —
+  // which is a drift signal that lies. Writes one field on the ORDER and never
+  // touches a build.
+  registerOrderDriftReconcilers()
+
   // Field-change post-hook — fires `<prefix>:field:updated` after every field
   // write. Registered globally so contacts, tickets, companies, and custom
   // entities all produce timeline entries.
@@ -193,9 +205,12 @@ export function registerAllHooks(): void {
     recomputeOnLineChange,
     syncBillingOnLineChange,
     stampPartOnCatalogItemChange,
+    // Model A+ (plans/products/13): a line's part, quantity or parent order
+    // moved, so what the order asks production for may have moved with it.
+    stampOrderOnLineChange,
   ])
   registerEntityFieldChangeHooks('quotes', [recomputeOnQuoteBillingChange])
-  registerEntityFieldChangeHooks('orders', [recomputeOnOrderBillingChange])
+  registerEntityFieldChangeHooks('orders', [recomputeOnOrderBillingChange, stampOrderOnOrderChange])
 
   // Buy-side totals engine (plans/purchasing/01-build-plan.md §4.1/§4.2). Same engine, a
   // different line entity and a different header shape — both named in
@@ -450,6 +465,9 @@ export function registerAllHooks(): void {
   // bill sits in the queue forever for a line that no longer exists.
   registerEntityPostDeleteHooks('vendor-bill-lines', [rematchAfterBillLineDelete])
   registerEntityPostDeleteHooks('invoices', [syncBillingAfterInvoiceDelete])
-  registerEntityPostDeleteHooks('line-items', [syncBillingAfterLineDelete])
+  registerEntityPostDeleteHooks('line-items', [
+    syncBillingAfterLineDelete,
+    stampOrderAfterLineDelete,
+  ])
   registerEntityPostDeleteHooks('work-orders', [syncContactAfterWorkOrderDelete])
 }

--- a/packages/lib/src/resources/registry/resources/build-fields.ts
+++ b/packages/lib/src/resources/registry/resources/build-fields.ts
@@ -635,6 +635,43 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
     description: 'Builds that undo this one',
   },
 
+  /**
+   * The order's demand fingerprint AS IT WAS when this build was raised
+   * (plans/products/13 Model A+). Stamped once, by `createBuild`, and only for a
+   * build the order raised — a hand-raised build tracks no order and gets none.
+   *
+   * 🛑 **Never rewritten.** The whole value of the stamp is that it is a record
+   * of a moment; refreshing it would erase the drift it exists to show. It works
+   * identically for `planned`, `in_progress` and `completed`, which is why plan
+   * 13 preferred it to a status field — §1.5 forbids automation from amending an
+   * `in_progress` build, but nothing forbids it from being HONEST about one.
+   */
+  orderRevision: {
+    id: toFieldId('orderRevision'),
+    key: 'orderRevision',
+    label: 'Order revision',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'build_order_revision',
+    systemSortOrder: 'aL',
+    nullable: true,
+    showInPanel: false,
+    showInTable: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      // Set on the insert by `createBuild` — there is no second write.
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Fingerprint of what the order asked production for at the moment this build was ' +
+      'raised. Differs from the order’s current fingerprint once the order has changed',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/resources/registry/resources/order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/order-fields.ts
@@ -620,6 +620,43 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
       'Builds raised to satisfy this order — what "cancel the builds for this order" looks up',
   },
 
+  /**
+   * The order's CURRENT production-demand fingerprint (plans/products/13 Model A+).
+   *
+   * Maintained by `builds/drift-reconciler.ts` and compared against a build's
+   * `build_order_revision` to answer "has this order changed since its builds
+   * were raised". Opaque — a SHA-256 hex string, never parsed, only compared.
+   *
+   * `updatable: false` and `creatable: false`: the reconciler is the only writer,
+   * and a hand-typed value would silence the drift signal on exactly the order
+   * somebody was looking at.
+   */
+  buildRevision: {
+    id: toFieldId('buildRevision'),
+    key: 'buildRevision',
+    label: 'Build revision',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'order_build_revision',
+    systemSortOrder: 'aL',
+    nullable: true,
+    // An internal comparison token. Nobody reads a hash off a screen.
+    showInPanel: false,
+    showInTable: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Fingerprint of what this order currently asks production for. Compared against a ' +
+      "build's own stamp to show that the order changed after the build was raised",
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -73,6 +73,7 @@ import { migration107Order } from './migrations/107-order'
 import { migration108Purchasing } from './migrations/108-purchasing'
 import { migration109BuildAndStandardCost } from './migrations/109-build-and-standard-cost'
 import { migration110BuildVisible } from './migrations/110-build-visible'
+import { migration111OrderBuildDrift } from './migrations/111-order-build-drift'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -193,6 +194,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // MUST sort after 109 — it flips the def 109 creates. See the migration itself
   // for why the `SYSTEM_ENTITIES` edit alone reaches no existing org.
   migration110BuildVisible,
+  migration111OrderBuildDrift,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
@@ -65,6 +65,7 @@ describe('order entity registration wiring', () => {
 
   it('carries exactly the 08 §2 field set, plus what later migrations added', () => {
     expect(Object.keys(ORDER_FIELDS).sort()).toEqual([
+      'buildRevision', // added by migration 111 — the drift fingerprint (products/13 A+)
       'builds', // added by migration 109 — inverse of build_order (build §1.2)
       'cancelledAt', // added by migration 109 — nullable, creatable, set never cleared
       'channel',

--- a/packages/lib/src/seed/entity-migrations/migrations/111-order-build-drift.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/111-order-build-drift.test.ts
@@ -1,0 +1,83 @@
+// packages/lib/src/seed/entity-migrations/migrations/111-order-build-drift.test.ts
+//
+// Migration 111 adds two `CustomField` rows, so what can silently go wrong is
+// the wiring rather than the write:
+//
+//  - the id must be unique across a space shared with `data-migrations/`, which
+//    has already collided once at 103;
+//  - it must run after 109, which creates the `build` def it hangs a field on;
+//  - the registry keys it names must exist, or it quietly creates one field
+//    fewer than it claims to;
+//  - both fields must reach the migration as system fields the reconciler can
+//    find by `systemAttribute`.
+
+import { describe, expect, it } from 'vitest'
+import { BUILD_FIELDS } from '../../../resources/registry/resources/build-fields'
+import { ORDER_FIELDS } from '../../../resources/registry/resources/order-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { migration111OrderBuildDrift } from './111-order-build-drift'
+
+describe('migration 111 registration', () => {
+  it('is registered exactly once, with a unique id, after 109', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '111-order-build-drift')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf('111-order-build-drift')).toBeGreaterThan(
+      ids.indexOf('109-build-and-standard-cost')
+    )
+    expect(migration111OrderBuildDrift.id).toBe('111-order-build-drift')
+  })
+
+  it('is last — a later migration must take 112, not reuse this number', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.at(-1)).toBe('111-order-build-drift')
+  })
+})
+
+describe('the fields it names exist and are shaped for the reconciler', () => {
+  it('order carries `buildRevision` as a system field on `order_build_revision`', () => {
+    const field = ORDER_FIELDS.buildRevision
+    expect(field).toBeDefined()
+    expect(field?.systemAttribute).toBe('order_build_revision')
+    expect(field?.isSystem).toBe(true)
+    expect(field?.nullable).toBe(true)
+  })
+
+  it('build carries `orderRevision` as a system field on `build_order_revision`', () => {
+    const field = BUILD_FIELDS.orderRevision
+    expect(field).toBeDefined()
+    expect(field?.systemAttribute).toBe('build_order_revision')
+    expect(field?.isSystem).toBe(true)
+    expect(field?.nullable).toBe(true)
+  })
+
+  it('neither is hand-writable — the stamp is the only writer of each', () => {
+    // A typed-in value would silence the drift signal on exactly the order
+    // somebody was looking at, which is worse than having no signal.
+    expect(ORDER_FIELDS.buildRevision?.capabilities.updatable).toBe(false)
+    expect(ORDER_FIELDS.buildRevision?.capabilities.creatable).toBe(false)
+    expect(BUILD_FIELDS.orderRevision?.capabilities.updatable).toBe(false)
+    // `creatable` on the build side only, because `createBuild` sets it on the
+    // insert rather than following up with a second write.
+    expect(BUILD_FIELDS.orderRevision?.capabilities.creatable).toBe(true)
+  })
+
+  it('keeps both out of the panel, the table and the dialog', () => {
+    // An opaque SHA-256. Nobody reads a hash off a screen, and a column of them
+    // would push a real one out of view.
+    for (const field of [ORDER_FIELDS.buildRevision, BUILD_FIELDS.orderRevision]) {
+      expect(field?.showInPanel).toBe(false)
+      expect(field?.showInTable).toBe(false)
+      expect(field?.showInDialogs).toBe(false)
+    }
+  })
+
+  it('does not collide with an existing sort order on either def', () => {
+    const collisions = (fields: Record<string, { systemSortOrder?: string }>, key: string) =>
+      Object.entries(fields).filter(
+        ([name, f]) => name !== key && f.systemSortOrder === fields[key]?.systemSortOrder
+      )
+    expect(collisions(ORDER_FIELDS, 'buildRevision')).toEqual([])
+    expect(collisions(BUILD_FIELDS, 'orderRevision')).toEqual([])
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/111-order-build-drift.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/111-order-build-drift.ts
@@ -1,0 +1,117 @@
+// packages/lib/src/seed/entity-migrations/migrations/111-order-build-drift.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getOrgCache } from '../../../cache'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { BUILD_FIELDS } from '../../../resources/registry/resources/build-fields'
+import { ORDER_FIELDS } from '../../../resources/registry/resources/order-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:111')
+
+/**
+ * The two defs that receive a field. Both are tolerated as absent: an org short
+ * of migration 107 has no `order` and one short of 109 has no `build`, and in
+ * either case there is nothing to fingerprint yet. A later run closes the gap.
+ */
+const TARGETS = ['order', 'build'] as const
+
+/**
+ * Listed by REGISTRY KEY rather than taken as "everything new on that registry",
+ * so a later unrelated field cannot silently join this migration's payload —
+ * the same discipline 109 records.
+ */
+const FIELD_KEYS: Record<(typeof TARGETS)[number], readonly string[]> = {
+  order: ['buildRevision'],
+  build: ['orderRevision'],
+}
+
+/**
+ * Migration 111: the order↔build drift pair, INERT
+ * (plans/products/13-order-build-reconciliation.md Model A+).
+ *
+ * ## What these two fields are
+ *
+ * `order_build_revision` is what the order currently asks production for, as one
+ * hash. `build_order_revision` is the same hash as it stood when the build was
+ * raised. **Drift is the two differing** — nothing more, and deliberately nothing
+ * more: this pair mutates no build, ever.
+ *
+ * That restraint is the reason plan 13 chose Model A+ over Model B. An order stays
+ * editable by design (13 §1.3, stated twice in source), the auto-build trigger
+ * fires once on `created`, and today the two silently disagree with nothing on any
+ * screen saying so (13 §0). Making the disagreement VISIBLE fixes that defect
+ * without answering 13 Q1 — snapshot or projection? — which nobody has decided.
+ * Whoever decides it inherits a convergence check already computed and stored.
+ *
+ * ## Inert on arrival, and briefly so
+ *
+ * Both fields read NULL and have no writer at the moment this migration runs, the
+ * same B10 precedent 109 followed (`plans/products/build/README.md`). A field with
+ * no writer carries no behavioural risk, and it clears the org-cache and
+ * def-exists gates for the code that lands with it.
+ *
+ * ## Id space
+ *
+ * 111 was the next free number counted across BOTH `data-migrations/migrations/`
+ * (which reaches 105) and `seed/entity-migrations/migrations/` (which reaches
+ * 110), and verified against every branch — the space is shared and has already
+ * collided once, at 103.
+ *
+ * **No DDL.** Both are `CustomField` rows on existing defs; nothing here touches
+ * a Postgres table. If a `.sql` file appears under `packages/database/drizzle/`
+ * for this work, something is wrong.
+ *
+ * Idempotent — `ensureCustomFields` skips a field that already exists.
+ */
+export const migration111OrderBuildDrift: EntityMigration = {
+  id: '111-order-build-drift',
+  description:
+    'Add the inert order_build_revision / build_order_revision drift pair, so an order ' +
+    'that changed after its builds were raised can say so',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const registries: Record<(typeof TARGETS)[number], Record<string, ResourceField>> = {
+      order: ORDER_FIELDS,
+      build: BUILD_FIELDS,
+    }
+
+    for (const entityType of TARGETS) {
+      const def = existing.entityDefs.get(entityType)
+      // Absent rather than failed: an org that has not reached 107 (order) or
+      // 109 (build) has nothing to fingerprint, and both migrations seed their
+      // full registry, so a later run picks these up on its own.
+      if (!def) continue
+
+      const fields: Record<string, ResourceField> = {}
+      for (const key of FIELD_KEYS[entityType]) {
+        const field = registries[entityType][key]
+        // Loud rather than silent: a renamed registry key would otherwise make
+        // this migration quietly create one field fewer than it claims to.
+        if (!field) {
+          throw new Error(`${entityType} registry is missing the key "${key}" (migration 111)`)
+        }
+        fields[key] = field
+      }
+
+      await ensureCustomFields(db, organizationId, entityType, def.id, fields, existing, state)
+    }
+
+    const alreadyUpToDate = state.fieldsCreated === 0
+
+    // A new field is invisible to every read path until the per-org caches that
+    // serve it are dropped. `runEntityMigrationsForOrg` does this after the whole
+    // batch, but `up()` can also be invoked directly, so it clears its own.
+    if (!alreadyUpToDate) {
+      await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+      logger.info('Migration 111 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -643,6 +643,11 @@ export const SYSTEM_ATTRIBUTES = [
   'stock_movement_qty_per_unit', // as-built BOM snapshot; NULL on a consume row = off-BOM
   'order_cancelled_at', // set, never cleared — a Shopify order can arrive cancelled
   'order_builds', // inverse of build_order
+  // The drift pair (plans/products/13 Model A+). The order carries its CURRENT
+  // demand fingerprint; a build carries the one that was current when it was
+  // raised. Drift is the two differing — and neither field mutates a build.
+  'order_build_revision',
+  'build_order_revision',
 
   // ─── Inbox fields ───────────────────────────────────────────────
   'inbox_name',


### PR DESCRIPTION
Phase 4 of `plans/events/08-derived-parent-reconciler-plan.md` — `plans/products/13-order-build-reconciliation.md`'s **Model A+**.

## The defect

An order stays editable by design (13 §1.3, stated twice in source) and the auto-build trigger fires once, `on: 'created'`. Edit a line from 3 to 5 and **nothing happens** — the build says 3 forever, and no screen anywhere says the two disagree.

The obvious fix is worse: "skip a part that already has a build" stops corrections with the same rule that stops duplicates, and the result *looks* like it is tracking the order when it is not.

## What this does

Two fields, one entity migration:

| field | on | written by | meaning |
| --- | --- | --- | --- |
| `order_build_revision` | `order` | the reconciler | what the order currently asks production for |
| `build_order_revision` | `build` | `createBuild`, once | the same, as it stood when the build was raised |

**Drift is the two differing.** It works identically for `planned`, `in_progress` and `completed` — which is why plan 13 preferred it to a status field. §1.5 forbids automation from *amending* an `in_progress` build (material may already be cut — not, as an earlier draft of that plan claimed, because it has consumed anything; `startBuild` writes no movements). Nothing forbids being **honest** about one.

## 🛑 It mutates no build

Not `createBuild`, not `cancelBuild`, not `quantityPlanned`. There is a test that spies on both writers and asserts they are never called, because a reconciler that quietly cancelled a `planned` build would leave `order_build_revision` looking perfectly correct.

That restraint is the point rather than a limitation. Model A+ was chosen over Model B precisely so **plan 13 Q1 — snapshot or projection? — stays open**, and whoever answers it inherits a convergence check already computed and stored. Turning this into real reconciliation is phase 5, and it needs a product decision first.

## The fingerprint

`stableHash` over the **demand, not the document** — part id, quantity, cancellation — via `sumQuantityByPart`, which is the very function the trigger raises builds from (12 §5.3 step 6).

Sharing that function is deliberate: a fingerprint derived from a second, parallel reading of the order could disagree with what auto-build would actually raise, and a drift signal that lies is worse than none. Three consequences, all intended and all tested:

- splitting one line of 5 into **2 + 3 is not drift** — production is asked for the same five units;
- **line order never matters** (`stableHash` preserves array order on purpose, so the parts are sorted before hashing);
- a zero, negative or non-finite quantity contributes nothing, exactly as at raise time.

Cancellation is carried as a **boolean, not the timestamp**: re-stamping `order_cancelled_at` with a different instant is not a change in demand.

## The reconciler

The third consumer of `reconcilers/dirty-parents.ts`, after the money totals engine (#1955) and the three-way match (#1956) — same mark-or-inline fallback, same compare-before-write, one query for line → order across the whole batch. Four seams mark: a line's part/quantity/parent-order, the order's cancellation, and a line **delete** (which fires no field-change hook, so the parent comes off the captured values the way `rematchAfterBillLineDelete` reads its own). A **reparented** line marks both orders — the one it left is reachable only through `oldValue`.

Gated on `inventory.autoBuildFromOrders`. With the feature off nothing can drift, so a stamp is a field write bought for nothing on every order edit in every org that does not manufacture. That also settles the seed lane by construction: the setting is off by default, so a seeded demo org stamps nothing.

## A question I answered myself — plan 13 Q11

**AB8's enablement window is deliberately not applied here.** The window exists so that switching auto-build on does not *raise* builds for the entire historical backlog. This raises nothing — it writes one opaque token — and honouring the window would instead leave every pre-enablement order permanently unable to show drift, which is the exact defect 13 §0 is about.

**This reasoning holds only while the reconciler mutates nothing. Phase 5 must revisit it before `apply` is turned on.** Q11 stays open; the position and its expiry are written on the function and pinned by a test.

## Migration 111

Next free id counted across **both** `data-migrations/migrations/` (reaches 105) and `seed/entity-migrations/migrations/` (reaches 110), verified against every branch — the space is shared and has already collided once, at 103. Inert on arrival, the B10 precedent 109 followed. No DDL: two `CustomField` rows on existing defs.

⚠️ **Not applied to any database.** Verified structurally only — registration order, uniqueness, and that the registry keys it names exist.

## No UI

Plan 13 Q4 leaves the surface open — badge, field or signal — and that is not this PR's call. `readBuildDrift` provides the batched answer (two queries regardless of batch size) so the surface is a rendering decision rather than another round of query design. It never reports drift for a hand-raised build, a build with no order, or an order with no fingerprint yet: a missing stamp is *unknown*, not *drifted*, and calling it drifted would light up every historical build at once and teach people to ignore the signal.

## Still open

Q1 (snapshot or projection), Q3 (human edits to an auto-raised build — and **not** to be solved by flipping `build_source`, which would corrupt provenance to encode control), Q5 (shortfall vs full quantity), Q6 (two orders, one part — `build_order` is a single relation), Q11 above, and the UI surface.

## Verified

- `pnpm exec vitest run` in `packages/lib` — **1032 files collected, 1028 passed, 4 skipped, 0 failures**
- `node scripts/ci/typecheck-ratchet.js --package lib` — **29 total, baseline 29**, no new errors
- `pnpm exec biome check` clean on every touched file

⚠️ A fresh worktree has no `node_modules`, and the ratchet then reports a **false pass** ("0 total, baseline 29" and a claim that 29 errors were *fixed*). Both numbers above are from after `pnpm install`; the honest re-run then caught a real error this branch had introduced.

`107-order.test.ts` pins the exact `ORDER_FIELDS` key set, so the new field is declared there with the migration that added it — that guard did its job and failed the first full run.
