### PR TITLE
fix(drawers): name the record you drilled into

### DIFF
--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -33,6 +33,7 @@ import {
   useRecordDrillStack,
   useRecordPeekStack,
 } from '~/components/records/record-drill-panels'
+import { RecordIdentityHeader } from '~/components/records/ui/record-identity-header'
 import { useCanViewRecordResource, useRecord, useResource } from '~/components/resources'
 import { useRecordLink } from '~/components/resources/utils/get-record-link'
 import { TasksSection } from '~/components/tasks/ui/tasks-section'
@@ -404,8 +405,15 @@ function DrawerRecordFrame({
             onReset={handleResetTabs}
           />
 
-          {/* Card content (person card, entity card, etc.) — base frame only (decision #9) */}
-          {isBase && cardContent}
+          {/* Identity header (avatar + display name + secondary line). The HOST's
+              `cardContent` is base-frame only (decision #9) — a peeked frame must
+              derive from its own resource, not the opener's. It still needs a
+              name though: without one, drilling into a supplier/part lands on a
+              header reading only the resource label ("Supplier") with the record's
+              name nowhere but a Details row. Every host's `cardContent` today IS a
+              `RecordIdentityHeader`, so a peeked frame renders the bare one against
+              its own `recordId`. */}
+          {isBase ? cardContent : <RecordIdentityHeader recordId={recordId} readOnly={readOnly} />}
 
           <div className='flex flex-1 overflow-hidden'>
             {/* Base tabs - static */}


### PR DESCRIPTION
## The bug

Drilling from a part into a supplier (or another part) inside the drawer gave you no name for what you opened. The header read `Supplier`, then tabs, then Details — the record's own name survived only as a row in the field list.

## Why

Drilling doesn't open a new drawer. It pushes a **peek frame** onto `useRecordPeekStack`, and each frame renders its own `DrawerRecordFrame`.

The record's name is never rendered by the drawer itself. It comes from `RecordIdentityHeader` (avatar + display name + secondary line), which the **host** passes down as `cardContent`:

- `record-drawer.tsx:325`
- `contact-drawer.tsx:216`
- `detail-view-sidebar.tsx:73` (detail page)

`base-entity-drawer.tsx` gated that prop to `frames[0]`:

```tsx
{/* Card content (person card, entity card, etc.) — base frame only (decision #9) */}
{isBase && cardContent}
```

The gate is right — dispatch v4/04 decision #9 says a peeked frame derives from its own resource, not the opener's — but nothing was put back in its place, so a peeked frame rendered no identity header at all. The drawer header (`base-entity-drawer.tsx:652`) shows `topResource?.label`, the *resource* label, so nothing else names the record either.

## The fix

```tsx
{isBase ? cardContent : <RecordIdentityHeader recordId={recordId} readOnly={readOnly} />}
```

Every host's `cardContent` today *is* a `RecordIdentityHeader` (record-drawer adds a `ConnectorSourceBadge` adornment, contact-drawer passes it bare, dispatch-board passes none), so a peeked frame gets the same header the base frame already shows, resolved against its own `recordId`. Decision #9 holds: the host's version stays base-only.

Fixes drill-down naming for every entity type at once, not just parts.

## Not changed

- The drawer **header title** still shows the resource label for peeked frames, same as for the base frame — that's the existing convention.
- `InvoiceDrillBar` remains the only place titling an *inner* drill bar with a record's `displayName`. The inner drill (`panel`/`item`) is a separate axis from the peek stack.

## Checks

- `src/components/drawers` + `src/components/records` — 13 files, 124 tests, all pass (includes `drawer-card-parity.test.ts` and `record-identity-header.test.tsx`).
- `node scripts/ci/typecheck-ratchet.js --package web` — no new type errors (0 total, baseline 0).
- Biome clean.

https://claude.ai/code/session_01Jrwm4yATf6Mmnnqn2BcDn9