### PR TITLE
fix: two silent-drop defects found driving the money tasks

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/standard-cost-section.tsx
+++ b/apps/web/src/components/accounting/ui/settings/standard-cost-section.tsx
@@ -20,6 +20,7 @@
 // with who to ask.
 
 import { FieldType } from '@auxx/database/enums'
+import { skipReasonLabel } from '@auxx/lib/builds/client'
 import { Button } from '@auxx/ui/components/button'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -35,12 +36,6 @@ import { useResource } from '~/components/resources'
 import { BaseType } from '~/components/workflow/types'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
-
-/** Why a part could not be valued, in words a person can act on. */
-const SKIP_REASON_LABEL: Record<string, string> = {
-  'no-live-cost': 'no supplier price and no priced bill of materials',
-  'no-bill-of-materials': 'classified as buildable but has no bill of materials',
-}
 
 /** How many skipped parts to name before summarising the rest. */
 const SKIPPED_VISIBLE = 8
@@ -210,8 +205,7 @@ export function StandardCostSection() {
                   <ul className='space-y-0.5'>
                     {plan.skipped.slice(0, SKIPPED_VISIBLE).map((skip) => (
                       <li key={skip.partId} className='truncate text-muted-foreground'>
-                        {skip.partName ?? skip.partId} &mdash;{' '}
-                        {SKIP_REASON_LABEL[skip.reason] ?? skip.reason}
+                        {skip.partName ?? skip.partId} &mdash; {skipReasonLabel(skip)}
                       </li>
                     ))}
                   </ul>

--- a/apps/web/src/components/manufacturing/parts/roll-standard-cost-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/roll-standard-cost-popover.tsx
@@ -17,6 +17,7 @@
 // this popover was opened from.
 
 import { FieldType } from '@auxx/database/enums'
+import { skipReasonLabel } from '@auxx/lib/builds/client'
 import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
@@ -29,12 +30,6 @@ import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapte
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
 import { api } from '~/trpc/react'
-
-/** Why a part could not be valued, in words a person can act on. */
-const SKIP_REASON_LABEL: Record<string, string> = {
-  'no-live-cost': 'no supplier price and no priced bill of materials',
-  'no-bill-of-materials': 'classified as buildable but has no bill of materials',
-}
 
 interface RollStandardCostPopoverProps {
   /** The part's entityInstanceId. */
@@ -194,8 +189,7 @@ export function RollStandardCostPopover({
                   <ul className='mt-1 space-y-0.5'>
                     {plan.skipped.slice(0, 5).map((skip) => (
                       <li key={skip.partId} className='truncate text-muted-foreground'>
-                        {skip.partName ?? skip.partId} —{' '}
-                        {SKIP_REASON_LABEL[skip.reason] ?? skip.reason}
+                        {skip.partName ?? skip.partId} — {skipReasonLabel(skip)}
                       </li>
                     ))}
                   </ul>

--- a/packages/lib/scripts/drive-standard-cost-roll.ts
+++ b/packages/lib/scripts/drive-standard-cost-roll.ts
@@ -1,0 +1,70 @@
+// packages/lib/scripts/drive-standard-cost-roll.ts
+//
+// Preview the org-wide standard cost roll against a real organization.
+//
+// PERSISTS NOTHING - `previewStandardCostRoll` is the same read the Settings >
+// Accounting > General panel makes, and it writes no field value and claims no
+// period. It exists because the Next dev server caches its compiled copy of
+// `@auxx/lib/dist`, so a lib change cannot always be seen in a browser without
+// restarting the whole turbo run.
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/drive-standard-cost-roll.ts <orgId>
+
+import { database as db } from '@auxx/database'
+import { skipReasonLabel } from '../src/builds/client'
+import { previewStandardCostRoll } from '../src/builds/standard-cost-queries'
+
+const ORG = process.argv[2] ?? ''
+
+if (!ORG) {
+  console.error('usage: drive-standard-cost-roll.ts <organizationId>')
+  process.exit(1)
+}
+
+const money = (cents: number | null | undefined) =>
+  cents == null ? '-' : `$${(cents / 100).toFixed(2)}`
+
+async function main() {
+  const result = await previewStandardCostRoll(db, ORG, { effectiveAt: new Date() })
+
+  if (result.isErr()) {
+    console.log(`REFUSED  ${result.error.message}`)
+    process.exit(0)
+  }
+
+  const plan = result.value
+  console.log(`\nwould revalue ${plan.lines.length} part(s)`)
+  for (const line of plan.lines.slice(0, 12)) {
+    console.log(
+      `  ${line.partName ?? line.partId}  ${money(line.previousStandardCost)} -> ${money(line.standardCost)}`
+    )
+  }
+  if (plan.lines.length > 12) console.log(`  ... and ${plan.lines.length - 12} more`)
+
+  console.log(`\nskipped ${plan.skipped.length} part(s), written as nothing`)
+  const byReason = new Map<string, number>()
+  for (const s of plan.skipped) byReason.set(s.reason, (byReason.get(s.reason) ?? 0) + 1)
+  for (const [reason, count] of byReason) console.log(`  ${count}x ${reason}`)
+
+  const blocked = plan.skipped.filter((s) => s.reason === 'component-not-valuable')
+  if (blocked.length > 0) {
+    console.log(`\nblocked by a component with no price:`)
+    for (const s of blocked.slice(0, 12)) {
+      console.log(`  ${s.partName ?? s.partId}  -  ${skipReasonLabel(s)}`)
+    }
+    if (blocked.length > 12) console.log(`  ... and ${blocked.length - 12} more`)
+
+    const roots = [...new Set(blocked.map((s) => s.blockedByPartName ?? '(unnamed)'))]
+    console.log(`\nthe ${roots.length} part(s) to go price:`)
+    for (const r of roots) console.log(`  ${r}`)
+  }
+
+  console.log(`\ninventory revaluation: ${money(plan.revaluationDelta)}`)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/packages/lib/src/builds/__tests__/ensure-standard-cost.test.ts
+++ b/packages/lib/src/builds/__tests__/ensure-standard-cost.test.ts
@@ -386,7 +386,13 @@ describe('ensureStandardCost: the doors it is called from', () => {
     expect(writesFor(ASSEMBLY)).toEqual([])
   })
 
-  it('surfaces the failure when the roll aborts and there is no explicit cost', async () => {
+  // ⤵️ Was 'surfaces the failure when the roll aborts'. The roll no longer aborts
+  // on an unvaluable component — it skips it — so this door now returns OK
+  // having written nothing, which is what this module's header asked for all
+  // along: *"a post-commit hook that throws on a vendor-price save is worse than
+  // one that writes nothing"*. The `explicitCost` fallback below still guards
+  // the one case that can still throw, a circular bill of materials.
+  it('writes nothing, and does not fail, when the roll can value nothing', async () => {
     h.subparts = [
       { parentPartId: ASSEMBLY, childPartId: MOTOR, quantity: 1 },
       { parentPartId: ASSEMBLY, childPartId: TUBE, quantity: 4 },
@@ -399,7 +405,7 @@ describe('ensureStandardCost: the doors it is called from', () => {
 
     const result = await ensureStandardCost(db, ORG, [MOTOR], { kind: 'manual' })
 
-    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrap().writtenPartIds).toEqual([])
     expect(h.setValueWithType).not.toHaveBeenCalled()
   })
 

--- a/packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
+++ b/packages/lib/src/builds/__tests__/standard-cost-roll.test.ts
@@ -154,27 +154,92 @@ describe('computeStandardCosts', () => {
     })
   })
 
-  it('aborts the parent with UnprocessableEntityError when a child has no standard cost', () => {
-    const naming = inputs({
-      scope: new Set([MOTOR, ASSEMBLY]),
-      partKinds: new Map<string, PartKindValue>([
-        [MOTOR, 'component'],
-        [ASSEMBLY, 'subassembly'],
-      ]),
-      // MOTOR has no `part_cost`, so it has no standard to contribute.
-      liveCosts: new Map(),
-      subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 1 }]]]),
-      partNames: new Map([
-        [MOTOR, '400Lbs Motor'],
-        [ASSEMBLY, '400Lbs motor Assembly'],
-      ]),
-    })
+  // 🛑 This used to THROW, which killed the whole run: one unpriced screw
+  // stopped every other part in the org from rolling. It skips now. What must
+  // NOT change is that the assembly is never valued at $0 for the motor -
+  // that understates it and dumps the difference into 5090.
+  it('skips the parent when a child has no standard cost, and writes nothing for it', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, ASSEMBLY]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [ASSEMBLY, 'subassembly'],
+        ]),
+        // MOTOR has no `part_cost`, so it has no standard to contribute.
+        liveCosts: new Map(),
+        subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 1 }]]]),
+        partNames: new Map([
+          [MOTOR, '400Lbs Motor'],
+          [ASSEMBLY, '400Lbs motor Assembly'],
+        ]),
+      })
+    )
 
-    expect(() => computeStandardCosts(naming)).toThrow(UnprocessableEntityError)
-    // Naming both parts is the point: silently valuing the assembly at $0 for
-    // the motor understates it and dumps the difference into 5090.
-    expect(() => computeStandardCosts(naming)).toThrow(/400Lbs motor Assembly/)
-    expect(() => computeStandardCosts(naming)).toThrow(/400Lbs Motor/)
+    expect(costs.has(ASSEMBLY)).toBe(false)
+    expect(skipped).toEqual([
+      { partId: MOTOR, reason: 'no-live-cost', partName: '400Lbs Motor' },
+      {
+        partId: ASSEMBLY,
+        reason: 'component-not-valuable',
+        partName: '400Lbs motor Assembly',
+        // The remedy is the MOTOR's price, never the assembly's.
+        blockedByPartName: '400Lbs Motor',
+      },
+    ])
+  })
+
+  // The whole point of skipping rather than aborting: everything that CAN be
+  // valued still is, in the same run.
+  it('rolls every other part in the same run', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, TUBE, ASSEMBLY]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [TUBE, 'component'],
+          [ASSEMBLY, 'subassembly'],
+        ]),
+        // TUBE is priced and unrelated; MOTOR is not and blocks ASSEMBLY.
+        liveCosts: new Map([[TUBE, 951]]),
+        subpartGraph: new Map([[ASSEMBLY, [{ childId: MOTOR, qty: 1 }]]]),
+      })
+    )
+
+    expect(costs.get(TUBE)!.standardCost).toBe(951)
+    expect(costs.has(ASSEMBLY)).toBe(false)
+    expect(skipped.map((s) => s.partId).sort()).toEqual([ASSEMBLY, MOTOR].sort())
+  })
+
+  // A three-level cascade must still name the ONE part to go price, not the
+  // sub-assembly that also gave up on it.
+  it('carries the root blame up through every level of the cascade', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, ASSEMBLY, LIFT]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [ASSEMBLY, 'subassembly'],
+          [LIFT, 'finished_good'],
+        ]),
+        liveCosts: new Map(),
+        subpartGraph: new Map<string, SubpartEdge[]>([
+          [ASSEMBLY, [{ childId: MOTOR, qty: 1 }]],
+          [LIFT, [{ childId: ASSEMBLY, qty: 2 }]],
+        ]),
+        partNames: new Map([
+          [MOTOR, '400Lbs Motor'],
+          [ASSEMBLY, 'Motor Assembly'],
+          [LIFT, 'Auxx Lift 400'],
+        ]),
+      })
+    )
+
+    expect(costs.size).toBe(0)
+    const lift = skipped.find((s) => s.partId === LIFT)
+    expect(lift?.reason).toBe('component-not-valuable')
+    // NOT 'Motor Assembly' — that is not the part anybody can price.
+    expect(lift?.blockedByPartName).toBe('400Lbs Motor')
   })
 
   it('aborts on a circular bill of materials rather than contributing zero', () => {
@@ -221,17 +286,31 @@ describe('computeStandardCosts', () => {
     expect(costs.has(ASSEMBLY)).toBe(false)
   })
 
-  it('aborts when an out-of-scope child has never been rolled', () => {
-    expect(() =>
-      computeStandardCosts(
-        inputs({
-          scope: new Set([LIFT]),
-          partKinds: new Map<string, PartKindValue>([[LIFT, 'finished_good']]),
-          subpartGraph: new Map([[LIFT, [{ childId: ASSEMBLY, qty: 2 }]]]),
-          storedStandardCosts: new Map(),
-        })
-      )
-    ).toThrow(UnprocessableEntityError)
+  it('skips when an out-of-scope child has never been rolled, blaming that child', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([LIFT]),
+        partKinds: new Map<string, PartKindValue>([[LIFT, 'finished_good']]),
+        subpartGraph: new Map([[LIFT, [{ childId: ASSEMBLY, qty: 2 }]]]),
+        storedStandardCosts: new Map(),
+        partNames: new Map([
+          [LIFT, 'Auxx Lift 400'],
+          [ASSEMBLY, 'Motor Assembly'],
+        ]),
+      })
+    )
+
+    expect(costs.has(LIFT)).toBe(false)
+    // The child is out of scope, so it was never itself skipped and has no
+    // blame entry — it IS the root, and gets named directly.
+    expect(skipped).toEqual([
+      {
+        partId: LIFT,
+        reason: 'component-not-valuable',
+        partName: 'Auxx Lift 400',
+        blockedByPartName: 'Motor Assembly',
+      },
+    ])
   })
 
   it('stores NULL, not zero, for an absorption rate that has not been declared', () => {
@@ -474,6 +553,83 @@ describe('computeStandardCosts', () => {
     expect(costs.has(MOTOR)).toBe(false)
     expect(skipped).toEqual([{ partId: MOTOR, reason: 'no-live-cost', partName: null }])
     expect(costs.get(TUBE)!.standardCost).toBe(951)
+  })
+
+  // 🛑 `part_cost` is written as a real `0` for a part with no supplier price and
+  // no priced bill of materials, not left NULL. Reading that as a cost rolled 83
+  // parts in the dev org to a $0.00 standard, which then passes every downstream
+  // `== null` guard and freezes onto an append-only movement.
+  it('skips a component whose live cost is a stored ZERO, not just a missing one', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR, TUBE]),
+        partKinds: new Map<string, PartKindValue>([
+          [MOTOR, 'component'],
+          [TUBE, 'component'],
+        ]),
+        liveCosts: new Map([
+          [MOTOR, 0],
+          [TUBE, 951],
+        ]),
+      })
+    )
+
+    expect(costs.has(MOTOR)).toBe(false)
+    expect(skipped).toEqual([{ partId: MOTOR, reason: 'no-live-cost', partName: null }])
+    expect(costs.get(TUBE)!.standardCost).toBe(951)
+  })
+
+  it('still rolls a component priced at one minor unit, so the guard is > 0 and not a threshold', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([MOTOR]),
+        partKinds: new Map<string, PartKindValue>([[MOTOR, 'component']]),
+        liveCosts: new Map([[MOTOR, 1]]),
+      })
+    )
+
+    expect(skipped).toEqual([])
+    expect(costs.get(MOTOR)!.standardCost).toBe(1)
+  })
+
+  // A zero live cost on a CHILD must skip the parent by name rather than quietly
+  // contributing nothing to it — the same treatment a missing cost already gets.
+  // 🛑 The assembly must NOT come back at 951 + 0: that is the understatement.
+  it('skips a parent whose child has a zero live cost, rather than costing the parent short', () => {
+    const { costs, skipped } = computeStandardCosts(
+      inputs({
+        scope: new Set([ASSEMBLY, MOTOR, TUBE]),
+        partKinds: new Map<string, PartKindValue>([
+          [ASSEMBLY, 'subassembly'],
+          [MOTOR, 'component'],
+          [TUBE, 'component'],
+        ]),
+        liveCosts: new Map([
+          [MOTOR, 0],
+          [TUBE, 951],
+        ]),
+        subpartGraph: new Map<string, SubpartEdge[]>([
+          [
+            ASSEMBLY,
+            [
+              { childId: MOTOR, qty: 1 },
+              { childId: TUBE, qty: 1 },
+            ],
+          ],
+        ]),
+        partNames: new Map([[MOTOR, 'Crown for 59 Motor']]),
+      })
+    )
+
+    expect(costs.has(ASSEMBLY)).toBe(false)
+    // The priced sibling still rolls — that is the point of skipping.
+    expect(costs.get(TUBE)!.standardCost).toBe(951)
+    expect(skipped.find((s) => s.partId === ASSEMBLY)).toEqual({
+      partId: ASSEMBLY,
+      reason: 'component-not-valuable',
+      partName: null,
+      blockedByPartName: 'Crown for 59 Motor',
+    })
   })
 
   it('skips a buildable part that has no bill of materials yet', () => {

--- a/packages/lib/src/builds/__tests__/standard-cost.test.ts
+++ b/packages/lib/src/builds/__tests__/standard-cost.test.ts
@@ -267,7 +267,12 @@ describe('previewStandardCostRoll', () => {
     expect(plan.lines.find((l) => l.partId === LIFT)!.standardCost).toBe(6120)
   })
 
-  it('surfaces an unpriced component as UnprocessableEntityError before anything commits', async () => {
+  // ⤵️ Was 'surfaces an unpriced component as UnprocessableEntityError'. The
+  // preview no longer fails the whole run for one unpriced part — it reports it
+  // and values everything else. The information is not lost, it moved from an
+  // error message into `skipped`, where a list can render every offender rather
+  // than only the first one the walk happened to reach.
+  it('reports an unpriced component in `skipped` instead of failing the preview', async () => {
     h.subparts = liftSubparts()
     queueOrg(PARTS, [
       fv(ASSEMBLY, FIELD.part_kind!.id, { option: 'subassembly' }),
@@ -276,8 +281,14 @@ describe('previewStandardCostRoll', () => {
 
     const result = await previewStandardCostRoll(db, ORG, { effectiveAt: EFFECTIVE_AT })
 
-    expect(result.isErr()).toBe(true)
-    expect(result._unsafeUnwrapErr().message).toMatch(/400Lbs Motor/)
+    const plan = result._unsafeUnwrap()
+    expect(plan.skipped.some((s) => s.partName === '400Lbs Motor')).toBe(true)
+    // The parent gave up too, and it names the motor rather than itself.
+    expect(
+      plan.skipped.some(
+        (s) => s.reason === 'component-not-valuable' && s.blockedByPartName === '400Lbs Motor'
+      )
+    ).toBe(true)
   })
 
   it('refuses when the part_standard_* fields have not been provisioned', async () => {
@@ -493,6 +504,42 @@ describe('readStandardCost', () => {
     expect(map.has(LIFT)).toBe(false)
   })
 
+  // 🛑 The invariant is POSITIVE, not non-null. `assertPlanIsPostable` documents
+  // this function as the reason it can exist ("a missing standard is a refusal,
+  // never a zero"), and its error says "Refusing to complete a build at zero
+  // cost" — but while a stored `0` stayed in the map, that check could not fire
+  // for the case it is named after, and `unitCost: 0` froze onto an append-only
+  // movement. A zero only ever arrives from a part that could not be valued.
+  it('omits a part rolled to ZERO, exactly like one never rolled at all', async () => {
+    h.queryQueue = [
+      [
+        fv(MOTOR, FIELD.part_standard_cost!.id, { number: 0 }),
+        fv(MOTOR, FIELD.part_standard_material_cost!.id, { number: 0 }),
+        fv(ASSEMBLY, FIELD.part_standard_cost!.id, { number: 2200 }),
+        fv(ASSEMBLY, FIELD.part_standard_material_cost!.id, { number: 2200 }),
+      ],
+    ]
+
+    const result = await readStandardCost(db, ORG, [MOTOR, ASSEMBLY])
+
+    const map = result._unsafeUnwrap()
+    expect(map.has(MOTOR)).toBe(false)
+    expect(map.get(ASSEMBLY)?.standardCost).toBe(2200)
+  })
+
+  it('keeps a part standing at one minor unit, so the rule is > 0 and not a threshold', async () => {
+    h.queryQueue = [
+      [
+        fv(MOTOR, FIELD.part_standard_cost!.id, { number: 1 }),
+        fv(MOTOR, FIELD.part_standard_material_cost!.id, { number: 1 }),
+      ],
+    ]
+
+    const result = await readStandardCost(db, ORG, [MOTOR])
+
+    expect(result._unsafeUnwrap().get(MOTOR)?.standardCost).toBe(1)
+  })
+
   it('short-circuits on an empty part list without querying', async () => {
     const result = await readStandardCost(db, ORG, [])
     expect(result._unsafeUnwrap().size).toBe(0)
@@ -576,11 +623,15 @@ describe('planStandardCostRoll descendant widening', () => {
       effectiveAt: EFFECTIVE_AT,
     })
 
-    expect(result.isErr()).toBe(true)
+    // ⤵️ Was an `isErr` assertion on the message. The remedy is still the point,
+    // it is just carried structurally now: `blockedByPartName` names the part to
+    // go price, and the two screens render it through `skipReasonLabel`.
     // "Give it a price or roll it first" was wrong: it is a lie when the
     // component already HAS a price and simply has no priced bill of materials.
-    expect(result._unsafeUnwrapErr().message).toMatch(
-      /has no supplier price and no priced bill of materials/
-    )
+    const plan = result._unsafeUnwrap()
+    const lift = plan.skipped.find((s) => s.partId === LIFT)
+    expect(lift?.reason).toBe('component-not-valuable')
+    // NOT the assembly in between, which nobody can price.
+    expect(lift?.blockedByPartName).toBe('400Lbs Motor')
   })
 })

--- a/packages/lib/src/builds/client.ts
+++ b/packages/lib/src/builds/client.ts
@@ -379,4 +379,37 @@ export type {
   BuildComponentLine,
   BuildComponentOverride,
   BuildComponentPlan,
+  SkippedPart,
+  SkipReason,
 } from './types'
+
+/**
+ * Why the roll left a part alone, in words somebody can act on.
+ *
+ * 🛑 Lives here and not in either screen because there are TWO of them - the
+ * per-part popover and the org-wide section - and they were already carrying
+ * duplicate copies of this map. A reason added in lib with no label renders as
+ * its own slug, which is ugly but never wrong.
+ *
+ * ⚠️ `component-not-valuable` MUST name `blockedByPartName` rather than the part
+ * it is reported against. The part that was skipped is not the remedy: pricing
+ * a finished good does nothing: the missing price is on some component below it,
+ * possibly several levels down.
+ */
+export function skipReasonLabel(skip: {
+  reason: string
+  blockedByPartName?: string | null
+}): string {
+  switch (skip.reason) {
+    case 'no-live-cost':
+      return 'no supplier price and no priced bill of materials'
+    case 'no-bill-of-materials':
+      return 'classified as buildable but has no bill of materials'
+    case 'component-not-valuable':
+      return skip.blockedByPartName
+        ? `needs a price on "${skip.blockedByPartName}"`
+        : 'a component below it has no price'
+    default:
+      return skip.reason
+  }
+}

--- a/packages/lib/src/builds/standard-cost-queries.ts
+++ b/packages/lib/src/builds/standard-cost-queries.ts
@@ -496,10 +496,22 @@ export async function previewStandardCostRoll(
 /**
  * The batch read `completeBuild` uses: the frozen standard for these parts.
  *
- * Returns an entry ONLY for a part that has a `part_standard_cost`. A part
- * missing from the map has never been rolled, and the caller must treat that as
- * a refusal — never as a zero. `completeBuild`'s "never post a zero cost" rule
- * is the same rule stated from the other side.
+ * Returns an entry ONLY for a part that has a **usable** `part_standard_cost`. A
+ * part missing from the map has never been rolled, and the caller must treat
+ * that as a refusal — never as a zero. `completeBuild`'s "never post a zero
+ * cost" rule is the same rule stated from the other side.
+ *
+ * 🛑 **A stored `0` is omitted too, exactly like a NULL.** The invariant every
+ * caller enforces is *positive*, not *non-null*: `assertPlanIsPostable` says
+ * this function "omits a part that has never been rolled rather than defaulting
+ * it, precisely so this check can exist", and its error reads *"Refusing to
+ * complete a build at zero cost"*. Keeping a zero here made that check unable to
+ * fire for the one case it is named after — `missingStandardPartIds` stayed
+ * empty, `completeBuild` proceeded, and `unitCost: 0` froze onto an
+ * `updatable: false` movement forever. A zero standard only ever arrives from a
+ * part that could not be valued (`part_cost = 0` reads as a real cost to
+ * `planStandardCostRoll`, which is fixed at its own end in `standard-cost-roll.ts`);
+ * it is never somebody asserting a part is genuinely free.
  */
 export async function readStandardCost(
   db: Database,
@@ -555,9 +567,11 @@ export async function readStandardCost(
       }
 
       for (const [partId, entry] of draft) {
-        // No `standardCost` means the part has never been rolled. It is omitted
-        // rather than defaulted, so a caller cannot mistake absence for zero.
-        if (entry.standardCost == null) continue
+        // No `standardCost` means the part has never been rolled, and a stored
+        // `0` means it was rolled from a cost that could not value it. Both are
+        // omitted rather than defaulted, so a caller cannot mistake either for a
+        // number it may freeze onto a movement. See the header.
+        if (entry.standardCost == null || entry.standardCost <= 0) continue
         result.set(partId, {
           partId,
           standardMaterialCost: entry.standardMaterialCost ?? entry.standardCost,

--- a/packages/lib/src/builds/standard-cost-roll.ts
+++ b/packages/lib/src/builds/standard-cost-roll.ts
@@ -101,11 +101,20 @@ export interface StandardCostRollComputation {
 /**
  * Roll every in-scope part, bottom-up.
  *
- * @throws UnprocessableEntityError when a built part's component has no standard
- * cost, or when the bill of materials contains a cycle. Both abort the roll
- * rather than valuing the parent short: silently treating a missing child as
- * zero understates the finished good and dumps the difference into 5090, which
- * is the precise failure section 2.2a exists to prevent.
+ * 🛑 **A part that cannot be valued is SKIPPED, never valued short.** Treating a
+ * missing child as zero understates the finished good and dumps the difference
+ * into 5090, which is the precise failure section 2.2a exists to prevent. A
+ * skipped part keeps whatever standard it already had: stale is a state a person
+ * can see and fix, an understated number is not.
+ *
+ * ⚠️ Skipping CASCADES upward - a parent of a skipped part cannot be valued
+ * either - and every level carries the same `blockedByPartName`, so a finished
+ * good three levels up still names the one component to go price.
+ *
+ * @throws UnprocessableEntityError only when the bill of materials contains a
+ * cycle. That is a data-integrity fault rather than a pricing gap: there is no
+ * node on the cycle that could be costed even in principle, and no part to go
+ * price, so there is nothing to report and continue with.
  */
 export function computeStandardCosts(inputs: StandardCostRollInputs): StandardCostRollComputation {
   const costs = new Map<string, StandardCostComponents>()
@@ -121,6 +130,16 @@ export function computeStandardCosts(inputs: StandardCostRollInputs): StandardCo
   const name = (partId: string) => inputs.partNames?.get(partId) ?? partId
   /** The name for a REPORT, where a missing one should read as absent, not as an id. */
   const partName = (partId: string) => inputs.partNames?.get(partId) ?? null
+
+  /**
+   * partId -> the name of the part whose missing price is the ROOT cause.
+   *
+   * A part that cannot be valued on its own blames itself. A parent that gave up
+   * because a child could not be valued inherits that child's blame rather than
+   * naming the child, so a three-level cascade still points at the one screw
+   * somebody has to go price. Only populated for parts that were skipped.
+   */
+  const blameFor = new Map<string, string | null>()
 
   /**
    * The standard a PARENT should multiply by its quantity.
@@ -166,8 +185,18 @@ export function computeStandardCosts(inputs: StandardCostRollInputs): StandardCo
     // ── A purchased part: its landed cost, and nothing else ──
     if (!absorbsConversionCost(partKind)) {
       const live = inputs.liveCosts.get(partId)
-      if (live == null || !Number.isFinite(live)) {
+      // 🛑 `<= 0` belongs here with the nulls. `part_cost` is written as a real
+      // `0` for a part with no supplier price and no priced bill of materials,
+      // not left NULL, so a null-only test read "unpriced" as "worth nothing"
+      // and froze a $0.00 standard onto it. That standard then passes every
+      // downstream guard, because those test `== null` too, and ends up as
+      // `unitCost: 0` on an append-only movement. `ensureStandardCost` already
+      // refuses an explicit `unitCost <= 0` for the same reason; this is the
+      // same rule at the other door.
+      if (live == null || !Number.isFinite(live) || live <= 0) {
         skipped.push({ partId, reason: 'no-live-cost', partName: partName(partId) })
+        // Its own root cause: this is the part somebody has to go price.
+        blameFor.set(partId, partName(partId))
         return null
       }
       const material = roundMinorUnits(live)
@@ -188,6 +217,8 @@ export function computeStandardCosts(inputs: StandardCostRollInputs): StandardCo
       // bill of materials was entered has no inputs at all, so no number is
       // being understated. It is reported so it is visible, not written.
       skipped.push({ partId, reason: 'no-bill-of-materials', partName: partName(partId) })
+      // Its own root cause: this is the part whose bill of materials is missing.
+      blameFor.set(partId, partName(partId))
       return null
     }
 
@@ -195,15 +226,29 @@ export function computeStandardCosts(inputs: StandardCostRollInputs): StandardCo
     for (const child of children) {
       const childStandard = contributionOf(child.childId)
       if (childStandard == null) {
-        throw new UnprocessableEntityError(
-          // The remedy matters. Since the scope widens to descendants that have
-          // no stored standard (see `widenToUnvaluedDescendants`), a child that
-          // reaches here was either rolled and could not be valued, or is not a
-          // live part at all. Telling somebody to "give it a price" is wrong
-          // when the child already HAS one and simply has no priced bill of
-          // materials underneath it.
-          `Cannot roll standard cost for "${name(partId)}": its component "${name(child.childId)}" has no supplier price and no priced bill of materials, so it cannot be valued.`
-        )
+        // 🛑 SKIP, do not abort. This used to throw, which killed the entire
+        // run: one unpriced screw stopped every other part in the org from
+        // rolling, so the org-wide button was unusable until somebody found and
+        // priced it. Skipping writes nothing for this part - it keeps whatever
+        // standard it already had, stale but visible - and lets every part that
+        // CAN be valued be valued.
+        //
+        // ⚠️ The parent is not the remedy and naming it would be bad advice.
+        // The scope widens to descendants with no stored standard
+        // (`widenToUnvaluedDescendants`), so a child reaching here was either
+        // rolled and found unvaluable, or is not a live part at all. Either way
+        // the part to go price is the ROOT of the chain, which is what
+        // `blameFor` carries up: a finished good blames the screw, not the
+        // sub-assembly that also gave up on it.
+        const blockedByPartName = blameFor.get(child.childId) ?? partName(child.childId)
+        skipped.push({
+          partId,
+          reason: 'component-not-valuable',
+          partName: partName(partId),
+          blockedByPartName,
+        })
+        blameFor.set(partId, blockedByPartName)
+        return null
       }
       material += childStandard * child.qty
     }

--- a/packages/lib/src/builds/types.ts
+++ b/packages/lib/src/builds/types.ts
@@ -57,6 +57,17 @@ export type SkipReason =
   | 'no-live-cost'
   /** A `subassembly` / `finished_good` with no bill of materials to roll. */
   | 'no-bill-of-materials'
+  /**
+   * A built part with at least one component that could not be valued.
+   *
+   * 🛑 This USED to abort the whole run with an `UnprocessableEntityError`, so
+   * one unpriced screw blocked every other part in the org. It skips now, and
+   * the skip CASCADES: a parent of a skipped part is itself unvaluable, so it
+   * skips too, naming the same root cause rather than its own child. Whatever
+   * standard the skipped part already carries is left exactly as it was - stale
+   * is a state a person can see and fix, an understated number is not.
+   */
+  | 'component-not-valuable'
 
 /** One part the roll declined to value, with the reason a person can act on. */
 export interface SkippedPart {
@@ -64,6 +75,15 @@ export interface SkippedPart {
   reason: SkipReason
   /** `EntityInstance.displayName`, so a preview can name the part to go fix. */
   partName: string | null
+  /**
+   * For `component-not-valuable`: the descendant that actually has no price.
+   *
+   * The part named by {@link partName} is only the one the roll gave up on -
+   * pricing it is not the remedy and never was. This is the part to go price,
+   * carried up unchanged through every level of the cascade so a finished good
+   * blames the screw and not the sub-assembly.
+   */
+  blockedByPartName?: string | null
 }
 
 /** One part the roll will write, with the balance-sheet effect of writing it. */

--- a/packages/lib/src/postings/__tests__/chart-write.test.ts
+++ b/packages/lib/src/postings/__tests__/chart-write.test.ts
@@ -128,23 +128,31 @@ function whereValues(node: unknown, out: string[] = [], depth = 0): string[] {
  * fixture returning what it was told to.
  */
 function stubDb(accounts: Account[], assignments: Assignment[] = []): Database {
-  const visible = accounts.filter((a) => !a.archived && (a.organizationId ?? ORG) === ORG)
-  const fieldValues = visible.flatMap((account) => {
-    const rows: Record<string, unknown>[] = []
-    if (account.code !== undefined) {
-      rows.push({ entityId: account.id, fieldId: CODE_FIELD, valueText: account.code })
-    }
-    if (account.name !== undefined) {
-      rows.push({ entityId: account.id, fieldId: NAME_FIELD, valueText: account.name })
-    }
-    if (account.accountType !== undefined) {
-      rows.push({ entityId: account.id, fieldId: TYPE_FIELD, optionId: account.accountType })
-    }
-    if (account.isActive !== undefined) {
-      rows.push({ entityId: account.id, fieldId: ACTIVE_FIELD, valueBoolean: account.isActive })
-    }
-    return rows
-  })
+  // A create fixture seeds the row the create is ABOUT to write, so `readBack`
+  // can find it afterwards. That row must not be visible BEFORE the write, or
+  // `assertCodeIsFree` sees the account colliding with its own future self.
+  // The stub cannot model time in general; it only has to model this one edge,
+  // and `h.creates` is exactly the signal for it.
+  const notYetCreated = (a: Account) => a.id === h.createdId && h.creates.length === 0
+  const liveAccounts = () =>
+    accounts.filter((a) => !a.archived && (a.organizationId ?? ORG) === ORG && !notYetCreated(a))
+  const visibleFieldValues = () =>
+    liveAccounts().flatMap((account) => {
+      const rows: Record<string, unknown>[] = []
+      if (account.code !== undefined) {
+        rows.push({ entityId: account.id, fieldId: CODE_FIELD, valueText: account.code })
+      }
+      if (account.name !== undefined) {
+        rows.push({ entityId: account.id, fieldId: NAME_FIELD, valueText: account.name })
+      }
+      if (account.accountType !== undefined) {
+        rows.push({ entityId: account.id, fieldId: TYPE_FIELD, optionId: account.accountType })
+      }
+      if (account.isActive !== undefined) {
+        rows.push({ entityId: account.id, fieldId: ACTIVE_FIELD, valueBoolean: account.isActive })
+      }
+      return rows
+    })
 
   const rowsFor = (table: unknown, params: string[]): unknown[] => {
     if (table === schema.GlRoleAssignment) {
@@ -158,13 +166,20 @@ function stubDb(accounts: Account[], assignments: Assignment[] = []): Database {
         .map((a) => ({ role: a.role, glAccountId: a.glAccountId }))
     }
     if (table === schema.EntityInstance) {
-      return accounts
-        .filter(
-          (a) => !a.archived && params.includes(a.organizationId ?? ORG) && params.includes(a.id)
-        )
+      return liveAccounts()
+        .filter((a) => params.includes(a.organizationId ?? ORG) && params.includes(a.id))
         .map((a) => ({ id: a.id }))
     }
-    return fieldValues.filter((row) => params.includes(row.entityId as string))
+    // `assertCodeIsFree` looks a code UP rather than reading rows for known ids,
+    // so its where-params are (org, codeFieldId, code) with no entityId at all.
+    // `readChartAccountValues` also carries CODE_FIELD, but alongside the other
+    // three field ids - so the absence of NAME_FIELD is what tells them apart.
+    if (params.includes(CODE_FIELD) && !params.includes(NAME_FIELD)) {
+      return visibleFieldValues().filter(
+        (row) => row.fieldId === CODE_FIELD && params.includes(row.valueText as string)
+      )
+    }
+    return visibleFieldValues().filter((row) => params.includes(row.entityId as string))
   }
 
   return {
@@ -357,6 +372,136 @@ describe('createChartAccount', () => {
   })
 })
 
+// ─── I4: a code another live account holds ───────────────────────────────────
+//
+// 🛑 Neither gate below this module stops a duplicate, which is why a collision
+// used to return HTTP 200 carrying the OLD code with no message anywhere:
+// `validateUniqueFields` reads `values[field.id]` while this module keys by
+// systemAttribute, and the field-value layer's throw is swallowed by
+// `setValuesForEntity`'s per-field catch. `readBack` cannot cover for either -
+// a dropped code leaves a perfectly well-formed account. So the refusal has to
+// happen HERE, before the handler is called at all.
+describe('I4: a code another live account already holds', () => {
+  const RAW_MATERIALS: Account = {
+    id: 'acct_1310',
+    code: '1310',
+    name: 'Raw Materials / Parts',
+    accountType: 'asset',
+    isActive: true,
+  }
+
+  it('refuses a create whose code is taken, naming the code, and writes nothing', async () => {
+    const error = (
+      await createChartAccount(stubDb([RAW_MATERIALS]), {
+        organizationId: ORG,
+        code: '1310',
+        name: 'Something Else',
+        accountType: 'asset',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(UniqueValueConflictError)
+    expect(error.message).toBe('1310 is already in use by another account in this chart.')
+    expect(h.creates).toHaveLength(0)
+  })
+
+  it('refuses a RENUMBER onto a taken code, and writes nothing', async () => {
+    const mine: Account = {
+      id: 'acct_mine',
+      code: '1350',
+      name: 'Test Scrap Inventory',
+      accountType: 'asset',
+      isActive: true,
+    }
+
+    const error = (
+      await updateChartAccount(stubDb([RAW_MATERIALS, mine]), {
+        organizationId: ORG,
+        accountId: mine.id,
+        code: '1310',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error).toBeInstanceOf(UniqueValueConflictError)
+    expect(error.message).toBe('1310 is already in use by another account in this chart.')
+    // 🛑 The whole point. Before this guard the handler was called, dropped the
+    // field, and the caller was told it succeeded.
+    expect(h.updates).toHaveLength(0)
+  })
+
+  it('lets an account keep its own code, so any other edit still saves', async () => {
+    const result = await updateChartAccount(stubDb([RAW_MATERIALS]), {
+      organizationId: ORG,
+      accountId: RAW_MATERIALS.id,
+      code: '1310',
+      name: 'Raw Materials',
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.updates).toHaveLength(1)
+  })
+
+  it('still writes a renumber onto a free code', async () => {
+    const mine: Account = {
+      id: 'acct_mine',
+      code: '1350',
+      name: 'Test Scrap Inventory',
+      accountType: 'asset',
+      isActive: true,
+    }
+
+    const result = await updateChartAccount(stubDb([RAW_MATERIALS, mine]), {
+      organizationId: ORG,
+      accountId: mine.id,
+      code: '1355',
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.updates[0]?.values).toMatchObject({ gl_account_code: '1355' })
+  })
+
+  // Removal IS archival, and every reader of this chart excludes archived rows.
+  // A code held only by a removed account is free, or removing an account would
+  // burn its number forever.
+  it('lets an ARCHIVED account release its code', async () => {
+    const removed: Account = { ...RAW_MATERIALS, id: 'acct_old', archived: true }
+    // `h.createdId`'s row, seeded so `readBack` finds it; the stub keeps it
+    // invisible until the create actually runs.
+    const written: Account = { ...RAW_MATERIALS, id: h.createdId, name: 'Raw Materials, again' }
+
+    const result = await createChartAccount(stubDb([removed, written]), {
+      organizationId: ORG,
+      code: '1310',
+      name: 'Raw Materials, again',
+      accountType: 'asset',
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.creates).toHaveLength(1)
+  })
+
+  it('does not see a code held in ANOTHER organization', async () => {
+    const theirs: Account = { ...RAW_MATERIALS, id: 'acct_theirs', organizationId: OTHER_ORG }
+    const written: Account = { ...RAW_MATERIALS, id: h.createdId }
+
+    const result = await createChartAccount(stubDb([theirs, written]), {
+      organizationId: ORG,
+      code: '1310',
+      name: 'Raw Materials',
+      accountType: 'asset',
+      actorUserId: USER,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.creates).toHaveLength(1)
+  })
+})
+
 describe('updateChartAccount', () => {
   it('writes only the keys it was sent', async () => {
     const db = stubDb([GRNI_ACCOUNT])
@@ -463,6 +608,31 @@ describe('I1: a type change may not break a role that posts here', () => {
     expect(error.message).toContain('revenue')
     expect(error.message).toContain('liability')
     expect(h.updates).toHaveLength(0)
+  })
+
+  // Three of the five account types start with a vowel, so a hardcoded "a"
+  // rendered "a asset account" on the sentence a person is meant to act on.
+  it('picks the article from the type, so it reads "an asset" and "a revenue"', async () => {
+    const cash: Account = {
+      id: 'acct_cash',
+      code: '1000',
+      name: 'Cash',
+      accountType: 'asset',
+      isActive: true,
+    }
+    const db = stubDb([cash], [{ role: 'cash', glAccountId: cash.id }])
+
+    const error = (
+      await updateChartAccount(db, {
+        organizationId: ORG,
+        accountId: cash.id,
+        accountType: 'revenue',
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error.message).toContain('a revenue account')
+    expect(error.message).toContain('an asset account')
   })
 
   it('allows a type change the role still accepts', async () => {

--- a/packages/lib/src/postings/chart-write.ts
+++ b/packages/lib/src/postings/chart-write.ts
@@ -48,7 +48,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import {
   AuxxError,
@@ -151,6 +151,7 @@ export async function createChartAccount(
     if (!name) throw new BadRequestError('An account needs a name.', { organizationId })
 
     const { fields, defId } = await loadChartTarget(organizationId)
+    await assertCodeIsFree(db, organizationId, code, fields)
 
     const handler = crudHandler(db, organizationId, actorUserId)
     const created = await namingTheCode(code, () =>
@@ -191,6 +192,12 @@ export async function updateChartAccount(
     if (options.code !== undefined) {
       const code = options.code.trim()
       if (!code) throw new BadRequestError('An account needs a code.', { organizationId })
+      // Only when it actually moves: re-asserting an account's own code is a
+      // no-op the person cannot tell apart from any other save, and checking it
+      // would make the account collide with itself.
+      if (code !== account.code) {
+        await assertCodeIsFree(db, organizationId, code, fields, accountId)
+      }
       values.gl_account_code = code
     }
 
@@ -212,7 +219,7 @@ export async function updateChartAccount(
         const expected = ROLE_ACCOUNT_TYPES[role]
         if (expected !== options.accountType) {
           throw new UnprocessableEntityError(
-            `Cannot make ${account.code} ${account.name} a ${options.accountType} account: '${role}' (${ACCOUNT_ROLE_LABELS[role]}) posts here and must be mapped to a ${expected} account. Repoint the role first, or mark it unused.`,
+            `Cannot make ${account.code} ${account.name} ${article(options.accountType)} account: '${role}' (${ACCOUNT_ROLE_LABELS[role]}) posts here and must be mapped to ${article(expected)} account. Repoint the role first, or mark it unused.`,
             { organizationId, accountId, role }
           )
         }
@@ -342,6 +349,16 @@ function crudHandler(db: Database, organizationId: string, actorUserId: string) 
  * error serialises as a plain 409. `code` is the only unique field on
  * `gl_account`, so any conflict from a chart write is that one, and the sentence
  * a person needs is the whole of "4000 is already in use".
+ *
+ * ⚠️ **Kept deliberately, and it cannot fire today.** {@link assertCodeIsFree}
+ * now refuses a duplicate before the handler is ever called, and the two gates
+ * this wrapper was written to catch are both inert for this caller anyway (see
+ * that function's header for why). It stays as the belt to that pre-check's
+ * braces: it costs one `try`, it is already tested, and the moment either gate
+ * is repaired - which is the point of the second stage of this fix - it starts
+ * carrying real conflicts again, including the concurrent-write race the
+ * pre-check knowingly does not close. Do not delete it as dead code without
+ * reading both.
  */
 async function namingTheCode<T>(code: string, write: () => Promise<T>): Promise<T> {
   try {
@@ -425,6 +442,89 @@ async function readBack(
 }
 
 /** One live (non-archived) account, decoded, or undefined. */
+/**
+ * "an asset", "a liability". Three of the five `GlAccountTypeValue`s take "an",
+ * so a hardcoded "a" is wrong more often than not.
+ */
+function article(accountType: string): string {
+  return /^[aeiou]/i.test(accountType) ? `an ${accountType}` : `a ${accountType}`
+}
+
+/**
+ * Refuse a code another live account in this chart already holds.
+ *
+ * 🛑 **This is THE uniqueness guard for the chart, and it has to live here.**
+ * The two gates below it both fail to stop a duplicate, which is why a
+ * collision used to return HTTP 200 carrying the OLD code, with no message
+ * anywhere and the editor pane left disagreeing with the list:
+ *
+ *  1. `UnifiedCrudHandler.validateUniqueFields` reads its candidate as
+ *     `values[field.id]`, keyed by **CustomField id**. This module keys
+ *     `AccountValues` by **systemAttribute** (`gl_account_code`), exactly as
+ *     `setFieldValues` invites callers to, so the lookup is `undefined` and the
+ *     whole gate `continue`s past it.
+ *  2. The field-value layer's own uniqueness gate DOES throw - and
+ *     `setValuesForEntity`'s per-field loop catches it, logs it, records
+ *     `state: 'failed'` and carries on. Nothing reads that state (it is written
+ *     in two places and inspected in none), so the throw never reaches
+ *     `handler.update` and {@link namingTheCode} never sees it.
+ *
+ * `readBack` cannot cover for either: a dropped `code` leaves a perfectly
+ * well-formed account, so it decodes fine and reports success.
+ *
+ * ⚠️ **Check-then-write, and knowingly so.** Two concurrent creates could still
+ * both pass. There is no backstop to lose: `gl_account_code` is a `FieldValue`
+ * row with no database unique index, so the behaviour this replaces had the
+ * identical race and merely hid it behind a silent no-op. Closing it properly
+ * means a partial index on the field-value table, which is its own change.
+ */
+async function assertCodeIsFree(
+  db: Database,
+  organizationId: string,
+  code: string,
+  fields: ChartAccountFields,
+  excludeAccountId?: string
+): Promise<void> {
+  const holders = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, fields.code.id),
+        eq(schema.FieldValue.valueText, code)
+      )
+    )
+
+  const candidates = holders.map((row) => row.entityId).filter((id) => id !== excludeAccountId)
+  if (candidates.length === 0) return
+
+  // An ARCHIVED account keeps its code and does not block a new one: every
+  // reader of this chart excludes archived rows, so the code is free as far as
+  // the chart, the role picker and the resolver are concerned. That matches
+  // `removeChartAccount`'s contract, where removal IS archival.
+  const live = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        inArray(schema.EntityInstance.id, candidates),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .limit(1)
+
+  if (live.length === 0) return
+
+  throw new UniqueValueConflictError({
+    message: `${code} is already in use by another account in this chart.`,
+    conflictingValue: code,
+    fieldId: fields.code.id,
+    existingEntityId: live[0]?.id,
+  })
+}
+
 async function loadLiveAccount(
   db: Database,
   organizationId: string,

--- a/packages/lib/src/receiving/open-stock-balance.ts
+++ b/packages/lib/src/receiving/open-stock-balance.ts
@@ -246,7 +246,14 @@ async function setFirstStandardCost(
   if (standard.isErr()) throw standard.error
 
   const { standardCost, displayName } = standard.value
-  if (standardCost == null || !Number.isFinite(standardCost)) {
+  // `<= 0` is part of the post-condition, not a separate case. `ensureStandardCost`
+  // writes only where the standard IS NULL, so a part already sitting at a stored
+  // `0` comes back from it unchanged — and a null-only test would then pass on
+  // that zero and leave the part holding a standard its own opening movement
+  // disagrees with. The movement itself is safe either way (`unit_cost` is the
+  // caller's number, and `assertOpeningUnitCost` already refused `<= 0`); this is
+  // about the part not being left in a state nothing downstream can value.
+  if (standardCost == null || !Number.isFinite(standardCost) || standardCost <= 0) {
     const partLabel = displayName ? `"${displayName}"` : `part ${input.partId}`
     throw new UnprocessableEntityError(
       `Could not set a standard cost for ${partLabel}, so its opening stock was not recorded. Stock that carries no standard cost cannot be adjusted, built or closed.`,

--- a/packages/lib/src/resources/crud/__tests__/unique-field-key-shapes.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/unique-field-key-shapes.test.ts
@@ -1,0 +1,168 @@
+// packages/lib/src/resources/crud/__tests__/unique-field-key-shapes.test.ts
+//
+// 🛑 `validateUniqueFields` is the handler's PRE-WRITE uniqueness gate, and it
+// used to be a no-op for half its callers.
+//
+// Values reach the handler keyed by fieldId OR by systemAttribute. Both other
+// functions in the same call chain accept both - `setFieldValues` builds a
+// `keyToIdMap` off `systemAttribute ?? name`, and `runPreHooks` tests both keys
+// for the reason its own comment gives ("a systemAttribute-keyed update would
+// silently bypass update hooks"). This one read `values[field.id]` alone, so
+// `chart-write.ts` writing `gl_account_code` and ingest writing `primary_email`
+// skipped it entirely.
+//
+// ⚠️ What that produced was not a silent success, which is what makes it hard to
+// spot. The field-value layer has its OWN uniqueness gate and it throws - but
+// `setValuesForEntity` catches per field, records `state: 'failed'` (which
+// nothing reads) and carries on, so the record wrote without the field and the
+// caller was told it worked. `addValues` has no such catch, so the same logical
+// write propagated or vanished depending only on whether the field happened to
+// be multi-value. This gate is what makes the two agree.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Every `checkUniqueValue` call the gate made, as `{ fieldId, value }`. */
+  checked: [] as { fieldId: string; value: unknown }[],
+  /** Values that should report as taken by another record. */
+  taken: new Set<string>(),
+  fields: [] as {
+    id: string
+    name: string
+    systemAttribute: string | null
+    isUnique: boolean
+  }[],
+}))
+
+vi.mock('../../../cache', () => ({
+  getCachedCustomFields: async () => h.fields,
+  findCachedResource: async () => null,
+  getCachedResources: async () => [],
+}))
+
+vi.mock('../../../custom-fields', () => ({
+  checkUniqueValue: async ({ fieldId, value }: { fieldId: string; value: unknown }) => {
+    h.checked.push({ fieldId, value })
+    return h.taken.has(String(value))
+      ? { isErr: () => true, error: { existingEntityId: 'other_record' } }
+      : { isErr: () => false }
+  },
+}))
+
+import { UnifiedCrudHandler } from '../unified-handler'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const DEF = 'def_gl_account'
+const CODE_FIELD = 'fld_code'
+
+/** The private gate, reached the way a test may reach one. */
+function gate(handler: UnifiedCrudHandler) {
+  return (values: Record<string, unknown>, excludeEntityId?: string) =>
+    (
+      handler as unknown as {
+        validateUniqueFields: (
+          defId: string,
+          values: Record<string, unknown>,
+          excludeEntityId?: string
+        ) => Promise<void>
+      }
+    ).validateUniqueFields(DEF, values, excludeEntityId)
+}
+
+beforeEach(() => {
+  h.checked = []
+  h.taken = new Set()
+  h.fields = [
+    { id: CODE_FIELD, name: 'Code', systemAttribute: 'gl_account_code', isUnique: true },
+    { id: 'fld_name', name: 'Name', systemAttribute: 'gl_account_name', isUnique: false },
+  ]
+})
+
+describe('validateUniqueFields: the key shapes a caller may use', () => {
+  it('checks a value keyed by fieldId', async () => {
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await check({ [CODE_FIELD]: '1310' })
+
+    expect(h.checked).toEqual([{ fieldId: CODE_FIELD, value: '1310' }])
+  })
+
+  // 🛑 THE regression. This is how `chart-write.ts` and ingest key their values,
+  // and before the fix the gate looked straight past them.
+  it('checks a value keyed by systemAttribute', async () => {
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await check({ gl_account_code: '1310' })
+
+    expect(h.checked).toEqual([{ fieldId: CODE_FIELD, value: '1310' }])
+  })
+
+  it('falls back to the field NAME for a custom field with no systemAttribute', async () => {
+    h.fields = [{ id: 'fld_promo', name: 'Promo Code', systemAttribute: null, isUnique: true }]
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await check({ 'Promo Code': 'SUMMER' })
+
+    expect(h.checked).toEqual([{ fieldId: 'fld_promo', value: 'SUMMER' }])
+  })
+
+  it('refuses a taken value, naming the conflicting one', async () => {
+    h.taken.add('1310')
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await expect(check({ gl_account_code: '1310' })).rejects.toMatchObject({
+      conflictingValue: '1310',
+      fieldId: CODE_FIELD,
+      existingEntityId: 'other_record',
+    })
+  })
+
+  it('lets a record keep its own value, via excludeEntityId', async () => {
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await check({ gl_account_code: '1310' }, 'my_record')
+
+    // The exclusion is the unique checker's job; what matters here is that the
+    // gate forwarded the check rather than skipping it.
+    expect(h.checked).toHaveLength(1)
+  })
+
+  // Precedence matches `setFieldValues`, which prefers an explicit UUID match so
+  // a caller mixing both shapes in one call behaves identically in both places.
+  it('prefers the fieldId key when a caller supplies both shapes', async () => {
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await check({ [CODE_FIELD]: '1310', gl_account_code: '9999' })
+
+    expect(h.checked).toEqual([{ fieldId: CODE_FIELD, value: '1310' }])
+  })
+
+  it('ignores a field that is not unique, whichever way it is keyed', async () => {
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await check({ gl_account_name: 'Raw Materials' })
+
+    expect(h.checked).toEqual([])
+  })
+
+  it('skips a clear, so emptying a unique field never collides', async () => {
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await check({ gl_account_code: null })
+    await check({ gl_account_code: '' })
+
+    expect(h.checked).toEqual([])
+  })
+
+  it('checks each element of a multi-value field, not the array', async () => {
+    const check = gate(new UnifiedCrudHandler(ORG, USER))
+
+    await check({ gl_account_code: ['1310', '1320'] })
+
+    expect(h.checked).toEqual([
+      { fieldId: CODE_FIELD, value: '1310' },
+      { fieldId: CODE_FIELD, value: '1320' },
+    ])
+  })
+})

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -1460,7 +1460,29 @@ export class UnifiedCrudHandler {
     const uniqueFields = fields.filter((f) => f.isUnique)
 
     for (const field of uniqueFields) {
-      const value = values[field.id]
+      // 🛑 Values reach here keyed by fieldId OR by systemAttribute, and this
+      // check has to accept both or it is a no-op for half its callers.
+      // `setFieldValues` resolves both (it builds a `keyToIdMap` off
+      // `systemAttribute ?? name`) and `runPreHooks` tests both, for the reason
+      // its own comment gives: *"a systemAttribute-keyed update would silently
+      // bypass update hooks"*. This function sat between those two doing
+      // neither, so a caller keying by systemAttribute - `chart-write.ts` with
+      // `gl_account_code`, ingest with `primary_email` - skipped the gate
+      // entirely.
+      //
+      // ⚠️ What that produced was NOT a silent success. The field-value layer
+      // has its own uniqueness gate and it throws. But `setValuesForEntity`
+      // catches per field, records `state: 'failed'` (which nothing reads) and
+      // carries on, so the record wrote without the field and the caller was
+      // told it worked. `addValues` has no such catch, so the SAME logical
+      // write propagated or vanished depending on whether the field happened to
+      // be multi-value. Checking here, before any write, is what makes the two
+      // agree.
+      //
+      // Precedence matches `setFieldValues`: an explicit UUID key wins, so a
+      // caller mixing both shapes in one call behaves identically in both.
+      const key = field.id in values ? field.id : (field.systemAttribute ?? field.name)
+      const value = values[key]
       if (value === undefined || value === null || value === '') continue
 
       // Multi-value fields (`options.multi`) arrive as arrays — check each


### PR DESCRIPTION
Found by driving [`plans/money/tasks/`](../tree/main/plans/money) 15 and 16 in a browser. Both are the same shape: a guard that reads as correct, refuses correctly at the layer below, and then reports success anyway.

Two independent fixes, one commit each.

---

## 1. An unpriced part rolled to a $0.00 standard

`part_cost` is written as a real `0` for a part with no supplier price and no priced bill of materials, not left NULL. Every guard that should have caught that tested `== null`.

**In the dev org, 83 of 243 parts already sit at a zero standard**, and the roll preview offered to overwrite a real $89.00 part with $0.00.

A zero standard is not a cheap part, it is an unvaluable one. Left alone it freezes `unitCost: 0` onto an append-only `stock_movement`, which is exactly what `assertPlanIsPostable`'s header forbids:

> `readStandardCost` omits a part that has never been rolled rather than defaulting it, **precisely so this check can exist: a missing standard is a refusal, not a zero.**

Its error even reads *"Refusing to complete a build at zero cost"*, and it could not fire for the case it is named after.

### Worked example, from real data

`Auxx Lift 600 Motor Sub Assembly` has 9 components. Four are priced and total $106.84; five are not:

| Component | Qty | Price |
|---|---|---|
| Motor 590# 100Nm | 2 | $37.99 |
| Tube for 59 Motor | 2 | $11.03 |
| Idler for 59 Motor | 2 | $3.38 |
| Clamp M 40x12x7mm | 4 | $0.51 |
| Crown for 59 Motor | 2 | **none** |
| Drive wheel for 59 Motor | 2 | **none** |
| External Retaining Ring 28mm | 2 | **none** |
| Rounded Machine Key | 2 | **none** |
| Set Screw M5X0.8X8 | 12 | **none** |

The system called it $136.84. **20 physical pieces counted as $0.00.**

### The change

- `standard-cost-roll.ts` : `live <= 0` joins the nulls, so the roll stops manufacturing zeros
- `standard-cost-queries.ts` : `readStandardCost` omits a stored `0` exactly like a NULL. One line, and it makes `missingStandardPartIds`, `completeBuild` and the build dialog's existing red refusal all correct at once. Two call sites, both valuing a movement, none in web/worker/api/services/seed
- `open-stock-balance.ts` : its post-condition asserts positive rather than merely non-null

`adjustStock` needed nothing: it already had a second `unitCost <= 0` guard after the null test.

### Skip and continue, rather than abort

A built part whose component cannot be valued is now **reported and skipped**, not thrown, so one unpriced screw no longer blocks every other part in the org.

🛑 **The blame cascades to the root.** A finished good three levels up says `needs a price on "Crown for 59 Motor"` rather than naming the sub-assembly that also gave up, because nobody can price a sub-assembly. A skipped part keeps the standard it had: stale is visible, understated is not. A circular bill of materials still throws, being a data fault with no part to go price.

Driven on the dev org:

```
would revalue 130 part(s)      (previously: 0, the whole run aborted)
skipped 114 part(s), written as nothing
  85x no-live-cost
  29x component-not-valuable

the 6 part(s) to go price:
  Crown for 59 Motor / Crown for 46 Motor / Power Cable white 5' /
  Grommet 3/4" / Double Rivet 8' Black / Spring Leg
```

Six parts to price, all named in one pass, instead of six rounds of run-fail-fix.

`skipReasonLabel` in `builds/client.ts` replaces duplicate reason maps both screens were carrying.

---

## 2. A duplicate account code refused, and reported success

Retyping a chart account's code as one another account already held returned **HTTP 200 carrying the OLD code**, with no message anywhere. The editor pane showed the new number, the list beside it showed the old one, and a reload discarded the edit.

Two chained causes, and the second is much wider than the chart:

**`validateUniqueFields` read `values[field.id]`**, keyed by CustomField id. Callers key by systemAttribute too, and both other functions in the same chain accept both: `setFieldValues` builds a `keyToIdMap` off `systemAttribute ?? name`, and `runPreHooks` tests both keys for the reason its own comment gives, *"a systemAttribute-keyed update would silently bypass update hooks"*. This one sat between them doing neither.

**`setValuesForEntity` swallows the field-value layer's throw** per field, records `state: 'failed'` and carries on. That state is **produced in two places and read in none**, so the record wrote without the field and the caller was told it worked. `readBack` cannot help: a dropped code leaves a perfectly well-formed account.

### Why this is a repair, not new policy

`participant-queries.ts` already carries:

```ts
// Surface uniqueness conflicts (the email belongs to another contact) —
// silently promoting with no email hides a real, actionable problem.
if (err instanceof UniqueValueConflictError) throw err
```

That branch was **dead on the `set` path**. And the old behaviour was inconsistent with itself: `addValues` has no such catch, so the same write threw or vanished depending only on whether the field happened to be multi-value.

**Zero new test failures across 14,721 tests.**

### Also

`assertCodeIsFree` refuses a taken code in `chart-write.ts` before the handler is called, where the friendly message already lives. It is check-then-write and says so: `gl_account_code` is a `FieldValue` row with no unique index, so the behaviour it replaces had the identical race and merely hid it. Archived accounts release their code, since removal is archival.

The type-change refusal read "a asset account"; three of the five account types take "an".

---

## Tests

`validateUniqueFields` had **no coverage at all** (the six crud tests mentioning it all stub it as `async () => {}`). The new test covers both key shapes, the name fallback, precedence, clears and multi-value elements, and was verified against a reverted fix: **5 of its 9 fail without the change**.

- lib: **14,721 pass**. The one failure, `108-purchasing.test.ts`'s inert-entities grep, names only `field-hooks/pre/vendor-bill-delete-guard.*`, untouched here and last modified by #2005. Pre-existing on `main`
- Typecheck ratchets clean: lib 29/29 baseline, web 0/0
- Biome clean

## Driven in a browser

- The roll preview: 114 skipped, `needs a price on "Crown for 59 Motor"` rendering, no $0.00 write offered
- Duplicate account code on create: **409**, *"1370 is already in use by another account in this chart."*, rendered on the Code field
- Type-change refusal: *"must be mapped to an asset account"*

⚠️ **One check still owed.** The `validateUniqueFields` half is proven by unit test but not in a browser: the running Next process held the pre-fix module (compiled chunks on disk had it, `part_sku` is `isUnique` on the def, the conflicting part was live). Worth repeating after a restart: creating a part with a duplicate SKU through `record.create` must return 409, not 200 with the SKU dropped.

## Not in this PR

- **The 83 parts already at a zero standard.** Untouched, and an owner decision. No `stock_movement` has yet frozen a zero cost (verified: 0 rows database-wide), so it is still cheap to fix
- **`part_cost` being `0` rather than NULL** for an unpriced part, which is the root cause of the first half. Schema change, own blast radius
- **What `state: 'failed'` should mean to a caller.** This narrows the blast radius but does nothing for the other error classes that path swallows. Worth landing a structured log there first and reading it

`packages/lib/scripts/drive-standard-cost-roll.ts` is added alongside the existing `drive-month-end-close.ts`: read-only, and the only way to check the roll when the dev server is serving a cached lib.

https://claude.ai/code/session_01CtMTL2xQd8cbXD2ShaUmEY
