### PR TITLE
fix(data-connectors): release the connector when a multi-stream steady run ends

### DIFF
--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -163,8 +163,9 @@ export interface ConnectorStreamState {
   backfillFloor?: string
   /** Legacy single-shot incremental cursor (snapshot-first generic-rest path). */
   cursor?: string
-  /** Set by a connector's terminal `nextState` when its backfill is exhausted. */
-  backfillComplete?: boolean
+  // 🛑 No `backfillComplete` — write-only dead state, removed in task 43 §4. It sat at
+  // `false` forever on every app connector; `phase` is the real completion signal.
+  // Mirror of lib `ConnectorStreamState`, which carries the full rationale.
   /** Consecutive no-progress slices (pagination stall guard). Mirror of lib
    *  `ConnectorStreamState.noProgressStrikes`. */
   noProgressStrikes?: number

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -118,10 +118,11 @@ export interface ConnectorSyncSourceDeps {
   credential: RuntimeConnectionData | null
   config: DataConnectorConfig
   /**
-   * The run this slice belongs to. `phase` is the RUN's phase (one per run): inside a
-   * `backfill` run the last stream closes the run whichever phase it completed in,
-   * because a sibling may have kept its steady delta while another stream crawled
-   * (see `finalizeSteady`). Absent/null on a legacy single-shot run.
+   * The run this slice belongs to. `phase` is the RUN's phase (one per run). The last
+   * stream closes the run whichever phase IT completed in and whichever phase the RUN
+   * is — a sibling may have kept its steady delta while another stream crawled. The
+   * run phase now decides only whether the pending re-sync marker may be cleared (see
+   * `finalizeSteady`). Absent/null on a legacy single-shot run.
    */
   run: { id: string; startedAt: Date; phase?: 'backfill' | 'steady' | null }
   /** The pinned stream this source drives (its own continuation chain). */
@@ -156,8 +157,9 @@ export interface ConnectorSyncSourceDeps {
 /**
  * A `SyncSource` plus the handler-invoked steady finalize. `finalizeBackfill` is
  * fired by the runner (backfill, before the steady flip); `finalizeSteady` is fired
- * by the slice handler after a steady-phase completion (the runner already closed
- * the run). Both gate connector-level finalize on the B1 latch.
+ * by the slice handler after a steady-phase completion. Both gate connector-level
+ * finalize on the B1 latch, and in both the LAST stream closes the run — the handler
+ * no-ops the runner's own close for every run, in either phase (task 43).
  */
 export interface ConnectorSyncSource extends SyncSource {
   finalizeSteady(): Promise<void>
@@ -348,7 +350,7 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
       })
       return
     }
-    await this.finalizeConnectorLevel({ finalizeRun: true, phase: 'backfill' })
+    await this.finalizeConnectorLevel({ closeRun: true, clearResync: true, phase: 'backfill' })
   }
 
   async resolveRelationshipsAtPark(): Promise<void> {
@@ -372,16 +374,25 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
   }
 
   /**
-   * Fired by the slice HANDLER when THIS stream's STEADY pass completes. In a STEADY
-   * run the runner already closed the run; in a BACKFILL run this stream kept its
-   * watermark delta while a sibling crawled, the handler made the runner's close a
-   * no-op, and the last stream closes the run here. Either way the last stream
-   * resolves relationships + reconciles (which self-skips incremental streams) and
-   * releases the connector.
+   * Fired by the slice HANDLER when THIS stream's STEADY pass completes. The handler
+   * no-ops the runner's run-close for EVERY multi-stream run, so the last stream
+   * closes the run here in both phases; it also resolves relationships + reconciles
+   * (which self-skips incremental streams) and releases the connector.
+   *
+   * 🛑 `closeRun` is unconditional, and that is the fix for task 43. It used to read
+   * `run.phase === 'backfill'`, which made a STEADY run's last stream decrement the
+   * latch and release the connector but never close the run — harmless only because
+   * the runner had already closed it, which is the very race that stranded the
+   * connector. Suppressing the runner's close without this becomes "nobody closes the
+   * run"; the two changes are one change.
+   *
+   * `clearResync` stays gated on the phase: only a BACKFILL run re-crawls every
+   * stream carrying a pending mapping-edit re-sync, so only it may clear the marker.
    */
   async finalizeSteady(): Promise<void> {
     await this.finalizeConnectorLevel({
-      finalizeRun: this.deps.run.phase === 'backfill',
+      closeRun: true,
+      clearResync: this.deps.run.phase === 'backfill',
       phase: 'steady',
     })
   }
@@ -393,7 +404,10 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
    * Shared by both phase completions so the lifecycle can't drift between them.
    */
   private async finalizeConnectorLevel(opts: {
-    finalizeRun: boolean
+    /** Close the run. True for the last stream of EITHER phase (task 43). */
+    closeRun: boolean
+    /** Clear the pending mapping-edit re-sync marker. BACKFILL runs only. */
+    clearResync: boolean
     phase: 'backfill' | 'steady'
   }): Promise<void> {
     const remaining = await decrementConnectorBackfillLatch(this.deps.db, this.deps.connector.id)
@@ -450,10 +464,10 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
       errorSample: counters.errorSample,
     })
 
-    // Close the run when this finalize owns it (a backfill run; the runner delegates
-    // that here); a steady run was already finalized in the runner. Then release the
-    // connector claim + stamp the item count.
-    if (opts.finalizeRun) await ledger.finalize()
+    // The last stream closes the run, in BOTH phases — the handler no-ops the runner's
+    // close for every multi-stream run, so this is the only place it happens. Then
+    // release the connector claim + stamp the item count.
+    if (opts.closeRun) await ledger.finalize()
     await finalizeConnector(this.deps.db, this.deps.connector.id, {
       ok: true,
       itemCount: await countConnectorItems(this.deps.db, this.deps.connector.id),
@@ -461,8 +475,9 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     // A completed BACKFILL run re-crawled every stream with a pending mapping-edit
     // re-sync (the orchestrator never lets such a stream keep its delta), so the
     // marker is satisfied, so clear the banner. A steady run touches only deltas, so it
-    // must NOT clear a pending rebackfill/rebind.
-    if (opts.finalizeRun) {
+    // must NOT clear a pending rebackfill/rebind — hence a flag separate from
+    // `closeRun`, which a steady run's last stream DOES own.
+    if (opts.clearResync) {
       await clearResyncPending(this.deps.db, this.deps.connector.id)
     }
 

--- a/packages/lib/src/data-connectors/connectors/fixture.ts
+++ b/packages/lib/src/data-connectors/connectors/fixture.ts
@@ -59,7 +59,9 @@ export const fixtureConnector: DataConnectorDefinition = {
     logger.debug('fixture fetch', { streamKey: args.streamKey, count: records.length })
     return {
       records: yieldFixtures(records),
-      nextState: { ...args.state, backfillComplete: true },
+      // No `backfillComplete` — removed with the field itself (task 43 §4); `phase`
+      // is the completion signal and nothing ever read this back.
+      nextState: { ...args.state },
     }
   },
 

--- a/packages/lib/src/data-connectors/connectors/generic-rest.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest.ts
@@ -564,10 +564,14 @@ export const genericRestConnector: DataConnectorDefinition = {
     // The records iterable is lazy and emits resume checkpoints between pages. The
     // sliced `SyncSource` persists those checkpoints via the `SyncStateStore`; the
     // legacy single-shot path drains to exhaustion and persists `nextState` once at
-    // the end (a terminal `backfillComplete`, no mid-stream cursor).
+    // the end (no mid-stream cursor).
+    //
+    // 🛑 This used to stamp `backfillComplete: true`. Nothing ever read it back off the
+    // persisted stream state — `phase` is the completion signal — so it only served to
+    // make the state row look authoritative about something it did not track (task 43 §4).
     return {
       records: fetchRecords(args),
-      nextState: { ...args.state, backfillComplete: true },
+      nextState: { ...args.state },
     }
   },
 }

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -272,6 +272,8 @@ export {
   newRunCounters,
   openRun,
   persistStreamState,
+  readConnectorBackfillLatch,
+  releaseStrandedConnector,
   setItemPendingRelations,
   setRunRateLimited,
   touchItem,
@@ -291,6 +293,7 @@ export {
   STALE_RUN_MS,
   startConnectorSync,
   sweepStaleConnectorRuns,
+  sweepStrandedConnectors,
 } from './slice-orchestrator'
 // §1 global stale-run sweep — maintenance-schedule handler
 export {

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -222,6 +222,62 @@ export async function decrementConnectorBackfillLatch(
   return row?.remaining ?? null
 }
 
+/**
+ * Read the B1 latch without touching it (task 43 D-4).
+ *
+ * The latch decides whether a connector ever gets released, and until this existed it
+ * was inspectable ONLY by hand-reading `DataConnector.state` in SQL — which is how the
+ * strand that motivated task 43 had to be diagnosed. `null` ⇒ never initialized.
+ */
+export async function readConnectorBackfillLatch(
+  db: Database,
+  dataConnectorId: string
+): Promise<number | null> {
+  const row = await db.query.DataConnector.findFirst({
+    where: eq(schema.DataConnector.id, dataConnectorId),
+    columns: { state: true },
+  })
+  const remaining = (row?.state as { backfillStreamsRemaining?: unknown } | null)
+    ?.backfillStreamsRemaining
+  return typeof remaining === 'number' ? remaining : null
+}
+
+/**
+ * Release a connector stranded in `syncing` with no chain left to release it, and drop
+ * its leaked latch (task 43 D-3).
+ *
+ * 🛑 Deliberately NOT `finalizeConnector({ ok: true })`, for two reasons that both
+ * corrupt data:
+ *   1. that path writes `itemCount: input.itemCount ?? 0`, so releasing without
+ *      re-counting would ZERO the connector's record count — the same class of defect
+ *      as plans/records/bulk-delete-followups.md B.4;
+ *   2. it stamps `lastSyncedAt: now`, which would claim a sync happened at sweep time.
+ *      The strand is a lifecycle leak; the data landed whenever the run actually ran,
+ *      so `lastSyncedAt` must keep whatever the last real finalize recorded.
+ *
+ * `status` is re-checked in the WHERE so a connector legitimately re-claimed between
+ * the caller's read and this write is left alone.
+ */
+export async function releaseStrandedConnector(
+  db: Database,
+  dataConnectorId: string
+): Promise<boolean> {
+  const T = schema.DataConnector
+  const itemCount = await countConnectorItems(db, dataConnectorId)
+  const [released] = await db
+    .update(T)
+    .set({
+      status: 'live',
+      itemCount,
+      error: null,
+      state: sql`coalesce(${T.state}, '{}'::jsonb) - 'backfillStreamsRemaining'`,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(T.id, dataConnectorId), eq(T.status, 'syncing')))
+    .returning({ id: T.id })
+  return !!released
+}
+
 // ── Runs ────────────────────────────────────────────────────────────────────
 
 /** Mutable counters accumulated across a run, flushed in `finalizeRun`. */

--- a/packages/lib/src/data-connectors/slice-orchestrator-park-links.test.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator-park-links.test.ts
@@ -189,7 +189,12 @@ const updateChain = {
 
 const db = {
   query: {
-    DataConnector: { findFirst: async () => world.connector },
+    DataConnector: {
+      findFirst: async () => world.connector,
+      // `sweepStrandedConnectors` (task 43 D-3) runs at chain start. Faithful rather
+      // than stubbed empty: it only ever sees a connector left `syncing` by this world.
+      findMany: async () => (world.connector.status === 'syncing' ? [world.connector] : []),
+    },
     DataConnectorRun: {
       findFirst: async ({ where }: { where: unknown }) => {
         const ids = paramValues(where)

--- a/packages/lib/src/data-connectors/slice-orchestrator-resume.test.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator-resume.test.ts
@@ -131,7 +131,12 @@ const updateChain = {
 
 const db = {
   query: {
-    DataConnector: { findFirst: async () => world.connector },
+    DataConnector: {
+      findFirst: async () => world.connector,
+      // `sweepStrandedConnectors` (task 43 D-3) runs at chain start. Faithful rather
+      // than stubbed empty: it only ever sees a connector left `syncing` by this world.
+      findMany: async () => (world.connector.status === 'syncing' ? [world.connector] : []),
+    },
     DataConnectorRun: {
       findFirst: async ({ where }: { where: unknown }) => {
         const ids = paramValues(where)

--- a/packages/lib/src/data-connectors/slice-orchestrator-steady-latch.test.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator-steady-latch.test.ts
@@ -1,0 +1,357 @@
+// packages/lib/src/data-connectors/slice-orchestrator-steady-latch.test.ts
+// plans/money/tasks/43-connector-finalize-latch.md: the B1 latch must reach zero in a
+// MULTI-STREAM STEADY run, so the last stream runs the connector-level finalize and
+// releases the claim. Drives the REAL orchestrator (`startConnectorSync` +
+// `runBackfillSlice`), the real sync-core runner and the real
+// `ConnectorStreamSyncSource` over an in-memory world.
+//
+// The defect this pins: the runner used to close a steady run itself on the FIRST
+// stream to finish. Every sibling's next slice then read `status !== 'running'` and
+// returned WITHOUT decrementing the latch, so the latch never hit zero, the
+// connector-level finalize never fired, and the connector was stranded `syncing` with a
+// `completed` run — a state `sweepStaleConnectorRuns` (which only sees `running` runs)
+// can never rescue. Observed live on a 3-stream Shopify connector, latch stuck at 1.
+//
+// ⚠️ `drainSlices` runs slices SEQUENTIALLY, which makes the bug deterministic rather
+// than racy here: pre-fix, stream 1 closes the run and streams 2 and 3 both bail, so the
+// latch lands on 2. In production the streams run concurrently and the landing value
+// depends on how many got past the guard before the close committed (it was 1 there).
+// Either way the invariant under test is the same: the latch must reach 0.
+
+import { is, Param, SQL } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncState, SyncStateStore } from '../sync-core/contracts'
+import type { ConnectorStreamState, DataConnectorDefinition } from './types'
+
+interface FakeStream {
+  id: string
+  dataConnectorId: string
+  organizationId: string
+  streamKey: string
+  syncMode: 'snapshot' | 'incremental'
+  enabled: boolean
+  requestConfig: null
+  state: ConnectorStreamState
+}
+
+interface FakeRun {
+  id: string
+  dataConnectorId: string
+  status: 'running' | 'completed' | 'partial' | 'failed'
+  phase: 'backfill' | 'steady' | null
+  trigger: string
+  chainSnapshot: Record<string, unknown> | null
+  startedAt: Date
+  sampleLimit: number | null
+  fetched: number
+}
+
+/** Three streams, all already in steady — this is what makes the RUN phase steady. */
+const STREAM_KEYS = ['customers', 'orders', 'products'] as const
+
+const world = {
+  streams: new Map<string, FakeStream>(),
+  runs: [] as FakeRun[],
+  runSeq: 0,
+  connector: {} as Record<string, unknown>,
+  latch: null as number | null,
+  sliceQueue: [] as { streamId: string; runId: string }[],
+  finalized: [] as { ok: boolean }[],
+  resyncCleared: 0,
+  fetchCalls: [] as { streamKey: string }[],
+}
+
+function resetWorld() {
+  world.streams.clear()
+  world.runs.length = 0
+  world.runSeq = 0
+  world.latch = null
+  world.sliceQueue.length = 0
+  world.finalized.length = 0
+  world.resyncCleared = 0
+  world.fetchCalls.length = 0
+  world.connector = {
+    id: 'dc1',
+    organizationId: 'org1',
+    type: 'fixture',
+    credentialId: null,
+    appInstallationId: null,
+    createdById: 'u1',
+    config: {},
+    state: null,
+    status: 'live',
+    // A pending mapping-edit marker, so the test can prove a STEADY run does not
+    // clear it even though its last stream now closes the run.
+    resyncPending: { level: 'rebackfill', reasons: ['record-filter'] },
+  }
+  for (const key of STREAM_KEYS) {
+    world.streams.set(`s-${key}`, {
+      id: `s-${key}`,
+      dataConnectorId: 'dc1',
+      organizationId: 'org1',
+      streamKey: key,
+      syncMode: 'incremental',
+      enabled: true,
+      requestConfig: null,
+      state: { phase: 'steady', watermark: 'W1', recordsSeen: 10 },
+    })
+  }
+}
+
+function paramValues(where: unknown): unknown[] {
+  const out: unknown[] = []
+  const walk = (chunk: unknown) => {
+    if (is(chunk, SQL)) for (const c of chunk.queryChunks) walk(c)
+    else if (is(chunk, Param)) out.push(chunk.value)
+    else if (Array.isArray(chunk)) for (const c of chunk) walk(c)
+    else if (typeof chunk === 'string' || chunk instanceof Date) out.push(chunk)
+  }
+  walk(where)
+  return out
+}
+
+const updateChain = { set: () => updateChain, where: () => updateChain, returning: async () => [] }
+
+const db = {
+  query: {
+    DataConnector: {
+      findFirst: async () => world.connector,
+      // `sweepStrandedConnectors` (task 43 D-3) runs at chain start. Faithful rather
+      // than stubbed empty: it only ever sees a connector left `syncing` by this world.
+      findMany: async () => (world.connector.status === 'syncing' ? [world.connector] : []),
+    },
+    DataConnectorRun: {
+      findFirst: async ({ where }: { where: unknown }) => {
+        const ids = paramValues(where)
+        return world.runs.find((r) => ids.includes(r.id)) ?? null
+      },
+      findMany: async ({ where }: { where: unknown }) => {
+        const params = paramValues(where)
+        return world.runs
+          .filter((r) => params.includes(r.dataConnectorId))
+          .map((r) => ({ id: r.id }))
+      },
+    },
+    DataConnectorStream: {
+      findFirst: async ({ where }: { where: unknown }) => {
+        const ids = paramValues(where)
+        return [...world.streams.values()].find((s) => ids.includes(s.id)) ?? null
+      },
+      findMany: async ({ where }: { where: unknown }) => {
+        const ids = paramValues(where)
+        return [...world.streams.values()].filter((s) => ids.includes(s.id))
+      },
+    },
+  },
+  update: () => updateChain,
+}
+
+vi.mock('./service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./service')>()
+  return {
+    ...actual,
+    loadConnector: async () => ({
+      connector: world.connector,
+      streams: [...world.streams.values()].map((s) => ({
+        stream: s,
+        syncMode: s.syncMode,
+        mappings: [],
+      })),
+    }),
+    claimForSync: async () => true,
+    initConnectorBackfillLatch: async (_db: unknown, _id: string, n: number) => {
+      world.latch = n
+    },
+    decrementConnectorBackfillLatch: async () => {
+      if (world.latch === null) return null
+      world.latch = Math.max(world.latch - 1, 0)
+      return world.latch
+    },
+    openRun: async (_db: unknown, input: { trigger: string; phase?: 'backfill' | 'steady' }) => {
+      const run: FakeRun = {
+        id: `run${++world.runSeq}`,
+        dataConnectorId: 'dc1',
+        status: 'running',
+        phase: input.phase ?? null,
+        trigger: input.trigger,
+        chainSnapshot: (input as { chainSnapshot?: Record<string, unknown> }).chainSnapshot ?? null,
+        startedAt: new Date(),
+        sampleLimit: null,
+        fetched: 0,
+      }
+      world.runs.push(run)
+      return run
+    },
+    persistStreamState: async (_db: unknown, streamId: string, state: ConnectorStreamState) => {
+      const s = world.streams.get(streamId)
+      if (s) s.state = state
+    },
+    getRunFetched: async (_db: unknown, runId: string) =>
+      world.runs.find((r) => r.id === runId)?.fetched ?? 0,
+    parkBackfillAtCeiling: async () => {},
+    finalizeConnector: async (_db: unknown, _id: string, input: { ok: boolean }) => {
+      world.connector.status = input.ok ? 'live' : 'error'
+      world.finalized.push(input)
+    },
+    countConnectorItems: async () => 0,
+    clearResyncPending: async () => {
+      world.resyncCleared += 1
+      world.connector.resyncPending = null
+    },
+    foldRunManifest: async () => {},
+    markRunManifestDegraded: async () => {},
+    getRunManifest: async () => null,
+    publishSyncRecordsChanged: async () => {},
+    setRunRateLimited: async () => {},
+    parkConnectorSampleIfLastStream: async () => {},
+  }
+})
+
+vi.mock('./sync-core-adapters', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./sync-core-adapters')>()
+  return {
+    ...actual,
+    createStreamSyncStateStore: (_db: unknown, streamId: string): SyncStateStore => ({
+      load: async () => actual.syncStateFromStream(world.streams.get(streamId)?.state ?? {}),
+      save: async (sync: SyncState) => {
+        const s = world.streams.get(streamId)
+        if (s) s.state = actual.applySyncStateToStream(s.state, sync)
+      },
+    }),
+    createConnectorRunLedger: (_db: unknown, run: { id: string }) => ({
+      recordSlice: async (entry: { counters?: { fetched?: number } }) => {
+        const r = world.runs.find((x) => x.id === run.id)
+        if (r) r.fetched += entry.counters?.fetched ?? 0
+      },
+      finalize: async () => {
+        const r = world.runs.find((x) => x.id === run.id)
+        if (r) r.status = 'completed'
+      },
+      fail: async () => {
+        const r = world.runs.find((x) => x.id === run.id)
+        if (r) r.status = 'failed'
+      },
+    }),
+  }
+})
+
+vi.mock('./data-connector-queue', () => ({
+  enqueueBackfillSlice: async (data: { streamId: string; runId: string }) => {
+    world.sliceQueue.push({ streamId: data.streamId, runId: data.runId })
+  },
+  enqueueConnectorSync: async () => {},
+}))
+
+vi.mock('./realtime', () => ({ publishConnectorSync: async () => {} }))
+vi.mock('../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishRecordsInvalidated: async () => {},
+  publishRunCompleted: async () => {},
+}))
+vi.mock('./provisioning', () => ({ materializeConnectorTargets: async () => {} }))
+vi.mock('../apps/installations/app-field-provisioning', () => ({
+  reconcileInstallationAppFields: async () => ({ errors: [] }),
+}))
+vi.mock('../agents/bindings/resolve', () => ({ resolveConnectorFieldRef: async () => 'resolved' }))
+vi.mock('../sync-core/throttle', () => ({
+  createThrottleHandle: () => ({ run: (fn: () => unknown) => fn() }),
+}))
+vi.mock('../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    async warmCache() {}
+  },
+}))
+vi.mock('../record-rules/sync-manifest-collector', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../record-rules/sync-manifest-collector')>()
+  return { ...actual, loadManifestCollector: async () => actual.createManifestCollector({}) }
+})
+vi.mock('./relationship-pass', () => ({ resolveRelationships: async () => {} }))
+vi.mock('./reconciliation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./reconciliation')>()
+  return { ...actual, reconcileManagedMarkers: async () => {} }
+})
+vi.mock('./sink-source-record', () => ({
+  sinkSourceRecord: async (ctx: { counters: { fetched: number } }) => {
+    ctx.counters.fetched += 1
+  },
+}))
+vi.mock('./sinks/entity-sink', () => ({
+  entitySink: { listExistingItems: async () => [], archiveRecord: async () => {} },
+}))
+
+/** Every stream yields a one-page delta and a terminal watermark checkpoint. */
+function fixtureDefinition(): DataConnectorDefinition {
+  return {
+    type: 'fixture',
+    schemaVersion: 1,
+    requestModel: 'fixed',
+    streams: [],
+    fetch: async (args) => {
+      world.fetchCalls.push({ streamKey: args.streamKey })
+      async function* one() {
+        yield { streamKey: args.streamKey, fields: { id: `${args.streamKey}-1` } }
+        yield { __checkpoint: true as const, watermark: 'W2' }
+      }
+      return { records: one(), nextState: {} }
+    },
+  }
+}
+vi.mock('./connector-runtime', () => ({
+  prepareConnectorFetch: async () => ({ definition: fixtureDefinition(), credential: null }),
+}))
+
+import { runBackfillSlice, startConnectorSync } from './slice-orchestrator'
+
+const DB = db as never
+
+async function drainSlices(): Promise<void> {
+  while (world.sliceQueue.length > 0) {
+    const job = world.sliceQueue.shift()!
+    await runBackfillSlice(DB, {
+      connectorId: 'dc1',
+      organizationId: 'org1',
+      streamId: job.streamId,
+      runId: job.runId,
+    })
+  }
+}
+
+beforeEach(resetWorld)
+
+describe('B1 latch in a multi-stream STEADY run (task 43)', () => {
+  it('drives the latch to zero so the last stream finalizes and releases the connector', async () => {
+    await startConnectorSync(DB, 'org1', 'dc1', { trigger: 'manual' })
+
+    // Guard the premise: every stream was already steady, so this is a STEADY run.
+    // If this ever flips to `backfill` the test stops covering the defect.
+    expect(world.runs[0]?.phase).toBe('steady')
+    expect(world.latch).toBe(STREAM_KEYS.length)
+
+    await drainSlices()
+
+    // Every stream ran its delta — none bailed early on a prematurely closed run.
+    expect(world.fetchCalls.map((c) => c.streamKey).sort()).toEqual([...STREAM_KEYS].sort())
+
+    // 🛑 The regression. Pre-fix the runner closed the run on the first stream, the
+    // other two bailed without decrementing, and this landed on 2.
+    expect(world.latch).toBe(0)
+
+    // The last stream owns the run close AND the connector release.
+    expect(world.runs[0]?.status).toBe('completed')
+    expect(world.connector.status).toBe('live')
+    // Exactly once — the latch is what stops the other two streams finalizing too.
+    expect(world.finalized).toHaveLength(1)
+    expect(world.finalized[0]?.ok).toBe(true)
+  })
+
+  it('does not clear a pending re-sync marker, even though its last stream closes the run', async () => {
+    // The D-1 split: `closeRun` is unconditional but `clearResync` stays backfill-only.
+    // Collapsing them back into one flag would silently clear this marker.
+    await startConnectorSync(DB, 'org1', 'dc1', { trigger: 'manual' })
+    await drainSlices()
+
+    expect(world.runs[0]?.status).toBe('completed')
+    expect(world.resyncCleared).toBe(0)
+    expect(world.connector.resyncPending).not.toBeNull()
+  })
+})

--- a/packages/lib/src/data-connectors/slice-orchestrator.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator.ts
@@ -14,7 +14,7 @@ import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { ResourceFieldId } from '@auxx/types/field'
-import { and, eq, inArray, lt } from 'drizzle-orm'
+import { and, desc, eq, inArray, lt } from 'drizzle-orm'
 import { resolveConnectorFieldRef } from '../agents/bindings/resolve'
 import { reconcileInstallationAppFields } from '../apps/installations/app-field-provisioning'
 import type { ConditionGroup } from '../conditions/types'
@@ -41,6 +41,8 @@ import {
   parkBackfillAtCeiling,
   parkConnectorSampleIfLastStream,
   persistStreamState,
+  readConnectorBackfillLatch,
+  releaseStrandedConnector,
   setRunRateLimited,
 } from './service'
 import { createConnectorRunLedger, createStreamSyncStateStore } from './sync-core-adapters'
@@ -127,7 +129,6 @@ export function freshBackfillState(
     backfillStartedAt: startedAtIso,
     recordsSeen: 0,
     watermark: undefined,
-    backfillComplete: false,
     // Step 9 §1.2 — pin the window floor ONCE so every slice injects the same value
     // (no per-slice `now` drift). Undefined ⇒ span 'all' / no window ⇒ full history.
     backfillFloor,
@@ -191,8 +192,15 @@ async function startConnectorSyncInner(
   // `syncMode='incremental'` instead fetches a cheap watermark catch-up (its state is
   // deliberately NOT reset below) and never archives. `sweep` flows from the run snapshot.
   const isSweep = options.trigger === 'sweep'
-  // Clear a crashed prior chain first so its stuck claim can't block us (H5).
+  // Clear a crashed prior chain first so its stuck claim can't block us (H5), then the
+  // opposite shape: a claim leaked by a run that ENDED (task 43 D-3). Without the second
+  // call a stranded connector can never be re-synced from the UI at all — `claimForSync`
+  // refuses while `status = 'syncing'`, so every "Sync now" silently no-ops forever.
+  //
+  // ⚠️ Both are age-gated on `STALE_RUN_MS`, so a strand younger than that survives one
+  // click; the periodic job picks it up within the next sweep either way.
   await sweepStaleConnectorRuns(db, { dataConnectorId })
+  await sweepStrandedConnectors(db, { dataConnectorId })
 
   // One connector-row fetch feeds both the provision pass (type → appSlug) and the
   // app-field reconcile below (appInstallationId).
@@ -493,10 +501,21 @@ export async function runBackfillSlice(
     where: eq(schema.DataConnectorRun.id, runId),
   })
   if (!run || run.status !== 'running') {
-    logger.info('runBackfillSlice: run not active, stopping chain', {
+    // 🛑 This stream's chain ends here WITHOUT decrementing the B1 latch — the decrement
+    // lives in the source's connector-level finalize, which this return skips. That is
+    // benign when the run was cancelled or already failed, and a defect when the run was
+    // closed under a still-working sibling (task 43). `leakedLatch` is what tells the two
+    // apart after the fact: a nonzero value on a run that reads `completed` means the
+    // connector is about to be stranded `syncing`, which is otherwise only visible by
+    // hand-reading `DataConnector.state`.
+    const leakedLatch =
+      run?.status === 'completed' ? await readConnectorBackfillLatch(db, connectorId) : null
+    const log = leakedLatch && leakedLatch > 0 ? logger.warn : logger.info
+    log('runBackfillSlice: run not active, stopping chain', {
       runId,
       streamId,
       status: run?.status,
+      leakedLatch,
     })
     return
   }
@@ -556,22 +575,30 @@ export async function runBackfillSlice(
       ? { ...SLICE_BUDGET, maxRecords: Math.min(SLICE_BUDGET.maxRecords, run.sampleLimit) }
       : SLICE_BUDGET
 
-  // In a BACKFILL run the last stream closes the run (B1 latch, via the source's
-  // connector-level finalize), never the runner. A stream that kept its steady delta
-  // inside this run completes as `steady`, where the runner would call
-  // `ledger.finalize()` and close the run under sibling chains that are still crawling
-  // (their next slice reads `status !== 'running'` and stops, stranding the connector
-  // `syncing`). Make that call a no-op here; `finalizeSteady` closes the run instead
-  // when it is the last stream. A STEADY run keeps the runner's single-pass close.
+  // The last stream closes the run (B1 latch, via the source's connector-level
+  // finalize), never the runner — in EITHER phase. A stream that completes as `steady`
+  // would otherwise have the runner call `ledger.finalize()` and close the run under
+  // sibling chains that are still crawling; their next slice reads `status !== 'running'`
+  // and returns WITHOUT decrementing the latch, so the latch never reaches zero, the
+  // connector-level finalize never fires, and the connector is stranded `syncing` with
+  // a `completed` run that `sweepStaleConnectorRuns` (which only sees `running` runs)
+  // can never rescue.
+  //
+  // 🛑 This used to be scoped to `run.phase === 'backfill'`, on the premise that "a
+  // STEADY run keeps the runner's single-pass close". A steady run is single-pass PER
+  // STREAM, and a connector has as many chains as streams — so a 3-stream steady run
+  // raced exactly as described above and stranded a live connector
+  // (plans/money/tasks/43-connector-finalize-latch.md).
+  //
+  // ⚠️ Only safe together with `finalizeSteady` passing `closeRun: true` unconditionally.
+  // Suppressing the runner's close while the source still gated its own close on
+  // `phase === 'backfill'` would leave NOBODY closing a steady run.
   const ledger = createConnectorRunLedger(db, { id: runId, startedAt: run.startedAt }, streamId)
-  const sliceLedger =
-    run.phase === 'backfill'
-      ? {
-          recordSlice: (entry: SliceLedgerEntry) => ledger.recordSlice(entry),
-          finalize: async () => {},
-          fail: (error: Error) => ledger.fail(error),
-        }
-      : ledger
+  const sliceLedger = {
+    recordSlice: (entry: SliceLedgerEntry) => ledger.recordSlice(entry),
+    finalize: async () => {},
+    fail: (error: Error) => ledger.fail(error),
+  }
 
   const sliceSignal = signal ?? new AbortController().signal
   const outcome = await runSyncSlice({
@@ -735,4 +762,72 @@ export async function sweepStaleConnectorRuns(
     })
   }
   return stale.length
+}
+
+/**
+ * Release connectors stuck `syncing` whose newest run has already ENDED (task 43 D-3).
+ *
+ * {@link sweepStaleConnectorRuns} keys on `status = 'running'` + a cold heartbeat, so it
+ * is structurally blind to the opposite shape: a run that finished cleanly while leaking
+ * the B1 latch, leaving the connector claimed with no chain alive to release it. Nothing
+ * else looks for that, which is why the strand behind task 43 needed a manual SQL fix.
+ *
+ * With D-1 + D-2 in place a leak now parks the run `running` instead, which the sweep
+ * above already rescues — so this should be unreachable. It is the backstop for the NEXT
+ * leak of the class, not a fix for a live one.
+ *
+ * 🛑 The predicate is "newest run is TERMINAL and ended before the threshold", never the
+ * latch value. Keying off a nonzero latch would kill a legitimately running multi-stream
+ * chain, whose latch is nonzero for its entire life by design.
+ *
+ * ⚠️ A connector claimed but with NO run at all (a crash between `claimForSync` and
+ * `openRun`) is also released, keyed on its own `updatedAt`.
+ */
+export async function sweepStrandedConnectors(
+  db: Database,
+  opts: { dataConnectorId?: string; staleMs?: number } = {}
+): Promise<number> {
+  const threshold = new Date(Date.now() - (opts.staleMs ?? STALE_RUN_MS))
+
+  const claimed = await db.query.DataConnector.findMany({
+    where: and(
+      eq(schema.DataConnector.status, 'syncing'),
+      ...(opts.dataConnectorId ? [eq(schema.DataConnector.id, opts.dataConnectorId)] : [])
+    ),
+    columns: { id: true, organizationId: true, updatedAt: true },
+  })
+  if (claimed.length === 0) return 0
+
+  let released = 0
+  for (const connector of claimed) {
+    const [newest] = await db
+      .select({
+        status: schema.DataConnectorRun.status,
+        finishedAt: schema.DataConnectorRun.finishedAt,
+      })
+      .from(schema.DataConnectorRun)
+      .where(eq(schema.DataConnectorRun.dataConnectorId, connector.id))
+      .orderBy(desc(schema.DataConnectorRun.startedAt))
+      .limit(1)
+
+    // A live chain — leave it to `sweepStaleConnectorRuns`, which owns the cold-heartbeat
+    // case and can actually fail the run.
+    if (newest?.status === 'running') continue
+
+    const endedAt = newest ? (newest.finishedAt ?? connector.updatedAt) : connector.updatedAt
+    if (endedAt.getTime() > threshold.getTime()) continue
+
+    // Report the leaked latch before clearing it — this is the number that explains WHY
+    // the connector was stranded, and it is gone the moment the release commits.
+    const latch = await readConnectorBackfillLatch(db, connector.id)
+    if (!(await releaseStrandedConnector(db, connector.id))) continue
+    released += 1
+    logger.warn('sweepStrandedConnectors: released a connector stuck syncing with no live run', {
+      dataConnectorId: connector.id,
+      newestRunStatus: newest?.status ?? 'none',
+      leakedLatch: latch,
+    })
+    await publishConnectorSync(db, connector.organizationId, connector.id, 'run-finished')
+  }
+  return released
 }

--- a/packages/lib/src/data-connectors/stale-sweep-job.ts
+++ b/packages/lib/src/data-connectors/stale-sweep-job.ts
@@ -9,18 +9,30 @@
 import { database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { JobContext } from '../jobs/types'
-import { sweepStaleConnectorRuns } from './slice-orchestrator'
+import { sweepStaleConnectorRuns, sweepStrandedConnectors } from './slice-orchestrator'
 
 const logger = createScopedLogger('data-connector-stale-sweep')
 
 export const DATA_CONNECTOR_STALE_SWEEP_JOB_NAME = 'dataConnectorStaleSweepJob'
 
-/** Global stale-run sweep handler. Idempotent + cheap — touches only cold runs. */
+/**
+ * Global stale-run sweep handler. Idempotent + cheap — touches only cold runs and
+ * connectors whose newest run has already ended.
+ *
+ * Two opposite failure shapes, one job: a chain that DIED mid-run leaves a `running` run
+ * with a cold heartbeat ({@link sweepStaleConnectorRuns}); a chain that FINISHED while
+ * leaking the B1 latch leaves a terminal run and a claim nobody drops
+ * ({@link sweepStrandedConnectors}, task 43 D-3). Neither sweep sees the other's shape.
+ */
 export async function dataConnectorStaleSweepJob(
   ctx: JobContext<{ staleMs?: number } | undefined>
 ): Promise<void> {
   const swept = await sweepStaleConnectorRuns(database, { staleMs: ctx.data?.staleMs })
   if (swept > 0) {
     logger.warn('Swept stale connector runs', { count: swept })
+  }
+  const stranded = await sweepStrandedConnectors(database, { staleMs: ctx.data?.staleMs })
+  if (stranded > 0) {
+    logger.warn('Released stranded connectors', { count: stranded })
   }
 }

--- a/packages/lib/src/data-connectors/sweep-stranded-connectors.test.ts
+++ b/packages/lib/src/data-connectors/sweep-stranded-connectors.test.ts
@@ -1,0 +1,230 @@
+// packages/lib/src/data-connectors/sweep-stranded-connectors.test.ts
+// plans/money/tasks/43-connector-finalize-latch.md D-3: the backstop that releases a
+// connector stuck `syncing` when its newest run has already ENDED — the shape
+// `sweepStaleConnectorRuns` is structurally blind to, because that one keys on
+// `status = 'running'` plus a cold heartbeat.
+//
+// The three things worth pinning, in order of how expensive getting them wrong is:
+//   1. it must NOT touch a connector whose chain is genuinely still running;
+//   2. it must NOT re-count `itemCount` as 0 or restamp `lastSyncedAt` (both would
+//      corrupt what the detail view reports — see `releaseStrandedConnector`);
+//   3. it must clear the leaked latch, and report the value BEFORE clearing it.
+
+import { is, Param, SQL } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface FakeConnector {
+  id: string
+  organizationId: string
+  status: string
+  itemCount: number
+  lastSyncedAt: Date | null
+  error: string | null
+  state: Record<string, unknown> | null
+  updatedAt: Date
+}
+
+interface FakeRun {
+  dataConnectorId: string
+  status: 'running' | 'completed' | 'partial' | 'failed'
+  startedAt: Date
+  finishedAt: Date | null
+}
+
+const MINUTE = 60_000
+const NOW = new Date('2026-09-03T22:30:00Z')
+/** Older than STALE_RUN_MS (5 min), so the age gate passes. */
+const LONG_AGO = new Date(NOW.getTime() - 30 * MINUTE)
+/** Inside the threshold — must be left alone as possibly mid-finalize. */
+const JUST_NOW = new Date(NOW.getTime() - 10_000)
+
+const world = {
+  connectors: [] as FakeConnector[],
+  runs: [] as FakeRun[],
+  published: [] as string[],
+  itemCount: 4242,
+}
+
+function connector(over: Partial<FakeConnector> = {}): FakeConnector {
+  return {
+    id: 'dc1',
+    organizationId: 'org1',
+    status: 'syncing',
+    itemCount: 4242,
+    lastSyncedAt: new Date('2026-09-03T22:08:47Z'),
+    error: null,
+    state: { backfillStreamsRemaining: 1 },
+    updatedAt: LONG_AGO,
+    ...over,
+  }
+}
+
+function paramValues(where: unknown): unknown[] {
+  const out: unknown[] = []
+  const walk = (chunk: unknown) => {
+    if (is(chunk, SQL)) for (const c of chunk.queryChunks) walk(c)
+    else if (is(chunk, Param)) out.push(chunk.value)
+    else if (Array.isArray(chunk)) for (const c of chunk) walk(c)
+    else if (typeof chunk === 'string' || chunk instanceof Date) out.push(chunk)
+  }
+  walk(where)
+  return out
+}
+
+/** Minimal drizzle stand-in: `select().from().where().orderBy().limit()` for runs. */
+const db = {
+  query: {
+    DataConnector: {
+      findMany: async ({ where }: { where: unknown }) => {
+        const params = paramValues(where)
+        return world.connectors
+          .filter((c) => c.status === 'syncing')
+          .filter((c) => (params.includes('dc2') ? c.id === 'dc2' : true))
+      },
+      findFirst: async ({ where }: { where: unknown }) => {
+        const ids = paramValues(where)
+        return world.connectors.find((c) => ids.includes(c.id)) ?? null
+      },
+    },
+  },
+  // Two different reads land here, told apart by their PROJECTION rather than by a
+  // thenable object (which `lint/suspicious/noThenProperty` rightly refuses):
+  //   - `countConnectorItems` selects `{ n: count() }`, awaited directly
+  //   - the newest-run lookup selects run columns and chains `.orderBy().limit()`
+  // 🛑 `countConnectorItems` cannot be stubbed with `vi.mock('./service')` here:
+  // `releaseStrandedConnector` calls it from INSIDE the same module, and module mocking
+  // does not intercept intra-module calls. The fake has to answer the real query.
+  select: (projection: Record<string, unknown>) => ({
+    from: () => ({
+      where: (w: unknown) =>
+        'n' in projection
+          ? Promise.resolve([{ n: world.itemCount }])
+          : {
+              orderBy: () => ({
+                limit: async () => {
+                  const ids = paramValues(w)
+                  const rows = world.runs
+                    .filter((r) => ids.includes(r.dataConnectorId))
+                    .sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime())
+                  return rows.length > 0 ? [rows[0]] : []
+                },
+              }),
+            },
+    }),
+  }),
+  update: () => ({
+    set: (patch: Record<string, unknown>) => ({
+      where: (w: unknown) => ({
+        returning: async () => {
+          const ids = paramValues(w)
+          // The release re-checks `status = 'syncing'` in its WHERE; honour that.
+          const target = world.connectors.find((c) => ids.includes(c.id) && c.status === 'syncing')
+          if (!target) return []
+          if (typeof patch.status === 'string') target.status = patch.status
+          if (typeof patch.itemCount === 'number') target.itemCount = patch.itemCount
+          if ('error' in patch) target.error = patch.error as string | null
+          // `state` arrives as a SQL expression that strips the latch key.
+          if ('state' in patch) {
+            const { backfillStreamsRemaining: _drop, ...rest } = target.state ?? {}
+            target.state = rest
+          }
+          if (patch.lastSyncedAt instanceof Date) target.lastSyncedAt = patch.lastSyncedAt
+          return [{ id: target.id }]
+        },
+      }),
+    }),
+  }),
+}
+
+// `./service` is deliberately NOT mocked — `releaseStrandedConnector` and
+// `readConnectorBackfillLatch` are exactly what this file is testing, and they run
+// against the fake db above.
+vi.mock('./realtime', () => ({
+  publishConnectorSync: async (_db: unknown, _org: string, id: string) => {
+    world.published.push(id)
+  },
+}))
+
+import { sweepStrandedConnectors } from './slice-orchestrator'
+
+const DB = db as never
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+  world.connectors = []
+  world.runs = []
+  world.published = []
+  world.itemCount = 4242
+})
+
+describe('sweepStrandedConnectors (task 43 D-3)', () => {
+  it('releases a connector whose newest run completed while leaking the latch', async () => {
+    world.connectors = [connector()]
+    world.runs = [
+      { dataConnectorId: 'dc1', status: 'completed', startedAt: LONG_AGO, finishedAt: LONG_AGO },
+    ]
+
+    expect(await sweepStrandedConnectors(DB)).toBe(1)
+
+    const c = world.connectors[0]!
+    expect(c.status).toBe('live')
+    // 🛑 The leaked latch is gone — otherwise the next run's finalize could inherit it.
+    expect(c.state).toEqual({})
+    expect(world.published).toEqual(['dc1'])
+  })
+
+  it('preserves lastSyncedAt and re-counts itemCount rather than zeroing it', async () => {
+    // Both are corruptions `finalizeConnector({ ok: true })` would have caused: it writes
+    // `itemCount ?? 0` and stamps `lastSyncedAt: now`.
+    const before = new Date('2026-09-03T22:08:47Z')
+    world.connectors = [connector({ lastSyncedAt: before, itemCount: 999 })]
+    world.runs = [
+      { dataConnectorId: 'dc1', status: 'completed', startedAt: LONG_AGO, finishedAt: LONG_AGO },
+    ]
+
+    await sweepStrandedConnectors(DB)
+
+    const c = world.connectors[0]!
+    expect(c.lastSyncedAt).toEqual(before)
+    expect(c.itemCount).toBe(4242)
+  })
+
+  it('leaves a connector alone while its chain is still running', async () => {
+    world.connectors = [connector()]
+    world.runs = [
+      { dataConnectorId: 'dc1', status: 'running', startedAt: LONG_AGO, finishedAt: null },
+    ]
+
+    expect(await sweepStrandedConnectors(DB)).toBe(0)
+    expect(world.connectors[0]?.status).toBe('syncing')
+    // The latch of a live multi-stream chain is nonzero BY DESIGN — never a trigger.
+    expect(world.connectors[0]?.state).toEqual({ backfillStreamsRemaining: 1 })
+  })
+
+  it('leaves a just-finished run alone (it may still be mid-finalize)', async () => {
+    world.connectors = [connector()]
+    world.runs = [
+      { dataConnectorId: 'dc1', status: 'completed', startedAt: JUST_NOW, finishedAt: JUST_NOW },
+    ]
+
+    expect(await sweepStrandedConnectors(DB)).toBe(0)
+    expect(world.connectors[0]?.status).toBe('syncing')
+  })
+
+  it('releases a connector claimed with no run at all, keyed on its own updatedAt', async () => {
+    // A crash between `claimForSync` and `openRun`.
+    world.connectors = [connector({ state: null })]
+    world.runs = []
+
+    expect(await sweepStrandedConnectors(DB)).toBe(1)
+    expect(world.connectors[0]?.status).toBe('live')
+  })
+
+  it('ignores connectors that are not syncing', async () => {
+    world.connectors = [connector({ status: 'live' }), connector({ id: 'dc9', status: 'paused' })]
+    world.runs = []
+
+    expect(await sweepStrandedConnectors(DB)).toBe(0)
+  })
+})

--- a/packages/lib/src/data-connectors/sync-core-adapters.ts
+++ b/packages/lib/src/data-connectors/sync-core-adapters.ts
@@ -33,9 +33,10 @@ export function syncStateFromStream(state: ConnectorStreamState): SyncState {
 
 /**
  * Merge a core `SyncState` back onto the persisted `ConnectorStreamState`,
- * preserving legacy/extra keys (`cursor`/`backfillComplete` from the single-shot
- * path, plus any connector-specific bookkeeping). Spread-first so only the
- * core-owned fields are overwritten.
+ * preserving legacy/extra keys (`cursor` from the single-shot path, the
+ * `backfillComplete` that older rows still carry from before task 43 §4 dropped it,
+ * plus any connector-specific bookkeeping). Spread-first so only the core-owned
+ * fields are overwritten.
  */
 export function applySyncStateToStream(
   prev: ConnectorStreamState,

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -216,7 +216,7 @@ export interface StreamWebhookTrigger {
  * Durable per-stream sync state (jsonb on `DataConnectorStream.state`). Persisted
  * across runs and checkpointed AFTER every committed slice. The shared sync-core
  * `SyncStateStore` adapter (sync-core/contracts `SyncState`) maps onto this; the
- * legacy single-shot generic-rest fetch path reads `cursor`/`backfillComplete`.
+ * legacy single-shot generic-rest fetch path reads `cursor`.
  *
  * This shape MUST stay byte-compatible with the DB mirror
  * `ConnectorStreamState` in `@auxx/database` schema/`data-connector-types.ts` —
@@ -245,8 +245,17 @@ export interface ConnectorStreamState {
   backfillFloor?: string
   /** Legacy single-shot incremental cursor (snapshot-first generic-rest path). */
   cursor?: string
-  /** Set by a connector's terminal `nextState` when its backfill is exhausted. */
-  backfillComplete?: boolean
+  // 🛑 No `backfillComplete` here, deliberately. It was written (`false` by
+  // `freshBackfillState`, `true` by generic-rest's terminal `nextState`) and read by
+  // NOTHING, so on every app connector it sat at `false` forever — a permanent false
+  // negative for anyone who took it to mean "this stream finished its backfill". The
+  // real signal is `phase` (`backfill` → `steady`). Removed in task 43 §4.
+  //
+  // ⚠️ Not to be confused with `AppConnectorPage['nextState'].backfillComplete`
+  // (`connectors/app-connector-adapter.ts`), which is the LIVE wire-protocol flag an
+  // app returns to mark its last page. That one is load-bearing — leave it alone.
+  //
+  // Existing rows still carry the key; the index signature below tolerates it.
   /** Consecutive no-progress slices (stall guard) — see the core `SyncState`. */
   noProgressStrikes?: number
   [key: string]: unknown


### PR DESCRIPTION
## The bug

A 3-stream Shopify connector finished a clean 900ms delta run and was left in `syncing` **forever**, with `lastSyncedAt` stuck on the previous run. Nothing self-healed it — the run was `completed`, and `sweepStaleConnectorRuns` only looks at `running` runs with a cold heartbeat. Recovery required raw SQL.

Found on a live connector: latch stuck at `1`, three enabled streams, zero running runs.

## Root cause

The connector-level finalize is gated on the B1 latch, decremented only inside `finalizeConnectorLevel`. In a **steady** run the runner closed the run itself on the first stream to finish (`slice-runner.ts:190`); every sibling's next slice then read `status !== 'running'` (`slice-orchestrator.ts:495`) and returned **without decrementing**. The latch never reached zero, so the finalize never fired and the claim was never released.

`slice-orchestrator.ts` already documented this exact hazard and no-op'd the runner's close to prevent it — but scoped to `run.phase === 'backfill'`, closing with *"A STEADY run keeps the runner's single-pass close."* That premise is the bug: a steady run is single-pass **per stream**, and a connector has as many chains as streams.

It stayed hidden because every earlier run on this connector was a backfill, where the guard applies. The first pure steady run with >1 stream hit it immediately.

## The fix

Two halves, and **neither works alone**:

- **Split `finalizeRun` into `closeRun` / `clearResync`.** The last stream must close the run in *both* phases, but only a backfill run may clear a pending mapping-edit re-sync marker.
- **Make the runner's-close no-op unconditional.** The run stays `running` until the last stream finalizes, so no sibling ever hits the bail.

Suppressing the close *without* the flag split would leave **nobody** closing a steady run, since `finalizeSteady` gated its own close on the run phase. That's why they're one commit.

Net effect is deleting a special case: steady runs now behave exactly like backfill runs, the path already proven correct in production.

It also improves the failure mode for free — a chain that dies for an unrelated reason now leaks a `running` run, which the existing stale sweep *does* rescue.

## Also included

- **`sweepStrandedConnectors`** — backstop for the shape the stale sweep can't see. Runs in the periodic job and at `startConnectorSync`; the latter matters because `claimForSync` refuses while `syncing`, so a stranded connector previously **could not be re-synced from the UI at all**. Deliberately *not* `finalizeConnector({ ok: true })`, which writes `itemCount ?? 0` (zeroing the record count) and restamps `lastSyncedAt`.
- **`readConnectorBackfillLatch`** — the latch had no read path, only the SQL that writes it, which is why diagnosis meant hand-reading jsonb. The bail now logs `leakedLatch` at warn when a completed run left it nonzero.
- **Dropped `ConnectorStreamState.backfillComplete`** — write-only state sitting at `false` forever on every app connector. Not to be confused with `AppConnectorPage.nextState.backfillComplete`, the live wire-protocol flag an app uses to mark its last page, which is untouched. Old rows keep the key; the index signature tolerates it, so no migration.

## Testing

**588 pass** across `data-connectors` + `sync-core` (64 files). Typecheck ratchet and biome clean.

Both new tests were verified to actually pin their defect by reverting the fix:

- revert the close guard → the steady-latch test fails with only the first stream fetching
- collapse the flag split → the re-sync-marker test fails
- remove the sweep's live-chain guard → the "leaves a running chain alone" test fails

There was **no test anywhere driving more than one stream through a single steady run**, which is why this shipped. Three existing orchestrator tests needed `db.query.DataConnector.findMany` added to their fakes for the new chain-start sweep; implemented faithfully rather than stubbed empty.

https://claude.ai/code/session_012uSRv3Hr73oMpgr9h7J99f
