### PR TITLE
feat(money): the standard-cost lifecycle

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
@@ -32,6 +32,7 @@ export const ACCOUNTING_KEYS = {
   qboOpeningJournalRef: 'accounting.qboOpeningJournalRef',
   assemblyLaborCostPerUnit: 'manufacturing.assemblyLaborCostPerUnit',
   overheadCostPerUnit: 'manufacturing.overheadCostPerUnit',
+  autoRollFirstStandard: 'manufacturing.autoRollFirstStandard',
 } as const
 
 /**
@@ -49,6 +50,7 @@ export const PERIOD_DRAFT_KEYS = [
 export const ABSORPTION_DRAFT_KEYS = [
   ACCOUNTING_KEYS.assemblyLaborCostPerUnit,
   ACCOUNTING_KEYS.overheadCostPerUnit,
+  ACCOUNTING_KEYS.autoRollFirstStandard,
 ] as const
 
 export const OPENING_DRAFT_KEYS = [

--- a/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
@@ -187,8 +187,8 @@ export function AccountingGeneralSettingsPage() {
 
             <SettingsSection
               icon={Scale}
-              title='Absorption rates'
-              description='Per assembled unit, in whole cents. An unset rate absorbs nothing; a zero rate is a real choice.'>
+              title='Standard cost'
+              description='Absorption per assembled unit, in whole cents, and how a part first gets a standard. An unset rate absorbs nothing; a zero rate is a real choice.'>
               <FieldPanel
                 className='mt-1 p-0'
                 resizeId='accounting-general-absorption'
@@ -224,12 +224,25 @@ export function AccountingGeneralSettingsPage() {
                     }
                   />
                 </SettingsFieldRow>
+                <SettingsFieldRow
+                  settingKey={ACCOUNTING_KEYS.autoRollFirstStandard}
+                  title='Set a first standard automatically'
+                  description='When a part first gets a price, opening stock or a receipt, freeze that as its standard cost.'
+                  value={absorptionDraft[ACCOUNTING_KEYS.autoRollFirstStandard] ?? true}
+                  onChange={(value) =>
+                    patchAbsorption({
+                      [ACCOUNTING_KEYS.autoRollFirstStandard]: value as SettingValue,
+                    })
+                  }
+                />
               </FieldPanel>
 
               <p className='text-muted-foreground text-xs'>
                 Conversion cost applies to a subassembly or a finished good only. Applying these
                 rates to a purchased component would capitalize labor that was never spent and
-                overstate raw materials.
+                overstate raw materials. Setting a first standard never overwrites one that already
+                exists, so a supplier raising a price moves the part&apos;s cost and leaves its
+                standard where it is. Re-valuing is what the roll below is for.
               </p>
             </SettingsSection>
 

--- a/apps/web/src/components/accounting/ui/settings/standard-cost-section.tsx
+++ b/apps/web/src/components/accounting/ui/settings/standard-cost-section.tsx
@@ -25,6 +25,7 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { formatCurrency } from '@auxx/utils/currency'
+import { keepPreviousData } from '@tanstack/react-query'
 import { Calculator, Lock } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
@@ -61,9 +62,17 @@ export function StandardCostSection() {
     if (canRoll) setEffectiveAt(new Date().toISOString())
   }, [canRoll])
 
+  // `keepPreviousData` because the effective date is part of the query key:
+  // without it every change to it blanks the whole preview (15 §4a), and this
+  // one is org-wide, so the list that unmounts mid-keystroke is every part.
   const preview = api.builds.previewRoll.useQuery(
     { effectiveAt: new Date(effectiveAt) },
-    { enabled: canRoll, retry: false, refetchOnWindowFocus: false }
+    {
+      enabled: canRoll,
+      retry: false,
+      refetchOnWindowFocus: false,
+      placeholderData: keepPreviousData,
+    }
   )
 
   const utils = api.useUtils()
@@ -140,8 +149,15 @@ export function StandardCostSection() {
           ) : plan ? (
             <div className='space-y-3 rounded-xl border p-3'>
               {changed.length === 0 ? (
+                // Two different empty states, and calling the second one the
+                // first is a lie: "already matches" claims every part carries a
+                // current standard, when in fact not one of them could be valued.
+                // Only say it when there genuinely were valuable lines and none
+                // moved. The other case has its reasons listed right below.
                 <p className='text-muted-foreground text-xs'>
-                  Nothing to roll. Every part&apos;s standard already matches today&apos;s cost.
+                  {plan.lines.length === 0 && plan.skipped.length > 0
+                    ? 'Nothing to roll. No part can be valued yet, see why below.'
+                    : 'Nothing to roll. Every part’s standard already matches today’s cost.'}
                 </p>
               ) : (
                 <div className='space-y-1'>

--- a/apps/web/src/components/drawers/cards/part-costing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-costing-card.tsx
@@ -8,6 +8,7 @@ import type { ResourceFieldId } from '@auxx/types/field'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { formatCurrency } from '@auxx/utils/currency'
+import Link from 'next/link'
 import { useMemo } from 'react'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { Tooltip } from '~/components/global/tooltip'
@@ -99,8 +100,16 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
 
   const hasComparison = purchaseCost != null && rollupCost != null
   const isUncosted = costSource === CostSource.NONE
-  // The standard block shows as soon as there is anything to say about it —
+  // Has a cost, has never been rolled. THIS is the state the org-wide roll fixes,
+  // and the only one worth pointing at it: a part with no live cost is skipped by
+  // that roll too (`no-live-cost`), so sending someone there would be bad advice.
+  // The `isUncosted` branch above already tells that part what it actually needs,
+  // which is a supplier price or a priced bill of materials.
+  const rollWouldValueIt = standardCost == null && liveCost != null
+  // The standard block shows as soon as there is anything to say about it,
   // including "not rolled yet", which is the state that needs the action most.
+  // A part with NO cost at all is deliberately not in that set: it would add a
+  // second amber row saying nothing the "Not costed" row above has not said.
   const hasStandardBlock = standardCost != null || liveCost != null
   // How far the standard has drifted from reality since it was last rolled.
   // Genuinely useful on its own: it is the number that tells you a roll is due.
@@ -187,9 +196,22 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
             description='The frozen value every stock movement is stamped with'>
             <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm tabular-nums'>
               {standardCost == null ? (
-                <Badge variant='amber' size='xs'>
-                  Not rolled
-                </Badge>
+                <>
+                  <Badge variant='amber' size='xs'>
+                    Not rolled
+                  </Badge>
+                  {rollWouldValueIt && (
+                    <span className='text-muted-foreground text-xs'>
+                      Roll it here, or{' '}
+                      <Link
+                        href='/app/accounting/settings/general'
+                        className='underline underline-offset-2 hover:text-foreground'>
+                        Settings &rsaquo; Accounting &rsaquo; General
+                      </Link>{' '}
+                      rolls every part at once.
+                    </span>
+                  )}
+                </>
               ) : (
                 <>
                   {formatCurrency(standardCost)}

--- a/apps/web/src/components/drawers/cards/part-family-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-family-card.tsx
@@ -26,7 +26,7 @@ import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { RecordLink } from '~/components/resources/ui/record-link'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import {
-  isPartKindUnset,
+  isPartKindUnclassified,
   shouldSuggestFamily,
   shouldSuggestFinishedGood,
 } from './part-family-suggestion'
@@ -75,8 +75,10 @@ function relatedInstanceId(raw: unknown): string | undefined {
  * exclusive by construction:
  *
  * - the `finished_good` suggestion (01 §4) — a part that has a product and is
- *   nobody's subpart is almost certainly a finished good. Never offered over an
- *   explicit human choice of `part_kind`.
+ *   nobody's subpart is almost certainly a finished good. Offered while
+ *   `part_kind` is unclassified (unset, or the `component` the field defaults
+ *   to since 15-costing-usability.md §4c); never over an explicit
+ *   `subassembly` or `finished_good`.
  * - the **family** suggestion (09 §6) — a part already classified
  *   `finished_good` that sits in no family. Without it a part with no family
  *   rendered nothing at all, so there was no route into a family from this side
@@ -142,7 +144,13 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
 
   // Finished-good condition (b): is this part anybody's subpart? Child-side
   // filter (`subpart:childPart`), limit 1 — presence is the only question.
-  const partKindUnset = isPartKindUnset(partKind)
+  //
+  // Gated on the same predicate condition (c) uses, so the read runs for every
+  // part the suggestion could fire on. That now includes a part sitting on the
+  // defaulted `component` (15-costing-usability.md §4c). With the old
+  // unset-only gate the lookup would never run for those, `subpartCheckLoaded`
+  // would stay false, and the widened suggestion could never appear.
+  const partKindUnclassified = isPartKindUnclassified(partKind)
   const usedInFilters: ConditionGroup[] = useMemo(
     () => [
       {
@@ -164,7 +172,7 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
     entityDefinitionId: subpartDefId ?? '',
     filters: usedInFilters,
     limit: 1,
-    enabled: !!productId && partKindUnset && !!partId && !!subpartDefId,
+    enabled: !!productId && partKindUnclassified && !!partId && !!subpartDefId,
   })
 
   const { save, isPending } = useSaveSystemValues(recordId)

--- a/apps/web/src/components/drawers/cards/part-family-suggestion.test.ts
+++ b/apps/web/src/components/drawers/cards/part-family-suggestion.test.ts
@@ -2,11 +2,19 @@
 //
 // The finished_good suggestion (plans/products/01-product-family.md §4) is
 // gated on ALL of: (a) the part HAS a product, (b) it is nobody's subpart,
-// (c) part_kind is unset — never over an explicit human choice. Gap C §3.2:
-// a suggestion the human confirms, never a derivation.
+// (c) part_kind is UNCLASSIFIED. Gap C §3.2: a suggestion the human confirms,
+// never a derivation.
+//
+// (c) used to mean "unset". Since 15-costing-usability.md §4c the `part_kind`
+// field carries `defaultValue: 'component'`, so a stored `component` no longer
+// proves a human typed it, and the unclassified set is "unset OR component".
+// Leaving the gate at unset-only would have silently deleted the only safety
+// net against a finished good posting to 1310 instead of 1330 on movement rows
+// that are `updatable: false` and can never be corrected.
 
 import { describe, expect, it } from 'vitest'
 import {
+  isPartKindUnclassified,
   isPartKindUnset,
   shouldSuggestFamily,
   shouldSuggestFinishedGood,
@@ -43,19 +51,40 @@ describe('shouldSuggestFinishedGood', () => {
     ).toBe(false)
   })
 
-  it('(c) never suggests over an explicit human choice — any set kind blocks it', () => {
-    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'component' })).toBe(false)
-    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'subassembly' })).toBe(false)
-    // Already finished_good: nothing to suggest.
-    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'finished_good' })).toBe(false)
-    // SINGLE_SELECT stored values are arrays on some read paths — same answer.
-    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: ['component'] })).toBe(false)
+  it('(c) still suggests over a `component`, the field default, not a human choice', () => {
+    // The load-bearing case: a finished good created through the form (or an
+    // import, or the API) lands on `component` without anybody saying so.
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'component' })).toBe(true)
+    // SINGLE_SELECT stored values are arrays on some read paths, same answer.
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: ['component'] })).toBe(true)
   })
 
-  it('(c) array-shaped and empty select values still read as unset', () => {
+  it('(c) never suggests over a deliberate classification', () => {
+    // Neither of these is reachable without somebody picking it.
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'subassembly' })).toBe(false)
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: ['subassembly'] })).toBe(false)
+    // Already finished_good: nothing to suggest.
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'finished_good' })).toBe(false)
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: ['finished_good'] })).toBe(false)
+  })
+
+  it('(c) array-shaped and empty select values still read as unclassified', () => {
     expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: null })).toBe(true)
     expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: '' })).toBe(true)
     expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: [] })).toBe(true)
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: [''] })).toBe(true)
+  })
+
+  it('(a) and (b) are unaffected by the widening: component alone is not enough', () => {
+    expect(
+      shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'component', hasProduct: false })
+    ).toBe(false)
+    expect(
+      shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'component', isSubpartOfAssembly: true })
+    ).toBe(false)
+    expect(
+      shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'component', subpartCheckLoaded: false })
+    ).toBe(false)
   })
 })
 
@@ -71,6 +100,28 @@ describe('isPartKindUnset', () => {
   it('treats any concrete value as set, scalar or array-wrapped', () => {
     expect(isPartKindUnset('component')).toBe(false)
     expect(isPartKindUnset(['finished_good'])).toBe(false)
+  })
+})
+
+describe('isPartKindUnclassified', () => {
+  it('agrees with isPartKindUnset on every unset shape', () => {
+    for (const value of [undefined, null, '', [], ['']]) {
+      expect(isPartKindUnset(value)).toBe(true)
+      expect(isPartKindUnclassified(value)).toBe(true)
+    }
+  })
+
+  it('adds `component`, the field default, so not a human choice', () => {
+    expect(isPartKindUnset('component')).toBe(false)
+    expect(isPartKindUnclassified('component')).toBe(true)
+    expect(isPartKindUnclassified(['component'])).toBe(true)
+  })
+
+  it('leaves the two deliberate kinds classified', () => {
+    expect(isPartKindUnclassified('subassembly')).toBe(false)
+    expect(isPartKindUnclassified(['subassembly'])).toBe(false)
+    expect(isPartKindUnclassified('finished_good')).toBe(false)
+    expect(isPartKindUnclassified(['finished_good'])).toBe(false)
   })
 })
 
@@ -100,16 +151,41 @@ describe('shouldSuggestFamily', () => {
     }
   })
 
+  it('is UNAFFECTED by the widened finished-good gate', () => {
+    // The widening only moved `component` into the unclassified set.
+    // shouldSuggestFamily gates on an explicit `finished_good`, which was never
+    // in that set, so every answer here is exactly what it was before.
+    for (const partKind of [
+      undefined,
+      null,
+      '',
+      [],
+      [''],
+      'component',
+      ['component'],
+      'subassembly',
+    ]) {
+      expect(shouldSuggestFamily({ hasProduct: false, partKind })).toBe(false)
+    }
+    expect(shouldSuggestFamily({ hasProduct: false, partKind: 'finished_good' })).toBe(true)
+  })
+
   it('is mutually exclusive with the finished-good suggestion', () => {
-    // The two gate on opposite sides of the same fact: one refuses to speak
-    // OVER a human choice of part_kind, the other refuses to speak WITHOUT one.
+    // The two gate on opposite sides of the same fact: one only speaks while
+    // part_kind is unclassified, the other only once it says finished_good,
+    // and finished_good is never unclassified. They also disagree on
+    // hasProduct, so the exclusion is doubly true.
     const cases: Array<{ hasProduct: boolean; partKind: unknown }> = [
       { hasProduct: false, partKind: undefined },
       { hasProduct: false, partKind: 'finished_good' },
       { hasProduct: false, partKind: 'component' },
+      { hasProduct: false, partKind: ['component'] },
+      { hasProduct: false, partKind: 'subassembly' },
       { hasProduct: true, partKind: undefined },
       { hasProduct: true, partKind: 'finished_good' },
       { hasProduct: true, partKind: 'component' },
+      { hasProduct: true, partKind: ['component'] },
+      { hasProduct: true, partKind: 'subassembly' },
     ]
     for (const input of cases) {
       const both =

--- a/apps/web/src/components/drawers/cards/part-family-suggestion.ts
+++ b/apps/web/src/components/drawers/cards/part-family-suggestion.ts
@@ -11,22 +11,51 @@
  */
 
 /**
- * Whether `part_kind` counts as unset — the "never suggest over an explicit
- * human choice" gate. `useSystemValues` collapses SINGLE_SELECT to a scalar,
- * but stored select values are arrays on other read paths, so both shapes are
- * handled: `null`/`undefined`, `''`, `[]`, and an array whose first entry is
- * empty all read as unset; any concrete value (including an explicit
- * `component`) is a human choice and blocks the suggestion.
+ * Whether `part_kind` counts as unset. `useSystemValues` collapses SINGLE_SELECT
+ * to a scalar, but stored select values are arrays on other read paths, so both
+ * shapes are handled: `null`/`undefined`, `''`, `[]`, and an array whose first
+ * entry is empty all read as unset.
+ *
+ * ⚠️ This is no longer the whole suggestion gate. `part_kind` now carries
+ * `defaultValue: 'component'` (part-fields.ts, 15-costing-usability.md §4c), so
+ * a stored `component` no longer proves a human chose it. See
+ * {@link isPartKindUnclassified}, which is what the suggestion gates on.
  */
 export function isPartKindUnset(value: unknown): boolean {
   const first = Array.isArray(value) ? value[0] : value
   return first == null || first === ''
 }
 
+/**
+ * Whether `part_kind` still reads as "nobody has said what this part is":
+ * unset, **or** the `component` the field now defaults to.
+ *
+ * 🛑 Why `component` counts. The old rule was "any concrete value (including an
+ * explicit `component`) is a human choice and blocks the suggestion", and its
+ * premise was that `component` only ever got there because somebody typed it.
+ * Defaulting `part_kind` to `component` falsifies that premise: after
+ * 15-costing-usability.md §4c it means "nobody said otherwise". Left alone, the
+ * gate would go quiet on exactly the parts it exists for, and a finished good
+ * sitting on the default posts to `1310` instead of `1330` and freezes that on
+ * `updatable: false` movement rows that can never be corrected.
+ *
+ * So the suggestion stops being "fill in the blank" and becomes "this looks
+ * misclassified", which also catches imported, seeded and API-created parts that
+ * the unset-only gate never could. `subassembly` and `finished_good` still block
+ * it: neither is reachable without somebody picking it.
+ */
+export function isPartKindUnclassified(value: unknown): boolean {
+  const first = Array.isArray(value) ? value[0] : value
+  return first == null || first === '' || first === 'component'
+}
+
 interface SuggestFinishedGoodInput {
   /** (a) The part HAS a product — it heads (or belongs to) a family. */
   hasProduct: boolean
-  /** (c) Raw `part_kind` value — any set value blocks the suggestion. */
+  /**
+   * (c) Raw `part_kind` value. Unset or `component` (the field default) leaves
+   * the suggestion open; `subassembly` and `finished_good` block it.
+   */
   partKind: unknown
   /**
    * Whether the "is anybody's subpart?" read has actually completed. Until it
@@ -43,11 +72,14 @@ interface SuggestFinishedGoodInput {
 
 /**
  * ALL required: (a) the part has a product, (b) it is nobody's subpart, and
- * (c) `part_kind` is currently unset.
+ * (c) `part_kind` is unclassified: unset, or the defaulted `component`.
+ *
+ * (a) and (b) are unchanged. Only (c) widened; see
+ * {@link isPartKindUnclassified} for why.
  */
 export function shouldSuggestFinishedGood(input: SuggestFinishedGoodInput): boolean {
   if (!input.hasProduct) return false
-  if (!isPartKindUnset(input.partKind)) return false
+  if (!isPartKindUnclassified(input.partKind)) return false
   if (!input.subpartCheckLoaded) return false
   return !input.isSubpartOfAssembly
 }
@@ -70,9 +102,11 @@ interface SuggestFamilyInput {
  * find the Product field in the Details panel.
  *
  * Note the symmetry with {@link shouldSuggestFinishedGood}, which is why the two
- * can never fire together: that one refuses to speak OVER a human choice of
- * `part_kind`, this one refuses to speak WITHOUT one. `finished_good` is
- * required explicitly and is never inferred — the same Gap C §3.2 rule.
+ * can never fire together: that one only speaks while the kind is unclassified,
+ * this one only speaks once it says `finished_good`, and `finished_good` is
+ * never in the unclassified set. It is required explicitly and never inferred,
+ * the same Gap C §3.2 rule. (They also disagree on `hasProduct`, so the two
+ * conditions are doubly exclusive.)
  */
 export function shouldSuggestFamily(input: SuggestFamilyInput): boolean {
   if (input.hasProduct) return false

--- a/apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
+++ b/apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
@@ -38,7 +38,7 @@
 // implementation of the variance to drift.
 
 import { FieldType } from '@auxx/database/enums'
-import { summarizeBuildCompletion } from '@auxx/lib/builds/client'
+import { absorbedRunCost, summarizeBuildCompletion } from '@auxx/lib/builds/client'
 import { getInstanceId, type RecordId } from '@auxx/lib/resources/client'
 import type { RelationshipConfig } from '@auxx/types/custom-field'
 import { toResourceFieldId } from '@auxx/types/field'
@@ -57,12 +57,14 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { formatCurrency } from '@auxx/utils/currency'
+import { keepPreviousData } from '@tanstack/react-query'
 import { RotateCcw, TriangleAlert } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { toRecordId, useResourceProperty } from '~/components/resources'
 import { BaseType } from '~/components/workflow/types'
+import { useDebounce } from '~/hooks/use-debounced-value'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
 import {
@@ -79,6 +81,15 @@ const OFF_BOM_PART_RELATIONSHIP: RelationshipConfig = {
   relationshipType: 'belongs_to',
   isInverse: false,
 }
+
+/**
+ * How long a typed quantity is held back before it becomes a preview request.
+ *
+ * Typing `120` is three keystrokes, and without this it is three explosions of
+ * the whole bill of materials. Only what feeds the query waits — the inputs
+ * themselves stay instant, so nothing on screen lags behind the keyboard.
+ */
+const PREVIEW_DEBOUNCE_MS = 250
 
 interface CompleteBuildDialogProps {
   open: boolean
@@ -107,7 +118,7 @@ export function CompleteBuildDialog({
   const [quantityScrapped, setQuantityScrapped] = useState<number>(0)
   const [overrides, setOverrides] = useState<Record<string, number>>({})
   // Every component the form has ever seen for this run — see `rememberComponents`.
-  const [known, setKnown] = useState<KnownComponent[]>([])
+  const [known, setKnown] = useState<readonly KnownComponent[]>([])
   // `null` means "take the org rate"; a number is what this run actually absorbed.
   const [laborCost, setLaborCost] = useState<number | null>(null)
   const [overheadCost, setOverheadCost] = useState<number | null>(null)
@@ -137,15 +148,51 @@ export function CompleteBuildDialog({
   const scrapped = quantityScrapped ?? 0
   const componentOverrides = useMemo(() => buildComponentOverrides(overrides), [overrides])
 
+  // What the preview is actually asked about. Held back so `1` -> `12` -> `120`
+  // is one explosion rather than three; the inputs above render the untouched
+  // state, so the keyboard never waits on the network.
+  const previewProduced = useDebounce(produced, PREVIEW_DEBOUNCE_MS)
+  const previewScrapped = useDebounce(scrapped, PREVIEW_DEBOUNCE_MS)
+  const previewOverrides = useDebounce(componentOverrides, PREVIEW_DEBOUNCE_MS)
+
   // The preview IS the form. It re-runs on every quantity and every override, so
   // what is on screen is always what the write would freeze.
+  //
+  // 🛑 `keepPreviousData` is load-bearing, not polish. Without it every keystroke
+  // changes the query key, `data` goes undefined, and the summary, the absorbed
+  // amounts, the unpriced warning and the submit button all blank together —
+  // which reads as "the numbers just went away" on the one form in this
+  // subsystem whose write cannot be undone.
   const preview = api.builds.previewCompletion.useQuery(
-    { partId, quantityProduced: produced, quantityScrapped: scrapped, componentOverrides },
-    { enabled: open && produced > 0, retry: false, refetchOnWindowFocus: false }
+    {
+      partId,
+      quantityProduced: previewProduced,
+      quantityScrapped: previewScrapped,
+      componentOverrides: previewOverrides,
+    },
+    {
+      enabled: open && previewProduced > 0,
+      retry: false,
+      refetchOnWindowFocus: false,
+      placeholderData: keepPreviousData,
+    }
   )
 
   const plan = preview.data?.plan
   const rates = preview.data?.rates
+
+  /**
+   * The numbers on screen do not yet answer the quantities in the inputs.
+   *
+   * True through the debounce window as well as the request, so the summary dims
+   * from the first keystroke instead of a beat later, and so the submit button
+   * can refuse a run whose figures nobody has actually seen.
+   */
+  const previewStale =
+    preview.isFetching ||
+    previewProduced !== produced ||
+    previewScrapped !== scrapped ||
+    previewOverrides !== componentOverrides
 
   // Accumulate rather than replace: a line overridden to zero is not in the
   // plan's `components`, and dropping it from the row list would take the input
@@ -164,18 +211,41 @@ export function CompleteBuildDialog({
   // is null until the produced part has a standard, and there is deliberately no
   // fallback: a completion at zero cost is what this whole subsystem exists to
   // prevent, so the summary shows nothing rather than a confident zero.
+  //
+  // Built from the quantities the PLAN was exploded at, not the ones in the
+  // inputs: pairing a fresh `quantityProduced` with a stale component list would
+  // print a variance that no single state of the form ever produced.
   const summary = useMemo(() => {
     if (!plan || plan.producedUnitCost == null || !rates) return null
     return summarizeBuildCompletion({
       components: plan.components,
       producedUnitCost: plan.producedUnitCost,
-      quantityProduced: produced,
-      quantityScrapped: scrapped,
+      quantityProduced: previewProduced,
+      quantityScrapped: previewScrapped,
       laborCost,
       overheadCost,
       rates,
     })
-  }, [plan, rates, produced, scrapped, laborCost, overheadCost])
+  }, [plan, rates, previewProduced, previewScrapped, laborCost, overheadCost])
+
+  // The org-rate prefill for the two absorption inputs, derived from `rates`
+  // rather than from `summary` so it survives a refetch: `summary` is null
+  // whenever the produced part has no standard, and chaining the displayed
+  // default off it is what emptied both inputs on every keystroke.
+  //
+  // 🛑 An UNDECLARED rate shows nothing, not `$0.00`. `absorbedRunCost` answers
+  // `0` for a null rate on purpose (a run under no rate absorbed nothing), but a
+  // confident zero in the input would tell somebody the rates are set when they
+  // are not — the same distinction `absorptionHint` makes just below.
+  const startedNow = produced + scrapped
+  const laborDefault =
+    rates?.laborCostPerUnit == null
+      ? null
+      : absorbedRunCost(null, rates.laborCostPerUnit, startedNow)
+  const overheadDefault =
+    rates?.overheadCostPerUnit == null
+      ? null
+      : absorbedRunCost(null, rates.overheadCostPerUnit, startedNow)
 
   const utils = api.useUtils()
   const buildDefId = useResourceProperty('build', 'id')
@@ -218,7 +288,12 @@ export function CompleteBuildDialog({
 
   const unpriced = plan?.missingStandardPartIds ?? []
   const blocked = unpriced.length > 0 || rows.every((row) => row.dropped)
-  const canSubmit = !!summary && produced > 0 && !blocked && !completeBuild.isPending
+  // 🛑 `!previewStale` is part of the gate, not a spinner nicety. The button
+  // posts the quantities in the INPUTS, so accepting a press while the summary
+  // still answers the previous ones would freeze an irreversible ledger entry
+  // whose variance nobody was ever shown.
+  const canSubmit =
+    !!summary && produced > 0 && !blocked && !previewStale && !completeBuild.isPending
 
   const writtenRows = rows.filter((row) => !row.dropped).length
 
@@ -300,9 +375,15 @@ export function CompleteBuildDialog({
                 <FieldInputAdapter
                   fieldType={FieldType.CURRENCY}
                   fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
-                  value={laborCost ?? summary?.laborCost ?? null}
+                  value={laborCost ?? laborDefault}
                   onChange={(val) => setLaborCost((val as number) ?? null)}
                   disabled={completeBuild.isPending}
+                />
+                <AbsorptionOrigin
+                  explicit={laborCost}
+                  rate={rates?.laborCostPerUnit}
+                  started={startedNow}
+                  currencyCode={currencyCode}
                 />
               </FieldPanelRow>
 
@@ -315,9 +396,15 @@ export function CompleteBuildDialog({
                 <FieldInputAdapter
                   fieldType={FieldType.CURRENCY}
                   fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
-                  value={overheadCost ?? summary?.overheadCost ?? null}
+                  value={overheadCost ?? overheadDefault}
                   onChange={(val) => setOverheadCost((val as number) ?? null)}
                   disabled={completeBuild.isPending}
+                />
+                <AbsorptionOrigin
+                  explicit={overheadCost}
+                  rate={rates?.overheadCostPerUnit}
+                  started={startedNow}
+                  currencyCode={currencyCode}
                 />
               </FieldPanelRow>
 
@@ -339,7 +426,7 @@ export function CompleteBuildDialog({
               error={preview.error?.message ?? null}
               currencyCode={currencyCode}
               disabled={completeBuild.isPending}
-              unitsStarted={produced + scrapped}
+              unitsStarted={previewProduced + previewScrapped}
               onOverride={(rowPartId, quantity) =>
                 setOverrides((current) => ({ ...current, [rowPartId]: quantity }))
               }
@@ -368,14 +455,21 @@ export function CompleteBuildDialog({
               <UnpricedWarning partIds={unpriced} rows={rows} producedPartId={partId} />
             )}
 
+            {/* Dimmed while the figures are catching up, never unmounted: a
+                block that disappears reads as "there is no answer", and a person
+                looking at an irreversible variance should see the previous
+                answer greying out rather than the space it used to occupy. */}
             {summary && (
-              <CostSummary
-                summary={summary}
-                currencyCode={currencyCode}
-                quantityProduced={produced}
-                quantityScrapped={scrapped}
-                producedUnitCost={plan?.producedUnitCost ?? null}
-              />
+              <div
+                className={previewStale ? 'opacity-60 transition-opacity' : 'transition-opacity'}>
+                <CostSummary
+                  summary={summary}
+                  currencyCode={currencyCode}
+                  quantityProduced={previewProduced}
+                  quantityScrapped={previewScrapped}
+                  producedUnitCost={plan?.producedUnitCost ?? null}
+                />
+              </div>
             )}
           </div>
         </ScrollArea>
@@ -600,6 +694,37 @@ function ComponentRowInput({
         <RotateCcw />
       </Button>
     </div>
+  )
+}
+
+/**
+ * Where the amount in an absorption input came from.
+ *
+ * The input holds `null` while it is showing the org rate's arithmetic, and
+ * `null` is what gets SENT — the server owns the multiplication. So the number
+ * on screen would otherwise be unattributable: a person cannot tell a prefilled
+ * figure from one somebody typed, and the difference decides whether editing the
+ * rate later changes anything. This line says which it is.
+ */
+function AbsorptionOrigin({
+  explicit,
+  rate,
+  started,
+  currencyCode,
+}: {
+  explicit: number | null
+  rate: number | null | undefined
+  started: number
+  currencyCode: string
+}) {
+  if (explicit != null) {
+    return <p className='mt-1 text-muted-foreground text-xs'>Entered for this run.</p>
+  }
+  if (rate == null) return null
+  return (
+    <p className='mt-1 text-muted-foreground text-xs tabular-nums'>
+      {formatCurrency(rate, { currencyCode })} × {formatQuantity(started)} units started (org rate)
+    </p>
   )
 }
 

--- a/apps/web/src/components/manufacturing/builds/completion-input.ts
+++ b/apps/web/src/components/manufacturing/builds/completion-input.ts
@@ -67,13 +67,30 @@ export interface KnownComponent {
  * them. Rebuilding the row list from each response alone would make the row
  * disappear the moment somebody typed `0`, taking the input that produced it
  * with it.
+ *
+ * 🛑 **Returns `known` itself when the merge changes nothing**, which is the
+ * common case: the preview re-runs on every keystroke and almost always names
+ * the same parts it named last time. A fresh array would be a new state value
+ * on every response, re-rendering the whole component table (and the row inputs
+ * somebody is typing into) for no change at all.
  */
 export function rememberComponents(
   known: readonly KnownComponent[],
   lines: readonly BuildComponentLine[]
-): KnownComponent[] {
+): readonly KnownComponent[] {
   const merged = new Map(known.map((entry) => [entry.partId, entry]))
+  let changed = false
   for (const line of lines) {
+    const existing = merged.get(line.partId)
+    if (
+      existing &&
+      existing.partName === line.partName &&
+      existing.qtyPerUnit === line.qtyPerUnit &&
+      existing.offBom === line.offBom
+    ) {
+      continue
+    }
+    changed = true
     merged.set(line.partId, {
       partId: line.partId,
       partName: line.partName,
@@ -81,6 +98,7 @@ export function rememberComponents(
       offBom: line.offBom,
     })
   }
+  if (!changed) return known
   return [...merged.values()]
 }
 

--- a/apps/web/src/components/manufacturing/parts/opening-stock-input.ts
+++ b/apps/web/src/components/manufacturing/parts/opening-stock-input.ts
@@ -1,0 +1,101 @@
+// apps/web/src/components/manufacturing/parts/opening-stock-input.ts
+
+// The opening-stock section's pure half: what the create form sends, and the
+// inventory account it says it will land in.
+//
+// Split out of `part-form-dialog.tsx` for the same reason `receipt-input.ts` is
+// split out of the receive popover — the sentence under the inputs and the
+// payload the mutation sends have to be derived from ONE description of the
+// form's state. Here that matters more than usual: the sentence names a GL
+// account, and `openStockBalance` writes an `updatable: false` movement stamped
+// with that account. A line that said one thing while the write did another
+// would be uncorrectable.
+//
+// plans/money/tasks/15-costing-usability.md §2.2.
+
+import { DEFAULT_CHART_OF_ACCOUNTS } from '@auxx/lib/postings/client'
+import { resolveInventoryRoleForPartKind } from '@auxx/lib/receiving/client'
+
+/** Everything the opening-stock section holds. */
+export interface OpeningStockFormValues {
+  /** Units on hand at the opening date. */
+  quantity: number | null
+  /** What a unit cost, in whole minor units — the CURRENCY input's own shape. */
+  unitCost: number | null
+  /** ISO string from the date input. The ACCOUNTING date, not `createdAt`. */
+  occurredAt: string
+}
+
+/** A blank section: no quantity, no cost, dated today. */
+export function defaultOpeningStockValues(): OpeningStockFormValues {
+  return { quantity: null, unitCost: null, occurredAt: new Date().toISOString() }
+}
+
+/** Nothing was typed, so there is no opening balance to record. */
+export function isOpeningStockEmpty(values: OpeningStockFormValues): boolean {
+  return values.quantity == null && values.unitCost == null
+}
+
+/**
+ * The `purchasing.openStockBalance` payload, or `null` when the section is not
+ * answered completely enough to send.
+ *
+ * 🛑 Both halves are required together. `openStockBalance` refuses a
+ * non-positive quantity or unit cost outright, because an opening balance IS a
+ * valuation — it becomes the part's first `part_standard_cost` — and a quantity
+ * with no cost would be a hand-valued adjustment wearing an opening balance's
+ * name, which is exactly what `G12` refuses for `adjustStock`.
+ *
+ * The unit cost is rounded here rather than trusted: `CURRENCY` is minor units
+ * in a `doublePrecision` column, and the procedure's schema takes an integer.
+ */
+export function buildOpeningStockInput(
+  partId: string,
+  values: OpeningStockFormValues
+): { partId: string; quantity: number; unitCost: number; occurredAt: Date } | null {
+  const quantity = values.quantity
+  const unitCost = values.unitCost
+  if (quantity == null || !Number.isFinite(quantity) || quantity <= 0) return null
+  if (unitCost == null || !Number.isFinite(unitCost) || unitCost <= 0) return null
+  return {
+    partId,
+    quantity,
+    unitCost: Math.round(unitCost),
+    occurredAt: new Date(values.occurredAt),
+  }
+}
+
+/** The validation errors the section contributes, keyed by field. */
+export function validateOpeningStock(values: OpeningStockFormValues): Record<string, string> {
+  const errors: Record<string, string> = {}
+  if (values.quantity == null || values.quantity <= 0) {
+    errors.quantity = 'Quantity must be greater than zero'
+  }
+  if (values.unitCost == null || values.unitCost <= 0) {
+    errors.unitCost = 'Unit cost must be greater than zero'
+  }
+  return errors
+}
+
+/**
+ * The inventory account an opening balance for this part kind will be stamped
+ * with — `1310 Raw Materials / Parts`.
+ *
+ * 🛑 **Resolved through `resolveInventoryRoleForPartKind`, never a second
+ * mapping.** That function is what the write path uses, so the only way this
+ * line can be wrong about the account is if the write is wrong about it too.
+ * A kind-to-account table maintained here would drift silently, and the
+ * movement it disagreed with is append-only.
+ *
+ * The code and name come from `DEFAULT_CHART_OF_ACCOUNTS`, which is the chart
+ * every org is seeded with. An org that has RENUMBERED its raw materials
+ * account will see the seeded number here rather than its own — the role is
+ * still right, and reading the org's chart would need `ledgerView`, which
+ * somebody creating a part is not required to hold.
+ */
+export function openingStockAccountLabel(partKind: string | null | undefined): string {
+  const role = resolveInventoryRoleForPartKind(partKind)
+  const account = DEFAULT_CHART_OF_ACCOUNTS.find((entry) => entry.role === role)
+  if (!account) return role
+  return `${account.code} ${account.name}`
+}

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -16,6 +16,7 @@ import {
 } from '@auxx/ui/components/dialog'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
@@ -25,7 +26,16 @@ import { useSystemField } from '~/components/resources/hooks/use-field'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { BaseType } from '~/components/workflow/types'
+import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
+import {
+  buildOpeningStockInput,
+  defaultOpeningStockValues,
+  isOpeningStockEmpty,
+  type OpeningStockFormValues,
+  openingStockAccountLabel,
+  validateOpeningStock,
+} from './opening-stock-input'
 import {
   defaultVendorPartValues,
   VendorPartFields,
@@ -95,6 +105,14 @@ export function PartFormDialog({
   // products taxonomy's option ids into part records.
   const categoryField = useSystemField('category', partDefId)
 
+  // The Kind select's preselection comes from the FIELD, not from a literal in
+  // this file, so an org that changes the default gets it everywhere and there
+  // is one source of truth for the fact (task 15 §4c).
+  const partKindField = useSystemField('part_kind', partDefId)
+
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+
   // Load initial values for edit mode
   const { values: systemValues } = useSystemValues(recordId, PART_SYSTEM_ATTRIBUTES, {
     autoFetch: true,
@@ -109,10 +127,13 @@ export function PartFormDialog({
     hsCode: '',
     category: [] as string[],
     productId: '',
-    // Deliberately never defaulted, not even when created from a product —
-    // Gap C §3.2 requires `part_kind` human-confirmed and auditable, and the
-    // part drawer's Family card is the confirmation surface. A silent default
-    // would defeat the `isPartKindUnset` gate that suggestion is built on.
+    // Seeded from `part_kind`'s own `defaultValue` in the reset effect below.
+    //
+    // 🛑 Preselecting is NOT the silent default Gap C §3.2 rules out. That rule
+    // asks for `part_kind` to be human-confirmed and auditable, and a value
+    // shown in the form, before save, changeable in one click, IS confirmed —
+    // the person saw it and pressed the button. A server-side fill on a key the
+    // form never sent is what it refuses, because nobody was ever shown it.
     kind: '',
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
@@ -120,6 +141,10 @@ export function PartFormDialog({
   const [vendorPartValues, setVendorPartValues] =
     useState<VendorPartFormValues>(defaultVendorPartValues)
   const [vendorPartErrors, setVendorPartErrors] = useState<Record<string, string>>({})
+  const [showOpeningStock, setShowOpeningStock] = useState(false)
+  const [openingStockValues, setOpeningStockValues] =
+    useState<OpeningStockFormValues>(defaultOpeningStockValues)
+  const [openingStockErrors, setOpeningStockErrors] = useState<Record<string, string>>({})
 
   // Initialize/reset values when dialog opens
   useEffect(() => {
@@ -151,8 +176,28 @@ export function PartFormDialog({
       setShowSupplier(false)
       setVendorPartValues(defaultVendorPartValues)
       setVendorPartErrors({})
+      setShowOpeningStock(false)
+      setOpeningStockValues(defaultOpeningStockValues())
+      setOpeningStockErrors({})
     }
   }, [open, isEditMode, systemValues, lockedProductId])
+
+  // Preselect Kind from the field's own `defaultValue` (task 15 §4c).
+  //
+  // Kept out of the reset effect above on purpose: the field store hydrates
+  // independently of this dialog, so the default can land AFTER somebody has
+  // started typing, and re-running the reset then would wipe the form. This one
+  // only ever fills a Kind that is still blank.
+  //
+  // The `?? ''` case is the field carrying no default, which is the state before
+  // the registry sets one — the select simply shows its placeholder, as it did
+  // before.
+  useEffect(() => {
+    if (!open || isEditMode) return
+    const preselect = partKindField?.defaultValue
+    if (typeof preselect !== 'string' || !preselect) return
+    setValues((prev) => (prev.kind ? prev : { ...prev, kind: preselect }))
+  }, [open, isEditMode, partKindField?.defaultValue])
 
   // Field change handler
   const handleChange = useCallback((field: string, value: any) => {
@@ -182,7 +227,20 @@ export function PartFormDialog({
     }
     setVendorPartErrors(vpErrors)
 
-    return Object.keys(newErrors).length === 0 && Object.keys(vpErrors).length === 0
+    // The opening-stock section is optional as a whole and complete once opened
+    // and answered: a quantity with no cost is not an opening balance, it is a
+    // hand-valued adjustment, which §2.2 refuses outright.
+    const osErrors =
+      showOpeningStock && !isOpeningStockEmpty(openingStockValues)
+        ? validateOpeningStock(openingStockValues)
+        : {}
+    setOpeningStockErrors(osErrors)
+
+    return (
+      Object.keys(newErrors).length === 0 &&
+      Object.keys(vpErrors).length === 0 &&
+      Object.keys(osErrors).length === 0
+    )
   }
 
   // Create mutation via entity system
@@ -192,10 +250,24 @@ export function PartFormDialog({
     },
   })
 
+  /**
+   * The part's opening balance: one `initial` movement, its first standard cost.
+   *
+   * A separate procedure and a separate call on purpose — it is chained AFTER
+   * the part exists (see `handleSubmit`), because a failure here leaves a part
+   * somebody can open the drawer on and set stock for, while the reverse order
+   * would leave a movement pointing at nothing.
+   */
+  const openStockBalance = api.purchasing.openStockBalance.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Part created, opening stock failed', description: error.message })
+    },
+  })
+
   // Save field values for edit mode
   const { saveMultipleAsync, isPending: isSavingFields } = useSaveFieldValue({})
 
-  const isPending = createRecord.isPending || isSavingFields
+  const isPending = createRecord.isPending || isSavingFields || openStockBalance.isPending
 
   // Submit
   const handleSubmit = async () => {
@@ -255,6 +327,21 @@ export function PartFormDialog({
           })
         }
 
+        // Opening stock LAST, and never inside the try that would abandon the
+        // rest: the part is already saved by now, so a refused opening balance
+        // is a toast and a drawer to finish the job in, not a lost form.
+        const openingStock =
+          showOpeningStock && !isOpeningStockEmpty(openingStockValues)
+            ? buildOpeningStockInput(result.instance.id, openingStockValues)
+            : null
+        if (openingStock) {
+          try {
+            await openStockBalance.mutateAsync(openingStock)
+          } catch {
+            // Surfaced by the mutation's onError. The part still stands.
+          }
+        }
+
         onSuccess?.(result.instance.id)
         onOpenChange(false)
       }
@@ -275,6 +362,22 @@ export function PartFormDialog({
       return prev
     })
   }, [])
+
+  // Handler for opening-stock field changes
+  const handleOpeningStockChange = useCallback(
+    (field: keyof OpeningStockFormValues, value: any) => {
+      setOpeningStockValues((prev) => ({ ...prev, [field]: value }))
+      setOpeningStockErrors((prev) => {
+        if (prev[field]) {
+          const next = { ...prev }
+          delete next[field]
+          return next
+        }
+        return prev
+      })
+    },
+    []
+  )
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -372,7 +475,8 @@ export function PartFormDialog({
             </FieldPanelRow>
           )}
 
-          {/* Kind — the GL classification. No default, ever (see state above). */}
+          {/* Kind — the GL classification. Preselected from the field's own
+              `defaultValue`, visibly and changeably (see the effect above). */}
           {!isEditMode && (
             <FieldPanelRow
               title='Kind'
@@ -452,6 +556,98 @@ export function PartFormDialog({
           </div>
         )}
 
+        {/* Opening stock — the same collapsible-optional pattern as Supplier,
+            chained into a second mutation after the part is created.
+
+            Never gated on Kind (task 15 §2.2, "DECIDED: no gate"). A disabled
+            section teaches nobody anything; naming the account the movement will
+            be stamped with does, and somebody creating a lift who reads "Raw
+            Materials" under it notices. */}
+        {!isEditMode && (
+          <div className='border-t pt-4 mt-4'>
+            <button
+              type='button'
+              onClick={() => setShowOpeningStock(!showOpeningStock)}
+              className='flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors'>
+              {showOpeningStock ? (
+                <ChevronDown className='h-4 w-4' />
+              ) : (
+                <ChevronRight className='h-4 w-4' />
+              )}
+              Add Opening Stock (Optional)
+            </button>
+
+            {showOpeningStock && (
+              <>
+                <FieldPanel
+                  className='p-0 mt-4'
+                  orientation='responsive'
+                  breakpoint='md'
+                  resizeId='part-form'
+                  defaultLabelWidth={200}>
+                  <FieldPanelRow
+                    title='Quantity'
+                    description='Units on hand at the opening date'
+                    type={BaseType.NUMBER}
+                    showIcon
+                    validationError={openingStockErrors.quantity}
+                    validationType='error'>
+                    <FieldInputAdapter
+                      fieldType={FieldType.NUMBER}
+                      value={openingStockValues.quantity}
+                      onChange={(val) => handleOpeningStockChange('quantity', val ?? null)}
+                      placeholder='0'
+                      disabled={isPending}
+                    />
+                  </FieldPanelRow>
+
+                  <FieldPanelRow
+                    title='Unit Cost'
+                    description='What a unit cost when it was bought'
+                    type={BaseType.CURRENCY}
+                    showIcon
+                    validationError={openingStockErrors.unitCost}
+                    validationType='error'>
+                    <FieldInputAdapter
+                      fieldType={FieldType.CURRENCY}
+                      fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+                      value={openingStockValues.unitCost}
+                      onChange={(val) => handleOpeningStockChange('unitCost', val ?? null)}
+                      placeholder='0.00'
+                      disabled={isPending}
+                    />
+                  </FieldPanelRow>
+
+                  <FieldPanelRow
+                    title='As of'
+                    description='The accounting date, which is not when it was keyed'
+                    type={BaseType.DATE}
+                    showIcon>
+                    <FieldInputAdapter
+                      fieldType={FieldType.DATETIME}
+                      value={openingStockValues.occurredAt}
+                      onChange={(val) =>
+                        handleOpeningStockChange(
+                          'occurredAt',
+                          (val as string) ?? new Date().toISOString()
+                        )
+                      }
+                      disabled={isPending}
+                    />
+                  </FieldPanelRow>
+                </FieldPanel>
+
+                <OpeningStockConsequence
+                  quantity={openingStockValues.quantity}
+                  unitCost={openingStockValues.unitCost}
+                  kind={values.kind}
+                  currencyCode={currencyCode}
+                />
+              </>
+            )}
+          </div>
+        )}
+
         <DialogFooter>
           <Button
             type='button'
@@ -475,4 +671,48 @@ export function PartFormDialog({
       </DialogContent>
     </Dialog>
   )
+}
+
+/**
+ * What the opening balance will actually do, in one sentence, live.
+ *
+ * 🛑 The account name is recomputed from the Kind select on every change, and it
+ * is resolved through the SAME `resolveInventoryRoleForPartKind` the write uses
+ * (via `openingStockAccountLabel`). This is the house pattern the complete-build
+ * dialog uses for scrap: state the consequence at the input rather than block
+ * the input. It matters more here because `stock_movement_gl_account` is frozen
+ * at write time on an `updatable: false` row, so a finished good stamped raw
+ * materials stays that way — the sentence is the only chance to catch it.
+ */
+function OpeningStockConsequence({
+  quantity,
+  unitCost,
+  kind,
+  currencyCode,
+}: {
+  quantity: number | null
+  unitCost: number | null
+  kind: string
+  currencyCode: string
+}) {
+  const account = openingStockAccountLabel(kind || null)
+  const units = quantity != null && quantity > 0 ? formatQuantity(quantity) : 'N'
+  const each = unitCost != null && unitCost > 0 ? formatCurrency(unitCost, { currencyCode }) : '$X'
+
+  return (
+    <div className='mt-3 space-y-1 text-muted-foreground text-xs'>
+      <p>
+        Records {units} units at {each} into <span className='font-medium'>{account}</span>.
+      </p>
+      <p>
+        This is the part&apos;s opening balance and its first standard cost, and it can only be set
+        once.
+      </p>
+    </div>
+  )
+}
+
+/** Trim a quantity's trailing zeros — `10` not `10.00`, `2.5` kept. */
+function formatQuantity(value: number): string {
+  return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)))
 }

--- a/apps/web/src/components/manufacturing/parts/roll-standard-cost-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/roll-standard-cost-popover.tsx
@@ -23,6 +23,7 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { formatCurrency } from '@auxx/utils/currency'
+import { keepPreviousData } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
@@ -56,9 +57,19 @@ export function RollStandardCostPopover({
     if (open) setEffectiveAt(new Date().toISOString())
   }, [open])
 
+  // `keepPreviousData` because the effective date is part of the query key:
+  // without it every change to it blanks the whole preview (15 §4a). The lines,
+  // the revaluation summary and the skipped list all unmount and the confirm
+  // button disables, mid-keystroke, on a surface whose entire job is showing
+  // numbers before a write.
   const preview = api.builds.previewRoll.useQuery(
     { partIds: [partId], effectiveAt: new Date(effectiveAt) },
-    { enabled: open, retry: false, refetchOnWindowFocus: false }
+    {
+      enabled: open,
+      retry: false,
+      refetchOnWindowFocus: false,
+      placeholderData: keepPreviousData,
+    }
   )
 
   const utils = api.useUtils()
@@ -88,9 +99,12 @@ export function RollStandardCostPopover({
         <div className='space-y-3'>
           <div>
             <h4 className='font-semibold text-sm'>Roll standard cost</h4>
+            {/* The mechanism AND the consequence: the second sentence is why
+                anyone would press this, and it is what "Not rolled" costs. */}
             <p className='mt-0.5 text-muted-foreground text-xs'>
               Freezes today&apos;s cost as the value every stock movement will be stamped with. This
-              part and everything built from it.
+              part and everything built from it. Without a standard this part cannot be built,
+              adjusted, received, or counted into a month-end close.
             </p>
           </div>
 
@@ -124,8 +138,15 @@ export function RollStandardCostPopover({
           ) : plan ? (
             <div className='space-y-2'>
               {changed.length === 0 ? (
+                // Two different empty states, and calling the second one the
+                // first is a lie: "already matches" claims a standard exists and
+                // is current, when in fact nothing could be valued at all. Only
+                // say it when there genuinely were valuable lines and none moved.
+                // The "cannot be valued" case has its reasons listed right below.
                 <p className='text-muted-foreground text-xs'>
-                  Nothing to roll — the standard already matches today&apos;s cost.
+                  {plan.lines.length === 0 && plan.skipped.length > 0
+                    ? 'Nothing to roll: no part here can be valued yet. See why below.'
+                    : 'Nothing to roll: the standard already matches today’s cost.'}
                 </p>
               ) : (
                 <ScrollArea className='max-h-48' allowScrollChaining>

--- a/apps/web/src/server/api/routers/purchasing.ts
+++ b/apps/web/src/server/api/routers/purchasing.ts
@@ -14,6 +14,7 @@ import {
   getLastReceiptCost,
   getPartReceiptHistory,
   listReceipts,
+  openStockBalance,
   receivePurchaseOrder,
   receiveStock,
   reverseMovement,
@@ -277,6 +278,48 @@ export const purchasingRouter = createTRPCRouter({
       ctx.capabilities.assertEditEntity(movementDefId)
 
       const result = await adjustStock(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * A part's opening balance: quantity and cost, once.
+   *
+   * plans/money/tasks/15-costing-usability.md §2.2. Writes one `initial`
+   * movement and sets the part's FIRST `part_standard_cost` from the typed
+   * `unitCost`, so the two agree by construction and the opening balance
+   * carries no variance.
+   *
+   * 🛑 A typed unit cost here does NOT reopen `G12`. That decision removed
+   * `adjustStock`'s cost input because an adjustment has no supplier row, no
+   * purchase order and no packing slip, so there is no *actual* to record. An
+   * opening balance is the one case where there is one, which is why `initial`
+   * is its own movement type. `adjustStock` still takes no cost.
+   *
+   * Gated on edit for `stock_movement` — the same door `receiveStock`,
+   * `adjustStock` and `reverseMovement` go through, because this writes the
+   * ledger. It also writes `part_standard_cost`, but a person who may move
+   * stock may set the opening cost of stock they are moving.
+   */
+  openStockBalance: capabilityProcedure
+    .input(
+      z.object({
+        partId: z.string().min(1),
+        /** Units on hand at the opening date. Strictly positive. */
+        quantity: z.number().finite().positive(),
+        /** What a unit cost, whole minor units. Strictly positive. */
+        unitCost: z.number().int().positive(),
+        /** The ACCOUNTING date, which is not `createdAt`. Defaults to now. */
+        occurredAt: z.coerce.date().optional(),
+        notes: z.string().max(2000).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const movementDefId = await requireDefId(organizationId, 'stock_movement')
+      ctx.capabilities.assertEditEntity(movementDefId)
+
+      const result = await openStockBalance(ctx.db, organizationId, userId, input)
       if (result.isErr()) throw result.error
       return result.value
     }),

--- a/packages/lib/src/builds/__tests__/ensure-standard-cost.test.ts
+++ b/packages/lib/src/builds/__tests__/ensure-standard-cost.test.ts
@@ -1,0 +1,424 @@
+// packages/lib/src/builds/__tests__/ensure-standard-cost.test.ts
+//
+// plans/money/tasks/15-costing-usability.md section 1. One rule carries the
+// whole safety argument:
+//
+//   🛑 it writes ONLY parts where `part_standard_cost IS NULL`, and never
+//      overwrites.
+//
+// Overwriting would turn a vendor-price change into an automatic revaluation of
+// on-hand inventory. The first two tests here are that rule, from both sides.
+//
+// Harness style follows `standard-cost.test.ts` next door: mock `@auxx/database`
+// so the schema is inert, hand the functions a fake `db` that replays queued
+// rows, and assert on the field-value writer's calls.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  queryQueue: [] as unknown[][],
+  setValueWithType: vi.fn(async (_ctx: unknown, _params: unknown) => [] as unknown[]),
+  publishFieldValueUpdates: vi.fn(async () => {}),
+  subparts: [] as { parentPartId: string; childPartId: string; quantity: number }[],
+  settings: {} as Record<string, unknown>,
+}))
+
+function nextRows(): unknown[] {
+  return h.queryQueue.shift() ?? []
+}
+
+const db = {
+  select: () => ({
+    from: () => ({
+      where: () => Promise.resolve(nextRows()),
+    }),
+  }),
+} as never
+
+vi.mock('@auxx/database', () => ({
+  schema: {
+    EntityInstance: {
+      id: 'id',
+      displayName: 'displayName',
+      organizationId: 'organizationId',
+      entityDefinitionId: 'entityDefinitionId',
+      archivedAt: 'archivedAt',
+    },
+    FieldValue: {
+      entityId: 'entityId',
+      fieldId: 'fieldId',
+      organizationId: 'organizationId',
+      valueNumber: 'valueNumber',
+      valueDate: 'valueDate',
+      optionId: 'optionId',
+    },
+  },
+}))
+
+const FIELD: Record<string, { id: string; type: string }> = {
+  part_kind: { id: 'f_kind', type: 'SINGLE_SELECT' },
+  part_cost: { id: 'f_cost', type: 'CURRENCY' },
+  part_quantity_on_hand: { id: 'f_qoh', type: 'NUMBER' },
+  part_standard_material_cost: { id: 'f_std_mat', type: 'CURRENCY' },
+  part_standard_labor_cost: { id: 'f_std_lab', type: 'CURRENCY' },
+  part_standard_overhead_cost: { id: 'f_std_ovh', type: 'CURRENCY' },
+  part_standard_cost: { id: 'f_std', type: 'CURRENCY' },
+  part_standard_cost_effective_at: { id: 'f_std_at', type: 'DATETIME' },
+}
+
+const SYSTEM_USER = 'user_system'
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(attrs.map((a) => [a, FIELD[a] ?? null])),
+    }),
+    get: async (_orgId: string, key: string) => (key === 'systemUser' ? SYSTEM_USER : null),
+  }),
+  requireCachedEntityDefId: async () => 'part_def',
+}))
+
+vi.mock('../../bom/cost-calculator', () => ({
+  recalculateAllPartCosts: async () => [],
+  loadOrgPricingData: async () => ({ vendorPrices: [], subparts: h.subparts }),
+  buildSubpartGraph: (rows: typeof h.subparts) => {
+    const map = new Map<string, { childId: string; qty: number }[]>()
+    for (const row of rows) {
+      const children = map.get(row.parentPartId) ?? []
+      children.push({ childId: row.childPartId, qty: row.quantity })
+      map.set(row.parentPartId, children)
+    }
+    return map
+  },
+  buildParentGraph: (rows: typeof h.subparts) => {
+    const map = new Map<string, string[]>()
+    for (const row of rows) {
+      const parents = map.get(row.childPartId) ?? []
+      parents.push(row.parentPartId)
+      map.set(row.childPartId, parents)
+    }
+    return map
+  },
+}))
+
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: async ({ key }: { key: string }) => h.settings[key] ?? null,
+}))
+
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: (organizationId: string, userId?: string) => ({
+    organizationId,
+    userId,
+  }),
+}))
+
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+
+vi.mock('../../field-values/stored-field-type', () => ({
+  toFieldType: (stored: string) => stored,
+}))
+
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishFieldValueUpdates: h.publishFieldValueUpdates,
+}))
+
+import { ensureStandardCost } from '../ensure-standard-cost'
+
+const ORG = 'org_1'
+const MOTOR = 'part_motor'
+const TUBE = 'part_tube'
+const ASSEMBLY = 'part_assembly'
+
+/** A `FieldValue` row as the loader reads it. */
+function fv(
+  entityId: string,
+  fieldId: string,
+  value: { number?: number; date?: string; option?: string }
+) {
+  return {
+    entityId,
+    fieldId,
+    valueNumber: value.number ?? null,
+    valueDate: value.date ?? null,
+    optionId: value.option ?? null,
+  }
+}
+
+/**
+ * Queue one org read pass: every part instance, then every stored field value.
+ *
+ * `ensureStandardCost` makes one pass through `planStandardCostRoll`, and a
+ * second one through `loadStandardCostWriteContext` only when the plan aborts.
+ */
+function queueOrg(
+  parts: { id: string; displayName: string | null }[],
+  fieldValues: ReturnType<typeof fv>[],
+  passes = 1
+) {
+  h.queryQueue = []
+  for (let i = 0; i < passes; i++) h.queryQueue.push(parts, fieldValues)
+}
+
+/** Every `setValueWithType` call for one part, flattened to `[fieldId, value]`. */
+function writesFor(partId: string) {
+  return h.setValueWithType.mock.calls
+    .map(([, params]) => params as { recordId: string; fieldId: string; value: unknown })
+    .filter((params) => params.recordId.includes(partId))
+    .map((params) => [params.fieldId, params.value] as const)
+}
+
+const PARTS = [
+  { id: MOTOR, displayName: '400Lbs Motor' },
+  { id: ASSEMBLY, displayName: '400Lbs motor Assembly' },
+  { id: TUBE, displayName: 'Support Tube' },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.setValueWithType.mockImplementation(async () => [])
+  h.queryQueue = []
+  h.subparts = []
+  h.settings = {}
+})
+
+describe('ensureStandardCost: the one rule', () => {
+  it('never overwrites a part that already has a standard cost', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        // The live cost moved to $22.00...
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+        // ...and the agreed standard is still $20.10, with stock valued at it.
+        fv(MOTOR, FIELD.part_standard_cost!.id, { number: 2010 }),
+        fv(MOTOR, FIELD.part_standard_material_cost!.id, { number: 2010 }),
+        fv(MOTOR, FIELD.part_quantity_on_hand!.id, { number: 10 }),
+      ]
+    )
+
+    const result = await ensureStandardCost(db, ORG, [MOTOR], { kind: 'supplier-price' })
+
+    expect(result.isOk()).toBe(true)
+    // Writing here would revalue 10 units of on-hand stock because a vendor
+    // changed a price. That is the manual roll's decision, never this one's.
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
+  })
+
+  it('never overwrites even when the caller supplies an explicit unit cost', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_standard_cost!.id, { number: 2010 }),
+        fv(MOTOR, FIELD.part_standard_material_cost!.id, { number: 2010 }),
+      ]
+    )
+
+    // A receipt landing at $12.00 against a standard of $20.10 is a purchase
+    // price variance, not a new standard.
+    const result = await ensureStandardCost(db, ORG, [MOTOR], { kind: 'receipt', unitCost: 1200 })
+
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+})
+
+describe('ensureStandardCost: writing a first standard', () => {
+  it("writes all five fields from the part's live cost", async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+      ]
+    )
+
+    const result = await ensureStandardCost(db, ORG, [MOTOR], { kind: 'supplier-price' })
+
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([MOTOR])
+    const writes = new Map(writesFor(MOTOR))
+    expect(writes.get(FIELD.part_standard_material_cost!.id)).toEqual({
+      type: 'number',
+      value: 2200,
+    })
+    // A component was not assembled, so its conversion cost is zero as a fact.
+    expect(writes.get(FIELD.part_standard_labor_cost!.id)).toEqual({ type: 'number', value: 0 })
+    expect(writes.get(FIELD.part_standard_overhead_cost!.id)).toEqual({ type: 'number', value: 0 })
+    expect(writes.get(FIELD.part_standard_cost!.id)).toEqual({ type: 'number', value: 2200 })
+    expect(writes.get(FIELD.part_standard_cost_effective_at!.id)).toMatchObject({ type: 'date' })
+    expect(h.publishFieldValueUpdates).toHaveBeenCalled()
+  })
+
+  it('freezes exactly the explicit unit cost, ignoring the live cost', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        // A live replacement cost of $50.00 that has nothing to do with what
+        // was actually paid for the stock being opened.
+        fv(MOTOR, FIELD.part_cost!.id, { number: 5000 }),
+      ]
+    )
+
+    const result = await ensureStandardCost(db, ORG, [MOTOR], {
+      kind: 'opening-stock',
+      unitCost: 1200,
+    })
+
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([MOTOR])
+    const writes = new Map(writesFor(MOTOR))
+    // The typed number, to the cent. It is being stocked, not built, so there
+    // is no conversion cost to absorb.
+    expect(writes.get(FIELD.part_standard_cost!.id)).toEqual({ type: 'number', value: 1200 })
+    expect(writes.get(FIELD.part_standard_material_cost!.id)).toEqual({
+      type: 'number',
+      value: 1200,
+    })
+    expect(writes.get(FIELD.part_standard_labor_cost!.id)).toEqual({ type: 'number', value: 0 })
+    expect(writes.get(FIELD.part_standard_overhead_cost!.id)).toEqual({ type: 'number', value: 0 })
+  })
+
+  it('widens to an unvalued parent, so pricing a component makes it rollable', async () => {
+    h.subparts = [{ parentPartId: ASSEMBLY, childPartId: MOTOR, quantity: 2 }]
+    queueOrg(
+      [PARTS[0]!, PARTS[1]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+        fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      ]
+    )
+
+    const result = await ensureStandardCost(db, ORG, [MOTOR], { kind: 'supplier-price' })
+
+    // Without the widening the assembly stays "Not rolled" one level up, which
+    // is the state 205 of 206 dev-org parts were in.
+    expect(result._unsafeUnwrap().writtenPartIds.sort()).toEqual([ASSEMBLY, MOTOR].sort())
+    expect(new Map(writesFor(ASSEMBLY)).get(FIELD.part_standard_cost!.id)).toEqual({
+      type: 'number',
+      value: 4400,
+    })
+  })
+
+  it('authors the write as the org system user', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(MOTOR, FIELD.part_cost!.id, { number: 2200 }),
+      ]
+    )
+
+    await ensureStandardCost(db, ORG, [MOTOR], { kind: 'supplier-price' })
+
+    // Nobody pressed a button. Attributing this to whoever edited a price would
+    // put a person's name on a decision the system made.
+    const ctx = h.setValueWithType.mock.calls[0]?.[0] as { userId?: string }
+    expect(ctx.userId).toBe(SYSTEM_USER)
+  })
+})
+
+describe('ensureStandardCost: the doors it is called from', () => {
+  it('skips a part that cannot be valued at all, rather than failing', async () => {
+    queueOrg(
+      [PARTS[0]!],
+      // No `part_cost` and no bill of materials: nothing to freeze.
+      [fv(MOTOR, FIELD.part_kind!.id, { option: 'component' })]
+    )
+
+    const result = await ensureStandardCost(db, ORG, [MOTOR], { kind: 'supplier-price' })
+
+    // A post-commit hook that throws on a vendor-price save is worse than one
+    // that writes nothing.
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([])
+  })
+
+  it('ignores a part id that does not exist', async () => {
+    queueOrg([], [])
+
+    const result = await ensureStandardCost(db, ORG, ['part_ghost'], {
+      kind: 'opening-stock',
+      unitCost: 1200,
+    })
+
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('writes the explicit cost even when planning the roll around it aborts', async () => {
+    // The motor's parent also contains an unpriced tube, so the roll cannot
+    // value the assembly and throws before returning a plan.
+    h.subparts = [
+      { parentPartId: ASSEMBLY, childPartId: MOTOR, quantity: 1 },
+      { parentPartId: ASSEMBLY, childPartId: TUBE, quantity: 4 },
+    ]
+    queueOrg(
+      PARTS,
+      [
+        fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+        fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+        fv(TUBE, FIELD.part_kind!.id, { option: 'component' }),
+      ],
+      // One pass for the plan, one for the fallback context after it aborts.
+      2
+    )
+
+    const result = await ensureStandardCost(db, ORG, [MOTOR], {
+      kind: 'opening-stock',
+      unitCost: 1200,
+    })
+
+    // Refusing to freeze a number somebody typed because an unrelated sibling
+    // has no price would make the create form unusable.
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([MOTOR])
+    expect(new Map(writesFor(MOTOR)).get(FIELD.part_standard_cost!.id)).toEqual({
+      type: 'number',
+      value: 1200,
+    })
+    expect(writesFor(ASSEMBLY)).toEqual([])
+  })
+
+  it('surfaces the failure when the roll aborts and there is no explicit cost', async () => {
+    h.subparts = [
+      { parentPartId: ASSEMBLY, childPartId: MOTOR, quantity: 1 },
+      { parentPartId: ASSEMBLY, childPartId: TUBE, quantity: 4 },
+    ]
+    queueOrg(PARTS, [
+      fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+      fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      fv(TUBE, FIELD.part_kind!.id, { option: 'component' }),
+    ])
+
+    const result = await ensureStandardCost(db, ORG, [MOTOR], { kind: 'manual' })
+
+    expect(result.isErr()).toBe(true)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('refuses a zero or negative explicit unit cost', async () => {
+    queueOrg([PARTS[0]!], [])
+
+    const result = await ensureStandardCost(db, ORG, [MOTOR], { kind: 'receipt', unitCost: 0 })
+
+    // Every consumer reads a zero standard as "not rolled", so storing one would
+    // give the part a standard that nothing recognises.
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toMatch(/positive/i)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('does nothing at all for an empty part list', async () => {
+    const result = await ensureStandardCost(db, ORG, [], { kind: 'manual' })
+
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
+++ b/packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
@@ -12,6 +12,7 @@ import {
   type StandardCostRollInputs,
   type SubpartEdge,
   widenToAncestors,
+  widenToUnvaluedDescendants,
 } from '../standard-cost-roll'
 import type { AbsorptionRates } from '../types'
 
@@ -388,5 +389,59 @@ describe('widenToAncestors', () => {
       [LIFT, [ASSEMBLY]],
     ])
     expect([...widenToAncestors([ASSEMBLY], cyclic)].sort()).toEqual([ASSEMBLY, LIFT].sort())
+  })
+})
+
+describe('widenToUnvaluedDescendants', () => {
+  // subpart graph: parent -> children. lift -> assembly -> [motor, tube]
+  const subpartGraph = new Map<string, SubpartEdge[]>([
+    [LIFT, [{ childId: ASSEMBLY, qty: 2 }]],
+    [
+      ASSEMBLY,
+      [
+        { childId: MOTOR, qty: 1 },
+        { childId: TUBE, qty: 4 },
+      ],
+    ],
+  ])
+
+  it('pulls in a descendant that has no stored standard', () => {
+    // The task 15 section 3 bug: without this the child is never in scope, so
+    // `contributionOf` reads its null stored standard and the walk aborts.
+    expect([...widenToUnvaluedDescendants([LIFT], subpartGraph, new Map())].sort()).toEqual(
+      [ASSEMBLY, MOTOR, TUBE].sort()
+    )
+  })
+
+  it('leaves a descendant that already has a standard alone', () => {
+    // It has an agreed value to re-value, which is exactly what a scoped roll
+    // must not do behind the caller's back.
+    const stored = new Map([[ASSEMBLY, 5000]])
+    expect([...widenToUnvaluedDescendants([LIFT], subpartGraph, stored)].sort()).toEqual(
+      [MOTOR, TUBE].sort()
+    )
+  })
+
+  it('walks THROUGH a valued descendant to reach an unvalued one beneath it', () => {
+    const stored = new Map([
+      [ASSEMBLY, 5000],
+      [TUBE, 400],
+    ])
+    expect([...widenToUnvaluedDescendants([LIFT], subpartGraph, stored)]).toEqual([MOTOR])
+  })
+
+  it('never includes the named parts themselves', () => {
+    // They arrive through the ancestor widening, which owns the upward half.
+    expect([...widenToUnvaluedDescendants([MOTOR], subpartGraph, new Map())]).toEqual([])
+  })
+
+  it('terminates on a cycle in the bill of materials', () => {
+    const cyclic = new Map<string, SubpartEdge[]>([
+      [ASSEMBLY, [{ childId: LIFT, qty: 1 }]],
+      [LIFT, [{ childId: ASSEMBLY, qty: 1 }]],
+    ])
+    expect([...widenToUnvaluedDescendants([LIFT], cyclic, new Map())].sort()).toEqual(
+      [ASSEMBLY, LIFT].sort()
+    )
   })
 })

--- a/packages/lib/src/builds/__tests__/standard-cost.test.ts
+++ b/packages/lib/src/builds/__tests__/standard-cost.test.ts
@@ -498,3 +498,89 @@ describe('readStandardCost', () => {
     expect(result._unsafeUnwrap().size).toBe(0)
   })
 })
+
+// ─── task 15 section 3: the roll used to throw on every built part ─────────
+//
+// `RollStandardCostPopover` sends `partIds: [thisPart]`. The scope widened to
+// ancestors ONLY, so a child was never in scope, `contributionOf` read its
+// stored (null) standard, and the walk aborted on every built part in a fresh
+// org. The fix widens DOWN as well, to the descendants with nothing to
+// re-value.
+describe('planStandardCostRoll descendant widening', () => {
+  it('pulls in a descendant that has no stored standard, and values it first', async () => {
+    h.subparts = liftSubparts()
+    queueOrg(PARTS, [
+      fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+      fv(MOTOR, FIELD.part_cost!.id, { number: 2010 }),
+      fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      fv(LIFT, FIELD.part_kind!.id, { option: 'finished_good' }),
+    ])
+
+    // Rolling the finished good from its own drawer, exactly as the popover does.
+    const result = await previewStandardCostRoll(db, ORG, {
+      partIds: [LIFT],
+      effectiveAt: EFFECTIVE_AT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    const plan = result._unsafeUnwrap()
+    const valued = new Map(plan.lines.map((line) => [line.partId, line]))
+    // Bottom-up, so the component is valued before the assembly built from it.
+    expect(plan.lines.map((line) => line.partId)).toEqual([MOTOR, ASSEMBLY, LIFT])
+    expect(valued.get(MOTOR)!.standardCost).toBe(2010)
+    expect(valued.get(ASSEMBLY)!.standardCost).toBe(2010)
+    expect(valued.get(LIFT)!.standardCost).toBe(4020)
+    // Every one of them is a FIRST valuation, which is what makes pulling them
+    // in safe: there is nothing to re-value.
+    expect(plan.lines.every((line) => line.isInitial)).toBe(true)
+    expect(plan.revaluationDelta).toBe(0)
+  })
+
+  it('leaves a descendant that already has a standard alone, and takes its stored value', async () => {
+    h.subparts = liftSubparts()
+    queueOrg(PARTS, [
+      fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+      fv(MOTOR, FIELD.part_cost!.id, { number: 2010 }),
+      fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      // An agreed standard. Re-valuing it is what the caller did NOT ask for.
+      fv(ASSEMBLY, FIELD.part_standard_cost!.id, { number: 9999 }),
+      fv(ASSEMBLY, FIELD.part_standard_material_cost!.id, { number: 9999 }),
+      fv(ASSEMBLY, FIELD.part_standard_cost_effective_at!.id, { date: '2026-01-01T00:00:00.000Z' }),
+      fv(LIFT, FIELD.part_kind!.id, { option: 'finished_good' }),
+    ])
+
+    const plan = (
+      await previewStandardCostRoll(db, ORG, { partIds: [LIFT], effectiveAt: EFFECTIVE_AT })
+    )._unsafeUnwrap()
+
+    const partIds = plan.lines.map((line) => line.partId)
+    expect(partIds).not.toContain(ASSEMBLY)
+    // 2 x the assembly's STORED standard, not a freshly rolled one. This is what
+    // keeps `completeBuild` balanced: the consume rows are valued at the same
+    // number the parent was built from.
+    expect(plan.lines.find((line) => line.partId === LIFT)!.standardCost).toBe(19998)
+  })
+
+  it('names the real remedy when a component genuinely cannot be valued', async () => {
+    h.subparts = liftSubparts()
+    queueOrg(PARTS, [
+      // No `part_cost` at all, so the motor is skipped and the assembly above it
+      // has no number to build from.
+      fv(MOTOR, FIELD.part_kind!.id, { option: 'component' }),
+      fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
+      fv(LIFT, FIELD.part_kind!.id, { option: 'finished_good' }),
+    ])
+
+    const result = await previewStandardCostRoll(db, ORG, {
+      partIds: [LIFT],
+      effectiveAt: EFFECTIVE_AT,
+    })
+
+    expect(result.isErr()).toBe(true)
+    // "Give it a price or roll it first" was wrong: it is a lie when the
+    // component already HAS a price and simply has no priced bill of materials.
+    expect(result._unsafeUnwrapErr().message).toMatch(
+      /has no supplier price and no priced bill of materials/
+    )
+  })
+})

--- a/packages/lib/src/builds/ensure-standard-cost.ts
+++ b/packages/lib/src/builds/ensure-standard-cost.ts
@@ -1,0 +1,386 @@
+// packages/lib/src/builds/ensure-standard-cost.ts
+
+/**
+ * `ensureStandardCost` — the ONLY writer that sets a FIRST standard cost.
+ *
+ * plans/money/tasks/15-costing-usability.md §1.
+ *
+ * 🛑 **It writes only parts where `part_standard_cost IS NULL`. It never overwrites.**
+ *
+ * That single rule is the whole safety argument. Overwriting would turn a
+ * vendor-price change into an automatic revaluation of on-hand inventory, which
+ * is exactly what `standard-cost.ts`'s header forbids: *"If the standard were
+ * recalculated automatically it would just BE `part_cost`, and every movement's
+ * frozen `unitCost` would drift with vendor prices."* Re-valuing is
+ * {@link rollStandardCost}'s job and nothing else's.
+ *
+ * Four callers, one function (§2):
+ *
+ * | source        | fires when                          | cost from                 |
+ * | ------------- | ----------------------------------- | ------------------------- |
+ * | `supplier-price` | a `vendor_part` price is written | the refreshed `part_cost` |
+ * | `opening-stock`  | a part is created with stock     | `unitCost`, typed         |
+ * | `receipt`        | a part's first receipt           | `unitCost`, landed        |
+ * | `manual`         | a caller asks explicitly         | the refreshed `part_cost` |
+ *
+ * ✅ **A first standard always finds `QoH = 0`,** because every door that can
+ * give a part stock either goes through here first or refuses without a
+ * standard. So this can never revalue anything and there is no initial
+ * valuation to post under any posting regime.
+ *
+ * No permission checks: the router asserts (`docs/lib-module-guide.md` §6).
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
+import type { Result } from 'neverthrow'
+import { getOrgCache } from '../cache'
+import { BadRequestError } from '../errors'
+import { createFieldValueContext } from '../field-values/field-value-helpers'
+import { setValueWithType } from '../field-values/field-value-mutations'
+import { toFieldType } from '../field-values/stored-field-type'
+import {
+  type FieldValueUpdateEntry,
+  getRealtimeService,
+  publishFieldValueUpdates,
+} from '../realtime'
+import { roundMinorUnits } from './client'
+import { guard } from './guard'
+import {
+  loadStandardCostWriteContext,
+  planStandardCostRoll,
+  type StandardCostFields,
+  type StandardCostWriteContext,
+} from './standard-cost-queries'
+import type { StandardCostComponents } from './types'
+
+const logger = createScopedLogger('builds:ensure-standard-cost')
+
+/** How many parts are written concurrently. Mirrors `persistStandardCosts`. */
+const WRITE_BATCH_SIZE = 20
+
+/** Which door called, and the cost it can supply. */
+export interface EnsureStandardCostSource {
+  kind: 'supplier-price' | 'opening-stock' | 'receipt' | 'manual'
+  /**
+   * The cost to freeze, in whole minor units.
+   *
+   * Supplied by `opening-stock` and `receipt`, which know an exact number.
+   * Omitted by `supplier-price` and `manual`, which fall back to the part's
+   * refreshed `part_cost` through the normal roll.
+   */
+  unitCost?: number
+}
+
+export interface EnsureStandardCostResult {
+  /** Parts that had no standard and now have one. */
+  writtenPartIds: string[]
+}
+
+/** One part's first standard, already reduced to the four numbers to store. */
+interface FirstStandard {
+  partId: string
+  components: StandardCostComponents
+}
+
+/**
+ * Give every named part a standard cost, if and only if it has none.
+ *
+ * Widens to ancestors first, then applies the NULL filter to the wider set:
+ * pricing a component makes its parent rollable, and without the widening the
+ * parent stays unvalued one level up.
+ *
+ * 🛑 **Never throws on an unvaluable part.** A part with no cost at all is
+ * skipped and reported, not an error — these callers are post-commit hooks and
+ * create forms, and one that throws on a vendor-price save is worse than one
+ * that writes nothing.
+ *
+ * ⚠️ Deliberately does NOT run `recalculateAllPartCosts`. `rollStandardCost`
+ * opens with that full-org sweep; every caller here has either just recalculated
+ * the affected parts or supplies `unitCost` outright.
+ *
+ * Authored as the org's system user: nobody pressed a button, and attributing
+ * the write to whoever edited a price is a lie.
+ */
+export async function ensureStandardCost(
+  db: Database,
+  organizationId: string,
+  partIds: string[],
+  source: EnsureStandardCostSource
+): Promise<Result<EnsureStandardCostResult, Error>> {
+  return guard(
+    async () => {
+      const requested = [...new Set(partIds.filter(Boolean))]
+      if (requested.length === 0) return { writtenPartIds: [] }
+
+      const explicitCost = resolveExplicitCost(source.unitCost)
+      const effectiveAt = new Date()
+
+      // The plan is where the widening happens: up to every ancestor, and (since
+      // task 15 §3) down to the descendants that have no standard either. Every
+      // line it returns is a candidate; the NULL filter below is what turns the
+      // candidates into writes.
+      let context: StandardCostWriteContext
+      let candidates: FirstStandard[] = []
+      let skipped = 0
+
+      try {
+        const planned = await planStandardCostRoll(db, organizationId, {
+          partIds: requested,
+          effectiveAt,
+        })
+        context = {
+          partDefId: planned.partDefId,
+          fields: planned.fields,
+          allPartIds: planned.allPartIds,
+          standardCosts: planned.stored.standardCosts,
+        }
+        skipped = planned.plan.skipped.length
+        // 🛑 THE ONE RULE. `previousStandardCost` is the stored
+        // `part_standard_cost`, so `== null` is literally `IS NULL`. It is
+        // applied here rather than to the input because the widened set is what
+        // gets written, and a widened ancestor that already has a standard must
+        // survive this untouched.
+        candidates = planned.plan.lines
+          .filter((line) => line.previousStandardCost == null)
+          .map((line) => ({
+            partId: line.partId,
+            components: {
+              standardMaterialCost: line.standardMaterialCost,
+              standardLaborCost: line.standardLaborCost,
+              standardOverheadCost: line.standardOverheadCost,
+              standardCost: line.standardCost,
+            },
+          }))
+      } catch (error) {
+        // With no cost of our own there is nothing left to do, so the failure is
+        // the answer. With one, the plan was only ever the widening half: an
+        // unpriced sibling under a shared parent aborts it, and refusing to
+        // freeze a cost somebody typed because of an unrelated part is worse
+        // than writing exactly what they typed.
+        if (explicitCost == null) throw error
+        logger.warn('Could not plan the roll around an explicit cost, writing it alone', {
+          organizationId,
+          source: source.kind,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        context = await loadStandardCostWriteContext(db, organizationId)
+      }
+
+      const writes = orderWrites(requested, candidates, explicitCost, context)
+      if (writes.length === 0) {
+        logger.info('No first standard cost to write', {
+          organizationId,
+          source: source.kind,
+          considered: requested.length,
+          written: 0,
+          skipped,
+        })
+        return { writtenPartIds: [] }
+      }
+
+      // Nobody pressed a button. Attributing the write to whoever edited a price
+      // would put a person's name on a decision the system made.
+      const userId = await getOrgCache().get(organizationId, 'systemUser')
+
+      const writtenPartIds = await persistFirstStandards(db, organizationId, userId, {
+        partDefId: context.partDefId,
+        fields: context.fields,
+        effectiveAt,
+        writes,
+      })
+
+      logger.info('Ensured first standard cost', {
+        organizationId,
+        source: source.kind,
+        considered: requested.length,
+        planned: writes.length,
+        written: writtenPartIds.length,
+        skipped,
+        explicitCost,
+      })
+
+      return { writtenPartIds }
+    },
+    'Failed to ensure standard cost',
+    { organizationId, source: source.kind, partIds: partIds.length }
+  )
+}
+
+/**
+ * Validate the caller's cost, in whole minor units.
+ *
+ * A zero or negative standard is refused rather than stored: `completeBuild`,
+ * `adjustStock` and `receiveStock` all treat a zero standard as "not rolled",
+ * so freezing one would give the part a standard that every consumer reads as
+ * an absence.
+ */
+function resolveExplicitCost(unitCost: number | undefined): number | null {
+  if (unitCost == null) return null
+  if (!Number.isFinite(unitCost) || unitCost <= 0) {
+    throw new BadRequestError('A standard cost must be a positive amount in whole minor units')
+  }
+  return roundMinorUnits(unitCost)
+}
+
+/**
+ * Merge the planned first standards with the caller's explicit cost, in the
+ * order they must be written.
+ *
+ * The explicit cost wins on the parts the caller NAMED, and only there: it is
+ * the cost of the stock being taken in, so material is that number and
+ * conversion is zero (the part is being stocked, not built). A widened ancestor
+ * is never overridden: it has a bill of materials and rolls normally.
+ *
+ * Overrides go first so the write order stays bottom-up: a part being stocked
+ * is a leaf of whatever the plan widened to above it.
+ */
+function orderWrites(
+  requested: string[],
+  candidates: FirstStandard[],
+  explicitCost: number | null,
+  context: StandardCostWriteContext
+): FirstStandard[] {
+  const ordered: FirstStandard[] = []
+  const claimed = new Set<string>()
+
+  if (explicitCost != null) {
+    for (const partId of requested) {
+      // A stale id from a caller must never invent a write target, and a part
+      // that already has a standard is never touched.
+      if (!context.allPartIds.has(partId)) continue
+      if (context.standardCosts.get(partId) != null) continue
+      if (claimed.has(partId)) continue
+      claimed.add(partId)
+      ordered.push({
+        partId,
+        components: {
+          standardMaterialCost: explicitCost,
+          standardLaborCost: 0,
+          standardOverheadCost: 0,
+          standardCost: explicitCost,
+        },
+      })
+    }
+  }
+
+  // `candidates` is already the plan's bottom-up order.
+  for (const candidate of candidates) {
+    if (claimed.has(candidate.partId)) continue
+    claimed.add(candidate.partId)
+    ordered.push(candidate)
+  }
+
+  return ordered
+}
+
+/**
+ * Write the five `part_standard_*` fields through `setValueWithType`, the same
+ * writer `persistStandardCosts` uses.
+ *
+ * Two deliberate differences from the roll's persist step:
+ *
+ *  1. **It never throws.** These callers are post-commit hooks and create forms.
+ *     A failed batch stops the loop (so what landed is still a bottom-up PREFIX
+ *     of the plan, the same consistency guarantee the roll gives) and is logged,
+ *     but the caller gets the parts that were written rather than an error that
+ *     would roll back a vendor price somebody just saved.
+ *  2. **Every part here is a FIRST standard,** so there is no `changed` diff to
+ *     apply: a part with nothing stored has, by definition, changed.
+ */
+async function persistFirstStandards(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  args: {
+    partDefId: string
+    fields: StandardCostFields
+    effectiveAt: Date
+    writes: readonly FirstStandard[]
+  }
+): Promise<string[]> {
+  const { partDefId, fields, effectiveAt, writes } = args
+  const effectiveAtIso = effectiveAt.toISOString()
+
+  const pending = writes.map((write) => ({
+    partId: write.partId,
+    values: [
+      { field: fields.material, value: numberValue(write.components.standardMaterialCost) },
+      { field: fields.labor, value: numberValue(write.components.standardLaborCost) },
+      { field: fields.overhead, value: numberValue(write.components.standardOverheadCost) },
+      { field: fields.standard, value: numberValue(write.components.standardCost) },
+      { field: fields.effectiveAt, value: { type: 'date' as const, value: effectiveAtIso } },
+    ],
+  }))
+
+  const ctx = createFieldValueContext(organizationId, userId, db)
+  const written = new Set<string>()
+
+  for (let i = 0; i < pending.length; i += WRITE_BATCH_SIZE) {
+    const batch = pending.slice(i, i + WRITE_BATCH_SIZE)
+    const settled = await Promise.allSettled(
+      batch.map(async (entry) => {
+        const recordId = toRecordId(partDefId, entry.partId) as RecordId
+        // Sequential per part: the five values belong to one record and
+        // `setValueWithType` stamps the instance on each write.
+        for (const write of entry.values) {
+          await setValueWithType(ctx, {
+            recordId,
+            fieldId: write.field.id,
+            fieldType: toFieldType(write.field.type),
+            value: write.value,
+          })
+        }
+        return entry.partId
+      })
+    )
+
+    for (const outcome of settled) {
+      if (outcome.status === 'fulfilled') written.add(outcome.value)
+    }
+
+    const failure = settled.find((outcome) => outcome.status === 'rejected')
+    if (failure) {
+      logger.error('Failed to freeze a first standard cost, stopping', {
+        organizationId,
+        written: written.size,
+        planned: pending.length,
+        error: failure.reason instanceof Error ? failure.reason.message : String(failure.reason),
+      })
+      break
+    }
+  }
+
+  publishFirstStandards(organizationId, partDefId, pending, written)
+
+  return [...written]
+}
+
+/** The same realtime frame `persistStandardCosts` publishes, for the parts that landed. */
+function publishFirstStandards(
+  organizationId: string,
+  partDefId: string,
+  pending: { partId: string; values: { field: { id: string }; value: unknown }[] }[],
+  written: ReadonlySet<string>
+): void {
+  if (written.size === 0) return
+  const entries: FieldValueUpdateEntry[] = []
+  for (const entry of pending) {
+    if (!written.has(entry.partId)) continue
+    const recordId = toRecordId(partDefId, entry.partId) as RecordId
+    for (const write of entry.values) {
+      entries.push({
+        key: buildFieldValueKey(recordId, write.field.id as FieldId),
+        value: write.value as FieldValueUpdateEntry['value'],
+      })
+    }
+  }
+  publishFieldValueUpdates(getRealtimeService(), organizationId, entries).catch(() => {})
+}
+
+/** `null` is a real answer: it clears the stored value. */
+function numberValue(value: number | null): { type: 'number'; value: number } | null {
+  return value == null ? null : { type: 'number', value }
+}

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -87,6 +87,13 @@ export {
   reconcileOrdersFromSync,
   registerOrderDriftReconcilers,
 } from './drift-reconciler'
+// The ONLY writer of a FIRST standard cost (plans/money/tasks/15 §1). It never
+// overwrites, which is what makes it safe to call from a post-commit hook.
+export {
+  type EnsureStandardCostResult,
+  type EnsureStandardCostSource,
+  ensureStandardCost,
+} from './ensure-standard-cost'
 export { hasDrifted, type OrderDemand, orderDemandFingerprint } from './order-fingerprint'
 export {
   type OrderBuildAmendment,
@@ -113,9 +120,11 @@ export { rollStandardCost } from './standard-cost'
 export {
   loadAbsorptionRates,
   loadStandardCostFields,
+  loadStandardCostWriteContext,
   previewStandardCostRoll,
   readStandardCost,
   type StandardCostFields,
+  type StandardCostWriteContext,
 } from './standard-cost-queries'
 export {
   computeStandardCosts,
@@ -123,6 +132,7 @@ export {
   type StandardCostRollInputs,
   type SubpartEdge,
   widenToAncestors,
+  widenToUnvaluedDescendants,
 } from './standard-cost-roll'
 export type {
   AbsorptionRates,

--- a/packages/lib/src/builds/standard-cost-queries.ts
+++ b/packages/lib/src/builds/standard-cost-queries.ts
@@ -27,6 +27,7 @@ import {
   type StandardCostRollComputation,
   type SubpartEdge,
   widenToAncestors,
+  widenToUnvaluedDescendants,
 } from './standard-cost-roll'
 import type {
   AbsorptionRates,
@@ -221,6 +222,14 @@ export interface StandardCostRollContext {
   plan: StandardCostRollPlan
   stored: StoredPartValues
   computation: StandardCostRollComputation
+  /**
+   * Every non-archived `part` in the org.
+   *
+   * Exposed so a caller writing a FIRST standard outside the plan (see
+   * `ensureStandardCost`) can tell "this id does not exist" from "this id has
+   * no cost", without a second round trip.
+   */
+  allPartIds: Set<string>
 }
 
 /**
@@ -258,13 +267,24 @@ export async function planStandardCostRoll(
   const subpartGraph: ReadonlyMap<string, SubpartEdge[]> = buildSubpartGraph(pricing.subparts)
   const parentGraph = buildParentGraph(pricing.subparts)
 
-  // Scoped -> widen to every ancestor, then intersect with the parts that
+  // Scoped -> widen UP to every ancestor, then DOWN to the descendants of that
+  // widened set that have no stored standard, then intersect with the parts that
   // actually exist, so a stale id from the caller cannot invent a write target.
+  //
+  // The downward half is not symmetric with the upward half: it takes only the
+  // parts with nothing to re-value (`widenToUnvaluedDescendants`). It is also
+  // computed from the ANCESTOR-widened set rather than from `requested`,
+  // because an ancestor pulled in by the upward walk has its own unvalued
+  // children, and leaving those out reproduces the same abort one level up.
   const requested = input.partIds?.filter((id) => allPartIds.has(id)) ?? []
-  const scope =
-    input.partIds && input.partIds.length > 0
-      ? new Set([...widenToAncestors(requested, parentGraph)].filter((id) => allPartIds.has(id)))
-      : allPartIds
+  let scope: Set<string>
+  if (input.partIds && input.partIds.length > 0) {
+    const upward = widenToAncestors(requested, parentGraph)
+    const downward = widenToUnvaluedDescendants(upward, subpartGraph, stored.standardCosts)
+    scope = new Set([...upward, ...downward].filter((id) => allPartIds.has(id)))
+  } else {
+    scope = allPartIds
+  }
 
   const computation = computeStandardCosts({
     scope,
@@ -320,6 +340,7 @@ export async function planStandardCostRoll(
     fields,
     stored,
     computation,
+    allPartIds,
     plan: {
       effectiveAt: new Date(effectiveAtIso),
       rates,
@@ -434,4 +455,43 @@ export async function readStandardCost(
     'Failed to read standard costs',
     { organizationId, partCount: partIds.length }
   )
+}
+
+/**
+ * The minimum a caller needs to write a FIRST standard cost onto a part
+ * without planning a roll at all.
+ *
+ * {@link planStandardCostRoll} returns a superset of this, so the happy path
+ * never calls it. It exists for the one case that matters at the doors in
+ * plans/money/tasks/15-costing-usability.md section 2: a part created with
+ * opening stock, or received for the first time, carries an EXPLICIT unit cost,
+ * and that number must still be frozen even when planning the roll around it
+ * aborts (an unpriced sibling under a shared parent is enough to abort it).
+ */
+export interface StandardCostWriteContext {
+  partDefId: string
+  fields: StandardCostFields
+  /** Every non-archived `part`. An id outside this set is stale and never written. */
+  allPartIds: Set<string>
+  /** `part_standard_cost` as stored. Absence is the NULL that makes a part writable. */
+  standardCosts: ReadonlyMap<string, number>
+}
+
+/** Load {@link StandardCostWriteContext}. Reads only. */
+export async function loadStandardCostWriteContext(
+  db: Database,
+  organizationId: string
+): Promise<StandardCostWriteContext> {
+  const partDefId = await requireCachedEntityDefId(organizationId, 'part')
+  const fields = await loadStandardCostFields(organizationId)
+  const [partRows, stored] = await Promise.all([
+    loadPartRows(db, organizationId, partDefId),
+    loadStoredPartValues(db, organizationId, fields),
+  ])
+  return {
+    partDefId,
+    fields,
+    allPartIds: new Set(partRows.map((row) => row.id)),
+    standardCosts: stored.standardCosts,
+  }
 }

--- a/packages/lib/src/builds/standard-cost-roll.ts
+++ b/packages/lib/src/builds/standard-cost-roll.ts
@@ -172,7 +172,13 @@ export function computeStandardCosts(inputs: StandardCostRollInputs): StandardCo
       const childStandard = contributionOf(child.childId)
       if (childStandard == null) {
         throw new UnprocessableEntityError(
-          `Cannot roll standard cost for "${name(partId)}": its component "${name(child.childId)}" has no standard cost. Give it a price or roll it first.`
+          // The remedy matters. Since the scope widens to descendants that have
+          // no stored standard (see `widenToUnvaluedDescendants`), a child that
+          // reaches here was either rolled and could not be valued, or is not a
+          // live part at all. Telling somebody to "give it a price" is wrong
+          // when the child already HAS one and simply has no priced bill of
+          // materials underneath it.
+          `Cannot roll standard cost for "${name(partId)}": its component "${name(child.childId)}" has no supplier price and no priced bill of materials, so it cannot be valued.`
         )
       }
       material += childStandard * child.qty
@@ -217,4 +223,52 @@ export function widenToAncestors(
   }
   for (const partId of partIds) walk(partId)
   return widened
+}
+
+/**
+ * Widen a set of part ids DOWNWARD, to the descendants that carry no stored
+ * standard cost.
+ *
+ * 🛑 The complement of {@link widenToAncestors}, and the two objections do not
+ * overlap. Refusing descendants outright (which this module used to do) is what
+ * made the part drawer's Roll button throw on every built part: the child was
+ * never in scope, so `contributionOf` read its STORED standard, which is `null`
+ * in an org that has never rolled, and the walk aborted.
+ *
+ * A descendant that already HAS a standard is still excluded, and that is the
+ * whole distinction: it has an agreed value to re-value, and re-valuing a
+ * subassembly the caller did not name is exactly what `widenToAncestors`'
+ * comment refuses. A descendant with NO standard has nothing to re-value, so
+ * the objection does not apply to it. It appears in the plan as `isInitial`,
+ * which is how the preview tells a person this is a first valuation.
+ *
+ * The walk continues THROUGH a valued descendant, because a valued
+ * subassembly's own children may still be unvalued and are equally free to
+ * value.
+ *
+ * @param partIds the parts already in scope, normally the ancestor-widened set
+ * @param subpartGraph parent -> children, the same graph the roll walks
+ * @param storedStandardCosts `part_standard_cost` as currently stored
+ */
+export function widenToUnvaluedDescendants(
+  partIds: Iterable<string>,
+  subpartGraph: ReadonlyMap<string, SubpartEdge[]>,
+  storedStandardCosts: ReadonlyMap<string, number>
+): Set<string> {
+  const unvalued = new Set<string>()
+  // Separate from `unvalued` so a cycle terminates even though a valued node is
+  // walked through without being collected.
+  const visited = new Set<string>()
+
+  const walk = (partId: string) => {
+    if (visited.has(partId)) return
+    visited.add(partId)
+    for (const edge of subpartGraph.get(partId) ?? []) {
+      if (storedStandardCosts.get(edge.childId) == null) unvalued.add(edge.childId)
+      walk(edge.childId)
+    }
+  }
+
+  for (const partId of partIds) walk(partId)
+  return unvalued
 }

--- a/packages/lib/src/builds/types.ts
+++ b/packages/lib/src/builds/types.ts
@@ -129,12 +129,22 @@ export interface StandardCostRollResult extends StandardCostRollPlan {
 /** Input to {@link rollStandardCost} and {@link previewStandardCostRoll}. */
 export interface RollStandardCostInput {
   /**
-   * Restrict the roll to these parts **and every ancestor of them**.
+   * Restrict the roll to these parts, **every ancestor of them, and every
+   * descendant that has no stored standard yet**.
    *
-   * Omitted (or empty) rolls every non-archived part in the org. Descendants are
-   * deliberately NOT pulled in: rolling a finished good values it at its
-   * subassemblies' already-agreed standards, which is what a standard cost roll
-   * is for.
+   * Omitted (or empty) rolls every non-archived part in the org.
+   *
+   * 🛑 The descendant half is ASYMMETRIC and the asymmetry is the point
+   * (plans/money/tasks/15-costing-usability.md §3):
+   *
+   * - A descendant that **already has** a standard is left alone and contributes
+   *   its stored value. Rolling a finished good values it at its subassemblies'
+   *   already-agreed standards, which is what a standard cost roll is for, and
+   *   re-valuing them is not something the caller asked for.
+   * - A descendant with **no** standard is pulled in, because it has nothing to
+   *   re-value and because leaving it out is what used to make this throw on
+   *   every built part in a fresh org: it would contribute a NULL stored standard
+   *   and abort the parent rather than value it short.
    */
   partIds?: string[]
   /** When the new standards take effect. */

--- a/packages/lib/src/field-hooks/post/bom-cost-triggers.ts
+++ b/packages/lib/src/field-hooks/post/bom-cost-triggers.ts
@@ -42,6 +42,7 @@ const recalculatePartCost: FieldTriggerHandler = async (event) => {
   })
 
   await recalculateAffectedParts(organizationId, partIds)
+  await ensureFirstStandardCosts(organizationId, partIds)
 }
 
 /**
@@ -100,10 +101,83 @@ export async function recalculatePartCostForEntityBatch(params: {
     affectedParts: partIds.size,
     organizationId,
   })
-  await recalculateAffectedParts(organizationId, [...partIds])
+  const affected = [...partIds]
+  await recalculateAffectedParts(organizationId, affected)
+  await ensureFirstStandardCosts(organizationId, affected)
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Give a newly priced part, and its parents, a FIRST standard cost
+ * (plans/money/tasks/15-costing-usability.md §2a).
+ *
+ * Runs immediately after `recalculateAffectedParts`, so `part_cost` is already
+ * the refreshed replacement cost `ensureStandardCost` rolls from. It widens to
+ * ancestors itself: pricing a component is what makes its parent rollable, and
+ * without the widening the parent stays unvalued one level up.
+ *
+ * 🛑 **This can never restate an existing standard.** `ensureStandardCost`
+ * writes exclusively where `part_standard_cost IS NULL`. A price change on a
+ * part that already has a standard moves `part_cost` and leaves the standard
+ * alone, which is the whole reason the two fields are separate: a standard that
+ * drifted with vendor quotes would silently restate every closed period.
+ *
+ * 🛑 **It must never break the price save.** This is a post-commit hook on a
+ * `vendor_part` or `subpart` write, and the price is the fact the user asked to
+ * record. A failure here is logged and swallowed, including the setting read:
+ * the worst case is a part that stays unrolled, which is the state it was in
+ * before the price arrived.
+ *
+ * The two collaborators are imported lazily, the same way `settings-service`
+ * reaches the org cache. Neither is on the path a field hook has to be able to
+ * load: this is optional, best-effort work hanging off the end of a recalc, and
+ * a static import would put the whole standard-cost and settings graph into
+ * every module that so much as registers a trigger.
+ */
+async function ensureFirstStandardCosts(organizationId: string, partIds: string[]): Promise<void> {
+  if (partIds.length === 0) return
+
+  try {
+    const [{ ensureStandardCost }, { getOrganizationSetting }] = await Promise.all([
+      import('../../builds/ensure-standard-cost'),
+      import('../../settings/settings-service'),
+    ])
+
+    const enabled = await getOrganizationSetting({
+      organizationId,
+      key: 'manufacturing.autoRollFirstStandard',
+    })
+    // Default is on, so only an explicit `false` turns it off. An org running a
+    // strict standard-cost discipline sets it and keeps the manual roll.
+    if (enabled === false) return
+
+    const result = await ensureStandardCost(database, organizationId, partIds, {
+      kind: 'supplier-price',
+    })
+    if (result.isErr()) {
+      logger.warn('Could not set first standard costs after a price change', {
+        organizationId,
+        consideredParts: partIds.length,
+        error: result.error,
+      })
+      return
+    }
+    if (result.value.writtenPartIds.length > 0) {
+      logger.info('Set first standard costs after a price change', {
+        organizationId,
+        consideredParts: partIds.length,
+        writtenParts: result.value.writtenPartIds.length,
+      })
+    }
+  } catch (error) {
+    logger.warn('First standard cost pass failed after a price change', {
+      organizationId,
+      consideredParts: partIds.length,
+      error,
+    })
+  }
+}
 
 /**
  * Batch resolve parent partIds for multiple entity instances in a single query.

--- a/packages/lib/src/receiving/__tests__/open-stock-balance.test.ts
+++ b/packages/lib/src/receiving/__tests__/open-stock-balance.test.ts
@@ -1,0 +1,402 @@
+// packages/lib/src/receiving/__tests__/open-stock-balance.test.ts
+//
+// The opening balance — the FOURTH movement writer, and the only one whose unit
+// cost a caller is entitled to state (plans/money/tasks/15-costing-usability.md
+// §2.2). The org cache, the CRUD handler, the two part reads and
+// `ensureStandardCost` are mocked, so nothing here needs a database.
+//
+// What is pinned:
+//
+//   - one `initial` movement, at the TYPED cost, `cost_basis: standard`, with
+//     the inventory role resolved from the part kind
+//   - the standard cost is set BEFORE the movement is written, from the same
+//     number, so the opening balance carries no variance
+//   - 🛑 a part that already has ANY movement is refused. That guard is what
+//     stops the create form becoming a back door into hand-valuing an
+//     adjustment, since `initial` is the one type that takes a caller's cost
+//   - zero and negative quantities and costs are refused, and nothing is written
+//   - 🛑 `adjustStock` still has no unit-cost input. `G12` stands, and the
+//     existence of a typed cost one file over must not be read as permission.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../../errors'
+
+const h = vi.hoisted(() => ({
+  createSpy: vi.fn(async (_defId: string, _values: Record<string, unknown>) => ({
+    instance: { id: 'mv_1' },
+  })),
+  ensureSpy: vi.fn(),
+  /** systemAttributes the org has materialised. */
+  materialised: new Set<string>(),
+  /** entityType -> def id; a missing key models a def the org does not have. */
+  defs: new Map<string, string>(),
+  partKind: null as string | null,
+  /** What `readPartStandardCost` answers AFTER `ensureStandardCost` has run. */
+  standardCost: null as number | null,
+  displayName: 'Widget 9000' as string | null,
+  /** Rows `assertPartHasNoMovements`' probe finds. Non-empty = already opened. */
+  existingMovements: [] as { id: string }[],
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  requireCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => {
+    const id = h.defs.get(entityType)
+    if (!id) throw new Error(`EntityDefinition not found for entityType: ${entityType}`)
+    return id
+  }),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(
+          attrs.map((a) => [a, h.materialised.has(a) ? { id: `fld_${a}` } : null])
+        ),
+    }),
+  }),
+}))
+
+vi.mock('../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    create = h.createSpy
+  },
+}))
+
+vi.mock('../receipt-queries', async () => {
+  const { ok } = await import('neverthrow')
+  return {
+    readPartKind: vi.fn(async () => ok(h.partKind)),
+    readPartStandardCost: vi.fn(async () =>
+      ok({ standardCost: h.standardCost, displayName: h.displayName })
+    ),
+  }
+})
+
+vi.mock('../../builds/ensure-standard-cost', () => ({
+  ensureStandardCost: h.ensureSpy,
+}))
+
+import { adjustStock } from '../adjust-stock'
+import { openStockBalance } from '../open-stock-balance'
+import type { AdjustStockInput } from '../types'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+
+/**
+ * A drizzle chain that ends in whatever `assertPartHasNoMovements`' probe is
+ * told to find. Every link returns itself, so the shape of the query is free to
+ * change without the double having to know about it.
+ */
+const db = {
+  select: () => {
+    const chain: Record<string, unknown> = {}
+    chain.from = () => chain
+    chain.innerJoin = () => chain
+    chain.where = () => chain
+    chain.limit = async () => h.existingMovements
+    return chain
+  },
+} as never
+
+/** Every systemAttribute a fully migrated org has for this write path. */
+const ALL_MOVEMENT_ATTRS = [
+  'stock_movement_part',
+  'stock_movement_unit_cost',
+  'stock_movement_cost_basis',
+  'stock_movement_extended_cost',
+  'stock_movement_gl_account',
+  'stock_movement_occurred_at',
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.materialised = new Set(ALL_MOVEMENT_ATTRS)
+  h.defs = new Map([
+    ['part', 'def_part'],
+    ['stock_movement', 'def_mv'],
+  ])
+  h.partKind = null
+  h.displayName = 'Widget 9000'
+  h.standardCost = null
+  h.existingMovements = []
+  h.createSpy.mockResolvedValue({ instance: { id: 'mv_1' } })
+  // The real thing writes only where `part_standard_cost IS NULL`, and this door
+  // always supplies a cost, so the part comes out holding the typed number.
+  h.ensureSpy.mockImplementation(
+    async (
+      _db: unknown,
+      _org: string,
+      partIds: string[],
+      source: { kind: string; unitCost?: number }
+    ) => {
+      const { ok } = await import('neverthrow')
+      if (h.standardCost == null && source.unitCost != null) h.standardCost = source.unitCost
+      return ok({ writtenPartIds: partIds })
+    }
+  )
+})
+
+/** The value bag handed to `UnifiedCrudHandler.create` on the single write. */
+function writtenValues(): Record<string, unknown> {
+  expect(h.createSpy).toHaveBeenCalledTimes(1)
+  return h.createSpy.mock.calls[0]![1]
+}
+
+async function expectErr(promise: ReturnType<typeof openStockBalance>) {
+  const result = await promise
+  expect(result.isErr()).toBe(true)
+  return result._unsafeUnwrapErr()
+}
+
+async function openAndRead(
+  input: Parameters<typeof openStockBalance>[3]
+): Promise<Record<string, unknown>> {
+  const result = await openStockBalance(db, ORG, USER, input)
+  expect(result.isOk()).toBe(true)
+  return writtenValues()
+}
+
+const OPENING = { partId: 'part_1', quantity: 10, unitCost: 1200 }
+
+describe('openStockBalance — the one movement it writes', () => {
+  it('writes exactly one movement, of type initial', async () => {
+    const values = await openAndRead(OPENING)
+    expect(values.stock_movement_type).toBe('initial')
+    expect(values.stock_movement_quantity).toBe(10)
+  })
+
+  // 🛑 The typed number, not a server read. This is the one movement type where
+  // that is correct: an opening balance IS what was paid for the stock on hand,
+  // and there is no supplier row or packing slip to read it from.
+  it('freezes the TYPED unit cost, and an extended cost signed like the quantity', async () => {
+    const values = await openAndRead(OPENING)
+    expect(values.stock_movement_unit_cost).toBe(1200)
+    expect(values.stock_movement_extended_cost).toBe(12000)
+  })
+
+  // `standard`, never `actual`: there is no vendor, no order and no invoice, and
+  // the standard was just made to agree with this number.
+  it('stamps cost_basis STANDARD', async () => {
+    expect((await openAndRead(OPENING)).stock_movement_cost_basis).toBe('standard')
+  })
+
+  it('stamps the inventory ROLE resolved from the part kind, never an account code', async () => {
+    expect((await openAndRead(OPENING)).stock_movement_gl_account).toBe('inventory_raw_materials')
+  })
+
+  it('follows the part kind to the finished-goods account', async () => {
+    h.partKind = 'finished_good'
+    expect((await openAndRead(OPENING)).stock_movement_gl_account).toBe('inventory_finished_goods')
+  })
+
+  // 🛑 `explodeBomMovement` inherits the parent movement's type AND its sign, so
+  // a true flag here would open a balance for every component in the BOM as
+  // well: ten assemblies on the shelf claiming ten of every screw inside them.
+  it('never explodes into the bill of materials', async () => {
+    expect((await openAndRead(OPENING)).stock_movement_adjust_subparts).toBe(false)
+  })
+
+  it('stamps the accounting date the caller gave, not the moment of the keystroke', async () => {
+    const occurredAt = new Date('2026-01-01T00:00:00.000Z')
+    const values = await openAndRead({ ...OPENING, occurredAt })
+    expect(values.stock_movement_occurred_at).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('records the note as the movement reason', async () => {
+    const values = await openAndRead({ ...OPENING, notes: 'Opening count 2026-01-01' })
+    expect(values.stock_movement_reason).toBe('Opening count 2026-01-01')
+  })
+
+  it('returns the row it wrote, with no vendor and no purchase order', async () => {
+    const result = await openStockBalance(db, ORG, USER, OPENING)
+    expect(result.isOk()).toBe(true)
+    const record = result._unsafeUnwrap()
+    expect(record).toMatchObject({
+      movementId: 'mv_1',
+      recordId: 'def_mv:mv_1',
+      partInstanceId: 'part_1',
+      quantity: 10,
+      unitCost: 1200,
+      extendedCost: 12000,
+      vendorPartId: null,
+      vendorUnitPrice: null,
+      purchaseOrderLineId: null,
+      glAccount: 'inventory_raw_materials',
+    })
+  })
+})
+
+describe('openStockBalance — it sets the first standard cost', () => {
+  it('calls ensureStandardCost with the opening-stock source and the typed cost', async () => {
+    await openAndRead(OPENING)
+    expect(h.ensureSpy).toHaveBeenCalledTimes(1)
+    expect(h.ensureSpy).toHaveBeenCalledWith(db, ORG, ['part_1'], {
+      kind: 'opening-stock',
+      unitCost: 1200,
+    })
+  })
+
+  // The order is the contract: a movement written first, with the standard write
+  // failing after it, is a part holding stock that nothing can value.
+  it('sets the standard BEFORE the movement is written', async () => {
+    const order: string[] = []
+    h.ensureSpy.mockImplementation(async () => {
+      order.push('ensure')
+      const { ok } = await import('neverthrow')
+      h.standardCost = 1200
+      return ok({ writtenPartIds: ['part_1'] })
+    })
+    h.createSpy.mockImplementation(async () => {
+      order.push('create')
+      return { instance: { id: 'mv_1' } }
+    })
+    await openStockBalance(db, ORG, USER, OPENING)
+    expect(order).toEqual(['ensure', 'create'])
+  })
+
+  it('writes nothing when the standard cost could not be set', async () => {
+    h.ensureSpy.mockImplementation(async () => {
+      const { err } = await import('neverthrow')
+      return err(new Error('boom'))
+    })
+    await expectErr(openStockBalance(db, ORG, USER, OPENING))
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  // 🛑 The post-condition, not the return value. A part that comes out of this
+  // holding stock and no standard refuses every later adjustment, build and
+  // close, so it is checked while a refusal is still possible.
+  it('refuses, naming the part, when the part still has no standard afterwards', async () => {
+    h.ensureSpy.mockImplementation(async () => {
+      const { ok } = await import('neverthrow')
+      return ok({ writtenPartIds: [] })
+    })
+    const error = await expectErr(openStockBalance(db, ORG, USER, OPENING))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toContain('Widget 9000')
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  // A part somebody already rolled keeps its standard: `ensureStandardCost`
+  // never overwrites, and this door does not ask it to.
+  it('leaves an existing standard cost alone', async () => {
+    h.standardCost = 9999
+    await openAndRead(OPENING)
+    expect(h.standardCost).toBe(9999)
+  })
+})
+
+describe('openStockBalance — opening is ONCE', () => {
+  // 🛑 The load-bearing guard. `initial` is the only movement type that accepts
+  // a caller's cost, so a second one against a part that already has a ledger
+  // would let anybody state any value for any quantity, on an append-only row.
+  it('refuses a part that already has a stock movement, and writes nothing', async () => {
+    h.existingMovements = [{ id: 'mv_earlier' }]
+    const error = await expectErr(openStockBalance(db, ORG, USER, OPENING))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toMatch(/already has stock movements/i)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not set a standard cost on the refused second attempt', async () => {
+    h.existingMovements = [{ id: 'mv_earlier' }]
+    await expectErr(openStockBalance(db, ORG, USER, OPENING))
+    expect(h.ensureSpy).not.toHaveBeenCalled()
+  })
+
+  // The refusal has to point somewhere. An adjustment is the door for a count
+  // that disagrees with the system after the part has a history.
+  it('names the adjustment as the way to correct a count instead', async () => {
+    h.existingMovements = [{ id: 'mv_earlier' }]
+    const error = await expectErr(openStockBalance(db, ORG, USER, OPENING))
+    expect(error.message).toMatch(/adjustment/i)
+  })
+})
+
+describe('openStockBalance — the quantity and cost guards', () => {
+  it.each([0, -5])('refuses a quantity of %s and writes nothing', async (quantity) => {
+    const error = await expectErr(openStockBalance(db, ORG, USER, { ...OPENING, quantity }))
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])('refuses a non-finite quantity (%s)', async (quantity) => {
+    // Infinity survives Math.round into the doublePrecision column and poisons
+    // every later SUM; NaN passes `<= 0` as false.
+    const error = await expectErr(openStockBalance(db, ORG, USER, { ...OPENING, quantity }))
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it.each([0, -1200])('refuses a unit cost of %s and writes nothing', async (unitCost) => {
+    // The same hard refusal `receiveStock` gives at zero: a zero frozen onto an
+    // append-only row sums into inventory as nothing and cannot be told apart
+    // from a genuinely free part.
+    const error = await expectErr(openStockBalance(db, ORG, USER, { ...OPENING, unitCost }))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    12.5,
+  ])('refuses a unit cost that is not a whole number of minor units (%s)', async (unitCost) => {
+    // Not rounded into a legal value: a fraction arriving here means the caller
+    // is working in the wrong units, and rounding would freeze that forever.
+    const error = await expectErr(openStockBalance(db, ORG, USER, { ...OPENING, unitCost }))
+    expect(error).toBeInstanceOf(BadRequestError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('runs the input guards before anything else', async () => {
+    // No defs at all: if the quantity check ran second this would surface as a
+    // NotFound and the caller would fix the wrong problem.
+    h.defs = new Map()
+    const error = await expectErr(openStockBalance(db, ORG, USER, { ...OPENING, quantity: 0 }))
+    expect(error).toBeInstanceOf(BadRequestError)
+  })
+
+  it('fails with NotFound when the org has no stock_movement definition', async () => {
+    h.defs.delete('stock_movement')
+    const error = await expectErr(openStockBalance(db, ORG, USER, OPENING))
+    expect(error).toBeInstanceOf(NotFoundError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+
+  it('refuses before the cost fields of entity migration 108 are materialised', async () => {
+    h.materialised.delete('stock_movement_unit_cost')
+    const error = await expectErr(openStockBalance(db, ORG, USER, OPENING))
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createSpy).not.toHaveBeenCalled()
+  })
+})
+
+// 🛑 The regression guard `plans/money/tasks/15-costing-usability.md` §5 asks
+// for by name: "`adjustStock` regaining a unit-cost input. Refused in §2.2.
+// `G12` stands." An opening balance takes a typed cost because it HAS one; an
+// adjustment has no supplier row, no purchase order and no packing slip, so a
+// number typed there would make the ledger's valuation depend on who counted.
+describe('adjustStock still has no unit-cost input', () => {
+  it('does not accept one at the type level', () => {
+    // @ts-expect-error — `unitCost` is not on AdjustStockInput and must not be.
+    const input: AdjustStockInput = { partId: 'part_1', quantity: 5, unitCost: 1200 }
+    expect(input.partId).toBe('part_1')
+  })
+
+  it('ignores one at runtime, valuing the adjustment at the part standard', async () => {
+    h.standardCost = 4400
+    const result = await adjustStock(db, ORG, USER, {
+      partId: 'part_1',
+      quantity: 5,
+      // @ts-expect-error — see above.
+      unitCost: 999_999,
+    })
+    expect(result.isOk()).toBe(true)
+    expect(writtenValues().stock_movement_unit_cost).toBe(4400)
+  })
+})

--- a/packages/lib/src/receiving/__tests__/receive-stock.test.ts
+++ b/packages/lib/src/receiving/__tests__/receive-stock.test.ts
@@ -16,6 +16,7 @@ const h = vi.hoisted(() => ({
   /** entityType -> def id; a missing key models a def the org does not have. */
   defs: new Map<string, string>(),
   partKind: null as string | null,
+  ensureSpy: vi.fn(),
   vendorTerms: null as {
     unitPrice: number | null
     shippingCost?: number | null
@@ -55,6 +56,13 @@ vi.mock('../receipt-queries', async () => {
   }
 })
 
+// A part's first receipt gives it a standard cost
+// (plans/money/tasks/15-costing-usability.md §2c). Mocked here because the real
+// one reads the standard-cost fields, and this file has no database.
+vi.mock('../../builds/ensure-standard-cost', () => ({
+  ensureStandardCost: h.ensureSpy,
+}))
+
 import { receiveStock } from '../receive-stock'
 
 const ORG = 'org_1'
@@ -83,6 +91,10 @@ beforeEach(() => {
   h.partKind = null
   h.vendorTerms = null
   h.createSpy.mockResolvedValue({ instance: { id: 'mv_1' } })
+  h.ensureSpy.mockImplementation(async (_db: unknown, _org: string, partIds: string[]) => {
+    const { ok } = await import('neverthrow')
+    return ok({ writtenPartIds: partIds })
+  })
 })
 
 /** The value bag handed to `UnifiedCrudHandler.create` on the single write. */
@@ -507,3 +519,64 @@ async function receiveAndRead(
   expect(result.isOk()).toBe(true)
   return writtenValues()
 }
+
+// A part's FIRST receipt gives it a standard cost
+// (plans/money/tasks/15-costing-usability.md §2c), so the adjust, build and
+// close paths that refuse without one stop refusing.
+describe('receiveStock — the first receipt sets the standard cost', () => {
+  it('offers the resolved LANDED cost, not the raw supplier price', async () => {
+    h.vendorTerms = { unitPrice: 4400, shippingCost: 300, tariffRate: 10, otherCost: 100 }
+    await receiveAndRead({ partId: 'part_1', quantity: 5, vendorPartId: 'vp_1' })
+    expect(h.ensureSpy).toHaveBeenCalledTimes(1)
+    expect(h.ensureSpy).toHaveBeenCalledWith(db, ORG, ['part_1'], {
+      kind: 'receipt',
+      unitCost: 5240,
+    })
+  })
+
+  it('offers it before the movement is written', async () => {
+    const order: string[] = []
+    h.ensureSpy.mockImplementation(async () => {
+      order.push('ensure')
+      const { ok } = await import('neverthrow')
+      return ok({ writtenPartIds: ['part_1'] })
+    })
+    h.createSpy.mockImplementation(async () => {
+      order.push('create')
+      return { instance: { id: 'mv_1' } }
+    })
+    await receiveStock(db, ORG, USER, { partId: 'part_1', quantity: 1, unitCost: 4400 })
+    expect(order).toEqual(['ensure', 'create'])
+  })
+
+  // 🛑 The scope limit. This does NOT change what the receipt is valued at:
+  // receiving AT standard and posting the difference to 5090 is a books change
+  // and lives in `plans/money/design/ppv-treatment.md`.
+  it('still values the receipt at the landed cost, on an ACTUAL basis', async () => {
+    const values = await receiveAndRead({ partId: 'part_1', quantity: 5, unitCost: 4400 })
+    expect(values.stock_movement_cost_basis).toBe('actual')
+    expect(values.stock_movement_unit_cost).toBe(4400)
+  })
+
+  // The receipt is the fact being recorded and it is already priced. Losing the
+  // arrival because a derived convenience could not be written is the worse
+  // outcome; the part simply stays unrolled.
+  it('records the receipt anyway when the standard cost could not be set', async () => {
+    h.ensureSpy.mockImplementation(async () => {
+      const { err } = await import('neverthrow')
+      return err(new Error('boom'))
+    })
+    const result = await receiveStock(db, ORG, USER, {
+      partId: 'part_1',
+      quantity: 5,
+      unitCost: 4400,
+    })
+    expect(result.isOk()).toBe(true)
+    expect(h.createSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is not attempted when the receipt is refused for having no price', async () => {
+    await expectErr(receiveStock(db, ORG, USER, { partId: 'part_1', quantity: 5 }))
+    expect(h.ensureSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/receiving/index.ts
+++ b/packages/lib/src/receiving/index.ts
@@ -13,6 +13,7 @@ export {
   resolveInventoryRoleForPartKind,
   roundMinorUnits,
 } from './client'
+export { openStockBalance } from './open-stock-balance'
 export {
   getLastReceiptCost,
   getPartReceiptHistory,
@@ -29,6 +30,7 @@ export type {
   AdjustStockInput,
   ListReceiptsFilters,
   MovementRecord,
+  OpenStockBalanceInput,
   ReceiptRow,
   ReceivePurchaseOrderInput,
   ReceivePurchaseOrderLineInput,

--- a/packages/lib/src/receiving/open-stock-balance.ts
+++ b/packages/lib/src/receiving/open-stock-balance.ts
@@ -1,0 +1,342 @@
+// packages/lib/src/receiving/open-stock-balance.ts
+
+/**
+ * `openStockBalance` — a part's opening balance: quantity and cost, once.
+ *
+ * plans/money/tasks/15-costing-usability.md §2.2.
+ *
+ * Writes one `stock_movement` of type **`initial`** ("Initial Stock"), a value
+ * that has existed in `StockMovementType` since the ledger was built and that
+ * nothing has ever written.
+ *
+ * 🛑 **This is beside `adjustStock`, never part of it.** `G12` removed
+ * `adjustStock`'s unit-cost input because *"an adjustment has no supplier row,
+ * no purchase order and no packing slip — there is no ACTUAL to record."* An
+ * opening balance is the one case where there IS one: what was paid for the
+ * stock being held on day one. That is why `initial` is its own movement type,
+ * and why the cost here is typed by a person while an adjustment's never is.
+ *
+ * **`adjustStock` still takes no unit cost. Do not add one.**
+ *
+ * The order of the steps is the contract:
+ *
+ * 1. `quantity > 0` and `unitCost > 0`, or refuse. The same hard refusal
+ *    `receiveStock` gives at zero cost, and for the same reason: a zero frozen
+ *    onto an append-only row is a number the ledger can never explain.
+ * 2. 🛑 Refuse if the part already has ANY `stock_movement`. Opening is once,
+ *    and this guard is what stops the create form becoming a back door into
+ *    hand-valuing an adjustment.
+ * 3. `ensureStandardCost` with `kind: 'opening-stock'` and this `unitCost`.
+ * 4. Write the movement at that standard, `cost_basis: standard`, with
+ *    `gl_account` from `resolveInventoryRoleForPartKind`.
+ * 5. `recalculatePartQoH`.
+ *
+ * No permission checks: the router asserts (`docs/lib-module-guide.md` §6).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { ensureStandardCost } from '../builds/ensure-standard-cost'
+import { getCachedEntityDefId, getOrgCache, requireCachedEntityDefId } from '../cache'
+import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../errors'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import { StockMovementCostBasis, StockMovementType } from '../resources/registry/enum-values'
+import { toRecordId } from '../resources/resource-id'
+import { computeExtendedCost, resolveInventoryRoleForPartKind } from './client'
+import { assertCostFieldsMaterialized } from './cost-fields'
+import { guard } from './guard'
+import { readPartKind, readPartStandardCost } from './receipt-queries'
+import type { MovementRecord, OpenStockBalanceInput } from './types'
+
+export type { OpenStockBalanceInput } from './types'
+
+/**
+ * Set a part's opening balance.
+ *
+ * @throws UnprocessableEntityError when the quantity or cost is not strictly
+ * positive, or when the part already has movements.
+ */
+export async function openStockBalance(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: OpenStockBalanceInput
+): Promise<Result<MovementRecord, Error>> {
+  return guard(
+    async () => {
+      assertOpeningQuantity(input.quantity)
+      assertOpeningUnitCost(input.unitCost)
+
+      const partDefId = await requireCachedEntityDefId(organizationId, 'part')
+      const movementDefId = await getCachedEntityDefId(organizationId, 'stock_movement')
+      if (!movementDefId) {
+        throw new NotFoundError('This organization has no stock_movement entity definition')
+      }
+      await assertCostFieldsMaterialized(
+        organizationId,
+        'Opening stock is not available until the stock movement cost fields are provisioned'
+      )
+
+      await assertPartHasNoMovements(db, organizationId, movementDefId, input.partId)
+
+      const kind = await readPartKind(db, organizationId, input.partId)
+      if (kind.isErr()) throw kind.error
+      const glAccount = resolveInventoryRoleForPartKind(kind.value)
+
+      await setFirstStandardCost(db, organizationId, input)
+
+      return writeInitialMovement(db, organizationId, userId, {
+        movementDefId,
+        partDefId,
+        input,
+        glAccount,
+        occurredAt: input.occurredAt ?? new Date(),
+      })
+    },
+    'Failed to set opening stock balance',
+    { organizationId, partId: input.partId, quantity: input.quantity }
+  )
+}
+
+/**
+ * Step 1a: the opening quantity must be a finite number strictly above zero.
+ *
+ * `Number.isFinite` is checked as well as the sign for the reason
+ * `assertReceivableQuantity` states: `NaN > 0` is false but so is `NaN <= 0`,
+ * and an `Infinity` quantity multiplies into an `extendedCost` of `Infinity`
+ * that `Math.round` preserves and every later `SUM` is then poisoned by.
+ *
+ * A negative opening balance is refused rather than reinterpreted. Starting life
+ * owing stock is not an opening balance, it is a count correction, and that door
+ * is `adjustStock`.
+ */
+function assertOpeningQuantity(quantity: number): void {
+  if (!Number.isFinite(quantity)) {
+    throw new BadRequestError('Opening quantity must be a finite number')
+  }
+  if (quantity <= 0) {
+    throw new BadRequestError(
+      'Opening quantity must be greater than zero. A part with no stock needs no opening balance.'
+    )
+  }
+}
+
+/**
+ * Step 1b: the opening unit cost must be a finite whole number above zero.
+ *
+ * The same hard refusal `receiveStock` gives at zero, and for the same reason: a
+ * zero frozen onto an append-only row sums into the inventory balance as
+ * nothing and cannot be told apart from a genuinely free part.
+ *
+ * Unlike a receipt this does NOT round a fractional input down into a legal
+ * value. A receipt derives its cost from supplier terms and rounds the result;
+ * an opening balance is typed, in whole minor units, by a person looking at what
+ * was paid, so a fraction arriving here means the caller is working in the wrong
+ * units and silently rounding it would freeze that mistake forever.
+ */
+function assertOpeningUnitCost(unitCost: number): void {
+  if (!Number.isFinite(unitCost) || !Number.isInteger(unitCost)) {
+    throw new BadRequestError('Opening unit cost must be a whole number of minor units')
+  }
+  if (unitCost <= 0) {
+    throw new UnprocessableEntityError(
+      'Refusing to open a stock balance at zero cost. Enter what a unit actually cost.'
+    )
+  }
+}
+
+/**
+ * Step 2: the load-bearing guard. Opening is once.
+ *
+ * 🛑 Without it the create form becomes a back door into hand-valuing an
+ * adjustment: `initial` is the only movement type that accepts a caller's cost,
+ * so a second one against a part that already has a ledger would let anybody
+ * state any value for any quantity, at any date, on an append-only row nobody
+ * can edit afterwards.
+ *
+ * ⚠️ Read-then-write with no DB constraint behind it, exactly like
+ * `reverseMovement`'s double-reversal guard, and best-effort for the same
+ * reason: there is no uniqueness a `FieldValue` row can express. Two opening
+ * balances raced through at the same instant would both pass. That is a far
+ * narrower window than the one this closes, and the create form is the only
+ * caller.
+ *
+ * The query lives here rather than in `receipt-queries.ts` because it is not a
+ * receipt read: it is this writer's own precondition and has no other caller.
+ *
+ * Archived movements still count. A soft-deleted movement is a movement that
+ * happened, and letting an archive re-open the door would make the guard
+ * bypassable by anybody who could archive a row.
+ */
+async function assertPartHasNoMovements(
+  db: Database,
+  organizationId: string,
+  movementDefId: string,
+  partId: string
+): Promise<void> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['stock_movement_part'])
+  const partField = fields.stock_movement_part
+  if (!partField) {
+    throw new UnprocessableEntityError(
+      'This organization has no stock_movement part field, so an opening balance cannot be linked to a part'
+    )
+  }
+
+  const [existing] = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      schema.FieldValue,
+      and(
+        eq(schema.FieldValue.entityId, schema.EntityInstance.id),
+        eq(schema.FieldValue.organizationId, schema.EntityInstance.organizationId),
+        eq(schema.FieldValue.fieldId, partField.id)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, movementDefId),
+        eq(schema.FieldValue.relatedEntityId, partId)
+      )
+    )
+    .limit(1)
+
+  if (existing) {
+    throw new UnprocessableEntityError(
+      'This part already has stock movements, so it cannot be given an opening balance. An opening balance is the first thing that ever happens to a part; correct a count with an adjustment instead.',
+      { partId }
+    )
+  }
+}
+
+/**
+ * Step 3: the part must come out of this holding a standard cost.
+ *
+ * `ensureStandardCost` writes only where `part_standard_cost IS NULL`, so a part
+ * somebody already rolled keeps the standard it has and this is a no-op.
+ *
+ * 🛑 **An error here fails the whole write.** `ensureStandardCost` is documented
+ * as never throwing on an unvaluable part, because its other callers are
+ * post-commit hooks; a genuine failure returned here is different. Writing the
+ * movement anyway would produce the one state the whole subsystem is built to
+ * exclude: a part holding stock with no standard to value it at, which then
+ * refuses every later adjustment and build.
+ *
+ * The post-condition is verified rather than assumed, for the same reason: the
+ * caller supplied a cost, so "no standard afterwards" can only mean something
+ * upstream declined to write, and finding that out before the ledger row exists
+ * is the difference between a refusal and a mess.
+ */
+async function setFirstStandardCost(
+  db: Database,
+  organizationId: string,
+  input: OpenStockBalanceInput
+): Promise<void> {
+  const ensured = await ensureStandardCost(db, organizationId, [input.partId], {
+    kind: 'opening-stock',
+    unitCost: input.unitCost,
+  })
+  if (ensured.isErr()) throw ensured.error
+
+  const standard = await readPartStandardCost(db, organizationId, input.partId)
+  if (standard.isErr()) throw standard.error
+
+  const { standardCost, displayName } = standard.value
+  if (standardCost == null || !Number.isFinite(standardCost)) {
+    const partLabel = displayName ? `"${displayName}"` : `part ${input.partId}`
+    throw new UnprocessableEntityError(
+      `Could not set a standard cost for ${partLabel}, so its opening stock was not recorded. Stock that carries no standard cost cannot be adjusted, built or closed.`,
+      { partId: input.partId }
+    )
+  }
+}
+
+interface WriteInitialMovementArgs {
+  movementDefId: string
+  partDefId: string
+  input: OpenStockBalanceInput
+  /** The inventory account ROLE, resolved from `partKind` at write time. */
+  glAccount: string
+  occurredAt: Date
+}
+
+/**
+ * Step 4: write the one movement, and let step 5 happen on its own.
+ *
+ * Values are keyed by `systemAttribute` and go through `UnifiedCrudHandler`
+ * rather than a hand-built `EntityInstance` + `FieldValue` insert, the same
+ * mechanism `writeAdjustMovement` and `writeReceiveMovement` use. That is what
+ * makes the post-commit triggers fire, and `recalculatePartQoH` (step 5) is one
+ * of them: quantity on hand has exactly one owner, the
+ * `mfg-stock-movements-created` rule, and a second writer here would give the
+ * same number two.
+ *
+ * 🛑 **The `unit_cost` is the CALLER's number, and this is the only movement
+ * writer where that is true.** Everywhere else a caller-supplied cost is a
+ * defect: `adjustStock` reads the standard because a count has no invoice
+ * (`G12`), and `receiveStock`'s `unitCost` seam is internal to lib and rejected
+ * by the router's input schema. Here the number IS the fact being recorded, and
+ * step 3 has just made the part's standard agree with it, so the opening balance
+ * carries no variance by construction.
+ *
+ * 🛑 **`adjustSubparts: false` is load-bearing, not a default.**
+ * `explodeBomMovement` inherits the parent movement's type AND its sign, so an
+ * opening balance with the flag set would open a balance for every component in
+ * the bill of materials as well: ten assemblies on the shelf would claim ten of
+ * every screw inside them, on top of whatever opening balance those screws were
+ * given in their own right. An opening count counts what is on the shelf, and
+ * the assemblies and their loose components are counted separately.
+ */
+async function writeInitialMovement(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  args: WriteInitialMovementArgs
+): Promise<MovementRecord> {
+  const { movementDefId, partDefId, input, glAccount, occurredAt } = args
+  const { quantity, unitCost } = input
+  const extendedCost = computeExtendedCost(unitCost, quantity)
+
+  const values: Record<string, unknown> = {
+    stock_movement_part: toRecordId(partDefId, input.partId),
+    stock_movement_type: StockMovementType.INITIAL,
+    stock_movement_quantity: quantity,
+    // See the JSDoc above. Never true on an opening balance.
+    stock_movement_adjust_subparts: false,
+    stock_movement_occurred_at: occurredAt.toISOString(),
+    // `standard`, not `actual`. There is no vendor row, no purchase order and no
+    // packing slip behind an opening balance, and step 3 has just made this cost
+    // BE the part's standard, so `standard` is the honest description of it.
+    stock_movement_cost_basis: StockMovementCostBasis.STANDARD,
+    stock_movement_unit_cost: unitCost,
+    stock_movement_extended_cost: extendedCost,
+    stock_movement_gl_account: glAccount,
+  }
+
+  // `stock_movement` has no notes attribute; `reason` is the free-text field on
+  // the row and 'Opening count 2026-01-01' is exactly what it is for.
+  if (input.notes) values.stock_movement_reason = input.notes
+
+  const crud = new UnifiedCrudHandler(organizationId, userId, db)
+  const created = await crud.create(movementDefId, values)
+
+  return {
+    movementId: created.instance.id,
+    recordId: toRecordId(movementDefId, created.instance.id),
+    partInstanceId: input.partId,
+    quantity,
+    unitCost,
+    extendedCost,
+    // An opening balance is not a purchase: nothing was bought and nobody sold
+    // it to us on this date. There is no supplier to state.
+    vendorUnitPrice: null,
+    vendorPartId: null,
+    glAccount,
+    occurredAt,
+    purchaseOrderLineId: null,
+  }
+}

--- a/packages/lib/src/receiving/receive-stock.ts
+++ b/packages/lib/src/receiving/receive-stock.ts
@@ -14,7 +14,9 @@
  */
 
 import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
 import type { Result } from 'neverthrow'
+import { ensureStandardCost } from '../builds/ensure-standard-cost'
 import { getCachedEntityDefId, requireCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../errors'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
@@ -31,6 +33,8 @@ import { guard } from './guard'
 import { readPartKind, readVendorPartCostInputs } from './receipt-queries'
 import type { MovementRecord, ReceiveStockInput } from './types'
 
+const logger = createScopedLogger('receiving')
+
 /**
  * Receive stock against a part.
  *
@@ -42,7 +46,9 @@ import type { MovementRecord, ReceiveStockInput } from './types'
  * 2. Resolve the price. See {@link resolveReceiptPrice} — the base is the price
  *    the caller sent, and the supplier row contributes only the landed adders.
  * 3. Round both money values ONCE, at the point of storage.
- * 4. Write one movement.
+ * 4. Give the part a standard cost if, and only if, it has none. See
+ *    {@link setFirstStandardCostFromReceipt}.
+ * 5. Write one movement.
  *
  * 🛑 **A receipt is never written at zero cost.** If neither a supplied price nor
  * the supplier row yields a positive number this fails with
@@ -72,6 +78,8 @@ export async function receiveStock(
 
       const priced = await resolveReceiptPrice(db, organizationId, input)
       const partKind = await unwrap(readPartKind(db, organizationId, input.partId))
+
+      await setFirstStandardCostFromReceipt(db, organizationId, input.partId, priced.unitCost)
 
       const written = await writeReceiveMovement(db, organizationId, userId, {
         movementDefId,
@@ -226,7 +234,52 @@ interface WriteReceiveMovementArgs {
 }
 
 /**
- * Step 4: write the one movement.
+ * Step 4: a part's FIRST receipt gives it a standard cost
+ * (plans/money/tasks/15-costing-usability.md §2c).
+ *
+ * `ensureStandardCost` writes only where `part_standard_cost IS NULL`, so this
+ * is a no-op on every receipt after the first, and on any part somebody already
+ * rolled. It is not gated on a setting: a receipt carries a landed cost off an
+ * invoice, which is a fact, not an inference from a price list.
+ *
+ * 🛑 **This does NOT change what the receipt is valued at.** The movement below
+ * still stamps `cost_basis: 'actual'` at the landed cost, exactly as before.
+ * Receiving AT standard and posting the difference to `5090` is a books change
+ * and lives in `plans/money/design/ppv-treatment.md`; all this does is make the
+ * part HAVE a standard afterwards, so the adjust, build and close paths that
+ * refuse without one stop refusing.
+ *
+ * 🛑 **A receipt never MOVES an existing standard.** That is the same file's §5:
+ * a standard that follows the last purchase is a moving average wearing a
+ * standard's name. A later receipt at a different price varies against the
+ * standard; it does not become it.
+ *
+ * Failures are swallowed. The receipt is the fact being recorded and it is
+ * already priced; refusing to record it because a derived convenience could not
+ * be written would lose the arrival. The part simply stays unrolled, which is
+ * the state it was in a moment ago.
+ */
+async function setFirstStandardCostFromReceipt(
+  db: Database,
+  organizationId: string,
+  partId: string,
+  unitCost: number
+): Promise<void> {
+  const ensured = await ensureStandardCost(db, organizationId, [partId], {
+    kind: 'receipt',
+    unitCost,
+  })
+  if (ensured.isErr()) {
+    logger.warn('Could not set a first standard cost from a receipt', {
+      organizationId,
+      partId,
+      error: ensured.error,
+    })
+  }
+}
+
+/**
+ * Step 5: write the one movement.
  *
  * Values are keyed by `systemAttribute` and go through `UnifiedCrudHandler`
  * rather than a hand-built `EntityInstance` + `FieldValue` insert. That is the

--- a/packages/lib/src/receiving/types.ts
+++ b/packages/lib/src/receiving/types.ts
@@ -154,6 +154,40 @@ export interface AdjustStockInput {
 }
 
 /**
+ * A part's opening balance: the quantity and unit cost it starts life holding
+ * (plans/money/tasks/15-costing-usability.md section 2.2).
+ *
+ * 🛑 **Not an adjustment and not a receipt.** It is written once, by the create
+ * form, as `StockMovementType.INITIAL`. See `open-stock-balance.ts` for why this
+ * is the one movement type whose cost a caller is entitled to state.
+ */
+export interface OpenStockBalanceInput {
+  /** `EntityInstance.id` of the `part`. */
+  partId: string
+  /** Units on hand at the opening date. Strictly positive. */
+  quantity: number
+  /**
+   * What a unit cost, in whole minor units. Strictly positive.
+   *
+   * Becomes the part's first `part_standard_cost` as well as this movement's
+   * frozen `unit_cost`, so the two agree by construction and the opening
+   * balance carries no variance.
+   */
+  unitCost: number
+  /**
+   * The ACCOUNTING date. Defaults to now.
+   *
+   * 🛑 Load-bearing for the close: an `initial` movement dated at or before
+   * `accounting.cutoffPeriod` falls outside the month-end window and is covered
+   * by the frozen `accounting.opening*` baseline; one dated after it is summed
+   * into inventory. Both are correct and the date is what chooses.
+   */
+  occurredAt?: Date
+  /** Free text: 'Opening count 2026-01-01'. */
+  notes?: string
+}
+
+/**
  * One line of a multi-line purchase-order receipt.
  *
  * 🛑 **No price.** The agreed price is already on the `purchase_order_line`, and

--- a/packages/lib/src/resources/registry/resources/part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/part-fields.ts
@@ -320,6 +320,21 @@ export const PART_FIELDS: Record<string, ResourceField> = {
   // consumer; an absent value reads NULL and every reader must treat NULL as
   // `component`, preserving today's explode-on-sale behaviour for every
   // unclassified part. No backfill.
+  //
+  // `defaultValue: 'component'` (15-costing-usability.md §4c) makes the common
+  // case the preselected one instead of an empty select nobody fills in. It is
+  // the SINGLE source of that default: the create dialog seeds its state from
+  // this field rather than from a literal, and `applyDefaults` covers the doors
+  // that send no key at all (import, API, connectors, seed). Reachable for
+  // existing orgs because `mergeSystemAndCustomFields` resolves
+  // `dbField.defaultValue ?? staticField.defaultValue`, and `part_kind` is NULL
+  // on every stored field row, exactly like `build_status` and its 'planned'.
+  //
+  // 🛑 It also changes what a stored `component` MEANS: it no longer proves a
+  // human typed it. `shouldSuggestFinishedGood` (part-family-suggestion.ts) was
+  // widened in the same change to fire on `component` as well as unset, because
+  // the unset-only gate was the only safety net against a finished good being
+  // posted to 1310 instead of 1330 and frozen on `updatable: false` movements.
   partKind: {
     id: toFieldId('partKind'),
     key: 'partKind',
@@ -339,6 +354,7 @@ export const PART_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'Select part kind',
+    defaultValue: PartKind.COMPONENT,
     description:
       'How this part is classified for build and sell purposes. Unset reads as a component',
   },

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -1152,6 +1152,28 @@ export const SETTINGS_CATALOG = {
       'Applied overhead per assembled unit, integer minor units: total annual factory ' +
       'overhead / expected annual units. Unset = no overhead absorption.',
   },
+  // ⚠️ A FIRST standard only. `ensureStandardCost` writes exclusively where
+  // `part_standard_cost IS NULL`, so this can never restate a part that already
+  // has a standard: a supplier price change moves `part_cost` (live replacement
+  // cost) and leaves the standard where the last roll put it. Re-valuing on-hand
+  // inventory stays the manual roll's job
+  // (plans/money/tasks/15-costing-usability.md §1 and §2a).
+  //
+  // On by default: without it a newly priced part shows "Not rolled" next to
+  // every action that refuses without a standard, which is the state 205 of 206
+  // parts in the dev org were found in. An org running a strict standard-cost
+  // discipline turns it off and keeps rolling by hand.
+  'manufacturing.autoRollFirstStandard': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CHECKBOX',
+    options: { variant: 'switch' },
+    defaultValue: true,
+    description:
+      'When on, adding or changing a supplier price gives an unvalued part (and its parents) ' +
+      'a first standard cost. It only ever sets a standard that is missing, and never ' +
+      'overwrites one that already exists.',
+  },
 
   // ── Order-triggered auto-build (plans/products/12-order-triggered-build.md §5.4) ────────
   //


### PR DESCRIPTION
Standard cost is the number `adjustStock`, `completeBuild` and the L1 month-end entry all refuse to work without. It was also the only cost a human had to set on purpose, through doors that were broken, hidden or absent. In the dev org **205 of 206 parts read "Not rolled"** beside a button that threw.

| door | before |
| --- | --- |
| Part drawer > Costing > **Roll** | threw on every built part |
| Settings > Accounting > General | worked, and nobody knew it was there |
| A supplier price being added | nothing |
| A part created with opening stock | no such form |
| A first receipt | received at actual, set no standard |

## One primitive

`ensureStandardCost` writes **only** where `part_standard_cost IS NULL` and never overwrites. Overwriting would turn a vendor-price change into an automatic revaluation of on-hand inventory, which is the whole reason `part_cost` and `part_standard_cost` are separate fields. Re-valuing stays `rollStandardCost`'s job.

It widens to ancestors then applies the NULL filter to the wider set, skips the full-org `recalculateAllPartCosts` sweep (every caller has either just recalculated or supplies an exact cost), never throws on an unvaluable part, and authors as the org system user because nobody pressed a button.

## Four doors

- **A supplier price is written** — hooked into `bom-cost-triggers` after `recalculateAffectedParts`, behind the new `manufacturing.autoRollFirstStandard` (default on), wrapped so it can never break the price save.
- **A part is created with opening stock** — new collapsible section on the part form.
- **A part's first receipt** — sets the standard from the landed cost.
- **The manual roll** — unchanged.

## `openStockBalance`

Writes the first-ever `initial` movement. That `StockMovementType` value has existed since the ledger was built with no writer.

A typed unit cost here does **not** reopen `G12`. That decision removed `adjustStock`'s cost input because an adjustment has no supplier row, no purchase order and no packing slip, so there is no *actual* to record. An opening balance is the one case where there is one, which is why `initial` is its own movement type. **`adjustStock` still takes no cost input**, with a regression test pinning it.

Refuses a second attempt, a non-positive quantity or cost, and a non-integer cost (typed, so a fraction means wrong units and rounding would freeze the mistake).

The close needs no changes: an `initial` movement dated at or before `accounting.cutoffPeriod` falls outside the month-end window and is covered by the frozen opening baseline; one dated after it is summed in carrying its cost and role.

## The roll's scope bug

It widened to ancestors only, so a child was never in scope and `contributionOf` returned its null **stored** standard, aborting on every built part in a fresh org. The error even said "give it a price or roll it first" about components that already had a price.

Now it also widens to descendants that have **no stored standard**, walking down from the ancestor-widened set (an ancestor pulled in upward has its own unvalued children). A descendant that already has a standard is still left alone and contributes its stored value, which is what a roll is for.

## `part_kind` default, and the gate that had to move with it

`defaultValue: 'component'` on the field, with the create form reading it rather than a literal. A registry default alone would not reach that form: `applyDefaults` skips a key that is merely present, and the dialog always sent `part_kind: values.kind || undefined`.

🛑 This changes what a stored `component` **means**. It is now "nobody said otherwise", not "somebody chose this". So `shouldSuggestFinishedGood` widens to fire on `component` as well as unset. Leaving that gate alone would silently delete the only guard against a finished good posting to `1310` instead of `1330` and freezing that on `updatable: false` rows. It also now catches imported and API-created parts, which the unset-only gate never could.

## UI

- `previewCompletion` and `previewRoll` keep previous data. Typing a quantity used to blank the cost summary, the labour/overhead inputs, every row's cost (flashing red "no standard"), the unpriced warning and the submit button, all at once.
- Labour and overhead derive their default from the org rates rather than from the in-flight preview, so they stop emptying mid-edit. State still holds `null` meaning "use the org rate", and that is still what gets sent.
- Both roll surfaces stop saying "already matches today's cost" when in fact nothing could be valued.

## Deliberately not here

A receipt still stamps `cost_basis: 'actual'` at landed cost. Moving to **receive at standard** with a `5090` PPV leg is a books change, argued separately in `plans/money/design/ppv-treatment.md`, and it depends on this PR having made a standard always exist first.

## Checks

- `typecheck-ratchet --package lib`: no new errors (29 total, baseline 29)
- `typecheck-ratchet --package web`: no new errors (0 total, baseline 0)
- lib `vitest` across builds/receiving/field-hooks/settings/resources: **1399 passed**, 107 files
- web `vitest` across cards/manufacturing/accounting: 50 passed
- biome clean

No migration. `part_kind`'s default reaches existing orgs through `mergeSystemAndCustomFields`, the same way `build_status` already gets its `'planned'`.

⚠️ **Tested but undriven.** Nothing here has been run in a browser, and the dev org still shows 205 unrolled parts until someone runs the org-wide roll or creates a part through the new form.

https://claude.ai/code/session_01E9cZNdH6F3JbNDs8oAB3RG
