### PR TITLE
fix(accounting): the write-off guard, the JE attachment, TIN masking and the review stats

### DIFF
--- a/apps/web/src/components/accounting/hooks/use-journal-entry-draft.ts
+++ b/apps/web/src/components/accounting/hooks/use-journal-entry-draft.ts
@@ -215,6 +215,14 @@ export function useJournalEntryDraft({
             // does not overwrite what is being typed with the record it just
             // wrote.
             loadedIdRef.current = record.id
+            // ⚠️ Claiming the id is exactly why the number has to be taken HERE.
+            // `setNumber` otherwise only ever runs in that load effect, which
+            // this line has just disabled for this id, so a freshly minted draft
+            // kept `number: null` for the life of the drawer and its Discard
+            // confirm read "Discard this journal entry?" instead of naming
+            // JNL-0011. The create response is the same record that effect would
+            // have read.
+            setNumber(record.number)
             void utils.ledger.journalEntry.list.invalidate()
             latestRef.current.onCreated(record.id)
           },

--- a/apps/web/src/components/accounting/ui/banking/review/review-stats.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-stats.tsx
@@ -30,6 +30,9 @@ interface ReviewStatsProps {
  */
 export function ReviewStats({ stats, loading, currencyCode, accountSelected }: ReviewStatsProps) {
   const mono = 'font-mono tabular-nums'
+  // A date is wider than a count or an amount, so it gets its own size rather
+  // than the card's default 2xl, which overflows a narrow column.
+  const dateMono = 'font-mono tabular-nums text-lg'
 
   return (
     <StatCards
@@ -38,25 +41,28 @@ export function ReviewStats({ stats, loading, currencyCode, accountSelected }: R
         {
           title: 'For review',
           icon: <Inbox className='size-4' />,
+          color: 'text-accent-500',
           body: <span className={mono}>{stats?.forReviewCount ?? 0}</span>,
           description:
             stats && stats.unreviewedCount > stats.forReviewCount
               ? `${stats.unreviewedCount - stats.forReviewCount} more have a suggestion waiting`
-              : 'Lines with nothing proposed yet',
+              : 'Nothing proposed yet',
         },
         {
           title: 'Oldest unreviewed',
           icon: <CalendarClock className='size-4' />,
-          body: <span className={mono}>{stats?.oldestUnreviewedDate ?? EMPTY_CELL}</span>,
-          description: 'How far back the queue reaches. A backlog is measured in months, not rows',
+          color: 'text-comparison-500',
+          body: <span className={dateMono}>{stats?.oldestUnreviewedDate ?? EMPTY_CELL}</span>,
+          description: 'How far back the queue reaches',
         },
         {
           title: 'Unreviewed in',
           icon: <TrendingUp className='size-4' />,
+          color: 'text-good-500',
           body: (
             <span className={mono}>{formatMinor(stats?.unreviewedInMinor ?? 0, currencyCode)}</span>
           ),
-          description: 'Money that arrived and has not been matched or coded',
+          description: 'Arrived, not yet matched or coded',
         },
         {
           title: accountSelected ? 'Coverage from' : 'Unreviewed out',
@@ -65,8 +71,9 @@ export function ReviewStats({ stats, loading, currencyCode, accountSelected }: R
           ) : (
             <TrendingDown className='size-4' />
           ),
+          color: accountSelected ? 'text-comparison-500' : 'text-bad-500',
           body: (
-            <span className={mono}>
+            <span className={accountSelected ? dateMono : mono}>
               {accountSelected
                 ? (stats?.coverageFrom ?? EMPTY_CELL)
                 : formatMinor(stats?.unreviewedOutMinor ?? 0, currencyCode)}
@@ -75,8 +82,8 @@ export function ReviewStats({ stats, loading, currencyCode, accountSelected }: R
           description: accountSelected
             ? stats && stats.coverageGapCount > 0
               ? `${stats.coverageGapCount} possible gap${stats.coverageGapCount === 1 ? '' : 's'} in this account's data`
-              : 'The earliest date this account holds data for'
-            : 'Money that left and has not been matched or coded',
+              : 'Earliest date this account holds data'
+            : 'Left, not yet matched or coded',
         },
       ]}
     />

--- a/apps/web/src/components/accounting/ui/journal/journal-entry-attachment.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-entry-attachment.tsx
@@ -1,0 +1,75 @@
+// apps/web/src/components/accounting/ui/journal/journal-entry-attachment.tsx
+
+'use client'
+
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { parseFileOptions } from '~/components/custom-fields/ui/file-options-editor'
+import { useFieldFileUpload } from '~/components/fields/inputs/hooks/use-field-file-upload'
+import { FileSelectDialog } from '~/components/file-select/file-select-dialog'
+import { FilePicker } from '~/components/pickers/file-picker'
+import type { RecordId } from '~/components/resources'
+
+/**
+ * The evidence behind a journal entry - the accountant's memo, a statement, a
+ * photo of the paper (`journal_entry_attachment`, a FILE field on the draft
+ * record).
+ *
+ * ⚠️ `useFieldFileUpload` takes `recordId`/`fieldRef` as plain arguments, so no
+ * `PropertyProvider` indirection is needed here - the same reason
+ * `line-photo-popover.tsx` mounts the hook directly. The drawer's own
+ * `FieldInputAdapter` rows cannot serve this field: its FILE case renders
+ * `FileInputField`, which reads `field` and `recordId` off
+ * `usePropertyContext()` rather than the value/onChange pair every other row in
+ * that panel passes.
+ *
+ * 🛑 The attachment stays editable after the entry posts, unlike every other
+ * control in the drawer. It is EVIDENCE about the entry rather than part of it:
+ * nothing here reaches `GlPostingLine`, which is what "correct by reversal,
+ * never by edit" protects. A statement that turns up a week after the close is
+ * exactly the thing somebody needs to be able to staple on.
+ */
+export function JournalEntryAttachment({
+  recordId,
+  field,
+}: {
+  recordId: RecordId
+  field: ResourceField
+}) {
+  const fileOptions = parseFileOptions(field.options)
+  const {
+    displayFiles,
+    uploadingFiles,
+    canAddMore,
+    remainingSlots,
+    openNativeFilePicker,
+    handleBrowseFilesSelected,
+    removeFile,
+    browseOpen,
+    setBrowseOpen,
+  } = useFieldFileUpload({ recordId, fieldRef: field.id, fileOptions })
+
+  return (
+    <>
+      <FilePicker
+        files={displayFiles}
+        uploadingFiles={uploadingFiles}
+        canAddMore={canAddMore}
+        onUpload={openNativeFilePicker}
+        onBrowse={() => setBrowseOpen(true)}
+        onRemove={removeFile}
+        placeholder='Search files...'
+      />
+      {browseOpen && (
+        <FileSelectDialog
+          open={browseOpen}
+          onOpenChange={setBrowseOpen}
+          onFilesSelected={handleBrowseFilesSelected}
+          allowMultiple={fileOptions.allowMultiple}
+          maxSelection={remainingSlots}
+          title='Select files'
+          confirmText='Attach'
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
@@ -12,16 +12,20 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { BookOpenCheck, ExternalLink, Trash2 } from 'lucide-react'
+import { useMemo } from 'react'
 import { useDiscardJournalEntry } from '~/components/accounting/hooks/use-discard-journal-entry'
 import { useJournalEntryDraft } from '~/components/accounting/hooks/use-journal-entry-draft'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import type { RecordId } from '~/components/resources'
+import { useResourceFields } from '~/components/resources/hooks/use-resource-fields'
 import { BaseType } from '~/components/workflow/types'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { LedgerBlocker } from '../ledger/entry-blockers'
 import { EntryBlockers } from '../ledger/entry-blockers'
 import { formatPeriodLabel } from '../ledger/format'
+import { JournalEntryAttachment } from './journal-entry-attachment'
 import { JournalLines, JournalLinesTotals } from './journal-lines'
 import { firstDayOfPeriod, nextOpenPeriodAfter, periodKeyForEntryDate } from './period-helpers'
 
@@ -58,13 +62,16 @@ interface JournalEntryDrawerProps {
  * SAME dock slot `PostingDrawer` uses on the ledger page, opened by `?je=new`
  * or `?je=<id>`.
  *
- * ⚠️ **Attachment: TODO, not wired.** `journal_entry_attachment` (FILE) exists
- * on the entity def (slot 1A), but nothing in this app renders
- * `FieldInputAdapter fieldType={FieldType.FILE}` as a bare value/onChange
- * one-liner anywhere - every FILE field in the app goes through a dedicated
- * uploader wired to `entityInstanceId` + the files pipeline
- * (`docs/files-upload-architecture-guide.md`), which is real work, not a
- * one-liner. Reported in the slot 1B handoff rather than guessed at here.
+ * ⚠️ **The Attachment row is not a `FieldInputAdapter`**, alone among the rows
+ * in this panel. `FieldInputAdapter`'s FILE case renders `FileInputField`,
+ * which reads its field and record off `usePropertyContext()` rather than the
+ * value/onChange pair every other row passes, so the field goes through
+ * {@link JournalEntryAttachment} and the files pipeline instead
+ * (`docs/files-upload-architecture-guide.md`).
+ *
+ * 🛑 That row needs a RECORD, and `useJournalEntryDraft` deliberately raises one
+ * on the first edit rather than on mount. A drawer opened at `?je=new` and not
+ * yet typed into therefore has nowhere to hang a file, and the row says so.
  */
 export function JournalEntryDrawer({
   journalEntryId,
@@ -91,6 +98,16 @@ export function JournalEntryDrawer({
 
   const periodsQuery = api.ledger.periods.useQuery()
   const { can } = useAccess()
+
+  // `journal_entry` is a HIDDEN def (`isVisible: false`), which is fine here:
+  // `resource.list` returns the whole org resources cache unfiltered, and only
+  // the sidebar reads `isVisible`. `null` on an org that has not picked up the
+  // field yet, in which case the row renders a sentence instead of a picker.
+  const { fields: journalEntryFields } = useResourceFields('journal-entries')
+  const attachmentField = useMemo(
+    () => journalEntryFields.find((f) => f.key === 'attachment') ?? null,
+    [journalEntryFields]
+  )
 
   const discard = useDiscardJournalEntry({ onDiscarded })
 
@@ -248,12 +265,21 @@ export function JournalEntryDrawer({
 
                 <FieldPanelRow
                   title='Attachment'
-                  type={BaseType.STRING}
+                  type={BaseType.FILE}
                   showIcon
-                  description='Not wired yet - see this file header. TODO for a follow-up slot.'>
-                  <span className='flex h-8 items-center text-sm text-muted-foreground'>
-                    Not available yet
-                  </span>
+                  description="The evidence behind the entry - the accountant's memo, a statement, a photo of the paper">
+                  {attachmentField && journalEntryId ? (
+                    <JournalEntryAttachment
+                      recordId={journalEntryId as RecordId}
+                      field={attachmentField}
+                    />
+                  ) : (
+                    <span className='flex h-8 items-center text-muted-foreground text-sm'>
+                      {attachmentField
+                        ? 'Type a date, memo or line first - a file needs an entry to hang on'
+                        : 'Not available on this organization yet'}
+                    </span>
+                  )}
                 </FieldPanelRow>
               </FieldPanel>
 

--- a/apps/web/src/components/fields/displays/display-text.tsx
+++ b/apps/web/src/components/fields/displays/display-text.tsx
@@ -1,15 +1,29 @@
 // apps/web/src/components/fields/displays/display-text.tsx
 
+import { Eye, EyeOff } from 'lucide-react'
+import { useState } from 'react'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
+import { FieldOptionButton } from './field-option-button'
+import { maskSensitive } from './mask-sensitive'
 
 /**
  * DisplayText component
  * Renders plain text value. Fields configured as multiline wrap onto several
  * lines and scroll internally past the cap; everything else stays single-line.
+ *
+ * 🛑 A field marked `sensitive` (a vendor's TIN is the motivating case) renders
+ * masked to its last four characters with a reveal toggle. The toggle is
+ * per-row and resets on unmount - revealing one TIN must never reveal the next
+ * record's. Copy still yields the REAL value: anybody who can reveal it can
+ * copy it, and a clipboard full of bullets is a bug, not a safeguard.
+ *
+ * ⚠️ This is a display hint and not an access control - see
+ * `ResourceField.sensitive`.
  */
 export function DisplayText() {
   const { value, field } = useFieldContext()
+  const [revealed, setRevealed] = useState(false)
   const wrap = field?.options?.multiline === true
 
   // Distinct from a null/absent value: an explicit empty string renders blank
@@ -19,6 +33,28 @@ export function DisplayText() {
   }
 
   const stringValue = value == null ? '' : String(value)
+  const isSensitive = field?.sensitive === true && stringValue !== ''
+
+  if (isSensitive) {
+    return (
+      <DisplayWrapper
+        wrap={false}
+        copyValue={stringValue}
+        buttons={[
+          <FieldOptionButton
+            key='reveal'
+            label={revealed ? 'Hide' : 'Reveal'}
+            onClick={() => setRevealed((r) => !r)}>
+            {revealed ? <EyeOff className='size-2.5' /> : <Eye className='size-2.5' />}
+          </FieldOptionButton>,
+        ]}>
+        <span className={revealed ? undefined : 'tracking-wider'}>
+          {revealed ? stringValue : maskSensitive(stringValue)}
+        </span>
+      </DisplayWrapper>
+    )
+  }
+
   return (
     <DisplayWrapper wrap={wrap} copyValue={stringValue || null}>
       {stringValue || '-'}

--- a/apps/web/src/components/fields/displays/mask-sensitive.test.ts
+++ b/apps/web/src/components/fields/displays/mask-sensitive.test.ts
@@ -1,0 +1,31 @@
+// apps/web/src/components/fields/displays/mask-sensitive.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { maskSensitive } from './mask-sensitive'
+
+describe('maskSensitive', () => {
+  it('keeps the last four characters of an EIN', () => {
+    expect(maskSensitive('12-3456789')).toBe('••••••6789')
+  })
+
+  it('keeps the last four characters of an SSN', () => {
+    expect(maskSensitive('123-45-6789')).toBe('•••••••6789')
+  })
+
+  // The one case where keeping the tail would reveal the whole value.
+  it('masks a value of exactly four characters entirely', () => {
+    expect(maskSensitive('6789')).toBe('••••')
+  })
+
+  it('masks a shorter value entirely', () => {
+    expect(maskSensitive('89')).toBe('••')
+  })
+
+  it('returns an empty string unchanged', () => {
+    expect(maskSensitive('')).toBe('')
+  })
+
+  it('preserves length, so the mask does not hint at a shorter secret', () => {
+    expect(maskSensitive('123456789012345')).toHaveLength(15)
+  })
+})

--- a/apps/web/src/components/fields/displays/mask-sensitive.ts
+++ b/apps/web/src/components/fields/displays/mask-sensitive.ts
@@ -1,0 +1,19 @@
+// apps/web/src/components/fields/displays/mask-sensitive.ts
+
+/** How many trailing characters a masked value keeps in the clear. */
+const VISIBLE_TAIL = 4
+
+/**
+ * Mask a sensitive field value down to its last {@link VISIBLE_TAIL}
+ * characters - the convention every bank statement and W-9 tool uses, and the
+ * shortest form that still lets somebody confirm they are looking at the right
+ * record.
+ *
+ * 🛑 A value of {@link VISIBLE_TAIL} characters or fewer is masked ENTIRELY.
+ * Keeping the tail of a four-character value reveals all of it, which is the
+ * one case where a "masked" render would be a lie.
+ */
+export function maskSensitive(value: string): string {
+  if (value.length <= VISIBLE_TAIL) return '•'.repeat(value.length)
+  return '•'.repeat(value.length - VISIBLE_TAIL) + value.slice(-VISIBLE_TAIL)
+}

--- a/packages/lib/scripts/add-dev-org-membership.ts
+++ b/packages/lib/scripts/add-dev-org-membership.ts
@@ -1,0 +1,75 @@
+// packages/lib/scripts/add-dev-org-membership.ts
+//
+// DEV ONLY. Adds a user to an organization as OWNER so a developer can drive a
+// seeded org in the browser.
+//
+// 🛑 There is no product reason for this script to exist: membership is granted
+// by an invitation, and this bypasses that whole path. It exists because the
+// seeded demo orgs and the seeded login user are not the same set - DemoOrg1
+// carries the working books that every accounting browser pass drives against,
+// and `markus@auxx.ai` (the account whose dev password is known) is not in it.
+//
+// Idempotent - a user who is already a member is left exactly as they are,
+// role included.
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/add-dev-org-membership.ts <email> <orgName>
+
+import { closePools, database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { onCacheEvent } from '../src/cache'
+
+async function main() {
+  const [email, orgName] = process.argv.slice(2)
+  if (!email || !orgName) {
+    console.error('usage: add-dev-org-membership.ts <email> <orgName>')
+    process.exit(1)
+  }
+
+  const [user] = await database
+    .select({ id: schema.User.id })
+    .from(schema.User)
+    .where(eq(schema.User.email, email))
+  if (!user) throw new Error(`No user ${email}`)
+
+  const [org] = await database
+    .select({ id: schema.Organization.id })
+    .from(schema.Organization)
+    .where(eq(schema.Organization.name, orgName))
+  if (!org) throw new Error(`No organization named ${orgName}`)
+
+  const [existing] = await database
+    .select({ id: schema.OrganizationMember.id, role: schema.OrganizationMember.role })
+    .from(schema.OrganizationMember)
+    .where(
+      and(
+        eq(schema.OrganizationMember.userId, user.id),
+        eq(schema.OrganizationMember.organizationId, org.id)
+      )
+    )
+
+  if (existing) {
+    console.log(`${email} is already a member of ${orgName} as ${existing.role} - left alone`)
+  } else {
+    await database.insert(schema.OrganizationMember).values({
+      userId: user.id,
+      organizationId: org.id,
+      role: 'OWNER',
+      status: 'ACTIVE',
+      updatedAt: new Date(),
+    })
+    // 🛑 The org cache is what `isMember` reads, and a direct INSERT fires no
+    // event of its own - so without this the switcher answers "Not a member of
+    // this organization" against a row that plainly exists.
+    await onCacheEvent('member.added', { orgId: org.id, userId: user.id, broadcastUserKeys: true })
+    console.log(`Added ${email} to ${orgName} as OWNER, and busted the member cache`)
+  }
+
+  await closePools()
+  process.exit(0)
+}
+
+main().catch(async (error) => {
+  console.error(error)
+  await closePools()
+  process.exit(1)
+})

--- a/packages/lib/src/money/invoices/__tests__/write-off.test.ts
+++ b/packages/lib/src/money/invoices/__tests__/write-off.test.ts
@@ -176,7 +176,7 @@ describe('writeOffInvoice - refusals before the ledger is ever asked', () => {
     ).rejects.toBeInstanceOf(NotFoundError)
   })
 
-  it.each(['void', 'written_off', 'draft', 'paid'])('refuses a %s invoice', async (status) => {
+  it.each(['void', 'draft'])('refuses a %s invoice on its status alone', async (status) => {
     wireInvoice(status)
     await expect(
       writeOffInvoice(stubDb(), {
@@ -187,6 +187,51 @@ describe('writeOffInvoice - refusals before the ledger is ever asked', () => {
       })
     ).rejects.toBeInstanceOf(BadRequestError)
     expect(h.postEntry).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'written_off',
+    'paid',
+  ])('refuses a %s invoice with nothing outstanding', async (status) => {
+    wireInvoice(status, { balanceMinor: 0, totalMinor: 50_000, amountPaidMinor: 50_000 })
+    await expect(
+      writeOffInvoice(stubDb(), {
+        organizationId: ORG,
+        actorUserId: USER,
+        invoiceId: INVOICE,
+        reason: 'Bankrupt',
+      })
+    ).rejects.toBeInstanceOf(BadRequestError)
+    expect(h.postEntry).not.toHaveBeenCalled()
+  })
+
+  // 🛑 The regression this pins was found in a BROWSER, not here, because both
+  // halves were individually right. `readWriteOffState` derives what is still
+  // outstanding and the dialog opens prefilled with it; the guard refused on the
+  // STATUS, so every preview and post against a `written_off` row that still
+  // carried a receivable failed with "already written off" and the balance was
+  // unreachable by every door at once. A row can reach that state by being
+  // written off before entity migration 128 existed.
+  it('allows a written_off invoice that still carries a receivable', async () => {
+    wireInvoice('written_off', {
+      balanceMinor: 49_583,
+      totalMinor: 72_583,
+      amountPaidMinor: 3_000,
+      writtenOffMinor: 20_000,
+    })
+    h.postEntry.mockResolvedValue({ status: 'posted', glPostingId: 'gl-1' })
+
+    await writeOffInvoice(stubDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      invoiceId: INVOICE,
+      reason: 'Bankrupt',
+    })
+
+    // Everything still outstanding, not the whole invoice a second time:
+    // 72,583 total less 3,000 paid less the 20,000 already written off.
+    expect(h.postEntry).toHaveBeenCalledTimes(1)
+    expect(h.postEntry.mock.calls[0]![1].entry.totalDebit).toBe(49_583)
   })
 
   it('refuses an amount over the invoice balance', async () => {

--- a/packages/lib/src/money/invoices/write-off.ts
+++ b/packages/lib/src/money/invoices/write-off.ts
@@ -226,16 +226,29 @@ function assertWriteOffAllowed(invoice: InvoiceForWriteOff, invoiceId: string): 
   if (invoice.status === 'void') {
     throw new BadRequestError('Cannot write off a void invoice', { invoiceId })
   }
-  if (invoice.status === 'written_off') {
-    throw new BadRequestError('This invoice is already written off', { invoiceId })
-  }
   if (invoice.status === 'draft') {
     throw new BadRequestError('Cannot write off a draft invoice - send it first', { invoiceId })
   }
-  if (invoice.status === 'paid') {
-    throw new BadRequestError('This invoice has no balance to write off - it is paid in full', {
-      invoiceId,
-    })
+  // 🛑 "Nothing left to write off" is decided by the DERIVED outstanding figure,
+  // never by the status. `written_off` and `paid` are each meant to imply a zero
+  // receivable, but neither is a reliable statement of one:
+  // `syncInvoicePaymentState` rewrites the balance mirror on every payment event
+  // knowing nothing about bad debt, and a row written off before entity
+  // migration 128 can carry `written_off` while a real receivable is still on it.
+  //
+  // ⚠️ Refusing on the status alone is what made {@link readWriteOffState} and
+  // this function disagree: the dialog opened prefilled with the remainder that
+  // read is built to compute, and every preview and post against it then failed
+  // with "already written off". Found in a browser, not by a test, because both
+  // halves are individually correct - only the pair is wrong. Both now key on
+  // `outstandingMinor`, so the screen cannot offer what this will refuse.
+  if (invoice.outstandingMinor <= 0) {
+    throw new BadRequestError(
+      invoice.status === 'written_off'
+        ? 'This invoice has no balance to write off - it is already written off in full'
+        : 'This invoice has no balance to write off - it is paid in full',
+      { invoiceId }
+    )
   }
   if (!invoice.number || invoice.number.trim().length === 0) {
     throw new BadRequestError(
@@ -417,9 +430,12 @@ export interface WriteOffInvoiceInput {
  *    it, the only trace was a reduction of `invoice_balance` that the next
  *    `syncInvoicePaymentState` re-derived away.
  *
- * `assertWriteOffAllowed` still refuses a `written_off` invoice before the
- * ledger is ever asked, with a sentence a person can act on: that status means
- * the whole receivable is gone, and only a full write-off sets it.
+ * `assertWriteOffAllowed` refuses on the DERIVED outstanding figure rather than
+ * on the status, so an invoice a partial write-off left with a receivable is
+ * still writable no matter what its status says. Only a full write-off sets
+ * `written_off`, but rows written off before entity migration 128 can carry that
+ * status with a balance still on them, and refusing those made the dialog offer
+ * an amount every preview and post then rejected.
  *
  * ⚠️ Still owed, in a file this does not own: `syncInvoicePaymentState`
  * computes `balance = total - amountPaid` and knows nothing about

--- a/packages/lib/src/resources/registry/field-types.ts
+++ b/packages/lib/src/resources/registry/field-types.ts
@@ -152,6 +152,29 @@ export interface ResourceField {
   /** Field description for help text */
   description?: string
 
+  /**
+   * The value is SECRET ENOUGH TO HIDE BY DEFAULT — a taxpayer identification
+   * number is the motivating case. A sensitive field renders masked to its last
+   * four characters wherever `DisplayText` draws it, with a per-row reveal.
+   *
+   * 🛑 This is a DISPLAY hint, never an access control. The value is on the
+   * wire, in `fieldValue.batchGet`, in the API and in an export exactly as it
+   * was before; anyone who can read the record can read the number. It exists so
+   * a vendor's SSN is not sitting in plain sight on a shared screen, which is
+   * the actual threat for this class of field. Do not reach for it to keep a
+   * value from somebody — that is what permissions are for.
+   *
+   * ⚠️ Honoured by `DisplayText` (the panel and drawer read display) only. The
+   * dynamic table renders its own non-editing cell content and does NOT mask,
+   * so do not mark a field sensitive and assume the grid followed.
+   *
+   * Registry-only, like {@link ResourceField.naturalKeyPosition}: whether a TIN
+   * is sensitive is a product fact and no `CustomField` column carries one.
+   *
+   * @optional
+   */
+  sensitive?: boolean
+
   // Validation rules
   validation?: FieldValidation
 

--- a/packages/lib/src/resources/registry/resource-registry-service.ts
+++ b/packages/lib/src/resources/registry/resource-registry-service.ts
@@ -967,6 +967,10 @@ export class ResourceRegistryService {
           // per-org boolean could ever express it, and `CustomField.isUnique` is
           // the wrong shape anyway — a tuple is not a per-field flag.
           naturalKeyPosition: staticField.naturalKeyPosition,
+          // SENSITIVE is registry-only for the same reason, and with no DB
+          // fallback: whether a TIN is secret enough to hide by default is a
+          // product fact, and `CustomField` has no column that could carry one.
+          sensitive: staticField.sensitive,
           // A NAMED IMPORTER is registry-only for the same reason: whether users
           // import supplier price lists is a product fact, and no `CustomField`
           // column carries one. It rides the relation field so the target def is

--- a/packages/lib/src/resources/registry/resources/company-fields.ts
+++ b/packages/lib/src/resources/registry/resources/company-fields.ts
@@ -790,15 +790,17 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     placeholder: 'XX-XXXXXXX',
-    // 🛑 No masking mechanism exists in the registry today: `ResourceField`'s
-    // `capabilities` carry no `sensitive`/`mask` flag anywhere in this repo
-    // (checked - grep turns up nothing). This is a plain TEXT field; masking
-    // the SSN/EIN in the company drawer is left to the drawer UI, which is not
-    // this slot's file. Flagged in the 2K report rather than left silent.
+    // 🛑 The whole reason `ResourceField.sensitive` exists. An SSN or EIN sitting
+    // in plain sight on a vendor drawer is the thing to avoid, so the panel shows
+    // `•••••1234` with a per-row reveal.
+    //
+    // ⚠️ Display only. The number is on the wire and in an export exactly as it
+    // was, and the dynamic table does not mask - see the flag's own doc.
+    sensitive: true,
     description:
       "The vendor's taxpayer identification number (SSN or EIN), from Form W-9. " +
-      'Not filterable - a TIN is never a lookup key. Should be masked on display; ' +
-      'no masking capability exists in the field registry yet.',
+      'Not filterable - a TIN is never a lookup key. Masked to its last four ' +
+      'characters on display, with a reveal.',
   },
 
   w9OnFile: {

--- a/packages/ui/src/components/stat-card.tsx
+++ b/packages/ui/src/components/stat-card.tsx
@@ -84,7 +84,11 @@ export function StatCard({
       </div>
       <div className='pt-1 px-3 pb-3'>
         <div className='text-2xl font-bold'>{body}</div>
-        <div className='text-xs text-muted-foreground'>{description}</div>
+        <div
+          className='text-xs text-muted-foreground line-clamp-2'
+          title={typeof description === 'string' ? description : undefined}>
+          {description}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Four loose ends the accounting pass left open, none of which depend on each
other. The Stripe payout trigger is the fifth and is in
#2058 instead, because it carries two entity migrations and a
production dependency these do not.

## The write-off guard and a draft's number

Two defects found by driving #2055 in a browser against DemoOrg1, both of which
every unit test passed.

`assertWriteOffAllowed` refused `status === 'written_off'` outright while
`readWriteOffState` — the read that drives the dialog — never called it. So the
dialog opened on INV-0005 prefilled with the $495.83 it correctly derived, and
`money.previewWriteOff` answered 400 *"This invoice is already written off"*. Both
halves were individually correct; only the pair was wrong, which is why 40 tests
missed it — a test per function cannot see two functions disagreeing about the
same question.

The guard now refuses on the derived `outstandingMinor <= 0` so the two key on
one figure and the screen cannot offer what the server refuses. `void` and
`draft` still refuse on status, because those are statements about the document
rather than about the balance. 🛑 A row can carry `written_off` with a real
receivable on it by having been written off before entity migration 128 existed,
so this is a live repair rather than a guard tidy-up.

`use-journal-entry-draft` claims `loadedIdRef` inside the create `onSuccess` so
the load-from-server effect cannot overwrite what is being typed, but `setNumber`
only ever ran in that effect. A draft minted in this session kept `number: null`
and its Discard confirm read *"Discard this journal entry?"* instead of naming
`JNL-0011`.

## The journal entry attachment

The drawer has carried *"Attachment: TODO, not wired"* since #2054, on the
grounds that no bare `FieldInputAdapter fieldType={FILE}` value/onChange
one-liner exists. True, but the wrong way round: **`useFieldFileUpload` takes
`recordId`/`fieldRef` as plain arguments**, so no `PropertyProvider` indirection
is needed at all, and `line-photo-popover.tsx` had already established exactly
this pattern for `line_item_photos`.

Two decisions worth not relitigating:

- **The row needs a RECORD, and `useJournalEntryDraft` raises one on the first
  EDIT rather than on mount.** A drawer opened at `?je=new` and not yet typed
  into says so in a sentence rather than rendering a picker that would fail. Do
  not "fix" this by creating the draft on mount — that leaves an abandoned `JNL-`
  number behind every time somebody opens the drawer and closes it, which is the
  whole reason `tasks/09` exists.
- **The attachment stays editable after the entry posts**, alone among the
  drawer's controls. It is evidence *about* the entry rather than part of it,
  nothing on this path reaches `GlPostingLine`, and a statement that turns up a
  week after the close is exactly the thing somebody needs to staple on.

## TIN masking

`company_tin` said *"should be masked on display; no masking capability exists in
the field registry yet"*. There is one now: **`ResourceField.sensitive`**,
honoured by `DisplayText`, which renders the value masked to its last four
characters with a per-row reveal. Registry-only and promoted beside
`naturalKeyPosition`, because whether a TIN is secret is a product fact and no
`CustomField` column carries one.

🛑 **It is a display hint and never an access control.** The value is on the
wire, in `fieldValue.batchGet`, in the API and in an export exactly as it was.

⚠️ **The dynamic table does not mask** — it renders its own non-editing cell
content rather than going through `DisplayField`. `company_tin` is
`filterable: false, sortable: false` and is not a default column, so this is a
gap rather than a live leak, but do not mark a field sensitive and assume the
grid followed. The flag's own doc says so.

## The review stats strip

The four cards on the banking review page were the only stat strip in the app
with no `color`, so they read grey next to the tasks and workflows strips. The
two date bodies also drop to `text-lg` — a date is wider than a count or an
amount and overflowed a narrow column at the card's default `text-2xl`.

`StatCard`'s description had no height ceiling, so the review strip's long
sentences wrapped to four lines and made every card in the row that tall. It is
now `line-clamp-2` with the full string on `title` for hover. That is in the
shared component, so it applies to every stat strip — no consumer wants a
four-line description, and the review descriptions (by far the longest in the
app) are shortened too, so at normal widths the clamp never bites.

## The dev script

Driving any of this needs an account that can reach DemoOrg1, and
`markus@auxx.ai` is not a member of it. 🛑 A direct INSERT into
`OrganizationMember` is **not** enough — `isMember` reads the org CACHE, so the
switcher answers *"Not a member of this organization"* against a row that plainly
exists, and nothing says why. The script fires `member.added` for that reason.

## Testing

- `mask-sensitive.test.ts`, 6 new tests.
- `write-off.test.ts` green (20).
- `packages/lib` typecheck ratchet clean against the tightened baseline (27/27);
  `@auxx/web` typecheck clean.
- The write-off dialog and the discard round trip were driven in a browser
  against DemoOrg1 when the fixes were written. **The attachment row and the TIN
  mask have not been driven** — they are unit-tested and typechecked only.

https://claude.ai/code/session_01S8TCUftQc1G3FaQrEuzeVp