### PR TITLE
feat(money): let a part carry its own labour and overhead rate

### DIFF
--- a/apps/web/src/components/drawers/cards/part-costing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-costing-card.tsx
@@ -1,7 +1,8 @@
 // apps/web/src/components/drawers/cards/part-costing-card.tsx
 'use client'
 
-import { standardCostDrift } from '@auxx/lib/builds/client'
+import { FieldType } from '@auxx/database/enums'
+import { absorbsConversionCost, resolvePartKind, standardCostDrift } from '@auxx/lib/builds/client'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { CostSource, parseRecordId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
@@ -9,12 +10,18 @@ import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { formatCurrency } from '@auxx/utils/currency'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { Tooltip } from '~/components/global/tooltip'
 import { RollStandardCostPopover } from '~/components/manufacturing/parts/roll-standard-cost-popover'
 import { useRecordList, useResourceProperty } from '~/components/resources'
+import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useResourceStore } from '~/components/resources/store/resource-store'
+import { resolveSystemAttributeForRecord } from '~/components/resources/utils/resolve-system-attribute'
+import { useSettings } from '~/hooks/use-settings'
+import { useAccess } from '~/providers/capabilities-provider'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 
 /**
@@ -33,7 +40,17 @@ const PART_COSTING_ATTRIBUTES = [
   'part_rollup_cost',
   'part_cost_source',
   'part_standard_cost',
+  'part_standard_material_cost',
+  'part_standard_labor_cost',
+  'part_standard_overhead_cost',
   'part_standard_cost_effective_at',
+  'part_kind',
+  // The two EDITABLE ones. Also `showInPanel: false`, and for a sharper reason
+  // than the frozen block: on a `component` the roll never reads them, and 82%
+  // of parts are components. They render here, gated on `part_kind`, so the
+  // inputs exist exactly where they mean something.
+  'part_labor_cost_per_unit',
+  'part_overhead_cost_per_unit',
 ] as const
 
 /** "12 Aug 2026" — the day the current standard took effect. */
@@ -59,6 +76,68 @@ function PartCostBadge({ source }: { source: string }) {
         Part cost
       </Badge>
     </Tooltip>
+  )
+}
+
+/** A `manufacturing.*` rate off the settings record. Anything non-numeric is unset. */
+function readRate(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+/**
+ * One editable absorption override.
+ *
+ * 🛑 **The empty state IS the feature.** `NULL` and a stored `0` are two
+ * different claims — "use the org rate" and "this part absorbs nothing" — and a
+ * bare currency input renders them identically. The trailing text is what keeps
+ * them apart, and it has three cases, not two:
+ *
+ * | stored | shows | says |
+ * | --- | --- | --- |
+ * | `null`, org rate set | empty | `Org default ($20.00)` |
+ * | `null`, org rate UNSET | empty | `No absorption declared` |
+ * | `0` | `$0.00` | `Absorbs nothing` |
+ *
+ * ⚠️ The middle row is the one that gets missed. `absorbedRate` deliberately
+ * keeps an undeclared org rate as `null` rather than collapsing it to zero, so
+ * printing `Org default ($0.00)` in an org that has set no rates would state a
+ * declared zero nobody declared.
+ */
+function AbsorptionOverrideRow({
+  title,
+  value,
+  orgRate,
+  onChange,
+}: {
+  title: string
+  value: number | null | undefined
+  orgRate: number | null
+  onChange: (next: unknown) => void
+}) {
+  const hint =
+    value != null
+      ? value === 0
+        ? 'Absorbs nothing'
+        : null
+      : orgRate != null
+        ? `Org default (${formatCurrency(orgRate)})`
+        : 'No absorption declared'
+
+  return (
+    <FieldPanelRow title={title} description='Overrides the org rate for this part only'>
+      <div className='flex min-h-8 items-center gap-2'>
+        <div className='w-32'>
+          <FieldInputAdapter
+            fieldType={FieldType.CURRENCY}
+            fieldOptions={{ currencyCode: 'USD', decimals: 2, currencyDisplay: 'symbol' }}
+            value={value ?? null}
+            onChange={onChange}
+            placeholder='Org default'
+          />
+        </div>
+        {hint && <span className='text-muted-foreground text-xs'>{hint}</span>}
+      </div>
+    </FieldPanelRow>
   )
 }
 
@@ -96,7 +175,17 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
   const costSource = values.part_cost_source as string | undefined
   const liveCost = values.part_cost as number | null | undefined
   const standardCost = values.part_standard_cost as number | null | undefined
+  const standardMaterialCost = values.part_standard_material_cost as number | null | undefined
+  const standardLaborCost = values.part_standard_labor_cost as number | null | undefined
+  const standardOverheadCost = values.part_standard_overhead_cost as number | null | undefined
   const standardEffectiveAt = values.part_standard_cost_effective_at as string | undefined
+
+  // 🛑 The gate for everything absorption-related on this card. A `component`
+  // never absorbs conversion cost (README B11), so on one its overrides are
+  // read by nothing and its composition line would say the same number twice.
+  const absorbs = absorbsConversionCost(resolvePartKind(values.part_kind as string | undefined))
+  const laborOverride = values.part_labor_cost_per_unit as number | null | undefined
+  const overheadOverride = values.part_overhead_cost_per_unit as number | null | undefined
 
   const hasComparison = purchaseCost != null && rollupCost != null
   const isUncosted = costSource === CostSource.NONE
@@ -112,8 +201,57 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
   // second amber row saying nothing the "Not costed" row above has not said.
   const hasStandardBlock = standardCost != null || liveCost != null
   // How far the standard has drifted from reality since it was last rolled.
-  // Genuinely useful on its own: it is the number that tells you a roll is due.
-  const drift = standardCostDrift(liveCost, standardCost)
+  //
+  // 🛑 For a BUILT part the comparison is against `part_standard_material_cost`,
+  // not `part_standard_cost`. `part_cost` is a pure material chain
+  // (`bom/cost-calculator.ts`) and can never contain conversion cost, so
+  // comparing it to a standard that carries the whole absorption stack showed a
+  // permanent offset on a freshly rolled part — -$270.00 on a lift whose
+  // standard was correct to the cent — under a label that says "how stale".
+  // Material against material renders 0 on a fresh roll, which is what the row
+  // claims to mean. For a component the two standards are equal, so nothing
+  // changes there.
+  const driftBasis = absorbs ? standardMaterialCost : standardCost
+  const drift = standardCostDrift(liveCost, driftBasis)
+
+  // ── The two editable absorption overrides ──────────────────────────
+  //
+  // Written through the same `fieldValue.set` door the generic panel uses, so
+  // the optimistic store update, the rollback and the realtime publish are the
+  // ones every other field write already gets.
+  const { canEditEntity } = useAccess()
+  // Read from the dehydrated settings the app already carries — no query. The
+  // placeholder has to name the rate a blank cell will actually fall through
+  // to, or "org default" tells nobody anything.
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const orgLaborRate = readRate(getSetting('manufacturing.assemblyLaborCostPerUnit'))
+  const orgOverheadRate = readRate(getSetting('manufacturing.overheadCostPerUnit'))
+  const partDefId = useResourceProperty('part', 'id')
+  const canEdit = !!partDefId && canEditEntity(partDefId)
+  const { saveFieldValue } = useSaveFieldValue()
+  // Selected one at a time, never as an object literal — a selector returning a
+  // fresh object re-renders this card on every unrelated store write.
+  const systemAttributeMap = useResourceStore((state) => state.systemAttributeMap)
+  const systemAttributeByDef = useResourceStore((state) => state.systemAttributeByDef)
+  const ambiguousSystemAttributes = useResourceStore((state) => state.ambiguousSystemAttributes)
+  const attributeMaps = useMemo(
+    () => ({ systemAttributeMap, systemAttributeByDef, ambiguousSystemAttributes }),
+    [systemAttributeMap, systemAttributeByDef, ambiguousSystemAttributes]
+  )
+
+  const saveOverride = useCallback(
+    (attribute: 'part_labor_cost_per_unit' | 'part_overhead_cost_per_unit', value: unknown) => {
+      const fieldId = resolveSystemAttributeForRecord(attributeMaps, attribute, recordId)
+      if (!fieldId) return
+      // 🛑 An empty input writes `null`, which CLEARS the cell and returns the
+      // part to the org rate. A typed `0` writes `0`, which is the different
+      // claim "this part absorbs nothing" — the two must not collapse, so this
+      // normalises only the empty string and passes a real 0 straight through.
+      const normalized = value === '' || value === undefined ? null : value
+      saveFieldValue(recordId, fieldId, normalized, FieldType.CURRENCY)
+    },
+    [attributeMaps, recordId, saveFieldValue]
+  )
 
   // Whether the part has a bill of materials at all — decides which "why" the
   // uncosted state shows. Same filter shape as PartInventoryCard's hasSubparts
@@ -222,6 +360,24 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
                 </RollStandardCostPopover>
               </div>
 
+              {/* 🛑 The composition, and it is the reason this row exists. A built
+                  part's standard carries its own absorption AND every
+                  subassembly's underneath it, so on the real lift $270.00 of a
+                  $441.07 standard was conversion cost against $171.07 of
+                  material — and the single figure above made that invisible.
+                  Rendered only for a part that absorbs: on a component the
+                  material cost IS the standard cost and this would print the
+                  same number twice followed by two zeroes. */}
+              {absorbs && standardCost != null && standardMaterialCost != null && (
+                <p className='text-muted-foreground text-xs tabular-nums'>
+                  Material {formatCurrency(standardMaterialCost)}
+                  {standardLaborCost != null && <> · Labour {formatCurrency(standardLaborCost)}</>}
+                  {standardOverheadCost != null && (
+                    <> · Overhead {formatCurrency(standardOverheadCost)}</>
+                  )}
+                </p>
+              )}
+
               {/* No "roll it here" — the button is one line up. This says only the
                   thing the button cannot: that 205 parts do not need 205 clicks. */}
               {rollWouldValueIt && (
@@ -236,6 +392,28 @@ export function PartCostingCard({ recordId }: DrawerTabProps) {
               )}
             </div>
           </FieldPanelRow>
+
+          {/* ── The two absorption inputs ────────────────────────────────
+              Gated on `absorbs` AND on edit authority: hidden rather than
+              disabled, the same call every other editable card row here makes.
+              Placed under the composition they produce, so the input and its
+              frozen output read as one thing. */}
+          {absorbs && canEdit && (
+            <>
+              <AbsorptionOverrideRow
+                title='Labor per unit'
+                value={laborOverride}
+                orgRate={orgLaborRate}
+                onChange={(next) => saveOverride('part_labor_cost_per_unit', next)}
+              />
+              <AbsorptionOverrideRow
+                title='Overhead per unit'
+                value={overheadOverride}
+                orgRate={orgOverheadRate}
+                onChange={(next) => saveOverride('part_overhead_cost_per_unit', next)}
+              />
+            </>
+          )}
 
           {drift != null && (
             <FieldPanelRow

--- a/apps/web/src/server/api/routers/builds.ts
+++ b/apps/web/src/server/api/routers/builds.ts
@@ -7,7 +7,7 @@ import {
   explodeBuildComponents,
   getBuild,
   listBuilds,
-  loadAbsorptionRates,
+  loadEffectiveAbsorptionRates,
   previewStandardCostRoll,
   readBuildDrift,
   reverseBuild,
@@ -315,9 +315,14 @@ export const buildsRouter = createTRPCRouter({
       const { organizationId } = ctx.session
       await assertCanPostBuildLedger(ctx)
 
+      // 🛑 The EFFECTIVE rates, not the bare org ones. The dialog previews the
+      // variance this run will post, and `completeBuild` resolves the produced
+      // part's own absorption overrides before it writes — a preview built from
+      // the org rate would disagree with the write on exactly the parts that
+      // carry an override.
       const [plan, rates] = await Promise.all([
         explodeBuildComponents(ctx.db, organizationId, input),
-        loadAbsorptionRates(organizationId),
+        loadEffectiveAbsorptionRates(ctx.db, organizationId, input.partId),
       ])
       if (plan.isErr()) throw plan.error
       return { plan: plan.value, rates }

--- a/packages/lib/src/builds/__tests__/absorption-override-fields.test.ts
+++ b/packages/lib/src/builds/__tests__/absorption-override-fields.test.ts
@@ -1,0 +1,83 @@
+// packages/lib/src/builds/__tests__/absorption-override-fields.test.ts
+//
+// The REGISTRY contract for the two per-part absorption overrides
+// (plans/money/tasks/22-per-part-absorption.md §2).
+//
+// These assertions look like they are testing a config object, and they are —
+// but every one of them is a behaviour somebody depends on and none of them is
+// visible at the call site. `creatable` is what puts a column in the import
+// picker, `updatable` is what lets a second import pass revise it, `hidden`
+// would remove it from import entirely, and an omitted `showInTable` silently
+// resolves to `showInPanel !== false`.
+
+import { describe, expect, it } from 'vitest'
+import { getImportableFields } from '../../import/fields/get-importable-fields'
+import { PART_FIELDS } from '../../resources/registry/resources/part-fields'
+import type { Resource } from '../../resources/registry/types'
+
+const LABOR = PART_FIELDS.laborCostPerUnit
+const OVERHEAD = PART_FIELDS.overheadCostPerUnit
+
+describe('per-part absorption override fields', () => {
+  it('declares both fields on the part registry', () => {
+    expect(LABOR?.systemAttribute).toBe('part_labor_cost_per_unit')
+    expect(OVERHEAD?.systemAttribute).toBe('part_overhead_cost_per_unit')
+  })
+
+  // 🛑 The importability contract. `getImportableFields` filters on
+  // `creatable && !hidden && !relationship` and never reads `updatable`; the
+  // CRUD layer enforces `updatable` on the write. Both are needed and they do
+  // different jobs — one to be offered a column, one so a re-import can revise
+  // the value rather than have it silently dropped.
+  it('is creatable AND updatable, and never `hidden`', () => {
+    for (const field of [LABOR, OVERHEAD]) {
+      expect(field?.capabilities.creatable).toBe(true)
+      expect(field?.capabilities.updatable).toBe(true)
+      expect(field?.capabilities.hidden).toBeFalsy()
+      // Not `computed` — that is the flag the five frozen `part_standard_*`
+      // fields carry, and it is what keeps every writer but the roll out.
+      expect(field?.capabilities.computed).toBeFalsy()
+    }
+  })
+
+  it('actually reaches the import column picker', () => {
+    const resource = { fields: [LABOR, OVERHEAD] } as unknown as Resource
+    const keys = getImportableFields(resource).map((f) => f.key)
+
+    expect(keys).toContain('part_labor_cost_per_unit')
+    expect(keys).toContain('part_overhead_cost_per_unit')
+  })
+
+  // The frozen block stays locked. If this ever flips, an import could write a
+  // standard cost directly and the roll would stop being its only writer.
+  it('leaves the frozen standard-cost fields uncreatable', () => {
+    const resource = {
+      fields: [
+        PART_FIELDS.standardLaborCost,
+        PART_FIELDS.standardOverheadCost,
+        PART_FIELDS.standardCost,
+      ],
+    } as unknown as Resource
+
+    expect(getImportableFields(resource)).toHaveLength(0)
+  })
+
+  // 🛑 `showInTable` unset resolves to `showInPanel !== false`, so omitting both
+  // would add two mostly-empty currency columns to every org's parts list.
+  it('is hidden from the panel and from the default table, explicitly', () => {
+    for (const field of [LABOR, OVERHEAD]) {
+      expect(field?.showInPanel).toBe(false)
+      expect(field?.showInTable).toBe(false)
+      expect(field?.showInDialogs).toBe(false)
+    }
+  })
+
+  // Migration 116 names its payload by registry KEY. A rename would make it
+  // throw rather than quietly create one field fewer than it claims to, but
+  // this fails first and says which key moved.
+  it('keeps the keys migration 116 names', () => {
+    expect(Object.keys(PART_FIELDS)).toEqual(
+      expect.arrayContaining(['laborCostPerUnit', 'overheadCostPerUnit'])
+    )
+  })
+})

--- a/packages/lib/src/builds/__tests__/build-client.test.ts
+++ b/packages/lib/src/builds/__tests__/build-client.test.ts
@@ -15,6 +15,7 @@ import {
   canReverseBuild,
   canStartBuild,
   componentConsumption,
+  resolveAbsorptionRates,
   resolveBuildStatus,
   summarizeBuildCompletion,
   unitsStarted,
@@ -168,6 +169,83 @@ describe('summarizeBuildCompletion', () => {
     expect(summary.overheadCost).toBe(2_000)
     expect(summary.producedValue).toBe(66_220)
     expect(summary.varianceAmount).toBe(59_216 + 5_000 + 2_000 - 66_220)
+  })
+
+  // ── The invariant per-part absorption must not break ────────────────
+  //
+  // 🛑 A build's variance closes to exactly ZERO when the rates the RUN absorbs
+  // are the rates the produced part's standard was ROLLED from. That is the
+  // only mechanical check that `completeBuild` and `rollStandardCost` resolved
+  // the same overrides; if they disagree, the gap lands in account 5090 on
+  // every completion, on `updatable: false` rows, and no error is raised.
+  //
+  // `resolveAbsorptionRates` is applied to both sides here exactly as the two
+  // production callers apply it (plans/money/tasks/22 §5a).
+  describe('closes to zero under per-part absorption', () => {
+    const orgRates = { laborCostPerUnit: 500, overheadCostPerUnit: 200 }
+    const materialPerUnit = 7_322
+
+    /**
+     * One run of 10, no scrap, whose produced part was rolled from `effective`.
+     * The standard is built the way the roll builds it: material + absorption.
+     */
+    const runVariance = (overrides: {
+      laborCostPerUnit?: number | null
+      overheadCostPerUnit?: number | null
+    }) => {
+      const effective = resolveAbsorptionRates(orgRates, overrides)
+      const standardCost =
+        materialPerUnit + (effective.laborCostPerUnit ?? 0) + (effective.overheadCostPerUnit ?? 0)
+
+      return summarizeBuildCompletion({
+        components: [{ extendedCost: materialPerUnit * 10 }],
+        producedUnitCost: standardCost,
+        quantityProduced: 10,
+        quantityScrapped: 0,
+        rates: effective,
+      }).varianceAmount
+    }
+
+    it('with no override — the org rate on both sides', () => {
+      expect(runVariance({})).toBe(0)
+    })
+
+    it('with an override higher than the org rate', () => {
+      expect(runVariance({ laborCostPerUnit: 4_500 })).toBe(0)
+    })
+
+    it('with a ZERO override — the phantom case', () => {
+      expect(runVariance({ laborCostPerUnit: 0, overheadCostPerUnit: 0 })).toBe(0)
+    })
+
+    it('with no org rate declared and no override', () => {
+      const effective = resolveAbsorptionRates(
+        { laborCostPerUnit: null, overheadCostPerUnit: null },
+        {}
+      )
+      const summary = summarizeBuildCompletion({
+        components: [{ extendedCost: materialPerUnit * 10 }],
+        producedUnitCost: materialPerUnit,
+        quantityProduced: 10,
+        quantityScrapped: 0,
+        rates: effective,
+      })
+      expect(summary.varianceAmount).toBe(0)
+    })
+
+    // The failure this whole section exists to catch: the standard carries the
+    // override, the run absorbs the bare org rate. 10 units x ($45.00 - $5.00).
+    it('does NOT close when the run absorbs the org rate but the standard did not', () => {
+      const standardCost = materialPerUnit + 4_500 + 200
+      const summary = summarizeBuildCompletion({
+        components: [{ extendedCost: materialPerUnit * 10 }],
+        producedUnitCost: standardCost,
+        quantityProduced: 10,
+        quantityScrapped: 0,
+        rates: orgRates,
+      })
+      expect(summary.varianceAmount).toBe(-40_000)
+    })
   })
 
   it('books the scrapped units whole standard cost to the variance (B7)', () => {

--- a/packages/lib/src/builds/__tests__/build-event.test.ts
+++ b/packages/lib/src/builds/__tests__/build-event.test.ts
@@ -62,6 +62,14 @@ const h = vi.hoisted(() => ({
   standards: new Map<string, number>(),
   /** The two `manufacturing.*` rates, per unit, minor units. */
   rates: { laborCostPerUnit: null as number | null, overheadCostPerUnit: null as number | null },
+  /**
+   * partId -> its two per-part absorption overrides. Absent = falls through to
+   * `h.rates`; a present `0` means "absorbs nothing" and must NOT read as unset.
+   */
+  absorptionOverrides: new Map<
+    string,
+    { laborCostPerUnit?: number | null; overheadCostPerUnit?: number | null }
+  >(),
   /** parentPartId -> direct children, the real depth-1 semantics over a fixture. */
   bom: new Map<string, { childId: string; qty: number }[]>(),
   created: [] as CreatedRecord[],
@@ -120,6 +128,9 @@ vi.mock('../standard-cost-queries', () => ({
     return ok(map)
   }),
   loadAbsorptionRates: vi.fn(async () => h.rates),
+  loadPartAbsorptionOverrides: vi.fn(
+    async (_db: unknown, _org: string, partId: string) => h.absorptionOverrides.get(partId) ?? {}
+  ),
 }))
 
 vi.mock('../../bom/qoh', () => ({
@@ -346,6 +357,7 @@ function completedMovementRows(): ValueRow[] {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  h.absorptionOverrides = new Map()
   h.materialised = new Set([...BUILD_ATTRS, ...MOVEMENT_ATTRS, 'part_kind'])
   h.defs = new Map([
     ['build', 'def_build'],

--- a/packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
+++ b/packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
@@ -32,6 +32,8 @@ function inputs(overrides: Partial<StandardCostRollInputs> = {}): StandardCostRo
     subpartGraph: new Map<string, SubpartEdge[]>(),
     storedStandardCosts: new Map<string, number>(),
     rates: RATES,
+    laborOverrides: new Map<string, number>(),
+    overheadOverrides: new Map<string, number>(),
     ...overrides,
   }
 }
@@ -274,6 +276,168 @@ describe('computeStandardCosts', () => {
 
     expect(costs.get(ASSEMBLY)!.standardLaborCost).toBe(0)
     expect(costs.get(ASSEMBLY)!.standardOverheadCost).toBeNull()
+  })
+
+  // ── Per-part absorption overrides (plans/money/tasks/22) ────────────
+
+  describe('per-part absorption overrides', () => {
+    /** A motor at $10.00 under a subassembly, with the org at $5.00 / $2.00. */
+    const twoLevel = (over: Partial<StandardCostRollInputs> = {}) =>
+      inputs({
+        scope: new Set([MOTOR, ASSEMBLY]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [ASSEMBLY, 'subassembly'],
+        ]),
+        liveCosts: new Map([[MOTOR, 1000]]),
+        subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 1 }]]]),
+        ...over,
+      })
+
+    it('prefers a per-part override over the org rate, in both directions', () => {
+      const { costs } = computeStandardCosts(
+        twoLevel({
+          laborOverrides: new Map([[ASSEMBLY, 4500]]),
+          overheadOverrides: new Map([[ASSEMBLY, 50]]),
+        })
+      )
+
+      expect(costs.get(ASSEMBLY)).toEqual({
+        standardMaterialCost: 1000,
+        standardLaborCost: 4500, // not the org's 500
+        standardOverheadCost: 50, // not the org's 200
+        standardCost: 5550,
+      })
+    })
+
+    // 🛑 The `??`-not-`||` pin. A stored 0 is "this part absorbs nothing" — the
+    // phantom case — and `0 || 500` is `500`, which would silently reinstate the
+    // org rate on exactly the parts somebody took the trouble to zero out.
+    it('lets a stored ZERO override beat a non-zero org rate', () => {
+      const { costs } = computeStandardCosts(
+        twoLevel({
+          laborOverrides: new Map([[ASSEMBLY, 0]]),
+          overheadOverrides: new Map([[ASSEMBLY, 0]]),
+        })
+      )
+
+      expect(costs.get(ASSEMBLY)).toEqual({
+        standardMaterialCost: 1000,
+        standardLaborCost: 0,
+        standardOverheadCost: 0,
+        standardCost: 1000, // material and nothing else
+      })
+    })
+
+    it('falls through to the org rate when a part has no override', () => {
+      const { costs } = computeStandardCosts(twoLevel({ laborOverrides: new Map([[MOTOR, 9999]]) }))
+
+      // The override sits on a DIFFERENT part; the assembly reads the org rate.
+      expect(costs.get(ASSEMBLY)!.standardLaborCost).toBe(500)
+      expect(costs.get(ASSEMBLY)!.standardOverheadCost).toBe(200)
+    })
+
+    it('stores NULL when neither an override nor an org rate is declared', () => {
+      const { costs } = computeStandardCosts(
+        twoLevel({ rates: { laborCostPerUnit: null, overheadCostPerUnit: null } })
+      )
+
+      // Still an ABSENCE, never a confident zero — `absorbedRate`'s rule.
+      expect(costs.get(ASSEMBLY)!.standardLaborCost).toBeNull()
+      expect(costs.get(ASSEMBLY)!.standardOverheadCost).toBeNull()
+    })
+
+    it('stores a declared zero override even when the org rate is undeclared', () => {
+      const { costs } = computeStandardCosts(
+        twoLevel({
+          rates: { laborCostPerUnit: null, overheadCostPerUnit: null },
+          laborOverrides: new Map([[ASSEMBLY, 0]]),
+        })
+      )
+
+      // 0 is a claim, null is the absence of one, and they must not collapse.
+      expect(costs.get(ASSEMBLY)!.standardLaborCost).toBe(0)
+      expect(costs.get(ASSEMBLY)!.standardOverheadCost).toBeNull()
+    })
+
+    // README B11: an override must not be a way around the partKind gate.
+    // Capitalising assembly labour onto a purchased motor overstates 1310
+    // whether the number came from the org setting or the part's own cell.
+    it('ignores an override on a component', () => {
+      const { costs } = computeStandardCosts(
+        twoLevel({
+          laborOverrides: new Map([[MOTOR, 7500]]),
+          overheadOverrides: new Map([[MOTOR, 7500]]),
+        })
+      )
+
+      expect(costs.get(MOTOR)).toEqual({
+        standardMaterialCost: 1000,
+        standardLaborCost: 0,
+        standardOverheadCost: 0,
+        standardCost: 1000,
+      })
+    })
+
+    it("carries a child's override up into its parent's material cost", () => {
+      const { costs } = computeStandardCosts(
+        inputs({
+          scope: new Set([MOTOR, ASSEMBLY, LIFT]),
+          partKinds: new Map<string, PartKindValue>([
+            [MOTOR, 'component'],
+            [ASSEMBLY, 'subassembly'],
+            [LIFT, 'finished_good'],
+          ]),
+          liveCosts: new Map([[MOTOR, 1000]]),
+          subpartGraph: new Map([
+            [ASSEMBLY, [{ childId: MOTOR, qty: 1 }]],
+            [LIFT, [{ childId: ASSEMBLY, qty: 2 }]],
+          ]),
+          laborOverrides: new Map([[ASSEMBLY, 100]]),
+        })
+      )
+
+      // assembly = 1000 material + 100 labour + 200 overhead = 1300
+      expect(costs.get(ASSEMBLY)!.standardCost).toBe(1300)
+      // lift material = 2 x 1300, and it still absorbs the ORG rate itself
+      expect(costs.get(LIFT)).toEqual({
+        standardMaterialCost: 2600,
+        standardLaborCost: 500,
+        standardOverheadCost: 200,
+        standardCost: 3300,
+      })
+    })
+
+    // The case the whole task exists for: the real lift carried 9 x the flat
+    // rate because it has 8 subassemblies. Zeroing them collapses the standard
+    // back to material plus the finished good's own absorption.
+    it('reduces a parent to material plus its OWN absorption when children are zeroed', () => {
+      const zeroed = computeStandardCosts(
+        inputs({
+          scope: new Set([MOTOR, ASSEMBLY, LIFT]),
+          partKinds: new Map<string, PartKindValue>([
+            [MOTOR, 'component'],
+            [ASSEMBLY, 'subassembly'],
+            [LIFT, 'finished_good'],
+          ]),
+          liveCosts: new Map([[MOTOR, 1000]]),
+          subpartGraph: new Map([
+            [ASSEMBLY, [{ childId: MOTOR, qty: 1 }]],
+            [LIFT, [{ childId: ASSEMBLY, qty: 2 }]],
+          ]),
+          laborOverrides: new Map([[ASSEMBLY, 0]]),
+          overheadOverrides: new Map([[ASSEMBLY, 0]]),
+        })
+      )
+
+      expect(zeroed.costs.get(ASSEMBLY)!.standardCost).toBe(1000)
+      expect(zeroed.costs.get(LIFT)).toEqual({
+        standardMaterialCost: 2000, // 2 x bare material, no embedded conversion
+        standardLaborCost: 500,
+        standardOverheadCost: 200,
+        standardCost: 2700,
+      })
+    })
   })
 
   it('rounds before freezing, because CURRENCY is integer minor units', () => {

--- a/packages/lib/src/builds/client.ts
+++ b/packages/lib/src/builds/client.ts
@@ -10,6 +10,8 @@
  * (`docs/lib-module-guide.md` section 7).
  */
 
+import type { AbsorptionRates } from './types'
+
 /** The three values `part_kind` can hold. Mirrors `PartKind` in the registry. */
 export type PartKindValue = 'component' | 'subassembly' | 'finished_good'
 
@@ -81,6 +83,38 @@ export function absorbedRate(rate: number | null | undefined): number | null {
   if (rate == null) return null
   if (!Number.isFinite(rate)) return null
   return roundMinorUnits(rate)
+}
+
+/**
+ * The two absorption rates in force for ONE part.
+ *
+ * A stored per-part override wins over the org rate, **including a stored `0`**.
+ * A NULL override falls through to the org rate, which may itself be NULL.
+ *
+ * 🛑 **`??`, never `||`.** A stored `0` means "this part absorbs nothing" — the
+ * way a subassembly is made cost-transparent without inventing a `phantom` part
+ * kind — and `0 || 2000` is `2000`, which silently reinstates the org rate on
+ * exactly the parts somebody took the trouble to zero out. The NULL-versus-zero
+ * distinction survives six layers between a CSV cell and this function
+ * (`isBlankValue('0')` is false; `currencyConverter` turns `'0'` into
+ * `{ value: 0 }` and `''` into `null`; `loadStoredPartValues` keeps a `0` in its
+ * map and an unset cell out of it). This operator is the last link in that
+ * chain and the only one that is new code.
+ *
+ * @param orgRates the two `manufacturing.*` settings, per assembled unit
+ * @param overrides `part_labor_cost_per_unit` / `part_overhead_cost_per_unit`
+ */
+export function resolveAbsorptionRates(
+  orgRates: AbsorptionRates,
+  overrides: {
+    laborCostPerUnit?: number | null
+    overheadCostPerUnit?: number | null
+  }
+): AbsorptionRates {
+  return {
+    laborCostPerUnit: overrides.laborCostPerUnit ?? orgRates.laborCostPerUnit,
+    overheadCostPerUnit: overrides.overheadCostPerUnit ?? orgRates.overheadCostPerUnit,
+  }
 }
 
 /**

--- a/packages/lib/src/builds/complete-build.ts
+++ b/packages/lib/src/builds/complete-build.ts
@@ -73,9 +73,9 @@ import {
   requireBuildFieldContext,
   requireBuildMovementFieldContext,
 } from './build-queries'
-import { canCompleteBuild, summarizeBuildCompletion } from './client'
+import { canCompleteBuild, resolveAbsorptionRates, summarizeBuildCompletion } from './client'
 import { guard } from './guard'
-import { loadAbsorptionRates } from './standard-cost-queries'
+import { loadAbsorptionRates, loadPartAbsorptionOverrides } from './standard-cost-queries'
 import type {
   AbsorptionRates,
   BuildComponentPlan,
@@ -121,13 +121,17 @@ export async function completeBuild(
       const quantityScrapped = input.quantityScrapped ?? 0
       assertQuantities(quantityProduced, quantityScrapped)
 
-      const [ctx, movementCtx, rates] = await Promise.all([
+      const [ctx, movementCtx, orgRates] = await Promise.all([
         requireBuildFieldContext(organizationId),
         requireBuildMovementFieldContext(organizationId),
         // Read OUTSIDE the transaction: the two absorption rates are org
         // settings, they are not part of the invariant the row lock protects,
         // and reading them inside would hold the lock across a settings round
         // trip for nothing.
+        //
+        // ⚠️ These are the ORG rates. The produced part's own overrides are
+        // applied inside `writeCompletion`, after the lock, because that is the
+        // first point the produced part is known.
         loadAbsorptionRates(organizationId),
       ])
 
@@ -137,7 +141,7 @@ export async function completeBuild(
         writeCompletion(tx, organizationId, userId, {
           ctx,
           movementCtx,
-          rates,
+          orgRates,
           input,
           quantityProduced,
           quantityScrapped,
@@ -176,7 +180,11 @@ export async function completeBuild(
 interface WriteCompletionArgs {
   ctx: BuildFieldContext
   movementCtx: BuildMovementFieldContext
-  rates: AbsorptionRates
+  /**
+   * The two `manufacturing.*` settings. The produced part's overrides are
+   * resolved onto these below, once the lock has named the part.
+   */
+  orgRates: AbsorptionRates
   input: CompleteBuildInput
   quantityProduced: number
   quantityScrapped: number
@@ -202,7 +210,8 @@ async function writeCompletion(
   userId: string,
   args: WriteCompletionArgs
 ): Promise<WrittenCompletion> {
-  const { ctx, movementCtx, rates, input, quantityProduced, quantityScrapped, completedAt } = args
+  const { ctx, movementCtx, orgRates, input, quantityProduced, quantityScrapped, completedAt } =
+    args
   const txDb = tx as unknown as Database
 
   // Step 1. The lock IS B8's enforcement — see `lockBuild`.
@@ -235,6 +244,17 @@ async function writeCompletion(
       'Refusing to complete a build at zero cost: roll the standard cost for the produced part first'
     )
   }
+
+  // 🛑 The rates this RUN absorbs must be the same ones the produced part's
+  // frozen standard was rolled from, or the variance stops closing to zero and
+  // the difference lands in 5090 on `updatable: false` rows, on every single
+  // completion. Read on `txDb` so it is the same snapshot `planBuildComponents`
+  // took its standard costs from, and read here rather than outside the
+  // transaction because `build.partId` does not exist until `lockBuild` returns.
+  const rates = resolveAbsorptionRates(
+    orgRates,
+    await loadPartAbsorptionOverrides(txDb, organizationId, build.partId)
+  )
 
   // 🛑 The SAME function the completion form runs to preview these five numbers
   // (`client.ts`). The form has to show the variance before the write, because a

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -119,8 +119,11 @@ export { reverseBuild } from './reverse-build'
 export { rollStandardCost } from './standard-cost'
 export {
   loadAbsorptionRates,
+  loadEffectiveAbsorptionRates,
+  loadPartAbsorptionOverrides,
   loadStandardCostFields,
   loadStandardCostWriteContext,
+  type PartAbsorptionOverrides,
   previewStandardCostRoll,
   readStandardCost,
   type StandardCostFields,

--- a/packages/lib/src/builds/standard-cost-queries.ts
+++ b/packages/lib/src/builds/standard-cost-queries.ts
@@ -20,7 +20,7 @@ import { buildParentGraph, buildSubpartGraph, loadOrgPricingData } from '../bom/
 import { getOrgCache, requireCachedEntityDefId } from '../cache'
 import { UnprocessableEntityError } from '../errors'
 import { getOrganizationSetting } from '../settings/settings-service'
-import { type PartKindValue, resolvePartKind } from './client'
+import { type PartKindValue, resolveAbsorptionRates, resolvePartKind } from './client'
 import { guard } from './guard'
 import {
   computeStandardCosts,
@@ -47,6 +47,8 @@ const ROLL_ATTRIBUTES = [
   'part_standard_overhead_cost',
   'part_standard_cost',
   'part_standard_cost_effective_at',
+  'part_labor_cost_per_unit',
+  'part_overhead_cost_per_unit',
 ] as const
 
 /** The five `part_standard_*` fields the roll owns. `rollStandardCost` is their only writer. */
@@ -60,6 +62,17 @@ export interface StandardCostFields {
   partKind: CustomFieldEntity | null
   liveCost: CustomFieldEntity | null
   quantityOnHand: CustomFieldEntity | null
+  /**
+   * The two per-part absorption overrides (migration 116).
+   *
+   * 🛑 Nullable, and {@link loadStandardCostFields} must NOT refuse when they are
+   * absent — unlike the five `part_standard_*` fields above. An org whose
+   * migration has not run has no overrides, every part falls through to the org
+   * rate, and the roll produces exactly what it produced before the feature
+   * existed. Refusing here would break the roll for every org until 116 lands.
+   */
+  laborOverride: CustomFieldEntity | null
+  overheadOverride: CustomFieldEntity | null
 }
 
 /**
@@ -96,6 +109,8 @@ export async function loadStandardCostFields(organizationId: string): Promise<St
     partKind: fields.part_kind,
     liveCost: fields.part_cost,
     quantityOnHand: fields.part_quantity_on_hand,
+    laborOverride: fields.part_labor_cost_per_unit,
+    overheadOverride: fields.part_overhead_cost_per_unit,
   }
 }
 
@@ -115,6 +130,87 @@ export async function loadAbsorptionRates(organizationId: string): Promise<Absor
     laborCostPerUnit: typeof labor === 'number' ? labor : null,
     overheadCostPerUnit: typeof overhead === 'number' ? overhead : null,
   }
+}
+
+/** One part's two absorption overrides, as stored. */
+export interface PartAbsorptionOverrides {
+  /** `undefined` = no stored value = use the org rate. A `0` is a real override. */
+  laborCostPerUnit?: number | null
+  overheadCostPerUnit?: number | null
+}
+
+/**
+ * Read one part's `part_labor_cost_per_unit` / `part_overhead_cost_per_unit`.
+ *
+ * Returns an empty object when the override fields are not provisioned, which
+ * resolves to the bare org rates — exactly the pre-migration-116 behaviour.
+ *
+ * Takes `db` so a caller inside a transaction can pass the transaction handle
+ * and read the same snapshot its standard costs came from.
+ */
+export async function loadPartAbsorptionOverrides(
+  db: Database,
+  organizationId: string,
+  partId: string
+): Promise<PartAbsorptionOverrides> {
+  const fields = await loadStandardCostFields(organizationId)
+  const fieldIds = [fields.laborOverride?.id, fields.overheadOverride?.id].filter(
+    (id): id is string => Boolean(id)
+  )
+  if (fieldIds.length === 0) return {}
+
+  const rows = await db
+    .select({
+      fieldId: schema.FieldValue.fieldId,
+      valueNumber: schema.FieldValue.valueNumber,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, partId),
+        inArray(schema.FieldValue.fieldId, fieldIds)
+      )
+    )
+
+  // `undefined` (no row) and `null` (a row with an empty cell) both mean "use
+  // the org rate"; only a real number, `0` included, overrides it.
+  const overrides: PartAbsorptionOverrides = {}
+  for (const row of rows) {
+    if (fields.laborOverride && row.fieldId === fields.laborOverride.id) {
+      overrides.laborCostPerUnit = row.valueNumber
+    } else if (fields.overheadOverride && row.fieldId === fields.overheadOverride.id) {
+      overrides.overheadCostPerUnit = row.valueNumber
+    }
+  }
+  return overrides
+}
+
+/**
+ * The org rates with ONE part's overrides applied — the rates a BUILD absorbs.
+ *
+ * 🛑 **`completeBuild` and `builds.previewCompletion` must both resolve the
+ * produced part's overrides, and the roll must apply the same ones per part.**
+ * If a part's frozen standard carries an override and its run absorbs the bare
+ * org rate, every completion produces
+ * `material + labour + overhead - producedValue != 0` and the difference lands
+ * in account 5090 forever, on `updatable: false` rows. That is the one way this
+ * feature can quietly corrupt the ledger.
+ *
+ * `completeBuild` does NOT call this — it already reads the org rates outside
+ * its transaction on purpose and composes {@link loadPartAbsorptionOverrides}
+ * inside, after the lock, where the produced part is known.
+ */
+export async function loadEffectiveAbsorptionRates(
+  db: Database,
+  organizationId: string,
+  partId: string
+): Promise<AbsorptionRates> {
+  const [orgRates, overrides] = await Promise.all([
+    loadAbsorptionRates(organizationId),
+    loadPartAbsorptionOverrides(db, organizationId, partId),
+  ])
+  return resolveAbsorptionRates(orgRates, overrides)
 }
 
 /** Every non-archived `part` in the org, with the name error messages use. */
@@ -145,6 +241,15 @@ export interface StoredPartValues {
   standardOverheadCosts: Map<string, number>
   standardCosts: Map<string, number>
   effectiveDates: Map<string, string>
+  /**
+   * `part_labor_cost_per_unit` / `part_overhead_cost_per_unit` as stored.
+   *
+   * 🛑 A part is in the map **only when it has a non-NULL stored value**, which
+   * is what keeps a declared `0` (absorb nothing) apart from an unset cell (use
+   * the org rate). `resolveAbsorptionRates` reads that absence with `??`.
+   */
+  laborOverrides: Map<string, number>
+  overheadOverrides: Map<string, number>
 }
 
 async function loadStoredPartValues(
@@ -161,6 +266,8 @@ async function loadStoredPartValues(
     standardOverheadCosts: new Map(),
     standardCosts: new Map(),
     effectiveDates: new Map(),
+    laborOverrides: new Map(),
+    overheadOverrides: new Map(),
   }
 
   const fieldIds = [
@@ -172,6 +279,8 @@ async function loadStoredPartValues(
     fields.overhead.id,
     fields.standard.id,
     fields.effectiveAt.id,
+    fields.laborOverride?.id,
+    fields.overheadOverride?.id,
   ].filter((id): id is string => Boolean(id))
 
   const rows = await db
@@ -209,6 +318,13 @@ async function loadStoredPartValues(
       if (row.valueNumber != null) values.standardCosts.set(row.entityId, row.valueNumber)
     } else if (row.fieldId === fields.effectiveAt.id) {
       if (row.valueDate != null) values.effectiveDates.set(row.entityId, row.valueDate)
+    } else if (fields.laborOverride && row.fieldId === fields.laborOverride.id) {
+      // `!= null` and not a truthiness check: a stored `0` is a declared
+      // "absorbs nothing" and MUST land in the map, or it reads as unset and
+      // silently reinstates the org rate.
+      if (row.valueNumber != null) values.laborOverrides.set(row.entityId, row.valueNumber)
+    } else if (fields.overheadOverride && row.fieldId === fields.overheadOverride.id) {
+      if (row.valueNumber != null) values.overheadOverrides.set(row.entityId, row.valueNumber)
     }
   }
 
@@ -293,6 +409,8 @@ export async function planStandardCostRoll(
     subpartGraph,
     storedStandardCosts: stored.standardCosts,
     rates,
+    laborOverrides: stored.laborOverrides,
+    overheadOverrides: stored.overheadOverrides,
     partNames,
   })
 

--- a/packages/lib/src/builds/standard-cost-roll.ts
+++ b/packages/lib/src/builds/standard-cost-roll.ts
@@ -21,6 +21,14 @@
  *     zero labour and zero overhead; capitalising assembly labour onto a motor
  *     we never assembled overstates 1310 Raw Materials.
  *
+ *  3. **The rate is per PART, falling back to the org.** One org-wide rate
+ *     applied at every level of a bill of materials multiplies with the depth of
+ *     the tree: a finished good over 8 subassemblies carries 9 x the flat rate,
+ *     which on the real lift was $270.00 of a $441.07 standard against $171.07
+ *     of actual material. A stored `0` is how a subassembly is made
+ *     cost-transparent, and it must survive as a `0` rather than reading as
+ *     unset (plans/money/tasks/22-per-part-absorption.md).
+ *
  * The walk is a memoized DFS with `inProgress` cycle detection, copying the
  * ordering discipline of `calculateAllCosts` in `bom/cost-calculator.ts`. That
  * ordering is not a performance detail: a parent read before its children have
@@ -28,7 +36,13 @@
  */
 
 import { UnprocessableEntityError } from '../errors'
-import { absorbedRate, absorbsConversionCost, type PartKindValue, roundMinorUnits } from './client'
+import {
+  absorbedRate,
+  absorbsConversionCost,
+  type PartKindValue,
+  resolveAbsorptionRates,
+  roundMinorUnits,
+} from './client'
 import type { AbsorptionRates, SkippedPart, StandardCostComponents } from './types'
 
 /** One edge of the bill of materials. Matches `bom/cost-calculator.ts`'s shape. */
@@ -60,6 +74,16 @@ export interface StandardCostRollInputs {
   storedStandardCosts: ReadonlyMap<string, number>
   /** The org's absorption rates. A `null` is "not declared", never zero. */
   rates: AbsorptionRates
+  /**
+   * `part_labor_cost_per_unit` / `part_overhead_cost_per_unit`, for the parts
+   * that carry one.
+   *
+   * 🛑 A part is present **only when it has a non-NULL stored value**, so an
+   * absence means "use the org rate" and a present `0` means "absorb nothing".
+   * {@link resolveAbsorptionRates} reads that distinction with `??`.
+   */
+  laborOverrides: ReadonlyMap<string, number>
+  overheadOverrides: ReadonlyMap<string, number>
   /** `EntityInstance.displayName` per part, for error messages only. */
   partNames?: ReadonlyMap<string, string>
 }
@@ -187,8 +211,19 @@ export function computeStandardCosts(inputs: StandardCostRollInputs): StandardCo
     // Quantities are `doublePrecision`, so the sum can carry a fractional cent
     // even though every child standard is a whole one.
     const standardMaterialCost = roundMinorUnits(material)
-    const standardLaborCost = absorbedRate(inputs.rates.laborCostPerUnit)
-    const standardOverheadCost = absorbedRate(inputs.rates.overheadCostPerUnit)
+
+    // 🛑 Resolved HERE and not above the `absorbsConversionCost` branch, however
+    // tempting the hoist looks. A `component`'s zero labour is a fact about a
+    // part we did not assemble (README B11), and an override must never be a
+    // way around that gate: capitalising assembly labour onto a purchased motor
+    // overstates 1310 Raw Materials whether the number came from the org
+    // setting or from the part's own cell.
+    const rates = resolveAbsorptionRates(inputs.rates, {
+      laborCostPerUnit: inputs.laborOverrides.get(partId),
+      overheadCostPerUnit: inputs.overheadOverrides.get(partId),
+    })
+    const standardLaborCost = absorbedRate(rates.laborCostPerUnit)
+    const standardOverheadCost = absorbedRate(rates.overheadCostPerUnit)
 
     return {
       standardMaterialCost,

--- a/packages/lib/src/resources/registry/resources/part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/part-fields.ts
@@ -919,6 +919,98 @@ export const PART_FIELDS: Record<string, ResourceField> = {
       'between part_cost and part_standard_cost since this date is what tells you a roll is due',
   },
 
+  // ─── Per-part absorption overrides (plans/money/tasks/22) ───────────
+  //
+  // The INPUTS whose output is the frozen `part_standard_labor_cost` /
+  // `part_standard_overhead_cost` block above — the same relationship
+  // `part_cost` has to `part_standard_cost`: one is live and editable, the
+  // other is what was agreed and only `rollStandardCost` writes it.
+  //
+  // Without these, `standard-cost-roll.ts` reads ONE org-wide rate for every
+  // built part at every level of every bill of materials, so a finished good
+  // assembled from 8 subassemblies carries 9 x the flat rate whether or not
+  // that describes the work. A NULL here means "use the org rate"; a stored 0
+  // means "absorb nothing" and is how a subassembly is made cost-transparent.
+  //
+  // 🛑 `creatable` / `updatable` are TRUE and `computed` is absent — unlike
+  // every `part_standard_*` field. That is deliberate and it is what makes
+  // them settable by the importer: `getImportableFields` filters on
+  // `creatable && !hidden && !relationship` and never reads `updatable`, while
+  // the CRUD layer enforces `updatable` on the write. Both are needed — one to
+  // be offered a column, one so a second update pass can revise it.
+  //
+  // ⚠️ `showInPanel: false` is a DEFAULT, not a lock (`resolveFieldVisible`
+  // lets an explicit org choice win) and it does NOT affect import. They are
+  // hidden because 82% of parts are components, where both fields are inert;
+  // the part drawer's Costing card renders them gated on `part_kind`, next to
+  // the frozen composition they produce.
+
+  laborCostPerUnit: {
+    id: toFieldId('laborCostPerUnit'),
+    key: 'laborCostPerUnit',
+    label: 'Labor Cost Per Unit',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'part_labor_cost_per_unit',
+    systemSortOrder: 'a5j',
+    nullable: true,
+    showInPanel: false,
+    // Explicit, because an unset `showInTable` resolves to `showInPanel !== false`
+    // — omitting both would add two mostly-empty columns to every parts list.
+    showInTable: false,
+    showInDialogs: false,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Absorbed direct labour per assembled unit for THIS part, integer minor units. Overrides ' +
+      'manufacturing.assemblyLaborCostPerUnit. Empty = use the org rate; 0 = absorb nothing. ' +
+      'Ignored on a component, which never absorbs conversion cost (README B11). On re-import a ' +
+      'blank cell LEAVES the stored value alone — clearing one needs mergeStrategy: overwrite',
+  },
+
+  overheadCostPerUnit: {
+    id: toFieldId('overheadCostPerUnit'),
+    key: 'overheadCostPerUnit',
+    label: 'Overhead Cost Per Unit',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'part_overhead_cost_per_unit',
+    systemSortOrder: 'a5k',
+    nullable: true,
+    showInPanel: false,
+    showInTable: false,
+    showInDialogs: false,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Applied overhead per assembled unit for THIS part, integer minor units. Overrides ' +
+      'manufacturing.overheadCostPerUnit. Gated on partKind exactly as laborCostPerUnit is',
+  },
+
   // Reverse relationship: builds (from build.part)
   builds: {
     id: toFieldId('builds'),

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -76,6 +76,7 @@ import { migration111OrderBuildDrift } from './migrations/111-order-build-drift'
 import { migration112RecordDocuments } from './migrations/112-record-documents'
 import { migration114RetireGlPostingDefs } from './migrations/114-retire-gl-posting-defs'
 import { migration115VendorPartDisplayPart } from './migrations/115-vendor-part-display-part'
+import { migration116PerPartAbsorption } from './migrations/116-per-part-absorption'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -208,6 +209,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // `DISPLAY_FIELD_CONFIG` edit that ships with it reaches fresh orgs only,
   // because `linkDisplayFields` runs at seed time.
   migration115VendorPartDisplayPart,
+  migration116PerPartAbsorption,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/116-per-part-absorption.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/116-per-part-absorption.ts
@@ -1,0 +1,104 @@
+// packages/lib/src/seed/entity-migrations/migrations/116-per-part-absorption.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getOrgCache } from '../../../cache'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { PART_FIELDS } from '../../../resources/registry/resources/part-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:116')
+
+/** The def that receives the two fields. Created by an earlier migration. */
+const PART_ENTITY_TYPE = 'part'
+
+/**
+ * The two fields added, listed by REGISTRY KEY rather than taken as "everything
+ * new on `PART_FIELDS`".
+ *
+ * Migration 109's comment gives the reason and it holds here: naming the keys
+ * means a later, unrelated field on the part registry cannot silently join this
+ * migration's payload.
+ */
+const FIELD_KEYS = ['laborCostPerUnit', 'overheadCostPerUnit'] as const
+
+/**
+ * Migration 116: per-part labour and overhead absorption overrides
+ * (plans/money/tasks/22-per-part-absorption.md).
+ *
+ * ## Why
+ *
+ * `standard-cost-roll.ts` read ONE org-wide rate for every built part, at every
+ * level of every bill of materials. Because a built parent's material is
+ * `SUM(child.standardCost x qty)` and a child's standard already contains its
+ * own absorption, the flat rate compounds once per level: a finished good over 8
+ * subassemblies carried 9 x the rate. On the real lift that was $270.00 of a
+ * $441.07 standard against $171.07 of actual material, and the same $30.00 was
+ * absorbed by a $1.88 feet assembly and a $68.22 motor assembly alike.
+ *
+ * These two fields let a part state its own rate. NULL falls through to the org
+ * rate; a stored `0` means "absorbs nothing", which is how a subassembly is made
+ * cost-transparent without inventing a fourth `part_kind`.
+ *
+ * ## Why they are creatable and updatable
+ *
+ * Unlike the five `part_standard_*` fields beside them, these are INPUTS. Both
+ * capabilities are load-bearing and they do different jobs: `getImportableFields`
+ * filters on `creatable && !hidden && !relationship` and never reads `updatable`,
+ * so `creatable` is what puts the column in the import picker, while the CRUD
+ * layer enforces `updatable` on the write, so `updatable` is what lets a second
+ * import pass revise the numbers. Setting 43 built parts is an
+ * export-edit-import round trip, not 43 drawers.
+ *
+ * ## Inert
+ *
+ * 🛑 Two nullable fields and NO backfill. Every existing part reads NULL, falls
+ * through to the org rate, and produces exactly the standard cost it produces
+ * today. This migration must not change one stored `part_standard_*` value —
+ * only a subsequent roll can, and only for parts somebody has since given an
+ * override.
+ *
+ * Idempotent: `ensureCustomFields` creates nothing on a second run.
+ */
+export const migration116PerPartAbsorption: EntityMigration = {
+  id: '116-per-part-absorption',
+  description:
+    'Add part_labor_cost_per_unit and part_overhead_cost_per_unit — per-part absorption overrides',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const def = existing.entityDefs.get(PART_ENTITY_TYPE)
+    // An org with no `part` def has nothing to hang these on; a later run of the
+    // migration that seeds it will not create them, but neither did 109's
+    // `part` fields, and the seeder covers a fresh org from the registry.
+    if (!def) return { ...state, alreadyUpToDate: true }
+
+    const fields: Record<string, ResourceField> = {}
+    for (const key of FIELD_KEYS) {
+      const field = PART_FIELDS[key]
+      // Loud rather than silent: a renamed registry key would otherwise make
+      // this migration quietly create one field fewer than it claims to.
+      if (!field) {
+        throw new Error(`part registry is missing the key "${key}" (migration 116)`)
+      }
+      fields[key] = field
+    }
+
+    await ensureCustomFields(db, organizationId, PART_ENTITY_TYPE, def.id, fields, existing, state)
+
+    const alreadyUpToDate = state.fieldsCreated === 0
+
+    // New fields are invisible to every read path until the per-org caches that
+    // serve them are dropped. `runEntityMigrationsForOrg` does this after the
+    // whole batch, but `up()` can also be invoked directly, so it clears its own.
+    if (!alreadyUpToDate) {
+      await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+      logger.info('Migration 116 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -648,6 +648,12 @@ export const SYSTEM_ATTRIBUTES = [
   'part_standard_overhead_cost',
   'part_standard_cost', // the sum — the value every movement stamps
   'part_standard_cost_effective_at',
+  // The two per-part absorption overrides (plans/money/tasks/22). The INPUTS
+  // whose output is the frozen block above — NULL falls through to the org
+  // rate, a stored 0 means "absorbs nothing", and unlike the frozen fields
+  // these are creatable and updatable so the importer can set them in bulk.
+  'part_labor_cost_per_unit',
+  'part_overhead_cost_per_unit',
   'part_builds', // inverse of build_part
   'stock_movement_build', // nullable; `reference` stays as-is
   'stock_movement_qty_per_unit', // as-built BOM snapshot; NULL on a consume row = off-BOM


### PR DESCRIPTION
## The problem

`standard-cost-roll.ts:190` read ONE org-wide rate for every built part, at every level of every bill of materials. `partId` was in scope on that line and was never consulted.

Because a built parent's material is `SUM(child.standardCost x qty)` and a child's standard already contains its own absorption, the flat rate **compounds once per level of the tree**. Measured on DemoOrg1, where all 43 built parts carry an identical $20 labour + $10 overhead:

`Auxx Lift 400 lb 4x8 Onyx Black`, 8 subassemblies at qty 1:

| | |
| --- | --- |
| `part_cost` (pure material rollup) | $171.07 |
| `part_standard_material_cost` | $411.07 |
| its own labour + overhead | $30.00 |
| **`part_standard_cost`** | **$441.07** |

The $240.00 gap between the two material figures is exactly `8 x $30.00`. **$270.00 of a $441.07 standard — 61% — is a flat rate applied nine times.**

And the flat rate does not describe the work: the `Feet Sub Assembly` ($1.88 of material) absorbs the same $30.00 as the `Motor Sub Assembly` ($68.22). The feet absorb sixteen times their own material cost.

The compounding itself is correct standard costing *provided each subassembly is genuinely built as its own build event* — the variance closes to zero when it is. What was wrong is that one number described every operation in the plant.

## The change

Two nullable part fields override the org rate. NULL falls through to the org setting; a stored `0` means "absorbs nothing", which is how a subassembly is made cost-transparent without inventing a fourth `part_kind`.

One resolver, `resolveAbsorptionRates`, is the single place the effective rate is decided.

### Why both `creatable` and `updatable`

Unlike the five `part_standard_*` fields beside them, these are inputs, and the two capabilities do different jobs:

- `getImportableFields` filters on `creatable && !hidden && !relationship` and **never reads `updatable`** — so `creatable` is what puts the column in the import picker
- the CRUD layer enforces `updatable` on the write — so `updatable` is what lets a **second** import pass revise the numbers

Setting 43 built parts is an export-edit-import round trip, not 43 drawers. That second pass is the realistic workflow.

### NULL versus zero

The distinction has to survive from a CSV cell to `computeOne`, or the phantom case is unreachable. It already did at every layer; only the last link is new code:

| layer | empty cell | a `0` cell |
| --- | --- | --- |
| `getSourceValue` | `''` | `'0'` |
| `isBlankValue` | `true` | **`false`** |
| `stripBlankValues` | skipped on update | written |
| `currencyConverter.toTypedInput` | `null` | `{ value: 0 }` |
| `FieldValue` | no row / NULL | `valueNumber = 0` |
| `loadStoredPartValues` (`!= null` guard) | absent from map | present as `0` |
| `resolveAbsorptionRates` (`??`) | falls through to org rate | **wins** |

`||` would break that chain at the final step after six layers carried it correctly. It has its own pinning test.

> ⚠️ One consequence worth knowing: on **re-import a blank cell leaves the stored value alone** rather than clearing it — `stripBlankValues` treats it as an absence unless the column's `mergeStrategy` is `overwrite`. That behaviour is deliberate (partial re-imports were blanking hand-entered data) but surprising, so it is stated in the field description.

## The ledger trap

`loadAbsorptionRates` had three callers: the roll, `completeBuild`, and `builds.previewCompletion`.

🛑 **If a part's frozen standard carries an override and its run absorbs the bare org rate, every completion produces a non-zero variance into account 5090 — forever, on `updatable: false` rows, with no error raised.** All three now resolve the same overrides.

`completeBuild` resolves **inside** its transaction, after `lockBuild` names the part. The brief had it resolving up front; it cannot, because `build.partId` does not exist until the lock returns. Splitting into `loadPartAbsorptionOverrides` + a composing helper preserved the existing "read org settings outside the lock" decision rather than overturning it.

`previewCompletion` switching to `loadEffectiveAbsorptionRates` means `complete-build-dialog.tsx` needed **zero changes** — its prefill and hints simply start telling the truth per part.

## Migration 116 is inert

Two nullable fields, **no backfill**. Every existing part reads NULL, falls through to the org rate, and produces exactly the standard cost it produces today. Verified after it ran across all 28 orgs: zero override values written, DemoOrg1's 244 rolled parts unchanged, all 43 built parts still at 2000/1000.

## UI

Three changes, all in `PartCostingCard`, all gated on `part_kind` so nothing renders on the 201 of 244 parts that are components:

1. **The composition** — `Material $411.07 · Labour $20.00 · Overhead $10.00` under the standard. This was invisible; the numbers had to be read out of the raw field list, which is how this work came to be written.
2. **The two editable overrides**, whose empty state is the feature. Three cases, not two:

| stored | shows | says |
| --- | --- | --- |
| `null`, org rate set | empty | `Org default ($20.00)` |
| `null`, org rate UNSET | empty | `No absorption declared` |
| `0` | `$0.00` | `Absorbs nothing` |

The middle row is the one that gets missed — `absorbedRate` keeps an undeclared org rate as `null` rather than collapsing it to zero, so `Org default ($0.00)` would state a declared zero nobody declared.

3. **The Drift fix** (see below).

The fields are `showInPanel: false` — a *default* an org can toggle back on via `resolveFieldVisible`, and one that does not affect import at all. `showInTable: false` is explicit, not tidiness: an unset `showInTable` resolves to `showInPanel !== false`, so omitting both would add two mostly-empty currency columns to every org's parts list.

## Fixes a pre-existing defect on the way

The part drawer's **Drift row was wrong for every built part**. `standardCostDrift(liveCost, standardCost)` compared `part_cost` — a pure material chain that can never contain conversion cost — against `part_standard_cost`, which carries the whole absorption stack, under the label *"Today's cost minus the standard — how stale the standard is"*.

A freshly rolled Onyx Black read **-$270.00** of staleness that was not staleness. Per-part overrides would have turned that constant confusion into a variable one. For a built part it now compares against `part_standard_material_cost`, the like-for-like pair, which renders `0` on a fresh roll. Components are unaffected — their two standards are equal.

## Tests

**329 in `src/builds`**, up from 308. The load-bearing ones:

- the `??`-not-`||` pin — a stored `0` must beat a non-zero org rate
- an override on a `component` is **ignored** (README B11 — an override must not route around the `partKind` gate; the resolver sits below that branch on purpose)
- a NULL override with a NULL org rate still stores **NULL**, never a confident `0`
- zeroing both subassembly overrides collapses the parent to material plus its own absorption — the case the whole change exists for
- the **variance-closes-to-zero invariant** across all three override states, with a negative control asserting `-40_000` when the standard carries an override and the run absorbs the org rate, so the test fails if anyone reconnects those two wrongly
- `absorption-override-fields.test.ts` runs `getImportableFields` over the real registry entries, proving both columns reach the picker while the frozen `part_standard_*` block stays out

Typecheck ratchet clean on both packages (lib 29/29 baseline, web 0/0).

## Not done

🛑 **Undriven.** Nothing here has been run in a browser, and the `completeBuild` path **cannot** be driven — there is not one `build` row in any org, so the variance invariant has never closed against real data. The unit test is the whole of the evidence.

The import door is likewise untested end to end. The step that matters is importing an explicit `0` and confirming it lands as `valueNumber = 0`, then blanking that cell and confirming it does **not** reset.

## Does not do

- **It does not make a subassembly a true phantom.** `0/0` fixes the cost, but `explodeBuildComponents` still consumes the direct children, so the subassembly must still be built and stocked. Worth settling whether nine build events per lift is what actually happens — if each subassembly is genuinely built, today's compounding was already right and only the rates were ever wrong.
- No new tRPC procedure, no new permission key. The fields ride ordinary `part` edit authority.
- Nothing touches `stock_movement` or any posted `GlPosting`. A roll after setting an override produces a revaluation delta through the existing preview, returned and never posted (README B9).

Brief: `plans/money/tasks/22-per-part-absorption.md`

https://claude.ai/code/session_01CxRdgA2qXLzyV8XMkFZHms
