### PR TITLE
fix(builds): show the ledger as soon as a build completes

### DIFF
--- a/apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-ledger-card.tsx
@@ -22,9 +22,12 @@ import { StockMovementType } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { formatCurrency } from '@auxx/utils/currency'
+import { PackageMinus, PackagePlus } from 'lucide-react'
 import { useMemo } from 'react'
-import { EmptyRow, RowSkeleton } from '~/components/drawers/cards/related-record-row'
+import { EmptyRow } from '~/components/drawers/cards/related-record-row'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { toRecordId, useRecord, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
@@ -35,6 +38,16 @@ const TYPE_VARIANT: Record<string, Variant> = Object.fromEntries(
   StockMovementType.values.map((value) => [value.value, value.color as Variant])
 )
 
+/**
+ * Movement type value → badge text, straight from the registry.
+ *
+ * `build_consume` / `build_produce` read "Consumed" / "Produced" — renamed in
+ * `enum-values.ts` itself, so this card and the two part-inventory surfaces
+ * share one vocabulary. ⚠️ Orgs installed before that rename still hold the old
+ * "Build (consume)" label in their materialized `CustomField.options`, so the
+ * movements GRID and its filters can disagree with this badge until a migration
+ * rewrites them. Known and accepted, not a bug to "fix" by hardcoding here.
+ */
 const TYPE_LABEL: Record<string, string> = Object.fromEntries(
   StockMovementType.values.map((value) => [value.value, value.label])
 )
@@ -68,6 +81,9 @@ const MOVEMENT_ATTRIBUTES = [
 
 /** How many movements render before the list stops. A build writes one row per component. */
 const MOVEMENT_LIMIT = 200
+
+/** Placeholder rows while the ids and their values land. */
+const SKELETON_ROWS = 3
 
 export function BuildLedgerCard({ entityInstanceId }: DrawerTabProps) {
   const { getSetting } = useSettings({})
@@ -120,24 +136,28 @@ export function BuildLedgerCard({ entityInstanceId }: DrawerTabProps) {
   // `isLoading: false` with `records` still empty. Without `isLoadingRecords`
   // the empty row below claims a completed build posted nothing, which is
   // exactly the statement it exists to make about a `planned` one.
-  if (isLoading || isLoadingRecords) return <RowSkeleton />
-  if (movementIds.length === 0) {
+  const loading = isLoading || isLoadingRecords
+
+  if (!loading && movementIds.length === 0) {
     // Not an error and not a gap: a `planned` build writes no movements at all
     // (B2), which is the safety property the whole phasing rests on.
     return <EmptyRow label='Nothing posted yet (A build writes its ledger when it completes)' />
   }
 
   return (
-    <div className='divide-y divide-border/50'>
-      {records.map((record, index) => (
+    <TreeRowList
+      items={records}
+      loading={loading}
+      skeletonCount={SKELETON_ROWS}
+      getKey={(record) => record.id}
+      renderRow={(record, index) => (
         <MovementRow
-          key={record.id}
           fallbackLabel={record.displayName}
           values={valuesById[recordIds[index] ?? ''] ?? {}}
           currencyCode={currencyCode}
         />
-      ))}
-    </div>
+      )}
+    />
   )
 }
 
@@ -173,11 +193,29 @@ function MovementRow({
   const isConsume = type === 'build_consume'
   const offBom = isConsume && qtyPerUnit == null
 
+  // What the row cost and where it posted, as one string for `description`.
+  // ⚠️ `description` is a TOOLTIP, not a subtitle — TreeRow renders it as a
+  // `HelpCircle` beside the title (`tooltip.tsx` `TooltipExplanation`), so this
+  // text is only readable on hover. Deliberate: it keeps the row to a name, a
+  // badge and two numbers. Move it back into `actions` to make it always visible.
+  const costDescription = [
+    unitCost == null ? 'no cost' : `${formatCurrency(unitCost, { currencyCode })} each`,
+    inventoryRoleLabel,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
   return (
-    <div className='flex items-center gap-2 py-1.5'>
-      <div className='min-w-0 flex-1'>
-        <div className='flex items-center gap-1.5'>
-          <span className='truncate text-sm'>{label || 'Movement'}</span>
+    // `TREE_SECONDARY_NOTRUNCATE`: the `secondary` slot truncates by default,
+    // which would clip a two-badge cluster into an ellipsis on a narrow drawer.
+    // The part name is the one thing here that should absorb the squeeze.
+    <TreeRow
+      className={TREE_SECONDARY_NOTRUNCATE}
+      icon={isConsume ? <PackageMinus className='size-4' /> : <PackagePlus className='size-4' />}
+      title={<span className='truncate text-sm'>{label || 'Movement'}</span>}
+      description={costDescription}
+      secondary={
+        <span className='flex items-center gap-1.5'>
           {type && (
             <Badge variant={TYPE_VARIANT[type] ?? 'secondary'} size='xs'>
               {TYPE_LABEL[type] ?? type}
@@ -188,20 +226,17 @@ function MovementRow({
               Off BOM
             </Badge>
           )}
-        </div>
-        <span className='text-muted-foreground text-xs tabular-nums'>
-          {unitCost == null ? 'no cost' : `${formatCurrency(unitCost, { currencyCode })} each`}
-          {inventoryRoleLabel && ` · ${inventoryRoleLabel}`}
         </span>
-      </div>
-
-      <span className='shrink-0 text-sm tabular-nums'>
-        {quantity == null ? '—' : formatSignedQuantity(quantity)}
-      </span>
-      <span className='w-24 shrink-0 text-right text-sm tabular-nums'>
-        {extendedCost == null ? '—' : formatCurrency(extendedCost, { currencyCode })}
-      </span>
-    </div>
+      }
+      actions={
+        <div className='flex shrink-0 items-center gap-3 pr-1 text-sm tabular-nums'>
+          <span>{quantity == null ? '—' : formatSignedQuantity(quantity)}</span>
+          <span className='w-24 text-right'>
+            {extendedCost == null ? '—' : formatCurrency(extendedCost, { currencyCode })}
+          </span>
+        </div>
+      }
+    />
   )
 }
 

--- a/apps/web/src/components/manufacturing/builds/build-run-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-run-card.tsx
@@ -89,6 +89,10 @@ export function BuildRunCard({ entityInstanceId }: DrawerTabProps) {
    * its own realtime events. Either way the tab that pressed the button is the
    * one that has to invalidate — which is what this does, in the one place all
    * four mutations funnel through.
+   *
+   * Builds only. The movement rows a completion or a reversal writes are
+   * announced by `publishBuildMovements` on the server, so the ledger card
+   * repaints from realtime and nothing here needs to touch `stock_movement`.
    */
   const refresh = async () => {
     await Promise.all([

--- a/apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
+++ b/apps/web/src/components/manufacturing/builds/complete-build-dialog.tsx
@@ -268,10 +268,17 @@ export function CompleteBuildDialog({
         completedAt: new Date(completedAt),
         notes: notes || undefined,
       })
-      // `completeBuild` publishes its own field-value frame for the build row, so
-      // OTHER tabs repaint on their own. The acting tab is excluded from its own
-      // realtime events, and the movements were written on the quiet lane and
-      // announce nothing anywhere — so the ledger card's list has to be told.
+      // The BUILD row only. `completeBuild` publishes its own field-value frame
+      // for it, but the acting tab is excluded from its own realtime events, so
+      // this tab still has to invalidate the two `builds.*` reads and the
+      // generic record list.
+      //
+      // The ledger is NOT this tab's job: the movements are written on the quiet
+      // lane, and `publishBuildMovements` announces them with one tier-2
+      // `records:changed` frame that every tab receives — including this one, it
+      // passes no `excludeSocketId`. Invalidating them from here would aim at
+      // the `stock_movement` def, not `build`, and would still miss the store
+      // list cache that `useRecordList` checks before it fetches.
       await Promise.all([
         utils.builds.get.invalidate({ buildId }),
         utils.builds.list.invalidate(),

--- a/packages/lib/src/builds/__tests__/build-event.test.ts
+++ b/packages/lib/src/builds/__tests__/build-event.test.ts
@@ -40,6 +40,8 @@ interface ValueRow {
 /** One created record, as the CRUD double reports it back. */
 interface CreatedRecord {
   defId: string
+  /** The id the double minted — what a realtime frame must carry, bare. */
+  id: string
   values: Record<string, unknown>
 }
 
@@ -70,6 +72,8 @@ const h = vi.hoisted(() => ({
   /** Interleaved trace: what ran, and on which side of the commit. */
   trace: [] as string[],
   publishedEntries: [] as unknown[],
+  /** Every tier-2 `records:changed` frame `publishQuietBuildWrites` emitted. */
+  movementFrames: [] as Array<{ entityDefinitionId: string; entries: Array<{ recordId: string }> }>,
   getDeductionTargets: vi.fn(),
   loadSubpartGraph: vi.fn(),
   nextId: 0,
@@ -131,6 +135,16 @@ vi.mock('../../realtime', () => ({
     h.trace.push('publish')
     h.publishedEntries.push(...entries)
   }),
+  publishRecordsChanged: vi.fn(
+    async (
+      _svc: unknown,
+      _org: string,
+      args: { entityDefinitionId: string; entries: Array<{ recordId: string }> }
+    ) => {
+      h.trace.push('publish-movements')
+      h.movementFrames.push(args)
+    }
+  ),
 }))
 
 vi.mock('../../resources/crud/unified-handler', () => ({
@@ -145,9 +159,9 @@ vi.mock('../../resources/crud/unified-handler', () => ({
       h.constructions.push(options)
     }
     async create(defId: string, values: Record<string, unknown>) {
-      h.created.push({ defId, values })
       h.nextId += 1
       const id = defId === h.defs.get('build') ? `bld_new_${h.nextId}` : `mv_new_${h.nextId}`
+      h.created.push({ defId, id, values })
       h.trace.push(`create:${String(values.stock_movement_type ?? 'build')}`)
       return { instance: { id }, recordId: `${defId}:${id}`, values }
     }
@@ -367,12 +381,18 @@ beforeEach(() => {
   h.recalcCalls = []
   h.trace = []
   h.publishedEntries = []
+  h.movementFrames = []
   h.nextId = 0
 })
 
 /** Every `stock_movement` the CRUD double was asked to create. */
 function movementWrites(): Record<string, unknown>[] {
   return h.created.filter((row) => row.defId === 'def_mv').map((row) => row.values)
+}
+
+/** The ids of every `stock_movement` written, in write order. */
+function movementIdsWritten(): string[] {
+  return h.created.filter((row) => row.defId === 'def_mv').map((row) => row.id)
 }
 
 /** Every `build` the CRUD double was asked to create. */
@@ -718,6 +738,24 @@ describe('completeBuild', () => {
     }
   })
 
+  it('announces the movements with ONE tier-2 frame, after the commit', async () => {
+    await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
+
+    // ONE frame: a completion writes movements only — its build row already
+    // exists, and `publishBuildUpdate` carries that row's changed values.
+    expect(h.movementFrames).toHaveLength(1)
+    const frame = h.movementFrames[0]!
+    // The `stock_movement` def, NOT `build`: the ledger card lists movements, so
+    // a frame addressed to the build def is delivered to the wrong query.
+    expect(frame.entityDefinitionId).toBe('def_mv')
+    // BARE instance ids (`RecordChangedEntry.recordId`), never composite ones.
+    expect(frame.entries.map((entry) => entry.recordId)).toEqual(movementIdsWritten())
+    for (const entry of frame.entries) expect(entry.recordId).not.toContain(':')
+    // After the commit, like every other post-commit door here — the rows have
+    // to be readable by the refetch the frame provokes.
+    expect(h.trace.indexOf('publish-movements')).toBeGreaterThan(h.trace.indexOf('commit'))
+  })
+
   it('writes the ledger on the quiet lane, and never with the deprecated skipEvents alias', async () => {
     await completeBuild(db, ORG, USER, { buildId: BUILD, quantityProduced: 10 })
 
@@ -902,6 +940,28 @@ describe('reverseBuild', () => {
     expect(h.recalcCalls).toHaveLength(1)
     expect([...h.recalcCalls[0]!].sort()).toEqual([PART_ASM, PART_LIFT].sort())
     expect(h.trace.indexOf('recalc')).toBeGreaterThan(h.trace.indexOf('commit'))
+  })
+
+  it('announces BOTH defs — the reversing movements and the new build row', async () => {
+    // A reversal writes on two defs and both are silent. The movements feed the
+    // reversing build's own ledger; the `build` row is a CREATE that no open
+    // builds list would otherwise learn about (`completeBuild` never needs this
+    // — its build row already exists).
+    await reverseBuild(db, ORG, USER, { buildId: BUILD })
+
+    expect(h.movementFrames).toHaveLength(2)
+    const byDef = Object.fromEntries(
+      h.movementFrames.map((frame) => [frame.entityDefinitionId, frame.entries])
+    )
+    expect(Object.keys(byDef).sort()).toEqual(['def_build', 'def_mv'])
+    expect(byDef.def_mv?.map((entry) => entry.recordId)).toEqual(movementIdsWritten())
+    // The REVERSING build, not the one being reversed — that is the row the
+    // list is missing.
+    expect(byDef.def_build?.map((entry) => entry.recordId)).toEqual(['bld_new_1'])
+    for (const entry of [...(byDef.def_mv ?? []), ...(byDef.def_build ?? [])]) {
+      expect(entry.recordId).not.toContain(':')
+    }
+    expect(h.trace.indexOf('publish-movements')).toBeGreaterThan(h.trace.indexOf('commit'))
   })
 
   it('refuses a build that is already reversed — a second negation is invisible', async () => {

--- a/packages/lib/src/builds/complete-build.ts
+++ b/packages/lib/src/builds/complete-build.ts
@@ -83,7 +83,7 @@ import type {
   CompleteBuildInput,
   CompleteBuildResult,
 } from './types'
-import { buildWriteSession } from './write-lane'
+import { buildWriteSession, publishQuietBuildWrites } from './write-lane'
 
 const logger = createScopedLogger('builds:complete')
 
@@ -150,6 +150,10 @@ export async function completeBuild(
       // rows above; per movement it would be 51 full re-SUMs.
       await recalculateAfterCommit(organizationId, written.result.recalculatedPartIds)
       publishBuildUpdate(organizationId, ctx, written.result, completedAt)
+      // The ledger's own frame. `publishBuildUpdate` covers the build ROW; the
+      // movement rows are silent without this and `build-ledger-card` goes on
+      // rendering "Nothing posted yet" until the drawer remounts.
+      publishQuietBuildWrites(organizationId, movementCtx.movementDefId, written.result.movementIds)
 
       logger.info('Completed build', {
         organizationId,

--- a/packages/lib/src/builds/reverse-build.ts
+++ b/packages/lib/src/builds/reverse-build.ts
@@ -69,7 +69,7 @@ import { canReverseBuild } from './client'
 import { recalculateAfterCommit } from './complete-build'
 import { guard } from './guard'
 import type { BuildRecord, ReverseBuildInput, ReverseBuildResult } from './types'
-import { buildWriteSession } from './write-lane'
+import { buildWriteSession, publishQuietBuildWrites } from './write-lane'
 
 const logger = createScopedLogger('builds:reverse')
 
@@ -120,6 +120,15 @@ export async function reverseBuild(
       )
 
       await recalculateAfterCommit(organizationId, result.recalculatedPartIds)
+      // Two frames, two defs — a reversal writes on BOTH.
+      //
+      // The movements, so the reversing build's own ledger renders. And the
+      // `build` ROW, which `completeBuild` never has to announce because its row
+      // already exists and `publishBuildUpdate` carries the field changes: a
+      // reversal CREATES a build, on the quiet lane, so without this frame no
+      // open builds list ever learns the reversal happened.
+      publishQuietBuildWrites(organizationId, movementCtx.movementDefId, result.movementIds)
+      publishQuietBuildWrites(organizationId, ctx.buildDefId, [result.buildId])
 
       logger.info('Reversed build', {
         organizationId,

--- a/packages/lib/src/builds/write-lane.ts
+++ b/packages/lib/src/builds/write-lane.ts
@@ -48,6 +48,7 @@
  * if the lane is ever changed.
  */
 
+import { getRealtimeService, publishRecordsChanged } from '../realtime'
 import { quietSession, type WriteSession } from '../resources/crud/write-origin'
 
 /** The prose recorded on every silent build write. Greppable, and the audit trail. */
@@ -65,4 +66,63 @@ export const BUILD_WRITE_LANE_REASON =
  */
 export function buildWriteSession(): WriteSession {
   return quietSession(BUILD_WRITE_LANE_REASON)
+}
+
+/**
+ * Announce rows a build wrote silently — the ONE frame per def that replaces
+ * the per-write frames {@link buildWriteSession} suppresses.
+ *
+ * The lane above is right to silence 51 `record:created` frames and wrong to
+ * leave the rows unannounced. Two surfaces prove it: `build-ledger-card` reads
+ * the movements through the ordinary `record.listFiltered` query, so with no
+ * frame it renders "Nothing posted yet" until the drawer is remounted; and a
+ * REVERSAL creates a whole `build` row on the same lane, so the builds list
+ * never learns the reversal happened. `publishBuildUpdate` already does this
+ * for a completion's build row; this covers everything else.
+ *
+ * Tier-2 (`records:changed`, plan events/03 §7b) rather than tier-1, because
+ * that is what the tier exists for: a bulk-shaped write that suppressed its
+ * per-record frames. The client (`use-resource-sync`) coalesces the frame into
+ * one list invalidate per def, and its other two lanes short-circuit — freshly
+ * written rows are in neither the record store nor the value store, so nothing
+ * is fetched that is not already on screen. The row VALUES then arrive in the
+ * card's own second wave (`useSystemValuesForRecords`), which is why a ledger
+ * row can render its id before its cost.
+ *
+ * 🛑 No `excludeSocketId`, deliberately, and unlike `bulkArchiveEntities`. The
+ * tab that completed the build is the one most likely to have the ledger open,
+ * and it is excluded from its own tier-1 frames everywhere else — excluding it
+ * here would silence the exact surface this call exists to repair.
+ *
+ * ⚠️ A quiet lane normally emits nothing because a finalize pass announces on
+ * its behalf. `quietSession` carries no `txScope` and no collector, so a build
+ * has no finalize pass — it announces its own writes, here and in
+ * `publishBuildUpdate`. Do not "restore" the silence.
+ *
+ * Fire-and-forget, after the commit: a Pusher hiccup must never fail a build
+ * whose ledger is already written.
+ *
+ * @param organizationId The org whose record channel receives the frame.
+ * @param entityDefinitionId The def the rows belong to — one def per call, since
+ *   a `records:changed` frame is addressed to that def's own record channel.
+ * @param recordIds Bare `EntityInstance` ids — never composite `RecordId`s.
+ */
+export function publishQuietBuildWrites(
+  organizationId: string,
+  entityDefinitionId: string,
+  recordIds: string[]
+): void {
+  if (recordIds.length === 0) return
+  // 🛑 try/catch AND `.catch`, both. `getRealtimeService()` resolves transport
+  // config and throws SYNCHRONOUSLY when it is absent, which a promise handler
+  // never sees — and this runs after the commit, so a throw here would report a
+  // build that is already in the ledger as failed.
+  try {
+    publishRecordsChanged(getRealtimeService(), organizationId, {
+      entityDefinitionId,
+      entries: recordIds.map((recordId) => ({ recordId })),
+    }).catch(() => {})
+  } catch {
+    // Best effort. The next list fetch or channel rebind catches the rows up.
+  }
 }

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -325,8 +325,17 @@ export const StockMovementType = {
     { value: 'ship', label: 'Ship', color: 'blue' },
     { value: 'adjust', label: 'Adjustment', color: 'amber' },
     { value: 'sale', label: 'Sale', color: 'indigo' },
-    { value: 'build_consume', label: 'Build (consume)', color: 'orange' },
-    { value: 'build_produce', label: 'Build (produce)', color: 'teal' },
+    // ⚠️ These two labels are ALSO materialized per org into `CustomField.options`
+    // at install time (`stock-movement-fields.ts`), and `ensureCustomFields` never
+    // updates an existing field's options (see migration 037). So this edit reaches
+    // only the code that reads the constant — `build-ledger-card`,
+    // `part-inventory-tab`, `part-inventory-card` — plus orgs installed from here
+    // on. The 28 existing orgs keep 'Build (consume)' / 'Build (produce)' in the
+    // movements grid and its filter dropdowns until a migration rewrites them.
+    // Deliberate: the qualifier is redundant inside a build, and still useful on a
+    // grid that mixes receipts, sales and adjustments.
+    { value: 'build_consume', label: 'Consumed', color: 'orange' },
+    { value: 'build_produce', label: 'Produced', color: 'teal' },
     { value: 'scrap', label: 'Scrap', color: 'red' },
     { value: 'return_in', label: 'Return (inbound)', color: 'purple' },
     { value: 'return_out', label: 'Return (outbound)', color: 'pink' },


### PR DESCRIPTION
## The bug

Complete a build, and its drawer's Ledger card keeps saying **"Nothing posted yet (A build writes its ledger when it completes)"** against a build that just wrote nine movements. It only corrects itself when the drawer is remounted.

A build writes its consume/produce rows on the quiet lane (`buildWriteSession`), which suppresses the per-row realtime frames. That is right for 51 rows and wrong for the ledger: `build-ledger-card` reads those movements through the ordinary `record.listFiltered` query, so nothing ever told it to refetch.

## The fix

`publishQuietBuildWrites` sends **one tier-2 `records:changed` frame per def**, after the commit. That tier exists for exactly this shape (a bulk write that suppressed its per-record frames), so **no client change was needed** - `use-resource-sync` already coalesces the frame into one list invalidate per def, and its other two lanes short-circuit because freshly written rows are in neither the record store nor the value store.

| Path | Frames | Why |
| --- | --- | --- |
| `completeBuild` | 1 (`stock_movement`) | the build row already exists; `publishBuildUpdate` carries its changed values |
| `reverseBuild` | 2 (`stock_movement` + `build`) | a reversal **creates** a build row on the same silent lane, which no open builds list would otherwise learn about |

Two deliberate details:

- **try/catch AND `.catch`.** `getRealtimeService()` throws *synchronously* when transport config is absent, which a promise handler never sees. This runs post-commit, so a throw would report an already-written build as failed. The tests caught this.
- **No `excludeSocketId`**, unlike `bulkArchiveEntities`. The tab that ran the build is the one most likely to have the ledger open.

## Also in here

- **`build_consume` / `build_produce` now read "Consumed" / "Produced".** The qualifier is redundant inside a build's own ledger.
  > ⚠️ Renamed in `enum-values.ts`, so it reaches the code that reads the constant (`build-ledger-card`, `part-inventory-tab`, `part-inventory-card`) and every org installed from here on. The 28 existing orgs keep `"Build (consume)"` in their materialized `CustomField.options`, so **the movements grid and its filter dropdowns can still show the old label** until a migration in the shape of 037 rewrites them. Known and accepted, not an oversight - the qualifier still earns its place on a grid that mixes receipts, sales and adjustments.
- **Ledger rows are `TreeRow` inside `TreeRowList`**, replacing a hand-rolled `divide-y` stack. Cost and GL role moved into `description`, which is a hover tooltip rather than a subtitle; loading now uses the list's own skeletons.

## Verification

Driven in a browser against real data, not just tests:

- A completion's **9 movements render live with no refresh**, with part names, roles and costs.
- A reversal renders **its own 9 with the signs flipped** (`+1` back to each component, `-1` of the finished lift), costs matching the original exactly because cost is frozen at write time.

Automated: **980 tests pass** across `src/builds` + `src/resources`, `lib` typecheck at baseline (29/29), biome clean. Four new assertions cover the frame count, that it is addressed to the `stock_movement` def and not `build`, that ids are bare rather than composite, and that it fires after the commit.

> One finding worth recording: the first tab I tested in showed a stale ledger *and* a stale Details panel. That turned out to be five leaked Pusher instances from dev HMR, with the record-channel one disconnected - no record frame of any kind could land. Unrelated to this change, and it would have masked the fix if we had not checked the socket.

https://claude.ai/code/session_01JUP7y6BFKKLcR9VpcpNP1D