### PR TITLE
feat(purchasing): compute a vendor bill's balance

### DIFF
--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -528,8 +528,9 @@ it VACATED holding a phantom quantity. `newValue` names only the destination, so
 reads `EntityFieldChangeEvent.oldValue` — the pre-write value, and the only place the vacated
 parent is still named — and marks both. This is why the reconciler is keyed on the PURCHASE ORDER
 LINE (the marked record IS the parent, no `resolve` step): one keyed on the bill line could only
-ever resolve the parent it now points at. ⚠️ The fix prevents new divergence; it does **not**
-repair rows that already diverged — those need a backfill.
+ever resolve the parent it now points at. ⚠️ A fix of this shape prevents new divergence and does
+**not** repair rows that already diverged; whether that needs a backfill is a separate call, and
+for this one it did not (purchasing was pre-deployment, so the stale rows went with the dev seed).
 
 **A cached value derived from CODE outlives the code.** The `recordRules` cache once held DB
 rules unioned with code-declared system rules, so adding an action to a system rule did nothing

--- a/packages/lib/scripts/backfill-vendor-bill-balance.ts
+++ b/packages/lib/scripts/backfill-vendor-bill-balance.ts
@@ -1,0 +1,57 @@
+// packages/lib/scripts/backfill-vendor-bill-balance.ts
+//
+// One-time backfill: write `vendor_bill_balance` for every vendor bill that
+// carries a total.
+//
+// WHY THESE ROWS EXIST: the field shipped declared `creatable: false`, "computed
+// from total and amountPaid", with NO writer of any kind — zero FieldValue rows
+// in the whole installation. `purchasing/vendor-bill-balance.ts` is now that
+// writer, but a hook only fires on a write, so every already-entered bill would
+// have stayed NULL until somebody re-keyed its total. This is that one pass.
+//
+// Idempotent: it recalculates from the bill's own stored total and amount paid,
+// and the writer skips the write when the stored balance already agrees. Bills
+// with no total are skipped, not zeroed — an unentered invoice owes an unknown
+// amount, not nothing.
+//
+// Run from the repo root:
+//   npx dotenv -- npx tsx packages/lib/scripts/backfill-vendor-bill-balance.ts
+
+import { database } from '@auxx/database'
+import { sql } from 'drizzle-orm'
+// Relative import on purpose — see the note in backfill-po-line-rollups.ts.
+import { recalculateVendorBillBalance } from '../src/purchasing/vendor-bill-balance'
+
+/** Every (org, vendor bill) pair where a total has been keyed. */
+async function billsWithATotal(): Promise<{ org: string; bill: string }[]> {
+  const rows = await database.execute<{ organizationId: string; billId: string }>(sql`
+    SELECT DISTINCT fv."organizationId", fv."entityId" AS "billId"
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf ON cf.id = fv."fieldId"
+    WHERE cf."systemAttribute" = 'vendor_bill_total'
+      AND fv."valueNumber" IS NOT NULL
+  `)
+  const list = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? [])
+  return (list as { organizationId: string; billId: string }[]).map((r) => ({
+    org: r.organizationId,
+    bill: r.billId,
+  }))
+}
+
+async function main(): Promise<void> {
+  const bills = await billsWithATotal()
+  console.log(`${bills.length} vendor bill(s) carrying a total`)
+
+  let written = 0
+  for (const { org, bill } of bills) {
+    if (await recalculateVendorBillBalance(org, bill)) written++
+  }
+
+  console.log(`balances written: ${written}, unchanged: ${bills.length - written}`)
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -52,6 +52,10 @@ import {
   rematchOnBillLineChange,
 } from '../purchasing/match-hook'
 import { registerMatchReconcilers } from '../purchasing/match-reconciler'
+import {
+  recalculateBalanceOnBillChange,
+  registerVendorBillBalanceReconcilers,
+} from '../purchasing/vendor-bill-balance'
 import { handleRecordRulesOnFieldChange } from '../record-rules/hook-handler'
 import {
   enqueueQuickbooksInvoiceSyncOnSent,
@@ -143,6 +147,12 @@ export function registerAllHooks(): void {
   // `purchase_order_line_quantity_billed` — which is the shape the create/delete
   // triggers alone left open.
   registerPurchaseOrderLineRollupReconcilers()
+
+  // The vendor bill balance's drain. Same rule again: the bill hook below only
+  // MARKS. `vendor_bill_balance` had NO writer at all before this pair — zero
+  // stored values in the whole installation — so an omission here restores the
+  // exact defect it closes.
+  registerVendorBillBalanceReconcilers()
 
   // The billing projectors' four drains. Same rule again: the six billing hooks
   // below only MARK, so without this nothing rebuilds a projection.
@@ -252,7 +262,19 @@ export function registerAllHooks(): void {
   // `_match_variance` and `_match_notes` all declare the match hook as their only writer,
   // so these registrations are what make the exception queue anything other than empty.
   // The bill's own totals are NOT recomputed here — they are transcribed (01 §5.4b).
-  registerEntityFieldChangeHooks('vendor-bills', [rematchOnBillChange])
+  // Two independent derivations off the bill's own writes: the match writes the
+  // bill's VERDICT, the balance writes what is still OWED on it.
+  // `recalculateBalanceOnBillChange` is the only writer `vendor_bill_balance`
+  // has ever had — the field shipped `creatable: false` "computed from total and
+  // amountPaid" with nothing computing it, so every bill in every org carried a
+  // NULL balance until this registration existed. It covers the CLEAR path as
+  // well as the set path (a null write fires the same post-hook chain), which is
+  // why there is no delete hook beside it; the bill's total is transcribed, not
+  // derived from lines, so no bill-line door can move it either.
+  registerEntityFieldChangeHooks('vendor-bills', [
+    rematchOnBillChange,
+    recalculateBalanceOnBillChange,
+  ])
   // Two independent derivations off the same writes: the match writes the BILL's
   // verdict, the roll-up writes the ORDER LINE's billed quantity. Both must be
   // here — a bill line is created at the default quantity `1` and the real

--- a/packages/lib/src/purchasing/__tests__/vendor-bill-balance.test.ts
+++ b/packages/lib/src/purchasing/__tests__/vendor-bill-balance.test.ts
@@ -1,0 +1,300 @@
+// packages/lib/src/purchasing/__tests__/vendor-bill-balance.test.ts
+//
+// `vendor_bill_balance` shipped declared "computed from total and amountPaid"
+// with NO writer — zero stored values in the entire installation, across every
+// org and every bill. It stayed invisible because the payment card computes the
+// subtraction in the browser and never reads the column. These tests pin the
+// wiring and the three arithmetic rules that are easy to get wrong.
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityFieldChangeEvent } from '../../field-hooks/types'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  requireCachedEntityDefId: vi.fn(),
+  setValueWithType: vi.fn(),
+  publishFieldValueUpdates: vi.fn(),
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+  requireCachedEntityDefId: h.requireCachedEntityDefId,
+}))
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: (organizationId: string) => ({ organizationId }),
+}))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishFieldValueUpdates: h.publishFieldValueUpdates,
+}))
+// `readFieldScalars` runs for real over these rows, so the test exercises the
+// absent-vs-null distinction the writer depends on rather than stubbing it away.
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../../database/src/db/schema/index')
+  return {
+    schema,
+    database: { select: () => ({ from: () => ({ where: () => storedRows() }) }) },
+  }
+})
+
+import { runWithDirtyParents } from '../../reconcilers/dirty-parents'
+import {
+  recalculateBalanceOnBillChange,
+  recalculateVendorBillBalance,
+  registerVendorBillBalanceReconcilers,
+  VENDOR_BILL_BALANCE_TRIGGER_ATTRS,
+  vendorBillBalance,
+} from '../vendor-bill-balance'
+
+const FIELDS: Record<string, { id: string; type: string }> = {
+  vendor_bill_total: { id: 'f-total', type: 'CURRENCY' },
+  vendor_bill_amount_paid: { id: 'f-paid', type: 'CURRENCY' },
+  vendor_bill_balance: { id: 'f-balance', type: 'CURRENCY' },
+}
+
+const BILL = 'bill-1'
+
+/** What the bill currently has stored, per fieldId. `null` means a row with no value. */
+let stored: Record<string, number | null> = {}
+
+function storedRows() {
+  return Object.entries(stored).map(([fieldId, valueNumber]) => ({
+    entityId: BILL,
+    fieldId,
+    valueNumber,
+  }))
+}
+
+/** The value the last write sent, or `undefined` when nothing was written. */
+function written(): unknown {
+  return h.setValueWithType.mock.calls.at(-1)?.[1]?.value
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  stored = {}
+  h.bySystemAttributes.mockImplementation(async (attrs: string[]) =>
+    Object.fromEntries(attrs.filter((a) => FIELDS[a]).map((a) => [a, FIELDS[a]]))
+  )
+  h.requireCachedEntityDefId.mockResolvedValue('def-vendor-bill')
+  h.setValueWithType.mockResolvedValue([])
+  h.publishFieldValueUpdates.mockResolvedValue(undefined)
+})
+
+const recalc = () => recalculateVendorBillBalance('org_1', BILL)
+
+describe('vendorBillBalance', () => {
+  it('subtracts what has been paid from the total', () => {
+    expect(vendorBillBalance(115000, 100000)).toBe(15000)
+  })
+
+  it('treats an absent payment as a payment of nothing', () => {
+    expect(vendorBillBalance(20000, null)).toBe(20000)
+  })
+
+  it('has NO balance when the bill has no total', () => {
+    // Not zero. A bill nobody has keyed a total onto owes an unknown amount, and
+    // storing `0 - paid` would render an unentered invoice as fully settled —
+    // then collect it in a `balance = 0` filter alongside genuinely paid bills.
+    expect(vendorBillBalance(null, 50000)).toBeNull()
+    expect(vendorBillBalance(null, null)).toBeNull()
+  })
+
+  it('keeps an overpayment negative rather than clamping it to zero', () => {
+    // The vendor owes US money. `Math.max(0, …)` here would erase that fact from
+    // the column; the bills card clamps for display, and that is the right place.
+    expect(vendorBillBalance(1000, 1500)).toBe(-500)
+  })
+
+  it('rounds, because the inputs live in a double column', () => {
+    // Integer minor units stored as doubles: `setValueWithType` rejects a
+    // non-integer CURRENCY value outright, so float drift would throw rather
+    // than store a wrong number — but it would still take the write down.
+    expect(Number.isInteger(vendorBillBalance(0.3 * 3 * 100000, 1))).toBe(true)
+  })
+})
+
+describe('recalculateVendorBillBalance', () => {
+  it('writes the balance when a bill has a total and a part payment', async () => {
+    stored = { 'f-total': 115000, 'f-paid': 100000 }
+
+    await recalc()
+
+    expect(written()).toEqual({ type: 'number', value: 15000 })
+  })
+
+  it('writes the whole total when nothing has been paid', async () => {
+    stored = { 'f-total': 20000 }
+
+    await recalc()
+
+    expect(written()).toEqual({ type: 'number', value: 20000 })
+  })
+
+  it('writes ZERO for a fully settled bill, and does not confuse it with absent', async () => {
+    stored = { 'f-total': 430000, 'f-paid': 430000 }
+
+    await recalc()
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    expect(written()).toEqual({ type: 'number', value: 0 })
+  })
+
+  it('changes nothing → writes nothing', async () => {
+    // The case that keeps a derived write cheap: a second trigger attribute
+    // landing in the same save, or a total re-keyed to what it already was, must
+    // not cost a write, a realtime frame and a timeline entry.
+    stored = { 'f-total': 115000, 'f-paid': 100000, 'f-balance': 15000 }
+
+    await recalc()
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
+  })
+
+  it('writes nothing when there is no total and no stored balance', async () => {
+    stored = {}
+
+    await recalc()
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('CLEARS a stored balance when the total is cleared', async () => {
+    // The delete path. Nothing else clears this column, so without it a bill
+    // whose total was removed keeps a balance derived from a number that is
+    // gone.
+    stored = { 'f-paid': 5000, 'f-balance': 15000 }
+
+    await recalc()
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    expect(written()).toBeNull()
+  })
+
+  it('publishes the new value so an open drawer does not show the old one', async () => {
+    stored = { 'f-total': 3000 }
+
+    await recalc()
+
+    expect(h.publishFieldValueUpdates).toHaveBeenCalledTimes(1)
+    const entries = h.publishFieldValueUpdates.mock.calls[0]?.[2] as Array<{ value?: unknown }>
+    expect(entries[0]?.value).toEqual({ type: 'number', value: 3000 })
+  })
+
+  it('publishes a clear with no value at all — the signal a cell is empty', async () => {
+    stored = { 'f-balance': 15000 }
+
+    await recalc()
+
+    const entries = h.publishFieldValueUpdates.mock.calls[0]?.[2] as Array<{ value?: unknown }>
+    expect(entries[0]).not.toHaveProperty('value')
+  })
+
+  it('does nothing when the org is missing one of the three fields', async () => {
+    h.bySystemAttributes.mockResolvedValue({ vendor_bill_total: FIELDS.vendor_bill_total })
+    stored = { 'f-total': 3000 }
+
+    await recalc()
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('reports whether it wrote, so a backfill can count', async () => {
+    stored = { 'f-total': 3000 }
+    expect(await recalc()).toBe(true)
+
+    stored = { 'f-total': 3000, 'f-balance': 3000 }
+    expect(await recalc()).toBe(false)
+  })
+})
+
+describe('the trigger vocabulary', () => {
+  it('watches BOTH inputs — a balance driven by only one of them is wrong half the time', () => {
+    expect(VENDOR_BILL_BALANCE_TRIGGER_ATTRS.has('vendor_bill_total' as never)).toBe(true)
+    expect(VENDOR_BILL_BALANCE_TRIGGER_ATTRS.has('vendor_bill_amount_paid' as never)).toBe(true)
+  })
+
+  it('never contains the field the hook itself writes — that would recurse', () => {
+    expect(VENDOR_BILL_BALANCE_TRIGGER_ATTRS.has('vendor_bill_balance' as never)).toBe(false)
+  })
+})
+
+describe('recalculateBalanceOnBillChange', () => {
+  const event = (systemAttribute: string) =>
+    ({
+      recordId: `def-vendor-bill:${BILL}`,
+      organizationId: 'org_1',
+      userId: 'usr_1',
+      field: { id: 'f', systemAttribute },
+    }) as unknown as EntityFieldChangeEvent
+
+  it('recomputes when the total is written', async () => {
+    stored = { 'f-total': 3000 }
+
+    await recalculateBalanceOnBillChange(event('vendor_bill_total'))
+
+    expect(written()).toEqual({ type: 'number', value: 3000 })
+  })
+
+  it('recomputes when the amount paid is written', async () => {
+    stored = { 'f-total': 3000, 'f-paid': 1000 }
+
+    await recalculateBalanceOnBillChange(event('vendor_bill_amount_paid'))
+
+    expect(written()).toEqual({ type: 'number', value: 2000 })
+  })
+
+  it('recomputes on a CLEAR of a trigger field, not just a set', async () => {
+    // A cleared value fires the same post-hook chain as a set one, which is why
+    // there is no separate delete hook beside this one.
+    stored = { 'f-paid': 1000, 'f-balance': 2000 }
+
+    await recalculateBalanceOnBillChange({
+      ...event('vendor_bill_total'),
+      newValue: null,
+    } as EntityFieldChangeEvent)
+
+    expect(written()).toBeNull()
+  })
+
+  it('ignores a bill write the balance does not depend on', async () => {
+    stored = { 'f-total': 3000 }
+
+    await recalculateBalanceOnBillChange(event('vendor_bill_payment_method'))
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+})
+
+describe('coalescing', () => {
+  beforeAll(() => {
+    registerVendorBillBalanceReconcilers()
+  })
+
+  const event = (systemAttribute: string) =>
+    ({
+      recordId: `def-vendor-bill:${BILL}`,
+      organizationId: 'org_1',
+      userId: 'usr_1',
+      field: { id: 'f', systemAttribute },
+    }) as unknown as EntityFieldChangeEvent
+
+  it('collapses one payment save into ONE recompute', async () => {
+    // `MarkBillPaidDialog` writes six attributes in one call, two of which are
+    // triggers. Without the drain that is two recomputes, and the first runs
+    // against a half-applied payment.
+    stored = { 'f-total': 115000, 'f-paid': 100000 }
+
+    await runWithDirtyParents('org_1', 'usr_1', async () => {
+      await recalculateBalanceOnBillChange(event('vendor_bill_total'))
+      await recalculateBalanceOnBillChange(event('vendor_bill_amount_paid'))
+    })
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    expect(written()).toEqual({ type: 'number', value: 15000 })
+  })
+})

--- a/packages/lib/src/purchasing/vendor-bill-balance.ts
+++ b/packages/lib/src/purchasing/vendor-bill-balance.ts
@@ -1,0 +1,263 @@
+// packages/lib/src/purchasing/vendor-bill-balance.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
+import { getOrgCache, requireCachedEntityDefId } from '../cache'
+import type { EntityFieldChangeHandler } from '../field-hooks/types'
+import { createFieldValueContext } from '../field-values/field-value-helpers'
+import { setValueWithType } from '../field-values/field-value-mutations'
+import { readFieldScalars } from '../field-values/read-field-scalars'
+import { toFieldType } from '../field-values/stored-field-type'
+import {
+  type FieldValueUpdateEntry,
+  getRealtimeService,
+  publishFieldValueUpdates,
+} from '../realtime'
+import { defineParentReconciler } from '../reconcilers/parent-reconciler'
+
+const logger = createScopedLogger('purchasing:vendor-bill-balance')
+
+/**
+ * `vendor_bill_balance` — what is still owed on a bill, in integer minor units.
+ *
+ * 🛑 **This module exists because the field had no writer at all.** It shipped
+ * declared `creatable: false` / `updatable: false` with the description
+ * *"computed as `total - amountPaid`"* and nothing computed it: verified against
+ * the dev database on 2026-08-28, the column held **zero `FieldValue` rows in
+ * the entire installation**, across 28 organizations and every bill in them. A
+ * field nobody can type and nothing derives is permanently NULL, which is the
+ * same shape that once shipped NULL order numbers.
+ *
+ * It stayed invisible because the ONE surface that shows a balance —
+ * `vendor-bill-payment-card.tsx` — computes `total - amountPaid` in the browser
+ * and never reads the stored field. So the screen was right and the column was
+ * empty. What was wrong is everything that trusts the column instead of the
+ * card: a filter on Balance, a sort on Balance, and the general-ledger work,
+ * which is the consumer that would have been surprised.
+ *
+ * ## Why this is not in `purchase-order-line-rollups.ts`
+ *
+ * That file is the four PO-line roll-ups, and every one of them is the same
+ * shape: SUM a child entity's rows into a parent, then derive the order's
+ * status from the result. The balance shares none of it — no children, no SUM,
+ * no order-level pass. It is same-record arithmetic over two transcribed
+ * figures, so it lives beside the OTHER writer of the bill's computed fields
+ * (`match-hook.ts`, which owns `vendor_bill_status` / `_match_variance` /
+ * `_match_notes`).
+ *
+ * ## The write is derived, not transcribed
+ *
+ * `total` is keyed from the vendor's document and is never re-derived from the
+ * lines (HANDOFF rule 4 — recomputing it would silently correct the vendor's
+ * arithmetic, which is the discrepancy the three-way match exists to surface).
+ * The balance is the one figure on the bill that IS ours: a subtraction of two
+ * facts we already hold.
+ */
+
+/** The two inputs. A write to either can move the balance; nothing else can. */
+export const VENDOR_BILL_BALANCE_TRIGGER_ATTRS = new Set<SystemAttribute>([
+  'vendor_bill_total',
+  'vendor_bill_amount_paid',
+])
+
+const BALANCE_ATTRS = [
+  'vendor_bill_total',
+  'vendor_bill_amount_paid',
+  'vendor_bill_balance',
+] as const
+
+/** `dirty-parents` key for the balance. The marked record IS the bill. */
+export const VENDOR_BILL_BALANCE_RECONCILER = 'vendor-bill:balance'
+
+/**
+ * The balance a bill should be carrying, or `null` when it should carry none.
+ *
+ * Pure, and exported for the same reason `match.ts` is: the arithmetic is worth
+ * testing without a database, and a caller that wants to preview it should not
+ * have to write first.
+ *
+ * - **No total → no balance.** A bill nobody has keyed a total onto owes an
+ *   unknown amount, not zero. Storing `0 - paid` there would render an unentered
+ *   invoice as fully settled, and a filter on `balance = 0` would collect it.
+ * - **No amount paid → the whole total.** An absent payment is a payment of
+ *   nothing; that one genuinely is zero.
+ * - **Overpayment stays negative.** `Math.max(0, …)` would erase the fact that
+ *   the vendor owes us money. The bills card clamps for DISPLAY; the stored
+ *   column must not.
+ */
+export function vendorBillBalance(total: number | null, amountPaid: number | null): number | null {
+  if (total === null) return null
+  // Both inputs are integer minor units, but they are stored in a double column
+  // — round rather than trust float subtraction, because `setValueWithType`
+  // rejects a non-integer CURRENCY value outright.
+  return Math.round(total - (amountPaid ?? 0))
+}
+
+/**
+ * Recompute and store one bill's balance.
+ *
+ * Exported so a caller that needs the balance to reflect its own transaction can
+ * run it explicitly after `COMMIT`, and so a one-off backfill can reuse the one
+ * implementation rather than restating the arithmetic in SQL.
+ *
+ * ⚡ Reads the stored balance in the same query as its two inputs and returns
+ * before writing when they already agree — the "changes nothing → writes
+ * nothing" case. Re-keying a total to the value it already had, or a second
+ * attribute landing in a write whose first attribute already triggered the
+ * recompute, must not cost a write, a realtime frame and a timeline entry.
+ *
+ * ⚠️ POST-COMMIT only, like every recompute in this subsystem: with no `db`
+ * passed the read runs on the module-level connection and cannot see a caller's
+ * open transaction.
+ *
+ * @returns whether a value was actually written. The reconciler ignores it; a
+ * backfill can count from it.
+ */
+export async function recalculateVendorBillBalance(
+  organizationId: string,
+  vendorBillInstanceId: string,
+  db?: Database
+): Promise<boolean> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes<SystemAttribute>([...BALANCE_ATTRS])
+
+  const totalField = fields.vendor_bill_total
+  const amountPaidField = fields.vendor_bill_amount_paid
+  const balanceField = fields.vendor_bill_balance
+
+  if (!totalField || !amountPaidField || !balanceField) {
+    logger.warn('Missing custom fields for vendor bill balance', {
+      organizationId,
+      total: !!totalField,
+      amountPaid: !!amountPaidField,
+      balance: !!balanceField,
+    })
+    return false
+  }
+
+  const scalars = await readFieldScalars(
+    db,
+    organizationId,
+    [vendorBillInstanceId],
+    [totalField.id, amountPaidField.id, balanceField.id]
+  )
+  const values = scalars.get(vendorBillInstanceId)
+
+  const next = vendorBillBalance(num(values, totalField.id), num(values, amountPaidField.id))
+  const stored = num(values, balanceField.id)
+
+  if (stored === next) {
+    logger.debug('Vendor bill balance unchanged — nothing written', {
+      vendorBillInstanceId,
+      balance: next,
+    })
+    return false
+  }
+
+  const billDefId = await requireCachedEntityDefId(organizationId, 'vendor_bill')
+  const recordId = toRecordId(billDefId, vendorBillInstanceId) as RecordId
+
+  // The low-level writer, deliberately — the same door
+  // `purchase-order-line-rollups.ts` uses. A context with no `userId` does not
+  // fire the field-change post-hook chain, which is what keeps a derived write
+  // from re-entering the hooks that produced it; the realtime frame the chain
+  // would have published is published explicitly below.
+  await setValueWithType(createFieldValueContext(organizationId, undefined, db), {
+    recordId,
+    fieldId: balanceField.id,
+    fieldType: toFieldType(balanceField.type),
+    value: next === null ? null : { type: 'number', value: next },
+  })
+
+  // A cleared value publishes an entry with NO `value`, which is how the clear
+  // branch of `setValueWithType` signals it (`field-value-mutations.ts`).
+  const entry: FieldValueUpdateEntry =
+    next === null
+      ? { key: buildFieldValueKey(recordId, balanceField.id as FieldId) }
+      : {
+          key: buildFieldValueKey(recordId, balanceField.id as FieldId),
+          value: { type: 'number', value: next },
+        }
+
+  publishFieldValueUpdates(getRealtimeService(), organizationId, [entry]).catch((err) => {
+    logger.error('Failed to publish vendor bill balance', {
+      vendorBillInstanceId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  })
+
+  logger.info('Vendor bill balance recalculated', { vendorBillInstanceId, balance: next })
+  return true
+}
+
+/** A number out of {@link readFieldScalars}' scalar map; anything else reads as absent. */
+function num(values: Map<string, unknown> | undefined, fieldId: string): number | null {
+  const value = values?.get(fieldId)
+  return typeof value === 'number' ? value : null
+}
+
+/**
+ * Coalescing drain for the balance.
+ *
+ * The marked record IS the bill, so the spec needs no `resolve`. Coalescing is
+ * the whole reason it is here rather than a direct call: `MarkBillPaidDialog`
+ * writes six attributes in one `useSaveSystemValues` call, two of which are
+ * triggers, and the drawer's own Total edit lands beside a status write. One
+ * drain per write scope means one recompute against committed truth, instead of
+ * one per changed attribute — and, more importantly, no transient balance
+ * computed from a half-applied payment.
+ */
+const balanceReconciler = defineParentReconciler<string>({
+  key: VENDOR_BILL_BALANCE_RECONCILER,
+  // The drain wants `Promise<void>`; the recompute reports whether it wrote so a
+  // backfill can count. Discarded here rather than widened there.
+  rebuild: async (organizationId, _userId, vendorBillInstanceId) => {
+    await recalculateVendorBillBalance(organizationId, vendorBillInstanceId)
+  },
+})
+
+/**
+ * Register the balance drain. Called from `registerAllHooks()`.
+ *
+ * 🛑 Must stay paired with the hook below, which only MARKS. Without this
+ * nothing recomputes — which is the exact defect this module exists to close,
+ * restored by omission.
+ */
+export function registerVendorBillBalanceReconcilers(): void {
+  balanceReconciler.register()
+}
+
+/**
+ * Recompute the balance when a bill's total or amount paid is written.
+ *
+ * **This covers the clear path as well as the set path, and that is why there is
+ * no separate delete hook.** `setValueWithType`'s null-delete branch fires the
+ * post-hook chain identically to the set branch (`field-value-mutations.ts`
+ * §3.6 captures `oldValue` before the branch precisely so it can), so clearing a
+ * total arrives here with `newValue: null` and clears the balance with it.
+ *
+ * There is no bill-line door either, and that is deliberate rather than an
+ * omission: a bill's totals are TRANSCRIBED from the vendor's document, never
+ * derived from its lines (HANDOFF rule 4 / plan 01 §5.4b), so deleting a bill
+ * line cannot move `vendor_bill_total` and therefore cannot move the balance.
+ * If that ever stops being true, the balance's inputs changed and this trigger
+ * set is what has to change with them.
+ *
+ * ⚠️ Known gap, shared with the three-way match and both PO-line roll-ups: the
+ * sync/import lanes suppress the field-change chain, and
+ * `events/handlers/finalize-integrity-passes.ts` runs four hard-coded passes
+ * that do not include any purchasing recompute. A bill whose total arrives by
+ * connector or CSV gets its balance on the next interactive write. That is a gap
+ * in the finalize pass, not in this hook.
+ */
+export const recalculateBalanceOnBillChange: EntityFieldChangeHandler = async (event) => {
+  const attr = event.field.systemAttribute as SystemAttribute | undefined
+  if (!attr || !VENDOR_BILL_BALANCE_TRIGGER_ATTRS.has(attr)) return
+
+  const { entityInstanceId } = parseRecordId(event.recordId)
+  await balanceReconciler.mark(event.organizationId, event.userId, entityInstanceId)
+}

--- a/packages/lib/src/resources/registry/resources/vendor-bill-fields.ts
+++ b/packages/lib/src/resources/registry/resources/vendor-bill-fields.ts
@@ -468,6 +468,21 @@ export const VENDOR_BILL_FIELDS: Record<string, ResourceField> = {
       'the provider poll while `vendor_payment` is inert',
   },
 
+  // Written by `purchasing/vendor-bill-balance.ts`, never by hand — a
+  // hand-maintained copy of a subtraction diverges silently. Stored, like every
+  // money field here, in integer minor units.
+  //
+  // 🛑 `computed` was FALSE while the field also had no writer, which is how the
+  // two halves of one defect hid each other: nothing derived the value, and
+  // nothing declared that anything should. It is `true` now for the same reason
+  // `purchase_order_line_quantity_billed` is — it is what `fieldLockReason`
+  // reads to say "computed" rather than merely "system", and what excludes the
+  // field from connector-writable surfaces.
+  //
+  // ⚠️ `ensureCustomFields` is INSERT-only, so flipping it here reaches NEW orgs
+  // only — an org that already ran 108 keeps whatever its `CustomField` row was
+  // created with. No migration carries it, deliberately: nothing is live yet, so
+  // the dev database was corrected in place instead.
   balance: {
     id: toFieldId('balance'),
     key: 'balance',
@@ -489,11 +504,10 @@ export const VENDOR_BILL_FIELDS: Record<string, ResourceField> = {
       sortable: true,
       creatable: false, // computed from total and amountPaid
       updatable: false,
+      computed: true,
       configurable: false,
     },
-    description:
-      'Computed as `total - amountPaid`, integer minor units — what is still owed. Never typed: ' +
-      'a hand-maintained copy of a subtraction diverges silently.',
+    description: 'What is still owed on this bill — the total minus what has been paid',
   },
 
   paymentMethod: {


### PR DESCRIPTION
`vendor_bill_balance` was declared `creatable: false` with the description *"computed from total and amountPaid"* — and **nothing computed it**. Unwritable by a human, uncomputed by the system.

**Verified against the dev DB before the fix: 0 `FieldValue` rows for that attribute in the entire database.**

### Why it stayed invisible

The payment card sidesteps the column entirely and recomputes `total − amountPaid` for display. **The screen was right; the stored value was absent.** A filter or sort on Balance returned nothing useful, and any later consumer trusting the column would read a null — the GL work being the one that would have been surprised.

Same shape as the NULL order numbers in #1911: a field declared computed with nothing computing it. `capabilities.computed` was *also* `false`, so the two halves hid each other — nothing derived the value, and nothing declared that anything should.

### Where it lives, and why not where the brief said

`purchasing/vendor-bill-balance.ts`, on the `vendor-bills` field-change chain beside the match — **not** in `purchase-order-line-rollups.ts`.

Every roll-up in that file SUMs a child into a parent then derives order status. The balance has no children, no SUM and no order pass: it is same-record arithmetic, and belongs with the bill's other computed fields.

### Three rules, each of them a way to get it wrong

- **No total means no balance — not `0`.** A `0` renders an unentered invoice as settled and collects it in a `balance = 0` filter.
- An absent payment is zero.
- **An overpayment stays negative.** The bills card clamps for display; the column must not.

### Triggering

Fires on `vendor_bill_total` and `vendor_bill_amount_paid`, never on `vendor_bill_balance` itself. Marked through a dirty-parents reconciler, so one payment save is **one** recompute, and the write is skipped when the stored value already agrees.

A **clear** rides the same hook — a null write fires the same post-hook chain — so no separate delete door. There is **no bill-line door on purpose**: a bill's totals are transcribed, never derived from its lines.

### `computed: true` with no migration

Deliberate. Nothing is live, so the existing orgs were corrected in place rather than spending a migration id on a pre-deployment field. ⚠️ Worth knowing *why* that was a choice at all: `ensureCustomFields` is INSERT-only, so a registry flip reaches **new orgs only** — an org that already ran 108 keeps whatever its row was created with. The reasoning is in a comment above the field.

`packages/lib/scripts/backfill-vendor-bill-balance.ts` wrote the 10 dev bills' balances (3 legitimately `0`). Re-running writes nothing; proved both paths by deleting one row and re-running → `written: 1, unchanged: 9`.

### The description is user-facing

It now reads **"What is still owed on this bill — the total minus what has been paid"**. The previous text carried backticked identifiers, storage units and a source file path, all of which render to a person in the product. The engineering reasoning moved into a comment above the field rather than being deleted.

### Tests

22, including **"changes nothing → writes nothing"** (asserts neither the value write nor the publish fires), zero-vs-absent, the clear path, overpayment, and coalescing — two trigger writes in one scope produce one recompute.

Checks: `typecheck-ratchet --package lib` → `29 total, baseline 29` exit 0 · 181 purchasing tests pass · biome clean.

### 🛑 Left open, and it is not this field's problem

**The sync and import lanes fire no purchasing recompute at all.** They suppress the field-change chain, and `events/handlers/finalize-integrity-passes.ts` runs four hard-coded passes with none of purchasing's among them. A bill whose total arrives by connector or CSV gets its balance on the next interactive write.

**The three-way match and both PO-line roll-ups have the identical gap — one fix, four consumers.** Worth its own task.

Also: the writer is proven against the live dev DB via the script, but the hook firing from a drawer edit has not been driven by hand.

https://claude.ai/code/session_01DebKVm93wUUyZSy3a1YRKr