### PR TITLE
feat(money): gather the month-end inventory entry's inputs, and guard the regime

### DIFF
--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -533,7 +533,7 @@ build's movements from exploding their own BOM. Update the reasoning, not the co
   Postgres-enforced unique index on `(organizationId, postingType, periodKey, revision)` and an
   `INSERT … ON CONFLICT DO NOTHING` claim. Amounts are `bigint` **integer minor units**;
   `GlPostingLine` has no `updatedAt` and no update path, so its immutability is structural rather
-  than advisory. **0 rows** — nothing writes them yet.
+  than advisory. **`postings/post-entry.ts` writes them** (#1978).
 - **`GlRoleAssignment` Drizzle TABLE** (migration `0353`): `(organizationId, role) -> gl_account`,
   with a Postgres unique index on the pair. This is where a posting role is mapped, and
   `postings/resolve-roles.ts` is the single door that reads it.
@@ -550,8 +550,12 @@ build's movements from exploding their own BOM. Update the reasoning, not the co
   number cannot carry the meaning: a customer renumbering GRNI from `2160` to `2155` would silently
   break every builder that hardcoded it, and the entry would still balance, so nothing downstream
   could detect it.
-- `packages/lib/src/postings/` — `build-entry.ts`, `periods.ts`, `provider.ts`. Pure-ish;
-  persists nothing yet.
+- `packages/lib/src/postings/` — the whole seam. `build-entry.ts`, `periods.ts`, `period-lock.ts`,
+  `provider.ts`, `default-chart.ts`, `resolve-roles.ts`, `doc-number.ts`, `verify-balance.ts`
+  (pure); `post-entry.ts` + `reverse-entry.ts` (the poster and its reversal, #1978);
+  `draft.ts` (the `GlPosting.draft` envelope contract), `opening-baseline.ts`,
+  `build-month-end-inventory.ts` and `gather-month-end-inventory.ts` (the L1 month-end entry,
+  #1979 + this change). See §9.5.
 - Postings are stored as **double-entry lines keyed on an account CODE** (`'2160'`), never a
   provider account id. Provider ids live in `RecordIdentity`, hung off `gl_account` by the app
   that owns them. This is the whole cash value of "the provider is an exporter" (P2).
@@ -624,13 +628,16 @@ that one *is* a `G8` violation and should resolve the `grni` role instead.)
 
 ### 9.2 What is designed and not built
 
-`packages/lib/src/money/gl/` **does not exist**. The builder/poster seam, the fulfillment entry,
-and the close console are all design-only — see `plans/money/design/gap-e/f/g`.
+⚠️ **Corrected 2026-08-28.** This section previously said the builder/poster seam was design-only.
+It is **built** — the seam lives in `packages/lib/src/postings/`, not in a `money/gl/` directory
+that never existed. *Builders are the accounting, the poster is the plumbing*: a builder returns a
+`BuiltEntry` of **posting ROLES** and **integer minor units, always positive, with direction as a
+separate field**; `postEntry` resolves roles to account codes, asserts `Σ Debit === Σ Credit`,
+claims the period and handles idempotency.
 
-The intended seam is *builders are the accounting, the poster is the plumbing*: each builder
-returns a `DraftJournalEntry` of **logical account keys** and **integer minor units, always
-positive, with direction as a separate field**; one poster resolves keys to provider ids,
-asserts `Σ Debit === Σ Credit`, and handles idempotency.
+Still design-only: **the fulfillment entry, the payout entry, the month-end deferral, and the close
+console**. The accounting **setup wizard** that produces the opening baseline §9.5 consumes is also
+unbuilt — see `plans/money/tasks/12-accounting-setup.md`.
 
 ### 9.3 L1 vs L3 — the load-bearing constraint
 
@@ -714,6 +721,66 @@ fails such a write with `22003` — so a month-end close would refuse to post ra
 Caught and widened before either table held a row. Any *new* money column anywhere in this
 subsystem is `bigint` minor units for the same reason; the type is pinned by the structural tests
 in `packages/database/src/tests/gl-posting-schema.test.ts` so it cannot silently regress.
+
+### 9.5 The L1 month-end inventory reader — `gatherMonthEndInventoryInputs`
+
+`postings/gather-month-end-inventory.ts` is the read half of the one entry that turns the
+subledger into the general ledger. `build-month-end-inventory.ts` is the pure arithmetic beside
+it, and the split is the module guide's read/write split: an arithmetic failure is a bug and
+throws, a read failure is a runtime condition and returns a `Result`.
+
+**Two source lanes, and that is a property of the design.** The inventory BALANCES come from the
+movement ledger — Σ signed `stock_movement_extended_cost` grouped by each movement's own frozen
+`stock_movement_gl_account` role. The ABSORPTION totals cannot: a movement freezes a single total
+`unit_cost` and has no labour or overhead column, so the split is not in there to recover.
+`build_labor_cost` / `build_overhead_cost` on the **build** are where it is frozen (§7).
+
+**The window starts at the cutoff, ends at the period end, and is CUMULATIVE.** Never "movements
+in this month". A build dated in January but entered after the January close must show up in the
+next open entry still carrying its own frozen labour and overhead; that only works because both
+lanes sum from the cutoff forward and the builder takes the delta against the prior snapshot.
+
+🛑 **Both boundaries are INSTANTS derived from wall-clock midnights in `accounting.bookTimeZone`.**
+Membership is `stock_movement_occurred_at` and `build_completed_at` — never `createdAt`, which
+records when auxx.ai learned of a row. A receipt logged at 7pm on January 31 in `America/New_York`
+is already February 1 in UTC, so a UTC-derived boundary posts month-edge activity into the wrong
+month: invisible except at a close, and uncorrectable once the period is locked.
+
+🛑 **The NULL-cost rule is DIFFERENT on each side of the cutoff.** Before it, uncosted movements
+are ignored — they predate the costing regime and the opening snapshot replaces that history.
+After it, a movement missing `occurred_at`, `unit_cost`, `extended_cost` or its inventory role
+**fails the close and names itself**. Every sanctioned writer already refuses to write one, so
+such a row came through some other door, and *filtering it produces a balanced entry that
+understates inventory with no signal* — the exact failure the assertion design exists to prevent.
+A movement with no `occurred_at` at all cannot be placed in any period, so the window predicate
+cannot see it; the reader catches it on `EntityInstance.createdAt >= windowStart` instead, which
+is the only use of `createdAt` in the file and is a "recent enough to be a defect?" test rather
+than a period classification.
+
+⚠️ **`stock_movement_adjust_subparts = true` rows are excluded from both the sums and that scan.**
+They are the PARENT of a bill-of-materials explosion; the children carry the real quantities,
+which is why `recalculateQoHForPart` excludes the parent from the quantity ledger too
+(`field-hooks/post/inventory-triggers.ts`). Including them would double-count. The CHILDREN are
+not excluded — `explodeBomMovement` writes them with no cost fields at all, so post-cutoff they
+correctly trip the rule above.
+
+**An `adjust` movement appears in BOTH the balance and the adjustment total.** It moved inventory,
+so it is in the balance; `G12` requires count and shrinkage to be classified into their own role,
+so it is also its own signed total. The adjustment total is never subtracted out of the balance —
+the builder emits them as separate legs and the 5000 plug absorbs the difference.
+
+**Build reversals are NOT filtered.** `reverse-build.ts` writes a *negated* `build_labor_cost` on
+a second build row, so a cumulative sum nets a reversal out on its own. Filtering would leave the
+original's absorption in the total and remove the correction that cancels it.
+
+**The prior-row rule is exact:** the `posted` `month_end_inventory` row with the greatest
+`periodKey` strictly before this period, then the greatest `revision` in that period, and its
+draft's `assertions.after` is the prior snapshot. The original of a reversal pair is `reversed`
+and drops out. At cutover there is no such row and the frozen opening baseline stands in with
+all-zero activity totals — never a synthetic `GlPosting`, never zero balances. 🛑 A prior row whose
+draft carries **no** assertions is a corrupt chain and fails the close naming the document; falling
+back to the baseline there would silently restate every month since the cutoff into one entry that
+balances perfectly.
 
 ---
 

--- a/packages/lib/src/postings/__tests__/gather-month-end-inventory.int.test.ts
+++ b/packages/lib/src/postings/__tests__/gather-month-end-inventory.int.test.ts
@@ -1,0 +1,695 @@
+// packages/lib/src/postings/__tests__/gather-month-end-inventory.int.test.ts
+//
+// DB-backed tests (vitest.integration.config.ts -> auxx_test) for the claims the
+// unit test structurally cannot make.
+//
+// `gather-month-end-inventory.test.ts` fakes the database, so it can prove the
+// SHAPE of every query and the arithmetic that consumes the rows — and nothing
+// about whether those queries actually select the rows they are supposed to.
+// Four of this reader's rules live entirely in SQL:
+//
+//   1. **The window.** Movements before the cutoff are excluded and movements
+//      after it are included, with the boundary interpreted in the BOOK
+//      timezone — so a movement one hour either side of a month edge under a
+//      non-UTC zone lands in the right month. This is the one test that proves
+//      rule B end to end.
+//   2. **Rule A.** A post-cutoff movement with a NULL cost fails the close and
+//      names itself, rather than being silently dropped by a join.
+//   3. **A build reversal nets out WITHOUT being filtered.** `reverseBuild`
+//      writes a NEGATED `build_labor_cost` on a second row, so the cumulative
+//      sum cancels it on its own; a filter would leave the original's absorption
+//      in the total and remove the correction.
+//   4. **An `adjust` movement appears in BOTH the balance and the adjustment
+//      total.** It is a separate total, never a subtraction.
+//
+// 🛑 `packages/lib/vitest.config.ts` EXCLUDES `*.int.test.*`, so a green package
+// suite is not evidence any of this ran. `pnpm -F @auxx/lib test:integration`.
+//
+// Rows are inserted directly as `EntityInstance` + `FieldValue` rather than
+// through `receiveStock` / `completeBuild`, deliberately: half of what is under
+// test here is what happens to rows the sanctioned writers REFUSE to write (a
+// NULL cost) or cannot be made to write on demand (an exact `occurred_at` on a
+// month boundary in a named zone). The fixture is the input; the reader is the
+// thing under test.
+
+import { type Database, schema } from '@auxx/database'
+import { getTestDb } from '@auxx/test-utils'
+import { and, eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type BuildFixture, seedBuildOrg } from '../../builds/__tests__/support/build-fixture'
+import { getOrgCache } from '../../cache'
+import { buildPostingDraft, type MonthEndInventorySnapshot } from '../draft'
+import { gatherMonthEndInventoryInputs } from '../gather-month-end-inventory'
+import { OPENING_BASELINE_SETTING_KEYS } from '../opening-baseline'
+
+const db = () => getTestDb() as unknown as Database
+
+// The two queue-backed externals, mocked off. `seedBuildOrg` writes parts and
+// subparts through `UnifiedCrudHandler`, whose interactive lane AWAITS
+// `publisher.publishLater` — a BullMQ write that never settles against an
+// unreachable Redis. Same reason, same shape, as
+// `builds/__tests__/complete-build-transaction.int.test.ts`.
+vi.mock('../../events/publisher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, publisher: { publish: async () => {}, publishLater: async () => {} } }
+})
+
+vi.mock('../../dedup/enqueue-scan', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../dedup/enqueue-scan')>()
+  return { ...actual, enqueueDuplicateScan: async () => {} }
+})
+
+const K = OPENING_BASELINE_SETTING_KEYS
+
+/** Cutoff December 2026, books kept in New York — UTC-5 in winter, UTC-4 in summer. */
+const CUTOFF = '2026-12'
+const ZONE = 'America/New_York'
+
+const OPENING = {
+  inventory_raw_materials: 125_000,
+  inventory_wip: 0,
+  inventory_finished_goods: 480_050,
+}
+
+let f: BuildFixture
+
+// ── Fixture helpers ──────────────────────────────────────────────────────────
+
+/** `systemAttribute` -> `CustomField.id`, straight off the org cache. */
+async function fieldId(attribute: string): Promise<string> {
+  const fields = await getOrgCache()
+    .from(f.organizationId, 'customFields')
+    .bySystemAttributes([attribute] as never)
+  const field = (fields as Record<string, { id: string } | null>)[attribute]
+  if (!field) throw new Error(`no CustomField for ${attribute}`)
+  return field.id
+}
+
+/** Finalize the accounting setup for the seeded org, and drop the settings cache. */
+async function finalizeAccountingSetup(overrides: Record<string, unknown> = {}): Promise<void> {
+  const values: Record<string, unknown> = {
+    [K.setupState]: 'finalized',
+    [K.cutoffPeriod]: CUTOFF,
+    [K.bookTimeZone]: ZONE,
+    [K.inventory_raw_materials]: OPENING.inventory_raw_materials,
+    [K.inventory_wip]: OPENING.inventory_wip,
+    [K.inventory_finished_goods]: OPENING.inventory_finished_goods,
+    ...overrides,
+  }
+
+  const now = new Date()
+  for (const [key, value] of Object.entries(values)) {
+    await db()
+      .insert(schema.OrganizationSetting)
+      .values({ organizationId: f.organizationId, key, value, scope: 'GENERAL', updatedAt: now })
+  }
+
+  // 🛑 `readOpeningBaseline` reads through `getOrgCache().get(org, 'orgSettings')`
+  // — the same cached path every other consumer uses — so a direct table insert
+  // is invisible to it until the key is dropped. In production the settings
+  // router fires `org.settings.changed`; here the write is the test's own.
+  await getOrgCache().invalidateAndRecompute(f.organizationId, ['orgSettings'])
+}
+
+interface MovementSpec {
+  /** `stock_movement_occurred_at`. Omit to write a movement with no accounting date. */
+  occurredAt?: Date
+  type?: string
+  unitCost?: number | null
+  extendedCost?: number | null
+  glAccount?: string | null
+  /** `EntityInstance.createdAt`. Defaults to `occurredAt`, else long before the cutoff. */
+  createdAt?: Date
+  adjustSubparts?: boolean
+}
+
+/** Write one `stock_movement` row directly. Returns its instance id. */
+async function insertMovement(spec: MovementSpec): Promise<string> {
+  const createdAt = spec.createdAt ?? spec.occurredAt ?? new Date('2020-01-01T00:00:00.000Z')
+
+  const [instance] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: f.organizationId,
+      entityDefinitionId: f.movementDefId,
+      displayName: 'movement',
+      createdAt,
+      updatedAt: createdAt,
+    })
+    .returning({ id: schema.EntityInstance.id })
+
+  const entityId = (instance as { id: string }).id
+
+  const write = async (attribute: string, value: Record<string, unknown>) => {
+    await db()
+      .insert(schema.FieldValue)
+      .values({
+        organizationId: f.organizationId,
+        entityId,
+        entityDefinitionId: f.movementDefId,
+        fieldId: await fieldId(attribute),
+        updatedAt: createdAt,
+        ...value,
+      })
+  }
+
+  await write('stock_movement_part', { relatedEntityId: f.componentPartIds[0] as string })
+  await write('stock_movement_type', { optionId: spec.type ?? 'receive' })
+  await write('stock_movement_quantity', { valueNumber: 1 })
+  if (spec.occurredAt) {
+    await write('stock_movement_occurred_at', { valueDate: spec.occurredAt.toISOString() })
+  }
+  if (spec.unitCost !== null) {
+    await write('stock_movement_unit_cost', { valueNumber: spec.unitCost ?? 100 })
+  }
+  if (spec.extendedCost !== null) {
+    await write('stock_movement_extended_cost', { valueNumber: spec.extendedCost ?? 100 })
+  }
+  if (spec.glAccount !== null) {
+    await write('stock_movement_gl_account', {
+      valueText: spec.glAccount ?? 'inventory_raw_materials',
+    })
+  }
+  if (spec.adjustSubparts !== undefined) {
+    await write('stock_movement_adjust_subparts', { valueBoolean: spec.adjustSubparts })
+  }
+
+  return entityId
+}
+
+/** Write one completed `build` row directly. Returns its instance id. */
+async function insertBuild(spec: {
+  completedAt: Date
+  laborCost: number
+  overheadCost: number
+}): Promise<string> {
+  const [instance] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: f.organizationId,
+      entityDefinitionId: f.buildDefId,
+      displayName: 'build',
+      createdAt: spec.completedAt,
+      updatedAt: spec.completedAt,
+    })
+    .returning({ id: schema.EntityInstance.id })
+
+  const entityId = (instance as { id: string }).id
+
+  const write = async (attribute: string, value: Record<string, unknown>) => {
+    await db()
+      .insert(schema.FieldValue)
+      .values({
+        organizationId: f.organizationId,
+        entityId,
+        entityDefinitionId: f.buildDefId,
+        fieldId: await fieldId(attribute),
+        updatedAt: spec.completedAt,
+        ...value,
+      })
+  }
+
+  await write('build_status', { optionId: 'completed' })
+  await write('build_completed_at', { valueDate: spec.completedAt.toISOString() })
+  await write('build_labor_cost', { valueNumber: spec.laborCost })
+  await write('build_overhead_cost', { valueNumber: spec.overheadCost })
+
+  return entityId
+}
+
+async function gather(periodKey: string) {
+  return gatherMonthEndInventoryInputs(db(), f.organizationId, periodKey)
+}
+
+beforeEach(async () => {
+  f = await seedBuildOrg({ components: 1 })
+  await finalizeAccountingSetup()
+})
+
+// ── The window ───────────────────────────────────────────────────────────────
+
+describe('the cumulative window starts at the cutoff', () => {
+  it('excludes movements before the cutoff and includes movements after it', async () => {
+    // Pre-cutoff history. The frozen opening snapshot replaces it entirely, so
+    // summing it would double-count everything the wizard already counted.
+    await insertMovement({
+      occurredAt: new Date('2026-11-15T12:00:00.000Z'),
+      extendedCost: 999_999,
+    })
+    await insertMovement({
+      occurredAt: new Date('2026-12-31T12:00:00.000Z'),
+      extendedCost: 888_888,
+    })
+    // After the cutoff.
+    await insertMovement({ occurredAt: new Date('2027-01-15T12:00:00.000Z'), extendedCost: 25_000 })
+
+    const inputs = (await gather('2027-01'))._unsafeUnwrap()
+
+    expect(inputs.current.balances.inventory_raw_materials).toBe(
+      OPENING.inventory_raw_materials + 25_000
+    )
+  })
+
+  it('is CUMULATIVE — a later month still carries every movement since the cutoff', async () => {
+    await insertMovement({ occurredAt: new Date('2027-01-15T12:00:00.000Z'), extendedCost: 25_000 })
+    await insertMovement({ occurredAt: new Date('2027-02-15T12:00:00.000Z'), extendedCost: 10_000 })
+    await insertMovement({ occurredAt: new Date('2027-03-15T12:00:00.000Z'), extendedCost: 1_000 })
+
+    const february = (await gather('2027-02'))._unsafeUnwrap()
+    // Not "movements in February" — everything from the cutoff through the end
+    // of February. That is what lets a backdated row appear in the next open
+    // entry carrying its own classification.
+    expect(february.current.balances.inventory_raw_materials).toBe(
+      OPENING.inventory_raw_materials + 35_000
+    )
+  })
+
+  it('excludes an archived movement', async () => {
+    const movementId = await insertMovement({
+      occurredAt: new Date('2027-01-15T12:00:00.000Z'),
+      extendedCost: 25_000,
+    })
+    await db()
+      .update(schema.EntityInstance)
+      .set({ archivedAt: new Date() })
+      .where(eq(schema.EntityInstance.id, movementId))
+
+    const inputs = (await gather('2027-01'))._unsafeUnwrap()
+    expect(inputs.current.balances.inventory_raw_materials).toBe(OPENING.inventory_raw_materials)
+  })
+})
+
+describe('🛑 rule B — a boundary movement lands in the right month, in the BOOK timezone', () => {
+  // 7pm on January 31 in New York is 00:00 on February 1 in UTC. A reader that
+  // derived the boundary in UTC posts this receipt into February — invisible
+  // except at a close, and uncorrectable once January is locked.
+  const LATE_ON_JANUARY_31 = new Date('2027-02-01T00:00:00.000Z')
+
+  beforeEach(async () => {
+    await insertMovement({ occurredAt: LATE_ON_JANUARY_31, extendedCost: 25_000 })
+  })
+
+  it('counts it in January, because January in New York has not ended', async () => {
+    const january = (await gather('2027-01'))._unsafeUnwrap()
+    expect(january.current.balances.inventory_raw_materials).toBe(
+      OPENING.inventory_raw_materials + 25_000
+    )
+    expect(january.txnDate).toBe('2027-01-31')
+  })
+
+  it('does not double it in February — the window is cumulative, so it appears once', async () => {
+    const february = (await gather('2027-02'))._unsafeUnwrap()
+    expect(february.current.balances.inventory_raw_materials).toBe(
+      OPENING.inventory_raw_materials + 25_000
+    )
+  })
+
+  it('the SAME instant is February when the books are kept in UTC', async () => {
+    // The proof that the zone is doing the work rather than the calendar: one
+    // row, one instant, two answers, and the only thing that changed is a
+    // setting.
+    await db()
+      .update(schema.OrganizationSetting)
+      .set({ value: 'UTC' })
+      .where(
+        and(
+          eq(schema.OrganizationSetting.organizationId, f.organizationId),
+          eq(schema.OrganizationSetting.key, K.bookTimeZone)
+        )
+      )
+    await getOrgCache().invalidateAndRecompute(f.organizationId, ['orgSettings'])
+
+    const january = (await gather('2027-01'))._unsafeUnwrap()
+    expect(january.current.balances.inventory_raw_materials).toBe(OPENING.inventory_raw_materials)
+
+    const february = (await gather('2027-02'))._unsafeUnwrap()
+    expect(february.current.balances.inventory_raw_materials).toBe(
+      OPENING.inventory_raw_materials + 25_000
+    )
+  })
+})
+
+// ── Rule A ───────────────────────────────────────────────────────────────────
+
+describe('🛑 rule A — a post-cutoff uncosted movement fails the close', () => {
+  it('refuses and names the movement when the extended cost is NULL', async () => {
+    const offender = await insertMovement({
+      occurredAt: new Date('2027-01-15T12:00:00.000Z'),
+      extendedCost: null,
+    })
+
+    const result = await gather('2027-01')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain(offender)
+  })
+
+  it('refuses when the unit cost is NULL', async () => {
+    const offender = await insertMovement({
+      occurredAt: new Date('2027-01-15T12:00:00.000Z'),
+      unitCost: null,
+    })
+
+    expect((await gather('2027-01'))._unsafeUnwrapErr().message).toContain(offender)
+  })
+
+  it('refuses when the movement carries no inventory role', async () => {
+    const offender = await insertMovement({
+      occurredAt: new Date('2027-01-15T12:00:00.000Z'),
+      glAccount: null,
+    })
+
+    expect((await gather('2027-01'))._unsafeUnwrapErr().message).toContain(offender)
+  })
+
+  it('refuses a role the chart cannot value', async () => {
+    const offender = await insertMovement({
+      occurredAt: new Date('2027-01-15T12:00:00.000Z'),
+      glAccount: 'inventory_consigned',
+    })
+
+    expect((await gather('2027-01'))._unsafeUnwrapErr().message).toContain(offender)
+  })
+
+  it('refuses a movement with no accounting date at all that was learned of after the cutoff', async () => {
+    // It cannot be placed in any period, so the window predicate cannot see it.
+    // A reader that stopped there would drop it in silence and produce a
+    // balanced entry that understates inventory.
+    const offender = await insertMovement({
+      createdAt: new Date('2027-01-15T12:00:00.000Z'),
+      extendedCost: 25_000,
+    })
+
+    expect((await gather('2027-01'))._unsafeUnwrapErr().message).toContain(offender)
+  })
+
+  it('still IGNORES an uncosted movement from before the cutoff', async () => {
+    // The mirror of rule A, and the reason the window starts where it does.
+    // Historical movements predate the costing regime; the opening snapshot
+    // replaces that history entirely.
+    await insertMovement({ occurredAt: new Date('2026-06-15T12:00:00.000Z'), extendedCost: null })
+    await insertMovement({ createdAt: new Date('2026-06-15T12:00:00.000Z') })
+
+    const inputs = (await gather('2027-01'))._unsafeUnwrap()
+    expect(inputs.current.balances.inventory_raw_materials).toBe(OPENING.inventory_raw_materials)
+  })
+
+  it('ignores the uncosted PARENT of a bill-of-materials explosion', async () => {
+    // Its children carry the real quantities, which is why
+    // `recalculateQoHForPart` excludes it from the quantity ledger too.
+    await insertMovement({
+      occurredAt: new Date('2027-01-15T12:00:00.000Z'),
+      adjustSubparts: true,
+      extendedCost: null,
+      unitCost: null,
+      glAccount: null,
+    })
+
+    const result = await gather('2027-01')
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().current.balances.inventory_raw_materials).toBe(
+      OPENING.inventory_raw_materials
+    )
+  })
+})
+
+// ── The adjustment lane ──────────────────────────────────────────────────────
+
+describe('an `adjust` movement appears in BOTH the balance and the adjustment total', () => {
+  it('moves the balance and is separately classified, without being subtracted out', async () => {
+    await insertMovement({ occurredAt: new Date('2027-01-10T12:00:00.000Z'), extendedCost: 30_000 })
+    await insertMovement({
+      occurredAt: new Date('2027-01-20T12:00:00.000Z'),
+      type: 'adjust',
+      extendedCost: -4_000,
+    })
+
+    const { current } = (await gather('2027-01'))._unsafeUnwrap()
+
+    // 🛑 The receipt AND the shrinkage are both in the balance. `G12` breaks the
+    // shrinkage out into its own leg; it does not remove it from inventory
+    // twice.
+    expect(current.balances.inventory_raw_materials).toBe(
+      OPENING.inventory_raw_materials + 30_000 - 4_000
+    )
+    expect(current.activityTotals.inventoryAdjustments).toBe(-4_000)
+  })
+
+  it('sums adjustments across roles and keeps the sign', async () => {
+    await insertMovement({
+      occurredAt: new Date('2027-01-10T12:00:00.000Z'),
+      type: 'adjust',
+      extendedCost: -4_000,
+    })
+    await insertMovement({
+      occurredAt: new Date('2027-01-11T12:00:00.000Z'),
+      type: 'adjust',
+      glAccount: 'inventory_finished_goods',
+      extendedCost: 1_500,
+    })
+
+    const { current } = (await gather('2027-01'))._unsafeUnwrap()
+    expect(current.activityTotals.inventoryAdjustments).toBe(-2_500)
+    expect(current.balances.inventory_raw_materials).toBe(OPENING.inventory_raw_materials - 4_000)
+    expect(current.balances.inventory_finished_goods).toBe(OPENING.inventory_finished_goods + 1_500)
+  })
+})
+
+// ── Absorption ───────────────────────────────────────────────────────────────
+
+describe('absorption reads the frozen build costs', () => {
+  it('sums labour and overhead over builds completed since the cutoff', async () => {
+    await insertBuild({
+      completedAt: new Date('2027-01-10T12:00:00.000Z'),
+      laborCost: 7_500,
+      overheadCost: 2_250,
+    })
+    await insertBuild({
+      completedAt: new Date('2027-02-10T12:00:00.000Z'),
+      laborCost: 500,
+      overheadCost: 100,
+    })
+    // Before the cutoff — covered by the opening snapshot.
+    await insertBuild({
+      completedAt: new Date('2026-11-10T12:00:00.000Z'),
+      laborCost: 99_999,
+      overheadCost: 99_999,
+    })
+
+    const { activityTotals } = (await gather('2027-02'))._unsafeUnwrap().current
+    expect(activityTotals.absorbedLabor).toBe(8_000)
+    expect(activityTotals.absorbedOverhead).toBe(2_350)
+  })
+
+  it('🛑 nets a reversal out WITHOUT filtering it', async () => {
+    // `reverse-build.ts` writes a NEGATED `build_labor_cost` onto a second build
+    // row. The cumulative sum cancels the pair on its own. Filtering reversals
+    // would leave the original's absorption in the total and remove the
+    // correction that cancels it — double-counting the mistake.
+    await insertBuild({
+      completedAt: new Date('2027-01-10T12:00:00.000Z'),
+      laborCost: 7_500,
+      overheadCost: 2_250,
+    })
+    await insertBuild({
+      completedAt: new Date('2027-01-20T12:00:00.000Z'),
+      laborCost: -7_500,
+      overheadCost: -2_250,
+    })
+
+    const { activityTotals } = (await gather('2027-01'))._unsafeUnwrap().current
+    expect(activityTotals.absorbedLabor).toBe(0)
+    expect(activityTotals.absorbedOverhead).toBe(0)
+  })
+
+  it('ignores a build with no completion date', async () => {
+    const [instance] = await db()
+      .insert(schema.EntityInstance)
+      .values({
+        organizationId: f.organizationId,
+        entityDefinitionId: f.buildDefId,
+        displayName: 'planned build',
+        updatedAt: new Date(),
+      })
+      .returning({ id: schema.EntityInstance.id })
+    await db()
+      .insert(schema.FieldValue)
+      .values({
+        organizationId: f.organizationId,
+        entityId: (instance as { id: string }).id,
+        entityDefinitionId: f.buildDefId,
+        fieldId: await fieldId('build_labor_cost'),
+        valueNumber: 99_999,
+        updatedAt: new Date(),
+      })
+
+    const { activityTotals } = (await gather('2027-01'))._unsafeUnwrap().current
+    expect(activityTotals.absorbedLabor).toBe(0)
+  })
+})
+
+// ── The cutover, against real rows ───────────────────────────────────────────
+
+describe('the cutover close', () => {
+  it('measures the first month against the frozen opening baseline', async () => {
+    await insertMovement({ occurredAt: new Date('2027-01-15T12:00:00.000Z'), extendedCost: 25_000 })
+
+    const inputs = (await gather('2027-01'))._unsafeUnwrap()
+
+    expect(inputs.periodKey).toBe('2027-01')
+    expect(inputs.txnDate).toBe('2027-01-31')
+    expect(inputs.prior).toEqual({
+      balances: { ...OPENING },
+      activityTotals: { absorbedLabor: 0, absorbedOverhead: 0, inventoryAdjustments: 0 },
+    })
+  })
+
+  it('refuses a period at or before the cutoff', async () => {
+    expect((await gather(CUTOFF)).isErr()).toBe(true)
+    expect((await gather('2026-06')).isErr()).toBe(true)
+  })
+})
+
+// ── The prior-row selection rule, against real rows ──────────────────────────
+//
+// 🛑 A WRONG prior still produces a perfectly balanced entry. That is why
+// `assertions.before` exists at all, and it is why this rule has to be asserted
+// directly: nothing downstream of the reader can detect a broken selection.
+
+interface PostingSpec {
+  periodKey: string
+  revision?: number
+  status?: 'pending' | 'posted' | 'failed' | 'reversed'
+  docNumber: string
+  /** The `assertions.after` this posting claims. Omit for the corrupt-chain case. */
+  after?: MonthEndInventorySnapshot | null
+  reversesId?: string
+}
+
+async function insertPosting(spec: PostingSpec): Promise<string> {
+  const snapshot = spec.after ?? {
+    balances: { inventory_raw_materials: 0, inventory_wip: 0, inventory_finished_goods: 0 },
+    activityTotals: { absorbedLabor: 0, absorbedOverhead: 0, inventoryAdjustments: 0 },
+  }
+  const draft = buildPostingDraft({
+    docNumber: spec.docNumber,
+    revision: spec.revision ?? 0,
+    entry: {} as never,
+    resolvedLines: [],
+    assertions:
+      spec.after === null
+        ? undefined
+        : { kind: 'month_end_inventory', before: snapshot, after: snapshot },
+  })
+
+  const [row] = await db()
+    .insert(schema.GlPosting)
+    .values({
+      organizationId: f.organizationId,
+      postingType: 'month_end_inventory',
+      periodKey: spec.periodKey,
+      revision: spec.revision ?? 0,
+      status: spec.status ?? 'posted',
+      txnDate: `${spec.periodKey}-28`,
+      docNumber: spec.docNumber,
+      totalMinor: 1_000,
+      draft,
+      requestId: `req-${spec.docNumber}`,
+      postedAt: new Date(),
+      reversesId: spec.reversesId,
+      updatedAt: new Date(),
+    })
+    .returning({ id: schema.GlPosting.id })
+
+  return (row as { id: string }).id
+}
+
+/** A snapshot whose raw-materials balance identifies which posting was chosen. */
+function marker(raw: number): MonthEndInventorySnapshot {
+  return {
+    balances: { inventory_raw_materials: raw, inventory_wip: 0, inventory_finished_goods: 0 },
+    activityTotals: { absorbedLabor: 0, absorbedOverhead: 0, inventoryAdjustments: 0 },
+  }
+}
+
+describe('the prior effective posting, selected from real rows', () => {
+  it('takes the GREATEST period strictly before this one', async () => {
+    await insertPosting({ periodKey: '2027-01', docNumber: 'JE-1', after: marker(111) })
+    await insertPosting({ periodKey: '2027-02', docNumber: 'JE-2', after: marker(222) })
+    // Not eligible: this IS the period being closed.
+    await insertPosting({ periodKey: '2027-03', docNumber: 'JE-3', after: marker(333) })
+
+    const inputs = (await gather('2027-03'))._unsafeUnwrap()
+    expect(inputs.prior.balances.inventory_raw_materials).toBe(222)
+  })
+
+  it('takes the GREATEST revision within that period', async () => {
+    const original = await insertPosting({
+      periodKey: '2027-02',
+      docNumber: 'JE-2',
+      status: 'reversed',
+      after: marker(222),
+    })
+    // The reversal is an ordinary `posted` entry (decision G4) and carries the
+    // assertions resulting after ITSELF.
+    await insertPosting({
+      periodKey: '2027-02',
+      revision: 1,
+      docNumber: 'JE-2-R1',
+      after: marker(999),
+      reversesId: original,
+    })
+
+    const inputs = (await gather('2027-03'))._unsafeUnwrap()
+    expect(inputs.prior.balances.inventory_raw_materials).toBe(999)
+  })
+
+  it('ignores a `pending` or `failed` row', async () => {
+    await insertPosting({ periodKey: '2027-01', docNumber: 'JE-1', after: marker(111) })
+    await insertPosting({
+      periodKey: '2027-02',
+      docNumber: 'JE-2',
+      status: 'failed',
+      after: marker(222),
+    })
+
+    const inputs = (await gather('2027-03'))._unsafeUnwrap()
+    expect(inputs.prior.balances.inventory_raw_materials).toBe(111)
+  })
+
+  it('ignores another organization’s postings', async () => {
+    const other = await seedBuildOrg({ components: 1 })
+    await db()
+      .insert(schema.GlPosting)
+      .values({
+        organizationId: other.organizationId,
+        postingType: 'month_end_inventory',
+        periodKey: '2027-02',
+        revision: 0,
+        status: 'posted',
+        txnDate: '2027-02-28',
+        docNumber: 'JE-OTHER',
+        totalMinor: 1_000,
+        draft: buildPostingDraft({
+          docNumber: 'JE-OTHER',
+          revision: 0,
+          entry: {} as never,
+          resolvedLines: [],
+          assertions: { kind: 'month_end_inventory', before: marker(1), after: marker(777) },
+        }),
+        requestId: 'req-other',
+        postedAt: new Date(),
+        updatedAt: new Date(),
+      })
+
+    const inputs = (await gather('2027-03'))._unsafeUnwrap()
+    expect(inputs.prior.balances).toEqual({ ...OPENING })
+  })
+
+  it('🛑 refuses a prior row whose draft carries no assertions, naming the document', async () => {
+    await insertPosting({ periodKey: '2027-02', docNumber: 'JE-BROKEN', after: null })
+
+    const result = await gather('2027-03')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('JE-BROKEN')
+  })
+})

--- a/packages/lib/src/postings/__tests__/gather-month-end-inventory.test.ts
+++ b/packages/lib/src/postings/__tests__/gather-month-end-inventory.test.ts
@@ -1,0 +1,551 @@
+// packages/lib/src/postings/__tests__/gather-month-end-inventory.test.ts
+//
+// The reader half of the L1 month-end inventory entry, with the database faked.
+//
+// Two things are defended here, and everything below is a face of one of them:
+//
+//   1. **The prior snapshot is selected by the exact rule, or the close is
+//      refused.** A WRONG prior still produces a perfectly balanced entry —
+//      that is the whole reason `assertions.before` exists — so nothing
+//      downstream can catch a broken selection. It has to be caught here.
+//   2. **Nothing is ever defaulted, skipped, or coerced to zero.** A period at
+//      or before the cutoff, a day key, an uncosted post-cutoff movement, an
+//      unknown inventory role, a prior posting with no assertions: every one of
+//      them refuses and names what to fix.
+//
+// 🛑 `@auxx/database` is re-mocked with the REAL schema barrel, following
+// `approval-requests/__tests__/approval-request-queries.test.ts`. The default lib
+// config mocks `schema` as a Proxy of empty objects (`src/test/setup.ts:76`), so
+// every Drizzle column is `undefined` and every assertion on a predicate built
+// from one passes VACUOUSLY. With the real tables in place the predicates can be
+// rendered through `PgDialect` and the selection rule is actually asserted — a
+// mutation that drops `status = 'posted'` or flips an `ORDER BY` to ascending
+// changes the SQL text and fails.
+//
+// The window boundaries get the same treatment. They are the mechanical
+// expression of "period membership is the accounting date in the BOOK
+// timezone", and the only way to see them is in the bound parameters.
+
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// See the header. Pure Drizzle, no connection.
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../../database/src/db/schema/index')
+  const enums = await import('../../../../database/src/enums')
+  return { schema, ...enums, database: {} }
+})
+
+const h = vi.hoisted(() => ({
+  settings: {} as Record<string, unknown>,
+}))
+
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: async (params: { key: string }) =>
+    params.key in h.settings ? h.settings[params.key] : null,
+  getAllOrganizationSettings: async () => {
+    throw new Error('getAllOrganizationSettings is not the cached path')
+  },
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: async (_organizationId: string, entityType: string) =>
+    entityType === 'stock_movement' ? 'def_stock_movement' : 'def_build',
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attributes: readonly string[]) =>
+        Object.fromEntries(attributes.map((attribute) => [attribute, { id: `fld_${attribute}` }])),
+    }),
+  }),
+}))
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { UnprocessableEntityError } from '../../errors'
+import { buildPostingDraft } from '../draft'
+import { gatherMonthEndInventoryInputs } from '../gather-month-end-inventory'
+import { OPENING_BASELINE_SETTING_KEYS } from '../opening-baseline'
+
+const ORG = 'org_1'
+const K = OPENING_BASELINE_SETTING_KEYS
+
+const OPENING = {
+  inventory_raw_materials: 125_000,
+  inventory_wip: 0,
+  inventory_finished_goods: 480_050,
+}
+
+/** A finalized baseline: cutoff December 2026, books kept in New York. */
+function validSettings(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    [K.setupState]: 'finalized',
+    [K.cutoffPeriod]: '2026-12',
+    [K.bookTimeZone]: 'America/New_York',
+    [K.inventory_raw_materials]: OPENING.inventory_raw_materials,
+    [K.inventory_wip]: OPENING.inventory_wip,
+    [K.inventory_finished_goods]: OPENING.inventory_finished_goods,
+    ...overrides,
+  }
+}
+
+// ── The faked database ───────────────────────────────────────────────────────
+//
+// A chainable recorder. Each awaited chain is matched to one of the reader's
+// four queries by the table it selects `from` and the shape of its projection,
+// so the tests supply rows per QUERY rather than per call order — which matters,
+// because three of them run inside one `Promise.all` and their resolution order
+// is not fixed.
+
+type Rows = Record<string, unknown>[]
+
+interface RecordedQuery {
+  table: unknown
+  fields: Record<string, unknown>
+  steps: Array<{ name: string; args: unknown[] }>
+}
+
+interface QueryResults {
+  /** Rows for the prior-posting select. */
+  glPostings?: Rows
+  /** Rows for the rule-A offender scan. */
+  offenders?: Rows
+  /** Grouped `{ role, total, adjustTotal }` rows. */
+  movementSums?: Rows
+  /** The single `{ labor, overhead }` row. */
+  buildSums?: Rows
+}
+
+let recorded: RecordedQuery[] = []
+
+function rowsFor(state: RecordedQuery, results: QueryResults): Rows {
+  if (state.table === schema.GlPosting) return results.glPostings ?? []
+  const projection = Object.keys(state.fields)
+  if (projection.includes('adjustTotal')) return results.movementSums ?? []
+  if (projection.includes('labor')) return results.buildSums ?? []
+  return results.offenders ?? []
+}
+
+function makeDb(results: QueryResults): Database {
+  const chain = (state: RecordedQuery): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_target, property: string) {
+          if (property === 'then') {
+            return (resolve: (rows: Rows) => void) => {
+              recorded.push(state)
+              resolve(rowsFor(state, results))
+            }
+          }
+          return (...args: unknown[]) => {
+            if (property === 'from') state.table = args[0]
+            state.steps.push({ name: property, args })
+            return chain(state)
+          }
+        },
+      }
+    )
+
+  return {
+    select: (fields: Record<string, unknown>) =>
+      chain({ table: undefined, fields, steps: [{ name: 'select', args: [fields] }] }),
+  } as unknown as Database
+}
+
+/** The one recorded chain whose projection contains `key`. */
+function queryWith(key: string): RecordedQuery {
+  const found = recorded.filter((query) => key in query.fields)
+  if (found.length !== 1) {
+    throw new Error(`expected exactly one query projecting ${key}, saw ${found.length}`)
+  }
+  return found[0] as RecordedQuery
+}
+
+/** The prior-posting select — the only one that reads `GlPosting`. */
+function priorQuery(): RecordedQuery {
+  const found = recorded.filter((query) => query.table === schema.GlPosting)
+  if (found.length !== 1) {
+    throw new Error(`expected exactly one GlPosting query, saw ${found.length}`)
+  }
+  return found[0] as RecordedQuery
+}
+
+const dialect = new PgDialect()
+
+/** Every argument of `step` on this chain, rendered to SQL text and parameters. */
+function rendered(query: RecordedQuery, step: string): { sql: string; params: unknown[] } {
+  const args = query.steps.filter((s) => s.name === step).flatMap((s) => s.args)
+  const parts = args.map((arg) => dialect.sqlToQuery(arg as never))
+  return {
+    sql: parts.map((part) => part.sql).join(' | '),
+    params: parts.flatMap((part) => part.params),
+  }
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function snapshot(overrides: {
+  raw?: number
+  wip?: number
+  finished?: number
+  labor?: number
+  overhead?: number
+  adjustments?: number
+}) {
+  return {
+    balances: {
+      inventory_raw_materials: overrides.raw ?? 0,
+      inventory_wip: overrides.wip ?? 0,
+      inventory_finished_goods: overrides.finished ?? 0,
+    },
+    activityTotals: {
+      absorbedLabor: overrides.labor ?? 0,
+      absorbedOverhead: overrides.overhead ?? 0,
+      inventoryAdjustments: overrides.adjustments ?? 0,
+    },
+  }
+}
+
+/** A `GlPosting` row as the prior-posting select reads it back. */
+function priorRow(options: {
+  docNumber?: string
+  periodKey?: string
+  revision?: number
+  after?: ReturnType<typeof snapshot>
+  before?: ReturnType<typeof snapshot>
+  /** Set to drop the assertions entirely — the corrupt-chain case. */
+  withoutAssertions?: boolean
+}) {
+  const draft = buildPostingDraft({
+    docNumber: options.docNumber ?? 'JE-2026-07-ME',
+    revision: options.revision ?? 0,
+    entry: {} as never,
+    resolvedLines: [],
+    assertions: options.withoutAssertions
+      ? undefined
+      : {
+          kind: 'month_end_inventory',
+          before: options.before ?? snapshot({}),
+          after: options.after ?? snapshot({}),
+        },
+  })
+  return {
+    docNumber: options.docNumber ?? 'JE-2026-07-ME',
+    periodKey: options.periodKey ?? '2026-07',
+    revision: options.revision ?? 0,
+    draft,
+  }
+}
+
+async function gather(results: QueryResults = {}, periodKey = '2027-08') {
+  return gatherMonthEndInventoryInputs(makeDb(results), ORG, periodKey)
+}
+
+async function refusal(results: QueryResults = {}, periodKey = '2027-08'): Promise<string> {
+  const result = await gather(results, periodKey)
+  if (result.isOk()) throw new Error(`expected a refusal, got ${JSON.stringify(result.value)}`)
+  expect(result.error).toBeInstanceOf(UnprocessableEntityError)
+  return result.error.message
+}
+
+beforeEach(() => {
+  h.settings = validSettings()
+  recorded = []
+})
+
+// ── The cutover ──────────────────────────────────────────────────────────────
+
+describe('the cutover close, which has no previous posting', () => {
+  it('uses the frozen opening baseline as the prior, with all activity totals zero', async () => {
+    const result = await gather({ glPostings: [] }, '2027-01')
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().prior).toEqual({
+      balances: { ...OPENING },
+      // Nothing has been absorbed or adjusted since a cutoff that has only just
+      // happened. Zero here is a real answer, not a default.
+      activityTotals: { absorbedLabor: 0, absorbedOverhead: 0, inventoryAdjustments: 0 },
+    })
+  })
+
+  it('never manufactures a synthetic prior of zero balances', async () => {
+    // The failure this refuses: reading a missing prior as `{0,0,0}` would post
+    // the whole opening inventory as a January debit and balance perfectly.
+    const inputs = (await gather({ glPostings: [] }, '2027-01'))._unsafeUnwrap()
+    expect(inputs.prior.balances.inventory_raw_materials).toBe(125_000)
+    expect(inputs.prior.balances.inventory_finished_goods).toBe(480_050)
+  })
+})
+
+// ── The prior-row selection rule ─────────────────────────────────────────────
+
+describe('the prior effective posting', () => {
+  it("becomes the prior snapshot, verbatim, from its draft's assertions.after", async () => {
+    const after = snapshot({ raw: 90_000, finished: 12_500, labor: 4_000, adjustments: -750 })
+    const result = await gather({
+      glPostings: [priorRow({ after, before: snapshot({ raw: 1 }) })],
+    })
+
+    expect(result._unsafeUnwrap().prior).toEqual(after)
+  })
+
+  it('selects the greatest periodKey strictly before this one, then the greatest revision', async () => {
+    await gather({ glPostings: [priorRow({})] })
+
+    const { sql, params } = rendered(priorQuery(), 'where')
+    expect(sql).toContain('"periodKey" <')
+    expect(params).toContain('2027-08')
+
+    const order = rendered(priorQuery(), 'orderBy')
+    // Both descending, periodKey first. Ascending on either one selects the
+    // OLDEST prior, which still produces a balanced entry — so the direction is
+    // exactly the kind of mistake nothing downstream can catch.
+    expect(order.sql.toLowerCase()).toMatch(/"periodkey" desc.*"revision" desc/s)
+
+    const limit = priorQuery().steps.find((step) => step.name === 'limit')
+    expect(limit?.args).toEqual([1])
+  })
+
+  it('reads only `posted` rows of type `month_end_inventory`', async () => {
+    await gather({ glPostings: [priorRow({})] })
+
+    const { params } = rendered(priorQuery(), 'where')
+    // `reversed` is the original of a reversal pair and must not be selected;
+    // its effective reversal or re-entry is an ordinary `posted` row.
+    expect(params).toContain('posted')
+    expect(params).toContain('month_end_inventory')
+    expect(params).toContain(ORG)
+  })
+
+  it('🛑 refuses a prior row whose draft carries no assertions, naming the document', async () => {
+    // The corrupt chain. Falling back to the opening baseline here would restate
+    // every month since the cutoff into one entry that balances perfectly.
+    const message = await refusal({
+      glPostings: [
+        priorRow({ docNumber: 'JE-2027-07-ME', periodKey: '2027-07', withoutAssertions: true }),
+      ],
+    })
+
+    expect(message).toContain('JE-2027-07-ME')
+    expect(message).toContain('2027-07')
+    expect(message).not.toContain('opening baseline as the prior')
+  })
+})
+
+// ── The period ───────────────────────────────────────────────────────────────
+
+describe('which periods may be closed', () => {
+  it('refuses a period at the cutoff', async () => {
+    const message = await refusal({}, '2026-12')
+    expect(message).toContain('2026-12')
+    expect(message).toContain('cutoff')
+  })
+
+  it('refuses a period before the cutoff', async () => {
+    const message = await refusal({}, '2026-05')
+    expect(message).toContain('cutoff')
+  })
+
+  it('accepts the very first month after the cutoff', async () => {
+    const result = await gather({}, '2027-01')
+    expect(result.isOk()).toBe(true)
+  })
+
+  it('refuses a day-granularity period key', async () => {
+    const result = await gather({}, '2027-08-18')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('closes a month, not a day')
+  })
+
+  it('refuses a malformed period key', async () => {
+    const result = await gather({}, '2027-8')
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('reads no baseline-dependent query when the period is refused', async () => {
+    await gather({}, '2026-11')
+    expect(recorded).toEqual([])
+  })
+})
+
+// ── txnDate and the window, both in the book timezone ────────────────────────
+
+describe('the accounting dates are derived in the book timezone', () => {
+  it('sets txnDate to the last day of the period', async () => {
+    expect((await gather({}, '2027-08'))._unsafeUnwrap().txnDate).toBe('2027-08-31')
+    expect((await gather({}, '2027-02'))._unsafeUnwrap().txnDate).toBe('2027-02-28')
+    expect((await gather({}, '2028-02'))._unsafeUnwrap().txnDate).toBe('2028-02-29')
+  })
+
+  it('🛑 bounds the movement window with INSTANTS, not with UTC calendar edges', async () => {
+    await gather({}, '2027-08')
+
+    const { params } = rendered(queryWith('adjustTotal'), 'where')
+    // Midnight on 2027-01-01 in America/New_York is 05:00Z (EST); midnight on
+    // 2027-09-01 there is 04:00Z (EDT). Deriving either boundary in UTC posts a
+    // month's edge activity into the wrong month — invisible except at a close,
+    // and uncorrectable once the period is locked.
+    expect(params).toContain('2027-01-01T05:00:00.000Z')
+    expect(params).toContain('2027-09-01T04:00:00.000Z')
+  })
+
+  it('moves the window when the book timezone moves', async () => {
+    h.settings = validSettings({ [K.bookTimeZone]: 'Asia/Tokyo' })
+    await gather({}, '2027-08')
+
+    const { params } = rendered(queryWith('adjustTotal'), 'where')
+    expect(params).toContain('2026-12-31T15:00:00.000Z')
+    expect(params).toContain('2027-08-31T15:00:00.000Z')
+  })
+
+  it('bounds the build absorption window identically', async () => {
+    await gather({}, '2027-08')
+
+    const { params } = rendered(queryWith('labor'), 'where')
+    expect(params).toContain('2027-01-01T05:00:00.000Z')
+    expect(params).toContain('2027-09-01T04:00:00.000Z')
+  })
+})
+
+// ── The cumulative current state ─────────────────────────────────────────────
+
+describe('the cumulative current state', () => {
+  it('adds the movement totals to the frozen opening balances, per role', async () => {
+    const result = await gather({
+      glPostings: [],
+      movementSums: [
+        { role: 'inventory_raw_materials', total: 25_000, adjustTotal: 0 },
+        { role: 'inventory_finished_goods', total: -30_050, adjustTotal: 0 },
+      ],
+    })
+
+    expect(result._unsafeUnwrap().current.balances).toEqual({
+      inventory_raw_materials: 150_000,
+      inventory_wip: 0,
+      inventory_finished_goods: 450_000,
+    })
+  })
+
+  it('keeps the adjustment total SEPARATE from the balance it also moved', async () => {
+    // 🛑 The adjust movement legitimately appears in BOTH. It moved inventory,
+    // so it is in the balance; `G12` requires count and shrinkage to be
+    // classified into their own role, so it is also its own signed total. It is
+    // never subtracted out of the balance.
+    const result = await gather({
+      glPostings: [],
+      movementSums: [{ role: 'inventory_raw_materials', total: -4_000, adjustTotal: -4_000 }],
+    })
+
+    const { current } = result._unsafeUnwrap()
+    expect(current.balances.inventory_raw_materials).toBe(121_000)
+    expect(current.activityTotals.inventoryAdjustments).toBe(-4_000)
+  })
+
+  it('sums the adjustment total across every role', async () => {
+    const result = await gather({
+      glPostings: [],
+      movementSums: [
+        { role: 'inventory_raw_materials', total: -4_000, adjustTotal: -4_000 },
+        { role: 'inventory_finished_goods', total: 1_000, adjustTotal: 1_000 },
+      ],
+    })
+
+    expect(result._unsafeUnwrap().current.activityTotals.inventoryAdjustments).toBe(-3_000)
+  })
+
+  it('reads absorbed labour and overhead from the build rows, not the ledger', async () => {
+    const result = await gather({
+      glPostings: [],
+      buildSums: [{ labor: 7_500, overhead: 2_250 }],
+    })
+
+    const { activityTotals } = result._unsafeUnwrap().current
+    expect(activityTotals.absorbedLabor).toBe(7_500)
+    expect(activityTotals.absorbedOverhead).toBe(2_250)
+  })
+
+  it('coerces a string aggregate, and rounds float representation away', async () => {
+    const result = await gather({
+      glPostings: [],
+      movementSums: [
+        { role: 'inventory_raw_materials', total: '25000', adjustTotal: '0' },
+        { role: 'inventory_wip', total: 1_000.0000000001, adjustTotal: 0 },
+      ],
+    })
+
+    const { balances } = result._unsafeUnwrap().current
+    expect(balances.inventory_raw_materials).toBe(150_000)
+    expect(balances.inventory_wip).toBe(1_000)
+  })
+
+  it('refuses a non-finite aggregate rather than rounding it', async () => {
+    const message = await refusal({
+      glPostings: [],
+      movementSums: [{ role: 'inventory_raw_materials', total: 'not a number', adjustTotal: 0 }],
+    })
+    expect(message).toContain('not a finite number')
+  })
+})
+
+// ── Rule A ───────────────────────────────────────────────────────────────────
+
+describe('rule A — a post-cutoff uncosted movement fails the close', () => {
+  it('refuses, naming the offending movement', async () => {
+    const message = await refusal({ offenders: [{ id: 'mv_bad_1' }, { id: 'mv_bad_2' }] })
+
+    expect(message).toContain('mv_bad_1')
+    expect(message).toContain('mv_bad_2')
+    expect(message).toContain('outside those')
+  })
+
+  it('names at most ten, and says there are more', async () => {
+    const many = Array.from({ length: 11 }, (_unused, index) => ({ id: `mv_${index}` }))
+    const message = await refusal({ offenders: many })
+
+    expect(message).toContain('(and more)')
+    expect(message).not.toContain('mv_10')
+  })
+
+  it('scans with LEFT joins, so an uncosted movement is visible to the scan', async () => {
+    // 🛑 An INNER join on the cost fields makes exactly the rows this scan is
+    // looking for invisible to it — rule A's failure mode expressed in SQL.
+    await gather({})
+    const scan = recorded.filter(
+      (query) => Object.keys(query.fields).length === 1 && 'id' in query.fields
+    )
+    expect(scan).toHaveLength(1)
+    const joins = (scan[0] as RecordedQuery).steps.map((step) => step.name)
+    expect(joins.filter((name) => name === 'innerJoin')).toEqual([])
+    expect(joins.filter((name) => name === 'leftJoin').length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('refuses a role the chart cannot value, even if the scan let it through', async () => {
+    // Belt and braces: the scan above already refuses an unrecognised role. This
+    // is the second gate, so a later edit to the scan cannot silently drop a
+    // whole account's worth of inventory into the COGS plug.
+    const message = await refusal({
+      glPostings: [],
+      movementSums: [{ role: 'inventory_consigned', total: 9_999, adjustTotal: 0 }],
+    })
+    expect(message).toContain('inventory_consigned')
+    expect(message).toContain('unknown inventory role')
+  })
+})
+
+// ── The baseline gate ────────────────────────────────────────────────────────
+
+describe('it refuses before it reads when the baseline is not usable', () => {
+  it('passes the opening baseline refusal straight through', async () => {
+    h.settings = validSettings({ [K.setupState]: 'draft' })
+    const message = await refusal()
+    expect(message).toContain('not finalized')
+    expect(recorded).toEqual([])
+  })
+
+  it('refuses an unrecognised book timezone rather than deriving the window in UTC', async () => {
+    h.settings = validSettings({ [K.bookTimeZone]: 'Mars/Olympus_Mons' })
+    const message = await refusal()
+    expect(message).toContain('IANA zone')
+    expect(recorded).toEqual([])
+  })
+})

--- a/packages/lib/src/postings/__tests__/regime.test.ts
+++ b/packages/lib/src/postings/__tests__/regime.test.ts
@@ -1,0 +1,94 @@
+// packages/lib/src/postings/__tests__/regime.test.ts
+//
+// gap-e risk E5. This is the ONLY mechanical guard that L1 and L3 are not both
+// live, and the thing it guards against produces two entries that each balance
+// perfectly - so nothing else, anywhere, can catch it.
+
+import { describe, expect, it } from 'vitest'
+import { ACCOUNT_ROLES } from '../build-entry'
+import {
+  ENABLED_POSTING_TYPES,
+  findInventoryWriterConflicts,
+  INVENTORY_ROLES,
+  INVENTORY_ROLES_BY_POSTING_TYPE,
+} from '../regime'
+import { POSTING_TYPES } from '../types'
+
+describe('the enabled regime', () => {
+  it('has NO inventory account with two writers', () => {
+    // The assertion itself. If this ever fails, a close is both asserting a
+    // balance and accumulating postings into the same account: the monthly
+    // entry reverses the per-event ones and the residual lands in the COGS
+    // plug looking like consumption.
+    expect(findInventoryWriterConflicts()).toEqual([])
+  })
+
+  it('is L1 only - `receipt` and `vendor_bill` exist but are not enabled', () => {
+    // They are in `POSTING_TYPES`, in the pgEnum, and their builders are written
+    // and tested. Being buildable is not being enabled, which is the whole
+    // reason this constant exists separately from the union.
+    expect([...ENABLED_POSTING_TYPES]).toEqual(['month_end_inventory'])
+    expect(ENABLED_POSTING_TYPES).not.toContain('receipt')
+    expect(ENABLED_POSTING_TYPES).not.toContain('vendor_bill')
+  })
+})
+
+describe('the conflict detector actually bites', () => {
+  it('catches the L1+L3 state that turning L3 on WITHOUT turning L1 off would create', () => {
+    // The realistic mistake: someone adds the L3 types and leaves the monthly
+    // assertion in place. `vendor_bill` touches no inventory account, so the
+    // conflict is `receipt` against `month_end_inventory` - on exactly the two
+    // accounts a receipt can debit.
+    const conflicts = findInventoryWriterConflicts([
+      'month_end_inventory',
+      'receipt',
+      'vendor_bill',
+    ])
+
+    expect(conflicts.map((c) => c.role).sort()).toEqual(
+      [ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS, ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS].sort()
+    )
+    for (const conflict of conflicts) {
+      expect(conflict.postingTypes.sort()).toEqual(['month_end_inventory', 'receipt'])
+    }
+  })
+
+  it('passes for a clean L3 switch - the monthly assertion turned OFF', () => {
+    // Turning L3 on is ONE change: swap the contents, do not extend them.
+    expect(findInventoryWriterConflicts(['receipt', 'vendor_bill'])).toEqual([])
+  })
+
+  it('does not flag WIP, which no builder drives per-event', () => {
+    const conflicts = findInventoryWriterConflicts(['month_end_inventory', 'receipt'])
+    expect(conflicts.map((c) => c.role)).not.toContain(ACCOUNT_ROLES.INVENTORY_WIP)
+  })
+})
+
+describe('the declaration cannot drift from the vocabulary', () => {
+  it('declares an entry for every posting type', () => {
+    // A type with no entry would read as "drives nothing" and be invisible to
+    // the assertion - the failure mode is silence, so pin the key set.
+    expect(Object.keys(INVENTORY_ROLES_BY_POSTING_TYPE).sort()).toEqual([...POSTING_TYPES].sort())
+  })
+
+  it('every enabled type is a real posting type', () => {
+    for (const type of ENABLED_POSTING_TYPES) expect(POSTING_TYPES).toContain(type)
+  })
+
+  it('names exactly the three inventory roles', () => {
+    expect([...INVENTORY_ROLES].sort()).toEqual(
+      [
+        ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS,
+        ACCOUNT_ROLES.INVENTORY_WIP,
+        ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS,
+      ].sort()
+    )
+  })
+
+  it('only ever declares real account roles', () => {
+    const valid = new Set<string>(Object.values(ACCOUNT_ROLES))
+    for (const roles of Object.values(INVENTORY_ROLES_BY_POSTING_TYPE)) {
+      for (const role of roles) expect(valid.has(role)).toBe(true)
+    }
+  })
+})

--- a/packages/lib/src/postings/gather-month-end-inventory.ts
+++ b/packages/lib/src/postings/gather-month-end-inventory.ts
@@ -1,0 +1,648 @@
+// packages/lib/src/postings/gather-month-end-inventory.ts
+//
+// The READ half of the L1 month-end inventory entry. `buildMonthEndInventoryEntry`
+// (build-month-end-inventory.ts) is the pure arithmetic; this file is everything
+// that touches a database, and the two are split because they fail differently:
+// an arithmetic failure is a bug and throws, a read failure is a runtime
+// condition and comes back as a `Result` (docs/lib-module-guide.md section 3).
+//
+// ── The four reads ──────────────────────────────────────────────────────────
+//
+// 1. **The opening baseline** — `readOpeningBaseline`, through the org settings
+//    cache. It supplies `cutoffPeriod`, `bookTimeZone` and the three frozen
+//    opening balances, and it already fails closed with no default and no UTC.
+// 2. **The prior effective posting** — the `posted` `month_end_inventory` row
+//    with the greatest `periodKey` strictly before this one, then the greatest
+//    `revision` inside that period. Its draft's `assertions.after` IS the prior
+//    snapshot. At cutover there is none and the opening baseline stands in.
+// 3. **The movement ledger** — Σ signed `stock_movement_extended_cost` grouped
+//    by each movement's own FROZEN `stock_movement_gl_account` role, plus the
+//    same sum restricted to `adjust`.
+// 4. **The build rows** — Σ `build_labor_cost` and Σ `build_overhead_cost`.
+//
+// Lanes 3 and 4 are two SOURCES because the split cannot be recovered from one
+// of them: a `stock_movement` freezes a single total `unit_cost` and carries no
+// labour or overhead column at all. See `build-month-end-inventory.ts`'s header.
+//
+// ── 🛑 Three rules, each of which has a way of being got wrong ──────────────
+//
+// **A. Post-cutoff, an uncosted or role-less movement FAILS THE CLOSE.** It is
+// never filtered. BEFORE the cutoff, NULL-cost movements are ignored — they
+// predate the costing regime and the opening snapshot replaces that history
+// entirely, which is the whole reason the window starts where it does. AFTER the
+// cutoff every sanctioned writer already refuses to write one
+// (`adjust-stock.ts` step 2, `complete-build.ts:228`, `receiveStock`), so a
+// movement missing `occurred_at`, `unit_cost`, `extended_cost` or its inventory
+// role means something wrote outside those doors. Filtering it would produce a
+// balanced entry that understates inventory with NO SIGNAL — the exact failure
+// this module exists to refuse, reintroduced on the other side of the line.
+//
+// **B. Period membership is the ACCOUNTING date, in the BOOK TIMEZONE.**
+// `stock_movement_occurred_at` and `build_completed_at`, never `createdAt`.
+// `createdAt` records when auxx.ai learned about a row and is audit evidence, not
+// its accounting date. A receipt logged at 7pm on January 31 in
+// `America/New_York` is already February 1 in UTC, so the window boundaries are
+// computed as INSTANTS from wall-clock midnights in `bookTimeZone`.
+//
+// **C. Both lanes are CUMULATIVE from the cutoff, never per-period.** A build
+// dated in January but entered after the January close must appear in the next
+// open entry still carrying its own frozen labour and overhead. That only works
+// because both lanes sum from the cutoff through the period end and the builder
+// takes the delta against the prior snapshot. Never sum "movements in this
+// month".
+//
+// ── What this file deliberately excludes, and why ───────────────────────────
+//
+// `stock_movement_adjust_subparts = true` rows — the PARENT of a bill-of-
+// materials explosion — are excluded from both the sums and the fail-closed
+// scan. `explodeBomMovement` writes one child movement per component and the
+// children carry the real quantities, which is why `recalculateQoHForPart`
+// excludes the parent from the quantity ledger too
+// (`field-hooks/post/inventory-triggers.ts`, the `fv_flag` predicate). Summing
+// both would double-count, and failing the close on a parent that is not
+// supposed to carry a cost would block every close for a legitimate write. The
+// CHILDREN are not excluded: `explodeBomMovement` writes them with no cost
+// fields at all, so post-cutoff they trip rule A — correctly, because an
+// uncosted movement that does move quantity is precisely the thing rule A is
+// for.
+//
+// No permission checks anywhere here. The router asserts
+// (`docs/lib-module-guide.md` section 6).
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { fromZonedTime } from 'date-fns-tz'
+import { and, desc, eq, gte, isNull, lt, notInArray, or, type SQL, sql } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import { err, ok, type Result } from 'neverthrow'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { AuxxError, BadRequestError, UnprocessableEntityError } from '../errors'
+import type { MonthEndInventoryInputs } from './build-month-end-inventory'
+import { type MonthEndInventorySnapshot, parsePostingDraft } from './draft'
+import { readOpeningBaseline } from './opening-baseline'
+import { compareMonths, parsePeriodKey, periodKeyForDate } from './periods'
+
+const logger = createScopedLogger('postings:gather-month-end-inventory')
+
+/** The three inventory roles a movement's frozen `gl_account` may name. */
+const INVENTORY_ROLES = [
+  'inventory_raw_materials',
+  'inventory_wip',
+  'inventory_finished_goods',
+] as const
+
+type InventoryRole = (typeof INVENTORY_ROLES)[number]
+
+/**
+ * An aliased `FieldValue` table, as `alias()` returns it.
+ *
+ * Widened over the alias NAME on purpose: `alias(t, 'mv_gl')` and
+ * `alias(t, 'mv_type')` have different types, so a join predicate helper typed
+ * against one of them cannot accept the others.
+ */
+type FieldValueAlias = ReturnType<typeof alias<typeof schema.FieldValue, string>>
+
+/** The movement attributes this reader needs. Every one is required. */
+const MOVEMENT_ATTRIBUTES = [
+  'stock_movement_type',
+  'stock_movement_unit_cost',
+  'stock_movement_extended_cost',
+  'stock_movement_gl_account',
+  'stock_movement_occurred_at',
+  'stock_movement_adjust_subparts',
+] as const
+
+/** The build attributes this reader needs. */
+const BUILD_ATTRIBUTES = ['build_labor_cost', 'build_overhead_cost', 'build_completed_at'] as const
+
+/** How many offending movement ids an error message names before it stops. */
+const MAX_NAMED_OFFENDERS = 10
+
+/**
+ * Gather everything the L1 month-end inventory entry for `periodKey` is computed
+ * from.
+ *
+ * The returned {@link MonthEndInventoryInputs} is a flat record of integers, so
+ * the pure builder that consumes it needs no database and every golden test can
+ * construct one by hand.
+ *
+ * @param db The database handle. Reads only — nothing here writes.
+ * @param organizationId The organization whose books are being closed.
+ * @param periodKey The accounting MONTH being closed, `'2026-08'`. A day key is
+ * refused: this entry summarizes a month.
+ *
+ * @returns The inputs, or an {@link UnprocessableEntityError} that names the
+ * exact row, setting or movement to fix. Nothing here is ever defaulted,
+ * skipped, or coerced to zero.
+ */
+export async function gatherMonthEndInventoryInputs(
+  db: Database,
+  organizationId: string,
+  periodKey: string
+): Promise<Result<MonthEndInventoryInputs, Error>> {
+  try {
+    const baselineResult = await readOpeningBaseline(organizationId)
+    if (baselineResult.isErr()) return err(baselineResult.error)
+    const { cutoffPeriod, bookTimeZone, balances: openingBalances } = baselineResult.value
+
+    const month = requireMonthKey(periodKey)
+    if (compareMonths(month, cutoffPeriod) <= 0) {
+      return err(
+        new UnprocessableEntityError(
+          `Cannot close ${month}: the accounting cutoff is ${cutoffPeriod}, so ${month} is ` +
+            'covered by the frozen opening balances rather than by the subledger. Close a ' +
+            'month after the cutoff.',
+          { organizationId, periodKey: month, cutoffPeriod }
+        )
+      )
+    }
+
+    // The half-open instant window `[start, end)`, both derived from wall-clock
+    // midnights in the BOOK timezone. Expressed as "the first instant of the
+    // month after" on both ends rather than "the last instant of" — the latter
+    // needs a fictional 23:59:59.999 that a leap second or a sub-millisecond
+    // timestamp can fall outside of.
+    const windowStart = monthStartInstant(nextMonth(cutoffPeriod), bookTimeZone)
+    const windowEnd = monthStartInstant(nextMonth(month), bookTimeZone)
+
+    // The last DAY of the period, in the book timezone: the instant one
+    // millisecond before the window closes, formatted through the same helper
+    // every other period derivation uses. A calendar month's last day number is
+    // zone-independent, but routing it through `periodKeyForDate` means this
+    // date and the window boundaries cannot disagree.
+    const txnDate = periodKeyForDate(new Date(windowEnd.getTime() - 1), 'day', bookTimeZone)
+
+    const [prior, movements, absorption] = await Promise.all([
+      readPriorSnapshot(db, organizationId, month, openingBalances),
+      readMovementTotals(db, organizationId, windowStart, windowEnd),
+      readAbsorptionTotals(db, organizationId, windowStart, windowEnd),
+    ])
+
+    const current: MonthEndInventorySnapshot = {
+      balances: {
+        inventory_raw_materials:
+          openingBalances.inventory_raw_materials + movements.byRole.inventory_raw_materials,
+        inventory_wip: openingBalances.inventory_wip + movements.byRole.inventory_wip,
+        inventory_finished_goods:
+          openingBalances.inventory_finished_goods + movements.byRole.inventory_finished_goods,
+      },
+      activityTotals: {
+        absorbedLabor: absorption.absorbedLabor,
+        absorbedOverhead: absorption.absorbedOverhead,
+        inventoryAdjustments: movements.inventoryAdjustments,
+      },
+    }
+
+    return ok({ periodKey: month, txnDate, prior, current })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to gather month-end inventory inputs', {
+      error,
+      organizationId,
+      periodKey,
+    })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+// ── The period ─────────────────────────────────────────────────────────────
+
+/**
+ * `periodKey` must be a MONTH key.
+ *
+ * A day key is refused rather than widened to the month containing it: this
+ * entry summarizes a month, and silently accepting `'2026-08-18'` would let a
+ * caller believe it closed the 18th while the arithmetic closed August.
+ */
+function requireMonthKey(periodKey: string): string {
+  const parsed = parsePeriodKey(periodKey)
+  if (parsed.granularity !== 'month') {
+    throw new BadRequestError(
+      `The month-end inventory entry closes a month, not a day - "${periodKey}" is a date. ` +
+        'Pass a YYYY-MM period key.',
+      { periodKey }
+    )
+  }
+  return periodKey
+}
+
+/** `'2026-12'` -> `'2027-01'`. Month keys are zero-padded, so December rolls. */
+function nextMonth(monthKey: string): string {
+  const { year, month } = parsePeriodKey(monthKey)
+  const nextYear = month === 12 ? year + 1 : year
+  const next = month === 12 ? 1 : month + 1
+  return `${String(nextYear).padStart(4, '0')}-${String(next).padStart(2, '0')}`
+}
+
+/**
+ * The INSTANT at which `monthKey` begins in `timeZone`.
+ *
+ * This is rule B made mechanical. `fromZonedTime` reads the wall-clock string as
+ * local to the zone and returns the UTC instant it corresponds to, which is the
+ * same `date-fns-tz` call `workflow-engine/nodes/wait/*` and `sequences/anchor`
+ * already use for exactly this. Hand-rolled offset arithmetic gets DST wrong
+ * roughly twice a year, and one of those two times is inside a month boundary.
+ */
+function monthStartInstant(monthKey: string, timeZone: string): Date {
+  const instant = fromZonedTime(`${monthKey}-01T00:00:00`, timeZone)
+  if (Number.isNaN(instant.getTime())) {
+    throw new UnprocessableEntityError(
+      `Could not place the start of ${monthKey} in the book timezone "${timeZone}"`,
+      { periodKey: monthKey, timeZone }
+    )
+  }
+  return instant
+}
+
+// ── The prior snapshot ─────────────────────────────────────────────────────
+
+/**
+ * What the previous effective posting asserted about the world after itself.
+ *
+ * The selection rule is exact and load-bearing: the `posted`
+ * `month_end_inventory` row with the greatest `periodKey` STRICTLY BEFORE this
+ * period, then the greatest `revision` within that period. The original of a
+ * reversal pair is `reversed` and drops out; its effective reversal or re-entry
+ * is `posted`. Every revision carries the balances resulting AFTER itself, so
+ * the highest posted revision of the latest earlier period is the one number the
+ * delta may be measured from.
+ *
+ * The `<` is a plain string compare, which is exact for zero-padded `YYYY-MM`
+ * and is the same property `compareMonths` relies on.
+ *
+ * 🛑 **A prior row whose draft carries no assertions is a CORRUPT CHAIN and
+ * fails the close, naming the document.** It must NOT fall back to the opening
+ * baseline: that would silently restate every month between the cutoff and now
+ * into one entry, which balances perfectly and is invisible until somebody
+ * reconciles by hand. `postEntry` refuses to claim a `month_end_inventory`
+ * without assertions (`draft.ts`'s `requiresAssertions`), so such a row can only
+ * have been written by something that bypassed it.
+ */
+async function readPriorSnapshot(
+  db: Database,
+  organizationId: string,
+  periodKey: string,
+  openingBalances: MonthEndInventorySnapshot['balances']
+): Promise<MonthEndInventorySnapshot> {
+  const [row] = await db
+    .select({
+      docNumber: schema.GlPosting.docNumber,
+      periodKey: schema.GlPosting.periodKey,
+      revision: schema.GlPosting.revision,
+      draft: schema.GlPosting.draft,
+    })
+    .from(schema.GlPosting)
+    .where(
+      and(
+        eq(schema.GlPosting.organizationId, organizationId),
+        eq(schema.GlPosting.postingType, 'month_end_inventory'),
+        eq(schema.GlPosting.status, 'posted'),
+        lt(schema.GlPosting.periodKey, periodKey)
+      )
+    )
+    .orderBy(desc(schema.GlPosting.periodKey), desc(schema.GlPosting.revision))
+    .limit(1)
+
+  // The cutover. No previous posting exists, so the prior IS the frozen
+  // reconciled opening baseline — and its activity totals are all zero, because
+  // nothing has been absorbed or adjusted since a cutoff that has only just
+  // happened. This never assumes zero BALANCES and never manufactures a
+  // synthetic `GlPosting` for an entry auxx.ai did not post.
+  if (!row) {
+    return {
+      balances: { ...openingBalances },
+      activityTotals: { absorbedLabor: 0, absorbedOverhead: 0, inventoryAdjustments: 0 },
+    }
+  }
+
+  const draft = parsePostingDraft(row.draft)
+  if (!draft.assertions) {
+    throw new UnprocessableEntityError(
+      `The previous month-end inventory posting ${row.docNumber} (${row.periodKey} revision ` +
+        `${row.revision}) carries no balance assertions, so there is nothing for ${periodKey} ` +
+        'to measure its delta against. The assertion chain is broken and must be repaired ' +
+        'before another close; falling back to the opening baseline here would silently ' +
+        'restate every month since the cutoff into one entry.',
+      { organizationId, periodKey, priorDocNumber: row.docNumber, priorPeriodKey: row.periodKey }
+    )
+  }
+
+  return draft.assertions.after
+}
+
+// ── The movement ledger ────────────────────────────────────────────────────
+
+interface MovementTotals {
+  /** Σ signed `extendedCost` per inventory role, over the window. */
+  byRole: Record<InventoryRole, number>
+  /** The same sum restricted to `adjust`. SIGNED — negative is shrinkage. */
+  inventoryAdjustments: number
+}
+
+/**
+ * The cumulative movement totals from the cutoff through the period end.
+ *
+ * `inventoryAdjustments` is a SEPARATE total, not a subtraction from the
+ * balances: an `adjust` movement legitimately appears in both. It moved
+ * inventory (so it belongs in the balance) and `G12` requires count and
+ * shrinkage to be classified into their own role rather than buried in the COGS
+ * plug (so it belongs in its own total too). The builder's 5095 lane and its
+ * inventory lanes are different legs of the same entry, and the plug absorbs the
+ * difference.
+ *
+ * Aggregated in SQL, in one pass over the window, because this runs over the
+ * whole ledger from the cutoff forward and grows every month.
+ */
+async function readMovementTotals(
+  db: Database,
+  organizationId: string,
+  windowStart: Date,
+  windowEnd: Date
+): Promise<MovementTotals> {
+  const movementDefId = await getCachedEntityDefId(organizationId, 'stock_movement')
+  if (!movementDefId) {
+    throw new UnprocessableEntityError(
+      'This organization has no stock movement entity definition, so its inventory balance ' +
+        'cannot be read from the subledger',
+      { organizationId }
+    )
+  }
+
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...MOVEMENT_ATTRIBUTES])) as Record<
+    (typeof MOVEMENT_ATTRIBUTES)[number],
+    { id: string } | null
+  >
+
+  const required = [
+    'stock_movement_type',
+    'stock_movement_unit_cost',
+    'stock_movement_extended_cost',
+    'stock_movement_gl_account',
+    'stock_movement_occurred_at',
+  ] as const
+  const missing = required.filter((attribute) => !fields[attribute])
+  if (missing.length > 0) {
+    throw new UnprocessableEntityError(
+      `Closing the books is not available until the stock movement costing fields are ` +
+        `provisioned. Missing: ${missing.join(', ')}.`,
+      { organizationId, missing }
+    )
+  }
+
+  const occurredAt = alias(schema.FieldValue, 'mv_occurred')
+  const extendedCost = alias(schema.FieldValue, 'mv_extended')
+  const unitCost = alias(schema.FieldValue, 'mv_unit')
+  const glAccount = alias(schema.FieldValue, 'mv_gl')
+  const movementType = alias(schema.FieldValue, 'mv_type')
+  const explosionParent = alias(schema.FieldValue, 'mv_explode')
+
+  /** `EntityInstance` -> its `FieldValue` row for one field. */
+  const on = (table: FieldValueAlias, fieldId: string): SQL | undefined =>
+    and(
+      eq(table.entityId, schema.EntityInstance.id),
+      eq(table.organizationId, schema.EntityInstance.organizationId),
+      eq(table.fieldId, fieldId)
+    )
+
+  /** Every live, non-explosion-parent movement in the org. */
+  const scope = and(
+    eq(schema.EntityInstance.organizationId, organizationId),
+    eq(schema.EntityInstance.entityDefinitionId, movementDefId),
+    isNull(schema.EntityInstance.archivedAt),
+    // See the module header: the parent of a BOM explosion carries no quantity
+    // of its own and is excluded from the quantity ledger for the same reason.
+    or(isNull(explosionParent.valueBoolean), eq(explosionParent.valueBoolean, false))
+  )
+
+  // `valueDate` is `timestamp with time zone`, so this is an INSTANT comparison
+  // against two instants derived from wall-clock midnights in the book timezone
+  // — rule B, discharged by the boundaries rather than by anything per-row.
+  const inWindow = and(
+    gte(occurredAt.valueDate, windowStart.toISOString()),
+    lt(occurredAt.valueDate, windowEnd.toISOString())
+  )
+
+  // ── Rule A, first and on its own ──────────────────────────────────────────
+  //
+  // A movement counts as an offender when it is inside the window and missing a
+  // cost or a role, OR when it has no accounting date at all but was LEARNED OF
+  // after the window opened.
+  //
+  // 🛑 That second clause is the only place `createdAt` appears in this file, and
+  // it is not a period classification — it is the answer to "is this undateable
+  // row recent enough to be a defect?". A movement with no `occurred_at` cannot
+  // be placed in any period, so the window predicate cannot see it at all; a
+  // reader that stopped at the window predicate would therefore drop it in
+  // silence, which is precisely the balanced-but-understated entry rule A
+  // exists to refuse. Rows created before the window opened stay ignored — they
+  // are the pre-costing history the opening snapshot replaces.
+  //
+  // Every join below is a LEFT join, on purpose. An INNER join on the cost
+  // fields would make an uncosted movement invisible to this query — which is
+  // rule A's failure mode expressed in SQL rather than in code.
+  const offenders = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .leftJoin(explosionParent, on(explosionParent, fields.stock_movement_adjust_subparts?.id ?? ''))
+    .leftJoin(occurredAt, on(occurredAt, fields.stock_movement_occurred_at!.id))
+    .leftJoin(extendedCost, on(extendedCost, fields.stock_movement_extended_cost!.id))
+    .leftJoin(unitCost, on(unitCost, fields.stock_movement_unit_cost!.id))
+    .leftJoin(glAccount, on(glAccount, fields.stock_movement_gl_account!.id))
+    .where(
+      and(
+        scope,
+        or(
+          and(
+            inWindow,
+            or(
+              isNull(extendedCost.valueNumber),
+              isNull(unitCost.valueNumber),
+              isNull(glAccount.valueText),
+              sql`length(trim(coalesce(${glAccount.valueText}, ''))) = 0`,
+              notInArray(glAccount.valueText, [...INVENTORY_ROLES])
+            )
+          ),
+          and(isNull(occurredAt.valueDate), gte(schema.EntityInstance.createdAt, windowStart))
+        )
+      )
+    )
+    .limit(MAX_NAMED_OFFENDERS + 1)
+
+  if (offenders.length > 0) {
+    const named = offenders.slice(0, MAX_NAMED_OFFENDERS).map((row) => row.id)
+    const more = offenders.length > MAX_NAMED_OFFENDERS ? ' (and more)' : ''
+    throw new UnprocessableEntityError(
+      `Cannot close the books: ${named.length}${more} stock movement(s) written after the ` +
+        'accounting cutoff have no accounting date, no frozen cost, or no inventory role. ' +
+        'Every sanctioned writer refuses to write one, so these were written outside those ' +
+        'doors. They are refused rather than skipped, because skipping them produces a ' +
+        `journal entry that balances and understates inventory with no signal. Movements: ${named.join(', ')}${more}.`,
+      { organizationId, movementIds: named }
+    )
+  }
+
+  // ── The sums ──────────────────────────────────────────────────────────────
+  const rows = await db
+    .select({
+      role: glAccount.valueText,
+      total: sql<string | number>`coalesce(sum(${extendedCost.valueNumber}), 0)`,
+      adjustTotal: sql<
+        string | number
+      >`coalesce(sum(${extendedCost.valueNumber}) filter (where ${movementType.optionId} = 'adjust'), 0)`,
+    })
+    .from(schema.EntityInstance)
+    .leftJoin(explosionParent, on(explosionParent, fields.stock_movement_adjust_subparts?.id ?? ''))
+    .innerJoin(occurredAt, on(occurredAt, fields.stock_movement_occurred_at!.id))
+    .innerJoin(extendedCost, on(extendedCost, fields.stock_movement_extended_cost!.id))
+    .innerJoin(glAccount, on(glAccount, fields.stock_movement_gl_account!.id))
+    .leftJoin(movementType, on(movementType, fields.stock_movement_type!.id))
+    .where(and(scope, inWindow))
+    .groupBy(glAccount.valueText)
+
+  const byRole: Record<InventoryRole, number> = {
+    inventory_raw_materials: 0,
+    inventory_wip: 0,
+    inventory_finished_goods: 0,
+  }
+  let inventoryAdjustments = 0
+
+  for (const row of rows) {
+    const role = row.role
+    // Unreachable: the offender scan above already refused every movement whose
+    // role is absent or is not one of the three. Kept as a hard stop rather than
+    // a silent `continue`, because a `continue` here would be rule A defeated by
+    // a later edit to that scan.
+    if (!role || !isInventoryRole(role)) {
+      throw new UnprocessableEntityError(
+        `Stock movements after the accounting cutoff carry the unknown inventory role ` +
+          `"${String(role)}". Only ${INVENTORY_ROLES.join(', ')} may value the books.`,
+        { organizationId, role: String(role) }
+      )
+    }
+    byRole[role] += toMinorUnits(row.total, `${role} balance`)
+    inventoryAdjustments += toMinorUnits(row.adjustTotal, 'inventory adjustments')
+  }
+
+  return { byRole, inventoryAdjustments }
+}
+
+function isInventoryRole(value: string): value is InventoryRole {
+  return (INVENTORY_ROLES as readonly string[]).includes(value)
+}
+
+// ── The build rows ─────────────────────────────────────────────────────────
+
+interface AbsorptionTotals {
+  absorbedLabor: number
+  absorbedOverhead: number
+}
+
+/**
+ * Cumulative absorbed labour and overhead from the cutoff through the period
+ * end, read from the FROZEN `build_labor_cost` / `build_overhead_cost`.
+ *
+ * 🛑 **Not from the movement ledger, and that is not an oversight.** A movement
+ * freezes one total `unit_cost` and has no labour or overhead column, so the
+ * split is not in there to recover. Re-deriving it from the part's CURRENT
+ * `standardLaborCost` would value last month's production at this month's rates
+ * — the restatement the frozen-cost rule exists to prevent.
+ *
+ * ⚠️ **Reversals are NOT filtered, deliberately.** `reverse-build.ts` writes a
+ * NEGATED `build_labor_cost` onto a second build row, so the cumulative sum nets
+ * a reversal out on its own. Filtering reversals would double-count the
+ * correction: the original's absorption would stay in the total AND the negation
+ * that cancels it would be gone.
+ *
+ * Membership is `build_completed_at`, in the book timezone, for the reason in
+ * rule B. A planned or in-progress build has no completion date and contributes
+ * nothing, which is correct — `B2` says a planned build writes no movements
+ * either.
+ */
+async function readAbsorptionTotals(
+  db: Database,
+  organizationId: string,
+  windowStart: Date,
+  windowEnd: Date
+): Promise<AbsorptionTotals> {
+  const buildDefId = await getCachedEntityDefId(organizationId, 'build')
+  // An org with no build entity has produced nothing, so it has absorbed
+  // nothing. Zero here is a real answer, not a default standing in for one.
+  if (!buildDefId) return { absorbedLabor: 0, absorbedOverhead: 0 }
+
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...BUILD_ATTRIBUTES])) as Record<
+    (typeof BUILD_ATTRIBUTES)[number],
+    { id: string } | null
+  >
+
+  if (!fields.build_completed_at || !fields.build_labor_cost || !fields.build_overhead_cost) {
+    throw new UnprocessableEntityError(
+      'Closing the books is not available until the build absorption fields ' +
+        '(build_completed_at, build_labor_cost, build_overhead_cost) are provisioned.',
+      { organizationId }
+    )
+  }
+
+  const completedAt = alias(schema.FieldValue, 'b_completed')
+  const laborCost = alias(schema.FieldValue, 'b_labor')
+  const overheadCost = alias(schema.FieldValue, 'b_overhead')
+
+  const on = (table: FieldValueAlias, fieldId: string): SQL | undefined =>
+    and(
+      eq(table.entityId, schema.EntityInstance.id),
+      eq(table.organizationId, schema.EntityInstance.organizationId),
+      eq(table.fieldId, fieldId)
+    )
+
+  const [row] = await db
+    .select({
+      labor: sql<string | number>`coalesce(sum(${laborCost.valueNumber}), 0)`,
+      overhead: sql<string | number>`coalesce(sum(${overheadCost.valueNumber}), 0)`,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(completedAt, on(completedAt, fields.build_completed_at.id))
+    .leftJoin(laborCost, on(laborCost, fields.build_labor_cost.id))
+    .leftJoin(overheadCost, on(overheadCost, fields.build_overhead_cost.id))
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, buildDefId),
+        isNull(schema.EntityInstance.archivedAt),
+        gte(completedAt.valueDate, windowStart.toISOString()),
+        lt(completedAt.valueDate, windowEnd.toISOString())
+      )
+    )
+
+  return {
+    absorbedLabor: toMinorUnits(row?.labor ?? 0, 'absorbed labour'),
+    absorbedOverhead: toMinorUnits(row?.overhead ?? 0, 'absorbed overhead'),
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Coerce one aggregate to integer minor units.
+ *
+ * `FieldValue.valueNumber` is `double precision`, so `SUM` comes back as a
+ * float and — depending on the driver and the aggregate — as a number or a
+ * string. Every stored cost is a whole number of minor units, so a sum of them
+ * is exact well past any balance this ledger will hold; `Math.round` is here to
+ * absorb float representation, not to make a fractional cent go away. A value
+ * that is not finite is refused rather than rounded: `NaN` propagates silently
+ * through the builder's subtraction and would surface naming an account role
+ * rather than the sum that poisoned it.
+ */
+function toMinorUnits(value: string | number, label: string): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) {
+    throw new UnprocessableEntityError(
+      `The ${label} total read from the subledger is not a finite number (${String(value)})`,
+      { field: label, value: String(value) }
+    )
+  }
+  return Math.round(numeric)
+}

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -22,6 +22,11 @@ export {
   type VendorBillEntryInput,
 } from './build-entry'
 export {
+  type BuiltMonthEndInventoryDraft,
+  buildMonthEndInventoryEntry,
+  type MonthEndInventoryInputs,
+} from './build-month-end-inventory'
+export {
   DEFAULT_CHART_OF_ACCOUNTS,
   type DefaultChartAccount,
   type GlAccountTypeValue,
@@ -42,6 +47,7 @@ export {
   requiresAssertions,
   reverseAssertions,
 } from './draft'
+export { gatherMonthEndInventoryInputs } from './gather-month-end-inventory'
 export {
   FINALIZED_SETUP_STATE,
   OPENING_BASELINE_SETTING_KEYS,
@@ -80,6 +86,13 @@ export {
   resolveAccountingProvider,
   setConnectedProviderResolver,
 } from './provider'
+export {
+  ENABLED_POSTING_TYPES,
+  findInventoryWriterConflicts,
+  INVENTORY_ROLES,
+  INVENTORY_ROLES_BY_POSTING_TYPE,
+  type InventoryWriterConflict,
+} from './regime'
 export { type ResolvedAccount, resolveRoles } from './resolve-roles'
 export { type ReverseEntryOptions, reverseEntry } from './reverse-entry'
 export {

--- a/packages/lib/src/postings/regime.ts
+++ b/packages/lib/src/postings/regime.ts
@@ -1,0 +1,88 @@
+// packages/lib/src/postings/regime.ts
+//
+// PURE. Which posting regime is live, and the roles each posting type may drive.
+//
+// This file exists for one assertion, and the assertion is the only mechanical
+// guard that L1 and L3 are not both running (plans/money/04-books.md §2.2,
+// gap-e risk E5).
+//
+// ── The failure it prevents ─────────────────────────────────────────────────
+//
+// `1310` / `1320` / `1330` may be driven by a monthly balance ASSERTION or by
+// per-event postings, never both. The two are not additive and the conflict is
+// undetectable downstream: the month-end entry moves each inventory account TO
+// the value the subledger computes, so it would silently reverse every perpetual
+// posting made during the month and dump the residual into the COGS plug, where
+// it reads exactly like consumption. Both entries balance. Both claim cleanly.
+// Nothing in the engine can tell the difference.
+//
+// `receipt` and `vendor_bill` are present in `POSTING_TYPES` and in the pgEnum,
+// and `buildReceiptEntry` / `buildVendorBillEntry` are written and tested - they
+// are the L3 regime, deliberately built ahead and deliberately not enabled. So
+// the union does not tell you what is live, and neither does the existence of a
+// builder. This constant does.
+
+import { ACCOUNT_ROLES, type AccountRole } from './build-entry'
+import type { PostingType } from './types'
+
+/**
+ * The posting types a production close may actually emit today.
+ *
+ * 🛑 **Turning L3 on is ONE change, never two.** Adding `receipt` and
+ * `vendor_bill` here while leaving `month_end_inventory` is the exact
+ * both-regimes-live state {@link assertSingleInventoryWriter} refuses. Swap the
+ * contents; do not extend them.
+ */
+export const ENABLED_POSTING_TYPES: readonly PostingType[] = ['month_end_inventory']
+
+/** The three accounts that may only ever have one writer. */
+export const INVENTORY_ROLES: readonly AccountRole[] = [
+  ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS,
+  ACCOUNT_ROLES.INVENTORY_WIP,
+  ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS,
+]
+
+/**
+ * Which inventory roles each posting type can put on a line.
+ *
+ * DECLARED, not derived from the builders. Deriving it would make the assertion
+ * tautological - a builder that started emitting an inventory role would simply
+ * be reflected here and the check would keep passing. The point is that a human
+ * has to come to this file and say so.
+ */
+export const INVENTORY_ROLES_BY_POSTING_TYPE: Record<PostingType, readonly AccountRole[]> = {
+  // Asserts all three to the subledger's computed balance. The L1 regime.
+  month_end_inventory: INVENTORY_ROLES,
+  // L3. `buildReceiptEntry` debits raw materials or finished goods at landed
+  // cost - built, tested, and not enabled.
+  receipt: [ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS, ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS],
+  // L3. Moves GRNI to A/P with a PPV residual; touches no inventory account.
+  vendor_bill: [],
+  fulfillment: [],
+  payout: [],
+  build: [],
+  month_end_deferral: [],
+  month_end_reversal: [],
+}
+
+/** One posting type paired with the inventory roles it would drive. */
+export interface InventoryWriterConflict {
+  role: AccountRole
+  postingTypes: PostingType[]
+}
+
+/**
+ * Every inventory role that more than one ENABLED posting type would drive.
+ *
+ * Empty is the healthy answer. A non-empty result means the ledger is running
+ * two regimes at once and the inventory accounts are being both accumulated and
+ * asserted.
+ */
+export function findInventoryWriterConflicts(
+  enabled: readonly PostingType[] = ENABLED_POSTING_TYPES
+): InventoryWriterConflict[] {
+  return INVENTORY_ROLES.flatMap((role) => {
+    const writers = enabled.filter((type) => INVENTORY_ROLES_BY_POSTING_TYPE[type].includes(role))
+    return writers.length > 1 ? [{ role, postingTypes: writers }] : []
+  })
+}


### PR DESCRIPTION
The rest of task 09. With this, **the subledger reaches the general ledger end to end** — opening baseline → movements and builds → a balanced entry → a claimed, posted `GlPosting`.

Follows #1979 (the contract and builder), #1978 (the poster), #1977 (the GL foundation).

| | |
| --- | --- |
| `postings/gather-month-end-inventory.ts` | The reader. Four queries → `MonthEndInventoryInputs` |
| `postings/regime.ts` | The E5 assertion, which #1979 skipped |
| `docs/inventory-costing-architecture-guide.md` | §9.5 for the reader; §9.1/§9.2 corrected |

## 🛑 The plan was wrong, and it would have blocked every close

The brief said any post-cutoff movement missing a cost **fails the close** — the idea being that since #1977 every writer fails closed, an uncosted movement means something wrote outside the sanctioned doors, and filtering it would understate inventory silently.

That is right for ordinary movements and **wrong for BOM-explosion parents.** `explodeBomMovement` writes parents with *no cost fields at all*; the children carry the real quantities. It is why `recalculateQoHForPart` already excludes the parent on `stock_movement_adjust_subparts = true` (`field-hooks/post/inventory-triggers.ts:36`, `:194`).

Verified in Postgres, not inferred: **13 parent rows in dev, zero with an extended cost.**

So a literal reading of the rule would have refused the first close for a perfectly legitimate write, and summing them instead would have double-counted every explosion. Parents are excluded from the sums **and** the scan; children are not, and still fail the close. Both behaviours are pinned by integration tests.

**A second hole in the same rule:** a movement with no `occurred_at` cannot be caught by a window predicate at all — the filter drops it in silence, which is precisely the failure the rule exists to refuse. It is caught separately on `EntityInstance.createdAt`. That is the only `createdAt` in the reader, and it is a *"recent enough to be a defect?"* test, never a period classification.

## The E5 assertion now exists

Task 09's Done-when listed it and #1979 shipped without it. It is the **only mechanical guard that L1 and L3 are not both live**, and what it guards against is undetectable downstream: the monthly assertion moves each inventory account *to* a computed value, so it silently reverses every per-event posting made that month and the residual lands in the COGS plug **looking exactly like consumption**. Both entries balance. Both claim cleanly.

`regime.ts` names `ENABLED_POSTING_TYPES` (`['month_end_inventory']`) and declares which inventory roles each posting type would drive. The map is **declared, not derived from the builders** — deriving it would make the check tautological, since a builder that started emitting an inventory role would simply be reflected and keep passing. The point is that a human has to come to the file and say so.

The test proves it bites, rather than passing vacuously: enabling `receipt` while leaving the assertion on flags raw materials and finished goods, and a clean L3 switch (assertion off) passes.

## Three rules the reader has to hold

- **Membership is the accounting date, in the book timezone** — `stock_movement_occurred_at` and `build_completed_at`. A receipt logged 7pm Jan 31 in `America/New_York` is Feb 1 in UTC.
- **Both lanes are cumulative from the cutoff**, never per-period. A build entered after its month closed carries its frozen labour and overhead into the next open delta instead of dissolving into the plug.
- **Build reversals are deliberately not filtered.** `reverse-build.ts` writes a *negated* `build_labor_cost` on a second row, so the sum nets them out; filtering would double-count the correction.

## One thing this surfaced for task 12

`build_labor_cost` is **never NULL** — `absorbedRunCost` (`builds/client.ts:261`) returns `0` for an unset rate, so `completeBuild` always writes a number. The plan's "a `null` rate must never collapse to `0`" describes `loadAbsorptionRates`' return, not what is written.

The consequence is worse than a NULL: an org with unset absorption rates **absorbs nothing, and the entire amount lands silently in the 5000 plug.** Nothing in the reader can detect it. That is the accounting setup wizard's readiness gate (`plans/money/tasks/12`) and it is now the strongest argument for one.

## Testing

- `vitest run src/postings` — **335 passed**, 15 files (298 before this PR).
- `pnpm -F @auxx/lib test:integration` — **actually executed**: 43 files, **517 passed**, 25 from the new file. The default config excludes `*.int.test.*`, so this was run explicitly.
- Ratchet: `no new type errors (29 total, baseline 29)`.
- The integration assertions were **mutation-tested**: flipping `orderBy(desc(revision))` to ascending and deriving the window end in UTC each turn tests red, so they bite rather than pass vacuously.
- Full `@auxx/lib` unit suite: **14,313 passed**, 79 skipped, 1053 files, exit 0.

## Docs

§9.1 said `postings/` "persists nothing yet" and §9.2 said the builder/poster seam was "designed and not built" — both stale since #1978. Corrected, with the still-design-only list narrowed to the fulfillment entry, the payout entry, the month-end deferral, the close console and the setup wizard.

## Still not drivable end to end

`rollStandardCost` has never been run in any org, so there are no completed builds and no `adjust` movements anywhere. The integration test inserts its own rows. Per `plans/money/tasks/09` §4 that is the intended state — *"the dev DB can prove the code runs; it can never prove the entry is right."*

https://claude.ai/code/session_0129oa1VuSdXQevapg3kLWtU
