### PR TITLE
fix(money): fold the account map into the chart of accounts

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
@@ -4,24 +4,40 @@
 // The `G19` account map: which account in the connected accounting system each
 // of the org's own accounts corresponds to.
 //
-// 🛑 One component, two homes - the setup wizard's mapping step and the Accounts
-// settings page's third tab. `wizard-accounts-page.tsx` deliberately does the
-// opposite (a read-only summary linking to settings) because the ROLE map is a
-// review, not a task. This one is a task: it is the step between connecting
-// QuickBooks and being able to post, and sending somebody out of the wizard to
-// do it is sending them out of the wizard at its most important moment.
+// 🛑 ONE home, since task 19: the setup wizard's mapping step. This used to be
+// the Accounts settings page's third tab as well, and that tab is gone - the
+// provider account is an attribute of a `gl_account`, so in settings it is a row
+// in `chart-account-editor.tsx` beside the code, the name and the type, with the
+// list-level half (counter, bulk accept, broken banner, badges) in
+// `chart-list.tsx`.
+//
+// What survives here is the WIZARD's version, and the difference is the point:
+// `compact` shows only what still needs a decision, because a wizard page
+// answers "what is left" where settings answers "what is the state of things".
+// `wizard-accounts-page.tsx` does the opposite again (a read-only summary
+// linking to settings) because the ROLE map is a review, not a task. This one is
+// a task: it is the step between connecting QuickBooks and being able to post,
+// and sending somebody out of the wizard to do it is losing them at the exact
+// moment they were going to finish.
 //
 // ── Why this list has no detail pane ────────────────────────────────────────
 //
 // `chart-list.tsx`'s row shape, deliberately - the same `TreeRow`, the same
 // `code · name` title, the same badge-shaped `secondary`. What differs is the
 // trailing slot: the chart's rows OPEN an editor, and these rows ARE the editor.
-// A mapping is one value chosen from one list, so a detail pane would hold a
-// single dropdown and cost a click to reach it. The picker lives in `actions`.
+// A mapping is one value chosen from one list, so inside a wizard a detail pane
+// would hold a single dropdown and cost a click to reach it. The picker lives in
+// `actions`.
 //
 // That is also why no row is selectable and `onToggleOpen` is unset: a row click
 // would have nothing to do, and with an interactive `actions` slot it would fire
 // on every use of the picker.
+//
+// ⚠️ Two renderings of one map now exist, and that is accepted. The shared
+// authority is the three `ledger` procedures, NOT this component:
+// `setAccountIdentity` revalidates against the live provider chart before
+// writing, whatever any picker was offering. `isMappingBroken` is shared for the
+// same reason - it is the predicate a close refuses on.
 //
 // 🛑 A confirmation is a WRITE, and the picker only ever offers type-compatible
 // active accounts. Both are conveniences, not authorities: `setAccountIdentity`
@@ -31,7 +47,6 @@
 // person from being offered a choice that would be refused; it does not replace
 // the refusal.
 
-import type { AccountIdentityRow, AccountSuggestionReason } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Combobox } from '@auxx/ui/components/combobox'
@@ -43,13 +58,13 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Check, Landmark, Link2, Sparkles, TriangleAlert, X } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '~/trpc/react'
-import { accountTypeColor, accountTypeLabel } from './accounts-types'
-
-/** How a suggestion earned itself, in the words the row shows. */
-const REASON_COPY: Record<AccountSuggestionReason, string> = {
-  number: 'same account number',
-  name: 'same name',
-}
+import {
+  ACCOUNT_SUGGESTION_REASON_COPY,
+  accountTypeColor,
+  accountTypeLabel,
+  formatProviderAccount,
+  isMappingBroken,
+} from './accounts-types'
 
 export interface AccountMapListProps {
   /**
@@ -137,7 +152,7 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
   const suggested = rows.filter((row) => row.suggestion)
 
   const visible = (
-    compact ? rows.filter((row) => row.state !== 'confirmed' || isBroken(row)) : rows
+    compact ? rows.filter((row) => row.state !== 'confirmed' || isMappingBroken(row)) : rows
   ).filter(
     (row) =>
       !search ||
@@ -178,8 +193,12 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
               {broken.length} mapping{broken.length === 1 ? '' : 's'} no longer valid
             </p>
             <p className='text-muted-foreground text-xs'>
-              {broken.join(', ')} point at accounts that have been removed, deactivated or moved to
-              a different section. Every close refuses until they are re-mapped.
+              {broken.join(', ')}{' '}
+              {broken.length === 1
+                ? 'points at an account that has'
+                : 'point at accounts that have'}{' '}
+              been removed, deactivated or moved to a different section. Every close refuses until{' '}
+              {broken.length === 1 ? 'it is' : 'they are'} re-mapped.
             </p>
           </div>
         </div>
@@ -200,17 +219,12 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
         // in `secondary` without taking it back off.
         <div className={cn('flex flex-col gap-0.5', TREE_SECONDARY_NOTRUNCATE)}>
           {visible.map((row) => {
-            const brokenRow = isBroken(row)
+            const brokenRow = isMappingBroken(row)
             const options = providerAccounts
               .filter(
                 (account) => account.active && account.classification === row.account.accountType
               )
-              .map((account) => ({
-                value: account.id,
-                label: account.number
-                  ? `${account.number} · ${account.fullyQualifiedName}`
-                  : account.fullyQualifiedName,
-              }))
+              .map((account) => ({ value: account.id, label: formatProviderAccount(account) }))
 
             return (
               <TreeRow
@@ -252,7 +266,7 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
                         variant='outline'
                         size='xs'
                         disabled={setAccountIdentity.isPending}
-                        title={`Suggested by ${REASON_COPY[row.suggestion.reason]}`}
+                        title={`Suggested by ${ACCOUNT_SUGGESTION_REASON_COPY[row.suggestion.reason]}`}
                         onClick={() =>
                           setAccountIdentity.mutate({
                             glAccountId: row.account.id,
@@ -309,11 +323,4 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
       </p>
     </div>
   )
-}
-
-/** A confirmed mapping whose target has gone, been deactivated, or changed section. */
-function isBroken(row: AccountIdentityRow): boolean {
-  if (row.state !== 'confirmed') return false
-  const live = row.liveProviderAccount
-  return !live || !live.active || live.classification !== row.account.accountType
 }

--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -1,12 +1,22 @@
 // apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
 'use client'
 
-// Accounting > Settings > Accounts (13-accounting-ui.md §5.4).
+// Accounting > Settings > Accounts (13-accounting-ui.md §5.4, task 19).
 //
 // Shape B, master-detail: `SettingsPage` + a `ResponsiveTabs` subHeader with the
 // tab in `useQueryState('s')`, and a `grid-cols-[1fr_420px]` body whose right
 // column is a PERSISTENT editor pane, docked at `lg` and a floating
 // `DockableDrawer` below it. The products-services page is the reference.
+//
+// 🛑 TWO tabs, and there used to be three. The account map was its own
+// vendor-named tab until task 19 folded it into the chart, because which
+// provider account one of ours corresponds to is an ATTRIBUTE of that account -
+// it is stored on the `gl_account` instance, and it belongs beside the code, the
+// name and the type. A tab named after a vendor also contradicts `P1`, which
+// makes the provider one adapter behind one interface.
+//
+// `?s=quickbooks` therefore no longer resolves; the ternary below falls it
+// through to `roles`, as it does any other unknown value.
 //
 // Both tabs read real rows now: `ledger.roleMap` returns one row for EVERY role
 // in `ACCOUNT_ROLES` (mapped or not, so the list is a checklist rather than a
@@ -36,7 +46,7 @@ import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { toastError } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils'
-import { Landmark, Link2, Lock, Waypoints } from 'lucide-react'
+import { Landmark, Lock, Waypoints } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -46,19 +56,18 @@ import { useMedia } from '~/hooks/use-media'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
-import { AccountMapList } from './account-map-list'
-import type { ChartDraftHandle } from './accounts-types'
+import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
+import type { ChartDraftHandle, ChartMapView } from './accounts-types'
 import { ChartAccountEditor } from './chart-account-editor'
 import { ChartList } from './chart-list'
 import { RoleMapEditor } from './role-map-editor'
 import { RoleMapList } from './role-map-list'
 
-type AccountsTab = 'roles' | 'chart' | 'quickbooks'
+type AccountsTab = 'roles' | 'chart'
 
 const TABS = [
   { value: 'roles', label: 'Roles', icon: Waypoints },
   { value: 'chart', label: 'Chart of accounts', icon: Landmark },
-  { value: 'quickbooks', label: 'QuickBooks', icon: Link2 },
 ]
 
 const BREADCRUMBS = [
@@ -68,7 +77,7 @@ const BREADCRUMBS = [
 ]
 
 const PAGE_DESCRIPTION =
-  'Which account each posting role lands on, the chart those accounts live in, and which account in QuickBooks each one corresponds to.'
+  'Which account each posting role lands on, and the chart those accounts live in - including which account in your accounting system each one corresponds to.'
 
 export function AccountingAccountsSettingsPage() {
   useRequireCapability(PermissionKey.ledgerView)
@@ -76,8 +85,7 @@ export function AccountingAccountsSettingsPage() {
   const utils = api.useUtils()
 
   const [tab, setTab] = useQueryState('s', { defaultValue: 'roles' as string })
-  const activeTab: AccountsTab =
-    tab === 'chart' ? 'chart' : tab === 'quickbooks' ? 'quickbooks' : 'roles'
+  const activeTab: AccountsTab = tab === 'chart' ? 'chart' : 'roles'
 
   const roleMap = api.ledger.roleMap.useQuery()
   const chart = api.ledger.chartAccounts.useQuery()
@@ -85,6 +93,14 @@ export function AccountingAccountsSettingsPage() {
   // note. A separate read rather than a field on `ChartAccountRow`, which is
   // shared with the resolver's path and decoded by every reader of this chart.
   const chartUsage = api.ledger.chartAccountUsage.useQuery()
+  // 🛑 Gated on the tab, unlike every query above it. `accountMap` is a PROVIDER
+  // ROUND TRIP - it fetches QuickBooks' whole chart - where `chartAccounts` and
+  // `roleMap` are local reads. The Roles tab has no use for it and must not pay
+  // for it, and the chart must never WAIT on it: see `ChartMapView`.
+  const accountMap = api.ledger.accountMap.useQuery(undefined, {
+    enabled: activeTab === 'chart',
+  })
+  const provider = useAccountingProviderStatus()
 
   const [selectedRole, setSelectedRole] = useState<AccountRole | null>(null)
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null)
@@ -102,6 +118,31 @@ export function AccountingAccountsSettingsPage() {
   const accounts = useMemo(() => chart.data ?? [], [chart.data])
 
   const rowsByRole = useMemo(() => new Map(roleRows.map((row) => [row.role, row])), [roleRows])
+
+  /**
+   * The account map, as the chart tab consumes it.
+   *
+   * 🛑 Gate `connected` on the PROVIDER (`providerId`/`providerAccounts`), never
+   * on an empty `rows` array. "Nothing is connected" and "connected but nothing
+   * mapped" are different answers needing different actions, and collapsing them
+   * would tell somebody to map a chart with nothing to map it against.
+   */
+  const mapView = useMemo<ChartMapView>(() => {
+    const rows = accountMap.data?.rows ?? []
+    return {
+      connected:
+        !!accountMap.data &&
+        accountMap.data.providerId !== 'none' &&
+        accountMap.data.providerAccounts.length > 0,
+      byAccountId: new Map(rows.map((row) => [row.account.id, row])),
+      providerAccounts: accountMap.data?.providerAccounts ?? [],
+      broken: accountMap.data?.broken ?? [],
+      suggested: rows.filter((row) => row.suggestion).length,
+      providerLabel: provider.providerLabel,
+      isPending: accountMap.isPending,
+      isError: accountMap.isError,
+    }
+  }, [accountMap.data, accountMap.isPending, accountMap.isError, provider.providerLabel])
 
   /** Which roles point at each account. Renders the "2 roles" note on a chart row. */
   const rolesByAccountId = useMemo(() => {
@@ -167,9 +208,27 @@ export function AccountingAccountsSettingsPage() {
   const updateAccount = api.ledger.chartAccountUpdate.useMutation()
   const removeAccount = api.ledger.chartAccountRemove.useMutation()
 
-  /** A rename or a renumber changes the account rendered on every role row too. */
+  /**
+   * A rename or a renumber changes the account rendered on every role row too.
+   *
+   * 🛑 `accountMap` is in here, and it was not before task 19. A mapping's
+   * validity depends on `live.classification === account.accountType`, so
+   * changing an account's TYPE breaks its confirmed mapping on the server
+   * immediately - and while the map was a separate tab, that tab went on
+   * rendering the mapping as fine until something else happened to refetch.
+   *
+   * 🛑 The break is SHOWN, never repaired by clearing the cell. There is
+   * deliberately no `source`/`confirmedAt` column (a populated cell IS a
+   * confirmation), so silently clearing one is indistinguishable from a mapping
+   * nobody ever made - where a broken one is visible, refuses at the provider,
+   * and is one pick away from being fixed.
+   */
   const invalidateChart = useCallback(async () => {
-    await Promise.all([utils.ledger.chartAccounts.invalidate(), utils.ledger.roleMap.invalidate()])
+    await Promise.all([
+      utils.ledger.chartAccounts.invalidate(),
+      utils.ledger.roleMap.invalidate(),
+      utils.ledger.accountMap.invalidate(),
+    ])
   }, [utils])
 
   const handleCreateAccount = useCallback(
@@ -235,6 +294,46 @@ export function AccountingAccountsSettingsPage() {
     },
     [accounts, confirm, removeAccount, invalidateChart, selectedAccountId]
   )
+
+  // ── The account map writes ──────────────────────────────────────────────
+  //
+  // 🛑 Both are on `ledgerPost`, the same rung as the chart's own writes and for
+  // the same reason: reading the map is a view, changing where a role's money
+  // lands is a post-grade act.
+  //
+  // The per-row write exposes `mutateAsync` so its refusal lands on the FIELD in
+  // the editor - `setAccountIdentity` re-checks existence, active status and
+  // classification against the LIVE provider chart, and its sentence names the
+  // account and the problem. The bulk one toasts instead: it acts on rows that
+  // are not on screen, so there is no field for a message to land on.
+  const setIdentity = api.ledger.setAccountIdentity.useMutation()
+
+  const handleSetIdentity = useCallback(
+    async (glAccountId: string, providerAccountId: string | null) => {
+      await setIdentity.mutateAsync({ glAccountId, providerAccountId })
+      await utils.ledger.accountMap.invalidate()
+    },
+    [setIdentity, utils]
+  )
+
+  const confirmSuggested = api.ledger.confirmSuggestedAccounts.useMutation({
+    onSuccess: async (result) => {
+      await utils.ledger.accountMap.invalidate()
+      // ⚠️ Partial success is the normal shape here, not an edge case: the
+      // suggester offers many rows at once and the server validates each against
+      // the live chart. Every failure carries its own sentence, so they are
+      // surfaced rather than collapsed into a count.
+      if (result.failures.length > 0) {
+        toastError({
+          title: `${result.failures.length} mapping${result.failures.length === 1 ? '' : 's'} could not be saved`,
+          description: result.failures.join(' '),
+        })
+      }
+    },
+    onError: (error) => {
+      toastError({ title: 'Error confirming the suggestions', description: error.message })
+    },
+  })
 
   // ── The phantom draft ───────────────────────────────────────────────────
 
@@ -311,14 +410,15 @@ export function AccountingAccountsSettingsPage() {
         onDraftCommitted={handleChartDraftCommitted}
         onUpdate={handleUpdateAccount}
         onRemove={handleRemoveAccount}
+        map={mapView}
+        onSetIdentity={handleSetIdentity}
       />
     )
 
   const selectedId = activeTab === 'roles' ? selectedRole : selectedAccountId
-  // 🛑 The QuickBooks tab is NOT master-detail. Its rows are edited in place by
-  // a picker, so there is nothing for a right-hand editor pane to hold and a
-  // drawer would open onto an empty panel on mobile.
-  const mobileDrawerOpen = activeTab !== 'quickbooks' && !isDesktop && !!selectedId
+  // Both tabs are master-detail now. The exception this used to carry was for the
+  // QuickBooks tab, which edited in place and had nothing for a drawer to hold.
+  const mobileDrawerOpen = !isDesktop && !!selectedId
 
   return (
     <SettingsPage
@@ -328,38 +428,36 @@ export function AccountingAccountsSettingsPage() {
       subHeader={
         <ResponsiveTabs value={activeTab} onValueChange={handleTabChange} size='sm' items={TABS} />
       }>
-      {activeTab === 'quickbooks' ? (
+      <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
         <div className='min-w-0'>
-          <AccountMapList />
+          {activeTab === 'roles' ? (
+            <RoleMapList
+              rows={roleRows}
+              // 🛑 Gate on the query, never on an empty array. Thirteen rows
+              // reading "Not mapped - every preview refuses until this is set"
+              // is a CLAIM about the org, and rendering it mid-load makes it a
+              // false one.
+              isLoading={roleMap.isPending}
+              selectedRole={selectedRole}
+              onSelect={setSelectedRole}
+              onToggleUnused={handleToggleUnused}
+            />
+          ) : (
+            <ChartList
+              accounts={accounts}
+              isLoading={chart.isPending}
+              selectedId={selectedAccountId}
+              onSelect={handleSelectAccount}
+              rolesByAccountId={rolesByAccountId}
+              draft={chartDraft}
+              onAddDraft={handleAddChartDraft}
+              map={mapView}
+              onConfirmSuggested={() => confirmSuggested.mutate()}
+              confirming={confirmSuggested.isPending}
+            />
+          )}
         </div>
-      ) : (
-        <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
-          <div className='min-w-0'>
-            {activeTab === 'roles' ? (
-              <RoleMapList
-                rows={roleRows}
-                // 🛑 Gate on the query, never on an empty array. Thirteen rows
-                // reading "Not mapped - every preview refuses until this is set"
-                // is a CLAIM about the org, and rendering it mid-load makes it a
-                // false one.
-                isLoading={roleMap.isPending}
-                selectedRole={selectedRole}
-                onSelect={setSelectedRole}
-                onToggleUnused={handleToggleUnused}
-              />
-            ) : (
-              <ChartList
-                accounts={accounts}
-                isLoading={chart.isPending}
-                selectedId={selectedAccountId}
-                onSelect={handleSelectAccount}
-                rolesByAccountId={rolesByAccountId}
-                draft={chartDraft}
-                onAddDraft={handleAddChartDraft}
-              />
-            )}
-          </div>
-          {/* The column stays STRETCHED and a wrapper inside it does the sticking.
+        {/* The column stays STRETCHED and a wrapper inside it does the sticking.
             Making the column itself `self-start` would size it to the editor, and
             `border-l` would then stop dead at the editor's bottom edge instead of
             dividing the whole list. A stretched column also gives the sticky child
@@ -369,19 +467,18 @@ export function AccountingAccountsSettingsPage() {
             `sticky top-0 z-20` title/tabs block above - pinning at a hardcoded `0`
             would slide this underneath it. `z-10` matches `FormSaveBar`, i.e.
             deliberately below that header. */}
-          <div className='hidden border-l lg:block'>
-            <div
-              className='lg:sticky lg:z-10 lg:overflow-hidden'
-              style={{
-                top: 'var(--settings-sticky-top, 0px)',
-                maxHeight:
-                  'calc(var(--settings-viewport-h, 100vh) - var(--settings-sticky-top, 0px))',
-              }}>
-              {editorContent}
-            </div>
+        <div className='hidden border-l lg:block'>
+          <div
+            className='lg:sticky lg:z-10 lg:overflow-hidden'
+            style={{
+              top: 'var(--settings-sticky-top, 0px)',
+              maxHeight:
+                'calc(var(--settings-viewport-h, 100vh) - var(--settings-sticky-top, 0px))',
+            }}>
+            {editorContent}
           </div>
         </div>
-      )}
+      </div>
 
       <DockableDrawer
         open={mobileDrawerOpen}

--- a/apps/web/src/components/accounting/ui/settings/accounts-types.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounts-types.ts
@@ -10,7 +10,14 @@
 // statement classifications, the two roles the L1 regime never emits, and how an
 // account reads inside a row.
 
-import type { AccountRole, ChartAccountRow, GlAccountTypeValue } from '@auxx/lib/postings/client'
+import type {
+  AccountIdentityRow,
+  AccountRole,
+  AccountSuggestionReason,
+  ChartAccountRow,
+  GlAccountTypeValue,
+  ProviderAccount,
+} from '@auxx/lib/postings/client'
 import type { SelectOptionColor } from '@auxx/types/custom-field'
 
 /**
@@ -48,6 +55,78 @@ export function accountTypeLabel(type: GlAccountTypeValue): string {
  */
 export function accountTypeColor(type: GlAccountTypeValue): SelectOptionColor {
   return ACCOUNT_TYPE_OPTIONS.find((option) => option.value === type)?.color ?? 'blue'
+}
+
+/**
+ * The account map, as the Chart of accounts tab consumes it.
+ *
+ * 🛑 This DECORATES the chart, it never sources it. `ledger.chartAccounts` is a
+ * local read and `ledger.accountMap` is a provider round trip that can fail for
+ * reasons that have nothing to do with us - an expired token, a revoked
+ * connection, QuickBooks being down. The list renders from the first and is
+ * annotated by the second, so a provider outage can never make an org's chart
+ * unreadable or unrenamable. `P1` makes "nothing connected" first class: every
+ * field below has an honest value when there is no provider at all.
+ */
+export interface ChartMapView {
+  /** A provider is connected AND returned a chart to map against. */
+  connected: boolean
+  /** The map row per `gl_account` id. Empty until `ledger.accountMap` resolves. */
+  byAccountId: Map<string, AccountIdentityRow>
+  /** The provider's own chart, for the picker. Empty when nothing is connected. */
+  providerAccounts: ProviderAccount[]
+  /**
+   * Codes whose confirmed mapping no longer validates - the target was deleted,
+   * deactivated, or its classification no longer agrees.
+   *
+   * Carried separately from the rows because `G19` requires every close to
+   * refuse on exactly these, so the screen has to be able to LEAD with them
+   * rather than leave them to be found by scrolling.
+   */
+  broken: string[]
+  /** How many unmapped accounts the matcher has a candidate for. */
+  suggested: number
+  /** `'QuickBooks Online'`, or null with nothing connected. Never hardcode it. */
+  providerLabel: string | null
+  /** The provider round trip is in flight. The chart does not wait on it. */
+  isPending: boolean
+  /** The provider round trip failed. One muted line, not a page-level error. */
+  isError: boolean
+}
+
+/**
+ * How a suggestion earned itself, in the words a person is shown.
+ *
+ * 🛑 Always rendered WITH the suggestion, never behind a tooltip in settings. A
+ * wrong account id in a journal entry balances, so nothing downstream can catch
+ * it and the confirming person is the last line of defence - showing them the
+ * answer without the evidence turns a confirmation back into a guess.
+ */
+export const ACCOUNT_SUGGESTION_REASON_COPY: Record<AccountSuggestionReason, string> = {
+  number: 'same account number',
+  name: 'same name',
+}
+
+/** `1310 · Inventory Asset`, the way a PROVIDER account reads in a picker. */
+export function formatProviderAccount(account: ProviderAccount): string {
+  return account.number
+    ? `${account.number} · ${account.fullyQualifiedName}`
+    : account.fullyQualifiedName
+}
+
+/**
+ * A confirmed mapping whose target has gone, been deactivated, or changed
+ * statement section.
+ *
+ * 🛑 ONE definition, two screens. This predicate decides whether a close will
+ * refuse (`resolveMappedAccounts` re-checks the identical three conditions
+ * against the chart it just fetched), so the chart list and the wizard's map
+ * must not each carry their own copy of it to drift.
+ */
+export function isMappingBroken(row: AccountIdentityRow): boolean {
+  if (row.state !== 'confirmed') return false
+  const live = row.liveProviderAccount
+  return !live || !live.active || live.classification !== row.account.accountType
 }
 
 /**

--- a/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
@@ -30,24 +30,52 @@
 // it was an autosaving form whose every commit wrote LOCAL REACT STATE. The
 // read-only pane was the fix for that, not a placeholder for this: what makes the
 // inputs honest now is that `chartAccountUpdate` exists, and nothing else.
+//
+// ── The provider account (task 19) ──────────────────────────────────────────
+//
+// The sixth row is the account map, which used to be a whole tab. It is here
+// because it IS an attribute of this account - stored on the `gl_account`
+// instance as a connection-scoped `qboAccountId`, exactly as its code and its
+// type are stored on it.
+//
+// 🛑 It writes through `ledger.setAccountIdentity` (`ledgerPost`), NOT through
+// `onUpdate`. `chartAccountUpdate` knows nothing about a provider, and the
+// mapping write has its own job: it revalidates the target against the LIVE
+// provider chart before writing, because a picker rendered five minutes ago may
+// be offering an account somebody has since deactivated.
+//
+// 🛑 The row degrades, it never blocks. With no provider connected, while the
+// map is loading, and when the provider round trip has FAILED, the row renders
+// one muted line and the other five rows stay fully editable. A QuickBooks
+// outage must not be able to stop somebody renaming an account.
 
 import { FieldType } from '@auxx/database/enums'
 import {
   ACCOUNT_ROLE_LABELS,
+  type AccountIdentityRow,
   type AccountRole,
   type ChartAccountRow,
   type GlAccountTypeValue,
 } from '@auxx/lib/postings/client'
 import { Button } from '@auxx/ui/components/button'
+import { Combobox } from '@auxx/ui/components/combobox'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection } from '@auxx/ui/components/section'
-import { Landmark, Trash2 } from 'lucide-react'
+import { Check, Landmark, Trash2 } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { PickerTrigger } from '~/components/ui/picker-trigger'
 import { BaseType } from '~/components/workflow/types'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
-import { ACCOUNT_TYPE_OPTIONS, type ChartDraftHandle } from './accounts-types'
+import {
+  ACCOUNT_SUGGESTION_REASON_COPY,
+  ACCOUNT_TYPE_OPTIONS,
+  type ChartDraftHandle,
+  type ChartMapView,
+  formatProviderAccount,
+  isMappingBroken,
+} from './accounts-types'
 
 /**
  * ⚠️ A `SINGLE_SELECT` hands its value back as an ARRAY - `['expense']` - because
@@ -65,7 +93,7 @@ function firstSelected(value: unknown): string | null {
 }
 
 /** Which field a refusal belongs to. Routed from the patch key that caused it. */
-type FieldKey = 'code' | 'name' | 'accountType' | 'isActive' | 'form'
+type FieldKey = 'code' | 'name' | 'accountType' | 'isActive' | 'mapping' | 'form'
 
 /** The four writable attributes, as the form holds them. */
 interface AccountValues {
@@ -103,6 +131,10 @@ interface ChartAccountEditorProps {
   onUpdate: (id: string, patch: Partial<AccountValues>) => Promise<ChartAccountRow>
   /** Confirms, then archives. Rejects with the server's message. */
   onRemove: (id: string) => Promise<void>
+  /** The account map. Decorates this pane; never gates the rest of it. */
+  map: ChartMapView
+  /** Pairs this account with a provider account, or clears it with `null`. */
+  onSetIdentity: (glAccountId: string, providerAccountId: string | null) => Promise<void>
 }
 
 /**
@@ -134,6 +166,8 @@ export function ChartAccountEditor({
   onDraftCommitted,
   onUpdate,
   onRemove,
+  map,
+  onSetIdentity,
 }: ChartAccountEditorProps) {
   // The draft stays active while `selectedId` is its COMMITTED id too - swapping
   // to a query-bound instance would remount the inputs mid-typing (replaced text,
@@ -153,6 +187,8 @@ export function ChartAccountEditor({
         onDraftCommitted={onDraftCommitted}
         onUpdate={onUpdate}
         onRemove={onRemove}
+        map={map}
+        onSetIdentity={onSetIdentity}
       />
     )
   }
@@ -183,6 +219,8 @@ export function ChartAccountEditor({
       onDraftCommitted={onDraftCommitted}
       onUpdate={onUpdate}
       onRemove={onRemove}
+      map={map}
+      onSetIdentity={onSetIdentity}
     />
   )
 }
@@ -211,13 +249,21 @@ function ChartAccountForm({
   onDraftCommitted,
   onUpdate,
   onRemove,
+  map,
+  onSetIdentity,
 }: {
   account: ChartAccountRow | null
   roles: AccountRole[]
   postedLines: number
 } & Pick<
   ChartAccountEditorProps,
-  'onDraftChange' | 'onCreate' | 'onDraftCommitted' | 'onUpdate' | 'onRemove'
+  | 'onDraftChange'
+  | 'onCreate'
+  | 'onDraftCommitted'
+  | 'onUpdate'
+  | 'onRemove'
+  | 'map'
+  | 'onSetIdentity'
 >) {
   const valuesRef = useRef<AccountValues>({
     code: account?.code ?? '',
@@ -229,6 +275,7 @@ function ChartAccountForm({
   const [errors, setErrors] = useState<Partial<Record<FieldKey, string>>>({})
   const [creating, setCreating] = useState(false)
   const [removing, setRemoving] = useState(false)
+  const [mapping, setMapping] = useState(false)
 
   // 🛑 Synchronous, NOT state-derived: a `disabled` prop driven by `creating` is
   // not enough, because two clicks landing before a re-render both pass it. In
@@ -333,6 +380,35 @@ function ChartAccountForm({
     }
   }, [onCreate, onDraftCommitted, onUpdate])
 
+  /**
+   * Pair this account with a provider account, or clear the pairing with `null`.
+   *
+   * 🛑 Nothing is re-validated here. `setAccountIdentity` re-checks existence,
+   * active status and classification against the LIVE provider chart before
+   * writing, and its refusal names the account and the problem; a second
+   * client-side authority would drift from it and "Could not save" would throw
+   * away the only sentence that says what to do next.
+   */
+  const handleSetIdentity = useCallback(
+    async (providerAccountId: string | null) => {
+      const recordId = recordIdRef.current
+      if (!recordId) return
+      setErrors((prev) => ({ ...prev, mapping: undefined }))
+      setMapping(true)
+      try {
+        await onSetIdentity(recordId, providerAccountId)
+      } catch (error) {
+        setErrors((prev) => ({
+          ...prev,
+          mapping: error instanceof Error ? error.message : 'Could not save the mapping.',
+        }))
+      } finally {
+        setMapping(false)
+      }
+    },
+    [onSetIdentity]
+  )
+
   const handleRemove = useCallback(async () => {
     const recordId = recordIdRef.current
     if (!recordId) return
@@ -436,6 +512,25 @@ function ChartAccountForm({
 
           {committed && (
             <FieldPanelRow
+              title={map.providerLabel ?? 'Accounting system'}
+              type={BaseType.STRING}
+              showIcon
+              description={PROVIDER_ROW_DESCRIPTION}>
+              <ProviderAccountField
+                map={map}
+                accountType={values.accountType}
+                identity={
+                  recordIdRef.current ? map.byAccountId.get(recordIdRef.current) : undefined
+                }
+                pending={mapping}
+                onSet={handleSetIdentity}
+              />
+              <FieldError message={errors.mapping} />
+            </FieldPanelRow>
+          )}
+
+          {committed && (
+            <FieldPanelRow
               title='Roles'
               type={BaseType.STRING}
               showIcon
@@ -490,6 +585,160 @@ function ChartAccountForm({
           )}
         </div>
       </ScrollArea>
+    </div>
+  )
+}
+
+/**
+ * ⚠️ Says CONFIRM, not "pick". `G19` stores a human confirmation rather than a
+ * match, and the sentence has to carry why: without it, a later rename or
+ * renumber on either side silently moves where a role posts.
+ */
+const PROVIDER_ROW_DESCRIPTION =
+  'The account over there that this one corresponds to. Confirming it once is what stops a later rename or renumber on either side from quietly moving where a role posts.'
+
+/**
+ * The provider account for one `gl_account`: a picker, the matcher's suggestion
+ * with its reason, and the unmap control.
+ *
+ * 🛑 Four states, and three of them are NOT errors. Nothing connected, a map
+ * still loading, and a map that failed to load all render one muted line - never
+ * an alert, never a blocked pane. `P1` makes "nothing connected" a first-class
+ * outcome: the entry is still built, balanced and stored here.
+ */
+function ProviderAccountField({
+  map,
+  accountType,
+  identity,
+  pending,
+  onSet,
+}: {
+  map: ChartMapView
+  /** The LIVE local value, not the saved one - see the filter below. */
+  accountType: GlAccountTypeValue | null
+  identity: AccountIdentityRow | undefined
+  pending: boolean
+  onSet: (providerAccountId: string | null) => Promise<void>
+}) {
+  // 🛑 LOADING is checked before "nothing connected", not after. `connected` is
+  // false for the whole of the provider round trip, so testing it first would
+  // tell every reader their accounting system is disconnected for as long as it
+  // takes to answer - a CLAIM about the org, made false by the render order.
+  if (map.isPending) {
+    return (
+      <p className='flex min-h-8 items-center text-muted-foreground text-sm'>
+        Reading the account map...
+      </p>
+    )
+  }
+
+  if (map.isError) {
+    return (
+      <p className='flex min-h-8 items-center text-muted-foreground text-sm'>
+        Could not read the account map. Everything else about this account is unaffected.
+      </p>
+    )
+  }
+
+  if (!map.connected) {
+    return (
+      <p className='flex min-h-8 items-center text-muted-foreground text-sm'>
+        Nothing connected. Entries are still built, balanced and stored here.
+      </p>
+    )
+  }
+
+  // Live in the chart but not yet in the map: an account created moments ago,
+  // before the invalidated `accountMap` came back.
+  if (!identity) {
+    return (
+      <p className='flex min-h-8 items-center text-muted-foreground text-sm'>
+        Not in the account map yet.
+      </p>
+    )
+  }
+
+  // 🛑 Filtered by the LIVE `accountType`, not by `identity.account.accountType`.
+  // Somebody who has just changed this account's type is picking for what it is
+  // NOW; offering candidates for the type it used to be would hand them a
+  // mapping the server is about to refuse.
+  //
+  // ⚠️ Type compatibility is a FILTER, not a tiebreak. A candidate in the wrong
+  // statement section is never offered at any confidence: mapping a liability to
+  // a revenue account balances AND misstates the P&L, and the number somebody
+  // recognises gives them no way to tell.
+  const options = map.providerAccounts
+    .filter((account) => account.active && account.classification === accountType)
+    .map((account) => ({ value: account.id, label: formatProviderAccount(account) }))
+
+  const suggestion = identity.suggestion
+  const broken = isMappingBroken(identity)
+
+  // The confirmed target, as it should READ. `liveProviderAccount` is the truth
+  // when there is one; the recorded name is the fallback that keeps a BROKEN row
+  // able to say what it used to point at, which is the only clue to what it
+  // should point at now.
+  const selectedLabel = identity.liveProviderAccount
+    ? formatProviderAccount(identity.liveProviderAccount)
+    : identity.providerAccountNumber
+      ? `${identity.providerAccountNumber} · ${identity.providerAccountName ?? 'Unknown account'}`
+      : (identity.providerAccountName ?? 'Unknown account')
+
+  return (
+    <div className='flex min-w-0 flex-col gap-1.5'>
+      {/* 🛑 `PickerTrigger`, not the Combobox's own default button. Every other
+          picker in a `FieldPanelRow` is a transparent full-width trigger with the
+          chevron at the end - the Type row directly above this one included - and
+          an outline button here would read as the one control on the pane that
+          came from somewhere else.
+
+          Its clear affordance IS the unmap: `onClear` writes `null`, which is
+          what `setAccountIdentity` takes to mean "this pairing is off". A
+          separate Unmap button would be a second control for one act. */}
+      <Combobox
+        placeholder='Select account'
+        emptyText='No compatible account'
+        value={identity.providerAccountId ?? undefined}
+        options={options}
+        disabled={pending}
+        onChangeValue={(value) => void onSet(value)}
+        trigger={
+          <PickerTrigger
+            asCombobox
+            disabled={pending}
+            className='w-full ps-0 pe-1'
+            hasValue={!!identity.providerAccountId}
+            placeholder='Select account'
+            showClear
+            onClear={() => void onSet(null)}>
+            <span className='truncate text-sm'>{selectedLabel}</span>
+          </PickerTrigger>
+        }
+      />
+
+      {suggestion && (
+        <div className='flex min-w-0 items-center gap-1.5'>
+          <Button
+            variant='outline'
+            size='xs'
+            className='min-w-0'
+            disabled={pending}
+            onClick={() => void onSet(suggestion.account.id)}>
+            <Check />
+            <span className='truncate'>Confirm {formatProviderAccount(suggestion.account)}</span>
+          </Button>
+          <span className='shrink-0 text-muted-foreground text-xs'>
+            {ACCOUNT_SUGGESTION_REASON_COPY[suggestion.reason]}
+          </span>
+        </div>
+      )}
+
+      {broken && (
+        <p className='text-destructive text-xs'>
+          The account this points at has been removed, deactivated or moved to a different section.
+          Every close refuses until it is re-mapped.
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -14,6 +14,20 @@
 // account" and the Create button becoming enabled, the only evidence that
 // anything is happening is this row tracking what is being typed - without it
 // the person is filling in a form with no place in the list.
+//
+// ── The account map lives here too (task 19) ────────────────────────────────
+//
+// There is no QuickBooks tab any more. Which provider account each of ours
+// corresponds to is an ATTRIBUTE of a `gl_account` - it is stored on the
+// instance, and it is edited in the detail pane beside the code, the name and
+// the type. What is left on this side is the part of the map that is about the
+// LIST rather than about a row: the progress counter, the bulk confirm, the
+// broken banner, and one badge per row.
+//
+// 🛑 The map DECORATES this list, it never sources it. `ChartMapView`'s header
+// has the argument; the operative consequence is that everything below renders
+// from `accounts` and stays fully usable while `map.isPending`, while
+// `map.isError`, and with no provider connected at all.
 
 import type { AccountRole, ChartAccountRow } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
@@ -22,9 +36,15 @@ import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Landmark, Plus } from 'lucide-react'
+import { Landmark, Plus, Sparkles, TriangleAlert } from 'lucide-react'
 import { useState } from 'react'
-import { accountTypeColor, accountTypeLabel, type ChartDraftHandle } from './accounts-types'
+import {
+  accountTypeColor,
+  accountTypeLabel,
+  type ChartDraftHandle,
+  type ChartMapView,
+  isMappingBroken,
+} from './accounts-types'
 
 interface ChartListProps {
   accounts: ChartAccountRow[]
@@ -38,6 +58,11 @@ interface ChartListProps {
   /** The uncommitted draft, if any. Rendered as a phantom row at the top. */
   draft: ChartDraftHandle | null
   onAddDraft: () => void
+  /** The account map, decorating the rows. Never the source of them. */
+  map: ChartMapView
+  /** Confirms every suggested mapping at once. */
+  onConfirmSuggested: () => void
+  confirming: boolean
 }
 
 export function ChartList({
@@ -48,8 +73,17 @@ export function ChartList({
   rolesByAccountId,
   draft,
   onAddDraft,
+  map,
+  onConfirmSuggested,
+  confirming,
 }: ChartListProps) {
   const [search, setSearch] = useState('')
+
+  // 29 rows, recomputed per keystroke of the search box. A `useMemo` here would
+  // cost more to read than the loop costs to run.
+  const mapped = accounts.filter(
+    (account) => map.byAccountId.get(account.id)?.state === 'confirmed'
+  ).length
 
   const filtered = search
     ? accounts.filter(
@@ -76,6 +110,53 @@ export function ChartList({
           Add account
         </Button>
       </div>
+
+      {/* 🛑 Gate on the PROVIDER, never on an empty map. "Nothing is connected"
+          and "connected but nothing mapped" are different answers needing
+          different actions, and collapsing them would tell somebody to map a
+          chart with nothing to map it against. With nothing connected this whole
+          strip is absent and the chart is unchanged - the explanation lives in
+          the detail pane, on the row it is about. */}
+      {map.connected && (
+        <div className='flex flex-wrap items-center gap-2'>
+          <span className='text-muted-foreground text-xs tabular-nums'>
+            {mapped} of {accounts.length} mapped to {map.providerLabel ?? 'your accounting system'}
+          </span>
+          {map.suggested > 0 && (
+            <Button
+              variant='outline'
+              size='xs'
+              loading={confirming}
+              loadingText='Confirming...'
+              onClick={onConfirmSuggested}>
+              <Sparkles />
+              Accept {map.suggested}
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* A dangling mapping is a REPAIR, not a mapping, and `G19` requires every
+          close to refuse on exactly these - so it leads the tab rather than
+          waiting to be found by selecting the right row. */}
+      {map.broken.length > 0 && (
+        <div className='flex items-start gap-2 rounded-xl border border-destructive/40 bg-destructive/5 p-3'>
+          <TriangleAlert className='mt-0.5 size-4 shrink-0 text-destructive' />
+          <div className='min-w-0'>
+            <p className='font-medium text-sm'>
+              {map.broken.length} mapping{map.broken.length === 1 ? '' : 's'} no longer valid
+            </p>
+            <p className='text-muted-foreground text-xs'>
+              {map.broken.join(', ')}{' '}
+              {map.broken.length === 1
+                ? 'points at an account that has'
+                : 'point at accounts that have'}{' '}
+              been removed, deactivated or moved to a different section. Every close refuses until{' '}
+              {map.broken.length === 1 ? 'it is' : 'they are'} re-mapped.
+            </p>
+          </div>
+        </div>
+      )}
 
       {isLoading ? (
         <EmptySection loading />
@@ -127,6 +208,7 @@ export function ChartList({
 
           {filtered.map((account) => {
             const roles = rolesByAccountId.get(account.id) ?? []
+            const identity = map.byAccountId.get(account.id)
             return (
               <TreeRow
                 key={account.id}
@@ -156,6 +238,23 @@ export function ChartList({
                         Inactive
                       </Badge>
                     )}
+                    {/* Only ever rendered against a LOADED map. An unmapped
+                        badge on rows the provider round trip has not answered
+                        for yet is a claim about the org, and rendering it
+                        mid-load makes it a false one. */}
+                    {map.connected && !map.isPending && identity && isMappingBroken(identity) && (
+                      <Badge variant='destructive' size='xs'>
+                        Re-map
+                      </Badge>
+                    )}
+                    {map.connected &&
+                      !map.isPending &&
+                      identity?.state === 'unmapped' &&
+                      !identity.suggestion && (
+                        <Badge variant='outline' size='xs'>
+                          Not mapped
+                        </Badge>
+                      )}
                     {roles.length > 0 && (
                       <span>
                         {roles.length} {roles.length === 1 ? 'role' : 'roles'}

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-account-map-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-account-map-page.tsx
@@ -17,23 +17,27 @@
 // works, because an org that never connects QuickBooks still has a complete
 // internal ledger. What it does not do is pretend the map is done.
 //
-// The editor itself is `AccountMapList`, shared with the Accounts settings tab,
-// so the two cannot drift into disagreeing about what a mapping is.
+// The editor itself is `AccountMapList`, which since task 19 renders HERE only -
+// settings folded the map into the chart of accounts, where the provider account
+// is a row in the detail pane beside the code, the name and the type. The two
+// surfaces cannot drift into disagreeing about what a mapping is because the
+// authority is `ledger.setAccountIdentity`, which revalidates against the live
+// provider chart before writing, not the component either one renders.
 
 import { Button } from '@auxx/ui/components/button'
 import { ArrowUpRight } from 'lucide-react'
 import Link from 'next/link'
 import { AccountMapList } from '~/components/accounting/ui/settings/account-map-list'
 
-const MAP_HREF = '/app/accounting/settings/accounts?s=quickbooks'
+const MAP_HREF = '/app/accounting/settings/accounts?s=chart'
 
 /**
  * The account map, in `compact` mode: only the rows that still need a decision,
  * plus any confirmed mapping that has since broken.
  *
  * Compact because a wizard page answers "what is left to do" - a full 29-row
- * table with twenty already-settled rows buries the four that are not. The
- * settings tab renders the whole map for the times somebody wants to audit it.
+ * table with twenty already-settled rows buries the four that are not. The chart
+ * of accounts carries the whole map for the times somebody wants to audit it.
  */
 export function WizardAccountMapPage() {
   return (
@@ -53,7 +57,7 @@ export function WizardAccountMapPage() {
       <div>
         <Button variant='outline' size='sm' asChild>
           <Link href={MAP_HREF}>
-            Open the full account map
+            Open the chart of accounts
             <ArrowUpRight />
           </Link>
         </Button>


### PR DESCRIPTION
The Accounts settings page had three tabs: Roles, Chart of accounts, and QuickBooks. Two now.

Which provider account one of ours corresponds to is an **attribute of a `gl_account`** — it is stored on the instance as a connection-scoped `qboAccountId` — so it belongs beside the code, the name and the type, not in a tab of its own. `account-map-list.tsx`'s own header already recorded that it copies `chart-list.tsx`'s row shape deliberately, down to the badge-shaped secondary: two tabs were rendering one list of `gl_account` rows and differing by one field.

A tab named after a vendor also contradicts `P1`, which makes the provider one adapter behind one interface. The field label reads off `providerLabel` and falls back to "Accounting system" rather than disappearing.

**Nothing in `packages/lib`, no new procedure, no new permission key, no migration.** Six files in `apps/web`.

## Where each piece of the tab went

| Piece | New home |
| --- | --- |
| the per-row picker | a sixth `FieldPanelRow` in `chart-account-editor.tsx` |
| the suggestion, with its reason | beside it, promoted out of the tooltip |
| `Accept {n}` bulk confirm | the chart list header |
| the `broken` banner | above the list, leading the tab |
| `{mapped} of {total} mapped` | the chart list header |
| `Not mapped` / `Re-map` badges | the row's `secondary`, beside the type badge |
| "nothing connected" full-screen empty state | dissolved into one muted line in the pane |

## The defect this fixes

`invalidateChart` never invalidated `accountMap`. A mapping's validity depends on `live.classification === account.accountType`, so changing a mapped account's **type** broke its mapping on the server immediately, while the other tab went on rendering it as fine until something else happened to refetch. Nobody noticed because the two states lived on two tabs.

The break is **shown, never repaired by clearing the cell**. There is deliberately no `source`/`confirmedAt` column — a populated cell *is* a confirmation — so silently clearing one is indistinguishable from a mapping nobody ever made, where a broken one is visible, refuses at the provider, and is one pick away from being fixed.

## Invariants worth reviewing for

- **The chart never waits on the provider.** `chartAccounts` is a local read; `accountMap` is a QuickBooks round trip. The list renders from the first and is only decorated by the second, so a token expiry cannot make an org's chart unreadable or unrenamable. The query is also gated to the chart tab so Roles does not pay for it.
- **Loading is checked before "nothing connected."** `connected` is false for the whole round trip, so testing it first would tell every reader their accounting system was disconnected for as long as QuickBooks took to answer.
- **Type compatibility stays a filter, not a tiebreak**, and it filters on the *live* local type — somebody who has just changed the type is picking for what it is now.
- **`isMappingBroken` is shared, not copied.** It is the predicate a close refuses on, so the wizard's map and the chart list must not each carry their own. `ACCOUNT_SUGGESTION_REASON_COPY` and `formatProviderAccount` came out with it.
- **The picker is a `PickerTrigger`**, matching the Type row above it and every other picker in a `FieldPanelRow`; its clear affordance is the unmap, so there is no second control for one act.
- `account-map-list.tsx` survives for the wizard's mapping step, which is `compact` and answers "what is left" rather than "what is the state of things". The shared authority is `ledger.setAccountIdentity`, which revalidates against the live provider chart before writing — not the component either surface renders.

## Driven, against the dev org's live QuickBooks

| Checked | Result |
| --- | --- |
| Two tabs; `?s=quickbooks` | Falls through to Roles. No blank pane |
| Counter, badges | `5 of 24 mapped to QuickBooks Online`; unmapped rows carry `Not mapped` |
| Picker type filter | 2160 (liability) offered **only** QuickBooks liabilities |
| Write | 2160 → Notes Payable: counter 5 → 6, persisted across reload |
| The type-change defect | 1190 mapped, then Asset → Expense: banner appeared, row flipped to `Re-map`, mapping **not** cleared. Setting the type back cleared the break |
| Refusal copy | 2160 → Expense refused verbatim on the Type row: *"'grni' … posts here and must be mapped to a liability account. Repoint the role first, or mark it unused."* |
| Unmap | 7 → 6 → 5. Dev org left exactly as found |
| Console | No errors |

One copy defect found and fixed while driving: the banner read *"1190 point at accounts that have been…"*. It now agrees with the count, here and in the wizard's map.

## Not driven

- **`Accept {n}`** — this org's matcher returns zero suggestions against that QuickBooks company, so the button never rendered.
- **Nothing-connected and provider-failure states** — both need the connection pulled. Read, not run.
- **The wizard's mapping step** — stepping to page 7 writes draft setup state on an org that is already `finalized`. Its component is unchanged apart from the shared helpers.

## Unchanged by this PR

`close-month.ts` still does not consult the account map, so a month previews clean and fails on export. `G19`'s "refuse the close" is still satisfied one layer later than it reads.

https://claude.ai/code/session_01NJ9nPX1Tv9Jh4gU17fLx76
