### PR TITLE
fix(import): five resources had no import route, so Import opened a record

### DIFF
--- a/apps/web/src/app/(protected)/app/builds/import/[jobId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/builds/import/[jobId]/page.tsx
@@ -1,0 +1,24 @@
+// apps/web/src/app/(protected)/app/builds/import/[jobId]/page.tsx
+
+import { ImportPage } from '~/components/data-import/import-page'
+
+interface PageProps {
+  params: Promise<{ jobId: string }>
+}
+
+/**
+ * Builds import page with URL-based step routing.
+ */
+export default async function BuildsImportStepPage({ params }: PageProps) {
+  const { jobId } = await params
+
+  return (
+    <ImportPage
+      entityDefinitionId='build'
+      resourceLabel='Builds'
+      basePath='/app/builds'
+      importBasePath='/app/builds/import'
+      jobId={jobId}
+    />
+  )
+}

--- a/apps/web/src/app/(protected)/app/builds/import/page.tsx
+++ b/apps/web/src/app/(protected)/app/builds/import/page.tsx
@@ -1,0 +1,11 @@
+// apps/web/src/app/(protected)/app/builds/import/page.tsx
+
+import { redirect } from 'next/navigation'
+
+/**
+ * Builds import entry point.
+ * Redirects to the upload step for a new import.
+ */
+export default function BuildsImportPage() {
+  redirect('/app/builds/import/new?step=upload')
+}

--- a/apps/web/src/app/(protected)/app/orders/import/[jobId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/orders/import/[jobId]/page.tsx
@@ -1,0 +1,24 @@
+// apps/web/src/app/(protected)/app/orders/import/[jobId]/page.tsx
+
+import { ImportPage } from '~/components/data-import/import-page'
+
+interface PageProps {
+  params: Promise<{ jobId: string }>
+}
+
+/**
+ * Orders import page with URL-based step routing.
+ */
+export default async function OrdersImportStepPage({ params }: PageProps) {
+  const { jobId } = await params
+
+  return (
+    <ImportPage
+      entityDefinitionId='order'
+      resourceLabel='Orders'
+      basePath='/app/orders'
+      importBasePath='/app/orders/import'
+      jobId={jobId}
+    />
+  )
+}

--- a/apps/web/src/app/(protected)/app/orders/import/page.tsx
+++ b/apps/web/src/app/(protected)/app/orders/import/page.tsx
@@ -1,0 +1,11 @@
+// apps/web/src/app/(protected)/app/orders/import/page.tsx
+
+import { redirect } from 'next/navigation'
+
+/**
+ * Orders import entry point.
+ * Redirects to the upload step for a new import.
+ */
+export default function OrdersImportPage() {
+  redirect('/app/orders/import/new?step=upload')
+}

--- a/apps/web/src/app/(protected)/app/products/import/[jobId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/products/import/[jobId]/page.tsx
@@ -1,0 +1,24 @@
+// apps/web/src/app/(protected)/app/products/import/[jobId]/page.tsx
+
+import { ImportPage } from '~/components/data-import/import-page'
+
+interface PageProps {
+  params: Promise<{ jobId: string }>
+}
+
+/**
+ * Products import page with URL-based step routing.
+ */
+export default async function ProductsImportStepPage({ params }: PageProps) {
+  const { jobId } = await params
+
+  return (
+    <ImportPage
+      entityDefinitionId='product'
+      resourceLabel='Products'
+      basePath='/app/products'
+      importBasePath='/app/products/import'
+      jobId={jobId}
+    />
+  )
+}

--- a/apps/web/src/app/(protected)/app/products/import/page.tsx
+++ b/apps/web/src/app/(protected)/app/products/import/page.tsx
@@ -1,0 +1,11 @@
+// apps/web/src/app/(protected)/app/products/import/page.tsx
+
+import { redirect } from 'next/navigation'
+
+/**
+ * Products import entry point.
+ * Redirects to the upload step for a new import.
+ */
+export default function ProductsImportPage() {
+  redirect('/app/products/import/new?step=upload')
+}

--- a/apps/web/src/app/(protected)/app/purchase-orders/import/[jobId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/purchase-orders/import/[jobId]/page.tsx
@@ -1,0 +1,24 @@
+// apps/web/src/app/(protected)/app/purchase-orders/import/[jobId]/page.tsx
+
+import { ImportPage } from '~/components/data-import/import-page'
+
+interface PageProps {
+  params: Promise<{ jobId: string }>
+}
+
+/**
+ * Purchase Orders import page with URL-based step routing.
+ */
+export default async function PurchaseOrdersImportStepPage({ params }: PageProps) {
+  const { jobId } = await params
+
+  return (
+    <ImportPage
+      entityDefinitionId='purchase_order'
+      resourceLabel='Purchase Orders'
+      basePath='/app/purchase-orders'
+      importBasePath='/app/purchase-orders/import'
+      jobId={jobId}
+    />
+  )
+}

--- a/apps/web/src/app/(protected)/app/purchase-orders/import/page.tsx
+++ b/apps/web/src/app/(protected)/app/purchase-orders/import/page.tsx
@@ -1,0 +1,11 @@
+// apps/web/src/app/(protected)/app/purchase-orders/import/page.tsx
+
+import { redirect } from 'next/navigation'
+
+/**
+ * Purchase Orders import entry point.
+ * Redirects to the upload step for a new import.
+ */
+export default function PurchaseOrdersImportPage() {
+  redirect('/app/purchase-orders/import/new?step=upload')
+}

--- a/apps/web/src/app/(protected)/app/vendor-bills/import/[jobId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/vendor-bills/import/[jobId]/page.tsx
@@ -1,0 +1,24 @@
+// apps/web/src/app/(protected)/app/vendor-bills/import/[jobId]/page.tsx
+
+import { ImportPage } from '~/components/data-import/import-page'
+
+interface PageProps {
+  params: Promise<{ jobId: string }>
+}
+
+/**
+ * Vendor Bills import page with URL-based step routing.
+ */
+export default async function VendorBillsImportStepPage({ params }: PageProps) {
+  const { jobId } = await params
+
+  return (
+    <ImportPage
+      entityDefinitionId='vendor_bill'
+      resourceLabel='Vendor Bills'
+      basePath='/app/vendor-bills'
+      importBasePath='/app/vendor-bills/import'
+      jobId={jobId}
+    />
+  )
+}

--- a/apps/web/src/app/(protected)/app/vendor-bills/import/page.tsx
+++ b/apps/web/src/app/(protected)/app/vendor-bills/import/page.tsx
@@ -1,0 +1,11 @@
+// apps/web/src/app/(protected)/app/vendor-bills/import/page.tsx
+
+import { redirect } from 'next/navigation'
+
+/**
+ * Vendor Bills import entry point.
+ * Redirects to the upload step for a new import.
+ */
+export default function VendorBillsImportPage() {
+  redirect('/app/vendor-bills/import/new?step=upload')
+}

--- a/apps/web/src/components/drawers/cards/part-pricing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-pricing-card.tsx
@@ -329,11 +329,11 @@ export function PartPricingCard({ recordId }: DrawerTabProps) {
           <Sparkles className='size-4 shrink-0 text-amber-600' />
           <p className='flex-1 text-xs text-muted-foreground'>
             <span className='font-medium text-foreground'>
-              {showOfferNudge ? 'No price set' : 'Not sellable'}
+              {showOfferNudge ? 'No price set.' : 'Not sellable.'}
             </span>{' '}
             {showOfferNudge
-              ? "— this finished good isn't sellable yet. Check Sellable to set a price."
-              : "— this finished good's catalog item is inactive. Re-check Sellable to sell it again."}
+              ? "This finished good isn't sellable yet. Check Sellable to set a price."
+              : "This finished good's catalog item is inactive. Re-check Sellable to sell it again."}
           </p>
         </div>
       )}

--- a/apps/web/src/test/import-routes.test.ts
+++ b/apps/web/src/test/import-routes.test.ts
@@ -1,0 +1,40 @@
+// apps/web/src/test/import-routes.test.ts
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const APP_DIR = join(process.cwd(), 'src/app/(protected)/app')
+
+/**
+ * Every records page must ship an import route.
+ *
+ * 🛑 `RecordsView` renders the Import menu unconditionally at
+ * `${basePath}/import`. A resource that owns `[recordId]/page.tsx` but no
+ * `import/` folder does not 404 — the detail route swallows the segment and the
+ * page reads "Record not found", because `import` is taken for a record id.
+ * That is exactly what happened to orders, products, purchase orders, vendor
+ * bills and builds: each was added without the two route files, and the bug
+ * only surfaced when someone clicked Import.
+ */
+describe('import routes', () => {
+  const recordsPages = readdirSync(APP_DIR).filter((entry) => {
+    const dir = join(APP_DIR, entry)
+    if (!statSync(dir).isDirectory()) return false
+    try {
+      return readFileSync(join(dir, 'page.tsx'), 'utf8').includes('<RecordsView')
+    } catch {
+      return false
+    }
+  })
+
+  it('finds the records pages', () => {
+    expect(recordsPages.length).toBeGreaterThan(5)
+  })
+
+  it.each(recordsPages)('%s has an import route', (slug) => {
+    const importDir = join(APP_DIR, slug, 'import')
+    expect(statSync(join(importDir, 'page.tsx')).isFile()).toBe(true)
+    expect(statSync(join(importDir, '[jobId]', 'page.tsx')).isFile()).toBe(true)
+  })
+})


### PR DESCRIPTION
## The bug

Clicking **Import / Export → Import data** on Orders (and four other resources)
lands on a page that says **"Record not found"**.

## Cause

`RecordsView` renders the Import menu unconditionally at `${basePath}/import`
([records-view.tsx:986](apps/web/src/components/records/records-view.tsx#L986)),
but each system resource needs two hand-written route files of its own:
`import/page.tsx` and `import/[jobId]/page.tsx`. Nine resources have them.
Five never got them when they were added:

| Resource | Def |
| --- | --- |
| builds | `build` |
| orders | `order` |
| products | `product` |
| purchase-orders | `purchase_order` |
| vendor-bills | `vendor_bill` |

With no `import/` folder, Next does not 404. It falls through to the sibling
dynamic segment `[recordId]/page.tsx`, so `/app/orders/import` renders
`<DetailView apiSlug='order' instanceId='import' />` and the detail view
correctly reports that no record with the id `import` exists.

This predates named importers rather than being caused by them. Parts worked
because it has had an import route since #384; #1889/#1892 only touched parts.

## The fix

- The ten missing route files, copied from the existing `companies`/`tickets`
  shape.
- `apps/web/src/test/import-routes.test.ts` scans `(protected)/app` for pages
  mounting `<RecordsView` and asserts each has both import files. Worth having
  because the symptom is a plausible-looking detail page rather than a 404, so
  the next resource added would repeat this silently.

Also drops the em dashes from the part pricing card's nudge copy.

## Checks

- `pnpm exec vitest run src/test/import-routes.test.ts` — 14 passed
- `pnpm --filter @auxx/web typecheck` — clean

https://claude.ai/code/session_01MGwcfFtTyUkF5S789FHTSN
