### PR TITLE
feat(money): QuickBooks export toggle, and Accounting/Catalog in the palette

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/quickbooks-section.tsx
+++ b/apps/web/src/components/accounting/ui/settings/quickbooks-section.tsx
@@ -29,6 +29,7 @@ import { InlineAppInstallButton } from '~/components/apps/ui/app-install-button'
 import { AppSettingsDialog } from '~/components/apps/ui/app-settings-dialog'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
 import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
 
 /** What "none connected" actually means, spelled the same way everywhere. */
@@ -54,9 +55,13 @@ function formatDate(value: Date | string | null | undefined): string | null {
  *    its `connections` tab, which owns the whole OAuth flow.
  * 3. Connected - which company, who authorized it and when, plus Manage.
  *
- * 🛑 This section owns NO settings values. It is presentational plus two dialog
- * actions, so it stays outside the page's `useDirtyDraft` slices and adds nothing
- * to `DRAFT_KEYS`.
+ * 🛑 The export switch is the section's ONLY settings value, and it stays outside
+ * the page's `useDirtyDraft` slices anyway: an uncontrolled `SettingsFieldRow`
+ * autosaves straight through to `updateOrganizationSetting`, so there is no draft
+ * for it to join and nothing to add to `DRAFT_KEYS`. Do not "fix" that by wiring
+ * it to the page's `scope: 'GENERAL'` draft - the key's catalog scope is
+ * `DOCUMENTS`, so a scoped read would return nothing and the switch would render
+ * permanently off while appearing to save.
  *
  * 🛑 None of the three states is a warning. See the `P1` note at the top of this
  * file and in `use-accounting-provider-status.ts` before changing a badge colour.
@@ -156,6 +161,12 @@ export function QuickbooksSettingsSection() {
                   : (connectedAt ?? '-')}
               </div>
             </FieldPanelRow>
+
+            <SettingsFieldRow
+              settingKey='quickbooks.postJournalEntries'
+              title='Export posted entries'
+              description='When on, a posted entry is also pushed to QuickBooks as a journal entry. Off, the entry is still built, balanced and stored here - the close is unaffected.'
+            />
           </>
         )}
       </FieldPanel>

--- a/apps/web/src/components/kbar/actions/navigation.ts
+++ b/apps/web/src/components/kbar/actions/navigation.ts
@@ -347,6 +347,33 @@ export function useNavigationActions(): PaletteAction[] {
         perform: () => nav('/files'),
       })
     }
+    // Gates mirror SIDEBAR_MENU exactly (`featureKey: 'accounting'` +
+    // `permissionKey: 'ledger.view'`), and they have to: the close console
+    // guards on the same key, so a looser gate here would walk a member into
+    // the landing page's /access-denied redirect.
+    if (hasAccess('accounting') && can('ledger.view')) {
+      actions.push({
+        id: 'nav.accounting',
+        label: 'Accounting',
+        subtitle: 'Close the books',
+        icon: 'calculator',
+        keywords: 'accounting ledger close books journal gl month end period',
+        perform: () => nav('/accounting'),
+      })
+    }
+    // `dispatch` + `settings.manage` — matches SIDEBAR_MENU and the page's own
+    // `useRequireCapability(settingsManage)` in `catalog-page.tsx`. The feature
+    // key is deliberately `dispatch`, not a catalog key of its own.
+    if (hasAccess('dispatch') && can('settings.manage')) {
+      actions.push({
+        id: 'nav.catalog',
+        label: 'Catalog',
+        subtitle: 'The sellable catalog',
+        icon: 'tags',
+        keywords: 'catalog items groups products sellable services',
+        perform: () => nav('/catalog'),
+      })
+    }
     return actions
   }, [hasAccess, can, nav, viewableSlugs, resourcesLoading])
 }

--- a/apps/web/src/components/kbar/use-palette-actions.ts
+++ b/apps/web/src/components/kbar/use-palette-actions.ts
@@ -26,6 +26,8 @@ const SIDEBAR_TO_ACTION: Record<string, string> = {
   workflows: 'nav.workflows',
   tasks: 'nav.tasks',
   schedule: 'nav.schedule',
+  accounting: 'nav.accounting',
+  catalog: 'nav.catalog',
 }
 
 /** Warn (once per render that trips it) about uncovered top-level sidebar items. */


### PR DESCRIPTION
Two small front-end follow-ups to the G19 account map work.

## QuickBooks export toggle

The QuickBooks settings section gains its one settings value: an uncontrolled `SettingsFieldRow` for `quickbooks.postJournalEntries`. Off, a posted entry is still built, balanced and stored locally - only the push to QuickBooks is skipped, so the close is unaffected.

It stays out of the page's `useDirtyDraft` slices on purpose. The key's catalog scope is `DOCUMENTS`, not the page's `GENERAL`, so wiring it into the page draft would read nothing back and render the switch permanently off while appearing to save. The comment block at the top of the section now says so.

## Accounting and Catalog in the command palette

Both are top-level sidebar items that had no palette action - the uncovered-item warning in `use-palette-actions` flags exactly this.

Gates mirror `SIDEBAR_MENU` exactly:

- Accounting: `accounting` feature + `ledger.view`, the same key the close console guards on
- Catalog: `dispatch` feature + `settings.manage`, matching `catalog-page.tsx`'s own `useRequireCapability`

A looser gate on either would walk a member into the landing page's `/access-denied` redirect.

## Checks

`pnpm --filter @auxx/web typecheck` passes.

https://claude.ai/code/session_01BazSJQMipueLDRKGTj8L3S