### PR TITLE
feat(money): the G19 account map - pair the chart with QuickBooks

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
@@ -1,0 +1,258 @@
+// apps/web/src/components/accounting/ui/settings/account-map-list.tsx
+'use client'
+
+// The `G19` account map: which account in the connected accounting system each
+// of the org's own accounts corresponds to.
+//
+// 🛑 One component, two homes - the setup wizard's mapping step and the Accounts
+// settings page's third tab. `wizard-accounts-page.tsx` deliberately does the
+// opposite (a read-only summary linking to settings) because the ROLE map is a
+// review, not a task. This one is a task: it is the step between connecting
+// QuickBooks and being able to post, and sending somebody out of the wizard to
+// do it is sending them out of the wizard at its most important moment.
+//
+// 🛑 A confirmation is a WRITE, and the picker only ever offers type-compatible
+// active accounts. Both are conveniences, not authorities: `setAccountIdentity`
+// re-checks existence, active status and classification against the LIVE
+// provider chart before writing, because a picker rendered five minutes ago may
+// be offering an account somebody has since deactivated. Filtering here keeps a
+// person from being offered a choice that would be refused; it does not replace
+// the refusal.
+
+import type { AccountIdentityRow, AccountSuggestionReason } from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { Combobox } from '@auxx/ui/components/combobox'
+import { EmptySection } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
+import { Check, Sparkles, TriangleAlert, X } from 'lucide-react'
+import { api } from '~/trpc/react'
+import { accountTypeColor, accountTypeLabel } from './accounts-types'
+
+/** How a suggestion earned itself, in the words the row shows. */
+const REASON_COPY: Record<AccountSuggestionReason, string> = {
+  number: 'same account number',
+  name: 'same name',
+}
+
+export interface AccountMapListProps {
+  /**
+   * Hide the mapped rows once everything that needs attention is dealt with.
+   * The wizard wants a short list of what is left; settings wants the whole map.
+   */
+  compact?: boolean
+}
+
+/**
+ * Every account in the org's chart and the provider account it points at.
+ *
+ * Three states per row, and they are the whole screen:
+ *
+ * | State | What the reader is being told | What they can do |
+ * | --- | --- | --- |
+ * | `confirmed` | somebody paired these two | unmap it |
+ * | `unmapped` + suggestion | we found a likely match, and here is why | confirm, or pick another |
+ * | `unmapped` | nothing plausible matched | pick one |
+ *
+ * ⚠️ A `confirmed` row whose `liveProviderAccount` is null is the DANGLING case
+ * - the provider account was deleted or deactivated under a confirmed mapping -
+ * and it renders as a repair rather than as a mapping. `G19` requires every
+ * close to refuse on exactly these, so the screen has to lead with them.
+ */
+export function AccountMapList({ compact = false }: AccountMapListProps) {
+  const accountMap = api.ledger.accountMap.useQuery()
+  const utils = api.useUtils()
+
+  const invalidate = async () => {
+    await utils.ledger.accountMap.invalidate()
+  }
+
+  const setAccountIdentity = api.ledger.setAccountIdentity.useMutation({
+    onSuccess: invalidate,
+    onError: (error) => {
+      toastError({ title: 'Error saving the mapping', description: error.message })
+    },
+  })
+
+  const confirmSuggested = api.ledger.confirmSuggestedAccounts.useMutation({
+    onSuccess: async (result) => {
+      await invalidate()
+      if (result.failures.length > 0) {
+        toastError({
+          title: `${result.failures.length} mapping${result.failures.length === 1 ? '' : 's'} could not be saved`,
+          description: result.failures.join(' '),
+        })
+      }
+    },
+    onError: (error) => {
+      toastError({ title: 'Error confirming the suggestions', description: error.message })
+    },
+  })
+
+  if (accountMap.isPending) return <EmptySection loading />
+
+  if (accountMap.isError) {
+    return (
+      <div className='rounded-xl border border-destructive/40 bg-destructive/5 p-3'>
+        <p className='font-medium text-sm'>Could not read the account map</p>
+        <p className='text-muted-foreground text-xs'>{accountMap.error.message}</p>
+      </div>
+    )
+  }
+
+  const { rows, providerAccounts, broken, providerId } = accountMap.data
+
+  // 🛑 Gate on the PROVIDER, not on an empty chart. "Nothing is connected" and
+  // "connected but nothing mapped" are different answers needing different
+  // actions, and collapsing them would tell somebody to map a chart that has
+  // nothing to map against.
+  if (providerId === 'none' || providerAccounts.length === 0) {
+    return (
+      <p className='text-muted-foreground text-sm'>
+        No accounting system is connected, so there is nothing to map yet. Entries are still built,
+        balanced and stored here.
+      </p>
+    )
+  }
+
+  const mapped = rows.filter((row) => row.state === 'confirmed')
+  const suggested = rows.filter((row) => row.suggestion)
+  const visible = compact ? rows.filter((row) => row.state !== 'confirmed' || isBroken(row)) : rows
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <span className='font-medium text-foreground text-sm'>
+          {mapped.length} of {rows.length} accounts mapped
+        </span>
+        {suggested.length > 0 && (
+          <Button
+            variant='outline'
+            size='sm'
+            loading={confirmSuggested.isPending}
+            loadingText='Confirming...'
+            onClick={() => confirmSuggested.mutate()}>
+            <Sparkles />
+            Confirm {suggested.length} suggestion{suggested.length === 1 ? '' : 's'}
+          </Button>
+        )}
+      </div>
+
+      {broken.length > 0 && (
+        <div className='flex items-start gap-2 rounded-xl border border-destructive/40 bg-destructive/5 p-3'>
+          <TriangleAlert className='mt-0.5 size-4 shrink-0 text-destructive' />
+          <div className='min-w-0'>
+            <p className='font-medium text-sm'>
+              {broken.length} mapping{broken.length === 1 ? '' : 's'} no longer valid
+            </p>
+            <p className='text-muted-foreground text-xs'>
+              {broken.join(', ')} point at accounts that have been removed, deactivated or moved to
+              a different section. Every close refuses until they are re-mapped.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {visible.length === 0 ? (
+        <p className='text-muted-foreground text-sm'>
+          Every account is mapped. Nothing here needs a decision.
+        </p>
+      ) : (
+        <div className='overflow-hidden rounded-xl border'>
+          <ul className='flex flex-col'>
+            {visible.map((row) => (
+              <li
+                key={row.account.id}
+                className='flex flex-wrap items-center gap-2 border-b px-3 py-2 text-sm last:border-b-0'>
+                <div className='flex min-w-0 flex-1 items-center gap-2'>
+                  <span className='truncate font-medium'>{row.account.code}</span>
+                  <span className='truncate text-muted-foreground'>{row.account.name}</span>
+                  <Badge variant={accountTypeColor(row.account.accountType)} size='sm'>
+                    {accountTypeLabel(row.account.accountType)}
+                  </Badge>
+                </div>
+
+                <div className='flex min-w-0 flex-1 items-center justify-end gap-2'>
+                  {row.state === 'confirmed' && !isBroken(row) ? (
+                    <>
+                      <span className='min-w-0 truncate text-muted-foreground'>
+                        {row.providerAccountName}
+                      </span>
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        title='Remove this mapping'
+                        disabled={setAccountIdentity.isPending}
+                        onClick={() =>
+                          setAccountIdentity.mutate({
+                            glAccountId: row.account.id,
+                            providerAccountId: null,
+                          })
+                        }>
+                        <X />
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {row.suggestion && (
+                        <Button
+                          variant='outline'
+                          size='sm'
+                          disabled={setAccountIdentity.isPending}
+                          title={`Suggested by ${REASON_COPY[row.suggestion.reason]}`}
+                          onClick={() =>
+                            setAccountIdentity.mutate({
+                              glAccountId: row.account.id,
+                              providerAccountId: row.suggestion?.account.id,
+                            })
+                          }>
+                          <Check />
+                          {row.suggestion.account.fullyQualifiedName}
+                        </Button>
+                      )}
+                      <Combobox
+                        size='sm'
+                        placeholder={row.suggestion ? 'Or pick...' : 'Pick an account'}
+                        emptyText='No compatible account'
+                        value={row.providerAccountId ?? undefined}
+                        options={providerAccounts
+                          .filter(
+                            (account) =>
+                              account.active && account.classification === row.account.accountType
+                          )
+                          .map((account) => ({
+                            value: account.id,
+                            label: account.number
+                              ? `${account.number} · ${account.fullyQualifiedName}`
+                              : account.fullyQualifiedName,
+                          }))}
+                        onChangeValue={(value) =>
+                          setAccountIdentity.mutate({
+                            glAccountId: row.account.id,
+                            providerAccountId: value,
+                          })
+                        }
+                      />
+                    </>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <p className='text-muted-foreground text-xs'>
+        A suggestion is a guess from the account number or name. Confirm it so a later rename or
+        renumber on either side cannot quietly move where a role posts.
+      </p>
+    </div>
+  )
+}
+
+/** A confirmed mapping whose target has gone, been deactivated, or changed section. */
+function isBroken(row: AccountIdentityRow): boolean {
+  if (row.state !== 'confirmed') return false
+  const live = row.liveProviderAccount
+  return !live || !live.active || live.classification !== row.account.accountType
+}

--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -36,7 +36,7 @@ import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { toastError } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils'
-import { Landmark, Lock, Waypoints } from 'lucide-react'
+import { Landmark, Link2, Lock, Waypoints } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -46,17 +46,19 @@ import { useMedia } from '~/hooks/use-media'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
+import { AccountMapList } from './account-map-list'
 import type { ChartDraftHandle } from './accounts-types'
 import { ChartAccountEditor } from './chart-account-editor'
 import { ChartList } from './chart-list'
 import { RoleMapEditor } from './role-map-editor'
 import { RoleMapList } from './role-map-list'
 
-type AccountsTab = 'roles' | 'chart'
+type AccountsTab = 'roles' | 'chart' | 'quickbooks'
 
 const TABS = [
   { value: 'roles', label: 'Roles', icon: Waypoints },
   { value: 'chart', label: 'Chart of accounts', icon: Landmark },
+  { value: 'quickbooks', label: 'QuickBooks', icon: Link2 },
 ]
 
 const BREADCRUMBS = [
@@ -66,7 +68,7 @@ const BREADCRUMBS = [
 ]
 
 const PAGE_DESCRIPTION =
-  'Which account each posting role lands on, and the chart those accounts live in.'
+  'Which account each posting role lands on, the chart those accounts live in, and which account in QuickBooks each one corresponds to.'
 
 export function AccountingAccountsSettingsPage() {
   useRequireCapability(PermissionKey.ledgerView)
@@ -74,7 +76,8 @@ export function AccountingAccountsSettingsPage() {
   const utils = api.useUtils()
 
   const [tab, setTab] = useQueryState('s', { defaultValue: 'roles' as string })
-  const activeTab: AccountsTab = tab === 'chart' ? 'chart' : 'roles'
+  const activeTab: AccountsTab =
+    tab === 'chart' ? 'chart' : tab === 'quickbooks' ? 'quickbooks' : 'roles'
 
   const roleMap = api.ledger.roleMap.useQuery()
   const chart = api.ledger.chartAccounts.useQuery()
@@ -312,7 +315,10 @@ export function AccountingAccountsSettingsPage() {
     )
 
   const selectedId = activeTab === 'roles' ? selectedRole : selectedAccountId
-  const mobileDrawerOpen = !isDesktop && !!selectedId
+  // 🛑 The QuickBooks tab is NOT master-detail. Its rows are edited in place by
+  // a picker, so there is nothing for a right-hand editor pane to hold and a
+  // drawer would open onto an empty panel on mobile.
+  const mobileDrawerOpen = activeTab !== 'quickbooks' && !isDesktop && !!selectedId
 
   return (
     <SettingsPage
@@ -322,33 +328,38 @@ export function AccountingAccountsSettingsPage() {
       subHeader={
         <ResponsiveTabs value={activeTab} onValueChange={handleTabChange} size='sm' items={TABS} />
       }>
-      <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
-        <div className='min-w-0'>
-          {activeTab === 'roles' ? (
-            <RoleMapList
-              rows={roleRows}
-              // 🛑 Gate on the query, never on an empty array. Thirteen rows
-              // reading "Not mapped - every preview refuses until this is set"
-              // is a CLAIM about the org, and rendering it mid-load makes it a
-              // false one.
-              isLoading={roleMap.isPending}
-              selectedRole={selectedRole}
-              onSelect={setSelectedRole}
-              onToggleUnused={handleToggleUnused}
-            />
-          ) : (
-            <ChartList
-              accounts={accounts}
-              isLoading={chart.isPending}
-              selectedId={selectedAccountId}
-              onSelect={handleSelectAccount}
-              rolesByAccountId={rolesByAccountId}
-              draft={chartDraft}
-              onAddDraft={handleAddChartDraft}
-            />
-          )}
+      {activeTab === 'quickbooks' ? (
+        <div className='min-w-0 p-4'>
+          <AccountMapList />
         </div>
-        {/* The column stays STRETCHED and a wrapper inside it does the sticking.
+      ) : (
+        <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
+          <div className='min-w-0'>
+            {activeTab === 'roles' ? (
+              <RoleMapList
+                rows={roleRows}
+                // 🛑 Gate on the query, never on an empty array. Thirteen rows
+                // reading "Not mapped - every preview refuses until this is set"
+                // is a CLAIM about the org, and rendering it mid-load makes it a
+                // false one.
+                isLoading={roleMap.isPending}
+                selectedRole={selectedRole}
+                onSelect={setSelectedRole}
+                onToggleUnused={handleToggleUnused}
+              />
+            ) : (
+              <ChartList
+                accounts={accounts}
+                isLoading={chart.isPending}
+                selectedId={selectedAccountId}
+                onSelect={handleSelectAccount}
+                rolesByAccountId={rolesByAccountId}
+                draft={chartDraft}
+                onAddDraft={handleAddChartDraft}
+              />
+            )}
+          </div>
+          {/* The column stays STRETCHED and a wrapper inside it does the sticking.
             Making the column itself `self-start` would size it to the editor, and
             `border-l` would then stop dead at the editor's bottom edge instead of
             dividing the whole list. A stretched column also gives the sticky child
@@ -358,18 +369,19 @@ export function AccountingAccountsSettingsPage() {
             `sticky top-0 z-20` title/tabs block above - pinning at a hardcoded `0`
             would slide this underneath it. `z-10` matches `FormSaveBar`, i.e.
             deliberately below that header. */}
-        <div className='hidden border-l lg:block'>
-          <div
-            className='lg:sticky lg:z-10 lg:overflow-hidden'
-            style={{
-              top: 'var(--settings-sticky-top, 0px)',
-              maxHeight:
-                'calc(var(--settings-viewport-h, 100vh) - var(--settings-sticky-top, 0px))',
-            }}>
-            {editorContent}
+          <div className='hidden border-l lg:block'>
+            <div
+              className='lg:sticky lg:z-10 lg:overflow-hidden'
+              style={{
+                top: 'var(--settings-sticky-top, 0px)',
+                maxHeight:
+                  'calc(var(--settings-viewport-h, 100vh) - var(--settings-sticky-top, 0px))',
+              }}>
+              {editorContent}
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       <DockableDrawer
         open={mobileDrawerOpen}

--- a/apps/web/src/components/accounting/ui/setup-wizard/accounting-setup-wizard.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/accounting-setup-wizard.tsx
@@ -6,7 +6,9 @@ import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
 import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { useEffect, useRef, useState } from 'react'
 import { api } from '~/trpc/react'
+import { WizardAccountMapPage } from './wizard-account-map-page'
 import { WizardAccountsPage } from './wizard-accounts-page'
+import { WizardConnectPage } from './wizard-connect-page'
 import { WizardCostingPage } from './wizard-costing-page'
 import { WizardDonePage } from './wizard-done-page'
 import { WizardOpeningPage } from './wizard-opening-page'
@@ -14,7 +16,21 @@ import { WizardPeriodPage } from './wizard-period-page'
 import type { WizardLeaveDirection, WizardStepHandle } from './wizard-step-handle'
 import { WizardWelcomePage } from './wizard-welcome-page'
 
-const PAGES = ['welcome', 'period', 'opening', 'costing', 'accounts', 'done'] as const
+// 🛑 `connect` sits immediately before `accountMap`, and the order is the whole
+// point of the pair: the mapping page cannot render a single row until a
+// provider chart exists to map against. `accounts` (the role map) stays BEFORE
+// both, because a role has to point at one of our accounts before that account
+// has anything to be paired with.
+const PAGES = [
+  'welcome',
+  'period',
+  'opening',
+  'costing',
+  'accounts',
+  'connect',
+  'accountMap',
+  'done',
+] as const
 type WizardPage = (typeof PAGES)[number]
 
 const PAGE_TITLES: Record<WizardPage, string> = {
@@ -22,7 +38,9 @@ const PAGE_TITLES: Record<WizardPage, string> = {
   period: 'Accounting period',
   opening: 'Opening balances',
   costing: 'Costing',
-  accounts: 'Account map',
+  accounts: 'Account roles',
+  connect: 'Accounting system',
+  accountMap: 'QuickBooks accounts',
   done: 'Finalize',
 }
 
@@ -32,10 +50,16 @@ export interface AccountingSetupWizardProps {
 }
 
 /**
- * `AccountingSetupWizard` (plans/money/tasks/13-accounting-ui.md section 3.3) - a six-page
- * `DialogNav` wizard covering the four things that have to be true before a month-end entry can
- * legally be posted (accounting period, opening balances, costing, the account map) plus a
- * "finalize" page that freezes the opening baseline.
+ * `AccountingSetupWizard` (plans/money/tasks/13-accounting-ui.md section 3.3) - an eight-page
+ * `DialogNav` wizard covering the things that have to be true before a month-end entry can
+ * legally be posted (accounting period, opening balances, costing, the role map) plus the
+ * `G19` provider pair - connect an accounting system, then say which of ITS accounts each of
+ * ours corresponds to - and a "finalize" page that freezes the opening baseline.
+ *
+ * 🛑 The two `G19` pages are SKIPPABLE, like every other page here. `P1` makes
+ * "nothing connected" a supported configuration rather than an unfinished setup: the ledger is
+ * ours, entries are still built, balanced and persisted, and only the export does not happen.
+ * Neither page may ever block Continue.
  *
  * 🛑 Pages write REAL data through the settings catalog keys, never a wizard-local progress
  * record. That is task 12's scalar-keys decision and it is what lets the settings pages, the
@@ -127,6 +151,12 @@ export function AccountingSetupWizard({ open, onOpenChange }: AccountingSetupWiz
           </DialogNavPage>
           <DialogNavPage value='accounts' size='lg'>
             <WizardAccountsPage />
+          </DialogNavPage>
+          <DialogNavPage value='connect' size='lg'>
+            <WizardConnectPage />
+          </DialogNavPage>
+          <DialogNavPage value='accountMap' size='xl'>
+            <WizardAccountMapPage />
           </DialogNavPage>
           <DialogNavPage value='done' size='md'>
             <WizardDonePage onFinish={finish} />

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-account-map-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-account-map-page.tsx
@@ -1,0 +1,59 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-account-map-page.tsx
+'use client'
+
+// Page 7 of `AccountingSetupWizard` - say which account in QuickBooks each of
+// the org's own accounts corresponds to (decision `G19`, the provider half).
+//
+// 🛑 Unlike `wizard-accounts-page.tsx`, this one EDITS rather than summarising,
+// and the difference is deliberate. The role map is a review - the seed already
+// pointed each role somewhere and the page's job is to let somebody check it.
+// This map starts entirely empty on every new connection, nothing downstream can
+// resolve an account until it is filled in, and sending a person out to a
+// settings page to do the one task that unblocks posting is losing them at the
+// exact moment they were going to finish.
+//
+// 🛑 It still must not BLOCK. `P1` keeps "nothing connected" first class and
+// this page inherits that: with no provider connected it says so and Continue
+// works, because an org that never connects QuickBooks still has a complete
+// internal ledger. What it does not do is pretend the map is done.
+//
+// The editor itself is `AccountMapList`, shared with the Accounts settings tab,
+// so the two cannot drift into disagreeing about what a mapping is.
+
+import { Button } from '@auxx/ui/components/button'
+import { ArrowUpRight } from 'lucide-react'
+import Link from 'next/link'
+import { AccountMapList } from '~/components/accounting/ui/settings/account-map-list'
+
+const MAP_HREF = '/app/accounting/settings/accounts?s=quickbooks'
+
+/**
+ * The account map, in `compact` mode: only the rows that still need a decision,
+ * plus any confirmed mapping that has since broken.
+ *
+ * Compact because a wizard page answers "what is left to do" - a full 29-row
+ * table with twenty already-settled rows buries the four that are not. The
+ * settings tab renders the whole map for the times somebody wants to audit it.
+ */
+export function WizardAccountMapPage() {
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      <p className='text-muted-foreground text-sm'>
+        A journal entry names your accounts; QuickBooks needs its own. Pair them once here and every
+        month-end entry lands in the right place. Nothing is matched automatically - a wrong account
+        still balances, so it would never be caught later.
+      </p>
+
+      <AccountMapList compact />
+
+      <div>
+        <Button variant='outline' size='sm' asChild>
+          <Link href={MAP_HREF}>
+            Open the full account map
+            <ArrowUpRight />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-connect-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-connect-page.tsx
@@ -1,0 +1,129 @@
+// apps/web/src/components/accounting/ui/setup-wizard/wizard-connect-page.tsx
+'use client'
+
+// Page 6 of `AccountingSetupWizard` - connect the accounting system, immediately
+// before the page that maps the chart onto it.
+//
+// 🛑 THIS STEP IS SKIPPABLE, AND IT MUST STAY SKIPPABLE. Decision `P1` makes
+// "nothing connected" a first-class outcome: entries are still built, balanced
+// and persisted, and the result is `not_connected` rather than a failure. So
+// this page has no destructive variant, no "action required", and Continue is
+// never blocked - `quickbooks-section.tsx` carries the same instruction for the
+// same reason, and `getting-started.ts` records that `connect-quickbooks` is
+// deliberately not a checklist goal.
+//
+// What the step DOES earn its place with is ordering. The next page cannot show
+// a single row until a provider chart exists to map against, so connecting has
+// to happen before it rather than in a settings page somebody visits later.
+//
+// 🛑 CONNECT AND MANAGE OPEN `AppSettingsDialog`, they do not navigate - the
+// same call `quickbooks-section.tsx` makes. Sending somebody to
+// `/app/settings/apps/quickbooks` from inside a wizard drops them out of it
+// mid-setup with no way back but the browser button, and the dialog is where the
+// OAuth flow lives anyway.
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { EmptySection } from '@auxx/ui/components/section'
+import { Landmark } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import { useState } from 'react'
+import { InlineAppInstallButton } from '~/components/apps/ui/app-install-button'
+import { AppSettingsDialog } from '~/components/apps/ui/app-settings-dialog'
+import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
+
+/**
+ * Install / connect / connected, as one wizard page.
+ *
+ * Three states off `useAccountingProviderStatus()`, none of them a failure:
+ *
+ * 1. not installed - an install button, and the honest note that skipping is fine
+ * 2. installed, not connected - "Connect QuickBooks" opens the OAuth dialog
+ * 3. connected - which company, and what the next page will do with it
+ */
+export function WizardConnectPage() {
+  const status = useAccountingProviderStatus()
+  const pathname = usePathname()
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      <p className='text-muted-foreground text-sm'>
+        Auxx keeps the ledger either way - entries are built, balanced and stored here whether or
+        not an accounting system is connected. Connecting one lets Auxx also push each month's
+        journal entry to it.
+      </p>
+
+      {status.loading ? (
+        <EmptySection loading />
+      ) : (
+        <div className='flex flex-col gap-2 rounded-xl border p-3'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <Landmark className='size-4 text-muted-foreground' />
+            <span className='font-medium text-sm'>QuickBooks Online</span>
+            {status.connected && (
+              <Badge variant='green' size='sm'>
+                Connected
+              </Badge>
+            )}
+          </div>
+
+          {status.connected ? (
+            <>
+              <p className='text-muted-foreground text-xs'>
+                {status.connection?.label ?? 'Connected'}. On the next page you will say which
+                account in QuickBooks each of your accounts corresponds to.
+              </p>
+              <div>
+                <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
+                  Manage connection
+                </Button>
+              </div>
+            </>
+          ) : status.installed ? (
+            <>
+              <p className='text-muted-foreground text-xs'>
+                Installed, but not yet authorized. Connecting opens QuickBooks to sign in and choose
+                a company.
+              </p>
+              <div>
+                <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>
+                  Connect QuickBooks
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className='text-muted-foreground text-xs'>
+                Not installed. You can add it now, or skip this and set it up later - nothing on the
+                remaining pages depends on it.
+              </p>
+              <div>
+                <InlineAppInstallButton appSlug='quickbooks' />
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <p className='text-muted-foreground text-xs'>
+        Nothing is pushed to QuickBooks until you post a month, and posting is off until you turn it
+        on in Accounting settings.
+      </p>
+
+      {status.installed && status.installationType && (
+        <AppSettingsDialog
+          appSlug='quickbooks'
+          installationType={status.installationType}
+          // The popup-blocked -> full-page-redirect fallback cannot be fully
+          // prevented, so name where to come back to. `/app/accounting` reopens
+          // the wizard gate rather than stranding somebody on `/app`.
+          returnTo={pathname || '/app/accounting'}
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          initialTab={status.connected ? 'about' : 'connections'}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/drawers/cards/part-costing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-costing-card.tsx
@@ -194,39 +194,46 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
           <FieldPanelRow
             title='Standard'
             description='The frozen value every stock movement is stamped with'>
-            <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm tabular-nums'>
-              {standardCost == null ? (
-                <>
+            {/* The value and the action share ONE non-wrapping line, so the Roll
+                button sits at the same right edge whatever the left side says.
+                The bulk-roll hint is a separate block beneath it: inside the flex
+                row it wrapped, and `ms-auto` then pushed the button to the end of
+                whichever line it happened to land on. */}
+            <div className='space-y-1'>
+              <div className='flex min-h-8 items-center gap-2 text-sm tabular-nums'>
+                {standardCost == null ? (
                   <Badge variant='amber' size='xs'>
                     Not rolled
                   </Badge>
-                  {rollWouldValueIt && (
-                    <span className='text-muted-foreground text-xs'>
-                      Roll it here, or{' '}
-                      <Link
-                        href='/app/accounting/settings/general'
-                        className='underline underline-offset-2 hover:text-foreground'>
-                        Settings &rsaquo; Accounting &rsaquo; General
-                      </Link>{' '}
-                      rolls every part at once.
-                    </span>
-                  )}
-                </>
-              ) : (
-                <>
-                  {formatCurrency(standardCost)}
-                  {standardEffectiveAt && (
-                    <span className='text-muted-foreground text-xs'>
-                      set {formatEffectiveDate(standardEffectiveAt)}
-                    </span>
-                  )}
-                </>
+                ) : (
+                  <>
+                    {formatCurrency(standardCost)}
+                    {standardEffectiveAt && (
+                      <span className='text-muted-foreground text-xs'>
+                        set {formatEffectiveDate(standardEffectiveAt)}
+                      </span>
+                    )}
+                  </>
+                )}
+                <RollStandardCostPopover partId={partId}>
+                  <Button variant='outline' size='xs' className='ms-auto'>
+                    Roll
+                  </Button>
+                </RollStandardCostPopover>
+              </div>
+
+              {/* No "roll it here" — the button is one line up. This says only the
+                  thing the button cannot: that 205 parts do not need 205 clicks. */}
+              {rollWouldValueIt && (
+                <p className='text-muted-foreground text-xs'>
+                  <Link
+                    href='/app/accounting/settings/general'
+                    className='underline underline-offset-2 hover:text-foreground'>
+                    Settings &rsaquo; Accounting &rsaquo; General
+                  </Link>{' '}
+                  rolls every part at once.
+                </p>
               )}
-              <RollStandardCostPopover partId={partId}>
-                <Button variant='outline' size='xs' className='ms-auto'>
-                  Roll
-                </Button>
-              </RollStandardCostPopover>
             </div>
           </FieldPanelRow>
 

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -6,9 +6,11 @@ import { PermissionKey } from '@auxx/lib/permissions'
 import {
   ACCOUNT_ROLES,
   buildEntry,
+  confirmSuggestedIdentities,
   createChartAccount,
   GL_ACCOUNT_TYPES,
   getPosting,
+  listAccountIdentities,
   listChartAccounts,
   listChartAccountUsage,
   listClosePeriods,
@@ -22,6 +24,7 @@ import {
   removeChartAccount,
   resolvePeriodLock,
   reverseEntry,
+  setAccountIdentity,
   setRoleAssignment,
   updateChartAccount,
   verifyBooksBalance,
@@ -371,6 +374,74 @@ export const ledgerRouter = createTRPCRouter({
     if (result.isErr()) throw result.error
     return result.value
   }),
+
+  /**
+   * The `G19` account map: every account in the org's chart, the account it is
+   * mapped to in the connected accounting system, and what the matcher would
+   * suggest for the ones without a mapping.
+   *
+   * ⚠️ **This one reaches the provider**, unlike every other read on this
+   * router - it fetches the connected system's chart of accounts over the app
+   * Lambda. Expect it to be slow relative to its neighbours, and do not put it
+   * behind a component that renders on every page.
+   *
+   * An org with nothing connected gets its own chart back with every row
+   * `unmapped` and no provider accounts, which is `P1`'s supported
+   * configuration rather than an error.
+   */
+  accountMap: permissionProcedure(PermissionKey.ledgerView).query(async ({ ctx }) => {
+    const result = await listAccountIdentities(ctx.db, ctx.session.organizationId)
+    if (result.isErr()) throw result.error
+    return result.value
+  }),
+
+  /**
+   * Confirm that one of the org's accounts IS one account in the connected
+   * system, or withdraw that confirmation by sending a null id.
+   *
+   * Gated on `ledgerPost` for `setRoleAssignment`'s reason: this decides which
+   * external account real money lands in, so it belongs with the people trusted
+   * to write to the books rather than everyone who can read them.
+   */
+  setAccountIdentity: permissionProcedure(PermissionKey.ledgerPost)
+    .input(
+      z.object({
+        glAccountId: z.string().min(1),
+        providerAccountId: z.string().min(1).nullish(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const result = await setAccountIdentity(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        glAccountId: input.glAccountId,
+        providerAccountId: input.providerAccountId,
+        actorUserId: ctx.session.userId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Confirm every suggestion at once - the wizard's "accept all" action.
+   *
+   * 🛑 Still a human confirmation under `G19`, not an automatic mapping: the
+   * person has been shown every proposed pairing and the reason for it, and this
+   * is them agreeing to the set. Nothing calls it on connect, and nothing may.
+   *
+   * Reports partial success rather than rolling back. Twenty good mappings and
+   * one refusal is a better outcome than none, and the refusals come back named
+   * so the screen can show which.
+   */
+  confirmSuggestedAccounts: permissionProcedure(PermissionKey.ledgerPost).mutation(
+    async ({ ctx }) => {
+      const result = await confirmSuggestedIdentities(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }
+  ),
 
   /**
    * Write the 29-account default chart, and point each role at the account that

--- a/packages/lib/scripts/probe-qbo-account-resolution.ts
+++ b/packages/lib/scripts/probe-qbo-account-resolution.ts
@@ -1,0 +1,95 @@
+// packages/lib/scripts/probe-qbo-account-resolution.ts
+//
+// Read-only probe: can this org's GL account codes be resolved to accounts in
+// the connected accounting system?
+//
+// Under decision `G19` that question is answered by the ACCOUNT MAP - a person
+// confirms once that one of our accounts IS one of theirs, and the mapping is
+// stored in the `qboAccountId` cell on the `gl_account` instance. There is no
+// matching at post time, so an unmapped account is the only reason a code fails
+// to resolve. This walks the whole chart and reports which are mapped, which are
+// merely suggested, and which have nothing.
+//
+// It WRITES NOTHING, to the provider or to the database.
+//
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/probe-qbo-account-resolution.ts <orgId>
+
+import { database as db } from '@auxx/database'
+import {
+  listAccountIdentities,
+  registerAccountingProvider,
+  setConnectedProviderResolver,
+} from '../src/postings'
+
+const ORG = process.argv[2] ?? ''
+if (!ORG) {
+  console.error('usage: probe-qbo-account-resolution.ts <organizationId>')
+  process.exit(1)
+}
+
+/**
+ * The adapter registers from the APP layer (`apps/web/src/server/accounting-providers.ts`),
+ * which a standalone script never boots - so the script installs the same two
+ * hooks itself. Without this every org resolves to the null provider and the
+ * probe would report "nothing connected" for a connected org.
+ */
+async function registerQuickbooks() {
+  const { createQuickbooksAccountingProvider } = await import(
+    '../src/money/quickbooks/quickbooks-accounting-provider'
+  )
+  registerAccountingProvider('quickbooks', async () => createQuickbooksAccountingProvider())
+  setConnectedProviderResolver(async () => 'quickbooks')
+}
+
+async function main() {
+  await registerQuickbooks()
+
+  const result = await listAccountIdentities(db, ORG)
+  if (result.isErr()) {
+    console.error(`listAccountIdentities refused: ${result.error.message}`)
+    process.exit(1)
+  }
+
+  const { providerId, rows, providerAccounts, broken } = result.value
+  console.log(`\nprovider: ${providerId}`)
+  console.log(`provider chart: ${providerAccounts.length} accounts`)
+  console.log(`auxx chart:     ${rows.length} accounts\n`)
+
+  let mapped = 0
+  let suggested = 0
+  let unmapped = 0
+
+  for (const row of rows) {
+    const label = `${row.account.code.padEnd(8)} ${row.account.name}`
+    if (row.state === 'confirmed') {
+      mapped++
+      const live = row.liveProviderAccount
+      console.log(
+        live
+          ? `  ✅ ${label} -> ${live.fullyQualifiedName} (id ${live.id})`
+          : `  🛑 ${label} -> id ${row.providerAccountId} NO LONGER EXISTS`
+      )
+    } else if (row.suggestion) {
+      suggested++
+      console.log(
+        `  💡 ${label} -> suggested ${row.suggestion.account.fullyQualifiedName} (${row.suggestion.reason})`
+      )
+    } else {
+      unmapped++
+      console.log(`  ❌ ${label} -> nothing mapped, nothing suggested`)
+    }
+  }
+
+  console.log(
+    `\nmapped ${mapped}/${rows.length}   suggested ${suggested}   unmapped ${unmapped}   broken ${broken.length}`
+  )
+  if (broken.length > 0) console.log(`broken: ${broken.join(', ')}`)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('SCRIPT ERROR:', err)
+    process.exit(1)
+  })

--- a/packages/lib/scripts/reconcile-app-fields.ts
+++ b/packages/lib/scripts/reconcile-app-fields.ts
@@ -1,0 +1,50 @@
+// packages/lib/scripts/reconcile-app-fields.ts
+//
+// Provision an installed app's declared fields against its CURRENT catalog.
+//
+// A `auxx dev --once` deploy uploads a new catalog but does NOT provision the
+// fields in it: `reconcileInstallationAppFields` runs on install, on production
+// roll-forward, and when a connection is saved - not on a development deploy. So
+// after adding a field to an app's `defineFields`, a local workspace needs this
+// (or a reconnect, which fires the same reconcile through `saveAppConnection`).
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/reconcile-app-fields.ts <orgId> <appSlug>
+
+import { database } from '@auxx/database'
+import { reconcileInstallationAppFields } from '../src/apps/installations/app-field-provisioning'
+
+const ORG = process.argv[2] ?? ''
+const SLUG = process.argv[3] ?? ''
+
+if (!ORG || !SLUG) {
+  console.error('usage: reconcile-app-fields.ts <organizationId> <appSlug>')
+  process.exit(1)
+}
+
+async function main() {
+  const installations = await database.query.AppInstallation.findMany({
+    where: (t, { eq }) => eq(t.organizationId, ORG),
+    with: { app: { columns: { slug: true } } },
+  })
+  const target = installations.find((row) => row.app?.slug === SLUG)
+  if (!target) {
+    console.error(
+      `'${SLUG}' is not installed for ${ORG}. Installed: ${installations.map((i) => i.app?.slug).join(', ')}`
+    )
+    process.exit(1)
+  }
+
+  console.log(`reconciling ${SLUG} (installation ${target.id})...`)
+  const result = await reconcileInstallationAppFields({
+    appInstallationId: target.id,
+    organizationId: ORG,
+  })
+  console.log(JSON.stringify(result, null, 2))
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('SCRIPT ERROR:', err)
+    process.exit(1)
+  })

--- a/packages/lib/src/money/quickbooks/__tests__/quickbooks-accounting-provider.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/quickbooks-accounting-provider.test.ts
@@ -7,6 +7,7 @@
 // the duplicate-document-number net under the create, and the retry
 // classification the core routes on.
 
+import { ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getOrganizationSetting = vi.fn()
@@ -17,6 +18,22 @@ vi.mock('../../../settings/settings-service', () => ({
 const resolveQuickbooksContext = vi.fn()
 vi.mock('../invoke-quickbooks-tool', () => ({
   resolveQuickbooksContext: (...a: unknown[]) => resolveQuickbooksContext(...a),
+}))
+
+// The `G19` account map replaced AcctNum matching, so resolution now reads two
+// things this file has no database for: OUR chart, and the confirmed
+// `gl_account -> QuickBooks account` map. Both are stubbed; the QuickBooks chart
+// itself still comes through the real `callTool` below, because how this adapter
+// reads a provider chart is exactly what these tests are for.
+const listChartAccounts = vi.fn()
+vi.mock('../../../postings/role-map', () => ({
+  listChartAccounts: (...a: unknown[]) => listChartAccounts(...a),
+}))
+
+const readQuickbooksAccountMap = vi.fn()
+vi.mock('../account-map', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../account-map')>()),
+  readQuickbooksAccountMap: (...a: unknown[]) => readQuickbooksAccountMap(...a),
 }))
 
 import type { PostEntryInput } from '../../../postings/types'
@@ -33,11 +50,55 @@ const DOC_NUMBER = 'AUXX-FUL-20260818'
 /** What the core wrote to `GlPosting.requestId` at claim time. No run salt. */
 const IDEMPOTENCY_KEY = 'a1b2c3d4e5f60718293a4b5c6d7e8f90'
 
+/** The QuickBooks company's chart, in `list_quickbooks_accounts`' own shape. */
 const CHART = [
-  { id: '92', name: 'Inventory', fullyQualifiedName: 'Inventory', acctNum: '1310', active: true },
-  { id: '79', name: 'GRNI', fullyQualifiedName: 'GRNI', acctNum: '2160', active: true },
-  { id: '11', name: 'Retired', fullyQualifiedName: 'Retired', acctNum: '9999', active: false },
+  {
+    id: '92',
+    name: 'Inventory',
+    fullyQualifiedName: 'Inventory',
+    acctNum: '1310',
+    accountType: 'Other Current Asset',
+    classification: 'Asset',
+    active: true,
+  },
+  {
+    id: '79',
+    name: 'GRNI',
+    fullyQualifiedName: 'GRNI',
+    acctNum: '2160',
+    accountType: 'Other Current Liability',
+    classification: 'Liability',
+    active: true,
+  },
+  {
+    id: '11',
+    name: 'Retired',
+    fullyQualifiedName: 'Retired',
+    acctNum: '9999',
+    accountType: 'Other Current Asset',
+    classification: 'Asset',
+    active: false,
+  },
 ]
+
+/** The org's OWN chart - what a posting line's `accountCode` names. */
+const OUR_CHART = [
+  { id: 'gl1310', code: '1310', name: 'Inventory', accountType: 'asset', isActive: true },
+  { id: 'gl2160', code: '2160', name: 'GRNI', accountType: 'liability', isActive: true },
+  { id: 'gl5090', code: '5090', name: 'PPV', accountType: 'expense', isActive: true },
+  { id: 'gl9999', code: '9999', name: 'Retired', accountType: 'asset', isActive: true },
+]
+
+/**
+ * The confirmed map. `5090` is deliberately absent - it is the unmapped account
+ * every "fails closed" test below leans on, and under `G19` unmapped is the
+ * ONLY reason a code fails to resolve. There is no matching left to miss.
+ */
+const ACCOUNT_MAP = new Map([
+  ['gl1310', '92'],
+  ['gl2160', '79'],
+  ['gl9999', '11'],
+])
 
 function baseInput(over: Partial<PostEntryInput> = {}): PostEntryInput {
   return {
@@ -94,6 +155,8 @@ function connect(handlers: Record<string, (inputs: any) => unknown> = {}) {
       callTool,
     },
   })
+  listChartAccounts.mockResolvedValue(ok(OUR_CHART))
+  readQuickbooksAccountMap.mockResolvedValue(new Map(ACCOUNT_MAP))
   return callTool
 }
 
@@ -511,47 +574,66 @@ describe('failure classification', () => {
 })
 
 describe('resolveAccount - the only place a code becomes a provider id', () => {
-  it('resolves an account code by AcctNum', async () => {
+  it('resolves a code through the confirmed account map', async () => {
     connect()
     const result = await provider.resolveAccount(ORG_ID, '1310')
     expect(result._unsafeUnwrap()).toBe('92')
   })
 
-  it('fails closed and names the code when nothing matches', async () => {
+  it('fails closed and names the code when nothing is mapped to it', async () => {
     connect()
     const result = await provider.resolveAccount(ORG_ID, '5090')
 
     expect(result.isErr()).toBe(true)
     expect(result._unsafeUnwrapErr().message).toContain('5090')
+    expect(result._unsafeUnwrapErr().message).toContain('not mapped')
   })
 
-  it('ignores inactive accounts rather than posting to one', async () => {
+  it('refuses a mapping whose target has been deactivated', async () => {
+    // 9999 IS mapped, to account 11, which is inactive. `G19` requires every
+    // resolution to revalidate active status, and the remedy differs from
+    // "unmapped" - so the message has to say which of the two it is.
     connect()
     const result = await provider.resolveAccount(ORG_ID, '9999')
+
     expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('9999')
   })
 
-  it('refuses ambiguity instead of taking the first hit', async () => {
-    resolveQuickbooksContext.mockResolvedValue({
-      connected: true,
-      context: {
-        organizationId: ORG_ID,
-        installationId: 'i',
-        connectionId: 'c',
-        userId: 'u',
-        callTool: vi.fn(async () => ({
-          accounts: [
-            { id: '1', name: 'A', fullyQualifiedName: 'A', acctNum: '1310', active: true },
-            { id: '2', name: 'B', fullyQualifiedName: 'B', acctNum: '1310', active: true },
-          ],
-        })),
-      },
-    })
+  it('refuses a mapping whose target has vanished from the provider chart', async () => {
+    connect()
+    readQuickbooksAccountMap.mockResolvedValue(new Map([['gl1310', 'deleted-99']]))
 
     const result = await provider.resolveAccount(ORG_ID, '1310')
 
     expect(result.isErr()).toBe(true)
-    expect(result._unsafeUnwrapErr().message).toContain('matches 2 QuickBooks accounts')
+    expect(result._unsafeUnwrapErr().message).toContain('no longer exists')
+  })
+
+  it('refuses a mapping that has drifted into the wrong statement section', async () => {
+    // The one failure no downstream reader can catch: an entry posted to a
+    // revenue account instead of an asset one still BALANCES.
+    connect()
+    readQuickbooksAccountMap.mockResolvedValue(new Map([['gl1310', '79']]))
+
+    const result = await provider.resolveAccount(ORG_ID, '1310')
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('liability')
+  })
+
+  it('does NOT fall back to matching account numbers', async () => {
+    // The behaviour this replaced. `1310` appears in both charts with the same
+    // number, and that must no longer be enough on its own - `G19` has no
+    // fallback, because a renumber in QuickBooks would otherwise move where a
+    // role posts with nothing to notice it.
+    connect()
+    readQuickbooksAccountMap.mockResolvedValue(new Map())
+
+    const result = await provider.resolveAccount(ORG_ID, '1310')
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('not mapped')
   })
 
   it('an unresolvable line code fails the post as configuration, before anything is sent', async () => {
@@ -584,6 +666,7 @@ describe('resolveAccount - the only place a code becomes a provider id', () => {
     expect(error.failureClass).toBe('configuration')
     expect(error.retryable).toBe(false)
     expect(error.message).toContain('5090')
+    expect(error.message).toContain('not mapped')
     expect(callTool).not.toHaveBeenCalledWith('create_quickbooks_journal_entry', expect.anything())
     expect(callTool).not.toHaveBeenCalledWith('find_quickbooks_journal_entry', expect.anything())
   })

--- a/packages/lib/src/money/quickbooks/account-map.ts
+++ b/packages/lib/src/money/quickbooks/account-map.ts
@@ -1,0 +1,292 @@
+// packages/lib/src/money/quickbooks/account-map.ts
+
+/**
+ * The `G19` account map, QuickBooks side: which QuickBooks account each of the
+ * org's own `gl_account` rows corresponds to.
+ *
+ * ## Where the mapping actually lives
+ *
+ * In the `qboAccountId` cell on the `gl_account` instance - a hidden,
+ * connection-scoped, `identity: true` field the QuickBooks app declares
+ * (`auxxai-apps/apps/quickbooks/src/fields.ts`), mirrored into `RecordIdentity`
+ * by the platform. Exactly the pattern `qboCustomerId` / `qboItemId` /
+ * `qboInvoiceId` already use, and the one `gl-account-fields.ts` and entity
+ * migration 114 both say in writing is where a provider's account id goes:
+ * "`gl_account` is NOT touched. It stays an `EntityInstance` on purpose -
+ * `RecordIdentity` is keyed on an instance and has no other addressing mode, and
+ * decision `P2` hangs the provider's account id there."
+ *
+ * 🛑 **No `source` or `confirmedAt` anywhere, and that is the design.** `G19`
+ * requires a suggested match to read differently from a confirmed one. Here that
+ * distinction is structural rather than stored: the suggester
+ * (`postings/suggest-account-identities.ts`) is PURE and never writes, and the
+ * only writer is a person confirming in the setup wizard. So a populated cell
+ * IS a confirmation, and an empty one is an open question. Two states, no
+ * columns, and no way for a stored flag to drift out of step with the cell it
+ * describes.
+ *
+ * ## Connection-scoped, which is load-bearing
+ *
+ * A QuickBooks account id means nothing against a different QuickBooks company.
+ * The field is `scope: 'connection'`, so reconnecting to another realm resolves
+ * a different `CustomField` and the previous company's map is neither read nor
+ * silently reused. That is the one property a plain system field on `gl_account`
+ * could not have given.
+ */
+
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq, isNotNull } from 'drizzle-orm'
+import { getCachedEntityDefId } from '../../cache'
+import { FieldValueService } from '../../field-values/field-value-service'
+import { deleteRecordIdentity } from '../../identity'
+import type { ProviderAccount } from '../../postings/client'
+import { QUICKBOOKS_SOURCE, writeQuickbooksIdField } from './identity-field'
+import type { QuickbooksToolContext } from './invoke-quickbooks-tool'
+
+const logger = createScopedLogger('quickbooks-account-map')
+
+/** The app field key holding one `gl_account`'s QuickBooks `Account.Id`. */
+export const QBO_ACCOUNT_ID_FIELD = 'qboAccountId'
+
+/** The system entity type slug the map hangs on. Not the definition's UUID. */
+const GL_ACCOUNT_ENTITY_TYPE = 'gl_account'
+
+/** `list_quickbooks_accounts`, as this module consumes it. */
+interface MappedAccount {
+  id: string
+  name: string
+  fullyQualifiedName: string
+  acctNum: string | null
+  accountType: string
+  classification: string
+  active: boolean
+}
+
+/**
+ * QuickBooks' five-way `Classification` mapped onto ours.
+ *
+ * Both vocabularies are the same five statement sections, so this is a rename
+ * rather than a judgement - which is why an unrecognised value is DROPPED below
+ * rather than defaulted. A provider account whose section we cannot read must
+ * not be offered as a candidate for any of ours: `suggestAccountIdentities`
+ * filters on classification, and a wrong default there would offer a revenue
+ * account for a liability and produce an entry that balances and misstates the
+ * P&L.
+ */
+const CLASSIFICATION: Record<string, ProviderAccount['classification']> = {
+  Asset: 'asset',
+  Liability: 'liability',
+  Equity: 'equity',
+  Revenue: 'revenue',
+  Expense: 'expense',
+}
+
+/**
+ * The connected company's chart, in the provider-neutral shape a mapping screen
+ * reads.
+ *
+ * Inactive accounts are KEPT, unlike `fetchChart`'s posting-path read. A screen
+ * has to be able to say "this mapping points at an account that has been
+ * deactivated", and it cannot say that about a row it never received - which is
+ * `G19`'s revalidation requirement and the difference between a repair prompt
+ * and a silently missing row.
+ */
+export async function listQuickbooksProviderAccounts(
+  ctx: QuickbooksToolContext
+): Promise<ProviderAccount[]> {
+  const result = await ctx.callTool('list_quickbooks_accounts', {})
+  const raw: MappedAccount[] = Array.isArray(result?.accounts) ? result.accounts : []
+
+  const accounts: ProviderAccount[] = []
+  for (const account of raw) {
+    const classification = CLASSIFICATION[account.classification]
+    if (!classification) {
+      logger.warn('Skipping a QuickBooks account with an unreadable classification', {
+        providerAccountId: account.id,
+        classification: account.classification,
+      })
+      continue
+    }
+    accounts.push({
+      id: String(account.id),
+      name: account.name,
+      fullyQualifiedName: account.fullyQualifiedName || account.name,
+      number: account.acctNum?.trim() || null,
+      accountType: account.accountType,
+      classification,
+      active: account.active !== false,
+    })
+  }
+  return accounts
+}
+
+/**
+ * Every `gl_account` in this org that carries a QuickBooks account id, as
+ * `glAccountId -> providerAccountId`.
+ *
+ * 🛑 **One query for the whole chart, never one per account.** The poster
+ * resolves every line of an entry through this map and the settings screen
+ * renders all 29 rows from it; a per-record read (`readQuickbooksIdField`, which
+ * needs a `UnifiedCrudHandler`) would be 29 round trips to answer one question.
+ * Reading `FieldValue` directly is the same shortcut `chart-accounts.ts` takes
+ * for the same reason.
+ *
+ * ⚠️ The join column is `FieldValue.entityId`, NOT `entityInstanceId` - the trap
+ * `plans/money/HANDOFF.md` §3 records because it has been got wrong twice.
+ *
+ * Returns an EMPTY map, not an error, when the field is not provisioned. That is
+ * the state of every org until the QuickBooks app is deployed with
+ * `qboAccountId`, and it means exactly what an unmapped chart means: nothing is
+ * confirmed yet.
+ */
+export async function readQuickbooksAccountMap(params: {
+  organizationId: string
+  installationId: string
+  connectionId: string
+}): Promise<Map<string, string>> {
+  const { organizationId, installationId, connectionId } = params
+
+  const field = await database.query.CustomField.findFirst({
+    where: and(
+      eq(schema.CustomField.organizationId, organizationId),
+      eq(schema.CustomField.appInstallationId, installationId),
+      eq(schema.CustomField.connectionId, connectionId),
+      eq(schema.CustomField.appFieldKey, QBO_ACCOUNT_ID_FIELD)
+    ),
+    columns: { id: true },
+  })
+  if (!field) {
+    logger.debug('qboAccountId is not provisioned for this connection - the map is empty', {
+      organizationId,
+    })
+    return new Map()
+  }
+
+  const rows = await database
+    .select({ entityId: schema.FieldValue.entityId, valueText: schema.FieldValue.valueText })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, field.id),
+        isNotNull(schema.FieldValue.valueText)
+      )
+    )
+
+  const map = new Map<string, string>()
+  for (const row of rows) {
+    const value = row.valueText?.trim()
+    if (value) map.set(row.entityId, value)
+  }
+  return map
+}
+
+/**
+ * Confirm one pairing: this `gl_account` IS that QuickBooks account.
+ *
+ * Writes the cell and mirrors it into `RecordIdentity` through the shared
+ * `writeQuickbooksIdField`, so the account map converges on the same reverse
+ * lookup every other QuickBooks id already uses.
+ *
+ * The caller validates that the pairing is legal - the account exists, the
+ * provider account is active, and the two classifications agree. That check
+ * lives in `postings/suggest-account-identities.ts` because the resolver runs it
+ * too, and one copy is what keeps a mapping the wizard accepted from being one
+ * the close refuses.
+ */
+export async function setQuickbooksAccountMapping(params: {
+  organizationId: string
+  installationId: string
+  connectionId: string
+  glAccountId: string
+  providerAccountId: string
+  userId?: string
+}): Promise<void> {
+  await writeQuickbooksIdField({
+    organizationId: params.organizationId,
+    installationId: params.installationId,
+    connectionId: params.connectionId,
+    appFieldKey: QBO_ACCOUNT_ID_FIELD,
+    entityType: GL_ACCOUNT_ENTITY_TYPE,
+    entityInstanceId: params.glAccountId,
+    externalId: params.providerAccountId,
+    userId: params.userId,
+  })
+}
+
+/**
+ * Withdraw a confirmation - the account goes back to unmapped.
+ *
+ * Both halves are removed, the cell and its `RecordIdentity` mirror, because a
+ * mirror outliving its cell is exactly the drift the reconciler exists to catch
+ * and there is no reason to create work for it here.
+ *
+ * 🛑 Clearing is not the same as pointing the mapping somewhere else, and the UI
+ * must not offer it as "no account". An unmapped account blocks the close with a
+ * message naming it; a mapping quietly cleared during a close is the same
+ * outcome with no sentence attached.
+ */
+export async function clearQuickbooksAccountMapping(params: {
+  organizationId: string
+  installationId: string
+  connectionId: string
+  glAccountId: string
+  userId?: string
+}): Promise<void> {
+  const { organizationId, installationId, connectionId, glAccountId, userId } = params
+
+  const field = await database.query.CustomField.findFirst({
+    where: and(
+      eq(schema.CustomField.organizationId, organizationId),
+      eq(schema.CustomField.appInstallationId, installationId),
+      eq(schema.CustomField.connectionId, connectionId),
+      eq(schema.CustomField.appFieldKey, QBO_ACCOUNT_ID_FIELD)
+    ),
+    columns: { id: true },
+  })
+  if (!field) return
+
+  const service = new FieldValueService(organizationId, userId)
+  await service.deleteValue({
+    recordId: toRecordId(GL_ACCOUNT_ENTITY_TYPE, glAccountId),
+    fieldId: field.id,
+  })
+
+  const removed = await deleteRecordIdentity({
+    organizationId,
+    entityInstanceId: glAccountId,
+    source: QUICKBOOKS_SOURCE,
+    connectionId,
+    appFieldKey: QBO_ACCOUNT_ID_FIELD,
+  })
+  if (!removed.ok) {
+    logger.warn('Cleared the qboAccountId cell but not its RecordIdentity mirror', {
+      organizationId,
+      glAccountId,
+      error: removed.error.message,
+    })
+  }
+}
+
+/**
+ * The `gl_account` definition id, for callers that need to scope a query to the
+ * chart. Null when the org has no chart provisioned at all.
+ */
+export async function getGlAccountDefinitionId(organizationId: string): Promise<string | null> {
+  return (await getCachedEntityDefId(organizationId, GL_ACCOUNT_ENTITY_TYPE)) ?? null
+}
+
+/** Narrow the map to one org's live chart, dropping cells whose account is gone. */
+export function scopeMapToChart(
+  map: ReadonlyMap<string, string>,
+  glAccountIds: readonly string[]
+): Map<string, string> {
+  const live = new Set(glAccountIds)
+  const scoped = new Map<string, string>()
+  for (const [glAccountId, providerAccountId] of map) {
+    if (live.has(glAccountId)) scoped.set(glAccountId, providerAccountId)
+  }
+  return scoped
+}

--- a/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
+++ b/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
@@ -58,17 +58,32 @@
 // does not depend on recognising QuickBooks' duplicate-document-number fault
 // code (see `classifyQuickbooksFailure`).
 
+import { database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { err, ok, type Result } from 'neverthrow'
 import { UnprocessableEntityError } from '../../errors'
-import type { AccountingProvider } from '../../postings/provider'
+import type {
+  AccountingProvider,
+  ClearAccountMappingInput,
+  SetAccountMappingInput,
+} from '../../postings/provider'
+import { listChartAccounts } from '../../postings/role-map'
+import { validateProviderMapping } from '../../postings/suggest-account-identities'
 import {
+  type ChartAccountRow,
   type PostEntryInput,
   type PostEntryResult,
   type PostFailureClass,
+  type ProviderAccount,
   ProviderPostError,
 } from '../../postings/types'
 import { getOrganizationSetting } from '../../settings/settings-service'
+import {
+  clearQuickbooksAccountMapping,
+  listQuickbooksProviderAccounts,
+  readQuickbooksAccountMap,
+  setQuickbooksAccountMapping,
+} from './account-map'
 import { type QuickbooksToolContext, resolveQuickbooksContext } from './invoke-quickbooks-tool'
 
 const logger = createScopedLogger('quickbooks-accounting-provider')
@@ -99,16 +114,6 @@ interface QboJournalLine {
   accountId: string
   accountName?: string
   description?: string
-}
-
-/** The subset of `list_quickbooks_accounts`' mapped account this adapter reads. */
-interface QboAccount {
-  id: string
-  name: string
-  fullyQualifiedName: string
-  /** The account NUMBER ('1310'), not the id. Null when the company has none. */
-  acctNum: string | null
-  active: boolean
 }
 
 /**
@@ -260,59 +265,98 @@ function norm(value: string | null | undefined): string {
 }
 
 /**
- * Fetch the org's QuickBooks chart of accounts, once.
+ * Fetch the org's QuickBooks chart of accounts, once, in the provider-neutral
+ * shape.
  *
  * `Account.AcctNum` is NOT filterable, so `WHERE AcctNum = '1310'` is
- * unsupported by the API - the obvious server-side design does not work and
- * matching has to happen client-side. A chart is a few hundred rows, inside the
- * API's 1000-row page cap, so one `returnAll` fetch is both correct and cheap.
+ * unsupported by the API - which is moot now that resolution runs off the `G19`
+ * account map rather than off account numbers, but is still why the chart is
+ * fetched whole. A chart is a few hundred rows, inside the API's 1000-row page
+ * cap, so one `returnAll` fetch is both correct and cheap.
+ *
+ * Only ACTIVE accounts, unlike `listQuickbooksProviderAccounts`' read for the
+ * mapping screen. A posting cannot use an inactive account, and a mapping that
+ * names one has to be reported as broken rather than silently resolved - which
+ * `validateProviderMapping` does off the absence.
  */
-async function fetchChart(ctx: QuickbooksToolContext): Promise<QboAccount[]> {
-  const result = await ctx.callTool(TOOL_LIST_ACCOUNTS, {})
-  const accounts: QboAccount[] = Array.isArray(result?.accounts) ? result.accounts : []
-  return accounts.filter((a) => a.active !== false)
+async function fetchChart(ctx: QuickbooksToolContext): Promise<ProviderAccount[]> {
+  const accounts = await listQuickbooksProviderAccounts(ctx)
+  return accounts.filter((account) => account.active)
 }
 
 /**
- * Match one account CODE against a fetched chart, failing closed both ways.
+ * Resolve every account CODE an entry names to a QuickBooks account id, through
+ * the `G19` account map.
  *
- * Matches on `AcctNum` alone. A name fallback is deliberately NOT offered: our
- * codes come from `G7`'s seeded chart, our names will not be QuickBooks' names,
- * and a near-miss here puts a wrong account id into a journal entry - which is
- * the single failure a resolver exists to prevent. When a company does not use
- * account numbers at all, every `acctNum` is null and this refuses every code,
- * which is the correct and legible outcome: turn account numbers on, or map the
- * chart.
+ * 🛑 **There is no matching here, and that is the point.** This used to compare
+ * our code against `Account.AcctNum` and take the single hit. That looked like a
+ * sensible resolver and had two fatal properties: QuickBooks ships with account
+ * numbers switched OFF, so every `AcctNum` is null and every code refuses; and
+ * for the companies that do number their accounts, renumbering one in QuickBooks
+ * silently moved where a role posted. `G19` replaced it with a confirmation a
+ * person makes once - "this account IS that account" - which is what the map
+ * below reads.
  *
- * Ambiguity is refused, never resolved by taking the first hit.
+ * Every mapping is revalidated on every entry against the chart just fetched:
+ * the target must still exist, still be active, and still sit in the same
+ * statement section. `G19` requires exactly this at every close, and it is the
+ * whole reason the map stores an id rather than a resolved account.
+ *
+ * ⚠️ Every failure is collected, never thrown on the first one. Fixing a chart
+ * one refused post at a time is how a close slips a day.
  */
-function matchAccount(chart: QboAccount[], code: string): Result<QboAccount, Error> {
-  const needle = norm(code)
-  if (!needle) {
-    return err(new UnprocessableEntityError('An account code is required to resolve an account'))
-  }
+async function resolveMappedAccounts(
+  ctx: QuickbooksToolContext,
+  codes: readonly string[]
+): Promise<Result<Map<string, ProviderAccount>, Error>> {
+  const [chart, ourChart] = await Promise.all([
+    fetchChart(ctx),
+    listChartAccounts(database, ctx.organizationId),
+  ])
+  if (ourChart.isErr()) return err(ourChart.error)
 
-  const hits = chart.filter((a) => norm(a.acctNum) === needle)
-  if (hits.length === 1) return ok(hits[0]!)
+  const map = await readQuickbooksAccountMap({
+    organizationId: ctx.organizationId,
+    installationId: ctx.installationId,
+    connectionId: ctx.connectionId,
+  })
 
-  if (hits.length > 1) {
-    const shown = hits.map((a) => `${a.fullyQualifiedName} (id ${a.id})`).join(', ')
-    return err(
-      new UnprocessableEntityError(
-        `Account code '${code}' matches ${hits.length} QuickBooks accounts: ${shown}. ` +
-          'Give each one a distinct account number in QuickBooks.',
-        { accountCode: code }
+  const byCode = new Map(ourChart.value.map((row) => [norm(row.code), row]))
+  const byProviderId = new Map(chart.map((account) => [account.id, account]))
+
+  const resolved = new Map<string, ProviderAccount>()
+  const problems: string[] = []
+
+  for (const code of new Set(codes)) {
+    const account = byCode.get(norm(code))
+    if (!account) {
+      problems.push(`No account in this organization's chart has the code '${code}'.`)
+      continue
+    }
+
+    const providerAccountId = map.get(account.id)
+    if (!providerAccountId) {
+      problems.push(
+        `${account.code} ${account.name} is not mapped to a QuickBooks account. Map it under Accounting > Settings > Accounts.`
       )
-    )
+      continue
+    }
+
+    const live = byProviderId.get(providerAccountId)
+    const invalid = validateProviderMapping(account, live, providerAccountId)
+    if (invalid) {
+      problems.push(invalid)
+      continue
+    }
+
+    // `validateProviderMapping` returns null only when `live` is present.
+    resolved.set(code, live as ProviderAccount)
   }
 
-  return err(
-    new UnprocessableEntityError(
-      `No active QuickBooks account has account number '${code}'. ` +
-        'Add the number to the matching account in QuickBooks, or change the code in the chart of accounts.',
-      { accountCode: code }
-    )
-  )
+  if (problems.length > 0) {
+    return err(new UnprocessableEntityError(problems.join(' ')))
+  }
+  return ok(resolved)
 }
 
 /**
@@ -362,11 +406,11 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
    *
    * NOT cached across calls. The provider instance is a process-lifetime
    * singleton, so an instance-level cache would keep serving an account id after
-   * the account was renumbered, merged or deactivated in QuickBooks, with no
+   * the mapping was changed or its target deactivated in QuickBooks, with no
    * invalidation signal to act on - and a stale account id in a journal entry
    * balances perfectly and is therefore invisible. {@link postEntry} instead
-   * fetches the chart ONCE per entry and resolves every line against it, which
-   * gets the read amplification down without holding anything between calls.
+   * resolves every line of an entry in ONE call, which gets the read
+   * amplification down without holding anything between calls.
    */
   async resolveAccount(orgId: string, code: string): Promise<Result<string, Error>> {
     const resolved = await resolveQuickbooksContext({ organizationId: orgId })
@@ -380,13 +424,138 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
     }
 
     try {
-      const chart = await fetchChart(resolved.context)
-      return matchAccount(chart, code).map((account) => account.id)
+      const accounts = await resolveMappedAccounts(resolved.context, [code])
+      if (accounts.isErr()) return err(accounts.error)
+      const account = accounts.value.get(code)
+      return account
+        ? ok(account.id)
+        : err(
+            new UnprocessableEntityError(
+              `Account code '${code}' could not be resolved to a QuickBooks account.`,
+              { accountCode: code }
+            )
+          )
     } catch (error) {
       return err(
         new UnprocessableEntityError(
           `Could not read the QuickBooks chart of accounts to resolve '${code}': ${errorMessage(error)}`,
           { accountCode: code }
+        )
+      )
+    }
+  }
+
+  /**
+   * The connected company's chart, for the `G19` mapping screen.
+   *
+   * Inactive accounts INCLUDED - see the interface. This is the only chart read
+   * in this file that keeps them, and the difference is deliberate: a screen has
+   * to be able to say "the account you mapped has been deactivated", which it
+   * cannot do about a row it never received.
+   */
+  async listProviderAccounts(orgId: string): Promise<Result<ProviderAccount[], Error>> {
+    const resolved = await resolveQuickbooksContext({ organizationId: orgId })
+    if (!resolved.connected) return ok([])
+
+    try {
+      return ok(await listQuickbooksProviderAccounts(resolved.context))
+    } catch (error) {
+      return err(
+        new UnprocessableEntityError(
+          `Could not read the QuickBooks chart of accounts: ${errorMessage(error)}`
+        )
+      )
+    }
+  }
+
+  /** The org's confirmed `gl_account -> QuickBooks account` map. */
+  async listAccountMappings(orgId: string): Promise<Result<Map<string, string>, Error>> {
+    const resolved = await resolveQuickbooksContext({ organizationId: orgId })
+    if (!resolved.connected) return ok(new Map())
+
+    try {
+      return ok(
+        await readQuickbooksAccountMap({
+          organizationId: orgId,
+          installationId: resolved.context.installationId,
+          connectionId: resolved.context.connectionId,
+        })
+      )
+    } catch (error) {
+      return err(
+        new UnprocessableEntityError(
+          `Could not read the QuickBooks account map: ${errorMessage(error)}`
+        )
+      )
+    }
+  }
+
+  /**
+   * Record one human confirmation.
+   *
+   * The pairing has already been validated by `postings/account-identities.ts`
+   * against the live chart. This writes it and does not re-decide it.
+   */
+  async setAccountMapping(input: SetAccountMappingInput): Promise<Result<void, Error>> {
+    const resolved = await resolveQuickbooksContext({ organizationId: input.orgId })
+    if (!resolved.connected) {
+      return err(
+        new UnprocessableEntityError(
+          'QuickBooks is not connected, so an account mapping cannot be saved.',
+          { organizationId: input.orgId }
+        )
+      )
+    }
+
+    try {
+      await setQuickbooksAccountMapping({
+        organizationId: input.orgId,
+        installationId: resolved.context.installationId,
+        connectionId: resolved.context.connectionId,
+        glAccountId: input.glAccountId,
+        providerAccountId: input.providerAccountId,
+        userId: input.actorUserId,
+      })
+      return ok(undefined)
+    } catch (error) {
+      return err(
+        new UnprocessableEntityError(`Could not save the account mapping: ${errorMessage(error)}`, {
+          organizationId: input.orgId,
+          glAccountId: input.glAccountId,
+        })
+      )
+    }
+  }
+
+  /** Withdraw one confirmation. The account goes back to unmapped. */
+  async clearAccountMapping(input: ClearAccountMappingInput): Promise<Result<void, Error>> {
+    const resolved = await resolveQuickbooksContext({ organizationId: input.orgId })
+    if (!resolved.connected) {
+      return err(
+        new UnprocessableEntityError(
+          'QuickBooks is not connected, so there is no account mapping to clear.',
+          { organizationId: input.orgId }
+        )
+      )
+    }
+
+    try {
+      await clearQuickbooksAccountMapping({
+        organizationId: input.orgId,
+        installationId: resolved.context.installationId,
+        connectionId: resolved.context.connectionId,
+        glAccountId: input.glAccountId,
+        userId: input.actorUserId,
+      })
+      return ok(undefined)
+    } catch (error) {
+      return err(
+        new UnprocessableEntityError(
+          `Could not clear the account mapping: ${errorMessage(error)}`,
+          {
+            organizationId: input.orgId,
+            glAccountId: input.glAccountId,
+          }
         )
       )
     }
@@ -437,32 +606,35 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
       const ctx = resolved.context
 
       // ── Resolve every account code before anything is written ────────────
-      // Naming every offending code at once matters: fixing them one failed post
-      // at a time is how a close slips a day.
-      const chart = await fetchChart(ctx)
-      const lines: QboJournalLine[] = []
-      const unresolved: string[] = []
-      for (const line of [...input.lines].sort((a, b) => a.sortOrder - b.sortOrder)) {
-        const match = matchAccount(chart, line.accountCode)
-        if (match.isErr()) {
-          unresolved.push(match.error.message)
-          continue
-        }
-        lines.push({
-          amountMinor: line.amount,
-          postingType: line.direction === 'debit' ? 'Debit' : 'Credit',
-          accountId: match.value.id,
-          accountName: match.value.fullyQualifiedName,
-          ...(line.memo && { description: line.memo }),
-        })
-      }
-      if (unresolved.length > 0) {
+      // One call for the whole entry, and it collects every problem rather than
+      // stopping at the first: naming all the offending codes at once matters,
+      // because fixing them one failed post at a time is how a close slips a day.
+      const accounts = await resolveMappedAccounts(
+        ctx,
+        input.lines.map((line) => line.accountCode)
+      )
+      if (accounts.isErr()) {
         return err(
-          new ProviderPostError(unresolved.join(' '), {
+          new ProviderPostError(accounts.error.message, {
             failureClass: 'configuration',
             providerId: QUICKBOOKS_PROVIDER_ID,
           })
         )
+      }
+
+      const lines: QboJournalLine[] = []
+      for (const line of [...input.lines].sort((a, b) => a.sortOrder - b.sortOrder)) {
+        // `resolveMappedAccounts` refuses unless every code resolved, so a miss
+        // here is unreachable rather than merely unlikely.
+        const account = accounts.value.get(line.accountCode)
+        if (!account) continue
+        lines.push({
+          amountMinor: line.amount,
+          postingType: line.direction === 'debit' ? 'Debit' : 'Credit',
+          accountId: account.id,
+          accountName: account.fullyQualifiedName,
+          ...(line.memo && { description: line.memo }),
+        })
       }
 
       // ── Layer 2: query by DocNumber, and HEAL rather than re-post ────────

--- a/packages/lib/src/postings/__tests__/account-identities.test.ts
+++ b/packages/lib/src/postings/__tests__/account-identities.test.ts
@@ -1,0 +1,298 @@
+// packages/lib/src/postings/__tests__/account-identities.test.ts
+//
+// `account-identities.ts` is the provider-NEUTRAL half of the `G19` account map,
+// so what is stubbed here is an `AccountingProvider` rather than QuickBooks.
+// That is the point of the seam: if any of these tests needed to know what a
+// realm id was, the layering would be wrong.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const listChartAccounts = vi.fn()
+vi.mock('../role-map', () => ({
+  listChartAccounts: (...a: unknown[]) => listChartAccounts(...a),
+}))
+
+const resolveAccountingProvider = vi.fn()
+vi.mock('../provider', () => ({
+  resolveAccountingProvider: (...a: unknown[]) => resolveAccountingProvider(...a),
+}))
+
+import type { Database } from '@auxx/database'
+import { err, ok, type Result } from 'neverthrow'
+import {
+  confirmSuggestedIdentities,
+  listAccountIdentities,
+  resolveProviderAccountIds,
+  setAccountIdentity,
+} from '../account-identities'
+import type { ChartAccountRow, ProviderAccount } from '../types'
+
+const ORG = 'org1'
+const db = {} as Database
+
+const OUR_CHART: ChartAccountRow[] = [
+  { id: 'gl1310', code: '1310', name: 'Raw Materials', accountType: 'asset', isActive: true },
+  { id: 'gl2160', code: '2160', name: 'GRNI', accountType: 'liability', isActive: true },
+  { id: 'gl5090', code: '5090', name: 'PPV', accountType: 'expense', isActive: true },
+]
+
+function providerAccount(over: Partial<ProviderAccount> = {}): ProviderAccount {
+  return {
+    id: '92',
+    name: 'Inventory Asset',
+    fullyQualifiedName: 'Inventory Asset',
+    number: '1310',
+    accountType: 'Other Current Asset',
+    classification: 'asset',
+    active: true,
+    ...over,
+  }
+}
+
+const THEIR_CHART = [
+  providerAccount(),
+  providerAccount({ id: '79', name: 'GRNI', number: '2160', classification: 'liability' }),
+]
+
+/** A provider whose four map methods answer from the arguments given. */
+function stubProvider(
+  options: { id?: string; accounts?: ProviderAccount[]; mappings?: Map<string, string> } = {}
+) {
+  // Typed as the interface returns rather than inferred from the happy path, so
+  // a test can hand back an `err` without fighting the inferred `Ok<undefined>`.
+  const set = vi.fn<() => Promise<Result<void, Error>>>(async () => ok(undefined))
+  const clear = vi.fn<() => Promise<Result<void, Error>>>(async () => ok(undefined))
+  const provider = {
+    id: options.id ?? 'stub',
+    accounts: options.accounts ?? THEIR_CHART,
+    listProviderAccounts: async () => ok(options.accounts ?? THEIR_CHART),
+    listAccountMappings: async () => ok(options.mappings ?? new Map<string, string>()),
+    setAccountMapping: set,
+    clearAccountMapping: clear,
+  }
+  resolveAccountingProvider.mockResolvedValue(provider)
+  return { set, clear }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  listChartAccounts.mockResolvedValue(ok(OUR_CHART))
+})
+
+describe('listAccountIdentities - the checklist', () => {
+  it('returns a row for EVERY account, mapped or not', async () => {
+    // The difference between this and a table dump: a screen that rendered only
+    // the mappings that exist could never show what is missing.
+    stubProvider()
+
+    const result = await listAccountIdentities(db, ORG)
+
+    expect(result._unsafeUnwrap().rows).toHaveLength(3)
+    expect(result._unsafeUnwrap().rows.every((row) => row.state === 'unmapped')).toBe(true)
+  })
+
+  it('marks a mapped account confirmed and resolves its live provider account', async () => {
+    stubProvider({ mappings: new Map([['gl1310', '92']]) })
+
+    const row = (await listAccountIdentities(db, ORG))._unsafeUnwrap().rows[0]
+
+    expect(row?.state).toBe('confirmed')
+    expect(row?.providerAccountId).toBe('92')
+    expect(row?.liveProviderAccount?.fullyQualifiedName).toBe('Inventory Asset')
+    // A confirmation cannot also be a suggestion.
+    expect(row?.suggestion).toBeNull()
+  })
+
+  it('attaches a suggestion to an unmapped account, with its reason', async () => {
+    stubProvider()
+
+    const rows = (await listAccountIdentities(db, ORG))._unsafeUnwrap().rows
+
+    expect(rows[0]?.suggestion?.account.id).toBe('92')
+    expect(rows[0]?.suggestion?.reason).toBe('number')
+    // 5090 has no counterpart at all, so it gets a row and no proposal.
+    expect(rows[2]?.suggestion).toBeNull()
+  })
+
+  it('reports a mapping whose target has vanished as broken, not as mapped', async () => {
+    stubProvider({ mappings: new Map([['gl1310', 'deleted-99']]) })
+
+    const map = (await listAccountIdentities(db, ORG))._unsafeUnwrap()
+
+    expect(map.broken).toEqual(['1310'])
+    expect(map.rows[0]?.liveProviderAccount).toBeNull()
+  })
+
+  it('reports a mapping that has drifted into another section as broken', async () => {
+    stubProvider({ mappings: new Map([['gl1310', '79']]) })
+
+    expect((await listAccountIdentities(db, ORG))._unsafeUnwrap().broken).toEqual(['1310'])
+  })
+
+  it('gives an org with nothing connected its own chart, unmapped', async () => {
+    // `P1`: a chart nobody exports is still a chart, and this is not an error.
+    stubProvider({ id: 'none', accounts: [] })
+
+    const map = (await listAccountIdentities(db, ORG))._unsafeUnwrap()
+
+    expect(map.providerId).toBe('none')
+    expect(map.rows).toHaveLength(3)
+    expect(map.providerAccounts).toEqual([])
+    expect(map.rows.every((row) => row.suggestion === null)).toBe(true)
+  })
+})
+
+describe('setAccountIdentity - the confirmation', () => {
+  it('writes a legal pairing through the provider', async () => {
+    const { set } = stubProvider()
+
+    const result = await setAccountIdentity(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1310',
+      providerAccountId: '92',
+      actorUserId: 'u1',
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(set).toHaveBeenCalledWith({
+      orgId: ORG,
+      glAccountId: 'gl1310',
+      providerAccountId: '92',
+      actorUserId: 'u1',
+    })
+  })
+
+  it('refuses a pairing across statement sections, before writing', async () => {
+    // The one misposting nothing downstream can detect, because it balances.
+    const { set } = stubProvider()
+
+    const result = await setAccountIdentity(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1310',
+      providerAccountId: '79',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('liability')
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('refuses an inactive provider account, before writing', async () => {
+    const { set } = stubProvider({ accounts: [providerAccount({ active: false })] })
+
+    const result = await setAccountIdentity(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1310',
+      providerAccountId: '92',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('not active')
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('validates against the LIVE chart, not against what a screen was showing', async () => {
+    const { set } = stubProvider()
+
+    const result = await setAccountIdentity(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1310',
+      providerAccountId: 'stale-id-from-an-old-render',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('Refresh')
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('refuses an account that is not in this org', async () => {
+    const { set } = stubProvider()
+
+    const result = await setAccountIdentity(db, {
+      organizationId: ORG,
+      glAccountId: 'someone-elses',
+      providerAccountId: '92',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('clears the mapping when the provider account id is null', async () => {
+    const { set, clear } = stubProvider()
+
+    const result = await setAccountIdentity(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1310',
+      providerAccountId: null,
+    })
+
+    expect(result._unsafeUnwrap().state).toBe('unmapped')
+    expect(clear).toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+  })
+})
+
+describe('confirmSuggestedIdentities - accept all', () => {
+  it('confirms every suggestion and counts them', async () => {
+    const { set } = stubProvider()
+
+    const result = await confirmSuggestedIdentities(db, { organizationId: ORG })
+
+    expect(result._unsafeUnwrap().confirmed).toBe(2)
+    expect(result._unsafeUnwrap().failures).toEqual([])
+    expect(set).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports partial success rather than rolling the good ones back', async () => {
+    // Nineteen good mappings and one refusal beats none, and the refusal has to
+    // come back named so the screen can say which.
+    const { set } = stubProvider()
+    set.mockImplementationOnce(async () => err(new Error('QuickBooks said no')))
+
+    const result = await confirmSuggestedIdentities(db, { organizationId: ORG })
+
+    expect(result._unsafeUnwrap().confirmed).toBe(1)
+    expect(result._unsafeUnwrap().failures[0]).toContain('1310')
+  })
+})
+
+describe('resolveProviderAccountIds - the poster read', () => {
+  it('resolves confirmed codes to provider ids', async () => {
+    stubProvider({ mappings: new Map([['gl1310', '92']]) })
+
+    const result = await resolveProviderAccountIds(db, ORG, ['1310'])
+
+    expect(result._unsafeUnwrap().get('1310')).toBe('92')
+  })
+
+  it('refuses an unmapped code and names the screen that fixes it', async () => {
+    stubProvider()
+
+    const result = await resolveProviderAccountIds(db, ORG, ['1310'])
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('not mapped')
+    expect(result._unsafeUnwrapErr().message).toContain('Settings')
+  })
+
+  it('collects EVERY problem rather than stopping at the first', async () => {
+    // Fixing a chart one refused post at a time is how a close slips a day.
+    stubProvider()
+
+    const result = await resolveProviderAccountIds(db, ORG, ['1310', '2160', '5090'])
+
+    const message = result._unsafeUnwrapErr().message
+    expect(message).toContain('1310')
+    expect(message).toContain('2160')
+    expect(message).toContain('5090')
+  })
+
+  it('refuses a code that is not in the org chart at all', async () => {
+    stubProvider()
+
+    const result = await resolveProviderAccountIds(db, ORG, ['9999'])
+
+    expect(result._unsafeUnwrapErr().message).toContain("code '9999'")
+  })
+})

--- a/packages/lib/src/postings/__tests__/post-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/post-entry.test.ts
@@ -414,6 +414,21 @@ beforeEach(() => {
   __resetAccountingProvidersForTests()
 })
 
+/**
+ * The `G19` account-map half of `AccountingProvider`, stubbed to "nothing
+ * mapped, nothing to map".
+ *
+ * `postEntry`'s own path never touches these four - resolution lives inside an
+ * adapter - so a posting test states them once here rather than restating an
+ * empty chart in every stub it builds.
+ */
+const NO_ACCOUNT_MAP = {
+  listProviderAccounts: async () => ok([]),
+  listAccountMappings: async () => ok(new Map<string, string>()),
+  setAccountMapping: async () => ok(undefined),
+  clearAccountMapping: async () => ok(undefined),
+}
+
 /** A provider that records what it was handed and answers however the test says. */
 function stubProvider(
   answer: (input: PostEntryInput) => Result<PostEntryResult, Error>,
@@ -422,6 +437,7 @@ function stubProvider(
   const seen: PostEntryInput[] = []
   registerAccountingProvider(id, async () => ({
     id,
+    ...NO_ACCOUNT_MAP,
     resolveAccount: async (_org: string, code: string) => ok(code),
     postEntry: async (input: PostEntryInput) => {
       seen.push(input)
@@ -907,6 +923,7 @@ describe('the provider outcome', () => {
     const fake = createFakeDb(FULL_CHART)
     registerAccountingProvider('explodes', async () => ({
       id: 'explodes',
+      ...NO_ACCOUNT_MAP,
       resolveAccount: async (_org: string, code: string) => ok(code),
       postEntry: async () => {
         throw new Error('boom')

--- a/packages/lib/src/postings/__tests__/suggest-account-identities.test.ts
+++ b/packages/lib/src/postings/__tests__/suggest-account-identities.test.ts
@@ -1,0 +1,200 @@
+// packages/lib/src/postings/__tests__/suggest-account-identities.test.ts
+//
+// The `G19` matcher is pure, so this file needs no doubles of any kind - both
+// charts are arrays and every rule below is argued for in the module header.
+//
+// What is actually being defended here is the ambiguity rule. A suggestion that
+// silently takes the first of two candidates produces a mapping a person will
+// confirm without looking, and a wrong account id in a journal entry BALANCES -
+// so there is no reader downstream that could ever catch it.
+
+import { describe, expect, it } from 'vitest'
+import {
+  isMappableTo,
+  suggestAccountIdentities,
+  validateProviderMapping,
+} from '../suggest-account-identities'
+import type { ChartAccountRow, ProviderAccount } from '../types'
+
+function ours(over: Partial<ChartAccountRow> = {}): ChartAccountRow {
+  return {
+    id: 'gl1',
+    code: '1310',
+    name: 'Raw Materials',
+    accountType: 'asset',
+    isActive: true,
+    ...over,
+  }
+}
+
+function theirs(over: Partial<ProviderAccount> = {}): ProviderAccount {
+  return {
+    id: '92',
+    name: 'Inventory Asset',
+    fullyQualifiedName: 'Inventory Asset',
+    number: null,
+    accountType: 'Other Current Asset',
+    classification: 'asset',
+    active: true,
+    ...over,
+  }
+}
+
+describe('matching by account number', () => {
+  it('pairs two accounts carrying the same number', () => {
+    const [suggestion] = suggestAccountIdentities([ours()], [theirs({ number: '1310' })])
+
+    expect(suggestion?.glAccountId).toBe('gl1')
+    expect(suggestion?.account.id).toBe('92')
+    expect(suggestion?.reason).toBe('number')
+  })
+
+  it('ignores surrounding whitespace and case on both sides', () => {
+    const [suggestion] = suggestAccountIdentities(
+      [ours({ code: ' 1310 ' })],
+      [theirs({ number: '1310' })]
+    )
+    expect(suggestion?.reason).toBe('number')
+  })
+
+  it('offers nothing when two provider accounts share the number', () => {
+    // The whole point. Two candidates means the evidence does not distinguish
+    // them, and answering anyway hides that behind something that looks decided.
+    const suggestions = suggestAccountIdentities(
+      [ours()],
+      [theirs({ id: '1', number: '1310' }), theirs({ id: '2', number: '1310' })]
+    )
+    expect(suggestions).toHaveLength(0)
+  })
+
+  it('does not treat two blank numbers as a match', () => {
+    // The ordinary QuickBooks case: numbering is off, so every `number` is null.
+    // Reading that as "they agree" would map the entire chart at random.
+    const suggestions = suggestAccountIdentities(
+      [ours({ code: '' })],
+      [theirs({ number: null }), theirs({ id: '93', number: null })]
+    )
+    expect(suggestions).toHaveLength(0)
+  })
+})
+
+describe('matching by name', () => {
+  it('pairs on an exact name when no number matches', () => {
+    const [suggestion] = suggestAccountIdentities(
+      [ours({ name: 'Inventory Asset' })],
+      [theirs({ number: '9999' })]
+    )
+    expect(suggestion?.reason).toBe('name')
+  })
+
+  it('matches the fully-qualified name for a nested provider account', () => {
+    const [suggestion] = suggestAccountIdentities(
+      [ours({ accountType: 'revenue', name: 'Sales:Product Income' })],
+      [
+        theirs({
+          classification: 'revenue',
+          name: 'Product Income',
+          fullyQualifiedName: 'Sales:Product Income',
+        }),
+      ]
+    )
+    expect(suggestion?.reason).toBe('name')
+  })
+
+  it('collapses punctuation and spacing rather than demanding an exact string', () => {
+    const [suggestion] = suggestAccountIdentities(
+      [ours({ accountType: 'expense', name: 'COGS - Product Cost' })],
+      [theirs({ classification: 'expense', name: 'Cogs   Product Cost' })]
+    )
+    expect(suggestion?.reason).toBe('name')
+  })
+
+  it('offers nothing when two provider accounts share the name', () => {
+    const suggestions = suggestAccountIdentities(
+      [ours({ name: 'Inventory Asset' })],
+      [theirs({ id: '1' }), theirs({ id: '2' })]
+    )
+    expect(suggestions).toHaveLength(0)
+  })
+
+  it('prefers the number match over the name match', () => {
+    const [suggestion] = suggestAccountIdentities(
+      [ours({ name: 'Inventory Asset' })],
+      [theirs({ id: 'by-name' }), theirs({ id: 'by-number', name: 'Other', number: '1310' })]
+    )
+    expect(suggestion?.account.id).toBe('by-number')
+    expect(suggestion?.reason).toBe('number')
+  })
+})
+
+describe('what is never offered', () => {
+  it('never crosses statement sections, however strong the other evidence', () => {
+    // A liability and a revenue account both numbered 2160 is a filter case, not
+    // a tiebreak: posting to the wrong section balances and misstates the P&L.
+    const suggestions = suggestAccountIdentities(
+      [ours({ accountType: 'liability', code: '2160' })],
+      [theirs({ classification: 'revenue', number: '2160' })]
+    )
+    expect(suggestions).toHaveLength(0)
+  })
+
+  it('never offers an inactive provider account', () => {
+    const suggestions = suggestAccountIdentities(
+      [ours()],
+      [theirs({ number: '1310', active: false })]
+    )
+    expect(suggestions).toHaveLength(0)
+  })
+
+  it('skips accounts somebody has already mapped', () => {
+    // A suggestion must never appear to compete with a confirmation.
+    const suggestions = suggestAccountIdentities(
+      [ours()],
+      [theirs({ number: '1310' })],
+      new Set(['gl1'])
+    )
+    expect(suggestions).toHaveLength(0)
+  })
+
+  it('returns nothing at all when the provider chart is empty', () => {
+    expect(suggestAccountIdentities([ours()], [])).toHaveLength(0)
+  })
+})
+
+describe('validateProviderMapping - the check every close re-runs', () => {
+  it('passes a live, active, type-compatible mapping', () => {
+    expect(validateProviderMapping(ours(), theirs(), '92')).toBeNull()
+  })
+
+  it('names the account when the provider account has gone', () => {
+    const message = validateProviderMapping(ours(), null, '92')
+    expect(message).toContain('1310')
+    expect(message).toContain('no longer exists')
+  })
+
+  it('distinguishes deactivated from missing', () => {
+    // Different remedies: reactivate it there, versus re-map it here.
+    const message = validateProviderMapping(ours(), theirs({ active: false }), '92')
+    expect(message).toContain('deactivated')
+  })
+
+  it('catches a mapping that has drifted into another section', () => {
+    const message = validateProviderMapping(ours(), theirs({ classification: 'revenue' }), '92')
+    expect(message).toContain('revenue')
+    expect(message).toContain('balance')
+  })
+})
+
+describe('isMappableTo - what a picker may offer', () => {
+  it('accepts an active account in the same section', () => {
+    expect(isMappableTo(ours(), theirs())).toBe(true)
+  })
+
+  it('rejects an inactive one', () => {
+    expect(isMappableTo(ours(), theirs({ active: false }))).toBe(false)
+  })
+
+  it('rejects one in another section', () => {
+    expect(isMappableTo(ours(), theirs({ classification: 'expense' }))).toBe(false)
+  })
+})

--- a/packages/lib/src/postings/account-identities.ts
+++ b/packages/lib/src/postings/account-identities.ts
@@ -1,0 +1,378 @@
+// packages/lib/src/postings/account-identities.ts
+
+/**
+ * `G19`'s account map, read and written: which account in the CONNECTED
+ * accounting system each of the org's own accounts corresponds to.
+ *
+ * `role-map.ts` answers the hop above this one - which of MY accounts fulfils
+ * each posting role. Together they are the whole chain:
+ *
+ *     posting role  ->  auxx gl_account  ->  provider account
+ *      (role-map.ts)       (this file)
+ *
+ * ## Nothing here knows what QuickBooks is
+ *
+ * Every provider-shaped fact arrives through the `AccountingProvider` interface
+ * - the chart through `listProviderAccounts`, the mapping through
+ * `listAccountMappings`, the write through `setAccountMapping`. That is decision
+ * `P1` applied to the setup surface rather than to the poster: the mapping
+ * screen has to work the same way for the second accounting system as for the
+ * first, and a module that imported the QuickBooks adapter to read a chart would
+ * quietly make QuickBooks the only one that could ever be mapped.
+ *
+ * ## The list is a CHECKLIST
+ *
+ * {@link listAccountIdentities} returns a row for EVERY live account in the
+ * chart, mapped or not - `role-map.ts`'s rule, for `role-map.ts`'s reason. The
+ * question this screen exists to answer is "what is still unmapped", and a list
+ * of the rows that happen to exist could never show it.
+ *
+ * No permission checks here. The router asserts (`docs/lib-module-guide.md` §6).
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError, UnprocessableEntityError } from '../errors'
+import { resolveAccountingProvider } from './provider'
+import { listChartAccounts } from './role-map'
+import {
+  classificationArticle,
+  isMappableTo,
+  suggestAccountIdentities,
+} from './suggest-account-identities'
+import type { AccountIdentityRow, ChartAccountRow, ProviderAccount } from './types'
+
+const logger = createScopedLogger('postings:account-identities')
+
+/** The chart, the provider's chart, and every row's mapping state. */
+export interface AccountIdentityMap {
+  /** The connected provider's id, or `'none'`. */
+  providerId: string
+  /** One row per live `gl_account`, mapped or not. */
+  rows: AccountIdentityRow[]
+  /** The provider's own chart, for a picker. Empty when nothing is connected. */
+  providerAccounts: ProviderAccount[]
+  /**
+   * Rows that are mapped but whose mapping no longer validates - the target was
+   * deleted, deactivated, or its classification no longer agrees.
+   *
+   * Surfaced separately because `G19` requires a close to refuse on exactly
+   * these, and a screen has to be able to lead with them rather than leave them
+   * to be found by scrolling.
+   */
+  broken: string[]
+}
+
+/**
+ * Every account in the org's chart, its provider mapping, and what the matcher
+ * would suggest for the ones without one.
+ *
+ * Three reads, never N+1: our chart, their chart, and the mapping table. The
+ * suggester then runs purely over the first two.
+ *
+ * An org with nothing connected gets its chart back with every row `unmapped`,
+ * no suggestions and no provider accounts. That is `P1`'s supported
+ * configuration and not an error - the ledger is ours, and a chart nobody
+ * exports is still a chart.
+ */
+export async function listAccountIdentities(
+  db: Database,
+  organizationId: string
+): Promise<Result<AccountIdentityMap, Error>> {
+  try {
+    const chart = await listChartAccounts(db, organizationId)
+    if (chart.isErr()) return err(chart.error)
+    const accounts = chart.value
+
+    const provider = await resolveAccountingProvider(organizationId)
+
+    const [providerChart, mappings] = await Promise.all([
+      provider.listProviderAccounts(organizationId),
+      provider.listAccountMappings(organizationId),
+    ])
+    if (providerChart.isErr()) return err(providerChart.error)
+    if (mappings.isErr()) return err(mappings.error)
+
+    const providerAccounts = providerChart.value
+    const byProviderId = new Map(providerAccounts.map((a) => [a.id, a]))
+    const map = mappings.value
+
+    const suggestions = new Map(
+      suggestAccountIdentities(accounts, providerAccounts, new Set([...map.keys()])).map((s) => [
+        s.glAccountId,
+        s,
+      ])
+    )
+
+    const broken: string[] = []
+    const rows = accounts.map<AccountIdentityRow>((account) => {
+      const providerAccountId = map.get(account.id) ?? null
+
+      if (!providerAccountId) {
+        const suggestion = suggestions.get(account.id)
+        return {
+          account,
+          state: 'unmapped',
+          providerAccountId: null,
+          providerAccountName: null,
+          providerAccountNumber: null,
+          source: null,
+          confirmedAt: null,
+          liveProviderAccount: null,
+          suggestion: suggestion
+            ? { account: suggestion.account, reason: suggestion.reason }
+            : null,
+        }
+      }
+
+      // A populated mapping IS a confirmation - the suggester never writes, so
+      // the only thing that could have put this here is a person. See
+      // `money/quickbooks/account-map.ts` on why there is no stored flag.
+      const live = byProviderId.get(providerAccountId) ?? null
+      if (!live || !live.active || live.classification !== account.accountType) {
+        broken.push(account.code)
+      }
+
+      return {
+        account,
+        state: 'confirmed',
+        providerAccountId,
+        providerAccountName: live?.fullyQualifiedName ?? null,
+        providerAccountNumber: live?.number ?? null,
+        source: 'human',
+        confirmedAt: null,
+        liveProviderAccount: live,
+        suggestion: null,
+      }
+    })
+
+    return ok({ providerId: provider.id, rows, providerAccounts, broken })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to list the account map', { error, organizationId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/** What one account-map edit is asking for. */
+export interface SetAccountIdentityOptions {
+  organizationId: string
+  /** The `gl_account` instance to map. */
+  glAccountId: string
+  /** The provider account to map it to, or null to withdraw the mapping. */
+  providerAccountId?: string | null
+  actorUserId?: string
+}
+
+/**
+ * Confirm one pairing, or withdraw one.
+ *
+ * ## What is validated before anything is written
+ *
+ * - the account exists in THIS org and is not archived
+ * - the provider account exists in the connected system's live chart
+ * - it is active
+ * - its classification matches ours
+ *
+ * The last two are the ones that matter, and they are checked HERE rather than
+ * only at close time for `setRoleAssignment`'s reason, one level down: a mapping
+ * that only fails at a close fails on the night of the close. An entry posted to
+ * a provider account in the wrong statement section BALANCES, so no reader
+ * downstream can catch it - the confirmation step is the last place a person
+ * can.
+ *
+ * 🛑 The check runs against the LIVE provider chart, not against whatever the
+ * screen was showing. A picker rendered five minutes ago may be offering an
+ * account somebody has since deactivated in QuickBooks.
+ */
+export async function setAccountIdentity(
+  db: Database,
+  options: SetAccountIdentityOptions
+): Promise<Result<AccountIdentityRow, Error>> {
+  const { organizationId, glAccountId, actorUserId } = options
+  const providerAccountId = options.providerAccountId?.trim() || null
+
+  try {
+    const chart = await listChartAccounts(db, organizationId)
+    if (chart.isErr()) return err(chart.error)
+
+    const account = chart.value.find((row) => row.id === glAccountId)
+    if (!account) {
+      throw new UnprocessableEntityError(
+        `Account ${glAccountId} does not exist in this organization, or has been archived.`,
+        { organizationId, glAccountId }
+      )
+    }
+
+    const provider = await resolveAccountingProvider(organizationId)
+
+    if (!providerAccountId) {
+      const cleared = await provider.clearAccountMapping({
+        orgId: organizationId,
+        glAccountId,
+        actorUserId,
+      })
+      if (cleared.isErr()) return err(cleared.error)
+      return ok(unmappedRow(account))
+    }
+
+    const providerChart = await provider.listProviderAccounts(organizationId)
+    if (providerChart.isErr()) return err(providerChart.error)
+
+    const target = providerChart.value.find((row) => row.id === providerAccountId)
+    if (!target) {
+      throw new UnprocessableEntityError(
+        `No account with id ${providerAccountId} exists in the connected accounting system. Refresh the chart and choose again.`,
+        { organizationId, glAccountId, providerAccountId }
+      )
+    }
+
+    if (!isMappableTo(account, target)) {
+      throw new UnprocessableEntityError(
+        target.active
+          ? `${account.code} ${account.name} is ${classificationArticle(account.accountType)} account, but '${target.fullyQualifiedName}' is ${target.classification}. Posting to it would balance and still be wrong.`
+          : `'${target.fullyQualifiedName}' is not active in the connected accounting system. Reactivate it there, or choose another account.`,
+        { organizationId, glAccountId, providerAccountId }
+      )
+    }
+
+    const written = await provider.setAccountMapping({
+      orgId: organizationId,
+      glAccountId,
+      providerAccountId,
+      actorUserId,
+    })
+    if (written.isErr()) return err(written.error)
+
+    return ok({
+      account,
+      state: 'confirmed',
+      providerAccountId,
+      providerAccountName: target.fullyQualifiedName,
+      providerAccountNumber: target.number,
+      source: 'human',
+      confirmedAt: new Date().toISOString(),
+      liveProviderAccount: target,
+      suggestion: null,
+    })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to set an account mapping', { error, organizationId, glAccountId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/**
+ * Confirm every suggestion in one go - the wizard's "accept all" action.
+ *
+ * ⚠️ This is still a human confirmation under `G19`, not an automatic mapping:
+ * the person is shown every proposed pairing and its reason, and this is them
+ * agreeing to the set. That is why it lives behind an explicit button and why
+ * nothing calls it on connect.
+ *
+ * Partial success is reported, never rolled back. Nineteen good mappings and one
+ * refusal is a better outcome than none, and the refusals are returned so the
+ * screen can name them.
+ */
+export async function confirmSuggestedIdentities(
+  db: Database,
+  options: { organizationId: string; actorUserId?: string }
+): Promise<Result<{ confirmed: number; failures: string[] }, Error>> {
+  const listed = await listAccountIdentities(db, options.organizationId)
+  if (listed.isErr()) return err(listed.error)
+
+  let confirmed = 0
+  const failures: string[] = []
+
+  for (const row of listed.value.rows) {
+    if (!row.suggestion) continue
+    const result = await setAccountIdentity(db, {
+      organizationId: options.organizationId,
+      glAccountId: row.account.id,
+      providerAccountId: row.suggestion.account.id,
+      actorUserId: options.actorUserId,
+    })
+    if (result.isErr()) failures.push(`${row.account.code}: ${result.error.message}`)
+    else confirmed++
+  }
+
+  return ok({ confirmed, failures })
+}
+
+/**
+ * Resolve one account CODE to the connected provider's own account id.
+ *
+ * 🛑 **The poster's read, and the only one.** `G19` has no default-account
+ * fallback and this function has no matching logic of any kind: an account is
+ * either confirmed against a provider account or it is not, and "not" refuses
+ * with a sentence naming the account and the screen that fixes it. Matching on
+ * account NUMBER at post time - what this replaced - looks like a convenience
+ * and is a silent misposting waiting for somebody to renumber their chart.
+ */
+export async function resolveProviderAccountIds(
+  db: Database,
+  organizationId: string,
+  codes: readonly string[]
+): Promise<Result<Map<string, string>, Error>> {
+  const listed = await listAccountIdentities(db, organizationId)
+  if (listed.isErr()) return err(listed.error)
+
+  const byCode = new Map(listed.value.rows.map((row) => [row.account.code, row]))
+  const resolved = new Map<string, string>()
+  const problems: string[] = []
+
+  for (const code of new Set(codes)) {
+    const row = byCode.get(code)
+    if (!row) {
+      problems.push(`No account in this organization's chart has the code '${code}'.`)
+      continue
+    }
+    if (!row.providerAccountId) {
+      problems.push(
+        `${code} ${row.account.name} is not mapped to an account in the connected accounting system. Map it under Accounting > Settings > Accounts.`
+      )
+      continue
+    }
+    const live = row.liveProviderAccount
+    if (!live) {
+      problems.push(
+        `${code} ${row.account.name} is mapped to an account that no longer exists in the connected accounting system. Re-map it.`
+      )
+      continue
+    }
+    if (!live.active) {
+      problems.push(
+        `${code} ${row.account.name} is mapped to '${live.fullyQualifiedName}', which has been deactivated. Reactivate it or map ${code} elsewhere.`
+      )
+      continue
+    }
+    if (live.classification !== row.account.accountType) {
+      problems.push(
+        `${code} ${row.account.name} is ${classificationArticle(row.account.accountType)} account but is mapped to '${live.fullyQualifiedName}', which is ${live.classification}.`
+      )
+      continue
+    }
+    resolved.set(code, row.providerAccountId)
+  }
+
+  if (problems.length > 0) {
+    return err(new UnprocessableEntityError(problems.join(' '), { organizationId }))
+  }
+  return ok(resolved)
+}
+
+/** The shape every unmapped row takes. One place, so the two callers agree. */
+function unmappedRow(account: ChartAccountRow): AccountIdentityRow {
+  return {
+    account,
+    state: 'unmapped',
+    providerAccountId: null,
+    providerAccountName: null,
+    providerAccountNumber: null,
+    source: null,
+    confirmedAt: null,
+    liveProviderAccount: null,
+    suggestion: null,
+  }
+}

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -79,6 +79,15 @@ export {
   type SetupReadiness,
 } from './setup-readiness'
 export {
+  type AccountSuggestion,
+  isMappableTo,
+  suggestAccountIdentities,
+  validateProviderMapping,
+} from './suggest-account-identities'
+export {
+  type AccountIdentityRow,
+  type AccountIdentityState,
+  type AccountSuggestionReason,
   type BooksBalanceDiscrepancy,
   type BooksBalanceReport,
   type BuiltEntry,
@@ -98,6 +107,7 @@ export {
   type PostingType,
   type PostResult,
   type PostResultStatus,
+  type ProviderAccount,
   ProviderPostError,
   type ResolvedPostingLine,
   type RoleAssignmentRow,

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -10,6 +10,14 @@
 // Client code must import `@auxx/lib/postings/client`, never this barrel.
 
 export {
+  type AccountIdentityMap,
+  confirmSuggestedIdentities,
+  listAccountIdentities,
+  resolveProviderAccountIds,
+  type SetAccountIdentityOptions,
+  setAccountIdentity,
+} from './account-identities'
+export {
   ACCOUNT_ROLE_LABELS,
   ACCOUNT_ROLES,
   type AccountRole,
@@ -120,6 +128,15 @@ export {
   setRoleAssignment,
 } from './role-map'
 export {
+  type AccountSuggestion,
+  isMappableTo,
+  suggestAccountIdentities,
+  validateProviderMapping,
+} from './suggest-account-identities'
+export {
+  type AccountIdentityRow,
+  type AccountIdentityState,
+  type AccountSuggestionReason,
   type BuiltEntry,
   type ChartAccountRow,
   type ClosePeriod,
@@ -136,6 +153,7 @@ export {
   type PostingType,
   type PostResult,
   type PostResultStatus,
+  type ProviderAccount,
   ProviderPostError,
   type ResolvedPostingLine,
   type RoleAssignmentRow,

--- a/packages/lib/src/postings/provider.ts
+++ b/packages/lib/src/postings/provider.ts
@@ -16,8 +16,8 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import { err, ok, type Result } from 'neverthrow'
-import { NotFoundError } from '../errors'
-import type { PostEntryInput, PostEntryResult } from './types'
+import { NotFoundError, UnprocessableEntityError } from '../errors'
+import type { PostEntryInput, PostEntryResult, ProviderAccount } from './types'
 
 const logger = createScopedLogger('postings-provider')
 
@@ -59,6 +59,63 @@ export interface AccountingProvider {
    * an unbalanced one. An adapter must not silently repair amounts.
    */
   postEntry(input: PostEntryInput): Promise<Result<PostEntryResult, Error>>
+
+  /**
+   * The connected system's own chart, for the `G19` mapping screen.
+   *
+   * 🛑 This is what keeps the mapping UI provider-neutral. A screen that fetched
+   * QuickBooks' chart directly could only ever map QuickBooks, and `P2` exists
+   * precisely so that swapping the accounting system is a settings change rather
+   * than a rewrite. Everything above this line speaks {@link ProviderAccount}.
+   *
+   * Inactive accounts are INCLUDED. `G19` requires every close to revalidate
+   * that a mapping's target still exists and is still active, and a screen
+   * cannot say "the account you mapped has been deactivated" about a row it
+   * never received.
+   */
+  listProviderAccounts(orgId: string): Promise<Result<ProviderAccount[], Error>>
+
+  /**
+   * Which provider account each of the org's own accounts is mapped to, as
+   * `glAccountId -> providerAccountId`.
+   *
+   * A missing entry means unmapped, which is the state that blocks a close with
+   * a message naming the account. Never guess: `G19` has no default-account
+   * fallback, because a guess that lands on a real account produces an entry
+   * that balances and is wrong, and nothing downstream can detect it.
+   */
+  listAccountMappings(orgId: string): Promise<Result<Map<string, string>, Error>>
+
+  /**
+   * Record that one of the org's accounts IS one provider account - the human
+   * confirmation `G19` step 4 requires.
+   *
+   * The caller has already checked that the pairing is legal (the provider
+   * account exists, is active, and its classification matches ours). An adapter
+   * may re-check but must not silently repair.
+   */
+  setAccountMapping(input: SetAccountMappingInput): Promise<Result<void, Error>>
+
+  /** Withdraw a confirmation. The account goes back to unmapped. */
+  clearAccountMapping(input: ClearAccountMappingInput): Promise<Result<void, Error>>
+}
+
+/** One confirmed pairing, as {@link AccountingProvider.setAccountMapping} takes it. */
+export interface SetAccountMappingInput {
+  orgId: string
+  /** The `gl_account` `EntityInstance` id. */
+  glAccountId: string
+  /** The provider's own account id. */
+  providerAccountId: string
+  /** Who confirmed it, for the audit trail the mapping's storage keeps. */
+  actorUserId?: string
+}
+
+/** One withdrawal, as {@link AccountingProvider.clearAccountMapping} takes it. */
+export interface ClearAccountMappingInput {
+  orgId: string
+  glAccountId: string
+  actorUserId?: string
 }
 
 /**
@@ -86,6 +143,47 @@ class NoneAccountingProvider implements AccountingProvider {
       docNumber: input.docNumber,
     })
     return ok({ status: 'not_connected', externalId: '', providerId: NONE_PROVIDER_ID })
+  }
+
+  /**
+   * No external chart to read, and that is an ANSWER rather than a failure.
+   *
+   * An empty list is what the mapping screen needs to render "nothing is
+   * connected, so there is nothing to map" - which under `P1` is a supported
+   * configuration, not a setup step somebody has skipped.
+   */
+  async listProviderAccounts(): Promise<Result<ProviderAccount[], Error>> {
+    return ok([])
+  }
+
+  async listAccountMappings(): Promise<Result<Map<string, string>, Error>> {
+    return ok(new Map())
+  }
+
+  /**
+   * 🛑 A write REFUSES rather than succeeding silently.
+   *
+   * The two reads above answer emptily because "nothing connected" is a true and
+   * complete answer to them. A write is different: somebody is trying to record
+   * a pairing with a system that is not there, and an `ok()` would tell them it
+   * was saved. Nothing would have been.
+   */
+  async setAccountMapping(input: SetAccountMappingInput): Promise<Result<void, Error>> {
+    return err(
+      new UnprocessableEntityError(
+        'No accounting system is connected, so there is no account to map to.',
+        { organizationId: input.orgId, glAccountId: input.glAccountId }
+      )
+    )
+  }
+
+  async clearAccountMapping(input: ClearAccountMappingInput): Promise<Result<void, Error>> {
+    return err(
+      new UnprocessableEntityError(
+        'No accounting system is connected, so there is no mapping to clear.',
+        { organizationId: input.orgId, glAccountId: input.glAccountId }
+      )
+    )
   }
 }
 

--- a/packages/lib/src/postings/suggest-account-identities.ts
+++ b/packages/lib/src/postings/suggest-account-identities.ts
@@ -1,0 +1,206 @@
+// packages/lib/src/postings/suggest-account-identities.ts
+
+/**
+ * `G19` step 3: propose a type-compatible provider account for each of the org's
+ * own accounts, and say WHY.
+ *
+ * Pure. No database, no provider call, no logger - both charts arrive as
+ * arrays. That is what lets the whole matcher be tested without a double, and it
+ * is why the number-versus-name precedence below can be argued about in a test
+ * rather than in production.
+ *
+ * ## A suggestion is never a mapping
+ *
+ * Nothing here writes anything, and nothing downstream may treat a suggestion as
+ * a resolution. `G19` is explicit - "require a human to confirm an existing
+ * account" - and the reason is that every match this file can make is a guess
+ * from a string. `1310` in our chart and `1310` in QuickBooks agreeing is strong
+ * evidence and not proof; two accounts both called `Inventory Asset` is weaker
+ * still. A wrong account id in a journal entry BALANCES, so no reader downstream
+ * can ever catch it. The person confirming is the last line, which is why they
+ * are shown the reason and not just the answer.
+ *
+ * ## Why type compatibility is a filter and not a tiebreak
+ *
+ * A candidate whose classification disagrees with ours is never offered at all,
+ * at any confidence. Suggesting that our `2160` liability be mapped to a revenue
+ * account because both are called "Accrual" would produce an entry that balances
+ * and misstates the P&L, and a person clicking through a wizard has no way to
+ * know that the number they recognised belonged to the wrong section.
+ */
+
+import type { AccountSuggestionReason, ChartAccountRow, ProviderAccount } from './types'
+
+/** One proposal: our account, their account, and the evidence for the pairing. */
+export interface AccountSuggestion {
+  glAccountId: string
+  account: ProviderAccount
+  reason: AccountSuggestionReason
+}
+
+/**
+ * `'an asset'` / `'a liability'` - the indefinite article for a classification.
+ *
+ * Trivial, and it lives here rather than at three call sites because these
+ * sentences are read by a bookkeeper at 11pm deciding whether to trust a
+ * mapping, and "is a asset account" reads like a machine wrote it.
+ */
+export function classificationArticle(classification: string): string {
+  return /^[aeiou]/i.test(classification) ? `an ${classification}` : `a ${classification}`
+}
+
+/** Case- and whitespace-insensitive compare. `' 1310 '` matches `'1310'`. */
+function norm(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase()
+}
+
+/**
+ * Strip the punctuation and filler that differ between two charts describing the
+ * same account, so `'COGS - Product Cost'` and `'Cogs   Product Cost'` compare
+ * equal.
+ *
+ * Deliberately conservative: it collapses separators and whitespace and nothing
+ * else. No stemming, no synonym list, no "inventory ≈ stock". Every loosening
+ * makes a false match likelier, and a false match here is a misposting nobody
+ * downstream can detect.
+ */
+function normName(value: string | null | undefined): string {
+  return norm(value)
+    .replace(/[-_/&,.()]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Propose one provider account per unmapped auxx account.
+ *
+ * ## Precedence, and why it is this order
+ *
+ * | Rank | Reason | Evidence |
+ * | --- | --- | --- |
+ * | 1 | `number` | the provider account carries the same account NUMBER |
+ * | 2 | `name` | the same normalised name, and only one candidate has it |
+ *
+ * The number wins because it is the one field in a chart of accounts that people
+ * maintain deliberately and rarely reuse. Names are chosen for readability and
+ * collide constantly - QuickBooks alone ships several accounts containing
+ * "Income" - so a name match is offered only when no number matches at all.
+ *
+ * ⚠️ There is deliberately no third rank matching the two `accountType` strings.
+ * Ours is the five-way statement classification (`'asset'`); a provider's is its
+ * own detailed subtype (`'Other Current Asset'`), and the two vocabularies never
+ * compare equal. The classification filter above is where type already does its
+ * work, and a rank that could never fire would only read as though the matcher
+ * were more careful than it is.
+ *
+ * 🛑 **Ambiguity yields NO suggestion, never the first hit.** Two candidates
+ * tying at the same rank means the evidence does not distinguish them, and
+ * picking one would hide that fact behind an answer that looks decided. The
+ * account is left unmapped and the person chooses. This is `matchAccount`'s rule
+ * in `quickbooks-accounting-provider.ts` and it is the same rule for the same
+ * reason.
+ *
+ * 🛑 **Inactive provider accounts are never suggested.** Mapping to one produces
+ * a confirmed mapping that fails its next revalidation, which is a worse outcome
+ * than never having suggested it.
+ *
+ * @param accounts the org's own live chart
+ * @param providerAccounts the connected provider's chart
+ * @param alreadyMapped `gl_account` ids that already carry a mapping - skipped,
+ *   because a suggestion must never appear to compete with a human's confirmation
+ */
+export function suggestAccountIdentities(
+  accounts: readonly ChartAccountRow[],
+  providerAccounts: readonly ProviderAccount[],
+  alreadyMapped: ReadonlySet<string> = new Set()
+): AccountSuggestion[] {
+  const candidates = providerAccounts.filter((a) => a.active)
+
+  const suggestions: AccountSuggestion[] = []
+  for (const account of accounts) {
+    if (alreadyMapped.has(account.id)) continue
+
+    // The filter, not a tiebreak. See the file header.
+    const compatible = candidates.filter((c) => c.classification === account.accountType)
+    if (compatible.length === 0) continue
+
+    const byNumber = pickOne(
+      compatible,
+      (c) => norm(c.number) !== '' && norm(c.number) === norm(account.code)
+    )
+    if (byNumber) {
+      suggestions.push({ glAccountId: account.id, account: byNumber, reason: 'number' })
+      continue
+    }
+
+    const byName = pickByName(compatible, account)
+    if (byName) suggestions.push({ glAccountId: account.id, account: byName, reason: 'name' })
+  }
+
+  return suggestions
+}
+
+/**
+ * The one provider account sharing this account's name, or null.
+ *
+ * Matches either the plain name or the fully-qualified one, because a provider
+ * that nests accounts reports `'Sales:Product Income'` where our chart simply
+ * says `'Product Income'`, and either spelling agreeing is the same evidence.
+ *
+ * Ambiguity yields null rather than the first hit - see the header.
+ */
+function pickByName(
+  compatible: readonly ProviderAccount[],
+  account: ChartAccountRow
+): ProviderAccount | null {
+  const wanted = normName(account.name)
+  if (!wanted) return null
+
+  return pickOne(
+    compatible,
+    (c) => normName(c.name) === wanted || normName(c.fullyQualifiedName) === wanted
+  )
+}
+
+/** The single account matching a predicate, or null when none or several do. */
+function pickOne(
+  candidates: readonly ProviderAccount[],
+  predicate: (account: ProviderAccount) => boolean
+): ProviderAccount | null {
+  const hits = candidates.filter(predicate)
+  return hits.length === 1 ? hits[0]! : null
+}
+
+/**
+ * Is a confirmed mapping still safe to post through?
+ *
+ * `G19`: "every close revalidates existence, active status, and type
+ * compatibility". This is that check, as one function, so the resolver and the
+ * settings screen cannot come to disagree about what "still valid" means.
+ *
+ * @returns null when the mapping is good, else the sentence explaining what broke
+ */
+export function validateProviderMapping(
+  account: ChartAccountRow,
+  providerAccount: ProviderAccount | undefined | null,
+  providerAccountId: string
+): string | null {
+  if (!providerAccount) {
+    return `${account.code} ${account.name} is mapped to an account that no longer exists in the connected accounting system (id ${providerAccountId}). Re-map it.`
+  }
+  if (!providerAccount.active) {
+    return `${account.code} ${account.name} is mapped to '${providerAccount.fullyQualifiedName}', which has been deactivated. Reactivate it or map ${account.code} to another account.`
+  }
+  if (providerAccount.classification !== account.accountType) {
+    return `${account.code} ${account.name} is ${classificationArticle(account.accountType)} account but is mapped to '${providerAccount.fullyQualifiedName}', which is ${providerAccount.classification}. Posting to it would balance and still be wrong.`
+  }
+  return null
+}
+
+/** Type-compatible, active, and therefore offerable in a picker for `account`. */
+export function isMappableTo(
+  account: Pick<ChartAccountRow, 'accountType'>,
+  providerAccount: ProviderAccount
+): boolean {
+  return providerAccount.active && providerAccount.classification === account.accountType
+}

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -521,6 +521,98 @@ export interface RoleAssignmentRow {
 }
 
 /**
+ * One account as a connected accounting provider reports it.
+ *
+ * Provider-neutral by construction, and deliberately NOT QuickBooks' own shape:
+ * `AccountingProvider.listProviderAccounts` is what a mapping screen reads, and
+ * a screen that spoke `MappedAccount` could only ever map one provider.
+ *
+ * `number` is the account NUMBER ('1310'), not the id, and is null for a company
+ * that does not use account numbers at all - which is the ordinary case in
+ * QuickBooks, where numbering is off by default. That is exactly why `G19` maps
+ * by CONFIRMATION rather than by matching numbers at post time.
+ */
+export interface ProviderAccount {
+  /** The provider's own id. The only value that ever reaches a journal entry. */
+  id: string
+  name: string
+  /** `'Sales:Product Income'` where the provider nests accounts; else `name`. */
+  fullyQualifiedName: string
+  number: string | null
+  /** The provider's own type string, for display - `'Other Current Asset'`. */
+  accountType: string
+  /** Normalised to the five statement sections every double-entry system shares. */
+  classification: GlAccountTypeValue
+  active: boolean
+}
+
+/**
+ * Whether an account's provider mapping was chosen by a person or merely proposed.
+ *
+ * The same three-way distinction {@link RoleAssignmentState} draws one level up,
+ * and for the same `G19` reason: a match the suggester made must read visibly
+ * differently from one a human agreed to, because only the second is allowed to
+ * put money into a provider account.
+ *
+ * 🛑 There is no `unused` member, and that asymmetry with `RoleAssignmentState`
+ * is deliberate. A ROLE may legitimately be one an org never emits. An ACCOUNT
+ * in the org's own chart that no provider account corresponds to is not
+ * "excused" - it is either not mapped yet or not needed by any role, and the
+ * role map is where the second is already recorded. A second way to say it would
+ * let the two disagree.
+ */
+export type AccountIdentityState = 'confirmed' | 'suggested' | 'unmapped'
+
+/**
+ * Why the suggester proposed a provider account, in the words a screen shows.
+ *
+ * `G19` requires the UI to "clearly separate suggestions from confirmed
+ * mappings", which means saying WHY - "matched on account number 1310" earns a
+ * different amount of trust than "matched on the name Inventory Asset", and the
+ * person confirming is the only one who can tell which is right.
+ */
+export type AccountSuggestionReason = 'number' | 'name'
+
+/**
+ * One of the org's own accounts, its provider mapping, and the state of that
+ * mapping.
+ *
+ * Returned for EVERY live account in the chart, mapped or not - the same
+ * checklist rule {@link RoleAssignmentRow} follows, for the same reason: a list
+ * of only the rows that happen to exist could never show what is missing, and
+ * "which accounts still need mapping" is the question this screen exists to
+ * answer.
+ */
+export interface AccountIdentityRow {
+  /** The `gl_account` instance, always present - this row IS an account. */
+  account: ChartAccountRow
+  state: AccountIdentityState
+  /** The provider account this maps to. Null while `unmapped`. */
+  providerAccountId: string | null
+  /** As recorded when the mapping was made - see the schema on why it is display-only. */
+  providerAccountName: string | null
+  providerAccountNumber: string | null
+  /** `'suggested'` | `'human'`, or null with no row. */
+  source: string | null
+  confirmedAt: string | null
+  /**
+   * The live provider account the mapping currently names, re-read from the
+   * provider's chart.
+   *
+   * 🛑 Null with a non-null `providerAccountId` is the DANGLING case - the
+   * provider account was deleted, deactivated or merged out from under a
+   * confirmed mapping. `G19` requires every close to revalidate exactly this, so
+   * a screen must render it as a repair rather than as a mapping.
+   */
+  liveProviderAccount: ProviderAccount | null
+  /**
+   * What the matcher would propose for an unmapped account, and why. Null once
+   * something is mapped, and null when nothing plausible matched.
+   */
+  suggestion: { account: ProviderAccount; reason: AccountSuggestionReason } | null
+}
+
+/**
  * One month in the close console's period strip.
  *
  * Derived, never stored. `state` is computed from three things that already


### PR DESCRIPTION
Decision `G19` maps `posting role -> auxx gl_account -> provider account`. #1975 shipped the first hop as `GlRoleAssignment`. **The second hop did not exist**, and this is it.

## The bug this closes

The QuickBooks adapter resolved account codes by matching `Account.AcctNum` at post time. Probed against the live dev sandbox:

```
QBO chart: 89 accounts, 89 active
  carrying an account number: 0
auxx chart: 29 accounts
resolvable 0/29   ambiguous 0   missing 29
```

**Zero.** QuickBooks ships with account numbers off, so every `AcctNum` is null and every posting line would have refused at line 1. The adapter was behaving exactly as its own comment predicted — *"When a company does not use account numbers at all, every `acctNum` is null and this refuses every code, which is the correct and legible outcome."* The design was missing a step, not the code.

The second failure mode is worse and silent: for companies that *do* number their accounts, renumbering one in QuickBooks quietly moved where a role posts. The entry still balances, so nothing downstream catches it.

## What replaces it

A confirmation a person makes once, stored in the `qboAccountId` cell on the `gl_account` instance and mirrored into `RecordIdentity` by the existing `writeQuickbooksIdField` — the same path `qboCustomerId` / `qboItemId` / `qboInvoiceId` already take.

That is the shape `gl-account-fields.ts` and entity migration 114 **both already specified in writing**: *"`gl_account` is NOT touched. It stays an `EntityInstance` on purpose — `RecordIdentity` is keyed on an instance and has no other addressing mode, and decision `P2` hangs the provider's account id there."*

### No new table, and no migration

An earlier draft of this work added a `GlAccountIdentity` table, reasoning from `GlRoleAssignment`'s precedent. **That precedent does not transfer**, and the check is worth recording:

| | Constraint | Expressible in `FieldValue`? |
|---|---|---|
| `GlRoleAssignment` | each **role** appears on at most one account | No — uniqueness **across rows**, and `FieldValue` has exactly two unique indexes (`G6`) |
| this | one provider id per **account** | Yes — uniqueness **within a row**. That is what a field *is*. |

CLAUDE.md is explicit that this subsystem is `EntityInstance`-backed with no new Drizzle tables. The table was me copying a conclusion without re-running its argument.

### No `source` / `confirmedAt` either

`G19` needs a suggestion to read differently from a confirmation. Here that is **structural rather than stored**: the matcher is pure and never writes, and the only writer is a person confirming. So a populated cell *is* a confirmation, and there is no flag that can drift from the cell it describes.

## Layers

| File | What it owns |
|---|---|
| `postings/suggest-account-identities.ts` | The matcher. Pure — its 20 tests use no doubles of any kind. |
| `postings/account-identities.ts` | The composed read/write. Provider-**neutral**. |
| `postings/provider.ts` | Four new `AccountingProvider` methods. |
| `money/quickbooks/account-map.ts` | The QuickBooks half. One query for the whole chart. |
| `quickbooks-accounting-provider.ts` | Resolution now goes through the map. |

Three rules worth reviewing specifically:

- **Ambiguity yields no suggestion, never the first hit.** Two candidates means the evidence does not distinguish them; answering anyway hides that behind something that looks decided.
- **Type incompatibility is a filter, not a tiebreak.** A candidate in the wrong statement section is never offered at any confidence, because posting to it balances and misstates the P&L.
- **`None` refuses the writes** while answering the reads emptily. "Nothing connected" is a complete answer to *"what is your chart"* and not to *"save this pairing"* — an `ok()` there would claim something was saved.

`account-identities.ts` knows nothing about QuickBooks; every provider fact arrives through the interface. If any test in it needed a realm id, the layering would be wrong.

## The wizard

```
welcome -> period -> opening -> costing -> accounts -> connect -> accountMap -> done
                                           (roles)    (QBO)      (chart->QBO)
```

Connect sits immediately before the mapping because the mapping page cannot render a row until a provider chart exists to map against.

🛑 **Both new pages are skippable and must stay so.** `P1` makes "nothing connected" a supported configuration, not an unfinished setup — the ledger is ours, entries are still built, balanced and persisted, and only the export does not happen. Neither page ever blocks Continue.

`wizard-accountMap` **edits**, unlike `wizard-accounts` which summarises and links out. The role map is a review; this map starts empty on every new connection and is the one task that unblocks posting, so sending somebody out of the wizard to do it loses them at the exact moment they were going to finish. The editor is shared with a new Accounts settings tab, so the two cannot drift.

## Verified against the live sandbox

```
our account : 1310 Raw Materials / Parts (asset)
qbo target  : 81 Inventory Asset (asset)
map         : ok, state=confirmed, re-read confirmed -> Inventory Asset (id 81)
wrong section: refused - "...is an asset account, but 'Billable Expense Income'
               is revenue. Posting to it would balance and still be wrong."
clear       : ok, state=unmapped
```

`packages/lib/scripts/probe-qbo-account-resolution.ts` reports mapping state for an org, read-only.

⚠️ `packages/lib/scripts/reconcile-app-fields.ts` is included because of a gap worth knowing about: **a `auxx dev` deploy uploads a catalog but does not provision its fields.** `reconcileInstallationAppFields` runs on install, production roll-forward, connector sync-setup and connection-save only. Adding a field to an app needs a deploy *and* a reconcile (or a reconnect).

## Checks

- lib **1061 files / 14552 tests green**, 38 new
- typecheck ratchet: `lib` no new errors (29/29), `web` clean (0/0)
- biome clean; **no migration**

Pre-existing and untouched: the test-count ratchet fails on `post-journal-entry.test.ts` and `103-gl-posting.test.ts`, both deleted in #1978. The baseline is stale on `main`; I did not re-record it, since that would sweep this branch's counts in alongside.

## Paired with

https://github.com/Auxx-Ai/auxxai-apps/pull/63 declares `qboAccountId`. **Merge that first.** Without it this side degrades gracefully — the map reads empty and everything reports "not mapped" — but cannot map anything.

## Also here

One unrelated commit, folded in on request: `part-costing-card.tsx`'s standard-cost row. The value and the Roll button now share one non-wrapping line, so the button sits at the same right edge whether the row reads "Not rolled" or "$124.99 set 12 Aug". The bulk-roll hint had been inside that flex row, wrapping, and `ms-auto` then pushed the button to the end of whichever line it landed on. It becomes a block beneath and drops its "Roll it here" half, since the button one line up says that itself.

## Not in scope

- `G19` step 4's *"ask Auxx to create the recommended account in the provider"* needs a `create_quickbooks_account` tool that does not exist in the app repo.
- The dev org's close is still blocked by task 14's **data** problem (36 stock movements with no accounting date, cost or GL role). Unrelated to this, and the guard is right to refuse.

https://claude.ai/code/session_01JekaaFcoPZXpfi3nmMny9z
