### PR TITLE
feat(parts): the tariff schedule reaches the supplier offer

### DIFF
--- a/apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
+++ b/apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
@@ -1,7 +1,11 @@
 // apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
 'use client'
 
-import { computeLandedBreakdown, type LandedCostBreakdown } from '@auxx/lib/bom/client'
+import {
+  computeLandedBreakdown,
+  type LandedCostBreakdown,
+  type OfferTariff,
+} from '@auxx/lib/bom/client'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -14,8 +18,9 @@ import {
 import { TableCell, TableRow } from '@auxx/ui/components/table'
 import { pluralize } from '@auxx/utils'
 import { formatCurrency } from '@auxx/utils/currency'
-import { BadgeCheck, Edit, MoreHorizontal, Star, Trash2 } from 'lucide-react'
+import { BadgeCheck, Edit, Globe, MoreHorizontal, Star, Trash2 } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
+import { authorityLabel } from '~/components/manufacturing/tariff-types'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
 import { useAccess } from '~/providers/capabilities-provider'
 
@@ -31,6 +36,7 @@ export interface VendorPartRowValues {
   vendorSku?: string
   unitPrice: number | null
   shippingCost: number | null
+  /** The RESOLVED rate - override or schedule - once the tab has resolved it. */
   tariffRate: number | null
   otherCost: number | null
   leadTime: number | null
@@ -42,6 +48,10 @@ export interface VendorPartRowValues {
 interface VendorPartRowProps {
   recordId: RecordId
   values: VendorPartRowValues
+  /** Where `values.tariffRate` came from, for the breakdown's label. */
+  tariff?: OfferTariff
+  /** `8481.80.9005 CN`, when the offer carries a code. Drives the Globe chip. */
+  codeLabel?: string
   /**
    * Whether this offer is the one the part's Cost actually came from.
    *
@@ -63,13 +73,31 @@ interface VendorPartRowProps {
  * carry a fraction. The tariff shows both its rate and the money that rate
  * produced, because "10%" alone does not answer where the tariff went.
  */
-function LandedBreakdown({ breakdown }: { breakdown: LandedCostBreakdown }) {
+function LandedBreakdown({
+  breakdown,
+  tariff,
+  codeLabel,
+}: {
+  breakdown: LandedCostBreakdown
+  tariff?: OfferTariff
+  codeLabel?: string
+}) {
+  // Where the rate came from, so "10%" is never a bare number (task 30 §4):
+  // `(override)`, or the code it resolved from with the components beneath.
+  const tariffSource =
+    tariff?.source === 'override'
+      ? ' (override)'
+      : tariff?.source === 'schedule' && codeLabel
+        ? ` (${codeLabel})`
+        : ''
   const rows: { label: string; value: number }[] = [
     { label: 'Unit price', value: breakdown.unitPrice },
     { label: 'Shipping', value: breakdown.shipping },
-    { label: `Tariff (${breakdown.tariffRate}%)`, value: breakdown.tariff },
+    { label: `Tariff ${breakdown.tariffRate}%${tariffSource}`, value: breakdown.tariff },
     { label: 'Other', value: breakdown.other },
   ]
+  const components =
+    tariff?.source === 'schedule' && tariff.status === 'resolved' ? tariff.components : []
 
   return (
     <div className='min-w-44 space-y-1'>
@@ -79,6 +107,18 @@ function LandedBreakdown({ breakdown }: { breakdown: LandedCostBreakdown }) {
           <span className='tabular-nums'>{row.value === 0 ? '—' : formatCurrency(row.value)}</span>
         </div>
       ))}
+      {components.length > 1 && (
+        <div className='space-y-0.5 ps-3'>
+          {components.map((component) => (
+            <div
+              key={component.id}
+              className='flex justify-between gap-4 text-muted-foreground text-xs'>
+              <span className='truncate'>{authorityLabel(component.authority)}</span>
+              <span className='tabular-nums'>{component.rate}%</span>
+            </div>
+          ))}
+        </div>
+      )}
       <div className='flex justify-between gap-4 border-t pt-1 text-xs font-medium'>
         <span>Landed</span>
         <span className='tabular-nums'>{formatCurrency(breakdown.landed)}</span>
@@ -91,6 +131,8 @@ function LandedBreakdown({ breakdown }: { breakdown: LandedCostBreakdown }) {
 export function VendorPartRow({
   recordId,
   values,
+  tariff,
+  codeLabel,
   isWinner,
   onEdit,
   onDelete,
@@ -135,6 +177,15 @@ export function VendorPartRow({
               </div>
             </Tooltip>
           )}
+          {/* Standing-control-once-set: rendered only when the offer carries a
+              code, so a domestic row shows nothing and loses no width. */}
+          {codeLabel && (
+            <Tooltip content={`Tariff code ${codeLabel}`}>
+              <div className='text-muted-foreground'>
+                <Globe className='size-3.5' />
+              </div>
+            </Tooltip>
+          )}
         </div>
       </TableCell>
       <TableCell className='font-mono text-sm'>{vendorSku ?? '—'}</TableCell>
@@ -151,7 +202,10 @@ export function VendorPartRow({
           // whenever landed equalled the unit price, which is most rows — a
           // supplier with no shipping, tariff or other costs still HAS a landed
           // cost, and it is that supplier's unit price.
-          <Tooltip contentComponent={<LandedBreakdown breakdown={breakdown} />}>
+          <Tooltip
+            contentComponent={
+              <LandedBreakdown breakdown={breakdown} tariff={tariff} codeLabel={codeLabel} />
+            }>
             <span className='underline decoration-dotted underline-offset-4'>
               {formatCurrency(breakdown.landed)}
             </span>

--- a/apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
@@ -13,6 +13,7 @@ import { Table, TableBody, TableHead, TableHeader, TableRow } from '@auxx/ui/com
 import { toastError } from '@auxx/ui/components/toast'
 import { Store } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useOfferTariffs } from '~/components/manufacturing/hooks/use-offer-tariffs'
 import { VendorPartDialog } from '~/components/manufacturing/parts/vendor-part-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
@@ -35,6 +36,7 @@ const VENDOR_PART_ATTRIBUTES = [
   'vendor_part_vendor_sku',
   'vendor_part_unit_price',
   'vendor_part_shipping_cost',
+  'vendor_part_tariff_code',
   'vendor_part_tariff_rate',
   'vendor_part_other_cost',
   'vendor_part_lead_time',
@@ -42,14 +44,23 @@ const VENDOR_PART_ATTRIBUTES = [
   'vendor_part_contact',
 ] as const
 
-/** Narrow one record's raw system values into the row's shape. */
-function toRowValues(values: Record<string, unknown> | undefined): VendorPartRowValues {
+/**
+ * Narrow one record's raw system values into the row's shape.
+ *
+ * `tariffRate` here is the RAW override; the tab resolves the schedule into it
+ * before the winner rule or the row sees it (task 30 §4).
+ */
+function toRowValues(
+  values: Record<string, unknown> | undefined
+): VendorPartRowValues & { tariffCodeId: string | null } {
   const contact = values?.vendor_part_contact as RecordId[] | undefined
+  const code = values?.vendor_part_tariff_code as RecordId[] | undefined
   return {
     vendorSku: values?.vendor_part_vendor_sku as string | undefined,
     unitPrice: (values?.vendor_part_unit_price as number | null | undefined) ?? null,
     shippingCost: (values?.vendor_part_shipping_cost as number | null | undefined) ?? null,
     tariffRate: (values?.vendor_part_tariff_rate as number | null | undefined) ?? null,
+    tariffCodeId: code?.[0] ? parseRecordId(code[0]).entityInstanceId : null,
     otherCost: (values?.vendor_part_other_cost as number | null | undefined) ?? null,
     leadTime: (values?.vendor_part_lead_time as number | null | undefined) ?? null,
     isPreferred: (values?.vendor_part_is_preferred as boolean | undefined) ?? false,
@@ -120,6 +131,31 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
     enabled: rowRecordIds.length > 0,
   })
 
+  // The raw rows, then the schedule resolved INTO each row's `tariffRate` the
+  // way the cost calculator does server-side (task 30 §4). Before this the tab
+  // computed landed cost from the raw override alone, so a classified offer
+  // with no override showed no duty here while `part_cost` included it - two
+  // numbers both called "the landed cost".
+  const rawOffers = useMemo(
+    () => rowRecordIds.map((recordId) => ({ id: recordId, ...toRowValues(valuesById[recordId]) })),
+    [rowRecordIds, valuesById]
+  )
+  const { byId: tariffById, codeLabelById } = useOfferTariffs(rawOffers)
+  const offers = useMemo(
+    () =>
+      rawOffers.map((offer) => {
+        const tariff = tariffById.get(offer.id)
+        return {
+          ...offer,
+          tariffRate: tariff ? tariff.rate : offer.tariffRate,
+          tariff,
+          codeLabel: offer.tariffCodeId ? codeLabelById.get(offer.tariffCodeId) : undefined,
+        }
+      }),
+    [rawOffers, tariffById, codeLabelById]
+  )
+  const offersById = useMemo(() => new Map(offers.map((offer) => [offer.id, offer])), [offers])
+
   /**
    * Which offer the part's Cost came from.
    *
@@ -128,13 +164,7 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
    * float produced by `unitPrice * (tariffRate / 100)`, and equality on it is
    * not a safe key.
    */
-  const winningRecordId = useMemo(() => {
-    const offers = rowRecordIds.map((recordId) => ({
-      id: recordId,
-      ...toRowValues(valuesById[recordId]),
-    }))
-    return selectWinningVendor(offers)?.id ?? null
-  }, [rowRecordIds, valuesById])
+  const winningRecordId = useMemo(() => selectWinningVendor(offers)?.id ?? null, [offers])
 
   // Delete via entity system
   const deleteRecord = api.record.delete.useMutation({
@@ -242,11 +272,14 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
               <TableBody>
                 {recordIds.map((id, index) => {
                   const rowRecordId = rowRecordIds[index] as RecordId
+                  const offer = offersById.get(rowRecordId)
                   return (
                     <VendorPartRow
                       key={id}
                       recordId={rowRecordId}
-                      values={toRowValues(valuesById[rowRecordId])}
+                      values={offer ?? toRowValues(valuesById[rowRecordId])}
+                      tariff={offer?.tariff}
+                      codeLabel={offer?.codeLabel}
                       isWinner={rowRecordId === winningRecordId}
                       onEdit={() => handleEditVendorPart(id)}
                       onDelete={() => handleDeleteVendorPart(id)}

--- a/apps/web/src/components/manufacturing/hooks/use-offer-classification.ts
+++ b/apps/web/src/components/manufacturing/hooks/use-offer-classification.ts
@@ -1,0 +1,164 @@
+// apps/web/src/components/manufacturing/hooks/use-offer-classification.ts
+
+// The Classification tab's read (plans/money/tasks/30-tariff-offer-surfaces.md
+// §6.1): every PRICED supplier offer in the org with its part, supplier, code
+// and override, resolved through the shared seam.
+//
+// `vendor_part` is `isVisible: false` and so has no records page; this list is
+// the only place "what is still unclassified" is answerable at all. Read in
+// full through `useAllRecords` (`record.listAll` does not gate on visibility -
+// checked 2026-09-01) - offers are tens to hundreds of rows, the same shape as
+// the schedule read beside it.
+
+import type { OfferTariff } from '@auxx/lib/bom/client'
+import type { RecordId } from '@auxx/lib/resources/client'
+import { useMemo } from 'react'
+import { type AllRecordsItem, useAllRecords } from '~/components/resources/hooks/use-all-records'
+import type { RecordMeta } from '~/components/resources/store/record-store'
+import { type OfferTariffInput, useOfferTariffs } from './use-offer-tariffs'
+
+/** apiSlug of the supplier offer definition. */
+export const VENDOR_PART_SLUG = 'vendor-parts'
+
+/** The offer's writable tariff attributes, named once. */
+export const VENDOR_PART_TARIFF_ATTRS = {
+  tariffCode: 'vendor_part_tariff_code',
+  tariffRate: 'vendor_part_tariff_rate',
+} as const
+
+interface VendorPartRecord extends RecordMeta {
+  recordId: RecordId
+  fieldValues: {
+    vendor_part_part?: string[] | string | null
+    vendor_part_contact?: string[] | string | null
+    vendor_part_unit_price?: number | null
+    vendor_part_tariff_code?: string[] | string | null
+    vendor_part_tariff_rate?: number | null
+  }
+}
+
+/** One supplier offer as the Classification tab renders and edits it. */
+export interface ClassifiedOffer {
+  id: string
+  recordId: RecordId
+  /** The part's `RecordId`, for a badge. */
+  partRecordId: RecordId | null
+  /** The supplier company's `RecordId`, for a badge. */
+  supplierRecordId: RecordId | null
+  unitPrice: number | null
+  /** `tariff_code` instance id, or `null` when unclassified. */
+  tariffCodeId: string | null
+  /** The override, `null` when the schedule decides. */
+  tariffRate: number | null
+  /** ISO-2 origin of the code, for the country filter. */
+  country: string | null
+  /** `8481.80.9005 CN`. */
+  codeLabel: string | null
+  tariff: OfferTariff
+}
+
+function firstRecordId(value: string[] | string | null | undefined): RecordId | null {
+  const first = Array.isArray(value) ? value[0] : value
+  return first ? (first as RecordId) : null
+}
+
+function instanceIdOf(recordId: RecordId | null): string | null {
+  return recordId ? (recordId.split(':')[1] ?? null) : null
+}
+
+export interface UseOfferClassificationResult {
+  /** Every priced offer, unclassified first, then by part. */
+  offers: ClassifiedOffer[]
+  /** What the schedule alone says per offer id - `useOfferTariffs().scheduleById`. */
+  scheduleById: Map<string, OfferTariff>
+  /** Resolved `vendor_part` definition id, once loaded. */
+  vendorPartDefId: string | null
+  isLoading: boolean
+  /** The schedule is not readable by this viewer - see `useOfferTariffs`. */
+  unavailable: boolean
+  /** ISO-2 -> count of offers classified under that origin, for the filter chips. */
+  countries: Map<string, number>
+}
+
+/** Every priced offer, classified or not, in one read. */
+export function useOfferClassification(
+  codeCountryById: Map<string, string | null>
+): UseOfferClassificationResult {
+  const query = useAllRecords<VendorPartRecord>({
+    apiSlug: VENDOR_PART_SLUG,
+    includeArchived: false,
+  })
+
+  const raw = useMemo(
+    () =>
+      query.records
+        .filter((record) => record.fieldValues.vendor_part_unit_price != null)
+        .map((record) => {
+          const codeRecordId = firstRecordId(record.fieldValues.vendor_part_tariff_code)
+          return {
+            id: record.id,
+            recordId: record.recordId,
+            partRecordId: firstRecordId(record.fieldValues.vendor_part_part),
+            supplierRecordId: firstRecordId(record.fieldValues.vendor_part_contact),
+            unitPrice: record.fieldValues.vendor_part_unit_price ?? null,
+            tariffCodeId: instanceIdOf(codeRecordId),
+            tariffRate: record.fieldValues.vendor_part_tariff_rate ?? null,
+            displayName: record.displayName ?? '',
+          }
+        }),
+    [query.records]
+  )
+
+  const inputs = useMemo<OfferTariffInput[]>(
+    () => raw.map(({ id, tariffCodeId, tariffRate }) => ({ id, tariffCodeId, tariffRate })),
+    [raw]
+  )
+  const {
+    byId,
+    scheduleById,
+    codeLabelById,
+    isLoading: scheduleLoading,
+    unavailable,
+  } = useOfferTariffs(inputs)
+
+  const offers = useMemo<ClassifiedOffer[]>(() => {
+    const rows = raw.map((offer) => {
+      const tariff = byId.get(offer.id) ?? ({ source: 'none', rate: 0 } as OfferTariff)
+      return {
+        ...offer,
+        country: offer.tariffCodeId ? (codeCountryById.get(offer.tariffCodeId) ?? null) : null,
+        codeLabel: offer.tariffCodeId ? (codeLabelById.get(offer.tariffCodeId) ?? null) : null,
+        tariff,
+      }
+    })
+    // The checklist reads top-down: unclassified first, then by the offer's
+    // display name (the part, since migration 115).
+    rows.sort((a, b) => {
+      const aOpen = a.tariffCodeId || a.tariffRate != null ? 1 : 0
+      const bOpen = b.tariffCodeId || b.tariffRate != null ? 1 : 0
+      if (aOpen !== bOpen) return aOpen - bOpen
+      return a.displayName.localeCompare(b.displayName)
+    })
+    return rows
+  }, [raw, byId, codeLabelById, codeCountryById])
+
+  const countries = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const offer of offers) {
+      if (!offer.country) continue
+      map.set(offer.country, (map.get(offer.country) ?? 0) + 1)
+    }
+    return map
+  }, [offers])
+
+  return {
+    offers,
+    scheduleById,
+    vendorPartDefId: query.entityDefinitionId,
+    isLoading: query.isLoading || scheduleLoading,
+    unavailable,
+    countries,
+  }
+}
+
+export type { AllRecordsItem }

--- a/apps/web/src/components/manufacturing/hooks/use-offer-tariffs.ts
+++ b/apps/web/src/components/manufacturing/hooks/use-offer-tariffs.ts
@@ -1,0 +1,140 @@
+// apps/web/src/components/manufacturing/hooks/use-offer-tariffs.ts
+
+// The client-side read seam for an offer's duty rate
+// (plans/money/tasks/30-tariff-offer-surfaces.md §2).
+//
+// Every surface that shows a supplier offer - the supplier form, the Suppliers
+// tab, the Receive form, the Classification tab - needs the same three things
+// per offer: its override, its tariff code, and the rate rows behind that code.
+// The first two are one more attribute in each surface's existing read; the
+// third is what `useTariffSchedule` already loads, both defs in full, which its
+// header defends (a schedule is tens of codes with a handful of rows each).
+//
+// 🛑 The precedence rule is `resolveOfferTariff` from `@auxx/lib/bom/client` and
+// nothing here re-derives it. Six callers each deciding "override, else
+// schedule, else zero" is how the landed formula came to live twice.
+//
+// 🛑 The zone is the org's `bookTimeZone`, read HERE so no caller can forget it.
+// `effectiveFrom` is a calendar day and the lookup is an instant; compared in
+// UTC a rate starting March 2 puts a March 1 evening on the wrong side of the
+// change, silently and by exactly one day.
+
+import { type OfferTariff, type OfferTariffInputs, resolveOfferTariff } from '@auxx/lib/bom/client'
+import { useMemo } from 'react'
+import { useSettings } from '~/hooks/use-settings'
+import { useAccess } from '~/providers/capabilities-provider'
+import { composeTariffLabel } from '../tariff-types'
+import { useTariffSchedule } from './use-tariff-schedule'
+
+/** One offer, as the surfaces hand it in. `id` is whatever key the caller wants back. */
+export interface OfferTariffInput extends OfferTariffInputs {
+  id: string
+}
+
+export interface UseOfferTariffsResult {
+  /** The resolved answer per offer `id`. Every input has an entry. */
+  byId: Map<string, OfferTariff>
+  /**
+   * What the SCHEDULE alone says per offer `id`, override ignored. Same as
+   * {@link byId} unless the offer carries both an override and a code - the
+   * both-set case 29 §3.1 resolves silently and 30 §3.2 says must be loud.
+   */
+  scheduleById: Map<string, OfferTariff>
+  /** `8481.80.9005 CN`, per `tariff_code` instance id, for chips and tooltips. */
+  codeLabelById: Map<string, string>
+  /** False once loaded with no `tariff_code` at all - the picker's empty state. */
+  hasCodes: boolean
+  /** True while the two schedule reads are in flight. */
+  isLoading: boolean
+  /**
+   * The viewer cannot read the schedule, so every classified offer below is
+   * resolved as if its code had no rows. Surfaces render the override-only view
+   * with a hint rather than a confident `0%`.
+   */
+  unavailable: boolean
+  /** The org's book timezone, for a caller that resolves something else in the same zone. */
+  bookTimeZone: string
+}
+
+/**
+ * Resolve a list of offers at `atDate` (default: now) through the shared rule.
+ *
+ * `atDate` defaults to a single `Date` per mount, so a list of rows agrees on
+ * what "today" is rather than each row straddling midnight on its own. The
+ * Receive form passes its `occurredAt`, which is the point of a dated schedule.
+ */
+export function useOfferTariffs(
+  offers: ReadonlyArray<OfferTariffInput>,
+  atDate?: Date | string | null
+): UseOfferTariffsResult {
+  const { canViewEntity } = useAccess()
+  const { codes, ratesByCode, codeDefId, rateDefId, isLoading } = useTariffSchedule()
+
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const bookTimeZone = (getSetting('accounting.bookTimeZone') as string) || 'UTC'
+
+  // Only asked once the defs are known. Before that the answer is "loading",
+  // not "unavailable".
+  const unavailable =
+    !!codeDefId && !!rateDefId && !(canViewEntity(codeDefId) && canViewEntity(rateDefId))
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- one instant per mount when no date is given
+  const now = useMemo(() => new Date(), [])
+  const resolvedAt = useMemo(() => {
+    if (atDate == null || atDate === '') return now
+    const parsed = atDate instanceof Date ? atDate : new Date(atDate)
+    return Number.isNaN(parsed.getTime()) ? now : parsed
+  }, [atDate, now])
+
+  const codeLabelById = useMemo(
+    () => new Map(codes.map((code) => [code.id, composeTariffLabel(code.code, code.country)])),
+    [codes]
+  )
+
+  // `resolveOfferTariff` takes `TariffRateRow`s; the page's `TariffRate` is a
+  // superset of that shape, so the map is passed straight through.
+  const { byId, scheduleById } = useMemo(() => {
+    const byId = new Map<string, OfferTariff>()
+    const scheduleById = new Map<string, OfferTariff>()
+    for (const offer of offers) {
+      byId.set(offer.id, resolveOfferTariff(offer, ratesByCode, resolvedAt, bookTimeZone))
+      scheduleById.set(
+        offer.id,
+        resolveOfferTariff({ ...offer, tariffRate: null }, ratesByCode, resolvedAt, bookTimeZone)
+      )
+    }
+    return { byId, scheduleById }
+  }, [offers, ratesByCode, resolvedAt, bookTimeZone])
+
+  return {
+    byId,
+    scheduleById,
+    codeLabelById,
+    hasCodes: codes.length > 0,
+    isLoading,
+    unavailable,
+    bookTimeZone,
+  }
+}
+
+/**
+ * The one-line reading of an {@link OfferTariff}: `47% (schedule)`,
+ * `12% (override)`, or `none`. For places with room for a single token; the
+ * supplier form's Duty row renders the components in full.
+ */
+export function describeOfferTariff(tariff: OfferTariff): string {
+  switch (tariff.source) {
+    case 'override':
+      return `${formatPercent(tariff.rate)} (override)`
+    case 'schedule':
+      if (tariff.status === 'resolved') return `${formatPercent(tariff.rate)} (schedule)`
+      return tariff.status === 'pending' ? 'Starts later' : 'No rate on code'
+    case 'none':
+      return 'No duty'
+  }
+}
+
+/** `25` reads `25%`, `12.375` reads `12.38%`. Trailing zeros dropped. */
+export function formatPercent(rate: number): string {
+  return `${Math.round(rate * 100) / 100}%`
+}

--- a/apps/web/src/components/manufacturing/hooks/use-tariff-schedule.ts
+++ b/apps/web/src/components/manufacturing/hooks/use-tariff-schedule.ts
@@ -1,4 +1,4 @@
-// apps/web/src/components/manufacturing/ui/settings/use-tariff-schedule.ts
+// apps/web/src/components/manufacturing/hooks/use-tariff-schedule.ts
 
 // Reads the whole tariff schedule - every `tariff_code` and every `tariff_rate`
 // in the org - through the generic record system.
@@ -30,7 +30,7 @@ import {
   TARIFF_RATE_SLUG,
   type TariffCode,
   type TariffRate,
-} from './tariff-types'
+} from '../tariff-types'
 
 /** `tariff_code` as `useAllRecords` hands it back (systemAttribute-keyed). */
 interface TariffCodeRecord extends RecordMeta {

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -96,6 +96,7 @@ export function PartFormDialog({
   const partDefId = useResourceProperty('part', 'id')
   const productDefId = useResourceProperty('product', 'id')
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
+  const tariffCodeDefId = useResourceProperty('tariff_code', 'id')
   const companyDefId = useResourceProperty('company', 'id')
 
   // Live field def for the Category TAGS input (sources existing option pool).
@@ -321,6 +322,17 @@ export function PartFormDialog({
               vendor_part_contact: toRecordId(companyDefId!, vendorPartValues.entityInstanceId),
               vendor_part_vendor_sku: vendorPartValues.vendorSku,
               vendor_part_unit_price: vendorPartValues.unitPrice,
+              // ⚠️ Every field `VendorPartFields` renders is written. Shipping,
+              // tariff and other cost were rendered and NOT written here for a
+              // long time, so anything typed into them at part creation was
+              // dropped without error (task 30 §3.5).
+              vendor_part_shipping_cost: vendorPartValues.shippingCost,
+              vendor_part_tariff_code:
+                vendorPartValues.tariffCodeId && tariffCodeDefId
+                  ? toRecordId(tariffCodeDefId, vendorPartValues.tariffCodeId)
+                  : undefined,
+              vendor_part_tariff_rate: vendorPartValues.tariffRate,
+              vendor_part_other_cost: vendorPartValues.otherCost,
               vendor_part_lead_time: vendorPartValues.leadTime,
               vendor_part_min_order_qty: vendorPartValues.minOrderQty,
               vendor_part_is_preferred: vendorPartValues.isPreferred,
@@ -496,10 +508,12 @@ export function PartFormDialog({
             </FieldPanelRow>
           )}
 
-          {/* HS Code */}
+          {/* HS Code. ⚠️ Read by nothing (29 §0.1). The duty comes from the
+              supplier offer's tariff code, which pairs a code with an origin;
+              this is a hint the supplier form shows under that picker. */}
           <FieldPanelRow
             title='HS Code'
-            description='Harmonized System Code for customs'
+            description="A hint for the supplier's tariff code picker. The duty itself comes from each supplier offer's tariff code, which pairs the code with a country of origin."
             type={BaseType.STRING}
             showIcon>
             <FieldInputAdapter
@@ -551,6 +565,7 @@ export function PartFormDialog({
                   onChange={handleVendorPartChange}
                   errors={vendorPartErrors}
                   disabled={isPending}
+                  partHsCode={values.hsCode}
                 />
               </FieldPanel>
             )}

--- a/apps/web/src/components/manufacturing/parts/receipt-input.ts
+++ b/apps/web/src/components/manufacturing/parts/receipt-input.ts
@@ -39,7 +39,10 @@ export interface ReceiptFormState {
   /** The selected supplier row, or null when the part has none. */
   vendorPartId: string | null
   /** The selected row's freight/tariff/other terms. */
-  terms: Pick<ReceiptCostInputs, 'shippingCost' | 'tariffRate' | 'otherCost'> | null
+  terms: Pick<
+    ReceiptCostInputs,
+    'shippingCost' | 'tariffRate' | 'tariffSource' | 'otherCost'
+  > | null
   /** The base price as it stands in the input — prefilled, possibly edited. */
   unitPrice: number | null
   /** ISO string from the date input. */
@@ -63,6 +66,7 @@ export function receiptBreakdown(state: ReceiptFormState): ReceiptCostParts | nu
     unitPrice: state.unitPrice,
     shippingCost: state.terms?.shippingCost ?? null,
     tariffRate: state.terms?.tariffRate ?? null,
+    tariffSource: state.terms?.tariffSource ?? null,
     otherCost: state.terms?.otherCost ?? null,
   })
 }

--- a/apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/receive-stock-popover.tsx
@@ -28,6 +28,7 @@
 import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { formatLandedCostSummary, type ReceiptCostInputs } from '@auxx/lib/receiving/client'
+import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
@@ -36,6 +37,7 @@ import { formatCurrency } from '@auxx/utils/currency'
 import { useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useOfferTariffs } from '~/components/manufacturing/hooks/use-offer-tariffs'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 import { BaseType } from '~/components/workflow/types'
@@ -48,6 +50,7 @@ const VENDOR_PART_ATTRIBUTES = [
   'vendor_part_vendor_sku',
   'vendor_part_unit_price',
   'vendor_part_shipping_cost',
+  'vendor_part_tariff_code',
   'vendor_part_tariff_rate',
   'vendor_part_other_cost',
   'vendor_part_is_preferred',
@@ -91,7 +94,10 @@ export function ReceiveStockForm({ partId, onSuccess, onDone }: ReceiveStockForm
   const { getSetting } = useSettings({})
   const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
 
-  const suppliers = usePartSuppliers(partId)
+  // Resolved at the RECEIPT'S date, not at now (task 30 §5): a receipt back-dated
+  // to before a rate change shows the earlier rate, and changing the date below
+  // re-resolves. The server read makes the same call at `occurredAt`.
+  const suppliers = usePartSuppliers(partId, occurredAt)
   const selected = suppliers.find((option) => option.id === vendorPartId) ?? null
 
   // Prefill the supplier once the rows land, defaulting to the preferred one
@@ -307,7 +313,7 @@ export function ReceiveStockPopover({ partId, onSuccess, children }: ReceiveStoc
  * nothing, it only prefills, so it wants the terms and a label and not the
  * lead-time/contact columns that tab renders.
  */
-function usePartSuppliers(partId: string): SupplierOption[] {
+function usePartSuppliers(partId: string, occurredAt: string): SupplierOption[] {
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
 
   const filters: ConditionGroup[] = useMemo(
@@ -345,11 +351,28 @@ function usePartSuppliers(partId: string): SupplierOption[] {
     enabled: recordIds.length > 0,
   })
 
+  // The override and the pointer, per offer, for the shared precedence rule.
+  const offers = useMemo(
+    () =>
+      records.map((record, index) => {
+        const values = valuesById[recordIds[index] ?? ''] ?? ({} as Record<string, unknown>)
+        const code = values.vendor_part_tariff_code as RecordId[] | undefined
+        return {
+          id: record.id,
+          tariffRate: (values.vendor_part_tariff_rate as number | null | undefined) ?? null,
+          tariffCodeId: code?.[0] ? parseRecordId(code[0]).entityInstanceId : null,
+        }
+      }),
+    [records, recordIds, valuesById]
+  )
+  const { byId: tariffById } = useOfferTariffs(offers, occurredAt)
+
   return useMemo(
     () =>
       records.map((record, index) => {
         const values = valuesById[recordIds[index] ?? ''] ?? ({} as Record<string, unknown>)
         const sku = values.vendor_part_vendor_sku as string | undefined
+        const tariff = tariffById.get(record.id)
         return {
           id: record.id,
           label: record.displayName || sku || 'Supplier part',
@@ -357,11 +380,15 @@ function usePartSuppliers(partId: string): SupplierOption[] {
           terms: {
             unitPrice: (values.vendor_part_unit_price as number | null | undefined) ?? null,
             shippingCost: (values.vendor_part_shipping_cost as number | null | undefined) ?? null,
-            tariffRate: (values.vendor_part_tariff_rate as number | null | undefined) ?? null,
+            // Resolved, never the raw override: the server resolves the same
+            // way at the same date, so the figure shown is the figure frozen.
+            tariffRate: tariff ? tariff.rate : null,
+            tariffSource:
+              tariff?.source === 'override' || tariff?.source === 'schedule' ? tariff.source : null,
             otherCost: (values.vendor_part_other_cost as number | null | undefined) ?? null,
           },
         }
       }),
-    [records, recordIds, valuesById]
+    [records, recordIds, valuesById, tariffById]
   )
 }

--- a/apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
@@ -32,6 +32,7 @@ const VENDOR_PART_SYSTEM_ATTRIBUTES = [
   'vendor_part_vendor_sku',
   'vendor_part_unit_price',
   'vendor_part_shipping_cost',
+  'vendor_part_tariff_code',
   'vendor_part_tariff_rate',
   'vendor_part_other_cost',
   'vendor_part_lead_time',
@@ -40,6 +41,8 @@ const VENDOR_PART_SYSTEM_ATTRIBUTES = [
   'vendor_part_contact',
   'vendor_part_part',
 ] as const
+
+const PART_HINT_ATTRIBUTES = ['hs_code'] as const
 
 /** Props for VendorPartDialog component */
 interface VendorPartDialogProps {
@@ -76,6 +79,7 @@ export function VendorPartDialog({
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
   const partDefId = useResourceProperty('part', 'id')
   const companyDefId = useResourceProperty('company', 'id')
+  const tariffCodeDefId = useResourceProperty('tariff_code', 'id')
 
   // Field definition for the Part relationship picker (contact-centric mode) — sourced live
   // so FieldInputAdapter gets a real RelationshipConfig and can offer "create new part"
@@ -86,6 +90,17 @@ export function VendorPartDialog({
     autoFetch: true,
     enabled: isEditMode && open,
   })
+
+  // The part's free-text HS code, as a hint under the tariff code picker (task
+  // 30 §3.6). Part-centric mode knows the part up front; company-centric mode
+  // knows it once one is picked.
+  const hintPartId = partIdProp ?? (isEditMode ? undefined : undefined)
+  const { values: partValues } = useSystemValues(
+    partDefId && hintPartId ? toRecordId(partDefId, hintPartId) : undefined,
+    PART_HINT_ATTRIBUTES,
+    { autoFetch: true, enabled: open && !!partDefId && !!hintPartId }
+  )
+  const partHsCode = (partValues?.hs_code as string | undefined) ?? null
 
   // State - uses shared type plus partId for contact-centric mode
   const [values, setValues] = useState<VendorPartFormValues & { partId: string }>({
@@ -113,12 +128,22 @@ export function VendorPartDialog({
             ? getInstanceId(partFirst)
             : ((partFirst as string) ?? '')
 
+        const codeRaw = systemValues.vendor_part_tariff_code
+        const codeFirst = Array.isArray(codeRaw) ? codeRaw[0] : codeRaw
+        const tariffCodeId =
+          typeof codeFirst === 'string' && codeFirst.length > 0
+            ? isRecordId(codeFirst)
+              ? getInstanceId(codeFirst)
+              : codeFirst
+            : null
+
         setValues({
           entityInstanceId: contactId,
           partId,
           vendorSku: (systemValues.vendor_part_vendor_sku as string) ?? '',
           unitPrice: (systemValues.vendor_part_unit_price as number) ?? null,
           shippingCost: (systemValues.vendor_part_shipping_cost as number) ?? null,
+          tariffCodeId,
           tariffRate: (systemValues.vendor_part_tariff_rate as number) ?? null,
           otherCost: (systemValues.vendor_part_other_cost as number) ?? null,
           leadTime: (systemValues.vendor_part_lead_time as number) ?? null,
@@ -210,6 +235,14 @@ export function VendorPartDialog({
           fieldType: FieldType.CURRENCY,
         },
         {
+          fieldId: 'vendor_part_tariff_code',
+          value:
+            values.tariffCodeId && tariffCodeDefId
+              ? [toRecordId(tariffCodeDefId, values.tariffCodeId)]
+              : [],
+          fieldType: FieldType.RELATIONSHIP,
+        },
+        {
           fieldId: 'vendor_part_tariff_rate',
           value: values.tariffRate,
           fieldType: FieldType.NUMBER,
@@ -248,6 +281,10 @@ export function VendorPartDialog({
           vendor_part_vendor_sku: values.vendorSku,
           vendor_part_unit_price: values.unitPrice,
           vendor_part_shipping_cost: values.shippingCost,
+          vendor_part_tariff_code:
+            values.tariffCodeId && tariffCodeDefId
+              ? toRecordId(tariffCodeDefId, values.tariffCodeId)
+              : undefined,
           vendor_part_tariff_rate: values.tariffRate,
           vendor_part_other_cost: values.otherCost,
           vendor_part_lead_time: values.leadTime,
@@ -306,6 +343,7 @@ export function VendorPartDialog({
             disabled={isPending}
             disableContactEdit={isEditMode}
             showContactField={isPartMode}
+            partHsCode={partHsCode}
           />
         </FieldPanel>
 

--- a/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
@@ -3,10 +3,14 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { getInstanceId, type RecordId, toRecordId } from '@auxx/lib/field-values/client'
+import Link from 'next/link'
+import { useMemo } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useSystemField } from '~/components/resources/hooks/use-field'
 import { BaseType } from '~/components/workflow/types'
+import { useOfferTariffs } from '../hooks/use-offer-tariffs'
+import { OfferTariffReadout } from '../ui/offer-tariff-readout'
 
 /**
  * Default values for vendor part form fields
@@ -16,6 +20,9 @@ export const defaultVendorPartValues = {
   vendorSku: '',
   unitPrice: null as number | null,
   shippingCost: null as number | null,
+  /** `tariff_code` instance id. The classification and origin the duty resolves from. */
+  tariffCodeId: null as string | null,
+  /** The OVERRIDE. `null` means "use the schedule" (29 §3.1). */
   tariffRate: null as number | null,
   otherCost: null as number | null,
   leadTime: null as number | null,
@@ -44,6 +51,13 @@ interface VendorPartFieldsProps {
   disableContactEdit?: boolean
   /** Whether to show the contact field (false for contact-centric mode) */
   showContactField?: boolean
+  /**
+   * The part's free-text `hsCode`, when the host knows it. Shown as a hint
+   * under the code picker so the person can find the right origin for it -
+   * the picker cannot be pre-searched, and the field itself is read by nothing
+   * (29 §0.1, 30 §3.6).
+   */
+  partHsCode?: string | null
 }
 
 /**
@@ -56,8 +70,10 @@ export function VendorPartFields({
   disabled,
   disableContactEdit,
   showContactField = true,
+  partHsCode,
 }: VendorPartFieldsProps) {
   const contactField = useSystemField('vendor_part_contact')
+  const tariffCodeField = useSystemField('vendor_part_tariff_code')
 
   return (
     <>
@@ -112,19 +128,45 @@ export function VendorPartFields({
         />
       </FieldPanelRow>
 
-      {/* Tariff Rate */}
+      {/* Tariff — three rows where there was one (30 §3.1). The code sets the
+          duty from the schedule; the rate is the OVERRIDE; the readout is the
+          only feedback that the code picked actually has rates behind it. */}
       <FieldPanelRow
-        title='Tariff Rate (%)'
-        description='Percentage of unit price'
+        title='Tariff code'
+        description='Classification and country of origin. Sets the duty from the schedule.'
+        type={BaseType.RELATION}
+        showIcon>
+        <FieldInputAdapter
+          triggerProps={{ className: 'w-full ps-0 pe-1' }}
+          fieldType={tariffCodeField?.fieldType ?? FieldType.RELATIONSHIP}
+          fieldOptions={tariffCodeField?.options}
+          value={values.tariffCodeId ? [toRecordId('tariff_code', values.tariffCodeId)] : []}
+          onChange={(recordIds) => {
+            const ids = recordIds as RecordId[]
+            onChange('tariffCodeId', ids[0] ? getInstanceId(ids[0]) : null)
+          }}
+          placeholder='Select tariff code...'
+          disabled={disabled}
+        />
+        <TariffCodeHint tariffCodeId={values.tariffCodeId} partHsCode={partHsCode} />
+      </FieldPanelRow>
+
+      <FieldPanelRow
+        title='Override rate (%)'
+        description='Leave blank to use the schedule. Set it for a DDP price that already includes duty, a Section 301 exclusion, or an unclassified part.'
         type={BaseType.NUMBER}
         showIcon>
         <FieldInputAdapter
           fieldType={FieldType.NUMBER}
           value={values.tariffRate}
           onChange={(val) => onChange('tariffRate', val)}
-          placeholder='0'
+          placeholder='Schedule'
           disabled={disabled}
         />
+      </FieldPanelRow>
+
+      <FieldPanelRow title='Duty' type={BaseType.NUMBER} showIcon>
+        <DutyRow tariffCodeId={values.tariffCodeId} tariffRate={values.tariffRate} />
       </FieldPanelRow>
 
       {/* Shipping Cost */}
@@ -206,3 +248,67 @@ export function VendorPartFields({
     </>
   )
 }
+
+/** The form's own draft, resolved through the shared seam like any saved offer. */
+function DutyRow({
+  tariffCodeId,
+  tariffRate,
+}: {
+  tariffCodeId: string | null
+  tariffRate: number | null
+}) {
+  const offers = useMemo(
+    () => [{ id: 'draft', tariffCodeId, tariffRate }],
+    [tariffCodeId, tariffRate]
+  )
+  const { byId, scheduleById, codeLabelById, unavailable } = useOfferTariffs(offers)
+  const tariff = byId.get('draft')
+  if (!tariff) return null
+  return (
+    <OfferTariffReadout
+      tariff={tariff}
+      scheduleTariff={scheduleById.get('draft')}
+      codeLabel={tariffCodeId ? codeLabelById.get(tariffCodeId) : undefined}
+      unavailable={unavailable}
+    />
+  )
+}
+
+/**
+ * Under the code picker: the empty-state link when the org has no codes yet
+ * (an empty picker is a dead control), or the part's free-text HS code as a
+ * search hint when no code is chosen yet.
+ */
+function TariffCodeHint({
+  tariffCodeId,
+  partHsCode,
+}: {
+  tariffCodeId: string | null
+  partHsCode?: string | null
+}) {
+  const { hasCodes, isLoading } = useOfferTariffs(NO_OFFERS)
+  if (isLoading) return null
+  if (!hasCodes) {
+    return (
+      <p className='mt-1 text-muted-foreground text-xs'>
+        No tariff codes yet.{' '}
+        <Link
+          href='/app/parts/settings/tariffs'
+          className='underline underline-offset-2 hover:text-foreground'>
+          Add them in Parts &rsaquo; Settings &rsaquo; Tariffs
+        </Link>
+      </p>
+    )
+  }
+  if (!tariffCodeId && partHsCode?.trim()) {
+    return (
+      <p className='mt-1 text-muted-foreground text-xs'>
+        The part's HS code is <span className='tabular-nums'>{partHsCode.trim()}</span> - search for
+        it and pick the country of origin.
+      </p>
+    )
+  }
+  return null
+}
+
+const NO_OFFERS: never[] = []

--- a/apps/web/src/components/manufacturing/tariff-types.ts
+++ b/apps/web/src/components/manufacturing/tariff-types.ts
@@ -1,4 +1,4 @@
-// apps/web/src/components/manufacturing/ui/settings/tariff-types.ts
+// apps/web/src/components/manufacturing/tariff-types.ts
 
 // Shared shapes for Parts > Settings > Tariffs (money 29-tariff-schedule.md).
 //
@@ -12,7 +12,7 @@
 // renders.
 
 import type { TariffRateComponent, TariffResolutionStatus } from '@auxx/lib/bom/client'
-import { resolveTariffRate } from '@auxx/lib/bom/client'
+import { composeTariffCodeLabel, resolveTariffRate } from '@auxx/lib/bom/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 
 /** apiSlug of the two definitions this page reads and writes. */
@@ -170,13 +170,14 @@ export function formatEffectiveFrom(iso: string | null): string {
 /**
  * The composed label: `8481.80.9005 CN`.
  *
- * 🛑 Composed, never stored (§1.1). The two halves stay separate fields so the
- * code half can be typed ahead of, so *"what origins have I classified this code
- * for"* is answerable, and so a trailing space in a hand-typed string can never
- * fork the `(code, country)` natural key.
+ * 🛑 ONE composer, in `@auxx/lib/bom/client`, because the server stamps the
+ * same string into the derived `tariff_code_label` field the importers match
+ * on (task 30 §8). The two legs stay separate fields - the code half can be
+ * typed ahead of, *"what origins have I classified this code for"* stays
+ * answerable, and nothing ever parses the label back apart.
  */
 export function composeTariffLabel(code: string, country: string | null): string {
-  return country ? `${code} ${country}` : code
+  return composeTariffCodeLabel(code, country)
 }
 
 /** Newest first - the order the rate history renders in. */

--- a/apps/web/src/components/manufacturing/ui/offer-tariff-readout.tsx
+++ b/apps/web/src/components/manufacturing/ui/offer-tariff-readout.tsx
@@ -1,0 +1,119 @@
+// apps/web/src/components/manufacturing/ui/offer-tariff-readout.tsx
+'use client'
+
+// The Duty row (plans/money/tasks/30-tariff-offer-surfaces.md §3.2): what one
+// supplier offer's rate resolves to, and where it came from.
+//
+// 🛑 Five readings and only one of them is a bare percentage. `none`,
+// `unclassified` and `pending` all carry 0 and mean three different things -
+// never classified; classified but the code has no rows; classified and every
+// row starts in the future. A row that prints `0%` for all three tells a person
+// with an unfinished offer that they are done.
+//
+// 🛑 The both-set case is LOUD. Under 29 §3.1 a set override beats the schedule
+// silently, so an offer classified last month with a 25% typed last year shows
+// 25% forever while the schedule says 47%. This is the row the person is
+// looking at when that happens, so it says so here as well as on the
+// Classification tab's Override badge.
+
+import type { OfferTariff } from '@auxx/lib/bom/client'
+import { TriangleAlert } from 'lucide-react'
+import Link from 'next/link'
+import { formatPercent } from '../hooks/use-offer-tariffs'
+import { authorityLabel, formatEffectiveFrom } from '../tariff-types'
+
+interface OfferTariffReadoutProps {
+  /** The offer's resolved rate, override included. */
+  tariff: OfferTariff
+  /** What the schedule alone says. Only read when {@link tariff} is an override. */
+  scheduleTariff?: OfferTariff
+  /** `8481.80.9005 CN`, when the offer carries a code. */
+  codeLabel?: string
+  /** The viewer cannot read the schedule (`useOfferTariffs().unavailable`). */
+  unavailable?: boolean
+}
+
+const TARIFFS_HREF = '/app/parts/settings/tariffs'
+
+/** One line, plus the per-authority components when the schedule produced the number. */
+export function OfferTariffReadout({
+  tariff,
+  scheduleTariff,
+  codeLabel,
+  unavailable,
+}: OfferTariffReadoutProps) {
+  if (tariff.source === 'override') {
+    const scheduleSays =
+      scheduleTariff?.source === 'schedule' && scheduleTariff.status === 'resolved'
+        ? scheduleTariff.rate
+        : null
+    return (
+      <div className='flex min-h-8 flex-col justify-center gap-0.5 text-sm'>
+        <span className='tabular-nums'>
+          {formatPercent(tariff.rate)} <span className='text-muted-foreground'>(override)</span>
+        </span>
+        {scheduleSays != null && scheduleSays !== tariff.rate && (
+          <span className='flex items-center gap-1 text-amber-700 text-xs dark:text-amber-400'>
+            <TriangleAlert className='size-3.5 shrink-0' />
+            Schedule says {formatPercent(scheduleSays)} - the override wins. Clear it to use the
+            schedule.
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  if (tariff.source === 'none') {
+    return (
+      <div className='flex min-h-8 items-center text-muted-foreground text-sm'>
+        No duty - no code and no override
+      </div>
+    )
+  }
+
+  if (unavailable) {
+    return (
+      <div className='flex min-h-8 items-center text-muted-foreground text-sm'>
+        Schedule not readable - the rate is resolved on the server
+      </div>
+    )
+  }
+
+  if (tariff.status === 'unclassified') {
+    return (
+      <div className='flex min-h-8 flex-col justify-center text-sm'>
+        <span>No rate rows on {codeLabel ?? 'this code'}</span>
+        <Link
+          href={TARIFFS_HREF}
+          className='text-muted-foreground text-xs underline underline-offset-2 hover:text-foreground'>
+          Add the rates in Parts &rsaquo; Settings &rsaquo; Tariffs
+        </Link>
+      </div>
+    )
+  }
+
+  if (tariff.status === 'pending') {
+    return (
+      <div className='flex min-h-8 items-center text-muted-foreground text-sm'>
+        Starts later - nothing on {codeLabel ?? 'this code'} is in force today
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex min-h-8 flex-col justify-center gap-0.5 text-sm'>
+      <span className='tabular-nums'>
+        {formatPercent(tariff.rate)}
+        {codeLabel && <span className='text-muted-foreground'> ({codeLabel})</span>}
+      </span>
+      <span className='text-muted-foreground text-xs tabular-nums'>
+        {tariff.components
+          .map(
+            (component) =>
+              `${authorityLabel(component.authority)} ${formatPercent(component.rate)} from ${formatEffectiveFrom(component.effectiveFrom)}`
+          )
+          .join(' + ')}
+      </span>
+    </div>
+  )
+}

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-classification-editor.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-classification-editor.tsx
@@ -1,0 +1,200 @@
+// apps/web/src/components/manufacturing/ui/settings/tariff-classification-editor.tsx
+'use client'
+
+// The right column of the Classification tab (money 30-tariff-offer-surfaces.md
+// §6.2): the selected offer's THREE tariff rows and nothing else - the code
+// picker, the override, and the Duty readout - the same three the supplier form
+// renders, writing through `useSaveFieldValue` exactly as the Codes editor does.
+//
+// No price, no lead time, no SKU: that is what the supplier dialog is for, and
+// the part badge at the top opens the drawer's Suppliers tab. One action only
+// this pane has: Clear override, because the reason to be here is moving offers
+// off the hand-keyed number and onto the schedule, and clearing a NUMBER input
+// to empty is not an obvious gesture.
+
+import { FieldType } from '@auxx/database/enums'
+import { getInstanceId, type RecordId, toRecordId } from '@auxx/lib/field-values/client'
+import { Button } from '@auxx/ui/components/button'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { EmptySection } from '@auxx/ui/components/section'
+import { Package } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useSystemField } from '~/components/resources/hooks/use-field'
+import { RecordBadge } from '~/components/resources/ui/record-badge'
+import { BaseType } from '~/components/workflow/types'
+import type { ClassifiedOffer } from '../../hooks/use-offer-classification'
+import { OfferTariffReadout } from '../offer-tariff-readout'
+
+interface TariffClassificationEditorProps {
+  offer: ClassifiedOffer | null
+  /** What the schedule alone says for this offer, for the both-set warning. */
+  scheduleTariff: ClassifiedOffer['tariff'] | undefined
+  unavailable: boolean
+  tariffCodeDefId: string | null
+  canEdit: boolean
+  /** Writes the pointer. Rejects with the server's message. */
+  onSetCode: (recordId: RecordId, tariffCodeId: string | null) => Promise<void>
+  /** Writes the override. `null` clears it. */
+  onSetOverride: (recordId: RecordId, rate: number | null) => Promise<void>
+}
+
+export function TariffClassificationEditor({
+  offer,
+  scheduleTariff,
+  unavailable,
+  tariffCodeDefId,
+  canEdit,
+  onSetCode,
+  onSetOverride,
+}: TariffClassificationEditorProps) {
+  if (!offer) {
+    return (
+      <div className='p-3'>
+        <EmptySection
+          orientation='horizontal'
+          icon={<Package />}
+          title='Select an offer'
+          description='Set its tariff code, or clear an override so the schedule decides.'
+        />
+      </div>
+    )
+  }
+  return (
+    <OfferForm
+      key={offer.id}
+      offer={offer}
+      scheduleTariff={scheduleTariff}
+      unavailable={unavailable}
+      tariffCodeDefId={tariffCodeDefId}
+      canEdit={canEdit}
+      onSetCode={onSetCode}
+      onSetOverride={onSetOverride}
+    />
+  )
+}
+
+function OfferForm({
+  offer,
+  scheduleTariff,
+  unavailable,
+  tariffCodeDefId,
+  canEdit,
+  onSetCode,
+  onSetOverride,
+}: Omit<TariffClassificationEditorProps, 'offer'> & { offer: ClassifiedOffer }) {
+  const tariffCodeField = useSystemField('vendor_part_tariff_code')
+  const [error, setError] = useState<string | null>(null)
+  const [pending, setPending] = useState(false)
+
+  const run = useCallback(async (write: () => Promise<void>) => {
+    setPending(true)
+    setError(null)
+    try {
+      await write()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save the change.')
+    } finally {
+      setPending(false)
+    }
+  }, [])
+
+  return (
+    <div className='flex h-full min-h-0 flex-col p-3'>
+      <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
+        <div className='mb-3 flex flex-wrap items-center gap-2 text-sm'>
+          {offer.partRecordId && (
+            <RecordBadge
+              recordId={offer.partRecordId}
+              variant='link'
+              link={{ tab: 'vendors' }}
+              openInStack
+            />
+          )}
+          {offer.supplierRecordId && (
+            <>
+              <span className='text-muted-foreground text-xs'>from</span>
+              <RecordBadge recordId={offer.supplierRecordId} variant='link' openInStack />
+            </>
+          )}
+        </div>
+
+        <FieldPanel
+          orientation='horizontal'
+          breakpoint='md'
+          resizeId='tariff-classification-detail'
+          defaultLabelWidth={150}
+          className='shrink-0 grow-0 p-0'>
+          <FieldPanelRow
+            title='Tariff code'
+            type={BaseType.RELATION}
+            showIcon
+            description='Classification and country of origin. Sets the duty from the schedule.'>
+            <FieldInputAdapter
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              fieldType={tariffCodeField?.fieldType ?? FieldType.RELATIONSHIP}
+              fieldOptions={tariffCodeField?.options}
+              value={
+                offer.tariffCodeId && tariffCodeDefId
+                  ? [toRecordId(tariffCodeDefId, offer.tariffCodeId)]
+                  : []
+              }
+              onChange={(recordIds) => {
+                const ids = recordIds as RecordId[]
+                void run(() => onSetCode(offer.recordId, ids[0] ? getInstanceId(ids[0]) : null))
+              }}
+              placeholder='Select tariff code...'
+              disabled={!canEdit || pending}
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow
+            title='Override rate (%)'
+            type={BaseType.NUMBER}
+            showIcon
+            description='Leave blank to use the schedule. Set it for a DDP price, a Section 301 exclusion, or an unclassified part.'>
+            <div className='flex items-center gap-2'>
+              <div className='min-w-0 flex-1'>
+                <FieldInputAdapter
+                  fieldType={FieldType.NUMBER}
+                  value={offer.tariffRate}
+                  onChange={(value) => {
+                    const next = value === '' || value == null ? null : (value as number)
+                    void run(() => onSetOverride(offer.recordId, next))
+                  }}
+                  placeholder='Schedule'
+                  disabled={!canEdit || pending}
+                />
+              </div>
+              {canEdit && offer.tariffRate != null && (
+                <Button
+                  variant='outline'
+                  size='xs'
+                  disabled={pending}
+                  onClick={() => void run(() => onSetOverride(offer.recordId, null))}>
+                  Clear override
+                </Button>
+              )}
+            </div>
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Duty' type={BaseType.NUMBER} showIcon>
+            <OfferTariffReadout
+              tariff={offer.tariff}
+              scheduleTariff={scheduleTariff}
+              codeLabel={offer.codeLabel ?? undefined}
+              unavailable={unavailable}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+
+        {error && <p className='mt-2 text-destructive text-xs'>{error}</p>}
+        <p className='mt-3 text-muted-foreground text-xs'>
+          Changes save as you make them and move this part's estimated cost. Nothing already
+          received or valued changes - a movement freezes its cost when it is written.
+        </p>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-classification-list.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-classification-list.tsx
@@ -1,0 +1,245 @@
+// apps/web/src/components/manufacturing/ui/settings/tariff-classification-list.tsx
+'use client'
+
+// The left column of the Classification tab (money 30-tariff-offer-surfaces.md
+// §6.1): one row for EVERY priced supplier offer, classified or not, so the
+// list is a checklist rather than a table dump - the direct analogue of the
+// Roles tab on `accounting/settings/accounts`.
+//
+// Filter chips are client-side over the loaded set. Unclassified is the
+// checklist; Override is "who is still on the old hand-keyed number"; a country
+// is "show me everything from China", which is 29 §0's literal scenario and the
+// reason the pointer lives on the offer and not the part (29 §4).
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { EmptySection } from '@auxx/ui/components/section'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Package } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { RecordBadge } from '~/components/resources/ui/record-badge'
+import type { ClassifiedOffer } from '../../hooks/use-offer-classification'
+import { formatPercent } from '../../hooks/use-offer-tariffs'
+
+type Filter = 'all' | 'unclassified' | 'override' | `country:${string}`
+
+interface TariffClassificationListProps {
+  offers: ClassifiedOffer[]
+  /** ISO-2 -> offer count, for the country chips. */
+  countries: Map<string, number>
+  /** ISO-2 -> country name. */
+  countryLabels: Map<string, string>
+  isLoading: boolean
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+}
+
+export function TariffClassificationList({
+  offers,
+  countries,
+  countryLabels,
+  isLoading,
+  selectedId,
+  onSelect,
+}: TariffClassificationListProps) {
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<Filter>('all')
+  // 🛑 Paged, and not for scroll performance. Every row mounts two
+  // `RecordBadge`s (part, supplier), each of which asks the relationship store
+  // to hydrate its record, and the store batches those into ONE
+  // `record.getByIds` GET - 202 offers put 400 ids on the query string and the
+  // dev server answered 431 Request Header Fields Too Large for every batch
+  // (driven 2026-09-01). Fifty rows keeps a batch under the limit; the rest
+  // arrive on demand.
+  const [limit, setLimit] = useState(PAGE_SIZE)
+  const changeFilter = (next: Filter) => {
+    setFilter(next)
+    setLimit(PAGE_SIZE)
+  }
+  const changeSearch = (next: string) => {
+    setSearch(next)
+    setLimit(PAGE_SIZE)
+  }
+
+  const counts = useMemo(
+    () => ({
+      unclassified: offers.filter((o) => !o.tariffCodeId && o.tariffRate == null).length,
+      override: offers.filter((o) => o.tariffRate != null).length,
+    }),
+    [offers]
+  )
+
+  const query = search.trim().toLowerCase()
+  const filtered = offers.filter((offer) => {
+    if (filter === 'unclassified' && (offer.tariffCodeId || offer.tariffRate != null)) return false
+    if (filter === 'override' && offer.tariffRate == null) return false
+    if (filter.startsWith('country:') && offer.country !== filter.slice('country:'.length)) {
+      return false
+    }
+    if (!query) return true
+    return (offer.codeLabel ?? '').toLowerCase().includes(query)
+  })
+
+  return (
+    <div className='flex flex-col gap-3 p-3'>
+      <InputSearch
+        value={search}
+        onChange={(e) => changeSearch(e.target.value)}
+        placeholder='Search by tariff code...'
+      />
+
+      <div className='flex flex-wrap items-center gap-1.5'>
+        <FilterChip active={filter === 'all'} onClick={() => changeFilter('all')}>
+          All ({offers.length})
+        </FilterChip>
+        <FilterChip active={filter === 'unclassified'} onClick={() => changeFilter('unclassified')}>
+          Unclassified ({counts.unclassified})
+        </FilterChip>
+        <FilterChip active={filter === 'override'} onClick={() => changeFilter('override')}>
+          Override ({counts.override})
+        </FilterChip>
+        {[...countries.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .map(([iso, count]) => (
+            <FilterChip
+              key={iso}
+              active={filter === `country:${iso}`}
+              onClick={() => changeFilter(`country:${iso}`)}>
+              {countryLabels.get(iso) ?? iso} ({count})
+            </FilterChip>
+          ))}
+      </div>
+
+      {isLoading ? (
+        <EmptySection loading />
+      ) : filtered.length === 0 ? (
+        <EmptySection
+          icon={<Package className='size-5' />}
+          title={
+            offers.length === 0
+              ? 'No priced supplier offers'
+              : filter === 'unclassified'
+                ? 'Every priced offer is classified'
+                : 'No matches'
+          }
+          description={
+            offers.length === 0
+              ? 'Add a supplier with a unit price to a part and it appears here to be classified.'
+              : undefined
+          }
+        />
+      ) : (
+        <div className={cn('flex flex-col gap-0.5', TREE_SECONDARY_NOTRUNCATE)}>
+          {filtered.slice(0, limit).map((offer) => (
+            <TreeRow
+              key={offer.id}
+              icon={<Package className='size-4 text-muted-foreground' />}
+              title={
+                <span className='flex min-w-0 items-center gap-1.5'>
+                  {offer.partRecordId ? (
+                    <RecordBadge recordId={offer.partRecordId} showIcon={false} />
+                  ) : (
+                    <span className='text-muted-foreground'>-</span>
+                  )}
+                  {offer.supplierRecordId && (
+                    <>
+                      <span className='text-muted-foreground text-xs'>from</span>
+                      <RecordBadge recordId={offer.supplierRecordId} showIcon={false} />
+                    </>
+                  )}
+                </span>
+              }
+              secondaryFill
+              onToggleOpen={() => onSelect(offer.id)}
+              rowClassName={cn(
+                'bg-primary-100/50 hover:bg-primary-100',
+                selectedId === offer.id && 'bg-primary-100 ring-1 ring-primary-200'
+              )}
+              secondary={<OfferBadges offer={offer} />}
+            />
+          ))}
+          {filtered.length > limit && (
+            <Button
+              variant='ghost'
+              size='sm'
+              className='mt-1 self-center'
+              onClick={() => setLimit((current) => current + PAGE_SIZE)}>
+              Show {Math.min(PAGE_SIZE, filtered.length - limit)} more of {filtered.length}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const PAGE_SIZE = 50
+
+/**
+ * The row's reading. Same three-state discipline as the Codes list, plus the
+ * two states only an offer has: Unclassified (no code, no override) and
+ * Override (a hand-keyed rate beating whatever the code says).
+ */
+function OfferBadges({ offer }: { offer: ClassifiedOffer }) {
+  const { tariff } = offer
+  return (
+    <span className='flex min-w-0 items-center gap-1.5 text-muted-foreground text-xs'>
+      {offer.codeLabel && <span className='tabular-nums'>{offer.codeLabel}</span>}
+      {tariff.source === 'none' && (
+        <Badge
+          variant='outline'
+          size='xs'
+          title='No tariff code and no override. Estimated with no duty.'>
+          Unclassified
+        </Badge>
+      )}
+      {tariff.source === 'override' && (
+        <>
+          <Badge
+            variant='amber'
+            size='xs'
+            title='A hand-keyed rate; the schedule is ignored for this offer.'>
+            Override
+          </Badge>
+          <span className='tabular-nums'>{formatPercent(tariff.rate)}</span>
+        </>
+      )}
+      {tariff.source === 'schedule' && tariff.status === 'resolved' && (
+        <Badge variant='green' size='xs'>
+          {formatPercent(tariff.rate)}
+        </Badge>
+      )}
+      {tariff.source === 'schedule' && tariff.status === 'pending' && (
+        <Badge variant='outline' size='xs' title='Every row on this code takes effect after today.'>
+          Starts later
+        </Badge>
+      )}
+      {tariff.source === 'schedule' && tariff.status === 'unclassified' && (
+        <Badge
+          variant='destructive'
+          size='xs'
+          title='The code has no rate rows, so this offer is estimated with no duty.'>
+          No rate on code
+        </Badge>
+      )}
+    </span>
+  )
+}
+
+function FilterChip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <Button variant={active ? 'default' : 'outline'} size='xs' onClick={onClick}>
+      {children}
+    </Button>
+  )
+}

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-code-editor.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-code-editor.tsx
@@ -38,7 +38,6 @@ import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapte
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
-import { TariffRateHistory, type TariffRateValues } from './tariff-rate-history'
 import {
   authorityLabel,
   formatEffectiveFrom,
@@ -48,7 +47,8 @@ import {
   type TariffCodeDraft,
   type TariffRate,
   type TariffScheduleView,
-} from './tariff-types'
+} from '../../tariff-types'
+import { TariffRateHistory, type TariffRateValues } from './tariff-rate-history'
 
 /**
  * ⚠️ A `SINGLE_SELECT` hands its value back as an ARRAY - `['CN']` - because the

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-codes-list.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-codes-list.tsx
@@ -36,7 +36,7 @@ import {
   type TariffCode,
   type TariffCodeDraft,
   type TariffRate,
-} from './tariff-types'
+} from '../../tariff-types'
 
 interface TariffCodesListProps {
   codes: TariffCode[]

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-rate-history.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-rate-history.tsx
@@ -49,7 +49,7 @@ import {
   isBaseAuthority,
   type TariffRate,
   type TariffScheduleView,
-} from './tariff-types'
+} from '../../tariff-types'
 
 /** The writable half of a rate row, as a form holds it. */
 export interface TariffRateValues {

--- a/apps/web/src/components/manufacturing/ui/settings/tariffs-settings-page.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariffs-settings-page.tsx
@@ -7,13 +7,10 @@
 // column is a PERSISTENT editor pane, docked at `lg` and a floating drawer below
 // it.
 //
-// ⚠️ ONE TAB, so no tab strip - and that is deliberate rather than unfinished.
-// §6.1 specifies two tabs, Codes and Classification, with the active one in
-// `useQueryState('s')`. Classification is not built. A `ResponsiveTabs` strip
-// with a single item is a control that cannot be operated, and a second tab that
-// renders a placeholder is a half-wired feature; both are worse than the strip
-// arriving with the thing it switches to. The `subHeader` slot and the `s` query
-// param land together with that tab, and nothing else about this shell moves.
+// Two tabs, the active one in `useQueryState('s')`: Codes (the registry) and
+// Classification (every priced supplier offer, classified or not - task 30 §6).
+// Codes is the entry point even though a first-run org has its work on the
+// other tab, because nothing can be classified before a code exists.
 //
 // 🛑 THE GATE IS THE RECORD CAPABILITY, not `settingsManage` - decided in §12
 // (d) and it is the opposite call from the sibling Parts > General page. Both
@@ -28,10 +25,12 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeValue } from '@auxx/database/types'
-import type { RecordId } from '@auxx/lib/resources/client'
+import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { toastError } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils'
-import { Globe } from 'lucide-react'
+import { Globe, Package } from 'lucide-react'
+import { useQueryState } from 'nuqs'
 import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import { MasterDetailSplit } from '~/components/global/master-detail-split'
@@ -46,9 +45,15 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { useSettings } from '~/hooks/use-settings'
 import { useAccess, useRequireEntityEdit } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
-import { TariffCodeEditor, type TariffCodeValues } from './tariff-code-editor'
-import { TariffCodesList } from './tariff-codes-list'
-import type { TariffRateValues } from './tariff-rate-history'
+import {
+  useOfferClassification,
+  VENDOR_PART_TARIFF_ATTRS,
+} from '../../hooks/use-offer-classification'
+import {
+  useTariffCountryFieldOptions,
+  useTariffCountryLabels,
+  useTariffSchedule,
+} from '../../hooks/use-tariff-schedule'
 import {
   composeTariffLabel,
   TARIFF_CODE_ATTRS,
@@ -56,12 +61,12 @@ import {
   type TariffCode,
   type TariffCodeDraft,
   type TariffRate,
-} from './tariff-types'
-import {
-  useTariffCountryFieldOptions,
-  useTariffCountryLabels,
-  useTariffSchedule,
-} from './use-tariff-schedule'
+} from '../../tariff-types'
+import { TariffClassificationEditor } from './tariff-classification-editor'
+import { TariffClassificationList } from './tariff-classification-list'
+import { TariffCodeEditor, type TariffCodeValues } from './tariff-code-editor'
+import { TariffCodesList } from './tariff-codes-list'
+import type { TariffRateValues } from './tariff-rate-history'
 
 const BREADCRUMBS = [
   { title: 'Parts', href: '/app/parts' },
@@ -72,7 +77,17 @@ const BREADCRUMBS = [
 const PAGE_DESCRIPTION =
   'Harmonized codes by country of origin, and the rates behind them. A rate is a function of what the thing is, where it was made, and when - so a code is a classification for an origin, and its rates are dated rows that are never edited in place.'
 
+const TABS = [
+  { value: 'codes', label: 'Codes', icon: Globe },
+  { value: 'classification', label: 'Classification', icon: Package },
+]
+
+type TariffsTab = 'codes' | 'classification'
+
 export function TariffsSettingsPage() {
+  const [tab, setTab] = useQueryState('s', { defaultValue: 'codes' as string })
+  const activeTab: TariffsTab = tab === 'classification' ? 'classification' : 'codes'
+
   const {
     codes,
     ratesByCode,
@@ -117,6 +132,21 @@ export function TariffsSettingsPage() {
   const bookTimeZone = (getSetting('accounting.bookTimeZone') as string) || 'UTC'
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedOfferId, setSelectedOfferId] = useState<string | null>(null)
+
+  // ── The Classification tab's read and writes ────────────────────────────
+  //
+  // The country per code, so the offer list can filter by origin.
+  const codeCountryById = useMemo(
+    () => new Map(codes.map((code) => [code.id, code.country])),
+    [codes]
+  )
+  const classification = useOfferClassification(codeCountryById)
+  const canEditOffers = classification.vendorPartDefId
+    ? canEditEntity(classification.vendorPartDefId)
+    : false
+  const selectedOffer = classification.offers.find((offer) => offer.id === selectedOfferId) ?? null
+
   // The phantom draft. The full field set lives inside the draft form instance
   // (keyed by `draftId`); this page tracks only enough to render the list's
   // phantom row and to know whether the selection is a draft.
@@ -249,6 +279,37 @@ export function TariffsSettingsPage() {
       if (draft?.recordId === code.id) setDraft(null)
     },
     [ratesByCode, confirm, deleteRecord, removeCode, selectedId, draft]
+  )
+
+  // ── The offer writes ────────────────────────────────────────────────────
+  //
+  // The same two attributes the supplier dialog writes, through the same door.
+  // `mfg-vendor-part-tariff-code` / `-tariff-rate` recalculate the part's cost
+  // on the server; nothing here computes a number.
+
+  const handleSetOfferCode = useCallback(
+    async (recordId: RecordId, tariffCodeId: string | null) => {
+      if (!codeDefId) throw new Error('Tariff codes are not available in this organization yet.')
+      const ok = await saveMultipleAsync(recordId, [
+        {
+          fieldId: VENDOR_PART_TARIFF_ATTRS.tariffCode,
+          value: tariffCodeId ? [toRecordId(codeDefId, tariffCodeId)] : [],
+          fieldType: FieldType.RELATIONSHIP,
+        },
+      ])
+      if (ok === false) throw new Error('Could not save the tariff code.')
+    },
+    [codeDefId, saveMultipleAsync]
+  )
+
+  const handleSetOfferOverride = useCallback(
+    async (recordId: RecordId, rate: number | null) => {
+      const ok = await saveMultipleAsync(recordId, [
+        { fieldId: VENDOR_PART_TARIFF_ATTRS.tariffRate, value: rate, fieldType: FieldType.NUMBER },
+      ])
+      if (ok === false) throw new Error('Could not save the override.')
+    },
+    [saveMultipleAsync]
   )
 
   // ── The rate writes ─────────────────────────────────────────────────────
@@ -435,31 +496,72 @@ export function TariffsSettingsPage() {
     )
   }
 
+  const classificationEditor = (
+    <TariffClassificationEditor
+      offer={selectedOffer}
+      scheduleTariff={selectedOffer ? classification.scheduleById.get(selectedOffer.id) : undefined}
+      unavailable={classification.unavailable}
+      tariffCodeDefId={codeDefId}
+      canEdit={canEditOffers}
+      onSetCode={handleSetOfferCode}
+      onSetOverride={handleSetOfferOverride}
+    />
+  )
+
   return (
-    <SettingsPage title='Tariffs' description={PAGE_DESCRIPTION} breadcrumbs={BREADCRUMBS}>
-      <MasterDetailSplit
-        id='tariff-codes'
-        pane={editorContent}
-        paneTitle='Tariff code'
-        paneOpen={!!selectedId}
-        onPaneClose={() => handleSelect(null)}>
-        <TariffCodesList
-          codes={codes}
-          ratesByCode={ratesByCode}
-          today={today}
-          bookTimeZone={bookTimeZone}
-          countryLabels={countryLabels}
-          // 🛑 Gate on the QUERY, never on an empty array. "No tariff codes
-          // yet" is a claim about the org, and rendering it mid-load makes it
-          // a false one.
-          isLoading={isLoading}
-          selectedId={selectedId}
-          onSelect={handleSelect}
-          draft={draft}
-          onAddDraft={handleAddDraft}
-          canEdit={canEditCodes}
+    <SettingsPage
+      title='Tariffs'
+      description={PAGE_DESCRIPTION}
+      breadcrumbs={BREADCRUMBS}
+      subHeader={
+        <ResponsiveTabs
+          value={activeTab}
+          onValueChange={(next) => void setTab(next)}
+          size='sm'
+          items={TABS}
         />
-      </MasterDetailSplit>
+      }>
+      {activeTab === 'codes' ? (
+        <MasterDetailSplit
+          id='tariff-codes'
+          pane={editorContent}
+          paneTitle='Tariff code'
+          paneOpen={!!selectedId}
+          onPaneClose={() => handleSelect(null)}>
+          <TariffCodesList
+            codes={codes}
+            ratesByCode={ratesByCode}
+            today={today}
+            bookTimeZone={bookTimeZone}
+            countryLabels={countryLabels}
+            // 🛑 Gate on the QUERY, never on an empty array. "No tariff codes
+            // yet" is a claim about the org, and rendering it mid-load makes it
+            // a false one.
+            isLoading={isLoading}
+            selectedId={selectedId}
+            onSelect={handleSelect}
+            draft={draft}
+            onAddDraft={handleAddDraft}
+            canEdit={canEditCodes}
+          />
+        </MasterDetailSplit>
+      ) : (
+        <MasterDetailSplit
+          id='tariff-classification'
+          pane={classificationEditor}
+          paneTitle='Supplier offer'
+          paneOpen={!!selectedOfferId}
+          onPaneClose={() => setSelectedOfferId(null)}>
+          <TariffClassificationList
+            offers={classification.offers}
+            countries={classification.countries}
+            countryLabels={countryLabels}
+            isLoading={classification.isLoading}
+            selectedId={selectedOfferId}
+            onSelect={setSelectedOfferId}
+          />
+        </MasterDetailSplit>
+      )}
 
       <ConfirmDialog />
     </SettingsPage>

--- a/apps/worker/scripts/run-entity-migration-120.ts
+++ b/apps/worker/scripts/run-entity-migration-120.ts
@@ -1,0 +1,33 @@
+// apps/worker/scripts/run-entity-migration-120.ts
+/**
+ * One-off runner for entity migration 120 (the derived `tariff_code_label` -
+ * plans/money/tasks/30-tariff-offer-surfaces.md §8) across all orgs. Runs ONLY
+ * 120 - deliberately not runAllEntityMigrations, so pending migrations from
+ * parallel work stay untouched. Idempotent - safe to re-run to confirm
+ * alreadyUpToDate.
+ *
+ * Run (from repo root) under the worker runtime so the @auxx/lib import chain
+ * resolves its native ESM deps:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/run-entity-migration-120.ts
+ */
+
+import { database } from '@auxx/database'
+import {
+  ALL_ENTITY_MIGRATIONS,
+  runEntityMigrationForAllOrgs,
+} from '@auxx/lib/seed/entity-migrations'
+
+async function main() {
+  const migration = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '120-tariff-code-label')
+  if (!migration) throw new Error('Migration 120 not found in registry')
+
+  await runEntityMigrationForAllOrgs(database, migration)
+  console.log('done')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lib/src/bom/client.ts
+++ b/packages/lib/src/bom/client.ts
@@ -14,6 +14,8 @@
 
 export type {
   LandedCostBreakdown,
+  OfferTariff,
+  OfferTariffInputs,
   TariffRateComponent,
   TariffRateRow,
   TariffResolution,
@@ -21,8 +23,12 @@ export type {
   VendorCostRow,
 } from './vendor-cost'
 export {
+  composeTariffCodeLabel,
   computeLandedBreakdown,
   computeLandedCost,
+  // The supplier form, the Suppliers tab, the Receive form and the Classification
+  // tab all decide an offer's rate through this one function (30 §1).
+  resolveOfferTariff,
   // The tariffs settings screen and the supplier drawer resolve the schedule in
   // the browser through this export. Resolving server-side only and shipping
   // the client a number is how the landed formula came to live in two places.

--- a/packages/lib/src/bom/cost-calculator.test.ts
+++ b/packages/lib/src/bom/cost-calculator.test.ts
@@ -16,6 +16,10 @@ const h = vi.hoisted(() => ({
   getRealtimeService: vi.fn(() => ({})),
   publishFieldValueUpdates: vi.fn(async (_svc: unknown, _orgId: string, _entries: unknown[]) => {}),
   syncCatalogItemPricing: vi.fn(async () => {}),
+  // The schedule read behind a classified offer (task 30 §1). Keyed by
+  // `tariff_code` instance id; empty unless a test loads one.
+  loadTariffSchedule: vi.fn(async () => new Map<string, unknown[]>()),
+  readBookTimeZone: vi.fn(async () => 'UTC'),
 }))
 
 function nextRows(): unknown[] {
@@ -57,6 +61,7 @@ const FIELD: Record<string, { id: string; type: string }> = {
   vendor_part_is_preferred: { id: 'f_vp_pref', type: 'CHECKBOX' },
   vendor_part_shipping_cost: { id: 'f_vp_ship', type: 'CURRENCY' },
   vendor_part_tariff_rate: { id: 'f_vp_tariff', type: 'NUMBER' },
+  vendor_part_tariff_code: { id: 'f_vp_tariff_code', type: 'RELATIONSHIP' },
   vendor_part_other_cost: { id: 'f_vp_other', type: 'CURRENCY' },
   subpart_parent_part: { id: 'f_sp_parent', type: 'RELATIONSHIP' },
   subpart_child_part: { id: 'f_sp_child', type: 'RELATIONSHIP' },
@@ -97,6 +102,11 @@ vi.mock('../realtime', () => ({
 
 vi.mock('../money/catalog-pricing', () => ({
   syncCatalogItemPricing: h.syncCatalogItemPricing,
+}))
+
+vi.mock('./tariff-schedule', () => ({
+  loadTariffSchedule: h.loadTariffSchedule,
+  readBookTimeZone: h.readBookTimeZone,
 }))
 
 import {
@@ -587,5 +597,89 @@ describe('loadOrgPricingData — the offer id the tiebreak depends on', () => {
     expect(vendorPrices.map((row) => row.id).sort()).toEqual(['vp_acme', 'vp_bolt'])
     // ...and the part id stays a separate field rather than being overwritten.
     expect(new Set(vendorPrices.map((row) => row.partInstanceId))).toEqual(new Set([MOTOR]))
+  })
+})
+
+describe('loadOrgPricingData — the tariff schedule (task 30 §1)', () => {
+  /** A `tariff_code` pointer FieldValue row on an offer. */
+  function codeRow(instanceId: string, codeId: string) {
+    return {
+      instanceId,
+      fieldId: FIELD.vendor_part_tariff_code!.id,
+      valueNumber: null,
+      valueBoolean: null,
+      relatedEntityId: codeId,
+    }
+  }
+
+  /** A `tariff_rate` FieldValue row on an offer (the OVERRIDE). */
+  function overrideRow(instanceId: string, rate: number) {
+    return {
+      instanceId,
+      fieldId: FIELD.vendor_part_tariff_rate!.id,
+      valueNumber: rate,
+      valueBoolean: null,
+      relatedEntityId: null,
+    }
+  }
+
+  const CN_VALVE = 'code_cn'
+  const CN_SCHEDULE = new Map<string, unknown[]>([
+    [
+      CN_VALVE,
+      [
+        { id: 'mfn', authority: 'MFN', rate: 2, effectiveFrom: '1995-01-01', chapter99Code: null },
+        {
+          id: 's301',
+          authority: 'Section 301 List 3',
+          rate: 25,
+          effectiveFrom: '2019-05-10',
+          chapter99Code: '9903.88.03',
+        },
+      ],
+    ],
+  ])
+
+  it('resolves a classified offer with no override from the schedule', async () => {
+    h.loadTariffSchedule.mockResolvedValue(CN_SCHEDULE)
+    queue([...vendorPartRows('vp_motor', MOTOR, 1999), codeRow('vp_motor', CN_VALVE)], [], [])
+
+    const { vendorPrices } = await loadOrgPricingData(ORG)
+
+    expect(h.loadTariffSchedule).toHaveBeenCalledTimes(1)
+    expect(h.readBookTimeZone).toHaveBeenCalledWith(ORG)
+    expect(vendorPrices).toEqual([expect.objectContaining({ id: 'vp_motor', tariffRate: 27 })])
+  })
+
+  it('a set override wins and the schedule is not even loaded', async () => {
+    queue(
+      [
+        ...vendorPartRows('vp_motor', MOTOR, 1999),
+        codeRow('vp_motor', CN_VALVE),
+        overrideRow('vp_motor', 12),
+      ],
+      [],
+      []
+    )
+
+    const { vendorPrices } = await loadOrgPricingData(ORG)
+
+    expect(h.loadTariffSchedule).not.toHaveBeenCalled()
+    expect(vendorPrices[0]!.tariffRate).toBe(12)
+  })
+
+  it('an unclassified org pays no schedule read at all', async () => {
+    queue(vendorPartRows('vp_motor', MOTOR, 1999), [], [])
+    await loadOrgPricingData(ORG)
+    expect(h.loadTariffSchedule).not.toHaveBeenCalled()
+    expect(h.readBookTimeZone).not.toHaveBeenCalled()
+  })
+
+  it('a classified offer whose code has no rows resolves to no duty, not to a failure', async () => {
+    h.loadTariffSchedule.mockResolvedValue(new Map())
+    queue([...vendorPartRows('vp_motor', MOTOR, 1999), codeRow('vp_motor', 'code_empty')], [], [])
+
+    const { vendorPrices } = await loadOrgPricingData(ORG)
+    expect(vendorPrices[0]!.tariffRate).toBe(0)
   })
 })

--- a/packages/lib/src/bom/cost-calculator.ts
+++ b/packages/lib/src/bom/cost-calculator.ts
@@ -16,7 +16,13 @@ import {
   getRealtimeService,
   publishFieldValueUpdates,
 } from '../realtime'
-import { computeLandedCost, selectWinningVendor, type VendorCostRow } from './vendor-cost'
+import { loadTariffSchedule, readBookTimeZone } from './tariff-schedule'
+import {
+  computeLandedCost,
+  resolveOfferTariff,
+  selectWinningVendor,
+  type VendorCostRow,
+} from './vendor-cost'
 
 const logger = createScopedLogger('bom:cost-calculator')
 
@@ -141,6 +147,7 @@ async function loadOrgPricingData(orgId: string): Promise<OrgPricingData> {
       'vendor_part_is_preferred',
       'vendor_part_shipping_cost',
       'vendor_part_tariff_rate',
+      'vendor_part_tariff_code',
       'vendor_part_other_cost',
       'subpart_parent_part',
       'subpart_child_part',
@@ -152,6 +159,7 @@ async function loadOrgPricingData(orgId: string): Promise<OrgPricingData> {
   const vpPreferredField = cfFields.vendor_part_is_preferred
   const vpShippingField = cfFields.vendor_part_shipping_cost
   const vpTariffField = cfFields.vendor_part_tariff_rate
+  const vpTariffCodeField = cfFields.vendor_part_tariff_code
   const vpOtherField = cfFields.vendor_part_other_cost
   const spParentField = cfFields.subpart_parent_part
   const spChildField = cfFields.subpart_child_part
@@ -205,6 +213,7 @@ async function loadOrgPricingData(orgId: string): Promise<OrgPricingData> {
         unitPrice: number | null
         shippingCost: number | null
         tariffRate: number | null
+        tariffCodeId: string | null
         otherCost: number | null
         isPreferred: boolean
       }
@@ -217,6 +226,7 @@ async function loadOrgPricingData(orgId: string): Promise<OrgPricingData> {
           unitPrice: null,
           shippingCost: null,
           tariffRate: null,
+          tariffCodeId: null,
           otherCost: null,
           isPreferred: false,
         })
@@ -232,8 +242,29 @@ async function loadOrgPricingData(orgId: string): Promise<OrgPricingData> {
         entry.shippingCost = row.valueNumber
       } else if (vpTariffField && row.fieldId === vpTariffField.id) {
         entry.tariffRate = row.valueNumber
+      } else if (vpTariffCodeField && row.fieldId === vpTariffCodeField.id) {
+        entry.tariffCodeId = row.relatedEntityId
       } else if (vpOtherField && row.fieldId === vpOtherField.id) {
         entry.otherCost = row.valueNumber
+      }
+    }
+
+    // The schedule half of 29 §3.1: an offer with NO override and a tariff code
+    // takes its rate from the code's dated rows, resolved at NOW in the book
+    // timezone - `part_cost` is the live replacement cost by definition (29
+    // §5.1). Loaded only when some offer actually needs it, so an org that has
+    // never classified anything pays no extra query and no settings read.
+    const classified = [...byInstance.values()].filter(
+      (entry) => entry.partInstanceId && entry.tariffRate == null && entry.tariffCodeId
+    )
+    if (classified.length > 0) {
+      const [schedule, timeZone] = await Promise.all([
+        loadTariffSchedule(database, orgId),
+        readBookTimeZone(orgId),
+      ])
+      const now = new Date()
+      for (const entry of classified) {
+        entry.tariffRate = resolveOfferTariff(entry, schedule, now, timeZone).rate
       }
     }
 

--- a/packages/lib/src/bom/index.ts
+++ b/packages/lib/src/bom/index.ts
@@ -3,8 +3,11 @@
 export { recalculateAffectedParts, recalculateAllPartCosts } from './cost-calculator'
 export { batchRecalculateQoH } from './qoh'
 export { getDeductionTargets, loadDirectSubparts, loadSubpartGraph } from './subpart-graph'
+export { loadTariffSchedule, readBookTimeZone } from './tariff-schedule'
 export type {
   LandedCostBreakdown,
+  OfferTariff,
+  OfferTariffInputs,
   TariffRateComponent,
   TariffRateRow,
   TariffResolution,
@@ -12,8 +15,10 @@ export type {
   VendorCostRow,
 } from './vendor-cost'
 export {
+  composeTariffCodeLabel,
   computeLandedBreakdown,
   computeLandedCost,
+  resolveOfferTariff,
   resolveTariffRate,
   selectWinningVendor,
 } from './vendor-cost'

--- a/packages/lib/src/bom/offer-tariff.test.ts
+++ b/packages/lib/src/bom/offer-tariff.test.ts
@@ -1,0 +1,121 @@
+// packages/lib/src/bom/offer-tariff.test.ts
+//
+// 29 §3.1 as a function (30 §1): override, else schedule, else zero - with the
+// three "zero" readings kept apart, because the six callers that share this
+// would otherwise each collapse them differently.
+
+import { describe, expect, it } from 'vitest'
+import { resolveOfferTariff, type TariffRateRow } from './vendor-cost'
+
+function rateRow(id: string, overrides: Partial<TariffRateRow> = {}): TariffRateRow {
+  return {
+    id,
+    authority: null,
+    rate: 0,
+    effectiveFrom: '2019-01-01',
+    chapter99Code: null,
+    ...overrides,
+  }
+}
+
+const CN_VALVE = 'code_cn'
+const SCHEDULE = new Map<string, TariffRateRow[]>([
+  [
+    CN_VALVE,
+    [
+      rateRow('mfn', { authority: 'MFN', rate: 2, effectiveFrom: '1995-01-01' }),
+      rateRow('s301', {
+        authority: 'Section 301 List 3',
+        rate: 25,
+        effectiveFrom: '2019-05-10',
+        chapter99Code: '9903.88.03',
+      }),
+    ],
+  ],
+  ['code_future', [rateRow('later', { rate: 10, effectiveFrom: '2030-01-01' })]],
+  ['code_empty', []],
+])
+
+const at = (day: string) => new Date(`${day}T12:00:00.000Z`)
+
+describe('resolveOfferTariff', () => {
+  it('a set override wins and the schedule is not consulted', () => {
+    const result = resolveOfferTariff(
+      { tariffRate: 12, tariffCodeId: CN_VALVE },
+      SCHEDULE,
+      at('2025-06-01')
+    )
+    expect(result).toEqual({ source: 'override', rate: 12 })
+  })
+
+  it('an override of 0 is still an override - a DDP price carries no separate duty', () => {
+    const result = resolveOfferTariff(
+      { tariffRate: 0, tariffCodeId: CN_VALVE },
+      SCHEDULE,
+      at('2025-06-01')
+    )
+    expect(result).toEqual({ source: 'override', rate: 0 })
+  })
+
+  it('resolves the schedule when the override is blank', () => {
+    const result = resolveOfferTariff(
+      { tariffRate: null, tariffCodeId: CN_VALVE },
+      SCHEDULE,
+      at('2025-06-01')
+    )
+    expect(result.source).toBe('schedule')
+    expect(result.rate).toBe(27)
+    if (result.source !== 'schedule' || result.status !== 'resolved') throw new Error('shape')
+    expect(result.components.map((c) => c.authority)).toEqual(['MFN', 'Section 301 List 3'])
+  })
+
+  it('resolves at the date given, not at now', () => {
+    const before301 = resolveOfferTariff(
+      { tariffRate: null, tariffCodeId: CN_VALVE },
+      SCHEDULE,
+      at('2019-01-15')
+    )
+    expect(before301.rate).toBe(2)
+  })
+
+  it('keeps the three zero readings apart', () => {
+    const none = resolveOfferTariff(
+      { tariffRate: null, tariffCodeId: null },
+      SCHEDULE,
+      at('2025-06-01')
+    )
+    expect(none).toEqual({ source: 'none', rate: 0 })
+
+    const pending = resolveOfferTariff(
+      { tariffRate: null, tariffCodeId: 'code_future' },
+      SCHEDULE,
+      at('2025-06-01')
+    )
+    expect(pending).toEqual({ source: 'schedule', status: 'pending', rate: 0, components: [] })
+
+    // A code that exists but has no rows, and a code the map has never heard
+    // of, are the same answer: classified, nothing behind it.
+    for (const tariffCodeId of ['code_empty', 'code_unknown']) {
+      const unclassified = resolveOfferTariff(
+        { tariffRate: null, tariffCodeId },
+        SCHEDULE,
+        at('2025-06-01')
+      )
+      expect(unclassified).toEqual({
+        source: 'schedule',
+        status: 'unclassified',
+        rate: 0,
+        components: [],
+      })
+    }
+  })
+
+  it('threads the timezone through to the day comparison', () => {
+    // 2019-05-09T22:00Z is May 10 in Berlin and May 9 in UTC. The 301 row starts
+    // May 10, so the zone decides whether it is in force.
+    const instant = new Date('2019-05-09T22:00:00.000Z')
+    const offer = { tariffRate: null, tariffCodeId: CN_VALVE }
+    expect(resolveOfferTariff(offer, SCHEDULE, instant, 'UTC').rate).toBe(2)
+    expect(resolveOfferTariff(offer, SCHEDULE, instant, 'Europe/Berlin').rate).toBe(27)
+  })
+})

--- a/packages/lib/src/bom/tariff-schedule.ts
+++ b/packages/lib/src/bom/tariff-schedule.ts
@@ -1,0 +1,141 @@
+// packages/lib/src/bom/tariff-schedule.ts
+
+/**
+ * The server-side read of the tariff schedule
+ * (plans/money/tasks/30-tariff-offer-surfaces.md §1, §2).
+ *
+ * Reads only. Returns the shape `resolveOfferTariff` / `resolveTariffRate` take,
+ * grouped by `tariff_code` instance id, so a caller resolves any number of
+ * offers from one load. The browser reads the same rows through
+ * `record.listAll` and never through this module.
+ *
+ * ⚠️ **No org-cache key, deliberately** (29 §7). The invalidation graph has no
+ * event for an ordinary record write, so a cached schedule would fail OPEN and
+ * serve a stale rate indefinitely. A schedule is tens of codes with a handful of
+ * rows each; one indexed query per recalculation is the honest cost.
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import type { TariffRateRow } from './vendor-cost'
+
+/**
+ * Every live `tariff_rate` row in the org, grouped by the `tariff_code` it
+ * belongs to.
+ *
+ * `codeInstanceIds` narrows the read to the codes named. Pass it when one offer
+ * is being priced (the receipt path); leave it out when the whole org is being
+ * recalculated, where the calculator wants every code once.
+ *
+ * Empty map when the org has no `tariff_rate` definition or its fields are not
+ * materialised yet, which an org mid-migration reaches. Every offer then
+ * resolves as `unclassified`, the safe reading.
+ */
+export async function loadTariffSchedule(
+  db: Database,
+  organizationId: string,
+  codeInstanceIds?: readonly string[]
+): Promise<Map<string, TariffRateRow[]>> {
+  const byCode = new Map<string, TariffRateRow[]>()
+  if (codeInstanceIds && codeInstanceIds.length === 0) return byCode
+
+  const rateDefId = await getCachedEntityDefId(organizationId, 'tariff_rate')
+  if (!rateDefId) return byCode
+
+  // The four rate attributes the resolver reads, plus the pointer that groups them.
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([
+      'tariff_rate_tariff_code',
+      'tariff_rate_rate',
+      'tariff_rate_effective_from',
+      'tariff_rate_authority',
+      'tariff_rate_chapter99_code',
+    ] as const)
+  const codeField = fields.tariff_rate_tariff_code
+  const rateField = fields.tariff_rate_rate
+  const fromField = fields.tariff_rate_effective_from
+  if (!codeField || !rateField || !fromField) return byCode
+
+  const rows = await db
+    .select({
+      instanceId: schema.EntityInstance.id,
+      fieldId: schema.FieldValue.fieldId,
+      valueNumber: schema.FieldValue.valueNumber,
+      valueText: schema.FieldValue.valueText,
+      valueDate: schema.FieldValue.valueDate,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      schema.FieldValue,
+      and(
+        eq(schema.FieldValue.entityId, schema.EntityInstance.id),
+        eq(schema.FieldValue.organizationId, schema.EntityInstance.organizationId)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, rateDefId),
+        isNull(schema.EntityInstance.archivedAt),
+        inArray(schema.FieldValue.fieldId, [
+          codeField.id,
+          rateField.id,
+          fromField.id,
+          ...(fields.tariff_rate_authority ? [fields.tariff_rate_authority.id] : []),
+          ...(fields.tariff_rate_chapter99_code ? [fields.tariff_rate_chapter99_code.id] : []),
+        ])
+      )
+    )
+
+  // One `tariff_rate` is several FieldValue rows; fold them back into one row.
+  const byInstance = new Map<string, TariffRateRow & { codeId: string | null }>()
+  for (const row of rows) {
+    let entry = byInstance.get(row.instanceId)
+    if (!entry) {
+      entry = {
+        id: row.instanceId,
+        codeId: null,
+        authority: null,
+        rate: null,
+        effectiveFrom: null,
+        chapter99Code: null,
+      }
+      byInstance.set(row.instanceId, entry)
+    }
+    if (row.fieldId === codeField.id) entry.codeId = row.relatedEntityId
+    else if (row.fieldId === rateField.id) entry.rate = row.valueNumber
+    else if (row.fieldId === fromField.id) entry.effectiveFrom = row.valueDate
+    else if (row.fieldId === fields.tariff_rate_authority?.id) entry.authority = row.valueText
+    else if (row.fieldId === fields.tariff_rate_chapter99_code?.id) {
+      entry.chapter99Code = row.valueText
+    }
+  }
+
+  const wanted = codeInstanceIds ? new Set(codeInstanceIds) : null
+  for (const { codeId, ...rate } of byInstance.values()) {
+    if (!codeId) continue
+    if (wanted && !wanted.has(codeId)) continue
+    const bucket = byCode.get(codeId) ?? []
+    bucket.push(rate)
+    byCode.set(codeId, bucket)
+  }
+  return byCode
+}
+
+/**
+ * The org's `accounting.bookTimeZone`, or `UTC` when it has never been set.
+ *
+ * The zone every schedule lookup on the server resolves in - the same rule
+ * `gather-month-end-inventory.ts` applies to period membership. Imported lazily
+ * the way `bom-cost-triggers.ts` reaches the settings service: the setting
+ * graph is not something the cost calculator should load for orgs that have
+ * never classified an offer.
+ */
+export async function readBookTimeZone(organizationId: string): Promise<string> {
+  const { getOrganizationSetting } = await import('../settings/settings-service')
+  const value = await getOrganizationSetting({ organizationId, key: 'accounting.bookTimeZone' })
+  return typeof value === 'string' && value.trim().length > 0 ? value : 'UTC'
+}

--- a/packages/lib/src/bom/vendor-cost.ts
+++ b/packages/lib/src/bom/vendor-cost.ts
@@ -373,6 +373,104 @@ export function resolveTariffRate(
 }
 
 /**
+ * The composed label of a `tariff_code`: `8481.80.9005 CN`.
+ *
+ * ONE definition, shared by the browser (pickers, chips) and the server (the
+ * derived `tariff_code_label` field the importers match on - 30 §8). Two
+ * spellings of this string would fork the relation match the same way two
+ * spellings of a country fork the natural key.
+ */
+export function composeTariffCodeLabel(code: string, country: string | null): string {
+  const trimmed = code.trim()
+  return country ? `${trimmed} ${country.trim().toUpperCase()}` : trimmed
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Precedence at the point of use (29 §3.1, 30 §1)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * The two fields on a supplier offer that decide its duty rate.
+ *
+ * Structural, like {@link VendorCostRow}: the calculator reads them off
+ * `FieldValue` rows and the browser off its field-value store.
+ */
+export interface OfferTariffInputs {
+  /** `vendor_part_tariff_rate` - the OVERRIDE. A percentage; `null` means "use the schedule". */
+  tariffRate: number | null
+  /** `vendor_part_tariff_code` - the `tariff_code` instance id, or `null` when unclassified. */
+  tariffCodeId: string | null
+}
+
+/**
+ * Where an offer's duty rate came from, with the rate itself.
+ *
+ * 🛑 **`rate` alone is not the answer, for the same reason it is not on
+ * {@link TariffResolution}.** `none`, `unclassified` and `pending` all carry
+ * `0`, and they mean three different things: no code was ever set; a code is
+ * set but has no rows; a code is set and every row starts in the future. A UI
+ * that prints `0%` for all three tells a person with an unfinished row that
+ * they are done.
+ */
+export type OfferTariff =
+  /** `tariffRate` is set. The schedule was not consulted. */
+  | { source: 'override'; rate: number }
+  /** `tariffCodeId` is set and at least one authority is in force. */
+  | {
+      source: 'schedule'
+      status: 'resolved'
+      rate: number
+      components: TariffRateComponent[]
+    }
+  /** `tariffCodeId` is set but nothing resolves: no rows, or none in force yet. */
+  | { source: 'schedule'; status: 'pending' | 'unclassified'; rate: 0; components: [] }
+  /** Neither field is set. Today's behaviour for every existing offer. */
+  | { source: 'none'; rate: 0 }
+
+/**
+ * 29 §3.1 as one function: **a set override wins; else the schedule at
+ * `atDate`; else zero.**
+ *
+ * This is the only place the precedence lives. Before it existed the rule was
+ * prose on {@link resolveTariffRate}, and six callers - the cost calculator, the
+ * receipt read, the supplier form, the Suppliers tab, the Receive form and the
+ * Classification tab - would each have re-derived it. The one that actually
+ * diverges under that arrangement is the three-state handling: a UI author
+ * collapses `pending` into `0%` and a server author does not, and the two then
+ * disagree about whether an offer is classified.
+ *
+ * Pure, and exported through `bom/client.ts` for the same reason
+ * {@link resolveTariffRate} is.
+ *
+ * @param offer The offer's override and pointer.
+ * @param ratesByCode Every rate row in the org, grouped by `tariff_code`
+ *   instance id. A code with no entry resolves as `unclassified`.
+ * @param atDate The instant to resolve as of. `part_cost` passes now; a receipt
+ *   passes its `occurredAt`.
+ * @param timeZone The org's `bookTimeZone`. See {@link resolveTariffRate}.
+ */
+export function resolveOfferTariff(
+  offer: OfferTariffInputs,
+  ratesByCode: ReadonlyMap<string, readonly TariffRateRow[]>,
+  atDate: Date,
+  timeZone = 'UTC'
+): OfferTariff {
+  if (offer.tariffRate != null) return { source: 'override', rate: offer.tariffRate }
+  if (!offer.tariffCodeId) return { source: 'none', rate: 0 }
+
+  const resolution = resolveTariffRate(ratesByCode.get(offer.tariffCodeId) ?? [], atDate, timeZone)
+  if (resolution.status === 'resolved') {
+    return {
+      source: 'schedule',
+      status: 'resolved',
+      rate: resolution.rate,
+      components: resolution.components,
+    }
+  }
+  return { source: 'schedule', status: resolution.status, rate: 0, components: [] }
+}
+
+/**
  * Display order: oldest first, so a code reads the way an entry summary does -
  * the base duty, then the layers stacked on top of it. Ties fall through to the
  * authority and then the id so the order is TOTAL: two rows sharing a day would

--- a/packages/lib/src/field-hooks/__tests__/delete-guard-registration.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/delete-guard-registration.test.ts
@@ -31,6 +31,7 @@ import { guardInvoiceDelete } from '../pre/invoice-delete-guard'
 import { cascadeOrderLinesOnDelete } from '../pre/order-delete-guard'
 import { guardPartDelete } from '../pre/part-delete-guard'
 import { guardPurchaseOrderDelete } from '../pre/purchase-order-delete-guard'
+import { guardTariffCodeDelete } from '../pre/tariff-code-delete-guard'
 import { guardVendorBillDelete } from '../pre/vendor-bill-delete-guard'
 import { getEntityPreDeleteHooks } from '../registry'
 
@@ -42,6 +43,7 @@ const GUARDED = [
   { slug: 'builds', handler: guardBuildDelete },
   { slug: 'purchase-orders', handler: guardPurchaseOrderDelete },
   { slug: 'vendor-bills', handler: guardVendorBillDelete },
+  { slug: 'tariff-codes', handler: guardTariffCodeDelete },
 ] as const
 
 /**
@@ -68,6 +70,11 @@ const MONEY_ENTITY_TYPES = [
   'gl_account',
   'vendor_payment',
   'vendor_payment_allocation',
+  // The tariff schedule (tasks 29/30). `tariff_code` is a visible parent with
+  // two child types behind it. `tariff_rate` is deliberately NOT listed: it is
+  // a visible LEAF - nothing points at a rate row - and a guard that guards
+  // nothing would only make this list read as complete when it is not.
+  'tariff_code',
 ] as const
 
 /**
@@ -116,10 +123,16 @@ describe('pre-delete hook registration', () => {
     expect(unguarded).toEqual([])
   })
 
-  it('holds the four visible money parents the costing guide §3 names', () => {
+  it('holds the four visible money parents the costing guide §3 names, plus the tariff registry', () => {
     // Pins the derivation itself: if a money entity flips to visible, or a new
     // one ships visible, this fails and the guard question gets asked BEFORE the
     // delete button is live — which is the whole point of the file.
-    expect(visibleMoneyParents()).toEqual(['builds', 'parts', 'purchase-orders', 'vendor-bills'])
+    expect(visibleMoneyParents()).toEqual([
+      'builds',
+      'parts',
+      'purchase-orders',
+      'tariff-codes',
+      'vendor-bills',
+    ])
   })
 })

--- a/packages/lib/src/field-hooks/__tests__/guard-sees-archived.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/guard-sees-archived.test.ts
@@ -41,6 +41,8 @@ const FIXED = [
   'build-delete-guard.ts',
   'part-delete-guard.ts',
   'purchase-order-delete-guard.ts',
+  // Born on `findRelatedInstanceIds` (task 30 §9.1); never had the defect.
+  'tariff-code-delete-guard.ts',
   'vendor-bill-delete-guard.ts',
 ]
 

--- a/packages/lib/src/field-hooks/__tests__/system-record-rules.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/system-record-rules.test.ts
@@ -35,16 +35,22 @@ afterEach(() => {
 })
 
 describe('registerFieldSystemRules — declarations', () => {
-  it('declares exactly the 7 field triggers', () => {
+  it('declares exactly the 11 field triggers', () => {
     const decls = getSystemRuleDeclarations()
-    expect(decls).toHaveLength(7)
+    expect(decls).toHaveLength(11)
     expect(decls.map((d) => d.fieldRef?.systemAttribute).sort()).toEqual(
       [
         'part_reorder_point',
         'subpart_quantity',
+        // The schedule (29 §7): the three rate-row fields the resolver reads,
+        // and the offer's pointer.
+        'tariff_rate_authority',
+        'tariff_rate_effective_from',
+        'tariff_rate_rate',
         'vendor_part_is_preferred',
         'vendor_part_other_cost',
         'vendor_part_shipping_cost',
+        'vendor_part_tariff_code',
         'vendor_part_tariff_rate',
         'vendor_part_unit_price',
       ].sort()
@@ -67,14 +73,23 @@ describe('registerFieldSystemRules — declarations', () => {
     const bySlug = (attr: string) =>
       getSystemRuleDeclarations().find((d) => d.fieldRef?.systemAttribute === attr)!.defSlug
     expect(bySlug('vendor_part_unit_price')).toBe('vendor-parts')
+    expect(bySlug('vendor_part_tariff_code')).toBe('vendor-parts')
     expect(bySlug('subpart_quantity')).toBe('subparts')
     expect(bySlug('part_reorder_point')).toBe('parts')
+    expect(bySlug('tariff_rate_rate')).toBe('tariff-rates')
+  })
+
+  it('routes the tariff rate fields to the two-join handler, not the vendor-part one', () => {
+    const handlers = getSystemRuleDeclarations()
+      .filter((d) => d.defSlug === 'tariff-rates')
+      .flatMap((d) => d.actions.map((a) => (a as { handler: string }).handler))
+    expect(new Set(handlers)).toEqual(new Set(['recalculatePartCostFromTariffRate']))
   })
 
   it('is idempotent — a second call does not duplicate declarations', () => {
     __resetFieldSystemRulesLatch()
     registerFieldSystemRules()
-    expect(getSystemRuleDeclarations()).toHaveLength(7)
+    expect(getSystemRuleDeclarations()).toHaveLength(11)
   })
 })
 

--- a/packages/lib/src/field-hooks/post/bom-cost-triggers.ts
+++ b/packages/lib/src/field-hooks/post/bom-cost-triggers.ts
@@ -107,6 +107,22 @@ export async function recalculatePartCostForEntityBatch(params: {
   await ensureFirstStandardCosts(organizationId, affected)
 }
 
+/**
+ * Recalculate a known set of parts and give any newly priced one its first
+ * standard - the tail every handler in this file ends with, exported so a
+ * handler that resolves its parts by a different route (`tariff-rate-triggers.ts`
+ * walks rate -> code -> offer -> part) ends the same way.
+ */
+export async function recalculatePartCostsForParts(
+  organizationId: string,
+  partIds: readonly string[]
+): Promise<void> {
+  if (partIds.length === 0) return
+  const affected = [...new Set(partIds)]
+  await recalculateAffectedParts(organizationId, affected)
+  await ensureFirstStandardCosts(organizationId, affected)
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────
 
 /**
@@ -181,10 +197,11 @@ async function ensureFirstStandardCosts(organizationId: string, partIds: string[
 }
 
 /**
- * Batch resolve parent partIds for multiple entity instances in a single query.
- * Looks up the relationship field value (e.g., vendor_part_part) for all instances at once.
+ * Batch resolve the related instance ids behind one relationship attribute for
+ * many entity instances, in a single query - `vendor_part_part` for a set of
+ * offers, `tariff_rate_tariff_code` for a set of rates. De-duplicated.
  */
-async function batchResolvePartIds(
+export async function batchResolvePartIds(
   entityInstanceIds: string[],
   organizationId: string,
   relationshipSystemAttribute: string

--- a/packages/lib/src/field-hooks/post/tariff-rate-triggers.test.ts
+++ b/packages/lib/src/field-hooks/post/tariff-rate-triggers.test.ts
@@ -1,0 +1,92 @@
+// packages/lib/src/field-hooks/post/tariff-rate-triggers.test.ts
+// 29 §7: the two-join widening from a rate row to the parts it reprices.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  batchResolvePartIds: vi.fn(),
+  recalculatePartCostsForParts: vi.fn(async () => {}),
+  findRelated: vi.fn(),
+}))
+
+vi.mock('./bom-cost-triggers', () => ({
+  batchResolvePartIds: h.batchResolvePartIds,
+  recalculatePartCostsForParts: h.recalculatePartCostsForParts,
+}))
+vi.mock('../pre/related-rows', () => ({ findRelatedInstanceIds: h.findRelated }))
+
+import { recalculatePartCostForTariffRates } from './tariff-rate-triggers'
+
+const ORG = 'org_1'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.findRelated.mockResolvedValue([])
+  h.batchResolvePartIds.mockResolvedValue([])
+})
+
+describe('recalculatePartCostForTariffRates', () => {
+  it('walks rate -> code -> offers -> parts and recalculates once', async () => {
+    h.findRelated.mockResolvedValue(['vp_1', 'vp_2'])
+    h.batchResolvePartIds.mockResolvedValue(['part_a', 'part_b'])
+
+    await recalculatePartCostForTariffRates({
+      organizationId: ORG,
+      rateInstanceIds: ['rate_1'],
+      values: { rate_1: { tariff_rate_tariff_code: 'tcdef:code_cn' } },
+    })
+
+    // The code came threaded, so the only `batchResolvePartIds` call is offers -> parts.
+    expect(h.batchResolvePartIds).toHaveBeenCalledTimes(1)
+    expect(h.batchResolvePartIds).toHaveBeenCalledWith(['vp_1', 'vp_2'], ORG, 'vendor_part_part')
+    expect(h.findRelated).toHaveBeenCalledWith(ORG, 'vendor_part', 'vendor_part_tariff_code', [
+      'code_cn',
+    ])
+    expect(h.recalculatePartCostsForParts).toHaveBeenCalledWith(ORG, ['part_a', 'part_b'])
+  })
+
+  it('reads the code from the row when the firing carried no values', async () => {
+    h.batchResolvePartIds
+      .mockResolvedValueOnce(['code_de']) // rate -> code
+      .mockResolvedValueOnce(['part_x']) // offers -> parts
+    h.findRelated.mockResolvedValue(['vp_9'])
+
+    await recalculatePartCostForTariffRates({ organizationId: ORG, rateInstanceIds: ['rate_2'] })
+
+    expect(h.batchResolvePartIds).toHaveBeenNthCalledWith(
+      1,
+      ['rate_2'],
+      ORG,
+      'tariff_rate_tariff_code'
+    )
+    expect(h.recalculatePartCostsForParts).toHaveBeenCalledWith(ORG, ['part_x'])
+  })
+
+  it('does nothing when no offer is classified under the code', async () => {
+    await recalculatePartCostForTariffRates({
+      organizationId: ORG,
+      rateInstanceIds: ['rate_1'],
+      values: { rate_1: { tariff_rate_tariff_code: 'code_cn' } },
+    })
+    expect(h.recalculatePartCostsForParts).not.toHaveBeenCalled()
+  })
+
+  it('dedupes codes across a batch of rates', async () => {
+    h.findRelated.mockResolvedValue(['vp_1'])
+    h.batchResolvePartIds.mockResolvedValue(['part_a'])
+
+    await recalculatePartCostForTariffRates({
+      organizationId: ORG,
+      rateInstanceIds: ['r1', 'r2', 'r3'],
+      values: {
+        r1: { tariff_rate_tariff_code: 'code_cn' },
+        r2: { tariff_rate_tariff_code: 'code_cn' },
+        r3: { tariff_rate_tariff_code: 'code_cn' },
+      },
+    })
+
+    expect(h.findRelated).toHaveBeenCalledWith(ORG, 'vendor_part', 'vendor_part_tariff_code', [
+      'code_cn',
+    ])
+  })
+})

--- a/packages/lib/src/field-hooks/post/tariff-rate-triggers.ts
+++ b/packages/lib/src/field-hooks/post/tariff-rate-triggers.ts
@@ -1,0 +1,82 @@
+// packages/lib/src/field-hooks/post/tariff-rate-triggers.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { unwrapRelationId } from '../../resources/events/captured-values'
+import { findRelatedInstanceIds } from '../pre/related-rows'
+import { batchResolvePartIds, recalculatePartCostsForParts } from './bom-cost-triggers'
+
+const logger = createScopedLogger('field-hooks:tariff-rate')
+
+/**
+ * Recalculate every part whose replacement cost a `tariff_rate` write moved
+ * (29 §7, 30 §10 phase A).
+ *
+ * The widening is two joins deeper than `recalculatePartCost`'s, which is why
+ * this is its own function rather than a third prefix branch there:
+ *
+ *     tariff_rate -> tariff_code -> every vendor_part pointing at that code
+ *                 -> each offer's part -> recalculateAffectedParts
+ *
+ * Only offers with NO override are actually repriced by the calculator (a set
+ * `vendor_part_tariff_rate` wins under 29 §3.1), but the walk does not filter
+ * on that: the calculator re-reads the whole offer anyway, and a recalc that
+ * changes nothing is cheaper than a second query to avoid it.
+ *
+ * `values` is the create/delete-time capture when the dispatching door had one
+ * (a lifecycle firing); a field-change firing has none and the code is read
+ * from the row, which soft-archive keeps, so a deleted rate still resolves.
+ */
+export async function recalculatePartCostForTariffRates(params: {
+  organizationId: string
+  rateInstanceIds: readonly string[]
+  values?: Record<string, Record<string, unknown> | undefined>
+}): Promise<void> {
+  const { organizationId, rateInstanceIds, values } = params
+  if (rateInstanceIds.length === 0) return
+
+  const codeIds = new Set<string>()
+  const missing: string[] = []
+  for (const rateId of rateInstanceIds) {
+    const threaded = unwrapRelationId(values?.[rateId]?.tariff_rate_tariff_code)
+    if (threaded) codeIds.add(threaded)
+    else missing.push(rateId)
+  }
+  if (missing.length > 0) {
+    for (const id of await batchResolvePartIds(
+      missing,
+      organizationId,
+      'tariff_rate_tariff_code'
+    )) {
+      codeIds.add(id)
+    }
+  }
+  if (codeIds.size === 0) {
+    logger.warn('Could not resolve a tariff code for any changed rate', {
+      organizationId,
+      rateCount: rateInstanceIds.length,
+    })
+    return
+  }
+
+  // Archived offers come back too (see `related-rows.ts`). Harmless here: the
+  // calculator skips archived instances, so the extra ids only widen the recalc
+  // to parts whose cost then comes out unchanged.
+  const offerIds = await findRelatedInstanceIds(
+    organizationId,
+    'vendor_part',
+    'vendor_part_tariff_code',
+    [...codeIds]
+  )
+  if (offerIds.length === 0) return
+
+  const partIds = await batchResolvePartIds(offerIds, organizationId, 'vendor_part_part')
+  if (partIds.length === 0) return
+
+  logger.info('Recalculating part costs from a tariff schedule change', {
+    organizationId,
+    codes: codeIds.size,
+    offers: offerIds.length,
+    affectedParts: partIds.length,
+  })
+  await recalculatePartCostsForParts(organizationId, partIds)
+}

--- a/packages/lib/src/field-hooks/pre/tariff-code-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/tariff-code-delete-guard.test.ts
@@ -1,0 +1,86 @@
+// packages/lib/src/field-hooks/pre/tariff-code-delete-guard.test.ts
+// plans/money/tasks/30-tariff-offer-surfaces.md §9.1: refuse while an offer is
+// classified under the code, cascade the rate rows otherwise.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../../errors'
+import type { EntityPreDeleteEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  findRelated: vi.fn(),
+  del: vi.fn(),
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    delete = h.del
+  },
+}))
+vi.mock('./related-rows', () => ({ findRelatedInstanceIds: h.findRelated }))
+
+import { guardTariffCodeDelete } from './tariff-code-delete-guard'
+
+const CODE_DEF = 'tc0def00000000000000000001'
+const CODE_ID = 'tc0id000000000000000000001'
+const ORG = 'org_1'
+
+function event(): EntityPreDeleteEvent {
+  return {
+    recordId: `${CODE_DEF}:${CODE_ID}` as EntityPreDeleteEvent['recordId'],
+    entityDefinitionId: CODE_DEF,
+    entityType: 'tariff_code',
+    entitySlug: 'tariff-codes',
+    values: {},
+    organizationId: ORG,
+    userId: 'usr_1',
+    bypass: new Set(),
+  }
+}
+
+/** Route `findRelatedInstanceIds` by child type. */
+function related(offers: string[], rates: string[]) {
+  h.findRelated.mockImplementation(async (_org: string, childType: string) =>
+    childType === 'vendor_part' ? offers : childType === 'tariff_rate' ? rates : []
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.del.mockResolvedValue(undefined)
+})
+
+describe('guardTariffCodeDelete', () => {
+  it('refuses while any supplier offer points at the code, and deletes nothing', async () => {
+    related(['vp_1', 'vp_2', 'vp_3'], ['rate_1'])
+
+    await expect(guardTariffCodeDelete(event())).rejects.toBeInstanceOf(BadRequestError)
+    await expect(guardTariffCodeDelete(event())).rejects.toThrow(/3 supplier prices are classified/)
+    expect(h.del).not.toHaveBeenCalled()
+  })
+
+  it('reads the offer count with `vendor_part_tariff_code`, archived rows included', async () => {
+    related(['vp_1'], [])
+    await expect(guardTariffCodeDelete(event())).rejects.toThrow(/1 supplier price is classified/)
+    expect(h.findRelated).toHaveBeenCalledWith(ORG, 'vendor_part', 'vendor_part_tariff_code', [
+      CODE_ID,
+    ])
+  })
+
+  it('cascades the rate rows through the handler when no offer is classified', async () => {
+    related([], ['rate_a', 'rate_b'])
+
+    await guardTariffCodeDelete(event())
+
+    expect(h.del).toHaveBeenCalledTimes(2)
+    expect(h.del.mock.calls.map((call) => call[0])).toEqual([
+      'tariff_rate:rate_a',
+      'tariff_rate:rate_b',
+    ])
+  })
+
+  it('is a no-op for a code with neither offers nor rates', async () => {
+    related([], [])
+    await guardTariffCodeDelete(event())
+    expect(h.del).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/field-hooks/pre/tariff-code-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/tariff-code-delete-guard.ts
@@ -1,0 +1,70 @@
+// packages/lib/src/field-hooks/pre/tariff-code-delete-guard.ts
+
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { BadRequestError } from '../../errors'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import type { EntityPreDeleteHandler } from '../types'
+import { findRelatedInstanceIds } from './related-rows'
+
+/**
+ * Pre-delete guard for `tariff-codes` (plans/money/tasks/30-tariff-offer-surfaces.md §9.1).
+ *
+ * `tariff_code` is `isVisible: true`, so it carries an ordinary records table
+ * with an ordinary row delete and bulk delete - the same combination that
+ * shipped `parts` unguarded (task 20). Deleting a code leaves every
+ * `vendor_part.tariffCode` pointing at nothing, which `resolveOfferTariff`
+ * reads as `none`: **duty silently drops to zero on every offer that used it**,
+ * and `part_cost` follows on the next recalculation with nothing thrown.
+ *
+ * Two dispositions:
+ *
+ *   1. **Supplier offers - REFUSE.** A classification is a deliberate act and
+ *      undoing it should be too. Cascading the pointer to null would be the
+ *      silent zero above with one extra step. The refusal names the count and
+ *      points at the Classification tab, which is where reclassifying happens.
+ *   2. **Rate rows - CASCADE.** A `tariff_rate` with no code is meaningless -
+ *      its display name is projected FROM the code - so they go with it. Deleted
+ *      through `UnifiedCrudHandler.delete` so `mfg-tariff-rates-deleted` fires;
+ *      with no offers left on the code it finds nothing to reprice, which is
+ *      correct.
+ *
+ * Archived offers count (see `related-rows.ts`): archiving is the sanctioned
+ * way to retire an offer, so an archived offer cannot also mean "nothing depends
+ * on this code any more".
+ *
+ * No admin gate, following `parts`: a code carries no ledger and no RESTRICT
+ * foreign key, so the per-row `record.delete` the mutation already asserts is
+ * the whole authorization story.
+ */
+export const guardTariffCodeDelete: EntityPreDeleteHandler = async (event) => {
+  const { organizationId, userId, recordId } = event
+  const { entityInstanceId: codeInstanceId } = parseRecordId(recordId)
+
+  const offerIds = await findRelatedInstanceIds(
+    organizationId,
+    'vendor_part',
+    'vendor_part_tariff_code',
+    [codeInstanceId]
+  )
+  if (offerIds.length > 0) {
+    const noun = offerIds.length === 1 ? 'supplier price is' : 'supplier prices are'
+    throw new BadRequestError(
+      `${offerIds.length} ${noun} classified under this tariff code. Reclassify them first ` +
+        '(Parts > Settings > Tariffs > Classification), or archive the code instead of deleting it.',
+      { organizationId, codeInstanceId, offerCount: String(offerIds.length) }
+    )
+  }
+
+  const rateIds = await findRelatedInstanceIds(
+    organizationId,
+    'tariff_rate',
+    'tariff_rate_tariff_code',
+    [codeInstanceId]
+  )
+  if (rateIds.length === 0) return
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  for (const id of rateIds) {
+    await handler.delete(toRecordId('tariff_rate', id))
+  }
+}

--- a/packages/lib/src/field-hooks/pre/tariff-code-label.test.ts
+++ b/packages/lib/src/field-hooks/pre/tariff-code-label.test.ts
@@ -1,0 +1,149 @@
+// packages/lib/src/field-hooks/pre/tariff-code-label.test.ts
+// The derived `tariff_code_label` (task 30 §8): stamped into the create's own
+// value bag, re-stamped when either leg changes, one composer for both.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityFieldChangeEvent, EntityPreCreateEvent } from '../types'
+
+const h = vi.hoisted(() => ({
+  bySystemAttributes: vi.fn(),
+  where: vi.fn(),
+  setValueWithType: vi.fn(async () => []),
+  createFieldValueContext: vi.fn(async (organizationId: string) => ({ organizationId })),
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: h.createFieldValueContext,
+}))
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+vi.mock('../../field-values/stored-field-type', () => ({ toFieldType: (stored: string) => stored }))
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => ({ from: () => ({ where: () => ({ limit: h.where }) }) }),
+  },
+  schema: {
+    FieldValue: {
+      valueText: 'vt',
+      optionId: 'oi',
+      organizationId: 'o',
+      entityId: 'e',
+      fieldId: 'f',
+    },
+  },
+}))
+
+import { composeTariffCodeLabel } from '../../bom/vendor-cost'
+import { restampTariffCodeLabel, stampTariffCodeLabel } from './tariff-code-label'
+
+const FIELDS = {
+  tariff_code_code: { id: 'f_code', type: 'TEXT' },
+  tariff_code_country: { id: 'f_country', type: 'SINGLE_SELECT' },
+  tariff_code_label: { id: 'f_label', type: 'TEXT' },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.bySystemAttributes.mockResolvedValue(FIELDS)
+  h.where.mockResolvedValue([])
+})
+
+function createEvent(values: Record<string, unknown>): EntityPreCreateEvent {
+  return {
+    entityDefinitionId: 'def_tc',
+    entityType: 'tariff_code',
+    entitySlug: 'tariff-codes',
+    values,
+    organizationId: 'org_1',
+    userId: 'usr_1',
+  }
+}
+
+function changeEvent(attribute: string, newValue: unknown): EntityFieldChangeEvent {
+  return {
+    recordId: 'def_tc:tc_1' as EntityFieldChangeEvent['recordId'],
+    entityDefinitionId: 'def_tc',
+    entityType: 'tariff_code',
+    entitySlug: 'tariff-codes',
+    field: { systemAttribute: attribute } as EntityFieldChangeEvent['field'],
+    oldValue: null,
+    newValue,
+    oldDisplay: null,
+    newDisplay: null,
+    organizationId: 'org_1',
+    userId: 'usr_1',
+  }
+}
+
+describe('composeTariffCodeLabel', () => {
+  it('is `{code} {country}`, trimmed, country upper-cased', () => {
+    expect(composeTariffCodeLabel(' 8481.80.9005 ', 'cn')).toBe('8481.80.9005 CN')
+    expect(composeTariffCodeLabel('8481.80.9005', null)).toBe('8481.80.9005')
+  })
+})
+
+describe('stampTariffCodeLabel', () => {
+  it('adds the label to the create values in place, whatever envelope the legs arrive in', async () => {
+    const values: Record<string, unknown> = {
+      tariff_code_code: '8481.80.9005',
+      tariff_code_country: ['CN'],
+    }
+    await stampTariffCodeLabel(createEvent(values))
+    expect(values.tariff_code_label).toBe('8481.80.9005 CN')
+  })
+
+  it('overwrites a caller-supplied label', async () => {
+    const values: Record<string, unknown> = {
+      tariff_code_code: '8481.80.9005',
+      tariff_code_country: { optionId: 'DE' },
+      tariff_code_label: 'whatever the script said',
+    }
+    await stampTariffCodeLabel(createEvent(values))
+    expect(values.tariff_code_label).toBe('8481.80.9005 DE')
+  })
+
+  it('leaves a create with no code alone - the required-field check refuses it anyway', async () => {
+    const values: Record<string, unknown> = { tariff_code_country: 'CN' }
+    await stampTariffCodeLabel(createEvent(values))
+    expect(values.tariff_code_label).toBeUndefined()
+  })
+})
+
+describe('restampTariffCodeLabel', () => {
+  it('ignores writes to other fields', async () => {
+    await restampTariffCodeLabel(changeEvent('tariff_code_description', 'Valves'))
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('re-composes from the changed code and the stored country', async () => {
+    h.where.mockResolvedValue([{ valueText: null, optionId: 'CN' }])
+    await restampTariffCodeLabel(changeEvent('tariff_code_code', '8481.80.9010'))
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      { organizationId: 'org_1' },
+      expect.objectContaining({
+        fieldId: 'f_label',
+        value: { type: 'text', value: '8481.80.9010 CN' },
+      })
+    )
+  })
+
+  it('re-composes from the stored code and the changed country', async () => {
+    h.where.mockResolvedValue([{ valueText: '8481.80.9005', optionId: null }])
+    await restampTariffCodeLabel(changeEvent('tariff_code_country', ['DE']))
+    expect(h.setValueWithType).toHaveBeenCalledWith(
+      { organizationId: 'org_1' },
+      expect.objectContaining({ value: { type: 'text', value: '8481.80.9005 DE' } })
+    )
+  })
+
+  it('never throws out of the edit that triggered it', async () => {
+    h.bySystemAttributes.mockRejectedValue(new Error('cache down'))
+    await expect(
+      restampTariffCodeLabel(changeEvent('tariff_code_code', '8481'))
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/field-hooks/pre/tariff-code-label.ts
+++ b/packages/lib/src/field-hooks/pre/tariff-code-label.ts
@@ -1,0 +1,112 @@
+// packages/lib/src/field-hooks/pre/tariff-code-label.ts
+
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { parseRecordId } from '@auxx/types/resource'
+import { and, eq, inArray } from 'drizzle-orm'
+import { composeTariffCodeLabel } from '../../bom/vendor-cost'
+import { getOrgCache } from '../../cache'
+import { createFieldValueContext } from '../../field-values/field-value-helpers'
+import { setValueWithType } from '../../field-values/field-value-mutations'
+import { toFieldType } from '../../field-values/stored-field-type'
+import { unwrapStatusValue } from '../../resources/events/captured-values'
+import type { EntityFieldChangeHandler, EntityPreCreateHandler } from '../types'
+
+const logger = createScopedLogger('field-hooks:tariff-code-label')
+
+const CODE_ATTR = 'tariff_code_code'
+const COUNTRY_ATTR = 'tariff_code_country'
+const LABEL_ATTR = 'tariff_code_label'
+
+/**
+ * Stamp `tariff_code_label` onto a create (task 30 §8).
+ *
+ * A PRE-CREATE hook because `event.values` is the very object `createEntity`
+ * hands to `setFieldValues` next, so adding a key here is how a derived field
+ * lands in the same write as its inputs - no second round trip and no window in
+ * which the record exists nameless. Registered AFTER `guardTariffCodeUniqueness`
+ * so a refused duplicate is never stamped.
+ *
+ * ⚠️ Overwrites whatever a caller put under `tariff_code_label`. The field is
+ * `creatable: false`, but the write path does not read capabilities (see the
+ * tags guards), so a script that sends its own label would otherwise fork the
+ * one string two importers match on.
+ */
+export const stampTariffCodeLabel: EntityPreCreateHandler = async (event) => {
+  const code = readText(event.values[CODE_ATTR])
+  const country = readText(event.values[COUNTRY_ATTR])
+  if (!code) return
+  event.values[LABEL_ATTR] = composeTariffCodeLabel(code, country)
+}
+
+/**
+ * Re-stamp the label when either leg changes on an existing code.
+ *
+ * A FIELD-CHANGE hook rather than a field pre-hook: a pre-hook can only
+ * transform the value being written, and the label is a different field. Reads
+ * the other leg off the row, writes the label through the ordinary field-value
+ * door so the display name, the realtime frame and the timeline all follow.
+ *
+ * Never fails the edit that triggered it. A stale label is a display and import
+ * defect; a refused code edit is a person's work lost.
+ */
+export const restampTariffCodeLabel: EntityFieldChangeHandler = async (event) => {
+  const attribute = event.field.systemAttribute
+  if (attribute !== CODE_ATTR && attribute !== COUNTRY_ATTR) return
+
+  const { organizationId, userId, recordId } = event
+  try {
+    const fields = await getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttributes([CODE_ATTR, COUNTRY_ATTR, LABEL_ATTR] as const)
+    const codeField = fields.tariff_code_code
+    const countryField = fields.tariff_code_country
+    const labelField = fields.tariff_code_label
+    if (!codeField || !countryField || !labelField) return
+
+    // The changed leg from the event, the other from the row.
+    const { entityInstanceId } = parseRecordId(recordId)
+    const otherFieldId = attribute === CODE_ATTR ? countryField.id : codeField.id
+    const [other] = await database
+      .select({ valueText: schema.FieldValue.valueText, optionId: schema.FieldValue.optionId })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          eq(schema.FieldValue.entityId, entityInstanceId),
+          inArray(schema.FieldValue.fieldId, [otherFieldId])
+        )
+      )
+      .limit(1)
+
+    const changed = readText(event.newValue)
+    const code = attribute === CODE_ATTR ? changed : (other?.valueText ?? null)
+    const country = attribute === COUNTRY_ATTR ? changed : (other?.optionId ?? null)
+    if (!code) return
+
+    const ctx = await createFieldValueContext(organizationId, userId)
+    await setValueWithType(ctx, {
+      recordId,
+      fieldId: labelField.id,
+      fieldType: toFieldType(labelField.type),
+      value: { type: 'text', value: composeTariffCodeLabel(code, country) },
+    })
+  } catch (error) {
+    logger.warn('could not re-stamp tariff_code_label', {
+      organizationId,
+      recordId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * One leg as trimmed text, or `null`. Values arrive pre-coercion on the create
+ * door (a bare string, or a `{value}` / `{optionId}` envelope, or a one-element
+ * array from a SINGLE_SELECT) and post-write on the change door (a string, or an
+ * option-id array). `unwrapStatusValue` flattens every one of those.
+ */
+function readText(raw: unknown): string | null {
+  const value = unwrapStatusValue(raw)
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -97,6 +97,8 @@ import {
   rejectIfSystemTag,
 } from './pre/tag-system-guard'
 import { dropUnauthorizedTemplateKey, rejectDeleteIfTemplateTag } from './pre/tag-template-guard'
+import { guardTariffCodeDelete } from './pre/tariff-code-delete-guard'
+import { restampTariffCodeLabel, stampTariffCodeLabel } from './pre/tariff-code-label'
 import { guardTariffCodeUniqueness } from './pre/tariff-code-uniqueness-guard'
 import { guardVendorBillDelete } from './pre/vendor-bill-delete-guard'
 import { guardWorkOrderDelete } from './pre/work-order-delete-guard'
@@ -477,7 +479,11 @@ export function registerAllHooks(): void {
   // `(code, country)` is a natural key and `naturalKeyPosition` enforces nothing
   // on create. This must be a PRE-CREATE hook, not a field pre-hook - see the
   // guard's header for the record it produced when it was the latter.
-  registerEntityPreCreateHooks('tariff-codes', [guardTariffCodeUniqueness])
+  // ORDER MATTERS: refuse the duplicate first, then stamp the derived label into
+  // the same value bag the create writes (task 30 §8). Edits to either leg
+  // re-stamp it through the field-change door below.
+  registerEntityPreCreateHooks('tariff-codes', [guardTariffCodeUniqueness, stampTariffCodeLabel])
+  registerEntityFieldChangeHooks('tariff-codes', [restampTariffCodeLabel])
 
   registerFieldPreHooks('tags', 'is_system_tag', [dropUnauthorizedSystemFlag])
   registerFieldPreHooks('tags', 'title', [rejectIfSystemTag])
@@ -529,6 +535,12 @@ export function registerAllHooks(): void {
   registerEntityPreDeleteHooks('builds', [guardBuildDelete])
   registerEntityPreDeleteHooks('purchase-orders', [guardPurchaseOrderDelete])
   registerEntityPreDeleteHooks('vendor-bills', [guardVendorBillDelete])
+
+  // The tariff registry (plans/money/tasks/30-tariff-offer-surfaces.md §9.1). Visible, so it
+  // has the same ordinary row delete `parts` had; refuses while any supplier offer is
+  // classified under the code (duty would silently drop to zero on every one of them) and
+  // cascades the code's rate rows through the handler so `mfg-tariff-rates-deleted` fires.
+  registerEntityPreDeleteHooks('tariff-codes', [guardTariffCodeDelete])
 
   // Billing projections after deletes (plan 24 §4.6) — deletes fire no field-change hooks, so
   // these are the explicit post-cleanup projector calls for every delete path (generic

--- a/packages/lib/src/field-hooks/system-entity-rules.test.ts
+++ b/packages/lib/src/field-hooks/system-entity-rules.test.ts
@@ -57,6 +57,10 @@ describe('registerEntitySystemRules — declarations', () => {
         'stock-movements:created',
         'stock-movements:deleted',
         'companies:created',
+        // The tariff schedule (29 §7): a rate row appearing or disappearing
+        // reprices every offer behind its code.
+        'tariff-rates:created',
+        'tariff-rates:deleted',
       ])
     )
     // No lifecycle rule declares a fieldRef.

--- a/packages/lib/src/field-hooks/system-entity-rules.ts
+++ b/packages/lib/src/field-hooks/system-entity-rules.ts
@@ -29,6 +29,8 @@ const RECALC_PART_QOH = 'recalculatePartQoH'
 const ENRICH_COMPANY_ON_CREATE = 'enrichCompanyOnCreate'
 const RECALC_PO_LINE_RECEIVED = 'recalculatePurchaseOrderLineReceived'
 const RECALC_PO_LINE_BILLED = 'recalculatePurchaseOrderLineBilled'
+/** Lifecycle twin of the field handler in `system-record-rules.ts`; same key on purpose. */
+const RECALC_PART_COST_TARIFF_RATE = 'recalculatePartCostFromTariffRate'
 
 /**
  * Fan a batch native event out to a single-record `EntityTriggerHandler`, reconstructing the
@@ -140,6 +142,22 @@ export function registerEntitySystemRules(): void {
     await fanOutEntityHandler(event, 'vendor-bill-lines', recalculatePurchaseOrderLineBilled)
   })
 
+  // The tariff schedule (29 §7) — BATCH. A rate row appearing or disappearing
+  // reprices every offer behind its code. The captured create/delete values
+  // carry the code, so the common case resolves without a DB read.
+  registerNativeRuleHandler(RECALC_PART_COST_TARIFF_RATE, async (event) => {
+    const { recalculatePartCostForTariffRates } = await import('./post/tariff-rate-triggers')
+    const values: Record<string, Record<string, unknown> | undefined> = {}
+    for (const rid of event.recordIds) {
+      values[parseRecordId(rid).entityInstanceId] = event.eventDataByRecordId?.[rid]
+    }
+    await recalculatePartCostForTariffRates({
+      organizationId: event.organizationId,
+      rateInstanceIds: event.recordIds.map((rid) => parseRecordId(rid).entityInstanceId),
+      values,
+    })
+  })
+
   // Company enrichment — created only, per-record (HTTP fetch).
   registerNativeRuleHandler(ENRICH_COMPANY_ON_CREATE, async (event) => {
     const { enrichCompanyOnCreate } = await import('./post/company-triggers')
@@ -167,6 +185,20 @@ const ENTITY_SYSTEM_RULES: SystemRuleDeclaration[] = [
     defSlug: 'vendor-parts',
     on: 'deleted',
     actions: [{ type: 'native', handler: ENTITY_COST_RECALC_VENDOR }],
+  },
+  {
+    key: 'mfg-tariff-rates-created',
+    name: 'Recalculate part cost on tariff rate create',
+    defSlug: 'tariff-rates',
+    on: 'created',
+    actions: [{ type: 'native', handler: RECALC_PART_COST_TARIFF_RATE }],
+  },
+  {
+    key: 'mfg-tariff-rates-deleted',
+    name: 'Recalculate part cost on tariff rate delete',
+    defSlug: 'tariff-rates',
+    on: 'deleted',
+    actions: [{ type: 'native', handler: RECALC_PART_COST_TARIFF_RATE }],
   },
   {
     key: 'mfg-subparts-created',

--- a/packages/lib/src/field-hooks/system-record-rules.ts
+++ b/packages/lib/src/field-hooks/system-record-rules.ts
@@ -11,6 +11,7 @@
 // realtime, field-value-mutations) are lazy-imported inside the wrappers so loading this
 // module never drags those in.
 
+import { parseRecordId } from '@auxx/types/resource'
 import { registerNativeRuleHandler } from '../record-rules/actions'
 import type { SystemRuleDeclaration } from '../record-rules/system-rules'
 import { declareSystemRules } from '../record-rules/system-rules'
@@ -27,6 +28,12 @@ const RECALC_PART_COST_VENDOR = 'recalculatePartCostFromVendorPart'
 const RECALC_PART_COST_SUBPART = 'recalculatePartCostFromSubpart'
 const CLEAR_OTHER_PREFERRED = 'clearOtherPreferred'
 const RECALC_STOCK_STATUS = 'recalculateStockStatus'
+/**
+ * A `tariff_rate` write is two joins away from a part (rate -> code -> every
+ * offer on that code -> its part), which is why it is its own handler rather
+ * than a third branch in `recalculatePartCost` (29 §7).
+ */
+const RECALC_PART_COST_TARIFF_RATE = 'recalculatePartCostFromTariffRate'
 
 /** Adapt a native batch event to the legacy `FieldTriggerEvent` shape. */
 function asFieldTriggerEvent(
@@ -69,16 +76,37 @@ export function registerFieldSystemRules(): void {
     const { recalculateStockStatus } = await import('./post/inventory-triggers')
     await recalculateStockStatus(asFieldTriggerEvent(event, 'part_reorder_point'))
   })
+  registerNativeRuleHandler(RECALC_PART_COST_TARIFF_RATE, async (event) => {
+    const { recalculatePartCostForTariffRates } = await import('./post/tariff-rate-triggers')
+    await recalculatePartCostForTariffRates({
+      organizationId: event.organizationId,
+      rateInstanceIds: event.recordIds.map((id) => parseRecordId(id).entityInstanceId),
+    })
+  })
 
   declareSystemRules(FIELD_SYSTEM_RULES)
 }
 
 /**
- * The 7 field triggers, one declaration per systemAttribute. All fire `on: 'changed'` — the
+ * The field triggers, one declaration per systemAttribute. All fire `on: 'changed'` — the
  * transition the legacy registry implied (any field-value change). `vendor_part_is_preferred`
  * keeps its ORDERED pair `[recalculatePartCost, clearOtherPreferred]`.
  */
 const FIELD_SYSTEM_RULES: SystemRuleDeclaration[] = [
+  // The schedule (29 §7). Editing a rate row's number, day or authority moves
+  // `part_cost` on every offer behind its code. Create and delete are lifecycle
+  // rules in `system-entity-rules.ts`; `tariffCode` is `updatable: false`, so a
+  // row can never be re-parented and needs no rule.
+  ...(['tariff_rate_rate', 'tariff_rate_effective_from', 'tariff_rate_authority'] as const).map(
+    (systemAttribute) => ({
+      key: `mfg-${systemAttribute.replace(/_/g, '-')}`,
+      name: `Recalculate part cost on ${systemAttribute} change`,
+      defSlug: 'tariff-rates',
+      fieldRef: { systemAttribute },
+      on: 'changed' as const,
+      actions: [{ type: 'native' as const, handler: RECALC_PART_COST_TARIFF_RATE }],
+    })
+  ),
   {
     key: 'mfg-vendor-part-unit-price',
     name: 'Recalculate part cost on vendor unit price change',
@@ -100,6 +128,14 @@ const FIELD_SYSTEM_RULES: SystemRuleDeclaration[] = [
     name: 'Recalculate part cost on vendor tariff rate change',
     defSlug: 'vendor-parts',
     fieldRef: { systemAttribute: 'vendor_part_tariff_rate' },
+    on: 'changed',
+    actions: [{ type: 'native', handler: RECALC_PART_COST_VENDOR }],
+  },
+  {
+    key: 'mfg-vendor-part-tariff-code',
+    name: 'Recalculate part cost on vendor tariff code change',
+    defSlug: 'vendor-parts',
+    fieldRef: { systemAttribute: 'vendor_part_tariff_code' },
     on: 'changed',
     actions: [{ type: 'native', handler: RECALC_PART_COST_VENDOR }],
   },

--- a/packages/lib/src/receiving/client.ts
+++ b/packages/lib/src/receiving/client.ts
@@ -41,8 +41,14 @@ export interface ReceiptCostInputs {
   unitPrice: number | null
   /** Minor units, per unit. */
   shippingCost?: number | null
-  /** A PERCENTAGE, not minor units: `4.3` means 4.3%. */
+  /** A PERCENTAGE, not minor units: `4.3` means 4.3%. Already RESOLVED - override or schedule. */
   tariffRate?: number | null
+  /**
+   * Where {@link tariffRate} came from, for the summary line. Display only;
+   * the arithmetic never reads it. Absent on the server path, which has no
+   * summary to print.
+   */
+  tariffSource?: 'override' | 'schedule' | null
   /** Minor units, per unit. */
   otherCost?: number | null
 }
@@ -68,6 +74,8 @@ export interface ReceiptCostParts {
   tariff: number
   /** The percentage that produced {@link tariff}, carried for display. */
   tariffRate: number
+  /** Where the rate came from, when the caller knows. See {@link ReceiptCostInputs.tariffSource}. */
+  tariffSource?: 'override' | 'schedule' | null
   /** Anything else the supplier row capitalises, minor units. */
   other: number
   /** `base + freight + tariff + other`, exact by construction. */
@@ -133,6 +141,9 @@ export function computeReceiptLandedBreakdown(inputs: ReceiptCostInputs): Receip
     freight: breakdown.shipping,
     tariff: breakdown.tariff,
     tariffRate: breakdown.tariffRate,
+    // Only when the caller said: the server path has no source to report and
+    // its consumers compare these parts by exact shape.
+    ...(inputs.tariffSource !== undefined ? { tariffSource: inputs.tariffSource } : {}),
     other: breakdown.other,
     landed: breakdown.landed,
   }
@@ -158,7 +169,10 @@ export function formatLandedCostSummary(
   const terms: string[] = []
   if (parts.freight !== 0) terms.push(`${format(parts.freight)} freight`)
   if (parts.tariff !== 0) {
-    terms.push(`${format(parts.tariff)} tariff (${formatTariffRate(parts.tariffRate)})`)
+    // `(47%, schedule)` / `(12%, override)` - the source rides along so a
+    // person can tell a hand-keyed rate from a resolved one (task 30 §5).
+    const source = parts.tariffSource ? `, ${parts.tariffSource}` : ''
+    terms.push(`${format(parts.tariff)} tariff (${formatTariffRate(parts.tariffRate)}${source})`)
   }
   if (parts.other !== 0) terms.push(`${format(parts.other)} other`)
   if (terms.length === 0) return format(parts.landed)

--- a/packages/lib/src/receiving/receipt-queries.ts
+++ b/packages/lib/src/receiving/receipt-queries.ts
@@ -18,6 +18,8 @@ import { type Database, schema } from '@auxx/database'
 import { and, desc, eq, gte, inArray, isNull, lte, type SQL, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
 import type { Result } from 'neverthrow'
+import { loadTariffSchedule, readBookTimeZone } from '../bom/tariff-schedule'
+import { resolveOfferTariff } from '../bom/vendor-cost'
 import { getCachedEntityDefId, getOrgCache } from '../cache'
 import type { ReceiptCostInputs } from './client'
 import { guard } from './guard'
@@ -317,11 +319,21 @@ export async function getLastReceiptCost(
  * Exported because the Receive form prefills from exactly this — the form and
  * the write path must derive the landed cost from the same four numbers or the
  * price shown is not the price frozen.
+ *
+ * **The tariff rate is RESOLVED, not read** (29 §3.1, 30 §5). A set
+ * `vendor_part_tariff_rate` is an override and wins outright; otherwise the
+ * offer's `tariff_code` schedule is resolved at `atDate` in the org's book
+ * timezone. `atDate` is the receipt's `occurredAt` - a receipt back-dated to
+ * before a rate change is valued at the earlier rate, which is the whole point
+ * of a dated schedule. ⚠️ This serves the AD-HOC receive door only;
+ * `receivePurchaseOrder` passes `unitCost` explicitly and never reaches here
+ * (29 §5.1).
  */
 export async function readVendorPartCostInputs(
   db: Database,
   organizationId: string,
-  vendorPartInstanceId: string
+  vendorPartInstanceId: string,
+  atDate: Date = new Date()
 ): Promise<Result<ReceiptCostInputs | null, Error>> {
   return guard(
     async () => {
@@ -348,6 +360,7 @@ export async function readVendorPartCostInputs(
           'vendor_part_unit_price',
           'vendor_part_shipping_cost',
           'vendor_part_tariff_rate',
+          'vendor_part_tariff_code',
           'vendor_part_other_cost',
         ])
 
@@ -358,16 +371,65 @@ export async function readVendorPartCostInputs(
         fields.vendor_part_other_cost?.id,
       ])
 
+      const override = pick(numbers, fields.vendor_part_tariff_rate?.id)
+      const tariffRate =
+        override ??
+        (await resolveScheduledRate(
+          db,
+          organizationId,
+          vendorPartInstanceId,
+          fields.vendor_part_tariff_code?.id,
+          atDate
+        ))
+
       return {
         unitPrice: pick(numbers, fields.vendor_part_unit_price?.id),
         shippingCost: pick(numbers, fields.vendor_part_shipping_cost?.id),
-        tariffRate: pick(numbers, fields.vendor_part_tariff_rate?.id),
+        tariffRate,
         otherCost: pick(numbers, fields.vendor_part_other_cost?.id),
       }
     },
     'Failed to read vendor part cost inputs',
     { organizationId, vendorPartInstanceId }
   )
+}
+
+/**
+ * The schedule half of the precedence rule for one offer: its `tariff_code`
+ * pointer, that code's rows, and `resolveOfferTariff` at `atDate`. `null` when
+ * the offer is unclassified, so the caller's `?? 0` reads the same as today.
+ *
+ * The pointer is read separately from the numbers because it lives in
+ * `relatedEntityId`, not `valueNumber`. The schedule and the timezone are only
+ * fetched once a pointer is actually found.
+ */
+async function resolveScheduledRate(
+  db: Database,
+  organizationId: string,
+  vendorPartInstanceId: string,
+  tariffCodeFieldId: string | undefined,
+  atDate: Date
+): Promise<number | null> {
+  if (!tariffCodeFieldId) return null
+  const [pointer] = await db
+    .select({ relatedEntityId: schema.FieldValue.relatedEntityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, vendorPartInstanceId),
+        eq(schema.FieldValue.fieldId, tariffCodeFieldId)
+      )
+    )
+    .limit(1)
+  const tariffCodeId = pointer?.relatedEntityId ?? null
+  if (!tariffCodeId) return null
+
+  const [schedule, timeZone] = await Promise.all([
+    loadTariffSchedule(db, organizationId, [tariffCodeId]),
+    readBookTimeZone(organizationId),
+  ])
+  return resolveOfferTariff({ tariffRate: null, tariffCodeId }, schedule, atDate, timeZone).rate
 }
 
 /**

--- a/packages/lib/src/receiving/receive-stock.ts
+++ b/packages/lib/src/receiving/receive-stock.ts
@@ -178,7 +178,16 @@ async function resolveReceiptPrice(
   // already known it is not read at all.
   let terms: ReceiptCostInputs | null = null
   if ((landed == null || vendorUnitPrice == null) && input.vendorPartId) {
-    terms = await unwrap(readVendorPartCostInputs(db, organizationId, input.vendorPartId))
+    // Resolved at the receipt's accounting date, not at now: a back-dated receipt
+    // takes the duty rate that was in force on the day (29 §5.1, 30 §5).
+    terms = await unwrap(
+      readVendorPartCostInputs(
+        db,
+        organizationId,
+        input.vendorPartId,
+        input.occurredAt ?? new Date()
+      )
+    )
     if (!terms) {
       throw new NotFoundError(`Vendor part ${input.vendorPartId} not found`)
     }

--- a/packages/lib/src/resources/registry/resources/tariff-code-fields.ts
+++ b/packages/lib/src/resources/registry/resources/tariff-code-fields.ts
@@ -125,6 +125,39 @@ export const TARIFF_CODE_FIELDS: Record<string, ResourceField> = {
       'Chinese-made goods is origin CN',
   },
 
+  // 🛑 DERIVED - `{code} {country}` - and the record's PRIMARY DISPLAY FIELD.
+  // Stamped by `field-hooks/pre/tariff-code-label.ts` on create and whenever
+  // either leg changes; never creatable or updatable by a person. It exists
+  // because a relation column on import matches ONE field and this record's
+  // identity is two: matched on `code`, `8481.80.9005` resolves to the CN and
+  // DE records interchangeably and the import succeeds pointing half the
+  // Chinese offers at the German classification (30 §8). This does not reopen
+  // §1.1's "compose, never store": nothing parses it, and `code` / `country`
+  // remain the only inputs.
+  label: {
+    id: toFieldId('label'),
+    key: 'label',
+    label: 'Tariff Code',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'tariff_code_label',
+    systemSortOrder: 'a2b',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'The code and country of origin as one label, e.g. 8481.80.9005 CN. Derived from the two ' +
+      'fields above; this is what a spreadsheet column names when it points at a tariff code',
+  },
+
   description: {
     id: toFieldId('description'),
     key: 'description',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -80,6 +80,7 @@ import { migration116PerPartAbsorption } from './migrations/116-per-part-absorpt
 import { migration117PartKindFromBom } from './migrations/117-part-kind-from-bom'
 import { migration118MovementTypeRelabel } from './migrations/118-movement-type-relabel'
 import { migration119TariffSchedule } from './migrations/119-tariff-schedule'
+import { migration120TariffCodeLabel } from './migrations/120-tariff-code-label'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -220,6 +221,9 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // MUST sort after 001 - it hangs `vendor_part.tariffCode` off the def 001
   // creates, and skips an org that has not reached 001 yet.
   migration119TariffSchedule,
+  // MUST sort after 119 - it adds a derived field to the def 119 creates and
+  // repoints that def's display field at it.
+  migration120TariffCodeLabel,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/120-tariff-code-label.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/120-tariff-code-label.ts
@@ -1,0 +1,227 @@
+// packages/lib/src/seed/entity-migrations/migrations/120-tariff-code-label.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { generateKeyBetween } from '@auxx/utils/fractional-indexing'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { composeTariffCodeLabel } from '../../../bom/vendor-cost'
+import { getOrgCache } from '../../../cache'
+import { notifyEntityDefChanged } from '../../../entity-definitions/notify'
+import { DisplayFieldService } from '../../../field-values/display-field-service'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { TARIFF_CODE_FIELDS } from '../../../resources/registry/resources/tariff-code-fields'
+import { ensureCustomFields, fieldKey, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:120')
+
+const TARIFF_CODE_ENTITY_TYPE = 'tariff_code'
+const TARIFF_RATE_ENTITY_TYPE = 'tariff_rate'
+
+const CODE_ATTR = 'tariff_code_code'
+const COUNTRY_ATTR = 'tariff_code_country'
+const LABEL_ATTR = 'tariff_code_label'
+const DESCRIPTION_ATTR = 'tariff_code_description'
+
+/**
+ * The one field this migration adds, by REGISTRY KEY (migration 119's rule):
+ * a later field on `tariff_code` cannot silently join this payload.
+ */
+const NEW_FIELD_KEYS = ['label'] as const
+
+/**
+ * Migration 120: the derived `tariff_code_label`
+ * (plans/money/tasks/30-tariff-offer-surfaces.md §8).
+ *
+ * ## Why
+ *
+ * A relation column on import matches ONE field, and `tariff_code`'s identity is
+ * TWO. With `code` as the display field the supplier-price importer resolved
+ * `8481.80.9005` to the CN and DE records interchangeably and reported success,
+ * pointing half the Chinese offers at the German classification. The rate
+ * importer (29 §12 e) had no way to name its code at all.
+ *
+ * `label` is `{code} {country}`, stamped by `field-hooks/pre/tariff-code-label.ts`
+ * on create and on every edit to either leg, `creatable: false` /
+ * `updatable: false`, and becomes the PRIMARY DISPLAY FIELD - so `displayName`
+ * reads `8481.80.9005 CN` everywhere and both importers match on it exactly.
+ *
+ * ## Three steps, each idempotent
+ *
+ * 1. `ensureCustomFields` for `label` (insert-only).
+ * 2. Backfill: one `FieldValue` per existing code that has none, composed from
+ *    its `code` (valueText) and `country` (optionId). Rows that already carry a
+ *    label are left alone - the hook owns them from here.
+ * 3. Repoint display: primary `code` -> `label`, secondary `country` ->
+ *    `description`, then recompute every code's `displayName` AND every rate's,
+ *    because a rate's display is projected from its code. Skipped when an org
+ *    has customised the pointer, following 115.
+ *
+ * MUST sort after 119, which creates the def and both legs.
+ */
+export const migration120TariffCodeLabel: EntityMigration = {
+  id: '120-tariff-code-label',
+  description:
+    'Add the derived tariff_code label ({code} {country}), backfill it, and make it the display field',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const codeDef = existing.entityDefs.get(TARIFF_CODE_ENTITY_TYPE)
+    if (!codeDef) return { ...state, alreadyUpToDate: true }
+
+    const codeField = existing.fields.get(fieldKey(codeDef.id, CODE_ATTR))
+    const countryField = existing.fields.get(fieldKey(codeDef.id, COUNTRY_ATTR))
+    const descriptionField = existing.fields.get(fieldKey(codeDef.id, DESCRIPTION_ATTR))
+    if (!codeField || !countryField || !descriptionField) {
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    // ── Step 1: the field ──────────────────────────────────────────────
+    const newFields: Record<string, ResourceField> = {}
+    for (const key of NEW_FIELD_KEYS) {
+      const field = TARIFF_CODE_FIELDS[key]
+      if (!field) {
+        throw new Error(`tariff_code registry is missing the key "${key}" (migration 120)`)
+      }
+      newFields[key] = field
+    }
+    const created = await ensureCustomFields(
+      db,
+      organizationId,
+      TARIFF_CODE_ENTITY_TYPE,
+      codeDef.id,
+      newFields,
+      existing,
+      state
+    )
+    const labelFieldId =
+      created.get(`${TARIFF_CODE_ENTITY_TYPE}:label`)?.id ??
+      existing.fields.get(fieldKey(codeDef.id, LABEL_ATTR))?.id
+    if (!labelFieldId) throw new Error('migration 120 could not resolve tariff_code_label')
+
+    // ── Step 2: backfill ───────────────────────────────────────────────
+    const backfilled = await backfillLabels(db, organizationId, {
+      entityDefinitionId: codeDef.id,
+      codeFieldId: codeField.id,
+      countryFieldId: countryField.id,
+      labelFieldId,
+    })
+
+    // ── Step 3: display pointer ────────────────────────────────────────
+    const [pointers] = await db
+      .select({
+        primaryDisplayFieldId: schema.EntityDefinition.primaryDisplayFieldId,
+        secondaryDisplayFieldId: schema.EntityDefinition.secondaryDisplayFieldId,
+      })
+      .from(schema.EntityDefinition)
+      .where(eq(schema.EntityDefinition.id, codeDef.id))
+
+    let repointed = false
+    if (pointers?.primaryDisplayFieldId === codeField.id) {
+      await db
+        .update(schema.EntityDefinition)
+        .set({
+          primaryDisplayFieldId: labelFieldId,
+          secondaryDisplayFieldId: descriptionField.id,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.EntityDefinition.id, codeDef.id))
+      repointed = true
+    } else if (pointers?.primaryDisplayFieldId !== labelFieldId) {
+      logger.debug('Migration 120 left a customised display pointer alone', {
+        organizationId,
+        primaryDisplayFieldId: pointers?.primaryDisplayFieldId ?? null,
+      })
+    }
+
+    const changed = state.fieldsCreated > 0 || backfilled > 0 || repointed
+    if (!changed) return { ...state, alreadyUpToDate: true }
+
+    // New field and pointer are invisible to every read path until the per-org
+    // caches are dropped - and `recalculateDisplayFields` READS the pointer
+    // through that cache, so the bust must come first (115's load-bearing
+    // ordering). `notifyEntityDefChanged` also publishes `resourceDefChanged`.
+    await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+    await notifyEntityDefChanged(organizationId, codeDef.id, 'updated')
+
+    const display = new DisplayFieldService(organizationId, db)
+    await display.recalculateDisplayFields(codeDef.id, ['primary', 'secondary'])
+    const rateDef = existing.entityDefs.get(TARIFF_RATE_ENTITY_TYPE)
+    if (rateDef) await display.recalculateDisplayFields(rateDef.id, ['primary'])
+
+    logger.info('Migration 120 applied', { organizationId, ...state, backfilled, repointed })
+    return { ...state, alreadyUpToDate: false }
+  },
+}
+
+/**
+ * One `tariff_code_label` value per live code that has none. Returns how many
+ * were written. Codes with no `code` value (impossible under the registry, but
+ * a half-written row from before the pre-create guard could exist) are skipped
+ * rather than given an empty label.
+ */
+async function backfillLabels(
+  db: Database,
+  organizationId: string,
+  ids: {
+    entityDefinitionId: string
+    codeFieldId: string
+    countryFieldId: string
+    labelFieldId: string
+  }
+): Promise<number> {
+  const rows = await db
+    .select({
+      instanceId: schema.EntityInstance.id,
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+      optionId: schema.FieldValue.optionId,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      schema.FieldValue,
+      and(
+        eq(schema.FieldValue.entityId, schema.EntityInstance.id),
+        eq(schema.FieldValue.organizationId, schema.EntityInstance.organizationId)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, ids.entityDefinitionId),
+        isNull(schema.EntityInstance.archivedAt),
+        inArray(schema.FieldValue.fieldId, [ids.codeFieldId, ids.countryFieldId, ids.labelFieldId])
+      )
+    )
+
+  const byInstance = new Map<
+    string,
+    { code: string | null; country: string | null; hasLabel: boolean }
+  >()
+  for (const row of rows) {
+    const entry = byInstance.get(row.instanceId) ?? { code: null, country: null, hasLabel: false }
+    if (row.fieldId === ids.codeFieldId) entry.code = row.valueText
+    else if (row.fieldId === ids.countryFieldId) entry.country = row.optionId
+    else if (row.fieldId === ids.labelFieldId) entry.hasLabel = true
+    byInstance.set(row.instanceId, entry)
+  }
+
+  const now = new Date()
+  const inserts = [...byInstance.entries()]
+    .filter(([, entry]) => !entry.hasLabel && !!entry.code)
+    .map(([instanceId, entry]) => ({
+      organizationId,
+      entityId: instanceId,
+      entityDefinitionId: ids.entityDefinitionId,
+      fieldId: ids.labelFieldId,
+      sortKey: generateKeyBetween(null, null),
+      valueText: composeTariffCodeLabel(entry.code as string, entry.country),
+      updatedAt: now,
+    }))
+  if (inserts.length === 0) return 0
+
+  await db.insert(schema.FieldValue).values(inserts)
+  return inserts.length
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -503,13 +503,14 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
     primaryDisplayField: 'amount',
     secondaryDisplayField: undefined,
   },
-  // 🛑 The primary is the CODE and the secondary the COUNTRY, because the label
-  // `8481.80.9005 CN` is COMPOSED and never stored - see the field file. Both
-  // legs are `required: true` / `nullable: false`, so neither can render the
-  // record nameless the way an optional primary would.
+  // 🛑 The primary is the DERIVED `label` - `8481.80.9005 CN` - stamped by a
+  // hook from the two legs on every write (task 30 §8), so the display name and
+  // the importers' relation match read the same string that names the whole
+  // `(code, country)` identity. It was `code` until migration 120, which
+  // repoints existing orgs; this constant reaches fresh orgs only.
   tariff_code: {
-    primaryDisplayField: 'code',
-    secondaryDisplayField: 'country',
+    primaryDisplayField: 'label',
+    secondaryDisplayField: 'description',
   },
   // The `authority` is the natural thing to read first, but it is NULLABLE and
   // `computeDisplayValue` has no fallback - an absent value writes

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -679,6 +679,13 @@ export const SYSTEM_ATTRIBUTES = [
   // space.
   'tariff_code_code',
   'tariff_code_country', // ISO 3166-1 alpha-2, a seeded SINGLE_SELECT
+  // DERIVED, never typed: `{code} {country}`, stamped by a hook on every write
+  // to either leg. It exists so the display name and the importers' relation
+  // match have ONE text field that names the whole `(code, country)` identity -
+  // a relation column matches on one field, and matching on `code` alone
+  // resolves `8481.80.9005` to CN and DE interchangeably (task 30 §8). Nothing
+  // parses it back apart; the two legs stay the source of truth.
+  'tariff_code_label',
   'tariff_code_description',
   'tariff_code_rates', // inverse of tariff_rate_tariff_code
   'tariff_code_vendor_parts', // inverse of vendor_part_tariff_code


### PR DESCRIPTION
## Summary

Part 2 of the tariff schedule: `plans/money/tasks/30-tariff-offer-surfaces.md`. #2011 built the registry and its page; nothing consumed it, and `vendor_part` is `isVisible: false`, so every surface that shows a supplier offer is hand-built and had to be touched by hand. This PR makes setting a code on an offer change a cost, and gives every surface the same answer through one function.

### Phase A, parity (lib)

- `resolveOfferTariff` in `bom/vendor-cost.ts`: 29 §3.1 as one function. Override wins, else the schedule at a date, else zero, with `unclassified` / `pending` / `none` kept apart. Exported client-safe.
- `bom/tariff-schedule.ts`: server read of the rate rows grouped by code, plus `readBookTimeZone`. No org-cache key, per 29 §7.
- `cost-calculator.ts` resolves each classified offer at now in the book timezone, only when some offer has a code and no override. An unclassified org pays no extra query.
- `readVendorPartCostInputs` takes `atDate`; the ad-hoc receive door passes `occurredAt`. `receivePurchaseOrder` is untouched, per 29 §5.1.
- Six new record rules: `vendor_part_tariff_code` changed; `tariff_rate` rate / effective_from / authority changed; `tariff-rates` created and deleted. All route to `recalculatePartCostFromTariffRate`, a two-join walk (rate -> code -> offers -> parts) in its own file.
- `tariff-codes` pre-delete guard: refuses while any offer points at the code (archived included), cascades rate rows through the handler. Added to the registration test's money list.

### Phase B, the offer (web)

- `hooks/use-offer-tariffs.ts`: the one client seam. Every surface hands it offers and gets `OfferTariff` back, plus what the schedule alone says for the both-set warning.
- Supplier form: three rows where there was one. Code picker, the rate relabelled as an override with 29 §3.1's three reasons, and a Duty readout with five readings. Empty-state link to the Tariffs page when the org has no codes.
- Suppliers tab resolves before `selectWinningVendor`, so the Landed column and the winner marker agree with `part_cost`. The tooltip names the source and lists the components.
- Receive form resolves at the receipt's date and prints `(47%, schedule)` / `(12%, override)`.
- Part create dialog: the inline supplier form rendered shipping, tariff and other cost and never wrote them. Fixed while adding the pointer.

### Phase C, bulk

- Classification tab: every priced offer, classified or not, with Unclassified / Override / country chips and an editor pane with the same three rows and a Clear override button. `ResponsiveTabs` + `useQueryState('s')` land with it.
- Derived `tariff_code_label` (`{code} {country}`): a relation column on import matches ONE field and this identity is two, so matching on `code` resolved `8481.80.9005` to CN and DE interchangeably. Stamped by a pre-create hook into the create's own value bag and re-stamped on either leg by a field-change hook; now the primary display field. Migration 120 adds, backfills and repoints; it has run on dev for 28 orgs.

### Verification

- lib ratchet clean (29 baseline), web typecheck exit 0, biome clean.
- lib suites for `bom`, `field-hooks`, `receiving`, `seed/entity-migrations`, `import`: 1233 pass, 1 pre-existing fail (`108-purchasing.test.ts`, named in 29 §13, untouched here).
- Driven in the browser on dev: picking a code on the Classification tab wrote the pointer, the Duty row showed the resolved breakdown, and the log history shows `Processed field trigger: vendor_part_tariff_code` then `Recalculating part costs from field change`.

### Found while driving

Rendering 202 offers mounted 404 `RecordBadge`s, whose hydration the relationship store batched into ONE `record.getByIds` GET; the dev server answered 431 Request Header Fields Too Large for every batch. The list is paged at 50 rows. The store-level cap on ids per request is owned by nobody and is recorded in 30 §14.

### Deviations from the brief

Inline create on the code picker cannot be disabled by prop, so it stays. The picker cannot be pre-searched, so the part's HS code renders as a hint under it. Full list in 30 §14.

https://claude.ai/code/session_01PkYemqvNomz3tzpqjwoPqH
