### PR TITLE
fix(resources): don't serve a list cache too short for the reader asking

### DIFF
--- a/apps/web/src/components/drawers/cards/part-pricing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-pricing-card.tsx
@@ -325,7 +325,7 @@ export function PartPricingCard({ recordId }: DrawerTabProps) {
       {/* The partKind nudge — the ONLY kind interplay (§6.1): for a finished
           good, no active catalog item is almost certainly an omission. */}
       {(showOfferNudge || showInactiveNudge) && (
-        <div className='flex items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5'>
+        <div className='flex items-center gap-2 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-2.5'>
           <Sparkles className='size-4 shrink-0 text-amber-600' />
           <p className='flex-1 text-xs text-muted-foreground'>
             <span className='font-medium text-foreground'>

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -594,6 +594,7 @@ export function PartFormDialog({
                     validationType='error'>
                     <FieldInputAdapter
                       fieldType={FieldType.NUMBER}
+                      triggerProps={{ className: 'ps-0 pe-1 w-full' }}
                       value={openingStockValues.quantity}
                       onChange={(val) => handleOpeningStockChange('quantity', val ?? null)}
                       placeholder='0'
@@ -610,6 +611,7 @@ export function PartFormDialog({
                     validationType='error'>
                     <FieldInputAdapter
                       fieldType={FieldType.CURRENCY}
+                      triggerProps={{ className: 'ps-0 pe-1 w-full' }}
                       fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
                       value={openingStockValues.unitCost}
                       onChange={(val) => handleOpeningStockChange('unitCost', val ?? null)}
@@ -625,6 +627,7 @@ export function PartFormDialog({
                     showIcon>
                     <FieldInputAdapter
                       fieldType={FieldType.DATETIME}
+                      triggerProps={{ className: 'ps-0 pe-1 w-full' }}
                       value={openingStockValues.occurredAt}
                       onChange={(val) =>
                         handleOpeningStockChange(

--- a/apps/web/src/components/resources/hooks/use-record-list.test.ts
+++ b/apps/web/src/components/resources/hooks/use-record-list.test.ts
@@ -81,8 +81,10 @@ function pages(...list: Array<ReturnType<typeof page>>) {
   return { pages: list, pageParams: [undefined] }
 }
 
-function render() {
-  return renderHook(() => useRecordList({ entityDefinitionId: DEF }))
+function render(limit?: number) {
+  return renderHook(() =>
+    useRecordList({ entityDefinitionId: DEF, ...(limit === undefined ? {} : { limit }) })
+  )
 }
 
 beforeEach(() => {
@@ -138,6 +140,67 @@ describe('store cache vs query', () => {
     h.enabledSeen = []
     render()
     expect(h.enabledSeen.at(-1)).toBe(true)
+  })
+})
+
+// A cached list is shared by every reader of the same (def, filters, sorting,
+// search) — `createListKey` deliberately ignores `limit`. So a PRESENCE check
+// (`limit: 1`, "does this part have any subparts?") writes a one-id list under
+// the same key as the tab that wants the whole BOM. Being served that list is
+// terminal: the store cache disables the query, so `hasNextPage` is false and
+// there is nothing left to page from.
+describe('cache sufficiency', () => {
+  it('refuses a partial cache too short for this reader (the presence-check poison)', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    // What `part-costing-card` / `part-family-card` leave behind at limit 1.
+    useRecordStore.getState().setList(LIST_KEY, {
+      ids: ['a'],
+      total: 12,
+      fetchedAt: NOW,
+      nextCursor: 'more',
+    })
+
+    const { result } = render(100)
+
+    expect(result.current.isCached).toBe(false)
+    expect(h.enabledSeen.at(-1)).toBe(true)
+  })
+
+  it('serves a COMPLETE cache whatever limit produced it', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    // The same presence check on a part that really does have one subpart.
+    useRecordStore.getState().setList(LIST_KEY, {
+      ids: ['a'],
+      total: 1,
+      fetchedAt: NOW,
+      nextCursor: null,
+    })
+
+    const { result } = render(100)
+
+    expect(result.current.recordIds).toEqual(['a'])
+    expect(result.current.isCached).toBe(true)
+    expect(h.enabledSeen.at(-1)).toBe(false)
+  })
+
+  it("still serves a partial cache that fills this reader's page", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const ids = Array.from({ length: 50 }, (_, i) => `r${i}`)
+    useRecordStore.getState().setList(LIST_KEY, {
+      ids,
+      total: 500,
+      fetchedAt: NOW,
+      nextCursor: 'more',
+    })
+
+    const { result } = render(50)
+
+    expect(result.current.recordIds).toEqual(ids)
+    expect(result.current.isCached).toBe(true)
+    expect(h.enabledSeen.at(-1)).toBe(false)
   })
 })
 

--- a/apps/web/src/components/resources/hooks/use-record-list.ts
+++ b/apps/web/src/components/resources/hooks/use-record-list.ts
@@ -128,7 +128,30 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
   // Check if we have a valid cache before fetching
 
   const listCache = useRecordStore((s) => s.lists[listKey])
-  const cachedList = listCache && !isListStale(listCache) ? listCache : undefined
+
+  // 🛑 A cached list is only usable by a reader whose own first page it could
+  // have satisfied — being fresh is not enough.
+  //
+  // `createListKey` hashes (def, filters, sorting, search) and deliberately
+  // NOT `limit`, so readers of the same rows share one entry. But a PRESENCE
+  // check writes under that shared key too: `part-costing-card` and
+  // `part-family-card` both ask `subpart` with `limit: 1` and filters that are
+  // byte-identical to `part-subparts-tab`'s, and they are OVERVIEW cards, so
+  // they run first. Without the length test the tab mounts, finds a two-second-
+  // old one-id list, and is served it — `shouldFetch` goes false, so its query
+  // never runs at all, `hasNextPage` is false (a disabled query has no pages to
+  // continue from) and the drain effect cannot save it. The Subparts and Used In
+  // sections render ONE row of a twelve-row BOM until the page is reloaded.
+  //
+  // A complete list (`nextCursor === null`) is always usable — it is the whole
+  // answer, whatever limit produced it — which is what keeps the deliberate
+  // sharing in `line-builder` / `use-purchase-order-lines` / this tab intact.
+  const cachedList =
+    listCache &&
+    !isListStale(listCache) &&
+    (listCache.nextCursor === null || listCache.ids.length >= limit)
+      ? listCache
+      : undefined
 
   // Select action functions (stable references)
   const setList = useRecordStore((s) => s.setList)


### PR DESCRIPTION
Follow-up to #1988. Those lists drain their pages now, and they still came back short until the page was reloaded — reported as "I have to refresh for it to work, while the drawer is open". The paging was never the problem.

## The collision

`createListKey` hashes `(def, filters, sorting, search)` and deliberately **not** `limit`, so every reader of the same rows shares one `lists[...]` entry. That sharing is load-bearing — `line-values.ts:562` and `use-purchase-order-lines.ts:130` both carry long comments about why two components asking for the same rows must land on the same key, because `appendCreatedRecord` only patches the one key that created the record.

But a **presence check** writes under that shared key too:

| Card | Question it asks | limit | Filters |
| --- | --- | --- | --- |
| `part-costing-card:139` | does this part have a BOM at all? | `1` | `subpart:parentPart is partId` |
| `part-family-card` | is this part anybody's subpart? | `1` | `subpart:childPart is partId` |
| `part-subparts-tab` | the whole BOM, both directions | `100` | **byte-identical to both of the above** |

Same condition ids, same field ids, same operator, same value — so the same hash. And both cards are registered under `PART OVERVIEW CARDS` in `drawer-tab-registry.tsx`, so they run before the Subparts tab is ever opened.

## Why being served that cache is terminal

```ts
const cachedList = listCache && !isListStale(listCache) ? listCache : undefined
const shouldFetch = enabled && !cachedList
```

The tab mounts, finds a two-second-old one-id list, and is served it. `shouldFetch` goes false, so the tab's query **never runs**. With no pages of its own `hasNextPage` is `false` — a disabled infinite query has nothing to continue from — so `fetchNextPage` is a no-op and #1988's drain effect cannot save it.

The tab renders **one row of a twelve-row BOM, under a header that correctly says twelve**, because `total` is a real `COUNT(*)` on page 1 (`unified-handler.ts` → `includeTotal = params.includeTotal ?? offset === 0`) while the ids came from the limit-1 read. That mismatch is why it looked like a bug in the tab rather than in the hook.

Reloading the page clears the zustand store, and whichever list fetches first wins — which is exactly "I have to refresh for it to work".

## The fix

A cached list is now only served to a reader whose own first page it could have satisfied:

```ts
const cachedList =
  listCache &&
  !isListStale(listCache) &&
  (listCache.nextCursor === null || listCache.ids.length >= limit)
    ? listCache
    : undefined
```

- **Complete lists stay shareable whatever limit produced them** — `nextCursor === null` means it is the whole answer. This is what keeps the deliberate sharing between `line-builder`, `use-purchase-order-lines` and the vendor-bill hook intact, and it means a part that genuinely has one subpart still serves its cache to both readers with no extra request.
- **Same-limit readers are unchanged.** A page-1 cache holds exactly `limit` ids, so `ids.length >= limit` holds and the records table keeps its cache hit on remount.
- **Only the mismatched case refetches** — which is the bug.

### Considered and not taken

- **`limit` in `createListKey`.** Mirrors the React Query key, but gives up cross-limit sharing even when the cache is complete (a fully-drained BOM would stop answering the presence check), and `record-list-context-store.ts:61` uses `createListKey` to let a detail page reuse the table's cache, so the limits would have to match there too. More blast radius, worse outcome.
- **Making the presence checks stop using `useRecordList`.** Cleaner in principle, but it is a new endpoint and it fixes only these two callers — the next `limit: 1` check reintroduces the bug.

### Known residue, deliberately out of scope

A reader served a cache **it did not fetch itself** cannot page at all. `use-record-list.ts` means to handle this:

```ts
hasNextPage: hasNextPage ?? cachedList?.nextCursor !== null
```

…but it never fires, because a disabled query returns `hasNextPage: false`, not `undefined`. It wants to be a ternary on `cachedList`. Left alone here because it changes paging behaviour on the records table, the hottest surface in the app, and it is not what breaks the BOM.

## Tests

Three added to `use-record-list.test.ts`, in the existing harness (nothing talks to a server):

- refuses a partial cache too short for this reader — the presence-check poison
- serves a complete cache whatever limit produced it
- still serves a partial cache that fills this reader's page

Verified the first one **fails** against the old condition and passes with the fix.

## Also in this PR

A second commit carries two unrelated UI tweaks that were sitting in the working tree: the pricing card's partKind nudge takes `rounded-2xl`, and the three opening-stock inputs in the part form (quantity, unit cost, date) take the same `triggerProps` the other `FieldInputAdapter` call sites use, so they sit flush in their rows.

## Checks

- `pnpm --filter @auxx/web typecheck` — exit 0
- `pnpm exec vitest run src/components/resources src/components/drawers src/components/purchasing` — 234 passed across 26 files

https://claude.ai/code/session_01BazSJQMipueLDRKGTj8L3S