### PR TITLE
fix(money): guard deletes on every visible money parent

### DIFF
--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -352,6 +352,97 @@ incremental and therefore locked). See §7.3.
 a date correction under standard or average costing — and a full recomputation under FIFO. That
 asymmetry is one of the reasons FIFO is not on the table.
 
+### 6.4 The generic delete door, and why `updatable: false` does not close it
+
+**Every entity in this subsystem is `EntityInstance`-backed and adds no Drizzle table (§3). The
+consequence nobody decided on is that each one inherits the generic records table — with its row
+delete and its bulk delete — for free.** Everything else in this guide reasons about the money
+doors (receive, bill, match, reverse). This is the door that arrived with the storage choice, and
+it is the one that had no guard for the first six weeks of this subsystem's life.
+
+🛑 **`updatable: false` is ADVISORY and has no delete counterpart.** It is read by the grid cell
+and the connector catalog and by nothing on the write path
+(`postings/build-month-end-inventory.ts:35` says so in prose). There is no `deletable: false`
+anywhere in the schema. So "append-only" is a claim about EDITS only, and reading it as a claim
+about the row's existence is the specific mistake that let a part be hard-deleted out of a posted
+period.
+
+⚠️ **The evidence lock has the same hole, and it is the third instance of this shape.**
+`field-hooks/pre/purchase-order-line-evidence-lock.ts` freezes a line's `quantityOrdered` and
+`expectedUnitPrice` the moment a receipt or a bill line exists — an EDIT guard with no delete
+counterpart, so until `guardPurchaseOrderDelete` shipped you could not change a received line's
+quantity but could delete the line outright, or the order above it.
+
+🛑 **And the generic delete is quieter than a dangling reference, not louder.**
+`deleteEntityInstance` calls `sweepEntityFieldValues`, which removes **both halves** of every
+relation `FieldValue` before dropping the row. A dangling id is evidence — you can still see what
+the child pointed at. A swept relation leaves the child with an **empty cell and no trace a parent
+ever existed**, so an unguarded parent delete is unrecoverable rather than merely wrong. Children
+are never themselves deleted: before these guards, deleting a purchase order left its lines, its
+receipts and any bill naming it all alive and all unlinked.
+
+The seam that does close it is `registerEntityPreDeleteHooks(apiSlug, [...])`
+(`field-hooks/register-hooks.ts`), which fires synchronously inside `deleteEntity` — before
+`deleteEntityInstance` — on **every** path: `record.delete`, `record.bulkDelete`, drawers, Kopilot
+and the API. Throwing rejects the delete.
+
+⚠️ **A `deleted` record rule is NOT that seam.** It fires after the row is gone and cannot refuse;
+`RecordRuleRun.entityInstanceId` has no foreign key precisely because deleted-rules log runs for
+records that no longer exist. The four `on: 'deleted'` rules this subsystem declares
+(`mfg-vendor-parts-deleted`, `mfg-subparts-deleted`, `mfg-stock-movements-deleted`,
+`purchasing-vendor-bill-lines-deleted`) each recompute a roll-up on a **surviving parent** — which
+is also why a pre-delete cascade must delete its children through `UnifiedCrudHandler.delete` and
+not raw SQL, or those rules never fire.
+
+**Who is visible, and who is guarded:**
+
+| Entity | `isVisible` | Pre-delete hook |
+| --- | --- | --- |
+| `part` | **true** | ✅ `guardPartDelete` — refuses when a movement sits in a settled period; cascades `subpart` + `vendor_part`; leaves the vendor documents |
+| `build` | **true** | ✅ `guardBuildDelete` — refuses on a settled movement **or** on either end of a reversal pair; cascades the `build_consume`/`build_produce` movements |
+| `purchase_order` | **true** | ✅ `guardPurchaseOrderDelete` — refuses when any `vendor_bill` names it, or when a receipt under any of its lines is settled; cascades receipts **then** lines |
+| `vendor_bill` | **true** | ✅ `guardVendorBillDelete` — refuses on `posted`/`partially_paid`/`paid`, on any `vendor_payment_allocation`, or on a settled `billedAt`; cascades its lines |
+| `stock_movement`, `subpart`, `vendor_part`, `purchase_order_line`, `vendor_bill_line`, `gl_account` | false | n/a — not reachable from a records table, only through a parent |
+
+All four share `postings/settled-periods.ts` (`settledPeriodsFor`) and, where they read the ledger,
+`field-hooks/pre/guarded-movements.ts`. Both were extracted precisely so the reasoning below
+survives being reused — a copied predicate keeps the behaviour and loses the reason.
+
+The set is pinned by `field-hooks/__tests__/delete-guard-registration.test.ts`, which now derives
+the visible money parents from `SYSTEM_ENTITIES` and asserts every one carries a hook, rather than
+listing the unguarded ones — that earlier form went vacuously true the moment the list emptied. So
+a money entity flipping to visible, or a new one shipping visible, is a test failure rather than a
+discovery six weeks later.
+
+🛑 **`suppressPostDeleteHooks` is the trap, and the correct answer differs per guard.** Suppress
+when the child's post-delete hook re-projects **the document being deleted** — `vendor_bill`, whose
+`rematchAfterBillLineDelete` calls `markOrRematchBill` on the dying bill once per line, and the
+existing `invoices`/`orders` guards. Do **not** suppress when it lands on a **surviving** record —
+`part`, `build` and `purchase_order`, where `recalculatePartQoH` on the other end is the entire
+integration and suppressing it reproduces the stale-rolled-cost bug the part guard exists to fix.
+Nothing at the call site distinguishes the two cases.
+
+**"Settled" is three predicates, and each catches a case the others miss.** `settledPeriodsFor`
+refuses when a month is locked (`resolvePeriodLock` + `isPeriodLocked`), **or** has an
+entry currently standing in the books, **or** falls at or before `accounting.cutoffPeriod` (those
+months "are covered by the frozen opening baseline and can never be closed here" —
+`postings/close-periods.ts`).
+
+🛑 **The posted check reads `GlPosting` directly and must NOT use `listClosePeriods`.** The close
+strip answers *"can I close this month?"*, so `resolveState` reports the **effective** posting —
+the highest revision that is not itself reversed. A month holding rev 1 `posted` followed by rev 2
+`failed` therefore reads **`open`**, correctly, because there is an unfinished attempt in it — while
+rev 1 is still standing in the books with `assertions.before.balances` computed from the very
+movements a guard would be deciding about. This is not hypothetical: it is the state of DemoOrg1's
+`2026-08` today. `status = 'posted'` is the right predicate because a reversal flips the row it
+supersedes to `reversed`, so a reversed entry stops matching on its own.
+
+🛑 **A guard that reads movements must not be built on `listReceipts` /
+`getPartReceiptHistory`.** Both hard-filter `stock_movement_type = 'receive'`
+(`receiving/receipt-queries.ts`), so a part whose only history is a `scrap`, an `initial` opening
+balance or a `build_consume` would pass a receipts-only check and delete clean out of a posted
+month.
+
 ---
 
 ## 7. Costing — where a number comes from and when it freezes

--- a/packages/lib/scripts/audit-part-references.ts
+++ b/packages/lib/scripts/audit-part-references.ts
@@ -1,0 +1,763 @@
+// packages/lib/scripts/audit-part-references.ts
+//
+// Read-only audit of everything the four visible money parents are attached to,
+// and a before/after diff for the "delete them all and see what stays" test
+// (plans/money/tasks/20-part-delete-safety.md §7, widened to `builds`,
+// `purchase-orders` and `vendor-bills` by
+// plans/money/tasks/21-money-parent-delete-safety.md §8).
+//
+// ⚠️ **The diff now measures the GUARDS as much as the strands.** Before task 20
+// and 21 every parent deleted clean and every child was left behind; now a
+// settled parent refuses, so a `subject` count that does NOT fall to zero is the
+// guard working rather than the test failing. Read it against
+// `docs/inventory-costing-architecture-guide.md` §6.4.
+//
+// It touches nothing. Run it, wipe the parts, run it again against the saved
+// snapshot, and the diff tells you which numbers moved and which ones were not
+// allowed to.
+//
+//   # before
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/audit-part-references.ts --save /tmp/parts-before.json
+//
+//   # ...delete the parts...
+//
+//   # after
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/audit-part-references.ts --compare /tmp/parts-before.json
+//
+//   # one org only (name or id)
+//   … audit-part-references.ts --org DemoOrg1
+//
+// ## What the four metric kinds mean
+//
+// Every metric is tagged, and the diff's verdict comes from the tag rather than
+// from a human reading the numbers:
+//
+//   * `subject`   - the parents themselves. Falling to zero means everything was
+//     deletable; a residue is what the guards refused.
+//   * `must-hold` - a change here is an INTEGRITY FAILURE, not an observation.
+//     The GL is the whole of it: a posted `GlPosting` and its lines, the role
+//     assignments and the chart are frozen accounting records, and a record
+//     delete may not move them. The vendor's own documents are here for the same
+//     reason - a purchase order line and a bill line are things a vendor sent
+//     us, and deleting our part does not unsend them
+//     (`docs/inventory-costing-architecture-guide.md`: a bill's totals are
+//     transcribed, never computed).
+//   * `strand`    - orphaned children: rows that survive with the part cell now
+//     empty. Growth here is the finding this whole exercise exists to measure,
+//     and today it is EXPECTED to grow, because `parts` has no pre-delete hook.
+//   * `hygiene`   - must be zero before and after. A non-zero value means
+//     `sweepEntityFieldValues` did not do its job, which would be a much more
+//     serious bug than anything task 20 is about.
+//
+// ⚠️ Read the `strand` lines against the briefs before calling any of them a bug.
+// Purchase order lines and vendor bill lines are SUPPOSED to survive a PART
+// delete (`disposition: leave`) while being cascaded by their own parent's
+// delete; `subparts` and `vendor-parts` are not supposed to survive either.
+
+import { database as db } from '@auxx/database'
+import { sql } from 'drizzle-orm'
+
+// =============================================================================
+// ARGS
+// =============================================================================
+
+const argv = process.argv.slice(2)
+
+function flag(name: string): string | null {
+  const i = argv.indexOf(name)
+  return i >= 0 && argv[i + 1] ? argv[i + 1]! : null
+}
+
+const ORG_FILTER = flag('--org')
+const SAVE_PATH = flag('--save')
+const COMPARE_PATH = flag('--compare')
+
+// =============================================================================
+// SHAPE
+// =============================================================================
+
+type MetricKind = 'subject' | 'must-hold' | 'strand' | 'hygiene'
+
+interface Metric {
+  key: string
+  kind: MetricKind
+  value: number
+  /** Free-text context printed beside the number. */
+  note?: string
+}
+
+interface OrgSnapshot {
+  organizationId: string
+  organizationName: string
+  metrics: Metric[]
+  /** Inbound relationship rows by systemAttribute, for the human-readable table. */
+  inbound: { attribute: string; rows: number; distinctParts: number }[]
+  /** Stock movements by accounting period, for the settled-period question. */
+  movementPeriods: { period: string; movements: number; uncosted: number }[]
+}
+
+interface Snapshot {
+  takenAt: string
+  orgs: OrgSnapshot[]
+}
+
+/**
+ * Every relationship that names one of the audited parents, as
+ * `systemAttribute`. Sourced from the live `CustomField` rows rather than from a
+ * hand-kept list — but pinned here so a renamed attribute shows up as a missing
+ * line instead of silently dropping out of the audit.
+ */
+const REFERENCE_ATTRIBUTES = [
+  // → part
+  'stock_movement_part',
+  'purchase_order_line_part',
+  'vendor_bill_line_part',
+  'vendor_part_part',
+  'subpart_parent_part',
+  'subpart_child_part',
+  'catalog_item_part',
+  'line_item_part',
+  'product_parts',
+  // → build
+  'stock_movement_build',
+  'build_reversal_of',
+  // → purchase_order
+  'purchase_order_line_purchase_order',
+  'vendor_bill_purchase_order',
+  // → vendor_bill
+  'vendor_bill_line_vendor_bill',
+  'vendor_payment_allocation_vendor_bill',
+] as const
+
+/**
+ * What the guard is supposed to do with a child, which drives the metric kind so
+ * the diff's verdict and the briefs cannot drift apart.
+ *
+ *   * `cascade`           - should go with the parent. Its total is watched.
+ *   * `refuse-or-cascade` - goes only when the period is open; a settled one
+ *     makes the parent undeletable.
+ *   * `refuse`            - its mere existence refuses the parent's delete, so
+ *     the parent count is what should not move.
+ *   * `leave`             - somebody else's document. Its total is `must-hold`.
+ */
+type Disposition = 'cascade' | 'refuse-or-cascade' | 'refuse' | 'leave'
+
+interface ParentSpec {
+  /** `EntityDefinition.entityType`. */
+  entityType: string
+  /** Metric prefix — the apiSlug, so a key reads the way the guard registers. */
+  slug: string
+  children: readonly { entityType: string; attribute: string; disposition: Disposition }[]
+}
+
+/**
+ * The four `isVisible` money parents
+ * (`docs/inventory-costing-architecture-guide.md` §3), each with the children
+ * that hang off it and what its guard does with them.
+ *
+ * ⚠️ **`purchase_order`'s receipts are deliberately absent from its `children`.**
+ * A `stock_movement` names the purchase order LINE, never the order, so it is
+ * not an inbound reference to the parent at all — which is exactly why
+ * `sweepEntityFieldValues` never touched receipts and an unguarded order delete
+ * looked harmless. The line's own total is what moves.
+ */
+const PARENTS: readonly ParentSpec[] = [
+  {
+    entityType: 'part',
+    slug: 'parts',
+    children: [
+      {
+        entityType: 'stock_movement',
+        attribute: 'stock_movement_part',
+        disposition: 'refuse-or-cascade',
+      },
+      { entityType: 'subpart', attribute: 'subpart_child_part', disposition: 'cascade' },
+      { entityType: 'vendor_part', attribute: 'vendor_part_part', disposition: 'cascade' },
+      {
+        entityType: 'purchase_order_line',
+        attribute: 'purchase_order_line_part',
+        disposition: 'leave',
+      },
+      { entityType: 'vendor_bill_line', attribute: 'vendor_bill_line_part', disposition: 'leave' },
+      { entityType: 'catalog_item', attribute: 'catalog_item_part', disposition: 'leave' },
+      { entityType: 'line_item', attribute: 'line_item_part', disposition: 'leave' },
+    ],
+  },
+  {
+    entityType: 'build',
+    slug: 'builds',
+    children: [
+      {
+        entityType: 'stock_movement',
+        attribute: 'stock_movement_build',
+        disposition: 'refuse-or-cascade',
+      },
+      { entityType: 'build', attribute: 'build_reversal_of', disposition: 'refuse' },
+    ],
+  },
+  {
+    entityType: 'purchase_order',
+    slug: 'purchase-orders',
+    children: [
+      {
+        entityType: 'purchase_order_line',
+        attribute: 'purchase_order_line_purchase_order',
+        disposition: 'cascade',
+      },
+      { entityType: 'vendor_bill', attribute: 'vendor_bill_purchase_order', disposition: 'refuse' },
+    ],
+  },
+  {
+    entityType: 'vendor_bill',
+    slug: 'vendor-bills',
+    children: [
+      {
+        entityType: 'vendor_bill_line',
+        attribute: 'vendor_bill_line_vendor_bill',
+        disposition: 'cascade',
+      },
+      {
+        entityType: 'vendor_payment_allocation',
+        attribute: 'vendor_payment_allocation_vendor_bill',
+        disposition: 'refuse',
+      },
+    ],
+  },
+]
+
+// =============================================================================
+// QUERIES
+// =============================================================================
+
+/**
+ * ⚠️ **A named org qualifies on its part DEFINITION, never on having parts left.**
+ * Requiring instances is right for the unfiltered listing — it keeps the ~28
+ * seeded orgs that have a part def and no parts out of the way — and it is
+ * exactly wrong for `--compare`, where the whole point is that the parts are
+ * gone. Gating both the same way made the after-run of the delete test print
+ * "No org matched" instead of the diff it exists to produce.
+ */
+async function resolveOrgs(): Promise<{ id: string; name: string }[]> {
+  const { rows } = await db.execute<{ id: string; name: string }>(sql`
+    SELECT DISTINCT o.id, o.name
+    FROM "Organization" o
+    JOIN "EntityDefinition" ed
+      ON ed."organizationId" = o.id AND ed."entityType" = 'part'
+    ${
+      ORG_FILTER
+        ? sql`WHERE o.name = ${ORG_FILTER} OR o.id = ${ORG_FILTER}`
+        : sql`WHERE EXISTS (SELECT 1 FROM "EntityInstance" ei WHERE ei."entityDefinitionId" = ed.id)`
+    }
+    ORDER BY o.name
+  `)
+  return rows
+}
+
+/** One entity definition's id for an org, or null if it has none. */
+async function defIdFor(organizationId: string, entityType: string): Promise<string | null> {
+  const { rows } = await db.execute<{ id: string }>(sql`
+    SELECT id FROM "EntityDefinition"
+    WHERE "organizationId" = ${organizationId} AND "entityType" = ${entityType}
+    LIMIT 1
+  `)
+  return rows[0]?.id ?? null
+}
+
+async function scalar(query: ReturnType<typeof sql>): Promise<number> {
+  const { rows } = await db.execute<{ n: number }>(query)
+  return Number(rows[0]?.n ?? 0)
+}
+
+/**
+ * Inbound relationship rows, one line per attribute that names a part.
+ *
+ * Counted through `CustomField.systemAttribute` rather than through
+ * `FieldValue.relatedEntityDefinitionId`, because the second is a denormalized
+ * copy and this audit's whole job is to notice when copies disagree.
+ */
+async function inboundByAttribute(
+  organizationId: string,
+  defId: string
+): Promise<{ attribute: string; rows: number; distinctParts: number }[]> {
+  const { rows } = await db.execute<{
+    attribute: string
+    rows: number
+    distinct_parts: number
+  }>(sql`
+    SELECT cf."systemAttribute" AS attribute,
+           count(*)::int AS rows,
+           count(DISTINCT fv."relatedEntityId")::int AS distinct_parts
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf ON cf.id = fv."fieldId"
+    JOIN "EntityInstance" target ON target.id = fv."relatedEntityId"
+    WHERE fv."organizationId" = ${organizationId}
+      AND target."entityDefinitionId" = ${defId}
+      AND cf."systemAttribute" IS NOT NULL
+    GROUP BY 1
+    ORDER BY 2 DESC
+  `)
+  return rows.map((r) => ({
+    attribute: r.attribute,
+    rows: Number(r.rows),
+    distinctParts: Number(r.distinct_parts),
+  }))
+}
+
+/**
+ * Stock movements by accounting month.
+ *
+ * ⚠️ The accounting date is `stock_movement_occurred_at` **coalesced onto
+ * `EntityInstance.createdAt`** — the documented fallback (`receipt-queries.ts`).
+ * The guard in task 20 §2a must derive its period the same way or a movement can
+ * be judged under one date and posted under another.
+ *
+ * Explosion parents (`stock_movement_adjust_subparts`) are excluded, matching
+ * `gather-month-end-inventory.ts`: they carry no quantity of their own and
+ * legitimately carry no cost, so counting them would report phantom "uncosted"
+ * movements.
+ */
+async function movementsByPeriod(
+  organizationId: string
+): Promise<{ period: string; movements: number; uncosted: number }[]> {
+  const { rows } = await db.execute<{ period: string; movements: number; uncosted: number }>(sql`
+    WITH mv AS (
+      SELECT ei.id,
+             coalesce(occurred."valueDate", ei."createdAt") AS accounting_date,
+             cost."valueNumber" AS unit_cost
+      FROM "EntityInstance" ei
+      JOIN "EntityDefinition" ed
+        ON ed.id = ei."entityDefinitionId" AND ed."entityType" = 'stock_movement'
+      LEFT JOIN "FieldValue" occurred
+        ON occurred."entityId" = ei.id
+       AND occurred."fieldId" IN (
+             SELECT id FROM "CustomField"
+             WHERE "entityDefinitionId" = ed.id
+               AND "systemAttribute" = 'stock_movement_occurred_at')
+      LEFT JOIN "FieldValue" cost
+        ON cost."entityId" = ei.id
+       AND cost."fieldId" IN (
+             SELECT id FROM "CustomField"
+             WHERE "entityDefinitionId" = ed.id
+               AND "systemAttribute" = 'stock_movement_unit_cost')
+      LEFT JOIN "FieldValue" explode
+        ON explode."entityId" = ei.id
+       AND explode."fieldId" IN (
+             SELECT id FROM "CustomField"
+             WHERE "entityDefinitionId" = ed.id
+               AND "systemAttribute" = 'stock_movement_adjust_subparts')
+      WHERE ei."organizationId" = ${organizationId}
+        AND ei."archivedAt" IS NULL
+        AND coalesce(explode."valueBoolean", false) = false
+    )
+    SELECT to_char(accounting_date, 'YYYY-MM') AS period,
+           count(*)::int AS movements,
+           count(*) FILTER (WHERE unit_cost IS NULL)::int AS uncosted
+    FROM mv GROUP BY 1 ORDER BY 1
+  `)
+  return rows.map((r) => ({
+    period: r.period,
+    movements: Number(r.movements),
+    uncosted: Number(r.uncosted),
+  }))
+}
+
+// =============================================================================
+// SNAPSHOT
+// =============================================================================
+
+async function snapshotOrg(org: { id: string; name: string }): Promise<OrgSnapshot> {
+  const metrics: Metric[] = []
+  const push = (key: string, kind: MetricKind, value: number, note?: string) =>
+    metrics.push({ key, kind, value, note })
+
+  const partDef = await defIdFor(org.id, 'part')
+  if (!partDef) {
+    return {
+      organizationId: org.id,
+      organizationName: org.name,
+      metrics,
+      inbound: [],
+      movementPeriods: [],
+    }
+  }
+
+  // ── one block per visible money parent ────────────────────────────────────
+  for (const parent of PARENTS) {
+    const defId = await defIdFor(org.id, parent.entityType)
+    if (!defId) continue
+
+    // ── subject: the parents themselves ─────────────────────────────────────
+    push(
+      `${parent.slug}.instances`,
+      'subject',
+      await scalar(sql`
+      SELECT count(*)::int AS n FROM "EntityInstance" WHERE "entityDefinitionId" = ${defId}`)
+    )
+
+    push(
+      `${parent.slug}.fieldValues`,
+      'subject',
+      await scalar(sql`
+      SELECT count(*)::int AS n FROM "FieldValue" fv
+      JOIN "EntityInstance" ei ON ei.id = fv."entityId"
+      WHERE ei."entityDefinitionId" = ${defId}`)
+    )
+
+    push(
+      `${parent.slug}.timelineEvents.own`,
+      'subject',
+      await scalar(sql`
+      SELECT count(*)::int AS n FROM "TimelineEvent" te
+      JOIN "EntityInstance" ei ON ei.id = te."entityId"
+      WHERE ei."entityDefinitionId" = ${defId}`)
+    )
+
+    // Deliberately NOT `subject`: `deleteEntityInstance` leaves these on purpose
+    // — "this contact once had an order" survives the order. Watched, not
+    // expected to fall.
+    push(
+      `${parent.slug}.timelineEvents.asRelated`,
+      'strand',
+      await scalar(sql`
+      SELECT count(*)::int AS n FROM "TimelineEvent" te
+      JOIN "EntityInstance" ei ON ei.id = te."relatedEntityId"
+      WHERE ei."entityDefinitionId" = ${defId}`),
+      'left behind deliberately'
+    )
+
+    // ── children: total, and how many have lost their parent ────────────────
+    for (const child of parent.children) {
+      const total = await scalar(sql`
+        SELECT count(*)::int AS n FROM "EntityInstance" ei
+        JOIN "EntityDefinition" ed ON ed.id = ei."entityDefinitionId"
+        WHERE ei."organizationId" = ${org.id} AND ed."entityType" = ${child.entityType}`)
+
+      const orphaned = await scalar(sql`
+        SELECT count(*)::int AS n FROM "EntityInstance" ei
+        JOIN "EntityDefinition" ed ON ed.id = ei."entityDefinitionId"
+        WHERE ei."organizationId" = ${org.id} AND ed."entityType" = ${child.entityType}
+          AND NOT EXISTS (
+            SELECT 1 FROM "FieldValue" fv
+            JOIN "CustomField" cf ON cf.id = fv."fieldId"
+            WHERE fv."entityId" = ei.id
+              AND cf."systemAttribute" = ${child.attribute}
+              AND fv."relatedEntityId" IS NOT NULL)`)
+
+      // A `leave` child's total is frozen: it is the vendor's document, and the
+      // parent's delete may not touch it. `cascade` and `refuse-or-cascade`
+      // totals are SUPPOSED to fall, so they are only watched.
+      push(
+        `children.${parent.slug}.${child.entityType}.total`,
+        child.disposition === 'leave' ? 'must-hold' : 'strand',
+        total,
+        child.disposition
+      )
+      push(
+        `children.${parent.slug}.${child.entityType}.orphaned`,
+        'strand',
+        orphaned,
+        child.disposition
+      )
+    }
+  }
+
+  const defId = partDef
+
+  // The BOM row whose displayName IS its child part: after a part delete the
+  // display cascade nulls it and the row renders as nothing at all.
+  push(
+    'subparts.namelessRows',
+    'strand',
+    await scalar(sql`
+    SELECT count(*)::int AS n FROM "EntityInstance" ei
+    JOIN "EntityDefinition" ed ON ed.id = ei."entityDefinitionId"
+    WHERE ei."organizationId" = ${org.id} AND ed."entityType" = 'subpart'
+      AND ei."displayName" IS NULL`)
+  )
+
+  // ── hygiene: the sweep's own work ─────────────────────────────────────────
+  push(
+    'hygiene.danglingRelationValues',
+    'hygiene',
+    await scalar(sql`
+    SELECT count(*)::int AS n FROM "FieldValue" fv
+    LEFT JOIN "EntityInstance" ei ON ei.id = fv."relatedEntityId"
+    JOIN "CustomField" cf ON cf.id = fv."fieldId"
+    WHERE fv."organizationId" = ${org.id}
+      AND fv."relatedEntityId" IS NOT NULL
+      AND ei.id IS NULL
+      AND cf."systemAttribute" IN (${sql.join(
+        REFERENCE_ATTRIBUTES.map((a) => sql`${a}`),
+        sql`, `
+      )})`),
+    'money-parent relations pointing at a row that is gone'
+  )
+
+  push(
+    'hygiene.orphanedTimelineEvents',
+    'hygiene',
+    await scalar(sql`
+    SELECT count(*)::int AS n FROM "TimelineEvent" te
+    LEFT JOIN "EntityInstance" ei ON ei.id = te."entityId"
+    WHERE te."organizationId" = ${org.id}
+      AND te."entityType" = ${defId}
+      AND ei.id IS NULL`)
+  )
+
+  // Both halves of a relation are separate rows and nothing enforces the pair.
+  // A non-zero value here is a pre-existing writer bug, not a delete bug — but
+  // it is exactly the class of drift this audit is for.
+  push(
+    'hygiene.mirrorHalfMissing',
+    'hygiene',
+    await scalar(sql`
+    WITH fwd AS (
+      SELECT fv."entityId" AS child, fv."relatedEntityId" AS part
+      FROM "FieldValue" fv JOIN "CustomField" cf ON cf.id = fv."fieldId"
+      WHERE fv."organizationId" = ${org.id}
+        AND cf."systemAttribute" = 'purchase_order_line_part'
+        AND fv."relatedEntityId" IS NOT NULL),
+    rev AS (
+      SELECT fv."relatedEntityId" AS child, fv."entityId" AS part
+      FROM "FieldValue" fv JOIN "CustomField" cf ON cf.id = fv."fieldId"
+      WHERE fv."organizationId" = ${org.id}
+        AND cf."systemAttribute" = 'part_purchase_order_lines'
+        AND fv."relatedEntityId" IS NOT NULL)
+    SELECT (
+      (SELECT count(*) FROM fwd f LEFT JOIN rev r
+         ON r.child = f.child AND r.part = f.part WHERE r.child IS NULL)
+    + (SELECT count(*) FROM rev r LEFT JOIN fwd f
+         ON f.child = r.child AND f.part = r.part WHERE f.child IS NULL)
+    )::int AS n`),
+    'part <-> purchase order line, unpaired halves'
+  )
+
+  // ── must-hold: the frozen accounting record ───────────────────────────────
+  // The `GlPostingStatus` enum, exhaustively. Postgres rejects an unknown label
+  // outright, so a status added later fails loudly here rather than quietly
+  // dropping out of the audit.
+  for (const status of ['pending', 'posted', 'failed', 'reversed'] as const) {
+    push(
+      `gl.postings.${status}`,
+      'must-hold',
+      await scalar(sql`
+      SELECT count(*)::int AS n FROM "GlPosting"
+      WHERE "organizationId" = ${org.id} AND status = ${status}`)
+    )
+  }
+
+  push(
+    'gl.postedTotalMinor',
+    'must-hold',
+    await scalar(sql`
+    SELECT coalesce(sum("totalMinor"), 0)::float8 AS n FROM "GlPosting"
+    WHERE "organizationId" = ${org.id} AND status = 'posted'`)
+  )
+
+  push(
+    'gl.postingLines',
+    'must-hold',
+    await scalar(sql`
+    SELECT count(*)::int AS n FROM "GlPostingLine" l
+    JOIN "GlPosting" p ON p.id = l."glPostingId"
+    WHERE p."organizationId" = ${org.id}`)
+  )
+
+  push(
+    'gl.roleAssignments',
+    'must-hold',
+    await scalar(sql`
+    SELECT count(*)::int AS n FROM "GlRoleAssignment" WHERE "organizationId" = ${org.id}`)
+  )
+
+  push(
+    'gl.accounts',
+    'must-hold',
+    await scalar(sql`
+    SELECT count(*)::int AS n FROM "EntityInstance" ei
+    JOIN "EntityDefinition" ed ON ed.id = ei."entityDefinitionId"
+    WHERE ei."organizationId" = ${org.id} AND ed."entityType" = 'gl_account'`)
+  )
+
+  // ── the subledger the posted entry was derived from ───────────────────────
+  push(
+    'subledger.movementExtendedCost',
+    'strand',
+    await scalar(sql`
+    SELECT coalesce(sum(fv."valueNumber"), 0)::float8 AS n
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf ON cf.id = fv."fieldId"
+    WHERE fv."organizationId" = ${org.id}
+      AND cf."systemAttribute" = 'stock_movement_extended_cost'`)
+  )
+
+  push(
+    'subledger.partsWithQoH',
+    'strand',
+    await scalar(sql`
+    SELECT count(*)::int AS n FROM "FieldValue" fv
+    JOIN "CustomField" cf ON cf.id = fv."fieldId"
+    WHERE fv."organizationId" = ${org.id}
+      AND cf."systemAttribute" = 'part_quantity_on_hand'`)
+  )
+
+  return {
+    organizationId: org.id,
+    organizationName: org.name,
+    metrics,
+    inbound: await inboundByAttribute(org.id, defId),
+    movementPeriods: await movementsByPeriod(org.id),
+  }
+}
+
+// =============================================================================
+// OUTPUT
+// =============================================================================
+
+const KIND_MARK: Record<MetricKind, string> = {
+  subject: '  ',
+  'must-hold': '🔒',
+  strand: '· ',
+  hygiene: '✓ ',
+}
+
+function printSnapshot(snap: Snapshot): void {
+  for (const org of snap.orgs) {
+    console.log(
+      `\n${'='.repeat(78)}\n${org.organizationName}  (${org.organizationId})\n${'='.repeat(78)}`
+    )
+
+    if (org.metrics.length === 0) {
+      console.log('  no part definition')
+      continue
+    }
+
+    for (const m of org.metrics) {
+      const note = m.note ? `  ${m.note}` : ''
+      // A hygiene metric is defined as zero. Non-zero at BASELINE is a
+      // pre-existing defect that has nothing to do with the delete test, and it
+      // is worth naming now — the diff only reports metrics that MOVE, so a
+      // value that is already wrong and stays wrong would never be printed again.
+      const preExisting = m.kind === 'hygiene' && m.value > 0 ? '  ⚠ non-zero BEFORE the test' : ''
+      console.log(
+        `${KIND_MARK[m.kind]} ${m.key.padEnd(42)} ${String(m.value).padStart(12)}${note}${preExisting}`
+      )
+    }
+
+    if (org.inbound.length > 0) {
+      console.log('\n  inbound relationship rows (what points AT a part)')
+      for (const r of org.inbound) {
+        console.log(
+          `    ${r.attribute.padEnd(34)} ${String(r.rows).padStart(6)} rows  ${r.distinctParts} parts`
+        )
+      }
+    }
+
+    if (org.movementPeriods.length > 0) {
+      console.log('\n  stock movements by accounting month')
+      for (const p of org.movementPeriods) {
+        const flag = p.uncosted > 0 ? `  (${p.uncosted} uncosted)` : ''
+        console.log(`    ${p.period}  ${String(p.movements).padStart(6)}${flag}`)
+      }
+      console.log('    ⚠️  cross-check against `listClosePeriods` — a month that is')
+      console.log('        posted or locked is what task 20 §2a refuses on.')
+    }
+  }
+}
+
+function printDiff(before: Snapshot, after: Snapshot): void {
+  console.log(`\nBEFORE ${before.takenAt}\nAFTER  ${after.takenAt}`)
+
+  let failures = 0
+  let strands = 0
+
+  for (const afterOrg of after.orgs) {
+    const beforeOrg = before.orgs.find((o) => o.organizationId === afterOrg.organizationId)
+    if (!beforeOrg) {
+      console.log(`\n${afterOrg.organizationName}: not in the before snapshot, skipped`)
+      continue
+    }
+
+    const lines: string[] = []
+    for (const m of afterOrg.metrics) {
+      const prior = beforeOrg.metrics.find((p) => p.key === m.key)
+      if (!prior || prior.value === m.value) continue
+
+      const delta = m.value - prior.value
+      const sign = delta > 0 ? `+${delta}` : String(delta)
+      let verdict = ''
+
+      if (m.kind === 'must-hold') {
+        verdict = '  ✗ INTEGRITY FAILURE — a record delete moved a frozen accounting number'
+        failures++
+      } else if (m.kind === 'hygiene' && m.value > 0) {
+        verdict = '  ✗ SWEEP FAILURE — sweepEntityFieldValues left references behind'
+        failures++
+      } else if (m.kind === 'strand' && delta > 0) {
+        verdict = '  ⚠ STRANDED — orphaned rows grew'
+        strands++
+      } else if (m.kind === 'subject') {
+        verdict = '  ✓'
+      }
+
+      lines.push(
+        `  ${m.key.padEnd(42)} ${String(prior.value).padStart(10)} → ${String(m.value).padStart(10)}  ${sign.padStart(8)}${verdict}`
+      )
+    }
+
+    console.log(`\n${'='.repeat(78)}\n${afterOrg.organizationName}\n${'='.repeat(78)}`)
+    console.log(lines.length > 0 ? lines.join('\n') : '  nothing moved')
+  }
+
+  console.log(`\n${'-'.repeat(78)}`)
+  console.log(`${failures} integrity/sweep failure(s), ${strands} metric(s) stranded rows.`)
+  if (strands > 0 && failures === 0) {
+    console.log('Stranded rows with no integrity failure is the EXPECTED result today:')
+    console.log('`parts` has no pre-delete hook. That is what task 20 builds.')
+  }
+}
+
+// =============================================================================
+
+async function main(): Promise<void> {
+  const orgs = await resolveOrgs()
+  if (orgs.length === 0) {
+    console.log(
+      ORG_FILTER ? `No org matched "${ORG_FILTER}" with any parts.` : 'No org has any parts.'
+    )
+    process.exit(0)
+  }
+
+  const snapshot: Snapshot = {
+    takenAt: new Date().toISOString(),
+    orgs: [],
+  }
+  for (const org of orgs) {
+    snapshot.orgs.push(await snapshotOrg(org))
+  }
+
+  if (COMPARE_PATH) {
+    const { readFileSync } = await import('node:fs')
+    printDiff(JSON.parse(readFileSync(COMPARE_PATH, 'utf8')) as Snapshot, snapshot)
+  } else {
+    printSnapshot(snapshot)
+    console.log('\n🔒 must-hold — a change is an integrity failure')
+    console.log('·  strand    — orphaned rows; growth is the finding')
+    console.log('✓  hygiene   — must be zero, before and after')
+  }
+
+  if (SAVE_PATH) {
+    const { writeFileSync } = await import('node:fs')
+    writeFileSync(SAVE_PATH, JSON.stringify(snapshot, null, 2))
+    console.log(`\nSaved to ${SAVE_PATH}`)
+  }
+
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/lib/src/field-hooks/__tests__/delete-guard-registration.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/delete-guard-registration.test.ts
@@ -1,0 +1,125 @@
+// packages/lib/src/field-hooks/__tests__/delete-guard-registration.test.ts
+//
+// Which entities have a pre-delete hook, pinned as a set.
+//
+// 🛑 **This file exists because the same defect has now been fixed four times
+// by naming one entity.** `registerEntityPreDeleteHooks` was added for `tags`
+// alone, which left every other type leaking; plan
+// `plans/dispatch/money/12-delete-safety.md` extended it to the dispatch money
+// documents; `orders` was added a month later when its lines were found
+// orphaned; `parts` was found unguarded a further six weeks after that, having
+// shipped `isVisible: true` with an ordinary delete button the whole time
+// (plans/money/tasks/20-part-delete-safety.md §1); and `builds`,
+// `purchase-orders` and `vendor-bills` were still unguarded when task 20
+// shipped, which is what task 21 closed.
+//
+// `sweep-entity-references.ts` states the rule the guards kept failing: a fix
+// has to be "keyed off the mechanism (a record is going away), not off a
+// registration list, or it drifts the same way again". A pre-delete hook IS a
+// registration list and cannot be keyed off the mechanism — so the next best
+// thing is to derive the list that SHOULD exist from the seeded entity
+// definitions, and assert the registry covers it.
+//
+// Registered under the **apiSlug**, never the entityType: `deleteEntity` reads
+// `getEntityPreDeleteHooks(entityDef.apiSlug)`, so `part` would be a silent
+// no-op where `parts` is the hook.
+
+import { describe, expect, it } from 'vitest'
+import { SYSTEM_ENTITIES } from '../../seed/entity-seeder/constants'
+import { guardBuildDelete } from '../pre/build-delete-guard'
+import { guardInvoiceDelete } from '../pre/invoice-delete-guard'
+import { cascadeOrderLinesOnDelete } from '../pre/order-delete-guard'
+import { guardPartDelete } from '../pre/part-delete-guard'
+import { guardPurchaseOrderDelete } from '../pre/purchase-order-delete-guard'
+import { guardVendorBillDelete } from '../pre/vendor-bill-delete-guard'
+import { getEntityPreDeleteHooks } from '../registry'
+
+/** Every slug that must carry a pre-delete hook, and the handler it must carry. */
+const GUARDED = [
+  { slug: 'invoices', handler: guardInvoiceDelete },
+  { slug: 'orders', handler: cascadeOrderLinesOnDelete },
+  { slug: 'parts', handler: guardPartDelete },
+  { slug: 'builds', handler: guardBuildDelete },
+  { slug: 'purchase-orders', handler: guardPurchaseOrderDelete },
+  { slug: 'vendor-bills', handler: guardVendorBillDelete },
+] as const
+
+/**
+ * The inventory/purchasing subsystem's entity types, from
+ * `docs/inventory-costing-architecture-guide.md` §3 — the table that calls them
+ * "thirteen entities, zero new tables", minus `gl_posting` and
+ * `gl_posting_line`, which entity migration 114 deleted because they are Drizzle
+ * tables and never were entities.
+ *
+ * This list is what makes the assertion below meaningful rather than circular:
+ * it is a claim about the SUBSYSTEM, checked against the seeded definitions, not
+ * a restatement of what happens to be registered.
+ */
+const MONEY_ENTITY_TYPES = [
+  'purchase_order',
+  'purchase_order_line',
+  'vendor_bill',
+  'vendor_bill_line',
+  'stock_movement',
+  'build',
+  'part',
+  'vendor_part',
+  'subpart',
+  'gl_account',
+  'vendor_payment',
+  'vendor_payment_allocation',
+] as const
+
+/**
+ * A money entity is a "parent" for delete purposes when it is `isVisible` — that
+ * is what gives it an ordinary records table with an ordinary row delete and
+ * bulk delete that no money code has ever seen. `isVisible` is optional in
+ * `SystemEntityConfig` and **defaults to true**, which is precisely how `parts`
+ * shipped unguarded: nobody wrote `isVisible: true`, it simply was.
+ */
+function visibleMoneyParents(): string[] {
+  return SYSTEM_ENTITIES.filter(
+    (entity) =>
+      (MONEY_ENTITY_TYPES as readonly string[]).includes(entity.entityType) &&
+      entity.isVisible !== false
+  )
+    .map((entity) => entity.apiSlug)
+    .sort()
+}
+
+describe('pre-delete hook registration', () => {
+  for (const { slug, handler } of GUARDED) {
+    it(`registers a pre-delete hook for ${slug}`, () => {
+      expect(getEntityPreDeleteHooks(slug)).toContain(handler)
+    })
+  }
+
+  it('registers parts under the apiSlug, not the entityType', () => {
+    expect(getEntityPreDeleteHooks('part')).toHaveLength(0)
+  })
+
+  it('names only entity types that are actually seeded', () => {
+    const seeded = new Set(SYSTEM_ENTITIES.map((entity) => entity.entityType))
+    const missing = MONEY_ENTITY_TYPES.filter((type) => !seeded.has(type))
+    // A rename in `constants.ts` must not quietly shrink the set below.
+    expect(missing).toEqual([])
+  })
+
+  it('guards EVERY visible money parent (task 21 §6)', () => {
+    // The positive form, deliberately. The old assertion listed the entities
+    // that were still unguarded and asserted they still were — which went
+    // vacuously true the moment the list emptied, and would have protected
+    // nothing from then on.
+    const unguarded = visibleMoneyParents().filter(
+      (slug) => getEntityPreDeleteHooks(slug).length === 0
+    )
+    expect(unguarded).toEqual([])
+  })
+
+  it('holds the four visible money parents the costing guide §3 names', () => {
+    // Pins the derivation itself: if a money entity flips to visible, or a new
+    // one ships visible, this fails and the guard question gets asked BEFORE the
+    // delete button is live — which is the whole point of the file.
+    expect(visibleMoneyParents()).toEqual(['builds', 'parts', 'purchase-orders', 'vendor-bills'])
+  })
+})

--- a/packages/lib/src/field-hooks/pre/build-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/build-delete-guard.test.ts
@@ -1,0 +1,206 @@
+// packages/lib/src/field-hooks/pre/build-delete-guard.test.ts
+// The guard that stops a build being hard-deleted out of a settled period, and
+// stops either end of a reversal pair being deleted at all.
+//
+// plans/money/tasks/21-money-parent-delete-safety.md §3. Dev ground truth the
+// cases are modelled on: DemoOrg1 is locked through `2026-07` and every one of
+// its 31 movements sits in `2026-08` — a month whose revision 1 stands POSTED at
+// $1,320,563.80 while a later revision 2 sits `failed`, so the close strip
+// correctly reports that month as **`open`**. That is why the posted-entry check
+// reads `GlPosting` directly and why it is tested against an `open` strip.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityPreDeleteEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  listFiltered: vi.fn(),
+  del: vi.fn(),
+  getCachedEntityDefId: vi.fn(),
+  bySystemAttributes: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  postedPeriodRows: vi.fn(),
+  getOrganizationSetting: vi.fn(),
+  movementRows: vi.fn(),
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    listFiltered = h.listFiltered
+    delete = h.del
+  },
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: h.getCachedEntityDefId,
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+
+vi.mock('../../postings/period-lock', () => ({ resolvePeriodLock: h.resolvePeriodLock }))
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: h.getOrganizationSetting,
+}))
+
+vi.mock('@auxx/database', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@auxx/database')
+  const movementChain: Record<string, unknown> = {}
+  for (const method of ['from', 'innerJoin', 'leftJoin', '$dynamic']) {
+    movementChain[method] = () => movementChain
+  }
+  movementChain.where = async () => h.movementRows()
+
+  const postedChain: Record<string, unknown> = {}
+  postedChain.from = () => postedChain
+  postedChain.where = async () => h.postedPeriodRows()
+
+  return {
+    ...actual,
+    database: { select: () => movementChain, selectDistinct: () => postedChain },
+  }
+})
+
+import { guardBuildDelete } from './build-delete-guard'
+
+const BUILD_DEF = 'b5hzr4xbn1fhznih3u74gtza'
+const BUILD_ID = 'bu1ld0000000000000000001'
+const BUILD_RECORD_ID = `${BUILD_DEF}:${BUILD_ID}`
+const ORG = 'abgwpa1l81reht2zmwrcihfu'
+
+function event(values: Record<string, unknown> = {}): EntityPreDeleteEvent {
+  return {
+    recordId: BUILD_RECORD_ID as EntityPreDeleteEvent['recordId'],
+    entityDefinitionId: BUILD_DEF,
+    entityType: 'build',
+    entitySlug: 'builds',
+    values,
+    organizationId: ORG,
+    userId: 'usr_1',
+    bypass: new Set(),
+  }
+}
+
+function movement(id: string, occurredAt: string | null, createdAt = new Date('2026-08-15')) {
+  return { id, occurredAt, createdAt }
+}
+
+function settings(values: Record<string, string | null>): void {
+  h.getOrganizationSetting.mockImplementation(
+    async ({ key }: { key: string }) => values[key] ?? null
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getCachedEntityDefId.mockResolvedValue('movement-def')
+  h.bySystemAttributes.mockResolvedValue({
+    stock_movement_build: { id: 'f-build' },
+    stock_movement_occurred_at: { id: 'f-occurred' },
+  })
+  h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
+  h.postedPeriodRows.mockResolvedValue([])
+  h.movementRows.mockResolvedValue([])
+  h.listFiltered.mockResolvedValue({ ids: [] })
+  settings({})
+})
+
+describe('guardBuildDelete — refusals', () => {
+  it('refuses when a movement sits in a locked month', async () => {
+    h.movementRows.mockResolvedValue([movement('m1', '2026-07-10')])
+    h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: '2026-07' })
+
+    await expect(guardBuildDelete(event())).rejects.toThrow(/2026-07/)
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('refuses when a movement sits in a month holding a standing posted entry', async () => {
+    // The DemoOrg1 case: the close strip reports `2026-08` as OPEN because the
+    // effective revision is a failed one, but revision 1 still stands posted.
+    h.movementRows.mockResolvedValue([movement('m1', '2026-08-15')])
+    h.postedPeriodRows.mockResolvedValue([{ periodKey: '2026-08' }])
+
+    await expect(guardBuildDelete(event())).rejects.toThrow(/2026-08/)
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('refuses when a movement sits at or before the cutoff', async () => {
+    h.movementRows.mockResolvedValue([movement('m1', '2026-05-02')])
+    settings({ 'accounting.cutoffPeriod': '2026-05' })
+
+    await expect(guardBuildDelete(event())).rejects.toThrow(/2026-05/)
+  })
+
+  it('points at reversing the build, not at archiving it', async () => {
+    h.movementRows.mockResolvedValue([movement('m1', '2026-08-15')])
+    h.postedPeriodRows.mockResolvedValue([{ periodKey: '2026-08' }])
+
+    await expect(guardBuildDelete(event())).rejects.toThrow(/reverse the build/i)
+  })
+
+  it('refuses when this build IS a reversal', async () => {
+    await expect(
+      guardBuildDelete(event({ build_reversal_of: `${BUILD_DEF}:other` }))
+    ).rejects.toThrow(/reverses another build/i)
+  })
+
+  it('refuses when this build HAS BEEN reversed', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['reversing-build'] })
+
+    await expect(guardBuildDelete(event())).rejects.toThrow(/already been reversed/i)
+  })
+
+  it('checks the reversal pair before reading movements, so nothing is deleted', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['reversing-build'] })
+    h.movementRows.mockResolvedValue([movement('m1', '2026-09-01')])
+
+    await expect(guardBuildDelete(event())).rejects.toThrow()
+    expect(h.del).not.toHaveBeenCalled()
+  })
+})
+
+describe('guardBuildDelete — cascade', () => {
+  it('deletes every movement when the period is open', async () => {
+    h.movementRows.mockResolvedValue([
+      movement('consume-1', '2026-09-01'),
+      movement('consume-2', '2026-09-01'),
+      movement('produce-1', '2026-09-01'),
+    ])
+
+    await guardBuildDelete(event())
+
+    expect(h.del).toHaveBeenCalledTimes(3)
+    for (const id of ['consume-1', 'consume-2', 'produce-1']) {
+      expect(h.del).toHaveBeenCalledWith(`stock_movement:${id}`)
+    }
+  })
+
+  it('never suppresses post-delete hooks — the QoH recompute lands on surviving parts', async () => {
+    h.movementRows.mockResolvedValue([movement('consume-1', '2026-09-01')])
+
+    await guardBuildDelete(event())
+
+    // One argument only: no options object, so nothing is suppressed.
+    expect(h.del).toHaveBeenCalledWith('stock_movement:consume-1')
+    expect(h.del.mock.calls[0]).toHaveLength(1)
+  })
+
+  it('falls back to createdAt when a movement has no occurredAt', async () => {
+    h.movementRows.mockResolvedValue([movement('m1', null, new Date('2026-07-20'))])
+    h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: '2026-07' })
+
+    await expect(guardBuildDelete(event())).rejects.toThrow(/2026-07/)
+  })
+
+  it('does nothing when the build has no movements', async () => {
+    await guardBuildDelete(event())
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('settles nothing for an org with no accounting setup', async () => {
+    // No cutoff, no lock, no postings — the org is not keeping books, so the
+    // guard must stay out of the way entirely.
+    h.movementRows.mockResolvedValue([movement('m1', '2020-01-01')])
+
+    await guardBuildDelete(event())
+
+    expect(h.del).toHaveBeenCalledWith('stock_movement:m1')
+  })
+})

--- a/packages/lib/src/field-hooks/pre/build-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/build-delete-guard.ts
@@ -1,0 +1,148 @@
+// packages/lib/src/field-hooks/pre/build-delete-guard.ts
+
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { BadRequestError } from '../../errors'
+import { describeSettledPeriods, settledPeriodsFor } from '../../postings/settled-periods'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import type { EntityPreDeleteEvent, EntityPreDeleteHandler } from '../types'
+import { type GuardedMovement, readMovementsByRelation } from './guarded-movements'
+
+/**
+ * Pre-delete guard for `builds` (plans/money/tasks/21-money-parent-delete-safety.md §3).
+ * Fires inside `deleteEntity` for EVERY delete path — generic `record.delete`,
+ * bulk delete, drawers, Kopilot and the API — because `builds` is
+ * `isVisible: true` and therefore carries an ordinary records table with an
+ * ordinary delete button that no money code has ever seen.
+ *
+ * **What deleting a build costs today.** A completed build writes one
+ * `build_consume` per component at the negated quantity and one `build_produce`
+ * at `+quantityProduced` (`builds/complete-build.ts`). Deleting the build leaves
+ * every one of them alive — `sweepEntityFieldValues` removes the link rather
+ * than the row — so the ledger keeps the quantities and loses the only thing
+ * that explains them. QoH still nets out, which is exactly why nothing looks
+ * wrong.
+ *
+ * Two refusals and one cascade:
+ *
+ *   1. **REFUSE when any movement sits in a settled period.** `settledPeriodsFor`
+ *      owns the three predicates.
+ *   2. **REFUSE when the build is either end of a reversal pair.** Deleting one
+ *      end leaves the other end's negation explaining nothing, and cascading
+ *      both is a two-document decision a delete button should not be making.
+ *   3. **CASCADE the movements** otherwise.
+ *
+ * ⚠️ **The refusal points at `reverseBuild`, not at archive.** Unlike a part, a
+ * build has a sanctioned correction path (`builds/reverse-build.ts`) that
+ * already writes the negation with the type carried verbatim, so the message
+ * names it.
+ *
+ * ⚠️ **Nothing is suppressed on the cascade**, matching `guardPartDelete` and
+ * differing from the invoice/order/vendor-bill guards. Those suppress because
+ * their post-delete hook re-projects the document being deleted; here
+ * `mfg-stock-movements-deleted` recomputes `recalculatePartQoH` on a SURVIVING
+ * part — and it must fire once per row, because one build touches one component
+ * movement per BOM line plus the produced part, all of them survivors.
+ */
+export const guardBuildDelete: EntityPreDeleteHandler = async (event) => {
+  const { organizationId, userId, recordId } = event
+  const { entityInstanceId: buildInstanceId } = parseRecordId(recordId)
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+
+  // Refuse BEFORE any cascade, so a rejected delete mutates nothing.
+  await refuseIfReversalPair(handler, event)
+
+  const movements = await readMovementsByRelation(organizationId, 'stock_movement_build', [
+    buildInstanceId,
+  ])
+  if (movements.length > 0) {
+    const settled = await settledPeriodsFor(
+      organizationId,
+      movements.map((movement) => movement.accountingDate)
+    )
+    if (settled.size > 0) {
+      throw new BadRequestError(
+        `This build has ${describeSettledPeriods(settled, 'stock movement')}. ` +
+          `A posted period is corrected by reversing an entry, never by deleting its history — ` +
+          `reverse the build instead.`,
+        { organizationId, buildInstanceId, periods: [...settled.keys()] }
+      )
+    }
+  }
+
+  await cascadeMovements(handler, movements)
+}
+
+/**
+ * Refuse when this build reverses another, or has itself been reversed.
+ *
+ * The two directions are read differently on purpose. **"This build IS a
+ * reversal"** is a value on the dying row, and `deleteEntity` has already
+ * captured it — its own comment says the capture exists so "pre-delete hooks can
+ * inspect the record's current state", so re-reading it would be a query for
+ * data already in hand. **"This build HAS BEEN reversed"** lives on a different
+ * row and has to be looked up.
+ */
+async function refuseIfReversalPair(
+  handler: UnifiedCrudHandler,
+  event: EntityPreDeleteEvent
+): Promise<void> {
+  const { organizationId, recordId } = event
+
+  const reversalOf = event.values.build_reversal_of
+  if (typeof reversalOf === 'string' && reversalOf.length > 0) {
+    throw new BadRequestError(
+      'This build reverses another build. Deleting it would leave the original ' +
+        'reversed by nothing — archive it instead.',
+      { organizationId, recordId }
+    )
+  }
+
+  const { ids: reversedBy } = await handler.listFiltered({
+    entityDefinitionId: 'build',
+    filters: [
+      {
+        id: 'build-reversed-by',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'build-reversed-by-original',
+            fieldId: 'build:reversalOf',
+            operator: 'is',
+            value: recordId,
+          },
+        ],
+      },
+    ],
+    limit: 1000,
+  })
+
+  if (reversedBy.length > 0) {
+    throw new BadRequestError(
+      `This build has already been reversed by ${reversedBy.length} ` +
+        `${reversedBy.length === 1 ? 'build' : 'builds'}. Deleting it would leave the ` +
+        `reversal explaining nothing — archive it instead.`,
+      { organizationId, recordId, reversedBy }
+    )
+  }
+}
+
+/**
+ * The `build_consume` / `build_produce` pair, once every one of them is known to
+ * sit in an open period.
+ *
+ * Deleted one at a time through the handler so `mfg-stock-movements-deleted`
+ * fires per row and `recalculatePartQoH` runs for every part the build touched.
+ *
+ * ⚠️ Deliberately O(movements) round trips rather than one bulk statement: each
+ * of those handlers re-SUMs whole, and a bulk delete that skipped them would
+ * leave every component's on-hand quantity holding stock the ledger no longer
+ * accounts for. A build with a long BOM is short in absolute terms.
+ */
+async function cascadeMovements(
+  handler: UnifiedCrudHandler,
+  movements: readonly GuardedMovement[]
+): Promise<void> {
+  for (const movement of movements) {
+    await handler.delete(toRecordId('stock_movement', movement.id))
+  }
+}

--- a/packages/lib/src/field-hooks/pre/guarded-movements.ts
+++ b/packages/lib/src/field-hooks/pre/guarded-movements.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/field-hooks/pre/guarded-movements.ts
+
+import { database, schema } from '@auxx/database'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import { getCachedEntityDefId, getOrgCache } from '../../cache'
+
+/** One movement, reduced to the two facts a delete guard decides on. */
+export interface GuardedMovement {
+  id: string
+  accountingDate: Date
+}
+
+/**
+ * The `stock_movement` relations a delete guard can hang off.
+ *
+ * `stock_movement_purchase_order_line` points at the LINE, never at the order —
+ * which is why the purchase-order guard is a two-hop read and the other two are
+ * not.
+ */
+export type MovementRelationAttribute =
+  | 'stock_movement_part'
+  | 'stock_movement_build'
+  | 'stock_movement_purchase_order_line'
+
+/**
+ * Every live stock movement whose `relationAttribute` names one of
+ * `targetInstanceIds` (plans/money/tasks/21-money-parent-delete-safety.md §2).
+ *
+ * 🛑 **Not built on `listReceipts` / `getPartReceiptHistory`.** Both hard-filter
+ * `stock_movement_type = 'receive'` (`receiving/receipt-queries.ts`), so a row
+ * whose only history is a scrap, an `initial` opening balance or a build
+ * consumption would pass a receipts-only check and delete clean out of a posted
+ * month. A guard has to see every `StockMovementType`.
+ *
+ * ⚠️ **BOM explosion parents are deliberately INCLUDED**, which is where this
+ * read differs from `gather-month-end-inventory.ts`. That module excludes them
+ * because they carry no quantity and legitimately carry no cost, so counting
+ * them would distort a total. Here they are ordinary ledger rows attached to the
+ * record being deleted, and a settled month containing one is still settled.
+ *
+ * The accounting date is `stock_movement_occurred_at` **coalesced onto
+ * `EntityInstance.createdAt`** — the documented fallback (`receipt-queries.ts`).
+ * Deriving it any other way lets a movement be judged under one date and posted
+ * under another.
+ */
+export async function readMovementsByRelation(
+  organizationId: string,
+  relationAttribute: MovementRelationAttribute,
+  targetInstanceIds: readonly string[]
+): Promise<GuardedMovement[]> {
+  if (targetInstanceIds.length === 0) return []
+
+  const movementDefId = await getCachedEntityDefId(organizationId, 'stock_movement')
+  if (!movementDefId) return []
+
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([relationAttribute, 'stock_movement_occurred_at'])) as Record<
+    string,
+    { id: string } | null
+  >
+
+  // No relation field means no movement can name this parent, so there is
+  // nothing to guard. An org mid-provisioning reaches this, not an error case.
+  const relationField = fields[relationAttribute]
+  if (!relationField) return []
+
+  const relationValue = alias(schema.FieldValue, 'guard_mv_rel')
+  const occurredValue = alias(schema.FieldValue, 'guard_mv_occurred')
+  const occurredField = fields.stock_movement_occurred_at
+
+  const query = database
+    .select({
+      id: schema.EntityInstance.id,
+      occurredAt: occurredValue.valueDate,
+      createdAt: schema.EntityInstance.createdAt,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      relationValue,
+      and(
+        eq(relationValue.entityId, schema.EntityInstance.id),
+        eq(relationValue.organizationId, schema.EntityInstance.organizationId),
+        eq(relationValue.fieldId, relationField.id),
+        inArray(relationValue.relatedEntityId, [...targetInstanceIds])
+      )
+    )
+    .$dynamic()
+
+  const rows = await (occurredField
+    ? query.leftJoin(
+        occurredValue,
+        and(
+          eq(occurredValue.entityId, schema.EntityInstance.id),
+          eq(occurredValue.organizationId, schema.EntityInstance.organizationId),
+          eq(occurredValue.fieldId, occurredField.id)
+        )
+      )
+    : query
+  ).where(
+    and(
+      eq(schema.EntityInstance.organizationId, organizationId),
+      eq(schema.EntityInstance.entityDefinitionId, movementDefId),
+      isNull(schema.EntityInstance.archivedAt)
+    )
+  )
+
+  return rows.map((row) => ({
+    id: row.id,
+    accountingDate: row.occurredAt ? new Date(row.occurredAt) : row.createdAt,
+  }))
+}

--- a/packages/lib/src/field-hooks/pre/part-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/part-delete-guard.test.ts
@@ -1,0 +1,301 @@
+// packages/lib/src/field-hooks/pre/part-delete-guard.test.ts
+// The guard that stops a part being hard-deleted out of a settled period, and
+// stops a deleted part leaving its BOM and supplier rows behind.
+//
+// plans/money/tasks/20-part-delete-safety.md §4. Dev ground truth the cases are
+// modelled on: DemoOrg1 is locked through `2026-07` and holds 31 movements, every
+// one of them in `2026-08` — a month whose revision 1 stands POSTED at
+// $1,320,563.80 while a later revision 2 sits `failed`, so the close strip
+// correctly reports that month as **`open`**. That is why the posted-entry check
+// reads `GlPosting` directly and why it is tested against an `open` strip.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityPreDeleteEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  listFiltered: vi.fn(),
+  del: vi.fn(),
+  getCachedEntityDefId: vi.fn(),
+  bySystemAttributes: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  postedPeriodRows: vi.fn(),
+  getOrganizationSetting: vi.fn(),
+  movementRows: vi.fn(),
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    listFiltered = h.listFiltered
+    delete = h.del
+  },
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: h.getCachedEntityDefId,
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+
+vi.mock('../../postings/period-lock', () => ({ resolvePeriodLock: h.resolvePeriodLock }))
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: h.getOrganizationSetting,
+}))
+
+// Two drizzle chains, stubbed separately so the tests cannot confuse them:
+// `select()` is the movement read, `selectDistinct()` is the posted-period read.
+// Each is a builder whose methods return itself and whose TERMINAL `.where()`
+// resolves. Keeping `where` as the resolution point (rather than making the
+// chain thenable) also pins the shape of the real queries: if either read stops
+// ending in `.where()`, these tests fail loudly instead of quietly awaiting a
+// builder.
+vi.mock('@auxx/database', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@auxx/database')
+  const movementChain: Record<string, unknown> = {}
+  for (const method of ['from', 'innerJoin', 'leftJoin', '$dynamic']) {
+    movementChain[method] = () => movementChain
+  }
+  movementChain.where = async () => h.movementRows()
+
+  const postedChain: Record<string, unknown> = {}
+  postedChain.from = () => postedChain
+  postedChain.where = async () => h.postedPeriodRows()
+
+  return {
+    ...actual,
+    database: { select: () => movementChain, selectDistinct: () => postedChain },
+  }
+})
+
+import { guardPartDelete } from './part-delete-guard'
+
+const PART_DEF = 'x5hzr4xbn1fhznih3u74gtza'
+const PART_ID = 'p4rt00000000000000000001'
+const PART_RECORD_ID = `${PART_DEF}:${PART_ID}`
+const ORG = 'abgwpa1l81reht2zmwrcihfu'
+
+function event(): EntityPreDeleteEvent {
+  return {
+    recordId: PART_RECORD_ID as EntityPreDeleteEvent['recordId'],
+    entityDefinitionId: PART_DEF,
+    entityType: 'part',
+    entitySlug: 'parts',
+    values: {},
+    organizationId: ORG,
+    userId: 'usr_1',
+    bypass: new Set(),
+  }
+}
+
+/** A movement row as the drizzle select shapes it. */
+function movement(id: string, occurredAt: string | null, createdAt = new Date('2026-08-15')) {
+  return { id, occurredAt, createdAt }
+}
+
+/** Settings, keyed the way `settledMovementPeriods` reads them. */
+function settings(values: Record<string, string | null>): void {
+  h.getOrganizationSetting.mockImplementation(
+    async ({ key }: { key: string }) => values[key] ?? null
+  )
+}
+
+/** Months with an entry currently standing in the books. */
+function posted(...periodKeys: string[]) {
+  return periodKeys.map((periodKey) => ({ periodKey }))
+}
+
+const BOOKS_OPEN = {
+  'accounting.cutoffPeriod': '2025-12',
+  'accounting.bookTimeZone': 'America/Los_Angeles',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.del.mockResolvedValue(undefined)
+  h.listFiltered.mockResolvedValue({ ids: [] })
+  h.getCachedEntityDefId.mockResolvedValue('v9xn5fhvb68jja0wcvog5gl4')
+  h.bySystemAttributes.mockResolvedValue({
+    stock_movement_part: { id: 'fld_part' },
+    stock_movement_occurred_at: { id: 'fld_occurred' },
+  })
+  h.movementRows.mockReturnValue([])
+  h.postedPeriodRows.mockReturnValue([])
+  h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
+  settings(BOOKS_OPEN)
+})
+
+describe('guardPartDelete — refusal', () => {
+  it('refuses a part whose movement sits in a month with a POSTED entry', async () => {
+    h.movementRows.mockReturnValue([movement('mv1', '2026-08-15T00:00:00Z')])
+    h.postedPeriodRows.mockReturnValue(posted('2026-08'))
+
+    await expect(guardPartDelete(event())).rejects.toThrow(/2026-08/)
+    // Refusal happens BEFORE any cascade: a rejected delete mutates nothing.
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('refuses a part whose movement sits in a LOCKED period with no posting at all', async () => {
+    // The case a posted-entry-only check would miss. DemoOrg1 is locked through
+    // 2026-07 with nothing posted in most of those months.
+    h.movementRows.mockReturnValue([movement('mv1', '2026-06-15T00:00:00Z')])
+    h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: '2026-07' })
+
+    await expect(guardPartDelete(event())).rejects.toThrow(/closed or posted/)
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('refuses a movement AT OR BEFORE the cutoff, which never appears in the strip', async () => {
+    // `close-periods.ts`: months at or before the cutoff "are covered by the
+    // frozen opening baseline and can never be closed here".
+    h.movementRows.mockReturnValue([movement('mv1', '2025-11-04T00:00:00Z')])
+
+    await expect(guardPartDelete(event())).rejects.toThrow(/2025-11/)
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('names every settled month and the total, not just the first', async () => {
+    h.movementRows.mockReturnValue([
+      movement('mv1', '2026-07-02T00:00:00Z'),
+      movement('mv2', '2026-08-15T00:00:00Z'),
+      movement('mv3', '2026-08-16T00:00:00Z'),
+    ])
+    h.postedPeriodRows.mockReturnValue(posted('2026-07', '2026-08'))
+
+    await expect(guardPartDelete(event())).rejects.toThrow(/3 stock movements in 2026-07, 2026-08/)
+  })
+
+  it('derives the period in the BOOK timezone, not UTC', async () => {
+    // 2026-09-01T04:00Z is still 2026-08-31 in Los Angeles. Judged in UTC this
+    // part would delete out of a posted August.
+    h.movementRows.mockReturnValue([movement('mv1', '2026-09-01T04:00:00Z')])
+    h.postedPeriodRows.mockReturnValue(posted('2026-08'))
+
+    await expect(guardPartDelete(event())).rejects.toThrow(/2026-08/)
+  })
+})
+
+describe('guardPartDelete — open books', () => {
+  it('deletes the movements when every one of them is in an OPEN period', async () => {
+    h.movementRows.mockReturnValue([
+      movement('mv1', '2026-08-15T00:00:00Z'),
+      movement('mv2', '2026-08-16T00:00:00Z'),
+    ])
+
+    await guardPartDelete(event())
+
+    expect(h.del).toHaveBeenCalledWith('stock_movement:mv1')
+    expect(h.del).toHaveBeenCalledWith('stock_movement:mv2')
+  })
+
+  it('does not suppress the post-delete hooks — the roll-up lands on a SURVIVING record', async () => {
+    h.movementRows.mockReturnValue([movement('mv1', '2026-08-15T00:00:00Z')])
+
+    await guardPartDelete(event())
+
+    // One argument only. `suppressPostDeleteHooks` here would strand the
+    // purchase order lines this guard deliberately keeps.
+    expect(h.del).toHaveBeenCalledWith('stock_movement:mv1')
+    for (const call of h.del.mock.calls) expect(call).toHaveLength(1)
+  })
+
+  it('settles nothing for an org that has not finished accounting setup', async () => {
+    settings({ 'accounting.bookTimeZone': 'UTC' }) // no cutoff
+    h.movementRows.mockReturnValue([movement('mv1', '2026-08-15T00:00:00Z')])
+
+    await guardPartDelete(event())
+
+    expect(h.del).toHaveBeenCalledWith('stock_movement:mv1')
+  })
+
+  it('falls back to createdAt when the movement carries no accounting date', async () => {
+    h.movementRows.mockReturnValue([movement('mv1', null, new Date('2026-08-15T18:00:00Z'))])
+    h.postedPeriodRows.mockReturnValue(posted('2026-08'))
+
+    await expect(guardPartDelete(event())).rejects.toThrow(/2026-08/)
+  })
+})
+
+describe('guardPartDelete — cascades', () => {
+  it('deletes the BOM rows on BOTH ends, de-duplicated', async () => {
+    h.listFiltered.mockImplementation(
+      async ({ entityDefinitionId }: { entityDefinitionId: string }) =>
+        entityDefinitionId === 'subpart' ? { ids: ['sub1', 'sub2'] } : { ids: [] }
+    )
+
+    await guardPartDelete(event())
+
+    const deleted = h.del.mock.calls.map((c) => c[0])
+    // Both queries return the same two ids; a part that is both a parent and a
+    // component must not be deleted twice.
+    expect(deleted.filter((id) => String(id).startsWith('subpart:'))).toEqual([
+      'subpart:sub1',
+      'subpart:sub2',
+    ])
+  })
+
+  it('queries both subpart relations, not just one', async () => {
+    await guardPartDelete(event())
+
+    const subpartFields = h.listFiltered.mock.calls
+      .filter((c) => c[0].entityDefinitionId === 'subpart')
+      .map((c) => c[0].filters[0].conditions[0].fieldId)
+    expect(subpartFields).toEqual(['subpart:parentPart', 'subpart:childPart'])
+  })
+
+  it('deletes the supplier pricing rows', async () => {
+    h.listFiltered.mockImplementation(
+      async ({ entityDefinitionId }: { entityDefinitionId: string }) =>
+        entityDefinitionId === 'vendor_part' ? { ids: ['vp1'] } : { ids: [] }
+    )
+
+    await guardPartDelete(event())
+
+    expect(h.del).toHaveBeenCalledWith('vendor_part:vp1')
+    const [query] = h.listFiltered.mock.calls.find(
+      (c) => c[0].entityDefinitionId === 'vendor_part'
+    )!
+    expect(query.filters[0].conditions[0]).toEqual({
+      id: 'part-supplier-pricing-part',
+      fieldId: 'vendor_part:part',
+      operator: 'is',
+      value: PART_RECORD_ID,
+    })
+  })
+
+  it('never touches the vendor documents — a bill line is not ours to delete', async () => {
+    h.listFiltered.mockResolvedValue({ ids: ['x1'] })
+
+    await guardPartDelete(event())
+
+    const queried = h.listFiltered.mock.calls.map((c) => c[0].entityDefinitionId)
+    expect(queried).not.toContain('purchase_order_line')
+    expect(queried).not.toContain('vendor_bill_line')
+    expect(queried).not.toContain('catalog_item')
+    expect(queried).not.toContain('line_item')
+  })
+})
+
+describe('guardPartDelete — provisioning edge cases', () => {
+  it('is a no-op for an org with no stock movement definition', async () => {
+    h.getCachedEntityDefId.mockResolvedValue(undefined)
+
+    await expect(guardPartDelete(event())).resolves.toBeUndefined()
+    expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when the movement part field has not been provisioned', async () => {
+    h.bySystemAttributes.mockResolvedValue({
+      stock_movement_part: null,
+      stock_movement_occurred_at: { id: 'fld_occurred' },
+    })
+
+    await expect(guardPartDelete(event())).resolves.toBeUndefined()
+  })
+
+  it('skips the settled-period read entirely for a part with no movements', async () => {
+    h.movementRows.mockReturnValue([])
+
+    await guardPartDelete(event())
+
+    expect(h.getOrganizationSetting).not.toHaveBeenCalled()
+    expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/field-hooks/pre/part-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/part-delete-guard.ts
@@ -1,0 +1,190 @@
+// packages/lib/src/field-hooks/pre/part-delete-guard.ts
+
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import { BadRequestError } from '../../errors'
+import { describeSettledPeriods, settledPeriodsFor } from '../../postings/settled-periods'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import type { EntityPreDeleteHandler } from '../types'
+import { type GuardedMovement, readMovementsByRelation } from './guarded-movements'
+
+/**
+ * Pre-delete guard for `parts` (plans/money/tasks/20-part-delete-safety.md).
+ * Fires inside `deleteEntity` for EVERY delete path — generic `record.delete`,
+ * bulk delete, drawers, Kopilot and the API — because `parts` is
+ * `isVisible: true` and therefore carries an ordinary records table with an
+ * ordinary delete button that no money code has ever seen.
+ *
+ * Three dispositions, one per class of child (§2 of the brief):
+ *
+ *   1. **`stock_movement` — REFUSE when the period is settled, else cascade.**
+ *      "Settled" is `settledPeriodsFor` (`postings/settled-periods.ts`), which
+ *      owns the three predicates and the reason each one is needed.
+ *      The movement ledger is append-only and a mistake is corrected by
+ *      reversing, never by editing, so hard-deleting the ledger's SUBJECT after
+ *      it has been posted is an accounting problem rather than a referential
+ *      one. `part_quantity_on_hand` also lives on the part, so the running total
+ *      vanishes while the ledger it summarises stays.
+ *   2. **`subpart` + `vendor_part` — CASCADE.** A BOM row is `(parent, child,
+ *      qty)` with no meaning once an end is gone — `subparts` even projects its
+ *      `displayName` FROM the child part, so a survivor renders as nothing at
+ *      all — and a supplier price for a part that does not exist prices nothing.
+ *   3. **`purchase_order_line`, `vendor_bill_line`, `catalog_item`, `line_item`
+ *      — LEAVE.** These are somebody else's document. A vendor really did bill
+ *      us for that thing, and a bill's totals are transcribed, never computed
+ *      (`docs/inventory-costing-architecture-guide.md`). They survive with an
+ *      empty part cell, which is correct and not a defect.
+ *
+ * **Why the cascade goes through `UnifiedCrudHandler.delete` and not raw SQL.**
+ * `mfg-subparts-deleted`, `mfg-vendor-parts-deleted` and
+ * `mfg-stock-movements-deleted` already exist as system record rules, and each
+ * recomputes a roll-up on a SURVIVING parent. Deleting through the handler is
+ * what makes them fire, and it is the whole integration — this task adds no rule
+ * of its own.
+ *
+ * ⚠️ **Nothing is suppressed here**, which is where this guard differs from the
+ * invoice and order ones. Those pass `suppressPostDeleteHooks` because their
+ * hook re-projects the very document being deleted; here the recompute lands on
+ * a DIFFERENT, surviving part, and suppressing it is precisely the bug this
+ * guard exists to fix (see {@link cascadeBomRows}).
+ *
+ * **No admin gate**, following the `orders`/`quotes` precedent rather than the
+ * `invoices` one: a part carries no payment ledger and no RESTRICT foreign key,
+ * so the per-row permission `record.delete` already asserts is the whole
+ * authorization story.
+ */
+export const guardPartDelete: EntityPreDeleteHandler = async (event) => {
+  const { organizationId, userId, recordId } = event
+  const { entityInstanceId: partInstanceId } = parseRecordId(recordId)
+
+  // Refuse BEFORE any cascade, so a rejected delete mutates nothing.
+  const movements = await readMovementsByRelation(organizationId, 'stock_movement_part', [
+    partInstanceId,
+  ])
+  if (movements.length > 0) {
+    const settled = await settledPeriodsFor(
+      organizationId,
+      movements.map((movement) => movement.accountingDate)
+    )
+    if (settled.size > 0) {
+      throw new BadRequestError(describeRefusal(settled), {
+        organizationId,
+        partInstanceId,
+        periods: [...settled.keys()],
+      })
+    }
+  }
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  await cascadeBomRows(handler, recordId)
+  await cascadeSupplierPricing(handler, recordId)
+  await cascadeMovements(handler, movements)
+}
+
+/**
+ * The refusal a user reads. Names the months and the counts, and points at
+ * archive — which is what `deleteEntityInstance`'s own docblock recommends over
+ * deletion anyway, and which loses nothing.
+ */
+function describeRefusal(settled: Map<string, number>): string {
+  return (
+    `This part has ${describeSettledPeriods(settled, 'stock movement')}. ` +
+    `A posted period is corrected by reversing an entry, never by deleting its history — ` +
+    `archive the part instead.`
+  )
+}
+
+// =============================================================================
+// CASCADES
+// =============================================================================
+
+/**
+ * The BOM rows on both ends.
+ *
+ * ✅ **This fixes a live bug rather than merely tidying up.** Deleting a
+ * component part today leaves its `subpart` rows alive, so
+ * `mfg-subparts-deleted` never fires and **every parent assembly's rolled cost
+ * goes stale permanently**. Cascading is what makes the existing rule do its
+ * job, which is also why nothing here is suppressed.
+ *
+ * Two queries rather than one OR group: `parentPart` and `childPart` are
+ * different relations answering different questions, and a part is routinely
+ * both. Ids are de-duplicated before deletion so a part that is its own
+ * assembly's component is not deleted twice.
+ */
+async function cascadeBomRows(handler: UnifiedCrudHandler, partRecordId: RecordId): Promise<void> {
+  const ids = new Set<string>()
+  for (const field of ['subpart:parentPart', 'subpart:childPart'] as const) {
+    const { ids: found } = await handler.listFiltered({
+      entityDefinitionId: 'subpart',
+      filters: [
+        {
+          id: 'part-bom-rows',
+          logicalOperator: 'AND',
+          conditions: [
+            { id: `part-bom-rows-${field}`, fieldId: field, operator: 'is', value: partRecordId },
+          ],
+        },
+      ],
+      limit: 1000,
+    })
+    for (const id of found) ids.add(id)
+  }
+
+  for (const id of ids) {
+    await handler.delete(toRecordId('subpart', id))
+  }
+}
+
+/** Supplier prices. A price for a part that does not exist prices nothing. */
+async function cascadeSupplierPricing(
+  handler: UnifiedCrudHandler,
+  partRecordId: RecordId
+): Promise<void> {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'vendor_part',
+    filters: [
+      {
+        id: 'part-supplier-pricing',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'part-supplier-pricing-part',
+            fieldId: 'vendor_part:part',
+            operator: 'is',
+            value: partRecordId,
+          },
+        ],
+      },
+    ],
+    limit: 1000,
+  })
+
+  for (const id of ids) {
+    await handler.delete(toRecordId('vendor_part', id))
+  }
+}
+
+/**
+ * The movements, once every one of them is known to sit in an open period.
+ *
+ * Deleted one at a time through the handler so `mfg-stock-movements-deleted`
+ * fires per row: `recalculatePartQoH` (a no-op for the dying part, but correct
+ * for a BOM explosion child pointing at a surviving one) and
+ * `recalculatePurchaseOrderLineReceived`, which is what keeps a SURVIVING
+ * purchase order line's received quantity honest after its receipts go.
+ *
+ * ⚠️ Each of those handlers re-SUMs whole, so this is deliberately O(movements)
+ * round trips rather than one bulk statement. A part with a long history is
+ * exactly the part this guard refuses to delete, so the loop stays short in
+ * practice — and a bulk delete that skipped the roll-ups would leave the
+ * purchase order lines this guard just decided to KEEP holding a phantom
+ * received quantity, which is worse than the round trips.
+ */
+async function cascadeMovements(
+  handler: UnifiedCrudHandler,
+  movements: readonly GuardedMovement[]
+): Promise<void> {
+  for (const movement of movements) {
+    await handler.delete(toRecordId('stock_movement', movement.id))
+  }
+}

--- a/packages/lib/src/field-hooks/pre/purchase-order-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-delete-guard.test.ts
@@ -1,0 +1,196 @@
+// packages/lib/src/field-hooks/pre/purchase-order-delete-guard.test.ts
+// The guard that stops a purchase order being hard-deleted out from under its
+// receipts or a vendor's bill.
+//
+// plans/money/tasks/21-money-parent-delete-safety.md §4. Note the two-hop read
+// the cases exercise: a `stock_movement` names the LINE, never the order, which
+// is why `sweepEntityFieldValues` never touched receipts and why an unguarded
+// delete looked harmless.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityPreDeleteEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  listFiltered: vi.fn(),
+  del: vi.fn(),
+  getCachedEntityDefId: vi.fn(),
+  bySystemAttributes: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  postedPeriodRows: vi.fn(),
+  getOrganizationSetting: vi.fn(),
+  movementRows: vi.fn(),
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    listFiltered = h.listFiltered
+    delete = h.del
+  },
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: h.getCachedEntityDefId,
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+
+vi.mock('../../postings/period-lock', () => ({ resolvePeriodLock: h.resolvePeriodLock }))
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: h.getOrganizationSetting,
+}))
+
+vi.mock('@auxx/database', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@auxx/database')
+  const movementChain: Record<string, unknown> = {}
+  for (const method of ['from', 'innerJoin', 'leftJoin', '$dynamic']) {
+    movementChain[method] = () => movementChain
+  }
+  movementChain.where = async () => h.movementRows()
+
+  const postedChain: Record<string, unknown> = {}
+  postedChain.from = () => postedChain
+  postedChain.where = async () => h.postedPeriodRows()
+
+  return {
+    ...actual,
+    database: { select: () => movementChain, selectDistinct: () => postedChain },
+  }
+})
+
+import { guardPurchaseOrderDelete } from './purchase-order-delete-guard'
+
+const PO_DEF = 'q5hzr4xbn1fhznih3u74gtza'
+const PO_ID = 'p00rd0000000000000000001'
+const PO_RECORD_ID = `${PO_DEF}:${PO_ID}`
+const ORG = 'abgwpa1l81reht2zmwrcihfu'
+
+function event(): EntityPreDeleteEvent {
+  return {
+    recordId: PO_RECORD_ID as EntityPreDeleteEvent['recordId'],
+    entityDefinitionId: PO_DEF,
+    entityType: 'purchase_order',
+    entitySlug: 'purchase-orders',
+    values: {},
+    organizationId: ORG,
+    userId: 'usr_1',
+    bypass: new Set(),
+  }
+}
+
+/** `listFiltered` answers per entity, so a test cannot confuse the two reads. */
+function children({ bills = [], lines = [] }: { bills?: string[]; lines?: string[] }): void {
+  h.listFiltered.mockImplementation(
+    async ({ entityDefinitionId }: { entityDefinitionId: string }) =>
+      entityDefinitionId === 'vendor_bill' ? { ids: bills } : { ids: lines }
+  )
+}
+
+function movement(id: string, occurredAt: string | null, createdAt = new Date('2026-08-15')) {
+  return { id, occurredAt, createdAt }
+}
+
+function settings(values: Record<string, string | null>): void {
+  h.getOrganizationSetting.mockImplementation(
+    async ({ key }: { key: string }) => values[key] ?? null
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getCachedEntityDefId.mockResolvedValue('movement-def')
+  h.bySystemAttributes.mockResolvedValue({
+    stock_movement_purchase_order_line: { id: 'f-line' },
+    stock_movement_occurred_at: { id: 'f-occurred' },
+  })
+  h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
+  h.postedPeriodRows.mockResolvedValue([])
+  h.movementRows.mockResolvedValue([])
+  children({})
+  settings({})
+})
+
+describe('guardPurchaseOrderDelete — refusals', () => {
+  it('refuses when a vendor bill is billed against the order', async () => {
+    children({ bills: ['bill-1'], lines: ['line-1'] })
+
+    await expect(guardPurchaseOrderDelete(event())).rejects.toThrow(/three-way match/i)
+  })
+
+  it('refuses on the bill before deleting anything at all', async () => {
+    children({ bills: ['bill-1'], lines: ['line-1'] })
+    h.movementRows.mockResolvedValue([movement('m1', '2026-09-01')])
+
+    await expect(guardPurchaseOrderDelete(event())).rejects.toThrow()
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('refuses when a receipt sits in a locked month', async () => {
+    children({ lines: ['line-1'] })
+    h.movementRows.mockResolvedValue([movement('m1', '2026-07-10')])
+    h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: '2026-07' })
+
+    await expect(guardPurchaseOrderDelete(event())).rejects.toThrow(/2026-07/)
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('refuses when a receipt sits in a month holding a standing posted entry', async () => {
+    children({ lines: ['line-1'] })
+    h.movementRows.mockResolvedValue([movement('m1', '2026-08-15')])
+    h.postedPeriodRows.mockResolvedValue([{ periodKey: '2026-08' }])
+
+    await expect(guardPurchaseOrderDelete(event())).rejects.toThrow(/2026-08/)
+  })
+
+  it('counts receipts, not stock movements, in the message', async () => {
+    children({ lines: ['line-1'] })
+    h.movementRows.mockResolvedValue([movement('m1', '2026-08-15')])
+    h.postedPeriodRows.mockResolvedValue([{ periodKey: '2026-08' }])
+
+    await expect(guardPurchaseOrderDelete(event())).rejects.toThrow(/1 receipt in 2026-08/)
+  })
+})
+
+describe('guardPurchaseOrderDelete — cascade', () => {
+  it('deletes the receipts BEFORE the lines', async () => {
+    children({ lines: ['line-1', 'line-2'] })
+    h.movementRows.mockResolvedValue([movement('m1', '2026-09-01')])
+
+    await guardPurchaseOrderDelete(event())
+
+    expect(h.del.mock.calls.map((call) => call[0])).toEqual([
+      'stock_movement:m1',
+      'purchase_order_line:line-1',
+      'purchase_order_line:line-2',
+    ])
+  })
+
+  it('never suppresses the movement delete — QoH lands on a surviving part', async () => {
+    children({ lines: ['line-1'] })
+    h.movementRows.mockResolvedValue([movement('m1', '2026-09-01')])
+
+    await guardPurchaseOrderDelete(event())
+
+    expect(h.del.mock.calls[0]).toEqual(['stock_movement:m1'])
+  })
+
+  it('cascades the lines even when the order never received anything', async () => {
+    children({ lines: ['line-1'] })
+
+    await guardPurchaseOrderDelete(event())
+
+    expect(h.del).toHaveBeenCalledExactlyOnceWith('purchase_order_line:line-1')
+  })
+
+  it('does nothing for an order with no lines and no bills', async () => {
+    await guardPurchaseOrderDelete(event())
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('settles nothing for an org with no accounting setup', async () => {
+    children({ lines: ['line-1'] })
+    h.movementRows.mockResolvedValue([movement('m1', '2020-01-01')])
+
+    await guardPurchaseOrderDelete(event())
+
+    expect(h.del).toHaveBeenCalledWith('stock_movement:m1')
+  })
+})

--- a/packages/lib/src/field-hooks/pre/purchase-order-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-delete-guard.ts
@@ -1,0 +1,161 @@
+// packages/lib/src/field-hooks/pre/purchase-order-delete-guard.ts
+
+import { type RecordId, toRecordId } from '@auxx/types/resource'
+import { BadRequestError } from '../../errors'
+import { describeSettledPeriods, settledPeriodsFor } from '../../postings/settled-periods'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import type { EntityPreDeleteHandler } from '../types'
+import { readMovementsByRelation } from './guarded-movements'
+
+/**
+ * Pre-delete guard for `purchase-orders`
+ * (plans/money/tasks/21-money-parent-delete-safety.md §4). Fires inside
+ * `deleteEntity` for EVERY delete path, because `purchase-orders` is
+ * `isVisible: true` and has carried an ordinary row delete and bulk delete since
+ * the day it shipped.
+ *
+ * **What deleting a purchase order costs today.** The order row goes and every
+ * child survives: the `purchase_order_line`s are orphaned, the receipt
+ * `stock_movement`s under them are untouched (they point at the LINE, so
+ * `sweepEntityFieldValues` never even sees them), and any `vendor_bill` naming
+ * the order loses its match anchor.
+ *
+ * 🛑 **And the sweep BLANKS the link rather than dangling it.** A dangling id is
+ * evidence — you can still see what the child pointed at. A swept relation
+ * leaves the line with an empty Purchase Order cell and no trace that a parent
+ * ever existed, so an unguarded delete here is unrecoverable rather than merely
+ * wrong.
+ *
+ * ⚠️ **The missing lever, for the third recorded time.** A line's
+ * `quantityOrdered` and `expectedUnitPrice` are evidence-locked against EDITS
+ * the moment a receipt or a bill line exists
+ * (`pre/purchase-order-line-evidence-lock.ts`), and there is no delete
+ * counterpart — so the line cannot be edited but can be deleted outright, or the
+ * order above it. `docs/inventory-costing-architecture-guide.md` §6.4 records
+ * the shape: `updatable: false` and the evidence lock are both claims about
+ * edits only, and there is no `deletable: false` in the schema at all.
+ *
+ * Two refusals and one cascade:
+ *
+ *   1. **REFUSE when any `vendor_bill` names this order.**
+ *   2. **REFUSE when any receipt under any of its lines sits in a settled
+ *      period.** Note the two-hop read — movements name the line, not the order.
+ *   3. **CASCADE the receipts, then the lines.**
+ */
+export const guardPurchaseOrderDelete: EntityPreDeleteHandler = async (event) => {
+  const { organizationId, userId, recordId } = event
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+
+  // Refuse BEFORE any cascade, so a rejected delete mutates nothing.
+  await refuseIfBilled(handler, organizationId, recordId)
+
+  const lineIds = await readLineIds(handler, recordId)
+  const movements = await readMovementsByRelation(
+    organizationId,
+    'stock_movement_purchase_order_line',
+    lineIds
+  )
+
+  if (movements.length > 0) {
+    const settled = await settledPeriodsFor(
+      organizationId,
+      movements.map((movement) => movement.accountingDate)
+    )
+    if (settled.size > 0) {
+      throw new BadRequestError(
+        `This purchase order has ${describeSettledPeriods(settled, 'receipt')}. ` +
+          `A posted period is corrected by reversing an entry, never by deleting its ` +
+          `history — archive the order instead.`,
+        { organizationId, recordId, periods: [...settled.keys()] }
+      )
+    }
+  }
+
+  // 🛑 Receipts first, lines second. `mfg-stock-movements-deleted` recomputes
+  // `recalculatePartQoH` for the received part (a survivor, so nothing is
+  // suppressed) and also `recalculatePurchaseOrderLineReceived` against a line
+  // that is about to be deleted — wasted, but harmless, and suppressing it to
+  // avoid the waste would take the QoH recompute down with it.
+  for (const movement of movements) {
+    await handler.delete(toRecordId('stock_movement', movement.id))
+  }
+
+  // A line's `purchaseOrder` relation is `required: true` in the registry, so a
+  // line without an order is invalid by the schema's own definition. That is the
+  // argument for cascading rather than orphaning, and it is a stronger one than
+  // the order/line-item guard had to make.
+  for (const lineId of lineIds) {
+    await handler.delete(toRecordId('purchase_order_line', lineId))
+  }
+}
+
+/**
+ * Refuse when a vendor has billed against this order.
+ *
+ * ⚠️ **This is where the task departs from `guardPartDelete`, deliberately.**
+ * That guard LEAVES the vendor's own documents alone, on the grounds that a
+ * vendor really did bill us for that thing. The distinction: a bill line
+ * surviving a *part* delete is still a complete document that merely lost a
+ * cell, whereas a bill surviving its *order*'s delete has lost the anchor the
+ * three-way match is computed against — `purchasing/match.ts` reads the order
+ * leg to produce a verdict at all.
+ */
+async function refuseIfBilled(
+  handler: UnifiedCrudHandler,
+  organizationId: string,
+  recordId: RecordId
+): Promise<void> {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'vendor_bill',
+    filters: [
+      {
+        id: 'po-bills',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'po-bills-order',
+            fieldId: 'vendor_bill:purchaseOrder',
+            operator: 'is',
+            value: recordId,
+          },
+        ],
+      },
+    ],
+    limit: 1000,
+  })
+
+  if (ids.length > 0) {
+    throw new BadRequestError(
+      `This purchase order has ${ids.length} vendor ${ids.length === 1 ? 'bill' : 'bills'} ` +
+        `billed against it. Deleting the order would leave the three-way match with no order ` +
+        `leg — delete or unlink the bills first, or archive the order instead.`,
+      { organizationId, recordId, vendorBillIds: ids }
+    )
+  }
+}
+
+/** The order's own lines. */
+async function readLineIds(
+  handler: UnifiedCrudHandler,
+  recordId: RecordId
+): Promise<readonly string[]> {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'purchase_order_line',
+    filters: [
+      {
+        id: 'po-lines',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'po-lines-order',
+            fieldId: 'purchase_order_line:purchaseOrder',
+            operator: 'is',
+            value: recordId,
+          },
+        ],
+      },
+    ],
+    limit: 1000,
+  })
+  return ids
+}

--- a/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.test.ts
@@ -1,0 +1,208 @@
+// packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.test.ts
+// The guard that stops a vendor bill being hard-deleted once it is in the books,
+// part-paid, or dated in a settled month.
+//
+// plans/money/tasks/21-money-parent-delete-safety.md §5. The shape difference
+// from the other three guards: a bill has no movements of its own, so the
+// settled test runs on ONE date — `vendor_bill_billed_at`, which the field's own
+// description calls "the ACCOUNTING date".
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityPreDeleteEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  listFiltered: vi.fn(),
+  del: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  postedPeriodRows: vi.fn(),
+  getOrganizationSetting: vi.fn(),
+  instanceRows: vi.fn(),
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    listFiltered = h.listFiltered
+    delete = h.del
+  },
+}))
+
+vi.mock('../../postings/period-lock', () => ({ resolvePeriodLock: h.resolvePeriodLock }))
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: h.getOrganizationSetting,
+}))
+
+// `select()` is the `createdAt` fallback read; `selectDistinct()` is the
+// posted-period read. Separate chains so a test cannot confuse them.
+vi.mock('@auxx/database', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@auxx/database')
+  const instanceChain: Record<string, unknown> = {}
+  instanceChain.from = () => instanceChain
+  instanceChain.where = async () => h.instanceRows()
+
+  const postedChain: Record<string, unknown> = {}
+  postedChain.from = () => postedChain
+  postedChain.where = async () => h.postedPeriodRows()
+
+  return {
+    ...actual,
+    database: { select: () => instanceChain, selectDistinct: () => postedChain },
+  }
+})
+
+import { guardVendorBillDelete } from './vendor-bill-delete-guard'
+
+const BILL_DEF = 'v5hzr4xbn1fhznih3u74gtza'
+const BILL_ID = 'b1ll00000000000000000001'
+const BILL_RECORD_ID = `${BILL_DEF}:${BILL_ID}`
+const ORG = 'abgwpa1l81reht2zmwrcihfu'
+
+function event(values: Record<string, unknown> = {}): EntityPreDeleteEvent {
+  return {
+    recordId: BILL_RECORD_ID as EntityPreDeleteEvent['recordId'],
+    entityDefinitionId: BILL_DEF,
+    entityType: 'vendor_bill',
+    entitySlug: 'vendor-bills',
+    values: { vendor_bill_billed_at: '2026-09-05', ...values },
+    organizationId: ORG,
+    userId: 'usr_1',
+    bypass: new Set(),
+  }
+}
+
+/** `listFiltered` answers per entity, so a test cannot confuse the two reads. */
+function children({ allocations = [], lines = [] }: { allocations?: string[]; lines?: string[] }) {
+  h.listFiltered.mockImplementation(
+    async ({ entityDefinitionId }: { entityDefinitionId: string }) =>
+      entityDefinitionId === 'vendor_payment_allocation' ? { ids: allocations } : { ids: lines }
+  )
+}
+
+function settings(values: Record<string, string | null>): void {
+  h.getOrganizationSetting.mockImplementation(
+    async ({ key }: { key: string }) => values[key] ?? null
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
+  h.postedPeriodRows.mockResolvedValue([])
+  h.instanceRows.mockResolvedValue([{ createdAt: new Date('2026-09-05') }])
+  children({})
+  settings({})
+})
+
+describe('guardVendorBillDelete — status', () => {
+  for (const status of ['posted', 'partially_paid', 'paid']) {
+    it(`refuses a ${status} bill`, async () => {
+      await expect(guardVendorBillDelete(event({ vendor_bill_status: status }))).rejects.toThrow(
+        /in the books or part-paid/i
+      )
+      expect(h.del).not.toHaveBeenCalled()
+    })
+  }
+
+  for (const status of ['draft', 'awaiting_receipt', 'matched', 'exception']) {
+    it(`allows a ${status} bill through the status wall`, async () => {
+      children({ lines: ['line-1'] })
+
+      await guardVendorBillDelete(event({ vendor_bill_status: status }))
+
+      expect(h.del).toHaveBeenCalled()
+    })
+  }
+
+  it('unwraps a coerced SINGLE_SELECT value', async () => {
+    // The `build-status-guard.ts` trap: on the field chain a select arrives as
+    // `{ type: 'option', optionId }`, and a guard comparing the raw value is
+    // inert while reading perfectly in review.
+    await expect(
+      guardVendorBillDelete(event({ vendor_bill_status: { type: 'option', optionId: 'paid' } }))
+    ).rejects.toThrow(/part-paid/i)
+  })
+})
+
+describe('guardVendorBillDelete — allocations and period', () => {
+  it('refuses when a vendor payment has been allocated to the bill', async () => {
+    children({ allocations: ['alloc-1'], lines: ['line-1'] })
+
+    await expect(guardVendorBillDelete(event())).rejects.toThrow(/payment allocation/i)
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the bill date sits in a locked month', async () => {
+    h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: '2026-07' })
+
+    await expect(
+      guardVendorBillDelete(event({ vendor_bill_billed_at: '2026-07-02' }))
+    ).rejects.toThrow(/2026-07/)
+  })
+
+  it('refuses when the bill date sits in a month holding a standing posted entry', async () => {
+    h.postedPeriodRows.mockResolvedValue([{ periodKey: '2026-08' }])
+
+    await expect(
+      guardVendorBillDelete(event({ vendor_bill_billed_at: '2026-08-15' }))
+    ).rejects.toThrow(/2026-08/)
+  })
+
+  it('refuses when the bill date is at or before the cutoff', async () => {
+    settings({ 'accounting.cutoffPeriod': '2026-05' })
+
+    await expect(
+      guardVendorBillDelete(event({ vendor_bill_billed_at: '2026-04-30' }))
+    ).rejects.toThrow(/2026-04/)
+  })
+
+  it('falls back to createdAt when billedAt is unset, rather than reading it as open', async () => {
+    h.instanceRows.mockResolvedValue([{ createdAt: new Date('2026-07-20') }])
+    h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: '2026-07' })
+
+    await expect(guardVendorBillDelete(event({ vendor_bill_billed_at: null }))).rejects.toThrow(
+      /2026-07/
+    )
+  })
+
+  it('falls back to createdAt when billedAt is unparseable', async () => {
+    h.instanceRows.mockResolvedValue([{ createdAt: new Date('2026-07-20') }])
+    h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: '2026-07' })
+
+    await expect(
+      guardVendorBillDelete(event({ vendor_bill_billed_at: 'not a date' }))
+    ).rejects.toThrow(/2026-07/)
+  })
+})
+
+describe('guardVendorBillDelete — cascade', () => {
+  it('deletes the bill lines WITH post-delete hooks suppressed', async () => {
+    // `rematchAfterBillLineDelete` re-projects the bill being deleted, so
+    // leaving it live re-runs the whole match once per line against a document
+    // that is about to vanish. This is the one guard of the four that suppresses.
+    children({ lines: ['line-1', 'line-2'] })
+
+    await guardVendorBillDelete(event())
+
+    expect(h.del).toHaveBeenCalledTimes(2)
+    expect(h.del).toHaveBeenCalledWith('vendor_bill_line:line-1', {
+      suppressPostDeleteHooks: true,
+    })
+    expect(h.del).toHaveBeenCalledWith('vendor_bill_line:line-2', {
+      suppressPostDeleteHooks: true,
+    })
+  })
+
+  it('does nothing for a bill with no lines', async () => {
+    await guardVendorBillDelete(event())
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('settles nothing for an org with no accounting setup', async () => {
+    children({ lines: ['line-1'] })
+
+    await guardVendorBillDelete(event({ vendor_bill_billed_at: '2020-01-01' }))
+
+    expect(h.del).toHaveBeenCalledWith('vendor_bill_line:line-1', {
+      suppressPostDeleteHooks: true,
+    })
+  })
+})

--- a/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.ts
@@ -1,0 +1,212 @@
+// packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.ts
+
+import { database, schema } from '@auxx/database'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
+import { BadRequestError } from '../../errors'
+import { settledPeriodsFor } from '../../postings/settled-periods'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import { VendorBillStatus } from '../../resources/registry/enum-values'
+import type { EntityPreDeleteEvent, EntityPreDeleteHandler } from '../types'
+
+/**
+ * The bill statuses that mean the document is already in the books or already
+ * part-settled with the vendor.
+ *
+ * `posted` is usually implied by the period predicates below, but not always — a
+ * bill can be marked posted before its month closes — so it is checked
+ * explicitly rather than reasoned about.
+ */
+const SETTLED_BILL_STATUSES: ReadonlySet<string> = new Set([
+  VendorBillStatus.POSTED,
+  VendorBillStatus.PARTIALLY_PAID,
+  VendorBillStatus.PAID,
+])
+
+/**
+ * Pre-delete guard for `vendor-bills`
+ * (plans/money/tasks/21-money-parent-delete-safety.md §5). Fires inside
+ * `deleteEntity` for EVERY delete path, because `vendor-bills` is
+ * `isVisible: true` and has carried an ordinary row delete and bulk delete since
+ * the day it shipped.
+ *
+ * **The shape difference from the other three guards: a bill has no movements of
+ * its own.** Its accounting date is its own field, `vendor_bill_billed_at` —
+ * whose description states outright that it is *"the ACCOUNTING date"* and that
+ * `createdAt` "is routinely a different period". So the settled test runs on one
+ * date rather than over a set of children.
+ *
+ * Three refusals and one cascade:
+ *
+ *   1. **REFUSE on status** — `posted`, `partially_paid`, `paid`.
+ *   2. **REFUSE when any `vendor_payment_allocation` names this bill.** Money has
+ *      been applied. The relation is `required: true`, so the allocation cannot
+ *      survive meaningfully — and it must not be silently cascaded either,
+ *      because deleting it changes what a vendor payment paid for with no record.
+ *   3. **REFUSE when the bill date's period is settled.**
+ *   4. **CASCADE `vendor_bill_line`** — `required: true` again.
+ *
+ * 🛑 **The cascade suppresses post-delete hooks, unlike the part, build and
+ * purchase-order guards.** `registerEntityPostDeleteHooks('vendor-bill-lines',
+ * [rematchAfterBillLineDelete])` re-projects **the bill being deleted**
+ * (`purchasing/match-hook.ts` → `markOrRematchBill(…, vendorBillInstanceId)`),
+ * so leaving it live runs the whole three-way match once per line against a
+ * document that is about to vanish.
+ *
+ * ⚠️ **That is the trap in this whole task, and it is invisible at the call
+ * site.** The rule: suppress when the hook re-projects the document being
+ * deleted (here, and the existing invoice/order guards); do NOT suppress when it
+ * lands on a surviving record (parts, builds, purchase orders — where the
+ * recompute is the entire integration).
+ */
+export const guardVendorBillDelete: EntityPreDeleteHandler = async (event) => {
+  const { organizationId, userId, recordId } = event
+  const { entityInstanceId: billInstanceId } = parseRecordId(recordId)
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+
+  // Refuse BEFORE any cascade, so a rejected delete mutates nothing.
+  refuseOnStatus(event)
+  await refuseIfAllocated(handler, organizationId, recordId)
+
+  const billedAt = await resolveAccountingDate(organizationId, billInstanceId, event)
+  const settled = await settledPeriodsFor(organizationId, [billedAt])
+  if (settled.size > 0) {
+    throw new BadRequestError(
+      `This vendor bill is dated in ${[...settled.keys()].join(', ')}, which has been ` +
+        `closed or posted. A posted period is corrected by reversing an entry, never by ` +
+        `deleting its history — archive the bill instead.`,
+      { organizationId, recordId, periods: [...settled.keys()] }
+    )
+  }
+
+  await cascadeLines(handler, recordId)
+}
+
+/** The status wall, read off the values `deleteEntity` already captured. */
+function refuseOnStatus(event: EntityPreDeleteEvent): void {
+  const status = unwrapStatus(event.values.vendor_bill_status)
+  if (status !== null && SETTLED_BILL_STATUSES.has(status)) {
+    throw new BadRequestError(
+      `This vendor bill is ${status.replace(/_/g, ' ')}. A bill that is in the books or ` +
+        `part-paid is corrected by reversing it, never by deleting it — archive it instead.`,
+      { organizationId: event.organizationId, recordId: event.recordId, status }
+    )
+  }
+}
+
+/**
+ * A captured SINGLE_SELECT value, reduced to its option id.
+ *
+ * ⚠️ Captured values are not uniformly bare strings — `rematchAfterBillLineDelete`
+ * has to unwrap a `RecordId` from the same source, and a select arrives as
+ * `{ type: 'option', optionId }` on the field chain. Both shapes are handled
+ * rather than assumed, because a guard that compares the wrong shape is inert
+ * and reads perfectly in review (`pre/build-status-guard.ts` documents that
+ * exact trap).
+ */
+function unwrapStatus(value: unknown): string | null {
+  if (typeof value === 'string') return value.length > 0 ? value : null
+  if (Array.isArray(value)) return unwrapStatus(value[0])
+  if (value && typeof value === 'object') {
+    if ('optionId' in value) return unwrapStatus((value as { optionId: unknown }).optionId)
+    if ('value' in value) return unwrapStatus((value as { value: unknown }).value)
+  }
+  return null
+}
+
+/** Refuse when a vendor payment has been applied to this bill. */
+async function refuseIfAllocated(
+  handler: UnifiedCrudHandler,
+  organizationId: string,
+  recordId: RecordId
+): Promise<void> {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'vendor_payment_allocation',
+    filters: [
+      {
+        id: 'bill-allocations',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'bill-allocations-bill',
+            fieldId: 'vendor_payment_allocation:vendorBill',
+            operator: 'is',
+            value: recordId,
+          },
+        ],
+      },
+    ],
+    limit: 1000,
+  })
+
+  if (ids.length > 0) {
+    throw new BadRequestError(
+      `This vendor bill has ${ids.length} payment ${ids.length === 1 ? 'allocation' : 'allocations'} ` +
+        `against it. Deleting it would change what a vendor payment paid for, with no record — ` +
+        `unallocate the payment first, or archive the bill instead.`,
+      { organizationId, recordId, allocationIds: ids }
+    )
+  }
+}
+
+/**
+ * The bill's accounting date: `billedAt` when set, otherwise the row's
+ * `createdAt`.
+ *
+ * 🛑 **The fallback matters and must not be "unset means open".** `billedAt` is
+ * nullable, and reading a missing one as "no period" would make an
+ * un-transcribed bill the easiest one to delete — while `createdAt` is exactly
+ * what the field's own description warns is "routinely a different period", so
+ * it is a fallback and never the primary. This mirrors the movement read's
+ * `occurredAt`-coalesced-onto-`createdAt` rule rather than inventing a second
+ * convention.
+ */
+async function resolveAccountingDate(
+  organizationId: string,
+  billInstanceId: string,
+  event: EntityPreDeleteEvent
+): Promise<Date> {
+  const billedAt = event.values.vendor_bill_billed_at
+  if (typeof billedAt === 'string' || billedAt instanceof Date) {
+    const parsed = new Date(billedAt)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  }
+
+  const [row] = await database
+    .select({ createdAt: schema.EntityInstance.createdAt })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.id, billInstanceId),
+        eq(schema.EntityInstance.organizationId, organizationId)
+      )
+    )
+
+  return row?.createdAt ?? new Date()
+}
+
+/** The bill's own lines. See the class docblock for why this one suppresses. */
+async function cascadeLines(handler: UnifiedCrudHandler, recordId: RecordId): Promise<void> {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'vendor_bill_line',
+    filters: [
+      {
+        id: 'bill-lines',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'bill-lines-bill',
+            fieldId: 'vendor_bill_line:vendorBill',
+            operator: 'is',
+            value: recordId,
+          },
+        ],
+      },
+    ],
+    limit: 1000,
+  })
+
+  for (const id of ids) {
+    await handler.delete(toRecordId('vendor_bill_line', id), { suppressPostDeleteHooks: true })
+  }
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -72,6 +72,7 @@ import {
   registerPurchaseOrderLineRollupReconcilers,
 } from './post/purchase-order-line-rollups'
 import { touchActivityOnFieldChange } from './post/touch-activity-on-field-change'
+import { guardBuildDelete } from './pre/build-delete-guard'
 import { guardManualBuildLifecycleStatus } from './pre/build-status-guard'
 import { guardInboxOwnerField } from './pre/inbox-owner-guard'
 import { guardInvoiceDelete } from './pre/invoice-delete-guard'
@@ -80,6 +81,8 @@ import {
   guardManualQuoteLifecycleStatus,
 } from './pre/lifecycle-status-guard'
 import { cascadeOrderLinesOnDelete } from './pre/order-delete-guard'
+import { guardPartDelete } from './pre/part-delete-guard'
+import { guardPurchaseOrderDelete } from './pre/purchase-order-delete-guard'
 import {
   EVIDENCE_LOCKED_LINE_ATTRS,
   guardEvidenceLockedLineFields,
@@ -94,6 +97,7 @@ import {
   rejectIfSystemTag,
 } from './pre/tag-system-guard'
 import { dropUnauthorizedTemplateKey, rejectDeleteIfTemplateTag } from './pre/tag-template-guard'
+import { guardVendorBillDelete } from './pre/vendor-bill-delete-guard'
 import { guardWorkOrderDelete } from './pre/work-order-delete-guard'
 import {
   registerEntityFieldChangeHooks,
@@ -501,6 +505,23 @@ export function registerAllHooks(): void {
   registerEntityPreDeleteHooks('quotes', [guardQuoteConvertedDelete])
   // Orders own their lines outright (08 §5.4) — no guard, just the cascade.
   registerEntityPreDeleteHooks('orders', [cascadeOrderLinesOnDelete])
+
+  // Inventory delete-safety (plans/money/tasks/20-part-delete-safety.md) — the same pass, six
+  // weeks later, for the subsystem that never inherited it. `parts` is `isVisible: true`, so it
+  // has carried an ordinary row delete and bulk delete since the day it shipped: refuses when a
+  // movement sits in a settled period, cascades the BOM and supplier rows, and leaves the vendor's
+  // own documents alone.
+  registerEntityPreDeleteHooks('parts', [guardPartDelete])
+
+  // The other three visible money parents (plans/money/tasks/21-money-parent-delete-safety.md).
+  // Same threshold as `parts` — cascade when the period is open, refuse when it is settled — and
+  // the same shared `settledPeriodsFor` behind all four.
+  // 🛑 The `suppressPostDeleteHooks` answer DIFFERS per guard and is invisible here: `vendor-bills`
+  // suppresses because `rematchAfterBillLineDelete` re-projects the bill being deleted, while
+  // `builds` and `purchase-orders` must NOT, because their recompute lands on a surviving part.
+  registerEntityPreDeleteHooks('builds', [guardBuildDelete])
+  registerEntityPreDeleteHooks('purchase-orders', [guardPurchaseOrderDelete])
+  registerEntityPreDeleteHooks('vendor-bills', [guardVendorBillDelete])
 
   // Billing projections after deletes (plan 24 §4.6) — deletes fire no field-change hooks, so
   // these are the explicit post-cleanup projector calls for every delete path (generic

--- a/packages/lib/src/postings/settled-periods.ts
+++ b/packages/lib/src/postings/settled-periods.ts
@@ -1,0 +1,123 @@
+// packages/lib/src/postings/settled-periods.ts
+
+import { database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { getOrganizationSetting } from '../settings/settings-service'
+import { resolvePeriodLock } from './period-lock'
+import { compareMonths, isPeriodLocked, periodKeyForDate } from './periods'
+import { OPENING_BASELINE_SETTING_KEYS } from './setup-readiness'
+
+/**
+ * Which of these dates fall in a month the books are already closed to.
+ *
+ * **Extracted from `field-hooks/pre/part-delete-guard.ts`**
+ * (plans/money/tasks/21-money-parent-delete-safety.md §2) because four delete
+ * guards now need the same answer, and the reason each predicate is written the
+ * way it is does not survive being copy-pasted.
+ *
+ * **Three predicates, and each one catches a case the others miss.** All three
+ * are needed; this was established against the dev database, not by reasoning:
+ *
+ *   1. **The period lock.** `resolvePeriodLock` + `isPeriodLocked`. DemoOrg1 is
+ *      locked through `2026-07`, so everything up to there is settled.
+ *   2. **A posted entry stands for the month.** Read from `GlPosting` directly,
+ *      NOT from `listClosePeriods`.
+ *   3. **At or before `accounting.cutoffPeriod`.** Those months never appear in
+ *      the close strip at all — `close-periods.ts` states that they "are covered
+ *      by the frozen opening baseline and can never be closed here".
+ *
+ * 🛑 **Why predicate 2 does not use the close strip, which is the obvious move
+ * and is wrong.** `listClosePeriods` answers *"can I close this month?"*, and
+ * its `resolveState` reports the EFFECTIVE posting — the highest revision that
+ * is not itself reversed. DemoOrg1's `2026-08` holds revision 0 `reversed`,
+ * revision 1 **`posted`** at $1,320,563.80, and revision 2 `failed` on four
+ * unmapped QuickBooks accounts. The effective row is revision 2, so the strip
+ * correctly reports `2026-08` as **`open`** — there is an unfinished attempt in
+ * it. But revision 1 is still standing in the books, and its
+ * `assertions.before.balances` were computed from exactly the rows a guard is
+ * deciding about. A guard keyed on the strip's state would have let every part
+ * in the dev org delete its ledger out from under a filed entry.
+ *
+ * `status = 'posted'` is precisely "currently standing in the books": a reversal
+ * flips the row it supersedes to `reversed`, so a reversed entry stops matching
+ * on its own.
+ *
+ * An organization that has not finished accounting setup has no cutoff, gets no
+ * posted rows and holds no lock, so it settles nothing. That is the correct
+ * reading of "we have not started keeping books yet", and it keeps every guard
+ * built on this out of the way of the orgs not using the accounting module.
+ *
+ * @returns the settled months among `dates`, each mapped to how many of the
+ *   dates landed in it. Empty when nothing is settled.
+ */
+export async function settledPeriodsFor(
+  organizationId: string,
+  dates: readonly Date[]
+): Promise<Map<string, number>> {
+  const settled = new Map<string, number>()
+  if (dates.length === 0) return settled
+
+  const [cutoff, bookTimeZone, lock, postedPeriods] = await Promise.all([
+    readSetting(organizationId, OPENING_BASELINE_SETTING_KEYS.cutoffPeriod),
+    readSetting(organizationId, OPENING_BASELINE_SETTING_KEYS.bookTimeZone),
+    // Fails CLOSED on a malformed lock, which is the behaviour a guard wants:
+    // refusing one delete until a settings row is fixed is a five-second repair,
+    // and the alternative reading lets history out from under a closed month.
+    resolvePeriodLock(organizationId),
+    readPostedPeriods(organizationId),
+  ])
+
+  for (const date of dates) {
+    const periodKey = periodKeyForDate(date, 'month', bookTimeZone ?? 'UTC')
+    const isSettled =
+      isPeriodLocked(periodKey, lock) ||
+      postedPeriods.has(periodKey) ||
+      (cutoff !== null && compareMonths(periodKey, cutoff) <= 0)
+    if (isSettled) settled.set(periodKey, (settled.get(periodKey) ?? 0) + 1)
+  }
+  return settled
+}
+
+/** Every month this organization has an entry currently standing in the books for. */
+async function readPostedPeriods(organizationId: string): Promise<ReadonlySet<string>> {
+  const rows = await database
+    .selectDistinct({ periodKey: schema.GlPosting.periodKey })
+    .from(schema.GlPosting)
+    .where(
+      and(
+        eq(schema.GlPosting.organizationId, organizationId),
+        eq(schema.GlPosting.status, 'posted')
+      )
+    )
+  return new Set(rows.map((row) => row.periodKey))
+}
+
+/**
+ * One organization setting as a trimmed string, or null.
+ *
+ * The key is typed off `getOrganizationSetting`'s own parameter rather than
+ * widened to `string`, so a catalog key that is renamed or retired fails here at
+ * compile time instead of silently reading as "unset" — which for the cutoff
+ * would mean "this org keeps no books" and would quietly disarm every guard
+ * built on this function.
+ */
+type SettingKey = Parameters<typeof getOrganizationSetting>[0]['key']
+
+async function readSetting(organizationId: string, key: SettingKey): Promise<string | null> {
+  const value = await getOrganizationSetting({ organizationId, key })
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
+}
+
+/**
+ * The shared half of a guard's refusal message: names the months and the counts.
+ *
+ * @param settled the map {@link settledPeriodsFor} returned
+ * @param noun what the counted rows are, singular — pluralised with a bare `s`
+ */
+export function describeSettledPeriods(settled: Map<string, number>, noun: string): string {
+  const total = [...settled.values()].reduce((sum, n) => sum + n, 0)
+  const months = [...settled.keys()].sort().join(', ')
+  const subject = total === 1 ? noun : `${noun}s`
+  const verb = settled.size === 1 ? 'has' : 'have'
+  return `${total} ${subject} in ${months}, which ${verb} been closed or posted`
+}


### PR DESCRIPTION
Every entity in the inventory/purchasing subsystem is `EntityInstance`-backed and adds no Drizzle table, so each one inherits the generic records table (with its row delete and its bulk delete) for free. Four of them are `isVisible: true` and **none had a pre-delete hook**, so a part, build, purchase order or vendor bill could be hard-deleted out of a period that had already posted.

## What deleting one costs today

`deleteEntity` runs pre-delete hooks (there were none for three of the four), deletes comments, then calls `deleteEntityInstance`. The only cascade in there is `sweepEntityFieldValues`, which removes **both halves of every relation `FieldValue`** and then drops the row. Children are never deleted.

So deleting a purchase order left its lines, its receipts and any bill naming it all alive and all unlinked.

🛑 **And the sweep makes this quieter than a dangling reference, not louder.** A dangling id is evidence, you can still see what the child pointed at. A swept relation leaves the child with an empty cell and **no trace a parent ever existed**, so an unguarded parent delete is unrecoverable rather than merely wrong.

## The guards

`guardBuildDelete`, `guardPurchaseOrderDelete` and `guardVendorBillDelete`, alongside the existing `guardPartDelete`. All four cascade when the period is open and refuse when it is settled.

| Slug | Refuses on | Cascades |
| --- | --- | --- |
| `builds` | a settled movement, **or** either end of a reversal pair | the `build_consume`/`build_produce` movements |
| `purchase-orders` | any `vendor_bill` naming the order, **or** a settled receipt under any line | receipts **then** lines |
| `vendor-bills` | `posted`/`partially_paid`/`paid`, any payment allocation, **or** a settled `billedAt` | its lines, suppressed |

`purchase-orders` is the one place this departs from `guardPartDelete`, which leaves the vendor's documents alone. The distinction: a bill line surviving a *part* delete is still a complete document that lost a cell, whereas a bill surviving its *order*'s delete has lost the anchor the three-way match is computed against.

## Two extractions

So the reasoning survives being reused four times rather than being copy-pasted:

- **`postings/settled-periods.ts`** (`settledPeriodsFor`) owns the three predicates. The posted check reads `GlPosting` directly and must **not** use `listClosePeriods`, which answers *"can I close this month?"* and therefore reports a month holding a standing rev 1 `posted` plus a later rev 2 `failed` as `open`.
- **`field-hooks/pre/guarded-movements.ts`** (`readMovementsByRelation`) owns the movement join three of the four guards need. Not built on `listReceipts` (it hard-filters `receive`), and BOM explosion parents are deliberately included.

`part-delete-guard.ts` is refactored onto both. **Its 16 tests stay green unmodified**, which is the regression check that the extractions changed nothing.

## The trap worth reviewing

`suppressPostDeleteHooks` differs per guard and nothing at the call site says so:

- **Suppress** when the child's post-delete hook re-projects the document being deleted. `vendor-bills`, where `rematchAfterBillLineDelete` calls `markOrRematchBill` on the dying bill once per line.
- **Never suppress** when it lands on a surviving record. `parts`, `builds`, `purchase-orders`, where `recalculatePartQoH` on the other end is the entire integration and suppressing it reproduces the stale-rolled-cost bug the part guard exists to fix.

## The pinning test went positive

`delete-guard-registration.test.ts` used to list the unguarded entities and assert they still were, which goes vacuously true the moment that list empties. It now derives the visible money parents from `SYSTEM_ENTITIES` and asserts each carries a hook. It independently produces exactly the four the costing guide §3 names, so the derivation and the docs check each other.

⚠️ `isVisible` is optional and **defaults to true**, which is precisely how `parts` shipped unguarded, so the filter tests `!== false` rather than `=== true`.

## Also

- `scripts/audit-part-references.ts` generalised from parts to all four parents.
- `docs/inventory-costing-architecture-guide.md` §6.4 rewritten, including a third recorded instance of the shape: `purchase_order_line`'s quantity and price are evidence-locked against **edits** once a receipt exists, and there is no delete counterpart.

**No migration, no procedure, no permission key, no new record rule, nothing in `apps/web`.**

## Testing

- 39 new tests. `src/field-hooks` green at **260** (was 216).
- `typecheck-ratchet --package lib` adds no errors (29, baseline 29).
- The audit script was run read-only against dev to validate its SQL.

🛑 **Undriven.** Nothing has been clicked with the guards live. `guardBuildDelete` in particular **cannot** be driven: there is not one `build` row in any organization, which is consistent with the standing gate that `completeBuild` refuses every part because none carries a standard cost.

⚠️ **Unrelated to this diff, found while validating it:** DemoOrg1 now holds zero parts, zero stock movements and zero builds (not archived, gone), while `GlPosting` rev 1 is still `posted` at $1,320,563.80 asserting opening balances computed from the 31 movements that no longer exist. `hygiene.danglingRelationValues` is 0, so nothing looks broken. That is the exact scenario these guards prevent, already realised in dev before any of them was live. Repairing it is a reversal decision, not a code change.

https://claude.ai/code/session_01TvFJjx5eisqyEHZvWa2mq8
