### PR TITLE
fix(import): relation auto-create stores a RecordId, and a create that loses a required field fails

### DIFF
--- a/packages/lib/scripts/repair-empty-vendor-parts.ts
+++ b/packages/lib/scripts/repair-empty-vendor-parts.ts
@@ -1,0 +1,223 @@
+// packages/lib/scripts/repair-empty-vendor-parts.ts
+//
+// Repair or delete supplier offers (`vendor_part`) that have NO supplier.
+//
+// WHY THEY EXIST
+//
+//   The importer's relation auto-create stored the minted company's bare
+//   instance id, the write path refused it, and the create swallowed the
+//   refusal, so the offer landed with a part, a SKU and a price but no
+//   supplier (plans/importer/09-relation-create-record-id.md §1). A re-run
+//   could not match those offers by (part, supplier) and created a second,
+//   correct offer next to each one.
+//
+// WHAT THIS DOES, PER EMPTY OFFER
+//
+//   The intended supplier is still recoverable: the offer's `ImportPlanRow`
+//   names its row, the row's raw Supplier cell hashes to the job's resolution,
+//   and that resolution still holds the bare company id. With that in hand:
+//
+//   - the (part, company) pair ALREADY has an offer with a supplier
+//       => DELETE the empty one; it is the duplicate.
+//   - the pair has no other offer and the company still exists
+//       => REPAIR: write the supplier link.
+//   - the company no longer exists, or the offer has no import row at all
+//       => REPORTED and left alone. Decide those by hand.
+//
+// EVERY WRITE GOES THROUGH `UnifiedCrudHandler` under the default interactive
+// session, so the `mfg-vendor-parts-deleted` lifecycle rule and the field
+// seams fire and part cost is recalculated by the rules engine. The script
+// ALSO calls `recalculateAffectedParts` for the touched parts at the end, so
+// the cost is right even if the events lane is down when it runs.
+//
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/repair-empty-vendor-parts.ts --org <orgId> [--dry-run]
+//
+// Run it with `--dry-run` first and read the plan it prints.
+
+import { database as db } from '@auxx/database'
+import { toRecordId } from '@auxx/types/resource'
+import { sql } from 'drizzle-orm'
+import { recalculateAffectedParts } from '../src/bom'
+import { UnifiedCrudHandler } from '../src/resources/crud'
+import { SystemUserService } from '../src/users/system-user-service'
+
+const DRY_RUN = process.argv.includes('--dry-run')
+
+function argValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+/** One empty offer whose import row still names its supplier. */
+interface ChainRow extends Record<string, unknown> {
+  offerId: string
+  offerDefId: string
+  partId: string | null
+  jobId: string
+  rowIndex: number
+  supplierCell: string | null
+  companyId: string | null
+  companyDefId: string | null
+  pairHasGoodOffer: boolean
+}
+
+/** One empty offer with no import row behind it. */
+interface OrphanRow extends Record<string, unknown> {
+  offerId: string
+  createdAt: string
+}
+
+async function findChain(organizationId: string): Promise<ChainRow[]> {
+  const { rows } = await db.execute<ChainRow>(sql`
+    with orphans as (
+      select ei.id, ei."entityDefinitionId" as def_id
+      from "EntityInstance" ei
+      join "EntityDefinition" ed on ed.id = ei."entityDefinitionId" and ed."entityType" = 'vendor_part'
+      join "CustomField" cf on cf."entityDefinitionId" = ed.id and cf."systemAttribute" = 'vendor_part_contact'
+      left join "FieldValue" fv on fv."entityId" = ei.id and fv."fieldId" = cf.id
+      where ei."organizationId" = ${organizationId} and ei."archivedAt" is null and fv.id is null
+    ),
+    chain as (
+      select o.id as offer_id, o.def_id, j.id as job_id, pr."rowIndex" as row_index,
+             rd.value as supplier_cell,
+             r."resolvedValues"->0->>'value' as company_id
+      from orphans o
+      join "ImportPlanRow" pr on pr."resultRecordId" = o.id
+      join "ImportPlanStrategy" ps on ps.id = pr."importPlanStrategyId"
+      join "ImportPlan" p on p.id = ps."importPlanId"
+      join "ImportJob" j on j.id = p."importJobId"
+      join "ImportMapping" m on m.id = j."importMappingId"
+      join "ImportMappingProperty" mp on mp."importMappingId" = m.id and mp."targetFieldKey" = 'vendor_part_contact'
+      join "ImportJobRawData" rd on rd."importJobId" = j.id and rd."rowIndex" = pr."rowIndex" and rd."columnIndex" = mp."sourceColumnIndex"
+      join "ImportJobProperty" jp on jp."importJobId" = j.id and jp."importMappingPropertyId" = mp.id
+      join "ImportValueResolution" r on r."importJobPropertyId" = jp.id and r."hashedValue" = rd."valueHash"
+    )
+    select
+      c.offer_id as "offerId",
+      c.def_id as "offerDefId",
+      pfv."relatedEntityId" as "partId",
+      c.job_id as "jobId",
+      c.row_index as "rowIndex",
+      c.supplier_cell as "supplierCell",
+      company.id as "companyId",
+      company."entityDefinitionId" as "companyDefId",
+      exists (
+        select 1 from "EntityInstance" x
+        join "FieldValue" sfv on sfv."entityId" = x.id and sfv."fieldId" = scf.id and sfv."relatedEntityId" = company.id
+        join "FieldValue" pfv2 on pfv2."entityId" = x.id and pfv2."fieldId" = pcf.id and pfv2."relatedEntityId" = pfv."relatedEntityId"
+        where x."entityDefinitionId" = c.def_id and x."archivedAt" is null and x.id <> c.offer_id
+      ) as "pairHasGoodOffer"
+    from chain c
+    join "CustomField" pcf on pcf."entityDefinitionId" = c.def_id and pcf."systemAttribute" = 'vendor_part_part'
+    join "CustomField" scf on scf."entityDefinitionId" = c.def_id and scf."systemAttribute" = 'vendor_part_contact'
+    left join "FieldValue" pfv on pfv."entityId" = c.offer_id and pfv."fieldId" = pcf.id
+    left join "EntityInstance" company
+      on company.id = split_part(c.company_id, ':', array_length(string_to_array(c.company_id, ':'), 1))
+     and company."organizationId" = ${organizationId} and company."archivedAt" is null
+    order by c.job_id, c.row_index
+  `)
+  return rows
+}
+
+async function findWithoutImportRow(organizationId: string): Promise<OrphanRow[]> {
+  const { rows } = await db.execute<OrphanRow>(sql`
+    select ei.id as "offerId", ei."createdAt" as "createdAt"
+    from "EntityInstance" ei
+    join "EntityDefinition" ed on ed.id = ei."entityDefinitionId" and ed."entityType" = 'vendor_part'
+    join "CustomField" cf on cf."entityDefinitionId" = ed.id and cf."systemAttribute" = 'vendor_part_contact'
+    left join "FieldValue" fv on fv."entityId" = ei.id and fv."fieldId" = cf.id
+    left join "ImportPlanRow" pr on pr."resultRecordId" = ei.id
+    where ei."organizationId" = ${organizationId} and ei."archivedAt" is null and fv.id is null and pr.id is null
+    order by ei."createdAt"
+  `)
+  return rows
+}
+
+async function main() {
+  const organizationId = argValue('--org')
+  if (!organizationId) {
+    console.error('Usage: repair-empty-vendor-parts.ts --org <orgId> [--dry-run]')
+    process.exit(2)
+  }
+
+  console.log(DRY_RUN ? 'DRY RUN: nothing is written\n' : 'APPLYING\n')
+
+  const chain = await findChain(organizationId)
+  const noRow = await findWithoutImportRow(organizationId)
+
+  const toDelete = chain.filter((r) => r.companyId && r.pairHasGoodOffer)
+  const toRepair = chain.filter((r) => r.companyId && !r.pairHasGoodOffer && r.partId)
+  const unresolved = chain.filter((r) => !r.companyId || !r.partId)
+
+  console.log(`Empty supplier offers in org ${organizationId}: ${chain.length + noRow.length}\n`)
+  console.log(`  delete (pair already has a good offer)   ${toDelete.length}`)
+  console.log(`  repair (write the supplier link)         ${toRepair.length}`)
+  console.log(`  left alone: company or part not found    ${unresolved.length}`)
+  console.log(`  left alone: no import row                ${noRow.length}\n`)
+
+  for (const r of toDelete) {
+    console.log(`  DELETE ${r.offerId}  row ${r.rowIndex}  "${r.supplierCell}"  ${r.companyId}`)
+  }
+  for (const r of toRepair) {
+    console.log(`  REPAIR ${r.offerId}  row ${r.rowIndex}  "${r.supplierCell}"  -> ${r.companyId}`)
+  }
+  for (const r of unresolved) {
+    console.log(`  SKIP   ${r.offerId}  row ${r.rowIndex}  "${r.supplierCell}"  (unresolved)`)
+  }
+  for (const r of noRow) {
+    console.log(`  SKIP   ${r.offerId}  created ${r.createdAt}  (no import row)`)
+  }
+
+  if (DRY_RUN) {
+    console.log('\nDry run complete. Nothing was written.')
+    process.exit(0)
+  }
+
+  const userId = await SystemUserService.getSystemUserForActions(organizationId)
+  // Default interactive session on purpose: the lifecycle rules that keep
+  // part cost right listen on the events this lane publishes.
+  const handler = new UnifiedCrudHandler(organizationId, userId, db)
+
+  const touchedParts = new Set<string>()
+  let deleted = 0
+  let repaired = 0
+  let failed = 0
+
+  for (const r of toDelete) {
+    try {
+      await handler.delete(toRecordId(r.offerDefId, r.offerId))
+      if (r.partId) touchedParts.add(r.partId)
+      deleted++
+    } catch (error) {
+      failed++
+      console.error(`  FAILED delete ${r.offerId}: ${(error as Error).message}`)
+    }
+  }
+
+  for (const r of toRepair) {
+    try {
+      await handler.update(toRecordId(r.offerDefId, r.offerId), {
+        vendor_part_contact: toRecordId(r.companyDefId as string, r.companyId as string),
+      })
+      if (r.partId) touchedParts.add(r.partId)
+      repaired++
+    } catch (error) {
+      failed++
+      console.error(`  FAILED repair ${r.offerId}: ${(error as Error).message}`)
+    }
+  }
+
+  if (touchedParts.size > 0) {
+    const changed = await recalculateAffectedParts(organizationId, [...touchedParts])
+    console.log(`\nRecalculated ${touchedParts.size} parts, ${changed.length} cost values changed.`)
+  }
+
+  console.log(`\nDeleted ${deleted}, repaired ${repaired}, ${failed} failed.`)
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -3474,6 +3474,7 @@ export async function setValuesForEntity(
           performedAt: new Date().toISOString(),
           values: [],
           changed: false,
+          error: error instanceof Error ? error.message : String(error),
         })
       } finally {
         // The pre-read snapshot for this pair is stale the moment the pair

--- a/packages/lib/src/field-values/types.ts
+++ b/packages/lib/src/field-values/types.ts
@@ -293,6 +293,13 @@ export interface SetValuesResult {
   values: TypedFieldValue[]
   /** See {@link SetValueResult.changed} — real change vs idempotent no-op. */
   changed?: boolean
+  /**
+   * Why the write failed, present only when `state === 'failed'`.
+   * `setValuesForEntity` swallows a per-field throw so the other fields still
+   * land; this is the message it swallowed, so a caller that must not accept a
+   * partial record (a create losing a required field) can refuse it.
+   */
+  error?: string
 }
 
 /**

--- a/packages/lib/src/import/resolution/__tests__/materialize-relation-creates.test.ts
+++ b/packages/lib/src/import/resolution/__tests__/materialize-relation-creates.test.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/import/resolution/__tests__/materialize-relation-creates.test.ts
 
+import { isRecordId } from '@auxx/types/resource'
 import { PgDialect } from 'drizzle-orm/pg-core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BaseType } from '../../../resources/types'
@@ -156,8 +157,32 @@ describe('materializeRelationCreates', () => {
     for (const write of writes) {
       expect(write.status).toBe('valid')
       expect(write.isValid).toBe('true')
-      expect(write.resolvedValues).toEqual([{ type: 'value', value: 'company-new' }])
+      expect(write.resolvedValues).toEqual([{ type: 'value', value: 'def-company:company-new' }])
     }
+  })
+
+  it('stores the minted target as a full RecordId, the same shape the match path stores', async () => {
+    // A bare `EntityInstance.id` is rejected by the write path's `recordIdSchema`
+    // and the rejection is swallowed per field, so the importer used to land a
+    // record with every field except the link. The RecordId is built on the
+    // org's def CUID, never on the request's slug.
+    const { db, statements } = buildFakeDb([
+      pendingRow('res-1', 'Acme Motors', { entityDefinitionId: 'company' }),
+    ])
+    const createRecord = vi.fn(async () => ({ id: 'company-new' }))
+
+    await materializeRelationCreates(db, {
+      organizationId: 'org-1',
+      jobId: 'job-1',
+      userId: 'user-1',
+      createRecord,
+      ...allow,
+    })
+
+    const [write] = allWrites(statements)
+    const value = (write?.resolvedValues as Array<{ value: string }>)[0]?.value
+    expect(isRecordId(value)).toBe(true)
+    expect(value).toBe('def-company:company-new')
   })
 
   it('mints the RAW cell onto the display field, addressed by its CustomField id', async () => {
@@ -226,7 +251,9 @@ describe('materializeRelationCreates', () => {
     for (const id of ['res-1', 'res-3']) {
       expect(byId.get(id)?.status).toBe('valid')
       expect(byId.get(id)?.isValid).toBe('true')
-      expect(byId.get(id)?.resolvedValues).toEqual([{ type: 'value', value: 'company-acme' }])
+      expect(byId.get(id)?.resolvedValues).toEqual([
+        { type: 'value', value: 'def-company:company-acme' },
+      ])
       expect(byId.get(id)?.errorMessage).toBeNull()
     }
     expect(byId.get('res-2')?.status).toBe('error')
@@ -256,9 +283,9 @@ describe('materializeRelationCreates', () => {
     expect(statements.map((s) => s.writes.length)).toEqual([500, 500, 201])
     const writes = allWrites(statements)
     expect(writes).toHaveLength(total)
-    expect(writes[0]?.resolvedValues).toEqual([{ type: 'value', value: 'company-0' }])
+    expect(writes[0]?.resolvedValues).toEqual([{ type: 'value', value: 'def-company:company-0' }])
     expect(writes[total - 1]?.resolvedValues).toEqual([
-      { type: 'value', value: `company-${total - 1}` },
+      { type: 'value', value: `def-company:company-${total - 1}` },
     ])
   })
 

--- a/packages/lib/src/import/resolution/materialize-relation-creates.ts
+++ b/packages/lib/src/import/resolution/materialize-relation-creates.ts
@@ -2,6 +2,7 @@
 
 import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
 import { getCachedResource } from '../../cache'
 import { ForbiddenError } from '../../errors'
 import type { RelationCreateRequest, ResolvedValue } from '../types/resolution'
@@ -53,8 +54,18 @@ export interface MaterializeRelationCreatesResult {
   failures: Array<{ entityDefinitionId: string; value: string; error: string }>
 }
 
-/** One distinct target: either minted, or failed with a reason. */
-type MintOutcome = { id: string } | { error: string }
+/**
+ * One distinct target: either minted, or failed with a reason.
+ *
+ * A minted target is carried as a full `defId:instanceId` RecordId, never the
+ * bare `EntityInstance.id` the writer returns. The write path's `relationship`
+ * arm parses the stored value with `recordIdSchema`, which requires the colon,
+ * so a bare id is rejected at write time; and because `setValuesForEntity`
+ * swallows a per-field throw, the rejection surfaced as a record created with
+ * every field EXCEPT the link. The match path (`resolve-relation-lookups.ts`)
+ * has stored a RecordId for the same reason; this is the same value shape.
+ */
+type MintOutcome = { recordId: RecordId } | { error: string }
 
 /**
  * Every resolution row that shares one mint outcome. Bucketing is what lets N
@@ -128,8 +139,8 @@ export async function materializeRelationCreates(
     let outcome = outcomes.get(key)
     if (!outcome) {
       try {
-        const id = await mintTarget(organizationId, row.request, createRecord)
-        outcome = { id }
+        const recordId = await mintTarget(organizationId, row.request, createRecord)
+        outcome = { recordId }
         created++
         byEntityDefinition[row.request.entityDefinitionId] =
           (byEntityDefinition[row.request.entityDefinitionId] ?? 0) + 1
@@ -184,9 +195,9 @@ async function writeBackOutcomes(db: Database, buckets: WriteBackBucket[]): Prom
 
   for (const bucket of buckets) {
     const settled = bucket.outcome
-    const succeeded = 'id' in settled
+    const succeeded = 'recordId' in settled
     const resolvedValues: ResolvedValue[] = succeeded
-      ? [{ type: 'value', value: settled.id }]
+      ? [{ type: 'value', value: settled.recordId }]
       : [{ type: 'error', error: `Could not create "${bucket.value}": ${settled.error}` }]
     const errorMessage = succeeded ? null : (resolvedValues[0]?.error ?? null)
 
@@ -210,12 +221,16 @@ async function writeBackOutcomes(db: Database, buckets: WriteBackBucket[]): Prom
  * The field is addressed by its CustomField id when it has one and by its key
  * otherwise, the same dual convention `buildRecordData` uses, so the CRUD
  * layer routes it identically to every other imported value.
+ *
+ * Returns the new record as a RecordId built on the org's EntityDefinition
+ * CUID (`resource.entityDefinitionId`), not on `request.entityDefinitionId`,
+ * which may be the bare slug. See {@link MintOutcome}.
  */
 async function mintTarget(
   organizationId: string,
   request: RelationCreateRequest,
   createRecord: RelationTargetWriter
-): Promise<string> {
+): Promise<RecordId> {
   const resource = await getCachedResource(organizationId, request.entityDefinitionId)
   if (!resource) {
     throw new Error(`Relation target not found: ${request.entityDefinitionId}`)
@@ -223,7 +238,7 @@ async function mintTarget(
   const field = resource.fields.find((f) => f.key === request.matchField)
   const dataKey = field?.id ?? request.matchField
   const result = await createRecord(resource.entityDefinitionId, { [dataKey]: request.value })
-  return result.id
+  return toRecordId(resource.entityDefinitionId, result.id)
 }
 
 /** Options for {@link createRelationTargetWriter} */

--- a/packages/lib/src/resources/crud/__tests__/archive-duplicate-pair-cleanup.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/archive-duplicate-pair-cleanup.test.ts
@@ -65,7 +65,7 @@ function ctx(): MutationContext {
     getFields: async () => [],
     runPreHooks: async (_o, _d, values) => values,
     validateUniqueFields: async () => {},
-    setFieldValues: async () => {},
+    setFieldValues: async () => [],
   }
 }
 

--- a/packages/lib/src/resources/crud/__tests__/build-movement-explosion-lanes.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/build-movement-explosion-lanes.test.ts
@@ -206,7 +206,7 @@ function ctx(session: WriteSession): MutationContext {
     getFields: async () => MOVEMENT_FIELDS as never,
     runPreHooks: async (_o, _d, values) => values,
     validateUniqueFields: async () => {},
-    setFieldValues: async () => {},
+    setFieldValues: async () => [],
   }
 }
 

--- a/packages/lib/src/resources/crud/__tests__/bulk-archive-records-changed.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/bulk-archive-records-changed.test.ts
@@ -70,7 +70,7 @@ function ctx(session: WriteSession = interactiveSession('user_1', 'sock_1')): Mu
     getFields: async () => [],
     runPreHooks: async (_o: unknown, _d: unknown, values: unknown) => values,
     validateUniqueFields: async () => {},
-    setFieldValues: async () => {},
+    setFieldValues: async () => [],
   } as never
 }
 

--- a/packages/lib/src/resources/crud/__tests__/create-required-field-failure.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/create-required-field-failure.test.ts
@@ -1,0 +1,159 @@
+// packages/lib/src/resources/crud/__tests__/create-required-field-failure.test.ts
+//
+// A create that loses a REQUIRED field must not succeed. `setValuesForEntity`
+// swallows a per-field throw and continues, which is right for an edit and
+// wrong for a create: the required-presence check ran before coercion, the
+// value was present, coercion refused it, and the record landed without it.
+// The importer produced 232 supplier offers with no supplier this way
+// (plans/importer/09-relation-create-record-id.md §1). `createEntity` now reads
+// the failures `setFieldValues` reports, rolls the instance back when a
+// required field is among them, and throws 422 with the swallowed reason.
+//
+// @auxx/database is globally mocked in src/test/setup.ts; the mutation-seam
+// mocks mirror sync-lifecycle-capture.test.ts.
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  deleteEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  publish: vi.fn(async () => {}),
+  publishLater: vi.fn(() => {}),
+}))
+
+vi.mock('../../../dedup/pairs', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteOpenPairsForRecord: vi.fn(async () => ok(0)),
+}))
+vi.mock('../../../dedup/enqueue-scan', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  enqueueDuplicateScan: vi.fn(async () => 'job_1'),
+}))
+vi.mock('../../../entity-instances', () => ({
+  getEntityInstance: vi.fn(async () => ok({ id: 'inst_1', archivedAt: null })),
+  updateEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  createEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  deleteEntityInstance: h.deleteEntityInstance,
+}))
+vi.mock('../../../realtime', () => ({
+  getRealtimeService: () => ({ publish: h.publish }),
+  publishRecordsChanged: vi.fn(async () => {}),
+  rooms: { orgRecords: () => 'room' },
+}))
+vi.mock('../../../events/publisher', () => ({
+  publisher: { publishLater: h.publishLater, publish: h.publishLater },
+}))
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  findCachedResource: vi.fn(async () => undefined),
+}))
+vi.mock('../../../comments', () => ({
+  CommentService: class {
+    deleteCommentsByRecordId = vi.fn(async () => {})
+  },
+}))
+
+import { UnprocessableEntityError } from '../../../errors'
+import {
+  createEntity,
+  type FieldWriteFailure,
+  type MutationContext,
+} from '../unified-handler-mutations'
+import { interactiveSession } from '../write-origin'
+
+/** Minimal CustomField-shaped rows for the create path's field plumbing. */
+function fieldRow(id: string, systemAttribute: string, required: boolean) {
+  return { id, name: id, systemAttribute, required, isCreatable: true }
+}
+
+function ctx(fields: unknown[], failures: FieldWriteFailure[]): MutationContext {
+  return {
+    db: {} as never,
+    organizationId: 'org_1',
+    userId: 'user_1',
+    session: interactiveSession('user_1'),
+    fieldValueService: {} as never,
+    resolveEntityDefinition: async () => ({
+      id: 'def_1',
+      entityType: 'vendor_part',
+      apiSlug: 'vendor-parts',
+    }),
+    getFields: async () => fields as never,
+    runPreHooks: async (_o, _d, values) => values,
+    validateUniqueFields: async () => {},
+    setFieldValues: async () => failures,
+  }
+}
+
+const REJECTED = 'RecordId must be in format entityDefinitionId:entityInstanceId'
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('createEntity when a field write is swallowed', () => {
+  it('rolls the instance back and throws 422 when the lost field is required', async () => {
+    const fields = [
+      fieldRow('f_part', 'vendor_part_part', true),
+      fieldRow('f_contact', 'vendor_part_contact', true),
+      fieldRow('f_price', 'vendor_part_unit_price', false),
+    ]
+
+    await expect(
+      createEntity(ctx(fields, [{ fieldId: 'f_contact', error: REJECTED }]), 'def_1', {
+        vendor_part_part: 'def_part:part_1',
+        // The bare id the relation materializer used to hand over.
+        vendor_part_contact: 'company_1',
+        vendor_part_unit_price: 1234,
+      })
+    ).rejects.toMatchObject({
+      name: 'UnprocessableEntityError',
+      message: `Could not write required field f_contact: ${REJECTED}`,
+      details: { failedFields: ['vendor_part_contact'] },
+    })
+
+    // The stub is gone, not left behind as a record missing its supplier.
+    expect(h.deleteEntityInstance).toHaveBeenCalledWith({ id: 'inst_1', organizationId: 'org_1' })
+    // Nothing announced a record that no longer exists.
+    expect(h.publish).not.toHaveBeenCalled()
+    expect(h.publishLater).not.toHaveBeenCalled()
+  })
+
+  it('keeps the lenient behaviour when the lost field is optional', async () => {
+    const fields = [
+      fieldRow('f_part', 'vendor_part_part', true),
+      fieldRow('f_note', 'vendor_part_note', false),
+    ]
+
+    const result = await createEntity(
+      ctx(fields, [{ fieldId: 'f_note', error: 'Invalid value' }]),
+      'def_1',
+      { vendor_part_part: 'def_part:part_1', vendor_part_note: 'x' }
+    )
+
+    expect(result.instance.id).toBe('inst_1')
+    expect(h.deleteEntityInstance).not.toHaveBeenCalled()
+  })
+
+  it('names every required field that was lost', async () => {
+    const fields = [
+      fieldRow('f_part', 'vendor_part_part', true),
+      fieldRow('f_contact', 'vendor_part_contact', true),
+    ]
+
+    await expect(
+      createEntity(
+        ctx(fields, [
+          { fieldId: 'f_part', error: 'bad part' },
+          { fieldId: 'f_contact', error: 'bad supplier' },
+        ]),
+        'def_1',
+        { vendor_part_part: 'x', vendor_part_contact: 'y' }
+      )
+    ).rejects.toSatisfy(
+      (e: unknown) =>
+        e instanceof UnprocessableEntityError &&
+        e.details.failedFields?.length === 2 &&
+        e.message.includes('bad part') &&
+        e.message.includes('bad supplier')
+    )
+  })
+})

--- a/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
@@ -185,7 +185,7 @@ async function runScenario(
   const handler = makeHandler()
   // The field-value write itself is not under test (its own doors — per-field
   // timeline, searchText, D-7 content stamp — are the field-value layer's).
-  vi.spyOn(handler.fieldValueService, 'setValuesForEntity').mockResolvedValue(undefined as never)
+  vi.spyOn(handler.fieldValueService, 'setValuesForEntity').mockResolvedValue([])
   const recordId = 'def_1:inst_1' as RecordId
   const create = await observeOp(() => handler.create('contact', { first_name: 'Ada' }, options))
   const update = await observeOp(() =>

--- a/packages/lib/src/resources/crud/__tests__/sync-lifecycle-capture.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/sync-lifecycle-capture.test.ts
@@ -90,7 +90,7 @@ function ctx(session: WriteSession, fields: unknown[] = []): MutationContext {
     getFields: async () => fields as never,
     runPreHooks: async (_o, _d, values) => values,
     validateUniqueFields: async () => {},
-    setFieldValues: async () => {},
+    setFieldValues: async () => [],
   }
 }
 

--- a/packages/lib/src/resources/crud/__tests__/tx-write-scope.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/tx-write-scope.test.ts
@@ -486,7 +486,7 @@ describe('convergence through the REAL createEntity — B-17, the point of Phase
       getFields: async () => [],
       runPreHooks: async (_op: string, _def: unknown, values: Record<string, unknown>) => values,
       validateUniqueFields: async () => {},
-      setFieldValues: vi.fn(async () => {}),
+      setFieldValues: vi.fn(async () => []),
     } as unknown as Parameters<typeof createEntity>[0]
   }
 

--- a/packages/lib/src/resources/crud/__tests__/write-session.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/write-session.test.ts
@@ -152,7 +152,7 @@ describe('S3 — derived publishEvents at the mutation seam', () => {
       getFields: async () => [],
       runPreHooks: async (_o, _d, values) => values,
       validateUniqueFields: async () => {},
-      setFieldValues: async () => {},
+      setFieldValues: async () => [],
     }
   }
 

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -131,12 +131,35 @@ export interface MutationContext {
     values: Record<string, unknown>,
     excludeEntityId?: string
   ) => Promise<void>
+  /**
+   * Write a record's values. Resolves to the SET-lane writes that failed,
+   * because the field-value layer swallows a per-field throw and continues.
+   * See {@link FieldWriteFailure}.
+   */
   setFieldValues: (
     recordId: RecordId,
     values: Record<string, unknown>,
     modes?: Record<string, 'set' | 'add' | 'remove'>,
     opts?: { publishEvents?: boolean }
-  ) => Promise<void>
+  ) => Promise<FieldWriteFailure[]>
+}
+
+/**
+ * One field whose write was refused and swallowed by `setValuesForEntity`.
+ *
+ * On an EDIT this is the lenient behaviour every caller relies on: the other
+ * fields still land and the record stays whole. On a CREATE it is how a
+ * record ends up existing without a required field, because the required
+ * check ran on presence before the coercion that refused the value. The
+ * importer produced 232 supplier offers with no supplier this way: the
+ * relation materializer handed it a bare instance id, `recordIdSchema`
+ * refused it, and the create kept going.
+ */
+export interface FieldWriteFailure {
+  /** `CustomField.id` of the field that did not land */
+  fieldId: string
+  /** The message the field-value layer swallowed */
+  error: string
 }
 
 /**
@@ -420,9 +443,40 @@ export async function createEntity(
   // passes `true` here on purpose: the field-value layer resolves the scope
   // itself and captures instead of publishing, so a `false` would be read as
   // the C3 "an aggregator announces this" escape hatch and lose the writes.
-  await ctx.setFieldValues(recordId, processedValues, undefined, {
+  const failures = await ctx.setFieldValues(recordId, processedValues, undefined, {
     publishEvents: publishEvents || txScope !== undefined,
   })
+
+  // A create that lost a REQUIRED field is not a record, it is a stub that
+  // reads as complete and is not. `assertRequiredFieldsPresent` above cannot
+  // catch this: it checks presence, and the value WAS present, just refused by
+  // coercion (a relationship handed a bare instance id, a select handed a
+  // label). Roll the instance back and surface the reason, so the caller (an
+  // import row, a form) sees an error where it would otherwise see a success.
+  // Optional fields keep the lenient behaviour every edit path relies on.
+  if (failures.length > 0) {
+    const requiredById = new Map(
+      entityFields.filter((f) => f.required && f.isCreatable).map((f) => [f.id, f] as const)
+    )
+    const fatal = failures.filter((f) => requiredById.has(f.fieldId))
+    if (fatal.length > 0) {
+      // `deleteEntityInstance` sweeps the values already written for the row
+      // inside its own transaction, so nothing is left behind.
+      unwrapResult(
+        await deleteEntityInstance({ id: instance.id, organizationId: ctx.organizationId })
+      )
+      syncCollectorOf(ctx.session)?.recordArchived(recordId)
+      const detail = fatal
+        .map((f) => `${requiredById.get(f.fieldId)?.name ?? f.fieldId}: ${f.error}`)
+        .join('; ')
+      throw new UnprocessableEntityError(`Could not write required field ${detail}`, {
+        failedFields: fatal.map((f) => {
+          const field = requiredById.get(f.fieldId)
+          return field?.systemAttribute ?? field?.name ?? f.fieldId
+        }),
+      })
+    }
+  }
 
   // Re-read the instance so displayName / secondaryDisplayValue / avatarUrl
   // reflect what setFieldValues' maybeUpdateDisplayValue just wrote. The

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -57,6 +57,7 @@ import {
   createEntity,
   createWithValues as createWithValuesImpl,
   deleteEntity,
+  type FieldWriteFailure,
   type MutationContext,
   mergeEntities,
   restoreEntity,
@@ -1306,12 +1307,20 @@ export class UnifiedCrudHandler {
    * watermark covers additions via `FieldValue.updatedAt`, matching the
    * pre-D-7 behavior for those paths.
    */
+  /**
+   * Write a record's values, bucketed by mode.
+   *
+   * Returns the SET-lane writes that failed. `setValuesForEntity` swallows a
+   * per-field throw so the other fields still land, which is right for an edit
+   * and wrong for a create that just lost a required field; `createEntity`
+   * reads this list to tell the two apart.
+   */
   private async setFieldValues(
     recordId: RecordId,
     values: Record<string, unknown>,
     modes?: Record<string, 'set' | 'add' | 'remove'>,
     opts?: { publishEvents?: boolean }
-  ): Promise<void> {
+  ): Promise<FieldWriteFailure[]> {
     const { entityDefinitionId } = parseRecordId(recordId)
 
     // Get cached fields and build key → id map for all entity types
@@ -1343,12 +1352,18 @@ export class UnifiedCrudHandler {
     // per-record field triggers. Default true preserves interactive-edit behavior.
     const publishEvents = opts?.publishEvents ?? true
 
+    const failures: FieldWriteFailure[] = []
     if (setEntries.length > 0) {
-      await this.fieldValueService.setValuesForEntity({
+      const results = await this.fieldValueService.setValuesForEntity({
         recordId,
         values: setEntries.map((e) => ({ fieldId: e.fieldId, value: e.value })),
         publishEvents,
       })
+      for (const result of results) {
+        if (result.state === 'failed') {
+          failures.push({ fieldId: result.fieldId, error: result.error ?? 'Write failed' })
+        }
+      }
     }
 
     for (const e of addEntries) {
@@ -1368,6 +1383,8 @@ export class UnifiedCrudHandler {
         skipPublishEvents: !publishEvents,
       })
     }
+
+    return failures
   }
 
   /**


### PR DESCRIPTION
## Summary

Two supplier-price imports on production produced 232 vendor parts with no supplier, and a re-run duplicated them. Root cause and fix are in `plans/importer/09-relation-create-record-id.md` (untracked).

**The chain**

1. `materializeRelationCreates` stored the minted company's bare instance id.
2. The relationship write parses the value with `recordIdSchema`, which requires `defId:instanceId`, and refused it.
3. `setValuesForEntity` swallows a per-field throw and continues, so the vendor part was created with part, SKU and price but no supplier.
4. The required-field check runs on presence, and the value was present.

**Fix A**: the materializer stores `toRecordId(defCUID, id)`, the same shape the match path already stores. Three assertions updated, one new test pins the invariant.

**Fix B**: `setValuesForEntity` records the swallowed message, the handler's `setFieldValues` returns the failures, and `createEntity` rolls the instance back and throws 422 when a required field is among them. Optional fields keep the lenient behaviour. New test file covers rollback, the optional case, and multiple failures.

**Cleanup script**: `packages/lib/scripts/repair-empty-vendor-parts.ts` deletes an empty offer when its (part, supplier) pair already has a good one, repairs the link otherwise, and reports the rest. Writes go through the CRUD handler so the `mfg-vendor-parts-deleted` rule fires, plus an explicit recalc at the end.

## Verification

- `vitest run src/import/resolution src/resources/crud src/field-values`: all green.
- `node scripts/ci/typecheck-ratchet.js --package lib`: no new errors, two fixed.
- Script rehearsed locally on fabricated orphans (delete 1, repair 2), then run on production: Auxx Ai 75 deleted, Auxx Lift 155 repaired and 1 deleted. Both orgs verified afterwards: no empty offers left except the 3 that need a human decision, no dangling values, worker recalc fired.

https://claude.ai/code/session_018VBcMbujv2SaRjwLvysFqR
