### PR TITLE
fix(purchasing): re-sum the billed roll-up when a bill line is edited

### DIFF
--- a/apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/create-bill-from-purchase-order-dialog.tsx
@@ -147,10 +147,33 @@ export function CreateBillFromPurchaseOrderDialog({
 
   const vendorRecordId = extractRelationshipRecordIds(values.purchase_order_vendor)[0] ?? null
   const billRecordIds = extractRelationshipRecordIds(values.purchase_order_bills)
-  const { valuesById } = useSystemValuesForRecords(billRecordIds, BILL_ATTRS, {
+  const { valuesById, loadedById } = useSystemValuesForRecords(billRecordIds, BILL_ATTRS, {
     autoFetch: true,
     enabled: open && billRecordIds.length > 0,
   })
+
+  // 🛑 Every remainder below subtracts what the existing bills already charged,
+  // and an UNFETCHED value reads as 0 — which silently turns "order minus
+  // billed" into "order". That is not a transient: the prefill fires on the
+  // first render where a figure is non-zero and its `=== null` guard then makes
+  // that first wrong number permanent.
+  //
+  // It is not hypothetical either. `purchase_order_bills` arrives with the
+  // order, so this second read cannot even START until the first resolves, and
+  // whichever of the four attributes some card on the page happens to have
+  // warmed already resolves a render earlier than the rest. Observed on PO-0007
+  // (fully billed, unbilled $0.00): the Bills card had warmed
+  // `vendor_bill_total`, so Total correctly did not prefill — while Subtotal,
+  // still unread, prefilled the order's full $30.00.
+  //
+  // `loadedById` is the hook's own answer to this: it distinguishes "no value"
+  // from "not fetched yet", which is precisely the difference that matters here.
+  // Failing closed costs a prefill; failing open writes a wrong payable.
+  const billFiguresLoaded =
+    billRecordIds.length === 0 ||
+    billRecordIds.every((billRecordId) =>
+      BILL_ATTRS.every((attr) => loadedById[billRecordId]?.[attr])
+    )
 
   /** An order figure minus what every existing bill already charged for it. */
   const remainder = (orderAttr: (typeof PO_ATTRS)[number], billAttr: (typeof BILL_ATTRS)[number]) =>
@@ -209,7 +232,7 @@ export function CreateBillFromPurchaseOrderDialog({
   // that is what makes it unable to overwrite typing, including a total the user
   // deliberately cleared to zero.
   useEffect(() => {
-    if (!open) return
+    if (!open || !billFiguresLoaded) return
     setDraft((prev) => {
       const next = { ...prev }
       if (prev.total === null && unbilled > 0) {
@@ -224,7 +247,15 @@ export function CreateBillFromPurchaseOrderDialog({
       }
       return next
     })
-  }, [open, unbilled, hasDiscount, unbilledSubtotal, unbilledShipping, unbilledTax])
+  }, [
+    open,
+    billFiguresLoaded,
+    unbilled,
+    hasDiscount,
+    unbilledSubtotal,
+    unbilledShipping,
+    unbilledTax,
+  ])
 
   // The order's received-but-unbilled lines, raised onto the new bill so the
   // person holding the invoice types NUMBERS rather than rebuilding its line list

--- a/apps/web/src/components/purchasing/purchase-order/purchase-order-lines-tab.tsx
+++ b/apps/web/src/components/purchasing/purchase-order/purchase-order-lines-tab.tsx
@@ -129,9 +129,17 @@ export function PurchaseOrderLinesTab({ recordId, variant = 'tab' }: DetailViewT
   ].filter((b): b is BadgeSpec => !!b)
 
   // ⚠️ The addressee is the CONTACT, never the vendor: `purchase_order_vendor` targets a
-  // `company` and a company carries no email field at all (§7.2). `purchase_order_contact`
-  // is nullable and nothing prefills it, so "no contact" is the COMMON case — surfacing it
-  // as a disabled reason beats letting `prepareDocumentEmail` reject the round trip.
+  // `company` and a company carries no email field at all (§7.2).
+  //
+  // `purchase_order_contact` IS prefilled from the vendor's `company_primary_contact` —
+  // `field-hooks/post/purchase-order-contact-prefill.ts`, two doors, one for creates through
+  // `UnifiedCrudHandler` and one for later edits. But it stays nullable and the prefill has
+  // nothing to copy when the vendor has no primary contact, so "no contact" remains a case
+  // worth naming rather than a rarity — surfacing it as a disabled reason beats letting
+  // `prepareDocumentEmail` reject the round trip.
+  //
+  // (This comment previously claimed nothing prefills the field. That was true before #1948
+  // and false after it, and it misled a later reader into recording the gap as by-design.)
   const hasContact = extractRelationshipRecordIds(values.purchase_order_contact).length > 0
 
   // Shared send/download flow (compose + PDF + no-channel guard) — the same hook quote

--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -506,6 +506,31 @@ different connection and cannot see uncommitted rows.
 
 These are the silent failures this subsystem has already paid for. Every one of them passed CI.
 
+**A child-to-parent roll-up needs a door for every way its child can change, and
+`created`/`deleted` is only complete when the child is append-only.**
+`purchase_order_line_quantity_billed` had exactly those two triggers, and
+`purchase-order-status-writer.ts` asserted in prose that they were "the two events that can move
+either axis". That held for the RECEIPT roll-up, whose child `stock_movement` is append-only —
+a correction is a reversal, which is another create. It was false for BILLING, because a
+`vendor_bill_line` is created at its registry default of `1` and the real quantity is typed in
+**afterwards**: the ordinary act of transcribing an invoice moved the child and never re-SUMmed
+the parent. Two dev orders sat at a stored `1` against bill lines reading `4` and `10`, and the
+divergence was permanent. Downstream, `selectBillableLines` gates on `billed < ordered`, so a
+fully-billed line kept being offered back on the next bill, and `purchase_order_billing_status`
+is classified from the same stale figure. Fixed 2026-08-28 by
+`recalculateBilledRollupOnBillLineChange` marking a per-line reconciler.
+
+**A relationship repoint dirties TWO parents, and the post-hook only names one.** The edit door
+above is keyed on `vendor_bill_line_quantity_billed` *and*
+`vendor_bill_line_purchase_order_line`, because the match key is user-editable
+(`PurchaseOrderLinePicker`) and re-pointing a bill line at a different order line leaves the line
+it VACATED holding a phantom quantity. `newValue` names only the destination, so the handler
+reads `EntityFieldChangeEvent.oldValue` — the pre-write value, and the only place the vacated
+parent is still named — and marks both. This is why the reconciler is keyed on the PURCHASE ORDER
+LINE (the marked record IS the parent, no `resolve` step): one keyed on the bill line could only
+ever resolve the parent it now points at. ⚠️ The fix prevents new divergence; it does **not**
+repair rows that already diverged — those need a backfill.
+
 **A cached value derived from CODE outlives the code.** The `recordRules` cache once held DB
 rules unioned with code-declared system rules, so adding an action to a system rule did nothing
 for a day per org — the cached list kept firing, nothing threw, nothing logged. Two rules:

--- a/packages/lib/src/field-hooks/post/purchase-order-line-rollups.test.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-line-rollups.test.ts
@@ -22,6 +22,13 @@ const h = vi.hoisted(() => ({
   rematchBillsForPurchaseOrderLines: vi.fn(
     async (_organizationId: string, _userId: string, _lineIds: string[]) => {}
   ),
+  // The reconciler the billed roll-up's EDIT door marks into. Captured at module
+  // load so a test can invoke the spec's own `rebuild` — the only way to prove
+  // the drain is wired to the BILLED spec and not the received one.
+  reconcilerSpec: null as { key: string; rebuild: Function; resolve?: unknown } | null,
+  mark: vi.fn(async (_org: string, _user: string, _id: string) => {}),
+  register: vi.fn(),
+  resolveParentsByRelation: vi.fn(async () => [] as string[]),
   // The two shapes the module asks the db for, in call order.
   dbResults: [] as unknown[][],
 }))
@@ -72,13 +79,24 @@ vi.mock('../../purchasing/purchase-order-status-writer', () => ({
 vi.mock('../../purchasing/match-reconciler', () => ({
   rematchBillsForPurchaseOrderLines: h.rematchBillsForPurchaseOrderLines,
 }))
+vi.mock('../../reconcilers/parent-reconciler', () => ({
+  defineParentReconciler: (spec: { key: string; rebuild: Function }) => {
+    h.reconcilerSpec = spec
+    return { register: h.register, mark: h.mark }
+  },
+  resolveParentsByRelation: h.resolveParentsByRelation,
+}))
 
+import type { EntityFieldChangeEvent } from '../types'
 import {
+  PURCHASE_ORDER_LINE_BILLED_ROLLUP,
   PURCHASE_ORDER_LINE_ROLLUPS,
+  recalculateBilledRollupOnBillLineChange,
   recalculatePurchaseOrderLineBilled,
   recalculatePurchaseOrderLineReceived,
   recalculatePurchaseOrderLineRollup,
   recalculatePurchaseOrderLineRollups,
+  registerPurchaseOrderLineRollupReconcilers,
 } from './purchase-order-line-rollups'
 
 const PO_LINE = 'poline-1'
@@ -118,6 +136,7 @@ beforeEach(() => {
   h.recalculatePurchaseOrderStatuses.mockResolvedValue(ok({}))
   h.recalculatePurchaseOrderStatusesForLines.mockResolvedValue(ok([]))
   h.rematchBillsForPurchaseOrderLines.mockResolvedValue(undefined)
+  h.resolveParentsByRelation.mockResolvedValue([])
 })
 
 describe('recalculatePurchaseOrderLineReceived', () => {
@@ -568,5 +587,145 @@ describe('a receipt re-matches the bills that charge the line', () => {
 
     // The quantity is the primary fact and is already committed.
     expect(h.setValueWithType).toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The EDIT door.
+//
+// The create/delete triggers above are complete coverage for RECEIPTS, because a
+// movement is append-only. They were never complete for BILLING: a bill line is
+// created at its registry default of `1` and the real quantity typed in after, so
+// the ordinary act of transcribing an invoice moved the child and left the parent
+// permanently stale. Found in a browser, not by a test — these are the tests that
+// would have.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A post-write field-change event on a bill line. */
+function billLineChange(
+  systemAttribute: string,
+  {
+    oldValue = null,
+    newValue = null,
+    recordId = 'vbldef:vbl-1',
+  }: { oldValue?: unknown; newValue?: unknown; recordId?: string } = {}
+): EntityFieldChangeEvent {
+  return {
+    recordId,
+    entityDefinitionId: 'vbldef',
+    entityType: 'vendor_bill_line',
+    entitySlug: 'vendor-bill-lines',
+    field: { id: 'fld', systemAttribute },
+    oldValue,
+    newValue,
+    oldDisplay: null,
+    newDisplay: null,
+    organizationId: 'org_1',
+    userId: 'usr_1',
+  } as unknown as EntityFieldChangeEvent
+}
+
+/** Every PO line id the handler marked, sorted so order is not asserted. */
+const markedLines = () => h.mark.mock.calls.map((call) => call[2]).sort()
+
+describe('recalculateBilledRollupOnBillLineChange', () => {
+  it('re-SUMs the line a quantity edit belongs to — the case create/delete missed', async () => {
+    h.resolveParentsByRelation.mockResolvedValue(['poline-9'])
+
+    await recalculateBilledRollupOnBillLineChange(
+      billLineChange('vendor_bill_line_quantity_billed')
+    )
+
+    // A quantity write does not say which line it belongs to, so the match key is
+    // resolved off the bill line itself.
+    expect(h.resolveParentsByRelation).toHaveBeenCalledWith(
+      'org_1',
+      'vendor_bill_line_purchase_order_line',
+      ['vbl-1']
+    )
+    expect(markedLines()).toEqual(['poline-9'])
+  })
+
+  it('marks BOTH sides of a repoint, so the line the bill line left is re-SUMmed', async () => {
+    await recalculateBilledRollupOnBillLineChange(
+      billLineChange('vendor_bill_line_purchase_order_line', {
+        oldValue: [{ recordId: 'poldef:poline-old' }],
+        newValue: [{ recordId: 'poldef:poline-new' }],
+      })
+    )
+
+    // 🛑 The whole point. `newValue` names only the line it now points at; without
+    // `oldValue` the vacated line keeps the phantom quantity forever.
+    expect(markedLines()).toEqual(['poline-new', 'poline-old'])
+    // Both sides came off the event — a repoint costs no read.
+    expect(h.resolveParentsByRelation).not.toHaveBeenCalled()
+  })
+
+  it('re-SUMs the vacated line when the match key is CLEARED, not swapped', async () => {
+    await recalculateBilledRollupOnBillLineChange(
+      billLineChange('vendor_bill_line_purchase_order_line', {
+        oldValue: [{ recordId: 'poldef:poline-old' }],
+        newValue: null,
+      })
+    )
+
+    expect(markedLines()).toEqual(['poline-old'])
+  })
+
+  it('accepts the legacy relationship shape as well as { recordId }', async () => {
+    await recalculateBilledRollupOnBillLineChange(
+      billLineChange('vendor_bill_line_purchase_order_line', {
+        oldValue: null,
+        newValue: [{ relatedEntityId: 'poline-legacy', relatedEntityDefinitionId: 'poldef' }],
+      })
+    )
+
+    expect(markedLines()).toEqual(['poline-legacy'])
+  })
+
+  it('ignores an attribute that cannot move the total', async () => {
+    // Moving a line to another BILL does not change which order line it feeds.
+    await recalculateBilledRollupOnBillLineChange(
+      billLineChange('vendor_bill_line_vendor_bill', { newValue: [{ recordId: 'bdef:bill-2' }] })
+    )
+
+    expect(h.mark).not.toHaveBeenCalled()
+    expect(h.resolveParentsByRelation).not.toHaveBeenCalled()
+  })
+
+  it('marks nothing for a bill line with no match key — a freight line is ordinary', async () => {
+    h.resolveParentsByRelation.mockResolvedValue([])
+
+    await recalculateBilledRollupOnBillLineChange(
+      billLineChange('vendor_bill_line_quantity_billed')
+    )
+
+    expect(h.mark).not.toHaveBeenCalled()
+  })
+})
+
+describe('the billed roll-up reconciler', () => {
+  it('is keyed on the PURCHASE ORDER LINE, with no child resolve step', () => {
+    // Load-bearing: the marked record IS the parent. A reconciler keyed on the
+    // bill line could only ever name the line it now points at, which is exactly
+    // what makes a repoint unexpressible.
+    expect(h.reconcilerSpec?.key).toBe(PURCHASE_ORDER_LINE_BILLED_ROLLUP)
+    expect(h.reconcilerSpec?.resolve).toBeUndefined()
+  })
+
+  it('rebuilds with the BILLED spec, never the received one', async () => {
+    h.dbResults.push([{ total: '9' }])
+
+    await h.reconcilerSpec?.rebuild('org_1', 'usr_1', PO_LINE)
+
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fieldId: 'fld-billed', value: { type: 'number', value: 9 } })
+    )
+  })
+
+  it('registers its drain — without it the hook marks into nothing', () => {
+    registerPurchaseOrderLineRollupReconcilers()
+    expect(h.register).toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/field-hooks/post/purchase-order-line-rollups.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-line-rollups.ts
@@ -10,6 +10,7 @@ import { and, eq, inArray, type SQL, sql } from 'drizzle-orm'
 import { getOrgCache, requireCachedEntityDefId } from '../../cache'
 import { createFieldValueContext } from '../../field-values/field-value-helpers'
 import { setValueWithType } from '../../field-values/field-value-mutations'
+import { extractRelationshipRecordIds } from '../../field-values/relationship-field'
 import { type StoredFieldType, toFieldType } from '../../field-values/stored-field-type'
 import {
   type PurchaseOrderStatusEvidence,
@@ -21,7 +22,11 @@ import {
   getRealtimeService,
   publishFieldValueUpdates,
 } from '../../realtime'
-import type { EntityTriggerHandler } from '../types'
+import {
+  defineParentReconciler,
+  resolveParentsByRelation,
+} from '../../reconcilers/parent-reconciler'
+import type { EntityFieldChangeHandler, EntityTriggerHandler } from '../types'
 
 const logger = createScopedLogger('field-hooks:purchase-order-line-rollups')
 
@@ -515,6 +520,123 @@ export const PURCHASE_ORDER_LINE_ROLLUPS = {
   received: RECEIVED_ROLLUP,
   billed: BILLED_ROLLUP,
 } as const
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The EDIT door for the billed roll-up
+//
+// 🛑 The create/delete triggers above are NOT complete coverage for billing, and
+// this is the half that was missing (verified in a browser 2026-08-28; the
+// architecture guide §12 carries the finding).
+//
+// `purchase-order-status-writer.ts` states the assumption the old shape rested
+// on — the roll-ups "fire on exactly the two events that can move either axis (a
+// `stock_movement` or a `vendor_bill_line` create/delete)". That is true of
+// RECEIPTS, because a movement is append-only: correcting one means reversing
+// it, which is another create. It is false of BILLING, because a bill line is
+// created at its registry default of `1` and the real quantity is typed in
+// AFTERWARDS. So the ordinary act of transcribing an invoice moved the child and
+// never re-SUMMED the parent, and the divergence was permanent: two dev orders
+// sat at a stored `1` against bill lines reading `4` and `10`.
+//
+// What that broke, beyond the number itself: `selectBillableLines` gates on
+// `billed < ordered`, so a fully-billed line kept being offered back on the next
+// bill, and `purchase_order_billing_status` is classified from the same stale
+// figure.
+//
+// ⚠️ The receipt roll-up deliberately does NOT get an edit door. `stock_movement`
+// declares every field `updatable: false` and a correction is a reversal, so
+// there is no legitimate edit to catch. (That capability is advisory rather than
+// enforced at the write path — but the answer to a movement being edited is to
+// stop the edit, not to re-derive around it.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** `dirty-parents` key for the billed roll-up. The marked record IS the parent. */
+export const PURCHASE_ORDER_LINE_BILLED_ROLLUP = 'po-line-rollup:billed'
+
+/**
+ * Coalescing drain for the billed roll-up.
+ *
+ * Marked with a PURCHASE ORDER LINE id, not a bill line id — the marked record
+ * is already the parent, so the spec needs no `resolve`. That is what makes a
+ * repoint expressible at all: one bill line write can dirty TWO parents, and a
+ * reconciler keyed on the child could only ever name the one it now points at.
+ *
+ * Coalescing is the other half of the point. Typing quantity and price on a
+ * three-line bill is six field writes hitting the same three lines; the drain
+ * re-SUMs each distinct line once.
+ */
+const billedRollupReconciler = defineParentReconciler<string>({
+  key: PURCHASE_ORDER_LINE_BILLED_ROLLUP,
+  rebuild: (organizationId, _userId, purchaseOrderLineInstanceId) =>
+    recalculatePurchaseOrderLineRollup(organizationId, purchaseOrderLineInstanceId, BILLED_ROLLUP),
+})
+
+/**
+ * Register the billed roll-up's drain. Called from `registerAllHooks()`.
+ *
+ * 🛑 Must stay paired with the hook below, which only MARKS. Without this,
+ * nothing re-SUMs — which is the exact bug this pair exists to close, restored
+ * by omission.
+ */
+export function registerPurchaseOrderLineRollupReconcilers(): void {
+  billedRollupReconciler.register()
+}
+
+/** The two bill-line attributes whose EDIT can move a purchase order line's billed total. */
+const BILLED_ROLLUP_TRIGGER_ATTRS = new Set<SystemAttribute>([
+  'vendor_bill_line_quantity_billed',
+  'vendor_bill_line_purchase_order_line',
+])
+
+/**
+ * Re-SUM the billed roll-up after a bill line is EDITED.
+ *
+ * Deliberately a second handler beside `rematchOnBillLineChange` rather than a
+ * branch inside it. They fire on overlapping attributes and are otherwise
+ * unrelated: the match writes the BILL's verdict, this writes the ORDER LINE's
+ * quantity, and this module is that field's only writer. Folding one into the
+ * other would put the roll-up's write behind the match's trigger set, where the
+ * next person to tune that set would move it by accident.
+ *
+ * 🛑 **A repoint dirties the line it LEFT.** `vendor_bill_line_purchase_order_line`
+ * is user-editable through `PurchaseOrderLinePicker`, so picking the wrong line
+ * and correcting it is ordinary. The post-hook's `newValue` names only the new
+ * line; without `oldValue` the old one keeps the phantom quantity forever, which
+ * is the same defect one level down. Both are marked.
+ */
+export const recalculateBilledRollupOnBillLineChange: EntityFieldChangeHandler = async (event) => {
+  const attr = event.field.systemAttribute as SystemAttribute | undefined
+  if (!attr || !BILLED_ROLLUP_TRIGGER_ATTRS.has(attr)) return
+
+  const lineInstanceIds = new Set<string>()
+
+  if (attr === 'vendor_bill_line_purchase_order_line') {
+    // Both sides come off the event — no read needed, and `oldValue` is the only
+    // place the vacated line is still named.
+    for (const value of [event.oldValue, event.newValue]) {
+      for (const recordId of extractRelationshipRecordIds(value)) {
+        lineInstanceIds.add(parseRecordId(recordId).entityInstanceId)
+      }
+    }
+  } else {
+    // A quantity write says nothing about which line it belongs to, so resolve
+    // the bill line's current match key. One query, and the same helper the match
+    // reconciler uses for its own parent lookup.
+    const { entityInstanceId: billLineInstanceId } = parseRecordId(event.recordId)
+    const parents = await resolveParentsByRelation(
+      event.organizationId,
+      'vendor_bill_line_purchase_order_line',
+      [billLineInstanceId]
+    )
+    for (const parent of parents) lineInstanceIds.add(parent)
+  }
+
+  // A bill line with no match key is ordinary — a freight line, a one-off — and
+  // contributes nothing to any order line's total.
+  for (const lineInstanceId of lineInstanceIds) {
+    await billedRollupReconciler.mark(event.organizationId, event.userId, lineInstanceId)
+  }
+}
 
 /**
  * Extract a related entity id from threaded event values. Values may be keyed by

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -63,6 +63,10 @@ import { invalidateInboxCacheOnFieldChange } from './post/inbox-cache-invalidati
 import { stampPartOnCatalogItemChange } from './post/line-item-part-stamp'
 import { publishFieldChangeEvent } from './post/publish-field-change-event'
 import { prefillContactOnVendorChange } from './post/purchase-order-contact-prefill'
+import {
+  recalculateBilledRollupOnBillLineChange,
+  registerPurchaseOrderLineRollupReconcilers,
+} from './post/purchase-order-line-rollups'
 import { touchActivityOnFieldChange } from './post/touch-activity-on-field-change'
 import { guardManualBuildLifecycleStatus } from './pre/build-status-guard'
 import { guardInboxOwnerField } from './pre/inbox-owner-guard'
@@ -133,6 +137,12 @@ export function registerAllHooks(): void {
   // The three-way match's two drains. Same rule as above: the bill and bill-line
   // hooks only MARK, so without this nothing re-matches.
   registerMatchReconcilers()
+
+  // The billed roll-up's drain. Same rule again: the bill-line hook below only
+  // MARKS, so without this a bill line EDIT never re-SUMs
+  // `purchase_order_line_quantity_billed` — which is the shape the create/delete
+  // triggers alone left open.
+  registerPurchaseOrderLineRollupReconcilers()
 
   // The billing projectors' four drains. Same rule again: the six billing hooks
   // below only MARK, so without this nothing rebuilds a projection.
@@ -243,7 +253,14 @@ export function registerAllHooks(): void {
   // so these registrations are what make the exception queue anything other than empty.
   // The bill's own totals are NOT recomputed here — they are transcribed (01 §5.4b).
   registerEntityFieldChangeHooks('vendor-bills', [rematchOnBillChange])
-  registerEntityFieldChangeHooks('vendor-bill-lines', [rematchOnBillLineChange])
+  // Two independent derivations off the same writes: the match writes the BILL's
+  // verdict, the roll-up writes the ORDER LINE's billed quantity. Both must be
+  // here — a bill line is created at the default quantity `1` and the real
+  // number typed in after, and only the second handler sees that edit.
+  registerEntityFieldChangeHooks('vendor-bill-lines', [
+    rematchOnBillLineChange,
+    recalculateBilledRollupOnBillLineChange,
+  ])
   //
   // Client-notifications plan §4.3: enroll the seeded `invoice_reminders` sequence on the
   // draft→sent transition (`enrollInvoiceReminderOnSent` checks the PREVIOUS value so a


### PR DESCRIPTION
Two defects found by driving the bill leg in a browser for the first time. Neither could have been caught by a test — both were found by using the thing, and the second one's unit tests all passed while the feature was wrong.

## 1. `purchase_order_line_quantity_billed` never updated on a bill-line EDIT

The roll-up was registered on `vendor-bill-lines` **`created`** and **`deleted`** only, and the entity rule system has no `updated` — that is a *field*-level action.

That is complete coverage for the RECEIPT roll-up, whose child `stock_movement` is append-only: a correction is a reversal, which is another create. It is **not** complete for BILLING, because a `vendor_bill_line` is created at its registry default of `1` and the real quantity is typed in **afterwards**. So the ordinary act of transcribing an invoice moved the child and never re-SUMmed the parent, and the divergence was permanent.

`purchase-order-status-writer.ts` stated the assumption in prose — *"fires on exactly the two events that can move either axis (a `stock_movement` or a `vendor_bill_line` create/delete)"* — and that sentence is where the hole was.

**Reproduced twice, in two different sessions:**

| PO line | bill line says | roll-up said |
| --- | --- | --- |
| PO-0002 line 1 | `4` | **`1`** |
| PO-0008 line 1 | `10` | **`1`** |

Downstream: `selectBillableLines` gates on `billed < ordered`, so a fully-billed line kept being offered back on the next bill — observed as an Add-bill dialog advertising *"Add 2 lines from the order"* when only one line was genuinely unbilled. `purchase_order_billing_status` is classified from the same stale figure.

### The fix

A `dirty-parents` reconciler keyed on the **purchase order line** — the marked record IS the parent, so the spec needs no `resolve` — plus a bill-line field-change hook that marks it. Registered *beside* the match's hook rather than folded into it: the match writes the BILL's verdict, this writes the ORDER LINE's quantity, and they only happen to share a trigger set.

**A repoint dirties TWO parents.** `vendor_bill_line_purchase_order_line` is user-editable through `PurchaseOrderLinePicker`, and `newValue` names only the destination, so the vacated line would keep a phantom quantity — the same defect one level down. The handler reads `EntityFieldChangeEvent.oldValue`, the pre-write value and the only place that line is still named, and marks both. Keying the reconciler on the PO line rather than the bill line is what makes that expressible at all.

### Verified in the running app, not only in tests

| Action | `26" S` | `54" D` | `18" D` (untouched) |
| --- | --- | --- | --- |
| before | `3` *(was stuck at `1`)* | `1` | `1` |
| edit quantity 4 → 3 | **`3`** ✓ | — | — |
| repoint bill line onto `54" D` | **`0`** ✓ | **`4`** ✓ | unchanged, not rewritten ✓ |

The untouched line's `updatedAt` did not move, so the unchanged-total short-circuit still holds. The Lines card then correctly offered *"Add 1 line from order"*.

10 tests added (39 in the file). **Mutation-checked**: dropping `oldValue` from the handler fails exactly the two repoint tests.

## 2. The create-bill dialog prefilled the order's GROSS figure, permanently

Each amount prefills as `order figure − what existing bills already charged`. The subtrahend comes from a **second** read that cannot start until the first resolves (`purchase_order_bills` arrives with the order). An **unfetched** value reads as `0`, collapsing the remainder to the full order figure — and the prefill's `prev.x === null` guard then makes that first wrong number **permanent**.

Deterministic rather than a race: the Bills card warms `vendor_bill_total` and only that, so `total` had its subtrahend and behaved while `subtotal`/`shipping`/`tax` never do.

**Observed on PO-0007** — a fully-billed order whose own dialog header read *Unbilled $0.00* while Subtotal prefilled the full **$30.00**. Reopening with a warm store gave the correct blank, which is the proof rather than a flake. Freight is the case that matters: the file's header says the subtraction exists precisely so a second invoice does not re-charge the order's shipping.

Gated on the hook's `loadedById`, which distinguishes "no value" from "not fetched yet" — the Bills card already guards the same way via `billsLoading`. Verified both directions: no prefill where the remainder is zero, correct prefill ($1,300/$100/$200/$1,600) where it is not.

## Also

Corrects a stale comment in `purchase-order-lines-tab.tsx` claiming nothing prefills `purchase_order_contact`. The prefill shipped in #1948 with two doors; the comment had already misled a reader (me) into recording a shipped feature as a deliberate gap.

The two durable invariants are recorded in `docs/inventory-costing-architecture-guide.md` §11.

## Checks

- `packages/lib` + `apps/web` typecheck ratchets: **no new type errors** from this branch
- 396 tests green across `field-hooks` / `purchasing` / `reconcilers`
- Biome clean

⚠️ This fix prevents new divergence; it does not repair rows that already diverged. Purchasing has never been deployed and none of the data is real, so no backfill is planned.

https://claude.ai/code/session_01EAGuEcz9XL8vfxQjo8hxnJ
