### PR TITLE
refactor(data-connectors): declare provider release as a capability, not a feature call

### DIFF
--- a/packages/lib/src/banking/feed/actions.ts
+++ b/packages/lib/src/banking/feed/actions.ts
@@ -13,6 +13,7 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
+import { readProviderAccountId as readAccountIdFromMetadata } from '../../connections/hosted-provision/types'
 import { getProviderByKey } from '../../connections/providers'
 import { enqueueConnectorSync } from '../../data-connectors/data-connector-queue'
 import { getConnectorReadiness, READINESS_REASON } from '../../data-connectors/readiness'
@@ -239,6 +240,5 @@ async function readProviderAccountId(
 ): Promise<string | null> {
   const credential = await getCredential(credentialId, organizationId)
   if (credential.isErr()) return null
-  const id = (credential.value.metadata as Record<string, unknown> | undefined)?.providerAccountId
-  return typeof id === 'string' && id.length > 0 ? id : null
+  return readAccountIdFromMetadata(credential.value.metadata)
 }

--- a/packages/lib/src/banking/feed/reaper.ts
+++ b/packages/lib/src/banking/feed/reaper.ts
@@ -49,7 +49,8 @@
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, isNotNull, sql } from 'drizzle-orm'
-import { STRIPE_FC_CONNECTOR_TYPE } from '../../data-connectors/connectors/stripe-financial-connections'
+import { PROVIDER_ACCOUNT_ID_METADATA_KEY } from '../../connections/hosted-provision/types'
+import { STRIPE_FC_CONNECTOR_TYPE } from '../../data-connectors/connectors/stripe-financial-connections-type'
 import { disconnectAccountAtStripe, FC_PROVIDER_KEY } from './fc-client'
 
 const logger = createScopedLogger('banking-feed-reaper')
@@ -137,6 +138,10 @@ export interface ReapCandidate extends BankFeedAccountRef {
  * The columns every door reads, resolved the same way in all of them.
  *
  * 🛑 `providerAccountId` lives in the CREDENTIAL's jsonb metadata, not on the connector,
+ * under the shared {@link PROVIDER_ACCOUNT_ID_METADATA_KEY} rather than a retyped
+ * string literal - `Credential.metadata` is `Record<string, unknown>`, so a drifted
+ * key would filter out every candidate here and report a healthy sweep releasing
+ * nothing while every account kept billing.
  * so every path that wants to release an account has to make this join. Sharing the
  * projection is what stops door 3 or door 4 inventing its own and quietly reading the
  * wrong key.
@@ -145,7 +150,7 @@ const feedAccountColumns = {
   connectorId: schema.DataConnector.id,
   organizationId: schema.DataConnector.organizationId,
   credentialId: schema.Credential.id,
-  providerAccountId: sql<string>`${schema.Credential.metadata}->>'providerAccountId'`,
+  providerAccountId: sql<string>`${schema.Credential.metadata}->>${PROVIDER_ACCOUNT_ID_METADATA_KEY}`,
 }
 
 /** A Financial Connections connector whose credential still carries an account to release. */
@@ -153,7 +158,7 @@ function releasableBankFeedFilter() {
   return and(
     eq(schema.DataConnector.type, STRIPE_FC_CONNECTOR_TYPE),
     eq(schema.Credential.type, FC_PROVIDER_KEY),
-    isNotNull(sql`${schema.Credential.metadata}->>'providerAccountId'`)
+    isNotNull(sql`${schema.Credential.metadata}->>${PROVIDER_ACCOUNT_ID_METADATA_KEY}`)
   )
 }
 

--- a/packages/lib/src/banking/feed/webhook.ts
+++ b/packages/lib/src/banking/feed/webhook.ts
@@ -26,6 +26,7 @@ import { type Database, database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, sql } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
+import { PROVIDER_ACCOUNT_ID_METADATA_KEY } from '../../connections/hosted-provision/types'
 import { STRIPE_FC_CONNECTOR_TYPE } from '../../data-connectors/connectors/stripe-financial-connections'
 import { enqueueConnectorSync } from '../../data-connectors/data-connector-queue'
 import { isSuspendedConnectorStatus } from '../../data-connectors/data-connector-scheduler'
@@ -99,7 +100,7 @@ export async function resolveFeedConnectorByAccountId(
         eq(schema.Credential.kind, 'connection'),
         eq(schema.Credential.type, FC_PROVIDER_KEY),
         eq(schema.DataConnector.type, STRIPE_FC_CONNECTOR_TYPE),
-        sql`${schema.Credential.metadata}->>'providerAccountId' = ${providerAccountId}`
+        sql`${schema.Credential.metadata}->>${PROVIDER_ACCOUNT_ID_METADATA_KEY} = ${providerAccountId}`
       )
     )
     .limit(1)

--- a/packages/lib/src/connections/hosted-provision/types.ts
+++ b/packages/lib/src/connections/hosted-provision/types.ts
@@ -64,8 +64,40 @@ export type HostedProvisionCompleteCtx = {
   payload?: Record<string, unknown>
 }
 
+/**
+ * The `Credential.metadata` key that {@link HostedProvisionCompleteResult.providerAccountId}
+ * is persisted under.
+ *
+ * 🛑 **Exported because four independent readers key on it and `Credential.metadata`
+ * is `Record<string, unknown>`, so nothing type-checks the link between them.** The
+ * failure is silent in both directions: the connector's `resolveAccountId` throws a
+ * reconnect message at the user, the bank webhook resolves to no connector and
+ * no-ops, and the billing reaper's `isNotNull(...)` filter drops every candidate -
+ * reporting zero accounts to release while every one of them keeps billing.
+ *
+ * Use {@link readProviderAccountId} to read it from a decoded row, and this constant
+ * in SQL (`metadata->>${'$'}{PROVIDER_ACCOUNT_ID_METADATA_KEY}`). Do not retype the string.
+ */
+export const PROVIDER_ACCOUNT_ID_METADATA_KEY = 'providerAccountId'
+
+/**
+ * Read the durable provider-side handle out of a `Credential.metadata` blob.
+ *
+ * Returns `null` for a missing key, a non-string value and the empty string, so a
+ * caller never has to distinguish "no account" from "account is `''`".
+ */
+export function readProviderAccountId(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== 'object') return null
+  const value = (metadata as Record<string, unknown>)[PROVIDER_ACCOUNT_ID_METADATA_KEY]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
 export type HostedProvisionCompleteResult = {
-  /** The durable provider-side handle (e.g. a Stripe `acct_…` or `fca_…`). */
+  /**
+   * The durable provider-side handle (e.g. a Stripe `acct_…` or `fca_…`).
+   *
+   * Persisted to `Credential.metadata` under {@link PROVIDER_ACCOUNT_ID_METADATA_KEY}.
+   */
   providerAccountId: string
   /** Non-secret values persisted as Credential connection variables (plaintext metadata). */
   connectionVariables: Record<string, string>

--- a/packages/lib/src/data-connectors/connectors/stripe-financial-connections-type.ts
+++ b/packages/lib/src/data-connectors/connectors/stripe-financial-connections-type.ts
@@ -1,0 +1,20 @@
+// packages/lib/src/data-connectors/connectors/stripe-financial-connections-type.ts
+
+/**
+ * The Financial Connections connector's `type` id, on its own.
+ *
+ * 🛑 **A leaf module with no imports, and that is the whole reason it exists.**
+ * The connector implements `releaseOnDelete` by calling into `banking/feed/reaper`,
+ * and the reaper has to name this type to find releasable feeds - so with the
+ * constant living in the connector, the two modules import each other.
+ *
+ * The cycle would probably have worked (both sides use the other only inside
+ * function bodies, never at module scope), but "probably" is not a property to
+ * rely on: ESM cycles resolve to `undefined` bindings whenever evaluation order
+ * shifts, and the failure here would be a silent one - a filter matching nothing
+ * and a sweep that reports zero accounts to release while every one keeps billing.
+ *
+ * `stripe-financial-connections.ts` re-exports this, so every existing import
+ * keeps working.
+ */
+export const STRIPE_FC_CONNECTOR_TYPE = 'stripe-financial-connections'

--- a/packages/lib/src/data-connectors/connectors/stripe-financial-connections.ts
+++ b/packages/lib/src/data-connectors/connectors/stripe-financial-connections.ts
@@ -26,11 +26,15 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import { normalizeMatchKey } from '../../banking/feed/match-key'
+import { findBankFeedAccountForConnector, reapBankFeedAccount } from '../../banking/feed/reaper'
+import { readProviderAccountId } from '../../connections/hosted-provision/types'
 import { getStripeConnectClient } from '../../money/payments/connect-client'
 import { periodKeyForDate } from '../../postings/periods'
 import type { SyncCursor } from '../../sync-core/contracts'
+import { STRIPE_FC_CONNECTOR_TYPE } from './stripe-financial-connections-type'
 import type {
   ConnectorFetchArgs,
+  ConnectorReleaseContext,
   ConnectorYield,
   DataConnectorDefinition,
   FetchResult,
@@ -40,7 +44,7 @@ import { ConnectorRateLimitError } from './types'
 const logger = createScopedLogger('data-connector-stripe-fc')
 
 /** The connector `type` string. One connector row is ONE Financial Connections account. */
-export const STRIPE_FC_CONNECTOR_TYPE = 'stripe-financial-connections'
+export { STRIPE_FC_CONNECTOR_TYPE } from './stripe-financial-connections-type'
 
 /** The account stream: one row, the `bank_account` this connector feeds. */
 export const FC_ACCOUNTS_STREAM = 'accounts'
@@ -309,9 +313,8 @@ export function toAccountFields(
 
 /** Read the `fca_...` id: the credential is authoritative, config is the fallback. */
 function resolveAccountId(args: ConnectorFetchArgs): string {
-  const fromCredential = (args.credential?.metadata as { providerAccountId?: unknown } | undefined)
-    ?.providerAccountId
-  if (typeof fromCredential === 'string' && fromCredential.length > 0) return fromCredential
+  const fromCredential = readProviderAccountId(args.credential?.metadata)
+  if (fromCredential) return fromCredential
   const filters = readFilters(args)
   if (filters.accountId) return filters.accountId
   throw new Error(
@@ -353,6 +356,37 @@ export function createStripeFinancialConnectionsConnector(
   return {
     type: STRIPE_FC_CONNECTOR_TYPE,
     schemaVersion: 1,
+
+    /**
+     * 🛑 Stripe bills 30c per institution per account holder per month, and the ONLY
+     * thing that stops it is disconnecting the account at Stripe. Deleting the
+     * connector row does not, and the teardown takes the `fca_...` handle with it, so
+     * nothing can find the account afterwards to clean up - the nightly reaper sweeps
+     * `DataConnector` rows and this door destroys the row.
+     *
+     * Declared here rather than called by name from `deleteConnector`, so the generic
+     * delete path never learns that a bank feed exists (decision B13). Never throws:
+     * a failed release must not block a delete the user asked for.
+     */
+    async releaseOnDelete({ db, organizationId, connectorId }: ConnectorReleaseContext) {
+      try {
+        const account = await findBankFeedAccountForConnector(db, organizationId, connectorId)
+        if (!account) return
+        const released = await reapBankFeedAccount(db, account)
+        logger.info(
+          released
+            ? 'Released a Financial Connections account before connector delete'
+            : 'Stripe would not release a Financial Connections account - deleting anyway',
+          { organizationId, connectorId }
+        )
+      } catch (error) {
+        logger.error('Failed to release a Financial Connections account - deleting anyway', {
+          organizationId,
+          connectorId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    },
     // The request is baked into this code - there is no HTTP request to author, so the
     // detail view must not offer the generic-REST builder over it.
     requestModel: 'fixed',

--- a/packages/lib/src/data-connectors/connectors/types.ts
+++ b/packages/lib/src/data-connectors/connectors/types.ts
@@ -11,6 +11,7 @@ export type {
   ConnectorMapping,
   ConnectorOwnedMappingField,
   ConnectorRecord,
+  ConnectorReleaseContext,
   ConnectorStreamDecl,
   ConnectorStreamState,
   ConnectorYield,

--- a/packages/lib/src/data-connectors/mutations.test.ts
+++ b/packages/lib/src/data-connectors/mutations.test.ts
@@ -55,13 +55,15 @@ vi.mock('./data-connector-queue', async (importOriginal) => ({
 }))
 
 // plans/bank-connection/08-removing-a-bank-account.md §5.4 door 3. The LEAF module, not
-// the `banking` barrel - that is the import production makes, and mocking the barrel
-// would leave the real leaf in the graph.
-const findBankFeedAccountForConnector = vi.fn(async (..._a: unknown[]) => null as unknown)
-const reapBankFeedAccount = vi.fn(async (..._a: unknown[]) => true)
-vi.mock('../banking/feed/reaper', () => ({
-  findBankFeedAccountForConnector: (...a: unknown[]) => findBankFeedAccountForConnector(...a),
-  reapBankFeedAccount: (...a: unknown[]) => reapBankFeedAccount(...a),
+// `connectorFor` is the seam `deleteConnector` releases through. Mocking the REGISTRY
+// (not a feature module) is the point of the capability: the generic delete path never
+// learns which feature a connector belongs to.
+const releaseOnDelete = vi.fn(async (..._a: unknown[]) => {})
+const connectorDefinition = vi.fn(
+  (_type: string) => ({ releaseOnDelete }) as unknown as Record<string, unknown>
+)
+vi.mock('./connectors/registry', () => ({
+  connectorFor: (type: string) => connectorDefinition(type),
 }))
 
 import {
@@ -142,8 +144,6 @@ beforeEach(() => {
     .mockResolvedValue(ok({ success: true, deletedFieldIds: ['field_1'] }))
   notifyCustomFieldChanged.mockReset()
   enqueueConnectorTeardown.mockReset()
-  findBankFeedAccountForConnector.mockReset().mockResolvedValue(null)
-  reapBankFeedAccount.mockReset().mockResolvedValue(true)
 })
 
 describe('finalizeConnectorTeardown — delete behavior stray-field sweep', () => {
@@ -365,20 +365,20 @@ describe('deferred app-field sweep', () => {
   })
 })
 
-// plans/bank-connection/08-removing-a-bank-account.md §5.4 door 3 / §7.6.
+// plans/bank-connection/08-removing-a-bank-account.md §5.4 door 3 / §7.6, and
+// plans/bank-connection/09-data-connector-debt.md D1.
 //
 // 🛑 Stripe bills 30c per institution per account holder per month and the ONLY thing
 // that stops it is calling disconnect on the account. `deleteConnector` never did, and
 // the teardown it enqueues removes the row - so the nightly reaper, which sweeps
 // `DataConnector`, could never clean up after this door either.
-describe('deleteConnector releases a Financial Connections account', () => {
-  const FC_ACCOUNT = {
-    connectorId: 'dc_1',
-    organizationId: 'org_1',
-    credentialId: 'cred_1',
-    providerAccountId: 'fca_1',
-  }
-
+//
+// 🛑 These assert the CAPABILITY, not the bank. The first fix called
+// `banking/feed/reaper` by name from here, which pointed the generic connector engine
+// at a feature built on top of it. `releaseOnDelete` is declared on the connector
+// definition and resolved through `connectorFor`, the same way `asyncExport` and
+// `resolveDelete` are - so nothing below mentions a bank.
+describe('deleteConnector releases at the provider', () => {
   /** Records the release and the `deleting` mark in the order production made them. */
   function tracingDb(trace: string[]) {
     const chain: Record<string, unknown> = {
@@ -394,7 +394,9 @@ describe('deleteConnector releases a Financial Connections account', () => {
       limit: vi.fn(() => Promise.resolve([])),
       query: {
         DataConnector: {
-          findFirst: vi.fn().mockResolvedValue({ id: 'dc_1', organizationId: 'org_1' }),
+          findFirst: vi
+            .fn()
+            .mockResolvedValue({ id: 'dc_1', organizationId: 'org_1', type: 'some-connector' }),
         },
         AppInstallation: { findFirst: vi.fn().mockResolvedValue(undefined) },
       },
@@ -402,58 +404,81 @@ describe('deleteConnector releases a Financial Connections account', () => {
     return chain as unknown as Database
   }
 
-  it('releases at Stripe BEFORE the row is marked `deleting`', async () => {
+  beforeEach(() => {
+    releaseOnDelete.mockReset()
+    releaseOnDelete.mockImplementation(async () => {})
+    connectorDefinition.mockReset()
+    connectorDefinition.mockImplementation(
+      () => ({ releaseOnDelete }) as unknown as Record<string, unknown>
+    )
+  })
+
+  it('releases BEFORE the row is marked `deleting`', async () => {
     const trace: string[] = []
-    findBankFeedAccountForConnector.mockResolvedValue(FC_ACCOUNT)
-    reapBankFeedAccount.mockImplementation(async () => {
+    releaseOnDelete.mockImplementation(async () => {
       trace.push('release')
-      return true
     })
 
     await deleteConnector(tracingDb(trace), 'org_1', 'user_1', 'dc_1', 'archive')
 
-    // The ordering IS the fix: once the teardown starts, the `providerAccountId` is on
-    // its way out with the connector row and there is nothing left to disconnect.
+    // The ordering IS the fix: once the teardown starts, the provider handle is on its
+    // way out with the connector row and there is nothing left to disconnect.
     expect(trace).toEqual(['release', 'mark-deleting'])
-    expect(reapBankFeedAccount).toHaveBeenCalledWith(expect.anything(), FC_ACCOUNT)
-    expect(findBankFeedAccountForConnector).toHaveBeenCalledWith(expect.anything(), 'org_1', 'dc_1')
+    expect(releaseOnDelete).toHaveBeenCalledWith({
+      db: expect.anything(),
+      organizationId: 'org_1',
+      connectorId: 'dc_1',
+    })
+  })
+
+  it("resolves the definition by the ROW's type, never by a hardcoded one", async () => {
+    await deleteConnector(tracingDb([]), 'org_1', 'user_1', 'dc_1', 'archive')
+
+    expect(connectorDefinition).toHaveBeenCalledWith('some-connector')
   })
 
   it('releases on the `keep` path too, which returns before any teardown is enqueued', async () => {
     // `keep` short-circuits into `finalizeConnectorTeardown` and is the overwhelmingly
     // common case, so a release placed after that branch would cover almost nobody.
-    findBankFeedAccountForConnector.mockResolvedValue(FC_ACCOUNT)
     const db = buildDb({
-      connectorRow: { id: 'dc_1', organizationId: 'org_1' },
+      connectorRow: { id: 'dc_1', organizationId: 'org_1', type: 'some-connector' },
       strayFields: [],
       dataConnectorRows: [[], []],
     }) as unknown as Database
 
     await deleteConnector(db, 'org_1', 'user_1', 'dc_1', 'keep')
 
-    expect(reapBankFeedAccount).toHaveBeenCalledTimes(1)
+    expect(releaseOnDelete).toHaveBeenCalledTimes(1)
   })
 
-  it('releases nothing for a connector that is not a Financial Connections feed', async () => {
-    // Every other connector type resolves no account, so Stripe is never called. The
-    // type gate itself lives in `findBankFeedAccountForConnector`'s predicate and is
-    // pinned in `banking/feed/__tests__/reaper.test.ts`.
-    findBankFeedAccountForConnector.mockResolvedValue(null)
+  it('does nothing for a connector type that declares no release', async () => {
+    connectorDefinition.mockImplementation(() => ({}) as unknown as Record<string, unknown>)
 
-    await deleteConnector(tracingDb([]), 'org_1', 'user_1', 'dc_1', 'archive')
+    const result = await deleteConnector(tracingDb([]), 'org_1', 'user_1', 'dc_1', 'archive')
 
-    expect(reapBankFeedAccount).not.toHaveBeenCalled()
+    expect(result).toEqual({ success: true })
+    expect(releaseOnDelete).not.toHaveBeenCalled()
   })
 
   it('deletes the connector anyway when the release throws', async () => {
-    findBankFeedAccountForConnector.mockResolvedValue(FC_ACCOUNT)
-    reapBankFeedAccount.mockRejectedValue(new Error('stripe is down'))
+    releaseOnDelete.mockRejectedValue(new Error('provider is down'))
 
-    // The user asked for the connector to go. A leaked 30c is recoverable by a human
+    // The user asked for the connector to go. A leaked charge is recoverable by a human
     // reading an invoice; a connector that cannot be removed is not.
     const result = await deleteConnector(tracingDb([]), 'org_1', 'user_1', 'dc_1', 'archive')
 
     expect(result).toEqual({ success: true })
     expect(enqueueConnectorTeardown).toHaveBeenCalledTimes(1)
+  })
+
+  it('deletes the connector anyway when the TYPE no longer resolves', async () => {
+    // An app uninstalled out from under its connector: `connectorFor` throws NotFound.
+    connectorDefinition.mockImplementation(() => {
+      throw new Error('Unknown data connector type: some-connector')
+    })
+
+    const result = await deleteConnector(tracingDb([]), 'org_1', 'user_1', 'dc_1', 'archive')
+
+    expect(result).toEqual({ success: true })
   })
 })

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -21,9 +21,6 @@ import { getFieldDefinitionId, isAppFieldRef, toResourceFieldId } from '@auxx/ty
 import { generateId } from '@auxx/utils'
 import { and, asc, eq, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
-// The LEAF, not the `banking` barrel - the barrel pulls the whole banking read/write
-// surface (and the org cache behind it) in for two functions.
-import { findBankFeedAccountForConnector, reapBankFeedAccount } from '../banking/feed/reaper'
 import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
 import { onCacheEvent } from '../cache/invalidate'
 import type { ConditionGroup } from '../conditions/types'
@@ -44,6 +41,7 @@ import {
   storedRootPath,
 } from './catalog-shape'
 import { readCellSyncState } from './cell-sync-read'
+import { connectorFor } from './connectors/registry'
 import { enqueueConnectorTeardown } from './data-connector-queue'
 import { removeConnectorScheduler, syncConnectorScheduler } from './data-connector-scheduler'
 import {
@@ -1154,47 +1152,36 @@ export async function reconnectConnectorsForInstallation(
 export type DeleteSyncedDataBehavior = 'keep' | 'archive' | 'delete'
 
 /**
- * Release a Stripe Financial Connections account before its connector is torn down.
+ * Give the connector a chance to release a provider-side resource that would
+ * outlive its row.
  *
- * 🛑 Stripe bills 30c per institution per account holder per month and the ONLY thing
- * that stops it is calling disconnect on the account. Deleting the connector row does
- * not, and once the teardown has run the `providerAccountId` is gone with it - so the
- * nightly reaper (`banking/feed/reaper.ts`) can never clean up after this door. That is
- * why the call goes here, ahead of the `deleting` mark and ahead of the `keep`
- * short-circuit, rather than anywhere in the teardown chain.
+ * 🛑 **The generic layer must not name the feature.** An earlier version of this
+ * called into `banking/feed/reaper` directly, which put a backwards edge from the
+ * connector engine into a feature built on top of it and made the pair a cycle.
+ * The engine already had the right shape for this: `releaseOnDelete` is a declared
+ * capability on {@link DataConnectorDefinition}, resolved through `connectorFor`
+ * the same way `asyncExport` and `resolveDelete` are (decision B13).
  *
- * No-op for every connector type but Financial Connections.
- *
- * ⚠️ Never throws. A release that fails must not block the delete: the user asked for
- * the connector to go, a leaked 30c is recoverable by a human reading an invoice, and a
- * connector that cannot be removed is not. The nightly sweep is not a fallback here
- * (the row is on its way out), so the log line is the only trace - which is exactly why
- * it is logged at error.
+ * ⚠️ Never throws, on two counts: resolving the definition can throw for a type
+ * that is no longer registered (an app uninstalled out from under its connector),
+ * and the capability itself is contractually best-effort. A connector the user
+ * asked to remove must still go.
  */
-async function releaseBankFeedAccount(
+async function releaseAtProvider(
   db: Database,
   organizationId: string,
-  connectorId: string
+  connectorId: string,
+  type: string
 ): Promise<void> {
   try {
-    const account = await findBankFeedAccountForConnector(db, organizationId, connectorId)
-    if (!account) return
-    const released = await reapBankFeedAccount(db, account)
-    if (released) {
-      logger.info('Released a Financial Connections account before connector delete', {
-        organizationId,
-        connectorId,
-      })
-    } else {
-      logger.warn('Stripe would not release a Financial Connections account - deleting anyway', {
-        organizationId,
-        connectorId,
-      })
-    }
+    const definition = connectorFor(type)
+    if (!definition.releaseOnDelete) return
+    await definition.releaseOnDelete({ db, organizationId, connectorId })
   } catch (error) {
-    logger.error('Failed to release a Financial Connections account - deleting anyway', {
+    logger.error('Provider-side release failed before connector delete - deleting anyway', {
       organizationId,
       connectorId,
+      type,
       error: error instanceof Error ? error.message : String(error),
     })
   }
@@ -1229,9 +1216,12 @@ export async function deleteConnector(
   id: string,
   behavior: DeleteSyncedDataBehavior = 'keep'
 ): Promise<{ success: boolean }> {
-  // Existence guard (throws NotFound if missing) — no longer need the row itself.
-  await loadConnectorRow(db, organizationId, id)
-  await releaseBankFeedAccount(db, organizationId, id)
+  // Existence guard (throws NotFound if missing). The row's `type` is what routes
+  // the provider-side release below.
+  const row = await loadConnectorRow(db, organizationId, id)
+  // 🛑 Before the scheduler removal AND before the `keep` short-circuit, not merely
+  // before the `deleting` mark: `keep` is the default and returns earlier than that.
+  await releaseAtProvider(db, organizationId, id, row.type)
   await removeConnectorScheduler(id)
 
   if (behavior === 'keep') {

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -13,6 +13,7 @@ import type {
   CatalogConnectorMapping,
   CatalogConnectorOwnedMappingField,
   CatalogConnectorStream,
+  Database,
 } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import type { ResourceFieldId } from '@auxx/types/field'
@@ -475,6 +476,32 @@ export interface DataConnectorDefinition {
   asyncExport?: AsyncExportCapability
   /** Map a provider delete event onto a (streamKey, externalId). */
   resolveDelete?(event: unknown): { streamKey: string; externalId: string } | null
+  /**
+   * Release a provider-side resource that would OUTLIVE the connector row.
+   *
+   * 🛑 For a provider that keeps billing after we forget the connection. Stripe
+   * Financial Connections charges per linked account per month and the only thing
+   * that stops it is disconnecting the account at the provider - so a connector
+   * deleted without this call leaks money forever, and the row that carried the
+   * provider handle is gone, so nothing can find it afterwards to clean up.
+   *
+   * Called by `deleteConnector` BEFORE the teardown begins, and by the
+   * organization-delete path before its transaction. Declared here rather than
+   * called by name from the delete path so the generic layer never learns which
+   * feature a connector belongs to (decision B13).
+   *
+   * ⚠️ **Must not throw.** The caller treats a failure as non-fatal: the user asked
+   * for the connector to go, and a leaked charge is recoverable by a human reading
+   * an invoice while a connector that cannot be removed is not. Log and return.
+   */
+  releaseOnDelete?(ctx: ConnectorReleaseContext): Promise<void>
+}
+
+/** What {@link DataConnectorDefinition.releaseOnDelete} is given. */
+export interface ConnectorReleaseContext {
+  db: Database
+  organizationId: string
+  connectorId: string
 }
 
 // ── Policy types — identity / merge / link (02) ───────────────────────────────


### PR DESCRIPTION
Follow-up to #2069. Pays off D1 and D2 from the connector-layer audit. **No behaviour change** - the same release still runs, there is no migration and nothing is user-visible.

## D1: the generic engine was importing a feature

#2069 fixed a real billing leak by calling `banking/feed/reaper` **by name** from `deleteConnector`. That pointed the generic connector engine at a feature built on top of it. `banking -> data-connectors` is correct and appears eleven times; that was the only edge going the other way, and it made the pair a cycle. Not a package-tier violation - both are in `@auxx/lib` - which is exactly why nothing caught it.

The engine already had the right shape sitting beside it. `DataConnectorDefinition` declares optional capabilities that `connectorFor` resolves without ever branching on provider (`asyncExport`, `resolveDelete`). This adds a third:

```ts
/** Release a provider-side resource that would OUTLIVE the connector row. */
releaseOnDelete?(ctx: ConnectorReleaseContext): Promise<void>
```

The FC connector implements it; `deleteConnector` dispatches on `connectorFor(row.type)`. The only mention of `banking` left in the generic path is a comment explaining why it must not be there.

**The tests are the real change.** `mutations.test.ts` now mocks the **registry** instead of a feature module, which makes it a test of the capability rather than of the coupling - reintroducing a direct call fails it. Two cases added: the definition is resolved by the *row's* type, and a type that no longer resolves (an app uninstalled out from under its connector) still deletes.

## D2: four readers of an untyped key, two of them silent

Worse than the audit first recorded, and **not banking's key**: `providerAccountId` is a field of the generic `HostedProvisionCompleteResult` contract. `Credential.metadata` is `Record<string, unknown>`, so nothing type-checks any reader against the writer.

| Reader | If the key drifts |
|---|---|
| `stripe-financial-connections.ts` | throws "reconnect the bank" at a user whose bank is fine |
| `banking/feed/actions.ts` | disconnect silently skips the Stripe release |
| `banking/feed/reaper.ts` (×2, SQL) | **`isNotNull` drops every candidate - a healthy-looking sweep releasing nothing while all accounts keep billing** |
| `banking/feed/webhook.ts` (SQL) | **inbound webhooks resolve to no connector and no-op - the #2059 failure again** |

`PROVIDER_ACCOUNT_ID_METADATA_KEY` and a `readProviderAccountId` accessor now live beside the contract in `connections/hosted-provision/types.ts`. No literal `'providerAccountId'` survives outside that module.

## An ESM cycle this created, and how it was broken

Making the connector implement the capability meant it imported the reaper, while the reaper imported the connector for `STRIPE_FC_CONNECTOR_TYPE`. A genuine cycle. Both sides only use the other inside function bodies so it would *probably* have worked - which is the kind of "probably" that fails later under a different evaluation order, and the failure mode here is the silent one again. The constant moved to a leaf (`stripe-financial-connections-type.ts`) and is re-exported, so no existing import changed.

## Two limits worth knowing

1. **The backwards edge is moved, not deleted.** `stripe-financial-connections.ts` still imports `banking/feed/reaper`. That module already imported `banking/feed/match-key`, `money/payments/connect-client` and `postings/periods` before any of this - but it is still `data-connectors -> banking`. What changed is that the *generic* path no longer has one. Paying it off fully means moving the FC client primitives out of `banking/feed/`, which is bigger than this.
2. **D3, D4 and D5 remain open** (the transitional `Credential.type` coupling, the bespoke FC webhook route, and `bank_deposit_bank_account` holding a code rather than a relationship).

## Verification

```
lib: no new type errors (27 total, baseline 27)
web: no new type errors (0 total, baseline 0)
vitest run (full lib suite)
  Test Files  1231 passed | 4 skipped (1235)
```

https://claude.ai/code/session_012yq1UCB3pd9GJ85pNnzJLH
