### PR TITLE
fix(money): show the setup freeze as a lock and tooltip, not a paragraph

### DIFF
--- a/apps/web/src/components/accounting/hooks/use-accounting-settings-freeze.ts
+++ b/apps/web/src/components/accounting/hooks/use-accounting-settings-freeze.ts
@@ -12,9 +12,8 @@ import { api } from '~/trpc/react'
  * editing setup history.
  */
 export const FREEZE_REASON =
-  'Locked because an entry has already posted. Changing this would rewrite the arithmetic ' +
-  'behind a posted journal entry. Correct a mistake by reversing and re-entering, never by ' +
-  'editing setup history.'
+  'Locked because an entry has already posted. Correct a mistake by reversing and re-entering, ' +
+  'never by editing setup history.'
 
 export interface AccountingSettingsFreeze {
   /** True once anything has posted. */

--- a/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
@@ -71,7 +71,6 @@ export const OPENING_PAIRS = [
     label: 'Raw materials',
     auxxKey: ACCOUNTING_KEYS.openingRawMaterials,
     qboKey: ACCOUNTING_KEYS.qboOpeningRawMaterials,
-    hint: undefined as string | undefined,
   },
   {
     role: 'inventory_wip' as const,
@@ -79,7 +78,6 @@ export const OPENING_PAIRS = [
     label: 'Work in process',
     auxxKey: ACCOUNTING_KEYS.openingWip,
     qboKey: ACCOUNTING_KEYS.qboOpeningWip,
-    hint: 'Expected to be 0 at cutover. Zero is a real balance; unset is not.',
   },
   {
     role: 'inventory_finished_goods' as const,
@@ -87,7 +85,6 @@ export const OPENING_PAIRS = [
     label: 'Finished goods',
     auxxKey: ACCOUNTING_KEYS.openingFinishedGoods,
     qboKey: ACCOUNTING_KEYS.qboOpeningFinishedGoods,
-    hint: undefined as string | undefined,
   },
 ]
 

--- a/apps/web/src/components/accounting/ui/settings/frozen-lock.tsx
+++ b/apps/web/src/components/accounting/ui/settings/frozen-lock.tsx
@@ -1,0 +1,49 @@
+// apps/web/src/components/accounting/ui/settings/frozen-lock.tsx
+'use client'
+
+// The setup freeze, as an icon rather than a paragraph.
+//
+// Every frozen field previously carried the whole reason as body text under the
+// value. On the cutover snapshot that meant the same three sentences repeated
+// once per account, which read as an alarm rather than as a state — the panel's
+// own `showLabels` rule ("captions render only on the first pair, so the panel
+// is not repetitive") applies just as well to the explanation.
+//
+// 🛑 The reason still has to be REACHABLE, not merely implied. A locked field
+// with no explanation sends someone hunting for a disabled toggle that does not
+// exist, so the icon is a tooltip trigger and never a bare glyph.
+
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
+import { LockIcon } from 'lucide-react'
+
+interface FrozenLockProps {
+  /** Why this field is locked. Rendered in the tooltip and as the accessible name. */
+  reason: string
+  className?: string
+}
+
+/**
+ * A lock icon whose tooltip explains the freeze.
+ *
+ * The trigger is a focusable `span` rather than the bare icon so the reason is
+ * reachable by keyboard and named for a screen reader — an `<svg>` with an
+ * `aria-label` and no role is announced inconsistently.
+ */
+export function FrozenLock({ reason, className }: FrozenLockProps) {
+  return (
+    <SimpleTooltip content={reason} side='left'>
+      <span
+        role='img'
+        aria-label={reason}
+        tabIndex={0}
+        className={cn(
+          'inline-flex shrink-0 cursor-help items-center justify-self-end text-muted-foreground',
+          'rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          className
+        )}>
+        <LockIcon className='h-3.5 w-3.5' />
+      </span>
+    </SimpleTooltip>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
@@ -47,6 +47,7 @@ import {
   readMinorUnits,
   readText,
 } from './accounting-settings-keys'
+import { FrozenLock } from './frozen-lock'
 import { QuickbooksSettingsSection } from './quickbooks-section'
 import { SetupStatusSection } from './setup-status-section'
 import { StandardCostSection } from './standard-cost-section'
@@ -462,13 +463,17 @@ function ReadOnlyValue({
 }) {
   return (
     <div className={className}>
-      <div className='flex min-h-8 flex-wrap items-center gap-2 px-2 py-1.5 text-sm'>
-        <span>{value}</span>
-        <Badge variant='outline' size='xs' className='shrink-0'>
-          Locked
-        </Badge>
+      {/*
+        The value on the left, the lock on the right, and the reason in the
+        lock's tooltip. It used to be a `Locked` badge beside the value plus the
+        whole reason as body text underneath, which made a settled state read
+        like a warning and pushed the two rows out of line with every other row
+        on the page.
+      */}
+      <div className='flex min-h-8 items-center gap-2 px-2 py-1.5 text-sm'>
+        <span className='min-w-0 flex-1 truncate'>{value}</span>
+        {reason && <FrozenLock reason={reason} />}
       </div>
-      {reason && <p className='px-2 pb-1.5 text-muted-foreground text-xs'>{reason}</p>}
     </div>
   )
 }

--- a/apps/web/src/components/accounting/ui/settings/opening-reconciliation-panel.tsx
+++ b/apps/web/src/components/accounting/ui/settings/opening-reconciliation-panel.tsx
@@ -18,9 +18,20 @@ import { Badge } from '@auxx/ui/components/badge'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatCurrency } from '@auxx/utils/currency'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FrozenLock } from './frozen-lock'
 
 /** The two snapshots' column captions, rendered once above the first pair. */
 const COLUMN_LABELS = ['auxx.ai', 'QuickBooks', 'Difference'] as const
+
+/**
+ * Shared by the caption row and every value row so the columns line up.
+ *
+ * ⚠️ The fourth track is the freeze lock, and it is reserved **whether or not
+ * anything is frozen**. Adding the column only once frozen would shift the
+ * difference cell sideways the first time a month posts, on a page nobody is
+ * looking at when it happens.
+ */
+const COLUMN_GRID = 'grid grid-cols-[1fr_1fr_7rem_1.25rem]'
 
 interface OpeningPairFieldProps {
   auxx: number | null
@@ -30,8 +41,6 @@ interface OpeningPairFieldProps {
   /** Per-input validation, from `minorUnitError`. */
   auxxError?: string
   qboError?: string
-  /** Extra guidance for this account, e.g. "WIP is expected to be 0 at cutover". */
-  hint?: string
   /** Column captions render only on the first pair, so the panel is not repetitive. */
   showLabels?: boolean
   /** After the freeze, both snapshots render as values with the reason attached. */
@@ -49,7 +58,6 @@ export function OpeningPairField({
   onQboChange,
   auxxError,
   qboError,
-  hint,
   showLabels,
   readOnly,
   readOnlyReason,
@@ -61,7 +69,7 @@ export function OpeningPairField({
   return (
     <div className={cn('py-1', className)}>
       {showLabels && (
-        <div className='grid grid-cols-[1fr_1fr_7rem] gap-2 px-2 pb-1'>
+        <div className={cn(COLUMN_GRID, 'gap-2 px-2 pb-1')}>
           {COLUMN_LABELS.map((label) => (
             <span key={label} className='text-[10px] text-muted-foreground uppercase tracking-wide'>
               {label}
@@ -70,7 +78,7 @@ export function OpeningPairField({
         </div>
       )}
 
-      <div className='grid grid-cols-[1fr_1fr_7rem] items-center gap-2'>
+      <div className={cn(COLUMN_GRID, 'items-center gap-2')}>
         {readOnly ? (
           <>
             <span className='px-2 text-sm tabular-nums'>{formatCurrency(auxx)}</span>
@@ -96,14 +104,18 @@ export function OpeningPairField({
         )}
 
         <DifferenceCell difference={difference} />
+
+        {/*
+          The reason moved into this lock's tooltip. It used to render as body
+          text under every pair, so the same three sentences appeared once per
+          account — the panel's own `showLabels` rule against repetition applies
+          to the explanation just as much as to the captions.
+        */}
+        {readOnly && readOnlyReason && <FrozenLock reason={readOnlyReason} />}
       </div>
 
       {(auxxError || qboError) && (
         <p className='px-2 pt-1 text-destructive text-xs'>{auxxError ?? qboError}</p>
-      )}
-      {hint && <p className='px-2 pt-1 text-muted-foreground text-xs'>{hint}</p>}
-      {readOnly && readOnlyReason && (
-        <p className='px-2 pt-1 text-muted-foreground text-xs'>{readOnlyReason}</p>
       )}
     </div>
   )
@@ -140,16 +152,17 @@ interface OpeningTotalRowProps {
 /**
  * The summed verdict.
  *
- * 🛑 The two snapshots must agree before setup can be finalized. This row says
- * so in as many words rather than leaving a bookkeeper to infer it from a
- * disabled button on another page.
+ * 🛑 The two snapshots must agree before setup can be finalized, and when they
+ * do NOT this row says so in as many words rather than leaving a bookkeeper to
+ * infer it from a disabled button on another page. Agreement gets the badge
+ * alone — see the comment on the paragraph below.
  */
 export function OpeningTotalRow({ total, incomplete, className }: OpeningTotalRowProps) {
   const agrees = !incomplete && total === 0
 
   return (
     <div className={cn('space-y-1 py-1', className)}>
-      <div className='grid grid-cols-[1fr_1fr_7rem] items-center gap-2'>
+      <div className={cn(COLUMN_GRID, 'items-center gap-2')}>
         <span className='px-2 font-medium text-sm'>Total difference</span>
         <span />
         {incomplete ? (
@@ -166,18 +179,25 @@ export function OpeningTotalRow({ total, incomplete, className }: OpeningTotalRo
         )}
       </div>
 
-      <p className='px-2 text-muted-foreground text-xs'>
-        {incomplete
-          ? 'Some balances are still unset, so there is nothing to compare yet. Zero is a real ' +
-            'balance; unset is not.'
-          : agrees
-            ? 'The two snapshots agree. Setup can be finalized on the General page.'
+      {/*
+        🛑 Only the states somebody must ACT on get a paragraph. Agreement is
+        already carried by the green badge and by this row's own description
+        ("The two snapshots must agree before setup can be finalized."), so
+        spelling it out a third time made the settled case the loudest row on
+        the page — and pushed its badge out of line with the three above it.
+      */}
+      {!agrees && (
+        <p className='px-2 text-muted-foreground text-xs'>
+          {incomplete
+            ? 'Some balances are still unset, so there is nothing to compare yet. Zero is a real ' +
+              'balance; unset is not.'
             : 'Setup cannot be finalized while these disagree. Neither number overrides the ' +
               "other: a difference left to fall into the first month's balancing plug would be " +
               "booked as that month's COGS, and taking the auxx figure alone would let " +
               'QuickBooks and the subledger diverge from day one. Fix the count or the journal ' +
               'entry, then re-enter both.'}
-      </p>
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/accounting/ui/settings/opening-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/opening-settings-page.tsx
@@ -117,7 +117,6 @@ export function AccountingOpeningSettingsPage() {
                     onQboChange={(value) => patchKey(pair.qboKey, value)}
                     auxxError={minorUnitError(draft[pair.auxxKey])}
                     qboError={minorUnitError(draft[pair.qboKey])}
-                    hint={pair.hint}
                     showLabels={index === 0}
                     readOnly={frozen}
                     readOnlyReason={FREEZE_REASON}


### PR DESCRIPTION
## What

The accounting setup freeze rendered as a `Locked` badge beside each value plus the whole three-sentence reason as body text underneath. On the **Cutover snapshot** that meant the same paragraph once per account, so a settled state was the loudest thing on the page — and the rows it made taller pushed their badges out of line.

The freeze is now a right-aligned lock icon whose tooltip carries the reason, shared by both pages as `FrozenLock`. Applies to **Cutoff period**, **Book timezone**, and the three **Cutover snapshot** rows.

## Before / after

| | Before | After |
| --- | --- | --- |
| Cutoff period / Book timezone | value + `Locked` badge + 3-sentence paragraph | value + lock, one line, reason in the tooltip |
| Cutover snapshot | the same paragraph repeated 3× | one lock per row, reason in the tooltip |
| `Agrees` badges | reconciliation badge a column right of the other three | all four on one x |

## Three smaller things that fell out of it

- **The reason drops its middle sentence.** Why it is locked and what to do instead are what a person acts on. The arithmetic explanation ("changing this would rewrite the arithmetic behind a posted journal entry") stays as the comment above the constant, where it was doing real work.

- **The 1320 hint is deleted, not moved.** `accounting.openingWip`'s catalog description already reads *"Typically 0 at cutover. Unset = not configured, not zero."* on that row's own `?` tooltip. The hint was a second copy, not a misplaced first one.

- **The reconciliation paragraph renders only when `!agrees`.** Agreement was already carried by the green badge and by the row's own description (*"The two snapshots must agree before setup can be finalized"*). The *incomplete* and *disagree* messages are unchanged — those are states somebody has to act on.

## Layout

`OpeningTotalRow` now shares `COLUMN_GRID` with the pair rows, which is what fixes the badge alignment. The lock's column is reserved **whether or not anything is frozen**, so the difference cell does not shift sideways the first time a month posts — on a page nobody is watching when it happens.

## Accessibility

The tooltip trigger is a focusable `span` with `role='img'` rather than the bare `<svg>`, so the reason is keyboard-reachable and gets an accessible name. An `<svg>` carrying only an `aria-label` is announced inconsistently.

## Testing

Typecheck `@auxx/web` exit 0, zero errors. Biome clean.

Driven in a browser against a frozen org (`abgwpa1l81reht2zmwrcihfu`, which has three `GlPosting` rows, so `verifyBalance().postingsChecked > 0` and the locks actually render). Measured in the DOM after the change: all four `Agrees` badges at `x=1856`, all three locks at `x=1982`, every row one line tall, tooltip opens on focus with the shortened text.

https://claude.ai/code/session_011wSHwoRre2ciqmCfLZHbop
