### PR TITLE
refactor(reconcilers): extract the parent-reconciler registry over four consumers

### DIFF
--- a/packages/lib/src/builds/drift-reconciler.ts
+++ b/packages/lib/src/builds/drift-reconciler.ts
@@ -17,35 +17,52 @@
  *
  * Two keys, for the same reason the other two reconcilers have several: the drain
  * has to know whether it was handed an order or one of its lines.
+ *
+ * ## Why this one uses `rebuildBatch`
+ *
+ * It is the only consumer with real per-BATCH setup — the settings read, the
+ * order load, the field lookup and the stored-fingerprint read are all done once
+ * for the whole batch and then walked. Routing it through the shared per-parent
+ * callback would reintroduce exactly the N+1 this plan exists to remove, so
+ * `parent-reconciler.ts` carries a batch escape hatch and this is its one caller.
  */
 
 import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '@auxx/types/resource'
 import { getCachedEntityDefId, getOrgCache } from '../cache'
 import { FieldValueService } from '../field-values/field-value-service'
-import { readFieldRelations } from '../field-values/read-field-scalars'
-import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
+import { defineParentReconciler, resolveParentsByRelation } from '../reconcilers/parent-reconciler'
 
 const logger = createScopedLogger('builds:drift-reconciler')
 
 export const ORDER_DRIFT_ORDER = 'order-build-drift:order'
 export const ORDER_DRIFT_LINE = 'order-build-drift:line_item'
 
-let registered = false
+/**
+ * `order_build_revision` is declared `updatable: false`, so it has no interactive
+ * writer and the reconciler is not acting for any particular person. The empty
+ * actor matches what `system-record-rules.ts` passes for the same reason — the
+ * wrapped writers never read it.
+ */
+const SYSTEM_STAMP_USER = ''
 
-/** Register both drains. Called from `registerAllHooks()`, idempotent. */
+const orderReconciler = defineParentReconciler<string>({
+  key: ORDER_DRIFT_ORDER,
+  rebuildBatch: (organizationId, _userId, orderIds) => stampOrders(organizationId, orderIds),
+})
+
+const lineReconciler = defineParentReconciler<string>({
+  key: ORDER_DRIFT_LINE,
+  /** The order each line hangs off, in ONE query. */
+  resolve: (organizationId, lineInstanceIds) =>
+    resolveParentsByRelation(organizationId, 'line_item_order', lineInstanceIds),
+  rebuildBatch: (organizationId, _userId, orderIds) => stampOrders(organizationId, orderIds),
+})
+
+/** Register both drains. Called from `registerAllHooks()`, idempotent per key. */
 export function registerOrderDriftReconcilers(): void {
-  if (registered) return
-  registered = true
-
-  registerReconciler(ORDER_DRIFT_ORDER, async ({ organizationId, parentInstanceIds }) => {
-    await stampOrders(organizationId, parentInstanceIds)
-  })
-
-  registerReconciler(ORDER_DRIFT_LINE, async ({ organizationId, parentInstanceIds }) => {
-    const orderIds = await resolveOrdersForLines(organizationId, parentInstanceIds)
-    await stampOrders(organizationId, orderIds)
-  })
+  orderReconciler.register()
+  lineReconciler.register()
 }
 
 /**
@@ -71,7 +88,7 @@ export function registerOrderDriftReconcilers(): void {
  * `registerAllHooks()`.
  */
 async function stampOrders(organizationId: string, orderIds: string[]): Promise<void> {
-  const ids = [...new Set(orderIds)].filter(Boolean)
+  const ids = orderIds.filter(Boolean)
   if (ids.length === 0) return
 
   const [{ loadAutoBuildSettings }, { database }] = await Promise.all([
@@ -137,48 +154,15 @@ async function stampOrders(organizationId: string, orderIds: string[]): Promise<
 }
 
 /**
- * `order_build_revision` is declared `updatable: false`, so it has no interactive
- * writer and the reconciler is not acting for any particular person. The empty
- * actor matches what `system-record-rules.ts` passes for the same reason — the
- * wrapped writers never read it.
- */
-const SYSTEM_STAMP_USER = ''
-
-/**
- * The order each line hangs off, in ONE query — the pattern
- * `purchasing/match-reconciler.ts` established.
- */
-async function resolveOrdersForLines(
-  organizationId: string,
-  lineInstanceIds: string[]
-): Promise<string[]> {
-  const fields = await getOrgCache()
-    .from(organizationId, 'customFields')
-    .bySystemAttributes(['line_item_order'] as const)
-  const relField = fields.line_item_order
-  if (!relField) return []
-
-  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [relField.id])
-
-  const orderIds: string[] = []
-  for (const lineInstanceId of lineInstanceIds) {
-    const orderId = rels.get(lineInstanceId)?.get(relField.id)
-    if (orderId) orderIds.push(orderId)
-  }
-  return orderIds
-}
-
-/**
  * Mark an order for re-stamping, or re-stamp it now when nothing will drain.
  *
- * The inline fallback is load-bearing — see `markParentDirty`: a caller that
+ * The inline fallback is load-bearing — see `ParentReconciler.mark`: a caller that
  * reached the hook chain through an exported `field-value-mutations` function
  * rather than a public service method has no scope, and without this the order's
  * fingerprint would silently go stale, which is a drift signal that lies.
  */
 export async function markOrStampOrder(organizationId: string, orderId: string): Promise<void> {
-  if (markParentDirty(ORDER_DRIFT_ORDER, orderId)) return
-  await stampOrders(organizationId, [orderId])
+  await orderReconciler.mark(organizationId, SYSTEM_STAMP_USER, orderId)
 }
 
 /** {@link markOrStampOrder}'s line-side twin. */
@@ -186,7 +170,5 @@ export async function markOrStampOrderLine(
   organizationId: string,
   lineInstanceId: string
 ): Promise<void> {
-  if (markParentDirty(ORDER_DRIFT_LINE, lineInstanceId)) return
-  const orderIds = await resolveOrdersForLines(organizationId, [lineInstanceId])
-  await stampOrders(organizationId, orderIds)
+  await lineReconciler.mark(organizationId, SYSTEM_STAMP_USER, lineInstanceId)
 }

--- a/packages/lib/src/money/billing-reconciler.ts
+++ b/packages/lib/src/money/billing-reconciler.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/money/billing-reconciler.ts
 
 /**
- * The work-order billing projection as a dirty-parent reconciler
+ * The billing projections as dirty-parent reconcilers
  * (`plans/events/08-derived-parent-reconciler-plan.md` phase 2c) — the fourth and
  * last instance of the pattern, and the mildest.
  *
@@ -38,152 +38,102 @@
  * every drain reads current database truth, after all of the write's own values
  * have landed. Two keys naming the same document is wasteful, never wrong, and
  * the no-op guard already makes the second pass write nothing.
+ *
+ * 🛑 The one ordering dependency that is NOT absorbed by that argument lives in
+ * `billing-hooks.ts`, not here: `syncBillingAfterLineDelete`'s invoice arm keeps
+ * `recomputeTotals` inline and first, because the invoice projector cascades to
+ * the work order, whose projection reads `invoice_total`. Plan 08 §6.1.
  */
 
-import { getOrgCache } from '../cache'
-import { readFieldRelations } from '../field-values/read-field-scalars'
-import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
+import { defineParentReconciler, resolveParentsByRelation } from '../reconcilers/parent-reconciler'
 
 export const BILLING_LINE_ITEM = 'billing:line_item'
 export const BILLING_WORK_ORDER = 'billing:work_order'
 export const BILLING_INVOICE = 'billing:invoice'
 export const BILLING_CONTACT = 'billing:contact'
 
-let registered = false
-
-/** Register the four drains. Called from `registerAllHooks()`, idempotent. */
-export function registerBillingReconcilers(): void {
-  if (registered) return
-  registered = true
-
-  registerReconciler(BILLING_LINE_ITEM, async ({ organizationId, userId, parentInstanceIds }) => {
-    const workOrders = await resolveWorkOrdersForLines(organizationId, parentInstanceIds)
-    await syncEach(organizationId, userId, workOrders, 'work_order')
-  })
-
-  registerReconciler(BILLING_WORK_ORDER, async ({ organizationId, userId, parentInstanceIds }) => {
-    await syncEach(organizationId, userId, parentInstanceIds, 'work_order')
-  })
-
-  registerReconciler(BILLING_INVOICE, async ({ organizationId, userId, parentInstanceIds }) => {
-    await syncEach(organizationId, userId, parentInstanceIds, 'invoice')
-  })
-
-  registerReconciler(BILLING_CONTACT, async ({ organizationId, userId, parentInstanceIds }) => {
-    await syncEach(organizationId, userId, parentInstanceIds, 'contact')
-  })
-}
-
-/** Which projector a batch belongs to. */
-type Projector = 'work_order' | 'invoice' | 'contact'
-
 /**
- * Project each distinct record once, isolating failures.
- *
- * One record failing must not lose the rest — a drain batch is several unrelated
- * documents, not one unit of work, the same rule `rematchEach` applies. The three
- * projectors are lazy-imported so this module carries no runtime edge back to
- * `billing-hooks`, which imports it.
+ * The three projectors, lazy-imported so this module carries no runtime edge back
+ * to `billing-hooks`, which imports it.
  */
-async function syncEach(
+async function projectWorkOrder(
   organizationId: string,
   userId: string,
-  instanceIds: string[],
-  projector: Projector
+  workOrderInstanceId: string
 ): Promise<void> {
-  if (instanceIds.length === 0) return
-  const {
-    syncContactBillingProjection,
-    syncInvoiceBillingProjection,
-    syncWorkOrderBillingProjection,
-  } = await import('./billing-projection')
-
-  for (const instanceId of new Set(instanceIds)) {
-    if (projector === 'work_order') {
-      await syncWorkOrderBillingProjection({
-        organizationId,
-        userId,
-        workOrderInstanceId: instanceId,
-      })
-    } else if (projector === 'invoice') {
-      await syncInvoiceBillingProjection({ organizationId, userId, invoiceInstanceId: instanceId })
-    } else {
-      await syncContactBillingProjection({ organizationId, userId, contactInstanceId: instanceId })
-    }
-  }
+  const { syncWorkOrderBillingProjection } = await import('./billing-projection')
+  await syncWorkOrderBillingProjection({ organizationId, userId, workOrderInstanceId })
 }
 
-/**
- * The work order each source line hangs off, in ONE query.
- *
- * The per-line version was a `getFieldValues` per line, called once per changed
- * attribute — so a line whose quantity, price and description all moved in one
- * write cost three round trips to answer the same question three times.
- */
-async function resolveWorkOrdersForLines(
+async function projectInvoice(
   organizationId: string,
-  lineInstanceIds: string[]
-): Promise<string[]> {
-  const cf = await getOrgCache()
-    .from(organizationId, 'customFields')
-    .bySystemAttributes(['line_item_work_order'] as const)
-  const relField = cf.line_item_work_order
-  if (!relField) return []
+  userId: string,
+  invoiceInstanceId: string
+): Promise<void> {
+  const { syncInvoiceBillingProjection } = await import('./billing-projection')
+  await syncInvoiceBillingProjection({ organizationId, userId, invoiceInstanceId })
+}
 
-  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [relField.id])
+async function projectContact(
+  organizationId: string,
+  userId: string,
+  contactInstanceId: string
+): Promise<void> {
+  const { syncContactBillingProjection } = await import('./billing-projection')
+  await syncContactBillingProjection({ organizationId, userId, contactInstanceId })
+}
 
-  const workOrders: string[] = []
-  for (const lineInstanceId of lineInstanceIds) {
-    const workOrder = rels.get(lineInstanceId)?.get(relField.id)
-    if (workOrder) workOrders.push(workOrder)
-  }
-  return workOrders
+const workOrderReconciler = defineParentReconciler<string>({
+  key: BILLING_WORK_ORDER,
+  rebuild: projectWorkOrder,
+})
+
+const lineReconciler = defineParentReconciler<string>({
+  key: BILLING_LINE_ITEM,
+  /**
+   * The work order each source line hangs off, in ONE query. The per-line version
+   * was a `getFieldValues` per line, called once per changed attribute — so a line
+   * whose quantity, price and description all moved in one write cost three round
+   * trips to answer the same question three times.
+   */
+  resolve: (organizationId, lineInstanceIds) =>
+    resolveParentsByRelation(organizationId, 'line_item_work_order', lineInstanceIds),
+  rebuild: projectWorkOrder,
+})
+
+const invoiceReconciler = defineParentReconciler<string>({
+  key: BILLING_INVOICE,
+  rebuild: projectInvoice,
+})
+
+const contactReconciler = defineParentReconciler<string>({
+  key: BILLING_CONTACT,
+  rebuild: projectContact,
+})
+
+/** Register the four drains. Called from `registerAllHooks()`, idempotent per key. */
+export function registerBillingReconcilers(): void {
+  workOrderReconciler.register()
+  lineReconciler.register()
+  invoiceReconciler.register()
+  contactReconciler.register()
 }
 
 /**
  * Mark a work order for projection, or project it now when nothing will drain.
  *
- * The inline fallback is load-bearing — see `markParentDirty`: a caller that
+ * The inline fallback is load-bearing — see `ParentReconciler.mark`: a caller that
  * reached the hook chain through an exported `field-value-mutations` function
- * rather than a public service method has no scope, and without this the
- * work order's contract and uninvoiced amounts would silently stop updating.
+ * rather than a public service method has no scope, and without this the work
+ * order's contract and uninvoiced amounts would silently stop updating.
  */
-export async function markOrSyncWorkOrder(
-  organizationId: string,
-  userId: string,
-  workOrderInstanceId: string
-): Promise<void> {
-  if (markParentDirty(BILLING_WORK_ORDER, workOrderInstanceId)) return
-  await syncEach(organizationId, userId, [workOrderInstanceId], 'work_order')
-}
+export const markOrSyncWorkOrder = workOrderReconciler.mark
 
 /** {@link markOrSyncWorkOrder}'s line-side twin — the parent is resolved in the drain. */
-export async function markOrSyncLine(
-  organizationId: string,
-  userId: string,
-  lineInstanceId: string
-): Promise<void> {
-  if (markParentDirty(BILLING_LINE_ITEM, lineInstanceId)) return
-  const workOrders = await resolveWorkOrdersForLines(organizationId, [lineInstanceId])
-  await syncEach(organizationId, userId, workOrders, 'work_order')
-}
+export const markOrSyncLine = lineReconciler.mark
 
 /** {@link markOrSyncWorkOrder} for the invoice projector. */
-export async function markOrSyncInvoice(
-  organizationId: string,
-  userId: string,
-  invoiceInstanceId: string
-): Promise<void> {
-  if (markParentDirty(BILLING_INVOICE, invoiceInstanceId)) return
-  await syncEach(organizationId, userId, [invoiceInstanceId], 'invoice')
-}
+export const markOrSyncInvoice = invoiceReconciler.mark
 
 /** {@link markOrSyncWorkOrder} for the customer aggregate. */
-export async function markOrSyncContact(
-  organizationId: string,
-  userId: string,
-  contactInstanceId: string
-): Promise<void> {
-  if (markParentDirty(BILLING_CONTACT, contactInstanceId)) return
-  await syncEach(organizationId, userId, [contactInstanceId], 'contact')
-}
+export const markOrSyncContact = contactReconciler.mark

--- a/packages/lib/src/money/totals-reconciler.ts
+++ b/packages/lib/src/money/totals-reconciler.ts
@@ -20,11 +20,16 @@
  * accepted rather than merged: it is rare (a header field and a line body in one
  * operation), and #1953's compare-before-write makes the second pass write
  * nothing.
+ *
+ * This is the one consumer whose parent is NOT a bare instance id — it is
+ * `(documentType, instanceId)` — which is why `dedupeKey` exists on the shared
+ * spec at all, and why the quote -> invoice-without-work-order -> order ladder
+ * below stayed here rather than moving into `resolveParentsByRelation`.
  */
 
 import { getOrgCache } from '../cache'
 import { readFieldRelations } from '../field-values/read-field-scalars'
-import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
+import { defineParentReconciler, resolveParentsByRelation } from '../reconcilers/parent-reconciler'
 import type { TotalledDocumentType } from './totals-hooks'
 
 /** Key per marked entity. See the table above. */
@@ -41,77 +46,70 @@ interface ParentDocument {
   documentInstanceId: string
 }
 
-let registered = false
+/** Two documents are the same document only when BOTH halves match. */
+const documentDedupeKey = (parent: ParentDocument): string =>
+  `${parent.documentType}:${parent.documentInstanceId}`
 
 /**
- * Register the six drains. Called from `registerAllHooks()`, idempotent under a
- * repeated bootstrap the same way `registerAutoBuildRules()` is.
- */
-export function registerMoneyTotalsReconcilers(): void {
-  if (registered) return
-  registered = true
-
-  registerReconciler(
-    MONEY_TOTALS_LINE_ITEM,
-    async ({ organizationId, userId, parentInstanceIds }) => {
-      const parents = await resolveLineParents(organizationId, parentInstanceIds)
-      await recomputeEach(organizationId, userId, parents)
-    }
-  )
-
-  registerReconciler(
-    MONEY_TOTALS_PURCHASE_ORDER_LINE,
-    async ({ organizationId, userId, parentInstanceIds }) => {
-      const parents = await resolvePurchaseOrderLineParents(organizationId, parentInstanceIds)
-      await recomputeEach(organizationId, userId, parents)
-    }
-  )
-
-  for (const documentType of DOCUMENT_TYPES) {
-    registerReconciler(
-      moneyTotalsDocumentKey(documentType),
-      async ({ organizationId, userId, parentInstanceIds }) => {
-        await recomputeEach(
-          organizationId,
-          userId,
-          parentInstanceIds.map((documentInstanceId) => ({ documentType, documentInstanceId }))
-        )
-      }
-    )
-  }
-}
-
-/**
- * Recompute each distinct document once, isolating failures.
+ * Recompute one document.
  *
- * One document failing must not lose the rest of the batch — the same rule the
- * drain applies across keys, applied again within one key, because here a batch
- * is several unrelated user documents rather than one unit of work.
+ * `recomputeTotals` is lazy-imported so this module carries no RUNTIME edge back
+ * to `totals-hooks` — which imports this one. The type import above is erased, so
+ * the cycle is type-only, the same dodge `builds/auto-build-rule.ts` uses for its
+ * orchestrators.
  */
-async function recomputeEach(
+async function recomputeOne(
   organizationId: string,
   userId: string,
-  parents: ParentDocument[]
+  parent: ParentDocument
 ): Promise<void> {
-  if (parents.length === 0) return
-  // Lazy, so this module carries no RUNTIME edge back to `totals-hooks` — which
-  // imports this one. The type import above is erased, so the cycle is
-  // type-only, and the same dodge `builds/auto-build-rule.ts` uses for its
-  // orchestrators keeps it that way.
   const { recomputeTotals } = await import('./totals-hooks')
+  await recomputeTotals({
+    organizationId,
+    userId,
+    documentType: parent.documentType,
+    documentInstanceId: parent.documentInstanceId,
+  })
+}
 
-  const seen = new Set<string>()
-  for (const parent of parents) {
-    const dedupeKey = `${parent.documentType}:${parent.documentInstanceId}`
-    if (seen.has(dedupeKey)) continue
-    seen.add(dedupeKey)
-    await recomputeTotals({
-      organizationId,
-      userId,
-      documentType: parent.documentType,
-      documentInstanceId: parent.documentInstanceId,
-    })
-  }
+const lineReconciler = defineParentReconciler<ParentDocument>({
+  key: MONEY_TOTALS_LINE_ITEM,
+  resolve: resolveLineParents,
+  dedupeKey: documentDedupeKey,
+  rebuild: recomputeOne,
+})
+
+const purchaseOrderLineReconciler = defineParentReconciler<ParentDocument>({
+  key: MONEY_TOTALS_PURCHASE_ORDER_LINE,
+  resolve: resolvePurchaseOrderLineParents,
+  dedupeKey: documentDedupeKey,
+  rebuild: recomputeOne,
+})
+
+/**
+ * One self-reconciler per document type. The marked record IS the parent here, so
+ * there is no `resolve` — the document type comes from the closure rather than
+ * from a lookup, which is what keeps the four keys distinguishable in the buffer.
+ */
+const documentReconcilers = new Map(
+  DOCUMENT_TYPES.map((documentType) => [
+    documentType,
+    defineParentReconciler<string>({
+      key: moneyTotalsDocumentKey(documentType),
+      rebuild: (organizationId, userId, documentInstanceId) =>
+        recomputeOne(organizationId, userId, { documentType, documentInstanceId }),
+    }),
+  ])
+)
+
+/**
+ * Register the six drains. Called from `registerAllHooks()`, idempotent per key
+ * the same way `registerAutoBuildRules()` is.
+ */
+export function registerMoneyTotalsReconcilers(): void {
+  lineReconciler.register()
+  purchaseOrderLineReconciler.register()
+  for (const reconciler of documentReconcilers.values()) reconciler.register()
 }
 
 /**
@@ -121,9 +119,11 @@ async function recomputeEach(
  * source line stamped with `line_item_invoice` must never recompute the
  * invoice), then order.
  *
- * Reading `relatedEntityId` directly is what makes the batch possible; the
- * per-line version issued up to three `getFieldValues` calls to walk the same
- * ladder, so 20 lines cost up to 60 round trips before this.
+ * 🛑 The one parent resolution that did NOT move to `resolveParentsByRelation`,
+ * because it is the only one that reads several relations and ranks them. Reading
+ * `relatedEntityId` directly is what makes the batch possible; the per-line
+ * version issued up to three `getFieldValues` calls to walk the same ladder, so
+ * 20 lines cost up to 60 round trips before this.
  */
 async function resolveLineParents(
   organizationId: string,
@@ -182,31 +182,24 @@ async function resolvePurchaseOrderLineParents(
   organizationId: string,
   lineInstanceIds: string[]
 ): Promise<ParentDocument[]> {
-  const cf = await getOrgCache()
-    .from(organizationId, 'customFields')
-    .bySystemAttributes(['purchase_order_line_purchase_order'] as const)
-  const relField = cf.purchase_order_line_purchase_order
-  if (!relField) return []
-
-  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [relField.id])
-
-  const parents: ParentDocument[] = []
-  for (const lineInstanceId of lineInstanceIds) {
-    const purchaseOrder = rels.get(lineInstanceId)?.get(relField.id)
-    if (purchaseOrder) {
-      parents.push({ documentType: 'purchase_order', documentInstanceId: purchaseOrder })
-    }
-  }
-  return parents
+  const purchaseOrderIds = await resolveParentsByRelation(
+    organizationId,
+    'purchase_order_line_purchase_order',
+    lineInstanceIds
+  )
+  return purchaseOrderIds.map((documentInstanceId) => ({
+    documentType: 'purchase_order' as const,
+    documentInstanceId,
+  }))
 }
 
 /**
  * Mark a document for recompute, or recompute it now when nothing will drain.
  *
- * The inline fallback is load-bearing — see {@link markParentDirty}: a caller
- * that reached the hook chain through an exported `field-value-mutations`
- * function rather than a public service method has no scope, and without this
- * its totals would silently stop updating.
+ * The inline fallback is load-bearing — see `ParentReconciler.mark`: a caller that
+ * reached the hook chain through an exported `field-value-mutations` function
+ * rather than a public service method has no scope, and without this its totals
+ * would silently stop updating.
  */
 export async function markOrRecomputeDocument(
   organizationId: string,
@@ -214,8 +207,7 @@ export async function markOrRecomputeDocument(
   documentType: TotalledDocumentType,
   documentInstanceId: string
 ): Promise<void> {
-  if (markParentDirty(moneyTotalsDocumentKey(documentType), documentInstanceId)) return
-  await recomputeEach(organizationId, userId, [{ documentType, documentInstanceId }])
+  await documentReconcilers.get(documentType)?.mark(organizationId, userId, documentInstanceId)
 }
 
 /** {@link markOrRecomputeDocument}'s line-side twin. */
@@ -225,10 +217,6 @@ export async function markOrRecomputeLine(
   key: typeof MONEY_TOTALS_LINE_ITEM | typeof MONEY_TOTALS_PURCHASE_ORDER_LINE,
   lineInstanceId: string
 ): Promise<void> {
-  if (markParentDirty(key, lineInstanceId)) return
-  const parents =
-    key === MONEY_TOTALS_LINE_ITEM
-      ? await resolveLineParents(organizationId, [lineInstanceId])
-      : await resolvePurchaseOrderLineParents(organizationId, [lineInstanceId])
-  await recomputeEach(organizationId, userId, parents)
+  const reconciler = key === MONEY_TOTALS_LINE_ITEM ? lineReconciler : purchaseOrderLineReconciler
+  await reconciler.mark(organizationId, userId, lineInstanceId)
 }

--- a/packages/lib/src/purchasing/match-reconciler.ts
+++ b/packages/lib/src/purchasing/match-reconciler.ts
@@ -10,106 +10,66 @@
  *
  * Two keys, for the same reason the money reconciler has six: the drain has to
  * know whether it was handed a bill or one of its lines.
+ *
+ * Phase 3 moved the registration, the mark-or-inline pair, the dedupe loop and
+ * the single-relation parent resolve into `reconcilers/parent-reconciler.ts`;
+ * what is left below is the two things that are actually this subsystem's — which
+ * relation a bill line hangs off, and that the rebuild is `rematchBill`.
  */
 
-import { getOrgCache } from '../cache'
-import { readFieldRelations } from '../field-values/read-field-scalars'
-import { markParentDirty, registerReconciler } from '../reconcilers/dirty-parents'
+import { defineParentReconciler, resolveParentsByRelation } from '../reconcilers/parent-reconciler'
 
 export const MATCH_VENDOR_BILL = 'three-way-match:vendor_bill'
 export const MATCH_VENDOR_BILL_LINE = 'three-way-match:vendor_bill_line'
 
-let registered = false
-
-/** Register both drains. Called from `registerAllHooks()`, idempotent. */
-export function registerMatchReconcilers(): void {
-  if (registered) return
-  registered = true
-
-  registerReconciler(MATCH_VENDOR_BILL, async ({ organizationId, userId, parentInstanceIds }) => {
-    await rematchEach(organizationId, userId, parentInstanceIds)
-  })
-
-  registerReconciler(
-    MATCH_VENDOR_BILL_LINE,
-    async ({ organizationId, userId, parentInstanceIds }) => {
-      const bills = await resolveBillsForLines(organizationId, parentInstanceIds)
-      await rematchEach(organizationId, userId, bills)
-    }
-  )
-}
-
 /**
- * Match each distinct bill once, isolating failures.
+ * Match one bill.
  *
- * One bill failing must not lose the rest: a drain batch is several unrelated
- * documents, not one unit of work. `rematchBill` is lazy-imported so this module
- * carries no runtime edge back to `match-hook`, which imports it.
+ * `rematchBill` is lazy-imported so this module carries no runtime edge back to
+ * `match-hook`, which imports it.
  */
-async function rematchEach(
+async function rematchOne(
   organizationId: string,
   userId: string,
-  vendorBillInstanceIds: string[]
+  vendorBillInstanceId: string
 ): Promise<void> {
-  if (vendorBillInstanceIds.length === 0) return
   const { rematchBill } = await import('./match-hook')
-
-  for (const vendorBillInstanceId of new Set(vendorBillInstanceIds)) {
-    await rematchBill({ organizationId, userId, vendorBillInstanceId })
-  }
+  await rematchBill({ organizationId, userId, vendorBillInstanceId })
 }
 
-/**
- * The bill each line hangs off, in ONE query.
- *
- * The per-line version was a `getFieldValues` per line, called once per changed
- * attribute — four round trips for one line whose quantity, price and PO link all
- * moved in the same write.
- */
-async function resolveBillsForLines(
-  organizationId: string,
-  lineInstanceIds: string[]
-): Promise<string[]> {
-  const cf = await getOrgCache()
-    .from(organizationId, 'customFields')
-    .bySystemAttributes(['vendor_bill_line_vendor_bill'] as const)
-  const relField = cf.vendor_bill_line_vendor_bill
-  if (!relField) return []
+const billReconciler = defineParentReconciler<string>({
+  key: MATCH_VENDOR_BILL,
+  rebuild: rematchOne,
+})
 
-  const rels = await readFieldRelations(undefined, organizationId, lineInstanceIds, [relField.id])
+const billLineReconciler = defineParentReconciler<string>({
+  key: MATCH_VENDOR_BILL_LINE,
+  /**
+   * The bill each line hangs off, in ONE query. The per-line version was a
+   * `getFieldValues` per line, called once per changed attribute — four round
+   * trips for one line whose quantity, price and PO link all moved in the same
+   * write.
+   */
+  resolve: (organizationId, lineInstanceIds) =>
+    resolveParentsByRelation(organizationId, 'vendor_bill_line_vendor_bill', lineInstanceIds),
+  rebuild: rematchOne,
+})
 
-  const bills: string[] = []
-  for (const lineInstanceId of lineInstanceIds) {
-    const bill = rels.get(lineInstanceId)?.get(relField.id)
-    if (bill) bills.push(bill)
-  }
-  return bills
+/** Register both drains. Called from `registerAllHooks()`, idempotent per key. */
+export function registerMatchReconcilers(): void {
+  billReconciler.register()
+  billLineReconciler.register()
 }
 
 /**
  * Mark a bill for rematch, or rematch it now when nothing will drain.
  *
- * The inline fallback is load-bearing — see `markParentDirty`: a caller that
+ * The inline fallback is load-bearing — see `ParentReconciler.mark`: a caller that
  * reached the hook chain through an exported `field-value-mutations` function
  * rather than a public service method has no scope, and without this the bill
  * would silently stop leaving the exception queue.
  */
-export async function markOrRematchBill(
-  organizationId: string,
-  userId: string,
-  vendorBillInstanceId: string
-): Promise<void> {
-  if (markParentDirty(MATCH_VENDOR_BILL, vendorBillInstanceId)) return
-  await rematchEach(organizationId, userId, [vendorBillInstanceId])
-}
+export const markOrRematchBill = billReconciler.mark
 
-/** {@link markOrRematchBill}'s line-side twin. */
-export async function markOrRematchBillLine(
-  organizationId: string,
-  userId: string,
-  lineInstanceId: string
-): Promise<void> {
-  if (markParentDirty(MATCH_VENDOR_BILL_LINE, lineInstanceId)) return
-  const bills = await resolveBillsForLines(organizationId, [lineInstanceId])
-  await rematchEach(organizationId, userId, bills)
-}
+/** {@link markOrRematchBill}'s line-side twin — the bill is resolved in the drain. */
+export const markOrRematchBillLine = billLineReconciler.mark

--- a/packages/lib/src/reconcilers/__tests__/parent-reconciler.test.ts
+++ b/packages/lib/src/reconcilers/__tests__/parent-reconciler.test.ts
@@ -1,0 +1,276 @@
+// packages/lib/src/reconcilers/__tests__/parent-reconciler.test.ts
+//
+// Plan 08 phase 3. `dirty-parents.test.ts` pins the BUFFER — when work runs.
+// This pins the layer above it: how a marked id becomes a deduped set of parents,
+// and what happens when nothing is there to drain into.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { __resetReconcilersForTest, runWithDirtyParents } from '../dirty-parents'
+import { defineParentReconciler } from '../parent-reconciler'
+
+const ORG = 'org_1'
+const USER = 'usr_1'
+
+beforeEach(() => {
+  __resetReconcilersForTest()
+})
+
+describe('the self case — the marked record IS the parent', () => {
+  it('passes marked ids straight through as parents', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({ key: 'k', rebuild })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await r.mark(ORG, USER, 'p-1')
+      await r.mark(ORG, USER, 'p-2')
+    })
+
+    expect(rebuild.mock.calls.map((c) => c[2])).toEqual(['p-1', 'p-2'])
+  })
+
+  it('coalesces repeated marks of one parent into a single rebuild', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({ key: 'k', rebuild })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (let i = 0; i < 20; i++) await r.mark(ORG, USER, 'p-1')
+    })
+
+    expect(rebuild).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the child case — the marked record is resolved to a parent', () => {
+  it('calls resolve ONCE with the whole batch, not once per child', async () => {
+    const resolve = vi.fn(async () => ['doc-1'])
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({ key: 'k', resolve, rebuild })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (const id of ['c-1', 'c-2', 'c-3']) await r.mark(ORG, USER, id)
+    })
+
+    // The entire point of the drain: one resolution query for the batch.
+    expect(resolve).toHaveBeenCalledTimes(1)
+    expect(resolve.mock.calls[0]![1]).toEqual(['c-1', 'c-2', 'c-3'])
+    expect(rebuild).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds nothing when every child is orphaned', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async () => [],
+      rebuild,
+    })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await r.mark(ORG, USER, 'c-1')
+    })
+
+    expect(rebuild).not.toHaveBeenCalled()
+  })
+
+  it('collapses many children of one parent into a single rebuild', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async (_org, ids) => ids.map(() => 'doc-1'),
+      rebuild,
+    })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      for (const id of ['c-1', 'c-2', 'c-3']) await r.mark(ORG, USER, id)
+    })
+
+    expect(rebuild).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('dedupeKey', () => {
+  interface Doc {
+    documentType: string
+    documentInstanceId: string
+  }
+
+  it('treats a composite parent as one parent only when BOTH halves match', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<Doc>({
+      key: 'k',
+      resolve: async () => [
+        { documentType: 'quote', documentInstanceId: 'x' },
+        { documentType: 'invoice', documentInstanceId: 'x' }, // same id, other type
+        { documentType: 'quote', documentInstanceId: 'x' }, // a real duplicate
+      ],
+      dedupeKey: (p) => `${p.documentType}:${p.documentInstanceId}`,
+      rebuild,
+    })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await r.mark(ORG, USER, 'c-1')
+    })
+
+    // Without the composite key the invoice would be swallowed by the quote,
+    // which is money's exact failure mode: two documents share an id keyspace.
+    expect(rebuild.mock.calls.map((c) => (c[2] as Doc).documentType)).toEqual(['quote', 'invoice'])
+  })
+
+  it('falls back to the parent itself when no dedupeKey is given', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async () => ['a', 'b', 'a'],
+      rebuild,
+    })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await r.mark(ORG, USER, 'c-1')
+    })
+
+    expect(rebuild.mock.calls.map((c) => c[2])).toEqual(['a', 'b'])
+  })
+})
+
+describe('the unscoped inline fallback', () => {
+  it('does the work immediately when no write method opened a scope', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({ key: 'k', rebuild })
+    r.register()
+
+    // No `runWithDirtyParents` — the shape of a caller that reached the hook
+    // chain through an exported `field-value-mutations` function.
+    await r.mark(ORG, USER, 'p-1')
+
+    expect(rebuild).toHaveBeenCalledTimes(1)
+    expect(rebuild.mock.calls[0]![2]).toBe('p-1')
+  })
+
+  it('resolves the parent inline too, for a child mark', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async () => ['doc-1'],
+      rebuild,
+    })
+    r.register()
+
+    await r.mark(ORG, USER, 'c-1')
+
+    expect(rebuild.mock.calls[0]![2]).toBe('doc-1')
+  })
+
+  it('still works when register() was never called — the inline path skips the registry', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({ key: 'k', rebuild })
+
+    await r.mark(ORG, USER, 'p-1')
+
+    expect(rebuild).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('rebuildBatch', () => {
+  it('receives the whole deduped batch once, for a consumer with per-batch setup', async () => {
+    const rebuildBatch = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async () => ['o-1', 'o-2', 'o-1'],
+      rebuildBatch,
+    })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await r.mark(ORG, USER, 'c-1')
+    })
+
+    expect(rebuildBatch).toHaveBeenCalledTimes(1)
+    expect(rebuildBatch.mock.calls[0]![2]).toEqual(['o-1', 'o-2'])
+  })
+
+  it('is not called at all for an empty batch', async () => {
+    const rebuildBatch = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async () => [],
+      rebuildBatch,
+    })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await r.mark(ORG, USER, 'c-1')
+    })
+
+    expect(rebuildBatch).not.toHaveBeenCalled()
+  })
+})
+
+describe('register', () => {
+  it('is idempotent — a repeated bootstrap does not install two drains', async () => {
+    const rebuild = vi.fn(async () => {})
+    const r = defineParentReconciler<string>({ key: 'k', rebuild })
+    r.register()
+    r.register()
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await r.mark(ORG, USER, 'p-1')
+    })
+
+    expect(rebuild).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('failure isolation is per KEY, not per parent', () => {
+  it('a throwing parent DOES lose the parents after it, and never reaches the writer', async () => {
+    const rebuild = vi.fn(async (_org: string, _user: string, parent: string) => {
+      if (parent === 'b') throw new Error('boom')
+    })
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async () => ['a', 'b', 'c'],
+      rebuild,
+    })
+    r.register()
+
+    // Pinning the SHIPPED behaviour, which is not what three of the four
+    // consumers' doc comments used to claim. `drainDirtyParents` catches per
+    // KEY, so a mid-batch throw abandons the remainder of that key's batch —
+    // `c` never rebuilds. It is still swallowed before it reaches the writer,
+    // because the write has already committed and a reconciler failure must
+    // never surface as a command failure.
+    await expect(
+      runWithDirtyParents(ORG, USER, async () => {
+        await r.mark(ORG, USER, 'c-1')
+      })
+    ).resolves.toBeUndefined()
+
+    expect(rebuild.mock.calls.map((c) => c[2])).toEqual(['a', 'b'])
+  })
+
+  it('another key still drains after one key throws', async () => {
+    const good = vi.fn(async () => {})
+    const bad = defineParentReconciler<string>({
+      key: 'bad',
+      rebuild: async () => {
+        throw new Error('boom')
+      },
+    })
+    const ok = defineParentReconciler<string>({ key: 'good', rebuild: good })
+    bad.register()
+    ok.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await bad.mark(ORG, USER, 'x')
+      await ok.mark(ORG, USER, 'y')
+    })
+
+    expect(good).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/reconcilers/__tests__/resolve-parents-by-relation.test.ts
+++ b/packages/lib/src/reconcilers/__tests__/resolve-parents-by-relation.test.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/reconcilers/__tests__/resolve-parents-by-relation.test.ts
+//
+// Four of the five parent resolutions across the shipped consumers were this
+// function copied verbatim with a different systemAttribute, so a regression here
+// is four subsystems wide: the vendor bill of a bill line, the work order of a
+// source line, the order of an order line, the purchase order of a PO line.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  readFieldRelations: vi.fn(),
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../field-values/read-field-scalars', () => ({
+  readFieldRelations: h.readFieldRelations,
+}))
+
+import { resolveParentsByRelation } from '../parent-reconciler'
+
+const ORG = 'org_1'
+const ATTR = 'vendor_bill_line_vendor_bill'
+
+/** `childId -> fieldId -> parentId`, the shape `readFieldRelations` returns. */
+function rels(entries: Array<[string, string]>) {
+  return new Map(entries.map(([child, parent]) => [child, new Map([['f-rel', parent]])]))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.bySystemAttributes.mockResolvedValue({ [ATTR]: { id: 'f-rel' } })
+  h.readFieldRelations.mockResolvedValue(new Map())
+})
+
+describe('resolveParentsByRelation', () => {
+  it('reads every child in ONE relation query', async () => {
+    h.readFieldRelations.mockResolvedValue(
+      rels([
+        ['c-1', 'p-1'],
+        ['c-2', 'p-2'],
+      ])
+    )
+
+    const parents = await resolveParentsByRelation(ORG, ATTR as never, ['c-1', 'c-2'])
+
+    expect(h.readFieldRelations).toHaveBeenCalledTimes(1)
+    expect(h.readFieldRelations.mock.calls[0]![2]).toEqual(['c-1', 'c-2'])
+    expect(parents).toEqual(['p-1', 'p-2'])
+  })
+
+  it('returns one entry per child, so two children of one parent yield it twice', async () => {
+    h.readFieldRelations.mockResolvedValue(
+      rels([
+        ['c-1', 'p-1'],
+        ['c-2', 'p-1'],
+      ])
+    )
+
+    // Duplicates are intentional here — `defineParentReconciler` dedupes. Filtering
+    // twice would just hide which child contributed what.
+    expect(await resolveParentsByRelation(ORG, ATTR as never, ['c-1', 'c-2'])).toEqual([
+      'p-1',
+      'p-1',
+    ])
+  })
+
+  it('drops an orphaned child rather than yielding a hole', async () => {
+    h.readFieldRelations.mockResolvedValue(rels([['c-2', 'p-2']]))
+
+    expect(await resolveParentsByRelation(ORG, ATTR as never, ['c-1', 'c-2'])).toEqual(['p-2'])
+  })
+
+  it('preserves the order the children were given', async () => {
+    h.readFieldRelations.mockResolvedValue(
+      rels([
+        ['c-2', 'p-2'],
+        ['c-1', 'p-1'],
+      ])
+    )
+
+    expect(await resolveParentsByRelation(ORG, ATTR as never, ['c-1', 'c-2'])).toEqual([
+      'p-1',
+      'p-2',
+    ])
+  })
+
+  it('yields nothing, and queries nothing, when the org lacks the field', async () => {
+    h.bySystemAttributes.mockResolvedValue({ [ATTR]: null })
+
+    expect(await resolveParentsByRelation(ORG, ATTR as never, ['c-1'])).toEqual([])
+    // An unmigrated org has nothing to reconcile. Failing loudly would turn every
+    // write in that org into a logged error.
+    expect(h.readFieldRelations).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/reconcilers/parent-reconciler.ts
+++ b/packages/lib/src/reconcilers/parent-reconciler.ts
@@ -1,0 +1,207 @@
+// packages/lib/src/reconcilers/parent-reconciler.ts
+
+/**
+ * Phase 3 of `plans/events/08-derived-parent-reconciler-plan.md`: the machinery
+ * every dirty-parent consumer was hand-rolling, factored out once.
+ *
+ * `dirty-parents.ts` is the buffer — it answers *when* work runs. This is the
+ * layer above it, and it answers the three questions every consumer of that
+ * buffer had to answer identically:
+ *
+ * 1. how do I register a drain, idempotently;
+ * 2. how do I mark, and what do I do when there is no scope to mark into;
+ * 3. how do I turn a batch of marked ids into a deduped set of parents and
+ *    rebuild each one.
+ *
+ * Four consumers answered all three the same way, in about sixty lines apiece.
+ *
+ * ## What this deliberately does NOT contain
+ *
+ * No `apply`, no `project`, no `revisionAttr`. Plan 08 §4's original contract
+ * imagined all three; §4.2 records that when the drift consumer finally shipped
+ * it supplied the first two and **did not need the third at all**. So the rule
+ * applied here is: a member earns its place when TWO consumers share it. The
+ * drift revision stamp, money's document-type ladder and billing's
+ * three-projector switch each live in exactly one consumer and each stays there.
+ */
+
+import type { SystemAttribute } from '@auxx/types/system-attribute'
+import { getOrgCache } from '../cache'
+import { readFieldRelations } from '../field-values/read-field-scalars'
+import { markParentDirty, registerReconciler } from './dirty-parents'
+
+/**
+ * Turn the ids a drain was handed into the parents that need rebuilding.
+ *
+ * Batched by contract: it receives the WHOLE batch and is expected to answer in
+ * one query, which is the entire reason the drain exists. Returning duplicates is
+ * fine — the spec dedupes before rebuilding.
+ */
+type ResolveParents<P> = (organizationId: string, childInstanceIds: string[]) => Promise<P[]>
+
+interface BaseSpec<P> {
+  /** The `dirty-parents` key. One per shape of thing that can be marked. */
+  key: string
+  /**
+   * Present when the marked record is a CHILD of the parent; omitted when the
+   * marked record IS the parent.
+   */
+  resolve?: ResolveParents<P>
+  /**
+   * Two parents are the same parent when this matches. Defaults to `String(p)`,
+   * which is right for the common case where a parent is a bare instance id and
+   * wrong for money's, whose parent is `(documentType, instanceId)`.
+   */
+  dedupeKey?: (parent: P) => string
+}
+
+/** Rebuild one parent. The common case. */
+interface PerParentSpec<P> extends BaseSpec<P> {
+  rebuild: (organizationId: string, userId: string, parent: P) => Promise<void>
+  rebuildBatch?: never
+}
+
+/**
+ * Rebuild a whole deduped batch at once.
+ *
+ * The escape hatch for a consumer whose rebuild has real per-BATCH setup —
+ * `builds/drift-reconciler.ts` loads settings, orders, fields and stored
+ * fingerprints once for the batch and then walks it, so forcing it through a
+ * per-parent callback would reintroduce exactly the N+1 this whole plan removed.
+ */
+interface BatchSpec<P> extends BaseSpec<P> {
+  rebuildBatch: (organizationId: string, userId: string, parents: P[]) => Promise<void>
+  rebuild?: never
+}
+
+export type ParentReconcilerSpec<P> = PerParentSpec<P> | BatchSpec<P>
+
+/** What {@link defineParentReconciler} hands back. */
+export interface ParentReconciler {
+  /**
+   * Register the drain. Idempotent per key, so the module-level `let registered`
+   * latch every consumer used to carry is no longer needed — `registerReconciler`
+   * already ignores a second registration of the same key.
+   */
+  register: () => void
+  /**
+   * Mark, or do the work now when nothing will drain.
+   *
+   * The inline branch is load-bearing, not defensive tidiness.
+   * `field-value-mutations`' functions are exported and called directly
+   * (`field-hooks/post/purchase-order-line-rollups.ts` calls
+   * `setValueWithType(ctx, ...)`), so a write can fire the hook chain without ever
+   * passing a public service method. `markParentDirty` returns `false` in exactly
+   * that case, and without this branch those writes would silently stop updating
+   * derived values, with no error anywhere.
+   */
+  mark: (organizationId: string, userId: string, markedInstanceId: string) => Promise<void>
+}
+
+/**
+ * Build one reconciler: a registrable drain plus its mark-or-do-it-inline entry.
+ *
+ * Call at module scope and keep the handle; call `register()` from the module's
+ * `registerXReconcilers()` so registration still happens inside
+ * `registerAllHooks()` and not as an import side effect. `mark` works either way
+ * — the inline path never consults the registry.
+ */
+export function defineParentReconciler<P>(spec: ParentReconcilerSpec<P>): ParentReconciler {
+  return {
+    register: () => {
+      registerReconciler(spec.key, async ({ organizationId, userId, parentInstanceIds }) => {
+        const parents = await toParents(spec, organizationId, parentInstanceIds)
+        await rebuildAll(spec, organizationId, userId, parents)
+      })
+    },
+    mark: async (organizationId, userId, markedInstanceId) => {
+      if (markParentDirty(spec.key, markedInstanceId)) return
+      const parents = await toParents(spec, organizationId, [markedInstanceId])
+      await rebuildAll(spec, organizationId, userId, parents)
+    },
+  }
+}
+
+/**
+ * Marked ids to parents. Without a `resolve` the marked record IS the parent, so
+ * the ids pass through — the cast is safe because a spec with no `resolve` can
+ * only have been written with `P = string`.
+ */
+function toParents<P>(
+  spec: ParentReconcilerSpec<P>,
+  organizationId: string,
+  markedInstanceIds: string[]
+): Promise<P[]> {
+  if (!spec.resolve) return Promise.resolve(markedInstanceIds as unknown as P[])
+  return spec.resolve(organizationId, markedInstanceIds)
+}
+
+/**
+ * Dedupe, then rebuild.
+ *
+ * No per-parent `try`/`catch`, deliberately: this preserves the shipped behaviour
+ * exactly. Isolation today is per-KEY, in `drainDirtyParents`, so one parent
+ * throwing mid-batch loses the parents after it. Three of the four consumers
+ * carry a doc comment claiming otherwise. Fixing that is a behaviour change and
+ * is not this refactor's to make.
+ */
+async function rebuildAll<P>(
+  spec: ParentReconcilerSpec<P>,
+  organizationId: string,
+  userId: string,
+  parents: P[]
+): Promise<void> {
+  if (parents.length === 0) return
+
+  const seen = new Set<string>()
+  const deduped: P[] = []
+  for (const parent of parents) {
+    const key = spec.dedupeKey ? spec.dedupeKey(parent) : String(parent)
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(parent)
+  }
+
+  if (spec.rebuildBatch) {
+    await spec.rebuildBatch(organizationId, userId, deduped)
+    return
+  }
+  for (const parent of deduped) {
+    await spec.rebuild(organizationId, userId, parent)
+  }
+}
+
+/**
+ * The parent of each child, through ONE relationship field, in ONE query.
+ *
+ * Four of the five parent resolutions across the shipped consumers were this
+ * function copied verbatim with a different systemAttribute: the vendor bill of a
+ * bill line, the work order of a source line, the order of an order line, the
+ * purchase order of a PO line. The fifth (money's quote -> invoice-without-work-order
+ * -> order ladder) is genuinely different and stays where it is.
+ *
+ * Returns one entry per child that HAS a parent, in the order the children were
+ * given; an orphaned child simply contributes nothing. An org missing the field
+ * yields an empty list rather than an error — there is nothing to reconcile, and
+ * failing loudly would turn every write in an unmigrated org into a logged error.
+ */
+export async function resolveParentsByRelation(
+  organizationId: string,
+  systemAttribute: SystemAttribute,
+  childInstanceIds: string[]
+): Promise<string[]> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes<SystemAttribute>([systemAttribute])
+  const relField = fields[systemAttribute]
+  if (!relField) return []
+
+  const rels = await readFieldRelations(undefined, organizationId, childInstanceIds, [relField.id])
+
+  const parents: string[] = []
+  for (const childInstanceId of childInstanceIds) {
+    const parent = rels.get(childInstanceId)?.get(relField.id)
+    if (parent) parents.push(parent)
+  }
+  return parents
+}


### PR DESCRIPTION
Phase 3 of `plans/events/08-derived-parent-reconciler-plan.md`. Follows #1953, #1955, #1956, #1957, #1958.

**Behaviour-neutral.** The strongest evidence is that **every existing test passes with no edits at all** — `money/totals-coalescing.test.ts`, `purchasing/__tests__/match-hook.test.ts`, `money/billing-coalescing.test.ts`, `builds/__tests__/drift-*.test.ts` and `reconcilers/__tests__/dirty-parents.test.ts`. 46 files / 847 tests across the four consumers, untouched.

## What was duplicated

`dirty-parents.ts` is the buffer — it answers *when* work runs. Above it, four consumers had each hand-rolled the same three answers:

1. how to register a drain, idempotently;
2. how to mark, and what to do when there is no scope to mark into;
3. how to turn a batch of marked ids into a deduped set of parents and rebuild each one.

`reconcilers/parent-reconciler.ts` is those three, once.

| consumer | code lines before | after | delta |
| --- | --- | --- | --- |
| `purchasing/match-reconciler` | 79 | 39 | **−40** |
| `money/billing-reconciler` | 121 | 75 | **−46** |
| `builds/drift-reconciler` | 123 | 103 | **−20** |
| `money/totals-reconciler` | 172 | 154 | **−18** |
| consumers | 495 | 371 | **−124** |
| `parent-reconciler` (new) | — | 103 | +103 |

(Comments excluded.) Net −21, which is **not** the point and I would rather say so than dress it up: the win is that the machinery now exists once, so a fifth consumer costs its own ~20 lines of resolve-and-rebuild instead of ~60 lines of copied plumbing. Money sheds least because its ladder is bespoke and it constructs four document reconcilers.

`resolveParentsByRelation` is the other half. Four of the five parent resolutions were the same function with a different systemAttribute — the vendor bill of a bill line, the work order of a source line, the order of an order line, the purchase order of a PO line. Money's quote → invoice-without-work-order → order ladder is genuinely different and stays where it is.

## What is deliberately NOT extracted

Plan 08 §4.2's rule is that a member earns its place when **two** consumers share it. By that test:

- **`apply` — not built.** No shipped consumer has one. §4's original contract imagined `project`/`revisionAttr`/`apply`; #1958 supplied the first two and needed nothing like the third.
- **The drift revision stamp**, **money's document-type ladder**, **billing's three-projector switch** — one consumer each, all stay put.

## Two behaviours preserved rather than improved

**Dedupe is by `dedupeKey`.** Money's parent is `(documentType, instanceId)` and two document types share an id keyspace, so a bare-id `Set` would silently swallow one of them. Pinned by a test that would fail on the naive version.

**Failure isolation is per KEY, not per parent.** `drainDirtyParents` catches inside its `for (const [key, ids])` loop, so a mid-batch throw abandons the remainder of *that key's* batch. Three of the four consumers carried a doc comment claiming otherwise (`"One document failing must not lose the rest of the batch"`, and twins in `rematchEach` / `syncEach`). Only `builds` actually had per-parent isolation, and it keeps its own.

I removed the false comments and pinned the real behaviour in a test, but **did not change it** — adding per-parent isolation is a behaviour change and belongs in its own PR with its own argument. Flagged for a decision.

## Tests

- **`parent-reconciler.test.ts`** (15) — self and child cases, `resolve` called once with the whole batch, coalescing, composite vs default dedupe, the unscoped inline fallback (including when `register()` was never called), `rebuildBatch`, idempotent registration, and both halves of the isolation story.
- **`resolve-parents-by-relation.test.ts`** (11) — one query for many children, one entry per child, orphans dropped, input order preserved, and no query at all when the org lacks the field.

## Verification

- `node scripts/ci/typecheck-ratchet.js --package lib` — **29 total, baseline 29** (after `pnpm install` in the worktree; without it the ratchet reports a false pass)
- `pnpm exec biome check` — clean on all 7 files
- Full `packages/lib` suite — 1029 passed, **2 pre-existing timeouts**, both outside this PR's blast radius:
  - `events/handlers/resolve-resource-trigger-match.test.ts` — the known flake, ~8.9s against a 10s budget
  - `workflows/__tests__/workflow-draft-cas.test.ts` — **verified failing identically on pristine `main`** with none of these changes present, so it is not caused by this PR. Worth its own timeout bump alongside the other one.
