### PR TITLE
feat(reconcilers): converge an order's builds when the connector edits it

### DIFF
--- a/packages/lib/src/builds/drift-reconciler.ts
+++ b/packages/lib/src/builds/drift-reconciler.ts
@@ -222,6 +222,33 @@ async function reconcileOrders(organizationId: string, orderIds: string[]): Prom
 }
 
 /**
+ * Reconcile a batch of orders NOW, with no dirty-parent buffer in play.
+ *
+ * The **R6(c)** seam of `plans/events/08-derived-parent-reconciler-plan.md` §6.6:
+ * sync finalize, off the plan-07 manifest. It exists because the other two
+ * seams provably cannot see a connector write —
+ * `derivePublishEvents` returns `false` for the `sync` lane, and
+ * `field-value-mutations.ts`'s post-hook chain is gated on exactly that — so
+ * {@link markOrStampOrderLine} never fires for a value the connector writes
+ * (products/13 §1.6 traces the four steps).
+ *
+ * 🛑 **Takes the whole batch, deliberately.** The caller has already resolved
+ * every order the run touched; handing them over one at a time would run the
+ * settings read, the order load, the field lookup and the stored-fingerprint
+ * read once per order, which is the N+1 this plan exists to remove. The
+ * no-op guard inside means an order whose demand did not actually move costs
+ * two reads and no writes, so over-delivery from a large manifest is cheap.
+ *
+ * Never throws — it is called from a finalize door that must not fail a run.
+ */
+export async function reconcileOrdersFromSync(
+  organizationId: string,
+  orderIds: string[]
+): Promise<void> {
+  await reconcileOrders(organizationId, [...new Set(orderIds.filter(Boolean))])
+}
+
+/**
  * Mark an order for reconciliation, or reconcile it now when nothing will drain.
  *
  * The inline fallback is load-bearing — see `ParentReconciler.mark`: a caller that

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -84,6 +84,7 @@ export { type BuildDrift, readBuildDrift } from './drift-queries'
 export {
   markOrStampOrder,
   markOrStampOrderLine,
+  reconcileOrdersFromSync,
   registerOrderDriftReconcilers,
 } from './drift-reconciler'
 export { hasDrifted, type OrderDemand, orderDemandFingerprint } from './order-fingerprint'

--- a/packages/lib/src/events/handlers/finalize-integrity-passes.test.ts
+++ b/packages/lib/src/events/handlers/finalize-integrity-passes.test.ts
@@ -19,6 +19,10 @@ const h = vi.hoisted(() => ({
   fillBlankGeoFields: vi.fn(async () => {}),
   lookupPhoneGeo: vi.fn(),
   getValue: vi.fn(),
+  resolveParentsByRelation: vi.fn(async (): Promise<string[]> => []),
+  // Typed parameters, not `vi.fn(async () => {})` — an untyped mock makes
+  // `mock.calls[0]` read as `[]` and forces a cast at every assertion (#1961).
+  reconcileOrdersFromSync: vi.fn(async (_organizationId: string, _orderIds: string[]) => {}),
 }))
 
 // Cache barrel — mocked whole, like sync-finalize.test.ts (the lazy import means the real
@@ -89,6 +93,21 @@ vi.mock('../../phone-geo/derive-geo-hook', () => ({
 }))
 vi.mock('../../phone-geo/lookup', () => ({ lookupPhoneGeo: h.lookupPhoneGeo }))
 
+// Pass 4 (order demand → build convergence, events/08 R6(c)). The trigger vocabularies are
+// literal copies for the same reason the totals ones are — they are plain data, and
+// `builds/drift-hooks.ts` owns them. `reconcileOrdersFromSync` is the observable seam; the
+// real one drags the org cache and the whole build write path.
+vi.mock('../../builds/drift-hooks', () => ({
+  LINE_DEMAND_TRIGGER_ATTRS: new Set(['line_item_part', 'line_item_qty', 'line_item_order']),
+  ORDER_DEMAND_TRIGGER_ATTRS: new Set(['order_cancelled_at']),
+}))
+vi.mock('../../builds/drift-reconciler', () => ({
+  reconcileOrdersFromSync: h.reconcileOrdersFromSync,
+}))
+vi.mock('../../reconcilers/parent-reconciler', () => ({
+  resolveParentsByRelation: h.resolveParentsByRelation,
+}))
+
 vi.mock('../../field-values/field-value-helpers', () => ({
   createFieldValueContext: vi.fn((organizationId: string, userId: string, db: unknown) => ({
     organizationId,
@@ -110,12 +129,16 @@ const RESOURCES = [
   { entityDefinitionId: 'def_quote', entityType: 'quote', apiSlug: 'quotes' },
   { entityDefinitionId: 'def_invoice', entityType: 'invoice', apiSlug: 'invoices' },
   { entityDefinitionId: 'def_ticket', entityType: 'ticket', apiSlug: 'tickets' },
+  { entityDefinitionId: 'def_order', entityType: 'order', apiSlug: 'orders' },
 ]
 
 const FIELDS_BY_DEF: Record<string, Array<Record<string, unknown>>> = {
   def_li: [
     { id: 'fld_qty', systemAttribute: 'line_item_qty', type: 'NUMBER' },
     { id: 'fld_inv_rel', systemAttribute: 'line_item_invoice', type: 'RELATIONSHIP' },
+    { id: 'fld_part', systemAttribute: 'line_item_part', type: 'RELATIONSHIP' },
+    { id: 'fld_ord_rel', systemAttribute: 'line_item_order', type: 'RELATIONSHIP' },
+    { id: 'fld_price', systemAttribute: 'line_item_unit_price', type: 'NUMBER' },
   ],
   def_contact: [
     // Custom field — no systemAttribute, so its manifest outputKey is the field id.
@@ -135,6 +158,10 @@ const FIELDS_BY_DEF: Record<string, Array<Record<string, unknown>>> = {
   def_quote: [{ id: 'fld_qtax', systemAttribute: 'quote_tax_rate', type: 'NUMBER' }],
   def_invoice: [],
   def_ticket: [{ id: 'fld_subj', systemAttribute: 'ticket_subject', type: 'TEXT' }],
+  def_order: [
+    { id: 'fld_cancelled', systemAttribute: 'order_cancelled_at', type: 'DATETIME' },
+    { id: 'fld_placed', systemAttribute: 'order_placed_at', type: 'DATETIME' },
+  ],
 }
 
 /** A fully rule-subscribed v2 manifest: touched keys derived from the delta buckets. */
@@ -165,6 +192,19 @@ function tier1Manifest(touched: Record<string, string[] | 1>) {
   } as unknown as SyncChangeManifest
 }
 
+/** A tier-1 manifest that also carries archived ids (pass 4 reads them). */
+function archivedManifest(touched: Record<string, string[] | 1>, archivedRecordIds: string[]) {
+  return {
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched,
+    deltas: {},
+    createdRecordIds: [],
+    archivedRecordIds,
+  } as unknown as SyncChangeManifest
+}
+
 function run(m: SyncChangeManifest) {
   return runIntegrityPasses(DB, { organizationId: ORG, manifest: m })
 }
@@ -182,6 +222,7 @@ beforeEach(() => {
     async (_org: string, defId: string) => FIELDS_BY_DEF[defId] ?? []
   )
   h.resolveLineParentDocument.mockResolvedValue(null)
+  h.resolveParentsByRelation.mockResolvedValue([])
   h.lookupPhoneGeo.mockReturnValue(null)
   // Fresh stored values per field: an unstamped address struct and a multi phone.
   h.getValue.mockImplementation(async (_ctx: unknown, params: { fieldId: string }) => {
@@ -423,5 +464,112 @@ describe('failure isolation', () => {
     h.fillBlankGeoFields.mockRejectedValue(new Error('e'))
     h.lookupPhoneGeo.mockReturnValue({ city: 'LA' })
     await expect(run(mixedManifest())).resolves.toBeUndefined()
+  })
+})
+
+describe('order-demand pass (events/08 R6(c))', () => {
+  it('maps a changed line quantity to its order and reconciles once', async () => {
+    h.resolveParentsByRelation.mockResolvedValue(['ord_1'])
+
+    await run(tier1Manifest({ 'def_li:l1': ['line_item_qty'] }))
+
+    expect(h.resolveParentsByRelation).toHaveBeenCalledWith(ORG, 'line_item_order', ['l1'])
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledTimes(1)
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledWith(ORG, ['ord_1'])
+  })
+
+  it('hands the WHOLE order set over in one call — two lines of one order is one reconcile', async () => {
+    h.resolveParentsByRelation.mockResolvedValue(['ord_1', 'ord_1'])
+
+    await run(
+      tier1Manifest({
+        'def_li:l1': ['line_item_qty'],
+        'def_li:l2': ['line_item_part'],
+      })
+    )
+
+    // One resolve for both lines, and the duplicate order collapses.
+    expect(h.resolveParentsByRelation).toHaveBeenCalledTimes(1)
+    expect(h.resolveParentsByRelation).toHaveBeenCalledWith(ORG, 'line_item_order', ['l1', 'l2'])
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledTimes(1)
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledWith(ORG, ['ord_1'])
+  })
+
+  it('ignores a line change that moves money but not demand', async () => {
+    await run(tier1Manifest({ 'def_li:l1': ['line_item_unit_price'] }))
+
+    expect(h.resolveParentsByRelation).not.toHaveBeenCalled()
+    expect(h.reconcileOrdersFromSync).not.toHaveBeenCalled()
+  })
+
+  it('takes a cancelled order directly — no line resolution needed', async () => {
+    await run(tier1Manifest({ 'def_order:ord_9': ['order_cancelled_at'] }))
+
+    expect(h.resolveParentsByRelation).not.toHaveBeenCalled()
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledWith(ORG, ['ord_9'])
+  })
+
+  it('ignores an order header change that is not cancellation', async () => {
+    await run(tier1Manifest({ 'def_order:ord_9': ['order_placed_at'] }))
+
+    expect(h.reconcileOrdersFromSync).not.toHaveBeenCalled()
+  })
+
+  it('reconciles the order of an ARCHIVED line — a deleted line asks for less', async () => {
+    h.resolveParentsByRelation.mockResolvedValue(['ord_1'])
+
+    await run(archivedManifest({}, ['def_li:l7']))
+
+    expect(h.resolveParentsByRelation).toHaveBeenCalledWith(ORG, 'line_item_order', ['l7'])
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledWith(ORG, ['ord_1'])
+  })
+
+  it('treats an ids-only degraded line as "any demand attribute may have moved"', async () => {
+    h.resolveParentsByRelation.mockResolvedValue(['ord_1'])
+
+    await run(tier1Manifest({ 'def_li:l1': 1 }))
+
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledWith(ORG, ['ord_1'])
+  })
+
+  it('unions a line-derived order with a directly cancelled one', async () => {
+    h.resolveParentsByRelation.mockResolvedValue(['ord_1'])
+
+    await run(
+      tier1Manifest({
+        'def_li:l1': ['line_item_qty'],
+        'def_order:ord_2': ['order_cancelled_at'],
+      })
+    )
+
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledTimes(1)
+    const orderIds = h.reconcileOrdersFromSync.mock.calls[0]?.[1] ?? []
+    expect([...orderIds].sort()).toEqual(['ord_1', 'ord_2'])
+  })
+
+  it('does not reconcile when no line resolves to an order', async () => {
+    h.resolveParentsByRelation.mockResolvedValue([])
+
+    await run(tier1Manifest({ 'def_li:l1': ['line_item_qty'] }))
+
+    expect(h.reconcileOrdersFromSync).not.toHaveBeenCalled()
+  })
+
+  it('never rejects when the reconciler throws — the run must not fail', async () => {
+    h.resolveParentsByRelation.mockResolvedValue(['ord_1'])
+    h.reconcileOrdersFromSync.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(run(tier1Manifest({ 'def_li:l1': ['line_item_qty'] }))).resolves.toBeUndefined()
+
+    // Reached and contained, not skipped: the throw came from inside the pass.
+    expect(h.reconcileOrdersFromSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('never rejects when the parent resolve throws, and never reconciles on a bad resolve', async () => {
+    h.resolveParentsByRelation.mockRejectedValueOnce(new Error('resolve boom'))
+
+    await expect(run(tier1Manifest({ 'def_li:l1': ['line_item_qty'] }))).resolves.toBeUndefined()
+
+    expect(h.reconcileOrdersFromSync).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/events/handlers/finalize-integrity-passes.ts
+++ b/packages/lib/src/events/handlers/finalize-integrity-passes.ts
@@ -10,7 +10,7 @@
 // the finalize pass by its caller. The CALLER decides which lanes invoke it — per the door
 // matrix, integrity hooks are batched at finalize for sync-large AND seed runs (D-10),
 // while the small-lane / per-record story is the caller's decision; this module just runs
-// the three passes over whatever manifest it is handed. It reuses the hooks' own extracted
+// the four passes over whatever manifest it is handed. It reuses the hooks' own extracted
 // cores (`money/totals-hooks.ts`, `geocoding/address-normalize-hook.ts`,
 // `phone-geo/derive-geo-hook.ts`) — no math or merge policy is reimplemented here.
 //
@@ -70,7 +70,7 @@ export interface IntegrityPassesInput {
 }
 
 /**
- * Run the three data-integrity batch passes over a sync-change manifest:
+ * Run the four data-integrity batch passes over a sync-change manifest:
  *
  * 1. Totals — changed line-item records map (via the hook's own parent resolution) to
  *    DISTINCT parent quotes/invoices, each recomputed once; lines whose qty/unitPrice
@@ -80,6 +80,11 @@ export interface IntegrityPassesInput {
  *    hook's core under a bounded-concurrency pool.
  * 3. Phone geo — changed PHONE_INTL fields, blank city/region/country/timezone filled
  *    via the hook's core (in-memory lookup, sequential).
+ * 4. Order demand — changed order lines (and cancelled orders) map to DISTINCT orders,
+ *    whose demand fingerprint is re-stamped and whose builds are converged onto it.
+ *    This is events/08 R6(c), and it is the same class of bug as pass 1: the inline
+ *    seam cannot see a sync write, so without it a Shopify order edited from 3 to 5
+ *    keeps a build for 3 forever.
  *
  * NEVER throws: each pass — and each record inside a pass — is individually guarded and
  * logged, so one bad record or one failing pass cannot starve the others (mirrors
@@ -88,12 +93,20 @@ export interface IntegrityPassesInput {
 export async function runIntegrityPasses(db: Database, input: IntegrityPassesInput): Promise<void> {
   const { organizationId, manifest } = input
   try {
-    if (Object.keys(manifest.touched).length === 0) return
+    // An archived-only manifest still has work: pass 4 reads `archivedRecordIds`
+    // (a deleted line means its order asks production for less).
+    if (
+      Object.keys(manifest.touched).length === 0 &&
+      (manifest.archivedRecordIds?.length ?? 0) === 0
+    ) {
+      return
+    }
 
     const resolveDef = await buildDefFieldResolver(organizationId)
     await totalsPass(db, organizationId, manifest, resolveDef)
     await addressPass(db, organizationId, manifest, resolveDef)
     await phoneGeoPass(db, organizationId, manifest, resolveDef)
+    await orderDemandPass(organizationId, manifest, resolveDef)
   } catch (error) {
     logger.error('integrity passes failed', {
       organizationId,
@@ -498,6 +511,118 @@ async function phoneGeoPass(
     })
   } catch (error) {
     logger.error('integrity phone-geo pass failed', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+// =============================================================================
+// Pass 4: order demand → build convergence
+// =============================================================================
+
+/**
+ * Re-stamp the demand fingerprint of every order this run touched, and converge
+ * its builds onto it.
+ *
+ * **This is R6(c) of `plans/events/08-derived-parent-reconciler-plan.md` §6.6**, and
+ * it closes the same class of hole passes 1-3 close. `builds/drift-hooks.ts` marks an
+ * order dirty from two seams — the field-change post hook and the post-delete handler
+ * — and *neither can see a connector write*: the `sync` lane resolves to
+ * `publishEvents: false`, which is precisely what the post-hook chain is gated on
+ * (`field-value-mutations.ts`). So a Shopify order edited from 3 to 5 keeps a build
+ * for 3 forever, with nothing on any screen saying so — plans/products/13 §0's defect,
+ * arriving through the one door that plan never covered.
+ *
+ * ⚠️ **What saves the FIRST sync is a different lane, not this pass.** The connector's
+ * relationship pass writes `line_item_order` through an `automation`-origin handler,
+ * which is inline, so linking a line to its order does fire the hook. This pass is for
+ * every sync after that one (products/13 §1.6 traces both).
+ *
+ * 🛑 **One resolve, one reconcile — never per record.** The lines are mapped to their
+ * orders in ONE query and the whole deduped order set is handed over at once, because
+ * `reconcileOrdersFromSync` does its settings read, order load, field lookup and
+ * stored-fingerprint read once per BATCH. Marking each order separately would restore
+ * the N+1 that events/08 exists to remove.
+ *
+ * Cheap when nothing moved: the reconciler's fingerprint compare drops an order whose
+ * demand did not actually change before any write, so a large manifest that touched a
+ * hundred order headers costs two reads and no writes.
+ *
+ * 🛑 **Known residual — a REPARENTED line marks its new order only.** The inline seam
+ * marks both, because `EntityFieldChangeEvent` carries `oldValue`; here the old parent
+ * is only in the tier-2 delta, which is rule-gated (so often absent) and stores a raw
+ * value whose shape this pass would have to guess at. Guessing and silently getting it
+ * wrong is worse than a documented gap, so: a line moved between orders under sync
+ * leaves the OLD order holding a build for a part it no longer sells, until that order
+ * is touched again. Connector runs do not reparent line items (a Shopify line belongs
+ * to its order permanently); imports can. Recorded in events/08 §6.6.
+ */
+async function orderDemandPass(
+  organizationId: string,
+  manifest: SyncChangeManifest,
+  resolveDef: DefFieldResolver
+): Promise<void> {
+  try {
+    const { LINE_DEMAND_TRIGGER_ATTRS, ORDER_DEMAND_TRIGGER_ATTRS } = await import(
+      '../../builds/drift-hooks'
+    )
+
+    const lineInstanceIds = new Set<string>()
+    const orderInstanceIds = new Set<string>()
+
+    for (const [rid, touched] of Object.entries(manifest.touched)) {
+      const { entityDefinitionId: rawDefId, entityInstanceId } = parseRecordId(rid as RecordId)
+      const def = await resolveDef(rawDefId)
+      if (!def) continue
+      // Ids-only degradation: the keys were shed under the byte budget, so any
+      // demand attribute may have moved and the record enters its def's arm.
+      const idsOnly = touched === 1
+      const keys = idsOnly ? [] : touched
+      const hasTrigger = (set: ReadonlySet<SystemAttribute>) =>
+        idsOnly || keys.some((key) => set.has(key as SystemAttribute))
+      // Def entityType decides the arm, never the attribute alone — the same rule
+      // pass 1 follows, and what keeps a stray key on another def out of here.
+      switch (def.entityType) {
+        case 'line_item':
+          if (hasTrigger(LINE_DEMAND_TRIGGER_ATTRS)) lineInstanceIds.add(entityInstanceId)
+          break
+        case 'order':
+          if (hasTrigger(ORDER_DEMAND_TRIGGER_ATTRS)) orderInstanceIds.add(entityInstanceId)
+          break
+      }
+    }
+
+    // A line archived during the run asks production for less, and archival fires no
+    // field change at all — the inline twin of this is `stampOrderAfterLineDelete`.
+    // The relation is still readable: `readFieldRelations` selects `FieldValue` rows
+    // directly and never joins `EntityInstance`, so a soft-archived line still resolves
+    // its order.
+    for (const rid of manifest.archivedRecordIds ?? []) {
+      const { entityDefinitionId: rawDefId, entityInstanceId } = parseRecordId(rid)
+      const def = await resolveDef(rawDefId)
+      if (def?.entityType === 'line_item') lineInstanceIds.add(entityInstanceId)
+    }
+
+    if (lineInstanceIds.size > 0) {
+      const { resolveParentsByRelation } = await import('../../reconcilers/parent-reconciler')
+      const parents = await resolveParentsByRelation(organizationId, 'line_item_order', [
+        ...lineInstanceIds,
+      ])
+      for (const orderId of parents) orderInstanceIds.add(orderId)
+    }
+    if (orderInstanceIds.size === 0) return
+
+    const { reconcileOrdersFromSync } = await import('../../builds/drift-reconciler')
+    await reconcileOrdersFromSync(organizationId, [...orderInstanceIds])
+
+    logger.info('integrity order-demand pass done', {
+      organizationId,
+      lines: lineInstanceIds.size,
+      orders: orderInstanceIds.size,
+    })
+  } catch (error) {
+    logger.error('integrity order-demand pass failed', {
       organizationId,
       error: error instanceof Error ? error.message : String(error),
     })


### PR DESCRIPTION
**R6(c) of `plans/events/08`** — the sync-finalize invalidation seam that plan specified and nobody built. Closes the last open item in that plan.

## The hole

The two seams `builds/drift-hooks.ts` implements — the field-change post hook and the post-delete handler — **provably cannot see a connector write**:

| step | where | answer |
| --- | --- | --- |
| connector record writes carry `origin.kind: 'sync'` | `connector-sync-source.ts:445` | — |
| `sessionLane('sync')` | `write-origin.ts:133` | `silent` |
| `derivePublishEvents` | `unified-handler-mutations.ts:168` | `false` |
| the post-hook chain is gated on it | `field-value-mutations.ts:3002` | 🛑 does not fire |

So a Shopify order edited from 3 to 5 kept a build for 3 until somebody touched it in the app.

What saves the **first** sync is a different lane, not the hook: the connector's relationship pass builds its own handler with `origin.kind: 'automation'` (inline, deliberately — `connector-sync-source.ts:470`) and writes `line_item_order`, one of the three demand attributes. Every sync after that one had nothing.

This is pre-existing, and not caused by #1963 — `on: 'created'` never fired for a re-sync either. But that PR removed the door partly covering for it, which promoted this from a footnote to the next piece of work.

## The fix

Pass 4 of `finalize-integrity-passes.ts`, **not a new module**: that file already *is* this seam for three other subsystems. It exists to fix bug B-1 — *"synced/imported writes never run the field-change integrity hooks"* — which is R6(c) with different nouns.

- order lines and cancelled orders selected off **tier-1 membership** (unconditional), never the rule-gated deltas
- **archived lines included** — a deleted line means less demand, and `readFieldRelations` selects `FieldValue` directly without joining `EntityInstance`, so an archived line still resolves its order
- **one** `resolveParentsByRelation` for the whole set, then **one** `reconcileOrdersFromSync` for the deduped orders. Never per record: the reconciler's per-batch setup (settings, order load, field lookup, stored fingerprints) is exactly the N+1 events/08 exists to amortise. The fingerprint no-op guard means orders that did not really move cost two reads and no writes.

## Residual, documented rather than guessed at

A **reparented** line marks its new order only. The inline seam marks both because `EntityFieldChangeEvent` carries `oldValue`; at finalize the old parent lives only in the tier-2 delta, which is rule-gated and holds a raw value whose shape this pass would have to guess at. Guessing and silently getting it wrong is worse than a documented gap. Import-only in practice — a Shopify line belongs to its order permanently.

## Testing

- 11 new tests (30 in the file): line→order mapping, batch dedupe, non-demand attributes ignored, cancelled orders taken directly, archived lines, ids-only degradation, union, and both never-throws arms.
- 812 tests pass across `field-hooks`, `purchasing`, `builds`, `events/handlers`.
- Typecheck ratchet: no new errors (lib 29/29 baseline).