### PR TITLE
fix(dashboards): put a date axis back in date order

### DIFF
--- a/apps/web/src/components/dashboard/ui/config/group-by-section.tsx
+++ b/apps/web/src/components/dashboard/ui/config/group-by-section.tsx
@@ -8,7 +8,13 @@
 // WidgetFieldRefs. Field eligibility mirrors the server's validateGroupBy.
 
 import { FieldType } from '@auxx/database/enums'
-import type { DateGranularity, GroupBy, GroupSort, WidgetSource } from '@auxx/lib/dashboards/client'
+import {
+  type DateGranularity,
+  defaultGroupSort,
+  type GroupBy,
+  type GroupSort,
+  type WidgetSource,
+} from '@auxx/lib/dashboards/client'
 import type { SelectOption } from '@auxx/types/custom-field'
 import { isFieldPath, type ResourceFieldId } from '@auxx/types/field'
 import { useField } from '~/components/resources/hooks/use-field'
@@ -34,6 +40,14 @@ const SORT_OPTIONS: SelectOption[] = [
   { value: 'labelDesc', label: 'Label (Z → A)' },
 ]
 
+/** Same options for a date dimension, where "label" order IS chronological. */
+const DATE_SORT_OPTIONS: SelectOption[] = [
+  { value: 'labelAsc', label: 'Date (oldest → newest)' },
+  { value: 'labelDesc', label: 'Date (newest → oldest)' },
+  { value: 'valueDesc', label: 'Value (high → low)' },
+  { value: 'valueAsc', label: 'Value (low → high)' },
+]
+
 const leaf = (ref: GroupBy['fieldRef']): ResourceFieldId =>
   isFieldPath(ref) ? (ref[ref.length - 1] ?? ref[0]) : ref
 
@@ -57,6 +71,11 @@ export function GroupBySection({
   const field = useField(groupBy?.fieldRef ? leaf(groupBy.fieldRef) : null)
   const fieldType = field ? effectiveFieldTypeOf(field) : undefined
   const showGranularity = supportsDateGranularity(fieldType)
+  // Mirrors the server: a date dimension buckets by day unless told otherwise,
+  // and that is what decides the default sort.
+  const effectiveGranularity = showGranularity
+    ? (groupBy?.dateGranularity ?? ('day' as const))
+    : undefined
 
   const patch = (p: Partial<GroupBy>) => {
     if (!groupBy) return
@@ -90,10 +109,14 @@ export function GroupBySection({
           )}
           <ConfigFieldRow
             title='Sort'
-            description='Order the categories — by value (biggest first) or by name.'
+            description={
+              showGranularity
+                ? 'Order the buckets — chronologically, or by value.'
+                : 'Order the categories — by value (biggest first) or by name.'
+            }
             fieldType={FieldType.SINGLE_SELECT}
-            fieldOptions={{ options: SORT_OPTIONS }}
-            value={groupBy.sort ?? 'valueDesc'}
+            fieldOptions={{ options: showGranularity ? DATE_SORT_OPTIONS : SORT_OPTIONS }}
+            value={groupBy.sort ?? defaultGroupSort(effectiveGranularity)}
             onChange={(v) => patch({ sort: v as GroupSort })}
           />
           <ConfigFieldRow

--- a/packages/lib/src/dashboards/client.ts
+++ b/packages/lib/src/dashboards/client.ts
@@ -84,7 +84,7 @@ export type GroupBy = {
   fieldRef: WidgetFieldRef
   /** Only when the resolved field is DATE/DATETIME. */
   dateGranularity?: DateGranularity
-  /** Default `'valueDesc'`. */
+  /** Default {@link defaultGroupSort} — chronological for date buckets. */
   sort?: GroupSort
   /** Default {@link DEFAULT_GROUP_LIMIT}, hard cap {@link MAX_GROUP_LIMIT}. */
   limit?: number
@@ -490,6 +490,16 @@ export const MAX_RECORD_LIST_PAGE_SIZE = 50
 export const DEFAULT_GAUGE_MAX = 100
 
 // ── Guards / helpers ────────────────────────────────────────────────────────
+
+/**
+ * The sort a group-by falls back to when it carries none. Date buckets sort
+ * chronologically (`labelAsc` compares the raw `yyyy-MM-dd` key, and the cyclic
+ * granularities their numeric key) — a time axis ordered by count is unreadable.
+ * Everything else keeps the biggest-first ranking a categorical chart wants.
+ */
+export function defaultGroupSort(dateGranularity: DateGranularity | undefined): GroupSort {
+  return dateGranularity ? 'labelAsc' : 'valueDesc'
+}
 
 /** Configs carrying a data `source` + `metric` (charts, KPI, gauge, recordList). */
 export function isDataWidget(config: WidgetConfiguration): config is DataWidgetConfig {

--- a/packages/lib/src/resources/aggregate/group-order.test.ts
+++ b/packages/lib/src/resources/aggregate/group-order.test.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/resources/aggregate/group-order.test.ts
+//
+// Ordering of a grouped aggregate: the default sort a group-by falls back to,
+// and which groups survive the limit. A date axis ranked by count renders as
+// "Sep 3, Aug 15, May 27, Apr 7…" — the bug this pair of rules exists to stop.
+
+import { describe, expect, it } from 'vitest'
+import type { DateGranularity, GroupSort } from '../../dashboards/client'
+import { defaultGroupSort } from '../../dashboards/client'
+import { capGroups } from './run-aggregate'
+import type { AggregateGroup, ResolvedGroupBy } from './types'
+
+const group = (key: string, value: number): AggregateGroup => ({ key, label: key, value })
+
+const groupBy = (
+  dateGranularity?: DateGranularity,
+  sort?: GroupSort
+): Pick<ResolvedGroupBy, 'dateGranularity' | 'sort'> => ({
+  dateGranularity,
+  sort: sort ?? defaultGroupSort(dateGranularity),
+})
+
+describe('defaultGroupSort', () => {
+  it('orders date buckets chronologically', () => {
+    expect(defaultGroupSort('day')).toBe('labelAsc')
+    expect(defaultGroupSort('month')).toBe('labelAsc')
+    expect(defaultGroupSort('monthOfYear')).toBe('labelAsc')
+  })
+
+  it('keeps biggest-first for categorical dimensions', () => {
+    expect(defaultGroupSort(undefined)).toBe('valueDesc')
+  })
+})
+
+describe('capGroups', () => {
+  const days = ['2026-04-07', '2026-05-27', '2026-08-15', '2026-09-03'].map((k, i) =>
+    group(k, i + 1)
+  )
+
+  it('keeps the most RECENT calendar buckets, still in order', () => {
+    expect(capGroups(days, groupBy('day'), 2).map((g) => g.key)).toEqual([
+      '2026-08-15',
+      '2026-09-03',
+    ])
+  })
+
+  it('keeps the head for a categorical dimension', () => {
+    const cats = [group('a', 9), group('b', 5), group('c', 1)]
+    expect(capGroups(cats, groupBy(undefined), 2).map((g) => g.key)).toEqual(['a', 'b'])
+  })
+
+  it('keeps the head when the date axis is explicitly ranked by value', () => {
+    const ranked = [...days].sort((a, b) => b.value - a.value)
+    const byValue = groupBy('day', 'valueDesc')
+    expect(capGroups(ranked, byValue, 2).map((g) => g.key)).toEqual(['2026-09-03', '2026-08-15'])
+  })
+
+  it('leaves a short list untouched', () => {
+    expect(capGroups(days, groupBy('day'), 50)).toHaveLength(4)
+  })
+})

--- a/packages/lib/src/resources/aggregate/run-aggregate.ts
+++ b/packages/lib/src/resources/aggregate/run-aggregate.ts
@@ -23,6 +23,7 @@ import { getAggregateCache, getCachedResourceFields, PromiseMemoizer } from '../
 import { type ConditionGroup, resolveConditionContext } from '../../conditions'
 import {
   DEFAULT_GROUP_LIMIT,
+  defaultGroupSort,
   type GroupBy,
   MAX_GROUP_LIMIT,
   type WidgetFieldRef,
@@ -359,7 +360,7 @@ async function prepareAggregate(
     const resolvedGroup: ResolvedGroupBy = {
       field,
       dateGranularity,
-      sort: g.sort ?? 'valueDesc',
+      sort: g.sort ?? defaultGroupSort(dateGranularity),
       limit: Math.min(Math.max(g.limit ?? limit, 1), MAX_GROUP_LIMIT),
       omitEmpty: g.omitEmpty ?? false,
     }
@@ -571,6 +572,25 @@ function compareByLabel(
   const bn = Number(bv)
   if (Number.isFinite(an) && Number.isFinite(bn)) return an - bn
   return av.localeCompare(bv)
+}
+
+/**
+ * Apply the group cap. Categorical dimensions keep the FIRST `limit` groups —
+ * the sort already put the interesting ones there. A calendar date axis sorted
+ * chronologically must keep the most RECENT buckets instead: taking the head
+ * would end the chart months ago and read as "we stopped getting records".
+ * Cyclic granularities never exceed 12 keys, so they need no special case.
+ */
+export function capGroups(
+  sorted: AggregateGroup[],
+  groupBy: Pick<ResolvedGroupBy, 'dateGranularity' | 'sort'>,
+  limit: number
+): AggregateGroup[] {
+  if (sorted.length <= limit) return sorted
+  const calendarDates =
+    groupBy.dateGranularity !== undefined && !isCyclicGranularity(groupBy.dateGranularity)
+  if (calendarDates && groupBy.sort === 'labelAsc') return sorted.slice(sorted.length - limit)
+  return sorted.slice(0, limit)
 }
 
 function sortGroups(groups: AggregateGroup[], groupBy: ResolvedGroupBy): AggregateGroup[] {
@@ -821,7 +841,12 @@ async function computeAggregate(
   const totalValue = sorted.reduce((sum, g) => sum + g.value, 0)
   const hasMoreGroups = overflow || sorted.length > limit
 
-  return ok({ groups: sorted.slice(0, limit), totalValue, hasMoreGroups, ...droppedReport })
+  return ok({
+    groups: capGroups(sorted, groupBy, limit),
+    totalValue,
+    hasMoreGroups,
+    ...droppedReport,
+  })
 }
 
 /**


### PR DESCRIPTION
## The bug

On any dashboard chart grouped by a date, the x-axis came out scrambled:

> Sep 3 · Aug 15 · Aug 18 · Aug 22 · May 27 · Sep 4 · Apr 7 · Jun 13 · Jul 2 · Aug 28

Not a formatting problem — the axis was never sorted by date. `prepareAggregate` fell back to `sort: 'valueDesc'` for **every** group-by, date buckets included, so a "records over time" chart ranked its days by count and rendered them in that order. The biggest day first, and the calendar wherever it landed.

Every seeded entity dashboard stores its date widgets without a `sort`:

```json
{ "fieldRef": "…:createdAt", "dateGranularity": "day" }
```

so all of them shipped this way.

## The fix

`defaultGroupSort(dateGranularity)` — `labelAsc` for date buckets, `valueDesc` for everything else. Chronological falls out of `labelAsc` for free: the raw bucket key is `yyyy-MM-dd`, and the cyclic granularities (`dayOfWeek`, `monthOfYear`) key on `'1'`–`'7'` / `'1'`–`'12'`, which `compareByLabel` already compares numerically. It lives in `dashboards/client.ts` so the server and the config panel resolve the same default — the Sort picker was showing "Value (high → low)" as the default for date fields too, which was at least honest, but wrong.

The group cap needed the same treatment, or the fix would have traded one bad chart for another. `slice(0, limit)` on a chronologically sorted axis keeps the **oldest** buckets — a year of daily data under the default limit of 50 would have ended the chart in February and read as "we stopped getting records". `capGroups` keeps the most recent buckets for a calendar date axis, and the head for everything else (categorical dimensions, and date axes the user explicitly ranked by value).

The picker also now offers date-shaped labels for a date dimension — "Date (oldest → newest)" rather than "Label (A → Z)".

## Notes

- **No migration needed.** Existing widgets store no `sort`, so they pick up the new default on next render. A widget where someone deliberately chose a value sort keeps it.
- Cyclic granularities cap at 12 keys, so they never hit `capGroups`' date branch.

## Testing

New `group-order.test.ts` — 6 tests covering the default per granularity and all four cap cases. `pnpm exec vitest run src/resources/aggregate src/dashboards` → 14 files, 143 tests, green. Web typecheck clean; the lib typecheck ratchet reports no new errors from these files.

https://claude.ai/code/session_01JJxEfaKzGJCoiLSWkLqGqJ
