### PR TITLE
fix(banking): sweep every line on archive, and drop archived accounts from the review queue

### DIFF
--- a/packages/lib/src/banking/__tests__/removal-writes.test.ts
+++ b/packages/lib/src/banking/__tests__/removal-writes.test.ts
@@ -33,6 +33,9 @@ const h = vi.hoisted(() => ({
   deleteCredential: vi.fn(),
   crudUpdate: vi.fn(),
   crudDelete: vi.fn(),
+  /** One call for the whole set - a per-row loop is the defect these pin. */
+  crudBulkUpdate: vi.fn(),
+  crudBulkDelete: vi.fn(),
   crudArchive: vi.fn(),
   crudRestore: vi.fn(),
   /** `bank_transaction` rows `listForReview` answers, keyed by the state asked for. */
@@ -62,6 +65,8 @@ vi.mock('../../resources/crud/unified-handler', () => ({
     delete = h.crudDelete
     archive = h.crudArchive
     restore = h.crudRestore
+    bulkUpdate = h.crudBulkUpdate
+    bulkDelete = h.crudBulkDelete
   },
 }))
 vi.mock('../review/reads', () => ({
@@ -75,6 +80,7 @@ vi.mock('../review/reads', () => ({
     isOk: () => true,
     value: h.linesByState.get(filters.state ?? 'for_review') ?? [],
   }),
+  loadReviewFieldContextWithSuggestions: async () => null,
 }))
 vi.mock('../reads', () => ({
   requireBankAccountFieldContext: async () => ({ bankAccountDefId: 'def_ba', fields: {} }),
@@ -92,6 +98,16 @@ vi.mock('../reads', () => ({
     isErr: () => false,
     isOk: () => true,
     value: { bankTransactionDefId: 'def_bt', ids: h.cascadeLineIds },
+  }),
+  // Uncapped and status-filtered, which is what replaced the capped
+  // `listForReview` paging the sweep used to do.
+  readAccountLinesByStatus: async (_db: unknown, p: { statuses: readonly string[] }) => ({
+    isErr: () => false,
+    isOk: () => true,
+    value: {
+      bankTransactionDefId: 'def_bt',
+      lines: p.statuses.flatMap((state) => h.linesByState.get(state) ?? []),
+    },
   }),
 }))
 
@@ -197,6 +213,18 @@ beforeEach(() => {
   h.crudUpdate.mockImplementation(async (recordId: string) => {
     h.trace.push(`crud-update ${recordId}`)
   })
+  // 🛑 ONE trace entry for the whole set. If a future change goes back to a
+  // per-row loop, the ordering assertions below stop matching.
+  h.crudBulkUpdate.mockImplementation(
+    async (updates: Array<{ recordId: string; values: Record<string, unknown> }>) => {
+      h.trace.push(`crud-bulk-update ${updates.length}`)
+      return { updated: updates.length, errors: [] }
+    }
+  )
+  h.crudBulkDelete.mockImplementation(async (recordIds: string[]) => {
+    h.trace.push(`crud-bulk-delete ${recordIds.length}`)
+    return { count: recordIds.length, errors: [] }
+  })
 })
 
 describe('deleteBankAccount', () => {
@@ -248,12 +276,11 @@ describe('deleteBankAccount', () => {
 
     expect(result.isOk()).toBe(true)
     if (result.isOk()) expect(result.value.transactionsDeleted).toBe(3)
-    expect(h.trace).toEqual([
-      'crud-delete def_bt:txn_1',
-      'crud-delete def_bt:txn_2',
-      'crud-delete def_bt:txn_3',
-      `crud-delete def_ba:${ACCOUNT}`,
-    ])
+    // 🛑 ONE bulk call for the lines, then the account. A per-row loop opened a
+    // write session, an `assertEditRows` and a cache warm for EVERY line, which
+    // on a wrongly-connected account is thousands inside one request.
+    expect(h.trace).toEqual(['crud-bulk-delete 3', `crud-delete def_ba:${ACCOUNT}`])
+    expect(h.crudBulkDelete).toHaveBeenCalledWith(['def_bt:txn_1', 'def_bt:txn_2', 'def_bt:txn_3'])
   })
 
   it('refuses once anything has posted, and names the archive', async () => {
@@ -343,11 +370,16 @@ describe('archiveBankAccount', () => {
     expect(result.isOk()).toBe(true)
     if (result.isOk()) expect(result.value.excluded).toBe(3)
 
-    const touched = h.crudUpdate.mock.calls.map((call) => call[0])
-    expect(touched).toEqual(['def_bt:txn_a', 'def_bt:txn_b', 'def_bt:txn_c'])
-    for (const call of h.crudUpdate.mock.calls) {
-      expect(call[1]).toMatchObject({ bank_transaction_review_status: 'excluded' })
-      expect(String((call[1] as Record<string, unknown>).bank_transaction_exclude_reason)).toMatch(
+    // One call carrying every line, not one call per line.
+    expect(h.crudBulkUpdate).toHaveBeenCalledTimes(1)
+    const updates = h.crudBulkUpdate.mock.calls[0]?.[0] as Array<{
+      recordId: string
+      values: Record<string, unknown>
+    }>
+    expect(updates.map((u) => u.recordId)).toEqual(['def_bt:txn_a', 'def_bt:txn_b', 'def_bt:txn_c'])
+    for (const update of updates) {
+      expect(update.values).toMatchObject({ bank_transaction_review_status: 'excluded' })
+      expect(String(update.values.bank_transaction_exclude_reason)).toMatch(
         /^Excluded when the bank account was archived/
       )
     }
@@ -434,9 +466,13 @@ describe('restoreBankAccount', () => {
     // clean up - so a restore that left them excluded would make archive one-way
     // in practice. But a row a PERSON excluded carries their decision and the
     // reason they had to give for it, and survives untouched.
-    const touched = h.crudUpdate.mock.calls.map((call) => call[0])
-    expect(touched).toEqual(['def_bt:txn_swept'])
-    expect(h.crudUpdate.mock.calls[0]?.[1]).toMatchObject({
+    expect(h.crudBulkUpdate).toHaveBeenCalledTimes(1)
+    const updates = h.crudBulkUpdate.mock.calls[0]?.[0] as Array<{
+      recordId: string
+      values: Record<string, unknown>
+    }>
+    expect(updates.map((u) => u.recordId)).toEqual(['def_bt:txn_swept'])
+    expect(updates[0]?.values).toMatchObject({
       bank_transaction_review_status: 'for_review',
       bank_transaction_exclude_reason: null,
     })
@@ -453,7 +489,7 @@ describe('restoreBankAccount', () => {
     })
 
     expect(result.isOk()).toBe(true)
-    expect(h.crudUpdate).not.toHaveBeenCalled()
+    expect(h.crudBulkUpdate).not.toHaveBeenCalled()
   })
 
   it('refuses an account that is not archived', async () => {

--- a/packages/lib/src/banking/reads.ts
+++ b/packages/lib/src/banking/reads.ts
@@ -63,6 +63,9 @@ const BANK_TRANSACTION_ATTRIBUTES = [
   'bank_transaction_bank_account',
   'bank_transaction_posted_at',
   'bank_transaction_review_status',
+  // Read by `readAccountLinesByStatus` so a restore can tell the ARCHIVE's own
+  // exclusions from a person's without a second query per row.
+  'bank_transaction_exclude_reason',
 ] as const
 
 type BankAccountAttribute = (typeof BANK_ACCOUNT_ATTRIBUTES)[number]
@@ -400,6 +403,103 @@ export async function readBankTransactionIdsForAccount(
       }
     },
     'Failed to read the bank transactions on an account',
+    { organizationId, bankAccountId }
+  )
+}
+
+/**
+ * Every live line on one account whose review status is one of `statuses`, with
+ * the exclusion reason attached.
+ *
+ * 🛑 **Uncapped, deliberately.** `listForReview` clamps at `MAX_LIMIT` (500),
+ * which is right for a queue a person is reading and wrong for a sweep that has
+ * to touch every row or leave debris behind. An archive that swept 500 of 2,390
+ * rows left the rest in the queue under an account the user could no longer see
+ * or select (plans/bank-connection/08-removing-a-bank-account.md §6.1).
+ *
+ * 🛑 **A line with NO status row counts as `for_review`**, the same default
+ * `resolveReviewStatus` applies everywhere else. Filtering on an inner join
+ * against the status field would silently skip exactly the rows an archive
+ * sweep exists to catch.
+ *
+ * Three queries, whatever the row count: the account link, the statuses, the
+ * reasons. Nothing here is per-row.
+ */
+export async function readAccountLinesByStatus(
+  db: Database,
+  params: { organizationId: string; bankAccountId: string; statuses: readonly string[] }
+): Promise<
+  Result<
+    { bankTransactionDefId: string; lines: { id: string; excludeReason: string | null }[] },
+    Error
+  >
+> {
+  const { organizationId, bankAccountId, statuses } = params
+  return guard(
+    async () => {
+      const ctx = await loadBankTransactionFieldContext(organizationId)
+      const linkField = ctx?.fields.bank_transaction_bank_account
+      if (!ctx || !linkField) return { bankTransactionDefId: '', lines: [] }
+
+      // Joined to the instance so an ARCHIVED line - a reversed import, a
+      // duplicate the feed converged away - is left alone.
+      const linked = await db
+        .select({ entityId: schema.FieldValue.entityId })
+        .from(schema.FieldValue)
+        .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            eq(schema.FieldValue.fieldId, linkField.id),
+            eq(schema.FieldValue.relatedEntityId, bankAccountId),
+            isNull(schema.EntityInstance.archivedAt)
+          )
+        )
+
+      const ids = [...new Set(linked.map((row) => row.entityId))]
+      if (ids.length === 0) return { bankTransactionDefId: ctx.bankTransactionDefId, lines: [] }
+
+      const statusField = ctx.fields.bank_transaction_review_status
+      const byStatus = new Map<string, string | null>()
+      if (statusField) {
+        const rows = await db
+          .select({ entityId: schema.FieldValue.entityId, optionId: schema.FieldValue.optionId })
+          .from(schema.FieldValue)
+          .where(
+            and(
+              eq(schema.FieldValue.organizationId, organizationId),
+              eq(schema.FieldValue.fieldId, statusField.id),
+              inArray(schema.FieldValue.entityId, ids)
+            )
+          )
+        for (const row of rows) byStatus.set(row.entityId, row.optionId)
+      }
+
+      const wanted = ids.filter((id) => statuses.includes(byStatus.get(id) ?? 'for_review'))
+      if (wanted.length === 0) return { bankTransactionDefId: ctx.bankTransactionDefId, lines: [] }
+
+      const reasonField = ctx.fields.bank_transaction_exclude_reason
+      const byReason = new Map<string, string | null>()
+      if (reasonField) {
+        const rows = await db
+          .select({ entityId: schema.FieldValue.entityId, valueText: schema.FieldValue.valueText })
+          .from(schema.FieldValue)
+          .where(
+            and(
+              eq(schema.FieldValue.organizationId, organizationId),
+              eq(schema.FieldValue.fieldId, reasonField.id),
+              inArray(schema.FieldValue.entityId, wanted)
+            )
+          )
+        for (const row of rows) byReason.set(row.entityId, row.valueText)
+      }
+
+      return {
+        bankTransactionDefId: ctx.bankTransactionDefId,
+        lines: wanted.map((id) => ({ id, excludeReason: byReason.get(id) ?? null })),
+      }
+    },
+    'Failed to read the bank transactions on an account by status',
     { organizationId, bankAccountId }
   )
 }

--- a/packages/lib/src/banking/review/__tests__/reads-archived-account.test.ts
+++ b/packages/lib/src/banking/review/__tests__/reads-archived-account.test.ts
@@ -1,0 +1,85 @@
+// packages/lib/src/banking/review/__tests__/reads-archived-account.test.ts
+//
+// plans/bank-connection/08-removing-a-bank-account.md §6.1.
+//
+// 🛑 `listForReview` filtered `archivedAt IS NULL` on the bank_transaction row
+// and never looked at the ACCOUNT. So archiving an account hid it from settings
+// and from every picker while its lines kept appearing in the queue - under an
+// account the reader could no longer see, select or filter by, and therefore
+// could not act on. The archive's exclusion sweep hid the symptom for small
+// accounts and missed it entirely above its old 500-row cap.
+//
+// The account join is therefore UNCONDITIONAL now: it used to be made only when
+// filtering by account, because filtering was the only thing it was for. These
+// pin that it happens even when no account filter is passed, which is the shape
+// the regression had.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Every join the builder was asked to make, in order. */
+  joins: [] as string[],
+}))
+
+vi.mock('../../../cache', () => ({
+  getCachedEntityDefId: async () => 'def_bt',
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attributes: string[]) =>
+        Object.fromEntries(attributes.map((attribute) => [attribute, { id: `f:${attribute}` }])),
+    }),
+  }),
+}))
+vi.mock('../../reads', () => ({
+  listBankAccounts: async () => ({ isOk: () => true, value: [] }),
+  readCoverage: async () => ({ isOk: () => true, isErr: () => false, value: {} }),
+}))
+
+const { listForReview } = await import('../reads')
+
+/** Chainable, thenable, and records which joins were asked for. */
+function chain(): Record<string, unknown> {
+  const answer = () => Object.assign(Promise.resolve([]), chain())
+  return {
+    from: answer,
+    innerJoin: () => {
+      h.joins.push('inner')
+      return Object.assign(Promise.resolve([]), chain())
+    },
+    leftJoin: () => {
+      h.joins.push('left')
+      return Object.assign(Promise.resolve([]), chain())
+    },
+    where: answer,
+    orderBy: answer,
+    limit: answer,
+    offset: answer,
+    groupBy: answer,
+    $dynamic: answer,
+  }
+}
+
+const db = { select: () => chain() } as never
+
+beforeEach(() => {
+  h.joins.length = 0
+})
+
+describe('listForReview joins the bank account so an archived one drops out', () => {
+  it('joins the account even when NOT filtering by account', async () => {
+    await listForReview(db, { organizationId: 'org_1' })
+
+    // Two of them: the account's FieldValue, then the account's EntityInstance,
+    // which is the row carrying `archivedAt`.
+    expect(h.joins.filter((join) => join === 'left').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('joins the account when filtering by one, and does it with a LEFT join', async () => {
+    await listForReview(db, { organizationId: 'org_1', bankAccountId: 'acct_1' })
+
+    // ⚠️ LEFT, not INNER, and the difference is load-bearing. A line whose
+    // account link is missing entirely is an orphan, not an archived account's
+    // row; an inner join would swallow it and it would never be reviewable.
+    expect(h.joins.filter((join) => join === 'left').length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/lib/src/banking/review/reads.ts
+++ b/packages/lib/src/banking/review/reads.ts
@@ -233,16 +233,29 @@ export async function listForReview(
         )
       }
 
+      // 🛑 The account join is ALWAYS made, not only when filtering by account,
+      // because it carries a second condition: the account must not be ARCHIVED.
+      //
+      // The `archivedAt IS NULL` above is on the bank_transaction row. Without
+      // this one, archiving an ACCOUNT hid it from settings and every picker
+      // while its lines kept appearing here - under an account the reader could
+      // no longer see, select or filter by, and so could not act on
+      // (plans/bank-connection/08-removing-a-bank-account.md §6.1).
+      //
+      // ⚠️ A LEFT join, and the null check is deliberate. A line whose account
+      // link is missing entirely is an orphan, not an archived account's row, and
+      // it still belongs in the queue - an inner join would silently swallow it.
       const accountField = ctx.fields.bank_transaction_bank_account
-      if (filters.bankAccountId && accountField) {
+      if (accountField) {
         const accountValue = alias(schema.FieldValue, 'bt_account_v')
-        query = query.innerJoin(
-          accountValue,
-          and(
-            valueJoin(accountValue, accountField.id),
-            eq(accountValue.relatedEntityId, filters.bankAccountId)
-          )
-        )
+        const accountInstance = alias(schema.EntityInstance, 'bt_account_i')
+        query = query
+          .leftJoin(accountValue, valueJoin(accountValue, accountField.id))
+          .leftJoin(accountInstance, eq(accountInstance.id, accountValue.relatedEntityId))
+        where.push(isNull(accountInstance.archivedAt))
+        if (filters.bankAccountId) {
+          where.push(eq(accountValue.relatedEntityId, filters.bankAccountId))
+        }
       }
 
       const dateField = ctx.fields.bank_transaction_posted_at

--- a/packages/lib/src/banking/writes.ts
+++ b/packages/lib/src/banking/writes.ts
@@ -83,11 +83,12 @@ import { findBankFeedAccountForConnector, reapBankFeedAccount } from './feed/rea
 import { guard } from './guard'
 import {
   getBankAccount,
+  readAccountLinesByStatus,
   readBankTransactionIdsForAccount,
   readRemovalFacts,
   requireBankAccountFieldContext,
 } from './reads'
-import { listForReview, requireReviewFieldContext } from './review/reads'
+import { requireReviewFieldContext } from './review/reads'
 
 const logger = createScopedLogger('banking')
 
@@ -357,22 +358,6 @@ export function resolveRemoval(facts: BankAccountRemovalFacts): BankAccountRemov
   }
 }
 
-/**
- * The ceiling on one archive's exclusion sweep.
- *
- * `listForReview` caps at 500 per call anyway, and an account somebody is
- * archiving with more than 500 lines still waiting for review is a queue nobody
- * was ever going to clear by hand. A hard cap is better than a paging loop that
- * could write for minutes inside one request; the rest keep their status and can
- * be excluded from the queue.
- *
- * ⚠️ The DELETE cascade has no such cap and does not use this: it reads the
- * account's lines directly (`readBankTransactionIdsForAccount`) so that archived
- * rows go too, and a partial delete would leave exactly the orphans it exists to
- * avoid.
- */
-const MAX_CASCADE_ROWS = 500
-
 /** What `deleteBankAccount` accepts. */
 export interface DeleteBankAccountInput {
   organizationId: string
@@ -509,8 +494,22 @@ export async function deleteBankAccount(
       const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
       const lines = await readBankTransactionIdsForAccount(db, { organizationId, bankAccountId })
       if (lines.isErr()) throw lines.error
-      for (const lineId of lines.value.ids) {
-        await crud.delete(toRecordId(lines.value.bankTransactionDefId, lineId))
+      // 🛑 `bulkDelete`, not a loop. Every single-record method wraps itself in
+      // `inWriteSession` and runs its own `assertEditRows` + cache warm, so a
+      // per-row loop over a wrongly-connected account's 2,390 lines opened 2,390
+      // write sessions inside one request. The bulk call does all three once.
+      if (lines.value.ids.length > 0) {
+        const result = await crud.bulkDelete(
+          lines.value.ids.map((id) => toRecordId(lines.value.bankTransactionDefId, id))
+        )
+        if (result.errors.length > 0) {
+          // Refusing loudly beats deleting the account over the top of lines that
+          // would not go: the leftovers would point at an `EntityInstance` that no
+          // longer exists, with no foreign key to find them by.
+          throw new ConflictError(
+            `${result.errors.length} of ${lines.value.ids.length} bank transactions could not be deleted, so the account was kept. First: ${result.errors[0]?.message ?? 'unknown'}`
+          )
+        }
       }
 
       // 4. The account. Its `RecordIdentity` rows cascade off `EntityInstance`.
@@ -636,9 +635,16 @@ export async function archiveBankAccount(
  * Sweep `for_review` and `suggested` to `excluded`, and touch nothing else.
  *
  * ⚠️ **`matched`, `coded` and human-`excluded` rows are left alone**, and the
- * narrowing is done by asking `listForReview` for exactly those two states rather
- * than by filtering afterwards. They are already in the books, or they carry a
- * decision somebody made and the reason they were required to give for it.
+ * narrowing is done in the query rather than by filtering afterwards. They are
+ * already in the books, or they carry a decision somebody made and the reason
+ * they were required to give for it.
+ *
+ * 🛑 **Uncapped, and one write.** This used to page `listForReview` (which clamps
+ * at 500) and then `crud.update` per row, so an archive swept at most 1,000 of
+ * however many the account had and opened a write session for each. The rest
+ * stayed in the For Review queue under an account nobody could see any more
+ * (plans/bank-connection/08-removing-a-bank-account.md §6.1). The cap existed to
+ * bound a per-row loop; with `bulkUpdate` there is nothing to bound.
  *
  * The reason is prefixed so a later path can tell an archive's own bookkeeping
  * from a person's - the same job `IMPORT_LINK_EXCLUSION_PREFIX` does for the
@@ -656,30 +662,37 @@ async function excludeUnreviewedLines(
   const { organizationId, actorUserId, bankAccountId, accountLabel } = params
   const ctx = await requireReviewFieldContext(organizationId)
 
-  const pending = await Promise.all(
-    (['for_review', 'suggested'] as const).map((state) =>
-      listForReview(db, { organizationId, bankAccountId, state, limit: MAX_CASCADE_ROWS })
-    )
-  )
+  const pending = await readAccountLinesByStatus(db, {
+    organizationId,
+    bankAccountId,
+    statuses: ['for_review', 'suggested'],
+  })
+  if (pending.isErr()) throw pending.error
+  if (pending.value.lines.length === 0) return 0
 
   const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
   const reason = `${ARCHIVE_EXCLUSION_PREFIX}: ${accountLabel}`
   const reviewedAt = new Date().toISOString()
 
-  let excluded = 0
-  for (const batch of pending) {
-    if (batch.isErr()) throw batch.error
-    for (const line of batch.value) {
-      await crud.update(toRecordId(ctx.bankTransactionDefId, line.id), {
+  const result = await crud.bulkUpdate(
+    pending.value.lines.map((line) => ({
+      recordId: toRecordId(ctx.bankTransactionDefId, line.id),
+      values: {
         bank_transaction_review_status: 'excluded',
         bank_transaction_exclude_reason: reason,
         bank_transaction_reviewed_at: reviewedAt,
         bank_transaction_reviewed_by_user_id: actorUserId,
-      })
-      excluded += 1
-    }
+      },
+    }))
+  )
+  if (result.errors.length > 0) {
+    logger.warn('Some lines could not be excluded while archiving a bank account', {
+      organizationId,
+      bankAccountId,
+      failed: result.errors.length,
+    })
   }
-  return excluded
+  return result.updated
 }
 
 /**
@@ -697,27 +710,29 @@ async function reopenArchiveExclusions(
   const { organizationId, actorUserId, bankAccountId } = params
   const ctx = await requireReviewFieldContext(organizationId)
 
-  const excluded = await listForReview(db, {
+  const excluded = await readAccountLinesByStatus(db, {
     organizationId,
     bankAccountId,
-    state: 'excluded',
-    limit: MAX_CASCADE_ROWS,
+    statuses: ['excluded'],
   })
   if (excluded.isErr()) throw excluded.error
 
+  const mine = excluded.value.lines.filter((line) => isArchiveExclusion(line.excludeReason))
+  if (mine.length === 0) return 0
+
   const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
-  let reopened = 0
-  for (const line of excluded.value) {
-    if (!isArchiveExclusion(line.excludeReason)) continue
-    await crud.update(toRecordId(ctx.bankTransactionDefId, line.id), {
-      bank_transaction_review_status: 'for_review',
-      bank_transaction_exclude_reason: null,
-      bank_transaction_reviewed_at: null,
-      bank_transaction_reviewed_by_user_id: null,
-    })
-    reopened += 1
-  }
-  return reopened
+  const result = await crud.bulkUpdate(
+    mine.map((line) => ({
+      recordId: toRecordId(ctx.bankTransactionDefId, line.id),
+      values: {
+        bank_transaction_review_status: 'for_review',
+        bank_transaction_exclude_reason: null,
+        bank_transaction_reviewed_at: null,
+        bank_transaction_reviewed_by_user_id: null,
+      },
+    }))
+  )
+  return result.updated
 }
 
 /** What `restoreBankAccount` accepts. */


### PR DESCRIPTION
Closes the last open item from the bank-account removal work (#2069). Plan: `08-removing-a-bank-account.md` §6.1.

## The bug

Archiving a bank account swept **at most 1,000** of its unreviewed lines, while the confirm dialog rendered the **uncapped** count and promised all of them got excluded. The rest stayed in For Review under an account that had just disappeared from settings and from every picker - so nobody could see it, select it, or act on the rows.

On the 2,390-item account this feature exists to clean up, **1,390 rows were stranded** with no way to reach them.

## Two independent causes

**1. The queue never looked at the account.** `listForReview` filtered `archivedAt IS NULL` on the *bank_transaction* row only. It now joins the account unconditionally and requires the same of it.

⚠️ The join is **LEFT**, deliberately. A line whose account link is missing entirely is an orphan, not an archived account's row, and an inner join would swallow it from the queue forever - trading one invisible-rows bug for another.

**2. The cap was a workaround for not using the bulk API.** `excludeUnreviewedLines` looped `crud.update` per row, and every single-record `UnifiedCrudHandler` method wraps itself in `inWriteSession` with its own `assertEditRows` and cache warm - so a thousand rows meant a thousand write sessions in one request. `MAX_CASCADE_ROWS`'s own doc block justified itself by saying a paging loop *"could write for minutes inside one request"*, which was true **of a per-row loop**. The cap bounded the loop by silently truncating the work.

A row-count cap introduced to bound a per-row write loop means the loop is the bug, not that the cap needs raising.

## What changed

| | |
|---|---|
| `readAccountLinesByStatus` (new) | Uncapped, status-filtered, three queries whatever the row count |
| archive sweep | Uncapped read + **one** `bulkUpdate` |
| restore re-open | Same, filtered to the archive's own prefix |
| delete cascade | **One** `bulkDelete` |
| `MAX_CASCADE_ROWS` | Deleted - no loop left to bound |
| `listForReview` | Joins the account, requires `archivedAt IS NULL` on it |

**Why a new reader rather than a bigger limit:** `listForReview` clamps internally at `MAX_LIMIT` (500) whatever you pass, so it could never have served a sweep.

**One subtlety worth reviewing:** the new reader counts a line with **no** status row as `for_review`, the same default as everywhere else. Filtering with an inner join on the status field would have silently skipped exactly the rows a sweep exists to catch.

The delete cascade now **refuses** the account when any line will not go, rather than deleting it over the top of leftovers that would then point at a row that no longer exists.

The dialog needed no change - with the cap gone, `preview.unreviewed` is honest again.

## Tests

Assertions now pin the **bulk payload** (one call carrying the right set), which is stronger than the old per-row list and also fails if a future change reverts to a loop. The new `reads-archived-account.test.ts` was confirmed red against the conditional-join shape before being restored.

```
lib: no new type errors (27 total, baseline 27)
web: no new type errors (0 total, baseline 0)
vitest run src/banking   20 files, 340 tests passed
```

https://claude.ai/code/session_012yq1UCB3pd9GJ85pNnzJLH
