### PR TITLE
feat(companies): reach website enrichment from four doors, not one

### DIFF
--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -1,6 +1,10 @@
 // apps/web/src/server/api/routers/record.ts
 
-import { getCachedResource, getCachedResources } from '@auxx/lib/cache'
+import { getCachedEntityDefId, getCachedResource, getCachedResources } from '@auxx/lib/cache'
+// Leaf subpath, NOT the `@auxx/lib/companies` barrel: the barrel reaches the fetch/parse
+// module, which pulls cheerio and the whole files graph into the web server for a function
+// that only writes a queue message.
+import { enqueueCompanyEnrichment } from '@auxx/lib/companies/enqueue'
 import { conditionGroupSchema } from '@auxx/lib/conditions'
 import {
   type AuxxError,
@@ -1113,6 +1117,47 @@ export const recordRouter = createTRPCRouter({
   /**
    * Archive entity instance (soft delete)
    */
+  /**
+   * Re-run website enrichment for one company, now.
+   *
+   * The explicit-intent door. Every other one is a rule firing off a write, so all of them
+   * pass `shouldEnrich`'s freshness windows (30 days after a success, 7 after a failure) —
+   * which is exactly right for automatic traffic and exactly wrong for a person looking at
+   * a stale logo. `reason: 'manual'` bypasses those windows, and only those: a company with
+   * no domain and no website still has nothing to fetch, and the per-org hourly budget
+   * still applies.
+   *
+   * Authority is `assertWriteEntity` on the company def. Enrichment writes
+   * `company_name` / `company_notes` / `company_logo` as the SYSTEM user once it reaches
+   * the worker, so this procedure is the only place a human's authority to cause those
+   * writes is ever checked.
+   */
+  enrichCompany: capabilityProcedure
+    .input(z.object({ recordId: recordIdSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const { entityDefinitionId, entityInstanceId } = parseRecordId(input.recordId)
+
+      ctx.capabilities.assertWriteEntity(entityDefinitionId)
+      await assertNotInstanceAccessDefForWrite(organizationId, recordIdDefParts([input.recordId]))
+
+      const companyDefId = await getCachedEntityDefId(organizationId, 'company')
+      if (!companyDefId || companyDefId !== entityDefinitionId) {
+        throw new BadRequestError('Enrichment is only available for companies')
+      }
+
+      const queued = await enqueueCompanyEnrichment({
+        organizationId,
+        companyInstanceId: entityInstanceId,
+        reason: 'manual',
+      })
+      if (!queued) {
+        throw new UnprocessableEntityError('Could not queue enrichment, please try again')
+      }
+
+      return { queued }
+    }),
+
   archive: capabilityProcedure
     .input(z.object({ recordId: recordIdSchema }))
     .mutation(async ({ ctx, input }) => {

--- a/apps/worker/scripts/enrich-companies-backfill.ts
+++ b/apps/worker/scripts/enrich-companies-backfill.ts
@@ -1,0 +1,50 @@
+// apps/worker/scripts/enrich-companies-backfill.ts
+//
+// One-time enrichment backfill (plans/company/v4-enrichment-doors.md §5, Door 5a) — thin
+// caller around `sweepCompaniesNeedingEnrichment` in `@auxx/lib/companies` (query code
+// lives in lib; apps/worker has no drizzle-orm dependency of its own).
+//
+// Safe to re-run. It only selects companies with no terminal enrichment status, and every
+// company it queues reaches one — including `skipped` for the ones with neither a domain
+// nor a usable website, which is the point: those records currently carry NO trace at all,
+// so the gap is invisible in the UI.
+//
+// ⚠️ It ENQUEUES; the fetches happen on the enrichment worker. Nothing is enriched unless a
+// worker is running. The per-org hourly budget still applies, so a very large org drains
+// across several runs (or waits for the nightly sweep).
+//
+// Run (from repo root) under the worker runtime:
+//   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
+//     scripts/enrich-companies-backfill.ts [organizationId] [--dry-run]
+
+import { sweepCompaniesNeedingEnrichment } from '@auxx/lib/companies'
+
+async function main() {
+  const args = process.argv.slice(2)
+  const dryRun = args.includes('--dry-run')
+  const organizationId = args.find((a) => !a.startsWith('--'))
+
+  const scope = organizationId ? `org ${organizationId}` : 'every org'
+  console.log(`Company enrichment backfill — ${scope}${dryRun ? ' (dry run)' : ''}`)
+
+  const summary = await sweepCompaniesNeedingEnrichment({
+    ...(organizationId ? { organizationId } : {}),
+    dryRun,
+  })
+
+  if (summary.candidates === 0) {
+    console.log('No companies without a terminal enrichment status — nothing to do.')
+  } else {
+    console.log(
+      `${summary.candidates} candidates across ${summary.organizations} orgs → ` +
+        `${summary.enqueued} ${dryRun ? 'would be queued' : 'queued'}, ` +
+        `${summary.deferred} deferred past the per-org cap.`
+    )
+  }
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -18,6 +18,7 @@ import { startDatasetMaintenanceWorker } from './worker-definitions/dataset-main
 import { startDocumentPdfWorker } from './worker-definitions/document-pdf-worker'
 import { startDocumentProcessingWorker } from './worker-definitions/document-processing-worker'
 import { startEmailWorker } from './worker-definitions/email-worker'
+import { startEnrichmentWorker } from './worker-definitions/enrichment-worker'
 import { startEvalRunWorker } from './worker-definitions/eval-run-worker'
 import { startEventHandlersWorker, startEventsWorker } from './worker-definitions/events-worker'
 import { startKBSyncWorker } from './worker-definitions/kb-sync-worker'
@@ -136,6 +137,10 @@ export async function startWorkers() {
   // order (plans/money/tasks/38-purchase-order-from-a-document.md §3.3)
   const purchaseIntakeWorker = startPurchaseIntakeWorker()
 
+  // Company enrichment worker: one outbound homepage fetch per job, bounded apart
+  // from the events worker (plans/company/v4-enrichment-doors.md §6)
+  const enrichmentWorker = startEnrichmentWorker()
+
   const workers = [
     // defaultWorker,
     eventsWorker,
@@ -172,6 +177,7 @@ export async function startWorkers() {
     quickbooksInvoiceSyncWorker,
     mailClassificationWorker,
     purchaseIntakeWorker,
+    enrichmentWorker,
   ]
 
   return Promise.all(workers)
@@ -509,6 +515,26 @@ export async function setupSchedules() {
         attempts: 2,
         backoff: { type: 'exponential', delay: 60000 },
         priority: 8,
+        removeOnComplete: { count: 14 },
+        removeOnFail: { count: 30 },
+      },
+    }
+  )
+
+  // Company enrichment gap-filling sweep — every day at 04:45 UTC, half an hour after the
+  // vendor-bill sweep so the two large per-org passes do not overlap. Every other
+  // enrichment door is event-driven, so this is the only path back for companies created
+  // before a door existed, companies the per-org window limiter dropped mid-import, and
+  // companies stranded on `pending` by a worker that died mid-fetch. Idempotent: every
+  // record it enqueues reaches a terminal status, so a re-run selects strictly less.
+  await maintenanceQueue.upsertJobScheduler(
+    'companyEnrichmentSweepJob',
+    { pattern: '45 4 * * *', tz: 'UTC' },
+    {
+      opts: {
+        attempts: 2,
+        backoff: { type: 'exponential', delay: 60000 },
+        priority: 9,
         removeOnComplete: { count: 14 },
         removeOnFail: { count: 30 },
       },

--- a/apps/worker/src/workers/worker-definitions/enrichment-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/enrichment-worker.ts
@@ -1,0 +1,32 @@
+// apps/worker/src/workers/worker-definitions/enrichment-worker.ts
+
+import { enrichCompanyJob } from '@auxx/lib/jobs'
+import { Queues } from '@auxx/lib/jobs/queues'
+import { createScopedLogger } from '@auxx/logger'
+import { createWorker } from '../utils/createWorker'
+
+const logger = createScopedLogger('worker:enrichment')
+
+// The key MUST equal `ENRICH_COMPANY_JOB_NAME` — `enqueueCompanyEnrichment` adds the job
+// under that name and `createJobHandler` dispatches on it.
+const enrichmentJobMappings = {
+  enrichCompanyJob,
+}
+
+/**
+ * Starts the record-enrichment worker (plans/company/v4-enrichment-doors.md §6 L5).
+ *
+ * Its OWN queue, deliberately. Every job is an outbound HTTP fetch of a third-party
+ * homepage plus a logo, up to 13s worst case, and the four enrichment doors mean a bulk
+ * import can enqueue hundreds at once. Run inline on the events worker (which is where it
+ * lived while `created` was the only door) a 315-company import occupied one slot for
+ * nearly an hour and head-of-line blocked every unrelated event behind it.
+ *
+ * Concurrency 3 is the global cap on simultaneous outbound fetches. The per-org hourly
+ * budget in `companies/enrichment/guards.ts` is the binding constraint above that.
+ */
+export function startEnrichmentWorker() {
+  logger.info(`Starting worker for queue: ${Queues.enrichmentQueue}`)
+
+  return createWorker(Queues.enrichmentQueue, enrichmentJobMappings, { concurrency: 3 })
+}

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -8,6 +8,7 @@ import {
   approvalOrphanSweeperJob,
   appStorageSweepJob,
   cleanupExpiredMediaAssetsJob,
+  companyEnrichmentSweepJob,
   type DemoSeedJobData,
   dataDeletionJob,
   dataMigrationsJob,
@@ -256,6 +257,12 @@ export const jobMappings = {
   // shipped. Re-uses `rematchBill`, so it decides which bills to re-ask about and
   // never what a bill's status is.
   vendorBillAgingJob,
+
+  // Company enrichment gap-filling sweep (plans/company/v4-enrichment-doors.md §5, Door
+  // 5b). Every other enrichment door is event-driven, so this is the only path back for
+  // companies created before a door existed, ones the per-org window limiter dropped
+  // mid-import, and ones stranded on `pending` by a worker that died mid-fetch.
+  companyEnrichmentSweepJob,
 
   // Dispatch worker-facing daily schedule digest sweep (plans/dispatch/19-client-notifications.md
   // §4.9, opt-in): hourly tick, per-org local-hour + Redis dedupe guard inside the job itself.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -298,6 +298,18 @@
       "import": "./dist/comments/index.mjs",
       "default": "./src/comments/index.ts"
     },
+    "./companies": {
+      "types": "./src/companies/index.ts",
+      "source": "./src/companies/index.ts",
+      "import": "./dist/companies/index.mjs",
+      "default": "./src/companies/index.ts"
+    },
+    "./companies/enqueue": {
+      "types": "./src/companies/enrichment/enqueue.ts",
+      "source": "./src/companies/enrichment/enqueue.ts",
+      "import": "./dist/companies/enrichment/enqueue.mjs",
+      "default": "./src/companies/enrichment/enqueue.ts"
+    },
     "./conditions": {
       "types": "./src/conditions/index.ts",
       "source": "./src/conditions/index.ts",

--- a/packages/lib/src/companies/enrichment/__tests__/guards.test.ts
+++ b/packages/lib/src/companies/enrichment/__tests__/guards.test.ts
@@ -1,0 +1,190 @@
+// packages/lib/src/companies/enrichment/__tests__/guards.test.ts
+// `shouldEnrich` is the whole throttle policy, and it is pure — no db, no Redis, no
+// doubles of any kind. Everything that decides whether a third-party website gets fetched
+// is exercised here.
+
+import { describe, expect, it } from 'vitest'
+import { domainFromUrl, domainFromWebsite } from '../derive-domain'
+import {
+  type CompanyEnrichmentState,
+  ENRICHED_TTL_MS,
+  FAILED_TTL_MS,
+  shouldEnrich,
+} from '../guards'
+
+const NOW = new Date('2026-09-02T12:00:00Z')
+
+function state(overrides: Partial<CompanyEnrichmentState> = {}): CompanyEnrichmentState {
+  return {
+    domain: null,
+    website: [],
+    status: null,
+    enrichedAt: null,
+    name: null,
+    notes: null,
+    logoRef: null,
+    ...overrides,
+  }
+}
+
+const ago = (ms: number) => new Date(NOW.getTime() - ms)
+
+describe('shouldEnrich — domain resolution', () => {
+  it('enriches against the stored domain', () => {
+    expect(shouldEnrich(state({ domain: 'acme.com' }), 'created', NOW)).toEqual({
+      action: 'enrich',
+      domain: 'acme.com',
+      derivedFromWebsite: false,
+    })
+  })
+
+  it('normalizes a stored domain that carries case or padding', () => {
+    const decision = shouldEnrich(state({ domain: '  ACME.com ' }), 'created', NOW)
+    expect(decision).toMatchObject({ action: 'enrich', domain: 'acme.com' })
+  })
+
+  // This is the whole point of the website door: before it, `company_domain` had exactly
+  // one writer in the codebase (the mail ingest path), so a company that did not arrive by
+  // email was unenrichable no matter what the user typed in.
+  it('derives the domain from the website when none is stored', () => {
+    expect(
+      shouldEnrich(state({ website: ['https://www.mcmaster.com/about'] }), 'website-changed', NOW)
+    ).toEqual({ action: 'enrich', domain: 'mcmaster.com', derivedFromWebsite: true })
+  })
+
+  it('prefers the stored domain over the website', () => {
+    const decision = shouldEnrich(
+      state({ domain: 'acme.com', website: ['https://other.com'] }),
+      'created',
+      NOW
+    )
+    expect(decision).toMatchObject({ domain: 'acme.com', derivedFromWebsite: false })
+  })
+})
+
+describe('shouldEnrich — the domainless case', () => {
+  // The 17 companies an import minted by name carried NO trace at all before this: the old
+  // handler returned before even writing a status, so the gap was invisible in the UI.
+  it('marks a company with neither domain nor website as skipped', () => {
+    expect(shouldEnrich(state(), 'created', NOW)).toEqual({
+      action: 'skip',
+      why: 'no-domain',
+      writeStatus: 'skipped',
+    })
+  })
+
+  it('does not rewrite the marker on a company already marked skipped', () => {
+    expect(shouldEnrich(state({ status: 'skipped' }), 'domain-changed', NOW)).toEqual({
+      action: 'skip',
+      why: 'no-domain',
+      writeStatus: null,
+    })
+  })
+
+  it('treats a blank or unusable website as no website', () => {
+    for (const website of [[''], ['   '], ['not a url'], ['mailto:a@b.com'], ['https://']]) {
+      expect(shouldEnrich(state({ website }), 'website-changed', NOW)).toMatchObject({
+        action: 'skip',
+        why: 'no-domain',
+      })
+    }
+  })
+
+  it('refuses a free-mail provider or an excluded TLD as a company website', () => {
+    expect(shouldEnrich(state({ website: ['https://gmail.com'] }), 'created', NOW)).toMatchObject({
+      why: 'no-domain',
+    })
+    expect(shouldEnrich(state({ website: ['https://mit.edu'] }), 'created', NOW)).toMatchObject({
+      why: 'no-domain',
+    })
+  })
+})
+
+describe('shouldEnrich — freshness windows', () => {
+  it('skips a company enriched inside the success window', () => {
+    const s = state({
+      domain: 'acme.com',
+      status: 'enriched',
+      enrichedAt: ago(ENRICHED_TTL_MS - 1),
+    })
+    expect(shouldEnrich(s, 'domain-changed', NOW)).toEqual({
+      action: 'skip',
+      why: 'recently-enriched',
+      writeStatus: null,
+    })
+  })
+
+  it('re-enriches once the success window has passed', () => {
+    const s = state({
+      domain: 'acme.com',
+      status: 'enriched',
+      enrichedAt: ago(ENRICHED_TTL_MS + 1),
+    })
+    expect(shouldEnrich(s, 'backfill', NOW)).toMatchObject({ action: 'enrich' })
+  })
+
+  it('skips a company whose site just failed', () => {
+    const s = state({ domain: 'acme.com', status: 'failed', enrichedAt: ago(FAILED_TTL_MS - 1) })
+    expect(shouldEnrich(s, 'created', NOW)).toMatchObject({ why: 'recently-failed' })
+  })
+
+  it('retries a failure once its shorter window has passed', () => {
+    const s = state({ domain: 'acme.com', status: 'failed', enrichedAt: ago(FAILED_TTL_MS + 1) })
+    expect(shouldEnrich(s, 'backfill', NOW)).toMatchObject({ action: 'enrich' })
+  })
+
+  // A worker that dies between the `pending` marker and the terminal write must not strand
+  // the record. Concurrency is handled by the BullMQ jobId and the Redis claim, both of
+  // which expire; a `pending` guard here would not.
+  it('never treats pending as a reason to stay away', () => {
+    expect(
+      shouldEnrich(state({ domain: 'acme.com', status: 'pending' }), 'created', NOW)
+    ).toMatchObject({ action: 'enrich' })
+  })
+
+  it('enriches a company that has a status but no timestamp', () => {
+    expect(
+      shouldEnrich(
+        state({ domain: 'acme.com', status: 'enriched', enrichedAt: null }),
+        'created',
+        NOW
+      )
+    ).toMatchObject({ action: 'enrich' })
+  })
+})
+
+describe('shouldEnrich — manual', () => {
+  it('bypasses both freshness windows', () => {
+    const fresh = state({ domain: 'acme.com', status: 'enriched', enrichedAt: NOW })
+    expect(shouldEnrich(fresh, 'manual', NOW)).toMatchObject({ action: 'enrich' })
+  })
+
+  // Manual is an override on the WINDOWS, not on physics. There is still nothing to fetch.
+  it('does not conjure a domain', () => {
+    expect(shouldEnrich(state(), 'manual', NOW)).toMatchObject({ why: 'no-domain' })
+  })
+})
+
+describe('domainFromWebsite', () => {
+  it('accepts a bare host, a www host, and a full url', () => {
+    expect(domainFromWebsite(['acme.com'])).toBe('acme.com')
+    expect(domainFromWebsite(['www.acme.com'])).toBe('acme.com')
+    expect(domainFromWebsite(['https://shop.acme.co.uk/x?y=1'])).toBe('acme.co.uk')
+  })
+
+  it('takes the first usable entry of a multi-value field', () => {
+    expect(domainFromWebsite(['', 'not a url', 'https://acme.com'])).toBe('acme.com')
+  })
+
+  it('returns null for an empty or absent list', () => {
+    expect(domainFromWebsite([])).toBeNull()
+    expect(domainFromWebsite(null)).toBeNull()
+    expect(domainFromWebsite(undefined)).toBeNull()
+  })
+
+  it('rejects non-http schemes rather than coercing them', () => {
+    expect(domainFromUrl('mailto:sales@acme.com')).toBeNull()
+    expect(domainFromUrl('ftp://acme.com')).toBeNull()
+    expect(domainFromUrl('javascript:alert(1)')).toBeNull()
+  })
+})

--- a/packages/lib/src/companies/enrichment/__tests__/metadata.test.ts
+++ b/packages/lib/src/companies/enrichment/__tests__/metadata.test.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/companies/enrichment/__tests__/metadata.test.ts
+// The value-sanity half of enrichment. A homepage is arbitrary third-party HTML, and
+// everything extracted from one lands on a customer's record, so nothing gets out of the
+// module without passing these.
+
+import { describe, expect, it } from 'vitest'
+import { cleanText, emptyMetadata, isEmptyMetadata } from '../metadata'
+
+describe('cleanText', () => {
+  it('trims, and collapses the multi-line whitespace a pretty-printed <title> carries', () => {
+    expect(cleanText('  Acme\n   Industries  ', 2, 120)).toBe('Acme Industries')
+  })
+
+  it('strips zero-width characters that survive trim', () => {
+    expect(cleanText('\u200BAcme\uFEFF', 2, 120)).toBe('Acme')
+  })
+
+  it('returns null for empty, whitespace-only, and non-string input', () => {
+    expect(cleanText('', 2, 120)).toBeNull()
+    expect(cleanText('   ', 2, 120)).toBeNull()
+    expect(cleanText('\u200B\u200C', 2, 120)).toBeNull()
+    expect(cleanText(null, 2, 120)).toBeNull()
+    expect(cleanText(undefined, 2, 120)).toBeNull()
+  })
+
+  it('returns null below the minimum length', () => {
+    expect(cleanText('A', 2, 120)).toBeNull()
+    expect(cleanText('too short', 20, 500)).toBeNull()
+  })
+
+  it('truncates with an ellipsis above the maximum', () => {
+    const out = cleanText('x'.repeat(200), 2, 10)
+    expect(out).toBe(`${'x'.repeat(9)}…`)
+    expect(out).toHaveLength(10)
+  })
+})
+
+describe('isEmptyMetadata', () => {
+  it('is true for a fetch that produced nothing', () => {
+    expect(isEmptyMetadata(emptyMetadata())).toBe(true)
+  })
+
+  it('is false as soon as a content field survived', () => {
+    expect(isEmptyMetadata({ ...emptyMetadata(), siteName: 'Acme' })).toBe(false)
+    expect(isEmptyMetadata({ ...emptyMetadata(), description: 'x'.repeat(30) })).toBe(false)
+  })
+
+  // 🛑 `faviconUrl` falls back to a hard-coded `/favicon.ico` guess, so it is non-null for
+  // ANY page that was fetched at all. If it counted here, a site whose title was a bot wall
+  // and whose description was missing would be recorded `enriched` and locked out for 30
+  // days instead of `failed` and retried in 7. Whether an image was usable is answered by
+  // the stored asset id, which the caller checks alongside this.
+  it('ignores the speculative image candidates', () => {
+    expect(
+      isEmptyMetadata({ ...emptyMetadata(), faviconUrl: 'https://acme.com/favicon.ico' })
+    ).toBe(true)
+    expect(isEmptyMetadata({ ...emptyMetadata(), ogImageUrl: 'https://acme.com/og.png' })).toBe(
+      true
+    )
+  })
+})

--- a/packages/lib/src/companies/enrichment/derive-domain.ts
+++ b/packages/lib/src/companies/enrichment/derive-domain.ts
@@ -1,0 +1,72 @@
+// packages/lib/src/companies/enrichment/derive-domain.ts
+// Turn a `company_website` value into the registrable domain enrichment fetches against.
+//
+// This is what makes the website field mean something. Before it, `company_domain` had
+// exactly ONE writer in the whole codebase (`ingest/companies/find-or-create.ts`, the mail
+// path), so a company that did not arrive by email could never be enriched no matter what
+// the user typed into it.
+//
+// The exclusions are the mail path's, reused rather than reimplemented: a free-mail
+// provider or an edu/gov TLD is no more a company website than it is a company email
+// domain. The OWN-domain check is deliberately NOT applied — an inbound address on our own
+// domain is us, but a user typing a URL onto a company record is being deliberate.
+
+import { getDomain } from 'tldts'
+import { isExcludedTld, isPersonalDomain, normalizeDomain } from '../../ingest/domain/classifier'
+
+/**
+ * First entry of a multi-value `company_website` that yields a usable registrable domain.
+ *
+ * Accepts both what the URL field stores (`https://acme.com/about`) and what users paste
+ * into it anyway (`acme.com`, `www.acme.com`), because the field is `URL`-typed but the
+ * import path writes whatever the CSV column held.
+ */
+export function domainFromWebsite(
+  website: readonly (string | null | undefined)[] | null | undefined
+): string | null {
+  if (!website) return null
+
+  for (const raw of website) {
+    const domain = domainFromUrl(raw)
+    if (domain) return domain
+  }
+
+  return null
+}
+
+/** Registrable domain (eTLD+1) for one URL-ish string, or null when it is unusable. */
+export function domainFromUrl(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null
+
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+
+  // `new URL` needs a scheme, so a bare host gets one. A string that ALREADY carries a
+  // scheme must not: prefixing `mailto:sales@acme.com` yields
+  // `https://mailto:sales@acme.com`, which parses cleanly with `mailto:sales` as userinfo
+  // and `acme.com` as the host. That silently turned an email address into a website.
+  //
+  // The digit test separates a scheme from a bare host with a port — `acme.com:8080` is
+  // not an `acme.com:` scheme, and rejecting it would be wrong.
+  const hasScheme = /^[a-z][a-z0-9+.-]*:(?![0-9])/i.test(trimmed)
+  if (hasScheme && !/^https?:\/\//i.test(trimmed)) return null
+  const candidate = hasScheme ? trimmed : `https://${trimmed}`
+
+  let host: string
+  try {
+    host = new URL(candidate).hostname
+  } catch {
+    return null
+  }
+
+  if (host.length === 0) return null
+
+  const domain = getDomain(host)
+  if (!domain) return null
+
+  const normalized = normalizeDomain(domain)
+  if (isPersonalDomain(normalized)) return null
+  if (isExcludedTld(normalized)) return null
+
+  return normalized
+}

--- a/packages/lib/src/companies/enrichment/enqueue.ts
+++ b/packages/lib/src/companies/enrichment/enqueue.ts
@@ -1,0 +1,65 @@
+// packages/lib/src/companies/enrichment/enqueue.ts
+// Every door's actual call. Enqueue, never enrich inline.
+//
+// Inline was viable while `created` was the only door: `fanOutEntityHandler` awaits each
+// record in turn inside ONE events-queue job, and a company costs up to 8s of HTML plus 5s
+// of logo. A 315-row import therefore held an events-worker slot for the better part of an
+// hour, head-of-line blocking every unrelated event behind it. v3 called this out as the
+// trigger for a dedicated queue ("If enrichment ever needs to fan out ... that's when a
+// dedicated queue makes sense"), and three more doors is that moment.
+
+import { createScopedLogger } from '@auxx/logger'
+import { getQueue } from '../../jobs/queues'
+import { Queues } from '../../jobs/queues/types'
+import type { EnrichReason } from './guards'
+
+const logger = createScopedLogger('companies:enrichment')
+
+/** Must equal the key the enrichment worker maps, or `createJobHandler` never dispatches. */
+export const ENRICH_COMPANY_JOB_NAME = 'enrichCompanyJob'
+
+export interface EnrichCompanyJobData {
+  organizationId: string
+  companyInstanceId: string
+  reason: EnrichReason
+}
+
+/**
+ * Queue one company for enrichment.
+ *
+ * The `jobId` is the first of the four throttle layers: BullMQ drops an `add` whose custom
+ * id is already live, which collapses the sync-door double-fire (an import creating a
+ * company with a domain fires BOTH the lifecycle rule and the `company_domain` field rule,
+ * because `skipOnCreate` is only honoured on the interactive path) and any burst of saves
+ * before the job runs. It is only a first line of defence: BullMQ forgets the id once the
+ * job completes and is removed, so the durable guard is the stored
+ * `company_enrichment_status` that `shouldEnrich` reads.
+ *
+ * ⚠️ Hyphens, not colons. BullMQ rejects a custom `jobId` containing `:` unless it splits
+ * into exactly three parts, and the resulting throw would be swallowed by the catch below,
+ * silently enqueueing nothing at all.
+ *
+ * Never throws: an enrichment that did not get queued must not fail the write that
+ * triggered it, nor spend the originating event handler's retry budget.
+ */
+export async function enqueueCompanyEnrichment(args: EnrichCompanyJobData): Promise<boolean> {
+  const { organizationId, companyInstanceId, reason } = args
+  if (!organizationId || !companyInstanceId) return false
+
+  try {
+    await getQueue(Queues.enrichmentQueue).add(
+      ENRICH_COMPANY_JOB_NAME,
+      { organizationId, companyInstanceId, reason },
+      { jobId: `enrich-company-${organizationId}-${companyInstanceId}` }
+    )
+    return true
+  } catch (error) {
+    logger.error('Failed to enqueue company enrichment', {
+      organizationId,
+      companyId: companyInstanceId,
+      reason,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}

--- a/packages/lib/src/companies/enrichment/enrich.ts
+++ b/packages/lib/src/companies/enrichment/enrich.ts
@@ -1,0 +1,368 @@
+// packages/lib/src/companies/enrichment/enrich.ts
+// The single entry point every enrichment door funnels through.
+//
+// ⚠️ It reads live record state and NEVER trusts the triggering event's values. Two
+// reasons, both load-bearing:
+//
+//   1. `fanOutEntityHandler` builds a handler's `values` from
+//      `event.eventDataByRecordId?.[recordId] ?? {}`. FIELD firings carry no `eventData`,
+//      so a handler that read `event.values.company_domain` would see `{}` and skip every
+//      time it was reached from the `company_domain` / `company_website` doors.
+//   2. The interactive field door does not carry real values at all — it presents
+//      `INTERACTIVE_FIELD_WRITE` against `oldValue: undefined` so the transition always
+//      matches. It fires when a user CLEARS the domain just as loudly as when they set it.
+//      Only a live read can tell those apart.
+//
+// It also never throws. Every failure mode is a terminal status on the record; a throwing
+// job would be retried by BullMQ, and a retried website fetch is exactly the "called too
+// often" behaviour the guards exist to prevent.
+
+import { type Database, database as defaultDb, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getCachedEntityDefId, getOrgCache } from '../../cache'
+import { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
+import { type RecordId, toRecordId } from '../../resources/resource-id'
+import { SystemUserService } from '../../users/system-user-service'
+import { checkFixedWindowLimit } from '../../utils/rate-limiter/fixed-window'
+import {
+  CLAIM_TTL_MS,
+  type CompanyEnrichmentState,
+  type EnrichmentStatus,
+  type EnrichReason,
+  type EnrichSkipReason,
+  ORG_WINDOW_LIMIT,
+  ORG_WINDOW_MS,
+  shouldEnrich,
+} from './guards'
+import { fetchAndStoreLogo, fetchWebsiteMetadata, isEmptyMetadata } from './metadata'
+
+const logger = createScopedLogger('companies:enrichment')
+
+/** The seven fields enrichment reads or writes. Nothing else is touched. */
+const FIELDS = [
+  'company_domain',
+  'company_website',
+  'company_enrichment_status',
+  'company_enriched_at',
+  'company_name',
+  'company_notes',
+  'company_logo',
+] as const
+
+export interface EnrichCompanyInput {
+  organizationId: string
+  companyInstanceId: string
+  reason: EnrichReason
+  db?: Database
+}
+
+export type CompanyEnrichmentOutcome =
+  | { outcome: 'enriched'; domain: string; applied: string[] }
+  | { outcome: 'failed'; domain: string; error?: string }
+  | { outcome: 'skipped'; why: EnrichSkipReason | 'claimed' | 'rate-limited' | 'not-configured' }
+
+/**
+ * Enrich one company from its website.
+ *
+ * Reads live state, applies {@link shouldEnrich}, takes a short Redis claim, checks the
+ * per-org budget, fetches, and writes ONE terminal update. Returns what happened rather
+ * than throwing, so callers (job, script, sweep) can count outcomes.
+ *
+ * The derived domain, when the domain came from `company_website`, is written in that SAME
+ * terminal update rather than up front. Writing it earlier would re-enter the
+ * `company_domain` door with the record still on a non-terminal status, so the re-fired
+ * job would fetch the site a second time.
+ */
+export async function enrichCompany(input: EnrichCompanyInput): Promise<CompanyEnrichmentOutcome> {
+  const { organizationId, companyInstanceId, reason } = input
+  const db = input.db ?? defaultDb
+
+  const companyDefId = await getCachedEntityDefId(organizationId, 'company')
+  if (!companyDefId) {
+    logger.debug('Org has no company definition', { organizationId })
+    return { outcome: 'skipped', why: 'not-configured' }
+  }
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...FIELDS])
+
+  // The def-id filter matters: `customFields` is an ORG-wide projection, and a
+  // systemAttribute is only unique within its def.
+  const fieldIdByAttr = new Map<string, string>()
+  for (const attr of FIELDS) {
+    const field = fields[attr]
+    if (field && field.entityDefinitionId === companyDefId) fieldIdByAttr.set(attr, field.id)
+  }
+
+  // `company_domain` is what enrichment is keyed on and `company_enrichment_status` is
+  // what records the answer. Without both there is nothing coherent to do.
+  if (!fieldIdByAttr.has('company_domain') || !fieldIdByAttr.has('company_enrichment_status')) {
+    logger.warn('Company def is missing the enrichment fields', { organizationId, companyDefId })
+    return { outcome: 'skipped', why: 'not-configured' }
+  }
+
+  const state = await readState(db, organizationId, companyInstanceId, fieldIdByAttr)
+  const decision = shouldEnrich(state, reason, new Date())
+
+  const recordId = toRecordId(companyDefId, companyInstanceId)
+  const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+  const crud = new UnifiedCrudHandler(organizationId, systemUserId, db)
+
+  if (decision.action === 'skip') {
+    if (decision.writeStatus) {
+      await crud
+        .update(recordId, { company_enrichment_status: decision.writeStatus })
+        .catch((err: unknown) => {
+          logger.warn('Could not mark company skipped', {
+            organizationId,
+            companyId: companyInstanceId,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        })
+    }
+    logger.debug('Enrichment skipped', {
+      organizationId,
+      companyId: companyInstanceId,
+      reason,
+      why: decision.why,
+    })
+    return { outcome: 'skipped', why: decision.why }
+  }
+
+  const { domain, derivedFromWebsite } = decision
+
+  // In-flight claim. Keyed on the DOMAIN as well as the record, so correcting a domain
+  // enriches immediately while re-saving the same one inside the window does not.
+  if (reason !== 'manual' && !(await claim(organizationId, companyInstanceId, domain))) {
+    logger.debug('Enrichment already claimed', {
+      organizationId,
+      companyId: companyInstanceId,
+      domain,
+    })
+    return { outcome: 'skipped', why: 'claimed' }
+  }
+
+  // Per-org budget. Deliberately writes NO status when it blocks: the record must stay
+  // eligible so `companyEnrichmentSweepJob` drains the remainder in a later window.
+  const { allowed, count } = await checkFixedWindowLimit({
+    key: `enrich:org:${organizationId}`,
+    limit: ORG_WINDOW_LIMIT,
+    windowMs: ORG_WINDOW_MS,
+  })
+  if (!allowed) {
+    logger.info('Company enrichment rate limited for org', { organizationId, count })
+    return { outcome: 'skipped', why: 'rate-limited' }
+  }
+
+  try {
+    await crud.update(recordId, { company_enrichment_status: 'pending' })
+
+    const metadata = await fetchWebsiteMetadata(`https://${domain}`, domain)
+    const logoAssetId = await fetchAndStoreLogo({ organizationId, userId: systemUserId, metadata })
+
+    // Reached the site and got nothing usable. That is a `failed`, not an `enriched` with
+    // an empty payload: `failed` carries the shorter retry window and reads correctly in
+    // the UI as "we tried and could not get anything".
+    if (isEmptyMetadata(metadata) && !logoAssetId) {
+      await writeTerminal(crud, recordId, 'failed', derivedFromWebsite ? domain : null, {})
+      logger.info('Company enrichment found nothing usable', {
+        organizationId,
+        companyId: companyInstanceId,
+        domain,
+      })
+      return { outcome: 'failed', domain, error: 'no-usable-metadata' }
+    }
+
+    // Never overwrite what a person put there. `company_name` is replaced only while it is
+    // still the raw domain the mail path seeded it with; notes and logo are filled only
+    // when empty.
+    const applied: Record<string, unknown> = {}
+    if (metadata.siteName && nameIsReplaceable(state.name, domain)) {
+      applied.company_name = metadata.siteName
+    }
+    if (metadata.description && isBlank(state.notes)) applied.company_notes = metadata.description
+    if (logoAssetId && isBlank(state.logoRef))
+      applied.company_logo = { ref: `asset:${logoAssetId}` }
+
+    await writeTerminal(crud, recordId, 'enriched', derivedFromWebsite ? domain : null, applied)
+
+    logger.info('Company enriched', {
+      organizationId,
+      companyId: companyInstanceId,
+      domain,
+      reason,
+      derivedFromWebsite,
+      applied: Object.keys(applied),
+    })
+    return { outcome: 'enriched', domain, applied: Object.keys(applied) }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    logger.error('Company enrichment failed', {
+      organizationId,
+      companyId: companyInstanceId,
+      domain,
+      error,
+    })
+    await writeTerminal(crud, recordId, 'failed', derivedFromWebsite ? domain : null, {}).catch(
+      () => {}
+    )
+    return { outcome: 'failed', domain, error }
+  }
+}
+
+/**
+ * One update carrying the terminal status, the timestamp, any derived domain, and whatever
+ * the fetch produced. Single write on purpose: each `crud.update` re-enters the field-hook
+ * and record-rule machinery, so splitting this would multiply the dispatch it triggers.
+ */
+async function writeTerminal(
+  crud: UnifiedCrudHandler,
+  recordId: RecordId,
+  status: Extract<EnrichmentStatus, 'enriched' | 'failed'>,
+  derivedDomain: string | null,
+  applied: Record<string, unknown>
+): Promise<void> {
+  await crud.update(recordId, {
+    ...applied,
+    ...(derivedDomain ? { company_domain: derivedDomain } : {}),
+    company_enrichment_status: status,
+    company_enriched_at: new Date(),
+  })
+}
+
+/** `SET NX PX`. Fails OPEN when Redis is down — the stored status is the durable guard. */
+async function claim(
+  organizationId: string,
+  companyInstanceId: string,
+  domain: string
+): Promise<boolean> {
+  try {
+    const redis = await getRedisClient(false)
+    if (!redis) return true
+    const key = `enrich:claim:${organizationId}:${companyInstanceId}:${domain}`
+    return !!(await redis.set(key, '1', 'PX', CLAIM_TTL_MS, 'NX'))
+  } catch {
+    return true
+  }
+}
+
+/**
+ * Read the seven field values off the record.
+ *
+ * Raw column reads rather than `FieldValueService`: the four storage columns in play here
+ * are unambiguous (TEXT/URL land in `valueText`, DATETIME in `valueDate`, SINGLE_SELECT in
+ * `optionId`, FILE in `valueJson`) and this runs once per job on a hot path.
+ */
+async function readState(
+  db: Database,
+  organizationId: string,
+  companyInstanceId: string,
+  fieldIdByAttr: Map<string, string>
+): Promise<CompanyEnrichmentState> {
+  const idToAttr = new Map([...fieldIdByAttr].map(([attr, id]) => [id, attr]))
+
+  const rows = await db
+    .select({
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+      valueDate: schema.FieldValue.valueDate,
+      valueJson: schema.FieldValue.valueJson,
+      optionId: schema.FieldValue.optionId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, companyInstanceId),
+        inArray(schema.FieldValue.fieldId, [...idToAttr.keys()])
+      )
+    )
+
+  const state: CompanyEnrichmentState = {
+    domain: null,
+    website: [],
+    status: null,
+    enrichedAt: null,
+    name: null,
+    notes: null,
+    logoRef: null,
+  }
+
+  for (const row of rows) {
+    switch (idToAttr.get(row.fieldId)) {
+      case 'company_domain':
+        state.domain = row.valueText
+        break
+      // Multi-value: one row per entry.
+      case 'company_website':
+        if (row.valueText) state.website.push(row.valueText)
+        break
+      case 'company_enrichment_status':
+        state.status = asStatus(row.optionId)
+        break
+      // `FieldValue.valueDate` is declared `mode: 'string'`, so this is an ISO string on
+      // the way out, not a Date. An unparseable one reads as "never enriched", which fails
+      // toward re-enriching rather than toward silently never enriching again.
+      case 'company_enriched_at':
+        state.enrichedAt = parseDate(row.valueDate)
+        break
+      case 'company_name':
+        state.name = row.valueText
+        break
+      case 'company_notes':
+        state.notes = row.valueText
+        break
+      case 'company_logo':
+        state.logoRef = assetRefOf(row.valueJson)
+        break
+    }
+  }
+
+  return state
+}
+
+function parseDate(value: string | null): Date | null {
+  if (!value) return null
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function asStatus(optionId: string | null): EnrichmentStatus | null {
+  switch (optionId) {
+    case 'pending':
+    case 'enriched':
+    case 'failed':
+    case 'skipped':
+      return optionId
+    default:
+      return null
+  }
+}
+
+/** FILE values are stored wrapped: `{ v: { ref: 'asset:<id>' } }`. */
+function assetRefOf(valueJson: unknown): string | null {
+  if (!valueJson || typeof valueJson !== 'object') return null
+  const inner = (valueJson as { v?: unknown }).v ?? valueJson
+  if (!inner || typeof inner !== 'object') return null
+  const ref = (inner as { ref?: unknown }).ref
+  return typeof ref === 'string' && ref.length > 0 ? ref : null
+}
+
+/** Empty, whitespace-only, and absent all count as "nothing is there to protect". */
+function isBlank(value: string | null | undefined): boolean {
+  return typeof value !== 'string' || value.trim().length === 0
+}
+
+/**
+ * A name we are allowed to replace: blank, or still the raw domain the mail path seeds
+ * (`findOrCreateCompanyByDomain` writes `company_name: domain`). Anything else is a name a
+ * person chose, and enrichment does not get to argue with it.
+ */
+function nameIsReplaceable(current: string | null, domain: string): boolean {
+  if (isBlank(current)) return true
+  const normalized = current!.trim().toLowerCase()
+  return normalized === domain || normalized === `www.${domain}`
+}

--- a/packages/lib/src/companies/enrichment/guards.ts
+++ b/packages/lib/src/companies/enrichment/guards.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/companies/enrichment/guards.ts
+// The whole "should we fetch this company's website right now?" policy, as one pure
+// function over one plain state object.
+//
+// It lives apart from `enrich.ts` on purpose. Enrichment is reachable from four doors
+// (record created, `company_domain` changed, `company_website` changed, manual/backfill)
+// and two of them fire more often than they look:
+//
+//   1. The interactive field-trigger door presents a SENTINEL, not real values
+//      (`field-hooks/field-hook-job.ts` — `INTERACTIVE_FIELD_WRITE` against
+//      `oldValue: undefined`, "guaranteed unequal, so the transition always matches").
+//      So a rule on `company_domain` fires on EVERY write of that field, including
+//      clearing it and including re-saving the identical value.
+//   2. `skipOnCreate` is honoured only on the interactive create path
+//      (`field-hooks/collect-triggers.ts`). The sync door
+//      (`events/handlers/handle-sync-record-rules.ts`) splits rules into field /
+//      created / deleted buckets and never consults it, so an IMPORT that creates a
+//      company carrying a domain fires the lifecycle rule AND the field rule for the
+//      same record.
+//
+// No rule-declaration trick avoids either. The guard therefore sits in the work, and
+// every door funnels through it.
+
+import { domainFromWebsite } from './derive-domain'
+
+/** Why enrichment was asked for. Only `'manual'` bypasses the freshness windows. */
+export type EnrichReason = 'created' | 'domain-changed' | 'website-changed' | 'manual' | 'backfill'
+
+/** The `company_enrichment_status` single-select options, as stored (`FieldValue.optionId`). */
+export type EnrichmentStatus = 'pending' | 'enriched' | 'failed' | 'skipped'
+
+/** Don't re-fetch a company we already enriched inside this window. */
+export const ENRICHED_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * Don't re-fetch a company whose site just failed. Shorter than the success window:
+ * a 404 or a timeout is often transient, a successful enrichment rarely goes stale fast.
+ */
+export const FAILED_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+/** Redis in-flight claim. Short: the durable guard is the stored status, not this. */
+export const CLAIM_TTL_MS = 10 * 60 * 1000
+
+/** Per-org outbound fetch budget. The backstop for a five-thousand-row import. */
+export const ORG_WINDOW_LIMIT = 300
+export const ORG_WINDOW_MS = 60 * 60 * 1000
+
+/** Live record state the decision is made against. Read fresh, never taken from an event. */
+export interface CompanyEnrichmentState {
+  domain: string | null
+  /** `company_website` is a multi-value URL field, so this is always a list. */
+  website: string[]
+  status: EnrichmentStatus | null
+  enrichedAt: Date | null
+  name: string | null
+  notes: string | null
+  /** The `asset:<id>` ref out of `company_logo`, or null when unset. */
+  logoRef: string | null
+}
+
+export type EnrichSkipReason = 'no-domain' | 'recently-enriched' | 'recently-failed'
+
+export type EnrichDecision =
+  | { action: 'enrich'; domain: string; derivedFromWebsite: boolean }
+  | {
+      action: 'skip'
+      why: EnrichSkipReason
+      /** `'skipped'` writes the status so the gap is visible; null touches nothing. */
+      writeStatus: 'skipped' | null
+    }
+
+/**
+ * Decide whether to enrich, and against which domain.
+ *
+ * Order matters: the domain resolution runs first because a company with no domain and
+ * no website is the single most common case (every company an import mints by name), and
+ * it must cost nothing beyond the read that already happened.
+ *
+ * `'pending'` is deliberately NOT a skip reason. It is written just before the fetch, so
+ * treating it as "in progress, stay away" would strand any company whose worker died
+ * mid-fetch in a state nothing ever retries. Concurrency is handled by the BullMQ jobId
+ * and the Redis claim instead, both of which expire on their own.
+ */
+export function shouldEnrich(
+  state: CompanyEnrichmentState,
+  reason: EnrichReason,
+  now: Date
+): EnrichDecision {
+  const stored = state.domain?.trim().toLowerCase() || null
+  const derived = stored ? null : domainFromWebsite(state.website)
+  const domain = stored ?? derived
+
+  if (!domain) {
+    // Write the marker once, then leave the record alone. Without the second half, every
+    // save of a domainless company would issue a pointless no-op update.
+    return {
+      action: 'skip',
+      why: 'no-domain',
+      writeStatus: state.status === 'skipped' ? null : 'skipped',
+    }
+  }
+
+  if (reason !== 'manual' && state.enrichedAt) {
+    const age = now.getTime() - state.enrichedAt.getTime()
+    if (state.status === 'enriched' && age < ENRICHED_TTL_MS) {
+      return { action: 'skip', why: 'recently-enriched', writeStatus: null }
+    }
+    if (state.status === 'failed' && age < FAILED_TTL_MS) {
+      return { action: 'skip', why: 'recently-failed', writeStatus: null }
+    }
+  }
+
+  return { action: 'enrich', domain, derivedFromWebsite: derived !== null }
+}

--- a/packages/lib/src/companies/enrichment/metadata.ts
+++ b/packages/lib/src/companies/enrichment/metadata.ts
@@ -1,0 +1,306 @@
+// packages/lib/src/companies/enrichment/metadata.ts
+// Fetch a company homepage and pull the three things worth keeping: a clean name, a
+// description, and a logo-ish image. Moved out of `field-hooks/post/company-triggers.ts`
+// when enrichment gained more doors than `created`; the fetch/parse bodies are unchanged
+// apart from the sanity filtering below.
+//
+// Everything here returns null rather than throwing on bad input. A homepage is arbitrary
+// third-party HTML: it can be an empty body, a Cloudflare interstitial, a parked-domain
+// placeholder, or a 200 that is actually a JSON error. Writing any of that onto a customer
+// record is worse than writing nothing, so every extracted value goes through
+// `cleanText` + a junk check before it is allowed out of this module.
+
+import { database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { load } from 'cheerio'
+import { assertPublicHost, fetchAndStoreRemoteImage } from '../../files/fetch-remote-image'
+
+const logger = createScopedLogger('companies:enrichment')
+
+const HTML_FETCH_TIMEOUT_MS = 8000
+const LOGO_FETCH_TIMEOUT_MS = 5000
+const MAX_HTML_BYTES = 500_000
+const MAX_LOGO_BYTES = 1_000_000
+const USER_AGENT = 'AuxxAi-Enrichment/1.0 (+https://auxx.ai/bot)'
+
+/** Below this a "name" is an artefact (an initial, a stray bullet), not a company. */
+const MIN_NAME_LENGTH = 2
+const MAX_NAME_LENGTH = 120
+/** Below this a "description" is a label, not a description. */
+const MIN_DESCRIPTION_LENGTH = 20
+const MAX_DESCRIPTION_LENGTH = 500
+
+/**
+ * Titles that are the page's furniture rather than the company's name. Lowercased and
+ * compared whole, so a real company called "Home Depot" is untouched.
+ *
+ * The bot-wall entries are the ones that actually bite: a site behind Cloudflare answers
+ * 200 with `<title>Just a moment...</title>`, which sails past every other check and would
+ * rename the record to that.
+ */
+const JUNK_NAMES = new Set([
+  'home',
+  'homepage',
+  'home page',
+  'index',
+  'untitled',
+  'untitled document',
+  'welcome',
+  'welcome!',
+  'new page',
+  'default',
+  'default page',
+  'coming soon',
+  'under construction',
+  'parked domain',
+  'domain for sale',
+  'just a moment',
+  'just a moment...',
+  'attention required!',
+  'access denied',
+  'forbidden',
+  'not found',
+  'error',
+  'page not found',
+  'security check',
+  'redirecting',
+  'loading',
+  'website',
+  'my site',
+])
+
+export interface WebsiteMetadata {
+  siteName: string | null
+  description: string | null
+  faviconUrl: string | null
+  appleTouchIconUrl: string | null
+  ogImageUrl: string | null
+}
+
+/**
+ * True when the fetch produced no CONTENT worth writing.
+ *
+ * ⚠️ The three image URLs deliberately do not count. `faviconUrl` falls back to a
+ * hard-coded `/favicon.ico` guess, so it is non-null whenever the page was fetched at all
+ * — including for a page whose title was a bot wall and whose description was absent.
+ * Counting it would make this almost always false, and a company where every extracted
+ * value was rejected would be recorded `enriched` (30-day lockout) instead of `failed`
+ * (7-day retry). Whether an image was actually usable is answered by the stored asset id,
+ * which the caller checks alongside this.
+ */
+export function isEmptyMetadata(m: WebsiteMetadata): boolean {
+  return !m.siteName && !m.description
+}
+
+export function emptyMetadata(): WebsiteMetadata {
+  return {
+    siteName: null,
+    description: null,
+    faviconUrl: null,
+    appleTouchIconUrl: null,
+    ogImageUrl: null,
+  }
+}
+
+/**
+ * Fetch and parse one homepage. Never throws: a company we cannot reach is a `failed`
+ * status, not an exception that costs the job its retry budget.
+ *
+ * `domain` is passed alongside the url purely so the junk check can reject a title that is
+ * just the domain back at us, which is what parked pages and many small sites serve.
+ */
+export async function fetchWebsiteMetadata(url: string, domain: string): Promise<WebsiteMetadata> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), HTML_FETCH_TIMEOUT_MS)
+
+  try {
+    assertPublicHost(url)
+
+    const res = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: {
+        'user-agent': USER_AGENT,
+        accept: 'text/html,application/xhtml+xml',
+      },
+    })
+
+    if (!res.ok) {
+      logger.warn('Non-OK response fetching website', { url, status: res.status })
+      return emptyMetadata()
+    }
+
+    // A 200 that is not HTML is a JSON API, a PDF, or an image at the apex. Parsing it as
+    // markup yields a `<title>` of whatever the first bytes happened to be.
+    const contentType = res.headers.get('content-type')?.toLowerCase() ?? ''
+    if (contentType && !contentType.includes('html')) {
+      logger.debug('Skipping non-HTML response', { url, contentType })
+      return emptyMetadata()
+    }
+
+    const reader = res.body?.getReader()
+    if (!reader) return emptyMetadata()
+
+    const chunks: Uint8Array[] = []
+    let total = 0
+    while (total < MAX_HTML_BYTES) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+      total += value.byteLength
+    }
+    await reader.cancel()
+
+    if (total === 0) {
+      logger.debug('Empty response body', { url })
+      return emptyMetadata()
+    }
+
+    const html = new TextDecoder('utf-8', { fatal: false }).decode(
+      Buffer.concat(chunks.map((c) => Buffer.from(c)))
+    )
+
+    const $ = load(html)
+
+    const rawTitle = $('title').first().text().trim()
+    const titleFirstSegment = rawTitle ? rawTitle.split(/[|\-–—]/)[0]?.trim() : null
+
+    const siteName = acceptName(
+      $('meta[property="og:site_name"]').attr('content') ||
+        $('meta[name="application-name"]').attr('content') ||
+        titleFirstSegment,
+      domain
+    )
+
+    const description = acceptDescription(
+      $('meta[property="og:description"]').attr('content') ||
+        $('meta[name="description"]').attr('content'),
+      siteName,
+      domain
+    )
+
+    const faviconUrl = resolveUrl(
+      url,
+      $('link[rel="icon"]').attr('href') ||
+        $('link[rel="shortcut icon"]').attr('href') ||
+        '/favicon.ico'
+    )
+
+    const appleTouchIconUrl = resolveUrl(url, $('link[rel="apple-touch-icon"]').attr('href'))
+    const ogImageUrl = resolveUrl(url, $('meta[property="og:image"]').attr('content'))
+
+    return { siteName, description, faviconUrl, appleTouchIconUrl, ogImageUrl }
+  } catch (err) {
+    logger.warn('Fetch website metadata failed', { url, error: (err as Error).message })
+    return emptyMetadata()
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Store the best logo candidate as a MediaAsset and return its id, or null when every
+ * candidate failed.
+ *
+ * apple-touch-icon is usually the cleanest logo-like asset, followed by og:image, then the
+ * tiny favicon as a last resort.
+ */
+export async function fetchAndStoreLogo(args: {
+  organizationId: string
+  userId: string
+  metadata: WebsiteMetadata
+}): Promise<string | null> {
+  const candidates = [
+    args.metadata.appleTouchIconUrl,
+    args.metadata.ogImageUrl,
+    args.metadata.faviconUrl,
+  ].filter((v): v is string => typeof v === 'string' && v.length > 0)
+
+  for (const url of candidates) {
+    try {
+      const result = await fetchAndStoreRemoteImage({
+        db: database,
+        url,
+        organizationId: args.organizationId,
+        userId: args.userId,
+        pathPrefix: 'company-logos',
+        purpose: 'company-logo',
+        name: 'company-logo',
+        maxBytes: MAX_LOGO_BYTES,
+        timeoutMs: LOGO_FETCH_TIMEOUT_MS,
+      })
+      if (result.assetId) return result.assetId
+    } catch (err) {
+      logger.debug('Logo candidate failed', { url, error: (err as Error).message })
+    }
+  }
+
+  return null
+}
+
+// ─── Value sanity ──────────────────────────────────────────────────────
+
+/**
+ * Trim, collapse internal whitespace, drop zero-width characters, and enforce a length
+ * band. Returns null for anything that ends up empty or too short to mean something.
+ *
+ * The whitespace collapse matters more than it looks: `<title>` content is routinely
+ * pretty-printed across several lines, and writing that verbatim puts newlines into a
+ * single-line text field.
+ */
+export function cleanText(raw: string | null | undefined, min: number, max: number): string | null {
+  if (typeof raw !== 'string') return null
+
+  const collapsed = raw
+    // Zero-width space / non-joiner / joiner / BOM, which survive `trim`.
+    .replace(/[\u200B-\u200D\uFEFF]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (collapsed.length < min) return null
+  return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed
+}
+
+/** A site name we are willing to put on a record, or null. */
+function acceptName(raw: string | null | undefined, domain: string): string | null {
+  const cleaned = cleanText(raw, MIN_NAME_LENGTH, MAX_NAME_LENGTH)
+  if (!cleaned) return null
+
+  const lower = cleaned.toLowerCase()
+  if (JUNK_NAMES.has(lower)) return null
+  // The domain back at us is not an improvement on the domain we already stored.
+  if (lower === domain || lower === `www.${domain}` || lower === domain.split('.')[0]) return null
+  // A bare URL is a title on plenty of parked pages.
+  if (/^https?:\/\//i.test(cleaned)) return null
+
+  return cleaned
+}
+
+/** A description we are willing to put on a record, or null. */
+function acceptDescription(
+  raw: string | null | undefined,
+  siteName: string | null,
+  domain: string
+): string | null {
+  const cleaned = cleanText(raw, MIN_DESCRIPTION_LENGTH, MAX_DESCRIPTION_LENGTH)
+  if (!cleaned) return null
+
+  const lower = cleaned.toLowerCase()
+  // A description that is just the name (or the domain) adds nothing and reads as a bug.
+  if (siteName && lower === siteName.toLowerCase()) return null
+  if (lower === domain) return null
+  if (JUNK_NAMES.has(lower)) return null
+
+  return cleaned
+}
+
+function resolveUrl(base: string, href: string | null | undefined): string | null {
+  if (!href || href.trim().length === 0) return null
+  try {
+    const resolved = new URL(href.trim(), base)
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') return null
+    return resolved.toString()
+  } catch {
+    return null
+  }
+}

--- a/packages/lib/src/companies/enrichment/sweep.ts
+++ b/packages/lib/src/companies/enrichment/sweep.ts
@@ -1,0 +1,176 @@
+// packages/lib/src/companies/enrichment/sweep.ts
+// The gap filler. Finds companies that never reached a terminal enrichment status and
+// queues them.
+//
+// Three things land here and nothing else would ever pick them up:
+//   1. Companies created BEFORE enrichment existed, or before it had more than one door.
+//   2. Companies the per-org window limiter dropped mid-import — deliberately left with no
+//      status write precisely so this sweep re-finds them.
+//   3. Companies stuck on `pending` because a worker died between the marker and the
+//      terminal write.
+//
+// It is deliberately NOT a re-enricher. Records already on `enriched` are never selected,
+// and `shouldEnrich` would refuse them anyway. Widening it to re-enrich on TTL expiry is a
+// one-predicate change once real fetch volumes are known.
+
+import { type Database, database as defaultDb, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray, isNull, lt, or, sql } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import { enqueueCompanyEnrichment } from './enqueue'
+import { FAILED_TTL_MS, ORG_WINDOW_LIMIT } from './guards'
+
+const logger = createScopedLogger('companies:enrichment-sweep')
+
+/** Hard ceiling on one sweep, across every org. */
+const DEFAULT_MAX_RECORDS = 2000
+
+export interface EnrichmentSweepOptions {
+  db?: Database
+  /** Restrict to one org. Used by the backfill script. */
+  organizationId?: string
+  /** Ceiling across all orgs (default 2000). */
+  maxRecords?: number
+  /** Ceiling per org (defaults to the org's hourly fetch budget). */
+  maxPerOrganization?: number
+  /** Resolve candidates and report, enqueue nothing. */
+  dryRun?: boolean
+}
+
+export interface EnrichmentSweepSummary {
+  candidates: number
+  enqueued: number
+  /** Candidates dropped because their org had already hit `maxPerOrganization`. */
+  deferred: number
+  organizations: number
+}
+
+export interface EnrichmentCandidate {
+  organizationId: string
+  companyInstanceId: string
+}
+
+/**
+ * Companies with no terminal enrichment status, oldest first.
+ *
+ * Note it does NOT filter on having a domain. A company with neither a domain nor a usable
+ * website is exactly the case worth surfacing: `enrichCompany` resolves it to the
+ * `'skipped'` status, which is a terminal state, so it costs one cheap pass and is never
+ * selected again. Filtering it out here would instead leave those records invisible
+ * forever, which is the bug this whole change exists to fix.
+ */
+export async function findCompaniesNeedingEnrichment(
+  options: EnrichmentSweepOptions = {}
+): Promise<EnrichmentCandidate[]> {
+  const db = options.db ?? defaultDb
+  const limit = options.maxRecords ?? DEFAULT_MAX_RECORDS
+  // `FieldValue.valueDate` is `mode: 'string'` in the schema, so the comparison value has
+  // to be an ISO string too.
+  const staleBefore = new Date(Date.now() - FAILED_TTL_MS).toISOString()
+
+  const statusField = alias(schema.CustomField, 'enrichment_status_field')
+  const statusValue = alias(schema.FieldValue, 'enrichment_status_value')
+  const atField = alias(schema.CustomField, 'enriched_at_field')
+  const atValue = alias(schema.FieldValue, 'enriched_at_value')
+
+  const rows = await db
+    .select({
+      organizationId: schema.EntityInstance.organizationId,
+      companyInstanceId: schema.EntityInstance.id,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      schema.EntityDefinition,
+      and(
+        eq(schema.EntityDefinition.id, schema.EntityInstance.entityDefinitionId),
+        eq(schema.EntityDefinition.entityType, 'company')
+      )
+    )
+    .leftJoin(
+      statusField,
+      and(
+        eq(statusField.entityDefinitionId, schema.EntityInstance.entityDefinitionId),
+        eq(statusField.systemAttribute, 'company_enrichment_status')
+      )
+    )
+    .leftJoin(
+      statusValue,
+      and(
+        eq(statusValue.entityId, schema.EntityInstance.id),
+        eq(statusValue.fieldId, statusField.id)
+      )
+    )
+    .leftJoin(
+      atField,
+      and(
+        eq(atField.entityDefinitionId, schema.EntityInstance.entityDefinitionId),
+        eq(atField.systemAttribute, 'company_enriched_at')
+      )
+    )
+    .leftJoin(
+      atValue,
+      and(eq(atValue.entityId, schema.EntityInstance.id), eq(atValue.fieldId, atField.id))
+    )
+    .where(
+      and(
+        isNull(schema.EntityInstance.archivedAt),
+        options.organizationId
+          ? eq(schema.EntityInstance.organizationId, options.organizationId)
+          : undefined,
+        or(
+          // Never attempted.
+          isNull(statusValue.optionId),
+          // Attempted, non-terminal or stale-failed. `pending` is in here because a worker
+          // that died between the marker and the terminal write leaves exactly that, and
+          // nothing else would ever retry it.
+          and(
+            inArray(statusValue.optionId, ['failed', 'pending']),
+            or(isNull(atValue.valueDate), lt(atValue.valueDate, staleBefore))
+          )
+        )
+      )
+    )
+    .orderBy(sql`${schema.EntityInstance.createdAt} asc`)
+    .limit(limit)
+
+  return rows
+}
+
+/**
+ * Find and enqueue. Per-org capped so one large org cannot consume a whole sweep, and
+ * because everything past the org's hourly budget would only come back `rate-limited`.
+ */
+export async function sweepCompaniesNeedingEnrichment(
+  options: EnrichmentSweepOptions = {}
+): Promise<EnrichmentSweepSummary> {
+  const candidates = await findCompaniesNeedingEnrichment(options)
+  const perOrgCap = options.maxPerOrganization ?? ORG_WINDOW_LIMIT
+
+  const takenByOrg = new Map<string, number>()
+  let enqueued = 0
+  let deferred = 0
+
+  for (const candidate of candidates) {
+    const taken = takenByOrg.get(candidate.organizationId) ?? 0
+    if (taken >= perOrgCap) {
+      deferred++
+      continue
+    }
+    takenByOrg.set(candidate.organizationId, taken + 1)
+
+    if (options.dryRun) {
+      enqueued++
+      continue
+    }
+    if (await enqueueCompanyEnrichment({ ...candidate, reason: 'backfill' })) enqueued++
+  }
+
+  const summary: EnrichmentSweepSummary = {
+    candidates: candidates.length,
+    enqueued,
+    deferred,
+    organizations: takenByOrg.size,
+  }
+  logger.info('Company enrichment sweep finished', { ...summary, dryRun: options.dryRun ?? false })
+  return summary
+}

--- a/packages/lib/src/companies/index.ts
+++ b/packages/lib/src/companies/index.ts
@@ -1,0 +1,38 @@
+// packages/lib/src/companies/index.ts
+
+export { domainFromUrl, domainFromWebsite } from './enrichment/derive-domain'
+export type { EnrichCompanyJobData } from './enrichment/enqueue'
+export { ENRICH_COMPANY_JOB_NAME, enqueueCompanyEnrichment } from './enrichment/enqueue'
+export type { CompanyEnrichmentOutcome, EnrichCompanyInput } from './enrichment/enrich'
+export { enrichCompany } from './enrichment/enrich'
+export type {
+  CompanyEnrichmentState,
+  EnrichDecision,
+  EnrichmentStatus,
+  EnrichReason,
+  EnrichSkipReason,
+} from './enrichment/guards'
+export {
+  CLAIM_TTL_MS,
+  ENRICHED_TTL_MS,
+  FAILED_TTL_MS,
+  ORG_WINDOW_LIMIT,
+  ORG_WINDOW_MS,
+  shouldEnrich,
+} from './enrichment/guards'
+export type { WebsiteMetadata } from './enrichment/metadata'
+export {
+  cleanText,
+  fetchAndStoreLogo,
+  fetchWebsiteMetadata,
+  isEmptyMetadata,
+} from './enrichment/metadata'
+export type {
+  EnrichmentCandidate,
+  EnrichmentSweepOptions,
+  EnrichmentSweepSummary,
+} from './enrichment/sweep'
+export {
+  findCompaniesNeedingEnrichment,
+  sweepCompaniesNeedingEnrichment,
+} from './enrichment/sweep'

--- a/packages/lib/src/field-hooks/__tests__/system-record-rules.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/system-record-rules.test.ts
@@ -1,8 +1,9 @@
 // packages/lib/src/field-hooks/__tests__/system-record-rules.test.ts
-// B2 §8: the manufacturing FIELD_TRIGGERS as server-declared system rules. Asserts the 7
-// declarations (keys, transition, ordered actions) and that the 4 native handlers are thin
+// B2 §8: the manufacturing FIELD_TRIGGERS as server-declared system rules, plus the two
+// company-enrichment field doors added in plans/company/v4-enrichment-doors.md. Asserts the
+// declarations (keys, transition, ordered actions) and that the native handlers are thin
 // wrappers that call the EXISTING trigger functions with an adapted event. Trigger modules
-// mocked so no DB/bom/realtime is touched.
+// mocked so no DB/bom/realtime/queue is touched.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -10,11 +11,15 @@ const h = vi.hoisted(() => ({
   recalculatePartCost: vi.fn(async () => {}),
   clearOtherPreferred: vi.fn(async () => {}),
   recalculateStockStatus: vi.fn(async () => {}),
+  enqueueCompanyEnrichmentForRecords: vi.fn(async () => {}),
 }))
 
 vi.mock('../post/bom-cost-triggers', () => ({ recalculatePartCost: h.recalculatePartCost }))
 vi.mock('../post/vendor-part-triggers', () => ({ clearOtherPreferred: h.clearOtherPreferred }))
 vi.mock('../post/inventory-triggers', () => ({ recalculateStockStatus: h.recalculateStockStatus }))
+vi.mock('../post/company-triggers', () => ({
+  enqueueCompanyEnrichmentForRecords: h.enqueueCompanyEnrichmentForRecords,
+}))
 
 import { __clearNativeRuleHandlers, getNativeRuleHandler } from '../../record-rules/actions'
 import { __clearSystemRules, getSystemRuleDeclarations } from '../../record-rules/system-rules'
@@ -35,11 +40,15 @@ afterEach(() => {
 })
 
 describe('registerFieldSystemRules — declarations', () => {
-  it('declares exactly the 11 field triggers', () => {
+  it('declares exactly the 13 field triggers', () => {
     const decls = getSystemRuleDeclarations()
-    expect(decls).toHaveLength(11)
+    expect(decls).toHaveLength(13)
     expect(decls.map((d) => d.fieldRef?.systemAttribute).sort()).toEqual(
       [
+        // Company enrichment's two field doors: a domain arriving or being corrected, and
+        // a website the domain can be derived from.
+        'company_domain',
+        'company_website',
         'part_reorder_point',
         'subpart_quantity',
         // The schedule (29 §7): the three rate-row fields the resolver reads,
@@ -89,7 +98,77 @@ describe('registerFieldSystemRules — declarations', () => {
   it('is idempotent — a second call does not duplicate declarations', () => {
     __resetFieldSystemRulesLatch()
     registerFieldSystemRules()
-    expect(getSystemRuleDeclarations()).toHaveLength(11)
+    expect(getSystemRuleDeclarations()).toHaveLength(13)
+  })
+})
+
+describe('company enrichment field doors', () => {
+  const companyRules = () => getSystemRuleDeclarations().filter((d) => d.defSlug === 'companies')
+
+  it('declares one rule for company_domain and one for company_website', () => {
+    expect(
+      companyRules()
+        .map((d) => d.fieldRef?.systemAttribute)
+        .sort()
+    ).toEqual(['company_domain', 'company_website'])
+  })
+
+  // 🛑 `'set'` is `isEmpty(old) && !isEmpty(new)`, which misses a CORRECTION (`acme.com`
+  // to `acme.io`) — and a correction is exactly when the cached logo and description are
+  // wrong. On the interactive door the two behave identically anyway, since the sentinel
+  // makes every transition match, so `'set'` would buy nothing and lose the case that
+  // matters. (The blanket `on === 'changed'` assertion above covers this too; this names
+  // why it must stay true for these two.)
+  it('fires on changed, not set, so a domain CORRECTION re-enriches', () => {
+    for (const rule of companyRules()) expect(rule.on).toBe('changed')
+  })
+
+  // Suppresses the interactive create double-fire — the def's `created` rule owns that
+  // case. It does NOT suppress the sync one: `handle-sync-record-rules.ts` never reads the
+  // flag, so an import creating a company with a domain fires both. That is absorbed by
+  // the BullMQ jobId and the stored status, not here.
+  it('skips the create path, leaving it to the lifecycle rule', () => {
+    for (const rule of companyRules()) expect(rule.skipOnCreate).toBe(true)
+  })
+
+  it('routes each field to its own native handler', () => {
+    const byAttr = new Map(
+      companyRules().map((d) => [
+        d.fieldRef?.systemAttribute,
+        d.actions.map((a) => (a as { handler: string }).handler),
+      ])
+    )
+    expect(byAttr.get('company_domain')).toEqual(['enrichCompanyFromDomain'])
+    expect(byAttr.get('company_website')).toEqual(['enrichCompanyFromWebsite'])
+  })
+
+  // 🛑 NOT routed through `fanOutEntityHandler`: it bails on any firing with no lifecycle
+  // `action`, and field firings carry none. Routing them through it would have compiled,
+  // registered, and silently never run.
+  it('passes the batch recordIds straight through, with no lifecycle action present', async () => {
+    await getNativeRuleHandler('enrichCompanyFromDomain')!({
+      recordIds: ['companyDef:c1', 'companyDef:c2'] as never,
+      organizationId: 'org_1',
+    })
+    expect(h.enqueueCompanyEnrichmentForRecords).toHaveBeenCalledTimes(1)
+    expect(h.enqueueCompanyEnrichmentForRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: 'org_1',
+        recordIds: ['companyDef:c1', 'companyDef:c2'],
+      }),
+      'domain-changed'
+    )
+  })
+
+  it('tags the website door with its own reason', async () => {
+    await getNativeRuleHandler('enrichCompanyFromWebsite')!({
+      recordIds: ['companyDef:c1'] as never,
+      organizationId: 'org_1',
+    })
+    expect(h.enqueueCompanyEnrichmentForRecords).toHaveBeenCalledWith(
+      expect.anything(),
+      'website-changed'
+    )
   })
 })
 

--- a/packages/lib/src/field-hooks/post/company-triggers.ts
+++ b/packages/lib/src/field-hooks/post/company-triggers.ts
@@ -1,251 +1,67 @@
 // packages/lib/src/field-hooks/post/company-triggers.ts
+// Rule-door adapters for company enrichment. Thin on purpose: these translate a firing
+// into an enqueue and nothing else.
+//
+// The fetch, the parsing, the never-overwrite rules and the whole throttle live in
+// `packages/lib/src/companies/enrichment/`, because enrichment is reachable from four
+// doors now (record created, `company_domain` changed, `company_website` changed, manual
+// or backfill) and a policy split across four adapters would drift within a release.
+//
+// ⚠️ Neither adapter reads the event's values. A FIELD firing carries no `eventData`, and
+// the interactive field door presents a sentinel rather than the real write, so the only
+// trustworthy source is the record itself. `enrichCompany` re-reads it.
 
-import { database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { toRecordId } from '@auxx/types/resource'
-import { load } from 'cheerio'
-import { assertPublicHost, fetchAndStoreRemoteImage } from '../../files/fetch-remote-image'
-import { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
-import { SystemUserService } from '../../users/system-user-service'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import { enqueueCompanyEnrichment } from '../../companies/enrichment/enqueue'
+import type { EnrichReason } from '../../companies/enrichment/guards'
 import type { EntityTriggerHandler } from '../types'
 
 const logger = createScopedLogger('field-hooks:company')
 
-const HTML_FETCH_TIMEOUT_MS = 8000
-const FAVICON_FETCH_TIMEOUT_MS = 5000
-const MAX_HTML_BYTES = 500_000
-const MAX_FAVICON_BYTES = 1_000_000
-const USER_AGENT = 'AuxxAi-Enrichment/1.0 (+https://auxx.ai/bot)'
-
 /**
- * Enrich a company from its website on create.
+ * Lifecycle door: a company row appeared.
  *
- * Fetches the company's homepage and extracts:
- * - Clean site name (from og:site_name or <title>) → company_name
- * - Description (from og:description or meta description) → company_notes
- * - Logo (apple-touch-icon, og:image, favicon) → company_logo
- *
- * Never overwrites user-edited values: only replaces company_name when it
- * equals the raw domain, and only fills company_notes / company_logo when empty.
+ * This is the only door that fires for a company created with a domain already on it, such
+ * as one the mail path minted from a sender address. Shaped as an `EntityTriggerHandler`
+ * because `fanOutEntityHandler` in `system-entity-rules.ts` invokes it per record.
  */
 export const enrichCompanyOnCreate: EntityTriggerHandler = async (event) => {
   if (event.action !== 'created') return
+  await queue(event.organizationId, event.entityInstanceId, 'created')
+}
 
-  const domain = event.values.company_domain
-  if (!domain || typeof domain !== 'string') {
-    logger.debug('Skipping enrichment — no domain', { entityInstanceId: event.entityInstanceId })
-    return
-  }
-
-  const { organizationId, entityInstanceId, entityDefinitionId } = event
-  const recordId = toRecordId(entityDefinitionId, entityInstanceId)
-
-  const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
-  const crud = new UnifiedCrudHandler(organizationId, systemUserId)
-
-  const currentName = typeof event.values.company_name === 'string' ? event.values.company_name : ''
-  const currentNotes = event.values.company_notes
-  const currentLogo = event.values.company_logo
-
-  const websiteUrl = `https://${domain}`
-
-  try {
-    await crud.update(recordId, { company_enrichment_status: 'pending' })
-
-    const metadata = await fetchWebsiteMetadata(websiteUrl)
-    const logoAssetId = await fetchAndStoreLogo({
-      organizationId,
-      userId: systemUserId,
-      metadata,
-    })
-
-    const updates: Record<string, unknown> = {
-      company_enrichment_status: 'enriched',
-      company_enriched_at: new Date(),
-    }
-
-    if (metadata.siteName && currentName === domain) {
-      updates.company_name = metadata.siteName
-    }
-    if (metadata.description && !currentNotes) {
-      updates.company_notes = metadata.description
-    }
-    if (logoAssetId && !currentLogo) {
-      updates.company_logo = { ref: `asset:${logoAssetId}` }
-    }
-
-    await crud.update(recordId, updates)
-
-    logger.info('Company enriched', {
-      organizationId,
-      companyId: entityInstanceId,
-      domain,
-      applied: Object.keys(updates),
-    })
-  } catch (err) {
-    logger.error('Enrichment failed', {
-      organizationId,
-      companyId: entityInstanceId,
-      domain,
-      error: (err as Error).message,
-    })
-    await crud.update(recordId, {
-      company_enrichment_status: 'failed',
-      company_enriched_at: new Date(),
-    })
+/**
+ * Field door: `company_domain` or `company_website` was written.
+ *
+ * ⚠️ NOT an `EntityTriggerHandler`, and not routed through `fanOutEntityHandler`. That
+ * helper bails on any firing without a lifecycle `action` ("Entity triggers are
+ * lifecycle-only"), and field firings carry none — routing this through it would silently
+ * never run. It takes the native batch event's `recordIds` directly instead.
+ *
+ * `company_website` is what makes that field mean something. Until this door existed,
+ * `company_domain` had exactly one writer in the codebase (the mail ingest path), so a
+ * company that did not arrive by email could never be enriched no matter what a user typed
+ * into it.
+ */
+export async function enqueueCompanyEnrichmentForRecords(
+  args: { organizationId: string; recordIds: readonly RecordId[] },
+  reason: Extract<EnrichReason, 'domain-changed' | 'website-changed'>
+): Promise<void> {
+  for (const recordId of args.recordIds) {
+    const { entityInstanceId } = parseRecordId(recordId)
+    await queue(args.organizationId, entityInstanceId, reason)
   }
 }
 
-// ─── Metadata fetch ────────────────────────────────────────────────────
-
-interface WebsiteMetadata {
-  siteName: string | null
-  description: string | null
-  faviconUrl: string | null
-  appleTouchIconUrl: string | null
-  ogImageUrl: string | null
-}
-
-async function fetchWebsiteMetadata(url: string): Promise<WebsiteMetadata> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), HTML_FETCH_TIMEOUT_MS)
-
-  try {
-    assertPublicHost(url)
-
-    const res = await fetch(url, {
-      signal: controller.signal,
-      redirect: 'follow',
-      headers: {
-        'user-agent': USER_AGENT,
-        accept: 'text/html,application/xhtml+xml',
-      },
-    })
-
-    if (!res.ok) {
-      logger.warn('Non-OK response fetching website', { url, status: res.status })
-      return emptyMetadata()
-    }
-
-    const reader = res.body?.getReader()
-    if (!reader) return emptyMetadata()
-
-    const chunks: Uint8Array[] = []
-    let total = 0
-    while (total < MAX_HTML_BYTES) {
-      const { done, value } = await reader.read()
-      if (done) break
-      chunks.push(value)
-      total += value.byteLength
-    }
-    await reader.cancel()
-
-    const html = new TextDecoder('utf-8', { fatal: false }).decode(
-      Buffer.concat(chunks.map((c) => Buffer.from(c)))
-    )
-
-    const $ = load(html)
-
-    const rawTitle = $('title').first().text().trim()
-    const titleFirstSegment = rawTitle ? rawTitle.split(/[|\-—]/)[0]?.trim() : null
-
-    const siteName =
-      $('meta[property="og:site_name"]').attr('content')?.trim() ||
-      $('meta[name="application-name"]').attr('content')?.trim() ||
-      titleFirstSegment ||
-      null
-
-    const description =
-      $('meta[property="og:description"]').attr('content')?.trim() ||
-      $('meta[name="description"]').attr('content')?.trim() ||
-      null
-
-    const faviconUrl = resolveUrl(
-      url,
-      $('link[rel="icon"]').attr('href') ||
-        $('link[rel="shortcut icon"]').attr('href') ||
-        '/favicon.ico'
-    )
-
-    const appleTouchIconUrl = resolveUrl(url, $('link[rel="apple-touch-icon"]').attr('href'))
-    const ogImageUrl = resolveUrl(url, $('meta[property="og:image"]').attr('content'))
-
-    return {
-      siteName: truncate(siteName, 120),
-      description: truncate(description, 500),
-      faviconUrl,
-      appleTouchIconUrl,
-      ogImageUrl,
-    }
-  } catch (err) {
-    logger.warn('Fetch website metadata failed', { url, error: (err as Error).message })
-    return emptyMetadata()
-  } finally {
-    clearTimeout(timer)
+async function queue(
+  organizationId: string,
+  companyInstanceId: string,
+  reason: EnrichReason
+): Promise<void> {
+  if (!organizationId || !companyInstanceId) return
+  const queued = await enqueueCompanyEnrichment({ organizationId, companyInstanceId, reason })
+  if (!queued) {
+    logger.warn('Company enrichment was not queued', { organizationId, companyInstanceId, reason })
   }
-}
-
-// ─── Logo fetch + store ────────────────────────────────────────────────
-
-async function fetchAndStoreLogo(args: {
-  organizationId: string
-  userId: string
-  metadata: WebsiteMetadata
-}): Promise<string | null> {
-  // apple-touch-icon is usually the cleanest "logo-like" asset, followed by
-  // og:image, then the tiny favicon as a last resort.
-  const candidates = [
-    args.metadata.appleTouchIconUrl,
-    args.metadata.ogImageUrl,
-    args.metadata.faviconUrl,
-  ].filter((v): v is string => typeof v === 'string' && v.length > 0)
-
-  for (const url of candidates) {
-    try {
-      const result = await fetchAndStoreRemoteImage({
-        db: database,
-        url,
-        organizationId: args.organizationId,
-        userId: args.userId,
-        pathPrefix: 'company-logos',
-        purpose: 'company-logo',
-        name: 'company-logo',
-        maxBytes: MAX_FAVICON_BYTES,
-        timeoutMs: FAVICON_FETCH_TIMEOUT_MS,
-      })
-      return result.assetId
-    } catch (err) {
-      logger.debug('Logo candidate failed', { url, error: (err as Error).message })
-    }
-  }
-
-  return null
-}
-
-// ─── Helpers ───────────────────────────────────────────────────────────
-
-function emptyMetadata(): WebsiteMetadata {
-  return {
-    siteName: null,
-    description: null,
-    faviconUrl: null,
-    appleTouchIconUrl: null,
-    ogImageUrl: null,
-  }
-}
-
-function resolveUrl(base: string, href: string | null | undefined): string | null {
-  if (!href) return null
-  try {
-    return new URL(href, base).toString()
-  } catch {
-    return null
-  }
-}
-
-function truncate(s: string | null, max: number): string | null {
-  if (!s) return null
-  const trimmed = s.trim()
-  if (trimmed.length === 0) return null
-  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed
 }

--- a/packages/lib/src/field-hooks/system-entity-rules.test.ts
+++ b/packages/lib/src/field-hooks/system-entity-rules.test.ts
@@ -13,11 +13,15 @@ const h = vi.hoisted(() => ({
   enrichCompanyOnCreate: vi.fn(async () => {}),
   recalculatePartCostForEntityBatch: vi.fn(async () => {}),
   derivePartKindForSubpartBatch: vi.fn(async () => {}),
+  enqueueCompanyEnrichmentForRecords: vi.fn(async () => {}),
 }))
 
 vi.mock('./post/bom-movement-triggers', () => ({ explodeBomMovement: h.explodeBomMovement }))
 vi.mock('./post/inventory-triggers', () => ({ recalculatePartQoH: h.recalculatePartQoH }))
-vi.mock('./post/company-triggers', () => ({ enrichCompanyOnCreate: h.enrichCompanyOnCreate }))
+vi.mock('./post/company-triggers', () => ({
+  enrichCompanyOnCreate: h.enrichCompanyOnCreate,
+  enqueueCompanyEnrichmentForRecords: h.enqueueCompanyEnrichmentForRecords,
+}))
 vi.mock('./post/bom-cost-triggers', () => ({
   recalculatePartCostForEntityBatch: h.recalculatePartCostForEntityBatch,
 }))
@@ -139,6 +143,9 @@ describe('native handlers — fan-out + batch adaptation', () => {
       },
     })
     expect(h.enrichCompanyOnCreate).toHaveBeenCalledTimes(2)
+    // The threaded values still reach the handler, but enrichment no longer READS them:
+    // it re-reads the record, because the field doors carry no `eventData` at all and the
+    // interactive one carries a sentinel. See `companies/enrichment/enrich.ts`.
     expect(h.enrichCompanyOnCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'created',

--- a/packages/lib/src/field-hooks/system-entity-rules.ts
+++ b/packages/lib/src/field-hooks/system-entity-rules.ts
@@ -158,7 +158,8 @@ export function registerEntitySystemRules(): void {
     })
   })
 
-  // Company enrichment — created only, per-record (HTTP fetch).
+  // Company enrichment — created only, per-record. The handler ENQUEUES; the fetch itself
+  // runs on `enrichmentQueue`, off this worker (see `companies/enrichment/enqueue.ts`).
   registerNativeRuleHandler(ENRICH_COMPANY_ON_CREATE, async (event) => {
     const { enrichCompanyOnCreate } = await import('./post/company-triggers')
     await fanOutEntityHandler(event, 'companies', enrichCompanyOnCreate)
@@ -260,7 +261,7 @@ const ENTITY_SYSTEM_RULES: SystemRuleDeclaration[] = [
     actions: [{ type: 'native', handler: RECALC_PO_LINE_BILLED }],
   },
   {
-    key: 'mfg-companies-created',
+    key: 'company-created',
     name: 'Enrich company from website on create',
     defSlug: 'companies',
     on: 'created',

--- a/packages/lib/src/field-hooks/system-record-rules.ts
+++ b/packages/lib/src/field-hooks/system-record-rules.ts
@@ -34,6 +34,13 @@ const RECALC_STOCK_STATUS = 'recalculateStockStatus'
  * than a third branch in `recalculatePartCost` (29 §7).
  */
 const RECALC_PART_COST_TARIFF_RATE = 'recalculatePartCostFromTariffRate'
+/**
+ * Company enrichment reached from a FIELD write rather than the record's creation.
+ * Two declarations share one handler: `company_domain` (a domain arriving or being
+ * corrected) and `company_website` (a URL the domain can be derived from).
+ */
+const ENRICH_COMPANY_FROM_DOMAIN = 'enrichCompanyFromDomain'
+const ENRICH_COMPANY_FROM_WEBSITE = 'enrichCompanyFromWebsite'
 
 /** Adapt a native batch event to the legacy `FieldTriggerEvent` shape. */
 function asFieldTriggerEvent(
@@ -82,6 +89,17 @@ export function registerFieldSystemRules(): void {
       organizationId: event.organizationId,
       rateInstanceIds: event.recordIds.map((id) => parseRecordId(id).entityInstanceId),
     })
+  })
+
+  // Company enrichment, field doors. NOT routed through `fanOutEntityHandler`: it bails on
+  // any firing with no lifecycle `action`, and field firings carry none.
+  registerNativeRuleHandler(ENRICH_COMPANY_FROM_DOMAIN, async (event) => {
+    const { enqueueCompanyEnrichmentForRecords } = await import('./post/company-triggers')
+    await enqueueCompanyEnrichmentForRecords(event, 'domain-changed')
+  })
+  registerNativeRuleHandler(ENRICH_COMPANY_FROM_WEBSITE, async (event) => {
+    const { enqueueCompanyEnrichmentForRecords } = await import('./post/company-triggers')
+    await enqueueCompanyEnrichmentForRecords(event, 'website-changed')
   })
 
   declareSystemRules(FIELD_SYSTEM_RULES)
@@ -182,6 +200,36 @@ const FIELD_SYSTEM_RULES: SystemRuleDeclaration[] = [
     fieldRef: { systemAttribute: 'part_reorder_point' },
     on: 'changed',
     actions: [{ type: 'native', handler: RECALC_STOCK_STATUS }],
+  },
+  // ─── Company enrichment field doors ──────────────────────────────────
+  //
+  // `'changed'`, not `'set'`. `'set'` is `isEmpty(old) && !isEmpty(new)`, which misses a
+  // CORRECTION (`acme.com` to `acme.io`) — and a correction is exactly when the cached
+  // logo and description are wrong. On the interactive door the two behave identically
+  // anyway (the sentinel makes every transition match), so `'set'` would buy nothing and
+  // lose the case that matters.
+  //
+  // `skipOnCreate` suppresses the interactive create double-fire. It does NOT suppress the
+  // sync one: `handle-sync-record-rules.ts` never consults the flag, so an import creating
+  // a company with a domain fires this rule AND `company-created`. That is absorbed by the
+  // BullMQ jobId dedupe and the stored status, not here (see `companies/enrichment/guards.ts`).
+  {
+    key: 'company-domain-changed',
+    name: 'Enrich company when its domain changes',
+    defSlug: 'companies',
+    fieldRef: { systemAttribute: 'company_domain' },
+    on: 'changed',
+    skipOnCreate: true,
+    actions: [{ type: 'native', handler: ENRICH_COMPANY_FROM_DOMAIN }],
+  },
+  {
+    key: 'company-website-changed',
+    name: 'Enrich company when its website changes',
+    defSlug: 'companies',
+    fieldRef: { systemAttribute: 'company_website' },
+    on: 'changed',
+    skipOnCreate: true,
+    actions: [{ type: 'native', handler: ENRICH_COMPANY_FROM_WEBSITE }],
   },
 ]
 

--- a/packages/lib/src/jobs/enrichment/enrich-company-job.ts
+++ b/packages/lib/src/jobs/enrichment/enrich-company-job.ts
@@ -1,0 +1,38 @@
+// packages/lib/src/jobs/enrichment/enrich-company-job.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { EnrichCompanyJobData } from '../../companies'
+import { enrichCompany } from '../../companies'
+import type { JobContext } from '../types/job-context'
+
+const logger = createScopedLogger('enrich-company-job')
+
+/**
+ * Enrich one company from its website.
+ *
+ * ⚠️ NEVER THROWS. `enrichCompany` represents every failure as a terminal status on the
+ * record, so a throw here would only earn the job a BullMQ retry — and a retried website
+ * fetch is precisely the repeat traffic the guards exist to prevent. The catch is the
+ * belt to that braces.
+ */
+export async function enrichCompanyJob(ctx: JobContext<EnrichCompanyJobData>): Promise<void> {
+  const { organizationId, companyInstanceId, reason } = ctx.data
+
+  try {
+    const result = await enrichCompany({ organizationId, companyInstanceId, reason })
+    logger.debug('Enrichment job finished', {
+      jobId: ctx.jobId,
+      organizationId,
+      companyId: companyInstanceId,
+      reason,
+      ...result,
+    })
+  } catch (error) {
+    logger.error('Enrichment job threw', {
+      jobId: ctx.jobId,
+      organizationId,
+      companyId: companyInstanceId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/jobs/enrichment/index.ts
+++ b/packages/lib/src/jobs/enrichment/index.ts
@@ -1,0 +1,3 @@
+// packages/lib/src/jobs/enrichment/index.ts
+
+export { enrichCompanyJob } from './enrich-company-job'

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -124,6 +124,7 @@ export {
 export { createEmailEnqueuer, enqueueEmailJob } from './email/enqueue-email-job'
 export { sendEmailJob } from './email/send-email-job'
 export type { EmailPayloadByType, EmailType, SendEmailJobData } from './email/types'
+export { enrichCompanyJob } from './enrichment/enrich-company-job'
 // Data export job
 export { type ExportRecordsJobData, exportRecordsJob } from './export/export-records-job'
 // Data print job (PDF export — plans/printing/01-unified-print.md §D)
@@ -153,6 +154,8 @@ export {
   type AppStorageSweepStats,
   appStorageSweepJob,
 } from './maintenance/app-storage-sweep-job'
+// Money P24 vendor-bill aging daily sweep — `awaiting_receipt` -> `exception`
+export { companyEnrichmentSweepJob } from './maintenance/company-enrichment-sweep-job'
 // Per-request provider deletion / deauthorize teardown
 // (plans/channels/meta-data-deletion-callback.md §4.4). On-demand: enqueued by the
 // Meta signed_request routes and the Shopify compliance webhook, never scheduled.
@@ -253,7 +256,6 @@ export {
   sendTrialConversionEmailsJob,
   type TrialConversionStats,
 } from './maintenance/trial-conversion-job'
-// Money P24 vendor-bill aging daily sweep — `awaiting_receipt` -> `exception`
 export { vendorBillAgingJob } from './maintenance/vendor-bill-aging-job'
 export {
   type WebhookRenewalJobData,

--- a/packages/lib/src/jobs/maintenance/company-enrichment-sweep-job.ts
+++ b/packages/lib/src/jobs/maintenance/company-enrichment-sweep-job.ts
@@ -1,0 +1,27 @@
+// packages/lib/src/jobs/maintenance/company-enrichment-sweep-job.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { sweepCompaniesNeedingEnrichment } from '../../companies/enrichment/sweep'
+import type { JobContext } from '../types/job-context'
+
+const logger = createScopedLogger('company-enrichment-sweep-job')
+
+/**
+ * Daily gap-filling sweep for company enrichment.
+ *
+ * Every other enrichment door is event-driven (record created, `company_domain` changed,
+ * `company_website` changed, a manual click), so three populations have no path back:
+ * companies created before enrichment had that door, companies the per-org window limiter
+ * dropped during a large import, and companies stranded on `pending` by a worker that died
+ * mid-fetch. This is their only path.
+ *
+ * Scheduled nightly via `upsertJobScheduler` — see `apps/worker/src/workers/index.ts`.
+ * Idempotent: it selects only non-terminal records, and every record it enqueues reaches a
+ * terminal status (including `skipped` for the ones with no domain and no website), so a
+ * re-run after a failure re-selects strictly less.
+ */
+export async function companyEnrichmentSweepJob(ctx: JobContext): Promise<void> {
+  logger.info('Running company enrichment sweep', { jobId: ctx.jobId })
+  const summary = await sweepCompaniesNeedingEnrichment()
+  logger.info('Company enrichment sweep finished', { jobId: ctx.jobId, ...summary })
+}

--- a/packages/lib/src/jobs/queues/types.ts
+++ b/packages/lib/src/jobs/queues/types.ts
@@ -71,4 +71,10 @@ export enum Queues {
   // the call cannot run in the `message:received` gate (2s timeout, shared
   // `eventsQueue`) and must not hold `eventHandlersQueue` slots for seconds.
   mailClassificationQueue = 'mail-classification',
+  // Company website enrichment. Its OWN queue: one job is an outbound fetch of a
+  // third-party homepage plus a logo (8s + 5s worst case), and a bulk import can enqueue
+  // hundreds at once. Inline on the events worker, a 315-row import held one slot for the
+  // better part of an hour. `maintenanceQueue` is not an alternative — it runs at
+  // concurrency 1 shared with ~30 sweep jobs.
+  enrichmentQueue = 'enrichment',
 }


### PR DESCRIPTION
## The problem

Company enrichment only ever ran on `created`, and only when `company_domain` was already present in the create-time values:

```ts
// field-hooks/post/company-triggers.ts, before
const domain = event.values.company_domain
if (!domain || typeof domain !== 'string') { logger.debug('Skipping enrichment — no domain'); return }
```

`company_domain` has exactly one writer in the codebase: `findOrCreateCompanyByDomain`, the mail ingest path. So a company that did not arrive by email was unenrichable by construction, no matter what a user typed into `company_website` (which the enricher never read). The handler also returned before writing any status, so those records carried **no trace at all**.

In one production org the correlation is total:

| created | count | with domain | with logo | with notes | with status |
| --- | --- | --- | --- | --- | --- |
| mail ingest | 315 | 315 | 82 | 185 | 315 |
| import, relation auto-create | 17 | 0 | 0 | 0 | 0 |

Those 17 were minted by `mintTarget`, which writes exactly one field, the relation match field.

## The doors

| door | rule | note |
| --- | --- | --- |
| record created | `company-created` (renamed from `mfg-companies-created`) | unchanged behaviour |
| `company_domain` changed | `company-domain-changed` | `'changed'` not `'set'`, so a **correction** re-enriches |
| `company_website` changed | `company-website-changed` | derives the domain via the ingest classifier |
| manual | `record.enrichCompany` | `reason: 'manual'` bypasses the freshness windows |
| backfill | nightly sweep + `apps/worker/scripts/enrich-companies-backfill.ts` | |

All five funnel through one entry point, `enrichCompany`, which **reads live record state and never trusts the event**. Two reasons, both load-bearing:

1. `fanOutEntityHandler` builds `values` from `event.eventDataByRecordId?.[recordId] ?? {}`. Field firings carry no `eventData`, so a handler reading `event.values.company_domain` would see `{}` and skip every time.
2. The interactive field door carries no real values at all. It presents `INTERACTIVE_FIELD_WRITE` against `oldValue: undefined` so the transition always matches, meaning it fires when a user **clears** the domain exactly as loudly as when they set it.

## The throttle

Two doors fire more often than they look, and no rule-declaration trick fixes either:

- the sentinel above means every write of the field fires, including re-saving the same value
- `skipOnCreate` is honoured **only** on the interactive create path (`collect-triggers.ts:43`). The sync door splits rules into field/created/deleted buckets and never reads it, so an **import** creating a company with a domain fires the lifecycle rule *and* the field rule for the same record

So the guard sits in the work, not the declarations. Four layers, cheapest first:

| | mechanism | covers | hole it leaves |
| --- | --- | --- | --- |
| L1 | BullMQ `jobId` dedupe | the sync double-fire, save bursts | id frees on completion |
| L2 | Redis claim, 10 min, keyed on record + domain | repeated saves, in-flight overlap | evaporates on flush |
| L3 | stored status + TTL (30d enriched, 7d failed) | everything durable | none, this is the real answer |
| L4 | per-org 300/hour window | a 5,000-row import | writes no status, so the sweep drains it |

Plus a dedicated `enrichmentQueue` at concurrency 3. Run inline on the events worker (where it lived while `created` was the only door) `fanOutEntityHandler` awaited each record in turn, so a 315-row import held one events slot for the better part of an hour. `maintenanceQueue` was not an option: it runs at concurrency 1 shared with ~30 sweep jobs.

## Value sanity

A homepage is arbitrary third-party HTML and everything extracted lands on a customer record. Content-type must be HTML, empty bodies are rejected, text is trimmed / whitespace-collapsed / zero-width-stripped / length-banded, and a junk list catches what actually bites: Cloudflare interstitials (`Just a moment...`, `Attention Required!`), parked-page titles, and the domain echoed back.

A company with no domain and no usable website now gets the `skipped` status. That option **already existed in the enum and nothing wrote it** — which is exactly why the 17 import-minted companies were invisible rather than merely un-enriched.

## Verification

Live, against a real org. Websites were being typed into the UI while this was being built, which made for a better test than planned:

- **McMaster** — derived `mcmaster.com`, pulled the real McMaster-Carr description and logo
- **Mayan Hardwood**, **Hiland** — went through the running dev worker via the new `company_website` door with no manual involvement

Backfill dry-run found exactly 20 candidates, matching the analysis above (381 companies, 361 with a status).

Two bugs the tests caught before anything shipped:

- `domainFromUrl('mailto:sales@acme.com')` returned `acme.com`. Prefixing a scheme-carrying string with `https://` gives `https://mailto:sales@acme.com`, which parses cleanly with `mailto:sales` as userinfo and `acme.com` as the host — an email address silently becoming a company website.
- `isEmptyMetadata` counted the image candidates, but `faviconUrl` falls back to a hard-coded `/favicon.ico` guess and so is non-null for any page fetched at all. A site whose title was a bot wall and whose description was absent would have been recorded `enriched` (30-day lockout) instead of `failed` (7-day retry).

## Checks

- `pnpm --filter @auxx/lib typecheck`, `pnpm --filter @auxx/web typecheck` — no new errors
- `packages/lib` full suite: 15,407 passed. Two failures, both pre-existing and in the purchasing delete-guard area (`delete-guard-registration.test.ts` / `108-purchasing.test.ts`), neither naming a file this PR touches
- 28 new tests in `src/companies`, all pure (no db, no Redis, no `vi.mock`)

**No schema change and no migration.** `company_enrichment_status` already carried the `skipped` option and `company_enriched_at` already existed; both are in `activity-touch.ts`'s exclusion list, so enrichment writes still do not bump record activity.

## Not in this PR

The **"Enrich now" button is not wired.** `record.enrichCompany` exists and is authorized on `assertWriteEntity` for the company def, but no UI calls it yet — the natural home is the company detail page, most useful on records showing `skipped` or `failed`.

Door 6 from the plan (deriving domains for import-minted companies, which needs `mintTarget` to carry more than the match field) remains a separate follow-up.

https://claude.ai/code/session_018fWyUcbN6d4XrWDPayNBhY
