### PR TITLE
feat(builds): backfill builds in batches from historical order demand

### DIFF
--- a/apps/web/src/app/(protected)/app/builds/page.tsx
+++ b/apps/web/src/app/(protected)/app/builds/page.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { BackfillBuildsButton } from '~/components/manufacturing/builds'
 import { RecordsView } from '~/components/records'
 
 /**
@@ -20,7 +21,12 @@ import { RecordsView } from '~/components/records'
  * so the primary cell falls back to the record's own display name. Nothing here
  * needs to know that; it is why no surface in this feature formats a number
  * without a fallback.
+ *
+ * The `pageActions` button is the backfill dialog's entry point
+ * (plans/money/tasks/44 §11.3), following the `purchase-orders` page's
+ * `ReadQuoteButton` precedent: one header action beside Create, no extra row
+ * above the table.
  */
 export default function BuildsPage() {
-  return <RecordsView slug='builds' basePath='/app/builds' />
+  return <RecordsView slug='builds' basePath='/app/builds' pageActions={<BackfillBuildsButton />} />
 }

--- a/apps/web/src/components/manufacturing/builds/backfill-builds-button.tsx
+++ b/apps/web/src/components/manufacturing/builds/backfill-builds-button.tsx
@@ -1,0 +1,43 @@
+// apps/web/src/components/manufacturing/builds/backfill-builds-button.tsx
+'use client'
+
+// The entry point on the builds list — `RecordsView`'s `pageActions` slot,
+// beside Create (plans/money/tasks/44 §11.3). Same shape as
+// `purchasing/intake/ui/read-quote-button.tsx`, which is the precedent for a
+// list-level action that opens a dialog.
+//
+// 🛑 A standalone tool, not a wizard step (§7). The cutover checklist links here
+// at its step 6, but the other half of this dialog's life is ordinary: a
+// connector was off for a week, or auto-build was switched on late, and demand
+// has run ahead of builds. An entry point that only existed inside an onboarding
+// flow could not be reached then.
+
+import { Button } from '@auxx/ui/components/button'
+import { Layers } from 'lucide-react'
+import { useState } from 'react'
+import { api } from '~/trpc/react'
+import { BackfillDialog } from './backfill-dialog'
+
+export function BackfillBuildsButton() {
+  const [open, setOpen] = useState(false)
+  const utils = api.useUtils()
+
+  return (
+    <>
+      <Button variant='outline' size='sm' onClick={() => setOpen(true)}>
+        <Layers /> Backfill builds
+      </Button>
+      {/* Mounted only while open so the preview query does not run on every
+          visit to the list. Same reasoning as `ReadQuoteButton`. */}
+      {open && (
+        <BackfillDialog
+          open={open}
+          onOpenChange={setOpen}
+          // The run writes builds the list is showing, and a batch build is
+          // written on a lane the list does not learn about on its own.
+          onCompleted={() => void utils.invalidate()}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/src/components/manufacturing/builds/backfill-dialog.tsx
+++ b/apps/web/src/components/manufacturing/builds/backfill-dialog.tsx
@@ -1,0 +1,627 @@
+// apps/web/src/components/manufacturing/builds/backfill-dialog.tsx
+'use client'
+
+// The bulk builder (§7 of plans/money/tasks/44-auto-build-cutoff-and-backfill.md)
+// — *"a way to create builds from orders that don't have builds, and combine
+// them so we don't have thousands."*
+//
+// A standalone tool, not a wizard step. The cutover checklist links to it, but
+// its other half of life is ordinary: a connector was off for a week, or
+// auto-build was switched on late, and demand has run ahead of builds. A step
+// that only exists inside an onboarding flow cannot be reached then.
+//
+// ## The two dates are not the same date
+//
+// - The **cutoff** (`inventory.autoBuildEnabledAt`) is where LIVE per-order
+//   raising begins. It is a settings row and this dialog only reads it.
+// - The **range** is what HISTORY to batch, and it is what actually delivers
+//   *"give me the builds for everything since January 1"*.
+//
+// 🛑 A batch build is only safe BELOW the cutoff: above it the reconciler is
+// live and a batch build does not suppress a raise, so any order up there that
+// later moves gets a per-order build stacked on top of the batch one. The range
+// is therefore bounded above by the cutoff, and a `to` past it is REFUSED with
+// the reason, never clamped silently. The server runs the same predicate.
+//
+// ## Why the grouping control stays even though the owner always picks month
+//
+// The footer moving from 94 builds to 20 to 217 as the control changes IS the
+// feature (§7.2). It makes the tradeoff visible instead of baked into a constant
+// nobody can see.
+
+import { FieldType } from '@auxx/database/enums'
+import {
+  BACKFILL_GROUPINGS,
+  type BackfillGrouping,
+  type BackfillRunSummary,
+  type BackfillStatus,
+} from '@auxx/lib/builds/client'
+import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { keepPreviousData } from '@tanstack/react-query'
+import { TriangleAlert } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useResourceProperty } from '~/components/resources'
+import { BaseType } from '~/components/workflow/types'
+import { api } from '~/trpc/react'
+import { BackfillExclusions } from './backfill-exclusions'
+import { BackfillPeriodStrip } from './backfill-period-strip'
+import { BackfillPlanTable, formatQuantity } from './backfill-plan-table'
+
+const GROUPING_LABELS: Record<BackfillGrouping, string> = {
+  order: 'One build per order',
+  day: 'One build per day',
+  week: 'One build per week',
+  month: 'One build per month',
+  range: 'One build for the whole range',
+}
+
+const STATUS_OPTIONS = [
+  { value: 'planned', label: 'Planned — work still to do' },
+  { value: 'completed', label: 'Completed — this already happened' },
+]
+
+interface BackfillDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCompleted?: () => void
+}
+
+export function BackfillDialog({ open, onOpenChange, onCompleted }: BackfillDialogProps) {
+  const [page, setPage] = useState<'plan' | 'result'>('plan')
+  const [from, setFrom] = useState<string>(() => startOfYear().toISOString())
+  const [to, setTo] = useState<string>(() => new Date().toISOString())
+  const [grouping, setGrouping] = useState<BackfillGrouping>('month')
+  const [status, setStatus] = useState<BackfillStatus>('planned')
+  const [periodFilter, setPeriodFilter] = useState<string | null>(null)
+  const [acknowledged, setAcknowledged] = useState(false)
+  const [result, setResult] = useState<BackfillRunSummary | null>(null)
+
+  const buildDefId = useResourceProperty('build', 'id')
+  const utils = api.useUtils()
+
+  // A fresh dialog on every open. A range somebody abandoned yesterday would
+  // silently backfill the wrong window, and a stale acknowledgement would carry
+  // consent for a ledger nobody has now been shown.
+  useEffect(() => {
+    if (!open) return
+    setPage('plan')
+    setFrom(startOfYear().toISOString())
+    setTo(new Date().toISOString())
+    setGrouping('month')
+    setStatus('planned')
+    setPeriodFilter(null)
+    setAcknowledged(false)
+    setResult(null)
+  }, [open])
+
+  const fromDate = useMemo(() => new Date(from), [from])
+  const toDate = useMemo(() => new Date(to), [to])
+
+  // §7.3 / the `BackfillGrouping` contract: `build_completed_at` decides which
+  // month-end entry reflects a build, so one build for a multi-month range
+  // misstates every month it spans. Not selectable rather than disabled — a
+  // control that cannot be operated is worse than one that is not offered.
+  const rangeGroupingBarred = status === 'completed' && spansSeveralMonths(fromDate, toDate)
+  const groupingOptions = useMemo(
+    () =>
+      BACKFILL_GROUPINGS.filter((value) => value !== 'range' || !rangeGroupingBarred).map(
+        (value) => ({ value, label: GROUPING_LABELS[value] })
+      ),
+    [rangeGroupingBarred]
+  )
+
+  useEffect(() => {
+    if (rangeGroupingBarred && grouping === 'range') setGrouping('month')
+  }, [rangeGroupingBarred, grouping])
+
+  const preview = api.builds.previewBackfill.useQuery(
+    { from: fromDate, to: toDate, grouping, status },
+    {
+      enabled: open && page === 'plan',
+      retry: false,
+      refetchOnWindowFocus: false,
+      // Without this every grouping change blanks the table, the strip and the
+      // footer together — which reads as "the numbers just went away" on the one
+      // screen whose whole point is watching those numbers move.
+      placeholderData: keepPreviousData,
+    }
+  )
+
+  // Any change to the plan invalidates a filter pinned to a period that may no
+  // longer exist under the new grouping.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resetting on the inputs, not on the response
+  useEffect(() => setPeriodFilter(null), [grouping, from, to])
+
+  const data = preview.data
+  const plan = data?.plan ?? null
+  const preflight = data?.preflight ?? null
+  const refusal = data?.refusal ?? null
+  const cutoff = data?.cutoff ?? null
+
+  const runBackfill = api.builds.runBackfill.useMutation({
+    onError: (error) => toastError({ title: 'Backfill failed', description: error.message }),
+  })
+
+  const handleRun = async () => {
+    if (!plan || plan.buildCount === 0) return
+    try {
+      const summary = await runBackfill.mutateAsync({
+        from: fromDate,
+        to: toDate,
+        grouping,
+        status,
+      })
+      setResult(summary)
+      setPage('result')
+      await Promise.all([
+        utils.builds.list.invalidate(),
+        buildDefId
+          ? utils.record.listFiltered.invalidate({ entityDefinitionId: buildDefId })
+          : Promise.resolve(),
+      ])
+      onCompleted?.()
+    } catch {
+      // onError already surfaced the toast.
+    }
+  }
+
+  const stale = preview.isFetching
+  const negatives = preflight?.projectedOnHand.filter((row) => row.projected < 0) ?? []
+  const needsAcknowledgement = status === 'completed'
+  const canRun =
+    !!plan &&
+    plan.buildCount > 0 &&
+    !refusal &&
+    !stale &&
+    (!needsAcknowledgement || acknowledged) &&
+    !runBackfill.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !runBackfill.isPending && onOpenChange(next)}>
+      <DialogContent size='content' position='tc' innerClassName='p-0'>
+        <DialogNav
+          title='Backfill builds'
+          description='Create builds for demand that has been ordered and never built.'
+          crumbs={[
+            {
+              label: 'Backfill builds',
+              onClick: page === 'result' ? () => setPage('plan') : undefined,
+            },
+            ...(page === 'result' ? [{ label: 'Result' }] : []),
+          ]}
+        />
+
+        <DialogNavPages value={page}>
+          <DialogNavPage value='plan' size='3xl'>
+            <div className='flex max-h-[78vh] flex-col'>
+              <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
+                <div className='flex flex-col gap-4 p-4'>
+                  <FieldPanel
+                    className='p-0'
+                    orientation='responsive'
+                    breakpoint='md'
+                    resizeId='backfill-builds'
+                    defaultLabelWidth={180}>
+                    <FieldPanelRow
+                      title='From'
+                      type={BaseType.DATE}
+                      showIcon
+                      isRequired
+                      description='On the date the order was placed'>
+                      <FieldInputAdapter
+                        fieldType={FieldType.DATE}
+                        value={from}
+                        onChange={(val) => setFrom((val as string) ?? from)}
+                        disabled={runBackfill.isPending}
+                      />
+                    </FieldPanelRow>
+
+                    <FieldPanelRow
+                      title='To'
+                      type={BaseType.DATE}
+                      showIcon
+                      isRequired
+                      description={
+                        cutoff
+                          ? `Bounded by the build cutoff, ${formatDate(cutoff)}`
+                          : 'Exclusive — the day itself is not included'
+                      }>
+                      <FieldInputAdapter
+                        fieldType={FieldType.DATE}
+                        value={to}
+                        onChange={(val) => setTo((val as string) ?? to)}
+                        disabled={runBackfill.isPending}
+                      />
+                    </FieldPanelRow>
+
+                    <FieldPanelRow
+                      title='Group into'
+                      type={BaseType.ENUM}
+                      showIcon
+                      isRequired
+                      description='How much demand one build covers'>
+                      <FieldInputAdapter
+                        fieldType={FieldType.SINGLE_SELECT}
+                        fieldOptions={{ options: groupingOptions }}
+                        value={grouping}
+                        onChange={(val) =>
+                          setGrouping(((val as string[])[0] as BackfillGrouping) ?? 'month')
+                        }
+                        disabled={runBackfill.isPending}
+                      />
+                    </FieldPanelRow>
+
+                    <FieldPanelRow
+                      title='Create as'
+                      type={BaseType.ENUM}
+                      showIcon
+                      isRequired
+                      description='Is this history, or is it work to do?'>
+                      <FieldInputAdapter
+                        fieldType={FieldType.SINGLE_SELECT}
+                        fieldOptions={{ options: STATUS_OPTIONS }}
+                        value={status}
+                        onChange={(val) => {
+                          setStatus(((val as string[])[0] as BackfillStatus) ?? 'planned')
+                          setAcknowledged(false)
+                        }}
+                        disabled={runBackfill.isPending}
+                      />
+                    </FieldPanelRow>
+                  </FieldPanel>
+
+                  {rangeGroupingBarred && (
+                    <Note>
+                      One build for the whole range is not available here: this range spans more
+                      than one month, and a completed build's date decides which month-end entry
+                      reflects it.
+                    </Note>
+                  )}
+
+                  {refusal && <Note tone='warning'>{refusal}</Note>}
+
+                  {refusal && cutoff && toDate.getTime() > cutoff.getTime() && (
+                    <div>
+                      <Button
+                        variant='outline'
+                        size='sm'
+                        onClick={() => setTo(new Date(cutoff).toISOString())}>
+                        Use the cutoff date
+                      </Button>
+                    </div>
+                  )}
+
+                  {preview.error && !refusal && <Note tone='warning'>{preview.error.message}</Note>}
+
+                  {preview.isPending && !plan && <PlanSkeleton />}
+
+                  {plan && (
+                    <div
+                      className={
+                        stale
+                          ? 'flex flex-col gap-4 opacity-60 transition-opacity'
+                          : 'flex flex-col gap-4 transition-opacity'
+                      }>
+                      <BackfillPeriodStrip
+                        plan={plan}
+                        selected={periodFilter}
+                        onSelect={setPeriodFilter}
+                      />
+
+                      <BackfillPlanTable
+                        plan={plan}
+                        partNames={data?.partNames ?? {}}
+                        periodFilter={periodFilter}
+                      />
+
+                      <BackfillExclusions
+                        exclusions={plan.excluded}
+                        partNames={data?.partNames ?? {}}
+                      />
+
+                      {preflight && (
+                        <CompletionPreflight
+                          buildCount={preflight.buildCount}
+                          movementCount={preflight.movementCount}
+                          unpricedParts={preflight.unpricedParts}
+                          negatives={negatives}
+                          acknowledged={acknowledged}
+                          onAcknowledge={setAcknowledged}
+                          disabled={runBackfill.isPending}
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+              </ScrollArea>
+
+              {/* 🛑 The footer is the feature, not decoration. Watching it go
+                  from 94 builds to 20 to 217 as the grouping changes is how the
+                  tradeoff becomes visible instead of a constant nobody sees. */}
+              <div className='flex shrink-0 flex-wrap items-center justify-between gap-2 border-t px-4 py-2.5'>
+                <p className='text-muted-foreground text-sm tabular-nums'>
+                  {plan ? (
+                    <>
+                      <strong className='font-medium text-foreground'>{plan.parts.length}</strong>{' '}
+                      {plan.parts.length === 1 ? 'part' : 'parts'} ·{' '}
+                      <strong className='font-medium text-foreground'>{plan.buildCount}</strong>{' '}
+                      {plan.buildCount === 1 ? 'build' : 'builds'} ·{' '}
+                      <strong className='font-medium text-foreground'>
+                        {formatQuantity(plan.unitCount)}
+                      </strong>{' '}
+                      {plan.unitCount === 1 ? 'unit' : 'units'}
+                    </>
+                  ) : (
+                    'No preview yet'
+                  )}
+                </p>
+
+                <div className='flex items-center gap-2'>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='sm'
+                    onClick={() => onOpenChange(false)}
+                    disabled={runBackfill.isPending}>
+                    Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={handleRun}
+                    loading={runBackfill.isPending}
+                    loadingText='Creating builds...'
+                    disabled={!canRun}
+                    data-dialog-submit>
+                    {status === 'completed' ? 'Create and post' : 'Create builds'}{' '}
+                    <KbdSubmit variant='outline' size='sm' />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </DialogNavPage>
+
+          <DialogNavPage value='result' size='3xl'>
+            <BackfillResult
+              result={result}
+              onClose={() => onOpenChange(false)}
+              onBack={() => setPage('plan')}
+            />
+          </DialogNavPage>
+        </DialogNavPages>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Completed-run preflight (§7.3) ──────────────────────────────────────
+
+/**
+ * What a `completed` run would write, before it writes any of it.
+ *
+ * §7.3: `planned` is "N builds". `completed` is "N builds, M stock movements, on
+ * an append-only ledger correctable only by reversing." Different consent, and
+ * the ledger sentence has to be in the dialog rather than in a doc.
+ *
+ * 🛑 The projected-stock block WARNS and does not refuse. Negative on hand is a
+ * true statement about a ledger that is missing its receipts, and refusing would
+ * make the backfill unusable on exactly the org that needs it most. The remedy
+ * is opening stock, which is the person's call to make first.
+ */
+function CompletionPreflight({
+  buildCount,
+  movementCount,
+  unpricedParts,
+  negatives,
+  acknowledged,
+  onAcknowledge,
+  disabled,
+}: {
+  buildCount: number
+  movementCount: number
+  unpricedParts: { partId: string; partName: string | null }[]
+  negatives: { partId: string; partName: string | null; onHand: number; projected: number }[]
+  acknowledged: boolean
+  onAcknowledge: (next: boolean) => void
+  disabled: boolean
+}) {
+  return (
+    <div className='flex flex-col gap-3 rounded-md border border-amber-300 bg-amber-50/60 p-3 dark:border-amber-900 dark:bg-amber-950/30'>
+      <p className='font-medium text-sm'>
+        This run writes {buildCount} {buildCount === 1 ? 'build' : 'builds'} and {movementCount}{' '}
+        stock {movementCount === 1 ? 'movement' : 'movements'}.
+      </p>
+
+      {unpricedParts.length > 0 && (
+        <div className='text-sm'>
+          <p className='flex items-start gap-1.5'>
+            <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+            <span>
+              {unpricedParts.length} {unpricedParts.length === 1 ? 'part has' : 'parts have'} no
+              standard cost. A completion is refused per build when a component is unpriced, so
+              those builds will be raised and left in progress.
+            </span>
+          </p>
+          <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
+            {unpricedParts.slice(0, 12).map((part) => (
+              <li key={part.partId}>{part.partName ?? part.partId}</li>
+            ))}
+            {unpricedParts.length > 12 && <li>and {unpricedParts.length - 12} more</li>}
+          </ul>
+        </div>
+      )}
+
+      {negatives.length > 0 && (
+        <div className='text-sm'>
+          <p className='flex items-start gap-1.5'>
+            <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+            <span>
+              This run takes {negatives.length}{' '}
+              {negatives.length === 1 ? 'component' : 'components'} below zero. That is usually a
+              ledger missing its receipts rather than a mistake here, and opening stock is the fix.
+            </span>
+          </p>
+          <ul className='mt-1 ps-6 text-muted-foreground text-xs tabular-nums'>
+            {negatives.slice(0, 12).map((row) => (
+              <li key={row.partId}>
+                {row.partName ?? row.partId}: {formatQuantity(row.onHand)} to{' '}
+                {formatQuantity(row.projected)}
+              </li>
+            ))}
+            {negatives.length > 12 && <li>and {negatives.length - 12} more</li>}
+          </ul>
+        </div>
+      )}
+
+      <label className='flex items-start gap-2 text-sm'>
+        <Checkbox
+          checked={acknowledged}
+          onCheckedChange={(next) => onAcknowledge(next === true)}
+          disabled={disabled}
+          className='mt-0.5'
+        />
+        <span>
+          I understand these movements land on an append-only ledger and can only be corrected by
+          reversing them.
+        </span>
+      </label>
+    </div>
+  )
+}
+
+// ─── Result (§7.4) ───────────────────────────────────────────────────────
+
+/**
+ * What the run actually did.
+ *
+ * 🛑 **A refused completion is not a failure of the run.** `buildNow` reports it
+ * as the `left_in_progress` RESULT carrying the build it already raised, so this
+ * has to name that arm separately — telling somebody "failed" about builds that
+ * exist is what makes them press the button a second time.
+ */
+function BackfillResult({
+  result,
+  onBack,
+  onClose,
+}: {
+  result: BackfillRunSummary | null
+  onBack: () => void
+  onClose: () => void
+}) {
+  if (!result) return null
+
+  const created = result.created.length
+  const left = result.leftInProgress.length
+  const failed = result.failed.length
+
+  return (
+    <div className='flex max-h-[78vh] flex-col'>
+      <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
+        <div className='flex flex-col gap-3 p-4 text-sm'>
+          <p>
+            <strong className='font-medium'>{created}</strong>{' '}
+            {created === 1 ? 'build was' : 'builds were'} created.
+          </p>
+
+          {left > 0 && (
+            <div>
+              <p className='flex items-start gap-1.5'>
+                <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+                <span>
+                  {left} of them could not be completed and {left === 1 ? 'is' : 'are'} sitting in
+                  progress. They exist — do not run the backfill again for them.
+                </span>
+              </p>
+              <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
+                {result.leftInProgress.slice(0, 12).map((row) => (
+                  <li key={row.buildId}>{row.reason}</li>
+                ))}
+                {left > 12 && <li>and {left - 12} more</li>}
+              </ul>
+            </div>
+          )}
+
+          {failed > 0 && (
+            <div>
+              <p>
+                {failed} {failed === 1 ? 'bucket' : 'buckets'} produced nothing at all.
+              </p>
+              <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
+                {result.failed.slice(0, 12).map((row) => (
+                  <li key={row.bucketId}>
+                    {row.periodKey}: {row.reason}
+                  </li>
+                ))}
+                {failed > 12 && <li>and {failed - 12} more</li>}
+              </ul>
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+
+      <div className='flex shrink-0 items-center justify-end gap-2 border-t px-4 py-2.5'>
+        <Button type='button' variant='ghost' size='sm' onClick={onBack}>
+          Back to the preview
+        </Button>
+        <Button variant='outline' size='sm' onClick={onClose} data-dialog-submit>
+          Done <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Small pieces ────────────────────────────────────────────────────────
+
+function Note({ children, tone }: { children: React.ReactNode; tone?: 'warning' }) {
+  return (
+    <p
+      className={
+        tone === 'warning'
+          ? 'flex items-start gap-1.5 rounded-md border border-amber-300 bg-amber-50/60 px-3 py-2 text-sm dark:border-amber-900 dark:bg-amber-950/30'
+          : 'rounded-md border bg-muted/40 px-3 py-2 text-muted-foreground text-sm'
+      }>
+      {tone === 'warning' && (
+        <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+      )}
+      <span>{children}</span>
+    </p>
+  )
+}
+
+function PlanSkeleton() {
+  return (
+    <div className='flex flex-col gap-2'>
+      <Skeleton className='h-9 w-full' />
+      <Skeleton className='h-9 w-full' />
+      <Skeleton className='h-9 w-full' />
+    </div>
+  )
+}
+
+/** January 1 of the current year — the range the cutover actually asks for. */
+function startOfYear(): Date {
+  return new Date(Date.UTC(new Date().getUTCFullYear(), 0, 1))
+}
+
+/** Does `[from, to)` cross a calendar month boundary? Mirrors the server's predicate. */
+function spansSeveralMonths(from: Date, to: Date): boolean {
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return false
+  const last = new Date(to.getTime() - 1)
+  return (
+    from.getUTCFullYear() !== last.getUTCFullYear() || from.getUTCMonth() !== last.getUTCMonth()
+  )
+}
+
+function formatDate(value: Date | string): string {
+  return new Date(value).toLocaleDateString()
+}

--- a/apps/web/src/components/manufacturing/builds/backfill-exclusions.tsx
+++ b/apps/web/src/components/manufacturing/builds/backfill-exclusions.tsx
@@ -1,0 +1,120 @@
+// apps/web/src/components/manufacturing/builds/backfill-exclusions.tsx
+'use client'
+
+// The parts that are ordered and produce no build, with the reason
+// (§7.2b of plans/money/tasks/44-auto-build-cutoff-and-backfill.md).
+//
+// 🛑 **The first question anyone asks this screen is "why isn't the 400 lift in
+// here?"** If an excluded part is simply absent, that question has no answer,
+// and a preview whose omissions cannot be explained is a preview nobody trusts.
+//
+// The vocabulary is not invented here. `BackfillExclusionReason` is the three
+// members of `ConvergenceSkipReason` that transfer to an AGGREGATE, plus
+// `already-covered`, which is native to the aggregate and has no per-order twin.
+// The other five `ConvergenceSkipReason` members describe a build's relationship
+// to ONE order, which is the question this screen does not ask. The set is
+// closed on purpose, so `EXCLUSION_COPY` below is a total `Record` over it — a
+// fifth member stops this file compiling rather than rendering as a raw slug.
+//
+// Ordered, Built and On hand ride along on every row because they are what make
+// the reason self-evident. `covered-by-stock` is only believable next to the two
+// numbers that produced it, and `already-covered` needs the third — the two
+// share a shape and differ entirely in remedy.
+
+import type { BackfillExclusion, BackfillExclusionReason } from '@auxx/lib/builds/client'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { formatQuantity } from './backfill-plan-table'
+
+/**
+ * What each reason says on the row.
+ *
+ * A `Record` over the closed union rather than a `switch` with a default: add a
+ * fourth member to `BackfillExclusionReason` and this stops compiling, which is
+ * the whole point of the set being closed.
+ */
+const EXCLUSION_COPY: Record<BackfillExclusionReason, { label: string; detail: string }> = {
+  'not-a-built-part': {
+    label: 'Purchased, not made',
+    detail: 'Its part kind is a component, so there is no run to raise.',
+  },
+  'no-bill-of-materials': {
+    label: 'No bill of materials',
+    detail: 'It is classified as buildable but has nothing to consume.',
+  },
+  'covered-by-stock': {
+    label: 'Covered by stock',
+    detail: 'The shelf already covers everything ordered in this range.',
+  },
+  // 🛑 Deliberately NOT folded into `covered-by-stock`. The two have different
+  // remedies, and conflating them is actively misleading on the SECOND run of
+  // this dialog, where every part just built is fully covered and would
+  // otherwise be reported as sitting on the shelf.
+  'already-covered': {
+    label: 'Already planned',
+    detail: 'Builds already exist for the whole of this demand.',
+  },
+}
+
+interface BackfillExclusionsProps {
+  exclusions: readonly BackfillExclusion[]
+  /** `partId` -> `EntityInstance.displayName`. */
+  partNames: Record<string, string | null>
+}
+
+export function BackfillExclusions({ exclusions, partNames }: BackfillExclusionsProps) {
+  if (exclusions.length === 0) return null
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <p className='font-medium text-muted-foreground text-xs'>
+        Not being built ({exclusions.length})
+      </p>
+
+      <div className='overflow-x-auto rounded-md border border-dashed bg-muted/40'>
+        <Table>
+          <TableHeader>
+            <TableRow className='hover:bg-transparent'>
+              <TableHead className='min-w-[180px] text-muted-foreground'>Part</TableHead>
+              <TableHead className='min-w-[160px] text-muted-foreground'>Reason</TableHead>
+              <TableHead className='text-right text-muted-foreground'>Ordered</TableHead>
+              <TableHead className='text-right text-muted-foreground'>Built</TableHead>
+              <TableHead className='text-right text-muted-foreground'>On hand</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {exclusions.map((exclusion) => {
+              const copy = EXCLUSION_COPY[exclusion.reason]
+              return (
+                <TableRow key={exclusion.partId} className='text-muted-foreground'>
+                  <TableCell className='truncate'>
+                    {partNames[exclusion.partId] ?? exclusion.partId}
+                  </TableCell>
+                  <TableCell>
+                    <span className='block text-xs'>{copy.label}</span>
+                    <span className='block text-[11px]'>{copy.detail}</span>
+                  </TableCell>
+                  <TableCell className='text-right tabular-nums'>
+                    {formatQuantity(exclusion.quantityOrdered)}
+                  </TableCell>
+                  <TableCell className='text-right tabular-nums'>
+                    {formatQuantity(exclusion.quantityCovered)}
+                  </TableCell>
+                  <TableCell className='text-right tabular-nums'>
+                    {formatQuantity(exclusion.quantityOnHand)}
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/manufacturing/builds/backfill-period-strip.tsx
+++ b/apps/web/src/components/manufacturing/builds/backfill-period-strip.tsx
@@ -1,0 +1,119 @@
+// apps/web/src/components/manufacturing/builds/backfill-period-strip.tsx
+'use client'
+
+// The chronological read the part-first table gives up (§7.2a of
+// plans/money/tasks/44-auto-build-cutoff-and-backfill.md).
+//
+// Rows are PART-first for a mechanical reason — on hand is a per-part quantity
+// consumed earliest-first, so it has nowhere honest to sit in a period-first
+// table. That costs the person backfilling history the one view they actually
+// want: *how much lands in January, how much in February*. This strip gives it
+// back above the table without making period the row axis, and clicking a
+// period filters the table to it, which is the "backfill January, then
+// February" workflow — available without splitting the RUN, which §7.1a rules
+// out anyway because coverage has to be netted at range level.
+
+import type { BackfillPlan } from '@auxx/lib/builds/client'
+import { cn } from '@auxx/ui/lib/utils'
+import { useMemo } from 'react'
+
+/** One column of the strip: a period, and everything the plan puts in it. */
+interface PeriodSummary {
+  periodKey: string
+  /** Earliest `periodStart` seen for the key, which is what orders the strip. */
+  startedAt: number
+  buildCount: number
+  unitCount: number
+}
+
+interface BackfillPeriodStripProps {
+  plan: BackfillPlan
+  /** The period the table is filtered to, or `null` for all of them. */
+  selected: string | null
+  onSelect: (periodKey: string | null) => void
+}
+
+export function BackfillPeriodStrip({ plan, selected, onSelect }: BackfillPeriodStripProps) {
+  const periods = useMemo(() => summarizePeriods(plan), [plan])
+
+  if (periods.length < 2) return null
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <div className='flex items-center justify-between'>
+        <p className='font-medium text-muted-foreground text-xs'>Periods</p>
+        {selected && (
+          <button
+            type='button'
+            className='text-muted-foreground text-xs underline-offset-2 hover:underline'
+            onClick={() => onSelect(null)}>
+            Show all
+          </button>
+        )}
+      </div>
+
+      <div className='-mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1'>
+        {periods.map((period) => {
+          const active = period.periodKey === selected
+          return (
+            <button
+              key={period.periodKey}
+              type='button'
+              aria-pressed={active}
+              onClick={() => onSelect(active ? null : period.periodKey)}
+              className={cn(
+                'shrink-0 rounded-md border px-2.5 py-1.5 text-left transition-colors',
+                active
+                  ? 'border-primary-300 bg-primary-100 dark:border-primary-700'
+                  : 'border-border bg-muted/40 hover:bg-muted'
+              )}>
+              <span className='block font-medium text-xs'>{period.periodKey}</span>
+              <span className='block text-[11px] text-muted-foreground'>
+                {period.buildCount} {period.buildCount === 1 ? 'build' : 'builds'} ·{' '}
+                {formatCount(period.unitCount)}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Roll the plan's buckets up by period key.
+ *
+ * Ordered by the earliest `periodStart` behind each key rather than by the key
+ * itself: `'2026-01'` sorts correctly as a string and a per-order key does not,
+ * and the strip is the chronological view — sorting it lexically would be the
+ * one place on this screen where time runs in the wrong order.
+ */
+function summarizePeriods(plan: BackfillPlan): PeriodSummary[] {
+  const byKey = new Map<string, PeriodSummary>()
+
+  for (const part of plan.parts) {
+    for (const bucket of part.buckets) {
+      const startedAt = new Date(bucket.periodStart).getTime()
+      const existing = byKey.get(bucket.periodKey)
+      if (existing) {
+        existing.buildCount += 1
+        existing.unitCount += bucket.quantityToBuild
+        existing.startedAt = Math.min(existing.startedAt, startedAt)
+        continue
+      }
+      byKey.set(bucket.periodKey, {
+        periodKey: bucket.periodKey,
+        startedAt,
+        buildCount: 1,
+        unitCount: bucket.quantityToBuild,
+      })
+    }
+  }
+
+  return [...byKey.values()].sort((a, b) => a.startedAt - b.startedAt)
+}
+
+function formatCount(value: number): string {
+  const rounded = Number.isInteger(value) ? value : Number(value.toFixed(4))
+  return `${rounded.toLocaleString()} ${rounded === 1 ? 'unit' : 'units'}`
+}

--- a/apps/web/src/components/manufacturing/builds/backfill-plan-table.tsx
+++ b/apps/web/src/components/manufacturing/builds/backfill-plan-table.tsx
@@ -1,0 +1,210 @@
+// apps/web/src/components/manufacturing/builds/backfill-plan-table.tsx
+'use client'
+
+// The preview table (§7.2 of plans/money/tasks/44-auto-build-cutoff-and-backfill.md).
+//
+// 🛑 **Rows are PART-first, never period-first.** The argument is the On hand
+// column and it is mechanical rather than aesthetic: on hand is a PER-PART
+// quantity consumed earliest-first across periods (§7.1a), so in a period-first
+// table it has nowhere honest to sit — repeated on every period row it reads as
+// "3 available in January and 3 in February", shown only on the first it looks
+// like a rendering fault. Part-first states it once, where it is true, and the
+// periods below show what is left after it is consumed.
+//
+// ⚠️ **"Builds per part" is builds per part PER PERIOD.** One part with demand
+// in eight months is eight builds at monthly grouping: the part row is a rollup
+// and the period rows underneath it are the actual builds. That is why the
+// Period cell on a part row reads "8 periods" rather than a date.
+//
+// The judgement this screen asks for is per part — *is this actually something
+// we make, is 412 units over eight months plausible* — which is also why parts
+// are the expandable axis and periods are the axis you scan.
+
+import type { BackfillPartPlan, BackfillPlan } from '@auxx/lib/builds/client'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { cn } from '@auxx/ui/lib/utils'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+
+interface BackfillPlanTableProps {
+  plan: BackfillPlan
+  /** `partId` -> `EntityInstance.displayName`. */
+  partNames: Record<string, string | null>
+  /** The period the strip is filtering to, or `null` for the whole range. */
+  periodFilter: string | null
+}
+
+export function BackfillPlanTable({ plan, partNames, periodFilter }: BackfillPlanTableProps) {
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set<string>())
+
+  const parts = periodFilter
+    ? plan.parts.filter((part) => part.buckets.some((b) => b.periodKey === periodFilter))
+    : plan.parts
+
+  if (parts.length === 0) {
+    return (
+      <p className='rounded-md border border-dashed px-3 py-6 text-center text-muted-foreground text-sm'>
+        {periodFilter
+          ? `Nothing to build in ${periodFilter}.`
+          : 'Nothing to build in this range. Every ordered part is either already covered or not made here.'}
+      </p>
+    )
+  }
+
+  const toggle = (partId: string) =>
+    setExpanded((current) => {
+      const next = new Set(current)
+      if (!next.delete(partId)) next.add(partId)
+      return next
+    })
+
+  return (
+    <div className='overflow-x-auto rounded-md border'>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className='min-w-[180px]'>Part</TableHead>
+            <TableHead className='min-w-[110px]'>Period</TableHead>
+            <TableHead className='text-right'>Ordered</TableHead>
+            <TableHead className='text-right'>Built</TableHead>
+            <TableHead className='text-right'>On hand</TableHead>
+            <TableHead className='text-right'>To build</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {parts.map((part) => {
+            // A period filter only ever narrows what is shown, never what is
+            // planned — the plan is netted at RANGE level (§7.1a), so a filtered
+            // part row still states the range totals it was computed from.
+            const buckets = periodFilter
+              ? part.buckets.filter((bucket) => bucket.periodKey === periodFilter)
+              : part.buckets
+            const open = expanded.has(part.partId) || !!periodFilter
+
+            return (
+              <PartRows
+                key={part.partId}
+                part={part}
+                buckets={buckets}
+                open={open}
+                // With a period filter on there is exactly one bucket to show
+                // and hiding it behind a chevron would be a click that hides the
+                // answer the filter was clicked for.
+                toggleable={!periodFilter}
+                name={partNames[part.partId] ?? null}
+                onToggle={() => toggle(part.partId)}
+              />
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+/** The rollup row, and the build rows underneath it. */
+function PartRows({
+  part,
+  buckets,
+  open,
+  toggleable,
+  name,
+  onToggle,
+}: {
+  part: BackfillPartPlan
+  buckets: BackfillPartPlan['buckets']
+  open: boolean
+  toggleable: boolean
+  name: string | null
+  onToggle: () => void
+}) {
+  const Chevron = open ? ChevronDown : ChevronRight
+
+  return (
+    <>
+      <TableRow
+        className={cn(toggleable && 'cursor-pointer')}
+        onClick={toggleable ? onToggle : undefined}>
+        <TableCell className='font-medium'>
+          <span className='flex items-center gap-1'>
+            {toggleable ? (
+              <Chevron className='size-3.5 shrink-0 text-muted-foreground' />
+            ) : (
+              <span className='w-3.5 shrink-0' />
+            )}
+            <span className='truncate'>{name ?? part.partId}</span>
+          </span>
+        </TableCell>
+        <TableCell className='text-muted-foreground text-xs'>
+          {part.buckets.length} {part.buckets.length === 1 ? 'period' : 'periods'}
+        </TableCell>
+        <TableCell className='text-right font-medium tabular-nums'>
+          {formatQuantity(part.quantityOrdered)}
+        </TableCell>
+        {/* ⚠️ The SUM over buckets, not `part.quantityCovered`. The plan-level
+            figure is coverage AVAILABLE, which can exceed what was ordered; in a
+            column headed "Built" that reads as a contradiction. The buckets
+            carry what was actually consumed. */}
+        <TableCell className='text-right font-medium tabular-nums'>
+          {formatQuantity(sumCovered(part.buckets))}
+        </TableCell>
+        <TableCell className='text-right font-medium tabular-nums'>
+          {formatQuantity(part.quantityOnHand)}
+        </TableCell>
+        <TableCell className='text-right font-medium tabular-nums'>
+          {formatQuantity(part.quantityToBuild)}
+        </TableCell>
+      </TableRow>
+
+      {open &&
+        buckets.map((bucket) => (
+          // 🛑 `bucketId`, never `(partId, periodKey)`. Under `grouping: 'order'`
+          // two orders placed on the same local day share a period key, and a
+          // React list keyed off that pair silently drops one of them.
+          <TableRow key={bucket.bucketId} className='bg-muted/30 hover:bg-muted/40'>
+            <TableCell />
+            <TableCell className='text-xs'>
+              <span className='block'>{bucket.periodKey}</span>
+              {/* Nothing stores the batch build's orders (§6.2), so this is the
+                  only place the link is ever visible. Somebody who does not
+                  believe a number has to be able to see how many orders are
+                  behind it — the build itself will never be able to tell them. */}
+              <span className='block text-[11px] text-muted-foreground'>
+                {bucket.orderIds.length} {bucket.orderIds.length === 1 ? 'order' : 'orders'}
+              </span>
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatQuantity(bucket.quantityOrdered)}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatQuantity(bucket.quantityCovered)}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatQuantity(bucket.quantityFromStock)}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatQuantity(bucket.quantityToBuild)}
+            </TableCell>
+          </TableRow>
+        ))}
+    </>
+  )
+}
+
+/** What the buckets actually consumed, which is the honest "Built" figure. */
+function sumCovered(buckets: BackfillPartPlan['buckets']): number {
+  return buckets.reduce((total, bucket) => total + bucket.quantityCovered, 0)
+}
+
+/** Quantities are `doublePrecision`, so a fraction is legal and must not round to nothing. */
+export function formatQuantity(value: number): string {
+  const rounded = Number.isInteger(value) ? value : Number(value.toFixed(4))
+  return rounded.toLocaleString()
+}

--- a/apps/web/src/components/manufacturing/builds/index.ts
+++ b/apps/web/src/components/manufacturing/builds/index.ts
@@ -1,5 +1,7 @@
 // apps/web/src/components/manufacturing/builds/index.ts
 
+export { BackfillBuildsButton } from './backfill-builds-button'
+export { BackfillDialog } from './backfill-dialog'
 export { BuildLedgerCard } from './build-ledger-card'
 export { BuildRunCard } from './build-run-card'
 export { CompleteBuildDialog } from './complete-build-dialog'

--- a/apps/web/src/server/api/routers/builds.ts
+++ b/apps/web/src/server/api/routers/builds.ts
@@ -1,23 +1,38 @@
 // apps/web/src/server/api/routers/builds.ts
 
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
 import {
   buildNow,
   cancelBuild,
   completeBuild,
   createBuild,
+  executeBackfill,
   explodeBuildComponents,
   getBuild,
   listBuilds,
+  loadAutoBuildSettings,
   loadEffectiveAbsorptionRates,
+  planBackfill,
   previewStandardCostRoll,
+  readBackfillPlanReads,
   readBuildDrift,
   readPartQuantitiesOnHand,
   reverseBuild,
   rollStandardCost,
   startBuild,
 } from '@auxx/lib/builds'
+import type {
+  BackfillExclusion,
+  BackfillGrouping,
+  BackfillPartPlan,
+  BackfillPlan,
+  BackfillStatus,
+} from '@auxx/lib/builds/client'
 import { getCachedEntityDefId } from '@auxx/lib/cache'
-import { NotFoundError } from '@auxx/lib/errors'
+import { BadRequestError, NotFoundError } from '@auxx/lib/errors'
+import { getOrganizationSetting } from '@auxx/lib/settings'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { capabilityProcedure, createTRPCRouter } from '~/server/api/trpc'
 
@@ -61,6 +76,39 @@ const componentOverride = z.object({
   /** Units consumed by the WHOLE run, not per produced unit. */
   quantityConsumed: z.number().finite().nonnegative().max(1_000_000),
 })
+
+/**
+ * The backfill's window and how it batches (plans/money/tasks/44 sections 7.0-7.3).
+ *
+ * `as const satisfies` rather than a bare `z.enum`: the vocabularies live in
+ * `backfill-types.ts`, and a member renamed there has to break this file rather
+ * than silently narrow what the browser is allowed to ask for.
+ */
+const BACKFILL_GROUPING_VALUES = [
+  'order',
+  'day',
+  'week',
+  'month',
+  'range',
+] as const satisfies readonly BackfillGrouping[]
+
+const BACKFILL_STATUS_VALUES = ['planned', 'completed'] as const satisfies readonly BackfillStatus[]
+
+const backfillShape = {
+  /** Inclusive lower bound on `order_placed_at`. */
+  from: z.coerce.date(),
+  /** Exclusive upper bound. Bounded above by the build cutoff (section 7.0). */
+  to: z.coerce.date(),
+  grouping: z.enum(BACKFILL_GROUPING_VALUES),
+  /**
+   * What the run would land in. Section 7.3.
+   *
+   * On the PREVIEW it is not merely decoration: `completed` is what turns the
+   * preflight on, and it is what makes this preview disclose the standard costs
+   * a completion would freeze — which is why it also raises the gate.
+   */
+  status: z.enum(BACKFILL_STATUS_VALUES),
+}
 
 /** The two quantities and the overrides — everything that prices a run. */
 const completionShape = {
@@ -444,7 +492,376 @@ export const buildsRouter = createTRPCRouter({
       if (result.isErr()) throw result.error
       return result.value
     }),
+
+  // ─── The backfill (plans/money/tasks/44 §7) ─────────────────────────
+
+  /**
+   * What the backfill WOULD create over a range, netted per part.
+   *
+   * 🛑 **The only read in this subsystem that is an AGGREGATE** (§7.1). Every
+   * other read in `builds/` answers for one order; this one answers *"what has
+   * been ordered and not yet built"* across a window, which is the whole content
+   * of the preview screen. Rows are `(part, period)` and an order is never a row
+   * — an order with two parts can carry a build for one and not the other, so it
+   * is neither covered nor uncovered as a whole.
+   *
+   * **It returns a REFUSAL rather than throwing on a bad range**, and that is
+   * deliberate. §7.0 says the dialog must refuse a `to` past the build cutoff
+   * *and say why* rather than clamp silently — but the dialog cannot bound its
+   * own date picker without knowing the cutoff, and a thrown error carries a
+   * sentence, not a date. So the cutoff rides on every response, a refused range
+   * comes back with `plan: null` and the reason, and the write door
+   * ({@link runBackfill}) throws on exactly the same conditions. The refusal is
+   * real; it is just legible.
+   *
+   * Gated as a write, not as a read, on the same argument `previewRoll` and
+   * `previewCompletion` make: the preview exists solely to be the first half of
+   * a write, and a reader who cannot raise a build has no use for it. When
+   * `status` is `completed` it also discloses the standard costs the run would
+   * freeze, so it takes the full ledger gate.
+   */
+  previewBackfill: capabilityProcedure
+    .input(z.object(backfillShape))
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await assertCanRunBackfill(ctx, input.status)
+
+      // ⚠️ `enabledAt`, not `enabled`. The bound exists because the reconciler is
+      // live ABOVE the cutoff (§7.0); a null stamp means no order has ever
+      // qualified for a live raise, so there is nothing for a batch build to
+      // collide with and the range is unbounded above.
+      const [{ enabledAt: cutoff }, timeZone] = await Promise.all([
+        loadAutoBuildSettings(organizationId),
+        readBookTimeZone(organizationId),
+      ])
+      const refusal = refuseBackfillRange(input, cutoff, timeZone)
+      if (refusal) return { cutoff, refusal, plan: null, partNames: {}, preflight: null }
+
+      const plan = await buildBackfillPlan(ctx.db, organizationId, input, timeZone)
+
+      // The contract carries part IDS; a screen somebody has to judge carries
+      // part NAMES. Resolved here rather than in the plan because the plan is
+      // the thing the writer executes, and a display name has no business in it.
+      const [partNames, preflight] = await Promise.all([
+        readEntityNames(ctx.db, organizationId, [
+          ...plan.parts.map((part: BackfillPartPlan) => part.partId),
+          ...plan.excluded.map((exclusion: BackfillExclusion) => exclusion.partId),
+        ]),
+        input.status === 'completed'
+          ? computeBackfillPreflight(ctx.db, organizationId, plan)
+          : Promise.resolve(null),
+      ])
+
+      return { cutoff, refusal: null, plan, partNames, preflight }
+    }),
+
+  /**
+   * Create the builds the preview showed.
+   *
+   * 🛑 **Not atomic, and the summary says so** (§7.4). `buildNow` reports a
+   * refused completion as the `left_in_progress` RESULT rather than an error,
+   * carrying the build it already raised, so the run records those and keeps
+   * going. A run that aborted on the first refusal would tell somebody "failed"
+   * about builds that exist, and they would press the button again.
+   *
+   * Same two gates as the preview, for the same reason — a `completed` backfill
+   * is a stock movement by any other name.
+   */
+  runBackfill: capabilityProcedure
+    .input(z.object(backfillShape))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      await assertCanRunBackfill(ctx, input.status)
+
+      const [{ enabledAt: cutoff }, timeZone] = await Promise.all([
+        loadAutoBuildSettings(organizationId),
+        readBookTimeZone(organizationId),
+      ])
+      // The write door throws where the preview merely explains. Both run the
+      // same predicate, so the button the dialog disables and the call the
+      // server refuses can never disagree.
+      const refusal = refuseBackfillRange(input, cutoff, timeZone)
+      if (refusal) throw new BadRequestError(refusal)
+
+      // 🛑 Re-planned server-side rather than taken from the browser. The plan
+      // is what `executeBackfill` writes, and a client-supplied one would let a
+      // stale preview (or a crafted payload) name quantities and periods that no
+      // read ever produced.
+      const plan = await buildBackfillPlan(ctx.db, organizationId, input, timeZone)
+
+      const result = await executeBackfill(ctx.db, organizationId, userId, plan, {
+        from: input.from,
+        to: input.to,
+        grouping: input.grouping,
+        status: input.status,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
 })
+
+/**
+ * Read what the plan is decided from, then decide it.
+ *
+ * The split is `reconcile-policy.ts` / `reconcile-order-builds.ts`'s: the reads
+ * come back as data and the decision is pure, so the painful cases (a monthly
+ * build viewed by week, on hand spread across eight buckets) are unit tests
+ * rather than browser clicks. `grouping` and `timeZone` are the caller's — one
+ * is a dialog choice, the other an org setting, and neither is a read.
+ */
+async function buildBackfillPlan(
+  db: Database,
+  organizationId: string,
+  input: { from: Date; to: Date; grouping: BackfillGrouping },
+  timeZone: string | null
+): Promise<BackfillPlan> {
+  const reads = await readBackfillPlanReads(db, organizationId, {
+    from: input.from,
+    to: input.to,
+  })
+  if (reads.isErr()) throw reads.error
+  return planBackfill({ ...reads.value, grouping: input.grouping, timeZone: timeZone ?? 'UTC' })
+}
+
+/**
+ * `accounting.bookTimeZone`, or `null` when the org has not set one.
+ *
+ * ⚠️ The catalog says this setting fails CLOSED, and it does — for posting. It
+ * cannot fail closed here without contradicting §11.1, which puts the preview
+ * and the `planned` write in phases 1-3, explicitly *"blocked by nothing"* in
+ * the cutover chain: an org that has not begun the chain has no book timezone
+ * and would be unable to open this dialog at all. So the preview and a
+ * `planned` run fall back to UTC, and a `completed` run — the one that dates a
+ * ledger — is refused outright when the zone is unset
+ * ({@link refuseBackfillRange}). Nothing is silently posted into the wrong
+ * month, because nothing is posted.
+ */
+async function readBookTimeZone(organizationId: string): Promise<string | null> {
+  const value = await getOrganizationSetting({
+    organizationId,
+    key: 'accounting.bookTimeZone',
+  })
+  // Deliberately `null` rather than `'UTC'`: an org whose books genuinely ARE
+  // kept in UTC has SET the zone, and collapsing the two would refuse it a
+  // completed backfill it is entitled to.
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+/**
+ * What a `completed` backfill would write, checked before anything is written.
+ *
+ * §7.3 gates 2, 3 and 4: the consent for a completed run is *"N builds, M stock
+ * movements, on an append-only ledger correctable only by reversing"*, and both
+ * numbers have to be real. `completeBuild` also aborts per build when a
+ * component has no `part_standard_cost`, and discovering that on build 400 of
+ * 900 is the wrong time.
+ */
+interface BackfillPreflight {
+  /** Builds the run would raise. */
+  buildCount: number
+  /** `build_consume` + `build_produce` rows those builds would append. */
+  movementCount: number
+  /** Parts with no standard cost, which `completeBuild` refuses outright. */
+  unpricedParts: { partId: string; partName: string | null }[]
+  /**
+   * Where the run leaves each consumed component.
+   *
+   * ⚠️ A WARNING's input, never a gate's (§7.3 gate 4). Negative on hand is a
+   * true statement about a ledger missing its receipts, and refusing would make
+   * the backfill unusable on exactly the org that needs it most. The remedy is
+   * opening stock, which is the person's call to make first.
+   */
+  projectedOnHand: {
+    partId: string
+    partName: string | null
+    onHand: number
+    consumed: number
+    projected: number
+  }[]
+}
+
+/**
+ * Explode every part in the plan and total what the run would consume.
+ *
+ * Exploded once per part at its WHOLE range quantity rather than once per
+ * bucket: component quantities are linear in the produced quantity, so the total
+ * is identical and a twenty-part plan costs twenty round trips instead of
+ * ninety-four.
+ */
+async function computeBackfillPreflight(
+  db: Database,
+  organizationId: string,
+  plan: BackfillPlan
+): Promise<BackfillPreflight> {
+  const buildCount = plan.buildCount
+  let movementCount = 0
+  const unpriced = new Set<string>()
+  const consumed = new Map<string, number>()
+
+  const explosions = await Promise.all(
+    plan.parts.map((part) =>
+      explodeBuildComponents(db, organizationId, {
+        partId: part.partId,
+        quantityProduced: part.quantityToBuild,
+      })
+    )
+  )
+
+  for (const [index, explosion] of explosions.entries()) {
+    const part = plan.parts[index]
+    if (!part) continue
+    if (explosion.isErr()) throw explosion.error
+    const components = explosion.value.components
+    // One `build_produce` per build, plus one `build_consume` per component per
+    // build. The component set is the same for every bucket of a part.
+    movementCount += part.buckets.length * (components.length + 1)
+    for (const missing of explosion.value.missingStandardPartIds) unpriced.add(missing)
+    for (const line of components) {
+      consumed.set(line.partId, (consumed.get(line.partId) ?? 0) + line.quantityConsumed)
+    }
+  }
+
+  const componentIds = [...consumed.keys()]
+  const [onHand, names] = await Promise.all([
+    readPartQuantitiesOnHand(db, organizationId, componentIds),
+    readEntityNames(db, organizationId, [...componentIds, ...unpriced]),
+  ])
+
+  return {
+    buildCount,
+    movementCount,
+    unpricedParts: [...unpriced].map((partId) => ({
+      partId,
+      partName: names[partId] ?? null,
+    })),
+    projectedOnHand: componentIds
+      .map((partId) => {
+        const available = onHand.get(partId) ?? 0
+        const used = consumed.get(partId) ?? 0
+        return {
+          partId,
+          partName: names[partId] ?? null,
+          onHand: available,
+          consumed: used,
+          projected: available - used,
+        }
+      })
+      // Worst first: the rows that matter are the ones the run drives negative.
+      .sort((a, b) => a.projected - b.projected),
+  }
+}
+
+/**
+ * Why this range cannot be backfilled, or `null` when it can.
+ *
+ * One predicate, run by both the preview and the write, so the reason the dialog
+ * prints is literally the reason the server would give.
+ */
+function refuseBackfillRange(
+  input: { from: Date; to: Date; grouping: BackfillGrouping; status: BackfillStatus },
+  cutoff: Date | null,
+  timeZone: string | null
+): string | null {
+  if (!(input.from.getTime() < input.to.getTime())) {
+    return 'The from date has to be before the to date.'
+  }
+
+  // §7.0. A batch build is only safe BELOW the cutoff: above it the reconciler
+  // is live and a batch build does not suppress a raise, so any order up there
+  // that later moves would get a per-order build stacked on the batch one.
+  if (cutoff && input.to.getTime() > cutoff.getTime()) {
+    return `This range ends after the build cutoff of ${cutoff.toISOString().slice(0, 10)}. Above the cutoff builds are raised per order, so a batch build there would end up stacked on top of a live one. Move the to date back to the cutoff or earlier.`
+  }
+
+  if (input.status === 'completed') {
+    // The one place `accounting.bookTimeZone` still fails closed, as its catalog
+    // entry demands: a completed build carries the date that decides which
+    // month-end entry reflects it, and deriving that date in an assumed UTC is
+    // exactly the silent misstatement the setting exists to prevent.
+    if (!timeZone) {
+      return 'Set the book timezone in accounting settings before creating completed builds. A completed build carries the date that decides which month it closes in, and that date cannot be derived without it.'
+    }
+
+    // §7.3 gate 1. Completing future demand is meaningless.
+    if (input.to.getTime() > Date.now()) {
+      return 'A completed backfill dates the ledger, so its range cannot reach into the future. Move the to date back to today, or create the builds as planned.'
+    }
+
+    // §7.3 / the contract on `BackfillGrouping`. `build_completed_at` decides
+    // which month-end entry reflects a build, so one build for a range spanning
+    // several months misstates every month it spans.
+    //
+    // ⚠️ Compared in UTC, while the writer buckets in the org's book timezone.
+    // The two can disagree for a range that ends within hours of a month
+    // boundary; this is a guard rail on an obviously multi-month range, not the
+    // authority on where a period ends.
+    if (input.grouping === 'range' && spansSeveralMonths(input.from, input.to)) {
+      return 'One build for the whole range would date every unit to a single month, and this range spans more than one. Group by month or finer, or create the builds as planned.'
+    }
+  }
+
+  return null
+}
+
+/** Does `[from, to)` cross a calendar month boundary? `to` is exclusive. */
+function spansSeveralMonths(from: Date, to: Date): boolean {
+  const last = new Date(to.getTime() - 1)
+  return (
+    from.getUTCFullYear() !== last.getUTCFullYear() || from.getUTCMonth() !== last.getUTCMonth()
+  )
+}
+
+/**
+ * `EntityInstance.displayName` for a set of ids, as a plain record.
+ *
+ * A record rather than a `Map` because it crosses the tRPC boundary — superjson
+ * would carry a `Map`, but every consumer here is a lookup in JSX.
+ */
+async function readEntityNames(
+  db: Database,
+  organizationId: string,
+  ids: string[]
+): Promise<Record<string, string | null>> {
+  const unique = [...new Set(ids)]
+  if (unique.length === 0) return {}
+
+  const rows = await db
+    .select({ id: schema.EntityInstance.id, displayName: schema.EntityInstance.displayName })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        inArray(schema.EntityInstance.id, unique),
+        eq(schema.EntityInstance.organizationId, organizationId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+
+  const names: Record<string, string | null> = {}
+  for (const row of rows) names[row.id] = row.displayName
+  return names
+}
+
+/**
+ * The gate on both halves of the backfill.
+ *
+ * EDIT on `build` always, because builds are raised. Plus EDIT on
+ * `stock_movement` when the run lands `completed`, because that is the arm that
+ * appends consume and produce rows — the same split
+ * {@link assertCanPostBuildLedger} makes for a single completion.
+ */
+async function assertCanRunBackfill(
+  ctx: {
+    session: { organizationId: string }
+    capabilities: { assertEditEntity: (defId: string) => void }
+  },
+  status: BackfillStatus
+): Promise<void> {
+  if (status === 'completed') {
+    await assertCanPostBuildLedger(ctx)
+    return
+  }
+  ctx.capabilities.assertEditEntity(await requireDefId(ctx.session.organizationId, 'build'))
+}
 
 /**
  * The gate on every path that writes a build's ledger.

--- a/packages/lib/src/builds/__tests__/backfill-builds.test.ts
+++ b/packages/lib/src/builds/__tests__/backfill-builds.test.ts
@@ -1,0 +1,504 @@
+// packages/lib/src/builds/__tests__/backfill-builds.test.ts
+//
+// The bulk builder's WRITE half
+// (plans/money/tasks/44-auto-build-cutoff-and-backfill.md §6, §7.3, §7.4).
+//
+// The DECISION is not under test here — `backfill-policy.test.ts` owns it, pure
+// and with no doubles. What is under test is the shell: the values one bucket
+// becomes, the accounting date it is completed at, and the three-layer
+// never-throw discipline that has to keep four hundred builds from being lost
+// to one unpriced screw.
+//
+// Two properties carry most of the weight:
+//
+//   1. §7.4 — a refused completion is a `leftInProgress` RESULT carrying the
+//      build id, and the run CONTINUES. An error channel cannot name a build,
+//      so the person would be told "failed" about builds that exist and would
+//      press the button again.
+//   2. §6.2 / the accounting rule — `completedAt` comes from the bucket's own
+//      demand period, in the book timezone, and never from `new Date()`.
+//      Dating eight months of production to today puts all of it in one
+//      month-end entry.
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import type { BackfillBucket, BackfillPlan, BackfillRequest } from '../backfill-types'
+import type { BuildRecord } from '../types'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const LIFT = 'part_lift'
+const HOIST = 'part_hoist'
+const BUILD_DEF = 'def_build'
+
+const h = vi.hoisted(() => ({
+  /** `accounting.bookTimeZone`, or null for an org that keeps no books. */
+  timeZone: null as string | null,
+  /** Which of the two demand-period fields are provisioned. */
+  periodFields: { start: true, end: true },
+  /** Every `createBuild` call, as the `CreateBuildInput` it was handed. */
+  createCalls: [] as Record<string, unknown>[],
+  startCalls: [] as Record<string, unknown>[],
+  completeCalls: [] as Record<string, unknown>[],
+  /** partIds whose `createBuild` must return an `err`. */
+  createRefusals: new Map<string, Error>(),
+  /** buildIds whose `startBuild` must return an `err`. */
+  startRefusals: new Map<string, Error>(),
+  /** buildIds whose `completeBuild` must return an `err`. */
+  completeRefusals: new Map<string, Error>(),
+  nextBuild: 0,
+}))
+
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: vi.fn(async () => h.timeZone),
+}))
+
+vi.mock('../../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async () => ({
+        build_period_start: h.periodFields.start ? { id: 'f_period_start' } : null,
+        build_period_end: h.periodFields.end ? { id: 'f_period_end' } : null,
+      }),
+    }),
+  }),
+}))
+
+// The three sanctioned writers are doubles: each has its own suite, and what is
+// under test here is the SEAM between them. `createBuild` in particular owns the
+// part-kind and bill-of-materials refusals and the demand-period write, so this
+// file asserts on the input it is handed rather than re-testing those.
+vi.mock('../build-mutations', () => ({
+  createBuild: vi.fn(
+    async (_db: unknown, _org: string, _user: string, input: Record<string, unknown>) => {
+      h.createCalls.push(input)
+      const refusal = h.createRefusals.get(String(input.partId))
+      if (refusal) return err(refusal)
+      h.nextBuild += 1
+      const buildId = `bld_${h.nextBuild}`
+      return ok(raised(buildId, { partId: String(input.partId) }))
+    }
+  ),
+  startBuild: vi.fn(
+    async (_db: unknown, _org: string, _user: string, input: { buildId: string }) => {
+      h.startCalls.push(input)
+      const refusal = h.startRefusals.get(input.buildId)
+      return refusal ? err(refusal) : ok(raised(input.buildId, { status: 'in_progress' }))
+    }
+  ),
+}))
+
+vi.mock('../complete-build', () => ({
+  completeBuild: vi.fn(
+    async (_db: unknown, _org: string, _user: string, input: Record<string, unknown>) => {
+      h.completeCalls.push(input)
+      const refusal = h.completeRefusals.get(String(input.buildId))
+      return refusal ? err(refusal) : ok({ buildId: input.buildId, movementIds: ['mv_1'] })
+    }
+  ),
+}))
+
+import { executeBackfill, resolveBackfillCompletedAt } from '../backfill-builds'
+
+/** Nothing in this file reads the database — every writer it calls is a double. */
+const db = {} as never
+
+function raised(buildId: string, over: Partial<BuildRecord> = {}): BuildRecord {
+  return {
+    buildId,
+    recordId: `${BUILD_DEF}:${buildId}`,
+    number: null,
+    partId: LIFT,
+    status: 'planned',
+    quantityPlanned: 10,
+    quantityProduced: null,
+    quantityScrapped: null,
+    startedAt: null,
+    completedAt: null,
+    materialCost: null,
+    laborCost: null,
+    overheadCost: null,
+    producedValue: null,
+    varianceAmount: null,
+    postedAt: null,
+    notes: null,
+    orderId: null,
+    source: 'batch',
+    reversalOfBuildId: null,
+    orderRevision: null,
+    createdAt: new Date('2026-09-03T00:00:00.000Z'),
+    ...over,
+  } as BuildRecord
+}
+
+/** One monthly bucket. `month` is 1-based; the period is UTC-bounded by default. */
+function bucket(over: Partial<BackfillBucket> = {}): BackfillBucket {
+  return {
+    partId: LIFT,
+    periodStart: new Date('2026-01-01T00:00:00.000Z'),
+    periodEnd: new Date('2026-02-01T00:00:00.000Z'),
+    periodKey: '2026-01',
+    bucketId: `${LIFT}:2026-01`,
+    quantityOrdered: 10,
+    quantityCovered: 0,
+    quantityFromStock: 0,
+    quantityToBuild: 10,
+    orderIds: ['ord_1'],
+    ...over,
+  }
+}
+
+function planOf(...buckets: BackfillBucket[]): BackfillPlan {
+  const byPart = new Map<string, BackfillBucket[]>()
+  for (const b of buckets) {
+    const list = byPart.get(b.partId) ?? []
+    list.push(b)
+    byPart.set(b.partId, list)
+  }
+  return {
+    parts: [...byPart.entries()].map(([partId, list]) => ({
+      partId,
+      quantityOrdered: list.reduce((n, b) => n + b.quantityOrdered, 0),
+      quantityCovered: 0,
+      quantityOnHand: 0,
+      quantityToBuild: list.reduce((n, b) => n + b.quantityToBuild, 0),
+      buckets: list,
+    })),
+    excluded: [],
+    buildCount: buckets.length,
+    unitCount: buckets.reduce((n, b) => n + b.quantityToBuild, 0),
+  }
+}
+
+const PLANNED: BackfillRequest = {
+  from: new Date('2026-01-01T00:00:00.000Z'),
+  to: new Date('2026-03-01T00:00:00.000Z'),
+  grouping: 'month',
+  status: 'planned',
+}
+const COMPLETED: BackfillRequest = { ...PLANNED, status: 'completed' }
+
+beforeEach(() => {
+  vi.useRealTimers()
+  h.timeZone = 'UTC'
+  h.periodFields = { start: true, end: true }
+  h.createCalls = []
+  h.startCalls = []
+  h.completeCalls = []
+  h.createRefusals = new Map()
+  h.startRefusals = new Map()
+  h.completeRefusals = new Map()
+  h.nextBuild = 0
+})
+
+// ─── The accounting date ────────────────────────────────────────────────
+
+describe('🛑 completedAt comes from the period, never from now', () => {
+  it('is the last instant of the period, not its exclusive end', () => {
+    const at = resolveBackfillCompletedAt(bucket(), 'UTC')
+    expect(at.toISOString()).toBe('2026-01-31T23:59:59.999Z')
+  })
+
+  it('falls INSIDE the half-open period for every bucket', () => {
+    for (const month of ['01', '02', '06', '11'] as const) {
+      const next = month === '11' ? '12' : String(Number(month) + 1).padStart(2, '0')
+      const b = bucket({
+        periodStart: new Date(`2026-${month}-01T00:00:00.000Z`),
+        periodEnd: new Date(`2026-${next}-01T00:00:00.000Z`),
+      })
+      const at = resolveBackfillCompletedAt(b, 'UTC').getTime()
+      expect(at).toBeGreaterThanOrEqual(b.periodStart.getTime())
+      expect(at).toBeLessThan(b.periodEnd.getTime())
+    }
+  })
+
+  // 🛑 January 31 19:00 in New York is already February in UTC. Derive this in
+  // UTC and eight months of production land in the wrong month-end entries,
+  // invisibly, and uncorrectably once the period is locked.
+  it('derives the local day end in the BOOK timezone', () => {
+    const b = bucket({
+      // The month, bounded as New York wall-clock midnights.
+      periodStart: new Date('2026-01-01T05:00:00.000Z'),
+      periodEnd: new Date('2026-02-01T05:00:00.000Z'),
+    })
+    const at = resolveBackfillCompletedAt(b, 'America/New_York')
+    expect(at.toISOString()).toBe('2026-02-01T04:59:59.999Z')
+    // Which is still January in the books — the whole point.
+    const local = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/New_York',
+      year: 'numeric',
+      month: '2-digit',
+    }).format(at)
+    expect(local).toBe('2026-01')
+  })
+
+  // A boundary computed in a different zone from the one read here must still
+  // only produce an instant the build's own period contains.
+  it('clamps below the exclusive end when the zones disagree', () => {
+    const b = bucket({
+      periodStart: new Date('2026-01-01T00:00:00.000Z'),
+      periodEnd: new Date('2026-02-01T00:00:00.000Z'),
+    })
+    const at = resolveBackfillCompletedAt(b, 'America/New_York')
+    expect(at.getTime()).toBeLessThan(b.periodEnd.getTime())
+    expect(at.toISOString()).toBe('2026-01-31T23:59:59.999Z')
+  })
+
+  // Under `grouping: 'order'` the two bounds collapse onto the one order's date.
+  it('returns the start for a period with no width', () => {
+    const day = new Date('2026-01-17T14:30:00.000Z')
+    const at = resolveBackfillCompletedAt(bucket({ periodStart: day, periodEnd: day }), 'UTC')
+    expect(at.toISOString()).toBe(day.toISOString())
+  })
+})
+
+// ─── What one bucket becomes ────────────────────────────────────────────
+
+describe('one bucket, one build', () => {
+  it('writes a batch build carrying the demand period', async () => {
+    const result = await executeBackfill(db, ORG, USER, planOf(bucket()), PLANNED)
+
+    expect(result.isOk()).toBe(true)
+    expect(h.createCalls).toHaveLength(1)
+    expect(h.createCalls[0]).toEqual({
+      partId: LIFT,
+      quantityPlanned: 10,
+      source: 'batch',
+      period: {
+        start: new Date('2026-01-01T00:00:00.000Z'),
+        end: new Date('2026-02-01T00:00:00.000Z'),
+      },
+    })
+  })
+
+  // §6.2: a batch build carries a PERIOD, not its orders. A relation would put
+  // row growth back on order count, which is what batching exists to escape.
+  it('carries no order relation, however many orders are behind it', async () => {
+    const b = bucket({ orderIds: ['ord_1', 'ord_2', 'ord_3'] })
+    await executeBackfill(db, ORG, USER, planOf(b), PLANNED)
+    expect(h.createCalls[0]).not.toHaveProperty('orderId')
+    expect(h.createCalls[0]).not.toHaveProperty('orderRevision')
+  })
+
+  it('reports every build it raised', async () => {
+    const plan = planOf(bucket(), bucket({ periodKey: '2026-02', bucketId: `${LIFT}:2026-02` }))
+    const summary = (await executeBackfill(db, ORG, USER, plan, PLANNED))._unsafeUnwrap()
+
+    expect(summary.created).toEqual([
+      { partId: LIFT, buildId: 'bld_1', quantity: 10, periodKey: '2026-01' },
+      { partId: LIFT, buildId: 'bld_2', quantity: 10, periodKey: '2026-02' },
+    ])
+    expect(summary.failed).toEqual([])
+    expect(summary.leftInProgress).toEqual([])
+  })
+
+  it('does nothing at all for an empty plan', async () => {
+    const summary = (await executeBackfill(db, ORG, USER, planOf(), PLANNED))._unsafeUnwrap()
+    expect(summary).toEqual({ created: [], leftInProgress: [], failed: [] })
+    expect(h.createCalls).toHaveLength(0)
+  })
+})
+
+describe('planned is the whole of the write', () => {
+  it('never starts or completes a planned run', async () => {
+    await executeBackfill(db, ORG, USER, planOf(bucket()), PLANNED)
+    expect(h.startCalls).toHaveLength(0)
+    expect(h.completeCalls).toHaveLength(0)
+  })
+})
+
+describe('completed walks create -> start -> complete', () => {
+  it('completes at the period date, not at now', async () => {
+    await executeBackfill(db, ORG, USER, planOf(bucket()), COMPLETED)
+
+    expect(h.startCalls).toEqual([{ buildId: 'bld_1' }])
+    expect(h.completeCalls).toHaveLength(1)
+    expect(h.completeCalls[0]).toMatchObject({ buildId: 'bld_1', quantityProduced: 10 })
+    expect((h.completeCalls[0]?.completedAt as Date).toISOString()).toBe('2026-01-31T23:59:59.999Z')
+  })
+
+  // The failure this exists to prevent: eight monthly builds all dated today
+  // land in ONE month-end entry, and the other seven months show no production.
+  it('dates each month to its own month, across a long range', async () => {
+    const months = ['01', '02', '03'] as const
+    const plan = planOf(
+      ...months.map((m) =>
+        bucket({
+          periodStart: new Date(`2026-${m}-01T00:00:00.000Z`),
+          periodEnd: new Date(`2026-${String(Number(m) + 1).padStart(2, '0')}-01T00:00:00.000Z`),
+          periodKey: `2026-${m}`,
+          bucketId: `${LIFT}:2026-${m}`,
+        })
+      )
+    )
+    await executeBackfill(db, ORG, USER, plan, COMPLETED)
+
+    const dates = h.completeCalls.map((call) =>
+      (call.completedAt as Date).toISOString().slice(0, 7)
+    )
+    expect(dates).toEqual(['2026-01', '2026-02', '2026-03'])
+  })
+
+  // §7.3 rule 1: completing demand that has not happened yet is meaningless.
+  it('refuses a period that has not ended, and raises no build for it', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-15T00:00:00.000Z'))
+
+    const summary = (
+      await executeBackfill(db, ORG, USER, planOf(bucket()), COMPLETED)
+    )._unsafeUnwrap()
+
+    expect(h.createCalls).toHaveLength(0)
+    expect(summary.created).toEqual([])
+    expect(summary.failed).toHaveLength(1)
+    expect(summary.failed[0]?.reason).toContain('has not ended yet')
+    expect(summary.failed[0]?.bucketId).toBe(`${LIFT}:2026-01`)
+  })
+})
+
+// ─── §7.4 — it is not atomic, and the summary says so ───────────────────
+
+describe('🛑 a refused completion is a result, not an error', () => {
+  it('records the build that exists and CONTINUES the run', async () => {
+    h.completeRefusals.set(
+      'bld_1',
+      new UnprocessableEntityError('Feet Bracket has no standard cost')
+    )
+    const plan = planOf(bucket(), bucket({ periodKey: '2026-02', bucketId: `${LIFT}:2026-02` }))
+
+    const result = await executeBackfill(db, ORG, USER, plan, COMPLETED)
+
+    // ✅ Ok, not err — the caller has to be able to name and link the run.
+    expect(result.isOk()).toBe(true)
+    const summary = result._unsafeUnwrap()
+    expect(summary.leftInProgress).toEqual([
+      { partId: LIFT, buildId: 'bld_1', reason: 'Feet Bracket has no standard cost' },
+    ])
+    // The batch is NOT aborted: the second bucket still ran and completed.
+    expect(h.createCalls).toHaveLength(2)
+    expect(h.completeCalls).toHaveLength(2)
+  })
+
+  // A build left in progress WAS created, and `created.length` is the answer to
+  // "how many builds does this org have that it did not before".
+  it('still counts the raised build as created', async () => {
+    h.completeRefusals.set('bld_1', new UnprocessableEntityError('nope'))
+    const summary = (
+      await executeBackfill(db, ORG, USER, planOf(bucket()), COMPLETED)
+    )._unsafeUnwrap()
+
+    expect(summary.created).toHaveLength(1)
+    expect(summary.created[0]?.buildId).toBe('bld_1')
+    expect(summary.failed).toEqual([])
+  })
+
+  it('records a refused START too, because that build also exists', async () => {
+    h.startRefusals.set(
+      'bld_1',
+      new UnprocessableEntityError('Only a planned build can be started')
+    )
+
+    const summary = (
+      await executeBackfill(db, ORG, USER, planOf(bucket()), COMPLETED)
+    )._unsafeUnwrap()
+
+    expect(h.completeCalls).toHaveLength(0)
+    expect(summary.leftInProgress).toHaveLength(1)
+    expect(summary.leftInProgress[0]?.buildId).toBe('bld_1')
+    expect(summary.leftInProgress[0]?.reason).toContain('could not be started')
+  })
+})
+
+// ─── Never throws ───────────────────────────────────────────────────────
+
+describe('🛑 never throws', () => {
+  it('a bucket whose raise is refused is recorded and stepped over', async () => {
+    h.createRefusals.set(LIFT, new UnprocessableEntityError('crud blew up for part_lift'))
+    const plan = planOf(bucket(), bucket({ partId: HOIST, bucketId: `${HOIST}:2026-01` }))
+
+    const summary = (await executeBackfill(db, ORG, USER, plan, PLANNED))._unsafeUnwrap()
+
+    expect(summary.failed).toHaveLength(1)
+    expect(summary.failed[0]?.partId).toBe(LIFT)
+    expect(summary.failed[0]?.reason).toContain('crud blew up')
+    // The other part still got its build.
+    expect(summary.created).toHaveLength(1)
+    expect(summary.created[0]?.partId).toBe(HOIST)
+  })
+
+  it('records one row per failed bucket, never two', async () => {
+    h.createRefusals.set(LIFT, new UnprocessableEntityError('crud blew up for part_lift'))
+    const plan = planOf(bucket(), bucket({ periodKey: '2026-02', bucketId: `${LIFT}:2026-02` }))
+
+    const summary = (await executeBackfill(db, ORG, USER, plan, PLANNED))._unsafeUnwrap()
+
+    expect(summary.failed).toHaveLength(2)
+    expect(summary.failed.map((row) => row.bucketId)).toEqual([
+      `${LIFT}:2026-01`,
+      `${LIFT}:2026-02`,
+    ])
+  })
+})
+
+// ─── The writer re-refuses what the policy already excluded ─────────────
+
+// 🛑 The part-kind, bill-of-materials, part-existence and quantity refusals all
+// live in `createBuild` and have their own suite there. What this file owns is
+// what a refusal MEANS to a run: the bucket wrote nothing, so it is `failed` and
+// never `leftInProgress`, and the run keeps going.
+describe('a refused raise is a failed bucket, not a build to go and finish', () => {
+  it('records the refusal verbatim and raises nothing', async () => {
+    h.createRefusals.set(
+      LIFT,
+      new UnprocessableEntityError('This part is classified as purchased, so it cannot be built.')
+    )
+
+    const summary = (
+      await executeBackfill(db, ORG, USER, planOf(bucket()), PLANNED)
+    )._unsafeUnwrap()
+
+    expect(summary.created).toEqual([])
+    expect(summary.leftInProgress).toEqual([])
+    expect(summary.failed).toEqual([
+      {
+        partId: LIFT,
+        bucketId: `${LIFT}:2026-01`,
+        periodKey: '2026-01',
+        reason: 'This part is classified as purchased, so it cannot be built.',
+      },
+    ])
+  })
+
+  it('never starts or completes a bucket whose raise was refused', async () => {
+    h.createRefusals.set(LIFT, new UnprocessableEntityError('no bill of materials'))
+    await executeBackfill(db, ORG, USER, planOf(bucket()), COMPLETED)
+    expect(h.startCalls).toHaveLength(0)
+    expect(h.completeCalls).toHaveLength(0)
+  })
+})
+
+// ─── The refusals that write nothing at all ─────────────────────────────
+
+describe('🛑 the demand-period fields are required before anything is written', () => {
+  // A batch build with no period is invisible to the netting read that decides
+  // what the NEXT run owes (§6.2), so an unprovisioned org would get four
+  // hundred builds and then get them all again on the second pass.
+  it('refuses the whole run, having raised nothing', async () => {
+    h.periodFields = { start: true, end: false }
+
+    const result = await executeBackfill(db, ORG, USER, planOf(bucket()), PLANNED)
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.createCalls).toHaveLength(0)
+  })
+})
+
+describe('an organization that keeps no books yet', () => {
+  it('falls back to UTC rather than refusing the run', async () => {
+    h.timeZone = null
+    await executeBackfill(db, ORG, USER, planOf(bucket()), COMPLETED)
+    expect((h.completeCalls[0]?.completedAt as Date).toISOString()).toBe('2026-01-31T23:59:59.999Z')
+  })
+})

--- a/packages/lib/src/builds/__tests__/backfill-policy.test.ts
+++ b/packages/lib/src/builds/__tests__/backfill-policy.test.ts
@@ -1,0 +1,783 @@
+// packages/lib/src/builds/__tests__/backfill-policy.test.ts
+//
+// The whole of the backfill decision, with no database in sight
+// (plans/money/tasks/44-auto-build-cutoff-and-backfill.md sections 7.1, 7.1a,
+// 7.2b). Pure - no doubles, no mocks, nothing to set up.
+//
+// The cases that earn their keep are the three the plan names as the ones the
+// obvious implementation gets wrong: on-hand spread across many buckets, a
+// monthly coverage entry viewed at weekly grouping, and an order placed late on
+// the last evening of a month in a negative-offset zone.
+
+import { describe, expect, it } from 'vitest'
+import { planBackfill } from '../backfill-policy'
+import {
+  BACKFILL_EXCLUSION_REASONS,
+  BACKFILL_GROUPINGS,
+  type BackfillCoverage,
+  type BackfillDemandLine,
+  type BackfillGrouping,
+  type BackfillPlanInput,
+} from '../backfill-types'
+
+const LIFT = 'part_lift'
+const HOIST = 'part_hoist'
+const BOLT = 'part_bolt'
+
+/** Negative offset year-round, and the zone section 7.1a's example is written in. */
+const NEW_YORK = 'America/New_York'
+
+let sequence = 0
+
+/** One order line. Defaults to a single unit of the lift, mid-January. */
+function line(overrides: Partial<BackfillDemandLine> = {}): BackfillDemandLine {
+  sequence += 1
+  return {
+    orderId: `order_${sequence}`,
+    partId: LIFT,
+    quantity: 1,
+    placedAt: new Date('2026-01-15T12:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+/** Committed production: a `planned` build's units, per section 7.1a. */
+function coverage(overrides: Partial<BackfillCoverage> = {}): BackfillCoverage {
+  return { partId: LIFT, quantity: 1, appliesAt: null, ...overrides }
+}
+
+/**
+ * The happy-path world: every part is a `finished_good` with a bill of
+ * materials, nothing on the shelf and nothing committed, so the arithmetic turns
+ * entirely on what the test varies.
+ */
+function input(overrides: Partial<BackfillPlanInput> = {}): BackfillPlanInput {
+  return {
+    lines: [],
+    coverage: [],
+    quantitiesOnHand: new Map(),
+    partKinds: new Map([
+      [LIFT, 'finished_good'],
+      [HOIST, 'subassembly'],
+      [BOLT, 'component'],
+    ]),
+    hasBom: new Map([
+      [LIFT, true],
+      [HOIST, true],
+    ]),
+    grouping: 'month',
+    timeZone: NEW_YORK,
+    ...overrides,
+  }
+}
+
+/** Monthly demand at noon UTC, one order per month, starting in January. */
+function monthlyLines(quantities: readonly number[], partId = LIFT): BackfillDemandLine[] {
+  return quantities.map((quantity, index) =>
+    line({
+      partId,
+      quantity,
+      orderId: `order_m${index + 1}`,
+      placedAt: new Date(`2026-${String(index + 1).padStart(2, '0')}-15T12:00:00.000Z`),
+    })
+  )
+}
+
+function onlyPart(plan: ReturnType<typeof planBackfill>) {
+  const part = plan.parts[0]
+  if (!part) throw new Error('expected exactly one part in the plan')
+  return part
+}
+
+describe('planBackfill admission', () => {
+  it('excludes a component as not-a-built-part', () => {
+    const plan = planBackfill(input({ lines: [line({ partId: BOLT, quantity: 4 })] }))
+
+    expect(plan.parts).toEqual([])
+    expect(plan.excluded).toEqual([
+      {
+        partId: BOLT,
+        quantityOrdered: 4,
+        quantityOnHand: 0,
+        quantityCovered: 0,
+        reason: 'not-a-built-part',
+      },
+    ])
+  })
+
+  it('reads an absent or unrecognised part kind as a component', () => {
+    const lines = [line({ partId: 'part_mystery', quantity: 2 })]
+    const absent = planBackfill(input({ lines, hasBom: new Map([['part_mystery', true]]) }))
+    const unknown = planBackfill(
+      input({
+        lines,
+        partKinds: new Map([['part_mystery', 'widget']]),
+        hasBom: new Map([['part_mystery', true]]),
+      })
+    )
+
+    expect(absent.excluded[0]?.reason).toBe('not-a-built-part')
+    expect(unknown.excluded[0]?.reason).toBe('not-a-built-part')
+  })
+
+  it('excludes a built part with no bill of materials', () => {
+    const plan = planBackfill(
+      input({ lines: [line({ quantity: 7 })], hasBom: new Map([[LIFT, false]]) })
+    )
+
+    expect(plan.parts).toEqual([])
+    expect(plan.excluded).toEqual([
+      {
+        partId: LIFT,
+        quantityOrdered: 7,
+        quantityOnHand: 0,
+        quantityCovered: 0,
+        reason: 'no-bill-of-materials',
+      },
+    ])
+  })
+
+  it('checks the part kind before the bill of materials', () => {
+    // A purchased part never needs a bill of materials, so it must not be the
+    // reason shown for one.
+    const plan = planBackfill(input({ lines: [line({ partId: BOLT })], hasBom: new Map() }))
+
+    expect(plan.excluded[0]?.reason).toBe('not-a-built-part')
+  })
+
+  it('excludes a part the shelf already covers, carrying the numbers that show why', () => {
+    const plan = planBackfill(
+      input({ lines: [line({ quantity: 3 })], quantitiesOnHand: new Map([[LIFT, 5]]) })
+    )
+
+    expect(plan.parts).toEqual([])
+    expect(plan.excluded).toEqual([
+      {
+        partId: LIFT,
+        quantityOrdered: 3,
+        quantityOnHand: 5,
+        quantityCovered: 0,
+        reason: 'covered-by-stock',
+      },
+    ])
+  })
+
+  it('excludes a part committed production already covers as already-covered', () => {
+    // The second run of the dialog: every part just built is fully covered by
+    // its own new builds, and calling that `covered-by-stock` would claim the
+    // stock room is full of units nobody has made yet.
+    const plan = planBackfill(
+      input({ lines: [line({ quantity: 3 })], coverage: [coverage({ quantity: 3 })] })
+    )
+
+    expect(plan.excluded).toEqual([
+      {
+        partId: LIFT,
+        quantityOrdered: 3,
+        quantityOnHand: 0,
+        quantityCovered: 3,
+        reason: 'already-covered',
+      },
+    ])
+  })
+
+  it('prefers already-covered when BOTH pools contributed', () => {
+    // The committed-production remedy is the actionable one, so it wins the tie.
+    const plan = planBackfill(
+      input({
+        lines: [line({ quantity: 10 })],
+        coverage: [coverage({ quantity: 4 })],
+        quantitiesOnHand: new Map([[LIFT, 6]]),
+      })
+    )
+
+    expect(plan.excluded).toEqual([
+      {
+        partId: LIFT,
+        quantityOrdered: 10,
+        quantityOnHand: 6,
+        quantityCovered: 4,
+        reason: 'already-covered',
+      },
+    ])
+  })
+
+  it('still says covered-by-stock when the shelf did all of the work', () => {
+    const plan = planBackfill(
+      input({
+        lines: [line({ quantity: 10 })],
+        coverage: [coverage({ quantity: 0 })],
+        quantitiesOnHand: new Map([[LIFT, 10]]),
+      })
+    )
+
+    expect(plan.excluded).toEqual([
+      {
+        partId: LIFT,
+        quantityOrdered: 10,
+        quantityOnHand: 10,
+        quantityCovered: 0,
+        reason: 'covered-by-stock',
+      },
+    ])
+  })
+
+  it('carries the evidence for its own reason on every exclusion row', () => {
+    // Section 7.2b: an omission a person cannot explain makes the preview
+    // untrustworthy, so the two netting reasons must be distinguishable by the
+    // numbers on the row and not only by the reason string.
+    const plan = planBackfill(
+      input({
+        lines: [line({ partId: LIFT, quantity: 6 }), line({ partId: HOIST, quantity: 6 })],
+        coverage: [coverage({ partId: HOIST, quantity: 9 })],
+        quantitiesOnHand: new Map([[LIFT, 8]]),
+      })
+    )
+
+    expect(plan.excluded).toEqual([
+      {
+        partId: HOIST,
+        quantityOrdered: 6,
+        quantityOnHand: 0,
+        // The pool AVAILABLE, not the 6 consumed - a part with no surviving
+        // bucket has no per-bucket consumption to report.
+        quantityCovered: 9,
+        reason: 'already-covered',
+      },
+      {
+        partId: LIFT,
+        quantityOrdered: 6,
+        quantityOnHand: 8,
+        quantityCovered: 0,
+        reason: 'covered-by-stock',
+      },
+    ])
+  })
+
+  it('reads the netting reason off the DROPPED buckets, not the surviving ones', () => {
+    // Nothing survives, so the answer can only come from what the dropped
+    // buckets consumed. Coverage runs out in February; stock finishes March.
+    const plan = planBackfill(
+      input({
+        lines: monthlyLines([10, 10, 10]),
+        coverage: [coverage({ quantity: 15 })],
+        quantitiesOnHand: new Map([[LIFT, 15]]),
+      })
+    )
+
+    expect(plan.parts).toEqual([])
+    expect(plan.excluded[0]?.reason).toBe('already-covered')
+  })
+
+  it('draws every exclusion from the closed four-member vocabulary', () => {
+    const plan = planBackfill(
+      input({
+        lines: [
+          line({ partId: BOLT }),
+          line({ partId: HOIST }),
+          line({ partId: LIFT, quantity: 2 }),
+          line({ partId: 'part_winch', quantity: 2 }),
+        ],
+        partKinds: new Map([
+          [BOLT, 'component'],
+          [HOIST, 'subassembly'],
+          [LIFT, 'finished_good'],
+          ['part_winch', 'finished_good'],
+        ]),
+        hasBom: new Map([
+          [LIFT, true],
+          ['part_winch', true],
+        ]),
+        quantitiesOnHand: new Map([[LIFT, 9]]),
+        coverage: [coverage({ partId: 'part_winch', quantity: 2 })],
+      })
+    )
+
+    expect(plan.excluded.map((row) => row.reason).sort()).toEqual([
+      'already-covered',
+      'covered-by-stock',
+      'no-bill-of-materials',
+      'not-a-built-part',
+    ])
+    expect(BACKFILL_EXCLUSION_REASONS).toEqual(
+      expect.arrayContaining(plan.excluded.map((row) => row.reason))
+    )
+  })
+})
+
+describe('planBackfill on-hand netting', () => {
+  it('consumes on hand ONCE across every bucket, not once per bucket', () => {
+    // Section 7.1: three lifts on the shelf and eight monthly buckets is three
+    // units of coverage in total. The per-row bug reads as 3 x 8 = 24.
+    const plan = planBackfill(
+      input({
+        lines: monthlyLines([10, 10, 10, 10, 10, 10, 10, 10]),
+        quantitiesOnHand: new Map([[LIFT, 3]]),
+      })
+    )
+
+    const part = onlyPart(plan)
+    expect(part.quantityOrdered).toBe(80)
+    expect(part.quantityToBuild).toBe(77)
+    expect(plan.unitCount).toBe(77)
+    expect(part.buckets).toHaveLength(8)
+    expect(part.buckets.reduce((total, b) => total + b.quantityFromStock, 0)).toBe(3)
+  })
+
+  it('takes on hand off the EARLIEST bucket', () => {
+    const plan = planBackfill(
+      input({
+        lines: monthlyLines([10, 10, 10]),
+        quantitiesOnHand: new Map([[LIFT, 4]]),
+      })
+    )
+
+    expect(
+      onlyPart(plan).buckets.map((b) => [b.periodKey, b.quantityFromStock, b.quantityToBuild])
+    ).toEqual([
+      ['2026-01', 4, 6],
+      ['2026-02', 0, 10],
+      ['2026-03', 0, 10],
+    ])
+  })
+
+  it('drops a bucket stock swallows whole without handing its stock on', () => {
+    // The bucket is dropped AFTER it has taken its share - skipping it instead
+    // would let January's stock be spent again in February.
+    const plan = planBackfill(
+      input({ lines: monthlyLines([10, 10, 10]), quantitiesOnHand: new Map([[LIFT, 10]]) })
+    )
+
+    const part = onlyPart(plan)
+    expect(part.buckets.map((b) => b.periodKey)).toEqual(['2026-02', '2026-03'])
+    expect(part.quantityToBuild).toBe(20)
+    expect(plan.buildCount).toBe(2)
+  })
+
+  it('reads a negative quantity on hand as no coverage, and still reports it', () => {
+    // Section 5: -280 across all 22 components of the org this was written for.
+    // Negative coverage would inflate every build in the range.
+    const plan = planBackfill(
+      input({ lines: monthlyLines([10, 10]), quantitiesOnHand: new Map([[LIFT, -280]]) })
+    )
+
+    const part = onlyPart(plan)
+    expect(part.quantityOnHand).toBe(-280)
+    expect(part.quantityToBuild).toBe(20)
+    expect(part.buckets.every((b) => b.quantityFromStock === 0)).toBe(true)
+  })
+
+  it('reads an absent or non-finite quantity on hand as zero', () => {
+    const plan = planBackfill(
+      input({ lines: monthlyLines([10]), quantitiesOnHand: new Map([[LIFT, Number.NaN]]) })
+    )
+
+    expect(onlyPart(plan).quantityOnHand).toBe(0)
+    expect(onlyPart(plan).quantityToBuild).toBe(10)
+  })
+})
+
+describe('planBackfill coverage netting', () => {
+  it('counts a monthly coverage entry ONCE across the weeks it overlaps', () => {
+    // Section 7.1a: build by month, view by week, and one monthly build overlaps
+    // five weekly buckets. Netting per bucket counts it fivefold - here that
+    // would leave nothing to build at all.
+    const plan = planBackfill(
+      input({
+        grouping: 'week',
+        lines: [
+          line({ quantity: 10, placedAt: new Date('2026-03-02T12:00:00.000Z') }),
+          line({ quantity: 10, placedAt: new Date('2026-03-09T12:00:00.000Z') }),
+          line({ quantity: 10, placedAt: new Date('2026-03-16T12:00:00.000Z') }),
+          line({ quantity: 10, placedAt: new Date('2026-03-23T12:00:00.000Z') }),
+        ],
+        coverage: [coverage({ quantity: 25, appliesAt: new Date('2026-03-01T05:00:00.000Z') })],
+      })
+    )
+
+    const part = onlyPart(plan)
+    expect(part.quantityOrdered).toBe(40)
+    expect(part.quantityCovered).toBe(25)
+    expect(part.quantityToBuild).toBe(15)
+    // Netting per bucket would set 25 against each week's 10 and exclude the
+    // part outright; the two fully-covered weeks are dropped, and the third
+    // takes only what is left of the pool.
+    expect(part.buckets.map((b) => [b.periodKey, b.quantityCovered, b.quantityToBuild])).toEqual([
+      ['2026-W12', 5, 5],
+      ['2026-W13', 0, 10],
+    ])
+  })
+
+  it('pools several coverage entries for one part', () => {
+    const plan = planBackfill(
+      input({
+        lines: monthlyLines([10, 10]),
+        coverage: [coverage({ quantity: 4 }), coverage({ quantity: 6 })],
+      })
+    )
+
+    const part = onlyPart(plan)
+    expect(part.quantityCovered).toBe(10)
+    expect(part.buckets.map((b) => b.periodKey)).toEqual(['2026-02'])
+  })
+
+  it('drains coverage before stock, and reports the two columns separately', () => {
+    const plan = planBackfill(
+      input({
+        lines: monthlyLines([10, 10]),
+        coverage: [coverage({ quantity: 6 })],
+        quantitiesOnHand: new Map([[LIFT, 3]]),
+      })
+    )
+
+    const part = onlyPart(plan)
+    expect(part.quantityToBuild).toBe(11)
+    expect(
+      part.buckets.map((b) => [
+        b.periodKey,
+        b.quantityCovered,
+        b.quantityFromStock,
+        b.quantityToBuild,
+      ])
+    ).toEqual([
+      ['2026-01', 6, 3, 1],
+      ['2026-02', 0, 0, 10],
+    ])
+  })
+
+  it('ignores a non-positive or non-finite coverage quantity', () => {
+    const plan = planBackfill(
+      input({
+        lines: monthlyLines([10]),
+        coverage: [
+          coverage({ quantity: 0 }),
+          coverage({ quantity: -5 }),
+          coverage({ quantity: Number.POSITIVE_INFINITY }),
+          coverage({ quantity: 3 }),
+        ],
+      })
+    )
+
+    expect(onlyPart(plan).quantityCovered).toBe(3)
+    expect(onlyPart(plan).quantityToBuild).toBe(7)
+  })
+
+  it('ignores coverage for a part nothing was ordered of', () => {
+    const plan = planBackfill(
+      input({ lines: monthlyLines([10]), coverage: [coverage({ partId: HOIST, quantity: 99 })] })
+    )
+
+    expect(plan.parts.map((p) => p.partId)).toEqual([LIFT])
+    expect(onlyPart(plan).quantityToBuild).toBe(10)
+  })
+})
+
+describe('planBackfill bucketing in the book timezone', () => {
+  it('buckets 7pm on the last day of a month into that month, not the next', () => {
+    // 2026-01-31T23:00 in New York is already 2026-02-01T04:00 in UTC.
+    const placedAt = new Date('2026-02-01T04:00:00.000Z')
+
+    const local = planBackfill(input({ lines: [line({ quantity: 5, placedAt })] }))
+    const utc = planBackfill(input({ timeZone: 'UTC', lines: [line({ quantity: 5, placedAt })] }))
+
+    expect(onlyPart(local).buckets[0]?.periodKey).toBe('2026-01')
+    expect(onlyPart(utc).buckets[0]?.periodKey).toBe('2026-02')
+  })
+
+  it('buckets the same instant into the right DAY and WEEK too', () => {
+    const placedAt = new Date('2026-02-01T04:00:00.000Z')
+    const lines = [line({ quantity: 5, placedAt })]
+
+    expect(onlyPart(planBackfill(input({ grouping: 'day', lines }))).buckets[0]?.periodKey).toBe(
+      '2026-01-31'
+    )
+    expect(onlyPart(planBackfill(input({ grouping: 'week', lines }))).buckets[0]?.periodKey).toBe(
+      '2026-W05'
+    )
+  })
+
+  it('gives a monthly bucket half-open boundaries at local midnight', () => {
+    const plan = planBackfill(input({ lines: monthlyLines([10]) }))
+
+    const bucket = onlyPart(plan).buckets[0]
+    expect(bucket?.periodStart.toISOString()).toBe('2026-01-01T05:00:00.000Z')
+    expect(bucket?.periodEnd.toISOString()).toBe('2026-02-01T05:00:00.000Z')
+  })
+
+  it('keys a week by its ISO week-numbering year, which is not always its calendar year', () => {
+    const plan = planBackfill(
+      input({
+        grouping: 'week',
+        lines: [line({ quantity: 2, placedAt: new Date('2025-12-29T12:00:00.000Z') })],
+      })
+    )
+
+    expect(onlyPart(plan).buckets[0]?.periodKey).toBe('2026-W01')
+  })
+
+  it('separates two instants that share a UTC day but not a local one', () => {
+    const plan = planBackfill(
+      input({
+        grouping: 'day',
+        lines: [
+          line({ quantity: 1, placedAt: new Date('2026-03-10T03:00:00.000Z') }),
+          line({ quantity: 1, placedAt: new Date('2026-03-10T12:00:00.000Z') }),
+        ],
+      })
+    )
+
+    expect(onlyPart(plan).buckets.map((b) => b.periodKey)).toEqual(['2026-03-09', '2026-03-10'])
+  })
+})
+
+describe('planBackfill grouping', () => {
+  const threeOrders = [
+    line({ orderId: 'order_a', quantity: 5, placedAt: new Date('2026-03-02T12:00:00.000Z') }),
+    line({ orderId: 'order_b', quantity: 5, placedAt: new Date('2026-03-02T18:00:00.000Z') }),
+    line({ orderId: 'order_c', quantity: 5, placedAt: new Date('2026-03-09T12:00:00.000Z') }),
+  ]
+
+  const expectedBuckets: Record<BackfillGrouping, number> = {
+    order: 3,
+    day: 2,
+    week: 2,
+    month: 1,
+    range: 1,
+  }
+
+  for (const grouping of BACKFILL_GROUPINGS) {
+    it(`collapses the same demand into ${expectedBuckets[grouping]} bucket(s) at '${grouping}' grouping`, () => {
+      const plan = planBackfill(input({ grouping, lines: threeOrders }))
+
+      const part = onlyPart(plan)
+      expect(part.buckets).toHaveLength(expectedBuckets[grouping])
+      expect(plan.buildCount).toBe(expectedBuckets[grouping])
+      // The grouping is a presentation and write choice, never an input to the
+      // arithmetic (section 7.1a).
+      expect(part.quantityOrdered).toBe(15)
+      expect(part.quantityToBuild).toBe(15)
+      expect(plan.unitCount).toBe(15)
+      expect(part.buckets.reduce((total, b) => total + b.quantityOrdered, 0)).toBe(15)
+    })
+  }
+
+  it("collapses period start and end onto the order's own instant at 'order' grouping", () => {
+    const plan = planBackfill(input({ grouping: 'order', lines: threeOrders }))
+
+    const buckets = onlyPart(plan).buckets
+    expect(buckets.map((b) => b.orderIds)).toEqual([['order_a'], ['order_b'], ['order_c']])
+    expect(buckets[0]?.periodStart.toISOString()).toBe('2026-03-02T12:00:00.000Z')
+    expect(buckets[0]?.periodEnd.toISOString()).toBe('2026-03-02T12:00:00.000Z')
+    // Display only: two orders on one local day share a key, and `orderIds` is
+    // what tells them apart.
+    expect(buckets[0]?.periodKey).toBe('2026-03-02')
+    expect(buckets[1]?.periodKey).toBe('2026-03-02')
+  })
+
+  it("keeps one order's lines together at 'order' grouping, dated to the earlier one", () => {
+    const plan = planBackfill(
+      input({
+        grouping: 'order',
+        lines: [
+          line({ orderId: 'order_a', quantity: 2, placedAt: new Date('2026-03-04T12:00:00.000Z') }),
+          line({ orderId: 'order_a', quantity: 3, placedAt: new Date('2026-03-02T12:00:00.000Z') }),
+        ],
+      })
+    )
+
+    const buckets = onlyPart(plan).buckets
+    expect(buckets).toHaveLength(1)
+    expect(buckets[0]?.quantityOrdered).toBe(5)
+    expect(buckets[0]?.periodStart.toISOString()).toBe('2026-03-02T12:00:00.000Z')
+  })
+
+  it("spans every part's demand with one window at 'range' grouping", () => {
+    const plan = planBackfill(
+      input({
+        grouping: 'range',
+        lines: [
+          line({ partId: LIFT, quantity: 4, placedAt: new Date('2026-01-15T12:00:00.000Z') }),
+          line({ partId: HOIST, quantity: 6, placedAt: new Date('2026-08-20T12:00:00.000Z') }),
+        ],
+      })
+    )
+
+    const keys = plan.parts.flatMap((part) => part.buckets.map((b) => b.periodKey))
+    expect(keys).toEqual(['2026-01-15..2026-08-20', '2026-01-15..2026-08-20'])
+    const bucket = plan.parts[0]?.buckets[0]
+    expect(bucket?.periodStart.toISOString()).toBe('2026-01-15T05:00:00.000Z')
+    expect(bucket?.periodEnd.toISOString()).toBe('2026-08-21T04:00:00.000Z')
+  })
+
+  it('gives two same-day orders distinct bucket ids where their period keys collide', () => {
+    const plan = planBackfill(input({ grouping: 'order', lines: threeOrders }))
+
+    const buckets = onlyPart(plan).buckets
+    expect(buckets.map((b) => b.bucketId)).toEqual([
+      `${LIFT}:order_a`,
+      `${LIFT}:order_b`,
+      `${LIFT}:order_c`,
+    ])
+    // The pair anything else might have keyed off does collide.
+    expect(new Set(buckets.map((b) => `${b.partId}:${b.periodKey}`)).size).toBe(2)
+  })
+
+  it('keys a calendar bucket by its part and period', () => {
+    const plan = planBackfill(input({ lines: monthlyLines([10, 10]) }))
+
+    expect(onlyPart(plan).buckets.map((b) => b.bucketId)).toEqual([
+      `${LIFT}:2026-01`,
+      `${LIFT}:2026-02`,
+    ])
+  })
+
+  it('keeps bucket ids unique across the whole plan, at every grouping', () => {
+    const lines = [...threeOrders, ...threeOrders.map((entry) => ({ ...entry, partId: HOIST }))]
+
+    for (const grouping of BACKFILL_GROUPINGS) {
+      const plan = planBackfill(input({ grouping, lines }))
+      const ids = plan.parts.flatMap((part) => part.buckets.map((b) => b.bucketId))
+
+      expect(ids).toHaveLength(plan.buildCount)
+      expect(new Set(ids).size).toBe(ids.length)
+    }
+  })
+
+  it('gathers every order behind a bucket, deduplicated and sorted', () => {
+    const plan = planBackfill(
+      input({
+        lines: [
+          line({ orderId: 'order_c', quantity: 1 }),
+          line({ orderId: 'order_a', quantity: 1 }),
+          line({ orderId: 'order_c', quantity: 1 }),
+          line({ orderId: 'order_b', quantity: 1 }),
+        ],
+      })
+    )
+
+    expect(onlyPart(plan).buckets[0]?.orderIds).toEqual(['order_a', 'order_b', 'order_c'])
+  })
+})
+
+describe('planBackfill line hygiene', () => {
+  it('contributes nothing from a non-positive or non-finite quantity', () => {
+    const plan = planBackfill(
+      input({
+        lines: [
+          line({ quantity: 0 }),
+          line({ quantity: -5 }),
+          line({ quantity: Number.NaN }),
+          line({ quantity: Number.POSITIVE_INFINITY }),
+          line({ quantity: 4 }),
+        ],
+      })
+    )
+
+    expect(onlyPart(plan).quantityOrdered).toBe(4)
+    expect(onlyPart(plan).quantityToBuild).toBe(4)
+  })
+
+  it('leaves a part with no usable line out of the plan entirely, excluded or not', () => {
+    // Not an exclusion: "0 ordered, not a built part" answers a question nobody
+    // asked, and the screen is a list of what was ordered.
+    const plan = planBackfill(
+      input({
+        lines: [line({ quantity: 0 }), line({ partId: BOLT, quantity: Number.NaN })],
+      })
+    )
+
+    expect(plan.parts).toEqual([])
+    expect(plan.excluded).toEqual([])
+    expect(plan.buildCount).toBe(0)
+    expect(plan.unitCount).toBe(0)
+  })
+
+  it('drops a line whose placed date is invalid rather than inventing a period', () => {
+    const plan = planBackfill(
+      input({
+        lines: [line({ quantity: 6, placedAt: new Date('nonsense') }), line({ quantity: 2 })],
+      })
+    )
+
+    expect(onlyPart(plan).quantityOrdered).toBe(2)
+    expect(onlyPart(plan).buckets).toHaveLength(1)
+  })
+
+  it('returns an empty plan for no lines at all', () => {
+    expect(planBackfill(input())).toEqual({
+      parts: [],
+      excluded: [],
+      buildCount: 0,
+      unitCount: 0,
+    })
+  })
+})
+
+describe('planBackfill determinism', () => {
+  it('orders parts ascending by id, whatever order the lines arrive in', () => {
+    const plan = planBackfill(
+      input({
+        lines: [
+          line({ partId: HOIST, quantity: 1 }),
+          line({ partId: BOLT, quantity: 1 }),
+          line({ partId: LIFT, quantity: 1 }),
+        ],
+      })
+    )
+
+    expect(plan.parts.map((p) => p.partId)).toEqual([HOIST, LIFT])
+    expect(plan.excluded.map((p) => p.partId)).toEqual([BOLT])
+  })
+
+  it('orders buckets chronologically, whatever order the lines arrive in', () => {
+    const chronological = monthlyLines([1, 2, 3, 4, 5])
+    const shuffled = [
+      chronological[3],
+      chronological[0],
+      chronological[4],
+      chronological[2],
+      chronological[1],
+    ].filter((entry): entry is BackfillDemandLine => entry !== undefined)
+
+    const plan = planBackfill(input({ lines: shuffled }))
+
+    expect(onlyPart(plan).buckets.map((b) => b.periodKey)).toEqual([
+      '2026-01',
+      '2026-02',
+      '2026-03',
+      '2026-04',
+      '2026-05',
+    ])
+    expect(
+      onlyPart(plan).buckets.every(
+        (bucket, index, all) =>
+          index === 0 || (all[index - 1]?.periodStart.getTime() ?? 0) < bucket.periodStart.getTime()
+      )
+    ).toBe(true)
+  })
+
+  it('produces an identical plan from the same input in a different order', () => {
+    const lines = [
+      ...monthlyLines([10, 20, 30]),
+      ...monthlyLines([5, 15], HOIST),
+      line({ partId: BOLT, quantity: 2 }),
+    ]
+    const world = { quantitiesOnHand: new Map([[LIFT, 12]]), coverage: [coverage({ quantity: 7 })] }
+
+    const first = planBackfill(input({ ...world, lines }))
+    const second = planBackfill(input({ ...world, lines: [...lines].reverse() }))
+
+    expect(second).toEqual(first)
+  })
+
+  it('totals the plan across every part', () => {
+    const plan = planBackfill(
+      input({ lines: [...monthlyLines([10, 20]), ...monthlyLines([5, 15], HOIST)] })
+    )
+
+    expect(plan.buildCount).toBe(4)
+    expect(plan.unitCount).toBe(50)
+    expect(plan.buildCount).toBe(plan.parts.reduce((n, part) => n + part.buckets.length, 0))
+    expect(plan.unitCount).toBe(plan.parts.reduce((n, part) => n + part.quantityToBuild, 0))
+  })
+})

--- a/packages/lib/src/builds/__tests__/backfill-queries.int.test.ts
+++ b/packages/lib/src/builds/__tests__/backfill-queries.int.test.ts
@@ -1,0 +1,457 @@
+// packages/lib/src/builds/__tests__/backfill-queries.int.test.ts
+//
+// The aggregate read behind the bulk builder, against a REAL database
+// (`plans/money/tasks/44-auto-build-cutoff-and-backfill.md` sections 7.1/7.1a).
+//
+// 🛑 **This file exists because the rules that matter here live in SQL.** Which
+// build statuses count as coverage, whether a cancelled order contributes
+// demand, whether the range is applied to `order_placed_at` or to the row's
+// `createdAt` — every one of those is a `WHERE` or a join predicate, and the
+// default vitest config mocks `@auxx/database` into a Proxy whose columns are
+// `undefined`, so a double there cannot see any of it. The unit file next door
+// covers what a double CAN see (the query budget, the attribution pass) and
+// says so at the top.
+//
+// Rows are written as raw `EntityInstance` + `FieldValue` inserts rather than
+// through `UnifiedCrudHandler`. Two reasons: `build_status` is guarded against
+// any manual write of `in_progress`/`completed`/`canceled`
+// (`field-hooks/pre/build-status-guard.ts`), and a real order write would fire
+// the drift reconciler, which raises builds — the exact rows this file is
+// asserting the ABSENCE of.
+//
+// Run: npx vitest run --config vitest.integration.config.ts src/builds
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, createTestUser, getTestDb } from '@auxx/test-utils'
+import { eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createEntityDefinitions } from '../../seed/entity-seeder/create-entity-defs'
+import { createAllFields } from '../../seed/entity-seeder/create-fields'
+import { linkDisplayFields } from '../../seed/entity-seeder/link-display-fields'
+import { linkRelationships } from '../../seed/entity-seeder/link-relationships'
+import type { EntityDefMap } from '../../seed/entity-seeder/types'
+import { readBackfillPlanReads } from '../backfill-queries'
+
+const db = () => getTestDb() as unknown as Database
+
+/** The only defs the backfill read touches. Narrowed, because field seeding is the cost. */
+const BACKFILL_ENTITY_TYPES = ['order', 'line_item', 'part', 'subpart', 'build'] as const
+
+const JANUARY = {
+  from: new Date('2026-01-01T00:00:00.000Z'),
+  to: new Date('2026-02-01T00:00:00.000Z'),
+}
+const IN_RANGE = new Date('2026-01-10T00:00:00.000Z')
+const OUT_OF_RANGE = new Date('2026-03-10T00:00:00.000Z')
+
+interface Fixture {
+  organizationId: string
+  defId: (entityType: string) => string
+  fieldId: (systemAttribute: string) => string
+}
+
+let fx: Fixture
+
+/** Seed an org whose five defs and their registry fields are the real ones. */
+async function seedBackfillOrg(): Promise<Fixture> {
+  const org = await createTestOrganization()
+  const user = await createTestUser({ name: 'Backfill Operator' })
+  await db()
+    .update(schema.Organization)
+    .set({ systemUserId: user.id })
+    .where(eq(schema.Organization.id, org.id))
+
+  // Every definition — `getCachedEntityDefId` reads the whole org — but only the
+  // five defs this read touches get their registry fields materialised.
+  const entityDefMap = await createEntityDefinitions(db(), org.id)
+  const narrowed: EntityDefMap = new Map()
+  for (const entityType of BACKFILL_ENTITY_TYPES) {
+    const def = entityDefMap.get(entityType)
+    if (!def) throw new Error(`fixture: no ${entityType} entity definition was seeded`)
+    narrowed.set(entityType, def)
+  }
+  const fieldMap = await createAllFields(db(), org.id, narrowed)
+  await linkRelationships(db(), narrowed, fieldMap)
+  await linkDisplayFields(db(), narrowed, fieldMap)
+
+  const fields = await db()
+    .select({
+      id: schema.CustomField.id,
+      systemAttribute: schema.CustomField.systemAttribute,
+    })
+    .from(schema.CustomField)
+    .where(eq(schema.CustomField.organizationId, org.id))
+
+  const byAttribute = new Map<string, string>()
+  for (const field of fields) {
+    if (field.systemAttribute) byAttribute.set(field.systemAttribute, field.id)
+  }
+
+  return {
+    organizationId: org.id,
+    defId: (entityType) => {
+      const def = narrowed.get(entityType)
+      if (!def) throw new Error(`fixture: no ${entityType} entity definition was seeded`)
+      return def.id
+    },
+    fieldId: (systemAttribute) => {
+      const id = byAttribute.get(systemAttribute)
+      if (!id) throw new Error(`fixture: no ${systemAttribute} field was seeded`)
+      return id
+    },
+  }
+}
+
+/** One typed `FieldValue` column, keyed by the attribute that owns it. */
+type ValueColumns = Partial<{
+  valueNumber: number
+  valueDate: string
+  optionId: string
+  relatedEntityId: string
+}>
+
+/** Write one instance plus its field values, with no hooks and no CRUD layer. */
+async function writeRecord(
+  entityType: string,
+  values: Record<string, ValueColumns>,
+  createdAt?: Date
+): Promise<string> {
+  const entityDefinitionId = fx.defId(entityType)
+  const [instance] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: fx.organizationId,
+      entityDefinitionId,
+      displayName: entityType,
+      // Explicit: the live column carries no DB-side default, so drizzle's
+      // `defaultNow()` renders as `default` and the insert fails not-null.
+      updatedAt: new Date(),
+      ...(createdAt ? { createdAt } : {}),
+    })
+    .returning({ id: schema.EntityInstance.id })
+  if (!instance) throw new Error(`fixture: could not write a ${entityType}`)
+
+  const rows = Object.entries(values).map(([systemAttribute, columns]) => ({
+    organizationId: fx.organizationId,
+    entityId: instance.id,
+    entityDefinitionId,
+    fieldId: fx.fieldId(systemAttribute),
+    updatedAt: new Date(),
+    ...columns,
+  }))
+  if (rows.length > 0) await db().insert(schema.FieldValue).values(rows)
+  return instance.id
+}
+
+/** A finished good with a one-component bill of materials. */
+async function seedBuiltPart(): Promise<string> {
+  const partId = await writeRecord('part', { part_kind: { optionId: 'finished_good' } })
+  const componentId = await writeRecord('part', { part_kind: { optionId: 'component' } })
+  await writeRecord('subpart', {
+    subpart_parent_part: { relatedEntityId: partId },
+    subpart_child_part: { relatedEntityId: componentId },
+    subpart_quantity: { valueNumber: 2 },
+  })
+  return partId
+}
+
+/** An order carrying one line for `partId`, and its id. */
+async function seedOrderWithLine(
+  partId: string,
+  options: { placedAt?: Date; cancelledAt?: Date; createdAt?: Date; quantity?: number } = {}
+): Promise<string> {
+  const orderValues: Record<string, ValueColumns> = {}
+  if (options.placedAt) orderValues.order_placed_at = { valueDate: options.placedAt.toISOString() }
+  if (options.cancelledAt) {
+    orderValues.order_cancelled_at = { valueDate: options.cancelledAt.toISOString() }
+  }
+  const orderId = await writeRecord('order', orderValues, options.createdAt)
+
+  await writeRecord('line_item', {
+    line_item_order: { relatedEntityId: orderId },
+    line_item_part: { relatedEntityId: partId },
+    line_item_qty: { valueNumber: options.quantity ?? 2 },
+  })
+  return orderId
+}
+
+async function seedBuild(
+  partId: string,
+  values: Record<string, ValueColumns> = {}
+): Promise<string> {
+  return writeRecord('build', {
+    build_part: { relatedEntityId: partId },
+    build_status: { optionId: 'planned' },
+    build_quantity_planned: { valueNumber: 5 },
+    ...values,
+  })
+}
+
+async function read(range = JANUARY) {
+  const result = await readBackfillPlanReads(db(), fx.organizationId, range)
+  if (result.isErr()) throw result.error
+  return result.value
+}
+
+beforeEach(async () => {
+  // A fresh org per test, so nothing the org cache memoized for the previous
+  // one can be read back — `per-test-setup` truncates every table between tests.
+  fx = await seedBackfillOrg()
+})
+
+describe('demand', () => {
+  it('reads a line whose order was placed inside the range', async () => {
+    const partId = await seedBuiltPart()
+    const orderId = await seedOrderWithLine(partId, { placedAt: IN_RANGE, quantity: 3 })
+
+    const { lines } = await read()
+
+    expect(lines).toEqual([{ orderId, partId, quantity: 3, placedAt: IN_RANGE }])
+  })
+
+  it('falls back to the row’s createdAt when the order carries no placed date', async () => {
+    // An order typed by hand in auxx may have no business date at all. Falling
+    // back to when the row was made keeps it inside the window rather than
+    // silently dropping it — the same fallback `loadAutoBuildOrders` applies.
+    const partId = await seedBuiltPart()
+    await seedOrderWithLine(partId, { createdAt: IN_RANGE })
+
+    const { lines } = await read()
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]?.placedAt).toEqual(IN_RANGE)
+  })
+
+  it('excludes an order placed outside the range', async () => {
+    const partId = await seedBuiltPart()
+    await seedOrderWithLine(partId, { placedAt: OUT_OF_RANGE })
+
+    const { lines } = await read()
+
+    expect(lines).toEqual([])
+  })
+
+  it('🛑 excludes a cancelled order', async () => {
+    // Its demand is not demand. The comparison is on the presence of
+    // `order_cancelled_at`, exactly as the auto-build trigger reads it.
+    const partId = await seedBuiltPart()
+    await seedOrderWithLine(partId, { placedAt: IN_RANGE, cancelledAt: IN_RANGE })
+
+    const { lines } = await read()
+
+    expect(lines).toEqual([])
+  })
+
+  it('drops a line that reaches no part', async () => {
+    const partId = await seedBuiltPart()
+    const orderId = await seedOrderWithLine(partId, { placedAt: IN_RANGE })
+    await writeRecord('line_item', {
+      line_item_order: { relatedEntityId: orderId },
+      line_item_qty: { valueNumber: 9 },
+    })
+
+    const { lines } = await read()
+
+    expect(lines).toHaveLength(1)
+  })
+
+  it('keeps two lines for the same part on one order, uncollapsed', async () => {
+    const partId = await seedBuiltPart()
+    const orderId = await seedOrderWithLine(partId, { placedAt: IN_RANGE, quantity: 2 })
+    await writeRecord('line_item', {
+      line_item_order: { relatedEntityId: orderId },
+      line_item_part: { relatedEntityId: partId },
+      line_item_qty: { valueNumber: 3 },
+    })
+
+    const { lines } = await read()
+
+    expect(lines.map((line) => line.quantity).sort()).toEqual([2, 3])
+  })
+})
+
+describe('coverage', () => {
+  let partId: string
+  let orderId: string
+
+  beforeEach(async () => {
+    partId = await seedBuiltPart()
+    orderId = await seedOrderWithLine(partId, { placedAt: IN_RANGE, quantity: 10 })
+  })
+
+  it('counts a planned order-raised build, at its order’s date', async () => {
+    await seedBuild(partId, {
+      build_order: { relatedEntityId: orderId },
+      build_quantity_planned: { valueNumber: 4 },
+    })
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([{ partId, quantity: 4, appliesAt: IN_RANGE }])
+  })
+
+  it('counts an in_progress build', async () => {
+    await seedBuild(partId, { build_status: { optionId: 'in_progress' } })
+
+    const { coverage } = await read()
+
+    expect(coverage).toHaveLength(1)
+  })
+
+  it('🛑 does NOT count a completed build', async () => {
+    // Section 7.1a, and this is the shape of the bug: `completeBuild` wrote a
+    // `build_produce` movement and `recalculatePartQoH` re-SUMmed the ledger, so
+    // those units are already in `part_quantity_on_hand`. Counting them here as
+    // well, while also subtracting on hand, under-builds by exactly the produced
+    // quantity. The fixture writes the resulting on-hand alongside, so the two
+    // halves of the double count are both present.
+    await seedBuild(partId, { build_status: { optionId: 'completed' } })
+    await db()
+      .insert(schema.FieldValue)
+      .values({
+        organizationId: fx.organizationId,
+        entityId: partId,
+        entityDefinitionId: fx.defId('part'),
+        fieldId: fx.fieldId('part_quantity_on_hand'),
+        updatedAt: new Date(),
+        valueNumber: 5,
+      })
+
+    const { coverage, quantitiesOnHand } = await read()
+
+    expect(coverage).toEqual([])
+    expect(quantitiesOnHand.get(partId)).toBe(5)
+  })
+
+  it('🛑 does NOT count a canceled build', async () => {
+    await seedBuild(partId, { build_status: { optionId: 'canceled' } })
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([])
+  })
+
+  it('🛑 counts a planned MANUAL build, as undated coverage', async () => {
+    // Diverges from `reconcile-policy.ts` on purpose (section 7.1a): the
+    // aggregate asks whether enough production is planned, and a planned manual
+    // build will produce units. Do not align the two models.
+    await seedBuild(partId, {
+      build_source: { optionId: 'manual' },
+      build_quantity_planned: { valueNumber: 6 },
+    })
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([{ partId, quantity: 6, appliesAt: null }])
+  })
+
+  it('counts a batch build at its own period start', async () => {
+    await seedBuild(partId, {
+      build_source: { optionId: 'batch' },
+      build_quantity_planned: { valueNumber: 8 },
+      build_period_start: { valueDate: JANUARY.from.toISOString() },
+      build_period_end: { valueDate: JANUARY.to.toISOString() },
+    })
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([{ partId, quantity: 8, appliesAt: JANUARY.from }])
+  })
+
+  it('drops a build raised against an order outside the range', async () => {
+    const otherOrderId = await seedOrderWithLine(partId, { placedAt: OUT_OF_RANGE })
+    await seedBuild(partId, { build_order: { relatedEntityId: otherOrderId } })
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([])
+  })
+
+  it('ignores a build for a part nothing in the range ordered', async () => {
+    const otherPartId = await seedBuiltPart()
+    await seedBuild(otherPartId)
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([])
+  })
+
+  it('ignores an archived build', async () => {
+    const buildId = await seedBuild(partId)
+    await db()
+      .update(schema.EntityInstance)
+      .set({ archivedAt: new Date() })
+      .where(eq(schema.EntityInstance.id, buildId))
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([])
+  })
+})
+
+describe('the per-part maps', () => {
+  it('reports a bill of materials only for the part that has one', async () => {
+    const builtPartId = await seedBuiltPart()
+    const bareId = await writeRecord('part', { part_kind: { optionId: 'finished_good' } })
+    await seedOrderWithLine(builtPartId, { placedAt: IN_RANGE })
+    await seedOrderWithLine(bareId, { placedAt: IN_RANGE })
+
+    const { hasBom, partKinds } = await read()
+
+    expect(hasBom.get(builtPartId)).toBe(true)
+    expect(hasBom.get(bareId)).toBeUndefined()
+    expect(partKinds.get(builtPartId)).toBe('finished_good')
+  })
+
+  it('ignores a subpart edge with a non-positive quantity', async () => {
+    // Same edge semantics as `loadDirectSubparts`, which is the function this
+    // batched check replaces.
+    const partId = await writeRecord('part', { part_kind: { optionId: 'finished_good' } })
+    const componentId = await writeRecord('part', { part_kind: { optionId: 'component' } })
+    await writeRecord('subpart', {
+      subpart_parent_part: { relatedEntityId: partId },
+      subpart_child_part: { relatedEntityId: componentId },
+      subpart_quantity: { valueNumber: 0 },
+    })
+    await seedOrderWithLine(partId, { placedAt: IN_RANGE })
+
+    const { hasBom } = await read()
+
+    expect(hasBom.get(partId)).toBeUndefined()
+  })
+})
+
+describe('the query budget', () => {
+  it('🛑 issues the same five queries for twelve orders as for one', async () => {
+    // Section 4.1: the historical lane must not inherit `readOrderRaisedBuilds`'s
+    // one-read-per-order cost, and a regression here would be invisible in every
+    // other assertion in this file.
+    const partId = await seedBuiltPart()
+    for (let index = 0; index < 12; index += 1) {
+      const orderId = await seedOrderWithLine(partId, { placedAt: IN_RANGE })
+      await seedBuild(partId, { build_order: { relatedEntityId: orderId } })
+    }
+
+    const counter = { selects: 0 }
+    const counting = new Proxy(db() as object, {
+      get(target, prop) {
+        const value = Reflect.get(target, prop)
+        if (typeof value !== 'function') return value
+        if (prop === 'select') {
+          return (...args: unknown[]) => {
+            counter.selects += 1
+            return value.apply(target, args)
+          }
+        }
+        return value.bind(target)
+      },
+    }) as unknown as Database
+
+    const result = await readBackfillPlanReads(counting, fx.organizationId, JANUARY)
+    if (result.isErr()) throw result.error
+
+    expect(result.value.lines).toHaveLength(12)
+    expect(result.value.coverage).toHaveLength(12)
+    expect(counter.selects).toBe(5)
+  })
+})

--- a/packages/lib/src/builds/__tests__/backfill-queries.test.ts
+++ b/packages/lib/src/builds/__tests__/backfill-queries.test.ts
@@ -1,0 +1,394 @@
+// packages/lib/src/builds/__tests__/backfill-queries.test.ts
+//
+// The aggregate read behind the bulk builder
+// (`plans/money/tasks/44-auto-build-cutoff-and-backfill.md` sections 7.1/7.1a),
+// at the only two things a db double can actually see: how many queries it
+// issues, and what it makes of the rows they come back with.
+//
+// ⚠️ **The SQL predicates are NOT under test here and cannot be.**
+// `src/test/setup.ts` mocks `@auxx/database` wholesale, so `schema.Foo` is a
+// memoized `{}` whose COLUMNS are `undefined` — a `WHERE` is unreadable and an
+// alias is indistinguishable from any other. So the rules that live in SQL —
+// `completed` and `canceled` builds excluded from coverage, cancelled orders
+// excluded from demand, the range applied to `order_placed_at` with the
+// `createdAt` fallback — are asserted in `backfill-queries.int.test.ts` against
+// a real database. Asserting them here would only be asserting the double.
+//
+// What IS here: the query BUDGET (five, whatever the range holds — section 4.1
+// is explicit that this read must not inherit `readOrderRaisedBuilds`'s
+// per-order cost) and the attribution pass that turns build rows into
+// `BackfillCoverage`, which is where a build gets counted against the wrong
+// window or against no window at all.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG = 'org_1'
+const LIFT = 'part_lift'
+const BOLT = 'part_bolt'
+const ORDER_IN = 'ord_in_range'
+const ORDER_OUT = 'ord_out_of_range'
+const PLACED_AT = '2026-01-10T00:00:00.000Z'
+
+/** `db.select({...})` projections, which is how the double tells the reads apart. */
+const DEMAND = 'orderId|partId|quantity|placedAt'
+const COVERAGE = 'buildPartId|plannedQuantity|buildOrderId|periodStart|periodEnd'
+const QUANTITY_ON_HAND = 'entityId|valueNumber'
+const PART_KINDS = 'entityId|optionId'
+const HAS_BOM = 'parentPartId'
+
+const h = vi.hoisted(() => ({
+  /** entityType -> `EntityDefinition.id`, for the defs the org has. */
+  defs: new Map<string, string>(),
+  /** systemAttributes the org has materialised, mapped to a field row id. */
+  fields: new Map<string, string>(),
+  /** projection key -> the rows that read returns. */
+  rows: new Map<string, Record<string, unknown>[]>(),
+  /** projection keys, in the order the reads were issued. */
+  issued: [] as string[],
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(
+          attrs.map((attr) => {
+            const id = h.fields.get(attr)
+            return [attr, id ? { id } : null]
+          })
+        ),
+    }),
+  }),
+}))
+
+import { readBackfillPlanReads } from '../backfill-queries'
+
+const CHAIN_METHODS = ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'offset']
+
+/**
+ * A promise carrying the chain methods, so `await` works anywhere along it —
+ * the same shape `auto-build-queries.test.ts` uses.
+ */
+function chain(rows: Record<string, unknown>[]) {
+  const promise = Promise.resolve(rows) as Promise<Record<string, unknown>[]> &
+    Record<string, unknown>
+  for (const method of CHAIN_METHODS) promise[method] = () => promise
+  return promise
+}
+
+const db = {
+  select: (projection: Record<string, unknown>) => {
+    const key = Object.keys(projection).join('|')
+    h.issued.push(key)
+    return chain(h.rows.get(key) ?? [])
+  },
+} as never
+
+const RANGE = {
+  from: new Date('2026-01-01T00:00:00.000Z'),
+  to: new Date('2026-02-01T00:00:00.000Z'),
+}
+
+/** One row as the demand query returns it. */
+function demandRow(overrides: Record<string, unknown> = {}) {
+  return { orderId: ORDER_IN, partId: LIFT, quantity: 2, placedAt: PLACED_AT, ...overrides }
+}
+
+/** One row as the coverage query returns it. */
+function coverageRow(overrides: Record<string, unknown> = {}) {
+  return {
+    buildPartId: LIFT,
+    plannedQuantity: 3,
+    buildOrderId: null,
+    periodStart: null,
+    periodEnd: null,
+    ...overrides,
+  }
+}
+
+async function read() {
+  const result = await readBackfillPlanReads(db, ORG, RANGE)
+  if (result.isErr()) throw result.error
+  return result.value
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.defs = new Map([
+    ['order', 'def_order'],
+    ['line_item', 'def_line'],
+    ['build', 'def_build'],
+    ['subpart', 'def_subpart'],
+  ])
+  h.fields = new Map(
+    [
+      'order_placed_at',
+      'order_cancelled_at',
+      'line_item_order',
+      'line_item_part',
+      'line_item_qty',
+      'part_kind',
+      'part_quantity_on_hand',
+      'build_part',
+      'build_status',
+      'build_quantity_planned',
+      'build_order',
+      'build_reversal_of',
+      'build_period_start',
+      'build_period_end',
+      'subpart_parent_part',
+      'subpart_child_part',
+      'subpart_quantity',
+    ].map((attr) => [attr, `fld_${attr}`])
+  )
+  h.rows = new Map()
+  h.issued = []
+})
+
+describe('readBackfillPlanReads — the query budget', () => {
+  it('answers a whole range in five queries', async () => {
+    // Section 4.1: the historical lane must NOT inherit `readOrderRaisedBuilds`'s
+    // one-read-per-order cost. Five reads whatever the range holds — demand,
+    // coverage, on hand, part kind, bill of materials.
+    h.rows.set(DEMAND, [
+      demandRow(),
+      demandRow({ orderId: 'ord_2', partId: BOLT }),
+      demandRow({ orderId: 'ord_3' }),
+      demandRow({ orderId: 'ord_4' }),
+    ])
+    h.rows.set(PART_KINDS, [
+      { entityId: LIFT, optionId: 'finished_good' },
+      { entityId: BOLT, optionId: 'finished_good' },
+    ])
+
+    await read()
+
+    // Sorted, because the three middle reads are issued together and resolve in
+    // whatever order their cache lookups do — the BUDGET is what matters here,
+    // not the sequence.
+    expect([...h.issued].sort()).toEqual(
+      [DEMAND, COVERAGE, QUANTITY_ON_HAND, PART_KINDS, HAS_BOM].sort()
+    )
+  })
+
+  it('stops after the demand read when the range holds no demand', async () => {
+    // Nothing ordered is nothing to build, and every read below it is keyed on
+    // the parts the demand names.
+    const reads = await read()
+
+    expect(h.issued).toEqual([DEMAND])
+    expect(reads.lines).toEqual([])
+    expect(reads.coverage).toEqual([])
+    expect(reads.quantitiesOnHand.size).toBe(0)
+  })
+
+  it('never asks for the bill of materials of a purchased part', async () => {
+    // `reconcileOrderBuilds` orders these the same way — step 3 before step 2.
+    // A `component` can never be built, so its BOM is never worth a read.
+    h.rows.set(DEMAND, [demandRow({ partId: BOLT })])
+    h.rows.set(PART_KINDS, [{ entityId: BOLT, optionId: 'component' }])
+
+    await read()
+
+    expect(h.issued).not.toContain(HAS_BOM)
+  })
+})
+
+describe('readBackfillPlanReads — demand', () => {
+  it('keeps one line per row, uncollapsed', async () => {
+    // The contract hands the policy every line, not one per part: the drill-down
+    // names the orders behind a bucket, and collapsing here would lose them.
+    h.rows.set(DEMAND, [demandRow({ quantity: 2 }), demandRow({ quantity: 3 })])
+
+    const { lines } = await read()
+
+    expect(lines).toEqual([
+      { orderId: ORDER_IN, partId: LIFT, quantity: 2, placedAt: new Date(PLACED_AT) },
+      { orderId: ORDER_IN, partId: LIFT, quantity: 3, placedAt: new Date(PLACED_AT) },
+    ])
+  })
+
+  it('reads a line with no `line_item_qty` as zero rather than dropping it', async () => {
+    // Same as `loadAutoBuildOrders`. The POLICY decides a non-positive line
+    // contributes nothing; dropping it in the reader would also hide its order
+    // from the drill-down.
+    h.rows.set(DEMAND, [demandRow({ quantity: null })])
+
+    const { lines } = await read()
+
+    expect(lines).toEqual([
+      { orderId: ORDER_IN, partId: LIFT, quantity: 0, placedAt: new Date(PLACED_AT) },
+    ])
+  })
+
+  it('drops a line whose date cannot be read', async () => {
+    // An Invalid Date compares false against everything, so it would silently
+    // fall out of every bucket much later instead of here.
+    h.rows.set(DEMAND, [demandRow({ placedAt: 'not a date' }), demandRow()])
+
+    const { lines } = await read()
+
+    expect(lines).toHaveLength(1)
+  })
+})
+
+describe('readBackfillPlanReads — coverage attribution', () => {
+  beforeEach(() => {
+    h.rows.set(DEMAND, [demandRow()])
+    h.rows.set(PART_KINDS, [{ entityId: LIFT, optionId: 'finished_good' }])
+  })
+
+  it('resolves an order-raised build through its order to that order’s date', async () => {
+    h.rows.set(COVERAGE, [coverageRow({ buildOrderId: ORDER_IN, plannedQuantity: 4 })])
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([{ partId: LIFT, quantity: 4, appliesAt: new Date(PLACED_AT) }])
+  })
+
+  it('🛑 drops an order-raised build whose order is outside the range', async () => {
+    // It covers demand this run is not looking at. Counting it as UNDATED
+    // coverage instead — the tempting fallback — would let an April build
+    // suppress January's, which is the opposite of what netting is for.
+    h.rows.set(COVERAGE, [coverageRow({ buildOrderId: ORDER_OUT })])
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([])
+  })
+
+  it('resolves a batch build to its own period start', async () => {
+    h.rows.set(COVERAGE, [
+      coverageRow({
+        plannedQuantity: 7,
+        periodStart: '2026-01-01T00:00:00.000Z',
+        periodEnd: '2026-02-01T00:00:00.000Z',
+      }),
+    ])
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([
+      { partId: LIFT, quantity: 7, appliesAt: new Date('2026-01-01T00:00:00.000Z') },
+    ])
+  })
+
+  it('🛑 keeps a period that OVERLAPS the range, not only one that starts inside it', async () => {
+    // A January batch build still covers the first half of a January-15 range.
+    // A start-inside test would drop it and rebuild demand that is already
+    // committed.
+    h.rows.set(COVERAGE, [
+      coverageRow({
+        periodStart: '2026-01-01T00:00:00.000Z',
+        periodEnd: '2026-02-01T00:00:00.000Z',
+      }),
+    ])
+
+    const result = await readBackfillPlanReads(db, ORG, {
+      from: new Date('2026-01-15T00:00:00.000Z'),
+      to: new Date('2026-02-15T00:00:00.000Z'),
+    })
+    if (result.isErr()) throw result.error
+
+    expect(result.value.coverage).toEqual([
+      { partId: LIFT, quantity: 3, appliesAt: new Date('2026-01-01T00:00:00.000Z') },
+    ])
+  })
+
+  it('drops a period that ends before the range opens', async () => {
+    h.rows.set(COVERAGE, [
+      coverageRow({
+        periodStart: '2025-11-01T00:00:00.000Z',
+        periodEnd: '2025-12-01T00:00:00.000Z',
+      }),
+    ])
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([])
+  })
+
+  it('🛑 counts a build with neither an order nor a period as undated coverage', async () => {
+    // That is a `manual` build, and section 7.1a is explicit that it counts:
+    // the aggregate asks "is enough production planned for this demand?", not
+    // "does this order have its build?". This DIVERGES from
+    // `reconcile-policy.ts` deliberately — do not align the two.
+    h.rows.set(COVERAGE, [coverageRow({ plannedQuantity: 5 })])
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([{ partId: LIFT, quantity: 5, appliesAt: null }])
+  })
+
+  it('commits nothing for a build that plans nothing', async () => {
+    h.rows.set(COVERAGE, [
+      coverageRow({ plannedQuantity: null }),
+      coverageRow({ plannedQuantity: 0 }),
+      coverageRow({ plannedQuantity: -3 }),
+    ])
+
+    const { coverage } = await read()
+
+    expect(coverage).toEqual([])
+  })
+})
+
+describe('readBackfillPlanReads — the per-part maps', () => {
+  it('carries on hand, part kind and the bill-of-materials flag straight through', async () => {
+    h.rows.set(DEMAND, [demandRow(), demandRow({ partId: BOLT })])
+    h.rows.set(QUANTITY_ON_HAND, [{ entityId: LIFT, valueNumber: 3 }])
+    h.rows.set(PART_KINDS, [
+      { entityId: LIFT, optionId: 'finished_good' },
+      { entityId: BOLT, optionId: 'component' },
+    ])
+    h.rows.set(HAS_BOM, [{ parentPartId: LIFT }])
+
+    const reads = await read()
+
+    // A part nobody has counted has nothing on the shelf, not "unknown".
+    expect(reads.quantitiesOnHand.get(LIFT)).toBe(3)
+    expect(reads.quantitiesOnHand.get(BOLT)).toBe(0)
+    expect(reads.partKinds.get(LIFT)).toBe('finished_good')
+    expect(reads.hasBom.get(LIFT)).toBe(true)
+    // Absent, not `false`: the contract says an absent part reads as no BOM,
+    // and a purchased part is never asked about at all.
+    expect(reads.hasBom.has(BOLT)).toBe(false)
+  })
+})
+
+describe('readBackfillPlanReads — refusals', () => {
+  it('reads an org with no order entity as having no demand', async () => {
+    // Nothing to build from. Refusing loudly would turn opening the dialog on an
+    // unmigrated org into an error rather than an empty preview.
+    h.defs.delete('order')
+
+    const reads = await read()
+
+    expect(reads.lines).toEqual([])
+    expect(h.issued).toEqual([])
+  })
+
+  it('🛑 refuses an org that HAS demand but no provisioned build entity', async () => {
+    // The opposite call from the one above, and for the reason
+    // `reconcile-queries.ts` documents: reading coverage as empty here would
+    // plan builds on top of production that already exists.
+    h.rows.set(DEMAND, [demandRow()])
+    h.defs.delete('build')
+
+    const result = await readBackfillPlanReads(db, ORG, RANGE)
+
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('🛑 refuses when `build_quantity_planned` is not materialised', async () => {
+    // Every coverage row would read zero and be dropped, which is a silently
+    // widened answer handed to a writer.
+    h.rows.set(DEMAND, [demandRow()])
+    h.fields.delete('build_quantity_planned')
+
+    const result = await readBackfillPlanReads(db, ORG, RANGE)
+
+    expect(result.isErr()).toBe(true)
+  })
+})

--- a/packages/lib/src/builds/backfill-builds.ts
+++ b/packages/lib/src/builds/backfill-builds.ts
@@ -1,0 +1,380 @@
+// packages/lib/src/builds/backfill-builds.ts
+
+/**
+ * Phases 3 and 4 of the bulk builder — EXECUTE a {@link BackfillPlan}.
+ *
+ * `plans/money/tasks/44-auto-build-cutoff-and-backfill.md` sections 6 and 7.4.
+ *
+ * `backfill-policy.ts` decides what to build with no database, no clock and no
+ * settings; this file writes it. The split is `reconcile-policy.ts` /
+ * `reconcile-order-builds.ts` again, for the reason 44 section 11.1 gives: the
+ * painful cases — on-hand spread across eight buckets, a completed build that
+ * must not be counted twice — are unit tests rather than browser clicks.
+ *
+ * ## 🛑 It is NOT atomic, and the summary is what says so
+ *
+ * `createBuild -> startBuild -> completeBuild` is three separate writes, so a
+ * refused completion leaves a raised run sitting at `in_progress` with no
+ * movements. Section 7.4: that comes back as the `leftInProgress` RESULT rather
+ * than an error, carrying the build id, and the run CONTINUES. An error channel
+ * cannot name a build, so the person would be told "failed" about builds that
+ * exist and would press the button again — the exact failure `build-now.ts`'s
+ * header refuses, multiplied by four hundred.
+ *
+ * ## 🛑 `completedAt` is derived from the PERIOD, never from now
+ *
+ * It is THE accounting date, stamped on the build and on every stock movement
+ * it writes, and it decides which month-end entry reflects the build. Dating
+ * eight months of production to today puts all of it in one entry and leaves
+ * the other seven showing no production at all. See
+ * {@link resolveBackfillCompletedAt}, which derives it in the organization's
+ * `accounting.bookTimeZone` for the same reason `postings/periods.ts` does.
+ *
+ * ## 🛑 Never throws
+ *
+ * Three layers, matching `reconcile-order-builds.ts`: every BUCKET inside its
+ * own `try` so one refused completion does not lose the rest of the part; every
+ * PART inside its own `try` so one bad part does not lose the run; and the whole
+ * body inside the module {@link guard}. A caller that ignores the returned
+ * `Result` is behaving correctly.
+ *
+ * ## Chunking and resumability
+ *
+ * No transaction spans the run. Each bucket is an independent set of writes, so
+ * an interrupted run leaves the builds it already wrote and nothing half-written, and
+ * re-running converges rather than duplicating: section 6.2's netting reads
+ * ordered quantity minus built quantity per `(part, period)`, so a second pass
+ * over a partly-backfilled range raises exactly the delta.
+ *
+ * ⚠️ **The quantity-on-hand recalculation is per build, not per run.**
+ * `completeBuild` runs ONE `batchRecalculateQoH` over the produced part and
+ * every consumed part, after its own commit (`complete-build.ts` traps 1 and 3),
+ * and there is no way to defer it from out here. Batching across builds would
+ * need `completeBuild` to take a deferral flag; the recalc is a full re-SUM and
+ * therefore idempotent, so the cost of not batching is duplicated work, never a
+ * wrong number.
+ *
+ * No permission checks. The router asserts (`docs/lib-module-guide.md`
+ * section 6) — and it must assert BOTH halves, because the `completed` path
+ * writes stock movements.
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { fromZonedTime } from 'date-fns-tz'
+import type { Result } from 'neverthrow'
+import { getOrgCache } from '../cache'
+import { UnprocessableEntityError } from '../errors'
+import { periodKeyForDate } from '../postings/periods'
+import { OPENING_BASELINE_SETTING_KEYS } from '../postings/setup-readiness'
+import { getOrganizationSetting } from '../settings/settings-service'
+import type {
+  BackfillBucket,
+  BackfillPlan,
+  BackfillRequest,
+  BackfillRunSummary,
+} from './backfill-types'
+import { createBuild, startBuild } from './build-mutations'
+import { completeBuild } from './complete-build'
+import { guard } from './guard'
+
+const logger = createScopedLogger('builds:backfill')
+
+/** One progress line per this many buckets, so a long run is observable. */
+const PROGRESS_EVERY = 25
+
+/**
+ * {@link BackfillRunSummary} while it is still being assembled.
+ *
+ * The contract's arrays are `readonly` because nothing downstream may edit a
+ * finished run; this is the same shape with them writable, and it is the only
+ * thing the helpers below are handed.
+ */
+interface MutableRunSummary {
+  created: { partId: string; buildId: string; quantity: number; periodKey: string }[]
+  leftInProgress: { partId: string; buildId: string; reason: string }[]
+  failed: { partId: string; bucketId: string; periodKey: string; reason: string }[]
+}
+
+/** Everything resolved once for the whole run, before any build is written. */
+interface RunContext {
+  /** `accounting.bookTimeZone`, or `'UTC'` when the org keeps no books yet. */
+  timeZone: string
+  /** Captured once, so every bucket judges "in the future" against the same instant. */
+  now: Date
+}
+
+/**
+ * Write every build a {@link BackfillPlan} calls for.
+ *
+ * One bucket becomes one build, `source: 'batch'`, carrying the bucket's demand
+ * period rather than its orders (section 6.2). When `request.status` is
+ * `completed` the build is then started and completed at its period date.
+ *
+ * ⚠️ **Every raised build appears in `created`, including one whose completion
+ * was refused** — that build exists, and `created.length` is therefore the
+ * answer to "how many builds does this org now have that it did not before".
+ * `leftInProgress` flags the subset that needs a person, and its entries are
+ * also in `created`.
+ *
+ * @param plan what to build, from `planBackfill`. Parts ascending, buckets
+ *   chronological; this executes them in exactly that order.
+ * @param request what the dialog was asked for. Only `status` changes what is
+ *   written — the range and grouping are already baked into the plan's buckets.
+ * @returns a summary, never a throw. `err` is reserved for the refusals that
+ *   write NOTHING AT ALL: no build entity, no demand-period fields.
+ */
+export async function executeBackfill(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  plan: BackfillPlan,
+  request: BackfillRequest
+): Promise<Result<BackfillRunSummary, Error>> {
+  return guard(
+    async () => {
+      const summary: MutableRunSummary = { created: [], leftInProgress: [], failed: [] }
+      if (plan.parts.length === 0) return summary
+
+      const run = await prepareRun(organizationId)
+      let written = 0
+
+      for (const part of plan.parts) {
+        const attempted = new Set<string>()
+        try {
+          for (const bucket of part.buckets) {
+            attempted.add(bucket.bucketId)
+            // 🛑 One refused bucket must not lose the rest of the part.
+            try {
+              await executeBucket(db, organizationId, userId, run, bucket, request, summary)
+            } catch (error) {
+              recordFailure(summary, bucket, error)
+            }
+            written += 1
+            if (written % PROGRESS_EVERY === 0) {
+              logger.info('Backfilling builds', { organizationId, written, of: plan.buildCount })
+            }
+          }
+        } catch (error) {
+          // 🛑 One bad part must not lose the run. Only the buckets this part
+          // never reached are recorded — the ones it did have a row already, and
+          // a second one would report the same bucket failing twice.
+          const message = error instanceof Error ? error.message : String(error)
+          for (const bucket of part.buckets) {
+            if (attempted.has(bucket.bucketId)) continue
+            summary.failed.push({
+              partId: part.partId,
+              bucketId: bucket.bucketId,
+              periodKey: bucket.periodKey,
+              reason: message,
+            })
+          }
+          logger.error('Backfilling one part failed; continuing with the run', {
+            organizationId,
+            partId: part.partId,
+            message,
+          })
+        }
+      }
+
+      logger.info('Backfilled builds', {
+        organizationId,
+        status: request.status,
+        grouping: request.grouping,
+        planned: plan.buildCount,
+        created: summary.created.length,
+        leftInProgress: summary.leftInProgress.length,
+        failed: summary.failed.length,
+      })
+
+      return summary
+    },
+    'Backfilling builds failed',
+    { organizationId, buckets: plan.buildCount, status: request.status }
+  )
+}
+
+/**
+ * THE accounting date for one bucket, derived from the demand it covers.
+ *
+ * The period is half-open — `periodStart` inclusive, `periodEnd` exclusive — and
+ * `build_completed_at` must land INSIDE it, so this takes the end of the last
+ * calendar day the period contains, in the book timezone. A monthly bucket for
+ * January in `America/New_York` therefore completes at 23:59:59.999 on
+ * January 31 local, which is February 1 05:59 UTC: derive that in UTC instead
+ * and the build posts to the wrong month, invisibly, and uncorrectably once the
+ * period is locked. Same rule, same reason, as `postings/periods.ts`.
+ *
+ * Clamped into `[periodStart, periodEnd)` afterwards, so a boundary that was
+ * computed in a different zone from the one read here can still only produce an
+ * instant the build's own period contains. Under `grouping: 'order'` the two
+ * bounds collapse onto the one order's date and the clamp returns `periodStart`,
+ * which is that date.
+ *
+ * @param timeZone `accounting.bookTimeZone`. `'UTC'` is correct only for an
+ *   organization whose boundaries are already normalized to it.
+ */
+export function resolveBackfillCompletedAt(bucket: BackfillBucket, timeZone: string): Date {
+  const startMs = bucket.periodStart.getTime()
+  const endMs = bucket.periodEnd.getTime()
+  if (!Number.isFinite(startMs)) {
+    throw new UnprocessableEntityError('This build period has no usable start date')
+  }
+  const lastMs = Number.isFinite(endMs) && endMs > startMs ? endMs - 1 : startMs
+
+  const localDay = periodKeyForDate(new Date(lastMs), 'day', timeZone)
+  const endOfLocalDay = fromZonedTime(`${localDay}T23:59:59.999`, timeZone)
+  const candidate = Number.isNaN(endOfLocalDay.getTime()) ? lastMs : endOfLocalDay.getTime()
+
+  return new Date(Math.min(Math.max(candidate, startMs), lastMs))
+}
+
+/**
+ * Resolve the run's ambient facts, and refuse before writing anything.
+ *
+ * 🛑 **The two demand-period fields are required, not optional.** `createBuild`
+ * writes them only when the build entity carries them and otherwise raises the
+ * build regardless, which is the right call for one build and the wrong shape
+ * for four hundred: a batch build with no period is invisible to the netting
+ * read that decides what the NEXT run owes (section 6.2), so an unprovisioned
+ * org would get the whole range built and then get it all built again on the
+ * second pass. Refusing here writes nothing; discovering it on build one has
+ * already written one.
+ */
+async function prepareRun(organizationId: string): Promise<RunContext> {
+  const [periodFields, timeZone] = await Promise.all([
+    getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttributes(['build_period_start', 'build_period_end'] as const),
+    readBookTimeZone(organizationId),
+  ])
+
+  if (!periodFields.build_period_start || !periodFields.build_period_end) {
+    throw new UnprocessableEntityError(
+      'Backfilling builds is not available until the build demand-period fields are provisioned'
+    )
+  }
+
+  return { timeZone, now: new Date() }
+}
+
+/** Raise one bucket's build, and complete it when the run was asked to. */
+async function executeBucket(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  run: RunContext,
+  bucket: BackfillBucket,
+  request: BackfillRequest,
+  summary: MutableRunSummary
+): Promise<void> {
+  // Derived BEFORE anything is written: a bucket that cannot be dated must not
+  // leave a raised build behind, and section 7.3's first rule is that completing
+  // demand that has not happened yet is meaningless.
+  let completedAt: Date | undefined
+  if (request.status === 'completed') {
+    completedAt = resolveBackfillCompletedAt(bucket, run.timeZone)
+    if (completedAt.getTime() > run.now.getTime()) {
+      throw new UnprocessableEntityError(
+        `The ${bucket.periodKey} demand period has not ended yet, so its build cannot be completed`
+      )
+    }
+  }
+
+  // 🛑 The period goes in HERE or never: `build_period_start` and
+  // `build_period_end` are `updatable: false`, because moving a claimed period
+  // silently restates what the next netting run believes is already covered
+  // (section 6.2). `createBuild` writes them from `period` at create time, and
+  // ignores them unless the source is `batch`.
+  const created = await createBuild(db, organizationId, userId, {
+    partId: bucket.partId,
+    quantityPlanned: bucket.quantityToBuild,
+    source: 'batch',
+    period: { start: bucket.periodStart, end: bucket.periodEnd },
+  })
+  // A refused raise wrote nothing at all, so it is a `failed` bucket rather than
+  // a build somebody has to go and finish. Thrown, not returned, so the bucket
+  // layer records it and the run steps over it.
+  if (created.isErr()) throw created.error
+  const build = created.value
+
+  summary.created.push({
+    partId: bucket.partId,
+    buildId: build.buildId,
+    quantity: bucket.quantityToBuild,
+    periodKey: bucket.periodKey,
+  })
+
+  if (request.status === 'planned' || !completedAt) return
+
+  const started = await startBuild(db, organizationId, userId, { buildId: build.buildId })
+  if (started.isErr()) {
+    recordLeftInProgress(
+      summary,
+      bucket,
+      build.buildId,
+      `The build was raised but could not be started: ${started.error.message}`
+    )
+    return
+  }
+
+  const completed = await completeBuild(db, organizationId, userId, {
+    buildId: build.buildId,
+    quantityProduced: bucket.quantityToBuild,
+    completedAt,
+  })
+  if (completed.isErr()) {
+    // The refusal verbatim — an unpriced component, almost always — because it
+    // is what the person has to go and fix.
+    recordLeftInProgress(summary, bucket, build.buildId, completed.error.message)
+  }
+}
+
+/** `accounting.bookTimeZone`, or `'UTC'` for an org that keeps no books yet. */
+async function readBookTimeZone(organizationId: string): Promise<string> {
+  const value = await getOrganizationSetting({
+    organizationId,
+    key: OPENING_BASELINE_SETTING_KEYS.bookTimeZone,
+  })
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : 'UTC'
+}
+
+/**
+ * A build that exists and needs a person.
+ *
+ * 🛑 NOT `failed`, whose contract is "buckets that produced nothing at all".
+ * The distinction is the whole of section 7.4: this build is in the builds list
+ * and somebody has to complete or cancel it, and reporting it as a failure is
+ * what makes them run the backfill again and raise a duplicate.
+ */
+function recordLeftInProgress(
+  summary: MutableRunSummary,
+  bucket: BackfillBucket,
+  buildId: string,
+  reason: string
+): void {
+  summary.leftInProgress.push({ partId: bucket.partId, buildId, reason })
+  logger.warn('A backfilled build was raised but not completed', {
+    partId: bucket.partId,
+    periodKey: bucket.periodKey,
+    buildId,
+    reason,
+  })
+}
+
+/** One bucket that wrote nothing, recorded and stepped over. */
+function recordFailure(summary: MutableRunSummary, bucket: BackfillBucket, error: unknown): void {
+  const reason = error instanceof Error ? error.message : String(error)
+  summary.failed.push({
+    partId: bucket.partId,
+    bucketId: bucket.bucketId,
+    periodKey: bucket.periodKey,
+    reason,
+  })
+  logger.error('A backfill bucket failed; continuing with the run', {
+    partId: bucket.partId,
+    bucketId: bucket.bucketId,
+    periodKey: bucket.periodKey,
+    reason,
+  })
+}

--- a/packages/lib/src/builds/backfill-policy.ts
+++ b/packages/lib/src/builds/backfill-policy.ts
@@ -1,0 +1,506 @@
+// packages/lib/src/builds/backfill-policy.ts
+
+/**
+ * What the bulk build backfill would create, for a range of demand that has
+ * already happened.
+ *
+ * `plans/money/tasks/44-auto-build-cutoff-and-backfill.md` sections 7.1, 7.1a
+ * and 7.2b, which is phase 1 of that plan's ladder (section 11.1) and the phase
+ * it names as *"where the bugs are and where the testing leverage is"*.
+ *
+ * 🛑 **This is the whole of the decision, and it touches nothing.** No database,
+ * no clock, no settings read, no writer. It is handed every order line in the
+ * range, the production already committed against those parts, and the shelf,
+ * and it returns the builds it would raise. The split is the one
+ * `reconcile-policy.ts` / `reconcile-order-builds.ts` already make, for the same
+ * reason: the painful cases here are a monthly build viewed by week, three units
+ * of stock spread across eight monthly buckets, and an order placed at 7pm on
+ * the last day of a month. Every one of those is a unit test only while the
+ * decision needs nothing to run.
+ *
+ * ## The rails it exists to enforce
+ *
+ * - **The unit is uncovered QUANTITY, never "an order without a build"** (7.1).
+ *   An order with two parts can carry a build for one and not the other, so it
+ *   is neither covered nor uncovered as a whole. Orders are the input to this
+ *   function and never a row in its output; rows are `(part, period)`.
+ * - **On hand is consumed ONCE, earliest bucket first** (7.1). Three lifts on
+ *   the shelf against eight monthly buckets is three units of coverage in total,
+ *   not three per bucket. ⚠️ The obvious per-row implementation passes a
+ *   single-bucket test and under-builds by `onHand x (buckets - 1)` everywhere
+ *   else.
+ * - **Net at the RANGE level, then distribute chronologically** (7.1a). A batch
+ *   build's own period will not line up with the grouping the person is looking
+ *   at — build by month, view by week, and one monthly build overlaps five
+ *   weekly buckets. Netting per bucket counts it fivefold. So committed
+ *   production and stock are two pools, drained earliest-bucket-first in one
+ *   pass. That is also what makes {@link BackfillPlanInput.grouping} a
+ *   presentation and write choice rather than an input to the arithmetic.
+ * - **Committed production is `planned` and `in_progress` only** (7.1a). The
+ *   caller owes this: a `completed` build's units are already in
+ *   `part_quantity_on_hand` through its `build_produce` movement, so counting it
+ *   as coverage *and* subtracting on hand counts the same production twice.
+ *   Nothing here can detect the mistake, which is why
+ *   {@link BackfillCoverage} says it too.
+ * - **Bucketing is in the BOOK timezone** (`input.timeZone`). An order placed at
+ *   7pm on January 31 in `America/New_York` is already February 1 in UTC, and
+ *   bucketing it in UTC dates its build to the wrong accounting month. Same rule
+ *   and the same `date-fns-tz` round-trip as `postings/periods.ts` and
+ *   `resources/aggregate/date-buckets.ts`; hand-rolled offset arithmetic gets
+ *   DST wrong roughly twice a year.
+ * - **Never throws.** Total on every input, including a line with a `NaN`
+ *   quantity, an invalid `placedAt`, or a negative `part_quantity_on_hand` —
+ *   which is not hypothetical, section 5 records -280 across all 22 components
+ *   of the org this was written for.
+ *
+ * ## What it deliberately does NOT do
+ *
+ * - **No permission check, no range bound, no cutoff.** Section 7.0's rule that
+ *   a batch build is only safe below `inventory.autoBuildEnabledAt` is a caller
+ *   gate, exactly as the enablement window is for `planOrderBuildConvergence`:
+ *   keeping it out here is what lets this file stay clock-free.
+ * - **No use of {@link BackfillCoverage.appliesAt} in the arithmetic.** v1 pools
+ *   coverage per part and drains it chronologically over the buckets, which is
+ *   7.1a's decision; the field carries 7.1a's deferred refinement, and
+ *   {@link BackfillCoverage.appliesAt} says so on the contract.
+ */
+
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  format,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns'
+import { fromZonedTime, toZonedTime } from 'date-fns-tz'
+import type {
+  BackfillBucket,
+  BackfillCoverage,
+  BackfillDemandLine,
+  BackfillExclusion,
+  BackfillExclusionReason,
+  BackfillGrouping,
+  BackfillPartPlan,
+  BackfillPlan,
+  BackfillPlanInput,
+} from './backfill-types'
+import { resolvePartKind } from './client'
+
+/**
+ * Decide what the backfill would build.
+ *
+ * The pass, per part, in this order — the same order
+ * `planOrderBuildConvergence`'s `admissionDecision` takes, so the two layers
+ * answer "why not" the same way:
+ *
+ * | state of the part | result |
+ * | --- | --- |
+ * | nothing actually ordered | absent from the plan entirely |
+ * | `component`, or unclassified | `not-a-built-part` exclusion |
+ * | built, no bill of materials | `no-bill-of-materials` exclusion |
+ * | built, demand fully met by committed production | `already-covered` exclusion |
+ * | built, demand fully met by the shelf alone | `covered-by-stock` exclusion |
+ * | built, with demand left over | a {@link BackfillPartPlan} and its buckets |
+ *
+ * 🛑 **The two "nothing left to build" reasons are not interchangeable, and when
+ * both pools contributed the answer is `already-covered`.** They have different
+ * remedies — cancel or complete the committed builds versus sell what is on the
+ * shelf — and the deciding case is the SECOND run of the dialog, where every
+ * part just built is fully covered by its own new builds. Reporting those as
+ * `covered-by-stock` would claim the stock room is full of units nobody has
+ * made yet. So the tie-break is: coverage consumed anything at all -> the
+ * committed production is what the person has to act on -> `already-covered`.
+ *
+ * Every exclusion carries both quantities regardless of its reason, which is
+ * 7.2b's rule that a row must prove itself — `quantityOnHand` proves
+ * `covered-by-stock`, `quantityCovered` proves `already-covered`, and a
+ * conditional that populated only the one the reason needs would be a branch to
+ * get wrong for no saving. Both are the pool AVAILABLE over the range, matching
+ * {@link BackfillPartPlan.quantityCovered}, not the amount consumed — a part
+ * with no surviving bucket has no per-bucket consumption to report.
+ *
+ * The output is deterministic — parts ascending by id, buckets chronological
+ * within a part — which is what lets a test assert on the whole structure and
+ * what keeps a preview stable between two runs against unchanged data.
+ */
+export function planBackfill(input: BackfillPlanInput): BackfillPlan {
+  const lines = input.lines.filter(isUsableLine)
+  const linesByPart = groupLinesByPart(lines)
+  const coverageByPart = sumCoverageByPart(input.coverage)
+  // One window for every part, so `'range'` names the same period on each build
+  // rather than each part's own first-to-last demand.
+  const wholeRange = input.grouping === 'range' ? rangeWindow(lines, input.timeZone) : null
+
+  const parts: BackfillPartPlan[] = []
+  const excluded: BackfillExclusion[] = []
+
+  for (const partId of [...linesByPart.keys()].sort(compareIds)) {
+    const partLines = linesByPart.get(partId) ?? []
+    const quantityOrdered = sumQuantity(partLines)
+    // A part whose every line was dropped as unusable is not demand, and a row
+    // reading "0 ordered, excluded" answers a question nobody asked.
+    if (quantityOrdered <= 0) continue
+
+    const quantityOnHand = finiteOrZero(input.quantitiesOnHand.get(partId))
+    const quantityCovered = coverageByPart.get(partId) ?? 0
+
+    const reason = admissionReason(input, partId)
+    if (reason) {
+      excluded.push({ partId, quantityOrdered, quantityOnHand, quantityCovered, reason })
+      continue
+    }
+
+    const { buckets, coverageUsed } = distribute(
+      draftBuckets(partLines, input.grouping, input.timeZone, wholeRange),
+      quantityCovered,
+      quantityOnHand
+    )
+    if (buckets.length === 0) {
+      // Both pools may have contributed; committed production wins the tie
+      // because it is the half the person can act on.
+      const reason = coverageUsed > 0 ? 'already-covered' : 'covered-by-stock'
+      excluded.push({ partId, quantityOrdered, quantityOnHand, quantityCovered, reason })
+      continue
+    }
+
+    parts.push({
+      partId,
+      quantityOrdered,
+      quantityCovered,
+      quantityOnHand,
+      quantityToBuild: buckets.reduce((total, bucket) => total + bucket.quantityToBuild, 0),
+      buckets,
+    })
+  }
+
+  return {
+    parts,
+    excluded,
+    buildCount: parts.reduce((total, part) => total + part.buckets.length, 0),
+    unitCount: parts.reduce((total, part) => total + part.quantityToBuild, 0),
+  }
+}
+
+/**
+ * Why this part produces no build at all, or `null` when it may build.
+ *
+ * Kind before bill of materials, matching `admissionDecision`: a `component` is
+ * purchased, so its bill of materials is never read and never has to exist.
+ * Coverage is not tested here — it is not a property of the part, it is what is
+ * left after {@link distribute} has drained both pools.
+ */
+function admissionReason(
+  input: BackfillPlanInput,
+  partId: string
+): Extract<BackfillExclusionReason, 'not-a-built-part' | 'no-bill-of-materials'> | null {
+  if (resolvePartKind(input.partKinds.get(partId)) === 'component') return 'not-a-built-part'
+  if (input.hasBom.get(partId) !== true) return 'no-bill-of-materials'
+  return null
+}
+
+/**
+ * Drain the two pools across the buckets, earliest first, and keep what is left.
+ *
+ * 🛑 **This one pass is both of section 7's netting rules**, not two special
+ * cases: committed production and on-hand stock are pools at the RANGE level
+ * (7.1a) and each is consumed once, by the earliest bucket that wants it (7.1).
+ * Coverage drains before stock because committed production is already earmarked
+ * for this demand; the totals do not depend on the order, only the two reported
+ * columns do.
+ *
+ * ⚠️ A fully-consumed bucket is dropped **after** it has taken its share. Skipping
+ * it instead would hand its coverage to the next bucket and re-create the
+ * per-row bug from the other direction.
+ *
+ * Both pools are floored at zero: a negative `part_quantity_on_hand` is a ledger
+ * missing its receipts (section 5), and reading it as *negative coverage* would
+ * inflate every build in the range.
+ */
+function distribute(
+  drafts: readonly DraftBucket[],
+  quantityCovered: number,
+  quantityOnHand: number
+): Distribution {
+  let coveragePool = Math.max(0, quantityCovered)
+  let stockPool = Math.max(0, quantityOnHand)
+  const available = { coverage: coveragePool, stock: stockPool }
+
+  const buckets: BackfillBucket[] = []
+  for (const draft of drafts) {
+    const covered = Math.min(coveragePool, draft.quantityOrdered)
+    coveragePool -= covered
+    const fromStock = Math.min(stockPool, draft.quantityOrdered - covered)
+    stockPool -= fromStock
+
+    const quantityToBuild = draft.quantityOrdered - covered - fromStock
+    if (quantityToBuild <= 0) continue
+
+    buckets.push({
+      partId: draft.partId,
+      bucketId: `${draft.partId}:${draft.id}`,
+      periodStart: draft.periodStart,
+      periodEnd: draft.periodEnd,
+      periodKey: draft.periodKey,
+      quantityOrdered: draft.quantityOrdered,
+      quantityCovered: covered,
+      quantityFromStock: fromStock,
+      quantityToBuild,
+      orderIds: [...draft.orderIds].sort(compareIds),
+    })
+  }
+  return {
+    buckets,
+    coverageUsed: available.coverage - coveragePool,
+    stockUsed: available.stock - stockPool,
+  }
+}
+
+/**
+ * What {@link distribute} did, including to the buckets it dropped.
+ *
+ * The two `Used` totals count consumption across EVERY draft bucket, not only
+ * the surviving ones — which is the entire point of them. A part that nets to
+ * nothing has no surviving bucket to read the answer off, and "which pool
+ * emptied this part" is exactly the question the exclusion reason answers.
+ */
+interface Distribution {
+  buckets: BackfillBucket[]
+  /** Committed production actually consumed. Non-zero means `already-covered`. */
+  coverageUsed: number
+  /** On-hand stock actually consumed. */
+  stockUsed: number
+}
+
+/** A bucket before any netting: what was ordered in it, and by whom. */
+interface DraftBucket {
+  partId: string
+  /**
+   * Identity within the part — the order id under `'order'`, else the period
+   * key. `${partId}:${id}` is {@link BackfillBucket.bucketId}, which is unique
+   * across the whole plan because a part appears in it once.
+   */
+  id: string
+  periodKey: string
+  periodStart: Date
+  periodEnd: Date
+  quantityOrdered: number
+  orderIds: Set<string>
+}
+
+/**
+ * Collapse one part's lines into the buckets the chosen grouping asks for,
+ * chronologically.
+ *
+ * Ties are broken on the bucket's identity so that two orders placed at the same
+ * instant under `'order'` grouping have a stable order between runs.
+ */
+function draftBuckets(
+  lines: readonly BackfillDemandLine[],
+  grouping: BackfillGrouping,
+  timeZone: string,
+  wholeRange: BucketWindow | null
+): DraftBucket[] {
+  const byBucket = new Map<string, DraftBucket>()
+
+  for (const line of lines) {
+    const window = windowFor(line, grouping, timeZone, wholeRange)
+    const id = grouping === 'order' ? line.orderId : window.periodKey
+    const existing = byBucket.get(id)
+    if (!existing) {
+      byBucket.set(id, {
+        partId: line.partId,
+        id,
+        periodKey: window.periodKey,
+        periodStart: window.periodStart,
+        periodEnd: window.periodEnd,
+        quantityOrdered: line.quantity,
+        orderIds: new Set([line.orderId]),
+      })
+      continue
+    }
+    existing.quantityOrdered += line.quantity
+    existing.orderIds.add(line.orderId)
+    // Only reachable under `'order'` grouping, where the window IS one line's
+    // instant: two lines of one order carrying different dates settle on the
+    // earlier, rather than on whichever the reader happened to hand us first.
+    if (window.periodStart.getTime() < existing.periodStart.getTime()) {
+      existing.periodKey = window.periodKey
+      existing.periodStart = window.periodStart
+      existing.periodEnd = window.periodEnd
+    }
+  }
+
+  return [...byBucket.values()].sort(
+    (a, b) => a.periodStart.getTime() - b.periodStart.getTime() || compareIds(a.id, b.id)
+  )
+}
+
+/** The demand period one build claims. Half-open: `periodStart` in, `periodEnd` out. */
+interface BucketWindow {
+  periodKey: string
+  periodStart: Date
+  periodEnd: Date
+}
+
+/**
+ * The window one line falls in.
+ *
+ * `'order'` collapses the period onto the order's own instant, which is what
+ * {@link BackfillBucket} means by the two dates collapsing; its key is the local
+ * day, and is deliberately display-only — two orders on one day share it, which
+ * is why {@link BackfillBucket.bucketId} exists and why nothing may key a row
+ * off `(partId, periodKey)`.
+ *
+ * `'range'` uses the window computed once over every line, so a part with demand
+ * in one month still names the whole backfilled range as its period.
+ */
+function windowFor(
+  line: BackfillDemandLine,
+  grouping: BackfillGrouping,
+  timeZone: string,
+  wholeRange: BucketWindow | null
+): BucketWindow {
+  if (grouping === 'order') {
+    return {
+      periodKey: localFormat(line.placedAt, timeZone, 'yyyy-MM-dd'),
+      periodStart: line.placedAt,
+      periodEnd: line.placedAt,
+    }
+  }
+  // `wholeRange` is null only when there are no usable lines, and then there is
+  // no line to place either. The fallback keeps the function total.
+  if (grouping === 'range') return wholeRange ?? calendarWindow(line.placedAt, 'day', timeZone)
+  return calendarWindow(line.placedAt, grouping, timeZone)
+}
+
+/**
+ * The calendar window containing an instant, in the book timezone.
+ *
+ * The round-trip is the repo's established one (`resources/aggregate/date-buckets.ts`):
+ * `toZonedTime` gives a naive date whose fields ARE the zone's wall clock,
+ * `date-fns` truncates it as plain calendar arithmetic, and `fromZonedTime`
+ * reads those fields back in the zone to get the real instant. The key is
+ * formatted from the truncated value rather than derived separately, so a key
+ * and its boundaries can never disagree.
+ *
+ * Weeks are ISO — Monday start, `'2026-W05'` — matching `date-buckets.ts`, and
+ * the key carries the ISO week-numbering year (`RRRR`), which is not always the
+ * calendar year of the days in it.
+ */
+function calendarWindow(
+  at: Date,
+  grouping: 'day' | 'week' | 'month',
+  timeZone: string
+): BucketWindow {
+  const local = toZonedTime(at, timeZone)
+  if (grouping === 'month') {
+    const start = startOfMonth(local)
+    return {
+      periodKey: format(start, 'yyyy-MM'),
+      periodStart: fromZonedTime(start, timeZone),
+      periodEnd: fromZonedTime(addMonths(start, 1), timeZone),
+    }
+  }
+  if (grouping === 'week') {
+    const start = startOfWeek(local, { weekStartsOn: 1 })
+    return {
+      periodKey: format(start, "RRRR-'W'II"),
+      periodStart: fromZonedTime(start, timeZone),
+      periodEnd: fromZonedTime(addWeeks(start, 1), timeZone),
+    }
+  }
+  const start = startOfDay(local)
+  return {
+    periodKey: format(start, 'yyyy-MM-dd'),
+    periodStart: fromZonedTime(start, timeZone),
+    periodEnd: fromZonedTime(addDays(start, 1), timeZone),
+  }
+}
+
+/**
+ * The one window `'range'` grouping collapses everything into: the first local
+ * day any line was placed, through the end of the last.
+ *
+ * Derived from the lines rather than taken from the request, because the request
+ * is not something a pure decision is handed — and the days are local, so a
+ * range that ends at 7pm on August 31 in `America/New_York` still closes at that
+ * day's local midnight rather than a few hours short of it.
+ */
+function rangeWindow(lines: readonly BackfillDemandLine[], timeZone: string): BucketWindow | null {
+  const first = lines[0]
+  if (!first) return null
+  let earliest = first.placedAt
+  let latest = first.placedAt
+  for (const line of lines) {
+    if (line.placedAt.getTime() < earliest.getTime()) earliest = line.placedAt
+    if (line.placedAt.getTime() > latest.getTime()) latest = line.placedAt
+  }
+  const firstDay = startOfDay(toZonedTime(earliest, timeZone))
+  const lastDay = startOfDay(toZonedTime(latest, timeZone))
+  return {
+    periodKey: `${format(firstDay, 'yyyy-MM-dd')}..${format(lastDay, 'yyyy-MM-dd')}`,
+    periodStart: fromZonedTime(firstDay, timeZone),
+    periodEnd: fromZonedTime(addDays(lastDay, 1), timeZone),
+  }
+}
+
+/** Format an instant's local calendar fields in the book timezone. */
+function localFormat(at: Date, timeZone: string, pattern: string): string {
+  return format(toZonedTime(at, timeZone), pattern)
+}
+
+/**
+ * Is this line demand at all?
+ *
+ * Non-positive and non-finite quantities contribute nothing, the same reading
+ * `sumQuantityByPart` and `planOrderBuildConvergence` already take. An invalid
+ * `placedAt` is dropped for a different reason: it cannot be bucketed, and every
+ * alternative — today, the range start, a bucket of its own — invents a period
+ * the order does not have.
+ */
+function isUsableLine(line: BackfillDemandLine): boolean {
+  return (
+    Number.isFinite(line.quantity) && line.quantity > 0 && !Number.isNaN(line.placedAt.getTime())
+  )
+}
+
+function groupLinesByPart(lines: readonly BackfillDemandLine[]): Map<string, BackfillDemandLine[]> {
+  const byPart = new Map<string, BackfillDemandLine[]>()
+  for (const line of lines) {
+    const bucket = byPart.get(line.partId)
+    if (bucket) bucket.push(line)
+    else byPart.set(line.partId, [line])
+  }
+  return byPart
+}
+
+/**
+ * Committed production per part, as one pool.
+ *
+ * Several `planned` builds for one part are one pool of units and nothing here
+ * distinguishes them, which is the whole point of 7.1a's range-level netting.
+ * A non-positive or non-finite quantity adds nothing rather than subtracting.
+ */
+function sumCoverageByPart(coverage: readonly BackfillCoverage[]): Map<string, number> {
+  const byPart = new Map<string, number>()
+  for (const entry of coverage) {
+    if (!Number.isFinite(entry.quantity) || entry.quantity <= 0) continue
+    byPart.set(entry.partId, (byPart.get(entry.partId) ?? 0) + entry.quantity)
+  }
+  return byPart
+}
+
+function sumQuantity(lines: readonly BackfillDemandLine[]): number {
+  return lines.reduce((total, line) => total + line.quantity, 0)
+}
+
+/** `part_quantity_on_hand` as reported: negative is kept, `NaN` is not a number. */
+function finiteOrZero(raw: number | undefined): number {
+  return raw !== undefined && Number.isFinite(raw) ? raw : 0
+}
+
+function compareIds(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}

--- a/packages/lib/src/builds/backfill-queries.ts
+++ b/packages/lib/src/builds/backfill-queries.ts
@@ -1,0 +1,572 @@
+// packages/lib/src/builds/backfill-queries.ts
+
+/**
+ * The ONE aggregate read behind the bulk builder: what has been ordered over a
+ * range, and what production is already committed against it.
+ *
+ * `plans/money/tasks/44-auto-build-cutoff-and-backfill.md` sections 7.1 and
+ * 7.1a. The pure decision that consumes this lives in `backfill-policy.ts` and
+ * the contract both are written against is `backfill-types.ts`.
+ *
+ * Reads only, and no permission checks — the router asserts and hands the range
+ * down (`docs/lib-module-guide.md` sections 5 and 6). The writes live in
+ * `backfill-builds.ts`.
+ *
+ * 🛑 **This must not inherit the per-order cost of `readOrderRaisedBuilds`.**
+ * That read is one query per order because `listBuilds` has no multi-order
+ * filter, and the live lane absorbs it by chunking. The historical lane cannot:
+ * its range is nine months of orders, and one read per order is the shape
+ * batching exists to escape (section 4.1). So this file issues a **bounded five
+ * queries regardless of how large the range is**, the way `loadAutoBuildOrders`
+ * answers a whole batch in four:
+ *
+ * 1. demand — every line in the range that reaches a part, with its order's date
+ * 2. coverage — every open build for those parts
+ * 3. `part_quantity_on_hand` for those parts
+ * 4. `part_kind` for those parts
+ * 5. the bill-of-materials existence check, for the parts that could be built
+ *
+ * 🛑 **AB3 — demand is read off the NATIVE `order` / `line_item`, never
+ * `shopify_orders`.** Only a native `line_item` carries `line_item_part`;
+ * `shopify_line_items` carries a `variant` reference, which is a different
+ * keyspace. Same rule, and the same reason, as `auto-build-queries.ts`.
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray, isNotNull, isNull, type SQL, sql } from 'drizzle-orm'
+import type { AnyPgColumn } from 'drizzle-orm/pg-core'
+import { alias } from 'drizzle-orm/pg-core'
+import type { Result } from 'neverthrow'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { UnprocessableEntityError } from '../errors'
+import { readPartQuantitiesOnHand } from './auto-build-queries'
+import type { BackfillCoverage, BackfillDemandLine, BackfillPlanInput } from './backfill-types'
+import { readPartKinds, requireBuildFieldContext } from './build-queries'
+import { resolvePartKind } from './client'
+import { guard } from './guard'
+
+/**
+ * Everything the pure plan needs that has to come out of the database.
+ *
+ * Declared as an `Omit` of the contract rather than restated, so a field added
+ * to {@link BackfillPlanInput} is a compile error here rather than a silently
+ * missing input. `grouping` and `timeZone` are the caller's — they are dialog
+ * choices and an org setting, not reads.
+ */
+export type BackfillPlanReads = Omit<BackfillPlanInput, 'grouping' | 'timeZone'>
+
+/** The half-open window the backfill was asked about, on the order's business date. */
+export interface BackfillRange {
+  /** Inclusive lower bound. */
+  from: Date
+  /** Exclusive upper bound. */
+  to: Date
+}
+
+/**
+ * The build statuses that count as committed production (section 7.1a).
+ *
+ * 🛑 **`completed` is deliberately absent, and that is the whole subtlety of
+ * this read.** `completeBuild` writes a `build_produce` movement and
+ * `recalculatePartQoH` re-SUMs the ledger, so a completed build's units already
+ * ARE `part_quantity_on_hand`. Counting it here as well, while also subtracting
+ * on hand, counts the same production twice and under-builds by exactly the
+ * produced quantity. `canceled` is absent because it produced nothing.
+ */
+const COVERAGE_STATUSES = ['planned', 'in_progress'] as const
+
+/** The order fields the demand read needs. Both optional; migration 109 provisions them. */
+const ORDER_ATTRIBUTES = ['order_placed_at', 'order_cancelled_at'] as const
+
+/** The line fields the demand read needs. Without the first two there is no demand. */
+const LINE_ATTRIBUTES = ['line_item_order', 'line_item_part', 'line_item_qty'] as const
+
+/** The subpart fields the bill-of-materials existence check needs. */
+const SUBPART_ATTRIBUTES = [
+  'subpart_parent_part',
+  'subpart_child_part',
+  'subpart_quantity',
+] as const
+
+/** An aliased `FieldValue` table, as `alias()` returns it. */
+type FieldValueAlias = ReturnType<typeof alias<typeof schema.FieldValue, string>>
+
+/**
+ * Read everything the backfill plan is decided from, for one date range.
+ *
+ * The range is on the order's **business** date — `order_placed_at`, falling
+ * back to the order row's `createdAt` — never on when the row was written. A
+ * connector back-fill creates rows today carrying last year's date, and those
+ * are precisely the orders this feature exists to build.
+ *
+ * Cancelled orders (`order_cancelled_at` non-null) contribute no demand.
+ *
+ * An org with no `order` or `line_item` definition, or with the line fields
+ * unprovisioned, reads as **no demand** rather than as an error: there is
+ * nothing to build from, and the preview showing an empty plan is the honest
+ * answer. An org that HAS demand but no provisioned `build` entity is refused,
+ * because reading coverage as empty there would plan builds for demand that is
+ * already covered.
+ */
+export async function readBackfillPlanReads(
+  db: Database,
+  organizationId: string,
+  range: BackfillRange
+): Promise<Result<BackfillPlanReads, Error>> {
+  return guard(
+    async () => {
+      const lines = await readDemandLines(db, organizationId, range)
+      if (lines.length === 0) return emptyReads()
+
+      const partIds = [...new Set(lines.map((line) => line.partId))]
+      const placedByOrder = new Map<string, Date>()
+      for (const line of lines) placedByOrder.set(line.orderId, line.placedAt)
+
+      const [coverage, quantitiesOnHand, partKinds] = await Promise.all([
+        readCoverage(db, organizationId, partIds, placedByOrder, range),
+        readPartQuantitiesOnHand(db, organizationId, partIds),
+        readPartKinds(db, organizationId, partIds),
+      ])
+
+      // Step 3 before step 2, as `reconcileOrderBuilds` does it: a purchased
+      // part can never be built, so its bill of materials is never read.
+      const buildablePartIds = partIds.filter(
+        (partId) => resolvePartKind(partKinds.get(partId)) !== 'component'
+      )
+      const hasBom = await readHasBom(db, organizationId, buildablePartIds)
+
+      return { lines, coverage, quantitiesOnHand, partKinds, hasBom }
+    },
+    'Failed to read the build backfill plan inputs',
+    { organizationId, from: range.from, to: range.to }
+  )
+}
+
+function emptyReads(): BackfillPlanReads {
+  return {
+    lines: [],
+    coverage: [],
+    quantitiesOnHand: new Map(),
+    partKinds: new Map(),
+    hasBom: new Map(),
+  }
+}
+
+/**
+ * Every order line in the range that reaches a part, uncollapsed.
+ *
+ * ONE query for the whole range. The order is joined rather than read in a
+ * second pass keyed on a list of ids, so the cost does not scale with how many
+ * orders the range happens to contain.
+ *
+ * ⚠️ The bucketing date is **selected from the same expression the range is
+ * filtered on**, rather than being recomposed in TypeScript from a separate
+ * `createdAt` column. `EntityInstance.createdAt` is `timestamp` without a zone
+ * while `FieldValue.valueDate` is `timestamptz`, so a bare `coalesce` of the two
+ * resolves through whatever the session timezone happens to be. `at time zone
+ * 'UTC'` pins it, which is also exactly drizzle's own convention for reading a
+ * zoneless column back (`mapFromDriverValue` appends `+0000`) — so the filter
+ * and the bucket can never disagree about which side of a boundary an order
+ * falls on.
+ */
+async function readDemandLines(
+  db: Database,
+  organizationId: string,
+  range: BackfillRange
+): Promise<BackfillDemandLine[]> {
+  const [orderDefId, lineDefId] = await Promise.all([
+    getCachedEntityDefId(organizationId, 'order'),
+    getCachedEntityDefId(organizationId, 'line_item'),
+  ])
+  if (!orderDefId || !lineDefId) return []
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...ORDER_ATTRIBUTES, ...LINE_ATTRIBUTES])
+
+  const lineOrderField = fields.line_item_order
+  const linePartField = fields.line_item_part
+  if (!lineOrderField || !linePartField) return []
+
+  const orderInstance = alias(schema.EntityInstance, 'backfill_order_ei')
+  const lineOrderValue = alias(schema.FieldValue, 'backfill_line_order_v')
+  const linePartValue = alias(schema.FieldValue, 'backfill_line_part_v')
+  const lineQtyValue = alias(schema.FieldValue, 'backfill_line_qty_v')
+  const orderPlacedValue = alias(schema.FieldValue, 'backfill_order_placed_v')
+  const orderCancelledValue = alias(schema.FieldValue, 'backfill_order_cancelled_v')
+
+  const placedAt = sql<string>`
+    coalesce(${orderPlacedValue.valueDate}, ${orderInstance.createdAt} at time zone 'UTC')
+  `
+
+  const rows = await db
+    .select({
+      orderId: orderInstance.id,
+      partId: linePartValue.relatedEntityId,
+      quantity: lineQtyValue.valueNumber,
+      placedAt,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      lineOrderValue,
+      ownValue(lineOrderValue, schema.EntityInstance.id, organizationId, lineOrderField.id)
+    )
+    .innerJoin(
+      orderInstance,
+      and(
+        eq(orderInstance.id, lineOrderValue.relatedEntityId),
+        eq(orderInstance.organizationId, organizationId),
+        eq(orderInstance.entityDefinitionId, orderDefId),
+        isNull(orderInstance.archivedAt)
+      )
+    )
+    .innerJoin(
+      linePartValue,
+      and(
+        ownValue(linePartValue, schema.EntityInstance.id, organizationId, linePartField.id),
+        isNotNull(linePartValue.relatedEntityId)
+      )
+    )
+    .leftJoin(
+      lineQtyValue,
+      ownValue(
+        lineQtyValue,
+        schema.EntityInstance.id,
+        organizationId,
+        fieldId(fields.line_item_qty)
+      )
+    )
+    .leftJoin(
+      orderPlacedValue,
+      ownValue(orderPlacedValue, orderInstance.id, organizationId, fieldId(fields.order_placed_at))
+    )
+    // A LEFT JOIN plus `IS NULL`, so an order with no cancellation ROW at all is
+    // kept alongside one whose row is present and empty. An inner join would
+    // drop the first group, which is almost every order there is.
+    .leftJoin(
+      orderCancelledValue,
+      ownValue(
+        orderCancelledValue,
+        orderInstance.id,
+        organizationId,
+        fieldId(fields.order_cancelled_at)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, lineDefId),
+        isNull(schema.EntityInstance.archivedAt),
+        isNull(orderCancelledValue.valueDate),
+        sql`${placedAt} >= ${range.from}`,
+        sql`${placedAt} < ${range.to}`
+      )
+    )
+
+  const lines: BackfillDemandLine[] = []
+  for (const row of rows) {
+    if (!row.orderId || !row.partId) continue
+    const placed = toDate(row.placedAt)
+    if (!placed) continue
+    lines.push({
+      orderId: row.orderId,
+      partId: row.partId,
+      // A line with no `line_item_qty` reads 0, exactly as `loadAutoBuildOrders`
+      // reads it. The policy is what decides a non-positive line contributes
+      // nothing; a reader that dropped it here would hide the order from the
+      // drill-down as well.
+      quantity: row.quantity == null ? 0 : Number(row.quantity),
+      placedAt: placed,
+    })
+  }
+  return lines
+}
+
+/**
+ * Committed production for these parts, attributed to a point in the range.
+ *
+ * ONE query. Only `planned` and `in_progress` builds are read — see
+ * {@link COVERAGE_STATUSES} for why a `completed` build must not be here — and
+ * every source is included, `manual` along with `order` and `batch`.
+ *
+ * 🛑 **Including `manual` DIVERGES from `reconcile-policy.ts`'s rule that a
+ * manual build does not block a raise, and it does so deliberately (section
+ * 7.1a).** That rule answers *does this order have its build?*, where blocking
+ * on a manual build would suppress an order's build set forever. This read
+ * answers a different question — *is enough production already planned for this
+ * demand?* — and a planned manual build will produce units, so it answers yes.
+ * Do not align the two.
+ *
+ * Attribution, and it is what bounds the answer to the range:
+ *
+ * - a build carrying `build_order` resolves to that order's date, taken from
+ *   the demand read's own map. An order that is not in that map is out of the
+ *   range (or cancelled), so its build covers demand this run is not looking at
+ *   and is **dropped** rather than counted as undated coverage;
+ * - a build carrying a demand period is kept when the period OVERLAPS the
+ *   range, not only when it starts inside it — a January build still covers the
+ *   first half of a January-15 range;
+ * - anything else is undated coverage, which sorts first.
+ */
+async function readCoverage(
+  db: Database,
+  organizationId: string,
+  partIds: string[],
+  placedByOrder: ReadonlyMap<string, Date>,
+  range: BackfillRange
+): Promise<BackfillCoverage[]> {
+  if (partIds.length === 0) return []
+
+  // Refuses when the org has no `build` def, no `build_status` or no
+  // `build_part`. Deliberately louder than the demand read: this org HAS demand,
+  // and reading its coverage as empty would plan builds on top of production
+  // that already exists.
+  const ctx = await requireBuildFieldContext(organizationId)
+  const partField = ctx.fields.build_part
+  const statusField = ctx.fields.build_status
+  const quantityField = ctx.fields.build_quantity_planned
+  const orderField = ctx.fields.build_order
+  if (!partField || !statusField || !quantityField || !orderField) {
+    throw new UnprocessableEntityError(
+      'Backfilling builds is not available until the build part, status, quantity and order fields are provisioned'
+    )
+  }
+
+  const partValue = alias(schema.FieldValue, 'backfill_build_part_v')
+  const statusValue = alias(schema.FieldValue, 'backfill_build_status_v')
+  const quantityValue = alias(schema.FieldValue, 'backfill_build_qty_v')
+  const orderValue = alias(schema.FieldValue, 'backfill_build_order_v')
+  const reversalValue = alias(schema.FieldValue, 'backfill_build_reversal_v')
+  const periodStartValue = alias(schema.FieldValue, 'backfill_build_period_start_v')
+  const periodEndValue = alias(schema.FieldValue, 'backfill_build_period_end_v')
+
+  const rows = await db
+    .select({
+      buildPartId: partValue.relatedEntityId,
+      plannedQuantity: quantityValue.valueNumber,
+      buildOrderId: orderValue.relatedEntityId,
+      periodStart: periodStartValue.valueDate,
+      periodEnd: periodEndValue.valueDate,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      partValue,
+      and(
+        ownValue(partValue, schema.EntityInstance.id, organizationId, partField.id),
+        inArray(partValue.relatedEntityId, partIds)
+      )
+    )
+    .innerJoin(
+      statusValue,
+      and(
+        ownValue(statusValue, schema.EntityInstance.id, organizationId, statusField.id),
+        inArray(statusValue.optionId, [...COVERAGE_STATUSES])
+      )
+    )
+    .leftJoin(
+      quantityValue,
+      ownValue(quantityValue, schema.EntityInstance.id, organizationId, quantityField.id)
+    )
+    .leftJoin(
+      orderValue,
+      ownValue(orderValue, schema.EntityInstance.id, organizationId, orderField.id)
+    )
+    // Belt and braces: a reversal and the build it reverses are both `completed`,
+    // so the status filter already excludes them. Asserted anyway, because the
+    // day a reversal can be raised against an open build this read would start
+    // counting production that nets out to nothing.
+    .leftJoin(
+      reversalValue,
+      ownValue(
+        reversalValue,
+        schema.EntityInstance.id,
+        organizationId,
+        fieldId(ctx.fields.build_reversal_of)
+      )
+    )
+    .leftJoin(
+      periodStartValue,
+      ownValue(
+        periodStartValue,
+        schema.EntityInstance.id,
+        organizationId,
+        fieldId(ctx.fields.build_period_start)
+      )
+    )
+    .leftJoin(
+      periodEndValue,
+      ownValue(
+        periodEndValue,
+        schema.EntityInstance.id,
+        organizationId,
+        fieldId(ctx.fields.build_period_end)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, ctx.buildDefId),
+        isNull(schema.EntityInstance.archivedAt),
+        isNull(reversalValue.relatedEntityId)
+      )
+    )
+
+  const coverage: BackfillCoverage[] = []
+  for (const row of rows) {
+    if (!row.buildPartId) continue
+    const quantity = row.plannedQuantity == null ? 0 : Number(row.plannedQuantity)
+    // A build planning nothing commits no production. Dropped here rather than
+    // handed to the policy as a zero, so the coverage list is only ever things
+    // that actually cover something.
+    if (!Number.isFinite(quantity) || quantity <= 0) continue
+
+    if (row.buildOrderId) {
+      const placedAt = placedByOrder.get(row.buildOrderId)
+      if (!placedAt) continue
+      coverage.push({ partId: row.buildPartId, quantity, appliesAt: placedAt })
+      continue
+    }
+
+    const periodStart = toDate(row.periodStart)
+    if (periodStart) {
+      const periodEnd = toDate(row.periodEnd) ?? periodStart
+      if (periodStart >= range.to || periodEnd <= range.from) continue
+      coverage.push({ partId: row.buildPartId, quantity, appliesAt: periodStart })
+      continue
+    }
+
+    coverage.push({ partId: row.buildPartId, quantity, appliesAt: null })
+  }
+  return coverage
+}
+
+/**
+ * Does each part have at least one direct subpart?
+ *
+ * ONE query for every part, rather than `loadDirectSubparts` per part.
+ * `reconcileOrderBuilds` calls that function in a loop because it is answering
+ * for one order's handful of parts; the backfill's range reaches every part the
+ * org has ever sold, and the answer it needs is only ever a boolean. Same edge
+ * semantics as `loadDirectSubparts`: a non-archived `subpart` in this org whose
+ * parent is the part, carrying a child and a positive quantity.
+ *
+ * A part absent from the result reads as `false`, which is what the contract
+ * says. Parts already known to be `component` are never asked about.
+ */
+async function readHasBom(
+  db: Database,
+  organizationId: string,
+  partIds: string[]
+): Promise<Map<string, boolean>> {
+  const hasBom = new Map<string, boolean>()
+  if (partIds.length === 0) return hasBom
+
+  const subpartDefId = await getCachedEntityDefId(organizationId, 'subpart')
+  if (!subpartDefId) return hasBom
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...SUBPART_ATTRIBUTES])
+  const parentField = fields.subpart_parent_part
+  const childField = fields.subpart_child_part
+  const qtyField = fields.subpart_quantity
+  if (!parentField || !childField || !qtyField) return hasBom
+
+  const parentValue = alias(schema.FieldValue, 'backfill_subpart_parent_v')
+  const childValue = alias(schema.FieldValue, 'backfill_subpart_child_v')
+  const qtyValue = alias(schema.FieldValue, 'backfill_subpart_qty_v')
+
+  const rows = await db
+    .select({ parentPartId: parentValue.relatedEntityId })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      parentValue,
+      and(
+        ownValue(parentValue, schema.EntityInstance.id, organizationId, parentField.id),
+        inArray(parentValue.relatedEntityId, partIds)
+      )
+    )
+    .innerJoin(
+      childValue,
+      and(
+        ownValue(childValue, schema.EntityInstance.id, organizationId, childField.id),
+        isNotNull(childValue.relatedEntityId)
+      )
+    )
+    .innerJoin(
+      qtyValue,
+      and(
+        ownValue(qtyValue, schema.EntityInstance.id, organizationId, qtyField.id),
+        sql`${qtyValue.valueNumber} > 0`
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, subpartDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+
+  for (const row of rows) {
+    if (row.parentPartId) hasBom.set(row.parentPartId, true)
+  }
+  return hasBom
+}
+
+/**
+ * Join predicate for "this instance's value of <field>".
+ *
+ * Takes the alias OBJECT and composes with `eq`, so drizzle emits the table as
+ * an identifier. A hand-written `sql` fragment interpolating a table binds it as
+ * a parameter instead, which is a mistake this codebase has already paid for
+ * (`build-queries.ts`).
+ */
+function ownValue(
+  value: FieldValueAlias,
+  ownerId: AnyPgColumn,
+  organizationId: string,
+  fieldId: string
+): SQL | undefined {
+  return and(
+    eq(value.entityId, ownerId),
+    eq(value.organizationId, organizationId),
+    eq(value.fieldId, fieldId)
+  )
+}
+
+/**
+ * A materialised field's id, or a sentinel that matches no row.
+ *
+ * Every optional field below is reached through a LEFT JOIN, so joining on an
+ * id that cannot exist gives exactly the behaviour an unmaterialised field
+ * should have — the column reads `null`, and the `coalesce` fallback or the
+ * `IS NULL` predicate above it takes over. The alternative, adding the join
+ * conditionally, changes drizzle's nullability type on every branch and is what
+ * turns one static query into four.
+ *
+ * 🛑 It follows that a MISSING field is silently indistinguishable from an
+ * empty value here. That is safe only because every field it is used on is
+ * optional by design: none of them is a filter whose absence would WIDEN the
+ * answer. The four whose absence would — `build_part`, `build_status`,
+ * `build_quantity_planned`, `build_order` — are required outright above, for
+ * the reason `reconcile-queries.ts` gives about silently dropped filters.
+ */
+function fieldId(field: { id: string } | null | undefined): string {
+  return field?.id ?? '__unmaterialised__'
+}
+
+/**
+ * Read a date column back as a `Date`.
+ *
+ * `FieldValue.valueDate` is declared `mode: 'string'` while a `timestamptz`
+ * expression comes back from the driver already parsed, so both shapes reach
+ * here. An unparseable value is `null` rather than an Invalid Date, because an
+ * Invalid Date compares false against everything and would silently vanish from
+ * the arithmetic much later.
+ */
+function toDate(value: string | Date | null | undefined): Date | null {
+  if (value == null) return null
+  const parsed = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}

--- a/packages/lib/src/builds/backfill-types.ts
+++ b/packages/lib/src/builds/backfill-types.ts
@@ -1,0 +1,275 @@
+// packages/lib/src/builds/backfill-types.ts
+
+/**
+ * The contract the build backfill is written against.
+ *
+ * `plans/money/tasks/44-auto-build-cutoff-and-backfill.md` sections 6 and 7.
+ *
+ * This file is the seam between the four halves of the feature and it holds no
+ * logic of its own:
+ *
+ * - `backfill-policy.ts` is PURE and decides what to build,
+ * - `backfill-queries.ts` reads what the policy is handed,
+ * - `backfill-builds.ts` executes the plan,
+ * - the router and the dialog render it.
+ *
+ * The split follows `reconcile-policy.ts` / `reconcile-order-builds.ts` exactly,
+ * for the reason that file's header gives: the decision has to be testable
+ * without a database, a clock or a settings read.
+ */
+
+import type { ConvergenceSkipReason } from './reconcile-policy'
+
+/**
+ * How much demand one build covers.
+ *
+ * `'range'` collapses the whole window into one build per part.
+ *
+ * Section 7.3: when the run creates `completed` builds and the range spans more
+ * than one accounting month, `'range'` is not selectable. `build_completed_at`
+ * decides which month-end entry reflects the build, so a coarser grouping
+ * misstates every month it spans.
+ */
+export type BackfillGrouping = 'order' | 'day' | 'week' | 'month' | 'range'
+
+export const BACKFILL_GROUPINGS: readonly BackfillGrouping[] = [
+  'order',
+  'day',
+  'week',
+  'month',
+  'range',
+]
+
+/**
+ * Why an ordered part produces no build at all.
+ *
+ * Three members of {@link ConvergenceSkipReason} transfer to the aggregate
+ * (section 7.2b). The other five are per-(order, part) concepts and would be
+ * inventing a meaning they do not have here.
+ *
+ * 🛑 `already-covered` is NATIVE to the aggregate and has no per-order twin. It
+ * is the state a part is in when committed production already meets the whole
+ * demand, and it is deliberately not folded into `covered-by-stock`: the two
+ * have different remedies, and conflating them is actively misleading on the
+ * SECOND run of the dialog, where every part just built is fully covered and
+ * would otherwise be reported as sitting on the shelf.
+ */
+export type BackfillExclusionReason =
+  | Extract<ConvergenceSkipReason, 'not-a-built-part' | 'no-bill-of-materials' | 'covered-by-stock'>
+  | 'already-covered'
+
+export const BACKFILL_EXCLUSION_REASONS: readonly BackfillExclusionReason[] = [
+  'not-a-built-part',
+  'no-bill-of-materials',
+  'covered-by-stock',
+  'already-covered',
+]
+
+/** One order line's contribution to demand, already resolved to a part. */
+export interface BackfillDemandLine {
+  /** `EntityInstance.id` of the `order` the line hangs off. */
+  orderId: string
+  /** `EntityInstance.id` of the `part` the line reaches through `line_item_part`. */
+  partId: string
+  /** `line_item_qty`. Non-positive and non-finite values contribute nothing. */
+  quantity: number
+  /**
+   * `order_placed_at`, falling back to the order row's `createdAt`.
+   *
+   * This is what buckets the line, and it is a business date: a connector
+   * back-fill creates rows today carrying last year's date.
+   */
+  placedAt: Date
+}
+
+/**
+ * Production already committed for a part, which demand must be netted against.
+ *
+ * Section 7.1a: this carries `planned` and `in_progress` builds ONLY. A
+ * `completed` build's units are already in `part_quantity_on_hand` through its
+ * `build_produce` movement, so counting it here and subtracting on hand counts
+ * the same production twice.
+ */
+export interface BackfillCoverage {
+  /** `EntityInstance.id` of the `part`. */
+  partId: string
+  /** `build_quantity_planned`. */
+  quantity: number
+  /**
+   * When this coverage applies.
+   *
+   * An order-raised build resolves it through `build_order` to the order's
+   * `order_placed_at`. A batch build resolves it to the start of its own demand
+   * period. `null` when neither is knowable, which sorts first.
+   *
+   * ⚠️ **Deliberately UNUSED by the v1 policy, not forgotten.** Section 7.1a
+   * pools coverage per part and drains it chronologically against the buckets;
+   * consuming period-scoped coverage against its own overlapping buckets first
+   * is the refinement that section explicitly defers. The field is populated so
+   * that refinement needs no change to the reader.
+   */
+  appliesAt: Date | null
+}
+
+/** Everything the pure decision is allowed to see. No db, no clock, no settings. */
+export interface BackfillPlanInput {
+  /** Every line in the range that reaches a part, uncollapsed. */
+  lines: readonly BackfillDemandLine[]
+  /** Committed production per part. See {@link BackfillCoverage}. */
+  coverage: readonly BackfillCoverage[]
+  /** `partId` -> `part_quantity_on_hand`. Absent reads as `0`. */
+  quantitiesOnHand: ReadonlyMap<string, number>
+  /** `partId` -> raw `part_kind` option value, exactly as stored. `null` reads as `component`. */
+  partKinds: ReadonlyMap<string, string | null>
+  /** `partId` -> does the part have at least one direct subpart? Absent reads as `false`. */
+  hasBom: ReadonlyMap<string, boolean>
+  /** How much demand one build covers. */
+  grouping: BackfillGrouping
+  /**
+   * The organization's book timezone (`accounting.bookTimeZone`), which decides
+   * which bucket a line falls in.
+   *
+   * Not optional decoration: an order placed at 7pm on January 31 in
+   * `America/New_York` is already February 1 in UTC, and bucketing it in UTC
+   * puts its build in the wrong accounting month. Same rule as
+   * `postings/periods.ts`.
+   */
+  timeZone: string
+}
+
+/** One build the backfill would create. */
+export interface BackfillBucket {
+  /** `EntityInstance.id` of the `part` to produce. */
+  partId: string
+  /**
+   * The demand period this build claims, as stored on the build.
+   *
+   * Half-open: `periodStart` inclusive, `periodEnd` exclusive. Under
+   * `grouping: 'order'` the two collapse onto the one order's date.
+   */
+  periodStart: Date
+  periodEnd: Date
+  /** Human key for the period, `'2026-01'` at monthly grouping. Display only. */
+  periodKey: string
+  /**
+   * Stable identity for this bucket within the plan.
+   *
+   * 🛑 **`(partId, periodKey)` is NOT unique.** Under `grouping: 'order'` two
+   * orders placed on the same local day share a period key, so anything that
+   * keys a row, a summary entry or a React list off that pair collides and
+   * silently loses one. Key off this instead.
+   *
+   * 🛑 **Never persist it onto a build as an identity.** It is not stable across
+   * a grouping change, by construction: changing the grouping changes which
+   * buckets exist at all. It is a within-plan key for React lists and run
+   * summaries, nothing more.
+   */
+  bucketId: string
+  /** Units ordered in this bucket, before any netting. */
+  quantityOrdered: number
+  /** Committed production consumed by this bucket. */
+  quantityCovered: number
+  /** On-hand stock consumed by this bucket. Section 7.1: earliest bucket first. */
+  quantityFromStock: number
+  /** What the build is created for. Never zero, or the bucket is dropped. */
+  quantityToBuild: number
+  /** The orders behind this bucket, for the read-only drill-down. */
+  orderIds: readonly string[]
+}
+
+/** One part, and every build the backfill would create for it. */
+export interface BackfillPartPlan {
+  partId: string
+  /** Units ordered across the whole range. */
+  quantityOrdered: number
+  /**
+   * Committed production AVAILABLE across the whole range, which is not the
+   * same as the amount consumed.
+   *
+   * ⚠️ A part whose coverage exceeds its demand reports more here than it
+   * ordered. That is truthful but reads oddly in a "Built" column, so the
+   * screen (section 7.2) sums `quantityCovered` over {@link buckets} for
+   * display, which is the amount actually consumed.
+   */
+  quantityCovered: number
+  /** `part_quantity_on_hand` at the moment the plan was computed. */
+  quantityOnHand: number
+  /** Sum of `quantityToBuild` over {@link buckets}. */
+  quantityToBuild: number
+  /** One per build to create, chronological. Empty when nothing is owed. */
+  buckets: readonly BackfillBucket[]
+}
+
+/**
+ * One part that is ordered but produces no build, and why.
+ *
+ * 🛑 Every quantity here exists so the REASON is self-evident on the row.
+ * Section 7.2b's whole argument is that an omission a person cannot explain
+ * makes the preview untrustworthy, so a row must carry the number that proves
+ * its own reason: `quantityOnHand` for `covered-by-stock`, `quantityCovered`
+ * for `already-covered`.
+ */
+export interface BackfillExclusion {
+  partId: string
+  /** Units ordered in the range. Shown so the exclusion can be judged. */
+  quantityOrdered: number
+  /** `part_quantity_on_hand`, which is what makes `covered-by-stock` self-evident. */
+  quantityOnHand: number
+  /** Committed production, which is what makes `already-covered` self-evident. */
+  quantityCovered: number
+  reason: BackfillExclusionReason
+}
+
+/**
+ * What the backfill would do. The preview renders this; the writer executes it.
+ *
+ * Deterministic: parts ascending by id, buckets chronological within a part.
+ * That is what lets a test assert on the whole structure.
+ */
+export interface BackfillPlan {
+  /** Parts with at least one build to create. */
+  parts: readonly BackfillPartPlan[]
+  /** Parts that are ordered but not buildable. Section 7.2b. */
+  excluded: readonly BackfillExclusion[]
+  /** Total builds this plan would create, across every part. */
+  buildCount: number
+  /** Total units, across every build. */
+  unitCount: number
+}
+
+/** The status a backfilled build lands in. Section 7.3. */
+export type BackfillStatus = 'planned' | 'completed'
+
+/** What one backfill run was asked to do. */
+export interface BackfillRequest {
+  /** Inclusive lower bound on `order_placed_at`. */
+  from: Date
+  /** Exclusive upper bound. Section 7.0 bounds this above by the build cutoff. */
+  to: Date
+  grouping: BackfillGrouping
+  status: BackfillStatus
+}
+
+/** What one backfill run did. Never throws; a failure is a row in here. */
+export interface BackfillRunSummary {
+  /**
+   * Builds created, in creation order.
+   *
+   * 🛑 **`created` and {@link leftInProgress} OVERLAP.** A build whose
+   * completion was refused was still raised, so it appears in both: `created`
+   * means "builds that now exist and did not before", never "builds that
+   * finished". Adding the two array lengths double-counts, and a screen that
+   * does will report more builds than the run made.
+   */
+  created: readonly { partId: string; buildId: string; quantity: number; periodKey: string }[]
+  /**
+   * Builds raised whose completion was refused, leaving them `in_progress`.
+   *
+   * Section 7.4: `buildNow` is not atomic and reports this as a RESULT rather
+   * than an error, because the build exists and the person has to be able to
+   * name it. A run must record these and continue, never abort the batch.
+   */
+  leftInProgress: readonly { partId: string; buildId: string; reason: string }[]
+  /** Buckets that produced nothing at all, with the reason. Keyed by `bucketId`. */
+  failed: readonly { partId: string; bucketId: string; periodKey: string; reason: string }[]
+}

--- a/packages/lib/src/builds/build-mutations.ts
+++ b/packages/lib/src/builds/build-mutations.ts
@@ -129,6 +129,28 @@ export async function createBuild(
         build_source: input.source ?? 'manual',
       }
       if (input.notes) values.build_notes = input.notes
+
+      // The demand period a batch build claims (plans/money/tasks/44 §6.2).
+      //
+      // 🛑 Written HERE or never: both fields are `updatable: false`, so a
+      // post-create write would be writing a field the schema refuses. That is
+      // deliberate — moving a claimed period restates what the next netting run
+      // believes is already covered.
+      //
+      // Guarded on `source` for the same reason `build_order_revision` is: an
+      // order-raised build answers to one order and a hand-raised one to nobody,
+      // so neither claims a period, and a stray period on one would make it look
+      // like coverage to a pass that must not see it.
+      if (input.period && (input.source ?? 'manual') === 'batch') {
+        if (input.period.end.getTime() <= input.period.start.getTime()) {
+          throw new BadRequestError('A build period must end after it starts')
+        }
+        if (ctx.fields.build_period_start && ctx.fields.build_period_end) {
+          values.build_period_start = input.period.start.toISOString()
+          values.build_period_end = input.period.end.toISOString()
+        }
+      }
+
       if (input.orderId) {
         const orderDefId = await requireDefId(organizationId, 'order')
         values.build_order = toRecordId(orderDefId, input.orderId)

--- a/packages/lib/src/builds/build-queries.ts
+++ b/packages/lib/src/builds/build-queries.ts
@@ -70,6 +70,12 @@ const BUILD_ATTRIBUTES = [
   'build_source',
   'build_reversal_of',
   'build_order_revision',
+  // The demand period a `batch` build claims (plans/money/tasks/44 §6.2). Both
+  // are `updatable: false`, so `createBuild` is the only writer and this is the
+  // only place the ids are resolved. Absent on an org short of migration 124,
+  // which is why every reader guards on them rather than assuming.
+  'build_period_start',
+  'build_period_end',
 ] as const
 
 type BuildAttribute = (typeof BUILD_ATTRIBUTES)[number]

--- a/packages/lib/src/builds/client.ts
+++ b/packages/lib/src/builds/client.ts
@@ -423,3 +423,29 @@ export function skipReasonLabel(skip: {
       return skip.reason
   }
 }
+
+/**
+ * The backfill contract, re-exported for the browser.
+ *
+ * `backfill-types.ts` is the shared seam
+ * (`plans/money/tasks/44-auto-build-cutoff-and-backfill.md` section 11.2) and it
+ * holds nothing but types plus two frozen vocabularies. The preview dialog
+ * renders exactly this shape, and client code may not reach `@auxx/lib/builds`
+ * (the index barrel pulls the whole write path in), so the two `const` arrays
+ * and every type it needs come through here.
+ *
+ * Additive only: nothing in `backfill-types.ts` is redeclared or narrowed.
+ */
+export {
+  BACKFILL_EXCLUSION_REASONS,
+  BACKFILL_GROUPINGS,
+  type BackfillBucket,
+  type BackfillExclusion,
+  type BackfillExclusionReason,
+  type BackfillGrouping,
+  type BackfillPartPlan,
+  type BackfillPlan,
+  type BackfillRequest,
+  type BackfillRunSummary,
+  type BackfillStatus,
+} from './backfill-types'

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -38,6 +38,25 @@ export {
 } from './auto-build-queries'
 export { CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED, registerAutoBuildRules } from './auto-build-rule'
 export { type AutoBuildSettings, loadAutoBuildSettings } from './auto-build-settings'
+export { executeBackfill, resolveBackfillCompletedAt } from './backfill-builds'
+export { planBackfill } from './backfill-policy'
+export { readBackfillPlanReads } from './backfill-queries'
+export {
+  BACKFILL_EXCLUSION_REASONS,
+  BACKFILL_GROUPINGS,
+  type BackfillBucket,
+  type BackfillCoverage,
+  type BackfillDemandLine,
+  type BackfillExclusion,
+  type BackfillExclusionReason,
+  type BackfillGrouping,
+  type BackfillPartPlan,
+  type BackfillPlan,
+  type BackfillPlanInput,
+  type BackfillRequest,
+  type BackfillRunSummary,
+  type BackfillStatus,
+} from './backfill-types'
 export {
   amendPlannedBuildQuantity,
   cancelBuild,

--- a/packages/lib/src/builds/types.ts
+++ b/packages/lib/src/builds/types.ts
@@ -237,11 +237,18 @@ export interface CreateBuildInput {
   /** `EntityInstance.id` of the `order` that caused this run, if any. */
   orderId?: string
   /**
-   * `manual` (a person raised it) or `order` (the auto-build trigger did).
+   * `manual` (a person raised it), `order` (the auto-build trigger did) or
+   * `batch` (the backfill raised it for a whole demand period).
    * Defaults to `manual` — an auto-build must be distinguishable from one a
    * person raised against the same order deliberately (products/12 AB7).
+   *
+   * 🛑 `batch` is not a label, it is the mechanism: `reconcile-policy.ts` skips
+   * any build whose source is not `order`, so a batch build is invisible to
+   * Model B convergence — and, by the mirror rule at its line 227, is not
+   * coverage to the reconciler either. That is why a batch build is only safe
+   * below the auto-build cutoff (plans/money/tasks/44 §6.1).
    */
-  source?: 'manual' | 'order'
+  source?: 'manual' | 'order' | 'batch'
   /**
    * The order's demand fingerprint to stamp on the new build, when the caller
    * already has it.
@@ -256,6 +263,25 @@ export interface CreateBuildInput {
    * stamp, because it is not tracking anything (products/12 AB7).
    */
   orderRevision?: string
+  /**
+   * The DEMAND period a `batch` build claims. Half-open: `start` inclusive,
+   * `end` exclusive.
+   *
+   * 🛑 **It has to be settable HERE, at create time.** `build_period_start` and
+   * `build_period_end` are declared `updatable: false`, because moving a claimed
+   * period silently restates what the next netting run believes is already
+   * covered (plans/money/tasks/44 §6.2). So there is no legitimate second write,
+   * and a post-create update would be writing a field the schema says cannot be
+   * written.
+   *
+   * ⚠️ Not the same thing as when the build HAPPENED. A build raised in
+   * September covering January demand claims January and completes in January;
+   * `build_completed_at` is the accounting date and must fall inside this range.
+   *
+   * Ignored unless `source` is `batch`. An order-raised or hand-raised build
+   * claims no period: it answers to one order, or to nobody.
+   */
+  period?: { start: Date; end: Date }
 }
 
 /** Move a `planned` run to `in_progress`. */
@@ -406,7 +432,7 @@ export interface ListBuildsFilters {
   partId?: string
   /** Only runs raised against this `order` instance. */
   orderId?: string
-  source?: 'manual' | 'order'
+  source?: 'manual' | 'order' | 'batch'
   /** Defaults to 50. */
   limit?: number
   offset?: number

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -763,18 +763,38 @@ export const BuildStatus = {
 
 /**
  * Build Source
- * plans/products/build/01-build-plan.md §1.1, plans/products/12 AB7.
+ * plans/products/build/01-build-plan.md §1.1, plans/products/12 AB7,
+ * plans/money/tasks/44-auto-build-cutoff-and-backfill.md §6.1.
  *
  * An auto-raised build must be distinguishable from one a person raised against
  * the same order deliberately — without that, "cancel the builds this order
  * caused" cannot tell the two apart and would revoke a human decision.
+ *
+ * ## 🛑 `batch` is not a label, it is the mechanism
+ *
+ * `reconcile-policy.ts:316` skips any build whose `source !== 'order'` as
+ * `not-order-raised`, so a `batch` build is invisible to Model B convergence the
+ * moment it is written: no rework to `planOrderBuildConvergence`, no change to
+ * the drift comparison, nothing new in the Model B path. The cancellation sweep
+ * is the same — `cancelAutoBuildsForOrders` goes through `readOrderRaisedBuilds`,
+ * which filters `source === 'order'` in SQL and re-checks in memory, so an order
+ * cancellation can never reach a batch build.
+ *
+ * ⚠️ The mirror of that, at `reconcile-policy.ts:227`: a non-`order` build does
+ * NOT block a raise, because blocking on one would let a single manual build
+ * suppress an order's build set forever. So a batch build is not coverage to the
+ * reconciler either — raise one inside the live window and per-order builds land
+ * on top of the same demand. **Batch builds are only safe below the auto-build
+ * cutoff**, which is exactly where per-order raising does not run.
  */
 export const BuildSource = {
   MANUAL: 'manual',
   ORDER: 'order',
+  BATCH: 'batch',
 
   values: [
     { value: 'manual', label: 'Manual', color: 'gray' },
     { value: 'order', label: 'Order', color: 'blue' },
+    { value: 'batch', label: 'Batch', color: 'purple' },
   ] satisfies FieldOptionItem[],
 } as const

--- a/packages/lib/src/resources/registry/resources/build-fields.ts
+++ b/packages/lib/src/resources/registry/resources/build-fields.ts
@@ -664,6 +664,89 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
     description: 'The order version used when this build was created or last updated',
   },
 
+  /**
+   * The DEMAND period a batch build claims, half-open: `periodStart` inclusive,
+   * `periodEnd` exclusive
+   * (plans/money/tasks/44-auto-build-cutoff-and-backfill.md §6.2).
+   *
+   * 🛑 **This is not when the build happened.** A batch build carries no orders
+   * — §6.2 rejected both widening `build_order` and adding a second relation,
+   * because the relation's real job was coverage, and coverage is answered
+   * better by netting ordered quantity against built quantity per
+   * `(part, period)`. That netting is what these two fields make queryable, and
+   * it is what absorbs a late order backfilled into a closed period: 345 ordered
+   * against 340 built raises a 5-unit build instead of leaving the demand
+   * permanently invisible.
+   *
+   * 🛑 **`build_completed_at` cannot be reused for this.** A build created in
+   * September covering January demand has to say January, and
+   * `build_completed_at` says September. The two answer different questions and
+   * both are needed: §7.3 makes `build_completed_at` THE accounting date, so the
+   * period and the completion date have to be kept in agreement by whoever
+   * writes them — a build that covers January and posts to September is the
+   * defect this pair exists to make visible rather than the one it causes.
+   *
+   * NULL on order-raised and manual builds. An order-raised build resolves its
+   * coverage date through `build_order` instead, and a manual build claims no
+   * period at all.
+   *
+   * DATETIME rather than DATE on purpose: a bucket boundary is a book-timezone
+   * instant, and January 31 19:00 in `America/New_York` is already February in
+   * UTC. Rounding these to UTC midnight would move demand across the month
+   * boundary, which is the exact error §7.1's `timeZone` input exists to avoid.
+   */
+  periodStart: {
+    id: toFieldId('periodStart'),
+    key: 'periodStart',
+    label: 'Period Start',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'build_period_start',
+    systemSortOrder: 'aM',
+    nullable: true,
+    // Stamped by the bulk builder, never picked out of the create dialog: the
+    // period is derived from the range and grouping the dialog was given, and a
+    // hand-typed one could disagree with the demand the build was sized from.
+    showInPanel: true,
+    showInTable: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      // Backend-owned, like `orderRevision`: there is no interactive writer, and
+      // moving a completed build's claimed period would silently restate what
+      // the next netting run thinks is already covered.
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Start of the demand period this build covers, inclusive',
+  },
+
+  periodEnd: {
+    id: toFieldId('periodEnd'),
+    key: 'periodEnd',
+    label: 'Period End',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'build_period_end',
+    systemSortOrder: 'aN',
+    nullable: true,
+    showInPanel: true,
+    showInTable: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'End of the demand period this build covers, exclusive',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -84,6 +84,7 @@ import { migration120TariffCodeLabel } from './migrations/120-tariff-code-label'
 import { migration121RatePrecision } from './migrations/121-rate-precision'
 import { migration122OrderShippingAndNote } from './migrations/122-order-shipping-and-note'
 import { migration123PartSkuOptional } from './migrations/123-part-sku-optional'
+import { migration124BuildBatchSourceAndPeriod } from './migrations/124-build-batch-source-and-period'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -230,6 +231,10 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration121RatePrecision,
   migration122OrderShippingAndNote,
   migration123PartSkuOptional,
+  // MUST sort after 109 — it adds two fields to the def 109 creates and widens
+  // the `build_source` option list 109 materialized, and skips an org that has
+  // not reached 109 yet.
+  migration124BuildBatchSourceAndPeriod,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/124-build-batch-source-and-period.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/124-build-batch-source-and-period.test.ts
@@ -1,0 +1,128 @@
+// packages/lib/src/seed/entity-migrations/migrations/124-build-batch-source-and-period.test.ts
+//
+// Migration 124 adds two `CustomField` rows and one option to a third, so what
+// can silently go wrong is the wiring rather than the write:
+//
+//  - the id must be unique across a space shared with `data-migrations/`, which
+//    has already collided once at 103;
+//  - it must run after 109, which creates the `build` def and materializes the
+//    two-value `build_source` option list it widens;
+//  - the registry keys it names must exist, or it quietly creates one field
+//    fewer than it claims to;
+//  - the option append must preserve every stored entry, because
+//    `FieldValue.optionId` stores the `value` key.
+
+import { describe, expect, it } from 'vitest'
+import { BuildSource } from '../../../resources/registry/enum-values'
+import { BUILD_FIELDS } from '../../../resources/registry/resources/build-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import {
+  appendMissingOptions,
+  migration124BuildBatchSourceAndPeriod,
+} from './124-build-batch-source-and-period'
+
+const MIGRATION_ID = '124-build-batch-source-and-period'
+
+describe('migration 124 registration', () => {
+  it('is registered exactly once, with a unique id, after 109', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf(MIGRATION_ID)).toBeGreaterThan(ids.indexOf('109-build-and-standard-cost'))
+    expect(migration124BuildBatchSourceAndPeriod.id).toBe(MIGRATION_ID)
+  })
+
+  it('is last, so the next migration takes 125', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids[ids.length - 1]).toBe(MIGRATION_ID)
+  })
+})
+
+describe('BuildSource gains batch without disturbing what is already stored', () => {
+  it('carries three values, with manual and order still first and in order', () => {
+    expect(BuildSource.values.map((option) => option.value)).toEqual(['manual', 'order', 'batch'])
+    expect(BuildSource.BATCH).toBe('batch')
+  })
+
+  it('gives batch a colour distinct from manual and order', () => {
+    const colors = BuildSource.values.map((option) => option.color)
+    expect(new Set(colors).size).toBe(colors.length)
+  })
+})
+
+describe('appendMissingOptions', () => {
+  const wanted = [
+    { value: 'manual', label: 'Manual', color: 'gray' },
+    { value: 'order', label: 'Order', color: 'blue' },
+    { value: 'batch', label: 'Batch', color: 'purple' },
+  ]
+
+  it('appends only what is missing, preserving stored entries verbatim', () => {
+    // A renamed label and a recoloured option: both are the org's, and a
+    // wholesale rewrite from the registry would discard them.
+    const stored = [
+      { value: 'manual', label: 'By hand', color: 'gray' },
+      { value: 'order', label: 'Order', color: 'teal' },
+    ]
+    expect(appendMissingOptions(stored, wanted)).toEqual([
+      { value: 'manual', label: 'By hand', color: 'gray' },
+      { value: 'order', label: 'Order', color: 'teal' },
+      { value: 'batch', label: 'Batch', color: 'purple' },
+    ])
+  })
+
+  it('returns null once every wanted option is present, so a re-run writes nothing', () => {
+    const stored = wanted.map((option) => ({ ...option }))
+    expect(appendMissingOptions(stored, wanted)).toBeNull()
+  })
+
+  it('never rewrites a stored value key', () => {
+    // `FieldValue.optionId` stores this key on `updatable: false` fields that
+    // nothing can restate, so changing one orphans every build carrying it.
+    const stored = [{ value: 'manual', label: 'Manual', color: 'gray' }]
+    const next = appendMissingOptions(stored, wanted)
+    expect(next?.[0]).toBe(stored[0])
+  })
+})
+
+describe('the two demand-period fields are shaped for netting', () => {
+  it('are system DATETIME fields on the two named attributes', () => {
+    expect(BUILD_FIELDS.periodStart?.systemAttribute).toBe('build_period_start')
+    expect(BUILD_FIELDS.periodEnd?.systemAttribute).toBe('build_period_end')
+    for (const field of [BUILD_FIELDS.periodStart, BUILD_FIELDS.periodEnd]) {
+      expect(field?.isSystem).toBe(true)
+      // DATETIME, not DATE: a bucket boundary is a book-timezone instant, and
+      // rounding it to UTC midnight moves demand across the month boundary.
+      expect(field?.fieldType).toBe('DATETIME')
+    }
+  })
+
+  it('are nullable, because a manual or order-raised build claims no period', () => {
+    expect(BUILD_FIELDS.periodStart?.nullable).toBe(true)
+    expect(BUILD_FIELDS.periodEnd?.nullable).toBe(true)
+  })
+
+  it('are set on the insert and never edited afterwards', () => {
+    for (const field of [BUILD_FIELDS.periodStart, BUILD_FIELDS.periodEnd]) {
+      expect(field?.capabilities.creatable).toBe(true)
+      expect(field?.capabilities.updatable).toBe(false)
+      // The period is derived from the range and grouping the dialog was given,
+      // so it is not a question the create dialog asks.
+      expect(field?.showInDialogs).toBe(false)
+    }
+  })
+
+  it('are filterable, which is what the netting read needs', () => {
+    expect(BUILD_FIELDS.periodStart?.capabilities.filterable).toBe(true)
+    expect(BUILD_FIELDS.periodEnd?.capabilities.filterable).toBe(true)
+  })
+
+  it('do not collide with an existing sort order on the build def', () => {
+    const collisions = (key: string) =>
+      Object.entries(BUILD_FIELDS).filter(
+        ([name, f]) => name !== key && f.systemSortOrder === BUILD_FIELDS[key]?.systemSortOrder
+      )
+    expect(collisions('periodStart')).toEqual([])
+    expect(collisions('periodEnd')).toEqual([])
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/124-build-batch-source-and-period.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/124-build-batch-source-and-period.ts
@@ -1,0 +1,189 @@
+// packages/lib/src/seed/entity-migrations/migrations/124-build-batch-source-and-period.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import type { FieldOptions } from '../../../custom-fields'
+import { BuildSource } from '../../../resources/registry/enum-values'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { BUILD_FIELDS } from '../../../resources/registry/resources/build-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:124')
+
+/** The def that receives all of this. Created by migration 109. */
+const BUILD_ENTITY_TYPE = 'build'
+
+/** The field whose stored `options` JSONB has to learn about `batch`. */
+const BUILD_SOURCE_ATTRIBUTE = 'build_source'
+
+/**
+ * Listed by REGISTRY KEY rather than taken as "everything new on
+ * `BUILD_FIELDS`", so a later unrelated field cannot silently join this
+ * migration's payload. The same discipline 109, 111 and 119 record.
+ */
+const FIELD_KEYS = ['periodStart', 'periodEnd'] as const
+
+/** One stored option, as `CustomField.options.options[]` holds it. */
+interface StoredOption {
+  value: string
+  label: string
+  [key: string]: unknown
+}
+
+/**
+ * Append every wanted option the stored list does not already carry, returning
+ * the new list or `null` when nothing is missing.
+ *
+ * 🛑 **Append, never replace.** `108-purchasing.ts`'s `refreshSelectOptions`
+ * rewrites the whole array from the registry when the `value` keys differ, which
+ * here would also restate `Manual` and `Order` — discarding any label or colour
+ * an org set on them. 118 records why that matters: only the thing that actually
+ * changed should be written. Existing entries are preserved verbatim, in order,
+ * and `value` is never touched, because `FieldValue.optionId` stores that key
+ * and rewriting one orphans every build that carries it.
+ *
+ * Pure, so the rule is testable without a database.
+ */
+export function appendMissingOptions(
+  stored: readonly StoredOption[],
+  wanted: readonly { value: string; label: string; color: string }[]
+): StoredOption[] | null {
+  const present = new Set(stored.map((option) => option.value))
+  const missing = wanted.filter((option) => !present.has(option.value))
+  if (missing.length === 0) return null
+  return [...stored, ...missing]
+}
+
+/**
+ * Migration 124: `BuildSource.batch`, and the two demand-period fields a batch
+ * build claims (plans/money/tasks/44-auto-build-cutoff-and-backfill.md §6, §11.1
+ * phase 0).
+ *
+ * ## What it adds
+ *
+ * 1. `batch` on `build_source`, beside `manual` and `order`.
+ * 2. `build_period_start` / `build_period_end` on the `build` def.
+ *
+ * ## 🛑 Why the enum edit alone reaches no existing org
+ *
+ * `build-fields.ts` declares `options: { options: BuildSource.values }`, and
+ * those options are **materialized into `CustomField.options` JSONB at seed
+ * time**. `mergeSystemAndCustomFields` reads them off the DB row, never off the
+ * registry — `106-supplier-pricing-relabel.ts` and `118-movement-type-relabel.ts`
+ * both exist for exactly this reason. Without this migration a batch build would
+ * write an `optionId` of `batch` that no stored option matches, and the records
+ * view, the filter dropdown and the Details panel would all render it as blank
+ * while the registry-backed surfaces read `Batch`.
+ *
+ * ## Inert on arrival
+ *
+ * Nothing writes `batch` or either period field until the bulk builder lands
+ * (§11.1 phases 1-4), the same B10 precedent 109 and 111 followed. A value with
+ * no writer carries no behavioural risk, and shipping it first is what clears
+ * the org-cache and field-exists gates for the code that follows.
+ *
+ * ## Id space
+ *
+ * 124 is the next free number counted across BOTH `data-migrations/migrations/`
+ * (which reaches 106) and `seed/entity-migrations/migrations/` (which reaches
+ * 123), and verified against every local and remote branch — the space is shared
+ * and has already collided once, at 103.
+ *
+ * **No DDL.** The two fields are `CustomField` rows on an existing def and the
+ * option is JSONB on an existing row; nothing here touches a Postgres table. If
+ * a `.sql` file appears under `packages/database/drizzle/` for this work,
+ * something is wrong.
+ *
+ * Idempotent — `ensureCustomFields` skips a field that already exists, and
+ * {@link appendMissingOptions} returns `null` once `batch` is stored.
+ */
+export const migration124BuildBatchSourceAndPeriod: EntityMigration = {
+  id: '124-build-batch-source-and-period',
+  description:
+    'Add the batch build source and the build_period_start / build_period_end demand-period ' +
+    'pair, so a batch build can claim a period instead of carrying its orders',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const def = existing.entityDefs.get(BUILD_ENTITY_TYPE)
+    // Absent rather than failed: an org short of migration 109 has no `build`
+    // def, and 109 seeds the full registry — including these two fields and the
+    // three-value option list — so a later run picks the whole thing up on its
+    // own.
+    if (!def) return { ...state, alreadyUpToDate: true }
+
+    // ── The two demand-period fields ───────────────────────────────────
+    const fields: Record<string, ResourceField> = {}
+    for (const key of FIELD_KEYS) {
+      const field = BUILD_FIELDS[key]
+      // Loud rather than silent: a renamed registry key would otherwise make
+      // this migration quietly create one field fewer than it claims to.
+      if (!field) {
+        throw new Error(`build registry is missing the key "${key}" (migration 124)`)
+      }
+      fields[key] = field
+    }
+
+    await ensureCustomFields(db, organizationId, BUILD_ENTITY_TYPE, def.id, fields, existing, state)
+
+    // ── `batch` on the stored build_source options ─────────────────────
+    const optionsAdded = await addBatchSourceOption(db, organizationId, def.id)
+
+    const changed = state.fieldsCreated > 0 || optionsAdded
+    const alreadyUpToDate = !changed
+
+    // A new field, and a new option on an existing one, are both invisible to
+    // every read path until the per-org caches that serve them are dropped.
+    // `runEntityMigrationsForOrg` does this after the whole batch, but `up()`
+    // can also be invoked directly, so it clears its own.
+    if (changed) {
+      await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+      logger.info('Migration 124 applied', { organizationId, ...state, optionsAdded })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}
+
+/**
+ * Add `batch` to the org's stored `build_source` options, preserving everything
+ * already there. Returns whether a row was written.
+ */
+async function addBatchSourceOption(
+  db: Database,
+  organizationId: string,
+  entityDefId: string
+): Promise<boolean> {
+  const field = await db.query.CustomField.findFirst({
+    where: and(
+      eq(schema.CustomField.organizationId, organizationId),
+      eq(schema.CustomField.entityDefinitionId, entityDefId),
+      eq(schema.CustomField.systemAttribute, BUILD_SOURCE_ATTRIBUTE)
+    ),
+    columns: { id: true, options: true },
+  })
+  // An org whose `build` def predates the `source` field has nothing to widen;
+  // `ensureCustomFields` in a later 109 run creates it with all three values.
+  if (!field) return false
+
+  const stored = (field.options as { options?: StoredOption[] } | null)?.options
+  if (!Array.isArray(stored)) return false
+
+  const next = appendMissingOptions(stored, BuildSource.values)
+  if (!next) return false
+
+  await db
+    .update(schema.CustomField)
+    .set({
+      options: { ...(field.options as FieldOptions), options: next },
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.CustomField.id, field.id))
+
+  return true
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -646,7 +646,18 @@ export const SYSTEM_ATTRIBUTES = [
   'build_posted_at', // denormalized convenience ONLY — never gate on it
   'build_notes',
   'build_order', // which order caused this build (plans/products/12 AB7)
-  'build_source', // manual | order — an auto-build must be distinguishable
+  'build_source', // manual | order | batch — an auto-build must be distinguishable
+  // The DEMAND period a `batch` build claims, half-open (start inclusive, end
+  // exclusive), entity migration 124. NULL on manual and order-raised builds.
+  //
+  // 🛑 NOT when the build happened. A batch build carries no orders (plan 44
+  // §6.2 rejected the relation), so coverage is answered by netting ordered
+  // quantity against built quantity per (part, period) — and a build created in
+  // September covering January demand has to say January, which
+  // `build_completed_at` cannot, because that is the accounting date and says
+  // September.
+  'build_period_start',
+  'build_period_end',
   // The frozen standard, deliberately separate from the live `part_cost`. The
   // three components are split because the fulfillment COGS entry has to land
   // across 5000 / 5010 / 5020, which it can only do if the finished good's


### PR DESCRIPTION
## Why

Raising one build per order does not scale. Builds grow with **order count**, which is the wrong denominator: a business selling low-value goods at high quantity gets thousands of builds where it makes a few dozen things. This adds a second way to raise them, keyed on what actually gets made.

Concretely, on 60 days of Shopify data in dev: 858 distinct (order, part) pairs, of which 217 are buildable, collapse to **38 builds** at one per part per month.

## What

A backfill run reads demand over a date range, nets it against production that already exists, and raises one build per `(part, period)` for what is left. Grouping is chosen at run time, from one build per order up to one for the whole range. A preview shows the plan before anything is written, including the parts it is **not** building and why.

Four pieces, split so the decision is testable without a database, following the existing `reconcile-policy.ts` / `reconcile-order-builds.ts` split:

| file | role |
| --- | --- |
| `backfill-types.ts` | the contract |
| `backfill-policy.ts` | pure decision, no db / clock / settings |
| `backfill-queries.ts` | the aggregate reads, 5 queries flat regardless of range |
| `backfill-builds.ts` | the writer |

Plus two tRPC procedures, a preview dialog reached from a `pageActions` button on the builds list, and migration 124.

## The parts worth reviewing closely

**The netting rule.** Coverage counts `planned` and `in_progress` builds only. A `completed` build's units are already in `part_quantity_on_hand` via its `build_produce` movement, so counting it as coverage too under-builds by exactly the produced quantity. One rule that also settles cancellations and reversals with no special cases.

**Chronological consumption.** Coverage and on-hand are consumed at **range** level and distributed earliest-bucket-first, never netted per bucket. Three on hand across eight monthly buckets is three units of coverage in total, not twenty-four. The per-bucket implementation passes a single-bucket test and under-builds everywhere else, so there is a test asserting the total.

**`BuildSource.batch` is the mechanism, not a label.** `reconcile-policy.ts:316` skips any build whose source is not `order`, so a batch build is invisible to Model B convergence and needs no rework to it. Its mirror at `:227`, that a non-order build does not *block* a raise, is why the dialog refuses a range past the auto-build cutoff: above it the reconciler is live and would later stack a per-order build on the same demand.

**A batch build carries a period, not its orders.** Coverage is answered by netting, which converges on the late arrivals a connector sync produces constantly. A relation would put row growth back on order count, which is the denominator this exists to escape. `build_period_start` / `build_period_end` are `updatable: false`, so they must be written at create time, hence `CreateBuildInput.period`.

**Migration 124 is not optional.** A registry edit reaches no existing organization: select options are materialized into `CustomField.options` at seed time and read back off the DB row, so without it a batch build writes an `optionId` no stored option matches and renders blank in the records view, filter dropdown and Details panel.

## Accounting

`build_completed_at` decides which month-end entry a build reaches, so a completed run dates each build inside its own demand period rather than today, derived in the org's book timezone. Preview and `planned` runs fall back to UTC when `accounting.bookTimeZone` is unset; a `completed` run is refused.

The dialog **warns rather than blocks** when completing would drive components negative. That is a true statement about a ledger missing its receipts, and refusing would make the backfill unusable on exactly the org that needs it.

## Tests

`435 passing` across `src/builds`, plus 18 integration tests against real Postgres (`pnpm test:integration` in `packages/lib`). **CI does not run the integration file** and it is where the netting rules are actually asserted against SQL, so re-run it locally after any change to the reads.

## Not done

- **Migration 124 is written and registered but not applied.** The dialog correctly refuses until it runs.
- The preflight is composed in the router rather than lib.
- A period row shows its order count but does not expand to name the orders.
- The QoH recalc is not batched across a run. A full re-SUM is idempotent, so the cost is duplicated work, never a wrong number.

## Follow-up

`plans/money/tasks/45-batch-only-builds.md` argues for turning per-order auto-build off entirely and using this as the only path, which removes the cutoff fence and the drift signal's stuck-badge problem. Not in this PR.

https://claude.ai/code/session_01X5GVEDwzTbGMUFpw8YyPw9
