### PR TITLE
fix(purchasing): a removed quote line can be put back

### DIFF
--- a/apps/web/src/components/purchasing/intake/hooks/use-intake-draft.ts
+++ b/apps/web/src/components/purchasing/intake/hooks/use-intake-draft.ts
@@ -60,7 +60,10 @@ export interface IntakeDraftEditor {
    * typed into the cell is nobody's break and clears it.
    */
   chooseBreak: (lineId: string, index: number | null) => void
+  /** Take a line out of the order — reversible, see {@link IntakeDraftEditor.restoreLine}. */
   removeLine: (lineId: string) => void
+  /** Put a removed line back as an ordinary line. */
+  restoreLine: (lineId: string) => void
   /** §5.4: move a line's amount onto a header total and take the row out. */
   foldLine: (lineId: string, into: IntakeFold) => void
   unfoldLine: (lineId: string) => void
@@ -196,11 +199,55 @@ export function useIntakeDraftEditor(
     [update]
   )
 
+  /**
+   * Take a line out of the order, keeping it on the draft.
+   *
+   * 🛑 A flag, not a `filter`. This screen autosaves, so dropping the line from
+   * the array put it beyond recovery the moment the debounce fired — on a
+   * forty-line quote the only way back was re-reading the document. `restoreLine`
+   * is the other half, and `orderableLines` is what keeps the removal invisible
+   * to the table, the totals, the commit gate and the commit.
+   *
+   * 🛑 Un-folds on the way out. A folded line's amount is already in
+   * `shippingCents`/`taxCents`; removing it while folded would leave that money
+   * on the header with nothing on screen accounting for it.
+   */
   const removeLine = useCallback(
+    (lineId: string) => {
+      update((current) => {
+        const target = current.lines.find((line) => line.lineId === lineId)
+        if (!target || target.removed) return current
+        const fold = target.foldedInto
+        const amount = fold ? foldAmountCents(target, current.currency) : 0
+        return {
+          ...current,
+          shippingCents: current.shippingCents - (fold === 'shipping' ? amount : 0),
+          taxCents: current.taxCents - (fold === 'tax' ? amount : 0),
+          lines: current.lines.map((line) =>
+            line.lineId === lineId ? { ...line, removed: true, foldedInto: null } : line
+          ),
+        }
+      })
+    },
+    [update]
+  )
+
+  /**
+   * Put a removed line back.
+   *
+   * It returns as an ORDINARY line — its part, price and printed data are
+   * untouched, because nothing about them changed when it left. A line that was
+   * folded when it was removed comes back unfolded: the fold was undone on the
+   * way out, and silently re-applying it would move money onto the header that
+   * the person restoring the line never asked for.
+   */
+  const restoreLine = useCallback(
     (lineId: string) => {
       update((current) => ({
         ...current,
-        lines: current.lines.filter((line) => line.lineId !== lineId),
+        lines: current.lines.map((line) =>
+          line.lineId === lineId ? { ...line, removed: false } : line
+        ),
       }))
     },
     [update]
@@ -252,6 +299,7 @@ export function useIntakeDraftEditor(
     patchLine,
     chooseBreak,
     removeLine,
+    restoreLine,
     foldLine,
     unfoldLine,
     flush,

--- a/apps/web/src/components/purchasing/intake/ui/intake-lines-table.tsx
+++ b/apps/web/src/components/purchasing/intake/ui/intake-lines-table.tsx
@@ -14,13 +14,14 @@ import {
   type IntakeLine,
   isAutoLinkTier,
   orderableLines,
+  removedLines,
   unresolvedLines,
 } from '@auxx/lib/purchasing/intake/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { cn } from '@auxx/ui/lib/utils'
-import { Receipt, Truck, Undo2 } from 'lucide-react'
+import { Receipt, Trash2, Truck, Undo2 } from 'lucide-react'
 import { useMemo, useRef, useState } from 'react'
 import type { PartPrefillResolver } from '~/components/money/ui/line-builder/line-rows'
 import { LINE_COLS } from '~/components/money/ui/line-builder/line-rows'
@@ -42,6 +43,7 @@ interface IntakeLinesTableProps {
   onFold: (lineId: string, into: IntakeFold) => void
   onUnfold: (lineId: string) => void
   onRemove: (lineId: string) => void
+  onRestore: (lineId: string) => void
 }
 
 export function IntakeLinesTable({
@@ -55,13 +57,18 @@ export function IntakeLinesTable({
   onFold,
   onUnfold,
   onRemove,
+  onRestore,
 }: IntakeLinesTableProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [onlyReview, setOnlyReview] = useState(false)
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set())
 
   const orderable = useMemo(() => orderableLines(lines), [lines])
-  const folded = useMemo(() => lines.filter((line) => line.foldedInto !== null), [lines])
+  const folded = useMemo(
+    () => lines.filter((line) => line.foldedInto !== null && !line.removed),
+    [lines]
+  )
+  const removed = useMemo(() => removedLines(lines), [lines])
 
   // "Needs review" is broader than "blocks the commit": a `fuzzy` row that
   // somebody has since picked a part for no longer blocks anything, but a row the
@@ -161,6 +168,37 @@ export function IntakeLinesTable({
           {blocking.length} {blocking.length === 1 ? 'line' : 'lines'} still need a part. Pick one,
           create one, or fold the amount into shipping or tax.
         </p>
+      )}
+
+      {/* And a delete that cannot be seen or reversed is that with no way back at
+          all — which is what this was until the line gained a `removed` flag.
+          Same strip, same `Undo2`, deliberately: the two are the same promise. */}
+      {removed.length > 0 && (
+        <div className='mt-3 flex flex-col gap-1 rounded-lg border border-dashed p-2'>
+          <span className='px-1 font-medium text-muted-foreground text-xs'>
+            Removed from this order
+          </span>
+          {removed.map((line) => (
+            <div
+              key={line.lineId}
+              className='flex items-center gap-2 px-1 py-0.5 text-muted-foreground text-xs'>
+              <Trash2 className='size-3.5 shrink-0' />
+              <span className='truncate line-through'>
+                {line.printed.description ?? line.printed.vendorCode ?? 'Unnamed line'}
+              </span>
+              <span className='ml-auto shrink-0 tabular-nums'>
+                {formatCurrency(foldAmountCents(line, currency), currency)}
+              </span>
+              <Button
+                variant='ghost'
+                size='icon-xs'
+                aria-label='Put this line back'
+                onClick={() => onRestore(line.lineId)}>
+                <Undo2 />
+              </Button>
+            </div>
+          ))}
+        </div>
       )}
 
       {/* A fold that cannot be seen or reversed is a delete with extra steps. */}

--- a/apps/web/src/components/purchasing/intake/ui/intake-review-page.tsx
+++ b/apps/web/src/components/purchasing/intake/ui/intake-review-page.tsx
@@ -286,6 +286,7 @@ export function IntakeReviewPage({ draftId }: { draftId: string }) {
                   onFold={editor.foldLine}
                   onUnfold={editor.unfoldLine}
                   onRemove={editor.removeLine}
+                  onRestore={editor.restoreLine}
                 />
               </div>
             </ResizablePanel>

--- a/apps/web/src/server/api/routers/purchasing.ts
+++ b/apps/web/src/server/api/routers/purchasing.ts
@@ -219,6 +219,9 @@ const intakeLine = z.object({
   unitPriceCents: intakeRateMinorUnits.nullable(),
   chosenBreakIndex: z.number().int().nonnegative().nullable(),
   foldedInto: z.enum(['shipping', 'tax']).nullable(),
+  // Defaulted, not required: a draft written before the field existed is still
+  // under its 24-hour TTL, and its lines come back with no `removed` key.
+  removed: z.boolean().default(false),
 })
 
 const intakeDraftPayload = z.object({

--- a/packages/lib/src/purchasing/intake/__tests__/commit.test.ts
+++ b/packages/lib/src/purchasing/intake/__tests__/commit.test.ts
@@ -120,6 +120,7 @@ function intakeLine(partial: Partial<IntakeLine> = {}): IntakeLine {
     unitPriceCents: 42,
     chosenBreakIndex: null,
     foldedInto: null,
+    removed: false,
     ...partial,
   }
 }
@@ -425,6 +426,35 @@ describe('commitIntakeDraft — the shipping fold (§5.4)', () => {
       Number(line?.values.purchase_order_line_expected_unit_price) *
       Number(line?.values.purchase_order_line_quantity_ordered)
     expect(lineSum + Number(h.creates[0]?.values.purchase_order_shipping_total)).toBe(24500)
+  })
+})
+
+describe('commitIntakeDraft — a removed line', () => {
+  const dropped = () =>
+    intakeLine({ lineId: 'dropped', partRecordId: 'def_part:part_2' as never, removed: true })
+
+  it('never becomes a purchase order line', async () => {
+    h.draft = draftRow({ payload: payload({ lines: [intakeLine(), dropped()] }) })
+
+    await commitIntakeDraft(db, 'org_1', 'user_1', INPUT)
+
+    const lines = h.creates.filter((c) => c.def === 'purchase_order_line')
+    expect(lines).toHaveLength(1)
+    expect(lines[0]?.values.purchase_order_line_part).toBe('def_part:part_1')
+  })
+
+  // 🛑 The whole point of the soft flag. A removed line keeps whatever state it
+  // had — including no part — and it must not hold the commit hostage for a
+  // decision the person already made by removing it.
+  it('does not block the commit even with no part', async () => {
+    h.draft = draftRow({
+      payload: payload({
+        lines: [intakeLine(), intakeLine({ lineId: 'x', partRecordId: null, removed: true })],
+      }),
+    })
+
+    const result = await commitIntakeDraft(db, 'org_1', 'user_1', INPUT)
+    expect(result.isOk()).toBe(true)
   })
 })
 

--- a/packages/lib/src/purchasing/intake/client.ts
+++ b/packages/lib/src/purchasing/intake/client.ts
@@ -154,6 +154,23 @@ export interface IntakeLine {
   chosenBreakIndex: number | null
   /** Set instead of a part when the amount belongs on a header total (§5.4). */
   foldedInto: IntakeFold | null
+  /**
+   * Taken out of the order, but NOT thrown away.
+   *
+   * 🛑 A soft flag rather than dropping the line from the array, for the same
+   * reason a fold is visible and reversible: *"a fold that cannot be seen or
+   * reversed is a delete with extra steps"* — and a delete that cannot be undone
+   * is that with no way back at all. The draft autosaves, so a dropped line was
+   * gone from Redis before anybody could regret it, and the only way to recover
+   * one was to re-read the whole document.
+   *
+   * Nothing downstream needs to know: {@link orderableLines} is the one gate the
+   * table, the totals, the commit gate and the commit itself all pass through.
+   *
+   * ⚠️ Read as falsy, never compared to `false`. A draft written before this
+   * field existed is still sitting under its 24-hour TTL with no `removed` key.
+   */
+  removed: boolean
 }
 
 /** The whole proposal, as stored under the draft's Redis key (plans/money/tasks/38 §6.1). */
@@ -336,9 +353,20 @@ export function effectiveUnitPriceCents(line: IntakeLine): number | null {
   return line.unitPriceCents
 }
 
-/** Lines that will become purchase order lines — folds and drops excluded. */
+/** Lines that will become purchase order lines — folds and removals excluded. */
 export function orderableLines(lines: IntakeLine[]): IntakeLine[] {
-  return lines.filter((line) => line.foldedInto === null)
+  return lines.filter((line) => line.foldedInto === null && !line.removed)
+}
+
+/**
+ * Lines somebody took out of the order, newest state last.
+ *
+ * The review screen lists these under the table so a removal can be undone. A
+ * folded line is NOT one of these: it still contributes its amount to a header
+ * total and has its own strip. @see IntakeLine.removed
+ */
+export function removedLines(lines: IntakeLine[]): IntakeLine[] {
+  return lines.filter((line) => line.removed)
 }
 
 /**

--- a/packages/lib/src/purchasing/intake/resolve.ts
+++ b/packages/lib/src/purchasing/intake/resolve.ts
@@ -510,6 +510,7 @@ export async function resolveQuoteLines(
           unitPriceCents: parseIntakeUnitPrice(printed.unitPriceText, currency),
           chosenBreakIndex: null,
           foldedInto: null,
+          removed: false,
         })
       }
 


### PR DESCRIPTION
Follow-up to #2033. Deleting a line on the quote review screen was the one irreversible act on a screen whose whole posture is that nothing is written until you confirm.

## The problem

`removeLine` filtered the line out of `payload.lines`, and the screen autosaves — so a mis-click was out of Redis the moment the debounce fired. On a forty-line quote the only way back was re-reading the document.

The code already stated the principle for the other half of this. From `intake-lines-table.tsx`, above the folded strip:

> A fold that cannot be seen or reversed is a delete with extra steps.

Delete was that with no way back at all.

## The change

`IntakeLine` gains a `removed` flag, and `orderableLines` excludes it. That helper is the single gate the table, the totals, the commit gate and the commit itself all pass through, so nothing downstream needed changing.

`removedLines` feeds a **"Removed from this order"** strip below the table — same dashed border, same `Undo2`, as the folded strip it sits beside, because it is the same promise:

```
Removed from this order
🗑  Hex bolt M8x40 zinc                    €210.00   ↩
```

## Two things that fell out of it

**Removing a folded line unfolds it on the way out.** Its amount is already in `shippingCents`/`taxCents`; removing it while folded would leave that money on the header with nothing on screen accounting for it.

**A restored line comes back unfolded**, for the same reason in reverse — silently re-applying the fold would move money onto the header that the person restoring the line never asked for.

## Back-compat

The zod field is `z.boolean().default(false)` and every read is a falsy check, never `=== false`: drafts written before this are still sitting under their 24-hour TTL with no `removed` key.

## Testing

Two new cases in `commit.test.ts` — a removed line never becomes a purchase order line, and a removed line with **no part** does not block the commit. That second one is the point of the soft flag: removing it *was* the decision, and it must not then hold the order hostage for a part.

65 intake tests and 292 purchasing tests pass; typecheck and `lint:changed` clean.

https://claude.ai/code/session_01ApGj2R2xsZ27ZzLfQ4ePRj
