### PR TITLE
feat(records): dashboard tab on orders, purchase orders, vendor bills, builds and products

### DIFF
--- a/apps/web/src/app/(protected)/app/builds/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/builds/dashboard/page.tsx
@@ -1,0 +1,14 @@
+// apps/web/src/app/(protected)/app/builds/dashboard/page.tsx
+'use client'
+
+import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
+
+/**
+ * Builds entity dashboard, reached via the Dashboard tab that
+ * `EntityRouteLayout` emits. The builds `layout.tsx` owns the `MainPage`
+ * shell; `EntityDashboardPage` renders its own `MainPageContent` and shows
+ * the create-one empty state until a dashboard is linked to the def.
+ */
+export default function BuildsDashboardPage() {
+  return <EntityDashboardPage slug='builds' />
+}

--- a/apps/web/src/app/(protected)/app/builds/layout.tsx
+++ b/apps/web/src/app/(protected)/app/builds/layout.tsx
@@ -2,26 +2,19 @@
 
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
 import { usePathname } from 'next/navigation'
-import { RecordRouteGuard } from '~/components/records'
-import { useResource } from '~/components/resources'
+import { EntityRouteLayout } from '~/components/records'
 
 type Props = { children: React.ReactNode }
 
 const BASE_PATH = '/app/builds'
 
 /**
- * Builds layout — the purchase-orders/orders recipe
- * (plans/products/build/01-build-plan.md §3.6): a plain breadcrumb shell for the
- * list route only. `RecordsView` (mounted by `builds/page.tsx`) renders its own
- * MainPageContent and contributes the Create button via `MainPageAction`; the
- * detail route (`[buildId]`) owns its own `MainPage` and bypasses the shell.
+ * Builds layout, the companies recipe: the shared entity route shell
+ * (List | Dashboard) for the list and dashboard routes only. `RecordsView`
+ * (mounted by `builds/page.tsx`) renders its own `MainPageContent` and
+ * contributes the Create button via `MainPageAction`. Detail (`[buildId]`)
+ * and import routes own their own `MainPage` and bypass the shell.
  *
  * There is no catch-all route for system entities, and the Records sidebar links
  * a system def as `/app/${apiSlug}`. This folder IS what makes entity migration
@@ -29,23 +22,16 @@ const BASE_PATH = '/app/builds'
  */
 export default function BuildsLayout({ children }: Props) {
   const pathname = usePathname()
-  const { resource } = useResource('builds')
-  const isDetailOrSpecialPage = pathname !== BASE_PATH
+  const isDetailOrSpecialPage =
+    pathname !== BASE_PATH && !pathname.startsWith(`${BASE_PATH}/dashboard`)
+
+  if (isDetailOrSpecialPage) {
+    return <>{children}</>
+  }
 
   return (
-    <RecordRouteGuard slug='builds'>
-      {isDetailOrSpecialPage ? (
-        <>{children}</>
-      ) : (
-        <MainPage>
-          <MainPageHeader>
-            <MainPageBreadcrumb>
-              <MainPageBreadcrumbItem title={resource?.plural ?? 'Builds'} href={BASE_PATH} />
-            </MainPageBreadcrumb>
-          </MainPageHeader>
-          {children}
-        </MainPage>
-      )}
-    </RecordRouteGuard>
+    <EntityRouteLayout slug='builds' basePath={BASE_PATH}>
+      {children}
+    </EntityRouteLayout>
   )
 }

--- a/apps/web/src/app/(protected)/app/orders/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/orders/dashboard/page.tsx
@@ -1,0 +1,14 @@
+// apps/web/src/app/(protected)/app/orders/dashboard/page.tsx
+'use client'
+
+import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
+
+/**
+ * Orders entity dashboard, reached via the Dashboard tab that
+ * `EntityRouteLayout` emits. The orders `layout.tsx` owns the `MainPage`
+ * shell; `EntityDashboardPage` renders its own `MainPageContent` and shows
+ * the create-one empty state until a dashboard is linked to the def.
+ */
+export default function OrdersDashboardPage() {
+  return <EntityDashboardPage slug='orders' />
+}

--- a/apps/web/src/app/(protected)/app/orders/layout.tsx
+++ b/apps/web/src/app/(protected)/app/orders/layout.tsx
@@ -2,46 +2,33 @@
 
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
 import { usePathname } from 'next/navigation'
-import { RecordRouteGuard } from '~/components/records'
-import { useResource } from '~/components/resources'
+import { EntityRouteLayout } from '~/components/records'
 
 type Props = { children: React.ReactNode }
 
 const BASE_PATH = '/app/orders'
 
 /**
- * Orders layout — the quotes recipe (plans/products/08-order-build.md §5.7/§5.8,
- * D17): a plain breadcrumb shell for the list route only. `RecordsView` (mounted
- * by `orders/page.tsx`) renders its own MainPageContent and contributes the
- * Create button via `MainPageAction`; the detail route (`[orderId]`) owns its own
- * `MainPage` and bypasses the shell entirely.
+ * Orders layout, the companies recipe: the shared entity route shell
+ * (List | Dashboard) for the list and dashboard routes only. `RecordsView`
+ * (mounted by `orders/page.tsx`) renders its own `MainPageContent` and
+ * contributes the Create button via `MainPageAction`. Detail (`[orderId]`)
+ * and import (`import/[jobId]`) routes own their own `MainPage` and bypass
+ * the shell, or two `MainPage` trees nest.
  */
 export default function OrdersLayout({ children }: Props) {
   const pathname = usePathname()
-  const { resource } = useResource('orders')
-  const isDetailOrSpecialPage = pathname !== BASE_PATH
+  const isDetailOrSpecialPage =
+    pathname !== BASE_PATH && !pathname.startsWith(`${BASE_PATH}/dashboard`)
+
+  if (isDetailOrSpecialPage) {
+    return <>{children}</>
+  }
 
   return (
-    <RecordRouteGuard slug='orders'>
-      {isDetailOrSpecialPage ? (
-        <>{children}</>
-      ) : (
-        <MainPage>
-          <MainPageHeader>
-            <MainPageBreadcrumb>
-              <MainPageBreadcrumbItem title={resource?.plural ?? 'Orders'} href={BASE_PATH} />
-            </MainPageBreadcrumb>
-          </MainPageHeader>
-          {children}
-        </MainPage>
-      )}
-    </RecordRouteGuard>
+    <EntityRouteLayout slug='orders' basePath={BASE_PATH}>
+      {children}
+    </EntityRouteLayout>
   )
 }

--- a/apps/web/src/app/(protected)/app/products/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/products/dashboard/page.tsx
@@ -1,0 +1,14 @@
+// apps/web/src/app/(protected)/app/products/dashboard/page.tsx
+'use client'
+
+import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
+
+/**
+ * Products entity dashboard, reached via the Dashboard tab that
+ * `EntityRouteLayout` emits. The products `layout.tsx` owns the `MainPage`
+ * shell; `EntityDashboardPage` renders its own `MainPageContent` and shows
+ * the create-one empty state until a dashboard is linked to the def.
+ */
+export default function ProductsDashboardPage() {
+  return <EntityDashboardPage slug='products' />
+}

--- a/apps/web/src/app/(protected)/app/products/layout.tsx
+++ b/apps/web/src/app/(protected)/app/products/layout.tsx
@@ -2,40 +2,31 @@
 
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
-import { Package2 } from 'lucide-react'
 import { usePathname } from 'next/navigation'
+import { EntityRouteLayout } from '~/components/records'
+
+type Props = { children: React.ReactNode }
 
 const BASE_PATH = '/app/products'
 
 /**
- * Products layout — the parts recipe: a plain breadcrumb shell for the list
- * route only. Detail pages (via DetailView) render their own MainPage.
+ * Products layout, the companies recipe: the shared entity route shell
+ * (List | Dashboard) for the list and dashboard routes only. Detail
+ * (`[productId]`) and import routes own their own `MainPage` via
+ * `DetailView` / `ImportPage` and bypass the shell.
  */
-export default function ProductsLayout({ children }: { children: React.ReactNode }) {
+export default function ProductsLayout({ children }: Props) {
   const pathname = usePathname()
+  const isDetailOrSpecialPage =
+    pathname !== BASE_PATH && !pathname.startsWith(`${BASE_PATH}/dashboard`)
 
-  if (pathname !== BASE_PATH) {
+  if (isDetailOrSpecialPage) {
     return <>{children}</>
   }
 
   return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem
-            title='Products'
-            href={BASE_PATH}
-            icon={<Package2 className='size-4' />}
-          />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
+    <EntityRouteLayout slug='products' basePath={BASE_PATH}>
       {children}
-    </MainPage>
+    </EntityRouteLayout>
   )
 }

--- a/apps/web/src/app/(protected)/app/purchase-orders/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/purchase-orders/dashboard/page.tsx
@@ -1,0 +1,14 @@
+// apps/web/src/app/(protected)/app/purchase-orders/dashboard/page.tsx
+'use client'
+
+import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
+
+/**
+ * Purchase orders entity dashboard, reached via the Dashboard tab that
+ * `EntityRouteLayout` emits. The purchase-orders `layout.tsx` owns the `MainPage`
+ * shell; `EntityDashboardPage` renders its own `MainPageContent` and shows
+ * the create-one empty state until a dashboard is linked to the def.
+ */
+export default function PurchaseOrdersDashboardPage() {
+  return <EntityDashboardPage slug='purchase-orders' />
+}

--- a/apps/web/src/app/(protected)/app/purchase-orders/layout.tsx
+++ b/apps/web/src/app/(protected)/app/purchase-orders/layout.tsx
@@ -2,50 +2,33 @@
 
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
 import { usePathname } from 'next/navigation'
-import { RecordRouteGuard } from '~/components/records'
-import { useResource } from '~/components/resources'
+import { EntityRouteLayout } from '~/components/records'
 
 type Props = { children: React.ReactNode }
 
 const BASE_PATH = '/app/purchase-orders'
 
 /**
- * Purchase orders layout — the orders/quotes recipe
- * (plans/purchasing/01-build-plan.md §4.4): a plain breadcrumb shell for the list
- * route only. `RecordsView` (mounted by `purchase-orders/page.tsx`) renders its
- * own MainPageContent and contributes the Create button via `MainPageAction`; the
- * detail route (`[purchaseOrderId]`) owns its own `MainPage` and bypasses the
- * shell entirely.
+ * Purchase orders layout, the companies recipe: the shared entity route shell
+ * (List | Dashboard) for the list and dashboard routes only. `RecordsView`
+ * (mounted by `purchase-orders/page.tsx`) renders its own `MainPageContent`
+ * and contributes the Create button via `MainPageAction`. Detail
+ * (`[purchaseOrderId]`), intake and import routes own their own `MainPage`
+ * and bypass the shell, or two `MainPage` trees nest.
  */
 export default function PurchaseOrdersLayout({ children }: Props) {
   const pathname = usePathname()
-  const { resource } = useResource('purchase-orders')
-  const isDetailOrSpecialPage = pathname !== BASE_PATH
+  const isDetailOrSpecialPage =
+    pathname !== BASE_PATH && !pathname.startsWith(`${BASE_PATH}/dashboard`)
+
+  if (isDetailOrSpecialPage) {
+    return <>{children}</>
+  }
 
   return (
-    <RecordRouteGuard slug='purchase-orders'>
-      {isDetailOrSpecialPage ? (
-        <>{children}</>
-      ) : (
-        <MainPage>
-          <MainPageHeader>
-            <MainPageBreadcrumb>
-              <MainPageBreadcrumbItem
-                title={resource?.plural ?? 'Purchase Orders'}
-                href={BASE_PATH}
-              />
-            </MainPageBreadcrumb>
-          </MainPageHeader>
-          {children}
-        </MainPage>
-      )}
-    </RecordRouteGuard>
+    <EntityRouteLayout slug='purchase-orders' basePath={BASE_PATH}>
+      {children}
+    </EntityRouteLayout>
   )
 }

--- a/apps/web/src/app/(protected)/app/vendor-bills/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/vendor-bills/dashboard/page.tsx
@@ -1,0 +1,14 @@
+// apps/web/src/app/(protected)/app/vendor-bills/dashboard/page.tsx
+'use client'
+
+import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
+
+/**
+ * Vendor bills entity dashboard, reached via the Dashboard tab that
+ * `EntityRouteLayout` emits. The vendor-bills `layout.tsx` owns the `MainPage`
+ * shell; `EntityDashboardPage` renders its own `MainPageContent` and shows
+ * the create-one empty state until a dashboard is linked to the def.
+ */
+export default function VendorBillsDashboardPage() {
+  return <EntityDashboardPage slug='vendor-bills' />
+}

--- a/apps/web/src/app/(protected)/app/vendor-bills/layout.tsx
+++ b/apps/web/src/app/(protected)/app/vendor-bills/layout.tsx
@@ -2,39 +2,32 @@
 
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
-import { RecordRouteGuard } from '~/components/records'
-import { useResource } from '~/components/resources'
+import { usePathname } from 'next/navigation'
+import { EntityRouteLayout } from '~/components/records'
 
 type Props = { children: React.ReactNode }
 
 const BASE_PATH = '/app/vendor-bills'
 
 /**
- * Vendor bills layout — the breadcrumb shell for the list route.
- *
- * Unlike `purchase-orders/layout.tsx` there is no detail-route escape hatch:
- * `vendor_bill` is drawer-only (plans/purchasing/01-build-plan.md §5.1), so this
- * segment has exactly one page and the shell always applies.
+ * Vendor bills layout, the companies recipe: the shared entity route shell
+ * (List | Dashboard) for the list and dashboard routes only. `vendor_bill` is
+ * drawer-only (plans/purchasing/01-build-plan.md §5.1) so there is no detail
+ * route, but `import/[jobId]` renders its own `MainPage` via `ImportPage`
+ * and must bypass the shell, or two `MainPage` trees nest.
  */
 export default function VendorBillsLayout({ children }: Props) {
-  const { resource } = useResource('vendor-bills')
+  const pathname = usePathname()
+  const isDetailOrSpecialPage =
+    pathname !== BASE_PATH && !pathname.startsWith(`${BASE_PATH}/dashboard`)
+
+  if (isDetailOrSpecialPage) {
+    return <>{children}</>
+  }
 
   return (
-    <RecordRouteGuard slug='vendor-bills'>
-      <MainPage>
-        <MainPageHeader>
-          <MainPageBreadcrumb>
-            <MainPageBreadcrumbItem title={resource?.plural ?? 'Vendor Bills'} href={BASE_PATH} />
-          </MainPageBreadcrumb>
-        </MainPageHeader>
-        {children}
-      </MainPage>
-    </RecordRouteGuard>
+    <EntityRouteLayout slug='vendor-bills' basePath={BASE_PATH}>
+      {children}
+    </EntityRouteLayout>
   )
 }


### PR DESCRIPTION
## Summary

- Orders, purchase orders, vendor bills, builds and products now use the shared `EntityRouteLayout` (List | Dashboard tabs), matching parts and companies.
- Each route gets a `dashboard/page.tsx` mounting `EntityDashboardPage`. No default dashboard is created; the page shows the "No dashboard yet" empty state with a Create dashboard button (gated on `dashboards.manage`, tab gated on the dashboards feature).
- Side effect: the vendor-bills layout no longer wraps `import/[jobId]` in its shell, which previously nested two `MainPage` trees.

## Test plan

- [ ] Open each of the five list pages and confirm the List | Dashboard tab strip renders.
- [ ] Click Dashboard, confirm the empty state, click Create dashboard, confirm it opens in edit mode.
- [ ] Open a detail page and an import page for each and confirm no double header.
- [ ] `node scripts/ci/typecheck-ratchet.js --package web` passes (no new errors).

https://claude.ai/code/session_01EHkgJrC1Sidu4VatzvLwiA