### PR TITLE
test: raise the timeout on the two tests sitting on the 10s boundary

### DIFF
--- a/packages/lib/src/events/handlers/resolve-resource-trigger-match.test.ts
+++ b/packages/lib/src/events/handlers/resolve-resource-trigger-match.test.ts
@@ -38,6 +38,12 @@ describe('resolveResourceTriggerMatch', () => {
     hoisted.getCachedEntityDefId.mockImplementation(async (_orgId, slug) => CACHE[slug])
   })
 
+  // 30s, not the 10s default. This test pays for the whole
+  // `trigger-resource-workflows` module graph on its dynamic import — ~6.1s on an
+  // idle machine, and the rest of the file rides on it for free. Against a 10s
+  // budget that tipped whenever the box was busy, and a timing failure on a loaded
+  // machine reads exactly like a deterministic one: it has now cost three separate
+  // false-alarm investigations. The number is the import, not the assertion.
   it('normalizes the legacy ticket slug to the org EntityDefinition id', async () => {
     const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
 
@@ -49,7 +55,7 @@ describe('resolveResourceTriggerMatch', () => {
     // The picker stores the CUID; without this the strict compare in
     // `byTrigger` / `trigger-agents` never matches and the trigger is dead.
     expect(match?.entityDefinitionId).toBe(TICKET_DEF)
-  })
+  }, 30_000)
 
   it('keeps the slug in matchIds so slug-keyed rows still fire', async () => {
     const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')

--- a/packages/lib/src/workflows/__tests__/workflow-draft-cas.test.ts
+++ b/packages/lib/src/workflows/__tests__/workflow-draft-cas.test.ts
@@ -182,6 +182,9 @@ describe('WorkflowService.update draft CAS', () => {
     expect(updateCalls).toHaveLength(0)
   })
 
+  // 30s, not the 10s default. This one test owns ~6.5s of the file's runtime on an
+  // idle machine, so under any load it tipped the default and failed as a TIMEOUT
+  // rather than an assertion — which looks like a real break and is not one.
   it('writes under FOR UPDATE and returns the new graph hash when the hash matches', async () => {
     const { tx, updateCalls, forUpdate } = makeTx([{ graph: storedGraphJsonb, version: 3 }])
     const service = makeService(tx)
@@ -204,7 +207,7 @@ describe('WorkflowService.update draft CAS', () => {
     expect(draftWrite?.set?.version).toBe(4)
 
     expect(result.graphHash).toBe(hashWorkflowGraph(newGraph))
-  })
+  }, 30_000)
 
   it('keeps the legacy unconditional write when expectedGraphHash is absent', async () => {
     const { tx, updateCalls, forUpdate } = makeTx([])


### PR DESCRIPTION
## The problem

Two tests sit right on the default 10s timeout, and neither is slow because of what it asserts — both spend their budget on setup the rest of their file then rides for free:

| test | idle cost | what the time goes on |
| --- | --- | --- |
| `events/handlers/resolve-resource-trigger-match.test.ts` | ~6.1s | one dynamic `import('./trigger-resource-workflows')`, paying for the whole module graph |
| `workflows/__tests__/workflow-draft-cas.test.ts` | ~6.5s | a single test owning most of the file's runtime |

Against a 10s budget both tip whenever the machine is busy, and they fail as **timeouts rather than assertions** — which reads exactly like a real break.

## Why this is worth a PR rather than a re-run

It has now cost three separate false-alarm investigations, across #1953, #1957 and #1959. Each time someone had to establish from scratch that the failure was pre-existing and unrelated.

Including one of mine that was simply wrong: I reported `workflow-draft-cas` as *"fails in isolation at 10004ms"* on clean `main`. That reading was taken while two agents were saturating the box. Three consecutive idle runs pass at ~6537ms. A timing failure on a loaded machine is indistinguishable from a deterministic one without re-testing on an idle one, which is precisely the trap worth removing.

## The change

30s on those two tests only — **not** a global bump, which would also mask a genuinely hung test, and catching those is what the default is for. Each gets a comment recording that the number is the import cost, not the assertion, so the next person doesn't read it as a magic constant.

Recorded in `plans/events/08-derived-parent-reconciler-plan.md` §6.4.

## Verified

`pnpm exec vitest run` in `packages/lib` — **1035 files, 13,832 tests, 0 failures**.