### PR TITLE
fix(banking): release FC accounts on delete, and let a bank account be removed

### DIFF
--- a/apps/web/src/components/accounting/ui/bank-account-badge.tsx
+++ b/apps/web/src/components/accounting/ui/bank-account-badge.tsx
@@ -59,7 +59,11 @@ export function BankAccountBadge({
 }: BankAccountBadgeProps) {
   // Cheap: React Query dedupes this against every other reader on the screen,
   // and the badge never issues a request of its own for a single account.
-  const { accounts } = useBankAccounts()
+  //
+  // ⚠️ Archived included. This badge NAMES a stored id rather than offering a
+  // choice, and an archived account that a record still points at has to keep
+  // rendering as itself instead of falling back to "Unassigned account".
+  const { accounts } = useBankAccounts({ includeArchived: true })
   const resolved = account ?? accounts.find((row) => row.id === bankAccountId) ?? null
 
   if (!resolved) {

--- a/apps/web/src/components/accounting/ui/bank-account-picker.tsx
+++ b/apps/web/src/components/accounting/ui/bank-account-picker.tsx
@@ -3,15 +3,20 @@
 'use client'
 
 import type { BankAccountRow } from '@auxx/lib/banking/client'
+import { PermissionKey } from '@auxx/lib/permissions/client'
 import type { SelectOption } from '@auxx/types/custom-field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { useMemo, useState } from 'react'
+import { Landmark } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
 import { BankInstitutionIcon } from '~/components/accounting/ui/bank-institution-icon'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
 import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
+import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
+import { BankAccountConnectDialog } from './settings/bank-account-connect-dialog'
+import { BankAccountManualDialog } from './settings/bank-account-manual-dialog'
 
 /**
  * Reads the org's bank accounts through `banking.bankAccount.list`.
@@ -22,16 +27,30 @@ import { api } from '~/trpc/react'
  * review queue's empty state, the rules list's name lookup) can keep its own
  * `useQuery` without a second roundtrip.
  *
+ * 🛑 **The query always asks for archived rows and the filtering happens here.**
+ * One key across the whole app is what keeps the dedupe working; asking the
+ * server twice with two different inputs would put a second roundtrip on every
+ * screen that renders a picker beside a list. What each caller gets is decided
+ * by `includeArchived`, which defaults to false so nothing existing changes.
+ *
+ * ⚠️ A caller that RESOLVES A NAME - a badge, a rules list - should pass
+ * `{ includeArchived: true }`. An archived account that is still some record's
+ * stored value has to keep rendering as itself, or the row goes blank and the
+ * next save writes the blank back.
+ *
  * `isLoading` is the query's `isPending`: what every call site actually wants
  * is "there is nothing to pick from yet", which is what disables the trigger
  * on first load.
  */
-export function useBankAccounts() {
-  const query = api.banking.bankAccount.list.useQuery()
-  return {
-    accounts: query.data ?? [],
-    isLoading: query.isPending,
-  }
+export function useBankAccounts(options: { includeArchived?: boolean } = {}) {
+  const query = api.banking.bankAccount.list.useQuery({ includeArchived: true })
+  const all = query.data ?? []
+  const accounts = useMemo(
+    () => (options.includeArchived ? all : all.filter((account) => !account.archivedAt)),
+    // `all` is a fresh array identity only when the query data changes.
+    [all, options.includeArchived]
+  )
+  return { accounts, isLoading: query.isPending }
 }
 
 /**
@@ -132,6 +151,18 @@ export interface BankAccountPickerProps {
  * The trigger is disabled while the list is still loading: an empty picker that
  * opens onto nothing reads as "you have no accounts", which is a different and
  * wrong answer.
+ *
+ * **Both creation doors are on the list's floor, in EVERY instance of this
+ * picker** - the pair the settings page shows as two buttons: Connect a bank,
+ * and Add manually. There is no prop to suppress them, filters included: a
+ * reader who notices a missing account is looking at this list at the moment
+ * they notice, and sending them to Settings to come back is the trip the rows
+ * exist to remove. The one gate is `ledgerPost` (below), because the server has
+ * one too.
+ *
+ * 🛑 Not one "Add a bank account" row opening a chooser - that is a dialog
+ * whose only question is which dialog you wanted, and it buries connect, which
+ * is the path that produces a live feed.
  */
 export function BankAccountPicker({
   value,
@@ -143,11 +174,32 @@ export function BankAccountPicker({
   triggerProps,
   className,
 }: BankAccountPickerProps) {
-  const { accounts, isLoading } = useBankAccounts()
+  // Archived rows come back, and the filter below drops all but the one that is
+  // still this field's value. See the comment on `visible`.
+  const { accounts, isLoading } = useBankAccounts({ includeArchived: true })
+  const { can } = useAccess()
   const [open, setOpen] = useState(false)
+  const [manualOpen, setManualOpen] = useState(false)
+  const [connectOpen, setConnectOpen] = useState(false)
 
-  const { options, groups, groupBy, last4ById, showGroups } = useMemo(() => {
-    const visible = accounts.filter((account) => account.id !== excludeId)
+  const utils = api.useUtils()
+  const connect = api.banking.connect.useMutation()
+  const startConnection = useCallback(() => connect.mutateAsync(), [connect])
+
+  // 🛑 `ledgerPost`, the same rung `bank-accounts-settings-page.tsx` gates its
+  // whole page on: a bank account's mapping decides where cash lands on the
+  // balance sheet. A `ledgerView` reader is offered neither row rather than a
+  // server refusal after filling the form.
+  const showCreate = can(PermissionKey.ledgerPost)
+
+  const { options, groups, groupBy, last4ById, archivedIds, showGroups } = useMemo(() => {
+    // 🛑 An archived account is out of the list, EXCEPT when it is the current
+    // value. A rule scoped to an account somebody archived must still render its
+    // own selection: a picker that silently shows empty over a stored id is one
+    // where the next save rewrites the record to null and nobody sees it happen.
+    const visible = accounts.filter(
+      (account) => account.id !== excludeId && (!account.archivedAt || account.id === value)
+    )
     const institutionById = new Map(visible.map((a) => [a.id, institutionOf(a)]))
 
     // Institutions alphabetically, the catch-all always last. `MultiSelectPicker`
@@ -198,81 +250,134 @@ export function BankAccountPicker({
       opt.value === ALL_ACCOUNTS ? '' : (institutionById.get(opt.value) ?? NO_INSTITUTION)
 
     const last4ById = new Map(visible.filter((a) => a.last4).map((a) => [a.id, a.last4 as string]))
+    const archivedIds = new Set(visible.filter((a) => a.archivedAt).map((a) => a.id))
 
-    return { options, groups, groupBy, last4ById, showGroups: grouped || !!allLabel }
-  }, [accounts, excludeId, allLabel])
+    return { options, groups, groupBy, last4ById, archivedIds, showGroups: grouped || !!allLabel }
+  }, [accounts, excludeId, allLabel, value])
 
   const selected = useMemo(
     () => accounts.find((account) => account.id === value) ?? null,
     [accounts, value]
   )
 
+  /** Open one of the dialogs, closing the list it was reached from. */
+  const openDialog = useCallback((which: 'manual' | 'connect') => {
+    setOpen(false)
+    if (which === 'manual') setManualOpen(true)
+    else setConnectOpen(true)
+  }, [])
+
   return (
-    <Popover open={disabled ? false : open} onOpenChange={disabled ? undefined : setOpen}>
-      <PopoverTrigger asChild>
-        <PickerTrigger
-          open={open}
-          disabled={disabled || isLoading}
-          variant={triggerProps?.variant ?? 'transparent'}
-          size={triggerProps?.size}
-          hasValue={!!selected}
-          placeholder={allLabel ?? placeholder}
-          // A filter clears by picking its own "All accounts" row, so the extra
-          // affordance would be a second control for one decision.
-          showClear={triggerProps?.showClear ?? !allLabel}
-          hideIcon={triggerProps?.hideIcon}
-          onClear={(e) => {
-            e.stopPropagation()
-            onChange(null)
-          }}
-          asCombobox
-          className={cn('h-auto min-h-8 w-full ps-0 pe-1', className, triggerProps?.className)}>
-          {/* The institution IS included here: a closed trigger has no heading
+    <>
+      <Popover open={disabled ? false : open} onOpenChange={disabled ? undefined : setOpen}>
+        <PopoverTrigger asChild>
+          <PickerTrigger
+            open={open}
+            disabled={disabled || isLoading}
+            variant={triggerProps?.variant ?? 'transparent'}
+            size={triggerProps?.size}
+            hasValue={!!selected}
+            placeholder={allLabel ?? placeholder}
+            // A filter clears by picking its own "All accounts" row, so the extra
+            // affordance would be a second control for one decision.
+            showClear={triggerProps?.showClear ?? !allLabel}
+            hideIcon={triggerProps?.hideIcon}
+            onClear={(e) => {
+              e.stopPropagation()
+              onChange(null)
+            }}
+            asCombobox
+            className={cn('h-auto min-h-8 w-full ps-0 pe-1', className, triggerProps?.className)}>
+            {/* The institution IS included here: a closed trigger has no heading
               above it to borrow the bank name from. */}
-          {selected && (
-            <span className='flex min-w-0 items-center gap-1.5'>
-              <BankInstitutionIcon
-                institution={selected.institution}
-                connectorId={selected.connectorId}
-              />
-              <span className='truncate text-sm'>{accountRowLabel(selected, false)}</span>
-              {selected.last4 && (
-                <Badge variant='outline' size='xs' className='shrink-0 font-mono'>
-                  {selected.last4}
+            {selected && (
+              <span className='flex min-w-0 items-center gap-1.5'>
+                <BankInstitutionIcon
+                  institution={selected.institution}
+                  connectorId={selected.connectorId}
+                />
+                <span className='truncate text-sm'>{accountRowLabel(selected, false)}</span>
+                {selected.last4 && (
+                  <Badge variant='outline' size='xs' className='shrink-0 font-mono'>
+                    {selected.last4}
+                  </Badge>
+                )}
+              </span>
+            )}
+          </PickerTrigger>
+        </PopoverTrigger>
+        <PopoverContent
+          className='min-w-[max(var(--radix-popover-trigger-width),18rem)] p-0'
+          align='start'>
+          <MultiSelectPicker
+            options={options}
+            value={value ? [value] : allLabel ? [ALL_ACCOUNTS] : []}
+            multi={false}
+            canAdd={false}
+            canManage={false}
+            isLoading={isLoading}
+            placeholder='Search accounts…'
+            groupBy={showGroups ? groupBy : undefined}
+            groups={showGroups ? groups : undefined}
+            renderItemAction={(opt) => {
+              // The one archived row this list can carry is the current value,
+              // and it says so instead of showing its last four - the reader has
+              // to be able to tell why an account nobody can pick is in here.
+              if (archivedIds.has(opt.value)) {
+                return (
+                  <Badge variant='destructive' size='xs'>
+                    Archived
+                  </Badge>
+                )
+              }
+              const last4 = last4ById.get(opt.value)
+              return last4 ? (
+                <Badge variant='outline' size='xs' className='font-mono'>
+                  {last4}
                 </Badge>
-              )}
-            </span>
-          )}
-        </PickerTrigger>
-      </PopoverTrigger>
-      <PopoverContent
-        className='min-w-[max(var(--radix-popover-trigger-width),18rem)] p-0'
-        align='start'>
-        <MultiSelectPicker
-          options={options}
-          value={value ? [value] : allLabel ? [ALL_ACCOUNTS] : []}
-          multi={false}
-          canAdd={false}
-          canManage={false}
-          isLoading={isLoading}
-          placeholder='Search accounts…'
-          groupBy={showGroups ? groupBy : undefined}
-          groups={showGroups ? groups : undefined}
-          renderItemAction={(opt) => {
-            const last4 = last4ById.get(opt.value)
-            return last4 ? (
-              <Badge variant='outline' size='xs' className='font-mono'>
-                {last4}
-              </Badge>
-            ) : null
-          }}
-          onChange={(next) => {
-            const picked = next[0] ?? null
-            onChange(picked === ALL_ACCOUNTS ? null : picked)
-          }}
-          onSelectSingle={() => setOpen(false)}
-        />
-      </PopoverContent>
-    </Popover>
+              ) : null
+            }}
+            onChange={(next) => {
+              const picked = next[0] ?? null
+              onChange(picked === ALL_ACCOUNTS ? null : picked)
+            }}
+            onSelectSingle={() => setOpen(false)}
+            onCreate={showCreate ? () => openDialog('manual') : undefined}
+            createLabel='Add manually'
+            onBrowse={showCreate ? () => openDialog('connect') : undefined}
+            browseLabel='Connect a bank'
+            browseIcon={Landmark}
+          />
+        </PopoverContent>
+      </Popover>
+
+      {/* Siblings of the `Popover`, never children of its content: opening one of
+        these closes the popover, and a dialog mounted inside it would unmount
+        on the same click that opened it. */}
+      <BankAccountManualDialog
+        open={manualOpen}
+        onOpenChange={setManualOpen}
+        // The account was just added FROM this picker, so it becomes its value.
+        // Making the operator reopen the list and find the row they just created
+        // is the step this dialog was reached to avoid.
+        //
+        // ⚠️ On a FILTER that means the list narrows to an account with no
+        // transactions yet, so the queue behind it reads empty. That is true
+        // rather than broken, and one click on the "all" row undoes it.
+        onCreated={(account) => onChange(account.id)}
+      />
+      <BankAccountConnectDialog
+        open={connectOpen}
+        onOpenChange={setConnectOpen}
+        onStart={startConnection}
+        onConnected={async (connected) => {
+          await utils.banking.bankAccount.list.invalidate()
+          // 🛑 No auto-select. One login can bring back several accounts and the
+          // flow answers a COUNT, not ids, so there is nothing here to choose
+          // honestly - the list reopens carrying all of them.
+          if (connected > 0) setOpen(true)
+        }}
+      />
+    </>
   )
 }

--- a/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
@@ -119,8 +119,15 @@ export function BankingReviewQueuePage() {
   const dockedWidth = useDockStore((state) => state.dockedWidth)
   const setDockedWidth = useDockStore((state) => state.setDockedWidth)
 
-  const accountsQuery = api.banking.bankAccount.list.useQuery()
-  const accounts = useMemo(() => accountsQuery.data ?? [], [accountsQuery.data])
+  // The same input `useBankAccounts` sends, so this and the toolbar's picker
+  // share one React Query key rather than issuing two reads of the same list.
+  // Archived rows are filtered out below - this list drives the empty state and
+  // the "which account" copy, and an archived account is not one to work in.
+  const accountsQuery = api.banking.bankAccount.list.useQuery({ includeArchived: true })
+  const accounts = useMemo(
+    () => (accountsQuery.data ?? []).filter((account) => !account.archivedAt),
+    [accountsQuery.data]
+  )
 
   const listInput = useMemo(
     () => ({

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-dialog.tsx
@@ -68,8 +68,9 @@ export function BankRuleDialog({ open, onClose, rule }: BankRuleDialogProps) {
   }, [open, rule])
 
   // Each page owns its own `BankAccountPicker`; the list is read here only to
-  // name the chosen counterpart in the action summary row.
-  const { accounts: bankAccounts } = useBankAccounts()
+  // name the chosen counterpart in the action summary row - so archived rows
+  // are included, or a rule scoped to an archived account summarises as blank.
+  const { accounts: bankAccounts } = useBankAccounts({ includeArchived: true })
   const { accounts: chartAccounts } = useChartAccounts()
 
   const createRule = api.bankingRules.create.useMutation({

--- a/apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx
@@ -111,7 +111,10 @@ export function BankingRulesPage() {
   const rulesQuery = api.bankingRules.list.useQuery()
   const rules = useMemo(() => rulesQuery.data ?? [], [rulesQuery.data])
 
-  const accountsQuery = api.banking.bankAccount.list.useQuery()
+  // Archived included, and the same key the pickers use: this only RESOLVES A
+  // NAME for a rule's stored scope, and a rule pointing at an archived account
+  // has to keep saying which account rather than rendering blank.
+  const accountsQuery = api.banking.bankAccount.list.useQuery({ includeArchived: true })
   const resolveAccountName = useCallback(
     (id: string) =>
       (accountsQuery.data ?? []).find((account) => account.id === id)?.name ?? undefined,

--- a/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
@@ -50,7 +50,7 @@
 // touching the inputs.
 
 import { FieldType } from '@auxx/database/enums'
-import type { BankAccountCoverage, BankAccountRow } from '@auxx/lib/banking/client'
+import type { BankAccountCoverage, BankAccountRow, RemovalVerb } from '@auxx/lib/banking/client'
 import {
   BANK_ACCOUNT_GL_TYPES,
   BANK_ACCOUNT_TYPE_LABELS,
@@ -61,7 +61,7 @@ import { Button } from '@auxx/ui/components/button'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { Section } from '@auxx/ui/components/section'
 import { cn } from '@auxx/ui/lib/utils'
-import { PlugZap, RefreshCw, TriangleAlert } from 'lucide-react'
+import { PlugZap, RefreshCw, Trash2, TriangleAlert } from 'lucide-react'
 import Link from 'next/link'
 import { useRef, useState } from 'react'
 import { GlAccountPicker } from '~/components/accounting/ui/gl-account-picker'
@@ -130,12 +130,32 @@ interface BankAccountEditorProps {
   disconnecting?: boolean
   /** True while a manual sync is being queued. */
   syncing?: boolean
+  /**
+   * `banking.bankAccount.removalPreview`, or null while it is loading.
+   *
+   * 🛑 It decides the WORD on the button and nothing else. The server re-runs
+   * the gate on the call, because a sync can land a transaction between this
+   * read and the click that follows it.
+   */
+  removal: BankAccountRemoval | null
+  /** True while the remove is in flight. */
+  removing?: boolean
   onPatch: (patch: BankAccountPatch) => void
   /** Queue a manual sync for this account's feed. */
   onSync?: () => void
   /** Re-authenticate at the bank. Same flow as connecting. */
   onReconnect?: () => void
   onDisconnect: () => void
+  /** Delete or archive, whichever the server's gate says applies. */
+  onRemove: () => void
+}
+
+/** What `banking.bankAccount.removalPreview` answers, as this pane reads it. */
+export interface BankAccountRemoval {
+  verb: RemovalVerb
+  cascade: { transactions: number; matched: number; releasesAtStripe: boolean }
+  unreviewed: number
+  warnings: { id: string; name: string }[]
 }
 
 export function BankAccountEditor({ account, ...rest }: BankAccountEditorProps) {
@@ -168,10 +188,13 @@ function BankAccountForm({
   pending,
   disconnecting = false,
   syncing = false,
+  removal,
+  removing = false,
   onPatch,
   onSync,
   onReconnect,
   onDisconnect,
+  onRemove,
 }: BankAccountEditorProps & { account: BankAccountRow }) {
   const [values, setValues] = useState<TextValues>({
     name: account.name ?? '',
@@ -430,29 +453,76 @@ function BankAccountForm({
         </Section>
       )}
 
-      {isConnected && (
-        <Section title='Danger zone' initialOpen={false}>
-          <div className='flex flex-col gap-2 p-1'>
-            <p className='text-muted-foreground text-xs'>
-              Disconnecting stops the feed and keeps every transaction, including the ones already
-              coded and posted. A posted bank line is the source document of a journal entry, so
-              nothing here is ever deleted.
-            </p>
+      {/* 🛑 The Danger zone is NOT gated on `isConnected` any more, and that gate
+          was the bug: a manual account had no destructive action of any kind, and
+          a manual account is the one you create by typing a name into a form - so
+          the duplicate and the typo, the overwhelmingly common reasons anybody
+          wants an account gone, were exactly the cases with no way out.
+
+          Disconnect stays gated, because the verb genuinely does not apply
+          without a connector - `disconnectBankAccountFeed` opens with
+          `requireConnectorId` and throws. Remove is always here. */}
+      <Section title='Danger zone' initialOpen={false}>
+        <div className='flex flex-col gap-3 p-1'>
+          {isConnected && (
+            <div className='flex flex-col gap-2'>
+              <p className='text-muted-foreground text-xs'>
+                Disconnecting stops the feed and keeps every transaction, including the ones already
+                coded and posted. A posted bank line is the source document of a journal entry, so
+                nothing is deleted.
+              </p>
+              <div>
+                <Button variant='outline' size='sm' loading={disconnecting} onClick={onDisconnect}>
+                  <PlugZap />
+                  Disconnect
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className='flex flex-col gap-2'>
+            <p className='text-muted-foreground text-xs'>{removalBlurb(removal)}</p>
             <div>
+              {/* 🛑 Never says "Delete" for something that will archive. The
+                  label waits for the preview rather than guessing, because the
+                  two words promise opposite things about the history. */}
               <Button
                 variant='destructive'
                 size='sm'
-                loading={disconnecting}
-                onClick={onDisconnect}>
-                <PlugZap />
-                Disconnect
+                loading={removing}
+                disabled={!removal}
+                onClick={onRemove}>
+                <Trash2 />
+                {removal?.verb === 'archive' ? 'Archive' : 'Delete'}
               </Button>
             </div>
           </div>
-        </Section>
-      )}
+        </div>
+      </Section>
     </div>
   )
+}
+
+/**
+ * The sentence under the Remove button, which has to differ by verb.
+ *
+ * ⚠️ Archive and delete promise opposite things about the history, so one
+ * paragraph covering both would be wrong for whichever one it is not.
+ */
+function removalBlurb(removal: BankAccountRemoval | null): string {
+  if (!removal) return 'Checking what removing this account would do…'
+  if (removal.verb === 'archive') {
+    return (
+      'Something on this account has been posted to the ledger, so it can only be archived. ' +
+      'It leaves every list and picker; the transactions, the journal entries and the account ' +
+      'you mapped it to are all untouched, and you can restore it from Show archived.'
+    )
+  }
+  const rows =
+    removal.cascade.transactions === 1
+      ? '1 transaction'
+      : `${removal.cascade.transactions} transactions`
+  return `Nothing on this account has ever reached the ledger, so it can be deleted for good, along with its ${rows}. This cannot be undone.`
 }
 
 /**

--- a/apps/web/src/components/accounting/ui/settings/bank-account-manual-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-account-manual-dialog.tsx
@@ -1,0 +1,210 @@
+// apps/web/src/components/accounting/ui/settings/bank-account-manual-dialog.tsx
+'use client'
+
+// "Add manually" - the second of the two doors that create a `bank_account`
+// (the first is `BankAccountConnectDialog`).
+//
+// Extracted from `bank-accounts-settings-page.tsx` so the picker can open the
+// same dialog the settings page opens. Two copies of this form would be two
+// places for the field list and the refusal handling to drift, and the fields
+// are not obvious - `last4` is text so a leading zero survives, and `type`
+// decides whether the account maps to an asset or a liability.
+
+import { FieldType } from '@auxx/database/enums'
+import type { BankAccountRow } from '@auxx/lib/banking/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError } from '@auxx/ui/components/toast'
+import { useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { api } from '~/trpc/react'
+
+const TYPE_OPTIONS = [
+  { value: 'depository', label: 'Depository', color: 'blue' as const },
+  { value: 'credit', label: 'Credit', color: 'amber' as const },
+]
+
+/** The dialog's fields, as it holds them before the write. */
+interface ManualDraft {
+  name: string
+  institution: string
+  last4: string
+  type: 'depository' | 'credit'
+  currency: string
+}
+
+const EMPTY_DRAFT: ManualDraft = {
+  name: '',
+  institution: '',
+  last4: '',
+  type: 'depository',
+  currency: 'USD',
+}
+
+export interface BankAccountManualDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /**
+   * The account that was just written. `banking.bankAccount.list` is already
+   * invalidated by the time this fires, so a caller only has to do what is
+   * particular to it - select the new row, or set it as a field's value.
+   */
+  onCreated?: (account: BankAccountRow) => void
+}
+
+/**
+ * BankAccountManualDialog
+ *
+ * Adds a `bank_account` by hand: for an account statements are imported into,
+ * or one at an institution the feed does not cover.
+ *
+ * 🛑 The refusal is surfaced VERBATIM. `createBankAccount` says that the last
+ * four is digits only; replacing that with "Could not save" throws away the one
+ * sentence that says what to do next.
+ */
+export function BankAccountManualDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: BankAccountManualDialogProps) {
+  const utils = api.useUtils()
+  const [draft, setDraft] = useState<ManualDraft>(EMPTY_DRAFT)
+
+  const create = api.banking.bankAccount.create.useMutation({
+    onSuccess: async (account) => {
+      await utils.banking.bankAccount.list.invalidate()
+      onOpenChange(false)
+      setDraft(EMPTY_DRAFT)
+      onCreated?.(account)
+    },
+    onError: (error) => {
+      toastError({ title: 'Error adding the account', description: error.message })
+    },
+  })
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next)
+        // A dialog reopened after a cancel starts empty. Keeping the draft would
+        // resurrect half an account somebody had already walked away from.
+        if (!next) setDraft(EMPTY_DRAFT)
+      }}>
+      <DialogContent position='tc'>
+        <DialogHeader>
+          <DialogTitle>Add a bank account</DialogTitle>
+          <DialogDescription>
+            For an account you will import statements into, or one at an institution the feed does
+            not cover. Map it to your chart afterwards.
+          </DialogDescription>
+        </DialogHeader>
+
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='accounting-bank-account-add'
+          defaultLabelWidth={140}
+          className='p-0'>
+          <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={draft.name}
+              placeholder='Business Adv Relationship'
+              disabled={create.isPending}
+              onChange={(value) => setDraft({ ...draft, name: (value as string) ?? '' })}
+            />
+          </FieldPanelRow>
+          <FieldPanelRow title='Institution' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={draft.institution}
+              placeholder='Bank of America'
+              disabled={create.isPending}
+              onChange={(value) => setDraft({ ...draft, institution: (value as string) ?? '' })}
+            />
+          </FieldPanelRow>
+          <FieldPanelRow
+            title='Last four'
+            type={BaseType.STRING}
+            showIcon
+            description='Digits only. Stored as text, so a leading zero survives.'>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={draft.last4}
+              placeholder='5381'
+              disabled={create.isPending}
+              onChange={(value) => setDraft({ ...draft, last4: (value as string) ?? '' })}
+            />
+          </FieldPanelRow>
+          <FieldPanelRow
+            title='Type'
+            type={BaseType.ENUM}
+            showIcon
+            description='A credit card is a liability and maps to a liability account.'>
+            <FieldInputAdapter
+              fieldType={FieldType.SINGLE_SELECT}
+              fieldOptions={{ options: TYPE_OPTIONS }}
+              value={draft.type}
+              disabled={create.isPending}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              placeholder='Select type'
+              onChange={(value) => {
+                const next = Array.isArray(value) ? value[0] : value
+                if (next === 'depository' || next === 'credit') setDraft({ ...draft, type: next })
+              }}
+            />
+          </FieldPanelRow>
+          <FieldPanelRow title='Currency' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={draft.currency}
+              placeholder='USD'
+              disabled={create.isPending}
+              onChange={(value) => setDraft({ ...draft, currency: (value as string) ?? '' })}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={create.isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            loading={create.isPending}
+            loadingText='Adding...'
+            disabled={!draft.name.trim()}
+            onClick={() =>
+              create.mutate({
+                name: draft.name.trim(),
+                institution: draft.institution.trim() || null,
+                last4: draft.last4.trim() || null,
+                type: draft.type,
+                currency: draft.currency.trim() || null,
+              })
+            }
+            data-dialog-submit>
+            Add account <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/bank-accounts-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-accounts-list.tsx
@@ -24,10 +24,20 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
+import { Switch } from '@auxx/ui/components/switch'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
-import { Building2, CreditCard, Landmark, PlugZap, Plus, RefreshCw, Upload } from 'lucide-react'
+import {
+  ArchiveRestore,
+  Building2,
+  CreditCard,
+  Landmark,
+  PlugZap,
+  Plus,
+  RefreshCw,
+  Upload,
+} from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 import { BankInstitutionIcon } from '~/components/accounting/ui/bank-institution-icon'
@@ -48,9 +58,23 @@ interface BankAccountsListProps {
   onSync: (bankAccountId: string) => void
   /** Re-authenticate a whole LOGIN. Offered on the section, never on a row. */
   onReconnect: (bankAccountId: string) => void
+  /** Bring an archived account back. Offered on the archived row alone. */
+  onRestore: (bankAccountId: string) => void
   connecting: boolean
   /** The account whose sync is in flight, so only its button spins. */
   syncingId: string | null
+  /** The account whose restore is in flight. */
+  restoringId: string | null
+  /**
+   * Whether `accounts` currently carries the archived rows.
+   *
+   * 🛑 The page owns the state and the filtering. This component renders what it
+   * is given; a second filter here would be a second answer to which rows exist.
+   */
+  showArchived: boolean
+  onShowArchivedChange: (next: boolean) => void
+  /** How many archived accounts the org holds, so the toggle can say so. */
+  archivedCount: number
 }
 
 /** Institutions in a stable order, with unnamed ones last under one heading. */
@@ -65,8 +89,13 @@ export function BankAccountsList({
   onAddManually,
   onSync,
   onReconnect,
+  onRestore,
   connecting,
   syncingId,
+  restoringId,
+  showArchived,
+  onShowArchivedChange,
+  archivedCount,
 }: BankAccountsListProps) {
   const [search, setSearch] = useState('')
   /**
@@ -121,6 +150,20 @@ export function BankAccountsList({
         </>
       )}
 
+      {/* Offered only when there is something behind it. An always-present
+          toggle over an empty set advertises a state most orgs never reach, and
+          archiving is meant to be the quiet default rather than a mode. */}
+      {archivedCount > 0 && (
+        <label className='flex cursor-pointer items-center gap-2 px-1 text-muted-foreground text-xs'>
+          <Switch
+            checked={showArchived}
+            onCheckedChange={onShowArchivedChange}
+            aria-label='Show archived accounts'
+          />
+          Show archived ({archivedCount})
+        </label>
+      )}
+
       {isLoading ? (
         <EmptySection loading />
       ) : accounts.length === 0 ? (
@@ -162,9 +205,12 @@ export function BankAccountsList({
                 />
               }
               title={<span className='truncate font-medium text-sm'>{group.institution}</span>}
+              // 🛑 The count is of LIVE accounts. An archived one is not an
+              // account this bank is feeding any more, and counting it would
+              // make "Show archived" appear to add accounts to the login.
               secondary={
                 <span className='text-muted-foreground text-xs'>
-                  {group.accounts.length === 1 ? '1 account' : `${group.accounts.length} accounts`}
+                  {group.liveCount === 1 ? '1 account' : `${group.liveCount} accounts`}
                 </span>
               }
               // 🛑 Reconnect belongs on the LOGIN, not on a row. Two accounts at one
@@ -212,10 +258,26 @@ export function BankAccountsList({
                     onToggleOpen={() => onSelect(account.id)}
                     rowClassName={cn(
                       'bg-primary-100/50 hover:bg-primary-100',
+                      // Dimmed rather than styled apart: an archived account is
+                      // still the same row, and it has to stay legible enough to
+                      // find the one you meant to restore.
+                      account.archivedAt && 'opacity-60',
                       selectedId === account.id && 'bg-primary-100 ring-1 ring-primary-200'
                     )}
                     actions={
-                      account.connectorId ? (
+                      account.archivedAt ? (
+                        // Restore, and nothing else. Sync on an archived account
+                        // would start a feed for a row that is out of every list.
+                        <TreeRowButton
+                          tooltipText='Restore'
+                          disabled={restoringId === account.id}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            onRestore(account.id)
+                          }}>
+                          <ArchiveRestore />
+                        </TreeRowButton>
+                      ) : account.connectorId ? (
                         <TreeRowButton
                           tooltipText={
                             account.status === 'disconnected'
@@ -238,7 +300,13 @@ export function BankAccountsList({
                     }
                     secondary={
                       <span className='flex flex-wrap items-center gap-1.5 text-muted-foreground text-xs'>
-                        <BankAccountStatusChip account={account} />
+                        {account.archivedAt ? (
+                          <Badge variant='secondary' size='xs'>
+                            Archived
+                          </Badge>
+                        ) : (
+                          <BankAccountStatusChip account={account} />
+                        )}
                         {account.glAccountCode ? (
                           <Badge variant='outline' size='xs' className='font-mono'>
                             {account.glAccountCode}
@@ -340,6 +408,8 @@ export function needsReconnect(accounts: BankAccountRow[]): boolean {
 interface InstitutionGroup {
   institution: string
   accounts: BankAccountRow[]
+  /** Live accounts only. What the heading counts; see the `secondary` above. */
+  liveCount: number
 }
 
 /**
@@ -365,5 +435,9 @@ export function groupByInstitution(accounts: BankAccountRow[], search: string): 
 
   return [...byInstitution.entries()]
     .sort(([a], [b]) => (a === NO_INSTITUTION ? 1 : b === NO_INSTITUTION ? -1 : a.localeCompare(b)))
-    .map(([institution, group]) => ({ institution, accounts: group }))
+    .map(([institution, group]) => ({
+      institution,
+      accounts: group,
+      liveCount: group.filter((account) => !account.archivedAt).length,
+    }))
 }

--- a/apps/web/src/components/accounting/ui/settings/bank-accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-accounts-settings-page.tsx
@@ -25,33 +25,20 @@
 // stops being billed 30c a month (open question S4). Every transaction stays - a
 // coded and posted bank line is the source document of a journal entry.
 
-import { FieldType } from '@auxx/database/enums'
 import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
-import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { Lock } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
-import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { EmptyState } from '~/components/global/empty-state'
-import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { MasterDetailSplit } from '~/components/global/master-detail-split'
 import SettingsPage from '~/components/global/settings-page'
-import { BaseType } from '~/components/workflow/types'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { BankAccountConnectDialog } from './bank-account-connect-dialog'
 import { BankAccountEditor, type BankAccountPatch } from './bank-account-editor'
+import { BankAccountManualDialog } from './bank-account-manual-dialog'
 import { BankAccountsList } from './bank-accounts-list'
 
 const BREADCRUMBS = [
@@ -62,28 +49,6 @@ const BREADCRUMBS = [
 
 const PAGE_DESCRIPTION =
   'The accounts your money actually sits in, and which account in your chart each one maps to. Everything the bank feed and the statement importer produce lands against a row here.'
-
-const TYPE_OPTIONS = [
-  { value: 'depository', label: 'Depository', color: 'blue' as const },
-  { value: 'credit', label: 'Credit', color: 'amber' as const },
-]
-
-/** The manual-add dialog's fields, as it holds them before the write. */
-interface ManualDraft {
-  name: string
-  institution: string
-  last4: string
-  type: 'depository' | 'credit'
-  currency: string
-}
-
-const EMPTY_DRAFT: ManualDraft = {
-  name: '',
-  institution: '',
-  last4: '',
-  type: 'depository',
-  currency: 'USD',
-}
 
 export function BankAccountsSettingsPage() {
   // 🛑 `ledgerPost`, not `ledgerView`. Every control on this page is a WRITE -
@@ -96,13 +61,23 @@ export function BankAccountsSettingsPage() {
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [manualOpen, setManualOpen] = useState(false)
-  const [draft, setDraft] = useState<ManualDraft>(EMPTY_DRAFT)
   const [connectOpen, setConnectOpen] = useState(false)
   const [reconnectingId, setReconnectingId] = useState<string | null>(null)
+  const [showArchived, setShowArchived] = useState(false)
   const [confirm, ConfirmDialog] = useConfirm()
 
-  const accounts = api.banking.bankAccount.list.useQuery()
+  // 🛑 Archived rows are FETCHED always and filtered here, on the same query key
+  // `useBankAccounts` uses, so the toggle costs no roundtrip and every picker on
+  // the app shares this cache entry.
+  const accounts = api.banking.bankAccount.list.useQuery({ includeArchived: true })
   const rows = useMemo(() => accounts.data ?? [], [accounts.data])
+  const visibleRows = useMemo(
+    () => (showArchived ? rows : rows.filter((row) => !row.archivedAt)),
+    [rows, showArchived]
+  )
+  // Selected from ALL rows, not the visible ones: archiving the open account
+  // must leave its pane readable long enough to say what happened and offer the
+  // restore, rather than blanking under the person who pressed the button.
   const selected = useMemo(
     () => rows.find((row) => row.id === selectedId) ?? null,
     [rows, selectedId]
@@ -116,29 +91,26 @@ export function BankAccountsSettingsPage() {
     { enabled: !!selectedId }
   )
 
+  // What the Danger zone's button says, and what the confirm dialog counts.
+  // 🛑 Advisory only - `bankAccount.remove` re-runs the gate server side, so a
+  // sync that lands a transaction between this read and the click cannot turn a
+  // delete into something it should not have been.
+  const removal = api.banking.bankAccount.removalPreview.useQuery(
+    { id: selectedId ?? '' },
+    { enabled: !!selectedId && !selected?.archivedAt }
+  )
+
   const invalidate = useCallback(async () => {
     await Promise.all([
       utils.banking.bankAccount.list.invalidate(),
       utils.banking.bankAccount.coverage.invalidate(),
+      utils.banking.bankAccount.removalPreview.invalidate(),
     ])
   }, [utils])
 
   // 🛑 Refusals are surfaced VERBATIM. `updateBankAccount` says which field a
-  // connected account owns and what to do instead; `createBankAccount` says
-  // that the last four is digits only. Replacing either with "Could not save"
-  // throws away the only sentence that says what to do next.
-  const create = api.banking.bankAccount.create.useMutation({
-    onSuccess: async (account) => {
-      await invalidate()
-      setManualOpen(false)
-      setDraft(EMPTY_DRAFT)
-      setSelectedId(account.id)
-    },
-    onError: (error) => {
-      toastError({ title: 'Error adding the account', description: error.message })
-    },
-  })
-
+  // connected account owns and what to do instead. Replacing it with "Could not
+  // save" throws away the only sentence that says what to do next.
   const update = api.banking.bankAccount.update.useMutation({
     onSuccess: invalidate,
     onError: (error) => {
@@ -162,6 +134,26 @@ export function BankAccountsSettingsPage() {
     onSuccess: invalidate,
     onError: (error) => {
       toastError({ title: 'Error disconnecting the account', description: error.message })
+    },
+  })
+
+  const remove = api.banking.bankAccount.remove.useMutation({
+    onSuccess: async (result) => {
+      await invalidate()
+      // A deleted account has no row left to select. An archived one does, and
+      // keeping it selected is what puts Restore in front of the person who has
+      // just realised they did not mean it.
+      if (result.verb === 'delete') setSelectedId(null)
+    },
+    onError: (error) => {
+      toastError({ title: 'Error removing the account', description: error.message })
+    },
+  })
+
+  const restore = api.banking.bankAccount.restore.useMutation({
+    onSuccess: invalidate,
+    onError: (error) => {
+      toastError({ title: 'Error restoring the account', description: error.message })
     },
   })
 
@@ -206,6 +198,57 @@ export function BankAccountsSettingsPage() {
     disconnect.mutate({ id: selected.id })
   }, [selected, confirm, disconnect])
 
+  /**
+   * Delete or archive, whichever the server's gate says applies.
+   *
+   * 🛑 The confirm text NAMES THE COUNTS. "This cannot be undone" over an
+   * unnamed cascade is what people click through; "1,240 transactions, 3 of them
+   * matched to documents" is what makes somebody stop and check.
+   */
+  const handleRemove = useCallback(async () => {
+    if (!selected || !removal.data) return
+    const preview = removal.data
+    const confirmed = await confirm({
+      title:
+        preview.verb === 'delete'
+          ? `Delete ${selected.name?.trim() || 'this bank account'}?`
+          : `Archive ${selected.name?.trim() || 'this bank account'}?`,
+      description:
+        preview.verb === 'delete'
+          ? [
+              `Nothing on this account has ever reached the ledger, so it is removed for good with its ${countLabel(preview.cascade.transactions, 'transaction')}.`,
+              preview.cascade.matched > 0
+                ? `${countLabel(preview.cascade.matched, 'of them is', 'of them are')} matched to a document. The document and its journal entry stay in the books; only the bank line confirming it goes.`
+                : null,
+              preview.cascade.releasesAtStripe
+                ? 'The bank connection is released at your bank, so it stops being billed. Reconnecting later means signing in again.'
+                : null,
+              warningLine(preview.warnings, 'deleting'),
+              'This cannot be undone.',
+            ]
+              .filter(Boolean)
+              .join(' ')
+          : [
+              'Something on this account has been posted to the ledger, so it is archived rather than deleted. It leaves every list and picker; the transactions, the journal entries and the account you mapped it to are all untouched.',
+              preview.unreviewed > 0
+                ? `${countLabel(preview.unreviewed, 'transaction is', 'transactions are')} still waiting for review. Archiving marks them excluded, so they will not reach the books.`
+                : null,
+              preview.cascade.releasesAtStripe
+                ? 'The feed is disconnected and the account is released at your bank first, so it stops being billed.'
+                : null,
+              warningLine(preview.warnings, 'archiving'),
+              'You can restore it from Show archived.',
+            ]
+              .filter(Boolean)
+              .join(' '),
+      confirmText: preview.verb === 'delete' ? 'Delete' : 'Archive',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    remove.mutate({ id: selected.id })
+  }, [selected, removal.data, confirm, remove])
+
   const handleReconnect = useCallback((id: string) => {
     setReconnectingId(id)
     setConnectOpen(true)
@@ -241,17 +284,20 @@ export function BankAccountsSettingsPage() {
             pending={update.isPending}
             disconnecting={disconnect.isPending}
             syncing={sync.isPending}
+            removal={removal.data ?? null}
+            removing={remove.isPending}
             onPatch={handlePatch}
             onSync={() => selected && sync.mutate({ id: selected.id })}
             onReconnect={() => selected && handleReconnect(selected.id)}
             onDisconnect={handleDisconnect}
+            onRemove={handleRemove}
           />
         }
         paneTitle='Bank account'
         paneOpen={!!selected}
         onPaneClose={() => setSelectedId(null)}>
         <BankAccountsList
-          accounts={rows}
+          accounts={visibleRows}
           isLoading={accounts.isPending}
           selectedId={selectedId}
           onSelect={setSelectedId}
@@ -259,117 +305,26 @@ export function BankAccountsSettingsPage() {
           onAddManually={() => setManualOpen(true)}
           onSync={(id) => sync.mutate({ id })}
           onReconnect={handleReconnect}
+          onRestore={(id) => restore.mutate({ id })}
           connecting={connect.isPending || reconnect.isPending}
           syncingId={sync.isPending ? (sync.variables?.id ?? null) : null}
+          restoringId={restore.isPending ? (restore.variables?.id ?? null) : null}
+          showArchived={showArchived}
+          onShowArchivedChange={setShowArchived}
+          archivedCount={rows.filter((row) => row.archivedAt).length}
         />
       </MasterDetailSplit>
 
-      <Dialog open={manualOpen} onOpenChange={setManualOpen}>
-        <DialogContent position='tc'>
-          <DialogHeader>
-            <DialogTitle>Add a bank account</DialogTitle>
-            <DialogDescription>
-              For an account you will import statements into, or one at an institution the feed does
-              not cover. Map it to your chart afterwards.
-            </DialogDescription>
-          </DialogHeader>
-
-          <FieldPanel
-            orientation='responsive'
-            breakpoint='md'
-            resizeId='accounting-bank-account-add'
-            defaultLabelWidth={140}
-            className='p-0'>
-            <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={draft.name}
-                placeholder='Business Adv Relationship'
-                disabled={create.isPending}
-                onChange={(value) => setDraft({ ...draft, name: (value as string) ?? '' })}
-              />
-            </FieldPanelRow>
-            <FieldPanelRow title='Institution' type={BaseType.STRING} showIcon>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={draft.institution}
-                placeholder='Bank of America'
-                disabled={create.isPending}
-                onChange={(value) => setDraft({ ...draft, institution: (value as string) ?? '' })}
-              />
-            </FieldPanelRow>
-            <FieldPanelRow
-              title='Last four'
-              type={BaseType.STRING}
-              showIcon
-              description='Digits only. Stored as text, so a leading zero survives.'>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={draft.last4}
-                placeholder='5381'
-                disabled={create.isPending}
-                onChange={(value) => setDraft({ ...draft, last4: (value as string) ?? '' })}
-              />
-            </FieldPanelRow>
-            <FieldPanelRow
-              title='Type'
-              type={BaseType.ENUM}
-              showIcon
-              description='A credit card is a liability and maps to a liability account.'>
-              <FieldInputAdapter
-                fieldType={FieldType.SINGLE_SELECT}
-                fieldOptions={{ options: TYPE_OPTIONS }}
-                value={draft.type}
-                disabled={create.isPending}
-                triggerProps={{ className: 'w-full ps-0 pe-1' }}
-                placeholder='Select type'
-                onChange={(value) => {
-                  const next = Array.isArray(value) ? value[0] : value
-                  if (next === 'depository' || next === 'credit') setDraft({ ...draft, type: next })
-                }}
-              />
-            </FieldPanelRow>
-            <FieldPanelRow title='Currency' type={BaseType.STRING} showIcon>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={draft.currency}
-                placeholder='USD'
-                disabled={create.isPending}
-                onChange={(value) => setDraft({ ...draft, currency: (value as string) ?? '' })}
-              />
-            </FieldPanelRow>
-          </FieldPanel>
-
-          <DialogFooter>
-            <Button
-              type='button'
-              variant='ghost'
-              size='sm'
-              onClick={() => setManualOpen(false)}
-              disabled={create.isPending}>
-              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-            </Button>
-            <Button
-              variant='outline'
-              size='sm'
-              loading={create.isPending}
-              loadingText='Adding...'
-              disabled={!draft.name.trim()}
-              onClick={() =>
-                create.mutate({
-                  name: draft.name.trim(),
-                  institution: draft.institution.trim() || null,
-                  last4: draft.last4.trim() || null,
-                  type: draft.type,
-                  currency: draft.currency.trim() || null,
-                })
-              }
-              data-dialog-submit>
-              Add account <KbdSubmit variant='outline' size='sm' />
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <BankAccountManualDialog
+        open={manualOpen}
+        onOpenChange={setManualOpen}
+        onCreated={async (account) => {
+          // The dialog already invalidated the list; coverage is this page's own
+          // read, and selecting the new row is what makes the editor open on it.
+          await utils.banking.bankAccount.coverage.invalidate()
+          setSelectedId(account.id)
+        }}
+      />
 
       <BankAccountConnectDialog
         open={connectOpen}
@@ -385,4 +340,23 @@ export function BankAccountsSettingsPage() {
       <ConfirmDialog />
     </SettingsPage>
   )
+}
+
+/** `3 transactions` / `1 transaction`, so no sentence reads "1 transactions". */
+function countLabel(count: number, singular: string, plural?: string): string {
+  return `${count} ${count === 1 ? singular : (plural ?? `${singular}s`)}`
+}
+
+/**
+ * The inert-rule warning, or null.
+ *
+ * ⚠️ Named, never a blocker. `evaluateRules` skips a rule whose `bankAccountId`
+ * does not match the line, so a rule left pointing at a removed account is
+ * silently DEAD rather than silently universal - which is worth saying, and not
+ * worth refusing over.
+ */
+function warningLine(rules: { id: string; name: string }[], verb: string): string | null {
+  if (rules.length === 0) return null
+  const names = rules.map((rule) => rule.name).join(', ')
+  return `${rules.length === 1 ? 'One rule' : `${rules.length} rules`} name this account (${names}); ${verb} it leaves ${rules.length === 1 ? 'it' : 'them'} matching nothing.`
 }

--- a/apps/web/src/components/pickers/multi-select-picker.tsx
+++ b/apps/web/src/components/pickers/multi-select-picker.tsx
@@ -117,6 +117,13 @@ export interface MultiSelectPickerProps {
   /** Label for browse button (default: "Browse all") */
   browseLabel?: string
 
+  /**
+   * Icon for the browse row (default: `LayoutGrid`). The label alone is not
+   * always enough to tell two footer actions apart - "Connect a bank" beside
+   * "Add manually" reads as one grid icon and one plus until this is set.
+   */
+  browseIcon?: React.ComponentType<{ className?: string }>
+
   /** Render a per-row secondary action (e.g., a "favorite" star). Rendered before the selection indicator. */
   renderItemAction?: (opt: SelectOption) => React.ReactNode
 
@@ -176,6 +183,7 @@ export function MultiSelectPicker({
   onEdit,
   onBrowse,
   browseLabel = 'Browse all',
+  browseIcon: BrowseIcon = LayoutGrid,
   renderItemAction,
   groupBy,
   groups,
@@ -832,7 +840,7 @@ export function MultiSelectPicker({
             )}
             {onBrowse && (
               <CommandItem onSelect={onBrowse} disabled={disabled} className='cursor-pointer h-7.5'>
-                <LayoutGrid className='text-muted-foreground' />
+                <BrowseIcon className='text-muted-foreground' />
                 <span>{browseLabel}</span>
               </CommandItem>
             )}

--- a/apps/web/src/server/api/routers/banking.ts
+++ b/apps/web/src/server/api/routers/banking.ts
@@ -1,8 +1,9 @@
 // apps/web/src/server/api/routers/banking.ts
 //
-// Bank accounts: the list, the editor's writes, the coverage read, and the four
-// feed actions - connect, reconnect, sync now, disconnect
-// (plans/accounting/HANDOFF.md slots 2I and 3A, plans/accounting/ui-plan.md §2.7).
+// Bank accounts: the list, the editor's writes, the coverage read, removal, and
+// the four feed actions - connect, reconnect, sync now, disconnect
+// (plans/accounting/HANDOFF.md slots 2I and 3A, plans/accounting/ui-plan.md §2.7,
+// plans/bank-connection/08-removing-a-bank-account.md §7.3).
 // Mounted as `banking` in `root.ts`.
 //
 // 🛑 Reads are `ledgerView`; every write is `ledgerPost`. Mapping a bank account
@@ -18,13 +19,18 @@
 // do next.
 
 import {
+  archiveBankAccount,
   BANK_ACCOUNT_STATUSES,
   BANK_ACCOUNT_TYPES,
   createBankAccount,
+  deleteBankAccount,
   disconnectBankAccountFeed,
   getBankAccount,
   listBankAccounts,
   readCoverage,
+  readRemovalFacts,
+  resolveRemoval,
+  restoreBankAccount,
   startBankConnection,
   syncBankAccountFeed,
   updateBankAccount,
@@ -69,13 +75,19 @@ export const bankingRouter = createTRPCRouter({
      * round trips to draw a list. The live polling in
      * `use-connector-sync-realtime.ts` takes over for the SELECTED account only.
      */
-    list: permissionProcedure(PermissionKey.ledgerView).query(async ({ ctx }) => {
-      const result = await listBankAccounts(ctx.db, {
-        organizationId: ctx.session.organizationId,
-      })
-      if (result.isErr()) throw result.error
-      return result.value
-    }),
+    list: permissionProcedure(PermissionKey.ledgerView)
+      .input(z.object({ includeArchived: z.boolean().optional() }).optional())
+      .query(async ({ ctx, input }) => {
+        const result = await listBankAccounts(ctx.db, {
+          organizationId: ctx.session.organizationId,
+          // Default false. Only the settings list's "Show archived" toggle and
+          // the picker - which has to keep rendering an archived account that is
+          // still some record's current value - ever ask for the other answer.
+          includeArchived: input?.includeArchived ?? false,
+        })
+        if (result.isErr()) throw result.error
+        return result.value
+      }),
 
     get: permissionProcedure(PermissionKey.ledgerView)
       .input(z.object({ id: z.string().min(1) }))
@@ -158,6 +170,82 @@ export const bankingRouter = createTRPCRouter({
           actorUserId: ctx.session.userId,
           bankAccountId: id,
           ...patch,
+        })
+        if (result.isErr()) throw result.error
+        return result.value
+      }),
+
+    /**
+     * What removing this account would do, for the confirm dialog.
+     *
+     * `ledgerView`, because it reads and decides nothing. It answers the verb,
+     * what a delete would take with it, how many unreviewed lines an archive
+     * would exclude, and which rules a delete would leave inert.
+     */
+    removalPreview: permissionProcedure(PermissionKey.ledgerView)
+      .input(z.object({ id: z.string().min(1) }))
+      .query(async ({ ctx, input }) => {
+        const facts = await readRemovalFacts(ctx.db, {
+          organizationId: ctx.session.organizationId,
+          bankAccountId: input.id,
+        })
+        if (facts.isErr()) throw facts.error
+        return { facts: facts.value, ...resolveRemoval(facts.value) }
+      }),
+
+    /**
+     * Remove a bank account.
+     *
+     * 🛑 **ONE procedure, not two, and the gate runs HERE.** A pristine account
+     * is deleted for real; anything a journal entry has ever come off is
+     * archived. The client must not be the one to decide which verb applies: a
+     * client that decided could race a sync landing a transaction between the
+     * preview it read and the call it made, and would then ask for a hard delete
+     * of an account whose rows are now a posting's source documents.
+     *
+     * The preview above exists only so the button can read "Delete" or "Archive"
+     * and the confirm text can name the right consequences. It is never the
+     * authority.
+     */
+    remove: permissionProcedure(PermissionKey.ledgerPost)
+      .input(z.object({ id: z.string().min(1) }))
+      .mutation(async ({ ctx, input }) => {
+        const facts = await readRemovalFacts(ctx.db, {
+          organizationId: ctx.session.organizationId,
+          bankAccountId: input.id,
+        })
+        if (facts.isErr()) throw facts.error
+
+        const params = {
+          organizationId: ctx.session.organizationId,
+          actorUserId: ctx.session.userId,
+          bankAccountId: input.id,
+        }
+        if (resolveRemoval(facts.value).verb === 'delete') {
+          const result = await deleteBankAccount(ctx.db, params)
+          if (result.isErr()) throw result.error
+          return { verb: 'delete' as const, ...result.value, excluded: 0 }
+        }
+        const result = await archiveBankAccount(ctx.db, params)
+        if (result.isErr()) throw result.error
+        return { verb: 'archive' as const, ...result.value }
+      }),
+
+    /**
+     * Put an archived account back.
+     *
+     * ⚠️ It does not reconnect the feed - the account was released at Stripe, so
+     * the only way back to a live one is a fresh authentication at the bank - and
+     * it does not un-exclude the lines the archive swept, which stay undoable one
+     * at a time in the review queue.
+     */
+    restore: permissionProcedure(PermissionKey.ledgerPost)
+      .input(z.object({ id: z.string().min(1) }))
+      .mutation(async ({ ctx, input }) => {
+        const result = await restoreBankAccount(ctx.db, {
+          organizationId: ctx.session.organizationId,
+          actorUserId: ctx.session.userId,
+          bankAccountId: input.id,
         })
         if (result.isErr()) throw result.error
         return result.value

--- a/packages/lib/src/banking/__tests__/reads-archived.test.ts
+++ b/packages/lib/src/banking/__tests__/reads-archived.test.ts
@@ -1,0 +1,249 @@
+// packages/lib/src/banking/__tests__/reads-archived.test.ts
+
+/**
+ * The two reads the removal feature added
+ * (plans/bank-connection/08-removing-a-bank-account.md §7.2, §8).
+ *
+ * 🛑 `listBankAccounts` must exclude archived rows BY DEFAULT. Every existing
+ * caller - the settings list, every picker, the review queue, the importer -
+ * passes nothing, and archiving is only "removal" as far as the product is
+ * concerned because the query already filters. A default that flipped would put
+ * removed accounts back into every dropdown in the app.
+ *
+ * 🛑 `readRemovalFacts` must read `hasEverPosted` STRAIGHT OFF THE FIELD. The
+ * test below hands it an account whose every transaction is back in `for_review`
+ * with no posting id - what the queue looks like after an undo - and a stored
+ * flag that says `true`, and the fact has to come back `true`.
+ */
+
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Every `where` fragment the module built, in order. */
+  wheres: [] as unknown[],
+  /** The rows each successive query resolves to. */
+  script: [] as unknown[][],
+  rules: [] as {
+    id: string
+    name: string
+    bankAccountId: string | null
+    counterpartBankAccountId: string | null
+  }[],
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: async (_org: string, entityType: string) =>
+    entityType === 'bank_account' ? 'def_ba' : 'def_bt',
+  getOrgCache: () => ({
+    from: () => ({
+      // Every attribute resolves to a field whose id IS the attribute name, so a
+      // captured predicate is legible without a fixture table.
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(attrs.map((attr) => [attr, { id: attr }])),
+    }),
+  }),
+}))
+
+vi.mock('../rules/reads', () => ({
+  listBankRules: async () => ({ isErr: () => false, isOk: () => true, value: h.rules }),
+}))
+
+const { listBankAccounts, readRemovalFacts } = await import('../reads')
+
+/**
+ * The SQL a drizzle fragment renders to, so a predicate can be asserted.
+ *
+ * ⚠️ Rendered OUTSIDE a query builder, so column references come back blank and
+ * values are bound parameters - the same trade `feed/__tests__/reaper.test.ts`
+ * makes. What is pinned here is the SHAPE (is there an `is null` arm at all),
+ * which is exactly the difference `includeArchived` makes.
+ */
+function render(fragment: unknown): string {
+  return new PgDialect().sqlToQuery(fragment as never).sql
+}
+
+/**
+ * One query stage: chainable and awaitable, resolving to `rows`.
+ *
+ * The same shape `review/__tests__/writes.test.ts` builds - a promise with the
+ * builder methods hung off it - so every stage can be either the terminal one or
+ * the next link without the double knowing which.
+ */
+function stage(rows: unknown[]): unknown {
+  const chain: Record<string, unknown> = {}
+  for (const method of ['from', 'innerJoin', 'leftJoin', 'limit', 'orderBy']) {
+    chain[method] = () => stage(rows)
+  }
+  chain.where = (fragment: unknown) => {
+    h.wheres.push(fragment)
+    return stage(rows)
+  }
+  return Object.assign(Promise.resolve(rows), chain)
+}
+
+/** A db double that answers `h.script` in order and records every `where`. */
+function fakeDb() {
+  let call = 0
+  // One `select()` is one query, so the script advances here rather than at the
+  // await - which is what keeps the scripted rows lined up with the call order.
+  return { select: () => stage(h.script[call++] ?? []) } as never
+}
+
+const ORG = 'org_1'
+
+beforeEach(() => {
+  h.wheres.length = 0
+  h.script.length = 0
+  h.rules = []
+})
+
+describe('listBankAccounts', () => {
+  it('excludes archived rows by default', async () => {
+    h.script.push([]) // no instances, so nothing hydrates
+    const result = await listBankAccounts(fakeDb(), { organizationId: ORG })
+
+    expect(result.isOk()).toBe(true)
+    expect(render(h.wheres[0])).toContain('is null')
+  })
+
+  it('includes them on the flag', async () => {
+    h.script.push([])
+    const result = await listBankAccounts(fakeDb(), {
+      organizationId: ORG,
+      includeArchived: true,
+    })
+
+    expect(result.isOk()).toBe(true)
+    // 🛑 The ONLY difference between the two calls. If this arm survives the
+    // flag, "Show archived" shows nothing and a picker cannot render an archived
+    // account that is still a record's current value.
+    expect(render(h.wheres[0])).not.toContain('is null')
+  })
+
+  it('carries archivedAt onto the row so the list can dim it', async () => {
+    const archivedAt = new Date('2026-09-08T00:00:00.000Z')
+    h.script.push([{ id: 'acct_1', createdAt: null, archivedAt }])
+    h.script.push([
+      { entityId: 'acct_1', fieldId: 'bank_account_name', valueText: 'Old account' },
+      { entityId: 'acct_1', fieldId: 'bank_account_has_posted', valueBoolean: true },
+    ])
+
+    const result = await listBankAccounts(fakeDb(), {
+      organizationId: ORG,
+      includeArchived: true,
+    })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value[0]?.archivedAt).toEqual(archivedAt)
+      expect(result.value[0]?.hasEverPosted).toBe(true)
+    }
+  })
+
+  it('reads hasEverPosted as false when the field carries nothing', async () => {
+    h.script.push([{ id: 'acct_1', createdAt: null, archivedAt: null }])
+    h.script.push([{ entityId: 'acct_1', fieldId: 'bank_account_name', valueText: 'New account' }])
+
+    const result = await listBankAccounts(fakeDb(), { organizationId: ORG })
+    if (result.isOk()) expect(result.value[0]?.hasEverPosted).toBe(false)
+  })
+})
+
+describe('readRemovalFacts', () => {
+  it('reads hasEverPosted off the FIELD, not off the rows', async () => {
+    // 1. getBankAccount's instance row (archived rows allowed through).
+    h.script.push([{ id: 'acct_1', createdAt: null, archivedAt: null }])
+    // 2. its field values: the flag is TRUE and nothing else says so.
+    h.script.push([
+      { entityId: 'acct_1', fieldId: 'bank_account_name', valueText: 'Chequing' },
+      { entityId: 'acct_1', fieldId: 'bank_account_has_posted', valueBoolean: true },
+    ])
+    // 3. the account's live lines...
+    h.script.push([{ entityId: 'txn_1' }, { entityId: 'txn_2' }])
+    // 4. ...every one of which is back in `for_review` with no posting id, which
+    //    is exactly what the queue looks like after `undoReview`.
+    h.script.push([
+      { entityId: 'txn_1', optionId: 'for_review' },
+      { entityId: 'txn_2', optionId: 'for_review' },
+    ])
+
+    const result = await readRemovalFacts(fakeDb(), {
+      organizationId: ORG,
+      bankAccountId: 'acct_1',
+    })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value.hasEverPosted).toBe(true)
+      expect(result.value.transactionCount).toBe(2)
+      expect(result.value.unreviewedCount).toBe(2)
+      expect(result.value.matchedCount).toBe(0)
+    }
+  })
+
+  it('counts matched and unreviewed lines separately', async () => {
+    h.script.push([{ id: 'acct_1', createdAt: null, archivedAt: null }])
+    h.script.push([{ entityId: 'acct_1', fieldId: 'bank_account_name', valueText: 'Chequing' }])
+    h.script.push([
+      { entityId: 'txn_1' },
+      { entityId: 'txn_2' },
+      { entityId: 'txn_3' },
+      { entityId: 'txn_4' },
+    ])
+    h.script.push([
+      { entityId: 'txn_1', optionId: 'matched' },
+      { entityId: 'txn_2', optionId: 'coded' },
+      { entityId: 'txn_3', optionId: 'suggested' },
+      { entityId: 'txn_4', optionId: 'for_review' },
+    ])
+
+    const result = await readRemovalFacts(fakeDb(), {
+      organizationId: ORG,
+      bankAccountId: 'acct_1',
+    })
+
+    if (result.isOk()) {
+      expect(result.value.transactionCount).toBe(4)
+      expect(result.value.matchedCount).toBe(1)
+      expect(result.value.unreviewedCount).toBe(2)
+    }
+  })
+
+  it('names the rules pointing at the account, in either field', async () => {
+    h.rules = [
+      { id: 'rule_1', name: 'Bank fee', bankAccountId: 'acct_1', counterpartBankAccountId: null },
+      {
+        id: 'rule_2',
+        name: 'Sweep to savings',
+        bankAccountId: 'acct_9',
+        counterpartBankAccountId: 'acct_1',
+      },
+      { id: 'rule_3', name: 'Unrelated', bankAccountId: 'acct_9', counterpartBankAccountId: null },
+    ]
+    h.script.push([{ id: 'acct_1', createdAt: null, archivedAt: null }])
+    h.script.push([{ entityId: 'acct_1', fieldId: 'bank_account_name', valueText: 'Chequing' }])
+    h.script.push([])
+
+    const result = await readRemovalFacts(fakeDb(), {
+      organizationId: ORG,
+      bankAccountId: 'acct_1',
+    })
+
+    if (result.isOk()) {
+      expect(result.value.rules.map((rule) => rule.id)).toEqual(['rule_1', 'rule_2'])
+    }
+  })
+
+  it('refuses by name when the account does not exist', async () => {
+    h.script.push([])
+
+    const result = await readRemovalFacts(fakeDb(), {
+      organizationId: ORG,
+      bankAccountId: 'gone',
+    })
+
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.message).toContain('gone')
+  })
+})

--- a/packages/lib/src/banking/__tests__/removal-gate.test.ts
+++ b/packages/lib/src/banking/__tests__/removal-gate.test.ts
@@ -1,0 +1,179 @@
+// packages/lib/src/banking/__tests__/removal-gate.test.ts
+
+/**
+ * The bank-account removal gate, with **no database**
+ * (plans/bank-connection/08-removing-a-bank-account.md §8).
+ *
+ * 🛑 `resolveRemoval` has exactly ONE term - `hasEverPosted` - and every test
+ * here exists to keep it that way. The failure this guards against is somebody
+ * "simplifying" the gate to read the transaction rows instead: `undoReview` sets
+ * `bank_transaction_gl_posting_id` back to null, so a row-derived predicate
+ * flips back to false while the `GlPosting` it reversed and the reversal itself
+ * both stay in the books forever. An account that permanently changed the ledger
+ * would become hard-deletable again the moment somebody undid the last review.
+ *
+ * Tested the way `import/reverse.ts`'s `refusalReason` is: pure, exhaustive, and
+ * without a single double.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { BankAccountRemovalFacts } from '../client'
+import { resolveRemoval } from '../writes'
+
+function facts(partial: Partial<BankAccountRemovalFacts> = {}): BankAccountRemovalFacts {
+  return {
+    hasEverPosted: false,
+    transactionCount: 0,
+    matchedCount: 0,
+    unreviewedCount: 0,
+    connectorId: null,
+    rules: [],
+    ...partial,
+  }
+}
+
+const THREE_RULES = [
+  { id: 'rule_1', name: 'Monthly bank fee' },
+  { id: 'rule_2', name: 'Card payments' },
+  { id: 'rule_3', name: 'Transfer to savings' },
+]
+
+describe('resolveRemoval - hasEverPosted is the only term', () => {
+  it('deletes a bare account', () => {
+    expect(resolveRemoval(facts()).verb).toBe('delete')
+  })
+
+  it('deletes an account with 400 rows, a live connector and three rules', () => {
+    const plan = resolveRemoval(
+      facts({
+        transactionCount: 400,
+        matchedCount: 12,
+        unreviewedCount: 388,
+        connectorId: 'conn_1',
+        rules: THREE_RULES,
+      })
+    )
+    expect(plan.verb).toBe('delete')
+    // Every one of those is the dialog's business and none of them is the gate's.
+    expect(plan.cascade).toEqual({ transactions: 400, matched: 12, releasesAtStripe: true })
+    expect(plan.warnings).toEqual(THREE_RULES)
+  })
+
+  it('deletes an account whose rows are MATCHED but never coded', () => {
+    // ⚠️ A real decision (§5.1): a match is evidence ABOUT an entry, never the
+    // entry itself, and blocking on it would let one auto-detected transfer make
+    // a wrongly-connected account permanently undeletable.
+    const plan = resolveRemoval(facts({ transactionCount: 9, matchedCount: 9 }))
+    expect(plan.verb).toBe('delete')
+    expect(plan.cascade.matched).toBe(9)
+  })
+
+  it('archives once anything has posted, whatever else is true', () => {
+    expect(resolveRemoval(facts({ hasEverPosted: true })).verb).toBe('archive')
+    expect(
+      resolveRemoval(
+        facts({
+          hasEverPosted: true,
+          transactionCount: 0,
+          matchedCount: 0,
+          unreviewedCount: 0,
+          connectorId: null,
+          rules: [],
+        })
+      ).verb
+    ).toBe('archive')
+    expect(
+      resolveRemoval(
+        facts({
+          hasEverPosted: true,
+          transactionCount: 400,
+          matchedCount: 12,
+          unreviewedCount: 388,
+          connectorId: 'conn_1',
+          rules: THREE_RULES,
+        })
+      ).verb
+    ).toBe('archive')
+  })
+
+  it('names no cascade for an archive, because an archive destroys nothing', () => {
+    const plan = resolveRemoval(
+      facts({ hasEverPosted: true, transactionCount: 1240, matchedCount: 3 })
+    )
+    // 🛑 "1,240 transactions will be deleted" in front of somebody about to
+    // archive is a lie that reads exactly like the truth on the other branch.
+    expect(plan.cascade.transactions).toBe(0)
+    expect(plan.cascade.matched).toBe(0)
+  })
+
+  it('carries the unreviewed count on BOTH branches - the archive excludes them', () => {
+    expect(resolveRemoval(facts({ unreviewedCount: 14 })).unreviewed).toBe(14)
+    expect(resolveRemoval(facts({ hasEverPosted: true, unreviewedCount: 14 })).unreviewed).toBe(14)
+  })
+
+  it('reports the Stripe release on both branches - archive disconnects first', () => {
+    expect(resolveRemoval(facts({ connectorId: 'conn_1' })).cascade.releasesAtStripe).toBe(true)
+    expect(
+      resolveRemoval(facts({ hasEverPosted: true, connectorId: 'conn_1' })).cascade.releasesAtStripe
+    ).toBe(true)
+    expect(resolveRemoval(facts()).cascade.releasesAtStripe).toBe(false)
+  })
+
+  it('never blocks on a rule - it names it', () => {
+    const plan = resolveRemoval(facts({ rules: THREE_RULES }))
+    expect(plan.verb).toBe('delete')
+    expect(plan.warnings.map((rule) => rule.name)).toEqual([
+      'Monthly bank fee',
+      'Card payments',
+      'Transfer to savings',
+    ])
+  })
+})
+
+describe('resolveRemoval - the flag survives every undo', () => {
+  /**
+   * 🛑 The test §5.1's whole argument reduces to.
+   *
+   * `undoReview` on the only coded row, a posting reversal, and `reverseImport`
+   * each leave `bank_account_has_posted` TRUE - the write paths are asserted not
+   * to touch it in `review/__tests__/writes.test.ts` and
+   * `__tests__/reverse-keeps-has-posted.test.ts` - and this is the consequence
+   * that matters: the account still archives, and never becomes deletable again.
+   */
+  const AFTER_EVERY_UNDO = facts({
+    hasEverPosted: true,
+    // What each undo path leaves behind, and none of it is the gate's business:
+    // the line is back in `for_review`, carries no posting id, and nothing on the
+    // account looks posted any more.
+    transactionCount: 1,
+    matchedCount: 0,
+    unreviewedCount: 1,
+  })
+
+  it('still archives after undoReview returned the only coded row to the queue', () => {
+    expect(resolveRemoval(AFTER_EVERY_UNDO).verb).toBe('archive')
+  })
+
+  it('still archives after the posting was reversed', () => {
+    // A reversal is a SECOND GlPosting at revision N+1; both halves stay in the
+    // register. There is more in the books after a reversal, not less.
+    expect(resolveRemoval({ ...AFTER_EVERY_UNDO, transactionCount: 1 }).verb).toBe('archive')
+  })
+
+  it('still archives after reverseImport removed every row it was allowed to', () => {
+    // The import is gone and the account holds nothing at all. It still archives:
+    // the entry that was posted from one of those rows is still in the ledger.
+    expect(
+      resolveRemoval({ ...AFTER_EVERY_UNDO, transactionCount: 0, unreviewedCount: 0 }).verb
+    ).toBe('archive')
+  })
+
+  it('would WRONGLY delete if the gate were derived from the rows', () => {
+    // The counter-example, kept explicit so the reason for the stored field is
+    // legible: every row-shaped signal says "nothing here ever posted", and the
+    // stored flag is the only thing that disagrees.
+    const rowDerived = { ...AFTER_EVERY_UNDO, hasEverPosted: false }
+    expect(resolveRemoval(rowDerived).verb).toBe('delete')
+    expect(resolveRemoval(AFTER_EVERY_UNDO).verb).toBe('archive')
+  })
+})

--- a/packages/lib/src/banking/__tests__/removal-writes.test.ts
+++ b/packages/lib/src/banking/__tests__/removal-writes.test.ts
@@ -1,0 +1,471 @@
+// packages/lib/src/banking/__tests__/removal-writes.test.ts
+
+/**
+ * The three removal verbs
+ * (plans/bank-connection/08-removing-a-bank-account.md §8).
+ *
+ * 🛑 The two assertions that matter most are about ORDER and about ABSENCE:
+ *
+ *  1. **A delete releases at Stripe BEFORE it drops the connector**, and drops
+ *     nothing if the release threw. Deleting first and failing the release is
+ *     unrecoverable - the `providerAccountId` we would need is on the row we just
+ *     destroyed, and the nightly reaper only sweeps connectors that still EXIST -
+ *     so the org keeps paying 30c a month forever with nothing left to find it by.
+ *  2. **An archive touches no `GlPosting` and no `gl_account`.** §3 is the
+ *     load-bearing claim of the whole brief: a `bank_account` holds a POINTER to
+ *     a GL code, so archiving one cannot move the trial balance by a cent. If a
+ *     later change breaks that, this is where it should fail.
+ *
+ * The collaborators are mocked rather than faked, the way
+ * `review/__tests__/writes.test.ts` mocks `postEntry`: what is under test is the
+ * ordering and the set of writes, not the behaviour of the things being called.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BankAccountRemovalFacts, BankAccountRow } from '../client'
+
+const h = vi.hoisted(() => ({
+  /** Every collaborator call, in the order it happened. The ordering assertions read this. */
+  trace: [] as string[],
+  reapBankFeedAccount: vi.fn(),
+  findBankFeedAccountForConnector: vi.fn(),
+  disconnectBankAccountFeed: vi.fn(),
+  deleteCredential: vi.fn(),
+  crudUpdate: vi.fn(),
+  crudDelete: vi.fn(),
+  crudArchive: vi.fn(),
+  crudRestore: vi.fn(),
+  /** `bank_transaction` rows `listForReview` answers, keyed by the state asked for. */
+  linesByState: new Map<string, { id: string; excludeReason?: string | null }[]>(),
+  /**
+   * Every line the DELETE cascade finds - archived ones included, which is why
+   * it does not go through `listForReview`.
+   */
+  cascadeLineIds: [] as string[],
+  /** Every `db.delete(...)` the verbs issued, as a table name. */
+  deletes: [] as string[],
+  /** What a `db.select(...).limit()` resolves to - the sibling-connector probe. */
+  siblings: [] as { id: string }[],
+  account: null as BankAccountRow | null,
+  facts: null as BankAccountRemovalFacts | null,
+}))
+
+vi.mock('../feed/reaper', () => ({
+  reapBankFeedAccount: h.reapBankFeedAccount,
+  findBankFeedAccountForConnector: h.findBankFeedAccountForConnector,
+}))
+vi.mock('../feed/actions', () => ({ disconnectBankAccountFeed: h.disconnectBankAccountFeed }))
+vi.mock('@auxx/credentials/store', () => ({ deleteCredential: h.deleteCredential }))
+vi.mock('../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    update = h.crudUpdate
+    delete = h.crudDelete
+    archive = h.crudArchive
+    restore = h.crudRestore
+  },
+}))
+vi.mock('../review/reads', () => ({
+  requireReviewFieldContext: async () => ({
+    bankTransactionDefId: 'def_bt',
+    fields: {},
+    suggestionFields: {},
+  }),
+  listForReview: async (_db: unknown, filters: { state?: string }) => ({
+    isErr: () => false,
+    isOk: () => true,
+    value: h.linesByState.get(filters.state ?? 'for_review') ?? [],
+  }),
+}))
+vi.mock('../reads', () => ({
+  requireBankAccountFieldContext: async () => ({ bankAccountDefId: 'def_ba', fields: {} }),
+  getBankAccount: async () => ({
+    isErr: () => false,
+    isOk: () => true,
+    value: h.account,
+  }),
+  readRemovalFacts: async () => ({
+    isErr: () => false,
+    isOk: () => true,
+    value: h.facts,
+  }),
+  readBankTransactionIdsForAccount: async () => ({
+    isErr: () => false,
+    isOk: () => true,
+    value: { bankTransactionDefId: 'def_bt', ids: h.cascadeLineIds },
+  }),
+}))
+
+const { archiveBankAccount, deleteBankAccount, restoreBankAccount } = await import('../writes')
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const ACCOUNT = 'acct_1'
+
+function account(partial: Partial<BankAccountRow> = {}): BankAccountRow {
+  return {
+    id: ACCOUNT,
+    recordId: `def_ba:${ACCOUNT}`,
+    name: 'Business Adv Relationship',
+    institution: 'Bank of America',
+    last4: '5381',
+    type: 'depository',
+    currency: 'USD',
+    glAccountCode: '1010',
+    feedStartDate: null,
+    coverageFrom: '2026-01-01',
+    coverageGaps: [],
+    connectorId: null,
+    status: 'manual',
+    hasEverPosted: false,
+    archivedAt: null,
+    createdAt: null,
+    connector: null,
+    ...partial,
+  }
+}
+
+function facts(partial: Partial<BankAccountRemovalFacts> = {}): BankAccountRemovalFacts {
+  return {
+    hasEverPosted: false,
+    transactionCount: 0,
+    matchedCount: 0,
+    unreviewedCount: 0,
+    connectorId: null,
+    rules: [],
+    ...partial,
+  }
+}
+
+/** A db double whose only real jobs are the connector delete and the sibling probe. */
+function fakeDb() {
+  return {
+    delete: () => ({
+      where: () => ({
+        returning: async () => {
+          h.trace.push('delete-connector')
+          h.deletes.push('DataConnector')
+          return [{ id: 'conn_1' }]
+        },
+      }),
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => h.siblings,
+        }),
+      }),
+    }),
+  } as never
+}
+
+beforeEach(() => {
+  h.trace.length = 0
+  h.deletes.length = 0
+  h.siblings = []
+  h.linesByState.clear()
+  h.cascadeLineIds = []
+  h.account = account()
+  h.facts = facts()
+  vi.clearAllMocks()
+  h.reapBankFeedAccount.mockImplementation(async () => {
+    h.trace.push('reap')
+    return true
+  })
+  h.findBankFeedAccountForConnector.mockImplementation(async () => ({
+    connectorId: 'conn_1',
+    organizationId: ORG,
+    credentialId: 'cred_1',
+    providerAccountId: 'fca_123',
+  }))
+  h.disconnectBankAccountFeed.mockImplementation(async () => {
+    h.trace.push('disconnect')
+    return { isErr: () => false, isOk: () => true, value: {} }
+  })
+  h.deleteCredential.mockImplementation(async () => {
+    h.trace.push('delete-credential')
+    return { isOk: () => true, isErr: () => false }
+  })
+  h.crudDelete.mockImplementation(async (recordId: string) => {
+    h.trace.push(`crud-delete ${recordId}`)
+  })
+  h.crudArchive.mockImplementation(async (recordId: string) => {
+    h.trace.push(`crud-archive ${recordId}`)
+  })
+  h.crudRestore.mockImplementation(async (recordId: string) => {
+    h.trace.push(`crud-restore ${recordId}`)
+  })
+  h.crudUpdate.mockImplementation(async (recordId: string) => {
+    h.trace.push(`crud-update ${recordId}`)
+  })
+})
+
+describe('deleteBankAccount', () => {
+  it('releases at Stripe BEFORE dropping the connector', async () => {
+    h.account = account({ connectorId: 'conn_1', status: 'connected' })
+    h.facts = facts({ connectorId: 'conn_1', transactionCount: 2 })
+    h.cascadeLineIds = ['txn_1', 'txn_2']
+
+    const result = await deleteBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.trace.indexOf('reap')).toBeGreaterThanOrEqual(0)
+    expect(h.trace.indexOf('reap')).toBeLessThan(h.trace.indexOf('delete-connector'))
+  })
+
+  it('drops NOTHING when the release threw', async () => {
+    h.account = account({ connectorId: 'conn_1', status: 'connected' })
+    h.facts = facts({ connectorId: 'conn_1' })
+    h.reapBankFeedAccount.mockRejectedValue(new Error('stripe is down'))
+
+    const result = await deleteBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isErr()).toBe(true)
+    // 🛑 The account is still whole, so pressing Remove again is a real retry.
+    expect(h.deletes).toEqual([])
+    expect(h.crudDelete).not.toHaveBeenCalled()
+    expect(h.deleteCredential).not.toHaveBeenCalled()
+  })
+
+  it('deletes every line whatever its review status, then the account last', async () => {
+    h.facts = facts({ transactionCount: 3, matchedCount: 1 })
+    // The third is ARCHIVED, and it goes too: a line left pointing at a deleted
+    // account is an orphan nothing would ever clean up.
+    h.cascadeLineIds = ['txn_1', 'txn_2', 'txn_3']
+
+    const result = await deleteBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value.transactionsDeleted).toBe(3)
+    expect(h.trace).toEqual([
+      'crud-delete def_bt:txn_1',
+      'crud-delete def_bt:txn_2',
+      'crud-delete def_bt:txn_3',
+      `crud-delete def_ba:${ACCOUNT}`,
+    ])
+  })
+
+  it('refuses once anything has posted, and names the archive', async () => {
+    h.facts = facts({ hasEverPosted: true })
+
+    const result = await deleteBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.message).toMatch(/archived/)
+    expect(h.trace).toEqual([])
+  })
+
+  it('keeps the credential when another connector still holds the same LOGIN', async () => {
+    h.account = account({ connectorId: 'conn_1', status: 'connected' })
+    h.facts = facts({ connectorId: 'conn_1' })
+    h.siblings = [{ id: 'conn_2' }]
+
+    await deleteBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    // 🛑 One credential is one bank LOGIN. Deleting it would take the sibling
+    // account's feed down as a side effect of removing this one.
+    expect(h.deleteCredential).not.toHaveBeenCalled()
+  })
+
+  it('deletes the credential when this was the last account on the login', async () => {
+    h.account = account({ connectorId: 'conn_1', status: 'connected' })
+    h.facts = facts({ connectorId: 'conn_1' })
+    h.siblings = []
+
+    const result = await deleteBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(h.deleteCredential).toHaveBeenCalledWith('cred_1', ORG)
+    if (result.isOk()) expect(result.value.credentialDeleted).toBe(true)
+  })
+})
+
+describe('archiveBankAccount', () => {
+  it('disconnects AND reaps before setting archivedAt', async () => {
+    h.account = account({ connectorId: 'conn_1', status: 'connected', hasEverPosted: true })
+
+    const result = await archiveBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value.disconnected).toBe(true)
+    // `disconnectBankAccountFeed` is what calls `reapBankFeedAccount`, and it is
+    // the only thing that stops the 30c a month. Archiving a still-billing
+    // account out of the UI is the leak `feed/reaper.ts` was built to stop.
+    expect(h.trace.indexOf('disconnect')).toBe(0)
+    expect(h.trace.indexOf('disconnect')).toBeLessThan(
+      h.trace.indexOf(`crud-archive def_ba:${ACCOUNT}`)
+    )
+  })
+
+  it('sweeps for_review and suggested to excluded with the prefix, and nothing else', async () => {
+    h.account = account({ hasEverPosted: true })
+    h.linesByState.set('for_review', [{ id: 'txn_a' }, { id: 'txn_b' }])
+    h.linesByState.set('suggested', [{ id: 'txn_c' }])
+    // 🛑 Present in the store and NEVER asked for. `matched`, `coded` and
+    // human-`excluded` rows are already in the books or carry somebody's
+    // decision, so the narrowing is done in the query rather than afterwards.
+    h.linesByState.set('matched', [{ id: 'txn_matched' }])
+    h.linesByState.set('coded', [{ id: 'txn_coded' }])
+    h.linesByState.set('excluded', [{ id: 'txn_excluded' }])
+
+    const result = await archiveBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value.excluded).toBe(3)
+
+    const touched = h.crudUpdate.mock.calls.map((call) => call[0])
+    expect(touched).toEqual(['def_bt:txn_a', 'def_bt:txn_b', 'def_bt:txn_c'])
+    for (const call of h.crudUpdate.mock.calls) {
+      expect(call[1]).toMatchObject({ bank_transaction_review_status: 'excluded' })
+      expect(String((call[1] as Record<string, unknown>).bank_transaction_exclude_reason)).toMatch(
+        /^Excluded when the bank account was archived/
+      )
+    }
+  })
+
+  it('leaves GlPosting and the mapped gl_account untouched', async () => {
+    // 🛑 The regression test §3 asks for. A `bank_account` carries a POINTER to a
+    // GL code and `GlPostingLine` snapshots the code with no foreign key back
+    // here, so archiving cannot move the trial balance by a cent. The only way it
+    // could is if this path started writing to the chart or the ledger.
+    h.account = account({ hasEverPosted: true, glAccountCode: '1010' })
+    h.linesByState.set('for_review', [{ id: 'txn_a' }])
+
+    await archiveBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    // No raw db write of any kind, so no `GlPosting` and no `GlAccount` row moved.
+    expect(h.deletes).toEqual([])
+    // The only record writes are the three exclusions and the archive itself.
+    for (const call of h.crudUpdate.mock.calls) {
+      expect(String(call[0])).toMatch(/^def_bt:/)
+      const patch = call[1] as Record<string, unknown>
+      expect(patch).not.toHaveProperty('bank_account_gl_account')
+      expect(patch).not.toHaveProperty('bank_account_coverage_from')
+    }
+    expect(h.crudArchive).toHaveBeenCalledTimes(1)
+    expect(h.crudArchive).toHaveBeenCalledWith(`def_ba:${ACCOUNT}`)
+    expect(h.crudDelete).not.toHaveBeenCalled()
+  })
+
+  it('never clears coverage_from', async () => {
+    // A balance sheet spanning the archived account's period still has to know
+    // what was covered (§5.3).
+    h.account = account({ hasEverPosted: true, coverageFrom: '2026-01-01' })
+
+    await archiveBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    const accountWrites = h.crudUpdate.mock.calls.filter((call) =>
+      String(call[0]).startsWith('def_ba:')
+    )
+    expect(accountWrites).toEqual([])
+  })
+})
+
+describe('restoreBankAccount', () => {
+  it('round-trips an archived account', async () => {
+    h.account = account({ hasEverPosted: true, archivedAt: new Date('2026-09-08T00:00:00.000Z') })
+
+    const result = await restoreBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.crudRestore).toHaveBeenCalledWith(`def_ba:${ACCOUNT}`)
+  })
+
+  it("re-opens the ARCHIVE's own exclusions and leaves a person's alone", async () => {
+    h.account = account({ hasEverPosted: true, archivedAt: new Date('2026-09-08T00:00:00.000Z') })
+    h.linesByState.set('excluded', [
+      { id: 'txn_swept', excludeReason: 'Excluded when the bank account was archived: Checking' },
+      { id: 'txn_human', excludeReason: 'Personal, not the business' },
+      { id: 'txn_no_reason', excludeReason: null },
+    ])
+
+    const result = await restoreBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    // 🛑 Exactly one row moves. Reversibility is the whole argument for sweeping
+    // the queue instead of refusing the archive (plan §6), and "undo it one row
+    // at a time" is not a path for the 400-row account this feature exists to
+    // clean up - so a restore that left them excluded would make archive one-way
+    // in practice. But a row a PERSON excluded carries their decision and the
+    // reason they had to give for it, and survives untouched.
+    const touched = h.crudUpdate.mock.calls.map((call) => call[0])
+    expect(touched).toEqual(['def_bt:txn_swept'])
+    expect(h.crudUpdate.mock.calls[0]?.[1]).toMatchObject({
+      bank_transaction_review_status: 'for_review',
+      bank_transaction_exclude_reason: null,
+    })
+  })
+
+  it('re-opens nothing when the archive swept nothing', async () => {
+    h.account = account({ hasEverPosted: true, archivedAt: new Date('2026-09-08T00:00:00.000Z') })
+    h.linesByState.set('excluded', [{ id: 'txn_human', excludeReason: 'Owner draw' }])
+
+    const result = await restoreBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.crudUpdate).not.toHaveBeenCalled()
+  })
+
+  it('refuses an account that is not archived', async () => {
+    h.account = account({ archivedAt: null })
+
+    const result = await restoreBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(h.crudRestore).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/banking/client.ts
+++ b/packages/lib/src/banking/client.ts
@@ -53,6 +53,29 @@ export const CREDIT_SIGN_WARNING =
   'so nothing downstream will catch it.'
 
 /**
+ * How an exclusion written by an ARCHIVE begins.
+ *
+ * 🛑 Archiving a bank account bulk-sets its `for_review` and `suggested` lines to
+ * `excluded`, because after the archive nobody will ever look at them again and
+ * the two alternatives are worse: refusing until the queue is empty leaves an org
+ * that connected the wrong bank unable to clear 180 days of noise off the screen,
+ * and a silent bulk delete destroys evidence that cash moved with no trace
+ * (plans/bank-connection/08-removing-a-bank-account.md §6).
+ *
+ * The prefix is what lets a later path tell an archive's own bookkeeping from a
+ * person's decision, exactly as `IMPORT_LINK_EXCLUSION_PREFIX` does for the
+ * importer's. An exclusion a HUMAN wrote carries the reason they gave and is the
+ * record of that decision; this one carries the account's name and the fact that
+ * the account went away.
+ */
+export const ARCHIVE_EXCLUSION_PREFIX = 'Excluded when the bank account was archived'
+
+/** Was this exclusion written by an archive, or by a person? */
+export function isArchiveExclusion(reason: string | null | undefined): boolean {
+  return !!reason?.trimStart().startsWith(ARCHIVE_EXCLUSION_PREFIX)
+}
+
+/**
  * A range with no data on an account, as inclusive `YYYY-MM-DD` date keys.
  *
  * Stored on `bank_account.coverageGaps` as an array of exactly this shape.
@@ -232,9 +255,58 @@ export interface BankAccountRow {
   coverageGaps: CoverageGap[]
   connectorId: string | null
   status: BankAccountStatus
+  /**
+   * 🛑 The write-once high-water mark: `true` once any line on this account has
+   * produced a journal entry, and NOTHING ever clears it - not `undoReview`, not
+   * a reversal, not `reverseImport`. It is the ONLY term in the removal gate
+   * (`resolveRemoval`): false deletes, true archives
+   * (plans/bank-connection/08-removing-a-bank-account.md §5.1).
+   */
+  hasEverPosted: boolean
+  /** When this account was archived, or null while it is live. */
+  archivedAt: Date | null
   createdAt: Date | null
   /** Null for a manual account, or when the connector row has gone. */
   connector: BankConnectorHealth | null
+}
+
+/**
+ * What the removal gate and the confirm dialog both read
+ * (plans/bank-connection/08-removing-a-bank-account.md §7.1).
+ *
+ * 🛑 **Only {@link BankAccountRemovalFacts.hasEverPosted} decides.** Everything
+ * else on this shape is there so the dialog can say what a delete would take
+ * with it, and none of it is allowed to change the verb.
+ */
+export interface BankAccountRemovalFacts {
+  /**
+   * 🛑 The write-once high-water mark, read straight off
+   * `bank_account_has_posted`. The ONLY term in the gate.
+   */
+  hasEverPosted: boolean
+  /** For the dialog: how much a delete would take with it. Never decides. */
+  transactionCount: number
+  /** Lines matched to a document. A delete removes them, deliberately (§5.1). */
+  matchedCount: number
+  /** `for_review` + `suggested`. An archive bulk-excludes these (§6). */
+  unreviewedCount: number
+  connectorId: string | null
+  /** Rules naming this account, in either field. A WARNING, never a blocker. */
+  rules: { id: string; name: string }[]
+}
+
+/** What removing a bank account actually does. Never a third option. */
+export type RemovalVerb = 'delete' | 'archive'
+
+/** {@link resolveRemoval}'s answer: the verb, what it costs, and what it breaks. */
+export interface BankAccountRemovalPlan {
+  verb: RemovalVerb
+  /** What a delete would destroy. Zeroed for an archive, which destroys nothing. */
+  cascade: { transactions: number; matched: number; releasesAtStripe: boolean }
+  /** How many unreviewed lines an archive would bulk-exclude (§6). */
+  unreviewed: number
+  /** Rules a delete would leave inert. Never blocks. */
+  warnings: { id: string; name: string }[]
 }
 
 /** The `DataConnector` columns a bank account's settings row renders. */

--- a/packages/lib/src/banking/feed/__tests__/reaper.test.ts
+++ b/packages/lib/src/banking/feed/__tests__/reaper.test.ts
@@ -21,7 +21,9 @@ vi.mock('../fc-client', () => ({
 const {
   clearFeedDisconnectedAt,
   FEED_DISCONNECTED_AT_KEY,
+  findBankFeedAccountForConnector,
   findReapableBankFeeds,
+  listBankFeedAccountsForOrganization,
   REAP_AFTER_DAYS,
   reapBankFeedAccount,
   reapDisconnectedBankFeeds,
@@ -283,5 +285,80 @@ describe('reapDisconnectedBankFeeds', () => {
     const stats = await reapDisconnectedBankFeeds(fakeDb([]), NOW)
     expect(stats).toEqual({ candidates: 0, disconnected: 0, failed: 0 })
     expect(disconnectAccountAtStripe).not.toHaveBeenCalled()
+  })
+})
+
+// plans/bank-connection/08-removing-a-bank-account.md §5.4 doors 3 and 4. The sweep is
+// the LAST line of defence, and for these two doors it is not a line of defence at all:
+// both destroy the `DataConnector` row on the way out, so the account has to be resolved
+// and released before they run. These two readers are how they do it.
+describe('the door lookups', () => {
+  /** The two-table read `listBankFeedAccountsForOrganization` and its per-connector sibling make. */
+  function lookupDb(rows: Array<{ providerAccountId: string | null }>) {
+    const predicates: unknown[] = []
+    const settle = (predicate: unknown) => {
+      predicates.push(predicate)
+      const promise = Promise.resolve(rows) as Promise<unknown> & { limit?: unknown }
+      promise.limit = () => Promise.resolve(rows)
+      return promise
+    }
+    return {
+      predicates,
+      select: () => ({
+        from: () => ({
+          innerJoin: () => ({ where: settle }),
+        }),
+      }),
+    } as never
+  }
+
+  const account = (over: Record<string, unknown> = {}) => ({
+    connectorId: 'conn_1',
+    organizationId: 'org_1',
+    credentialId: 'cred_1',
+    providerAccountId: 'fca_1',
+    ...over,
+  })
+
+  it('lists every account an organization holds, with no status filter', async () => {
+    // 🛑 A `disconnected` connector is a connection Stripe or the bank dropped, NOT an
+    // account that was released - it is still billing. The org is going away, so all of
+    // them go.
+    const db = lookupDb([account(), account({ connectorId: 'conn_2', providerAccountId: 'fca_2' })])
+    const accounts = await listBankFeedAccountsForOrganization(db, 'org_1')
+    expect(accounts.map((a) => a.providerAccountId)).toEqual(['fca_1', 'fca_2'])
+    const { params } = render((db as unknown as { predicates: unknown[] }).predicates[0])
+    expect(params).toContain('org_1')
+    // No `status` value is bound into the predicate at all.
+    expect(params).not.toContain('disconnected')
+  })
+
+  it('drops a row whose credential lost its provider account id', async () => {
+    const db = lookupDb([account({ providerAccountId: null })])
+    expect(await listBankFeedAccountsForOrganization(db, 'org_1')).toEqual([])
+  })
+
+  it('🛑 gates the per-connector lookup on the Financial Connections type', async () => {
+    // This predicate IS the "non-FC connectors are untouched" guarantee for the
+    // connector-delete door: every other connector type resolves no account, so nothing
+    // is ever disconnected at Stripe on its behalf.
+    const db = lookupDb([account()])
+    await findBankFeedAccountForConnector(db, 'org_1', 'conn_1')
+    const { params } = render((db as unknown as { predicates: unknown[] }).predicates[0])
+    expect(params).toContain('stripe-financial-connections')
+    expect(params).toContain('stripeFinancialConnections')
+    expect(params).toContain('org_1')
+    expect(params).toContain('conn_1')
+  })
+
+  it('returns null when the connector has no releasable account', async () => {
+    expect(await findBankFeedAccountForConnector(lookupDb([]), 'org_1', 'conn_1')).toBeNull()
+    expect(
+      await findBankFeedAccountForConnector(
+        lookupDb([account({ providerAccountId: null })]),
+        'org_1',
+        'conn_1'
+      )
+    ).toBeNull()
   })
 })

--- a/packages/lib/src/banking/feed/reaper.ts
+++ b/packages/lib/src/banking/feed/reaper.ts
@@ -12,13 +12,31 @@
  * inactive account still bills - because the failure is silent and the fix is one API
  * call.
  *
- * Three doors, and this file is the third:
+ * Four doors end a bank feed, numbered as `plans/bank-connection/08-removing-a-bank-account.md`
+ * §5.4 numbers them, and every one of them now releases:
  *   1. **Disconnect in our UI** - `banking.bankAccount.disconnect` calls
  *      {@link reapBankFeedAccount} directly. Immediate, because the user just said so.
- *   2. **Connector delete** - the same call from the delete path.
- *   3. **The nightly sweep** - this file. It catches everything the first two missed: a
+ *   2. **The nightly sweep** - this file. It catches what the others could not: a
  *      connector left `disconnected` by a Stripe event nobody acted on, and an
- *      organization that was deleted out from under its connectors.
+ *      organization that was suspended rather than deleted.
+ *   3. **Connector delete** - `data-connectors/mutations.ts`'s `deleteConnector` resolves
+ *      the account with {@link findBankFeedAccountForConnector} and calls
+ *      {@link reapBankFeedAccount} BEFORE it marks the row `deleting`, because the
+ *      teardown takes the `providerAccountId` with it.
+ *   4. **Organization delete** - `organizations/organization-service.ts` lists the org's
+ *      accounts with {@link listBankFeedAccountsForOrganization} and releases each one
+ *      BEFORE its transaction.
+ *
+ * 🛑 Doors 3 and 4 are NOT backstopped by the sweep, which is why they call the release
+ * themselves rather than leaving it to this file. `DataConnector.organizationId` is
+ * `onDelete: 'cascade'` and the connector teardown removes the row outright, so both of
+ * them destroy the evidence the sweep selects on - in door 4's case in the very
+ * transaction that would otherwise create the leak.
+ *
+ * ⚠️ Both of them tolerate a failed release and carry on. That is deliberate, and it is
+ * the opposite tradeoff from the plan-subscription cancel that sits beside door 4: a
+ * leaked 30c is recoverable by a human reading an invoice, an organization or a
+ * connector that can never be removed is not.
  *
  * ⚠️ The sweep waits {@link REAP_AFTER_DAYS} days. A `disconnected` connector is very
  * often a connection a person is about to REPAIR - `reconnectConnectorsForInstallation`
@@ -95,14 +113,96 @@ export async function clearFeedDisconnectedAt(db: Database, connectorId: string)
     .where(eq(schema.DataConnector.id, connectorId))
 }
 
-/** One connector the sweep decided to release. */
-export interface ReapCandidate {
+/**
+ * One Financial Connections account that can still be released at Stripe.
+ *
+ * The unit every door works in: a connector row, the credential it is bound to, and the
+ * `fca_...` id on that credential's metadata. Without the last of those there is nothing
+ * to call disconnect on.
+ */
+export interface BankFeedAccountRef {
   connectorId: string
   organizationId: string
   credentialId: string
   providerAccountId: string
+}
+
+/** One connector the sweep decided to release. */
+export interface ReapCandidate extends BankFeedAccountRef {
   /** Why it was picked: the connector is stale, or its organization is gone. */
   reason: 'disconnected' | 'organization-gone'
+}
+
+/**
+ * The columns every door reads, resolved the same way in all of them.
+ *
+ * 🛑 `providerAccountId` lives in the CREDENTIAL's jsonb metadata, not on the connector,
+ * so every path that wants to release an account has to make this join. Sharing the
+ * projection is what stops door 3 or door 4 inventing its own and quietly reading the
+ * wrong key.
+ */
+const feedAccountColumns = {
+  connectorId: schema.DataConnector.id,
+  organizationId: schema.DataConnector.organizationId,
+  credentialId: schema.Credential.id,
+  providerAccountId: sql<string>`${schema.Credential.metadata}->>'providerAccountId'`,
+}
+
+/** A Financial Connections connector whose credential still carries an account to release. */
+function releasableBankFeedFilter() {
+  return and(
+    eq(schema.DataConnector.type, STRIPE_FC_CONNECTOR_TYPE),
+    eq(schema.Credential.type, FC_PROVIDER_KEY),
+    isNotNull(sql`${schema.Credential.metadata}->>'providerAccountId'`)
+  )
+}
+
+/**
+ * Every releasable account one organization holds. Door 4 (organization delete).
+ *
+ * 🛑 No status filter. A `disconnected` connector is a connection Stripe or the bank
+ * dropped, NOT an account that was released - it is still billing. The org is going
+ * away, so every account it holds has to go with it.
+ */
+export async function listBankFeedAccountsForOrganization(
+  db: Database,
+  organizationId: string
+): Promise<BankFeedAccountRef[]> {
+  const rows = await db
+    .select(feedAccountColumns)
+    .from(schema.DataConnector)
+    .innerJoin(schema.Credential, eq(schema.DataConnector.credentialId, schema.Credential.id))
+    .where(and(releasableBankFeedFilter(), eq(schema.DataConnector.organizationId, organizationId)))
+
+  return rows.filter((row) => !!row.providerAccountId)
+}
+
+/**
+ * The releasable account behind ONE connector, org-scoped. Door 3 (connector delete).
+ *
+ * Returns null for every non-Financial-Connections connector and for an FC connector
+ * whose credential has no account id left, which is the caller's cue to do nothing.
+ */
+export async function findBankFeedAccountForConnector(
+  db: Database,
+  organizationId: string,
+  connectorId: string
+): Promise<BankFeedAccountRef | null> {
+  const rows = await db
+    .select(feedAccountColumns)
+    .from(schema.DataConnector)
+    .innerJoin(schema.Credential, eq(schema.DataConnector.credentialId, schema.Credential.id))
+    .where(
+      and(
+        releasableBankFeedFilter(),
+        eq(schema.DataConnector.organizationId, organizationId),
+        eq(schema.DataConnector.id, connectorId)
+      )
+    )
+    .limit(1)
+
+  const row = rows[0]
+  return row?.providerAccountId ? row : null
 }
 
 export interface ReapStats {
@@ -127,10 +227,7 @@ export async function findReapableBankFeeds(
 
   const rows = await db
     .select({
-      connectorId: schema.DataConnector.id,
-      organizationId: schema.DataConnector.organizationId,
-      credentialId: schema.Credential.id,
-      providerAccountId: sql<string>`${schema.Credential.metadata}->>'providerAccountId'`,
+      ...feedAccountColumns,
       organizationRowId: schema.Organization.id,
       organizationDisabledAt: schema.Organization.disabledAt,
       connectorUpdatedAt: schema.DataConnector.updatedAt,
@@ -141,9 +238,7 @@ export async function findReapableBankFeeds(
     .leftJoin(schema.Organization, eq(schema.Organization.id, schema.DataConnector.organizationId))
     .where(
       and(
-        eq(schema.DataConnector.type, STRIPE_FC_CONNECTOR_TYPE),
-        eq(schema.Credential.type, FC_PROVIDER_KEY),
-        isNotNull(sql`${schema.Credential.metadata}->>'providerAccountId'`),
+        releasableBankFeedFilter(),
         // Three arms, and only ONE of them skips the waiting period.
         //
         // 🛑 `disabledAt` is ADMIN SUSPENSION, not deletion - a billing dispute,

--- a/packages/lib/src/banking/import/__tests__/reverse-keeps-has-posted.test.ts
+++ b/packages/lib/src/banking/import/__tests__/reverse-keeps-has-posted.test.ts
@@ -1,0 +1,140 @@
+// packages/lib/src/banking/import/__tests__/reverse-keeps-has-posted.test.ts
+
+/**
+ * 🛑 `reverseImport` never clears `bank_account_has_posted`
+ * (plans/bank-connection/08-removing-a-bank-account.md §5.1, §8).
+ *
+ * The third of the three undo paths the removal gate has to survive - the other
+ * two, `undoReview` and the posting reversal it performs, are pinned in
+ * `review/__tests__/writes.test.ts`.
+ *
+ * Reversing an import can take an account down to zero rows. What it cannot do is
+ * take a journal entry out of the ledger: `refusalReason` refuses every row that
+ * carries a posting or a match precisely because they are the source documents of
+ * entries that stay in the books. So an account that has ever posted must still
+ * archive rather than delete after a reverse, and the only way that holds is if
+ * nothing on this path writes the flag.
+ *
+ * ⚠️ This path DOES write to the bank account - `recomputeAfterDelete` pulls
+ * `coverageFrom` back to the earliest surviving row - so "it never touches the
+ * account" would be the wrong assertion and would pass for the wrong reason. The
+ * assertion is about the FIELD.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BankTransactionRow } from '../fields'
+
+const h = vi.hoisted(() => ({
+  crudUpdate: vi.fn(),
+  crudDelete: vi.fn(),
+  rows: [] as BankTransactionRow[],
+  remaining: [] as BankTransactionRow[],
+}))
+
+vi.mock('../../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    update = h.crudUpdate
+    delete = h.crudDelete
+  },
+}))
+vi.mock('../fields', () => ({
+  requireBankTransactionImportContext: async () => ({
+    bankTransactionDefId: 'def_bt',
+    fields: {},
+  }),
+  readTransactionsByBatch: async () => h.rows,
+  readTransactionsByAccount: async () => h.remaining,
+}))
+vi.mock('../../reads', () => ({
+  requireBankAccountFieldContext: async () => ({ bankAccountDefId: 'def_ba', fields: {} }),
+  getBankAccount: async () => ({
+    isErr: () => false,
+    isOk: () => true,
+    // A coverage claim that no longer matches the surviving rows, so the
+    // pull-back write really fires and the assertion below is not vacuous.
+    value: { id: 'acct_1', name: 'Chequing', coverageFrom: '2026-01-01' },
+  }),
+  readCoverage: async () => ({
+    isErr: () => false,
+    isOk: () => true,
+    value: { coverageFrom: null, gaps: [] },
+  }),
+}))
+
+const { reverseImport } = await import('../reverse')
+
+function row(over: Partial<BankTransactionRow> = {}): BankTransactionRow {
+  return {
+    id: 'txn_1',
+    createdAt: null,
+    externalId: 'bt-0001',
+    bankAccountId: 'acct_1',
+    postedAt: '2026-02-01',
+    description: 'ACME SUPPLY CO',
+    amountMinor: -12_450,
+    matchKey: 'acme supply co',
+    importBatchId: 'batch_1',
+    source: 'import',
+    reviewStatus: 'for_review',
+    excludeReason: null,
+    glPostingId: null,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.rows = []
+  h.remaining = []
+  h.crudUpdate.mockResolvedValue(undefined)
+  h.crudDelete.mockResolvedValue(undefined)
+})
+
+describe('reverseImport and the removal gate', () => {
+  it('writes no bank_account_has_posted, even while it rewrites coverageFrom', async () => {
+    h.rows = [row({ id: 'txn_1' }), row({ id: 'txn_2', postedAt: '2026-02-02' })]
+
+    const result = await reverseImport({} as never, {
+      organizationId: 'org_1',
+      actorUserId: 'user_1',
+      importBatchId: 'batch_1',
+    })
+
+    expect(result.isOk()).toBe(true)
+    // The account WAS written - this is the coverage pull-back, and it proves the
+    // assertion below is looking at a path that really reaches the record.
+    const accountWrites = h.crudUpdate.mock.calls.filter(([id]) => String(id).startsWith('def_ba:'))
+    expect(accountWrites.length).toBeGreaterThan(0)
+    for (const [, patch] of accountWrites) {
+      expect(Object.keys((patch ?? {}) as object)).toEqual(['bank_account_coverage_from'])
+    }
+  })
+
+  it('leaves the flag alone on a batch whose posted row it refuses', async () => {
+    // The realistic shape: one line posted an entry, the rest did not. The posted
+    // one is refused by name and the entry stays in the books, which is exactly
+    // why the account may never become deletable again.
+    h.rows = [
+      row({ id: 'txn_1', glPostingId: 'post_1', reviewStatus: 'coded' }),
+      row({ id: 'txn_2' }),
+    ]
+    h.remaining = [row({ id: 'txn_1', glPostingId: 'post_1', reviewStatus: 'coded' })]
+
+    const result = await reverseImport({} as never, {
+      organizationId: 'org_1',
+      actorUserId: 'user_1',
+      importBatchId: 'batch_1',
+    })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value.deleted).toBe(1)
+      expect(result.value.refused).toHaveLength(1)
+    }
+    expect(
+      h.crudUpdate.mock.calls.some(([, patch]) =>
+        Object.hasOwn((patch ?? {}) as object, 'bank_account_has_posted')
+      )
+    ).toBe(false)
+  })
+})

--- a/packages/lib/src/banking/index.ts
+++ b/packages/lib/src/banking/index.ts
@@ -9,13 +9,17 @@
 
 export type {
   BankAccountCoverage,
+  BankAccountRemovalFacts,
+  BankAccountRemovalPlan,
   BankAccountRow,
   BankAccountStatus,
   BankAccountType,
   BankConnectorHealth,
   CoverageGap,
+  RemovalVerb,
 } from './client'
 export {
+  ARCHIVE_EXCLUSION_PREFIX,
   BANK_ACCOUNT_GL_TYPES,
   BANK_ACCOUNT_STATUS_LABELS,
   BANK_ACCOUNT_STATUSES,
@@ -25,6 +29,7 @@ export {
   CREDIT_SIGN_WARNING,
   computeCoverageGaps,
   daysBetween,
+  isArchiveExclusion,
   mergeCoverageGaps,
   resolveBankAccountStatus,
   resolveBankAccountType,
@@ -128,7 +133,23 @@ export {
   loadBankAccountFieldContext,
   loadBankTransactionFieldContext,
   readCoverage,
+  readRemovalFacts,
   requireBankAccountFieldContext,
 } from './reads'
-export type { CreateBankAccountInput, UpdateBankAccountInput } from './writes'
-export { createBankAccount, updateBankAccount } from './writes'
+export type {
+  ArchiveBankAccountInput,
+  ArchiveBankAccountResult,
+  CreateBankAccountInput,
+  DeleteBankAccountInput,
+  DeleteBankAccountResult,
+  RestoreBankAccountInput,
+  UpdateBankAccountInput,
+} from './writes'
+export {
+  archiveBankAccount,
+  createBankAccount,
+  deleteBankAccount,
+  resolveRemoval,
+  restoreBankAccount,
+  updateBankAccount,
+} from './writes'

--- a/packages/lib/src/banking/reads.ts
+++ b/packages/lib/src/banking/reads.ts
@@ -27,6 +27,7 @@ import { NotFoundError, UnprocessableEntityError } from '../errors'
 import { toRecordId } from '../resources/resource-id'
 import {
   type BankAccountCoverage,
+  type BankAccountRemovalFacts,
   type BankAccountRow,
   type BankConnectorHealth,
   type CoverageGap,
@@ -37,6 +38,9 @@ import {
   toDateKey,
 } from './client'
 import { guard } from './guard'
+// The leaf, not `./rules`: the barrel drags the rule evaluator and the
+// suggestion miner in to answer "which rules name this account".
+import { listBankRules } from './rules/reads'
 
 /** Every `bank_account` attribute a {@link BankAccountRow} is assembled from. */
 const BANK_ACCOUNT_ATTRIBUTES = [
@@ -51,12 +55,14 @@ const BANK_ACCOUNT_ATTRIBUTES = [
   'bank_account_coverage_gaps',
   'bank_account_connector_id',
   'bank_account_status',
+  'bank_account_has_posted',
 ] as const
 
 /** The `bank_transaction` attributes the coverage derivation reads. */
 const BANK_TRANSACTION_ATTRIBUTES = [
   'bank_transaction_bank_account',
   'bank_transaction_posted_at',
+  'bank_transaction_review_status',
 ] as const
 
 type BankAccountAttribute = (typeof BANK_ACCOUNT_ATTRIBUTES)[number]
@@ -138,22 +144,30 @@ export async function loadBankTransactionFieldContext(
  */
 export async function listBankAccounts(
   db: Database,
-  params: { organizationId: string }
+  params: { organizationId: string; includeArchived?: boolean }
 ): Promise<Result<BankAccountRow[], Error>> {
-  const { organizationId } = params
+  const { organizationId, includeArchived = false } = params
   return guard(
     async () => {
       const ctx = await loadBankAccountFieldContext(organizationId)
       if (!ctx) return []
 
       const instances = await db
-        .select({ id: schema.EntityInstance.id, createdAt: schema.EntityInstance.createdAt })
+        .select({
+          id: schema.EntityInstance.id,
+          createdAt: schema.EntityInstance.createdAt,
+          archivedAt: schema.EntityInstance.archivedAt,
+        })
         .from(schema.EntityInstance)
         .where(
           and(
             eq(schema.EntityInstance.organizationId, organizationId),
             eq(schema.EntityInstance.entityDefinitionId, ctx.bankAccountDefId),
-            isNull(schema.EntityInstance.archivedAt)
+            // 🛑 Default FALSE, so every existing caller is unchanged. Only the
+            // settings list's "Show archived" toggle and the pickers - which
+            // have to render an archived account that is still a record's
+            // current value - ever ask for the other answer.
+            ...(includeArchived ? [] : [isNull(schema.EntityInstance.archivedAt)])
           )
         )
         .orderBy(asc(schema.EntityInstance.createdAt))
@@ -175,23 +189,29 @@ export async function listBankAccounts(
  */
 export async function getBankAccount(
   db: Database,
-  params: { organizationId: string; bankAccountId: string }
+  params: { organizationId: string; bankAccountId: string; includeArchived?: boolean }
 ): Promise<Result<BankAccountRow | null, Error>> {
-  const { organizationId, bankAccountId } = params
+  const { organizationId, bankAccountId, includeArchived = false } = params
   return guard(
     async () => {
       const ctx = await loadBankAccountFieldContext(organizationId)
       if (!ctx) return null
 
       const [instance] = await db
-        .select({ id: schema.EntityInstance.id, createdAt: schema.EntityInstance.createdAt })
+        .select({
+          id: schema.EntityInstance.id,
+          createdAt: schema.EntityInstance.createdAt,
+          archivedAt: schema.EntityInstance.archivedAt,
+        })
         .from(schema.EntityInstance)
         .where(
           and(
             eq(schema.EntityInstance.id, bankAccountId),
             eq(schema.EntityInstance.organizationId, organizationId),
             eq(schema.EntityInstance.entityDefinitionId, ctx.bankAccountDefId),
-            isNull(schema.EntityInstance.archivedAt)
+            // Default false, as above. `restoreBankAccount` and the removal
+            // preview are the only readers that need an archived row back.
+            ...(includeArchived ? [] : [isNull(schema.EntityInstance.archivedAt)])
           )
         )
         .limit(1)
@@ -274,6 +294,183 @@ export async function readCoverage(
 }
 
 /**
+ * Everything the removal gate and its confirm dialog need, in one pass
+ * (plans/bank-connection/08-removing-a-bank-account.md §7.2).
+ *
+ * 🛑 **`hasEverPosted` is read STRAIGHT OFF THE FIELD and is never derived from
+ * the rows.** That is §5.1's whole point: `undoReview` sets
+ * `bank_transaction_gl_posting_id` back to `null`, so a predicate computed from
+ * the transactions flips back to false - while the `GlPosting` it reversed and
+ * the reversal itself both stay in the books forever with a row on this account
+ * as their source document. An account that permanently changed the ledger would
+ * become deletable again the moment somebody undid the last review.
+ *
+ * Every other fact here is for the dialog and DECIDES NOTHING. The counts say
+ * how much a delete would take with it; the rules are named so a person knows
+ * which configuration a delete leaves inert (`rules/evaluate.ts` skips a rule
+ * whose `bankAccountId` does not match, so a dangling scope makes the rule
+ * silently DEAD, not silently universal - a warning, never a blocker).
+ *
+ * Reads an ARCHIVED account too, because the preview is also what a restore
+ * screen renders.
+ */
+export async function readRemovalFacts(
+  db: Database,
+  params: { organizationId: string; bankAccountId: string }
+): Promise<Result<BankAccountRemovalFacts, Error>> {
+  const { organizationId, bankAccountId } = params
+  return guard(
+    async () => {
+      const account = await getBankAccount(db, {
+        organizationId,
+        bankAccountId,
+        includeArchived: true,
+      })
+      if (account.isErr()) throw account.error
+      if (!account.value) {
+        throw new NotFoundError(`Bank account ${bankAccountId} was not found`)
+      }
+
+      const txCtx = await loadBankTransactionFieldContext(organizationId)
+      const counts = txCtx
+        ? await readTransactionStatusCounts(db, organizationId, txCtx, bankAccountId)
+        : { total: 0, matched: 0, unreviewed: 0 }
+
+      const rules = await listBankRules(db, { organizationId })
+      if (rules.isErr()) throw rules.error
+
+      return {
+        hasEverPosted: account.value.hasEverPosted,
+        transactionCount: counts.total,
+        matchedCount: counts.matched,
+        unreviewedCount: counts.unreviewed,
+        connectorId: account.value.connectorId,
+        rules: rules.value
+          .filter(
+            (rule) =>
+              rule.bankAccountId === bankAccountId ||
+              rule.counterpartBankAccountId === bankAccountId
+          )
+          .map((rule) => ({ id: rule.id, name: rule.name || 'Untitled rule' })),
+      } satisfies BankAccountRemovalFacts
+    },
+    'Failed to read bank account removal facts',
+    { organizationId, bankAccountId }
+  )
+}
+
+/**
+ * Every `bank_transaction` instance id on one account, **archived ones included**.
+ *
+ * 🛑 `listForReview` filters `archivedAt IS NULL`, which is right for a queue and
+ * wrong for a cascade: a reversed import and a duplicate the feed converged away
+ * both leave archived lines behind, and a "real delete" that stepped over them
+ * would leave rows pointing at an `EntityInstance` that no longer exists.
+ * `FieldValue.relatedEntityId` carries no foreign key, so nothing would ever
+ * clean them up.
+ *
+ * Returns the def id alongside, because the caller needs it to build a
+ * `RecordId` and resolving it twice is two cache reads for one answer.
+ */
+export async function readBankTransactionIdsForAccount(
+  db: Database,
+  params: { organizationId: string; bankAccountId: string }
+): Promise<Result<{ bankTransactionDefId: string; ids: string[] }, Error>> {
+  const { organizationId, bankAccountId } = params
+  return guard(
+    async () => {
+      const ctx = await loadBankTransactionFieldContext(organizationId)
+      const linkField = ctx?.fields.bank_transaction_bank_account
+      if (!ctx || !linkField) return { bankTransactionDefId: '', ids: [] }
+
+      const rows = await db
+        .select({ entityId: schema.FieldValue.entityId })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            eq(schema.FieldValue.fieldId, linkField.id),
+            eq(schema.FieldValue.relatedEntityId, bankAccountId)
+          )
+        )
+
+      return {
+        bankTransactionDefId: ctx.bankTransactionDefId,
+        ids: [...new Set(rows.map((row) => row.entityId))],
+      }
+    },
+    'Failed to read the bank transactions on an account',
+    { organizationId, bankAccountId }
+  )
+}
+
+/**
+ * How many live lines this account holds, and how they are split.
+ *
+ * `matched` is counted on its own because a delete destroys it and the dialog has
+ * to name that: a match is what says a document we already posted really cleared,
+ * and deleting it removes that evidence while the document's own entry stays in
+ * the books. `unreviewed` is `for_review` + `suggested` - the rows an ARCHIVE
+ * bulk-excludes (§6), which is the other sentence the dialog owes a person.
+ *
+ * Both filters run in SQL. A post-read `.filter()` would pull every statement
+ * line in the org into memory to answer a question about one account.
+ */
+async function readTransactionStatusCounts(
+  db: Database,
+  organizationId: string,
+  ctx: BankTransactionFieldContext,
+  bankAccountId: string
+): Promise<{ total: number; matched: number; unreviewed: number }> {
+  const linkField = ctx.fields.bank_transaction_bank_account
+  const statusField = ctx.fields.bank_transaction_review_status
+  if (!linkField) return { total: 0, matched: 0, unreviewed: 0 }
+
+  // Joined to the instance so an ARCHIVED line - a reversed import, a duplicate
+  // the feed converged away - is not counted as something a delete would remove.
+  const linked = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, linkField.id),
+        eq(schema.FieldValue.relatedEntityId, bankAccountId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+
+  const ids = [...new Set(linked.map((row) => row.entityId))]
+  if (ids.length === 0 || !statusField) {
+    return { total: ids.length, matched: 0, unreviewed: 0 }
+  }
+
+  const statuses = await db
+    .select({ entityId: schema.FieldValue.entityId, optionId: schema.FieldValue.optionId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, statusField.id),
+        inArray(schema.FieldValue.entityId, ids)
+      )
+    )
+
+  const byInstance = new Map(statuses.map((row) => [row.entityId, row.optionId]))
+  let matched = 0
+  let unreviewed = 0
+  for (const id of ids) {
+    // A line with no status row at all has not been reviewed - the same default
+    // `resolveReviewStatus` applies everywhere else.
+    const status = byInstance.get(id) ?? 'for_review'
+    if (status === 'matched') matched += 1
+    if (status === 'for_review' || status === 'suggested') unreviewed += 1
+  }
+  return { total: ids.length, matched, unreviewed }
+}
+
+/**
  * Every `postedAt` date key on one account, ascending.
  *
  * Two joins on `FieldValue` - the account link and the date - so the filter runs
@@ -333,7 +530,7 @@ async function hydrateBankAccounts(
   db: Database,
   organizationId: string,
   ctx: BankAccountFieldContext,
-  page: { id: string; createdAt: Date | null }[]
+  page: { id: string; createdAt: Date | null; archivedAt: Date | null }[]
 ): Promise<BankAccountRow[]> {
   const ids = page.map((row) => row.id)
   const fieldIds = Object.values(ctx.fields)
@@ -346,6 +543,7 @@ async function hydrateBankAccounts(
           entityId: schema.FieldValue.entityId,
           fieldId: schema.FieldValue.fieldId,
           valueText: schema.FieldValue.valueText,
+          valueBoolean: schema.FieldValue.valueBoolean,
           valueDate: schema.FieldValue.valueDate,
           valueJson: schema.FieldValue.valueJson,
           optionId: schema.FieldValue.optionId,
@@ -402,6 +600,12 @@ async function hydrateBankAccounts(
       coverageGaps: normalizeCoverageGaps(read(row.id, 'bank_account_coverage_gaps')?.valueJson),
       connectorId,
       status: resolveBankAccountStatus(read(row.id, 'bank_account_status')?.optionId),
+      // 🛑 Read STRAIGHT off the field, never derived from the rows. That is the
+      // whole point of the field: `undoReview` nulls a line's posting id, so a
+      // predicate computed off the transactions flips back to false while the
+      // entry and its reversal both stay in the books (08 §5.1).
+      hasEverPosted: read(row.id, 'bank_account_has_posted')?.valueBoolean === true,
+      archivedAt: row.archivedAt,
       createdAt: row.createdAt,
       connector: connectorId ? (connectors.get(connectorId) ?? null) : null,
     } satisfies BankAccountRow

--- a/packages/lib/src/banking/review/__tests__/writes.test.ts
+++ b/packages/lib/src/banking/review/__tests__/writes.test.ts
@@ -64,6 +64,10 @@ vi.mock('../../reads', () => ({
     isOk: () => true,
     value: { id: params.bankAccountId, name: 'Counterpart', glAccountCode: '1010' },
   }),
+  // The write-once posting high-water mark is stamped on the ACCOUNT beside the
+  // line's own `gl_posting_id`, so the treatments resolve the bank_account def
+  // too. `updateFor('def_ba:acct_1')` is how the tests below read that stamp.
+  requireBankAccountFieldContext: async () => ({ bankAccountDefId: 'def_ba', fields: {} }),
 }))
 vi.mock('../reads', async () => {
   const { NotFoundError } = await import('../../../errors')
@@ -899,5 +903,102 @@ describe('matching a customer payment', () => {
     expect(result.isOk()).toBe(true)
     expect(h.dbUpdates).toHaveLength(1)
     expect(h.dbUpdates[0]).toEqual({ bankTransactionId: null, bankClearedAt: null })
+  })
+})
+
+describe('🛑 bank_account_has_posted - the write-once removal gate', () => {
+  /**
+   * §5.1 of plans/bank-connection/08-removing-a-bank-account.md, and the reason
+   * the fact is STORED rather than computed.
+   *
+   * The gate that decides whether removing a bank account deletes it or archives
+   * it has one term, and it is written here - at the two sites where a bank line
+   * first produces a journal entry. Miss either one and an account whose rows are
+   * a posting's source documents becomes hard-deletable.
+   *
+   * 🛑 The undo tests below are the important half. `undoReview` nulls the line's
+   * `gl_posting_id` and REVERSES the entry, and it must still leave the account's
+   * flag alone: the original posting and its reversal both stay in the books
+   * forever, so the account permanently changed the ledger whatever the queue now
+   * looks like.
+   */
+  it('is stamped on the account when a line is CODED', async () => {
+    row()
+    const result = await codeTransaction(db, {
+      organizationId: ORG,
+      actorUserId: ACTOR,
+      transactionId: 'txn_1',
+      glAccountCode: '6100',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(updateFor('def_ba:acct_1')).toEqual({ bank_account_has_posted: true })
+  })
+
+  it('is stamped on the FILING leg account when a transfer posts', async () => {
+    row({ amountMinor: -50_000 })
+    h.listRows = []
+    const result = await transferTransaction(db, {
+      organizationId: ORG,
+      actorUserId: ACTOR,
+      transactionId: 'txn_1',
+      counterpartBankAccountId: 'acct_2',
+    })
+    expect(result.isOk()).toBe(true)
+    // The entry is filed on the outgoing leg, which is this line's own account.
+    expect(updateFor('def_ba:acct_1')).toEqual({ bank_account_has_posted: true })
+  })
+
+  it('is NOT stamped when the ledger refused the post', async () => {
+    row()
+    h.postEntry.mockResolvedValue({ status: 'period_locked', error: 'September is closed' })
+    await codeTransaction(db, {
+      organizationId: ORG,
+      actorUserId: ACTOR,
+      transactionId: 'txn_1',
+      glAccountCode: '6100',
+    })
+    // Nothing reached the books, so nothing may claim it did.
+    expect(updateFor('def_ba:acct_1')).toBeUndefined()
+  })
+
+  it('survives undoReview on the only coded row', async () => {
+    row({ reviewStatus: 'coded', glAccountCode: '6100', glPostingId: 'post_1' })
+    const result = await undoReview(db, {
+      organizationId: ORG,
+      actorUserId: ACTOR,
+      transactionId: 'txn_1',
+    })
+    expect(result.isOk()).toBe(true)
+    // The line went back to `for_review` and lost its posting id...
+    expect(updateFor('def_bt:txn_1')).toMatchObject({
+      bank_transaction_review_status: 'for_review',
+      bank_transaction_gl_posting_id: null,
+    })
+    // ...and the account was not touched at all. Not cleared, not rewritten.
+    expect(updateFor('def_ba:acct_1')).toBeUndefined()
+    expect(
+      h.crudUpdate.mock.calls.some(([, patch]) =>
+        Object.hasOwn((patch ?? {}) as object, 'bank_account_has_posted')
+      )
+    ).toBe(false)
+  })
+
+  it('survives the posting reversal undoReview performs', async () => {
+    row({ reviewStatus: 'coded', glAccountCode: '6100', glPostingId: 'post_1' })
+    await undoReview(db, { organizationId: ORG, actorUserId: ACTOR, transactionId: 'txn_1' })
+    // The reversal really did run - it is a SECOND GlPosting, so there is more in
+    // the books afterwards, not less - and the flag is still untouched.
+    expect(h.reverseEntry).toHaveBeenCalledTimes(1)
+    expect(updateFor('def_ba:acct_1')).toBeUndefined()
+  })
+
+  it('survives undoing a MATCHED line', async () => {
+    row({
+      reviewStatus: 'matched',
+      matchedRecordId: 'dep_1',
+      matchedRecordType: 'bank_deposit',
+    })
+    await undoReview(db, { organizationId: ORG, actorUserId: ACTOR, transactionId: 'txn_1' })
+    expect(updateFor('def_ba:acct_1')).toBeUndefined()
   })
 })

--- a/packages/lib/src/banking/review/writes.ts
+++ b/packages/lib/src/banking/review/writes.ts
@@ -47,7 +47,7 @@ import { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
 import { toRecordId } from '../../resources/resource-id'
 import { pinPostedBankTransaction, unpinPostedBankTransaction } from '../feed/pins'
 import { guard } from '../guard'
-import { getBankAccount } from '../reads'
+import { getBankAccount, requireBankAccountFieldContext } from '../reads'
 import { buildCodedBankEntry, buildTransferEntry } from './build-entry'
 import {
   type BankTransactionRow,
@@ -307,6 +307,7 @@ export async function codeTransaction(
         bank_transaction_reviewed_at: new Date().toISOString(),
         bank_transaction_reviewed_by_user_id: actorUserId,
       })
+      await stampAccountHasPosted(db, { organizationId, actorUserId, line })
 
       // 🛑 After the post, never before: a pin on a row whose entry was refused
       // would freeze the feed out of a line it still owns. Slot 3A's function -
@@ -532,6 +533,10 @@ export async function transferTransaction(
         bank_transaction_reviewed_at: now,
         bank_transaction_reviewed_by_user_id: actorUserId,
       })
+      // 🛑 The FILING leg's account, because that is the one the entry was posted
+      // against. The other leg carries no posting id and its account is stamped
+      // by its own treatment if and when one posts from it.
+      await stampAccountHasPosted(db, { organizationId, actorUserId, line: filedOn })
       if (other) {
         // The second leg is `matched` and carries NO posting id: one event, one
         // entry, and the id lives on the leg that filed it.
@@ -890,6 +895,39 @@ async function readCounterpartLeg(
   } catch {
     return null
   }
+}
+
+/**
+ * Record, on the BANK ACCOUNT, that a line on it has produced a journal entry.
+ *
+ * 🛑 **Write-once, and nothing ever clears it.** Not `undoReview`, not a
+ * reversal, not `reverseImport`: the `GlPosting` and its reversal both stay in
+ * the books forever with a row on this account as their source document, so an
+ * account that permanently changed the ledger must never become deletable again.
+ * It is a high-water mark, not a current state, and the one-way-ness IS the
+ * feature (plans/bank-connection/08-removing-a-bank-account.md §5.1).
+ *
+ * 🛑 Called at BOTH sites where a bank line first produces an entry - the code
+ * treatment and the transfer treatment - beside the `gl_posting_id` write.
+ * Missing either one puts a hole in the removal gate, and the hole is a hard
+ * delete of an account whose rows are a posting's source documents.
+ *
+ * ⚠️ Errors propagate rather than being swallowed. A stamp that failed silently
+ * is exactly the hole above; a failed treatment is visible and retryable.
+ */
+async function stampAccountHasPosted(
+  db: Database,
+  params: { organizationId: string; actorUserId: string; line: BankTransactionRow }
+): Promise<void> {
+  const { organizationId, actorUserId, line } = params
+  // A line with no account cannot post - `buildCodedBankEntry` needs the bank
+  // account's GL code - so this is defensive rather than a real branch.
+  if (!line.bankAccountId) return
+  const ctx = await requireBankAccountFieldContext(organizationId)
+  const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+  await crud.update(toRecordId(ctx.bankAccountDefId, line.bankAccountId), {
+    bank_account_has_posted: true,
+  })
 }
 
 // ── The document side of a match ────────────────────────────────────────────

--- a/packages/lib/src/banking/rules/reads.ts
+++ b/packages/lib/src/banking/rules/reads.ts
@@ -352,7 +352,7 @@ export async function listForReviewTransactionIds(
         const acctIds = new Set(acctRows.map((row) => row.entityId))
         ids = ids.filter((id) => acctIds.has(id))
       }
-      return ids
+      return filterLiveTransactionIds(db, organizationId, ctx.bankTransactionDefId, ids)
     },
     'Failed to list for-review transactions',
     { organizationId, bankAccountId }
@@ -503,6 +503,39 @@ export async function findTransferCandidate(
   )
 }
 
+/**
+ * Keep only the ids that are still live `bank_transaction` instances, in the
+ * order given.
+ *
+ * 🛑 Every transaction read in this file starts from `FieldValue`, and a
+ * `FieldValue` row outlives an archive - archiving a bank account archives its
+ * lines but leaves their values in place. Without this filter a removed
+ * account's lines still arrive as review candidates, history samples and
+ * transfer legs, and `crud.update` then refuses them with `Entity not found`
+ * (it reads through `getEntityInstanceRow`, which is `archivedAt IS NULL`).
+ */
+async function filterLiveTransactionIds(
+  db: Database,
+  organizationId: string,
+  bankTransactionDefId: string,
+  ids: string[]
+): Promise<string[]> {
+  if (ids.length === 0) return []
+  const rows = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, bankTransactionDefId),
+        isNull(schema.EntityInstance.archivedAt),
+        inArray(schema.EntityInstance.id, ids)
+      )
+    )
+  const live = new Set(rows.map((row) => row.id))
+  return ids.filter((id) => live.has(id))
+}
+
 /** Turn a page of `bank_transaction` ids into {@link TransactionMatchRow}s, one query. */
 async function readTxMatchRows(
   db: Database,
@@ -510,7 +543,8 @@ async function readTxMatchRows(
   ctx: RuleTransactionFieldContext,
   ids: string[]
 ): Promise<TransactionMatchRow[]> {
-  if (ids.length === 0) return []
+  const liveIds = await filterLiveTransactionIds(db, organizationId, ctx.bankTransactionDefId, ids)
+  if (liveIds.length === 0) return []
   const fieldIds = Object.values(ctx.fields)
     .filter((field): field is { id: string } => field != null)
     .map((field) => field.id)
@@ -530,7 +564,7 @@ async function readTxMatchRows(
         .where(
           and(
             eq(schema.FieldValue.organizationId, organizationId),
-            inArray(schema.FieldValue.entityId, ids),
+            inArray(schema.FieldValue.entityId, liveIds),
             inArray(schema.FieldValue.fieldId, fieldIds)
           )
         )
@@ -551,7 +585,7 @@ async function readTxMatchRows(
     return fieldId ? (byInstance.get(id)?.get(fieldId) ?? null) : null
   }
 
-  return ids.map((id) => ({
+  return liveIds.map((id) => ({
     id,
     bankAccountId: read(id, 'bank_transaction_bank_account')?.relatedEntityId ?? null,
     postedAt: toDateOrNull(read(id, 'bank_transaction_posted_at')?.valueDate),

--- a/packages/lib/src/banking/writes.ts
+++ b/packages/lib/src/banking/writes.ts
@@ -14,27 +14,80 @@
  * arrives with the bank feed wave. The router's `connect` procedure is a stub
  * that says so.
  *
- * **Deleting an account.** There is no delete and there will not be a hard one.
- * A `bank_transaction` that has been coded and posted is the source document of
- * a journal entry, so disconnecting sets `status: 'disconnected'` and keeps
- * every row - the movement ledger's rule, applied to cash
- * (plans/bank-connection/02-connection-architecture.md §5.1).
+ * ## Removal: four verbs, and one fact decides between two of them
+ *
+ * ⚠️ **This file used to say there was no delete and never would be. That is no
+ * longer true**, and the reason it changed is written down in
+ * `plans/bank-connection/08-removing-a-bank-account.md` §4.1 - read it before
+ * treating {@link deleteBankAccount} as a mistake.
+ *
+ * | Verb | When | Effect |
+ * |---|---|---|
+ * | **Disconnect** | a connected account whose feed is no longer wanted | `feed/actions.ts`. Feed stops, account released at Stripe, every row kept |
+ * | **Delete** | nothing on the account has EVER posted | account, rows, connector and the Stripe subscription all gone |
+ * | **Archive** | anything else | `archivedAt` set. Out of every list and picker, history intact |
+ * | **Restore** | an archived account | `archivedAt` cleared |
+ *
+ * 🛑 **The line is the first journal entry**, and it is recorded rather than
+ * computed: `bank_account_has_posted` is a write-once high-water mark that
+ * nothing clears (§5.1). `undoReview` nulls a line's posting id, so a gate that
+ * read the rows would hand a delete back to an account that permanently changed
+ * the ledger the moment somebody undid the last review - while the `GlPosting`
+ * and its reversal both stay in the books.
+ *
+ * 🛑 **A hard delete is safe here in a way it is not for the chart**
+ * (`postings/chart-write.ts:264`) because two of that module's three reasons do
+ * not transfer: nothing seeds a user's bank accounts, so there is no re-seed to
+ * defend against, and the `RecordIdentity` holding Stripe's `fca_` id is a STEP
+ * (release first, §5.1) rather than a reason to refuse. Archive-as-default
+ * survives; archive-ONLY does not - connecting the wrong bank pulls up to 180
+ * days of transactions, and permanent debris plus 30c a month is not an
+ * acceptable price for a misclick.
+ *
+ * 🛑 **Removing a bank account never touches the chart.** A `bank_account` is not
+ * a GL account: it carries a POINTER to a code, and the balance lives in
+ * `GlPosting` / `GlPostingLine` against that code with no foreign key back here
+ * (§3). So archiving cannot move the trial balance by a cent, and the
+ * Opening-Balance-Equity manoeuvre QuickBooks performs has nothing to do here.
+ * "What happens to the money" is `removeChartAccount`'s question, not this one.
  */
 
-import type { Database } from '@auxx/database'
+import { deleteCredential } from '@auxx/credentials/store'
+import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { and, eq, ne } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
-import { BadRequestError, NotFoundError } from '../errors'
+import { BadRequestError, ConflictError, NotFoundError } from '../errors'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { toRecordId } from '../resources/resource-id'
 import {
+  ARCHIVE_EXCLUSION_PREFIX,
   BANK_ACCOUNT_TYPES,
+  type BankAccountRemovalFacts,
+  type BankAccountRemovalPlan,
   type BankAccountRow,
   type BankAccountStatus,
   type BankAccountType,
+  isArchiveExclusion,
 } from './client'
+// ⚠️ `./feed/actions` imports `updateBankAccount` from THIS file, so these two
+// modules form a cycle. It is safe and deliberate: neither side touches the
+// other at module scope, so the live binding is resolved when `archiveBankAccount`
+// actually runs. The alternative is re-implementing disconnect's three effects
+// here, and a second writer that forgot the Stripe release is the exact leak
+// `feed/reaper.ts` exists to stop.
+import { disconnectBankAccountFeed } from './feed/actions'
+// The LEAF, not the `./feed` barrel: the barrel pulls the Stripe SDK, the
+// connector engine and the org cache in to answer one join.
+import { findBankFeedAccountForConnector, reapBankFeedAccount } from './feed/reaper'
 import { guard } from './guard'
-import { getBankAccount, requireBankAccountFieldContext } from './reads'
+import {
+  getBankAccount,
+  readBankTransactionIdsForAccount,
+  readRemovalFacts,
+  requireBankAccountFieldContext,
+} from './reads'
+import { listForReview, requireReviewFieldContext } from './review/reads'
 
 const logger = createScopedLogger('banking')
 
@@ -256,4 +309,490 @@ function normalizeLast4(value: string | null | undefined): string | null {
     throw new BadRequestError('The last four is up to four digits, with nothing else in it')
   }
   return trimmed
+}
+
+// ── Removal: the gate, and the three verbs behind it ────────────────────────
+
+/**
+ * Which verb applies to this account. **Pure, and no database.**
+ *
+ * 🛑 **ONE term decides: `hasEverPosted`.** False deletes, true archives. Every
+ * other fact on {@link BankAccountRemovalFacts} is for the confirm dialog and is
+ * forbidden from changing the answer - 400 rows in `for_review`, a live
+ * connector and three rules naming the account are all deletable, because
+ * nothing on the account reached the books
+ * (plans/bank-connection/08-removing-a-bank-account.md §5.1).
+ *
+ * ⚠️ **A `matched` row is deletable, and that is a real decision.** A match says
+ * a document we already posted really cleared, so deleting it removes that
+ * evidence while the document's own entry stays in the books. It is still the
+ * right answer: the alternative is that one auto-detected transfer match makes a
+ * wrongly-connected account permanently undeletable, and a match is evidence
+ * *about* an entry, never the entry itself. The dialog names the count.
+ *
+ * ⚠️ **A `bank_rule` is a WARNING, never a blocker.** `rules/evaluate.ts` skips a
+ * rule whose `bankAccountId` does not match the line, so a dangling scope makes
+ * the rule INERT rather than universal - silently dead, not silently dangerous.
+ *
+ * Exported and pure so the gate is tested without a database, exactly the way
+ * `import/reverse.ts`'s `refusalReason` is.
+ */
+export function resolveRemoval(facts: BankAccountRemovalFacts): BankAccountRemovalPlan {
+  const verb = facts.hasEverPosted ? 'archive' : 'delete'
+  return {
+    verb,
+    cascade:
+      verb === 'delete'
+        ? {
+            transactions: facts.transactionCount,
+            matched: facts.matchedCount,
+            releasesAtStripe: facts.connectorId != null,
+          }
+        : // An archive destroys nothing, so there is no cascade to name. Filling
+          // these in for an archive would put "1,240 transactions will be
+          // deleted" in front of somebody about to archive.
+          { transactions: 0, matched: 0, releasesAtStripe: facts.connectorId != null },
+    unreviewed: facts.unreviewedCount,
+    warnings: facts.rules,
+  }
+}
+
+/**
+ * The ceiling on one archive's exclusion sweep.
+ *
+ * `listForReview` caps at 500 per call anyway, and an account somebody is
+ * archiving with more than 500 lines still waiting for review is a queue nobody
+ * was ever going to clear by hand. A hard cap is better than a paging loop that
+ * could write for minutes inside one request; the rest keep their status and can
+ * be excluded from the queue.
+ *
+ * ⚠️ The DELETE cascade has no such cap and does not use this: it reads the
+ * account's lines directly (`readBankTransactionIdsForAccount`) so that archived
+ * rows go too, and a partial delete would leave exactly the orphans it exists to
+ * avoid.
+ */
+const MAX_CASCADE_ROWS = 500
+
+/** What `deleteBankAccount` accepts. */
+export interface DeleteBankAccountInput {
+  organizationId: string
+  actorUserId: string
+  bankAccountId: string
+}
+
+/** What `deleteBankAccount` did. */
+export interface DeleteBankAccountResult {
+  id: string
+  /** Every `bank_transaction` on the account, whatever its review status. */
+  transactionsDeleted: number
+  connectorDeleted: boolean
+  /** True when Stripe confirmed the release, so the 30c a month stops. */
+  releasedAtStripe: boolean
+  /** True when the bank LOGIN this was the last account on went with it. */
+  credentialDeleted: boolean
+}
+
+/**
+ * A real, permanent delete. Only reachable while nothing on the account has ever
+ * posted (§5.1) - {@link resolveRemoval} is re-asked here rather than trusted
+ * from the caller, because a sync can land a transaction between a preview and
+ * the click that follows it.
+ *
+ * 🛑 **Stripe first, and outside everything else.** The release is the only thing
+ * that stops the 30c per institution per month, and the ordering is the same one
+ * `deleteOrganization` states for the plan subscription: failing the delete after
+ * a release is recoverable - reconnecting is a fresh authentication either way -
+ * and deleting first then failing the release is not, because the
+ * `providerAccountId` we would need is on the row we just destroyed and the
+ * nightly reaper sweeps `DataConnector` rows that still EXIST.
+ *
+ * Then, in order:
+ *
+ * 1. the `DataConnector` (its streams and mappings cascade with it);
+ * 2. its credential, but ONLY when no other connector still uses it - one
+ *    credential is one bank LOGIN, and two accounts at the same bank share it,
+ *    so an unconditional delete would break the sibling account's feed;
+ * 3. every `bank_transaction` on the account, whatever its review status;
+ * 4. the account itself. The `RecordIdentity` carrying Stripe's `fca_` id
+ *    cascades off `EntityInstance`.
+ *
+ * ⚠️ **Not one Postgres transaction**, and deliberately: `UnifiedCrudHandler`
+ * opens its own write session per call, which is also how `import/reverse.ts`
+ * deletes a batch. The order above is what makes a partial failure recoverable -
+ * the account is destroyed last, so anything that dies half way leaves a row the
+ * operator can press Remove on again.
+ */
+export async function deleteBankAccount(
+  db: Database,
+  input: DeleteBankAccountInput
+): Promise<Result<DeleteBankAccountResult, Error>> {
+  const { organizationId, actorUserId, bankAccountId } = input
+  return guard(
+    async () => {
+      const ctx = await requireBankAccountFieldContext(organizationId)
+      const account = await getBankAccount(db, { organizationId, bankAccountId })
+      if (account.isErr()) throw account.error
+      if (!account.value) {
+        throw new NotFoundError(`Bank account ${bankAccountId} was not found`)
+      }
+
+      const facts = await readRemovalFacts(db, { organizationId, bankAccountId })
+      if (facts.isErr()) throw facts.error
+      if (resolveRemoval(facts.value).verb !== 'delete') {
+        throw new ConflictError(
+          'A line on this account has produced a journal entry, so the account can only be ' +
+            'archived. The entry and any reversal of it stay in the books, and the row they ' +
+            'were posted from is their source document.',
+          { verb: 'archive' }
+        )
+      }
+
+      // 1. Stripe, first and on its own.
+      let releasedAtStripe = false
+      const connectorId = account.value.connectorId
+      let credentialId: string | null = null
+      if (connectorId) {
+        const feedAccount = await findBankFeedAccountForConnector(db, organizationId, connectorId)
+        if (feedAccount) {
+          credentialId = feedAccount.credentialId
+          // Throws on a Stripe failure, and the throw is the point: nothing below
+          // has run yet, so the account is still whole and still retryable.
+          releasedAtStripe = await reapBankFeedAccount(db, {
+            connectorId,
+            providerAccountId: feedAccount.providerAccountId,
+          })
+        }
+      }
+
+      // 2. The connector, then the credential when nothing else holds it.
+      let connectorDeleted = false
+      let credentialDeleted = false
+      if (connectorId) {
+        const deleted = await db
+          .delete(schema.DataConnector)
+          .where(
+            and(
+              eq(schema.DataConnector.id, connectorId),
+              eq(schema.DataConnector.organizationId, organizationId)
+            )
+          )
+          .returning({ id: schema.DataConnector.id })
+        connectorDeleted = deleted.length > 0
+
+        if (credentialId) {
+          // 🛑 One credential is one bank LOGIN. Two accounts under one login
+          // share it, so deleting it while a sibling connector still points at
+          // it would take that account's feed down as a side effect of removing
+          // this one.
+          const siblings = await db
+            .select({ id: schema.DataConnector.id })
+            .from(schema.DataConnector)
+            .where(
+              and(
+                eq(schema.DataConnector.credentialId, credentialId),
+                ne(schema.DataConnector.id, connectorId)
+              )
+            )
+            .limit(1)
+          if (siblings.length === 0) {
+            const removed = await deleteCredential(credentialId, organizationId)
+            credentialDeleted = removed.isOk()
+          }
+        }
+      }
+
+      // 3. Every line on the account, whatever it says and whether or not it is
+      //    archived. Nothing here reached the books - that is what the gate above
+      //    just established - and an archived line left behind would point at an
+      //    `EntityInstance` that no longer exists, with no foreign key to clean
+      //    it up.
+      const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+      const lines = await readBankTransactionIdsForAccount(db, { organizationId, bankAccountId })
+      if (lines.isErr()) throw lines.error
+      for (const lineId of lines.value.ids) {
+        await crud.delete(toRecordId(lines.value.bankTransactionDefId, lineId))
+      }
+
+      // 4. The account. Its `RecordIdentity` rows cascade off `EntityInstance`.
+      await crud.delete(toRecordId(ctx.bankAccountDefId, bankAccountId))
+
+      logger.info('Deleted a bank account', {
+        organizationId,
+        bankAccountId,
+        transactionsDeleted: lines.value.ids.length,
+        connectorDeleted,
+        releasedAtStripe,
+      })
+      return {
+        id: bankAccountId,
+        transactionsDeleted: lines.value.ids.length,
+        connectorDeleted,
+        releasedAtStripe,
+        credentialDeleted,
+      } satisfies DeleteBankAccountResult
+    },
+    'Failed to delete bank account',
+    { organizationId, bankAccountId }
+  )
+}
+
+/** What `archiveBankAccount` accepts. */
+export interface ArchiveBankAccountInput {
+  organizationId: string
+  actorUserId: string
+  bankAccountId: string
+}
+
+/** What `archiveBankAccount` did, so the confirmation can say it. */
+export interface ArchiveBankAccountResult {
+  id: string
+  /** `for_review` and `suggested` lines swept to `excluded` (§6). */
+  excluded: number
+  /** True when a live feed was stopped and released at Stripe first. */
+  disconnected: boolean
+}
+
+/**
+ * Take the account out of every list and picker, keeping its history whole.
+ *
+ * ## What it does
+ *
+ * 1. **Disconnects first, when there is a feed.** 🛑 Not optional and not
+ *    skippable: `reapBankFeedAccount` is the only thing that stops the 30c per
+ *    month, so archiving a still-billing account out of the UI would recreate
+ *    precisely the silent leak `feed/reaper.ts` was built to stop. It happens in
+ *    one action rather than as a refusal, with the consequence spelled out in the
+ *    confirm dialog, because the extra sentence is cheaper than the leak (§10 q3).
+ * 2. **Sweeps the unreviewed queue to `excluded`** with a machine-recognisable
+ *    reason (§6, option C). Those rows are cash movements that never reached the
+ *    ledger and that nobody will look at again; refusing until the queue is empty
+ *    leaves an org that connected the wrong bank unable to clear 180 days of
+ *    noise, and discarding them silently destroys evidence with no trace.
+ * 3. **Sets `archivedAt`.**
+ *
+ * ## 🛑 What it must NOT do (§5.3)
+ *
+ * - never touches the mapped `gl_account`;
+ * - never touches any `GlPosting`;
+ * - never deletes or modifies a `bank_transaction` other than step 2's
+ *   exclusions - `matched`, `coded` and human-`excluded` rows come out
+ *   byte-identical;
+ * - never clears `bank_account_coverage_from`. A balance sheet spanning the
+ *   archived account's period still has to know what was covered.
+ *
+ * There is no balance check, no posting check and no period check either, and
+ * §3 is why: a `bank_account` holds a POINTER to a GL code, so none of them can
+ * be affected by this write.
+ */
+export async function archiveBankAccount(
+  db: Database,
+  input: ArchiveBankAccountInput
+): Promise<Result<ArchiveBankAccountResult, Error>> {
+  const { organizationId, actorUserId, bankAccountId } = input
+  return guard(
+    async () => {
+      const ctx = await requireBankAccountFieldContext(organizationId)
+      const account = await getBankAccount(db, { organizationId, bankAccountId })
+      if (account.isErr()) throw account.error
+      if (!account.value) {
+        throw new NotFoundError(`Bank account ${bankAccountId} was not found`)
+      }
+
+      let disconnected = false
+      if (account.value.connectorId) {
+        const stopped = await disconnectBankAccountFeed(db, {
+          organizationId,
+          actorUserId,
+          bankAccountId,
+        })
+        if (stopped.isErr()) throw stopped.error
+        disconnected = true
+      }
+
+      const excluded = await excludeUnreviewedLines(db, {
+        organizationId,
+        actorUserId,
+        bankAccountId,
+        accountLabel: account.value.name ?? 'this account',
+      })
+
+      const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+      await crud.archive(toRecordId(ctx.bankAccountDefId, bankAccountId))
+
+      logger.info('Archived a bank account', {
+        organizationId,
+        bankAccountId,
+        excluded,
+        disconnected,
+      })
+      return { id: bankAccountId, excluded, disconnected } satisfies ArchiveBankAccountResult
+    },
+    'Failed to archive bank account',
+    { organizationId, bankAccountId }
+  )
+}
+
+/**
+ * Sweep `for_review` and `suggested` to `excluded`, and touch nothing else.
+ *
+ * ⚠️ **`matched`, `coded` and human-`excluded` rows are left alone**, and the
+ * narrowing is done by asking `listForReview` for exactly those two states rather
+ * than by filtering afterwards. They are already in the books, or they carry a
+ * decision somebody made and the reason they were required to give for it.
+ *
+ * The reason is prefixed so a later path can tell an archive's own bookkeeping
+ * from a person's - the same job `IMPORT_LINK_EXCLUSION_PREFIX` does for the
+ * importer's link exclusions.
+ */
+async function excludeUnreviewedLines(
+  db: Database,
+  params: {
+    organizationId: string
+    actorUserId: string
+    bankAccountId: string
+    accountLabel: string
+  }
+): Promise<number> {
+  const { organizationId, actorUserId, bankAccountId, accountLabel } = params
+  const ctx = await requireReviewFieldContext(organizationId)
+
+  const pending = await Promise.all(
+    (['for_review', 'suggested'] as const).map((state) =>
+      listForReview(db, { organizationId, bankAccountId, state, limit: MAX_CASCADE_ROWS })
+    )
+  )
+
+  const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+  const reason = `${ARCHIVE_EXCLUSION_PREFIX}: ${accountLabel}`
+  const reviewedAt = new Date().toISOString()
+
+  let excluded = 0
+  for (const batch of pending) {
+    if (batch.isErr()) throw batch.error
+    for (const line of batch.value) {
+      await crud.update(toRecordId(ctx.bankTransactionDefId, line.id), {
+        bank_transaction_review_status: 'excluded',
+        bank_transaction_exclude_reason: reason,
+        bank_transaction_reviewed_at: reviewedAt,
+        bank_transaction_reviewed_by_user_id: actorUserId,
+      })
+      excluded += 1
+    }
+  }
+  return excluded
+}
+
+/**
+ * Put the archive's own exclusions back to `for_review`, and only those.
+ *
+ * The mirror of {@link excludeUnreviewedLines}. It reads the account's `excluded`
+ * lines and re-opens the ones {@link isArchiveExclusion} recognises, so a row a
+ * person excluded by hand - and the reason they were required to give for it -
+ * survives a restore untouched.
+ */
+async function reopenArchiveExclusions(
+  db: Database,
+  params: { organizationId: string; actorUserId: string; bankAccountId: string }
+): Promise<number> {
+  const { organizationId, actorUserId, bankAccountId } = params
+  const ctx = await requireReviewFieldContext(organizationId)
+
+  const excluded = await listForReview(db, {
+    organizationId,
+    bankAccountId,
+    state: 'excluded',
+    limit: MAX_CASCADE_ROWS,
+  })
+  if (excluded.isErr()) throw excluded.error
+
+  const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+  let reopened = 0
+  for (const line of excluded.value) {
+    if (!isArchiveExclusion(line.excludeReason)) continue
+    await crud.update(toRecordId(ctx.bankTransactionDefId, line.id), {
+      bank_transaction_review_status: 'for_review',
+      bank_transaction_exclude_reason: null,
+      bank_transaction_reviewed_at: null,
+      bank_transaction_reviewed_by_user_id: null,
+    })
+    reopened += 1
+  }
+  return reopened
+}
+
+/** What `restoreBankAccount` accepts. */
+export interface RestoreBankAccountInput {
+  organizationId: string
+  actorUserId: string
+  bankAccountId: string
+}
+
+/**
+ * Put an archived account back.
+ *
+ * 🛑 **Restore is not optional.** Archive is only a safe default if it is
+ * reversible in the product; without this, "Archive" is a hard delete with a
+ * nicer word on it (§4.2).
+ *
+ * ⚠️ It does NOT reconnect the feed. The connector was released at Stripe, so
+ * the only way back to a live feed is a fresh authentication at the bank.
+ *
+ * 🛑 **It DOES un-exclude the lines the archive swept**, and only those: the ones
+ * whose reason still carries {@link ARCHIVE_EXCLUSION_PREFIX}. Three reasons, and
+ * the first is the load-bearing one:
+ *
+ *  1. Reversibility is the whole argument for sweeping the queue rather than
+ *     refusing the archive (plan §6). "Undo it one row at a time in the queue" is
+ *     not a path for the 400-row account this feature exists to clean up, so
+ *     without this, archive is one-way in practice and the argument collapses.
+ *  2. These exclusions are the archive's OWN bookkeeping, not a person's. The
+ *     precedent is `isImportLinkExclusion` in `import/reverse.ts`: a
+ *     machine-written exclusion belongs to the operation that wrote it and is
+ *     reversed with it, while a human one is never touched by either path.
+ *  3. A row a person excluded by hand keeps its reason and stays excluded,
+ *     because {@link isArchiveExclusion} is false for it. The surprising restore
+ *     would be the one that re-opened those.
+ */
+export async function restoreBankAccount(
+  db: Database,
+  input: RestoreBankAccountInput
+): Promise<Result<BankAccountRow, Error>> {
+  const { organizationId, actorUserId, bankAccountId } = input
+  return guard(
+    async () => {
+      const ctx = await requireBankAccountFieldContext(organizationId)
+      const existing = await getBankAccount(db, {
+        organizationId,
+        bankAccountId,
+        includeArchived: true,
+      })
+      if (existing.isErr()) throw existing.error
+      if (!existing.value) {
+        throw new NotFoundError(`Bank account ${bankAccountId} was not found`)
+      }
+      if (!existing.value.archivedAt) {
+        throw new BadRequestError('That bank account is not archived.')
+      }
+
+      const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+      await crud.restore(toRecordId(ctx.bankAccountDefId, bankAccountId))
+
+      const reopened = await reopenArchiveExclusions(db, {
+        organizationId,
+        actorUserId,
+        bankAccountId,
+      })
+
+      const row = await getBankAccount(db, { organizationId, bankAccountId })
+      if (row.isErr()) throw row.error
+      if (!row.value) {
+        throw new NotFoundError('The bank account could not be read back after restoring')
+      }
+
+      logger.info('Restored a bank account', { organizationId, bankAccountId, reopened })
+      return row.value
+    },
+    'Failed to restore bank account',
+    { organizationId, bankAccountId }
+  )
 }

--- a/packages/lib/src/data-connectors/mutations.test.ts
+++ b/packages/lib/src/data-connectors/mutations.test.ts
@@ -54,6 +54,16 @@ vi.mock('./data-connector-queue', async (importOriginal) => ({
   enqueueConnectorTeardown: (arg: unknown) => enqueueConnectorTeardown(arg),
 }))
 
+// plans/bank-connection/08-removing-a-bank-account.md §5.4 door 3. The LEAF module, not
+// the `banking` barrel - that is the import production makes, and mocking the barrel
+// would leave the real leaf in the graph.
+const findBankFeedAccountForConnector = vi.fn(async (..._a: unknown[]) => null as unknown)
+const reapBankFeedAccount = vi.fn(async (..._a: unknown[]) => true)
+vi.mock('../banking/feed/reaper', () => ({
+  findBankFeedAccountForConnector: (...a: unknown[]) => findBankFeedAccountForConnector(...a),
+  reapBankFeedAccount: (...a: unknown[]) => reapBankFeedAccount(...a),
+}))
+
 import {
   deleteConnector,
   disconnectConnectors,
@@ -132,6 +142,8 @@ beforeEach(() => {
     .mockResolvedValue(ok({ success: true, deletedFieldIds: ['field_1'] }))
   notifyCustomFieldChanged.mockReset()
   enqueueConnectorTeardown.mockReset()
+  findBankFeedAccountForConnector.mockReset().mockResolvedValue(null)
+  reapBankFeedAccount.mockReset().mockResolvedValue(true)
 })
 
 describe('finalizeConnectorTeardown — delete behavior stray-field sweep', () => {
@@ -350,5 +362,98 @@ describe('deferred app-field sweep', () => {
     await expect(teardown({ uninstalled: true, survivors: [] })).resolves.toEqual({
       success: true,
     })
+  })
+})
+
+// plans/bank-connection/08-removing-a-bank-account.md §5.4 door 3 / §7.6.
+//
+// 🛑 Stripe bills 30c per institution per account holder per month and the ONLY thing
+// that stops it is calling disconnect on the account. `deleteConnector` never did, and
+// the teardown it enqueues removes the row - so the nightly reaper, which sweeps
+// `DataConnector`, could never clean up after this door either.
+describe('deleteConnector releases a Financial Connections account', () => {
+  const FC_ACCOUNT = {
+    connectorId: 'dc_1',
+    organizationId: 'org_1',
+    credentialId: 'cred_1',
+    providerAccountId: 'fca_1',
+  }
+
+  /** Records the release and the `deleting` mark in the order production made them. */
+  function tracingDb(trace: string[]) {
+    const chain: Record<string, unknown> = {
+      update: vi.fn(() => chain),
+      set: vi.fn((payload: Record<string, unknown>) => {
+        if (payload.status === 'deleting') trace.push('mark-deleting')
+        return chain
+      }),
+      where: vi.fn(() => Promise.resolve(undefined)),
+      select: vi.fn(() => chain),
+      from: vi.fn(() => chain),
+      delete: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve([])),
+      query: {
+        DataConnector: {
+          findFirst: vi.fn().mockResolvedValue({ id: 'dc_1', organizationId: 'org_1' }),
+        },
+        AppInstallation: { findFirst: vi.fn().mockResolvedValue(undefined) },
+      },
+    }
+    return chain as unknown as Database
+  }
+
+  it('releases at Stripe BEFORE the row is marked `deleting`', async () => {
+    const trace: string[] = []
+    findBankFeedAccountForConnector.mockResolvedValue(FC_ACCOUNT)
+    reapBankFeedAccount.mockImplementation(async () => {
+      trace.push('release')
+      return true
+    })
+
+    await deleteConnector(tracingDb(trace), 'org_1', 'user_1', 'dc_1', 'archive')
+
+    // The ordering IS the fix: once the teardown starts, the `providerAccountId` is on
+    // its way out with the connector row and there is nothing left to disconnect.
+    expect(trace).toEqual(['release', 'mark-deleting'])
+    expect(reapBankFeedAccount).toHaveBeenCalledWith(expect.anything(), FC_ACCOUNT)
+    expect(findBankFeedAccountForConnector).toHaveBeenCalledWith(expect.anything(), 'org_1', 'dc_1')
+  })
+
+  it('releases on the `keep` path too, which returns before any teardown is enqueued', async () => {
+    // `keep` short-circuits into `finalizeConnectorTeardown` and is the overwhelmingly
+    // common case, so a release placed after that branch would cover almost nobody.
+    findBankFeedAccountForConnector.mockResolvedValue(FC_ACCOUNT)
+    const db = buildDb({
+      connectorRow: { id: 'dc_1', organizationId: 'org_1' },
+      strayFields: [],
+      dataConnectorRows: [[], []],
+    }) as unknown as Database
+
+    await deleteConnector(db, 'org_1', 'user_1', 'dc_1', 'keep')
+
+    expect(reapBankFeedAccount).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases nothing for a connector that is not a Financial Connections feed', async () => {
+    // Every other connector type resolves no account, so Stripe is never called. The
+    // type gate itself lives in `findBankFeedAccountForConnector`'s predicate and is
+    // pinned in `banking/feed/__tests__/reaper.test.ts`.
+    findBankFeedAccountForConnector.mockResolvedValue(null)
+
+    await deleteConnector(tracingDb([]), 'org_1', 'user_1', 'dc_1', 'archive')
+
+    expect(reapBankFeedAccount).not.toHaveBeenCalled()
+  })
+
+  it('deletes the connector anyway when the release throws', async () => {
+    findBankFeedAccountForConnector.mockResolvedValue(FC_ACCOUNT)
+    reapBankFeedAccount.mockRejectedValue(new Error('stripe is down'))
+
+    // The user asked for the connector to go. A leaked 30c is recoverable by a human
+    // reading an invoice; a connector that cannot be removed is not.
+    const result = await deleteConnector(tracingDb([]), 'org_1', 'user_1', 'dc_1', 'archive')
+
+    expect(result).toEqual({ success: true })
+    expect(enqueueConnectorTeardown).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -21,6 +21,9 @@ import { getFieldDefinitionId, isAppFieldRef, toResourceFieldId } from '@auxx/ty
 import { generateId } from '@auxx/utils'
 import { and, asc, eq, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
+// The LEAF, not the `banking` barrel - the barrel pulls the whole banking read/write
+// surface (and the org cache behind it) in for two functions.
+import { findBankFeedAccountForConnector, reapBankFeedAccount } from '../banking/feed/reaper'
 import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
 import { onCacheEvent } from '../cache/invalidate'
 import type { ConditionGroup } from '../conditions/types'
@@ -1151,6 +1154,53 @@ export async function reconnectConnectorsForInstallation(
 export type DeleteSyncedDataBehavior = 'keep' | 'archive' | 'delete'
 
 /**
+ * Release a Stripe Financial Connections account before its connector is torn down.
+ *
+ * 🛑 Stripe bills 30c per institution per account holder per month and the ONLY thing
+ * that stops it is calling disconnect on the account. Deleting the connector row does
+ * not, and once the teardown has run the `providerAccountId` is gone with it - so the
+ * nightly reaper (`banking/feed/reaper.ts`) can never clean up after this door. That is
+ * why the call goes here, ahead of the `deleting` mark and ahead of the `keep`
+ * short-circuit, rather than anywhere in the teardown chain.
+ *
+ * No-op for every connector type but Financial Connections.
+ *
+ * ⚠️ Never throws. A release that fails must not block the delete: the user asked for
+ * the connector to go, a leaked 30c is recoverable by a human reading an invoice, and a
+ * connector that cannot be removed is not. The nightly sweep is not a fallback here
+ * (the row is on its way out), so the log line is the only trace - which is exactly why
+ * it is logged at error.
+ */
+async function releaseBankFeedAccount(
+  db: Database,
+  organizationId: string,
+  connectorId: string
+): Promise<void> {
+  try {
+    const account = await findBankFeedAccountForConnector(db, organizationId, connectorId)
+    if (!account) return
+    const released = await reapBankFeedAccount(db, account)
+    if (released) {
+      logger.info('Released a Financial Connections account before connector delete', {
+        organizationId,
+        connectorId,
+      })
+    } else {
+      logger.warn('Stripe would not release a Financial Connections account - deleting anyway', {
+        organizationId,
+        connectorId,
+      })
+    }
+  } catch (error) {
+    logger.error('Failed to release a Financial Connections account - deleting anyway', {
+      organizationId,
+      connectorId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
  * Delete a connector. The provisioned def/fields and synced entity records are the
  * user's CRM data — we never auto-delete them. `behavior` governs the entity records
  * this connector CREATED, identified by the `integrationSource = connector.id` stamp
@@ -1181,6 +1231,7 @@ export async function deleteConnector(
 ): Promise<{ success: boolean }> {
   // Existence guard (throws NotFound if missing) — no longer need the row itself.
   await loadConnectorRow(db, organizationId, id)
+  await releaseBankFeedAccount(db, organizationId, id)
   await removeConnectorScheduler(id)
 
   if (behavior === 'keep') {

--- a/packages/lib/src/organizations/__tests__/delete-organization-fc-release.test.ts
+++ b/packages/lib/src/organizations/__tests__/delete-organization-fc-release.test.ts
@@ -1,0 +1,252 @@
+// packages/lib/src/organizations/__tests__/delete-organization-fc-release.test.ts
+//
+// plans/bank-connection/08-removing-a-bank-account.md §5.4 door 4 / §7.6.
+//
+// 🛑 Stripe bills 30c per institution per account holder per month and the ONLY thing
+// that stops it is calling disconnect on the account. `DataConnector.organizationId` is
+// `onDelete: 'cascade'`, so deleting an organization takes its connectors with it and
+// the nightly reaper can never find them afterwards - the delete destroys the evidence
+// in the same transaction that would otherwise create the leak. So the release has to
+// happen BEFORE the transaction, and these tests pin both halves of that: that it
+// happens, and that a failure does not take the deletion down with it.
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/** Every call the ordering assertion cares about, in the order production made it. */
+const trace: string[] = []
+
+const listBankFeedAccountsForOrganization = vi.fn(async (_db: unknown, _orgId: string) => [
+  {
+    connectorId: 'conn_1',
+    organizationId: 'org_1',
+    credentialId: 'cred_1',
+    providerAccountId: 'fca_1',
+  },
+  {
+    connectorId: 'conn_2',
+    organizationId: 'org_1',
+    credentialId: 'cred_2',
+    providerAccountId: 'fca_2',
+  },
+])
+const reapBankFeedAccount = vi.fn(async (_db: unknown, candidate: { connectorId: string }) => {
+  trace.push(`release:${candidate.connectorId}`)
+  return true
+})
+
+/** The plan-subscription cancel. `subscriptionCancel` is swapped per test. */
+let subscriptionCancel = vi.fn(async () => {
+  trace.push('subscription-cancel')
+})
+
+vi.mock('@auxx/billing', () => ({
+  stripeClient: {
+    getClient: () => ({
+      subscriptions: {
+        retrieve: async () => ({ id: 'sub_1', status: 'active' }),
+        cancel: (...a: []) => subscriptionCancel(...a),
+      },
+    }),
+  },
+}))
+
+vi.mock('../../banking/feed/reaper', () => ({
+  listBankFeedAccountsForOrganization: (...a: [never, never]) =>
+    listBankFeedAccountsForOrganization(...a),
+  reapBankFeedAccount: (...a: [never, never]) => reapBankFeedAccount(...a),
+}))
+
+// Everything below is module-load ballast for `organization-service.ts`: Redis, BullMQ,
+// Pusher and the seeder. None of it participates in the release path.
+vi.mock('../../cache', () => ({
+  flushOrganization: vi.fn(async () => {}),
+  onCacheEvent: vi.fn(async () => {}),
+}))
+vi.mock('../../dehydration', () => ({
+  DehydrationService: class {
+    invalidateUser = vi.fn(async () => {})
+  },
+}))
+vi.mock('../../email/message-service', () => ({
+  MessageService: { unregisterWebhooks: vi.fn(async () => {}) },
+}))
+vi.mock('../../email/polling-import-cache', () => ({ clearImportCache: vi.fn(async () => {}) }))
+vi.mock('../../inboxes', () => ({ InboxService: class {} }))
+vi.mock('../../jobs/maintenance/storage-cleanup-job', () => ({
+  enqueueStorageCleanupJob: vi.fn(async () => {}),
+}))
+vi.mock('../../members', () => ({ getMembership: vi.fn(async () => null) }))
+vi.mock('../../permissions/profiles', () => ({ ensureSystemProfiles: vi.fn(async () => {}) }))
+vi.mock('../../seed/organization-seeder', () => ({ OrganizationSeeder: class {} }))
+vi.mock('../../users/system-user-service', () => ({
+  SystemUserService: { invalidateSystemUserCache: vi.fn(async () => {}) },
+}))
+
+const { OrganizationService } = await import('../organization-service')
+
+/**
+ * A db double for the pre-transaction reads `deleteOrganization` makes, in order:
+ * the owner count, the member list, and the organization's system user.
+ *
+ * ⚠️ The WHERE clauses are never evaluated. What these tests pin is the ORDERING of
+ * the Stripe release against the transaction, not the SQL.
+ */
+function fakeDb() {
+  const selectResults: unknown[][] = [[{ count: 1 }], [], [{ systemUserId: null }]]
+
+  const selectChain = () => {
+    const chain: Record<string, unknown> = {
+      from: () => chain,
+      innerJoin: () => chain,
+      leftJoin: () => chain,
+      where: () => {
+        const rows = selectResults.shift() ?? []
+        const promise = Promise.resolve(rows) as Promise<unknown> & { limit?: unknown }
+        promise.limit = () => Promise.resolve(rows)
+        return promise
+      },
+      limit: () => Promise.resolve([]),
+    }
+    return chain
+  }
+
+  const writable = {
+    select: () => selectChain(),
+    delete: () => ({ where: async () => undefined }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  }
+
+  return {
+    ...writable,
+    query: { PlanSubscription: { findFirst: async () => undefined } },
+    transaction: async (cb: (tx: unknown) => Promise<void>) => {
+      trace.push('transaction')
+      // Inside the transaction the integration read must yield an empty list; queue it
+      // here rather than up front so a missed pre-transaction read cannot borrow it.
+      selectResults.push([])
+      await cb(writable)
+    },
+  }
+}
+
+/** The db double covers only the calls this path makes, so the cast is deliberate. */
+const asDb = (db: unknown) => db as Database
+
+beforeEach(() => {
+  trace.length = 0
+  reapBankFeedAccount.mockClear()
+  reapBankFeedAccount.mockImplementation(async (_db, candidate) => {
+    trace.push(`release:${candidate.connectorId}`)
+    return true
+  })
+  listBankFeedAccountsForOrganization.mockClear()
+  subscriptionCancel = vi.fn(async () => {
+    trace.push('subscription-cancel')
+  })
+})
+
+/** A db double whose org carries an active plan subscription, so the cancel runs. */
+function dbWithSubscription() {
+  const db = fakeDb()
+  return {
+    ...db,
+    query: {
+      PlanSubscription: {
+        findFirst: async () => ({
+          id: 'psub_1',
+          stripeSubscriptionId: 'sub_1',
+          status: 'active',
+        }),
+      },
+    },
+  }
+}
+
+describe('deleteOrganization releases Financial Connections accounts', () => {
+  it('releases every account the org holds, BEFORE the transaction', async () => {
+    const service = new OrganizationService(asDb(fakeDb()))
+
+    const result = await service.deleteOrganization({
+      organizationId: 'org_1',
+      isSystemDeletion: true,
+    })
+
+    expect(result).toEqual({ success: true, userDeleted: false })
+    expect(reapBankFeedAccount).toHaveBeenCalledTimes(2)
+    // 🛑 The ordering IS the fix. Once the transaction commits, the connectors have
+    // cascaded away and there is no `providerAccountId` left to disconnect - not here,
+    // and not in the nightly sweep either.
+    expect(trace).toEqual(['release:conn_1', 'release:conn_2', 'transaction'])
+  })
+
+  it('completes the deletion when a release throws', async () => {
+    reapBankFeedAccount.mockImplementation(async (_db, candidate) => {
+      trace.push(`release:${candidate.connectorId}`)
+      if (candidate.connectorId === 'conn_1') throw new Error('stripe is down')
+      return true
+    })
+    const service = new OrganizationService(asDb(fakeDb()))
+
+    // The opposite tradeoff from the plan-subscription cancel that sits beside this
+    // block, and deliberately so: a leaked 30c is recoverable by a human reading an
+    // invoice, an organization that can never be deleted is not.
+    const result = await service.deleteOrganization({
+      organizationId: 'org_1',
+      isSystemDeletion: true,
+    })
+
+    expect(result).toEqual({ success: true, userDeleted: false })
+    // And the throw does not stop the SECOND account being released either.
+    expect(trace).toEqual(['release:conn_1', 'release:conn_2', 'transaction'])
+  })
+
+  it('releases AFTER the plan-subscription cancel, not before it', async () => {
+    const service = new OrganizationService(asDb(dbWithSubscription()))
+
+    await service.deleteOrganization({ organizationId: 'org_1', isSystemDeletion: true })
+
+    // 🛑 Both steps run before the transaction, but the ORDER between them matters and
+    // is not arbitrary. See the next test for what it buys.
+    expect(trace).toEqual([
+      'subscription-cancel',
+      'release:conn_1',
+      'release:conn_2',
+      'transaction',
+    ])
+  })
+
+  it('releases NOTHING when the subscription cancel aborts the deletion', async () => {
+    subscriptionCancel = vi.fn(async () => {
+      trace.push('subscription-cancel')
+      throw new Error('stripe rejected the cancel')
+    })
+    const service = new OrganizationService(asDb(dbWithSubscription()))
+
+    await expect(
+      service.deleteOrganization({ organizationId: 'org_1', isSystemDeletion: true })
+    ).rejects.toThrow()
+
+    // 🛑 This is why the release sits BELOW the cancel. The cancel is the one step here
+    // that throws and aborts the delete, and it is the one with a history of doing so.
+    // Releasing first would leave a SURVIVING organization whose bank feeds had already
+    // been released at Stripe - recoverable only by the customer authenticating at their
+    // bank again, which is a far worse outcome than the leaked 30c the release prevents.
+    expect(reapBankFeedAccount).not.toHaveBeenCalled()
+    expect(trace).toEqual(['subscription-cancel'])
+  })
+
+  it('completes the deletion when the account lookup itself throws', async () => {
+    listBankFeedAccountsForOrganization.mockRejectedValueOnce(new Error('no db'))
+    const service = new OrganizationService(asDb(fakeDb()))
+
+    const result = await service.deleteOrganization({
+      organizationId: 'org_1',
+      isSystemDeletion: true,
+    })
+
+    expect(result).toEqual({ success: true, userDeleted: false })
+    expect(reapBankFeedAccount).not.toHaveBeenCalled()
+    expect(trace).toEqual(['transaction'])
+  })
+})

--- a/packages/lib/src/organizations/organization-service.ts
+++ b/packages/lib/src/organizations/organization-service.ts
@@ -7,6 +7,9 @@ import { OrganizationRole, type OrganizationType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { and, eq, isNull, sql } from 'drizzle-orm'
+// The LEAF, not the `banking` barrel: the barrel drags the org cache and the whole
+// review/rules surface into this module's import graph for two functions.
+import { listBankFeedAccountsForOrganization, reapBankFeedAccount } from '../banking/feed/reaper'
 import { flushOrganization, onCacheEvent } from '../cache'
 import { DehydrationService } from '../dehydration'
 import type { ForwardingIntegrationMetadata } from '../email/inbound'
@@ -525,6 +528,61 @@ export class OrganizationService {
             'Failed to cancel active subscription. Please cancel your subscription first or contact support.',
         })
       }
+    }
+
+    // --- Release Financial Connections accounts at Stripe (does NOT block deletion) ---
+    //
+    // Stripe bills 30c per institution per account holder per month and the only thing
+    // that stops it is calling disconnect on the account. This runs BEFORE the
+    // transaction for the same reason the subscription cancel below does, and for one
+    // more that is specific to it: `DataConnector.organizationId` is `onDelete: 'cascade'`,
+    // so the moment the org row goes the connectors go with it and the nightly reaper
+    // (`banking/feed/reaper.ts`) can never find them. The delete would destroy the
+    // evidence in the same transaction that creates the leak.
+    //
+    // 🛑 This sits AFTER the subscription cancel, not before it, and the order matters.
+    // The cancel is the step that THROWS and aborts the delete, and it is the one with a
+    // history of doing so. Releasing first would mean a failed cancel left a surviving
+    // organization whose bank feeds had already been released at Stripe - recoverable
+    // only by the customer authenticating at their bank again. Everything from here to
+    // COMMIT is either tolerant or the transaction itself.
+    //
+    // 🛑 A failure here is LOGGED AND SWALLOWED, which is the opposite of what the
+    // subscription cancel above does, and the difference is deliberate. That one blocks
+    // because Stripe billing a customer who no longer has an account is unrecoverable.
+    // This one must not block, because a leaked 30c a month is recoverable by a human
+    // reading an invoice while an organization that can never be deleted is not - and an
+    // account already released, or one whose credential Stripe no longer resolves, would
+    // otherwise wedge every retry exactly the way the blind `cancel()` once did.
+    try {
+      const feedAccounts = await listBankFeedAccountsForOrganization(this.db, organizationId)
+      for (const account of feedAccounts) {
+        try {
+          const released = await reapBankFeedAccount(this.db, account)
+          if (released) {
+            logger.info('Released a Financial Connections account before org deletion', {
+              organizationId,
+              connectorId: account.connectorId,
+            })
+          } else {
+            logger.warn(
+              'Stripe would not release a Financial Connections account - continuing deletion',
+              { organizationId, connectorId: account.connectorId }
+            )
+          }
+        } catch (releaseError) {
+          logger.error('Failed to release a Financial Connections account - continuing deletion', {
+            organizationId,
+            connectorId: account.connectorId,
+            error: releaseError instanceof Error ? releaseError.message : String(releaseError),
+          })
+        }
+      }
+    } catch (listError) {
+      logger.error('Could not list Financial Connections accounts - continuing deletion', {
+        organizationId,
+        error: listError instanceof Error ? listError.message : String(listError),
+      })
     }
 
     // --- Begin Transaction ---

--- a/packages/lib/src/resources/registry/resources/bank-account-fields.ts
+++ b/packages/lib/src/resources/registry/resources/bank-account-fields.ts
@@ -401,6 +401,36 @@ export const BANK_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       'linkNewRelationships skips the pair with a debug line',
   },
 
+  hasPosted: {
+    id: toFieldId('hasPosted'),
+    key: 'hasPosted',
+    label: 'Has Posted',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'bank_account_has_posted',
+    systemSortOrder: 'aD',
+    nullable: false,
+    defaultValue: false,
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'A WRITE-ONCE high-water mark: true once any line on this account has produced a journal ' +
+      'entry. The only term in the removal gate - false deletes, true archives ' +
+      '(plans/bank-connection/08-removing-a-bank-account.md §5.1). Nothing clears it: undoing a ' +
+      'review, reversing an entry and reversing an import all leave the GlPosting and its ' +
+      'reversal in the books, so an account that permanently changed the ledger must never ' +
+      'become deletable again. Reading the question off the transaction rows instead is the ' +
+      'trap this field exists to close - undoReview nulls glPostingId and the answer flips back',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -90,6 +90,7 @@ import { migration126ServiceRevenueAccount } from './migrations/126-service-reve
 import { migration128InvoiceWrittenOff } from './migrations/128-invoice-written-off'
 import { migration132CardClearingRename } from './migrations/132-card-clearing-rename'
 import { migration133Payout } from './migrations/133-payout'
+import { migration134BankAccountHasPosted } from './migrations/134-bank-account-has-posted'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -262,6 +263,10 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // 108, which owns the chart, and after 132, which renamed the clearing role
   // the payout drains.
   migration133Payout,
+  // `bank_account_has_posted`, the write-once high-water mark the bank-account
+  // removal gate reads: false deletes, true archives, and nothing clears it.
+  // MUST sort after 125, which owns the `bank_account` def it widens.
+  migration134BankAccountHasPosted,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/134-bank-account-has-posted.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/134-bank-account-has-posted.ts
@@ -1,0 +1,226 @@
+// packages/lib/src/seed/entity-migrations/migrations/134-bank-account-has-posted.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { generateKeyBetween } from '@auxx/utils/fractional-indexing'
+import { and, eq, inArray, isNotNull } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { BANK_ACCOUNT_FIELDS } from '../../../resources/registry/resources/bank-account-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:134')
+
+/** The def that receives the field. */
+const BANK_ACCOUNT_ENTITY_TYPE = 'bank_account'
+
+/** Listed by REGISTRY KEY, so a later unrelated field cannot join this payload. */
+const FIELD_KEYS = ['hasPosted'] as const
+
+/** The link a bank line carries to its account. Read as `relatedEntityId`. */
+const LINK_ATTRIBUTE = 'bank_transaction_bank_account'
+
+/** The posting id a coded or transferred line carries. `NOT NULL` is the backfill. */
+const POSTING_ATTRIBUTE = 'bank_transaction_gl_posting_id'
+
+/**
+ * Migration 134: `bank_account_has_posted`, the write-once fact that decides
+ * whether a bank account can be deleted or only archived
+ * (plans/bank-connection/08-removing-a-bank-account.md §5.1, §7.5).
+ *
+ * ## Why a stored field rather than a query
+ *
+ * "Has anything on this account ever reached the books" is not answerable from
+ * the transaction rows, and that is the whole point. `undoReview` sets
+ * `bank_transaction_gl_posting_id` back to `null` and returns the line to
+ * `for_review`, so a predicate computed off the rows FLIPS BACK to false - while
+ * the `GlPosting` it reversed and the reversal itself both stay in the books
+ * forever, with a row on this account as their source document. Compute the gate
+ * that way and an account that permanently changed the ledger becomes deletable
+ * again the moment somebody undoes the last review.
+ *
+ * So the fact is RECORDED at the two sites where a bank line first produces an
+ * entry (`banking/review/writes.ts`), and 🛑 **nothing ever clears it** - not
+ * `undoReview`, not a reversal, not `reverseImport`. It is a high-water mark,
+ * not a current state, and the one-way-ness is the feature.
+ *
+ * ## The backfill is one statement, and it is not a reconciliation
+ *
+ * `default false` is already correct for every existing row: the bank feed has
+ * never been used in production - zero Financial Connections accounts
+ * (`plans/accounting/HANDOFF.md` §14.3 item 1) - and nothing has posted from a
+ * bank line. The single `INSERT ... SELECT`-shaped pass below over lines that
+ * still carry a `glPostingId` is written because it is free, not because there
+ * is anything to find.
+ *
+ * ⚠️ It is deliberately INEXACT and says so: a line that posted and was then
+ * undone carries no `glPostingId` any more, so the backfill misses it. That set
+ * is empty in practice, and building a reconciliation pass over `GlPosting` to
+ * close a hole with nothing in it would be more code than the feature.
+ *
+ * ## Id space
+ *
+ * 134 is the next free id. The space is SHARED between
+ * `data-migrations/migrations/` (which reaches 131) and
+ * `seed/entity-migrations/migrations/` (which reaches 133), and has already
+ * collided once, at 103.
+ *
+ * **No DDL.** The field is a `CustomField` row on an existing def and the
+ * backfill writes `FieldValue` rows; nothing here touches a Postgres table.
+ *
+ * Idempotent - `ensureCustomFields` skips a field that already exists, and the
+ * backfill only inserts where no `FieldValue` is present.
+ */
+export const migration134BankAccountHasPosted: EntityMigration = {
+  id: '134-bank-account-has-posted',
+  description:
+    'Add bank_account_has_posted, the write-once high-water mark that decides whether removing ' +
+    'a bank account deletes it or archives it, and stamp it on any account that still holds a ' +
+    'posted bank line',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const def = existing.entityDefs.get(BANK_ACCOUNT_ENTITY_TYPE)
+    // Absent rather than failed: an org short of migration 125 has no
+    // `bank_account` def to widen, and the seeder creates the field with the
+    // rest of the registry.
+    if (!def) return { ...state, alreadyUpToDate: true }
+
+    const fields: Record<string, ResourceField> = {}
+    for (const key of FIELD_KEYS) {
+      const field = BANK_ACCOUNT_FIELDS[key]
+      // Loud rather than silent: a renamed registry key would otherwise make
+      // this migration quietly create one field fewer than it claims to.
+      if (!field) {
+        throw new Error(`bank_account registry is missing the key "${key}" (migration 134)`)
+      }
+      fields[key] = field
+    }
+
+    const created = await ensureCustomFields(
+      db,
+      organizationId,
+      BANK_ACCOUNT_ENTITY_TYPE,
+      def.id,
+      fields,
+      existing,
+      state
+    )
+
+    const fieldId = created.get(
+      `${BANK_ACCOUNT_ENTITY_TYPE}:${BANK_ACCOUNT_FIELDS.hasPosted!.id}`
+    )?.id
+    if (!fieldId) {
+      throw new Error(
+        `migration 134 could not resolve the bank_account_has_posted field for ${def.id}`
+      )
+    }
+
+    const backfilled = await backfillHasPosted(db, organizationId, def.id, fieldId)
+
+    const changed = state.fieldsCreated > 0 || backfilled > 0
+    // A new field is invisible to every read path until the per-org caches that
+    // serve it are dropped. `runEntityMigrationsForOrg` does this after the
+    // whole batch, but `up()` can also be invoked directly, so it clears its own.
+    if (changed) {
+      await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+      logger.info('Migration 134 applied', { organizationId, ...state, backfilled })
+    }
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}
+
+/**
+ * Stamp `true` on every account that still holds a line carrying a posting id.
+ *
+ * Returns how many rows were inserted. Exported so the backfill can be exercised
+ * on its own, the way 128's is.
+ */
+export async function backfillHasPosted(
+  db: Database,
+  organizationId: string,
+  entityDefinitionId: string,
+  fieldId: string
+): Promise<number> {
+  const linkField = await findFieldByAttribute(db, organizationId, LINK_ATTRIBUTE)
+  const postingField = await findFieldByAttribute(db, organizationId, POSTING_ATTRIBUTE)
+  // An org whose `bank_transaction` def is short either field has no posted bank
+  // line to find, which is the ordinary case and not a failure.
+  if (!linkField || !postingField) return 0
+
+  const posted = db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, postingField),
+        isNotNull(schema.FieldValue.valueText)
+      )
+    )
+
+  const links = await db
+    .select({ bankAccountId: schema.FieldValue.relatedEntityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, linkField),
+        inArray(schema.FieldValue.entityId, posted)
+      )
+    )
+
+  const accountIds = [...new Set(links.map((row) => row.bankAccountId).filter((id) => !!id))]
+  if (accountIds.length === 0) return 0
+
+  const present = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, fieldId),
+        inArray(schema.FieldValue.entityId, accountIds as string[])
+      )
+    )
+  const alreadyWritten = new Set(present.map((row) => row.entityId))
+
+  const now = new Date()
+  const inserts = (accountIds as string[])
+    .filter((accountId) => !alreadyWritten.has(accountId))
+    .map((accountId) => ({
+      organizationId,
+      entityId: accountId,
+      entityDefinitionId,
+      fieldId,
+      sortKey: generateKeyBetween(null, null),
+      valueBoolean: true,
+      updatedAt: now,
+    }))
+  if (inserts.length === 0) return 0
+
+  await db.insert(schema.FieldValue).values(inserts)
+  return inserts.length
+}
+
+/** One `CustomField.id` by its `systemAttribute`, or null when the org lacks it. */
+async function findFieldByAttribute(
+  db: Database,
+  organizationId: string,
+  systemAttribute: string
+): Promise<string | null> {
+  const [row] = await db
+    .select({ id: schema.CustomField.id })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.systemAttribute, systemAttribute)
+      )
+    )
+    .limit(1)
+  return row?.id ?? null
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -774,6 +774,10 @@ export const SYSTEM_ATTRIBUTES = [
   'bank_account_coverage_gaps', // [{ from, to }]; a balance sheet over a hole is silent and wrong
   'bank_account_connector_id', // a POINTER at DataConnector, never a copy of its health
   'bank_account_status', // manual | connected | disconnected
+  // 🛑 A WRITE-ONCE high-water mark, never cleared. The only term in the
+  // bank-account removal gate: false deletes, true archives
+  // (plans/bank-connection/08-removing-a-bank-account.md §5.1)
+  'bank_account_has_posted',
   'bank_account_transactions', // inverse of bank_transaction_bank_account
 
   // Connector-owned (raw). The feed may correct any of these.


### PR DESCRIPTION
Two commits, separable. The first is a live billing leak with no dependency on the second.

## 1. `b28b940` Release Financial Connections accounts on org and connector delete

Stripe bills 30c per institution per account holder per month and the only thing that stops it is calling disconnect on the FC account. **Two paths ended a bank feed without doing so, and both destroyed the `DataConnector` row on the way out, so the nightly reaper could never clean up after them.**

| Door | Released before? |
|---|---|
| Disconnect button | yes |
| Nightly sweep | yes, but only finds connectors that still exist |
| **Connector delete** | **no** |
| **Organization delete** | **no** |

`deleteOrganization` cancels the plan subscription at Stripe but never called `reapBankFeedAccount`. `DataConnector.organizationId` is `onDelete: 'cascade'`, so it destroyed the evidence in the same transaction that created the leak. All five call sites funnel through that one function. `deleteConnector` had no reference to the release at all.

Two ordering decisions worth reviewing:

- **The release runs after the plan-subscription cancel**, immediately before the transaction. The cancel is the one step that throws and aborts the delete. Releasing first would leave a *surviving* organization whose bank feeds were already released at Stripe, recoverable only by the customer authenticating at their bank again. Two tests pin it.
- **In `deleteConnector` it goes before the `keep` short-circuit**, not merely before the `deleting` mark. `keep` is the default and returns earlier than that mark, so the obvious placement would have covered almost nobody.

A failed release is logged and swallowed. That is the opposite tolerance from the subscription cancel beside it, deliberately: a leaked 30c is recoverable by a human reading an invoice, an organization that can never be deleted is not.

`reaper.ts`'s header claimed the connector-delete door already called the release. It did not; the header now matches the code.

**Not user-visible.** Production holds zero FC accounts, so this has never billed anyone.

## 2. `ce1d7d7` Remove a bank account

A bank account could be created and never removed. The Danger zone was gated on `isConnected`, so a manual account added with a typo was permanent in the list and in every picker.

**The line is the first journal entry.** Below it a delete is real and takes the transactions, connector, credential and Stripe subscription with it. At or above it the account archives and keeps everything.

That needed a stored fact: `undoReview` clears `bank_transaction_gl_posting_id`, so "has this account posted" read off the rows flips back to false while the entry and its reversal stay in the books forever. New write-once `bank_account_has_posted`, stamped at both posting sites and cleared by nothing. Entity migration 134.

Archiving cannot move the trial balance: a `bank_account` holds a pointer to a GL code, and `GlPostingLine` snapshots the code and name with no FK to the instance. A regression test pins that no `GlPosting`, `gl_account` or coverage floor is touched.

Two things beyond the design: the credential delete is **conditional**, because one credential is one bank *login* and dropping it unconditionally would take a sibling account's feed down; and the delete cascade reads the account's lines directly rather than through `listForReview`, which filters archived rows and would have orphaned them.

### Known gap, not addressed here

The archive sweep is capped at 500 rows per state, and `listForReview` filters `archivedAt` on the transaction row only, never on the account. Above the cap the leftovers stay visible in For Review under an account the user can no longer see. Not the edge case: LFK's QuickBooks carries 2,390 unreviewed items. The likely fix is joining the account's `archivedAt` in `listForReview`, which is correct on its own merits.

## Also in this branch

Finished bank-account picker and manual-dialog work from a parallel session. `bank-accounts-settings-page.tsx` and `bank-account-picker.tsx` import `BankAccountManualDialog` and `MultiSelectPicker`, so the branch does not compile without them.

## Verification

```
lib: no new type errors (27 total, baseline 27)
web: no new type errors (0 total, baseline 0)
vitest src/banking src/organizations src/data-connectors
  Test Files  85 passed (85)
       Tests  972 passed (972)
```

Both agent implementations were reviewed; two defects found and fixed, each with a regression test confirmed red against the original code (the release ordering above, and restore not re-opening the archive's own exclusions).

https://claude.ai/code/session_012yq1UCB3pd9GJ85pNnzJLH
