### PR TITLE
fix(billing): panel and dialog field configs no longer count against the saved-view limit

### DIFF
--- a/apps/web/src/server/api/routers/table-view-structural.ts
+++ b/apps/web/src/server/api/routers/table-view-structural.ts
@@ -1,6 +1,7 @@
 // apps/web/src/server/api/routers/table-view-structural.ts
 
 import type { Resource } from '@auxx/lib/resources/client'
+import { isStructuralContextType } from '@auxx/lib/table-views'
 
 /**
  * Pure table-view def-admin gating logic (perms v2 doc 07), no server deps so it
@@ -13,8 +14,10 @@ import type { Resource } from '@auxx/lib/resources/client'
  * `isShared` is deliberately NOT a trigger.
  */
 
-/** Context types whose views are the def's shared panel/dialog field layouts. */
-const STRUCTURAL_CONTEXT_TYPES = new Set(['panel', 'dialog_create', 'dialog_edit'])
+// The context-type set itself lives in `@auxx/lib/table-views` because the
+// `savedViews` counter must exclude exactly the rows this gate protects — a
+// panel/dialog config is definition configuration, not a member's saved view.
+// Two copies of that list is how the billing counters drifted apart before.
 
 /** Shape of a write's structural inputs (from create input or a loaded row). */
 export interface StructuralViewShape {
@@ -27,10 +30,7 @@ export interface StructuralViewShape {
  * for panel/dialog field configs or any write that designates the org default.
  */
 export function isStructural(view: StructuralViewShape): boolean {
-  return (
-    (view.contextType != null && STRUCTURAL_CONTEXT_TYPES.has(view.contextType)) ||
-    view.isDefault === true
-  )
+  return isStructuralContextType(view.contextType) || view.isDefault === true
 }
 
 /** Table/kanban views built as `entity-<defId>`; panel/dialog use a bare `<defId>`. */

--- a/packages/lib/src/table-views/index.ts
+++ b/packages/lib/src/table-views/index.ts
@@ -5,6 +5,12 @@ export { createTableView } from './create-table-view'
 export { countSavedViewsUsed } from './saved-view-limits'
 export type { SetDefaultTableViewInput, SetDefaultTableViewResult } from './set-default-table-view'
 export { setDefaultTableView } from './set-default-table-view'
+export {
+  BILLABLE_VIEW_CONTEXT_TYPES,
+  isStructuralContextType,
+  STRUCTURAL_CONTEXT_TYPE_SET,
+  STRUCTURAL_CONTEXT_TYPES,
+} from './structural-contexts'
 export { computeUserTableViews } from './table-view-queries'
 export type { UpdateTableViewInput, UpdateTableViewResult } from './update-table-view'
 export { updateTableView } from './update-table-view'

--- a/packages/lib/src/table-views/saved-view-limits.ts
+++ b/packages/lib/src/table-views/saved-view-limits.ts
@@ -1,13 +1,14 @@
 // packages/lib/src/table-views/saved-view-limits.ts
 
 import { type Database, schema } from '@auxx/database'
-import { and, count, eq, ne } from 'drizzle-orm'
+import { and, count, eq, ne, notInArray } from 'drizzle-orm'
+import { STRUCTURAL_CONTEXT_TYPES } from './structural-contexts'
 
 /**
  * The single counter behind the `savedViews` plan limit.
  *
  * A "saved view" for billing purposes is a **shared** view a **member** created —
- * across both `TableView` (records) and `MailView` (mail). Two exclusions matter:
+ * across both `TableView` (records) and `MailView` (mail). Three exclusions matter:
  *
  * 1. **System-seeded views don't count.** `entity-seeder/create-default-views.ts`,
  *    `create-field-views.ts` and the `ensureDefaultTableViews`/`ensureFieldViews`
@@ -18,6 +19,15 @@ import { and, count, eq, ne } from 'drizzle-orm'
  *    permanently closed.
  * 2. **Personal views don't count.** Only `isShared` views consume the limit;
  *    that's what the create gates have always enforced.
+ * 3. **Panel/dialog field configs don't count.** A `panel`/`dialog_create`/
+ *    `dialog_edit` row is the DEFINITION's field layout, not a saved view: one per
+ *    def per context, written by a def admin through its own gate
+ *    (`isStructural` → `assertStructuralAccess`), never named or picked from a list.
+ *    They are created `isShared: true` under the acting admin's id
+ *    (`use-field-view-draft.ts`), so neither exclusion above catches them — which
+ *    meant customizing the Details panel on four definitions could exhaust a
+ *    Demo/Free limit of 10 and then block real saved views with an error about
+ *    "saved views". See {@link STRUCTURAL_CONTEXT_TYPES}.
  *
  * Exported so the create gates (`tableView.create`, `mailView.create`) and
  * `OverageDetectionService` read one number — three independent counters for one
@@ -41,6 +51,7 @@ export async function countSavedViewsUsed(db: Database, organizationId: string):
       and(
         eq(schema.TableView.organizationId, organizationId),
         eq(schema.TableView.isShared, true),
+        notInArray(schema.TableView.contextType, [...STRUCTURAL_CONTEXT_TYPES]),
         ...(systemUserId ? [ne(schema.TableView.userId, systemUserId)] : [])
       )
     )

--- a/packages/lib/src/table-views/structural-contexts.test.ts
+++ b/packages/lib/src/table-views/structural-contexts.test.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/table-views/structural-contexts.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { viewContextTypes } from '../conditions/field-view-config'
+import {
+  BILLABLE_VIEW_CONTEXT_TYPES,
+  isStructuralContextType,
+  STRUCTURAL_CONTEXT_TYPES,
+} from './structural-contexts'
+
+/**
+ * The `savedViews` plan limit meters saved views — artifacts a member creates,
+ * names and picks. It must NOT meter definition configuration (the panel and
+ * create/edit dialog field layouts), which is one row per def per context written
+ * by a def admin.
+ *
+ * The partition test below is the point of this file: every view context type is
+ * either structural (excluded from the limit) or billable (counted). Adding a
+ * context type — `drawer` and `detail` are coming, see
+ * plans/drawer/record-layout-system.md — fails this test until someone classifies
+ * it, rather than silently defaulting it into the billing counter.
+ */
+describe('structural view contexts', () => {
+  it('classifies the panel and dialog field layouts as structural', () => {
+    expect([...STRUCTURAL_CONTEXT_TYPES]).toEqual(['panel', 'dialog_create', 'dialog_edit'])
+  })
+
+  it('leaves the member-authored contexts billable', () => {
+    expect([...BILLABLE_VIEW_CONTEXT_TYPES]).toEqual(['table', 'kanban'])
+  })
+
+  it('partitions every known context type into exactly one bucket', () => {
+    const structural = new Set<string>(STRUCTURAL_CONTEXT_TYPES)
+    const billable = new Set<string>(BILLABLE_VIEW_CONTEXT_TYPES)
+
+    // Disjoint.
+    for (const contextType of structural) {
+      expect(billable.has(contextType)).toBe(false)
+    }
+    // Exhaustive — a new context type in `viewContextTypes` lands in neither and fails here.
+    expect([...structural, ...billable].sort()).toEqual([...viewContextTypes].sort())
+  })
+
+  it('recognises structural context types, and nothing else', () => {
+    expect(isStructuralContextType('panel')).toBe(true)
+    expect(isStructuralContextType('dialog_create')).toBe(true)
+    expect(isStructuralContextType('dialog_edit')).toBe(true)
+    expect(isStructuralContextType('table')).toBe(false)
+    expect(isStructuralContextType('kanban')).toBe(false)
+  })
+
+  it('treats an absent context type as non-structural', () => {
+    // `TableView.contextType` is `text()` defaulting to 'table', but the column is
+    // nullable in the type and router inputs make it optional — a missing value must
+    // not accidentally exempt a row from the limit.
+    expect(isStructuralContextType(null)).toBe(false)
+    expect(isStructuralContextType(undefined)).toBe(false)
+    expect(isStructuralContextType('')).toBe(false)
+    expect(isStructuralContextType('workflow-runs')).toBe(false)
+  })
+})

--- a/packages/lib/src/table-views/structural-contexts.ts
+++ b/packages/lib/src/table-views/structural-contexts.ts
@@ -1,0 +1,49 @@
+// packages/lib/src/table-views/structural-contexts.ts
+
+import { type ViewContextType, viewContextTypes } from '../conditions/field-view-config'
+
+/**
+ * View contexts that are **definition configuration**, not user-authored artifacts.
+ *
+ * A `panel` / `dialog_create` / `dialog_edit` `TableView` is the field layout of an
+ * entity definition: which fields show in the Details panel and in the create/edit
+ * dialogs. There is at most one per definition per context, it is written by a def
+ * admin through a gate of its own (`isStructural` → `assertStructuralAccess`), and
+ * nobody names it or picks it from a list.
+ *
+ * A `table` / `kanban` view is the opposite: a member makes it, names it, and
+ * chooses it. That is the artifact the `savedViews` plan limit is meant to meter.
+ *
+ * The distinction has two consumers and they MUST agree:
+ * 1. the def-admin gate on structural writes (`table-view-structural.ts`), and
+ * 2. {@link countSavedViewsUsed}, which excludes these rows from the plan limit.
+ *
+ * Keeping one set here is the point. The counter's own history is the argument:
+ * three independent counters for one billing invariant is exactly how they drifted
+ * apart before.
+ */
+export const STRUCTURAL_CONTEXT_TYPES = [
+  'panel',
+  'dialog_create',
+  'dialog_edit',
+] as const satisfies readonly ViewContextType[]
+
+/** Set form for membership checks. */
+export const STRUCTURAL_CONTEXT_TYPE_SET: ReadonlySet<string> = new Set(STRUCTURAL_CONTEXT_TYPES)
+
+/**
+ * Contexts whose shared rows DO consume the `savedViews` plan limit — the
+ * complement of {@link STRUCTURAL_CONTEXT_TYPES}, derived rather than typed out so
+ * a new context type cannot be silently omitted from both lists.
+ */
+export const BILLABLE_VIEW_CONTEXT_TYPES: readonly ViewContextType[] = viewContextTypes.filter(
+  (contextType) => !STRUCTURAL_CONTEXT_TYPE_SET.has(contextType)
+)
+
+/**
+ * Whether a view's context makes it definition configuration rather than a saved view.
+ * Tolerates the free-form `string | null` the DB column and router inputs carry.
+ */
+export function isStructuralContextType(contextType: string | null | undefined): boolean {
+  return contextType != null && STRUCTURAL_CONTEXT_TYPE_SET.has(contextType)
+}


### PR DESCRIPTION
## The bug

`countSavedViewsUsed` (`packages/lib/src/table-views/saved-view-limits.ts`) is the single counter behind the `savedViews` plan limit, read by the `tableView.create` / `mailView.create` gates and by `OverageDetectionService`. It excluded system-seeded rows and personal rows, but **never excluded by `contextType`** — while `use-field-view-draft.ts:462` writes panel and dialog field configs as:

```ts
createView.mutateAsync({
  tableId: entityDefinitionId,
  contextType: draftContextType,   // 'panel' | 'dialog_create' | 'dialog_edit'
  isShared: true,
  isDefault: true,
  config: draft,
})
```

Shared, and authored by the acting admin rather than the system user, so it passed both existing exclusions and counted.

**Result:** the first time a def admin customised a Details panel or a create/edit dialog, it consumed a saved-view slot. Each definition has three structural contexts, so customising four definitions could exhaust a Demo/Free limit of 10 and then block real saved views with an error message about "saved views" that had nothing to do with what they did. `OverageDetectionService` inherited the same gap, since it delegates to the same counter.

## Why these rows are not saved views

A `panel` / `dialog_create` / `dialog_edit` row is **definition configuration**: one per def per context, written by a def admin through a gate of its own (`isStructural` → `assertStructuralAccess`), never named or picked from a list. A `table` / `kanban` view is the opposite — a member makes it, names it and chooses it, which is the artifact the limit is meant to meter.

The distinction already existed in `isStructural`; only the counter missed it.

## The change

- **`table-views/structural-contexts.ts`** (new) owns `STRUCTURAL_CONTEXT_TYPES` plus `BILLABLE_VIEW_CONTEXT_TYPES`, **derived** as the complement of `viewContextTypes` rather than typed out, so a new context type cannot be silently omitted from both lists.
- **`countSavedViewsUsed`** excludes those contexts.
- **`table-view-structural.ts`** imports the same set instead of keeping a second copy, so the def-admin gate and the billing counter cannot drift. Two lists for one invariant is exactly how the three previous counters diverged, per that file's own docstring.
- **`structural-contexts.test.ts`** asserts the two sets **partition** `viewContextTypes`, so adding a context type fails the build until someone classifies it. There were previously no tests on this counter.

## Testing

- 1014 lib tests pass (`src/table-views` + `src/permissions`), including 5 new ones.
- 1453 web router tests pass, including the 8 existing `table-view-structural` tests.
- No new type errors.

Two unrelated pre-existing failures were observed and left alone: `src/files/file-type-constants.test.ts` (`UploadPolicy` renamed to `EntityUploadPolicy` without updating the test) and `file-attachment-permission.test.ts` (import error in `packages/lib/src/agents/index.ts`). Both files are unmodified at HEAD.

## Follow-up

A record-layout system in planning adds `contextType: 'drawer'` and `'detail'` rows, which are also `isShared`, admin-authored and one-per-definition. The partition test is a deliberate tripwire: those will fail it until they are classified, and they belong on the structural side.

https://claude.ai/code/session_013JV5dJQRaAQ54GkrpXCMKw
