### PR TITLE
fix(records): let a delete guard see archived children, and make archive reversible

### DIFF
--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -408,6 +408,34 @@ a re-SUM of (§8), silently, with `hygiene.danglingRelationValues` still reading
 `typeof === 'string'`** — on a relation or a select it is always false, and the reader silently
 matches nothing.
 
+🛑 **And a guard must count ARCHIVED children, which none of them did.** Every guard asked "does
+anything still depend on this record?" through `UnifiedCrudHandler.listFiltered`, whose paged query
+hardcodes `isNull(archivedAt)` into the `baseWhere` it shares with its `COUNT(*)`
+(`unified-handler-queries.ts:692`) with no way to disable it. So an archived child was invisible,
+and that broke the guards in two directions at once: a **refusal under-refused** —
+`guardPurchaseOrderDelete` deleted `PO-0002` on 2026-08-31 while an archived vendor bill still named
+it, and the sweep then erased both halves of the relation — and a **cascade under-cascaded**,
+stranding the archived subpart, vendor-part or line it exists to collect. `readMovementsByRelation`
+had it too, so an archived movement could not hold its settled month closed.
+
+The replacement is `field-hooks/pre/related-rows.ts` (`findRelatedInstanceIds`), which reads
+`EntityInstance ⋈ FieldValue` directly and deliberately applies no `archivedAt` predicate.
+**`archivedAt` is a soft delete, not a delete:** the row is still in the table, a vendor's bill is
+still a document the vendor sent, and the three-way match still references it. The guards' own
+messages say *"archive it instead"* — archiving is the sanctioned way to retire a record, which is
+exactly why it cannot also mean "nothing depends on this any more".
+
+⚠️ **The dispatch guards (`invoice`, `order`, `quote`, `work-order`) still carry this**, five
+`listFiltered` call sites, pinned by `field-hooks/__tests__/guard-sees-archived.test.ts`'s
+`KNOWN_UNFIXED` list rather than silently excluded.
+
+🛑 **Archive was also a one-way door, which is why the refusal's own advice was impossible.**
+`getEntityInstance` excluded archived rows, and both `restoreEntity` and `deleteEntity` load through
+it — so `restoreEntity`, whose only purpose is to clear `archivedAt`, could never find its target,
+and an archived record could be neither restored nor purged. `guardPurchaseOrderDelete` telling a
+caller to "delete or unlink the bills first" was asking for something the API refused to do. Fixed
+with an explicit `includeArchived` on the loader, passed by those two callers only.
+
 ⚠️ The lesson for this guide is narrower than "write better guards": every one of these four
 instances passed review and passed its unit tests, and each was found only by performing the
 action in a browser and then asking the database whether it had happened. Budget for that step.

--- a/packages/lib/src/entity-instances/__tests__/get-entity-instance-archived.test.ts
+++ b/packages/lib/src/entity-instances/__tests__/get-entity-instance-archived.test.ts
@@ -1,0 +1,75 @@
+// packages/lib/src/entity-instances/__tests__/get-entity-instance-archived.test.ts
+//
+// `includeArchived` — the flag that makes an archived record reachable again.
+//
+// 🛑 **Without it, archive was a ONE-WAY DOOR.** This loader excluded any row
+// carrying `archivedAt`, and both `restoreEntity` and `deleteEntity` call it
+// before doing anything. So `restoreEntity` — whose entire purpose is to clear
+// that column — could never load its own target and answered
+// `Entity not found` for every record it existed to serve, and a hard delete of
+// an archived record failed the same way. An archived row could be neither
+// brought back nor purged.
+//
+// Found 2026-08-31 with DemoOrg1's 9 purchase orders and 9 vendor bills stuck
+// behind it. It also made a delete guard's own advice impossible to follow:
+// `guardPurchaseOrderDelete` says "delete or unlink the bills first", and the
+// API refused to delete them.
+//
+// The default must stay `false` — every read path wants the archived row hidden,
+// and flipping that would surface soft-deleted records across the app.
+
+import { describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ findFirst: vi.fn() }))
+
+vi.mock('@auxx/database', () => ({
+  database: { query: { EntityInstance: { findFirst: h.findFirst } } },
+}))
+
+vi.mock('@auxx/services/shared/utils', async () => {
+  const { ok } = await import('neverthrow')
+  return { fromDatabase: async (p: Promise<unknown>) => ok(await p) }
+})
+
+const { getEntityInstance } = await import('../get-entity-instance')
+
+/**
+ * Drizzle's relational `where` is a callback over `(table, operators)`. Calling
+ * it with recording stubs tells us which predicates were built — the archived
+ * one is the whole subject of this file.
+ */
+function predicatesFor(includeArchived?: boolean): string[] {
+  h.findFirst.mockReset()
+  h.findFirst.mockReturnValue(Promise.resolve({ id: 'inst_1' }))
+
+  void getEntityInstance({ id: 'inst_1', organizationId: 'org_1', includeArchived })
+
+  const built: string[] = []
+  const ops = {
+    eq: (col: unknown, _v: unknown) => `eq:${String(col)}`,
+    isNull: (col: unknown) => {
+      built.push(`isNull:${String(col)}`)
+      return `isNull:${String(col)}`
+    },
+    and: (...args: unknown[]) => args,
+  }
+  const table = { id: 'id', organizationId: 'organizationId', archivedAt: 'archivedAt' }
+  const { where } = h.findFirst.mock.calls[0]![0]
+  where(table, ops)
+  return built
+}
+
+describe('getEntityInstance — the archived predicate', () => {
+  it('excludes archived rows by default', () => {
+    expect(predicatesFor(undefined)).toContain('isNull:archivedAt')
+  })
+
+  it('excludes them on an explicit false too', () => {
+    expect(predicatesFor(false)).toContain('isNull:archivedAt')
+  })
+
+  it('does NOT exclude them when includeArchived is true', () => {
+    // The regression that made restore and hard-delete unreachable.
+    expect(predicatesFor(true)).not.toContain('isNull:archivedAt')
+  })
+})

--- a/packages/lib/src/entity-instances/get-entity-instance.ts
+++ b/packages/lib/src/entity-instances/get-entity-instance.ts
@@ -8,13 +8,28 @@ import { err, ok } from 'neverthrow'
 export interface GetEntityInstanceParams {
   id: string
   organizationId: string
+  /**
+   * Load the row even when it is archived. Default `false`, which is what every
+   * read path wants.
+   *
+   * 🛑 **`restoreEntity` and `deleteEntity` MUST pass `true`.** Archiving sets
+   * `archivedAt`, and this loader excluded any row that carries it — so
+   * `restoreEntity`, whose entire purpose is to clear that column, could never
+   * load its own target and answered `Entity not found` for every record it
+   * existed to serve. A hard delete of an archived record failed the same way,
+   * which meant an archived row could be neither restored nor purged: archive
+   * was a one-way door. Found 2026-08-31 with DemoOrg1's 9 purchase orders and
+   * 9 vendor bills stuck behind it, and it also made a delete guard's own advice
+   * ("delete or unlink the bills first") impossible to follow.
+   */
+  includeArchived?: boolean
 }
 
 /**
  * Get entity instance by ID with field values
  */
 export async function getEntityInstance(params: GetEntityInstanceParams) {
-  const { id, organizationId } = params
+  const { id, organizationId, includeArchived = false } = params
 
   const dbResult = await fromDatabase(
     database.query.EntityInstance.findFirst({
@@ -22,7 +37,7 @@ export async function getEntityInstance(params: GetEntityInstanceParams) {
         and(
           eq(instances.id, id),
           eq(instances.organizationId, organizationId),
-          isNull(instances.archivedAt)
+          includeArchived ? undefined : isNull(instances.archivedAt)
         ),
       with: {
         entityDefinition: true,

--- a/packages/lib/src/field-hooks/__tests__/guard-sees-archived.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/guard-sees-archived.test.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/field-hooks/__tests__/guard-sees-archived.test.ts
+//
+// A pre-delete guard must not decide "does anything still depend on this
+// record?" through `UnifiedCrudHandler.listFiltered`.
+//
+// 🛑 **`listFiltered` cannot see an archived row.** Its paged query hardcodes
+// `isNull(archivedAt)` into the `baseWhere` it shares with its `COUNT(*)`
+// (`resources/crud/unified-handler-queries.ts:692`), and there is no option to
+// turn that off. Every guard used it, which broke them in both directions:
+//
+//   - **Refusals under-refused.** Driven against dev on 2026-08-31,
+//     `guardPurchaseOrderDelete` deleted `PO-0002` while an ARCHIVED vendor bill
+//     still named it. `sweepEntityFieldValues` then removed both halves of the
+//     relation, so the bill kept an empty Purchase Order cell and no trace an
+//     order had ever existed — recoverable by nothing. It was caught only
+//     because the §8 audit's orphan count moved 1 → 2; a query run afterwards
+//     cannot see it, because the evidence is exactly what got swept.
+//   - **Cascades under-cascaded**, stranding the archived children they exist
+//     to collect.
+//
+// The replacement is `pre/related-rows.ts` (`findRelatedInstanceIds`), which
+// reads `EntityInstance ⋈ FieldValue` directly and deliberately applies no
+// `archivedAt` predicate. `pre/guarded-movements.ts` had the same bug and the
+// same fix — an archived movement is still in the ledger and still under
+// whatever entry was filed for its month.
+//
+// This test is source-level on purpose. The behaviour it protects is the
+// ABSENCE of a predicate, which no unit test with a mocked handler can observe:
+// every guard test doubles the child lookup, so a guard could silently go back
+// to `listFiltered` with all 262 of them still green. That is precisely how the
+// original defect shipped.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const PRE_DIR = join(__dirname, '..', 'pre')
+
+/** The money delete guards — fixed and driven in a browser on 2026-08-31. */
+const FIXED = [
+  'build-delete-guard.ts',
+  'part-delete-guard.ts',
+  'purchase-order-delete-guard.ts',
+  'vendor-bill-delete-guard.ts',
+]
+
+/**
+ * 🛑 **The dispatch guards carry the SAME defect and are not fixed here.**
+ * Five `listFiltered` call sites: `invoice`/`order`/`work-order` cascade their
+ * own lines (an archived line is stranded), and `quote`/`work-order` refuse on
+ * a child that an archive makes invisible. They are listed rather than silently
+ * excluded, because that is what the old `KNOWN_UNGUARDED` list did in
+ * `delete-guard-registration.test.ts` and it is the reason `builds`,
+ * `purchase-orders` and `vendor-bills` were found rather than forgotten.
+ *
+ * When one is fixed, move it up to `FIXED` in the same commit.
+ */
+const KNOWN_UNFIXED = [
+  'invoice-delete-guard.ts',
+  'order-delete-guard.ts',
+  'quote-delete-guard.ts',
+  'work-order-delete-guard.ts',
+]
+
+function source(file: string): string {
+  return readFileSync(join(PRE_DIR, file), 'utf8')
+}
+
+describe('delete guards read children through a path that sees archived rows', () => {
+  it('accounts for every delete guard on disk — no guard escapes both lists', () => {
+    const onDisk = readdirSync(PRE_DIR)
+      .filter((f) => f.endsWith('-delete-guard.ts') && !f.endsWith('.test.ts'))
+      .sort()
+    expect(onDisk).toEqual([...FIXED, ...KNOWN_UNFIXED].sort())
+  })
+
+  it.each(FIXED)('%s reads children through findRelatedInstanceIds, not listFiltered', (file) => {
+    const src = source(file)
+    // A comment naming it is fine; a call is not.
+    expect(src).not.toMatch(/handler\.listFiltered\(/)
+    expect(src).toContain('findRelatedInstanceIds')
+  })
+
+  it.each(KNOWN_UNFIXED)('%s is still on the old path — pinned, not forgotten', (file) => {
+    expect(source(file)).toMatch(/handler\.listFiltered\(/)
+  })
+
+  it('the shared reader applies no archivedAt predicate', () => {
+    const related = readFileSync(join(PRE_DIR, 'related-rows.ts'), 'utf8')
+    // The predicate this module exists to omit, in the form Drizzle writes it.
+    expect(related).not.toMatch(/isNull\(\s*schema\.EntityInstance\.archivedAt\s*\)/)
+  })
+
+  it('the movement reader applies no archivedAt predicate either', () => {
+    const movements = readFileSync(join(PRE_DIR, 'guarded-movements.ts'), 'utf8')
+    expect(movements).not.toMatch(/isNull\(schema\.EntityInstance\.archivedAt\)/)
+  })
+})

--- a/packages/lib/src/field-hooks/pre/build-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/build-delete-guard.test.ts
@@ -14,6 +14,7 @@ import type { EntityPreDeleteEvent } from '../types'
 
 const h = vi.hoisted(() => ({
   listFiltered: vi.fn(),
+  findRelated: vi.fn(),
   del: vi.fn(),
   getCachedEntityDefId: vi.fn(),
   bySystemAttributes: vi.fn(),
@@ -29,6 +30,8 @@ vi.mock('../../resources/crud', () => ({
     delete = h.del
   },
 }))
+
+vi.mock('./related-rows', () => ({ findRelatedInstanceIds: h.findRelated }))
 
 vi.mock('../../cache', () => ({
   getCachedEntityDefId: h.getCachedEntityDefId,
@@ -99,7 +102,7 @@ beforeEach(() => {
   h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
   h.postedPeriodRows.mockResolvedValue([])
   h.movementRows.mockResolvedValue([])
-  h.listFiltered.mockResolvedValue({ ids: [] })
+  h.findRelated.mockResolvedValue([])
   settings({})
 })
 
@@ -159,13 +162,13 @@ describe('guardBuildDelete — refusals', () => {
   })
 
   it('refuses when this build HAS BEEN reversed', async () => {
-    h.listFiltered.mockResolvedValue({ ids: ['reversing-build'] })
+    h.findRelated.mockResolvedValue(['reversing-build'])
 
     await expect(guardBuildDelete(event())).rejects.toThrow(/already been reversed/i)
   })
 
   it('checks the reversal pair before reading movements, so nothing is deleted', async () => {
-    h.listFiltered.mockResolvedValue({ ids: ['reversing-build'] })
+    h.findRelated.mockResolvedValue(['reversing-build'])
     h.movementRows.mockResolvedValue([movement('m1', '2026-09-01')])
 
     await expect(guardBuildDelete(event())).rejects.toThrow()

--- a/packages/lib/src/field-hooks/pre/build-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/build-delete-guard.ts
@@ -7,6 +7,7 @@ import { UnifiedCrudHandler } from '../../resources/crud'
 import { unwrapRelationId } from '../../resources/events/captured-values'
 import type { EntityPreDeleteEvent, EntityPreDeleteHandler } from '../types'
 import { type GuardedMovement, readMovementsByRelation } from './guarded-movements'
+import { findRelatedInstanceIds } from './related-rows'
 
 /**
  * Pre-delete guard for `builds` (plans/money/tasks/21-money-parent-delete-safety.md §3).
@@ -50,7 +51,7 @@ export const guardBuildDelete: EntityPreDeleteHandler = async (event) => {
   const handler = new UnifiedCrudHandler(organizationId, userId)
 
   // Refuse BEFORE any cascade, so a rejected delete mutates nothing.
-  await refuseIfReversalPair(handler, event)
+  await refuseIfReversalPair(event)
 
   const movements = await readMovementsByRelation(organizationId, 'stock_movement_build', [
     buildInstanceId,
@@ -83,10 +84,7 @@ export const guardBuildDelete: EntityPreDeleteHandler = async (event) => {
  * data already in hand. **"This build HAS BEEN reversed"** lives on a different
  * row and has to be looked up.
  */
-async function refuseIfReversalPair(
-  handler: UnifiedCrudHandler,
-  event: EntityPreDeleteEvent
-): Promise<void> {
+async function refuseIfReversalPair(event: EntityPreDeleteEvent): Promise<void> {
   const { organizationId, recordId } = event
 
   // 🛑 Through `unwrapRelationId`, never `typeof === 'string'`. The capture chain hands a
@@ -103,24 +101,12 @@ async function refuseIfReversalPair(
     )
   }
 
-  const { ids: reversedBy } = await handler.listFiltered({
-    entityDefinitionId: 'build',
-    filters: [
-      {
-        id: 'build-reversed-by',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: 'build-reversed-by-original',
-            fieldId: 'build:reversalOf',
-            operator: 'is',
-            value: recordId,
-          },
-        ],
-      },
-    ],
-    limit: 1000,
-  })
+  // ⚠️ Archived reversals count — see `related-rows.ts`. A reversal somebody
+  // archived still negates this build's movements, so deleting the original
+  // would leave that negation explaining nothing.
+  const reversedBy = await findRelatedInstanceIds(organizationId, 'build', 'build_reversal_of', [
+    parseRecordId(recordId).entityInstanceId,
+  ])
 
   if (reversedBy.length > 0) {
     throw new BadRequestError(

--- a/packages/lib/src/field-hooks/pre/guarded-movements.ts
+++ b/packages/lib/src/field-hooks/pre/guarded-movements.ts
@@ -101,8 +101,14 @@ export async function readMovementsByRelation(
   ).where(
     and(
       eq(schema.EntityInstance.organizationId, organizationId),
-      eq(schema.EntityInstance.entityDefinitionId, movementDefId),
-      isNull(schema.EntityInstance.archivedAt)
+      eq(schema.EntityInstance.entityDefinitionId, movementDefId)
+      // 🛑 Archived movements are INCLUDED, deliberately. `archivedAt` is a soft
+      // delete — the row is still in the ledger and still under whatever entry
+      // was filed for its month, so a settled period containing an archived
+      // movement is still settled. Filtering them here let a parent delete its
+      // history out from under a posted entry as long as somebody had archived
+      // the rows first. See `related-rows.ts` for the same decision on the
+      // relation side and the dev evidence behind it.
     )
   )
 

--- a/packages/lib/src/field-hooks/pre/part-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/part-delete-guard.test.ts
@@ -14,6 +14,7 @@ import type { EntityPreDeleteEvent } from '../types'
 
 const h = vi.hoisted(() => ({
   listFiltered: vi.fn(),
+  findRelated: vi.fn(),
   del: vi.fn(),
   getCachedEntityDefId: vi.fn(),
   bySystemAttributes: vi.fn(),
@@ -29,6 +30,8 @@ vi.mock('../../resources/crud', () => ({
     delete = h.del
   },
 }))
+
+vi.mock('./related-rows', () => ({ findRelatedInstanceIds: h.findRelated }))
 
 vi.mock('../../cache', () => ({
   getCachedEntityDefId: h.getCachedEntityDefId,
@@ -110,7 +113,7 @@ const BOOKS_OPEN = {
 beforeEach(() => {
   vi.clearAllMocks()
   h.del.mockResolvedValue(undefined)
-  h.listFiltered.mockResolvedValue({ ids: [] })
+  h.findRelated.mockResolvedValue([])
   h.getCachedEntityDefId.mockResolvedValue('v9xn5fhvb68jja0wcvog5gl4')
   h.bySystemAttributes.mockResolvedValue({
     stock_movement_part: { id: 'fld_part' },
@@ -215,9 +218,8 @@ describe('guardPartDelete — open books', () => {
 
 describe('guardPartDelete — cascades', () => {
   it('deletes the BOM rows on BOTH ends, de-duplicated', async () => {
-    h.listFiltered.mockImplementation(
-      async ({ entityDefinitionId }: { entityDefinitionId: string }) =>
-        entityDefinitionId === 'subpart' ? { ids: ['sub1', 'sub2'] } : { ids: [] }
+    h.findRelated.mockImplementation(async (_org: string, childType: string) =>
+      childType === 'subpart' ? ['sub1', 'sub2'] : []
     )
 
     await guardPartDelete(event())
@@ -234,38 +236,31 @@ describe('guardPartDelete — cascades', () => {
   it('queries both subpart relations, not just one', async () => {
     await guardPartDelete(event())
 
-    const subpartFields = h.listFiltered.mock.calls
-      .filter((c) => c[0].entityDefinitionId === 'subpart')
-      .map((c) => c[0].filters[0].conditions[0].fieldId)
-    expect(subpartFields).toEqual(['subpart:parentPart', 'subpart:childPart'])
+    const subpartAttributes = h.findRelated.mock.calls
+      .filter((c) => c[1] === 'subpart')
+      .map((c) => c[2])
+    expect(subpartAttributes).toEqual(['subpart_parent_part', 'subpart_child_part'])
   })
 
   it('deletes the supplier pricing rows', async () => {
-    h.listFiltered.mockImplementation(
-      async ({ entityDefinitionId }: { entityDefinitionId: string }) =>
-        entityDefinitionId === 'vendor_part' ? { ids: ['vp1'] } : { ids: [] }
+    h.findRelated.mockImplementation(async (_org: string, childType: string) =>
+      childType === 'vendor_part' ? ['vp1'] : []
     )
 
     await guardPartDelete(event())
 
     expect(h.del).toHaveBeenCalledWith('vendor_part:vp1')
-    const [query] = h.listFiltered.mock.calls.find(
-      (c) => c[0].entityDefinitionId === 'vendor_part'
-    )!
-    expect(query.filters[0].conditions[0]).toEqual({
-      id: 'part-supplier-pricing-part',
-      fieldId: 'vendor_part:part',
-      operator: 'is',
-      value: PART_RECORD_ID,
-    })
+    const call = h.findRelated.mock.calls.find((c) => c[1] === 'vendor_part')!
+    expect(call[2]).toBe('vendor_part_part')
+    expect(call[3]).toEqual([PART_ID])
   })
 
   it('never touches the vendor documents — a bill line is not ours to delete', async () => {
-    h.listFiltered.mockResolvedValue({ ids: ['x1'] })
+    h.findRelated.mockResolvedValue(['x1'])
 
     await guardPartDelete(event())
 
-    const queried = h.listFiltered.mock.calls.map((c) => c[0].entityDefinitionId)
+    const queried = h.findRelated.mock.calls.map((c) => c[1])
     expect(queried).not.toContain('purchase_order_line')
     expect(queried).not.toContain('vendor_bill_line')
     expect(queried).not.toContain('catalog_item')

--- a/packages/lib/src/field-hooks/pre/part-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/part-delete-guard.ts
@@ -6,6 +6,7 @@ import { describeSettledPeriods, settledPeriodsFor } from '../../postings/settle
 import { UnifiedCrudHandler } from '../../resources/crud'
 import type { EntityPreDeleteHandler } from '../types'
 import { type GuardedMovement, readMovementsByRelation } from './guarded-movements'
+import { findRelatedInstanceIds } from './related-rows'
 
 /**
  * Pre-delete guard for `parts` (plans/money/tasks/20-part-delete-safety.md).
@@ -75,8 +76,8 @@ export const guardPartDelete: EntityPreDeleteHandler = async (event) => {
   }
 
   const handler = new UnifiedCrudHandler(organizationId, userId)
-  await cascadeBomRows(handler, recordId)
-  await cascadeSupplierPricing(handler, recordId)
+  await cascadeBomRows(handler, organizationId, recordId)
+  await cascadeSupplierPricing(handler, organizationId, recordId)
   await cascadeMovements(handler, movements)
 }
 
@@ -111,23 +112,22 @@ function describeRefusal(settled: Map<string, number>): string {
  * both. Ids are de-duplicated before deletion so a part that is its own
  * assembly's component is not deleted twice.
  */
-async function cascadeBomRows(handler: UnifiedCrudHandler, partRecordId: RecordId): Promise<void> {
+async function cascadeBomRows(
+  handler: UnifiedCrudHandler,
+  organizationId: string,
+  partRecordId: RecordId
+): Promise<void> {
+  const { entityInstanceId } = parseRecordId(partRecordId)
+  // Archived rows are collected too — see `related-rows.ts`. A subpart left
+  // behind by its part is nameless (the display cascade nulls it) and keeps its
+  // parent's rolled cost stale forever, archived or not.
   const ids = new Set<string>()
-  for (const field of ['subpart:parentPart', 'subpart:childPart'] as const) {
-    const { ids: found } = await handler.listFiltered({
-      entityDefinitionId: 'subpart',
-      filters: [
-        {
-          id: 'part-bom-rows',
-          logicalOperator: 'AND',
-          conditions: [
-            { id: `part-bom-rows-${field}`, fieldId: field, operator: 'is', value: partRecordId },
-          ],
-        },
-      ],
-      limit: 1000,
-    })
-    for (const id of found) ids.add(id)
+  for (const attribute of ['subpart_parent_part', 'subpart_child_part'] as const) {
+    for (const id of await findRelatedInstanceIds(organizationId, 'subpart', attribute, [
+      entityInstanceId,
+    ])) {
+      ids.add(id)
+    }
   }
 
   for (const id of ids) {
@@ -138,26 +138,12 @@ async function cascadeBomRows(handler: UnifiedCrudHandler, partRecordId: RecordI
 /** Supplier prices. A price for a part that does not exist prices nothing. */
 async function cascadeSupplierPricing(
   handler: UnifiedCrudHandler,
+  organizationId: string,
   partRecordId: RecordId
 ): Promise<void> {
-  const { ids } = await handler.listFiltered({
-    entityDefinitionId: 'vendor_part',
-    filters: [
-      {
-        id: 'part-supplier-pricing',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: 'part-supplier-pricing-part',
-            fieldId: 'vendor_part:part',
-            operator: 'is',
-            value: partRecordId,
-          },
-        ],
-      },
-    ],
-    limit: 1000,
-  })
+  const ids = await findRelatedInstanceIds(organizationId, 'vendor_part', 'vendor_part_part', [
+    parseRecordId(partRecordId).entityInstanceId,
+  ])
 
   for (const id of ids) {
     await handler.delete(toRecordId('vendor_part', id))

--- a/packages/lib/src/field-hooks/pre/purchase-order-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-delete-guard.test.ts
@@ -12,6 +12,7 @@ import type { EntityPreDeleteEvent } from '../types'
 
 const h = vi.hoisted(() => ({
   listFiltered: vi.fn(),
+  findRelated: vi.fn(),
   del: vi.fn(),
   getCachedEntityDefId: vi.fn(),
   bySystemAttributes: vi.fn(),
@@ -27,6 +28,8 @@ vi.mock('../../resources/crud', () => ({
     delete = h.del
   },
 }))
+
+vi.mock('./related-rows', () => ({ findRelatedInstanceIds: h.findRelated }))
 
 vi.mock('../../cache', () => ({
   getCachedEntityDefId: h.getCachedEntityDefId,
@@ -76,11 +79,10 @@ function event(): EntityPreDeleteEvent {
   }
 }
 
-/** `listFiltered` answers per entity, so a test cannot confuse the two reads. */
+/** `findRelatedInstanceIds` answers per child type, so a test cannot confuse the two reads. */
 function children({ bills = [], lines = [] }: { bills?: string[]; lines?: string[] }): void {
-  h.listFiltered.mockImplementation(
-    async ({ entityDefinitionId }: { entityDefinitionId: string }) =>
-      entityDefinitionId === 'vendor_bill' ? { ids: bills } : { ids: lines }
+  h.findRelated.mockImplementation(async (_org: string, childType: string) =>
+    childType === 'vendor_bill' ? bills : lines
   )
 }
 

--- a/packages/lib/src/field-hooks/pre/purchase-order-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/purchase-order-delete-guard.ts
@@ -1,11 +1,12 @@
 // packages/lib/src/field-hooks/pre/purchase-order-delete-guard.ts
 
-import { type RecordId, toRecordId } from '@auxx/types/resource'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { BadRequestError } from '../../errors'
 import { describeSettledPeriods, settledPeriodsFor } from '../../postings/settled-periods'
 import { UnifiedCrudHandler } from '../../resources/crud'
 import type { EntityPreDeleteHandler } from '../types'
 import { readMovementsByRelation } from './guarded-movements'
+import { findRelatedInstanceIds } from './related-rows'
 
 /**
  * Pre-delete guard for `purchase-orders`
@@ -47,9 +48,9 @@ export const guardPurchaseOrderDelete: EntityPreDeleteHandler = async (event) =>
   const handler = new UnifiedCrudHandler(organizationId, userId)
 
   // Refuse BEFORE any cascade, so a rejected delete mutates nothing.
-  await refuseIfBilled(handler, organizationId, recordId)
+  await refuseIfBilled(organizationId, recordId)
 
-  const lineIds = await readLineIds(handler, recordId)
+  const lineIds = await readLineIds(organizationId, recordId)
   const movements = await readMovementsByRelation(
     organizationId,
     'stock_movement_purchase_order_line',
@@ -100,29 +101,17 @@ export const guardPurchaseOrderDelete: EntityPreDeleteHandler = async (event) =>
  * three-way match is computed against — `purchasing/match.ts` reads the order
  * leg to produce a verdict at all.
  */
-async function refuseIfBilled(
-  handler: UnifiedCrudHandler,
-  organizationId: string,
-  recordId: RecordId
-): Promise<void> {
-  const { ids } = await handler.listFiltered({
-    entityDefinitionId: 'vendor_bill',
-    filters: [
-      {
-        id: 'po-bills',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: 'po-bills-order',
-            fieldId: 'vendor_bill:purchaseOrder',
-            operator: 'is',
-            value: recordId,
-          },
-        ],
-      },
-    ],
-    limit: 1000,
-  })
+async function refuseIfBilled(organizationId: string, recordId: RecordId): Promise<void> {
+  const { entityInstanceId } = parseRecordId(recordId)
+  // ⚠️ Through `findRelatedInstanceIds`, NOT `listFiltered` — an ARCHIVED bill
+  // still names this order, and the shared list path cannot see one. Driving
+  // this guard on 2026-08-31 deleted `PO-0002` out from under exactly that.
+  const ids = await findRelatedInstanceIds(
+    organizationId,
+    'vendor_bill',
+    'vendor_bill_purchase_order',
+    [entityInstanceId]
+  )
 
   if (ids.length > 0) {
     throw new BadRequestError(
@@ -135,27 +124,14 @@ async function refuseIfBilled(
 }
 
 /** The order's own lines. */
-async function readLineIds(
-  handler: UnifiedCrudHandler,
-  recordId: RecordId
-): Promise<readonly string[]> {
-  const { ids } = await handler.listFiltered({
-    entityDefinitionId: 'purchase_order_line',
-    filters: [
-      {
-        id: 'po-lines',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: 'po-lines-order',
-            fieldId: 'purchase_order_line:purchaseOrder',
-            operator: 'is',
-            value: recordId,
-          },
-        ],
-      },
-    ],
-    limit: 1000,
-  })
-  return ids
+async function readLineIds(organizationId: string, recordId: RecordId): Promise<readonly string[]> {
+  const { entityInstanceId } = parseRecordId(recordId)
+  // Archived lines are collected too — a line left behind by its order is the
+  // strand this cascade exists to prevent, and archiving it does not change that.
+  return findRelatedInstanceIds(
+    organizationId,
+    'purchase_order_line',
+    'purchase_order_line_purchase_order',
+    [entityInstanceId]
+  )
 }

--- a/packages/lib/src/field-hooks/pre/related-rows.ts
+++ b/packages/lib/src/field-hooks/pre/related-rows.ts
@@ -1,0 +1,93 @@
+// packages/lib/src/field-hooks/pre/related-rows.ts
+
+import { database, schema } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import { getCachedEntityDefId, getOrgCache } from '../../cache'
+
+/**
+ * Every row of `childType` whose `relationAttribute` names one of
+ * `parentInstanceIds` — **archived rows included**.
+ *
+ * 🛑 **Included, and that is the entire point of this function.** Every delete
+ * guard previously asked this question through `UnifiedCrudHandler.listFiltered`,
+ * whose paged query hardcodes `isNull(archivedAt)` in the `baseWhere` it shares
+ * with its `COUNT(*)` (`unified-handler-queries.ts:692`). So an archived child
+ * was invisible to a guard, and that broke the guards in two different
+ * directions at once:
+ *
+ *   - **A refusal under-refused.** `guardPurchaseOrderDelete` asks "does a vendor
+ *     bill name this order?". Driven against dev on 2026-08-31 it deleted
+ *     `PO-0002` while an ARCHIVED bill still named it — and
+ *     `sweepEntityFieldValues` then removed **both halves** of the relation, so
+ *     the bill kept an empty Purchase Order cell with no trace an order ever
+ *     existed. That is the exact harm
+ *     `plans/money/tasks/21-money-parent-delete-safety.md` §0.1 opens with, and
+ *     it was caught only by an orphan count moving 1 → 2 in the §8 audit; a
+ *     query run afterwards cannot see it, because the evidence is what got
+ *     swept.
+ *   - **A cascade under-cascaded.** The same blindness leaves an archived
+ *     subpart, vendor-part, purchase-order line or bill line behind when its
+ *     parent goes — stranding exactly the row the cascade exists to collect.
+ *
+ * ⚠️ **Archived is not deleted.** `archivedAt` is a soft delete: the row is
+ * still in the table, still referenced by the three-way match, and a vendor's
+ * bill is still a document the vendor really sent. A guard asking "does
+ * anything still depend on this record?" must count it. The guards' own
+ * refusal messages say *"archive it instead"* — archiving is the sanctioned way
+ * to retire a record, which is precisely why an archived child cannot also mean
+ * "nothing depends on this any more".
+ *
+ * Modelled on {@link import('./guarded-movements').readMovementsByRelation},
+ * which reads `EntityInstance ⋈ FieldValue` directly for the same reason. Going
+ * through the shared list path instead would mean threading a flag into a query
+ * every dashboard, picker and record table also reads.
+ *
+ * @param childType entity type of the rows to find (e.g. `vendor_bill`)
+ * @param relationAttribute the child's systemAttribute holding the relation
+ * @param parentInstanceIds entity instance ids of the parents being deleted
+ * @returns matching child entity instance ids, de-duplicated. Empty when the
+ *   org has no such definition or field, which an org mid-provisioning reaches.
+ */
+export async function findRelatedInstanceIds(
+  organizationId: string,
+  childType: string,
+  relationAttribute: string,
+  parentInstanceIds: readonly string[]
+): Promise<string[]> {
+  if (parentInstanceIds.length === 0) return []
+
+  const childDefId = await getCachedEntityDefId(organizationId, childType)
+  if (!childDefId) return []
+
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([relationAttribute])) as Record<string, { id: string } | null>
+
+  const relationField = fields[relationAttribute]
+  if (!relationField) return []
+
+  const relationValue = alias(schema.FieldValue, 'guard_rel')
+
+  const rows = await database
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      relationValue,
+      and(
+        eq(relationValue.entityId, schema.EntityInstance.id),
+        eq(relationValue.organizationId, schema.EntityInstance.organizationId),
+        eq(relationValue.fieldId, relationField.id),
+        inArray(relationValue.relatedEntityId, [...parentInstanceIds])
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, childDefId)
+        // NO isNull(archivedAt) — see the docblock. Deliberate.
+      )
+    )
+
+  return [...new Set(rows.map((row) => row.id))]
+}

--- a/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.test.ts
@@ -12,6 +12,7 @@ import type { EntityPreDeleteEvent } from '../types'
 
 const h = vi.hoisted(() => ({
   listFiltered: vi.fn(),
+  findRelated: vi.fn(),
   del: vi.fn(),
   resolvePeriodLock: vi.fn(),
   postedPeriodRows: vi.fn(),
@@ -25,6 +26,8 @@ vi.mock('../../resources/crud', () => ({
     delete = h.del
   },
 }))
+
+vi.mock('./related-rows', () => ({ findRelatedInstanceIds: h.findRelated }))
 
 vi.mock('../../postings/period-lock', () => ({ resolvePeriodLock: h.resolvePeriodLock }))
 vi.mock('../../settings/settings-service', () => ({
@@ -69,11 +72,10 @@ function event(values: Record<string, unknown> = {}): EntityPreDeleteEvent {
   }
 }
 
-/** `listFiltered` answers per entity, so a test cannot confuse the two reads. */
+/** `findRelatedInstanceIds` answers per child type, so a test cannot confuse the two reads. */
 function children({ allocations = [], lines = [] }: { allocations?: string[]; lines?: string[] }) {
-  h.listFiltered.mockImplementation(
-    async ({ entityDefinitionId }: { entityDefinitionId: string }) =>
-      entityDefinitionId === 'vendor_payment_allocation' ? { ids: allocations } : { ids: lines }
+  h.findRelated.mockImplementation(async (_org: string, childType: string) =>
+    childType === 'vendor_payment_allocation' ? allocations : lines
   )
 }
 

--- a/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/vendor-bill-delete-guard.ts
@@ -9,6 +9,7 @@ import { UnifiedCrudHandler } from '../../resources/crud'
 import { unwrapStatusValue } from '../../resources/events/captured-values'
 import { VendorBillStatus } from '../../resources/registry/enum-values'
 import type { EntityPreDeleteEvent, EntityPreDeleteHandler } from '../types'
+import { findRelatedInstanceIds } from './related-rows'
 
 /**
  * The bill statuses that mean the document is already in the books or already
@@ -67,7 +68,7 @@ export const guardVendorBillDelete: EntityPreDeleteHandler = async (event) => {
 
   // Refuse BEFORE any cascade, so a rejected delete mutates nothing.
   refuseOnStatus(event)
-  await refuseIfAllocated(handler, organizationId, recordId)
+  await refuseIfAllocated(organizationId, recordId)
 
   const billedAt = await resolveAccountingDate(organizationId, billInstanceId, event)
   const settled = await settledPeriodsFor(organizationId, [billedAt])
@@ -80,7 +81,7 @@ export const guardVendorBillDelete: EntityPreDeleteHandler = async (event) => {
     )
   }
 
-  await cascadeLines(handler, recordId)
+  await cascadeLines(handler, organizationId, recordId)
 }
 
 /** The status wall, read off the values `deleteEntity` already captured. */
@@ -108,29 +109,16 @@ function unwrapStatus(value: unknown): string | null {
 }
 
 /** Refuse when a vendor payment has been applied to this bill. */
-async function refuseIfAllocated(
-  handler: UnifiedCrudHandler,
-  organizationId: string,
-  recordId: RecordId
-): Promise<void> {
-  const { ids } = await handler.listFiltered({
-    entityDefinitionId: 'vendor_payment_allocation',
-    filters: [
-      {
-        id: 'bill-allocations',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: 'bill-allocations-bill',
-            fieldId: 'vendor_payment_allocation:vendorBill',
-            operator: 'is',
-            value: recordId,
-          },
-        ],
-      },
-    ],
-    limit: 1000,
-  })
+async function refuseIfAllocated(organizationId: string, recordId: RecordId): Promise<void> {
+  const { entityInstanceId } = parseRecordId(recordId)
+  // ⚠️ Archived allocations count. Money that has been applied stays applied
+  // whether or not somebody archived the row recording it — see `related-rows.ts`.
+  const ids = await findRelatedInstanceIds(
+    organizationId,
+    'vendor_payment_allocation',
+    'vendor_payment_allocation_vendor_bill',
+    [entityInstanceId]
+  )
 
   if (ids.length > 0) {
     throw new BadRequestError(
@@ -179,25 +167,18 @@ async function resolveAccountingDate(
 }
 
 /** The bill's own lines. See the class docblock for why this one suppresses. */
-async function cascadeLines(handler: UnifiedCrudHandler, recordId: RecordId): Promise<void> {
-  const { ids } = await handler.listFiltered({
-    entityDefinitionId: 'vendor_bill_line',
-    filters: [
-      {
-        id: 'bill-lines',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: 'bill-lines-bill',
-            fieldId: 'vendor_bill_line:vendorBill',
-            operator: 'is',
-            value: recordId,
-          },
-        ],
-      },
-    ],
-    limit: 1000,
-  })
+async function cascadeLines(
+  handler: UnifiedCrudHandler,
+  organizationId: string,
+  recordId: RecordId
+): Promise<void> {
+  const { entityInstanceId } = parseRecordId(recordId)
+  const ids = await findRelatedInstanceIds(
+    organizationId,
+    'vendor_bill_line',
+    'vendor_bill_line_vendor_bill',
+    [entityInstanceId]
+  )
 
   for (const id of ids) {
     await handler.delete(toRecordId('vendor_bill_line', id), { suppressPostDeleteHooks: true })

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -693,9 +693,12 @@ export async function restoreEntity(
   const publishEvents = derivePublishEvents(ctx, options)
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
+  // 🛑 `includeArchived` — an archived row is the ONLY kind this function is
+  // ever called for, and without it the loader excluded every one of them.
   const instanceResult = await getEntityInstance({
     id: entityInstanceId,
     organizationId: ctx.organizationId,
+    includeArchived: true,
   })
   const instance = instanceResult.isOk() ? instanceResult.value : null
   if (!instance) throw new Error(`Entity not found: ${entityInstanceId}`)
@@ -743,9 +746,14 @@ export async function deleteEntity(
   const publishEvents = derivePublishEvents(ctx, options)
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
+  // 🛑 `includeArchived` — a hard delete must reach an archived row. Without it
+  // an archived record could be neither restored nor purged, so archive was a
+  // one-way door, and a guard telling the caller to "delete the bills first"
+  // was asking for something the API refused to do.
   const instanceResult = await getEntityInstance({
     id: entityInstanceId,
     organizationId: ctx.organizationId,
+    includeArchived: true,
   })
   const instance = instanceResult.isOk() ? instanceResult.value : null
   if (!instance) throw new Error(`Entity not found: ${entityInstanceId}`)


### PR DESCRIPTION
Two defects, found by driving the four money delete guards through a browser for the first time. Fixed together because the first one's remedy was impossible while the second stood.

## 1. A guard could not see an archived child

Every guard asked *"does anything still depend on this record?"* through `UnifiedCrudHandler.listFiltered`, whose paged query hardcodes `isNull(archivedAt)` into the `baseWhere` it shares with its `COUNT(*)` (`unified-handler-queries.ts:692`) — with no option to disable it. That broke the guards in **two directions at once**:

| | What happened |
| --- | --- |
| **Refusals under-refused** | `guardPurchaseOrderDelete` deleted `PO-0002` in dev while an archived vendor bill still named it |
| **Cascades under-cascaded** | archived subparts, vendor-parts and lines stranded — the exact rows the cascade exists to collect |

After the delete, `sweepEntityFieldValues` removed **both halves** of the relation, so the bill kept an empty Purchase Order cell and no trace an order had ever existed. It surfaced only because the audit's orphan count moved **1 → 2**: a query run afterwards cannot see it, because the evidence is precisely what got swept.

`readMovementsByRelation` had the same blindness, so an archived stock movement could not hold its own settled month closed.

### The fix

Threading a flag through `listFiltered` would change a query every dashboard, picker and record table also reads. So the guards move to **`field-hooks/pre/related-rows.ts`** — `EntityInstance` joined to `FieldValue` directly, no `archivedAt` predicate — modelled on `guarded-movements.ts`, which already read that way for the same reason. Seven call sites across four guards, plus the movements reader.

**`archivedAt` is a soft delete, not a delete.** The row is still there, the three-way match still references it, and a vendor's bill is still a document the vendor sent. The guards' own messages say *"archive it instead"* — archiving is how you retire a record, which is exactly why it cannot also mean *"nothing depends on this any more"*.

## 2. Archive was a one-way door

`getEntityInstance` excluded archived rows, and both `restoreEntity` and `deleteEntity` load through it. So **`restoreEntity` — whose entire purpose is to clear `archivedAt` — could never find its own target**, and answered `Entity not found` for every record it existed to serve. A hard delete failed identically. DemoOrg1's 9 purchase orders and 9 vendor bills were stuck behind it, restorable and deletable by nothing.

It also made the guard above give advice the API refused to honour: *"delete or unlink the bills first."*

The loader gains an explicit `includeArchived`, **default `false` so no read path moves**, passed by those two callers only.

## Driven

| Test | Before | Now |
| --- | --- | --- |
| Delete archived `PO-0003`, which an archived bill names | 404 — unreachable; and the guard could not see the bill anyway | **400** naming the bill |
| Restore an archived record | 404, always | **200** |
| Re-archive it | — | **200**, dev left as found |

The first row exercises both fixes in one call, and is the exact combination that silently deleted `PO-0002` earlier the same day.

## Tests

`guard-sees-archived.test.ts` (11) is **source-level on purpose**: every guard test doubles the child lookup, so a guard could revert to `listFiltered` with all 262 unit tests still green — which is how the inert guard shipped in the first place. It also asserts every delete guard on disk appears in `FIXED` or `KNOWN_UNFIXED`, so a new one cannot escape both lists.

`get-entity-instance-archived.test.ts` (3) pins the predicate: present on default and on explicit `false`, absent on `true`.

## Checks

- `src/field-hooks` + `src/resources` + `src/entity-instances`: **975 passed**
- Full `packages/lib`: **14,705 passed**, 3 failed — `108-purchasing.test.ts` (P13) is **pre-existing on `main`** from #1995 and already tracked in `plans/money/tasks/README.md`; `record-rules/batch.test.ts` and `076-mail-category-rework.test.ts` are timeout flakes that **pass in isolation** (2.4s and 7.7s tests, run while the dev server was rebuilding)
- `typecheck-ratchet --package lib`: no new errors (29, baseline 29)

## Deliberately not fixed

The **dispatch** guards — `invoice`, `order`, `quote`, `work-order`, five `listFiltered` call sites — carry the identical defect. They are pinned in `KNOWN_UNFIXED` rather than silently excluded, following the `KNOWN_UNGUARDED` precedent that is the reason `builds`, `purchase-orders` and `vendor-bills` were found rather than forgotten. Rewriting four guards nobody has driven is how the last inert one shipped; they want their own pass with a browser at the end.

https://claude.ai/code/session_01JyZZyQuwHFHuyoSRmXQVob