### PR TITLE
fix(banking): selecting an archived bank account 404s, and it has no way back

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
@@ -114,6 +114,19 @@ export interface BankAccountPatch {
   feedStartDate?: string | null
 }
 
+/**
+ * Cancels the scroll container's `p-3` so a `Section` sits FLUSH with the panel.
+ *
+ * `Section` draws its own `p-3` and a full-width `border-b`, which is a divider
+ * meant to run edge to edge. Nested inside a padded container it was inset by
+ * twelve pixels on each side, so the rule stopped short of both edges and the
+ * section read as a floating card rather than a band of the panel.
+ *
+ * `className` lands on the section WRAPPER, so the negative margin takes the
+ * border with it. The inner `p-3` still holds the content off the edge.
+ */
+const SECTION_BLEED = '-mx-3'
+
 interface BankAccountEditorProps {
   account: BankAccountRow | null
   coverage: BankAccountCoverage | null
@@ -450,7 +463,7 @@ function BankAccountForm({
       )}
 
       {account.connector && (
-        <Section title='Runs' initialOpen={false}>
+        <Section title='Runs' initialOpen={false} className={SECTION_BLEED}>
           <ConnectorRunsPanel
             connectorId={account.connector.id}
             initialStatus={asConnectorStatus(account.connector.status)}
@@ -474,7 +487,7 @@ function BankAccountForm({
           has posted can be archived in the first place. Showing them would offer
           two buttons that both fail. */}
       {account.archivedAt ? (
-        <Section title='Archived' initialOpen>
+        <Section title='Archived' initialOpen className={SECTION_BLEED}>
           <div className='flex flex-col gap-2 p-1'>
             <p className='text-muted-foreground text-xs'>
               This account is archived. It is out of the account pickers and its lines are out of
@@ -491,7 +504,7 @@ function BankAccountForm({
           </div>
         </Section>
       ) : (
-        <Section title='Danger zone' initialOpen={false}>
+        <Section title='Danger zone' initialOpen={false} className={SECTION_BLEED}>
           <div className='flex flex-col gap-3 p-1'>
             {isConnected && (
               <div className='flex flex-col gap-2'>

--- a/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
@@ -61,7 +61,7 @@ import { Button } from '@auxx/ui/components/button'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { Section } from '@auxx/ui/components/section'
 import { cn } from '@auxx/ui/lib/utils'
-import { PlugZap, RefreshCw, Trash2, TriangleAlert } from 'lucide-react'
+import { ArchiveRestore, PlugZap, RefreshCw, Trash2, TriangleAlert } from 'lucide-react'
 import Link from 'next/link'
 import { useRef, useState } from 'react'
 import { GlAccountPicker } from '~/components/accounting/ui/gl-account-picker'
@@ -138,6 +138,8 @@ interface BankAccountEditorProps {
    * read and the click that follows it.
    */
   removal: BankAccountRemoval | null
+  /** True while this account's restore is in flight. */
+  restoring?: boolean
   /** True while the remove is in flight. */
   removing?: boolean
   onPatch: (patch: BankAccountPatch) => void
@@ -148,6 +150,8 @@ interface BankAccountEditorProps {
   onDisconnect: () => void
   /** Delete or archive, whichever the server's gate says applies. */
   onRemove: () => void
+  /** Put an archived account back. Replaces the Danger zone while it is archived. */
+  onRestore: () => void
 }
 
 /** What `banking.bankAccount.removalPreview` answers, as this pane reads it. */
@@ -190,11 +194,13 @@ function BankAccountForm({
   syncing = false,
   removal,
   removing = false,
+  restoring = false,
   onPatch,
   onSync,
   onReconnect,
   onDisconnect,
   onRemove,
+  onRestore,
 }: BankAccountEditorProps & { account: BankAccountRow }) {
   const [values, setValues] = useState<TextValues>({
     name: account.name ?? '',
@@ -462,43 +468,71 @@ function BankAccountForm({
           Disconnect stays gated, because the verb genuinely does not apply
           without a connector - `disconnectBankAccountFeed` opens with
           `requireConnectorId` and throws. Remove is always here. */}
-      <Section title='Danger zone' initialOpen={false}>
-        <div className='flex flex-col gap-3 p-1'>
-          {isConnected && (
-            <div className='flex flex-col gap-2'>
-              <p className='text-muted-foreground text-xs'>
-                Disconnecting stops the feed and keeps every transaction, including the ones already
-                coded and posted. A posted bank line is the source document of a journal entry, so
-                nothing is deleted.
-              </p>
-              <div>
-                <Button variant='outline' size='sm' loading={disconnecting} onClick={onDisconnect}>
-                  <PlugZap />
-                  Disconnect
-                </Button>
-              </div>
-            </div>
-          )}
-
-          <div className='flex flex-col gap-2'>
-            <p className='text-muted-foreground text-xs'>{removalBlurb(removal)}</p>
+      {/* 🛑 An ARCHIVED account gets Restore and nothing else. Every action in
+          the Danger zone below refuses on one: `archiveBankAccount` will not
+          archive twice, and a delete cannot apply because only an account that
+          has posted can be archived in the first place. Showing them would offer
+          two buttons that both fail. */}
+      {account.archivedAt ? (
+        <Section title='Archived' initialOpen>
+          <div className='flex flex-col gap-2 p-1'>
+            <p className='text-muted-foreground text-xs'>
+              This account is archived. It is out of the account pickers and its lines are out of
+              the review queue, and nothing about its history changed. Restoring puts it back and
+              re-opens the lines the archive excluded - the ones a person excluded by hand stay
+              excluded. It does not reconnect the feed: that needs signing in at the bank again.
+            </p>
             <div>
-              {/* 🛑 Never says "Delete" for something that will archive. The
-                  label waits for the preview rather than guessing, because the
-                  two words promise opposite things about the history. */}
-              <Button
-                variant='destructive'
-                size='sm'
-                loading={removing}
-                disabled={!removal}
-                onClick={onRemove}>
-                <Trash2 />
-                {removal?.verb === 'archive' ? 'Archive' : 'Delete'}
+              <Button variant='outline' size='sm' loading={restoring} onClick={onRestore}>
+                <ArchiveRestore />
+                Restore
               </Button>
             </div>
           </div>
-        </div>
-      </Section>
+        </Section>
+      ) : (
+        <Section title='Danger zone' initialOpen={false}>
+          <div className='flex flex-col gap-3 p-1'>
+            {isConnected && (
+              <div className='flex flex-col gap-2'>
+                <p className='text-muted-foreground text-xs'>
+                  Disconnecting stops the feed and keeps every transaction, including the ones
+                  already coded and posted. A posted bank line is the source document of a journal
+                  entry, so nothing is deleted.
+                </p>
+                <div>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    loading={disconnecting}
+                    onClick={onDisconnect}>
+                    <PlugZap />
+                    Disconnect
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            <div className='flex flex-col gap-2'>
+              <p className='text-muted-foreground text-xs'>{removalBlurb(removal)}</p>
+              <div>
+                {/* 🛑 Never says "Delete" for something that will archive. The
+                  label waits for the preview rather than guessing, because the
+                  two words promise opposite things about the history. */}
+                <Button
+                  variant='destructive'
+                  size='sm'
+                  loading={removing}
+                  disabled={!removal}
+                  onClick={onRemove}>
+                  <Trash2 />
+                  {removal?.verb === 'archive' ? 'Archive' : 'Delete'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Section>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/accounting/ui/settings/bank-accounts-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-accounts-list.tsx
@@ -22,9 +22,9 @@
 import type { BankAccountRow } from '@auxx/lib/banking/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
-import { Switch } from '@auxx/ui/components/switch'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
@@ -142,26 +142,32 @@ export function BankAccountsList({
       {accounts.length > 0 && (
         <>
           <div className='flex items-center gap-2'>{buttons}</div>
-          <InputSearch
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder='Search accounts...'
-          />
+          {/* The search and the archived toggle share a row, which is safe where
+              the two BUTTONS above were not: `ButtonSwitch` at `xs` is narrow
+              enough that `InputSearch`'s `flex-1` still has room, and the row
+              never wraps - so the wrapper cannot stretch over a second line and
+              swallow the toggle's clicks. */}
+          <div className='flex items-center gap-2'>
+            <InputSearch
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder='Search accounts...'
+            />
+            {/* Offered only when there is something behind it. An always-present
+                toggle over an empty set advertises a state most orgs never
+                reach, and archiving is meant to be the quiet default rather
+                than a mode. */}
+            {archivedCount > 0 && (
+              <ButtonSwitch
+                label={`Show archived (${archivedCount})`}
+                size='xs'
+                checked={showArchived}
+                onCheckedChange={onShowArchivedChange}
+                className='shrink-0'
+              />
+            )}
+          </div>
         </>
-      )}
-
-      {/* Offered only when there is something behind it. An always-present
-          toggle over an empty set advertises a state most orgs never reach, and
-          archiving is meant to be the quiet default rather than a mode. */}
-      {archivedCount > 0 && (
-        <label className='flex cursor-pointer items-center gap-2 px-1 text-muted-foreground text-xs'>
-          <Switch
-            checked={showArchived}
-            onCheckedChange={onShowArchivedChange}
-            aria-label='Show archived accounts'
-          />
-          Show archived ({archivedCount})
-        </label>
       )}
 
       {isLoading ? (

--- a/apps/web/src/components/accounting/ui/settings/bank-accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-accounts-settings-page.tsx
@@ -291,6 +291,8 @@ export function BankAccountsSettingsPage() {
             onReconnect={() => selected && handleReconnect(selected.id)}
             onDisconnect={handleDisconnect}
             onRemove={handleRemove}
+            onRestore={() => selected && restore.mutate({ id: selected.id })}
+            restoring={restore.isPending && restore.variables?.id === selected?.id}
           />
         }
         paneTitle='Bank account'

--- a/packages/lib/src/banking/__tests__/removal-writes.test.ts
+++ b/packages/lib/src/banking/__tests__/removal-writes.test.ts
@@ -413,6 +413,22 @@ describe('archiveBankAccount', () => {
     expect(h.crudDelete).not.toHaveBeenCalled()
   })
 
+  it('refuses an account that is ALREADY archived', async () => {
+    h.account = account({ hasEverPosted: true, archivedAt: new Date('2026-09-08T00:00:00.000Z') })
+
+    const result = await archiveBankAccount(fakeDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      bankAccountId: ACCOUNT,
+    })
+
+    // A sentence, not a 404 on a record the caller is looking at: the settings
+    // list can select an archived account, so this is reachable by clicking.
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.message).toMatch(/already archived/i)
+    expect(h.crudArchive).not.toHaveBeenCalled()
+  })
+
   it('never clears coverage_from', async () => {
     // A balance sheet spanning the archived account's period still has to know
     // what was covered (§5.3).

--- a/packages/lib/src/banking/reads.ts
+++ b/packages/lib/src/banking/reads.ts
@@ -253,7 +253,15 @@ export async function readCoverage(
   const { organizationId, bankAccountId } = params
   return guard(
     async () => {
-      const account = await getBankAccount(db, { organizationId, bankAccountId })
+      // 🛑 `includeArchived`, because the settings list can SELECT an archived
+      // account (that is what the "Show archived" toggle is for) and the editor
+      // asks for its coverage the moment it is selected. Without this the click
+      // answered 404 on a row the same page had just rendered.
+      const account = await getBankAccount(db, {
+        organizationId,
+        bankAccountId,
+        includeArchived: true,
+      })
       if (account.isErr()) throw account.error
       if (!account.value) {
         throw new NotFoundError(`Bank account ${bankAccountId} was not found`)

--- a/packages/lib/src/banking/writes.ts
+++ b/packages/lib/src/banking/writes.ts
@@ -591,10 +591,19 @@ export async function archiveBankAccount(
   return guard(
     async () => {
       const ctx = await requireBankAccountFieldContext(organizationId)
-      const account = await getBankAccount(db, { organizationId, bankAccountId })
+      // Read the archived row too, so archiving one twice refuses with a sentence
+      // that says so rather than a 404 on a record the caller is looking at.
+      const account = await getBankAccount(db, {
+        organizationId,
+        bankAccountId,
+        includeArchived: true,
+      })
       if (account.isErr()) throw account.error
       if (!account.value) {
         throw new NotFoundError(`Bank account ${bankAccountId} was not found`)
+      }
+      if (account.value.archivedAt) {
+        throw new ConflictError('That bank account is already archived.')
       }
 
       let disconnected = false


### PR DESCRIPTION
Reported from the dev server: clicking an archived account in Accounting > Settings > Bank accounts answers

```
tRPC failed on banking.bankAccount.coverage:
  Bank account rc6tos0l9h0x1ydnvl8ep8bc was not found
```

Three faults, all reachable by turning on **Show archived** and clicking a row.

## 1. `readCoverage` 404s on an archived account

It did not pass `includeArchived`, so the editor asked for the coverage of the account the same page had just rendered and got a `NotFoundError`. `readRemovalFacts` and `restoreBankAccount` already passed it - this was the one that did not.

## 2. The editor had no Restore

Restore existed only on the **list row**. So a selected archived account showed a Danger zone whose every action refuses on one: `archiveBankAccount` will not archive twice, and a delete cannot apply because only an account that has posted can be archived in the first place. Two buttons, both guaranteed to fail.

It now renders an **Archived** section with Restore and nothing else, and says what restoring actually does: re-opens the lines the archive excluded, leaves the ones a person excluded by hand, and does **not** reconnect the feed - that needs signing in at the bank again.

## 3. Archiving twice 404'd instead of explaining

`archiveBankAccount` read the account without `includeArchived`, so a second archive answered "not found" about a record the caller was looking at. Now a `ConflictError` that says it is already archived. Test added.

## Also: the requested toggle change

"Show archived" moves next to the search and onto `ButtonSwitch` at `size='xs'`.

⚠️ The two **buttons** above it still need their own row. `InputSearch` wraps its input in a `relative flex flex-1` div, so when that row wraps the wrapper stretches the full width and swallows the buttons' clicks - a bug this file already carries a comment about. A single xs switch beside the search does not wrap, so it is safe there; I kept the existing comment and explained why this case differs rather than deleting it.

## Verification

```
lib: no new type errors (27 total, baseline 27)
web: no new type errors (0 total, baseline 0)
vitest run src/banking   21 files, 343 tests passed
```

Not visually verified in a browser - worth a look at the toggle's alignment beside the search box.

https://claude.ai/code/session_012yq1UCB3pd9GJ85pNnzJLH
