### PR TITLE
feat(parts): the supplier offer form owns its panels, and prices in the vendor's unit

### DIFF
--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -561,7 +561,7 @@ export function FieldInputAdapter({
     case FieldType.NUMBER:
       return (
         <FocusableInputWrapper open={open} onOpenChange={onOpenChange}>
-          <NumberInput {...nodeInputProps} />
+          <NumberInput {...nodeInputProps} triggerProps={triggerProps} />
         </FocusableInputWrapper>
       )
 
@@ -582,6 +582,7 @@ export function FieldInputAdapter({
                 : (fieldOptions?.currencyDisplay ?? 'symbol')
             }
             useGrouping={fieldOptions?.useGrouping ?? true}
+            triggerProps={triggerProps}
           />
         </FocusableInputWrapper>
       )

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -336,6 +336,8 @@ export function PartFormDialog({
               vendor_part_lead_time: vendorPartValues.leadTime,
               vendor_part_min_order_qty: vendorPartValues.minOrderQty,
               vendor_part_is_preferred: vendorPartValues.isPreferred,
+              vendor_part_purchase_unit: vendorPartValues.purchaseUnit,
+              vendor_part_purchase_ratio: vendorPartValues.purchaseRatio,
             },
           })
         }
@@ -554,20 +556,17 @@ export function PartFormDialog({
             </button>
 
             {showSupplier && (
-              <FieldPanel
-                className='p-0 mt-4'
-                orientation='responsive'
-                breakpoint='md'
-                resizeId='part-form'
-                defaultLabelWidth={200}>
+              <div className='mt-4'>
                 <VendorPartFields
                   values={vendorPartValues}
                   onChange={handleVendorPartChange}
                   errors={vendorPartErrors}
                   disabled={isPending}
                   partHsCode={values.hsCode}
+                  resizeId='part-form'
+                  defaultLabelWidth={200}
                 />
-              </FieldPanel>
+              </div>
             )}
           </div>
         )}

--- a/apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
@@ -15,10 +15,7 @@ import {
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useState } from 'react'
-import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useResourceProperty } from '~/components/resources'
-import { useSystemField } from '~/components/resources/hooks/use-field'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { api } from '~/trpc/react'
@@ -83,10 +80,6 @@ export function VendorPartDialog({
   const companyDefId = useResourceProperty('company', 'id')
   const tariffCodeDefId = useResourceProperty('tariff_code', 'id')
 
-  // Field definition for the Part relationship picker (contact-centric mode) — sourced live
-  // so FieldInputAdapter gets a real RelationshipConfig and can offer "create new part"
-  const partField = useSystemField('vendor_part_part')
-
   // Load initial values for edit mode via system attributes
   const { values: systemValues } = useSystemValues(recordId, VENDOR_PART_SYSTEM_ATTRIBUTES, {
     autoFetch: true,
@@ -104,11 +97,7 @@ export function VendorPartDialog({
   )
   const partHsCode = (partValues?.hs_code as string | undefined) ?? null
 
-  // State - uses shared type plus partId for contact-centric mode
-  const [values, setValues] = useState<VendorPartFormValues & { partId: string }>({
-    ...defaultVendorPartValues,
-    partId: '',
-  })
+  const [values, setValues] = useState<VendorPartFormValues>(defaultVendorPartValues)
   const [errors, setErrors] = useState<Record<string, string>>({})
 
   // Initialize/reset values when dialog opens
@@ -155,10 +144,7 @@ export function VendorPartDialog({
           purchaseRatio: (systemValues.vendor_part_purchase_ratio as number) ?? null,
         })
       } else if (!isEditMode) {
-        setValues({
-          ...defaultVendorPartValues,
-          partId: '',
-        })
+        setValues(defaultVendorPartValues)
       }
       setErrors({})
     }
@@ -166,19 +152,6 @@ export function VendorPartDialog({
 
   // Handler for vendor part field changes
   const handleVendorPartChange = useCallback((field: keyof VendorPartFormValues, value: any) => {
-    setValues((prev) => ({ ...prev, [field]: value }))
-    setErrors((prev) => {
-      if (prev[field]) {
-        const next = { ...prev }
-        delete next[field]
-        return next
-      }
-      return prev
-    })
-  }, [])
-
-  // Field change handler
-  const handleChange = useCallback((field: string, value: any) => {
     setValues((prev) => ({ ...prev, [field]: value }))
     setErrors((prev) => {
       if (prev[field]) {
@@ -328,40 +301,18 @@ export function VendorPartDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <FieldPanel className='p-0' breakpoint='md' resizeId='vendor-part'>
-          {/* Part Selection - only shown in contact-centric mode */}
-          {isContactMode && (
-            <FieldPanelRow
-              title='Part'
-              isRequired
-              validationError={errors.partId}
-              validationType='error'>
-              <FieldInputAdapter
-                fieldType={partField?.fieldType ?? FieldType.RELATIONSHIP}
-                triggerProps={{ className: 'w-full ps-0 pe-1' }}
-                fieldOptions={partField?.options}
-                value={values.partId ? [toRecordId('part', values.partId)] : []}
-                onChange={(recordIds) => {
-                  const ids = recordIds as RecordId[]
-                  handleChange('partId', ids[0] ? getInstanceId(ids[0]) : '')
-                }}
-                placeholder='Select part...'
-                disabled={isPending || isEditMode}
-              />
-            </FieldPanelRow>
-          )}
-
-          {/* Shared vendor part fields */}
-          <VendorPartFields
-            values={values}
-            onChange={handleVendorPartChange}
-            errors={errors}
-            disabled={isPending}
-            disableContactEdit={isEditMode}
-            showContactField={isPartMode}
-            partHsCode={partHsCode}
-          />
-        </FieldPanel>
+        <VendorPartFields
+          values={values}
+          onChange={handleVendorPartChange}
+          errors={errors}
+          disabled={isPending}
+          showContactField={isPartMode}
+          disableContactEdit={isEditMode}
+          showPartField={isContactMode}
+          disablePartEdit={isEditMode}
+          partHsCode={partHsCode}
+          resizeId='vendor-part'
+        />
 
         <DialogFooter>
           <Button

--- a/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
@@ -3,13 +3,17 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { getInstanceId, type RecordId, toRecordId } from '@auxx/lib/field-values/client'
-import { RATE_DECIMALS, roundMinor } from '@auxx/utils/currency'
+import { Button } from '@auxx/ui/components/button'
+import { SegmentedControl } from '@auxx/ui/components/segmented-control'
+import { formatCurrency, RATE_DECIMALS, roundMinor } from '@auxx/utils/currency'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { FieldPanelRow } from '~/components/global/forms/field-panel'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { TooltipExplanation } from '~/components/global/tooltip'
 import { useSystemField } from '~/components/resources/hooks/use-field'
 import { BaseType } from '~/components/workflow/types'
+import { VarTypeIcon } from '~/components/workflow/utils/icon-helper'
 import { useOfferTariffs } from '../hooks/use-offer-tariffs'
 import { OfferTariffReadout } from '../ui/offer-tariff-readout'
 
@@ -17,6 +21,9 @@ import { OfferTariffReadout } from '../ui/offer-tariff-readout'
  * Default values for vendor part form fields
  */
 export const defaultVendorPartValues = {
+  /** The part, when the host lets the person pick one (company-centric mode). */
+  partId: '',
+  /** The supplier company. */
   entityInstanceId: '',
   vendorSku: '',
   unitPrice: null as number | null,
@@ -32,7 +39,7 @@ export const defaultVendorPartValues = {
   /**
    * `vendor_part_purchase_unit` - the vendor's selling unit, free text
    * ('thousand', 'box of 500', 'kg'). B-lite, plans/money/tasks/31-sub-cent-rates.md
-   * §2.9. `null` means the offer form never got this far / carries no unit yet.
+   * §2.9. `null` means the vendor sells by the each.
    */
   purchaseUnit: null as string | null,
   /**
@@ -60,10 +67,14 @@ interface VendorPartFieldsProps {
   errors?: Record<string, string>
   /** Whether the form is disabled */
   disabled?: boolean
-  /** Whether to disable the contact selection (for edit mode) */
-  disableContactEdit?: boolean
-  /** Whether to show the contact field (false for contact-centric mode) */
+  /** Whether to show the supplier picker (false for company-centric mode) */
   showContactField?: boolean
+  /** Whether to disable the supplier picker (for edit mode) */
+  disableContactEdit?: boolean
+  /** Whether to show the part picker (true for company-centric mode) */
+  showPartField?: boolean
+  /** Whether to disable the part picker (for edit mode) */
+  disablePartEdit?: boolean
   /**
    * The part's free-text `hsCode`, when the host knows it. Shown as a hint
    * under the code picker so the person can find the right origin for it -
@@ -71,259 +82,469 @@ interface VendorPartFieldsProps {
    * (29 §0.1, 30 §3.6).
    */
   partHsCode?: string | null
+  /**
+   * Shared with every other panel on the host form, so the label column drags
+   * together (`docs/ui-design-guide.md` §5).
+   */
+  resizeId: string
+  /** Label column width for the horizontal panels. */
+  defaultLabelWidth?: number
 }
 
 /**
- * Shared form fields for vendor part creation/editing
+ * Shared form for a supplier offer: who supplies it, what they charge and in
+ * what unit, and what duty it carries. Owns its own panels; the host only
+ * supplies values and a change handler.
  */
 export function VendorPartFields({
   values,
   onChange,
   errors,
   disabled,
-  disableContactEdit,
   showContactField = true,
+  disableContactEdit,
+  showPartField = false,
+  disablePartEdit,
   partHsCode,
+  resizeId,
+  defaultLabelWidth,
 }: VendorPartFieldsProps) {
   const contactField = useSystemField('vendor_part_contact')
+  const partField = useSystemField('vendor_part_part')
   const tariffCodeField = useSystemField('vendor_part_tariff_code')
 
+  const panelProps = {
+    className: 'p-0',
+    breakpoint: 'md' as const,
+    resizeId,
+    defaultLabelWidth,
+  }
+
   return (
-    <>
-      {/* Supplier (company) Selection */}
-      {showContactField && (
+    <div className='space-y-3'>
+      <FieldPanel {...panelProps}>
+        {showPartField && (
+          <FieldPanelRow
+            title='Part'
+            isRequired
+            validationError={errors?.partId}
+            validationType='error'>
+            <FieldInputAdapter
+              fieldType={partField?.fieldType ?? FieldType.RELATIONSHIP}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              fieldOptions={partField?.options}
+              value={values.partId ? [toRecordId('part', values.partId)] : []}
+              onChange={(recordIds) => {
+                const ids = recordIds as RecordId[]
+                onChange('partId', ids[0] ? getInstanceId(ids[0]) : '')
+              }}
+              placeholder='Select part...'
+              disabled={disabled || disablePartEdit}
+            />
+          </FieldPanelRow>
+        )}
+
+        {showContactField && (
+          <FieldPanelRow
+            title='Supplier'
+            isRequired
+            validationError={errors?.entityInstanceId}
+            validationType='error'>
+            <FieldInputAdapter
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              fieldType={contactField?.fieldType ?? FieldType.RELATIONSHIP}
+              fieldOptions={{ ...contactField?.options, showDefinitionIcon: true }}
+              value={
+                values.entityInstanceId ? [toRecordId('company', values.entityInstanceId)] : []
+              }
+              onChange={(recordIds) => {
+                const ids = recordIds as RecordId[]
+                onChange('entityInstanceId', ids[0] ? getInstanceId(ids[0]) : '')
+              }}
+              placeholder='Select supplier...'
+              disabled={disabled || disableContactEdit}
+            />
+          </FieldPanelRow>
+        )}
+
+        {/* Optional; identity is the (part, supplier) pair above */}
         <FieldPanelRow
-          title='Supplier'
-          isRequired
-          validationError={errors?.entityInstanceId}
+          title='Supplier SKU'
+          description='The SKU or part number used by this supplier'
+          type={BaseType.STRING}
+          showIcon
+          validationError={errors?.vendorSku}
           validationType='error'>
           <FieldInputAdapter
-            triggerProps={{ className: 'w-full ps-0 pe-1' }}
-            fieldType={contactField?.fieldType ?? FieldType.RELATIONSHIP}
-            fieldOptions={{ ...contactField?.options, showDefinitionIcon: true }}
-            value={values.entityInstanceId ? [toRecordId('company', values.entityInstanceId)] : []}
-            onChange={(recordIds) => {
-              const ids = recordIds as RecordId[]
-              onChange('entityInstanceId', ids[0] ? getInstanceId(ids[0]) : '')
-            }}
-            placeholder='Select supplier...'
-            disabled={disabled || disableContactEdit}
+            fieldType={FieldType.TEXT}
+            value={values.vendorSku}
+            onChange={(val) => onChange('vendorSku', val)}
+            placeholder="Supplier's part number"
+            disabled={disabled}
           />
         </FieldPanelRow>
-      )}
 
-      {/* Vendor SKU — optional; identity is the (part, supplier) pair above */}
-      <FieldPanelRow
-        title='Supplier SKU'
-        description='The SKU or part number used by this supplier'
-        type={BaseType.STRING}
-        showIcon
-        validationError={errors?.vendorSku}
-        validationType='error'>
-        <FieldInputAdapter
-          fieldType={FieldType.TEXT}
-          value={values.vendorSku}
-          onChange={(val) => onChange('vendorSku', val)}
-          placeholder="Supplier's part number"
-          disabled={disabled}
-        />
-      </FieldPanelRow>
-
-      {/* Unit Price - a RATE (plans/money/tasks/31-sub-cent-rates.md §2.2): a
-          quote per thousand needs the fifth decimal place ($15.94 / 1000 =
-          $0.01594), so `decimals: RATE_DECIMALS` here, unlike the per-line
-          amounts elsewhere in the app. */}
-      <FieldPanelRow title='Unit Price' type={BaseType.CURRENCY} showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.CURRENCY}
-          value={values.unitPrice}
-          onChange={(val) => onChange('unitPrice', val)}
-          placeholder='0.00'
-          disabled={disabled}
-          fieldOptions={{ currencyCode: 'USD', decimals: RATE_DECIMALS }}
-        />
-      </FieldPanelRow>
-
-      {/* Tariff — three rows where there was one (30 §3.1). The code sets the
-          duty from the schedule; the rate is the OVERRIDE; the readout is the
-          only feedback that the code picked actually has rates behind it. */}
-      <FieldPanelRow
-        title='Tariff code'
-        description='Classification and country of origin. Sets the duty from the schedule.'
-        type={BaseType.RELATION}
-        showIcon>
-        <FieldInputAdapter
-          triggerProps={{ className: 'w-full ps-0 pe-1' }}
-          fieldType={tariffCodeField?.fieldType ?? FieldType.RELATIONSHIP}
-          fieldOptions={tariffCodeField?.options}
-          value={values.tariffCodeId ? [toRecordId('tariff_code', values.tariffCodeId)] : []}
-          onChange={(recordIds) => {
-            const ids = recordIds as RecordId[]
-            onChange('tariffCodeId', ids[0] ? getInstanceId(ids[0]) : null)
-          }}
-          placeholder='Select tariff code...'
-          disabled={disabled}
-        />
-        <TariffCodeHint tariffCodeId={values.tariffCodeId} partHsCode={partHsCode} />
-      </FieldPanelRow>
-
-      <FieldPanelRow
-        title='Override rate (%)'
-        description='Leave blank to use the schedule. Set it for a DDP price that already includes duty, a Section 301 exclusion, or an unclassified part.'
-        type={BaseType.NUMBER}
-        showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.NUMBER}
-          value={values.tariffRate}
-          onChange={(val) => onChange('tariffRate', val)}
-          placeholder='Schedule'
-          disabled={disabled}
-        />
-      </FieldPanelRow>
-
-      <FieldPanelRow title='Duty' type={BaseType.NUMBER} showIcon>
-        <DutyRow tariffCodeId={values.tariffCodeId} tariffRate={values.tariffRate} />
-      </FieldPanelRow>
-
-      {/* Shipping Cost - a RATE too (§2.2). */}
-      <FieldPanelRow
-        title='Shipping Cost'
-        description='Per-unit shipping/freight'
-        type={BaseType.CURRENCY}
-        showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.CURRENCY}
-          value={values.shippingCost}
-          onChange={(val) => onChange('shippingCost', val)}
-          placeholder='0.00'
-          disabled={disabled}
-          fieldOptions={{ currencyCode: 'USD', decimals: RATE_DECIMALS }}
-        />
-      </FieldPanelRow>
-
-      {/* Other Cost - a RATE too (§2.2). */}
-      <FieldPanelRow
-        title='Other Cost'
-        description='Insurance, brokerage, handling'
-        type={BaseType.CURRENCY}
-        showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.CURRENCY}
-          value={values.otherCost}
-          onChange={(val) => onChange('otherCost', val)}
-          placeholder='0.00'
-          disabled={disabled}
-          fieldOptions={{ currencyCode: 'USD', decimals: RATE_DECIMALS }}
-        />
-      </FieldPanelRow>
-
-      {/* Lead Time */}
-      <FieldPanelRow
-        title='Lead Time'
-        description='Days to receive order'
-        type={BaseType.NUMBER}
-        showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.NUMBER}
-          value={values.leadTime}
-          onChange={(val) => onChange('leadTime', val)}
-          placeholder='Days'
-          disabled={disabled}
-        />
-      </FieldPanelRow>
-
-      {/* Min Order Qty */}
-      <FieldPanelRow
-        title='Min Order'
-        description='Minimum order quantity'
-        type={BaseType.NUMBER}
-        showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.NUMBER}
-          value={values.minOrderQty}
-          onChange={(val) => onChange('minOrderQty', val)}
-          placeholder='Qty'
-          disabled={disabled}
-        />
-      </FieldPanelRow>
-
-      {/* Purchase unit + ratio - B-lite (30 §2.9): how THIS supplier packs the
-          part, as an entry conversion only. Stock, BOM lines and the PO line all
-          stay in the part's own unit; this is what lets the Price-per-unit row
-          below exist, and the PO line editor's purchase-quantity draft. */}
-      <FieldPanelRow
-        title='Purchase Unit'
-        description="The vendor's selling unit - thousand, box of 500, kg"
-        type={BaseType.STRING}
-        showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.TEXT}
-          value={values.purchaseUnit}
-          onChange={(val) => onChange('purchaseUnit', val || null)}
-          placeholder='thousand'
-          disabled={disabled}
-        />
-      </FieldPanelRow>
-
-      <FieldPanelRow
-        title='Purchase Ratio'
-        description='Tracking units per purchase unit, e.g. 1000. Blank or 1 means sold by the each.'
-        type={BaseType.NUMBER}
-        showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.NUMBER}
-          value={values.purchaseRatio}
-          onChange={(val) => onChange('purchaseRatio', val)}
-          placeholder='1'
-          disabled={disabled}
-        />
-      </FieldPanelRow>
-
-      {/* Derived - shown only once a ratio actually changes the math. Editing
-          THIS field writes `unitPrice` (the stored, per-each field); it never
-          stores anything of its own. */}
-      {values.purchaseRatio !== null && values.purchaseRatio > 1 && (
         <FieldPanelRow
-          title={`Price per ${values.purchaseUnit || 'purchase unit'}`}
-          description={`unit_price x ${values.purchaseRatio} - editing this divides back into the per-each price above`}
-          type={BaseType.CURRENCY}
+          title='Lead Time'
+          description='Days to receive order'
+          type={BaseType.NUMBER}
           showIcon>
           <FieldInputAdapter
-            fieldType={FieldType.CURRENCY}
-            value={values.unitPrice !== null ? values.unitPrice * values.purchaseRatio : null}
-            onChange={(val) => {
-              const typed = val as number | null
-              onChange(
-                'unitPrice',
-                typed === null || !values.purchaseRatio
-                  ? typed
-                  : roundMinor(typed / values.purchaseRatio, RATE_DECIMALS)
-              )
-            }}
-            placeholder='0.00'
+            fieldType={FieldType.NUMBER}
+            value={values.leadTime}
+            onChange={(val) => onChange('leadTime', val ?? null)}
+            placeholder='Days'
             disabled={disabled}
-            fieldOptions={{ currencyCode: 'USD', decimals: RATE_DECIMALS }}
           />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Preferred'
+          description='Mark as preferred supplier for this part'
+          type={BaseType.BOOLEAN}
+          showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            value={values.isPreferred}
+            onChange={(val) => onChange('isPreferred', val)}
+            disabled={disabled}
+            fieldOptions={{ variant: 'switch' }}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
+
+      <PricingPanel values={values} onChange={onChange} disabled={disabled} {...panelProps} />
+
+      {/* Tariff - three rows (30 §3.1). The code sets the duty from the
+          schedule; the rate is the OVERRIDE; the readout is the only feedback
+          that the code picked actually has rates behind it. */}
+      <FieldPanel {...panelProps}>
+        <FieldPanelRow
+          title='Tariff code'
+          description='Classification and country of origin. Sets the duty from the schedule.'
+          type={BaseType.RELATION}
+          showIcon>
+          <FieldInputAdapter
+            triggerProps={{ className: 'w-full ps-0 pe-1' }}
+            fieldType={tariffCodeField?.fieldType ?? FieldType.RELATIONSHIP}
+            fieldOptions={tariffCodeField?.options}
+            value={values.tariffCodeId ? [toRecordId('tariff_code', values.tariffCodeId)] : []}
+            onChange={(recordIds) => {
+              const ids = recordIds as RecordId[]
+              onChange('tariffCodeId', ids[0] ? getInstanceId(ids[0]) : null)
+            }}
+            placeholder='Select tariff code...'
+            disabled={disabled}
+          />
+          <TariffCodeHint tariffCodeId={values.tariffCodeId} partHsCode={partHsCode} />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Override rate (%)'
+          description='Leave blank to use the schedule. Set it for a DDP price that already includes duty, a Section 301 exclusion, or an unclassified part.'
+          type={BaseType.NUMBER}
+          showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.NUMBER}
+            value={values.tariffRate}
+            onChange={(val) => onChange('tariffRate', val ?? null)}
+            placeholder='Schedule'
+            disabled={disabled}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Duty' type={BaseType.NUMBER} showIcon>
+          <DutyRow tariffCodeId={values.tariffCodeId} tariffRate={values.tariffRate} />
+        </FieldPanelRow>
+      </FieldPanel>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pricing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The offer's money-per-unit fields. All stored per each, all rates (31 §2.2). */
+const MONEY_FIELDS = ['unitPrice', 'shippingCost', 'otherCost'] as const
+type MoneyField = (typeof MONEY_FIELDS)[number]
+
+/**
+ * What the person typed, in the vendor's unit, while the panel is in pack mode.
+ *
+ * The stored fields are always per each; these are the per-pack figures they
+ * were divided out of. Kept locally so a pack price typed before the ratio is
+ * reinterpreted once the ratio lands (rather than stored per each and then
+ * multiplied back up), and so `$1.00 per 3` keeps reading `1.00` instead of the
+ * `0.99999` its stored per-each re-multiplies to.
+ */
+interface PackDrafts {
+  unitPrice: number | null
+  shippingCost: number | null
+  otherCost: number | null
+  minOrderQty: number | null
+}
+
+const CURRENCY_OPTIONS = { currencyCode: 'USD', decimals: RATE_DECIMALS }
+
+function isPackRatio(ratio: number | null): ratio is number {
+  return ratio !== null && Number.isFinite(ratio) && ratio > 1
+}
+
+/** Five places, enough for a kg ratio without float noise. */
+function roundQty(value: number): number {
+  return Math.round(value * 1e5) / 1e5
+}
+
+/** Per-pack figures from the stored per-each ones. */
+function seedDrafts(values: VendorPartFormValues): PackDrafts {
+  const factor = isPackRatio(values.purchaseRatio) ? values.purchaseRatio : 1
+  const scale = (v: number | null) => (v === null ? null : roundMinor(v * factor, RATE_DECIMALS))
+  return {
+    unitPrice: scale(values.unitPrice),
+    shippingCost: scale(values.shippingCost),
+    otherCost: scale(values.otherCost),
+    minOrderQty: values.minOrderQty === null ? null : roundQty(values.minOrderQty / factor),
+  }
+}
+
+interface PricingPanelProps extends Pick<VendorPartFieldsProps, 'resizeId' | 'defaultLabelWidth'> {
+  values: VendorPartFormValues
+  onChange: VendorPartFieldsProps['onChange']
+  disabled?: boolean
+  className?: string
+  breakpoint?: 'sm' | 'md'
+}
+
+/**
+ * Price, freight, other cost and minimum order, entered either per each or in
+ * the vendor's own unit (B-lite, 31 §2.9).
+ *
+ * Pack mode is an ENTRY conversion. Every input reads in the purchase unit and
+ * the per-each figure the calculator will see is the readout beside it. The
+ * stored fields never change meaning: stock, BOM lines, the PO line and the
+ * roll all keep reading per each. Freight here is the buyer's own per-unit
+ * estimate; the real freight on an order is allocated from the bill.
+ */
+function PricingPanel({ values, onChange, disabled, ...panelProps }: PricingPanelProps) {
+  const [packMode, setPackMode] = useState(() => isPackRatio(values.purchaseRatio))
+  const [drafts, setDrafts] = useState<PackDrafts>(() => seedDrafts(values))
+
+  // Edit mode loads its values after mount. A ratio that arrives from outside
+  // switches the panel to pack mode and seeds the drafts from what is stored.
+  useEffect(() => {
+    if (!packMode && isPackRatio(values.purchaseRatio)) {
+      setPackMode(true)
+      setDrafts(seedDrafts(values))
+    }
+  }, [packMode, values])
+
+  const factor = isPackRatio(values.purchaseRatio) ? values.purchaseRatio : 1
+  const unitLabel = values.purchaseUnit?.trim() || 'purchase unit'
+
+  const setMode = (pack: boolean) => {
+    if (pack === packMode) return
+    setPackMode(pack)
+    if (pack) {
+      setDrafts(seedDrafts(values))
+    } else {
+      // The stored figures are already per each; only the pack goes.
+      onChange('purchaseUnit', null)
+      onChange('purchaseRatio', null)
+    }
+  }
+
+  const writeMoney = (field: MoneyField, typed: number | null) => {
+    if (!packMode) {
+      onChange(field, typed)
+      return
+    }
+    setDrafts((d) => ({ ...d, [field]: typed }))
+    onChange(field, typed === null ? null : roundMinor(typed / factor, RATE_DECIMALS))
+  }
+
+  const writeMinOrder = (typed: number | null) => {
+    if (!packMode) {
+      onChange('minOrderQty', typed)
+      return
+    }
+    setDrafts((d) => ({ ...d, minOrderQty: typed }))
+    onChange('minOrderQty', typed === null ? null : roundQty(typed * factor))
+  }
+
+  // A new ratio re-derives every stored figure from what was typed, so the
+  // typed pack price is what survives, not the stale per-each one.
+  const writeRatio = (next: number | null) => {
+    onChange('purchaseRatio', next)
+    const f = isPackRatio(next) ? next : 1
+    for (const field of MONEY_FIELDS) {
+      const draft = drafts[field]
+      onChange(field, draft === null ? null : roundMinor(draft / f, RATE_DECIMALS))
+    }
+    onChange('minOrderQty', drafts.minOrderQty === null ? null : roundQty(drafts.minOrderQty * f))
+  }
+
+  const moneyColumn = (field: MoneyField, title: string, description?: string) => (
+    <PricingColumn
+      title={title}
+      description={description}
+      type={BaseType.CURRENCY}
+      unit={packMode ? `per ${unitLabel}` : 'each'}
+      readout={
+        packMode && values[field] !== null
+          ? `${formatCurrency(values[field], { decimals: RATE_DECIMALS })} each`
+          : undefined
+      }>
+      <FieldInputAdapter
+        fieldType={FieldType.CURRENCY}
+        // The symbol prefix carries its own start padding; flush it with the label.
+        triggerProps={{ className: '[&_span:first-child]:ps-0' }}
+        fieldOptions={CURRENCY_OPTIONS}
+        value={packMode ? drafts[field] : values[field]}
+        onChange={(val) => writeMoney(field, (val as number | null) ?? null)}
+        placeholder='0.00'
+        disabled={disabled}
+      />
+    </PricingColumn>
+  )
+
+  return (
+    <FieldPanel {...panelProps}>
+      <FieldPanelRow
+        title='Sold'
+        description='Per pack when the supplier quotes in their own unit - per thousand, per box, per kg. Everything typed below is then in that unit, and the per-each figure the cost calculator sees is shown beside it.'>
+        <div className='flex h-8 items-center'>
+          <SegmentedControl
+            mode='toggle'
+            toggleMode='single'
+            isPill
+            value={[packMode ? 1 : 0]}
+            onChange={(indices) => {
+              if (indices.length) setMode(indices[0] === 1)
+            }}>
+            <Button variant='transparent' size='xs' disabled={disabled} className={MODE_BUTTON}>
+              Per each
+            </Button>
+            <Button variant='transparent' size='xs' disabled={disabled} className={MODE_BUTTON}>
+              Per pack
+            </Button>
+          </SegmentedControl>
+        </div>
+      </FieldPanelRow>
+
+      {packMode && (
+        <FieldPanelRow
+          title='Pack'
+          description="How this supplier packs the part. Stock, BOM lines and the purchase order line stay in each; this only converts what's typed here and on the PO line."
+          type={BaseType.STRING}
+          showIcon>
+          <Sentence>
+            <Word>1</Word>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              triggerProps={{ className: 'w-20' }}
+              value={values.purchaseUnit ?? ''}
+              onChange={(val) => onChange('purchaseUnit', (val as string) || null)}
+              placeholder='thousand'
+              disabled={disabled}
+            />
+            <Word>=</Word>
+            <FieldInputAdapter
+              fieldType={FieldType.NUMBER}
+              triggerProps={{ className: 'w-20' }}
+              value={values.purchaseRatio}
+              onChange={(val) => writeRatio((val as number | null) ?? null)}
+              placeholder='1000'
+              disabled={disabled}
+            />
+            <Word>each</Word>
+          </Sentence>
         </FieldPanelRow>
       )}
 
-      {/* Is Preferred */}
-      <FieldPanelRow
-        title='Preferred'
-        description='Mark as preferred supplier for this part'
-        type={BaseType.BOOLEAN}
-        showIcon>
-        <FieldInputAdapter
-          fieldType={FieldType.CHECKBOX}
-          value={values.isPreferred}
-          onChange={(val) => onChange('isPreferred', val)}
-          disabled={disabled}
-          fieldOptions={{ variant: 'switch' }}
-        />
-      </FieldPanelRow>
-    </>
+      {/* One block, four columns: label, input, unit, per-each readout. Carries
+          the row slot so the panel's border rules treat it as a row. */}
+      <div data-slot='field-row' className='border-b'>
+        <div className='grid w-full grid-cols-2 gap-x-3 gap-y-3 px-2 py-2 sm:grid-cols-4'>
+          {moneyColumn('unitPrice', 'Price')}
+          {moneyColumn(
+            'shippingCost',
+            'Shipping',
+            'Your own per-unit freight estimate, for costing'
+          )}
+          {moneyColumn('otherCost', 'Other', 'Insurance, brokerage, handling')}
+          <PricingColumn
+            title='Min order'
+            description='Minimum order quantity'
+            type={BaseType.NUMBER}
+            unit={packMode ? unitLabel : 'each'}
+            readout={
+              packMode && values.minOrderQty !== null
+                ? `${values.minOrderQty.toLocaleString()} each`
+                : undefined
+            }>
+            <FieldInputAdapter
+              fieldType={FieldType.NUMBER}
+              value={packMode ? drafts.minOrderQty : values.minOrderQty}
+              onChange={(val) => writeMinOrder((val as number | null) ?? null)}
+              placeholder='Qty'
+              disabled={disabled}
+            />
+          </PricingColumn>
+        </div>
+      </div>
+    </FieldPanel>
   )
 }
+
+interface PricingColumnProps {
+  title: string
+  description?: string
+  type: BaseType
+  /** What the input is in: `each`, `per thousand`. */
+  unit: string
+  /** The stored per-each figure, shown only when it differs from what was typed. */
+  readout?: string
+  children: ReactNode
+}
+
+/** Label over input over unit, the same label styling as a `FieldPanelRow`. */
+function PricingColumn({ title, description, type, unit, readout, children }: PricingColumnProps) {
+  return (
+    <div className='flex min-w-0 flex-col'>
+      <div className='flex items-center gap-1 text-sm [&_svg]:size-4'>
+        <VarTypeIcon type={type} />
+        <span className='text-primary-600'>{title}</span>
+        {description && <TooltipExplanation text={description} />}
+      </div>
+      {/* Fixed height: the number input's stepper is taller than the currency
+          group, and the unit lines below must sit on one baseline. */}
+      <div className='flex h-8 items-center [&>*]:w-full'>{children}</div>
+      <div className='text-muted-foreground text-xs'>{unit}</div>
+      {readout && <div className='text-muted-foreground text-xs tabular-nums'>{readout}</div>}
+    </div>
+  )
+}
+
+const MODE_BUTTON =
+  'aria-checked:inset-shadow-black/20 rounded-full aria-checked:bg-info aria-checked:to-info aria-checked:from-info aria-checked:text-white duration-0'
+
+/** Inputs and connector words on one wrapping line. */
+function Sentence({ children }: { children: ReactNode }) {
+  return (
+    <div className='flex min-h-8 flex-wrap items-center gap-x-2 gap-y-1 pe-2 text-sm'>
+      {children}
+    </div>
+  )
+}
+
+function Word({ children }: { children: ReactNode }) {
+  return <span className='text-muted-foreground'>{children}</span>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Duty
+// ─────────────────────────────────────────────────────────────────────────────
 
 /** The form's own draft, resolved through the shared seam like any saved offer. */
 function DutyRow({

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/currency-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/currency-input.tsx
@@ -6,8 +6,10 @@ import {
   CurrencyInput as CurrencyInputUi,
 } from '@auxx/ui/components/input-currency'
 import { InputGroup } from '@auxx/ui/components/input-group'
+import { cn } from '@auxx/ui/lib/utils'
 import type React from 'react'
 import { useCallback, useRef } from 'react'
+import type { PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { createNodeInput, type NodeInputProps } from './base-node-input'
 
 /**
@@ -26,6 +28,8 @@ interface CurrencyInputProps extends NodeInputProps {
   currencyDisplay?: 'symbol' | 'code' | 'name' | 'compact'
   /** Whether to use grouping separators */
   useGrouping?: boolean
+  /** Trigger customization options (className is merged into the input group) */
+  triggerProps?: PickerTriggerOptions
 }
 
 /**
@@ -46,6 +50,7 @@ export const CurrencyInput = createNodeInput<CurrencyInputProps>(
     currencyCode = 'USD',
     decimals,
     currencyDisplay = 'symbol',
+    triggerProps,
   }) => {
     // Track if we should trigger onChange after blur parsing
     const shouldUpdateRef = useRef(false)
@@ -96,7 +101,11 @@ export const CurrencyInput = createNodeInput<CurrencyInputProps>(
         currencyDisplay={currencyDisplay === 'compact' ? 'symbol' : currencyDisplay}
         decimals={decimals}
         disabled={isLoading}>
-        <InputGroup className='bg-transparent dark:bg-transparent h-[28px] shadow-none ring-0 border-0 has-[[data-slot=input-group-control]:focus-visible]:ring-[0px]'>
+        <InputGroup
+          className={cn(
+            'bg-transparent dark:bg-transparent h-[28px] shadow-none ring-0 border-0 has-[[data-slot=input-group-control]:focus-visible]:ring-[0px]',
+            triggerProps?.className
+          )}>
           <CurrencyInputField
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/number-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/number-input.tsx
@@ -8,6 +8,8 @@ import {
   NumberInputIncrement,
   NumberInput as NumberInputUi,
 } from '@auxx/ui/components/input-number'
+import { cn } from '@auxx/ui/lib/utils'
+import type { PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { createNodeInput, type NodeInputProps } from './base-node-input'
 
 interface NumberInputProps extends NodeInputProps {
@@ -25,6 +27,8 @@ interface NumberInputProps extends NodeInputProps {
   allowDecimals?: boolean
   /** Stepper control style: 'buttons' (default +/- buttons) or 'arrows' (compact vertical arrows) */
   stepper?: 'buttons' | 'arrows'
+  /** Trigger customization options (className is merged into the input group) */
+  triggerProps?: PickerTriggerOptions
 }
 
 /**
@@ -44,6 +48,7 @@ export const NumberInput = createNodeInput<NumberInputProps>(
     step,
     allowDecimals = true,
     stepper = 'arrows',
+    triggerProps,
   }) => {
     // Parse value to ensure it's a number, not a string (prevents "3" + 1 = "31" bug)
     const rawValue = inputs[name]
@@ -97,8 +102,12 @@ export const NumberInput = createNodeInput<NumberInputProps>(
         min={min}
         step={step}
         disabled={isLoading}>
-        <div className='flex flex-col items-start w-full'>
-          <InputGroup className='bg-transparent! min-h-8 shadow-none ring-0 border-0 has-[[data-slot=input-group-control]:focus-visible]:ring-[0px]'>
+        <div className={cn('flex flex-col items-start w-full', triggerProps?.className)}>
+          <InputGroup
+            className={cn(
+              'bg-transparent! min-h-8 shadow-none ring-0 border-0 has-[[data-slot=input-group-control]:focus-visible]:ring-[0px]',
+              triggerProps?.className
+            )}>
             <NumberInputField
               id={inputId}
               placeholder={placeholder}


### PR DESCRIPTION
## What

The supplier offer form (`VendorPartFields`, shared by Add/Edit Supplier and the Create Part dialog) now renders its own three panels instead of fourteen flat rows inside a host-supplied panel:

1. **Supplier**: Part, Supplier, Supplier SKU, Lead time, Preferred. Standard rows.
2. **Pricing**: a Sold toggle (per each / per pack). Pack mode adds a `1 [thousand] = [1000] each` row. Price, Shipping, Other and Min order sit in one four-column block: label, input, the unit it is in, and the per-each figure the calculator will see.
3. **Tariff**: code, override rate, duty readout. Standard rows.

All three share the host's `resizeId`, so the label columns drag together.

## Pack mode is an entry conversion only

Every input in pack mode is in the vendor's unit. The stored fields (`vendor_part_unit_price`, shipping, other, min order) stay per each, so the cost calculator, the standard roll and the PO line read exactly what they read today (plan 31 §2.9, B-lite). Typed pack figures are held as local drafts:

- a price typed before the ratio is reinterpreted once the ratio lands, rather than stored per each and then multiplied back up
- `$1.00 per 3` keeps reading `1.00` instead of the `0.99999` its stored per-each re-multiplies to

Switching to per each clears unit and ratio and leaves the stored per-each figures alone. Mode is derived from the ratio on load, never stored.

## Also

- `triggerProps` now reaches `FieldInputAdapter`'s NUMBER and CURRENCY inputs the way it already reached TEXT. The part dialog was passing it to both and it was silently dropped.
- **Bug fix**: the Create Part dialog's supplier path never wrote `vendor_part_purchase_unit` or `vendor_part_purchase_ratio`, so a pack set at part creation was lost without error. Both are in the create payload now.
- Both host dialogs shrink to a single `<VendorPartFields>` call. The part picker and its edit-mode lock moved into the form.

## Verified

Driven in the browser on the nylock nut's offer (ratio 1000) and on a fresh Create Part:

- Edit Supplier opens in pack mode: `1 thousand = 1000 each`, `$15.94 per thousand`, readout `$0.01594 each`
- Per each shows `$0.01594 each` and hides the pack row; back to per pack keeps the price and empties the pack row
- Typing `15.94` per thousand derives `$0.01594 each`; min order `5` thousand reads `5,000 each`
- No console errors. `typecheck-ratchet --package web` clean. Biome clean.

Not built: the pricing block does not show a landed-cost total. The Suppliers tab row already does.

https://claude.ai/code/session_013jfBFWaMBxHZPQoukKLdcC
