### PR TITLE
feat(money): the accounting module and the close console UI

### DIFF
--- a/apps/web/src/app/(protected)/app/accounting/[period]/page.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/[period]/page.tsx
@@ -1,0 +1,16 @@
+// apps/web/src/app/(protected)/app/accounting/[period]/page.tsx
+
+import { LedgerPage } from '~/components/accounting/ui/ledger/ledger-page'
+
+/**
+ * One explicit accounting month. Same component as the module home — only the
+ * period resolution differs (13-accounting-ui.md §5.1).
+ */
+export default async function AccountingPeriodPage({
+  params,
+}: {
+  params: Promise<{ period: string }>
+}) {
+  const { period } = await params
+  return <LedgerPage periodKey={period} />
+}

--- a/apps/web/src/app/(protected)/app/accounting/layout.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/layout.tsx
@@ -1,0 +1,86 @@
+// apps/web/src/app/(protected)/app/accounting/layout.tsx
+
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { MainPageTabs } from '@auxx/ui/components/main-page-tabs'
+import { BookOpenCheck, Settings } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import { AccountingSetupWizardGate } from '~/components/accounting/ui/setup-wizard/setup-wizard-gate'
+import { CapabilityPageGuard } from '~/components/global/capability-page-guard'
+import { useAccess } from '~/providers/capabilities-provider'
+
+/**
+ * Module header for `/app/accounting/*` — Ledger · Settings via `MainPageTabs`
+ * in route mode, the same shape `dispatch/layout.tsx` uses for Board · Settings.
+ *
+ * ⚠️ The date/period navigation is deliberately NOT here. Dispatch keeps its
+ * header to breadcrumb + tabs and puts the date nav in a toolbar inside
+ * `MainPageContent` (`board-toolbar.tsx`); the ledger's period picker follows
+ * that, in `ledger-toolbar.tsx`.
+ */
+function AccountingLayoutHeader() {
+  const { can } = useAccess()
+
+  return (
+    <MainPageHeader className='justify-start'>
+      <MainPageBreadcrumb>
+        <MainPageBreadcrumbItem title='Accounting' href='/app/accounting' />
+      </MainPageBreadcrumb>
+      <MainPageTabs
+        items={[
+          {
+            value: 'ledger',
+            label: 'Ledger',
+            icon: <BookOpenCheck />,
+            href: '/app/accounting',
+            tooltip: 'Ledger',
+          },
+          {
+            value: 'settings',
+            label: 'Settings',
+            icon: <Settings />,
+            // The SEGMENT, not a leaf: `MainPageTabs` matches longest-prefix, so
+            // a leaf href leaves every sibling settings page matching only
+            // `/app/accounting` and showing Ledger as active.
+            href: '/app/accounting/settings',
+            tooltip: 'Settings',
+            hidden: !can('ledger.post'),
+          },
+        ]}
+      />
+    </MainPageHeader>
+  )
+}
+
+/**
+ * Module shell for `/app/accounting/*` (plans/money/tasks/13-accounting-ui.md §1).
+ *
+ * `AccountingSetupWizardGate` mounts here so the wizard can auto-open on first
+ * visit anywhere under this route tree; it renders nothing until its own gating
+ * conditions are met.
+ *
+ * 🛑 The `ledger.view` guard is only half the gate. `FeatureKey.accounting` is
+ * enforced server-side on the `ledger` router — a feature key that only hides a
+ * nav item is a fake gate, because the procedures stay callable.
+ */
+export default function AccountingLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const isSettings = pathname.startsWith('/app/accounting/settings')
+  const permissionKey = isSettings ? 'ledger.post' : 'ledger.view'
+
+  return (
+    <CapabilityPageGuard permissionKey={permissionKey} area='Accounting'>
+      <MainPage>
+        <AccountingLayoutHeader />
+        {children}
+        <AccountingSetupWizardGate />
+      </MainPage>
+    </CapabilityPageGuard>
+  )
+}

--- a/apps/web/src/app/(protected)/app/accounting/page.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/page.tsx
@@ -1,0 +1,16 @@
+// apps/web/src/app/(protected)/app/accounting/page.tsx
+
+import { LedgerPage } from '~/components/accounting/ui/ledger/ledger-page'
+
+/**
+ * Module home — the RESOLVED period (13-accounting-ui.md §5.1).
+ *
+ * 🛑 Renders, never redirects. A redirect would make the module home URL
+ * unstable and break "Accounting" as a bookmark. `LedgerPage` with no
+ * `periodKey` resolves one itself: the earliest unposted month, else the most
+ * recent posted one — and when setup is not finalized it renders the
+ * getting-started checklist instead.
+ */
+export default function AccountingHome() {
+  return <LedgerPage />
+}

--- a/apps/web/src/app/(protected)/app/accounting/settings/accounts/page.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/settings/accounts/page.tsx
@@ -1,0 +1,7 @@
+// apps/web/src/app/(protected)/app/accounting/settings/accounts/page.tsx
+
+import { AccountingAccountsSettingsPage } from '~/components/accounting/ui/settings/accounts-settings-page'
+
+export default function Page() {
+  return <AccountingAccountsSettingsPage />
+}

--- a/apps/web/src/app/(protected)/app/accounting/settings/general/page.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/settings/general/page.tsx
@@ -1,0 +1,7 @@
+// apps/web/src/app/(protected)/app/accounting/settings/general/page.tsx
+
+import { AccountingGeneralSettingsPage } from '~/components/accounting/ui/settings/general-settings-page'
+
+export default function Page() {
+  return <AccountingGeneralSettingsPage />
+}

--- a/apps/web/src/app/(protected)/app/accounting/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/settings/layout.tsx
@@ -1,0 +1,69 @@
+// apps/web/src/app/(protected)/app/accounting/settings/layout.tsx
+
+'use client'
+
+import { MainPageContent } from '@auxx/ui/components/main-page'
+import { Landmark, Scale, SlidersHorizontal } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import SidebarSecondary from '~/components/global/sidebar-secondary'
+import type { SidebarProps } from '~/constants/menu'
+
+/**
+ * Accounting settings navigation (13-accounting-ui.md §5.4) — THREE pages, not
+ * four. Costing folds into General: four sections in a two-column grid is
+ * exactly `scheduling-settings-page.tsx`'s shape, so General is not overloaded.
+ */
+const ACCOUNTING_SETTINGS: SidebarProps[] = [
+  {
+    id: 'accounting-settings',
+    label: 'Accounting',
+    type: 'header',
+    items: [
+      {
+        id: 'accounting-settings-general',
+        label: 'General',
+        slug: 'general',
+        icon: <SlidersHorizontal />,
+        description: 'Period, timezone, absorption rates and the standard-cost roll',
+      },
+      {
+        id: 'accounting-settings-opening',
+        label: 'Opening balances',
+        slug: 'opening',
+        icon: <Scale />,
+        description: 'The auxx and QuickBooks snapshots, and their reconciliation',
+        keywords: ['cutover', 'baseline', 'quickbooks'],
+      },
+      {
+        id: 'accounting-settings-accounts',
+        label: 'Accounts',
+        slug: 'accounts',
+        icon: <Landmark />,
+        description: 'Map posting roles to accounts, and edit the chart',
+        keywords: ['chart of accounts', 'roles', 'gl'],
+      },
+    ],
+  },
+]
+
+export default function AccountingSettingsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const pages = pathname.split('/')
+  const page = pages[pages.length - 1]
+
+  return (
+    <MainPageContent>
+      {/* `md:` must match SidebarSecondary's own breakpoint — at `sm:` the sidebar is
+          still in mobile-disclosure mode with no fixed width and collapses to a sliver. */}
+      <div className='flex flex-col md:flex-row h-full flex-1 overflow-hidden'>
+        <SidebarSecondary
+          items={ACCOUNTING_SETTINGS}
+          baseUrl='/app/accounting/settings'
+          current={page}
+          title='Settings'
+        />
+        <div className='relative flex h-full w-full flex-1 grow overflow-hidden'>{children}</div>
+      </div>
+    </MainPageContent>
+  )
+}

--- a/apps/web/src/app/(protected)/app/accounting/settings/opening/page.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/settings/opening/page.tsx
@@ -1,0 +1,7 @@
+// apps/web/src/app/(protected)/app/accounting/settings/opening/page.tsx
+
+import { AccountingOpeningSettingsPage } from '~/components/accounting/ui/settings/opening-settings-page'
+
+export default function Page() {
+  return <AccountingOpeningSettingsPage />
+}

--- a/apps/web/src/app/(protected)/app/accounting/settings/page.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/settings/page.tsx
@@ -1,0 +1,20 @@
+// apps/web/src/app/(protected)/app/accounting/settings/page.tsx
+
+import { redirect } from 'next/navigation'
+
+/**
+ * Index route for the accounting settings segment.
+ *
+ * Two things need it. `SidebarSecondary` always links to `${baseUrl}/${slug}`
+ * with no empty-slug support, and `MainPageTabs` derives its active tab by
+ * LONGEST-PREFIX match on the pathname — so the Settings tab has to point at
+ * this segment rather than at a leaf. Pointing it at `/settings/general`
+ * (which it did) made every OTHER settings page fall through to the `/app/accounting`
+ * prefix and light up the Ledger tab instead. Same shape as
+ * `dispatch/settings/page.tsx`.
+ */
+function AccountingSettings() {
+  redirect('/app/accounting/settings/general')
+}
+
+export default AccountingSettings

--- a/apps/web/src/components/accounting/fixtures.ts
+++ b/apps/web/src/components/accounting/fixtures.ts
@@ -1,0 +1,611 @@
+// apps/web/src/components/accounting/fixtures.ts
+//
+// 🛑 PLACEHOLDER DATA. Delete this file when the four missing procedures land.
+//
+// plans/money/tasks/13-accounting-ui.md §4 lists four tRPC procedures this UI
+// needs that do not exist yet:
+//
+//   * `ledger.previewMonthEnd({ periodKey })`  — `ledger.preview` takes a
+//     CLIENT-SUPPLIED line array, so nothing today can build a month-end entry
+//     from a period key.
+//   * `ledger.postMonthEnd({ periodKey })`     — same.
+//   * `ledger.get(id)`                         — there is no read surface for a
+//     posting at all; `listUnpostedPeriods` returns claimed-but-not-posted only.
+//   * the role-map read/write                  — `GlRoleAssignment` exists and
+//     `resolveRoles` fails closed, but no procedure can read or create one.
+//
+// Until they exist the screens render from here, so the whole surface can be
+// looked at and driven. Every shape below is the REAL lib type imported from
+// `@auxx/lib/postings/client` — not a hand-rolled lookalike — so swapping a
+// fixture for a query is a one-line change and the compiler catches any drift.
+//
+// ⚠️ Numbers are integer MINOR units everywhere, as they are in the real thing.
+// Nothing here should ever be read as dollars.
+
+import type {
+  AccountRole,
+  BooksBalanceReport,
+  EntryPreview,
+  GlAccountTypeValue,
+  PostingAssertions,
+  PostingDraftV1,
+  PostResult,
+  ResolvedPostingLine,
+  UnpostedPeriod,
+} from '@auxx/lib/postings/client'
+
+/** Where the fixture org sits in the calendar, so every screen agrees on "now". */
+export const FIXTURE_CUTOFF_PERIOD = '2026-12'
+export const FIXTURE_CURRENT_PERIOD = '2027-03'
+export const FIXTURE_BOOK_TIME_ZONE = 'America/New_York'
+
+/** Months from the cutoff through the current period, oldest first. */
+export const FIXTURE_PERIODS = ['2027-01', '2027-02', '2027-03'] as const
+
+export type FixturePeriodState = 'open' | 'posted' | 'locked'
+
+export interface FixturePeriodSummary {
+  periodKey: string
+  state: FixturePeriodState
+  docNumber?: string
+  totalMinor?: number
+  /** Present once posted. */
+  postedAt?: string
+  /** `0` for an original; a reversal chain climbs from there. */
+  revision: number
+}
+
+export const FIXTURE_PERIOD_SUMMARIES: FixturePeriodSummary[] = [
+  {
+    periodKey: '2027-01',
+    state: 'locked',
+    docNumber: 'AUXX-MEI-2027-01',
+    totalMinor: 4_812_00,
+    postedAt: '2027-02-03T14:22:00.000Z',
+    revision: 0,
+  },
+  {
+    periodKey: '2027-02',
+    state: 'posted',
+    docNumber: 'AUXX-MEI-2027-02',
+    totalMinor: 6_204_00,
+    postedAt: '2027-03-02T09:41:00.000Z',
+    // A reversal + re-entry happened here, so the revision strip has something
+    // to render. See FIXTURE_REVISIONS.
+    revision: 2,
+  },
+  { periodKey: '2027-03', state: 'open', revision: 0 },
+]
+
+/** The `?posting=<id>` drawer's rows for `2027-02`. Newest revision first. */
+export interface FixtureRevision {
+  glPostingId: string
+  revision: number
+  status: 'posted' | 'reversed'
+  docNumber: string
+  postedAt: string
+  memo?: string
+}
+
+export const FIXTURE_REVISIONS: Record<string, FixtureRevision[]> = {
+  '2027-02': [
+    {
+      glPostingId: 'glp_2027_02_r2',
+      revision: 2,
+      status: 'posted',
+      docNumber: 'AUXX-MEI-2027-02',
+      postedAt: '2027-03-02T09:41:00.000Z',
+      memo: 'Re-entry after the February shrinkage correction.',
+    },
+    {
+      glPostingId: 'glp_2027_02_r1',
+      revision: 1,
+      status: 'posted',
+      docNumber: 'AUXX-MEI-2027-02',
+      postedAt: '2027-03-02T09:38:00.000Z',
+      memo: 'Reversal of revision 0.',
+    },
+    {
+      glPostingId: 'glp_2027_02_r0',
+      revision: 0,
+      status: 'reversed',
+      docNumber: 'AUXX-MEI-2027-02',
+      postedAt: '2027-03-01T17:03:00.000Z',
+    },
+  ],
+}
+
+/**
+ * The account code + name each role resolves to in the fixture org.
+ *
+ * Mirrors the seeded 29-account chart. `ppv` and `inventory_wip` are absent on
+ * purpose: nothing emits them under L1, and `13-accounting-ui.md` §5.4 requires
+ * the role map to let those two be marked unused rather than blocking Preview.
+ */
+export const FIXTURE_ROLE_ACCOUNTS: Partial<Record<AccountRole, { code: string; name: string }>> = {
+  cash: { code: '1010', name: 'Operating Cash' },
+  inventory_raw_materials: { code: '1310', name: 'Inventory — Raw Materials' },
+  inventory_finished_goods: { code: '1330', name: 'Inventory — Finished Goods' },
+  accounts_payable: { code: '2010', name: 'Accounts Payable' },
+  payroll_clearing: { code: '2110', name: 'Payroll Clearing' },
+  freight_accrual: { code: '2150', name: 'Inbound Freight & Brokerage Accrual' },
+  grni: { code: '2160', name: 'Goods Received Not Invoiced' },
+  duties_accrual: { code: '2170', name: 'Duties Accrual' },
+  cogs_product_cost: { code: '5000', name: 'COGS — Product Cost' },
+  applied_overhead: { code: '5020', name: 'COGS — Applied Overhead' },
+  inventory_count_variance: { code: '5095', name: 'Inventory Count Variance' },
+}
+
+/** One row of the org's editable chart (`gl_account`, an EntityInstance). */
+export interface FixtureGlAccount {
+  id: string
+  code: string
+  name: string
+  accountType: GlAccountTypeValue
+  isActive: boolean
+}
+
+export const FIXTURE_CHART: FixtureGlAccount[] = [
+  { id: 'gla_1010', code: '1010', name: 'Operating Cash', accountType: 'asset', isActive: true },
+  {
+    id: 'gla_1310',
+    code: '1310',
+    name: 'Inventory — Raw Materials',
+    accountType: 'asset',
+    isActive: true,
+  },
+  {
+    id: 'gla_1320',
+    code: '1320',
+    name: 'Inventory — Work in Process',
+    accountType: 'asset',
+    isActive: true,
+  },
+  {
+    id: 'gla_1330',
+    code: '1330',
+    name: 'Inventory — Finished Goods',
+    accountType: 'asset',
+    isActive: true,
+  },
+  {
+    id: 'gla_2010',
+    code: '2010',
+    name: 'Accounts Payable',
+    accountType: 'liability',
+    isActive: true,
+  },
+  {
+    id: 'gla_2110',
+    code: '2110',
+    name: 'Payroll Clearing',
+    accountType: 'liability',
+    isActive: true,
+  },
+  {
+    id: 'gla_2150',
+    code: '2150',
+    name: 'Inbound Freight & Brokerage Accrual',
+    accountType: 'liability',
+    isActive: true,
+  },
+  {
+    id: 'gla_2160',
+    code: '2160',
+    name: 'Goods Received Not Invoiced',
+    accountType: 'liability',
+    isActive: true,
+  },
+  {
+    id: 'gla_2170',
+    code: '2170',
+    name: 'Duties Accrual',
+    accountType: 'liability',
+    isActive: true,
+  },
+  {
+    id: 'gla_5000',
+    code: '5000',
+    name: 'COGS — Product Cost',
+    accountType: 'expense',
+    isActive: true,
+  },
+  {
+    id: 'gla_5020',
+    code: '5020',
+    name: 'COGS — Applied Overhead',
+    accountType: 'expense',
+    isActive: true,
+  },
+  {
+    id: 'gla_5090',
+    code: '5090',
+    name: 'Purchase Price Variance',
+    accountType: 'expense',
+    isActive: true,
+  },
+  {
+    id: 'gla_5095',
+    code: '5095',
+    name: 'Inventory Count Variance',
+    accountType: 'expense',
+    isActive: true,
+  },
+]
+
+/** Which roles the fixture org has confirmed, vs merely suggested. `G19` step 4. */
+export type FixtureRoleAssignmentState = 'confirmed' | 'suggested' | 'unmapped' | 'unused'
+
+export const FIXTURE_ROLE_ASSIGNMENT_STATE: Record<string, FixtureRoleAssignmentState> = {
+  cash: 'confirmed',
+  inventory_raw_materials: 'confirmed',
+  inventory_finished_goods: 'confirmed',
+  accounts_payable: 'confirmed',
+  payroll_clearing: 'confirmed',
+  freight_accrual: 'suggested',
+  grni: 'confirmed',
+  duties_accrual: 'suggested',
+  cogs_product_cost: 'confirmed',
+  applied_overhead: 'confirmed',
+  inventory_count_variance: 'confirmed',
+  // Nothing emits either of these under L1 — the map must let them be excused.
+  ppv: 'unused',
+  inventory_wip: 'unused',
+}
+
+// ── The entry ───────────────────────────────────────────────────────────────
+
+function line(
+  accountCode: string,
+  accountName: string,
+  direction: 'debit' | 'credit',
+  amount: number,
+  memo: string,
+  sortOrder: number
+): ResolvedPostingLine & { accountRole: string } {
+  return {
+    accountCode,
+    accountName,
+    accountRole: '',
+    direction,
+    amount,
+    memo,
+    sourceType: 'month_end_inventory',
+    sourceId: '2027-03',
+    sortOrder,
+  }
+}
+
+/**
+ * March 2027's proposed entry.
+ *
+ * Balanced by construction, as the real builder guarantees. `5000` is the plug —
+ * which is exactly why `13-accounting-ui.md` insists the roll-forward is shown
+ * beside the JE: flipping any one lane's direction is absorbed at twice the
+ * error and the entry still balances.
+ */
+export const FIXTURE_PREVIEW_LINES: Array<ResolvedPostingLine & { accountRole: string }> = [
+  {
+    ...line('1310', 'Inventory — Raw Materials', 'debit', 822_000, 'Raw materials movement', 0),
+    accountRole: 'inventory_raw_materials',
+  },
+  {
+    ...line('1330', 'Inventory — Finished Goods', 'credit', 301_000, 'Finished goods movement', 1),
+    accountRole: 'inventory_finished_goods',
+  },
+  {
+    ...line('2110', 'Payroll Clearing', 'credit', 412_000, 'Absorbed assembly labor', 2),
+    accountRole: 'payroll_clearing',
+  },
+  {
+    ...line('5020', 'COGS — Applied Overhead', 'credit', 268_000, 'Absorbed overhead', 3),
+    accountRole: 'applied_overhead',
+  },
+  {
+    ...line('5095', 'Inventory Count Variance', 'debit', 31_000, 'Cycle-count shrinkage', 4),
+    accountRole: 'inventory_count_variance',
+  },
+  {
+    ...line('5000', 'COGS — Product Cost', 'debit', 128_000, 'Balancing figure', 5),
+    accountRole: 'cogs_product_cost',
+  },
+]
+
+export const FIXTURE_PREVIEW: EntryPreview = {
+  postingType: 'month_end_inventory',
+  periodKey: '2027-03',
+  txnDate: '2027-03-31',
+  docNumber: 'AUXX-MEI-2027-03',
+  lines: FIXTURE_PREVIEW_LINES,
+  totalMinor: 981_000,
+}
+
+/**
+ * The same preview, refused.
+ *
+ * 🛑 Task 09 §4 requires an uncosted post-cutoff movement to FAIL the close and
+ * NAME ITSELF rather than be filtered — filtering would produce a balanced entry
+ * that understates inventory with no signal. So the blocker text carries the row.
+ */
+export const FIXTURE_PREVIEW_BLOCKED: EntryPreview = {
+  ...FIXTURE_PREVIEW,
+  lines: [],
+  totalMinor: 0,
+  blockedBy: {
+    status: 'account_unmapped',
+    error: 'No account is mapped for role "applied_overhead".',
+  },
+}
+
+/** `before` and `after`, which is what the roll-forward renders. */
+export const FIXTURE_ASSERTIONS: PostingAssertions = {
+  kind: 'month_end_inventory',
+  before: {
+    balances: {
+      inventory_raw_materials: 12_040_000,
+      inventory_wip: 0,
+      inventory_finished_goods: 8_810_000,
+    },
+    activityTotals: {
+      absorbedLabor: 1_890_000,
+      absorbedOverhead: 1_204_000,
+      inventoryAdjustments: -84_000,
+    },
+  },
+  after: {
+    balances: {
+      inventory_raw_materials: 12_862_000,
+      inventory_wip: 0,
+      inventory_finished_goods: 8_509_000,
+    },
+    activityTotals: {
+      absorbedLabor: 2_302_000,
+      absorbedOverhead: 1_472_000,
+      inventoryAdjustments: -115_000,
+    },
+  },
+}
+
+/** What `ledger.get(id)` would return for a posted month. */
+export const FIXTURE_POSTED_DRAFT: PostingDraftV1 = {
+  v: 1,
+  docNumber: 'AUXX-MEI-2027-02',
+  revision: 2,
+  memo: 'Re-entry after the February shrinkage correction.',
+  entry: {
+    postingType: 'month_end_inventory',
+    periodKey: '2027-02',
+    txnDate: '2027-02-28',
+    lines: [],
+    totalDebit: 620_400,
+    totalCredit: 620_400,
+  },
+  resolvedLines: FIXTURE_PREVIEW_LINES,
+  assertions: FIXTURE_ASSERTIONS,
+}
+
+export const FIXTURE_POST_RESULT: PostResult = {
+  status: 'posted',
+  glPostingId: 'glp_2027_03_r0',
+  docNumber: 'AUXX-MEI-2027-03',
+  providerId: 'quickbooks',
+  providerEntryId: '184',
+}
+
+/** ⚠️ A first-class outcome, never an error — decision `P1`. */
+export const FIXTURE_POST_RESULT_NOT_CONNECTED: PostResult = {
+  status: 'not_connected',
+  glPostingId: 'glp_2027_03_r0',
+  docNumber: 'AUXX-MEI-2027-03',
+}
+
+export const FIXTURE_UNPOSTED_PERIODS: UnpostedPeriod[] = [
+  {
+    periodKey: '2027-03',
+    postingType: 'month_end_inventory',
+    glPostingId: 'glp_2027_03_r0',
+    status: 'failed',
+    docNumber: 'AUXX-MEI-2027-03',
+    attempts: 2,
+    failureReason: 'QuickBooks refused the entry: account 5020 is inactive.',
+  },
+]
+
+export const FIXTURE_BOOKS_BALANCE: BooksBalanceReport = {
+  balanced: true,
+  postingsChecked: 4,
+  discrepancies: [],
+}
+
+// ── Evidence sections ───────────────────────────────────────────────────────
+
+/** One `G12` count adjustment, as the cycle-count evidence table renders it. */
+export interface FixtureCountAdjustment {
+  movementId: string
+  partNumber: string
+  partName: string
+  systemQuantity: number
+  countedQuantity: number
+  delta: number
+  /** Frozen standard cost at the time of the adjustment, minor units. */
+  unitCostMinor: number
+  extendedCostMinor: number
+  reason: string
+  actorName: string
+  occurredAt: string
+}
+
+export const FIXTURE_COUNT_ADJUSTMENTS: FixtureCountAdjustment[] = [
+  {
+    movementId: 'sm_a1',
+    partNumber: 'HYD-4410',
+    partName: 'Hydraulic cylinder, 4in bore',
+    systemQuantity: 48,
+    countedQuantity: 44,
+    delta: -4,
+    unitCostMinor: 6_250_0,
+    extendedCostMinor: -250_000,
+    reason: 'Cycle count — March',
+    actorName: 'Dana Whitfield',
+    occurredAt: '2027-03-18T15:10:00.000Z',
+  },
+  {
+    movementId: 'sm_a2',
+    partNumber: 'FRM-2201',
+    partName: 'Mast frame weldment',
+    systemQuantity: 12,
+    countedQuantity: 13,
+    delta: 1,
+    unitCostMinor: 4_100_0,
+    extendedCostMinor: 41_000,
+    reason: 'Cycle count — March',
+    actorName: 'Dana Whitfield',
+    occurredAt: '2027-03-18T15:24:00.000Z',
+  },
+  {
+    movementId: 'sm_a3',
+    partNumber: 'CTL-0090',
+    partName: 'Control harness',
+    systemQuantity: 30,
+    countedQuantity: 28,
+    delta: -2,
+    unitCostMinor: 1_010_0,
+    extendedCostMinor: -20_200,
+    reason: 'Damaged in handling',
+    actorName: 'Miguel Ortiz',
+    occurredAt: '2027-03-24T11:02:00.000Z',
+  },
+]
+
+/**
+ * Activity dated before this period but entered after the prior close.
+ *
+ * 🛑 The section that keeps the number explainable. Task 09's legs are CUMULATIVE
+ * deltas, so a build or adjustment dated in a closed month but entered after that
+ * close lands in the next OPEN month's delta. Without this on screen, March's
+ * entry containing February activity reads as a bug.
+ *
+ * `createdAt` says when auxx LEARNED about the row — audit evidence, never its
+ * accounting date.
+ */
+export interface FixtureLateArrival {
+  id: string
+  kind: 'build' | 'adjustment' | 'receipt'
+  reference: string
+  description: string
+  /** The accounting date — what decides which period it belongs to. */
+  occurredAt: string
+  /** When auxx learned about it. */
+  createdAt: string
+  amountMinor: number
+}
+
+export const FIXTURE_LATE_ARRIVALS: FixtureLateArrival[] = [
+  {
+    id: 'bld_0219',
+    kind: 'build',
+    reference: 'BLD-0219',
+    description: 'Backdated February build entered on March 4',
+    occurredAt: '2027-02-26T00:00:00.000Z',
+    createdAt: '2027-03-04T13:47:00.000Z',
+    amountMinor: 214_000,
+  },
+  {
+    id: 'sm_a0',
+    kind: 'adjustment',
+    reference: 'ADJ-0088',
+    description: 'February shrinkage recorded after the February close',
+    occurredAt: '2027-02-27T00:00:00.000Z',
+    createdAt: '2027-03-06T09:15:00.000Z',
+    amountMinor: -31_000,
+  },
+]
+
+/**
+ * What sits behind one line of the entry.
+ *
+ * ⚠️ NOT stored provenance. `GlPostingLineInput` carries ONE `sourceType` +
+ * `sourceId` per line, and a month-end line summarises hundreds of movements —
+ * so the real version of this is a query back into the subledger, a report
+ * rather than an expander. Gap-g §3's "click 4000 and see the 41 order ids" is
+ * not backed by the shipped data.
+ */
+export interface FixtureDrillDownRow {
+  id: string
+  reference: string
+  description: string
+  occurredAt: string
+  quantity: number
+  unitCostMinor: number
+  extendedCostMinor: number
+}
+
+export const FIXTURE_DRILL_DOWN: Record<string, FixtureDrillDownRow[]> = {
+  '1310': [
+    {
+      id: 'sm_r1',
+      reference: 'RCV-1204',
+      description: 'Received against PO-0455',
+      occurredAt: '2027-03-06T00:00:00.000Z',
+      quantity: 40,
+      unitCostMinor: 6_250_0,
+      extendedCostMinor: 2_500_000,
+    },
+    {
+      id: 'sm_r2',
+      reference: 'BLD-0221',
+      description: 'Consumed by build',
+      occurredAt: '2027-03-14T00:00:00.000Z',
+      quantity: -22,
+      unitCostMinor: 6_250_0,
+      extendedCostMinor: -1_375_000,
+    },
+  ],
+  '2110': [
+    {
+      id: 'bld_0221',
+      reference: 'BLD-0221',
+      description: 'Absorbed assembly labor',
+      occurredAt: '2027-03-14T00:00:00.000Z',
+      quantity: 8,
+      unitCostMinor: 51_500,
+      extendedCostMinor: 412_000,
+    },
+  ],
+}
+
+/** Parts with no standard cost — what `settings/general`'s costing section lists. */
+export interface FixtureUnrolledPart {
+  partId: string
+  partNumber: string
+  name: string
+  reason: 'no-live-cost' | 'no-bill-of-materials'
+}
+
+export const FIXTURE_UNROLLED_PARTS: FixtureUnrolledPart[] = [
+  {
+    partId: 'prt_1',
+    partNumber: 'ASM-7700',
+    name: 'Lift assembly, 7700 series',
+    reason: 'no-bill-of-materials',
+  },
+  {
+    partId: 'prt_2',
+    partNumber: 'HYD-4415',
+    name: 'Hydraulic cylinder, 5in bore',
+    reason: 'no-live-cost',
+  },
+]
+
+/** Whether a provider is connected at all. `not_connected` is FIRST-CLASS (`P1`). */
+export const FIXTURE_PROVIDER = {
+  id: 'quickbooks' as const,
+  label: 'QuickBooks Online',
+  connected: true,
+  realmId: '4620816365320394982',
+}
+
+/** Deep link into the provider's own register, so reconciliation is not copy-paste. */
+export function fixtureProviderEntryUrl(providerEntryId: string): string {
+  return `https://app.qbo.intuit.com/app/journal?txnId=${providerEntryId}`
+}

--- a/apps/web/src/components/accounting/getting-started.ts
+++ b/apps/web/src/components/accounting/getting-started.ts
@@ -1,0 +1,87 @@
+// apps/web/src/components/accounting/getting-started.ts
+// Client-safe display catalog for the accounting module's getting-started
+// checklist. Same shape and tone as the dispatch catalog
+// (`~/components/dispatch/getting-started`) and the org-wide one
+// (`~/components/getting-started/client`) - labels, descriptions, icons and
+// CTAs (web concerns); the canonical key set + persisted state shapes come
+// from @auxx/lib/getting-started/client.
+//
+// The six goals are deliberately COARSE - one per wizard page, not one per
+// settings field (plans/money/tasks/13-accounting-ui.md section 3.2). There is
+// no `connect-quickbooks` goal on purpose: decision `P1` makes "nothing
+// connected" a first-class outcome, so nagging for a provider would contradict
+// the design the poster rests on.
+
+import { ACCOUNTING_GOAL_KEYS, type AccountingGoalKey } from '@auxx/lib/getting-started/client'
+import type { GettingStartedGoal } from '~/components/getting-started/client'
+
+const GOALS: Record<AccountingGoalKey, Omit<GettingStartedGoal, 'key'>> = {
+  'set-accounting-period': {
+    label: 'Set your accounting period',
+    description:
+      'Name the last month closed in your old system and the timezone your books are kept in. There is no UTC fallback.',
+    iconId: 'calendar-clock',
+    color: 'blue',
+    ctaText: 'Set period',
+    href: '/app/accounting/settings/general',
+    docsPath: '/help/accounting/set-accounting-period',
+  },
+  'set-opening-balances': {
+    label: 'Enter your opening balances',
+    description:
+      'Record the inventory you were carrying at the cutoff, and reconcile it against what your accounting provider says.',
+    iconId: 'banknote',
+    color: 'green',
+    ctaText: 'Enter balances',
+    href: '/app/accounting/settings/opening',
+    docsPath: '/help/accounting/set-opening-balances',
+  },
+  'set-costing': {
+    label: 'Set up costing',
+    description:
+      'Absorb labor and overhead onto every unit you assemble, then roll standard cost so each part carries a number.',
+    iconId: 'calculator',
+    color: 'amber',
+    ctaText: 'Set up costing',
+    href: '/app/accounting/settings/general',
+    docsPath: '/help/accounting/set-costing',
+  },
+  'map-accounts': {
+    label: 'Map your accounts',
+    description:
+      'Point each accounting role at an account in your chart. Nothing can be previewed until they are mapped.',
+    iconId: 'list-checks',
+    color: 'purple',
+    ctaText: 'Map accounts',
+    href: '/app/accounting/settings/accounts?s=roles',
+    docsPath: '/help/accounting/map-accounts',
+  },
+  'finalize-setup': {
+    label: 'Finalize your setup',
+    description:
+      'Freeze the opening baseline so the ledger can start. Later corrections use a reversal, never an edit.',
+    iconId: 'check-circle',
+    color: 'teal',
+    ctaText: 'Finalize setup',
+    href: '/app/accounting/settings/general',
+    docsPath: '/help/accounting/finalize-setup',
+  },
+  'post-first-entry': {
+    label: 'Close your first month',
+    description:
+      'Preview the month-end inventory entry, check it balances, and post it to your books.',
+    iconId: 'book-open',
+    color: 'indigo',
+    ctaText: 'Open the ledger',
+    href: '/app/accounting',
+    docsPath: '/help/accounting/post-first-entry',
+  },
+}
+
+/** Ordered display catalog (display order = ACCOUNTING_GOAL_KEYS order). */
+export const ACCOUNTING_GETTING_STARTED_GOALS: GettingStartedGoal[] = ACCOUNTING_GOAL_KEYS.map(
+  (key) => ({
+    key,
+    ...GOALS[key],
+  })
+)

--- a/apps/web/src/components/accounting/hooks/use-accounting-settings-freeze.ts
+++ b/apps/web/src/components/accounting/hooks/use-accounting-settings-freeze.ts
@@ -1,0 +1,54 @@
+// apps/web/src/components/accounting/hooks/use-accounting-settings-freeze.ts
+'use client'
+
+import { api } from '~/trpc/react'
+
+/**
+ * Why a frozen field is frozen, in the words the settings catalog uses.
+ *
+ * ⚠️ Changing the opening baseline or the book timezone after a posting exists
+ * rewrites the arithmetic behind a journal entry that has already been booked.
+ * A later mistake is corrected through the reversal / re-entry path, never by
+ * editing setup history.
+ */
+export const FREEZE_REASON =
+  'Locked because an entry has already posted. Changing this would rewrite the arithmetic ' +
+  'behind a posted journal entry. Correct a mistake by reversing and re-entering, never by ' +
+  'editing setup history.'
+
+export interface AccountingSettingsFreeze {
+  /** True once anything has posted. */
+  frozen: boolean
+  /** How many posted entries the sweep looked at. `0 of 0` is not the same answer as `0 of 412`. */
+  postingsChecked: number
+  isLoading: boolean
+}
+
+/**
+ * Whether the opening baseline and book timezone are frozen.
+ *
+ * 🛑 Read off a REAL query rather than a settings flag. `ledger.verifyBalance`
+ * already sweeps every posted entry and returns `postingsChecked`, so "has this
+ * organization posted anything" is a fact the server hands over rather than a
+ * second stored bit that could disagree with the ledger. It is gated on
+ * `ledger.view`, which every accounting settings page already requires.
+ *
+ * Fails OPEN on error (nothing frozen) on purpose: a failed sweep must not lock
+ * an organization out of its own setup during onboarding, when the count is
+ * zero anyway. The server refuses a baseline edit after the first claim
+ * regardless of what this returns.
+ */
+export function useAccountingSettingsFreeze(): AccountingSettingsFreeze {
+  const query = api.ledger.verifyBalance.useQuery(undefined, {
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+
+  const postingsChecked = query.data?.postingsChecked ?? 0
+
+  return {
+    frozen: postingsChecked > 0,
+    postingsChecked,
+    isLoading: query.isPending,
+  }
+}

--- a/apps/web/src/components/accounting/hooks/use-accounting-setup-draft.ts
+++ b/apps/web/src/components/accounting/hooks/use-accounting-setup-draft.ts
@@ -1,0 +1,63 @@
+// apps/web/src/components/accounting/hooks/use-accounting-setup-draft.ts
+'use client'
+
+import type { SettingKey, SettingValue } from '@auxx/lib/settings/client'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
+import { useSettings } from '~/hooks/use-settings'
+
+/**
+ * A dirty draft over an EXPLICIT list of `GENERAL`-scope catalog keys, batch-saved in one call.
+ *
+ * 🛑 The explicit key list is the whole point, not a convenience.
+ * `useSettings({ scope: 'GENERAL' })` hands back EVERY `GENERAL`-scope setting in the entire app,
+ * so a save built from "the whole settings object" would write back dozens of unrelated keys.
+ * Every `accounting.*` and `manufacturing.*` key is `GENERAL` (there is no `ACCOUNTING` value in
+ * the `SettingScope` enum), so the accounting wizard is in exactly the situation
+ * `scheduling-settings-page.tsx`'s warning was written for.
+ *
+ * Reads cost nothing: `useSettings` rides the org cache hydrated by the provider, so every key is
+ * in hand on load at zero queries. That is also why there is no `setupReadiness` endpoint - see
+ * `packages/lib/src/postings/setup-readiness.ts`.
+ */
+export function useAccountingSetupDraft(keys: readonly string[]) {
+  const { getSetting, batchUpdateOrganizationSettings, isBatchUpdatingOrgSettings } = useSettings({
+    scope: 'GENERAL',
+  })
+
+  // Rebuilt each render; `useDirtyDraft` compares by value, so a fresh object identity never
+  // triggers a reseed.
+  const server: Record<string, SettingValue> = {}
+  for (const key of keys) server[key] = getSetting(key as SettingKey)
+
+  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+    isSaving: isBatchUpdatingOrgSettings,
+    onSave: (next) => {
+      const changed = keys
+        .filter((key) => next[key] !== server[key])
+        .map((key) => ({ key, value: next[key] ?? null }))
+      if (changed.length > 0) batchUpdateOrganizationSettings(changed)
+    },
+  })
+
+  /** Controlled-mode props for a `SettingsFieldRow` fed by this draft. */
+  const controlled = (key: string) => ({
+    value: draft[key],
+    // NUMBER/SELECT inputs report a clear as `undefined`, not `null` - normalize, since
+    // `SettingValue` and the server normalizer only accept `null` for "unset".
+    onChange: (value: unknown) =>
+      patch({ [key]: (value === undefined ? null : value) as SettingValue }),
+  })
+
+  return {
+    /** The working copy, keyed by catalog key. Safe to hand to the `setup-readiness` helpers. */
+    draft,
+    patch,
+    dirty,
+    save,
+    discard,
+    controlled,
+    /** Every `GENERAL` setting as stored, for predicates that read beyond this draft's keys. */
+    getSetting,
+    isSaving: isBatchUpdatingOrgSettings,
+  }
+}

--- a/apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
+++ b/apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
@@ -1,0 +1,135 @@
+// apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
+
+'use client'
+
+import type { EntryPreview, PostResult } from '@auxx/lib/postings/client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  FIXTURE_POST_RESULT,
+  FIXTURE_POST_RESULT_NOT_CONNECTED,
+  FIXTURE_PREVIEW,
+  FIXTURE_PREVIEW_BLOCKED,
+} from '~/components/accounting/fixtures'
+
+interface UseLedgerEntryActionsOptions {
+  periodKey: string
+  /** Render the refused preview instead of the buildable one. */
+  blocked: boolean
+  /** With no provider connected, a post still succeeds with outcome `not_connected`. */
+  providerConnected: boolean
+}
+
+export interface LedgerEntryActions {
+  preview: EntryPreview
+  postResult: PostResult | null
+  isPreviewing: boolean
+  isPosting: boolean
+  isReversing: boolean
+  /** True once this session posted the month, so Post stops offering itself. */
+  justPosted: boolean
+  runPreview: () => void
+  runPost: () => void
+  runReverse: (memo: string) => void
+  clearPostResult: () => void
+}
+
+/** How long the placeholder pretends the round trip takes. */
+const FAKE_LATENCY_MS = 550
+
+/**
+ * Post / Reverse / Preview, against local state.
+ *
+ * 🛑 PLACEHOLDER: none of the three procedures exist yet
+ * (13-accounting-ui.md §4), so nothing here talks to a server:
+ *
+ *   * `runPreview` will become `ledger.previewMonthEnd({ periodKey })`
+ *   * `runPost`    will become `ledger.postMonthEnd({ periodKey })`
+ *   * `runReverse` will become `ledger.reverse({ glPostingId, memo })`
+ *   * the posted read behind it will become `ledger.get(id)`
+ *
+ * Everything else about this file is real: the shapes are the shipped
+ * `EntryPreview` / `PostResult`, and `not_connected` is returned as a SUCCESS
+ * (decision `P1`) rather than an error, which is the behaviour the screens have
+ * to get right whether the data is fixture or not.
+ */
+export function useLedgerEntryActions({
+  periodKey,
+  blocked,
+  providerConnected,
+}: UseLedgerEntryActionsOptions): LedgerEntryActions {
+  const [isPreviewing, setIsPreviewing] = useState(false)
+  const [isPosting, setIsPosting] = useState(false)
+  const [isReversing, setIsReversing] = useState(false)
+  const [postResult, setPostResult] = useState<PostResult | null>(null)
+  const [justPosted, setJustPosted] = useState(false)
+
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([])
+  useEffect(() => {
+    const pending = timers.current
+    return () => {
+      for (const timer of pending) clearTimeout(timer)
+    }
+  }, [])
+
+  const schedule = useCallback((run: () => void) => {
+    const timer = setTimeout(run, FAKE_LATENCY_MS)
+    timers.current.push(timer)
+  }, [])
+
+  // A new month clears whatever the previous one's buttons produced. Adjusted
+  // during render rather than in an effect: an effect would paint the previous
+  // month's post result for one frame.
+  const [lastPeriodKey, setLastPeriodKey] = useState(periodKey)
+  if (lastPeriodKey !== periodKey) {
+    setLastPeriodKey(periodKey)
+    setPostResult(null)
+    setJustPosted(false)
+  }
+
+  const preview: EntryPreview = blocked
+    ? { ...FIXTURE_PREVIEW_BLOCKED, periodKey, docNumber: `AUXX-MEI-${periodKey}` }
+    : { ...FIXTURE_PREVIEW, periodKey, docNumber: `AUXX-MEI-${periodKey}` }
+
+  const runPreview = useCallback(() => {
+    setIsPreviewing(true)
+    schedule(() => setIsPreviewing(false))
+  }, [schedule])
+
+  const runPost = useCallback(() => {
+    setIsPosting(true)
+    schedule(() => {
+      setIsPosting(false)
+      setJustPosted(true)
+      // ⚠️ `not_connected` is a first-class SUCCESS, not a degraded post: the
+      // entry is built, balanced and persisted identically. Never an error.
+      setPostResult(providerConnected ? FIXTURE_POST_RESULT : FIXTURE_POST_RESULT_NOT_CONNECTED)
+    })
+  }, [providerConnected, schedule])
+
+  const runReverse = useCallback(
+    (_memo: string) => {
+      setIsReversing(true)
+      schedule(() => {
+        setIsReversing(false)
+        setJustPosted(false)
+        setPostResult(null)
+      })
+    },
+    [schedule]
+  )
+
+  const clearPostResult = useCallback(() => setPostResult(null), [])
+
+  return {
+    preview,
+    postResult,
+    isPreviewing,
+    isPosting,
+    isReversing,
+    justPosted,
+    runPreview,
+    runPost,
+    runReverse,
+    clearPostResult,
+  }
+}

--- a/apps/web/src/components/accounting/hooks/use-ledger-period.ts
+++ b/apps/web/src/components/accounting/hooks/use-ledger-period.ts
@@ -1,0 +1,121 @@
+// apps/web/src/components/accounting/hooks/use-ledger-period.ts
+
+'use client'
+
+import { useQueryState } from 'nuqs'
+import { useMemo } from 'react'
+import {
+  FIXTURE_PERIOD_SUMMARIES,
+  FIXTURE_PERIODS,
+  type FixturePeriodSummary,
+} from '~/components/accounting/fixtures'
+import { formatPeriodLabel } from '~/components/accounting/ui/ledger/format'
+
+/**
+ * Which of the module home's three states the ledger is in
+ * (plans/money/tasks/13-accounting-ui.md §5.1), plus `blocked`.
+ *
+ * `blocked` is not a fourth ORG state. It is the open state with a refused
+ * preview, and it is selectable here only so the blocker treatment can be seen
+ * before `ledger.previewMonthEnd` exists to produce one.
+ */
+export type LedgerScreenState = 'checklist' | 'open' | 'blocked' | 'posted'
+
+const SCREEN_STATES: LedgerScreenState[] = ['checklist', 'open', 'blocked', 'posted']
+
+export interface LedgerPeriodOption {
+  periodKey: string
+  label: string
+  summary: FixturePeriodSummary
+}
+
+export interface LedgerPeriodModel {
+  screenState: LedgerScreenState
+  setScreenState: (state: LedgerScreenState) => void
+  /** Whether a provider is treated as connected. Placeholder toggle, see below. */
+  providerConnected: boolean
+  setProviderConnected: (connected: boolean) => void
+  /** Cutoff through now, oldest first. */
+  options: LedgerPeriodOption[]
+  /** Earliest unposted month, else the most recent posted one. */
+  resolvedPeriodKey: string
+  /** What the screen is actually showing. */
+  activePeriodKey: string
+  activeSummary: FixturePeriodSummary | undefined
+  previousPeriodKey: string | null
+  nextPeriodKey: string | null
+  /** False once every month from the cutoff forward is posted or locked. */
+  hasOpenPeriod: boolean
+}
+
+/**
+ * Everything the ledger screens need to know about WHICH month they are on.
+ *
+ * 🛑 PLACEHOLDER. Both the period list and each month's state come from
+ * `~/components/accounting/fixtures`. The real version derives all of it from
+ * `GlPosting` rows plus `accounting.cutoffPeriod` and `ledger.lockedThroughMonth`,
+ * with no new table, per 13-accounting-ui.md §5.1.
+ *
+ * ⚠️ `?state=` and `?provider=` are DEV TOGGLES and nothing else. They exist so
+ * every screen state is reachable while the four procedures in §4 are still
+ * missing; both disappear with the fixtures.
+ */
+export function useLedgerPeriod(periodKey?: string): LedgerPeriodModel {
+  const [stateParam, setStateParam] = useQueryState('state')
+  const [providerParam, setProviderParam] = useQueryState('provider')
+
+  const screenState: LedgerScreenState = SCREEN_STATES.includes(stateParam as LedgerScreenState)
+    ? (stateParam as LedgerScreenState)
+    : 'open'
+
+  const providerConnected = providerParam !== 'none'
+
+  return useMemo(() => {
+    // In the everything-posted state the open month is treated as closed, so the
+    // "nothing to close" body has a posted month to render behind it.
+    const summaries: FixturePeriodSummary[] = FIXTURE_PERIOD_SUMMARIES.map((summary) =>
+      screenState === 'posted' && summary.state === 'open'
+        ? {
+            ...summary,
+            state: 'posted',
+            docNumber: `AUXX-MEI-${summary.periodKey}`,
+            totalMinor: 981_000,
+            postedAt: '2027-04-02T10:12:00.000Z',
+          }
+        : summary
+    )
+
+    const byKey = new Map(summaries.map((summary) => [summary.periodKey, summary]))
+    const options: LedgerPeriodOption[] = FIXTURE_PERIODS.map((key) => {
+      const summary = byKey.get(key) ?? { periodKey: key, state: 'open' as const, revision: 0 }
+      return { periodKey: key, label: formatPeriodLabel(key), summary }
+    })
+
+    const firstOpen = options.find((option) => option.summary.state === 'open')
+    const lastPosted = [...options].reverse().find((option) => option.summary.state !== 'open')
+    const resolvedPeriodKey =
+      firstOpen?.periodKey ?? lastPosted?.periodKey ?? options[options.length - 1]?.periodKey ?? ''
+
+    const requested = periodKey && byKey.has(periodKey) ? periodKey : resolvedPeriodKey
+    const index = options.findIndex((option) => option.periodKey === requested)
+
+    return {
+      screenState,
+      setScreenState: (next: LedgerScreenState) => {
+        void setStateParam(next === 'open' ? null : next)
+      },
+      providerConnected,
+      setProviderConnected: (connected: boolean) => {
+        void setProviderParam(connected ? null : 'none')
+      },
+      options,
+      resolvedPeriodKey,
+      activePeriodKey: requested,
+      activeSummary: byKey.get(requested),
+      previousPeriodKey: index > 0 ? (options[index - 1]?.periodKey ?? null) : null,
+      nextPeriodKey:
+        index >= 0 && index < options.length - 1 ? (options[index + 1]?.periodKey ?? null) : null,
+      hasOpenPeriod: !!firstOpen,
+    }
+  }, [periodKey, providerConnected, screenState, setProviderParam, setStateParam])
+}

--- a/apps/web/src/components/accounting/ui/checklist/accounting-checklist-panel.tsx
+++ b/apps/web/src/components/accounting/ui/checklist/accounting-checklist-panel.tsx
@@ -1,0 +1,116 @@
+// apps/web/src/components/accounting/ui/checklist/accounting-checklist-panel.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Progress } from '@auxx/ui/components/progress'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { Rocket, Wand2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useQueryState } from 'nuqs'
+import { ACCOUNTING_GETTING_STARTED_GOALS } from '~/components/accounting/getting-started'
+import type { GettingStartedGoal } from '~/components/getting-started/client'
+import { useGettingStarted } from '~/components/getting-started/hooks/use-getting-started'
+import { useEnv } from '~/providers/dehydrated-state-provider'
+import { AccountingChecklistStep } from './accounting-checklist-step'
+
+interface AccountingChecklistPanelProps {
+  className?: string
+}
+
+/**
+ * The accounting getting-started checklist, as PAGE BODY content.
+ *
+ * This is what `/app/accounting` renders while setup is not finalized
+ * (13-accounting-ui.md section 5.5), so it has to read as a finished landing state rather than a
+ * leftover widget: a progress indicator, one row per goal with its description and CTA, and a
+ * button back into the wizard.
+ *
+ * ⚠️ Deliberately NOT `GettingStartedGroup`. That component is `SidebarGroupCollapse`-based and
+ * built for a sidebar footer - it hides itself once every goal is done, tucks descriptions into a
+ * side hovercard, and auto-collapses. All three are wrong for a page body. What is reused is the
+ * part worth reusing: `useGettingStarted`, which folds `gettingStarted.getStatus` into a display
+ * catalog, and the catalog itself.
+ *
+ * 🛑 The checklist is NOT the readiness predicate and NOT the Post gate. It says "set up costing";
+ * `resolveSetupReadiness` says which setting is missing; only the server's `blockedBy` knows which
+ * PART has no standard cost, and only that may refuse a posting.
+ */
+export function AccountingChecklistPanel({ className }: AccountingChecklistPanelProps) {
+  const router = useRouter()
+  const { docsUrl } = useEnv()
+  const [, setSetupParam] = useQueryState('setup')
+  const { isLoading, goals, completed, done, total } = useGettingStarted(
+    'accounting',
+    ACCOUNTING_GETTING_STARTED_GOALS
+  )
+
+  const handleCTA = (goal: GettingStartedGoal) => {
+    if (goal.external) {
+      window.open(goal.href, '_blank', 'noopener,noreferrer')
+      return
+    }
+    router.push(goal.href)
+  }
+
+  const allDone = total > 0 && done === total
+
+  return (
+    <div className={cn('mx-auto flex w-full max-w-3xl flex-col gap-5 p-6', className)}>
+      <div className='flex flex-col gap-1'>
+        <div className='flex items-center gap-2'>
+          <Rocket className='size-4 text-muted-foreground' />
+          <h1 className='font-medium text-base text-foreground'>Set up accounting</h1>
+        </div>
+        <p className='text-muted-foreground text-sm'>
+          {allDone
+            ? 'Everything is configured. The ledger is ready to close a month.'
+            : 'Auxx values your inventory activity and posts one journal entry a month. These are the things that have to be true before it can.'}
+        </p>
+      </div>
+
+      <div className='flex flex-col gap-2'>
+        <div className='flex items-center justify-between gap-2'>
+          <span className='text-muted-foreground text-xs'>
+            {isLoading ? 'Loading...' : `${done} of ${total} done`}
+          </span>
+          <Button variant='outline' size='sm' onClick={() => setSetupParam('wizard')}>
+            <Wand2 />
+            Set up accounting
+          </Button>
+        </div>
+        <Progress
+          value={total > 0 ? (done / total) * 100 : 0}
+          indicatorClassName={allDone ? 'bg-good-500' : 'bg-info'}
+        />
+      </div>
+
+      <div className='overflow-hidden rounded-xl border'>
+        {isLoading ? (
+          <div className='flex flex-col gap-3 p-4'>
+            {ACCOUNTING_GETTING_STARTED_GOALS.map((goal) => (
+              <Skeleton key={goal.key} className='h-12 w-full rounded-lg' />
+            ))}
+          </div>
+        ) : (
+          <ul className='flex flex-col'>
+            {goals.map((goal) => (
+              <AccountingChecklistStep
+                key={goal.key}
+                goal={goal}
+                completed={completed.has(goal.key)}
+                docsUrl={docsUrl}
+                onCTA={handleCTA}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <p className='text-muted-foreground text-xs'>
+        Every step above is derived from what is actually configured, not from a stored flag - so it
+        stays honest the moment somebody changes a rate.
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/checklist/accounting-checklist-step.tsx
+++ b/apps/web/src/components/accounting/ui/checklist/accounting-checklist-step.tsx
@@ -1,0 +1,72 @@
+// apps/web/src/components/accounting/ui/checklist/accounting-checklist-step.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { cn } from '@auxx/ui/lib/utils'
+import { ArrowUpRight, Check, ExternalLink } from 'lucide-react'
+import type { GettingStartedGoal } from '~/components/getting-started/client'
+
+interface AccountingChecklistStepProps {
+  goal: GettingStartedGoal
+  completed: boolean
+  /** Docs base URL from `useEnv()`, joined with the goal's `docsPath`. */
+  docsUrl: string
+  onCTA: (goal: GettingStartedGoal) => void
+}
+
+/**
+ * One goal, rendered as PAGE BODY content: icon, label, description, completion state and a CTA.
+ *
+ * 🛑 Not `GettingStartedStep`. That one is a `SidebarMenuSubButton` built for the sidebar footer
+ * checklist, where the description lives in a hovercard and a row is a compact nav item. This is
+ * the module home's whole body until setup is finalized, so the description is on the page and
+ * every goal carries its own button.
+ */
+export function AccountingChecklistStep({
+  goal,
+  completed,
+  docsUrl,
+  onCTA,
+}: AccountingChecklistStepProps) {
+  return (
+    <li className='flex items-start gap-3 border-b px-4 py-3 last:border-b-0'>
+      <div className='relative shrink-0 pt-0.5'>
+        <EntityIcon iconId={goal.iconId} color={goal.color} size='default' />
+        {completed && (
+          <span className='-end-1 -top-1 absolute flex size-4 items-center justify-center rounded-full border border-blue-800 bg-info'>
+            <Check className='size-2.5! text-white' strokeWidth={4} />
+          </span>
+        )}
+      </div>
+
+      <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+        <span
+          className={cn(
+            'font-medium text-foreground text-sm',
+            completed && 'text-muted-foreground line-through'
+          )}>
+          {goal.label}
+        </span>
+        <p className='text-muted-foreground text-sm'>{goal.description}</p>
+        <a
+          href={`${docsUrl}${goal.docsPath}`}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='mt-0.5 inline-flex w-fit items-center gap-1 text-muted-foreground text-xs hover:text-foreground'>
+          Learn more
+          <ExternalLink className='size-3' />
+        </a>
+      </div>
+
+      <Button
+        variant={completed ? 'ghost' : 'outline'}
+        size='sm'
+        className='shrink-0'
+        onClick={() => onCTA(goal)}>
+        {completed ? 'Review' : goal.ctaText}
+        <ArrowUpRight />
+      </Button>
+    </li>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/books-health.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/books-health.tsx
@@ -1,0 +1,137 @@
+// apps/web/src/components/accounting/ui/ledger/books-health.tsx
+
+'use client'
+
+import type { BooksBalanceReport, UnpostedPeriod } from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import { CircleAlert, Loader, Scale } from 'lucide-react'
+import { formatPeriodLabel } from './format'
+
+interface BooksBalanceLineProps {
+  report: BooksBalanceReport
+}
+
+/**
+ * The after-the-fact balance sweep.
+ *
+ * 🛑 Never a bare green tick. "0 discrepancies out of 0" and "0 out of 412" are
+ * very different answers, and `postingsChecked` rides along on the shipped type
+ * precisely so the two can be told apart. A tick that renders identically for
+ * both is a check that cannot fail (13-accounting-ui.md §5.1).
+ */
+export function BooksBalanceLine({ report }: BooksBalanceLineProps) {
+  const count = report.discrepancies.length
+  const clean = report.balanced && count === 0
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <div className='flex items-center gap-2 text-sm'>
+        <Scale className={cn('size-4', clean ? 'text-muted-foreground' : 'text-destructive')} />
+        <span className={cn(!clean && 'text-destructive')}>
+          {count} {count === 1 ? 'discrepancy' : 'discrepancies'} out of {report.postingsChecked}{' '}
+          {report.postingsChecked === 1 ? 'posting' : 'postings'} checked
+        </span>
+      </div>
+
+      {report.postingsChecked === 0 && (
+        <p className='text-xs text-muted-foreground'>
+          Nothing has been posted yet, so nothing was checked. This is not the same as the books
+          being in balance.
+        </p>
+      )}
+
+      {count > 0 && (
+        <div className='flex flex-col gap-1.5'>
+          {report.discrepancies.map((discrepancy) => (
+            <div
+              key={discrepancy.glPostingId}
+              className='rounded-lg border border-destructive/40 bg-destructive/5 p-2 text-xs'>
+              <span className='font-mono'>{discrepancy.docNumber}</span>{' '}
+              <span className='text-muted-foreground'>
+                debits {discrepancy.totalDebitMinor}, credits {discrepancy.totalCreditMinor},
+                recorded total {discrepancy.recordedTotalMinor} (minor units)
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface UnpostedPeriodsBannerProps {
+  periods: UnpostedPeriod[]
+}
+
+/**
+ * Entries that were claimed but never landed in the books.
+ *
+ * 🛑 `pending` and `failed` stay visually distinct. They call for different
+ * actions: `pending` is claimed and in flight (or claimed by a run that died
+ * mid-push, which the idempotency ladder heals), while `failed` was attempted and
+ * refused and carries the reason. `attempts` and `failureReason` are on the
+ * shipped row precisely so nobody is sent to the logs for a string that is
+ * already in the database.
+ *
+ * ⚠️ Nothing is filtered out of this list. `periodMonth` throws on keys
+ * `GlPosting` explicitly permits (`build` keys on the build number, `payout` on
+ * the payout id), and the answer is to include the row anyway, because
+ * under-reporting is the dangerous direction: a bookkeeper who is not shown an
+ * entry closes the month without it. `formatPeriodLabel` returns a non-month key
+ * unchanged rather than throwing.
+ */
+export function UnpostedPeriodsBanner({ periods }: UnpostedPeriodsBannerProps) {
+  if (periods.length === 0) return null
+
+  const failed = periods.filter((period) => period.status === 'failed')
+  const pending = periods.filter((period) => period.status === 'pending')
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-xl border p-4',
+        failed.length > 0 ? 'border-destructive/40 bg-destructive/5' : 'border-border bg-muted/40'
+      )}>
+      <div className='flex items-center gap-2'>
+        {failed.length > 0 ? (
+          <CircleAlert className='size-4 text-destructive' />
+        ) : (
+          <Loader className='size-4 text-muted-foreground' />
+        )}
+        <span className='font-medium'>
+          {periods.length} {periods.length === 1 ? 'entry has' : 'entries have'} been claimed but
+          are not in the books
+        </span>
+      </div>
+
+      <div className='flex flex-col gap-2'>
+        {[...failed, ...pending].map((period) => (
+          <div
+            key={period.glPostingId}
+            className='flex flex-col gap-1 rounded-lg border bg-background p-3'>
+            <div className='flex flex-wrap items-center gap-2 text-sm'>
+              <Badge variant={period.status === 'failed' ? 'red' : 'amber'} size='sm'>
+                {period.status === 'failed' ? 'Failed' : 'In flight'}
+              </Badge>
+              <span>{formatPeriodLabel(period.periodKey)}</span>
+              <span className='font-mono text-xs text-muted-foreground'>{period.docNumber}</span>
+              <span className='text-xs text-muted-foreground'>{period.postingType}</span>
+              <span className='text-xs text-muted-foreground'>
+                {period.attempts} {period.attempts === 1 ? 'attempt' : 'attempts'}
+              </span>
+            </div>
+            {period.failureReason ? (
+              <p className='text-sm text-muted-foreground'>{period.failureReason}</p>
+            ) : (
+              <p className='text-xs text-muted-foreground'>
+                No failure was recorded. This entry is still in flight, or the run that claimed it
+                died mid-push and the next attempt will heal it.
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/count-evidence-section.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/count-evidence-section.tsx
@@ -1,0 +1,130 @@
+// apps/web/src/components/accounting/ui/ledger/count-evidence-section.tsx
+
+'use client'
+
+import { EmptySection } from '@auxx/ui/components/section'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { cn } from '@auxx/ui/lib/utils'
+import { ClipboardCheck } from 'lucide-react'
+import type { FixtureCountAdjustment } from '~/components/accounting/fixtures'
+import {
+  formatAccountingDate,
+  formatMinor,
+  formatSignedMinor,
+  formatSignedQuantity,
+} from './format'
+
+interface CountEvidenceSectionProps {
+  adjustments: FixtureCountAdjustment[]
+  currencyCode: string
+  bookTimeZone: string
+}
+
+/**
+ * Cycle-count evidence for the period.
+ *
+ * 🛑 EVIDENCE, not a passing check, and the distinction is the whole reason this
+ * section exists. Under the L1 regime the GL inventory balance is SET FROM the
+ * subledger by the month-end entry, so a "does the GL agree with the subledger"
+ * tie-out is tautological: it can only ever agree, and a green check that cannot
+ * fail trains people to stop reading checks.
+ *
+ * The physical count is the real error detector: it is the only row on this
+ * whole screen that can disagree with itself (13-accounting-ui.md §0.1).
+ */
+export function CountEvidenceSection({
+  adjustments,
+  currencyCode,
+  bookTimeZone,
+}: CountEvidenceSectionProps) {
+  if (adjustments.length === 0) {
+    return (
+      <EmptySection
+        icon={<ClipboardCheck className='size-5' />}
+        title='No counts were recorded this period'
+        description='With no count there is no independent evidence for the closing inventory balance. That is not the same as the balance being right.'
+      />
+    )
+  }
+
+  const netMinor = adjustments.reduce((sum, row) => sum + row.extendedCostMinor, 0)
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <p className='text-sm text-muted-foreground'>
+        Every count adjustment in the period, with the system quantity, what was actually counted,
+        and the frozen standard cost the difference was valued at. Read this as evidence about the
+        closing balance, not as a check that passed.
+      </p>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Part</TableHead>
+            <TableHead className='w-20 text-right'>System</TableHead>
+            <TableHead className='w-20 text-right'>Counted</TableHead>
+            <TableHead className='w-20 text-right'>Delta</TableHead>
+            <TableHead className='w-28 text-right'>Unit cost</TableHead>
+            <TableHead className='w-32 text-right'>Extended</TableHead>
+            <TableHead>Reason</TableHead>
+            <TableHead>Counted by</TableHead>
+            <TableHead className='w-28'>Date</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {adjustments.map((row) => (
+            <TableRow key={row.movementId}>
+              <TableCell>
+                <div className='flex flex-col'>
+                  <span className='font-mono text-xs text-muted-foreground'>{row.partNumber}</span>
+                  <span>{row.partName}</span>
+                </div>
+              </TableCell>
+              <TableCell className='text-right font-mono tabular-nums'>
+                {row.systemQuantity}
+              </TableCell>
+              <TableCell className='text-right font-mono tabular-nums'>
+                {row.countedQuantity}
+              </TableCell>
+              <TableCell
+                className={cn(
+                  'text-right font-mono tabular-nums',
+                  row.delta < 0 && 'text-destructive'
+                )}>
+                {formatSignedQuantity(row.delta)}
+              </TableCell>
+              <TableCell className='text-right font-mono tabular-nums'>
+                {formatMinor(row.unitCostMinor, currencyCode)}
+              </TableCell>
+              <TableCell className='text-right font-mono tabular-nums'>
+                {formatSignedMinor(row.extendedCostMinor, currencyCode)}
+              </TableCell>
+              <TableCell className='text-muted-foreground'>{row.reason}</TableCell>
+              <TableCell className='text-muted-foreground'>{row.actorName}</TableCell>
+              <TableCell className='text-muted-foreground'>
+                {formatAccountingDate(row.occurredAt, bookTimeZone)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={5}>Net count variance</TableCell>
+            <TableCell className='text-right font-mono tabular-nums'>
+              {formatSignedMinor(netMinor, currencyCode)}
+            </TableCell>
+            <TableCell colSpan={3} />
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
@@ -1,0 +1,140 @@
+// apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
+
+'use client'
+
+import type { PostResultStatus } from '@auxx/lib/postings/client'
+import { Button } from '@auxx/ui/components/button'
+import { Ban, KeyRound, Lock, Map as MapIcon, Scale, Settings2, TriangleAlert } from 'lucide-react'
+import Link from 'next/link'
+import type { ComponentType } from 'react'
+
+/** One reason a preview or a post refused, as the console renders it. */
+export interface LedgerBlocker {
+  status: PostResultStatus
+  error: string
+}
+
+interface BlockerRemedy {
+  icon: ComponentType<{ className?: string }>
+  title: string
+  /** What to do about it, in the operator's terms. */
+  guidance: string
+  href?: string
+  actionLabel?: string
+  /** For the remedies that are a control on this page rather than another page. */
+  action?: 'unlock'
+}
+
+/**
+ * What each refusal means and where it is fixed.
+ *
+ * 🛑 Every status gets its own line with its own destination. A single generic
+ * "preview failed" is what sends an operator to the logs for a string that is
+ * already in the database (13-accounting-ui.md §5.2).
+ */
+const REMEDIES: Partial<Record<PostResultStatus, BlockerRemedy>> = {
+  account_unmapped: {
+    icon: MapIcon,
+    title: 'An account role is not mapped',
+    guidance:
+      'A builder emits a role and the org chart maps it to an account code. The resolver fails closed on zero matches and on more than one, so the entry cannot be built until the named role points at exactly one account.',
+    href: '/app/accounting/settings/accounts',
+    actionLabel: 'Map the role',
+  },
+  period_closed: {
+    icon: Lock,
+    title: 'The period is locked',
+    guidance:
+      'Nothing may post into a month that has been declared shut. Unlocking permits posting into a month the accountant may already have seen, so it is a deliberate, named action rather than a toggle.',
+    action: 'unlock',
+    actionLabel: 'Review the lock',
+  },
+  unbalanced: {
+    icon: Scale,
+    title: 'The entry does not balance',
+    guidance:
+      'Debits and credits disagree, so the entry was refused before the period was claimed. This is a builder or subledger fault, not something a retry can change.',
+  },
+  error: {
+    icon: Settings2,
+    title: 'Accounting setup is still a draft',
+    guidance:
+      'The opening baseline, the book time zone and the absorption rates are what the month-end arithmetic is computed from. Finalize the setup before the first entry is posted.',
+    href: '/app/accounting/settings/general',
+    actionLabel: 'Finish setup',
+  },
+  disabled: {
+    icon: Ban,
+    title: 'Export to the accounting system is switched off',
+    guidance:
+      'The entry is still built, balanced and persisted here. Only the push to the provider is off, and it is a setting somebody can flip.',
+  },
+  not_connected: {
+    icon: KeyRound,
+    title: 'No accounting system is connected',
+    guidance:
+      'This is not a blocker. The entry is built, balanced and persisted identically with no provider at all.',
+  },
+}
+
+const FALLBACK: BlockerRemedy = {
+  icon: TriangleAlert,
+  title: 'The entry could not be built',
+  guidance: 'The reason is below, verbatim, so it can be acted on without reading the logs.',
+}
+
+interface EntryBlockersProps {
+  blockers: LedgerBlocker[]
+  /** Invoked by the `period_closed` remedy. */
+  onReviewLock?: () => void
+}
+
+/**
+ * Why this month cannot be posted, at the SAME visual weight as the entry.
+ *
+ * ⚠️ Not a warning strip above the entry. When a close is refused, the refusal
+ * IS the screen's content: an operator who has to hunt for a thin yellow bar to
+ * find out why the Post button does nothing has been given a puzzle instead of a
+ * task (13-accounting-ui.md §5.2).
+ */
+export function EntryBlockers({ blockers, onReviewLock }: EntryBlockersProps) {
+  if (blockers.length === 0) return null
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {blockers.map((blocker) => {
+        const remedy = REMEDIES[blocker.status] ?? FALLBACK
+        const Icon = remedy.icon
+        return (
+          <div
+            key={`${blocker.status}-${blocker.error}`}
+            className='flex flex-col gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4 sm:flex-row sm:items-start'>
+            <Icon className='mt-0.5 size-5 shrink-0 text-destructive' />
+            <div className='flex min-w-0 flex-1 flex-col gap-1.5'>
+              <div className='flex flex-wrap items-center gap-2'>
+                <span className='font-medium'>{remedy.title}</span>
+                <span className='font-mono text-xs text-muted-foreground'>{blocker.status}</span>
+              </div>
+              {/* The server's own text, verbatim: on `account_unmapped` it names
+                  every offending role, and on an uncosted movement it names the
+                  row. Paraphrasing it here would throw away the only part that
+                  identifies what to go and fix. */}
+              <p className='text-sm'>{blocker.error}</p>
+              <p className='text-xs text-muted-foreground'>{remedy.guidance}</p>
+            </div>
+            {remedy.href && remedy.actionLabel && (
+              <Button asChild variant='outline' size='sm' className='shrink-0'>
+                <Link href={remedy.href}>{remedy.actionLabel}</Link>
+              </Button>
+            )}
+            {remedy.action === 'unlock' && onReviewLock && (
+              <Button variant='outline' size='sm' className='shrink-0' onClick={onReviewLock}>
+                {remedy.actionLabel}
+              </Button>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
@@ -1,0 +1,129 @@
+// apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
+
+'use client'
+
+import type { ResolvedPostingLine } from '@auxx/lib/postings/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { cn } from '@auxx/ui/lib/utils'
+import { CheckCircle2, Search, TriangleAlert } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
+import { formatMinor } from './format'
+
+interface EntryJournalProps {
+  lines: ResolvedPostingLine[]
+  currencyCode: string
+  /** Opens the "what is behind this number" report for an account code. */
+  onDrillDown?: (accountCode: string, accountName?: string) => void
+}
+
+/**
+ * The journal entry, in the accountant's indented layout: debits first and
+ * flush left, credits indented beneath them, a totals row, and an explicit
+ * balanced verdict.
+ *
+ * 🛑 No number on this table is ever signed. `direction` is the only carrier of
+ * sign in the whole postings module and `amount` is always positive, so a
+ * signed rendering would be inventing a second, disagreeing convention, and a
+ * bookkeeper handed a two-column table of signed numbers is being asked to do
+ * the conversion in their head (13-accounting-ui.md §5.2).
+ *
+ * ⚠️ The balanced verdict is stated rather than implied. `buildEntry` refuses to
+ * return an unbalanced entry, so in practice this always reads "Balanced", but
+ * a screen that shows totals and leaves the reader to compare them is asking for
+ * the one mental step this section exists to remove.
+ */
+export function EntryJournal({ lines, currencyCode, onDrillDown }: EntryJournalProps) {
+  const debits = lines
+    .filter((line) => line.direction === 'debit')
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+  const credits = lines
+    .filter((line) => line.direction === 'credit')
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+
+  const totalDebit = debits.reduce((sum, line) => sum + line.amount, 0)
+  const totalCredit = credits.reduce((sum, line) => sum + line.amount, 0)
+  const balanced = totalDebit === totalCredit
+  const difference = Math.abs(totalDebit - totalCredit)
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className='w-[45%]'>Account</TableHead>
+            <TableHead>Memo</TableHead>
+            <TableHead className='w-32 text-right'>Debit</TableHead>
+            <TableHead className='w-32 text-right'>Credit</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {[...debits, ...credits].map((line) => (
+            <TableRow key={`${line.direction}-${line.accountCode}-${line.sortOrder}`}>
+              <TableCell className={cn('align-top', line.direction === 'credit' && 'ps-8')}>
+                <div className='flex items-center gap-2'>
+                  <span className='font-mono text-xs text-muted-foreground'>
+                    {line.accountCode}
+                  </span>
+                  <span>{line.accountName ?? line.accountCode}</span>
+                  {onDrillDown && (
+                    <Tooltip content='What is behind this number'>
+                      <Button
+                        variant='ghost'
+                        size='icon-xs'
+                        aria-label={`What is behind account ${line.accountCode}`}
+                        onClick={() => onDrillDown(line.accountCode, line.accountName)}>
+                        <Search />
+                      </Button>
+                    </Tooltip>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell className='align-top text-muted-foreground'>{line.memo}</TableCell>
+              <TableCell className='text-right font-mono tabular-nums align-top'>
+                {line.direction === 'debit' ? formatMinor(line.amount, currencyCode) : null}
+              </TableCell>
+              <TableCell className='text-right font-mono tabular-nums align-top'>
+                {line.direction === 'credit' ? formatMinor(line.amount, currencyCode) : null}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={2}>Totals</TableCell>
+            <TableCell className='text-right font-mono tabular-nums'>
+              {formatMinor(totalDebit, currencyCode)}
+            </TableCell>
+            <TableCell className='text-right font-mono tabular-nums'>
+              {formatMinor(totalCredit, currencyCode)}
+            </TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+
+      <div
+        className={cn(
+          'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm',
+          balanced
+            ? 'border-green-500/40 text-green-700 dark:text-green-400'
+            : 'border-destructive/50 text-destructive'
+        )}>
+        {balanced ? <CheckCircle2 className='size-4' /> : <TriangleAlert className='size-4' />}
+        <span>
+          {balanced
+            ? 'Balanced. Debits equal credits.'
+            : `Out of balance by ${formatMinor(difference, currencyCode)}.`}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/entry-roll-forward.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-roll-forward.tsx
@@ -1,0 +1,128 @@
+// apps/web/src/components/accounting/ui/ledger/entry-roll-forward.tsx
+
+'use client'
+
+import {
+  ACCOUNT_ROLE_LABELS,
+  type AccountRole,
+  type PostingAssertions,
+} from '@auxx/lib/postings/client'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { EMPTY_CELL, formatMinor, formatSignedMinor } from './format'
+
+/** The three balances a `month_end_inventory` snapshot asserts, in statement order. */
+const BALANCE_ROLES = [
+  'inventory_raw_materials',
+  'inventory_wip',
+  'inventory_finished_goods',
+] as const satisfies readonly AccountRole[]
+
+/** The activity totals. These have an Activity column and nothing else. */
+const ACTIVITY_ROWS = [
+  { key: 'absorbedLabor', label: 'Absorbed assembly labor' },
+  { key: 'absorbedOverhead', label: 'Absorbed overhead' },
+  { key: 'inventoryAdjustments', label: 'Count variance' },
+] as const
+
+interface EntryRollForwardProps {
+  assertions: PostingAssertions
+  currencyCode: string
+  /** Account code per role, from the org's own chart. Optional: labels stand alone. */
+  accountCodeByRole?: Partial<Record<AccountRole, string>>
+}
+
+/**
+ * Opening / Activity / Closing, built from the draft's `assertions.before` and
+ * `assertions.after`.
+ *
+ * This is the CPA-legible view and it is not decoration. The journal entry shows
+ * the DELTA; the roll-forward shows what the delta is a delta OF, and it is the
+ * only thing on screen that makes the `before` = prior row's `after` chain
+ * visible to a person (13-accounting-ui.md §5.2).
+ *
+ * ⚠️ It also catches what the entry cannot. The month-end entry is balanced BY
+ * CONSTRUCTION with COGS as the plug, so flipping one lane's direction is
+ * absorbed at twice the error and the entry still balances. The roll-forward is
+ * where that shows up.
+ *
+ * The Activity column is a genuine delta, so it carries an explicit sign, the
+ * opposite of the journal entry, where `direction` carries the sign and every
+ * amount is positive.
+ */
+export function EntryRollForward({
+  assertions,
+  currencyCode,
+  accountCodeByRole,
+}: EntryRollForwardProps) {
+  const { before, after } = assertions
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className='w-[40%]'>Balance</TableHead>
+            <TableHead className='w-40 text-right'>Opening</TableHead>
+            <TableHead className='w-40 text-right'>Activity</TableHead>
+            <TableHead className='w-40 text-right'>Closing</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {BALANCE_ROLES.map((role) => {
+            const opening = before.balances[role]
+            const closing = after.balances[role]
+            const code = accountCodeByRole?.[role]
+            return (
+              <TableRow key={role}>
+                <TableCell>
+                  <div className='flex items-center gap-2'>
+                    {code && (
+                      <span className='font-mono text-xs text-muted-foreground'>{code}</span>
+                    )}
+                    <span>{ACCOUNT_ROLE_LABELS[role]}</span>
+                  </div>
+                </TableCell>
+                <TableCell className='text-right font-mono tabular-nums'>
+                  {formatMinor(opening, currencyCode)}
+                </TableCell>
+                <TableCell className='text-right font-mono tabular-nums'>
+                  {formatSignedMinor(closing - opening, currencyCode)}
+                </TableCell>
+                <TableCell className='text-right font-mono tabular-nums'>
+                  {formatMinor(closing, currencyCode)}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+
+          {ACTIVITY_ROWS.map((row) => (
+            <TableRow key={row.key}>
+              <TableCell className='text-muted-foreground'>{row.label}</TableCell>
+              <TableCell className='text-right text-muted-foreground'>{EMPTY_CELL}</TableCell>
+              <TableCell className='text-right font-mono tabular-nums'>
+                {formatSignedMinor(
+                  after.activityTotals[row.key] - before.activityTotals[row.key],
+                  currencyCode
+                )}
+              </TableCell>
+              <TableCell className='text-right text-muted-foreground'>{EMPTY_CELL}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <p className='text-xs text-muted-foreground'>
+        Opening is what the previous month&apos;s entry asserted as its closing position. The
+        activity totals are cumulative to the period end, so their Activity column is the difference
+        between the two assertions, not a balance of its own.
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/format.ts
+++ b/apps/web/src/components/accounting/ui/ledger/format.ts
@@ -1,0 +1,105 @@
+// apps/web/src/components/accounting/ui/ledger/format.ts
+
+import { formatCurrency } from '@auxx/utils/currency'
+
+/**
+ * Display helpers for the ledger screens.
+ *
+ * ⚠️ Every money value that reaches this file is an INTEGER COUNT OF MINOR
+ * UNITS, exactly as the postings module stores it. Nothing here accepts a
+ * major-unit decimal, and nothing here converts one: `formatCurrency` already
+ * owns the scale via the ISO code's minor-unit exponent, so a zero-exponent
+ * currency renders correctly without a second opinion about where the point
+ * goes. `~/components/money/ui/settings/format-money.ts` is the same idea for
+ * catalog CURRENCY fields.
+ */
+
+/** Placeholder for a cell that has no value, as opposed to a zero. */
+export const EMPTY_CELL = '—'
+
+/** Format minor units for a ledger column. Never signed: see {@link formatSignedMinor}. */
+export function formatMinor(minorUnits: number | null | undefined, currencyCode: string): string {
+  if (minorUnits === null || minorUnits === undefined) return EMPTY_CELL
+  return formatCurrency(minorUnits, { currencyCode })
+}
+
+/**
+ * Format minor units with an explicit sign, for a DELTA column only.
+ *
+ * 🛑 A journal entry must never use this. A bookkeeper reading a two-column
+ * table of signed numbers is being asked to convert in their head; debits and
+ * credits carry the sign there, and the amount stays positive. The
+ * roll-forward's Activity column is a genuine delta, so a sign is the correct
+ * reading there.
+ */
+export function formatSignedMinor(
+  minorUnits: number | null | undefined,
+  currencyCode: string
+): string {
+  if (minorUnits === null || minorUnits === undefined) return EMPTY_CELL
+  if (minorUnits === 0) return formatCurrency(0, { currencyCode })
+  const sign = minorUnits > 0 ? '+' : '-'
+  return `${sign}${formatCurrency(Math.abs(minorUnits), { currencyCode })}`
+}
+
+/** A signed integer quantity, for a count delta. */
+export function formatSignedQuantity(quantity: number): string {
+  if (quantity === 0) return '0'
+  return quantity > 0 ? `+${quantity}` : String(quantity)
+}
+
+const MONTH_LABEL = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  year: 'numeric',
+  timeZone: 'UTC',
+})
+
+/** `'2027-03'` becomes `'March 2027'`. Returns the key unchanged if it is not a month. */
+export function formatPeriodLabel(periodKey: string): string {
+  const match = /^(\d{4})-(\d{2})$/.exec(periodKey)
+  if (!match) return periodKey
+  const year = Number(match[1])
+  const month = Number(match[2])
+  if (!Number.isFinite(year) || month < 1 || month > 12) return periodKey
+  return MONTH_LABEL.format(new Date(Date.UTC(year, month - 1, 1)))
+}
+
+/** `'2027-03'` becomes `'Mar 2027'`, for a dense strip. */
+export function formatShortPeriodLabel(periodKey: string): string {
+  return formatPeriodLabel(periodKey).replace(/^(\w{3})\w*/, '$1')
+}
+
+/**
+ * An ACCOUNTING date: the date that decides which period a row belongs to.
+ * Rendered in the org's book time zone, because that is the zone the period
+ * boundary was drawn in.
+ */
+export function formatAccountingDate(iso: string, timeZone: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone,
+  }).format(date)
+}
+
+/**
+ * An AUDIT timestamp: when auxx learned about a row.
+ *
+ * ⚠️ Never a substitute for the accounting date. The late-arrivals section
+ * shows both side by side precisely because they can disagree by weeks.
+ */
+export function formatAuditTimestamp(iso: string, timeZone: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone,
+  }).format(date)
+}

--- a/apps/web/src/components/accounting/ui/ledger/late-arrivals-section.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/late-arrivals-section.tsx
@@ -1,0 +1,109 @@
+// apps/web/src/components/accounting/ui/ledger/late-arrivals-section.tsx
+
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { EmptySection } from '@auxx/ui/components/section'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { Clock3 } from 'lucide-react'
+import type { FixtureLateArrival } from '~/components/accounting/fixtures'
+import { formatAccountingDate, formatAuditTimestamp, formatSignedMinor } from './format'
+
+const KIND_LABEL: Record<FixtureLateArrival['kind'], string> = {
+  build: 'Build',
+  adjustment: 'Adjustment',
+  receipt: 'Receipt',
+}
+
+interface LateArrivalsSectionProps {
+  arrivals: FixtureLateArrival[]
+  currencyCode: string
+  bookTimeZone: string
+  /** The month being closed, for the explanatory sentence. */
+  periodLabel: string
+}
+
+/**
+ * Activity dated before this period but entered after the prior close.
+ *
+ * 🛑 The section that keeps the number explainable. The month-end entry's legs
+ * are CUMULATIVE DELTAS, so a build or an adjustment dated in a closed month but
+ * entered after that close lands in the next OPEN month's delta. This month's
+ * entry can therefore legitimately contain last month's activity, and with
+ * nothing on screen saying so, the first instinct is "the entry is wrong"
+ * (13-accounting-ui.md §5.2).
+ *
+ * ⚠️ Both dates are shown because they answer different questions and they can
+ * disagree by weeks. `occurredAt` is the ACCOUNTING date, which decides which
+ * period a row belongs to. `createdAt` is when auxx LEARNED about the row: audit
+ * evidence, never an accounting date.
+ */
+export function LateArrivalsSection({
+  arrivals,
+  currencyCode,
+  bookTimeZone,
+  periodLabel,
+}: LateArrivalsSectionProps) {
+  if (arrivals.length === 0) {
+    return (
+      <EmptySection
+        icon={<Clock3 className='size-5' />}
+        title='Nothing arrived late'
+        description={`Every row in ${periodLabel}'s entry was both dated in and entered during the period.`}
+      />
+    )
+  }
+
+  const netMinor = arrivals.reduce((sum, row) => sum + row.amountMinor, 0)
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <p className='text-sm text-muted-foreground'>
+        These rows are dated before {periodLabel} but were entered after the previous month had
+        already closed. The entry&apos;s legs are cumulative deltas, so they land here rather than
+        reopening a closed month. That is why {periodLabel}&apos;s entry carries{' '}
+        {formatSignedMinor(netMinor, currencyCode)} of earlier activity.
+      </p>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className='w-28'>Kind</TableHead>
+            <TableHead className='w-32'>Reference</TableHead>
+            <TableHead>Description</TableHead>
+            <TableHead className='w-36'>Accounting date</TableHead>
+            <TableHead className='w-44'>Entered</TableHead>
+            <TableHead className='w-32 text-right'>Amount</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {arrivals.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell>
+                <Badge variant='outline' size='sm'>
+                  {KIND_LABEL[row.kind]}
+                </Badge>
+              </TableCell>
+              <TableCell className='font-mono text-xs'>{row.reference}</TableCell>
+              <TableCell className='text-muted-foreground'>{row.description}</TableCell>
+              <TableCell>{formatAccountingDate(row.occurredAt, bookTimeZone)}</TableCell>
+              <TableCell className='text-muted-foreground'>
+                {formatAuditTimestamp(row.createdAt, bookTimeZone)}
+              </TableCell>
+              <TableCell className='text-right font-mono tabular-nums'>
+                {formatSignedMinor(row.amountMinor, currencyCode)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
@@ -1,0 +1,515 @@
+// apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { MainPageContent } from '@auxx/ui/components/main-page'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Section } from '@auxx/ui/components/section'
+import { Separator } from '@auxx/ui/components/separator'
+import {
+  BookOpenCheck,
+  CalendarCheck2,
+  ClipboardCheck,
+  Clock3,
+  Layers,
+  Lock,
+  LockOpen,
+  Scale,
+  Send,
+} from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useQueryState } from 'nuqs'
+import { useRef, useState } from 'react'
+import {
+  FIXTURE_ASSERTIONS,
+  FIXTURE_BOOK_TIME_ZONE,
+  FIXTURE_BOOKS_BALANCE,
+  FIXTURE_COUNT_ADJUSTMENTS,
+  FIXTURE_LATE_ARRIVALS,
+  FIXTURE_POSTED_DRAFT,
+  FIXTURE_PROVIDER,
+  FIXTURE_REVISIONS,
+  FIXTURE_ROLE_ACCOUNTS,
+  FIXTURE_UNPOSTED_PERIODS,
+  type FixtureRevision,
+} from '~/components/accounting/fixtures'
+import { useLedgerEntryActions } from '~/components/accounting/hooks/use-ledger-entry-actions'
+import { useLedgerPeriod } from '~/components/accounting/hooks/use-ledger-period'
+// PLACEHOLDER SLOT: another agent owns this component (13-accounting-ui.md
+// §5.5). Setup-not-finalized is the module home's FIRST state: the body IS the
+// goals, progress and CTAs, not a sidebar widget.
+import { AccountingChecklistPanel } from '~/components/accounting/ui/checklist/accounting-checklist-panel'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useMedia } from '~/hooks/use-media'
+import { useSettings } from '~/hooks/use-settings'
+import { useDockStore } from '~/stores/dock-store'
+import { BooksBalanceLine, UnpostedPeriodsBanner } from './books-health'
+import { CountEvidenceSection } from './count-evidence-section'
+import { EntryBlockers, type LedgerBlocker } from './entry-blockers'
+import { EntryJournal } from './entry-journal'
+import { EntryRollForward } from './entry-roll-forward'
+import { formatPeriodLabel } from './format'
+import { LateArrivalsSection } from './late-arrivals-section'
+import { LedgerToolbar } from './ledger-toolbar'
+import { LineDrillDown, type LineDrillDownTarget } from './line-drill-down'
+import { PostResultCallout } from './post-result-callout'
+import { PostingDrawer } from './posting-drawer'
+import { RevisionStrip } from './revision-strip'
+
+/** Account code per role, for the roll-forward's left column. */
+const ACCOUNT_CODE_BY_ROLE = Object.fromEntries(
+  Object.entries(FIXTURE_ROLE_ACCOUNTS).map(([role, account]) => [role, account.code])
+)
+
+interface LedgerPageProps {
+  /** Absent on `/app/accounting`, which resolves a period instead. */
+  periodKey?: string
+}
+
+/**
+ * The ledger: ONE component behind both `/app/accounting` and
+ * `/app/accounting/[period]` (13-accounting-ui.md §5.1).
+ *
+ * 🛑 `/app/accounting` RENDERS, it never redirects: a redirect would make the
+ * module home URL unstable and break "Accounting" as a bookmark. Only the period
+ * resolution differs between the two routes.
+ *
+ * Three states:
+ *
+ *   1. Setup not finalized  → the getting-started checklist, period nav disabled
+ *   2. A month is open      → that month's entry, ready to preview and post
+ *   3. Everything posted    → the most recent posted month, plus "nothing to close"
+ *
+ * 🛑 Under the L1 regime a month has exactly ONE entry (no receipt, build or
+ * shipment posts individually), so the entry renders inline with no list. What a
+ * month does have is a revision chain, which is why the revision strip appears
+ * only above revision 0 and why `?posting=<id>` exists.
+ *
+ * ⚠️ Every number on this screen is placeholder data from
+ * `~/components/accounting/fixtures`. See `use-ledger-entry-actions.ts` for the
+ * four procedures that replace it.
+ */
+export function LedgerPage({ periodKey }: LedgerPageProps) {
+  const router = useRouter()
+  const period = useLedgerPeriod(periodKey)
+  const isDesktop = useMedia('(min-width: 1024px)')
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  // 🛑 The deep link. A ledger entry is the thing somebody pastes into Slack.
+  const [postingId, setPostingId] = useQueryState('posting')
+  const [drillDown, setDrillDown] = useState<LineDrillDownTarget | null>(null)
+  const lockSectionRef = useRef<HTMLDivElement | null>(null)
+
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const currencyCode = (getSetting('organization.currency') as string) || 'USD'
+  // PLACEHOLDER: `accounting.bookTimeZone` is a real catalog key; the fixture
+  // value stands in until an org has been through setup.
+  const bookTimeZone = (getSetting('accounting.bookTimeZone') as string) || FIXTURE_BOOK_TIME_ZONE
+
+  const activePeriodKey = period.activePeriodKey
+  const summary = period.activeSummary
+  const periodLabel = formatPeriodLabel(activePeriodKey)
+  const isBlocked = period.screenState === 'blocked'
+  const isPostedPeriod = !!summary && summary.state !== 'open'
+
+  const actions = useLedgerEntryActions({
+    periodKey: activePeriodKey,
+    blocked: isBlocked,
+    providerConnected: period.providerConnected,
+  })
+
+  // PLACEHOLDER: `ledger.lockedThroughMonth` is a DOCUMENTS-scope setting and
+  // nothing in the app writes it today: the last step of a close currently has
+  // no button anywhere. Locking is a SEPARATE action from posting, never a side
+  // effect of it: a person may reasonably want to post, look at it for a day,
+  // then lock (13-accounting-ui.md §5.2).
+  const [lockOverrides, setLockOverrides] = useState<Record<string, boolean>>({})
+  const isLocked = lockOverrides[activePeriodKey] ?? summary?.state === 'locked'
+
+  // PLACEHOLDER: `ledger.get(id)` returns the chain. Only 2027-02 carries a
+  // reversal in the fixtures, so a posted month without one is given its single
+  // revision 0 here rather than leaving the drawer unreachable from it.
+  const revisions: FixtureRevision[] =
+    FIXTURE_REVISIONS[activePeriodKey] ??
+    (summary && summary.state !== 'open' && summary.docNumber
+      ? [
+          {
+            glPostingId: `glp_${activePeriodKey.replace('-', '_')}_r0`,
+            revision: 0,
+            status: 'posted',
+            docNumber: summary.docNumber,
+            postedAt: summary.postedAt ?? '',
+          },
+        ]
+      : [])
+  const showRevisionStrip = !!summary && summary.revision > 0 && revisions.length > 1
+
+  const blockers: LedgerBlocker[] = actions.preview.blockedBy ? [actions.preview.blockedBy] : []
+  const lines = isPostedPeriod ? FIXTURE_POSTED_DRAFT.resolvedLines : actions.preview.lines
+  const canPost = !isPostedPeriod && !isLocked && blockers.length === 0 && !actions.justPosted
+
+  function goToPeriod(next: string) {
+    // The placeholder `?state=` / `?provider=` toggles are carried across a
+    // period change so a demo state survives navigation. They go away with the
+    // fixtures; `?posting=` deliberately does NOT survive, because a posting id
+    // belongs to one month.
+    const carried = new URLSearchParams()
+    if (period.screenState !== 'open') carried.set('state', period.screenState)
+    if (!period.providerConnected) carried.set('provider', 'none')
+    const query = carried.toString()
+    router.push(`/app/accounting/${next}${query ? `?${query}` : ''}`)
+  }
+
+  async function handleToggleLock() {
+    if (isLocked) {
+      // ⚠️ Unlocking is mechanically just a setting write, so it is made loud.
+      // It permits posting into a month the accountant may already have seen.
+      const confirmed = await confirm({
+        title: `Unlock ${periodLabel}?`,
+        description: `Unlocking permits new postings into ${periodLabel}, a month that has already been closed and may already have been reported on. Anything posted after this changes figures somebody has seen.`,
+        confirmText: 'Unlock the month',
+        cancelText: 'Keep it locked',
+        destructive: true,
+      })
+      if (!confirmed) return
+    }
+    // PLACEHOLDER: writes `ledger.lockedThroughMonth` (scope DOCUMENTS).
+    setLockOverrides((previous) => ({ ...previous, [activePeriodKey]: !isLocked }))
+  }
+
+  const postingDrawer = (
+    <PostingDrawer
+      postingId={postingId}
+      chain={revisions}
+      chainPeriodKey={activePeriodKey}
+      onOpenChange={(open) => {
+        if (!open) void setPostingId(null)
+      }}
+      isDocked={isDesktop}
+      width={dockedWidth}
+      onWidthChange={setDockedWidth}
+      currencyCode={currencyCode}
+      bookTimeZone={bookTimeZone}
+      providerLabel={FIXTURE_PROVIDER.label}
+      providerConnected={period.providerConnected}
+    />
+  )
+
+  const isChecklistState = period.screenState === 'checklist'
+
+  const content = (
+    <MainPageContent
+      dockedPanels={
+        isDesktop && postingId
+          ? [
+              {
+                key: 'posting',
+                content: postingDrawer,
+                width: dockedWidth,
+                onWidthChange: setDockedWidth,
+                minWidth: 380,
+                maxWidth: 720,
+              },
+            ]
+          : []
+      }>
+      <LedgerToolbar
+        periodKey={activePeriodKey}
+        options={period.options}
+        summary={summary}
+        previousPeriodKey={period.previousPeriodKey}
+        nextPeriodKey={period.nextPeriodKey}
+        resolvedPeriodKey={period.resolvedPeriodKey}
+        onSelectPeriod={goToPeriod}
+        disabled={isChecklistState}
+      />
+
+      <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
+        <div className='mx-auto flex w-full max-w-5xl flex-col gap-2 p-4'>
+          {isChecklistState ? (
+            <AccountingChecklistPanel />
+          ) : (
+            <>
+              {FIXTURE_UNPOSTED_PERIODS.length > 0 && (
+                <UnpostedPeriodsBanner periods={FIXTURE_UNPOSTED_PERIODS} />
+              )}
+
+              {!period.hasOpenPeriod && (
+                <div className='flex items-start gap-3 rounded-xl border bg-muted/40 p-4'>
+                  <CalendarCheck2 className='mt-0.5 size-5 shrink-0 text-muted-foreground' />
+                  <div className='flex flex-col gap-1'>
+                    <span className='font-medium'>Nothing to close</span>
+                    <p className='text-sm text-muted-foreground'>
+                      Every month from the cutoff forward has been posted. {periodLabel} is the most
+                      recent, and it is shown below.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {showRevisionStrip && (
+                <RevisionStrip
+                  revisions={revisions}
+                  activePostingId={postingId}
+                  onSelect={(id) => void setPostingId(id)}
+                  bookTimeZone={bookTimeZone}
+                />
+              )}
+
+              {blockers.length > 0 && (
+                <Section
+                  title={`${periodLabel} cannot be closed yet`}
+                  icon={<Lock className='size-4' />}
+                  description='Every refusal names what is missing and where it is fixed.'
+                  collapsible={false}>
+                  <EntryBlockers
+                    blockers={blockers}
+                    onReviewLock={() =>
+                      lockSectionRef.current?.scrollIntoView({ behavior: 'smooth' })
+                    }
+                  />
+                </Section>
+              )}
+
+              <Section
+                title='Journal entry'
+                icon={<BookOpenCheck className='size-4' />}
+                secondary={actions.preview.docNumber}
+                description={
+                  isPostedPeriod
+                    ? 'The stored draft, exactly as it was posted. Never a re-run of the builder.'
+                    : `The month-end inventory entry auxx would post for ${periodLabel}.`
+                }
+                collapsible={false}
+                actions={
+                  <div className='flex items-center gap-1'>
+                    {!isPostedPeriod && (
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        loading={actions.isPreviewing}
+                        loadingText='Building...'
+                        onClick={actions.runPreview}>
+                        Rebuild preview
+                      </Button>
+                    )}
+                  </div>
+                }>
+                {lines.length === 0 && blockers.length > 0 ? (
+                  <p className='text-sm text-muted-foreground'>
+                    No entry was built. The refusals above are the whole of what happened.
+                  </p>
+                ) : (
+                  <div className='flex flex-col gap-4'>
+                    <EntryJournal
+                      lines={lines}
+                      currencyCode={currencyCode}
+                      onDrillDown={(accountCode, accountName) =>
+                        setDrillDown({ accountCode, accountName })
+                      }
+                    />
+
+                    {actions.postResult && (
+                      <PostResultCallout
+                        result={actions.postResult}
+                        providerLabel={FIXTURE_PROVIDER.label}
+                      />
+                    )}
+
+                    {/* 🛑 Post and Reverse live HERE, beside the entry they act
+                        on, not in the toolbar. They are the decision, not
+                        navigation, and exceptions and the Post control share one
+                        screen by design. */}
+                    <div className='flex flex-wrap items-center gap-2 border-t pt-3'>
+                      <Button
+                        disabled={!canPost}
+                        loading={actions.isPosting}
+                        loadingText='Posting...'
+                        onClick={actions.runPost}>
+                        <Send />
+                        Post {periodLabel}
+                      </Button>
+                      <Button
+                        variant='outline'
+                        disabled={!isPostedPeriod || revisions.length === 0}
+                        onClick={() => {
+                          const newest = revisions[0]
+                          if (newest) void setPostingId(newest.glPostingId)
+                        }}>
+                        Reverse or re-enter
+                      </Button>
+                      <Separator orientation='vertical' className='h-6' />
+                      <span className='text-xs text-muted-foreground'>
+                        {canPost
+                          ? 'Posting records the entry here and pushes it to the accounting system, if one is connected.'
+                          : isPostedPeriod || actions.justPosted
+                            ? 'This month is posted. A mistake is corrected by reversing and re-entering, never by editing.'
+                            : 'Posting is refused until the blockers above are cleared.'}
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </Section>
+
+              <Section
+                title='Roll-forward'
+                icon={<Layers className='size-4' />}
+                description='Opening, activity and closing per balance. The entry shows the delta; this shows what the delta is a delta of.'
+                collapsible={false}>
+                <EntryRollForward
+                  assertions={FIXTURE_ASSERTIONS}
+                  currencyCode={currencyCode}
+                  accountCodeByRole={ACCOUNT_CODE_BY_ROLE}
+                />
+              </Section>
+
+              <div ref={lockSectionRef}>
+                <Section
+                  title='Close the month'
+                  icon={isLocked ? <Lock className='size-4' /> : <LockOpen className='size-4' />}
+                  description='Declaring the month shut is a separate assertion from posting the entry.'
+                  collapsible={false}>
+                  <div className='flex flex-wrap items-center gap-3'>
+                    <Button
+                      variant={isLocked ? 'outline' : 'default'}
+                      disabled={!isPostedPeriod && !actions.justPosted}
+                      onClick={() => void handleToggleLock()}>
+                      {isLocked ? <LockOpen /> : <Lock />}
+                      {isLocked ? `Unlock ${periodLabel}` : `Lock ${periodLabel}`}
+                    </Button>
+                    <span className='text-sm text-muted-foreground'>
+                      {isLocked
+                        ? 'Locked. Nothing can post into this month until it is unlocked, and unlocking asks first.'
+                        : 'Open. The entry can still be reversed and re-entered.'}
+                    </span>
+                  </div>
+                </Section>
+              </div>
+
+              <Section
+                title='Late-arriving activity'
+                icon={<Clock3 className='size-4' />}
+                description='Rows dated before this month but entered after the previous close.'
+                collapsible={false}>
+                <LateArrivalsSection
+                  arrivals={FIXTURE_LATE_ARRIVALS}
+                  currencyCode={currencyCode}
+                  bookTimeZone={bookTimeZone}
+                  periodLabel={periodLabel}
+                />
+              </Section>
+
+              <Section
+                title='Cycle-count evidence'
+                icon={<ClipboardCheck className='size-4' />}
+                description='Evidence about the closing inventory balance. Not a check that passed.'
+                collapsible={false}>
+                <CountEvidenceSection
+                  adjustments={FIXTURE_COUNT_ADJUSTMENTS}
+                  currencyCode={currencyCode}
+                  bookTimeZone={bookTimeZone}
+                />
+              </Section>
+
+              <Section
+                title='Books'
+                icon={<Scale className='size-4' />}
+                description='The after-the-fact balance sweep across every posting in the books.'
+                collapsible={false}>
+                <BooksBalanceLine report={FIXTURE_BOOKS_BALANCE} />
+              </Section>
+            </>
+          )}
+
+          <PlaceholderStateSwitcher
+            screenState={period.screenState}
+            onScreenStateChange={period.setScreenState}
+            providerConnected={period.providerConnected}
+            onProviderConnectedChange={period.setProviderConnected}
+          />
+        </div>
+      </ScrollArea>
+    </MainPageContent>
+  )
+
+  return (
+    <>
+      {content}
+
+      {/* Below the dock breakpoint the same drawer renders as a floating
+          overlay. Placed outside `MainPageContent`, the way every other docked
+          panel's overlay fallback is. */}
+      {!isDesktop && postingDrawer}
+
+      <LineDrillDown
+        target={drillDown}
+        onOpenChange={(open) => {
+          if (!open) setDrillDown(null)
+        }}
+        currencyCode={currencyCode}
+        bookTimeZone={bookTimeZone}
+        periodLabel={periodLabel}
+      />
+
+      <ConfirmDialog />
+    </>
+  )
+}
+
+interface PlaceholderStateSwitcherProps {
+  screenState: ReturnType<typeof useLedgerPeriod>['screenState']
+  onScreenStateChange: (state: PlaceholderStateSwitcherProps['screenState']) => void
+  providerConnected: boolean
+  onProviderConnectedChange: (connected: boolean) => void
+}
+
+const PLACEHOLDER_STATES: Array<{
+  value: PlaceholderStateSwitcherProps['screenState']
+  label: string
+}> = [
+  { value: 'checklist', label: 'Setup not finalized' },
+  { value: 'open', label: 'A month is open' },
+  { value: 'blocked', label: 'Open, preview refused' },
+  { value: 'posted', label: 'Everything posted' },
+]
+
+/**
+ * 🛑 PLACEHOLDER CONTROL: delete with `fixtures.ts`.
+ *
+ * The four procedures in 13-accounting-ui.md §4 do not exist, so nothing on this
+ * screen can reach a state by doing the thing that causes it. This strip writes
+ * `?state=` and `?provider=` so every state is reachable and reviewable. It is
+ * not a product feature and no real org will ever see it.
+ */
+function PlaceholderStateSwitcher({
+  screenState,
+  onScreenStateChange,
+  providerConnected,
+  onProviderConnectedChange,
+}: PlaceholderStateSwitcherProps) {
+  return (
+    <div className='mt-6 flex flex-wrap items-center gap-2 rounded-xl border border-dashed p-3'>
+      <span className='text-xs font-medium text-muted-foreground'>Placeholder states</span>
+      <Separator orientation='vertical' className='h-5' />
+      {PLACEHOLDER_STATES.map((state) => (
+        <Button
+          key={state.value}
+          variant={screenState === state.value ? 'secondary' : 'ghost'}
+          size='sm'
+          onClick={() => onScreenStateChange(state.value)}>
+          {state.label}
+        </Button>
+      ))}
+      <Separator orientation='vertical' className='h-5' />
+      <Button
+        variant={providerConnected ? 'ghost' : 'secondary'}
+        size='sm'
+        onClick={() => onProviderConnectedChange(!providerConnected)}>
+        {providerConnected ? 'Provider connected' : 'No provider connected'}
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/ledger-toolbar.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-toolbar.tsx
@@ -1,0 +1,155 @@
+// apps/web/src/components/accounting/ui/ledger/ledger-toolbar.tsx
+
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { Separator } from '@auxx/ui/components/separator'
+import { cn } from '@auxx/ui/lib/utils'
+import { ChevronDown, ChevronLeft, ChevronRight, Lock } from 'lucide-react'
+import type { FixturePeriodState, FixturePeriodSummary } from '~/components/accounting/fixtures'
+import type { LedgerPeriodOption } from '~/components/accounting/hooks/use-ledger-period'
+import { Tooltip } from '~/components/global/tooltip'
+import { formatPeriodLabel } from './format'
+
+const STATE_LABEL: Record<FixturePeriodState, string> = {
+  open: 'Open',
+  posted: 'Posted',
+  locked: 'Locked',
+}
+
+/** The pill's dot. Locked reads as "shut", not as a stronger Posted. */
+const STATE_DOT: Record<FixturePeriodState, string> = {
+  open: 'bg-amber-500',
+  posted: 'bg-green-500',
+  locked: 'bg-primary-400',
+}
+
+interface LedgerToolbarProps {
+  periodKey: string
+  options: LedgerPeriodOption[]
+  summary?: FixturePeriodSummary
+  previousPeriodKey: string | null
+  nextPeriodKey: string | null
+  resolvedPeriodKey: string
+  onSelectPeriod: (periodKey: string) => void
+  /** Setup is not finalized: there is no month to navigate to yet. */
+  disabled?: boolean
+}
+
+/**
+ * The ledger's first row inside `MainPageContent`, on `BoardToolbar`'s scale
+ * (`gap-1 p-1`, ghost `h-7` buttons, `Separator` dividers, tooltips).
+ *
+ * ```
+ * [ Current ] [ ‹ ] [ March 2027 ▾ ] [ › ]  │  ● Posted · AUXX-MEI-2027-03
+ * ```
+ *
+ * ⚠️ Ordered by `BoardToolbar`'s own rule: the period nav is the STABLE PREFIX
+ * and never moves, so switching months causes no layout shift; everything that
+ * varies with the month's state lives after the `Separator`.
+ *
+ * 🛑 Post and Reverse are deliberately NOT here. They are the decision, not
+ * navigation, and a consequential button in a dense ghost strip reads as a
+ * minor control. They sit in the body beside the entry they act on
+ * (13-accounting-ui.md §5.1).
+ */
+export function LedgerToolbar({
+  periodKey,
+  options,
+  summary,
+  previousPeriodKey,
+  nextPeriodKey,
+  resolvedPeriodKey,
+  onSelectPeriod,
+  disabled = false,
+}: LedgerToolbarProps) {
+  const state = summary?.state ?? 'open'
+
+  return (
+    <div className='flex flex-wrap items-center gap-1 border-b p-1'>
+      <Button
+        variant='ghost'
+        size='sm'
+        disabled={disabled || periodKey === resolvedPeriodKey}
+        onClick={() => onSelectPeriod(resolvedPeriodKey)}>
+        Current
+      </Button>
+
+      <Tooltip content='Previous month'>
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          aria-label='Previous month'
+          disabled={disabled || !previousPeriodKey}
+          onClick={() => previousPeriodKey && onSelectPeriod(previousPeriodKey)}>
+          <ChevronLeft />
+        </Button>
+      </Tooltip>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild disabled={disabled}>
+          <Button variant='ghost' size='sm' className='min-w-[9.5rem] justify-between'>
+            {formatPeriodLabel(periodKey)}
+            <ChevronDown />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='start' className='min-w-[13rem]'>
+          {options.map((option) => (
+            <DropdownMenuItem
+              key={option.periodKey}
+              onSelect={() => onSelectPeriod(option.periodKey)}
+              className='justify-between gap-6'>
+              <span className={cn(option.periodKey === periodKey && 'font-medium')}>
+                {option.label}
+              </span>
+              <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+                {option.summary.state === 'locked' && <Lock className='size-3' />}
+                {STATE_LABEL[option.summary.state]}
+              </span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Tooltip content='Next month'>
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          aria-label='Next month'
+          disabled={disabled || !nextPeriodKey}
+          onClick={() => nextPeriodKey && onSelectPeriod(nextPeriodKey)}>
+          <ChevronRight />
+        </Button>
+      </Tooltip>
+
+      <Separator orientation='vertical' className='h-6' />
+
+      {!disabled && (
+        <div className='flex items-center gap-2 px-1 text-xs text-muted-foreground'>
+          <span className={cn('size-1.5 rounded-full', STATE_DOT[state])} aria-hidden />
+          <span className='text-foreground'>{STATE_LABEL[state]}</span>
+          {summary?.docNumber && (
+            <>
+              <span aria-hidden>·</span>
+              <span className='font-mono'>{summary.docNumber}</span>
+            </>
+          )}
+          {summary && summary.revision > 0 && (
+            <Badge variant='outline' size='sm'>
+              Revision {summary.revision}
+            </Badge>
+          )}
+        </div>
+      )}
+
+      <div className='flex-1' />
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/line-drill-down.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/line-drill-down.tsx
@@ -1,0 +1,126 @@
+// apps/web/src/components/accounting/ui/ledger/line-drill-down.tsx
+
+'use client'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { EmptySection } from '@auxx/ui/components/section'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { FileSearch } from 'lucide-react'
+import { FIXTURE_DRILL_DOWN } from '~/components/accounting/fixtures'
+import { formatAccountingDate, formatMinor, formatSignedMinor } from './format'
+
+export interface LineDrillDownTarget {
+  accountCode: string
+  accountName?: string
+}
+
+interface LineDrillDownProps {
+  target: LineDrillDownTarget | null
+  onOpenChange: (open: boolean) => void
+  currencyCode: string
+  bookTimeZone: string
+  periodLabel: string
+}
+
+/**
+ * "What is behind this number" for one line of the entry.
+ *
+ * ⚠️ A REPORT, not an expander, and the difference is not cosmetic. A posting
+ * line carries exactly ONE `sourceType` + `sourceId`, and a month-end line is a
+ * single row per account role summarising hundreds of movements, so there is
+ * no stored provenance to expand. Gap-g's "click 4000 and see the 41 order ids"
+ * is not backed by the shipped data; this is a separate query back into the
+ * subledger, and presenting it as an inline expander would imply the ledger
+ * stores something it does not (13-accounting-ui.md §5.2).
+ *
+ * 🛑 PLACEHOLDER data: `FIXTURE_DRILL_DOWN`, keyed by account code. The real
+ * version is a subledger query scoped to the account role and the period.
+ */
+export function LineDrillDown({
+  target,
+  onOpenChange,
+  currencyCode,
+  bookTimeZone,
+  periodLabel,
+}: LineDrillDownProps) {
+  const rows = target ? (FIXTURE_DRILL_DOWN[target.accountCode] ?? []) : []
+  const total = rows.reduce((sum, row) => sum + row.extendedCostMinor, 0)
+
+  return (
+    <Dialog open={!!target} onOpenChange={onOpenChange}>
+      <DialogContent size='xl'>
+        <DialogHeader>
+          <DialogTitle>
+            {target?.accountCode} {target?.accountName ?? ''}
+          </DialogTitle>
+          <DialogDescription>
+            The subledger rows behind this line for {periodLabel}. The posting line itself records
+            one summarised figure, so this is read back out of the subledger rather than out of the
+            entry.
+          </DialogDescription>
+        </DialogHeader>
+
+        {rows.length === 0 ? (
+          <EmptySection
+            icon={<FileSearch className='size-5' />}
+            title='Nothing to show for this account'
+            description='No subledger rows resolved to this account in the period.'
+          />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className='w-32'>Reference</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead className='w-32'>Date</TableHead>
+                <TableHead className='w-24 text-right'>Quantity</TableHead>
+                <TableHead className='w-32 text-right'>Unit cost</TableHead>
+                <TableHead className='w-32 text-right'>Extended</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell className='font-mono text-xs'>{row.reference}</TableCell>
+                  <TableCell className='text-muted-foreground'>{row.description}</TableCell>
+                  <TableCell>{formatAccountingDate(row.occurredAt, bookTimeZone)}</TableCell>
+                  <TableCell className='text-right font-mono tabular-nums'>
+                    {row.quantity}
+                  </TableCell>
+                  <TableCell className='text-right font-mono tabular-nums'>
+                    {formatMinor(row.unitCostMinor, currencyCode)}
+                  </TableCell>
+                  <TableCell className='text-right font-mono tabular-nums'>
+                    {formatSignedMinor(row.extendedCostMinor, currencyCode)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell colSpan={5}>Net movement</TableCell>
+                <TableCell className='text-right font-mono tabular-nums'>
+                  {formatSignedMinor(total, currencyCode)}
+                </TableCell>
+              </TableRow>
+            </TableFooter>
+          </Table>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
@@ -1,0 +1,162 @@
+// apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
+
+'use client'
+
+import type { PostResult, PostResultStatus } from '@auxx/lib/postings/client'
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { CheckCircle2, CircleSlash, ExternalLink, PlugZap, TriangleAlert } from 'lucide-react'
+import type { ComponentType } from 'react'
+import { fixtureProviderEntryUrl } from '~/components/accounting/fixtures'
+
+interface OutcomeCopy {
+  icon: ComponentType<{ className?: string }>
+  title: string
+  detail: string
+  /** Successes read as successes. Only a genuine failure gets the destructive treatment. */
+  tone: 'success' | 'neutral' | 'failure'
+}
+
+/**
+ * How each outcome reads.
+ *
+ * 🛑 `already_posted` and `not_connected` are SUCCESSES and must never render as
+ * errors. `already_posted` is a converged re-run (the provider already held the
+ * entry and nothing was sent), and logging a routine convergence as a failure
+ * trains everyone to ignore the channel that a real double-post would arrive on.
+ * `not_connected` is first-class by decision `P1`: an org with no accounting
+ * system has its entry built, balanced and persisted identically
+ * (13-accounting-ui.md §5.3).
+ *
+ * `disabled` is kept separate from `not_connected` on purpose: one is a setting
+ * somebody can flip, the other is a missing integration, and merging them makes
+ * the remedy unguessable from the record.
+ */
+const OUTCOMES: Record<PostResultStatus, OutcomeCopy> = {
+  posted: {
+    icon: CheckCircle2,
+    title: 'Posted',
+    detail: 'The entry was recorded here and pushed to the accounting system.',
+    tone: 'success',
+  },
+  already_posted: {
+    icon: CheckCircle2,
+    title: 'Already posted',
+    detail:
+      'The accounting system already held this entry, so nothing was sent. A converged re-run, not a failure.',
+    tone: 'success',
+  },
+  healed: {
+    icon: CheckCircle2,
+    title: 'Reconciled with the accounting system',
+    detail:
+      'The provider held the entry but our record of its id did not. The id was written back rather than posting a second time.',
+    tone: 'success',
+  },
+  not_connected: {
+    icon: PlugZap,
+    title: 'Posted. No accounting system is connected',
+    detail:
+      'The entry is built, balanced and recorded here exactly as it would be with a provider. There is simply nowhere to push it.',
+    tone: 'success',
+  },
+  disabled: {
+    icon: CircleSlash,
+    title: 'Posted. Export is switched off',
+    detail:
+      'An accounting system is connected but export is turned off at the integration. The entry is recorded here.',
+    tone: 'neutral',
+  },
+  period_closed: {
+    icon: TriangleAlert,
+    title: 'Refused: the period is locked',
+    detail: 'Nothing was written. The month must be unlocked before it can be posted into.',
+    tone: 'failure',
+  },
+  account_unmapped: {
+    icon: TriangleAlert,
+    title: 'Refused: an account role is not mapped',
+    detail: 'Nothing was written. The period was never claimed.',
+    tone: 'failure',
+  },
+  unbalanced: {
+    icon: TriangleAlert,
+    title: 'Refused: the entry does not balance',
+    detail: 'Nothing was written. A retry cannot change this answer.',
+    tone: 'failure',
+  },
+  error: {
+    icon: TriangleAlert,
+    title: 'The post failed',
+    detail: 'The reason is below, verbatim.',
+    tone: 'failure',
+  },
+}
+
+const TONE_CLASS: Record<OutcomeCopy['tone'], string> = {
+  success: 'border-green-500/40 bg-green-500/5',
+  neutral: 'border-border bg-muted/40',
+  failure: 'border-destructive/40 bg-destructive/5',
+}
+
+const TONE_ICON_CLASS: Record<OutcomeCopy['tone'], string> = {
+  success: 'text-green-600 dark:text-green-400',
+  neutral: 'text-muted-foreground',
+  failure: 'text-destructive',
+}
+
+interface PostResultCalloutProps {
+  result: PostResult
+  providerLabel: string
+}
+
+/**
+ * The provider result, inline with the entry it belongs to.
+ *
+ * Two systems that never link to each other is how reconciliation becomes
+ * copy-paste, so a posted entry carries a deep link straight into the
+ * provider's own register (gap-g §3).
+ */
+export function PostResultCallout({ result, providerLabel }: PostResultCalloutProps) {
+  const copy = OUTCOMES[result.status]
+  const Icon = copy.icon
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-start',
+        TONE_CLASS[copy.tone]
+      )}>
+      <Icon className={cn('mt-0.5 size-5 shrink-0', TONE_ICON_CLASS[copy.tone])} />
+      <div className='flex min-w-0 flex-1 flex-col gap-1'>
+        <div className='flex flex-wrap items-center gap-2'>
+          <span className='font-medium'>{copy.title}</span>
+          {result.docNumber && (
+            <span className='font-mono text-xs text-muted-foreground'>{result.docNumber}</span>
+          )}
+        </div>
+        <p className='text-sm text-muted-foreground'>{copy.detail}</p>
+        {result.error && <p className='text-sm'>{result.error}</p>}
+        {result.retryable && (
+          <p className='text-xs text-muted-foreground'>
+            This was a transport failure, so it is worth trying again.
+          </p>
+        )}
+      </div>
+      {result.providerEntryId && (
+        <Button asChild variant='outline' size='sm' className='shrink-0'>
+          {/* PLACEHOLDER: the real deep link comes from the connected provider's
+              adapter. `fixtureProviderEntryUrl` stands in until `ledger.get`
+              returns the provider entry id alongside the stored draft. */}
+          <a
+            href={fixtureProviderEntryUrl(result.providerEntryId)}
+            target='_blank'
+            rel='noreferrer'>
+            <ExternalLink />
+            Open in {providerLabel}
+          </a>
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/posting-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/posting-drawer.tsx
@@ -1,0 +1,257 @@
+// apps/web/src/components/accounting/ui/ledger/posting-drawer.tsx
+
+'use client'
+
+import { type PostingAssertions, reverseAssertions } from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { DrawerHeader } from '@auxx/ui/components/drawer'
+import { Label } from '@auxx/ui/components/label'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Section } from '@auxx/ui/components/section'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { BookOpenCheck, Layers, Undo2 } from 'lucide-react'
+import { useState } from 'react'
+import {
+  FIXTURE_POST_RESULT,
+  FIXTURE_POST_RESULT_NOT_CONNECTED,
+  FIXTURE_POSTED_DRAFT,
+  FIXTURE_REVISIONS,
+  type FixtureRevision,
+} from '~/components/accounting/fixtures'
+import { EntryJournal } from './entry-journal'
+import { EntryRollForward } from './entry-roll-forward'
+import { formatAuditTimestamp, formatPeriodLabel } from './format'
+import { PostResultCallout } from './post-result-callout'
+
+/** Flatten the fixture chain so a `?posting=<id>` deep link resolves from any month. */
+function findRevision(
+  glPostingId: string
+): { periodKey: string; revision: FixtureRevision } | null {
+  for (const [periodKey, revisions] of Object.entries(FIXTURE_REVISIONS)) {
+    const revision = revisions.find((candidate) => candidate.glPostingId === glPostingId)
+    if (revision) return { periodKey, revision }
+  }
+  return null
+}
+
+interface PostingDrawerProps {
+  /** From `?posting=<id>`. `null` closes the drawer. */
+  postingId: string | null
+  /**
+   * The revision chain of the month currently on screen, checked before the
+   * global fixture map so a period that has never been reversed still resolves.
+   */
+  chain?: FixtureRevision[]
+  /** The period `chain` belongs to. */
+  chainPeriodKey?: string
+  onOpenChange: (open: boolean) => void
+  isDocked: boolean
+  width: number
+  onWidthChange: (width: number) => void
+  currencyCode: string
+  bookTimeZone: string
+  providerLabel: string
+  providerConnected: boolean
+}
+
+/**
+ * One posting, deep-linked on `?posting=<id>`.
+ *
+ * `DockableDrawer` rather than `RecordDrawer`: `RecordDrawer` is entity-driven
+ * and `GlPosting` is a Drizzle table, which was the whole point of decision
+ * `G6`. The analogue is the workflow execution detail drawer: a non-entity,
+ * table-backed detail panel opened from a list (13-accounting-ui.md §1).
+ *
+ * 🛑 The URL matters. A ledger entry is the thing somebody pastes into Slack
+ * asking "why is this three thousand dollars high", and a drawer with no URL
+ * cannot be linked to. On an auditable surface that is a real loss.
+ *
+ * ⚠️ This renders the STORED draft, never a re-run of the builder. Re-deriving
+ * gives a different answer the moment the subledger moves, and the number that
+ * matters is the one that was posted.
+ */
+export function PostingDrawer({
+  postingId,
+  chain: chainProp,
+  chainPeriodKey,
+  onOpenChange,
+  isDocked,
+  width,
+  onWidthChange,
+  currencyCode,
+  bookTimeZone,
+  providerLabel,
+  providerConnected,
+}: PostingDrawerProps) {
+  const [memo, setMemo] = useState('')
+  const [isReversing, setIsReversing] = useState(false)
+
+  const fromChain =
+    postingId && chainProp && chainPeriodKey
+      ? chainProp.find((candidate) => candidate.glPostingId === postingId)
+      : undefined
+  const found = fromChain
+    ? { periodKey: chainPeriodKey as string, revision: fromChain }
+    : postingId
+      ? findRevision(postingId)
+      : null
+  const revision = found?.revision
+  const periodKey = found?.periodKey ?? ''
+  const chain =
+    fromChain && chainProp ? chainProp : periodKey ? (FIXTURE_REVISIONS[periodKey] ?? []) : []
+
+  // PLACEHOLDER derivation. A reversal is the revision that sits directly above
+  // a reversed one; the real `ledger.get(id)` carries the posting type, so this
+  // guess goes away with the fixtures.
+  const below = revision
+    ? chain.find((candidate) => candidate.revision === revision.revision - 1)
+    : undefined
+  const isReversal = below?.status === 'reversed'
+
+  // 🛑 A reversal's assertions are the original's, SWAPPED, read off frozen
+  // data, never by re-running the month-end reader against the prior-prior
+  // period, which would pick up movements that arrived after the original
+  // posted.
+  const storedAssertions: PostingAssertions | undefined = FIXTURE_POSTED_DRAFT.assertions
+  const assertions =
+    storedAssertions && isReversal ? reverseAssertions(storedAssertions) : storedAssertions
+
+  const postResult = providerConnected ? FIXTURE_POST_RESULT : FIXTURE_POST_RESULT_NOT_CONNECTED
+
+  function handleReverse() {
+    // PLACEHOLDER: becomes `ledger.reverse({ glPostingId, memo })`.
+    setIsReversing(true)
+    setTimeout(() => {
+      setIsReversing(false)
+      setMemo('')
+      onOpenChange(false)
+    }, 550)
+  }
+
+  return (
+    <DockableDrawer
+      open={!!postingId}
+      onOpenChange={onOpenChange}
+      isDocked={isDocked}
+      width={width}
+      onWidthChange={onWidthChange}
+      minWidth={380}
+      maxWidth={720}
+      title={revision ? `Posting ${revision.docNumber}` : 'Posting'}>
+      <div className='flex min-h-0 flex-1 flex-col rounded-t-xl'>
+        <DrawerHeader
+          icon={<BookOpenCheck className='size-5 text-muted-foreground' />}
+          title={
+            <div className='flex flex-wrap items-center gap-2'>
+              <span className='font-mono font-medium'>{revision?.docNumber ?? 'Posting'}</span>
+              {revision && (
+                <>
+                  <Badge variant='outline' size='sm'>
+                    Revision {revision.revision}
+                  </Badge>
+                  <Badge variant={revision.status === 'reversed' ? 'outline' : 'green'} size='sm'>
+                    {revision.status === 'reversed' ? 'Reversed' : 'Posted'}
+                  </Badge>
+                </>
+              )}
+            </div>
+          }
+          onClose={() => onOpenChange(false)}
+        />
+
+        {!revision ? (
+          <div className='p-4 text-sm text-muted-foreground'>
+            No posting matches this link. It may have been reversed and re-entered under a new
+            revision.
+          </div>
+        ) : (
+          <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
+            <div className='flex flex-col gap-2 p-3'>
+              <div className='flex flex-col gap-1 rounded-lg border bg-muted/30 p-3 text-sm'>
+                <div className='flex justify-between gap-4'>
+                  <span className='text-muted-foreground'>Period</span>
+                  <span>{formatPeriodLabel(periodKey)}</span>
+                </div>
+                <div className='flex justify-between gap-4'>
+                  <span className='text-muted-foreground'>Posted</span>
+                  <span>{formatAuditTimestamp(revision.postedAt, bookTimeZone)}</span>
+                </div>
+                {revision.memo && (
+                  <div className='flex justify-between gap-4'>
+                    <span className='shrink-0 text-muted-foreground'>Memo</span>
+                    <span className='text-right'>{revision.memo}</span>
+                  </div>
+                )}
+              </div>
+
+              <Section
+                title='Journal entry'
+                icon={<BookOpenCheck className='size-4' />}
+                description='The stored draft, exactly as it was posted.'
+                collapsible={false}>
+                <EntryJournal
+                  lines={FIXTURE_POSTED_DRAFT.resolvedLines}
+                  currencyCode={currencyCode}
+                />
+              </Section>
+
+              {assertions && (
+                <Section
+                  title={isReversal ? 'Roll-forward (swapped)' : 'Roll-forward'}
+                  icon={<Layers className='size-4' />}
+                  description={
+                    isReversal
+                      ? 'A reversal asserts the original pair the other way round, so its opening is the original closing.'
+                      : 'What this entry asserted about the world on either side of itself.'
+                  }
+                  collapsible={false}>
+                  <EntryRollForward assertions={assertions} currencyCode={currencyCode} />
+                </Section>
+              )}
+
+              <div className='px-1'>
+                <PostResultCallout result={postResult} providerLabel={providerLabel} />
+              </div>
+
+              <Section
+                title='Reverse this posting'
+                icon={<Undo2 className='size-4' />}
+                description='A mistake is corrected by reversing and re-entering, never by editing a posted entry.'
+                collapsible={false}>
+                <div className='flex flex-col gap-2'>
+                  <Label htmlFor='reversal-memo'>Why is it being reversed?</Label>
+                  <Textarea
+                    id='reversal-memo'
+                    value={memo}
+                    onChange={(event) => setMemo(event.target.value)}
+                    placeholder='This memo is carried onto the reversing entry and is the only explanation a reader gets later.'
+                    rows={3}
+                  />
+                  <div>
+                    <Button
+                      variant='outline'
+                      size='sm'
+                      disabled={memo.trim().length === 0 || revision.status === 'reversed'}
+                      loading={isReversing}
+                      loadingText='Reversing...'
+                      onClick={handleReverse}>
+                      <Undo2 />
+                      Reverse
+                    </Button>
+                  </div>
+                  {revision.status === 'reversed' && (
+                    <p className='text-xs text-muted-foreground'>
+                      This revision has already been reversed.
+                    </p>
+                  )}
+                </div>
+              </Section>
+            </div>
+          </ScrollArea>
+        )}
+      </div>
+    </DockableDrawer>
+  )
+}

--- a/apps/web/src/components/accounting/ui/ledger/revision-strip.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/revision-strip.tsx
@@ -1,0 +1,73 @@
+// apps/web/src/components/accounting/ui/ledger/revision-strip.tsx
+
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { History } from 'lucide-react'
+import type { FixtureRevision } from '~/components/accounting/fixtures'
+import { formatAuditTimestamp } from './format'
+
+interface RevisionStripProps {
+  revisions: FixtureRevision[]
+  activePostingId: string | null
+  onSelect: (glPostingId: string) => void
+  bookTimeZone: string
+}
+
+/**
+ * The month's revision chain: revision 0 posted then reversed, revision 1 the
+ * reversal, revision 2 the re-entry.
+ *
+ * 🛑 Renders ONLY when the month has a revision above 0, which is what the
+ * caller checks. Under the L1 regime a month has exactly one effective entry, so
+ * a permanent list-of-one would be chrome; the chain is the only thing a month
+ * genuinely has more than one of (13-accounting-ui.md §5.2).
+ *
+ * Selecting a revision opens the posting drawer on it. That is what
+ * `?posting=<id>` is for: a historical revision, not the primary read path.
+ */
+export function RevisionStrip({
+  revisions,
+  activePostingId,
+  onSelect,
+  bookTimeZone,
+}: RevisionStripProps) {
+  if (revisions.length === 0) return null
+
+  return (
+    <div className='flex flex-col gap-2 rounded-xl border bg-muted/30 p-3'>
+      <div className='flex items-center gap-2 text-xs text-muted-foreground'>
+        <History className='size-3.5' />
+        <span>
+          This month was posted {revisions.length} times. The effective entry is the newest
+          revision; the earlier ones are kept and reversed, never edited.
+        </span>
+      </div>
+      <div className='flex flex-wrap gap-1.5'>
+        {revisions.map((revision) => (
+          <Button
+            key={revision.glPostingId}
+            variant={revision.glPostingId === activePostingId ? 'secondary' : 'outline'}
+            size='sm'
+            className={cn('h-auto flex-col items-start gap-0.5 py-1.5')}
+            onClick={() => onSelect(revision.glPostingId)}>
+            <span className='flex items-center gap-1.5'>
+              <span>Revision {revision.revision}</span>
+              <Badge
+                variant={revision.status === 'reversed' ? 'outline' : 'green'}
+                size='sm'
+                className='font-normal'>
+                {revision.status === 'reversed' ? 'Reversed' : 'Posted'}
+              </Badge>
+            </span>
+            <span className='font-normal text-[11px] text-muted-foreground'>
+              {formatAuditTimestamp(revision.postedAt, bookTimeZone)}
+            </span>
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
@@ -1,0 +1,146 @@
+// apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
+//
+// The setting keys the three accounting settings pages read and write, plus the
+// two small predicates every one of them needs.
+//
+// The key names are spelled out for readability at the call sites, but they are
+// NOT a second source of truth: `buildReadinessRecord` below feeds the shared
+// predicate from `SETUP_READINESS_SETTING_KEYS`, so the keys the readiness
+// answer is computed over can never drift from the ones the predicate declares.
+// `OPENING_BASELINE_SETTING_KEYS` and `FINALIZED_SETUP_STATE` are also exported
+// from `@auxx/lib/postings/client` if a caller wants them by reference.
+
+import {
+  minorUnitError,
+  SETUP_READINESS_SETTING_KEYS,
+  type SettingsRecord,
+} from '@auxx/lib/postings/client'
+
+/** Every `accounting.*` / `manufacturing.*` key these pages touch. */
+export const ACCOUNTING_KEYS = {
+  setupState: 'accounting.setupState',
+  cutoffPeriod: 'accounting.cutoffPeriod',
+  bookTimeZone: 'accounting.bookTimeZone',
+  setupFinalizedAt: 'accounting.setupFinalizedAt',
+  setupFinalizedByUserId: 'accounting.setupFinalizedByUserId',
+  openingRawMaterials: 'accounting.openingRawMaterials',
+  openingWip: 'accounting.openingWip',
+  openingFinishedGoods: 'accounting.openingFinishedGoods',
+  qboOpeningRawMaterials: 'accounting.qboOpeningRawMaterials',
+  qboOpeningWip: 'accounting.qboOpeningWip',
+  qboOpeningFinishedGoods: 'accounting.qboOpeningFinishedGoods',
+  qboOpeningJournalRef: 'accounting.qboOpeningJournalRef',
+  assemblyLaborCostPerUnit: 'manufacturing.assemblyLaborCostPerUnit',
+  overheadCostPerUnit: 'manufacturing.overheadCostPerUnit',
+} as const
+
+/**
+ * 🛑 Draft scoping. `useSettings({ scope: 'GENERAL' })` returns EVERY
+ * `GENERAL`-scope setting in the whole app, and every `accounting.*` key is
+ * `GENERAL` (there is no `ACCOUNTING` value in `SettingScope`). A save built
+ * from the whole record would write back unrelated settings, so each section
+ * narrows its draft to one of these arrays and diffs only against it.
+ */
+export const PERIOD_DRAFT_KEYS = [
+  ACCOUNTING_KEYS.cutoffPeriod,
+  ACCOUNTING_KEYS.bookTimeZone,
+] as const
+
+export const ABSORPTION_DRAFT_KEYS = [
+  ACCOUNTING_KEYS.assemblyLaborCostPerUnit,
+  ACCOUNTING_KEYS.overheadCostPerUnit,
+] as const
+
+export const OPENING_DRAFT_KEYS = [
+  ACCOUNTING_KEYS.openingRawMaterials,
+  ACCOUNTING_KEYS.openingWip,
+  ACCOUNTING_KEYS.openingFinishedGoods,
+  ACCOUNTING_KEYS.qboOpeningRawMaterials,
+  ACCOUNTING_KEYS.qboOpeningWip,
+  ACCOUNTING_KEYS.qboOpeningFinishedGoods,
+  ACCOUNTING_KEYS.qboOpeningJournalRef,
+] as const
+
+/** The three opening balances, paired auxx snapshot against provider snapshot. */
+export const OPENING_PAIRS = [
+  {
+    role: 'inventory_raw_materials' as const,
+    accountCode: '1310',
+    label: 'Raw materials',
+    auxxKey: ACCOUNTING_KEYS.openingRawMaterials,
+    qboKey: ACCOUNTING_KEYS.qboOpeningRawMaterials,
+    hint: undefined as string | undefined,
+  },
+  {
+    role: 'inventory_wip' as const,
+    accountCode: '1320',
+    label: 'Work in process',
+    auxxKey: ACCOUNTING_KEYS.openingWip,
+    qboKey: ACCOUNTING_KEYS.qboOpeningWip,
+    hint: 'Expected to be 0 at cutover. Zero is a real balance; unset is not.',
+  },
+  {
+    role: 'inventory_finished_goods' as const,
+    accountCode: '1330',
+    label: 'Finished goods',
+    auxxKey: ACCOUNTING_KEYS.openingFinishedGoods,
+    qboKey: ACCOUNTING_KEYS.qboOpeningFinishedGoods,
+    hint: undefined as string | undefined,
+  },
+]
+
+/**
+ * Where each readiness requirement is fixed.
+ *
+ * Keyed by `ReadinessRequirement.key`, which `resolveSetupReadiness` keeps in
+ * step with the getting-started goal keys.
+ */
+export const READINESS_LINKS: Record<string, { label: string; href: string }> = {
+  'set-accounting-period': {
+    label: 'Accounting period',
+    href: '/app/accounting/settings/general',
+  },
+  'set-opening-balances': {
+    label: 'Opening balances',
+    href: '/app/accounting/settings/opening',
+  },
+  'set-costing': {
+    label: 'Absorption rates',
+    href: '/app/accounting/settings/general',
+  },
+}
+
+/**
+ * Feed the shared predicate.
+ *
+ * Built from `SETUP_READINESS_SETTING_KEYS` so the record carries exactly what
+ * the predicate reads. `getSetting` falls back to the catalog default, which is
+ * `null` for every key here except `accounting.setupState` (`'draft'`) — and a
+ * `null` must stay a `null`, because an unset currency absorbs nothing while a
+ * zero is a real choice.
+ */
+export function buildReadinessRecord(getSetting: (key: string) => unknown): SettingsRecord {
+  const record: SettingsRecord = {}
+  for (const key of SETUP_READINESS_SETTING_KEYS) record[key] = getSetting(key)
+  return record
+}
+
+// ── The minor-unit and text predicates: ONE authority, in lib ───────────────
+//
+// 🛑 These are re-exports, not copies. The rule "an opening balance is whole
+// minor units" decides whether a setup can close, and it was briefly written in
+// three places at once - here, in the wizard pages, and in
+// `postings/setup-readiness.ts`. Three copies of a validation rule drift, and
+// the drift is silent: the form accepts a value the reader later refuses, so the
+// setup SAVES and then cannot close. The lib copy is the one the server also
+// reads, so it is the one that wins.
+export {
+  minorUnitError,
+  readSettingMinorUnits as readMinorUnits,
+  readSettingText as readText,
+} from '@auxx/lib/postings/client'
+
+/** True when every value in `record` under `keys` is a legal minor-unit amount. */
+export function everyMinorUnitValid(record: Record<string, unknown>, keys: readonly string[]) {
+  return keys.every((key) => minorUnitError(record[key]) === undefined)
+}

--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -1,0 +1,342 @@
+// apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+'use client'
+
+// Accounting > Settings > Accounts (13-accounting-ui.md §5.4).
+//
+// Shape B, master-detail: `SettingsPage` + a `ResponsiveTabs` subHeader with the
+// tab in `useQueryState('s')`, and a `grid-cols-[1fr_420px]` body whose right
+// column is a PERSISTENT editor pane, docked at `lg` and a floating
+// `DockableDrawer` below it. The products-services page is the reference.
+//
+// 🛑 PLACEHOLDER STATE. Neither tab has a procedure behind it:
+//   * the role map would need `GlRoleAssignment` read/write, which does not
+//     exist, which is why `resolveRoles` returns `account_unmapped` in every
+//     org today;
+//   * the chart would need `gl_account` record reads/writes through this
+//     surface.
+// So both run on `components/accounting/fixtures.ts` seeds plus local state.
+// Every handler below is shaped like the mutation that will replace it.
+
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
+import { ACCOUNT_ROLES, type AccountRole } from '@auxx/lib/postings/client'
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
+import { generateId } from '@auxx/utils'
+import { Landmark, Lock, Waypoints } from 'lucide-react'
+import { useQueryState } from 'nuqs'
+import { useMemo, useState } from 'react'
+import { EmptyState } from '~/components/global/empty-state'
+import SettingsPage from '~/components/global/settings-page'
+import { useMedia } from '~/hooks/use-media'
+import { useRequireCapability } from '~/providers/capabilities-provider'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { FIXTURE_CHART, FIXTURE_ROLE_ACCOUNTS, FIXTURE_ROLE_ASSIGNMENT_STATE } from '../../fixtures'
+import { useAccountingSettingsFreeze } from '../../hooks/use-accounting-settings-freeze'
+import type { ChartAccount, ChartDraftHandle, RoleAssignment } from './accounts-types'
+import { ChartAccountEditor } from './chart-account-editor'
+import { ChartList } from './chart-list'
+import { RoleMapEditor } from './role-map-editor'
+import { RoleMapList } from './role-map-list'
+
+type AccountsTab = 'roles' | 'chart'
+
+const TABS = [
+  { value: 'roles', label: 'Roles', icon: Waypoints },
+  { value: 'chart', label: 'Chart of accounts', icon: Landmark },
+]
+
+const BREADCRUMBS = [
+  { title: 'Accounting', href: '/app/accounting' },
+  { title: 'Settings' },
+  { title: 'Accounts' },
+]
+
+const PAGE_DESCRIPTION =
+  'Which account each posting role lands on, and the chart those accounts live in.'
+
+const ALL_ROLES = Object.values(ACCOUNT_ROLES) as AccountRole[]
+
+/** PLACEHOLDER: replaced by a `gl_account` record list. */
+function seedChart(): ChartAccount[] {
+  return FIXTURE_CHART.map((row) => ({ ...row }))
+}
+
+/** PLACEHOLDER: replaced by a `GlRoleAssignment` read. */
+function seedAssignments(accounts: ChartAccount[]): Record<string, RoleAssignment> {
+  const byCode = new Map(accounts.map((account) => [account.code, account]))
+  const seeded: Record<string, RoleAssignment> = {}
+  for (const role of ALL_ROLES) {
+    const state = FIXTURE_ROLE_ASSIGNMENT_STATE[role] ?? 'unmapped'
+    const code = FIXTURE_ROLE_ACCOUNTS[role]?.code
+    const account = code ? byCode.get(code) : undefined
+    seeded[role] = {
+      state,
+      accountId: state === 'unused' ? null : (account?.id ?? null),
+    }
+    // A role the fixture claims is mapped but whose account is missing from the
+    // chart is unmapped, not quietly confirmed against nothing.
+    if (seeded[role].accountId === null && state !== 'unused') seeded[role].state = 'unmapped'
+  }
+  return seeded
+}
+
+export function AccountingAccountsSettingsPage() {
+  useRequireCapability(PermissionKey.ledgerView)
+  const { hasAccess } = useFeatureFlags()
+  const { frozen: postingsExist } = useAccountingSettingsFreeze()
+
+  const [tab, setTab] = useQueryState('s', { defaultValue: 'roles' as string })
+  const activeTab: AccountsTab = tab === 'chart' ? 'chart' : 'roles'
+
+  const [accounts, setAccounts] = useState<ChartAccount[]>(seedChart)
+  const [assignments, setAssignments] = useState<Record<string, RoleAssignment>>(() =>
+    seedAssignments(seedChart())
+  )
+
+  const [selectedRole, setSelectedRole] = useState<AccountRole | null>(null)
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null)
+
+  // The phantom draft. An untouched draft is dropped silently on selecting
+  // another row, adding another draft, or switching tabs. Never on a re-render.
+  const [chartDraft, setChartDraft] = useState<ChartDraftHandle | null>(null)
+
+  const isDesktop = useMedia('(min-width: 1024px)')
+
+  const accountsById = useMemo(
+    () => new Map(accounts.map((account) => [account.id, account])),
+    [accounts]
+  )
+
+  /** Which roles point at each account. Drives the delete refusal. */
+  const rolesByAccountId = useMemo(() => {
+    const map = new Map<string, AccountRole[]>()
+    for (const role of ALL_ROLES) {
+      const accountId = assignments[role]?.accountId
+      if (!accountId) continue
+      const list = map.get(accountId) ?? []
+      list.push(role)
+      map.set(accountId, list)
+    }
+    return map
+  }, [assignments])
+
+  const isCodeTaken = (code: string, exceptId: string | null) =>
+    accounts.some((account) => account.code === code && account.id !== exceptId)
+
+  // ── Roles tab ────────────────────────────────────────────────────────────
+
+  function handleAssignRole(role: AccountRole, accountId: string) {
+    // PLACEHOLDER: replaced by a `GlRoleAssignment` upsert. Picking an account
+    // is what turns a suggestion into a confirmation; that is the whole point
+    // of `G19` step 4.
+    setAssignments((prev) => ({ ...prev, [role]: { accountId, state: 'confirmed' } }))
+  }
+
+  function handleClearRole(role: AccountRole) {
+    // PLACEHOLDER: replaced by a `GlRoleAssignment` delete.
+    setAssignments((prev) => ({ ...prev, [role]: { accountId: null, state: 'unmapped' } }))
+  }
+
+  function handleToggleUnused(role: AccountRole) {
+    setAssignments((prev) => {
+      const current = prev[role] ?? { accountId: null, state: 'unmapped' as const }
+      if (current.state === 'unused') {
+        return {
+          ...prev,
+          [role]: {
+            accountId: current.accountId,
+            state: current.accountId ? 'confirmed' : 'unmapped',
+          },
+        }
+      }
+      return { ...prev, [role]: { accountId: null, state: 'unused' } }
+    })
+  }
+
+  // ── Chart tab ────────────────────────────────────────────────────────────
+
+  function handleSelectAccount(id: string | null) {
+    // Selecting anything other than the draft itself, or its committed row
+    // (which keeps the draft form mounted), drops the draft.
+    if (chartDraft && id !== chartDraft.draftId && id !== chartDraft.recordId) {
+      setChartDraft(null)
+    }
+    setSelectedAccountId(id)
+  }
+
+  function handleAddDraft() {
+    if (chartDraft && !chartDraft.recordId) {
+      setSelectedAccountId(chartDraft.draftId) // an uncommitted one exists; re-select it
+      return
+    }
+    const draftId = generateId('draft')
+    setChartDraft({ draftId, code: '', name: '' })
+    setSelectedAccountId(draftId)
+  }
+
+  function handleDraftChange(patch: { code?: string; name?: string }) {
+    setChartDraft((prev) => (prev ? { ...prev, ...patch } : prev))
+  }
+
+  /**
+   * PLACEHOLDER: replaced by `record.create` on the `gl_account` definition.
+   *
+   * Kept async and id-returning so the draft form's create path does not change
+   * shape when the mutation lands. `checkUniqueValueTyped` will throw a
+   * `UniqueValueConflictError` from the real one when the code race is lost;
+   * the local check in the draft form is the same refusal, run earlier.
+   */
+  async function handleCreateAccount(values: Omit<ChartAccount, 'id'>): Promise<string> {
+    const id = generateId('gla')
+    setAccounts((prev) => [...prev, { id, ...values }])
+    return id
+  }
+
+  function handleUpdateAccount(id: string, patch: Partial<Omit<ChartAccount, 'id'>>) {
+    // PLACEHOLDER: replaced by `useSaveFieldValue` against the `gl_account` row.
+    setAccounts((prev) =>
+      prev.map((account) => (account.id === id ? { ...account, ...patch } : account))
+    )
+  }
+
+  function handleDeleteAccount(account: ChartAccount) {
+    // PLACEHOLDER: replaced by `record.delete`. The refusal for a mapped
+    // account is enforced in `ChartList` before this is ever reached.
+    setAccounts((prev) => prev.filter((row) => row.id !== account.id))
+    if (selectedAccountId === account.id) setSelectedAccountId(null)
+  }
+
+  function handleToggleActive(account: ChartAccount) {
+    handleUpdateAccount(account.id, { isActive: !account.isActive })
+  }
+
+  // First create resolved: swap selection to the real id but KEEP the draft, so
+  // the draft editor form stays mounted and text typed during the round trip
+  // survives.
+  function handleDraftCommitted(recordId: string) {
+    setChartDraft((prev) => (prev ? { ...prev, recordId } : prev))
+    setSelectedAccountId(recordId)
+  }
+
+  function handleTabChange(next: string) {
+    setTab(next)
+    // An untouched draft does not survive a tab switch: the other tab's list no
+    // longer renders the phantom row, so keeping it would be confusing.
+    if (chartDraft) setChartDraft(null)
+  }
+
+  if (!hasAccess(FeatureKey.accounting)) {
+    return (
+      <SettingsPage title='Accounts' description={PAGE_DESCRIPTION} breadcrumbs={BREADCRUMBS}>
+        <EmptyState
+          icon={Lock}
+          title='Accounting Not Available'
+          description='Upgrade your plan to keep books in Auxx.'
+          button={<div className='h-12' />}
+        />
+      </SettingsPage>
+    )
+  }
+
+  const editorContent =
+    activeTab === 'roles' ? (
+      <RoleMapEditor
+        role={selectedRole}
+        assignment={selectedRole ? assignments[selectedRole] : undefined}
+        accounts={accounts}
+        onAssign={handleAssignRole}
+        onClear={handleClearRole}
+        onToggleUnused={handleToggleUnused}
+      />
+    ) : (
+      <ChartAccountEditor
+        selectedId={selectedAccountId}
+        accounts={accounts}
+        postingsExist={postingsExist}
+        isCodeTaken={isCodeTaken}
+        onUpdate={handleUpdateAccount}
+        draft={chartDraft}
+        onDraftChange={handleDraftChange}
+        onCreate={handleCreateAccount}
+        onDraftCommitted={handleDraftCommitted}
+      />
+    )
+
+  const selectedId = activeTab === 'roles' ? selectedRole : selectedAccountId
+  const mobileDrawerOpen = !isDesktop && !!selectedId
+
+  return (
+    <SettingsPage
+      title='Accounts'
+      description={PAGE_DESCRIPTION}
+      breadcrumbs={BREADCRUMBS}
+      subHeader={
+        <ResponsiveTabs value={activeTab} onValueChange={handleTabChange} size='sm' items={TABS} />
+      }>
+      <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
+        <div className='min-w-0'>
+          {activeTab === 'roles' ? (
+            <RoleMapList
+              assignments={assignments}
+              accountsById={accountsById}
+              selectedRole={selectedRole}
+              onSelect={setSelectedRole}
+              onClear={handleClearRole}
+              onToggleUnused={handleToggleUnused}
+            />
+          ) : (
+            <ChartList
+              accounts={accounts}
+              selectedId={selectedAccountId}
+              onSelect={handleSelectAccount}
+              rolesByAccountId={rolesByAccountId}
+              onAdd={handleAddDraft}
+              onDelete={handleDeleteAccount}
+              onToggleActive={handleToggleActive}
+              draft={chartDraft}
+            />
+          )}
+        </div>
+        {/* The column stays STRETCHED and a wrapper inside it does the sticking.
+            Making the column itself `self-start` would size it to the editor, and
+            `border-l` would then stop dead at the editor's bottom edge instead of
+            dividing the whole list. A stretched column also gives the sticky child
+            room to travel, which an already-full-height element does not have.
+
+            `--settings-sticky-top` is published by `SettingsPage`, which owns the
+            `sticky top-0 z-20` title/tabs block above — pinning at a hardcoded `0`
+            would slide this underneath it. `z-10` matches `FormSaveBar`, i.e.
+            deliberately below that header. */}
+        <div className='hidden border-l lg:block'>
+          <div
+            className='lg:sticky lg:z-10 lg:overflow-hidden'
+            style={{
+              top: 'var(--settings-sticky-top, 0px)',
+              maxHeight:
+                'calc(var(--settings-viewport-h, 100vh) - var(--settings-sticky-top, 0px))',
+            }}>
+            {editorContent}
+          </div>
+        </div>
+      </div>
+
+      <DockableDrawer
+        open={mobileDrawerOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedRole(null)
+            setSelectedAccountId(null)
+            setChartDraft(null)
+          }
+        }}
+        isDocked={false}
+        width={380}
+        onWidthChange={() => {}}
+        minWidth={320}
+        maxWidth={480}
+        title={activeTab === 'roles' ? 'Map role' : 'Edit account'}>
+        {editorContent}
+      </DockableDrawer>
+    </SettingsPage>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/accounts-types.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounts-types.ts
@@ -1,0 +1,113 @@
+// apps/web/src/components/accounting/ui/settings/accounts-types.ts
+//
+// Shared shapes for the Accounts settings page's two tabs.
+//
+// 🛑 PLACEHOLDER-BACKED. There is no procedure that can read or create a
+// `GlRoleAssignment`, and none that reads or writes a `gl_account` row through
+// this surface, so both tabs run on `components/accounting/fixtures.ts` plus
+// local state. Every type below is either the real lib type or a thin local
+// mirror of a row that already exists in the database, so swapping a fixture
+// for a query stays a small change.
+
+import type { AccountRole, GlAccountTypeValue } from '@auxx/lib/postings/client'
+import type { SelectOptionColor } from '@auxx/types/custom-field'
+
+/**
+ * Whether a role's account was chosen by a person or merely proposed.
+ *
+ * `G19` step 4: a suggested-but-unconfirmed match must read visibly differently
+ * from a confirmed one, and a role nothing can ever emit must be markable
+ * unused rather than blocking Preview forever.
+ */
+export type RoleAssignmentState = 'confirmed' | 'suggested' | 'unmapped' | 'unused'
+
+export interface RoleAssignment {
+  /** The `gl_account` row this role points at, or `null` while unmapped/unused. */
+  accountId: string | null
+  state: RoleAssignmentState
+}
+
+/** One row of the org's editable chart. Mirrors the `gl_account` EntityInstance. */
+export interface ChartAccount {
+  id: string
+  code: string
+  name: string
+  accountType: GlAccountTypeValue
+  isActive: boolean
+}
+
+/**
+ * The phantom-draft handle for a not-yet-created chart row.
+ *
+ * The page owns only enough to render the placeholder row in the list and to
+ * know whether the current selection is a draft; the full field set lives in
+ * the editor component instance, keyed by `draftId`.
+ */
+export interface ChartDraftHandle {
+  draftId: string
+  code: string
+  name: string
+  /**
+   * Set once the draft's first create resolves. The draft is KEPT alive after
+   * creation (selection swapped to this id) so the draft editor form stays
+   * mounted: remounting onto the committed form mid-typing would replace the
+   * input's text with the create snapshot and cancel the pending debounced
+   * commit.
+   */
+  recordId?: string
+}
+
+/**
+ * The five statement classifications.
+ *
+ * ⚠️ Mirrored from `GlAccountType` in
+ * `packages/lib/src/resources/registry/enum-values.ts`, which is NOT among
+ * `@auxx/lib/resources/client`'s re-exports. The literal union
+ * (`GlAccountTypeValue`) IS client-exported from `@auxx/lib/postings/client`
+ * and every value below is typed against it, so a divergence is a compile
+ * error rather than a silently wrong dropdown.
+ */
+export const ACCOUNT_TYPE_OPTIONS: Array<{
+  value: GlAccountTypeValue
+  label: string
+  color: SelectOptionColor
+}> = [
+  { value: 'asset', label: 'Asset', color: 'blue' },
+  { value: 'liability', label: 'Liability', color: 'amber' },
+  { value: 'equity', label: 'Equity', color: 'purple' },
+  { value: 'revenue', label: 'Revenue', color: 'green' },
+  { value: 'expense', label: 'Expense', color: 'red' },
+]
+
+export function accountTypeLabel(type: GlAccountTypeValue): string {
+  return ACCOUNT_TYPE_OPTIONS.find((option) => option.value === type)?.label ?? type
+}
+
+/**
+ * The badge colour for a statement classification.
+ *
+ * Declared once, in {@link ACCOUNT_TYPE_OPTIONS}, so the chart list, the role
+ * map and the editor cannot drift into three different palettes for the same
+ * five words. Every value is a real `Badge` colour variant.
+ */
+export function accountTypeColor(type: GlAccountTypeValue): SelectOptionColor {
+  return ACCOUNT_TYPE_OPTIONS.find((option) => option.value === type)?.color ?? 'blue'
+}
+
+/**
+ * The two roles nothing emits under the L1 regime, and which therefore DEFAULT
+ * to unused.
+ *
+ * `ppv` is a report rather than a posting (nothing accumulates in 5090 during
+ * the year), and `inventory_wip` is structurally unreachable because
+ * `resolveInventoryRoleForPartKind`'s range is raw materials and finished goods
+ * only. A map that demanded all thirteen would block Preview on two roles
+ * nothing can ever post to.
+ */
+export const DEFAULT_UNUSED_ROLES: AccountRole[] = ['ppv', 'inventory_wip']
+
+/** `1310 · Inventory — Raw Materials`, the way an account reads in a row. */
+export function formatAccount(account: ChartAccount | undefined): string {
+  if (!account) return ''
+  return `${account.code} · ${account.name}`
+}

--- a/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
@@ -1,0 +1,465 @@
+// apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
+'use client'
+
+// The right column of the Chart of accounts tab: a `FieldPanel` form for the
+// selected `gl_account` row.
+//
+// 🛑 AUTOSAVES PER FIELD. No submit button and no dialog, exactly like
+// `ProductEditor` — `gl_account` stayed an `EntityInstance` under `G6` partly
+// because a chart is "a record a person maintains", and `catalog_item` is the
+// same kind of row, so the products pattern applies line for line.
+//
+// 🛑 PLACEHOLDER: every commit here writes LOCAL STATE. There is no procedure
+// that reads or writes a `gl_account` through this surface yet. The real
+// version routes a committed row through `useSaveFieldValue` (the same
+// optimistic path record detail views use) and a draft's first commit through
+// `record.create` on the `gl_account` definition. The shape of the code below
+// is already that shape, so swapping the two callbacks is the whole change.
+
+import { FieldType } from '@auxx/database/enums'
+import type { GlAccountTypeValue } from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useRef, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+import { ACCOUNT_TYPE_OPTIONS, type ChartAccount, type ChartDraftHandle } from './accounts-types'
+
+/**
+ * ⚠️ Renumbering after postings exist does NOT rewrite history, and the code
+ * field has to say so. A posting line names an account by CODE with no foreign
+ * key, deliberately, so the ledger outlives the chart. That is a feature, and
+ * it means a renumber silently detaches old lines from the row on screen.
+ */
+const RENUMBER_NOTE =
+  'Renumbering does not rewrite history. A posted line stores the account code with no ' +
+  'foreign key, on purpose, so the ledger outlives the chart. Lines already posted keep the ' +
+  'old code and will no longer point at this row.'
+
+const CODE_DESCRIPTION = 'The account number. Unique across the chart, and yours to change.'
+
+/** `FocusableInputWrapper` autofocuses once `open` is truthy; a stable no-op
+ *  keeps the effect from refiring every render. */
+function noop() {}
+
+/** SINGLE_SELECT hands back an array; normalize at the boundary. */
+function firstSelected(value: unknown): string | null {
+  if (Array.isArray(value)) return (value[0] as string) ?? null
+  return (value as string) || null
+}
+
+interface ChartAccountEditorProps {
+  selectedId: string | null
+  accounts: ChartAccount[]
+  /** True once anything has posted, which is when the renumber note matters. */
+  postingsExist: boolean
+  /** Is this code already taken by a different row? Drives the on-field error. */
+  isCodeTaken: (code: string, exceptId: string | null) => boolean
+  onUpdate: (id: string, patch: Partial<Omit<ChartAccount, 'id'>>) => void
+  /** Phantom draft for this tab, owned by `accounts-settings-page.tsx`. */
+  draft: ChartDraftHandle | null
+  /** List phantom-row preview sync, fired per debounced commit. */
+  onDraftChange: (patch: { code?: string; name?: string }) => void
+  /** Creates the row and returns its id. PLACEHOLDER for `record.create`. */
+  onCreate: (values: Omit<ChartAccount, 'id'>) => Promise<string>
+  /** First create resolved: swap `selectedId` to the real id, KEEPING the draft. */
+  onDraftCommitted: (recordId: string) => void
+}
+
+export function ChartAccountEditor({
+  selectedId,
+  accounts,
+  postingsExist,
+  isCodeTaken,
+  onUpdate,
+  draft,
+  onDraftChange,
+  onCreate,
+  onDraftCommitted,
+}: ChartAccountEditorProps) {
+  // The draft form also stays active while `selectedId` is the draft's
+  // committed recordId. Swapping to the committed form would remount the inputs
+  // mid-typing: replaced text and a cancelled debounce timer.
+  const draftActive =
+    !!draft && (selectedId === draft.draftId || (!!draft.recordId && selectedId === draft.recordId))
+
+  if (draft && draftActive) {
+    return (
+      <ChartAccountDraftForm
+        key={draft.draftId}
+        postingsExist={postingsExist}
+        isCodeTaken={isCodeTaken}
+        onDraftChange={onDraftChange}
+        onCreate={onCreate}
+        onUpdate={onUpdate}
+        onDraftCommitted={onDraftCommitted}
+      />
+    )
+  }
+
+  const account = selectedId ? accounts.find((row) => row.id === selectedId) : undefined
+
+  if (!account) {
+    return <div className='p-4 text-muted-foreground text-sm'>Select an account to edit.</div>
+  }
+
+  return (
+    <ChartAccountForm
+      key={account.id}
+      account={account}
+      postingsExist={postingsExist}
+      isCodeTaken={isCodeTaken}
+      onUpdate={onUpdate}
+    />
+  )
+}
+
+function ChartAccountForm({
+  account,
+  postingsExist,
+  isCodeTaken,
+  onUpdate,
+}: {
+  account: ChartAccount
+  postingsExist: boolean
+  isCodeTaken: (code: string, exceptId: string | null) => boolean
+  onUpdate: (id: string, patch: Partial<Omit<ChartAccount, 'id'>>) => void
+}) {
+  const [code, setCode] = useState(account.code)
+  const [name, setName] = useState(account.name)
+  const [codeError, setCodeError] = useState<string | undefined>(undefined)
+
+  const commitCode = useDebouncedCallback((value: string) => {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      setCodeError('An account needs a number.')
+      return
+    }
+    // 🛑 `gl_account.code` is `isUnique: true`, enforced by a query-then-write
+    // application check. A conflict surfaces HERE, on the code field, because
+    // "4000 is already in use" is the whole of what the person needs. A generic
+    // toast would make them hunt for which field went wrong.
+    if (isCodeTaken(trimmed, account.id)) {
+      setCodeError(`${trimmed} is already in use.`)
+      return
+    }
+    setCodeError(undefined)
+    onUpdate(account.id, { code: trimmed })
+  }, 500)
+
+  const commitName = useDebouncedCallback((value: string) => {
+    if (!value.trim()) return
+    onUpdate(account.id, { name: value.trim() })
+  }, 500)
+
+  return (
+    // `min-h-0` + `ScrollArea`: this editor sits inside a sticky pane capped at
+    // the viewport height (`accounts-settings-page.tsx`), so a form taller than
+    // that must scroll ITSELF. Without this it is clipped with no indication
+    // there is anything below.
+    <div className='flex h-full min-h-0 flex-col p-3'>
+      <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
+        <FieldPanel
+          orientation='horizontal'
+          breakpoint='md'
+          resizeId='gl-account-form'
+          defaultLabelWidth={160}
+          className='p-0'>
+          <FieldPanelRow
+            title='Code'
+            type={BaseType.STRING}
+            showIcon
+            isRequired
+            validationError={codeError}
+            description={postingsExist ? `${CODE_DESCRIPTION} ${RENUMBER_NOTE}` : CODE_DESCRIPTION}>
+            <div className='w-full'>
+              <FieldInputAdapter
+                fieldType={FieldType.TEXT}
+                value={code}
+                onChange={(value) => {
+                  setCode(value as string)
+                  commitCode(value as string)
+                }}
+                placeholder='1310'
+              />
+              {postingsExist && (
+                <p className='px-2 pb-1 text-muted-foreground text-xs'>{RENUMBER_NOTE}</p>
+              )}
+            </div>
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={name}
+              onChange={(value) => {
+                setName(value as string)
+                commitName(value as string)
+              }}
+              placeholder='Inventory'
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow
+            title='Type'
+            type={BaseType.ENUM}
+            showIcon
+            description='The statement classification. A role can only be mapped to an account of the type it declares.'>
+            <FieldInputAdapter
+              fieldType={FieldType.SINGLE_SELECT}
+              fieldOptions={{ options: ACCOUNT_TYPE_OPTIONS }}
+              value={[account.accountType]}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              onChange={(value) => {
+                const next = firstSelected(value)
+                if (next) onUpdate(account.id, { accountType: next as GlAccountTypeValue })
+              }}
+              placeholder='Select type'
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Active' type={BaseType.BOOLEAN} showIcon>
+            <div className='flex flex-1 items-center gap-2'>
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
+                fieldOptions={{ variant: 'switch' }}
+                value={account.isActive}
+                onChange={(value) => onUpdate(account.id, { isActive: value as boolean })}
+              />
+              {!account.isActive && (
+                <Badge variant='outline' size='xs' className='shrink-0'>
+                  Inactive
+                </Badge>
+              )}
+            </div>
+          </FieldPanelRow>
+        </FieldPanel>
+      </ScrollArea>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Draft (phantom) editor: same layout, local state instead of the row.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ChartDraftValues {
+  code: string
+  name: string
+  accountType: GlAccountTypeValue
+  isActive: boolean
+}
+
+function freshDraftValues(): ChartDraftValues {
+  return { code: '', name: '', accountType: 'asset', isActive: true }
+}
+
+/**
+ * Draft-mode form.
+ *
+ * Creation is GATED on both `code` and `name` being non-empty: a chart row with
+ * no number is meaningless and the number is the unique key, so a placeholder
+ * must never be persisted. Edits before then merge into local state at zero
+ * network cost.
+ */
+function ChartAccountDraftForm({
+  postingsExist,
+  isCodeTaken,
+  onDraftChange,
+  onCreate,
+  onUpdate,
+  onDraftCommitted,
+}: {
+  postingsExist: boolean
+  isCodeTaken: (code: string, exceptId: string | null) => boolean
+  onDraftChange: (patch: { code?: string; name?: string }) => void
+  onCreate: (values: Omit<ChartAccount, 'id'>) => Promise<string>
+  onUpdate: (id: string, patch: Partial<Omit<ChartAccount, 'id'>>) => void
+  onDraftCommitted: (recordId: string) => void
+}) {
+  const valuesRef = useRef<ChartDraftValues>(freshDraftValues())
+  const [values, setValues] = useState<ChartDraftValues>(valuesRef.current)
+
+  // 🛑 Guard one: a SYNCHRONOUS ref, not state-derived. Two commits landing
+  // before a re-render (a debounced name flushing while the type select fires,
+  // say) would both read the same stale state and race two creates for one
+  // draft, leaving a duplicate row that then loses the unique-code race.
+  const creatingRef = useRef(false)
+
+  // 🛑 Guard two: set the moment the create resolves. This form STAYS MOUNTED
+  // afterwards (the page keeps the draft alive, see `onDraftCommitted`) and
+  // every later commit routes straight to the committed row through this id.
+  // A remount here would replace the input's text with the create snapshot and
+  // cancel the pending debounce timer, losing whatever was typed during the
+  // round trip.
+  const recordIdRef = useRef<string | null>(null)
+
+  const [code, setCode] = useState('')
+  const [name, setName] = useState('')
+  const [codeError, setCodeError] = useState<string | undefined>(undefined)
+
+  const createNow = useCallback(
+    async (snapshot: ChartDraftValues) => {
+      try {
+        const recordId = await onCreate({
+          code: snapshot.code.trim(),
+          name: snapshot.name.trim(),
+          accountType: snapshot.accountType,
+          isActive: snapshot.isActive,
+        })
+
+        // Flip the commit target FIRST: a keystroke landing while the diff
+        // flush below runs must route to the real row, not the buffered path.
+        recordIdRef.current = recordId
+
+        // Whatever landed locally while the create was in flight.
+        const latest = valuesRef.current
+        const patch: Partial<Omit<ChartAccount, 'id'>> = {}
+        if (latest.code.trim() !== snapshot.code.trim()) patch.code = latest.code.trim()
+        if (latest.name.trim() !== snapshot.name.trim()) patch.name = latest.name.trim()
+        if (latest.accountType !== snapshot.accountType) patch.accountType = latest.accountType
+        if (latest.isActive !== snapshot.isActive) patch.isActive = latest.isActive
+        if (Object.keys(patch).length > 0) onUpdate(recordId, patch)
+
+        onDraftCommitted(recordId)
+      } catch (error) {
+        creatingRef.current = false
+        toastError({
+          title: 'Error creating account',
+          description: error instanceof Error ? error.message : 'Could not create the account',
+        })
+      }
+    },
+    [onCreate, onUpdate, onDraftCommitted]
+  )
+
+  const commitDraft = useCallback(
+    (patch: Partial<ChartDraftValues>) => {
+      const merged = { ...valuesRef.current, ...patch }
+      valuesRef.current = merged
+      setValues(merged)
+
+      if (patch.code !== undefined || patch.name !== undefined) {
+        onDraftChange({ code: merged.code, name: merged.name })
+      }
+
+      const trimmedCode = merged.code.trim()
+      if (trimmedCode && isCodeTaken(trimmedCode, recordIdRef.current)) {
+        setCodeError(`${trimmedCode} is already in use.`)
+        return
+      }
+      setCodeError(undefined)
+
+      // Already created: plain field updates, exactly like the committed form.
+      const recordId = recordIdRef.current
+      if (recordId) {
+        const update: Partial<Omit<ChartAccount, 'id'>> = {}
+        if (patch.code !== undefined) update.code = trimmedCode
+        if (patch.name !== undefined) update.name = merged.name.trim()
+        if (patch.accountType !== undefined) update.accountType = merged.accountType
+        if (patch.isActive !== undefined) update.isActive = merged.isActive
+        if (Object.keys(update).length > 0) onUpdate(recordId, update)
+        return
+      }
+
+      if (creatingRef.current) return // create in flight; the diff flush picks this up
+      if (!trimmedCode || !merged.name.trim()) return // buffering: both are required
+
+      creatingRef.current = true
+      void createNow(merged)
+    },
+    [createNow, isCodeTaken, onDraftChange, onUpdate]
+  )
+
+  const commitCode = useDebouncedCallback((value: string) => commitDraft({ code: value }), 500)
+  const commitName = useDebouncedCallback((value: string) => commitDraft({ name: value }), 500)
+
+  return (
+    // `min-h-0` + `ScrollArea`: this editor sits inside a sticky pane capped at
+    // the viewport height (`accounts-settings-page.tsx`), so a form taller than
+    // that must scroll ITSELF. Without this it is clipped with no indication
+    // there is anything below.
+    <div className='flex h-full min-h-0 flex-col p-3'>
+      <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
+        <FieldPanel
+          orientation='horizontal'
+          breakpoint='md'
+          resizeId='gl-account-form'
+          defaultLabelWidth={160}
+          className='p-0'>
+          <FieldPanelRow
+            title='Code'
+            type={BaseType.STRING}
+            showIcon
+            isRequired
+            validationError={codeError}
+            description={CODE_DESCRIPTION}>
+            <div className='w-full'>
+              <FieldInputAdapter
+                fieldType={FieldType.TEXT}
+                value={code}
+                open
+                onOpenChange={noop}
+                onChange={(value) => {
+                  setCode(value as string)
+                  commitCode(value as string)
+                }}
+                placeholder='1310'
+              />
+              {postingsExist && (
+                <p className='px-2 pb-1 text-muted-foreground text-xs'>{RENUMBER_NOTE}</p>
+              )}
+            </div>
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={name}
+              onChange={(value) => {
+                setName(value as string)
+                commitName(value as string)
+              }}
+              placeholder='Inventory'
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow
+            title='Type'
+            type={BaseType.ENUM}
+            showIcon
+            description='The statement classification. A role can only be mapped to an account of the type it declares.'>
+            <FieldInputAdapter
+              fieldType={FieldType.SINGLE_SELECT}
+              fieldOptions={{ options: ACCOUNT_TYPE_OPTIONS }}
+              value={[values.accountType]}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              onChange={(value) => {
+                const next = firstSelected(value)
+                if (next) commitDraft({ accountType: next as GlAccountTypeValue })
+              }}
+              placeholder='Select type'
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Active' type={BaseType.BOOLEAN} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.CHECKBOX}
+              fieldOptions={{ variant: 'switch' }}
+              value={values.isActive}
+              onChange={(value) => commitDraft({ isActive: value as boolean })}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+
+        <p className='px-1 pt-2 text-muted-foreground text-xs'>
+          Saved as soon as it has a number and a name. Nothing is written before then, so an
+          abandoned draft never leaves a placeholder in the chart.
+        </p>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -1,0 +1,194 @@
+// apps/web/src/components/accounting/ui/settings/chart-list.tsx
+'use client'
+
+// The left column of the Chart of accounts tab: search + "Add account" above a
+// flat `TreeRow` list, with the phantom draft rendered as a final row.
+
+import { ACCOUNT_ROLE_LABELS, type AccountRole } from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { Switch } from '@auxx/ui/components/switch'
+import { toastError } from '@auxx/ui/components/toast'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Landmark, Plus, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
+import {
+  accountTypeColor,
+  accountTypeLabel,
+  type ChartAccount,
+  type ChartDraftHandle,
+} from './accounts-types'
+
+interface ChartListProps {
+  accounts: ChartAccount[]
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+  /** Roles pointing at each account id. A non-empty list makes the row undeletable. */
+  rolesByAccountId: Map<string, AccountRole[]>
+  onAdd: () => void
+  onDelete: (account: ChartAccount) => void
+  onToggleActive: (account: ChartAccount) => void
+  draft: ChartDraftHandle | null
+}
+
+export function ChartList({
+  accounts,
+  selectedId,
+  onSelect,
+  rolesByAccountId,
+  onAdd,
+  onDelete,
+  onToggleActive,
+  draft,
+}: ChartListProps) {
+  const [search, setSearch] = useState('')
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  async function handleDelete(account: ChartAccount) {
+    const roles = rolesByAccountId.get(account.id) ?? []
+    if (roles.length > 0) {
+      // 🛑 Refused, naming the role. The chart is an editable template, not a
+      // free-for-all: `resolveRoles` fails closed, so a silent delete here
+      // becomes a refused close next month with no obvious cause.
+      const named = roles.map((role) => `"${ACCOUNT_ROLE_LABELS[role]}"`).join(', ')
+      toastError({
+        title: 'Cannot delete this account',
+        description:
+          `${account.code} ${account.name} is mapped to the ${named} ` +
+          `${roles.length === 1 ? 'role' : 'roles'}. Repoint ${roles.length === 1 ? 'it' : 'them'} ` +
+          'on the Roles tab first, or mark the role unused.',
+      })
+      return
+    }
+
+    const confirmed = await confirm({
+      title: 'Delete account?',
+      description:
+        `${account.code} ${account.name} will be removed from the chart. Posting lines that ` +
+        'already name this code keep it, because a line stores the code with no foreign key.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    onDelete(account)
+  }
+
+  const filtered = search
+    ? accounts.filter(
+        (account) =>
+          account.name.toLowerCase().includes(search.toLowerCase()) || account.code.includes(search)
+      )
+    : accounts
+
+  return (
+    <div className='flex flex-col gap-3 p-3'>
+      <div className='flex items-center gap-2'>
+        <InputSearch
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder='Search accounts...'
+        />
+        <Button variant='outline' size='sm' onClick={onAdd}>
+          <Plus />
+          Add account
+        </Button>
+      </div>
+
+      {filtered.length === 0 && !draft ? (
+        <div className='p-4 text-center text-muted-foreground text-sm'>
+          {search ? 'No matches' : 'No accounts yet. Add the first one.'}
+        </div>
+      ) : (
+        // `TREE_SECONDARY_NOTRUNCATE`: TreeRow's `secondary` slot truncates
+        // (overflow-hidden) by default, which clips a Badge's pill edges and its
+        // `ring-1 ring-current/35`. The class is exported by `tree-row.tsx` for
+        // exactly this case and belongs on the container around the rows.
+        <div className={cn('flex flex-col gap-0.5', TREE_SECONDARY_NOTRUNCATE)}>
+          {filtered.map((account) => {
+            const roles = rolesByAccountId.get(account.id) ?? []
+            return (
+              <TreeRow
+                key={account.id}
+                icon={<Landmark className='size-4 text-muted-foreground' />}
+                title={
+                  <span className='flex items-baseline gap-2'>
+                    <span className='text-muted-foreground text-xs tabular-nums'>
+                      {account.code}
+                    </span>
+                    <span className='text-sm'>{account.name}</span>
+                  </span>
+                }
+                secondaryFill
+                onToggleOpen={() => onSelect(account.id)}
+                rowClassName={cn(
+                  'bg-primary-100/50 hover:bg-primary-100',
+                  selectedId === account.id && 'bg-primary-100 ring-1 ring-primary-200',
+                  !account.isActive && 'opacity-60'
+                )}
+                secondary={
+                  <span className='flex items-center gap-1.5 text-muted-foreground text-xs'>
+                    <Badge variant={accountTypeColor(account.accountType)} size='xs'>
+                      {accountTypeLabel(account.accountType)}
+                    </Badge>
+                    {roles.length > 0 && (
+                      <span>
+                        {roles.length} {roles.length === 1 ? 'role' : 'roles'}
+                      </span>
+                    )}
+                  </span>
+                }
+                actions={
+                  // `TreeRowButton`, never a raw icon Button: it owns the
+                  // hover-fade, the sizing and the tooltip side, and it stops
+                  // its own click. TreeRow wraps the whole `actions` slot in an
+                  // `onClick={stopPropagation}` container (tree-row.tsx:315),
+                  // so the Switch beside it cannot fire `onToggleOpen` either.
+                  <div className='flex items-center gap-1'>
+                    <TreeRowButton
+                      tooltipText='Delete account'
+                      variant='destructive'
+                      onClick={() => void handleDelete(account)}>
+                      <Trash2 />
+                    </TreeRowButton>
+                    <Switch
+                      size='xs'
+                      checked={account.isActive}
+                      onCheckedChange={() => onToggleActive(account)}
+                    />
+                  </div>
+                }
+              />
+            )
+          })}
+
+          {draft && !draft.recordId && (
+            <TreeRow
+              key={draft.draftId}
+              icon={<Landmark className='size-4 text-muted-foreground' />}
+              title={
+                <span className='flex items-baseline gap-2'>
+                  <span className='text-muted-foreground text-xs tabular-nums'>
+                    {draft.code || '----'}
+                  </span>
+                  <span className={cn('text-sm', !draft.name && 'text-muted-foreground italic')}>
+                    {draft.name || 'Untitled account'}
+                  </span>
+                </span>
+              }
+              onToggleOpen={() => onSelect(draft.draftId)}
+              rowClassName={cn(
+                'bg-primary-100/50 hover:bg-primary-100',
+                selectedId === draft.draftId && 'bg-primary-100 ring-1 ring-primary-200'
+              )}
+            />
+          )}
+        </div>
+      )}
+      <ConfirmDialog />
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
@@ -1,0 +1,419 @@
+// apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+'use client'
+
+// Accounting > Settings > General (13-accounting-ui.md §5.4).
+//
+// Shape A, the sectioned form page: `SettingsPage` + a two-column grid of
+// `SettingsSection`s, `FieldPanel` + `SettingsFieldRow`, and a `useDirtyDraft`
+// slice PER SECTION.
+//
+// 🛑 Draft keys are scoped explicitly. `useSettings({ scope: 'GENERAL' })`
+// returns EVERY `GENERAL`-scope setting in the whole app and every
+// `accounting.*` key is `GENERAL`, so an unscoped save here would clobber
+// unrelated settings. Each section takes its own key array from
+// `accounting-settings-keys.ts` through `useAccountingSetupDraft`, the same
+// hook the setup wizard narrows its writes with.
+
+import { FieldType } from '@auxx/database/enums'
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
+import { isValidTimeZone, resolveSetupReadiness } from '@auxx/lib/postings/client'
+import type { SettingValue } from '@auxx/lib/settings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { CalendarRange, Lock, Scale } from 'lucide-react'
+import { useMemo } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { EmptyState } from '~/components/global/empty-state'
+import { FieldPanel } from '~/components/global/forms/field-panel'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
+import { TimeZonePicker } from '~/components/pickers/timezone-picker'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useSettings } from '~/hooks/use-settings'
+import { useUser } from '~/hooks/use-user'
+import { useRequireCapability } from '~/providers/capabilities-provider'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import {
+  FREEZE_REASON,
+  useAccountingSettingsFreeze,
+} from '../../hooks/use-accounting-settings-freeze'
+import { useAccountingSetupDraft } from '../../hooks/use-accounting-setup-draft'
+import {
+  ABSORPTION_DRAFT_KEYS,
+  ACCOUNTING_KEYS,
+  buildReadinessRecord,
+  everyMinorUnitValid,
+  minorUnitError,
+  PERIOD_DRAFT_KEYS,
+  readMinorUnits,
+  readText,
+} from './accounting-settings-keys'
+import { SetupStatusSection } from './setup-status-section'
+import { StandardCostSection } from './standard-cost-section'
+
+const MONTH_KEY = /^\d{4}-(0[1-9]|1[0-2])$/
+
+const BREADCRUMBS = [
+  { title: 'Accounting', href: '/app/accounting' },
+  { title: 'Settings' },
+  { title: 'General' },
+]
+
+const PAGE_DESCRIPTION =
+  'The period the books are kept in, how setup is finalized, and what a build absorbs.'
+
+export function AccountingGeneralSettingsPage() {
+  useRequireCapability(PermissionKey.ledgerView)
+  const { hasAccess } = useFeatureFlags()
+  const { userId } = useUser()
+  const { getSetting, batchUpdateOrganizationSettings, isBatchUpdatingOrgSettings } = useSettings({
+    scope: 'GENERAL',
+  })
+  const { frozen } = useAccountingSettingsFreeze()
+
+  // The shared predicate, over the settings record. No query.
+  const readiness = useMemo(
+    () => resolveSetupReadiness(buildReadinessRecord(getSetting)),
+    [getSetting]
+  )
+
+  // ── Section 1: accounting period ─────────────────────────────────────────
+  // A SEPARATE draft slice per section: the two validate independently, and the
+  // rates could later save through a different mutation than the period does.
+  const period = useAccountingSetupDraft(PERIOD_DRAFT_KEYS)
+  const { draft: periodDraft, patch: patchPeriod } = period
+
+  const cutoff = readText(periodDraft[ACCOUNTING_KEYS.cutoffPeriod])
+  const bookZone = readText(periodDraft[ACCOUNTING_KEYS.bookTimeZone])
+  const cutoffError =
+    cutoff && !MONTH_KEY.test(cutoff) ? 'Must be a YYYY-MM month, for example 2026-12.' : undefined
+  const zoneError =
+    bookZone && !isValidTimeZone(bookZone)
+      ? `"${bookZone}" is not a valid IANA timezone.`
+      : undefined
+  const periodValid = !cutoffError && !zoneError
+
+  // ── Section 3: absorption rates ──────────────────────────────────────────
+  const absorption = useAccountingSetupDraft(ABSORPTION_DRAFT_KEYS)
+  const { draft: absorptionDraft, patch: patchAbsorption } = absorption
+
+  const absorptionValid = everyMinorUnitValid(absorptionDraft, ABSORPTION_DRAFT_KEYS)
+
+  const dirty = period.dirty || absorption.dirty
+  const isSaving = period.isSaving || absorption.isSaving || isBatchUpdatingOrgSettings
+  const saveDisabled = (period.dirty && !periodValid) || (absorption.dirty && !absorptionValid)
+
+  function handleFinalize() {
+    // The wizard's `done` page writes the same three keys. Both doors, one action.
+    batchUpdateOrganizationSettings([
+      { key: ACCOUNTING_KEYS.setupState, value: 'finalized' },
+      { key: ACCOUNTING_KEYS.setupFinalizedAt, value: new Date().toISOString() },
+      { key: ACCOUNTING_KEYS.setupFinalizedByUserId, value: userId ?? null },
+    ])
+  }
+
+  if (!hasAccess(FeatureKey.accounting)) {
+    return (
+      <SettingsPage title='General' description={PAGE_DESCRIPTION} breadcrumbs={BREADCRUMBS}>
+        <EmptyState
+          icon={Lock}
+          title='Accounting Not Available'
+          description='Upgrade your plan to keep books in Auxx.'
+          button={<div className='h-12' />}
+        />
+      </SettingsPage>
+    )
+  }
+
+  return (
+    <SettingsPage title='General' description={PAGE_DESCRIPTION} breadcrumbs={BREADCRUMBS}>
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
+        <div className='grid grid-cols-1 items-start gap-8 lg:grid-cols-2'>
+          <SettingsSection
+            icon={CalendarRange}
+            title='Accounting period'
+            description='The month the previous system last closed, and the timezone every period key is derived in.'>
+            <FieldPanel
+              className='mt-1 p-0'
+              resizeId='accounting-general-period'
+              defaultLabelWidth={220}>
+              <SettingsFieldRow settingKey={ACCOUNTING_KEYS.cutoffPeriod} title='Cutoff period'>
+                <MonthTextField
+                  value={cutoff}
+                  error={cutoffError}
+                  readOnly={frozen}
+                  readOnlyReason={FREEZE_REASON}
+                  onChange={(value) =>
+                    patchPeriod({ [ACCOUNTING_KEYS.cutoffPeriod]: value as SettingValue })
+                  }
+                />
+              </SettingsFieldRow>
+
+              <SettingsFieldRow settingKey={ACCOUNTING_KEYS.bookTimeZone} title='Book timezone'>
+                <BookTimeZoneField
+                  value={bookZone}
+                  error={zoneError}
+                  readOnly={frozen}
+                  readOnlyReason={FREEZE_REASON}
+                  onChange={(zone) =>
+                    patchPeriod({ [ACCOUNTING_KEYS.bookTimeZone]: zone as SettingValue })
+                  }
+                />
+              </SettingsFieldRow>
+            </FieldPanel>
+          </SettingsSection>
+
+          <SetupStatusSection
+            readiness={readiness}
+            finalizedAt={readText(getSetting(ACCOUNTING_KEYS.setupFinalizedAt))}
+            finalizedByUserId={readText(getSetting(ACCOUNTING_KEYS.setupFinalizedByUserId))}
+            hasUnsavedChanges={dirty}
+            isFinalizing={isBatchUpdatingOrgSettings}
+            onFinalize={handleFinalize}
+          />
+        </div>
+
+        <div className='grid grid-cols-1 items-start gap-8 lg:grid-cols-2'>
+          <SettingsSection
+            icon={Scale}
+            title='Absorption rates'
+            description='Per assembled unit, in whole cents. An unset rate absorbs nothing; a zero rate is a real choice.'>
+            <FieldPanel
+              className='mt-1 p-0'
+              resizeId='accounting-general-absorption'
+              defaultLabelWidth={220}>
+              <SettingsFieldRow
+                settingKey={ACCOUNTING_KEYS.assemblyLaborCostPerUnit}
+                title='Assembly labor'>
+                <AbsorptionRateField
+                  value={readMinorUnits(absorptionDraft[ACCOUNTING_KEYS.assemblyLaborCostPerUnit])}
+                  error={minorUnitError(absorptionDraft[ACCOUNTING_KEYS.assemblyLaborCostPerUnit])}
+                  onChange={(value) =>
+                    patchAbsorption({
+                      [ACCOUNTING_KEYS.assemblyLaborCostPerUnit]: value as SettingValue,
+                    })
+                  }
+                />
+              </SettingsFieldRow>
+
+              <SettingsFieldRow
+                settingKey={ACCOUNTING_KEYS.overheadCostPerUnit}
+                title='Applied overhead'>
+                <AbsorptionRateField
+                  value={readMinorUnits(absorptionDraft[ACCOUNTING_KEYS.overheadCostPerUnit])}
+                  error={minorUnitError(absorptionDraft[ACCOUNTING_KEYS.overheadCostPerUnit])}
+                  onChange={(value) =>
+                    patchAbsorption({
+                      [ACCOUNTING_KEYS.overheadCostPerUnit]: value as SettingValue,
+                    })
+                  }
+                />
+              </SettingsFieldRow>
+            </FieldPanel>
+
+            <p className='text-muted-foreground text-xs'>
+              Conversion cost applies to a subassembly or a finished good only. Applying these rates
+              to a purchased component would capitalize labor that was never spent and overstate raw
+              materials.
+            </p>
+          </SettingsSection>
+
+          <StandardCostSection />
+        </div>
+
+        {/*
+          One bar covering both drafts. The sections keep SEPARATE `useDirtyDraft`
+          slices (they validate independently and could later save through
+          different mutations), but two sticky bars would stack on top of each
+          other at the viewport bottom, so save/discard fan out to whichever
+          slice is actually dirty. Same arrangement as `scheduling-settings-page`.
+        */}
+        <FormSaveBar
+          dirty={dirty}
+          isSaving={isSaving}
+          onSave={() => {
+            if (period.dirty) period.save()
+            if (absorption.dirty) absorption.save()
+          }}
+          onDiscard={() => {
+            if (period.dirty) period.discard()
+            if (absorption.dirty) absorption.discard()
+          }}
+          saveDisabled={saveDisabled}
+        />
+      </div>
+    </SettingsPage>
+  )
+}
+
+/**
+ * The cutoff month.
+ *
+ * `TEXT` in the catalog because `FieldOptions` carries no pattern member, so the
+ * shape is validated here and again on read, where it fails closed.
+ *
+ * `disabled` / `className` are declared because `SettingsFieldRow` hands an
+ * org-access child to `AdminGate`, which clones it with exactly those two props.
+ */
+function MonthTextField({
+  value,
+  error,
+  readOnly,
+  readOnlyReason,
+  onChange,
+  disabled,
+  className,
+}: {
+  value: string | null
+  error?: string
+  readOnly?: boolean
+  readOnlyReason?: string
+  onChange: (value: string | null) => void
+  disabled?: boolean
+  className?: string
+}) {
+  if (readOnly) {
+    return (
+      <ReadOnlyValue value={value ?? 'Not set'} reason={readOnlyReason} className={className} />
+    )
+  }
+  return (
+    <div className={className}>
+      <FieldInputAdapter
+        fieldType={FieldType.TEXT}
+        value={value ?? ''}
+        disabled={disabled}
+        onChange={(next) => onChange(((next as string) || null) ?? null)}
+        placeholder='2026-12'
+      />
+      {error && <p className='px-2 pb-1 text-destructive text-xs'>{error}</p>}
+    </div>
+  )
+}
+
+/**
+ * The book timezone.
+ *
+ * 🛑 There is NO UTC fallback anywhere in this subsystem, so an unset zone reads
+ * as unset rather than defaulting to the browser's or to UTC. A receipt logged
+ * at 7pm on January 31 in `America/New_York` is already February 1 in UTC, so a
+ * quietly assumed zone posts a month's edge activity into the wrong period.
+ */
+function BookTimeZoneField({
+  value,
+  error,
+  readOnly,
+  readOnlyReason,
+  onChange,
+  disabled,
+  className,
+}: {
+  value: string | null
+  error?: string
+  readOnly?: boolean
+  readOnlyReason?: string
+  onChange: (zone: string) => void
+  disabled?: boolean
+  className?: string
+}) {
+  if (readOnly) {
+    return (
+      <ReadOnlyValue value={value ?? 'Not set'} reason={readOnlyReason} className={className} />
+    )
+  }
+  return (
+    <div className={className}>
+      <TimeZonePicker
+        selected={value ?? undefined}
+        onChange={onChange}
+        disabled={disabled}
+        placeholder='Not set'
+        triggerProps={{ variant: 'transparent', className: 'w-full ps-0 pe-1' }}
+      />
+      {!value && (
+        <p className='px-2 pb-1 text-muted-foreground text-xs'>
+          Unset refuses to post rather than assuming UTC.
+        </p>
+      )}
+      {error && <p className='px-2 pb-1 text-destructive text-xs'>{error}</p>}
+    </div>
+  )
+}
+
+/**
+ * An absorption rate.
+ *
+ * ⚠️ `null` and `0` MUST read differently. An unset rate absorbs nothing while
+ * looking like it worked; a zero rate is a business decision somebody made.
+ * `loadAbsorptionRates` returns `null` for unset and must keep doing so, so the
+ * screen has to be able to show the difference.
+ */
+function AbsorptionRateField({
+  value,
+  error,
+  onChange,
+  disabled,
+  className,
+}: {
+  value: number | null
+  error?: string
+  onChange: (value: number | null) => void
+  disabled?: boolean
+  className?: string
+}) {
+  return (
+    <div className={className}>
+      <div className='flex flex-1 items-center gap-2'>
+        <FieldInputAdapter
+          fieldType={FieldType.CURRENCY}
+          value={value}
+          disabled={disabled}
+          onChange={(next) => onChange((next as number | undefined) ?? null)}
+          placeholder='Not set'
+        />
+        {value === null ? (
+          <Badge variant='amber' size='xs' className='shrink-0 whitespace-nowrap'>
+            Not set
+          </Badge>
+        ) : value === 0 ? (
+          <Badge variant='outline' size='xs' className='shrink-0 whitespace-nowrap'>
+            Zero
+          </Badge>
+        ) : null}
+      </div>
+      <p className='px-2 pb-1 text-muted-foreground text-xs'>
+        {value === null
+          ? 'Unset. Nothing is absorbed, and no build carries this cost.'
+          : value === 0
+            ? 'Zero, deliberately. Nothing is absorbed, but the rate is configured.'
+            : 'Absorbed into every assembled unit.'}
+      </p>
+      {error && <p className='px-2 pb-1 text-destructive text-xs'>{error}</p>}
+    </div>
+  )
+}
+
+/** A frozen field: the value, plus why it can no longer be edited. */
+function ReadOnlyValue({
+  value,
+  reason,
+  className,
+}: {
+  value: string
+  reason?: string
+  className?: string
+}) {
+  return (
+    <div className={className}>
+      <div className='flex min-h-8 flex-wrap items-center gap-2 px-2 py-1.5 text-sm'>
+        <span>{value}</span>
+        <Badge variant='outline' size='xs' className='shrink-0'>
+          Locked
+        </Badge>
+      </div>
+      {reason && <p className='px-2 pb-1.5 text-muted-foreground text-xs'>{reason}</p>}
+    </div>
+  )
+}
+
+/** Exported so the wizard's period page can validate the same month shape. */
+export { MONTH_KEY }

--- a/apps/web/src/components/accounting/ui/settings/opening-reconciliation-panel.tsx
+++ b/apps/web/src/components/accounting/ui/settings/opening-reconciliation-panel.tsx
@@ -1,0 +1,183 @@
+// apps/web/src/components/accounting/ui/settings/opening-reconciliation-panel.tsx
+'use client'
+
+// The two opening snapshots, side by side, with their difference.
+//
+// 🛑 Neither number silently overrides the other, which is why this is a
+// DIFFERENCE rather than a fallback. A difference falling into January's
+// balancing plug would classify a cutover problem as January COGS; the auxx
+// number alone would let QuickBooks and the subledger disagree from day one.
+//
+// ⚠️ These controls are handed to `SettingsFieldRow` through its `children`
+// escape hatch, so they keep the row chrome (label, icon, description tooltip,
+// `AdminGate`). `AdminGate` clones the child with `disabled` and `className`,
+// which is why both props are declared even where this file never sets them.
+
+import { FieldType } from '@auxx/database/enums'
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import { formatCurrency } from '@auxx/utils/currency'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+
+/** The two snapshots' column captions, rendered once above the first pair. */
+const COLUMN_LABELS = ['auxx.ai', 'QuickBooks', 'Difference'] as const
+
+interface OpeningPairFieldProps {
+  auxx: number | null
+  qbo: number | null
+  onAuxxChange: (value: number | null) => void
+  onQboChange: (value: number | null) => void
+  /** Per-input validation, from `minorUnitError`. */
+  auxxError?: string
+  qboError?: string
+  /** Extra guidance for this account, e.g. "WIP is expected to be 0 at cutover". */
+  hint?: string
+  /** Column captions render only on the first pair, so the panel is not repetitive. */
+  showLabels?: boolean
+  /** After the freeze, both snapshots render as values with the reason attached. */
+  readOnly?: boolean
+  readOnlyReason?: string
+  disabled?: boolean
+  className?: string
+}
+
+/** One account: the auxx snapshot, the provider snapshot, and their difference. */
+export function OpeningPairField({
+  auxx,
+  qbo,
+  onAuxxChange,
+  onQboChange,
+  auxxError,
+  qboError,
+  hint,
+  showLabels,
+  readOnly,
+  readOnlyReason,
+  disabled,
+  className,
+}: OpeningPairFieldProps) {
+  const difference = auxx === null || qbo === null ? null : auxx - qbo
+
+  return (
+    <div className={cn('py-1', className)}>
+      {showLabels && (
+        <div className='grid grid-cols-[1fr_1fr_7rem] gap-2 px-2 pb-1'>
+          {COLUMN_LABELS.map((label) => (
+            <span key={label} className='text-[10px] text-muted-foreground uppercase tracking-wide'>
+              {label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className='grid grid-cols-[1fr_1fr_7rem] items-center gap-2'>
+        {readOnly ? (
+          <>
+            <span className='px-2 text-sm tabular-nums'>{formatCurrency(auxx)}</span>
+            <span className='px-2 text-sm tabular-nums'>{formatCurrency(qbo)}</span>
+          </>
+        ) : (
+          <>
+            <FieldInputAdapter
+              fieldType={FieldType.CURRENCY}
+              value={auxx}
+              disabled={disabled}
+              onChange={(next) => onAuxxChange((next as number | undefined) ?? null)}
+              placeholder='Not set'
+            />
+            <FieldInputAdapter
+              fieldType={FieldType.CURRENCY}
+              value={qbo}
+              disabled={disabled}
+              onChange={(next) => onQboChange((next as number | undefined) ?? null)}
+              placeholder='Not set'
+            />
+          </>
+        )}
+
+        <DifferenceCell difference={difference} />
+      </div>
+
+      {(auxxError || qboError) && (
+        <p className='px-2 pt-1 text-destructive text-xs'>{auxxError ?? qboError}</p>
+      )}
+      {hint && <p className='px-2 pt-1 text-muted-foreground text-xs'>{hint}</p>}
+      {readOnly && readOnlyReason && (
+        <p className='px-2 pt-1 text-muted-foreground text-xs'>{readOnlyReason}</p>
+      )}
+    </div>
+  )
+}
+
+/** A single difference, with "not comparable yet" kept distinct from "agrees". */
+function DifferenceCell({ difference }: { difference: number | null }) {
+  if (difference === null) {
+    return <span className='px-2 text-muted-foreground text-xs'>Not comparable</span>
+  }
+  if (difference === 0) {
+    return (
+      <Badge variant='green' size='xs' className='justify-self-start whitespace-nowrap'>
+        Agrees
+      </Badge>
+    )
+  }
+  return (
+    <span className='px-2 font-medium text-destructive text-sm tabular-nums'>
+      {difference > 0 ? '+' : ''}
+      {formatCurrency(difference)}
+    </span>
+  )
+}
+
+interface OpeningTotalRowProps {
+  /** `openingDifference(settings)` over the DRAFT, so the verdict tracks the form. */
+  total: number
+  /** True while any of the six balances is still unset. */
+  incomplete: boolean
+  className?: string
+}
+
+/**
+ * The summed verdict.
+ *
+ * 🛑 The two snapshots must agree before setup can be finalized. This row says
+ * so in as many words rather than leaving a bookkeeper to infer it from a
+ * disabled button on another page.
+ */
+export function OpeningTotalRow({ total, incomplete, className }: OpeningTotalRowProps) {
+  const agrees = !incomplete && total === 0
+
+  return (
+    <div className={cn('space-y-1 py-1', className)}>
+      <div className='grid grid-cols-[1fr_1fr_7rem] items-center gap-2'>
+        <span className='px-2 font-medium text-sm'>Total difference</span>
+        <span />
+        {incomplete ? (
+          <span className='px-2 text-muted-foreground text-xs'>Not comparable</span>
+        ) : agrees ? (
+          <Badge variant='green' size='xs' className='justify-self-start whitespace-nowrap'>
+            Agrees
+          </Badge>
+        ) : (
+          <span className='px-2 font-medium text-destructive text-sm tabular-nums'>
+            {total > 0 ? '+' : ''}
+            {formatCurrency(total)}
+          </span>
+        )}
+      </div>
+
+      <p className='px-2 text-muted-foreground text-xs'>
+        {incomplete
+          ? 'Some balances are still unset, so there is nothing to compare yet. Zero is a real ' +
+            'balance; unset is not.'
+          : agrees
+            ? 'The two snapshots agree. Setup can be finalized on the General page.'
+            : 'Setup cannot be finalized while these disagree. Neither number overrides the ' +
+              "other: a difference left to fall into the first month's balancing plug would be " +
+              "booked as that month's COGS, and taking the auxx figure alone would let " +
+              'QuickBooks and the subledger diverge from day one. Fix the count or the journal ' +
+              'entry, then re-enter both.'}
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/opening-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/opening-settings-page.tsx
@@ -1,0 +1,163 @@
+// apps/web/src/components/accounting/ui/settings/opening-settings-page.tsx
+'use client'
+
+// Accounting > Settings > Opening balances (13-accounting-ui.md §5.4).
+//
+// Shape A with ONE wide section: the two snapshots side by side, the difference
+// per account and in total, and the provider journal reference that says where
+// the other side came from.
+//
+// 🛑 Draft keys are scoped to `OPENING_DRAFT_KEYS` through
+// `useAccountingSetupDraft`, the same hook the setup wizard narrows its writes
+// with. `useSettings({ scope: 'GENERAL' })` returns every `GENERAL`-scope
+// setting in the app, so an unscoped save would clobber unrelated keys.
+//
+// 🛑 Integer minor units are validated BEFORE saving. `CURRENCY` does not
+// enforce them: `normalizeSettingValue` routes the value through
+// `fieldValueSchemas.number`, which accepts `12.5`. `readOpeningBaseline`
+// refuses a fractional value on the read side, so with no write-side check the
+// failure mode is a setup that saves and then cannot close.
+
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
+import { openingDifference, openingDifferenceRows } from '@auxx/lib/postings/client'
+import type { SettingValue } from '@auxx/lib/settings/client'
+import { Lock, Scale } from 'lucide-react'
+import { EmptyState } from '~/components/global/empty-state'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useRequireCapability } from '~/providers/capabilities-provider'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import {
+  FREEZE_REASON,
+  useAccountingSettingsFreeze,
+} from '../../hooks/use-accounting-settings-freeze'
+import { useAccountingSetupDraft } from '../../hooks/use-accounting-setup-draft'
+import {
+  ACCOUNTING_KEYS,
+  everyMinorUnitValid,
+  minorUnitError,
+  OPENING_DRAFT_KEYS,
+  OPENING_PAIRS,
+  readMinorUnits,
+} from './accounting-settings-keys'
+import { OpeningPairField, OpeningTotalRow } from './opening-reconciliation-panel'
+
+/** The six balances, without the journal reference. Only these are money. */
+const BALANCE_KEYS = OPENING_DRAFT_KEYS.filter(
+  (key) => key !== ACCOUNTING_KEYS.qboOpeningJournalRef
+)
+
+const BREADCRUMBS = [
+  { title: 'Accounting', href: '/app/accounting' },
+  { title: 'Settings' },
+  { title: 'Opening balances' },
+]
+
+const PAGE_DESCRIPTION =
+  'The frozen cutover snapshot, on both sides, and the arithmetic that has to agree before anything posts.'
+
+export function AccountingOpeningSettingsPage() {
+  useRequireCapability(PermissionKey.ledgerView)
+  const { hasAccess } = useFeatureFlags()
+  const { frozen } = useAccountingSettingsFreeze()
+  const { draft, patch, dirty, save, discard, controlled, isSaving } =
+    useAccountingSetupDraft(OPENING_DRAFT_KEYS)
+
+  // The difference is computed over the DRAFT, not the saved record, so the
+  // verdict tracks what is on screen. Both helpers are the shared lib arithmetic
+  // the readiness predicate and the checklist widget use.
+  const differenceRows = openingDifferenceRows(draft)
+  const total = openingDifference(draft)
+  const incomplete = BALANCE_KEYS.some((key) => readMinorUnits(draft[key]) === null)
+  const valid = everyMinorUnitValid(draft, BALANCE_KEYS)
+
+  const rowByRole = new Map(differenceRows.map((row) => [row.role, row]))
+
+  function patchKey(key: string, value: number | null) {
+    patch({ [key]: value as SettingValue })
+  }
+
+  if (!hasAccess(FeatureKey.accounting)) {
+    return (
+      <SettingsPage
+        title='Opening balances'
+        description={PAGE_DESCRIPTION}
+        breadcrumbs={BREADCRUMBS}>
+        <EmptyState
+          icon={Lock}
+          title='Accounting Not Available'
+          description='Upgrade your plan to keep books in Auxx.'
+          button={<div className='h-12' />}
+        />
+      </SettingsPage>
+    )
+  }
+
+  return (
+    <SettingsPage title='Opening balances' description={PAGE_DESCRIPTION} breadcrumbs={BREADCRUMBS}>
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
+        <SettingsSection
+          icon={Scale}
+          title='Cutover snapshot'
+          description='What each inventory account held at the cutoff, from the physical count on one side and from QuickBooks on the other. Amounts are whole cents.'>
+          <FieldPanel className='mt-1 p-0' resizeId='accounting-opening' defaultLabelWidth={220}>
+            {OPENING_PAIRS.map((pair, index) => {
+              const row = rowByRole.get(pair.role)
+              return (
+                <SettingsFieldRow
+                  key={pair.role}
+                  settingKey={pair.auxxKey}
+                  title={`${pair.accountCode} ${pair.label}`}>
+                  <OpeningPairField
+                    auxx={row?.auxx ?? null}
+                    qbo={row?.qbo ?? null}
+                    onAuxxChange={(value) => patchKey(pair.auxxKey, value)}
+                    onQboChange={(value) => patchKey(pair.qboKey, value)}
+                    auxxError={minorUnitError(draft[pair.auxxKey])}
+                    qboError={minorUnitError(draft[pair.qboKey])}
+                    hint={pair.hint}
+                    showLabels={index === 0}
+                    readOnly={frozen}
+                    readOnlyReason={FREEZE_REASON}
+                  />
+                </SettingsFieldRow>
+              )
+            })}
+
+            <FieldPanelRow
+              title='Reconciliation'
+              description='The two snapshots must agree before setup can be finalized.'>
+              <OpeningTotalRow total={total} incomplete={incomplete} />
+            </FieldPanelRow>
+
+            <SettingsFieldRow
+              settingKey={ACCOUNTING_KEYS.qboOpeningJournalRef}
+              title='QuickBooks journal reference'
+              placeholder='For example JE-1042'
+              {...controlled(ACCOUNTING_KEYS.qboOpeningJournalRef)}
+            />
+          </FieldPanel>
+
+          <p className='text-muted-foreground text-xs'>
+            The QuickBooks figures are provenance. The books are valued from the auxx snapshot once
+            the two agree, and the opening entry itself was booked in QuickBooks, which is why the
+            link here is a reference string rather than an auxx posting.
+          </p>
+        </SettingsSection>
+
+        <FormSaveBar
+          dirty={dirty}
+          isSaving={isSaving}
+          onSave={save}
+          onDiscard={discard}
+          saveDisabled={!valid}
+          label={
+            valid ? 'Unsaved changes' : 'Amounts must be whole cents before this can be saved.'
+          }
+        />
+      </div>
+    </SettingsPage>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
@@ -1,0 +1,227 @@
+// apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
+'use client'
+
+// The right pane of the Roles tab: pick the account a role points at, and say
+// why one was suggested.
+//
+// 🛑 The picker only offers accounts whose statement classification matches
+// `ROLE_ACCOUNT_TYPES[role]`. That expectation is DECLARED, never derived from
+// the chart, and `resolveRoles` fails closed on a mismatch naming the role, the
+// account and both types. An org may legitimately move `grni` from 2160 to
+// 2155; it may not point it at a revenue account, because the resulting entry
+// would still balance and nothing downstream could detect it.
+
+import {
+  ACCOUNT_ROLE_LABELS,
+  type AccountRole,
+  ROLE_ACCOUNT_TYPES,
+} from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { cn } from '@auxx/ui/lib/utils'
+import { Ban, Check, RotateCcw, Sparkles } from 'lucide-react'
+import { useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import {
+  accountTypeLabel,
+  type ChartAccount,
+  DEFAULT_UNUSED_ROLES,
+  type RoleAssignment,
+} from './accounts-types'
+
+interface RoleMapEditorProps {
+  role: AccountRole | null
+  assignment: RoleAssignment | undefined
+  accounts: ChartAccount[]
+  onAssign: (role: AccountRole, accountId: string) => void
+  onClear: (role: AccountRole) => void
+  onToggleUnused: (role: AccountRole) => void
+}
+
+export function RoleMapEditor({
+  role,
+  assignment,
+  accounts,
+  onAssign,
+  onClear,
+  onToggleUnused,
+}: RoleMapEditorProps) {
+  const [search, setSearch] = useState('')
+
+  if (!role) {
+    return (
+      <div className='p-4 text-muted-foreground text-sm'>
+        Select a role to choose the account it posts to.
+      </div>
+    )
+  }
+
+  const expectedType = ROLE_ACCOUNT_TYPES[role]
+  const state = assignment?.state ?? 'unmapped'
+  const currentId = assignment?.accountId ?? null
+
+  const eligible = accounts.filter((account) => account.accountType === expectedType)
+  const filtered = search
+    ? eligible.filter(
+        (account) =>
+          account.name.toLowerCase().includes(search.toLowerCase()) || account.code.includes(search)
+      )
+    : eligible
+
+  const isDefaultUnused = DEFAULT_UNUSED_ROLES.includes(role)
+
+  return (
+    <div className='flex h-full min-h-0 flex-col gap-3 p-3'>
+      {/* `shrink-0 grow-0`: `FieldPanel` bakes `grow` into its own class list
+          (field-panel.tsx:45), which is right in a page body and wrong here - this
+          is a flex COLUMN, so it stretched three rows to fill 300px. */}
+      <FieldPanel
+        className='shrink-0 grow-0 p-0'
+        resizeId='accounting-role-map'
+        defaultLabelWidth={140}>
+        <FieldPanelRow title='Role' type={BaseType.STRING} showIcon>
+          <div className='flex min-h-8 items-center text-sm'>{ACCOUNT_ROLE_LABELS[role]}</div>
+        </FieldPanelRow>
+        <FieldPanelRow
+          title='Account type'
+          type={BaseType.ENUM}
+          showIcon
+          description='Declared per role and revalidated on every close, so only accounts of this type can be chosen.'>
+          <div className='flex min-h-8 items-center'>
+            <Badge variant='outline' size='xs'>
+              {accountTypeLabel(expectedType)}
+            </Badge>
+          </div>
+        </FieldPanelRow>
+        <FieldPanelRow title='Status' type={BaseType.ENUM} showIcon>
+          <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm'>
+            {state === 'confirmed' && (
+              <Badge variant='green' size='xs'>
+                Confirmed
+              </Badge>
+            )}
+            {state === 'suggested' && (
+              <Badge variant='amber' size='xs'>
+                <Sparkles className='size-3' />
+                Suggested
+              </Badge>
+            )}
+            {state === 'unmapped' && (
+              <Badge variant='destructive' size='xs'>
+                Not mapped
+              </Badge>
+            )}
+            {state === 'unused' && (
+              <Badge variant='outline' size='xs'>
+                Unused
+              </Badge>
+            )}
+          </div>
+        </FieldPanelRow>
+      </FieldPanel>
+
+      {state === 'suggested' && (
+        <div className='space-y-1 rounded-xl border border-amber-500/30 bg-amber-500/5 p-3'>
+          <p className='font-medium text-sm'>Why this was suggested</p>
+          <p className='text-muted-foreground text-xs'>
+            The account number and the statement type both match what the seeded default chart
+            assigns to this role, and no one has repointed it. That is a guess, not a decision.
+            Confirm it by picking it below, so a close is not resting on an assumption nobody made.
+          </p>
+        </div>
+      )}
+
+      {isDefaultUnused && state !== 'unused' && (
+        <div className='space-y-1 rounded-xl border p-3'>
+          <p className='font-medium text-sm'>Nothing emits this role today</p>
+          <p className='text-muted-foreground text-xs'>
+            {role === 'ppv'
+              ? 'Purchase price variance is a report, not a posting. Nothing accumulates in 5090 ' +
+                'during the year, so no builder ever emits this role.'
+              : 'Work in process is structurally zero. A received part maps to raw materials or ' +
+                'to finished goods and never to work in process, so no movement can reach it.'}{' '}
+            Marking it unused is the expected choice. A map that demanded all thirteen would block
+            every preview on two roles nothing can post to.
+          </p>
+        </div>
+      )}
+
+      {state === 'unused' ? (
+        <div className='space-y-2 rounded-xl border p-3'>
+          <p className='text-muted-foreground text-sm'>
+            This role is excused. Previews will not ask for it.
+          </p>
+          <Button variant='outline' size='sm' onClick={() => onToggleUnused(role)}>
+            <RotateCcw />
+            Mark used again
+          </Button>
+        </div>
+      ) : (
+        <>
+          {/* ⚠️ `InputSearch`'s own wrapper is `flex flex-1`, which means "fill the
+              row" at every other call site and "grow to 200px tall" inside this
+              flex column - which is what detached the magnifier from the input.
+              Wrapping in a non-flex, non-growing box is the call-site fix; the
+              shared component is correct for the row case and must not change. */}
+          <div className='shrink-0'>
+            <InputSearch
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={`Search ${accountTypeLabel(expectedType).toLowerCase()} accounts...`}
+            />
+          </div>
+
+          <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
+            <div className='flex flex-col gap-0.5 pr-1'>
+              {filtered.length === 0 ? (
+                <p className='p-3 text-center text-muted-foreground text-sm'>
+                  {search
+                    ? 'No matches.'
+                    : `No ${accountTypeLabel(expectedType).toLowerCase()} accounts in the chart yet.`}
+                </p>
+              ) : (
+                filtered.map((account) => (
+                  <button
+                    key={account.id}
+                    type='button'
+                    onClick={() => onAssign(role, account.id)}
+                    className={cn(
+                      'flex items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm',
+                      'hover:bg-primary-100',
+                      currentId === account.id && 'bg-primary-100 ring-1 ring-primary-200'
+                    )}>
+                    <span className='w-14 shrink-0 text-muted-foreground tabular-nums'>
+                      {account.code}
+                    </span>
+                    <span className='min-w-0 flex-1 truncate'>{account.name}</span>
+                    {!account.isActive && (
+                      <Badge variant='outline' size='xs' className='shrink-0'>
+                        Inactive
+                      </Badge>
+                    )}
+                    {currentId === account.id && (
+                      <Check className='size-4 shrink-0 text-green-600' />
+                    )}
+                  </button>
+                ))
+              )}
+            </div>
+          </ScrollArea>
+
+          <div className='flex flex-wrap gap-2 border-t pt-3'>
+            <Button variant='ghost' size='sm' disabled={!currentId} onClick={() => onClear(role)}>
+              Clear mapping
+            </Button>
+            <Button variant='outline' size='sm' onClick={() => onToggleUnused(role)}>
+              <Ban />
+              Mark unused
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/role-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/role-map-list.tsx
@@ -1,0 +1,272 @@
+// apps/web/src/components/accounting/ui/settings/role-map-list.tsx
+'use client'
+
+// The `G19` role map: the thirteen posting roles, grouped by the statement
+// classification each one's account must carry (13-accounting-ui.md §5.4).
+//
+// 🛑 A `Section` per group with a FLAT `TreeRow` list, not nested `TreeRow`
+// depth. The tree is two levels and a parent row would add a chevron that
+// answers nothing.
+//
+// ⚠️ Grouping is derived from `ROLE_ACCOUNT_TYPES`, which already declares the
+// expected type per role, so no new constant is needed. Note what it yields
+// today: asset 4, liability 5, expense 4. There are no revenue and no equity
+// roles, so only three of the five groups render. The loop is written over all
+// five anyway, so the day a revenue role is added it appears on its own.
+//
+// 🛑 There are NO phantom drafts on this tab. The thirteen roles are a fixed
+// vocabulary and a person cannot create one; adding a role is a code change to
+// `ACCOUNT_ROLES`.
+
+import {
+  ACCOUNT_ROLE_LABELS,
+  ACCOUNT_ROLES,
+  type AccountRole,
+  ROLE_ACCOUNT_TYPES,
+} from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Section } from '@auxx/ui/components/section'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Ban, Coins, CreditCard, Eraser, Pencil, Receipt, RotateCcw, Sparkles } from 'lucide-react'
+import { useAppsContext } from '~/components/apps/providers/apps-context'
+import {
+  ACCOUNT_TYPE_OPTIONS,
+  type ChartAccount,
+  formatAccount,
+  type RoleAssignment,
+} from './accounts-types'
+
+const ALL_ROLES = Object.values(ACCOUNT_ROLES) as AccountRole[]
+
+/** Statement-section icon, one per group. */
+const GROUP_ICONS: Record<string, typeof Coins> = {
+  asset: Coins,
+  liability: CreditCard,
+  equity: Coins,
+  revenue: Receipt,
+  expense: Receipt,
+}
+
+const QUICKBOOKS_APP_SLUG = 'quickbooks'
+
+interface RoleMapListProps {
+  assignments: Record<string, RoleAssignment>
+  accountsById: Map<string, ChartAccount>
+  selectedRole: AccountRole | null
+  onSelect: (role: AccountRole) => void
+  onClear: (role: AccountRole) => void
+  onToggleUnused: (role: AccountRole) => void
+}
+
+export function RoleMapList({
+  assignments,
+  accountsById,
+  selectedRole,
+  onSelect,
+  onClear,
+  onToggleUnused,
+}: RoleMapListProps) {
+  return (
+    <div className='flex flex-col gap-4 p-3'>
+      <ProviderStatusSection />
+
+      {ACCOUNT_TYPE_OPTIONS.map(({ value: type, label }) => {
+        const roles = ALL_ROLES.filter((role) => ROLE_ACCOUNT_TYPES[role] === type)
+        // Equity and revenue have no roles today, and an empty section headed
+        // "no roles here" would be noise rather than information.
+        if (roles.length === 0) return null
+
+        const Icon = GROUP_ICONS[type] ?? Coins
+        const needed = roles.filter((role) => assignments[role]?.state !== 'unused')
+        const mapped = needed.filter((role) => {
+          const state = assignments[role]?.state
+          return state === 'confirmed' || state === 'suggested'
+        })
+
+        return (
+          <Section
+            key={type}
+            collapsible={false}
+            icon={<Icon className='size-4' />}
+            title={label}
+            secondary={`${mapped.length} of ${needed.length} mapped`}>
+            <div className='flex flex-col gap-0.5'>
+              {roles.map((role) => (
+                <RoleRow
+                  key={role}
+                  role={role}
+                  assignment={assignments[role]}
+                  account={
+                    assignments[role]?.accountId
+                      ? accountsById.get(assignments[role].accountId as string)
+                      : undefined
+                  }
+                  selected={selectedRole === role}
+                  onSelect={onSelect}
+                  onClear={onClear}
+                  onToggleUnused={onToggleUnused}
+                />
+              ))}
+            </div>
+          </Section>
+        )
+      })}
+    </div>
+  )
+}
+
+function RoleRow({
+  role,
+  assignment,
+  account,
+  selected,
+  onSelect,
+  onClear,
+  onToggleUnused,
+}: {
+  role: AccountRole
+  assignment: RoleAssignment | undefined
+  account: ChartAccount | undefined
+  selected: boolean
+  onSelect: (role: AccountRole) => void
+  onClear: (role: AccountRole) => void
+  onToggleUnused: (role: AccountRole) => void
+}) {
+  const state = assignment?.state ?? 'unmapped'
+  const Icon = GROUP_ICONS[ROLE_ACCOUNT_TYPES[role]] ?? Coins
+
+  return (
+    <TreeRow
+      icon={<Icon className='size-4 text-muted-foreground' />}
+      title={ACCOUNT_ROLE_LABELS[role]}
+      secondaryFill
+      onToggleOpen={() => onSelect(role)}
+      rowClassName={cn(
+        'bg-primary-100/50 hover:bg-primary-100',
+        selected && 'bg-primary-100 ring-1 ring-primary-200',
+        state === 'unused' && 'opacity-60'
+      )}
+      secondary={<AssignmentSecondary state={state} account={account} />}
+      actions={
+        // Always `TreeRowButton`, never a raw icon Button: it owns the
+        // hover-fade, the sizing and the tooltip side, and it stops the click
+        // from reaching the row's own `onToggleOpen`.
+        <div className='flex items-center gap-1'>
+          {state !== 'unused' && (
+            <TreeRowButton tooltipText='Change account' onClick={() => onSelect(role)}>
+              <Pencil />
+            </TreeRowButton>
+          )}
+          {account && state !== 'unused' && (
+            <TreeRowButton tooltipText='Clear mapping' onClick={() => onClear(role)}>
+              <Eraser />
+            </TreeRowButton>
+          )}
+          <TreeRowButton
+            tooltipText={
+              state === 'unused'
+                ? 'Mark used again'
+                : 'Mark unused. Nothing posts to it, so it stops blocking a preview.'
+            }
+            onClick={() => onToggleUnused(role)}>
+            {state === 'unused' ? <RotateCcw /> : <Ban />}
+          </TreeRowButton>
+        </div>
+      }
+    />
+  )
+}
+
+/**
+ * The mapped account, or why there isn't one.
+ *
+ * ⚠️ A suggested match reads visibly differently from a confirmed one. A
+ * suggestion is auxx's guess from the seeded default chart; nobody has agreed
+ * to it, and `resolveRoles` will happily post to whatever it names.
+ */
+function AssignmentSecondary({
+  state,
+  account,
+}: {
+  state: RoleAssignment['state']
+  account: ChartAccount | undefined
+}) {
+  if (state === 'unused') {
+    return (
+      <span className='flex items-center gap-1.5 text-muted-foreground text-xs'>
+        <Badge variant='outline' size='xs'>
+          Unused
+        </Badge>
+        Nothing posts to this role
+      </span>
+    )
+  }
+
+  if (!account) {
+    return (
+      <span className='flex items-center gap-1.5 text-xs'>
+        <Badge variant='destructive' size='xs'>
+          Not mapped
+        </Badge>
+        <span className='text-muted-foreground'>Every preview refuses until this is set</span>
+      </span>
+    )
+  }
+
+  if (state === 'suggested') {
+    return (
+      <span className='flex min-w-0 items-center gap-1.5 text-xs'>
+        <Badge variant='amber' size='xs' className='shrink-0'>
+          <Sparkles className='size-3' />
+          Suggested
+        </Badge>
+        <span className='truncate text-amber-700 dark:text-amber-400'>
+          {formatAccount(account)}
+        </span>
+      </span>
+    )
+  }
+
+  return <span className='truncate text-muted-foreground text-xs'>{formatAccount(account)}</span>
+}
+
+/**
+ * Whether an accounting provider is connected.
+ *
+ * 🛑 "None connected" is a NORMAL state, not a warning. `NoneAccountingProvider`
+ * makes it first class: the entry is still built, balanced and persisted, and
+ * the result is `not_connected` rather than a failure. Nagging for a provider
+ * here would contradict the decision the whole poster is built on.
+ */
+function ProviderStatusSection() {
+  const { appInstallations, appConnections } = useAppsContext()
+
+  const installation = appInstallations.find((inst) => inst.app.slug === QUICKBOOKS_APP_SLUG)
+  const connected = installation
+    ? appConnections.some(
+        (conn) => conn.appId === installation.app.id && conn.connectionStatus === 'connected'
+      )
+    : false
+
+  return (
+    <Section
+      collapsible={false}
+      icon={<CreditCard className='size-4' />}
+      title='Accounting provider'
+      secondary={connected ? 'QuickBooks Online' : 'None connected'}>
+      <div className='rounded-xl border p-3 text-sm'>
+        <div className='flex flex-wrap items-center gap-2'>
+          <Badge variant={connected ? 'green' : 'outline'} size='xs'>
+            {connected ? 'Connected' : 'None connected'}
+          </Badge>
+          <span className='text-muted-foreground text-xs'>
+            {connected
+              ? 'Posted entries are mirrored into QuickBooks Online and carry a deep link back.'
+              : 'Entries are still built, balanced and stored here. Nothing is blocked by this.'}
+          </span>
+        </div>
+      </div>
+    </Section>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/setup-status-section.tsx
+++ b/apps/web/src/components/accounting/ui/settings/setup-status-section.tsx
@@ -1,0 +1,196 @@
+// apps/web/src/components/accounting/ui/settings/setup-status-section.tsx
+'use client'
+
+// Setup state, the readiness list, and Finalize (13-accounting-ui.md §3.4).
+//
+// 🛑 `accounting.setupState` is rendered as STATUS, never as an editable select.
+// It moves by action: finalizing is an assertion about the books, not a value
+// somebody picks off a dropdown. The catalog does declare it as a
+// SINGLE_SELECT, and that is exactly the shape this screen must not expose.
+//
+// 🛑 Readiness comes from the shared pure predicate `resolveSetupReadiness`
+// over the settings record, not from a query. One authority, two callers: this
+// page client-side over hydrated `useSettings`, and `signals.ts` server-side
+// over cached settings for the checklist widget. Writing the arithmetic twice
+// is what would rot.
+
+import type { SetupReadiness } from '@auxx/lib/postings/client'
+import { toActorId } from '@auxx/types/actor'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { format, parseISO } from 'date-fns'
+import { AlertTriangle, ArrowRight, Check, ShieldCheck } from 'lucide-react'
+import Link from 'next/link'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { SettingsSection } from '~/components/global/settings-page'
+import { useActor } from '~/components/resources/hooks'
+import { BaseType } from '~/components/workflow/types'
+import { READINESS_LINKS } from './accounting-settings-keys'
+
+interface SetupStatusSectionProps {
+  readiness: SetupReadiness
+  /** `accounting.setupFinalizedAt`, ISO 8601. */
+  finalizedAt: string | null
+  /** `accounting.setupFinalizedByUserId`. */
+  finalizedByUserId: string | null
+  /** True while any section on this page holds unsaved edits. */
+  hasUnsavedChanges: boolean
+  isFinalizing: boolean
+  onFinalize: () => void
+}
+
+export function SetupStatusSection({
+  readiness,
+  finalizedAt,
+  finalizedByUserId,
+  hasUnsavedChanges,
+  isFinalizing,
+  onFinalize,
+}: SetupStatusSectionProps) {
+  const { finalized, requirements, settingsReady } = readiness
+
+  // Batched through the actor store, so naming the person who finalized costs
+  // no dedicated query.
+  const { actor } = useActor({
+    actorId: finalizedByUserId ? toActorId('user', finalizedByUserId) : null,
+  })
+
+  const blockedReason = finalized
+    ? undefined
+    : hasUnsavedChanges
+      ? 'Save your changes first. Readiness is computed from saved settings, so a dirty ' +
+        'form and this list would disagree.'
+      : !settingsReady
+        ? 'Every requirement below has to be met first.'
+        : undefined
+
+  return (
+    <SettingsSection
+      icon={ShieldCheck}
+      title='Setup status'
+      description='Finalizing freezes the opening baseline. Nothing may post until it is finalized.'>
+      <FieldPanel className='mt-1 p-0' resizeId='accounting-setup-status' defaultLabelWidth={220}>
+        <FieldPanelRow
+          title='State'
+          type={BaseType.ENUM}
+          showIcon
+          description='Moves by action, not by picking a value. Finalize below is the only way in.'>
+          <div className='flex min-h-8 flex-wrap items-center gap-2'>
+            <Badge variant={finalized ? 'green' : 'amber'} size='sm'>
+              {finalized ? 'Finalized' : 'Draft'}
+            </Badge>
+            <span className='text-muted-foreground text-xs'>
+              {finalized
+                ? 'Postings are permitted.'
+                : 'Every posting path refuses while this reads draft.'}
+            </span>
+          </div>
+        </FieldPanelRow>
+
+        {finalized && (
+          <FieldPanelRow
+            title='Finalized'
+            type={BaseType.DATETIME}
+            showIcon
+            description='Stamped when Finalize was pressed. Provenance, not an editable field.'>
+            <div className='flex min-h-8 items-center text-sm'>
+              {finalizedAt ? (
+                format(parseISO(finalizedAt), 'PPp')
+              ) : (
+                <span className='text-muted-foreground'>Not recorded</span>
+              )}
+            </div>
+          </FieldPanelRow>
+        )}
+
+        {finalized && (
+          <FieldPanelRow
+            title='Finalized by'
+            type={BaseType.ACTOR}
+            showIcon
+            description='Provenance, not an editable field.'>
+            <div className='flex min-h-8 items-center text-sm'>
+              {finalizedByUserId ? (
+                (actor?.name ?? finalizedByUserId)
+              ) : (
+                <span className='text-muted-foreground'>Not recorded</span>
+              )}
+            </div>
+          </FieldPanelRow>
+        )}
+      </FieldPanel>
+
+      <div className='space-y-3 rounded-xl border p-3'>
+        <p className='font-medium text-sm'>Requirements</p>
+
+        <ul className='space-y-2'>
+          {requirements.map((requirement) => {
+            const link = READINESS_LINKS[requirement.key]
+            return (
+              <li key={requirement.key} className='flex items-start gap-2 text-sm'>
+                {requirement.met ? (
+                  <Check className='mt-0.5 size-4 shrink-0 text-green-600' />
+                ) : (
+                  <AlertTriangle className='mt-0.5 size-4 shrink-0 text-amber-600' />
+                )}
+                <div className='min-w-0 space-y-0.5'>
+                  <p className={requirement.met ? 'text-muted-foreground' : undefined}>
+                    {link?.label ?? requirement.key}
+                  </p>
+                  {!requirement.met && requirement.reason && (
+                    <p className='text-muted-foreground text-xs'>{requirement.reason}</p>
+                  )}
+                  {!requirement.met && link && (
+                    <Link
+                      href={link.href}
+                      className='inline-flex items-center gap-1 text-primary-600 text-xs hover:underline'>
+                      Fix this <ArrowRight className='size-3' />
+                    </Link>
+                  )}
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+
+        {/*
+          The list is settings-derived and complete for what it claims. Three
+          more requirements are facts about ROWS rather than settings and are
+          deliberately absent from the predicate: the standard-cost roll (part
+          rows), the account role map (`GlRoleAssignment` rows), and whether a
+          first entry is posted (`GlPosting` rows). Each belongs to a page that
+          already loads them. Saying so beats a list that silently under-reports.
+        */}
+        <p className='text-muted-foreground text-xs'>
+          Two more things have to be true before a month can close, and neither is a setting: every
+          part carries a standard cost (roll it below), and every account role is mapped on{' '}
+          <Link href='/app/accounting/settings/accounts' className='hover:underline'>
+            Accounts
+          </Link>
+          . A preview refuses by naming the specific row, which is something no checklist can do.
+        </p>
+
+        <div className='flex flex-wrap items-center justify-end gap-3 border-t pt-3'>
+          {blockedReason && (
+            <span className='mr-auto text-muted-foreground text-xs'>{blockedReason}</span>
+          )}
+          {finalized && (
+            <span className='mr-auto text-muted-foreground text-xs'>
+              Already finalized. Correcting the baseline now goes through reversal and re-entry,
+              never an edit to setup history.
+            </span>
+          )}
+          <Button
+            variant='outline'
+            size='sm'
+            loading={isFinalizing}
+            loadingText='Finalizing...'
+            disabled={finalized || !settingsReady || hasUnsavedChanges || isFinalizing}
+            onClick={onFinalize}>
+            Finalize setup
+          </Button>
+        </div>
+      </div>
+    </SettingsSection>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/standard-cost-section.tsx
+++ b/apps/web/src/components/accounting/ui/settings/standard-cost-section.tsx
@@ -1,0 +1,254 @@
+// apps/web/src/components/accounting/ui/settings/standard-cost-section.tsx
+'use client'
+
+// The org-wide standard-cost roll, folded into the General settings page
+// (13-accounting-ui.md §5.4).
+//
+// 🛑 A roll restates the balance sheet, so this is never a button that just
+// fires. THE PREVIEW IS THE COMPONENT: `builds.previewRoll` runs the same plan
+// the mutation will run and reports the revaluation delta per part and summed,
+// plus every part that cannot be valued and why, in plain words. Confirm sits
+// BELOW the numbers, not beside a trigger.
+//
+// ⚠️ `builds.previewRoll` and `builds.roll` take `partIds` as OPTIONAL, so
+// omitting it is already the org-wide roll this page wants. No new procedure.
+//
+// 🛑 THE SECTION IS GATED, NEVER THE PAGE. Both procedures are
+// `capabilityProcedure` + `assertEditEntity(part def)` rather than a `ledger.*`
+// key, so a bookkeeper with full ledger access and no part rights must still
+// reach the period and Finalize rows above. They see this section read-only,
+// with who to ask.
+
+import { FieldType } from '@auxx/database/enums'
+import { Button } from '@auxx/ui/components/button'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
+import { Calculator, Lock } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { SettingsSection } from '~/components/global/settings-page'
+import { useResource } from '~/components/resources'
+import { BaseType } from '~/components/workflow/types'
+import { useAccess } from '~/providers/capabilities-provider'
+import { api } from '~/trpc/react'
+
+/** Why a part could not be valued, in words a person can act on. */
+const SKIP_REASON_LABEL: Record<string, string> = {
+  'no-live-cost': 'no supplier price and no priced bill of materials',
+  'no-bill-of-materials': 'classified as buildable but has no bill of materials',
+}
+
+/** How many skipped parts to name before summarising the rest. */
+const SKIPPED_VISIBLE = 8
+
+export function StandardCostSection() {
+  // The roll's authority is edit on the `part` definition, so the gate resolves
+  // the same def id the server asserts against rather than a coarser role check.
+  const { resource: partsResource } = useResource('parts')
+  const { canEditEntity, isLoading: accessLoading } = useAccess()
+  const partDefId = partsResource?.entityDefinitionId ?? null
+  const canRoll = partDefId ? canEditEntity(partDefId) : false
+
+  const [effectiveAt, setEffectiveAt] = useState<string>(() => new Date().toISOString())
+
+  // A fresh effective date whenever the section regains the ability to roll — a
+  // stale one left over from a tab somebody abandoned yesterday would silently
+  // backdate the roll.
+  useEffect(() => {
+    if (canRoll) setEffectiveAt(new Date().toISOString())
+  }, [canRoll])
+
+  const preview = api.builds.previewRoll.useQuery(
+    { effectiveAt: new Date(effectiveAt) },
+    { enabled: canRoll, retry: false, refetchOnWindowFocus: false }
+  )
+
+  const utils = api.useUtils()
+  const roll = api.builds.roll.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Failed to roll standard cost', description: error.message }),
+  })
+
+  const plan = preview.data
+  const changed = plan?.lines.filter((line) => line.changed) ?? []
+
+  async function handleRoll() {
+    try {
+      await roll.mutateAsync({ effectiveAt: new Date(effectiveAt) })
+      await utils.builds.previewRoll.invalidate()
+    } catch {
+      // onError above already surfaced the toast.
+    }
+  }
+
+  return (
+    <SettingsSection
+      icon={Calculator}
+      title='Standard cost'
+      description='Freeze today&apos;s cost as the value every stock movement is stamped with, across every part.'>
+      {!canRoll ? (
+        <div className='flex items-start gap-2 rounded-xl border bg-muted/40 p-3 text-sm'>
+          <Lock className='mt-0.5 size-4 shrink-0 text-muted-foreground' />
+          <div className='space-y-1'>
+            <p className='font-medium'>Read-only</p>
+            <p className='text-muted-foreground text-xs'>
+              {accessLoading
+                ? 'Checking your access to parts...'
+                : 'Rolling standard cost needs edit access to Parts, which is a separate ' +
+                  'permission from the ledger. Ask an administrator to grant it, or ask ' +
+                  'someone who maintains parts to run the roll. Everything else on this page ' +
+                  'is unaffected.'}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <>
+          <FieldPanel
+            className='mt-1 p-0'
+            resizeId='accounting-standard-cost'
+            defaultLabelWidth={220}>
+            <FieldPanelRow
+              title='Effective'
+              type={BaseType.DATE}
+              showIcon
+              description='When the new standards take effect.'>
+              <FieldInputAdapter
+                fieldType={FieldType.DATETIME}
+                value={effectiveAt}
+                onChange={(val) => setEffectiveAt((val as string) ?? new Date().toISOString())}
+                disabled={roll.isPending}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+
+          {preview.isPending ? (
+            <div className='space-y-2'>
+              <Skeleton className='h-5 w-full' />
+              <Skeleton className='h-5 w-full' />
+              <Skeleton className='h-5 w-2/3' />
+            </div>
+          ) : preview.error ? (
+            // An unpriced component surfaces HERE rather than half-way through a
+            // write: the server refuses to value a parent whose child has no
+            // standard, because treating it as zero understates the finished good.
+            <p className='rounded-md bg-destructive/10 p-2 text-destructive text-xs'>
+              {preview.error.message}
+            </p>
+          ) : plan ? (
+            <div className='space-y-3 rounded-xl border p-3'>
+              {changed.length === 0 ? (
+                <p className='text-muted-foreground text-xs'>
+                  Nothing to roll. Every part&apos;s standard already matches today&apos;s cost.
+                </p>
+              ) : (
+                <div className='space-y-1'>
+                  <p className='text-muted-foreground text-xs'>
+                    {changed.length} part{changed.length === 1 ? '' : 's'} would be revalued:
+                  </p>
+                  <ScrollArea className='max-h-56' allowScrollChaining>
+                    <div className='divide-y divide-border/50'>
+                      {changed.map((line) => (
+                        <div
+                          key={line.partId}
+                          className='flex items-baseline gap-2 py-1.5 text-xs tabular-nums'>
+                          <span className='flex-1 truncate'>{line.partName ?? line.partId}</span>
+                          <span className='text-muted-foreground'>
+                            {line.previousStandardCost == null
+                              ? 'not rolled'
+                              : formatCurrency(line.previousStandardCost)}
+                          </span>
+                          <span className='text-muted-foreground'>&rarr;</span>
+                          <span className='font-medium'>{formatCurrency(line.standardCost)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </ScrollArea>
+                </div>
+              )}
+
+              {/* The number this whole preview exists for. */}
+              <div className='space-y-1 border-t border-border/50 pt-2 text-xs tabular-nums'>
+                <SummaryRow
+                  label='Inventory revaluation'
+                  hint='(new standard minus old) x qty on hand'
+                  value={plan.revaluationDelta}
+                  signed
+                />
+                {plan.initialValue !== 0 && (
+                  <SummaryRow
+                    label='First valuation'
+                    hint='parts that had no standard before, so not a revaluation'
+                    value={plan.initialValue}
+                  />
+                )}
+              </div>
+
+              {plan.skipped.length > 0 && (
+                <div className='space-y-1 border-t border-border/50 pt-2 text-xs'>
+                  <p className='text-muted-foreground'>
+                    Not valued ({plan.skipped.length}). Left untouched, never written as zero:
+                  </p>
+                  <ul className='space-y-0.5'>
+                    {plan.skipped.slice(0, SKIPPED_VISIBLE).map((skip) => (
+                      <li key={skip.partId} className='truncate text-muted-foreground'>
+                        {skip.partName ?? skip.partId} &mdash;{' '}
+                        {SKIP_REASON_LABEL[skip.reason] ?? skip.reason}
+                      </li>
+                    ))}
+                  </ul>
+                  {plan.skipped.length > SKIPPED_VISIBLE && (
+                    <p className='text-muted-foreground'>
+                      and {plan.skipped.length - SKIPPED_VISIBLE} more.
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {/* Confirm sits below the numbers it confirms, deliberately. */}
+              <div className='flex justify-end border-t border-border/50 pt-3'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  loading={roll.isPending}
+                  loadingText='Rolling...'
+                  disabled={changed.length === 0 || roll.isPending}
+                  onClick={handleRoll}>
+                  Roll standard cost
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
+    </SettingsSection>
+  )
+}
+
+/** One summed number with the arithmetic that produced it spelled out. */
+function SummaryRow({
+  label,
+  hint,
+  value,
+  signed,
+}: {
+  label: string
+  hint: string
+  value: number
+  signed?: boolean
+}) {
+  const sign = signed && value > 0 ? '+' : ''
+  return (
+    <div className='flex items-baseline justify-between gap-2'>
+      <span className='text-muted-foreground'>
+        {label} <span className='text-[10px]'>{hint}</span>
+      </span>
+      <span className='font-medium'>
+        {sign}
+        {formatCurrency(value)}
+      </span>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/setup-wizard/accounting-setup-wizard.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/accounting-setup-wizard.tsx
@@ -1,0 +1,149 @@
+// apps/web/src/components/accounting/ui/setup-wizard/accounting-setup-wizard.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
+import { useEffect, useRef, useState } from 'react'
+import { api } from '~/trpc/react'
+import { WizardAccountsPage } from './wizard-accounts-page'
+import { WizardCostingPage } from './wizard-costing-page'
+import { WizardDonePage } from './wizard-done-page'
+import { WizardOpeningPage } from './wizard-opening-page'
+import { WizardPeriodPage } from './wizard-period-page'
+import type { WizardLeaveDirection, WizardStepHandle } from './wizard-step-handle'
+import { WizardWelcomePage } from './wizard-welcome-page'
+
+const PAGES = ['welcome', 'period', 'opening', 'costing', 'accounts', 'done'] as const
+type WizardPage = (typeof PAGES)[number]
+
+const PAGE_TITLES: Record<WizardPage, string> = {
+  welcome: 'Set up accounting',
+  period: 'Accounting period',
+  opening: 'Opening balances',
+  costing: 'Costing',
+  accounts: 'Account map',
+  done: 'Finalize',
+}
+
+export interface AccountingSetupWizardProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * `AccountingSetupWizard` (plans/money/tasks/13-accounting-ui.md section 3.3) - a six-page
+ * `DialogNav` wizard covering the four things that have to be true before a month-end entry can
+ * legally be posted (accounting period, opening balances, costing, the account map) plus a
+ * "finalize" page that freezes the opening baseline.
+ *
+ * 🛑 Pages write REAL data through the settings catalog keys, never a wizard-local progress
+ * record. That is task 12's scalar-keys decision and it is what lets the settings pages, the
+ * checklist and the Post gate all read one source and agree.
+ *
+ * Pages holding a dirty draft expose a {@link WizardStepHandle} the shell consults before leaving
+ * the page in any direction - saving a dirty draft, or blocking Continue when the draft is
+ * invalid - so Back, Continue and "Set up later" never lose work. Only Continue is ever refused;
+ * see `wizard-step-handle.ts` for why the exits stay open.
+ *
+ * "Set up later" (any page) and reaching the last page both call `setWizardCompleted` for the
+ * `accounting` checklist - one timestamp, so the wizard never auto-opens again either way.
+ */
+export function AccountingSetupWizard({ open, onOpenChange }: AccountingSetupWizardProps) {
+  const [page, setPage] = useState<WizardPage>('welcome')
+  const periodRef = useRef<WizardStepHandle | null>(null)
+  const openingRef = useRef<WizardStepHandle | null>(null)
+  const costingRef = useRef<WizardStepHandle | null>(null)
+
+  // Reset to the first page each time the wizard is (re)opened.
+  useEffect(() => {
+    if (open) setPage('welcome')
+  }, [open])
+
+  const utils = api.useUtils()
+  // Write the stamp into the cache up front, then invalidate. `finish()` is often the last thing
+  // that happens before a navigation away from `/app/accounting` (the done page's "Open the
+  // ledger" link), which unmounts the gate - an invalidation that lands after that only marks the
+  // entry stale, so the stale `wizardCompletedAt: null` is what a remounted gate would read.
+  const setWizardCompleted = api.gettingStarted.setWizardCompleted.useMutation({
+    onMutate: () => {
+      utils.gettingStarted.getStatus.setData({ checklist: 'accounting' }, (prev) =>
+        prev ? { ...prev, wizardCompletedAt: new Date().toISOString() } : prev
+      )
+    },
+    // `onSettled`, not `onSuccess`: a failed write must not leave the optimistic stamp standing.
+    onSettled: () => utils.gettingStarted.getStatus.invalidate(),
+  })
+
+  const index = PAGES.indexOf(page)
+
+  /** Ask the current page (if it registered a handle) whether it is safe to navigate away. */
+  const attemptLeave = (direction: WizardLeaveDirection) => {
+    const handle =
+      page === 'period'
+        ? periodRef.current
+        : page === 'opening'
+          ? openingRef.current
+          : page === 'costing'
+            ? costingRef.current
+            : null
+    return handle?.tryAdvance(direction) ?? true
+  }
+
+  const goNext = () => {
+    if (attemptLeave('next')) setPage(PAGES[Math.min(index + 1, PAGES.length - 1)] ?? 'done')
+  }
+  const goBack = () => {
+    if (attemptLeave('back')) setPage(PAGES[Math.max(index - 1, 0)] ?? 'welcome')
+  }
+  const finish = () => {
+    if (!attemptLeave('exit')) return
+    setWizardCompleted.mutate({ checklist: 'accounting' })
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && finish()}>
+      <DialogContent size='content' position='tc' innerClassName='p-0'>
+        <DialogNav
+          title='Set up accounting'
+          description='A few things to configure before your books can be closed from Auxx.'
+          onBack={page !== 'welcome' && page !== 'done' ? goBack : undefined}
+          crumbs={[{ label: PAGE_TITLES[page] }]}
+        />
+
+        <DialogNavPages value={page}>
+          <DialogNavPage value='welcome' size='md'>
+            <WizardWelcomePage />
+          </DialogNavPage>
+          <DialogNavPage value='period' size='lg'>
+            <WizardPeriodPage ref={periodRef} />
+          </DialogNavPage>
+          <DialogNavPage value='opening' size='xl'>
+            <WizardOpeningPage ref={openingRef} />
+          </DialogNavPage>
+          <DialogNavPage value='costing' size='lg'>
+            <WizardCostingPage ref={costingRef} />
+          </DialogNavPage>
+          <DialogNavPage value='accounts' size='lg'>
+            <WizardAccountsPage />
+          </DialogNavPage>
+          <DialogNavPage value='done' size='md'>
+            <WizardDonePage onFinish={finish} />
+          </DialogNavPage>
+        </DialogNavPages>
+
+        {page !== 'done' && (
+          <DialogFooter className='border-t px-4 py-3 sm:justify-between'>
+            <Button variant='ghost' size='sm' onClick={finish}>
+              Set up later
+            </Button>
+            <Button variant='outline' size='sm' onClick={goNext}>
+              {page === 'welcome' ? 'Get started' : 'Continue'}
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/accounting/ui/setup-wizard/setup-wizard-gate.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/setup-wizard-gate.tsx
@@ -1,0 +1,99 @@
+// apps/web/src/components/accounting/ui/setup-wizard/setup-wizard-gate.tsx
+'use client'
+
+import type { AccountingGoalKey } from '@auxx/lib/getting-started/client'
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { useQueryState } from 'nuqs'
+import { useEffect, useState } from 'react'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { api } from '~/trpc/react'
+import { AccountingSetupWizard } from './accounting-setup-wizard'
+
+/**
+ * The setup goals - an org where all of these are already done never sees the wizard.
+ *
+ * 🛑 `post-first-entry` is deliberately NOT here. Closing a month is what the module is FOR, not
+ * part of setting it up: an org that has finished setup but has not yet had a month to close must
+ * not be handed a modal telling it to go and post something.
+ */
+const WIZARD_GOAL_KEYS: readonly AccountingGoalKey[] = [
+  'set-accounting-period',
+  'set-opening-balances',
+  'set-costing',
+  'map-accounts',
+  'finalize-setup',
+]
+
+/**
+ * Auto-opens `AccountingSetupWizard` the first time an admin/owner visits `/app/accounting`.
+ * Mounted once from the accounting layout - renders nothing besides the (closed, by default)
+ * dialog.
+ *
+ * Opens when ALL of:
+ * - the accounting checklist's `wizardCompletedAt` is `null` (never finished or skipped) and the
+ *   checklist is not dismissed - read from FRESH status only, never a stale cache entry
+ * - the current user is ADMIN/OWNER (plain role check - never redirects, just does not render)
+ * - `FeatureKey.accounting` is enabled for the org
+ * - the five setup goals are not already all complete - an org that configured everything from the
+ *   settings pages never sees it
+ *
+ * `/app/accounting?setup=wizard` opens it regardless of all of the above except the role and
+ * feature checks - the only way back into the wizard once it has been finished or skipped, and the
+ * only way to see it at all on an org that already satisfies the goals. That is the link
+ * `AccountingChecklistPanel`'s "Set up accounting" button pushes.
+ */
+export function AccountingSetupWizardGate() {
+  const { isAdminOrOwner } = useUser()
+  const { hasAccess } = useFeatureFlags()
+  const accountingEnabled = hasAccess(FeatureKey.accounting)
+  const shouldQuery = isAdminOrOwner && accountingEnabled
+
+  // `isStale` is the load-bearing bit: the gate unmounts whenever you leave `/app/accounting`, so
+  // a `getStatus` invalidation issued while you are away only MARKS the entry invalid (react-query
+  // refetches active queries only). Coming back, the remounted gate is handed that stale
+  // `wizardCompletedAt: null` synchronously and would auto-open before the refetch lands.
+  const { data: status, isStale } = api.gettingStarted.getStatus.useQuery(
+    { checklist: 'accounting' },
+    { enabled: shouldQuery }
+  )
+
+  const [setupParam, setSetupParam] = useQueryState('setup')
+  const [open, setOpen] = useState(false)
+  const [hasAutoOpened, setHasAutoOpened] = useState(false)
+
+  const allWizardGoalsComplete =
+    !!status && WIZARD_GOAL_KEYS.every((key) => status.completedGoals.includes(key))
+
+  // The explicit ask, in its own effect and NOT behind `hasAutoOpened`. It needs no status at all,
+  // so it works before the query resolves and on an org whose goals are long since complete.
+  //
+  // ⚠️ Separate from the auto-open branch below because this gate lives in the module LAYOUT: the
+  // checklist panel opens the wizard by setting this param on a page that never unmounts, so a
+  // once-only guard would make the button work exactly once per visit. The param is cleared on
+  // close, which is also what keeps the URL honest after the dialog is gone.
+  useEffect(() => {
+    if (!shouldQuery || setupParam !== 'wizard') return
+    setOpen(true)
+  }, [shouldQuery, setupParam])
+
+  useEffect(() => {
+    if (hasAutoOpened || !shouldQuery || setupParam === 'wizard') return
+    if (!status || isStale) return
+    if (status.wizardCompletedAt !== null || status.dismissed || allWizardGoalsComplete) return
+    setOpen(true)
+    setHasAutoOpened(true)
+  }, [hasAutoOpened, shouldQuery, setupParam, status, isStale, allWizardGoalsComplete])
+
+  if (!shouldQuery) return null
+
+  return (
+    <AccountingSetupWizard
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next && setupParam === 'wizard') setSetupParam(null)
+      }}
+    />
+  )
+}

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
@@ -1,0 +1,126 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
+'use client'
+
+import { ACCOUNT_ROLE_LABELS, type AccountRole } from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { ArrowUpRight } from 'lucide-react'
+import Link from 'next/link'
+import {
+  FIXTURE_ROLE_ACCOUNTS,
+  FIXTURE_ROLE_ASSIGNMENT_STATE,
+  type FixtureRoleAssignmentState,
+} from '~/components/accounting/fixtures'
+
+const ROLES_HREF = '/app/accounting/settings/accounts?s=roles'
+
+const STATE_BADGE: Record<
+  FixtureRoleAssignmentState,
+  { label: string; variant: 'green' | 'amber' | 'destructive' | 'gray' }
+> = {
+  confirmed: { label: 'Confirmed', variant: 'green' },
+  suggested: { label: 'Suggested', variant: 'amber' },
+  unmapped: { label: 'Not mapped', variant: 'destructive' },
+  unused: { label: 'Not used', variant: 'gray' },
+}
+
+/** Display order: the ones needing attention first, then confirmed, then excused. */
+const STATE_ORDER: Record<FixtureRoleAssignmentState, number> = {
+  unmapped: 0,
+  suggested: 1,
+  confirmed: 2,
+  unused: 3,
+}
+
+interface RoleRow {
+  role: string
+  label: string
+  account: string | null
+  state: FixtureRoleAssignmentState
+}
+
+/**
+ * Page 5 of `AccountingSetupWizard` - a READ-ONLY summary of the account role map.
+ *
+ * 🛑 Deliberately not an editor. The full map, with the account picker and the reason each account
+ * was suggested, lives on `settings/accounts` and this page links there rather than shipping a
+ * second copy that could disagree with it. Dispatch's workers page does the same thing.
+ *
+ * ⚠️ Two roles ship excused rather than unmapped, and that is a decision. Nothing emits `ppv`
+ * under L1 (purchase price variance is a report, not a posting) and `inventory_wip` is
+ * structurally unreachable, so a map that demanded all thirteen would block every Preview on two
+ * roles nothing can ever post to.
+ *
+ * 🛑 PLACEHOLDER DATA. There is no procedure that can read a `GlRoleAssignment` yet
+ * (13-accounting-ui.md section 4), so the counts come from
+ * `~/components/accounting/fixtures`. Swap the source, keep the rendering.
+ */
+export function WizardAccountsPage() {
+  const rows: RoleRow[] = Object.entries(FIXTURE_ROLE_ASSIGNMENT_STATE)
+    .map(([role, state]) => {
+      const account = FIXTURE_ROLE_ACCOUNTS[role as AccountRole]
+      return {
+        role,
+        label: ACCOUNT_ROLE_LABELS[role as AccountRole] ?? role,
+        account: account ? `${account.code} · ${account.name}` : null,
+        state,
+      }
+    })
+    .sort((a, b) => STATE_ORDER[a.state] - STATE_ORDER[b.state] || a.label.localeCompare(b.label))
+
+  const required = rows.filter((row) => row.state !== 'unused')
+  const confirmed = required.filter((row) => row.state === 'confirmed').length
+  const outstanding = required.filter((row) => row.state !== 'confirmed')
+
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      <p className='text-muted-foreground text-sm'>
+        Every line of a journal entry names an account by role, and each role has to point at a real
+        account in your chart. Nothing can be previewed until they do.
+      </p>
+
+      <div className='flex flex-wrap items-center gap-2'>
+        <span className='font-medium text-foreground text-sm'>
+          {confirmed} of {required.length} roles confirmed
+        </span>
+        {outstanding.length > 0 && (
+          <span className='text-muted-foreground text-sm'>
+            {outstanding.length} still need{outstanding.length === 1 ? 's' : ''} a look
+          </span>
+        )}
+      </div>
+
+      <div className='overflow-hidden rounded-xl border'>
+        <ul className='flex flex-col'>
+          {rows.map((row) => (
+            <li
+              key={row.role}
+              className='flex items-center justify-between gap-2 border-b px-3 py-1.5 text-sm last:border-b-0'>
+              <span className='min-w-0 flex-1 truncate'>{row.label}</span>
+              <span className='hidden min-w-0 flex-1 truncate text-muted-foreground sm:block'>
+                {row.account ?? '—'}
+              </span>
+              <Badge variant={STATE_BADGE[row.state].variant} size='sm' className='shrink-0'>
+                {STATE_BADGE[row.state].label}
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <p className='text-muted-foreground text-xs'>
+        A suggested account is a guess from the account number and name. Confirm it so a later
+        renumber cannot quietly move where a role posts.
+      </p>
+
+      <div>
+        <Button variant='outline' size='sm' asChild>
+          <Link href={ROLES_HREF}>
+            Open the account map
+            <ArrowUpRight />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-costing-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-costing-page.tsx
@@ -1,0 +1,120 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-costing-page.tsx
+'use client'
+
+import { readSettingMinorUnits } from '@auxx/lib/postings/client'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { ArrowUpRight } from 'lucide-react'
+import Link from 'next/link'
+import { forwardRef, useImperativeHandle } from 'react'
+import { FieldPanel } from '~/components/global/forms/field-panel'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useAccountingSetupDraft } from '../../hooks/use-accounting-setup-draft'
+import type { WizardStepHandle } from './wizard-step-handle'
+
+const LABOR_KEY = 'manufacturing.assemblyLaborCostPerUnit'
+const OVERHEAD_KEY = 'manufacturing.overheadCostPerUnit'
+
+const DRAFT_KEYS = [LABOR_KEY, OVERHEAD_KEY] as const
+
+/**
+ * Page 4 of `AccountingSetupWizard` - the two absorption rates, plus a pointer at the
+ * standard-cost roll.
+ *
+ * ⚠️ An unset rate is NOT zero. `loadAbsorptionRates` returns `null` for one and must keep doing
+ * so: a `null` collapsing to `0` absorbs nothing while looking like it worked, and the resulting
+ * entry understates inventory with no signal anywhere. So this page saves `null` for a cleared
+ * field and the readiness predicate reports it as unconfigured.
+ *
+ * 🛑 The standard-cost roll is an ACTION over part rows, not a settings field, and its full
+ * surface - the preview of what would change, the list of parts with no live cost - lives on
+ * `settings/general`. This page links there rather than carrying a second copy of it, because the
+ * roll needs part-def edit rights that the rest of the wizard does not.
+ */
+export const WizardCostingPage = forwardRef<WizardStepHandle>(
+  function WizardCostingPage(_props, ref) {
+    const { draft, dirty, save, controlled } = useAccountingSetupDraft(DRAFT_KEYS)
+
+    const labor = readSettingMinorUnits(draft[LABOR_KEY])
+    const overhead = readSettingMinorUnits(draft[OVERHEAD_KEY])
+
+    const fractional = [labor, overhead].some((n) => n !== null && !Number.isInteger(n))
+
+    useImperativeHandle(ref, () => ({
+      tryAdvance: (direction) => {
+        if (!dirty) return true
+        if (fractional) {
+          if (direction !== 'next') return true
+          toastError({
+            title: 'Fix your absorption rates',
+            description: 'A rate must be a whole number of cents.',
+          })
+          return false
+        }
+        save()
+        return true
+      },
+    }))
+
+    return (
+      <div className='flex flex-col gap-4 p-4'>
+        <p className='text-muted-foreground text-sm'>
+          Every unit you assemble carries labor and overhead on top of its materials. These two
+          per-unit figures are what gets absorbed. Leave one empty and nothing is absorbed for it.
+        </p>
+
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='accounting-wizard-costing'
+          defaultLabelWidth={190}
+          className='p-0'>
+          <SettingsFieldRow
+            settingKey={LABOR_KEY}
+            title='Assembly labor per unit'
+            description='Annual payroll times the assembly share, divided by expected annual units. Empty means no labor absorption at all.'
+            {...controlled(LABOR_KEY)}
+          />
+          <SettingsFieldRow
+            settingKey={OVERHEAD_KEY}
+            title='Overhead per unit'
+            description='Total annual factory overhead divided by expected annual units. Empty means no overhead absorption at all.'
+            {...controlled(OVERHEAD_KEY)}
+          />
+        </FieldPanel>
+
+        {(labor === null || overhead === null) && (
+          <p className='text-muted-foreground text-xs'>
+            {labor === null && overhead === null
+              ? 'Neither rate is set, so an assembled unit is valued at materials only.'
+              : labor === null
+                ? 'No labor rate, so assembled units carry overhead only.'
+                : 'No overhead rate, so assembled units carry labor only.'}
+          </p>
+        )}
+
+        <div className='flex flex-col gap-2 rounded-xl border p-3'>
+          <span className='font-medium text-foreground text-sm'>Standard cost</span>
+          <p className='text-muted-foreground text-sm'>
+            The rates above only reach your inventory once standard cost is rolled: that walks each
+            bill of materials, adds the absorbed labor and overhead, and freezes a cost onto every
+            part. Until it runs, an assembled part has no cost to value a movement with and the
+            month-end entry refuses rather than guessing.
+          </p>
+          <div>
+            <Button variant='outline' size='sm' asChild>
+              <Link href='/app/accounting/settings/general'>
+                Roll standard cost
+                <ArrowUpRight />
+              </Link>
+            </Button>
+          </div>
+          <p className='text-muted-foreground text-xs'>
+            Opens Accounting settings, where you can preview what the roll would change before
+            running it. You can come back to the wizard afterwards.
+          </p>
+        </div>
+      </div>
+    )
+  }
+)

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-done-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-done-page.tsx
@@ -1,0 +1,119 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-done-page.tsx
+'use client'
+
+import { resolveSetupReadiness, SETUP_READINESS_SETTING_KEYS } from '@auxx/lib/postings/client'
+import type { SettingKey } from '@auxx/lib/settings/client'
+import { Button } from '@auxx/ui/components/button'
+import { AlertTriangle, Check, PartyPopper } from 'lucide-react'
+import Link from 'next/link'
+import { useSettings } from '~/hooks/use-settings'
+import { useUser } from '~/hooks/use-user'
+
+interface WizardDonePageProps {
+  /** Stamps `setWizardCompleted` and closes the dialog. */
+  onFinish: () => void
+}
+
+/**
+ * Page 6 (last) of `AccountingSetupWizard` - the readiness verdict and one of the two Finalize
+ * doors.
+ *
+ * ✅ Finalize lives BOTH here and on `settings/general`, deliberately. The settings page is its
+ * primary home because this wizard has "Set up later" on every page and stamps completion either
+ * way, so a Finalize that existed only inside it could be walked straight past.
+ *
+ * 🛑 Finalizing freezes the opening baseline. After it, a mistake is corrected with a reversal and
+ * a re-entry, never by editing setup history - changing an opening balance or the book timezone
+ * afterwards would rewrite the arithmetic behind a journal entry that has already been posted.
+ *
+ * Readiness is the shared pure predicate over the settings record
+ * (`packages/lib/src/postings/setup-readiness.ts`), not a query: `useSettings` rides the org cache
+ * hydrated by the provider, so this costs nothing and can never disagree with the settings pages
+ * or the checklist.
+ */
+export function WizardDonePage({ onFinish }: WizardDonePageProps) {
+  const { user } = useUser()
+  const { getSetting, batchUpdateOrganizationSettings, isBatchUpdatingOrgSettings } = useSettings({
+    scope: 'GENERAL',
+  })
+
+  const record: Record<string, unknown> = {}
+  for (const key of SETUP_READINESS_SETTING_KEYS) record[key] = getSetting(key as SettingKey)
+
+  const readiness = resolveSetupReadiness(record)
+  const unmet = readiness.requirements.filter((requirement) => !requirement.met)
+
+  const finalize = () => {
+    batchUpdateOrganizationSettings([
+      { key: 'accounting.setupState', value: 'finalized' },
+      { key: 'accounting.setupFinalizedAt', value: new Date().toISOString() },
+      { key: 'accounting.setupFinalizedByUserId', value: user?.id ?? null },
+    ])
+  }
+
+  return (
+    <div className='flex flex-col items-center gap-3 px-4 py-6 text-center'>
+      <PartyPopper className='size-8 text-muted-foreground' />
+      <h2 className='font-medium text-base text-foreground'>
+        {readiness.finalized ? "You're set" : 'One last step'}
+      </h2>
+
+      {readiness.finalized ? (
+        <p className='max-w-sm text-muted-foreground text-sm'>
+          Your opening baseline is frozen and the ledger is open for business. Head to Accounting
+          when you are ready to close your first month.
+        </p>
+      ) : unmet.length === 0 ? (
+        <p className='max-w-sm text-muted-foreground text-sm'>
+          Everything checks out. Finalizing freezes your opening baseline so the ledger can start.
+          After that, a correction is a reversal and a re-entry, never an edit.
+        </p>
+      ) : (
+        <div className='flex max-w-sm flex-col gap-2'>
+          <p className='text-muted-foreground text-sm'>
+            Not ready to finalize yet. You can finish these now or come back to them in Accounting
+            settings.
+          </p>
+          <ul className='flex flex-col gap-1 rounded-lg border p-2 text-left'>
+            {unmet.map((requirement) => (
+              <li
+                key={requirement.key}
+                className='flex items-start gap-1.5 text-muted-foreground text-xs'>
+                <AlertTriangle className='mt-0.5 size-3.5 shrink-0 text-amber-500' />
+                <span>{requirement.reason}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className='mt-2 flex flex-wrap items-center justify-center gap-2'>
+        <Button variant='ghost' size='sm' onClick={onFinish}>
+          Close
+        </Button>
+        {readiness.finalized ? (
+          <Button variant='outline' size='sm' asChild onClick={onFinish}>
+            <Link href='/app/accounting'>Open the ledger</Link>
+          </Button>
+        ) : (
+          <Button
+            variant='outline'
+            size='sm'
+            disabled={unmet.length > 0}
+            loading={isBatchUpdatingOrgSettings}
+            loadingText='Finalizing...'
+            onClick={finalize}>
+            <Check />
+            Finalize setup
+          </Button>
+        )}
+      </div>
+
+      {!readiness.finalized && (
+        <p className='max-w-sm text-muted-foreground text-xs'>
+          You can also finalize from Accounting settings later.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-opening-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-opening-page.tsx
@@ -1,0 +1,211 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-opening-page.tsx
+'use client'
+
+import {
+  ACCOUNT_ROLE_LABELS,
+  openingDifference,
+  openingDifferenceRows,
+  readSettingMinorUnits,
+} from '@auxx/lib/postings/client'
+import { toastError } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
+import { AlertTriangle, Check } from 'lucide-react'
+import { forwardRef, useImperativeHandle } from 'react'
+import { FieldPanel } from '~/components/global/forms/field-panel'
+import { formatMoney } from '~/components/money/ui/settings/format-money'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useAccountingSetupDraft } from '../../hooks/use-accounting-setup-draft'
+import type { WizardStepHandle } from './wizard-step-handle'
+
+const AUXX_KEYS = [
+  'accounting.openingRawMaterials',
+  'accounting.openingWip',
+  'accounting.openingFinishedGoods',
+] as const
+
+const QBO_KEYS = [
+  'accounting.qboOpeningRawMaterials',
+  'accounting.qboOpeningWip',
+  'accounting.qboOpeningFinishedGoods',
+] as const
+
+const JOURNAL_REF_KEY = 'accounting.qboOpeningJournalRef'
+
+const DRAFT_KEYS = [...AUXX_KEYS, ...QBO_KEYS, JOURNAL_REF_KEY] as const
+
+const ROW_TITLES = ['Raw materials', 'Work in process', 'Finished goods'] as const
+
+/**
+ * Page 3 of `AccountingSetupWizard` - the two opening snapshots, side by side, and the difference
+ * between them.
+ *
+ * 🛑 Neither number silently overrides the other, which is why this is a DIFFERENCE rather than a
+ * fallback. A difference falling into the first month's balancing plug would classify a cutover
+ * problem as that month's COGS; the Auxx number alone would let the provider and the subledger
+ * disagree from day one. So the page refuses Continue until they agree.
+ *
+ * ⚠️ `0` and unset are not interchangeable. A business with no work in process at cutover has
+ * exactly zero; a business that never entered the figure has nothing. The catalog stores `null`
+ * for the second and every readiness check treats it as unconfigured.
+ *
+ * ⚠️ Values are integer MINOR units and `CURRENCY` does not enforce that -
+ * `normalizeSettingValue` routes it through `fieldValueSchemas.number`, which accepts `12.5`.
+ * `readOpeningBaseline` refuses a fractional value on the read side, so without the check here
+ * the failure mode is a setup that SAVES and then cannot close.
+ */
+export const WizardOpeningPage = forwardRef<WizardStepHandle>(
+  function WizardOpeningPage(_props, ref) {
+    const { draft, dirty, save, controlled, getSetting } = useAccountingSetupDraft(DRAFT_KEYS)
+
+    const currency = (getSetting('organization.currency') as string) || 'USD'
+    const rows = openingDifferenceRows(draft)
+    const difference = openingDifference(draft)
+
+    const allPresent = [...AUXX_KEYS, ...QBO_KEYS].every(
+      (k) => readSettingMinorUnits(draft[k]) !== null
+    )
+    const fractional = [...AUXX_KEYS, ...QBO_KEYS].some((k) => {
+      const n = readSettingMinorUnits(draft[k])
+      return n !== null && !Number.isInteger(n)
+    })
+
+    const blockingReason = fractional
+      ? 'An opening balance is not a whole number of cents. Enter the amount to two decimal places.'
+      : allPresent && difference !== 0
+        ? 'The Auxx and provider snapshots do not agree. Correct one of them before continuing.'
+        : null
+
+    useImperativeHandle(ref, () => ({
+      tryAdvance: (direction) => {
+        if (blockingReason && direction === 'next') {
+          toastError({ title: 'Opening balances do not reconcile', description: blockingReason })
+          return false
+        }
+        // Back and "Set up later" always save whatever is valid and let the user out. A page that
+        // can trap somebody has no escape hatch, and unlike a dirty-draft check this condition can
+        // be true on a page nobody touched.
+        if (dirty && !fractional) save()
+        return true
+      },
+    }))
+
+    return (
+      <div className='flex flex-col gap-4 p-4'>
+        <p className='text-muted-foreground text-sm'>
+          What you were carrying at the cutoff, from the physical count valued at your CPA-approved
+          costs, beside what your accounting provider says. Both, so a cutover problem cannot hide
+          inside the first month&apos;s numbers.
+        </p>
+
+        <div className='grid grid-cols-1 items-start gap-4 md:grid-cols-2'>
+          <div className='flex flex-col gap-1.5'>
+            <span className='font-medium text-foreground text-sm'>Auxx snapshot</span>
+            <FieldPanel
+              orientation='vertical'
+              resizeId='accounting-wizard-opening-auxx'
+              defaultLabelWidth={140}
+              className='p-0'>
+              {AUXX_KEYS.map((key, index) => (
+                <SettingsFieldRow
+                  key={key}
+                  settingKey={key}
+                  title={ROW_TITLES[index] ?? key}
+                  {...controlled(key)}
+                />
+              ))}
+            </FieldPanel>
+          </div>
+
+          <div className='flex flex-col gap-1.5'>
+            <span className='font-medium text-foreground text-sm'>Accounting provider</span>
+            <FieldPanel
+              orientation='vertical'
+              resizeId='accounting-wizard-opening-qbo'
+              defaultLabelWidth={140}
+              className='p-0'>
+              {QBO_KEYS.map((key, index) => (
+                <SettingsFieldRow
+                  key={key}
+                  settingKey={key}
+                  title={ROW_TITLES[index] ?? key}
+                  {...controlled(key)}
+                />
+              ))}
+            </FieldPanel>
+          </div>
+        </div>
+
+        <div className='flex flex-col gap-1.5'>
+          <span className='font-medium text-foreground text-sm'>Reconciliation</span>
+          <div className='overflow-hidden rounded-xl border'>
+            <table className='w-full text-sm'>
+              <thead>
+                <tr className='border-b text-muted-foreground text-xs'>
+                  <th className='px-3 py-1.5 text-left font-normal'>Account</th>
+                  <th className='px-3 py-1.5 text-right font-normal'>Auxx</th>
+                  <th className='px-3 py-1.5 text-right font-normal'>Provider</th>
+                  <th className='px-3 py-1.5 text-right font-normal'>Difference</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.role} className='border-b last:border-b-0'>
+                    <td className='px-3 py-1.5'>{ACCOUNT_ROLE_LABELS[row.role] ?? row.role}</td>
+                    <td className='px-3 py-1.5 text-right tabular-nums'>
+                      {formatMoney(row.auxx, currency)}
+                    </td>
+                    <td className='px-3 py-1.5 text-right tabular-nums'>
+                      {formatMoney(row.qbo, currency)}
+                    </td>
+                    <td
+                      className={cn(
+                        'px-3 py-1.5 text-right tabular-nums',
+                        row.difference !== null && row.difference !== 0 && 'text-destructive'
+                      )}>
+                      {formatMoney(row.difference, currency)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {allPresent ? (
+            difference === 0 ? (
+              <p className='flex items-center gap-1.5 text-muted-foreground text-xs'>
+                <Check className='size-3.5 text-good-500' />
+                Both snapshots agree.
+              </p>
+            ) : (
+              <p className='flex items-center gap-1.5 text-destructive text-xs'>
+                <AlertTriangle className='size-3.5' />
+                Off by {formatMoney(difference, currency)}. Setup cannot be finalized until they
+                agree.
+              </p>
+            )
+          ) : (
+            <p className='text-muted-foreground text-xs'>
+              Enter all six figures to reconcile. Zero is a real balance; leaving a field empty is
+              not the same thing.
+            </p>
+          )}
+        </div>
+
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='accounting-wizard-opening-ref'
+          defaultLabelWidth={150}
+          className='p-0'>
+          <SettingsFieldRow
+            settingKey={JOURNAL_REF_KEY}
+            title='Opening journal reference'
+            description='The journal entry in your provider that booked these balances. Auxx did not post it, so this is a reference for the audit trail rather than a posting.'
+            placeholder='JE-1042'
+            {...controlled(JOURNAL_REF_KEY)}
+          />
+        </FieldPanel>
+      </div>
+    )
+  }
+)

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-period-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-period-page.tsx
@@ -1,0 +1,120 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-period-page.tsx
+'use client'
+
+import { detectTimezone } from '@auxx/config/client'
+import { isValidTimeZone } from '@auxx/lib/postings/client'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { forwardRef, useImperativeHandle } from 'react'
+import { FieldPanel } from '~/components/global/forms/field-panel'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useAccountingSetupDraft } from '../../hooks/use-accounting-setup-draft'
+import type { WizardStepHandle } from './wizard-step-handle'
+
+const CUTOFF_KEY = 'accounting.cutoffPeriod'
+const TIMEZONE_KEY = 'accounting.bookTimeZone'
+
+const DRAFT_KEYS = [CUTOFF_KEY, TIMEZONE_KEY] as const
+
+/**
+ * `parsePeriodKey` requires a MONTH key and there is no pattern validation on a `TEXT` setting -
+ * `FieldOptions` has no such member - so the shape is checked here on the way in as well as on
+ * read, where it fails closed.
+ */
+const MONTH_KEY = /^\d{4}-(0[1-9]|1[0-2])$/
+
+function text(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Page 2 of `AccountingSetupWizard` - the two settings that decide which month a piece of
+ * subledger activity belongs to.
+ *
+ * 🛑 There is NO UTC fallback on the timezone, deliberately. A receipt logged at 7pm on January 31
+ * in `America/New_York` is already February 1 in UTC, so an org whose zone was quietly assumed
+ * posts a month's edge activity into the wrong period - invisible except at a close, and
+ * uncorrectable once the period is locked. Unset refuses to post rather than guessing.
+ *
+ * Edits are held in a local draft and written on leave through the {@link WizardStepHandle}, so
+ * Back, Continue and "Set up later" all save. A dirty-but-invalid draft blocks Continue only.
+ */
+export const WizardPeriodPage = forwardRef<WizardStepHandle>(
+  function WizardPeriodPage(_props, ref) {
+    const { draft, patch, dirty, save, controlled } = useAccountingSetupDraft(DRAFT_KEYS)
+
+    const cutoff = text(draft[CUTOFF_KEY])
+    const zone = text(draft[TIMEZONE_KEY])
+
+    const invalidReason = !cutoff
+      ? 'Enter the last month your previous system closed, as YYYY-MM.'
+      : !MONTH_KEY.test(cutoff)
+        ? `"${cutoff}" is not a YYYY-MM month.`
+        : !zone
+          ? 'Enter the timezone your books are kept in. There is no UTC fallback.'
+          : !isValidTimeZone(zone)
+            ? `"${zone}" is not a valid IANA timezone.`
+            : null
+
+    useImperativeHandle(ref, () => ({
+      tryAdvance: (direction) => {
+        if (!dirty) return true
+        if (invalidReason) {
+          // Back and "Set up later" are never refusable - the user keeps their typing and the
+          // wizard keeps its escape hatch. Only Continue is held.
+          if (direction !== 'next') return true
+          toastError({ title: 'Fix the accounting period', description: invalidReason })
+          return false
+        }
+        save()
+        return true
+      },
+    }))
+
+    const detected = detectTimezone()
+
+    return (
+      <div className='flex flex-col gap-4 p-4'>
+        <p className='text-muted-foreground text-sm'>
+          Everything dated after the cutoff is valued by Auxx. Everything before it is covered by
+          the opening balances on the next page.
+        </p>
+
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='accounting-wizard-period'
+          defaultLabelWidth={150}
+          className='p-0'>
+          <SettingsFieldRow
+            settingKey={CUTOFF_KEY}
+            title='Cutoff month'
+            description='The last month closed in your previous accounting system, as YYYY-MM.'
+            placeholder='2026-12'
+            {...controlled(CUTOFF_KEY)}
+          />
+          <SettingsFieldRow
+            settingKey={TIMEZONE_KEY}
+            title='Book timezone'
+            description='The IANA timezone period keys are derived in. Unset refuses to post rather than assuming UTC.'
+            placeholder='America/New_York'
+            {...controlled(TIMEZONE_KEY)}
+          />
+        </FieldPanel>
+
+        {zone !== detected && isValidTimeZone(detected) && (
+          <div className='flex items-center gap-2'>
+            <Button variant='outline' size='sm' onClick={() => patch({ [TIMEZONE_KEY]: detected })}>
+              Use {detected}
+            </Button>
+            <span className='text-muted-foreground text-xs'>Your browser&apos;s timezone.</span>
+          </div>
+        )}
+
+        {invalidReason && <p className='text-muted-foreground text-xs'>{invalidReason}</p>}
+      </div>
+    )
+  }
+)

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-step-handle.ts
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-step-handle.ts
@@ -1,0 +1,32 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-step-handle.ts
+
+/** Which way the shell is trying to leave the current page. */
+export type WizardLeaveDirection = 'next' | 'back' | 'exit'
+
+/**
+ * Imperative handle a wizard page can expose (via `forwardRef`) so the wizard shell can ask it,
+ * right before navigating away in any direction, whether it is safe to leave. Pages that write
+ * their data immediately on every change do not need one - pages with their own local draft
+ * (Period, Opening balances, Costing) register one to save on leave.
+ *
+ * Deliberately a LOCAL copy of the dispatch wizard's interface rather than an import across
+ * feature folders, with one addition: `direction`.
+ *
+ * 🛑 The direction matters because of the opening-balance rule. "Set up later" and Back must
+ * NEVER be refusable - a page that can trap the user has no escape hatch, and dispatch's own
+ * page only blocks because a dirty draft implies the user typed something. Opening balances have
+ * to block on a condition that can be true on a page the user never touched (the two snapshots
+ * disagreeing), so the block is scoped to `next` and both exits stay open.
+ */
+export interface WizardStepHandle {
+  /**
+   * Called before Back/Continue/"Set up later" moves off this page. Returns `true` when it is
+   * safe to navigate (saving a dirty-but-valid draft as a side effect first); returns `false`
+   * to block navigation (e.g. after showing a validation toast) so unsaved, invalid edits are
+   * never silently discarded.
+   *
+   * ⚠️ Only `'next'` may ever be refused. Implementations must return `true` for `'back'` and
+   * `'exit'` after doing whatever saving they can.
+   */
+  tryAdvance: (direction: WizardLeaveDirection) => boolean
+}

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-welcome-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-welcome-page.tsx
@@ -1,0 +1,51 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-welcome-page.tsx
+'use client'
+
+import { GuideColumn, GuideConcept, GuideConcepts } from '@auxx/ui/components/guide'
+import { Banknote, Calculator, CalendarClock, ListChecks } from 'lucide-react'
+
+/**
+ * Page 1 of `AccountingSetupWizard` - a plain-language explainer of what the accounting module
+ * does and the four things this wizard sets up, built from the container-agnostic
+ * `@auxx/ui/components/guide` content primitives (docs/ui-design-guide.md section 16), not a
+ * `GuideDialog` shell: the wizard already supplies its own `DialogNav`.
+ */
+export function WizardWelcomePage() {
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      <p className='text-muted-foreground text-sm'>
+        Accounting turns what your warehouse did into what your books say. Once a month it values
+        every movement, build and count against your standard costs and posts a single journal
+        entry. Four things have to be true before that entry can be trusted.
+      </p>
+      <GuideColumn title="What we'll set up">
+        <GuideConcepts>
+          <GuideConcept
+            glyph={<CalendarClock className='size-3.5 text-muted-foreground' />}
+            term='Accounting period'>
+            The last month your old system closed, and the timezone your books are kept in.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<Banknote className='size-3.5 text-muted-foreground' />}
+            term='Opening balances'>
+            What you were carrying at the cutoff, agreed with your accounting provider.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<Calculator className='size-3.5 text-muted-foreground' />}
+            term='Costing'>
+            The labor and overhead absorbed onto every unit you assemble.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<ListChecks className='size-3.5 text-muted-foreground' />}
+            term='Account map'>
+            Which account in your chart each accounting role posts to.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+      <p className='text-muted-foreground text-xs'>
+        You can leave at any point and pick it back up from Accounting settings. Nothing here posts
+        anything.
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/components/global/settings-page.tsx
+++ b/apps/web/src/components/global/settings-page.tsx
@@ -61,6 +61,7 @@ export default function SettingsPage({
   const [isScrolled, setIsScrolled] = useState(false)
   const sentinelRef = useRef<HTMLDivElement>(null)
   const viewportRef = useRef<HTMLDivElement>(null)
+  const stickyHeaderRef = useRef<HTMLDivElement>(null)
 
   // Use Intersection Observer for efficient scroll detection
   useEffect(() => {
@@ -82,6 +83,47 @@ export default function SettingsPage({
     )
 
     observer.observe(sentinel)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  /**
+   * Publish the sticky header's height, and the viewport's, as CSS variables on
+   * the scroll viewport.
+   *
+   * A page that wants a sticky side pane needs to know how far down to pin it,
+   * and that distance is NOT a constant: the header block below is title +
+   * optional description + optional `subHeader` + separator, so it differs per
+   * page and changes when a tab strip is added. Hardcoding a pixel value works
+   * on the page it was measured on and is quietly wrong on the next one.
+   *
+   * Measuring it here rather than in each page is the point — `SettingsPage`
+   * owns the sticky block, so it is the only thing that can answer this
+   * correctly, and every page opts in with one class:
+   *
+   *     lg:sticky lg:top-[var(--settings-sticky-top)]
+   *
+   * ⚠️ `--settings-viewport-h` is the SCROLL VIEWPORT's height, not the
+   * window's. This ScrollArea is nested inside a panel frame with its own
+   * insets, so `100dvh` overshoots by the chrome above and below it and a pane
+   * capped that way would run off the bottom.
+   */
+  useEffect(() => {
+    const header = stickyHeaderRef.current
+    const viewport = viewportRef.current
+    if (!header || !viewport) return
+
+    const publish = () => {
+      viewport.style.setProperty('--settings-sticky-top', `${header.offsetHeight}px`)
+      viewport.style.setProperty('--settings-viewport-h', `${viewport.clientHeight}px`)
+    }
+
+    publish()
+    const observer = new ResizeObserver(publish)
+    observer.observe(header)
+    observer.observe(viewport)
 
     return () => {
       observer.disconnect()
@@ -129,7 +171,9 @@ export default function SettingsPage({
         </header>
       )}
 
-      <div className='sticky top-0 z-20 backdrop-blur-sm bg-background/80 rounded-tr-xl'>
+      <div
+        ref={stickyHeaderRef}
+        className='sticky top-0 z-20 backdrop-blur-sm bg-background/80 rounded-tr-xl'>
         <div
           className={cn(
             'flex flex-col sm:flex-row sm:items-center gap-2 bg-muted/50 px-5 py-3 pe-2 sm:pe-5',

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -18,6 +18,7 @@ import {
   History,
   Import,
   Inbox,
+  Landmark,
   Layers,
   LayoutDashboard,
   Map,
@@ -183,6 +184,22 @@ export const SIDEBAR_MENU: SidebarProps[] = [
         icon: <Receipt />,
       },
     ],
+  },
+  {
+    // The accounting module (plans/money/tasks/13-accounting-ui.md §1) — the
+    // general ledger, the month-end close and the accounting setup wizard.
+    //
+    // No sub-items, deliberately. Orders, Purchase Orders, Vendor Bills, Parts,
+    // Products and Builds stay at their existing top-level routes; the Dispatch
+    // entry below shows how they COULD be grouped later (`skipParentSlug` + child
+    // items pointing at top-level routes), but grouping operational records under
+    // "Accounting" would force the group's gate to the loosest of its children.
+    id: 'accounting',
+    label: 'Accounting',
+    slug: 'accounting',
+    icon: <Landmark />,
+    featureKey: 'accounting',
+    permissionKey: 'ledger.view',
   },
   {
     // The sellable catalog's first-class entry (plans/products/01-product-family.md

--- a/packages/lib/src/getting-started/client.ts
+++ b/packages/lib/src/getting-started/client.ts
@@ -9,8 +9,14 @@ export const GETTING_STARTED_SETTING_KEY = 'onboarding.gettingStarted' as const
 /** The setting key under which the dispatch getting-started state is persisted. */
 export const DISPATCH_GETTING_STARTED_SETTING_KEY = 'onboarding.dispatchGettingStarted' as const
 
-/** The known onboarding checklists. `main` is the org-wide checklist; `dispatch` is the module one. */
-export const CHECKLIST_IDS = ['main', 'dispatch'] as const
+/** The setting key under which the accounting getting-started state is persisted. */
+export const ACCOUNTING_GETTING_STARTED_SETTING_KEY = 'onboarding.accountingGettingStarted' as const
+
+/**
+ * The known onboarding checklists. `main` is the org-wide checklist; `dispatch`
+ * and `accounting` are the module ones.
+ */
+export const CHECKLIST_IDS = ['main', 'dispatch', 'accounting'] as const
 
 export type ChecklistId = (typeof CHECKLIST_IDS)[number]
 
@@ -36,15 +42,42 @@ export const DISPATCH_GOAL_KEYS = [
   'schedule-visit',
 ] as const
 
+/**
+ * Canonical, ordered list of accounting onboarding goal keys. Order is display order.
+ *
+ * Deliberately COARSE - one goal per wizard page, not one per settings field.
+ * Cutoff and book timezone are two inputs on one page that take five seconds
+ * together, and `dispatch` does not split `set-address` into street and city
+ * either (plans/money/tasks/13-accounting-ui.md section 3.2).
+ *
+ * 🛑 There is no `connect-quickbooks` goal, and that is a decision rather than an
+ * omission. Decision `P1` makes "nothing connected" a FIRST-CLASS case: the entry
+ * is built, balanced and persisted identically and the poster reports
+ * `not_connected`. A checklist that nagged for a provider would contradict the
+ * design the whole poster rests on.
+ */
+export const ACCOUNTING_GOAL_KEYS = [
+  'set-accounting-period',
+  'set-opening-balances',
+  'set-costing',
+  'map-accounts',
+  'finalize-setup',
+  'post-first-entry',
+] as const
+
 export type MainGoalKey = (typeof MAIN_GOAL_KEYS)[number]
 export type DispatchGoalKey = (typeof DISPATCH_GOAL_KEYS)[number]
-export type GoalKey = MainGoalKey | DispatchGoalKey
+export type AccountingGoalKey = (typeof ACCOUNTING_GOAL_KEYS)[number]
+export type GoalKey = MainGoalKey | DispatchGoalKey | AccountingGoalKey
 
 /** Per-checklist registry: setting key, goal-key set, and manual-only goals. */
 export const CHECKLISTS: Record<
   ChecklistId,
   {
-    settingKey: typeof GETTING_STARTED_SETTING_KEY | typeof DISPATCH_GETTING_STARTED_SETTING_KEY
+    settingKey:
+      | typeof GETTING_STARTED_SETTING_KEY
+      | typeof DISPATCH_GETTING_STARTED_SETTING_KEY
+      | typeof ACCOUNTING_GETTING_STARTED_SETTING_KEY
     goalKeys: readonly GoalKey[]
     /** Goals with no server signal — completed only via manualCompletions. */
     manualGoalKeys: readonly GoalKey[]
@@ -58,6 +91,11 @@ export const CHECKLISTS: Record<
   dispatch: {
     settingKey: DISPATCH_GETTING_STARTED_SETTING_KEY,
     goalKeys: DISPATCH_GOAL_KEYS,
+    manualGoalKeys: [],
+  },
+  accounting: {
+    settingKey: ACCOUNTING_GETTING_STARTED_SETTING_KEY,
+    goalKeys: ACCOUNTING_GOAL_KEYS,
     manualGoalKeys: [],
   },
 }

--- a/packages/lib/src/getting-started/signals.ts
+++ b/packages/lib/src/getting-started/signals.ts
@@ -17,6 +17,8 @@ import {
   getCachedMembers,
   getOrgCache,
 } from '../cache'
+import { ENABLED_POSTING_TYPES, INVENTORY_ROLES_BY_POSTING_TYPE } from '../postings/regime'
+import { resolveSetupReadiness } from '../postings/setup-readiness'
 import type { ChecklistId, GoalKey } from './client'
 import type { GettingStartedContext } from './types'
 
@@ -162,6 +164,78 @@ async function hasScheduledVisit(ctx: GettingStartedContext): Promise<boolean> {
   return rows.length > 0
 }
 
+// ── accounting checklist signals ──
+//
+// 🛑 Three of the six delegate to `resolveSetupReadiness` rather than
+// re-implementing the arithmetic. That predicate is ALSO what the accounting
+// settings pages call client-side against hydrated `useSettings`, and writing
+// the same rules twice is the thing that rots: the two copies drift and the
+// checklist starts disagreeing with the button.
+//
+// ⚠️ None of these gate Post. `previewMonthEnd`'s `blockedBy` does. A checklist
+// says "set up costing"; a refusal names the part with no standard cost.
+
+/** One settings-derived requirement from the shared predicate. */
+async function settingsRequirementMet(ctx: GettingStartedContext, key: string): Promise<boolean> {
+  const settings = await getOrgCache().get(ctx.organizationId, 'orgSettings')
+  const readiness = resolveSetupReadiness(settings as Record<string, unknown>)
+  return readiness.requirements.find((r) => r.key === key)?.met ?? false
+}
+
+const hasAccountingPeriod = (ctx: GettingStartedContext) =>
+  settingsRequirementMet(ctx, 'set-accounting-period')
+const hasOpeningBalances = (ctx: GettingStartedContext) =>
+  settingsRequirementMet(ctx, 'set-opening-balances')
+const hasCostingRates = (ctx: GettingStartedContext) => settingsRequirementMet(ctx, 'set-costing')
+
+/** `accounting.setupState === 'finalized'`. */
+async function isSetupFinalized(ctx: GettingStartedContext): Promise<boolean> {
+  const settings = await getOrgCache().get(ctx.organizationId, 'orgSettings')
+  return resolveSetupReadiness(settings as Record<string, unknown>).finalized
+}
+
+/**
+ * Every role the enabled posting regime requires has a `GlRoleAssignment`.
+ *
+ * ⚠️ Scoped to `INVENTORY_ROLES_BY_POSTING_TYPE` for the ENABLED types only, not
+ * to all 13 roles. `ppv` and `inventory_wip` are in the vocabulary but nothing
+ * emits them under L1 — PPV is a report (task 09 §3) and WIP is unreachable —
+ * so demanding them would leave this goal permanently red.
+ */
+async function hasRequiredRoleAssignments(ctx: GettingStartedContext): Promise<boolean> {
+  const required = new Set<string>()
+  for (const postingType of ENABLED_POSTING_TYPES) {
+    for (const role of INVENTORY_ROLES_BY_POSTING_TYPE[postingType]) required.add(role)
+  }
+  if (required.size === 0) return true
+
+  const db = ctx.db ?? database
+  const rows = await db
+    .select({ role: schema.GlRoleAssignment.role })
+    .from(schema.GlRoleAssignment)
+    .where(eq(schema.GlRoleAssignment.organizationId, ctx.organizationId))
+
+  const assigned = new Set(rows.map((r) => r.role))
+  for (const role of required) if (!assigned.has(role)) return false
+  return true
+}
+
+/** At least one `posted` month-end entry exists. The books have started. */
+async function hasPostedEntry(ctx: GettingStartedContext): Promise<boolean> {
+  const db = ctx.db ?? database
+  const rows = await db
+    .select({ id: schema.GlPosting.id })
+    .from(schema.GlPosting)
+    .where(
+      and(
+        eq(schema.GlPosting.organizationId, ctx.organizationId),
+        eq(schema.GlPosting.status, 'posted')
+      )
+    )
+    .limit(1)
+  return rows.length > 0
+}
+
 /** Map of checklist → auto-inferred goal → signal. Manual-only goals have no entry. */
 const AUTO_SIGNALS: Record<ChecklistId, Partial<Record<GoalKey, Signal>>> = {
   main: {
@@ -180,6 +254,14 @@ const AUTO_SIGNALS: Record<ChecklistId, Partial<Record<GoalKey, Signal>>> = {
     'create-request': hasServiceRequest,
     'create-work-order': hasWorkOrder,
     'schedule-visit': hasScheduledVisit,
+  },
+  accounting: {
+    'set-accounting-period': hasAccountingPeriod,
+    'set-opening-balances': hasOpeningBalances,
+    'set-costing': hasCostingRates,
+    'map-accounts': hasRequiredRoleAssignments,
+    'finalize-setup': isSetupFinalized,
+    'post-first-entry': hasPostedEntry,
   },
 }
 

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -48,6 +48,7 @@ export enum FeatureKey {
   dataConnectors = 'dataConnectors',
   dashboards = 'dashboards',
   dispatch = 'dispatch',
+  accounting = 'accounting',
   sequences = 'sequences',
   granularPermissions = 'granularPermissions',
   /**
@@ -219,6 +220,14 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     label: 'Dispatch',
     description: 'Field-service work orders, scheduling, and dispatching.',
     group: 'Dispatch',
+  },
+  {
+    key: FeatureKey.accounting,
+    type: 'boolean',
+    label: 'Accounting',
+    description:
+      'The general ledger, the month-end close console, and the accounting setup wizard.',
+    group: 'Accounting',
   },
   {
     key: FeatureKey.sequences,

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -21,6 +21,11 @@ export {
   type VendorBillEntryInput,
 } from './build-entry'
 export {
+  type BuiltMonthEndInventoryDraft,
+  buildMonthEndInventoryEntry,
+  type MonthEndInventoryInputs,
+} from './build-month-end-inventory'
+export {
   DEFAULT_CHART_OF_ACCOUNTS,
   type DefaultChartAccount,
   type GlAccountTypeValue,
@@ -31,6 +36,14 @@ export {
   DOC_NUMBER_PREFIX,
   type DocNumberInput,
 } from './doc-number'
+export {
+  type MonthEndInventorySnapshot,
+  POSTING_DRAFT_VERSION,
+  type PostingAssertions,
+  type PostingDraftV1,
+  requiresAssertions,
+  reverseAssertions,
+} from './draft'
 export {
   assertPeriodOpen,
   compareMonths,
@@ -43,7 +56,32 @@ export {
   periodMonth,
 } from './periods'
 export {
+  ENABLED_POSTING_TYPES,
+  INVENTORY_ROLES,
+  INVENTORY_ROLES_BY_POSTING_TYPE,
+} from './regime'
+export {
+  ABSORPTION_RATE_SETTING_KEYS,
+  FINALIZED_SETUP_STATE,
+  isValidTimeZone,
+  isWholeMinorUnits,
+  minorUnitError,
+  OPENING_BASELINE_SETTING_KEYS,
+  openingDifference,
+  openingDifferenceRows,
+  type ReadinessRequirement,
+  readSettingMinorUnits,
+  readSettingText,
+  resolveSetupReadiness,
+  SETUP_READINESS_SETTING_KEYS,
+  type SettingsRecord,
+  type SetupReadiness,
+} from './setup-readiness'
+export {
+  type BooksBalanceDiscrepancy,
+  type BooksBalanceReport,
   type BuiltEntry,
+  type EntryPreview,
   type GlPostingLineInput,
   POSTING_TYPES,
   type PostEntryInput,
@@ -56,4 +94,5 @@ export {
   type PostResultStatus,
   ProviderPostError,
   type ResolvedPostingLine,
+  type UnpostedPeriod,
 } from './types'

--- a/packages/lib/src/postings/opening-baseline.ts
+++ b/packages/lib/src/postings/opening-baseline.ts
@@ -48,17 +48,12 @@ import { getOrganizationSetting } from '../settings/settings-service'
 import { parsePeriodKey } from './periods'
 
 /** The catalog keys this module reads. Nothing else in the read path names them. */
-export const OPENING_BASELINE_SETTING_KEYS = {
-  setupState: 'accounting.setupState',
-  cutoffPeriod: 'accounting.cutoffPeriod',
-  bookTimeZone: 'accounting.bookTimeZone',
-  inventory_raw_materials: 'accounting.openingRawMaterials',
-  inventory_wip: 'accounting.openingWip',
-  inventory_finished_goods: 'accounting.openingFinishedGoods',
-} as const
+// Declared in `setup-readiness.ts` - the client-safe half - because the setup
+// wizard needs these keys in a browser and this file reaches the database.
+// Re-exported so every existing server importer is unaffected.
+export { FINALIZED_SETUP_STATE, OPENING_BASELINE_SETTING_KEYS } from './setup-readiness'
 
-/** The value `accounting.setupState` must hold before anything may post. */
-export const FINALIZED_SETUP_STATE = 'finalized' as const
+import { FINALIZED_SETUP_STATE, OPENING_BASELINE_SETTING_KEYS } from './setup-readiness'
 
 /**
  * The frozen opening position the first month-end entry is measured against.

--- a/packages/lib/src/postings/post-entry.ts
+++ b/packages/lib/src/postings/post-entry.ts
@@ -134,16 +134,12 @@ export interface PreviewEntryOptions {
   lock: PeriodLock
 }
 
-export interface EntryPreview {
-  postingType: PostingType
-  periodKey: string
-  txnDate: string
-  docNumber: string
-  lines: ResolvedPostingLine[]
-  totalMinor: number
-  /** Non-empty when the preview would refuse: the same statuses `postEntry` returns. */
-  blockedBy?: { status: PostResultStatus; error: string }
-}
+// `EntryPreview` moved to `types.ts` (client-safe) so a browser can hold the
+// shape without importing this file, which pulls `@auxx/database`. Re-exported
+// here so existing importers are unaffected.
+export type { EntryPreview } from './types'
+
+import type { EntryPreview } from './types'
 
 /** One line after resolution, paired with the role it was resolved FROM. */
 interface PreparedLine {

--- a/packages/lib/src/postings/setup-readiness.ts
+++ b/packages/lib/src/postings/setup-readiness.ts
@@ -1,0 +1,286 @@
+// packages/lib/src/postings/setup-readiness.ts
+//
+// Whether an organization's accounting setup is ready, as a PURE function over a
+// settings record.
+//
+// PURE and CLIENT-SAFE. No database, no clock, no io - it is handed the settings
+// and answers a question about them.
+//
+// ── Why this file exists, and why it is not a query ─────────────────────────
+//
+// plans/money/tasks/12-accounting-setup.md is explicit that readiness is
+// "derived on read, not stored - a stored readiness flag goes stale the moment
+// somebody changes a rate." The front end already satisfies that for free:
+// `useSettings` rides the org cache, hydrated by the provider, so every
+// `accounting.*` key is in hand on load at ZERO queries.
+//
+// 🛑 So there is deliberately no `setupReadiness` endpoint. What there is
+// instead is ONE predicate with TWO callers:
+//
+//   * `getting-started/signals.ts` calls it server-side against cached settings,
+//     to light up the onboarding checklist.
+//   * the accounting settings pages call it client-side against `useSettings`,
+//     to render "not configured yet" hints inline.
+//
+// Writing that arithmetic twice is the thing that would rot: the two copies
+// drift and the checklist starts disagreeing with the button.
+//
+// ── What this is NOT ────────────────────────────────────────────────────────
+//
+// 🛑 This does not gate Post. `previewMonthEnd`'s `blockedBy` does, and the
+// difference is the whole point: this file can say "costing is not set up",
+// but only the server knows WHICH part has no standard cost or WHICH movement
+// is uncosted. A checklist nudges; a refusal names the row.
+//
+// Three requirements are therefore absent here by design - they are facts about
+// rows, not settings, and each belongs to a page that already loads them:
+// the standard-cost roll (part rows), the role map (`GlRoleAssignment` rows),
+// and whether a first entry is posted (`GlPosting` rows).
+
+/**
+ * The settings the opening baseline is read from.
+ *
+ * 🛑 Declared HERE rather than in `opening-baseline.ts` even though that is the
+ * module that reads them, because this file is client-safe and that one is not -
+ * it imports `settings-service`, which reaches the database. A browser importing
+ * these keys through that file would drag the server graph into the bundle.
+ * `opening-baseline.ts` re-exports them, so the server side is unaffected.
+ */
+export const OPENING_BASELINE_SETTING_KEYS = {
+  setupState: 'accounting.setupState',
+  cutoffPeriod: 'accounting.cutoffPeriod',
+  bookTimeZone: 'accounting.bookTimeZone',
+  inventory_raw_materials: 'accounting.openingRawMaterials',
+  inventory_wip: 'accounting.openingWip',
+  inventory_finished_goods: 'accounting.openingFinishedGoods',
+} as const
+
+/** The value `accounting.setupState` must hold before anything may post. */
+export const FINALIZED_SETUP_STATE = 'finalized' as const
+
+/**
+ * The absorption rates, which live under `manufacturing.*` rather than
+ * `accounting.*` because they predate this module - `G9` calls them business
+ * inputs, not a fixture gap.
+ */
+export const ABSORPTION_RATE_SETTING_KEYS = {
+  assemblyLabor: 'manufacturing.assemblyLaborCostPerUnit',
+  overhead: 'manufacturing.overheadCostPerUnit',
+} as const
+
+/** Every setting key this predicate reads. Handy for scoping a settings draft. */
+export const SETUP_READINESS_SETTING_KEYS = [
+  ...Object.values(OPENING_BASELINE_SETTING_KEYS),
+  'accounting.qboOpeningRawMaterials',
+  'accounting.qboOpeningWip',
+  'accounting.qboOpeningFinishedGoods',
+  'accounting.qboOpeningJournalRef',
+  ...Object.values(ABSORPTION_RATE_SETTING_KEYS),
+] as const
+
+/** A settings record as `useSettings`/`getAllOrganizationSettings` hand it over. */
+export type SettingsRecord = Record<string, unknown>
+
+/** One requirement, resolved. */
+export interface ReadinessRequirement {
+  /** Stable id. Matches the getting-started goal key where one exists. */
+  key: string
+  met: boolean
+  /** Why it is not met, in words a person can act on. Absent when `met`. */
+  reason?: string
+}
+
+export interface SetupReadiness {
+  /** Every settings-derived requirement, in display order. */
+  requirements: ReadinessRequirement[]
+  /** True when every requirement above is met. Says nothing about the row-level facts. */
+  settingsReady: boolean
+  /** `accounting.setupState === 'finalized'`. */
+  finalized: boolean
+}
+
+/**
+ * A `CURRENCY` setting, normalized.
+ *
+ * ⚠️ `null` and `0` are NOT interchangeable and this is the one place that most
+ * wants to conflate them. `0` is a legitimate opening balance - a business with
+ * no work in process at cutover has exactly that - so a null read as zero would
+ * report a baseline nobody supplied. Same rule `loadAbsorptionRates` follows.
+ */
+export function readSettingMinorUnits(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return value
+}
+
+/**
+ * ⚠️ The catalog cannot enforce integer minor units and it was verified that it
+ * does not: `normalizeSettingValue` routes `CURRENCY` through
+ * `fieldValueSchemas.number`, which accepts `12.5` and even coerces `"12.50"`.
+ * `readOpeningBaseline` refuses a fractional value on the read side, so without a
+ * check here the failure mode is a setup that SAVES and then cannot close.
+ */
+export function isWholeMinorUnits(value: unknown): boolean {
+  const n = readSettingMinorUnits(value)
+  return n !== null && Number.isInteger(n)
+}
+
+/**
+ * The same rule as {@link isWholeMinorUnits}, phrased for a form field.
+ *
+ * `null` is deliberately NOT an error here - "not configured" is
+ * {@link resolveSetupReadiness}'s answer to give, not this one's. A field that
+ * reported both would say "required" twice in two vocabularies.
+ */
+export function minorUnitError(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'Must be a number of cents.'
+  if (!Number.isInteger(value)) return 'Must be a whole number of cents, with no fraction.'
+  return undefined
+}
+
+export function readSettingText(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/** Whether a string names a zone this runtime knows. No UTC fallback, ever. */
+export function isValidTimeZone(zone: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: zone })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const MONTH_KEY = /^\d{4}-(0[1-9]|1[0-2])$/
+
+/**
+ * Resolve every settings-derived setup requirement.
+ *
+ * Coarse on purpose - one requirement per wizard page, matching
+ * `ACCOUNTING_GOAL_KEYS`. Cutoff and book timezone are two inputs on one page
+ * and are reported as one row.
+ */
+export function resolveSetupReadiness(settings: SettingsRecord): SetupReadiness {
+  const K = OPENING_BASELINE_SETTING_KEYS
+  const R = ABSORPTION_RATE_SETTING_KEYS
+
+  const cutoff = readSettingText(settings[K.cutoffPeriod])
+  const zone = readSettingText(settings[K.bookTimeZone])
+  const periodReason = !cutoff
+    ? 'No cutoff period set.'
+    : !MONTH_KEY.test(cutoff)
+      ? `Cutoff period "${cutoff}" is not a YYYY-MM month.`
+      : !zone
+        ? 'No book timezone set. There is no UTC fallback.'
+        : !isValidTimeZone(zone)
+          ? `"${zone}" is not a valid IANA timezone.`
+          : undefined
+
+  const auxxKeys = [K.inventory_raw_materials, K.inventory_wip, K.inventory_finished_goods]
+  const qboKeys = [
+    'accounting.qboOpeningRawMaterials',
+    'accounting.qboOpeningWip',
+    'accounting.qboOpeningFinishedGoods',
+  ]
+  const missingBalance = [...auxxKeys, ...qboKeys].some(
+    (k) => readSettingMinorUnits(settings[k]) === null
+  )
+  const fractional = [...auxxKeys, ...qboKeys].some(
+    (k) => readSettingMinorUnits(settings[k]) !== null && !isWholeMinorUnits(settings[k])
+  )
+  const journalRef = readSettingText(settings['accounting.qboOpeningJournalRef'])
+  const difference = openingDifference(settings)
+
+  const openingReason = missingBalance
+    ? 'Some opening balances are not set. Zero is a real balance; unset is not.'
+    : fractional
+      ? 'An opening balance is not a whole number of cents.'
+      : !journalRef
+        ? 'No QuickBooks opening journal reference.'
+        : difference !== 0
+          ? 'The auxx and QuickBooks opening snapshots do not agree.'
+          : undefined
+
+  const labor = readSettingMinorUnits(settings[R.assemblyLabor])
+  const overhead = readSettingMinorUnits(settings[R.overhead])
+  const costingReason =
+    labor === null
+      ? 'No assembly labor rate. An unset rate absorbs nothing.'
+      : overhead === null
+        ? 'No overhead rate. An unset rate absorbs nothing.'
+        : undefined
+
+  const requirements: ReadinessRequirement[] = [
+    { key: 'set-accounting-period', met: !periodReason, reason: periodReason },
+    { key: 'set-opening-balances', met: !openingReason, reason: openingReason },
+    { key: 'set-costing', met: !costingReason, reason: costingReason },
+  ]
+
+  return {
+    requirements,
+    settingsReady: requirements.every((r) => r.met),
+    finalized: readSettingText(settings[K.setupState]) === 'finalized',
+  }
+}
+
+/**
+ * Auxx total minus QuickBooks total, in minor units.
+ *
+ * 🛑 Neither number silently overrides the other, which is why this is a
+ * difference rather than a fallback. A difference falling into January's
+ * balancing plug would classify a cutover problem as January COGS; the auxx
+ * number alone would let QuickBooks and the subledger disagree from day one.
+ *
+ * Returns `0` when a figure is missing - "not configured" is reported by
+ * {@link resolveSetupReadiness}, not smuggled in here as a fake disagreement.
+ */
+export function openingDifference(settings: SettingsRecord): number {
+  const K = OPENING_BASELINE_SETTING_KEYS
+  const pairs: Array<[string, string]> = [
+    [K.inventory_raw_materials, 'accounting.qboOpeningRawMaterials'],
+    [K.inventory_wip, 'accounting.qboOpeningWip'],
+    [K.inventory_finished_goods, 'accounting.qboOpeningFinishedGoods'],
+  ]
+  return pairs.reduce((total, [auxxKey, qboKey]) => {
+    const auxx = readSettingMinorUnits(settings[auxxKey])
+    const qbo = readSettingMinorUnits(settings[qboKey])
+    if (auxx === null || qbo === null) return total
+    return total + (auxx - qbo)
+  }, 0)
+}
+
+/** Per-account difference rows, for the reconciliation panel. */
+export function openingDifferenceRows(settings: SettingsRecord): Array<{
+  role: 'inventory_raw_materials' | 'inventory_wip' | 'inventory_finished_goods'
+  auxx: number | null
+  qbo: number | null
+  difference: number | null
+}> {
+  const K = OPENING_BASELINE_SETTING_KEYS
+  const rows = [
+    {
+      role: 'inventory_raw_materials' as const,
+      a: K.inventory_raw_materials,
+      q: 'accounting.qboOpeningRawMaterials',
+    },
+    { role: 'inventory_wip' as const, a: K.inventory_wip, q: 'accounting.qboOpeningWip' },
+    {
+      role: 'inventory_finished_goods' as const,
+      a: K.inventory_finished_goods,
+      q: 'accounting.qboOpeningFinishedGoods',
+    },
+  ]
+  return rows.map(({ role, a, q }) => {
+    const auxx = readSettingMinorUnits(settings[a])
+    const qbo = readSettingMinorUnits(settings[q])
+    return {
+      role,
+      auxx,
+      qbo,
+      difference: auxx === null || qbo === null ? null : auxx - qbo,
+    }
+  })
+}

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -295,3 +295,64 @@ export interface PostResult {
   /** `true` only for a transport failure. The retry decision, precomputed. */
   retryable?: boolean
 }
+
+/**
+ * What an entry WOULD look like, resolved against the org's own chart.
+ *
+ * A read model: `previewEntry` builds it and writes nothing. It lives here
+ * rather than beside `previewEntry` because it crosses the wire to a browser,
+ * and everything in this file is client-safe by construction - `post-entry.ts`
+ * imports `@auxx/database`, so a UI importing this type from there would drag
+ * the server graph into a bundle.
+ */
+export interface EntryPreview {
+  postingType: PostingType
+  periodKey: string
+  txnDate: string
+  docNumber: string
+  lines: ResolvedPostingLine[]
+  totalMinor: number
+  /** Non-empty when the preview would refuse: the same statuses `postEntry` returns. */
+  blockedBy?: { status: PostResultStatus; error: string }
+}
+
+/** One claimed-but-not-posted entry, as the close console's banner reads it. */
+export interface UnpostedPeriod {
+  periodKey: string
+  postingType: PostingType
+  glPostingId: string
+  /**
+   * Kept distinct rather than collapsed into "unposted": `pending` is claimed
+   * and in flight (or claimed by a run that died mid-push, which the idempotency
+   * ladder heals), `failed` was attempted and refused and carries the reason.
+   * They call for different actions.
+   */
+  status: 'pending' | 'failed'
+  docNumber: string
+  attempts: number
+  failureReason: string | null
+}
+
+/** One entry whose lines do not tie, or do not sum to its recorded total. */
+export interface BooksBalanceDiscrepancy {
+  glPostingId: string
+  docNumber: string
+  postingType: PostingType
+  periodKey: string
+  totalDebitMinor: number
+  totalCreditMinor: number
+  /** `GlPosting.totalMinor`, which must equal BOTH sides. */
+  recordedTotalMinor: number
+}
+
+/**
+ * The after-the-fact balance sweep.
+ *
+ * `postingsChecked` rides along on purpose - "0 discrepancies out of 0" and
+ * "0 out of 412" are very different answers and a banner has to tell them apart.
+ */
+export interface BooksBalanceReport {
+  balanced: boolean
+  postingsChecked: number
+  discrepancies: BooksBalanceDiscrepancy[]
+}

--- a/packages/lib/src/postings/verify-balance.ts
+++ b/packages/lib/src/postings/verify-balance.ts
@@ -36,7 +36,12 @@ import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError } from '../errors'
 import { compareMonths, periodMonth } from './periods'
-import type { PostingType } from './types'
+import type {
+  BooksBalanceDiscrepancy,
+  BooksBalanceReport,
+  PostingType,
+  UnpostedPeriod,
+} from './types'
 
 const logger = createScopedLogger('postings:verify-balance')
 
@@ -64,23 +69,9 @@ const logger = createScopedLogger('postings:verify-balance')
 const POSTED_STATUSES = ['posted', 'reversed'] as const
 
 /** One entry whose lines do not tie, or do not agree with its recorded total. */
-export interface BooksBalanceDiscrepancy {
-  glPostingId: string
-  docNumber: string
-  postingType: PostingType
-  periodKey: string
-  totalDebitMinor: number
-  totalCreditMinor: number
-  /** `GlPosting.totalMinor`, which must equal BOTH sides. */
-  recordedTotalMinor: number
-}
-
-export interface BooksBalanceReport {
-  balanced: boolean
-  postingsChecked: number
-  /** One per entry whose lines do not tie, or whose lines do not sum to `totalMinor`. */
-  discrepancies: BooksBalanceDiscrepancy[]
-}
+// `BooksBalanceDiscrepancy` moved to `types.ts` - see the note there.
+// `BooksBalanceReport` moved to `types.ts` - see the note there.
+export type { BooksBalanceDiscrepancy, BooksBalanceReport } from './types'
 
 /**
  * Prove Sigma debit = Sigma credit across every posted entry.
@@ -180,16 +171,8 @@ export async function verifyBooksBalance(
   }
 }
 
-/** One claimed-but-not-posted entry, as the close console's banner reads it. */
-export interface UnpostedPeriod {
-  periodKey: string
-  postingType: PostingType
-  glPostingId: string
-  status: 'pending' | 'failed'
-  docNumber: string
-  attempts: number
-  failureReason: string | null
-}
+// `UnpostedPeriod` moved to `types.ts` - see the note there.
+export type { UnpostedPeriod } from './types'
 
 /**
  * Every entry that has been claimed but is not in the books.

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -141,6 +141,20 @@ export const SETTINGS_CATALOG = {
     description: 'Dispatch getting-started state (wizard + checklist dismissal/completions)',
   },
 
+  'onboarding.accountingGettingStarted': {
+    scope: 'ONBOARDING',
+    access: 'org',
+    fieldType: 'JSON',
+    // GettingStartedState — { dismissedAt, manualCompletions, wizardCompletedAt }
+    //
+    // ⚠️ Only the DISMISSAL and the wizard stamp live here. Every goal is a live
+    // signal computed per call (`getting-started/signals.ts`), which is what
+    // keeps task 12's rule — readiness is derived on read, never stored, because
+    // a stored flag goes stale the moment somebody changes a rate.
+    defaultValue: { dismissedAt: null, manualCompletions: [], wizardCompletedAt: null },
+    description: 'Accounting getting-started state (wizard + checklist dismissal/completions)',
+  },
+
   'notification.emailDigest': {
     scope: 'NOTIFICATION',
     access: 'user',

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -176,6 +176,10 @@ const BOOLEAN_GATES = {
     dataConnectors: true,
     dashboards: true,
     dispatch: true,
+    // The accounting module (plans/money/tasks/13-accounting-ui.md): the general
+    // ledger, the close console and the setup wizard. Tracks `dispatch` above -
+    // same tiers, and both are the manufacturing/field-service bundle.
+    accounting: true,
     // Sequences is metered by `sequencesLimit`, not bundled with `dispatch`. Demo
     // now carries both gates, so the dispatch-triggered client-notification templates
     // are reachable here too (see client-notifications-settings-page.tsx, which
@@ -213,6 +217,10 @@ const BOOLEAN_GATES = {
     dataConnectors: true,
     dashboards: true,
     dispatch: false,
+    // The accounting module (plans/money/tasks/13-accounting-ui.md): the general
+    // ledger, the close console and the setup wizard. Tracks `dispatch` above -
+    // same tiers, and both are the manufacturing/field-service bundle.
+    accounting: false,
     sequences: false,
     granularPermissions: false,
     unrestrictedAiProviders: false,
@@ -242,6 +250,10 @@ const BOOLEAN_GATES = {
     dataConnectors: true,
     dashboards: true,
     dispatch: false,
+    // The accounting module (plans/money/tasks/13-accounting-ui.md): the general
+    // ledger, the close console and the setup wizard. Tracks `dispatch` above -
+    // same tiers, and both are the manufacturing/field-service bundle.
+    accounting: false,
     // On at a metered 3 (`sequencesLimit`) — the upgrade lever into Growth's 25.
     sequences: true,
     granularPermissions: false,
@@ -272,6 +284,10 @@ const BOOLEAN_GATES = {
     dataConnectors: true,
     dashboards: true,
     dispatch: true,
+    // The accounting module (plans/money/tasks/13-accounting-ui.md): the general
+    // ledger, the close console and the setup wizard. Tracks `dispatch` above -
+    // same tiers, and both are the manufacturing/field-service bundle.
+    accounting: true,
     sequences: true,
     granularPermissions: true,
     unrestrictedAiProviders: false,
@@ -301,6 +317,10 @@ const BOOLEAN_GATES = {
     dataConnectors: true,
     dashboards: true,
     dispatch: true,
+    // The accounting module (plans/money/tasks/13-accounting-ui.md): the general
+    // ledger, the close console and the setup wizard. Tracks `dispatch` above -
+    // same tiers, and both are the manufacturing/field-service bundle.
+    accounting: true,
     sequences: true,
     granularPermissions: true,
     unrestrictedAiProviders: false,


### PR DESCRIPTION
Builds the surface a person closes a month in. [Task 10](https://github.com/Auxx-Ai/auxx-ai/pull/1978) shipped the poster **tested but undriven** because there is no ledger screen anywhere in `apps/web` — this is that screen, plus the setup a real organization needs before Post can legally be pressed.

Planned in `plans/money/tasks/13-accounting-ui.md`, which also records what this deliberately does **not** build.

## What this cuts from gap-g, and why

Gap-g describes a ten-check close console with a two-person sign-off. Three of its four headline features are **deferred, not rejected**, for one reason: they have nothing to hold yet.

| Feature | Status |
| --- | --- |
| The ten close checks | Deferred — **zero** of the ten are computable on Jan 1 scope |
| The `G11` sign-off | Already deferred (`decisions.md:143`) |
| `GlClosePeriod` | Deferred, and reshaped to an entity pair when picked up |
| The JE preview + Post | **Built here** |
| The `G19` role map | **Built here** |

🛑 **Gap-g §1 counted three checks as computable. That count assumed gap A (payouts) and gap F (the fulfillment entry) had landed — neither exists.** Re-classified against what the cutover actually ships, check 6 is *tautological* (the GL balance is set **from** the subledger by `month_end_inventory`, so it can only ever agree) and check 7 is *not computable at all* (task 09 resolved PPV to a report). Shipping the checklist now means ten empty checkboxes with prose attached, which gap-g itself argues is worse than none.

What survives from check 6 is the row that can actually fail: **cycle-count evidence**, labelled as evidence rather than as a passing check.

## The module

`/app/accounting`, shaped like `/app/dispatch`. `FeatureKey.accounting` on demo/growth/enterprise, enforced **server-side on the ledger router** as well as in the nav — a feature key that only hides a nav item is a fake gate, because the procedures stay callable.

**One component serves both routes.** The bare route resolves the period and **renders rather than redirecting**, so the module home stays a stable bookmark. Three states: the checklist when setup is not finalized, the open month, or the most recent posted month.

**The month body is a one-entry screen**, because under L1 a month has exactly one entry (`build`/`payout` are in the enum but unused). It carries the JE in accountant's layout, the roll-forward built from `assertions.before`/`after`, blockers at full weight with a link to the fix for each, late-arriving activity, and the count evidence. A revision strip appears only above revision 0 — which is what the `?posting=` drawer is actually for, rather than the primary read path.

Three settings pages, not four: costing folds into General.

## Readiness is a predicate, not a query

`useSettings` rides the hydrated org cache, so every `accounting.*` key is in hand at **zero queries**. `resolveSetupReadiness` is **one** client-safe pure function called by `getting-started/signals.ts` server-side and by the settings pages client-side. Writing that arithmetic twice is the thing that rots: the copies drift and the checklist starts disagreeing with the button.

The checklist **nudges**; `blockedBy` **gates**. Only the server knows *which* part has no standard cost.

## Two client-safety fixes found while wiring it

- `EntryPreview`, `UnpostedPeriod` and the two balance types were declared in files importing `@auxx/database`, so a browser could not hold them. Moved into the client-safe `types.ts`, with re-exports left behind so no server importer changes.
- Same for the opening-baseline setting keys, which lived in a module importing `settings-service`.

## Placeholders

Four procedures do not exist yet — `previewMonthEnd`, `postMonthEnd`, `ledger.get`, and the role-map read/write — so those screens render from `components/accounting/fixtures.ts`. Every fixture is typed against the **real** lib types rather than lookalikes, so swapping one for a query is a one-line change and the compiler catches drift. Each placeholder call site names the procedure that will replace it.

⚠️ **The role map is the first blocker on task 10's browser drive**, not the preview screen: until a role can be mapped, every Preview refuses with `account_unmapped`.

## Two contract items for whoever builds those procedures

1. 🛑 **`PostResultStatus` has no member for "setup is still a draft."** Verified against `types.ts:187`. That refusal — the one every org hits on day one — has nowhere to land but `error`, indistinguishable from an internal failure.
2. **`blockedBy` is one object, not an array**, so "each blocker on its own line" is currently a list of one. The component already takes an array, so widening costs nothing on the UI side.

## Checks

- `typecheck-ratchet --package web`: **0 new** (0 total, baseline 0)
- `typecheck-ratchet --package lib`: **0 new** (29 total, baseline 29)
- `vitest run src/postings src/getting-started`: **335 tests, 15 files, all pass**
- Biome clean

**No migration**, and no data migration either: existing orgs get the feature flipped by hand at `/admin/plans`, so the module is invisible everywhere until that happens. That is intended and must not be read as a bug during review.

🛑 **Not yet driven end to end against the sandbox realm.** That needs the real procedures and remains task 10's owed item — the poster is still not proven.

https://claude.ai/code/session_01XM2UD3MBBHcF3UyoFZ9gEU