### PR TITLE
fix(hooks): unwrap captured values, and stop five delete readers matching nothing

### DIFF
--- a/docs/entity-events-architecture-guide.md
+++ b/docs/entity-events-architecture-guide.md
@@ -238,6 +238,36 @@ All four are registered in the events worker's job mapping (`events-worker.ts`
 `eventHandlersJobMappings`) *and* the `EventHandlers` map (`events/handlers/publish-event-job.ts`) —
 miss either and the queued job won't resolve.
 
+### 7.1 The payload shape each door hands over
+
+🛑 **The same systemAttribute arrives in a different shape depending on which chain fired you, and
+nothing in the types says so** — every fire point declares `Record<string, unknown>`.
+
+| chain | fire point | SINGLE_SELECT | RELATIONSHIP |
+| --- | --- | --- | --- |
+| system hook | `UnifiedCrudHandler.runPreHooks` | `'issued'`, sometimes `['issued']` | `'defId:instId'` |
+| field pre-hook | `fireFieldPreHooks`, after `validateAndConvertValue` | `{type:'option', optionId}` | `{type:'relationship', recordId}` |
+| **capture** | `captureEventData` — feeds pre-delete hooks, post-delete hooks **and** the door-2 lifecycle payload | **`['issued']`** | **`['defId:instId']`** |
+
+The capture chain reads through `getValues`, which arrays every `ARRAY_RETURN_FIELD_TYPES` member
+(`SINGLE_SELECT`, `MULTI_SELECT`, `TAGS`, `RELATIONSHIP`, `FILE`) **regardless of how many values
+are stored** — a to-one relation is still an array of one. A create/update threads the caller's own
+input instead, where the same field is a bare string. Scalars (NUMBER, CURRENCY, TEXT, CHECKBOX)
+are bare everywhere; DATETIME is a **string**, not a `Date`; ACTOR is an object.
+
+⚠️ **Never test a captured value with `typeof value === 'string'`.** On a SINGLE_SELECT or
+RELATIONSHIP it is always false, so the reader matches nothing — it does not throw, it silently
+does nothing, and it passes any unit test built from a hand-written string fixture. That has
+shipped twice: once on the field pre-hook chain (#1940) and once on the capture chain (#1995,
+where a delete guard was inert in production and a delete that should have been refused cascaded
+9 stock movements).
+
+**Read through `resources/events/captured-values.ts`** — `unwrapStatusValue`,
+`unwrapRelationId`, `unwrapRelationIds` — which handle all three chains. The shape itself is
+pinned by `resources/events/captured-shape.test.ts`; guard fixtures build it with
+`field-hooks/__tests__/support/captured.ts` so a test cannot pass against a shape production never
+sends.
+
 ---
 
 ## 8. The Sync-Change Manifest (B2)
@@ -387,6 +417,10 @@ misses + 1 deduped recalc, not 500×).
 
 ## 13. Gotchas & Invariants
 
+- **A captured value is not the shape a create event sends.** `RELATIONSHIP` and `SINGLE_SELECT`
+  arrive as one-element arrays on the capture chain and as bare strings on create. Unwrap through
+  `resources/events/captured-values.ts`; a `typeof === 'string'` test is silently always false.
+  See §7.1 — this has shipped as a live defect twice.
 - **`skipEvents` suppresses everything.** Sync/import writes fire no per-write events, hooks, or
   realtime. The **only** way to react to synced data is the sync-change manifest (door 3). Do not
   add per-write hooks on the sync thread.
@@ -431,6 +465,8 @@ misses + 1 deduped recalc, not 500×).
 | Manifest types | `packages/lib/src/record-rules/sync-manifest-types.ts` |
 | Manifest collector + subscriptions | `packages/lib/src/record-rules/sync-manifest-collector.ts`, `subscriptions.ts` |
 | Old-value capture | `packages/lib/src/record-rules/capture-field-changes.ts` |
+| Payload capture (delete/lifecycle) | `packages/lib/src/resources/events/extract-event-data.ts` (`captureEventData`) |
+| Payload unwrappers + the three-chain table (§7.1) | `packages/lib/src/resources/events/captured-values.ts` |
 | Retention | `packages/lib/src/record-rules/run-retention-job.ts` |
 | Door 1 (interactive field) | `packages/lib/src/record-rules/hook-handler.ts`, `field-hooks/register-hooks.ts` |
 | Door 1b (native field-trigger) | `packages/lib/src/field-hooks/collect-triggers.ts`, `field-hook-job.ts` |

--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -95,6 +95,7 @@ Four properties carry the whole design:
 | **`partKind`** | `component` \| `subassembly` \| `finished_good`. Decides the inventory account (`1310` / `1330`) and whether a part is *buildable*. Stored and auditable — deliberately not derived. |
 | **L1 / L3** | The GL posting regime. **L1** = one periodic entry per month asserting inventory balances. **L3** = perpetual per-event postings. Exactly one may drive `1310/1320/1330`. |
 | **Buildable** | `subassembly` or `finished_good`. Only these absorb conversion (labour + overhead) cost. |
+| **Absorption rate** | Labour or overhead per assembled unit. Resolved **per part**: `part_labor_cost_per_unit` / `part_overhead_cost_per_unit` if set, else the org's `manufacturing.*` setting. A stored `0` is a declared "absorbs nothing"; NULL is "no override". Absorbed once per BOM **level**, not once per finished good. |
 
 ---
 
@@ -394,6 +395,23 @@ records that no longer exist. The four `on: 'deleted'` rules this subsystem decl
 is also why a pre-delete cascade must delete its children through `UnifiedCrudHandler.delete` and
 not raw SQL, or those rules never fire.
 
+🛑 **A registered guard is not a working guard, and the fourth instance of this shape was the
+guard itself.** `guardBuildDelete` shipped in #1995 registered, reviewed and green across 260
+tests, and was **inert in production**: it read `event.values.build_reversal_of` with a
+`typeof === 'string'` test, while `captureEventData` hands a RELATIONSHIP over as a one-element
+**array**. Deleting a reversal build in dev succeeded and cascaded its 9 stock movements. The same
+defect sat in four copy-pasted `extractRelatedEntityId` helpers, one of which made
+**`recalculatePartQoH` a no-op on every delete** — so QoH drifted from the ledger it is defined as
+a re-SUM of (§8), silently, with `hygiene.danglingRelationValues` still reading zero. Fixed by
+`resources/events/captured-values.ts`; the three payload shapes are tabulated in
+`docs/entity-events-architecture-guide.md` §7.1. **Never test a captured value with
+`typeof === 'string'`** — on a relation or a select it is always false, and the reader silently
+matches nothing.
+
+⚠️ The lesson for this guide is narrower than "write better guards": every one of these four
+instances passed review and passed its unit tests, and each was found only by performing the
+action in a browser and then asking the database whether it had happened. Budget for that step.
+
 **Who is visible, and who is guarded:**
 
 | Entity | `isVisible` | Pre-delete hook |
@@ -465,7 +483,7 @@ The standard is split into four components plus an effective date —
 **5000 Materials / 5010 Direct Labor / 5020 Applied Overhead**, and it can only do that if the
 finished-good standard remembers its composition.
 
-### 7.2 `rollStandardCost` — four rules learned the hard way
+### 7.2 `rollStandardCost` — five rules learned the hard way
 
 `packages/lib/src/builds/standard-cost.ts`.
 
@@ -482,6 +500,28 @@ finished-good standard remembers its composition.
    everybody runs first. `revaluationDelta` (old non-NULL: a real restatement, and the only one
    that belongs in the 5090 entry) is summed separately from `initialValue` (old NULL: opening
    balance material).
+5. **The absorption rate is resolved PER PART, and one rate compounds with tree depth.** Because
+   rule 1 sums children's `standardCost` and a child's standard already carries its own conversion
+   cost, a single org-wide rate is absorbed **once per level of the bill of materials** — a
+   finished good over 8 subassemblies carries 9 × the rate. That is arithmetically correct (rule 1
+   requires it, and `completeBuild`'s variance closes to zero when each subassembly is genuinely
+   built) but it is only *meaningful* if the rate describes one assembly operation rather than one
+   finished good. `part_labor_cost_per_unit` / `part_overhead_cost_per_unit` override the org
+   setting per part; `resolveAbsorptionRates` (`builds/client.ts`) is the single place that choice
+   is made, and it uses **`??`, never `||`** — a stored `0` means "this part absorbs nothing" and
+   `0 || rate` would silently reinstate the org rate on exactly the parts somebody zeroed out.
+
+   🛑 **All three readers must resolve the same overrides**: the roll, `completeBuild`, and
+   `builds.previewCompletion`. If a part's frozen standard carries an override and its run absorbs
+   the bare org rate, `material + labour + overhead − producedValue` stops closing to zero and the
+   difference lands in **5090 on every completion**, on `updatable: false` rows, with no error
+   raised. `completeBuild` resolves **inside** its transaction, after `lockBuild` names the part —
+   the produced part is not known any earlier, and reading on the transaction handle also keeps the
+   rates on the same snapshot the standard costs came from.
+
+   ⚠️ An override is still gated on `partKind` (rule 2). It is applied inside the buildable branch,
+   never above it: an override must not become a way to capitalise assembly labour onto a purchased
+   component.
 
 **Abort vs skip:** a *built* part whose child has no standard **throws**; a part with no inputs
 at all is **skipped and reported** — never written, and above all **never zeroed**, because `0`

--- a/packages/lib/src/field-hooks/__tests__/support/captured.ts
+++ b/packages/lib/src/field-hooks/__tests__/support/captured.ts
@@ -1,0 +1,25 @@
+// packages/lib/src/field-hooks/__tests__/support/captured.ts
+//
+// Fixture builders that produce the shape `captureEventData` ACTUALLY produces,
+// so a guard test cannot pass against a shape production never sends.
+//
+// 🛑 Every pre-delete and post-delete hook receives `values` from
+// `captureEventData`, which arrays every `ARRAY_RETURN_FIELD_TYPES` member
+// (`SINGLE_SELECT`, `MULTI_SELECT`, `TAGS`, `RELATIONSHIP`, `FILE`) regardless
+// of value count. A hand-written `{ build_reversal_of: 'def:id' }` fixture is
+// the CREATE chain's shape; a guard tested against it passes while being inert
+// in production, which is exactly what shipped in #1995
+// (`plans/money/tasks/24-captured-value-shape.md`).
+//
+// Use these instead of literals. The contract they encode is pinned by
+// `resources/events/captured-shape.test.ts`.
+
+/** A captured RELATIONSHIP: an array of RecordId strings, even for a to-one. */
+export function capturedRelation(...recordIds: string[]): string[] {
+  return recordIds
+}
+
+/** A captured SINGLE_SELECT / MULTI_SELECT: an array of option ids. */
+export function capturedOption(...optionIds: string[]): string[] {
+  return optionIds
+}

--- a/packages/lib/src/field-hooks/post/bom-cost-triggers.ts
+++ b/packages/lib/src/field-hooks/post/bom-cost-triggers.ts
@@ -5,6 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { parseRecordId } from '@auxx/types/resource'
 import { and, eq, inArray } from 'drizzle-orm'
 import { recalculateAffectedParts, recalculateAllPartCosts } from '../../bom/cost-calculator'
+import { unwrapRelationId } from '../../resources/events/captured-values'
 import type { FieldTriggerHandler } from '../types'
 
 const logger = createScopedLogger('field-hooks:bom-cost')
@@ -66,7 +67,7 @@ export async function recalculatePartCostForEntityBatch(params: {
   const partIds = new Set<string>()
   const missing: string[] = []
   for (const { entityInstanceId, values } of records) {
-    const fromValues = values ? extractRelatedEntityId(values, relationshipAttr) : undefined
+    const fromValues = values ? unwrapRelationId(values[relationshipAttr]) : undefined
     if (fromValues) partIds.add(fromValues)
     else missing.push(entityInstanceId)
   }
@@ -208,21 +209,6 @@ async function batchResolvePartIds(
 
   // Deduplicate — multiple instances may point to the same part
   return [...new Set(partIds)]
-}
-
-/**
- * Extract a related entity ID from event values.
- * Handles both plain entity instance IDs (from create events)
- * and RecordId format "defId:instId" (from delete events using captureEventData).
- */
-function extractRelatedEntityId(
-  values: Record<string, unknown>,
-  systemAttribute: string
-): string | undefined {
-  const value = values[systemAttribute]
-  if (typeof value !== 'string') return undefined
-  // RecordId format contains a colon — extract the entity instance ID
-  return value.includes(':') ? parseRecordId(value as any).entityInstanceId : value
 }
 
 export { recalculatePartCost }

--- a/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
+++ b/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
@@ -4,7 +4,7 @@ import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { TypedFieldValueInput } from '@auxx/types'
 import type { RecordId } from '@auxx/types/resource'
-import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { toRecordId } from '@auxx/types/resource'
 import { nextKeyAfter } from '@auxx/utils/fractional-indexing'
 import { batchRecalculateQoH } from '../../bom/qoh'
 import { getDeductionTargets, loadSubpartGraph } from '../../bom/subpart-graph'
@@ -12,6 +12,7 @@ import { getOrgCache, requireCachedEntityDefId } from '../../cache'
 import { createFieldValueContext } from '../../field-values/field-value-helpers'
 import { buildFieldValueRow, setValueWithType } from '../../field-values/field-value-mutations'
 import { type StoredFieldType, toFieldType } from '../../field-values/stored-field-type'
+import { unwrapRelationId } from '../../resources/events/captured-values'
 import type { EntityTriggerHandler } from '../types'
 
 const logger = createScopedLogger('field-hooks:bom-movement')
@@ -41,7 +42,7 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
   if (values.stock_movement_parent_movement) return
 
   // Resolve the affected part
-  const partInstanceId = extractRelatedEntityId(values, 'stock_movement_part')
+  const partInstanceId = unwrapRelationId(values.stock_movement_part)
   if (!partInstanceId) {
     logger.warn('Could not resolve part for BOM explosion', { entityInstanceId })
     return
@@ -230,14 +231,4 @@ async function clearAdjustSubpartsFlag(
     fieldType: toFieldType(flagField.type),
     value: { type: 'boolean', value: false },
   })
-}
-
-/** Extract a related entity ID from event values. */
-function extractRelatedEntityId(
-  values: Record<string, unknown>,
-  systemAttribute: string
-): string | undefined {
-  const value = values[systemAttribute]
-  if (typeof value !== 'string') return undefined
-  return value.includes(':') ? parseRecordId(value as any).entityInstanceId : value
 }

--- a/packages/lib/src/field-hooks/post/inventory-triggers.ts
+++ b/packages/lib/src/field-hooks/post/inventory-triggers.ts
@@ -15,6 +15,7 @@ import {
   getRealtimeService,
   publishFieldValueUpdates,
 } from '../../realtime'
+import { unwrapRelationId } from '../../resources/events/captured-values'
 import type { EntityTriggerHandler, FieldTriggerHandler } from '../types'
 
 const logger = createScopedLogger('field-hooks:inventory')
@@ -36,10 +37,16 @@ export const recalculatePartQoH: EntityTriggerHandler = async (event) => {
   if (values.stock_movement_adjust_subparts === true) return
 
   // Resolve the affected part ID
-  let partInstanceId = extractRelatedEntityId(values, 'stock_movement_part')
+  let partInstanceId = unwrapRelationId(values.stock_movement_part)
 
   if (!partInstanceId) {
-    // Look up from field values directly
+    // 🛑 This fallback CANNOT cover a delete, and must never be read as if it did.
+    // `deleteEntityInstance` has already swept the movement's `FieldValue` rows by the time
+    // the lifecycle event reaches the worker, so the select below returns nothing and the
+    // handler warns out. It rescues a create/update whose event data is thin — nothing else.
+    // While `unwrapRelationId` above was a `typeof === 'string'` test, that combination made
+    // this handler a silent no-op on EVERY delete, and QoH drifted from the ledger it is
+    // supposed to be a re-SUM of (plans/money/tasks/24-captured-value-shape.md §1.1).
     const partRow = await database
       .select({ relatedEntityId: schema.FieldValue.relatedEntityId })
       .from(schema.FieldValue)
@@ -292,16 +299,4 @@ function deriveStockStatus(qoh: number, reorderPoint: number | null): string {
   if (qoh <= 0) return 'out_of_stock'
   if (reorderPoint != null && qoh <= reorderPoint) return 'low_stock'
   return 'in_stock'
-}
-
-/**
- * Extract a related entity ID from event values.
- */
-function extractRelatedEntityId(
-  values: Record<string, unknown>,
-  systemAttribute: string
-): string | undefined {
-  const value = values[systemAttribute]
-  if (typeof value !== 'string') return undefined
-  return value.includes(':') ? parseRecordId(value as any).entityInstanceId : value
 }

--- a/packages/lib/src/field-hooks/post/purchase-order-line-rollups.ts
+++ b/packages/lib/src/field-hooks/post/purchase-order-line-rollups.ts
@@ -26,6 +26,7 @@ import {
   defineParentReconciler,
   resolveParentsByRelation,
 } from '../../reconcilers/parent-reconciler'
+import { unwrapRelationId } from '../../resources/events/captured-values'
 import type { EntityFieldChangeHandler, EntityTriggerHandler } from '../types'
 
 const logger = createScopedLogger('field-hooks:purchase-order-line-rollups')
@@ -483,7 +484,7 @@ function buildRollupTrigger(spec: RollupSpec): EntityTriggerHandler {
   return async (event) => {
     const { organizationId, entityInstanceId, values } = event
 
-    let lineInstanceId = extractRelatedEntityId(values, spec.lineRelAttr)
+    let lineInstanceId = unwrapRelationId(values[spec.lineRelAttr])
 
     if (!lineInstanceId) {
       const [row] = await database
@@ -636,18 +637,4 @@ export const recalculateBilledRollupOnBillLineChange: EntityFieldChangeHandler =
   for (const lineInstanceId of lineInstanceIds) {
     await billedRollupReconciler.mark(event.organizationId, event.userId, lineInstanceId)
   }
-}
-
-/**
- * Extract a related entity id from threaded event values. Values may be keyed by
- * systemAttribute or by field id, and a relationship value may be a bare instance id
- * or a `defId:instanceId` RecordId.
- */
-function extractRelatedEntityId(
-  values: Record<string, unknown>,
-  systemAttribute: string
-): string | undefined {
-  const value = values[systemAttribute]
-  if (typeof value !== 'string' || value.length === 0) return undefined
-  return value.includes(':') ? parseRecordId(value as RecordId).entityInstanceId : value
 }

--- a/packages/lib/src/field-hooks/pre/build-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/build-delete-guard.test.ts
@@ -58,6 +58,7 @@ vi.mock('@auxx/database', async () => {
   }
 })
 
+import { capturedRelation } from '../__tests__/support/captured'
 import { guardBuildDelete } from './build-delete-guard'
 
 const BUILD_DEF = 'b5hzr4xbn1fhznih3u74gtza'
@@ -135,10 +136,26 @@ describe('guardBuildDelete — refusals', () => {
     await expect(guardBuildDelete(event())).rejects.toThrow(/reverse the build/i)
   })
 
+  // 🛑 Through `capturedRelation`, NOT a bare string. This case shipped green in
+  // #1995 against `build_reversal_of: 'def:other'` while the guard was inert in
+  // production, because the capture chain sends `['def:other']` and the guard
+  // tested `typeof === 'string'`. Deleting build B-0007 in dev on 2026-08-31
+  // succeeded and cascaded its 9 movements. Keep the array.
   it('refuses when this build IS a reversal', async () => {
+    await expect(
+      guardBuildDelete(event({ build_reversal_of: capturedRelation(`${BUILD_DEF}:other`) }))
+    ).rejects.toThrow(/reverses another build/i)
+  })
+
+  it('refuses on a bare-string relation too — the create chain shape still counts', async () => {
     await expect(
       guardBuildDelete(event({ build_reversal_of: `${BUILD_DEF}:other` }))
     ).rejects.toThrow(/reverses another build/i)
+  })
+
+  it('does not refuse when the relation is absent or empty', async () => {
+    await expect(guardBuildDelete(event({ build_reversal_of: [] }))).resolves.toBeUndefined()
+    await expect(guardBuildDelete(event({ build_reversal_of: null }))).resolves.toBeUndefined()
   })
 
   it('refuses when this build HAS BEEN reversed', async () => {

--- a/packages/lib/src/field-hooks/pre/build-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/build-delete-guard.ts
@@ -4,6 +4,7 @@ import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { BadRequestError } from '../../errors'
 import { describeSettledPeriods, settledPeriodsFor } from '../../postings/settled-periods'
 import { UnifiedCrudHandler } from '../../resources/crud'
+import { unwrapRelationId } from '../../resources/events/captured-values'
 import type { EntityPreDeleteEvent, EntityPreDeleteHandler } from '../types'
 import { type GuardedMovement, readMovementsByRelation } from './guarded-movements'
 
@@ -88,8 +89,13 @@ async function refuseIfReversalPair(
 ): Promise<void> {
   const { organizationId, recordId } = event
 
-  const reversalOf = event.values.build_reversal_of
-  if (typeof reversalOf === 'string' && reversalOf.length > 0) {
+  // 🛑 Through `unwrapRelationId`, never `typeof === 'string'`. The capture chain hands a
+  // RELATIONSHIP over as `['defId:instId']` — an array of one — so the string test this
+  // originally used was always false and the refusal never fired in production, while its
+  // unit test passed a bare string and stayed green. See the three-chain table on
+  // `resources/events/captured-values.ts`.
+  const reversalOf = unwrapRelationId(event.values.build_reversal_of)
+  if (reversalOf) {
     throw new BadRequestError(
       'This build reverses another build. Deleting it would leave the original ' +
         'reversed by nothing — archive it instead.',

--- a/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.ts
@@ -6,6 +6,7 @@ import { and, eq } from 'drizzle-orm'
 import { BadRequestError } from '../../errors'
 import { settledPeriodsFor } from '../../postings/settled-periods'
 import { UnifiedCrudHandler } from '../../resources/crud'
+import { unwrapStatusValue } from '../../resources/events/captured-values'
 import { VendorBillStatus } from '../../resources/registry/enum-values'
 import type { EntityPreDeleteEvent, EntityPreDeleteHandler } from '../types'
 
@@ -97,21 +98,13 @@ function refuseOnStatus(event: EntityPreDeleteEvent): void {
 /**
  * A captured SINGLE_SELECT value, reduced to its option id.
  *
- * ⚠️ Captured values are not uniformly bare strings — `rematchAfterBillLineDelete`
- * has to unwrap a `RecordId` from the same source, and a select arrives as
- * `{ type: 'option', optionId }` on the field chain. Both shapes are handled
- * rather than assumed, because a guard that compares the wrong shape is inert
- * and reads perfectly in review (`pre/build-status-guard.ts` documents that
- * exact trap).
+ * Delegates to the shared `unwrapStatusValue` rather than carrying a private
+ * copy of its body — the three chains and the shapes each one produces are
+ * documented once, on `resources/events/captured-values.ts`.
  */
 function unwrapStatus(value: unknown): string | null {
-  if (typeof value === 'string') return value.length > 0 ? value : null
-  if (Array.isArray(value)) return unwrapStatus(value[0])
-  if (value && typeof value === 'object') {
-    if ('optionId' in value) return unwrapStatus((value as { optionId: unknown }).optionId)
-    if ('value' in value) return unwrapStatus((value as { value: unknown }).value)
-  }
-  return null
+  const unwrapped = unwrapStatusValue(value)
+  return typeof unwrapped === 'string' && unwrapped.length > 0 ? unwrapped : null
 }
 
 /** Refuse when a vendor payment has been applied to this bill. */

--- a/packages/lib/src/resources/events/captured-shape.test.ts
+++ b/packages/lib/src/resources/events/captured-shape.test.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/resources/events/captured-shape.test.ts
+//
+// The contract every pre-delete hook, post-delete hook and lifecycle-event
+// consumer depends on and that nothing else states: WHAT SHAPE does
+// `captureEventData` produce, per field type?
+//
+// 🛑 This test exists because the answer is NOT "the same as a create event".
+// A create threads the caller's own input (a relation is a bare
+// `'defId:instId'` string); a capture reads through `getValues`, which arrays
+// every `ARRAY_RETURN_FIELD_TYPES` member regardless of value count. Five
+// readers assumed the create shape on the delete chain, and each one silently
+// matched nothing rather than failing — see
+// `plans/money/tasks/24-captured-value-shape.md`.
+//
+// If a change here forces this file to be edited, that is a contract change for
+// the guards and the worker's roll-up handlers. Fix them in the same commit.
+
+import type { TypedFieldValue } from '@auxx/types/field-value'
+import type { RecordId } from '@auxx/types/resource'
+import { describe, expect, it } from 'vitest'
+import type { FieldValueService } from '../../field-values/field-value-service'
+import { captureEventData } from './extract-event-data'
+
+const RECORD_ID = 'movement-def:movement-1' as RecordId
+const PART_RECORD_ID = 'part-def:part-1' as RecordId
+
+/** The BaseFieldValue columns every variant carries; irrelevant to the shape. */
+const base = {
+  id: 'fv-1',
+  entityId: 'movement-1',
+  fieldId: 'f',
+  organizationId: 'org-1',
+  sortKey: '0',
+  createdAt: '2026-08-31T00:00:00.000Z',
+  updatedAt: '2026-08-31T00:00:00.000Z',
+}
+
+const FIELDS = [
+  { id: 'f-part', systemAttribute: 'stock_movement_part', type: 'RELATIONSHIP' },
+  { id: 'f-type', systemAttribute: 'stock_movement_type', type: 'SINGLE_SELECT' },
+  { id: 'f-qty', systemAttribute: 'stock_movement_quantity', type: 'NUMBER' },
+  { id: 'f-cost', systemAttribute: 'stock_movement_unit_cost', type: 'CURRENCY' },
+  { id: 'f-account', systemAttribute: 'stock_movement_gl_account', type: 'TEXT' },
+  { id: 'f-occurred', systemAttribute: 'stock_movement_occurred_at', type: 'DATETIME' },
+  { id: 'f-explode', systemAttribute: 'stock_movement_adjust_subparts', type: 'CHECKBOX' },
+]
+
+/**
+ * `getValues` arrays the ARRAY_RETURN types and leaves scalars bare — this stub
+ * reproduces that split, which is the behaviour the readers actually meet.
+ */
+function serviceReturning(): FieldValueService {
+  const values = new Map<string, TypedFieldValue | TypedFieldValue[]>([
+    ['f-part', [{ ...base, type: 'relationship', recordId: PART_RECORD_ID }] as TypedFieldValue[]],
+    ['f-type', [{ ...base, type: 'option', optionId: 'build_consume' }] as TypedFieldValue[]],
+    ['f-qty', { ...base, type: 'number', value: -10 } as TypedFieldValue],
+    ['f-cost', { ...base, type: 'number', value: 9822 } as TypedFieldValue],
+    ['f-account', { ...base, type: 'text', value: 'inventory_raw_materials' } as TypedFieldValue],
+    ['f-occurred', { ...base, type: 'date', value: '2026-08-31T23:55:10.318Z' } as TypedFieldValue],
+    ['f-explode', { ...base, type: 'boolean', value: false } as TypedFieldValue],
+  ])
+  return { getValues: async () => values } as unknown as FieldValueService
+}
+
+describe('captureEventData — the shape delete consumers actually receive', () => {
+  it('emits RELATIONSHIP as an ARRAY of RecordId strings, never a bare string', async () => {
+    const captured = await captureEventData(serviceReturning(), RECORD_ID, FIELDS)
+
+    expect(captured.stock_movement_part).toEqual([PART_RECORD_ID])
+    // The regression this whole task is about: the natural-looking test below is
+    // what a reader written against the create chain would satisfy, and it fails.
+    expect(typeof captured.stock_movement_part).not.toBe('string')
+  })
+
+  it('emits SINGLE_SELECT as an ARRAY of option ids', async () => {
+    const captured = await captureEventData(serviceReturning(), RECORD_ID, FIELDS)
+
+    expect(captured.stock_movement_type).toEqual(['build_consume'])
+    expect(typeof captured.stock_movement_type).not.toBe('string')
+  })
+
+  it('keeps a to-ONE relation an array — the shape is not count-dependent', async () => {
+    const captured = await captureEventData(serviceReturning(), RECORD_ID, FIELDS)
+
+    expect(Array.isArray(captured.stock_movement_part)).toBe(true)
+    expect((captured.stock_movement_part as unknown[]).length).toBe(1)
+  })
+
+  it('emits scalars bare — NUMBER, CURRENCY, TEXT, CHECKBOX', async () => {
+    const captured = await captureEventData(serviceReturning(), RECORD_ID, FIELDS)
+
+    expect(captured.stock_movement_quantity).toBe(-10)
+    expect(captured.stock_movement_unit_cost).toBe(9822)
+    expect(captured.stock_movement_gl_account).toBe('inventory_raw_materials')
+    expect(captured.stock_movement_adjust_subparts).toBe(false)
+  })
+
+  it('emits DATETIME as a string, not a Date', async () => {
+    const captured = await captureEventData(serviceReturning(), RECORD_ID, FIELDS)
+
+    expect(typeof captured.stock_movement_occurred_at).toBe('string')
+    expect(captured.stock_movement_occurred_at).not.toBeInstanceOf(Date)
+  })
+
+  it('keys by systemAttribute and drops fields that have none', async () => {
+    const captured = await captureEventData(serviceReturning(), RECORD_ID, [
+      ...FIELDS,
+      { id: 'f-custom', systemAttribute: null, type: 'TEXT' },
+    ])
+
+    expect(Object.keys(captured).sort()).toEqual(FIELDS.map((f) => f.systemAttribute).sort())
+  })
+})

--- a/packages/lib/src/resources/events/captured-values.test.ts
+++ b/packages/lib/src/resources/events/captured-values.test.ts
@@ -1,0 +1,77 @@
+// packages/lib/src/resources/events/captured-values.test.ts
+//
+// The unwrappers every hook now routes through. Each case is one of the THREE
+// chains in `captured-values.ts`'s table — the point is that one function
+// answers correctly for all of them, so no reader has to know which chain fired
+// it (`plans/money/tasks/24-captured-value-shape.md`).
+
+import { describe, expect, it } from 'vitest'
+import { unwrapRelationId, unwrapRelationIds, unwrapStatusValue } from './captured-values'
+
+const DEF = 'part-def'
+const INST = 'part-1'
+const RECORD_ID = `${DEF}:${INST}`
+
+describe('unwrapRelationId — one instance id, whatever the chain sent', () => {
+  it('unwraps the CAPTURE chain: an array of one RecordId', () => {
+    expect(unwrapRelationId([RECORD_ID])).toBe(INST)
+  })
+
+  it('unwraps the SYSTEM-HOOK chain: a bare RecordId string', () => {
+    expect(unwrapRelationId(RECORD_ID)).toBe(INST)
+  })
+
+  it('unwraps the FIELD PRE-HOOK chain: a { type, recordId } envelope', () => {
+    expect(unwrapRelationId({ type: 'relationship', recordId: RECORD_ID })).toBe(INST)
+    expect(unwrapRelationId([{ type: 'relationship', recordId: RECORD_ID }])).toBe(INST)
+  })
+
+  it('passes a bare instance id through — some create paths send no def half', () => {
+    expect(unwrapRelationId(INST)).toBe(INST)
+    expect(unwrapRelationId([INST])).toBe(INST)
+  })
+
+  it('returns undefined for every flavour of absent', () => {
+    expect(unwrapRelationId(undefined)).toBeUndefined()
+    expect(unwrapRelationId(null)).toBeUndefined()
+    expect(unwrapRelationId([])).toBeUndefined()
+    expect(unwrapRelationId('')).toBeUndefined()
+    expect(unwrapRelationId([''])).toBeUndefined()
+  })
+
+  it('takes the first of a to-many relation', () => {
+    expect(unwrapRelationId([`${DEF}:a`, `${DEF}:b`])).toBe('a')
+  })
+})
+
+describe('unwrapRelationIds — every id in a to-many relation', () => {
+  it('returns all of them, de-duplicated', () => {
+    expect(unwrapRelationIds([`${DEF}:a`, `${DEF}:b`, `${DEF}:a`])).toEqual(['a', 'b'])
+  })
+
+  it('handles a single value and the empty cases', () => {
+    expect(unwrapRelationIds(RECORD_ID)).toEqual([INST])
+    expect(unwrapRelationIds([])).toEqual([])
+    expect(unwrapRelationIds(null)).toEqual([])
+  })
+
+  it('drops empties rather than emitting undefined holes', () => {
+    expect(unwrapRelationIds([`${DEF}:a`, '', null])).toEqual(['a'])
+  })
+})
+
+describe('unwrapStatusValue — unchanged behaviour after the move', () => {
+  it('unwraps the capture chain array, the option envelope and the bare string', () => {
+    expect(unwrapStatusValue(['posted'])).toBe('posted')
+    expect(unwrapStatusValue({ type: 'option', optionId: 'posted' })).toBe('posted')
+    expect(unwrapStatusValue([{ type: 'option', optionId: 'posted' }])).toBe('posted')
+    expect(unwrapStatusValue({ value: 'posted' })).toBe('posted')
+    expect(unwrapStatusValue('posted')).toBe('posted')
+  })
+
+  it('leaves absent values alone', () => {
+    expect(unwrapStatusValue(undefined)).toBeUndefined()
+    expect(unwrapStatusValue([])).toBeUndefined()
+    expect(unwrapStatusValue(null)).toBeNull()
+  })
+})

--- a/packages/lib/src/resources/events/captured-values.ts
+++ b/packages/lib/src/resources/events/captured-values.ts
@@ -1,0 +1,82 @@
+// packages/lib/src/resources/events/captured-values.ts
+
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+
+/**
+ * Reduce a field value to the scalar a hook should compare against, whatever
+ * shape the chain that fired it hands over.
+ *
+ * 🛑 **Three chains hand a hook three DIFFERENT shapes for the same field, and
+ * that is the whole reason this module exists rather than being inlined.** Two
+ * of them were documented on `unwrapStatusValue` when #1940 fixed the update
+ * chain (2026-08-27); the third was not, and #1995 shipped a delete guard four
+ * days later that read the undocumented one as a bare string and was therefore
+ * inert (`plans/money/tasks/24-captured-value-shape.md`).
+ *
+ * | chain | fire point | SINGLE_SELECT arrives as | RELATIONSHIP arrives as |
+ * | --- | --- | --- | --- |
+ * | system hook | `UnifiedCrudHandler.runPreHooks` | `'issued'`, sometimes `['issued']` | `'defId:instId'` |
+ * | field pre-hook | `fireFieldPreHooks`, after `validateAndConvertValue` | `{type:'option', optionId}` | `{type:'relationship', recordId}` |
+ * | **capture** | `captureEventData` — feeds pre-delete hooks, post-delete hooks AND the lifecycle event the worker consumes | **`['issued']`** | **`['defId:instId']`** |
+ *
+ * The capture chain arrays **every** `ARRAY_RETURN_FIELD_TYPES` member
+ * (`SINGLE_SELECT`, `MULTI_SELECT`, `TAGS`, `RELATIONSHIP`, `FILE`) regardless
+ * of how many values are stored, so a to-one relation is still an array of one.
+ * A create/update event, by contrast, threads the caller's own input, where the
+ * same field is a bare string. Any reader that handles one shape and not the
+ * other passes silently — it does not throw, it just never matches.
+ *
+ * ⚠️ **A `typeof value === 'string'` test on a captured SINGLE_SELECT or
+ * RELATIONSHIP is always false.** That reads correctly in review and passes any
+ * unit test built from a hand-written string fixture, which is exactly how this
+ * has now shipped twice.
+ */
+export function unwrapStatusValue(raw: unknown): unknown {
+  if (Array.isArray(raw)) return unwrapStatusValue(raw[0])
+  if (raw && typeof raw === 'object') {
+    if ('optionId' in raw) return (raw as { optionId: unknown }).optionId
+    if ('value' in raw) return (raw as { value: unknown }).value
+  }
+  return raw
+}
+
+/**
+ * A captured relation, reduced to one entity instance id.
+ *
+ * Accepts every shape in {@link unwrapStatusValue}'s table plus the
+ * `{type:'relationship', recordId}` envelope, and unwraps a `defId:instId`
+ * RecordId to its instance half — a relation is stored as a RecordId on the
+ * capture chain and as a bare instance id on some create paths, and callers
+ * want the instance id either way.
+ *
+ * @returns the entity instance id, or `undefined` when the relation is unset.
+ */
+export function unwrapRelationId(raw: unknown): string | undefined {
+  const unwrapped = unwrapRecordIdEnvelope(raw)
+  if (typeof unwrapped !== 'string' || unwrapped.length === 0) return undefined
+  return unwrapped.includes(':') ? parseRecordId(unwrapped as RecordId).entityInstanceId : unwrapped
+}
+
+/**
+ * Every entity instance id in a captured to-many relation, de-duplicated.
+ *
+ * ⚠️ Use this, not {@link unwrapRelationId}, wherever the field can hold more
+ * than one value — `unwrapRelationId` takes the first and silently drops the
+ * rest, which is correct for a to-one relation and a bug for a to-many one.
+ */
+export function unwrapRelationIds(raw: unknown): string[] {
+  const values = Array.isArray(raw) ? raw : [raw]
+  const ids = values.map((value) => unwrapRelationId(value)).filter((id): id is string => !!id)
+  return [...new Set(ids)]
+}
+
+/** One level of envelope removal, shared by the two relation readers. */
+function unwrapRecordIdEnvelope(raw: unknown): unknown {
+  if (Array.isArray(raw)) return unwrapRecordIdEnvelope(raw[0])
+  if (raw && typeof raw === 'object') {
+    if ('recordId' in raw) return (raw as { recordId: unknown }).recordId
+    if ('optionId' in raw) return (raw as { optionId: unknown }).optionId
+    if ('value' in raw) return (raw as { value: unknown }).value
+  }
+  return raw
+}

--- a/packages/lib/src/resources/hooks/lifecycle-status-guard.ts
+++ b/packages/lib/src/resources/hooks/lifecycle-status-guard.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/resources/hooks/lifecycle-status-guard.ts
 
 import { BadRequestError } from '../../errors'
+import { unwrapStatusValue } from '../events/captured-values'
 import type { SystemHook } from './types'
 
 /**
@@ -101,32 +102,15 @@ export const BUILD_ACTION_STATUS_MESSAGE =
 /**
  * Reduce a status write to the bare value being set, whatever shape it arrives in.
  *
- * 🛑 The two chains hand a guard **different shapes**, and this is the whole reason the
- * function exists rather than being inlined twice:
- *
- * - On the **system**-hook chain (`UnifiedCrudHandler.runPreHooks`) the value is raw caller
- *   input — usually the bare string, sometimes a single-element array.
- * - On the **field** pre-hook chain (`fireFieldPreHooks`) the value has already been through
- *   `validateAndConvertValue`, so a SINGLE_SELECT arrives as `{ type: 'option', optionId }`
- *   and **never** as a bare string. A guard on that chain that compares the value directly
- *   to `'issued'` is inert: the comparison can never be true, so the guard silently passes
- *   everything.
- *
- * Unwrapping the envelope makes the system-hook side strictly stricter (it now also catches
- * a caller that passes the typed shape), which can only ever reject a write that was trying
- * to set a guarded status.
- *
- * @param raw - The value as the chain handed it over.
- * @returns The scalar the guard should compare against.
+ * 🛑 **Moved to `resources/events/captured-values.ts`** and re-exported here so the callers
+ * that already import it from this path keep working. It moved because a THIRD chain — the
+ * `captureEventData` capture that feeds pre-delete hooks, post-delete hooks and the lifecycle
+ * event — hands over yet another shape, and keeping the unwrapper next to the function that
+ * produces the shapes is what stops a fourth private copy being written
+ * (`plans/money/tasks/24-captured-value-shape.md`). The three-chain table lives on the
+ * definition.
  */
-export function unwrapStatusValue(raw: unknown): unknown {
-  if (Array.isArray(raw)) return unwrapStatusValue(raw[0])
-  if (raw && typeof raw === 'object') {
-    if ('optionId' in raw) return (raw as { optionId: unknown }).optionId
-    if ('value' in raw) return (raw as { value: unknown }).value
-  }
-  return raw
-}
+export { unwrapStatusValue }
 
 /** Options for {@link createLifecycleStatusGuard}. */
 export interface LifecycleStatusGuardOptions {


### PR DESCRIPTION
## What was wrong

A pre-delete hook, a post-delete hook and the lifecycle event the worker consumes all receive **one** object built by `captureEventData`. That object is not shaped like a create event's: `getValues` arrays every `ARRAY_RETURN_FIELD_TYPES` member, so a `RELATIONSHIP` arrives as `['defId:instId']` and a `SINGLE_SELECT` as `['issued']` — a to-one relation is still an array of one — while a create threads the caller's bare string.

**Five readers tested `typeof value === 'string'.`** On a captured relation that is always false, so each matched nothing, threw nothing, and did nothing:

| Reader | Consequence |
| --- | --- |
| `guardBuildDelete`'s "this build IS a reversal" refusal | Unreachable. Deleting build `B-0007` in dev **succeeded** and cascaded its 9 stock movements, leaving `B-0006` reversed by nothing |
| `recalculatePartQoH` | **A no-op on every delete.** QoH drifted from the ledger it is defined as a re-SUM of |
| `recalculatePurchaseOrderLineReceived` | PO line keeps a phantom received quantity |
| `bom-cost-triggers` | A deleted subpart never recomputes the parent's rolled cost — the "live bug" #1995 claimed cascading would fix |
| `bom-movement-triggers` | BOM explosion children not reconciled |

The last four are the **same eight-line helper, copy-pasted four times**. `recalculatePartQoH`'s database fallback cannot cover the gap: the movement's `FieldValue` rows are already swept by the time the worker sees the event. The B-0007 cascade produced exactly **9** `Could not resolve affected part` warnings and left 9 stale parts, while `hygiene.danglingRelationValues` still read zero — nothing looked broken.

## Why it wasn't caught

The unwrapper already existed. **#1940 fixed this same class on the update chain four days earlier** and wrote the warning down verbatim — *"passes any unit test that feeds it a bare string"* — but attached it to `newValue` on a chain that looks nothing like this one at the call site.

`build-delete-guard.test.ts` passed `build_reversal_of: 'def:other'`, a bare string. 260 tests green throughout.

## The fix

`unwrapStatusValue` moves to `resources/events/captured-values.ts`, beside the function that produces the shapes, re-exported from its old path so its four callers are untouched. It is joined by `unwrapRelationId` / `unwrapRelationIds` and **a table of all three chains**, which is the real deliverable. `vendor-bill-delete-guard`'s private copy now delegates to it.

The fixtures were the actual defect, so:
- `captured-shape.test.ts` pins what `captureEventData` emits per field type
- guard fixtures build it through `__tests__/support/captured.ts`
- the reversal case was **verified to fail against the old read** and pass against the new one; the bare-string case is kept so the create chain stays covered

## Driven, which is the only thing that proves it

| Step | Result |
| --- | --- |
| Delete the reversal build | **400** — *"This build reverses another build…"*, nothing mutated |
| Delete the reversed original | **400** — *"This build has already been reversed by 1 build…"* |
| Delete an open-period build | Cascaded 9 movements, **0** QoH-vs-ledger mismatches, **0** parts left holding stock with no ledger |

The worker log is the decisive part. The identical cascade before the fix logged **9 × `warn "Could not resolve affected part"`**. After:

```
9 × info  Recalculating QoH for part
9 × info  QoH recalculated
0 × warn  Could not resolve affected part
```

## Checks

- `packages/lib` full suite: **14,693 passed**. One pre-existing failure, `108-purchasing.test.ts:1408` (P13), is **on `main`** from #1995 and untouched by this branch — its three offending files name `vendor_payment_allocation` in their committed versions and this diff adds no such string. Already tracked in `plans/money/tasks/README.md`.
- `typecheck-ratchet --package lib`: no new errors (29, baseline 29)
- Biome clean

## Docs

- `entity-events-architecture-guide.md` §7.1 — the three-chain payload table, a §13 gotcha, two Key Files rows
- `inventory-costing-architecture-guide.md` §6.4 — the fourth instance of "an edit guard with no delete counterpart" is the guard itself. This commit also carries the per-part absorption notes (§7.2 rule 5) that were sitting uncommitted in that file from #2003.

https://claude.ai/code/session_01JyZZyQuwHFHuyoSRmXQVob