### PR TITLE
fix(banking): give the bank feed's webhook an endpoint it can actually reach

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,13 @@ STRIPE_PUBLISHABLE_KEY=
 STRIPE_CONNECT_WEBHOOK_SECRET=
 PAYMENTS_APPLICATION_FEE_PERCENT=2
 
+# Bank feed (Stripe Financial Connections) webhook, served by /api/banking/webhook.
+# A third Stripe secret because this is a third ENDPOINT: Stripe signs per endpoint, and an
+# endpoint's delivery mode (platform vs connected accounts) is fixed when it is created.
+# FC accounts belong to the platform account, so their events are platform events and cannot
+# arrive on the Connect endpoint above.
+STRIPE_BANKING_WEBHOOK_SECRET=
+
 # ------------------------------------
 # Realtime & Analytics
 # ------------------------------------

--- a/apps/web/src/app/api/banking/webhook/route.test.ts
+++ b/apps/web/src/app/api/banking/webhook/route.test.ts
@@ -1,0 +1,92 @@
+// apps/web/src/app/api/banking/webhook/route.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { POST } from './route'
+
+/**
+ * The delivery contract of the bank feed's PLATFORM endpoint (plans/bank-connection/06 §3).
+ *
+ * Pinned because the previous mounting point was unreachable and nothing noticed: the FC cases
+ * lived in `applyStripeEvent`, which only a CONNECT endpoint reaches, so four handlers shipped
+ * and never once ran. The three behaviours below are the ones an unreachable or over-eager
+ * endpoint gets wrong: a bad signature must not retry, an event type this endpoint does not own
+ * must not 500, and a real failure must.
+ */
+
+const verifyStripeSignature = vi.fn(() => true)
+const applyFinancialConnectionsEvent = vi.fn(async () => {})
+
+vi.mock('@auxx/credentials', () => ({
+  configService: { get: () => 'whsec_test' },
+}))
+vi.mock('@auxx/lib/webhooks', () => ({
+  verifyStripeSignature: (...args: unknown[]) => verifyStripeSignature(...(args as [])),
+}))
+vi.mock('@auxx/lib/banking', () => ({
+  isFinancialConnectionsEvent: (type: string) => type.startsWith('financial_connections.'),
+  applyFinancialConnectionsEvent: (...args: unknown[]) =>
+    applyFinancialConnectionsEvent(...(args as [])),
+}))
+vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
+
+const URL_BASE = 'https://app.auxx.ai/api/banking/webhook'
+
+const request = (event: unknown, headers: Record<string, string> = { 'stripe-signature': 't=1' }) =>
+  new Request(URL_BASE, { method: 'POST', headers, body: JSON.stringify(event) }) as never
+
+const fcEvent = {
+  id: 'evt_1',
+  type: 'financial_connections.account.disconnected',
+  data: { object: { id: 'fca_1' } },
+}
+
+beforeEach(() => {
+  verifyStripeSignature.mockClear().mockReturnValue(true)
+  applyFinancialConnectionsEvent.mockClear().mockResolvedValue(undefined)
+})
+
+describe('signature verification', () => {
+  it('rejects a request with no stripe-signature header with 400', async () => {
+    const response = await POST(request(fcEvent, {}))
+
+    expect(response.status).toBe(400)
+    expect(applyFinancialConnectionsEvent).not.toHaveBeenCalled()
+  })
+
+  it('rejects a bad signature with 400 so Stripe does not retry an untrusted payload', async () => {
+    verifyStripeSignature.mockReturnValue(false)
+
+    const response = await POST(request(fcEvent))
+
+    expect(response.status).toBe(400)
+    expect(applyFinancialConnectionsEvent).not.toHaveBeenCalled()
+  })
+})
+
+describe('dispatch', () => {
+  it('hands a Financial Connections event to the feed handler', async () => {
+    const response = await POST(request(fcEvent))
+
+    expect(response.status).toBe(200)
+    expect(applyFinancialConnectionsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'financial_connections.account.disconnected' })
+    )
+  })
+
+  it('answers 200 and does nothing for a type this endpoint does not own', async () => {
+    // Not an error: a platform endpoint can be sent types it never asked for, and a 500 here
+    // would make Stripe redeliver forever and eventually disable the endpoint.
+    const response = await POST(request({ id: 'evt_2', type: 'charge.succeeded', data: {} }))
+
+    expect(response.status).toBe(200)
+    expect(applyFinancialConnectionsEvent).not.toHaveBeenCalled()
+  })
+
+  it('answers 500 on a processing failure so Stripe retries the delivery', async () => {
+    applyFinancialConnectionsEvent.mockRejectedValue(new Error('db down'))
+
+    const response = await POST(request(fcEvent))
+
+    expect(response.status).toBe(500)
+  })
+})

--- a/apps/web/src/app/api/banking/webhook/route.ts
+++ b/apps/web/src/app/api/banking/webhook/route.ts
@@ -1,0 +1,72 @@
+// apps/web/src/app/api/banking/webhook/route.ts
+// Stripe PLATFORM webhook handler for the bank feed (plans/bank-connection/06 §3) — its OWN
+// endpoint + secret (`STRIPE_BANKING_WEBHOOK_SECRET`).
+//
+// 🛑 It cannot share `api/payments/webhook`. That endpoint is registered with Stripe in
+// "connected accounts" delivery mode, and Financial Connections sessions are created with no
+// `{ stripeAccount }` (`banking/feed/fc-client.ts`), so FC events are PLATFORM events and never
+// arrive there. Delivery mode is fixed per endpoint and Stripe signs per endpoint, so a second
+// endpoint at the same URL would fail signature verification against the Connect secret — hence
+// a third Stripe secret.
+
+export const runtime = 'nodejs'
+
+import { configService } from '@auxx/credentials'
+import { verifyStripeSignature } from '@auxx/lib/webhooks'
+import { createScopedLogger } from '@auxx/logger'
+import { type NextRequest, NextResponse } from 'next/server'
+import type Stripe from 'stripe'
+
+const logger = createScopedLogger('banking-webhook')
+
+/**
+ * Handles the four Financial Connections events the bank feed acts on: refreshed transactions,
+ * disconnect, deactivate and reactivate. `applyFinancialConnectionsEvent` is an idempotent
+ * reducer, so a Stripe redelivery is always safe. Bad signatures 400 (no retry, the payload is
+ * untrusted); an event type this endpoint does not handle is a plain 200, not an error; a real
+ * processing failure 500s so Stripe retries the delivery.
+ */
+export async function POST(req: NextRequest) {
+  const body = await req.text()
+  const signature = req.headers.get('stripe-signature')
+
+  if (!signature) {
+    logger.error('Missing stripe-signature header')
+    return NextResponse.json({ error: 'No signature' }, { status: 400 })
+  }
+
+  const webhookSecret = configService.get<string>('STRIPE_BANKING_WEBHOOK_SECRET')
+  if (
+    !webhookSecret ||
+    !verifyStripeSignature({ rawBody: body, header: signature, secret: webhookSecret })
+  ) {
+    logger.error('Stripe banking webhook signature verification failed')
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
+  }
+
+  const event = JSON.parse(body) as Stripe.Event
+
+  // Lazy-imported so this route never statically pulls the connector engine into web's module
+  // graph. The membership test and the handler both come from `banking/feed/webhook.ts`, so the
+  // event-type list and the code that implements it cannot drift.
+  const { applyFinancialConnectionsEvent, isFinancialConnectionsEvent } = await import(
+    '@auxx/lib/banking'
+  )
+
+  if (!isFinancialConnectionsEvent(event.type)) return NextResponse.json({ success: true })
+
+  try {
+    await applyFinancialConnectionsEvent(
+      event as unknown as Parameters<typeof applyFinancialConnectionsEvent>[0]
+    )
+  } catch (error) {
+    logger.error('Banking webhook processing failed', {
+      eventId: event.id,
+      eventType: event.type,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return NextResponse.json({ error: 'Processing failed' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/infra/secrets.ts
+++ b/infra/secrets.ts
@@ -201,6 +201,10 @@ export const secretsConfig = {
     secret: new sst.Secret('STRIPE_CONNECT_WEBHOOK_SECRET'),
     description: 'Stripe Connect payments webhook endpoint secret',
   },
+  STRIPE_BANKING_WEBHOOK_SECRET: {
+    secret: new sst.Secret('STRIPE_BANKING_WEBHOOK_SECRET'),
+    description: 'Stripe platform webhook endpoint secret for the bank feed',
+  },
   STRIPE_PUBLISHABLE_KEY: {
     secret: new sst.Secret('STRIPE_PUBLISHABLE_KEY'),
     description: 'Stripe publishable key for client-side',

--- a/packages/credentials/src/config/config-registry.ts
+++ b/packages/credentials/src/config/config-registry.ts
@@ -851,6 +851,22 @@ export const CONFIG_VARIABLES = {
     isSensitive: true,
     isEnvOnly: false,
   },
+  // A THIRD Stripe signing secret, because it is a third ENDPOINT. Stripe signs per
+  // endpoint, and an endpoint's delivery mode (platform vs connected accounts) is fixed
+  // when the endpoint is created. Financial Connections accounts belong to the platform
+  // account, so the bank feed's events are platform events and cannot arrive on the
+  // Connect endpoint above (plans/bank-connection/06). Served by /api/banking/webhook.
+  // `group: BILLING` matches its siblings so it lands beside them in the admin config UI,
+  // even though it serves the bank feed rather than billing.
+  STRIPE_BANKING_WEBHOOK_SECRET: {
+    key: 'STRIPE_BANKING_WEBHOOK_SECRET',
+    description:
+      'Stripe platform webhook signing secret for the bank feed (Financial Connections events)',
+    type: ConfigVariableType.STRING,
+    group: ConfigVariableGroup.BILLING,
+    isSensitive: true,
+    isEnvOnly: false,
+  },
   PAYMENTS_APPLICATION_FEE_PERCENT: {
     key: 'PAYMENTS_APPLICATION_FEE_PERCENT',
     description: 'Default application fee percent charged on Stripe Connect payments (money MP1)',

--- a/packages/lib/src/money/payments/stripe-rail.ts
+++ b/packages/lib/src/money/payments/stripe-rail.ts
@@ -872,33 +872,21 @@ export async function applyStripeEvent(event: Stripe.Event): Promise<void> {
       return
     }
 
-    default: {
-      // ── The bank feed (plans/bank-connection/01 §3, HANDOFF slot 3A) ──────────
+    default:
+      // 🛑 The Financial Connections dispatch that used to live here now lives in
+      // `apps/web/src/app/api/banking/webhook/route.ts`. Do not put it back.
       //
-      // 🛑 ONE case, and it names no provider logic of its own: it asks the feed
-      // module whether this event type is one of its four, and hands the event over.
-      // The list and the handler live together in `banking/feed/webhook.ts` so they
-      // cannot drift - a case list here that fell behind the handler would silently
-      // stop routing an event type, and a bank feed that stops and says nothing is
-      // the most expensive bug in this subsystem.
+      // FC sessions are created with no `{ stripeAccount }` (`banking/feed/fc-client.ts`),
+      // so every `fca_...` account belongs to the platform and Stripe emits its events as
+      // PLATFORM events. This reducer is only ever reached from `api/payments/webhook`,
+      // which is registered in Stripe's "connected accounts" delivery mode - so the branch
+      // could not fire in any environment, and did not, for the four days it existed
+      // (plans/bank-connection/06). The bank feed needs its own platform endpoint and its
+      // own signing secret; a case here is not a substitute for either.
       //
-      // The lookup it does (`fca_...` → `Credential.metadata.providerAccountId` →
-      // `DataConnector`) exists nowhere else: both webhook dispatch jobs key on
-      // org-scoped ids that a PLATFORM Stripe event does not carry
-      // (plans/accounting/implementation-review.md §2).
-      //
-      // Lazy-imported so `money/` never statically pulls the connector engine.
-      // A throw propagates: the route 500s and Stripe retries, which is what we want.
-      const { applyFinancialConnectionsEvent, isFinancialConnectionsEvent } = await import(
-        '../../banking/feed/webhook'
-      )
-      if (isFinancialConnectionsEvent(event.type)) {
-        await applyFinancialConnectionsEvent(
-          event as unknown as Parameters<typeof applyFinancialConnectionsEvent>[0]
-        )
-      }
+      // Everything else that lands here is a genuinely unknown event type: ignore it, so
+      // the route answers 200 and Stripe stops redelivering.
       return
-    }
   }
 }
 


### PR DESCRIPTION
#2054 shipped four Financial Connections webhook cases and **they have never
fired, in any environment.** The handler is correct; its mounting point is
unreachable.

## The defect

`createFinancialConnectionsSession` (`banking/feed/fc-client.ts:167`) creates the
session with **no `{ stripeAccount }`**, so every `fca_…` account belongs to the
PLATFORM account and Stripe emits its events as platform events. The dispatch
lived in `applyStripeEvent`'s `default:` block, which is only ever reached from
`api/payments/webhook` — and both of those endpoints are registered in Stripe's
**"connected accounts"** delivery mode (`application: ca_…`, confirmed by reading
the live API on both the dev and prod accounts). Delivery mode is fixed per
endpoint, so the branch could not fire and did not.

It also cannot be fixed by ticking the four types onto the existing endpoint, and
it cannot share that endpoint's URL: the route verifies against
`STRIPE_CONNECT_WEBHOOK_SECRET` only, and Stripe signs per endpoint, so a second
endpoint at the same URL would 400 on every delivery.

## 🛑 What was actually broken

**Not sync latency.** `data-connectors/data-connector-scheduler.ts` registers a
per-connector cron, so transactions still arrive. Losing
`refreshed_transactions` costs promptness, not data. (`bankFeedMaintenanceJob` is
not a syncer — it is the reaper, plus coverage and rule suggestions.)

**Silent disconnect, which is the reason to fix this.** `markFeedDisconnected`
has exactly one caller: the `disconnected` / `deactivated` cases. The only other
write of `status: 'disconnected'` is `actions.ts:187` — the user clicking
Disconnect in our own UI. So when a bank drops the link at the institution
(expired login, MFA re-auth, revoked at the bank):

- the connector stays `connected`;
- the settings page reports the feed healthy;
- the non-dismissible disconnect banner never appears;
- the reaper never starts its fourteen-day clock, so the dead FC account keeps
  billing 30¢/month.

That is precisely the failure the handler's own comment cites (#2049, #2050,
#2051, data-connectors guide §18): *a disconnected connector is structurally
indistinguishable from a healthy one, so every automated door has to ask the
status* — and nothing was setting the status. `.reactivated` →
`markFeedReconnected` is dead the same way, so a feed that recovers stays marked
broken.

## What lands

- **`apps/web/src/app/api/banking/webhook/route.ts`** — a platform endpoint
  mirroring the payments route: missing/bad signature → 400 (no retry, the
  payload is untrusted); an event type it does not handle → a plain 200, not an
  error; a real processing failure → 500 so Stripe retries, which is the contract
  `applyFinancialConnectionsEvent` already documents. The banking module is
  lazy-imported so the route never statically pulls the connector engine into
  web's module graph, and both the membership test and the handler come from
  `banking/feed/webhook.ts` so the event-type list and its implementation still
  cannot drift.
- **The dead branch is DELETED** from `applyStripeEvent`, replaced by a comment
  naming the new route and explaining platform-vs-Connect. Leaving it would be
  worse than useless: a code path that reads as working and cannot fire is what
  made this invisible for four days.
- **`STRIPE_BANKING_WEBHOOK_SECRET`** — a third Stripe secret because it is a
  third *endpoint*, and Stripe signs per endpoint. Declared in `.env.example`,
  `packages/credentials/src/config/config-registry.ts` and `infra/secrets.ts`.

Deliberately **not** added to `apps/web/.env.example` (which states at the top
that only env-only and boot-critical vars belong there, and carries no `STRIPE_*`
keys at all) or `apps/worker/.env.example` (the worker never verifies a webhook
signature, and its file omits `STRIPE_CONNECT_WEBHOOK_SECRET` for the same
reason).

## Alternatives rejected

**Reuse the existing platform endpoint** (`/api/billing/webhook`) — genuinely
tempting, since it needs no new endpoint and no new secret. Rejected primarily
because `billing/webhook/route.ts:65` returns **404 outright when
`isSelfHosted()`**, so every self-hosted deployment would lose bank webhooks
permanently and silently. It also imports `@auxx/billing`, `getProvider`, the
AI-quota handlers and `handlePlanDowngrade`, putting bank-feed health behind
billing's — and the payments route's own header says *"Never routes through
`@auxx/billing`"*.

**Dual-secret verification on the payments route** — needs the same env var and
the same second endpoint, so it saves no configuration; it only adds a
"try both secrets" branch.

**Create the FC session on the connected account** — would orphan every FC
account already connected and tie the bank feed to completed Connect onboarding.
The delivery channel is what is wrong, not the account model.

## 🛑 Deployment order

**Merge and deploy this before registering anything in Stripe.** An endpoint
created ahead of the route collects 404s, and Stripe disables an endpoint that
fails for long enough. `https://app.auxx.ai/api/banking/webhook` currently
returns 404; `/api/payments/webhook` returns 400, i.e. exists and correctly
rejected an unsigned POST.

After deploy, in order: create one platform endpoint per account
(`webhookEndpoints.create({ connect: false, … })`) carrying exactly

```
financial_connections.account.refreshed_transactions
financial_connections.account.disconnected
financial_connections.account.deactivated
financial_connections.account.reactivated
```

then set the returned `whsec_…` as `STRIPE_BANKING_WEBHOOK_SECRET` in Railway.
`IS_CONFIG_VARIABLES_IN_DB_ENABLED` is `false` in production, so the environment
variable is the only source there — this is not settable at `/admin/config`.

Verify by sending a test `financial_connections.account.disconnected` (expect
200) and confirming `DataConnector.lastWebhookEventAt` moves — that column is
stamped on every FC event before the switch, so it is the cleanest single proof
that delivery works.

## Testing

- `apps/web/src/app/api/banking/webhook/route.test.ts` — 5 tests, following the
  existing colocated route-test pattern (`api/outlook/webhook/route.test.ts`):
  missing header → 400, bad signature → 400, FC event → handler called, non-FC
  type → 200 with no handler call, handler throws → 500.
- `packages/lib` `src/banking src/money/payments`: 356 tests green. The existing
  `banking/feed/__tests__/webhook.test.ts` imports the handler directly, so it is
  unaffected by the dispatch moving.
- `@auxx/web` typecheck exit 0; lib ratchet clean at 27/27.

Plan and full evidence: `plans/bank-connection/06-platform-webhook-delivery.md`

https://claude.ai/code/session_01S8TCUftQc1G3FaQrEuzeVp
