### PR TITLE
fix(data-connectors): a skipped record no longer marks the run partial

### DIFF
--- a/packages/lib/src/data-connectors/sync-core-adapters.ts
+++ b/packages/lib/src/data-connectors/sync-core-adapters.ts
@@ -176,9 +176,11 @@ class ConnectorRunLedger implements RunLedger {
     // A run is 'partial' if the entity write threw (`failed`) OR any record/field was
     // dropped before the write (an `errorSample` entry — e.g. an unresolved field ref).
     // Pre-write drops don't bump `failed`, so without this an all-dropped run reported
-    // `completed / failed: 0` while writing no data (Step 9 §8).
-    const status =
-      (row?.failed ?? 0) > 0 || (row?.errorSample?.length ?? 0) > 0 ? 'partial' : 'completed'
+    // `completed / failed: 0` while writing no data (Step 9 §8). A `skipped` entry is a
+    // deliberate, explained outcome (a sibling-bound exclusive match, task 39 section 6.1)
+    // and must not keep every later run partial.
+    const dropped = (row?.errorSample ?? []).some((e) => e.tier !== 'skipped')
+    const status = (row?.failed ?? 0) > 0 || dropped ? 'partial' : 'completed'
     await this.db
       .update(T)
       .set({ status, finishedAt: new Date(), durationMs: Date.now() - this.startedAt.getTime() })


### PR DESCRIPTION
## Summary

`ConnectorRunLedger.finalize` marked a run `partial` whenever the error sample had any entry. A `skipped` entry is a deliberate outcome (an exclusive match that hit a part already bound to a sibling variant, task 39 section 6.1), so the same store's runs stayed partial forever. Only failures and non-skipped sample entries count now.

Observed on DemoOrg1 right after applying the connector update from #2032: 0 failed, 1 skipped, run marked partial.

## Testing

`packages/lib`: `vitest run src/data-connectors`, 484 tests passing. Lib ratchet unchanged.

https://claude.ai/code/session_011PpDGPPibb12V1yBXLAj3P
