### PR TITLE
fix(import): money columns read, review and preview at the field's precision

### DIFF
--- a/apps/web/src/components/data-import/column-mapping/column-mapping-row.tsx
+++ b/apps/web/src/components/data-import/column-mapping/column-mapping-row.tsx
@@ -58,6 +58,8 @@ interface ColumnMappingRowProps {
   onPolicyChange: (patch: ColumnPolicyPatch) => void
   /** How this column's cells are read. Offered only where more than one type is valid. */
   onResolutionTypeChange: (next: ResolutionType) => void
+  /** Which character marks decimals in this column's cells; null is per-cell detection. */
+  onDecimalSeparatorChange: (next: '.' | ',' | null) => void
 }
 
 /**
@@ -83,6 +85,7 @@ export function ColumnMappingRow({
   onToggleIdentifier,
   onPolicyChange,
   onResolutionTypeChange,
+  onDecimalSeparatorChange,
 }: ColumnMappingRowProps) {
   const [open, setOpen] = useState(false)
 
@@ -220,8 +223,10 @@ export function ColumnMappingRow({
             <ResolutionTypePopover
               field={selectedField}
               value={mapping.resolutionType}
+              decimalSeparator={mapping.numberDecimalSeparator}
               disabled={isSaving}
               onChange={onResolutionTypeChange}
+              onDecimalSeparatorChange={onDecimalSeparatorChange}
             />
           )}
 

--- a/apps/web/src/components/data-import/column-mapping/column-mapping-table.tsx
+++ b/apps/web/src/components/data-import/column-mapping/column-mapping-table.tsx
@@ -25,6 +25,7 @@ interface ColumnMappingTableProps {
   onToggleIdentifier: (columnIndex: number, next: boolean) => void
   onPolicyChange: (columnIndex: number, patch: ColumnPolicyPatch) => void
   onResolutionTypeChange: (columnIndex: number, next: ResolutionType) => void
+  onDecimalSeparatorChange: (columnIndex: number, next: '.' | ',' | null) => void
 }
 
 /**
@@ -42,6 +43,7 @@ export function ColumnMappingTable({
   onToggleIdentifier,
   onPolicyChange,
   onResolutionTypeChange,
+  onDecimalSeparatorChange,
 }: ColumnMappingTableProps) {
   /**
    * How many OTHER columns carry the identity flag. A composite-only (RELATION)
@@ -83,6 +85,9 @@ export function ColumnMappingTable({
             onPolicyChange={(patch) => onPolicyChange(mapping.sourceColumnIndex, patch)}
             onResolutionTypeChange={(next) =>
               onResolutionTypeChange(mapping.sourceColumnIndex, next)
+            }
+            onDecimalSeparatorChange={(next) =>
+              onDecimalSeparatorChange(mapping.sourceColumnIndex, next)
             }
           />
         ))}

--- a/apps/web/src/components/data-import/column-mapping/resolution-type-popover.tsx
+++ b/apps/web/src/components/data-import/column-mapping/resolution-type-popover.tsx
@@ -18,14 +18,20 @@ import { Binary } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 
+/** A column's decimal separator choice. `null` is per-cell detection. */
+export type DecimalSeparatorChoice = '.' | ',' | null
+
 interface ResolutionTypePopoverProps {
   /** The field this column is mapped to. */
   field: ImportableField
   /** The column's stored resolution type. */
   value: string
+  /** The column's stored decimal separator, when one was chosen. */
+  decimalSeparator: string | null
   /** Disables the control while a save is in flight. */
   disabled?: boolean
   onChange: (next: ResolutionType) => void
+  onDecimalSeparatorChange: (next: DecimalSeparatorChoice) => void
 }
 
 /**
@@ -57,6 +63,31 @@ export function hasResolutionChoice(field: ImportableField | undefined): boolean
 }
 
 /**
+ * The types whose reading depends on which character marks decimals. A whole
+ * number has no decimals to mark and text is imported as written, so the
+ * separator is offered only where it changes the answer.
+ */
+function readsDecimals(type: ResolutionType): boolean {
+  return type === 'currency:major' || type === 'number:decimal'
+}
+
+const SEPARATOR_OPTIONS: Array<{
+  value: 'auto' | '.' | ','
+  label: string
+  description: string
+}> = [
+  {
+    value: 'auto',
+    label: 'Detect per cell',
+    description:
+      'Point or comma, read from each cell. A lone separator with three digits after it ' +
+      '(1.234) is refused as ambiguous.',
+  },
+  { value: '.', label: 'Point', description: '1,234.56 → 1234.56' },
+  { value: ',', label: 'Comma', description: '1.234,56 → 1234.56' },
+]
+
+/**
  * How this column's cells are READ, as a per-column choice.
  *
  * This is the control that makes two engine behaviours reachable at all:
@@ -71,6 +102,10 @@ export function hasResolutionChoice(field: ImportableField | undefined): boolean
  *   a user can tell them apart — which is why they are rendered next to every
  *   option rather than only on the active one.
  *
+ * The decimal separator lives here too, for the types that read decimals. The
+ * resolver's own error for an ambiguous cell says "set the column's decimal
+ * separator", and this is the only place that can.
+ *
  * Lives on the mapping ROW next to the identity and policy controls, for the
  * same reason they do: the field picker closes on selection and resets its
  * drill-down, so a control inside it costs a reopen per change.
@@ -78,8 +113,10 @@ export function hasResolutionChoice(field: ImportableField | undefined): boolean
 export function ResolutionTypePopover({
   field,
   value,
+  decimalSeparator,
   disabled,
   onChange,
+  onDecimalSeparatorChange,
 }: ResolutionTypePopoverProps) {
   const [open, setOpen] = useState(false)
   const choices = useMemo(() => resolutionChoices(field), [field])
@@ -91,12 +128,21 @@ export function ResolutionTypePopover({
   if (!suggested || choices.length <= 1) return null
 
   const active = choices.includes(value as ResolutionType) ? (value as ResolutionType) : suggested
-  const isCustomised = active !== suggested
+  const showSeparator = readsDecimals(active)
+  const separator: 'auto' | '.' | ',' =
+    showSeparator && (decimalSeparator === '.' || decimalSeparator === ',')
+      ? decimalSeparator
+      : 'auto'
+  const isCustomised = active !== suggested || separator !== 'auto'
   const activeLabel = getResolutionTypeLabel(active)
+  const separatorLabel = SEPARATOR_OPTIONS.find((o) => o.value === separator)?.label ?? ''
+  const tooltip =
+    `Read as: ${activeLabel.label}. ${activeLabel.hint}` +
+    (showSeparator && separator !== 'auto' ? ` Decimal separator: ${separatorLabel}.` : '')
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <Tooltip content={`Read as: ${activeLabel.label}. ${activeLabel.hint}`}>
+      <Tooltip content={tooltip}>
         <span className='inline-flex'>
           <PopoverTrigger asChild>
             <Button
@@ -121,12 +167,11 @@ export function ResolutionTypePopover({
         </div>
         {/* `max-h-*` belongs on the VIEWPORT, not the root — see ScrollArea's own
             note: on the root the viewport grows to its content and never scrolls. */}
-        <ScrollArea viewportClassName='max-h-[320px]'>
+        <ScrollArea viewportClassName='max-h-[420px]'>
           <RadioGroup
             value={active}
             className='gap-1.5 p-3'
             onValueChange={(next) => {
-              setOpen(false)
               if (next !== active) onChange(next as ResolutionType)
             }}>
             {choices.map((type) => {
@@ -143,6 +188,34 @@ export function ResolutionTypePopover({
               )
             })}
           </RadioGroup>
+          {showSeparator && (
+            <>
+              <div className='px-3 py-2 border-t border-b'>
+                <p className='text-sm font-medium'>Decimal separator</p>
+                <p className='text-xs text-muted-foreground'>
+                  Which character marks decimals in this column
+                </p>
+              </div>
+              <RadioGroup
+                value={separator}
+                className='gap-1.5 p-3'
+                onValueChange={(next) => {
+                  if (next === separator) return
+                  onDecimalSeparatorChange(next === 'auto' ? null : (next as '.' | ','))
+                }}>
+                {SEPARATOR_OPTIONS.map((option) => (
+                  <RadioGroupItemCard
+                    key={option.value}
+                    id={`separator-${field.key}-${option.value}`}
+                    value={option.value}
+                    label={option.label}
+                    sublabel={option.value === 'auto' ? 'default' : undefined}
+                    description={option.description}
+                  />
+                ))}
+              </RadioGroup>
+            </>
+          )}
         </ScrollArea>
       </PopoverContent>
     </Popover>

--- a/apps/web/src/components/data-import/plan-preview/types.ts
+++ b/apps/web/src/components/data-import/plan-preview/types.ts
@@ -53,5 +53,9 @@ export interface PreviewColumnMapping {
   targetFieldKey: string | null
   targetFieldLabel?: string
   targetType?: string
+  /** The target field's storage type (`FieldType`), decides the cell renderer */
   fieldType?: string
+  /** CURRENCY targets: what the resolved minor units are denominated in, and the field's precision */
+  currencyCode?: string
+  decimals?: number
 }

--- a/apps/web/src/components/data-import/plan-preview/use-plan-preview-columns.tsx
+++ b/apps/web/src/components/data-import/plan-preview/use-plan-preview-columns.tsx
@@ -10,6 +10,12 @@ import { FormattedCell } from '~/components/dynamic-table'
 import { StrategyCell } from './strategy-cell'
 import type { PlanPreviewRow, PreviewColumnMapping } from './types'
 
+/** The cell renderer a preview column gets. Only the numeric types render as the field would. */
+function renderableType(fieldType: string | undefined): 'CURRENCY' | 'NUMBER' | 'TEXT' {
+  const upper = fieldType?.toUpperCase()
+  return upper === 'CURRENCY' || upper === 'NUMBER' ? upper : 'TEXT'
+}
+
 interface UsePlanPreviewColumnsOptions {
   /** Mapped columns from import job */
   mappings: PreviewColumnMapping[]
@@ -74,12 +80,21 @@ export function usePlanPreviewColumns(options: UsePlanPreviewColumnsOptions) {
 
     for (const mapping of mappedFields) {
       const fieldKey = mapping.targetFieldKey!
+      // A preview cell holds the RESOLVED value: minor units for money, a
+      // number for NUMBER. Those two are rendered as the field would render
+      // them; everything else (an ISO date string, a relation's pending
+      // lookup, an option key) stays text, which is what it is at this point.
+      const previewType = renderableType(mapping.fieldType)
+      const options =
+        previewType === 'CURRENCY'
+          ? { currencyCode: mapping.currencyCode, decimals: mapping.decimals }
+          : undefined
 
       columns.push({
         id: `field_${fieldKey}`,
         accessorFn: (row) => row.fields[fieldKey],
         header: mapping.targetFieldLabel ?? mapping.sourceColumnName ?? fieldKey,
-        fieldType: (mapping.fieldType?.toUpperCase() ?? 'TEXT') as FieldType,
+        fieldType: previewType as FieldType,
         enableSorting: true,
         enableFiltering: false,
         enableResize: true,
@@ -94,8 +109,9 @@ export function usePlanPreviewColumns(options: UsePlanPreviewColumnsOptions) {
           return (
             <FormattedCell
               value={value}
-              fieldType={mapping.fieldType?.toUpperCase() ?? 'TEXT'}
+              fieldType={previewType}
               columnId={`field_${fieldKey}`}
+              options={options}
             />
           )
         },

--- a/apps/web/src/components/data-import/steps/step-confirm-import.tsx
+++ b/apps/web/src/components/data-import/steps/step-confirm-import.tsx
@@ -52,7 +52,10 @@ export function StepConfirmImport({ jobId, onComplete }: StepConfirmImportProps)
       sourceColumnIndex: col.columnIndex,
       sourceColumnName: col.columnName,
       targetFieldKey: col.targetFieldKey,
-      targetFieldLabel: col.targetFieldKey ?? undefined,
+      targetFieldLabel: col.targetFieldLabel ?? col.targetFieldKey ?? undefined,
+      fieldType: col.fieldType ?? undefined,
+      currencyCode: col.currencyCode,
+      decimals: col.decimals,
     })) ?? []
 
   // Auto-generate plan when entering this step if not already generated.

--- a/apps/web/src/components/data-import/steps/step-map-columns.tsx
+++ b/apps/web/src/components/data-import/steps/step-map-columns.tsx
@@ -51,6 +51,8 @@ interface ColumnSavePayload {
     linkMode?: 'add' | 'set'
   }
   options?: Array<{ value: string; label: string }>
+  /** Tri-state, see `saveMappingProperty`: omit keeps, null clears, a value sets. */
+  numberDecimalSeparator?: '.' | ',' | null
 }
 
 /**
@@ -119,6 +121,7 @@ export function StepMapColumns({ jobId, onComplete, onMappingChange }: StepMapCo
         mergeStrategy: prop.mergeStrategy ?? null,
         onNoMatch: prop.onNoMatch ?? null,
         linkMode: prop.linkMode ?? null,
+        numberDecimalSeparator: prop.numberDecimalSeparator ?? null,
         distinctValueCount: prop.distinctValueCount ?? 0,
         totalValueCount: prop.totalValueCount ?? 0,
         createdAt: new Date(),
@@ -294,6 +297,7 @@ export function StepMapColumns({ jobId, onComplete, onMappingChange }: StepMapCo
             mergeStrategy: null,
             onNoMatch: null,
             linkMode: null,
+            numberDecimalSeparator: null,
             isMapped: false,
           }
         }
@@ -309,6 +313,7 @@ export function StepMapColumns({ jobId, onComplete, onMappingChange }: StepMapCo
             mergeStrategy: null,
             onNoMatch: payload.relationConfig?.onNoMatch ?? null,
             linkMode: payload.relationConfig?.linkMode ?? null,
+            numberDecimalSeparator: null,
             isMapped: !!fieldKey,
           }
         }
@@ -466,6 +471,44 @@ export function StepMapColumns({ jobId, onComplete, onMappingChange }: StepMapCo
     }
   }
 
+  /**
+   * Change which character marks decimals in a column's cells.
+   *
+   * Same shape as {@link handleResolutionTypeChange}, for the same reason: it
+   * changes how every cell is READ (`1,5` is fifteen or one and a half), so
+   * `saveMappingProperty` drops the column's cached resolutions and the review
+   * step re-resolves it. `null` returns the column to per-cell detection.
+   */
+  const handleDecimalSeparatorChange = async (columnIndex: number, next: '.' | ',' | null) => {
+    const mapping = mappings.find((m) => m.sourceColumnIndex === columnIndex)
+    if (!mapping?.targetFieldKey) return
+    const field = fields?.find((f) => f.key === mapping.targetFieldKey)
+
+    setMappings((prev) =>
+      prev.map((m) =>
+        m.sourceColumnIndex === columnIndex ? { ...m, numberDecimalSeparator: next } : m
+      )
+    )
+
+    markSaving(columnIndex, true)
+    try {
+      await saveColumnMapping.mutateAsync({
+        jobId,
+        columnIndex,
+        ...buildPayload(mapping, field, { targetFieldKey: mapping.targetFieldKey }),
+        numberDecimalSeparator: next,
+      })
+    } catch (error) {
+      toastError({
+        title: 'Could not change the decimal separator',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      })
+    } finally {
+      markSaving(columnIndex, false)
+      await refreshMappingState()
+    }
+  }
+
   const handleModeChange = async (nextMode: ImportStrategyMode) => {
     try {
       await setImportStrategy.mutateAsync({ jobId, mode: nextMode })
@@ -601,6 +644,7 @@ export function StepMapColumns({ jobId, onComplete, onMappingChange }: StepMapCo
             onToggleIdentifier={handleToggleIdentifier}
             onPolicyChange={handlePolicyChange}
             onResolutionTypeChange={handleResolutionTypeChange}
+            onDecimalSeparatorChange={handleDecimalSeparatorChange}
           />
         </div>
 

--- a/apps/web/src/components/data-import/types.ts
+++ b/apps/web/src/components/data-import/types.ts
@@ -73,6 +73,8 @@ export interface ColumnMappingUI {
   onNoMatch: RelationOnNoMatch | null
   /** Relation policy: replace or append on the update path (multi-valued only). */
   linkMode: RelationLinkMode | null
+  /** How this column's cells mark decimals, `.` or `,`; null means per-cell detection. */
+  numberDecimalSeparator: string | null
   /**
    * Distinct raw values in THIS column of THIS file. `distinctValueCount <
    * totalValueCount` on a identifier column is the failure field-level `isUnique`
@@ -144,6 +146,9 @@ export interface ColumnFieldConfig {
   /** `ImportMapping.entityDefinitionId` — the resource this column targets */
   entityDefinitionId?: string
   options?: SelectOption[]
+  /** CURRENCY targets only: what the resolved minor units are denominated in, and the field's precision */
+  currencyCode?: string
+  decimals?: number
 }
 
 // Re-export ImportableField from the lib package's CLIENT barrel, the server

--- a/apps/web/src/components/data-import/value-review/editing-input.tsx
+++ b/apps/web/src/components/data-import/value-review/editing-input.tsx
@@ -6,6 +6,7 @@ import { FieldType } from '@auxx/database/enums'
 import { isOptionResolutionType } from '@auxx/lib/import/client'
 import { getFieldOutputKey } from '@auxx/lib/resources/client'
 import { Input } from '@auxx/ui/components/input'
+import { minorToMajorString, parseMajorToMinor } from '@auxx/utils/currency'
 import { useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { useResourceFields } from '~/components/resources'
@@ -29,13 +30,23 @@ function sameKeys(a: string[], b: string[]): boolean {
   return sortedA.every((key, i) => key === sortedB[i])
 }
 
+/** A resolved or overridden minor-unit amount as a number, or undefined when there is none. */
+function readMinorUnits(text: string | null | undefined): number | undefined {
+  if (text === null || text === undefined || text.trim() === '') return undefined
+  const n = Number(text)
+  return Number.isFinite(n) ? n : undefined
+}
+
 /**
  * Component for editing value overrides.
  *
  * Option columns (`select:*` / `multiselect:*`) render the real select picker
  * via `FieldInputAdapter`, showing labels (`TagsView` chips inside the trigger)
- * instead of raw option keys. Everything else renders a text input that saves
- * on blur.
+ * instead of raw option keys. Money columns (a CURRENCY target field) render
+ * the currency input: the resolver's answer is MINOR units, and `1594` in a
+ * text box beside a cell reading `15.94` looks like a hundredfold error, while
+ * a rate resolved to `1.594` looks like a wrong one. Everything else renders a
+ * text input that saves on blur.
  */
 export function EditingInput({
   fieldConfig,
@@ -155,6 +166,67 @@ export function EditingInput({
       return
     }
     onSave(keys.map((value) => ({ type: 'value' as const, value })))
+  }
+
+  // ── Money editor ───────────────────────────────────────────────────
+  // The input works in minor units (what the resolver produced). What is
+  // SAVED is text the column's own resolver reads back: a major-unit string
+  // for `currency:major` (`1.594` → `0.01594`, at the field's precision), the
+  // minor-unit number itself for a column read as raw cents. The server
+  // re-resolves the override either way, so the two stay one contract.
+  const isMoneyColumn = fieldConfig?.type === 'currency' && !!fieldConfig.currencyCode
+  const currencyCode = fieldConfig?.currencyCode ?? 'USD'
+  const decimals = fieldConfig?.decimals
+  const toOverrideText = (minor: number): string =>
+    resolutionType === 'number:integer'
+      ? String(minor)
+      : minorToMajorString(minor, currencyCode, decimals)
+
+  // The EFFECTIVE minor-unit amount. An override is what the row displays
+  // (the optimistic cache patch writes `overrideValues`, not `resolvedValue`),
+  // so it is read back through the same conversion that produced it; otherwise
+  // `resolvedValue` is the resolver's answer. An unreadable cell has neither,
+  // and its raw text must never be read as minor units.
+  const overrideText = isOverridden && !isSkipped ? overrideValues?.[0]?.value : undefined
+  const moneyValue =
+    overrideText === undefined
+      ? readMinorUnits(resolvedValue)
+      : overrideText.trim() === ''
+        ? undefined
+        : resolutionType === 'number:integer'
+          ? readMinorUnits(overrideText)
+          : (parseMajorToMinor(overrideText, currencyCode, decimals) ?? undefined)
+
+  const handleMoneyChange = (next: unknown) => {
+    const minor = typeof next === 'number' && Number.isFinite(next) ? next : undefined
+
+    if (minor === undefined) {
+      // Cleared. Same override the text editor writes for an emptied cell: a
+      // blank the resolver reads as "import nothing".
+      if (moneyValue === undefined) return
+      onSave([{ type: 'value', value: '' }])
+      return
+    }
+    if (minor === moneyValue) return
+    onSave([{ type: 'value', value: toOverrideText(minor) }])
+  }
+
+  if (isMoneyColumn && fieldConfig) {
+    const value = moneyValue
+    return (
+      <div className='min-w-0 flex-1' title={rawValue}>
+        <FieldInputAdapter
+          fieldType={FieldType.CURRENCY}
+          fieldOptions={{ currencyCode, decimals }}
+          value={value ?? null}
+          onChange={handleMoneyChange}
+          // An unreadable cell has no resolved value; the cell text is the
+          // hint for what to type.
+          placeholder={value === undefined ? rawValue : undefined}
+          triggerProps={{ className: 'h-7' }}
+        />
+      </div>
+    )
   }
 
   // Option columns always render the picker — even with an empty live list —

--- a/apps/web/src/server/api/routers/data-import.ts
+++ b/apps/web/src/server/api/routers/data-import.ts
@@ -344,6 +344,8 @@ export const dataImportRouter = createTRPCRouter({
         identityRole: identityRoleSchema.nullish(),
         /** Same tri-state. Per-column write policy on the update path. */
         mergeStrategy: mergeStrategySchema.nullish(),
+        /** Same tri-state. How this column's cells mark decimals; `null` is per-cell detection. */
+        numberDecimalSeparator: z.enum(['.', ',']).nullish(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -372,6 +374,7 @@ export const dataImportRouter = createTRPCRouter({
         options: input.options,
         identityRole: input.identityRole,
         mergeStrategy: input.mergeStrategy,
+        numberDecimalSeparator: input.numberDecimalSeparator,
         naturalKeyFieldKeys: resource ? getNaturalKeyFieldKeys(resource) : undefined,
       })
 

--- a/packages/lib/src/import/fields/__tests__/valid-resolution-types.test.ts
+++ b/packages/lib/src/import/fields/__tests__/valid-resolution-types.test.ts
@@ -167,3 +167,19 @@ describe('getValidResolutionTypes — everything else', () => {
     ])
   })
 })
+
+describe('getValidResolutionTypes — a NUMBER field is a double', () => {
+  it('suggests the decimal reader, so a 7.5% rate or a 453.592 ratio survives', () => {
+    // `BaseType` has no integer/decimal split; `number:integer` used to be
+    // the default here and truncated every fraction without a word.
+    expect(suggestResolutionType(field({ type: 'number' }))).toBe('number:decimal')
+  })
+
+  it('keeps the strict whole-number reader on offer, suggestion first', () => {
+    expect(getValidResolutionTypes(field({ type: 'number' }))).toEqual([
+      'number:decimal',
+      'number:integer',
+      'text:value',
+    ])
+  })
+})

--- a/packages/lib/src/import/fields/resolution-type-labels.ts
+++ b/packages/lib/src/import/fields/resolution-type-labels.ts
@@ -31,9 +31,9 @@ export const RESOLUTION_TYPE_LABELS: Record<ResolutionType, ResolutionTypeLabel>
   'text:cuid': { label: 'Record ID', hint: 'The record’s internal ID, used to match' },
   'number:integer': {
     label: 'Whole number',
-    hint: 'No decimals — on a money field this is the raw cents value: 1234 → $12.34',
+    hint: 'No fraction, 12.5 is refused — on a money field this is the raw cents value: 1234 → $12.34',
   },
-  'number:decimal': { label: 'Decimal number', hint: 'Decimals kept: 12.34 → 12.34' },
+  'number:decimal': { label: 'Decimal number', hint: 'Fraction kept: 12.34 → 12.34, 7.5% → 7.5' },
   'currency:major': {
     label: 'Money amount',
     hint: 'What you would write on an invoice: 12.34 → $12.34, 1,234.56 → $1,234.56',

--- a/packages/lib/src/import/fields/suggest-resolution-type.ts
+++ b/packages/lib/src/import/fields/suggest-resolution-type.ts
@@ -45,20 +45,20 @@ export function suggestResolutionType(
 
   // Map field types to resolution types
   switch (field.type) {
+    // A NUMBER field is a double (`valueNumber`), and `BaseType` has no
+    // integer/decimal split, so this one case covers a quantity, a 7.5%
+    // tariff rate and a 453.592 purchase ratio alike. `number:decimal` reads
+    // every one of them exactly; `number:integer` used to be the default here
+    // and truncated the last two without a word.
     case 'number':
-    case 'integer':
-      return 'number:integer'
+      return 'number:decimal'
 
-    // Money is stored as INTEGER MINOR UNITS, so a decimal resolver is wrong
-    // twice over: `12.34` reaches the write path as `12.34` and is rejected
-    // ("CURRENCY values are integer minor units"), while `12` imports silently
-    // as 12 cents. `currency:major` scales by the field's own exponent.
+    // Money is stored as MINOR UNITS, so a decimal resolver is wrong twice
+    // over: `12.34` reaches the write path as `12.34` and is rejected, while
+    // `12` imports silently as 12 cents. `currency:major` scales by the
+    // field's own exponent and precision.
     case 'currency':
       return 'currency:major'
-
-    case 'decimal':
-    case 'float':
-      return 'number:decimal'
 
     case 'date':
       return 'date:iso'
@@ -188,9 +188,10 @@ function validResolutionTypesFor(field: ImportableField): ResolutionType[] {
   }
 
   switch (field.type) {
+    // `number:integer` stays on offer as the strict choice: it refuses a cell
+    // with a fraction, which is what a count column wants.
     case 'number':
-    case 'integer':
-      return ['number:integer', 'number:decimal', 'text:value']
+      return ['number:decimal', 'number:integer', 'text:value']
 
     // `number:integer` stays on offer for a file that ALREADY holds minor
     // units (an accounting export in cents). The labels are what keep the two

--- a/packages/lib/src/import/index.ts
+++ b/packages/lib/src/import/index.ts
@@ -269,6 +269,7 @@ export {
   resolveArraySplit,
   resolveBoolean,
   resolveColumnCurrencyCodes,
+  resolveColumnCurrencyFields,
   resolveColumnDecimals,
   resolveColumnOptions,
   resolveCurrencyMajor,

--- a/packages/lib/src/import/mapping/__tests__/identifier-lifecycle.test.ts
+++ b/packages/lib/src/import/mapping/__tests__/identifier-lifecycle.test.ts
@@ -900,3 +900,38 @@ describe('natural key defaults on after a hand REPAIR', () => {
     expect(db.mapping.defaultStrategy).toBe('create')
   })
 })
+
+describe('decimal separator, a per-column reading policy', () => {
+  let db: FakeDb
+
+  const storedSeparator = () =>
+    (JSON.parse(db.properties[0]?.resolutionConfig ?? '{}') as { numberDecimalSeparator?: string })
+      .numberDecimalSeparator
+
+  beforeEach(() => {
+    db = new FakeDb([column(0, { sourceColumnName: 'Price' })], {
+      identifierFieldKeys: [],
+      defaultStrategy: 'create',
+    })
+  })
+
+  it('is stored, kept across an unrelated re-save, and cleared by null', async () => {
+    await save(db, mapTo(0, 'vendor_part_unit_price', { numberDecimalSeparator: ',' }))
+    expect(storedSeparator()).toBe(',')
+
+    // A resolution-type change says nothing about the separator.
+    await save(db, mapTo(0, 'vendor_part_unit_price', { resolutionType: 'number:integer' }))
+    expect(storedSeparator()).toBe(',')
+
+    await save(db, mapTo(0, 'vendor_part_unit_price', { numberDecimalSeparator: null }))
+    expect(storedSeparator()).toBeUndefined()
+  })
+
+  it('is dropped when the column is retargeted', async () => {
+    await save(db, mapTo(0, 'vendor_part_unit_price', { numberDecimalSeparator: ',' }))
+
+    await save(db, mapTo(0, 'vendor_part_shipping_cost'))
+
+    expect(storedSeparator()).toBeUndefined()
+  })
+})

--- a/packages/lib/src/import/mapping/get-mappable-properties.ts
+++ b/packages/lib/src/import/mapping/get-mappable-properties.ts
@@ -102,6 +102,7 @@ export async function getMappablePropertiesWithSamples(
         // JSON purely to recover these two.
         onNoMatch: config.relationConfig?.onNoMatch ?? null,
         linkMode: config.relationConfig?.linkMode ?? null,
+        numberDecimalSeparator: config.numberDecimalSeparator ?? null,
         distinctValueCount: counts?.distinct ?? 0,
         totalValueCount: counts?.total ?? 0,
       }

--- a/packages/lib/src/import/mapping/get-mapped-columns.ts
+++ b/packages/lib/src/import/mapping/get-mapped-columns.ts
@@ -3,6 +3,9 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
+import { findCachedResource } from '../../cache'
+import { getFieldOutputKey } from '../../resources/registry/field-types'
+import { resolveColumnCurrencyFields } from '../resolution/resolve-currency-code'
 
 /**
  * Input for getting mapped columns with stats.
@@ -22,6 +25,13 @@ export interface MappedColumnWithStats {
   columnIndex: number
   columnName: string
   targetFieldKey: string | null
+  /** The target field's label, for the plan preview header; null when the field is gone */
+  targetFieldLabel: string | null
+  /** The target field's storage type (`FieldType`), so the preview renders a cell as the field would */
+  fieldType: string | null
+  /** CURRENCY targets only: the code and precision the preview formats minor units with */
+  currencyCode?: string
+  decimals?: number
   uniqueCount: number
   errorCount: number
   warningCount: number
@@ -138,13 +148,32 @@ export async function getMappedColumnsWithStats(
     }
   }
 
+  // The target fields themselves: label and type for the preview header and
+  // cell, plus code and precision for the money columns. The preview used to
+  // show the raw output key as the header and every value as text, so a unit
+  // price resolved to `1594` minor units read as "1594".
+  const entityDefinitionId = job.importMapping.entityDefinitionId
+  const resource = await findCachedResource(organizationId, entityDefinitionId)
+  const fieldByKey = new Map((resource?.fields ?? []).map((f) => [getFieldOutputKey(f), f]))
+  const currencyFields = await resolveColumnCurrencyFields(db, {
+    organizationId,
+    entityDefinitionId,
+    targetFieldKeys: mappedProperties.flatMap((p) => (p.targetFieldKey ? [p.targetFieldKey] : [])),
+  })
+
   // Build result
   return mappedProperties.map((prop) => {
     const mappable = mappableByIndex.get(prop.sourceColumnIndex)
+    const field = prop.targetFieldKey ? fieldByKey.get(prop.targetFieldKey) : undefined
+    const money = prop.targetFieldKey ? currencyFields.get(prop.targetFieldKey) : undefined
     return {
       columnIndex: prop.sourceColumnIndex,
       columnName: mappable?.visibleName ?? `Column ${prop.sourceColumnIndex}`,
       targetFieldKey: prop.targetFieldKey,
+      targetFieldLabel: field?.label ?? null,
+      fieldType: field?.fieldType ?? null,
+      currencyCode: money?.currencyCode,
+      decimals: money?.decimals,
       uniqueCount: countByColumn.get(prop.sourceColumnIndex) ?? 0,
       errorCount: errorByPropertyId.get(prop.id) ?? 0,
       warningCount: warningByPropertyId.get(prop.id) ?? 0,

--- a/packages/lib/src/import/mapping/save-mapping-property.ts
+++ b/packages/lib/src/import/mapping/save-mapping-property.ts
@@ -63,6 +63,13 @@ export interface SaveMappingInput {
    */
   mergeStrategy?: ImportMergeStrategy | null
   /**
+   * The decimal separator this column's cells use, `.` or `,`. Same tri-state
+   * as `mergeStrategy`: omit to keep what is stored, `null` to go back to
+   * per-cell detection. It is how a column's cells are READ, so a change
+   * invalidates the column's resolutions exactly like a resolution-type change.
+   */
+  numberDecimalSeparator?: '.' | ',' | null
+  /**
    * The resource's declared NATURAL KEY, in leg order, when it declares one.
    *
    * Same set auto-map receives, and it is here for the case auto-map cannot
@@ -317,6 +324,7 @@ export async function saveMappingProperty(db: Database, input: SaveMappingInput)
       // are about a field this column no longer feeds.
       identityRole: retargeted || unmapped ? undefined : stored.identityRole,
       mergeStrategy: retargeted || unmapped ? undefined : stored.mergeStrategy,
+      numberDecimalSeparator: retargeted || unmapped ? undefined : stored.numberDecimalSeparator,
     }
 
     // An explicit value in the same call wins over both the preserve and the
@@ -327,10 +335,18 @@ export async function saveMappingProperty(db: Database, input: SaveMappingInput)
     if (input.mergeStrategy !== undefined) {
       next.mergeStrategy = input.mergeStrategy ?? undefined
     }
+    if (input.numberDecimalSeparator !== undefined) {
+      next.numberDecimalSeparator = input.numberDecimalSeparator ?? undefined
+    }
+    // A separator change reads every cell differently (`1,5` is 15 or 1.5),
+    // so it invalidates the column like a resolution-type change does.
+    const separatorChanged =
+      (next.numberDecimalSeparator ?? null) !== (stored.numberDecimalSeparator ?? null)
     // An unmapped column is never part of the match key, whatever was requested.
     if (unmapped) {
       next.identityRole = undefined
       next.mergeStrategy = undefined
+      next.numberDecimalSeparator = undefined
     }
 
     // Update the mapping property
@@ -375,7 +391,7 @@ export async function saveMappingProperty(db: Database, input: SaveMappingInput)
     // …and re-resolution only re-resolves what is not already cached. A column
     // pointed at a new field, or read as a different type, has to lose its rows
     // or the re-run is a no-op behind a control that looks like it worked.
-    if (retargeted || reinterpreted) {
+    if (retargeted || reinterpreted || separatorChanged) {
       await invalidateColumnResolutions(tx, [current?.id])
     }
   })

--- a/packages/lib/src/import/planning/get-plan-preview-rows.ts
+++ b/packages/lib/src/import/planning/get-plan-preview-rows.ts
@@ -3,6 +3,7 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { and, desc, eq } from 'drizzle-orm'
+import { hashValue } from '../hashing/hash-value'
 import { getRawDataAsMap } from '../raw-data'
 import { getAllJobResolutions } from '../resolution'
 import type { StrategyType } from '../types/plan'
@@ -117,18 +118,19 @@ export async function getPlanPreviewRows(
       const cellValue = rowData[mapping.sourceColumnIndex]
       if (!cellValue) continue
 
-      // Look up resolution for this value
-      const resolutionKey = `${mapping.sourceColumnIndex}:${cellValue}`
-      const resolution = resolutions.get(resolutionKey)
+      // The cache is keyed by the hash of the raw cell, exactly as
+      // `analyzeRow` and `buildRecordData` read it. This used to look up
+      // `${columnIndex}:${cellValue}`, a key nothing ever wrote, so the
+      // preview showed the raw file text for every column, including money
+      // columns whose resolved value is minor units.
+      const resolution = resolutions.get(hashValue(cellValue))
 
-      if (resolution?.resolvedValues && resolution.resolvedValues.length > 0) {
-        // Use resolved value
-        const first = resolution.resolvedValues[0]
-        fields[mapping.targetFieldKey] = first?.value ?? cellValue
-      } else {
-        // Use raw value
-        fields[mapping.targetFieldKey] = cellValue
-      }
+      // A relation column resolves to a record id (or, before planning, a
+      // pending-lookup envelope). Neither means anything to a reviewer; the
+      // cell it was matched on does, so it is what the preview shows.
+      const isRelation = mapping.resolutionType?.startsWith('relation:') ?? false
+      const first = resolution?.resolvedValues?.[0]
+      fields[mapping.targetFieldKey] = isRelation ? cellValue : (first?.value ?? cellValue)
     }
 
     return {

--- a/packages/lib/src/import/resolution/__tests__/resolve-column-currency-fields.test.ts
+++ b/packages/lib/src/import/resolution/__tests__/resolve-column-currency-fields.test.ts
@@ -1,0 +1,77 @@
+// packages/lib/src/import/resolution/__tests__/resolve-column-currency-fields.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../cache', () => ({
+  findCachedResource: vi.fn(),
+}))
+vi.mock('../../../field-values/org-currency', () => ({
+  getOrgCurrencyCode: vi.fn(async () => 'EUR'),
+}))
+
+const { findCachedResource } = await import('../../../cache')
+const { getOrgCurrencyCode } = await import('../../../field-values/org-currency')
+const { resolveColumnCurrencyFields } = await import('../resolve-currency-code')
+
+const findCachedResourceMock = vi.mocked(findCachedResource)
+const getOrgCurrencyCodeMock = vi.mocked(getOrgCurrencyCode)
+
+const db = {} as never
+const scope = { organizationId: 'org_1', entityDefinitionId: 'vendor_part' }
+
+/** A registry field with only what the helper reads. */
+function field(key: string, type: string, options?: Record<string, unknown>) {
+  return { key, type, options, isSystem: true } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  findCachedResourceMock.mockResolvedValue({
+    fields: [
+      field('unitPrice', 'currency', { decimals: 5 }),
+      field('shippingCost', 'currency', { currencyCode: 'JPY' }),
+      field('leadTime', 'number'),
+      field('vendorSku', 'string'),
+    ],
+  } as never)
+})
+
+describe('resolveColumnCurrencyFields', () => {
+  it('answers only for CURRENCY target fields, whatever the column is read as', async () => {
+    const result = await resolveColumnCurrencyFields(db, {
+      ...scope,
+      targetFieldKeys: ['unitPrice', 'leadTime', 'vendorSku', 'missing'],
+    })
+
+    expect([...result.keys()]).toEqual(['unitPrice'])
+  })
+
+  it('carries the field precision and resolves the code through field then org', async () => {
+    const result = await resolveColumnCurrencyFields(db, {
+      ...scope,
+      targetFieldKeys: ['unitPrice', 'shippingCost'],
+    })
+
+    // A rate field: five places, org currency.
+    expect(result.get('unitPrice')).toEqual({ currencyCode: 'EUR', decimals: 5 })
+    // A field with its own code and no declared precision.
+    expect(result.get('shippingCost')).toEqual({ currencyCode: 'JPY', decimals: undefined })
+  })
+
+  it('does not read org settings when no money column is asked about', async () => {
+    const result = await resolveColumnCurrencyFields(db, {
+      ...scope,
+      targetFieldKeys: ['leadTime'],
+    })
+
+    expect(result.size).toBe(0)
+    expect(getOrgCurrencyCodeMock).not.toHaveBeenCalled()
+  })
+
+  it('is empty for an empty key list without touching the cache', async () => {
+    const result = await resolveColumnCurrencyFields(db, { ...scope, targetFieldKeys: [] })
+
+    expect(result.size).toBe(0)
+    expect(findCachedResourceMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/import/resolution/get-unique-values-with-status.ts
+++ b/packages/lib/src/import/resolution/get-unique-values-with-status.ts
@@ -15,6 +15,7 @@ import {
 } from './effective-status'
 import { isOptionResolutionType, resolveOptionLabel } from './option-labels'
 import { resolveColumnOptions } from './resolve-column-options'
+import { resolveColumnCurrencyFields } from './resolve-currency-code'
 import { isPendingRelationLookup } from './resolvers/relation'
 
 export type { EffectiveStatus, ResolutionStatus } from './effective-status'
@@ -234,6 +235,24 @@ export async function getUniqueValuesWithResolution(
 
   // Build field config from mapping property
   const fieldConfig = buildFieldConfig(mappingProp, entityDefinitionId)
+
+  // A money column's resolved value is MINOR units. The review row shows it as
+  // money, and for that it needs the field's code and precision, resolved live
+  // for the same reason the option list below is: both describe the target
+  // field, not a choice the user made about the column.
+  if (fieldConfig) {
+    const currencyFields = await resolveColumnCurrencyFields(db, {
+      organizationId,
+      entityDefinitionId,
+      targetFieldKeys: [fieldConfig.key],
+    })
+    const money = currencyFields.get(fieldConfig.key)
+    if (money) {
+      fieldConfig.type = 'currency'
+      fieldConfig.currencyCode = money.currencyCode
+      fieldConfig.decimals = money.decimals
+    }
+  }
 
   // Overlay the LIVE option list for select-ish columns, same rule as
   // `resolve-values-job`: the live list WINS, the stored snapshot only stands

--- a/packages/lib/src/import/resolution/index.ts
+++ b/packages/lib/src/import/resolution/index.ts
@@ -90,9 +90,12 @@ export {
 export { type ResolveColumnOptionsInput, resolveColumnOptions } from './resolve-column-options'
 // CURRENCY denomination and precision for `currency:*` columns, resolved at RUN time
 export {
+  type ColumnCurrencyField,
   type ResolveColumnCurrencyCodesInput,
+  type ResolveColumnCurrencyFieldsInput,
   type ResolveColumnDecimalsInput,
   resolveColumnCurrencyCodes,
+  resolveColumnCurrencyFields,
   resolveColumnDecimals,
 } from './resolve-currency-code'
 // Relation lookup resolution

--- a/packages/lib/src/import/resolution/resolve-currency-code.ts
+++ b/packages/lib/src/import/resolution/resolve-currency-code.ts
@@ -5,6 +5,7 @@ import { findCachedResource } from '../../cache'
 import { resolveCurrencyCode } from '../../field-values/converters/currency'
 import { getOrgCurrencyCode } from '../../field-values/org-currency'
 import { getFieldOutputKey } from '../../resources/registry/field-types'
+import { BaseType } from '../../resources/types'
 
 /** What {@link resolveColumnCurrencyCodes} needs to answer for a whole mapping */
 export interface ResolveColumnCurrencyCodesInput {
@@ -116,4 +117,60 @@ export async function resolveColumnDecimals(
   }
 
   return decimals
+}
+
+/** What {@link resolveColumnCurrencyFields} needs to answer for a set of columns */
+export interface ResolveColumnCurrencyFieldsInput {
+  organizationId: string
+  /** `ImportMapping.entityDefinitionId` — the resource every column targets */
+  entityDefinitionId: string
+  /** `targetFieldKey` of the columns to check; non-money keys are simply absent from the answer */
+  targetFieldKeys: string[]
+}
+
+/** How a CURRENCY target field denominates and displays its minor units. */
+export interface ColumnCurrencyField {
+  /** ISO 4217 code, resolved through the field → org → USD chain */
+  currencyCode: string
+  /** The field's declared major-unit precision (`options.decimals`), when it declares one */
+  decimals?: number
+}
+
+/**
+ * The currency code and precision of every column whose TARGET FIELD is a
+ * CURRENCY field, whatever resolution type the column uses.
+ *
+ * The two helpers above are keyed on the column being read with `currency:*`.
+ * This one is keyed on the FIELD, because the review and confirm steps need to
+ * show a resolved minor-unit number as money regardless of how it was read: a
+ * `number:integer` column feeding Unit Price still resolves to cents, and a
+ * bare `1594` beside `$15.94` in the file reads as a hundredfold error.
+ *
+ * @param db - Database instance (for the org-settings read)
+ * @param input - Org, target resource and the column keys to look up
+ * @returns Map of `targetFieldKey` → code and precision, CURRENCY fields only
+ */
+export async function resolveColumnCurrencyFields(
+  db: Database | Transaction,
+  input: ResolveColumnCurrencyFieldsInput
+): Promise<Map<string, ColumnCurrencyField>> {
+  const result = new Map<string, ColumnCurrencyField>()
+  if (input.targetFieldKeys.length === 0) return result
+
+  const resource = await findCachedResource(input.organizationId, input.entityDefinitionId)
+  const wanted = new Set(input.targetFieldKeys)
+  const moneyFields = (resource?.fields ?? []).filter(
+    (field) => field.type === BaseType.CURRENCY && wanted.has(getFieldOutputKey(field))
+  )
+  if (moneyFields.length === 0) return result
+
+  const orgCurrencyCode = await getOrgCurrencyCode(input.organizationId, db)
+  for (const field of moneyFields) {
+    const decimals = field.options?.decimals
+    result.set(getFieldOutputKey(field), {
+      currencyCode: resolveCurrencyCode(field.options?.currencyCode, orgCurrencyCode),
+      decimals: typeof decimals === 'number' ? decimals : undefined,
+    })
+  }
+  return result
 }

--- a/packages/lib/src/import/resolution/resolvers/__tests__/number.test.ts
+++ b/packages/lib/src/import/resolution/resolvers/__tests__/number.test.ts
@@ -1,0 +1,107 @@
+// packages/lib/src/import/resolution/resolvers/__tests__/number.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ResolutionConfig } from '../../../types/resolution'
+import { resolveDecimal, resolveInteger } from '../number'
+
+const none: ResolutionConfig = {}
+const comma: ResolutionConfig = { numberDecimalSeparator: ',' }
+
+/** The resolved number, or a marker so a failure reads clearly. */
+function read(
+  resolve: typeof resolveInteger,
+  raw: string,
+  config: ResolutionConfig = none
+): number | string | null | undefined {
+  const result = resolve(raw, config)
+  return result.type === 'error' ? `ERROR: ${result.error}` : (result.value as number | null)
+}
+
+describe('resolveInteger — the truncation this exists to stop', () => {
+  it('refuses a fraction instead of dropping it', () => {
+    // `parseInt('7.5')` is 7: a 7.5% tariff rate imported as 7%, silently.
+    expect(read(resolveInteger, '7.5')).toMatch(/not a whole number/)
+  })
+
+  it('refuses a fractional minor unit on a raw-cents column', () => {
+    // A per-thousand price list exported in cents carries `1.594` for the
+    // nut; `parseInt` made it 1 cent.
+    expect(read(resolveInteger, '1.594')).toMatch(/not a whole number/)
+  })
+
+  it('refuses trailing text instead of reading the numeric prefix', () => {
+    expect(read(resolveInteger, '12abc')).toMatch(/Invalid integer/)
+  })
+
+  it('points the user at the type that keeps the fraction', () => {
+    expect(read(resolveInteger, '2.5')).toMatch(/Decimal number/)
+  })
+})
+
+describe('resolveInteger — what it accepts', () => {
+  it('reads a plain, signed, or grouped whole number', () => {
+    expect(read(resolveInteger, '42')).toBe(42)
+    expect(read(resolveInteger, '-42')).toBe(-42)
+    expect(read(resolveInteger, '+42')).toBe(42)
+    expect(read(resolveInteger, '1,234,567')).toBe(1234567)
+    expect(read(resolveInteger, '1 234')).toBe(1234)
+  })
+
+  it('reads a blank cell as null', () => {
+    expect(read(resolveInteger, '')).toBeNull()
+    expect(read(resolveInteger, '   ')).toBeNull()
+  })
+
+  it('drops a trailing percent sign', () => {
+    expect(read(resolveInteger, '25%')).toBe(25)
+  })
+
+  it('accepts a lossless zero fraction', () => {
+    expect(read(resolveInteger, '12.0')).toBe(12)
+    expect(read(resolveInteger, '12.00')).toBe(12)
+    expect(read(resolveInteger, '12.10')).toMatch(/not a whole number/)
+  })
+
+  it('reads a comma decimal column by its configured separator', () => {
+    expect(read(resolveInteger, '1.234', comma)).toBe(1234)
+    expect(read(resolveInteger, '1,5', comma)).toMatch(/not a whole number/)
+  })
+
+  it('refuses a value too large to store exactly', () => {
+    expect(read(resolveInteger, '99999999999999999999')).toMatch(/too large/)
+  })
+})
+
+describe('resolveDecimal', () => {
+  it('keeps the fraction', () => {
+    expect(read(resolveDecimal, '7.5')).toBe(7.5)
+    expect(read(resolveDecimal, '453.592')).toBe(453.592)
+    expect(read(resolveDecimal, '.5')).toBe(0.5)
+    expect(read(resolveDecimal, '-0.25')).toBe(-0.25)
+  })
+
+  it('reads a percent cell as its number', () => {
+    // "Tariff Rate (%)" stores 7.5 for 7.5%.
+    expect(read(resolveDecimal, '7.5%')).toBe(7.5)
+  })
+
+  it('strips grouping under the default separator', () => {
+    expect(read(resolveDecimal, '1,234.56')).toBe(1234.56)
+  })
+
+  it('reads a comma decimal column by its configured separator', () => {
+    expect(read(resolveDecimal, '1.234,56', comma)).toBe(1234.56)
+    expect(read(resolveDecimal, '7,5', comma)).toBe(7.5)
+  })
+
+  it('refuses text instead of reading the numeric prefix', () => {
+    // `parseFloat('12abc')` is 12.
+    expect(read(resolveDecimal, '12abc')).toMatch(/Invalid number/)
+    expect(read(resolveDecimal, 'abc')).toMatch(/Invalid number/)
+    expect(read(resolveDecimal, '1.2.3')).toMatch(/Invalid number/)
+  })
+
+  it('reads a blank cell as null', () => {
+    expect(read(resolveDecimal, '')).toBeNull()
+  })
+})

--- a/packages/lib/src/import/resolution/resolvers/number.ts
+++ b/packages/lib/src/import/resolution/resolvers/number.ts
@@ -2,22 +2,65 @@
 
 import type { ResolutionConfig, ResolvedValue } from '../../types/resolution'
 
+/** Grouping characters that never mark a decimal point: spaces and the Swiss apostrophe. */
+const GROUPING_NOISE = /[\s'\u2019]/g
+
 /**
- * Resolve value as integer.
+ * Reduce a human-written number to `[-+]?digits[.digits]`, or null when the
+ * cell holds anything else.
+ *
+ * Grouping is stripped, the column's configured decimal separator (or `.` by
+ * default) is normalised to `.`, and ONE trailing percent sign is dropped: a
+ * NUMBER field labelled "Tariff Rate (%)" stores `7.5` for a cell reading
+ * `7.5%`, and the sign carries nothing the field does not already declare.
+ *
+ * `parseInt` / `parseFloat` are deliberately not used. Both read the longest
+ * numeric prefix and ignore the rest, so `12abc` was 12, `7.5` was 7 on a
+ * whole-number column, and `1.594` (a fractional cent in a minor-unit file)
+ * was 1. A silent truncation is the one thing an importer must never do.
  */
-export function resolveInteger(rawValue: string, _config: ResolutionConfig): ResolvedValue {
+function normalizeNumberText(rawValue: string, config: ResolutionConfig): string | null {
+  let text = rawValue.trim().replace(/%$/, '').replace(GROUPING_NOISE, '')
+  if (config.numberDecimalSeparator === ',') {
+    text = text.replace(/\./g, '').replace(',', '.')
+  } else {
+    text = text.replace(/,/g, '')
+  }
+  return /^[-+]?(\d+\.?\d*|\.\d+)$/.test(text) ? text : null
+}
+
+/**
+ * Resolve value as a whole number.
+ *
+ * A cell with a fraction is a row error, never rounded or truncated: on a
+ * money column read as minor units this is a fractional cent, and on a NUMBER
+ * column it is a value the "Decimal number" type keeps intact.
+ */
+export function resolveInteger(rawValue: string, config: ResolutionConfig): ResolvedValue {
   const trimmed = rawValue.trim()
 
   if (!trimmed) {
     return { type: 'value', value: null }
   }
 
-  // Remove thousand separators
-  const cleaned = trimmed.replace(/,/g, '')
-  const parsed = parseInt(cleaned, 10)
-
-  if (Number.isNaN(parsed)) {
+  const normalized = normalizeNumberText(trimmed, config)
+  if (normalized === null) {
     return { type: 'error', error: `Invalid integer: ${rawValue}` }
+  }
+  // A zero fraction (`12.0`, `12.00`) is lossless and common in exports.
+  const text = normalized.replace(/\.0*$/, '')
+  if (!/^[-+]?\d+$/.test(text)) {
+    return {
+      type: 'error',
+      error:
+        `"${rawValue}" is not a whole number. Read the column as "Decimal number" to keep ` +
+        'the fraction, or round it in the file.',
+    }
+  }
+
+  const parsed = Number(text)
+  if (!Number.isSafeInteger(parsed)) {
+    return { type: 'error', error: `Invalid integer: ${rawValue} is too large to store exactly` }
   }
 
   return { type: 'value', value: parsed }
@@ -33,18 +76,10 @@ export function resolveDecimal(rawValue: string, config: ResolutionConfig): Reso
     return { type: 'value', value: null }
   }
 
-  let cleaned = trimmed
+  const text = normalizeNumberText(trimmed, config)
+  const parsed = text === null ? Number.NaN : Number(text)
 
-  // Handle European decimal separator
-  if (config.numberDecimalSeparator === ',') {
-    cleaned = cleaned.replace(/\./g, '').replace(',', '.')
-  } else {
-    cleaned = cleaned.replace(/,/g, '')
-  }
-
-  const parsed = parseFloat(cleaned)
-
-  if (Number.isNaN(parsed)) {
+  if (!Number.isFinite(parsed)) {
     return { type: 'error', error: `Invalid number: ${rawValue}` }
   }
 

--- a/packages/lib/src/import/types/mapping.ts
+++ b/packages/lib/src/import/types/mapping.ts
@@ -132,6 +132,8 @@ export interface MappablePropertyWithSamples {
   onNoMatch: RelationOnNoMatch | null
   /** Replace-or-append for a multi-valued relation on the update path. */
   linkMode: RelationLinkMode | null
+  /** How this column's cells mark decimals, `.` or `,`; null means per-cell detection. */
+  numberDecimalSeparator: string | null
   /**
    * Distinct raw values in THIS column of THIS file.
    *

--- a/packages/lib/src/import/types/resolution.ts
+++ b/packages/lib/src/import/types/resolution.ts
@@ -218,11 +218,20 @@ export interface OverrideValue {
  */
 export interface ColumnFieldConfig {
   key: string
-  type: string // BaseType: 'text', 'number', 'enum', 'relationship', etc.
+  type: string // BaseType: 'text', 'number', 'currency', 'enum', 'relationship', etc.
   resolutionType: string // e.g., 'select:value', 'relation:match'
   /** `ImportMappingProperty.customFieldId` — null for system fields */
   customFieldId?: string | null
   /** `ImportMapping.entityDefinitionId` — the resource this column targets */
   entityDefinitionId?: string
   options?: SelectOption[]
+  /**
+   * Set when the TARGET FIELD is a CURRENCY field, whatever the column's
+   * resolution type. The resolved value is minor units (`1594`, or `1.594`
+   * on a rate field), and the review step needs the code and the field's
+   * precision to show that as `$15.94` / `$0.01594` rather than as a bare
+   * number. Resolved live, like `options`, never from the stored config.
+   */
+  currencyCode?: string
+  decimals?: number
 }


### PR DESCRIPTION
## What

The supplier-price importer, run end to end for the first time against a per-thousand price list (`0.01594` per each), with the defects that stood in the way fixed.

- **Review step showed money as raw minor units** (`15.94 -> 1594`, a rate as `1.594`). It now renders a currency input at the target field's code and precision; a typed amount is a major-unit string the column's own resolver reads back. `ColumnFieldConfig` carries `currencyCode` and `decimals` for CURRENCY targets, resolved live like the option list.
- **NUMBER fields truncated silently.** Every NUMBER field defaulted to `number:integer`, whose `parseInt` turned `7.5` into 7 and marked it valid. NUMBER now suggests `number:decimal`; `number:integer` refuses a fraction with an error naming the fix; both refuse trailing text; a trailing `%` is dropped; `12.0` is accepted.
- **The decimal separator had no UI.** The resolver's ambiguity error said "set the column's decimal separator" and nothing could. The Read-as popover gains a Decimal separator section for `currency:major` / `number:decimal`, stored as `resolutionConfig.numberDecimalSeparator` with the same tri-state as `mergeStrategy`; a change invalidates the column's resolutions.
- **Confirm-step preview** showed raw output keys as headers and the file's text in every cell: `getPlanPreviewRows` looked resolutions up by `${column}:${rawText}` while the cache is keyed by `hashValue(raw)`, so it never matched. Keyed by hash like every other reader; `getMappedColumnsWithStats` returns the field's label, type, code and precision so CURRENCY and NUMBER cells render as the field would; relation columns stay on the matched-on cell text.

## Verified

- Driven on dev (`Import supplier prices` from the parts page): five `vendor_part` rows created, zero failed. Stored unit prices `1.594 / 1234.56 / 123456 / 123 / 1.594` minor units, tariff rate `7.5`, purchase ratio `1000` and `500`, tariff code matched on its label. The write guard accepted every five-place rate.
- `0.015941` (six places) and `1.234` (ambiguous) refused with row errors; both fixed through the new money editor and re-resolved to `1.594` and `123`.
- 431 tests in `packages/lib/src/import` pass, including new ones for the number resolver, the NUMBER default, the currency-field helper, and the separator tri-state. Lib and web typecheck ratchets add nothing. Biome clean.

## Found, not fixed (recorded in `plans/importer/08-named-importers.md` section 10)

- `getAllJobResolutions` keys by `hashedValue` alone, so two columns with identical raw text collapse to one entry.
- The stepper's "N errors to fix" does not move when an error is overridden in review.
- The dev server kept serving the pre-fix `getPlanPreviewRows` module after the lib dist rebuilt; the source, run directly, returns the matched-on text for relation columns.

https://claude.ai/code/session_018aVfuaRK73JBha148nsFkb
