### PR TITLE
fix(fields): a DATE field is a calendar day stored at UTC midnight

### DIFF
--- a/apps/web/src/components/dynamic-table/utils/cell-coercion.test.ts
+++ b/apps/web/src/components/dynamic-table/utils/cell-coercion.test.ts
@@ -2,7 +2,7 @@
 
 import type { ResourceField } from '@auxx/lib/resources/client'
 import { toFieldId } from '@auxx/types/field'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { coerceForPaste, optionLabel } from './cell-coercion'
 
 /**
@@ -172,5 +172,83 @@ describe('coerceForPaste — dangling relationship targets', () => {
       { columnId: 'rel' }
     )
     expect(result).toEqual({ ok: true, value: DEAD })
+  })
+})
+
+/**
+ * A DATE field is a calendar day stored as UTC midnight. Pasting "May 10" must
+ * land on May 10 in every browser zone; only DATETIME keeps the instant.
+ */
+describe('coerceForPaste - calendar days', () => {
+  const originalTz = process.env.TZ
+  afterEach(() => {
+    process.env.TZ = originalTz
+  })
+
+  function dateField(fieldType: 'DATE' | 'DATETIME'): ResourceField {
+    return {
+      id: toFieldId('when'),
+      key: 'when',
+      label: 'When',
+      type: 'string',
+      fieldType,
+      capabilities: { updatable: true },
+    } as unknown as ResourceField
+  }
+
+  const MAY_10 = '2026-05-10T00:00:00.000Z'
+
+  for (const tz of ['Pacific/Auckland', 'America/Los_Angeles', 'Europe/Berlin']) {
+    describe(`in ${tz}`, () => {
+      it('takes a bare day as written', () => {
+        process.env.TZ = tz
+        const result = coerceForPaste({ display: '2026-05-10' }, dateField('DATE'), {
+          columnId: 'when',
+        })
+        expect(result).toEqual({ ok: true, value: MAY_10 })
+      })
+
+      it('keeps a stored DATE value on its day', () => {
+        process.env.TZ = tz
+        const result = coerceForPaste({ display: 'May 10, 2026', raw: MAY_10 }, dateField('DATE'), {
+          columnId: 'when',
+        })
+        expect(result).toEqual({ ok: true, value: MAY_10 })
+      })
+
+      it('reads a formatted day in the local zone', () => {
+        process.env.TZ = tz
+        const result = coerceForPaste({ display: 'May 10, 2026' }, dateField('DATE'), {
+          columnId: 'when',
+        })
+        expect(result).toEqual({ ok: true, value: MAY_10 })
+      })
+    })
+  }
+
+  it('keeps the local calendar day of a pasted instant', () => {
+    process.env.TZ = 'America/Los_Angeles'
+    // 03:00Z on May 10 is still the evening of May 9 in Los Angeles.
+    const result = coerceForPaste(
+      { display: 'May 9, 2026 8:00 PM', raw: '2026-05-10T03:00:00.000Z', fieldType: 'DATETIME' },
+      dateField('DATE'),
+      { columnId: 'when' }
+    )
+    expect(result).toEqual({ ok: true, value: '2026-05-09T00:00:00.000Z' })
+  })
+
+  it('leaves DATETIME as the instant', () => {
+    process.env.TZ = 'Pacific/Auckland'
+    const result = coerceForPaste({ display: '2026-05-10T03:00:00.000Z' }, dateField('DATETIME'), {
+      columnId: 'when',
+    })
+    expect(result).toEqual({ ok: true, value: '2026-05-10T03:00:00.000Z' })
+  })
+
+  it('still rejects text that is not a date', () => {
+    const result = coerceForPaste({ display: 'sometime soon' }, dateField('DATE'), {
+      columnId: 'when',
+    })
+    expect(result).toEqual({ ok: false, reason: 'not-a-date' })
   })
 })

--- a/apps/web/src/components/dynamic-table/utils/cell-coercion.ts
+++ b/apps/web/src/components/dynamic-table/utils/cell-coercion.ts
@@ -7,6 +7,7 @@ import {
   findOptionKey,
   resolveOptionId,
 } from '@auxx/lib/custom-fields/client'
+import { toCalendarDayIso } from '@auxx/lib/field-values/client'
 import {
   getRelatedEntityDefinitionId,
   isRecordId,
@@ -89,8 +90,11 @@ export function reasonToLabel(reason: CoerceReason): string {
 /**
  * Coerce a source payload into a value suitable for the target field.
  * Returns {ok: true, value} on success, or {ok: false, reason} on skip.
- * The returned `value` is a raw primitive (string, number, array, etc.) —
+ * The returned `value` is a raw primitive (string, number, array, etc.);
  * server-side `formatToTypedInput` will convert it to the internal typed form.
+ * A DATE target is the one case that is already canonical on the way out: it
+ * emits the pasted calendar day as `YYYY-MM-DDT00:00:00.000Z`, which the
+ * server's DATE normaliser passes through unchanged.
  */
 export function coerceForPaste(
   source: CopyCellPayload,
@@ -164,7 +168,19 @@ export function coerceForPaste(
       return { ok: false, reason: 'not-a-boolean' }
     }
 
-    case 'DATE':
+    case 'DATE': {
+      // A DATE is a calendar day, so the pasted text names a day, not an
+      // instant, and the browser's zone must not shift it.
+      const candidates: unknown[] = []
+      if (hasRaw) candidates.push(source.raw)
+      if (display !== '') candidates.push(display)
+      for (const c of candidates) {
+        const iso = parseCalendarDayIso(c)
+        if (iso !== null) return { ok: true, value: iso }
+      }
+      return { ok: false, reason: 'not-a-date' }
+    }
+
     case 'DATETIME':
     case 'TIME': {
       const candidates: unknown[] = []
@@ -339,17 +355,48 @@ function parseBool(v: unknown): boolean | null {
   return null
 }
 
-function parseDateIso(v: unknown): string | null {
-  if (v instanceof Date) return Number.isNaN(v.getTime()) ? null : v.toISOString()
+function parseDate(v: unknown): Date | null {
+  if (v instanceof Date) return Number.isNaN(v.getTime()) ? null : v
   if (typeof v === 'number') {
     const d = new Date(v)
-    return Number.isNaN(d.getTime()) ? null : d.toISOString()
+    return Number.isNaN(d.getTime()) ? null : d
   }
   if (typeof v !== 'string') return null
   const trimmed = v.trim()
   if (trimmed === '') return null
   const d = new Date(trimmed)
-  return Number.isNaN(d.getTime()) ? null : d.toISOString()
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+/** An instant for DATETIME and TIME targets. */
+function parseDateIso(v: unknown): string | null {
+  return parseDate(v)?.toISOString() ?? null
+}
+
+/**
+ * A bare `YYYY-MM-DD` or a UTC-midnight instant (the stored shape of a DATE value).
+ * Both name a day outright, so they must not go through `new Date(string)`, which
+ * reads them as UTC and lands on the previous day for every browser west of UTC.
+ */
+const DAY_PREFIX = /^(\d{4})-(\d{2})-(\d{2})(?:T00:00:00(?:\.000)?Z)?$/
+
+/**
+ * The calendar day a pasted value names, as `YYYY-MM-DDT00:00:00.000Z`.
+ *
+ * A bare day (or a stored DATE value) is taken as written. Anything else is
+ * parsed as the browser does and the local calendar day of that instant is
+ * kept, which is the day the user saw in the source cell.
+ */
+function parseCalendarDayIso(v: unknown): string | null {
+  if (typeof v === 'string') {
+    const match = DAY_PREFIX.exec(v.trim())
+    if (match) {
+      const [, y, m, d] = match
+      return toCalendarDayIso(new Date(Number(y), Number(m) - 1, Number(d)))
+    }
+  }
+  const date = parseDate(v)
+  return date ? toCalendarDayIso(date) : null
 }
 
 /**

--- a/apps/web/src/components/fields/inputs/date-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/date-input-field.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
+import { fromCalendarDayIso, toCalendarDayIso } from '@auxx/lib/field-values/client'
 import { useCallback, useEffect, useState } from 'react'
 import { DateTimePickerContent, type PickerMode } from '~/components/pickers/date-time-picker'
 import { useFieldNavigationOptional } from '../field-navigation-context'
@@ -17,9 +18,14 @@ const fieldTypeToPickerMode: Record<string, PickerMode> = {
 }
 
 /**
- * Parse date value from various formats to Date object
+ * Parse date value from various formats to Date object.
+ *
+ * A DATE field is a calendar day stored as UTC midnight, so it is read back as the
+ * local day with the same Y/M/D rather than as the instant, which would highlight
+ * the previous day for every viewer west of UTC. DATETIME and TIME are instants.
  */
-const parseDateValue = (value: unknown): Date | undefined => {
+const parseDateValue = (value: unknown, fieldType: string): Date | undefined => {
+  if (fieldType === FieldType.DATE) return fromCalendarDayIso(value)
   if (!value) return undefined
   if (value instanceof Date) return value
   if (typeof value === 'string') {
@@ -52,20 +58,26 @@ export function DateInputField() {
   const mode: PickerMode = fieldTypeToPickerMode[field.fieldType] || 'date'
 
   // Parse the incoming value
-  const [selectedDate, setSelectedDate] = useState<Date | undefined>(() => parseDateValue(value))
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(() =>
+    parseDateValue(value, field.fieldType)
+  )
 
   /**
    * Handle date selection from DateTimePickerContent
    * Fire-and-forget save, then close
+   *
+   * A DATE field commits the picked local day as `YYYY-MM-DDT00:00:00.000Z`, so the
+   * viewer's zone never crosses the wire. DATETIME and TIME commit the instant.
    */
   const handleChange = useCallback(
     (date: Date | undefined) => {
       setSelectedDate(date)
-      const isoValue = date ? date.toISOString() : null
+      const isDay = field.fieldType === FieldType.DATE
+      const isoValue = date ? (isDay ? toCalendarDayIso(date) : date.toISOString()) : null
       commitValue(isoValue)
       close()
     },
-    [commitValue, close]
+    [commitValue, close, field.fieldType]
   )
 
   return (

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-rate-history.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-rate-history.tsx
@@ -437,14 +437,6 @@ function TariffRateForm({
           />
         </FieldPanelRow>
 
-        {/* ⚠️ A `FieldType.DATE` is stored as a full ISO instant, so the calendar
-            day the resolver reads is the UTC slice of whatever the picker
-            produced. That is the platform's DATE semantics, shared with every
-            other date field in the app, and it is left alone here on purpose:
-            normalising the write to a bare `YYYY-MM-DD` would fix the stored day
-            for eastern viewers and break what the picker renders back to western
-            ones, and this page must not be the one writer that disagrees with
-            the importer and the API about what a date field holds. */}
         <FieldPanelRow
           title='Effective from'
           type={BaseType.DATE}

--- a/apps/web/src/components/pickers/date-time-picker/date-time-picker-content.tsx
+++ b/apps/web/src/components/pickers/date-time-picker/date-time-picker-content.tsx
@@ -81,8 +81,11 @@ export function DateTimePickerContent({
   /** Handle date selection from calendar */
   const handleDateSelect = useCallback(
     (date: Date) => {
-      // Preserve time from existing selection or use start of day
-      const newDate = selectedDate ? cloneTimeToDate(date, selectedDate) : startOfDay(date)
+      // Date mode is a calendar day and never carries a time-of-day, so a stray
+      // time on the incoming value must not survive a re-pick. Datetime mode
+      // preserves the time from the existing selection.
+      const newDate =
+        mode !== 'date' && selectedDate ? cloneTimeToDate(date, selectedDate) : startOfDay(date)
       setSelectedDate(newDate)
       setCurrentMonth(date)
 
@@ -91,7 +94,7 @@ export function DateTimePickerContent({
         onChange(newDate)
       }
     },
-    [selectedDate, noConfirm, onChange]
+    [mode, selectedDate, noConfirm, onChange]
   )
 
   /** Handle hour selection */

--- a/apps/web/src/components/pickers/filter-date-picker.tsx
+++ b/apps/web/src/components/pickers/filter-date-picker.tsx
@@ -48,6 +48,28 @@ interface FilterDatePickerProps {
   placeholder?: string
   /** Custom trigger element - if provided, will be used instead of default button */
   children?: React.ReactNode
+  /**
+   * The filtered field is a `DATE` (a calendar day). A picked day is emitted as a
+   * bare `YYYY-MM-DD`, which the SQL side compares with `::date`. Leave unset for a
+   * `DATETIME` field: `before`/`after` compare the raw instant, so a bare day there
+   * would move a local-midnight boundary to UTC midnight.
+   */
+  dateOnly?: boolean
+}
+
+const BARE_DAY = /^(\d{4})-(\d{2})-(\d{2})$/
+
+/**
+ * A bare `YYYY-MM-DD` as a local `Date` at midnight of that day, so the calendar
+ * highlights the day the value names in every browser zone. Any other string is
+ * parsed as the browser does.
+ */
+function parseFilterDate(value: string): Date | undefined {
+  const match = BARE_DAY.exec(value)
+  const date = match
+    ? new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+    : new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date
 }
 
 /**
@@ -63,6 +85,7 @@ export function FilterDatePicker({
   disabled = false,
   placeholder = 'Select date...',
   children,
+  dateOnly = false,
 }: FilterDatePickerProps) {
   const [isOpen, setIsOpen] = React.useState(false)
 
@@ -77,15 +100,8 @@ export function FilterDatePicker({
     if (relativeMatch) return relativeMatch.label
 
     // Otherwise, try to parse it as a date and format it
-    try {
-      const date = new Date(value)
-      // Check if parsing resulted in a valid date
-      if (!Number.isNaN(date.getTime())) {
-        return format(date, 'PPP') // e.g., "Dec 31st, 2023"
-      }
-    } catch (e) {
-      // Ignore errors if value is not a parsable date string
-    }
+    const date = parseFilterDate(value)
+    if (date) return format(date, 'PPP') // e.g., "Dec 31st, 2023"
     // Fallback: if value is not null, not relative, and not parsable, show the raw value
     return value
   }
@@ -105,8 +121,9 @@ export function FilterDatePicker({
    */
   const handleDateSelect = (selectedDate?: Date) => {
     if (selectedDate) {
-      // Output date as ISO string, consistent with how parseDateValue expects specific dates
-      onChange(selectedDate.toISOString())
+      // A DATE field gets the picked local day itself; a DATETIME field gets the
+      // instant, consistent with how parseDateValue expects specific dates.
+      onChange(dateOnly ? format(selectedDate, 'yyyy-MM-dd') : selectedDate.toISOString())
     } else {
       // If the calendar allows clearing, handle setting value to null
       // onChange(null); // Uncomment this if clearing is desired/possible
@@ -124,13 +141,7 @@ export function FilterDatePicker({
     if (relativeOptions.some((opt) => opt.value === value)) {
       return undefined // Don't highlight a date in calendar for relative ranges
     }
-    // Try to parse as a date
-    try {
-      const date = new Date(value)
-      return !Number.isNaN(date.getTime()) ? date : undefined
-    } catch {
-      return undefined // Invalid date string
-    }
+    return parseFilterDate(value)
   }, [value])
 
   return (

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/datetime-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/datetime-input.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/workflow/nodes/shared/node-inputs/datetime-input.tsx
 'use client'
 
+import { fromCalendarDayIso, toCalendarDayIso } from '@auxx/lib/field-values/client'
 import { format } from 'date-fns'
 import { DateTimePicker, type PickerMode } from '~/components/pickers/date-time-picker'
 import type { PickerTriggerOptions } from '~/components/ui/picker-trigger'
@@ -28,6 +29,10 @@ interface DateTimeInputProps extends NodeInputProps {
 /**
  * DateTime input component using DateTimePicker
  * Wraps DateTimePicker to match node-input interface (ISO string values)
+ *
+ * `type='date'` is a calendar day: it is read back as the local day with the same
+ * Y/M/D and written as `YYYY-MM-DDT00:00:00.000Z`, so the viewer's zone never
+ * crosses the wire. `datetime` and `time` are instants.
  */
 export const DateTimeInput = createNodeInput<DateTimeInputProps>(
   ({
@@ -46,9 +51,10 @@ export const DateTimeInput = createNodeInput<DateTimeInputProps>(
   }) => {
     const value = inputs[name]
     // const error = errors[name]
+    const isDay = type === 'date'
 
     // Parse ISO string to Date object
-    const dateValue = value ? new Date(value) : undefined
+    const dateValue = isDay ? fromCalendarDayIso(value) : value ? new Date(value) : undefined
     const isValidDate = dateValue && !Number.isNaN(dateValue.getTime())
 
     // Map type prop to mode prop
@@ -73,8 +79,8 @@ export const DateTimeInput = createNodeInput<DateTimeInputProps>(
       }
 
       onError(name, null)
-      // Store as ISO string (maintains existing behavior)
-      onChange(name, date.toISOString())
+      // Store as ISO string: the picked day for a date, the instant otherwise
+      onChange(name, isDay ? toCalendarDayIso(date) : date.toISOString())
     }
 
     /** Get placeholder based on mode */

--- a/packages/lib/scripts/seed-docket-marketing.ts
+++ b/packages/lib/scripts/seed-docket-marketing.ts
@@ -273,8 +273,12 @@ await database.transaction(async (tx) => {
     .onConflictDoNothing({ target: Participant.id })
 
   // -------- 2. Bump the Docket deal so it looks like an active opportunity ---
-  const expectedClose = new Date()
-  expectedClose.setDate(expectedClose.getDate() + 14) // ~2 weeks out
+  // `expected_close` is a DATE field (a calendar day stored at UTC midnight),
+  // and this writes `valueDate` directly, bypassing the normalisers, so it must
+  // carry the canonical shape itself rather than a live instant.
+  const expectedCloseInstant = new Date()
+  expectedCloseInstant.setUTCDate(expectedCloseInstant.getUTCDate() + 14) // ~2 weeks out
+  const expectedClose = `${expectedCloseInstant.toISOString().slice(0, 10)}T00:00:00.000Z`
 
   // Stage
   await tx

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields-output.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields-output.ts
@@ -56,6 +56,8 @@ export interface FieldOutput {
   readOnly?: true
   /** Only present when creatable && !updatable (e.g. ticket_type). */
   createOnly?: true
+  /** DATE fields only: the value shape to send (a bare calendar day). */
+  format?: 'YYYY-MM-DD'
   /** Select / multi-select / status option values. */
   options?: Array<{ value: string; label: string }>
   moreOptions?: true
@@ -110,6 +112,8 @@ export function formatFieldOutput(field: ResourceField): FieldOutput | null {
   }
 
   const ft = fieldType?.toUpperCase()
+
+  if (ft === 'DATE') entry.format = 'YYYY-MM-DD'
 
   // Select options
   if (ft && SELECT_TYPES.has(ft) && field.options?.options?.length) {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
@@ -100,6 +100,7 @@ Response shape:
     createOnly: true     — set at create, never updated after
     options              — valid values for select / multi-select / status
     relationship         — target entity for RELATIONSHIP fields
+    format: 'YYYY-MM-DD' - DATE fields take a bare calendar day, not a datetime
   Computed fields are omitted — the LLM can't set them.`,
     parameters: {
       type: 'object',

--- a/packages/lib/src/bom/vendor-cost.ts
+++ b/packages/lib/src/bom/vendor-cost.ts
@@ -218,9 +218,8 @@ export interface TariffRateRow {
   /**
    * The day this rate took effect.
    *
-   * A calendar day, not an instant. A `Date` is read in **UTC** because that is
-   * how a `FieldType.DATE` value is stored - reinterpreting midnight UTC in a
-   * western timezone would move every row back a day. A string is taken as
+   * A calendar day, not an instant. DATE values are stored as UTC midnight per
+   * the platform contract, so the UTC slice is the day. A string is taken as
    * already being a `YYYY-MM-DD` day and only its first ten characters are read.
    */
   effectiveFrom: Date | string | null
@@ -503,7 +502,8 @@ function normalizeAuthority(authority: string | null): string | null {
 /**
  * A row's effective day as `YYYY-MM-DD`, or `null` when it has none.
  *
- * A `Date` is read in UTC on purpose - see {@link TariffRateRow.effectiveFrom}.
+ * DATE values are stored as UTC midnight per the platform contract, so the UTC
+ * slice is the day.
  */
 function effectiveDay(effectiveFrom: Date | string | null): string | null {
   if (effectiveFrom == null) return null

--- a/packages/lib/src/data-migrations/migrations/106-date-fields-utc-midnight.int.test.ts
+++ b/packages/lib/src/data-migrations/migrations/106-date-fields-utc-midnight.int.test.ts
@@ -1,0 +1,152 @@
+// packages/lib/src/data-migrations/migrations/106-date-fields-utc-midnight.int.test.ts
+//
+// DB-backed test (vitest.integration.config.ts, auxx_test) for the backfill's
+// one rule: a DATE value rounds to the NEAREST UTC midnight. A picker write
+// from Pacific time (07:00Z) rounds down, a picker write from Berlin
+// (22:00Z the day before) rounds up, and a DATETIME value is an instant that
+// the migration must not touch.
+//
+// Runs against the ephemeral `auxx_test` database only.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { migration106DateFieldsUtcMidnight } from './106-date-fields-utc-midnight'
+
+const db = () => getTestDb() as never as Database
+
+interface Fixture {
+  orgId: string
+  dealDefId: string
+  dateFieldId: string
+  datetimeFieldId: string
+  dealId: string
+}
+
+async function seed(): Promise<Fixture> {
+  const org = await createTestOrganization()
+
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: org.id,
+      entityType: 'deal',
+      apiSlug: 'deals',
+      singular: 'deal',
+      plural: 'deals',
+      updatedAt: new Date(),
+    })
+    .returning()
+  const dealDefId = def!.id
+
+  const field = async (name: string, type: string) => {
+    const [row] = await db()
+      .insert(schema.CustomField)
+      .values({
+        organizationId: org.id,
+        entityDefinitionId: dealDefId,
+        modelType: 'deal',
+        name,
+        type: type as never,
+        sortOrder: 'a1',
+        isCustom: false,
+        updatedAt: new Date(),
+      })
+      .returning()
+    return row!.id
+  }
+
+  const dateFieldId = await field('Expected Close', 'DATE')
+  const datetimeFieldId = await field('Last Touched', 'DATETIME')
+
+  const [deal] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: org.id,
+      entityDefinitionId: dealDefId,
+      displayName: 'Deal 1',
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  return { orgId: org.id, dealDefId, dateFieldId, datetimeFieldId, dealId: deal!.id }
+}
+
+let f: Fixture
+
+async function dateValue(fieldId: string, valueDate: string, sortKey = 'a'): Promise<string> {
+  const [row] = await db()
+    .insert(schema.FieldValue)
+    .values({
+      organizationId: f.orgId,
+      entityId: f.dealId,
+      entityDefinitionId: f.dealDefId,
+      fieldId,
+      valueDate,
+      sortKey,
+      updatedAt: new Date(),
+    })
+    .returning()
+  return row!.id
+}
+
+/** The stored instant as canonical ISO, whatever rendering Postgres hands back. */
+async function storedIso(fieldValueId: string): Promise<string | null> {
+  const [row] = await db()
+    .select({ valueDate: schema.FieldValue.valueDate })
+    .from(schema.FieldValue)
+    .where(eq(schema.FieldValue.id, fieldValueId))
+  return row?.valueDate ? new Date(row.valueDate).toISOString() : null
+}
+
+beforeEach(async () => {
+  f = await seed()
+})
+
+describe('migration 106: DATE values round to the nearest UTC midnight', () => {
+  it('rounds a Pacific picker write (07:00Z) DOWN to the same day', async () => {
+    const id = await dateValue(f.dateFieldId, '2026-05-10T07:00:00.000Z')
+
+    await migration106DateFieldsUtcMidnight.run(db())
+
+    expect(await storedIso(id)).toBe('2026-05-10T00:00:00.000Z')
+  })
+
+  it('rounds a Berlin picker write (22:00Z the day before) UP to the picked day', async () => {
+    // A UTC+2 user picking May 10 sent local midnight, which is May 9 22:00Z.
+    // Truncation would keep May 9; the intended day is May 10.
+    const id = await dateValue(f.dateFieldId, '2026-05-09T22:00:00.000Z')
+
+    await migration106DateFieldsUtcMidnight.run(db())
+
+    expect(await storedIso(id)).toBe('2026-05-10T00:00:00.000Z')
+  })
+
+  it('leaves a DATETIME value exactly as it was', async () => {
+    const id = await dateValue(f.datetimeFieldId, '2026-05-10T07:00:00.000Z')
+
+    await migration106DateFieldsUtcMidnight.run(db())
+
+    expect(await storedIso(id)).toBe('2026-05-10T07:00:00.000Z')
+  })
+
+  it('leaves a DATE value already at UTC midnight alone', async () => {
+    const id = await dateValue(f.dateFieldId, '2026-05-10T00:00:00.000Z')
+
+    await migration106DateFieldsUtcMidnight.run(db())
+
+    expect(await storedIso(id)).toBe('2026-05-10T00:00:00.000Z')
+  })
+
+  it('is idempotent: a second pass changes nothing', async () => {
+    const down = await dateValue(f.dateFieldId, '2026-05-10T07:00:00.000Z', 'a')
+    const up = await dateValue(f.dateFieldId, '2026-05-09T22:00:00.000Z', 'b')
+
+    await migration106DateFieldsUtcMidnight.run(db())
+    await migration106DateFieldsUtcMidnight.run(db())
+
+    expect(await storedIso(down)).toBe('2026-05-10T00:00:00.000Z')
+    expect(await storedIso(up)).toBe('2026-05-10T00:00:00.000Z')
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/106-date-fields-utc-midnight.ts
+++ b/packages/lib/src/data-migrations/migrations/106-date-fields-utc-midnight.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/data-migrations/migrations/106-date-fields-utc-midnight.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-106')
+
+/**
+ * Round every `FieldType.DATE` value to the nearest UTC midnight.
+ *
+ * A DATE value is a calendar day, stored canonically as `YYYY-MM-DDT00:00:00.000Z`
+ * (plans/money/tasks/33-calendar-day-fields.md section 3). Before that contract
+ * was declared the browser date picker wrote the writer's LOCAL midnight
+ * (`07:00Z` / `08:00Z` from Pacific time), and the seeders wrote arbitrary
+ * instants, so a UTC+2 writer's May 10 read as May 9 to a UTC-7 teammate and
+ * to every UTC-day reader (filters, tariff rate lookup, quote expiry).
+ *
+ * **Nearest, not truncate**: `+12h`, then truncate to the day. Truncation is off
+ * by one for every writer east of UTC (May 9 `22:00Z` is a May 10 pick from
+ * Berlin). Rounding recovers the intended day for every zone from UTC-12 to
+ * UTC+12, and it is the same rule the write funnel now applies, so a row this
+ * migration touched and a row written afterwards are indistinguishable.
+ *
+ * DATETIME and TIME are instants and are not touched. `updatedAt` is not
+ * bumped and no events fire: this is a reinterpretation of the stored value,
+ * not an edit, which is why it is raw SQL and not the field-value write path.
+ *
+ * Idempotent: the WHERE clause only matches rows that are not yet at midnight.
+ */
+export const migration106DateFieldsUtcMidnight: DataMigrationDef = {
+  id: '106-date-fields-utc-midnight',
+  description:
+    'Round every DATE field value to the nearest UTC midnight (a DATE is a calendar day)',
+  async run(db: Database): Promise<void> {
+    const result = await db.execute(sql`
+      UPDATE "FieldValue" fv
+      SET "valueDate" = (date_trunc('day', (fv."valueDate" AT TIME ZONE 'UTC') + interval '12 hours')) AT TIME ZONE 'UTC'
+      FROM "CustomField" cf
+      WHERE cf.id = fv."fieldId"
+        AND cf.type = 'DATE'
+        AND fv."valueDate" IS NOT NULL
+        AND (fv."valueDate" AT TIME ZONE 'UTC')::time <> '00:00:00'
+    `)
+
+    logger.info('Rounded DATE field values to UTC midnight', {
+      rowsUpdated: result.rowCount ?? 0,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -66,6 +66,7 @@ import { migration098PruneOrphanedOptionValues } from './migrations/098-prune-or
 import { migration099ImapBackfillStamps } from './migrations/099-imap-backfill-stamps'
 import { migration103BackfillEmailStorageLocationOrg } from './migrations/103-backfill-email-storage-location-org'
 import { migration105PruneDanglingRelationValues } from './migrations/105-prune-dangling-relation-values'
+import { migration106DateFieldsUtcMidnight } from './migrations/106-date-fields-utc-midnight'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -160,6 +161,7 @@ function buildRegistry(): DataMigrationDef[] {
     // 104 (`vendor_sku_optional`) is an ENTITY migration and arrives via
     // ALL_ENTITY_MIGRATIONS above; it owns 104 in the shared id sequence.
     migration105PruneDanglingRelationValues,
+    migration106DateFieldsUtcMidnight,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/field-values/__tests__/calendar-day.test.ts
+++ b/packages/lib/src/field-values/__tests__/calendar-day.test.ts
@@ -1,0 +1,363 @@
+// packages/lib/src/field-values/__tests__/calendar-day.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { fromCalendarDayIso, normalizeCalendarDayIso, toCalendarDayIso } from '../calendar-day'
+import { calendarDateConverter } from '../converters/calendar-date'
+import { dateConverter } from '../converters/date'
+import { converters } from '../converters/index'
+import { validateSingleValue } from '../field-value-helpers'
+import { FieldValueValidator, fieldValueSchemas } from '../field-value-validator'
+
+const MAY_10 = '2026-05-10T00:00:00.000Z'
+const MAY_9 = '2026-05-09T00:00:00.000Z'
+
+/**
+ * Local-midnight instants a browser date picker at each zone emits for May 10,
+ * 2026. Auckland is UTC+12 in May (NZST), so its local midnight is exactly the
+ * 12h boundary that must round UP to May 10.
+ */
+const ZONES = [
+  { tz: 'Europe/Berlin', localMidnight: '2026-05-09T22:00:00.000Z' },
+  { tz: 'America/Los_Angeles', localMidnight: '2026-05-10T07:00:00.000Z' },
+  { tz: 'Pacific/Auckland', localMidnight: '2026-05-09T12:00:00.000Z' },
+] as const
+
+/**
+ * Pin `TZ` for one case. Node re-reads `process.env.TZ` on assignment, so the
+ * local-time `Date` accessors switch zone immediately; the sanity check inside
+ * each zone block below proves it for this vitest setup.
+ */
+function withTz<T>(tz: string, fn: () => T): T {
+  const previous = process.env.TZ
+  process.env.TZ = tz
+  try {
+    return fn()
+  } finally {
+    if (previous === undefined) delete process.env.TZ
+    else process.env.TZ = previous
+  }
+}
+
+describe('normalizeCalendarDayIso', () => {
+  for (const { tz, localMidnight } of ZONES) {
+    describe(`in ${tz}`, () => {
+      it('the zone is actually applied to local Date construction', () => {
+        withTz(tz, () => {
+          expect(new Date(2026, 4, 10).toISOString()).toBe(localMidnight)
+        })
+      })
+
+      it('a bare YYYY-MM-DD is that day at UTC midnight', () => {
+        withTz(tz, () => {
+          expect(normalizeCalendarDayIso('2026-05-10')).toBe(MAY_10)
+          expect(normalizeCalendarDayIso('  2026-05-10 ')).toBe(MAY_10)
+        })
+      })
+
+      it('the local-midnight instant the picker emits lands on the intended day', () => {
+        withTz(tz, () => {
+          expect(normalizeCalendarDayIso(localMidnight)).toBe(MAY_10)
+          expect(normalizeCalendarDayIso(new Date(2026, 4, 10))).toBe(MAY_10)
+        })
+      })
+
+      it('a +02:00 offset instant (the workflow date-time node) lands on the intended day', () => {
+        withTz(tz, () => {
+          expect(normalizeCalendarDayIso('2026-05-10T00:00:00.000+02:00')).toBe(MAY_10)
+        })
+      })
+
+      it('an epoch number rounds to the nearest UTC midnight', () => {
+        withTz(tz, () => {
+          expect(normalizeCalendarDayIso(Date.parse(localMidnight))).toBe(MAY_10)
+          expect(normalizeCalendarDayIso(Date.parse(MAY_10))).toBe(MAY_10)
+        })
+      })
+    })
+  }
+
+  it('rounds to the NEAREST midnight, with the exact 12h boundary going up', () => {
+    expect(normalizeCalendarDayIso('2026-05-09T12:00:00.000Z')).toBe(MAY_10)
+    expect(normalizeCalendarDayIso('2026-05-09T11:59:59.999Z')).toBe(MAY_9)
+    expect(normalizeCalendarDayIso('2026-05-10T11:59:59.999Z')).toBe(MAY_10)
+    expect(normalizeCalendarDayIso('2026-05-10T12:00:00.000Z')).toBe('2026-05-11T00:00:00.000Z')
+  })
+
+  it('leaves a canonical value untouched', () => {
+    expect(normalizeCalendarDayIso(MAY_10)).toBe(MAY_10)
+    expect(normalizeCalendarDayIso(new Date(MAY_10))).toBe(MAY_10)
+  })
+
+  it('returns null for empty input', () => {
+    expect(normalizeCalendarDayIso(null)).toBeNull()
+    expect(normalizeCalendarDayIso(undefined)).toBeNull()
+    expect(normalizeCalendarDayIso('')).toBeNull()
+    expect(normalizeCalendarDayIso('   ')).toBeNull()
+  })
+
+  it('returns null for garbage', () => {
+    expect(normalizeCalendarDayIso('not a date')).toBeNull()
+    expect(normalizeCalendarDayIso(new Date('garbage'))).toBeNull()
+    expect(normalizeCalendarDayIso(Number.NaN)).toBeNull()
+    expect(normalizeCalendarDayIso({ nope: 1 })).toBeNull()
+    expect(normalizeCalendarDayIso(true)).toBeNull()
+  })
+})
+
+describe('toCalendarDayIso / fromCalendarDayIso', () => {
+  for (const { tz } of ZONES) {
+    it(`round-trips the same Y/M/D in ${tz}`, () => {
+      withTz(tz, () => {
+        const picked = new Date(2026, 4, 10)
+        const iso = toCalendarDayIso(picked)
+        expect(iso).toBe(MAY_10)
+
+        const back = fromCalendarDayIso(iso)
+        expect(back).toBeDefined()
+        expect(back!.getFullYear()).toBe(2026)
+        expect(back!.getMonth()).toBe(4)
+        expect(back!.getDate()).toBe(10)
+        expect(back!.getHours()).toBe(0)
+        expect(back!.getMinutes()).toBe(0)
+      })
+    })
+  }
+
+  it('fromCalendarDayIso highlights the intended day for a not-yet-backfilled picker row', () => {
+    withTz('America/Los_Angeles', () => {
+      // A Berlin picker wrote 22:00Z on May 9; a naive local read in LA shows May 9.
+      expect(fromCalendarDayIso('2026-05-09T22:00:00.000Z')!.getDate()).toBe(10)
+    })
+  })
+
+  it('fromCalendarDayIso returns undefined for empty or garbage', () => {
+    expect(fromCalendarDayIso(null)).toBeUndefined()
+    expect(fromCalendarDayIso('')).toBeUndefined()
+    expect(fromCalendarDayIso('garbage')).toBeUndefined()
+  })
+})
+
+describe('calendarDateConverter', () => {
+  it('is what the DATE type routes to; DATETIME and TIME keep dateConverter', () => {
+    expect(converters.DATE).toBe(calendarDateConverter)
+    expect(converters.DATETIME).toBe(dateConverter)
+    expect(converters.TIME).toBe(dateConverter)
+  })
+
+  describe('toTypedInput', () => {
+    for (const { tz, localMidnight } of ZONES) {
+      it(`normalises every input shape to UTC midnight in ${tz}`, () => {
+        withTz(tz, () => {
+          const expected = { type: 'date', value: MAY_10 }
+          expect(calendarDateConverter.toTypedInput('2026-05-10')).toEqual(expected)
+          expect(calendarDateConverter.toTypedInput(localMidnight)).toEqual(expected)
+          expect(calendarDateConverter.toTypedInput(new Date(2026, 4, 10))).toEqual(expected)
+          expect(calendarDateConverter.toTypedInput(Date.parse(localMidnight))).toEqual(expected)
+          expect(calendarDateConverter.toTypedInput('2026-05-10T00:00:00.000+02:00')).toEqual(
+            expected
+          )
+        })
+      })
+    }
+
+    it('normalises the value inside an already-typed input', () => {
+      expect(
+        calendarDateConverter.toTypedInput({ type: 'date', value: '2026-05-09T22:00:00.000Z' })
+      ).toEqual({ type: 'date', value: MAY_10 })
+    })
+
+    it('returns null for empty, garbage, and a typed value of another type', () => {
+      expect(calendarDateConverter.toTypedInput(null)).toBeNull()
+      expect(calendarDateConverter.toTypedInput(undefined)).toBeNull()
+      expect(calendarDateConverter.toTypedInput('')).toBeNull()
+      expect(calendarDateConverter.toTypedInput('garbage')).toBeNull()
+      expect(calendarDateConverter.toTypedInput({ type: 'date', value: null })).toBeNull()
+      expect(calendarDateConverter.toTypedInput({ type: 'text', value: '2026-05-10' })).toBeNull()
+    })
+  })
+
+  describe('toRawValue', () => {
+    it('emits the canonical UTC-midnight ISO string', () => {
+      expect(calendarDateConverter.toRawValue({ type: 'date', value: MAY_10 })).toBe(MAY_10)
+      expect(
+        calendarDateConverter.toRawValue({ type: 'date', value: '2026-05-10T07:00:00.000Z' })
+      ).toBe(MAY_10)
+      expect(calendarDateConverter.toRawValue('2026-05-10')).toBe(MAY_10)
+      expect(calendarDateConverter.toRawValue(new Date('2026-05-09T22:00:00.000Z'))).toBe(MAY_10)
+    })
+
+    it('returns null for empty or garbage', () => {
+      expect(calendarDateConverter.toRawValue(null)).toBeNull()
+      expect(calendarDateConverter.toRawValue('garbage')).toBeNull()
+      expect(calendarDateConverter.toRawValue({ type: 'date', value: null })).toBeNull()
+    })
+  })
+
+  describe('toDisplayValue', () => {
+    const stored = { type: 'date' as const, value: MAY_10 }
+
+    for (const { tz } of ZONES) {
+      it(`renders the stored UTC day, not the viewer's local day, in ${tz}`, () => {
+        withTz(tz, () => {
+          for (const format of ['short', 'medium', 'long'] as const) {
+            const rendered = calendarDateConverter.toDisplayValue(stored, { format }) as string
+            expect(rendered).toBe(
+              new Date(MAY_10).toLocaleString(undefined, { timeZone: 'UTC', dateStyle: format })
+            )
+            expect(rendered).toMatch(/10/)
+            expect(rendered).not.toMatch(/:/)
+          }
+        })
+      })
+    }
+
+    it('differs from dateConverter west of UTC, which is the bug being fixed', () => {
+      withTz('America/Los_Angeles', () => {
+        const generic = dateConverter.toDisplayValue(stored, { format: 'iso' })
+        expect(generic).toBe(MAY_10)
+        // dateConverter renders midnight UTC as the previous evening in LA.
+        expect(dateConverter.toDisplayValue(stored, { format: 'medium' })).toMatch(/9/)
+        expect(calendarDateConverter.toDisplayValue(stored, { format: 'medium' })).toMatch(/10/)
+      })
+    })
+
+    it('iso is the bare YYYY-MM-DD', () => {
+      expect(calendarDateConverter.toDisplayValue(stored, { format: 'iso' })).toBe('2026-05-10')
+    })
+
+    it('rounds a not-yet-backfilled picker row onto its intended day', () => {
+      expect(
+        calendarDateConverter.toDisplayValue(
+          { type: 'date', value: '2026-05-09T22:00:00.000Z' },
+          { format: 'iso' }
+        )
+      ).toBe('2026-05-10')
+    })
+
+    it('ignores includeTime and time-only', () => {
+      expect(
+        calendarDateConverter.toDisplayValue(stored, { format: 'short', includeTime: true })
+      ).not.toMatch(/:/)
+      expect(calendarDateConverter.toDisplayValue(stored, { format: 'time-only' })).toBe(
+        new Date(MAY_10).toLocaleString(undefined, { timeZone: 'UTC', dateStyle: 'medium' })
+      )
+    })
+
+    it('keeps relative working', () => {
+      const today = { type: 'date' as const, value: toCalendarDayIso(new Date()) }
+      const rendered = calendarDateConverter.toDisplayValue(today, { format: 'relative' })
+      expect(typeof rendered).toBe('string')
+      expect(rendered).not.toBe('')
+      expect(rendered).not.toBe(today.value)
+    })
+
+    it('renders empty for a missing or garbage value', () => {
+      expect(
+        calendarDateConverter.toDisplayValue({ type: 'date', value: null as unknown as string })
+      ).toBe('')
+      expect(calendarDateConverter.toDisplayValue({ type: 'date', value: 'garbage' })).toBe('')
+    })
+  })
+})
+
+describe('FieldValueValidator.validateCalendarDate', () => {
+  const validator = new FieldValueValidator()
+
+  for (const { tz, localMidnight } of ZONES) {
+    it(`normalises every input shape to UTC midnight in ${tz}`, () => {
+      withTz(tz, () => {
+        for (const input of [
+          '2026-05-10',
+          localMidnight,
+          new Date(2026, 4, 10),
+          '2026-05-10T00:00:00.000+02:00',
+        ]) {
+          const result = validator.validateCalendarDate(input)
+          expect(result.success).toBe(true)
+          expect(result.success && result.data).toBe(MAY_10)
+        }
+      })
+    })
+  }
+
+  it('rejects empty and garbage with the same issue dateSchema reports', () => {
+    for (const input of ['', '   ', null, undefined, 'garbage']) {
+      const result = validator.validateCalendarDate(input)
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error.issues[0]?.message).toBe('Invalid date value')
+    }
+  })
+
+  it('is wired to fieldValueSchemas.calendarDate', () => {
+    expect(fieldValueSchemas.calendarDate.safeParse('2026-05-10')).toEqual({
+      success: true,
+      data: MAY_10,
+    })
+  })
+})
+
+describe('validateSingleValue routes by type', () => {
+  const ctx = { validator: new FieldValueValidator() } as never
+
+  it('DATE goes through validateCalendarDate', async () => {
+    await withTz('Europe/Berlin', async () => {
+      await expect(
+        validateSingleValue(ctx, '2026-05-09T22:00:00.000Z', 'DATE' as never)
+      ).resolves.toEqual({ type: 'date', value: MAY_10 })
+    })
+  })
+
+  it('DATETIME and TIME keep validateDate and the instant', async () => {
+    for (const type of ['DATETIME', 'TIME']) {
+      await expect(
+        validateSingleValue(ctx, '2026-05-09T22:00:00.000Z', type as never)
+      ).resolves.toEqual({ type: 'date', value: '2026-05-09T22:00:00.000Z' })
+    }
+  })
+})
+
+describe('DATETIME is byte-identical to before', () => {
+  const validator = new FieldValueValidator()
+  const inputs = [
+    '2026-05-09T22:00:00.000Z',
+    '2026-05-10T07:13:45.678Z',
+    '2026-05-10T00:00:00.000+02:00',
+    '2026-05-10',
+  ]
+
+  for (const { tz } of ZONES) {
+    it(`dateConverter and validateDate still emit new Date(v).toISOString() in ${tz}`, () => {
+      withTz(tz, () => {
+        for (const input of inputs) {
+          const expected = new Date(input).toISOString()
+          expect(dateConverter.toTypedInput(input)).toEqual({ type: 'date', value: expected })
+          expect(dateConverter.toRawValue(input)).toBe(expected)
+          const validated = validator.validateDate(input)
+          expect(validated.success && validated.data).toBe(expected)
+        }
+
+        const local = new Date(2026, 4, 10, 15, 30)
+        expect(dateConverter.toTypedInput(local)).toEqual({
+          type: 'date',
+          value: local.toISOString(),
+        })
+        const validatedLocal = validator.validateDate(local)
+        expect(validatedLocal.success && validatedLocal.data).toBe(local.toISOString())
+      })
+    })
+  }
+
+  it('dateConverter display still uses the viewer zone and honours includeTime', () => {
+    withTz('America/Los_Angeles', () => {
+      const stored = { type: 'date' as const, value: '2026-05-10T07:13:00.000Z' }
+      expect(dateConverter.toDisplayValue(stored, { format: 'short', includeTime: true })).toBe(
+        new Date(stored.value).toLocaleString(undefined, {
+          timeZone: undefined,
+          dateStyle: 'short',
+          timeStyle: 'short',
+        })
+      )
+      expect(dateConverter.toDisplayValue(stored, { format: 'iso' })).toBe(stored.value)
+    })
+  })
+})

--- a/packages/lib/src/field-values/calendar-day.ts
+++ b/packages/lib/src/field-values/calendar-day.ts
@@ -1,0 +1,74 @@
+// packages/lib/src/field-values/calendar-day.ts
+
+/**
+ * Calendar-day helpers for `FieldType.DATE`.
+ *
+ * A DATE value is a calendar day. Its canonical storage is `YYYY-MM-DDT00:00:00.000Z`,
+ * and every reader slices or formats it in UTC. These helpers are the single
+ * implementation of that rule, shared by the server normalisers (converter and
+ * validator) and the browser doors (picker, grid paste, filter picker).
+ *
+ * Contract: plans/money/tasks/33-calendar-day-fields.md §3.
+ */
+
+const BARE_DAY = /^\d{4}-\d{2}-\d{2}$/
+const DAY_MS = 86_400_000
+const HALF_DAY_MS = DAY_MS / 2
+
+/**
+ * The picked `Date`'s local calendar day as the canonical UTC-midnight ISO string.
+ *
+ * Browser doors use this so the viewer's zone never crosses the wire: a UTC+2 user
+ * picking May 10 sends `2026-05-10T00:00:00.000Z`, not `2026-05-09T22:00:00.000Z`.
+ */
+export function toCalendarDayIso(date: Date): string {
+  const y = String(date.getFullYear()).padStart(4, '0')
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}T00:00:00.000Z`
+}
+
+/**
+ * A local `Date` at local midnight of the stored value's UTC calendar day, so a
+ * calendar highlights the day that was stored regardless of the viewer's zone.
+ *
+ * Returns `undefined` for an empty or unparseable value.
+ */
+export function fromCalendarDayIso(value: unknown): Date | undefined {
+  const iso = normalizeCalendarDayIso(value)
+  if (!iso) return undefined
+  const utc = new Date(iso)
+  return new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate())
+}
+
+/**
+ * Normalise any DATE input to the canonical UTC-midnight ISO string.
+ *
+ * - a bare `YYYY-MM-DD` is that day at midnight UTC;
+ * - any other parseable instant (ISO with time or offset, a `Date`, an epoch number)
+ *   rounds to the **nearest** UTC midnight, so a local-midnight instant from either
+ *   side of UTC and an offset form like `T00:00:00+02:00` all land on the intended day;
+ * - empty or unparseable input returns `null`.
+ *
+ * Nearest rather than truncate is deliberate: truncation is off by one for every
+ * writer east of UTC.
+ */
+export function normalizeCalendarDayIso(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (value instanceof Date) return roundToUtcMidnight(value.getTime())
+  if (typeof value === 'number') return roundToUtcMidnight(value)
+  if (typeof value !== 'string') return null
+
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  if (BARE_DAY.test(trimmed)) {
+    return roundToUtcMidnight(new Date(`${trimmed}T00:00:00.000Z`).getTime())
+  }
+  return roundToUtcMidnight(new Date(trimmed).getTime())
+}
+
+/** The nearest UTC midnight to an epoch instant, or `null` when it is not a number. */
+function roundToUtcMidnight(epochMs: number): string | null {
+  if (Number.isNaN(epochMs)) return null
+  return new Date(Math.floor((epochMs + HALF_DAY_MS) / DAY_MS) * DAY_MS).toISOString()
+}

--- a/packages/lib/src/field-values/client.ts
+++ b/packages/lib/src/field-values/client.ts
@@ -15,6 +15,8 @@ export {
   type ParsedExpression,
   validateCalcExpression,
 } from '@auxx/utils/calc-expression'
+// Calendar-day rule for FieldType.DATE, shared by the server normalisers and the browser doors
+export { fromCalendarDayIso, normalizeCalendarDayIso, toCalendarDayIso } from './calendar-day'
 // Converters (for direct access if needed)
 export { converters, type FileValue } from './converters'
 // Currency value narrowing — shared by every render/edit surface

--- a/packages/lib/src/field-values/converters/calendar-date.ts
+++ b/packages/lib/src/field-values/converters/calendar-date.ts
@@ -1,0 +1,76 @@
+// packages/lib/src/field-values/converters/calendar-date.ts
+
+import type { DateFieldValue, TypedFieldValue, TypedFieldValueInput } from '@auxx/types/field-value'
+import { DEFAULT_DATE_OPTIONS } from '../../custom-fields/defaults'
+import { normalizeCalendarDayIso } from '../calendar-day'
+import { dateConverter } from './date'
+import type { FieldOptions, FieldValueConverter } from './index'
+
+/**
+ * Converter for `FieldType.DATE` only.
+ *
+ * A DATE value is a calendar day stored as `YYYY-MM-DDT00:00:00.000Z`
+ * (plans/money/tasks/33-calendar-day-fields.md §3). Input is normalised to that
+ * form by `normalizeCalendarDayIso`, and display always formats in UTC with no
+ * time component, so writer and viewer in different zones read the same day.
+ *
+ * DATETIME and TIME are instants and keep `dateConverter`.
+ */
+export const calendarDateConverter: FieldValueConverter = {
+  /**
+   * Convert raw input to TypedFieldValueInput.
+   * Accepts a bare `YYYY-MM-DD`, any parseable instant string, a Date, an epoch
+   * number, an already-typed `{ type: 'date', value }`, or null/undefined.
+   */
+  toTypedInput(value: unknown): TypedFieldValueInput | null {
+    const iso = normalizeCalendarDayIso(unwrapTyped(value))
+    return iso ? { type: 'date', value: iso } : null
+  },
+
+  /**
+   * Convert TypedFieldValue/Input to the canonical UTC-midnight ISO string.
+   */
+  toRawValue(value: TypedFieldValue | TypedFieldValueInput | unknown): string | null {
+    return normalizeCalendarDayIso(unwrapTyped(value))
+  },
+
+  /**
+   * Convert TypedFieldValue to display string.
+   *
+   * Always renders the stored UTC calendar day: `timeZone` is pinned to UTC and
+   * `includeTime` is ignored. `iso` yields the bare `YYYY-MM-DD`.
+   */
+  toDisplayValue(value: TypedFieldValue | TypedFieldValueInput, options?: FieldOptions): string {
+    if (!value) return ''
+
+    const iso = normalizeCalendarDayIso((value as DateFieldValue).value)
+    if (!iso) return ''
+
+    const opts = { ...DEFAULT_DATE_OPTIONS, ...options }
+
+    switch (opts.format) {
+      case 'iso':
+        return iso.slice(0, 10)
+      case 'relative':
+        return dateConverter.toDisplayValue(
+          { type: 'date', value: iso },
+          { format: 'relative' }
+        ) as string
+      case 'short':
+        return new Date(iso).toLocaleString(undefined, { timeZone: 'UTC', dateStyle: 'short' })
+      case 'long':
+        return new Date(iso).toLocaleString(undefined, { timeZone: 'UTC', dateStyle: 'long' })
+      default:
+        return new Date(iso).toLocaleString(undefined, { timeZone: 'UTC', dateStyle: 'medium' })
+    }
+  },
+}
+
+/** The inner value of an already-typed date, or the input itself. */
+function unwrapTyped(value: unknown): unknown {
+  if (typeof value === 'object' && value !== null && 'type' in value) {
+    const typed = value as TypedFieldValue
+    return typed.type === 'date' ? (typed as DateFieldValue).value : null
+  }
+  return value
+}

--- a/packages/lib/src/field-values/converters/index.ts
+++ b/packages/lib/src/field-values/converters/index.ts
@@ -67,6 +67,7 @@ export interface FieldValueConverter {
 import { actorConverter } from './actor'
 import { booleanConverter } from './boolean'
 import { calcConverter } from './calc'
+import { calendarDateConverter } from './calendar-date'
 import {
   currencyConverter,
   normalizeCurrencyCode,
@@ -107,8 +108,9 @@ export const converters: Record<StoredFieldType, FieldValueConverter> = {
   // Boolean - stores as valueBoolean in database
   CHECKBOX: booleanConverter,
 
-  // Date family - store as valueDate in database
-  DATE: dateConverter,
+  // Date family - store as valueDate in database.
+  // DATE is a calendar day (UTC midnight); DATETIME and TIME are instants.
+  DATE: calendarDateConverter,
   DATETIME: dateConverter,
   TIME: dateConverter,
 
@@ -140,6 +142,7 @@ export {
   numberConverter,
   currencyConverter,
   booleanConverter,
+  calendarDateConverter,
   dateConverter,
   selectConverter,
   relationshipConverter,

--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -838,7 +838,12 @@ export async function validateSingleValue(
       return { type: 'boolean', value: result.data ?? false }
     }
 
-    case 'DATE':
+    case 'DATE': {
+      const result = ctx.validator.validateCalendarDate(value)
+      if (!result.success) throwValidationError(result)
+      return { type: 'date', value: result.data || '' }
+    }
+
     case 'DATETIME':
     case 'TIME': {
       const result = ctx.validator.validateDate(value)

--- a/packages/lib/src/field-values/field-value-validator.ts
+++ b/packages/lib/src/field-values/field-value-validator.ts
@@ -11,6 +11,7 @@ import {
 import { formatPhoneNumber } from '@auxx/utils/contact'
 import { formatEmail } from '@auxx/utils/email'
 import { z } from 'zod'
+import { normalizeCalendarDayIso } from './calendar-day'
 
 /**
  * Validation schemas for each field type using Zod.
@@ -59,6 +60,19 @@ const dateSchema = z.unknown().transform((v, ctx) => {
   return date.toISOString()
 })
 
+// DATE only: a calendar day, normalised to `YYYY-MM-DDT00:00:00.000Z`
+// (plans/money/tasks/33-calendar-day-fields.md §3). A null/empty input is
+// rejected here exactly as `dateSchema` rejects it; clearing a value is decided
+// upstream in `validateAndConvertValue`, which never reaches a schema for null.
+const calendarDateSchema = z.unknown().transform((v, ctx) => {
+  const iso = normalizeCalendarDayIso(v)
+  if (!iso) {
+    ctx.addIssue({ code: 'custom', message: 'Invalid date value' })
+    return z.NEVER
+  }
+  return iso
+})
+
 // Field-specific schemas
 export const fieldValueSchemas = {
   // TEXT, RICH_TEXT, ADDRESS
@@ -101,8 +115,11 @@ export const fieldValueSchemas = {
   // CHECKBOX
   boolean: booleanSchema,
 
-  // DATE, DATETIME, TIME
+  // DATETIME, TIME
   date: dateSchema,
+
+  // DATE
+  calendarDate: calendarDateSchema,
 
   // SINGLE_SELECT, MULTI_SELECT, TAGS
   option: z
@@ -259,10 +276,17 @@ export class FieldValueValidator {
   }
 
   /**
-   * Validate date/datetime/time
+   * Validate datetime/time (an instant)
    */
   validateDate(value: unknown) {
     return fieldValueSchemas.date.safeParse(value)
+  }
+
+  /**
+   * Validate a DATE (a calendar day, normalised to UTC midnight)
+   */
+  validateCalendarDate(value: unknown) {
+    return fieldValueSchemas.calendarDate.safeParse(value)
   }
 
   /**

--- a/packages/lib/src/import/resolution/resolvers/__tests__/date.test.ts
+++ b/packages/lib/src/import/resolution/resolvers/__tests__/date.test.ts
@@ -1,0 +1,105 @@
+// packages/lib/src/import/resolution/resolvers/__tests__/date.test.ts
+
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ResolutionConfig } from '../../../types/resolution'
+import { resolveDateCustom, resolveDateIso } from '../date'
+
+const none: ResolutionConfig = {}
+const dmy: ResolutionConfig = { dateFormat: 'dd/MM/yyyy' }
+
+/**
+ * Zones on both sides of UTC plus one past the date line. A DATE cell must
+ * resolve to the same day in all of them; before this the resolvers froze a
+ * host-local midnight, which read as the previous day everywhere east of UTC.
+ */
+const ZONES = ['Europe/Berlin', 'America/Los_Angeles', 'Pacific/Auckland'] as const
+
+const originalTz = process.env.TZ
+
+afterEach(() => {
+  if (originalTz === undefined) delete process.env.TZ
+  else process.env.TZ = originalTz
+})
+
+/** The resolved value, or a marker so a failure reads clearly. */
+function read(
+  resolve: typeof resolveDateIso,
+  raw: string,
+  config: ResolutionConfig = none
+): unknown {
+  const result = resolve(raw, config)
+  return result.type === 'error' ? `ERROR: ${result.error}` : result.value
+}
+
+describe('resolveDateIso: a DATE cell is a calendar day, not a host-local instant', () => {
+  for (const zone of ZONES) {
+    it(`emits the typed day as a bare YYYY-MM-DD in ${zone}`, () => {
+      process.env.TZ = zone
+      expect(read(resolveDateIso, '2026-05-10')).toBe('2026-05-10')
+      expect(read(resolveDateIso, ' 2026-05-10 ')).toBe('2026-05-10')
+      // Year boundary and a DST switch day: the local fields still name the day.
+      expect(read(resolveDateIso, '2026-12-31')).toBe('2026-12-31')
+      expect(read(resolveDateIso, '2026-03-29')).toBe('2026-03-29')
+    })
+  }
+
+  it('never emits an instant for a bare day, whatever the host zone', () => {
+    for (const zone of ZONES) {
+      process.env.TZ = zone
+      const value = read(resolveDateIso, '2026-05-10')
+      expect(typeof value).toBe('string')
+      expect(value).not.toContain('T')
+    }
+  })
+
+  for (const zone of ZONES) {
+    it(`keeps a cell that carries a time as a full ISO instant in ${zone}`, () => {
+      // `date:iso` is offered on DATETIME targets too; a real datetime cell
+      // must not lose its time. On a DATE target the write funnel rounds it.
+      process.env.TZ = zone
+      expect(read(resolveDateIso, '2026-05-10T14:30:00Z')).toBe('2026-05-10T14:30:00.000Z')
+      expect(read(resolveDateIso, '2026-05-10T00:00:00+02:00')).toBe('2026-05-09T22:00:00.000Z')
+      expect(read(resolveDateIso, '2026-05-10 14:30:00Z')).toBe('2026-05-10T14:30:00.000Z')
+    })
+  }
+
+  it('reads a blank cell as null', () => {
+    expect(read(resolveDateIso, '')).toBeNull()
+    expect(read(resolveDateIso, '   ')).toBeNull()
+  })
+
+  it('refuses a cell that is not an ISO date', () => {
+    expect(read(resolveDateIso, '10/05/2026')).toMatch(/Invalid ISO date/)
+    expect(read(resolveDateIso, 'May 10, 2026')).toMatch(/Invalid ISO date/)
+    expect(read(resolveDateIso, '2026-13-40')).toMatch(/Invalid ISO date/)
+  })
+})
+
+describe('resolveDateCustom: the same day in every zone', () => {
+  for (const zone of ZONES) {
+    it(`emits the typed day as a bare YYYY-MM-DD in ${zone}`, () => {
+      process.env.TZ = zone
+      expect(read(resolveDateCustom, '10/05/2026', dmy)).toBe('2026-05-10')
+      expect(read(resolveDateCustom, '31/12/2026', dmy)).toBe('2026-12-31')
+      expect(read(resolveDateCustom, '01/01/2026', dmy)).toBe('2026-01-01')
+    })
+  }
+
+  it('honours the configured format', () => {
+    expect(read(resolveDateCustom, '05/10/2026', { dateFormat: 'MM/dd/yyyy' })).toBe('2026-05-10')
+    expect(read(resolveDateCustom, '10.05.2026', { dateFormat: 'dd.MM.yyyy' })).toBe('2026-05-10')
+  })
+
+  it('reads a blank cell as null', () => {
+    expect(read(resolveDateCustom, '', dmy)).toBeNull()
+  })
+
+  it('refuses a cell that does not match the format', () => {
+    expect(read(resolveDateCustom, '2026-05-10', dmy)).toMatch(/Invalid date for format/)
+    expect(read(resolveDateCustom, '32/05/2026', dmy)).toMatch(/Invalid date for format/)
+  })
+
+  it('refuses to guess when no format is configured', () => {
+    expect(read(resolveDateCustom, '10/05/2026', none)).toMatch(/Date format not configured/)
+  })
+})

--- a/packages/lib/src/import/resolution/resolvers/date.ts
+++ b/packages/lib/src/import/resolution/resolvers/date.ts
@@ -1,10 +1,30 @@
 // packages/lib/src/import/resolution/resolvers/date.ts
 
-import { isValid, parse, parseISO } from 'date-fns'
+import { format, isValid, parse, parseISO } from 'date-fns'
 import type { ResolutionConfig, ResolvedValue } from '../../types/resolution'
+
+/** A `T` or space followed by a digit: the cell carries a time-of-day. */
+const HAS_TIME_PART = /[T ]\d/
+
+/**
+ * The calendar day a parsed `Date` names, as a bare `YYYY-MM-DD`.
+ *
+ * date-fns parsers return the typed day at HOST-local midnight, and freezing
+ * that instant into the resolution row made an imported day depend on where
+ * the worker ran (UTC in prod, Pacific on a laptop). `format` reads the local
+ * fields back, which is exactly the day the cell said, in every zone. The
+ * write funnel turns the bare day into the canonical UTC midnight.
+ */
+function toCalendarDay(parsed: Date): string {
+  return format(parsed, 'yyyy-MM-dd')
+}
 
 /**
  * Resolve ISO date string (YYYY-MM-DD).
+ *
+ * Emits a bare day. `date:iso` is also offered on DATETIME targets, so a cell
+ * that carries a time (`2026-05-10T14:30:00Z`) keeps it as a full ISO instant;
+ * on a DATE target the write funnel rounds that to the nearest UTC midnight.
  */
 export function resolveDateIso(rawValue: string, _config: ResolutionConfig): ResolvedValue {
   const trimmed = rawValue.trim()
@@ -19,11 +39,15 @@ export function resolveDateIso(rawValue: string, _config: ResolutionConfig): Res
     return { type: 'error', error: `Invalid ISO date: ${rawValue}` }
   }
 
-  return { type: 'value', value: parsed }
+  if (HAS_TIME_PART.test(trimmed)) {
+    return { type: 'value', value: parsed.toISOString() }
+  }
+
+  return { type: 'value', value: toCalendarDay(parsed) }
 }
 
 /**
- * Resolve date with custom format.
+ * Resolve date with custom format. Emits a bare `YYYY-MM-DD`.
  */
 export function resolveDateCustom(rawValue: string, config: ResolutionConfig): ResolvedValue {
   const trimmed = rawValue.trim()
@@ -32,18 +56,18 @@ export function resolveDateCustom(rawValue: string, config: ResolutionConfig): R
     return { type: 'value', value: null }
   }
 
-  const format = config.dateFormat
-  if (!format) {
+  const pattern = config.dateFormat
+  if (!pattern) {
     return { type: 'error', error: 'Date format not configured' }
   }
 
-  const parsed = parse(trimmed, format, new Date())
+  const parsed = parse(trimmed, pattern, new Date())
 
   if (!isValid(parsed)) {
-    return { type: 'error', error: `Invalid date for format ${format}: ${rawValue}` }
+    return { type: 'error', error: `Invalid date for format ${pattern}: ${rawValue}` }
   }
 
-  return { type: 'value', value: parsed }
+  return { type: 'value', value: toCalendarDay(parsed) }
 }
 
 /**
@@ -75,15 +99,15 @@ export function resolveDatetimeCustom(rawValue: string, config: ResolutionConfig
     return { type: 'value', value: null }
   }
 
-  const format = config.timestampFormat || config.dateFormat
-  if (!format) {
+  const pattern = config.timestampFormat || config.dateFormat
+  if (!pattern) {
     return { type: 'error', error: 'Datetime format not configured' }
   }
 
-  const parsed = parse(trimmed, format, new Date())
+  const parsed = parse(trimmed, pattern, new Date())
 
   if (!isValid(parsed)) {
-    return { type: 'error', error: `Invalid datetime for format ${format}: ${rawValue}` }
+    return { type: 'error', error: `Invalid datetime for format ${pattern}: ${rawValue}` }
   }
 
   return { type: 'value', value: parsed }

--- a/packages/lib/src/resources/merge/merge-service.ts
+++ b/packages/lib/src/resources/merge/merge-service.ts
@@ -315,8 +315,8 @@ export class EntityMergeService {
     // Convert field array to map for quick lookup
     const fieldMap = new Map(fields.map((f) => [f.id, f]))
 
-    // FieldValueService.setValue internally uses formatToTypedInput
-    // to convert raw values → TypedFieldValueInput
+    // setValuesForEntity runs each raw value through validateAndConvertValue
+    // (the validator schemas), not formatToTypedInput, to build the TypedFieldValueInput
     await fieldValueService.setValuesForEntity({
       recordId: targetRecordId,
       values: mergedValues,

--- a/packages/seed/src/domains/ticket.domain.ts
+++ b/packages/seed/src/domains/ticket.domain.ts
@@ -229,8 +229,14 @@ export class TicketDomain {
     return new Date(Date.now() - daysAgo * 86400000)
   }
 
-  /** generateTicketDueDate creates priority-based due dates. */
-  private generateTicketDueDate(status: string, priority: string, createdAt: Date): Date | null {
+  /**
+   * generateTicketDueDate creates priority-based due dates.
+   *
+   * `due_date` is a DATE field, a calendar day, so this returns the bare
+   * `YYYY-MM-DD` of the computed instant's UTC day rather than the instant
+   * itself: the write funnel stores a day at UTC midnight, never a time-of-day.
+   */
+  private generateTicketDueDate(status: string, priority: string, createdAt: Date): string | null {
     // Open/In Progress tickets have due dates
     if (!['OPEN', 'IN_PROGRESS'].includes(status)) {
       return null
@@ -245,7 +251,7 @@ export class TicketDomain {
     }
 
     const hours = urgencyHours[priority as keyof typeof urgencyHours] || 72
-    return new Date(baseTime + hours * 3600000)
+    return new Date(baseTime + hours * 3600000).toISOString().slice(0, 10)
   }
 
   /** generateTicketTitle creates type-appropriate titles. */


### PR DESCRIPTION
## Summary

A `FieldType.DATE` value was a full instant that every writer and reader interpreted differently. The date picker wrote the viewer's local midnight, generic display rendered in the viewer's zone, and the day-key readers (tariff rate resolution, quote expiry, invoice overdue, filter SQL) read a UTC day. A UTC+2 writer picking May 10 stored `2026-05-09T22:00:00Z`, which read as May 9 to every UTC-day reader and to any teammate west of UTC.

This declares the contract on the type: **a DATE is a calendar day, stored as `YYYY-MM-DDT00:00:00.000Z`**, and every reader slices or formats it in UTC. DATETIME and TIME are instants and are untouched.

## What changed

- **One shared rule** in `packages/lib/src/field-values/calendar-day.ts`, exported from the client subpath: a bare `YYYY-MM-DD` maps to UTC midnight; any other parseable instant rounds to the **nearest** UTC midnight. Rounding rather than truncating is what keeps the SDK, connector sinks, agent tools, workflow templates and the date-time node's offset ISO correct without touching any of them.
- **Both server normalisers** apply it for DATE: a DATE-only converter in the converter map, and `calendarDateSchema` in the validator, which is the funnel behind `handler.create`/`update` and `applyBulk`.
- **Browser doors emit the day directly**: the date picker, the picker's re-pick (date mode no longer preserves a stray time-of-day), grid paste coercion, the filter picker (opt-in `dateOnly`, the component has no callers), and the workflow `DateTimeInput` that `FieldInputAdapter` actually renders for DATE fields.
- **CSV import** resolvers emit a bare day instead of a host-local `Date`; a `date:iso` cell that carries a time keeps it, since that resolver is also offered on DATETIME targets.
- **DataMigration `106-date-fields-utc-midnight`** rounds existing DATE values to the nearest UTC midnight. It is a runtime DataMigration rather than a drizzle SQL file because nothing in the schema depends on it, and a large `FieldValue` UPDATE should not sit inside the deploy migration transaction. Dry run on the local DB: 436 rows, all seed noise plus about twenty picker-written rows at 07:00/08:00 UTC.
- The ticket seeder and the docket marketing script write days, not instants.
- Stale comments fixed in `merge-service.ts`, `vendor-cost.ts` and `tariff-rate-history.tsx`. Kopilot's field listing now hints `YYYY-MM-DD` for DATE fields.

The rewritten brief with the full door table and the reasons a per-field flag was rejected is in `plans/money/tasks/33-calendar-day-fields.md` (untracked plans dir).

## Verification

- lib typecheck ratchet: no new errors (27 total, baseline 29). web ratchet: 0 errors. database typecheck: clean.
- Full `packages/lib` suite: 15006 passed, 2 failed, 79 skipped. The two failures are in the vendor-bill delete guard and the tariff-codes visibility test, both untouched by this change and both failing on `main`.
- New tests: 52 for the calendar-day rule, converter and validator with per-zone `TZ` pinning; 16 for the import resolvers; 12 for grid paste; 5 integration tests for migration 106.
- **Driven in two zones** through the real date picker on Parts > Settings > Tariffs: a May 10 pick from America/Los_Angeles and from Europe/Berlin both stored `2026-05-10T00:00:00.000Z` and render as `2026-05-10` when viewed from the other zone.

## After merge

- Run the count query from the brief's section 1.2 against prod before the maintenance job fires migration 106, and note the number.
- `FilterDatePicker` is dead code and can be deleted in a cleanup.

https://claude.ai/code/session_01Hq3kMaZsS7dvNETxTu45EG
