### PR TITLE
fix(data-connectors): pausing one field no longer refetches the record, and resume keeps its badge

### DIFF
--- a/apps/web/src/components/fields/connector-lock-badge.tsx
+++ b/apps/web/src/components/fields/connector-lock-badge.tsx
@@ -4,7 +4,7 @@
 
 import type { CellSyncInfo } from '@auxx/lib/data-connectors/client'
 import type { RecordId } from '@auxx/lib/resources/client'
-import type { FieldId } from '@auxx/types/field'
+import type { FieldId, FieldReference } from '@auxx/types/field'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +18,7 @@ import type { MouseEvent, PointerEvent } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { useConnectorName } from '~/components/resources/hooks/use-connector-name'
 import { useFieldValueStore } from '~/components/resources/store/field-value-store'
+import { buildCanonicalFieldValueKey } from '~/components/resources/utils/canonicalize-field-ref'
 import { api } from '~/trpc/react'
 
 interface OwnedBadgeProps {
@@ -120,7 +121,7 @@ function ContributingBadge({
 }: Omit<ContributingBadgeProps, 'mode'>) {
   const name = useConnectorName(sync.connectorId)
   const who = name ?? 'a data connector'
-  const invalidateResource = useFieldValueStore((s) => s.invalidateResource)
+  const setManagedState = useFieldValueStore((s) => s.setManagedState)
   const setFieldPin = api.dataConnector.setFieldPin.useMutation()
 
   const Icon = STATE_ICON[sync.state]
@@ -152,7 +153,18 @@ function ContributingBadge({
     setFieldPin.mutate(
       { recordId, fieldId, connectorId: sync.connectorId, pinned },
       {
-        onSuccess: () => invalidateResource(recordId),
+        // Repaint THIS cell from the mutation's own answer. 🛑 Do not reinstate
+        // `invalidateResource(recordId)` here: it DELETES every cached value,
+        // AI marker and sync state on the record, so pausing one field
+        // refetched every other cell — and when the new state was one the batch
+        // read stays silent on (a cleared cell), the badge never came back.
+        onSuccess: ({ sync: next }) => {
+          const { key } = buildCanonicalFieldValueKey(
+            recordId,
+            fieldId as unknown as FieldReference
+          )
+          setManagedState(key, next)
+        },
         onError: (error) =>
           toastError({
             title: 'Could not change sync for this field',

--- a/apps/web/src/components/resources/store/field-value-fetch-queue.ts
+++ b/apps/web/src/components/resources/store/field-value-fetch-queue.ts
@@ -435,7 +435,7 @@ class FieldValueFetchQueue {
         aiMetadata: AiValueMetadata | null
       }> = []
       // Contributing data-connector sync states to rehydrate (mirrors aiEntries).
-      const managedEntries: Array<{ key: FieldValueKey; sync: CellSyncInfo }> = []
+      const syncByKey = new Map<FieldValueKey, CellSyncInfo>()
       for (const result of results) {
         if (result.status === 'fulfilled') {
           for (const v of result.value.values) {
@@ -445,7 +445,7 @@ class FieldValueFetchQueue {
               aiEntries.push({ key, aiStatus: v.aiStatus, aiMetadata: v.aiMetadata ?? null })
             }
             if (v.sync != null) {
-              managedEntries.push({ key, sync: v.sync })
+              syncByKey.set(key, v.sync)
             }
           }
         } else {
@@ -486,10 +486,13 @@ class FieldValueFetchQueue {
       }
 
       // Rehydrate contributing data-connector sync states so the cell badge
-      // survives refresh.
+      // survives refresh. The response is AUTHORITATIVE over the whole requested
+      // cross product — the server emits `sync` even for cells with no stored
+      // row — so a combination it stayed silent on clears its badge rather than
+      // keeping a state the last sync run has since ended.
       const setManagedState = useFieldValueStore.getState().setManagedState
-      for (const entry of managedEntries) {
-        setManagedState(entry.key, entry.sync)
+      for (const key of allRequestedCombinations) {
+        setManagedState(key, syncByKey.get(key) ?? null)
       }
     } catch (error) {
       console.error('[FieldValueFetchQueue] Fetch failed:', error)

--- a/packages/lib/src/data-connectors/cell-sync-read.ts
+++ b/packages/lib/src/data-connectors/cell-sync-read.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/data-connectors/cell-sync-read.ts
+//
+// The single-cell twin of the batch read in `field-values/field-value-queries.ts`:
+// resolve ONE (record, field) pair's `CellSyncInfo` from the same three inputs
+// (live item bindings, the stored marker, the field shape) through the same
+// `resolveCellSyncState`. `setConnectorFieldPin` returns it so the badge can
+// paint the new state from the mutation response instead of invalidating the
+// record's whole field-value cache (plans/money/tasks/42 §0).
+
+import { type Database, schema, type Transaction } from '@auxx/database'
+import { and, eq, isNotNull } from 'drizzle-orm'
+import { listItemBindingsForInstances } from './item-bindings'
+import { type CellSyncInfo, resolveCellSyncState } from './sync-state'
+
+export interface ReadCellSyncStateInput {
+  organizationId: string
+  entityInstanceId: string
+  /** The concrete `CustomField.id` — the same key a pin stores. */
+  fieldId: string
+}
+
+/**
+ * The cell's sync state after a write, or `null` when the field is not bound to
+ * any contributing connector on this record.
+ *
+ * Three indexed reads, run together: the record's live items (with their
+ * mappings' bindings), any row of the cell still stamped by a connector, and the
+ * field's own `options` (only `multi` is read — a multi field never re-asserts
+ * another row, so it can never be `edited`). Deliberately NOT a per-cell read
+ * path for lists: the batch fetch resolves whole pages through
+ * `listItemBindingsForInstances` in one query.
+ */
+export async function readCellSyncState(
+  db: Database | Transaction,
+  input: ReadCellSyncStateInput
+): Promise<CellSyncInfo | null> {
+  const { organizationId, entityInstanceId, fieldId } = input
+
+  const [bindingsByInstance, markerRows, fieldRows] = await Promise.all([
+    listItemBindingsForInstances(db, organizationId, [entityInstanceId]),
+    db
+      .select({ managedByConnectorId: schema.FieldValue.managedByConnectorId })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          eq(schema.FieldValue.entityId, entityInstanceId),
+          eq(schema.FieldValue.fieldId, fieldId),
+          isNotNull(schema.FieldValue.managedByConnectorId)
+        )
+      )
+      .limit(1),
+    db
+      .select({ options: schema.CustomField.options })
+      .from(schema.CustomField)
+      .where(
+        and(
+          eq(schema.CustomField.organizationId, organizationId),
+          eq(schema.CustomField.id, fieldId)
+        )
+      )
+      .limit(1),
+  ])
+
+  return resolveCellSyncState({
+    fieldId,
+    field: { options: fieldRows[0]?.options as { multi?: boolean } | null | undefined },
+    markerConnectorId: markerRows[0]?.managedByConnectorId ?? null,
+    bindings: bindingsByInstance.get(entityInstanceId) ?? [],
+  })
+}

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -38,6 +38,7 @@ import {
   type ShapeResolver,
   storedRootPath,
 } from './catalog-shape'
+import { readCellSyncState } from './cell-sync-read'
 import { removeConnectorScheduler, syncConnectorScheduler } from './data-connector-scheduler'
 import {
   classifyConnectorChange,
@@ -56,6 +57,7 @@ import {
   loadConnector,
   stampResyncPending,
 } from './service'
+import type { CellSyncInfo } from './sync-state'
 import type {
   ConnectorTemplate,
   ConnectorTemplateFieldMapping,
@@ -1710,11 +1712,17 @@ export interface SetConnectorFieldPinInput {
  * must carry the pin. Idempotent by construction (jsonb `?` guards the append,
  * `-` removes every occurrence). Zero rows means the record is not bound to this
  * connector. Resume only removes the id: the next run heals the cell (D5).
+ *
+ * Returns the cell's resulting `CellSyncInfo` (`null` when nothing binds the
+ * field any more) so the caller can repaint that ONE cell. The badge used to
+ * drop the record's whole field-value cache instead, which refetched every
+ * other cell on the record and lost the badge outright whenever the new state
+ * was one the batch read stays silent on (task 42 §0).
  */
 export async function setConnectorFieldPin(
   db: DbOrTx,
   input: SetConnectorFieldPinInput
-): Promise<Result<{ pinnedFields: string[] }, Error>> {
+): Promise<Result<{ pinnedFields: string[]; sync: CellSyncInfo | null }, Error>> {
   const { pinnedFields } = schema.DataConnectorItem
   const next = input.pinned
     ? sql`CASE WHEN ${pinnedFields} ? ${input.fieldId}::text THEN ${pinnedFields} ELSE ${pinnedFields} || to_jsonb(array[${input.fieldId}::text]) END`
@@ -1735,5 +1743,11 @@ export async function setConnectorFieldPin(
 
   const first = rows[0]
   if (!first) return err(new NotFoundError('Record is not bound to this connector'))
-  return ok({ pinnedFields: first.pinnedFields ?? [] })
+
+  const sync = await readCellSyncState(db, {
+    organizationId: input.organizationId,
+    entityInstanceId: input.entityInstanceId,
+    fieldId: input.fieldId,
+  })
+  return ok({ pinnedFields: first.pinnedFields ?? [], sync })
 }

--- a/packages/lib/src/data-connectors/set-connector-field-pin.int.test.ts
+++ b/packages/lib/src/data-connectors/set-connector-field-pin.int.test.ts
@@ -11,6 +11,7 @@ import { NotFoundError } from '../errors'
 import {
   type BoundRecordFixture,
   bindThroughNewMapping,
+  insertTextValue,
   seedBoundRecord,
   testDb,
 } from './__int-test-helpers'
@@ -52,7 +53,7 @@ describe('setConnectorFieldPin', () => {
     const result = await pin(true)
 
     expect(result.isOk()).toBe(true)
-    expect(result._unsafeUnwrap()).toEqual({ pinnedFields: [f.descriptionFieldId] })
+    expect(result._unsafeUnwrap().pinnedFields).toEqual([f.descriptionFieldId])
     expect(await pinnedFieldsOf(f.itemId)).toEqual([f.descriptionFieldId])
   })
 
@@ -60,7 +61,7 @@ describe('setConnectorFieldPin', () => {
     await pin(true)
     const result = await pin(true)
 
-    expect(result._unsafeUnwrap()).toEqual({ pinnedFields: [f.descriptionFieldId] })
+    expect(result._unsafeUnwrap().pinnedFields).toEqual([f.descriptionFieldId])
     expect(await pinnedFieldsOf(f.itemId)).toEqual([f.descriptionFieldId])
   })
 
@@ -77,7 +78,7 @@ describe('setConnectorFieldPin', () => {
 
     const result = await pin(false)
 
-    expect(result._unsafeUnwrap()).toEqual({ pinnedFields: [f.titleFieldId] })
+    expect(result._unsafeUnwrap().pinnedFields).toEqual([f.titleFieldId])
     expect(await pinnedFieldsOf(f.itemId)).toEqual([f.titleFieldId])
   })
 
@@ -85,7 +86,7 @@ describe('setConnectorFieldPin', () => {
     const result = await pin(false)
 
     expect(result.isOk()).toBe(true)
-    expect(result._unsafeUnwrap()).toEqual({ pinnedFields: [] })
+    expect(result._unsafeUnwrap().pinnedFields).toEqual([])
   })
 
   it('fails with NotFoundError when the record is not bound to this connector', async () => {
@@ -140,13 +141,13 @@ describe('setConnectorFieldPin', () => {
 
     const result = await pin(true)
 
-    expect(result._unsafeUnwrap()).toEqual({ pinnedFields: [f.descriptionFieldId] })
+    expect(result._unsafeUnwrap().pinnedFields).toEqual([f.descriptionFieldId])
     expect(await pinnedFieldsOf(f.itemId)).toEqual([f.descriptionFieldId])
     expect(await pinnedFieldsOf(second.itemId)).toEqual([f.descriptionFieldId])
     expect(await pinnedFieldsOf(archived.itemId)).toEqual([])
 
     const unpinned = await pin(false)
-    expect(unpinned._unsafeUnwrap()).toEqual({ pinnedFields: [] })
+    expect(unpinned._unsafeUnwrap().pinnedFields).toEqual([])
     expect(await pinnedFieldsOf(second.itemId)).toEqual([])
   })
 
@@ -155,5 +156,84 @@ describe('setConnectorFieldPin', () => {
 
     expect(result.isErr()).toBe(true)
     expect(await pinnedFieldsOf(f.itemId)).toEqual([])
+  })
+})
+
+// The badge repaints the ONE cell it acted on from this answer instead of
+// dropping the record's whole field-value cache (task 42 §0), so the state it
+// gets back has to be the same one the batch read would have produced.
+describe('setConnectorFieldPin, the returned cell sync state', () => {
+  it('pinning answers paused, and names the connector that holds the pin', async () => {
+    await insertTextValue(testDb(), f, f.descriptionFieldId, 'From the shop', f.connectorId)
+
+    const result = await pin(true)
+
+    expect(result._unsafeUnwrap().sync).toEqual({
+      connectorId: f.connectorId,
+      state: 'paused',
+      willOverwrite: true,
+    })
+  })
+
+  it('resuming a still-stamped cell answers synced', async () => {
+    await insertTextValue(testDb(), f, f.descriptionFieldId, 'From the shop', f.connectorId)
+    await pin(true)
+
+    const result = await pin(false)
+
+    expect(result._unsafeUnwrap().sync).toEqual({
+      connectorId: f.connectorId,
+      state: 'synced',
+      willOverwrite: true,
+    })
+  })
+
+  it('resuming a hand-edited cell answers edited, not nothing', async () => {
+    await insertTextValue(testDb(), f, f.descriptionFieldId, 'my own words', null)
+    await pin(true)
+
+    const result = await pin(false)
+
+    expect(result._unsafeUnwrap().sync).toEqual({
+      connectorId: f.connectorId,
+      state: 'edited',
+      willOverwrite: true,
+    })
+  })
+
+  it('resuming a CLEARED cell answers edited: the next run re-fills it', async () => {
+    // No FieldValue row at all — the case that used to leave the cell with no
+    // badge, because the batch read only emits a row-less cell when it is paused.
+    await pin(true)
+
+    const result = await pin(false)
+
+    expect(result._unsafeUnwrap().sync).toEqual({
+      connectorId: f.connectorId,
+      state: 'edited',
+      willOverwrite: true,
+    })
+  })
+
+  it('a field the mapping does not bind answers null', async () => {
+    // Not pinned, no marker, not in `managedFields`: nothing binds this cell.
+    const [unbound] = await testDb()
+      .insert(schema.CustomField)
+      .values({
+        organizationId: f.orgId,
+        entityDefinitionId: f.defId,
+        modelType: 'product',
+        name: 'Internal note',
+        type: 'TEXT',
+        options: {},
+        sortOrder: 'a3',
+        isCustom: true,
+        updatedAt: new Date(),
+      })
+      .returning()
+
+    const result = await pin(false, { fieldId: unbound!.id })
+
+    expect(result._unsafeUnwrap().sync).toBeNull()
   })
 })

--- a/packages/lib/src/data-connectors/sinks/entity-sink-drift-pin.int.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-drift-pin.int.test.ts
@@ -223,3 +223,60 @@ describe('computeDriftedInstances with a pinned field', () => {
     expect(await markerOf(f, f.titleFieldId)).toBe(f.connectorId)
   })
 })
+
+// Task 42 §3: `overwrite` means overwrite, so a cell the user CLEARED (row
+// deleted, not edited) is drift like any other and the next run puts the value
+// back. Before this the drift query inner-joined `FieldValue`, so a cleared cell
+// was invisible and the content-hash skip left it empty until the SOURCE changed.
+describe('computeDriftedInstances with a cleared cell', () => {
+  const clear = (fieldId: string) =>
+    testDb()
+      .delete(schema.FieldValue)
+      .where(
+        and(eq(schema.FieldValue.entityId, f.instanceId), eq(schema.FieldValue.fieldId, fieldId))
+      )
+
+  it('a cleared overwrite cell is drift: the source value is re-asserted and re-stamped', async () => {
+    await clear(f.descriptionFieldId)
+    const ctx = runCtx(f, update)
+
+    await entitySink.upsertRecord(ctx, decoded(f), projected(f))
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0]?.[1]).toEqual({
+      [f.descriptionFieldId]: SOURCE_DESCRIPTION,
+      [f.titleFieldId]: SOURCE_TITLE,
+    })
+    // No marker assertion here: `crud.update` is a double, so the row the write
+    // would recreate never exists for the stamp UPDATE to find.
+  })
+
+  it('a cleared cell that is PINNED is not drift: the record is skipped and the cell stays empty', async () => {
+    await clear(f.descriptionFieldId)
+    expect((await pin(f, true)).isOk()).toBe(true)
+    const ctx = runCtx(f, update)
+
+    await entitySink.upsertRecord(ctx, decoded(f), projected(f))
+
+    expect(update).not.toHaveBeenCalled()
+    expect(ctx.counters.skipped).toBe(1)
+    expect(await markerOf(f, f.descriptionFieldId)).toBeNull()
+  })
+
+  it('a cleared cell the connector never managed is not drift: nothing to put back', async () => {
+    // `managedFields` is the connector's record of what it has written here. A
+    // field the source has never carried must not strand the record in a
+    // never-skip loop.
+    await clear(f.descriptionFieldId)
+    await testDb()
+      .update(schema.DataConnectorItem)
+      .set({ managedFields: [f.titleRef] })
+      .where(eq(schema.DataConnectorItem.id, f.itemId))
+    const ctx = runCtx(f, update)
+
+    await entitySink.upsertRecord(ctx, decoded(f), projected(f))
+
+    expect(update).not.toHaveBeenCalled()
+    expect(ctx.counters.skipped).toBe(1)
+  })
+})

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -13,7 +13,7 @@ import type { FieldId, ResourceFieldId } from '@auxx/types/field'
 import { getFieldId } from '@auxx/types/field'
 import type { TypedFieldValue } from '@auxx/types/field-value'
 import { stableHash } from '@auxx/utils/hash'
-import { and, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm'
+import { and, eq, inArray, isNull, ne, sql } from 'drizzle-orm'
 import { resolveConnectorFieldRef } from '../../agents/bindings/resolve'
 import { getCachedFieldMap } from '../../cache'
 import { UniqueValueConflictError } from '../../errors'
@@ -730,7 +730,11 @@ async function computeDriftedInstances(
   const connectionId = ctx.connector.credentialId ?? undefined
   const keyToId = await buildWriteKeyToFieldId(ctx.orgId, mapping.entityDefinitionId)
   const fieldMap = await getCachedFieldMap(ctx.orgId, mapping.entityDefinitionId)
-  const fieldIds = new Set<string>()
+  // The concrete `CustomField.id` a `FieldValue` row and a pin carry, paired with
+  // the RAW `targetFieldRef` an item's `managedFields` carries — the cleared-cell
+  // arm below needs both key spaces.
+  const fields: Array<{ uuid: string; ref: string }> = []
+  const seen = new Set<string>()
   for (const fm of healingBindings) {
     const concrete = await resolveConnectorFieldRef(fm.targetFieldRef, ctx.orgId, connectionId)
     if (!concrete) continue
@@ -745,36 +749,60 @@ async function computeDriftedInstances(
     // until the SOURCE value changes, consistent with never-touch-other-rows.
     const field = fieldMap.get(uuid) as SyncFieldShape | undefined
     if (!wouldHealField(fm, field)) continue
-    fieldIds.add(uuid)
+    if (seen.has(uuid)) continue
+    seen.add(uuid)
+    fields.push({ uuid, ref: fm.targetFieldRef })
   }
-  if (fieldIds.size === 0) return new Set()
+  if (fields.length === 0) return new Set()
 
-  // One query: bound instances of this mapping holding an overwrite cell no longer
-  // stamped by this connector (NULL = hand-edited, or a different connector took over).
-  // A cell the user PAUSED on the record (`pinnedFields`, plan 40) is not drift:
-  // the sink will not write it, so counting it would keep the record permanently
-  // drifted and the content-hash skip would never fire again. jsonb `?` tests
-  // string membership in the top-level array; one clause covers every field.
-  const rows = await ctx.db
-    .selectDistinct({ entityId: schema.FieldValue.entityId })
-    .from(schema.FieldValue)
-    .innerJoin(
-      schema.DataConnectorItem,
-      eq(schema.DataConnectorItem.entityInstanceId, schema.FieldValue.entityId)
-    )
-    .where(
-      and(
-        eq(schema.DataConnectorItem.dataConnectorId, ctx.connector.id),
-        eq(schema.DataConnectorItem.mappingId, mapping.row.id),
-        inArray(schema.FieldValue.fieldId, Array.from(fieldIds)),
-        or(
-          isNull(schema.FieldValue.managedByConnectorId),
-          ne(schema.FieldValue.managedByConnectorId, ctx.connector.id)
-        ),
-        sql`NOT (${schema.DataConnectorItem.pinnedFields} ? ${schema.FieldValue.fieldId})`
+  // One query: the mapping's live bindings CROSS JOINed with the healing fields
+  // and LEFT JOINed to the cell. A bound instance is drifted when a healing cell
+  //
+  //   - carries a row no longer stamped by this connector (NULL = hand-edited,
+  //     or a different connector took it over), or
+  //   - carries NO row at all — the user CLEARED it. `overwrite` means
+  //     overwrite, so a cleared cell is re-filled like any other drift (task 42
+  //     §3); before this it stayed empty forever, because the join was an INNER
+  //     one and the content-hash skip never fell through.
+  //
+  // The cleared arm is narrowed to fields the item already MANAGES: the
+  // connector has written that field on this record before, so it has a value to
+  // put back. Without that, a mapping whose source omits a field would mark
+  // every bound record permanently drifted and the content-hash skip would never
+  // fire again. It is also the exact rule the badge's `edited` state uses, so the
+  // two cannot disagree (plan 40 D2).
+  //
+  // A cell the user PAUSED (`pinnedFields`, plan 40) is not drift in either arm:
+  // the sink will not write it, so counting it would strand the record in the
+  // same never-skip loop, and an ARCHIVED binding is not drift either: the
+  // record is no longer bound through this mapping. jsonb `?` tests string
+  // membership in the top-level array; `managedFields` holds raw refs,
+  // `pinnedFields` concrete ids.
+  const I = schema.DataConnectorItem
+  const FV = schema.FieldValue
+  const result = await ctx.db.execute(sql`
+    SELECT DISTINCT ${I.entityInstanceId} AS "entityId"
+    FROM ${I}
+    CROSS JOIN unnest(
+        ${sql.param(fields.map((f) => f.uuid))}::text[],
+        ${sql.param(fields.map((f) => f.ref))}::text[]
+      ) AS healing(field_id, field_ref)
+    LEFT JOIN ${FV}
+      ON ${FV.entityId} = ${I.entityInstanceId}
+      AND ${FV.fieldId} = healing.field_id
+    WHERE ${I.dataConnectorId} = ${ctx.connector.id}
+      AND ${I.mappingId} = ${mapping.row.id}
+      AND ${I.archivedAt} IS NULL
+      AND ${I.entityInstanceId} IS NOT NULL
+      AND NOT (${I.pinnedFields} ? healing.field_id)
+      AND (
+        CASE WHEN ${FV.id} IS NULL
+          THEN ${I.managedFields} ? healing.field_ref
+          ELSE ${FV.managedByConnectorId} IS DISTINCT FROM ${ctx.connector.id}
+        END
       )
-    )
-  return new Set(rows.map((r) => r.entityId))
+  `)
+  return new Set((result.rows ?? []).map((r) => (r as { entityId: string }).entityId))
 }
 
 /**

--- a/packages/lib/src/field-values/__tests__/cell-sync-state-read.test.ts
+++ b/packages/lib/src/field-values/__tests__/cell-sync-state-read.test.ts
@@ -5,9 +5,11 @@
  * (plans/money/tasks/40-per-field-sync-pin.md sections 4 D2 and 7): the
  * records' live `DataConnectorItem`s are read BESIDE the value query and
  * collapsed with the row marker through `resolveCellSyncState`, in the D2
- * order paused > synced > edited > none. An empty paused cell has no row to
- * ride on, so the path emits a value-less result for it, and the item read is
- * one call per batch whether or not anything is bound.
+ * order paused > synced > edited > none. A cell with no stored row has nothing
+ * to ride on, so the path emits a value-less result for it whenever it is
+ * paused or edited (task 42 §3: a cleared overwrite cell is healed like any
+ * other drift), and the item read is one call per batch whether or not anything
+ * is bound.
  *
  * NOTE on imports: `field-value-helpers` is imported for its TYPES only; see
  * the cache mock below for why the double sits under the barrel.
@@ -317,9 +319,21 @@ describe('batchGetValues, cells with no stored row', () => {
     expect(cell(values, P1, TITLE)).toBeUndefined()
   })
 
-  it('an emptied overwrite cell is NOT reported as edited (drift never heals a deleted row)', async () => {
+  it('an emptied overwrite cell reaches the badge as edited (drift heals a cleared row, task 42)', async () => {
     bound([[P1_ID, [shopifyItem()]]])
     const { values } = await read([], [P1], [DESCRIPTION])
+
+    expect(cell(values, P1, DESCRIPTION)?.sync).toEqual({
+      connectorId: SHOPIFY,
+      state: 'edited',
+      willOverwrite: true,
+    })
+    expect(cell(values, P1, DESCRIPTION)?.value).toBeNull()
+  })
+
+  it('an emptied cell whose binding never heals (fill_blank) stays silent', async () => {
+    bound([[P1_ID, [shopifyItem()]]])
+    const { values } = await read([], [P1], [NOTES])
 
     expect(values).toEqual([])
   })

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -1048,15 +1048,16 @@ async function fetchFieldValueResults(
     })
   }
 
-  // A PAUSED cell with no stored row ("I removed the connector's value and want
-  // it to stay empty") has nothing above to ride on, and the client only
-  // null-backfills the combinations the server stayed silent on. Emit a
-  // value-less result for it so the badge still reaches the cell. Only
-  // `paused` qualifies: with no row there is nothing for `synced` to mark, and
-  // `edited` would promise a heal that `computeDriftedInstances` (an inner join
-  // on `FieldValue`) never performs for a deleted row.
+  // A cell with no stored row still has a sync state when the record is bound:
+  // PAUSED ("I cleared the connector's value and want it to stay empty") or
+  // EDITED (cleared without pausing — the connector re-fills it on the next
+  // run). Neither has a row to ride on above, and the client only null-backfills
+  // the combinations the server stayed silent on, so emit a value-less result
+  // for both. `synced` is excluded by construction: with no row there is nothing
+  // for a marker to be on. `edited` is honest here because
+  // `computeDriftedInstances` now heals a row-less overwrite cell too (task 42
+  // §3) — the two rules stay the same rule.
   for (const [entityId, bindings] of bindingsByInstance) {
-    if (!bindings.some((item) => item.pinnedFields.length > 0)) continue
     const recordId = instanceToRecordId.get(entityId)
     if (!recordId) continue
     for (const fieldId of fieldIds) {
@@ -1071,7 +1072,7 @@ async function fetchFieldValueResults(
         markerConnectorId: null,
         bindings,
       })
-      if (sync?.state !== 'paused') continue
+      if (!sync) continue
       results.push({
         recordId,
         fieldRef,


### PR DESCRIPTION
Two defects from the per-field sync pin (#2037), plus the cleared-cell heal that makes the second one honest. Written up as sections 0 and 3 of `plans/money/tasks/42-sync-pin-followups.md`.

### Pausing one field refetched every cell on the record

The badge called `invalidateResource(recordId)` in the mutation's `onSuccess`. That walks the field-value store and DELETES every key belonging to the record - `values`, `updatedAt`, `aiStates` and `managedStates` - which is the exact pattern two purchasing surfaces had already removed with a comment each, after it visibly reset their open forms.

`setConnectorFieldPin` now returns the cell's resulting `CellSyncInfo | null` beside `pinnedFields`, resolved through the new `data-connectors/cell-sync-read.ts`: the single-cell twin of the batch read, going through the same `resolveCellSyncState`, so the mutation and the list read can never answer differently. The badge repaints that ONE cell with `setManagedState(key, sync)` and invalidates nothing.

### "Resume syncing" left the cell with no badge at all

Once the pin is gone, the state can only be `synced` (the row still carries `managedByConnectorId` - but a hand edit nulls it) or `edited` (needs `managedFields` plus a healing binding). A CLEARED cell has no `FieldValue` row at all, and the row-less emit path in `field-value-queries.ts` hard-filtered `if (sync?.state !== 'paused') continue`, so on resume the cell fell out of the response entirely. On the client, `invalidateResource` had already deleted the state and the fetch merge only ever ADDED sync states, never cleared or re-asserted them.

- The read path now emits a value-less result for a row-less cell that is `paused` **or** `edited`.
- The fetch queue's sync merge is authoritative over the whole requested cross product: a combination the server stays silent on clears its badge instead of keeping a state a later run has ended.

### A cleared overwrite cell now heals (plan item 3)

`computeDriftedInstances` is one query over the mapping's live bindings CROSS JOINed with the healing fields and LEFT JOINed to the cell. A row-less overwrite cell is drift like any other, so the next run re-fills it - what `overwrite` promises, and what makes `edited` an honest badge on a cleared cell.

The cleared arm is narrowed to fields already in the item's `managedFields`: the connector has written that field on this record before, so it has something to put back. Without that guard a mapping whose source omits a field would mark every bound record permanently drifted and the content-hash skip would never fire again. It is also the exact rule the badge's `edited` uses, so the two still agree. Archived bindings are excluded from drift, which they were not before.

### Testing

- lib and web typecheck ratchets: no new errors.
- Data-connector integration tests 22/22, including 4 new cleared-cell drift cases and 5 new cases for the returned sync state (pin -> `paused`; resume of a stamped cell -> `synced`, of a hand-edited cell -> `edited`, of a cleared cell -> `edited`; an unbound field -> `null`).
- Full lib integration suite: 542/544. The 2 failures are in `import/resolution/resolution-write-back.int.test.ts` (minted-company id prefixes), untouched by this branch.
- Full unit suite (lib + web, 20,229 tests): 3 failures, all pre-existing and unrelated - `delete-guard-registration`, `108-purchasing`, `receipt-input`.
- Verified by hand in the app.

https://claude.ai/code/session_01Ft4y5R8CH1zUEN4uC6AmEq
