### PR TITLE
feat(parts): give the auto-build switch a screen to live on

### DIFF
--- a/apps/web/src/app/(protected)/app/parts/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/parts/dashboard/page.tsx
@@ -1,0 +1,14 @@
+// apps/web/src/app/(protected)/app/parts/dashboard/page.tsx
+'use client'
+
+import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
+
+/**
+ * Parts entity dashboard (plan 02) — reached via the Dashboard tab that
+ * `EntityRouteLayout` emits. The parts `layout.tsx` owns the `MainPage` shell;
+ * `EntityDashboardPage` renders its own `MainPageContent` and resolves the def
+ * server-side from the slug alone.
+ */
+export default function PartsDashboardPage() {
+  return <EntityDashboardPage slug='parts' />
+}

--- a/apps/web/src/app/(protected)/app/parts/layout.tsx
+++ b/apps/web/src/app/(protected)/app/parts/layout.tsx
@@ -2,44 +2,58 @@
 
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
-import { Package } from 'lucide-react'
+import { PermissionKey } from '@auxx/lib/permissions/client'
+import { Settings } from 'lucide-react'
 import { usePathname } from 'next/navigation'
+import { EntityRouteLayout } from '~/components/records'
+import { useAccess } from '~/providers/capabilities-provider'
 
 const BASE_PATH = '/app/parts'
 
 /**
- * Parts layout — a plain breadcrumb shell (not an `EntityRouteLayout`; parts
- * has no Dashboard tab). `RecordsView` (mounted by `parts/page.tsx`) renders
- * its own MainPageContent and contributes the Create button via
- * `MainPageAction`.
+ * Parts layout — the shared entity route shell (Parts | Dashboard | Settings).
+ *
+ * Only the tabbed routes get it. Detail (`[partId]`) and import
+ * (`import/[jobId]`) render their own `MainPage` via `DetailView` / `ImportPage`
+ * and must bypass this one, or two `MainPage` trees nest. Same guard as
+ * `companies/layout.tsx`, with the settings clause added.
+ *
+ * `RecordsView` (mounted by `page.tsx`) renders its own `MainPageContent` and
+ * contributes the Create button through `MainPageAction`.
  */
 export default function PartsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const { can } = useAccess()
 
-  // Detail pages (via DetailView) and import pages (via ImportPage) render their
-  // own MainPage — only the list route gets this breadcrumb shell.
-  if (pathname !== BASE_PATH) {
+  const isShellRoute =
+    pathname === BASE_PATH ||
+    pathname.startsWith(`${BASE_PATH}/dashboard`) ||
+    pathname.startsWith(`${BASE_PATH}/settings`)
+
+  if (!isShellRoute) {
     return <>{children}</>
   }
 
   return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem
-            title='Parts'
-            href={BASE_PATH}
-            icon={<Package className='size-4' />}
-          />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
+    <EntityRouteLayout
+      slug='parts'
+      basePath={BASE_PATH}
+      extraTabs={[
+        {
+          value: 'settings',
+          label: 'Settings',
+          icon: <Settings />,
+          // The segment, never `settings/general`: `MainPageTabs` matches by
+          // LONGEST PREFIX, so a leaf href makes every other settings page fall
+          // through to the `/app/parts` prefix and light up the Parts tab.
+          href: `${BASE_PATH}/settings`,
+          // Mirrors what the page and the mutation both assert. Hiding it can
+          // collapse the strip to a single tab, at which point `MainPageTabs`
+          // drops the whole control — that is intended, not a bug to patch.
+          hidden: !can(PermissionKey.settingsManage),
+        },
+      ]}>
       {children}
-    </MainPage>
+    </EntityRouteLayout>
   )
 }

--- a/apps/web/src/app/(protected)/app/parts/settings/general/page.tsx
+++ b/apps/web/src/app/(protected)/app/parts/settings/general/page.tsx
@@ -1,0 +1,7 @@
+// apps/web/src/app/(protected)/app/parts/settings/general/page.tsx
+
+import { PartsGeneralSettingsPage } from '~/components/manufacturing/ui/settings/parts-settings-page'
+
+export default function Page() {
+  return <PartsGeneralSettingsPage />
+}

--- a/apps/web/src/app/(protected)/app/parts/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/parts/settings/layout.tsx
@@ -1,0 +1,56 @@
+// apps/web/src/app/(protected)/app/parts/settings/layout.tsx
+
+'use client'
+
+import { MainPageContent } from '@auxx/ui/components/main-page'
+import { SlidersHorizontal } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import SidebarSecondary from '~/components/global/sidebar-secondary'
+import type { SidebarProps } from '~/constants/menu'
+
+/**
+ * Parts settings navigation (25-parts-settings-tab.md §3) — ONE page.
+ *
+ * Auto-build is the only org setting the parts domain owns today: receiving has
+ * none, and the `manufacturing.*` absorption rates live in Accounting > General,
+ * where a per-part override already overrides them.
+ */
+const PARTS_SETTINGS: SidebarProps[] = [
+  {
+    id: 'parts-settings',
+    label: 'Parts',
+    type: 'header',
+    items: [
+      {
+        id: 'parts-settings-general',
+        label: 'General',
+        slug: 'general',
+        icon: <SlidersHorizontal />,
+        description: 'Whether an order raises a build, and for which parts',
+        keywords: ['auto-build', 'production', 'manufacturing', 'orders'],
+      },
+    ],
+  },
+]
+
+export default function PartsSettingsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const pages = pathname.split('/')
+  const page = pages[pages.length - 1]
+
+  return (
+    <MainPageContent>
+      {/* `md:` must match SidebarSecondary's own breakpoint — at `sm:` the sidebar is
+          still in mobile-disclosure mode with no fixed width and collapses to a sliver. */}
+      <div className='flex flex-col md:flex-row h-full flex-1 overflow-hidden'>
+        <SidebarSecondary
+          items={PARTS_SETTINGS}
+          baseUrl='/app/parts/settings'
+          current={page}
+          title='Settings'
+        />
+        <div className='relative flex h-full w-full flex-1 grow overflow-hidden'>{children}</div>
+      </div>
+    </MainPageContent>
+  )
+}

--- a/apps/web/src/app/(protected)/app/parts/settings/page.tsx
+++ b/apps/web/src/app/(protected)/app/parts/settings/page.tsx
@@ -1,0 +1,19 @@
+// apps/web/src/app/(protected)/app/parts/settings/page.tsx
+
+import { redirect } from 'next/navigation'
+
+/**
+ * Index route for the parts settings segment.
+ *
+ * Two things need it. `SidebarSecondary` always links to `${baseUrl}/${slug}`
+ * with no empty-slug support, and `MainPageTabs` derives its active tab by
+ * LONGEST-PREFIX match on the pathname — so the Settings tab has to point at
+ * this segment rather than at a leaf, or every settings page falls through to
+ * the `/app/parts` prefix and lights up the Parts tab instead. Same shape as
+ * `accounting/settings/page.tsx`, which recorded that failure.
+ */
+function PartsSettings() {
+  redirect('/app/parts/settings/general')
+}
+
+export default PartsSettings

--- a/apps/web/src/components/manufacturing/ui/settings/parts-settings-page.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/parts-settings-page.tsx
@@ -1,0 +1,166 @@
+// apps/web/src/components/manufacturing/ui/settings/parts-settings-page.tsx
+'use client'
+
+// Parts > Settings > General (25-parts-settings-tab.md §4).
+//
+// Shape A, the sectioned form page: `SettingsPage` + `SettingsSection` +
+// `FieldPanel` + `SettingsFieldRow`, over one `useDirtyDraft` slice and one
+// `FormSaveBar`. One section, one column — there is not enough here for the
+// two-column flow `accounting/ui/settings/general-settings-page.tsx` uses.
+//
+// 🛑 Draft keys are scoped explicitly. `useSettings({ scope: 'GENERAL' })`
+// returns EVERY `GENERAL`-scope setting in the whole app and both keys here are
+// `GENERAL` (there is no `INVENTORY` value in the `SettingScope` pg enum), so an
+// unscoped save would clobber unrelated settings.
+
+import { PermissionKey } from '@auxx/lib/permissions/client'
+import type { SettingValue } from '@auxx/lib/settings/client'
+import { Factory } from 'lucide-react'
+import { FieldPanel } from '~/components/global/forms/field-panel'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useSettings } from '~/hooks/use-settings'
+import { useRequireCapability } from '~/providers/capabilities-provider'
+
+const BREADCRUMBS = [
+  { title: 'Parts', href: '/app/parts' },
+  { title: 'Settings' },
+  { title: 'General' },
+]
+
+const PAGE_DESCRIPTION = 'Whether an order raises a build, and for which parts.'
+
+/**
+ * The two catalog keys this page owns.
+ *
+ * 🛑 The other two `inventory.autoBuild*` keys are deliberately absent, and
+ * neither omission is an oversight:
+ *
+ * - `inventory.autoBuildEnabledAt` is written by the settings write path itself.
+ *   Both `updateOrganizationSetting` and `batchUpdateOrganizationSettings` read
+ *   the previous value BEFORE the upsert and call `stampAutoBuildEnabledAt` on
+ *   an off->on transition (AB8). Putting it in a draft would write a stale value
+ *   back in the same batch that flips the switch, defeating the stamp — and the
+ *   stamp is the only thing between turning auto-build on and manufacturing
+ *   against years of back-filled order history.
+ * - `inventory.autoBuildStatus` has ONE legal value: `resolveAutoBuildStatus`
+ *   ignores its argument and returns `'planned'` unconditionally (AB5). A select
+ *   with one option is a control that cannot be operated, and it would advertise
+ *   a `completed` mode that aborts `completeBuild` on its first run.
+ */
+const PARTS_SETTINGS_KEYS = {
+  autoBuildFromOrders: 'inventory.autoBuildFromOrders',
+  autoBuildStockRule: 'inventory.autoBuildStockRule',
+} as const
+
+const DRAFT_KEYS = [
+  PARTS_SETTINGS_KEYS.autoBuildFromOrders,
+  PARTS_SETTINGS_KEYS.autoBuildStockRule,
+] as const
+
+export function PartsGeneralSettingsPage() {
+  // Matches the server exactly: `setting.updateOrganizationSetting` and
+  // `setting.batchUpdateOrganizationSettings` both assert `settingsManage`, so
+  // the client gate cannot be more permissive than the mutation. There is no
+  // `inventory.*` or `parts.*` permission key, and no `FeatureKey` either — the
+  // parts list itself is ungated, so a feature gate here would make Settings
+  // vanish from a module that is otherwise fully available.
+  useRequireCapability(PermissionKey.settingsManage)
+
+  const { getSetting, batchUpdateOrganizationSettings, isBatchUpdatingOrgSettings } = useSettings({
+    scope: 'GENERAL',
+  })
+
+  // Rebuilt each render; `useDirtyDraft` compares by value, so a fresh object
+  // identity never triggers a reseed.
+  const server: Record<string, SettingValue> = {}
+  for (const key of DRAFT_KEYS) server[key] = getSetting(key)
+
+  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+    isSaving: isBatchUpdatingOrgSettings,
+    onSave: (next) => {
+      const changed = DRAFT_KEYS.filter((key) => next[key] !== server[key]).map((key) => ({
+        key,
+        value: next[key] ?? null,
+      }))
+      if (changed.length > 0) batchUpdateOrganizationSettings(changed)
+    },
+  })
+
+  /** Controlled-mode props for a catalog `SettingsFieldRow` fed by this draft. */
+  const controlled = (key: (typeof DRAFT_KEYS)[number]) => ({
+    value: draft[key],
+    // SELECT inputs report a clear as `undefined`, not `null` — normalize, since
+    // `SettingValue` and the server normalizer only accept `null` for "unset".
+    onChange: (value: unknown) =>
+      patch({ [key]: (value === undefined ? null : value) as SettingValue }),
+  })
+
+  return (
+    <SettingsPage title='General' description={PAGE_DESCRIPTION} breadcrumbs={BREADCRUMBS}>
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
+        <SettingsSection
+          icon={Factory}
+          title='Automatic builds'
+          description='When an order asks for a part that is made rather than bought, raise the production run for it.'>
+          <FieldPanel
+            className='mt-1 p-0'
+            resizeId='parts-general-auto-build'
+            defaultLabelWidth={220}>
+            <SettingsFieldRow
+              settingKey={PARTS_SETTINGS_KEYS.autoBuildFromOrders}
+              title='Raise builds from orders'
+              {...controlled(PARTS_SETTINGS_KEYS.autoBuildFromOrders)}
+            />
+            <SettingsFieldRow
+              settingKey={PARTS_SETTINGS_KEYS.autoBuildStockRule}
+              title='When to raise one'
+              {...controlled(PARTS_SETTINGS_KEYS.autoBuildStockRule)}
+            />
+          </FieldPanel>
+
+          {/*
+            Three things that are true, non-obvious, and will otherwise be
+            discovered as bugs. They live here rather than in the catalog's own
+            `description` strings, which are also the connector and API surface.
+          */}
+          <div className='space-y-2 text-muted-foreground text-xs'>
+            <p>
+              Only orders placed <strong>after</strong> this is switched on are built. Turning it
+              off and on again restarts the window, so a switch left off for three months does not
+              reopen those three months when it comes back.
+            </p>
+            <p>
+              A build is raised only for a part that is made rather than purchased{' '}
+              <strong>and</strong> has a bill of materials. An order line for a purchased component,
+              or for a part whose bill of materials is empty, raises nothing.
+            </p>
+            <p>
+              What gets raised is a <strong>planned</strong> build. It moves no stock and records no
+              cost until somebody completes it, which is what makes this safe to turn on before a
+              part has a standard cost.
+            </p>
+          </div>
+        </SettingsSection>
+
+        {/*
+          One draft, one bar. Both keys save in a single
+          `batchUpdateOrganizationSettings` call, which the settings service runs
+          in one transaction — that is the reason this page does not use
+          `SettingsFieldRow`'s default autosave. The stock rule only means
+          anything while the switch is on, so an autosaved switch would leave the
+          reconciler live under whichever rule was stored while the person is
+          still reaching for the second row.
+        */}
+        <FormSaveBar
+          dirty={dirty}
+          isSaving={isBatchUpdatingOrgSettings}
+          onSave={save}
+          onDiscard={discard}
+        />
+      </div>
+    </SettingsPage>
+  )
+}


### PR DESCRIPTION
## The problem

`inventory.autoBuildFromOrders` gates **both halves** of the order-triggered build (`drift-reconciler.ts:79` — the fingerprint stamp *and* the convergence). It shipped `defaultValue: false` with **no writer anywhere in `apps/web`**.

There was no generic fallback either: the two catalog-driven procedures that could have surfaced an undeclared key, `setting.getSettingsCatalog` and `setting.getOrganizationSettingsWithMetadata`, have **zero callers in the app** — every settings screen enumerates its keys by hand.

So the feature was complete and unreachable. No order had ever been fingerprint-stamped, and `reconcileOrderBuilds` had never executed in production.

## What this does

Parts moves onto `EntityRouteLayout` + `extraTabs` — the same shell `tickets`, `contacts`, `companies` and `custom/[slug]` already use — giving it **Parts | Dashboard | Settings**. Parts was the only one of the five entity routes that had opted out, and the only thing it was missing was a four-line `dashboard/page.tsx` (`EntityDashboardPage` takes nothing but a slug).

Adopting the shell also brings a route permission gate parts did not have (`RecordRouteGuard`'s `hasDefPresence`) and makes the breadcrumb and list tab read `resource.plural` instead of a hardcoded label.

The settings subtree copies `accounting/settings/*`: one sidebar item, one page, two rows.

## Two keys deliberately get no control

- **`autoBuildEnabledAt`** is written by the settings write path itself, which reads the previous value *before* the upsert and stamps on the off→on transition (AB8). A form field would write a stale value back in the same batch that flips the switch and defeat the backlog guard — the only thing between turning auto-build on and manufacturing against years of back-filled order history.
- **`autoBuildStatus`** has one legal value; `resolveAutoBuildStatus` ignores its argument and returns `planned` unconditionally.

## Why a save bar and not autosave

`SettingsFieldRow` autosaves by default, and two fields makes that tempting. But the stock rule only means anything while the switch is on, so an autosaved switch leaves the reconciler live under whichever rule was stored for however long it takes the person to reach the second row. One batch, one transaction.

## Driven

**B-0009 is the first order-raised build in the product's history** — order ORD-0006, qty 25, `source: 'order'`, `status: 'planned'`, **zero** stock movements written, and `order_build_revision` went from zero rows across the whole database to one byte-identical to its build's.

Also verified: `before-enablement` isolated (pre-stamp order pushed past its stock cover raised nothing, but *was* stamped — Q11's split, observed); the switch gates both halves when off; and the select round-trips both ways storing the bare scalar.

## Three findings from the drive, none in this PR's code

Each is logged as its own row in `plans/money/tasks/README.md`:

1. 🛑 **Toggling the switch off and on strands builds the feature itself raised.** The off→on re-stamp moves the window past those orders, so their builds can never be amended or cancelled again — and drift reads *clean*, because the order was never re-stamped.
2. ⚠️ **A `planned` build is invisible to `covered-by-stock`, in both directions.** A second order for a part with 25 already planned raised another 25. The same blindness makes two orders of 3 against 5 on hand build nothing.
3. ⚠️ **The line-item picker is unreachable by typing** and its `Pick product` hint is absent from the accessibility tree.

## Checks

Typecheck clean, ratchet 0 new (0 total, baseline 0), biome clean. No migration, no procedure, no permission key, no new setting key, nothing in `packages/lib`.

## Not driven

A member with `settingsManage` but without admin — needs a second seat. Note that `SettingsFieldRow` wraps org-access rows in `AdminGate`, which checks a **role**, not the capability this page and the mutation both assert. Pre-existing and product-wide, but this page makes the mismatch visible.

https://claude.ai/code/session_014fut3e25W5BQHskXGxH7vG
