### PR TITLE
drawer section polish: icons, hover, and the summary strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,31 +321,32 @@ record per `EntityType` in `upload/handlers/`, not a class hierarchy: the
 call sites to them. History and the open items are in `plans/attachments/`
 (untracked).
 
-## Duplicate Detection
+## Inventory, Purchasing & Costing
 
-**Before touching the dedup engine, the duplicate scan job, `DuplicateSuggestion`
-rows, or the duplicate review surfaces, read
-`docs/duplicate-detection-architecture-guide.md`.** It documents the **genesis
-map** (which write-time check produces which shape of duplicate, and why the
-exact arm is largely a backfill/enforcement-leak detector while the name arm
-catches what happens next), why **trigram cannot rank names** — `john smith`/`jane
-smith` measures 0.47, above `william klooth`/`bill klooth` at 0.42, and
-`bob`/`robert` share zero trigrams — the three-condition **name-alone rule** and
-why surname rarity exists, the one-job/three-scopes/two-arms scan, and the pair
-lifecycle.
+**Before touching purchase orders, vendor bills, the three-way match, receiving,
+`stock_movement`, builds, standard cost, QoH, or GL postings, read
+`docs/inventory-costing-architecture-guide.md`.** It documents the thirteen
+entities this subsystem adds (all `EntityInstance`-backed — **no new Drizzle
+tables**), the buy→receive→bill→match path, the costing model and where each
+number comes from, the movement writers and their doors, the L1/L3 posting
+regimes, and §12's list of places the plans and the code currently disagree.
 
-Short version: pairs are stored in canonical `(low, high)` order; **deletion is
-how an `open` pair goes away** while `dismissed`/`merged` are the only persisted
-terminal states; the watermark stamp MUST be raw SQL touching one column, because
-`EntityInstance.updatedAt` carries `$onUpdate` and a Drizzle update re-dirties the
-row into an infinite scan loop; the `sync:records:changed` consumer must never
-claim the manifest (that latch belongs to record rules); blocking is one lookup
-core call **per value**, because the core dedupes hits across candidates by
-recordId; both scan arms must merge onto the canonical key before scoring or
-`upsertPairs`' last-writer-wins silently rewrites a `high` pair as `medium`;
-trigram similarity is a blocker only and must never reach `score` or a `Signal`;
-and every read path filters `archivedAt IS NULL` on **both** sides and applies
-record scope per join alias (`dupLow`/`dupHigh`).
+Short version: the movement ledger is **append-only** (`updatable: false`
+everywhere) and a mistake is corrected by **reversing**, never editing; cost is
+**frozen onto the movement at write time** and a standard-cost change revalues
+on-hand inventory to 5090 rather than restating history — so `part_cost` (live
+replacement cost, rewritten on every vendor-price change) must never value a
+movement; `part_quantity_on_hand` is a **full re-SUM of the ledger** that only
+`recalculatePartQoH` may write, which is also why FIFO and lot *costing* are
+ruled out; the match's variance must use `quantityReceived × unitPriceExpected`
+or an over-billed quantity nets out against an under-billed price to zero;
+receiving part-first sets no `purchaseOrderLineId`, so it moves QoH and leaves
+the match with no receipt leg; a bill's totals are **transcribed, never
+computed**, because recomputing them silently corrects the vendor's arithmetic;
+`skipEvents` is insufficient for a silent ledger write (use `quietSession`, and
+remember a quiet lane also silences the QoH recalc); and **a balance assertion
+and per-event postings may never both drive 1310/1320/1330** — L1 or L3, never
+both. Status and open work live in `plans/money/` (untracked).
 
 ## Workflows
 

--- a/apps/web/src/components/detail-view/utils.ts
+++ b/apps/web/src/components/detail-view/utils.ts
@@ -1,27 +1,58 @@
 // apps/web/src/components/detail-view/utils.ts
 
 import {
+  Activity,
+  ArrowLeftRight,
+  Banknote,
   Box,
+  Boxes,
+  Calculator,
   Calendar,
   CalendarClock,
   Clock,
   CreditCard,
+  FileText,
+  Gauge,
+  Hammer,
   History,
   HouseIcon,
   Layers,
+  Link,
   ListTodo,
   type LucideIcon,
   Mail,
+  MapPin,
   MessagesSquare,
   Package,
+  Paperclip,
+  Plug,
+  Receipt,
   ReceiptText,
+  ScanSearch,
   ShoppingBag,
+  Store,
+  Tag,
   Ticket,
   Truck,
+  User,
+  Users,
+  Wrench,
 } from 'lucide-react'
 
 /**
- * Icon name to component mapping
+ * Icon name to component mapping — the ONE map for every `icon:` string in
+ * `drawer-config.ts` and `detail-view-config.ts`, covering main tabs, sidebar
+ * tabs, drawer additional tabs AND card section headers.
+ *
+ * It is one map because it used to be two. `base-entity-drawer.tsx` carried a
+ * second, shorter copy that `TabCardSection` resolved CARD icons through, and
+ * the two drifted: `store` and `paperclip` were live in the card configs but
+ * present only here, so every Vendor and Documents section header silently drew
+ * the fallback instead. An unmapped name has no type error and no console
+ * warning — it just renders the wrong glyph — so the only real defence is that
+ * there is nowhere else to look.
+ *
+ * Adding an `icon:` to a config means adding the name here in the same change.
  */
 const ICON_MAP: Record<string, LucideIcon> = {
   house: HouseIcon,
@@ -42,6 +73,27 @@ const ICON_MAP: Record<string, LucideIcon> = {
   history: History,
   // work_order Billing section anchor (money plan 10 §E).
   'credit-card': CreditCard,
+  'file-text': FileText,
+  // Card section headers. Keyed by the card's `value`, so the same card carries
+  // the same glyph in the drawer and in the detail page's sidebar.
+  activity: Activity,
+  'arrow-left-right': ArrowLeftRight,
+  banknote: Banknote,
+  boxes: Boxes,
+  calculator: Calculator,
+  gauge: Gauge,
+  hammer: Hammer,
+  link: Link,
+  'map-pin': MapPin,
+  paperclip: Paperclip,
+  plug: Plug,
+  receipt: Receipt,
+  'scan-search': ScanSearch,
+  store: Store,
+  tag: Tag,
+  user: User,
+  users: Users,
+  wrench: Wrench,
 }
 
 /**

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -15,28 +15,12 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { OverflowTabsList, type TabDefinition, Tabs, TabsContent } from '@auxx/ui/components/tabs'
 import { cn } from '@auxx/ui/lib/utils'
-import {
-  CalendarClock,
-  Clock,
-  CreditCard,
-  ExternalLink,
-  FileText,
-  HouseIcon,
-  Layers,
-  ListTodo,
-  Mail,
-  MessagesSquare,
-  Package,
-  Receipt,
-  ShoppingBag,
-  Ticket,
-  Truck,
-  Wrench,
-} from 'lucide-react'
+import { Clock, ExternalLink, HouseIcon, ListTodo, MessagesSquare } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
 import * as React from 'react'
 import { AppRecordActions } from '~/components/detail-view/components/app-record-actions'
+import { getIconComponent } from '~/components/detail-view/utils'
 import EntityFields from '~/components/fields/entity-fields'
 import DrawerComments from '~/components/global/comments/drawer-comments'
 import { useCommentAccess } from '~/components/global/comments/use-comment-access'
@@ -943,29 +927,4 @@ function LazyTabCard({
   }
 
   return <Component entityInstanceId={entityInstanceId} recordId={recordId} record={record} />
-}
-
-/**
- * Map icon name (string) to icon component
- */
-function getIconComponent(iconName: string) {
-  const icons: Record<string, any> = {
-    ticket: Ticket,
-    'shopping-bag': ShoppingBag,
-    mail: Mail,
-    package: Package,
-    house: HouseIcon,
-    clock: Clock,
-    messages: MessagesSquare,
-    layers: Layers,
-    truck: Truck,
-    'list-todo': ListTodo,
-    wrench: Wrench,
-    'file-text': FileText,
-    'calendar-clock': CalendarClock,
-    receipt: Receipt,
-    'credit-card': CreditCard,
-    // Add more as needed
-  }
-  return icons[iconName] ?? HouseIcon
 }

--- a/apps/web/src/components/drawers/cards/related-record-row.tsx
+++ b/apps/web/src/components/drawers/cards/related-record-row.tsx
@@ -10,6 +10,7 @@ import { getDefinitionId, type RecordId } from '@auxx/types/resource'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
 import { ExternalLink } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useOpenRecord } from '~/components/records/record-drill-panels'
@@ -37,7 +38,11 @@ export function RelatedRecordRow({
    * records-view drawer convention.
    */
   href?: string
-  /** Extra classes for the row (passed through to `TreeRow`), e.g. a hover tint. */
+  /**
+   * Extra classes for the row. Merged AFTER the shared `hover:bg-primary-100`
+   * tint, so passing a `hover:bg-*` of your own replaces it rather than fighting
+   * it (`cn` is tailwind-merge).
+   */
   rowClassName?: string
 }) {
   const router = useRouter()
@@ -63,7 +68,13 @@ export function RelatedRecordRow({
 
   return (
     <TreeRow
-      rowClassName={rowClassName}
+      // `TreeRow`'s own default is `hover:bg-background`, i.e. no visible tint on a
+      // card that already sits on the background. Every related-record block wants
+      // the same `primary-100` hover the hand-rolled `TreeRow`s in
+      // `work-order-related-cards.tsx` set inline, and before this the prop existed
+      // but no caller passed it — so the tint is the default here, not a per-card
+      // opt-in that eight cards each have to remember.
+      rowClassName={cn('hover:bg-primary-100', rowClassName)}
       onDrill={handleOpen}
       icon={
         <RecordIcon

--- a/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
@@ -24,11 +24,12 @@ import { useJobVisits } from '~/components/dispatch/ui/job-schedule/use-job-visi
 import { SchedulePopover } from '~/components/dispatch/ui/schedule-popover'
 import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
 import { BillingActionDialog } from '~/components/money/billing/billing-action-dialog'
-import { BillingSummaryStrip } from '~/components/money/billing/billing-summary-strip'
 import { InvoiceTreeRow } from '~/components/money/billing/invoice-tree-row'
 import { NewWorkOrderInvoiceButton } from '~/components/money/billing/new-work-order-invoice-button'
 import { resolveBillingAction } from '~/components/money/billing/types'
 import { useWorkOrderBillingState } from '~/components/money/billing/use-work-order-billing-state'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { PurchasingSummaryStrip } from '~/components/purchasing/purchasing-summary-strip'
 import { useOpenRecord, useRecordDrill } from '~/components/records/record-drill-panels'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import { EmptyRow, RowSkeleton, TREE_SECONDARY_NOTRUNCATE } from './related-record-row'
@@ -160,7 +161,38 @@ export function WorkOrderBillingCard({ recordId, entityInstanceId }: DrawerTabPr
           onOpenInvoice={(invoiceRecordId) => openRecord?.(invoiceRecordId)}
         />
       </DrawerCardActions>
-      <BillingSummaryStrip billing={billing} className='pb-2' />
+      {/*
+        `PurchasingSummaryStrip`, not the `BillingSummaryStrip` the full-page Billing tab
+        uses. That strip is `@container`-responsive across six cells, and at the drawer's
+        ~400px it had already collapsed to the two it considers the action-relevant tail
+        (Remaining + Balance due) — so the drawer was paying for a reveal ladder it never
+        climbed, in a shape no other drawer card uses. Three fixed cells is what every
+        other purchasing/manufacturing card in a drawer renders, so the job drawer now
+        shares that rhythm. The full-page tab keeps `BillingSummaryStrip`, where the wide
+        container does show the whole funnel.
+
+        Deposit held is dropped rather than made a fourth cell: it was already hidden
+        below @xl, so the drawer never showed it, and four money cells do not fit.
+      */}
+      <PurchasingSummaryStrip
+        cells={[
+          {
+            label: 'Invoiced',
+            value: formatCurrency(billing.invoiced, billing.currencyCode),
+            tone: billing.invoiced === 0 ? 'muted' : 'default',
+          },
+          {
+            label: 'Remaining',
+            value: formatCurrency(billing.remaining, billing.currencyCode),
+            tone: billing.remaining === 0 ? 'muted' : 'default',
+          },
+          {
+            label: 'Balance due',
+            value: formatCurrency(billing.balanceDue, billing.currencyCode),
+            tone: billing.balanceDue === 0 ? 'muted' : 'default',
+          },
+        ]}
+      />
       <TreeRow
         rowClassName='hover:bg-primary-100'
         icon={<CreditCard className='size-4' />}

--- a/apps/web/src/components/manufacturing/builds/build-run-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-run-card.tsx
@@ -244,7 +244,6 @@ export function BuildRunCard({ entityInstanceId }: DrawerTabProps) {
       )}
 
       <PurchasingSummaryStrip
-        className='pt-1'
         cells={[
           { label: 'Planned', value: formatQuantity(run.quantityPlanned) },
           {

--- a/apps/web/src/components/money/ui/document-actions-cluster.tsx
+++ b/apps/web/src/components/money/ui/document-actions-cluster.tsx
@@ -58,8 +58,22 @@ export function DocumentActionsCluster({
         {send &&
           (send.disabledReason ? (
             <Tooltip allowInteraction contentComponent={send.disabledReason}>
+              {/*
+                `rounded-r-none` is explicit here and NOT on the enabled branch below,
+                which looks inconsistent and is not. `ButtonGroup` squares its inner
+                corners with direct-child selectors (`[&>*:not(:last-child)]:rounded-r-none`),
+                and a disabled button cannot receive the hover that opens a tooltip — so
+                this branch needs the `<span>` wrapper, and that wrapper becomes the
+                group's direct child. The selectors then style the span, which has no
+                border or radius of its own, while the button inside keeps its full
+                `rounded-lg` and bulges out of the right-hand seam. The enabled branch
+                IS the direct child, so the group still reaches it.
+
+                `publish-cluster-shell.tsx` carries the same `rounded-none border-x-0`
+                on its own tooltip-wrapped disabled segment, for the same reason.
+              */}
               <span className='inline-flex'>
-                <Button size='xs' variant='outline' className='border-r-0' disabled>
+                <Button size='xs' variant='outline' className='rounded-r-none border-r-0' disabled>
                   {send.label}
                 </Button>
               </span>

--- a/apps/web/src/components/money/ui/invoice/invoice-billing-context-card.tsx
+++ b/apps/web/src/components/money/ui/invoice/invoice-billing-context-card.tsx
@@ -3,7 +3,8 @@
 
 import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import { Button } from '@auxx/ui/components/button'
-import { ArrowRight, CalendarDays, Wrench } from 'lucide-react'
+import { EmptySection } from '@auxx/ui/components/section'
+import { ArrowRight, CalendarDays, Receipt, Wrench } from 'lucide-react'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { useOpenRecord } from '~/components/records/record-drill-panels'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
@@ -25,8 +26,11 @@ export function InvoiceBillingContextCard({ recordId }: DrawerTabProps) {
   if (isLoading) return <div className='h-14 animate-pulse rounded-xl bg-muted' />
   const kind = String(values.invoice_billing_kind ?? 'standalone')
   const workOrderId = extractRelationshipRecordIds(values.invoice_work_order)[0]
+  // `horizontal` rather than the default `vertical`: this is the card's ordinary
+  // resting state, not a failure to load anything, so it holds one TreeRow's height
+  // instead of a 6rem empty panel.
   if (kind === 'standalone')
-    return <p className='text-sm text-muted-foreground'>Standalone invoice</p>
+    return <EmptySection orientation='horizontal' icon={<Receipt />} title='Standalone invoice' />
   const installmentValue = unwrap(values.invoice_installment_name)
   const installment = installmentValue == null ? null : String(installmentValue)
   const progress = Number(unwrap(values.invoice_progress_percent) ?? 0)

--- a/apps/web/src/components/money/ui/payments/payments-list.tsx
+++ b/apps/web/src/components/money/ui/payments/payments-list.tsx
@@ -176,6 +176,7 @@ export function PaymentsList({
 
         return (
           <TreeRow
+            rowClassName='hover:bg-primary-100'
             icon={<CreditCard className='size-4' />}
             title={
               <span className='flex min-w-0 items-center gap-1.5'>

--- a/apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
@@ -336,7 +336,6 @@ export function CreateBillFromPurchaseOrderDialog({
 
         <div className='space-y-4'>
           <PurchasingSummaryStrip
-            className='rounded-2xl border px-3 py-2'
             cells={[
               { label: 'Order total', value: formatCurrency(orderTotal, { currencyCode }) },
               { label: 'Already billed', value: formatCurrency(billed, { currencyCode }) },

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-bills-card.tsx
@@ -132,7 +132,6 @@ export function PurchaseOrderBillsCard({ recordId }: DrawerTabProps) {
         }}
       />
       <PurchasingSummaryStrip
-        className='pb-2'
         cells={[
           { label: 'Order total', value: formatCurrency(orderTotal, { currencyCode }) },
           { label: 'Billed', value: formatCurrency(billed, { currencyCode }) },

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-receiving-card.tsx
@@ -78,7 +78,6 @@ export function PurchaseOrderReceivingCard({ recordId }: DrawerTabProps) {
         purchaseOrderRecordId={recordId}
       />
       <PurchasingSummaryStrip
-        className='pb-2'
         cells={[
           { label: 'Ordered', value: formatQuantity(ordered) },
           { label: 'Received', value: formatQuantity(received) },

--- a/apps/web/src/components/purchasing/purchasing-summary-strip.tsx
+++ b/apps/web/src/components/purchasing/purchasing-summary-strip.tsx
@@ -32,6 +32,10 @@ export interface SummaryCell {
  * Column count is fixed to the cell count rather than container-queried: these
  * cards carry three cells, which fits the drawer's ~400px min width without the
  * reveal-as-it-widens treatment the six-cell billing strip needs.
+ *
+ * The strip owns its own spacing and border — call sites pass `className` only to
+ * place the strip, never to restyle it. Cell radius is the outer radius minus the
+ * outer padding (16px - 4px = 12px, `rounded-xl`) so the two curves stay concentric.
  */
 export function PurchasingSummaryStrip({
   cells,
@@ -42,10 +46,12 @@ export function PurchasingSummaryStrip({
 }) {
   return (
     <div
-      className={cn('grid gap-3', className)}
+      className={cn('grid gap-1 rounded-2xl border p-1', className)}
       style={{ gridTemplateColumns: `repeat(${cells.length}, minmax(0, 1fr))` }}>
       {cells.map((cell) => (
-        <div key={cell.label} className='flex flex-col gap-0.5'>
+        <div
+          key={cell.label}
+          className='flex flex-col gap-0.5 rounded-xl border px-2 py-1 bg-primary-100/50'>
           <span className='text-muted-foreground text-xs'>{cell.label}</span>
           <span
             className={cn(

--- a/apps/web/src/components/purchasing/vendor-bill/vendor-bill-match-card.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/vendor-bill-match-card.tsx
@@ -32,7 +32,13 @@
 // sits. The ruling is the badge and the reason list, and both come from the hook.
 //
 // The "Match" section title is rendered by the drawer's `TabCardSection` wrapper,
-// so this card must not draw one.
+// so this card must not draw one. The status badge is the one thing that DOES
+// belong up there beside the title — it is the card's verdict in two words, and
+// read before any of the numbers — so it is portaled into that same wrapper's
+// header actions slot via `DrawerCardActions` rather than drawn as the first row
+// of the body. Nothing renders it when the card is mounted outside a
+// `TabCardSection`: the portal target is absent and `DrawerCardActions` yields
+// null, which is the documented behaviour and not a badge worth duplicating.
 
 import type { RecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
@@ -50,6 +56,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { formatCurrency } from '@auxx/utils/currency'
 import { History, ScanSearch, TriangleAlert } from 'lucide-react'
 import { useMemo } from 'react'
+import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
@@ -250,11 +257,11 @@ export function VendorBillMatchCard({ recordId }: DrawerTabProps) {
   return (
     <div className='flex flex-col gap-3 pe-3'>
       {statusBadge && (
-        <div>
+        <DrawerCardActions>
           <Badge variant={statusBadge.variant} size='sm'>
             {statusBadge.label}
           </Badge>
-        </div>
+        </DrawerCardActions>
       )}
 
       <PurchasingSummaryStrip

--- a/apps/web/src/components/purchasing/vendor-bill/vendor-bill-payment-card.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/vendor-bill-payment-card.tsx
@@ -92,7 +92,6 @@ export function VendorBillPaymentCard({ recordId }: DrawerTabProps) {
       )}
 
       <PurchasingSummaryStrip
-        className='pb-2'
         cells={[
           { label: 'Bill total', value: formatCurrency(total, { currencyCode }) },
           { label: 'Paid', value: formatCurrency(amountPaid, { currencyCode }) },

--- a/apps/web/src/components/signals/ui/communications-list.tsx
+++ b/apps/web/src/components/signals/ui/communications-list.tsx
@@ -120,6 +120,7 @@ export function CommunicationsList({
         return (
           <TreeRow
             key={signal.id}
+            rowClassName='hover:bg-primary-100'
             icon={<Icon className='size-4' />}
             title={<span className='truncate text-sm'>{labelForSignal(signal)}</span>}
             secondary={<span className='truncate text-muted-foreground'>{signal.title}</span>}

--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -1,0 +1,635 @@
+<!-- docs/inventory-costing-architecture-guide.md -->
+
+# Inventory, Purchasing & Costing Architecture Guide
+
+**Last Updated:** 2026-08-28
+**Scope:** The money spine that points *inward and through* — buy, receive, bill, match, build,
+value, and post. `purchase_order` → `stock_movement` → `vendor_bill` → three-way match →
+`build` → `gl_posting`. What each entity owns, where a cost comes from and when it freezes,
+who may write the movement ledger, and the silent-failure modes this subsystem has already
+paid for.
+
+> This is the durable half. The design history and the open work live in `plans/money/`, which
+> is **not tracked in git** — `plans/money/README.md` is the status entry point, `decisions.md`
+> the decision register, `design/` the long-form arguments, `archive/` the finished ones.
+> **Where a plan and the code disagree, the code is the truth**, and §12 lists the places they
+> currently do.
+> Companions: `entity-architecture-guide.md` (definitions, fields, `FieldValue`, the lookup
+> core), `entity-events-architecture-guide.md` §8 (the sync-change manifest), `skip-events-history.md`
+> (the write lanes), `lib-module-guide.md` (module shape), `ui-design-guide.md` (the cards and
+> the line builder).
+
+---
+
+## Table of Contents
+
+1. [Executive Overview](#1-executive-overview)
+2. [Core Concepts & Vocabulary](#2-core-concepts--vocabulary)
+3. [The Data Model — thirteen entities, zero new tables](#3-the-data-model--thirteen-entities-zero-new-tables)
+4. [The Buy Side — purchase order to vendor bill](#4-the-buy-side--purchase-order-to-vendor-bill)
+5. [The Three-Way Match](#5-the-three-way-match)
+6. [The Movement Ledger](#6-the-movement-ledger)
+7. [Costing — where a number comes from and when it freezes](#7-costing--where-a-number-comes-from-and-when-it-freezes)
+8. [The Make Side — the build event](#8-the-make-side--the-build-event)
+9. [The GL Seam — what exists, what is designed](#9-the-gl-seam--what-exists-what-is-designed)
+10. [Write Lanes & the Silent Ledger Write](#10-write-lanes--the-silent-ledger-write)
+11. [Gotchas & Invariants](#11-gotchas--invariants)
+12. [Where the Plans and the Code Disagree](#12-where-the-plans-and-the-code-disagree)
+13. [Key Files](#13-key-files)
+
+---
+
+## 1. Executive Overview
+
+Everything auxx.ai did with money originally pointed **outward**: quote → order → invoice →
+payment. This subsystem is the inward half plus the transformation in the middle.
+
+```
+  BUY                        RECEIVE                 BILL                    MATCH
+ ──────────────────   ──────────────────────  ─────────────────────  ────────────────────
+  purchase_order        stock_movement          vendor_bill            matchBill()
+   + _line               type: 'receive'         + _line                three legs:
+   what we agreed        what arrived, when,     what we are            PO price  ── expected
+   to buy, at what       at what cost            being charged          receipt   ── received
+   price                  ↑ append-only           (transcribed,          bill      ── billed
+        │                  updatable: false        never computed)           ↓
+        │                       │                       │            matched | exception
+        └───────────────────────┴───────────────────────┘                     ↓
+                                │                                      (phase 7) gl_posting
+  MAKE                          │
+ ──────────────────             │
+  build                         │
+   completeBuild() writes  ──────┘
+   consume(−) + produce(+)
+   in ONE transaction
+   at a cost that sticks
+```
+
+Four properties carry the whole design:
+
+1. **auxx.ai is the system of record; the accounting provider is an exporter.** Every fact
+   lives in auxx entities. The provider push is one adapter behind one interface, and the
+   provider's own ids live in `RecordIdentity`, never in a column. (Decision P1.)
+2. **The movement ledger is append-only.** Every field on `stock_movement` is
+   `updatable: false`. A mistake is corrected by *reversing* it, never by editing it. This is
+   what makes the ledger trustworthy and what rules out FIFO layers (§7.3).
+3. **Cost is frozen onto the movement at write time**, and nothing ever restates it. A vendor
+   price change in March must not move January's COGS.
+4. **Quantity on hand is a full re-SUM of the ledger, per part, on every write.** Nothing else
+   may write it — not a connector, not a sink, not a form.
+
+---
+
+## 2. Core Concepts & Vocabulary
+
+| Term | Means |
+| --- | --- |
+| **Movement** | One `stock_movement` row. The only thing that changes stock. Append-only. |
+| **QoH** | `part_quantity_on_hand`. Derived — a full `SUM(quantity)` over the part's movements, recomputed by `recalculatePartQoH`. Never authored. |
+| **Standard cost** | `part_standard_cost`, frozen by `rollStandardCost`. The value every movement stamps. Distinct from `part_cost`. |
+| **`part_cost`** | The **live** rolled-up material cost, rewritten on every vendor-price change and propagated to ancestors. Correct for *pricing* (what to charge next), fatal for *valuation*. Read it as **replacement cost**. |
+| **Landed cost** | `unitPrice + shippingCost + unitPrice × tariffRate/100 + otherCost`. What a receipt actually cost, including freight and duty. |
+| **PPV** | Purchase price variance — account `5090`. The delta between what a receipt cost and the frozen standard. |
+| **GRNI** | Goods Received Not Invoiced, account `2160`. The clearing account between "we have the goods" and "we have the invoice". |
+| **Three-way match** | PO price × receipt quantity × bill amount, compared with tolerances. Produces `matched` or `exception`. |
+| **`partKind`** | `component` \| `subassembly` \| `finished_good`. Decides the inventory account (`1310` / `1330`) and whether a part is *buildable*. Stored and auditable — deliberately not derived. |
+| **L1 / L3** | The GL posting regime. **L1** = one periodic entry per month asserting inventory balances. **L3** = perpetual per-event postings. Exactly one may drive `1310/1320/1330`. |
+| **Buildable** | `subassembly` or `finished_good`. Only these absorb conversion (labour + overhead) cost. |
+
+---
+
+## 3. The Data Model — thirteen entities, zero new tables
+
+**Every entity in this subsystem is an `EntityInstance` on a seeded system definition.** There
+are no new Drizzle tables. Fields are `CustomField` rows; values are `FieldValue` rows. That is
+a deliberate decision (P2, P3, P4, P5) and it has consequences — see §12 for the one place it
+was argued against and lost.
+
+Seeded in `packages/lib/src/seed/entity-seeder/constants.ts`:
+
+| Entity | Visible | Owns |
+| --- | --- | --- |
+| `purchase_order` | ✅ | What we agreed to buy, at what price. The **price arm** of the match. |
+| `purchase_order_line` | ❌ | Part, quantity, `expected_unit_price`, the received/billed roll-ups. |
+| `vendor_bill` | ✅ | What we are being charged. Totals are **transcribed**, never computed. |
+| `vendor_bill_line` | ❌ | `quantityBilled`, `unitPriceBilled`, the `purchaseOrderLine` match key. |
+| `stock_movement` | — | The ledger. Append-only, `updatable: false` throughout. |
+| `build` | ✅ | A production run: consume components, produce a finished good. |
+| `part` | ✅ | The stock master. Carries `partKind`, QoH, and the five frozen standard-cost fields. |
+| `vendor_part` | ❌ | The `(part, supplier)` price row. Prefill and provenance only. |
+| `gl_account` | ❌ | Our chart of accounts. The provider's id hangs off it via `RecordIdentity`. |
+| `gl_posting` | ❌ | One journal entry. Written only by the poster. |
+| `gl_posting_line` | ❌ | Double-entry lines, keyed on an account **code** (`'2160'`), never a provider id. |
+| `vendor_payment` | ❌ | 🛑 **INERT.** Seeded, zero writers, zero rows. See §11. |
+| `vendor_payment_allocation` | ❌ | 🛑 **INERT.** The header/allocation split that lets one bank line clear several bills. |
+
+### 3.1 Why the line entities are their own type
+
+`line_item` is a **sell** line: `unitPrice` is a sell price and eight of its fields are
+permanently dead on a purchase. Reusing it would have put two incompatible meanings on one
+field. The *UI* is shared — `LineBuilder` renders all four document types — but the entity is
+not (P4, P5).
+
+### 3.2 What is deliberately absent
+
+- **No `goods_receipt` header.** The PO header already carries the totals and the freight
+  allocation basis, which was the header's one unique justification.
+- **No `line_item.unitCost`.** A sold line stores no cost. Point-in-time cost lives on the
+  movement at `(fulfillment, line)` grain; a single CURRENCY column cannot hold the two frozen
+  costs of one line shipping across two periods (D16).
+- **No lot costing.** A lot is a traceability axis — recall, warranty, supplier quality — and
+  a nullable label on a movement. It holds no quantity and no cost bucket (P11, §7.3).
+- **No aging, remittance or 1099.** Payment itself is in scope; the A/P *reporting* layer is not.
+
+---
+
+## 4. The Buy Side — purchase order to vendor bill
+
+### 4.1 The status axes
+
+A purchase order does **not** have one status enum. One enum conflated three independent
+questions and could not answer any of them. It is split into:
+
+| Axis | Written by | Values |
+| --- | --- | --- |
+| **Action** | guarded transitions | `draft` → `issued` → … |
+| **Receipt** | derived from the line roll-ups | nothing / partial / complete |
+| **Billing** | derived from the line roll-ups | nothing / partial / complete |
+
+Only the action axis is authored. The other two are read from
+`purchase_order_line_quantity_received` / `_quantity_billed`, which are maintained roll-ups.
+
+The confirmed-send flip writes **`issued`**, not `sent` — one event, one value. It lives in
+`flipDocumentStatusOnSend` on the `message:sent` event (a worker job), **not** in the router,
+so it fires on all four send doors.
+
+### 4.2 Receiving — two doors, one of which is the real one
+
+| Door | Surface | Sets `purchaseOrderLineId`? |
+| --- | --- | --- |
+| **PO-first** (primary) | `ReceivePurchaseOrderDialog`, off the Receiving card | ✅ yes |
+| Part-first | `ReceiveStockPopover` on the part's inventory tab | ❌ no |
+| Adjust stock | `stock-adjustment-popover.tsx` → `adjustStock` | ❌ no |
+
+🛑 **Part-first receiving against a purchase order is not merely tedious, it is wrong.** With no
+`purchaseOrderLineId` the movement never rolls up, `quantityReceived` stays at zero, and the
+three-way match has no receipt leg — so all that clicking produces a correct QoH and a broken
+match. The friction and the defect had the same cause.
+
+**The server prices a receipt, not the browser.** `receiveStock` → `resolveReceiptPrice` owns
+the arithmetic. A form that sends only a base price gets a cost derived from the *supplier row's*
+`unitPrice` — which may be the price the user just replaced. See §11.
+
+**Over-receipt is never clamped.** A vendor shipping 12 against an order for 10 is exactly what
+the match exists to surface; capping it hides the discrepancy at the one moment somebody is
+holding the packing slip.
+
+**A line receiving zero is excluded from freight allocation.** Freight is spread across what was
+actually on the truck; including a line that did not arrive dilutes every other line's share.
+
+### 4.3 The bill
+
+**Bill totals are transcribed, not computed.** Recomputing a bill's totals from its lines
+silently corrects the vendor's arithmetic — which is precisely the discrepancy the match exists
+to surface. This is the rule; the one deliberate exception is the *prefill* of the header total
+in `CreateBillFromPurchaseOrderDialog`, which is safe only because the header total is **not a
+match input** (the match weighs the lines).
+
+Raising a bill's lines from the order prefills the **structure** and never the **match inputs**:
+`purchaseOrderLine` (the join), `part`, `description` and the `2160` GRNI code are filled;
+`quantityBilled`, `unitPrice` and `lineTotal` are left for the person holding the invoice.
+
+⚠️ `quantityBilled` cannot literally be left blank — it is `nullable: false, defaultValue: 1`,
+so a created line reads `1` until typed. That is safe *because* `quantityExact: true`: billing 1
+against 10 received raises `quantity_under_billed` rather than passing quietly. A forgotten
+quantity is loud.
+
+---
+
+## 5. The Three-Way Match
+
+`packages/lib/src/purchasing/match.ts`. A pure function over three inputs, with tolerances.
+
+```
+                 purchase_order_line.expected_unit_price   ← what we agreed (price arm)
+matchBill(bill) ─ purchase_order_line.quantity_received    ← what arrived   (quantity arm)
+                 vendor_bill_line.quantity/unit_price      ← what we are charged
+                          ↓
+        { outcome: 'matched' } | { outcome: 'exception', reasons[], variance }
+```
+
+**The tolerance** (`DEFAULT_MATCH_TOLERANCE`): `pricePercent`, `priceAbsolute` (a flat floor in
+minor units), and `quantityExact: true`. The allowance is `max(percent, absolute)`. The actual
+default values are a **guess** — nobody has looked at a real vendor invoice yet.
+
+**Reasons** are discriminated on `code` and each carries the numbers it compared, so the queue
+renders billed / received / expected side by side without a string parse:
+`quantity_over_billed`, `quantity_under_billed`, `price_variance`.
+
+### 5.1 Two rules the match must not lose
+
+**Variance is `billed − (quantityReceived × unitPriceExpected)`.** Using *billed* quantity on
+both sides lets an over-billed quantity net out against an under-billed price to zero — hiding
+the exact failure the match exists to catch.
+
+**The match re-runs when the goods arrive.** `matchBill` fires on a bill write and a bill-line
+write. Nothing in `receiving/` originally called it, so the verdict depended on the order the
+paperwork happened to arrive in: enter the bill before the goods and `billed 1 but only 0
+received` stood **forever**. `rematchBillsForPurchaseOrderLines`
+(`purchasing/match-reconciler.ts`) closes it, driven from the receipt roll-up for lines whose
+received total actually moved — gated on the roll-up's own evidence, never on a `targetAttr`
+string.
+
+> 🛑 **The generalisable failure:** every unit test passed, because each one drives the match
+> directly and none of them models two documents arriving out of order. A queue holding
+> exceptions that are no longer true teaches people to clear it without reading it.
+
+### 5.2 The open question the match cannot currently answer
+
+A bill for goods that **have not arrived yet**. Prepayment is normal here — vendors often will
+not ship until the invoice is paid — so `billed > received` is the correct state of a correct
+bill for weeks, and the match calls it `quantity_over_billed`. The recommended shape is an
+`awaiting_receipt` outcome that is *not* an exception, aged off `purchase_order_expected_at` so
+it becomes one once late. `matchVariance` needs its own answer in that mode: price-only,
+because quantity cannot be judged yet.
+
+---
+
+## 6. The Movement Ledger
+
+`stock_movement` is the append-only spine. **Every field is `updatable: false`**, deliberately.
+
+### 6.1 The writers
+
+| Writer | Produces | Lane |
+| --- | --- | --- |
+| `receiveStock` / `receivePurchaseOrder` | `receive` (+) | interactive |
+| `adjustStock` | `adjust` (±) | interactive |
+| `completeBuild` | `build_consume` (−) **and** `build_produce` (+) | quiet, one transaction |
+| `reverseMovement` / `reverseBuild` | the negating row | quiet |
+
+**A correction is a reversal, never an edit.** `reverseMovement` exists for exactly this. The
+double-reversal guard is a read-then-write with no DB constraint available on a `FieldValue`,
+so it is best-effort.
+
+### 6.2 QoH is derived
+
+`recalculatePartQoH` re-SUMs the whole ledger for a part. This is what makes the ledger the
+truth and it is **why a connector or sink may never write `part_quantity_on_hand`** — the next
+movement would overwrite it. A Shopify `inventory_quantity` therefore has to land in its own
+column regardless of any mapping decision; the drift check is a column-vs-column comparison on
+one row.
+
+Being a full re-SUM makes QoH **order-independent**, which is exactly why it is compatible with
+standard cost and moving average, and *not* with FIFO layer allocation (which must be
+incremental and therefore locked). See §7.3.
+
+### 6.3 `occurredAt`
+
+`ORDER BY COALESCE(occurredAt, createdAt)` is the ledger's real ordering. A backdated receipt is
+a date correction under standard or average costing — and a full recomputation under FIFO. That
+asymmetry is one of the reasons FIFO is not on the table.
+
+---
+
+## 7. Costing — where a number comes from and when it freezes
+
+### 7.1 The three costs, named honestly
+
+| Field | Written by | Answers |
+| --- | --- | --- |
+| `part_cost` | `recalculateAffectedParts`, on every vendor-price change | *What would this cost to buy next?* — **replacement cost**. Drives markup pricing. |
+| `part_standard_cost` | `rollStandardCost` only. `updatable: false`, `computed: true` | *What do we value this at?* — **the value every movement stamps.** |
+| `part_average_cost` | — | Only exists if moving-average is ever chosen over standard. |
+
+🛑 **`part_cost` cannot be the accounting standard.** It is rewritten on every vendor-price
+change and propagates to every ancestor, so valuing a movement with it means a motor price
+change in March silently restates January's COGS.
+
+The standard is split into four components plus an effective date —
+`standardMaterialCost`, `standardLaborCost`, `standardOverheadCost`, `standardCost`,
+`standardCostEffectiveAt` — because the fulfillment COGS entry must split across
+**5000 Materials / 5010 Direct Labor / 5020 Applied Overhead**, and it can only do that if the
+finished-good standard remembers its composition.
+
+### 7.2 `rollStandardCost` — four rules learned the hard way
+
+`packages/lib/src/builds/standard-cost.ts`.
+
+1. **Bottom-up, summing children's `standardCost` — not their `part_cost`.** `part_cost` is a
+   pure material chain with no labour or overhead at any level, so rolling it drops every
+   subassembly's conversion cost on the way up. Because `completeBuild` values consumed rows at
+   the child's standard and produced rows at the parent's, that gap reappears as a **permanent
+   variance to 5090 on every build**.
+2. **Conversion cost only where `partKind` says buildable.** A purchased `component` must not
+   receive assembly labour it never got.
+3. **A scoped `partIds` must widen to every ancestor**, or a parent reads a stale child standard.
+4. **The revaluation delta is two figures, not one.** `(new − old) × QoH` with a **NULL `old`**
+   reports the entire on-hand inventory value as variance on the very first roll — the roll
+   everybody runs first. `revaluationDelta` (old non-NULL: a real restatement, and the only one
+   that belongs in the 5090 entry) is summed separately from `initialValue` (old NULL: opening
+   balance material).
+
+**Abort vs skip:** a *built* part whose child has no standard **throws**; a part with no inputs
+at all is **skipped and reported** — never written, and above all **never zeroed**, because `0`
+is a valid standard that would pass `completeBuild`'s "never post a zero cost" gate.
+
+**A standard-cost change touches no existing movement. Ever.** It is a one-time revaluation of
+*on-hand* inventory to 5090, not a restatement.
+
+### 7.3 Why not FIFO
+
+The receipt row looks like a cost layer, and it is necessary but nowhere near sufficient:
+
+- A layer needs a **mutable `remainingQty`**. Every movement field is `updatable: false`.
+- **One consume movement splits across layers**, so it no longer has a single `unitCost` — the
+  one-row-one-cost invariant dies, and with it the clean `SUM(extendedCost) GROUP BY glAccount`
+  the entire posting design rests on.
+- **QoH is a full re-SUM.** Layer allocation is order-dependent and must be incremental.
+- A backdated receipt forces relayering of everything downstream.
+
+The same three objections kill *lot costing*, which is specific identification with a per-lot
+key. It also imposes the cost that actually fails in practice: the floor recording which bin
+they pulled from, on every consume — and a missed selection is indistinguishable from a correct
+one until a year of margins is wrong.
+
+### 7.4 The four cost fields on the movement
+
+| Field | Meaning |
+| --- | --- |
+| `unitCost` | Standard cost per unit, frozen at write time, integer cents. |
+| `extendedCost` | `round(unitCost × quantity)`, **signed like `quantity`**, so a period rollup is a plain `SUM`. |
+| `costBasis` | `standard` \| `actual`. Always `standard` today. |
+| `glAccount` | `1310` / `1330`, resolved from `partKind` **at write time**. |
+| `qtyPerUnit` | The as-built BOM snapshot on a `build_consume` row. NULL means the component was **off-BOM** — a floor substitution. |
+
+**Why store both `unitCost` and `extendedCost`:** `unitCost` is what a human audits;
+`extendedCost` is what SQL sums without a multiply a NULL can poison.
+
+**Why store `glAccount` rather than derive it:** if a part is reclassified from `component` to
+`finished_good`, deriving would silently restate every closed period that touched it. The stored
+value is the classification *as of the movement*.
+
+**Historical movements have NULL costs and stay NULL.** They predate the regime and are not
+postable; any `listUnpostedMovements` must filter `unitCost IS NOT NULL`.
+
+### 7.5 Landed cost and the accrual split
+
+`computeLandedCost` = `unitPrice + shippingCost + unitPrice × tariffRate/100 + otherCost`.
+
+🛑 **GRNI is credited at `vendorUnitPrice`, not landed cost.** The vendor's invoice contains only
+`unitPrice` — freight is invoiced separately and weekly, duty comes from the broker. Credit GRNI
+landed and debit it vendor-only and the account never clears; it is a liability that grows
+monotonically and reconciles to nothing. Each adder clears against the accrual that matches its
+own invoice:
+
+```
+Dr 1310 Inventory              landed
+  Cr 2160 GRNI                 vendorUnitPrice × qty   ← clears against the vendor bill
+  Cr 2150 Freight Accrual      the shipping portion    ← clears against the freight invoice
+  Cr 2170 Duties Accrual       the tariff portion      ← only if tariffRate is ever non-zero
+```
+
+---
+
+## 8. The Make Side — the build event
+
+`packages/lib/src/builds/`. A `build` records: consume the components, produce the finished good,
+at a cost that sticks.
+
+```
+completeBuild()  —— ONE transaction ——▶  −20  400Lbs Motor Assembly  @ child standard
+                                          +10  Auxx Lift 400lbs      @ parent standard
+```
+
+- **WIP is derived, not stored.** Consume and produce are written in one transaction, so the
+  ledger never holds an intermediate state. `1320 WIP` exists in the GL entry — where the
+  variance becomes visible — and nets to zero on every completed build.
+- **A build is reversed, never edited.** Same rule as the movement it writes.
+- **`build_status` is guarded** on the field chain, for `['in_progress', 'completed', 'canceled']`.
+  `planned` is excluded *structurally*: it is the field's `defaultValue` and `applyDefaults`
+  injects it into every create before the field chain, which has no create exemption — guarding
+  it would refuse every build create.
+- 🛑 **The guard is registered on the field chain ONLY**, unlike quote/invoice/PO. See §11.
+- **Residual:** `completed → planned` by hand stays reachable. Closing it needs a *transition*
+  guard, which the field chain cannot express (`existingValue` is hardcoded `undefined` on the
+  single-field path), so writing one would produce an inert guard.
+
+### 8.1 An order-raised build tracks its order
+
+An order raises the builds needed to fulfil it, through **one** raise door. The build is a
+**projection** of the order, not a snapshot: the order controls the build, a reconcile overwrites
+a human's edit, and coverage is the full ordered quantity. Divergence is stamped
+(`order_build_revision` / `build_order_revision`) and *shown* — drift is `true` only when both
+stamps exist and differ; a missing stamp is *unknown*, never *drifted*.
+
+`reconcile-policy.ts` decides and `reconcile-order-builds.ts` executes; the stamp ignores the
+edit window and the apply honours it.
+
+### 8.2 `stock_movement_adjust_subparts` — do not delete this field
+
+It was once the inventory bridge's flag, and the bridge is deleted. **The field is still live and
+still must not be deleted**: `explodeBomMovement` guards on it as its third statement, before any
+query, so a `false` reaches that guard on every write lane. It is now the belt that keeps a
+build's movements from exploding their own BOM. Update the reasoning, not the conclusion.
+
+---
+
+## 9. The GL Seam — what exists, what is designed
+
+### 9.1 What is built
+
+- `gl_posting`, `gl_posting_line`, `gl_account` **entities**, seeded and invisible.
+- `packages/lib/src/postings/` — `build-entry.ts`, `periods.ts`, `provider.ts`. Pure-ish;
+  persists nothing yet.
+- Postings are stored as **double-entry lines keyed on an account CODE** (`'2160'`), never a
+  provider account id. Provider ids live in `RecordIdentity`, hung off `gl_account` by the app
+  that owns them. This is the whole cash value of "the provider is an exporter" (P2).
+
+### 9.2 What is designed and not built
+
+`packages/lib/src/money/gl/` **does not exist**. The builder/poster seam, the fulfillment entry,
+and the close console are all design-only — see `plans/money/design/gap-e/f/g`.
+
+The intended seam is *builders are the accounting, the poster is the plumbing*: each builder
+returns a `DraftJournalEntry` of **logical account keys** and **integer minor units, always
+positive, with direction as a separate field**; one poster resolves keys to provider ids,
+asserts `Σ Debit === Σ Credit`, and handles idempotency.
+
+### 9.3 L1 vs L3 — the load-bearing constraint
+
+🛑 **A balance assertion and per-event postings cannot both drive `1310` / `1320` / `1330`.** The
+monthly assertion would silently reverse every perpetual posting and dump the residual into COGS,
+where it would look like consumption.
+
+**L1 (what ships first):** one entry per month asserting each inventory account to the value the
+subledger computes, with labour and overhead absorbed out of their pools and COGS as the
+balancing figure. It needs **no A/P**, and it tolerates imprecise coding during the month because
+the balance is *asserted*, not accumulated — a miscoded purchase distorts one month and
+self-corrects the next.
+
+**L3 (perpetual)** is a switch thrown once GRNI has both sides. Turning on per-event postings and
+turning off the monthly assertion is **one** change, never two.
+
+> The A/P leg has a hard external ordering constraint: the provider's A/P account is not
+> addressable until one `Bill` object has existed in it.
+
+---
+
+## 10. Write Lanes & the Silent Ledger Write
+
+🛑 **`skipEvents: true` is INSUFFICIENT, not merely deprecated — there are TWO doors.**
+
+| Door | What it is | Gated on |
+| --- | --- | --- |
+| **A** | the per-write fan-out (`derivePublishEvents`) | `publishEvents` |
+| **B** | the **sync manifest** — `createEntity`'s `syncCollectorOf` + `recordCreated` block | **neither `publishEvents`, nor `txScope`, nor `skipEvents`** |
+
+So a session with `skipEvents: true` is still captured by door B and the manifest consumer still
+dispatches the native rules from it.
+
+**For a deliberately silent ledger write, use `quietSession(reason)`** — not `seedSession` (the
+reason string would be a lie), not `absorbedSession` (it needs a real named aggregator), and not
+a bare `publishEvents: false` (`silent-write-conformance.test.ts` scans for it and fails).
+`builds/write-lane.ts` is the reference.
+
+⚠️ **A quiet lane silences the WHOLE rule.** `mfg-stock-movements-created` also fires
+`recalculatePartQoH`. Go quiet and the caller's own post-commit recalc becomes the **only** QoH
+writer — and it must then cover every part the write touched.
+
+⚠️ **Post-commit work must be enqueued after `COMMIT`.** The enqueue resolves its source on a
+different connection and cannot see uncommitted rows.
+
+---
+
+## 11. Gotchas & Invariants
+
+These are the silent failures this subsystem has already paid for. Every one of them passed CI.
+
+**A cached value derived from CODE outlives the code.** The `recordRules` cache once held DB
+rules unioned with code-declared system rules, so adding an action to a system rule did nothing
+for a day per org — the cached list kept firing, nothing threw, nothing logged. Two rules:
+**never cache anything derived from a code-level declaration** unless the key carries a version
+bumped in the same commit; and when converting a cached union to a read-time union, **bump the
+key prefix**, or old entries get a second copy appended and every rule fires twice until expiry.
+
+**`invalidateResource` is a delete, not a refresh.** It removes every cached field value for the
+record, so calling it to refresh one roll-up wipes the record's relationships with it. Prefer the
+non-destructive publish path (`publishFieldValueUpdates` → `useResourceSync` → `setValues`);
+reach for invalidation only when there is no publisher.
+
+**An inverse relationship is a SECOND copy of the same fact.** It is stored on the child and
+mirrored on the parent. The realtime half is fixed — `relationship-sync.ts` publishes the diff —
+but the mirror still **fires no record rules and writes no timeline entry**, so an automation on
+"when this order's lines change" is dead. And if you reach for the list lane instead, **build the
+filter through a shared function**: `createListKey` hashes the filter's `id` strings, so a
+hand-written equivalent lands on a private cache entry no optimistic append ever reaches.
+
+**A card declared with no component renders nothing** — no error, no placeholder, no warning.
+Declare a card value in `drawer-config.ts` / `detail-view-config.ts` only in the same change that
+registers its component. Now automated by `drawer-card-parity.test.ts`, which carries a
+non-vacuity guard so a config shape change cannot make the walk yield zero keys and pass while
+checking nothing.
+
+**Entity colours and field-option colours are different unions**, differing by one entry —
+`ICON_COLORS` has `emerald`, `SELECT_OPTION_COLORS` has `forest`. `slate`, `rose`, `cyan` and
+`violet` are in neither, and `getIconColor` falls back to gray with no error.
+
+🛑 **A receipt that sends only `vendorUnitPrice` freezes the wrong cost, silently.**
+`resolveReceiptPrice` derives the landed cost from the **supplier row's own `unitPrice`** whenever
+`unitCost` is absent — so a form sending an edited base price without the landed total stores a
+cost computed from the price the user just replaced. Nothing throws; the frozen cost is wrong
+forever, on the one field the entire inventory valuation rests on. **The rule: whenever a form
+can price a receipt at all, it sends BOTH figures, and the landed one is the number the breakdown
+displayed.** `receipt-input.ts` exists to make that testable rather than a comment.
+
+🛑 **`ensureCustomFields` never rewrites an existing field's `options`.** Adding a value to a
+seeded SINGLE_SELECT reaches **new orgs only**; the code, the UI and the DB then disagree with no
+error anywhere, and the new value renders as a raw string with no label or colour. The fix is a
+re-materialize step in the migration that rewrites the whole array when it differs — **rewrite,
+do not append** (an appended value sits last on migrated orgs and mid-list on fresh ones), and
+**count it as work**, or the run skips the org-cache flush and the value stays invisible anyway.
+
+🛑 **`ensureEntityDefinitions` is CREATE-ONLY.** It skips any org already holding the def, so
+`isVisible` is evaluated only at creation. **Editing `SYSTEM_ENTITIES` reaches no existing org** —
+flipping one boolean across existing orgs needs its own migration. Same shape as the trap above,
+same consequence: no error, no log line. It reads as correct in review.
+
+🛑 **The system-hook chain has NO `bypassFieldGuards`.** That exemption lives only in
+`fireFieldPreHooks`. So which chain a lifecycle guard belongs on is decided by **how its
+sanctioned writers write**, not by taste: writers that go through `FieldValueService` directly
+need both chains; writers that go through `UnifiedCrudHandler.update` need the field chain
+**only**, or the guard refuses the very buttons it protects.
+
+⚠️ **`on: 'set'` is not a transition.** The interactive native-field door dispatches
+`oldValue: undefined` against a sentinel, guaranteed unequal, so **every write matches**. A
+handler needing a real transition must re-read the field. The sync-manifest door *does* carry
+real old→new values — so the same rule behaves differently by door.
+
+⚠️ **A new `entityType` takes EIGHT files, not five.** Beyond `enums.ts`, `SYSTEM_ENTITIES` and
+the fields registry: `SYSTEM_ATTRIBUTES` (miss it and nothing compiles), `ENTITY_DEFINITION_TYPES`,
+`RESOURCE_FIELD_REGISTRY`, the entityType→registry map in `create-fields.ts`, and
+`DISPLAY_FIELD_CONFIG` — the last four fail **silently and later**.
+
+🛑 **A Redis outage leaves every interactive write spinning rather than failing.**
+`publisher.publishLater` is **awaited** on the interactive lane, it is a BullMQ write, and
+`maxRetriesPerRequest: null` means the command never settles against an unreachable Redis.
+`setValuesForEntity({ publishEvents: true })` therefore never returns — no throw, no timeout.
+Not this subsystem's bug; it is on the write path every surface here uses.
+
+🛑 **`vendor_payment` is walled by a test.** `108-purchasing.test.ts` walks every `.ts`/`.tsx`
+under `packages/lib/src` and fails if any file outside a 9-entry allowlist so much as **names**
+`vendor_payment` / `VENDOR_PAYMENT`. Deliberately stronger than "nothing writes it" — a reference
+is the first step of a writer, and an allowlist entry is a reviewable edit. It is what keeps *a
+def with zero rows can be reshaped for free* a fact rather than a comment claiming to be one.
+Adding to that allowlist is the moment to re-read the payment shape decisions.
+
+**Integration tests do not run in the default suite.** `packages/lib/vitest.config.ts` excludes
+`src/**/*.int.test.*` — that config mocks `@auxx/database`. They need
+`pnpm -F @auxx/lib test:integration` and a live Postgres. **A green package suite is not evidence
+that any integration test passed, or even ran.**
+
+---
+
+## 12. Where the Plans and the Code Disagree
+
+Recorded because both documents still exist and a reader will otherwise trust the wrong one.
+
+| Claim | Reality |
+| --- | --- |
+| Gap E §4.2 recommends `GlPosting` as a **real Drizzle table**, for a Postgres-enforced `(org, type, period)` unique index and a three-line `INSERT … ON CONFLICT` claim step. | ❌ **Not what shipped.** `gl_posting`, `gl_posting_line` and `gl_account` are all `EntityInstance`-backed system defs. Gap E's objection therefore stands and is **unaddressed**: there is no composite unique constraint across two fields of an instance, because they are two `FieldValue` rows, not two columns. Double-posting protection will have to be application-level check-then-insert — the shape this codebase already knows leaks (see `duplicate-detection-architecture-guide.md` on the exact-match arm as an enforcement-leak detector). Resolve before the poster persists anything. |
+| Gap C §6.1's `rollStandardCost` formula (`standardMaterialCost = round(part_cost)`). | ❌ Superseded — see §7.2. The shipped roll sums children's `standardCost`, bottom-up, gated on `partKind`. |
+| Gap D §8 "purchase orders — later". | ❌ Stale. The buy side shipped ahead of it. |
+| `EntityTypeValues` / `EntityType` in `packages/database/src/enums.ts` | ⚠️ **Stale by thirteen types** — missing `order`, `purchase_order`, `vendor_bill`, `gl_account`, `build` and more. Its only consumer is a `z.enum` that system-seeded defs never reach, so nothing is broken. ⚠️ That file has a **destructive generator**; hand-edit it. |
+| `EntityRefKind` in `packages/sdk/src/root/tools/types.ts` | ⚠️ Stale — never gained `purchase_order` / `vendor_bill` / `gl_account` / `order` / `build`. **This one blocks work**: an installed app cannot declare a field against a kind not in the union, and hanging provider account ids off `gl_account` needs it. Different union from the one above; confusing them wastes a pass. |
+| `vendor_bill_balance` "computed from total and amountPaid" | ❌ **No writer exists.** Declared `creatable: false` with no hook, so it is unwritable by a human and uncomputed by the system: every bill's stored balance is NULL. The payment card sidesteps it by computing the display value, so the screen is right and any filter or sort on Balance is not. |
+
+---
+
+## 13. Key Files
+
+**Lib modules**
+
+| Path | Owns |
+| --- | --- |
+| `packages/lib/src/purchasing/` | `match.ts` (the pure match), `match-hook.ts` (triggers), `match-reconciler.ts` (re-match on receipt), `allocate-landed-cost.ts`, `purchase-order-status*.ts`, `vendor-part-lookup.ts` |
+| `packages/lib/src/receiving/` | `receive-stock.ts`, `receive-purchase-order.ts`, `adjust-stock.ts`, `reverse-movement.ts`, `cost-fields.ts`, `guard.ts`, `receipt-queries.ts` |
+| `packages/lib/src/builds/` | `complete-build.ts`, `standard-cost.ts`, `build-mutations.ts`, `reverse-build.ts`, `reconcile-order-builds.ts`, `reconcile-policy.ts`, `drift-*.ts`, `auto-build-*.ts`, `write-lane.ts`, `guard.ts` |
+| `packages/lib/src/bom/` | `cost-calculator.ts` (`computeLandedCost`, the live roll-up), `qoh.ts` (`recalculatePartQoH`), `subpart-graph.ts` |
+| `packages/lib/src/postings/` | `build-entry.ts`, `periods.ts`, `provider.ts` — the posting seam, persisting nothing yet |
+| `packages/lib/src/money/gl/` | 🛑 **does not exist** — Gap E is design-only |
+
+**Registry & seed**
+
+- `packages/lib/src/seed/entity-seeder/constants.ts` — `SYSTEM_ENTITIES`
+- `packages/lib/src/resources/registry/resources/` — `purchase-order-fields.ts`,
+  `vendor-bill-fields.ts`, `stock-movement-fields.ts`, `build-fields.ts`, `gl-*-fields.ts`,
+  `vendor-payment*-fields.ts`
+- `packages/lib/src/seed/entity-migrations/migrations/` — 108 purchasing, 109 build (inert),
+  110 build-visible, 111 build drift, 112 record-documents
+
+**Surfaces**
+
+- `apps/web/src/components/purchasing/` — the PO and bill cards, the line picker, the bill dialog
+- `apps/web/src/components/manufacturing/` — parts, receipts, builds
+- `apps/web/src/server/api/routers/purchasing.ts`

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -40,15 +40,20 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // Renders nothing when the contact has no external identities (card
     // returns null), so it's inert until an app/store/chat links the record.
     sidebarCards: [
-      { value: 'external-identities', label: 'External identities' },
+      { value: 'external-identities', label: 'External identities', icon: 'plug' },
       // First/last interaction rows (records/interaction-fields plan Phase 5).
       // Renders nothing until the record has correspondence.
-      { value: 'interactions', label: 'Interactions' },
+      { value: 'interactions', label: 'Interactions', icon: 'activity' },
       // Mail-permissions contact sharing (UI plan §4) — grants every thread
       // this contact participates in. Admin-managed; hidden for other roles
       // unless shares already exist.
-      { value: 'shared-with', label: 'Shared with' },
-      { value: 'billing', label: 'Billing', permissionKey: 'dispatch.board.view' },
+      { value: 'shared-with', label: 'Shared with', icon: 'users' },
+      {
+        value: 'billing',
+        label: 'Billing',
+        icon: 'credit-card',
+        permissionKey: 'dispatch.board.view',
+      },
     ],
   },
 
@@ -67,7 +72,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     defaultTab: 'timeline',
     defaultSidebarTab: 'overview',
     // First/last interaction rows — propagated from the company's contacts.
-    sidebarCards: [{ value: 'interactions', label: 'Interactions' }],
+    sidebarCards: [{ value: 'interactions', label: 'Interactions', icon: 'activity' }],
   },
 
   ticket: {
@@ -81,9 +86,9 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     defaultTab: 'conversation',
     defaultSidebarTab: 'overview',
     sidebarCards: [
-      { value: 'metrics', label: 'Metrics', position: 'before', fullBleed: true },
-      { value: 'customer', label: 'Customer' },
-      { value: 'relationships', label: 'Related Tickets' },
+      { value: 'metrics', label: 'Metrics', icon: 'gauge', position: 'before', fullBleed: true },
+      { value: 'customer', label: 'Customer', icon: 'user' },
+      { value: 'relationships', label: 'Related Tickets', icon: 'ticket' },
     ],
   },
 
@@ -150,9 +155,9 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     defaultTab: 'line-items',
     defaultSidebarTab: 'overview',
     sidebarCards: [
-      { value: 'customer', label: 'Customer' },
-      { value: 'origin', label: 'Origin' },
-      { value: 'jobs', label: 'Jobs', recordResource: 'work_order' },
+      { value: 'customer', label: 'Customer', icon: 'user' },
+      { value: 'origin', label: 'Origin', icon: 'link' },
+      { value: 'jobs', label: 'Jobs', icon: 'wrench', recordResource: 'work_order' },
     ],
   },
 
@@ -180,12 +185,12 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // an order carries no payment ledger (§5.4). `work_order` is the D4 manual
     // link that stands in for the deferred order→work_order conversion.
     sidebarCards: [
-      { value: 'customer', label: 'Customer' },
+      { value: 'customer', label: 'Customer', icon: 'user' },
       // `work-orders`, not the quote's `jobs`: DetailViewSidebar and the drawer read
       // the SAME `DRAWER_TAB_CARD_COMPONENTS` registry, so this value is the card key
       // and must match `order:work-orders` there and in the order's drawer block.
       // "Jobs" is dispatch vocabulary; an order links work orders (08 §5.8).
-      { value: 'work-orders', label: 'Work orders', recordResource: 'work_order' },
+      { value: 'work-orders', label: 'Work orders', icon: 'wrench', recordResource: 'work_order' },
     ],
   },
 
@@ -220,9 +225,9 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       // from a list and one opened as a page must offer the same files, or
       // expanding the record makes them disappear.
       { value: 'documents', label: 'Documents', icon: 'paperclip' },
-      { value: 'vendor', label: 'Vendor' },
-      { value: 'receiving', label: 'Receiving' },
-      { value: 'bills', label: 'Bills', recordResource: 'vendor_bill' },
+      { value: 'vendor', label: 'Vendor', icon: 'store' },
+      { value: 'receiving', label: 'Receiving', icon: 'truck' },
+      { value: 'bills', label: 'Bills', icon: 'receipt', recordResource: 'vendor_bill' },
     ],
   },
 
@@ -268,8 +273,8 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     defaultTab: 'schedule',
     defaultSidebarTab: 'overview',
     sidebarCards: [
-      { value: 'customer-site', label: 'Customer & site' },
-      { value: 'origin', label: 'Origin' },
+      { value: 'customer-site', label: 'Customer & site', icon: 'map-pin' },
+      { value: 'origin', label: 'Origin', icon: 'link' },
     ],
   },
 
@@ -296,8 +301,13 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // `ledger` is the only surface for `build_movements`, whose field is
     // `showInPanel: false` (section 1.6: "has_many; a card lists them").
     sidebarCards: [
-      { value: 'run', label: 'Run' },
-      { value: 'ledger', label: 'Ledger', recordResource: 'stock_movement' },
+      { value: 'run', label: 'Run', icon: 'hammer' },
+      {
+        value: 'ledger',
+        label: 'Ledger',
+        icon: 'arrow-left-right',
+        recordResource: 'stock_movement',
+      },
     ],
   },
 

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -22,10 +22,11 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     tabCards: {
       overview: [
         // First/last interaction rows (records/interaction-fields plan Phase 5).
-        { value: 'interactions', label: 'Interactions', position: 'after' },
+        { value: 'interactions', label: 'Interactions', icon: 'activity', position: 'after' },
         {
           value: 'billing',
           label: 'Billing',
+          icon: 'credit-card',
           position: 'after',
           permissionKey: 'dispatch.board.view',
         },
@@ -39,7 +40,9 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       { value: 'parts', label: 'Parts', icon: 'package', recordResource: 'vendor_part' },
     ],
     tabCards: {
-      overview: [{ value: 'interactions', label: 'Interactions', position: 'after' }],
+      overview: [
+        { value: 'interactions', label: 'Interactions', icon: 'activity', position: 'after' },
+      ],
     },
   },
 
@@ -48,9 +51,9 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     additionalTabs: [{ value: 'conversation', label: 'Conversation', icon: 'mail' }],
     tabCards: {
       overview: [
-        { value: 'metrics', label: 'Metrics', position: 'before', fullBleed: true },
-        { value: 'customer', label: 'Customer' },
-        { value: 'relationships', label: 'Related Tickets' },
+        { value: 'metrics', label: 'Metrics', icon: 'gauge', position: 'before', fullBleed: true },
+        { value: 'customer', label: 'Customer', icon: 'user' },
+        { value: 'relationships', label: 'Related Tickets', icon: 'ticket' },
       ],
     },
   },
@@ -63,21 +66,21 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     ],
     tabCards: {
       overview: [
-        { value: 'inventory', label: 'Inventory' },
+        { value: 'inventory', label: 'Inventory', icon: 'package' },
         // Cost provenance: buy-vs-build comparison + the not-costed signal.
         // The card renders nothing for a part with a single cost candidate
         // (the common case), which hides the whole section.
-        { value: 'costing', label: 'Costing' },
+        { value: 'costing', label: 'Costing', icon: 'calculator' },
         // Sellable toggle / pricing row — "sellable" is derived from the
         // backing catalog_item, never stored (plans/products/01-product-family.md
         // §6.1). Renders nothing for a part with no catalog item — unless it's
         // a finished good, whose missing price surfaces prominently.
-        { value: 'pricing', label: 'Pricing' },
+        { value: 'pricing', label: 'Pricing', icon: 'tag' },
         // Product-family membership + the finished-good suggestion
         // (plans/products/01-product-family.md phase 3). Renders nothing for a
         // part with no `product` relation (most parts — raw materials), which
         // hides the whole section.
-        { value: 'family', label: 'Family' },
+        { value: 'family', label: 'Family', icon: 'boxes' },
       ],
     },
   },
@@ -170,15 +173,21 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
         {
           value: 'lines',
           label: 'Line items',
+          icon: 'receipt-text',
           fullBleed: true,
           permissionKey: 'dispatch.board.view',
         },
-        { value: 'customer', label: 'Customer' },
-        { value: 'origin', label: 'Origin' },
-        { value: 'jobs', label: 'Jobs', recordResource: 'work_order' },
+        { value: 'customer', label: 'Customer', icon: 'user' },
+        { value: 'origin', label: 'Origin', icon: 'link' },
+        { value: 'jobs', label: 'Jobs', icon: 'wrench', recordResource: 'work_order' },
         // Deposit visibility (deposit-accounting plan 16 §D.5) — the card itself renders
         // null when the quote has no deposit charge, so this stays in the list unconditionally.
-        { value: 'deposit', label: 'Deposit', permissionKey: 'dispatch.board.view' },
+        {
+          value: 'deposit',
+          label: 'Deposit',
+          icon: 'banknote',
+          permissionKey: 'dispatch.board.view',
+        },
       ],
     },
   },
@@ -230,11 +239,17 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
         {
           value: 'lines',
           label: 'Line items',
+          icon: 'receipt-text',
           fullBleed: true,
           permissionKey: 'dispatch.board.view',
         },
-        { value: 'customer', label: 'Customer' },
-        { value: 'work-orders', label: 'Work orders', recordResource: 'work_order' },
+        { value: 'customer', label: 'Customer', icon: 'user' },
+        {
+          value: 'work-orders',
+          label: 'Work orders',
+          icon: 'wrench',
+          recordResource: 'work_order',
+        },
       ],
     },
   },
@@ -248,13 +263,13 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       // TotalsFooter renders them at the foot of the lines card. A totals card
       // would be a second, competing rendering of the same five mirrors.
       overview: [
-        { value: 'lines', label: 'Lines', fullBleed: true },
+        { value: 'lines', label: 'Lines', icon: 'receipt-text', fullBleed: true },
         // The generated PDF + the vendor's paperwork. Both fields are
         // `showInPanel: false`, so this card is their only surface (plan 08 P21).
         { value: 'documents', label: 'Documents', icon: 'paperclip' },
-        { value: 'vendor', label: 'Vendor' },
-        { value: 'receiving', label: 'Receiving' },
-        { value: 'bills', label: 'Bills', recordResource: 'vendor_bill' },
+        { value: 'vendor', label: 'Vendor', icon: 'store' },
+        { value: 'receiving', label: 'Receiving', icon: 'truck' },
+        { value: 'bills', label: 'Bills', icon: 'receipt', recordResource: 'vendor_bill' },
       ],
     },
   },
@@ -269,8 +284,13 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     additionalTabs: [],
     tabCards: {
       overview: [
-        { value: 'run', label: 'Run' },
-        { value: 'ledger', label: 'Ledger', recordResource: 'stock_movement' },
+        { value: 'run', label: 'Run', icon: 'hammer' },
+        {
+          value: 'ledger',
+          label: 'Ledger',
+          icon: 'arrow-left-right',
+          recordResource: 'stock_movement',
+        },
       ],
     },
   },
@@ -283,13 +303,13 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     additionalTabs: [],
     tabCards: {
       overview: [
-        { value: 'lines', label: 'Lines', fullBleed: true },
-        { value: 'match', label: 'Match' },
+        { value: 'lines', label: 'Lines', icon: 'receipt-text', fullBleed: true },
+        { value: 'match', label: 'Match', icon: 'scan-search' },
         // The vendor's own invoice, plus the packing slips and freight bills
         // that came with it (plan 08 P18/P21).
         { value: 'documents', label: 'Documents', icon: 'paperclip' },
-        { value: 'vendor', label: 'Vendor' },
-        { value: 'payment', label: 'Payment' },
+        { value: 'vendor', label: 'Vendor', icon: 'store' },
+        { value: 'payment', label: 'Payment', icon: 'credit-card' },
       ],
     },
   },

--- a/packages/lib/src/resources/registry/resources/build-fields.ts
+++ b/packages/lib/src/resources/registry/resources/build-fields.ts
@@ -98,7 +98,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Auto-generated build number — RecordSequence scope `build`, prefix `B`',
+    description: 'Automatically generated build number',
   },
 
   part: {
@@ -160,7 +160,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
     },
     placeholder: 'Select status',
     defaultValue: 'planned',
-    description: 'Where the build sits — planned, in progress, completed or canceled',
+    description: 'The current stage of the build',
   },
 
   quantityPlanned: {
@@ -202,7 +202,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: 'Good units that entered finished goods — the quantity of the produce movement',
+    description: 'The number of finished units produced',
   },
 
   quantityScrapped: {
@@ -223,9 +223,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'Units started but lost (B7). They consume material and produce NO movement — their ' +
-      'cost falls out in varianceAmount rather than being absorbed into the survivors',
+    description: 'The number of units lost or discarded during production',
   },
 
   startedAt: {
@@ -267,9 +265,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'THE accounting date — what every movement this build writes carries as its occurredAt, ' +
-      'and therefore which period the cost lands in',
+    description: 'When the build was completed',
   },
 
   materialCost: {
@@ -297,9 +293,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       computed: true,
       configurable: false,
     },
-    description:
-      'Sum of the consumed rows extended standard cost, integer minor units — written by ' +
-      'completeBuild and never recomputed',
+    description: 'The total cost of materials consumed by this build',
   },
 
   laborCost: {
@@ -327,9 +321,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       computed: true,
       configurable: false,
     },
-    description:
-      'Absorbed direct labour for this run, integer minor units — the org rate ' +
-      '`manufacturing.assemblyLaborCostPerUnit` applied to the units started',
+    description: 'The labor cost assigned to this build',
   },
 
   overheadCost: {
@@ -357,9 +349,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       computed: true,
       configurable: false,
     },
-    description:
-      'Applied overhead for this run, integer minor units — the org rate ' +
-      '`manufacturing.overheadCostPerUnit` applied to the units started',
+    description: 'The overhead cost assigned to this build',
   },
 
   producedValue: {
@@ -387,9 +377,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       computed: true,
       configurable: false,
     },
-    description:
-      'quantityProduced x the finished goods frozen part_standard_cost — what actually ' +
-      'entered inventory, integer minor units',
+    description: 'The inventory value of the finished units produced',
   },
 
   varianceAmount: {
@@ -419,10 +407,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
     },
     // Stays in the panel, unlike the part's five cost rows: the variance is the
     // number a person actually reads on a build.
-    description:
-      '(material + labor + overhead) - producedValue, integer minor units. Account 5090. ' +
-      'This is what scrap and yield loss show up as — it is meaningless the moment a ' +
-      'structural roll-up error is booked to it (README B11)',
+    description: 'The difference between production costs and the value of finished units',
   },
 
   order: {
@@ -456,9 +441,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Builds',
       inverseSystemAttribute: 'order_builds',
     },
-    description:
-      'The order this build was raised for. Without it, "cancel the builds for this order" ' +
-      'has nothing to look up (plans/products/12 AB7)',
+    description: 'The order associated with this build, if applicable',
   },
 
   source: {
@@ -487,9 +470,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     defaultValue: 'manual',
-    description:
-      'Who raised this build. An auto-build must be distinguishable from one a person raised ' +
-      'against the same order deliberately (plans/products/12 AB7)',
+    description: 'How this build was created',
   },
 
   notes: {
@@ -510,7 +491,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter notes',
-    description: 'Free text about this run',
+    description: 'Additional notes about this build',
   },
 
   postedAt: {
@@ -536,9 +517,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'Denormalized convenience only — never gate on it. The gl_posting rows are the truth ' +
-      'about whether this build has been posted',
+    description: 'When the build was posted to the general ledger',
   },
 
   // ─── Relationship inverses and the reversal pair ───────────────────
@@ -567,7 +546,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       relationshipType: 'has_many',
       isInverse: true,
     },
-    description: 'The consume and produce rows this build wrote — the costed subledger entries',
+    description: 'Inventory movements created by this build',
   },
 
   reversalOf: {
@@ -602,9 +581,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Reversed By',
       inverseSystemAttribute: 'build_reversed_by',
     },
-    description:
-      'Set on the REVERSING build, pointing at the one it undoes (B6). A completed build is ' +
-      'never edited or deleted — a period that has been posted must not change shape',
+    description: 'The original build that this build reverses',
   },
 
   reversedBy: {
@@ -684,9 +661,7 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description:
-      'Fingerprint of what the order asked production for at the moment this build was ' +
-      'raised. Differs from the order’s current fingerprint once the order has changed',
+    description: 'The order version used when this build was created or last updated',
   },
 
   createdAt: {

--- a/packages/lib/src/resources/registry/resources/gl-account-fields.ts
+++ b/packages/lib/src/resources/registry/resources/gl-account-fields.ts
@@ -91,10 +91,7 @@ export const GL_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: '1310',
-    description:
-      'The account code, unique per org. This is the key `gl_posting_line.accountCode` ' +
-      'points at, and the value a provider resolver maps to a provider id — never the ' +
-      "provider's id itself",
+    description: 'The unique code used to identify this account',
   },
 
   name: {
@@ -117,7 +114,7 @@ export const GL_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Raw Materials',
-    description: 'Human-readable account name, e.g. Raw Materials or GRNI',
+    description: 'The name used to identify this account',
   },
 
   accountType: {
@@ -140,9 +137,7 @@ export const GL_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select account type',
-    description:
-      'asset, liability, equity, revenue or expense. Ours rather than the provider ' +
-      'classification, so a posting can be sanity-checked before it is pushed anywhere',
+    description: 'The financial category for this account',
   },
 
   isActive: {
@@ -163,9 +158,7 @@ export const GL_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'Whether the account can still be coded to. Retired accounts are deactivated, never ' +
-      'deleted — historical postings reference the code and must stay explainable',
+    description: 'Whether this account is available for new postings',
   },
 
   createdAt: {

--- a/packages/lib/src/resources/registry/resources/gl-posting-fields.ts
+++ b/packages/lib/src/resources/registry/resources/gl-posting-fields.ts
@@ -72,8 +72,7 @@ export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'AUXX-FUL-20260818',
-    description:
-      'Deterministic natural key, also written to QuickBooks DocNumber. Max 21 characters — the QuickBooks limit. Derived from posting type and period, never random',
+    description: 'The reference number for this journal entry',
   },
 
   postingType: {
@@ -96,7 +95,7 @@ export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select posting type',
-    description: 'Which of the accrual entry types this posting represents',
+    description: 'The type of accounting activity represented by this journal entry',
   },
 
   periodKey: {
@@ -118,8 +117,7 @@ export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: '2026-08-18',
-    description:
-      'The summarization window — a day (2026-08-18) for daily entries, a month (2026-08) for month-end ones. Together with posting type this is what makes a double-post unrepresentable',
+    description: 'The day or month covered by this journal entry',
   },
 
   status: {
@@ -142,8 +140,7 @@ export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select status',
-    description:
-      'pending until the journal entry lands, then posted or failed. A pending row that outlives its run is the signal to reconcile against QuickBooks before retrying',
+    description: 'The current posting status of this journal entry',
   },
 
   totalDebit: {
@@ -169,8 +166,7 @@ export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'What was posted, in minor units. Computed from our own lines — QuickBooks TotalAmt is always zero on a journal entry and would read as $0',
+    description: 'The total debit amount for this journal entry',
   },
 
   postedAt: {
@@ -190,7 +186,7 @@ export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: 'When the journal entry was accepted by QuickBooks. Null until it posts',
+    description: 'When the journal entry was successfully posted',
   },
 
   failureReason: {
@@ -210,8 +206,7 @@ export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'The QuickBooks fault, verbatim, including its numeric code. Kept verbatim on purpose — a paraphrased accounting error is not diagnosable',
+    description: 'Details about why the journal entry failed to post',
   },
 
   createdAt: {
@@ -279,7 +274,6 @@ export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
       relationshipType: 'has_many',
       isInverse: true,
     },
-    description:
-      'The double-entry lines of this posting - account CODE plus a positive amount and a direction',
+    description: 'The debit and credit lines included in this journal entry',
   },
 }

--- a/packages/lib/src/resources/registry/resources/gl-posting-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/gl-posting-line-fields.ts
@@ -60,7 +60,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Unique GL posting line identifier',
   },
 
   glPosting: {
@@ -94,7 +93,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Lines',
       inverseSystemAttribute: 'gl_posting_lines',
     },
-    description: 'The journal entry this line belongs to — required',
   },
 
   accountCode: {
@@ -117,10 +115,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: '1310',
-    description:
-      "An account CODE such as '1310', matching `gl_account.code` — NEVER a provider " +
-      'account id (P2). Provider ids live in RecordIdentity on `gl_account`, so the ' +
-      'stored ledger survives disconnecting, re-authorising or replacing the provider',
   },
 
   direction: {
@@ -143,9 +137,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select direction',
-    description:
-      'debit or credit. This field alone carries the SIGN of the line — `amount` is ' +
-      'always positive',
   },
 
   amount: {
@@ -173,10 +164,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       required: true,
       configurable: false,
     },
-    description:
-      'Integer minor units, ALWAYS POSITIVE — `direction` carries the sign. Storing a ' +
-      'signed amount as well as a direction would let the two disagree, and a ledger ' +
-      'that can contradict itself is not a ledger',
   },
 
   memo: {
@@ -197,7 +184,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Line description',
-    description: 'Per-line description, pushed through to the provider line where one exists',
   },
 
   sourceType: {
@@ -219,9 +205,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'stock_movement, vendor_bill',
-    description:
-      'Which KIND of row produced this line. Half of the audit trail: with `sourceId` it ' +
-      "makes a posting explainable years later without joining through a provider's API",
   },
 
   sourceId: {
@@ -242,10 +225,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description:
-      'WHICH row produced this line — the id within `sourceType`. Kept as plain text ' +
-      'rather than a relation on purpose: the source can be any of several entities, ' +
-      'and the trail must stay readable even if that row is later archived',
   },
 
   sortOrder: {
@@ -266,7 +245,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: 'Presentation order of the lines within the entry',
   },
 
   createdAt: {
@@ -287,7 +265,6 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Automatically set when the GL posting line is created',
   },
 
   updatedAt: {
@@ -308,6 +285,5 @@ export const GL_POSTING_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Automatically updated when the GL posting line is modified',
   },
 }

--- a/packages/lib/src/resources/registry/resources/invoice-fields.ts
+++ b/packages/lib/src/resources/registry/resources/invoice-fields.ts
@@ -130,7 +130,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Invoices',
       inverseSystemAttribute: 'contact_invoices',
     },
-    description: 'Customer contact for this invoice — required, the billing party',
+    description: 'The customer being billed',
   },
 
   workOrder: {
@@ -161,7 +161,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Invoices',
       inverseSystemAttribute: 'work_order_invoices',
     },
-    description: 'Job this invoice was gathered from — optional, standalone invoices have none',
+    description: 'The work order associated with this invoice, if applicable',
   },
 
   issuedAt: {
@@ -182,7 +182,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select issue date',
-    description: 'Prefilled today at create; stamped by mark-sent if empty (§G.2)',
+    description: 'The date the invoice was issued',
   },
 
   dueDate: {
@@ -203,7 +203,6 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select due date',
-    description: 'Overdue badge derives from this (UI-side) — never a status',
   },
 
   discountType: {
@@ -226,7 +225,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select discount type',
-    description: 'Null = no discount',
+    description: 'How the discount is calculated',
   },
 
   discountValue: {
@@ -267,7 +266,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: "Snapshot of the picked tax rate's name (documents.taxRates)",
+    description: 'The tax name shown on the invoice',
   },
 
   taxRate: {
@@ -288,7 +287,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: 'Snapshot of the picked tax rate, percent (e.g. 7.5)',
+    description: 'The tax percentage applied to the invoice',
   },
 
   subtotal: {
@@ -315,7 +314,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Sum of line totals — written by the totals engine hook',
+    description: 'The total before discounts, tax, and payments',
   },
 
   taxTotal: {
@@ -342,7 +341,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Written by the totals engine hook',
+    description: 'The total tax charged on the invoice',
   },
 
   total: {
@@ -369,7 +368,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Written by the totals engine hook',
+    description: 'The final invoice amount after discounts and tax',
   },
 
   amountPaid: {
@@ -395,7 +394,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Sum of succeeded payments — written by syncInvoicePaymentState',
+    description: 'The total amount paid toward this invoice',
   },
 
   balance: {
@@ -421,7 +420,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'total - amountPaid — written by syncInvoicePaymentState',
+    description: 'The amount still due on this invoice',
   },
 
   notes: {
@@ -443,7 +442,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter internal notes',
-    description: 'Internal notes — not shown to the customer',
+    description: 'Internal notes that are not shown to the customer',
   },
 
   terms: {
@@ -465,7 +464,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter customer-facing terms',
-    description: 'Customer-facing terms (plain text, PDF-friendly)',
+    description: 'Payment terms shown to the customer',
   },
 
   photos: {
@@ -488,9 +487,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'Photos attached directly to this invoice (plan 37b scouting build spec) — no ' +
-      'auto-copy from quote_photos',
+    description: 'Photos attached to this invoice',
   },
 
   // The last-rendered invoice PDF, as a single FILE value
@@ -527,9 +524,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
       hidden: true,
     },
-    description:
-      'The generated invoice PDF ({ ref: "asset:<MediaAsset id>" }) — written only by ' +
-      'ensureDocumentPdf, surfaced read-only through the documents card, never user-editable',
+    description: 'The generated PDF for this invoice',
   },
 
   lineItems: {
@@ -579,7 +574,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       relationshipType: 'has_many',
       isInverse: true,
     },
-    description: 'Payment mirror records for this invoice (ledger-backed, §E)',
+    description: 'Payments applied to this invoice',
   },
 
   publicToken: {
@@ -601,10 +596,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
       hidden: true,
     },
-    description:
-      'Unguessable capability token for the public /pay/{token} page (money MP1 build spec ' +
-      '§H) — lazily minted by ensureInvoicePublicToken on first send/PDF-render, never ' +
-      'user-editable. Mirrors the invoice_pdf_asset recipe (FieldValueService-only writer).',
+    description: 'Secure token used to access the public payment page',
   },
 
   billingKind: {
@@ -627,7 +619,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     defaultValue: 'standalone',
-    description: 'Read-only billing intent for this invoice snapshot',
+    description: 'The type of billing represented by this invoice',
   },
   servicePeriodStart: {
     id: toFieldId('servicePeriodStart'),

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -35,7 +35,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Unique line item identifier',
   },
 
   name: {
@@ -58,7 +57,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter line name',
-    description: 'The catalog-combobox cell edits this field',
   },
 
   description: {
@@ -79,7 +77,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter description',
-    description: 'Toggleable sub-line shown under the line name (01-ui #1)',
   },
 
   qty: {
@@ -121,8 +118,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select unit',
-    description:
-      'Immutable-at-copy-time display snapshot; the current editable line may subsequently change it',
   },
 
   unitPrice: {
@@ -173,7 +168,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'qty * unitPrice — written by the totals engine hook',
   },
 
   taxable: {
@@ -215,7 +209,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     defaultValue: false,
-    description: 'True for quote line items the customer can opt in/out of',
   },
 
   optionalSelected: {
@@ -237,7 +230,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     defaultValue: true,
-    description: 'Meaningful only when optional is true; required lines ignore this',
   },
 
   category: {
@@ -299,7 +291,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: 'Written by the reorder mutation (§G.4)',
   },
 
   visitId: {
@@ -320,7 +311,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: 'Plain text bridge to WorkOrderVisit — visits are not entities (dispatch lock)',
   },
 
   sourceLine: {
@@ -341,8 +331,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'Quote-line instance id this line was copied from at convert (money plan 20 §E) — provenance only, no reader yet',
   },
 
   catalogItem: {
@@ -373,7 +361,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Line Items',
       inverseSystemAttribute: 'catalog_item_line_items',
     },
-    description: 'Catalog item this line was picked from — provenance only, values are snapshots',
   },
 
   quote: {
@@ -404,7 +391,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Line Items',
       inverseSystemAttribute: 'quote_line_items',
     },
-    description: 'Quote this line belongs to',
   },
 
   workOrder: {
@@ -435,7 +421,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Line Items',
       inverseSystemAttribute: 'work_order_line_items',
     },
-    description: 'Work order this line belongs to (copied from a converted quote)',
   },
 
   invoice: {
@@ -466,7 +451,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Line Items',
       inverseSystemAttribute: 'invoice_line_items',
     },
-    description: 'Parent invoice relation for invoice-owned snapshot lines only',
   },
 
   // The fourth document slot (plans/products/08-order-build.md §2). Sort keys
@@ -500,7 +484,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Line Items',
       inverseSystemAttribute: 'order_line_items',
     },
-    description: 'Order this line belongs to',
   },
 
   part: {
@@ -531,9 +514,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Line Items',
       inverseSystemAttribute: 'part_line_items',
     },
-    description:
-      'Part this line sells — STAMPED at write from the line\u2019s catalog item, not hand-set (08 \u00a76.2). ' +
-      'Provenance and grouping only, never a pricing input: `catalogItem` wins for pricing.',
   },
 
   photos: {
@@ -556,9 +536,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'Line-level scouting photos (plan 37b build spec) — surfaced via the line-builder ' +
-      'photo chip, not a generic dialog',
   },
 
   createdAt: {
@@ -579,7 +556,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Automatically set when the line item is created',
   },
 
   updatedAt: {
@@ -600,7 +576,6 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Automatically updated when the line item is modified',
   },
 
   createdBy: CREATED_BY_FIELD,

--- a/packages/lib/src/resources/registry/resources/purchase-order-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/purchase-order-line-fields.ts
@@ -46,7 +46,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Unique purchase order line identifier',
   },
 
   purchaseOrder: {
@@ -85,7 +84,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Lines',
       inverseSystemAttribute: 'purchase_order_lines',
     },
-    description: 'The purchase order this line belongs to',
   },
 
   part: {
@@ -122,7 +120,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
     },
     // The part is what receiving moves into stock, so it is required even when
     // the supplier's own catalogue entry is unknown.
-    description: 'The part being bought — required, and what a receipt moves into stock',
   },
 
   vendorPart: {
@@ -157,7 +154,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
     // Optional: a one-off buy from a supplier with no maintained price list is
     // still a legitimate line, and forcing a `vendor_part` row for it would
     // pollute the pricing catalogue.
-    description: "The supplier's catalogue entry this line was priced from — optional",
   },
 
   description: {
@@ -181,7 +177,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
     placeholder: 'Enter line description',
     // What the SUPPLIER calls it. Printing our own part name on their order is
     // how a picking error becomes a dispute.
-    description: 'How the line reads on the supplier-facing document',
   },
 
   quantityOrdered: {
@@ -204,7 +199,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter quantity',
-    description: 'How many units were ordered',
   },
 
   quantityReceived: {
@@ -228,7 +222,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
     // Same shape as `part_quantity_on_hand`, and for the same reason: the
     // subledger is the truth, and a hand-maintained copy of it diverges
     // silently. Re-summed whole, post-commit — never incremented in place.
-    description: 'Re-sum of the stock movements pointing at this line — computed, never typed',
   },
 
   quantityBilled: {
@@ -251,7 +244,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
     },
     // The billed leg of the three-way match. Typing it would let the control be
     // satisfied by the person the control exists to check.
-    description: 'Re-sum of the vendor bill lines pointing at this line — computed, never typed',
   },
 
   expectedUnitPrice: {
@@ -280,7 +272,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
     // Expected, not actual: the price agreed when the order went out, which the
     // three-way match holds the arriving invoice against. The received price
     // lives on the movement.
-    description: 'Agreed buy price per unit, integer minor units — the price arm of the match',
   },
 
   lineTotal: {
@@ -306,9 +297,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description:
-      'quantityOrdered * expectedUnitPrice — written by the totals engine hook, and the ' +
-      'weight the `value` allocation basis spreads freight by',
   },
 
   weight: {
@@ -332,7 +320,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
     placeholder: 'Enter line weight',
     // Only the `weight` allocation basis reads it, so leaving it empty costs
     // nothing until someone picks that basis.
-    description: 'Total shipped weight for this line — read only by the `weight` allocation basis',
   },
 
   sortOrder: {
@@ -354,7 +341,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: 'Position of this line on the printed order',
   },
 
   // Reverse relationship: stockMovements (from stock_movement.purchaseOrderLine).
@@ -383,7 +369,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       relationshipType: 'has_many',
       isInverse: true,
     },
-    description: 'Receipts booked against this line — what `quantityReceived` re-sums',
   },
 
   // Reverse relationship: vendorBillLines (from vendor_bill_line.purchaseOrderLine).
@@ -412,7 +397,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       relationshipType: 'has_many',
       isInverse: true,
     },
-    description: 'Bill lines matched to this line — what `quantityBilled` re-sums',
   },
 
   createdAt: {
@@ -433,7 +417,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Automatically set when the purchase order line is created',
   },
 
   updatedAt: {
@@ -454,7 +437,6 @@ export const PURCHASE_ORDER_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Automatically updated when the purchase order line is modified',
   },
 
   createdBy: CREATED_BY_FIELD,

--- a/packages/lib/src/resources/registry/resources/stock-movement-fields.ts
+++ b/packages/lib/src/resources/registry/resources/stock-movement-fields.ts
@@ -43,7 +43,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Unique stock movement identifier',
   },
 
   part: {
@@ -75,7 +74,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Stock Movements',
       inverseSystemAttribute: 'part_stock_movements',
     },
-    description: 'The part this movement applies to',
   },
 
   type: {
@@ -97,7 +95,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       required: true,
       configurable: false,
     },
-    description: 'Type of stock movement',
   },
 
   quantity: {
@@ -119,7 +116,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter quantity',
-    description: 'Quantity changed (positive or negative)',
   },
 
   reason: {
@@ -140,7 +136,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter reason',
-    description: 'Reason for the stock movement',
   },
 
   reference: {
@@ -161,7 +156,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter reference',
-    description: 'External reference (e.g., build batch ID)',
   },
 
   createdAt: {
@@ -182,7 +176,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'When the stock movement was created',
   },
 
   adjustSubparts: {
@@ -203,7 +196,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Whether to cascade this adjustment to leaf subparts via BOM explosion',
   },
 
   parentMovement: {
@@ -230,7 +222,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Child Movements',
       inverseSystemAttribute: 'stock_movement_child_movements',
     },
-    description: 'Parent movement that triggered this child movement via BOM explosion',
   },
 
   childMovements: {
@@ -257,7 +248,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Parent Movement',
       inverseSystemAttribute: 'stock_movement_parent_movement',
     },
-    description: 'Child movements created by BOM explosion from this parent movement',
   },
 
   // ─── Receiving: cost, date and provenance ─────────────────────────
@@ -287,9 +277,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description:
-      'Cost per unit, FROZEN at write time, integer minor units. Never recomputed - a March ' +
-      'vendor-price change must not restate January.',
   },
 
   extendedCost: {
@@ -315,9 +302,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description:
-      'round(unitCost x quantity), SIGNED like quantity so SUM(extendedCost) GROUP BY glAccount ' +
-      'is the account balance without a per-row case expression',
   },
 
   costBasis: {
@@ -339,9 +323,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select cost basis',
-    description:
-      'How this row was valued. A build values at `standard`; a receipt is the first thing in ' +
-      'the system that legitimately writes `actual`, and the difference between the two is PPV.',
   },
 
   glAccount: {
@@ -362,9 +343,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description:
-      'Account CODE (1310 / 1320 / 1330), resolved from the part kind at write time. A code, ' +
-      'never an accounting provider id - the provider is an exporter, not the system of record.',
   },
 
   occurredAt: {
@@ -385,10 +363,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select date',
-    description:
-      'The ACCOUNTING date, on every movement type. `createdAt` records when the row was typed ' +
-      'and cannot be set - the pallet lands Thursday and the paperwork is keyed Monday, so ' +
-      'without this every period boundary falls on the wrong side.',
   },
 
   vendorPart: {
@@ -420,9 +394,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Stock Movements',
       inverseSystemAttribute: 'vendor_part_stock_movements',
     },
-    description:
-      'Which supplier row priced this receipt. NULL on every non-receipt type. Incidentally the ' +
-      'first time the system can answer what we have actually bought from a supplier.',
   },
 
   vendorUnitPrice: {
@@ -448,10 +419,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description:
-      'The RAW invoice price per unit, before freight and tariff. Frozen. Kept beside unitCost ' +
-      'because the landed total alone cannot say whether the motor got more expensive or the ' +
-      'freight did - and it is what GRNI clears against, since the vendor bills only this part.',
   },
 
   purchaseOrderLine: {
@@ -483,9 +450,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Stock Movements',
       inverseSystemAttribute: 'purchase_order_line_stock_movements',
     },
-    description:
-      'The ordered line this receipt satisfies - one half of three-way match. Declared with the ' +
-      'other receiving fields; `linkNewRelationships` links it once the counterpart def exists.',
   },
 
   reversesMovement: {
@@ -512,11 +476,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Reversed By',
       inverseSystemAttribute: 'stock_movement_reversed_by_movements',
     },
-    description:
-      'The movement this row undoes - a vendor return or a keying correction, valued at the ' +
-      'ORIGINAL frozen cost. Deliberately NOT `parentMovement`: that means parent of a BOM ' +
-      'explosion and `explodeBomMovement` reads it, so overloading it would push reversal rows ' +
-      'into `childMovements` and corrupt the explosion bookkeeping.',
   },
 
   reversedByMovements: {
@@ -543,7 +502,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Reverses Movement',
       inverseSystemAttribute: 'stock_movement_reverses_movement',
     },
-    description: 'Rows that undo this movement',
   },
 
   // ─── Build provenance and the as-built BOM snapshot ────────────────
@@ -582,9 +540,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Stock Movements',
       inverseSystemAttribute: 'build_movements',
     },
-    description:
-      'The build that wrote this row. `reference` stays as-is - a free-text batch string is ' +
-      'not something a query can join on',
   },
 
   qtyPerUnit: {
@@ -608,10 +563,6 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description:
-      'The AS-BUILT BOM snapshot: on a build_consume row, the per-unit quantity in force at ' +
-      'build time. NULL on a consume row means the component was OFF-BOM - a floor ' +
-      'substitution, made visible instead of silent. NULL on every other movement type.',
   },
 
   createdBy: CREATED_BY_FIELD,

--- a/packages/lib/src/resources/registry/resources/vendor-bill-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/vendor-bill-line-fields.ts
@@ -42,7 +42,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Unique vendor bill line identifier',
   },
 
   vendorBill: {
@@ -79,7 +78,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Lines',
       inverseSystemAttribute: 'vendor_bill_lines',
     },
-    description: 'The bill this line belongs to — required',
   },
 
   // THE MATCH KEY. Nullable, because a bill line with no PO line behind it is
@@ -114,9 +112,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       inverseName: 'Vendor Bill Lines',
       inverseSystemAttribute: 'purchase_order_line_vendor_bill_lines',
     },
-    description:
-      'The PO line this bill line is against — THE MATCH KEY. Null for a line with no purchase ' +
-      'order behind it, which is legal and simply cannot be matched.',
   },
 
   // Stamped from the PO line at write, not hand-set — provenance and grouping
@@ -145,9 +140,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       relationshipType: 'belongs_to',
       isInverse: false,
     },
-    description:
-      'Part this line is for — STAMPED from the PO line at write, not hand-set. Provenance and ' +
-      'spend-by-part grouping only, never a pricing or matching input.',
   },
 
   description: {
@@ -168,7 +160,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Enter description',
-    description: 'What the vendor called it on their document — kept verbatim, not normalised',
   },
 
   quantityBilled: {
@@ -189,9 +180,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     defaultValue: 1,
-    description:
-      'How many the vendor billed for — the quantity the match compares against what was ' +
-      'received, not a copy of it',
   },
 
   unitPrice: {
@@ -217,9 +205,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'What the vendor charged per unit, integer minor units — a BUY price, in contrast to ' +
-      '`line_item.unitPrice`, which is what we SELL for. The two never belong in the same column.',
   },
 
   lineTotal: {
@@ -245,10 +230,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description:
-      'The extended amount the vendor billed, integer minor units — transcribed, NOT recomputed ' +
-      "from qty x price. Recomputing would quietly correct the vendor's own arithmetic, which is " +
-      'exactly the discrepancy the match exists to catch.',
   },
 
   // An account CODE — '2160', '5090' — never a provider account id (P2). The
@@ -273,9 +254,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: '2160',
-    description:
-      "The account CODE this line posts to — '2160' (GRNI) for a PO-matched line, an expense " +
-      'code otherwise. A code, never a provider account id.',
   },
 
   sortOrder: {
@@ -296,7 +274,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    description: "Keeps the lines in the order they appear on the vendor's document",
   },
 
   createdAt: {
@@ -317,7 +294,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Automatically set when the bill line is created',
   },
 
   updatedAt: {
@@ -338,7 +314,6 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Automatically updated when the bill line is modified',
   },
 
   createdBy: CREATED_BY_FIELD,


### PR DESCRIPTION
Drawer/detail-page card sections, plus two unrelated changes that were already in the tree.

Seven commits, each reviewable on its own.

## UI

**The summary strip owns its own design.** Five of six `PurchasingSummaryStrip` call sites were restyling it through `className`; the create-bill dialog re-declared the border, radius and padding the component already draws. Call sites now pass placement only. Nested radii made concentric: `inner = outer − padding = 16px − 4px = 12px`, so the cell drops to `rounded-xl`.

**An icon on every card section.** All 55 now have one, keyed by card `value` so a card looks the same in the drawer and in the sidebar.

The reason two were already wrong: there were **two icon maps** — one in `detail-view/utils.ts`, a shorter private copy in `base-entity-drawer.tsx` that `TabCardSection` resolved *card* icons through. They had drifted, so `store` (Vendor) and `paperclip` (Documents) had been silently drawing the `HouseIcon` fallback. An unmapped name is not a type error and logs nothing. The duplicate is deleted.

**Match verdict badge into the section header.** No new plumbing — `TabCardSection` already exposes the header actions slot, and the sibling Payment card already portals into it.

**Disabled Send button radius.** `ButtonGroup` squares inner corners with direct-child selectors. A disabled button can't receive tooltip hover, so that branch wraps it in a `span`, and `TooltipTrigger asChild` makes *that* the direct child — the selectors styled the span, the button kept all four corners. Fixed the way `publish-cluster-shell.tsx` already fixes it. Quote and invoice share the cluster and get it too.

**Hover, strip and empty state.** `TreeRow` defaults to `hover:bg-background`; sections had been opting into `hover:bg-primary-100` one at a time. `RelatedRecordRow` already had a `rowClassName` prop documented as "e.g. a hover tint" that **no caller passed** — now its default. The work-order Billing card swaps to `PurchasingSummaryStrip`; the full-page tab keeps `BillingSummaryStrip`.

## Not UI

**Field descriptions** rewritten in the reader's language — they'd drifted into plan references, storage detail and function names. Internal sub-entity defs drop theirs entirely. Presentational only.

**CLAUDE.md** gains the inventory/costing guide pointer and the guide itself.

## Worth a second look

- `RelatedRecordRow`'s hover default also reaches order Work orders, service-request Quotes/Work orders and work-order Origin — intended, but more sections than were individually named.
- Work-order Billing cell choice: **Invoiced / Remaining / Balance due**. Deposit held dropped rather than made a fourth cell — it was hidden below `@xl`, so the drawer never showed it.
- CLAUDE.md's new section **replaces** Duplicate Detection. Confirmed deliberate; `docs/duplicate-detection-architecture-guide.md` is untouched on disk, just no longer linked.

## Checks

`pnpm --filter @auxx/web typecheck` clean. 104 registry tests pass. Biome clean.

Not run: the full `packages/lib` suite. `@auxx/lib`'s own typecheck fails on a pre-existing vite version clash unrelated to this branch.

https://claude.ai/code/session_016VBRBMad6T61wvoKV7kfiZ