### PR TITLE
feat(money): make the chart of accounts editable

### DIFF
--- a/apps/web/src/components/accounting/hooks/use-accounting-provider-status.ts
+++ b/apps/web/src/components/accounting/hooks/use-accounting-provider-status.ts
@@ -20,6 +20,7 @@
 // the adapter on the server, which answers `not_connected`. That is consistent.
 // Do not reconcile the two, and do not build this hook on `resolveConnectedProvider`.
 
+import type { AppConnection } from '~/components/apps/providers/apps-context'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
 
 /** The QuickBooks app's installed-app slug. Same spelling the server's registry uses. */
@@ -37,6 +38,24 @@ export interface AccountingProviderStatus {
   providerLabel: string | null
   /** Where the user goes to install or authorize. */
   appDetailPath: string
+  /**
+   * The installed app's type, required by `AppSettingsDialog`'s settings queries.
+   * `null` until the app is installed - which is exactly when there is no dialog
+   * to open, so a consumer gating on `installed` never sees the null.
+   */
+  installationType: 'development' | 'production' | null
+  /**
+   * The authorized credential itself, when one exists - its label, who connected
+   * it and when, and whether it is org-wide.
+   *
+   * ⚠️ The QuickBooks COMPANY NAME is not in here and cannot be: the credential
+   * stores `metadata.realmId` and nothing else about the company, and the
+   * QuickBooks app's catalog has no `CompanyInfo` tool to fetch a name with. The
+   * label the OAuth callback writes is `Company <realmId>`, so the realm id is
+   * what a person can actually be shown. Naming the company needs a new tool in
+   * the QuickBooks app, not a change here.
+   */
+  connection: AppConnection | null
   /**
    * Installations or connections are still resolving. They land on two separate
    * queries, so `connected` is `false` for a beat after `installed` turns true.
@@ -67,17 +86,20 @@ export function useAccountingProviderStatus(): AccountingProviderStatus {
   // A connection identifies its app by `appId`, not by slug - `listAppConnections`
   // matches the credential's `appId` against the App table and carries no slug - so
   // the installed app's id is the only thing the two sides share.
-  const connected = installation
-    ? appConnections.some(
+  const connection = installation
+    ? (appConnections.find(
         (conn) => conn.appId === installation.app.id && conn.connectionStatus === 'connected'
-      )
-    : false
+      ) ?? null)
+    : null
+  const connected = Boolean(connection)
 
   return {
     installed: Boolean(installation),
     connected,
     providerLabel: connected ? 'QuickBooks Online' : null,
     appDetailPath: QUICKBOOKS_APP_DETAIL_PATH,
+    installationType: installation?.installationType ?? null,
+    connection,
     loading: isLoading || isLoadingConnections,
   }
 }

--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -13,27 +13,41 @@
 // table dump) and `ledger.chartAccounts` returns the org's live `gl_account`
 // instances.
 //
-// 🛑 The Roles tab WRITES; the Chart tab is READ-ONLY. `ledger.setRoleAssignment`
-// exists; there is no create/update procedure for `gl_account` through any
-// surface yet, so the chart is presented as a reference list with a detail pane
-// that has no inputs at all. A disabled-looking form that silently discarded
-// what somebody typed would be strictly worse than not offering the field.
+// 🛑 BOTH tabs write, and every write on this page is on `ledgerPost` - the
+// Full rung of the ledger area. `gl_account` stays `isVisible: false` and this
+// page is its only door, deliberately: `record.create` asserts the generic
+// RECORDS capability, so routing the chart through it would let records-Full /
+// ledger-None decide where money lands. See `routers/ledger.ts`.
+//
+// The chart tab keeps a phantom draft (`ChartDraftHandle`) exactly as the
+// products-services page does, with one difference: the create fires on an
+// explicit button, not on a commit. `gl_account` has three required fields to
+// `catalog_item`'s one, and a unique-code conflict belongs on an act somebody
+// knowingly performed.
 
 import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
-import type { AccountRole, RoleAssignmentRow } from '@auxx/lib/postings/client'
+import type {
+  AccountRole,
+  ChartAccountRow,
+  GlAccountTypeValue,
+  RoleAssignmentRow,
+} from '@auxx/lib/postings/client'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { toastError } from '@auxx/ui/components/toast'
+import { generateId } from '@auxx/utils'
 import { Landmark, Lock, Waypoints } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage from '~/components/global/settings-page'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useMedia } from '~/hooks/use-media'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
-import { ChartAccountDetail } from './chart-account-editor'
+import type { ChartDraftHandle } from './accounts-types'
+import { ChartAccountEditor } from './chart-account-editor'
 import { ChartList } from './chart-list'
 import { RoleMapEditor } from './role-map-editor'
 import { RoleMapList } from './role-map-list'
@@ -64,9 +78,20 @@ export function AccountingAccountsSettingsPage() {
 
   const roleMap = api.ledger.roleMap.useQuery()
   const chart = api.ledger.chartAccounts.useQuery()
+  // Chart tab only: how many posted lines carry each CODE, for the renumber
+  // note. A separate read rather than a field on `ChartAccountRow`, which is
+  // shared with the resolver's path and decoded by every reader of this chart.
+  const chartUsage = api.ledger.chartAccountUsage.useQuery()
 
   const [selectedRole, setSelectedRole] = useState<AccountRole | null>(null)
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null)
+  // The phantom draft for the Chart tab. The full field set lives inside the
+  // draft form instance (keyed by `draftId`); this page tracks only enough to
+  // render the list's phantom row and to know whether the selection is a draft.
+  // An untouched draft is dropped on selecting another row, on adding another
+  // draft, or on switching tabs - never on a mere re-render.
+  const [chartDraft, setChartDraft] = useState<ChartDraftHandle | null>(null)
+  const [confirm, ConfirmDialog] = useConfirm()
 
   const isDesktop = useMedia('(min-width: 1024px)')
 
@@ -126,7 +151,124 @@ export function AccountingAccountsSettingsPage() {
     setRole.mutate({ role, markedUnused: current.state !== 'unused' })
   }
 
+  // ── The chart writes ────────────────────────────────────────────────────
+  //
+  // 🛑 Every refusal below is surfaced VERBATIM, for the reason `setRole` above
+  // states: the server's sentence names the role, the account and what to do
+  // next, and "Could not save" throws that away. Nothing is re-validated here.
+  //
+  // The mutations expose `mutateAsync` to the editor rather than firing toasts,
+  // because a chart refusal belongs on the FIELD that caused it - the code that
+  // collided, the type a role cannot accept - not in a corner of the screen.
+  const createAccount = api.ledger.chartAccountCreate.useMutation()
+  const updateAccount = api.ledger.chartAccountUpdate.useMutation()
+  const removeAccount = api.ledger.chartAccountRemove.useMutation()
+
+  /** A rename or a renumber changes the account rendered on every role row too. */
+  const invalidateChart = useCallback(async () => {
+    await Promise.all([utils.ledger.chartAccounts.invalidate(), utils.ledger.roleMap.invalidate()])
+  }, [utils])
+
+  const handleCreateAccount = useCallback(
+    async (values: {
+      code: string
+      name: string
+      accountType: GlAccountTypeValue
+      isActive: boolean
+    }): Promise<ChartAccountRow> => {
+      const created = await createAccount.mutateAsync(values)
+      await invalidateChart()
+      return created
+    },
+    [createAccount, invalidateChart]
+  )
+
+  const handleUpdateAccount = useCallback(
+    async (
+      id: string,
+      patch: {
+        code?: string
+        name?: string
+        accountType?: GlAccountTypeValue | null
+        isActive?: boolean
+      }
+    ): Promise<ChartAccountRow> => {
+      const updated = await updateAccount.mutateAsync({
+        id,
+        code: patch.code,
+        name: patch.name,
+        // `null` is the draft form's "not chosen yet"; it never reaches a write.
+        accountType: patch.accountType ?? undefined,
+        isActive: patch.isActive,
+      })
+      await invalidateChart()
+      return updated
+    },
+    [updateAccount, invalidateChart]
+  )
+
+  /**
+   * Remove is ARCHIVE server-side, and the confirm says what that means.
+   *
+   * 🛑 The refusal when a role still posts here is the server's, not a
+   * pre-check: a client-side copy of `liveRolesFor` would be a second authority
+   * over the one question this page must not get wrong.
+   */
+  const handleRemoveAccount = useCallback(
+    async (id: string) => {
+      const account = accounts.find((row) => row.id === id)
+      const confirmed = await confirm({
+        title: 'Remove account?',
+        description: `${account ? `${account.code} ${account.name} ` : 'This account '}comes out of the chart. Entries already posted keep the code and the name they were written with, and a re-seed will not bring it back.`,
+        confirmText: 'Remove',
+        cancelText: 'Cancel',
+        destructive: true,
+      })
+      if (!confirmed) return
+
+      await removeAccount.mutateAsync({ id })
+      await invalidateChart()
+      if (selectedAccountId === id) setSelectedAccountId(null)
+    },
+    [accounts, confirm, removeAccount, invalidateChart, selectedAccountId]
+  )
+
+  // ── The phantom draft ───────────────────────────────────────────────────
+
+  function handleSelectAccount(id: string | null) {
+    // Selecting anything other than the draft itself - or its committed record,
+    // which keeps the draft form mounted - drops the draft.
+    if (chartDraft && id !== chartDraft.draftId && id !== chartDraft.recordId) {
+      setChartDraft(null)
+    }
+    setSelectedAccountId(id)
+  }
+
+  function handleAddChartDraft() {
+    if (chartDraft && !chartDraft.recordId) {
+      setSelectedAccountId(chartDraft.draftId) // uncommitted one exists - re-select it
+      return
+    }
+    const draftId = generateId('draft')
+    setChartDraft({ draftId, code: '', name: '' })
+    setSelectedAccountId(draftId)
+  }
+
+  function handleChartDraftChange(patch: { code?: string; name?: string }) {
+    setChartDraft((prev) => (prev ? { ...prev, ...patch } : prev))
+  }
+
+  /** First create resolved: swap selection to the real id but KEEP the draft, so
+   *  the draft form stays mounted and text typed mid-round-trip is not lost. */
+  function handleChartDraftCommitted(recordId: string) {
+    setChartDraft((prev) => (prev ? { ...prev, recordId } : prev))
+    setSelectedAccountId(recordId)
+  }
+
   function handleTabChange(next: string) {
+    // An untouched draft does not survive a tab switch - the other tab's list no
+    // longer renders the phantom row, so hanging onto it would be confusing.
+    if (chartDraft) setChartDraft(null)
     setTab(next)
   }
 
@@ -155,10 +297,17 @@ export function AccountingAccountsSettingsPage() {
         onToggleUnused={handleToggleUnused}
       />
     ) : (
-      <ChartAccountDetail
+      <ChartAccountEditor
         selectedId={selectedAccountId}
         accounts={accounts}
         roles={selectedAccountId ? (rolesByAccountId.get(selectedAccountId) ?? []) : []}
+        usage={chartUsage.data ?? {}}
+        draft={chartDraft}
+        onDraftChange={handleChartDraftChange}
+        onCreate={handleCreateAccount}
+        onDraftCommitted={handleChartDraftCommitted}
+        onUpdate={handleUpdateAccount}
+        onRemove={handleRemoveAccount}
       />
     )
 
@@ -192,8 +341,10 @@ export function AccountingAccountsSettingsPage() {
               accounts={accounts}
               isLoading={chart.isPending}
               selectedId={selectedAccountId}
-              onSelect={setSelectedAccountId}
+              onSelect={handleSelectAccount}
               rolesByAccountId={rolesByAccountId}
+              draft={chartDraft}
+              onAddDraft={handleAddChartDraft}
             />
           )}
         </div>
@@ -225,7 +376,7 @@ export function AccountingAccountsSettingsPage() {
         onOpenChange={(open) => {
           if (!open) {
             setSelectedRole(null)
-            setSelectedAccountId(null)
+            handleSelectAccount(null)
           }
         }}
         isDocked={false}
@@ -236,6 +387,8 @@ export function AccountingAccountsSettingsPage() {
         title={activeTab === 'roles' ? 'Map role' : 'Account'}>
         {editorContent}
       </DockableDrawer>
+
+      <ConfirmDialog />
     </SettingsPage>
   )
 }

--- a/apps/web/src/components/accounting/ui/settings/accounts-types.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounts-types.ts
@@ -70,3 +70,28 @@ export function formatAccount(account: ChartAccountRow | null | undefined): stri
   if (!account) return ''
   return `${account.code} · ${account.name}`
 }
+
+/**
+ * The phantom draft the Chart of accounts tab keeps while somebody is adding an
+ * account, owned by `accounts-settings-page.tsx`.
+ *
+ * Only enough to render the list's phantom row and to know whether the current
+ * selection is a draft — the full field set lives inside the draft form instance
+ * (keyed by `draftId`), exactly as `CatalogDraftHandle` has it.
+ */
+export interface ChartDraftHandle {
+  draftId: string
+  /** Live preview of the code being typed, for the phantom row. */
+  code: string
+  /** Live preview of the name being typed, for the phantom row. */
+  name: string
+  /**
+   * Set once the draft's `chartAccountCreate` resolves. The draft is KEPT alive
+   * after creation (with selection swapped to this id) so the draft form stays
+   * mounted — a remount onto the query-bound form mid-typing would replace the
+   * input's text and cancel the pending debounced commit. The list hides the
+   * phantom row once this is set (the real row arrived with the invalidated
+   * query); the draft is dropped when the user navigates to another row or tab.
+   */
+  recordId?: string
+}

--- a/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
@@ -1,58 +1,354 @@
 // apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
 'use client'
 
-// The right column of the Chart of accounts tab: what the selected `gl_account`
-// row says.
+// The right column of the Chart of accounts tab: the selected `gl_account`, as a
+// form.
 //
-// 🛑 A READ-ONLY PANE, not a disabled form. There is no create or update
-// procedure for a `gl_account` behind any surface yet - `ledger.chartAccounts`
-// reads, and nothing writes - so this pane renders values, never inputs. The
-// previous version was an autosaving `FieldInputAdapter` form plus a phantom
-// draft that created rows in local React state; both have been removed rather
-// than disabled, because the failure mode to avoid is somebody typing into a
-// field whose work is silently discarded, and a field that merely LOOKS disabled
-// is one prop away from doing exactly that again.
+// 🛑 ONE FORM, TWO MODES - not a draft form and an editor form. An uncommitted
+// draft and a saved account render the identical four rows off the identical
+// local state; the only difference is where a commit GOES, which is one branch
+// on `recordIdRef`. The products-services page (the pattern this copies) does
+// split them, and it has to: its committed form binds to the field-value store
+// through `useSaveFieldValue` while its draft binds to local state, so the two
+// really are different data paths. Here both go through `ledger.chartAccount*`,
+// so a split would be two copies of one layout drifting apart.
 //
-// When the `gl_account` record path lands (the generic resource CRUD already has
-// `resources/registry/resources/gl-account-fields.ts`), the honest move is to
-// link this pane at the record detail view rather than to grow a second door.
+// 🛑 AUTOSAVES PER FIELD once the account exists, through
+// `ledger.chartAccountUpdate` - NOT `useSaveFieldValue`, which routes to
+// `fieldValue.set` and therefore to the generic RECORDS capability. The chart
+// decides where real money lands, so its whole door is on `ledgerPost`; see the
+// argument on `chartAccountCreate` in `routers/ledger.ts`.
+//
+// 🛑 CREATE FIRES ON A BUTTON, not on a commit. `ProductDraftEditorForm` creates
+// implicitly the moment its ONE required field is non-empty. `gl_account` has
+// THREE required fields and `accountType` has no honest default, so an implicit
+// create would put a unique-code conflict on an act the person did not knowingly
+// perform - they picked a type, and back comes "4000 is already in use". The
+// button makes the create the thing they just did.
+//
+// This file was a READ-ONLY pane between #1982 and this change, and before #1982
+// it was an autosaving form whose every commit wrote LOCAL REACT STATE. The
+// read-only pane was the fix for that, not a placeholder for this: what makes the
+// inputs honest now is that `chartAccountUpdate` exists, and nothing else.
 
+import { FieldType } from '@auxx/database/enums'
 import {
   ACCOUNT_ROLE_LABELS,
   type AccountRole,
   type ChartAccountRow,
+  type GlAccountTypeValue,
 } from '@auxx/lib/postings/client'
-import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { EmptySection } from '@auxx/ui/components/section'
+import { Landmark, Trash2 } from 'lucide-react'
+import { useCallback, useRef, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { accountTypeColor, accountTypeLabel } from './accounts-types'
+import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+import { ACCOUNT_TYPE_OPTIONS, type ChartDraftHandle } from './accounts-types'
 
 /**
- * ⚠️ Renumbering does NOT rewrite history, and this pane says so because a
- * person reading a code here is the person who would go and change it. A posting
- * line names an account by CODE with no foreign key, deliberately, so the ledger
- * outlives the chart - which means a renumber silently detaches every line
- * already posted from the row on screen.
+ * ⚠️ A `SINGLE_SELECT` hands its value back as an ARRAY - `['expense']` - because
+ * the picker underneath is the multi-select one with `multi: false`
+ * (`field-input-adapter.tsx`, which normalises `value` to `[value]` on the way
+ * in and never un-wraps it on the way out). Passing that straight to the wire is
+ * a Zod refusal reading "Invalid option: expected one of asset|liability|...",
+ * which names the right values and gives no hint that the problem is the shape.
+ *
+ * Normalise at the boundary, exactly as the pre-#1982 version of this file did.
  */
-const RENUMBER_NOTE =
-  'A posted line stores the account code with no foreign key, on purpose, so the ledger ' +
-  'outlives the chart. Renumbering an account leaves every line already posted holding the ' +
-  'old code.'
-
-interface ChartAccountDetailProps {
-  selectedId: string | null
-  accounts: ChartAccountRow[]
-  /** Posting roles currently pointed at this account. */
-  roles: AccountRole[]
+function firstSelected(value: unknown): string | null {
+  if (Array.isArray(value)) return (value[0] as string) ?? null
+  return (value as string) || null
 }
 
-export function ChartAccountDetail({ selectedId, accounts, roles }: ChartAccountDetailProps) {
+/** Which field a refusal belongs to. Routed from the patch key that caused it. */
+type FieldKey = 'code' | 'name' | 'accountType' | 'isActive' | 'form'
+
+/** The four writable attributes, as the form holds them. */
+interface AccountValues {
+  code: string
+  name: string
+  /** `null` only in draft mode - "not chosen yet" never reaches a write. */
+  accountType: GlAccountTypeValue | null
+  isActive: boolean
+}
+
+/** One create's payload. Every field is settled by the time this is built. */
+export interface NewChartAccount {
+  code: string
+  name: string
+  accountType: GlAccountTypeValue
+  isActive: boolean
+}
+
+interface ChartAccountEditorProps {
+  selectedId: string | null
+  accounts: ChartAccountRow[]
+  /** Posting roles currently pointed at the selected account. */
+  roles: AccountRole[]
+  /** Posted lines per account CODE, from `ledger.chartAccountUsage`. */
+  usage: Record<string, number>
+  /** Phantom draft for this tab, owned by `accounts-settings-page.tsx`. */
+  draft: ChartDraftHandle | null
+  /** List phantom-row preview sync, fired per debounced commit. */
+  onDraftChange: (patch: { code?: string; name?: string }) => void
+  /** Creates the account. Rejects with the server's message. */
+  onCreate: (values: NewChartAccount) => Promise<ChartAccountRow>
+  /** First create resolved: swap `selectedId` to the real id, KEEPING the draft. */
+  onDraftCommitted: (recordId: string) => void
+  /** Writes one attribute. Rejects with the server's message. */
+  onUpdate: (id: string, patch: Partial<AccountValues>) => Promise<ChartAccountRow>
+  /** Confirms, then archives. Rejects with the server's message. */
+  onRemove: (id: string) => Promise<void>
+}
+
+/**
+ * ⚠️ Renumbering does NOT rewrite history, and this pane says so because a person
+ * reading a code here is the person who would go and change it. A posting line
+ * names an account by CODE with no foreign key, deliberately, so the ledger
+ * outlives the chart - which means a renumber leaves every line already posted
+ * holding the old code.
+ *
+ * Stated with a COUNT (`ledger.chartAccountUsage`): "142 posted lines carry 1310"
+ * is a fact about this account, where a general caution is something to scroll
+ * past.
+ */
+function codeDescription(code: string, postedLines: number): string {
+  if (postedLines === 0) {
+    return 'The account number. Unique across the chart, and yours to change. Nothing has posted to this code yet, so renumbering costs nothing today.'
+  }
+  return `${postedLines} posted ${postedLines === 1 ? 'line carries' : 'lines carry'} ${code}. A posted line stores the account code with no foreign key, on purpose, so the ledger outlives the chart - renumbering leaves every one of them holding the old code.`
+}
+
+export function ChartAccountEditor({
+  selectedId,
+  accounts,
+  roles,
+  usage,
+  draft,
+  onDraftChange,
+  onCreate,
+  onDraftCommitted,
+  onUpdate,
+  onRemove,
+}: ChartAccountEditorProps) {
+  // The draft stays active while `selectedId` is its COMMITTED id too - swapping
+  // to a query-bound instance would remount the inputs mid-typing (replaced text,
+  // cancelled debounce timer).
+  const draftActive =
+    !!draft && (selectedId === draft.draftId || (!!draft.recordId && selectedId === draft.recordId))
+
+  if (draft && draftActive) {
+    return (
+      <ChartAccountForm
+        key={draft.draftId}
+        account={null}
+        roles={[]}
+        postedLines={0}
+        onDraftChange={onDraftChange}
+        onCreate={onCreate}
+        onDraftCommitted={onDraftCommitted}
+        onUpdate={onUpdate}
+        onRemove={onRemove}
+      />
+    )
+  }
+
   const account = selectedId ? accounts.find((row) => row.id === selectedId) : undefined
 
   if (!account) {
-    return <div className='p-4 text-muted-foreground text-sm'>Select an account to see it.</div>
+    return (
+      <div className='p-3'>
+        <EmptySection
+          orientation='horizontal'
+          icon={<Landmark />}
+          title='Select an account'
+          description='Or add one to the chart.'
+        />
+      </div>
+    )
   }
+
+  return (
+    <ChartAccountForm
+      key={account.id}
+      account={account}
+      roles={roles}
+      postedLines={usage[account.code] ?? 0}
+      onDraftChange={onDraftChange}
+      onCreate={onCreate}
+      onDraftCommitted={onDraftCommitted}
+      onUpdate={onUpdate}
+      onRemove={onRemove}
+    />
+  )
+}
+
+/**
+ * The four rows, in both modes.
+ *
+ * `account: null` is the draft: commits buffer locally and the Create button
+ * appears. A non-null `account` seeds the same state and `recordIdRef`, so every
+ * commit writes immediately and Remove appears instead. **A draft that has just
+ * been created is the first case turning into the second WITHOUT a remount** -
+ * that is what `recordIdRef` is for, and it is why the page keeps the draft alive
+ * after `onDraftCommitted`.
+ *
+ * ⚠️ Values are local state seeded once, not bound to the query row, in both
+ * modes. This pane is the only writer, `key` remounts it on selection change, and
+ * local state is what keeps a `SINGLE_SELECT` from flickering back to its old
+ * value while its mutation is in flight.
+ */
+function ChartAccountForm({
+  account,
+  roles,
+  postedLines,
+  onDraftChange,
+  onCreate,
+  onDraftCommitted,
+  onUpdate,
+  onRemove,
+}: {
+  account: ChartAccountRow | null
+  roles: AccountRole[]
+  postedLines: number
+} & Pick<
+  ChartAccountEditorProps,
+  'onDraftChange' | 'onCreate' | 'onDraftCommitted' | 'onUpdate' | 'onRemove'
+>) {
+  const valuesRef = useRef<AccountValues>({
+    code: account?.code ?? '',
+    name: account?.name ?? '',
+    accountType: account?.accountType ?? null,
+    isActive: account?.isActive ?? true,
+  })
+  const [values, setValues] = useState<AccountValues>(valuesRef.current)
+  const [errors, setErrors] = useState<Partial<Record<FieldKey, string>>>({})
+  const [creating, setCreating] = useState(false)
+  const [removing, setRemoving] = useState(false)
+
+  // 🛑 Synchronous, NOT state-derived: a `disabled` prop driven by `creating` is
+  // not enough, because two clicks landing before a re-render both pass it. In
+  // products a double create is two catalog items; here the second collides on
+  // the unique `code`, so the person sees an error for an account that was in
+  // fact created fine.
+  const creatingRef = useRef(false)
+  // Null while the draft is uncommitted; set the moment the create resolves, and
+  // seeded for an existing account. THE branch this whole component turns on.
+  const recordIdRef = useRef<string | null>(account?.id ?? null)
+  const [committed, setCommitted] = useState(!!account)
+
+  /**
+   * Merge one attribute, then route it.
+   *
+   * 🛑 A refusal is rendered VERBATIM on the row that caused it. The role map
+   * made this call first and wrote down why: replacing "'grni' must be mapped to
+   * a liability account, but 4000 Sales is a revenue account" with "Could not
+   * save" throws away the only sentence that says what to do next. Nothing is
+   * re-validated here - a second client-side authority drifts from the server's.
+   */
+  const commit = useCallback(
+    (key: FieldKey, patch: Partial<AccountValues>) => {
+      const merged = { ...valuesRef.current, ...patch }
+      valuesRef.current = merged
+      setValues(merged)
+
+      const recordId = recordIdRef.current
+      if (!recordId) {
+        // Buffering. The phantom row is the only feedback there is until the
+        // Create button lights up, so keep it in step.
+        if (patch.code !== undefined || patch.name !== undefined) {
+          onDraftChange({ code: merged.code, name: merged.name })
+        }
+        return
+      }
+
+      setErrors((prev) => ({ ...prev, [key]: undefined }))
+      void onUpdate(recordId, patch).catch((error: unknown) => {
+        setErrors((prev) => ({
+          ...prev,
+          [key]: error instanceof Error ? error.message : 'Could not save the change.',
+        }))
+      })
+    },
+    [onDraftChange, onUpdate]
+  )
+
+  const commitCode = useDebouncedCallback((value: string) => commit('code', { code: value }), 500)
+  const commitName = useDebouncedCallback((value: string) => commit('name', { name: value }), 500)
+
+  const canCreate =
+    values.code.trim().length > 0 && values.name.trim().length > 0 && values.accountType !== null
+
+  const handleCreate = useCallback(async () => {
+    if (creatingRef.current || recordIdRef.current) return
+    const snapshot = valuesRef.current
+    if (!snapshot.code.trim() || !snapshot.name.trim() || !snapshot.accountType) return
+
+    creatingRef.current = true
+    setCreating(true)
+    setErrors({})
+
+    try {
+      const created = await onCreate({
+        code: snapshot.code.trim(),
+        name: snapshot.name.trim(),
+        accountType: snapshot.accountType,
+        isActive: snapshot.isActive,
+      })
+
+      // Flip the commit target FIRST - a keystroke landing while we settle below
+      // must route to the real account, not back into the buffered branch.
+      recordIdRef.current = created.id
+      setCommitted(true)
+
+      // Whatever was typed while the create was in flight, against the now-real
+      // account. One call, because a create carries the whole snapshot.
+      const latest = valuesRef.current
+      const changed: Partial<AccountValues> = {}
+      if (latest.code.trim() !== snapshot.code.trim()) changed.code = latest.code.trim()
+      if (latest.name.trim() !== snapshot.name.trim()) changed.name = latest.name.trim()
+      if (latest.accountType && latest.accountType !== snapshot.accountType) {
+        changed.accountType = latest.accountType
+      }
+      if (latest.isActive !== snapshot.isActive) changed.isActive = latest.isActive
+      if (Object.keys(changed).length > 0) await onUpdate(created.id, changed)
+
+      onDraftCommitted(created.id)
+    } catch (error) {
+      creatingRef.current = false
+      // A unique-code collision is a 409, and on `gl_account` it is always the
+      // code - the only unique field. Everything else is a form-level refusal.
+      const message = error instanceof Error ? error.message : 'Could not create the account.'
+      const isConflict =
+        typeof error === 'object' &&
+        error !== null &&
+        (error as { data?: { code?: string } }).data?.code === 'CONFLICT'
+      setErrors(isConflict ? { code: message } : { form: message })
+    } finally {
+      setCreating(false)
+    }
+  }, [onCreate, onDraftCommitted, onUpdate])
+
+  const handleRemove = useCallback(async () => {
+    const recordId = recordIdRef.current
+    if (!recordId) return
+    setRemoving(true)
+    setErrors((prev) => ({ ...prev, form: undefined }))
+    try {
+      await onRemove(recordId)
+    } catch (error) {
+      setErrors((prev) => ({
+        ...prev,
+        form: error instanceof Error ? error.message : 'Could not remove the account.',
+      }))
+    } finally {
+      setRemoving(false)
+    }
+  }, [onRemove])
 
   return (
     // `min-h-0` + `ScrollArea`: this pane sits inside a sticky container capped
@@ -67,58 +363,139 @@ export function ChartAccountDetail({ selectedId, accounts, roles }: ChartAccount
           resizeId='gl-account-detail'
           defaultLabelWidth={160}
           className='shrink-0 grow-0 p-0'>
-          <FieldPanelRow title='Code' type={BaseType.STRING} showIcon>
-            <div className='flex min-h-8 items-center text-sm tabular-nums'>{account.code}</div>
+          <FieldPanelRow
+            title='Code'
+            type={BaseType.STRING}
+            showIcon
+            isRequired
+            description={codeDescription(values.code, postedLines)}>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={values.code}
+              onChange={(value) => {
+                valuesRef.current = { ...valuesRef.current, code: value as string }
+                setValues(valuesRef.current)
+                commitCode(value as string)
+              }}
+              placeholder='1310'
+            />
+            <FieldError message={errors.code} />
           </FieldPanelRow>
 
-          <FieldPanelRow title='Name' type={BaseType.STRING} showIcon>
-            <div className='flex min-h-8 items-center text-sm'>{account.name}</div>
+          <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={values.name}
+              onChange={(value) => {
+                valuesRef.current = { ...valuesRef.current, name: value as string }
+                setValues(valuesRef.current)
+                commitName(value as string)
+              }}
+              placeholder='Raw Materials'
+            />
+            <FieldError message={errors.name} />
           </FieldPanelRow>
 
           <FieldPanelRow
             title='Type'
             type={BaseType.ENUM}
             showIcon
+            isRequired
             description='The statement classification. A role can only be mapped to an account of the type it declares.'>
-            <div className='flex min-h-8 items-center'>
-              <Badge variant={accountTypeColor(account.accountType)} size='xs'>
-                {accountTypeLabel(account.accountType)}
-              </Badge>
-            </div>
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Active' type={BaseType.BOOLEAN} showIcon>
-            <div className='flex min-h-8 items-center'>
-              <Badge variant={account.isActive ? 'green' : 'outline'} size='xs'>
-                {account.isActive ? 'Active' : 'Inactive'}
-              </Badge>
-            </div>
+            <FieldInputAdapter
+              fieldType={FieldType.SINGLE_SELECT}
+              fieldOptions={{ options: ACCOUNT_TYPE_OPTIONS }}
+              value={values.accountType}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              onChange={(value) => {
+                const next = firstSelected(value)
+                if (next) commit('accountType', { accountType: next as GlAccountTypeValue })
+              }}
+              placeholder='Select account type'
+            />
+            <FieldError message={errors.accountType} />
           </FieldPanelRow>
 
           <FieldPanelRow
-            title='Roles'
-            type={BaseType.STRING}
+            title='Active'
+            type={BaseType.BOOLEAN}
             showIcon
-            description='Posting roles that resolve to this account. Change them on the Roles tab.'>
-            <div className='flex min-h-8 items-center text-sm'>
-              {roles.length === 0 ? (
-                <span className='text-muted-foreground'>No role posts here</span>
-              ) : (
-                <span>{roles.map((role) => ACCOUNT_ROLE_LABELS[role]).join(', ')}</span>
-              )}
-            </div>
+            description='An inactive account stays in the chart but cannot be mapped to a posting role.'>
+            <FieldInputAdapter
+              fieldType={FieldType.CHECKBOX}
+              // The binary `switch` variant, not the default tri-state button
+              // group: `gl_account_is_active` is `nullable: false` with
+              // `defaultValue: true`, so a third "not set" state would be a value
+              // the column cannot hold.
+              fieldOptions={{ variant: 'switch' }}
+              value={values.isActive}
+              onChange={(value) => commit('isActive', { isActive: value as boolean })}
+            />
+            <FieldError message={errors.isActive} />
           </FieldPanelRow>
+
+          {committed && (
+            <FieldPanelRow
+              title='Roles'
+              type={BaseType.STRING}
+              showIcon
+              description='Posting roles that resolve to this account. Change them on the Roles tab.'>
+              <div className='flex min-h-8 items-center text-sm'>
+                {roles.length === 0 ? (
+                  <span className='text-muted-foreground'>No role posts here</span>
+                ) : (
+                  <span>{roles.map((role) => ACCOUNT_ROLE_LABELS[role]).join(', ')}</span>
+                )}
+              </div>
+            </FieldPanelRow>
+          )}
         </FieldPanel>
 
-        <div className='mt-3 space-y-1 rounded-xl border p-3'>
-          <p className='font-medium text-sm'>The chart is not editable here yet</p>
-          <p className='text-muted-foreground text-xs'>
-            Adding, renaming and renumbering accounts arrives with the account record path. Until
-            then this pane reads the chart, and the Roles tab decides where each posting role lands.{' '}
-            {RENUMBER_NOTE}
-          </p>
+        <div className='mt-3 flex flex-col gap-2'>
+          {committed ? (
+            <>
+              <Button
+                variant='outline'
+                size='sm'
+                className='self-start text-destructive'
+                loading={removing}
+                loadingText='Removing...'
+                onClick={() => void handleRemove()}>
+                <Trash2 />
+                Remove account
+              </Button>
+              <FieldError message={errors.form} />
+              <p className='text-muted-foreground text-xs'>
+                Changes save as you make them. Removing takes the account out of the chart; entries
+                already posted keep the code and the name they were written with.
+              </p>
+            </>
+          ) : (
+            <>
+              <Button
+                variant='outline'
+                size='sm'
+                className='self-start'
+                disabled={!canCreate}
+                loading={creating}
+                loadingText='Creating...'
+                onClick={() => void handleCreate()}>
+                Create account
+              </Button>
+              <FieldError message={errors.form} />
+              <p className='text-muted-foreground text-xs'>
+                A code, a name and a type are all required. Nothing is written until you create it.
+              </p>
+            </>
+          )}
         </div>
       </ScrollArea>
     </div>
   )
+}
+
+/** One server refusal, on the row that caused it. Rendered verbatim. */
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null
+  return <p className='mt-1 text-destructive text-xs'>{message}</p>
 }

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -1,24 +1,30 @@
 // apps/web/src/components/accounting/ui/settings/chart-list.tsx
 'use client'
 
-// The left column of the Chart of accounts tab: search above a flat `TreeRow`
-// list of the org's live `gl_account` rows, from `ledger.chartAccounts`.
+// The left column of the Chart of accounts tab: search and an Add button above a
+// flat `TreeRow` list of the org's live `gl_account` rows, from
+// `ledger.chartAccounts`.
 //
-// 🛑 READ-ONLY, and deliberately so. There is no create, update, archive or
-// activate procedure for a `gl_account` through any surface yet, so this list
-// offers no Add button, no delete and no active/inactive switch. An affordance
-// that looked writable and was not is worse than no affordance: it teaches
-// somebody the chart is theirs to edit here, and then loses the edit.
+// The chart WRITES now (`ledger.chartAccountCreate` / `Update` / `Remove`, all on
+// `ledgerPost`). This list owns only the Add affordance and the phantom row; the
+// fields, the removal and every refusal live in the detail pane, where a message
+// has a row to land on.
+//
+// 🛑 The phantom row is what makes the draft's buffering visible. Between "Add
+// account" and the Create button becoming enabled, the only evidence that
+// anything is happening is this row tracking what is being typed - without it
+// the person is filling in a form with no place in the list.
 
 import type { AccountRole, ChartAccountRow } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Landmark } from 'lucide-react'
+import { Landmark, Plus } from 'lucide-react'
 import { useState } from 'react'
-import { accountTypeColor, accountTypeLabel } from './accounts-types'
+import { accountTypeColor, accountTypeLabel, type ChartDraftHandle } from './accounts-types'
 
 interface ChartListProps {
   accounts: ChartAccountRow[]
@@ -29,6 +35,9 @@ interface ChartListProps {
   onSelect: (id: string | null) => void
   /** Roles pointing at each account id, for the "2 roles" note on a row. */
   rolesByAccountId: Map<string, AccountRole[]>
+  /** The uncommitted draft, if any. Rendered as a phantom row at the top. */
+  draft: ChartDraftHandle | null
+  onAddDraft: () => void
 }
 
 export function ChartList({
@@ -37,6 +46,8 @@ export function ChartList({
   selectedId,
   onSelect,
   rolesByAccountId,
+  draft,
+  onAddDraft,
 }: ChartListProps) {
   const [search, setSearch] = useState('')
 
@@ -47,24 +58,39 @@ export function ChartList({
       )
     : accounts
 
+  // Hidden once `recordId` is stamped: the real row arrived with the invalidated
+  // query, and rendering both would show the same account twice.
+  const phantom = draft && !draft.recordId ? draft : null
+
   return (
     <div className='flex flex-col gap-3 p-3'>
-      <InputSearch
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder='Search accounts...'
-      />
+      <div className='flex items-center gap-2'>
+        <InputSearch
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder='Search accounts...'
+          className='flex-1'
+        />
+        <Button variant='outline' size='sm' onClick={onAddDraft}>
+          <Plus />
+          Add account
+        </Button>
+      </div>
 
       {isLoading ? (
         <EmptySection loading />
-      ) : filtered.length === 0 ? (
+      ) : filtered.length === 0 && !phantom ? (
         <EmptySection
           icon={<Landmark className='size-5' />}
           title={search ? 'No matches' : 'No accounts in the chart'}
+          // ⚠️ This copy used to blame the entity migrations, and that stopped
+          // being true: `gl_account`'s DEFINITION ships with every org, its ROWS
+          // are provisioned on purpose from the setup wizard, so an empty chart
+          // is now an ordinary state rather than a broken one.
           description={
             search
               ? undefined
-              : 'The chart is provisioned with the org. If it is empty, the accounting entity migrations have not run for this organization.'
+              : 'Add accounts here, or let the accounting setup create the 29-account default chart for you.'
           }
         />
       ) : (
@@ -75,6 +101,30 @@ export function ChartList({
         // has. The role map's secondary carries a sentence instead, so it must
         // NOT wear this class or the sentence stops truncating and overflows.
         <div className={cn('flex flex-col gap-0.5', TREE_SECONDARY_NOTRUNCATE)}>
+          {phantom && (
+            <TreeRow
+              key={phantom.draftId}
+              icon={<Landmark className='size-4 text-muted-foreground' />}
+              title={
+                <span className='flex items-baseline gap-2'>
+                  <span className='text-muted-foreground text-xs tabular-nums'>
+                    {phantom.code || '—'}
+                  </span>
+                  <span className='text-sm'>{phantom.name || 'New account'}</span>
+                </span>
+              }
+              secondaryFill
+              onToggleOpen={() => onSelect(phantom.draftId)}
+              rowClassName={cn(
+                'bg-primary-100/50 hover:bg-primary-100',
+                selectedId === phantom.draftId && 'bg-primary-100 ring-1 ring-primary-200'
+              )}
+              secondary={
+                <span className='text-muted-foreground text-xs italic'>Not created yet</span>
+              }
+            />
+          )}
+
           {filtered.map((account) => {
             const roles = rolesByAccountId.get(account.id) ?? []
             return (

--- a/apps/web/src/components/accounting/ui/settings/quickbooks-section.tsx
+++ b/apps/web/src/components/accounting/ui/settings/quickbooks-section.tsx
@@ -4,24 +4,29 @@
 // Accounting > Settings > General: install, connect and status for the
 // accounting provider (14-drive-the-close.md §4).
 //
-// The module could be fully set up with no way to reach the provider from
-// anywhere inside it, and the status display that did exist was buried on the
-// Accounts > Role map tab, where it is a non sequitur. This section is that
-// display plus the two actions, copied from
-// `~/components/money/ui/settings/quickbooks-section.tsx`.
-//
 // 🛑 Keep the tone. Decision `P1` makes "nothing connected" a FIRST-CLASS
 // outcome: the entry is still built, balanced and persisted, and the result is
 // `not_connected` rather than a failure. The install button is discoverability -
 // no destructive variant, no "action required", no checklist goal.
 // `getting-started.ts` records that `connect-quickbooks` is deliberately not a
 // goal, and that decision stands.
+//
+// 🛑 CONNECT AND MANAGE OPEN `AppSettingsDialog`, they do not navigate. Sending
+// somebody to `/app/settings/apps/quickbooks` drops them out of the accounting
+// module in the middle of setting it up, with no way back but the browser button
+// - and the dialog is where the OAuth flow lives anyway (`app-install-card.tsx`
+// opens it exactly this way, on the `connections` tab). The app detail PAGE is
+// still linked from the not-installed row, because that is a browse action
+// rather than a step in a flow.
 
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Landmark } from 'lucide-react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useState } from 'react'
 import { InlineAppInstallButton } from '~/components/apps/ui/app-install-button'
+import { AppSettingsDialog } from '~/components/apps/ui/app-settings-dialog'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
@@ -30,26 +35,50 @@ import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider
 const NOT_CONNECTED_COPY =
   'Entries are still built, balanced and stored here. Nothing is blocked by this.'
 
+/** `12 Aug 2026`, or nothing at all rather than an `Invalid Date`. */
+function formatDate(value: Date | string | null | undefined): string | null {
+  if (!value) return null
+  const date = typeof value === 'string' ? new Date(value) : value
+  return Number.isNaN(date.getTime())
+    ? null
+    : date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
 /**
  * The accounting provider's install / connect / connected state, as one section.
  *
  * Three states, off `useAccountingProviderStatus()`:
  *
  * 1. Not installed - an `InlineAppInstallButton` and a link to the app detail page.
- * 2. Installed, not connected - a "Connect QuickBooks" button pointing at the app
- *    detail page, where the OAuth flow lives. Connecting is not done from here.
- * 3. Connected - the provider name, and what being connected changes.
+ * 2. Installed, not connected - "Connect QuickBooks" opens `AppSettingsDialog` on
+ *    its `connections` tab, which owns the whole OAuth flow.
+ * 3. Connected - which company, who authorized it and when, plus Manage.
  *
- * 🛑 This section owns NO settings values. It is presentational plus two
- * navigation actions, so it stays outside the page's `useDirtyDraft` slices and
- * adds nothing to `DRAFT_KEYS`.
+ * 🛑 This section owns NO settings values. It is presentational plus two dialog
+ * actions, so it stays outside the page's `useDirtyDraft` slices and adds nothing
+ * to `DRAFT_KEYS`.
  *
  * 🛑 None of the three states is a warning. See the `P1` note at the top of this
  * file and in `use-accounting-provider-status.ts` before changing a badge colour.
  */
 export function QuickbooksSettingsSection() {
-  const { installed, connected, providerLabel, appDetailPath, loading } =
-    useAccountingProviderStatus()
+  const {
+    installed,
+    connected,
+    providerLabel,
+    appDetailPath,
+    installationType,
+    connection,
+    loading,
+  } = useAccountingProviderStatus()
+  const pathname = usePathname()
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  // The connection's label is written by the OAuth callback as `Company <realmId>`
+  // - so the realm id IS the identifying fact, and showing both would print the
+  // same sixteen digits twice. See the note on `AccountingProviderStatus.connection`
+  // for why the company NAME is not available.
+  const connectedAt = formatDate(connection?.connectedAt)
 
   return (
     <SettingsSection
@@ -80,33 +109,74 @@ export function QuickbooksSettingsSection() {
               <Badge variant='outline' size='xs'>
                 Not connected
               </Badge>
-              <Button variant='outline' size='sm' asChild>
-                <Link href={appDetailPath}>Connect QuickBooks</Link>
+              <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
+                Connect QuickBooks
               </Button>
             </div>
           </FieldPanelRow>
         )}
 
         {installed && connected && (
-          <FieldPanelRow
-            title='QuickBooks Online'
-            description='Posted entries are mirrored into QuickBooks Online and carry a deep link back.'>
-            <div className='flex w-full items-center justify-between gap-2'>
-              <span className='flex items-center gap-2 text-sm'>
-                <Badge variant='green' size='xs'>
-                  Connected
-                </Badge>
-                <span className='text-muted-foreground'>{providerLabel}</span>
-              </span>
-              <Button variant='outline' size='sm' asChild>
-                <Link href={appDetailPath}>Manage</Link>
-              </Button>
-            </div>
-          </FieldPanelRow>
+          <>
+            <FieldPanelRow
+              title='QuickBooks Online'
+              description='Posted entries are mirrored into QuickBooks Online and carry a deep link back.'>
+              <div className='flex w-full items-center justify-between gap-2'>
+                <span className='flex items-center gap-2 text-sm'>
+                  <Badge variant='green' size='xs'>
+                    Connected
+                  </Badge>
+                  <span className='text-muted-foreground'>{providerLabel}</span>
+                </span>
+                <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
+                  Manage
+                </Button>
+              </div>
+            </FieldPanelRow>
+
+            <FieldPanelRow
+              title='Company'
+              description='The QuickBooks company id (realm) this organization is authorized against. Every posted entry lands in this company.'>
+              <div className='flex min-h-8 items-center gap-2 text-sm'>
+                <span className='tabular-nums'>{connection?.label ?? '-'}</span>
+                {connection?.global && (
+                  <Badge variant='outline' size='xs'>
+                    Organization-wide
+                  </Badge>
+                )}
+              </div>
+            </FieldPanelRow>
+
+            <FieldPanelRow
+              title='Authorized'
+              description='Who authorized this connection, and when. Re-authorizing is done from Manage.'>
+              <div className='flex min-h-8 items-center text-muted-foreground text-sm'>
+                {connection?.connectedBy
+                  ? `${connection.connectedBy}${connectedAt ? ` · ${connectedAt}` : ''}`
+                  : (connectedAt ?? '-')}
+              </div>
+            </FieldPanelRow>
+          </>
         )}
       </FieldPanel>
 
       {!connected && <p className='text-muted-foreground text-xs'>{NOT_CONNECTED_COPY}</p>}
+
+      {/* Mounted only once installed: the dialog's settings queries need an
+          `installationType`, and until then there is nothing to manage. */}
+      {installed && installationType && (
+        <AppSettingsDialog
+          appSlug='quickbooks'
+          installationType={installationType}
+          // The safety net for the popup-blocked -> full-page-redirect fallback
+          // that cannot be fully prevented: come back to the accounting settings
+          // page, not to /app.
+          returnTo={pathname || '/app/accounting/settings/general'}
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          initialTab={connected ? 'about' : 'connections'}
+        />
+      )}
     </SettingsSection>
   )
 }

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
@@ -9,12 +9,14 @@ import {
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { EmptySection } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
 import { ArrowUpRight } from 'lucide-react'
 import Link from 'next/link'
 import { formatAccount } from '~/components/accounting/ui/settings/accounts-types'
 import { api } from '~/trpc/react'
 
 const ROLES_HREF = '/app/accounting/settings/accounts?s=roles'
+const CHART_HREF = '/app/accounting/settings/accounts?s=chart'
 
 const STATE_BADGE: Record<
   RoleAssignmentState,
@@ -54,6 +56,20 @@ const STATE_ORDER: Record<RoleAssignmentState, number> = {
  */
 export function WizardAccountsPage() {
   const roleMap = api.ledger.roleMap.useQuery()
+  const chart = api.ledger.chartAccounts.useQuery()
+  const utils = api.useUtils()
+
+  const provisionChart = api.ledger.provisionChart.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.ledger.chartAccounts.invalidate(),
+        utils.ledger.roleMap.invalidate(),
+      ])
+    },
+    onError: (error) => {
+      toastError({ title: 'Error creating the chart', description: error.message })
+    },
+  })
 
   const rows = [...(roleMap.data ?? [])].sort(
     (a, b) =>
@@ -67,6 +83,50 @@ export function WizardAccountsPage() {
   const confirmed = required.filter((row) => row.state === 'confirmed').length
   const outstanding = required.filter((row) => row.state !== 'confirmed')
 
+  // 🛑 Gate on the QUERY, never on an empty array. An org whose chart has not
+  // loaded yet and an org that genuinely has no chart are different answers, and
+  // offering "create the default chart" to the first one is an offer to duplicate
+  // a chart that already exists.
+  const chartIsEmpty = !chart.isPending && !chart.isError && (chart.data?.length ?? 0) === 0
+
+  if (chartIsEmpty) {
+    return (
+      <div className='flex flex-col gap-4 p-4'>
+        <p className='text-muted-foreground text-sm'>
+          Every line of a journal entry names an account by role, and each role has to point at a
+          real account in your chart. This organization has no chart yet.
+        </p>
+
+        <div className='flex flex-col gap-2 rounded-xl border p-3'>
+          <p className='font-medium text-sm'>Create the default chart of accounts</p>
+          <p className='text-muted-foreground text-xs'>
+            29 accounts, with each posting role pointed at the one that fulfils it. It is a starting
+            template, not a standard - rename, renumber and add your own afterwards, and nothing
+            here is overwritten if you run this again.
+          </p>
+          <div>
+            <Button
+              variant='outline'
+              size='sm'
+              loading={provisionChart.isPending}
+              loadingText='Creating...'
+              onClick={() => provisionChart.mutate()}>
+              Create the default chart
+            </Button>
+          </div>
+        </div>
+
+        <p className='text-muted-foreground text-xs'>
+          Prefer to build your own? Add accounts on{' '}
+          <Link href={CHART_HREF} className='underline'>
+            the chart of accounts
+          </Link>
+          , then come back and map each role.
+        </p>
+      </div>
+    )
+  }
+
   return (
     <div className='flex flex-col gap-4 p-4'>
       <p className='text-muted-foreground text-sm'>
@@ -74,7 +134,7 @@ export function WizardAccountsPage() {
         account in your chart. Nothing can be previewed until they do.
       </p>
 
-      {roleMap.isPending ? (
+      {roleMap.isPending || chart.isPending ? (
         <EmptySection loading />
       ) : roleMap.isError ? (
         <div className='rounded-xl border border-destructive/40 bg-destructive/5 p-3'>

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -1,11 +1,16 @@
 // apps/web/src/server/api/routers/ledger.ts
 
+import { getCachedEntityDefId } from '@auxx/lib/cache'
+import { UnprocessableEntityError } from '@auxx/lib/errors'
 import { PermissionKey } from '@auxx/lib/permissions'
 import {
   ACCOUNT_ROLES,
   buildEntry,
+  createChartAccount,
+  GL_ACCOUNT_TYPES,
   getPosting,
   listChartAccounts,
+  listChartAccountUsage,
   listClosePeriods,
   listRoleMap,
   listUnpostedPeriods,
@@ -14,11 +19,14 @@ import {
   postMonthEnd,
   previewEntry,
   previewMonthEnd,
+  removeChartAccount,
   resolvePeriodLock,
   reverseEntry,
   setRoleAssignment,
+  updateChartAccount,
   verifyBooksBalance,
 } from '@auxx/lib/postings'
+import { seedDefaultChartOfAccounts } from '@auxx/lib/seed'
 import { z } from 'zod'
 import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
 
@@ -350,6 +358,145 @@ export const ledgerRouter = createTRPCRouter({
     if (result.isErr()) throw result.error
     return result.value
   }),
+
+  /**
+   * How many posted lines carry each account CODE.
+   *
+   * Read by the Chart of accounts tab alone, to turn the renumber caution into a
+   * number: a posting line names an account by code with no foreign key (`P2`),
+   * so renumbering leaves every line already posted holding the old one.
+   */
+  chartAccountUsage: permissionProcedure(PermissionKey.ledgerView).query(async ({ ctx }) => {
+    const result = await listChartAccountUsage(ctx.db, ctx.session.organizationId)
+    if (result.isErr()) throw result.error
+    return result.value
+  }),
+
+  /**
+   * Write the 29-account default chart, and point each role at the account that
+   * fulfils it.
+   *
+   * ── Why this is a BUTTON and not part of creating an organization ──
+   *
+   * `gl_account`'s DEFINITION ships with every org (`SYSTEM_ENTITIES`), but its
+   * ROWS do not, deliberately: most orgs never open the accounting module, and 29
+   * `EntityInstance`s plus 13 `GlRoleAssignment`s each is a chart nobody asked for
+   * in a table everybody has to scan. Provisioning is the first step of setting
+   * accounting up, so it lives where somebody has said they want accounting.
+   *
+   * 🛑 It also closes a real hole. `seedDefaultChartOfAccounts`' only other caller
+   * is entity migration 108, which reaches production through the DataMigration
+   * ledger - and `DataMigration.id` is the PRIMARY KEY, one global row, no
+   * `organizationId`. Once 108 is `applied` it never runs again, so **every org
+   * created after that deploy would have had a def, no accounts, thirteen
+   * unmapped roles and no way to fix it.** This is that way.
+   *
+   * Safe to press twice: the seed is idempotent on `code` and its assignments are
+   * `ON CONFLICT (organizationId, role) DO NOTHING`, so a second press reports
+   * `created: 0` and cannot disturb an account or a mapping somebody has edited.
+   * That is `seedDefaultChartOfAccounts`' rules 1, 3 and 4, and they are the whole
+   * reason this can be offered as a button at all.
+   */
+  provisionChart: permissionProcedure(PermissionKey.ledgerPost).mutation(async ({ ctx }) => {
+    const { organizationId } = ctx.session
+
+    const glAccountDefId = await getCachedEntityDefId(organizationId, 'gl_account')
+    if (!glAccountDefId) {
+      throw new UnprocessableEntityError(
+        'This organization has no gl_account definition, so there is nothing to seed a chart into. Run the entity migrations.',
+        { organizationId }
+      )
+    }
+
+    return await seedDefaultChartOfAccounts(ctx.db, organizationId, glAccountDefId)
+  }),
+
+  /**
+   * Add one account to the org's chart.
+   *
+   * ── Why these live on `ledgerPost` and not on the generic record path ──
+   *
+   * 🛑 `record.create` / `record.update` are `capabilityProcedure` and assert the
+   * RECORDS capability for the definition. Routing the chart through them would
+   * hand "which account does `grni` resolve to" to anyone with records-Full and
+   * ledger-None - and a renumber there is undetectable downstream, because the
+   * resulting entry still balances. The ledger area has exactly two rungs, and
+   * `setRoleAssignment` above already made this call for the same reason: this
+   * decides where real money lands.
+   *
+   * `gl_account` therefore stays `isVisible: false` and this is its only door.
+   *
+   * The refusals are the lib's, verbatim - see `postings/chart-write.ts`. Zod
+   * checks structure only, for the reason `postingLine` gives at the top of this
+   * file: two authorities over one input, and the worse message wins.
+   */
+  chartAccountCreate: permissionProcedure(PermissionKey.ledgerPost)
+    .input(
+      z.object({
+        code: z.string().min(1),
+        name: z.string().min(1),
+        accountType: z.enum(GL_ACCOUNT_TYPES),
+        isActive: z.boolean().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const result = await createChartAccount(ctx.db, {
+        ...input,
+        organizationId,
+        actorUserId: userId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Change one account. Only the keys sent are written.
+   *
+   * `code` and `name` are unconditional (`G7`); `accountType` and `isActive` are
+   * refused when a role still posts to the account, naming it.
+   */
+  chartAccountUpdate: permissionProcedure(PermissionKey.ledgerPost)
+    .input(
+      z.object({
+        id: z.string().min(1),
+        code: z.string().optional(),
+        name: z.string().optional(),
+        accountType: z.enum(GL_ACCOUNT_TYPES).optional(),
+        isActive: z.boolean().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const { id, ...values } = input
+      const result = await updateChartAccount(ctx.db, {
+        ...values,
+        organizationId,
+        accountId: id,
+        actorUserId: userId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Take one account out of the chart.
+   *
+   * ARCHIVES - the lib module carries the three reasons there is no hard delete.
+   * Refused while a role still posts to the account.
+   */
+  chartAccountRemove: permissionProcedure(PermissionKey.ledgerPost)
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const result = await removeChartAccount(ctx.db, {
+        organizationId,
+        accountId: input.id,
+        actorUserId: userId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
 
   /**
    * Every entry that has been claimed but is not in the books - the close

--- a/packages/lib/src/postings/__tests__/chart-write.test.ts
+++ b/packages/lib/src/postings/__tests__/chart-write.test.ts
@@ -1,0 +1,638 @@
+// packages/lib/src/postings/__tests__/chart-write.test.ts
+//
+// One property carries this file, and it is the reason `chart-write.ts` exists
+// at all:
+//
+// 🛑 **`mapRole` validates the pair (role, account) from the ROLE's side. Every
+// one of its checks is bypassable from the ACCOUNT's side.** Map `grni` to a
+// liability account, then retype that account to `revenue`: two legal-looking
+// writes, and the entry that results still BALANCES, so nothing downstream can
+// detect it. The tests below induce exactly that, and the deactivate and remove
+// variants of it, rather than asserting against a switch statement.
+//
+// The second property is narrower but has a body count: a write whose field the
+// crud handler cannot resolve is DROPPED SILENTLY - the failure that once wrote
+// 784 accounts across 28 orgs with the one field that mattered missing, and
+// logged success. `readBack` is the guard, and it gets a test.
+//
+// The database is a hand-written stub rather than a mock chain, for the reason
+// `role-map.test.ts` gives: this module reads three different tables and each has
+// to answer differently. Tables are identified by REFERENCE (`src/test/setup.ts`
+// memoizes `schema.*`) and filters are applied by the stub out of the parameters
+// the module actually passed.
+
+import { type Database, schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NotFoundError, UniqueValueConflictError, UnprocessableEntityError } from '../../errors'
+
+const h = vi.hoisted(() => ({
+  /** systemAttribute -> the CustomField row, or absent to model an unmigrated org. */
+  fields: new Map<string, { id: string; entityDefinitionId: string | null }>(),
+  /** What each handler call did, and what the next one should throw. */
+  creates: [] as { defId: string; values: Record<string, unknown> }[],
+  updates: [] as { recordId: string; values: Record<string, unknown> }[],
+  archives: [] as string[],
+  deletes: [] as string[],
+  /** Set to make the next create/update throw. */
+  writeError: null as Error | null,
+  /** The instance id `create` hands back. */
+  createdId: 'acct_new',
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(attrs.map((a) => [a, h.fields.get(a) ?? null])),
+    }),
+  }),
+}))
+
+vi.mock('../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    async create(defId: string, values: Record<string, unknown>) {
+      if (h.writeError) throw h.writeError
+      h.creates.push({ defId, values })
+      return { instance: { id: h.createdId }, recordId: `${defId}:${h.createdId}`, values }
+    }
+    async update(recordId: string, values: Record<string, unknown>) {
+      if (h.writeError) throw h.writeError
+      h.updates.push({ recordId, values })
+      return { values }
+    }
+    async archive(recordId: string) {
+      h.archives.push(recordId)
+    }
+    async delete(recordId: string) {
+      h.deletes.push(recordId)
+    }
+  },
+}))
+
+import { createChartAccount, removeChartAccount, updateChartAccount } from '../chart-write'
+
+const ORG = 'org_1'
+const OTHER_ORG = 'org_2'
+const DEF = 'def_gl_account'
+
+const CODE_FIELD = 'fld_code'
+const NAME_FIELD = 'fld_name'
+const TYPE_FIELD = 'fld_type'
+const ACTIVE_FIELD = 'fld_active'
+
+const USER = 'usr_bookkeeper'
+
+interface Account {
+  id: string
+  organizationId?: string
+  code?: string
+  name?: string
+  accountType?: string
+  isActive?: boolean
+  /** Archived rows are excluded by the query, so this models "not returned". */
+  archived?: boolean
+}
+
+interface Assignment {
+  role: string
+  glAccountId: string
+  organizationId?: string
+  markedUnused?: boolean
+}
+
+/** Every scalar the module put into a `where` clause, flattened. */
+function whereValues(node: unknown, out: string[] = [], depth = 0): string[] {
+  if (depth > 10 || node === null || node === undefined) return out
+  if (typeof node === 'string') {
+    out.push(node)
+    return out
+  }
+  if (typeof node !== 'object') return out
+  if (Array.isArray(node)) {
+    for (const child of node) whereValues(child, out, depth + 1)
+    return out
+  }
+  const obj = node as Record<string, unknown>
+  if ('value' in obj) whereValues(obj.value, out, depth + 1)
+  if (Array.isArray(obj.queryChunks)) whereValues(obj.queryChunks, out, depth + 1)
+  return out
+}
+
+/**
+ * A stub answering the three reads by table.
+ *
+ * `markedUnused` is filtered HERE rather than through `params`, because the real
+ * query compares it against a boolean and only strings survive `whereValues`.
+ * That is the same modelling `role-map.test.ts` uses for `archivedAt IS NULL`,
+ * and it is what makes "the role was marked unused" a real test rather than a
+ * fixture returning what it was told to.
+ */
+function stubDb(accounts: Account[], assignments: Assignment[] = []): Database {
+  const visible = accounts.filter((a) => !a.archived && (a.organizationId ?? ORG) === ORG)
+  const fieldValues = visible.flatMap((account) => {
+    const rows: Record<string, unknown>[] = []
+    if (account.code !== undefined) {
+      rows.push({ entityId: account.id, fieldId: CODE_FIELD, valueText: account.code })
+    }
+    if (account.name !== undefined) {
+      rows.push({ entityId: account.id, fieldId: NAME_FIELD, valueText: account.name })
+    }
+    if (account.accountType !== undefined) {
+      rows.push({ entityId: account.id, fieldId: TYPE_FIELD, optionId: account.accountType })
+    }
+    if (account.isActive !== undefined) {
+      rows.push({ entityId: account.id, fieldId: ACTIVE_FIELD, valueBoolean: account.isActive })
+    }
+    return rows
+  })
+
+  const rowsFor = (table: unknown, params: string[]): unknown[] => {
+    if (table === schema.GlRoleAssignment) {
+      return assignments
+        .filter(
+          (a) =>
+            !a.markedUnused &&
+            params.includes(a.organizationId ?? ORG) &&
+            params.includes(a.glAccountId)
+        )
+        .map((a) => ({ role: a.role, glAccountId: a.glAccountId }))
+    }
+    if (table === schema.EntityInstance) {
+      return accounts
+        .filter(
+          (a) => !a.archived && params.includes(a.organizationId ?? ORG) && params.includes(a.id)
+        )
+        .map((a) => ({ id: a.id }))
+    }
+    return fieldValues.filter((row) => params.includes(row.entityId as string))
+  }
+
+  return {
+    select: () => ({
+      from: (table: unknown) => {
+        let params: string[] = []
+        const chain: any = {
+          where: (condition: unknown) => {
+            params = whereValues(condition)
+            return chain
+          },
+          limit: () => chain,
+          orderBy: () => chain,
+          groupBy: () => chain,
+          // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
+          then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+            Promise.resolve(rowsFor(table, params)).then(resolve, reject),
+        }
+        return chain
+      },
+    }),
+  } as unknown as Database
+}
+
+const GRNI_ACCOUNT: Account = {
+  id: 'acct_grni',
+  code: '2160',
+  name: 'Goods Received Not Invoiced',
+  accountType: 'liability',
+  isActive: true,
+}
+
+beforeEach(() => {
+  h.fields = new Map([
+    ['gl_account_code', { id: CODE_FIELD, entityDefinitionId: DEF }],
+    ['gl_account_name', { id: NAME_FIELD, entityDefinitionId: DEF }],
+    ['gl_account_type', { id: TYPE_FIELD, entityDefinitionId: DEF }],
+    ['gl_account_is_active', { id: ACTIVE_FIELD, entityDefinitionId: DEF }],
+  ])
+  h.creates = []
+  h.updates = []
+  h.archives = []
+  h.deletes = []
+  h.writeError = null
+  h.createdId = 'acct_new'
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createChartAccount', () => {
+  it('writes all four attributes and returns the row as the list renders it', async () => {
+    h.createdId = 'acct_6410'
+    const db = stubDb([
+      {
+        id: 'acct_6410',
+        code: '6410',
+        name: 'Office Supplies',
+        accountType: 'expense',
+        isActive: true,
+      },
+    ])
+
+    const row = (
+      await createChartAccount(db, {
+        organizationId: ORG,
+        code: '6410',
+        name: 'Office Supplies',
+        accountType: 'expense',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrap()
+
+    expect(h.creates).toHaveLength(1)
+    expect(h.creates[0]).toEqual({
+      defId: DEF,
+      values: {
+        gl_account_code: '6410',
+        gl_account_name: 'Office Supplies',
+        gl_account_type: 'expense',
+        // Defaulted, matching the field's registry default.
+        gl_account_is_active: true,
+      },
+    })
+    expect(row).toEqual({
+      id: 'acct_6410',
+      code: '6410',
+      name: 'Office Supplies',
+      accountType: 'expense',
+      isActive: true,
+    })
+  })
+
+  it('trims the code and the name before writing', async () => {
+    h.createdId = 'acct_6410'
+    const db = stubDb([
+      {
+        id: 'acct_6410',
+        code: '6410',
+        name: 'Office Supplies',
+        accountType: 'expense',
+        isActive: true,
+      },
+    ])
+
+    await createChartAccount(db, {
+      organizationId: ORG,
+      code: '  6410  ',
+      name: '  Office Supplies  ',
+      accountType: 'expense',
+      actorUserId: USER,
+    })
+
+    expect(h.creates[0]?.values.gl_account_code).toBe('6410')
+    expect(h.creates[0]?.values.gl_account_name).toBe('Office Supplies')
+  })
+
+  it('refuses a whitespace-only code without touching the handler', async () => {
+    const result = await createChartAccount(stubDb([]), {
+      organizationId: ORG,
+      code: '   ',
+      name: 'Office Supplies',
+      accountType: 'expense',
+      actorUserId: USER,
+    })
+
+    expect(result._unsafeUnwrapErr().message).toBe('An account needs a code.')
+    expect(h.creates).toHaveLength(0)
+  })
+
+  // 🛑 I4. `validateUniqueFields` says "Code must be unique: value already
+  // exists", and only the MESSAGE crosses tRPC. The code that collided is the
+  // whole of what the person needs.
+  it('re-messages a unique-code conflict so it names the code', async () => {
+    h.writeError = new UniqueValueConflictError({
+      message: 'Code must be unique: value already exists',
+      conflictingValue: '1310',
+      fieldId: CODE_FIELD,
+    })
+
+    const error = (
+      await createChartAccount(stubDb([]), {
+        organizationId: ORG,
+        code: '1310',
+        name: 'Raw Materials',
+        accountType: 'asset',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(UniqueValueConflictError)
+    expect(error.message).toBe('1310 is already in use by another account in this chart.')
+  })
+
+  // ⚠️ The silent-drop guard. A create whose `gl_account_type` never landed
+  // decodes as malformed and VANISHES from the list it was just created in.
+  it('refuses when the written account cannot be read back with a code and a type', async () => {
+    h.createdId = 'acct_broken'
+    // The instance exists but carries no type - exactly what a dropped value
+    // looks like from the read side.
+    const db = stubDb([{ id: 'acct_broken', code: '6410', name: 'Office Supplies' }])
+
+    const error = (
+      await createChartAccount(db, {
+        organizationId: ORG,
+        code: '6410',
+        name: 'Office Supplies',
+        accountType: 'expense',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error.message).toContain('could not be read back')
+  })
+
+  it('refuses an unprovisioned chart before writing anything', async () => {
+    h.fields.delete('gl_account_type')
+
+    const error = (
+      await createChartAccount(stubDb([]), {
+        organizationId: ORG,
+        code: '6410',
+        name: 'Office Supplies',
+        accountType: 'expense',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.creates).toHaveLength(0)
+  })
+})
+
+describe('updateChartAccount', () => {
+  it('writes only the keys it was sent', async () => {
+    const db = stubDb([GRNI_ACCOUNT])
+
+    await updateChartAccount(db, {
+      organizationId: ORG,
+      accountId: GRNI_ACCOUNT.id,
+      name: 'GRNI',
+      actorUserId: USER,
+    })
+
+    expect(h.updates).toHaveLength(1)
+    expect(h.updates[0]?.values).toEqual({ gl_account_name: 'GRNI' })
+    expect(h.updates[0]?.recordId).toBe(`${DEF}:${GRNI_ACCOUNT.id}`)
+  })
+
+  // ⚠️ `G7`: the chart is the org's document. A renumber detaches posted lines
+  // from the row on screen, which is `P2` working as designed, and refusing it
+  // would be this module deciding it knows better.
+  it('renumbers without complaint, even with a role pointing at the account', async () => {
+    const db = stubDb([GRNI_ACCOUNT], [{ role: 'grni', glAccountId: GRNI_ACCOUNT.id }])
+
+    const result = await updateChartAccount(db, {
+      organizationId: ORG,
+      accountId: GRNI_ACCOUNT.id,
+      code: '2155',
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.updates[0]?.values).toEqual({ gl_account_code: '2155' })
+  })
+
+  it('makes no call at all when nothing actually changes', async () => {
+    const db = stubDb([GRNI_ACCOUNT])
+
+    const row = (
+      await updateChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        accountType: 'liability',
+        isActive: true,
+        actorUserId: USER,
+      })
+    )._unsafeUnwrap()
+
+    expect(h.updates).toHaveLength(0)
+    expect(row.code).toBe('2160')
+  })
+
+  it('is a NotFoundError for an account in another organization', async () => {
+    const db = stubDb([{ ...GRNI_ACCOUNT, organizationId: OTHER_ORG }])
+
+    const error = (
+      await updateChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        name: 'GRNI',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(NotFoundError)
+    expect(h.updates).toHaveLength(0)
+  })
+
+  it('is a NotFoundError for an archived account', async () => {
+    const db = stubDb([{ ...GRNI_ACCOUNT, archived: true }])
+
+    const error = (
+      await updateChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        name: 'GRNI',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(NotFoundError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// I1 - the guard the module exists for
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('I1: a type change may not break a role that posts here', () => {
+  // 🛑 THE test. Without this guard, `mapRole`'s type check is bypassable by
+  // mapping first and retyping second, and the entry that results BALANCES.
+  it('refuses, naming the role and both types', async () => {
+    const db = stubDb([GRNI_ACCOUNT], [{ role: 'grni', glAccountId: GRNI_ACCOUNT.id }])
+
+    const error = (
+      await updateChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        accountType: 'revenue',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toContain("'grni'")
+    expect(error.message).toContain('revenue')
+    expect(error.message).toContain('liability')
+    expect(h.updates).toHaveLength(0)
+  })
+
+  it('allows a type change the role still accepts', async () => {
+    // `cash` wants an asset; 1000 is an asset and stays one.
+    const cash: Account = {
+      id: 'acct_cash',
+      code: '1000',
+      name: 'Cash',
+      accountType: 'asset',
+      isActive: true,
+    }
+    const db = stubDb([cash], [{ role: 'cash', glAccountId: cash.id }])
+
+    const result = await updateChartAccount(db, {
+      organizationId: ORG,
+      accountId: cash.id,
+      accountType: 'asset',
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+  })
+
+  // ⚠️ A role the org has explicitly said it does not use is not a reason to
+  // refuse anything. `markedUnused` is the only state that exempts.
+  it('allows the change once the role is marked unused', async () => {
+    const db = stubDb(
+      [GRNI_ACCOUNT],
+      [{ role: 'grni', glAccountId: GRNI_ACCOUNT.id, markedUnused: true }]
+    )
+
+    const result = await updateChartAccount(db, {
+      organizationId: ORG,
+      accountId: GRNI_ACCOUNT.id,
+      accountType: 'revenue',
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.updates[0]?.values).toEqual({ gl_account_type: 'revenue' })
+  })
+
+  it('allows any type change on an account no role points at', async () => {
+    const db = stubDb([GRNI_ACCOUNT], [])
+
+    const result = await updateChartAccount(db, {
+      organizationId: ORG,
+      accountId: GRNI_ACCOUNT.id,
+      accountType: 'revenue',
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+  })
+})
+
+describe('I2: deactivating an account a role still posts to', () => {
+  it('refuses, naming the role', async () => {
+    const db = stubDb([GRNI_ACCOUNT], [{ role: 'grni', glAccountId: GRNI_ACCOUNT.id }])
+
+    const error = (
+      await updateChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        isActive: false,
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toContain("'grni'")
+    expect(h.updates).toHaveLength(0)
+  })
+
+  // Reactivating is what `resolveRoles`' own refusal tells the reader to do, so
+  // it can never be the thing that is blocked.
+  it('always allows REACTIVATING, role or no role', async () => {
+    const inactive = { ...GRNI_ACCOUNT, isActive: false }
+    const db = stubDb([inactive], [{ role: 'grni', glAccountId: inactive.id }])
+
+    const result = await updateChartAccount(db, {
+      organizationId: ORG,
+      accountId: inactive.id,
+      isActive: true,
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.updates[0]?.values).toEqual({ gl_account_is_active: true })
+  })
+
+  it('allows deactivating once the role is marked unused', async () => {
+    const db = stubDb(
+      [GRNI_ACCOUNT],
+      [{ role: 'grni', glAccountId: GRNI_ACCOUNT.id, markedUnused: true }]
+    )
+
+    const result = await updateChartAccount(db, {
+      organizationId: ORG,
+      accountId: GRNI_ACCOUNT.id,
+      isActive: false,
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+  })
+})
+
+describe('I3: removing an account a role still posts to', () => {
+  it('refuses, naming the role', async () => {
+    const db = stubDb([GRNI_ACCOUNT], [{ role: 'grni', glAccountId: GRNI_ACCOUNT.id }])
+
+    const error = (
+      await removeChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toContain("'grni'")
+    expect(h.archives).toHaveLength(0)
+  })
+
+  // 🛑 ARCHIVE, never delete. A hard delete forfeits the seeder's "someone who
+  // archived an account did not ask for it back" rule, and cascades away any
+  // `RecordIdentity` carrying a connected provider's own account id (`P2`).
+  it('ARCHIVES and never deletes', async () => {
+    const db = stubDb([GRNI_ACCOUNT], [])
+
+    const result = await removeChartAccount(db, {
+      organizationId: ORG,
+      accountId: GRNI_ACCOUNT.id,
+      actorUserId: USER,
+    })
+
+    expect(result._unsafeUnwrap()).toEqual({ id: GRNI_ACCOUNT.id })
+    expect(h.archives).toEqual([`${DEF}:${GRNI_ACCOUNT.id}`])
+    expect(h.deletes).toHaveLength(0)
+  })
+
+  it('allows removal once the role is marked unused', async () => {
+    const db = stubDb(
+      [GRNI_ACCOUNT],
+      [{ role: 'grni', glAccountId: GRNI_ACCOUNT.id, markedUnused: true }]
+    )
+
+    const result = await removeChartAccount(db, {
+      organizationId: ORG,
+      accountId: GRNI_ACCOUNT.id,
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.archives).toHaveLength(1)
+  })
+
+  it('is a NotFoundError for an account in another organization', async () => {
+    const db = stubDb([{ ...GRNI_ACCOUNT, organizationId: OTHER_ORG }])
+
+    const error = (
+      await removeChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(NotFoundError)
+    expect(h.archives).toHaveLength(0)
+  })
+})

--- a/packages/lib/src/postings/chart-write.ts
+++ b/packages/lib/src/postings/chart-write.ts
@@ -1,0 +1,514 @@
+// packages/lib/src/postings/chart-write.ts
+
+/**
+ * The chart of accounts, WRITTEN: create, update and remove one `gl_account`.
+ *
+ * `G7` has said the chart is the org's own document since it was seeded, and
+ * every piece of machinery downstream is built on that premise - `G8` exists
+ * only because the chart is editable, and `GlPostingLine.accountCode` has no
+ * foreign key only because the chart is editable. Until this file there was no
+ * writer but `seedDefaultChartOfAccounts`, which runs once at migration time.
+ *
+ * ## The invariant this module exists for
+ *
+ * 🛑 `mapRole` (`role-map.ts`) validates the pair (role, account) from the
+ * ROLE's side: not archived, active, and `accountType === ROLE_ACCOUNT_TYPES[role]`.
+ * `resolveRoles` re-checks the identical three at post time. **Editing the
+ * account is the other half of that pair**, and every one of those checks is
+ * bypassable without the guards below: map `grni` to a liability account, then
+ * change that account's type to `revenue`. Both writes pass, the resulting entry
+ * still BALANCES, and nothing downstream can detect it - which is exactly what
+ * `ROLE_ACCOUNT_TYPES`' header says about a type mismatch.
+ *
+ * So this file owns the same three refusals from the account's side ({@link I1},
+ * {@link I2}, {@link I3} below), plus code uniqueness, which the handler gives.
+ *
+ * ## What is deliberately NOT guarded
+ *
+ * ⚠️ **`code` and `name` are the org's, unconditionally.** Both are safe:
+ *
+ * - a RENAME cannot touch history - `GlPostingLine.accountName` is a snapshot
+ *   taken at post time, for exactly this reason
+ * - a RENUMBER cannot touch role resolution - `GlRoleAssignment.glAccountId`
+ *   names the INSTANCE, not the code, which is `G8` doing its job
+ *
+ * What a renumber does do is detach every line already posted from the row on
+ * screen, because a posted line stores the code with no foreign key. That is
+ * decision `P2` working as designed - the ledger outlives the chart - and it is
+ * not this module's business to refuse it. It is the UI's business to say so,
+ * with a count (`listChartAccountUsage` in `role-map.ts`).
+ *
+ * ## Removal is ARCHIVE, never delete
+ *
+ * See {@link removeChartAccount}. Three independent reasons, any one sufficient.
+ *
+ * No permission checks here. The router asserts `ledgerPost`
+ * (`docs/lib-module-guide.md` §6).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import {
+  AuxxError,
+  BadRequestError,
+  NotFoundError,
+  UniqueValueConflictError,
+  UnprocessableEntityError,
+} from '../errors'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import { toRecordId } from '../resources/resource-id'
+import { ACCOUNT_ROLE_LABELS, type AccountRole, ROLE_ACCOUNT_TYPES } from './build-entry'
+import {
+  type ChartAccountFields,
+  loadChartAccountFields,
+  readChartAccountValues,
+} from './chart-accounts'
+import type { GlAccountTypeValue } from './default-chart'
+import type { ChartAccountRow } from './types'
+
+const logger = createScopedLogger('postings:chart-write')
+
+/**
+ * What an unprovisioned chart refuses a WRITER with.
+ *
+ * `role-map.ts` and `resolve-roles.ts` each pass their own sentence to the same
+ * shared check, deliberately - the fact is one, the advice is not. This one is
+ * read by somebody who just clicked Create.
+ */
+const NOT_PROVISIONED =
+  'The chart of accounts is not provisioned for this organization - gl_account_code / gl_account_type are missing. Run the entity migrations.'
+
+/**
+ * The four `gl_account` attributes, as the crud handler wants them keyed.
+ *
+ * A `type` and not an `interface`: the handler takes `Record<string, unknown>`,
+ * and only a type alias carries the implicit index signature that satisfies it.
+ */
+type AccountValues = {
+  gl_account_code?: string
+  gl_account_name?: string
+  gl_account_type?: GlAccountTypeValue
+  gl_account_is_active?: boolean
+}
+
+/** A role that still posts to an account, and the account row it points at. */
+interface LiveRole {
+  role: AccountRole
+  glAccountId: string
+}
+
+export interface CreateChartAccountOptions {
+  organizationId: string
+  /** The account number. Unique per org; `UniqueValueConflictError` if taken. */
+  code: string
+  name: string
+  accountType: GlAccountTypeValue
+  /** Defaults to `true`, matching the field's registry default. */
+  isActive?: boolean
+  /** Who is doing this. Attributed on the write - never a system session. */
+  actorUserId: string
+}
+
+export interface UpdateChartAccountOptions {
+  organizationId: string
+  accountId: string
+  code?: string
+  name?: string
+  accountType?: GlAccountTypeValue
+  isActive?: boolean
+  actorUserId: string
+}
+
+export interface RemoveChartAccountOptions {
+  organizationId: string
+  accountId: string
+  actorUserId: string
+}
+
+/**
+ * Add one account to the org's chart.
+ *
+ * All three of `code`, `name` and `accountType` are required - the field
+ * registry declares them so and `assertRequiredFieldsPresent` enforces it. There
+ * is no default for `accountType` and this module invents none: a statement
+ * classification is what every role compatibility check is made against, and
+ * guessing one would defeat the only reason the type is read.
+ *
+ * @returns the account exactly as `listChartAccounts` would render it.
+ */
+export async function createChartAccount(
+  db: Database,
+  options: CreateChartAccountOptions
+): Promise<Result<ChartAccountRow, Error>> {
+  const { organizationId, actorUserId } = options
+
+  try {
+    const code = options.code.trim()
+    const name = options.name.trim()
+    if (!code) throw new BadRequestError('An account needs a code.', { organizationId })
+    if (!name) throw new BadRequestError('An account needs a name.', { organizationId })
+
+    const { fields, defId } = await loadChartTarget(organizationId)
+
+    const handler = crudHandler(db, organizationId, actorUserId)
+    const created = await namingTheCode(code, () =>
+      handler.create(defId, {
+        gl_account_code: code,
+        gl_account_name: name,
+        gl_account_type: options.accountType,
+        gl_account_is_active: options.isActive ?? true,
+      } satisfies AccountValues)
+    )
+
+    return ok(await readBack(db, organizationId, created.instance.id, fields))
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to create a chart account', { error, organizationId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/**
+ * Change one account. Only the keys present are written.
+ *
+ * Two of the four fields are guarded, and both guards are about a role that
+ * still posts here - see the file header.
+ */
+export async function updateChartAccount(
+  db: Database,
+  options: UpdateChartAccountOptions
+): Promise<Result<ChartAccountRow, Error>> {
+  const { organizationId, accountId, actorUserId } = options
+
+  try {
+    const { fields, defId } = await loadChartTarget(organizationId)
+    const account = await requireAccount(db, organizationId, accountId, fields)
+
+    const values: AccountValues = {}
+
+    if (options.code !== undefined) {
+      const code = options.code.trim()
+      if (!code) throw new BadRequestError('An account needs a code.', { organizationId })
+      values.gl_account_code = code
+    }
+
+    if (options.name !== undefined) {
+      const name = options.name.trim()
+      if (!name) throw new BadRequestError('An account needs a name.', { organizationId })
+      values.gl_account_name = name
+    }
+
+    // ── I1: a type change may not break a role that posts here ──────────────
+    //
+    // 🛑 The guard the whole module exists for. `mapRole` refuses to point a
+    // role at an incompatible account; without this, the same illegal pair is
+    // reachable by mapping first and retyping second, and the resulting entry
+    // BALANCES.
+    if (options.accountType !== undefined && options.accountType !== account.accountType) {
+      const live = await liveRolesFor(db, organizationId, accountId)
+      for (const { role } of live) {
+        const expected = ROLE_ACCOUNT_TYPES[role]
+        if (expected !== options.accountType) {
+          throw new UnprocessableEntityError(
+            `Cannot make ${account.code} ${account.name} a ${options.accountType} account: '${role}' (${ACCOUNT_ROLE_LABELS[role]}) posts here and must be mapped to a ${expected} account. Repoint the role first, or mark it unused.`,
+            { organizationId, accountId, role }
+          )
+        }
+      }
+      values.gl_account_type = options.accountType
+    }
+
+    // ── I2: deactivating an account a role still posts to ───────────────────
+    //
+    // `resolveRoles` refuses a mapped-inactive account at POST time, naming the
+    // role. Refusing here turns a refused close next month into a refused click
+    // now, which is the same trade `mapRole` makes.
+    if (options.isActive !== undefined && options.isActive !== account.isActive) {
+      if (options.isActive === false) {
+        await assertNoLiveRole(
+          db,
+          organizationId,
+          accountId,
+          account,
+          'deactivate',
+          'Reactivating it later is a click; a refused close is not.'
+        )
+      }
+      values.gl_account_is_active = options.isActive
+    }
+
+    if (Object.keys(values).length > 0) {
+      const handler = crudHandler(db, organizationId, actorUserId)
+      await namingTheCode(values.gl_account_code ?? account.code, () =>
+        handler.update(toRecordId(defId, accountId), values)
+      )
+    }
+
+    return ok(await readBack(db, organizationId, accountId, fields))
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to update a chart account', { error, organizationId, accountId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/**
+ * Take one account out of the chart.
+ *
+ * 🛑 **This ARCHIVES. `handler.delete` appears nowhere in this module**, and
+ * three independent reasons say so - any one of them sufficient:
+ *
+ *  1. Every reader already excludes archived rows **in the query**
+ *     (`listChartAccounts`, `loadChartAccountsById`, `resolveRoles`). Archiving
+ *     IS removal as far as the chart, the role picker and the resolver are
+ *     concerned.
+ *  2. `seedDefaultChartOfAccounts` reads existing codes INCLUDING archived rows,
+ *     deliberately, so a re-seed does not resurrect what somebody removed:
+ *     *"Someone who archived an account did not ask for it back."* A hard delete
+ *     forfeits that - the next migration re-run puts the account straight back.
+ *  3. A hard delete cascades away any `RecordIdentity` on the row, which is the
+ *     connected provider's own account id (`P2`). `scripts/reset-gl-chart.ts`
+ *     refuses to do that even in a dev wipe.
+ *
+ * Posted history is unaffected either way: `GlPostingLine` snapshots the code
+ * and the name and has no foreign key to the instance.
+ */
+export async function removeChartAccount(
+  db: Database,
+  options: RemoveChartAccountOptions
+): Promise<Result<{ id: string }, Error>> {
+  const { organizationId, accountId, actorUserId } = options
+
+  try {
+    const { fields, defId } = await loadChartTarget(organizationId)
+    const account = await requireAccount(db, organizationId, accountId, fields)
+
+    // ── I3: removing an account a role still posts to ───────────────────────
+    await assertNoLiveRole(
+      db,
+      organizationId,
+      accountId,
+      account,
+      'remove',
+      'A role pointing at a removed account fails the close closed, naming the role.'
+    )
+
+    const handler = crudHandler(db, organizationId, actorUserId)
+    await handler.archive(toRecordId(defId, accountId))
+
+    return ok({ id: accountId })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to remove a chart account', { error, organizationId, accountId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The handler every write in this module goes through.
+ *
+ * 🛑 **`capabilities: undefined` and NOT `requestPath: true`**, which the
+ * handler reads as "internal caller, no enforcement". That is correct here and
+ * is not an oversight: the router has already asserted `ledgerPost`, and
+ * re-asserting the generic RECORDS capability underneath it would hand the chart
+ * to anyone with records-Full and ledger-None - the authorization inversion this
+ * whole surface was built to avoid.
+ *
+ * The session is the default interactive one built from `actorUserId`. **Not**
+ * `seedSession` / `quietSession`: a person renaming an account is exactly the
+ * write that should be attributable, and the quiet lane also suppresses the
+ * events a rename should emit.
+ *
+ * Going through the handler at all (rather than writing `FieldValue` by hand) is
+ * what buys the uniqueness gate on `code`, `assertRequiredFieldsPresent`, and the
+ * `SINGLE_SELECT` -> `optionId` write for `accountType` that the decode reads
+ * back out of `optionId`.
+ */
+function crudHandler(db: Database, organizationId: string, actorUserId: string) {
+  return new UnifiedCrudHandler(organizationId, actorUserId, db, undefined)
+}
+
+/**
+ * Re-message a unique-code collision so it says which code collided.
+ *
+ * `validateUniqueFields` throws `"Code must be unique: value already exists"`,
+ * which is true and useless - and only the MESSAGE crosses tRPC, since the
+ * error serialises as a plain 409. `code` is the only unique field on
+ * `gl_account`, so any conflict from a chart write is that one, and the sentence
+ * a person needs is the whole of "4000 is already in use".
+ */
+async function namingTheCode<T>(code: string, write: () => Promise<T>): Promise<T> {
+  try {
+    return await write()
+  } catch (error) {
+    if (error instanceof UniqueValueConflictError) {
+      throw new UniqueValueConflictError({
+        message: `${code} is already in use by another account in this chart.`,
+        conflictingValue: code,
+        fieldId: error.fieldId,
+        existingEntityId: error.existingEntityId,
+      })
+    }
+    throw error
+  }
+}
+
+/** The four field ids and the `gl_account` definition, resolved together. */
+async function loadChartTarget(
+  organizationId: string
+): Promise<{ fields: ChartAccountFields; defId: string }> {
+  const fields = await loadChartAccountFields(organizationId, NOT_PROVISIONED)
+  const defId = fields.code.entityDefinitionId
+  if (!defId) {
+    throw new UnprocessableEntityError(
+      'The chart of accounts is not provisioned for this organization - gl_account_code is not attached to an entity definition. Run the entity migrations.',
+      { organizationId }
+    )
+  }
+  return { fields, defId }
+}
+
+/**
+ * The account as it stands, or `NotFoundError`.
+ *
+ * Archived rows are excluded by {@link loadLiveAccount}'s query, so "archived"
+ * and "does not exist" produce one answer - the same collapse every other reader
+ * of this chart makes.
+ */
+async function requireAccount(
+  db: Database,
+  organizationId: string,
+  accountId: string,
+  fields: ChartAccountFields
+): Promise<ChartAccountRow> {
+  const account = await loadLiveAccount(db, organizationId, accountId, fields)
+  if (!account) {
+    throw new NotFoundError(
+      `Account ${accountId} does not exist in this organization, or has been removed.`,
+      { organizationId, accountId }
+    )
+  }
+  return account
+}
+
+/**
+ * Re-read the account after a write, and refuse if it came back undecodable.
+ *
+ * ⚠️ **This is the §2.2 guard, not a convenience.** `UnifiedCrudHandler` resolves
+ * fields through the org cache and SILENTLY DROPS a value whose field it cannot
+ * resolve - the failure that once wrote 784 accounts across 28 orgs with the one
+ * field that mattered missing, and logged success. A dropped `gl_account_type`
+ * produces an account the decode classifies as malformed, which means it vanishes
+ * from the very list it was just created in. `loadChartAccountFields` above makes
+ * that structurally unlikely; this makes it impossible to go unnoticed.
+ */
+async function readBack(
+  db: Database,
+  organizationId: string,
+  accountId: string,
+  fields: ChartAccountFields
+): Promise<ChartAccountRow> {
+  const account = await loadLiveAccount(db, organizationId, accountId, fields)
+  if (!account) {
+    throw new AuxxError(
+      `The account was written but could not be read back with a code and a type (${accountId}). The write may have dropped a field value; nothing further has been changed.`,
+      { organizationId, accountId }
+    )
+  }
+  return account
+}
+
+/** One live (non-archived) account, decoded, or undefined. */
+async function loadLiveAccount(
+  db: Database,
+  organizationId: string,
+  accountId: string,
+  fields: ChartAccountFields
+): Promise<ChartAccountRow | undefined> {
+  const live = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.id, accountId),
+        // Archived is absent, exactly as every other reader of this chart has it.
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .limit(1)
+
+  if (live.length === 0) return undefined
+
+  const read = await readChartAccountValues(db, organizationId, [accountId], fields)
+  return read.accounts.get(accountId)
+}
+
+/**
+ * The roles that still post to this account.
+ *
+ * ⚠️ "Still posts" means a `GlRoleAssignment` row that is **not**
+ * `markedUnused`. That is the same exemption `listRoleMap`'s precedence table
+ * derives as the `unused` state, and it is the only state that exempts: a role
+ * the org has explicitly said it does not use is not a reason to refuse
+ * anything. A direct one-account query rather than `listRoleMap` because that
+ * one returns all thirteen roles and re-reads the chart to do it, and this needs
+ * neither.
+ */
+async function liveRolesFor(
+  db: Database,
+  organizationId: string,
+  accountId: string
+): Promise<LiveRole[]> {
+  const rows = await db
+    .select({
+      role: schema.GlRoleAssignment.role,
+      glAccountId: schema.GlRoleAssignment.glAccountId,
+    })
+    .from(schema.GlRoleAssignment)
+    .where(
+      and(
+        eq(schema.GlRoleAssignment.organizationId, organizationId),
+        eq(schema.GlRoleAssignment.glAccountId, accountId),
+        eq(schema.GlRoleAssignment.markedUnused, false)
+      )
+    )
+
+  return rows
+    .filter(
+      (row): row is LiveRole =>
+        (ROLE_ACCOUNT_TYPES as Record<string, string>)[row.role] !== undefined
+    )
+    .map((row) => ({ role: row.role as AccountRole, glAccountId: row.glAccountId }))
+}
+
+/**
+ * Refuse `verb` while any role still posts to this account, naming the first.
+ *
+ * The message names the role, its label and what to do next, because that is the
+ * standard the role map's refusals already set - "Could not save" throws away the
+ * only sentence that says what to do.
+ */
+async function assertNoLiveRole(
+  db: Database,
+  organizationId: string,
+  accountId: string,
+  account: ChartAccountRow,
+  verb: 'deactivate' | 'remove',
+  consequence: string
+): Promise<void> {
+  const live = await liveRolesFor(db, organizationId, accountId)
+  if (live.length === 0) return
+
+  const named = live.map(({ role }) => `'${role}' (${ACCOUNT_ROLE_LABELS[role]})`).join(', ')
+  throw new UnprocessableEntityError(
+    `Cannot ${verb} ${account.code} ${account.name}: ${named} ${live.length === 1 ? 'posts' : 'post'} here. Repoint ${live.length === 1 ? 'the role' : 'those roles'} on the Roles tab first, or mark ${live.length === 1 ? 'it' : 'them'} unused. ${consequence}`,
+    { organizationId, accountId, roles: live.map((row) => row.role).join(',') }
+  )
+}

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -28,6 +28,7 @@ export {
 export {
   DEFAULT_CHART_OF_ACCOUNTS,
   type DefaultChartAccount,
+  GL_ACCOUNT_TYPES,
   type GlAccountTypeValue,
 } from './default-chart'
 export {

--- a/packages/lib/src/postings/default-chart.ts
+++ b/packages/lib/src/postings/default-chart.ts
@@ -24,6 +24,23 @@ export type GlAccountTypeValue = (typeof GlAccountType)[Exclude<
   'values'
 >]
 
+/**
+ * The five statement classifications as a non-empty tuple, for a `z.enum`.
+ *
+ * Derived from `GlAccountType`'s NAMED members for the reason
+ * {@link GlAccountTypeValue} gives: `values` widens `value` to `string`, so a
+ * schema built from it would accept `'nonsense'`. Listed here rather than in the
+ * registry because a router needs it client-safely and this module is already
+ * the client-safe home of the type it is checked against.
+ */
+export const GL_ACCOUNT_TYPES = [
+  GlAccountType.ASSET,
+  GlAccountType.LIABILITY,
+  GlAccountType.EQUITY,
+  GlAccountType.REVENUE,
+  GlAccountType.EXPENSE,
+] as const satisfies readonly GlAccountTypeValue[]
+
 /** One account in the seeded default chart. */
 export interface DefaultChartAccount {
   /** The account number. Unique per org, and the org may change it. */

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -27,6 +27,14 @@ export {
   type MonthEndInventoryInputs,
 } from './build-month-end-inventory'
 export {
+  type CreateChartAccountOptions,
+  createChartAccount,
+  type RemoveChartAccountOptions,
+  removeChartAccount,
+  type UpdateChartAccountOptions,
+  updateChartAccount,
+} from './chart-write'
+export {
   type PostMonthEndOptions,
   type PreviewMonthEndOptions,
   postMonthEnd,
@@ -36,6 +44,7 @@ export { listClosePeriods } from './close-periods'
 export {
   DEFAULT_CHART_OF_ACCOUNTS,
   type DefaultChartAccount,
+  GL_ACCOUNT_TYPES,
   type GlAccountTypeValue,
 } from './default-chart'
 export {
@@ -105,6 +114,7 @@ export { type ResolvedAccount, resolveRoles } from './resolve-roles'
 export { type ReverseEntryOptions, reverseEntry } from './reverse-entry'
 export {
   listChartAccounts,
+  listChartAccountUsage,
   listRoleMap,
   type SetRoleAssignmentOptions,
   setRoleAssignment,

--- a/packages/lib/src/postings/role-map.ts
+++ b/packages/lib/src/postings/role-map.ts
@@ -42,7 +42,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, count, eq, isNull } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, BadRequestError, NotFoundError, UnprocessableEntityError } from '../errors'
 import { ACCOUNT_ROLES, type AccountRole, ROLE_ACCOUNT_TYPES } from './build-entry'
@@ -243,6 +243,53 @@ export async function listChartAccounts(
   } catch (error) {
     if (error instanceof AuxxError) return err(error)
     logger.error('Failed to list the chart of accounts', { error, organizationId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/**
+ * How many posted lines name each account CODE.
+ *
+ * The one number the chart's renumber warning needs. A posting line stores the
+ * account code with **no foreign key** (`P2`), deliberately, so the ledger
+ * outlives the chart - which means renumbering an account leaves every line
+ * already posted holding the old code. That is a feature, and it is also the
+ * kind of feature a person should be told about with a NUMBER rather than a
+ * caution: "142 posted lines carry 1310" is what makes the trade concrete.
+ *
+ * ⚠️ **Keyed on CODE, not on account id**, because a code is what a posted line
+ * actually stores. Two consequences, both correct: an account never posted to
+ * reports nothing, and an account whose code was PREVIOUSLY carried by a
+ * different account reports that history too. The question the number answers is
+ * "how many posted lines say `1310`", which is exactly the question somebody
+ * about to renumber is asking.
+ *
+ * 🛑 Deliberately NOT folded into {@link listChartAccounts}. `ChartAccountRow` is
+ * shared with `resolveRoles`' path and decoded by every reader of this chart; a
+ * field only the settings screen renders does not belong on it.
+ */
+export async function listChartAccountUsage(
+  db: Database,
+  organizationId: string
+): Promise<Result<Record<string, number>, Error>> {
+  try {
+    const rows = await db
+      .select({
+        accountCode: schema.GlPostingLine.accountCode,
+        lines: count(),
+      })
+      .from(schema.GlPostingLine)
+      .where(eq(schema.GlPostingLine.organizationId, organizationId))
+      .groupBy(schema.GlPostingLine.accountCode)
+
+    const usage: Record<string, number> = {}
+    for (const row of rows) {
+      if (row.accountCode) usage[row.accountCode] = Number(row.lines) || 0
+    }
+    return ok(usage)
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to count posted lines per account', { error, organizationId })
     return err(new AuxxError('Internal error'))
   }
 }

--- a/packages/lib/src/seed/index.ts
+++ b/packages/lib/src/seed/index.ts
@@ -4,6 +4,7 @@ export type { EntityDefMap, EntityDefRecord, FieldMap, FieldRecord } from './ent
 export { EntitySeeder } from './entity-seeder'
 // Entity Seeder (multi-pass implementation)
 export { deletePristineSeededDashboards } from './entity-seeder/create-default-dashboards'
+export { type ChartSeedResult, seedDefaultChartOfAccounts } from './gl-account-chart'
 export { seedNewUserDatabase } from './new-user'
 export { OrganizationSeeder, type SeedOrganizationOptions } from './organization-seeder'
 export { UserSeeder, type UserSeedOptions, type UserSeedResult } from './user-seeder'


### PR DESCRIPTION
`G7` has said the chart of accounts is the org's own document since it was seeded, and every piece of machinery downstream is built on that premise — `G8` exists *only* because the chart is editable, and `GlPostingLine.accountCode` has no foreign key *only* because the chart is editable.

And nothing could write one. `ledger.chartAccounts` read; the only writer that had ever existed was `seedDefaultChartOfAccounts`, at migration time. The Chart tab said "The chart is not editable here yet."

## Why not the generic record path

This resolves [task 14 §3]'s open branch, against the record path. `record.create` / `record.update` are `capabilityProcedure` and assert the **records** capability for the definition. The ledger area has two rungs, `Read → ledgerView` and `Full → ledgerPost`, and `setRoleAssignment` is already on `ledgerPost` because *"this decides which account real money lands in"*.

Routing the chart through the generic CRUD hands that same decision to anyone with records-Full and ledger-None. A renumber there is **undetectable downstream, because the resulting entry still balances**. So `gl_account` stays `isVisible: false` and this settings page is its only door.

## The invariant this exists for

`mapRole` validates the pair (role, account) from the **role's** side — not archived, active, and `accountType === ROLE_ACCOUNT_TYPES[role]`. `resolveRoles` re-checks the same three at post time.

**Editing the account is the other half of that pair**, and every one of those checks was bypassable from it: map `grni` to a liability account, then retype that account to `revenue`. Two legal-looking writes, one unbalanceable-but-wrong ledger.

So `postings/chart-write.ts` owns the same three refusals from the account's side, plus code uniqueness:

| | rule |
| --- | --- |
| **I1** | a type change may not break a role that posts here |
| **I2** | no deactivating an account a live role points at |
| **I3** | no removing one either |
| **I4** | the code is unique, and the refusal names *which* code |

A role explicitly `markedUnused` exempts all three — the org has said it does not post there.

`code` and `name` stay **unconditional** (`G7`). A rename cannot touch history (`GlPostingLine.accountName` is a snapshot); a renumber cannot touch role resolution (`GlRoleAssignment` names the instance). What a renumber *does* do is detach posted lines from the row on screen — `P2` working as designed — so the UI states it with a **count** (`142 posted lines carry 1310`) rather than a caution.

## Remove is ARCHIVE

`handler.delete` appears nowhere. Three independent reasons: every reader already excludes archived rows in the query; the seeder reads archived codes on purpose so a re-seed cannot resurrect what somebody removed; and a hard delete cascades away the `RecordIdentity` holding a connected provider's account id (`P2`).

## Provisioning is a wizard button — and it closes a real hole

`gl_account`'s *definition* ships with every org; its *rows* now do not. Most orgs never open accounting.

It also fixes something that would have bitten on the first production deploy. `seedDefaultChartOfAccounts`' only other caller is entity migration 108, which reaches production through the DataMigration ledger — where **`DataMigration.id` is the PRIMARY KEY, one global row, no `organizationId`**. Once 108 is `applied` it never runs again. Every org created after that deploy would have had a def, zero accounts, thirteen unmapped roles, every Preview refusing `account_unmapped`, and no way to fix it.

## Also in here

- The accounting provider's **Connect** and **Manage** open `AppSettingsDialog` instead of navigating to `/app/settings/apps/quickbooks` — which dropped people out of the module mid-setup. The dialog is where the OAuth flow lives anyway.
- The connected card now names the company, who authorized it and when.

## Checks

No migration, no new permission key. 22 new tests (`chart-write.test.ts`), 477 postings tests green, lib ratchet 29/29 baseline, web typecheck exit 0, biome clean.

## Not done

🛑 **Not driven in a browser.** `HANDOFF.md` §5 records four rounds of this subsystem's unit tests passing while the feature was broken, so this is worth clicking before merge: add an account, keep typing while the create is in flight, renumber one with posted lines, change a type a role points at and read the refusal, deactivate, remove.

Follow-up written up as `plans/money/tasks/17-name-the-quickbooks-company.md`: the card can only show `Company 9341456539348220`. The fix is entirely in the QuickBooks app — `saveAppConnection` already applies a `{ label }` returned from `connection-added`.

https://claude.ai/code/session_01L8tyoTFKPsig89oe2nMxAd
