### PR TITLE
fix(data-connectors): refuse a manual sync on a disconnected connector

### DIFF
--- a/apps/web/src/components/data-connectors/ui/connector-card.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-card.tsx
@@ -90,6 +90,11 @@ export function ConnectorCard({ connector, streamCount }: ConnectorCardProps) {
   const origin = connectorOrigin(connector)
   const isSyncing = status === 'syncing' || status === 'provisioning'
   const isPaused = status === 'paused'
+  // The app behind this connector is gone (task 44 D-1a), or its teardown is in
+  // flight. Both refuse a sync server-side via `getConnectorReadiness`; the menu
+  // must not offer it, or the click reads as a broken button. Pause/Resume stay
+  // available — those are local state, not a source round-trip.
+  const isSyncBlocked = status === 'disconnected' || status === 'deleting'
 
   const { syncNow, sampleSync, pause, resume, remove } = useConnectorMutations()
 
@@ -179,13 +184,15 @@ export function ConnectorCard({ connector, streamCount }: ConnectorCardProps) {
               <FileText />
               Open
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={wrap(() => syncNow(connector.id))} disabled={isSyncing}>
+            <DropdownMenuItem
+              onClick={wrap(() => syncNow(connector.id))}
+              disabled={isSyncing || isSyncBlocked}>
               <RefreshCw />
               Sync now
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={wrap(() => sampleSync(connector.id, DEFAULT_SAMPLE_SIZE))}
-              disabled={isSyncing}>
+              disabled={isSyncing || isSyncBlocked}>
               <FlaskConical />
               Sample sync
             </DropdownMenuItem>

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -209,13 +209,14 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
     }))
     return getConnectorReadiness(
       {
+        status,
         definitionKind: draftMeta.definitionKind,
         config: draftConfig as never,
         credentialId: draftMeta.credentialId,
       },
       streams
     )
-  }, [draftSeeded, draftMeta, draftStreams, draftConfig])
+  }, [draftSeeded, draftMeta, draftStreams, draftConfig, status])
 
   // Teardown in flight: the connector row survives only as the teardown's anchor
   // until the last slice removes it, so every action on it is meaningless — and
@@ -224,13 +225,21 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
 
   // Sync / Sample need a COMPLETE config (readiness) AND a SAVED one (not dirty) — §7a.
   // Reason text, or null when the action is allowed.
+  //
+  // ⚠️ The two lifecycle refusals are checked HERE as well as inside `getConnectorReadiness`,
+  // and the duplication is deliberate: `readiness` is null until the draft store seeds,
+  // so a reason derived only from it leaves the button live on first paint — which is
+  // exactly the window a merchant lands in when they open a disconnected connector from
+  // the list (task 44 §7.11).
   const syncBlockReason = isRemoving
-    ? 'Removing this connector'
-    : readiness && !readiness.canSync
-      ? READINESS_REASON[readiness.problems[0] ?? 'no-endpoint']
-      : isDirty
-        ? 'Save changes first'
-        : null
+    ? READINESS_REASON.removing
+    : isDisconnected
+      ? READINESS_REASON.disconnected
+      : readiness && !readiness.canSync
+        ? READINESS_REASON[readiness.problems[0] ?? 'no-endpoint']
+        : isDirty
+          ? 'Save changes first'
+          : null
 
   const handleDelete = async (syncedData: 'keep' | 'archive' | 'delete') => {
     // Owned defs split into those THIS delete tears down (sole owner) vs those it keeps

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -757,6 +757,17 @@ export const dataConnectorRouter = createTRPCRouter({
       if (result.isErr()) {
         throw new TRPCError({ code: 'NOT_FOUND', message: result.error.message })
       }
+      // Same gate as `syncNow` — this is the OTHER manual door onto
+      // `enqueueConnectorSync` (task 44 §7.11), and it had no readiness check at all.
+      // A re-crawl is a sync, so it needs `canSync`, not just a connector that exists.
+      const streams = await listStreams(ctx.db, ctx.session.organizationId, input.id)
+      const readiness = getConnectorReadiness(result.value, streams)
+      if (!readiness.canSync) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: READINESS_REASON[readiness.problems[0] ?? 'no-endpoint'],
+        })
+      }
       await backfillPendingChange(ctx.db, ctx.session.organizationId, input.id)
       return { success: true }
     }),

--- a/packages/lib/scripts/check-connector-schedulers.ts
+++ b/packages/lib/scripts/check-connector-schedulers.ts
@@ -1,0 +1,28 @@
+// packages/lib/scripts/check-connector-schedulers.ts
+// List the BullMQ job schedulers currently registered on the data-connector queue.
+// Used to verify `removeConnectorScheduler` actually ran when a connector was
+// disconnected (plans/money/tasks/44 §7.2 step 6) — a schedule that keeps ticking
+// for an uninstalled app is the bug the old delete-loop existed to fix.
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/check-connector-schedulers.ts
+
+import { getQueue, Queues } from '../src/jobs/queues'
+
+async function main() {
+  const queue = getQueue(Queues.dataConnectorQueue)
+  const schedulers = await queue.getJobSchedulers(0, 100, true)
+
+  console.log(`registered job schedulers on ${Queues.dataConnectorQueue}: ${schedulers.length}`)
+  for (const s of schedulers) {
+    console.log(
+      `  ${s.key}  pattern=${s.pattern ?? '-'}  tz=${s.tz ?? '-'}  next=${
+        s.next ? new Date(s.next).toISOString() : '-'
+      }`
+    )
+  }
+
+  await queue.close()
+  process.exit(0)
+}
+
+void main()

--- a/packages/lib/src/data-connectors/readiness.test.ts
+++ b/packages/lib/src/data-connectors/readiness.test.ts
@@ -6,13 +6,15 @@ import { getConnectorReadiness, type ReadinessStream } from './readiness'
 
 type Connector = Parameters<typeof getConnectorReadiness>[0]
 
-const genericRest = (config: Connector['config']): Connector => ({
+const genericRest = (config: Connector['config'], status = 'live'): Connector => ({
+  status,
   definitionKind: 'generic-rest',
   config,
   credentialId: null,
 })
 
-const app = (credentialId: string | null): Connector => ({
+const app = (credentialId: string | null, status = 'live'): Connector => ({
+  status,
   definitionKind: 'app',
   config: null,
   credentialId,
@@ -138,5 +140,70 @@ describe('getConnectorReadiness — canSync (streams)', () => {
     ])
     expect(r.canSync).toBe(false)
     expect(r.problems[0]).toBe('no-mapping')
+  })
+})
+
+// ── Lifecycle refusals (task 44 §7.11 / D-6) ─────────────────────────────────
+//
+// The regression these pin: uninstalling an app PRESERVES the connector's
+// credential, so a `disconnected` app connector is structurally perfect — every
+// config check passes and the manual door used to wave it through. One "Sync now"
+// then knocked it to `error`, discarding the Disconnected banner and putting it
+// outside `reconnectConnectorsForInstallation`'s `status = 'disconnected'` scope,
+// so a reinstall no longer repaired it.
+describe('getConnectorReadiness — lifecycle refusals', () => {
+  it('refuses a disconnected connector that is otherwise fully configured', () => {
+    const r = getConnectorReadiness(app('cred_1', 'disconnected'), [completeStream()])
+    expect(r.canSync).toBe(false)
+    expect(r.canSample).toBe(false)
+    expect(r.problems).toEqual(['disconnected'])
+  })
+
+  it('refuses a disconnected generic-rest connector too', () => {
+    const connector = genericRest(
+      { endpoint: { baseUrl: 'https://api.example.com' } },
+      'disconnected'
+    )
+    const r = getConnectorReadiness(connector, [completeStream()])
+    expect(r.canSync).toBe(false)
+    expect(r.problems).toEqual(['disconnected'])
+  })
+
+  it('refuses a connector whose teardown is in flight', () => {
+    const r = getConnectorReadiness(app('cred_1', 'deleting'), [completeStream()])
+    expect(r.canSync).toBe(false)
+    expect(r.canSample).toBe(false)
+    expect(r.problems).toEqual(['removing'])
+  })
+
+  // 🛑 The exact shape the defect took: same connector, same streams, only the
+  // status differs. If the guard is removed, this is the assertion that flips.
+  it('the SAME connector syncs when live and refuses when disconnected', () => {
+    const streams = [completeStream()]
+    expect(getConnectorReadiness(app('cred_1', 'live'), streams).canSync).toBe(true)
+    expect(getConnectorReadiness(app('cred_1', 'disconnected'), streams).canSync).toBe(false)
+  })
+
+  // ⚠️ Deliberately allowed — a merchant who paused a connector and presses Sync now
+  // plausibly means it, and they can resume it themselves. Only `disconnected` is a
+  // state they cannot get back once a click discards it.
+  it('still allows a paused connector to sync', () => {
+    const r = getConnectorReadiness(app('cred_1', 'paused'), [completeStream()])
+    expect(r.canSync).toBe(true)
+    expect(r.problems).toEqual([])
+  })
+
+  it.each([
+    'live',
+    'ready',
+    'syncing',
+    'error',
+    'paused',
+    'pending',
+    'provisioning',
+  ])('does not add a lifecycle problem for status %s', (status) => {
+    const r = getConnectorReadiness(app('cred_1', status), [completeStream()])
+    expect(r.problems).not.toContain('disconnected')
+    expect(r.problems).not.toContain('removing')
   })
 })

--- a/packages/lib/src/data-connectors/readiness.ts
+++ b/packages/lib/src/data-connectors/readiness.ts
@@ -10,6 +10,8 @@ import type { DataConnectorConfig } from './types'
  * `problems[0]` is the hint to surface in a tooltip / error message.
  */
 export type ReadinessProblem =
+  | 'disconnected' // the app behind the connector was uninstalled (task 44 D-6)
+  | 'removing' // teardown in flight — the row survives only as the chain's anchor
   | 'no-endpoint' // no base URL (generic-rest) / no bound connection (app)
   | 'no-stream' // no enabled stream at all
   | 'stream-no-path' // best stream missing requestConfig.path
@@ -40,6 +42,8 @@ export interface ReadinessStream {
 
 /** Human-readable hint per problem — tooltip text + server error message. */
 export const READINESS_REASON = {
+  disconnected: 'Reinstall the app to resume syncing',
+  removing: 'Removing this connector',
   'no-endpoint': 'Add a base URL',
   'no-stream': 'Add a stream',
   'stream-no-path': 'Add a request path to the stream',
@@ -78,8 +82,12 @@ function firstStreamFailure(
 }
 
 /**
- * Compute a connector's sync-action readiness from its committed/draft config.
+ * Compute a connector's sync-action readiness from its lifecycle status and its
+ * committed/draft config.
  *
+ * - A `disconnected` or `deleting` connector refuses everything, whatever the config
+ *   says (task 44 §7.11 / D-6). This is FIRST because it is not a config problem and
+ *   no amount of authoring fixes it — see the block comment on the check itself.
  * - `canSample` = endpoint present (generic-rest: `config.endpoint.baseUrl`;
  *   app connector: a bound `credentialId`). Enough for a Test fetch.
  * - `canSync` = `canSample` AND ≥1 ENABLED, fully-configured stream (a request
@@ -91,12 +99,34 @@ function firstStreamFailure(
  */
 export function getConnectorReadiness(
   connector: {
+    /** `DataConnector.status`. Widened to string — the enum lives server-side. */
+    status: string
     definitionKind: string
     config: DataConnectorConfig | null
     credentialId: string | null
   },
   streams: ReadinessStream[]
 ): ConnectorReadiness {
+  // 🛑 Lifecycle refusals come BEFORE the config checks, and they are the whole
+  // point of this block (task 44 §7.11). Uninstalling an app deliberately PRESERVES
+  // the credential, so a `disconnected` app connector still satisfies `canSample`
+  // and, with its streams intact, `canSync` — every structural check below passes
+  // and the manual door waves it through. That is not academic: one "Sync now" click
+  // moved a disconnected connector to `error`, which discarded the Disconnected
+  // banner AND put it outside `reconnectConnectorsForInstallation`'s
+  // `status = 'disconnected'` scope, so reinstalling the app no longer repaired it.
+  //
+  // ⚠️ `paused` is deliberately NOT here. A merchant who paused a connector and then
+  // presses Sync now plausibly means it, and they can resume it themselves.
+  // `disconnected` is different: they cannot make it work from here, and the click
+  // silently discards a state they cannot get back.
+  if (connector.status === 'disconnected') {
+    return { canSample: false, canSync: false, problems: ['disconnected'] }
+  }
+  if (connector.status === 'deleting') {
+    return { canSample: false, canSync: false, problems: ['removing'] }
+  }
+
   const isApp = connector.definitionKind === 'app'
   const canSample = isApp
     ? !!connector.credentialId


### PR DESCRIPTION
Follow-up to #2050, which made uninstalling an app disconnect its connector instead of deleting it. Found by driving that flow in a browser — every unit test passed throughout.

## The defect

#2050 taught the scheduler and both webhook dispatch jobs to refuse a connector whose app was uninstalled. It did not teach **the manual door, which is the one with a button on it.**

Uninstalling an app deliberately *preserves* the credential, so a `disconnected` app connector is structurally perfect:

| step | what it did with `disconnected` |
| --- | --- |
| the button | rendered **Sync now**, `disabled=false` |
| `syncNow` | gated on `getConnectorReadiness` only |
| `getConnectorReadiness` | **never read `status`** — credential present ⇒ `canSync` true |
| `claimForSync` | `ne(status, 'syncing')` — accepts `disconnected` |

So one **Sync now** click moved the connector to `error`. That discarded the Disconnected banner *and* put it outside `reconnectConnectorsForInstallation`'s `status = 'disconnected'` scope — so **reinstalling the app, the remedy the banner itself offered, no longer repaired it.**

The merchant-visible sequence: uninstall → connector reads *Disconnected* with a Reinstall link → press Sync now → page now reads *"Error · Last sync failed"* with a 20-line ref-resolution string and no mention the app is gone → reinstall → **still broken.**

## The fix

The guard goes into `getConnectorReadiness`, because that predicate is already the shared seam — `syncNow`, `sampleFetch` and the detail view's button state all call it. Those first two needed **no edit**: they already render `READINESS_REASON[problems[0]]`.

Also here, deliberately:

- **`deleting` is guarded on the same terms.** It had the identical server-side hole (the detail view blocked it via `isRemoving`, the API did not).
- **`backfillPendingChange` had no readiness check at all**, not merely a missing status check. It is the other manual call site onto `enqueueConnectorSync`, and a re-crawl is a sync.
- **`paused` is NOT refused.** A merchant who paused a connector and presses Sync now plausibly means it, and can resume it themselves. `disconnected` is different: they cannot make it work from here, and the click discarded a state they could not get back.

The lifecycle checks are duplicated in `connector-detail-view` on purpose: `readiness` is null until the draft store seeds, so a reason derived only from it leaves the button live on first paint — exactly the window a merchant lands in when opening a disconnected connector from the list.

## Verification

Driven against the dev database, going at the doors **through the API and bypassing the disabled buttons** — the way the original defect got in:

```
POST dataConnector.syncNow               → 400  "Reinstall the app to resume syncing"
POST dataConnector.backfillPendingChange → 400  "Reinstall the app to resume syncing"
POST dataConnector.sampleFetch           → 400  "Reinstall the app to resume syncing"
```

And the chain that was broken now holds end to end:

```
after the refused Sync now:  disconnected | "GitHub was uninstalled"   (state preserved, not `error`)
after reinstalling the app:  paused       | NULL                       (bindings 100, intact)
```

Header **Sync now** renders `aria-disabled="true"` and dimmed, with the Disconnected banner and Reinstall link still in place.

- `vitest run src/data-connectors src/apps src/jobs/data-connector` (lib) — **690 passed**
- `vitest run src/components/data-connectors src/components/apps` (web) — **150 passed**
- `readiness.test.ts` — 28 passed (16 pre-existing + 12 new)
- `typecheck-ratchet --package web` — no new type errors (0 total); `--package lib` clean apart from the pre-existing `file-type-constants.test.ts` report

`packages/lib/scripts/check-connector-schedulers.ts` is a small probe added while verifying that `removeConnectorScheduler` actually tears a schedule down (it does — registered schedulers went 1 → 0 on uninstall, and stayed 0 after reinstall since `paused` is suspended).

https://claude.ai/code/session_01V6nKtbnnfaAbfaTP1w7QUj
