### PR TITLE
fix(purchasing): re-run the three-way match when the goods arrive

### DIFF
--- a/packages/lib/src/field-hooks/post/purchase-order-line-rollups.test.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-line-rollups.test.ts
@@ -19,6 +19,9 @@ const h = vi.hoisted(() => ({
   publishFieldValueUpdates: vi.fn(),
   recalculatePurchaseOrderStatuses: vi.fn(),
   recalculatePurchaseOrderStatusesForLines: vi.fn(),
+  rematchBillsForPurchaseOrderLines: vi.fn(
+    async (_organizationId: string, _userId: string, _lineIds: string[]) => {}
+  ),
   // The two shapes the module asks the db for, in call order.
   dbResults: [] as unknown[][],
 }))
@@ -66,6 +69,9 @@ vi.mock('../../purchasing/purchase-order-status-writer', () => ({
   recalculatePurchaseOrderStatuses: h.recalculatePurchaseOrderStatuses,
   recalculatePurchaseOrderStatusesForLines: h.recalculatePurchaseOrderStatusesForLines,
 }))
+vi.mock('../../purchasing/match-reconciler', () => ({
+  rematchBillsForPurchaseOrderLines: h.rematchBillsForPurchaseOrderLines,
+}))
 
 import {
   PURCHASE_ORDER_LINE_ROLLUPS,
@@ -111,6 +117,7 @@ beforeEach(() => {
   h.publishFieldValueUpdates.mockResolvedValue(undefined)
   h.recalculatePurchaseOrderStatuses.mockResolvedValue(ok({}))
   h.recalculatePurchaseOrderStatusesForLines.mockResolvedValue(ok([]))
+  h.rematchBillsForPurchaseOrderLines.mockResolvedValue(undefined)
 })
 
 describe('recalculatePurchaseOrderLineReceived', () => {
@@ -486,5 +493,80 @@ describe('the batched roll-up', () => {
   it('is a no-op for an empty set', async () => {
     await recalculatePurchaseOrderLineRollups('org_1', [], PURCHASE_ORDER_LINE_ROLLUPS.received)
     expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+})
+
+describe('a receipt re-matches the bills that charge the line', () => {
+  // 🛑 The regression this pins: the three-way match re-runs on a bill write and a
+  // bill-LINE write and on nothing else, so a bill entered before the goods arrived
+  // recorded `billed 1 but only 0 received` and nothing ever revisited it. Found in
+  // dev data 2026-08-28 — BILL-0005's notes were stamped at 21:32:22 against a line
+  // whose receipt landed at 21:37:50, and the notes still said 0.
+  it('rematches the bills for a line whose received total moved', async () => {
+    h.dbResults.push([{ total: '2' }])
+
+    await recalculatePurchaseOrderLineReceived(
+      event({ stock_movement_purchase_order_line: PO_LINE })
+    )
+
+    expect(h.rematchBillsForPurchaseOrderLines).toHaveBeenCalledWith('org_1', '', [PO_LINE])
+  })
+
+  it('does NOT rematch when the received total did not move', async () => {
+    // Stored total equals the SUM — the write, the publish and the status pass are
+    // all short-circuited, and so is this.
+    h.dbResults.push([{ total: '2', current: 2 }])
+
+    await recalculatePurchaseOrderLineReceived(
+      event({ stock_movement_purchase_order_line: PO_LINE })
+    )
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.rematchBillsForPurchaseOrderLines).not.toHaveBeenCalled()
+  })
+
+  it('never rematches off the BILLED roll-up — a bill line write already drives the match', async () => {
+    h.dbResults.push([{ total: '6' }])
+
+    await recalculatePurchaseOrderLineBilled(
+      event(
+        { vendor_bill_line_purchase_order_line: PO_LINE },
+        { entitySlug: 'vendor-bill-lines', entityInstanceId: 'vbl-1' }
+      )
+    )
+
+    expect(h.rematchBillsForPurchaseOrderLines).not.toHaveBeenCalled()
+  })
+
+  it('passes only the CHANGED lines from a batched receipt', async () => {
+    // Two lines in, one already correct: only the mover is rematched.
+    h.dbResults.push([
+      { lineId: 'pol-a', total: '5' },
+      { lineId: 'pol-b', total: '3' },
+    ])
+    h.dbResults.push([
+      { entityId: 'pol-a', valueNumber: 1 },
+      { entityId: 'pol-b', valueNumber: 3 },
+    ])
+
+    await recalculatePurchaseOrderLineRollups(
+      'org_1',
+      ['pol-a', 'pol-b'],
+      PURCHASE_ORDER_LINE_ROLLUPS.received
+    )
+
+    expect(h.rematchBillsForPurchaseOrderLines).toHaveBeenCalledWith('org_1', '', ['pol-a'])
+  })
+
+  it('a failing rematch never takes the roll-up down with it', async () => {
+    h.dbResults.push([{ total: '2' }])
+    h.rematchBillsForPurchaseOrderLines.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(
+      recalculatePurchaseOrderLineReceived(event({ stock_movement_purchase_order_line: PO_LINE }))
+    ).resolves.toBeUndefined()
+
+    // The quantity is the primary fact and is already committed.
+    expect(h.setValueWithType).toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/field-hooks/post/purchase-order-line-rollups.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-line-rollups.ts
@@ -26,6 +26,14 @@ import type { EntityTriggerHandler } from '../types'
 const logger = createScopedLogger('field-hooks:purchase-order-line-rollups')
 
 /**
+ * Actor for the rematch this module triggers. Empty for the same reason
+ * `drift-reconciler.ts` passes an empty actor: nothing downstream reads it, and
+ * this pass acts for no particular person — it is a consequence of a receipt,
+ * not of somebody opening a bill.
+ */
+const ROLLUP_ACTOR = ''
+
+/**
  * The two subledger roll-ups a purchase order line carries
  * (plans/purchasing/01-build-plan.md §4.2). Both are `creatable: false`,
  * `updatable: false`, `computed: true` — this module is their ONLY writer.
@@ -234,6 +242,8 @@ export async function recalculatePurchaseOrderLineRollup(
       error: statuses.error.message,
     })
   }
+
+  await rematchBillsAfterReceipt(organizationId, spec, [purchaseOrderLineInstanceId])
 }
 
 /**
@@ -322,6 +332,45 @@ export async function recalculatePurchaseOrderLineRollups(
     logger.error('Failed to derive purchase order statuses after batched line roll-up', {
       target: spec.targetAttr,
       error: statuses.error.message,
+    })
+  }
+
+  await rematchBillsAfterReceipt(organizationId, spec, changed)
+}
+
+/**
+ * A receipt changes the match's answer, so the bills that charge these lines are
+ * re-matched.
+ *
+ * 🛑 **Without this the match's verdict depends on the order the paperwork
+ * arrives in.** It re-runs on a bill write and a bill-line write and on nothing
+ * else, so a bill entered before the goods records `billed 1 but only 0 received`
+ * and nothing ever revisits it — a permanent false exception in the queue a
+ * person is meant to work. The full argument, and the dev-data proof it was found
+ * in, are on `rematchBillsForPurchaseOrderLines`.
+ *
+ * ⚠️ **Gated on `spec.evidence`, never on `targetAttr`.** That field exists for
+ * exactly this reason — *"a string comparison at the call site is one careless
+ * edit away"*. The BILLED roll-up must not come through here: it is driven BY
+ * bill lines, whose writes already fire the match hook.
+ *
+ * Failure is logged and swallowed, like the status pass above it: the received
+ * quantity is the primary fact and is already committed.
+ */
+async function rematchBillsAfterReceipt(
+  organizationId: string,
+  spec: RollupSpec,
+  changedLineIds: string[]
+): Promise<void> {
+  if (spec.evidence !== 'receipt' || changedLineIds.length === 0) return
+  try {
+    const { rematchBillsForPurchaseOrderLines } = await import('../../purchasing/match-reconciler')
+    await rematchBillsForPurchaseOrderLines(organizationId, ROLLUP_ACTOR, changedLineIds)
+  } catch (error) {
+    logger.error('Failed to re-match bills after a receipt roll-up', {
+      target: spec.targetAttr,
+      lines: changedLineIds.length,
+      error: error instanceof Error ? error.message : String(error),
     })
   }
 }

--- a/packages/lib/src/purchasing/match-reconciler.ts
+++ b/packages/lib/src/purchasing/match-reconciler.ts
@@ -73,3 +73,84 @@ export const markOrRematchBill = billReconciler.mark
 
 /** {@link markOrRematchBill}'s line-side twin — the bill is resolved in the drain. */
 export const markOrRematchBillLine = billLineReconciler.mark
+
+/**
+ * Re-run the three-way match on every bill that charges these purchase order lines.
+ *
+ * 🛑 **The receipt leg had no trigger, and that made the match's answer depend on
+ * the order two documents happened to arrive in.** The match re-runs on a bill
+ * write and on a bill LINE write (`BILL_MATCH_TRIGGER_ATTRS`,
+ * `BILL_LINE_MATCH_TRIGGER_ATTRS`) — and on nothing else. So a bill entered
+ * *before* the goods arrive records `billed 1 but only 0 received`, an honest
+ * verdict at the time, and then **nothing ever revisits it**. Receiving the goods
+ * moves `purchase_order_line_quantity_received` and leaves the exception standing
+ * for good.
+ *
+ * Found 2026-08-28 in dev data, which is the only place it could have been found:
+ * bill `BILL-0005` carries *"Line 1: billed 1 but only 0 received"* stamped at
+ * 21:32:22, against a line whose receipt landed at 21:37:50. Every unit test
+ * passed, because each one drives the match directly and none of them models two
+ * documents arriving in the wrong order.
+ *
+ * Why it matters more than one stale string: `exception` is the queue a person is
+ * meant to work, and plan P6's whole argument for automating the match is that
+ * *"a control that requires a person to compare three documents by hand is a
+ * control that stops being run in week three."* A queue holding exceptions that
+ * are no longer true is the same failure, reached from the other side — it teaches
+ * people to clear the queue without reading it.
+ *
+ * Called from the RECEIPT roll-up only, and only for lines whose received total
+ * actually moved. The billed roll-up needs nothing: a bill line write already
+ * fires the hook that drives this.
+ *
+ * Never throws — it runs post-commit behind a quantity that is already committed,
+ * and `markOrRematchBill` isolates each bill internally.
+ */
+export async function rematchBillsForPurchaseOrderLines(
+  organizationId: string,
+  userId: string,
+  purchaseOrderLineInstanceIds: string[]
+): Promise<void> {
+  const lineIds = [...new Set(purchaseOrderLineInstanceIds)].filter(Boolean)
+  if (lineIds.length === 0) return
+
+  const [{ database, schema }, { getOrgCache }, { and, eq, inArray }] = await Promise.all([
+    import('@auxx/database'),
+    import('../cache'),
+    import('drizzle-orm'),
+  ])
+
+  // The INVERSE of `vendor_bill_line_purchase_order_line`, read from the bill-line
+  // side rather than through the purchase order line's `_vendor_bill_lines` mirror:
+  // the mirror is a maintained copy and this is the fact itself. One query.
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['vendor_bill_line_purchase_order_line'] as const)
+  const relField = fields.vendor_bill_line_purchase_order_line
+  // An org without the field has no bills to rematch — not an error.
+  if (!relField) return
+
+  const rows = await database
+    .select({ billLineId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, relField.id),
+        inArray(schema.FieldValue.relatedEntityId, lineIds)
+      )
+    )
+  const billLineIds = [...new Set(rows.map((row) => row.billLineId))]
+  if (billLineIds.length === 0) return
+
+  // Bill lines to their bills in ONE query, then one rematch per DISTINCT bill —
+  // a five-line bill against one receipt must be matched once, not five times.
+  const billIds = [
+    ...new Set(
+      await resolveParentsByRelation(organizationId, 'vendor_bill_line_vendor_bill', billLineIds)
+    ),
+  ]
+  for (const billId of billIds) {
+    await markOrRematchBill(organizationId, userId, billId)
+  }
+}


### PR DESCRIPTION
The match's verdict depended on **the order the paperwork happened to arrive in**, and a bill entered before its goods stayed in `exception` forever.

## The defect

`matchBill` re-runs on a bill write and a bill **line** write — `BILL_MATCH_TRIGGER_ATTRS`, `BILL_LINE_MATCH_TRIGGER_ATTRS` — and on nothing else. **Nothing in `receiving/` ever called it.** So receiving the goods moved `purchase_order_line_quantity_received` and left the bill's verdict exactly as it was.

Found in dev data, which is the only place it could have been found. Bill **BILL-0005** carries:

> *"Line 1: billed 1 but only 0 received; Line 2: billed 1 but only 0 received; …"*

| what | when |
| --- | --- |
| match notes + variance written | **21:32:22** |
| receipt landed on `aoemt4lvcgmav7rtonhb7n34` | 21:37:50 |
| receipt landed on `i0hvsxecodauehh6ceiihyvk` | 21:37:53 |

The note was true when written and false five minutes later. Both PO lines read `quantity_received = 2` today; the bill still says 0.

**Every unit test passed**, because each one drives the match directly and none of them models two documents arriving out of order. This is exactly the shape `plans/purchasing/02-handoff.md` §4 item 1 predicted — *"the last defects of this shape threw nothing, logged nothing and passed every test."*

## Why it matters more than one stale string

`exception` is the queue a person is meant to work, and **P6**'s whole argument for automating the match is that *"a control that requires a person to compare three documents by hand is a control that stops being run in week three."* A queue holding exceptions that are **no longer true** is the same failure reached from the other side — it teaches people to clear the queue without reading it.

The realistic sequence makes it worse: vendor invoices routinely arrive with or before the goods, so bill-then-receive is not an edge case.

## The fix

`rematchBillsForPurchaseOrderLines` (`purchasing/match-reconciler.ts`):

- reads the **inverse** of `vendor_bill_line_purchase_order_line` from the bill-line side — the fact itself, not the maintained `purchase_order_line_vendor_bill_lines` mirror — in one query
- resolves the distinct bills through the existing `resolveParentsByRelation` in one more
- rematches each bill **once**: a five-line bill against one receipt is matched once, not five times

Driven from the **receipt** roll-up only, for **changed** lines only, gated on `spec.evidence` and never on a `targetAttr` string — that field exists for exactly this reason (*"a string comparison at the call site is one careless edit away"*). The billed roll-up needs nothing: it is driven **by** bill lines, whose writes already fire the hook.

Failure is logged and swallowed, like the status pass beside it: the received quantity is the primary fact and is already committed.

## Testing

5 new tests (30 in the file), **mutation-checked** rather than trusted for passing first try — flipping the evidence gate to `'billing'` fails exactly three of them:

- a changed received total rematches; an unchanged one does not
- the billed roll-up never rematches
- a batched receipt passes only the lines that actually moved
- a throwing rematch never takes the roll-up down with it

812 tests pass across `field-hooks`, `purchasing`, `builds`, `events/handlers`. Typecheck ratchet: no new errors.

## What this does not do

🛑 **The browser pass is still open.** `plans/purchasing/02-handoff.md` §4 item 1 asks for a bill entered through `CreateBillFromPurchaseOrderDialog` with a line picked via `PurchaseOrderLinePicker`, watched end to end; §0g names the specific risk (the prefill effect racing the async value load). Neither surface has ever been driven. Finding this defect in the data is an argument **for** that pass, not a substitute for it.

Existing stale rows (BILL-0005) are not backfilled — they correct themselves on the next receipt or bill-line edit.