### PR TITLE
feat(parts): apply rate changes, so a future-dated tariff row reaches part cost

### DIFF
--- a/apps/web/src/components/manufacturing/ui/settings/tariffs-settings-page.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariffs-settings-page.tsx
@@ -26,15 +26,17 @@
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeValue } from '@auxx/database/types'
 import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { Button } from '@auxx/ui/components/button'
 import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { toastError } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils'
-import { Globe, Package } from 'lucide-react'
+import { Globe, Package, RefreshCw } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import { MasterDetailSplit } from '~/components/global/master-detail-split'
 import SettingsPage from '~/components/global/settings-page'
+import { useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import {
   type CreatedRecordInstance,
@@ -113,6 +115,37 @@ export function TariffsSettingsPage() {
   // to append a rate - and an affordance that is refused on click is worse than
   // one that is absent.
   const canEditRates = rateDefId ? canEditEntity(rateDefId) : false
+
+  // ── Apply rate changes (29 §8, §12 a) ───────────────────────────────────
+  //
+  // A future-dated rate row does not apply itself: nothing is written at
+  // midnight and the full recalc has no scheduled caller, so `part_cost` keeps
+  // the old rate until some unrelated vendor-price edit sweeps the part. The
+  // decision was an explicit action rather than a daily sweep, because nothing
+  // else in this subsystem revalues without a person.
+  //
+  // 🛑 Gated on PART edit, not on the code or rate defs, because `part` rows
+  // are what the mutation writes and what `purchasing.applyTariffSchedule`
+  // asserts. Same rule as the two gates above: a button the server refuses is
+  // worse than one that is absent.
+  const partDefId = useResourceProperty('part', 'id')
+  const canApplyRates = !!partDefId && canEditEntity(partDefId)
+  const applyRates = api.purchasing.applyTariffSchedule.useMutation()
+  const [lastApply, setLastApply] = useState<{ affectedParts: number; changed: number } | null>(
+    null
+  )
+
+  const handleApplyRates = useCallback(async () => {
+    try {
+      const result = await applyRates.mutateAsync()
+      setLastApply({ affectedParts: result.affectedParts, changed: result.changedPartIds.length })
+    } catch (error) {
+      toastError({
+        title: 'Error applying rate changes',
+        description: error instanceof Error ? error.message : 'Could not reprice the parts.',
+      })
+    }
+  }, [applyRates])
 
   const countryOptions = useTariffCountryFieldOptions(codeDefId)
   const countryLabels = useTariffCountryLabels(codeDefId)
@@ -508,11 +541,40 @@ export function TariffsSettingsPage() {
     />
   )
 
+  // The result stays on the page rather than in a toast: it is a number the
+  // person will read against the list below it, and "0 of 40 changed" is as
+  // much of an answer as "12 of 40" - it says the schedule was already applied.
+  const applyButton = canApplyRates ? (
+    <div className='flex items-center gap-3'>
+      {lastApply && !applyRates.isPending && (
+        <span className='text-xs text-muted-foreground'>
+          {lastApply.affectedParts === 0
+            ? 'No classified offers to reprice'
+            : `${lastApply.changed} of ${lastApply.affectedParts} ${
+                lastApply.affectedParts === 1 ? 'part' : 'parts'
+              } changed`}
+        </span>
+      )}
+      <Button
+        variant='outline'
+        size='sm'
+        onClick={() => void handleApplyRates()}
+        disabled={isLoading || codes.length === 0}
+        loading={applyRates.isPending}
+        loadingText='Applying...'
+        title='Reprice every part with a classified supplier offer at the rates in force today. Standard costs and movements are not touched.'>
+        <RefreshCw />
+        Apply rate changes
+      </Button>
+    </div>
+  ) : undefined
+
   return (
     <SettingsPage
       title='Tariffs'
       description={PAGE_DESCRIPTION}
       breadcrumbs={BREADCRUMBS}
+      button={applyButton}
       subHeader={
         <ResponsiveTabs
           value={activeTab}

--- a/apps/web/src/server/api/routers/purchasing.ts
+++ b/apps/web/src/server/api/routers/purchasing.ts
@@ -1,5 +1,6 @@
 // apps/web/src/server/api/routers/purchasing.ts
 
+import { applyTariffSchedule } from '@auxx/lib/bom'
 import { getCachedEntityDefId } from '@auxx/lib/cache'
 import { NotFoundError } from '@auxx/lib/errors'
 import { markPurchaseOrderSent } from '@auxx/lib/money'
@@ -542,4 +543,28 @@ export const purchasingRouter = createTRPCRouter({
       // is `rematchBill`).
       return matchBill(input.lines, new Date(), input.tolerance)
     }),
+
+  /**
+   * Reprice every part with a classified supplier offer at today's tariff
+   * schedule (money 29 §8, §12 a).
+   *
+   * A future-dated rate row does not apply itself - nothing is written at
+   * midnight and `recalculateAllPartCosts` has no scheduled caller - so the
+   * schedule screen carries this as an explicit action, in keeping with the
+   * rest of the subsystem, where nothing revalues without a person.
+   *
+   * Asserts `part` edit because `part_cost` on `part` rows is what it writes,
+   * the same gate `builds.roll` uses. It touches no standard cost and no
+   * movement: `part_cost` is the live replacement cost the same recalc rewrites
+   * on every vendor-price change, and a stale one is the whole reason the
+   * button exists.
+   */
+  applyTariffSchedule: capabilityProcedure.mutation(async ({ ctx }) => {
+    const { organizationId } = ctx.session
+    ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'part'))
+
+    const result = await applyTariffSchedule(ctx.db, organizationId)
+    if (result.isErr()) throw result.error
+    return result.value
+  }),
 })

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -196,6 +196,12 @@
       "import": "./dist/availability/client.mjs",
       "default": "./src/availability/client.ts"
     },
+    "./bom": {
+      "types": "./src/bom/index.ts",
+      "source": "./src/bom/index.ts",
+      "import": "./dist/bom/index.mjs",
+      "default": "./src/bom/index.ts"
+    },
     "./bom/client": {
       "types": "./src/bom/client.ts",
       "source": "./src/bom/client.ts",

--- a/packages/lib/src/bom/apply-tariff-schedule.test.ts
+++ b/packages/lib/src/bom/apply-tariff-schedule.test.ts
@@ -1,0 +1,128 @@
+// packages/lib/src/bom/apply-tariff-schedule.test.ts
+// 29 §8 / §12 (a): the explicit apply walks every classified offer to its part.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  rows: [] as Array<{ offerId: string; partId: string | null }>,
+  recalculateAffectedParts: vi.fn(async (_orgId: string, _partIds: string[]) => [] as string[]),
+  defId: 'vendor_part_def' as string | null,
+  fields: {
+    vendor_part_tariff_code: { id: 'f_vp_tariff_code' },
+    vendor_part_part: { id: 'f_vp_part' },
+  } as Record<string, { id: string } | null>,
+}))
+
+vi.mock('@auxx/database', () => ({
+  schema: {
+    EntityInstance: {
+      id: 'id',
+      organizationId: 'organizationId',
+      entityDefinitionId: 'entityDefinitionId',
+      archivedAt: 'archivedAt',
+    },
+    FieldValue: {
+      entityId: 'entityId',
+      fieldId: 'fieldId',
+      organizationId: 'organizationId',
+      relatedEntityId: 'relatedEntityId',
+    },
+  },
+}))
+
+vi.mock('drizzle-orm/pg-core', () => ({
+  alias: (table: unknown) => table,
+}))
+
+vi.mock('../cache', () => ({
+  getCachedEntityDefId: async () => h.defId,
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(attrs.map((a) => [a, h.fields[a] ?? null])),
+    }),
+  }),
+}))
+
+vi.mock('./cost-calculator', () => ({
+  recalculateAffectedParts: h.recalculateAffectedParts,
+}))
+
+import { applyTariffSchedule } from './apply-tariff-schedule'
+
+const ORG = 'org_1'
+
+const db = {
+  select: () => ({
+    from: () => ({
+      innerJoin: () => ({
+        innerJoin: () => ({ where: () => Promise.resolve(h.rows) }),
+      }),
+    }),
+  }),
+} as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.rows = []
+  h.defId = 'vendor_part_def'
+  h.fields = {
+    vendor_part_tariff_code: { id: 'f_vp_tariff_code' },
+    vendor_part_part: { id: 'f_vp_part' },
+  }
+})
+
+describe('applyTariffSchedule', () => {
+  it('recalculates each classified part once and reports what moved', async () => {
+    // Two offers on the same part (dual-sourced), one on another.
+    h.rows = [
+      { offerId: 'vp_1', partId: 'part_a' },
+      { offerId: 'vp_2', partId: 'part_a' },
+      { offerId: 'vp_3', partId: 'part_b' },
+    ]
+    h.recalculateAffectedParts.mockResolvedValue(['part_a', 'part_parent'])
+
+    const result = await applyTariffSchedule(db, ORG)
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual({
+      classifiedOffers: 3,
+      affectedParts: 2,
+      changedPartIds: ['part_a', 'part_parent'],
+    })
+    expect(h.recalculateAffectedParts).toHaveBeenCalledTimes(1)
+    expect(h.recalculateAffectedParts).toHaveBeenCalledWith(ORG, ['part_a', 'part_b'])
+  })
+
+  it('writes nothing when no offer is classified', async () => {
+    const result = await applyTariffSchedule(db, ORG)
+
+    expect(result._unsafeUnwrap()).toEqual({
+      classifiedOffers: 0,
+      affectedParts: 0,
+      changedPartIds: [],
+    })
+    expect(h.recalculateAffectedParts).not.toHaveBeenCalled()
+  })
+
+  it('is the empty result, not an error, for an org without the fields yet', async () => {
+    h.fields = { vendor_part_tariff_code: null, vendor_part_part: { id: 'f_vp_part' } }
+    h.rows = [{ offerId: 'vp_1', partId: 'part_a' }]
+
+    const result = await applyTariffSchedule(db, ORG)
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().affectedParts).toBe(0)
+    expect(h.recalculateAffectedParts).not.toHaveBeenCalled()
+  })
+
+  it('is the empty result for an org without a vendor_part definition', async () => {
+    h.defId = null
+    h.rows = [{ offerId: 'vp_1', partId: 'part_a' }]
+
+    const result = await applyTariffSchedule(db, ORG)
+
+    expect(result._unsafeUnwrap().classifiedOffers).toBe(0)
+    expect(h.recalculateAffectedParts).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/bom/apply-tariff-schedule.ts
+++ b/packages/lib/src/bom/apply-tariff-schedule.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/bom/apply-tariff-schedule.ts
+
+/**
+ * The explicit "apply rate changes" action
+ * (plans/money/tasks/29-tariff-schedule.md §8, §12 a).
+ *
+ * A `tariff_rate` row with a future `effectiveFrom` changes what every offer
+ * under its code resolves to from midnight on that day, and nothing is written
+ * at midnight - so `part_cost` stays at the old rate until some unrelated
+ * vendor-price edit happens to sweep the part. `recalculateAllPartCosts` has no
+ * scheduled caller anywhere (29 §8), and the decision was NOT to give it one:
+ * nothing in this subsystem revalues without a person, so the schedule screen
+ * carries a button that does it on demand.
+ *
+ * The walk is the same one `recalculatePartCostForTariffRates` makes when a
+ * rate row is written, minus the first join - every classified offer instead
+ * of the offers under one code:
+ *
+ *     every vendor_part with a tariff_code -> its part -> recalculateAffectedParts
+ *
+ * ⚠️ Only the CLASSIFIED offers are walked, not every part in the org. An
+ * offer with no code resolves to its override or to no duty, and neither of
+ * those reads the schedule, so a rate row cannot have moved its part. The
+ * calculator re-reads the whole offer anyway; an override on a classified
+ * offer wins under 29 §3.1 and comes out unchanged.
+ *
+ * ⚠️ No first-standard write here, unlike the trigger path. A rate cannot give
+ * an unpriced part a cost - `part_cost` needs a unit price first - so there is
+ * no part this can cost for the first time, and the sweep that priced it has
+ * already stamped its first standard. Reaching `ensureFirstStandardCosts` from
+ * here would also put a static `bom -> builds` edge under the `builds -> bom`
+ * one that already exists.
+ *
+ * No permission checks: the router asserts `part` edit, because `part` rows are
+ * what this writes (`docs/lib-module-guide.md` §6).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNotNull, isNull } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import { ok, type Result } from 'neverthrow'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { recalculateAffectedParts } from './cost-calculator'
+
+const logger = createScopedLogger('bom:apply-tariff-schedule')
+
+export interface ApplyTariffScheduleResult {
+  /** Live supplier offers that name a `tariff_code`. */
+  classifiedOffers: number
+  /** Distinct parts those offers price - the recalculation's scope. */
+  affectedParts: number
+  /** Parts whose stored cost actually moved, ancestors included. */
+  changedPartIds: string[]
+}
+
+/**
+ * Reprice every part with a classified supplier offer at today's schedule.
+ *
+ * Returns the empty result, not an error, when the org has no `vendor_part`
+ * definition or the two fields are not materialised yet - an org
+ * mid-migration reaches that, and there is nothing to apply.
+ */
+export async function applyTariffSchedule(
+  db: Database,
+  organizationId: string
+): Promise<Result<ApplyTariffScheduleResult, Error>> {
+  const empty: ApplyTariffScheduleResult = {
+    classifiedOffers: 0,
+    affectedParts: 0,
+    changedPartIds: [],
+  }
+
+  const offerDefId = await getCachedEntityDefId(organizationId, 'vendor_part')
+  if (!offerDefId) return ok(empty)
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['vendor_part_tariff_code', 'vendor_part_part'] as const)
+  const codeField = fields.vendor_part_tariff_code
+  const partField = fields.vendor_part_part
+  if (!codeField || !partField) return ok(empty)
+
+  const codeValue = alias(schema.FieldValue, 'offer_code')
+  const partValue = alias(schema.FieldValue, 'offer_part')
+
+  // Live offers only. An archived offer is skipped by the calculator, so
+  // walking it would only widen the scope to parts whose cost then comes out
+  // unchanged - the opposite call from the delete guards, which must count it.
+  const rows = await db
+    .select({ offerId: schema.EntityInstance.id, partId: partValue.relatedEntityId })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      codeValue,
+      and(
+        eq(codeValue.entityId, schema.EntityInstance.id),
+        eq(codeValue.organizationId, schema.EntityInstance.organizationId),
+        eq(codeValue.fieldId, codeField.id),
+        isNotNull(codeValue.relatedEntityId)
+      )
+    )
+    .innerJoin(
+      partValue,
+      and(
+        eq(partValue.entityId, schema.EntityInstance.id),
+        eq(partValue.organizationId, schema.EntityInstance.organizationId),
+        eq(partValue.fieldId, partField.id)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, offerDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+
+  const offerIds = new Set<string>()
+  const partIds = new Set<string>()
+  for (const row of rows) {
+    offerIds.add(row.offerId)
+    if (row.partId) partIds.add(row.partId)
+  }
+  if (partIds.size === 0) {
+    return ok({ ...empty, classifiedOffers: offerIds.size })
+  }
+
+  const changedPartIds = await recalculateAffectedParts(organizationId, [...partIds])
+
+  logger.info('Applied the tariff schedule', {
+    organizationId,
+    classifiedOffers: offerIds.size,
+    affectedParts: partIds.size,
+    changedParts: changedPartIds.length,
+  })
+
+  return ok({
+    classifiedOffers: offerIds.size,
+    affectedParts: partIds.size,
+    changedPartIds,
+  })
+}

--- a/packages/lib/src/bom/index.ts
+++ b/packages/lib/src/bom/index.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/bom/index.ts
 
+export { type ApplyTariffScheduleResult, applyTariffSchedule } from './apply-tariff-schedule'
 export { recalculateAffectedParts, recalculateAllPartCosts } from './cost-calculator'
 export { batchRecalculateQoH } from './qoh'
 export { getDeductionTargets, loadDirectSubparts, loadSubpartGraph } from './subpart-graph'


### PR DESCRIPTION
## What

The explicit "apply rate changes" action from `plans/money/tasks/29-tariff-schedule.md` §8 / §12 (a).

A `tariff_rate` row with a future `effectiveFrom` changes what every offer under its code resolves to from midnight on that day, and nothing is written at midnight. `recalculateAllPartCosts` has no scheduled caller, so `part_cost` kept the old rate until an unrelated vendor-price edit happened to sweep the part. The decision was an explicit action rather than a daily sweep, because nothing else in this subsystem revalues without a person.

- **`applyTariffSchedule`** (`packages/lib/src/bom/apply-tariff-schedule.ts`) walks every live `vendor_part` that names a `tariff_code` to its part and calls `recalculateAffectedParts`. Same walk the rate-write trigger makes, minus the first join. Only classified offers are walked, since an unclassified offer never reads the schedule. Four tests.
- **`purchasing.applyTariffSchedule`** exposes it, gated on `part` edit because `part` rows are what it writes (the gate `builds.roll` uses).
- **Tariffs settings page**: an "Apply rate changes" header button with an inline "N of M parts changed" readout, shown only to a member who can edit parts.
- `@auxx/lib/bom` becomes an exported subpath (the exports file is generated from consumer imports).

## Driven

On dev with no classified offer the button reports "No classified offers to reprice". After classifying `Cap Screw M6X1X14` under `7318.15.8065 CN`, the server log shows `Applied the tariff schedule {classifiedOffers: 1, affectedParts: 1}` and the calculator sweeping 25 dirty parts.

It then reported `0 of 1 changed`. That was not this change: every part-cost write in that dev tree was refused by the in-progress sub-cent precision guard (`CURRENCY values must be exact at this field's precision`), which is not on `main` and also silenced the classification trigger. This branch is cut from `origin/main` and contains none of that work.

## Worth knowing

`persistCosts` swallows a refused write and reports the part as unchanged, so this button, the rate trigger and the roll all report success on a sweep that wrote nothing. Recorded in brief 29's open findings; a refused count on the recalc result is the fix.

## Checks

Lib ratchet clean (29 total, baseline 29), web typecheck exit 0, biome clean, `src/bom` + tariff trigger suites green (84 tests).

https://claude.ai/code/session_017tfjeTqbMEczqGX4HNkKw5
