### PR TITLE
fix(purchasing): stop the bill-line duplicate window, and show a record's documents

### DIFF
--- a/apps/web/src/components/purchasing/record-documents-card.tsx
+++ b/apps/web/src/components/purchasing/record-documents-card.tsx
@@ -34,6 +34,7 @@ import { FileSelectDialog } from '~/components/file-select/file-select-dialog'
 import { FileIcon } from '~/components/files/utils/file-icon'
 import { Tooltip } from '~/components/global/tooltip'
 import { useResourceFields } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useAccess } from '~/providers/capabilities-provider'
 
 interface DocumentRow {
@@ -80,6 +81,29 @@ function RecordDocumentsCard({
 }) {
   const { entityDefinitionId } = parseRecordId(recordId)
   const { fields, isLoading } = useResourceFields(entityDefinitionId)
+
+  // 🛑 SOMEBODY has to fetch these two, and on this record it is nobody else.
+  //
+  // `useFieldFileUpload` only SUBSCRIBES — it reads `useFieldValueStore` at the
+  // canonical key and never issues a read of its own. Everywhere else that is
+  // correct, because a FILE field input is rendered inside a panel or a grid that
+  // has already fetched the row. This card is the exception: every field it
+  // renders is `showInPanel: false` — that is the whole reason the card exists —
+  // so the Details panel skips them and no other surface on the page asks for
+  // them either.
+  //
+  // The result was a card that rendered "No documents" forever on records that
+  // plainly had files. Observed on PO-0007 (a real 22,482-byte `PO-0007.pdf`) and
+  // on PO-0010 (21,721 bytes, sent, `issued`) — both showed the empty state, and
+  // the DB showed `purchase_order_pdf_asset` set on both. It reads as "the PDF
+  // was never generated", which is a different and much more alarming bug than
+  // the one it is.
+  //
+  // The fetch must go through the SAME canonical key the uploader subscribes with,
+  // which is what `useSystemValues` resolving a systemAttribute gives us — an
+  // ad-hoc read on a hand-built key populates a slot nothing is watching, exactly
+  // as `use-field-file-upload.ts`'s own note describes.
+  useSystemValues(recordId, [primaryAttribute, attachmentsAttribute], { autoFetch: true })
 
   const { primaryField, attachmentsField } = useMemo(() => {
     const byAttribute = new Map(

--- a/apps/web/src/components/purchasing/vendor-bill/add-purchase-order-lines-button.tsx
+++ b/apps/web/src/components/purchasing/vendor-bill/add-purchase-order-lines-button.tsx
@@ -43,7 +43,7 @@ export function AddPurchaseOrderLinesButton({
   onAdded?: () => void
 }) {
   const { lines: purchaseOrderLines } = usePurchaseOrderLines(purchaseOrderRecordId)
-  const { rows, refresh } = useVendorBillLines(billRecordId)
+  const { rows, ready, refresh } = useVendorBillLines(billRecordId)
 
   const billable = selectBillableLines(
     purchaseOrderLines,
@@ -65,7 +65,18 @@ export function AddPurchaseOrderLinesButton({
     onAdded?.()
   }, [lineDefId, billable, createMany, billRecordId, nextSortOrder, refresh, onAdded])
 
-  if (!purchaseOrderRecordId || billable.length === 0) return null
+  // 🛑 `ready`, not `rows.length` and not `isLoading` — see the flag's own note.
+  // `selectBillableLines` subtracts the order lines this bill already claims, and
+  // through every load window that subtraction comes out empty, so this button
+  // offers the WHOLE order back on a bill that already has it. Observed on a cold
+  // drawer open of a fully-linked bill: a live, clickable "Add 2 lines from
+  // order" for ~300–550 ms that would have duplicated both lines, with
+  // `nextSortOrder` reading 0 so they would have collided on order too.
+  //
+  // Hiding is the right failure: this button already renders nothing when there
+  // is nothing to add, so a late arrival is indistinguishable from the ordinary
+  // case, and the cost of being wrong the other way is silent double-billing.
+  if (!purchaseOrderRecordId || !ready || billable.length === 0) return null
 
   return (
     <Button

--- a/apps/web/src/components/purchasing/vendor-bill/use-vendor-bill-lines.ts
+++ b/apps/web/src/components/purchasing/vendor-bill/use-vendor-bill-lines.ts
@@ -111,10 +111,47 @@ export function useVendorBillLines(billRecordId: RecordId) {
     [records, lineDefId]
   )
 
-  const { valuesById } = useSystemValuesForRecords(rowRecordIds, VENDOR_BILL_LINE_ATTRIBUTES, {
-    autoFetch: true,
-    enabled: rowRecordIds.length > 0,
-  })
+  const { valuesById, loadedById } = useSystemValuesForRecords(
+    rowRecordIds,
+    VENDOR_BILL_LINE_ATTRIBUTES,
+    { autoFetch: true, enabled: rowRecordIds.length > 0 }
+  )
+
+  /**
+   * Whether `rows` is the bill's real line set, as opposed to a shape it passes
+   * through on the way there.
+   *
+   * 🛑 A caller whose correctness depends on a line being ABSENT must gate on
+   * this, never on `rows` and never on `isLoading` alone. An empty or valueless
+   * `rows` is reached three different ways after a drawer mounts, and only the
+   * last one means what it says:
+   *
+   *   1. `lineDefId` is undefined while the resource store hydrates. The list is
+   *      `enabled: false`, so it reports **`isLoading: false`** with no records —
+   *      an empty answer that was never asked. This is the window an `isLoading`
+   *      gate silently misses.
+   *   2. `isLoading` — the list query is in flight. No rows yet.
+   *   3. rows exist, values do not. They arrive from a SECOND batched fetch, so
+   *      every `purchaseOrderLineRecordId` reads `undefined`, which is
+   *      indistinguishable from a freight line carrying no match key.
+   *
+   * `selectBillableLines` subtracts the order lines this bill already claims,
+   * using exactly that field. Through all three windows it subtracts nothing, so
+   * "Add lines from order" offers the whole order back on a bill that already
+   * has it — observed as a live, clickable button on a cold open of a
+   * fully-linked bill. The pure guard is correct and its unit test passes; the
+   * component simply could not supply the argument yet.
+   *
+   * `loadedById` is the fetch layer's own answer to (3): a raw `undefined` means
+   * not fetched, a raw `null` means genuinely empty.
+   */
+  const ready =
+    !!billId &&
+    !!lineDefId &&
+    !isLoading &&
+    rowRecordIds.every((lineRecordId) =>
+      VENDOR_BILL_LINE_ATTRIBUTES.every((attr) => loadedById[lineRecordId]?.[attr])
+    )
 
   const rows = useMemo(
     () =>
@@ -127,5 +164,5 @@ export function useVendorBillLines(billRecordId: RecordId) {
     [rowRecordIds, valuesById]
   )
 
-  return { billId, lineDefId, rows, isLoading, refresh }
+  return { billId, lineDefId, rows, isLoading, ready, refresh }
 }


### PR DESCRIPTION
Two defects found by **driving the bill leg in a browser**. Neither is visible to a test, and both had shipped.

### 1. "Add N lines from order" duplicated every line during a load window

The pure guard is correct and its test passes — **the component could not supply its argument yet.** Rows exist before their values, so every `purchaseOrderLineRecordId` read `undefined`, `taken` came back empty, and the button re-offered the whole order onto a bill that already carried it.

Measured live and clickable for **373 / 294 / 556 ms** across three cold opens.

🛑 **There are three load windows, not one, and the first is the trap:** `lineDefId` is undefined → the query is `enabled: false` → `isLoading` is **false**. An `isLoading` gate misses it entirely. Two attempts failed on exactly that before the cause was clear, which is why this is a single explicit `ready` flag on the hook rather than a loading check.

### 2. The Documents card had never rendered a file, on any record

`useFieldFileUpload` only **subscribes** to the field-value store; it does not fetch. Every field this card renders is `showInPanel: false` — which is the card's *whole reason to exist* — so nothing else ever pulled those values.

Two POs carrying real PDFs (21,721 and 22,482 bytes) both displayed **"No documents"**. It reads exactly like the PDF was never generated.

Fixed **in the card**, by fetching the two file attributes it renders. Deliberately **not** in `useFieldFileUpload`, which is shared by every FILE input in the app.

### Verified in a browser after the fix

- one press adds exactly the outstanding lines, and the button then disappears
- the generated-PDF row is locked, with no remove affordance
- an uploaded attachment persists and renders as a TreeRow
- both downloads return `200 application/pdf` at the correct byte sizes

### Checks

`pnpm --filter @auxx/web typecheck` exit 0 · `typecheck-ratchet --package lib` → `29 total, baseline 29` exit 0 · `biome check` clean (the one warning is pre-existing, in a test double this PR does not touch).

### Not fixed here

**Match-note line numbers do not match the document.** `rematchBill` calls `listFiltered` with no `sorting`, so note indices follow query order while every surface renders by `sort_order` — visible *inside one card*, and after fixing one line the remaining fault pointed at the row that had just gone green. Lib-side and deserves its own change.

**Send is blocked on environment**, not code — the dev channel's login has expired. Two findings fell out and are recorded in the plans: `hasEmailChannel` checks that a channel **exists**, not that it is **authenticated**, so you get a PDF and a composed email and a failure at the last step; and `purchase_order_pdf_asset` is written when the composer **opens**, not on send.

https://claude.ai/code/session_01DebKVm93wUUyZSy3a1YRKr