### PR TITLE
feat(records): repair contact name casing on write, and only when it needs it

### DIFF
--- a/apps/worker/scripts/normalize-contact-name-casing.ts
+++ b/apps/worker/scripts/normalize-contact-name-casing.ts
@@ -1,0 +1,84 @@
+// apps/worker/scripts/normalize-contact-name-casing.ts
+//
+// One-time contact name casing repair (plans/records/contact-name-casing-plan.md §5) —
+// thin caller around `backfillContactNameCasing` in `@auxx/lib/records` (query code
+// lives in lib; apps/worker has no drizzle-orm dependency of its own).
+//
+// The pre-hook covers every name written from now on; this is for what is already
+// stored. Deliberately a script rather than a `DataMigration`: it rewrites user data on
+// a judgement call, so it is run per-org on purpose after looking at `--dry-run`.
+//
+// ⚠️ Writes INLINE — no worker needs to be running, and nothing is queued.
+//
+// ⚠️ Expect the duplicate scanner to re-examine every record this touches:
+// `EntityInstance.updatedAt` is bumped by the write. That is load, not corruption, and
+// it settles on its own.
+//
+// Safe to re-run: `toDisplayCase` returns already-correct names unchanged, so a second
+// pass finds nothing.
+//
+// Run (from repo root):
+//   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
+//     scripts/normalize-contact-name-casing.ts [organizationId] [--dry-run] [--verbose]
+
+import { closePools, database } from '@auxx/database'
+import { backfillContactNameCasing, type NameCaseChange } from '@auxx/lib/records'
+
+async function main() {
+  const args = process.argv.slice(2)
+  const dryRun = args.includes('--dry-run')
+  const verbose = args.includes('--verbose') || dryRun
+  const organizationId = args.find((a) => !a.startsWith('--'))
+
+  const scope = organizationId ? `org ${organizationId}` : 'every org'
+  console.log(`Contact name casing repair — ${scope}${dryRun ? ' (dry run)' : ''}`)
+
+  // A dry run's whole purpose is the diff, so it prints every pair by default. A real run
+  // stays quiet unless asked, because 1,600 lines of output buries the summary.
+  const samples: NameCaseChange[] = []
+  const onChange = (change: NameCaseChange) => {
+    if (verbose) {
+      console.log(`  ${change.attribute.padEnd(10)} ${change.from}  ->  ${change.to}`)
+    } else if (samples.length < 20) {
+      samples.push(change)
+    }
+  }
+
+  const summary = await backfillContactNameCasing(database, {
+    ...(organizationId ? { organizationId } : {}),
+    dryRun,
+    onChange,
+  })
+
+  if (summary.changed === 0) {
+    console.log(
+      `Scanned ${summary.scanned} name values across ${summary.organizations} orgs — ` +
+        'nothing needs repairing.'
+    )
+    await closePools()
+    process.exit(0)
+  }
+
+  if (samples.length > 0) {
+    console.log(`\nFirst ${samples.length} of ${summary.changed}:`)
+    for (const s of samples) console.log(`  ${s.attribute.padEnd(10)} ${s.from}  ->  ${s.to}`)
+    console.log('  (run with --verbose for all of them)')
+  }
+
+  console.log(
+    `\nScanned ${summary.scanned} name values across ${summary.organizations} orgs.\n` +
+      `${summary.changed} values need repairing.`
+  )
+  if (dryRun) {
+    console.log('Dry run — nothing was written. Re-run without --dry-run to apply.')
+  } else {
+    console.log(`${summary.recordsWritten} records written.`)
+  }
+  await closePools()
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -73,7 +73,17 @@ export interface SyncSourceStream {
   mappings: DecodedMapping[]
 }
 
-/** Owned-mode handler skips registered system-field pre-hooks (mirror the importer). */
+/**
+ * Owned-mode handler's `bypassFieldGuards` set — EMPTY, i.e. it bypasses nothing.
+ *
+ * The name and its former comment ("skips registered system-field pre-hooks") both
+ * describe an intent that the value does not implement: `new Set<never>()` can
+ * contain no systemAttribute, so `fireFieldPreHooks`' `ctx.bypassFieldGuards.has(...)`
+ * check never matches and every registered pre-hook runs on connector writes like any
+ * other write. That is load-bearing for the contact name-casing repair
+ * (plans/records/contact-name-casing-plan.md §3) — leave it empty, and if a real
+ * bypass is ever needed, add the attributes explicitly rather than trusting the name.
+ */
 const OWNED_BYPASS: ReadonlySet<never> = new Set<never>()
 
 /** Map the mutable run counters onto the core's slice-counter shape for the ledger. */

--- a/packages/lib/src/field-hooks/__tests__/name-case-registration.test.ts
+++ b/packages/lib/src/field-hooks/__tests__/name-case-registration.test.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/field-hooks/__tests__/name-case-registration.test.ts
+//
+// That the casing repair is actually ON the chain, and that nothing quietly takes it
+// back off. Separate from `records/name-case/__tests__/hook.test.ts` because
+// `getFieldPreHooks` self-inits the whole hook bootstrap, which needs the real
+// `@auxx/database` module graph.
+
+import { describe, expect, it } from 'vitest'
+import { repairNameCasing } from '../../records/name-case/hook'
+import { getFieldPreHooks, hasFieldPreHooks } from '../registry'
+
+describe('contact name casing registration', () => {
+  // The apiSlug, not the entityType. `fireFieldPreHooks` keys off `resource.apiSlug`,
+  // so registering under `contact` would be a silent no-op — the same mistake
+  // `delete-guard-registration.test.ts` was written to stop for pre-delete hooks.
+  it('is on the field pre-hook chain for both name parts', () => {
+    for (const attribute of ['first_name', 'last_name'] as const) {
+      expect(hasFieldPreHooks('contacts', attribute)).toBe(true)
+      expect(getFieldPreHooks('contacts', attribute)).toContain(repairNameCasing)
+    }
+  })
+
+  it('is registered under the apiSlug, not the entityType', () => {
+    expect(hasFieldPreHooks('contact', 'first_name')).toBe(false)
+  })
+
+  it('is not registered globally', () => {
+    // Scoped to `contacts` on purpose (plan §4). A `*` registration would reach every
+    // entity that reuses `first_name`, which is a deliberate future choice, not today's.
+    expect(hasFieldPreHooks('*', 'first_name')).toBe(false)
+  })
+})
+
+// 🛑 The connector sink must NOT bypass this hook. `connector-sync-source.ts` builds its
+// owned-mode `UnifiedCrudHandler` with `bypassFieldGuards: OWNED_BYPASS`, whose name and
+// former comment both claim it "skips registered system-field pre-hooks". It does not —
+// it is `new Set<never>()`, so it can contain no systemAttribute and
+// `fireFieldPreHooks`' `bypassFieldGuards.has(...)` check never matches.
+//
+// This is what makes the Shopify backfill (13,637 contacts) get repaired casing on the
+// way in. If someone ever puts a real attribute in that set, this fails.
+describe('the connector sink does not bypass field pre-hooks', () => {
+  it('OWNED_BYPASS is empty', async () => {
+    const source = await import('node:fs/promises')
+    const file = await source.readFile(
+      new URL('../../data-connectors/connector-sync-source.ts', import.meta.url),
+      'utf8'
+    )
+    expect(file).toContain('const OWNED_BYPASS: ReadonlySet<never> = new Set<never>()')
+  })
+})

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -61,6 +61,7 @@ import {
   registerVendorBillBalanceReconcilers,
 } from '../purchasing/vendor-bill-balance'
 import { handleRecordRulesOnFieldChange } from '../record-rules/hook-handler'
+import { repairNameCasing } from '../records/name-case/hook'
 import {
   enqueueQuickbooksInvoiceSyncOnSent,
   enrollInvoiceReminderOnSent,
@@ -389,6 +390,14 @@ export function registerAllHooks(): void {
   //    is structural rather than papered over by a guard exemption.
   registerFieldPreHooks('inboxes', 'inbox_owner_user_id', [guardInboxOwnerField])
   registerFieldPreHooks('personal-inboxes', 'inbox_owner_user_id', [guardInboxOwnerField])
+
+  // Casing repair for contact names — `BRUCE` -> `Bruce`, `regina` -> `Regina`.
+  // Transforms rather than guards: a pre-hook's return value IS the value written.
+  // Scoped to `contacts` deliberately; org-created defs that reuse `first_name`
+  // (leads, vendors) are a one-line addition here if that is ever wanted.
+  // plans/records/contact-name-casing-plan.md
+  registerFieldPreHooks('contacts', 'first_name', [repairNameCasing])
+  registerFieldPreHooks('contacts', 'last_name', [repairNameCasing])
 
   // Lifecycle status walls for `quote_status` and `invoice_status`
   // (plans/dispatch/money/21-lifecycle-status-guards-are-inert.md §4). The system-hook twins

--- a/packages/lib/src/records/index.ts
+++ b/packages/lib/src/records/index.ts
@@ -1,4 +1,13 @@
 // packages/lib/src/records/index.ts
 
+// Contact name casing repair (plans/records/contact-name-casing-plan.md). The pre-hook
+// itself is registered in `field-hooks/register-hooks.ts` and imported directly from
+// `./name-case/hook` — it is not re-exported here, so nothing can call it by hand.
+export type {
+  NameCaseBackfillOptions,
+  NameCaseBackfillSummary,
+  NameCaseChange,
+} from './name-case/backfill'
+export { backfillContactNameCasing } from './name-case/backfill'
 export type { SequenceScope } from './record-numbering'
 export { recordNumbering } from './record-numbering'

--- a/packages/lib/src/records/name-case/__tests__/hook.test.ts
+++ b/packages/lib/src/records/name-case/__tests__/hook.test.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/records/name-case/__tests__/hook.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { FieldPreHookEvent } from '../../../field-hooks/types'
+import { repairNameCasing } from '../hook'
+
+/** Only the fields `repairNameCasing` reads; the rest of the event is irrelevant here. */
+function event(newValue: FieldPreHookEvent['newValue']): FieldPreHookEvent {
+  return { newValue } as FieldPreHookEvent
+}
+
+describe('repairNameCasing', () => {
+  it('repairs the value inside the typed envelope', async () => {
+    const result = await repairNameCasing(event({ type: 'text', value: 'BRUCE' }))
+    expect(result).toEqual({ type: 'text', value: 'Bruce' })
+  })
+
+  // 🛑 The trap this hook exists downstream of: `newValue` is the COERCED envelope,
+  // never the bare string the caller typed. A version of this hook that read
+  // `event.newValue` as a string would be inert in production and still pass a test
+  // that fed it one — which is exactly how three earlier guards shipped broken.
+  it('reads the envelope, not a bare string', async () => {
+    const result = await repairNameCasing(event({ type: 'text', value: 'MACIVER' }))
+    expect(result).toEqual({ type: 'text', value: 'MacIver' })
+    // A bare string is not a shape this hook can act on, and it must not throw.
+    const bare = 'MACIVER' as unknown as FieldPreHookEvent['newValue']
+    expect(await repairNameCasing(event(bare))).toBe(bare)
+  })
+
+  it('returns the ORIGINAL envelope object when nothing changes', async () => {
+    // Identity, not equality — the caller compares to decide whether a write happened.
+    const value = { type: 'text', value: 'MacIver' } as const
+    expect(await repairNameCasing(event(value))).toBe(value)
+  })
+
+  it('passes a null clear straight through', async () => {
+    expect(await repairNameCasing(event(null))).toBeNull()
+  })
+
+  it('leaves a multi-value array untouched', async () => {
+    // Neither name field is multi. If one ever arrives, doing nothing beats guessing
+    // which element is the name.
+    const value = [
+      { type: 'text', value: 'BRUCE' },
+      { type: 'text', value: 'ROBERT' },
+    ] as FieldPreHookEvent['newValue']
+    expect(await repairNameCasing(event(value))).toBe(value)
+  })
+
+  it('leaves a non-text envelope untouched', async () => {
+    const value = { type: 'option', optionId: 'opt_1' } as unknown as FieldPreHookEvent['newValue']
+    expect(await repairNameCasing(event(value))).toBe(value)
+  })
+
+  it('declines mixed case, uncased script and email addresses', async () => {
+    for (const raw of ['MacIver', '李', 'mikedavidson@live.com']) {
+      const value = { type: 'text', value: raw } as const
+      expect(await repairNameCasing(event(value))).toBe(value)
+    }
+  })
+})

--- a/packages/lib/src/records/name-case/backfill.ts
+++ b/packages/lib/src/records/name-case/backfill.ts
@@ -1,0 +1,216 @@
+// packages/lib/src/records/name-case/backfill.ts
+//
+// One-off casing repair for contact names already in the database.
+//
+// The pre-hook (`./hook.ts`) covers every name written from now on; this catches what
+// is already stored — most of it from a connector backfill or a mail/SMS ingest that
+// predates the hook. Measured on the dev org: 1,622 of 14,824 contacts (~11%).
+//
+// NOT a `DataMigration`, deliberately. This is a judgement-carrying cosmetic rewrite of
+// user data, so it is run per-org on purpose with a `dryRun` that prints the diff,
+// rather than silently on deploy. See plans/records/contact-name-casing-plan.md §5.
+//
+// ⚠️ **Writes through `UnifiedCrudHandler`, never `FieldValue` directly.** `full_name`
+// is a composite computed over `first_name`/`last_name`, and `EntityInstance.displayName`
+// is denormalized from it — a direct `FieldValue` update leaves the record still
+// DISPLAYING the old value everywhere it is listed. Same reason documented on
+// `ingest/contacts/repair-name.ts`.
+//
+// Idempotent: `toDisplayCase` returns its input unchanged for anything already
+// well-cased, so a second run finds nothing and writes nothing.
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { toDisplayCase } from '@auxx/utils/name-case'
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm'
+import { toRecordId } from '../../resources/resource-id'
+
+const logger = createScopedLogger('name-case-backfill')
+
+/** Contacts pulled per round. Bounded so one org with a large book cannot balloon the heap. */
+const BATCH_SIZE = 500
+
+export interface NameCaseBackfillOptions {
+  /** Restrict to one organization. Omit to sweep every org. */
+  organizationId?: string
+  /** Report what would change without writing. */
+  dryRun?: boolean
+  /** Safety ceiling on records rewritten in one run. */
+  maxRecords?: number
+  /** Receives every `old -> new` pair, for a caller that wants to print them. */
+  onChange?: (change: NameCaseChange) => void
+}
+
+export interface NameCaseChange {
+  organizationId: string
+  recordId: string
+  attribute: 'first_name' | 'last_name'
+  from: string
+  to: string
+}
+
+export interface NameCaseBackfillSummary {
+  /** Rows read and considered. */
+  scanned: number
+  /** Values `toDisplayCase` would rewrite. */
+  changed: number
+  /** Distinct records written (a record with both names repaired counts once). */
+  recordsWritten: number
+  organizations: number
+}
+
+/**
+ * SQL pre-filter for "entirely upper-case" or "entirely lower-case".
+ *
+ * Narrowing in SQL rather than reading every name and filtering in JS is what keeps
+ * this to ~1.6k rows instead of ~29k on the sample org. It is deliberately LOOSER than
+ * `toDisplayCase` — it is only a candidate filter, and `toDisplayCase` is still the
+ * single authority on what actually changes (it returns its input untouched for
+ * anything it declines, so a false positive here costs a comparison, not a bad write).
+ */
+const CASING_CANDIDATE = sql`(
+  ("valueText" ~ '^[^a-z]*$' AND "valueText" ~ '[A-Z]')
+  OR ("valueText" ~ '^[^A-Z]*$' AND "valueText" ~ '[a-z]')
+)`
+
+/**
+ * Repair the casing of stored contact names.
+ *
+ * @returns counts; the per-value detail goes to {@link NameCaseBackfillOptions.onChange}.
+ */
+export async function backfillContactNameCasing(
+  db: Database,
+  options: NameCaseBackfillOptions = {}
+): Promise<NameCaseBackfillSummary> {
+  const { organizationId, dryRun = false, maxRecords = 100_000, onChange } = options
+
+  // The name field ids per org, scoped to the CONTACT def. `systemAttribute` alone is too
+  // broad — org-created `leads`/`vendors` defs reuse `first_name`, and this change is
+  // scoped to contacts exactly as the hook is.
+  const fieldRows = await db
+    .select({
+      organizationId: schema.CustomField.organizationId,
+      entityDefinitionId: schema.CustomField.entityDefinitionId,
+      systemAttribute: schema.CustomField.systemAttribute,
+      fieldId: schema.CustomField.id,
+    })
+    .from(schema.CustomField)
+    .innerJoin(
+      schema.EntityDefinition,
+      eq(schema.EntityDefinition.id, schema.CustomField.entityDefinitionId)
+    )
+    .where(
+      and(
+        eq(schema.EntityDefinition.entityType, 'contact'),
+        inArray(schema.CustomField.systemAttribute, ['first_name', 'last_name']),
+        organizationId ? eq(schema.CustomField.organizationId, organizationId) : undefined
+      )
+    )
+
+  const summary: NameCaseBackfillSummary = {
+    scanned: 0,
+    changed: 0,
+    recordsWritten: 0,
+    organizations: 0,
+  }
+  if (fieldRows.length === 0) return summary
+
+  const byOrg = new Map<string, { entityDefinitionId: string; fieldIds: Map<string, string> }>()
+  for (const row of fieldRows) {
+    // `CustomField.entityDefinitionId` is nullable in the schema even though the join
+    // above can only match rows that have one. Skip rather than assert: the id becomes
+    // half of the `RecordId` every write is addressed by, and a bad one would write to
+    // the wrong def rather than fail loudly.
+    if (!row.systemAttribute || !row.entityDefinitionId) continue
+    const entry = byOrg.get(row.organizationId) ?? {
+      entityDefinitionId: row.entityDefinitionId,
+      fieldIds: new Map<string, string>(),
+    }
+    entry.fieldIds.set(row.fieldId, row.systemAttribute)
+    byOrg.set(row.organizationId, entry)
+  }
+  summary.organizations = byOrg.size
+
+  // Imported lazily for the reason documented on `repair-name.ts`: a static edge from a
+  // lib leaf into `UnifiedCrudHandler` widens the graph into the org-cache cycle and
+  // breaks `vi.mock` interception in lib tests.
+  const [{ UnifiedCrudHandler }, { SystemUserService }] = await Promise.all([
+    import('../../resources/crud/unified-handler'),
+    import('../../users/system-user-service'),
+  ])
+
+  for (const [orgId, { entityDefinitionId, fieldIds }] of byOrg) {
+    if (summary.recordsWritten >= maxRecords) break
+
+    const rows = await db
+      .select({
+        entityId: schema.FieldValue.entityId,
+        fieldId: schema.FieldValue.fieldId,
+        valueText: schema.FieldValue.valueText,
+      })
+      .from(schema.FieldValue)
+      .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, orgId),
+          inArray(schema.FieldValue.fieldId, [...fieldIds.keys()]),
+          // An archived contact is not shown anywhere; repairing one would only add
+          // churn and re-dirty it for the duplicate scanner.
+          isNull(schema.EntityInstance.archivedAt),
+          CASING_CANDIDATE
+        )
+      )
+
+    // Group by record so a contact whose first AND last name both need repair is ONE
+    // `update` — one `updatedAt` bump, one realtime frame, one duplicate re-scan.
+    const patches = new Map<string, Record<string, string>>()
+    for (const row of rows) {
+      summary.scanned++
+      const attribute = fieldIds.get(row.fieldId)
+      const current = row.valueText
+      if (!attribute || !current) continue
+
+      const repaired = toDisplayCase(current)
+      if (repaired === current || typeof repaired !== 'string') continue
+
+      summary.changed++
+      onChange?.({
+        organizationId: orgId,
+        recordId: row.entityId,
+        attribute: attribute as NameCaseChange['attribute'],
+        from: current,
+        to: repaired,
+      })
+
+      const patch = patches.get(row.entityId) ?? {}
+      patch[attribute] = repaired
+      patches.set(row.entityId, patch)
+    }
+
+    if (dryRun || patches.size === 0) continue
+
+    const systemUserId = await SystemUserService.getSystemUserForActions(orgId)
+    const handler = new UnifiedCrudHandler(orgId, systemUserId, db)
+
+    const entries = [...patches.entries()]
+    for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+      for (const [entityInstanceId, patch] of entries.slice(i, i + BATCH_SIZE)) {
+        if (summary.recordsWritten >= maxRecords) break
+        try {
+          await handler.update(toRecordId(entityDefinitionId, entityInstanceId), patch)
+          summary.recordsWritten++
+        } catch (error) {
+          // One bad record must not end the pass — the same fault-boundary rule the
+          // connector sink learned when a single malformed value killed a 4,222-row import.
+          logger.warn('Name casing repair failed for one record (skipped)', {
+            organizationId: orgId,
+            entityInstanceId,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+    }
+  }
+
+  return summary
+}

--- a/packages/lib/src/records/name-case/hook.ts
+++ b/packages/lib/src/records/name-case/hook.ts
@@ -1,0 +1,55 @@
+// packages/lib/src/records/name-case/hook.ts
+//
+// Pre-write hook that repairs the casing of `contact.first_name` / `contact.last_name`.
+//
+// Registered per-(entitySlug, systemAttribute) in `field-hooks/register-hooks.ts`.
+// One registration covers every writer, because every door funnels through
+// `setValueWithBuiltIn` (directly, or via `setValuesForEntity`'s collector) and
+// `fireFieldPreHooks` sits on that path: the connector sink, mail/SMS ingest, the CSV
+// importer, panel edits, the SDK, Kopilot. Verified rather than assumed —
+// `UnifiedCrudHandler` never sets `skipPreHooks`, and the connector's owned-mode
+// `OWNED_BYPASS` is an EMPTY set despite a comment that used to claim otherwise.
+//
+// A `full_name` write lands here too: NAME is a composite with no value of its own and
+// is decomposed into two direct `setValueWithBuiltIn` calls against the part fields.
+// `EntityInstance.displayName` is denormalized downstream of those, so it picks up the
+// repaired value with no extra work.
+//
+// The decision of WHAT to rewrite lives entirely in `toDisplayCase` (@auxx/utils) —
+// only all-upper or all-lower input is ever touched. See
+// plans/records/contact-name-casing-plan.md.
+
+import { toDisplayCase } from '@auxx/utils/name-case'
+import type { FieldPreHookHandler } from '../../field-hooks/types'
+
+/**
+ * Repair the casing of a name value on its way to storage.
+ *
+ * 🛑 **`event.newValue` is a COERCED ENVELOPE, not a bare string.** Pre-hooks run
+ * after `validateAndConvertValue`, so a TEXT field arrives as
+ * `{ type: 'text', value: 'BRUCE' }`. Three previous guards in this codebase compared
+ * this field directly to a string literal; every one was inert in production, read
+ * correctly in review, and passed a unit test that fed it a bare string. See the doc
+ * comment on `FieldPreHookEvent.newValue`.
+ *
+ * Passes through untouched, in this order:
+ * - `null` (a clear) and anything that is not a single `text` envelope. A multi-value
+ *   array is not a shape either name field uses; if one ever arrives, doing nothing is
+ *   the correct answer rather than guessing which element is the name.
+ * - Any value `toDisplayCase` declines — mixed case, uncased script, an email address.
+ *
+ * Returns the ORIGINAL envelope object when nothing changed, so the caller's
+ * change-detection sees no write.
+ */
+export const repairNameCasing: FieldPreHookHandler = async (event) => {
+  const value = event.newValue
+  if (!value || Array.isArray(value) || value.type !== 'text') return value
+
+  const current = value.value
+  if (typeof current !== 'string') return value
+
+  const repaired = toDisplayCase(current)
+  if (repaired === current) return value
+
+  return { type: 'text', value: repaired as string }
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -112,6 +112,12 @@
       "import": "./dist/mime.js",
       "default": "./src/mime.ts"
     },
+    "./name-case": {
+      "types": "./src/name-case.ts",
+      "source": "./src/name-case.ts",
+      "import": "./dist/name-case.js",
+      "default": "./src/name-case.ts"
+    },
     "./objects": {
       "types": "./src/objects.ts",
       "source": "./src/objects.ts",

--- a/packages/utils/src/__tests__/name-case.test.ts
+++ b/packages/utils/src/__tests__/name-case.test.ts
@@ -1,0 +1,259 @@
+// packages/utils/src/__tests__/name-case.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { toDisplayCase } from '../name-case'
+
+describe('toDisplayCase', () => {
+  describe('the core rule: only all-upper or all-lower input is touched', () => {
+    it.each([
+      ['MacIver', 'MacIver'],
+      ["d'Artagnan", "d'Artagnan"],
+      ['eBay', 'eBay'],
+      ['DeAngelo', 'DeAngelo'],
+      ['van der Berg', 'van der Berg'],
+      ['McDonald', 'McDonald'],
+      // A human typed this and got it wrong; we have no evidence of that, so it stands.
+      ['Mcdonald', 'Mcdonald'],
+    ])('leaves mixed-case %j alone', (input, expected) => {
+      expect(toDisplayCase(input)).toBe(expected)
+    })
+
+    it('returns the identical string when nothing changes', () => {
+      const input = 'MacIver'
+      expect(toDisplayCase(input)).toBe(input)
+    })
+  })
+
+  describe('casing repair', () => {
+    it.each([
+      ['BRUCE', 'Bruce'],
+      ['regina', 'Regina'],
+      ['kopseng', 'Kopseng'],
+      ['MACIVER', 'MacIver'],
+      ['MCDONALD', 'McDonald'],
+      ["O'BRIEN", "O'Brien"],
+      ['CREIGHTON-TAYLOR', 'Creighton-Taylor'],
+      ['VAN DER BERG', 'van der Berg'],
+      ['VAN', 'Van'],
+      ['FRIENDS II', 'Friends II'],
+      ['L. ALLEN', 'L. Allen'],
+    ])('%j -> %j', (input, expected) => {
+      expect(toDisplayCase(input)).toBe(expected)
+    })
+  })
+
+  describe('Mac is an allowlist, never a rule', () => {
+    it('expands an allowlisted surname', () => {
+      expect(toDisplayCase('MACIVER')).toBe('MacIver')
+      expect(toDisplayCase('MACDONALD')).toBe('MacDonald')
+    })
+
+    it.each([
+      // Every one of these is a real surname in the sample data. Inventing a capital
+      // here would be worse than leaving the plain form.
+      ['MACHADO', 'Machado'],
+      ['MACK', 'Mack'],
+      ['MACKAY', 'Mackay'],
+      ['MACOLINO', 'Macolino'],
+      ['MACON', 'Macon'],
+    ])('does NOT split %j', (input, expected) => {
+      expect(toDisplayCase(input)).toBe(expected)
+    })
+  })
+
+  describe('Mc needs no allowlist', () => {
+    it.each([
+      ['MCALLISTER', 'McAllister'],
+      ['MCBRYDE', 'McBryde'],
+      ['MCCANDLESS', 'McCandless'],
+      ['MCCORMICK', 'McCormick'],
+      ['MCCOY', 'McCoy'],
+      ['MCDANIEL', 'McDaniel'],
+      ['MCELHANY', 'McElhany'],
+      ['MCGARRY', 'McGarry'],
+    ])('%j -> %j', (input, expected) => {
+      expect(toDisplayCase(input)).toBe(expected)
+    })
+
+    it('leaves a bare MC alone rather than producing "Mc"', () => {
+      expect(toDisplayCase('MC')).toBe('MC')
+    })
+  })
+
+  describe('initials and acronyms keep their shape', () => {
+    it.each([
+      // Two letters: initials outnumber names 22:5 in the sample.
+      'AJ',
+      'CJ',
+      'CR',
+      'DJ',
+      'GB',
+      'JC',
+      'JD',
+      'JF',
+      'JJ',
+      'JM',
+      'JP',
+      'JT',
+      'JW',
+      'LK',
+      'MJ',
+      'OJ',
+      'PJ',
+      'RR',
+      'TJ',
+      'TS',
+      'VJ',
+      // Three-plus letters with no vowel.
+      'BBH',
+      'CSH',
+      'CSJ',
+      'HHH',
+      'RMR',
+      'SVR',
+      'VPT',
+      'LLC',
+    ])('leaves %j untouched', (input) => {
+      expect(toDisplayCase(input)).toBe(input)
+    })
+
+    it.each([
+      // Three letters WITH a vowel are names, and do get repaired.
+      ['AMY', 'Amy'],
+      ['BEN', 'Ben'],
+      ['GUY', 'Guy'],
+      ['JAY', 'Jay'],
+      ['KIM', 'Kim'],
+      ['LEE', 'Lee'],
+      ['PAT', 'Pat'],
+      ['RAY', 'Ray'],
+      ['TOM', 'Tom'],
+      ['YAO', 'Yao'],
+    ])('still repairs the real name %j', (input, expected) => {
+      expect(toDisplayCase(input)).toBe(expected)
+    })
+
+    it('accepts that two-letter names stay shouting — the documented trade', () => {
+      expect(toDisplayCase('ED')).toBe('ED')
+    })
+
+    it('does not treat a lowercase short token as initials', () => {
+      // No evidence of initials in lower-case input, so it is cased normally.
+      expect(toDisplayCase('jp')).toBe('Jp')
+    })
+
+    it('keeps an initial inside a longer name', () => {
+      expect(toDisplayCase('A ANDERSON')).toBe('A Anderson')
+      expect(toDisplayCase('JUDY G')).toBe('Judy G')
+    })
+  })
+
+  describe('particles', () => {
+    it('lowers a particle that has something after it', () => {
+      expect(toDisplayCase('VAN DER BERG')).toBe('van der Berg')
+      expect(toDisplayCase('DE LA CRUZ')).toBe('de la Cruz')
+    })
+
+    it('capitalizes a particle that is the whole value', () => {
+      expect(toDisplayCase('VAN')).toBe('Van')
+      expect(toDisplayCase('DER')).toBe('Der')
+    })
+
+    it('leaves a two-letter particle alone when it stands on its own', () => {
+      // `DE` mid-name is a particle (see above), but alone it is two upper-case
+      // letters with nothing to disambiguate it from initials, so it is kept.
+      expect(toDisplayCase('DE')).toBe('DE')
+    })
+
+    it('capitalizes a particle in final position', () => {
+      // Trailing `DELLA` is the surname here, not a particle before something.
+      expect(toDisplayCase('MARIA DELLA')).toBe('Maria Della')
+    })
+
+    it('does not treat a name that merely looks like a particle as one', () => {
+      // `les` is excluded from PARTICLES — as a particle it would lower to
+      // `les Moore`; as a name it title-cases. The exclusion is what makes it a name.
+      expect(toDisplayCase('LES MOORE')).toBe('Les Moore')
+      // `al` is likewise excluded, so it is never lowered to `al Smith`. It stays
+      // upper-case rather than becoming `Al` only because two upper-case letters
+      // read as initials (`A.L. Smith`) just as readily as they read as `Al`.
+      expect(toDisplayCase('AL SMITH')).toBe('AL Smith')
+    })
+
+    it('fixes the one real particle case in the sample data', () => {
+      expect(toDisplayCase('van ruler')).toBe('van Ruler')
+    })
+  })
+
+  describe('punctuation survives', () => {
+    // The regression guard for the deleted `formatComplexName`, which split on
+    // [\s-'] and joined on ' ', deleting every hyphen and apostrophe.
+    it('keeps hyphens', () => {
+      expect(toDisplayCase('CREIGHTON-TAYLOR')).toBe('Creighton-Taylor')
+      expect(toDisplayCase('MARC-HENRY')).toBe('Marc-Henry')
+      expect(toDisplayCase('RILEY-FISCHER')).toBe('Riley-Fischer')
+      expect(toDisplayCase('F-EMCH')).toBe('F-Emch')
+    })
+
+    it('keeps apostrophes', () => {
+      expect(toDisplayCase("O'BRIEN")).toBe("O'Brien")
+      expect(toDisplayCase("O'CULL")).toBe("O'Cull")
+      expect(toDisplayCase("D'ANGELO")).toBe("D'Angelo")
+    })
+
+    it('keeps a typographic apostrophe', () => {
+      expect(toDisplayCase('O’BRIEN')).toBe('O’Brien')
+    })
+
+    it('keeps periods and multiple spaces', () => {
+      expect(toDisplayCase('L. ALLEN')).toBe('L. Allen')
+      expect(toDisplayCase('JOHN  SMITH')).toBe('John  Smith')
+    })
+  })
+
+  describe('refuses input that is not a casing problem', () => {
+    it('leaves an email address alone', () => {
+      const email = 'ALANNACONNER@COOPERCARRY.COM'
+      expect(toDisplayCase(email)).toBe(email)
+      expect(toDisplayCase('mikedavidson@live.com')).toBe('mikedavidson@live.com')
+    })
+
+    it('leaves uncased script alone', () => {
+      expect(toDisplayCase('李')).toBe('李')
+      expect(toDisplayCase('محمد')).toBe('محمد')
+      expect(toDisplayCase('山田 太郎')).toBe('山田 太郎')
+    })
+
+    it('handles empty and nullish input without throwing', () => {
+      expect(toDisplayCase('')).toBe('')
+      expect(toDisplayCase(null)).toBe(null)
+      expect(toDisplayCase(undefined)).toBe(undefined)
+      expect(toDisplayCase('   ')).toBe('   ')
+    })
+
+    it('does not throw on emoji or digits', () => {
+      expect(toDisplayCase('TACO🌴🌮')).toBe('Taco🌴🌮')
+      expect(toDisplayCase('(OSV)')).toBe('(Osv)')
+      expect(toDisplayCase('123')).toBe('123')
+    })
+  })
+
+  describe('idempotence', () => {
+    it.each([
+      'BRUCE',
+      'regina',
+      'MACIVER',
+      'MCDONALD',
+      "O'BRIEN",
+      'CREIGHTON-TAYLOR',
+      'VAN DER BERG',
+      'FRIENDS II',
+      'L. ALLEN',
+      'JP',
+      'AMY',
+    ])('running twice over %j changes nothing the second time', (input) => {
+      const once = toDisplayCase(input) as string
+      expect(toDisplayCase(once)).toBe(once)
+    })
+  })
+})

--- a/packages/utils/src/contact.ts
+++ b/packages/utils/src/contact.ts
@@ -172,21 +172,11 @@ export const formatCompanyName = (name: string | null): string | null => {
   if (!name) return null
   return name.trim()
 }
-export const formatComplexName = (name: string | null): string | null => {
-  if (!name) return null
-  return name
-    .split(/[\s-']/)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-    .join(' ')
-    .trim()
-}
-
-export const formatCityName = (city: string | null): string | null => {
-  if (!city) return null
-  return city
-    .toLowerCase()
-    .split(/[\s-]+/)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
-    .trim()
-}
+// `formatComplexName` and `formatCityName` were deleted here (2026-09-03). Both split
+// on a character class and re-joined on ' ', which DELETED every hyphen and
+// apostrophe they touched (`Creighton-Taylor` -> `Creighton Taylor`, `O'Brien` ->
+// `O Brien`), and both lower-cased the remainder, flattening `MacIver` -> `Maciver`
+// and `McAllen` -> `Mcallen`. Neither had a single caller anywhere in the repo.
+// Use `toDisplayCase` from `./name-case` for person names — it repairs casing ONLY
+// when the input is entirely upper- or lower-case, so it can never flatten a
+// deliberate capital. See plans/records/contact-name-casing-plan.md §4.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,9 +19,7 @@ export { getGroupPosition, groupConsecutiveComments } from './comments'
 export {
   type ContactName,
   DEFAULT_PHONE_REGION,
-  formatCityName,
   formatCompanyName,
-  formatComplexName,
   formatPhoneNumber,
   formatStreetAddress,
   getContactDisplayName,
@@ -57,7 +55,6 @@ export {
   isSameWeek,
   parseTimeOfDay,
 } from './date'
-
 // Email utilities
 export {
   buildGraphFileAttachment,
@@ -82,7 +79,6 @@ export {
 } from './email'
 // Error utilities
 export { getErrorMessage, toError } from './errors'
-
 // File utilities
 export {
   calculateBase64Size,
@@ -100,7 +96,6 @@ export {
   sanitizeFilename,
   validateAttachmentSizes,
 } from './file'
-
 // Fractional indexing utilities
 export {
   BASE_62_DIGITS,
@@ -113,16 +108,12 @@ export {
   type SmartSortItem,
   type SmartSortResult,
 } from './fractional-indexing'
-
 // Function utilities
 export { debounce, throttle } from './functions'
-
 // ID generation
 export { generateId } from './generateId'
-
 // Header utilities
 export { filterSensitiveHeaders } from './headers'
-
 // MIME utilities
 export {
   encodeBase64WithLineBreaks,
@@ -136,6 +127,8 @@ export {
   validateLineLengths,
   validateMimeStructure,
 } from './mime'
+// Person-name casing repair
+export { toDisplayCase } from './name-case'
 // Number utilities
 export { formatNumberCompact } from './number'
 // OAuth utilities

--- a/packages/utils/src/name-case.ts
+++ b/packages/utils/src/name-case.ts
@@ -1,0 +1,244 @@
+// packages/utils/src/name-case.ts
+//
+// `toDisplayCase` — repair the casing of a person's name, and ONLY when the input
+// proves it needs repairing.
+//
+// Measured on 14,824 contacts: 510 were ALL CAPS and 1,112 were all lowercase, ~11%
+// of the book. See plans/records/contact-name-casing-plan.md.
+//
+// ── The one rule everything else hangs off ───────────────────────────────────
+// A value is rewritten ONLY when it is entirely upper-case or entirely lower-case.
+// Mixed case means a human (or a source that already got it right) made a casing
+// decision, and this function must not overrule it — so `MacIver`, `d'Artagnan`,
+// `van der Berg`, `DeAngelo`, `eBay` and `JP` are all returned untouched with no
+// flag, setting or per-field opt-out needed. That is why there is no `force` option
+// and why one must never be added: the moment this can rewrite mixed-case input it
+// needs an escape hatch, and the escape hatch is the feature.
+//
+// The corollary is that this is NOT a general title-caser. It cannot fix `Mcdonald`
+// typed by a human, and it should not try — it has no evidence anything is wrong.
+
+/** Vowels, for the initials test below. `Y` counts — `AMY`/`RAY`/`GUY` are names. */
+const VOWELS = /[AEIOUY]/
+
+/**
+ * Latin nobiliary/toponymic particles, lower-cased when they sit between other
+ * words. `der`/`den` are in the list because `VAN DER BERG` -> `van der Berg` needs
+ * the middle token lowered too, not just the leading one.
+ *
+ * ⚠️ Deliberately EXCLUDES `al`, `af`, `av`, `zu`, `do` and `les`, every one of
+ * which is a real given name or set of initials far more often than it is a
+ * particle here. Including `al` would turn `AL SMITH` into `al Smith`. The list is
+ * only ever consulted for a word that has something after it, so a lone `AL`/`VAN`
+ * is capitalized normally either way.
+ *
+ * The measured benefit of this rule is small and honest: across the whole sample
+ * exactly ONE value is fixed by it (`van ruler` -> `van Ruler`). Every other
+ * particle name in the data — `de Alejo`, `van Dyck`, `von Disterlo`, `del Junco` —
+ * is already correct mixed case and is never touched at all.
+ */
+const PARTICLES: ReadonlySet<string> = new Set([
+  'van',
+  'von',
+  'der',
+  'den',
+  'de',
+  'del',
+  'della',
+  'di',
+  'da',
+  'dos',
+  'das',
+  'du',
+  'la',
+  'le',
+  'ter',
+  'ten',
+  'bin',
+  'ibn',
+])
+
+/** Generational suffixes that stay upper-case. */
+const ROMAN_SUFFIXES: ReadonlySet<string> = new Set([
+  'I',
+  'II',
+  'III',
+  'IV',
+  'V',
+  'VI',
+  'VII',
+  'VIII',
+  'IX',
+  'X',
+  'XI',
+  'XII',
+])
+
+/**
+ * Surnames where the `MacX` spelling is the established one.
+ *
+ * An ALLOWLIST, never a rule — and that is the whole point. `MACHADO`, `MACK`,
+ * `MACON` and `MACKAY` are not `MacHado` / `MacK` / `MacOn` / `MacKay`, so a
+ * `Mac` + capitalize rule invents a capital that appears in no source, which is
+ * strictly worse than leaving `Machado`. Anything not on this list falls through to
+ * plain capitalization.
+ *
+ * `Mc` needs no allowlist: `Mc` is a contraction of `Mac` and effectively always
+ * takes a following capital (verified against every `MC…` surname in the sample —
+ * McAllister, McBryde, McCandless, McCormick, McCoy, McDaniel, McElhany, McGarry).
+ */
+const MAC_NAMES: ReadonlySet<string> = new Set([
+  'macallister',
+  'macarthur',
+  'macaulay',
+  'macbride',
+  'maccarthy',
+  'macdonald',
+  'macdougall',
+  'macfarlane',
+  'macgregor',
+  'macintosh',
+  'macintyre',
+  'maciver',
+  'mackenzie',
+  'mackinnon',
+  'maclachlan',
+  'maclean',
+  'macleod',
+  'macmillan',
+  'macnamara',
+  'macneil',
+  'macpherson',
+  'macquarie',
+])
+
+/** Upper-case the first cased letter, leave the rest of the (already lowered) segment. */
+function upperFirst(segment: string): string {
+  return segment.replace(/\p{Ll}/u, (ch) => ch.toLocaleUpperCase())
+}
+
+/**
+ * Case one hyphen/apostrophe/period-delimited run: `o'brien` -> `O'Brien`,
+ * `creighton-taylor` -> `Creighton-Taylor`, `l.` -> `L.`.
+ *
+ * Splits with a capturing group so the delimiters are preserved and re-joined
+ * verbatim. `formatComplexName` (deleted with this change) split on `[\s-']` and
+ * joined on `' '`, which DELETED every hyphen and apostrophe it touched — that bug
+ * is the reason this function exists rather than being a two-line reuse.
+ */
+function caseSegments(lowered: string): string {
+  return lowered
+    .split(/([-'’.])/)
+    .map((part, index) => {
+      // Odd indices are the captured delimiters — pass them through untouched.
+      if (index % 2 === 1) return part
+      if (part.startsWith('mc') && part.length >= 4) return `Mc${upperFirst(part.slice(2))}`
+      if (part.startsWith('mac') && MAC_NAMES.has(part)) return `Mac${upperFirst(part.slice(3))}`
+      return upperFirst(part)
+    })
+    .join('')
+}
+
+/** Letters only, for the initials test — `(OSV)` should be judged on `OSV`. */
+function lettersOf(word: string): string {
+  return word.replace(/[^\p{L}]/gu, '')
+}
+
+/**
+ * Is this ALL-CAPS word a set of initials or an acronym rather than a name?
+ *
+ * Two signals, both measured against the 510 all-caps values in the sample:
+ *
+ * - **No vowel.** A perfect discriminator at length 3: every acronym there
+ *   (`BBH` `CSH` `CSJ` `HHH` `RMR` `SVR` `VPT` `LLC`) lacks one and every real name
+ *   (`ALI` `AMY` `BEN` `COX` `GUY` `JAY` `KEN` `LEE` `PAT` `RAY` `TIM` `TOM` …) has one.
+ * - **Exactly two letters.** Initials outnumber names 22:5 there (`AJ` `CJ` `DJ` `JP`
+ *   `TJ` `JC` `JD` `JF` `JJ` `JM` `JT` `JW` `LK` `MJ` `OJ` `PJ` `RR` `TS` `VJ` `CR`
+ *   `GB` `MC` against `ED` `ER` `HE` `JU` `LI`), and no vowel test separates `AJ`
+ *   from `ED`.
+ *
+ * The five two-letter names this leaves shouting are the accepted cost: an
+ * un-improved `ED` is a cosmetic miss, whereas `JP` -> `Jp` is visibly broken and
+ * invents a lowercase letter that was in no source.
+ */
+function looksLikeInitials(word: string): boolean {
+  const letters = lettersOf(word)
+  if (letters.length === 0) return false
+  return letters.length <= 2 || !VOWELS.test(letters)
+}
+
+/**
+ * Repair the casing of a name that is entirely upper-case or entirely lower-case.
+ *
+ * Returns the input **unchanged** — the same string, so callers can compare by
+ * value — for mixed-case input, empty/nullish input, script without case (`李`),
+ * and anything containing `@` (an email address parked in a name field is a
+ * different problem, and title-casing it would only disguise it).
+ *
+ * @example
+ * toDisplayCase('BRUCE')            // 'Bruce'
+ * toDisplayCase('regina')           // 'Regina'
+ * toDisplayCase('MACIVER')          // 'MacIver'
+ * toDisplayCase('MACHADO')          // 'Machado'  (allowlist miss — not MacHado)
+ * toDisplayCase('MCDONALD')         // 'McDonald'
+ * toDisplayCase('O\'BRIEN')         // 'O\'Brien'
+ * toDisplayCase('CREIGHTON-TAYLOR') // 'Creighton-Taylor'
+ * toDisplayCase('VAN DER BERG')     // 'van der Berg'
+ * toDisplayCase('JP')               // 'JP'       (initials — untouched)
+ * toDisplayCase('MacIver')          // 'MacIver'  (mixed case — untouched)
+ */
+export function toDisplayCase(value: string | null | undefined): string | null | undefined {
+  if (!value) return value
+  if (value.includes('@')) return value
+
+  const hasUpper = /\p{Lu}/u.test(value)
+  const hasLower = /\p{Ll}/u.test(value)
+  // Uncased script (CJK, Hebrew, Arabic) matches neither — nothing to repair.
+  if (hasUpper === hasLower) return value
+  const fromUpper = hasUpper
+
+  // Split on whitespace runs, capturing them so the original spacing survives.
+  const parts = value.split(/(\s+)/)
+  const wordIndices = parts.reduce<number[]>((acc, part, i) => {
+    if (i % 2 === 0 && part.length > 0) acc.push(i)
+    return acc
+  }, [])
+  const lastWordIndex = wordIndices[wordIndices.length - 1]
+  const isSingleWord = wordIndices.length === 1
+
+  const recased = parts.map((part, index) => {
+    if (index % 2 === 1 || part.length === 0) return part
+
+    const letters = lettersOf(part)
+    const isLast = index === lastWordIndex
+
+    // Generational suffix — `FRIENDS II` -> `Friends II`, `TAULMAN JR` -> `Taulman Jr`.
+    // Never on the first word, where `IV`/`V` are far more likely to be an initial.
+    if (index !== wordIndices[0]) {
+      const upper = letters.toLocaleUpperCase()
+      if (ROMAN_SUFFIXES.has(upper)) return part.toLocaleUpperCase()
+      if (upper === 'JR' || upper === 'SR') return caseSegments(part.toLocaleLowerCase())
+    }
+
+    const lowered = part.toLocaleLowerCase()
+
+    // A particle is lowered only when something follows it. `VAN` on its own is
+    // somebody's whole name and gets capitalized; `VAN DER BERG` does not.
+    //
+    // Ordered BEFORE the initials test on purpose: `DE` and `LA` are two letters, so
+    // the initials test would otherwise claim them and `DE LA CRUZ` would come back
+    // as `DE LA Cruz`. Particles are a closed known set, initials are a heuristic —
+    // the closed set wins.
+    if (!isSingleWord && !isLast && PARTICLES.has(lettersOf(lowered))) return lowered
+
+    // Initials/acronyms keep the shape they came in with, but only when that shape
+    // was upper-case to begin with — a lower-case `jp` carries no such evidence.
+    if (fromUpper && looksLikeInitials(part)) return part
+
+    return caseSegments(lowered)
+  })
+
+  const next = recased.join('')
+  // Return the ORIGINAL string when nothing moved, so callers can compare by identity.
+  return next === value ? value : next
+}


### PR DESCRIPTION
~11% of contacts carry a name nobody meant to type that way. Measured across the 14,824 contacts on DemoOrg1:

| problem | rows | share |
| --- | --- | --- |
| ALL CAPS (`BRUCE` / `MACIVER`) | 510 | 3.4% |
| all lowercase (`regina kopseng`) | 1,112 | 7.5% |

**This is not a connector problem.** Split by source, the non-connector contacts are proportionally worse — 18.6% lowercase-start vs 6.4% for Shopify-synced ones — so the fix belongs on the write path, not in the Shopify app.

## The one rule

A name is rewritten **only when it is entirely upper-case or entirely lower-case.**

Mixed case means a human, or a source that already got it right, made a casing decision — so `MacIver`, `d'Artagnan`, `van der Berg`, `DeAngelo` and `eBay` come back untouched. That single condition is what replaces a settings toggle, a per-field option and an "I edited this, stop touching it" flag.

There is deliberately no `force` option, and one should never be added: the moment this can rewrite mixed-case input it needs an escape hatch, and the escape hatch is the feature.

The corollary is that it is **not** a general title-caser. It cannot fix `Mcdonald` typed by a human, and it should not try — it has no evidence anything is wrong there.

## Where it hooks in

A `FieldPreHookHandler` on `contacts:first_name` / `contacts:last_name`. Pre-hooks return a transformed value, not just an accept/reject, so one registration covers every writer: connector sink, mail/SMS ingest, CSV import, panel edits, SDK, Kopilot — all of them funnel through `fireFieldPreHooks`.

Verified rather than assumed. `UnifiedCrudHandler` never sets `skipPreHooks`, and the connector's `OWNED_BYPASS` is `new Set<never>()` — empty — despite a comment claiming it "skips registered system-field pre-hooks". **That comment is corrected in this PR and a test pins the value**, because a future reader would otherwise conclude this design cannot work.

A `full_name` write lands here too: NAME is a composite decomposed into two direct part writes, and `EntityInstance.displayName` is denormalized downstream of those.

## Two rules derived from the data, not guessed

**`Mac` is an allowlist, never a rule.** `MACHADO`, `MACK`, `MACKAY` are not `MacHado` / `MacK` / `MacKay`. Inventing a capital that appears in no source is worse than leaving `Machado`, so anything off the list falls through to plain capitalization. `Mc` needs no allowlist — it was correct on 8/8 `MC…` surnames in the sample.

**Initials and acronyms keep their shape.** Naive title case turns `JP` into `Jp`. Measured over the 510 all-caps values: at length 3, "has no vowel" is a *perfect* discriminator — all 8 acronyms (`BBH CSH CSJ HHH RMR SVR VPT LLC`) lack one, all 24 real names (`ALI AMY BEN COX GUY JAY KEN LEE PAT RAY TIM TOM…`) have one. At length 2, initials outnumber names 22:5 with no test able to separate `AJ` from `ED`. The five two-letter names left shouting (`ED ER HE JU LI`) are the accepted cost: an un-improved `ED` is a cosmetic miss, `JP` → `Jp` is visibly broken.

## Deletes two helpers that were quietly wrong

`formatComplexName` and `formatCityName` had **zero callers** anywhere in the repo, and would have corrupted data if wired up. Both split on a character class and re-joined on `' '`, so they *deleted* every hyphen and apostrophe they touched:

```
formatComplexName("Creighton-Taylor") = "Creighton Taylor"   <- hyphen destroyed
formatComplexName("O'Brien")          = "O Brien"            <- apostrophe destroyed
formatComplexName("MacIver")          = "Maciver"
formatCityName("McAllen")             = "Mcallen"
```

Leaving them exported beside a correct implementation guarantees someone imports the wrong one. `formatCompanyName` (a `trim()` stub) and `formatStreetAddress` (whose suffix regex turns `Rd` into `RD`, fires on `St Louis`, and flattens `MacArthur`) stay — out of scope, with their defects recorded in the plan.

## Backfill

`apps/worker/scripts/normalize-contact-name-casing.ts`, per-org, with `--dry-run`. Deliberately a script rather than a `DataMigration`: it rewrites user data on a judgement call.

**Already run on DemoOrg1: 2,231 values repaired across 1,271 records.** Re-running now scans 419 and reports nothing to repair — idempotent, and every remainder is a deliberate exclusion (initials, or an email address parked in a name field).

Writes go through `UnifiedCrudHandler`, never `FieldValue` directly, because `full_name` is computed from the parts and `displayName` is denormalized from that — a direct write leaves records still *displaying* the old value. Confirmed on live rows.

Spot-checked against real data:

```
mckelvey        -> McKelvey         MACOLINO  -> Macolino   (allowlist miss)
MCCANDLESS      -> McCandless       F-EMCH    -> F-Emch
O'REILLY        -> O'Reilly         LEH, LLC  -> Leh, LLC   (acronym kept mid-string)
ortega-martinez -> Ortega-Martinez   SAN SOUCI -> San Souci
```

Both negatives hold: no initials and no mixed-case value appears anywhere in the change list.

## Known, accepted

- **Junk gets title-cased.** `(null)` → `(Null)`, `user` → `User`. These are "the field holds something that isn't a name" rows — a separate problem the function cannot distinguish from a surname.
- **`llc` → `Llc` while `LLC` stays `LLC`.** The initials rule only fires on all-caps input, because a lowercase token carries no evidence of being an acronym.
- **`TEC` → `Tec`.** Three letters with a vowel reads as a name. The vowel test is only perfect in the no-vowel direction.
- Backfilled records get `updatedAt` bumped, so the duplicate scanner re-examines them. Load, not corruption.

## Tests

`packages/utils` 341 green (101 new, covering every rule above plus idempotence and a regression guard for the deleted helpers' punctuation bug). `packages/lib` field-hooks/records/field-values 759 green; data-connectors/ingest 748 green. Typecheck ratchet: no new errors. Biome clean.

**Two pre-existing failures on `main`, neither caused nor fixed here** (both files untouched): `delete-guard-registration.test.ts` expects `tariff-codes` in `visibleMoneyParents()`, but `f8f4cf463` set `tariff_code` to `isVisible: false` without updating the test; and `files/file-type-constants.test.ts` imports `UploadPolicy` where `#1866` renamed it to `EntityUploadPolicy`.

https://claude.ai/code/session_01SsmZt1SL3FVQ3tyH65fUXb
