### PR TITLE
fix(records): surface guard rejections from bulk delete instead of "Internal server error"

### DIFF
--- a/apps/web/src/hooks/use-entity-instance-operations.tsx
+++ b/apps/web/src/hooks/use-entity-instance-operations.tsx
@@ -189,9 +189,14 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         destructive: true,
       })
       if (confirmed) {
+        // `mutateAsync` REJECTS when every record failed (the router raises the
+        // guard's reason as a 4xx there) — `bulkDeleteInstances.onError` already
+        // toasts it, so swallow the rejection rather than leaving an
+        // unhandledRejection behind.
         const result = await bulkDeleteMutateAsync({
           recordIds: rows.map((r) => buildRecordId(r.id)),
-        })
+        }).catch(() => null)
+        if (!result) return
 
         // Optimistic removal from store
         const failedIds = new Set(
@@ -212,9 +217,13 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         onRefetch?.()
 
         if (result.errors.length > 0) {
+          // Say WHY, not just how many: the per-record messages are the pre-delete
+          // hooks' own guard text ("This purchase order has 1 vendor bill billed
+          // against it…"), which is the only thing that tells the user what to do next.
+          const reasons = [...new Set(result.errors.map((e) => e.message))].join(' ')
           toastError({
             title: 'Some records could not be deleted',
-            description: `${result.count} deleted, ${result.errors.length} failed.`,
+            description: `${result.count} deleted, ${result.errors.length} failed. ${reasons}`,
           })
         }
       }

--- a/apps/web/src/server/api/routers/record-bulk-delete-messages.test.ts
+++ b/apps/web/src/server/api/routers/record-bulk-delete-messages.test.ts
@@ -1,0 +1,201 @@
+// apps/web/src/server/api/routers/record-bulk-delete-messages.test.ts
+
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * **Why a guard rejection has to leave `record.bulkDelete` as a 4xx.**
+ *
+ * The money pre-delete guards (plans/money/tasks/21-money-parent-delete-safety.md)
+ * refuse with an `AuxxError` whose message is the whole point — "This purchase
+ * order has 1 vendor bill billed against it… delete or unlink the bills first,
+ * or archive the order instead." `bulkDeleteEntities` catches that per record and
+ * flattens it to `{ recordId, message, statusCode }`, so by the time this router
+ * sees an all-failed batch the original error is gone.
+ *
+ * Raising that as an `INTERNAL_SERVER_ERROR` — which is what it used to do —
+ * loses the message entirely: `errorFormatter` in `trpc.ts` replaces the message
+ * of EVERY 500 with the literal "Internal server error", because unexpected
+ * errors carry internals like raw SQL. So the user tripped a guard written to
+ * tell them exactly what to do next and read "Internal server error".
+ *
+ * The `statusCode` the lib now carries is the only thing separating the two: a
+ * 4xx means a hook said no on purpose and its message is written for a person;
+ * anything else stays a masked 500.
+ */
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const DEF = 'edf_purchaseorder00000000000'
+const ROW_A = 'ins_a000000000000000000000'
+const ROW_B = 'ins_b000000000000000000000'
+
+const GUARD_MESSAGE =
+  'This purchase order has 1 vendor bill billed against it. Deleting the order would leave ' +
+  'the three-way match with no order leg — delete or unlink the bills first, or archive the ' +
+  'order instead.'
+
+const { handler, cache } = vi.hoisted(() => ({
+  handler: {
+    getByIds: vi.fn(async () => ({}) as Record<string, { _access?: string }>),
+    delete: vi.fn(async () => undefined),
+    bulkDelete: vi.fn(
+      async () =>
+        ({ count: 0, errors: [] }) as {
+          count: number
+          errors: Array<{ recordId: string; message: string; statusCode?: number }>
+        }
+    ),
+    merge: vi.fn(async () => ({ ok: true })),
+  },
+  cache: {
+    getCachedResources: vi.fn(async () => [] as unknown[]),
+    getCachedResource: vi.fn(async () => undefined as unknown),
+  },
+}))
+
+vi.mock('@auxx/lib/resources', () => ({
+  RESOURCE_TABLE_REGISTRY: [],
+  UnifiedCrudHandler: class {
+    getByIds = handler.getByIds
+    delete = handler.delete
+    bulkDelete = handler.bulkDelete
+    merge = handler.merge
+  },
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedResources: cache.getCachedResources,
+  getCachedResource: cache.getCachedResource,
+}))
+vi.mock('@auxx/lib/identity', () => ({ getRecordIdentityViews: vi.fn(async () => []) }))
+vi.mock('@auxx/lib/field-values', () => ({ getDescendantIds: vi.fn(async () => []) }))
+vi.mock('@auxx/lib/conditions', async () => {
+  const { z } = await import('zod')
+  return { conditionGroupSchema: z.any() }
+})
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const instanceAccess = await import('@auxx/lib/permissions/capabilities/instance-access')
+  return {
+    PermissionKey: registry.PermissionKey,
+    isInstanceAccessKey: instanceAccess.isInstanceAccessKey,
+  }
+})
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    isAuxxError: (e: unknown): boolean =>
+      typeof e === 'object' && e !== null && 'statusCode' in e && 'name' in e,
+  }
+})
+
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { recordRouter } = await import('./record')
+
+const RESOURCES = [
+  { id: DEF, entityDefinitionId: DEF, apiSlug: 'purchase-orders', entityType: 'purchase_order' },
+]
+
+/** A Records-Full member: the def gate short-circuits, so no row stamps are read. */
+function fullMember() {
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.records]: Level.Full })),
+    {},
+    'USER',
+    'full',
+    (id) => id,
+    new Set(),
+    (id) => id
+  )
+}
+
+function caller() {
+  return recordRouter.createCaller({
+    db: {},
+    headers: new Headers(),
+    capabilities: fullMember(),
+    session: { organizationId: ORG_ID, userId: USER_ID, user: { id: USER_ID } },
+  } as never)
+}
+
+beforeEach(() => {
+  handler.getByIds.mockReset()
+  handler.getByIds.mockResolvedValue({})
+  handler.bulkDelete.mockReset()
+  cache.getCachedResources.mockReset()
+  cache.getCachedResources.mockResolvedValue(RESOURCES)
+})
+
+describe('record.bulkDelete — an all-failed batch keeps the guard’s reason', () => {
+  it('a 4xx guard rejection surfaces VERBATIM under the hook’s own status', async () => {
+    handler.bulkDelete.mockResolvedValue({
+      count: 0,
+      errors: [{ recordId: `${DEF}:${ROW_A}`, message: GUARD_MESSAGE, statusCode: 400 }],
+    })
+    await expect(caller().bulkDelete({ recordIds: [`${DEF}:${ROW_A}`] })).rejects.toMatchObject({
+      cause: { name: 'BadRequestError', statusCode: 400, message: GUARD_MESSAGE },
+    })
+  })
+
+  it('the status is the hook’s, not a flattened 400 — a 409 stays a 409', async () => {
+    handler.bulkDelete.mockResolvedValue({
+      count: 0,
+      errors: [{ recordId: `${DEF}:${ROW_A}`, message: 'Still referenced.', statusCode: 409 }],
+    })
+    await expect(caller().bulkDelete({ recordIds: [`${DEF}:${ROW_A}`] })).rejects.toMatchObject({
+      cause: { name: 'ConflictError', statusCode: 409 },
+    })
+  })
+
+  it('N rows tripping the SAME guard read as one sentence, not N copies', async () => {
+    handler.bulkDelete.mockResolvedValue({
+      count: 0,
+      errors: [
+        { recordId: `${DEF}:${ROW_A}`, message: GUARD_MESSAGE, statusCode: 400 },
+        { recordId: `${DEF}:${ROW_B}`, message: GUARD_MESSAGE, statusCode: 400 },
+      ],
+    })
+    await expect(
+      caller().bulkDelete({ recordIds: [`${DEF}:${ROW_A}`, `${DEF}:${ROW_B}`] })
+    ).rejects.toMatchObject({ cause: { message: GUARD_MESSAGE } })
+  })
+
+  it('an unexpected failure stays a 500 — its message may carry raw SQL', async () => {
+    // No `statusCode` ⇒ not a deliberate refusal ⇒ masked by `errorFormatter`.
+    handler.bulkDelete.mockResolvedValue({
+      count: 0,
+      errors: [{ recordId: `${DEF}:${ROW_A}`, message: 'insert into "EntityValue" …' }],
+    })
+    await expect(caller().bulkDelete({ recordIds: [`${DEF}:${ROW_A}`] })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    })
+  })
+
+  it('ONE unexpected failure in a batch drags the whole batch back to 500', async () => {
+    handler.bulkDelete.mockResolvedValue({
+      count: 0,
+      errors: [
+        { recordId: `${DEF}:${ROW_A}`, message: GUARD_MESSAGE, statusCode: 400 },
+        { recordId: `${DEF}:${ROW_B}`, message: 'connection terminated' },
+      ],
+    })
+    await expect(
+      caller().bulkDelete({ recordIds: [`${DEF}:${ROW_A}`, `${DEF}:${ROW_B}`] })
+    ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' })
+  })
+
+  it('a PARTIAL failure still resolves — the per-record errors reach the client', async () => {
+    // The client renders the reasons in its toast; the batch is not an error.
+    const errors = [{ recordId: `${DEF}:${ROW_B}`, message: GUARD_MESSAGE, statusCode: 400 }]
+    handler.bulkDelete.mockResolvedValue({ count: 1, errors })
+    await expect(
+      caller().bulkDelete({ recordIds: [`${DEF}:${ROW_A}`, `${DEF}:${ROW_B}`] })
+    ).resolves.toEqual({ count: 1, errors })
+  })
+})

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -2,7 +2,14 @@
 
 import { getCachedResource, getCachedResources } from '@auxx/lib/cache'
 import { conditionGroupSchema } from '@auxx/lib/conditions'
-import { BadRequestError, ForbiddenError } from '@auxx/lib/errors'
+import {
+  type AuxxError,
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from '@auxx/lib/errors'
 import { getDescendantIds } from '@auxx/lib/field-values'
 import { getRecordIdentityViews } from '@auxx/lib/identity'
 import {
@@ -66,6 +73,46 @@ function rethrowIfInvoicePaymentFkViolation(error: unknown): void {
     }
     current = (current as { cause?: unknown }).cause
   }
+}
+
+/** Pre-delete-hook statuses that carry a message written for the user. */
+const AUXX_ERROR_BY_STATUS: Record<number, new (message: string) => AuxxError> = {
+  400: BadRequestError,
+  403: ForbiddenError,
+  404: NotFoundError,
+  409: ConflictError,
+  422: UnprocessableEntityError,
+}
+
+/**
+ * Turns an all-failed `record.bulkDelete` into the error the user should see.
+ *
+ * `bulkDeleteEntities` flattens each per-record failure to `{ recordId, message,
+ * statusCode }`. When every failure is a deliberate guard rejection (a 4xx from a
+ * pre-delete hook — "This purchase order has 1 vendor bill billed against it…"),
+ * the message is written for the user, so it is surfaced under the hook's own
+ * status code and survives `errorFormatter`. Anything else stays a 500 with its
+ * message masked — those carry internals like raw SQL.
+ */
+function bulkDeleteFailure(
+  errors: Array<{ message: string; statusCode?: number }>
+): TRPCError | AuxxError {
+  const statuses = errors.map((e) => e.statusCode)
+  const allUserFacing = statuses.every((s) => s !== undefined && s >= 400 && s < 500)
+  if (!allUserFacing) {
+    return new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `Failed to delete ${errors.length} record(s): ${errors[0]?.message}`,
+    })
+  }
+
+  // One reason per distinct message, so a batch that trips the same guard N times
+  // reads as one sentence rather than N copies of it.
+  const message = [...new Set(errors.map((e) => e.message))].join(' ')
+  // Mixed statuses collapse to the first — they are all 4xx, and the message is
+  // what the user acts on.
+  const Ctor = AUXX_ERROR_BY_STATUS[statuses[0] as number] ?? BadRequestError
+  return new Ctor(message)
 }
 
 /**
@@ -1204,12 +1251,14 @@ export const recordRouter = createTRPCRouter({
       await assertCanDeleteRows(handler, ctx.capabilities, input.recordIds)
 
       try {
-        // NOTE on friendly messages here: the invoice pre-delete hook's admin-gate /
-        // succeeded-charges guard throws `BadRequestError` with an already-friendly message
-        // (e.g. "Remove recorded payments before deleting this invoice") — `bulkDeleteEntities`
-        // (packages/lib/src/resources/crud/unified-handler-mutations.ts) catches that per-record
-        // and stores `error.message` verbatim in `result.errors`, so it reads well here with no
-        // extra mapping needed.
+        // NOTE on friendly messages here: the pre-delete hooks (the invoice payment guard,
+        // the money three-way-match guards) throw `AuxxError`s with an already-friendly
+        // message — `bulkDeleteEntities` (packages/lib/src/resources/crud/unified-handler-mutations.ts)
+        // catches that per-record and stores `error.message` verbatim in `result.errors`
+        // alongside the error's `statusCode`. `bulkDeleteFailure` needs that status: an
+        // `INTERNAL_SERVER_ERROR` has its message replaced with "Internal server error" by
+        // `errorFormatter`, so a guard rejection raised as a 500 reaches the toast with no
+        // reason at all.
         // The raw-FK defense-in-depth mapping (`rethrowIfInvoicePaymentFkViolation`, used in the
         // `delete` mutation above) does NOT apply here: `bulkDeleteEntities` flattens each per-record
         // failure to a plain `{ recordId, message }` string before it ever reaches this router
@@ -1221,10 +1270,7 @@ export const recordRouter = createTRPCRouter({
         const result = await handler.bulkDelete(input.recordIds)
 
         if (result.errors.length > 0 && result.count === 0) {
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Failed to delete ${result.errors.length} record(s): ${result.errors[0]?.message}`,
-          })
+          throw bulkDeleteFailure(result.errors)
         }
 
         return result

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -15,7 +15,7 @@ import {
   getEntityInstance,
   updateEntityInstance,
 } from '../../entity-instances'
-import { UnprocessableEntityError } from '../../errors'
+import { AuxxError, UnprocessableEntityError } from '../../errors'
 import { getEntityPostDeleteHooks, getEntityPreDeleteHooks } from '../../field-hooks/registry'
 import type { FieldValueService } from '../../field-values'
 // Leaf path on purpose (not the field-values barrel): the one shared narrowing
@@ -1009,6 +1009,33 @@ export async function bulkArchiveEntities(
 }
 
 /**
+ * One record's failure inside a bulk delete.
+ *
+ * `statusCode` is the HTTP status of the `AuxxError` the pre-delete hooks threw —
+ * 400/409/… for a deliberate guard rejection ("this purchase order has 1 vendor
+ * bill billed against it"), `undefined` for anything unexpected. The loop below
+ * flattens the error to a string, so this is the ONLY thing left telling the
+ * router whether `message` is safe to show the user: `record.bulkDelete`'s
+ * errorFormatter masks every `INTERNAL_SERVER_ERROR` message as "Internal server
+ * error", which is what a guard rejection used to surface as.
+ */
+export type BulkDeleteError = { recordId: RecordId; message: string; statusCode?: number }
+
+export type BulkDeleteResult = { count: number; errors: BulkDeleteError[] }
+
+/** HTTP status of an `AuxxError`, or `undefined` for an unexpected error. */
+function auxxStatusCode(error: unknown): number | undefined {
+  if (error instanceof AuxxError) return error.statusCode
+  // Duck-type fallback: `@auxx/lib` is transpiled per consumer, so a hook thrown
+  // from another copy of the module fails `instanceof` (see `isAuxxError` in
+  // apps/web/src/server/api/trpc.ts).
+  if (error instanceof Error && typeof (error as AuxxError).statusCode === 'number') {
+    return (error as AuxxError).statusCode
+  }
+  return undefined
+}
+
+/**
  * Bulk delete entities (hard delete)
  *
  * @param ctx - Mutation context
@@ -1019,11 +1046,11 @@ export async function bulkDeleteEntities(
   ctx: MutationContext,
   recordIds: RecordId[],
   options: CrudOptions = {}
-): Promise<{ count: number; errors: Array<{ recordId: RecordId; message: string }> }> {
+): Promise<BulkDeleteResult> {
   if (recordIds.length === 0) return { count: 0, errors: [] }
 
   let count = 0
-  const errors: Array<{ recordId: RecordId; message: string }> = []
+  const errors: BulkDeleteError[] = []
 
   for (const recordId of recordIds) {
     try {
@@ -1035,6 +1062,7 @@ export async function bulkDeleteEntities(
       errors.push({
         recordId,
         message: error instanceof Error ? error.message : 'Unknown error',
+        statusCode: auxxStatusCode(error),
       })
     }
   }

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -46,6 +46,7 @@ import { assertRecordRowsEditable } from './record-row-access'
 import type { ResolvedEntityDefinition } from './types'
 import {
   archiveEntity,
+  type BulkDeleteResult,
   bulkArchiveEntities,
   bulkCreateEntities,
   bulkDeleteEntities,
@@ -763,10 +764,7 @@ export class UnifiedCrudHandler {
    * @param recordIds - Array of RecordIds to delete
    * @param options - Optional CRUD options (skipEvents)
    */
-  async bulkDelete(
-    recordIds: RecordId[],
-    options: CrudOptions = {}
-  ): Promise<{ count: number; errors: Array<{ recordId: RecordId; message: string }> }> {
+  async bulkDelete(recordIds: RecordId[], options: CrudOptions = {}): Promise<BulkDeleteResult> {
     if (recordIds.length === 0) return { count: 0, errors: [] }
     return this.inWriteSession(async () => {
       await this.assertEditRows(recordIds)


### PR DESCRIPTION
Follow-up to #1995. Those money pre-delete guards refuse with an `AuxxError` whose message is the whole point:

> This purchase order has 1 vendor bill billed against it… delete or unlink the bills first, or archive the order instead.

But `record.bulkDelete` raised an all-failed batch as `INTERNAL_SERVER_ERROR`, and `errorFormatter` in `trpc.ts` replaces the message of **every** 500 with the literal `"Internal server error"` — correctly, since unexpected errors carry internals like raw SQL. So a user who tripped a guard written to tell them exactly what to do next read nothing useful at all.

## Why the status code is the fix

`bulkDeleteEntities` catches each per-record failure and flattens it to a string, so by the time the router sees the batch the original error object is gone. The HTTP status is the only thing left that can separate the two cases:

- **4xx** — a hook said no on purpose, and its message was written for a person
- **anything else** — something unexpected broke, and the message must stay masked

## Changes

- **`unified-handler-mutations.ts`** — `BulkDeleteError` carries `statusCode` off the thrown `AuxxError`. Includes a duck-type fallback for hooks thrown from another transpiled copy of `@auxx/lib`, where `instanceof` fails — the same reason `isAuxxError` exists in `trpc.ts`. Exports `BulkDeleteResult`.
- **`unified-handler.ts`** — uses the exported type rather than restating the shape inline.
- **`record.ts`** — `bulkDeleteFailure()` re-raises an all-4xx batch under the hook's own status code, with one reason per *distinct* message so a batch tripping the same guard N times reads as one sentence instead of N copies. Mixed 4xx statuses collapse to the first; they're all user-facing and the message is what gets acted on. Anything not entirely 4xx stays a masked 500.
- **`use-entity-instance-operations.tsx`** — the partial-failure toast now says *why*, not just how many. Also swallows the `mutateAsync` rejection on a total failure, since `onError` already toasts it — otherwise it leaves an unhandledRejection behind.

## Tests

New `record-bulk-delete-messages.test.ts` — 6 tests covering the guard-rejection path, the masked-500 path, and the mixed case. All passing; no new type errors in `@auxx/lib` or `@auxx/web`.

## Note on authorship

These changes were already in the working tree from a parallel session; I reviewed, verified and committed them rather than writing them. They were deliberately kept out of #1997. Worth a look at the diff to confirm it matches what was intended — a repo-wide `pnpm lint:fix` ran during that session and may have reformatted parts of the four tracked files.

https://claude.ai/code/session_015NoPtSwvy7mM976xxNQfxf