### PR TITLE
feat(parts): build a part from its own drawer

### DIFF
--- a/apps/web/src/components/drawers/cards/part-inventory-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-inventory-card.tsx
@@ -7,7 +7,6 @@ import type { ResourceFieldId } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import type { Variant } from '@auxx/ui/components/badge'
 import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -17,8 +16,7 @@ import { formatCurrency } from '@auxx/utils/currency'
 import { ChevronRight } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import { useMemo, useState } from 'react'
-import { ReceiveStockPopover } from '~/components/manufacturing/parts/receive-stock-popover'
-import { StockAdjustmentPopover } from '~/components/manufacturing/parts/stock-adjustment-popover'
+import { PartStockActions } from '~/components/manufacturing/parts/part-stock-actions'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSettings } from '~/hooks/use-settings'
@@ -48,7 +46,8 @@ const STATUS_LABEL_MAP: Record<string, string> = {
   out_of_stock: 'Out of Stock',
 }
 
-const PART_ATTRIBUTES = ['part_quantity_on_hand', 'part_stock_status'] as const
+// `part_kind` rides along for the Build gate below — one read, already made.
+const PART_ATTRIBUTES = ['part_quantity_on_hand', 'part_stock_status', 'part_kind'] as const
 
 const MOVEMENT_ATTRIBUTES = [
   'stock_movement_type',
@@ -119,14 +118,27 @@ function MovementRow({
 // Movements List (inline collapsible content)
 // ─────────────────────────────────────────────────────────────────
 
+/**
+ * The movements list, and the `Actions` popover that produces them.
+ *
+ * The three write forms live in `part-stock-actions.tsx`; this component owns
+ * only the list and hands that surface a refresh.
+ *
+ * Actions stays INSIDE this component, i.e. behind the Status row's expand,
+ * rather than being promoted to the card's always-visible top row. Promoting it
+ * would put a write action above a read-only count on a card that is otherwise a
+ * clean label/value grid; it is noted as an option and not taken here
+ * (plans/money/tasks/23 §2.1).
+ */
 function MovementsList({
   partId,
   currentQoH,
-  onAdjustSuccess,
+  partKind,
 }: {
   partId: string
   currentQoH: number
-  onAdjustSuccess: () => void
+  /** The part's stored `part_kind`, read once by the card above. */
+  partKind: string | undefined
 }) {
   const stockMovementDefId = useResourceProperty('stock_movement', 'id')
   const { getSetting } = useSettings({})
@@ -160,30 +172,32 @@ function MovementsList({
     enabled: !!partId && !!stockMovementDefId,
   })
 
-  const handleAdjustSuccess = () => {
+  /**
+   * What every write form calls when it lands.
+   *
+   * Only the movements list. The QoH number at the top of the card is NOT
+   * refetched here on purpose: every writer of it — `recalculateQoHForPart` and
+   * `batchRecalculateQoH` — ends in `publishFieldValueUpdates` with no
+   * `excludeSocketId`, and `use-resource-sync` merges that frame with no
+   * self-filter, so the acting tab repaints from realtime like every other. The
+   * alternative, `invalidateResource`, DELETES every cached field value on the
+   * part — the pattern two purchasing surfaces removed after it visibly reset
+   * their open forms.
+   */
+  const handleSuccess = () => {
     refresh()
-    onAdjustSuccess()
   }
 
   return (
     <div className='border-t border-border/50 pt-2 mt-1'>
       <div className='flex items-center justify-between mb-2'>
         <h4 className='text-xs font-semibold text-muted-foreground'>Stock Movements</h4>
-        <div className='flex items-center gap-1'>
-          <ReceiveStockPopover partId={partId} onSuccess={handleAdjustSuccess}>
-            <Button variant='outline' size='xs'>
-              Receive
-            </Button>
-          </ReceiveStockPopover>
-          <StockAdjustmentPopover
-            partId={partId}
-            currentQoH={currentQoH}
-            onSuccess={handleAdjustSuccess}>
-            <Button variant='outline' size='xs'>
-              Adjust
-            </Button>
-          </StockAdjustmentPopover>
-        </div>
+        <PartStockActions
+          partId={partId}
+          currentQoH={currentQoH}
+          partKind={partKind}
+          onSuccess={handleSuccess}
+        />
       </div>
 
       {isLoading || isLoadingRecords ? (
@@ -223,6 +237,7 @@ export function PartInventoryCard({ recordId, entityInstanceId }: DrawerTabProps
   const [isOpen, setIsOpen] = useState(false)
 
   const qoh = (values.part_quantity_on_hand as number) ?? 0
+  const partKind = values.part_kind as string | undefined
   const stockStatus =
     (values.part_stock_status as string | undefined) ?? (qoh <= 0 ? 'out_of_stock' : 'in_stock')
 
@@ -299,7 +314,7 @@ export function PartInventoryCard({ recordId, entityInstanceId }: DrawerTabProps
               }}
               exit={{ height: 0, opacity: 0, filter: 'blur(3px)', overflow: 'hidden' }}
               transition={{ type: 'spring', stiffness: 300, damping: 30 }}>
-              <MovementsList partId={partId} currentQoH={qoh} onAdjustSuccess={() => {}} />
+              <MovementsList partId={partId} currentQoH={qoh} partKind={partKind} />
             </motion.div>
           )}
         </AnimatePresence>

--- a/apps/web/src/components/manufacturing/builds/build-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-form-dialog.tsx
@@ -1,0 +1,214 @@
+// apps/web/src/components/manufacturing/builds/build-form-dialog.tsx
+'use client'
+
+// The "New build" form (plans/money/tasks/23-build-from-the-part.md §5).
+//
+// 🛑 **This exists so that `builds.create` is the only door.** Before it,
+// `build` was not in `CUSTOM_EDITORS`, so "New build" in the records view
+// resolved to the generic `EntityInstanceDialog` -> `record.create` ->
+// `UnifiedCrudHandler` and never entered `createBuild` at all — skipping both of
+// its validations. A person could raise a build against a purchased washer with
+// an empty bill of materials, and nothing said why the resulting run was
+// useless.
+//
+// It is not a money defect (`completeBuild` still refuses without a real
+// `part_standard_cost`, README B2). It is the kind that produces support tickets
+// rather than restatements, which is exactly the kind a create dialog should
+// close.
+//
+// Three fields, and no `build_status`. Status is `showInDialogs: false` and
+// every transition is a procedure with its own preconditions — `build-run-card`
+// is the only surface for them, and a run always lands `planned`.
+
+import { FieldType } from '@auxx/database/enums'
+import { getInstanceId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import type { RelationshipConfig } from '@auxx/types/custom-field'
+import { toResourceFieldId } from '@auxx/types/field'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError } from '@auxx/ui/components/toast'
+import { useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useResourceProperty } from '~/components/resources'
+import { BaseType } from '~/components/workflow/types'
+import { api } from '~/trpc/react'
+
+/** Synthetic relationship config for the ad-hoc Part picker — the `subpart-dialog` pattern. */
+const PART_RELATIONSHIP: RelationshipConfig = {
+  inverseResourceFieldId: toResourceFieldId('part', 'id'),
+  relationshipType: 'belongs_to',
+  isInverse: false,
+}
+
+interface BuildFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /**
+   * Prefills and LOCKS the part. Set when the dialog was opened from a part —
+   * changing it there would silently raise the run against something else.
+   */
+  partId?: string
+  onSuccess?: (buildId: string) => void
+}
+
+export function BuildFormDialog({
+  open,
+  onOpenChange,
+  partId: presetPartId,
+  onSuccess,
+}: BuildFormDialogProps) {
+  const partDefId = useResourceProperty('part', 'id')
+  const buildDefId = useResourceProperty('build', 'id')
+  const utils = api.useUtils()
+
+  const [partId, setPartId] = useState<string>(presetPartId ?? '')
+  const [quantity, setQuantity] = useState<number | null>(1)
+  const [notes, setNotes] = useState('')
+
+  // A fresh form every time it opens, and the preset re-applied — the dialog is
+  // kept mounted by the record editor, so stale state would otherwise carry
+  // from the last part somebody opened it against.
+  useEffect(() => {
+    if (!open) return
+    setPartId(presetPartId ?? '')
+    setQuantity(1)
+    setNotes('')
+  }, [open, presetPartId])
+
+  const createBuild = api.builds.create.useMutation({
+    onError: (error) => toastError({ title: 'Failed to raise build', description: error.message }),
+    onSuccess: async () => {
+      // `createBuild` writes on the DEFAULT lane, so the new row is announced —
+      // but the acting tab is excluded from its own record frames, so the list
+      // it was raised from still has to be told. Same set `build-run-card`
+      // invalidates, for the same reason.
+      await Promise.all([
+        utils.builds.list.invalidate(),
+        buildDefId
+          ? utils.record.listFiltered.invalidate({ entityDefinitionId: buildDefId })
+          : Promise.resolve(),
+      ])
+    },
+  })
+
+  const canSubmit = !!partId && quantity != null && quantity > 0
+
+  const handleSubmit = async () => {
+    if (!canSubmit || quantity == null) return
+    try {
+      const build = await createBuild.mutateAsync({
+        partId,
+        quantityPlanned: quantity,
+        ...(notes ? { notes } : {}),
+      })
+      onSuccess?.(build.buildId)
+      onOpenChange(false)
+    } catch {
+      // onError above already surfaced the toast. The two refusals a person
+      // meets here — a part classified as purchased, and a part with no bill of
+      // materials — are sentences from `createBuild`, deliberately not
+      // duplicated as a disabled button: this form does not read either fact,
+      // and a guess would be worse than the server's own words.
+    }
+  }
+
+  const isPending = createBuild.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='sm:max-w-[460px]' position='tc'>
+        <DialogHeader>
+          <DialogTitle>New Build</DialogTitle>
+          <DialogDescription>
+            A run always lands planned and writes no stock movements. Start and complete it from the
+            build itself.
+          </DialogDescription>
+        </DialogHeader>
+
+        <FieldPanel className='p-0' resizeId='build-form'>
+          <FieldPanelRow
+            title='Part'
+            type={BaseType.RELATION}
+            showIcon
+            isRequired
+            description='What this run produces'>
+            <FieldInputAdapter
+              fieldType={FieldType.RELATIONSHIP}
+              value={partId && partDefId ? [toRecordId(partDefId, partId)] : []}
+              onChange={(value) => {
+                const first = (value as RecordId[])[0]
+                setPartId(first ? getInstanceId(first) : '')
+              }}
+              triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+              placeholder='Select a part...'
+              disabled={isPending || !!presetPartId}
+              fieldOptions={{
+                relationship: PART_RELATIONSHIP,
+                showDefinitionIcon: true,
+                // Parts are looked up by SKU, so show it — otherwise a hit on a
+                // SKU query renders a name that looks unrelated to what was typed.
+                showSecondary: true,
+              }}
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow
+            title='Quantity'
+            type={BaseType.NUMBER}
+            showIcon
+            isRequired
+            description='Units this run intends to produce'>
+            <FieldInputAdapter
+              fieldType={FieldType.NUMBER}
+              value={quantity}
+              onChange={(val) => setQuantity((val as number) ?? null)}
+              placeholder='1'
+              disabled={isPending}
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Notes' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={notes}
+              onChange={(val) => setNotes((val as string) ?? '')}
+              placeholder='Optional notes about this run...'
+              disabled={isPending}
+              fieldOptions={{ multiline: true }}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant='outline'
+            size='sm'
+            loading={isPending}
+            loadingText='Raising...'
+            disabled={!canSubmit}
+            data-dialog-submit>
+            Raise Build <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/manufacturing/parts/build-part-form.tsx
+++ b/apps/web/src/components/manufacturing/parts/build-part-form.tsx
@@ -1,0 +1,462 @@
+// apps/web/src/components/manufacturing/parts/build-part-form.tsx
+'use client'
+
+// Build a part from its own drawer (plans/money/tasks/23-build-from-the-part.md §3).
+//
+// A part drawer could already move stock two ways — Receive and Adjust — and not
+// the third. This is the third, and it is a sibling of those two rather than a
+// mode of either.
+//
+// 🛑 **The breakdown underneath is not decoration.** `receive-stock-popover.tsx`
+// states the rule this follows: the figure that gets frozen forever must be
+// visible before it is frozen, because a number nobody can check is a number
+// nobody catches. Here it does double duty — it is also how a person sees that a
+// component has no standard cost before pressing a button that will refuse.
+//
+// ✅ It costs no new read path. `builds.previewCompletion` takes `{ partId,
+// quantityProduced }` and NEVER loads a build row, so this shows the exact
+// consumption plan, produced value and variance the run would post, from the
+// same query the completion dialog already trusts. A second read path over the
+// same arithmetic is how a preview and a write come to disagree.
+
+import { FieldType } from '@auxx/database/enums'
+import { summarizeBuildCompletion } from '@auxx/lib/builds/client'
+import type { RecordId } from '@auxx/lib/resources/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatCurrency } from '@auxx/utils/currency'
+import { keepPreviousData } from '@tanstack/react-query'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useOpenRecord } from '~/components/records/record-drill-panels'
+import { useResourceProperty } from '~/components/resources'
+import { BaseType } from '~/components/workflow/types'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+
+const PREVIEW_DEBOUNCE_MS = 250
+
+/**
+ * What every write on this surface invalidates afterwards.
+ *
+ * 🛑 `completeBuild` writes on the QUIET lane, so it emits no `record:created`
+ * frame and no open build list learns about it. The same set `build-run-card`
+ * invalidates, for the same reason.
+ *
+ * The part's own QoH is NOT here on purpose: `batchRecalculateQoH` ends in
+ * `publishFieldValueUpdates` with no `excludeSocketId`, and the client merges
+ * that frame with no self-filter, so the number at the top of the card repaints
+ * itself. Invalidating the part record would DELETE every cached field value on
+ * it — the pattern two purchasing surfaces removed after it visibly reset their
+ * open forms.
+ *
+ * Exported because the completion dialog `Plan and open...` raises is mounted by
+ * the CALLER, and it must land on the same invalidations as the form's own
+ * buttons.
+ */
+export function useBuildRefresh(onSuccess?: () => void): () => Promise<void> {
+  const utils = api.useUtils()
+  const buildDefId = useResourceProperty('build', 'id')
+
+  return useCallback(async () => {
+    await Promise.all([
+      utils.builds.list.invalidate(),
+      buildDefId
+        ? utils.record.listFiltered.invalidate({ entityDefinitionId: buildDefId })
+        : Promise.resolve(),
+    ])
+    onSuccess?.()
+  }, [utils, buildDefId, onSuccess])
+}
+
+/** A run `Plan and open...` has raised, handed up for the completion dialog. */
+export interface PlannedBuild {
+  buildId: string
+  quantityPlanned: number
+  number: string | null
+}
+
+interface BuildPartFormProps {
+  /** The part's entityInstanceId. */
+  partId: string
+  /** Whether this member may post a ledger — gates `Build now`, never `Plan` (B2). */
+  canPostLedger: boolean
+  /** Called after anything that changed the part's stock or its builds. */
+  onSuccess?: () => void
+  /** Dismiss whatever surface this form is mounted in. */
+  onDone: () => void
+  /**
+   * Hand a raised run to the caller so IT can open the completion dialog.
+   *
+   * 🛑 The dialog cannot live in here. This form unmounts the moment the run is
+   * raised — that is what dismissing the surface means — and a dialog rendered
+   * as its sibling would go with it before anybody saw it.
+   */
+  onPlanAndOpen: (planned: PlannedBuild) => void
+}
+
+/**
+ * Quantity, notes, the plan underneath, and three verbs.
+ *
+ * Mounted as a pane of the `Actions` popover (`part-stock-actions.tsx`), which
+ * owns the surface. It resets by unmounting, like its two siblings.
+ *
+ * | Button | Calls | Result |
+ * | --- | --- | --- |
+ * | `Plan` | `builds.create` | a `planned` run; writes nothing; opens its drawer |
+ * | `Plan and open...` | `builds.create` | the run, with the full completion dialog on it |
+ * | `Build now` | `builds.buildNow` | create + start + complete; ledger posted |
+ *
+ * 🛑 **`Build now` asserts BOM-standard consumption, zero scrap and the
+ * effective absorption rates.** No component overrides, no scrap, and the two
+ * absorbed amounts omitted so the server resolves them. That assertion is true
+ * for most small runs and false for some — `Plan and open...` is what the person
+ * wants when it is false, which is why this form does not grow override inputs.
+ */
+export function BuildPartForm({
+  partId,
+  canPostLedger,
+  onSuccess,
+  onDone,
+  onPlanAndOpen,
+}: BuildPartFormProps) {
+  const [quantity, setQuantity] = useState<number | null>(1)
+  const [notes, setNotes] = useState('')
+
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+  const openRecord = useOpenRecord()
+
+  const previewQuantity = useDebouncedPositive(quantity, PREVIEW_DEBOUNCE_MS)
+
+  // 🛑 `keepPreviousData` for the reason the completion dialog states: without
+  // it every keystroke changes the query key, `data` goes undefined, and the
+  // whole plan blanks — which reads as "the numbers just went away" on a form
+  // whose primary button cannot be undone.
+  const preview = api.builds.previewCompletion.useQuery(
+    { partId, quantityProduced: previewQuantity },
+    {
+      enabled: previewQuantity > 0,
+      retry: false,
+      refetchOnWindowFocus: false,
+      placeholderData: keepPreviousData,
+    }
+  )
+
+  const plan = preview.data?.plan
+  const rates = preview.data?.rates
+  const onHand = preview.data?.onHand
+
+  const summary = useMemo(() => {
+    if (!plan || plan.producedUnitCost == null || !rates) return null
+    return summarizeBuildCompletion({
+      components: plan.components,
+      producedUnitCost: plan.producedUnitCost,
+      quantityProduced: previewQuantity,
+      quantityScrapped: 0,
+      rates,
+    })
+  }, [plan, rates, previewQuantity])
+
+  /**
+   * The balance every component lands on, keyed by part.
+   *
+   * ⚠️ **A warning, never a gate.** `completeBuild` has no on-hand check at all
+   * and deliberately still has none: receiving keyed late is normal in a small
+   * shop, and a build refused on a stale count is a worse failure than a
+   * negative that a receipt corrects an hour later.
+   *
+   * 🛑 The call is recorded as the weakest one in the brief, against a number:
+   * three deliberate builds run from the completion dialog by somebody watching
+   * produced TWELVE negative balances in DemoOrg1, lowest -11. A warning would
+   * have fired three times and been ignored three times.
+   *
+   * So it is a COLUMN, not a block underneath. The old shape restated every
+   * short part in a second list below the plan — on a BOM where eight of eight
+   * go negative that is the same eight names twice, which is how a warning
+   * becomes wallpaper. The resulting balance now sits on the line it belongs to,
+   * red when it goes negative and green when it does not, so a plan that is fine
+   * says so on every row rather than only by the absence of something.
+   */
+  const resultingByPart = useMemo(() => {
+    if (!plan || !onHand) return null
+    return Object.fromEntries(
+      plan.components.map((line) => [
+        line.partId,
+        (onHand[line.partId] ?? 0) - line.quantityConsumed,
+      ])
+    ) as Record<string, number>
+  }, [plan, onHand])
+
+  const refresh = useBuildRefresh(onSuccess)
+
+  const createBuild = api.builds.create.useMutation({
+    onError: (error) => toastError({ title: 'Failed to raise build', description: error.message }),
+  })
+
+  const build = api.builds.buildNow.useMutation({
+    onError: (error) => toastError({ title: 'Failed to build', description: error.message }),
+  })
+
+  const isPending = createBuild.isPending || build.isPending
+  const canSubmit = quantity != null && quantity > 0 && !isPending
+
+  const raise = async () => {
+    if (quantity == null) return null
+    try {
+      const raised = await createBuild.mutateAsync({
+        partId,
+        quantityPlanned: quantity,
+        ...(notes ? { notes } : {}),
+      })
+      await refresh()
+      return raised
+    } catch {
+      // onError above already surfaced the toast. The two refusals a person
+      // meets here are sentences from `createBuild` — a part classified as
+      // purchased, and a part with no bill of materials — and they are not
+      // duplicated as a disabled button, because the menu item that opened this
+      // pane already applies the same two rules and this is the fallback.
+      return null
+    }
+  }
+
+  const handlePlan = async () => {
+    const raised = await raise()
+    if (!raised) return
+    onDone()
+    openRecord?.(raised.recordId as RecordId)
+  }
+
+  const handlePlanAndOpen = async () => {
+    const raised = await raise()
+    if (!raised) return
+    onDone()
+    onPlanAndOpen({
+      buildId: raised.buildId,
+      quantityPlanned: raised.quantityPlanned ?? quantity ?? 1,
+      number: raised.number,
+    })
+  }
+
+  const handleBuildNow = async () => {
+    if (quantity == null) return
+    try {
+      const outcome = await build.mutateAsync({
+        partId,
+        quantity,
+        ...(notes ? { notes } : {}),
+      })
+      await refresh()
+      onDone()
+
+      // 🛑 `buildNow` is not atomic, and this arm is why the failure comes back
+      // at a 200 rather than as an error. The run EXISTS and is `in_progress`
+      // with no movements written; saying only "failed" is what makes somebody
+      // press the button again and raise a duplicate against the same
+      // components. So the toast names it and the drawer opens on it.
+      if (outcome.status === 'left_in_progress') {
+        toastError({
+          title: `${outcome.build.number ?? 'The build'} was raised but not completed`,
+          description: outcome.reason,
+        })
+        openRecord?.(outcome.build.recordId as RecordId)
+      }
+    } catch {
+      // onError above already surfaced the toast — this arm wrote nothing.
+    }
+  }
+
+  const money = (value: number) => formatCurrency(value, { currencyCode })
+
+  return (
+    <>
+      <FieldPanel className='p-0' orientation='horizontal' defaultLabelWidth={112}>
+        <FieldPanelRow
+          title='Quantity'
+          type={BaseType.NUMBER}
+          showIcon
+          isRequired
+          description='Good units this run produces'>
+          <FieldInputAdapter
+            fieldType={FieldType.NUMBER}
+            value={quantity}
+            onChange={(val) => setQuantity((val as number) ?? null)}
+            placeholder='1'
+            disabled={isPending}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Notes' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={notes}
+            onChange={(val) => setNotes((val as string) ?? '')}
+            placeholder='e.g. Bench run'
+            disabled={isPending}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
+
+      {preview.isPending && previewQuantity > 0 ? (
+        <div className='space-y-2'>
+          <Skeleton className='h-4 w-full' />
+          <Skeleton className='h-4 w-full' />
+          <Skeleton className='h-4 w-2/3' />
+        </div>
+      ) : plan ? (
+        <div className='space-y-2'>
+          {/* No scroller of its own. The pane this form is mounted in scrolls
+              as a whole (`part-stock-actions.tsx`), and nesting a second one
+              gives two scrollbars and a list you have to scroll TO before you
+              can scroll IT. */}
+          <div className='divide-y divide-border/50 text-xs tabular-nums'>
+            {plan.components.map((line) => {
+              const resulting = resultingByPart?.[line.partId]
+              return (
+                <div key={line.partId} className='flex items-center gap-2 py-1'>
+                  <span className='flex-1 truncate'>{line.partName ?? line.partId}</span>
+                  {resulting != null && (
+                    <Badge variant={resulting < 0 ? 'red' : 'green'} size='xs' className='shrink-0'>
+                      {formatQuantity(resulting)}
+                    </Badge>
+                  )}
+                  <span className='shrink-0 text-muted-foreground'>
+                    {formatQuantity(line.quantityConsumed)}
+                    {line.unitCost != null && ` × ${money(line.unitCost)}`}
+                  </span>
+                  <span className='w-16 shrink-0 text-end'>
+                    {line.extendedCost != null ? money(line.extendedCost) : '—'}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+
+          {plan.missingStandardPartIds.length > 0 && (
+            <div className='rounded-md bg-destructive/10 p-2 text-destructive text-xs'>
+              <p className='font-medium'>
+                These parts have no standard cost, so this run cannot be completed:
+              </p>
+              <ul className='mt-1 space-y-0.5'>
+                {plan.missingStandardPartIds.map((id) => (
+                  <li key={id} className='truncate'>
+                    {nameFor(plan.components, id) ?? (id === partId ? 'This part' : id)}
+                  </li>
+                ))}
+              </ul>
+              <p className='mt-1'>
+                Roll the standard cost from the part&apos;s Costing card first. A build is never
+                posted at zero cost.
+              </p>
+            </div>
+          )}
+
+          {summary && (
+            <div className='space-y-1 rounded-md border p-2 text-xs tabular-nums'>
+              <SummaryLine label='Material' value={money(summary.materialCost)} />
+              <SummaryLine label='Labour' value={money(summary.laborCost)} />
+              <SummaryLine label='Overhead' value={money(summary.overheadCost)} />
+              <SummaryLine
+                label='Produced value'
+                value={money(summary.producedValue)}
+                className='border-border/50 border-t pt-1'
+              />
+              <SummaryLine
+                label='Variance → 5090'
+                value={`${summary.varianceAmount > 0 ? '+' : ''}${money(summary.varianceAmount)}`}
+                className='border-border/50 border-t pt-1 font-medium'
+              />
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      <div className='flex flex-wrap justify-end gap-2'>
+        <Button variant='ghost' size='xs' onClick={onDone} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant='ghost'
+          size='xs'
+          onClick={handlePlanAndOpen}
+          disabled={!canSubmit}
+          title='Raise the run and open the full completion form'>
+          Plan and open…
+        </Button>
+        <Button
+          variant='ghost'
+          size='xs'
+          onClick={handlePlan}
+          loading={createBuild.isPending}
+          loadingText='Planning...'
+          disabled={!canSubmit}>
+          Plan
+        </Button>
+        {canPostLedger && (
+          <Button
+            variant='outline'
+            size='xs'
+            onClick={handleBuildNow}
+            loading={build.isPending}
+            loadingText='Building...'
+            disabled={!canSubmit}>
+            Build now
+          </Button>
+        )}
+      </div>
+    </>
+  )
+}
+
+/**
+ * The quantity the preview is allowed to ask for.
+ *
+ * Debounced so a three-digit quantity is one request rather than three, and
+ * floored at zero so a cleared input does not fire a query the server would
+ * refuse — `quantityProduced` is `.positive()` on the procedure.
+ */
+function useDebouncedPositive(value: number | null, delayMs: number): number {
+  const [settled, setSettled] = useState(() => (value != null && value > 0 ? value : 0))
+
+  useEffect(() => {
+    const next = value != null && value > 0 ? value : 0
+    const timer = setTimeout(() => setSettled(next), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return settled
+}
+
+/** The name of an unpriced part, from the plan line that already carries it. */
+function nameFor(
+  components: readonly { partId: string; partName: string | null }[],
+  partId: string
+): string | null {
+  return components.find((line) => line.partId === partId)?.partName ?? null
+}
+
+function SummaryLine({
+  label,
+  value,
+  className,
+}: {
+  label: string
+  value: string
+  className?: string
+}) {
+  return (
+    <div className={`flex items-baseline justify-between gap-2 ${className ?? ''}`}>
+      <span className='text-muted-foreground'>{label}</span>
+      <span>{value}</span>
+    </div>
+  )
+}
+
+/** Trim a quantity's trailing zeros — `10` not `10.00`, `2.5` kept. */
+function formatQuantity(value: number): string {
+  return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)))
+}

--- a/apps/web/src/components/manufacturing/parts/part-stock-actions.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-stock-actions.tsx
@@ -1,0 +1,306 @@
+// apps/web/src/components/manufacturing/parts/part-stock-actions.tsx
+'use client'
+
+// The three ways a part drawer moves stock, behind one `Actions` button
+// (plans/money/tasks/23-build-from-the-part.md §2).
+//
+// 🛑 **This is ONE popover with two panes, and it is not a dropdown menu.** The
+// first cut was a `DropdownMenu` whose items opened three separate popovers
+// anchored on the menu's trigger. It opened and closed in the same tick, and
+// after the anchoring was fixed it worked only *sometimes* — which is the shape
+// of a race, not of a layout bug. Two Radix dismissable layers were tearing down
+// and standing up on the same click: the menu's close, the popover's open, and a
+// pointer event that belonged to both.
+//
+// So there is one layer. The `Actions` button opens a popover whose content is a
+// three-item list; choosing one swaps that SAME popover's content for the form,
+// with a back arrow. Nothing unmounts under the pointer, there is no second
+// layer to race, and the anchor never moves.
+//
+// The three forms are mounted as panes rather than wrapped in popovers of their
+// own — `ReceiveStockForm`, `StockAdjustmentForm`, `BuildPartForm`. Each resets
+// by unmounting, which a pane swap gives for free.
+
+import { resolvePartKind } from '@auxx/lib/builds/client'
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { Button } from '@auxx/ui/components/button'
+import { menuItemStyles } from '@auxx/ui/components/menu-styles'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { cn } from '@auxx/ui/lib/utils'
+import { ChevronDown, ChevronLeft } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { CompleteBuildDialog } from '~/components/manufacturing/builds/complete-build-dialog'
+import { useRecordList, useResourceProperty } from '~/components/resources'
+import { useAccess } from '~/providers/capabilities-provider'
+import { BuildPartForm, type PlannedBuild, useBuildRefresh } from './build-part-form'
+import { ReceiveStockForm } from './receive-stock-popover'
+import { StockAdjustmentForm } from './stock-adjustment-popover'
+
+/** Which of the three write forms the Actions popover is showing. */
+type StockAction = 'receive' | 'adjust' | 'build'
+
+const PANE_TITLE: Record<StockAction, string> = {
+  receive: 'Receive Stock',
+  adjust: 'Adjust Stock',
+  build: 'Build',
+}
+
+interface PartStockActionsProps {
+  /** The part's entityInstanceId. */
+  partId: string
+  /** Current quantity on hand, for the adjustment form's "Set to" mode. */
+  currentQoH: number
+  /** The part's stored `part_kind`, read once by the card that owns this. */
+  partKind: string | undefined
+  /** Called after anything that moved this part's stock. */
+  onSuccess: () => void
+}
+
+/**
+ * `Receive` / `Adjust` / `Build` in one dropdown-shaped popover.
+ *
+ * 🛑 **One popover, not a button row** (§2.1). `Receive` and `Adjust` lose one
+ * click; `Build` gains one it never had — it did not exist on this surface at
+ * all, and `builds.create` had no caller in the browser anywhere. The trigger
+ * reads the word `Actions` rather than a bare ellipsis because the whole point of
+ * the change is that Build was undiscoverable, and an icon with no word is how it
+ * stays that way.
+ */
+export function PartStockActions({
+  partId,
+  currentQoH,
+  partKind,
+  onSuccess,
+}: PartStockActionsProps) {
+  const [open, setOpen] = useState(false)
+  const [pane, setPane] = useState<StockAction | null>(null)
+  /** The run `Plan and open...` raised, waiting for the completion dialog. */
+  const [completing, setCompleting] = useState<PlannedBuild | null>(null)
+
+  const stockMovementDefId = useResourceProperty('stock_movement', 'id')
+  const buildDefId = useResourceProperty('build', 'id')
+  const subpartDefId = useResourceProperty('subpart', 'id')
+
+  // The client mirror of what `routers/builds.ts` asserts, so the item the UI
+  // hides and the door the server closes are the same door. `Plan` needs `build`
+  // alone (B2 — planning is not moving stock); `Build now` also needs
+  // `stock_movement`, which is where the rest of manufacturing puts that
+  // authority.
+  const { canEditEntity } = useAccess()
+  const canPlanBuild = !!buildDefId && canEditEntity(buildDefId)
+  const canPostLedger = canPlanBuild && !!stockMovementDefId && canEditEntity(stockMovementDefId)
+
+  // Whether the part has a bill of materials at all. Same filter shape as
+  // `part-costing-card.tsx`'s `hasSubparts` check, deliberately — same read,
+  // same question.
+  const subpartFilters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'parent-filter',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'parent-match',
+            fieldId: 'subpart:parentPart' as ResourceFieldId,
+            operator: 'is' as const,
+            value: partId,
+          },
+        ],
+      },
+    ],
+    [partId]
+  )
+  const { records: subpartRecords } = useRecordList({
+    entityDefinitionId: subpartDefId ?? '',
+    filters: subpartFilters,
+    limit: 1,
+    enabled: !!partId && !!subpartDefId,
+  })
+
+  const hasSubparts = subpartRecords.length > 0
+  const isPurchased = resolvePartKind(partKind) === 'component'
+  const canBuild = hasSubparts && !isPurchased && canPlanBuild
+
+  const refreshBuilds = useBuildRefresh(onSuccess)
+
+  /**
+   * Reset to the menu on OPEN rather than on close.
+   *
+   * `PopoverContent` animates out, so clearing the pane as it closes would show
+   * the person the menu sliding away instead of the form they were just in.
+   */
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next)
+    if (next) setPane(null)
+  }
+
+  const close = () => setOpen(false)
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <Button variant='outline' size='xs'>
+            Actions
+            <ChevronDown />
+          </Button>
+        </PopoverTrigger>
+        {/* 🛑 `p-0`, and the padding pushed inward onto the header and the
+            scroll viewport's own content. That is what puts the scrollbar on
+            the popover's EDGE instead of floating it inside a padded box, and
+            what lets the menu pane match `DropdownMenuContent` exactly — which
+            is `p-1` with `px-2 py-1` items, not the popover's default `p-4`. */}
+        <PopoverContent className={cn(pane ? 'w-96 p-0' : 'w-52 p-1')} align='end'>
+          {pane === null ? (
+            <div className='flex flex-col'>
+              <ActionItem onSelect={() => setPane('receive')}>Receive</ActionItem>
+              <ActionItem onSelect={() => setPane('adjust')}>Adjust</ActionItem>
+              {/* 🛑 The two inputs are keyed in the OPPOSITE order to the
+                  server's, deliberately. `createBuild` checks `part_kind` first
+                  and the BOM second; this checks the BOM first, because BOM
+                  presence is a structural fact while `part_kind` is a field
+                  somebody has to remember. Hidden rather than disabled with no
+                  BOM, because 82% of parts are components with no BOM and a
+                  permanently dead item on four parts in five is noise.
+                  Shown-but-disabled when the part HAS a BOM and still reads
+                  `component`, because since the derivation landed that state
+                  means somebody overrode the rule — a real answer the person is
+                  entitled to see, not an accident. */}
+              {hasSubparts && (
+                <ActionItem
+                  disabled={isPurchased || !canPlanBuild}
+                  hint={isPurchased ? 'This part is classified as purchased' : undefined}
+                  onSelect={() => setPane('build')}>
+                  Build
+                </ActionItem>
+              )}
+            </div>
+          ) : (
+            <div className='flex flex-col'>
+              <div className='flex shrink-0 items-center gap-1 px-2 pt-2'>
+                <Button
+                  variant='ghost'
+                  size='xs'
+                  aria-label='Back to actions'
+                  onClick={() => setPane(null)}>
+                  <ChevronLeft />
+                </Button>
+                <h4 className='font-semibold text-sm'>{PANE_TITLE[pane]}</h4>
+              </div>
+
+              {/* The header stays put and the FORM scrolls. `Build` is the pane
+                  that needs it — fields, then a line per component, then the
+                  shortage and missing-cost warnings, then the cost summary, then
+                  four buttons — but a receipt with six rows overflows a short
+                  viewport too, so the cap is on the pane rather than on one of
+                  them.
+                  🛑 The cap is the popover's OWN available height minus the
+                  header, on the viewport, and both halves of that matter.
+
+                  A fixed `60vh` was wrong because it is a second, independent
+                  limit inside `PopoverContent`'s
+                  `max-h-[var(--radix-popover-content-available-height)]`: when
+                  the window got short the popover clipped at its limit while the
+                  viewport still claimed 60vh, so the buttons at the bottom could
+                  be neither seen nor scrolled to.
+
+                  `flex-1 min-h-0` was wrong too, and less obviously: it makes
+                  the scroll height depend on the flex column resolving a
+                  definite height from a `max-height`-only parent, which holds
+                  while there is room and stops holding at exactly the sizes that
+                  need it. Radix sets the var on this element and CSS variables
+                  inherit, so `calc(...)` gives the viewport ONE definite cap
+                  that tracks the real space and needs nothing from the layout.
+                  `2.75rem` is the header row above it.
+
+                  `noFade` because the default mask dissolves the top field and
+                  the buttons at the bottom, which on a form reads as a rendering
+                  fault rather than as an affordance. */}
+              <ScrollArea
+                noFade
+                viewportClassName='max-h-[calc(var(--radix-popover-content-available-height,60vh)-2.75rem)]'
+                scrollbarClassName='w-1'
+                allowScrollChaining>
+                <div className='space-y-3 px-3 pt-1 pb-3'>
+                  {pane === 'receive' && (
+                    <ReceiveStockForm partId={partId} onSuccess={onSuccess} onDone={close} />
+                  )}
+                  {pane === 'adjust' && (
+                    <StockAdjustmentForm
+                      partId={partId}
+                      currentQoH={currentQoH}
+                      onSuccess={onSuccess}
+                      onDone={close}
+                    />
+                  )}
+                  {pane === 'build' && canBuild && (
+                    <BuildPartForm
+                      partId={partId}
+                      canPostLedger={canPostLedger}
+                      onSuccess={onSuccess}
+                      onDone={close}
+                      onPlanAndOpen={setCompleting}
+                    />
+                  )}
+                </div>
+              </ScrollArea>
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {/* 🛑 Mounted HERE, outside the popover, because `Plan and open...` closes
+          the popover as it raises the run — a dialog rendered inside the pane
+          would unmount before it was ever seen. */}
+      {completing && (
+        <CompleteBuildDialog
+          open
+          onOpenChange={(next) => {
+            if (!next) setCompleting(null)
+          }}
+          buildId={completing.buildId}
+          partId={partId}
+          quantityPlanned={completing.quantityPlanned}
+          number={completing.number}
+          onCompleted={refreshBuilds}
+        />
+      )}
+    </>
+  )
+}
+
+/**
+ * One row of the menu pane.
+ *
+ * A plain button rather than a `DropdownMenuItem`: the whole reason this surface
+ * is a popover is that it must not stack a menu layer on a popover layer.
+ */
+function ActionItem({
+  children,
+  hint,
+  disabled,
+  onSelect,
+}: {
+  children: React.ReactNode
+  /** Why the item is disabled, shown under it. */
+  hint?: string
+  disabled?: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type='button'
+      disabled={disabled}
+      onClick={onSelect}
+      className={cn(
+        menuItemStyles,
+        'w-full text-start hover:bg-accent/50 focus-visible:bg-accent/50',
+        hint && 'flex-col items-start gap-0'
+      )}>
+      {children}
+      {hint && <span className='text-[10px] text-muted-foreground'>{hint}</span>}
+    </button>
+  )
+}

--- a/apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
@@ -60,15 +60,23 @@ interface SupplierOption {
   terms: ReceiptCostInputs
 }
 
-interface ReceiveStockPopoverProps {
+interface ReceiveStockFormProps {
   /** The part's entityInstanceId. */
   partId: string
   onSuccess?: () => void
-  children: React.ReactNode
+  /** Dismiss whatever surface this form is mounted in. */
+  onDone: () => void
 }
 
-export function ReceiveStockPopover({ partId, onSuccess, children }: ReceiveStockPopoverProps) {
-  const [open, setOpen] = useState(false)
+/**
+ * The receipt form itself, with no surface of its own.
+ *
+ * 🛑 **It resets by UNMOUNTING, not by watching an `open` flag.** Both callers
+ * render it only while it is visible — `PopoverContent` unmounts its children on
+ * close, and the Actions pane swaps them — so a fresh form IS a fresh mount and
+ * there is no open state here to drift out of step with the surface's.
+ */
+export function ReceiveStockForm({ partId, onSuccess, onDone }: ReceiveStockFormProps) {
   const [vendorPartId, setVendorPartId] = useState<string | null>(null)
   const [quantity, setQuantity] = useState<number | null>(null)
   const [unitPrice, setUnitPrice] = useState<number | null>(null)
@@ -83,34 +91,22 @@ export function ReceiveStockPopover({ partId, onSuccess, children }: ReceiveStoc
   const { getSetting } = useSettings({})
   const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
 
-  const suppliers = usePartSuppliers(partId, open)
+  const suppliers = usePartSuppliers(partId)
   const selected = suppliers.find((option) => option.id === vendorPartId) ?? null
 
-  // Reset to a fresh form every time the popover opens, defaulting to the
-  // preferred supplier (§3.5) — the row the buyer already chose.
+  // Prefill the supplier once the rows land, defaulting to the preferred one
+  // (§3.5) — the row the buyer already chose. It is an effect rather than an
+  // initial value because the rows arrive asynchronously, after the mount.
   useEffect(() => {
-    if (!open) return
-    setQuantity(null)
-    setUnitPrice(null)
-    setPriceEdited(false)
-    setOccurredAt(new Date().toISOString())
-    setReference('')
-    setReason('')
-    setVendorPartId(null)
-  }, [open])
-
-  // Prefill the supplier once the rows land, then the price from that supplier.
-  // Split from the reset above because the rows arrive asynchronously, after it.
-  useEffect(() => {
-    if (!open || vendorPartId || suppliers.length === 0) return
+    if (vendorPartId || suppliers.length === 0) return
     const preferred = suppliers.find((option) => option.isPreferred) ?? suppliers[0]
     if (preferred) setVendorPartId(preferred.id)
-  }, [open, vendorPartId, suppliers])
+  }, [vendorPartId, suppliers])
 
   useEffect(() => {
-    if (!open || priceEdited) return
+    if (priceEdited) return
     setUnitPrice(selected?.terms.unitPrice ?? null)
-  }, [open, priceEdited, selected])
+  }, [priceEdited, selected])
 
   // Everything that decides the payload, in one value — so what the breakdown
   // below renders and what the mutation sends are computed from the same state
@@ -141,7 +137,7 @@ export function ReceiveStockPopover({ partId, onSuccess, children }: ReceiveStoc
     try {
       await receiveStock.mutateAsync(payload)
       onSuccess?.()
-      setOpen(false)
+      onDone()
     } catch {
       // onError above already surfaced the toast.
     }
@@ -153,123 +149,151 @@ export function ReceiveStockPopover({ partId, onSuccess, children }: ReceiveStoc
   )
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className='w-96' align='end'>
-        <div className='space-y-3'>
-          <h4 className='font-semibold text-sm'>Receive Stock</h4>
+    <>
+      <FieldPanel className='p-0' orientation='horizontal' defaultLabelWidth={112}>
+        <FieldPanelRow
+          title='Supplier part'
+          type={BaseType.ENUM}
+          showIcon
+          description='Sets the price and the freight and tariff terms'>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            value={vendorPartId}
+            onChange={(val) => {
+              setVendorPartId((val as string[])[0] ?? null)
+              // A different supplier means different terms, so the prefill is
+              // live again — the typed price belonged to the old row.
+              setPriceEdited(false)
+            }}
+            fieldOptions={supplierOptions}
+            disabled={isPending || suppliers.length === 0}
+          />
+        </FieldPanelRow>
 
-          <FieldPanel className='p-0'>
-            <FieldPanelRow
-              title='Supplier part'
-              type={BaseType.ENUM}
-              showIcon
-              description='Sets the price and the freight and tariff terms'>
-              <FieldInputAdapter
-                fieldType={FieldType.SINGLE_SELECT}
-                value={vendorPartId}
-                onChange={(val) => {
-                  setVendorPartId((val as string[])[0] ?? null)
-                  // A different supplier means different terms, so the prefill is
-                  // live again — the typed price belonged to the old row.
-                  setPriceEdited(false)
-                }}
-                fieldOptions={supplierOptions}
-                disabled={isPending || suppliers.length === 0}
-              />
-            </FieldPanelRow>
+        <FieldPanelRow title='Quantity' type={BaseType.NUMBER} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.NUMBER}
+            value={quantity}
+            onChange={(val) => setQuantity((val as number) ?? null)}
+            placeholder='0'
+            disabled={isPending}
+          />
+        </FieldPanelRow>
 
-            <FieldPanelRow title='Quantity' type={BaseType.NUMBER} showIcon isRequired>
-              <FieldInputAdapter
-                fieldType={FieldType.NUMBER}
-                value={quantity}
-                onChange={(val) => setQuantity((val as number) ?? null)}
-                placeholder='0'
-                disabled={isPending}
-              />
-            </FieldPanelRow>
-
-            <FieldPanelRow
-              title='Unit price'
-              type={BaseType.CURRENCY}
-              showIcon
-              isRequired
-              description='What the vendor actually charged'>
-              <FieldInputAdapter
-                fieldType={FieldType.CURRENCY}
-                fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
-                value={unitPrice}
-                onChange={(val) => {
-                  setUnitPrice((val as number) ?? null)
-                  setPriceEdited(true)
-                }}
-                disabled={isPending}
-              />
-              {breakdown && (
-                <p className='mt-1 text-muted-foreground text-xs tabular-nums'>
-                  {formatLandedCostSummary(breakdown, (minorUnits) =>
-                    formatCurrency(minorUnits, { currencyCode })
-                  )}
-                  {' landed'}
-                </p>
+        <FieldPanelRow
+          title='Unit price'
+          type={BaseType.CURRENCY}
+          showIcon
+          isRequired
+          description='What the vendor actually charged'>
+          <FieldInputAdapter
+            fieldType={FieldType.CURRENCY}
+            fieldOptions={{ currencyCode, decimals: 2, useGrouping: true }}
+            value={unitPrice}
+            onChange={(val) => {
+              setUnitPrice((val as number) ?? null)
+              setPriceEdited(true)
+            }}
+            disabled={isPending}
+          />
+          {breakdown && (
+            <p className='mt-1 text-muted-foreground text-xs tabular-nums'>
+              {formatLandedCostSummary(breakdown, (minorUnits) =>
+                formatCurrency(minorUnits, { currencyCode })
               )}
-            </FieldPanelRow>
-
-            <FieldPanelRow
-              title='Received on'
-              type={BaseType.DATE}
-              showIcon
-              isRequired
-              description='The accounting date, which is not when it was keyed'>
-              <FieldInputAdapter
-                fieldType={FieldType.DATETIME}
-                value={occurredAt}
-                onChange={(val) => setOccurredAt(val as string)}
-                disabled={isPending}
-              />
-            </FieldPanelRow>
-
-            <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={reference}
-                onChange={(val) => setReference((val as string) ?? '')}
-                placeholder='e.g. Packing slip 88213'
-                disabled={isPending}
-              />
-            </FieldPanelRow>
-
-            <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={reason}
-                onChange={(val) => setReason((val as string) ?? '')}
-                placeholder='e.g. Partial delivery'
-                disabled={isPending}
-              />
-            </FieldPanelRow>
-          </FieldPanel>
-
-          {suppliers.length === 0 && (
-            <p className='text-muted-foreground text-xs'>
-              This part has no supplier rows. Enter the price paid to receive it anyway.
+              {' landed'}
             </p>
           )}
+        </FieldPanelRow>
 
-          <div className='flex justify-end gap-2'>
-            <Button variant='ghost' size='xs' onClick={() => setOpen(false)} disabled={isPending}>
-              Cancel
-            </Button>
-            <Button
-              variant='outline'
-              size='xs'
-              onClick={handleSubmit}
-              loading={isPending}
-              loadingText='Receiving...'
-              disabled={!payload}>
-              Receive
-            </Button>
-          </div>
+        <FieldPanelRow
+          title='Received on'
+          type={BaseType.DATE}
+          showIcon
+          isRequired
+          description='The accounting date, which is not when it was keyed'>
+          <FieldInputAdapter
+            fieldType={FieldType.DATETIME}
+            value={occurredAt}
+            onChange={(val) => setOccurredAt(val as string)}
+            disabled={isPending}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={reference}
+            onChange={(val) => setReference((val as string) ?? '')}
+            placeholder='e.g. Packing slip 88213'
+            disabled={isPending}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={reason}
+            onChange={(val) => setReason((val as string) ?? '')}
+            placeholder='e.g. Partial delivery'
+            disabled={isPending}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
+
+      {suppliers.length === 0 && (
+        <p className='text-muted-foreground text-xs'>
+          This part has no supplier rows. Enter the price paid to receive it anyway.
+        </p>
+      )}
+
+      <div className='flex justify-end gap-2'>
+        <Button variant='ghost' size='xs' onClick={onDone} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant='outline'
+          size='xs'
+          onClick={handleSubmit}
+          loading={isPending}
+          loadingText='Receiving...'
+          disabled={!payload}>
+          Receive
+        </Button>
+      </div>
+    </>
+  )
+}
+
+interface ReceiveStockPopoverProps {
+  /** The part's entityInstanceId. */
+  partId: string
+  onSuccess?: () => void
+  /** The trigger. */
+  children: React.ReactNode
+}
+
+/**
+ * The receipt form in a popover of its own, for a surface with room for a
+ * trigger of its own — the Parts detail page's Inventory tab.
+ *
+ * 🛑 **Do NOT reach for this from inside a menu.** A `PopoverTrigger` in a
+ * `DropdownMenuItem` unmounts with the menu, and the popover that opens in the
+ * same tick races the menu's dismissable layer — it opened, closed instantly,
+ * and then did neither reliably. The part drawer uses `part-stock-actions.tsx`
+ * instead, which mounts this form as a pane of ONE popover and has no second
+ * layer to race.
+ */
+export function ReceiveStockPopover({ partId, onSuccess, children }: ReceiveStockPopoverProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className='w-96 p-3' align='end'>
+        <div className='space-y-3'>
+          <h4 className='font-semibold text-sm'>Receive Stock</h4>
+          <ReceiveStockForm partId={partId} onSuccess={onSuccess} onDone={() => setOpen(false)} />
         </div>
       </PopoverContent>
     </Popover>
@@ -283,7 +307,7 @@ export function ReceiveStockPopover({ partId, onSuccess, children }: ReceiveStoc
  * nothing, it only prefills, so it wants the terms and a label and not the
  * lead-time/contact columns that tab renders.
  */
-function usePartSuppliers(partId: string, enabled: boolean): SupplierOption[] {
+function usePartSuppliers(partId: string): SupplierOption[] {
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
 
   const filters: ConditionGroup[] = useMemo(
@@ -308,7 +332,7 @@ function usePartSuppliers(partId: string, enabled: boolean): SupplierOption[] {
     entityDefinitionId: vendorPartDefId ?? '',
     filters,
     limit: 50,
-    enabled: enabled && !!partId && !!vendorPartDefId,
+    enabled: !!partId && !!vendorPartDefId,
   })
 
   const recordIds = useMemo(
@@ -318,7 +342,7 @@ function usePartSuppliers(partId: string, enabled: boolean): SupplierOption[] {
 
   const { valuesById } = useSystemValuesForRecords(recordIds, VENDOR_PART_ATTRIBUTES, {
     autoFetch: true,
-    enabled: enabled && recordIds.length > 0,
+    enabled: recordIds.length > 0,
   })
 
   return useMemo(

--- a/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
@@ -5,7 +5,7 @@ import { FieldType } from '@auxx/database/enums'
 import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { toastError } from '@auxx/ui/components/toast'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
@@ -24,17 +24,21 @@ const QUANTITY_MODE_OPTIONS = [
   { label: 'Set to', value: 'set_to' },
 ]
 
-interface StockAdjustmentPopoverProps {
+interface StockAdjustmentFormProps {
   /** The part's entityInstanceId */
   partId: string
   /** Current quantity on hand (needed for "Set to" mode) */
   currentQoH: number
   onSuccess?: () => void
-  children: React.ReactNode
+  /** Dismiss whatever surface this form is mounted in. */
+  onDone: () => void
 }
 
 /**
- * Popover for creating manual stock movements — `type: 'adjust'` only.
+ * The form for creating manual stock movements — `type: 'adjust'` only.
+ *
+ * 🛑 It resets by UNMOUNTING rather than by watching an `open` flag; see
+ * `ReceiveStockForm` for why both callers guarantee that.
  *
  * 🛑 There is deliberately no "Adjust subparts" control and no BOM cascade.
  * The toggle that used to live here exploded the bill of materials WITHOUT
@@ -82,29 +86,17 @@ interface StockAdjustmentPopoverProps {
  * form does not know the part's standard cost and a guess would be worse than
  * the server's sentence.
  */
-export function StockAdjustmentPopover({
+export function StockAdjustmentForm({
   partId,
   currentQoH,
   onSuccess,
-  children,
-}: StockAdjustmentPopoverProps) {
-  const [open, setOpen] = useState(false)
+  onDone,
+}: StockAdjustmentFormProps) {
   const [direction, setDirection] = useState<Direction>('add')
   const [quantityMode, setQuantityMode] = useState<QuantityMode>('adjust_by')
   const [quantity, setQuantity] = useState<number | null>(null)
   const [reason, setReason] = useState('')
   const [reference, setReference] = useState('')
-
-  // Reset form when popover opens
-  useEffect(() => {
-    if (open) {
-      setDirection('add')
-      setQuantityMode('adjust_by')
-      setQuantity(null)
-      setReason('')
-      setReference('')
-    }
-  }, [open])
 
   /**
    * The signed delta this form will send — one number, derived once, so the
@@ -148,11 +140,11 @@ export function StockAdjustmentPopover({
         ...(reference ? { reference } : {}),
       })
       onSuccess?.()
-      setOpen(false)
+      onDone()
     } catch {
       // onError above already surfaced the toast.
     }
-  }, [canSubmit, adjustStock, partId, delta, reason, reference, onSuccess])
+  }, [canSubmit, adjustStock, partId, delta, reason, reference, onSuccess, onDone])
 
   const isSetToMode = quantityMode === 'set_to'
 
@@ -160,108 +152,141 @@ export function StockAdjustmentPopover({
   const quantityModeFieldOptions = useMemo(() => ({ options: QUANTITY_MODE_OPTIONS }), [])
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className='w-96' align='end'>
-        <div className='space-y-3'>
-          <h4 className='text-sm font-semibold'>Adjust Stock</h4>
+    <>
+      <FieldPanel className='p-0' orientation='horizontal' defaultLabelWidth={112}>
+        {/* Mode */}
+        <FieldPanelRow
+          title='Mode'
+          type={BaseType.ENUM}
+          showIcon
+          isRequired
+          description='Adjust by a relative amount or set to an absolute quantity'>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            value={quantityMode}
+            onChange={(val) =>
+              setQuantityMode(((val as string[])[0] as QuantityMode) ?? 'adjust_by')
+            }
+            fieldOptions={quantityModeFieldOptions}
+            disabled={isPending}
+          />
+        </FieldPanelRow>
 
-          <FieldPanel className='p-0'>
-            {/* Mode */}
-            <FieldPanelRow
-              title='Mode'
-              type={BaseType.ENUM}
-              showIcon
-              isRequired
-              description='Adjust by a relative amount or set to an absolute quantity'>
-              <FieldInputAdapter
-                fieldType={FieldType.SINGLE_SELECT}
-                value={quantityMode}
-                onChange={(val) =>
-                  setQuantityMode(((val as string[])[0] as QuantityMode) ?? 'adjust_by')
-                }
-                fieldOptions={quantityModeFieldOptions}
-                disabled={isPending}
-              />
-            </FieldPanelRow>
+        {/* Direction */}
+        {!isSetToMode && (
+          <FieldPanelRow
+            title='Direction'
+            type={BaseType.ENUM}
+            showIcon
+            isRequired
+            description='Whether to add or remove stock'>
+            <FieldInputAdapter
+              fieldType={FieldType.SINGLE_SELECT}
+              value={direction}
+              onChange={(val) => setDirection(((val as string[])[0] as Direction) ?? 'add')}
+              fieldOptions={directionFieldOptions}
+              disabled={isPending}
+            />
+          </FieldPanelRow>
+        )}
 
-            {/* Direction */}
-            {!isSetToMode && (
-              <FieldPanelRow
-                title='Direction'
-                type={BaseType.ENUM}
-                showIcon
-                isRequired
-                description='Whether to add or remove stock'>
-                <FieldInputAdapter
-                  fieldType={FieldType.SINGLE_SELECT}
-                  value={direction}
-                  onChange={(val) => setDirection(((val as string[])[0] as Direction) ?? 'add')}
-                  fieldOptions={directionFieldOptions}
-                  disabled={isPending}
-                />
-              </FieldPanelRow>
-            )}
+        {/* Quantity */}
+        <FieldPanelRow title='Quantity' type={BaseType.NUMBER} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.NUMBER}
+            value={quantity}
+            onChange={(val) => setQuantity((val as number) ?? null)}
+            placeholder={isSetToMode ? String(currentQoH) : '0'}
+            disabled={isPending}
+          />
+          {isSetToMode && quantity !== null && (
+            <p className='text-xs text-muted-foreground mt-1'>
+              Delta: {delta >= 0 ? '+' : ''}
+              {delta}
+            </p>
+          )}
+        </FieldPanelRow>
 
-            {/* Quantity */}
-            <FieldPanelRow title='Quantity' type={BaseType.NUMBER} showIcon isRequired>
-              <FieldInputAdapter
-                fieldType={FieldType.NUMBER}
-                value={quantity}
-                onChange={(val) => setQuantity((val as number) ?? null)}
-                placeholder={isSetToMode ? String(currentQoH) : '0'}
-                disabled={isPending}
-              />
-              {isSetToMode && quantity !== null && (
-                <p className='text-xs text-muted-foreground mt-1'>
-                  Delta: {delta >= 0 ? '+' : ''}
-                  {delta}
-                </p>
-              )}
-            </FieldPanelRow>
-
-            {/* No cost input. See the note on this component: `G12` values an
+        {/* No cost input. See the note on this component: `G12` values an
                 adjustment at the part's own frozen standard cost, server-side,
                 in both directions. */}
 
-            {/* Reason */}
-            <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={reason}
-                onChange={(val) => setReason((val as string) ?? '')}
-                placeholder='e.g. Recount, Damaged goods'
-                disabled={isPending}
-              />
-            </FieldPanelRow>
+        {/* Reason */}
+        <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={reason}
+            onChange={(val) => setReason((val as string) ?? '')}
+            placeholder='e.g. Recount, Damaged goods'
+            disabled={isPending}
+          />
+        </FieldPanelRow>
 
-            {/* Reference */}
-            <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={reference}
-                onChange={(val) => setReference((val as string) ?? '')}
-                placeholder='e.g. PO-1234, RMA-567'
-                disabled={isPending}
-              />
-            </FieldPanelRow>
-          </FieldPanel>
+        {/* Reference */}
+        <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={reference}
+            onChange={(val) => setReference((val as string) ?? '')}
+            placeholder='e.g. PO-1234, RMA-567'
+            disabled={isPending}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
 
-          {/* Actions */}
-          <div className='flex justify-end gap-2'>
-            <Button variant='ghost' size='xs' onClick={() => setOpen(false)} disabled={isPending}>
-              Cancel
-            </Button>
-            <Button
-              variant='outline'
-              size='xs'
-              onClick={handleSubmit}
-              loading={isPending}
-              loadingText='Saving...'
-              disabled={!canSubmit}>
-              Save
-            </Button>
-          </div>
+      {/* Actions */}
+      <div className='flex justify-end gap-2'>
+        <Button variant='ghost' size='xs' onClick={onDone} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button
+          variant='outline'
+          size='xs'
+          onClick={handleSubmit}
+          loading={isPending}
+          loadingText='Saving...'
+          disabled={!canSubmit}>
+          Save
+        </Button>
+      </div>
+    </>
+  )
+}
+
+interface StockAdjustmentPopoverProps {
+  /** The part's entityInstanceId */
+  partId: string
+  /** Current quantity on hand (needed for "Set to" mode) */
+  currentQoH: number
+  onSuccess?: () => void
+  /** The trigger. */
+  children: React.ReactNode
+}
+
+/**
+ * The adjustment form in a popover of its own, for a surface with room for a
+ * trigger. See `ReceiveStockPopover` for why a menu must not use this.
+ */
+export function StockAdjustmentPopover({
+  partId,
+  currentQoH,
+  onSuccess,
+  children,
+}: StockAdjustmentPopoverProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className='w-96 p-3' align='end'>
+        <div className='space-y-3'>
+          <h4 className='text-sm font-semibold'>Adjust Stock</h4>
+          <StockAdjustmentForm
+            partId={partId}
+            currentQoH={currentQoH}
+            onSuccess={onSuccess}
+            onDone={() => setOpen(false)}
+          />
         </div>
       </PopoverContent>
     </Popover>

--- a/apps/web/src/components/records/record-editor-dialog.tsx
+++ b/apps/web/src/components/records/record-editor-dialog.tsx
@@ -4,6 +4,7 @@
 import { getInstanceId, isRecordId, type RecordId } from '@auxx/lib/resources/client'
 import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
 import { WorkOrderEditorDialog } from '~/components/dispatch/ui/work-order-editor'
+import { BuildFormDialog } from '~/components/manufacturing/builds/build-form-dialog'
 import { PartFormDialog } from '~/components/manufacturing/parts/part-form-dialog'
 import { useSystemField } from '~/components/resources/hooks/use-field'
 import { useResource } from '~/components/resources/hooks/use-resource'
@@ -38,12 +39,41 @@ export interface RecordEditorDialogProps {
  * {@link RecordEditorDialogProps}.
  */
 const CUSTOM_EDITORS: Record<string, React.ComponentType<RecordEditorDialogProps>> = {
+  build: BuildEditorAdapter,
   part: PartEditorAdapter,
   work_order: WorkOrderEditorAdapter,
 }
 
 function WorkOrderEditorAdapter(props: RecordEditorDialogProps) {
   return <WorkOrderEditorDialog {...props} />
+}
+
+/**
+ * Routes "New build" through `builds.create`
+ * (plans/money/tasks/23-build-from-the-part.md §5).
+ *
+ * 🛑 **CREATE only.** `createBuild` makes two validations nothing else enforces
+ * — the part must not be classified as purchased, and it must have at least one
+ * direct subpart — and until this adapter existed the generic dialog reached
+ * `record.create` and skipped both. Editing a build is a different question:
+ * `build_status` is `showInDialogs: false` and every transition is a procedure
+ * with its own preconditions, so an edit falls through to the generic form
+ * rather than to a bespoke one that would have to reimplement the panel.
+ */
+function BuildEditorAdapter(props: RecordEditorDialogProps) {
+  const partField = useSystemField('build_part', props.entityDefinitionId)
+  const partId = presetInstanceId(props.presetValues, partField?.id)
+
+  if (props.recordId) return <EntityInstanceDialog {...props} />
+
+  return (
+    <BuildFormDialog
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      partId={partId}
+      onSuccess={(buildId) => props.onSaved?.(buildId)}
+    />
+  )
 }
 
 /**

--- a/apps/web/src/server/api/routers/builds.ts
+++ b/apps/web/src/server/api/routers/builds.ts
@@ -1,6 +1,7 @@
 // apps/web/src/server/api/routers/builds.ts
 
 import {
+  buildNow,
   cancelBuild,
   completeBuild,
   createBuild,
@@ -10,6 +11,7 @@ import {
   loadEffectiveAbsorptionRates,
   previewStandardCostRoll,
   readBuildDrift,
+  readPartQuantitiesOnHand,
   reverseBuild,
   rollStandardCost,
   startBuild,
@@ -86,7 +88,7 @@ const completionShape = {
  * | `previewRoll`, `roll`                  | edit on `part`                            |
  * | `list`, `get`                          | view on `build`                           |
  * | `create`, `start`, `cancel`            | edit on `build`                           |
- * | `previewCompletion`, `complete`, `reverse` | edit on `build` AND edit on `stock_movement` |
+ * | `previewCompletion`, `complete`, `reverse`, `buildNow` | edit on `build` AND edit on `stock_movement` |
  *
  * Three notes on why those, and not something coarser:
  *
@@ -325,7 +327,52 @@ export const buildsRouter = createTRPCRouter({
         loadEffectiveAbsorptionRates(ctx.db, organizationId, input.partId),
       ])
       if (plan.isErr()) throw plan.error
-      return { plan: plan.value, rates }
+
+      // What each consumed part has on hand RIGHT NOW, so a preview can say
+      // `will take Feet Bracket to -3` (23 §3.4). `completeBuild` performs no
+      // sufficiency check at all and deliberately still does not — receiving
+      // keyed late is normal in a small shop, and a build refused on a stale
+      // count is a worse failure than a negative a receipt corrects an hour
+      // later. So this is a WARNING's input, never a gate's.
+      const onHand = await readPartQuantitiesOnHand(
+        ctx.db,
+        organizationId,
+        plan.value.components.map((line) => line.partId)
+      )
+
+      return { plan: plan.value, rates, onHand: Object.fromEntries(onHand) }
+    }),
+
+  /**
+   * Raise, start and complete a run in one call — the part drawer's `Build now`
+   * (plans/money/tasks/23-build-from-the-part.md §3.3).
+   *
+   * Gated exactly as `complete` is, because it ends in a completion.
+   *
+   * 🛑 **It is not atomic and the result says so.** A refused completion comes
+   * back with `status: 'left_in_progress'` and the build that was raised, at a
+   * 200 — not as an error. The caller MUST render that arm as a failure that
+   * names and links the run, because "nothing happened" is what makes somebody
+   * press the button a second time and raise a duplicate.
+   */
+  buildNow: capabilityProcedure
+    .input(
+      z.object({
+        partId: z.string().min(1),
+        /** Good units produced. Both the planned and the produced quantity. */
+        quantity: runQuantity,
+        notes: z.string().max(2000).optional(),
+        /** THE accounting date, stamped on the build and every movement. Defaults to now. */
+        completedAt: z.coerce.date().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      await assertCanPostBuildLedger(ctx)
+
+      const result = await buildNow(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
     }),
 
   /**

--- a/packages/lib/src/builds/__tests__/build-now.test.ts
+++ b/packages/lib/src/builds/__tests__/build-now.test.ts
@@ -1,0 +1,201 @@
+// packages/lib/src/builds/__tests__/build-now.test.ts
+//
+// `buildNow` is a composition and nothing else — create -> start -> complete —
+// so what is under test is the SEAM between the three, not any arithmetic.
+// The three mutations have their own suites; here they are doubles.
+//
+// The property that matters is the one §3.3 of plans/money/tasks/23 refuses to
+// paper over: it is NOT atomic. A refused completion leaves an `in_progress` run
+// with no movements written, and that has to come back as a RESULT carrying the
+// build rather than as an error — because `errorFormatter` sends the client a
+// message and nothing else, and "failed" about a run that exists is what makes
+// somebody press the button again and raise a duplicate.
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import type { BuildRecord } from '../types'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const PART = 'part_lift'
+const BUILD = 'build_1'
+
+const h = vi.hoisted(() => ({
+  createResult: null as unknown,
+  startResult: null as unknown,
+  completeResult: null as unknown,
+  createCalls: [] as Record<string, unknown>[],
+  startCalls: [] as Record<string, unknown>[],
+  completeCalls: [] as Record<string, unknown>[],
+}))
+
+vi.mock('../build-mutations', () => ({
+  createBuild: vi.fn(async (_db, _org, _user, input) => {
+    h.createCalls.push(input)
+    return h.createResult
+  }),
+  startBuild: vi.fn(async (_db, _org, _user, input) => {
+    h.startCalls.push(input)
+    return h.startResult
+  }),
+}))
+
+vi.mock('../complete-build', () => ({
+  completeBuild: vi.fn(async (_db, _org, _user, input) => {
+    h.completeCalls.push(input)
+    return h.completeResult
+  }),
+}))
+
+import { buildNow } from '../build-now'
+
+const planned = (over: Partial<BuildRecord> = {}): BuildRecord =>
+  ({
+    buildId: BUILD,
+    recordId: `buildDef:${BUILD}`,
+    number: 'B-0042',
+    partId: PART,
+    status: 'planned',
+    quantityPlanned: 5,
+    quantityProduced: null,
+    quantityScrapped: null,
+    startedAt: null,
+    completedAt: null,
+    materialCost: null,
+    laborCost: null,
+    overheadCost: null,
+    producedValue: null,
+    varianceAmount: null,
+    postedAt: null,
+    notes: null,
+    orderId: null,
+    source: 'manual',
+    reversalOfBuildId: null,
+    orderRevision: null,
+    ...over,
+  }) as BuildRecord
+
+const completion = {
+  buildId: BUILD,
+  recordId: `buildDef:${BUILD}`,
+  quantityProduced: 5,
+  quantityScrapped: 0,
+  materialCost: 1000,
+  laborCost: 0,
+  overheadCost: 0,
+  producedValue: 1000,
+  varianceAmount: 0,
+  movementIds: ['mv_1', 'mv_2'],
+  recalculatedPartIds: [PART],
+}
+
+beforeEach(() => {
+  h.createCalls = []
+  h.startCalls = []
+  h.completeCalls = []
+  h.createResult = ok(planned())
+  h.startResult = ok(planned({ status: 'in_progress' }))
+  h.completeResult = ok(completion)
+})
+
+const db = {} as never
+
+describe('the happy path', () => {
+  it('walks create -> start -> complete and returns both halves', async () => {
+    const result = await buildNow(db, ORG, USER, { partId: PART, quantity: 5 })
+
+    expect(result.isOk()).toBe(true)
+    const outcome = result._unsafeUnwrap()
+    expect(outcome.status).toBe('completed')
+    if (outcome.status !== 'completed') throw new Error('unreachable')
+    expect(outcome.build.buildId).toBe(BUILD)
+    expect(outcome.completion).toEqual(completion)
+  })
+
+  it('plans and produces the SAME quantity', async () => {
+    await buildNow(db, ORG, USER, { partId: PART, quantity: 5 })
+    expect(h.createCalls[0]).toMatchObject({ partId: PART, quantityPlanned: 5 })
+    expect(h.completeCalls[0]).toMatchObject({ buildId: BUILD, quantityProduced: 5 })
+  })
+
+  // 🛑 The assertion this makes on the caller's behalf: BOM-standard
+  // consumption, zero scrap, effective absorption rates. Sending `laborCost` or
+  // `overheadCost` would override the produced part's own rates with a number
+  // the browser invented; sending `componentOverrides` would claim the floor
+  // consumed something other than the bill of materials. Both are the completion
+  // DIALOG's job, which is why the popover keeps a "Plan and open..." verb.
+  it('sends no overrides, no scrap and no absorbed amounts', async () => {
+    await buildNow(db, ORG, USER, { partId: PART, quantity: 5 })
+    const input = h.completeCalls[0]!
+    expect(input).not.toHaveProperty('componentOverrides')
+    expect(input).not.toHaveProperty('quantityScrapped')
+    expect(input).not.toHaveProperty('laborCost')
+    expect(input).not.toHaveProperty('overheadCost')
+  })
+
+  it('passes the accounting date through when the caller states one', async () => {
+    const completedAt = new Date('2026-08-31T00:00:00.000Z')
+    await buildNow(db, ORG, USER, { partId: PART, quantity: 5, completedAt })
+    expect(h.completeCalls[0]).toMatchObject({ completedAt })
+  })
+
+  it('omits notes rather than writing an empty string', async () => {
+    await buildNow(db, ORG, USER, { partId: PART, quantity: 5, notes: '' })
+    expect(h.createCalls[0]).not.toHaveProperty('notes')
+  })
+})
+
+describe('createBuild refusing — the arm that wrote nothing', () => {
+  it('comes back as an error, because there is no run to recover', async () => {
+    const refusal = new UnprocessableEntityError('This part is classified as purchased')
+    h.createResult = err(refusal)
+
+    const result = await buildNow(db, ORG, USER, { partId: PART, quantity: 5 })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBe(refusal)
+    expect(h.startCalls).toHaveLength(0)
+    expect(h.completeCalls).toHaveLength(0)
+  })
+})
+
+describe('🛑 it is not atomic, and the result says so', () => {
+  it('a refused COMPLETION returns left_in_progress with the build', async () => {
+    h.completeResult = err(new UnprocessableEntityError('Feet Bracket has no standard cost'))
+
+    const result = await buildNow(db, ORG, USER, { partId: PART, quantity: 5 })
+
+    // ✅ Ok, not err — the caller has to be able to name and link the run.
+    expect(result.isOk()).toBe(true)
+    const outcome = result._unsafeUnwrap()
+    expect(outcome.status).toBe('left_in_progress')
+    if (outcome.status !== 'left_in_progress') throw new Error('unreachable')
+    expect(outcome.stage).toBe('complete')
+    expect(outcome.build.buildId).toBe(BUILD)
+    expect(outcome.build.number).toBe('B-0042')
+    expect(outcome.build.recordId).toBe(`buildDef:${BUILD}`)
+    // The actual reason survives verbatim — it is what the person has to fix.
+    expect(outcome.reason).toBe('Feet Bracket has no standard cost')
+  })
+
+  it('carries the STARTED build, so the recovery state is what the run is in', async () => {
+    h.completeResult = err(new UnprocessableEntityError('nope'))
+    const result = await buildNow(db, ORG, USER, { partId: PART, quantity: 5 })
+    const outcome = result._unsafeUnwrap()
+    if (outcome.status !== 'left_in_progress') throw new Error('unreachable')
+    expect(outcome.build.status).toBe('in_progress')
+  })
+
+  it('a refused START stops before the completion, and says which stage', async () => {
+    h.startResult = err(new UnprocessableEntityError('Only a planned build can be started'))
+
+    const result = await buildNow(db, ORG, USER, { partId: PART, quantity: 5 })
+
+    const outcome = result._unsafeUnwrap()
+    expect(outcome.status).toBe('left_in_progress')
+    if (outcome.status !== 'left_in_progress') throw new Error('unreachable')
+    expect(outcome.stage).toBe('start')
+    expect(h.completeCalls).toHaveLength(0)
+  })
+})

--- a/packages/lib/src/builds/build-mutations.ts
+++ b/packages/lib/src/builds/build-mutations.ts
@@ -69,10 +69,17 @@ export const BUILD_STATUS_BYPASS: ReadonlySet<SystemAttribute> = new Set<SystemA
  *
  * 1. **`part_kind` must be `finished_good` or `subassembly`.** A `component` is
  *    purchased, not assembled; a build against one would consume nothing and
- *    produce inventory value out of thin air. NULL reads as `component`
- *    ({@link resolvePartKind}), so an unclassified part is refused with a
- *    message that says so — classifying the built parts is a prerequisite of
- *    the first roll and of the first build alike.
+ *    produce inventory value out of thin air.
+ *
+ *    ⚠️ **The refusal means something different since the derivation landed**
+ *    (plans/money/tasks/23 §4). `part_kind` used to be a field somebody had to
+ *    remember, defaulted to `component`, so this check refused parts nobody had
+ *    classified — 4 orgs of 5 held it NULL on every part. Now
+ *    `post/part-kind-derivation.ts` promotes a part to `subassembly` the moment
+ *    it gets a bill of materials, so a stored `component` ON A PART WITH A BOM
+ *    is somebody having deliberately overridden that rule. Refusing it is
+ *    correct rather than accidental, and the message says *classified as
+ *    purchased* rather than *set the part kind first* for that reason.
  * 2. **At least one direct subpart.** A run with no bill of materials has
  *    nothing to consume, and completing it would write a lone `build_produce`
  *    row: inventory created from nothing, at a standard cost that no consumed
@@ -103,7 +110,8 @@ export async function createBuild(
       const partKind = resolvePartKind(kinds.get(input.partId))
       if (partKind === 'component') {
         throw new UnprocessableEntityError(
-          'Only a finished good or a subassembly can be built. Set the part kind first.'
+          'This part is classified as purchased, so it cannot be built. Change its part kind ' +
+            'to a subassembly or a finished good if it is made in-house.'
         )
       }
 

--- a/packages/lib/src/builds/build-now.ts
+++ b/packages/lib/src/builds/build-now.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/builds/build-now.ts
+
+/**
+ * Raise, start and complete a run in one call
+ * (plans/money/tasks/23-build-from-the-part.md §3.3).
+ *
+ * The whole of it is a composition: `createBuild` -> `startBuild` ->
+ * `completeBuild`, in that order, with no arithmetic of its own. A shop
+ * assembling five brackets on the bench should not have to walk a three-state
+ * lifecycle to say so, and the three-state lifecycle is still what actually
+ * happens underneath.
+ *
+ * 🛑 **It is NOT atomic, and no caller may be told otherwise.** Each of the three
+ * runs its own `UnifiedCrudHandler` work inside its own `guard`, so a refused
+ * completion — a component with no `part_standard_cost` being the likely
+ * reason — leaves the run sitting at `in_progress` with no movements written.
+ * That is recoverable, not corrupt: the build is in the builds list and
+ * `build-run-card` can complete or cancel it.
+ *
+ * 🛑 **Which is why a mid-composition failure is a RESULT, not an error.** It
+ * comes back as {@link BuildNowOutcome} `left_in_progress`, carrying the build
+ * that was raised, because the caller has to be able to name and link it. An
+ * error channel cannot do that: `errorFormatter` sends the client a message and
+ * nothing else, so the person would be told "failed" about a run that exists,
+ * and would press the button again. The `err` channel is reserved for
+ * `createBuild` refusing, which writes nothing at all.
+ *
+ * 🛑 **Do not make it atomic by inlining the three bodies.** That would put a
+ * second copy of the ledger writer in the tree, which is the one thing
+ * `complete-build.ts` is structured to prevent.
+ *
+ * No permission checks. The router asserts (`docs/lib-module-guide.md` §6) —
+ * and it must assert BOTH halves, because this path writes stock movements.
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { createBuild, startBuild } from './build-mutations'
+import { completeBuild } from './complete-build'
+import type { BuildRecord, CompleteBuildResult } from './types'
+
+const logger = createScopedLogger('builds:build-now')
+
+/** What `buildNow` needs. The completion's overrides are deliberately absent — see below. */
+export interface BuildNowInput {
+  /** `EntityInstance.id` of the `part` to produce. */
+  partId: string
+  /** Good units produced. This is both the planned and the produced quantity. */
+  quantity: number
+  notes?: string
+  /** THE accounting date, stamped on the build and every movement. Defaults to now. */
+  completedAt?: Date
+}
+
+/**
+ * What happened. Both arms carry the build, because both arms raised one.
+ *
+ * `left_in_progress` is the recoverable end state §3.3 names: the run exists,
+ * it has written no movements, and somebody has to finish or cancel it from the
+ * builds list. `reason` is the refusal verbatim — an unpriced component, almost
+ * always — so the person is told why rather than only that.
+ */
+export type BuildNowOutcome =
+  | { status: 'completed'; build: BuildRecord; completion: CompleteBuildResult }
+  | {
+      status: 'left_in_progress'
+      build: BuildRecord
+      /** How far the composition got before it stopped. */
+      stage: 'start' | 'complete'
+      reason: string
+    }
+
+/**
+ * Create a run, start it, and complete it at BOM-standard consumption.
+ *
+ * 🛑 **The assertion this makes on the caller's behalf**: standard consumption
+ * straight off the bill of materials, zero scrap, and the effective absorption
+ * rates. No component overrides, and `laborCost` / `overheadCost` are omitted so
+ * the server resolves them from the produced part's own rates falling back to
+ * the org's (`routers/builds.ts` documents omitting them as the supported case).
+ *
+ * That assertion is true for most small runs and false for some. When it is
+ * false the person wants the full completion dialog, which is why the part
+ * drawer keeps a "Plan and open..." verb beside this one rather than growing
+ * override inputs into a two-field popover.
+ */
+export async function buildNow(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: BuildNowInput
+): Promise<Result<BuildNowOutcome, Error>> {
+  const created = await createBuild(db, organizationId, userId, {
+    partId: input.partId,
+    quantityPlanned: input.quantity,
+    ...(input.notes ? { notes: input.notes } : {}),
+  })
+  // Nothing was written, so this failure needs no recovery sentence — it is the
+  // ordinary refusal a person meets when the part is unclassified or has no BOM.
+  if (created.isErr()) return err(created.error)
+  const raised = created.value
+
+  const started = await startBuild(db, organizationId, userId, { buildId: raised.buildId })
+  if (started.isErr()) {
+    return ok(stopped(raised, 'start', started.error))
+  }
+  const build = started.value
+
+  const completed = await completeBuild(db, organizationId, userId, {
+    buildId: build.buildId,
+    quantityProduced: input.quantity,
+    ...(input.completedAt ? { completedAt: input.completedAt } : {}),
+  })
+  if (completed.isErr()) {
+    return ok(stopped(build, 'complete', completed.error))
+  }
+
+  logger.info('Built a run in one step', {
+    organizationId,
+    buildId: build.buildId,
+    partId: input.partId,
+    quantity: input.quantity,
+    varianceAmount: completed.value.varianceAmount,
+  })
+
+  return ok({ status: 'completed', build, completion: completed.value })
+}
+
+/** The `left_in_progress` arm, with the run that has to be finished or cancelled. */
+function stopped(
+  build: BuildRecord,
+  stage: 'start' | 'complete',
+  error: Error
+): Extract<BuildNowOutcome, { status: 'left_in_progress' }> {
+  logger.warn('buildNow stopped after raising the build', {
+    buildId: build.buildId,
+    stage,
+    error: error.message,
+  })
+  return { status: 'left_in_progress', build, stage, reason: error.message }
+}

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -44,6 +44,9 @@ export {
   createBuild,
   startBuild,
 } from './build-mutations'
+// One call that raises, starts and completes. NOT atomic — a refused completion
+// comes back as `left_in_progress` carrying the run it left behind (§3.3).
+export { type BuildNowInput, type BuildNowOutcome, buildNow } from './build-now'
 export {
   type BuildComponentPlanInput,
   type BuildFieldContext,

--- a/packages/lib/src/field-hooks/post/part-kind-derivation.ts
+++ b/packages/lib/src/field-hooks/post/part-kind-derivation.ts
@@ -1,0 +1,229 @@
+// packages/lib/src/field-hooks/post/part-kind-derivation.ts
+
+/**
+ * Derive `part_kind` from the bill of materials
+ * (plans/money/tasks/23-build-from-the-part.md §4).
+ *
+ * **The second a part has a bill of materials, it is a subassembly.**
+ *
+ * ## Why the field is derived rather than remembered
+ *
+ * `part_kind` holds no information the subpart graph does not already hold.
+ * Cross-tabbed across all 244 parts of the one org where a human ever set it,
+ * 2026-08-31: BOM + somebody's subpart => `subassembly` 22/22; BOM + nobody's
+ * subpart => `finished_good` 21/21; no BOM => `component` 201/201. **244 for
+ * 244, zero exceptions.** The other four orgs have it NULL on every part, and 4
+ * of those parts carry a real BOM — so in four orgs of five a genuine assembly
+ * could not be built, and the refusal told the user to go set a field.
+ *
+ * That is what made the gate in `createBuild` misfire rather than protect:
+ * `resolvePartKind` reads NULL as `component`, and `part-fields.ts` ships
+ * `defaultValue: COMPONENT`, so a stored `component` never proved a human typed
+ * it. Deriving the value restores the gate's meaning exactly where the gate is
+ * applied — after this, a `component` on a part that HAS a BOM is somebody
+ * having deliberately overridden the rule, and refusing it is correct.
+ *
+ * ## 🛑 Promotion to `subassembly` only, never to `finished_good`
+ *
+ * The full two-predicate derivation (*has a BOM and is nobody's subpart =>
+ * finished good*) does not work, because the second predicate is unstable at
+ * write time. People build bottom-up: the subassembly is nobody's subpart at the
+ * instant it gets its own BOM, so the rule would stamp `finished_good`, and
+ * adding it to a parent's BOM a minute later would mean *demoting* it.
+ *
+ * Demotion is the one move with a ledger consequence. `finished_good` is the
+ * only kind that maps to `INVENTORY_FINISHED_GOODS`, and `complete-build.ts`
+ * stamps the produce row from the produced part's kind on every completion, so
+ * an unrelated BOM edit would silently move where a part posts from then on.
+ * Frozen history is safe — every movement field is `updatable: false` — but
+ * every future build is not.
+ *
+ * Promotion to `subassembly` changes nothing anybody has to be careful about:
+ * `component` and `subassembly` map to the SAME account
+ * (`INVENTORY_RAW_MATERIALS`), it turns on `absorbsConversionCost` which is
+ * correct for anything with a BOM, and it makes the part buildable.
+ * `finished_good` keeps its own derivation, `shouldSuggestFinishedGood`, gated
+ * on product membership rather than on the BOM: the BOM says *we make this*,
+ * a product says *we sell this*.
+ *
+ * ## The three decisions
+ *
+ * 1. **Promotion only.** A stored `subassembly` or `finished_good` is never
+ *    overwritten. This fills an unclassified part in; it does not adjudicate a
+ *    classified one.
+ * 2. **No demotion on `mfg-subparts-deleted`.** A subassembly whose last subpart
+ *    was removed is a data question, and auto-reverting would silently restate
+ *    its standard cost. This rule is registered on `created` alone.
+ * 3. **The purchased assembly whose BOM is kept for spares** gets promoted and
+ *    starts absorbing conversion cost it never incurred. `part_kind` stays
+ *    `updatable: true`, so a human sets it back to `component` and decision 1
+ *    means it stays back. That override is the right answer to the one case the
+ *    derivation gets wrong, which is why 🛑 **`part_kind` must NOT be made
+ *    `computed: true`** — locking it removes the escape hatch this rests on.
+ */
+
+import { type Database, database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import type { RecordId } from '@auxx/types/resource'
+import { toRecordId } from '@auxx/types/resource'
+import { getOrgCache, requireCachedEntityDefId } from '../../cache'
+import { createFieldValueContext } from '../../field-values/field-value-helpers'
+import { setValueWithType } from '../../field-values/field-value-mutations'
+import { toFieldType } from '../../field-values/stored-field-type'
+import type { FieldValueUpdateEntry } from '../../realtime'
+import { getRealtimeService, publishFieldValueUpdates } from '../../realtime'
+import { PartKind } from '../../resources/registry/enum-values'
+
+const logger = createScopedLogger('field-hooks:part-kind')
+
+/**
+ * Decide what a stored `part_kind` becomes now that the part has a BOM.
+ *
+ * Pure, and the ONE definition of the rule — the backfill in entity migration
+ * 117 calls this same function, so a part promoted at write time and a part
+ * promoted by the migration cannot be promoted by two different rules.
+ *
+ * `null` in means unset. `'promote'` is the only action; everything else is
+ * `'leave'`, including a value this codebase does not recognise (an org that
+ * added a fourth kind owns it, exactly as `resolvePartKind` assumes).
+ */
+export function resolvePartKindPromotion(stored: string | null | undefined): 'promote' | 'leave' {
+  if (stored == null || stored === '' || stored === PartKind.COMPONENT) return 'promote'
+  return 'leave'
+}
+
+/**
+ * Promote every unclassified parent in a batch of new subpart edges.
+ *
+ * Shaped like `recalculatePartCostForEntityBatch` beside it and for the same
+ * reason: on a bulk BOM import this is one lookup and one write pass rather
+ * than one of each per edge. The parent is read from the threaded create values
+ * first and only falls back to a query for the edges that did not carry it.
+ *
+ * 🛑 **Registered BEFORE the cost recalc on `mfg-subparts-created`.** The recalc
+ * ends in `ensureFirstStandardCosts`, and `absorbsConversionCost` is false for a
+ * `component` — so a roll that ran before the promotion would freeze a standard
+ * with no labour or overhead in it, on exactly the parts this rule exists to
+ * make buildable.
+ *
+ * Never throws. This is post-commit work hanging off a subpart write, and the
+ * subpart is the fact the user asked to record: the worst case here is a part
+ * that stays unclassified, which is the state it was in a moment ago.
+ */
+export async function derivePartKindForSubpartBatch(params: {
+  organizationId: string
+  records: Array<{ entityInstanceId: string; values?: Record<string, unknown> }>
+}): Promise<void> {
+  const { organizationId, records } = params
+  if (records.length === 0) return
+
+  try {
+    const { unwrapRelationId } = await import('../../resources/events/captured-values')
+
+    const parentIds = new Set<string>()
+    const missing: string[] = []
+    for (const { entityInstanceId, values } of records) {
+      const fromValues = values ? unwrapRelationId(values.subpart_parent_part) : undefined
+      if (fromValues) parentIds.add(fromValues)
+      else missing.push(entityInstanceId)
+    }
+
+    if (missing.length > 0) {
+      const { batchResolveSubpartParentIds } = await import('./part-kind-queries')
+      for (const id of await batchResolveSubpartParentIds(organizationId, missing)) {
+        parentIds.add(id)
+      }
+    }
+
+    if (parentIds.size === 0) {
+      logger.warn('Could not resolve any parent part for kind derivation', {
+        organizationId,
+        recordCount: records.length,
+      })
+      return
+    }
+
+    await promoteUnclassifiedParts(organizationId, [...parentIds])
+  } catch (error) {
+    logger.warn('Part kind derivation failed after a subpart write', {
+      organizationId,
+      recordCount: records.length,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Write `subassembly` onto every part in `partIds` that is unset or
+ * `component`, and announce the change.
+ *
+ * Exported for the migration's backfill, which needs the same write against a
+ * set of parts it resolved itself, on the connection the migration runs on.
+ * Returns the ids actually promoted.
+ */
+export async function promoteUnclassifiedParts(
+  organizationId: string,
+  partIds: string[],
+  db: Database = database
+): Promise<string[]> {
+  if (partIds.length === 0) return []
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['part_kind'] as const)
+  const kindField = fields.part_kind
+  if (!kindField) {
+    logger.warn('No part_kind field in this org; nothing to derive', { organizationId })
+    return []
+  }
+
+  const { readPartKinds } = await import('../../builds/build-queries')
+  const stored = await readPartKinds(db, organizationId, partIds)
+
+  const toPromote = [...new Set(partIds)].filter(
+    (partId) => resolvePartKindPromotion(stored.get(partId) ?? null) === 'promote'
+  )
+  if (toPromote.length === 0) return []
+
+  const partDefId = await requireCachedEntityDefId(organizationId, 'part')
+  const ctx = createFieldValueContext(organizationId, undefined, db)
+  const fieldType = toFieldType(kindField.type)
+  const entries: FieldValueUpdateEntry[] = []
+
+  for (const partId of toPromote) {
+    const recordId = toRecordId(partDefId, partId) as RecordId
+    await setValueWithType(ctx, {
+      recordId,
+      fieldId: kindField.id,
+      fieldType,
+      value: { type: 'option', optionId: PartKind.SUBASSEMBLY },
+    })
+    entries.push({
+      key: buildFieldValueKey(recordId, kindField.id as FieldId),
+      value: { type: 'option', optionId: PartKind.SUBASSEMBLY },
+    })
+  }
+
+  // 🛑 try/catch around the SERVICE lookup, not only the publish. `getRealtimeService`
+  // constructs a Pusher provider on first use, and migration 117 calls this from the
+  // entity-migration runner — a context with no realtime credentials configured. A
+  // missed frame costs an open drawer a repaint; a throw here would abort a backfill
+  // whose write has already landed.
+  try {
+    await publishFieldValueUpdates(getRealtimeService(), organizationId, entries)
+  } catch (error) {
+    logger.warn('Could not announce the part kind promotion', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  logger.info('Promoted parts to subassembly from their bill of materials', {
+    organizationId,
+    considered: partIds.length,
+    promoted: toPromote.length,
+  })
+
+  return toPromote
+}

--- a/packages/lib/src/field-hooks/post/part-kind-queries.ts
+++ b/packages/lib/src/field-hooks/post/part-kind-queries.ts
@@ -1,0 +1,42 @@
+// packages/lib/src/field-hooks/post/part-kind-queries.ts
+
+/**
+ * The one lookup {@link derivePartKindForSubpartBatch} falls back to when a
+ * subpart edge did not thread its parent in the create values.
+ *
+ * Its own module so `part-kind-derivation.ts` can stay free of a static Drizzle
+ * import — the derivation is lazy-loaded from `system-entity-rules.ts` and that
+ * file's header states the rule: keep the top-level graph light so registering a
+ * trigger does not drag the query layer into every module that does it.
+ */
+
+import { database, schema } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+
+/**
+ * Parent `part` ids for a set of `subpart` instances, deduped, in one query.
+ *
+ * Soft-archive keeps `FieldValue` rows, so this resolves a deleted edge too —
+ * not that the derivation runs on deletes (§4.3 decision 2), but the query has
+ * no reason to be narrower than the table.
+ */
+export async function batchResolveSubpartParentIds(
+  organizationId: string,
+  subpartInstanceIds: string[]
+): Promise<string[]> {
+  if (subpartInstanceIds.length === 0) return []
+
+  const rows = await database
+    .select({ relatedEntityId: schema.FieldValue.relatedEntityId })
+    .from(schema.FieldValue)
+    .innerJoin(schema.CustomField, eq(schema.FieldValue.fieldId, schema.CustomField.id))
+    .where(
+      and(
+        inArray(schema.FieldValue.entityId, subpartInstanceIds),
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.CustomField.systemAttribute, 'subpart_parent_part')
+      )
+    )
+
+  return [...new Set(rows.map((r) => r.relatedEntityId).filter((id): id is string => id != null))]
+}

--- a/packages/lib/src/field-hooks/system-entity-rules.test.ts
+++ b/packages/lib/src/field-hooks/system-entity-rules.test.ts
@@ -12,6 +12,7 @@ const h = vi.hoisted(() => ({
   recalculatePartQoH: vi.fn(async () => {}),
   enrichCompanyOnCreate: vi.fn(async () => {}),
   recalculatePartCostForEntityBatch: vi.fn(async () => {}),
+  derivePartKindForSubpartBatch: vi.fn(async () => {}),
 }))
 
 vi.mock('./post/bom-movement-triggers', () => ({ explodeBomMovement: h.explodeBomMovement }))
@@ -19,6 +20,9 @@ vi.mock('./post/inventory-triggers', () => ({ recalculatePartQoH: h.recalculateP
 vi.mock('./post/company-triggers', () => ({ enrichCompanyOnCreate: h.enrichCompanyOnCreate }))
 vi.mock('./post/bom-cost-triggers', () => ({
   recalculatePartCostForEntityBatch: h.recalculatePartCostForEntityBatch,
+}))
+vi.mock('./post/part-kind-derivation', () => ({
+  derivePartKindForSubpartBatch: h.derivePartKindForSubpartBatch,
 }))
 
 import { __clearNativeRuleHandlers, getNativeRuleHandler } from '../record-rules/actions'
@@ -74,6 +78,31 @@ describe('registerEntitySystemRules — declarations', () => {
     expect(handlers.indexOf('explodeBomMovement')).toBeLessThan(
       handlers.indexOf('recalculatePartQoH')
     )
+  })
+
+  // 🛑 `derivePartKind` promotes the parent to `subassembly`, and the recalc that
+  // follows ends in `ensureFirstStandardCosts`. `absorbsConversionCost` is false
+  // for a `component`, so a roll that ran first would freeze a standard with no
+  // labour or overhead in it on exactly the parts the promotion exists to make
+  // buildable (plans/money/tasks/23 §4.1).
+  it('derives part kind BEFORE the cost recalc on subpart create', () => {
+    const created = getSystemRuleDeclarations().find(
+      (d) => d.defSlug === 'subparts' && d.on === 'created'
+    )!
+    const handlers = created.actions.map((a) => (a as { handler?: string }).handler)
+    expect(handlers).toEqual(['derivePartKind', 'entityCostRecalcSubpart'])
+  })
+
+  // 🛑 Decision 2 (§4.3): a subassembly whose last subpart was removed is a data
+  // question, and auto-demoting would silently restate its standard cost. The
+  // derivation is a `created`-only rule and this is what says so.
+  it('never runs the derivation on subpart DELETE', () => {
+    const deleted = getSystemRuleDeclarations().find(
+      (d) => d.defSlug === 'subparts' && d.on === 'deleted'
+    )!
+    const handlers = deleted.actions.map((a) => (a as { handler?: string }).handler)
+    expect(handlers).toEqual(['entityCostRecalcSubpart'])
+    expect(handlers).not.toContain('derivePartKind')
   })
 
   it('re-SUMs the PO line qty billed on both bill-line lifecycle doors', () => {
@@ -153,6 +182,24 @@ describe('native handlers — fan-out + batch adaptation', () => {
       records: [
         { entityInstanceId: 'v1', values: { vendor_part_part: 'p1' } },
         { entityInstanceId: 'v2', values: undefined },
+      ],
+    })
+  })
+
+  it('part kind derivation BATCHES the whole firing, with the threaded parents', async () => {
+    const handler = getNativeRuleHandler('derivePartKind')!
+    await handler({
+      recordIds: [RID('spDef:s1'), RID('spDef:s2')],
+      organizationId: 'org_1',
+      action: 'created',
+      eventDataByRecordId: { [RID('spDef:s1')]: { subpart_parent_part: 'p1' } },
+    })
+    expect(h.derivePartKindForSubpartBatch).toHaveBeenCalledTimes(1)
+    expect(h.derivePartKindForSubpartBatch).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      records: [
+        { entityInstanceId: 's1', values: { subpart_parent_part: 'p1' } },
+        { entityInstanceId: 's2', values: undefined },
       ],
     })
   })

--- a/packages/lib/src/field-hooks/system-entity-rules.ts
+++ b/packages/lib/src/field-hooks/system-entity-rules.ts
@@ -23,6 +23,7 @@ import type { EntityTriggerEvent, EntityTriggerHandler } from './types'
 
 const ENTITY_COST_RECALC_VENDOR = 'entityCostRecalcVendor'
 const ENTITY_COST_RECALC_SUBPART = 'entityCostRecalcSubpart'
+const DERIVE_PART_KIND = 'derivePartKind'
 const EXPLODE_BOM_MOVEMENT = 'explodeBomMovement'
 const RECALC_PART_QOH = 'recalculatePartQoH'
 const ENRICH_COMPANY_ON_CREATE = 'enrichCompanyOnCreate'
@@ -95,6 +96,22 @@ export function registerEntitySystemRules(): void {
     })
   })
 
+  // `part_kind` from the bill of materials (plans/money/tasks/23 §4) — BATCH, and declared
+  // BEFORE the subpart cost recalc on the same rule. The recalc ends in
+  // `ensureFirstStandardCosts`, and `absorbsConversionCost` is false for a `component`, so a
+  // roll that ran first would freeze a standard with no conversion cost in it on exactly the
+  // parts this promotion exists to make buildable.
+  registerNativeRuleHandler(DERIVE_PART_KIND, async (event) => {
+    const { derivePartKindForSubpartBatch } = await import('./post/part-kind-derivation')
+    await derivePartKindForSubpartBatch({
+      organizationId: event.organizationId,
+      records: event.recordIds.map((rid) => ({
+        entityInstanceId: parseRecordId(rid).entityInstanceId,
+        values: event.eventDataByRecordId?.[rid],
+      })),
+    })
+  })
+
   // Stock movement explosion + QoH — per-record (each movement resolves its own part). Order
   // within the created rule is [explode, qoh]; explode clears the parent adjust-subparts flag,
   // and because we thread the ORIGINAL create values, qoh's `adjust_subparts` skip stays correct.
@@ -153,16 +170,25 @@ const ENTITY_SYSTEM_RULES: SystemRuleDeclaration[] = [
   },
   {
     key: 'mfg-subparts-created',
-    name: 'Recalculate part cost on subpart create',
+    name: 'Derive part kind and recalculate part cost on subpart create',
     defSlug: 'subparts',
     on: 'created',
-    actions: [{ type: 'native', handler: ENTITY_COST_RECALC_SUBPART }],
+    // ORDER MATTERS — promote the parent to `subassembly` BEFORE the recalc rolls it.
+    // See `post/part-kind-derivation.ts` for why, and for why this promotion is the ONLY
+    // one the derivation makes.
+    actions: [
+      { type: 'native', handler: DERIVE_PART_KIND },
+      { type: 'native', handler: ENTITY_COST_RECALC_SUBPART },
+    ],
   },
   {
     key: 'mfg-subparts-deleted',
     name: 'Recalculate part cost on subpart delete',
     defSlug: 'subparts',
     on: 'deleted',
+    // 🛑 No `DERIVE_PART_KIND` here, deliberately (23 §4.3 decision 2). A subassembly whose
+    // last subpart was removed is a data question, and auto-demoting would silently restate
+    // its standard cost; the kind stays and a human changes it.
     actions: [{ type: 'native', handler: ENTITY_COST_RECALC_SUBPART }],
   },
   {

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -77,6 +77,8 @@ import { migration112RecordDocuments } from './migrations/112-record-documents'
 import { migration114RetireGlPostingDefs } from './migrations/114-retire-gl-posting-defs'
 import { migration115VendorPartDisplayPart } from './migrations/115-vendor-part-display-part'
 import { migration116PerPartAbsorption } from './migrations/116-per-part-absorption'
+import { migration117PartKindFromBom } from './migrations/117-part-kind-from-bom'
+import { migration118MovementTypeRelabel } from './migrations/118-movement-type-relabel'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -210,6 +212,10 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // because `linkDisplayFields` runs at seed time.
   migration115VendorPartDisplayPart,
   migration116PerPartAbsorption,
+  // MUST sort after 116 — it turns on conversion-cost absorption for the parts it
+  // promotes, which changes the inputs 116's per-part rates resolve against.
+  migration117PartKindFromBom,
+  migration118MovementTypeRelabel,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/117-part-kind-from-bom.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/117-part-kind-from-bom.test.ts
@@ -1,0 +1,87 @@
+// packages/lib/src/seed/entity-migrations/migrations/117-part-kind-from-bom.test.ts
+//
+// Migration 117 is a backfill of the rule `field-hooks/post/part-kind-derivation.ts`
+// applies at write time, so what can silently go wrong is a divergence between
+// the two: a part promoted when its BOM was entered and a part promoted here
+// must be promoted by the SAME rule, or the field means one thing on old data
+// and another on new.
+//
+// It pins that (the migration calls the rule's own function), the ordering
+// constraint against 116, and every case of the promotion rule itself — the one
+// piece of logic that decides whether a stored value is touched.
+
+import { describe, expect, it } from 'vitest'
+import { resolvePartKindPromotion } from '../../../field-hooks/post/part-kind-derivation'
+import { PartKind } from '../../../resources/registry/enum-values'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { migration117PartKindFromBom } from './117-part-kind-from-bom'
+
+describe('migration 117 registration', () => {
+  it('is registered exactly once, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '117-part-kind-from-bom')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(migration117PartKindFromBom.id).toBe('117-part-kind-from-bom')
+  })
+
+  // 🛑 The promotion turns on `absorbsConversionCost` for every part it touches,
+  // which changes those parts' standard cost at the next roll. 116 is what
+  // decides WHICH rate they absorb, so this must not run first or it changes the
+  // inputs 116's per-part overrides resolve against.
+  it('sorts after 116, which decides what a promoted part absorbs', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.indexOf('117-part-kind-from-bom')).toBeGreaterThan(
+      ids.indexOf('116-per-part-absorption')
+    )
+  })
+})
+
+describe('resolvePartKindPromotion — the whole of the rule', () => {
+  // The default that made a stored `component` meaningless: `part-fields.ts`
+  // ships `defaultValue: COMPONENT` and `applyDefaults` stamps it on import,
+  // API, connectors and seed. Both of these read as "nobody classified this".
+  it('promotes an unset kind', () => {
+    expect(resolvePartKindPromotion(null)).toBe('promote')
+    expect(resolvePartKindPromotion(undefined)).toBe('promote')
+    expect(resolvePartKindPromotion('')).toBe('promote')
+  })
+
+  it('promotes a stored component', () => {
+    expect(resolvePartKindPromotion(PartKind.COMPONENT)).toBe('promote')
+  })
+
+  // 🛑 Decision 1: this fills an unclassified part in, it does not adjudicate a
+  // classified one. Overwriting `finished_good` is the move with a ledger
+  // consequence — it is the only kind that maps to INVENTORY_FINISHED_GOODS, and
+  // `complete-build.ts` stamps the produce row from it on every completion.
+  it('leaves a part somebody classified as built', () => {
+    expect(resolvePartKindPromotion(PartKind.SUBASSEMBLY)).toBe('leave')
+    expect(resolvePartKindPromotion(PartKind.FINISHED_GOOD)).toBe('leave')
+  })
+
+  // Decision 3's escape hatch works only if an unrecognised value is left alone
+  // too — an org that added a fourth kind owns it, exactly as `resolvePartKind`
+  // assumes.
+  it('leaves a value this codebase does not recognise', () => {
+    expect(resolvePartKindPromotion('kit')).toBe('leave')
+  })
+})
+
+describe('the promotion never reaches finished_good', () => {
+  // 🛑 The tempting version is the full two-predicate derivation — *has a BOM
+  // and is nobody's subpart => finished good* — and it does not work, because
+  // the second predicate is unstable at write time. People build bottom-up, so
+  // a subassembly is nobody's subpart at the instant it gets its own BOM; the
+  // rule would stamp `finished_good` and then need to DEMOTE it, which silently
+  // moves where the part posts from that point on.
+  //
+  // The rule has one output and this is the test that says so.
+  it('has exactly two dispositions, neither of which is finished_good', () => {
+    const outcomes = new Set(
+      [null, '', PartKind.COMPONENT, PartKind.SUBASSEMBLY, PartKind.FINISHED_GOOD, 'kit'].map(
+        (stored) => resolvePartKindPromotion(stored)
+      )
+    )
+    expect([...outcomes].sort()).toEqual(['leave', 'promote'])
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/117-part-kind-from-bom.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/117-part-kind-from-bom.ts
@@ -1,0 +1,117 @@
+// packages/lib/src/seed/entity-migrations/migrations/117-part-kind-from-bom.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { promoteUnclassifiedParts } from '../../../field-hooks/post/part-kind-derivation'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:117')
+
+/**
+ * Migration 117: give every part that already has a bill of materials the
+ * `part_kind` the derivation would have given it
+ * (plans/money/tasks/23-build-from-the-part.md §4.4).
+ *
+ * ## Why a backfill at all
+ *
+ * The rule this completes fires on `mfg-subparts-created`, so it only ever sees
+ * NEW subpart edges. Every part whose BOM was entered before the rule existed
+ * would keep whatever `part_kind` it had — which, in four of the five orgs
+ * measured on 2026-08-31, was NULL on every single part. `resolvePartKind` reads
+ * NULL as `component`, so those parts stayed unbuildable and the refusal told
+ * the user to go set a field.
+ *
+ * Measured blast radius at the time of writing: **4 parts**, across MagnusCorp,
+ * Kunstler and Kopilot Test. DemoOrg1 needs nothing, and that is also the check
+ * that this is right — it must be a no-op on all 244 of its parts, because a
+ * human classified every one of them and the graph agreed 244 times out of 244.
+ *
+ * ## The rule, once
+ *
+ * `promoteUnclassifiedParts` is the SAME function the native rule handler calls,
+ * so a part promoted at write time and a part promoted here cannot be promoted
+ * by two different rules. It writes `subassembly` where the stored kind is unset
+ * or `component`, and touches nothing else — a `subassembly` stays, a
+ * `finished_good` stays, and an unrecognised value belongs to whoever added it.
+ *
+ * 🛑 **Promotion only, and never to `finished_good`.** The reasoning is in
+ * `field-hooks/post/part-kind-derivation.ts`: `finished_good` is the only kind
+ * that maps to `INVENTORY_FINISHED_GOODS`, and this migration must not move
+ * where any part posts. `component` and `subassembly` share an account, so it
+ * moves no money.
+ *
+ * ⚠️ It DOES turn on `absorbsConversionCost` for the parts it touches, so their
+ * standard cost changes at the next roll. That is the point — a part with a BOM
+ * that absorbed no labour or overhead was understating its own standard — but it
+ * is why this lands after migration 116 rather than beside it.
+ *
+ * Idempotent: a re-run finds every part already carrying a built kind and
+ * promotes nothing.
+ */
+export const migration117PartKindFromBom: EntityMigration = {
+  id: '117-part-kind-from-bom',
+  description:
+    'Set part_kind to subassembly on every unclassified part that has a bill of materials',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    const parentPartIds = await readPartsWithABom(db, organizationId)
+    if (parentPartIds.length === 0) return { ...state, alreadyUpToDate: true }
+
+    const promoted = await promoteUnclassifiedParts(organizationId, parentPartIds, db)
+
+    const alreadyUpToDate = promoted.length === 0
+    if (!alreadyUpToDate) {
+      logger.info('Migration 117 applied', {
+        organizationId,
+        partsWithABom: parentPartIds.length,
+        promoted: promoted.length,
+      })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}
+
+/**
+ * Every part that is the parent of at least one live subpart edge.
+ *
+ * The edge's own instance must be unarchived: a soft-deleted subpart keeps its
+ * `FieldValue` rows (which is what makes the delete trigger able to resolve its
+ * parent at all), so reading the values alone would promote a part whose bill of
+ * materials was removed.
+ */
+async function readPartsWithABom(db: Database, organizationId: string): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ parentPartId: schema.FieldValue.relatedEntityId })
+    .from(schema.FieldValue)
+    .innerJoin(schema.CustomField, eq(schema.FieldValue.fieldId, schema.CustomField.id))
+    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.CustomField.systemAttribute, 'subpart_parent_part'),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+
+  const partIds = rows.map((r) => r.parentPartId).filter((id): id is string => id != null)
+  if (partIds.length === 0) return []
+
+  // The parent must itself still exist and be unarchived — a dangling relation
+  // value is a hygiene question, not something to write a field onto.
+  const live = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        inArray(schema.EntityInstance.id, [...new Set(partIds)]),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+
+  return live.map((row) => row.id)
+}

--- a/packages/lib/src/seed/entity-migrations/migrations/118-movement-type-relabel.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/118-movement-type-relabel.test.ts
@@ -1,0 +1,135 @@
+// packages/lib/src/seed/entity-migrations/migrations/118-movement-type-relabel.test.ts
+//
+// Migration 118 is a pure label UPDATE inside a JSONB blob, so what can silently
+// go wrong is never the write:
+//
+//  - the label lives in TWO places — `StockMovementType.values` (fresh orgs, and
+//    every surface that reads the registry) and each org's own
+//    `CustomField.options` JSONB (this migration) — and if they diverge, which
+//    label a user sees depends on which screen they are on;
+//  - `FieldValue.optionId` stores the `value` key, so rewriting one here would
+//    orphan every stored movement type in the org;
+//  - and the guard has to leave an org's own wording alone.
+//
+// These pin all three, plus the rule that the two build labels move together.
+
+import { describe, expect, it } from 'vitest'
+import { StockMovementType } from '../../../resources/registry/enum-values'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import {
+  MOVEMENT_TYPE_RELABELS,
+  migration118MovementTypeRelabel,
+  relabelOptions,
+  resolveLabel,
+} from './118-movement-type-relabel'
+
+describe('migration 118 registration', () => {
+  it('is registered exactly once, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '118-movement-type-relabel')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(migration118MovementTypeRelabel.id).toBe('118-movement-type-relabel')
+  })
+
+  // The two migration directories share ONE id space, so a number free in one
+  // can still be taken in the other.
+  it('does not reuse an id already spent in the shared space', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id.startsWith('118-'))).toEqual(['118-movement-type-relabel'])
+  })
+})
+
+describe('the registry agrees with the migration', () => {
+  // 🛑 The registry reaches fresh orgs and this spec reaches existing ones.
+  // Changing one without the other is exactly the half-migration that splits a
+  // label by surface: `part-inventory-card.tsx` reads `StockMovementType.values`
+  // while the records view reads the stored JSONB.
+  it('every relabel names the value the registry already carries', () => {
+    for (const spec of MOVEMENT_TYPE_RELABELS) {
+      const option = StockMovementType.values.find((value) => value.value === spec.value)
+      expect(option, `${spec.value} is not a StockMovementType`).toBeDefined()
+      expect(option?.label).toBe(spec.next)
+    }
+  })
+
+  it('covers BOTH build movement types', () => {
+    expect(MOVEMENT_TYPE_RELABELS.map((spec) => spec.value).sort()).toEqual([
+      'build_consume',
+      'build_produce',
+    ])
+  })
+})
+
+describe('resolveLabel', () => {
+  const spec = { old: 'Build (produce)', next: 'Produced' }
+
+  it('updates the exact seeded label', () => {
+    expect(resolveLabel('Build (produce)', spec)).toBe('update')
+  })
+
+  it('reports the new label as already done', () => {
+    expect(resolveLabel('Produced', spec)).toBe('up-to-date')
+  })
+
+  // The org renamed it themselves and owns that string.
+  it('skips anything else', () => {
+    expect(resolveLabel('Made', spec)).toBe('skip')
+    expect(resolveLabel('', spec)).toBe('skip')
+  })
+})
+
+describe('relabelOptions', () => {
+  const seeded = [
+    { value: 'receive', label: 'Receive', color: 'green' },
+    { value: 'adjust', label: 'Adjust', color: 'yellow' },
+    { value: 'build_consume', label: 'Build (consume)', color: 'orange' },
+    { value: 'build_produce', label: 'Build (produce)', color: 'teal' },
+  ]
+
+  it('rewrites both build labels and nothing else', () => {
+    const next = relabelOptions(seeded, MOVEMENT_TYPE_RELABELS)
+    expect(next).not.toBeNull()
+    expect(next?.map((option) => option.label)).toEqual([
+      'Receive',
+      'Adjust',
+      'Consumed',
+      'Produced',
+    ])
+  })
+
+  // 🛑 `FieldValue.optionId` stores the `value`. Touching one would orphan every
+  // movement of that type, on `updatable: false` rows nothing can restate.
+  it('preserves every value, colour and position', () => {
+    const next = relabelOptions(seeded, MOVEMENT_TYPE_RELABELS)!
+    expect(next.map((option) => option.value)).toEqual(seeded.map((option) => option.value))
+    expect(next.map((option) => option.color)).toEqual(seeded.map((option) => option.color))
+  })
+
+  it('is a no-op on a second run', () => {
+    const once = relabelOptions(seeded, MOVEMENT_TYPE_RELABELS)!
+    expect(relabelOptions(once, MOVEMENT_TYPE_RELABELS)).toBeNull()
+  })
+
+  it('leaves an org that renamed the options alone', () => {
+    const customized = [
+      { value: 'build_consume', label: 'Issued to job', color: 'orange' },
+      { value: 'build_produce', label: 'Completed to stock', color: 'teal' },
+    ]
+    expect(relabelOptions(customized, MOVEMENT_TYPE_RELABELS)).toBeNull()
+  })
+
+  it('relabels the half that is still seeded when the other was customized', () => {
+    const mixed = [
+      { value: 'build_consume', label: 'Issued to job', color: 'orange' },
+      { value: 'build_produce', label: 'Build (produce)', color: 'teal' },
+    ]
+    const next = relabelOptions(mixed, MOVEMENT_TYPE_RELABELS)!
+    expect(next.map((option) => option.label)).toEqual(['Issued to job', 'Produced'])
+  })
+
+  it('ignores an option list that carries neither value', () => {
+    expect(
+      relabelOptions([{ value: 'receive', label: 'Receive' }], MOVEMENT_TYPE_RELABELS)
+    ).toBeNull()
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/118-movement-type-relabel.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/118-movement-type-relabel.ts
@@ -1,0 +1,164 @@
+// packages/lib/src/seed/entity-migrations/migrations/118-movement-type-relabel.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:118')
+
+/**
+ * The two `stock_movement_type` options a build writes, relabelled
+ * (plans/money/tasks/23-build-from-the-part.md §6).
+ *
+ * `Build (produce)` / `Build (consume)` name the mechanism; `Produced` /
+ * `Consumed` name what happened to the stock, which is what the other options
+ * beside them do (`Receive`, `Adjust`, `Sale`).
+ *
+ * 🛑 Both, or neither. `Produced` next to `Build (consume)` is a worse pairing
+ * than either original, so the two move in ONE spec array rather than in two
+ * migrations.
+ */
+export const MOVEMENT_TYPE_RELABELS = [
+  { value: 'build_consume', old: 'Build (consume)', next: 'Consumed' },
+  { value: 'build_produce', old: 'Build (produce)', next: 'Produced' },
+] as const
+
+/** The one field whose stored `options` JSONB carries them. */
+const MOVEMENT_TYPE_ATTRIBUTE = 'stock_movement_type'
+
+/**
+ * Decide what to do with one seeded option label.
+ *
+ * Verbatim from `106-supplier-pricing-relabel.ts`, deliberately — same problem,
+ * same rule, and divergence between the two would be a trap.
+ *
+ * `skip` when the stored label is NEITHER the old nor the new value, because an
+ * org that renamed the option themselves owns that string. This migration only
+ * replaces what the seeder wrote.
+ */
+export function resolveLabel(
+  current: string,
+  spec: { old: string; next: string }
+): 'update' | 'up-to-date' | 'skip' {
+  if (current === spec.next) return 'up-to-date'
+  if (current === spec.old) return 'update'
+  return 'skip'
+}
+
+/** One stored option, as `CustomField.options.options[]` holds it. */
+interface StoredOption {
+  value: string
+  label: string
+  [key: string]: unknown
+}
+
+/**
+ * Apply the spec array to a stored options list, returning the new list or
+ * `null` when nothing changed.
+ *
+ * 🛑 **`value` and every sibling key are preserved, and so is order.**
+ * `FieldValue.optionId` stores the `value` key, so rewriting one here would
+ * orphan every stored movement type in the org — 88 rows across the database
+ * as measured, all of them on `updatable: false` fields that nothing can
+ * restate. Only `label` is touched, and only on the two options named.
+ *
+ * Pure, so the rule is testable without a database.
+ */
+export function relabelOptions(
+  options: readonly StoredOption[],
+  specs: readonly { value: string; old: string; next: string }[]
+): StoredOption[] | null {
+  let changed = false
+  const next = options.map((option) => {
+    const spec = specs.find((candidate) => candidate.value === option.value)
+    if (!spec) return option
+    const action = resolveLabel(option.label, spec)
+    if (action !== 'update') return option
+    changed = true
+    return { ...option, label: spec.next }
+  })
+  return changed ? next : null
+}
+
+/**
+ * Migration 118: `Build (produce)` -> `Produced`, `Build (consume)` ->
+ * `Consumed`, in every org's stored `stock_movement_type` options.
+ *
+ * ## 🛑 Why the enum edit alone is not enough
+ *
+ * `stock-movement-fields.ts` declares `options: { options: StockMovementType.values }`,
+ * and those options are **materialized into `CustomField.options` JSONB at seed
+ * time**. `mergeSystemAndCustomFields` reads labels from the DB row, never from
+ * the registry — `106-supplier-pricing-relabel.ts` states this exactly, and it
+ * is the whole reason that migration exists.
+ *
+ * So after the registry edit and before this migration, ONE value has TWO labels
+ * depending on which surface you are looking at:
+ *
+ * | Surface | Label source | Shows |
+ * | --- | --- | --- |
+ * | Inventory card badge, build ledger card | `TYPE_LABEL_MAP` off the registry | `Produced` |
+ * | Records view column, filter dropdown, Details panel | DB `CustomField.options` | `Build (produce)` |
+ *
+ * ## 🛑 `refreshSelectOptions` will not do it
+ *
+ * `108-purchasing.ts` has a helper that looks like the right tool and is not.
+ * Its own doc says so: it compares `value` keys in order and returns `false`
+ * when they match, so *"a relabel or recolour alone does not trigger a
+ * rewrite."* Passing it this change is a silent no-op.
+ *
+ * Idempotent — a re-run finds the new labels and reports `alreadyUpToDate`.
+ */
+export const migration118MovementTypeRelabel: EntityMigration = {
+  id: '118-movement-type-relabel',
+  description: 'Relabel the two build stock-movement types to Produced and Consumed',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    const field = await db.query.CustomField.findFirst({
+      where: and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.modelType, 'stock_movement'),
+        eq(schema.CustomField.systemAttribute, MOVEMENT_TYPE_ATTRIBUTE)
+      ),
+      columns: { id: true, options: true },
+    })
+    // An org that never got the def (seeded before it existed, or a fleet where
+    // parts are off) is not a failure — there is nothing to relabel.
+    if (!field) return { ...state, alreadyUpToDate: true }
+
+    const stored = (field.options as { options?: StoredOption[] } | null)?.options
+    if (!Array.isArray(stored)) return { ...state, alreadyUpToDate: true }
+
+    const next = relabelOptions(stored, MOVEMENT_TYPE_RELABELS)
+    if (!next) {
+      // Either already relabelled, or the org renamed these themselves. Both are
+      // `alreadyUpToDate`; only the second is worth a line in the log.
+      const customized = stored.filter((option) => {
+        const spec = MOVEMENT_TYPE_RELABELS.find((s) => s.value === option.value)
+        return spec ? resolveLabel(option.label, spec) === 'skip' : false
+      })
+      if (customized.length > 0) {
+        logger.warn('Migration 118 skipped customized movement type labels', {
+          organizationId,
+          labels: customized.map((option) => option.label),
+        })
+      }
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    await db
+      .update(schema.CustomField)
+      .set({
+        options: { ...(field.options as Record<string, unknown>), options: next },
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.CustomField.id, field.id))
+
+    logger.info('Migration 118 applied', { organizationId, optionsRelabelled: next.length })
+
+    return { ...state, alreadyUpToDate: false }
+  },
+}


### PR DESCRIPTION
A part drawer could already move stock two ways — Receive and Adjust — and not the third. This adds the missing affordance, and closes the create-path gap the investigation exposed.

## The finding that shaped it

`builds.create` had **no caller in the browser**. Every `api.builds.*` call site was `previewRoll`/`roll`/`get`/`start`/`cancel`/`reverse`/`complete`/`previewCompletion`; the only production caller of `createBuild` anywhere was `reconcile-order-builds.ts`, the order trigger. `build` was not in `CUSTOM_EDITORS`, so "New build" in the records view went generic dialog → `record.create` → `UnifiedCrudHandler` and **skipped both of `createBuild`'s validations**. Not a money defect — `completeBuild` still gates on a real standard cost — but a build could be raised against a purchased washer with an empty BOM.

## What's here

| | |
| --- | --- |
| `part-stock-actions.tsx` | One `Actions` popover in the Inventory card's Stock Movements sub-header: `Receive` / `Adjust` / `Build` |
| `build-part-form.tsx` | Quantity, notes, the priced plan, and three verbs — `Plan`, `Plan and open…`, `Build now` |
| `builds/build-now.ts` + `builds.buildNow` | create → start → complete, 9 tests |
| `field-hooks/post/part-kind-derivation.ts` | `part_kind` derived from the BOM, on the existing `mfg-subparts-created` rule |
| **migration 117** | `117-part-kind-from-bom` — the backfill |
| **migration 118** | `118-movement-type-relabel` — `Build (produce)` → `Produced` |
| `build-form-dialog.tsx` | `build` in `CUSTOM_EDITORS`, CREATE only |

## Decisions worth reviewing

- 🛑 **`buildNow`'s mid-composition failure is a RESULT, not an error.** `BuildNowOutcome` is `{ status: 'completed' } | { status: 'left_in_progress', build, stage, reason }`, returned at a 200. The error channel cannot carry the build it left behind: `trpc.ts`'s `errorFormatter` sends the client `message` and `shape.data` only, and `AuxxError.details` is in neither — an error subclass with a `buildId` field would have compiled, shipped, and delivered nothing to the browser. The `err` channel is reserved for `createBuild` refusing, the one arm that wrote nothing.
- 🛑 **Promotion is to `subassembly` only, never `finished_good`.** `part_kind` holds no information the subpart graph does not already hold — DemoOrg1 cross-tabbed, 244 of 244, zero exceptions. But the two-predicate derivation is unstable at write time: people build bottom-up, so a subassembly is nobody's subpart at the instant it gets its BOM, and the rule would stamp `finished_good` and then need to **demote**, which is the one move that changes an account. `finished_good` keeps `shouldSuggestFinishedGood`'s `hasProduct` path.
- 🛑 **`part_kind` stays a stored field, not a computed one.** Once the kind is derived, a stored `component` on a part *with* a BOM means somebody overrode the rule — so `createBuild` refusing it is correct rather than accidental. The override is what that rests on.
- 🛑 **Migration 118 is not speculative.** The enum edit has landed on `main`, and `stock-movement-fields.ts` materializes the options into `CustomField.options` JSONB where labels are actually read from — so right now the Inventory card badge says `Produced` and the records view column says `Build (produce)` for the same value. `refreshSelectOptions` compares `value` keys only and is a silent no-op here; this follows `106-supplier-pricing-relabel.ts`.
- ⚠️ **On-hand is a warning, never a gate.** `completeBuild` has no on-hand check and deliberately still has none — receiving keyed late is normal in a small shop, and a build refused on a stale count is a worse failure than a negative a receipt corrects an hour later. The resulting balance rides each component line as a badge instead of a block underneath, because on a BOM where eight of eight go negative the block was the same eight names twice.
- ✅ **`BuildEditorAdapter` is CREATE-only.** A custom editor takes over edit as well, and a bespoke edit dialog would have to reimplement the whole Details panel. An edit falls through to `EntityInstanceDialog`; only the create path — the one that was skipping both validations — is claimed.
- **The QoH row is not invalidated after a write.** Both writers end in `publishFieldValueUpdates` with no `excludeSocketId`, the client merges with no self-filter, and every def channel is subscribed, so the acting tab repaints itself. `invalidateResource` would DELETE every cached field value on the part — the pattern `receive-purchase-order-dialog.tsx` and `purchase-order-bills-card.tsx` both removed after it visibly reset their open forms.

## The UI is one popover, not a dropdown

The first cut was a `DropdownMenu` whose items opened three popovers anchored on the menu's trigger. It opened and closed in the same tick, and after the anchoring was fixed it worked only *sometimes* — the shape of a race, not a layout bug: two Radix dismissable layers tearing down and standing up on the same click.

So there is one layer. The `Actions` button opens a popover whose content is the three-item list; choosing one swaps that same popover's content for the form, with a back arrow. Nothing unmounts under the pointer and the anchor never moves. The three forms are mounted as panes (`ReceiveStockForm`, `StockAdjustmentForm`, `BuildPartForm`) and each resets by unmounting, which a pane swap gives for free; `ReceiveStockPopover` and `StockAdjustmentPopover` keep their `children`-trigger API for the Parts detail tab, unchanged.

## Checks

- `typecheck-ratchet` clean both packages — lib 0 new (29 total, baseline 29), web 0 new (0 total, baseline 0)
- biome clean over every touched path
- `packages/lib` suite over `builds`, `field-hooks`, `entity-migrations`: **871 passed, 1 failed** — `108-purchasing.test.ts:1408`, the P13 allowlist against three `vendor-bill-delete-guard` files, already broken on `main` and untouched here

## Not done

- 🛑 **Nothing driven in a browser.** `Build now` → `Produced` badge on a real `finished_good`, and the promotion flipping an unclassified part to `subassembly` in the same drawer session, are both unverified.
- 🛑 **Neither migration applied.** 117's correctness claim is that it is a **no-op on all 244 of DemoOrg1's parts** while promoting exactly the **4** that carry a BOM and no kind elsewhere — that is the check, and it is unverified in SQL.
- ⚠️ `part-inventory-tab.tsx:163`'s redundant `invalidateResource` is left in place — a one-line removal on a surface this does not otherwise touch, wants its own before/after.

https://claude.ai/code/session_01L5LKuhLy5oKy1RirwzJeYF
