### PR TITLE
fix(trpc): query input travels in the body, and the record catch-up is one pass

### DIFF
--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -44,6 +44,11 @@ const handler = async (req: NextRequest) => {
     req,
     router: appRouter,
     createContext: () => createContext(req),
+    // Lets the browser clients send queries as POST so their input travels in
+    // the body instead of the URL (see `~/trpc/react.tsx`). GET still works —
+    // this only widens what POST is allowed to resolve, and tRPC still refuses
+    // a subscription over it.
+    allowMethodOverride: true,
     onError:
       configService.get<string>('NODE_ENV') === 'development'
         ? ({ path, error }) => {

--- a/apps/web/src/components/resources/hooks/use-resource-sync.ts
+++ b/apps/web/src/components/resources/hooks/use-resource-sync.ts
@@ -225,6 +225,19 @@ export function useResourceSync() {
 
   const runCatchUp = useCallback(
     (entityDefinitionIds: string[]) => {
+      // Lane 2 is collected across ALL defs in the pass and issued as chunks of
+      // the input cap, not one request per def. `record.getByIds` takes mixed
+      // RecordIds, so a per-def fan-out bought nothing and cost a lot: six defs
+      // subscribing in the same coalesce window put six `getByIds` calls in one
+      // tRPC batch, ~25KB of ids on the query string, and the dev server
+      // answered 431 Request Header Fields Too Large for the whole batch
+      // (driven 2026-09-01, /app/parts/settings/tariffs). Chunking the union is
+      // ceil(total / cap) requests — never more than the fan-out, usually far
+      // fewer.
+      const catchUpIds: RecordId[] = []
+      /** entityInstanceId -> the def it was requested under. */
+      const defByInstanceId = new Map<string, string>()
+
       for (const entityDefinitionId of entityDefinitionIds) {
         // 1. Row membership — creates/deletes/archives/bulk invalidations. The
         //    tRPC data stays cached while it refetches, so rows do not blank.
@@ -234,12 +247,26 @@ export function useResourceSync() {
         const ids = cachedRecordIdsForDef(entityDefinitionId, CATCH_UP_RECORD_CAP)
         if (ids.length === 0) continue
 
-        // 2. Record meta — a missed `record:updated` (display name, avatar).
-        //    `updateRecord` patches rows we already hold and ignores the rest.
+        for (const id of ids) {
+          defByInstanceId.set(id, entityDefinitionId)
+          catchUpIds.push(toRecordId(entityDefinitionId, id))
+        }
+
+        // 3. Cell values — a missed `fieldValues:updated`. Refreshes exactly
+        //    the cells already in the store, in one batched request.
+        const requests = cachedValueRequests(entityDefinitionId, new Set(ids))
+        if (requests.length > 0) fieldValueFetchQueue.refetch(requests)
+      }
+
+      // 2. Record meta — a missed `record:updated` (display name, avatar).
+      //    `updateRecord` patches rows we already hold and ignores the rest.
+      for (let i = 0; i < catchUpIds.length; i += CATCH_UP_RECORD_CAP) {
         utils.record.getByIds
-          .fetch({ items: ids.map((id) => toRecordId(entityDefinitionId, id)) }, { staleTime: 0 })
+          .fetch({ items: catchUpIds.slice(i, i + CATCH_UP_RECORD_CAP) }, { staleTime: 0 })
           .then((data) => {
             for (const item of Object.values(data ?? {})) {
+              const entityDefinitionId = defByInstanceId.get(item.id)
+              if (!entityDefinitionId) continue
               updateRecord(entityDefinitionId, item.id, {
                 displayName: item.displayName,
                 secondaryInfo: item.secondaryInfo,
@@ -255,11 +282,6 @@ export function useResourceSync() {
           .catch(() => {
             /* best-effort; the next subscribe or refresh retries */
           })
-
-        // 3. Cell values — a missed `fieldValues:updated`. Refreshes exactly
-        //    the cells already in the store, in one batched request.
-        const requests = cachedValueRequests(entityDefinitionId, new Set(ids))
-        if (requests.length > 0) fieldValueFetchQueue.refetch(requests)
       }
     },
     [invalidateLists, updateRecord, utils]

--- a/apps/web/src/trpc/react.tsx
+++ b/apps/web/src/trpc/react.tsx
@@ -65,6 +65,14 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
         unstable_httpBatchStreamLink({
           transformer: SuperJSON,
           url: getBaseUrl() + '/api/trpc',
+          // Queries go out as POST with their input in the BODY, not on the
+          // query string. A batch is only as sendable as its URL is short, and
+          // id-list procedures blow that budget quickly: six `record.getByIds`
+          // calls coalescing into one batch put ~25KB of RecordIds on the URL
+          // and the server answered 431 Request Header Fields Too Large for
+          // every procedure in the batch, unrelated ones included. Requires
+          // `allowMethodOverride` on the handler — see `api/trpc/[trpc]/route.ts`.
+          methodOverride: 'POST',
           headers: () => {
             const headers = new Headers()
             headers.set('x-trpc-source', 'nextjs-react')

--- a/apps/web/src/trpc/vanilla.ts
+++ b/apps/web/src/trpc/vanilla.ts
@@ -19,6 +19,9 @@ export const vanillaApi = createTRPCClient<AppRouter>({
     httpBatchLink({
       transformer: SuperJSON,
       url: `${getBaseUrl()}/api/trpc`,
+      // Same reason as the React client: query input belongs in the body, not
+      // on the URL. See `~/trpc/react.tsx`.
+      methodOverride: 'POST',
       headers: () => {
         const headers: Record<string, string> = {
           'x-trpc-source': 'nextjs-vanilla',


### PR DESCRIPTION
## What was happening

`record.getByIds` was being called many times per page load on
`/app/parts/settings/tariffs`, and the calls were failing.

`useResourceSync`'s `runCatchUp` fired **one `record.getByIds` per entity
definition**. Six defs bind their realtime channels inside the same 250ms
coalesce window on that page, so six `getByIds` calls landed in a single tRPC
HTTP batch — and because queries went out as **GET**, ~219 RecordIds rode the
query string. 25KB of URL, and the server answered **431 Request Header Fields
Too Large for the whole batch**, killing every unrelated procedure batched with
it. React Query then retried.

Measured in Chrome before the fix: **11 `getByIds` calls** per page load, URLs
of **13,303 chars** — one cookie away from failing again on the runs that did
not 431 outright.

## The fix

Both levels, because either alone leaves the other sharp edge in place.

**1. `use-resource-sync.ts` — stop the per-def fan-out.**
`runCatchUp` now collects ids across every def in the pass and issues
`ceil(total / 100)` chunked calls instead of one per def. `record.getByIds`
already accepts mixed RecordIds (that is how the record-store batcher uses it),
so the per-def split bought nothing and cost a request each. An
instance-id → def map preserves the exact `updateRecord` targeting the per-def
loop had, so no canonicalization behavior changes.

**2. `trpc/react.tsx`, `trpc/vanilla.ts`, `api/trpc/[trpc]/route.ts` — query
input into the body.**
`methodOverride: 'POST'` on both browser clients plus `allowMethodOverride:
true` on the handler. This is the durable half: no id-list procedure can build
an unsendable URL again, and one oversized procedure can no longer fail every
procedure batched beside it. GET still works, so the extension client and the
e2e POM are unaffected; tRPC still refuses a subscription over the override.

## Verification

Driven in Chrome on the tariffs page, before and after:

| | before | after |
| --- | --- | --- |
| `record.getByIds` calls per load | 11 | **4** |
| method | GET | **POST** |
| max URL length | 13,303 | **99** |
| failures | 431 on the 6-call batch | **none** |

Console clean, every request 200. The 4 remaining calls are 1 initial hydration
plus 3 chunks of the catch-up (219 cached ids ÷ 100).

- `pnpm --filter @auxx/web typecheck` — clean
- `pnpm exec vitest run src/components/resources src/trpc` — 166/166, including
  `use-resource-sync-catch-up.test.ts`
- biome clean

## Left alone deliberately

`tariff-classification-list.tsx:47` pages its list to 50 rows with a comment
saying the cap exists *only* to dodge this 431 and explicitly **not** for scroll
performance. That constraint is gone now, so the cap can be raised or dropped —
but that is a UX change, not part of this fix.

https://claude.ai/code/session_01U8TkH2WVZzXqNGSvC4TXRF
