### PR TITLE
fix(ui): the settings header button stacks until lg, and the detail pane grows the page

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
@@ -64,8 +64,7 @@ export default function AppsInstalledListPage() {
         { title: 'Settings', href: '/app/settings' },
         { title: 'Apps', href: '/app/settings/apps' },
         { title: 'Installed' },
-      ]}
-      button={<></>}>
+      ]}>
       <ConfirmDialog />
       <div className='flex flex-col flex-1 p-3 sm:p-6 space-y-6 @container'>
         <Input

--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 // ~/app/(protected)/app/settings/integrations/_components/integration-list.tsx
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { dedupeInstallationsByApp } from '~/components/apps/dedupe-installations'
 import { useUninstallApp } from '~/components/apps/hooks/use-uninstall-app'
 import { AppIcon } from '~/components/apps/ui/app-icon'
@@ -44,6 +44,12 @@ const iconMap = {
 
 /** Flag to control whether to show empty categories */
 const SHOW_EMPTY_CATEGORIES = false
+/** Air between the settings header and the stuck search bar, so it sits clear of the header's scroll shadow. */
+const STICKY_INSET = 12
+/** Gap between the stuck search bar and a section scrolled up to meet it. */
+const SECTION_GAP = 10
+/** How far past that line a section's top must be before it becomes the active category. */
+const ACTIVATION_BUFFER = 20
 
 /**
  * IntegrationList component
@@ -124,30 +130,49 @@ export default function IntegrationList() {
 
   // Create refs for each category section
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({})
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  // The stuck search-and-categories block. Measured, never assumed: its height
+  // changes with the breakpoint, and the header above it changes with the page.
+  const stickyRef = useRef<HTMLDivElement | null>(null)
 
   // Track active category based on scroll position
   const [activeCategory, setActiveCategory] = useState<string | null>(null)
 
+  /**
+   * Where content becomes visible, in window coordinates: the scroll viewport's
+   * top, plus the settings header it publishes as `--settings-sticky-top`, plus
+   * the stuck search block. A section scrolled to here sits just under the
+   * search bar. `null` before the DOM is ready.
+   */
+  const contentTop = useCallback(() => {
+    const sticky = stickyRef.current
+    const viewport = sticky?.closest<HTMLElement>('[data-slot="scroll-area-viewport"]')
+    if (!sticky || !viewport) return null
+    const headerHeight =
+      Number.parseFloat(getComputedStyle(viewport).getPropertyValue('--settings-sticky-top')) || 0
+    return {
+      viewport,
+      y:
+        viewport.getBoundingClientRect().top +
+        headerHeight +
+        STICKY_INSET +
+        sticky.offsetHeight +
+        SECTION_GAP,
+    }
+  }, [])
+
   // Scroll to category section
   const scrollToCategory = (categoryValue: string) => {
     const section = sectionRefs.current[categoryValue]
-    if (section) {
-      const scrollContainer = document.querySelector('[data-slot="settings-page"]')
-      if (scrollContainer) {
-        const rect = section.getBoundingClientRect()
-        const scrollTop = scrollContainer.scrollTop
-        const offset = 130 // Account for sticky header (80px) + input field (40px) + spacing (10px)
-
-        scrollContainer.scrollTo({
-          top: scrollTop + rect.top - offset,
-          behavior: 'smooth',
-        })
-      } else {
-        // Fallback
-        section.scrollIntoView({ behavior: 'smooth', block: 'start' })
-      }
+    if (!section) return
+    const target = contentTop()
+    if (!target) {
+      section.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      return
     }
+    target.viewport.scrollTo({
+      top: target.viewport.scrollTop + section.getBoundingClientRect().top - target.y,
+      behavior: 'smooth',
+    })
   }
 
   // Track scroll position to update active category using IntersectionObserver
@@ -169,10 +194,10 @@ export default function IntegrationList() {
           updateTimeout = setTimeout(() => {
             // Check all sections, not just the ones in entries
             let bestCategory: string | null = null
-            const stickyHeaderOffset = 80 // pt-20 = 5rem = 80px
-            const inputFieldHeight = 40 // Input field height
-            const spacing = 10 // Additional spacing
-            const activationPoint = stickyHeaderOffset + inputFieldHeight + spacing + 20 // 150px total with 20px buffer
+            const target = contentTop()
+            if (!target) return
+            // A little past the search bar, so a section counts once it is clearly the one on show.
+            const activationPoint = target.y + ACTIVATION_BUFFER
 
             // Loop through categories in order and find the LAST one that has passed the activation point
             for (const category of categoriesToDisplay) {
@@ -221,7 +246,7 @@ export default function IntegrationList() {
         observer.disconnect()
       }
     }
-  }, [categoriesToDisplay]) // Re-run when categories change
+  }, [categoriesToDisplay, contentTop]) // Re-run when categories change
   // Members see only the Installed strip (all installed apps, no Browse marketplace).
   // Their rendering uses installation.app directly because `apps.list` is admin-only.
   const memberInstalledCards = installed.map((installation) => ({
@@ -244,8 +269,7 @@ export default function IntegrationList() {
           ? 'Manage your external service integrations for email, messaging, and telephony'
           : 'Manage your personal connections to installed apps.'
       }
-      breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Apps' }]}
-      button={<></>}>
+      breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Apps' }]}>
       <ConfirmDialog />
       <div className='flex flex-col flex-1 p-3 sm:p-6 space-y-8'>
         <SettingsSection
@@ -333,7 +357,10 @@ export default function IntegrationList() {
             title='Browse apps'
             description='Discover new apps to help you work better'>
             <div className='flex flex-col gap-6 justify-start w-full'>
-              <div className='sticky pt-20 -mt-20 top-0 z-11'>
+              <div
+                ref={stickyRef}
+                className='sticky z-11'
+                style={{ top: `calc(var(--settings-sticky-top, 0px) + ${STICKY_INSET}px)` }}>
                 <div className='grid sm:grid-cols-3 pb-4 sm:pb-0'>
                   <Input
                     placeholder='Search apps'
@@ -342,7 +369,7 @@ export default function IntegrationList() {
                     onChange={(e) => setSearchQuery(e.target.value)}
                   />
                 </div>
-                <div className='sm:absolute sm:left-0 sm:top-[80px] z-1 pointer-events-none sm:grid sm:grid-cols-3'>
+                <div className='sm:absolute sm:left-0 sm:top-0 z-1 pointer-events-none sm:grid sm:grid-cols-3'>
                   <div className='pointer-events-auto '>
                     <div className='flex flex-row sm:flex-col sm:space-y-1 space-x-2 sm:space-x-0 no-scrollbar overflow-x-auto sm:overflow-x-hidden '>
                       {categoriesToDisplay.map((category) => {

--- a/apps/web/src/components/ai/ui/ai-model-list.tsx
+++ b/apps/web/src/components/ai/ui/ai-model-list.tsx
@@ -135,8 +135,7 @@ export function AiModelsList({ initialUnifiedData }: AiModelsListProps) {
     <SettingsPage
       title='AI Models'
       description='Connect your AI provider to Auxx.Ai'
-      breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'AI Models' }]}
-      button={<div className='flex gap-2'></div>}>
+      breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'AI Models' }]}>
       {isLoading ? (
         <EmptyState
           icon={RefreshCw}
@@ -159,7 +158,7 @@ export function AiModelsList({ initialUnifiedData }: AiModelsListProps) {
         />
       ) : (
         <div className='flex-1 h-full shrink-0 flex flex-col @container'>
-          <div className='h-12 shrink-0 flex items-center justify-between border-b px-2 gap-2 bg-primary-200/50 dark:bg-primary-100/50 sticky top-[67px] z-10 backdrop-blur'>
+          <div className='h-12 shrink-0 flex items-center justify-between border-b px-2 gap-2 bg-primary-200/50 dark:bg-primary-100/50 sticky top-[var(--settings-sticky-top,0px)] z-10 backdrop-blur'>
             <div className='flex items-center gap-2'>
               {quotaStatus && (
                 <BadgeAiQuota

--- a/apps/web/src/components/chat-widget/ui/settings/preview-pane.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/preview-pane.tsx
@@ -36,7 +36,10 @@ export function PreviewPane({ channelId, className }: PreviewPaneProps) {
 
   return (
     <div className={cn('h-full', className)}>
-      <div className='sticky top-[128px] flex h-[680px] max-h-[calc(100vh-9rem)] flex-col gap-3 p-4'>
+      {/* `MasterDetailSplit` does the sticking. The cap is the room it has under the
+          settings header, in the variables `SettingsPage` publishes - `100vh` would
+          overshoot by the chrome around the scroll viewport. */}
+      <div className='flex h-[680px] max-h-[calc(var(--settings-viewport-h,100vh)-var(--settings-sticky-top,0px))] flex-col gap-3 p-4'>
         <div className='flex items-center justify-between'>
           <div className='text-sm font-medium text-muted-foreground'>Live preview</div>
           <ThemeToggle value={theme} onChange={setTheme} />

--- a/apps/web/src/components/global/master-detail-split.tsx
+++ b/apps/web/src/components/global/master-detail-split.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { DrawerHeader } from '@auxx/ui/components/drawer'
 import { cn } from '@auxx/ui/lib/utils'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMedia } from '~/hooks/use-media'
@@ -10,6 +11,12 @@ const STORAGE_PREFIX = 'master-detail-width'
 
 /** Below this the split collapses to one column and the detail moves into a drawer. */
 const DESKTOP_QUERY = '(min-width: 1024px)'
+
+/**
+ * The list never gets narrower than this on desktop, whatever the pane asks for.
+ * A 720px pane in a 1100px window would otherwise leave the list a sliver.
+ */
+const MIN_LIST_WIDTH = 360
 
 type MasterDetailSplitProps = {
   /**
@@ -52,6 +59,8 @@ type MasterDetailSplitProps = {
  * mobile.
  *
  * Drag the divider to resize; the width persists per `id`. Double-click resets it.
+ * The pane never pushes the list below `MIN_LIST_WIDTH`: a stored width that no
+ * longer fits the window is capped, not applied.
  *
  * @example
  * <MasterDetailSplit
@@ -77,6 +86,30 @@ export function MasterDetailSplit({
   className,
 }: MasterDetailSplitProps) {
   const isDesktop = useMedia(DESKTOP_QUERY)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const stickyRef = useRef<HTMLDivElement>(null)
+  // Whether the pane fits under the settings header. A sticky element taller than
+  // the room it has pins its top and buries its bottom until the list runs out,
+  // so a pane that does not fit is left in the flow and scrolls with the page.
+  const [paneFits, setPaneFits] = useState(true)
+  useEffect(() => {
+    const el = stickyRef.current
+    if (scroll !== 'page' || !el) return
+    const check = () => {
+      const styles = getComputedStyle(el)
+      const viewportH =
+        Number.parseFloat(styles.getPropertyValue('--settings-viewport-h')) || window.innerHeight
+      const top = Number.parseFloat(styles.getPropertyValue('--settings-sticky-top')) || 0
+      setPaneFits(el.offsetHeight <= viewportH - top)
+    }
+    check()
+    const observer = new ResizeObserver(check)
+    observer.observe(el)
+    // The room changes with the window, which resizes the scroll viewport, not this element.
+    const viewport = el.closest('[data-slot="scroll-area-viewport"]')
+    if (viewport) observer.observe(viewport)
+    return () => observer.disconnect()
+  }, [scroll])
   const [width, setWidth] = useState(defaultWidth)
   const [isDragging, setIsDragging] = useState(false)
   // Read in an effect, not in the initial state: localStorage is unavailable
@@ -100,6 +133,11 @@ export function MasterDetailSplit({
 
       const startX = e.clientX
       const startWidth = widthRef.current
+      // The drag stops where the list would fall below its floor, so the stored
+      // width is one this window can actually show. The CSS `min()` below covers
+      // the other direction: a window that shrinks AFTER the width was stored.
+      const containerWidth = containerRef.current?.clientWidth ?? Number.POSITIVE_INFINITY
+      const cap = Math.max(minWidth, Math.min(maxWidth, containerWidth - MIN_LIST_WIDTH))
       const previousCursor = document.body.style.cursor
       document.body.style.cursor = 'ew-resize'
       document.body.style.userSelect = 'none'
@@ -107,7 +145,7 @@ export function MasterDetailSplit({
       const handleMouseMove = (moveEvent: MouseEvent) => {
         // The pane is on the RIGHT, so dragging left widens it.
         const next = startWidth + (startX - moveEvent.clientX)
-        setWidth(Math.min(maxWidth, Math.max(minWidth, next)))
+        setWidth(Math.min(cap, Math.max(minWidth, next)))
       }
 
       const handleMouseUp = () => {
@@ -133,11 +171,20 @@ export function MasterDetailSplit({
   return (
     <>
       <div
+        ref={containerRef}
         className={cn(
-          'relative grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_var(--detail-pane-w,420px)]',
+          'relative grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_var(--detail-pane-col)]',
           className
         )}
-        style={{ '--detail-pane-w': `${width}px` } as React.CSSProperties}>
+        style={
+          {
+            '--detail-pane-w': `${width}px`,
+            // The column the pane actually gets: the user's width, capped so the
+            // list keeps its floor. `100%` resolves against this grid for both
+            // the track and the divider's `right`, so the two always agree.
+            '--detail-pane-col': `min(var(--detail-pane-w), calc(100% - ${MIN_LIST_WIDTH}px))`,
+          } as React.CSSProperties
+        }>
         <div className={cn('min-w-0', scroll === 'columns' && 'overflow-y-auto')}>{children}</div>
 
         {/* The divider doubles as the resize handle: a transparent strip straddling
@@ -149,7 +196,7 @@ export function MasterDetailSplit({
         <div
           onMouseDown={handleDragStart}
           onDoubleClick={handleReset}
-          style={{ right: 'var(--detail-pane-w)' }}
+          style={{ right: 'var(--detail-pane-col)' }}
           className='absolute inset-y-0 z-20 hidden w-2 translate-x-1/2 cursor-ew-resize lg:block'>
           <div
             className={cn(
@@ -169,14 +216,17 @@ export function MasterDetailSplit({
             /* `--settings-sticky-top` is published by `SettingsPage`, which owns the
                sticky title/tabs block above — pinning at a hardcoded `0` would slide
                this underneath it. `z-10` matches `FormSaveBar`, i.e. deliberately
-               below that header. */
+               below that header.
+
+               No height cap and no overflow: the pane is as tall as its content and
+               the PAGE grows to hold it, so there is one scrollbar. Capping it at the
+               viewport forced a second, overlaid scrollbar inside the pane and made
+               the page scroll by the breadcrumb bar's height even when nothing
+               overflowed. */
             <div
-              className='lg:sticky lg:z-10 lg:overflow-hidden'
-              style={{
-                top: 'var(--settings-sticky-top, 0px)',
-                maxHeight:
-                  'calc(var(--settings-viewport-h, 100vh) - var(--settings-sticky-top, 0px))',
-              }}>
+              ref={stickyRef}
+              className={cn(paneFits && 'lg:sticky lg:z-10')}
+              style={{ top: 'var(--settings-sticky-top, 0px)' }}>
               {pane}
             </div>
           ) : (
@@ -197,7 +247,13 @@ export function MasterDetailSplit({
           minWidth={320}
           maxWidth={480}
           title={paneTitle}>
-          {pane}
+          {/* The pane has no header of its own - on desktop the list beside it is
+              the context. In the drawer that context is gone, and on a phone the
+              drawer covers the whole list, so this header is the only way out. */}
+          <div className='flex min-h-0 flex-1 flex-col rounded-t-xl'>
+            <DrawerHeader title={paneTitle} onClose={() => onPaneClose?.()} />
+            <div className='min-h-0 flex-1 overflow-y-auto'>{pane}</div>
+          </div>
         </DockableDrawer>
       )}
     </>

--- a/apps/web/src/components/global/settings-page.tsx
+++ b/apps/web/src/components/global/settings-page.tsx
@@ -41,8 +41,25 @@ type Props = {
    * strip (e.g. an underlined `TabsList variant='outline'`).
    */
   subHeaderClassName?: string
+  /**
+   * The breakpoint from which `button` sits beside the title instead of below
+   * it. Defaults to `lg`: beside a button, a description of any length wraps
+   * into several lines at tablet widths. Lower it for a page whose description
+   * is a few words.
+   */
+  buttonBreakpoint?: 'sm' | 'md' | 'lg'
   backLink?: string
 }
+
+/**
+ * Static class strings per breakpoint: Tailwind only ships classes it can see in
+ * source, so the variant cannot be built from the prop at runtime.
+ */
+const HEADER_ROW_AT = {
+  sm: { row: 'sm:flex-row sm:items-center sm:pe-5', button: 'sm:ml-auto' },
+  md: { row: 'md:flex-row md:items-center md:pe-5', button: 'md:ml-auto' },
+  lg: { row: 'lg:flex-row lg:items-center lg:pe-5', button: 'lg:ml-auto' },
+} as const
 
 export default function SettingsPage({
   icon,
@@ -53,8 +70,10 @@ export default function SettingsPage({
   button,
   subHeader,
   subHeaderClassName,
+  buttonBreakpoint = 'lg',
   backLink,
 }: Props) {
+  const headerRow = HEADER_ROW_AT[buttonBreakpoint]
   breadcrumbs = breadcrumbs || []
 
   // Track scroll state for shadow effect
@@ -175,12 +194,9 @@ export default function SettingsPage({
         ref={stickyHeaderRef}
         className='sticky top-0 z-20 backdrop-blur-sm bg-background/80 rounded-tr-xl'>
         <div
-          className={cn(
-            'flex flex-col sm:flex-row sm:items-center gap-2 bg-muted/50 px-5 py-3 pe-2 sm:pe-5',
-            {
-              'ps-2': !!icon,
-            }
-          )}>
+          className={cn('flex flex-col gap-2 bg-muted/50 px-5 py-3 pe-2', headerRow.row, {
+            'ps-2': !!icon,
+          })}>
           <div className='flex items-center gap-2'>
             {icon && <div className='flex h-10 w-10 items-center justify-center'>{icon}</div>}
             <div className='me-3'>
@@ -188,7 +204,7 @@ export default function SettingsPage({
               {description && <div className='text-sm text-muted-foreground'>{description}</div>}
             </div>
           </div>
-          {button && <div className='sm:ml-auto shrink-0'>{button}</div>}
+          {button && <div className={cn('shrink-0', headerRow.button)}>{button}</div>}
         </div>
         {subHeader && (
           <div className={cn('border-t bg-background/60 px-3 py-2.5', subHeaderClassName)}>

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-classification-editor.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-classification-editor.tsx
@@ -121,8 +121,10 @@ function OfferForm({
         </div>
 
         <FieldPanel
-          orientation='horizontal'
-          breakpoint='md'
+          // Side by side at the default pane width, stacked in the mobile drawer
+          // or once the pane is dragged near its minimum.
+          orientation='responsive'
+          breakpoint='sm'
           resizeId='tariff-classification-detail'
           defaultLabelWidth={150}
           className='shrink-0 grow-0 p-0'>

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-code-editor.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-code-editor.tsx
@@ -124,7 +124,7 @@ export function TariffCodeEditor(props: TariffCodeEditorProps) {
     return (
       <div className='p-3'>
         <EmptySection
-          orientation='horizontal'
+          orientation='vertical'
           icon={<Globe />}
           title='Select a code'
           description='Or add one. A code is a classification for an origin, so 8481.80.9005 from China and from Germany are two of them.'
@@ -296,8 +296,11 @@ function TariffCodeForm({
     <div className='flex h-full min-h-0 flex-col p-3'>
       <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
         <FieldPanel
-          orientation='horizontal'
-          breakpoint='md'
+          // Labels beside the inputs at the default pane width, above them in the
+          // mobile drawer or once the pane is dragged near its minimum. `md` would
+          // stack at the default width too.
+          orientation='responsive'
+          breakpoint='sm'
           resizeId='tariff-code-detail'
           defaultLabelWidth={150}
           className='shrink-0 grow-0 p-0'>

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-rate-history.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-rate-history.tsx
@@ -417,7 +417,9 @@ function TariffRateForm({
   return (
     <div className='flex flex-col gap-2'>
       <FieldPanel
-        orientation='horizontal'
+        // Same pane as the code form above, so it stacks and unstacks with it.
+        orientation='responsive'
+        breakpoint='sm'
         resizeId='tariff-rate-form'
         defaultLabelWidth={160}
         className='p-0'>

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-starter-dialog.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-starter-dialog.tsx
@@ -245,8 +245,10 @@ export function TariffStarterDialog({
 
         <div className='flex flex-col gap-3 p-3'>
           <FieldPanel
-            orientation='horizontal'
-            breakpoint='md'
+            // The dialog is wide on desktop and phone-width on mobile, where the
+            // labels move above the inputs.
+            orientation='responsive'
+            breakpoint='sm'
             resizeId='tariff-starter-dialog'
             defaultLabelWidth={180}
             className='shrink-0 grow-0 p-0'>

--- a/docs/ui-design-guide.md
+++ b/docs/ui-design-guide.md
@@ -125,7 +125,7 @@ export default function WebhooksPage() {
 }
 ```
 
-- `SettingsPage` is the scroll container + sticky header (icon/title/description/breadcrumbs, optional `subHeader` for a tab strip, optional `button` top-right action). It handles the scroll-shadow-on-scroll effect itself — don't reimplement it.
+- `SettingsPage` is the scroll container + sticky header (icon/title/description/breadcrumbs, optional `subHeader` for a tab strip, optional `button` top-right action). It handles the scroll-shadow-on-scroll effect itself — don't reimplement it. The button sits below the title until `lg`, then beside it; pass `buttonBreakpoint='sm'` or `'md'` only for a page whose `description` is a few words and can share the row earlier. Anything sticky below the header reads its measured height from `--settings-sticky-top` (and the scroll viewport's from `--settings-viewport-h`) rather than a hardcoded offset — `MasterDetailSplit`, the AI models toolbar and the marketplace search all do.
 - Gate admin-only settings pages with `useUser({ requireRoles: [...] })` at the top, and gate paid features with `useFeatureFlags().hasAccess(FeatureKey.x)` — render an `EmptyState` (`~/components/global/empty-state`) with a lock icon when the org doesn't have access, don't just hide the page.
 - Body content is stacked `SettingsSection`s (`icon`, `title`, `description`, right-aligned `action`) inside a `flex flex-col gap-8 p-3 sm:p-6` wrapper — one section per logical group (e.g. "Webhooks" config + "Webhook Endpoints" list as two sections on one page).
 - **Empty/add-new tiles in a settings grid use `ListCard` with `variant='placeholder'`**, not a bespoke dashed box:


### PR DESCRIPTION
## What

**Master-detail split**
- The mobile drawer had no visible header, so on a phone there was no way back to the list. It now renders the shared `DrawerHeader` with the pane title and a close button, over a scrolling body.
- On desktop the pane can no longer push the list below 360px. The stored width is capped in CSS and the drag respects the same cap.
- The pane wrapper has no height cap any more. It is as tall as its content and the page grows to hold it, so there is one scrollbar instead of an overlaid inner one. It stays sticky only while it fits under the header; a taller pane drops into the flow and scrolls with the page. This also removes the permanent 40px page scroll that the viewport-sized pane caused.

**Settings header**
- The action button sits below the title until `lg`, then beside it. Beside a button, a description of any length wrapped into several lines at tablet widths. The breakpoint is a prop (`buttonBreakpoint`) with `lg` as the default.
- Everything positioned off the header height now reads the measured `--settings-sticky-top` instead of a hardcoded offset: the AI models toolbar (67px), the marketplace search block (80px, plus a category scroll that looked for a `data-slot` that never existed), and the chat widget preview pane, whose own sticky was inert inside the split.
- Three pages dropped an empty header button that cost them a flex gap in the stacked layout.

**Tariffs**
- The four field panels are `responsive` at the `sm` container breakpoint, so they stack in the mobile drawer and when the pane is dragged near its minimum, and stay side by side at the default pane width.

## Verified

Measured live in the browser on the tariffs page: no page scroll with an empty or short pane, the pane sticky in both; a long pane drops to static, the page grows by its overflow, and no inner scrollbar appears. Marketplace search and category scroll checked live at the header's new height.

## Notes

Lint and typecheck are clean on the touched files. The web ratchet reports one pre-existing error in the data-import work, unrelated to this branch.

https://claude.ai/code/session_01TLWa64CzQEEkHwYzJ5nD6Q
