### PR TITLE
feat(banking): put the review queue's view in the URL, and move "apply rules" onto it

### DIFF
--- a/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
@@ -36,23 +36,25 @@
 // range, the signed in/out colouring and the suggestion badge, none of which the
 // registry can express. Reported in HANDOFF §5 for the coordinator.
 
-import type { BankTransactionRow } from '@auxx/lib/banking/review/client'
+import { type BankTransactionRow, REVIEW_QUEUE_STATES } from '@auxx/lib/banking/review/client'
 import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { toastError } from '@auxx/ui/components/toast'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
-import { Inbox, Landmark } from 'lucide-react'
-import { useQueryState } from 'nuqs'
-import { useCallback, useMemo, useState } from 'react'
+import { Inbox, Landmark, ListChecks } from 'lucide-react'
+import { parseAsStringLiteral, useQueryState } from 'nuqs'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRegisterDockedPanels } from '~/components/global/docked-panels-outlet'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage from '~/components/global/settings-page'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useMedia } from '~/hooks/use-media'
-import { useRequireCapability } from '~/providers/capabilities-provider'
+import { useAccess, useRequireCapability } from '~/providers/capabilities-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import { BankAccountBadge } from '../bank-account-badge'
@@ -76,6 +78,14 @@ const PAGE_DESCRIPTION =
  * display currency is that constant rather than a read.
  */
 const DISPLAY_CURRENCY = 'USD'
+
+/** What one "apply rules" run reports back, as `applySuggestions` returns it. */
+interface RunCounts {
+  suggested: number
+  ruleMatched: number
+  autoApplied: number
+  skipped: number
+}
 
 /** The status dot vocabulary, matching `ledger-toolbar.tsx`'s `STATE_DOT`. */
 const STATUS_DOT: Record<string, string> = {
@@ -103,10 +113,54 @@ function toMinor(value: string): number | undefined {
 
 export function BankingReviewQueuePage() {
   useRequireCapability(PermissionKey.ledgerView)
+  const utils = api.useUtils()
+  const { can } = useAccess()
+  const [confirm, ConfirmDialog] = useConfirm()
 
-  const [filters, setFilters] = useState<ReviewFilters>(EMPTY_REVIEW_FILTERS)
+  /**
+   * The tab and the account are the VIEW; the rest of the toolbar narrows it.
+   *
+   * Only the view goes in the URL (`plans/bank-connection/10-review-queue-url-state.md`
+   * §2). `?txn=` was already linkable, and a link that reopens a drawer inside a
+   * queue that has silently reset to For review / All accounts is the worst of
+   * the two halves. Search and the ranges stay local: a text box in the URL is
+   * either a history entry per keystroke or a throttle to tune, and nobody
+   * shares "amount between 12 and 40".
+   */
+  const [queueState, setQueueState] = useQueryState(
+    's',
+    parseAsStringLiteral(REVIEW_QUEUE_STATES).withDefault('for_review')
+  )
+  const [account, setAccount] = useQueryState('account')
+  const [localFilters, setLocalFilters] = useState<ReviewFilters>(EMPTY_REVIEW_FILTERS)
   const [selectedIds, setSelectedIds] = useState<string[]>([])
   const [txn, setTxn] = useQueryState('txn')
+
+  const filters = useMemo<ReviewFilters>(
+    () => ({ ...localFilters, state: queueState, bankAccountId: account }),
+    [localFilters, queueState, account]
+  )
+
+  const handleFiltersChange = useCallback(
+    (next: ReviewFilters) => {
+      if (next.state !== queueState) void setQueueState(next.state)
+      if (next.bankAccountId !== account) void setAccount(next.bankAccountId)
+      setLocalFilters(next)
+    },
+    [queueState, account, setQueueState, setAccount]
+  )
+
+  /**
+   * ⚠️ Keyed on the URL, not folded into `handleFiltersChange`. Back and forward
+   * change the tab or the account without going through the toolbar at all, and
+   * a bulk bar still holding rows that are no longer listed would act on them.
+   * The last run's counts go with it - they describe a view you have left.
+   */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the URL is the trigger
+  useEffect(() => {
+    setSelectedIds([])
+    setLastRun(null)
+  }, [queueState, account])
 
   /**
    * ⚠️ `1280px`, not the `1024px` `ledger-page.tsx` docks at. This page sits
@@ -128,6 +182,17 @@ export function BankingReviewQueuePage() {
     () => (accountsQuery.data ?? []).filter((account) => !account.archivedAt),
     [accountsQuery.data]
   )
+
+  /**
+   * A bookmarked `?account=` for an account that has since been archived or
+   * deleted is an ordinary state, not an error - `getBankAccount` takes the same
+   * posture on the read side. Clear it rather than render an empty list under a
+   * filter the picker cannot show.
+   */
+  useEffect(() => {
+    if (!account || accountsQuery.isPending) return
+    if (!accounts.some((row) => row.id === account)) void setAccount(null)
+  }, [account, accounts, accountsQuery.isPending, setAccount])
 
   const listInput = useMemo(
     () => ({
@@ -156,6 +221,81 @@ export function BankingReviewQueuePage() {
   }, [])
 
   const hasAccounts = accounts.length > 0
+
+  // ── Applying rules ──────────────────────────────────────────────────────
+  //
+  // 🛑 This button used to live on the Rules page under the name "Run
+  // suggestions now", where every neighbouring control acts on a rule - so it
+  // read as "propose some rules to me". It does the opposite: it writes
+  // suggestions onto TRANSACTIONS, and an `autoApply` rule posts to the ledger.
+  // It belongs here, where the lines it touches are on screen, and it says so.
+
+  /** Only `for_review` lines can be touched, so only those two tabs offer it. */
+  const canApplyRules =
+    can(PermissionKey.ledgerPost) && (queueState === 'for_review' || queueState === 'suggested')
+
+  // Fetched only when the button is on screen. Its one job is the confirm
+  // below: an auto-apply rule is the difference between suggesting and posting.
+  const rulesQuery = api.bankingRules.list.useQuery(undefined, { enabled: canApplyRules })
+  const autoApplyRules = useMemo(
+    () => (rulesQuery.data ?? []).filter((rule) => rule.enabled && rule.autoApply),
+    [rulesQuery.data]
+  )
+
+  const [lastRun, setLastRun] = useState<RunCounts | null>(null)
+
+  const applyRules = api.bankingRules.runSuggestions.useMutation({
+    onSuccess: async (result) => {
+      setLastRun(result)
+      await Promise.all([
+        utils.bankingReview.list.invalidate(),
+        utils.bankingReview.stats.invalidate(),
+      ])
+    },
+    onError: (error) => {
+      toastError({ title: 'Error applying rules', description: error.message })
+    },
+  })
+
+  const handleApplyRules = async () => {
+    if (autoApplyRules.length > 0) {
+      const names = autoApplyRules.map((rule) => rule.name).join(', ')
+      const confirmed = await confirm({
+        title: 'Apply rules now?',
+        description:
+          `${autoApplyRules.length === 1 ? 'One rule is' : `${autoApplyRules.length} rules are`} ` +
+          `set to auto-apply (${names}). Lines they match are coded and POSTED, not suggested. ` +
+          'Every other line only gets a suggestion for you to accept.',
+        confirmText: 'Apply rules',
+        cancelText: 'Cancel',
+      })
+      if (!confirmed) return
+    }
+    setLastRun(null)
+    // The account the person is looking at, not the whole org.
+    applyRules.mutate({ bankAccountId: filters.bankAccountId ?? undefined })
+  }
+
+  const applyRulesAction = canApplyRules ? (
+    <div className='flex items-center gap-2'>
+      <Button
+        variant='ghost'
+        size='sm'
+        className='h-7'
+        loading={applyRules.isPending}
+        loadingText='Applying...'
+        onClick={() => void handleApplyRules()}>
+        <ListChecks />
+        Apply rules to unreviewed lines
+      </Button>
+      {/* No success toasts by policy, so the counts have nowhere else to go. */}
+      {lastRun && !applyRules.isPending && (
+        <span className='whitespace-nowrap text-muted-foreground text-xs'>
+          {lastRun.suggested} suggested, {lastRun.autoApplied} applied, {lastRun.skipped} skipped
+        </span>
+      )}
+    </div>
+  ) : undefined
 
   /**
    * ⚠️ Built ONCE and memoised. The panel array below is published to the
@@ -210,10 +350,8 @@ export function BankingReviewQueuePage() {
 
         <ReviewToolbar
           filters={filters}
-          onChange={(next) => {
-            setFilters(next)
-            setSelectedIds([])
-          }}
+          onChange={handleFiltersChange}
+          actions={applyRulesAction}
         />
 
         {!list.isPending && rows.length === 0 ? (
@@ -335,6 +473,8 @@ export function BankingReviewQueuePage() {
       {/* Below the dock breakpoint the same drawer renders as a floating
           overlay, the way every other docked panel's fallback does. */}
       {!isDesktop && drawer}
+
+      <ConfirmDialog />
     </SettingsPage>
   )
 }

--- a/apps/web/src/components/accounting/ui/banking/review/review-toolbar.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-toolbar.tsx
@@ -49,6 +49,13 @@ const STATES: { value: ReviewQueueState; label: string }[] = [
 interface ReviewToolbarProps {
   filters: ReviewFilters
   onChange: (next: ReviewFilters) => void
+  /**
+   * Actions that change the DATA, rendered on row one after the state tabs.
+   *
+   * The page owns them, not this component: whatever runs here has to
+   * invalidate the queries the page holds, so the node arrives built.
+   */
+  actions?: React.ReactNode
 }
 
 /**
@@ -76,6 +83,10 @@ const asDate = (day: string) => new Date(`${day}T00:00:00`)
  * second on its row because the ACCOUNT is what a bookkeeper reconciles against
  * a statement.
  *
+ * Row one also carries `actions` (the page's "apply rules" button), because
+ * that button acts on the pile the tabs are selecting; row two is only ever
+ * about narrowing what is already listed.
+ *
  * Both rows are `sticky={false}` because the wrapper is the sticky element -
  * two sticky rows would pin to the same `top-0` and cover each other.
  *
@@ -83,7 +94,7 @@ const asDate = (day: string) => new Date(`${day}T00:00:00`)
  * that crosses the wire is integer minor units; this is the one boundary where
  * a person's `12.50` becomes `1250`, and it is deliberately not two conventions.
  */
-export function ReviewToolbar({ filters, onChange }: ReviewToolbarProps) {
+export function ReviewToolbar({ filters, onChange, actions }: ReviewToolbarProps) {
   const set = <K extends keyof ReviewFilters>(key: K, value: ReviewFilters[K]) =>
     onChange({ ...filters, [key]: value })
 
@@ -143,6 +154,13 @@ export function ReviewToolbar({ filters, onChange }: ReviewToolbarProps) {
             ))}
           </RadioTab>
         </ListToolbarGroup>
+
+        {actions && (
+          <>
+            <Separator orientation='vertical' className='h-5 shrink-0' />
+            <ListToolbarGroup className='shrink-0'>{actions}</ListToolbarGroup>
+          </>
+        )}
       </ListToolbar>
 
       <ListToolbar sticky={false}>

--- a/apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx
@@ -11,7 +11,7 @@
 // key were coded to 6100" is the strongest signal available before a single
 // rule exists. A `bank_rule` is the opt-in, ORDERED layer a reviewer adds once
 // a pattern is confirmed. This page lists them, lets a person add, edit,
-// disable or delete one, and runs suggestions over the queue on demand.
+// disable or delete one.
 //
 // ## ⚠️ Departure: a TreeRowList, not `RecordsView`
 //
@@ -22,6 +22,14 @@
 // the match and the action as one line, so this is a `TreeRowList` over
 // `bankingRules.list`, the same shape the review queue and the journal's
 // entries list use.
+//
+// ## 🛑 Running the rules is NOT on this page
+//
+// It is on the review queue, next to the state tabs
+// (`plans/bank-connection/10-review-queue-url-state.md` §4). A button here read
+// as "suggest some rules to me", because every other control on this page acts
+// on a rule; what it actually does is write suggestions onto TRANSACTIONS and,
+// for an `autoApply` rule, post. It belongs where its results render.
 //
 // 🛑 `autoApply` is off by default and the dialog explains why: a rule that
 // silently posts to the ledger is a rule that silently posts a WRONG entry, and
@@ -35,7 +43,7 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { toastError } from '@auxx/ui/components/toast'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
-import { ListChecks, Pencil, Plus, Power, Sparkles, Trash2 } from 'lucide-react'
+import { ListChecks, Pencil, Plus, Power, Trash2 } from 'lucide-react'
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage from '~/components/global/settings-page'
@@ -121,12 +129,6 @@ export function BankingRulesPage() {
     [accountsQuery.data]
   )
 
-  const runSuggestions = api.bankingRules.runSuggestions.useMutation({
-    onError: (error) => {
-      toastError({ title: 'Error running suggestions', description: error.message })
-    },
-  })
-
   const updateRule = api.bankingRules.update.useMutation({
     onSuccess: async () => {
       await utils.bankingRules.list.invalidate()
@@ -175,21 +177,10 @@ export function BankingRulesPage() {
       description={PAGE_DESCRIPTION}
       breadcrumbs={BREADCRUMBS}
       button={
-        <div className='flex items-center gap-2'>
-          <Button
-            variant='outline'
-            size='sm'
-            loading={runSuggestions.isPending}
-            loadingText='Running...'
-            onClick={() => runSuggestions.mutate({})}>
-            <Sparkles />
-            Run suggestions now
-          </Button>
-          <Button size='sm' onClick={openCreate}>
-            <Plus />
-            New rule
-          </Button>
-        </div>
+        <Button size='sm' onClick={openCreate}>
+          <Plus />
+          New rule
+        </Button>
       }>
       <div ref={frameRef} className='p-4' style={{ height: frameHeight }}>
         <div className='flex h-full flex-col overflow-hidden rounded-xl border bg-background'>

--- a/packages/lib/src/banking/rules/writes.ts
+++ b/packages/lib/src/banking/rules/writes.ts
@@ -308,7 +308,7 @@ export interface ApplySuggestionsResult {
   suggested: number
   /** How many of those matched a rule, whether or not it is `autoApply`. */
   ruleMatched: number
-  /** Always `0` until 3B's `banking/review/writes.ts` lands. See the file header. */
+  /** How many `autoApply` rules actually coded, transferred or excluded a line. */
   autoApplied: number
   /** How many `for_review` lines had nothing to suggest. */
   skipped: number


### PR DESCRIPTION
## What

Two things on `/app/accounting/banking`.

**1. The view is in the URL.** The queue already deep-linked the open line with `?txn=`, but held the state tab and the bank account in `useState`. One URL was six views: a shared or reloaded link reopened a drawer inside a queue that had silently reset to For review / All accounts.

```
/app/accounting/banking?s=suggested&account=<id>&txn=<id>
```

`s` and `account` are the names `deposits-page.tsx` and `accounts-settings-page.tsx` already use. `s` parses against `REVIEW_QUEUE_STATES` (already a `const` tuple in `banking/review/client.ts`), so `?s=nonsense` falls back to For review, and the default clears itself out of the URL. Search, dates and amounts stay local: a text box in the URL is either a history entry per keystroke or a throttle to tune.

**2. "Run suggestions now" moved off the Rules page.** There it sat among controls that all act on rules, so it read as *suggest some rules to me*. What it actually does is write suggestions onto **transactions** and, for an `autoApply` rule, **post to the ledger** — and its results render on a different page. It is now "Apply rules to unreviewed lines", in the queue toolbar next to the tabs that select the pile it works on.

## Details

- Shown on **For review** and **Suggested** (the only tabs whose lines it can touch), to anyone with `ledgerPost`; the page itself only requires `ledgerView`.
- Passes the selected `bankAccountId` instead of `{}`, which swept every account regardless of what you were looking at.
- Confirms first when an enabled `autoApply` rule would post, naming the rules. No confirm when none do, because then the run cannot reach the ledger.
- Invalidates `bankingReview.list` and `.stats`, and shows `12 suggested, 2 applied, 40 skipped` beside itself. The old mutation dropped that result and invalidated nothing.
- Selection and the run counts clear in an effect keyed on the URL, not in the toolbar callback: back/forward change the view without going through it, and a bulk bar holding rows that are no longer listed would act on them.
- A bookmarked `?account=` for an account that has since been removed clears itself, rather than showing an empty list under a filter the picker cannot render. Relevant now that #2069 has landed.
- `ReviewToolbar` gains one optional `actions` node; the page owns the mutation because it owns the queries to invalidate.
- Doc-only: `ApplySuggestionsResult.autoApplied` still claimed "always `0` until 3B's `banking/review/writes.ts` lands". That module shipped and `tryAutoApplyAction` calls into it.

## Testing

- `biome check` clean on the three web files.
- Web typecheck ratchet: no new errors (0 total, baseline 0).
- Not clicked through in a browser.

Manual checks worth doing on review: `?s=suggested&account=<id>` survives a reload; back/forward leaves the bulk bar empty; `?s=nonsense` renders For review; a member without `ledgerPost` does not see the button.

## Not in here

Mining **rule** suggestions from history — the feature the old label sounded like, and which nothing does. `listHistoryMatches` already computes the majority code for one key and `createRuleFromTransaction` is the writer; what is missing is the group-by across keys and an accept/dismiss surface. Written up as §6.2 of `plans/bank-connection/10-review-queue-url-state.md`.

https://claude.ai/code/session_01VJxTbSScPJLs1QU8uXfbPy
