### PR TITLE
feat(money): the month-end inventory entry's contract, builder and baseline

### DIFF
--- a/packages/lib/src/ai/kopilot/prompts/sections/now.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/now.ts
@@ -54,12 +54,19 @@ function formatIsoDate(now: Date, timeZone: string): string {
  * cache entry was written.
  *
  * **Zone resolution is org → user → UTC, and the org tier is a documented
- * no-op.** Nothing stores an org zone: `SETTINGS_CATALOG`
- * (`lib/settings/catalog.ts`) has no timezone key and the `Organization` table
- * has no timezone column, so the `orgSettings`/`orgProfile` cache keys have
+ * no-op.** The `Organization` table has no timezone column and nothing stores a
+ * DISPLAY zone for an org, so the `orgSettings`/`orgProfile` cache keys have
  * nothing to carry. No column or setting was invented to fill the tier — when
  * one is added, it slots in ahead of the user value at the `PromptCtx.timezone`
  * call site (`agents/agent.ts`), not here.
+ *
+ * 🛑 **`accounting.bookTimeZone` is NOT that setting. Do not wire it in here.**
+ * It was added for the general ledger, and it is the zone a journal entry's
+ * period is derived in — fail-closed, frozen at the first posting, and changed
+ * only through a ledger reversal. A display default is none of those things, and
+ * borrowing it would mean a bookkeeper correcting how a chat renders "yesterday"
+ * silently re-dates every future close. The two are different questions that
+ * happen to have the same units.
  *
  * The user tier is live: `User.preferredTimezone` rides the org `members` cache
  * projection and is threaded by `hydrateCaller` in `agents/agent.ts`. A caller

--- a/packages/lib/src/postings/__tests__/build-month-end-inventory.test.ts
+++ b/packages/lib/src/postings/__tests__/build-month-end-inventory.test.ts
@@ -1,0 +1,411 @@
+// packages/lib/src/postings/__tests__/build-month-end-inventory.test.ts
+//
+// All amounts are integer MINOR units (cents): 10_000 = $100.00.
+//
+// 🛑 **This is the file a CPA is shown, so every test is named for the
+// ACCOUNTING FACT it pins, not the code path it walks.**
+//
+// The sign tests below carry the whole weight of this module's correctness.
+// 5000 is the balancing plug, which means flipping any one lane's direction
+// still produces a PERFECTLY BALANCED entry - the plug simply absorbs twice the
+// error. `buildEntry`'s balance gate cannot see it. A property test cannot see
+// it. The exact per-lane, per-sign assertions in
+// `describe('the sign table', ...)` are the ONLY guard there is, which is why
+// they assert a literal direction rather than deriving one.
+
+import { describe, expect, it } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import { ACCOUNT_ROLES } from '../build-entry'
+import {
+  buildMonthEndInventoryEntry,
+  type MonthEndInventoryInputs,
+} from '../build-month-end-inventory'
+import type { MonthEndInventorySnapshot } from '../draft'
+
+const PERIOD = '2026-08'
+const TXN_DATE = '2026-08-31'
+
+interface SnapshotShorthand {
+  raw?: number
+  wip?: number
+  fg?: number
+  labor?: number
+  overhead?: number
+  adjustments?: number
+}
+
+function snap(values: SnapshotShorthand = {}): MonthEndInventorySnapshot {
+  return {
+    balances: {
+      inventory_raw_materials: values.raw ?? 0,
+      inventory_wip: values.wip ?? 0,
+      inventory_finished_goods: values.fg ?? 0,
+    },
+    activityTotals: {
+      absorbedLabor: values.labor ?? 0,
+      absorbedOverhead: values.overhead ?? 0,
+      inventoryAdjustments: values.adjustments ?? 0,
+    },
+  }
+}
+
+function build(prior: SnapshotShorthand, current: SnapshotShorthand) {
+  const inputs: MonthEndInventoryInputs = {
+    periodKey: PERIOD,
+    txnDate: TXN_DATE,
+    prior: snap(prior),
+    current: snap(current),
+  }
+  return buildMonthEndInventoryEntry(inputs)
+}
+
+/** `[role, direction, amount]` per line, in emitted order. The golden shape. */
+function legs(draft: ReturnType<typeof build>): Array<[string, string, number]> {
+  return draft.entry.lines.map((line) => [line.accountRole, line.direction, line.amount])
+}
+
+describe('the worked example - a month that produced, absorbed and shrank', () => {
+  // Raw materials rose $950, finished goods rose $540, $500 of labour and $200
+  // of overhead were absorbed, and a count found $50 of stock missing. The
+  // residual - what shipped, at full frozen cost - is the $840 COGS plug.
+  const draft = build(
+    { raw: 1_000_000, wip: 0, fg: 400_000, labor: 0, overhead: 0, adjustments: 0 },
+    {
+      raw: 1_095_000,
+      wip: 0,
+      fg: 454_000,
+      labor: 50_000,
+      overhead: 20_000,
+      adjustments: -5_000,
+    }
+  )
+
+  it('posts exactly six legs, debits first, with COGS as the plug', () => {
+    expect(legs(draft)).toEqual([
+      [ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS, 'debit', 95_000],
+      [ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS, 'debit', 54_000],
+      [ACCOUNT_ROLES.INVENTORY_COUNT_VARIANCE, 'debit', 5_000],
+      [ACCOUNT_ROLES.PAYROLL_CLEARING, 'credit', 50_000],
+      [ACCOUNT_ROLES.APPLIED_OVERHEAD, 'credit', 20_000],
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'credit', 84_000],
+    ])
+  })
+
+  it('balances at 154_000 on both sides', () => {
+    expect(draft.entry.totalDebit).toBe(154_000)
+    expect(draft.entry.totalCredit).toBe(154_000)
+  })
+
+  it('omits the 1320 WIP leg, because the WIP balance did not move', () => {
+    expect(legs(draft).map(([role]) => role)).not.toContain(ACCOUNT_ROLES.INVENTORY_WIP)
+  })
+
+  it('is a month_end_inventory posting dated the last day of the period', () => {
+    expect(draft.entry.postingType).toBe('month_end_inventory')
+    expect(draft.entry.periodKey).toBe(PERIOD)
+    expect(draft.entry.txnDate).toBe(TXN_DATE)
+  })
+
+  it('stamps every line with the period as its audit source', () => {
+    for (const line of draft.entry.lines) {
+      expect(line.sourceType).toBe('month_end_inventory')
+      expect(line.sourceId).toBe(PERIOD)
+    }
+    expect(draft.entry.lines.map((l) => l.sortOrder)).toEqual([0, 1, 2, 3, 4, 5])
+  })
+
+  it('gives every line a human memo naming its lane', () => {
+    for (const line of draft.entry.lines) {
+      expect(line.memo).toBeTruthy()
+    }
+  })
+})
+
+// 🛑 Each of the six assertions below is the only thing standing between a
+// flipped direction and a balanced, wrong, undetectable journal entry. Each
+// isolates ONE lane so the plug is the only other leg, which makes the
+// direction unambiguous rather than inferred from a mix.
+describe('the sign table - each lane maps its sign to a direction differently', () => {
+  it('a RISING inventory balance is a DEBIT to inventory', () => {
+    expect(legs(build({ raw: 100_000 }, { raw: 110_000 }))).toEqual([
+      [ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS, 'debit', 10_000],
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'credit', 10_000],
+    ])
+  })
+
+  it('a FALLING inventory balance is a CREDIT to inventory', () => {
+    expect(legs(build({ raw: 100_000 }, { raw: 90_000 }))).toEqual([
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'debit', 10_000],
+      [ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS, 'credit', 10_000],
+    ])
+  })
+
+  it('MORE cumulative absorbed labour is a CREDIT to payroll clearing', () => {
+    expect(legs(build({ labor: 0 }, { labor: 10_000 }))).toEqual([
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'debit', 10_000],
+      [ACCOUNT_ROLES.PAYROLL_CLEARING, 'credit', 10_000],
+    ])
+  })
+
+  // Cumulative absorption falls when a build is REVERSED: `reverse-build.ts`
+  // writes a negated `build_labor_cost` on a second row, so the cumulative sum
+  // nets the correction out on its own and the delta goes negative.
+  it('LESS cumulative absorbed labour is a DEBIT to payroll clearing', () => {
+    expect(legs(build({ labor: 10_000 }, { labor: 0 }))).toEqual([
+      [ACCOUNT_ROLES.PAYROLL_CLEARING, 'debit', 10_000],
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'credit', 10_000],
+    ])
+  })
+
+  it('MORE cumulative absorbed overhead is a CREDIT to applied overhead', () => {
+    expect(legs(build({ overhead: 0 }, { overhead: 10_000 }))).toEqual([
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'debit', 10_000],
+      [ACCOUNT_ROLES.APPLIED_OVERHEAD, 'credit', 10_000],
+    ])
+  })
+
+  it('LESS cumulative absorbed overhead is a DEBIT to applied overhead', () => {
+    expect(legs(build({ overhead: 10_000 }, { overhead: 0 }))).toEqual([
+      [ACCOUNT_ROLES.APPLIED_OVERHEAD, 'debit', 10_000],
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'credit', 10_000],
+    ])
+  })
+
+  // A recount that found MORE than the system thought: a favourable adjustment.
+  it('a RISING cumulative adjustment total is a CREDIT to 5095', () => {
+    expect(legs(build({ adjustments: 0 }, { adjustments: 10_000 }))).toEqual([
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'debit', 10_000],
+      [ACCOUNT_ROLES.INVENTORY_COUNT_VARIANCE, 'credit', 10_000],
+    ])
+  })
+
+  // Shrinkage. The expense lands in 5095, separately from PPV, per `G12`.
+  it('a FALLING cumulative adjustment total is a DEBIT to 5095', () => {
+    expect(legs(build({ adjustments: 0 }, { adjustments: -10_000 }))).toEqual([
+      [ACCOUNT_ROLES.INVENTORY_COUNT_VARIANCE, 'debit', 10_000],
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'credit', 10_000],
+    ])
+  })
+})
+
+describe('1320 work in process', () => {
+  // Structurally zero today: every movement writer resolves through
+  // `resolveInventoryRoleForPartKind`, whose range is two values, and a build's
+  // consume and produce movements commit together at completion.
+  it('is omitted when its balance did not move, so an unmapped role is never resolved', () => {
+    const draft = build({ raw: 100_000, wip: 0 }, { raw: 110_000, wip: 0 })
+    expect(legs(draft).map(([role]) => role)).not.toContain(ACCOUNT_ROLES.INVENTORY_WIP)
+  })
+
+  it('posts a normal balance leg the day the subledger can reach it', () => {
+    const draft = build({ wip: 0 }, { wip: 25_000 })
+    expect(legs(draft)).toEqual([
+      [ACCOUNT_ROLES.INVENTORY_WIP, 'debit', 25_000],
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'credit', 25_000],
+    ])
+  })
+})
+
+describe('a month in which inventory fell', () => {
+  // Everything shipped and nothing was built: all three balances drop, no
+  // absorption, and the whole relief lands in COGS as one debit.
+  const draft = build(
+    { raw: 500_000, wip: 30_000, fg: 200_000 },
+    { raw: 460_000, wip: 20_000, fg: 150_000 }
+  )
+
+  it('credits all three inventory accounts and debits COGS for the total', () => {
+    expect(legs(draft)).toEqual([
+      [ACCOUNT_ROLES.COGS_PRODUCT_COST, 'debit', 100_000],
+      [ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS, 'credit', 40_000],
+      [ACCOUNT_ROLES.INVENTORY_WIP, 'credit', 10_000],
+      [ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS, 'credit', 50_000],
+    ])
+    expect(draft.entry.totalDebit).toBe(100_000)
+  })
+})
+
+describe('the COGS plug', () => {
+  // Everything built and nothing shipped: the inventory increase is exactly the
+  // labour and overhead absorbed into it, so there is no residual to classify.
+  it('is omitted entirely when absorption exactly equals the inventory increase', () => {
+    const draft = build({}, { fg: 70_000, labor: 50_000, overhead: 20_000 })
+    expect(legs(draft)).toEqual([
+      [ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS, 'debit', 70_000],
+      [ACCOUNT_ROLES.PAYROLL_CLEARING, 'credit', 50_000],
+      [ACCOUNT_ROLES.APPLIED_OVERHEAD, 'credit', 20_000],
+    ])
+  })
+
+  // `G10` as amended: under L1 nothing posts to 5090 during the year, and a
+  // `receive` movement freezes actual cost with no standard to difference it
+  // against, so purchase price variance is a REPORT and never a leg of this
+  // entry.
+  it('is never a 5090 purchase price variance leg', () => {
+    const draft = build(
+      { raw: 1_000_000, fg: 400_000 },
+      { raw: 1_095_000, fg: 454_000, labor: 50_000, overhead: 20_000, adjustments: -5_000 }
+    )
+    expect(legs(draft).map(([role]) => role)).not.toContain(ACCOUNT_ROLES.PPV)
+  })
+})
+
+describe('the assertions the poster persists', () => {
+  const prior = snap({ raw: 1_000_000, fg: 400_000, labor: 4_000 })
+  const current = snap({ raw: 1_095_000, fg: 454_000, labor: 54_000, adjustments: -5_000 })
+  const draft = buildMonthEndInventoryEntry({
+    periodKey: PERIOD,
+    txnDate: TXN_DATE,
+    prior,
+    current,
+  })
+
+  it('carries the prior snapshot as `before`, verbatim and unmodified', () => {
+    expect(draft.assertions.before).toBe(prior)
+    expect(draft.assertions.before).toEqual(snap({ raw: 1_000_000, fg: 400_000, labor: 4_000 }))
+  })
+
+  it('carries the gathered snapshot as `after`, verbatim and unmodified', () => {
+    expect(draft.assertions.after).toBe(current)
+    expect(draft.assertions.after).toEqual(
+      snap({ raw: 1_095_000, fg: 454_000, labor: 54_000, adjustments: -5_000 })
+    )
+  })
+
+  it('is discriminated as month_end_inventory', () => {
+    expect(draft.assertions.kind).toBe('month_end_inventory')
+  })
+})
+
+describe('a month in which nothing moved', () => {
+  it('refuses to build an entry, naming the period', () => {
+    expect(() => build({ raw: 100_000, fg: 50_000 }, { raw: 100_000, fg: 50_000 })).toThrow(
+      /Nothing moved in 2026-08/
+    )
+  })
+
+  it('refuses with a 422 rather than an empty entry', () => {
+    try {
+      build({}, {})
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnprocessableEntityError)
+      expect((error as UnprocessableEntityError).statusCode).toBe(422)
+      expect((error as UnprocessableEntityError).details.periodKey).toBe(PERIOD)
+    }
+  })
+})
+
+describe('input validation - a poisoned number names itself', () => {
+  // `NaN - 0` is `NaN` and `Math.abs(NaN)` is `NaN`, so an unchecked bad input
+  // reaches `buildEntry` and is rejected naming a ROLE rather than the field
+  // that poisoned it. The person reading that message is trying to close the
+  // books; they need the row, not the account.
+  it('rejects a fractional prior balance, naming the field', () => {
+    expect(() => build({ raw: 1_000.5 }, { raw: 2_000 })).toThrow(
+      /prior\.balances\.inventory_raw_materials must be an integer/
+    )
+  })
+
+  it('rejects a fractional current balance, naming the field', () => {
+    expect(() => build({}, { fg: 0.1 })).toThrow(
+      /current\.balances\.inventory_finished_goods must be an integer/
+    )
+  })
+
+  it('rejects NaN in a cumulative activity total, naming the field', () => {
+    expect(() => build({}, { labor: Number.NaN })).toThrow(
+      /current\.activityTotals\.absorbedLabor must be an integer/
+    )
+  })
+
+  it('rejects Infinity, naming the field', () => {
+    expect(() => build({}, { overhead: Number.POSITIVE_INFINITY })).toThrow(
+      /current\.activityTotals\.absorbedOverhead must be an integer/
+    )
+  })
+
+  it('rejects a fractional adjustment total, naming the field', () => {
+    expect(() => build({}, { adjustments: -5_000.25 })).toThrow(
+      /current\.activityTotals\.inventoryAdjustments must be an integer/
+    )
+  })
+
+  it('rejects a missing snapshot rather than reading through it', () => {
+    expect(() =>
+      buildMonthEndInventoryEntry({
+        periodKey: PERIOD,
+        txnDate: TXN_DATE,
+        prior: undefined as unknown as MonthEndInventorySnapshot,
+        current: snap({ raw: 1 }),
+      })
+    ).toThrow(/prior is missing/)
+  })
+
+  it('reports the offending field in error details for structured logging', () => {
+    try {
+      build({ wip: 1.5 }, {})
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect((error as UnprocessableEntityError).details.field).toBe('prior.balances.inventory_wip')
+    }
+  })
+})
+
+// A property test cannot catch a flipped sign - see the file header - so this
+// pins the weaker but still worth-having claim: whatever the inputs, the plug
+// makes the entry balance, so the assembly can never produce something
+// `buildEntry` would refuse.
+describe('property - the entry balances for any inputs', () => {
+  /** Deterministic PRNG (mulberry32). Fixed seed, so a failure is reproducible. */
+  function rng(seed: number): () => number {
+    let state = seed >>> 0
+    return () => {
+      state = (state + 0x6d2b79f5) >>> 0
+      let t = Math.imul(state ^ (state >>> 15), 1 | state)
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+  }
+
+  it('holds over 500 pseudo-random snapshots', () => {
+    const next = rng(20260831)
+    const amount = () => Math.floor(next() * 10_000_001) - 5_000_000
+
+    let built = 0
+    for (let i = 0; i < 500; i++) {
+      const prior: SnapshotShorthand = {
+        raw: amount(),
+        wip: amount(),
+        fg: amount(),
+        labor: amount(),
+        overhead: amount(),
+        adjustments: amount(),
+      }
+      const current: SnapshotShorthand = {
+        raw: amount(),
+        wip: amount(),
+        fg: amount(),
+        labor: amount(),
+        overhead: amount(),
+        adjustments: amount(),
+      }
+
+      const draft = build(prior, current)
+      built++
+
+      let debits = 0
+      let credits = 0
+      for (const line of draft.entry.lines) {
+        expect(Number.isInteger(line.amount)).toBe(true)
+        expect(line.amount).toBeGreaterThan(0)
+        if (line.direction === 'debit') debits += line.amount
+        else credits += line.amount
+      }
+      expect(debits).toBe(credits)
+      expect(debits).toBe(draft.entry.totalDebit)
+      expect(credits).toBe(draft.entry.totalCredit)
+    }
+    expect(built).toBe(500)
+  })
+})

--- a/packages/lib/src/postings/__tests__/draft.test.ts
+++ b/packages/lib/src/postings/__tests__/draft.test.ts
@@ -1,0 +1,177 @@
+// packages/lib/src/postings/__tests__/draft.test.ts
+//
+// All amounts are integer MINOR units (cents): 10_000 = $100.00.
+//
+// The reversal swap gets the heaviest coverage here. It is the rule that makes a
+// correction readable by the NEXT close, and every way of getting it wrong
+// produces an entry that still balances - so no downstream check catches it.
+
+import { describe, expect, it } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import {
+  buildPostingDraft,
+  type MonthEndInventorySnapshot,
+  POSTING_DRAFT_VERSION,
+  type PostingAssertions,
+  parsePostingDraft,
+  requiresAssertions,
+  reverseAssertions,
+} from '../draft'
+import type { BuiltEntry } from '../types'
+
+function snapshot(raw: number, wip: number, fg: number, labor = 0, oh = 0, adj = 0) {
+  return {
+    balances: {
+      inventory_raw_materials: raw,
+      inventory_wip: wip,
+      inventory_finished_goods: fg,
+    },
+    activityTotals: {
+      absorbedLabor: labor,
+      absorbedOverhead: oh,
+      inventoryAdjustments: adj,
+    },
+  } satisfies MonthEndInventorySnapshot
+}
+
+const ASSERTIONS: PostingAssertions = {
+  kind: 'month_end_inventory',
+  before: snapshot(1_000_000, 0, 400_000, 50_000, 20_000, -5_000),
+  after: snapshot(1_095_000, 0, 454_000, 100_000, 40_000, -10_000),
+}
+
+const ENTRY: BuiltEntry = {
+  postingType: 'month_end_inventory',
+  periodKey: '2026-08',
+  txnDate: '2026-08-31',
+  lines: [],
+  totalDebit: 154_000,
+  totalCredit: 154_000,
+}
+
+function draft(assertions?: PostingAssertions) {
+  return buildPostingDraft({
+    docNumber: 'MEI-2026-08',
+    revision: 0,
+    entry: ENTRY,
+    resolvedLines: [],
+    assertions,
+  })
+}
+
+describe('buildPostingDraft', () => {
+  it('stamps the version, so nothing else has to remember to', () => {
+    expect(draft().v).toBe(POSTING_DRAFT_VERSION)
+  })
+
+  it('round-trips through the parser', () => {
+    expect(parsePostingDraft(JSON.parse(JSON.stringify(draft(ASSERTIONS))))).toEqual(
+      draft(ASSERTIONS)
+    )
+  })
+
+  it('carries no assertions when none were supplied', () => {
+    expect(parsePostingDraft(JSON.parse(JSON.stringify(draft()))).assertions).toBeUndefined()
+  })
+})
+
+describe('requiresAssertions', () => {
+  it('demands them for month_end_inventory, which asserts a balance', () => {
+    expect(requiresAssertions('month_end_inventory')).toBe(true)
+  })
+
+  it('does not demand them for a per-event posting', () => {
+    expect(requiresAssertions('receipt')).toBe(false)
+    expect(requiresAssertions('vendor_bill')).toBe(false)
+  })
+})
+
+describe('reverseAssertions', () => {
+  it('swaps the pair, so the next close reads the state before the original', () => {
+    const reversed = reverseAssertions(ASSERTIONS)
+    expect(reversed.before).toEqual(ASSERTIONS.after)
+    expect(reversed.after).toEqual(ASSERTIONS.before)
+  })
+
+  it('is self-inverse: reversing a reversal lands back on the original', () => {
+    expect(reverseAssertions(reverseAssertions(ASSERTIONS))).toEqual(ASSERTIONS)
+  })
+
+  it('keeps the discriminant, so the parser still recognises it', () => {
+    expect(reverseAssertions(ASSERTIONS).kind).toBe('month_end_inventory')
+  })
+
+  it('preserves the SIGN of a shrinkage total rather than negating it', () => {
+    // The lines of a reversal are negated; the assertions are SWAPPED. Negating
+    // these too would double the correction, and the entry would still balance.
+    const reversed = reverseAssertions(ASSERTIONS)
+    expect(reversed.before.activityTotals.inventoryAdjustments).toBe(-10_000)
+    expect(reversed.after.activityTotals.inventoryAdjustments).toBe(-5_000)
+  })
+})
+
+describe('parsePostingDraft - failing loudly', () => {
+  it('rejects a missing draft rather than reading it as "no assertions"', () => {
+    expect(() => parsePostingDraft(undefined)).toThrow(UnprocessableEntityError)
+    expect(() => parsePostingDraft(null)).toThrow(UnprocessableEntityError)
+  })
+
+  it('rejects an unknown version, naming it', () => {
+    expect(() => parsePostingDraft({ ...draft(), v: 2 })).toThrow(/version 2/)
+  })
+
+  it('rejects assertions of an unknown kind', () => {
+    expect(() =>
+      parsePostingDraft({ ...draft(), assertions: { kind: 'payout', before: {}, after: {} } })
+    ).toThrow(UnprocessableEntityError)
+  })
+
+  it('rejects a snapshot missing a side', () => {
+    expect(() =>
+      parsePostingDraft({
+        ...draft(),
+        assertions: { kind: 'month_end_inventory', before: ASSERTIONS.before },
+      })
+    ).toThrow(/assertions.after/)
+  })
+
+  it('rejects a non-integer balance - a float cent is a rounding bug', () => {
+    const bad = structuredClone(ASSERTIONS)
+    bad.after.balances.inventory_raw_materials = 1_095_000.5
+    expect(() => parsePostingDraft({ ...draft(), assertions: bad })).toThrow(
+      /inventory_raw_materials/
+    )
+  })
+
+  it('rejects a balance that arrived as a string', () => {
+    const bad = JSON.parse(JSON.stringify(ASSERTIONS))
+    bad.after.balances.inventory_finished_goods = '454000'
+    expect(() => parsePostingDraft({ ...draft(), assertions: bad })).toThrow(
+      /inventory_finished_goods/
+    )
+  })
+
+  it('ACCEPTS zero everywhere - 0 is a real balance, not an absent one', () => {
+    // 1320 WIP is structurally zero under L1, so this is the ordinary case and
+    // not an edge one. A parser that treated 0 as missing would drop the leg
+    // every month and nothing would notice.
+    const zeroed: PostingAssertions = {
+      kind: 'month_end_inventory',
+      before: snapshot(0, 0, 0),
+      after: snapshot(0, 0, 0),
+    }
+    expect(parsePostingDraft({ ...draft(), assertions: zeroed }).assertions).toEqual(zeroed)
+  })
+
+  it('ACCEPTS a negative adjustment total - shrinkage is signed', () => {
+    const shrink: PostingAssertions = {
+      kind: 'month_end_inventory',
+      before: snapshot(0, 0, 0, 0, 0, 0),
+      after: snapshot(0, 0, 0, 0, 0, -5_000),
+    }
+    expect(
+      parsePostingDraft({ ...draft(), assertions: shrink }).assertions?.after.activityTotals
+        .inventoryAdjustments
+    ).toBe(-5_000)
+  })
+})

--- a/packages/lib/src/postings/__tests__/opening-baseline.test.ts
+++ b/packages/lib/src/postings/__tests__/opening-baseline.test.ts
@@ -1,0 +1,378 @@
+// packages/lib/src/postings/__tests__/opening-baseline.test.ts
+//
+// The opening baseline is the one number in this system that must never be
+// guessed. It is what the FIRST month-end entry is measured against, and once
+// that entry is posted there is no un-post: a baseline that was wrong by any
+// amount produces a journal entry that balances, claims cleanly, and ties to
+// nothing.
+//
+// So there are exactly two behaviours defended here, and every test is a face of
+// one of them:
+//
+//   1. **It reads through the CACHED settings path.** Every key goes through
+//      `getOrganizationSetting` with NO `db` argument, which is the only way it
+//      answers from `getOrgCache().get(orgId, 'orgSettings')`
+//      (`settings-service.ts:171-174`); pass a `db` and it silently becomes a
+//      direct table query instead (`settings-service.ts:156-169`). The absence
+//      of that argument is load-bearing and invisible, so it is asserted. The
+//      cached value is dropped by the wizard that writes it —
+//      `routers/setting.ts:134` and `:221` fire `org.settings.changed`, which
+//      `invalidation-graph.ts:250` maps to `org: ['orgSettings']`.
+//   2. **It fails closed, naming the row to fix.** Never a default, never `0`,
+//      never UTC. And the mirror of that: `0` is a LEGITIMATE opening balance —
+//      an organization with no work in process at cutover has exactly zero WIP
+//      — so a `?? 0` anywhere in the read path is a bug that makes "unset" and
+//      "zero" indistinguishable. `zero is a real balance, not a missing one`
+//      below is the test that catches it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** The org's settings, as the cache would hand them back, keyed by setting key. */
+  settings: {} as Record<string, unknown>,
+  /**
+   * Every `getOrganizationSetting` call's params verbatim — so a test can prove
+   * no `db` was passed, which is what keeps the read on the cached path.
+   */
+  calls: [] as Record<string, unknown>[],
+}))
+
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: async (params: { organizationId: string; key: string; db?: unknown }) => {
+    h.calls.push({ ...params })
+    return params.key in h.settings ? h.settings[params.key] : null
+  },
+  // Present only so that reaching for it is a loud failure. It always queries
+  // the table (`settings-service.ts:187`), so it is NOT the cached path and this
+  // module must not use it.
+  getAllOrganizationSettings: async () => {
+    throw new Error('getAllOrganizationSettings is not the cached path — do not use it here')
+  },
+}))
+
+import { UnprocessableEntityError } from '../../errors'
+import { isSettingKey } from '../../settings/catalog'
+import { OPENING_BASELINE_SETTING_KEYS, readOpeningBaseline } from '../opening-baseline'
+
+const ORG = 'org_1'
+const K = OPENING_BASELINE_SETTING_KEYS
+
+/** A finalized, complete, valid baseline. Every test starts here and breaks one thing. */
+function validSettings(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    [K.setupState]: 'finalized',
+    [K.cutoffPeriod]: '2026-12',
+    [K.bookTimeZone]: 'America/New_York',
+    [K.inventory_raw_materials]: 125_000,
+    [K.inventory_wip]: 0,
+    [K.inventory_finished_goods]: 480_050,
+    // Catalog siblings the reader must ignore: provenance and audit metadata,
+    // not inputs to the arithmetic.
+    'accounting.qboOpeningRawMaterials': 999_999,
+    'accounting.qboOpeningWip': 999_999,
+    'accounting.qboOpeningFinishedGoods': 999_999,
+    'accounting.qboOpeningJournalRef': 'JE-1042',
+    'accounting.setupFinalizedAt': '2026-12-31T23:59:00.000Z',
+    'accounting.setupFinalizedByUserId': 'usr_1',
+    ...overrides,
+  }
+}
+
+/** The refusal's message, or a failure if the call unexpectedly succeeded. */
+async function refusalMessage(settings: Record<string, unknown>): Promise<string> {
+  h.settings = settings
+  const result = await readOpeningBaseline(ORG)
+  if (result.isOk()) {
+    throw new Error(`Expected a refusal, got ${JSON.stringify(result.value)}`)
+  }
+  expect(result.error).toBeInstanceOf(UnprocessableEntityError)
+  return result.error.message
+}
+
+beforeEach(() => {
+  h.settings = validSettings()
+  h.calls = []
+})
+
+describe('readOpeningBaseline', () => {
+  describe('the happy path', () => {
+    it('returns the cutoff, the zone and the three balances', async () => {
+      const result = await readOpeningBaseline(ORG)
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({
+        cutoffPeriod: '2026-12',
+        bookTimeZone: 'America/New_York',
+        balances: {
+          inventory_raw_materials: 125_000,
+          inventory_wip: 0,
+          inventory_finished_goods: 480_050,
+        },
+      })
+    })
+
+    it('ignores the provider snapshot and the audit metadata', async () => {
+      // The provider's figures are provenance and a finalize-time gate, not a
+      // second source for the same number. If they ever leaked into the result
+      // the balances below would read 999_999.
+      const baseline = (await readOpeningBaseline(ORG))._unsafeUnwrap()
+      expect(Object.keys(baseline).sort()).toEqual(['balances', 'bookTimeZone', 'cutoffPeriod'])
+      expect(baseline.balances.inventory_raw_materials).toBe(125_000)
+    })
+
+    it('trims a hand-typed cutoff and zone rather than refusing them', async () => {
+      h.settings = validSettings({
+        [K.cutoffPeriod]: '  2026-12 ',
+        [K.bookTimeZone]: ' America/New_York  ',
+      })
+      const baseline = (await readOpeningBaseline(ORG))._unsafeUnwrap()
+      expect(baseline.cutoffPeriod).toBe('2026-12')
+      expect(baseline.bookTimeZone).toBe('America/New_York')
+    })
+  })
+
+  describe('it reads through the org settings cache', () => {
+    it('passes NO db argument, which is the only thing that keeps it cached', async () => {
+      // 🛑 THE CACHED-PATH TEST. `getOrganizationSetting` answers from
+      // `getOrgCache().get(orgId, 'orgSettings')` only when `db` is omitted
+      // (`settings-service.ts:171-174`). Hand it a `Database` or a
+      // `Transaction` and it quietly switches to a direct `OrganizationSetting`
+      // query (`settings-service.ts:156-169`) — same signature, same return
+      // type, no error. The absence of the argument IS the mechanism, so it is
+      // the thing asserted.
+      await readOpeningBaseline(ORG)
+
+      expect(h.calls.length).toBeGreaterThan(0)
+      for (const call of h.calls) {
+        expect(Object.keys(call).sort()).toEqual(['key', 'organizationId'])
+        expect('db' in call).toBe(false)
+        expect(call.organizationId).toBe(ORG)
+      }
+    })
+
+    it('reads exactly the six declared keys, one cached lookup each', async () => {
+      await readOpeningBaseline(ORG)
+
+      expect(h.calls.map((call) => call.key).sort()).toEqual(Object.values(K).sort())
+    })
+
+    it('still reads through the cache when the baseline is refused', async () => {
+      // A refusal must not become a shortcut that reaches for a different reader.
+      h.settings = validSettings({ [K.setupState]: 'draft' })
+      await readOpeningBaseline(ORG)
+
+      expect(h.calls.length).toBeGreaterThan(0)
+      for (const call of h.calls) expect('db' in call).toBe(false)
+    })
+  })
+
+  describe('the setup gate', () => {
+    it.each([
+      ['draft', 'draft'],
+      ['unset', null],
+      ['some other value', 'in_progress'],
+    ])('refuses when setupState is %s, and says so', async (_label, state) => {
+      const message = await refusalMessage(validSettings({ [K.setupState]: state }))
+      expect(message).toContain(K.setupState)
+      expect(message).toContain('not finalized')
+    })
+
+    it('refuses draft BEFORE complaining about missing rows', async () => {
+      // A half-filled wizard is missing rows AND in draft. Reporting the missing
+      // rows first tells the person to fill in fields they are already looking
+      // at; reporting the state tells them the step they have not finished.
+      const message = await refusalMessage({ [K.setupState]: 'draft' })
+      expect(message).toContain('not finalized')
+      expect(message).not.toContain('incomplete')
+    })
+  })
+
+  describe('a missing key fails closed and names itself', () => {
+    it.each([
+      [K.cutoffPeriod],
+      [K.bookTimeZone],
+      [K.inventory_raw_materials],
+      [K.inventory_wip],
+      [K.inventory_finished_goods],
+    ])('refuses when %s is null', async (key) => {
+      const message = await refusalMessage(validSettings({ [key]: null }))
+      expect(message).toContain(key)
+      expect(message).toContain('incomplete')
+    })
+
+    it.each([
+      [K.cutoffPeriod],
+      [K.bookTimeZone],
+    ])('treats an empty %s as unset, because a cleared text input writes ""', async (key) => {
+      const message = await refusalMessage(validSettings({ [key]: '   ' }))
+      expect(message).toContain(key)
+    })
+
+    it('names every missing key in one message, not one refusal per blank field', async () => {
+      const message = await refusalMessage(
+        validSettings({ [K.bookTimeZone]: null, [K.inventory_wip]: null })
+      )
+      expect(message).toContain(K.bookTimeZone)
+      expect(message).toContain(K.inventory_wip)
+      expect(message).not.toContain(K.inventory_raw_materials)
+    })
+  })
+
+  describe('the cutoff period', () => {
+    it('refuses a malformed month', async () => {
+      const message = await refusalMessage(validSettings({ [K.cutoffPeriod]: '2026-13' }))
+      expect(message).toContain(K.cutoffPeriod)
+      expect(message).toContain('2026-13')
+    })
+
+    it('refuses a DAY key — the cutoff divides accounting months', async () => {
+      // `parsePeriodKey` accepts `'2026-12-31'` happily. Silently picking one
+      // edge of a day key is the fail-open reading in a different costume.
+      const message = await refusalMessage(validSettings({ [K.cutoffPeriod]: '2026-12-31' }))
+      expect(message).toContain('not a month')
+    })
+
+    it('refuses a non-string', async () => {
+      const message = await refusalMessage(validSettings({ [K.cutoffPeriod]: 202_612 }))
+      expect(message).toContain(K.cutoffPeriod)
+    })
+  })
+
+  describe('the book timezone', () => {
+    it('refuses an invalid IANA zone rather than falling back to UTC', async () => {
+      const message = await refusalMessage(validSettings({ [K.bookTimeZone]: 'Mars/Olympus' }))
+      expect(message).toContain(K.bookTimeZone)
+      expect(message).toContain('Mars/Olympus')
+      expect(message).toContain('IANA')
+    })
+
+    it('refuses an abbreviation that is not a zone name', async () => {
+      const message = await refusalMessage(validSettings({ [K.bookTimeZone]: 'EST5EDT-nope' }))
+      expect(message).toContain(K.bookTimeZone)
+    })
+
+    it('accepts UTC when it is actually configured, and only then', async () => {
+      h.settings = validSettings({ [K.bookTimeZone]: 'UTC' })
+      const baseline = (await readOpeningBaseline(ORG))._unsafeUnwrap()
+      expect(baseline.bookTimeZone).toBe('UTC')
+    })
+
+    it('validates with the same call periodKeyForDate will make', async () => {
+      // If this passes here it cannot throw there. The zone below is real but
+      // uncommon, which is the case a hand-written allowlist would have missed.
+      h.settings = validSettings({ [K.bookTimeZone]: 'Pacific/Chatham' })
+      expect((await readOpeningBaseline(ORG)).isOk()).toBe(true)
+      expect(() => new Intl.DateTimeFormat('en-CA', { timeZone: 'Pacific/Chatham' })).not.toThrow()
+    })
+  })
+
+  describe('the balances are integer minor units', () => {
+    it.each([
+      [K.inventory_raw_materials],
+      [K.inventory_wip],
+      [K.inventory_finished_goods],
+    ])('refuses a fractional %s, with the value in the message', async (key) => {
+      // The catalog cannot catch this: `normalizeSettingValue` routes CURRENCY
+      // through `fieldValueSchemas.number`, which rejects only a non-finite
+      // number, so `12.5` reaches storage.
+      const message = await refusalMessage(validSettings({ [key]: 1250.5 }))
+      expect(message).toContain(key)
+      expect(message).toContain('1250.5')
+      expect(message).toContain('minor units')
+    })
+
+    it('refuses a string that looks like a number', async () => {
+      const message = await refusalMessage(validSettings({ [K.inventory_wip]: '1250' }))
+      expect(message).toContain(K.inventory_wip)
+      expect(message).toContain('not a number')
+    })
+
+    it.each([[Number.NaN], [Number.POSITIVE_INFINITY]])('refuses %s', async (value) => {
+      const message = await refusalMessage(validSettings({ [K.inventory_wip]: value }))
+      expect(message).toContain('not a number')
+    })
+
+    it('accepts a negative balance — a credit inventory balance is wrong, not unreadable', async () => {
+      // Refusing it here would hide a real accounting problem behind a settings
+      // error. The close is where a negative inventory balance gets argued about.
+      h.settings = validSettings({ [K.inventory_wip]: -500 })
+      const baseline = (await readOpeningBaseline(ORG))._unsafeUnwrap()
+      expect(baseline.balances.inventory_wip).toBe(-500)
+    })
+
+    it('zero is a real balance, not a missing one', async () => {
+      // 🛑 THE `?? 0` TEST. An organization with nothing in process at cutover
+      // has exactly zero WIP, and a business that makes to order has zero
+      // finished goods. If any of these collapsed `0` into "unset" the reader
+      // would refuse a correctly configured organization; if the inverse ever
+      // ships — "unset" collapsing to `0` — the first entry values itself
+      // against a baseline nobody supplied and nothing downstream can tell.
+      h.settings = validSettings({
+        [K.inventory_raw_materials]: 0,
+        [K.inventory_wip]: 0,
+        [K.inventory_finished_goods]: 0,
+      })
+
+      const result = await readOpeningBaseline(ORG)
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap().balances).toEqual({
+        inventory_raw_materials: 0,
+        inventory_wip: 0,
+        inventory_finished_goods: 0,
+      })
+    })
+
+    it('a null balance and a zero balance take different paths', async () => {
+      const zero = await readOpeningBaseline(ORG)
+      expect(zero.isOk()).toBe(true) // the fixture already has WIP at 0
+
+      h.settings = validSettings({ [K.inventory_wip]: null })
+      const missing = await readOpeningBaseline(ORG)
+      expect(missing.isErr()).toBe(true)
+    })
+  })
+
+  describe('the refusal is an AuxxError carrying the row to fix', () => {
+    it('is a 422 with the organization and the setting in its details', async () => {
+      h.settings = validSettings({ [K.bookTimeZone]: 'Mars/Olympus' })
+      const result = await readOpeningBaseline(ORG)
+
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(UnprocessableEntityError)
+      expect((error as UnprocessableEntityError).statusCode).toBe(422)
+      expect((error as UnprocessableEntityError).details).toMatchObject({
+        organizationId: ORG,
+        setting: K.bookTimeZone,
+      })
+    })
+
+    it('returns a Result rather than throwing, so the poster can map it to a status', async () => {
+      h.settings = {}
+      await expect(readOpeningBaseline(ORG)).resolves.toBeDefined()
+    })
+  })
+
+  describe('the declared keys', () => {
+    it('names the catalog keys it reads, and only those', async () => {
+      expect(OPENING_BASELINE_SETTING_KEYS).toEqual({
+        setupState: 'accounting.setupState',
+        cutoffPeriod: 'accounting.cutoffPeriod',
+        bookTimeZone: 'accounting.bookTimeZone',
+        inventory_raw_materials: 'accounting.openingRawMaterials',
+        inventory_wip: 'accounting.openingWip',
+        inventory_finished_goods: 'accounting.openingFinishedGoods',
+      })
+    })
+
+    it('every key it names exists in the settings catalog', () => {
+      // The reader and the catalog are two files. A typo in either one produces
+      // a key that reads as permanently unset, which fails closed — loudly, but
+      // for a reason nobody can act on, because the row the error names does not
+      // exist to be filled in.
+      for (const key of Object.values(OPENING_BASELINE_SETTING_KEYS)) {
+        expect(isSettingKey(key), `${key} is not a catalog key`).toBe(true)
+      }
+    })
+  })
+})

--- a/packages/lib/src/postings/__tests__/post-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/post-entry.test.ts
@@ -607,6 +607,45 @@ describe('the claim', () => {
 // ── Refusals, and that none of them write ──────────────────────────────────
 
 describe('refusals', () => {
+  it('refuses a month-end inventory posting that carries no assertions', async () => {
+    const fake = createFakeDb(FULL_CHART)
+    const result = await postEntry(fake.db, {
+      organizationId: ORG,
+      entry: receiptEntry({ postingType: 'month_end_inventory', periodKey: '2026-08' }),
+      lock: OPEN,
+    })
+
+    // A month-end entry ASSERTS a balance rather than accumulating one, so the
+    // next close reads its opening figures out of this row's draft. Written
+    // without them it would hold the period - nothing can repair a claimed
+    // period - and leave the next month computing a delta from nothing. That
+    // entry balances perfectly, which is why this door exists.
+    expect(result.status).toBe('error')
+    expect(result.failureClass).toBe('data')
+    expect(result.retryable).toBe(false)
+    expect(result.error).toContain('assertions')
+    // Refused BEFORE the claim: nothing holds the period.
+    expect(fake.postings).toHaveLength(0)
+    expect(fake.lines).toHaveLength(0)
+  })
+
+  it('accepts a month-end inventory posting WITH assertions, and stores them verbatim', async () => {
+    const fake = createFakeDb(FULL_CHART)
+    const snapshot = {
+      balances: { inventory_raw_materials: 0, inventory_wip: 0, inventory_finished_goods: 0 },
+      activityTotals: { absorbedLabor: 0, absorbedOverhead: 0, inventoryAdjustments: 0 },
+    }
+    await postEntry(fake.db, {
+      organizationId: ORG,
+      entry: receiptEntry({ postingType: 'month_end_inventory', periodKey: '2026-08' }),
+      lock: OPEN,
+      assertions: { kind: 'month_end_inventory', before: snapshot, after: snapshot },
+    })
+
+    const draft = fake.postings[0]!.draft as { assertions?: { kind: string } }
+    expect(draft.assertions?.kind).toBe('month_end_inventory')
+  })
+
   it('refuses a closed period and writes nothing', async () => {
     const fake = createFakeDb(FULL_CHART)
     const result = await postEntry(fake.db, {

--- a/packages/lib/src/postings/__tests__/resolve-roles.test.ts
+++ b/packages/lib/src/postings/__tests__/resolve-roles.test.ts
@@ -273,7 +273,7 @@ describe('resolveRoles — it answers for the whole set at once', () => {
   // the night of a close.
   it('names every failing role in a single error', async () => {
     const db = stubDb([], [])
-    const roles = ['grni', 'ppv', 'cash', 'inventory_wip', 'cogs_materials', 'applied_overhead']
+    const roles = ['grni', 'ppv', 'cash', 'inventory_wip', 'cogs_product_cost', 'applied_overhead']
     const error = await expectErr(resolveRoles(db, ORG, roles))
 
     for (const role of roles) expect(error.message, role).toContain(`'${role}'`)

--- a/packages/lib/src/postings/build-entry.ts
+++ b/packages/lib/src/postings/build-entry.ts
@@ -159,11 +159,25 @@ export const ACCOUNT_ROLES = {
    */
   DUTIES_ACCRUAL: 'duties_accrual',
   /**
-   * COGS - materials (default `5000`). The balancing figure of the L1 month-end
-   * entry, and the account parts purchases must be coded to off the bank feed
-   * for that entry to have anything to reclassify (04-books §2.1).
+   * COGS - product cost (default `5000`). The balancing figure of the L1
+   * month-end entry, and the account parts purchases must be coded to off the
+   * bank feed for that entry to have anything to reclassify (04-books §2.1).
+   *
+   * 🛑 **Named "product cost", not "materials", because it holds more than
+   * materials and cannot be made to hold less.** The month-end entry credits
+   * the FULL labour and overhead absorbed this period out of `2110` and `5020`,
+   * but a unit that ships carries its whole frozen cost - materials, labour and
+   * overhead together - out of finished goods. The difference lands here.
+   *
+   * There is no `cogs_direct_labor` role and there cannot be one: a
+   * `stock_movement` freezes a single total `unit_cost` and carries no labour or
+   * overhead column, so nothing can say how much of a shipped unit's cost was
+   * labour. Reconstructing it from the part's CURRENT `standardLaborCost` would
+   * value last month's shipments at this month's rates, which is the
+   * restatement the frozen-cost rule exists to prevent. `5010 COGS - Direct
+   * Labor` is therefore in the chart with no role and stays at zero under L1.
    */
-  COGS_MATERIALS: 'cogs_materials',
+  COGS_PRODUCT_COST: 'cogs_product_cost',
   /**
    * COGS - applied overhead (default `5020`). Overhead absorbed into inventory
    * this period, credited by the L1 month-end entry.
@@ -219,7 +233,7 @@ export const ROLE_ACCOUNT_TYPES: Record<AccountRole, GlAccountTypeValue> = {
   freight_accrual: 'liability',
   grni: 'liability',
   duties_accrual: 'liability',
-  cogs_materials: 'expense',
+  cogs_product_cost: 'expense',
   applied_overhead: 'expense',
   ppv: 'expense',
   inventory_count_variance: 'expense',
@@ -245,7 +259,7 @@ export const ACCOUNT_ROLE_LABELS: Record<AccountRole, string> = {
   freight_accrual: 'Inbound Freight & Brokerage Accrual',
   grni: 'Goods Received Not Invoiced',
   duties_accrual: 'Duties Accrual',
-  cogs_materials: 'COGS — Materials',
+  cogs_product_cost: 'COGS - Product Cost',
   applied_overhead: 'COGS — Applied Overhead',
   ppv: 'Purchase Price Variance',
   inventory_count_variance: 'Inventory Count Variance',

--- a/packages/lib/src/postings/build-month-end-inventory.ts
+++ b/packages/lib/src/postings/build-month-end-inventory.ts
@@ -1,0 +1,360 @@
+// packages/lib/src/postings/build-month-end-inventory.ts
+//
+// The L1 month-end inventory entry. One entry per month turns the subledger into
+// the general ledger; under L1 no receipt, no build and no shipment posts
+// individually, so this is the ENTIRE GL surface for inventory at cutover
+// (plans/money/04-books.md §2.1).
+//
+// PURE. No database, no provider, no clock, no io. Every value it needs arrives
+// in `MonthEndInventoryInputs`, which is a flat record of integers a golden test
+// can build by hand. `gatherMonthEndInventoryInputs` does the reads; this file
+// does the arithmetic. They are split because they fail differently: a read
+// failure is a runtime condition, an arithmetic failure is a bug.
+//
+// Which is why this file THROWS `AuxxError` subclasses rather than returning a
+// `Result`, exactly as `build-entry.ts` does and for the same reason: per
+// docs/lib-module-guide.md `Result` is for runtime failure, and an entry that
+// cannot balance its own arithmetic is not a runtime failure - it is a
+// programmer error that must stop, loudly, before anything is persisted.
+//
+// ── The two source lanes, and why there are two ─────────────────────────────
+//
+// The inventory BALANCES come from the movement ledger: the frozen reconciled
+// opening snapshot plus Σ signed `extendedCost` over eligible post-cutoff
+// movements, grouped by each movement's own frozen `stock_movement_gl_account`.
+//
+// The ABSORPTION totals do NOT. A `stock_movement` freezes a single total
+// `unit_cost` and carries no labour or overhead column, so the split cannot be
+// recovered from the ledger at all; re-deriving it from the part's CURRENT
+// `standardLaborCost` would value last month's production at this month's rates,
+// which is the restatement the frozen-cost rule exists to prevent. The split IS
+// frozen, on the build: `build_labor_cost` and `build_overhead_cost`. That is a
+// property of the design, not an accident, and it is why the reader has two
+// lanes instead of one.
+//
+// ⚠️ Those two build fields carry `updatable: false`, but that flag is ADVISORY -
+// it is read by the grid cell and the connector catalog and by nothing on the
+// write path. The guarantee this builder relies on is "only `completeBuild` and
+// `reverseBuild` write them", NOT "the database refuses an update". That is a
+// materially weaker claim than `GlPostingLine`'s structural immutability and it
+// is worth knowing which one is holding the entry up.
+//
+// ── Everything here is a DELTA, and the deltas are CUMULATIVE ───────────────
+//
+// The entry posts `target − what we last asserted`, never the balance itself.
+// `prior` is what the previous effective posting asserted (or, at cutover, the
+// opening baseline); `current` is the cumulative state gathered through this
+// period end. Both activity totals are cumulative from the opening cutoff, NOT
+// the amounts in this one entry - that is what lets a build or an adjustment
+// entered after its accounting month has closed show up in the next open entry
+// still carrying its own frozen labour, overhead and 5095 classification,
+// instead of disappearing into the COGS plug.
+//
+// 🛑 A delta is only computable because auxx.ai is the ONLY writer of
+// 1310/1320/1330 in the GL (README §4.1). This is the cash value of "L1 or L3,
+// never both": the moment something else posts to those accounts the delta is a
+// lie, and nothing in this engine can detect it.
+//
+// ── 🛑 THE SIGN TABLE - three lanes, three DIFFERENT mappings ───────────────
+//
+// | Lane                                          | Positive delta | Negative delta |
+// | --------------------------------------------- | -------------- | -------------- |
+// | `inventory_raw_materials`   (balance)          | **Debit**      | Credit         |
+// | `inventory_wip`             (balance)          | **Debit**      | Credit         |
+// | `inventory_finished_goods`  (balance)          | **Debit**      | Credit         |
+// | `payroll_clearing`          (absorbedLabor)    | **Credit**     | Debit          |
+// | `applied_overhead`          (absorbedOverhead) | **Credit**     | Debit          |
+// | `inventory_count_variance`  (adjustments)      | **Credit**     | Debit          |
+//
+// `amount` is always `Math.abs(delta)`; the sign lives in `direction` and
+// nowhere else.
+//
+// 🛑 **The balance gate CANNOT catch a sign mistake here.** 5000 is the plug, so
+// flipping any one lane's direction is absorbed by the plug at twice the error
+// and `buildEntry` returns happily. A property test cannot catch it either, for
+// the same reason. The ONLY guard is the exact per-lane, per-sign golden tests
+// in `__tests__/build-month-end-inventory.test.ts`. If you change a direction
+// here and a golden test does not go red, the test file is broken, not lenient.
+//
+// ── What is deliberately NOT here ───────────────────────────────────────────
+//
+// - **No `5090` / PPV leg.** Under L1 nothing posts to 5090 during the year and
+//   the variance is not computable from a receipt anyway: `receive-stock.ts`
+//   stamps `cost_basis: 'actual'` and never reads `part_standard_cost`, so there
+//   is no standard/actual pair on the row to difference. PPV is a REPORT
+//   (`G10` as amended, `plans/money/design/costing-facts.md`).
+// - **No provider, and no provider id** (`G1`). A builder emits roles; the
+//   resolver in front of the claim maps a role to the org's own account.
+// - **No 1320 leg in practice.** WIP is structurally zero: every movement writer
+//   resolves through `resolveInventoryRoleForPartKind`, whose range is two
+//   values, and a build's consume and produce movements commit together at
+//   completion (`B2`, `B8`). The lane is built anyway so it works the day that
+//   stops being true - a zero delta simply drops out below.
+
+import { UnprocessableEntityError } from '../errors'
+import { ACCOUNT_ROLES, buildEntry } from './build-entry'
+import type { MonthEndInventorySnapshot, PostingAssertions } from './draft'
+import type { BuiltEntry, GlPostingLineInput, PostingDirection } from './types'
+
+/**
+ * Everything the month-end entry is computed from. A flat record of integers -
+ * no rows, no ids, nothing that needs a database to construct.
+ */
+export interface MonthEndInventoryInputs {
+  /** The accounting period this entry closes, e.g. `'2026-08'`. */
+  periodKey: string
+  /**
+   * `YYYY-MM-DD` - the last day of `periodKey` in the org's book timezone.
+   *
+   * GIVEN, never computed here. The timezone is the required
+   * `accounting.bookTimeZone` setting, read once by the caller and passed down,
+   * so a test can pin it and so this file stays free of a clock. There is no
+   * UTC fallback anywhere in this subsystem, deliberately.
+   */
+  txnDate: string
+  /**
+   * What the previous effective posting asserted about the world after itself -
+   * or, at cutover, the frozen reconciled opening baseline.
+   *
+   * 🛑 Never zero-by-default. The first close reads
+   * `accounting.opening*`; it does not assume zero and does not manufacture a
+   * synthetic `GlPosting` for an entry auxx.ai did not post.
+   */
+  prior: MonthEndInventorySnapshot
+  /** The cumulative state gathered through this period end. */
+  current: MonthEndInventorySnapshot
+}
+
+/**
+ * The built entry plus the assertion metadata the poster persists into
+ * `GlPosting.draft`.
+ *
+ * The entry stays usable by the generic poster; the assertions are the month-end
+ * contract around it, and they are what the NEXT month's delta is computed from.
+ */
+export interface BuiltMonthEndInventoryDraft {
+  entry: BuiltEntry
+  assertions: PostingAssertions
+}
+
+/** Both halves of every posting line's audit pair, in one place. */
+const SOURCE_TYPE = 'month_end_inventory'
+
+/** One delta lane, before it becomes a line. */
+interface Lane {
+  accountRole: string
+  /** `current − prior` for this lane. Signed. */
+  delta: number
+  /** The direction a POSITIVE delta takes. See the sign table in the header. */
+  positiveDirection: PostingDirection
+  memo: string
+}
+
+function assertMinorUnits(amount: unknown, label: string): number {
+  if (typeof amount !== 'number' || !Number.isFinite(amount) || !Number.isInteger(amount)) {
+    throw new UnprocessableEntityError(
+      `${label} must be an integer number of minor units, got ${String(amount)}`,
+      { field: label, value: String(amount) }
+    )
+  }
+  return amount
+}
+
+/**
+ * Validate one side's six numbers before any arithmetic touches them.
+ *
+ * Named per field, because the repair is always "which number is wrong" and
+ * `NaN` propagates silently through subtraction: `NaN − 0` is `NaN`,
+ * `Math.abs(NaN)` is `NaN`, and `buildEntry` would then reject the entry naming
+ * a ROLE rather than the input that poisoned it. One useless error message per
+ * close is one too many when the reader is somebody trying to close the books.
+ */
+function assertSnapshot(snapshot: MonthEndInventorySnapshot, label: string): void {
+  if (typeof snapshot !== 'object' || snapshot === null) {
+    throw new UnprocessableEntityError(`${label} is missing`, { field: label })
+  }
+  const { balances, activityTotals } = snapshot
+  if (typeof balances !== 'object' || balances === null) {
+    throw new UnprocessableEntityError(`${label}.balances is missing`, {
+      field: `${label}.balances`,
+    })
+  }
+  if (typeof activityTotals !== 'object' || activityTotals === null) {
+    throw new UnprocessableEntityError(`${label}.activityTotals is missing`, {
+      field: `${label}.activityTotals`,
+    })
+  }
+  assertMinorUnits(balances.inventory_raw_materials, `${label}.balances.inventory_raw_materials`)
+  assertMinorUnits(balances.inventory_wip, `${label}.balances.inventory_wip`)
+  assertMinorUnits(balances.inventory_finished_goods, `${label}.balances.inventory_finished_goods`)
+  assertMinorUnits(activityTotals.absorbedLabor, `${label}.activityTotals.absorbedLabor`)
+  assertMinorUnits(activityTotals.absorbedOverhead, `${label}.activityTotals.absorbedOverhead`)
+  assertMinorUnits(
+    activityTotals.inventoryAdjustments,
+    `${label}.activityTotals.inventoryAdjustments`
+  )
+}
+
+/** The sign table, applied. A negative delta flips the lane's direction. */
+function directionFor(lane: Lane): PostingDirection {
+  const flipped: PostingDirection = lane.positiveDirection === 'debit' ? 'credit' : 'debit'
+  return lane.delta > 0 ? lane.positiveDirection : flipped
+}
+
+/**
+ * Build the L1 month-end inventory entry:
+ *
+ * ```
+ * Dr/Cr inventory_raw_materials     Δ raw materials balance
+ * Dr/Cr inventory_wip               Δ WIP balance                 (omitted - structurally 0)
+ * Dr/Cr inventory_finished_goods    Δ finished goods balance
+ * Dr/Cr payroll_clearing            Δ cumulative absorbed labour
+ * Dr/Cr applied_overhead            Δ cumulative absorbed overhead
+ * Dr/Cr inventory_count_variance    Δ cumulative count adjustments
+ * Dr/Cr cogs_product_cost           whatever balances the six above
+ * ```
+ *
+ * **5000 is the PLUG, and that is what makes the entry self-correcting.** The
+ * balance is ASSERTED, not accumulated, so a miscoded purchase distorts one
+ * month and washes out the next. It is named "product cost" rather than
+ * "materials" because it holds direct materials plus the labour and overhead
+ * embedded in whatever finished goods shipped - a movement freezes only a total
+ * unit cost, so no defensible COGS-labour split can be reconstructed and calling
+ * this line "materials" would be false on the P&L.
+ *
+ * `5095` is broken out of that plug rather than buried in it, because `G12`
+ * requires count and shrinkage adjustments to post to their own role separately
+ * from PPV: they have different owners, different remedies and different trends,
+ * and one account holding both answers neither question. Under L1 nothing posts
+ * per-event, so a separate leg inside the monthly entry is the only way to
+ * honour it.
+ *
+ * Zero legs are dropped before `buildEntry` sees them. That is not tidiness:
+ * `buildEntry` rejects a zero amount outright, and a zero-amount leg against a
+ * role the org has not mapped - 1320 WIP, which no code path can reach - would
+ * fail the resolver, or force an account into the chart and into every
+ * provider's chart, for no information at all.
+ *
+ * Lines are ordered debits first, then credits, stable within each side in the
+ * sign table's order, with the plug last on its side. That is journal-entry
+ * presentation order and this is the entry a CPA reads.
+ *
+ * @throws {UnprocessableEntityError} on a non-integer or non-finite input
+ * (naming the field), on a month in which literally nothing moved, or - via
+ * {@link buildEntry} - on an entry that does not balance.
+ */
+export function buildMonthEndInventoryEntry(
+  inputs: MonthEndInventoryInputs
+): BuiltMonthEndInventoryDraft {
+  const { periodKey, txnDate, prior, current } = inputs
+
+  assertSnapshot(prior, 'prior')
+  assertSnapshot(current, 'current')
+
+  const lanes: Lane[] = [
+    {
+      accountRole: ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS,
+      delta: current.balances.inventory_raw_materials - prior.balances.inventory_raw_materials,
+      positiveDirection: 'debit',
+      memo: 'Raw materials balance change',
+    },
+    {
+      accountRole: ACCOUNT_ROLES.INVENTORY_WIP,
+      delta: current.balances.inventory_wip - prior.balances.inventory_wip,
+      positiveDirection: 'debit',
+      memo: 'Work in process balance change',
+    },
+    {
+      accountRole: ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS,
+      delta: current.balances.inventory_finished_goods - prior.balances.inventory_finished_goods,
+      positiveDirection: 'debit',
+      memo: 'Finished goods balance change',
+    },
+    {
+      // Absorption comes OUT of the payroll pool and INTO inventory, so more
+      // labour absorbed is a CREDIT here. The matching debit is already in the
+      // inventory balance lanes above - it is not posted twice.
+      accountRole: ACCOUNT_ROLES.PAYROLL_CLEARING,
+      delta: current.activityTotals.absorbedLabor - prior.activityTotals.absorbedLabor,
+      positiveDirection: 'credit',
+      memo: 'Standard labour absorbed into inventory',
+    },
+    {
+      accountRole: ACCOUNT_ROLES.APPLIED_OVERHEAD,
+      delta: current.activityTotals.absorbedOverhead - prior.activityTotals.absorbedOverhead,
+      positiveDirection: 'credit',
+      memo: 'Overhead absorbed into inventory',
+    },
+    {
+      // `inventoryAdjustments` is the only SIGNED total of the six. A shrinkage
+      // is a negative cumulative adjustment, so a falling total is a DEBIT to
+      // 5095 - an expense - which is what shrinkage is.
+      accountRole: ACCOUNT_ROLES.INVENTORY_COUNT_VARIANCE,
+      delta:
+        current.activityTotals.inventoryAdjustments - prior.activityTotals.inventoryAdjustments,
+      positiveDirection: 'credit',
+      memo: 'Inventory count and shrinkage adjustments',
+    },
+  ]
+
+  let laneDebits = 0
+  let laneCredits = 0
+  for (const lane of lanes) {
+    if (lane.delta === 0) continue
+    if (directionFor(lane) === 'debit') laneDebits += Math.abs(lane.delta)
+    else laneCredits += Math.abs(lane.delta)
+  }
+
+  // The plug: whatever makes the two sides equal. Positive means the six lanes
+  // credit more than they debit, so 5000 takes the missing DEBIT.
+  const plug = laneCredits - laneDebits
+  const plugLane: Lane = {
+    accountRole: ACCOUNT_ROLES.COGS_PRODUCT_COST,
+    delta: plug,
+    positiveDirection: 'debit',
+    memo: 'Product cost of goods sold',
+  }
+
+  const all = [...lanes, plugLane].filter((lane) => lane.delta !== 0)
+
+  // A month in which nothing moved has no entry to post. Every lane zero means
+  // no balance changed, nothing was absorbed and nothing was adjusted - so
+  // there is no delta to assert and the plug is zero too. Calling `buildEntry`
+  // with an empty line array would throw "at least one line", which is true but
+  // names the wrong thing; the caller needs to know this is a legitimate no-op
+  // month and not a malformed entry.
+  if (all.length === 0) {
+    throw new UnprocessableEntityError(
+      `Nothing moved in ${periodKey} - every inventory balance and activity total is unchanged, so there is no month-end entry to post`,
+      { periodKey }
+    )
+  }
+
+  const debits = all.filter((lane) => directionFor(lane) === 'debit')
+  const credits = all.filter((lane) => directionFor(lane) === 'credit')
+
+  const lines: GlPostingLineInput[] = [...debits, ...credits].map((lane, index) => ({
+    accountRole: lane.accountRole,
+    direction: directionFor(lane),
+    amount: Math.abs(lane.delta),
+    memo: lane.memo,
+    sourceType: SOURCE_TYPE,
+    // The period IS the source. There is no single row that produced this
+    // entry - it is the whole subledger through a date - so `periodKey` is the
+    // only honest audit pointer, and it is what makes the entry findable again.
+    sourceId: periodKey,
+    sortOrder: index,
+  }))
+
+  return {
+    // `buildEntry` is the balance gate. It is redundant here - the plug is
+    // computed to make the sides equal - and it is called anyway, because
+    // "balances by construction" is a property of today's arithmetic and not of
+    // tomorrow's edit to it.
+    entry: buildEntry({ postingType: 'month_end_inventory', periodKey, txnDate, lines }),
+    // Verbatim, both sides, unmodified. `after` is what next month subtracts;
+    // `before` is what makes the chain testable (row N's `before` must equal row
+    // N-1's `after`) and is what a reversal swaps.
+    assertions: { kind: 'month_end_inventory', before: prior, after: current },
+  }
+}

--- a/packages/lib/src/postings/default-chart.ts
+++ b/packages/lib/src/postings/default-chart.ts
@@ -258,16 +258,20 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     // the bank feed (or in a Purchases account that closes to it), so the L1
     // month-end entry has the right account to offset (04-books §2.1).
     code: '5000',
-    name: 'COGS - Materials',
+    name: 'COGS - Product Cost',
     accountType: GlAccountType.EXPENSE,
-    role: 'cogs_materials',
+    role: 'cogs_product_cost',
   },
   {
     code: '5010',
     name: 'COGS - Direct Labor',
     accountType: GlAccountType.EXPENSE,
-    // No role. Under L1 the labour that went into inventory is relieved from
-    // 2110 Payroll Clearing by the month-end entry, not from here.
+    // No role, and it stays empty under L1. The labour that went into inventory
+    // is relieved from 2110 Payroll Clearing by the month-end entry, and the
+    // labour that then LEFT inventory on a shipment lands in 5000's plug - a
+    // movement freezes one total unit cost, so nothing can say how much of a
+    // shipped unit's cost was labour. That is why 5000 is named for product
+    // cost rather than materials. See `COGS_PRODUCT_COST` in build-entry.ts.
   },
   {
     code: '5020',

--- a/packages/lib/src/postings/draft.ts
+++ b/packages/lib/src/postings/draft.ts
@@ -1,0 +1,266 @@
+// packages/lib/src/postings/draft.ts
+//
+// The `GlPosting.draft` envelope: its type, its single construction site, its
+// runtime parser, and the reversal swap.
+//
+// PURE. No database, no clock, no io - `parsePostingDraft` reads a value that
+// came out of a jsonb column, but it does not go and get it.
+//
+// ── Why this file exists ────────────────────────────────────────────────────
+//
+// The envelope used to be an anonymous object literal inside `claimPeriod`.
+// That was fine while the poster was the only thing that ever touched it: it
+// wrote the shape and nothing read it back. The L1 month-end inventory entry
+// (plans/money/tasks/09-month-end-inventory-entry.md) changes that - it READS
+// the previous month's envelope to learn what balance was last asserted, which
+// is the number its whole delta is computed from.
+//
+// The moment a shape is written by one module and read by another, an inline
+// literal is a contract nobody declared. So it is declared here, versioned, with
+// a parser that fails loudly rather than letting `undefined` flow into
+// arithmetic that decides what a journal entry says.
+
+import { UnprocessableEntityError } from '../errors'
+import type { BuiltEntry, PostingType, ResolvedPostingLine } from './types'
+
+/** The envelope version. Bump only for a shape change readers must branch on. */
+export const POSTING_DRAFT_VERSION = 1
+
+/**
+ * The three inventory balances and the three cumulative activity totals, as one
+ * posting asserted them.
+ *
+ * Every number is integer minor units. `inventoryAdjustments` is SIGNED - a
+ * shrinkage is negative - and it is the only one of the six that may be, because
+ * the other five are balances and cumulative absorption, which cannot go
+ * negative in any state the subledger can reach.
+ *
+ * 🛑 The activity totals are CUMULATIVE from the opening cutoff through the
+ * period end, not the amounts in this one entry. That is what lets a build or an
+ * adjustment entered after its accounting month has closed appear in the next
+ * open entry carrying its own frozen labour, overhead and 5095 classification,
+ * instead of vanishing into the COGS plug.
+ */
+export interface MonthEndInventorySnapshot {
+  balances: {
+    inventory_raw_materials: number
+    inventory_wip: number
+    inventory_finished_goods: number
+  }
+  activityTotals: {
+    absorbedLabor: number
+    absorbedOverhead: number
+    /** Signed. Negative is shrinkage. */
+    inventoryAdjustments: number
+  }
+}
+
+/**
+ * What a posting asserts about the world on either side of itself.
+ *
+ * ## Why BOTH sides, and why a reversal never re-reads the subledger
+ *
+ * `after` is what the next month's entry computes its delta from. `before` looks
+ * redundant with the previous posting's `after` - and it is, on the happy path.
+ * It earns its place twice.
+ *
+ * 1. **It makes the chain testable.** Row N's `before` must equal row N-1's
+ *    `after`. Nothing else in this design can detect a broken prior-row
+ *    selection rule, because a wrong prior still produces a *balanced* entry.
+ * 2. **It is what a reversal swaps.** See {@link reverseAssertions}.
+ *
+ * 🛑 The rejected alternative was to reconstruct a reversal's assertions by
+ * re-running the month-end reader against the prior-prior period. That is wrong:
+ * movements that arrived AFTER the original posted would be included, and the
+ * reversal would assert figures unrelated to the lines it is backing out. A
+ * reversal must reverse the FROZEN posting, never reinterpret today's subledger
+ * - the same rule that stops a standard-cost change from restating a movement.
+ *
+ * `kind` is a discriminant so a second assertion-carrying posting type is
+ * additive rather than a reshape.
+ */
+export interface PostingAssertions {
+  kind: 'month_end_inventory'
+  before: MonthEndInventorySnapshot
+  after: MonthEndInventorySnapshot
+}
+
+/**
+ * The audit record of WHAT WAS POSTED, verbatim.
+ *
+ * Not a hint for reconstructing the entry later: rebuilding from the subledger
+ * gives a different answer once the subledger moves, which is the one property a
+ * ledger must not have.
+ */
+export interface PostingDraftV1 {
+  v: typeof POSTING_DRAFT_VERSION
+  docNumber: string
+  revision: number
+  memo?: string
+  entry: BuiltEntry
+  /** Post-resolution. A provider never sees a role. */
+  resolvedLines: Array<ResolvedPostingLine & { accountRole: string }>
+  /** Present only for posting types that assert a balance. See {@link PostingAssertions}. */
+  assertions?: PostingAssertions
+}
+
+/**
+ * Posting types that MUST carry {@link PostingAssertions}.
+ *
+ * `month_end_inventory` asserts a balance rather than accumulating one, so the
+ * next month's entry is computable only from what this one recorded. A
+ * month-end posting written without assertions is not merely missing metadata -
+ * it silently ends the chain, and the next close reads a delta from nothing.
+ */
+const ASSERTION_REQUIRED_TYPES = new Set<PostingType>(['month_end_inventory'])
+
+/** Whether this posting type refuses to be claimed without assertions. */
+export function requiresAssertions(postingType: PostingType): boolean {
+  return ASSERTION_REQUIRED_TYPES.has(postingType)
+}
+
+/**
+ * Build the envelope. The SINGLE construction site - nothing else may assemble
+ * this object, so there is exactly one place the version is stamped.
+ */
+export function buildPostingDraft(input: {
+  docNumber: string
+  revision: number
+  memo?: string
+  entry: BuiltEntry
+  resolvedLines: Array<ResolvedPostingLine & { accountRole: string }>
+  assertions?: PostingAssertions
+}): PostingDraftV1 {
+  return {
+    v: POSTING_DRAFT_VERSION,
+    docNumber: input.docNumber,
+    revision: input.revision,
+    memo: input.memo,
+    entry: input.entry,
+    resolvedLines: input.resolvedLines,
+    assertions: input.assertions,
+  }
+}
+
+/**
+ * The assertions a REVERSAL of this posting must carry: the pair, swapped.
+ *
+ * ```
+ *   original   before: A   after: B
+ *   reversal   before: B   after: A
+ * ```
+ *
+ * Reversing the reversal swaps them again and lands back on the original, so
+ * this is self-consistent at any revision depth. It reads only frozen data.
+ */
+export function reverseAssertions(assertions: PostingAssertions): PostingAssertions {
+  return { kind: assertions.kind, before: assertions.after, after: assertions.before }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseMinor(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new UnprocessableEntityError(
+      `Posting draft ${path} must be an integer number of minor units, got ${String(value)}`,
+      { path, value: String(value) }
+    )
+  }
+  return value
+}
+
+function parseSnapshot(value: unknown, path: string): MonthEndInventorySnapshot {
+  if (!isRecord(value)) {
+    throw new UnprocessableEntityError(`Posting draft ${path} is missing or not an object`, {
+      path,
+    })
+  }
+  const balances = value.balances
+  const activityTotals = value.activityTotals
+  if (!isRecord(balances) || !isRecord(activityTotals)) {
+    throw new UnprocessableEntityError(
+      `Posting draft ${path} must carry both 'balances' and 'activityTotals'`,
+      { path }
+    )
+  }
+  return {
+    balances: {
+      inventory_raw_materials: parseMinor(
+        balances.inventory_raw_materials,
+        `${path}.balances.inventory_raw_materials`
+      ),
+      inventory_wip: parseMinor(balances.inventory_wip, `${path}.balances.inventory_wip`),
+      inventory_finished_goods: parseMinor(
+        balances.inventory_finished_goods,
+        `${path}.balances.inventory_finished_goods`
+      ),
+    },
+    activityTotals: {
+      absorbedLabor: parseMinor(
+        activityTotals.absorbedLabor,
+        `${path}.activityTotals.absorbedLabor`
+      ),
+      absorbedOverhead: parseMinor(
+        activityTotals.absorbedOverhead,
+        `${path}.activityTotals.absorbedOverhead`
+      ),
+      inventoryAdjustments: parseMinor(
+        activityTotals.inventoryAdjustments,
+        `${path}.activityTotals.inventoryAdjustments`
+      ),
+    },
+  }
+}
+
+/**
+ * Parse a `GlPosting.draft` jsonb value.
+ *
+ * 🛑 **Throws rather than returning a `Result`, and that is deliberate.** A draft
+ * that does not parse is not a runtime failure the caller can recover from - it
+ * means a row this code wrote cannot be read by this code, and the only honest
+ * response is to stop. Silently treating it as absent would make the next
+ * month's entry assert a delta from zero and restate the whole opening balance,
+ * which balances perfectly and is invisible until somebody reconciles by hand.
+ *
+ * @throws {UnprocessableEntityError} on an unknown version or a malformed shape.
+ */
+export function parsePostingDraft(value: unknown): PostingDraftV1 {
+  if (!isRecord(value)) {
+    throw new UnprocessableEntityError('Posting draft is missing or not an object')
+  }
+  if (value.v !== POSTING_DRAFT_VERSION) {
+    throw new UnprocessableEntityError(
+      `Unsupported posting draft version ${String(value.v)} (this build reads v${POSTING_DRAFT_VERSION})`,
+      { version: String(value.v) }
+    )
+  }
+
+  const assertions = value.assertions
+  let parsedAssertions: PostingAssertions | undefined
+  if (assertions !== undefined && assertions !== null) {
+    if (!isRecord(assertions) || assertions.kind !== 'month_end_inventory') {
+      throw new UnprocessableEntityError(
+        `Posting draft carries assertions of an unknown kind ${String(isRecord(assertions) ? assertions.kind : assertions)}`
+      )
+    }
+    parsedAssertions = {
+      kind: 'month_end_inventory',
+      before: parseSnapshot(assertions.before, 'assertions.before'),
+      after: parseSnapshot(assertions.after, 'assertions.after'),
+    }
+  }
+
+  return {
+    v: POSTING_DRAFT_VERSION,
+    docNumber: String(value.docNumber ?? ''),
+    revision: typeof value.revision === 'number' ? value.revision : 0,
+    memo: typeof value.memo === 'string' ? value.memo : undefined,
+    entry: value.entry as BuiltEntry,
+    resolvedLines: Array.isArray(value.resolvedLines)
+      ? (value.resolvedLines as PostingDraftV1['resolvedLines'])
+      : [],
+    assertions: parsedAssertions,
+  }
+}

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -32,6 +32,22 @@ export {
   DOC_NUMBER_PREFIX,
   type DocNumberInput,
 } from './doc-number'
+export {
+  buildPostingDraft,
+  type MonthEndInventorySnapshot,
+  POSTING_DRAFT_VERSION,
+  type PostingAssertions,
+  type PostingDraftV1,
+  parsePostingDraft,
+  requiresAssertions,
+  reverseAssertions,
+} from './draft'
+export {
+  FINALIZED_SETUP_STATE,
+  OPENING_BASELINE_SETTING_KEYS,
+  type OpeningBaseline,
+  readOpeningBaseline,
+} from './opening-baseline'
 export { PERIOD_LOCK_SETTING_KEY, resolvePeriodLock } from './period-lock'
 export {
   assertPeriodOpen,

--- a/packages/lib/src/postings/opening-baseline.ts
+++ b/packages/lib/src/postings/opening-baseline.ts
@@ -1,0 +1,400 @@
+// packages/lib/src/postings/opening-baseline.ts
+//
+// The opening baseline: what the books were worth the day auxx.ai took them over.
+//
+// The month-end inventory entry posts a DELTA — `target − what we last asserted`
+// — so every close needs a previous assertion to subtract from. Every close but
+// the first one has one: the prior `posted` `month_end_inventory` row carries
+// the balances resulting after itself. The FIRST close has nothing, and it must
+// not invent one. It never assumes zero, and it never manufactures a synthetic
+// `GlPosting` for an entry auxx.ai did not post. It reads this instead: the
+// frozen December 31 physical count, valued at CPA-approved costs, that the
+// accounting setup wizard (`plans/money/tasks/12-accounting-setup.md`) captured
+// and finalized.
+//
+// This module owns the CONTRACT — the setting keys, the shape, and the read.
+// The wizard that produces the values is task 12 and lives in `apps/web`.
+//
+// ## What this reader deliberately does NOT read
+//
+// The wizard also captures the accounting provider's own opening balances
+// (`accounting.qboOpening*`) and the reference to the journal entry that booked
+// them there (`accounting.qboOpeningJournalRef`). Those are PROVENANCE and a
+// finalize-time GATE: the wizard shows the difference between the two snapshots
+// and refuses to finalize until they agree, because a difference allowed to fall
+// into January's balancing plug would classify a cutover problem as January
+// COGS. Once that gate passes there is exactly one agreed set of balances, and
+// it is the `accounting.opening*` set. The entry is valued from those. Reading
+// the provider's copy here would be a second, unreconciled source of the same
+// number.
+//
+// Likewise `accounting.setupFinalizedAt` / `…ByUserId`: audit metadata for the
+// wizard, not inputs to the arithmetic.
+//
+// ## Everything here fails CLOSED
+//
+// There is no default, no zero and no UTC. Each refusal names the specific keys
+// that are missing or wrong, because the repair is a person filling in a
+// settings form and "the opening baseline is invalid" does not tell them which
+// row. The alternative reading — substitute a plausible value and carry on —
+// produces a journal entry that balances, claims cleanly, and is wrong by an
+// amount nothing downstream can detect. That is the failure this whole module
+// exists to refuse. Compare `resolvePeriodLock`, which makes the same call for
+// the same reason.
+
+import { err, ok, type Result } from 'neverthrow'
+import { type AuxxErrorDetails, UnprocessableEntityError } from '../errors'
+import { getOrganizationSetting } from '../settings/settings-service'
+import { parsePeriodKey } from './periods'
+
+/** The catalog keys this module reads. Nothing else in the read path names them. */
+export const OPENING_BASELINE_SETTING_KEYS = {
+  setupState: 'accounting.setupState',
+  cutoffPeriod: 'accounting.cutoffPeriod',
+  bookTimeZone: 'accounting.bookTimeZone',
+  inventory_raw_materials: 'accounting.openingRawMaterials',
+  inventory_wip: 'accounting.openingWip',
+  inventory_finished_goods: 'accounting.openingFinishedGoods',
+} as const
+
+/** The value `accounting.setupState` must hold before anything may post. */
+export const FINALIZED_SETUP_STATE = 'finalized' as const
+
+/**
+ * The frozen opening position the first month-end entry is measured against.
+ *
+ * Every field is required. There is no partial baseline: a cutoff with no
+ * timezone cannot derive a period key, and a timezone with no balances has
+ * nothing to subtract from.
+ */
+export interface OpeningBaseline {
+  /** The last month closed in the previous system, `'2026-12'`. Always a MONTH key. */
+  cutoffPeriod: string
+  /** The IANA zone period keys are derived in. Never defaulted to UTC. */
+  bookTimeZone: string
+  /**
+   * Opening balances in integer minor units, keyed by the same account roles the
+   * month-end entry asserts. `0` is a legitimate value and is NOT interchangeable
+   * with "unset" — an organization with no work in process at cutover has exactly
+   * zero WIP, and a reader that collapsed the two would silently value the first
+   * entry against a baseline nobody supplied.
+   */
+  balances: {
+    inventory_raw_materials: number
+    inventory_wip: number
+    inventory_finished_goods: number
+  }
+}
+
+/**
+ * Read and validate one organization's frozen opening baseline.
+ *
+ * ## Where the values come from: the org settings cache
+ *
+ * This reads the SAME cached path every other consumer of these settings uses.
+ * `getOrganizationSetting` with no `db` argument answers from
+ * `getOrgCache().get(orgId, 'orgSettings')` (`settings-service.ts:171-174`),
+ * which already merges catalog defaults over the persisted org rows. There is no
+ * transaction here and no row lock.
+ *
+ * ⚠️ Do NOT substitute `getAllOrganizationSettings`. Despite the name it never
+ * takes the cached path — it always queries `OrganizationSetting` directly
+ * (`settings-service.ts:187`). Six cached single-key reads are the cached path;
+ * one "read them all" call is not.
+ *
+ * ### The cache is busted by the thing that writes it
+ *
+ * `apps/web/src/server/api/routers/setting.ts` fires
+ * `onCacheEvent('org.settings.changed', { orgId, broadcastUserKeys: true })`
+ * after BOTH write paths — the single-key `update` (line 134) and the batch
+ * `batchUpdate` (line 221) — and `cache/invalidation-graph.ts:250` maps that
+ * event to `org: ['orgSettings']`. So the accounting setup wizard, which posts
+ * its values through those router mutations, drops this key on every save. The
+ * baseline a close reads is the baseline the wizard last wrote.
+ *
+ * ### 🛑 The invalidation lives in the ROUTER, not in the settings service
+ *
+ * `updateOrganizationSetting` and `batchUpdateOrganizationSettings` fire NO
+ * cache event of their own. Anything that writes one of these keys outside the
+ * tRPC router — a script, a worker job, a seeder, a data migration — MUST fire
+ * `onCacheEvent('org.settings.changed', { orgId })` itself or the org keeps
+ * serving the pre-write value until the key's TTL expires. Existing non-router
+ * writers already do exactly that: `settings/seed-document-business.ts:67` and
+ * `getting-started/mutations.ts:42`. This is the one remaining way a stale
+ * baseline can reach a close, and it is a bug in the writer, not here.
+ *
+ * ### Why the residual race is acceptable
+ *
+ * If a baseline did change underneath a close, the posted entry is still a
+ * permanent record of what it was valued against: the month-end draft carries
+ * `assertions.before` — the exact opening position it measured its delta from —
+ * in its own envelope (`postings/draft.ts`). A later disagreement between that
+ * snapshot and the current settings is therefore DISCOVERABLE by reading the
+ * entry, not silently lost. The ledger is the audit trail; a row lock is not the
+ * only thing that can provide one.
+ *
+ * And this was never a performance question either way: a close runs once a
+ * month, per organization, behind a person clicking Post. Reading it the same
+ * way everything else reads these settings is simply one fewer special case.
+ *
+ * ## What has NOT changed
+ *
+ * Everything below the read. No default, no `0`, no UTC, and every refusal names
+ * the specific rows to fix. See the module header.
+ *
+ * @param organizationId The organization whose baseline is being read.
+ * @returns The validated baseline, or an {@link UnprocessableEntityError} naming
+ * exactly which keys are missing or unusable.
+ */
+export async function readOpeningBaseline(
+  organizationId: string
+): Promise<Result<OpeningBaseline, Error>> {
+  const settings = await readSettings(organizationId)
+
+  const K = OPENING_BASELINE_SETTING_KEYS
+
+  // The setup gate first. A draft baseline is not a broken one — it is one
+  // nobody has finished — and saying so is a different instruction to the
+  // person reading the error than "cutoffPeriod is missing".
+  const setupState = settings[K.setupState]
+  if (setupState !== FINALIZED_SETUP_STATE) {
+    return err(
+      refusal(
+        organizationId,
+        `Accounting setup for this organization is not finalized (${K.setupState} is ` +
+          `${describe(setupState)}, expected "${FINALIZED_SETUP_STATE}"). Complete the ` +
+          'accounting setup before posting. Posting is refused until it is finalized.',
+        { setting: K.setupState, value: describe(setupState) }
+      )
+    )
+  }
+
+  // Then everything that is simply absent, in ONE message. A wizard that was
+  // half-filled is missing several rows and reporting them one refusal at a time
+  // makes the repair take as many attempts as there are blank fields.
+  const missing = (
+    [
+      K.cutoffPeriod,
+      K.bookTimeZone,
+      K.inventory_raw_materials,
+      K.inventory_wip,
+      K.inventory_finished_goods,
+    ] as const
+  ).filter((key) => isUnset(settings[key]))
+
+  if (missing.length > 0) {
+    return err(
+      refusal(
+        organizationId,
+        `The accounting opening baseline for this organization is incomplete. Missing: ` +
+          `${missing.join(', ')}. Set these in accounting setup. There is no default — an ` +
+          'unset opening balance is not zero, and posting against a guess would value a ' +
+          'journal entry that nothing downstream can check.',
+        { missing }
+      )
+    )
+  }
+
+  const cutoffPeriod = validateCutoffPeriod(settings[K.cutoffPeriod])
+  if (typeof cutoffPeriod !== 'string') {
+    return err(refusal(organizationId, cutoffPeriod.message, cutoffPeriod.meta))
+  }
+
+  const bookTimeZone = validateTimeZone(settings[K.bookTimeZone])
+  if (typeof bookTimeZone !== 'string') {
+    return err(refusal(organizationId, bookTimeZone.message, bookTimeZone.meta))
+  }
+
+  const roles = ['inventory_raw_materials', 'inventory_wip', 'inventory_finished_goods'] as const
+  const balances = {} as OpeningBaseline['balances']
+  for (const role of roles) {
+    const amount = validateMinorUnits(K[role], settings[K[role]])
+    if (typeof amount !== 'number') {
+      return err(refusal(organizationId, amount.message, amount.meta))
+    }
+    balances[role] = amount
+  }
+
+  return ok({ cutoffPeriod, bookTimeZone, balances })
+}
+
+// ── The read ───────────────────────────────────────────────────────────────
+
+/**
+ * The six catalog keys, one cached lookup each.
+ *
+ * 🛑 No `db` argument, deliberately. `getOrganizationSetting` only answers from
+ * `getOrgCache().get(orgId, 'orgSettings')` when `db` is omitted; supplying one
+ * — a `Database` or a `Transaction` — switches it to a direct
+ * `OrganizationSetting` query (`settings-service.ts:156-169`). So the ABSENCE of
+ * that argument is what makes this the cached path, which is exactly the kind of
+ * thing a later refactor adds back without noticing. The test asserts it.
+ *
+ * The cache map already merges catalog defaults over the persisted rows, and the
+ * defaults for five of these six keys are `null` — which is what every
+ * fail-closed check below is written against. `accounting.setupState` defaults to
+ * `'draft'`, which the setup gate refuses.
+ */
+async function readSettings(organizationId: string): Promise<Record<string, unknown>> {
+  const keys = Object.values(OPENING_BASELINE_SETTING_KEYS)
+  const values = await Promise.all(
+    keys.map((key) => getOrganizationSetting({ organizationId, key }))
+  )
+  return Object.fromEntries(keys.map((key, index) => [key, values[index]]))
+}
+
+// ── Validation ─────────────────────────────────────────────────────────────
+
+/** A validation failure carrying the message and metadata its refusal needs. */
+interface Invalid {
+  message: string
+  meta: AuxxErrorDetails
+}
+
+/**
+ * Unset, cleared, or whitespace. A settings form that clears a text input writes
+ * `''` rather than deleting the row, so both spellings of "nobody filled this
+ * in" have to land in the same place — and `0` is emphatically NOT one of them.
+ */
+function isUnset(value: unknown): boolean {
+  if (value == null) return true
+  return typeof value === 'string' && value.trim().length === 0
+}
+
+/**
+ * The cutoff must be a MONTH key. `parsePeriodKey` owns the keyspace so the
+ * pattern is not duplicated here, but it also accepts a DAY key, which this
+ * setting must not: the cutoff divides "covered by the opening balances" from
+ * "valued by the subledger", and that boundary is a month boundary. Silently
+ * picking one edge of a day key is the fail-open reading in a different costume.
+ */
+function validateCutoffPeriod(raw: unknown): string | Invalid {
+  const key = OPENING_BASELINE_SETTING_KEYS.cutoffPeriod
+  if (typeof raw !== 'string') {
+    return {
+      message:
+        `The accounting cutoff period for this organization is not a month: ${describe(raw)}. ` +
+        `Set ${key} to a YYYY-MM month.`,
+      meta: { setting: key, value: describe(raw) },
+    }
+  }
+
+  const trimmed = raw.trim()
+  let granularity: string
+  try {
+    granularity = parsePeriodKey(trimmed).granularity
+  } catch {
+    return {
+      message:
+        `The accounting cutoff period for this organization is not a valid month: ` +
+        `"${trimmed}". Set ${key} to a YYYY-MM month.`,
+      meta: { setting: key, value: trimmed },
+    }
+  }
+
+  if (granularity !== 'month') {
+    return {
+      message:
+        `The accounting cutoff period for this organization is a date, not a month: ` +
+        `"${trimmed}". The cutoff divides accounting months. Set ${key} to YYYY-MM.`,
+      meta: { setting: key, value: trimmed },
+    }
+  }
+
+  return trimmed
+}
+
+/**
+ * The book timezone must be a real IANA zone.
+ *
+ * There is no allowlist to check against and no zone database in the runtime we
+ * can enumerate, so the validation is the one the platform already performs:
+ * `Intl.DateTimeFormat` throws `RangeError` on an unrecognised `timeZone`. That
+ * is exactly the call `periodKeyForDate` will make later, so validating with it
+ * here means a value that passes cannot fail there.
+ *
+ * 🛑 No UTC fallback. `periodKeyForDate` defaults to UTC because its callers
+ * have already normalized; this value IS the normalization. A receipt logged at
+ * 7pm on January 31 in `America/New_York` is already February 1 in UTC, so an
+ * assumed zone posts a month's edge activity into the wrong period — invisible
+ * except at a close, and uncorrectable once the period is locked.
+ */
+function validateTimeZone(raw: unknown): string | Invalid {
+  const key = OPENING_BASELINE_SETTING_KEYS.bookTimeZone
+  if (typeof raw !== 'string') {
+    return {
+      message:
+        `The book timezone for this organization is not a timezone name: ${describe(raw)}. ` +
+        `Set ${key} to an IANA zone such as America/New_York.`,
+      meta: { setting: key, value: describe(raw) },
+    }
+  }
+
+  const trimmed = raw.trim()
+  try {
+    new Intl.DateTimeFormat('en-CA', { timeZone: trimmed })
+  } catch {
+    return {
+      message:
+        `The book timezone for this organization is not a recognised IANA zone: ` +
+        `"${trimmed}". Set ${key} to a zone such as America/New_York. Periods are refused ` +
+        'rather than derived in UTC, because a wrong zone posts month-edge activity into ' +
+        'the wrong month.',
+      meta: { setting: key, value: trimmed },
+    }
+  }
+
+  return trimmed
+}
+
+/**
+ * An opening balance is an integer count of minor units.
+ *
+ * The catalog cannot enforce this: `normalizeSettingValue` routes `CURRENCY`
+ * through `fieldValueSchemas.number`, which rejects only a non-finite number, so
+ * `12.5` reaches storage happily. A fractional cent then propagates into a
+ * posted entry's line amounts, where it is either silently rounded by whoever
+ * touches it next or breaks the balance assertion in a way that points at the
+ * wrong module. Refusing here is a one-row repair.
+ */
+function validateMinorUnits(key: string, raw: unknown): number | Invalid {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    return {
+      message:
+        `The opening balance ${key} for this organization is not a number: ${describe(raw)}. ` +
+        'Set it to an amount in integer minor units.',
+      meta: { setting: key, value: describe(raw) },
+    }
+  }
+
+  if (!Number.isInteger(raw)) {
+    return {
+      message:
+        `The opening balance ${key} for this organization is ${raw}, which is not a whole ` +
+        'number of minor units. Opening balances are integer minor units (cents), not ' +
+        'fractional currency.',
+      meta: { setting: key, value: describe(raw) },
+    }
+  }
+
+  return raw
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function refusal(
+  organizationId: string,
+  message: string,
+  meta: AuxxErrorDetails
+): UnprocessableEntityError {
+  return new UnprocessableEntityError(message, { organizationId, ...meta })
+}
+
+/** A stored value, described for an error message without dumping a blob into it. */
+function describe(value: unknown): string {
+  if (value === null) return 'unset'
+  if (value === undefined) return 'unset'
+  if (typeof value === 'string') return `"${value}"`
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return `a ${Array.isArray(value) ? 'list' : typeof value}`
+}

--- a/packages/lib/src/postings/post-entry.ts
+++ b/packages/lib/src/postings/post-entry.ts
@@ -38,9 +38,11 @@
 import { createHash } from 'node:crypto'
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { formatCurrency } from '@auxx/utils'
 import { and, eq, sql } from 'drizzle-orm'
 import { databaseErrorCodes, UnprocessableEntityError } from '../errors'
 import { buildDocNumber } from './doc-number'
+import { buildPostingDraft, type PostingAssertions, requiresAssertions } from './draft'
 import { assertPeriodOpen, type PeriodLock, parsePeriodKey } from './periods'
 import { resolveAccountingProvider } from './provider'
 import { resolveRoles } from './resolve-roles'
@@ -76,11 +78,17 @@ export const LEDGER_CURRENCY = 'USD'
  */
 const REQUEST_ID_MAX_LENGTH = 50
 
-const MONEY = new Intl.NumberFormat('en-US', { style: 'currency', currency: LEDGER_CURRENCY })
-
-/** Minor units to a string a bookkeeper reads - `1234000` -> `$12,340.00`. */
+/**
+ * Minor units to a string a bookkeeper reads - `1234000` -> `$12,340.00`.
+ *
+ * Delegates to `@auxx/utils`'s `formatCurrency` rather than dividing by 100
+ * here. The local version hardcoded a two-decimal scale, which is right for USD
+ * and wrong for JPY (0) and KWD (3) - latent rather than live only because
+ * {@link LEDGER_CURRENCY} pins the ledger to USD for the cutover. When that
+ * pin comes off, this is one of the places that would have been silently wrong.
+ */
 function formatMinor(minor: number): string {
-  return MONEY.format(minor / 100)
+  return formatCurrency(minor, { currencyCode: LEDGER_CURRENCY })
 }
 
 export interface PostEntryOptions {
@@ -102,6 +110,22 @@ export interface PostEntryOptions {
    */
   reversesId?: string
   revision?: number
+  /**
+   * Balance assertions recorded on the draft envelope.
+   *
+   * 🛑 **Required for every posting type {@link requiresAssertions} names**, and
+   * refused as a `data` failure when absent. `month_end_inventory` ASSERTS a
+   * balance rather than accumulating one, so the next month's entry is
+   * computable only from what this one recorded - a month-end posting written
+   * without them silently ends the chain, and the next close reads its delta
+   * from nothing. That entry balances perfectly, which is why the check is here
+   * and not left to a reviewer.
+   *
+   * Typed, not a loose `Record`: the poster stays generic because
+   * {@link PostingAssertions} is discriminated on `kind`, not because the field
+   * is untyped.
+   */
+  assertions?: PostingAssertions
 }
 
 export interface PreviewEntryOptions {
@@ -419,10 +443,25 @@ export async function previewEntry(
  *    cannot be two statements.
  */
 export async function postEntry(db: Database, options: PostEntryOptions): Promise<PostResult> {
-  const { organizationId, entry, actorUserId, memo, lock, reversesId } = options
+  const { organizationId, entry, actorUserId, memo, lock, reversesId, assertions } = options
   const revision = options.revision ?? 0
 
   try {
+    // Fail CLOSED before the claim, not after. A `month_end_inventory` row
+    // written with no assertions holds the period - so no later run can repair
+    // it - while leaving the next close nothing to compute its delta from.
+    if (requiresAssertions(entry.postingType) && !assertions) {
+      return {
+        status: 'error',
+        failureClass: 'data',
+        retryable: false,
+        error:
+          `A ${entry.postingType} posting must carry balance assertions. ` +
+          'It asserts a balance rather than accumulating one, so the next period reads ' +
+          'its opening figures from this entry and there would be nothing to read.',
+      }
+    }
+
     // `GlPosting_reversal_check` is `(revision = 0 AND reversesId IS NULL) OR
     // (revision > 0 AND reversesId IS NOT NULL)`. Caught here so the caller
     // gets a sentence instead of a constraint name.
@@ -481,6 +520,7 @@ export async function postEntry(db: Database, options: PostEntryOptions): Promis
         lines,
         memo,
         actorUserId,
+        assertions,
       })
     } catch (error) {
       // 🛑 `ON CONFLICT (organizationId, postingType, periodKey, revision) DO
@@ -728,6 +768,7 @@ async function claimPeriod(
     lines: PreparedLine[]
     memo?: string
     actorUserId?: string
+    assertions?: PostingAssertions
   }
 ): Promise<ClaimOutcome> {
   const { organizationId, entry, revision, reversesId, docNumber, requestId, totalMinor, lines } =
@@ -751,8 +792,10 @@ async function claimPeriod(
         // the resolved lines, not a hint for reconstructing them: rebuilding
         // from the subledger later gives a different answer once the subledger
         // moves, which is the one property a ledger must not have.
-        draft: {
-          v: 1,
+        // One construction site, in `draft.ts`, because this shape is no longer
+        // written-and-never-read: the L1 month-end reader reads the previous
+        // month's envelope to learn what balance was last asserted.
+        draft: buildPostingDraft({
           docNumber,
           revision,
           memo: input.memo,
@@ -761,7 +804,8 @@ async function claimPeriod(
             accountRole: line.accountRole,
             ...line.resolved,
           })),
-        },
+          assertions: input.assertions,
+        }),
         requestId,
         // A reversal names its original in the INSERT. `GlPosting_reversal_check`
         // makes inserting-then-linking impossible.

--- a/packages/lib/src/postings/reverse-entry.ts
+++ b/packages/lib/src/postings/reverse-entry.ts
@@ -27,6 +27,7 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, eq } from 'drizzle-orm'
 import { buildEntry } from './build-entry'
+import { parsePostingDraft, requiresAssertions, reverseAssertions } from './draft'
 import type { PeriodLock } from './periods'
 import { postEntry } from './post-entry'
 import { resolveRoles } from './resolve-roles'
@@ -92,6 +93,7 @@ export async function reverseEntry(
         revision: schema.GlPosting.revision,
         status: schema.GlPosting.status,
         docNumber: schema.GlPosting.docNumber,
+        draft: schema.GlPosting.draft,
       })
       .from(schema.GlPosting)
       .where(
@@ -217,6 +219,28 @@ export async function reverseEntry(
       lines: reversedLines,
     })
 
+    // ── The assertions, swapped ────────────────────────────────────────────
+    // A posting that ASSERTS a balance (month-end inventory) records the state
+    // on either side of itself. Its reversal asserts the same pair the other way
+    // round, so the next period's prior-row read lands on the state that existed
+    // before the original - and reversing the reversal swaps back.
+    //
+    // 🛑 Read from the FROZEN draft, never recomputed from today's subledger.
+    // Re-running the month-end reader here would pick up movements that arrived
+    // after the original posted, and the reversal would assert figures unrelated
+    // to the lines it is backing out.
+    //
+    // Parsed ONLY for a type that requires assertions. A receipt or vendor-bill
+    // posting has none to carry, so its draft is irrelevant to the reversal -
+    // and `parsePostingDraft` is strict on purpose, so parsing one anyway would
+    // let an old or hand-written envelope block a reversal that does not depend
+    // on it. Where assertions ARE required, a draft that will not parse is
+    // fatal: writing the reversal without them would silently break the chain
+    // the next close reads its opening figures from.
+    const originalAssertions = requiresAssertions(original.postingType as PostingType)
+      ? parsePostingDraft(original.draft).assertions
+      : undefined
+
     logger.info('Reversing posting', {
       organizationId,
       glPostingId: original.id,
@@ -228,6 +252,7 @@ export async function reverseEntry(
     return await postEntry(db, {
       organizationId,
       entry,
+      assertions: originalAssertions ? reverseAssertions(originalAssertions) : undefined,
       actorUserId,
       memo: memo ?? `Reversal of ${original.docNumber}`,
       lock,

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -855,6 +855,242 @@ export const SETTINGS_CATALOG = {
       'Postings into that month or earlier are refused. Unset = nothing is closed.',
   },
 
+  // ── Accounting setup / opening baseline (plans/money/tasks/12-accounting-setup.md §2) ───
+  //
+  // The opening baseline every organization needs before it can close its first
+  // month. Task 12 builds the wizard that WRITES these; `postings/opening-baseline.ts`
+  // is the reader that consumes them.
+  //
+  // Flat scalar keys, NOT one `JSON` blob. `fieldType: 'JSON'` exists, but its
+  // users are the `sidebar.*` keys — UI-state blobs written by code, not forms.
+  // This is a form, so its precedent is `documents.invoice.*` and
+  // `manufacturing.*`: sibling scalars get `normalizeSettingValue` validation and
+  // `SettingsFieldRow` rendering for free, and the catalog stays the schema of
+  // record instead of a hand-rolled `v:` field.
+  //
+  // Scoped GENERAL, following the `manufacturing.*` precedent above: there is no
+  // ACCOUNTING value in the `SettingScope` pg enum (`_shared.ts:520` — thirteen
+  // values, none of them) and adding one is a Drizzle migration this phase
+  // deliberately does not carry.
+  //
+  // 🛑 Every value below ships NULL except `setupState`. A null opening balance
+  // means "not configured" and must never collapse to `0` — `0` is a legitimate
+  // opening balance (a business with no WIP at cutover has exactly that), so the
+  // two readings are not interchangeable. This is the same rule
+  // `loadAbsorptionRates` follows for the absorption rates, and for the same
+  // reason: a null read as zero absorbs nothing while looking like it worked.
+  // `readOpeningBaseline` fails CLOSED on a null rather than defaulting.
+  //
+  // ⚠️ `CURRENCY` values here are integer MINOR units, and the catalog cannot
+  // enforce that: `normalizeSettingValue` routes `CURRENCY` through
+  // `fieldValueSchemas.number`, which only rejects a non-finite number. So
+  // `12.5` would be accepted on write. `readOpeningBaseline` therefore validates
+  // integrality itself on read, the same way `resolvePeriodLock` validates the
+  // `TEXT` period lock the catalog cannot pattern-check.
+
+  // 🛑 THE GATE ON THE WHOLE BASELINE. `readOpeningBaseline` refuses unless this
+  // reads `finalized`, so a half-filled wizard cannot value a journal entry.
+  //
+  // The opening baseline and book timezone also freeze at the first accounting
+  // claim, because changing either rewrites the arithmetic behind an entry that
+  // has already posted. That gate is an ordinary "does a posting exist" check,
+  // NOT a row lock — an earlier design took `SELECT … FOR UPDATE` on this row
+  // inside the posting transaction and it was dropped deliberately. It is
+  // technically race-able and the race is accepted: it needs two actors inside
+  // the same few hundred milliseconds of a once-a-month operation, and the
+  // claimed entry records the baseline it actually used in `assertions.before`
+  // on its draft envelope, so the outcome is discoverable in the ledger rather
+  // than silent. The ledger is the audit trail; a lock is not the only thing
+  // that can be one.
+  'accounting.setupState': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'SINGLE_SELECT',
+    // The only key with a non-null default: an organization that has never
+    // opened the wizard is genuinely in `draft`, and every posting path refuses
+    // until it says `finalized`.
+    defaultValue: 'draft',
+    options: {
+      options: [
+        { value: 'draft', label: 'Draft' },
+        { value: 'finalized', label: 'Finalized' },
+      ],
+    },
+    description:
+      'Whether the accounting opening baseline has been finalized. Postings are refused ' +
+      'while it is draft. Posting is refused until this reads finalized.',
+  },
+  // Parsed by `postings/periods.ts`'s `parsePeriodKey` and required to be a
+  // MONTH key. As with `ledger.lockedThroughMonth`, there is no pattern
+  // validation on a `TEXT` setting — `FieldOptions` has no such member — so the
+  // shape is validated on read, and fails closed.
+  'accounting.cutoffPeriod': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'TEXT',
+    defaultValue: null,
+    description:
+      'The last month closed in the previous accounting system, YYYY-MM. Subledger activity ' +
+      'after it values the general ledger; the opening balances cover everything before it.',
+  },
+  // 🛑 NO UTC FALLBACK. `periodKeyForDate` defaults to UTC because its callers
+  // have already normalized; this setting has no such caller. A receipt logged
+  // at 7pm on January 31 in `America/New_York` is already February 1 in UTC, so
+  // an org whose zone was quietly assumed posts a month's edge activity into the
+  // wrong period — invisible except at a close, and uncorrectable once the
+  // period is locked. Unset fails closed.
+  'accounting.bookTimeZone': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'TEXT',
+    defaultValue: null,
+    description:
+      'The IANA timezone the books are kept in, e.g. America/New_York. Period keys are ' +
+      'derived in it. Unset refuses to post rather than assuming UTC.',
+  },
+
+  // The frozen auxx.ai snapshot: the December 31 physical count valued at
+  // CPA-approved costs. This is the valuation layer that intentionally uncosted
+  // historical movements cannot supply, and it is what `readOpeningBaseline`
+  // returns. Integer minor units.
+  'accounting.openingRawMaterials': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CURRENCY',
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    defaultValue: null,
+    description:
+      'Opening 1310 Raw Materials balance at the cutoff, integer minor units, from the ' +
+      'December 31 physical count at CPA-approved costs. Unset = not configured, not zero.',
+  },
+  'accounting.openingWip': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CURRENCY',
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    defaultValue: null,
+    description:
+      'Opening 1320 Work in Process balance at the cutoff, integer minor units. Typically 0 ' +
+      'at cutover. Unset = not configured, not zero.',
+  },
+  'accounting.openingFinishedGoods': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CURRENCY',
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    defaultValue: null,
+    description:
+      'Opening 1330 Finished Goods balance at the cutoff, integer minor units, from the ' +
+      'December 31 physical count at CPA-approved costs. Unset = not configured, not zero.',
+  },
+
+  // The provider's side of the same three balances, plus the reference to the
+  // journal entry that booked them there. Existing QuickBooks organizations are
+  // the primary case, so the wizard IMPORTS rather than assumes — and neither
+  // number silently overrides the other. The wizard shows the difference and
+  // refuses to finalize until they agree: a difference falling into January's
+  // balancing plug would classify a cutover problem as January COGS, and the
+  // auxx.ai number alone would let the provider and the subledger disagree
+  // silently from day one.
+  //
+  // ⚠️ These are PROVENANCE. `readOpeningBaseline` deliberately does not read
+  // them — the reconciliation is the wizard's gate, and once it passes there is
+  // one agreed set of balances, which is the `accounting.opening*` set above.
+  'accounting.qboOpeningRawMaterials': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CURRENCY',
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    defaultValue: null,
+    description:
+      "The accounting provider's opening raw-materials balance at the cutoff, integer minor " +
+      'units. Reconciled against the auxx.ai snapshot before setup can be finalized.',
+  },
+  'accounting.qboOpeningWip': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CURRENCY',
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    defaultValue: null,
+    description:
+      "The accounting provider's opening work-in-process balance at the cutoff, integer minor " +
+      'units. Reconciled against the auxx.ai snapshot before setup can be finalized.',
+  },
+  'accounting.qboOpeningFinishedGoods': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CURRENCY',
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    defaultValue: null,
+    description:
+      "The accounting provider's opening finished-goods balance at the cutoff, integer minor " +
+      'units. Reconciled against the auxx.ai snapshot before setup can be finalized.',
+  },
+  // Not a `GlPosting`. The opening entry was built and booked in the provider,
+  // its retained-earnings leg uses an account the default chart deliberately
+  // does not seed, and `month_end_inventory` would be a false posting type for a
+  // zero-line sentinel auxx.ai never posted. So the link is a reference string.
+  'accounting.qboOpeningJournalRef': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'TEXT',
+    defaultValue: null,
+    description:
+      'Reference to the opening journal entry in the accounting provider, for audit trail. ' +
+      'Not an auxx.ai posting — auxx.ai did not book it.',
+  },
+
+  // Who finalized the baseline and when. Written by the wizard's finalize step,
+  // not by a form field.
+  'accounting.setupFinalizedAt': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'DATETIME',
+    defaultValue: null,
+    description:
+      'When the accounting opening baseline was finalized, ISO 8601. Stamped by the wizard; ' +
+      'not a user-facing field.',
+  },
+  'accounting.setupFinalizedByUserId': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'TEXT',
+    defaultValue: null,
+    description:
+      'The user who finalized the accounting opening baseline. Stamped by the wizard; not a ' +
+      'user-facing field.',
+  },
+
   // ── Manufacturing absorption rates (plans/products/build/01-build-plan.md §1.4) ─────────
   //
   // Per-UNIT, not per-hour: the merchant supplies a percentage split of a


### PR DESCRIPTION
Task 09's **arithmetic half**. The reader that gathers real subledger rows (`gatherMonthEndInventoryInputs`) is deliberately not here — everything in this PR is either pure or reads settings, so all of it is exhaustively testable with no database.

Follows #1978 (the poster) and #1977 (the GL foundation).

## What's here

| | |
| --- | --- |
| `postings/draft.ts` | The `GlPosting.draft` envelope as a declared, versioned contract + the reversal swap |
| `postings/build-month-end-inventory.ts` | The pure builder. Six delta legs and a plug |
| `postings/opening-baseline.ts` | Reads and validates the frozen cutover baseline |
| `settings/catalog.ts` | 12 `accounting.*` keys, scope `GENERAL` |
| `postings/post-entry.ts`, `reverse-entry.ts` | Wired to the contract; fails closed without assertions |

## The five decisions worth reviewing

**1. The draft envelope is a contract now, not a literal.** `post-entry.ts` wrote `draft` as an anonymous object inside `claimPeriod`. That was fine while the poster both wrote it and never read it back — the month-end entry reads the *previous* month's envelope to learn what balance was last asserted, which is the number its whole delta comes from. One construction site, one place the version is stamped, and `parsePostingDraft` **throws** rather than let `undefined` flow into arithmetic that decides what a journal entry says.

**2. A reversal swaps `assertions: { before, after }` — it never re-reads the subledger.** The rejected alternative was reconstructing a reversal's figures by re-running the reader for the prior-prior period. That picks up movements which arrived *after* the original posted, so the reversal would assert numbers unrelated to the lines it is backing out. The swap reads only frozen data and is self-inverse at any revision depth (`reverse(reverse(x)) === x` is a test).

`before` is not redundant with the prior row's `after`: it makes the chain testable — row N's `before` must equal row N-1's `after`. Nothing else in the design can detect a broken prior-row selection rule, because **a wrong prior still produces a balanced entry**.

**3. Three lanes, three different sign mappings, and the balance gate cannot check any of them.**

| Lane | Positive delta | Negative delta |
| --- | --- | --- |
| Inventory balance | Debit inventory | Credit inventory |
| Absorption | Credit clearing/overhead | Debit clearing/overhead |
| Count adjustment | Credit 5095 | Debit 5095 |

5000 is the plug, so flipping any one lane's direction is absorbed at twice the error and `buildEntry` returns happily. Both signs of all three lanes are pinned by exact golden tests. That is the only guard there is.

**4. `5000 COGS - Materials` → `COGS - Product Cost`.** The plug holds materials **plus** the labour and overhead embedded in finished goods that shipped — and it cannot be made to hold less. A `stock_movement` freezes one total unit cost with no labour or overhead column, so nothing can say how much of a shipped unit was labour; reconstructing it from the part's *current* standard labour cost would value last month's shipments at this month's rates. `5010 COGS - Direct Labor` stays in the chart with no role, at zero under L1.

**No migration.** Entity migration 108 is `applied` in the local dev ledger and nowhere else, so it is not frozen (task 07's rule, written into `reset-gl-chart.ts`'s header). The dev chart was re-seeded. Verified in Postgres rather than from script output: `cogs_product_cost` × 28 orgs with zero `cogs_materials` remaining, `COGS - Product Cost` × 28.

**5. The opening baseline reads the org settings cache, like everything else.** An earlier design took `SELECT … FOR UPDATE` on `accounting.setupState` inside the posting transaction. Dropped deliberately — the settings router fires `org.settings.changed` on both write paths and `invalidation-graph.ts:250` maps it to `orgSettings`, so the cache is invalidated by the wizard that writes it. And the residual race is *recorded, not lost*: a posted entry stores the baseline it used in `assertions.before`. The ledger is the audit trail; a row lock is not the only thing that can be one.

⚠️ The one real rule is about **writers**: anything setting these keys outside the tRPC router must fire `onCacheEvent('org.settings.changed', { orgId })` itself.

## Two things found along the way

- 🛑 **`CURRENCY` does not validate integers.** `normalizeSettingValue` routes it through `fieldValueSchemas.number`, which is `.pipe(z.number().finite())` — and the schema *coerces numeric strings*, so a form posting `"12.50"` lands as the float `12.5`. `readOpeningBaseline` validates integrality itself. The setup wizard (task 12) must too; nothing on the settings write path will.
- **`post-entry.ts` had its own `formatMinor`** doing `minor / 100`. `@auxx/utils` already exports `formatCurrency`, which derives the scale from the currency code. Two decimals is right for USD and wrong for JPY (0) and KWD (3) — latent only because `LEDGER_CURRENCY` pins the ledger to USD. Now delegates.

  Not fixed here, out of scope: `money/quickbooks/sync-invoice.ts:258` does `amount: lineTotalCents / 100` **at the QuickBooks boundary** with the same hardcoded scale, and `receiving/client.ts:175` hand-rolls `formatCurrency`.

## Testing

- **Full `@auxx/lib` suite green**: 1049 files, **14,276 passed**, 4 skipped (AI provider integration).
- `src/postings` + `src/settings`: **311 tests**, of which ~87 are new.
- Typecheck ratchet: `no new type errors (29 total, baseline 29)`.
- Golden tests are the CPA-facing artifact: the worked August example asserts the exact line set, and `0` is proven to be a legitimate balance distinguishable from unset in three separate places.

## Not in this PR

- `gatherMonthEndInventoryInputs` — the reader. It is the only lane that touches `EntityInstance`-backed movement and build rows, needs an `*.int.test.ts` (excluded from the default vitest config), and carries the post-cutoff fail-closed rule.
- The setup wizard (task 12).
- 🛑 Nothing here can be driven end to end yet: `rollStandardCost` has never been run in any org, so no build can complete and `adjustStock` fails closed too. Correctness rests on the golden tests, which is what `plans/money/tasks/09` §4 asks for — *"the dev DB can prove the code runs; it can never prove the entry is right."*

https://claude.ai/code/session_0129oa1VuSdXQevapg3kLWtU
