### PR TITLE
feat(build): say when a build no longer matches its order, and when an edit will not stick

### DIFF
--- a/apps/web/src/components/manufacturing/builds/build-run-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-run-card.tsx
@@ -200,6 +200,11 @@ export function BuildRunCard({ entityInstanceId }: DrawerTabProps) {
             From order
           </Badge>
         )}
+        {run.drifted && (
+          <Badge variant='amber' size='xs'>
+            Order changed
+          </Badge>
+        )}
         {isReversal && (
           <Badge variant='amber' size='xs'>
             Reversal
@@ -211,6 +216,8 @@ export function BuildRunCard({ entityInstanceId }: DrawerTabProps) {
           </Badge>
         )}
       </div>
+
+      {run.source === 'order' && <OrderTrackingNotice status={status} drifted={run.drifted} />}
 
       {/* §1.6: the two reversal relations are `showInPanel: false` on purpose —
           "surfaced as a banner/badge on a reversed build, not as two relationship
@@ -286,6 +293,57 @@ export function BuildRunCard({ entityInstanceId }: DrawerTabProps) {
         />
       )}
     </div>
+  )
+}
+
+/**
+ * What an order-raised build's relationship to its order actually IS, said
+ * before somebody edits it (plans/products/13 Q3 and Q4).
+ *
+ * 🛑 **Q3 decided that the order wins**: a hand edit to a `planned`
+ * order-raised build is not durable — the next change to the order replaces it.
+ * That decision came with a condition attached, and this is it: *"it must be
+ * surfaced in the UI **before** the edit, not discovered after it… §0's whole
+ * objection was the word* silently *— do not reintroduce it on this side."*
+ * `build_quantity_planned` is `updatable: true`, so the edit is genuinely
+ * reachable from the Details panel; without this notice, somebody bumping a
+ * build 3 → 4 for scrap allowance loses it with no warning anywhere.
+ *
+ * **Q4 is the other half**: how drift is surfaced on a build convergence cannot
+ * repair. Since Model B shipped, a `planned` build is converged automatically —
+ * so drift on one means the last pass could not finish, and (by the
+ * fingerprint no-op guard) nothing retries until the demand moves again. On an
+ * `in_progress` or `completed` build the drift is permanent by design: §1.0(a)
+ * forbids silently amending a run whose material may already be cut, and B6/B8
+ * forbid editing a completed one at all.
+ *
+ * The escape hatch named here is the one that actually exists — a
+ * `source: 'manual'` build, which no automatic path may ever touch.
+ */
+function OrderTrackingNotice({ status, drifted }: { status: string | null; drifted: boolean }) {
+  const tracked = status === 'planned'
+  // A cancelled build asks for nothing and is not coming back; saying its order
+  // moved is noise about a run nobody is making.
+  if (status === 'canceled') return null
+  if (!drifted && !tracked) return null
+
+  if (!drifted) {
+    return (
+      <p className='rounded-md bg-muted/50 px-2 py-1.5 text-muted-foreground text-xs'>
+        This build tracks its order. Changes you make to it are replaced when the order changes —
+        raise a build manually if you need one that stays.
+      </p>
+    )
+  }
+
+  return (
+    <p className='rounded-md bg-amber-500/10 px-2 py-1.5 text-amber-700 text-xs dark:text-amber-500'>
+      {tracked
+        ? 'The order has changed since this build was raised, and this build has not caught up. It is brought back into line the next time the order changes.'
+        : `The order has changed since this build was raised. It is no longer updated automatically because it has ${
+            status === 'completed' ? 'been completed' : 'started'
+          }.`}
+    </p>
   )
 }
 

--- a/apps/web/src/server/api/routers/builds.ts
+++ b/apps/web/src/server/api/routers/builds.ts
@@ -9,6 +9,7 @@ import {
   listBuilds,
   loadAbsorptionRates,
   previewStandardCostRoll,
+  readBuildDrift,
   reverseBuild,
   rollStandardCost,
   startBuild,
@@ -186,11 +187,24 @@ export const buildsRouter = createTRPCRouter({
     }),
 
   /**
-   * One build, fully priced.
+   * One build, fully priced, with its drift verdict.
    *
    * `null` for a build that does not exist, is archived, or belongs to another
    * org — the same three cases, deliberately indistinguishable, so this cannot
    * be used to probe for ids.
+   *
+   * `drifted` answers plans/products/13 Q4 — *"how is drift surfaced on a build
+   * that cannot be reconciled"*. It rides along rather than being its own
+   * procedure because `readBuildDrift` takes RECORDS, deliberately: *"every
+   * caller that wants drift is already listing builds, and re-reading them here
+   * would be the composed-read problem"*. A second procedure would re-read this
+   * very build to answer one boolean.
+   *
+   * ⚠️ Since Model B shipped, a `planned` order-raised build is converged
+   * automatically, so drift on one is transient — it means the last convergence
+   * could not finish. Persistent drift lives on the builds convergence may not
+   * touch: `in_progress`, `completed`, and `manual`. That is exactly the set Q4
+   * was asked about.
    */
   get: capabilityProcedure
     .input(z.object({ buildId: z.string().min(1) }))
@@ -200,7 +214,11 @@ export const buildsRouter = createTRPCRouter({
 
       const result = await getBuild(ctx.db, organizationId, input.buildId)
       if (result.isErr()) throw result.error
-      return result.value
+      const build = result.value
+      if (!build) return null
+
+      const drift = await readBuildDrift(ctx.db, organizationId, [build])
+      return { ...build, drifted: drift.get(build.buildId)?.drifted ?? false }
     }),
 
   /**


### PR DESCRIPTION
The two UI surfaces [#1963](https://github.com/Auxx-Ai/auxx-ai/pull/1963) deliberately left out — `plans/products/13` **Q4** and **Q3**.

## Q4 — drift was computed, stored, and invisible

`readBuildDrift` shipped in #1958 with six tests and **zero production callers**. The run card now carries an **"Order changed"** badge plus a sentence saying what the drift *means for this build*, which differs by status:

- `planned` + drifted — the last convergence could not finish, and the fingerprint no-op guard means nothing retries until demand moves again
- `in_progress` / `completed` — no longer updated automatically, and why: 13 §1.0(a) (material may already be cut) and B6/B8

⚠️ Model B **changed** this question rather than answering it. A `planned` order-raised build is now converged automatically, so drift on one is *transient*. Persistent drift lives exactly where Q4 asked about it: the builds convergence may not touch.

## Q3 — the condition attached to "the order wins"

Q3 decided a hand edit to a `planned` order-raised build is not durable, and attached a condition:

> *"it must be surfaced in the UI **before** the edit, not discovered after it… §0's whole objection was the word* silently *— do not reintroduce it on this side."*

That condition is not ceremonial: **`build_quantity_planned` is `updatable: true`**, so the edit is genuinely reachable from the Details panel. Somebody bumping a build 3 → 4 for scrap allowance loses it on the order's next change, with no warning anywhere. The card now says so, and names the escape hatch that actually exists — a `source: 'manual'` build, which no automatic path may touch.

## Why the verdict rides on `builds.get`

Rather than a `builds.drift` procedure. `readBuildDrift` takes **records** on purpose:

> *"every caller that wants drift is already listing builds, and re-reading them here would be the composed-read problem: a second query answering something the first already had in hand."*

A dedicated procedure would re-read this very build to answer one boolean. `get` returns `null` unchanged for the three indistinguishable not-found cases.

## Testing

Presentational over an existing, tested lib read — `drift-queries.test.ts` covers the verdict itself (including that a missing stamp is *unknown*, never *drifted*). Typecheck ratchet: **web 0 new errors, 0 total**. Lint clean.

🛑 Not driven in a browser — no dev credentials to hand. The risk is low (a badge and a paragraph, no new state), but saying so rather than implying otherwise.