### PR TITLE
fix(parts): the tariff defs stay out of the entity sidebar

### DIFF
--- a/packages/lib/src/seed/entity-migrations/migrations/119-tariff-schedule.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/119-tariff-schedule.ts
@@ -48,11 +48,17 @@ const VENDOR_PART_FIELD_KEYS = ['tariffCode'] as const
  *
  * ## What it adds
  *
- * Two defs, both `isVisible` with ordinary record CRUD (§12 d):
+ * Two defs, both `isVisible: false` with ordinary record CRUD:
  *
  *   tariff_code   code, country, description, + rates / vendorParts inverses
  *   tariff_rate   tariffCode, rate, effectiveFrom, authority,
  *                 chapter99Code, note
+ *
+ * The visibility flag is NOT set here - it is read off `SYSTEM_ENTITIES`, and
+ * the reversal of §12 d's `isVisible: true` is written up on those two entries.
+ * Short version: Parts > Settings > Tariffs is the door, so the entity sidebar
+ * should not auto-link a second one. This migration has not shipped in a
+ * release, so no org was seeded with the old value.
  *
  * And one field on the supplier offer:
  *

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -335,29 +335,42 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     // migration 119 and INERT: nothing resolves through it until somebody
     // classifies an offer, and a set `vendor_part_tariff_rate` still wins.
     //
-    // ✅ `isVisible` on purpose (§12 d), unlike `gl_account` beside it. A
-    // records-Full actor creating a tariff code decides nothing about where
-    // money lands; it is reference data. Visible also gets the importer, which
-    // matters because loading a schedule is a bulk job.
+    // 🛑 `isVisible: false`, like `gl_account` beside it - this REVERSES the
+    // §12 d decision, which read `true`. Parts > Settings > Tariffs is the door
+    // and it is a better one: the code list, the rate history, the
+    // classification editor and the starter catalogue all live there, so an
+    // auto-linked entity sidebar entry would be a second, dumber way into the
+    // same reference data. The cost is the record importer (§12 e), which was
+    // the argument for visible; the starter catalogue covers the bulk case it
+    // was meant to serve.
+    //
+    // Migration 119 reads THIS line rather than carrying its own flag, and it
+    // has not shipped in a release yet, so no org has been seeded `true`. If
+    // one has (a dev org that ran 119 early), `ensureEntityDefinitions` is
+    // insert-only and will not correct it - update the row by hand.
     entityType: 'tariff_code',
     apiSlug: 'tariff-codes',
     singular: 'Tariff Code',
     plural: 'Tariff Codes',
     icon: 'globe',
     color: 'teal',
-    isVisible: true,
+    isVisible: false,
   },
   {
     // The dated schedule behind a code. An ENTITY and not JSON on the code row
-    // (§12 f / §12.1): rows are importable, queryable across codes, and audited
+    // (§12 f / §12.1): rows are queryable across codes and audited
     // individually.
+    //
+    // Hidden with `tariff_code` above, for the same reason: the rate history
+    // reads under its code on Parts > Settings > Tariffs, where the dates mean
+    // something, and never as a flat list of loose percentages.
     entityType: 'tariff_rate',
     apiSlug: 'tariff-rates',
     singular: 'Tariff Rate',
     plural: 'Tariff Rates',
     icon: 'percent',
     color: 'teal',
-    isVisible: true,
+    isVisible: false,
   },
 ]
 


### PR DESCRIPTION
`tariff_code` and `tariff_rate` were seeded `isVisible: true`, so both auto-link into the entity sidebar as ordinary record types. Parts > Settings > Tariffs is the door that actually shipped — the code list, the rate history, the classification editor and the starter catalogue all live there — and a sidebar entry is a second, dumber way into the same reference data. Same argument as `gl_account` beside it, which is `isVisible: false` for the same reason.

## The decision this reverses

`plans/money/tasks/29-tariff-schedule.md` §12 d decided *visible*, earlier the same day. Two arguments were made for it and both are conceded here:

- **"A tariff code is reference data, not a control surface."** Still true, and it is why hiding is safe rather than a permission dodge — nothing about the gate changes, the record mutations assert what they always did.
- **"Visible also gets the importer, which matters because loading a schedule is a bulk job."** This is the real cost. But §12 e already recorded that `getImportableFields` filters on `creatable && !hidden && !relationship`, so `tariff_rate.tariffCode` was never importable and a spreadsheet of rates had no way to name its code. The starter catalogue (#2018) covers the bulk load the importer was meant to serve.

## Why no new migration

The flag is read off `SYSTEM_ENTITIES` at creation time by `ensureEntityDefinitions`, so migration 119 needs no change beyond the doc block that claimed both defs were visible. Migration **119 has not shipped in a release** — 0.1.226 (`1f3b69822`, 10:37) predates it and nothing has been released since — so no org was ever seeded with the old value. That is what makes this an edit to 119's inputs rather than a `110-build-visible`-style flip migration.

🛑 `ensureEntityDefinitions` is insert-only and will **not** correct an org that already holds the def. A dev DB that ran 119 early needs:

```sql
UPDATE "EntityDefinition" SET "isVisible" = false
WHERE "entityType" IN ('tariff_code','tariff_rate');
```

Applied to the local DB already (56 rows / 28 orgs). Bust the `entityDefs` / `resources` org cache after.

## Checks

- Typecheck ratchet: `lib: no new type errors (29 total, baseline 29)`.
- `vitest run src/seed`: 311 pass. One pre-existing failure, unrelated — `108-purchasing.test.ts > the inert payment entities stay inert (P13)` trips on the three `vendor-bill-delete-guard` files added in #2005, which name `vendor_payment` outside the allowed declaration list. Not touched here.

https://claude.ai/code/session_014Z7RMVNDkbMWKRh2sdam3X
