### PR TITLE
fix(drawers): stop the record lists truncating and vanishing silently

### DIFF
--- a/apps/web/src/components/drawers/cards/part-family-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-family-card.tsx
@@ -17,7 +17,7 @@ import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { pluralize } from '@auxx/utils'
 import { Package, Sparkles } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
@@ -47,6 +47,15 @@ const PRODUCT_STATUS_BY_VALUE = Object.fromEntries(ProductStatus.values.map((v) 
  * kind of family this is.
  */
 const SIBLING_LIMIT = 5
+
+/**
+ * Siblings per page — a page size, NOT a cap. The effect below drains every
+ * page before any count is rendered, because every number this card shows
+ * ("Variant 3 of 12", "Show all 12") is derived from the LOADED rows. On the
+ * old un-drained default of 50 a 60-variant family offered "Show all 50", and
+ * clicking it was the end of the road.
+ */
+const SIBLING_PAGE_SIZE = 100
 
 /** Synthetic relationship config for the ad-hoc product picker (not a real field). */
 const PRODUCT_RELATIONSHIP: RelationshipConfig = {
@@ -136,11 +145,30 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
     ],
     [productId]
   )
-  const { records: siblings, isLoading: isLoadingSiblings } = useRecordList({
+  const {
+    records: siblings,
+    isLoading: isLoadingSiblingList,
+    isLoadingRecords: isLoadingSiblingRecords,
+    hasNextPage: hasMoreSiblings,
+    isFetchingNextPage: isFetchingMoreSiblings,
+    fetchNextPage: fetchMoreSiblings,
+  } = useRecordList({
     entityDefinitionId: partDefId ?? '',
     filters: siblingFilters,
+    limit: SIBLING_PAGE_SIZE,
     enabled: !!productId && !!partDefId,
   })
+
+  useEffect(() => {
+    if (hasMoreSiblings && !isFetchingMoreSiblings && !isLoadingSiblingList) fetchMoreSiblings()
+  }, [hasMoreSiblings, isFetchingMoreSiblings, isLoadingSiblingList, fetchMoreSiblings])
+
+  // Held at "Loading..." until the family is BOTH fully paged and fully
+  // resolved. `siblings` is the record-store resolution of the ids, which
+  // arrives in a second wave and reports `isLoading: false` in between — so a
+  // count taken any earlier is a wrong number rather than a late one.
+  const isLoadingSiblings =
+    isLoadingSiblingList || isLoadingSiblingRecords || hasMoreSiblings || isFetchingMoreSiblings
 
   // Finished-good condition (b): is this part anybody's subpart? Child-side
   // filter (`subpart:childPart`), limit 1 — presence is the only question.

--- a/apps/web/src/components/drawers/cards/product-summary-card.tsx
+++ b/apps/web/src/components/drawers/cards/product-summary-card.tsx
@@ -64,15 +64,20 @@ export function ProductSummaryCard({ entityInstanceId, recordId }: DrawerTabProp
     [entityInstanceId]
   )
 
-  const { records, total, hasNextPage, isLoading } = useRecordList({
+  const { recordIds, total, hasNextPage, isLoading } = useRecordList({
     entityDefinitionId: partDefId ?? '',
     filters,
     enabled: !!entityInstanceId && !!partDefId,
   })
 
+  // 🛑 Ids, not `records`. `records` is the record-store resolution of these
+  // ids and arrives a wave later; the list is served from the store cache with
+  // `isLoading: false`, so a `records`-keyed gate makes the whole card (and its
+  // section header) vanish on a cached reopen of a product that has variants.
+  // Nothing here reads `RecordMeta` — only the id.
   const rowRecordIds = useMemo(
-    () => (partDefId ? records.map((record) => toRecordId(partDefId, record.id)) : []),
-    [partDefId, records]
+    () => (partDefId ? recordIds.map((id) => toRecordId(partDefId, id)) : []),
+    [partDefId, recordIds]
   )
 
   const { valuesById } = useSystemValuesForRecords(rowRecordIds, VARIANT_ATTRIBUTES, {
@@ -106,7 +111,7 @@ export function ProductSummaryCard({ entityInstanceId, recordId }: DrawerTabProp
 
   const rows: VariantRow[] = useMemo(
     () =>
-      records.map((record, index) => {
+      recordIds.map((id, index) => {
         const own = valuesById[rowRecordIds[index] as RecordId]
         const items = (own?.part_catalog_items as RecordId[] | undefined) ?? []
         // Only a SINGLE backing item supplies a price — price tiers are not a
@@ -118,13 +123,13 @@ export function ProductSummaryCard({ entityInstanceId, recordId }: DrawerTabProp
         const price =
           (soleValues?.catalog_item_default_unit_price as number | null | undefined) ?? null
         return {
-          id: record.id,
+          id,
           quantityOnHand: (own?.part_quantity_on_hand as number | null | undefined) ?? null,
           priceCents: soleItem && active ? price : null,
           catalogItemCount: items.length,
         }
       }),
-    [records, rowRecordIds, valuesById, itemValues]
+    [recordIds, rowRecordIds, valuesById, itemValues]
   )
 
   const summary = useMemo(
@@ -133,7 +138,7 @@ export function ProductSummaryCard({ entityInstanceId, recordId }: DrawerTabProp
   )
 
   // Nothing to summarize → no card, and TabCardSection drops the header too.
-  if (isLoading || records.length === 0) return null
+  if (isLoading || recordIds.length === 0) return null
 
   const statusMeta = status ? PRODUCT_STATUS_BY_VALUE[status] : undefined
   const { priceRange } = summary

--- a/apps/web/src/components/drawers/tabs/company-parts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/company-parts-tab.tsx
@@ -11,7 +11,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@auxx/ui/components/table'
 import { toastError } from '@auxx/ui/components/toast'
 import { Package } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { VendorPartDialog } from '~/components/manufacturing/parts/vendor-part-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
@@ -20,6 +20,13 @@ import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import { ContactVendorPartRow } from './contact-parts-tab-row'
+
+/**
+ * Page size for the supplied-parts list — a page size, NOT a cap. The effect
+ * below drains every page; the previous default of 50 truncated silently,
+ * with a header count taken from the loaded rows so it agreed with itself.
+ */
+const SUPPLIED_PARTS_PAGE_SIZE = 100
 
 /**
  * Parts tab for company drawer - shows parts this company supplies.
@@ -57,11 +64,17 @@ export function CompanyPartsTab({ entityInstanceId }: DrawerTabProps) {
     [entityInstanceId]
   )
 
-  const { records, isLoading, refresh } = useRecordList({
-    entityDefinitionId: vendorPartDefId ?? '',
-    filters,
-    enabled: !!entityInstanceId && !!vendorPartDefId,
-  })
+  const { recordIds, total, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage, refresh } =
+    useRecordList({
+      entityDefinitionId: vendorPartDefId ?? '',
+      filters,
+      limit: SUPPLIED_PARTS_PAGE_SIZE,
+      enabled: !!entityInstanceId && !!vendorPartDefId,
+    })
+
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage && !isLoading) fetchNextPage()
+  }, [hasNextPage, isFetchingNextPage, isLoading, fetchNextPage])
 
   // Delete via entity system
   const deleteRecord = api.record.delete.useMutation({
@@ -132,7 +145,7 @@ export function CompanyPartsTab({ entityInstanceId }: DrawerTabProps) {
     <>
       <ScrollArea className='flex-1'>
         <Section
-          title={`Parts (${records.length})`}
+          title={`Parts (${total})`}
           className='flex flex-col flex-1 min-h-0 w-full [&_[data-slot=section]]:flex-1 [&_[data-slot=section]]:border-b-0 [&_[data-slot=section-content]]:flex-1'
           collapsible={false}
           icon={<Package className='size-4 text-muted-foreground/50' />}
@@ -144,7 +157,7 @@ export function CompanyPartsTab({ entityInstanceId }: DrawerTabProps) {
               </Button>
             ) : undefined
           }>
-          {records.length === 0 ? (
+          {recordIds.length === 0 ? (
             <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>
               <Package className='mb-2 h-6 w-6 text-muted-foreground' />
               <p className='text-sm text-muted-foreground'>No parts added yet</p>
@@ -163,13 +176,13 @@ export function CompanyPartsTab({ entityInstanceId }: DrawerTabProps) {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {records.map((record) => (
+                  {recordIds.map((id) => (
                     <ContactVendorPartRow
-                      key={record.id}
-                      recordId={toRecordId(vendorPartDefId!, record.id)}
-                      onEdit={() => handleEditVendorPart(record.id)}
-                      onDelete={() => handleDeleteVendorPart(record.id)}
-                      onSetPreferred={() => handleSetPreferred(record.id)}
+                      key={id}
+                      recordId={toRecordId(vendorPartDefId!, id)}
+                      onEdit={() => handleEditVendorPart(id)}
+                      onDelete={() => handleDeleteVendorPart(id)}
+                      onSetPreferred={() => handleSetPreferred(id)}
                     />
                   ))}
                 </TableBody>

--- a/apps/web/src/components/drawers/tabs/part-inventory-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-inventory-tab.tsx
@@ -45,6 +45,15 @@ const TYPE_LABEL_MAP: Record<string, string> = Object.fromEntries(
   StockMovementType.values.map((t) => [t.value, t.label])
 )
 
+/**
+ * Movements per page.
+ *
+ * Unlike a BOM this list is UNBOUNDED — a busy part accumulates thousands — so
+ * it pages behind a control rather than draining. What changed is that the
+ * truncation is now visible: the header counts `total`, not the loaded rows.
+ */
+const MOVEMENT_PAGE_SIZE = 50
+
 /** Stock status → badge variant */
 const STATUS_VARIANT_MAP: Record<string, Variant> = {
   in_stock: 'green',
@@ -121,17 +130,33 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
 
   const {
     records,
+    recordIds,
+    total,
     isLoading: isLoadingMovements,
+    isLoadingRecords,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
     refresh,
   } = useRecordList({
     entityDefinitionId: stockMovementDefId ?? '',
     filters,
     sorting,
-    limit: 50,
+    limit: MOVEMENT_PAGE_SIZE,
     enabled: !!partId && !!stockMovementDefId,
   })
 
-  const isLoading = isLoadingPart || isLoadingMovements
+  // 🛑 `isLoadingRecords` belongs in this gate, not just `isLoadingMovements`.
+  // The rows below need `RecordMeta` (`createdAt`), which `useRecordList`
+  // resolves in a SECOND wave — and a list served from the store cache reports
+  // `isLoading: false` with `records` still empty, so without this the tab
+  // renders "Stock Movements (0)" and the "No stock movements yet" placeholder
+  // over a part that has plenty.
+  //
+  // Only when NOTHING is rendered yet, though: `isLoadingRecords` goes true
+  // again for each "Load more" page, and an unqualified gate would swap the
+  // whole tab back to a skeleton every time the user asked for more.
+  const isLoading = isLoadingPart || isLoadingMovements || (isLoadingRecords && !records.length)
 
   const handleAdjustSuccess = () => {
     refresh()
@@ -164,7 +189,7 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
 
       {/* Stock Movements */}
       <Section
-        title={`Stock Movements (${records.length})`}
+        title={`Stock Movements (${total})`}
         initialOpen
         actions={
           canAdjustStock ? (
@@ -189,7 +214,7 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
             </div>
           ) : undefined
         }>
-        {records.length === 0 ? (
+        {recordIds.length === 0 ? (
           <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>
             <Package className='mb-2 h-6 w-6 text-muted-foreground' />
             <p className='text-sm text-muted-foreground'>No stock movements yet</p>
@@ -223,6 +248,18 @@ export function PartInventoryTab({ recordId }: DrawerTabProps) {
                 ))}
               </TableBody>
             </Table>
+            {hasNextPage && (
+              <div className='flex justify-center border-t p-1'>
+                <Button
+                  variant='ghost'
+                  size='xs'
+                  loading={isFetchingNextPage}
+                  loadingText='Loading...'
+                  onClick={() => fetchNextPage()}>
+                  Load more
+                </Button>
+              </div>
+            )}
           </div>
         )}
       </Section>

--- a/apps/web/src/components/drawers/tabs/part-subparts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-subparts-tab.tsx
@@ -26,7 +26,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { pluralize } from '@auxx/utils'
 import { formatCurrency } from '@auxx/utils/currency'
 import { CircleAlert, Edit, MoreHorizontal, Package, PlusCircle, Trash2 } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { SubpartDialog } from '~/components/manufacturing/parts/subpart-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
@@ -37,6 +37,17 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
+
+/**
+ * Page size for both directions of the BOM.
+ *
+ * A page size, NOT a cap — the effects below drain every page, the same call
+ * `line-builder.tsx` makes for document lines. Both lists are bounded (an
+ * assembly has tens of components, a part is used in tens of assemblies), and
+ * the previous default of 50 truncated silently: the section headers counted
+ * the loaded rows, so a 60-component BOM read "Subparts (50)" and looked right.
+ */
+const BOM_PAGE_SIZE = 100
 
 /** What the assembly-level unpriced check reads off each subpart row. */
 const SUBPART_CHILD_ATTRIBUTES = ['subpart_child_part'] as const
@@ -88,14 +99,23 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
   )
 
   const {
-    records: subpartRecords,
+    recordIds: subpartIds,
+    total: subpartTotal,
     isLoading: isLoadingSubparts,
+    hasNextPage: hasMoreSubparts,
+    isFetchingNextPage: isFetchingMoreSubparts,
+    fetchNextPage: fetchMoreSubparts,
     refresh: refreshSubparts,
   } = useRecordList({
     entityDefinitionId: subpartDefId ?? '',
     filters: subpartFilters,
+    limit: BOM_PAGE_SIZE,
     enabled: !!partId && !!subpartDefId,
   })
+
+  useEffect(() => {
+    if (hasMoreSubparts && !isFetchingMoreSubparts && !isLoadingSubparts) fetchMoreSubparts()
+  }, [hasMoreSubparts, isFetchingMoreSubparts, isLoadingSubparts, fetchMoreSubparts])
 
   // Used In Assemblies section: parents of this part
   const parentFilters: ConditionGroup[] = useMemo(
@@ -117,14 +137,23 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
   )
 
   const {
-    records: parentRecords,
+    recordIds: parentIds,
+    total: parentTotal,
     isLoading: isLoadingParents,
+    hasNextPage: hasMoreParents,
+    isFetchingNextPage: isFetchingMoreParents,
+    fetchNextPage: fetchMoreParents,
     refresh: refreshParents,
   } = useRecordList({
     entityDefinitionId: subpartDefId ?? '',
     filters: parentFilters,
+    limit: BOM_PAGE_SIZE,
     enabled: !!partId && !!subpartDefId,
   })
+
+  useEffect(() => {
+    if (hasMoreParents && !isFetchingMoreParents && !isLoadingParents) fetchMoreParents()
+  }, [hasMoreParents, isFetchingMoreParents, isLoadingParents, fetchMoreParents])
 
   const isLoading = isLoadingSubparts || isLoadingParents
 
@@ -135,9 +164,16 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
   // Two lifted reads, because the answer spans the list: the subpart rows say
   // WHICH parts are components, and those parts say whether they are priced.
   // A row subscribing to its own values can only ever answer for itself.
+  //
+  // 🛑 Keyed on `recordIds`, never on `records`. `useRecordList` resolves
+  // `records` from the record store in a SECOND wave, and the list is served
+  // from the store cache (5-min TTL) with `isLoading: false` — so on a cached
+  // open the ids are known while `records` is still empty. Everything that
+  // decides what renders reads ids for that reason; only a row that needs
+  // `RecordMeta` itself (a `createdAt`, a `displayName`) may read `records`.
   const subpartRecordIds = useMemo(
-    () => (subpartDefId ? subpartRecords.map((record) => toRecordId(subpartDefId, record.id)) : []),
-    [subpartRecords, subpartDefId]
+    () => (subpartDefId ? subpartIds.map((id) => toRecordId(subpartDefId, id)) : []),
+    [subpartIds, subpartDefId]
   )
 
   const { valuesById: subpartValues } = useSystemValuesForRecords(
@@ -259,7 +295,7 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
     <ScrollArea className='flex-1'>
       {/* Subparts Section */}
       <Section
-        title={`Subparts (${subpartRecords.length})`}
+        title={`Subparts (${subpartTotal})`}
         initialOpen
         actions={
           canCreate ? (
@@ -269,7 +305,7 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
             </Button>
           ) : undefined
         }>
-        {subpartRecords.length === 0 ? (
+        {subpartIds.length === 0 ? (
           <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>
             <Package className='mb-2 h-6 w-6 text-muted-foreground' />
             <p className='text-sm text-muted-foreground'>No subparts added yet</p>
@@ -301,16 +337,16 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {subpartRecords.map((record) => (
+                  {subpartIds.map((id) => (
                     <SubpartRow
-                      key={record.id}
-                      recordId={toRecordId(subpartDefId!, record.id)}
+                      key={id}
+                      recordId={toRecordId(subpartDefId!, id)}
                       relatedPartField='subpart_child_part'
                       linkTab='subparts'
                       showActions
                       unpricedChildIds={unpricedChildIds}
-                      onEdit={() => handleEditSubpart(record.id)}
-                      onDelete={() => handleDeleteSubpart(record.id)}
+                      onEdit={() => handleEditSubpart(id)}
+                      onDelete={() => handleDeleteSubpart(id)}
                     />
                   ))}
                 </TableBody>
@@ -321,8 +357,8 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
       </Section>
 
       {/* Parent Parts Section */}
-      {parentRecords.length > 0 && (
-        <Section title={`Used In (${parentRecords.length})`} initialOpen>
+      {parentIds.length > 0 && (
+        <Section title={`Used In (${parentTotal})`} initialOpen>
           <div className='rounded-md border'>
             <Table>
               <TableHeader>
@@ -332,10 +368,10 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {parentRecords.map((record) => (
+                {parentIds.map((id) => (
                   <SubpartRow
-                    key={record.id}
-                    recordId={toRecordId(subpartDefId!, record.id)}
+                    key={id}
+                    recordId={toRecordId(subpartDefId!, id)}
                     relatedPartField='subpart_parent_part'
                     linkTab='subparts'
                   />

--- a/apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
@@ -12,7 +12,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@auxx/ui/components/table'
 import { toastError } from '@auxx/ui/components/toast'
 import { Store } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { VendorPartDialog } from '~/components/manufacturing/parts/vendor-part-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
@@ -22,6 +22,13 @@ import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import { VendorPartRow, type VendorPartRowValues } from './part-vendors-tab-row'
+
+/**
+ * Page size for the supplier list — a page size, NOT a cap. The effect below
+ * drains every page; a part's supplier list is bounded, and the previous
+ * default of 50 truncated with a header count that agreed with the truncation.
+ */
+const VENDOR_PAGE_SIZE = 100
 
 /** Everything a supplier row renders, and everything the winner rule needs. */
 const VENDOR_PART_ATTRIBUTES = [
@@ -85,15 +92,25 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
     [partId]
   )
 
-  const { records, isLoading, refresh } = useRecordList({
-    entityDefinitionId: vendorPartDefId ?? '',
-    filters,
-    enabled: !!partId && !!vendorPartDefId,
-  })
+  const { recordIds, total, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage, refresh } =
+    useRecordList({
+      entityDefinitionId: vendorPartDefId ?? '',
+      filters,
+      limit: VENDOR_PAGE_SIZE,
+      enabled: !!partId && !!vendorPartDefId,
+    })
 
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage && !isLoading) fetchNextPage()
+  }, [hasNextPage, isFetchingNextPage, isLoading, fetchNextPage])
+
+  // 🛑 Ids, not `records`. `records` resolves from the record store in a second
+  // wave, and a list served from the store cache reports `isLoading: false`
+  // with the ids already known — so a `records`-keyed count renders short (or
+  // renders the empty state) for that window. Rows need only the id.
   const rowRecordIds = useMemo(
-    () => (vendorPartDefId ? records.map((record) => toRecordId(vendorPartDefId, record.id)) : []),
-    [records, vendorPartDefId]
+    () => (vendorPartDefId ? recordIds.map((id) => toRecordId(vendorPartDefId, id)) : []),
+    [recordIds, vendorPartDefId]
   )
 
   // Lifted out of the rows: the winner is a property of the LIST, so no row can
@@ -191,7 +208,7 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
   return (
     <ScrollArea className='flex-1'>
       <Section
-        title={`Suppliers (${records.length})`}
+        title={`Suppliers (${total})`}
         initialOpen
         actions={
           canCreate ? (
@@ -201,7 +218,7 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
             </Button>
           ) : undefined
         }>
-        {records.length === 0 ? (
+        {recordIds.length === 0 ? (
           <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>
             <Store className='mb-2 h-6 w-6 text-muted-foreground' />
             <p className='text-sm text-muted-foreground'>No suppliers added yet</p>
@@ -223,17 +240,17 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {records.map((record, index) => {
+                {recordIds.map((id, index) => {
                   const rowRecordId = rowRecordIds[index] as RecordId
                   return (
                     <VendorPartRow
-                      key={record.id}
+                      key={id}
                       recordId={rowRecordId}
                       values={toRowValues(valuesById[rowRecordId])}
                       isWinner={rowRecordId === winningRecordId}
-                      onEdit={() => handleEditVendorPart(record.id)}
-                      onDelete={() => handleDeleteVendorPart(record.id)}
-                      onSetPreferred={() => handleSetPreferred(record.id)}
+                      onEdit={() => handleEditVendorPart(id)}
+                      onDelete={() => handleDeleteVendorPart(id)}
+                      onSetPreferred={() => handleSetPreferred(id)}
                     />
                   )
                 })}

--- a/apps/web/src/components/drawers/tabs/product-parts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/product-parts-tab.tsx
@@ -139,12 +139,21 @@ export function ProductPartsTab({ entityInstanceId }: DrawerTabProps) {
     [entityInstanceId]
   )
 
-  const { records, isLoading, total, hasNextPage, fetchNextPage, isFetchingNextPage, refresh } =
-    useRecordList({
-      entityDefinitionId: partDefId ?? '',
-      filters,
-      enabled: !!entityInstanceId && !!partDefId,
-    })
+  const {
+    records,
+    recordIds,
+    isLoading,
+    isLoadingRecords,
+    total,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    refresh,
+  } = useRecordList({
+    entityDefinitionId: partDefId ?? '',
+    filters,
+    enabled: !!entityInstanceId && !!partDefId,
+  })
 
   const rowRecordIds = useMemo(
     () => (partDefId ? records.map((record) => toRecordId(partDefId, record.id)) : []),
@@ -244,7 +253,15 @@ export function ProductPartsTab({ entityInstanceId }: DrawerTabProps) {
     [partDefId, confirmDetach, saveMultipleAsync, refresh]
   )
 
-  if (isLoading) {
+  // 🛑 `isLoadingRecords` too. The rows read `RecordMeta` (`record.displayName`
+  // feeds the detach confirmation), which resolves a wave after the ids — and a
+  // list served from the store cache reports `isLoading: false` in between, so
+  // without this the tab shows "No variants yet" over a product that has some.
+  //
+  // Qualified on an empty `records`, because this list pages behind a "Load
+  // more" button: an unqualified gate would blank the whole tab to a skeleton
+  // on every additional page.
+  if (isLoading || (isLoadingRecords && !records.length)) {
     return (
       <div className='p-4 space-y-4'>
         <Skeleton className='h-6 w-32' />
@@ -282,7 +299,7 @@ export function ProductPartsTab({ entityInstanceId }: DrawerTabProps) {
         className='flex flex-col flex-1 min-h-0 w-full [&_[data-slot=section]]:flex-1 [&_[data-slot=section]]:border-b-0 [&_[data-slot=section-content]]:flex-1'
         collapsible={false}
         icon={<Package className='size-4 text-muted-foreground/50' />}>
-        {records.length === 0 ? (
+        {recordIds.length === 0 ? (
           <div className='flex h-28 flex-col items-center justify-center gap-1 text-center border rounded-lg bg-muted/30'>
             <Package className='mb-1 h-6 w-6 text-muted-foreground' />
             <p className='text-sm text-muted-foreground'>No variants yet</p>

--- a/apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
@@ -93,7 +93,12 @@ export function BuildLedgerCard({ entityInstanceId }: DrawerTabProps) {
     [entityInstanceId]
   )
 
-  const { records, isLoading } = useRecordList({
+  const {
+    records,
+    recordIds: movementIds,
+    isLoading,
+    isLoadingRecords,
+  } = useRecordList({
     entityDefinitionId: movementDefId ?? '',
     filters,
     limit: MOVEMENT_LIMIT,
@@ -110,8 +115,13 @@ export function BuildLedgerCard({ entityInstanceId }: DrawerTabProps) {
     enabled: recordIds.length > 0,
   })
 
-  if (isLoading) return <RowSkeleton />
-  if (records.length === 0) {
+  // 🛑 Both halves. Rows read `RecordMeta` (`displayName`), which resolves in a
+  // SECOND wave after the ids — and a list served from the store cache reports
+  // `isLoading: false` with `records` still empty. Without `isLoadingRecords`
+  // the empty row below claims a completed build posted nothing, which is
+  // exactly the statement it exists to make about a `planned` one.
+  if (isLoading || isLoadingRecords) return <RowSkeleton />
+  if (movementIds.length === 0) {
     // Not an error and not a gap: a `planned` build writes no movements at all
     // (B2), which is the safety property the whole phasing rests on.
     return <EmptyRow label='Nothing posted yet (A build writes its ledger when it completes)' />

--- a/apps/web/src/components/purchasing/vendor-bill/use-vendor-bill-lines.ts
+++ b/apps/web/src/components/purchasing/vendor-bill/use-vendor-bill-lines.ts
@@ -16,7 +16,8 @@
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import { LINE_PAGE_SIZE } from '~/components/money/ui/line-builder/line-values'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 
@@ -100,15 +101,27 @@ export function useVendorBillLines(billRecordId: RecordId) {
     [billId]
   )
 
-  const { records, isLoading, refresh } = useRecordList({
-    entityDefinitionId: lineDefId ?? '',
-    filters,
-    enabled: !!billId && !!lineDefId,
-  })
+  const { recordIds, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage, refresh } =
+    useRecordList({
+      entityDefinitionId: lineDefId ?? '',
+      filters,
+      limit: LINE_PAGE_SIZE,
+      enabled: !!billId && !!lineDefId,
+    })
 
+  // Every page, eagerly — the same call the builder makes for the same rows.
+  // On the old un-drained default of 50 a bill with more lines than that fed
+  // the match card a SHORT line set, which reads as "the bill does not claim
+  // these order lines" and offers them for import a second time.
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage && !isLoading) fetchNextPage()
+  }, [hasNextPage, isFetchingNextPage, isLoading, fetchNextPage])
+
+  // Ids, not `records`: the record-store resolution is a second wave, and
+  // `ready` below already carries the "values have landed" half of the answer.
   const rowRecordIds = useMemo(
-    () => (lineDefId ? records.map((record) => toRecordId(lineDefId, record.id)) : []),
-    [records, lineDefId]
+    () => (lineDefId ? recordIds.map((id) => toRecordId(lineDefId, id)) : []),
+    [recordIds, lineDefId]
   )
 
   const { valuesById, loadedById } = useSystemValuesForRecords(
@@ -149,6 +162,10 @@ export function useVendorBillLines(billRecordId: RecordId) {
     !!billId &&
     !!lineDefId &&
     !isLoading &&
+    // A half-paged list is a SHORT list, which is the third window all over
+    // again — an absent line reads as "not claimed by this bill".
+    !hasNextPage &&
+    !isFetchingNextPage &&
     rowRecordIds.every((lineRecordId) =>
       VENDOR_BILL_LINE_ATTRIBUTES.every((attr) => loadedById[lineRecordId]?.[attr])
     )


### PR DESCRIPTION
Reported as "some parts have a lot of subparts and Used In, but they are not always shown". Two separate defects, both invisible by construction, and both present across nine list surfaces rather than just the one.

## 1. Silent truncation

Every one of these lists took `useRecordList`'s default `limit` of 50, never called `fetchNextPage`, and printed its section count from `records.length` — the **loaded** rows, not the server's `total`.

So a 60-component BOM rendered "Subparts (50)" over 50 rows. The count agreed with the truncation. Nothing looked wrong, and there was no control to get the rest.

`part-family-card` was the sharpest of them: a 60-variant Shopify family offered "Show all 50", and clicking it was the end of the road.

**Fix.** Bounded lists take a named page size and drain every page — the same `hasNextPage → fetchNextPage` call `line-builder.tsx` already makes for document lines, with the same reasoning (`LINE_PAGE_SIZE`'s doc comment explains why the size has to be named rather than defaulted).

| List | Before | After |
| --- | --- | --- |
| `part-subparts-tab` (both directions) | default 50 | `BOM_PAGE_SIZE = 100` + drain |
| `part-vendors-tab` | default 50 | `VENDOR_PAGE_SIZE = 100` + drain |
| `company-parts-tab` | default 50 | `SUPPLIED_PARTS_PAGE_SIZE = 100` + drain |
| `part-family-card` | default 50 | `SIBLING_PAGE_SIZE = 100` + drain |
| `use-vendor-bill-lines` | default 50 | `LINE_PAGE_SIZE` (shared with the builder) + drain |
| `part-inventory-tab` | 50, capped | `MOVEMENT_PAGE_SIZE = 50` + **Load more** |

Stock movements are the one genuinely unbounded list here — a busy part accumulates thousands — so it pages behind a control rather than draining, matching `product-parts-tab`. What changed there is that the truncation is now *visible*.

Every section count now reads `total`, so a truncated list can no longer agree with itself.

## 2. Sections vanishing over data that exists

`useRecordList` returns `records` as the **record-store resolution** of the ids, which arrives a wave after the ids themselves. The list is served from the store's 5-minute cache (`record-store.ts:255`), and in that window it reports `isLoading: false` with the ids known and `records` still empty.

Gating on `records` therefore renders the empty state — or drops the section entirely — over data that is there:

- `part-subparts-tab:324` — `parentRecords.length > 0` hid the whole **Used In** section
- `product-summary-card:136` — `if (isLoading || records.length === 0) return null` made the card vanish
- `build-ledger-card:114` — claimed a completed build had posted nothing, which is the statement it exists to make about a *planned* one
- `company-parts-tab`, `part-vendors-tab`, `part-inventory-tab` — empty-state flash

**Fix.** Anything that decides what renders reads `recordIds`. Where a row genuinely needs `RecordMeta` — `part-inventory-tab` for `createdAt`, `product-parts-tab` and `build-ledger-card` for `displayName`, `part-family-card` for the sibling names — the loading gate takes `isLoadingRecords` instead, which the hook already exposes and which `part-inventory-card:189` and `part-pricing-card:146` were already doing correctly.

That gate is qualified on an empty `records` for the two lists that page behind a button. Unqualified, `isLoadingRecords` goes true again for each additional page, and the whole tab would blank to a skeleton every time someone clicked Load more.

## 3. One consequence worth calling out

`use-vendor-bill-lines`'s `ready` flag now also requires `!hasNextPage`.

That file already carries a long comment about the three windows in which an empty `rows` does not mean what it says — because `selectBillableLines` subtracts the order lines a bill already claims, and through those windows it subtracts nothing and offers the whole order back on a bill that already has it. A half-paged line set is a **short** line set, which is that same failure reached through pagination rather than the value wave. It just needed the fourth condition.

## Not in this PR

The read-path waterfall itself — three sequential round trips to draw one subpart row — is untouched. It is written up separately in `plans/field-values/read-path-waterfall.md`; the short version is that the obvious fix (relationship-path field refs) drops the whole batch onto a sequential resolution loop, re-runs the shared hop once per ref, and narrows the permission gate from `hasDefPresence` to `canViewEntity` in a way that leaves grant-only members on a permanent "Loading…". That plan recommends measuring first and fixing the server's batching seam before any client change.

## Checks

- `pnpm --filter @auxx/web typecheck` — exit 0
- `pnpm exec vitest run src/components/drawers src/components/purchasing` — 82 passed
- Biome clean via the pre-commit hook

https://claude.ai/code/session_01BazSJQMipueLDRKGTj8L3S