### PR TITLE
feat(tariffs): adopted codes can take catalogue corrections, and rows delete from the list

### DIFF
--- a/apps/web/src/components/manufacturing/ui/settings/tariff-codes-list.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-codes-list.tsx
@@ -15,6 +15,24 @@
 // is filling in a form with no place in the list. `chart-list.tsx` is the
 // pattern.
 //
+// 🛑 The per-row catalogue button (money 35 §7.2) is a `TreeRowButton` in the
+// `actions` slot, hover-revealed by default and `persistent` when that code has
+// something waiting - so it doubles as the indicator without a second badge
+// competing with the resolved rate. It belongs only inside a `TreeRow`: it is
+// styled off the `group/tree-row` hover group and is inert anywhere else, and
+// `TreeRow`'s `actions` wrapper already stops propagation, so pressing it does
+// not also select the row.
+//
+// 🛑 The row's delete button is the SAME `onRemove` the detail editor calls -
+// the confirm, the `record.delete` and the local list patch all live once, on
+// the page. A second delete path here would be a second chance to get the
+// "nothing already valued changes" wording wrong. It is hover-revealed and NOT
+// `persistent`: unlike the catalogue button it advertises no state, and a
+// destructive affordance sitting on every row invites a misclick. It comes
+// FIRST in the slot, so the button that appears and disappears with a code's
+// pending updates is the one on the outside edge - the delete button then keeps
+// one position for every row instead of shifting under the pointer.
+//
 // 🛑 A code whose rows are ALL non-blank authorities is marked, not just
 // totalled. §3's rule sums one row per authority, so a 301 row with no MFN row
 // behind it resolves to 25% instead of 27% - arithmetically consistent, and
@@ -25,9 +43,10 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
-import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { toastError } from '@auxx/ui/components/toast'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { BookOpen, Globe, Plus } from 'lucide-react'
+import { BookOpen, BookOpenCheck, Globe, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import {
   composeTariffLabel,
@@ -57,7 +76,25 @@ interface TariffCodesListProps {
   onAddDraft: () => void
   /** Opens the "Add from catalogue" dialog (money 32 §3). */
   onAddFromCatalogue: () => void
-  /** False when the viewer cannot write `tariff_code` - Add hides. */
+  /**
+   * Instance id -> how many rows the catalogue would add to that code (money 35
+   * §7.2). Read off the ONE plan query the page already runs; a per-row query
+   * would be N round trips to render a badge.
+   */
+  resyncCounts: Map<string, number>
+  /** Opens the catalogue-updates dialog filtered to one code. Absent hides the button. */
+  onResync?: (codeInstanceId: string) => void
+  /**
+   * Remove a code. The page's own `handleRemoveCode` - the same one the detail
+   * editor's Trash2 calls, confirm copy included. Never a second delete path.
+   *
+   * It REJECTS on refusal rather than swallowing, because the editor renders
+   * the message as a field error. A row has no field for one to land on, so
+   * this list catches and toasts - the same call `handleRemoveRate` makes on
+   * the page, for the same reason.
+   */
+  onRemove: (code: TariffCode) => Promise<void>
+  /** False when the viewer cannot write `tariff_code` - Add and Remove hide. */
   canEdit: boolean
 }
 
@@ -73,6 +110,9 @@ export function TariffCodesList({
   draft,
   onAddDraft,
   onAddFromCatalogue,
+  resyncCounts,
+  onResync,
+  onRemove,
   canEdit,
 }: TariffCodesListProps) {
   const [search, setSearch] = useState('')
@@ -166,6 +206,7 @@ export function TariffCodesList({
             )
             const badge = resolutionBadge(resolution)
             const countryName = code.country ? countryLabels.get(code.country) : undefined
+            const pending = resyncCounts.get(code.id) ?? 0
             return (
               <TreeRow
                 key={code.id}
@@ -194,6 +235,42 @@ export function TariffCodesList({
                       {code.description || countryName || ''}
                     </span>
                   </span>
+                }
+                actions={
+                  <>
+                    {canEdit && (
+                      <TreeRowButton
+                        variant='destructive'
+                        tooltipText='Remove code'
+                        aria-label={`Remove ${composeTariffLabel(code.code, code.country)}`}
+                        onClick={() => {
+                          void onRemove(code).catch((error: unknown) => {
+                            toastError({
+                              title: 'Error removing the code',
+                              description:
+                                error instanceof Error
+                                  ? error.message
+                                  : 'Could not remove the tariff code.',
+                            })
+                          })
+                        }}>
+                        <Trash2 />
+                      </TreeRowButton>
+                    )}
+                    {onResync && (
+                      <TreeRowButton
+                        persistent={pending > 0}
+                        tooltipText={
+                          pending > 0
+                            ? `${pending} ${pending === 1 ? 'update' : 'updates'} from the catalogue`
+                            : 'Check catalogue'
+                        }
+                        aria-label='Check the catalogue for this code'
+                        onClick={() => onResync(code.id)}>
+                        <BookOpenCheck />
+                      </TreeRowButton>
+                    )}
+                  </>
                 }
               />
             )

--- a/apps/web/src/components/manufacturing/ui/settings/tariff-resync-dialog.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariff-resync-dialog.tsx
@@ -1,0 +1,419 @@
+// apps/web/src/components/manufacturing/ui/settings/tariff-resync-dialog.tsx
+'use client'
+
+// "Catalogue updates" on Parts > Settings > Tariffs (money 35 §7).
+//
+// `adoptTariffStarters` writes a code's rates once, at adoption, and never looks
+// at the catalogue again - so a correction to the catalogue never reaches an org
+// that already adopted. This dialog is where that correction is consented to and
+// applied.
+//
+// 🛑 THE ACTION IS THE UNIT OF CONSENT, and there is deliberately no "apply
+// everything" button. One row per government action, and the four Section 301
+// lists stay FOUR ROWS rather than being grouped under a "Section 301" family:
+// each list is its own authority to the resolver, and a family grouping invites
+// an "apply all of Section 301" button that would be four different government
+// actions behind one click.
+//
+// 🛑 THE PLAN IS DISPLAY ONLY. `purchasing.applyTariffResync` re-derives the
+// diff from the live schedule inside the write, so what is on screen here can
+// never be what gets written - it is what gets consented to. The
+// `codeInstanceIds` posted are a narrowing, not a payload.
+//
+// 🛑 AN APPLY CAN PARTIALLY COMPLETE (35 §5.1). The transaction unit is ONE
+// CODE, so a run over 200 codes that fails at 137 leaves 136 committed. The
+// result renders `applied` / `failed` / `remaining` and never reads "done" for a
+// run that stopped.
+//
+// `diverged` rows are rendered READ-ONLY and nothing is ever written for them:
+// an org that set List 3 to 30% themselves meant it (§3.2), and correcting a
+// wrong row is out of scope by decision - it is done by hand in the rate editor.
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
+import { DialogNav } from '@auxx/ui/components/dialog-nav'
+import { Kbd } from '@auxx/ui/components/kbd'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { EmptySection } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { CheckCircle2, Landmark, TriangleAlert } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { api, type RouterOutputs } from '~/trpc/react'
+import { composeTariffLabel, formatRate } from '../../tariff-types'
+
+type ResyncPlan = RouterOutputs['purchasing']['planTariffResync']
+type ResyncAction = ResyncPlan['actions'][number]
+type ResyncCode = ResyncAction['codes'][number]
+type ResyncApplyResult = RouterOutputs['purchasing']['applyTariffResync']
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`
+}
+
+/** `+25.0 pts`, `-20.0 pts`, or the honest `no change` when a step is not in force yet. */
+function formatSwing(before: number, after: number): string {
+  const delta = after - before
+  if (Math.abs(delta) < 0.001) return 'no change today'
+  return `${delta > 0 ? '+' : '-'}${Math.abs(delta).toFixed(1)} pts`
+}
+
+/** How an action reads when it has no authority of its own - the MFN base row. */
+function actionTitle(action: ResyncAction): string {
+  return action.authority ?? 'Ordinary duty (base rate)'
+}
+
+/**
+ * What changed, in the ACTION's own terms rather than as a row count.
+ *
+ * The three shapes an append actually takes: an action that ended (a dated `0`
+ * step - 35 §3.3's model of an expiry, since there is no end date), an action
+ * that gained one step, and an action being written onto codes for the first
+ * time, which brings its whole history at once.
+ */
+function describeAction(action: ResyncAction): string {
+  const additions = action.codes.flatMap((code) => code.additions)
+  if (additions.length === 0) return 'Nothing to add'
+
+  const days = [...new Set(additions.map((addition) => addition.effectiveFrom))].sort()
+  const first = days[0] as string
+  const last = days[days.length - 1] as string
+
+  if (additions.every((addition) => addition.rate === 0)) {
+    return `Terminated ${last} (0%)`
+  }
+  if (days.length === 1) {
+    const rates = [...new Set(additions.map((addition) => addition.rate))]
+    const rate = rates.length === 1 ? ` (${formatRate(rates[0] as number)})` : ''
+    return `New step ${first}${rate}`
+  }
+  return `${plural(days.length, 'step')}, ${first} to ${last}`
+}
+
+/** The aggregate - a HEADER, not the whole story. The per-code table below is. */
+function describeSpread(action: ResyncAction): string {
+  const swings = action.codes.map((code) => code.after - code.before)
+  const min = Math.min(...swings)
+  const max = Math.max(...swings)
+  const codes = plural(action.codes.length, 'code')
+  if (Math.abs(max - min) < 0.001) {
+    return `${codes}, ${formatSwing(0, max)}${Math.abs(max) < 0.001 ? '' : ' each'}`
+  }
+  return `${codes}, ${formatSwing(0, min)} to ${formatSwing(0, max)}`
+}
+
+interface TariffResyncDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The whole-org plan. `undefined` while the query is in flight. */
+  plan: ResyncPlan | undefined
+  isLoading: boolean
+  /**
+   * Narrows the dialog to one code - the per-row button (§7.2). The plan is the
+   * same one, filtered here rather than re-queried: the page already holds it.
+   */
+  focusCodeInstanceId?: string | null
+  /** Refetch the plan and the page's rate rows. */
+  onApplied: (result: ResyncApplyResult) => void
+}
+
+export function TariffResyncDialog({
+  open,
+  onOpenChange,
+  plan,
+  isLoading,
+  focusCodeInstanceId,
+  onApplied,
+}: TariffResyncDialogProps) {
+  const apply = api.purchasing.applyTariffResync.useMutation()
+  const [openActions, setOpenActions] = useState<Set<string>>(new Set())
+  /** The last apply's outcome per action, so a partial run stays on screen. */
+  const [results, setResults] = useState<Record<string, ResyncApplyResult>>({})
+  const [pendingKey, setPendingKey] = useState<string | null>(null)
+
+  const actions = useMemo(() => {
+    const all = plan?.actions ?? []
+    if (!focusCodeInstanceId) return all
+    return all
+      .map((action) => ({
+        ...action,
+        codes: action.codes.filter((code) => code.codeInstanceId === focusCodeInstanceId),
+      }))
+      .filter((action) => action.codes.length > 0)
+  }, [plan, focusCodeInstanceId])
+
+  const diverged = useMemo(() => {
+    const all = plan?.diverged ?? []
+    if (!focusCodeInstanceId) return all
+    return all.filter((row) => row.codeInstanceId === focusCodeInstanceId)
+  }, [plan, focusCodeInstanceId])
+
+  const toggleOpen = useCallback((actionKey: string) => {
+    setOpenActions((prev) => {
+      const next = new Set(prev)
+      if (next.has(actionKey)) next.delete(actionKey)
+      else next.add(actionKey)
+      return next
+    })
+  }, [])
+
+  const handleApply = useCallback(
+    async (action: ResyncAction) => {
+      setPendingKey(action.actionKey)
+      try {
+        const result = await apply.mutateAsync({
+          actionKey: action.actionKey,
+          codeInstanceIds: action.codes.map((code) => code.codeInstanceId),
+        })
+        setResults((prev) => ({ ...prev, [action.actionKey]: result }))
+        onApplied(result)
+      } catch (error) {
+        toastError({
+          title: 'Could not apply the catalogue update',
+          description:
+            error instanceof Error ? error.message : 'Could not write the catalogue rows.',
+        })
+      } finally {
+        setPendingKey(null)
+      }
+    },
+    [apply, onApplied]
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size='3xl' position='tc' innerClassName='p-0'>
+        <DialogNav
+          title='Catalogue updates'
+          description={
+            focusCodeInstanceId
+              ? 'What the catalogue would add to this code. Rows are only ever appended - nothing is edited or removed.'
+              : 'What the catalogue would add to the codes you already hold. Rows are only ever appended - nothing is edited or removed.'
+          }
+          crumbs={[{ label: 'Catalogue updates' }]}
+        />
+
+        <div className='flex flex-col gap-3 p-3'>
+          {isLoading ? (
+            <EmptySection loading />
+          ) : actions.length === 0 ? (
+            // 🛑 "Nothing to apply" says WHICH catalogue said so. A button that
+            // sometimes does nothing silently is worse than one that explains.
+            <EmptySection
+              icon={<CheckCircle2 className='size-5' />}
+              title='Up to date'
+              description={`Nothing in the auxx catalogue (${plan?.version ?? '-'}) is missing from ${
+                focusCodeInstanceId ? 'this code' : 'the codes you hold'
+              }.`}
+            />
+          ) : (
+            <ScrollArea viewportClassName='max-h-[26rem]'>
+              <div className={cn('flex flex-col gap-0.5 pe-3', TREE_SECONDARY_NOTRUNCATE)}>
+                {actions.map((action) => (
+                  <ResyncActionRow
+                    key={action.actionKey}
+                    action={action}
+                    isOpen={openActions.has(action.actionKey)}
+                    onToggleOpen={() => toggleOpen(action.actionKey)}
+                    isPending={pendingKey === action.actionKey}
+                    disabled={pendingKey !== null}
+                    result={results[action.actionKey]}
+                    onApply={() => void handleApply(action)}
+                  />
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+
+          {diverged.length > 0 && (
+            <div className='rounded-md border bg-muted/30 p-2.5'>
+              <div className='mb-1.5 flex items-center gap-1.5'>
+                <TriangleAlert className='size-3.5 text-amber-600' />
+                <span className='font-medium text-xs'>
+                  {plural(diverged.length, 'row')} you changed
+                </span>
+              </div>
+              {/* Read-only, and it says so: a row the org edited is theirs. §3.2 */}
+              <p className='mb-2 text-muted-foreground text-xs'>
+                These rows disagree with the catalogue at the same date. Nothing here is written or
+                overwritten - edit them in the rate history if you want the catalogue's number.
+              </p>
+              <div className='flex flex-col gap-1'>
+                {diverged.map((row) => (
+                  <div
+                    key={row.rateId}
+                    className='flex flex-wrap items-baseline gap-x-2 text-muted-foreground text-xs'>
+                    <span className='tabular-nums text-foreground'>{row.code}</span>
+                    <span className='tabular-nums'>{row.effectiveFrom}</span>
+                    {row.chapter99Code && <span className='tabular-nums'>{row.chapter99Code}</span>}
+                    <span>
+                      you have {formatRate(row.ours)}; the catalogue says {formatRate(row.theirs)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className='items-center gap-3 border-t px-4 py-3 sm:justify-between'>
+          <p className='text-muted-foreground text-xs'>
+            From the auxx catalogue, dated {plan?.version ?? '-'}. Rows are appended, never edited
+            or removed - verify against your broker's entry summary.
+          </p>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={apply.isPending}>
+            Close <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface ResyncActionRowProps {
+  action: ResyncAction
+  isOpen: boolean
+  onToggleOpen: () => void
+  isPending: boolean
+  disabled: boolean
+  result: ResyncApplyResult | undefined
+  onApply: () => void
+}
+
+/** One government action, with its per-code table underneath. */
+function ResyncActionRow({
+  action,
+  isOpen,
+  onToggleOpen,
+  isPending,
+  disabled,
+  result,
+  onApply,
+}: ResyncActionRowProps) {
+  const applied = result !== undefined
+
+  return (
+    <TreeRow
+      icon={<Landmark className='size-4 text-muted-foreground' />}
+      title={
+        <span className='flex min-w-0 items-baseline gap-2'>
+          <span className='shrink-0 text-sm'>{actionTitle(action)}</span>
+          {action.chapter99Code && (
+            <span className='shrink-0 text-muted-foreground text-xs tabular-nums'>
+              {action.chapter99Code}
+            </span>
+          )}
+        </span>
+      }
+      secondaryFill
+      secondary={
+        <span className='flex min-w-0 items-center gap-1.5 text-muted-foreground text-xs'>
+          <span className='shrink-0'>{describeAction(action)}</span>
+          <span className='min-w-0 truncate'>{describeSpread(action)}</span>
+        </span>
+      }
+      expandable
+      isOpen={isOpen}
+      onToggleOpen={onToggleOpen}
+      rowClassName='hover:bg-primary-100'
+      actions={
+        applied ? (
+          <ApplyOutcome result={result} />
+        ) : (
+          <Button
+            variant='outline'
+            size='xs'
+            onClick={onApply}
+            disabled={disabled}
+            loading={isPending}
+            loadingText='Applying...'>
+            Apply
+          </Button>
+        )
+      }>
+      <div className='flex flex-col gap-0.5'>
+        {action.codes.map((code) => (
+          <ResyncCodeRow key={code.codeInstanceId} action={action} code={code} />
+        ))}
+      </div>
+    </TreeRow>
+  )
+}
+
+/**
+ * 🛑 Never "done" for a run that stopped partway (§5.1). All three counts are
+ * rendered, and a failure keeps its message.
+ */
+function ApplyOutcome({ result }: { result: ResyncApplyResult }) {
+  const failure = result.failed[0]
+  if (!failure && result.remaining.length === 0) {
+    return (
+      <span className='flex items-center gap-1 text-xs text-good-600'>
+        <CheckCircle2 className='size-3.5' />
+        {plural(result.applied.length, 'code')} updated
+      </span>
+    )
+  }
+  return (
+    <span
+      className='flex items-center gap-1 text-bad-600 text-xs'
+      title={failure ? `${failure.code}: ${failure.error}` : undefined}>
+      <TriangleAlert className='size-3.5' />
+      {result.applied.length} applied, {result.failed.length} failed, {result.remaining.length} not
+      attempted
+    </span>
+  )
+}
+
+/**
+ * One code under an action: what it resolves to today, and what it would
+ * resolve to once these rows land.
+ *
+ * ⚠️ `spellingFromOrg` is SAID, never hidden. When a code carries its own
+ * spelling of the authority, the appended step takes that spelling so it lands
+ * in the same group the resolver already sums - rule 3 doing its job should be
+ * visible, not magic. It is only rendered when the spelling actually differs
+ * from the catalogue's, because "we used your spelling, which is our spelling"
+ * is noise.
+ */
+function ResyncCodeRow({ action, code }: { action: ResyncAction; code: ResyncCode }) {
+  const ownSpelling = code.additions.find(
+    (addition) => addition.spellingFromOrg && addition.authority !== action.authority
+  )
+
+  return (
+    <TreeRow
+      depth={1}
+      title={
+        <span className='flex min-w-0 items-baseline gap-2'>
+          <span className='shrink-0 text-sm tabular-nums'>
+            {composeTariffLabel(code.code, code.country)}
+          </span>
+          <span className='shrink-0 text-muted-foreground text-xs tabular-nums'>
+            {formatRate(code.before)} &rarr; {formatRate(code.after)}
+          </span>
+        </span>
+      }
+      secondaryFill
+      secondary={
+        <span className='flex min-w-0 items-center gap-1.5 text-muted-foreground text-xs'>
+          <Badge variant='outline' size='xs' className='shrink-0'>
+            {formatSwing(code.before, code.after)}
+          </Badge>
+          <span className='min-w-0 truncate'>
+            {plural(code.additions.length, 'row')}
+            {ownSpelling ? ` - written as "${ownSpelling.authority}", your spelling` : ''}
+          </span>
+        </span>
+      }
+      rowClassName='hover:bg-primary-100'
+    />
+  )
+}

--- a/apps/web/src/components/manufacturing/ui/settings/tariffs-settings-page.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/tariffs-settings-page.tsx
@@ -26,11 +26,12 @@
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeValue } from '@auxx/database/types'
 import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { toastError } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils'
-import { Globe, Package, RefreshCw } from 'lucide-react'
+import { BookOpenCheck, Globe, Package, RefreshCw } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -69,6 +70,7 @@ import { TariffClassificationList } from './tariff-classification-list'
 import { TariffCodeEditor, type TariffCodeValues } from './tariff-code-editor'
 import { TariffCodesList } from './tariff-codes-list'
 import type { TariffRateValues } from './tariff-rate-history'
+import { TariffResyncDialog } from './tariff-resync-dialog'
 import { TariffStarterDialog } from './tariff-starter-dialog'
 
 const BREADCRUMBS = [
@@ -191,6 +193,50 @@ export function TariffsSettingsPage() {
   const [selectedOfferId, setSelectedOfferId] = useState<string | null>(null)
   // "Add from catalogue" (money 32 §3).
   const [starterOpen, setStarterOpen] = useState(false)
+
+  // ── "Catalogue updates" (money 35 §7) ───────────────────────────────────
+  //
+  // ONE query for the whole page. The header button's badge, the per-row
+  // indicator and the dialog all read this single plan; a per-row query would
+  // be N round trips to render a badge, and two plans could disagree.
+  //
+  // 🛑 Gated on edit of BOTH defs even though the query itself only needs view.
+  // Every action the plan describes is an append to `tariff_rate` against a
+  // `tariff_code`, so a viewer who cannot write both would be shown a button
+  // the mutation then refuses - the same call the three gates above make.
+  const canResync = canEditCodes && canEditRates
+  const resyncPlan = api.purchasing.planTariffResync.useQuery(undefined, {
+    enabled: canResync,
+  })
+  const [resyncOpen, setResyncOpen] = useState(false)
+  /** Set by the per-row button; `null` is the whole-org view (§7.1 vs §7.2). */
+  const [resyncFocusId, setResyncFocusId] = useState<string | null>(null)
+
+  const resyncCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const action of resyncPlan.data?.actions ?? []) {
+      for (const code of action.codes) {
+        counts.set(
+          code.codeInstanceId,
+          (counts.get(code.codeInstanceId) ?? 0) + code.additions.length
+        )
+      }
+    }
+    return counts
+  }, [resyncPlan.data])
+
+  const openResync = useCallback((codeInstanceId: string | null) => {
+    setResyncFocusId(codeInstanceId)
+    setResyncOpen(true)
+  }, [])
+
+  // Rows were appended to `tariff_rate` outside this page's own create paths,
+  // so the rate read is refetched rather than patched row by row - and the plan
+  // is re-derived, because a partial run leaves work behind.
+  const handleResynced = useCallback(() => {
+    refreshRates()
+    void resyncPlan.refetch()
+  }, [refreshRates, resyncPlan])
 
   // ── The Classification tab's read and writes ────────────────────────────
   //
@@ -586,31 +632,55 @@ export function TariffsSettingsPage() {
   // The result stays on the page rather than in a toast: it is a number the
   // person will read against the list below it, and "Already current" is as
   // much of an answer as "25 parts repriced" - it says the schedule was applied.
-  const applyButton = canApplyRates ? (
-    <div className='flex items-center gap-3'>
-      {lastApply && !applyRates.isPending && (
-        <span className='text-xs text-muted-foreground'>{describeApply(lastApply)}</span>
+  // 🛑 The badge IS the notification (§10): there is no page banner, and nothing
+  // runs in the background. A code deploy must not rewrite org data, so every
+  // write here is a person pressing this button and then an action's Apply.
+  const resyncCount = resyncPlan.data?.actions.length ?? 0
+  const headerButtons = (
+    <div className='flex flex-wrap items-center gap-3'>
+      {canResync && (
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={() => openResync(null)}
+          disabled={isLoading || codes.length === 0}
+          title='What the auxx catalogue would add to the codes you already hold. Rows are only ever appended.'>
+          <BookOpenCheck />
+          Catalogue updates
+          {resyncCount > 0 && (
+            <Badge variant='amber' size='xs'>
+              {resyncCount}
+            </Badge>
+          )}
+        </Button>
       )}
-      <Button
-        variant='outline'
-        size='sm'
-        onClick={() => void handleApplyRates()}
-        disabled={isLoading || codes.length === 0}
-        loading={applyRates.isPending}
-        loadingText='Applying...'
-        title='Reprice every part with a classified supplier offer at the rates in force today. Standard costs and movements are not touched.'>
-        <RefreshCw />
-        Apply rate changes
-      </Button>
+      {canApplyRates && (
+        <div className='flex items-center gap-3'>
+          {lastApply && !applyRates.isPending && (
+            <span className='text-xs text-muted-foreground'>{describeApply(lastApply)}</span>
+          )}
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => void handleApplyRates()}
+            disabled={isLoading || codes.length === 0}
+            loading={applyRates.isPending}
+            loadingText='Applying...'
+            title='Reprice every part with a classified supplier offer at the rates in force today. Standard costs and movements are not touched.'>
+            <RefreshCw />
+            Apply rate changes
+          </Button>
+        </div>
+      )}
     </div>
-  ) : undefined
+  )
 
   return (
     <SettingsPage
       title='Tariffs'
       description={PAGE_DESCRIPTION}
       breadcrumbs={BREADCRUMBS}
-      button={applyButton}
+      button={canResync || canApplyRates ? headerButtons : undefined}
       subHeader={
         <ResponsiveTabs
           value={activeTab}
@@ -641,6 +711,9 @@ export function TariffsSettingsPage() {
             draft={draft}
             onAddDraft={handleAddDraft}
             onAddFromCatalogue={() => setStarterOpen(true)}
+            resyncCounts={resyncCounts}
+            onResync={canResync ? openResync : undefined}
+            onRemove={handleRemoveCode}
             canEdit={canEditCodes}
           />
         </MasterDetailSplit>
@@ -672,6 +745,15 @@ export function TariffsSettingsPage() {
         today={today}
         bookTimeZone={bookTimeZone}
         onAdopted={handleStarterAdopted}
+      />
+
+      <TariffResyncDialog
+        open={resyncOpen}
+        onOpenChange={setResyncOpen}
+        plan={resyncPlan.data}
+        isLoading={resyncPlan.isLoading}
+        focusCodeInstanceId={resyncFocusId}
+        onApplied={handleResynced}
       />
     </SettingsPage>
   )

--- a/apps/web/src/server/api/routers/purchasing.ts
+++ b/apps/web/src/server/api/routers/purchasing.ts
@@ -2,11 +2,13 @@
 
 import {
   adoptTariffStarters,
+  applyTariffResync,
   applyTariffSchedule,
   expandTariffStarter,
   listHtsChildren,
   loadHtsGeneral,
   loadTariffMemberships,
+  planTariffResync,
   TARIFF_STARTERS_VERSION,
 } from '@auxx/lib/bom'
 import { getCachedEntityDefId } from '@auxx/lib/cache'
@@ -672,6 +674,59 @@ export const purchasingRouter = createTRPCRouter({
       ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'tariff_rate'))
 
       const result = await adoptTariffStarters(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * What the catalogue would ADD to the codes this org already holds, grouped
+   * by the government action that would add it (money 35 §6).
+   *
+   * ONE query for the whole page, not one per row: the tariffs page already
+   * loads every code and every rate, and a per-row query would be N round trips
+   * to render a badge. The per-row button (§7.2) filters this same answer
+   * client-side rather than asking again.
+   *
+   * A read, so `assertViewEntity` on both defs - the plan resolves the schedule
+   * to say what a code would go from and to, which is reading rate rows.
+   */
+  planTariffResync: capabilityProcedure.query(async ({ ctx }) => {
+    const { organizationId } = ctx.session
+    ctx.capabilities.assertViewEntity(await requireDefId(organizationId, 'tariff_code'))
+    ctx.capabilities.assertViewEntity(await requireDefId(organizationId, 'tariff_rate'))
+
+    const result = await planTariffResync(ctx.db, organizationId)
+    if (result.isErr()) throw result.error
+    return result.value
+  }),
+
+  /**
+   * Append one government action's missing rows to the codes named (money 35
+   * §6).
+   *
+   * Asserts edit on BOTH defs - the same gate `adoptTariffStarters` uses, for
+   * the same reason: a tariff code is reference data, not a control surface, so
+   * this is not `settingsManage`.
+   *
+   * 🛑 The posted `codeInstanceIds` are a NARROWING, never a plan. The lib
+   * function re-derives the diff from the live schedule inside the call, so a
+   * stale browser plan cannot write a row that is already there. Everything
+   * else - insert only, one transaction per code, a partial run reported rather
+   * than thrown - is the lib function's contract.
+   */
+  applyTariffResync: capabilityProcedure
+    .input(
+      z.object({
+        actionKey: z.string().min(1).max(64),
+        codeInstanceIds: z.array(z.string().min(1)).min(1).max(500),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'tariff_code'))
+      ctx.capabilities.assertEditEntity(await requireDefId(organizationId, 'tariff_rate'))
+
+      const result = await applyTariffResync(ctx.db, organizationId, userId, input)
       if (result.isErr()) throw result.error
       return result.value
     }),

--- a/packages/lib/src/bom/index.ts
+++ b/packages/lib/src/bom/index.ts
@@ -8,6 +8,18 @@ export {
 export { type ApplyTariffScheduleResult, applyTariffSchedule } from './apply-tariff-schedule'
 export { recalculateAffectedParts, recalculateAllPartCosts } from './cost-calculator'
 export { batchRecalculateQoH } from './qoh'
+export {
+  applyTariffResync,
+  MFN_ACTION_KEY,
+  planTariffResync,
+  type ResyncAction,
+  type ResyncAddition,
+  type ResyncApplyResult,
+  type ResyncCode,
+  type ResyncDeps,
+  type ResyncDivergence,
+  type ResyncPlan,
+} from './resync-tariff-starters'
 export { getDeductionTargets, loadDirectSubparts, loadSubpartGraph } from './subpart-graph'
 export {
   loadTariff301Memberships,

--- a/packages/lib/src/bom/resync-tariff-starters.test.ts
+++ b/packages/lib/src/bom/resync-tariff-starters.test.ts
@@ -1,0 +1,623 @@
+// packages/lib/src/bom/resync-tariff-starters.test.ts
+// 35 §9: the catalogue diff, its per-code authority spelling, and the
+// partially-completable apply.
+//
+// 🛑 The test that matters is `keeps each code's own spelling`. Two codes carry
+// the SAME Chapter 99 heading spelled two different ways, and the additions have
+// to take each code's own. Resolving the spelling once for the action and
+// reusing it - 35 §3.1's bug - passes every single-code test in this file and
+// fails only that one, which is the whole reason it uses two codes.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StarterAction } from './tariff-starters'
+import type { TariffRateRow } from './vendor-cost'
+
+const h = vi.hoisted(() => ({
+  tariffCodeDefId: 'tariff_code_def' as string | undefined,
+  tariffRateDefId: 'tariff_rate_def' as string | undefined,
+  fields: {
+    tariff_code_code: { id: 'f_code' },
+    tariff_code_country: { id: 'f_country' },
+  } as Record<string, { id: string } | null>,
+  /** What `loadTariffCodeRows`'s query resolves to. */
+  codeRows: [] as Array<{ instanceId: string; code: string | null; country: string | null }>,
+  /** What `loadTariffSchedule` resolves to. Mutated by the fake writer. */
+  schedule: new Map<string, TariffRateRow[]>(),
+  createCalls: [] as Array<{ entityDefinitionId: string; values: Record<string, unknown> }>,
+  /** Instance ids whose FIRST rate create throws, to drive a partial apply. */
+  failOnCode: new Set<string>(),
+  /** Columns handed to drizzle's `isNull`, so the archived filter is provable. */
+  isNullColumns: [] as unknown[],
+  nextRateId: 0,
+}))
+
+vi.mock('@auxx/database', () => ({
+  schema: {
+    EntityInstance: {
+      id: 'id',
+      organizationId: 'organizationId',
+      entityDefinitionId: 'entityDefinitionId',
+      archivedAt: 'archivedAt',
+    },
+    FieldValue: {
+      entityId: 'entityId',
+      fieldId: 'fieldId',
+      organizationId: 'organizationId',
+      valueText: 'valueText',
+      optionId: 'optionId',
+    },
+  },
+}))
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  return {
+    ...actual,
+    // Archived codes are excluded in SQL, so the only honest way to test the
+    // rule from a doubled db is to prove the predicate is built at all.
+    isNull: (column: unknown) => {
+      h.isNullColumns.push(column)
+      return actual.isNull(column as never)
+    },
+  }
+})
+
+vi.mock('drizzle-orm/pg-core', () => ({
+  alias: (table: unknown) => table,
+}))
+
+vi.mock('../cache', () => ({
+  getCachedEntityDefId: async (_orgId: string, entityType: string) =>
+    entityType === 'tariff_code' ? h.tariffCodeDefId : h.tariffRateDefId,
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(attrs.map((a) => [a, h.fields[a] ?? null])),
+    }),
+  }),
+}))
+
+vi.mock('../resources/crud', () => {
+  class FakeUnifiedCrudHandler {
+    constructor(
+      private organizationId: string,
+      private userId: string,
+      private db: unknown
+    ) {}
+
+    async create(entityDefinitionId: string, values: Record<string, unknown>) {
+      const codeRecordId = String(values.tariff_rate_tariff_code ?? '')
+      const instanceId = codeRecordId.split(':')[1] ?? ''
+      if (h.failOnCode.has(instanceId)) {
+        throw new Error(`boom writing ${instanceId}`)
+      }
+      h.createCalls.push({ entityDefinitionId, values })
+
+      // The written row joins the schedule, so a second plan sees it and a
+      // re-derived apply has nothing left to insert.
+      h.nextRateId += 1
+      const bucket = h.schedule.get(instanceId) ?? []
+      bucket.push({
+        id: `rate_written_${h.nextRateId}`,
+        authority: (values.tariff_rate_authority as string | undefined) ?? null,
+        rate: values.tariff_rate_rate as number,
+        effectiveFrom: values.tariff_rate_effective_from as string,
+        chapter99Code: (values.tariff_rate_chapter99_code as string | undefined) ?? null,
+      })
+      h.schedule.set(instanceId, bucket)
+
+      return { instance: { id: `inst_${h.nextRateId}` }, recordId: `x:${h.nextRateId}`, values }
+    }
+  }
+
+  return { UnifiedCrudHandler: FakeUnifiedCrudHandler }
+})
+
+vi.mock('./tariff-hts-general', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./tariff-hts-general')>()
+  return {
+    ...actual,
+    loadHtsGeneral: async () => ({
+      fetchedAt: '2026-09-01',
+      source: 'test',
+      nodes: [],
+      lines: [
+        ['8501.40.40.20', 4, 'AC motors, other'],
+        ['8503.00.95.20', 3, 'Parts of motors'],
+      ],
+    }),
+  }
+})
+
+vi.mock('./tariff-301-memberships', () => ({
+  loadTariffMemberships: async () => ({
+    '8501.40.40': ['301-3'],
+    '8503.00.95': ['301-3'],
+  }),
+}))
+
+vi.mock('./tariff-schedule', () => ({
+  loadTariffSchedule: async (_db: unknown, _org: string, ids?: readonly string[]) => {
+    const wanted = ids ? new Set(ids) : null
+    const out = new Map<string, TariffRateRow[]>()
+    for (const [id, rows] of h.schedule) {
+      if (wanted && !wanted.has(id)) continue
+      out.set(id, [...rows])
+    }
+    return out
+  },
+  readBookTimeZone: async () => 'UTC',
+}))
+
+import { BadRequestError, NotFoundError } from '../errors'
+import {
+  applyTariffResync,
+  MFN_ACTION_KEY,
+  planTariffResync,
+  type ResyncPlan,
+} from './resync-tariff-starters'
+import { resolveTariffRate } from './vendor-cost'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const NOW = new Date('2026-09-01T12:00:00.000Z')
+
+/**
+ * The hand-kept half, cut down to two actions. Injected rather than using the
+ * real `TARIFF_ACTIONS` so a test can add a step or an expiry without the
+ * assertions drifting the next time the real catalogue is corrected.
+ */
+const ACTIONS: Record<string, StarterAction> = {
+  '301-3': {
+    authority: 'Section 301 List 3',
+    country: 'CN',
+    chapter99Code: '9903.88.03',
+    covers: 'listed',
+    steps: [
+      ['2018-09-24', 10],
+      ['2019-05-10', 25],
+    ],
+  },
+  'ieepa-fentanyl-cn': {
+    authority: 'IEEPA fentanyl',
+    country: 'CN',
+    chapter99Code: '9903.01.24',
+    covers: 'all',
+    steps: [
+      ['2025-02-04', 10],
+      ['2025-03-04', 20],
+    ],
+  },
+}
+
+/** The same table with one more List 3 step, i.e. a catalogue correction. */
+const ACTIONS_WITH_NEW_STEP: Record<string, StarterAction> = {
+  ...ACTIONS,
+  '301-3': {
+    ...(ACTIONS['301-3'] as StarterAction),
+    steps: [...ACTIONS['301-3']!.steps, ['2026-06-10', 30]],
+  },
+}
+
+/** The same table with the IEEPA action terminated by an explicit `0` (§3.3). */
+const ACTIONS_WITH_EXPIRY: Record<string, StarterAction> = {
+  ...ACTIONS,
+  'ieepa-fentanyl-cn': {
+    ...(ACTIONS['ieepa-fentanyl-cn'] as StarterAction),
+    steps: [...ACTIONS['ieepa-fentanyl-cn']!.steps, ['2026-02-24', 0]],
+  },
+}
+
+let rateId = 0
+function rate(
+  authority: string | null,
+  ratePercent: number,
+  effectiveFrom: string,
+  chapter99Code: string | null
+): TariffRateRow {
+  rateId += 1
+  return { id: `rate_${rateId}`, authority, rate: ratePercent, effectiveFrom, chapter99Code }
+}
+
+/**
+ * The rows `adoptTariffStarters` would have written for a CN code under
+ * {@link ACTIONS}, with the List 3 authority spelled however the org spells it.
+ */
+function adoptedCnRows(mfnRate: number, list3Authority: string | null = 'Section 301 List 3') {
+  return [
+    rate(null, mfnRate, '1995-01-01', null),
+    rate(list3Authority, 10, '2018-09-24', '9903.88.03'),
+    rate(list3Authority, 25, '2019-05-10', '9903.88.03'),
+    rate('IEEPA fentanyl', 10, '2025-02-04', '9903.01.24'),
+    rate('IEEPA fentanyl', 20, '2025-03-04', '9903.01.24'),
+  ]
+}
+
+const db = {
+  transaction: async (fn: (tx: unknown) => Promise<unknown>) => {
+    // Rollback, modelled: a code is whole or nothing (§5.1), so a throw must
+    // undo the rows the fake writer already appended.
+    const calls = h.createCalls.length
+    const snapshot = new Map([...h.schedule].map(([id, rows]) => [id, [...rows]]))
+    try {
+      return await fn({})
+    } catch (error) {
+      h.createCalls.length = calls
+      h.schedule = snapshot
+      throw error
+    }
+  },
+  select: () => ({
+    from: () => ({
+      innerJoin: () => ({
+        innerJoin: () => ({ where: () => Promise.resolve(h.codeRows) }),
+      }),
+    }),
+  }),
+} as never
+
+function actionOf(plan: ResyncPlan, actionKey: string) {
+  const action = plan.actions.find((entry) => entry.actionKey === actionKey)
+  expect(action, `expected an action ${actionKey}`).toBeDefined()
+  return action!
+}
+
+function codeOf(plan: ResyncPlan, actionKey: string, codeInstanceId: string) {
+  const entry = actionOf(plan, actionKey).codes.find(
+    (candidate) => candidate.codeInstanceId === codeInstanceId
+  )
+  expect(entry, `expected ${codeInstanceId} under ${actionKey}`).toBeDefined()
+  return entry!
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.tariffCodeDefId = 'tariff_code_def'
+  h.tariffRateDefId = 'tariff_rate_def'
+  h.fields = {
+    tariff_code_code: { id: 'f_code' },
+    tariff_code_country: { id: 'f_country' },
+  }
+  h.codeRows = []
+  h.schedule = new Map()
+  h.createCalls = []
+  h.failOnCode = new Set()
+  h.isNullColumns = []
+  h.nextRateId = 0
+  rateId = 0
+})
+
+describe('planTariffResync', () => {
+  it('plans nothing for an org whose rows already match the catalogue', async () => {
+    h.codeRows = [{ instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' }]
+    h.schedule.set('code_a', adoptedCnRows(4))
+
+    const result = await planTariffResync(db, ORG, undefined, { actions: ACTIONS, now: NOW })
+
+    const plan = result._unsafeUnwrap()
+    expect(plan.actions).toEqual([])
+    expect(plan.diverged).toEqual([])
+  })
+
+  it('plans one addition on every code carrying the heading, under ONE action', async () => {
+    h.codeRows = [
+      { instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' },
+      { instanceId: 'code_b', code: '8503.00.95.20', country: 'CN' },
+    ]
+    h.schedule.set('code_a', adoptedCnRows(4))
+    h.schedule.set('code_b', adoptedCnRows(3))
+
+    const result = await planTariffResync(db, ORG, undefined, {
+      actions: ACTIONS_WITH_NEW_STEP,
+      now: NOW,
+    })
+
+    const plan = result._unsafeUnwrap()
+    expect(plan.actions).toHaveLength(1)
+    const action = actionOf(plan, '301-3')
+    expect(action.authority).toBe('Section 301 List 3')
+    expect(action.chapter99Code).toBe('9903.88.03')
+    expect(action.codes).toHaveLength(2)
+    for (const entry of action.codes) {
+      expect(entry.additions).toHaveLength(1)
+      expect(entry.additions[0]?.effectiveFrom).toBe('2026-06-10')
+      expect(entry.additions[0]?.rate).toBe(30)
+      // 4 (or 3) + 25 + 20 before; the List 3 step moves 25 -> 30.
+      expect(entry.after - entry.before).toBe(5)
+    }
+  })
+
+  it('🛑 keeps each code OWN authority spelling, so a renamed code gains no second group', async () => {
+    // The §3.1 case. `code_b` renamed its List 3 rows to `301`; `code_a` did
+    // not. One spelling resolved for the action and reused would put `code_b`'s
+    // new step in a SECOND authority group and double its List 3 contribution.
+    h.codeRows = [
+      { instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' },
+      { instanceId: 'code_b', code: '8503.00.95.20', country: 'CN' },
+    ]
+    h.schedule.set('code_a', adoptedCnRows(4, 'Section 301 List 3'))
+    h.schedule.set('code_b', adoptedCnRows(3, '301'))
+
+    const result = await planTariffResync(db, ORG, undefined, {
+      actions: ACTIONS_WITH_NEW_STEP,
+      now: NOW,
+    })
+    const plan = result._unsafeUnwrap()
+
+    const a = codeOf(plan, '301-3', 'code_a')
+    expect(a.additions[0]?.authority).toBe('Section 301 List 3')
+    expect(a.additions[0]?.spellingFromOrg).toBe(false)
+
+    const b = codeOf(plan, '301-3', 'code_b')
+    expect(b.additions[0]?.authority).toBe('301')
+    expect(b.additions[0]?.spellingFromOrg).toBe(true)
+
+    // The whole point: current + additions still resolves to ONE Section 301
+    // component on the renamed code, and the total moves by the step, not by a
+    // whole extra action.
+    const stored = h.schedule.get('code_b') ?? []
+    const after = resolveTariffRate(
+      [
+        ...stored,
+        ...b.additions.map((addition, index) => ({
+          id: `~pending:${index}`,
+          authority: addition.authority,
+          rate: addition.rate,
+          effectiveFrom: addition.effectiveFrom,
+          chapter99Code: addition.chapter99Code,
+        })),
+      ],
+      NOW,
+      'UTC'
+    )
+    const list3 = after.components.filter((component) => component.chapter99Code === '9903.88.03')
+    expect(list3).toHaveLength(1)
+    expect(list3[0]?.rate).toBe(30)
+    // base 3 + List 3 30 + IEEPA 20. A second group would have made it 55.
+    expect(after.rate).toBe(53)
+    expect(b.after).toBe(53)
+    expect(b.before).toBe(48)
+  })
+
+  it('gives a code with no row for the heading the full step history, in OUR spelling', async () => {
+    // The membership case: seven of the dev org's twelve codes look like this.
+    h.codeRows = [{ instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' }]
+    h.schedule.set('code_a', [
+      rate(null, 4, '1995-01-01', null),
+      rate('IEEPA fentanyl', 10, '2025-02-04', '9903.01.24'),
+      rate('IEEPA fentanyl', 20, '2025-03-04', '9903.01.24'),
+    ])
+
+    const result = await planTariffResync(db, ORG, undefined, { actions: ACTIONS, now: NOW })
+    const entry = codeOf(result._unsafeUnwrap(), '301-3', 'code_a')
+
+    expect(entry.additions.map((addition) => [addition.effectiveFrom, addition.rate])).toEqual([
+      ['2018-09-24', 10],
+      ['2019-05-10', 25],
+    ])
+    for (const addition of entry.additions) {
+      expect(addition.authority).toBe('Section 301 List 3')
+      expect(addition.spellingFromOrg).toBe(false)
+      expect(addition.chapter99Code).toBe('9903.88.03')
+    }
+    // 24% understated by exactly the list rate, which is the complaint 35 §0.1
+    // is about.
+    expect(entry.before).toBe(24)
+    expect(entry.after).toBe(49)
+  })
+
+  it('plans a terminating 0 step and drops that authority contribution (§3.3)', async () => {
+    h.codeRows = [{ instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' }]
+    h.schedule.set('code_a', adoptedCnRows(4))
+
+    const result = await planTariffResync(db, ORG, undefined, {
+      actions: ACTIONS_WITH_EXPIRY,
+      now: NOW,
+    })
+    const entry = codeOf(result._unsafeUnwrap(), 'ieepa-fentanyl-cn', 'code_a')
+
+    expect(entry.additions).toEqual([
+      expect.objectContaining({
+        effectiveFrom: '2026-02-24',
+        rate: 0,
+        authority: 'IEEPA fentanyl',
+      }),
+    ])
+    expect(entry.before).toBe(49)
+    expect(entry.after).toBe(29)
+    expect(entry.before - entry.after).toBe(20)
+  })
+
+  it('plans nothing, and does not error, for a code the catalogue does not carry', async () => {
+    h.codeRows = [{ instanceId: 'code_x', code: '0000.00.00.00', country: 'CN' }]
+    h.schedule.set('code_x', [rate(null, 5, '2020-01-01', null)])
+
+    const result = await planTariffResync(db, ORG, undefined, { actions: ACTIONS, now: NOW })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().actions).toEqual([])
+    expect(result._unsafeUnwrap().diverged).toEqual([])
+  })
+
+  it('reads live codes only - archived ones are excluded in SQL', async () => {
+    h.codeRows = [{ instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' }]
+    h.schedule.set('code_a', adoptedCnRows(4))
+
+    await planTariffResync(db, ORG, undefined, { actions: ACTIONS, now: NOW })
+
+    expect(h.isNullColumns).toContain('archivedAt')
+  })
+
+  it('reports a stored row whose rate differs at the same day, and adds nothing for it', async () => {
+    h.codeRows = [{ instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' }]
+    const rows = adoptedCnRows(4)
+    // The org set List 3 to 30% themselves. The catalogue says 25%.
+    ;(rows[2] as TariffRateRow).rate = 30
+    h.schedule.set('code_a', rows)
+
+    const plan = (
+      await planTariffResync(db, ORG, undefined, { actions: ACTIONS, now: NOW })
+    )._unsafeUnwrap()
+
+    expect(plan.actions).toEqual([])
+    expect(plan.diverged).toEqual([
+      {
+        codeInstanceId: 'code_a',
+        code: '8501.40.40.20',
+        rateId: rows[2]?.id,
+        chapter99Code: '9903.88.03',
+        effectiveFrom: '2019-05-10',
+        ours: 30,
+        theirs: 25,
+      },
+    ])
+  })
+
+  it('offers the missing MFN base row as its own pseudo-action', async () => {
+    h.codeRows = [{ instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' }]
+    h.schedule.set('code_a', adoptedCnRows(4).slice(1)) // every action row, no base
+
+    const plan = (
+      await planTariffResync(db, ORG, undefined, { actions: ACTIONS, now: NOW })
+    )._unsafeUnwrap()
+    const entry = codeOf(plan, MFN_ACTION_KEY, 'code_a')
+
+    expect(entry.additions).toEqual([
+      expect.objectContaining({ effectiveFrom: '1995-01-01', rate: 4, authority: null }),
+    ])
+    expect(entry.before).toBe(45)
+    expect(entry.after).toBe(49)
+  })
+
+  it('narrows to the codes named, for the per-row button', async () => {
+    h.codeRows = [{ instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' }]
+    h.schedule.set('code_a', adoptedCnRows(4))
+    h.schedule.set('code_b', adoptedCnRows(3))
+
+    const plan = (
+      await planTariffResync(db, ORG, ['code_a'], { actions: ACTIONS_WITH_NEW_STEP, now: NOW })
+    )._unsafeUnwrap()
+
+    expect(actionOf(plan, '301-3').codes.map((entry) => entry.codeInstanceId)).toEqual(['code_a'])
+  })
+
+  it('returns NotFoundError when the org has no tariff_code / tariff_rate definitions', async () => {
+    h.tariffCodeDefId = undefined
+    const result = await planTariffResync(db, ORG, undefined, { actions: ACTIONS, now: NOW })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+  })
+})
+
+describe('applyTariffResync', () => {
+  const deps = { actions: ACTIONS_WITH_NEW_STEP, now: NOW }
+
+  it('writes the action across the codes named and re-deriving finds nothing left', async () => {
+    h.codeRows = [
+      { instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' },
+      { instanceId: 'code_b', code: '8503.00.95.20', country: 'CN' },
+    ]
+    h.schedule.set('code_a', adoptedCnRows(4))
+    h.schedule.set('code_b', adoptedCnRows(3, '301'))
+
+    const first = await applyTariffResync(
+      db,
+      ORG,
+      USER,
+      { actionKey: '301-3', codeInstanceIds: ['code_a', 'code_b'] },
+      deps
+    )
+    const result = first._unsafeUnwrap()
+    expect(result.applied).toEqual([
+      { codeInstanceId: 'code_a', code: '8501.40.40.20', rows: 1 },
+      { codeInstanceId: 'code_b', code: '8503.00.95.20', rows: 1 },
+    ])
+    expect(result.failed).toEqual([])
+    expect(result.remaining).toEqual([])
+    expect(h.createCalls).toHaveLength(2)
+
+    // Each code got ITS OWN spelling written, not one resolved for the action.
+    expect(h.createCalls[0]?.values.tariff_rate_authority).toBe('Section 301 List 3')
+    expect(h.createCalls[1]?.values.tariff_rate_authority).toBe('301')
+    expect(h.createCalls[0]?.values.tariff_rate_effective_from).toBe('2026-06-10T00:00:00.000Z')
+
+    // 🛑 The plan is re-derived inside the call, so a second press inserts
+    // nothing rather than doubling the step.
+    const second = await applyTariffResync(
+      db,
+      ORG,
+      USER,
+      { actionKey: '301-3', codeInstanceIds: ['code_a', 'code_b'] },
+      deps
+    )
+    expect(second._unsafeUnwrap().applied).toEqual([])
+    expect(h.createCalls).toHaveLength(2)
+  })
+
+  it('stops at the code that fails, keeps what committed, and names what is left', async () => {
+    h.codeRows = [
+      { instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' },
+      { instanceId: 'code_b', code: '8503.00.95.20', country: 'CN' },
+      { instanceId: 'code_c', code: '8501.40.40.20', country: 'CN' },
+    ]
+    h.schedule.set('code_a', adoptedCnRows(4))
+    h.schedule.set('code_b', adoptedCnRows(3))
+    h.schedule.set('code_c', adoptedCnRows(4))
+    h.failOnCode.add('code_b')
+
+    const result = (
+      await applyTariffResync(
+        db,
+        ORG,
+        USER,
+        { actionKey: '301-3', codeInstanceIds: ['code_a', 'code_b', 'code_c'] },
+        deps
+      )
+    )._unsafeUnwrap()
+
+    expect(result.applied).toEqual([{ codeInstanceId: 'code_a', code: '8501.40.40.20', rows: 1 }])
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0]?.codeInstanceId).toBe('code_b')
+    expect(result.remaining).toEqual([{ codeInstanceId: 'code_c', code: '8501.40.40.20' }])
+
+    // The first code's row is committed; the failed code's is rolled back and
+    // the third was never attempted.
+    expect(h.createCalls).toHaveLength(1)
+    expect(h.schedule.get('code_a')).toHaveLength(6)
+    expect(h.schedule.get('code_b')).toHaveLength(5)
+    expect(h.schedule.get('code_c')).toHaveLength(5)
+  })
+
+  it('refuses an empty code list', async () => {
+    const result = await applyTariffResync(
+      db,
+      ORG,
+      USER,
+      { actionKey: '301-3', codeInstanceIds: [] },
+      deps
+    )
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+  })
+
+  it('is a no-op for an action the re-derived plan does not carry', async () => {
+    h.codeRows = [{ instanceId: 'code_a', code: '8501.40.40.20', country: 'CN' }]
+    h.schedule.set('code_a', adoptedCnRows(4))
+
+    const result = await applyTariffResync(
+      db,
+      ORG,
+      USER,
+      { actionKey: 'ieepa-fentanyl-cn', codeInstanceIds: ['code_a'] },
+      deps
+    )
+
+    expect(result._unsafeUnwrap()).toEqual({
+      actionKey: 'ieepa-fentanyl-cn',
+      applied: [],
+      failed: [],
+      remaining: [],
+    })
+    expect(h.createCalls).toEqual([])
+  })
+})

--- a/packages/lib/src/bom/resync-tariff-starters.ts
+++ b/packages/lib/src/bom/resync-tariff-starters.ts
@@ -1,0 +1,677 @@
+// packages/lib/src/bom/resync-tariff-starters.ts
+
+/**
+ * Re-syncing a `tariff_code` the org ALREADY holds with the starter catalogue
+ * (plans/money/tasks/35-tariff-catalogue-resync.md).
+ *
+ * `adopt-tariff-starters.ts` writes a code's rate history once, at adoption, and
+ * is idempotent BY SKIP - a pair the org already holds "is skipped whole and
+ * reported. Never updated, never topped up." So a catalogue correction never
+ * reaches an org that already adopted. This module is the other half: it
+ * re-expands the catalogue for a code the org holds, diffs the result against
+ * the stored rows, and appends what is missing.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * 🛑 THE FAILURE THIS IS DESIGNED AROUND (35 §1)
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * `resolveTariffRate` groups rows by `authorityKey(row.authority)` - a case- and
+ * whitespace-FOLDED string - takes the latest `effectiveFrom <= today` per
+ * group, and then **SUMS across groups**.
+ *
+ * So the naive top-up is lethal. An org that renamed `IEEPA fentanyl` to
+ * `IEEPA` gets a new step appended under OUR spelling, which lands in a SECOND
+ * authority group, and the two now sum. The rate silently doubles. No error, no
+ * warning, and the "no base rate" check does not fire because the base row is
+ * intact.
+ *
+ * The three rules that follow from that, and which this file exists to keep:
+ *
+ *  1. **INSERT only. Never update, never archive.** Right on the merits, not
+ *     merely cautious: the model already says an expiry is "an explicit `0`, and
+ *     there is no end date", so a withdrawn action is a new dated `0` step, not
+ *     a deletion. Append covers rate changes, brand-new actions, membership
+ *     corrections and expiries - everything except "we wrote it wrong", which is
+ *     out of scope by decision (35 §3.2) and corrected by hand in the editor.
+ *  2. **Pair the action on `chapter99Code`, the step on `effectiveFrom`. NEVER
+ *     on `authority`.** `chapter99Code` is the government's own identifier for
+ *     an action, it is on every action row, it is `null` on exactly the MFN base
+ *     row, and an org has no reason to edit it. So `(chapter99Code,
+ *     effectiveFrom)` is a natural key for a catalogue-written row with no
+ *     schema change at all.
+ *  3. **A new step is written with the ORG's authority spelling for THAT code**,
+ *     read off the sibling rows on that same code sharing that `chapter99Code`.
+ *
+ * 🛑 **Rule 3 is resolved PER CODE, never once per action** (35 §3.1). One click
+ * applies an action across every code it touches, so an action-scoped apply over
+ * twelve codes is twelve chances to double-count. Resolving the spelling once
+ * for the action and reusing it is rule 2's bug wearing a different hat, and it
+ * will not show up in a test that uses one code.
+ *
+ * ⚠️ "No sibling" is the common case, not an edge: a code that has never carried
+ * a Section 301 row has nothing to copy a spelling from, and the catalogue's own
+ * is used. Rule 3 therefore protects only codes that ALREADY carry the
+ * authority. A code gaining an authority for the first time is unprotected by
+ * construction, and that is correct - there is nothing to collide with.
+ *
+ * ⚠️ The residual hole, stated so nobody rediscovers it as a surprise: an org
+ * that BLANKED a row's `chapter99Code` (it is display-only, §2 of task 29) has
+ * hidden that row from the sibling lookup. If they also renamed its authority,
+ * the appended step lands in a second group. There is no defence against that
+ * short of per-row provenance, which 35 §3.2 rules out until `9903.91`.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * NO VERSION COMPARISON (35 §4)
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * This never asks "is the catalogue newer than what this org has". It re-runs
+ * `expandTariffStarter` for the `(code, country)` and diffs it against the
+ * stored rows - pure, in memory, one expansion per code. That removes a bug
+ * class as well as being simpler: `TARIFF_STARTERS_VERSION` is a bare date and
+ * one date already covers materially different catalogues. The version stays
+ * provenance on the row and stops being a decision input.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * THE TRANSACTION UNIT IS ONE CODE (35 §5.1)
+ * ═══════════════════════════════════════════════════════════════════════
+ *
+ * Not the action. `UnifiedCrudHandler` takes a `Database`, not a `Transaction`,
+ * so each code's writes go in their own `db.transaction` with the
+ * `tx as unknown as Database` cast `adopt-tariff-starters.ts` already uses.
+ * Whole-or-nothing PER CODE - a code that gains three of four rows is 29 §3's
+ * silent understatement again - and codes are written sequentially, in order.
+ *
+ * 🛑 So an action apply can PARTIALLY COMPLETE, and says so.
+ * {@link ResyncApplyResult} carries `applied`, `failed` and `remaining`, and a
+ * partial run still returns `ok` - erring would throw away the record of what
+ * was already committed. Never report "done" for a run that stopped at code 137
+ * of 200.
+ *
+ * No permission checks: the router asserts `tariff_code` and `tariff_rate` edit
+ * before calling this (`docs/lib-module-guide.md` §6).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import { err, ok, type Result } from 'neverthrow'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { AuxxError, BadRequestError, NotFoundError } from '../errors'
+import { UnifiedCrudHandler } from '../resources/crud'
+import { loadTariffMemberships } from './tariff-301-memberships'
+import { findHtsGeneral, loadHtsGeneral } from './tariff-hts-general'
+import { loadTariffSchedule, readBookTimeZone } from './tariff-schedule'
+import {
+  expandTariffStarter,
+  type StarterAction,
+  TARIFF_ACTIONS,
+  TARIFF_STARTERS_VERSION,
+} from './tariff-starters'
+import { authorityKey, effectiveDay, resolveTariffRate, type TariffRateRow } from './vendor-cost'
+
+const logger = createScopedLogger('bom:resync-tariff-starters')
+
+/**
+ * The pseudo-action the MFN base row is grouped under.
+ *
+ * ⚠️ A DEVIATION from 35 §5, which typed `ResyncAction.chapter99Code` as a bare
+ * `string`. The base row is `(null, 1995-01-01)` by §2's own account, so it is
+ * part of the natural keyspace this module diffs on, and a code typed by hand
+ * before the catalogue existed can be missing it entirely - which is exactly
+ * 29 §3's silent understatement. Excluding it would have left the one addition
+ * that fixes that case unreachable. So `actionKey`/`authority`/`chapter99Code`
+ * admit the base row, and it is its own row in the dialog rather than being
+ * folded into a government action it is not.
+ *
+ * Appending it is safe under the resolution rule even when the org already has
+ * a base row at a later date: `1995-01-01` loses that group's latest-wins
+ * comparison and contributes nothing.
+ */
+export const MFN_ACTION_KEY = 'mfn'
+
+/** One row the catalogue would add to a code that already holds it. */
+export interface ResyncAddition {
+  /** A PERCENTAGE - `25` means 25%. */
+  rate: number
+  /** `YYYY-MM-DD`. */
+  effectiveFrom: string
+  /** This CODE's spelling where it already carries the authority; ours otherwise. §3.1 */
+  authority: string | null
+  chapter99Code: string | null
+  note: string
+  /**
+   * True when the spelling came from a sibling row rather than the catalogue.
+   *
+   * Rendered, not hidden: rule 3 doing its job should be visible. The dialog
+   * only says so when the sibling's spelling actually DIFFERS from the
+   * catalogue's, because "used your spelling, which is our spelling" is noise.
+   */
+  spellingFromOrg: boolean
+}
+
+/** One code an action would add rows to, with what it resolves to before and after. */
+export interface ResyncCode {
+  codeInstanceId: string
+  code: string
+  country: string
+  /** Oldest `effectiveFrom` first. */
+  additions: ResyncAddition[]
+  /** Resolved total today, before and after THIS action's additions. What a person consents to. */
+  before: number
+  after: number
+}
+
+/** The unit of apply: one government action, across every code it touches. */
+export interface ResyncAction {
+  /** A key into `TARIFF_ACTIONS`, or {@link MFN_ACTION_KEY}. */
+  actionKey: string
+  /** The CATALOGUE's spelling. `null` for the base row, which has no authority. */
+  authority: string | null
+  /** `null` for the base row - see {@link MFN_ACTION_KEY}. */
+  chapter99Code: string | null
+  /** Sorted by the largest swing first, so the biggest change reads first (§7.1). */
+  codes: ResyncCode[]
+}
+
+/** One stored row whose rate disagrees with the catalogue at the same day. */
+export interface ResyncDivergence {
+  codeInstanceId: string
+  code: string
+  /** The `tariff_rate` instance id, so the editor can be pointed at it. */
+  rateId: string
+  chapter99Code: string | null
+  effectiveFrom: string
+  /** What the org holds. */
+  ours: number
+  /** What the catalogue says. */
+  theirs: number
+}
+
+export interface ResyncPlan {
+  /** Most codes affected first. */
+  actions: ResyncAction[]
+  /**
+   * Rows the org holds whose rate differs from the catalogue at the same
+   * `effectiveFrom`. REPORTED ONLY - never written (§3.2). An org that set
+   * List 3 to 30% meant it, and this module does not argue.
+   */
+  diverged: ResyncDivergence[]
+  /** Stamped so "nothing to apply" can say WHICH catalogue said so (§7.3). */
+  version: string
+}
+
+/** What one apply did. A partial run is `ok` and reports all three lists. */
+export interface ResyncApplyResult {
+  actionKey: string
+  /** Codes written whole, in the order they were written. */
+  applied: Array<{ codeInstanceId: string; code: string; rows: number }>
+  /** The code the run stopped on. At most one - writing is sequential and aborts. */
+  failed: Array<{ codeInstanceId: string; code: string; error: string }>
+  /** Codes never attempted, because a failure stopped the run before them. */
+  remaining: Array<{ codeInstanceId: string; code: string }>
+}
+
+/**
+ * Test-only overrides, mirroring `expandTariffStarter`'s own `deps` seam.
+ * Production callers omit this.
+ */
+export interface ResyncDeps {
+  /** Override the hand-kept action table. */
+  actions?: Record<string, StarterAction>
+  /** Override the version stamped into the note of every row written. */
+  version?: string
+  /** The instant `before` / `after` resolve at. Defaults to now. */
+  now?: Date
+}
+
+/** One `tariff_code` record, reduced to what the diff needs. */
+interface CodeRow {
+  instanceId: string
+  code: string
+  country: string
+}
+
+/** `(chapter99Code, day)` - the natural key of a catalogue-written row (§2). */
+function rowKey(chapter99Code: string | null, day: string): string {
+  return `${(chapter99Code ?? '').trim()}|${day}`
+}
+
+/** The heading as a lookup key. Trimmed only: it is digits and dots, never prose. */
+function headingKey(chapter99Code: string | null): string {
+  return (chapter99Code ?? '').trim()
+}
+
+const emptyPlan = (version: string): ResyncPlan => ({ actions: [], diverged: [], version })
+
+/**
+ * Every LIVE `tariff_code` in the org with its code and country.
+ *
+ * 🛑 Archived codes are excluded, matching adopt's rule 1: archiving was a
+ * decision, and a sync that quietly appended rows to a code somebody
+ * soft-deleted would be undoing it. This is the OPPOSITE call from
+ * `loadExistingPairKeys` in `adopt-tariff-starters.ts`, which includes archived
+ * rows on purpose - there the question is "did the org ever adopt this", here it
+ * is "is this code live".
+ */
+async function loadTariffCodeRows(
+  db: Database,
+  organizationId: string,
+  tariffCodeDefId: string,
+  codeInstanceIds?: readonly string[]
+): Promise<CodeRow[]> {
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['tariff_code_code', 'tariff_code_country'] as const)
+  const codeField = fields.tariff_code_code
+  const countryField = fields.tariff_code_country
+  if (!codeField || !countryField) return []
+
+  const codeValue = alias(schema.FieldValue, 'resync_tariff_code_code')
+  const countryValue = alias(schema.FieldValue, 'resync_tariff_code_country')
+
+  const rows = await db
+    .select({
+      instanceId: schema.EntityInstance.id,
+      code: codeValue.valueText,
+      country: countryValue.optionId,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      codeValue,
+      and(
+        eq(codeValue.entityId, schema.EntityInstance.id),
+        eq(codeValue.organizationId, organizationId),
+        eq(codeValue.fieldId, codeField.id)
+      )
+    )
+    .innerJoin(
+      countryValue,
+      and(
+        eq(countryValue.entityId, schema.EntityInstance.id),
+        eq(countryValue.organizationId, organizationId),
+        eq(countryValue.fieldId, countryField.id)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, tariffCodeDefId),
+        isNull(schema.EntityInstance.archivedAt),
+        ...(codeInstanceIds ? [inArray(schema.EntityInstance.id, [...codeInstanceIds])] : [])
+      )
+    )
+
+  const result: CodeRow[] = []
+  for (const row of rows) {
+    // A code with no origin cannot be expanded - the whole catalogue is
+    // `(code, country)` - so it has nothing to sync and is not an error.
+    if (row.code && row.country) {
+      result.push({ instanceId: row.instanceId, code: row.code, country: row.country })
+    }
+  }
+  return result
+}
+
+/**
+ * This CODE's own spelling of the authority on each Chapter 99 heading it
+ * carries - rule 3, and the whole point of resolving it per code (§3.1).
+ *
+ * The latest row wins where a code carries several steps of the same action,
+ * because that is the spelling in force; ties break on the instance id so the
+ * answer is total. A code that carries no row for a heading is simply absent
+ * from the map, and the caller falls back to the catalogue's spelling.
+ */
+function orgAuthorityByHeading(rows: readonly TariffRateRow[]): Map<string, string | null> {
+  const best = new Map<string, { authority: string | null; day: string; id: string }>()
+  for (const row of rows) {
+    const heading = headingKey(row.chapter99Code)
+    if (heading === '') continue
+    const day = effectiveDay(row.effectiveFrom) ?? ''
+    const held = best.get(heading)
+    if (!held || day > held.day || (day === held.day && row.id > held.id)) {
+      best.set(heading, { authority: row.authority, day, id: row.id })
+    }
+  }
+  return new Map([...best].map(([heading, entry]) => [heading, entry.authority]))
+}
+
+/**
+ * The additions turned into rows the resolver can read, so `before` and `after`
+ * come out of the SAME function that prices a receipt.
+ *
+ * 🛑 The synthesised ids start with `~` deliberately. `resolveTariffRate` breaks
+ * a same-day tie inside an authority group on `row.id`, and ids in this system
+ * are alphanumeric, so `~` sorts after every real one and a pending row wins a
+ * tie against a stored row rather than losing it silently. That is the honest
+ * preview: the row being added is the newer one.
+ */
+function additionsAsRows(additions: readonly ResyncAddition[]): TariffRateRow[] {
+  return additions.map((addition, index) => ({
+    id: `~resync:${index}`,
+    authority: addition.authority,
+    rate: addition.rate,
+    effectiveFrom: addition.effectiveFrom,
+    chapter99Code: addition.chapter99Code,
+  }))
+}
+
+/**
+ * What the catalogue would add to every live `tariff_code` in the org, grouped
+ * by the government action that would add it.
+ *
+ * Reads only. `codeInstanceIds` narrows it to the codes named - the per-row
+ * button's "fix this one code" (§7.2) - and is the same narrowing
+ * {@link applyTariffResync} re-derives with.
+ *
+ * The schedule is read through `loadTariffSchedule`, which deliberately has no
+ * org-cache key (29 §7) and therefore cannot serve a stale schedule into a diff
+ * that decides what to write.
+ */
+export async function planTariffResync(
+  db: Database,
+  organizationId: string,
+  codeInstanceIds?: readonly string[],
+  deps?: ResyncDeps
+): Promise<Result<ResyncPlan, Error>> {
+  const actions = deps?.actions ?? (TARIFF_ACTIONS as Record<string, StarterAction>)
+  const version = deps?.version ?? TARIFF_STARTERS_VERSION
+
+  if (codeInstanceIds && codeInstanceIds.length === 0) return ok(emptyPlan(version))
+
+  const [tariffCodeDefId, tariffRateDefId] = await Promise.all([
+    getCachedEntityDefId(organizationId, 'tariff_code'),
+    getCachedEntityDefId(organizationId, 'tariff_rate'),
+  ])
+  if (!tariffCodeDefId || !tariffRateDefId) {
+    return err(
+      new NotFoundError(
+        'This org has no tariff_code / tariff_rate definitions yet - nothing to re-sync'
+      )
+    )
+  }
+
+  const codes = await loadTariffCodeRows(db, organizationId, tariffCodeDefId, codeInstanceIds)
+  if (codes.length === 0) return ok(emptyPlan(version))
+
+  const [schedule, catalogue, memberships, timeZone] = await Promise.all([
+    loadTariffSchedule(
+      db,
+      organizationId,
+      codes.map((code) => code.instanceId)
+    ),
+    loadHtsGeneral(),
+    loadTariffMemberships(),
+    readBookTimeZone(organizationId),
+  ])
+  const now = deps?.now ?? new Date()
+
+  // `(country, heading)` identifies an action: a `StarterAction` carries exactly
+  // one of each, and the same heading under two origins is two actions.
+  const actionKeyByCountryHeading = new Map<string, string>()
+  for (const [key, action] of Object.entries(actions)) {
+    actionKeyByCountryHeading.set(`${action.country}|${headingKey(action.chapter99Code)}`, key)
+  }
+
+  const diverged: ResyncDivergence[] = []
+  const grouped = new Map<string, ResyncAction>()
+
+  for (const code of codes) {
+    const line = findHtsGeneral(catalogue.lines, code.code)
+    // A code the catalogue does not carry - hand-typed, or a heading we have no
+    // general rate for - produces no additions. Nothing has to ask "did we
+    // write this row".
+    if (!line) continue
+
+    const expansion = expandTariffStarter(line, code.country, memberships, { actions, version })
+    const stored = schedule.get(code.instanceId) ?? []
+
+    const storedByKey = new Map<string, TariffRateRow>()
+    for (const row of stored) {
+      const day = effectiveDay(row.effectiveFrom)
+      if (day === null) continue
+      const key = rowKey(row.chapter99Code, day)
+      // First wins. A code holding two rows at the same `(heading, day)` is
+      // already ambiguous; picking one deterministically beats planning an
+      // addition against the second and writing a third.
+      if (!storedByKey.has(key)) storedByKey.set(key, row)
+    }
+
+    // 🛑 Rule 3, resolved from THIS CODE's own rows and used only for this code.
+    const authorityByHeading = orgAuthorityByHeading(stored)
+
+    /** The additions this code would take, split by the action that brings them. */
+    const byAction = new Map<string, ResyncAddition[]>()
+
+    for (const row of expansion.rows) {
+      const key = rowKey(row.chapter99Code, row.effectiveFrom)
+      const held = storedByKey.get(key)
+      if (held) {
+        if ((held.rate ?? 0) !== row.rate) {
+          diverged.push({
+            codeInstanceId: code.instanceId,
+            code: code.code,
+            rateId: held.id,
+            chapter99Code: row.chapter99Code,
+            effectiveFrom: row.effectiveFrom,
+            ours: held.rate ?? 0,
+            theirs: row.rate,
+          })
+        }
+        continue
+      }
+
+      const heading = headingKey(row.chapter99Code)
+      const hasSibling = authorityByHeading.has(heading)
+      const authority = hasSibling ? (authorityByHeading.get(heading) ?? null) : row.authority
+      const actionKey =
+        heading === ''
+          ? MFN_ACTION_KEY
+          : (actionKeyByCountryHeading.get(`${code.country}|${heading}`) ?? heading)
+
+      const bucket = byAction.get(actionKey) ?? []
+      bucket.push({
+        rate: row.rate,
+        effectiveFrom: row.effectiveFrom,
+        authority,
+        chapter99Code: row.chapter99Code,
+        note: row.note,
+        // Folded, not compared raw: `IEEPA` and `ieepa ` are the same authority
+        // to the resolver, so they are the same spelling here too.
+        spellingFromOrg: hasSibling && authorityKey(authority) !== authorityKey(row.authority),
+      })
+      byAction.set(actionKey, bucket)
+    }
+
+    for (const [actionKey, additions] of byAction) {
+      additions.sort((a, b) => (a.effectiveFrom < b.effectiveFrom ? -1 : 1))
+
+      // ONE resolver, over current rows and then over current + this action's
+      // additions - the same rule the Codes list and the picker preview render
+      // with. `before` and `after` are per action because apply is per action.
+      const before = resolveTariffRate(stored, now, timeZone).rate
+      const after = resolveTariffRate(
+        [...stored, ...additionsAsRows(additions)],
+        now,
+        timeZone
+      ).rate
+
+      const action = actions[actionKey]
+      let entry = grouped.get(actionKey)
+      if (!entry) {
+        entry = {
+          actionKey,
+          authority: actionKey === MFN_ACTION_KEY ? null : (action?.authority ?? null),
+          chapter99Code: actionKey === MFN_ACTION_KEY ? null : (action?.chapter99Code ?? actionKey),
+          codes: [],
+        }
+        grouped.set(actionKey, entry)
+      }
+      entry.codes.push({
+        codeInstanceId: code.instanceId,
+        code: code.code,
+        country: code.country,
+        additions,
+        before,
+        after,
+      })
+    }
+  }
+
+  const plan: ResyncPlan = {
+    actions: [...grouped.values()],
+    diverged,
+    version,
+  }
+
+  // Largest swing first inside an action (§7.1), most codes affected first
+  // across actions. Both ties break on a string so the order is total and the
+  // dialog does not reshuffle between renders.
+  for (const action of plan.actions) {
+    action.codes.sort((a, b) => {
+      const swing = Math.abs(b.after - b.before) - Math.abs(a.after - a.before)
+      return swing !== 0 ? swing : a.code.localeCompare(b.code)
+    })
+  }
+  plan.actions.sort((a, b) => {
+    const size = b.codes.length - a.codes.length
+    return size !== 0 ? size : a.actionKey.localeCompare(b.actionKey)
+  })
+
+  return ok(plan)
+}
+
+/**
+ * Writes one code's additions inside one transaction. Throws (rolling back all
+ * of them) on any failure; the caller decides what that means for the run.
+ */
+async function appendRows(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  tariffRateDefId: string,
+  codeInstanceId: string,
+  additions: readonly ResyncAddition[]
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    // See the file header: `UnifiedCrudHandler` takes a `Database`, not a
+    // `Transaction` - the same cast `adopt-tariff-starters.ts` makes.
+    const txDb = tx as unknown as Database
+    const handler = new UnifiedCrudHandler(organizationId, userId, txDb)
+    const codeRecordId = `tariff_code:${codeInstanceId}`
+
+    for (const addition of additions) {
+      await handler.create(tariffRateDefId, {
+        tariff_rate_tariff_code: codeRecordId,
+        tariff_rate_rate: addition.rate,
+        tariff_rate_effective_from: `${addition.effectiveFrom}T00:00:00.000Z`,
+        ...(addition.authority ? { tariff_rate_authority: addition.authority } : {}),
+        ...(addition.chapter99Code ? { tariff_rate_chapter99_code: addition.chapter99Code } : {}),
+        tariff_rate_note: addition.note,
+      })
+    }
+  })
+}
+
+/**
+ * Applies ONE government action across the codes named, appending the rows the
+ * catalogue would add and touching nothing else.
+ *
+ * 🛑 **Re-derives the plan inside the call** rather than trusting one posted
+ * from the browser. The dialog's plan is for display; the write re-computes.
+ * Otherwise a plan computed before somebody edited a rate applies against a
+ * schedule that has moved - and re-deriving is also what makes a double click,
+ * or two people pressing the button at once, insert nothing the second time.
+ *
+ * Codes are written sequentially in the order the caller named them, one
+ * transaction each. A failure STOPS the run: what committed stays committed,
+ * what was never attempted is reported as `remaining`, and the result is `ok`
+ * so the caller can render all three lists (§5.1).
+ */
+export async function applyTariffResync(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: { actionKey: string; codeInstanceIds: readonly string[] },
+  deps?: ResyncDeps
+): Promise<Result<ResyncApplyResult, Error>> {
+  if (input.codeInstanceIds.length === 0) {
+    return err(new BadRequestError('Name at least one tariff code to re-sync'))
+  }
+
+  const tariffRateDefId = await getCachedEntityDefId(organizationId, 'tariff_rate')
+  if (!tariffRateDefId) {
+    return err(new NotFoundError('This org has no tariff_rate definition yet - nothing to write'))
+  }
+
+  const planned = await planTariffResync(db, organizationId, input.codeInstanceIds, deps)
+  if (planned.isErr()) return err(planned.error)
+
+  const empty: ResyncApplyResult = {
+    actionKey: input.actionKey,
+    applied: [],
+    failed: [],
+    remaining: [],
+  }
+
+  const action = planned.value.actions.find((entry) => entry.actionKey === input.actionKey)
+  // Not an error: the re-derived plan says there is nothing left to add. That is
+  // the answer when the rows already landed - a second click, a second tab.
+  if (!action) return ok(empty)
+
+  // The caller's order, not the plan's - `codeInstanceIds` is what a person
+  // picked, and a partial run has to be describable against that list.
+  const byInstance = new Map(action.codes.map((entry) => [entry.codeInstanceId, entry]))
+  const queue = input.codeInstanceIds
+    .map((id) => byInstance.get(id))
+    .filter((entry): entry is ResyncCode => entry !== undefined)
+
+  const result: ResyncApplyResult = { ...empty }
+
+  for (let index = 0; index < queue.length; index++) {
+    const entry = queue[index] as ResyncCode
+    try {
+      await appendRows(
+        db,
+        organizationId,
+        userId,
+        tariffRateDefId,
+        entry.codeInstanceId,
+        entry.additions
+      )
+      result.applied.push({
+        codeInstanceId: entry.codeInstanceId,
+        code: entry.code,
+        rows: entry.additions.length,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error('Failed to re-sync a tariff code with the catalogue', {
+        organizationId,
+        actionKey: input.actionKey,
+        codeInstanceId: entry.codeInstanceId,
+        code: entry.code,
+        error,
+      })
+      result.failed.push({
+        codeInstanceId: entry.codeInstanceId,
+        code: entry.code,
+        error: error instanceof AuxxError ? error.message : message,
+      })
+      result.remaining = queue
+        .slice(index + 1)
+        .map((rest) => ({ codeInstanceId: rest.codeInstanceId, code: rest.code }))
+      break
+    }
+  }
+
+  logger.info('Re-synced tariff codes with the catalogue', {
+    organizationId,
+    actionKey: input.actionKey,
+    applied: result.applied.length,
+    failed: result.failed.length,
+    remaining: result.remaining.length,
+  })
+
+  return ok(result)
+}

--- a/packages/lib/src/bom/vendor-cost.ts
+++ b/packages/lib/src/bom/vendor-cost.ts
@@ -488,8 +488,15 @@ function compareComponents(a: TariffRateComponent, b: TariffRateComponent): numb
  * The grouping key for an authority. Trimmed and case-folded so `MFN`, `mfn`
  * and ` MFN ` are one authority rather than three that all get summed - which
  * would triple a base duty with nothing on screen to show it.
+ *
+ * 🛑 **Exported so the catalogue re-sync folds IDENTICALLY** (money 35 §2).
+ * `resync-tariff-starters.ts` has to decide whether a row it is about to write
+ * lands in an authority group the org already has; if its folding rule and this
+ * one ever disagree, an appended step lands in a SECOND group and the resolver
+ * sums the two - a silently doubled rate, with no error and no warning. One
+ * folding rule, one definition (29 §13).
  */
-function authorityKey(authority: string | null): string {
+export function authorityKey(authority: string | null): string {
   return (authority ?? '').trim().toLowerCase()
 }
 
@@ -504,8 +511,14 @@ function normalizeAuthority(authority: string | null): string | null {
  *
  * DATE values are stored as UTC midnight per the platform contract, so the UTC
  * slice is the day.
+ *
+ * Exported for the same reason {@link authorityKey} is (money 35 §2): the
+ * catalogue re-sync pairs a stored row against a catalogue row on
+ * `(chapter99Code, effectiveFrom)`, so its notion of "the same day" has to be
+ * this one. A second copy that read a `Date` in local time rather than UTC
+ * would mis-pair rows by a day and append a duplicate step.
  */
-function effectiveDay(effectiveFrom: Date | string | null): string | null {
+export function effectiveDay(effectiveFrom: Date | string | null): string | null {
   if (effectiveFrom == null) return null
   if (typeof effectiveFrom === 'string') {
     const day = effectiveFrom.slice(0, 10)


### PR DESCRIPTION
Implements `plans/money/tasks/35-tariff-catalogue-resync.md`. Follow-up to #2025.

## Why

`adoptTariffStarters` writes a code's rate history once, at adoption, and nothing reads the catalogue for that code again. Its rule 1 is idempotent *by skip* - a pair the org already holds "is skipped whole and reported. Never updated, never topped up." So a catalogue correction never reaches an org that already adopted, and re-picking renders "Already added".

That stopped being hypothetical when #2025 made Section 301 membership a generated table: **seven of the dev org's adopted codes are understated by 25 points**, and the picker already shows the corrected numbers while the stored rows hold the old ones.

## The three rules that carry it

**1. INSERT only. Never update, never archive.** The model already says an expiry is "an explicit `0`, and there is no end date", so a withdrawn action is a new dated `0` step. Append covers rate changes, new actions, membership corrections and expiries - everything except "we wrote it wrong", which stays out of scope (§3.2) and is corrected by hand.

**2. Pair on `chapter99Code`, never on `authority`.** `resolveTariffRate` folds authority to a lowercase string and **sums across groups**. An org that renamed `IEEPA fentanyl` to `IEEPA` would get our step in a second group and a silently doubled rate - no error, no warning, and the "no base rate" check never fires because the base row is intact.

`(chapter99Code, effectiveFrom)` is the government's own identifier and is already stored, so this needs no schema change. `authorityKey` and `effectiveDay` stop being private to `vendor-cost.ts`: the diff must fold authorities and resolve days *identically* to the resolver, or the two disagree about whether a row is a rename. (`effectiveDay` beyond the plan's ask - a local copy reading a `Date` in local time would mis-pair by a day and append a duplicate step.)

**3. The org's spelling is resolved PER CODE.** Applying one action across twelve codes is twelve chances to double-count, so it is read from each code's own sibling rows inside the loop, never once per action and reused.

> This one is pinned by a test with two codes spelling the same heading differently. It was verified load-bearing by temporarily mutating the source to hoist that resolution: the test failed with `expected 25 to be 30`, the renamed code's addition landing in a second authority group. Restored afterwards.

## Surface

**The apply unit is the action**, not the code. Three of the four things that change in this catalogue are action-shaped (an action gains a step, an action starts covering more codes, a new action ships); only an MFN change is genuinely per-code. Presenting them per code makes you re-infer the same cause once per code.

- Header button with an action-count badge opens a dialog: one row per action, expanding to a per-code table sorted by swing showing `before → after`.
- Four Section 301 lists stay **four rows**, never grouped under a "Section 301" family - each is its own authority to the resolver, and a family grouping invites an "apply all" that would be four different government actions behind one click.
- No "apply all". The action is the unit of consent.
- The per-row button opens the same dialog narrowed to one code.
- `diverged` rows (org's rate differs at the same date) are shown read-only and never written.

**One transaction per code, sequential**, so a run can partially complete. The result reports `applied` / `failed` / `remaining` rather than claiming success for a run that stopped at code 137 of 200.

## Also: delete from the list

A `Trash2` `TreeRowButton` per row, wired to the page's **existing** `handleRemoveCode`. No new delete path, and its carefully-worded confirm copy is untouched. Hover-revealed, hidden when `!canEdit`, absent on the phantom draft row.

One addition: that callback *rejects* on refusal because the detail editor renders the message as a `FieldError`, and a list row has no field for one to land on - so the list catches and `toastError`s, the same call and reasoning as the page's existing `handleRemoveRate`.

## Deviations from the plan, flagged for review

1. **The MFN base row is planned, under an `mfn` pseudo-action**, so `ResyncAction.authority` / `.chapter99Code` are `string | null`, not `string` as §5 typed them. §2 calls the base row part of the keyspace, and excluding it would leave a hand-typed code missing its base row - 29 §3's silent understatement - with no way to gain one. Safe: `1995-01-01` loses latest-wins against any later base row. Plans nothing on real data today.
2. Optional `deps` (`actions` / `version` / `now`) on both functions, mirroring `expandTariffStarter`'s existing seam. The expiry and new-step cases cannot be tested against the real `TARIFF_ACTIONS`.
3. `applyTariffResync` returns `ok` on a partial run rather than `err`, so `applied` is not discarded.

## Real-data read (no writes)

`planTariffResync` against the dev org, read path only:

- `301-3` - **8 codes**, seven going **+25 pts** (`7216.61.00.00` 20.0% → 45.0%, `7318.15.80.30` 53.5% → 78.5%, …). The plan predicted six; the data moved.
- `301-2` - `8503.00.95.20` 23.0% → 48.0%.
- `diverged: 0`; no `mfn` action, so every code already holds its base row.

Two results worth understanding before applying:

- `8481.80.9005` under `301-3` plans an addition that **changes nothing** (47.0% → 47.0%) - its 2018 step is superseded by a 2019 row already there. Rendered as "no change today" rather than hidden.
- The same code under `ieepa-fentanyl-cn` goes **down**, 47.0% → 37.0%, because the catalogue's 2025-11-10 10% step supersedes that code's stale 2025-03-04 20% row. That is the catalogue being right, but it is a decrease and worth eyeballing - especially with the IEEPA question from #2025 still unresolved.

**`applyTariffResync` has not been run against the dev org.** It is insert-only, so a wrong apply is undoable only by hand. Recommend clicking one code in the UI first.

## Testing

`packages/lib/src/bom`: **10 files, 161 tests pass.** Lib typecheck ratchet exit 0, `no new type errors (27 total, baseline 29)`. `@auxx/web` typecheck exit 0 (unpiped, exit code checked). Biome clean.

Full `packages/lib` suite: **1092 files passed, 4 skipped, 2 failed.** Both failures are the pre-existing pair - `field-hooks/__tests__/delete-guard-registration.test.ts` and `seed/entity-migrations/migrations/108-purchasing.test.ts` - verified against clean `main` at `5fd23fd5c` during #2025. Neither area is touched here. This branch adds no failures.

https://claude.ai/code/session_01YScvh3VMV73p7YK3HczYgN

