### PR TITLE
fix(reconcilers): isolate each parent, as three consumers already claimed

### DIFF
--- a/packages/lib/src/reconcilers/__tests__/parent-reconciler.test.ts
+++ b/packages/lib/src/reconcilers/__tests__/parent-reconciler.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 
 describe('the self case — the marked record IS the parent', () => {
   it('passes marked ids straight through as parents', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({ key: 'k', rebuild })
     r.register()
 
@@ -30,7 +30,7 @@ describe('the self case — the marked record IS the parent', () => {
   })
 
   it('coalesces repeated marks of one parent into a single rebuild', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({ key: 'k', rebuild })
     r.register()
 
@@ -44,8 +44,8 @@ describe('the self case — the marked record IS the parent', () => {
 
 describe('the child case — the marked record is resolved to a parent', () => {
   it('calls resolve ONCE with the whole batch, not once per child', async () => {
-    const resolve = vi.fn(async () => ['doc-1'])
-    const rebuild = vi.fn(async () => {})
+    const resolve = vi.fn(async (_org: string, _ids: string[]) => ['doc-1'])
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({ key: 'k', resolve, rebuild })
     r.register()
 
@@ -60,7 +60,7 @@ describe('the child case — the marked record is resolved to a parent', () => {
   })
 
   it('rebuilds nothing when every child is orphaned', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({
       key: 'k',
       resolve: async () => [],
@@ -76,7 +76,7 @@ describe('the child case — the marked record is resolved to a parent', () => {
   })
 
   it('collapses many children of one parent into a single rebuild', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({
       key: 'k',
       resolve: async (_org, ids) => ids.map(() => 'doc-1'),
@@ -99,7 +99,7 @@ describe('dedupeKey', () => {
   }
 
   it('treats a composite parent as one parent only when BOTH halves match', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<Doc>({
       key: 'k',
       resolve: async () => [
@@ -122,7 +122,7 @@ describe('dedupeKey', () => {
   })
 
   it('falls back to the parent itself when no dedupeKey is given', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({
       key: 'k',
       resolve: async () => ['a', 'b', 'a'],
@@ -140,7 +140,7 @@ describe('dedupeKey', () => {
 
 describe('the unscoped inline fallback', () => {
   it('does the work immediately when no write method opened a scope', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({ key: 'k', rebuild })
     r.register()
 
@@ -153,7 +153,7 @@ describe('the unscoped inline fallback', () => {
   })
 
   it('resolves the parent inline too, for a child mark', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({
       key: 'k',
       resolve: async () => ['doc-1'],
@@ -167,7 +167,7 @@ describe('the unscoped inline fallback', () => {
   })
 
   it('still works when register() was never called — the inline path skips the registry', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({ key: 'k', rebuild })
 
     await r.mark(ORG, USER, 'p-1')
@@ -178,7 +178,7 @@ describe('the unscoped inline fallback', () => {
 
 describe('rebuildBatch', () => {
   it('receives the whole deduped batch once, for a consumer with per-batch setup', async () => {
-    const rebuildBatch = vi.fn(async () => {})
+    const rebuildBatch = vi.fn(async (_org: string, _user: string, _parents: unknown[]) => {})
     const r = defineParentReconciler<string>({
       key: 'k',
       resolve: async () => ['o-1', 'o-2', 'o-1'],
@@ -195,7 +195,7 @@ describe('rebuildBatch', () => {
   })
 
   it('is not called at all for an empty batch', async () => {
-    const rebuildBatch = vi.fn(async () => {})
+    const rebuildBatch = vi.fn(async (_org: string, _user: string, _parents: unknown[]) => {})
     const r = defineParentReconciler<string>({
       key: 'k',
       resolve: async () => [],
@@ -213,7 +213,7 @@ describe('rebuildBatch', () => {
 
 describe('register', () => {
   it('is idempotent — a repeated bootstrap does not install two drains', async () => {
-    const rebuild = vi.fn(async () => {})
+    const rebuild = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const r = defineParentReconciler<string>({ key: 'k', rebuild })
     r.register()
     r.register()
@@ -227,8 +227,8 @@ describe('register', () => {
   })
 })
 
-describe('failure isolation is per KEY, not per parent', () => {
-  it('a throwing parent DOES lose the parents after it, and never reaches the writer', async () => {
+describe('failure isolation is per PARENT', () => {
+  it('a throwing parent does not lose the parents after it', async () => {
     const rebuild = vi.fn(async (_org: string, _user: string, parent: string) => {
       if (parent === 'b') throw new Error('boom')
     })
@@ -239,23 +239,57 @@ describe('failure isolation is per KEY, not per parent', () => {
     })
     r.register()
 
-    // Pinning the SHIPPED behaviour, which is not what three of the four
-    // consumers' doc comments used to claim. `drainDirtyParents` catches per
-    // KEY, so a mid-batch throw abandons the remainder of that key's batch —
-    // `c` never rebuilds. It is still swallowed before it reaches the writer,
-    // because the write has already committed and a reconciler failure must
-    // never surface as a command failure.
+    // A drain batch is several UNRELATED user documents, so one failing must not
+    // decide the fate of the rest. This inverts what #1959 pinned: that test
+    // recorded the shipped behaviour (a mid-batch throw abandoned `c`), which
+    // contradicted the doc comments three consumers carried and the isolation
+    // `builds/drift-reconciler.ts` had actually implemented. Plan 08 §6.3.
     await expect(
       runWithDirtyParents(ORG, USER, async () => {
         await r.mark(ORG, USER, 'c-1')
       })
     ).resolves.toBeUndefined()
 
-    expect(rebuild.mock.calls.map((c) => c[2])).toEqual(['a', 'b'])
+    expect(rebuild.mock.calls.map((c) => c[2])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('isolates every failure, not just the first', async () => {
+    const rebuild = vi.fn(async (_org: string, _user: string, parent: string) => {
+      if (parent !== 'c') throw new Error('boom')
+    })
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async () => ['a', 'b', 'c'],
+      rebuild,
+    })
+    r.register()
+
+    await runWithDirtyParents(ORG, USER, async () => {
+      await r.mark(ORG, USER, 'c-1')
+    })
+
+    expect(rebuild).toHaveBeenCalledTimes(3)
+  })
+
+  it('still never surfaces a failure to the writer — the write already committed', async () => {
+    const r = defineParentReconciler<string>({
+      key: 'k',
+      resolve: async () => ['a'],
+      rebuild: async () => {
+        throw new Error('boom')
+      },
+    })
+    r.register()
+
+    await expect(
+      runWithDirtyParents(ORG, USER, async () => {
+        await r.mark(ORG, USER, 'c-1')
+      })
+    ).resolves.toBeUndefined()
   })
 
   it('another key still drains after one key throws', async () => {
-    const good = vi.fn(async () => {})
+    const good = vi.fn(async (_org: string, _user: string, _parent: unknown) => {})
     const bad = defineParentReconciler<string>({
       key: 'bad',
       rebuild: async () => {

--- a/packages/lib/src/reconcilers/parent-reconciler.ts
+++ b/packages/lib/src/reconcilers/parent-reconciler.ts
@@ -25,9 +25,13 @@
  * three-projector switch each live in exactly one consumer and each stays there.
  */
 
+import { createScopedLogger } from '@auxx/logger'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { getOrgCache } from '../cache'
 import { readFieldRelations } from '../field-values/read-field-scalars'
+
+const logger = createScopedLogger('reconcilers:parent-reconciler')
+
 import { markParentDirty, registerReconciler } from './dirty-parents'
 
 /**
@@ -137,13 +141,30 @@ function toParents<P>(
 }
 
 /**
- * Dedupe, then rebuild.
+ * Dedupe, then rebuild — **isolating each parent**.
  *
- * No per-parent `try`/`catch`, deliberately: this preserves the shipped behaviour
- * exactly. Isolation today is per-KEY, in `drainDirtyParents`, so one parent
- * throwing mid-batch loses the parents after it. Three of the four consumers
- * carry a doc comment claiming otherwise. Fixing that is a behaviour change and
- * is not this refactor's to make.
+ * A drain batch is several UNRELATED user documents, not one unit of work: two
+ * quotes edited in the same paste, ten bills touched by one import. One of them
+ * failing must not decide the fate of the rest, and before this it did — the only
+ * `catch` was per-KEY in `drainDirtyParents`, so a parent throwing mid-batch
+ * silently abandoned every parent after it in the same key.
+ *
+ * 🛑 That is not a behaviour this codebase chose. Three of the four consumers
+ * carried a doc comment asserting the opposite — *"One document failing must not
+ * lose the rest of the batch"* — and the code never did it; only
+ * `builds/drift-reconciler.ts` actually implemented it, inside its own loop. The
+ * comment was the intent and the code was the accident, so this makes the code
+ * match, and makes the four consumers consistent with each other. History and
+ * the argument: `plans/events/08-derived-parent-reconciler-plan.md` §6.3.
+ *
+ * The failure stays LOUD — one log line per failed parent, naming it — because
+ * the real risk of per-parent catching is a systematic failure arriving as a
+ * trickle rather than a bang. The drain-level `catch` above still exists and
+ * still reports; this one only stops a single bad parent taking its siblings.
+ *
+ * `rebuildBatch` is deliberately NOT wrapped: its one caller already isolates per
+ * order internally, and wrapping the call would re-add the per-key behaviour this
+ * is fixing.
  */
 async function rebuildAll<P>(
   spec: ParentReconcilerSpec<P>,
@@ -167,7 +188,16 @@ async function rebuildAll<P>(
     return
   }
   for (const parent of deduped) {
-    await spec.rebuild(organizationId, userId, parent)
+    try {
+      await spec.rebuild(organizationId, userId, parent)
+    } catch (error) {
+      logger.error('reconciler failed for one parent; continuing with the rest', {
+        key: spec.key,
+        organizationId,
+        parent: spec.dedupeKey ? spec.dedupeKey(parent) : String(parent),
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
   }
 }
 


### PR DESCRIPTION
Follow-up to #1959, which found this and correctly declined to fix it.

## The defect

`money/totals-reconciler.ts` shipped in #1955 carrying this comment on its rebuild loop:

> *"Recompute each distinct document once, **isolating failures**. One document failing must not lose the rest of the batch."*

There was no `try`/`catch` in that loop. The same claim was copied into `purchasing/match-reconciler.ts` (#1956) and `money/billing-reconciler.ts` (#1957). Only `builds/drift-reconciler.ts` (#1958) actually implemented it, inside its own loop.

What *was* real is one level up: `drainDirtyParents` wraps `await drain(...)` per **key**, so a parent throwing mid-batch silently abandoned every parent after it in that key.

That's the wrong granularity. A drain batch is several **unrelated user documents** — two quotes edited in one paste, ten bills touched by one import — not one unit of work. The comment was the intent and the code was the accident.

## Why now, and not in #1959

#1959 deleted the false comments and pinned the shipped behaviour in a test rather than changing it. That was the right call: this is a behaviour change, and a refactor PR is not where to make one. The argument for and against is written up in `plans/events/08-derived-parent-reconciler-plan.md` §6.3 — the case *against* being that a per-parent catch can hide a systematic failure as a trickle of logs rather than one bang.

That's answered by keeping the failure loud: one `logger.error` per failed parent, naming it. The drain-level catch still exists and still reports; this one only stops a single bad parent taking its siblings down.

## The extraction paying for itself

Because #1959 centralised the rebuild loop, this is **one** `try`/`catch` in the primitive rather than three in the consumers — and all four now behave the way `builds` already did.

`rebuildBatch` is deliberately not wrapped: its one caller (`builds`) already isolates per order internally, and wrapping the batch call would re-add exactly the per-key behaviour this fixes.

## The test that had to invert

`parent-reconciler.test.ts`'s `'a throwing parent DOES lose the parents after it'` pinned the old behaviour deliberately. It now asserts the opposite, with a comment saying why and pointing at §6.3 — plus two siblings: that *every* failure is isolated (not just the first), and that a failure still never surfaces to the writer, because the write has already committed.

## Drive-by: 8 type errors from #1959

`node scripts/ci/typecheck-ratchet.js --package lib` reports these as **new against baseline 29**, so they were failing on `main`:

```
src/reconcilers/__tests__/parent-reconciler.test.ts  TS2352  0 -> 1
src/reconcilers/__tests__/parent-reconciler.test.ts  TS2493  0 -> 7
```

Cause: `const rebuild = vi.fn(async () => {})` — declared with no parameters — then read at `rebuild.mock.calls.map((c) => c[2])`, which types as indexing an empty tuple. Giving the mocks their real signatures clears it back to 29/29. Worth noting the ratchet caught this immediately once run with `node_modules` present; #1959's agent hit the worktree false-pass first (`0 total, baseline 29`, "29 errors fixed"), which is how it got through.

## Verified

- `pnpm exec vitest run` in `packages/lib` — **1035 files, 13,832 tests, 0 failures**
- ratchet — **29 total, baseline 29**
- biome clean