### PR TITLE
feat(purchasing): files on a record, and the generated PDF as a FILE value

### DIFF
--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -273,6 +273,18 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     })),
   // One component behind both vendor keys — a PO and a bill each link exactly one
   // company and ask the same question of it.
+  // The files on the record — the generated PDF (read-only) and the uploads.
+  // Both fields are `showInPanel: false`, so this card is their only surface
+  // (plans/purchasing/08-documents-on-records.md P21).
+  'purchase_order:documents': () =>
+    import('../purchasing/record-documents-card').then((m) => ({
+      default: m.PurchaseOrderDocumentsCard,
+    })),
+  'vendor_bill:documents': () =>
+    import('../purchasing/record-documents-card').then((m) => ({
+      default: m.VendorBillDocumentsCard,
+    })),
+
   'purchase_order:vendor': () =>
     import('../purchasing/vendor-card').then((m) => ({ default: m.PurchaseOrderVendorCard })),
   'vendor_bill:vendor': () =>

--- a/apps/web/src/components/purchasing/record-documents-card.tsx
+++ b/apps/web/src/components/purchasing/record-documents-card.tsx
@@ -1,0 +1,138 @@
+// apps/web/src/components/purchasing/record-documents-card.tsx
+'use client'
+
+// `purchase_order:documents` / `vendor_bill:documents` — the files that belong to
+// this record (plans/purchasing/08-documents-on-records.md P21).
+//
+// Both fields it renders are `showInPanel: false`, so this card is their ONLY
+// surface. That is the whole point: the Details panel keeps showing business
+// fields, and files get a row that shows a type icon, a name and a download,
+// none of which a bare field row in a list of twenty does well.
+//
+// 🛑 Nothing here special-cases the generated PDF into read-only. `toPanelField`
+// derives `readOnly` from `capabilities.updatable === false`, which the three
+// `*_pdf_asset` fields carry — and that is deliberately the same question the
+// Details panel and the record header ask, so no surface can disagree and offer
+// an editor for a write the server would reject.
+
+import { isValueEmpty } from '@auxx/lib/field-values/client'
+import { parseRecordId } from '@auxx/lib/resources/client'
+import { useMemo } from 'react'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { CompactFieldRow } from '~/components/fields/compact-field-row'
+import { useFieldPopoverCoordination } from '~/components/fields/hooks/use-field-popover-coordination'
+import { toPanelField } from '~/components/fields/rows/to-panel-field'
+import { useResourceFields } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+
+interface DocumentSlots {
+  /**
+   * System-written and read-only — the PDF we rendered. Hidden entirely until one
+   * exists, because an empty read-only row is noise a person cannot act on.
+   */
+  generated?: string
+  /**
+   * The one document a person owns — the vendor's bill. Always offered, INCLUDING
+   * when empty: an empty row is how the file gets uploaded in the first place.
+   */
+  primary?: string
+  /** Everything else: packing slips, confirmations, drawings, photos. */
+  attachments: string
+}
+
+function RecordDocumentsCard({ recordId, slots }: DrawerTabProps & { slots: DocumentSlots }) {
+  const { entityDefinitionId } = parseRecordId(recordId)
+  const { fields, isLoading: fieldsLoading } = useResourceFields(entityDefinitionId)
+
+  // Only the generated slot needs its value here — the others render whether or
+  // not they hold anything. `useSystemValues` reads the same field-value store
+  // the rows subscribe to, so this is a subscription, not a second fetch.
+  const generatedAttrs = useMemo(
+    () => (slots.generated ? ([slots.generated] as const) : ([] as const)),
+    [slots.generated]
+  )
+  const { values } = useSystemValues(recordId, generatedAttrs, { autoFetch: true })
+
+  const { onOpenChange, registerClose, unregisterClose } = useFieldPopoverCoordination()
+
+  const rows = useMemo(() => {
+    const byAttribute = new Map(
+      fields.filter((f) => f.systemAttribute).map((f) => [f.systemAttribute as string, f])
+    )
+
+    const wanted: string[] = []
+    // Order is the reading order, not the registry's: what we produced, then what
+    // they sent, then everything else.
+    if (slots.generated) wanted.push(slots.generated)
+    if (slots.primary) wanted.push(slots.primary)
+    wanted.push(slots.attachments)
+
+    return wanted.flatMap((attribute) => {
+      const field = byAttribute.get(attribute)
+      // An org that has not run migration 112 has no `attachments` field at all.
+      // Skipping is right: the card degrades to the slots that exist rather than
+      // rendering a row bound to a field id that does not resolve. A field with
+      // no `fieldType` is the same case — nothing can render it.
+      if (!field?.fieldType) return []
+      if (attribute === slots.generated && isValueEmpty(values[attribute], field.fieldType)) {
+        return []
+      }
+      return [toPanelField(field)]
+    })
+  }, [fields, slots, values])
+
+  if (rows.length === 0) return null
+
+  return (
+    <div className='flex flex-col'>
+      {rows.map((field) => (
+        <CompactFieldRow
+          key={field.id}
+          providerId={field.id}
+          field={field}
+          loading={fieldsLoading}
+          recordId={recordId}
+          readOnly={field.readOnly}
+          onOpenChange={onOpenChange}
+          registerClose={registerClose}
+          unregisterClose={unregisterClose}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * The PO's own PDF plus whatever the vendor sent back.
+ *
+ * The generated row appears only once a PDF exists, which for a PO means once it
+ * has been sent or previewed — before that the card is just Attachments.
+ */
+export function PurchaseOrderDocumentsCard(props: DrawerTabProps) {
+  return (
+    <RecordDocumentsCard
+      {...props}
+      slots={{
+        generated: 'purchase_order_pdf_asset',
+        attachments: 'purchase_order_attachments',
+      }}
+    />
+  )
+}
+
+/**
+ * The bill's paper.
+ *
+ * `document` is a single slot on purpose (P18) — it is what a phase-2 extraction
+ * would parse, and "the first element of the attachments array" is a convention
+ * that survives exactly until somebody reorders. Nothing renders INTO this field,
+ * so unlike the PO's generated slot it is fully user-writable.
+ */
+export function VendorBillDocumentsCard(props: DrawerTabProps) {
+  return (
+    <RecordDocumentsCard
+      {...props}
+      slots={{ primary: 'vendor_bill_document', attachments: 'vendor_bill_attachments' }}
+    />
+  )
+}

--- a/packages/lib/src/documents/__tests__/pdf-pointer-ref.test.ts
+++ b/packages/lib/src/documents/__tests__/pdf-pointer-ref.test.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/documents/__tests__/pdf-pointer-ref.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { assetIdFromFileValue } from '../ensure-pdf'
+
+/**
+ * The pointer field became a single FILE value in
+ * plans/purchasing/08-documents-on-records.md §4. Every case below is a way the
+ * read half can quietly return the wrong thing, and the symptom is always the
+ * same and always silent: `existingAssetId` comes back `undefined`, so the
+ * document re-renders and mints a SECOND MediaAsset on every single call —
+ * no throw, no log, and the "sent documents snapshot naturally" guarantee gone
+ * because the customer's version now lives on an asset nothing points at.
+ */
+describe('assetIdFromFileValue', () => {
+  it('reads the id out of a single-element FILE array', () => {
+    expect(assetIdFromFileValue([{ ref: 'asset:clx7abc' }])).toBe('clx7abc')
+  })
+
+  it('reads a bare envelope too — FILE is array-return, but the scalar shape must not crash', () => {
+    expect(assetIdFromFileValue({ ref: 'asset:clx7abc' })).toBe('clx7abc')
+  })
+
+  it('takes the FIRST element, since the field is single-valued', () => {
+    expect(assetIdFromFileValue([{ ref: 'asset:first' }, { ref: 'asset:second' }])).toBe('first')
+  })
+
+  // 🛑 A `file:` ref names a FolderFile, not a MediaAsset. Parsing it would hand
+  // the caller an id that `MediaAsset.findFirst` cannot find, and the render
+  // would then try to version an asset that does not exist.
+  it('treats a `file:` ref as NO pointer rather than parsing it', () => {
+    expect(assetIdFromFileValue([{ ref: 'file:clx7abc' }])).toBeUndefined()
+  })
+
+  it('rejects a bare id with no scheme — the old TEXT shape', () => {
+    expect(assetIdFromFileValue('clx7abc')).toBeUndefined()
+    expect(assetIdFromFileValue(['clx7abc'])).toBeUndefined()
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty array', []],
+    ['empty object', {}],
+    ['prefix with no id', [{ ref: 'asset:' }]],
+    ['non-string ref', [{ ref: 42 }]],
+  ])('returns undefined for %s', (_label, value) => {
+    expect(assetIdFromFileValue(value)).toBeUndefined()
+  })
+})

--- a/packages/lib/src/documents/ensure-pdf.ts
+++ b/packages/lib/src/documents/ensure-pdf.ts
@@ -78,6 +78,25 @@ function firstTyped(
   return Array.isArray(entry) ? entry[0] : entry
 }
 
+const ASSET_REF_PREFIX = 'asset:'
+
+/**
+ * Read a MediaAsset id back out of the pointer field's FILE value
+ * (plans/purchasing/08-documents-on-records.md §4).
+ *
+ * The stored shape is a single-element array of `{ ref: 'asset:<id>' }` envelopes.
+ * A `file:`-prefixed ref is treated as NO pointer rather than parsed: it names a
+ * `FolderFile`, not a `MediaAsset`, so the lookup that follows would find nothing
+ * and the caller must fall through to minting a fresh asset.
+ */
+export function assetIdFromFileValue(value: unknown): string | undefined {
+  const first = Array.isArray(value) ? value[0] : value
+  const ref = (first as { ref?: unknown } | null | undefined)?.ref
+  if (typeof ref !== 'string' || !ref.startsWith(ASSET_REF_PREFIX)) return undefined
+  const id = ref.slice(ASSET_REF_PREFIX.length)
+  return id.length > 0 ? id : undefined
+}
+
 async function buildPdfPayload(params: {
   documentType: DocumentType
   organizationId: string
@@ -128,7 +147,7 @@ export async function ensureDocumentPdf(params: {
   if (pointerField) {
     const values = await handler.getFieldValues(recordId, [pointerField.id])
     const typed = firstTyped(values.get(pointerField.id))
-    existingAssetId = typed ? (extractValue(typed) as string) : undefined
+    existingAssetId = typed ? assetIdFromFileValue(extractValue(typed)) : undefined
   }
 
   if (existingAssetId) {
@@ -220,7 +239,12 @@ export async function ensureDocumentPdf(params: {
     })
     await fieldValueService.setValuesForEntity({
       recordId,
-      values: [{ fieldId: pointerField.id, value: assetId }],
+      // A single-value FILE field, so the value is a ONE-ELEMENT ARRAY of envelopes —
+      // the same shape the web uploader writes through `fieldValue.set`. Passing the
+      // bare envelope (or the raw id, as this did while the field was TEXT) lands on
+      // the scalar path, and the read above then finds nothing: the symptom is a PDF
+      // that re-renders on every single call and no other error anywhere.
+      values: [{ fieldId: pointerField.id, value: [{ ref: `${ASSET_REF_PREFIX}${assetId}` }] }],
     })
   }
 

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -216,6 +216,10 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // the LineBuilder's TotalsFooter already renders them under the lines, so a
     // totals card would compete with it — the same call `order` made.
     sidebarCards: [
+      // Drawer parity: the same card key, from the same registry. A PO opened
+      // from a list and one opened as a page must offer the same files, or
+      // expanding the record makes them disappear.
+      { value: 'documents', label: 'Documents', icon: 'paperclip' },
       { value: 'vendor', label: 'Vendor' },
       { value: 'receiving', label: 'Receiving' },
       { value: 'bills', label: 'Bills', recordResource: 'vendor_bill' },

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -249,6 +249,9 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       // would be a second, competing rendering of the same five mirrors.
       overview: [
         { value: 'lines', label: 'Lines', fullBleed: true },
+        // The generated PDF + the vendor's paperwork. Both fields are
+        // `showInPanel: false`, so this card is their only surface (plan 08 P21).
+        { value: 'documents', label: 'Documents', icon: 'paperclip' },
         { value: 'vendor', label: 'Vendor' },
         { value: 'receiving', label: 'Receiving' },
         { value: 'bills', label: 'Bills', recordResource: 'vendor_bill' },
@@ -282,6 +285,9 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       overview: [
         { value: 'lines', label: 'Lines', fullBleed: true },
         { value: 'match', label: 'Match' },
+        // The vendor's own invoice, plus the packing slips and freight bills
+        // that came with it (plan 08 P18/P21).
+        { value: 'documents', label: 'Documents', icon: 'paperclip' },
         { value: 'vendor', label: 'Vendor' },
         { value: 'payment', label: 'Payment' },
       ],

--- a/packages/lib/src/resources/registry/resources/invoice-fields.ts
+++ b/packages/lib/src/resources/registry/resources/invoice-fields.ts
@@ -493,28 +493,43 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       'auto-copy from quote_photos',
   },
 
+  // The last-rendered invoice PDF, as a single FILE value
+  // (plans/purchasing/08-documents-on-records.md P19/P20). Written ONLY by
+  // `ensureDocumentPdf`; `updatable: false` is what keeps every human door shut —
+  // it is read by the grid cell, the panel, the dialogs and connector writability,
+  // and NOT by the field-value write path, so the renderer is unaffected
+  // (the `079-enrichment-fields-backend-owned` shape).
+  //
+  // 🛑 Never make this user-writable. `ensureDocumentPdf` reads the pointer, loads
+  // that MediaAsset and appends a new VERSION to it whenever the content hash
+  // disagrees. A file a person uploaded has no `contentHash` at all, so the
+  // comparison always fails and the next send would silently republish their file
+  // as our PDF.
   pdfAsset: {
     id: toFieldId('pdfAsset'),
     key: 'pdfAsset',
-    label: 'PDF Asset',
-    type: BaseType.STRING,
-    fieldType: FieldType.TEXT,
+    label: 'Invoice PDF',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
     isSystem: true,
     systemAttribute: 'invoice_pdf_asset',
-    systemSortOrder: 'aI',
+    systemSortOrder: 'aK',
     showInPanel: false,
     nullable: true,
+    options: {
+      file: { allowMultiple: false, maxFiles: 1, allowedFileTypes: ['document'] },
+    },
     capabilities: {
       filterable: false,
       sortable: false,
       creatable: false,
-      updatable: true,
+      updatable: false,
       configurable: false,
       hidden: true,
     },
     description:
-      'MediaAsset id of the last-rendered invoice PDF (money MQ2 build spec §C.1 recipe) — ' +
-      'written only by ensureDocumentPdf via FieldValueService, never user-editable',
+      'The generated invoice PDF ({ ref: "asset:<MediaAsset id>" }) — written only by ' +
+      'ensureDocumentPdf, surfaced read-only through the documents card, never user-editable',
   },
 
   lineItems: {

--- a/packages/lib/src/resources/registry/resources/purchase-order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/purchase-order-fields.ts
@@ -594,28 +594,76 @@ export const PURCHASE_ORDER_FIELDS: Record<string, ResourceField> = {
   // send re-renders AND mints a fresh MediaAsset — an asset leak that grows per
   // send, throws nothing, and produces a correct PDF every time. Nothing but
   // storage growth would ever show it.
+  // The last-rendered purchase order PDF, as a single FILE value
+  // (plans/purchasing/08-documents-on-records.md P19/P20). Written ONLY by
+  // `ensureDocumentPdf`; `updatable: false` is what keeps every human door shut —
+  // it is read by the grid cell, the panel, the dialogs and connector writability,
+  // and NOT by the field-value write path, so the renderer is unaffected
+  // (the `079-enrichment-fields-backend-owned` shape).
+  //
+  // 🛑 Never make this user-writable. `ensureDocumentPdf` reads the pointer, loads
+  // that MediaAsset and appends a new VERSION to it whenever the content hash
+  // disagrees. A file a person uploaded has no `contentHash` at all, so the
+  // comparison always fails and the next send would silently republish their file
+  // as our PDF.
   pdfAsset: {
     id: toFieldId('pdfAsset'),
     key: 'pdfAsset',
-    label: 'PDF Asset',
-    type: BaseType.STRING,
-    fieldType: FieldType.TEXT,
+    label: 'Purchase order PDF',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
     isSystem: true,
     systemAttribute: 'purchase_order_pdf_asset',
     systemSortOrder: 'aK',
     showInPanel: false,
     nullable: true,
+    options: {
+      file: { allowMultiple: false, maxFiles: 1, allowedFileTypes: ['document'] },
+    },
     capabilities: {
       filterable: false,
       sortable: false,
       creatable: false,
-      updatable: true,
+      updatable: false,
       configurable: false,
       hidden: true,
     },
     description:
-      'MediaAsset id of the last-rendered purchase order PDF (money MQ2 build spec §C.1 recipe) ' +
-      '— written only by ensureDocumentPdf via FieldValueService, never user-editable',
+      'The generated purchase order PDF ({ ref: "asset:<MediaAsset id>" }) — written only by ' +
+      'ensureDocumentPdf, surfaced read-only through the documents card, never user-editable',
+  },
+
+  // What the vendor sent back, and anything else worth keeping with the order:
+  // their order confirmation, their quote, a drawing, signed T&Cs
+  // (plans/purchasing/08-documents-on-records.md P18). Hidden from the Details
+  // panel — the documents card renders this beside the generated PDF.
+  //
+  // 🛑 An attachment is INTERNAL by default. Nothing here enters the PO's PDF
+  // payload or the send attachment set unless it is explicitly chosen (P22).
+  attachments: {
+    id: toFieldId('attachments'),
+    key: 'attachments',
+    label: 'Attachments',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'purchase_order_attachments',
+    systemSortOrder: 'aK1',
+    showInPanel: false,
+    nullable: true,
+    options: {
+      file: { allowMultiple: true, maxFiles: 20, allowedFileTypes: ['document', 'image'] },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Supporting documents for this purchase order — vendor order confirmations, quotes, ' +
+      'drawings, signed terms',
   },
 
   // Reverse relationship: lines (from purchase_order_line.purchaseOrder).

--- a/packages/lib/src/resources/registry/resources/quote-fields.ts
+++ b/packages/lib/src/resources/registry/resources/quote-fields.ts
@@ -504,28 +504,43 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     description: 'Site photos captured for this quote (plan 37b scouting build spec)',
   },
 
+  // The last-rendered quote PDF, as a single FILE value
+  // (plans/purchasing/08-documents-on-records.md P19/P20). Written ONLY by
+  // `ensureDocumentPdf`; `updatable: false` is what keeps every human door shut —
+  // it is read by the grid cell, the panel, the dialogs and connector writability,
+  // and NOT by the field-value write path, so the renderer is unaffected
+  // (the `079-enrichment-fields-backend-owned` shape).
+  //
+  // 🛑 Never make this user-writable. `ensureDocumentPdf` reads the pointer, loads
+  // that MediaAsset and appends a new VERSION to it whenever the content hash
+  // disagrees. A file a person uploaded has no `contentHash` at all, so the
+  // comparison always fails and the next send would silently republish their file
+  // as our PDF.
   pdfAsset: {
     id: toFieldId('pdfAsset'),
     key: 'pdfAsset',
-    label: 'PDF Asset',
-    type: BaseType.STRING,
-    fieldType: FieldType.TEXT,
+    label: 'Quote PDF',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
     isSystem: true,
     systemAttribute: 'quote_pdf_asset',
     systemSortOrder: 'aK',
     showInPanel: false,
     nullable: true,
+    options: {
+      file: { allowMultiple: false, maxFiles: 1, allowedFileTypes: ['document'] },
+    },
     capabilities: {
       filterable: false,
       sortable: false,
       creatable: false,
-      updatable: true,
+      updatable: false,
       configurable: false,
       hidden: true,
     },
     description:
-      'MediaAsset id of the last-rendered quote PDF (money MQ2 build spec §C.1) — written ' +
-      'only by ensureQuotePdf via FieldValueService, never user-editable',
+      'The generated quote PDF ({ ref: "asset:<MediaAsset id>" }) — written only by ' +
+      'ensureDocumentPdf, surfaced read-only through the documents card, never user-editable',
   },
 
   lineItems: {

--- a/packages/lib/src/resources/registry/resources/vendor-bill-fields.ts
+++ b/packages/lib/src/resources/registry/resources/vendor-bill-fields.ts
@@ -566,31 +566,62 @@ export const VENDOR_BILL_FIELDS: Record<string, ResourceField> = {
       'unconfirmed filter until a provider read or a bank line confirms them.',
   },
 
-  // TEXT holding a MediaAsset id, following the `invoice_pdf_asset` precedent —
-  // deliberately NOT a relation. MediaAsset is not an entity definition, so
-  // there is nothing on the far side for a relation to point at.
+  // The vendor's own paper — the bill itself, as a single FILE value
+  // (plans/purchasing/08-documents-on-records.md P18). `image` is in the allowed
+  // list deliberately: what arrives is very often a phone photo of paper. This is
+  // the phase-2 parse target, which is why it is a single slot and not the first
+  // element of `attachments` — a caption is a label, not a contract.
   document: {
     id: toFieldId('document'),
     key: 'document',
-    label: 'Document',
-    type: BaseType.STRING,
-    fieldType: FieldType.TEXT,
+    label: 'Bill document',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
     isSystem: true,
     systemAttribute: 'vendor_bill_document',
     systemSortOrder: 'aL',
     showInPanel: false,
     nullable: true,
+    options: {
+      file: { allowMultiple: false, maxFiles: 1, allowedFileTypes: ['document', 'image'] },
+    },
     capabilities: {
       filterable: false,
       sortable: false,
       creatable: true,
       updatable: true,
       configurable: false,
-      hidden: true,
     },
     description:
-      "MediaAsset id of the vendor's PDF (invoice_pdf_asset precedent) — surfaced through the " +
-      'bill drawer, never as an editable text box',
+      "The vendor's invoice as received (PDF or photo) — surfaced through the documents card, " +
+      'never as an editable text box',
+  },
+
+  // Everything that is not the bill: packing slip, freight invoice, correspondence,
+  // a photo of the damage. Multi, and hidden from the Details panel for the same
+  // reason `document` is — the documents card renders both.
+  attachments: {
+    id: toFieldId('attachments'),
+    key: 'attachments',
+    label: 'Attachments',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'vendor_bill_attachments',
+    systemSortOrder: 'aL1',
+    showInPanel: false,
+    nullable: true,
+    options: {
+      file: { allowMultiple: true, maxFiles: 20, allowedFileTypes: ['document', 'image'] },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Supporting documents for this bill — packing slips, freight invoices, photos',
   },
 
   // Reverse relationship: lines (from vendor_bill_line.vendorBill). Until the

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -74,6 +74,7 @@ import { migration108Purchasing } from './migrations/108-purchasing'
 import { migration109BuildAndStandardCost } from './migrations/109-build-and-standard-cost'
 import { migration110BuildVisible } from './migrations/110-build-visible'
 import { migration111OrderBuildDrift } from './migrations/111-order-build-drift'
+import { migration112RecordDocuments } from './migrations/112-record-documents'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -195,6 +196,9 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // for why the `SYSTEM_ENTITIES` edit alone reaches no existing org.
   migration110BuildVisible,
   migration111OrderBuildDrift,
+  // MUST sort after 108 — it converts four fields 108 creates, and
+  // `ensureCustomFields` is INSERT-only so 108 itself can never do it.
+  migration112RecordDocuments,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts
@@ -754,9 +754,15 @@ describe('purchase_order field shapes the plan is explicit about', () => {
   // time — so this is asserted rather than trusted.
   //
   // The shape is copied verbatim from the two incumbents because all three go
-  // through the same read path: a bare MediaAsset id in TEXT, hidden, and
-  // `updatable` but not `creatable` (only `ensureDocumentPdf` writes it, via
-  // `FieldValueService`, which bypasses the pre-hook chain).
+  // through the same read path: a single FILE value carrying `asset:<MediaAsset
+  // id>`, hidden, and neither creatable nor updatable — only `ensureDocumentPdf`
+  // writes it, via `FieldValueService`, which does not read the capability at all.
+  //
+  // 🛑 `updatable: false` is load-bearing here, not cosmetic. It is what stops a
+  // person putting their own upload in the slot: `ensureDocumentPdf` appends a
+  // new VERSION to whatever asset the pointer names when the content hash
+  // disagrees, and a user's file has no hash at all, so the next send would
+  // republish it as our PDF (plans/purchasing/08-documents-on-records.md P20).
   it('carries a pdf-asset pointer shaped exactly like the quote and invoice ones', () => {
     const po = PURCHASE_ORDER_FIELDS.pdfAsset
     expect(po?.systemAttribute).toBe('purchase_order_pdf_asset')
@@ -771,12 +777,16 @@ describe('purchase_order field shapes the plan is explicit about', () => {
     }
 
     // Spelled out too, so a change to all three at once still trips something.
-    expect(po?.fieldType).toBe(FieldType.TEXT)
+    expect(po?.fieldType).toBe(FieldType.FILE)
     expect(po?.capabilities?.creatable).toBe(false)
-    expect(po?.capabilities?.updatable).toBe(true)
+    expect(po?.capabilities?.updatable).toBe(false)
     expect(po?.capabilities?.hidden).toBe(true)
-    // Not a RELATIONSHIP: it stores a MediaAsset id as text, and `media_asset`
-    // is not an entity def, so a relation would have nothing to link to.
+    // Single, and a re-render replaces in place — which is what the pipeline
+    // already does (one MediaAsset per document, a new version per change).
+    expect(po?.options?.file?.allowMultiple).toBe(false)
+    expect(po?.options?.file?.maxFiles).toBe(1)
+    // Not a RELATIONSHIP: it stores a MediaAsset ref, and `media_asset` is not
+    // an entity def, so a relation would have nothing to link to.
     expect(po?.relationship).toBeUndefined()
     // Late/administrative, where the quote (aK) and invoice (aI) put theirs —
     // after `bills` (aJ) and before the createdAt/updatedAt `b*` block.

--- a/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/108-purchasing.ts
@@ -199,9 +199,15 @@ const INCUMBENT_FIELDS: Record<string, Record<string, ResourceField | undefined>
  * missing pointer makes `existingAssetId` permanently `undefined` and every
  * send re-renders AND mints a fresh `MediaAsset`. Nothing throws, the PDF is
  * correct, and the only symptom is unbounded storage growth. Copied verbatim
- * from `quote_pdf_asset` / `invoice_pdf_asset` — a bare MediaAsset id in TEXT,
- * hidden, `updatable` but not `creatable`, because all three are read through
- * the same code path and only `ensureDocumentPdf` writes them.
+ * from `quote_pdf_asset` / `invoice_pdf_asset`, because all three are read
+ * through the same code path and only `ensureDocumentPdf` writes them.
+ *
+ * ⚠️ All three were a bare MediaAsset id in TEXT when this migration was
+ * written. `112-record-documents` made them single `FILE` fields, read-only via
+ * `isUpdatable: false`. This migration reads the registry, so a FRESH org gets
+ * the new shape here and 112 is a no-op for it; 112 exists for the orgs that
+ * ran 108 while the registry still said TEXT, because `ensureCustomFields` is
+ * INSERT-only and can never reshape a row it already created.
  *
  * Plus one field that is not an inverse: `part.unit`, the stock unit of measure
  * (SINGLE_SELECT, nullable, no backfill). Every quantity in the inventory chain

--- a/packages/lib/src/seed/entity-migrations/migrations/111-order-build-drift.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/111-order-build-drift.test.ts
@@ -28,9 +28,12 @@ describe('migration 111 registration', () => {
     expect(migration111OrderBuildDrift.id).toBe('111-order-build-drift')
   })
 
-  it('is last — a later migration must take 112, not reuse this number', () => {
+  // The "is last" guard this used to carry moved to `112-record-documents.test.ts`
+  // when 112 took the next number. What stays here is the ordering claim, which
+  // is the part that was ever about 111.
+  it('sorts before 112, which took the next number', () => {
     const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
-    expect(ids.at(-1)).toBe('111-order-build-drift')
+    expect(ids.indexOf('111-order-build-drift')).toBeLessThan(ids.indexOf('112-record-documents'))
   })
 })
 

--- a/packages/lib/src/seed/entity-migrations/migrations/112-record-documents.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/112-record-documents.test.ts
@@ -1,0 +1,101 @@
+// packages/lib/src/seed/entity-migrations/migrations/112-record-documents.test.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { INVOICE_FIELDS } from '../../../resources/registry/resources/invoice-fields'
+import { PURCHASE_ORDER_FIELDS } from '../../../resources/registry/resources/purchase-order-fields'
+import { QUOTE_FIELDS } from '../../../resources/registry/resources/quote-fields'
+import { VENDOR_BILL_FIELDS } from '../../../resources/registry/resources/vendor-bill-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { migration112RecordDocuments } from './112-record-documents'
+
+describe('migration 112 registration', () => {
+  it('is registered exactly once, with a unique id, after 108', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '112-record-documents')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    // 🛑 Ordering is not cosmetic: 112 converts four fields that 108 CREATES, and
+    // `ensureCustomFields` is INSERT-only, so running it before 108 would find
+    // nothing to convert and silently do half the job.
+    expect(ids.indexOf('112-record-documents')).toBeGreaterThan(ids.indexOf('108-purchasing'))
+    expect(migration112RecordDocuments.id).toBe('112-record-documents')
+  })
+
+  it('is last — a later migration must take 113, not reuse this number', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.at(-1)).toBe('112-record-documents')
+  })
+})
+
+describe('the four fields it converts are FILE in the registry', () => {
+  // If any of these is still TEXT, the migration writes `type = 'TEXT'` over a
+  // row that is already TEXT and the conversion silently never happens.
+  const CONVERTED = [
+    ['quote.pdfAsset', QUOTE_FIELDS.pdfAsset],
+    ['invoice.pdfAsset', INVOICE_FIELDS.pdfAsset],
+    ['purchase_order.pdfAsset', PURCHASE_ORDER_FIELDS.pdfAsset],
+    ['vendor_bill.document', VENDOR_BILL_FIELDS.document],
+  ] as const
+
+  it.each(CONVERTED)('%s is a single FILE field', (_name, field) => {
+    expect(field).toBeDefined()
+    expect(field?.fieldType).toBe(FieldType.FILE)
+    expect(field?.options?.file?.allowMultiple).toBe(false)
+    expect(field?.options?.file?.maxFiles).toBe(1)
+    // Out of the Details panel — the documents card is the only surface.
+    expect(field?.showInPanel).toBe(false)
+  })
+
+  // 🛑 The whole safety argument of P20. `ensureDocumentPdf` appends a new
+  // VERSION to whatever asset the pointer names when the content hash disagrees,
+  // and a human upload has no hash at all — so a writable slot means the next
+  // send republishes a person's file as our PDF. `updatable: false` is read by
+  // the grid cell, the panel, the dialogs and connector writability, and NOT by
+  // the field-value write path, so it locks the human doors and leaves the
+  // renderer alone.
+  it.each([
+    ['quote', QUOTE_FIELDS.pdfAsset],
+    ['invoice', INVOICE_FIELDS.pdfAsset],
+    ['purchase_order', PURCHASE_ORDER_FIELDS.pdfAsset],
+  ] as const)('%s.pdfAsset is machine-owned: not creatable, not updatable', (_name, field) => {
+    expect(field?.capabilities?.creatable).toBe(false)
+    expect(field?.capabilities?.updatable).toBe(false)
+    expect(field?.capabilities?.hidden).toBe(true)
+  })
+
+  // The bill's own document is the opposite case: a person uploads it, and
+  // nothing ever renders INTO it, so the trap above does not apply.
+  it('vendor_bill.document stays user-writable', () => {
+    expect(VENDOR_BILL_FIELDS.document?.capabilities?.creatable).toBe(true)
+    expect(VENDOR_BILL_FIELDS.document?.capabilities?.updatable).toBe(true)
+    // A phone photo of paper is the common case, not the exception.
+    expect(VENDOR_BILL_FIELDS.document?.options?.file?.allowedFileTypes).toContain('image')
+    expect(VENDOR_BILL_FIELDS.document?.options?.file?.allowedFileTypes).toContain('document')
+  })
+})
+
+describe('the two fields it creates', () => {
+  it.each([
+    ['purchase_order', PURCHASE_ORDER_FIELDS.attachments, 'purchase_order_attachments'],
+    ['vendor_bill', VENDOR_BILL_FIELDS.attachments, 'vendor_bill_attachments'],
+  ] as const)('%s.attachments is a multi FILE field', (_name, field, attribute) => {
+    expect(field).toBeDefined()
+    expect(field?.systemAttribute).toBe(attribute)
+    expect(field?.fieldType).toBe(FieldType.FILE)
+    expect(field?.options?.file?.allowMultiple).toBe(true)
+    expect(field?.options?.file?.allowedFileTypes).toEqual(['document', 'image'])
+    expect(field?.showInPanel).toBe(false)
+    expect(field?.capabilities?.creatable).toBe(true)
+    expect(field?.capabilities?.updatable).toBe(true)
+  })
+
+  // P18: the single slot and the multi list are different fields on purpose. A
+  // phase-2 parser has to know which file is the bill, and "the first one in the
+  // array" is a convention that survives exactly until somebody reorders.
+  it('the bill keeps `document` and `attachments` as separate fields', () => {
+    expect(VENDOR_BILL_FIELDS.document?.systemAttribute).toBe('vendor_bill_document')
+    expect(VENDOR_BILL_FIELDS.attachments?.systemAttribute).toBe('vendor_bill_attachments')
+    expect(VENDOR_BILL_FIELDS.document?.options?.file?.allowMultiple).toBe(false)
+    expect(VENDOR_BILL_FIELDS.attachments?.options?.file?.allowMultiple).toBe(true)
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/112-record-documents.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/112-record-documents.ts
@@ -1,0 +1,243 @@
+// packages/lib/src/seed/entity-migrations/migrations/112-record-documents.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNotNull, isNull, ne, or, sql } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { INVOICE_FIELDS } from '../../../resources/registry/resources/invoice-fields'
+import { PURCHASE_ORDER_FIELDS } from '../../../resources/registry/resources/purchase-order-fields'
+import { QUOTE_FIELDS } from '../../../resources/registry/resources/quote-fields'
+import { VENDOR_BILL_FIELDS } from '../../../resources/registry/resources/vendor-bill-fields'
+import { buildFieldOptions, mapCapabilities } from '../../entity-seeder/utils'
+import { ensureCustomFields, fieldKey, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:112')
+
+const REGISTRIES: Record<string, Record<string, ResourceField>> = {
+  quote: QUOTE_FIELDS,
+  invoice: INVOICE_FIELDS,
+  purchase_order: PURCHASE_ORDER_FIELDS,
+  vendor_bill: VENDOR_BILL_FIELDS,
+}
+
+/**
+ * The two genuinely NEW fields. Listed by registry key rather than taken as
+ * "everything new on that registry", the discipline 109/111 record — a later
+ * unrelated field cannot silently join this migration's payload.
+ */
+const NEW_FIELDS: Record<string, readonly string[]> = {
+  purchase_order: ['attachments'],
+  vendor_bill: ['attachments'],
+}
+
+/**
+ * The four fields that CHANGE TYPE, `TEXT` → `FILE`.
+ *
+ * These are the whole reason this is a migration and not a re-run of `108`:
+ * `ensureCustomFields` is INSERT-only — an existing `(entityDefId,
+ * systemAttribute)` row is put in the field map and `continue`d, never compared
+ * and never updated. Editing the registry changes what a NEW org gets and
+ * changes nothing for one that already has the field.
+ */
+const CONVERSIONS: readonly { entityType: string; key: string; systemAttribute: string }[] = [
+  { entityType: 'quote', key: 'pdfAsset', systemAttribute: 'quote_pdf_asset' },
+  { entityType: 'invoice', key: 'pdfAsset', systemAttribute: 'invoice_pdf_asset' },
+  {
+    entityType: 'purchase_order',
+    key: 'pdfAsset',
+    systemAttribute: 'purchase_order_pdf_asset',
+  },
+  { entityType: 'vendor_bill', key: 'document', systemAttribute: 'vendor_bill_document' },
+]
+
+/**
+ * Migration 112: documents on a record
+ * (plans/purchasing/08-documents-on-records.md §5).
+ *
+ * ## What changes
+ *
+ * Two new multi `FILE` fields — `purchase_order_attachments` and
+ * `vendor_bill_attachments` — plus four existing `TEXT` pointer fields converted
+ * to single `FILE` fields:
+ *
+ * | field | was | becomes |
+ * | --- | --- | --- |
+ * | `quote_pdf_asset` | hidden TEXT, a bare MediaAsset id | single FILE, `isUpdatable: false` |
+ * | `invoice_pdf_asset` | same | same |
+ * | `purchase_order_pdf_asset` | same | same |
+ * | `vendor_bill_document` | hidden TEXT, no reader and no writer anywhere | single FILE, user-writable |
+ *
+ * ## Why convert rather than add a second field
+ *
+ * The render pipeline already keeps exactly ONE `MediaAsset` per document and
+ * adds a `MediaAssetVersion` per content change, so "single, and a new render
+ * replaces the old" is what it already does — the `TEXT` type was the only thing
+ * describing it wrongly. Two fields holding the same asset id would be drift by
+ * construction: the renderer writes one, the card reads the other, and the first
+ * disagreement is invisible.
+ *
+ * ## `isUpdatable: false` on the three generated pointers
+ *
+ * 🛑 Load-bearing, not tidiness. `ensureDocumentPdf` reads the pointer, loads
+ * that `MediaAsset`, and appends a new VERSION to it when the stored
+ * `contentHash` disagrees with the payload's. A file a person uploaded has no
+ * `contentHash` at all, so the comparison always fails — point the field at a
+ * user's file and the next send silently republishes their file as our PDF.
+ *
+ * `isUpdatable` is what closes that: it is read by the grid cell
+ * (`selectable-table-cell.tsx`), the panel, the dialogs and connector
+ * writability, and is NOT read by the field-value write path — so it locks every
+ * human door and leaves `ensureDocumentPdf` untouched. That asymmetry is the
+ * entire point, and it is the same move `079-enrichment-fields-backend-owned`
+ * made for the company enrichment markers.
+ *
+ * Flipping the registry alone would reach only orgs seeded afterwards, which is
+ * precisely the gap `078` and `079` exist to close.
+ *
+ * ## Id space
+ *
+ * 112 was the next free number counted across BOTH `data-migrations/migrations/`
+ * (which reaches 105) and `seed/entity-migrations/migrations/` (which reaches
+ * 111), and verified with `git log --all` against every branch — the space is
+ * shared and has already collided once, at 103.
+ *
+ * **No DDL.** Everything here is `CustomField` and `FieldValue` rows. If a
+ * `.sql` file appears under `packages/database/drizzle/` for this work,
+ * something is wrong.
+ *
+ * Idempotent in all three parts: `ensureCustomFields` skips an existing field,
+ * the `CustomField` update's `WHERE` matches only rows still in the old shape,
+ * and the value move only touches rows that still carry `valueText`.
+ */
+export const migration112RecordDocuments: EntityMigration = {
+  id: '112-record-documents',
+  description:
+    'Files on a record: PO/bill attachment fields, and the generated document PDFs converted ' +
+    'from hidden TEXT pointers into read-only single FILE fields',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+    let changed = false
+
+    // ── 1. The two new attachment fields ────────────────────────────────────
+    for (const [entityType, keys] of Object.entries(NEW_FIELDS)) {
+      const def = existing.entityDefs.get(entityType)
+      // Absent rather than failed: an org short of 108 has no purchasing defs at
+      // all, and 108 seeds each registry in full, so a later run picks these up.
+      if (!def) continue
+
+      const fields: Record<string, ResourceField> = {}
+      for (const key of keys) {
+        const field = REGISTRIES[entityType]?.[key]
+        // Loud rather than silent: a renamed registry key would otherwise make
+        // this migration quietly create one field fewer than it claims to.
+        if (!field) {
+          throw new Error(`${entityType} registry is missing the key "${key}" (migration 112)`)
+        }
+        fields[key] = field
+      }
+
+      await ensureCustomFields(db, organizationId, entityType, def.id, fields, existing, state)
+    }
+
+    // ── 2. TEXT → FILE on the four pointer fields ───────────────────────────
+    for (const conversion of CONVERSIONS) {
+      const def = existing.entityDefs.get(conversion.entityType)
+      if (!def) continue
+
+      const row = existing.fields.get(fieldKey(def.id, conversion.systemAttribute))
+      if (!row) continue
+
+      const field = REGISTRIES[conversion.entityType]?.[conversion.key]
+      if (!field) {
+        throw new Error(
+          `${conversion.entityType} registry is missing the key "${conversion.key}" (migration 112)`
+        )
+      }
+
+      const options = buildFieldOptions(field)
+      const capabilities = mapCapabilities(field.capabilities)
+
+      const updated = await db
+        .update(schema.CustomField)
+        .set({
+          name: field.label,
+          description: field.description,
+          type: field.fieldType!,
+          options,
+          ...capabilities,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(schema.CustomField.id, row.id),
+            // Only rows still in the old shape, so a re-run is a no-op. `type` is
+            // the load-bearing half; the rest are reconciled alongside it.
+            or(
+              ne(schema.CustomField.type, field.fieldType!),
+              ne(schema.CustomField.name, field.label),
+              ne(schema.CustomField.isUpdatable, capabilities.isUpdatable),
+              ne(schema.CustomField.options, options)
+            )
+          )
+        )
+        .returning({ id: schema.CustomField.id })
+
+      changed ||= updated.length > 0
+
+      // ── 3. Move the values: `valueText` → the `{ v, meta }` FILE envelope ──
+      //
+      // ⚠️ The stored shape is the envelope, NOT a bare `{ ref }` — verified
+      // against a live `company_logo` row: `{"v":{"ref":"asset:<id>"}}`. Writing
+      // the bare object here would produce a value that every FILE reader in the
+      // product silently skips.
+      //
+      // `valueText` is nulled in the same statement: a row carrying both columns
+      // is a row two readers disagree about. `sortKey` is left alone — these rows
+      // already sit at `a0`, which is exactly position 0 for a FILE field.
+      const moved = await db
+        .update(schema.FieldValue)
+        .set({
+          valueJson: sql`jsonb_build_object('v', jsonb_build_object('ref', 'asset:' || ${schema.FieldValue.valueText}))`,
+          valueText: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(schema.FieldValue.fieldId, row.id),
+            eq(schema.FieldValue.organizationId, organizationId),
+            isNotNull(schema.FieldValue.valueText),
+            ne(schema.FieldValue.valueText, ''),
+            isNull(schema.FieldValue.valueJson)
+          )
+        )
+        .returning({ id: schema.FieldValue.id })
+
+      if (moved.length > 0) {
+        changed = true
+        logger.info('Converted pointer values to FILE envelopes', {
+          organizationId,
+          systemAttribute: conversion.systemAttribute,
+          rows: moved.length,
+        })
+      }
+    }
+
+    const alreadyUpToDate = state.fieldsCreated === 0 && !changed
+
+    // A converted field is still TEXT to every read path until the per-org
+    // caches serving it are dropped — and a FILE write validated against a
+    // cached TEXT definition is rejected, invisibly, until something evicts.
+    // `runEntityMigrationsForOrg` clears these after the batch, but `up()` can
+    // also be invoked directly, so it clears its own.
+    if (!alreadyUpToDate) {
+      await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+      logger.info('Migration 112 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -500,7 +500,8 @@ export const SYSTEM_ATTRIBUTES = [
   'purchase_order_allocation_basis',
   'purchase_order_tax_recoverable',
   'purchase_order_notes',
-  'purchase_order_pdf_asset', // MediaAsset id, TEXT — the quote/invoice_pdf_asset precedent
+  'purchase_order_pdf_asset', // FILE — the generated PO PDF, written only by ensureDocumentPdf
+  'purchase_order_attachments', // FILE, multi — vendor confirmations, drawings, signed terms
   'purchase_order_lines', // inverse of purchase_order_line_purchase_order
   'purchase_order_bills', // inverse of vendor_bill_purchase_order
   'company_purchase_orders', // inverse of purchase_order_vendor
@@ -542,7 +543,8 @@ export const SYSTEM_ATTRIBUTES = [
   'vendor_bill_total',
   'vendor_bill_match_variance',
   'vendor_bill_match_notes',
-  'vendor_bill_document', // MediaAsset id, TEXT — the invoice_pdf_asset precedent
+  'vendor_bill_document', // FILE — the vendor's invoice as received; the phase-2 parse target
+  'vendor_bill_attachments', // FILE, multi — packing slips, freight invoices, photos
   'vendor_bill_lines',
   // Payment (P12): the same six fields in both modes. What differs is who
   // writes them and whether relieving A/P is our job.


### PR DESCRIPTION
Plan: `plans/purchasing/08-documents-on-records.md` (P17–P23).

## The problem

A vendor bill had no way to carry the vendor's paper, a purchase order had no way to carry the vendor's order confirmation, and the PDF we *generate* for a PO was a bare MediaAsset id in a hidden `TEXT` field that no surface rendered. These are one problem: there was no idea of **"the files on this record"**, only three unrelated pointers that happened to hold asset ids.

## What this does

| entity | field | before | after |
| --- | --- | --- | --- |
| `quote` | `pdfAsset` | hidden TEXT, bare asset id | single `FILE`, `isUpdatable: false` |
| `invoice` | `pdfAsset` | same | same |
| `purchase_order` | `pdfAsset` | same | same |
| `purchase_order` | `attachments` | — | **new** multi `FILE` |
| `vendor_bill` | `document` | hidden TEXT, **no reader, no writer** | single `FILE`, user-writable |
| `vendor_bill` | `attachments` | — | **new** multi `FILE` |

All six are `showInPanel: false` and surfaced by one **Documents** card — the PO drawer, the PO page sidebar and the bill drawer, from the single `DRAWER_TAB_CARD_COMPONENTS` entry both surfaces read.

## Why convert rather than add a second field

`ensureDocumentPdf` already keeps **exactly one `MediaAsset` per document** and adds a `MediaAssetVersion` per content change. "Single, and a new render replaces the old" is what the pipeline already does — `TEXT` was the only thing describing it wrongly. A second field beside the pointer would be drift by construction: the renderer writes one, the card reads the other, and the first disagreement is invisible.

## 🛑 `isUpdatable: false` is load-bearing, not tidiness

`ensureDocumentPdf` reads the pointer, loads that `MediaAsset`, and **appends a new version to it** when the stored `contentHash` disagrees with the payload's. A file a person uploaded has no `contentHash` at all, so the comparison always fails — point the field at a user's file and the next send silently republishes their file as our PDF.

`isUpdatable` closes that because of an asymmetry: it is read by the grid cell (`selectable-table-cell.tsx:72`), the panel, the dialogs and connector writability, and is **not** read by the field-value write path. So it locks every human door and leaves the renderer untouched — the same move `079-enrichment-fields-backend-owned` made for the company enrichment markers. The card derives its read-only rows from that one capability through `toPanelField`, whose documented job is stopping two surfaces from answering the question differently.

## Migration 112, not a fold into 108

`ensureCustomFields` is INSERT-only — an existing `(entityDefId, systemAttribute)` row is put in the field map and `continue`d, never compared. A registry edit reaches new orgs and can never reshape a row 108 already created, so 112 reconciles the four rows from the registry and moves their values out of `valueText` into the `{ v, meta }` FILE envelope. 108 still *creates* the fields: it reads the registry, so a fresh org gets the new shape there and 112 is a no-op for it.

Extending 108 in place would have been the `078`/`079` mistake — the runner skips an applied id, so the fold reaches exactly the environments that do not need it.

Idempotent in all three parts: `ensureCustomFields` skips an existing field, the `CustomField` `WHERE` matches only rows still in the old shape, and the value move only touches rows that still carry `valueText`.

## Notes

- `vendor_bill_document` was free to convert: **zero value rows**, and despite its own description promising a drawer surface, no reader and no writer anywhere in the repo.
- The bill keeps `document` and `attachments` as **separate** fields. The single slot is what a later extraction pass parses; "the first element of the array" is a convention that survives until somebody reorders.
- This is the first `allowedFileTypes: ['document']` field in the registry — every existing FILE field is images-only. Nothing in the record path is image-specific (`isImagesOnly` gates only camera capture and the HEIC transcode, and anything else falls through to `getMimePatternsForCategories`), but it has never been exercised, so it wants one browser round trip before it is called done.

## Testing

- `packages/lib` full suite: **13938 passed**, 79 skipped.
- New: `112-record-documents.test.ts` (registration + the field shapes the migration depends on) and `pdf-pointer-ref.test.ts` (every way the pointer read can silently return the wrong thing — the symptom is always a second MediaAsset per render and no error).
- `108-purchasing.test.ts`'s pdf-asset parity test updated to the new shape; the "111 is last" guard moved to 112.
- Typecheck ratchet: no new errors in `lib` or `web`.