### PR TITLE
feat(products): link several existing parts into a family at once

### DIFF
--- a/apps/web/src/components/drawers/tabs/product-variant-link-dialog.tsx
+++ b/apps/web/src/components/drawers/tabs/product-variant-link-dialog.tsx
@@ -15,14 +15,14 @@ import {
   DialogTitle,
 } from '@auxx/ui/components/dialog'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import { toastError } from '@auxx/ui/components/toast'
 import { TriangleAlert } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
-import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { RecordBadge } from '~/components/resources/ui/record-badge'
 import { BaseType } from '~/components/workflow/types'
 
 /** Synthetic relationship config for the ad-hoc part picker (not a real field). */
@@ -32,10 +32,13 @@ const PART_RELATIONSHIP: RelationshipConfig = {
   isInverse: false,
 }
 
-/** The candidate's own family, read to decide whether this is an add or a move. */
+/** The candidates' own family, read to decide whether each is an add or a move. */
 const CANDIDATE_ATTRIBUTES = ['part_product'] as const
-/** ...and the family's name, once the relation resolves. */
+/** ...and those families' names, once the relations resolve. */
 const PRODUCT_ATTRIBUTES = ['product_title'] as const
+
+/** How many moving parts are named before the banner collapses to "+n more". */
+const MAX_LISTED_MOVES = 6
 
 /** Unwrap a RELATIONSHIP value into the related instance id. */
 function relatedInstanceId(raw: unknown): string | undefined {
@@ -56,7 +59,7 @@ interface ProductVariantLinkDialogProps {
 }
 
 /**
- * Link an EXISTING part into a product family
+ * Link EXISTING parts into a product family
  * (plans/products/09-variant-ui.md §3.3).
  *
  * A create-only "Add variant" would be the wrong tool for the common case: any
@@ -64,14 +67,19 @@ interface ProductVariantLinkDialogProps {
  * offers, and creating fresh ones to group them would leave four duplicates and
  * four orphaned BOMs.
  *
- * ⚠️ `part.product` is **belongs_to**, so linking a part that already has a
- * family MOVES it — silently, if nothing says so. The dialog reads the
- * candidate's current family and, when it has one, names it and changes the
- * confirm verb to "Move". This is the whole reason the picker is a dialog and
- * not an inline combobox.
+ * The picker is multi-select, and the write is ONE `fieldValue.setBulk` for the
+ * whole selection — not a loop — through the same store-optimistic path the
+ * Details panel uses. Never a create.
  *
- * The write is a plain relation save on the PART, through the same
- * `useSaveFieldValue` path the Details panel uses — never a create.
+ * ⚠️ `part.product` is **belongs_to**, so linking a part that already has a
+ * family MOVES it — silently, if nothing says so. The dialog batch-reads every
+ * candidate's current family, names the ones that would move and the families
+ * they'd leave, and changes the confirm verb. This is the whole reason the
+ * picker is a dialog and not an inline combobox.
+ *
+ * That check is also why the confirm button waits on `candidatesResolved`: the
+ * picker returns an id instantly but its family lands a wave later, so a fast
+ * click could otherwise move parts before the warning ever painted.
  */
 export function ProductVariantLinkDialog({
   open,
@@ -83,63 +91,108 @@ export function ProductVariantLinkDialog({
   const partDefId = useResourceProperty('part', 'id')
   const productDefId = useResourceProperty('product', 'id')
 
-  const [selectedPartId, setSelectedPartId] = useState('')
+  // Held exactly as the picker emits them — the picker matches its rows by
+  // string equality against this array, so re-shaping the ids here would break
+  // the checkmarks and let the same part be selected twice.
+  const [selectedRecordIds, setSelectedRecordIds] = useState<RecordId[]>([])
 
   useEffect(() => {
-    if (open) setSelectedPartId('')
+    if (open) setSelectedRecordIds([])
   }, [open])
 
-  const selectedRecordId =
-    selectedPartId && partDefId ? toRecordId(partDefId, selectedPartId) : undefined
-
-  // The candidate's CURRENT family — the add-vs-move discriminator.
-  const { values: candidateValues } = useSystemValues(selectedRecordId, CANDIDATE_ATTRIBUTES, {
-    autoFetch: true,
-    enabled: !!selectedRecordId,
-  })
-  const currentProductId = relatedInstanceId(candidateValues.part_product)
-  // A part already on THIS family is excluded from the picker, so any current
-  // family here is a different one.
-  const isMove = !!currentProductId && currentProductId !== productId
-
-  const currentProductRecordId =
-    productDefId && currentProductId ? toRecordId(productDefId, currentProductId) : undefined
-  const { values: currentProductValues } = useSystemValues(
-    currentProductRecordId,
-    PRODUCT_ATTRIBUTES,
-    { autoFetch: true, enabled: !!currentProductRecordId }
+  // ...and canonicalised on the def id for every read and write.
+  const partRecordIds = useMemo(
+    () =>
+      partDefId ? selectedRecordIds.map((id) => toRecordId(partDefId, getInstanceId(id))) : [],
+    [partDefId, selectedRecordIds]
   )
-  const currentProductTitle = currentProductValues.product_title as string | undefined
 
-  const { saveMultipleAsync, isPending } = useSaveFieldValue({})
+  // The candidates' CURRENT families — the add-vs-move discriminator, one batch.
+  const { valuesById: candidateValues, loadedById: candidateLoaded } = useSystemValuesForRecords(
+    partRecordIds,
+    CANDIDATE_ATTRIBUTES,
+    { autoFetch: true, enabled: partRecordIds.length > 0 }
+  )
 
-  const handleSubmit = async () => {
-    if (!selectedRecordId || !productDefId) return
-    const success = await saveMultipleAsync(selectedRecordId, [
-      {
-        fieldId: 'part_product',
-        value: toRecordId(productDefId, productId),
-        fieldType: FieldType.RELATIONSHIP,
-      },
-    ])
-    if (!success) {
-      toastError({
-        title: isMove ? 'Error moving part' : 'Error linking part',
-        description: 'The part could not be linked to this product.',
-      })
-      return
-    }
+  /** Whether every selected part's family has actually been read. */
+  const candidatesResolved = partRecordIds.every(
+    (recordId) => candidateLoaded[recordId]?.part_product === true
+  )
+
+  // Parts already in THIS family are excluded from the picker, so any current
+  // family here is a different one.
+  const moving = useMemo(
+    () =>
+      partRecordIds
+        .map((recordId) => ({
+          recordId,
+          currentProductId: relatedInstanceId(candidateValues[recordId]?.part_product),
+        }))
+        .filter(
+          (entry): entry is { recordId: RecordId; currentProductId: string } =>
+            !!entry.currentProductId && entry.currentProductId !== productId
+        ),
+    [partRecordIds, candidateValues, productId]
+  )
+
+  const currentProductRecordIds = useMemo(() => {
+    if (!productDefId) return []
+    const ids = new Set<RecordId>()
+    for (const { currentProductId } of moving) ids.add(toRecordId(productDefId, currentProductId))
+    return [...ids]
+  }, [productDefId, moving])
+
+  const { valuesById: currentProductValues } = useSystemValuesForRecords(
+    currentProductRecordIds,
+    PRODUCT_ATTRIBUTES,
+    { autoFetch: true, enabled: currentProductRecordIds.length > 0 }
+  )
+
+  // All-or-nothing on purpose: naming three of four families reads as "these
+  // are the ones you'd empty", which is a lie about the fourth.
+  const currentProductTitles = currentProductRecordIds
+    .map((recordId) => currentProductValues[recordId]?.product_title)
+    .filter((title): title is string => typeof title === 'string' && title !== '')
+  const familyLabel =
+    currentProductTitles.length === currentProductRecordIds.length
+      ? currentProductTitles.join(', ')
+      : currentProductRecordIds.length > 1
+        ? 'their current products'
+        : 'another product'
+
+  const handleSaved = useCallback(() => {
     onSuccess?.()
     onOpenChange(false)
+  }, [onSuccess, onOpenChange])
+
+  // The hook is dialog-local, so its `onSuccess` can only be this one write.
+  const { saveBulkValues, isPending } = useSaveFieldValue({ onSuccess: handleSaved })
+
+  const handleSubmit = () => {
+    if (!partRecordIds.length || !productDefId) return
+    saveBulkValues(
+      partRecordIds,
+      'part_product',
+      toRecordId(productDefId, productId),
+      FieldType.RELATIONSHIP
+    )
   }
+
+  const count = partRecordIds.length
+  const moveCount = moving.length
+  const confirmLabel = (() => {
+    if (moveCount === 0) return count > 1 ? `Link ${count} Parts` : 'Link Part'
+    if (moveCount === count) return count > 1 ? `Move ${count} Parts` : 'Move to This Product'
+    return `Link & Move ${count} Parts`
+  })()
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className='sm:max-w-[500px]' position='tc'>
         <DialogHeader>
-          <DialogTitle>Link Existing Part</DialogTitle>
+          <DialogTitle>Link Existing Parts</DialogTitle>
           <DialogDescription>
-            Add a part you already have to this product family as a variant
+            Add parts you already have to this product family as variants
           </DialogDescription>
         </DialogHeader>
 
@@ -150,21 +203,18 @@ export function ProductVariantLinkDialog({
           resizeId='variant-link'
           defaultLabelWidth={140}>
           <FieldPanelRow
-            title='Part'
+            title='Parts'
             description='Parts already in this family are hidden'
             type={BaseType.RELATION}
             showIcon
             isRequired>
             <FieldInputAdapter
               fieldType={FieldType.RELATIONSHIP}
-              value={selectedRecordId ? [selectedRecordId] : []}
-              onChange={(value) => {
-                const recordIds = value as RecordId[]
-                const first = recordIds[0]
-                setSelectedPartId(first ? getInstanceId(first) : '')
-              }}
+              value={selectedRecordIds}
+              allowMultiple
+              onChange={(value) => setSelectedRecordIds(value as RecordId[])}
               triggerProps={{ className: 'ps-0 pe-1 w-full' }}
-              placeholder='Select a part...'
+              placeholder='Select parts...'
               disabled={isPending}
               fieldOptions={{
                 relationship: PART_RELATIONSHIP,
@@ -175,17 +225,31 @@ export function ProductVariantLinkDialog({
           </FieldPanelRow>
         </FieldPanel>
 
-        {isMove && (
+        {moveCount > 0 && (
           <div className='flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5'>
             <TriangleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
-            <p className='text-xs text-muted-foreground'>
-              <span className='font-medium text-foreground'>Already in a family.</span> This part is
-              currently a variant of{' '}
-              <span className='font-medium text-foreground'>
-                {currentProductTitle ?? 'another product'}
-              </span>
-              . A part belongs to one product, so linking it here moves it.
-            </p>
+            <div className='space-y-1.5'>
+              <p className='text-xs text-muted-foreground'>
+                <span className='font-medium text-foreground'>
+                  {moveCount === 1
+                    ? 'Already in a family.'
+                    : `${moveCount} of these parts are already in a family.`}
+                </span>{' '}
+                A part belongs to one product, so linking {moveCount === 1 ? 'it' : 'them'} here
+                moves {moveCount === 1 ? 'it' : 'them'} out of{' '}
+                <span className='font-medium text-foreground'>{familyLabel}</span>.
+              </p>
+              <div className='flex flex-wrap items-center gap-1'>
+                {moving.slice(0, MAX_LISTED_MOVES).map(({ recordId }) => (
+                  <RecordBadge key={recordId} recordId={recordId} size='sm' />
+                ))}
+                {moveCount > MAX_LISTED_MOVES && (
+                  <span className='text-xs text-muted-foreground'>
+                    +{moveCount - MAX_LISTED_MOVES} more
+                  </span>
+                )}
+              </div>
+            </div>
           </div>
         )}
 
@@ -203,11 +267,10 @@ export function ProductVariantLinkDialog({
             variant='outline'
             size='sm'
             loading={isPending}
-            loadingText={isMove ? 'Moving...' : 'Linking...'}
-            disabled={!selectedPartId || !productDefId}
+            loadingText={moveCount > 0 ? 'Moving...' : 'Linking...'}
+            disabled={!count || !productDefId || !candidatesResolved}
             data-dialog-submit>
-            {isMove ? 'Move to This Product' : 'Link Part'}{' '}
-            <KbdSubmit variant='outline' size='sm' />
+            {confirmLabel} <KbdSubmit variant='outline' size='sm' />
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
The product drawer's **Add Variant → Link existing part** took one part per trip. An org grouping four SKUs it already has into a family had to open the dialog four times.

### What changed

- **Multi-select picker** — `allowMultiple` on the existing `FieldInputAdapter`. Selected ids are held exactly as the picker emits them (it matches its rows by string equality, so re-shaping them breaks the checkmarks and lets the same part be selected twice) and canonicalised on the def id only for reads and writes.
- **One write** — `saveBulkValues(...)`, a single `fieldValue.setBulk` for the whole selection, not a loop. The dialog closes from the hook's `onSuccess`, which is dialog-local so it can only be this write.
- **The move warning, plural** — `part.product` is `belongs_to`, so linking a part that already has a family *moves* it; that warning is the whole reason this is a dialog. It now batch-reads `part_product` across the selection and the distinct source families' titles, and names the moving parts as chips (capped at 6, then "+n more"). Family names are all-or-nothing: naming three of four reads as a claim about the fourth.
- **Race closed** — submit waits until every selected part's family has actually been read. The picker returns an id instantly but its family lands a wave later, so a fast click could move parts before the warning painted. True in single-select too, just far likelier with five ids at once.

### Confirm verb

| selection | button |
| --- | --- |
| 2 free parts | `Link 2 Parts` |
| 1 free + 1 in another family | `Link & Move 2 Parts` |
| 2 both in another family | `Move 2 Parts` |

### Verification

Driven in the running dev app against a real product family:

- linking 2 parts at once took the tab 3 → 5 variants in one request, dialog closed, list refreshed
- all three button branches and both banner voices confirmed live, e.g. *"2 of these parts are already in a family. A part belongs to one product, so linking them here moves them out of **Auxx-Lift**."* with both parts chipped
- picker checkmarks and chips stay in sync across selections
- test data restored to its original 3 variants afterwards

`pnpm --filter @auxx/web typecheck` exits 0; biome clean. One file changed.

https://claude.ai/code/session_01MruUjwRW4RKSmgo6joDNHK
