### PR TITLE
feat(banking): give a bank deposit a real link to its bank account

### DIFF
--- a/apps/web/src/components/accounting/ui/banking/deposits/deposits-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/deposits/deposits-page.tsx
@@ -290,7 +290,20 @@ export function DepositsPage() {
     )
   }, [])
 
-  const canRecord = selectedIds.length > 0 && !!bankAccountCode && !!depositDate
+  // `bankAccountId` as well as its code: the mutation sends the id, and the
+  // code is only what proves the account is mapped well enough to post.
+  const canRecord = selectedIds.length > 0 && !!bankAccountId && !!bankAccountCode && !!depositDate
+
+  /** The selection, once {@link canRecord} has proved every part of it is there. */
+  const recordDeposit = () => {
+    if (!bankAccountId) return
+    createDeposit.mutate({
+      paymentIds: selectedIds,
+      depositDate,
+      bankAccountId,
+      reference: reference.trim() || undefined,
+    })
+  }
 
   const { ref: frameRef, height: frameHeight } = useFillViewportHeight()
 
@@ -345,14 +358,7 @@ export function DepositsPage() {
                   recordedId={recordedId}
                   canRecord={canRecord}
                   isRecording={createDeposit.isPending}
-                  onRecord={() =>
-                    createDeposit.mutate({
-                      paymentIds: selectedIds,
-                      depositDate,
-                      bankAccountCode: bankAccountCode ?? '',
-                      reference: reference.trim() || undefined,
-                    })
-                  }
+                  onRecord={recordDeposit}
                 />
               }>
               {/* The column is a full-height flex stack so the selection strip
@@ -474,14 +480,7 @@ export function DepositsPage() {
                       size='sm'
                       className='ml-auto'
                       disabled={!canRecord || createDeposit.isPending}
-                      onClick={() =>
-                        createDeposit.mutate({
-                          paymentIds: selectedIds,
-                          depositDate,
-                          bankAccountCode: bankAccountCode ?? '',
-                          reference: reference.trim() || undefined,
-                        })
-                      }>
+                      onClick={recordDeposit}>
                       Group into deposit
                     </Button>
                   </div>

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -897,7 +897,11 @@ export const moneyRouter = createTRPCRouter({
         z.object({
           paymentIds: z.array(z.string().min(1)).min(1).max(500),
           depositDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-          bankAccountCode: z.string().min(1).max(32),
+          // 🛑 The ACCOUNT, not a chart code. The code is read off the account's
+          // own mapping, because the feed posts every line on it against that
+          // mapping - a free code puts the deposit and the statement line it
+          // exists to match into two different accounts.
+          bankAccountId: z.string().min(1).max(64),
           reference: z.string().max(120).optional(),
         })
       )
@@ -946,7 +950,7 @@ export const moneyRouter = createTRPCRouter({
             .string()
             .regex(/^\d{4}-\d{2}-\d{2}$/)
             .optional(),
-          bankAccountCode: z.string().min(1).max(32).optional(),
+          bankAccountId: z.string().min(1).max(64).optional(),
           reference: z.string().max(120).optional(),
         })
       )

--- a/packages/database/src/db/schema/credential.ts
+++ b/packages/database/src/db/schema/credential.ts
@@ -46,6 +46,11 @@ export const Credential = pgTable(
      * Denormalized providerKey for `connection` rows ('gmail', 'telegram-bot', 'openaiApi').
      * NULL for app/mcp kinds — the owner FK (appId/mcpServerId) identifies the target.
      * Transitional: superseded by the resolved `ConnectionDefinition.providerKey` (Phase 2).
+     *
+     * Phase 2 must sweep the SQL predicates keyed on this column, not just the reads.
+     * `banking/feed/reaper.ts`'s `releasableBankFeedFilter()` is the one that bites:
+     * it only narrows, so a stale match silently releases nothing and every Stripe
+     * Financial Connections account keeps billing.
      */
     type: text(),
 

--- a/packages/lib/scripts/drive-bank-deposit.ts
+++ b/packages/lib/scripts/drive-bank-deposit.ts
@@ -11,6 +11,7 @@
 
 import { closePools, database, schema } from '@auxx/database'
 import { eq } from 'drizzle-orm'
+import { listBankAccounts } from '../src/banking'
 import { buildBankDepositPdfPayload } from '../src/documents/payload'
 import {
   clearBankDeposit,
@@ -39,12 +40,20 @@ async function main() {
   console.log(`RESULT undeposited=${undeposited.value.length} cheques=${cheques.length}`)
   if (cheques.length === 0) throw new Error('no undeposited cheques to group')
 
+  // The deposit is banked into an ACCOUNT now, not a code (migration 135), so
+  // the drive has to pick a mapped one the way the picker does.
+  const accounts = await listBankAccounts(database, { organizationId })
+  if (accounts.isErr()) throw accounts.error
+  const target = accounts.value.find((account) => !!account.glAccountCode?.trim())
+  if (!target) throw new Error('that organization has no bank account mapped to the chart')
+  console.log(`RESULT bankAccount=${target.name} code=${target.glAccountCode}`)
+
   const created = await createBankDeposit(database, {
     organizationId,
     actorUserId,
     paymentIds: cheques.map((c) => c.paymentId),
     depositDate: new Date().toISOString().slice(0, 10),
-    bankAccountCode: '1000',
+    bankAccountId: target.id,
     reference: 'SLIP-DRIVE',
   })
   if (created.isErr()) throw created.error
@@ -58,7 +67,7 @@ async function main() {
     actorUserId,
     paymentIds: cheques.map((c) => c.paymentId),
     depositDate: deposit.depositDate!,
-    bankAccountCode: '1000',
+    bankAccountId: target.id,
   })
   console.log(`RESULT regroup=${regroup.isErr() ? regroup.error.message : 'NOT REFUSED'}`)
 

--- a/packages/lib/scripts/run-migration-135.ts
+++ b/packages/lib/scripts/run-migration-135.ts
@@ -1,0 +1,41 @@
+// packages/lib/scripts/run-migration-135.ts
+//
+// Runs entity migration 135 (`bank_deposit.bankAccount`, the relationship to
+// `bank_account`, and its inverse `bank_account.deposits`) across every org.
+//
+// Exists for the same reason `run-migration-132-133.ts` does: the maintenance
+// job records a migration as applied after its first run and will not repeat it,
+// so a migration authored mid-development needs a door of its own.
+//
+// ⚠️ Deposits whose posted code names more than one bank account are left
+// UNLINKED on purpose and reported in the migration's own warn line. That is the
+// expected outcome, not a failure - see the file's doc block.
+//
+// Idempotent - a second run changes nothing and reports 0 changed.
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/run-migration-135.ts
+
+import { closePools, database, schema } from '@auxx/database'
+import { migration135BankDepositBankAccount } from '../src/seed/entity-migrations/migrations/135-bank-deposit-bank-account'
+
+async function main() {
+  const orgs = await database.select({ id: schema.Organization.id }).from(schema.Organization)
+
+  let changed = 0
+  for (const org of orgs) {
+    const result = await migration135BankDepositBankAccount.up(database, org.id)
+    if (!result.alreadyUpToDate) changed++
+  }
+  console.log(
+    `${migration135BankDepositBankAccount.id}: ran over ${orgs.length} orgs, ${changed} changed`
+  )
+
+  await closePools()
+  process.exit(0)
+}
+
+main().catch(async (error) => {
+  console.error(error)
+  await closePools()
+  process.exit(1)
+})

--- a/packages/lib/src/banking/feed/reaper.ts
+++ b/packages/lib/src/banking/feed/reaper.ts
@@ -153,7 +153,22 @@ const feedAccountColumns = {
   providerAccountId: sql<string>`${schema.Credential.metadata}->>${PROVIDER_ACCOUNT_ID_METADATA_KEY}`,
 }
 
-/** A Financial Connections connector whose credential still carries an account to release. */
+/**
+ * A Financial Connections connector whose credential still carries an account to release.
+ *
+ * Shared by all three SQL doors - the sweep ({@link findReapableBankFeeds}), door 4
+ * ({@link listBankFeedAccountsForOrganization}) and door 3
+ * ({@link findBankFeedAccountForConnector}).
+ *
+ * ⚠️ **`Credential.type` is transitional.** Its schema comment
+ * (`packages/database/src/db/schema/credential.ts`) marks it a denormalized providerKey
+ * that the resolved `ConnectionDefinition.providerKey` supersedes in Phase 2. Whoever
+ * does that migration has to come through here: these three queries key on it, and
+ * because the predicate only ever NARROWS the candidate set, a stale match does not
+ * fail loudly - the sweep reports zero candidates, looks healthy, and every account
+ * keeps billing at 30c a month. Same silent failure the shared
+ * {@link PROVIDER_ACCOUNT_ID_METADATA_KEY} exists to prevent, one column over.
+ */
 function releasableBankFeedFilter() {
   return and(
     eq(schema.DataConnector.type, STRIPE_FC_CONNECTOR_TYPE),

--- a/packages/lib/src/banking/writes.ts
+++ b/packages/lib/src/banking/writes.ts
@@ -335,6 +335,14 @@ function normalizeLast4(value: string | null | undefined): string | null {
  * rule whose `bankAccountId` does not match the line, so a dangling scope makes
  * the rule INERT rather than universal - silently dead, not silently dangerous.
  *
+ * ⚠️ **A `bank_deposit` needs no term of its own.** A posted deposit debits this
+ * account's chart mapping and names this account as where the money went, so
+ * `createBankDeposit` stamps `bank_account_has_posted` the same way a posted
+ * bank line does (`money/bank-deposits/writes.ts`). It reaches the gate through
+ * the one term rather than beside it, which is why §5.1's "ONE term decides"
+ * still holds after entity migration 135 gave the deposit a real relationship to
+ * the account.
+ *
  * Exported and pure so the gate is tested without a database, exactly the way
  * `import/reverse.ts`'s `refusalReason` is.
  */

--- a/packages/lib/src/money/bank-deposits/__tests__/writes.test.ts
+++ b/packages/lib/src/money/bank-deposits/__tests__/writes.test.ts
@@ -35,6 +35,8 @@ const h = vi.hoisted(() => ({
   calls: [] as string[],
   /** The `db` handle `readPaymentsByIds` was called with - the tx one, or the outer one. */
   readWith: [] as unknown[],
+  /** What `readDepositBankAccount` answers. Null stands in for "no such account". */
+  bankAccount: null as Record<string, unknown> | null,
 }))
 
 vi.mock('../../../cache', () => ({
@@ -44,6 +46,10 @@ vi.mock('../../../cache', () => ({
 
 vi.mock('../reads', () => ({
   requireBankDepositFieldContext: async () => ({ depositDefId: 'def_bank_deposit', fields: {} }),
+  requireBankDepositWriteContext: async () => ({
+    depositDefId: 'def_bank_deposit',
+    fields: { bank_deposit_bank_account_record: { id: 'fld_account' } },
+  }),
   requirePaymentFieldContext: async () => ({
     paymentDefId: 'def_payment',
     fields: { payment_bank_deposit: { id: 'fld_link' } },
@@ -56,6 +62,11 @@ vi.mock('../reads', () => ({
   },
   readBankDepositDetail: async () => h.deposit,
   readDepositPayments: async () => [],
+  requireDepositBankAccountContext: async () => ({
+    bankAccountDefId: 'def_bank_account',
+    fields: { bank_account_gl_account: { id: 'fld_gl' } },
+  }),
+  readDepositBankAccount: async () => h.bankAccount,
 }))
 
 vi.mock('../../../resources/crud/unified-handler', () => ({
@@ -149,6 +160,7 @@ function deposit(overrides: Record<string, unknown> = {}) {
     recordId: 'def_bank_deposit:dep_1',
     number: 'DEP-0001',
     depositDate: '2026-09-03',
+    bankAccountId: 'acct_1',
     bankAccountCode: '1000',
     reference: null,
     status: 'pending',
@@ -168,7 +180,22 @@ const input = {
   actorUserId: USER,
   paymentIds: ['pay_1'],
   depositDate: '2026-09-03',
-  bankAccountCode: '1000',
+  bankAccountId: 'acct_1',
+}
+
+/** The account the deposit is banked into, mapped to `1000` unless a test says otherwise. */
+function bankAccount(overrides: Record<string, unknown> = {}) {
+  const id = (overrides.id as string) ?? 'acct_1'
+  return {
+    name: 'Business Checking',
+    glAccountCode: '1000',
+    archivedAt: null,
+    ...overrides,
+    id,
+    // Derived, so overriding `id` cannot leave the record id pointing at the
+    // account the test was moving away from.
+    recordId: `def_bank_account:${id}`,
+  }
 }
 
 beforeEach(() => {
@@ -182,6 +209,7 @@ beforeEach(() => {
   h.postedEntries = []
   h.calls = []
   h.readWith = []
+  h.bankAccount = bankAccount()
 })
 
 describe('createBankDeposit refusals', () => {
@@ -197,8 +225,32 @@ describe('createBankDeposit refusals', () => {
   })
 
   it('refuses a blank bank account', async () => {
-    const result = await createBankDeposit(db, { ...input, bankAccountCode: '  ' })
+    const result = await createBankDeposit(db, { ...input, bankAccountId: '  ' })
     expect(result._unsafeUnwrapErr().message).toMatch(/bank account/i)
+  })
+
+  it('refuses a bank account that is not in this organization', async () => {
+    h.bankAccount = null
+    const result = await createBankDeposit(db, input)
+    expect(result._unsafeUnwrapErr().message).toMatch(/does not exist/i)
+    expect(h.created).toHaveLength(0)
+  })
+
+  it('refuses an archived bank account by name', async () => {
+    h.bankAccount = bankAccount({ archivedAt: new Date('2026-08-01T00:00:00Z') })
+    const result = await createBankDeposit(db, input)
+    expect(result._unsafeUnwrapErr().message).toMatch(/Business Checking is archived/)
+    expect(h.created).toHaveLength(0)
+  })
+
+  // 🛑 The whole reason the input is an id: an unmapped account has no code to
+  // debit, and the alternative to refusing is posting to one nobody named.
+  it('refuses a bank account with no chart mapping, and posts nothing', async () => {
+    h.bankAccount = bankAccount({ glAccountCode: null })
+    const result = await createBankDeposit(db, input)
+    expect(result._unsafeUnwrapErr().message).toMatch(/not mapped to an account in the chart/i)
+    expect(h.created).toHaveLength(0)
+    expect(h.postedEntries).toHaveLength(0)
   })
 
   it('refuses a payment that is already in a deposit, and writes nothing', async () => {
@@ -288,7 +340,8 @@ describe('createBankDeposit posts one cash line', () => {
   })
 
   it('banks into the SECOND bank account when that is the one named', async () => {
-    await createBankDeposit(db, { ...input, bankAccountCode: ' 1020 ' })
+    h.bankAccount = bankAccount({ id: 'acct_2', glAccountCode: '1020' })
+    await createBankDeposit(db, { ...input, bankAccountId: 'acct_2' })
 
     const entry = h.postedEntries[0] as {
       lines: Array<{ accountCode?: string; accountRole?: string; memo?: string }>
@@ -468,15 +521,19 @@ describe('clearBankDeposit', () => {
 
 describe('updateBankDeposit', () => {
   it('edits reference and account while the deposit is still pending', async () => {
+    h.bankAccount = bankAccount({ id: 'acct_2', glAccountCode: '1010' })
     const result = await updateBankDeposit(db, {
       organizationId: ORG,
       actorUserId: USER,
       depositId: 'dep_1',
       reference: ' slip-77 ',
-      bankAccountCode: '1010',
+      bankAccountId: 'acct_2',
     })
     expect(result.isOk()).toBe(true)
+    // Both halves move together, and only here: after the entry posts the
+    // branch below refuses, so the code can never drift from the relationship.
     expect(h.updated[0]?.values).toEqual({
+      bank_deposit_bank_account_record: 'def_bank_account:acct_2',
       bank_deposit_bank_account: '1010',
       bank_deposit_reference: 'slip-77',
     })
@@ -532,7 +589,7 @@ describe('updateBankDeposit', () => {
       organizationId: ORG,
       actorUserId: USER,
       depositId: 'dep_1',
-      bankAccountCode: '1020',
+      bankAccountId: 'acct_2',
     })
     expect(result._unsafeUnwrapErr().message).toMatch(/already posted/i)
     expect(h.updated).toHaveLength(0)
@@ -541,12 +598,12 @@ describe('updateBankDeposit', () => {
   // The date has always behaved this way; re-sending the SAME account must not
   // become a refusal just because the deposit has posted.
   it('lets a posted deposit re-send the account it already has', async () => {
-    h.deposit = deposit({ glPostingId: 'glp_1', bankAccountCode: '1000' })
+    h.deposit = deposit({ glPostingId: 'glp_1', bankAccountId: 'acct_1' })
     const result = await updateBankDeposit(db, {
       organizationId: ORG,
       actorUserId: USER,
       depositId: 'dep_1',
-      bankAccountCode: '1000',
+      bankAccountId: 'acct_1',
       reference: 'slip-88',
     })
     expect(result.isOk()).toBe(true)

--- a/packages/lib/src/money/bank-deposits/reads.ts
+++ b/packages/lib/src/money/bank-deposits/reads.ts
@@ -22,7 +22,7 @@ import { alias } from 'drizzle-orm/pg-core'
 import type { Result } from 'neverthrow'
 import { getCachedEntityDefId, getOrgCache } from '../../cache'
 import { UnprocessableEntityError } from '../../errors'
-import { toRecordId } from '../../resources/resource-id'
+import { type RecordId, toRecordId } from '../../resources/resource-id'
 import { methodsRoutedToUndepositedFunds, resolveBankDepositStatus } from './client'
 import { guard } from './guard'
 import type {
@@ -38,6 +38,7 @@ const DEPOSIT_ATTRIBUTES = [
   'bank_deposit_number',
   'bank_deposit_date',
   'bank_deposit_bank_account',
+  'bank_deposit_bank_account_record',
   'bank_deposit_reference',
   'bank_deposit_status',
   'bank_deposit_total',
@@ -45,6 +46,23 @@ const DEPOSIT_ATTRIBUTES = [
   'bank_deposit_cleared_at',
   'bank_deposit_reconciled_at',
   'bank_deposit_gl_posting_id',
+] as const
+
+/**
+ * The `bank_account` attributes a deposit needs to name the account it is banked
+ * into.
+ *
+ * 🛑 Read through the entity layer rather than by importing `banking/`.
+ * `banking/review/writes.ts` already imports `clearBankDeposit` from this
+ * module, so a `money -> banking` import would close a cycle - the same
+ * backwards edge `plans/bank-connection/09-data-connector-debt.md` D1 was about,
+ * one feature over. A `bank_account` is an `EntityInstance` like any other and
+ * this module already resolves `payment` and `bank_deposit` exactly this way.
+ */
+const BANK_ACCOUNT_ATTRIBUTES = [
+  'bank_account_name',
+  'bank_account_gl_account',
+  'bank_account_has_posted',
 ] as const
 
 /** Every `payment` attribute an {@link UndepositedPaymentRow} is assembled from. */
@@ -64,6 +82,10 @@ type PaymentAttribute = (typeof PAYMENT_ATTRIBUTES)[number]
 type DepositFields = Record<DepositAttribute, { id: string } | null>
 type PaymentFields = Record<PaymentAttribute, { id: string } | null>
 
+type BankAccountAttribute = (typeof BANK_ACCOUNT_ATTRIBUTES)[number]
+
+type BankAccountFields = Record<BankAccountAttribute, { id: string } | null>
+
 const DEFAULT_LIMIT = 100
 
 /** The resolved def and field ids every deposit read needs. */
@@ -76,6 +98,22 @@ export interface BankDepositFieldContext {
 export interface PaymentFieldContext {
   paymentDefId: string
   fields: PaymentFields
+}
+
+/** The resolved `bank_account` def and the fields a deposit reads off it. */
+export interface DepositBankAccountContext {
+  bankAccountDefId: string
+  fields: BankAccountFields
+}
+
+/** The account a deposit is banked into, as this module needs it. */
+export interface DepositBankAccount {
+  id: string
+  recordId: RecordId
+  name: string | null
+  /** Its mapping in the chart, trimmed. Null when the account is unmapped. */
+  glAccountCode: string | null
+  archivedAt: Date | null
 }
 
 /**
@@ -115,6 +153,32 @@ export async function requireBankDepositFieldContext(
   return ctx
 }
 
+/**
+ * {@link requireBankDepositFieldContext} plus the link to the bank account.
+ *
+ * 🛑 Separate from the plain require, and only the CREATE path asks for it. A
+ * deposit written without the link records the GL code alone, and a code cannot
+ * be resolved back to an account (several map to one), so the row would sit
+ * permanently outside the removal gate - the hole entity migration 135 closes.
+ *
+ * ⚠️ Clearing and correcting must NOT go through here. Neither writes the link,
+ * and refusing them on an org that has 125 but not yet 135 would break matching
+ * a bank line to a deposit that already exists - a path this field has nothing
+ * to do with, between a deploy and the migration run.
+ */
+export async function requireBankDepositWriteContext(
+  organizationId: string
+): Promise<BankDepositFieldContext> {
+  const ctx = await requireBankDepositFieldContext(organizationId)
+  if (!ctx.fields.bank_deposit_bank_account_record) {
+    throw new UnprocessableEntityError(
+      'Recording a bank deposit is not available until the deposit bank account link is ' +
+        'provisioned (entity migration 135)'
+    )
+  }
+  return ctx
+}
+
 /** Resolve the `payment` def and the fields a deposit reads and stamps. */
 export async function loadPaymentFieldContext(
   organizationId: string
@@ -126,6 +190,100 @@ export async function loadPaymentFieldContext(
     .bySystemAttributes([...PAYMENT_ATTRIBUTES])) as PaymentFields
   if (!fields.payment_amount || !fields.payment_method) return null
   return { paymentDefId, fields }
+}
+
+/**
+ * Resolve the `bank_account` def and the fields a deposit reads off it.
+ *
+ * `null` when the org has no `bank_account` def, which is every org short of
+ * entity migration 125.
+ */
+export async function loadDepositBankAccountContext(
+  organizationId: string
+): Promise<DepositBankAccountContext | null> {
+  const bankAccountDefId = await getCachedEntityDefId(organizationId, 'bank_account')
+  if (!bankAccountDefId) return null
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...BANK_ACCOUNT_ATTRIBUTES])) as BankAccountFields
+  return { bankAccountDefId, fields }
+}
+
+/**
+ * {@link loadDepositBankAccountContext}, as the refusal a write path needs.
+ *
+ * 🛑 The chart mapping is required, not optional. Without
+ * `bank_account_gl_account` there is no account to debit and a deposit could
+ * only be posted by guessing at a code the operator never named.
+ */
+export async function requireDepositBankAccountContext(
+  organizationId: string
+): Promise<DepositBankAccountContext> {
+  const ctx = await loadDepositBankAccountContext(organizationId)
+  if (!ctx?.fields.bank_account_gl_account) {
+    throw new UnprocessableEntityError(
+      'Banking a payment is not available until the bank account entity and its chart mapping ' +
+        'are provisioned (entity migration 125)'
+    )
+  }
+  return ctx
+}
+
+/**
+ * One bank account, by id, org-scoped.
+ *
+ * Archived accounts are INCLUDED so the caller can refuse by name - "that
+ * account is archived" is a better answer than "that account does not exist"
+ * for an account the operator can see in a picker's history.
+ */
+export async function readDepositBankAccount(
+  db: Database,
+  organizationId: string,
+  ctx: DepositBankAccountContext,
+  bankAccountId: string
+): Promise<DepositBankAccount | null> {
+  const [instance] = await db
+    .select({ id: schema.EntityInstance.id, archivedAt: schema.EntityInstance.archivedAt })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, ctx.bankAccountDefId),
+        eq(schema.EntityInstance.id, bankAccountId)
+      )
+    )
+    .limit(1)
+  if (!instance) return null
+
+  const fieldIds = [
+    ctx.fields.bank_account_name?.id,
+    ctx.fields.bank_account_gl_account?.id,
+  ].filter((id): id is string => !!id)
+  const values = fieldIds.length
+    ? await db
+        .select({ fieldId: schema.FieldValue.fieldId, valueText: schema.FieldValue.valueText })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            eq(schema.FieldValue.entityId, instance.id),
+            inArray(schema.FieldValue.fieldId, fieldIds)
+          )
+        )
+    : []
+  const byField = new Map(values.map((row) => [row.fieldId, row.valueText]))
+  const read = (attr: BankAccountAttribute) => {
+    const id = ctx.fields[attr]?.id
+    return id ? (byField.get(id) ?? null) : null
+  }
+
+  return {
+    id: instance.id,
+    recordId: toRecordId(ctx.bankAccountDefId, instance.id),
+    name: read('bank_account_name')?.trim() || null,
+    glAccountCode: read('bank_account_gl_account')?.trim() || null,
+    archivedAt: instance.archivedAt,
+  }
 }
 
 /** {@link loadPaymentFieldContext}, as the refusal a write path needs. */
@@ -623,6 +781,7 @@ async function hydrateDeposits(
       valueNumber: schema.FieldValue.valueNumber,
       valueDate: schema.FieldValue.valueDate,
       optionId: schema.FieldValue.optionId,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
     })
     .from(schema.FieldValue)
     .where(
@@ -657,6 +816,7 @@ async function hydrateDeposits(
       recordId: toRecordId(ctx.depositDefId, row.id),
       number: read('bank_deposit_number')?.valueText ?? null,
       depositDate: toIsoDay(read('bank_deposit_date')?.valueDate),
+      bankAccountId: read('bank_deposit_bank_account_record')?.relatedEntityId ?? null,
       bankAccountCode: read('bank_deposit_bank_account')?.valueText ?? null,
       reference: read('bank_deposit_reference')?.valueText ?? null,
       status: resolveBankDepositStatus(read('bank_deposit_status')?.optionId),

--- a/packages/lib/src/money/bank-deposits/types.ts
+++ b/packages/lib/src/money/bank-deposits/types.ts
@@ -43,7 +43,19 @@ export interface BankDepositRecord {
   number: string | null
   /** `YYYY-MM-DD`. THE accounting date of the posting. */
   depositDate: string | null
-  /** GL account CODE the money lands in. */
+  /**
+   * `EntityInstance.id` of the `bank_account` the money was banked into.
+   *
+   * Null on a deposit recorded before migration 135, and on one whose code named
+   * more than one account so the backfill refused to guess.
+   */
+  bankAccountId: string | null
+  /**
+   * The GL account CODE the entry POSTED to, frozen when it was built.
+   *
+   * 🛑 Not derived from {@link bankAccountId}: re-mapping a bank account to a
+   * different chart code must not restate a deposit that posted to the old one.
+   */
   bankAccountCode: string | null
   reference: string | null
   status: BankDepositStatus
@@ -88,8 +100,16 @@ export interface CreateBankDepositInput {
   paymentIds: string[]
   /** `YYYY-MM-DD`. The date the deposit hits the bank, and the posting's date. */
   depositDate: string
-  /** GL account CODE from the org's own chart. Resolved by the poster, not here. */
-  bankAccountCode: string
+  /**
+   * `EntityInstance.id` of the `bank_account` the money is banked into.
+   *
+   * 🛑 An ACCOUNT, never a chart code. The code is read off the account's own
+   * mapping, because the bank feed posts every line on that account against the
+   * same mapping - a free choice from the chart puts the deposit and the
+   * statement line it exists to match into two different accounts, and nothing
+   * catches that (match candidates are found by amount and date).
+   */
+  bankAccountId: string
   reference?: string
 }
 
@@ -119,6 +139,7 @@ export interface ClearBankDepositInput {
 export interface UpdateBankDepositInput {
   depositId: string
   depositDate?: string
-  bankAccountCode?: string
+  /** `EntityInstance.id` of the `bank_account`. Frozen once the entry posts. */
+  bankAccountId?: string
   reference?: string
 }

--- a/packages/lib/src/money/bank-deposits/writes.ts
+++ b/packages/lib/src/money/bank-deposits/writes.ts
@@ -53,10 +53,14 @@ import { toRecordId } from '../../resources/resource-id'
 import { BANK_DEPOSIT_SOURCE_TYPE, isBankDepositFrozen, resolvePaymentRoute } from './client'
 import { guard } from './guard'
 import {
+  type DepositBankAccount,
   loadBankDepositFieldContext,
   readBankDepositDetail,
+  readDepositBankAccount,
   readPaymentsByIds,
   requireBankDepositFieldContext,
+  requireBankDepositWriteContext,
+  requireDepositBankAccountContext,
   requirePaymentFieldContext,
 } from './reads'
 import type {
@@ -183,21 +187,22 @@ export async function createBankDeposit(
   db: Database,
   params: { organizationId: string; actorUserId: string } & CreateBankDepositInput
 ): Promise<Result<CreateBankDepositResult, Error>> {
-  const { organizationId, actorUserId, paymentIds, depositDate, bankAccountCode, reference } =
-    params
+  const { organizationId, actorUserId, paymentIds, depositDate, bankAccountId, reference } = params
 
   return guard(
     async () => {
       assertIsoDate(depositDate, 'Deposit date')
-      if (!bankAccountCode.trim()) {
+      if (!bankAccountId.trim()) {
         throw new BadRequestError('A deposit must name the bank account the money lands in')
       }
+      const bankAccount = await requireDepositTarget(db, organizationId, bankAccountId.trim())
+      const bankAccountCode = bankAccount.glAccountCode
       const uniqueIds = [...new Set(paymentIds)]
       if (uniqueIds.length === 0) {
         throw new BadRequestError('Select at least one payment to bank')
       }
 
-      const depositCtx = await requireBankDepositFieldContext(organizationId)
+      const depositCtx = await requireBankDepositWriteContext(organizationId)
       const paymentCtx = await requirePaymentFieldContext(organizationId)
       const settings = await getOrgCache().get(organizationId, 'orgSettings')
 
@@ -271,7 +276,8 @@ export async function createBankDeposit(
         const crud = new UnifiedCrudHandler(organizationId, actorUserId, txDb)
         const created = await crud.create(depositCtx.depositDefId, {
           bank_deposit_date: depositDate,
-          bank_deposit_bank_account: bankAccountCode.trim(),
+          bank_deposit_bank_account: bankAccountCode,
+          bank_deposit_bank_account_record: bankAccount.recordId,
           bank_deposit_reference: reference?.trim() || undefined,
           bank_deposit_status: 'pending',
           bank_deposit_total: total,
@@ -310,10 +316,10 @@ export async function createBankDeposit(
             // `resolveAccountLines` validates the code against this org's own
             // chart and refuses by name when it is missing, inactive or
             // ambiguous, so a bad code is a rolled-back refusal, not a bad post.
-            accountCode: bankAccountCode.trim(),
+            accountCode: bankAccountCode,
             direction: 'debit',
             amount: totalMinor,
-            memo: `Bank deposit ${deposit.number ?? ''} to ${bankAccountCode.trim()}`.trim(),
+            memo: `Bank deposit ${deposit.number ?? ''} to ${bankAccountCode}`.trim(),
             sourceType: BANK_DEPOSIT_SOURCE_TYPE,
             sourceId: depositId,
             sortOrder: 0,
@@ -355,6 +361,8 @@ export async function createBankDeposit(
         await crud.update(deposit.recordId, { bank_deposit_gl_posting_id: post.glPostingId })
       }
 
+      await stampBankAccountHasPosted(db, organizationId, actorUserId, bankAccount)
+
       logger.info('Recorded bank deposit', {
         organizationId,
         depositId,
@@ -370,6 +378,85 @@ export async function createBankDeposit(
     'Failed to create bank deposit',
     { organizationId, paymentIds: paymentIds.length }
   )
+}
+
+/**
+ * The account this deposit is banked into, refused by name when it cannot take one.
+ *
+ * 🛑 **An ACCOUNT is named and the CODE is read off it, never the other way
+ * round.** The bank feed posts every line on an account against that account's
+ * `glAccountCode`, so a code chosen freely from the chart puts the deposit and
+ * the statement line it exists to match into two different accounts. Nothing
+ * downstream catches it - match candidates are found by amount and date, not by
+ * account. The deposit picker has always worked this way; taking the id here is
+ * what stops any other caller working differently.
+ *
+ * ⚠️ Both refusals are `UnprocessableEntityError` and both name the account,
+ * because both are fixed somewhere else in the product rather than by retrying.
+ */
+async function requireDepositTarget(
+  db: Database,
+  organizationId: string,
+  bankAccountId: string
+): Promise<DepositBankAccount & { glAccountCode: string }> {
+  const ctx = await requireDepositBankAccountContext(organizationId)
+  const account = await readDepositBankAccount(db, organizationId, ctx, bankAccountId)
+  if (!account) {
+    throw new UnprocessableEntityError('That bank account does not exist in this organization')
+  }
+  if (account.archivedAt) {
+    throw new UnprocessableEntityError(
+      `${account.name ?? 'That bank account'} is archived, so nothing can be banked into it. ` +
+        'Restore it, or pick another account.'
+    )
+  }
+  if (!account.glAccountCode) {
+    throw new UnprocessableEntityError(
+      `${account.name ?? 'That bank account'} is not mapped to an account in the chart of ` +
+        'accounts, so there is no account to debit. Map it under Banking first.'
+    )
+  }
+  return { ...account, glAccountCode: account.glAccountCode }
+}
+
+/**
+ * Record on the BANK ACCOUNT that something on it has reached the books.
+ *
+ * 🛑 The same write-once high-water mark `banking/review/writes.ts` stamps when a
+ * bank LINE posts, and for the same reason: a posted deposit debits this
+ * account's chart mapping and names this account as where the money went, so the
+ * account has permanently changed the ledger and must never become hard-deletable
+ * again. Feeding the EXISTING term is deliberate -
+ * `plans/bank-connection/08-removing-a-bank-account.md` §5.1 says one term
+ * decides delete versus archive, and a second blocker beside it would be a
+ * second answer to the same question.
+ *
+ * ⚠️ Called only after the ledger ACCEPTED the entry. A refused post rolls the
+ * deposit back, and stamping a high-water mark for an entry that does not exist
+ * would make an account with nothing on it permanently un-deletable.
+ *
+ * ⚠️ Failures are logged, not thrown. The deposit and its entry are already
+ * written, and turning an accepted post into an error would report work that
+ * actually happened as a failure. The cost of a miss is one account that stays
+ * deletable when it should not be, which the operator sees named in the confirm
+ * dialog before anything goes.
+ */
+async function stampBankAccountHasPosted(
+  db: Database,
+  organizationId: string,
+  actorUserId: string,
+  account: DepositBankAccount
+): Promise<void> {
+  try {
+    const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+    await crud.update(account.recordId, { bank_account_has_posted: true })
+  } catch (error) {
+    logger.error('Failed to stamp bank_account_has_posted after a bank deposit', {
+      organizationId,
+      bankAccountId: account.id,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 }
 
 /**
@@ -472,7 +559,7 @@ export async function clearBankDeposit(
  * message is that the reader can go and look at it. Same rule as the movement
  * ledger: correct by reversing, never by editing.
  *
- * 🛑 `depositDate` AND `bankAccountCode` are additionally frozen once the entry
+ * 🛑 `depositDate` AND the bank account are additionally frozen once the entry
  * has posted, even while the deposit is still pending. They are the posting's
  * `txnDate` and its debit account, and a posted entry is immutable, so editing
  * either here would leave the record claiming one thing and the ledger holding
@@ -486,7 +573,7 @@ export async function updateBankDeposit(
   db: Database,
   params: { organizationId: string; actorUserId: string } & UpdateBankDepositInput
 ): Promise<Result<BankDepositDetail, Error>> {
-  const { organizationId, actorUserId, depositId, depositDate, bankAccountCode, reference } = params
+  const { organizationId, actorUserId, depositId, depositDate, bankAccountId, reference } = params
 
   return guard(
     async () => {
@@ -517,8 +604,8 @@ export async function updateBankDeposit(
         }
         values.bank_deposit_date = depositDate
       }
-      if (bankAccountCode !== undefined && bankAccountCode.trim() !== deposit.bankAccountCode) {
-        if (!bankAccountCode.trim()) {
+      if (bankAccountId !== undefined && bankAccountId.trim() !== deposit.bankAccountId) {
+        if (!bankAccountId.trim()) {
           throw new BadRequestError('A deposit must name the bank account the money lands in')
         }
         if (deposit.glPostingId) {
@@ -529,7 +616,12 @@ export async function updateBankDeposit(
             { glPostingId: deposit.glPostingId }
           )
         }
-        values.bank_deposit_bank_account = bankAccountCode.trim()
+        // Only reachable before the entry posts, so the code has nothing frozen
+        // to disagree with yet and both halves move together. After it posts the
+        // branch above refuses, which is what keeps them from ever diverging.
+        const account = await requireDepositTarget(db, organizationId, bankAccountId.trim())
+        values.bank_deposit_bank_account_record = account.recordId
+        values.bank_deposit_bank_account = account.glAccountCode
       }
       if (reference !== undefined) values.bank_deposit_reference = reference.trim() || null
 

--- a/packages/lib/src/resources/registry/resources/bank-account-fields.ts
+++ b/packages/lib/src/resources/registry/resources/bank-account-fields.ts
@@ -401,6 +401,36 @@ export const BANK_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       'linkNewRelationships skips the pair with a debug line',
   },
 
+  deposits: {
+    id: toFieldId('deposits'),
+    key: 'deposits',
+    label: 'Deposits',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'bank_account_deposits',
+    systemSortOrder: 'aCV',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'bank_deposit:bankAccountRecord' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description:
+      'The bank deposits banked into this account. The INVERSE half - the owning side is ' +
+      'bank_deposit.bankAccount (field id bankAccountRecord - the id, not the key, is what ' +
+      'linkNewRelationships looks the inverse up by), and both halves must exist in one ' +
+      'migration or ' +
+      'linkNewRelationships skips the pair with a debug line',
+  },
+
   hasPosted: {
     id: toFieldId('hasPosted'),
     key: 'hasPosted',
@@ -422,7 +452,8 @@ export const BANK_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     description:
-      'A WRITE-ONCE high-water mark: true once any line on this account has produced a journal ' +
+      'A WRITE-ONCE high-water mark: true once any line on this account, or any bank deposit ' +
+      'banked into it, has produced a journal ' +
       'entry. The only term in the removal gate - false deletes, true archives ' +
       '(plans/bank-connection/08-removing-a-bank-account.md §5.1). Nothing clears it: undoing a ' +
       'review, reversing an entry and reversing an import all leave the GlPosting and its ' +

--- a/packages/lib/src/resources/registry/resources/bank-deposit-fields.ts
+++ b/packages/lib/src/resources/registry/resources/bank-deposit-fields.ts
@@ -61,9 +61,22 @@ export const BANK_DEPOSIT_STATUS_OPTIONS = [
  * does not exist yet (slot 2I), and a RELATIONSHIP cannot point at a def that
  * is not in the org. A later migration converts BOTH sides together.
  *
- * `bankAccount` is a GL account **CODE** as TEXT, the
- * `vendor_bill_line_gl_account` precedent, and becomes a RELATIONSHIP to
- * `bank_account` when 2I lands.
+ * ⚠️ **`bankAccount` and `bankAccountCode` are two halves of one fact, and the
+ * split is deliberate** (migration 135, `plans/bank-connection/09-data-connector-debt.md`
+ * D5). `bankAccount` is a RELATIONSHIP and is the truth: an operator has always
+ * chosen a bank ACCOUNT, never a code from the chart, and the picker reads the
+ * code off it. `bankAccountCode` is the code that entry actually POSTED to,
+ * frozen at build time the way `GlPostingLine` freezes it.
+ *
+ * 🛑 **The code is not derivable from the relationship after the fact.**
+ * Re-mapping a bank account to a different chart code would otherwise restate
+ * every deposit that already posted to the old one. It is the same rule the
+ * movement ledger keeps about cost.
+ *
+ * ⚠️ Nor is the relationship derivable from the code, which is why migration
+ * 135's backfill leaves rows null rather than guessing: several bank accounts
+ * legitimately map to one code, and in the first org that had deposits at all,
+ * three did.
  *
  * Money is integer minor units ({@link BANK_DEPOSIT_FIELDS.totalMinor}).
  */
@@ -140,10 +153,16 @@ export const BANK_DEPOSIT_FIELDS: Record<string, ResourceField> = {
       'this, not from when the payments were received',
   },
 
-  bankAccount: {
+  bankAccountCode: {
+    // 🛑 `id` stays `bankAccount` while the key became `bankAccountCode`, and the
+    // relationship below takes `bankAccountRecord` rather than the key it wanted.
+    // The id is what `ResourceFieldId` persists into saved views and filters, so
+    // renaming it would orphan them; the key is only how this file reads.
+    // `linkNewRelationships` resolves an inverse by ID, which is why the pair is
+    // declared as `bank_deposit:bankAccountRecord` on the account side.
     id: toFieldId('bankAccount'),
-    key: 'bankAccount',
-    label: 'Bank Account',
+    key: 'bankAccountCode',
+    label: 'Bank Account Code',
     type: BaseType.STRING,
     fieldType: FieldType.TEXT,
     isSystem: true,
@@ -159,9 +178,45 @@ export const BANK_DEPOSIT_FIELDS: Record<string, ResourceField> = {
     },
     placeholder: '1000',
     description:
-      'The GL account CODE the money lands in, from the org own chart. TEXT rather than a ' +
-      'RELATIONSHIP because the bank_account def does not exist yet (HANDOFF slot 2I); a ' +
-      'later migration converts it, alongside the vendor payment side twin',
+      'The GL account CODE this deposit was POSTED to, copied off ' +
+      'bankAccount.glAccountCode when the entry was built and frozen there. Kept beside the ' +
+      'relationship rather than derived from it, because re-mapping a bank account to a ' +
+      'different code must not restate a deposit that already posted to the old one',
+  },
+
+  bankAccount: {
+    id: toFieldId('bankAccountRecord'),
+    key: 'bankAccount',
+    label: 'Bank Account',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'bank_deposit_bank_account_record',
+    systemSortOrder: 'a3a',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'bank_account:deposits' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'bank_account',
+      relationshipType: 'belongs_to',
+      inverseName: 'Deposits',
+      inverseSystemAttribute: 'bank_account_deposits',
+    },
+    description:
+      'The bank account the money was banked INTO - the truth, and what the removal gate ' +
+      'reads. The operator has always picked an account rather than a code (the picker reads ' +
+      'the code off it); this records which one, which a code cannot because several accounts ' +
+      'legitimately map to the same one',
   },
 
   reference: {

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -91,6 +91,7 @@ import { migration128InvoiceWrittenOff } from './migrations/128-invoice-written-
 import { migration132CardClearingRename } from './migrations/132-card-clearing-rename'
 import { migration133Payout } from './migrations/133-payout'
 import { migration134BankAccountHasPosted } from './migrations/134-bank-account-has-posted'
+import { migration135BankDepositBankAccount } from './migrations/135-bank-deposit-bank-account'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -267,6 +268,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // removal gate reads: false deletes, true archives, and nothing clears it.
   // MUST sort after 125, which owns the `bank_account` def it widens.
   migration134BankAccountHasPosted,
+  migration135BankDepositBankAccount,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/135-bank-deposit-bank-account.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/135-bank-deposit-bank-account.test.ts
@@ -1,0 +1,46 @@
+// packages/lib/src/seed/entity-migrations/migrations/135-bank-deposit-bank-account.test.ts
+//
+// The one decision in migration 135 that can be wrong without anything failing:
+// which deposit gets linked to which bank account.
+//
+// A wrong link is silent. The deposit still reads fine, its code is still right,
+// its entry is untouched - and the removal gate now protects an account the
+// money never went into while leaving the real one deletable. So the rule is a
+// pure function and every branch of it is pinned here, the way 118's
+// `resolveLabel` is.
+
+import { describe, expect, it } from 'vitest'
+import { resolveLinkDecision } from './135-bank-deposit-bank-account'
+
+describe('resolveLinkDecision', () => {
+  it('links a code that names exactly one bank account', () => {
+    expect(resolveLinkDecision('1000', ['acct_1'])).toBe('link')
+  })
+
+  // 🛑 The case that made the backfill partial. Three accounts mapped to `1000`
+  // in the first org that had deposits at all, and all four of its deposits
+  // carry that code - so "pick the first" would have mislinked every one of them.
+  it('refuses to guess when a code names more than one bank account', () => {
+    expect(resolveLinkDecision('1000', ['acct_1', 'acct_2'])).toBe('ambiguous')
+    expect(resolveLinkDecision('1000', ['acct_1', 'acct_2', 'acct_3'])).toBe('ambiguous')
+  })
+
+  it('reports a code no bank account is mapped to', () => {
+    expect(resolveLinkDecision('9999', [])).toBe('unmatched')
+    expect(resolveLinkDecision('9999', undefined)).toBe('unmatched')
+  })
+
+  // Distinct from `unmatched`: there is nothing to resolve, not a failure to
+  // resolve it. A deposit with no code was never posted to an account.
+  it('skips a deposit carrying no code', () => {
+    expect(resolveLinkDecision(null, ['acct_1'])).toBe('skip')
+    expect(resolveLinkDecision(undefined, ['acct_1'])).toBe('skip')
+    expect(resolveLinkDecision('   ', ['acct_1'])).toBe('skip')
+  })
+
+  // The migration trims before it looks the code up; the rule must agree, or a
+  // padded code would report `skip` on one side and `unmatched` on the other.
+  it('treats a whitespace-only code as absent rather than unmatched', () => {
+    expect(resolveLinkDecision('', undefined)).toBe('skip')
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/135-bank-deposit-bank-account.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/135-bank-deposit-bank-account.ts
@@ -1,0 +1,454 @@
+// packages/lib/src/seed/entity-migrations/migrations/135-bank-deposit-bank-account.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq, inArray, isNotNull, isNull } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import { seedSession, UnifiedCrudHandler } from '../../../resources/crud'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { BANK_ACCOUNT_FIELDS } from '../../../resources/registry/resources/bank-account-fields'
+import { BANK_DEPOSIT_FIELDS } from '../../../resources/registry/resources/bank-deposit-fields'
+import { SystemUserService } from '../../../users/system-user-service'
+import { ensureCustomFields, linkNewRelationships, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:135')
+
+/** The GL code a deposit was posted to. Already on every org that has migration 125. */
+const CODE_ATTRIBUTE = 'bank_deposit_bank_account'
+
+/** What a bank account is mapped to in the chart. The backfill's only join key. */
+const GL_ACCOUNT_ATTRIBUTE = 'bank_account_gl_account'
+
+/** The label the code field carried while it was the ONLY account field on a deposit. */
+const OLD_CODE_LABEL = 'Bank Account'
+
+/**
+ * Migration 135: `bank_deposit.bankAccount`, the RELATIONSHIP the deposit should
+ * always have had, and its inverse `bank_account.deposits`
+ * (plans/bank-connection/09-data-connector-debt.md D5,
+ * plans/bank-connection/08-removing-a-bank-account.md §3 (3)).
+ *
+ * ## Why the code field STAYS
+ *
+ * `bank_deposit_bank_account` holds a GL account code (`'1020'`) and the
+ * registry has said since 125 that a later migration converts it. This one does
+ * NOT convert it - it adds the relationship beside it, and the two halves mean
+ * different things:
+ *
+ * - the RELATIONSHIP is which bank account the money was banked into. That is
+ *   what the operator actually chose (the deposit picker has always made them
+ *   pick an account and read the code off its mapping) and it is what the
+ *   removal gate reads.
+ * - the CODE is which chart account the entry POSTED to, frozen when the entry
+ *   was built, exactly the way `GlPostingLine` freezes code and name and holds
+ *   no foreign key to the instance (§3 (1)).
+ *
+ * 🛑 Deriving the code from the relationship later would restate history: remap
+ * a bank account to a different chart code and every deposit that posted to the
+ * old one silently changes account. Deriving the relationship from the code
+ * cannot be done at all - see the backfill.
+ *
+ * ## The backfill is deliberately incomplete, and refuses to guess
+ *
+ * A code names at most one chart account but MANY bank accounts: two current
+ * accounts at different banks both mapped to `1000 Checking` is ordinary, not an
+ * edge case. In the first organization that had any deposits at all, three bank
+ * accounts shared the code all four of its deposits carry.
+ *
+ * So the backfill links a deposit only when the org has EXACTLY ONE bank account
+ * mapped to that code, and leaves the rest null. A guess would attach the
+ * deposit to the wrong account and then hand that wrong answer to the removal
+ * gate, which is worse than a null: null means "unknown", and the code - the
+ * fact that IS true - is still on the row and still on the posted entry.
+ *
+ * ## Id space
+ *
+ * 135 is the next free id. The space is SHARED between
+ * `data-migrations/migrations/` (which reaches 131) and
+ * `seed/entity-migrations/migrations/` (which reaches 134), and has already
+ * collided once, at 103.
+ *
+ * **No DDL.** Two `CustomField` rows on existing defs, plus `FieldValue` rows
+ * written through `UnifiedCrudHandler` so both halves of the relationship land.
+ *
+ * Idempotent - `ensureCustomFields` skips a field that already exists,
+ * `linkNewRelationships` only writes a null inverse, the relabel is guarded on
+ * the old label and the backfill skips a deposit that already has a link.
+ */
+export const migration135BankDepositBankAccount: EntityMigration = {
+  id: '135-bank-deposit-bank-account',
+  description:
+    'Add bank_deposit.bankAccount (a RELATIONSHIP to bank_account) and its inverse ' +
+    'bank_account.deposits, keeping the posted GL code beside it, and link every deposit ' +
+    'whose code names exactly one bank account',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const depositDef = existing.entityDefs.get('bank_deposit')
+    const accountDef = existing.entityDefs.get('bank_account')
+    // Absent rather than failed: an org short of migration 125 has neither def,
+    // and the seeder creates both halves with the rest of the registry.
+    if (!depositDef || !accountDef) return { ...state, alreadyUpToDate: true }
+
+    const depositFields = pick(BANK_DEPOSIT_FIELDS, ['bankAccount'], 'bank_deposit')
+    const accountFields = pick(BANK_ACCOUNT_FIELDS, ['deposits'], 'bank_account')
+
+    // 🛑 The relabel goes FIRST, before the new field is created. `CustomField`
+    // is UNIQUE on (name, organizationId, modelType, entityDefinitionId), and
+    // the relationship this migration adds is labelled "Bank Account" - the name
+    // the CODE field still holds. Creating it first is a 23505 on every org that
+    // has the deposit def, which is how this ordering was found.
+    const relabelled = await relabelCodeField(db, organizationId, depositDef.id)
+
+    // 🛑 ONE field map spanning BOTH defs. `linkNewRelationships` resolves the
+    // inverse out of this map by `<entityType>:<field id>`, so linking the two
+    // halves in separate calls would leave each unable to see the other and skip
+    // the pair with a debug line.
+    const fieldMap = new Map([
+      ...(await ensureCustomFields(
+        db,
+        organizationId,
+        'bank_deposit',
+        depositDef.id,
+        depositFields,
+        existing,
+        state
+      )),
+      ...(await ensureCustomFields(
+        db,
+        organizationId,
+        'bank_account',
+        accountDef.id,
+        accountFields,
+        existing,
+        state
+      )),
+    ])
+
+    await linkNewRelationships(
+      db,
+      fieldMap,
+      new Map([
+        ['bank_deposit', depositDef.id],
+        ['bank_account', accountDef.id],
+      ]),
+      state
+    )
+
+    const relationField = fieldMap.get(`bank_deposit:${BANK_DEPOSIT_FIELDS.bankAccount!.id}`)
+    if (!relationField) {
+      throw new Error(
+        `migration 135 could not resolve the bank_deposit_bank_account_record field for ${depositDef.id}`
+      )
+    }
+    // 🛑 An UNLINKED relationship is worse than a missing one: the field exists,
+    // so writes are accepted, but with no inverse the account side reads empty
+    // and the removal gate sees no deposits. `linkNewRelationships` only logs a
+    // debug line when it cannot find the other half, so it is checked here.
+    const linked = await db.query.CustomField.findFirst({
+      where: eq(schema.CustomField.id, relationField.id),
+      columns: { options: true },
+    })
+    const inverseId = (linked?.options as { relationship?: { inverseResourceFieldId?: string } })
+      ?.relationship?.inverseResourceFieldId
+    if (!inverseId) {
+      throw new Error(
+        'migration 135 created bank_deposit.bankAccount but could not link it to ' +
+          'bank_account.deposits - the inverse half is missing, and an unlinked relationship ' +
+          'writes rows the account side cannot see'
+      )
+    }
+
+    const backfill = await backfillDepositBankAccount(db, organizationId, {
+      depositDefId: depositDef.id,
+      accountDefId: accountDef.id,
+      relationFieldId: relationField.id,
+    })
+
+    const changed =
+      state.fieldsCreated > 0 || state.relationshipsLinked > 0 || relabelled || backfill.linked > 0
+    // A new field is invisible to every read path until the per-org caches that
+    // serve it are dropped. `runEntityMigrationsForOrg` does this after the whole
+    // batch, but `up()` can also be invoked directly, so it clears its own.
+    if (changed) {
+      await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+      logger.info('Migration 135 applied', { organizationId, ...state, ...backfill })
+    }
+    // ⚠️ Deposits left unlinked are reported, not failed. An ambiguous code is
+    // the expected outcome, not a broken migration.
+    if (backfill.ambiguous > 0 || backfill.unmatched > 0) {
+      logger.warn('Migration 135 left deposits without a bank account', {
+        organizationId,
+        ...backfill,
+      })
+    }
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}
+
+/** The registry fields this migration adds, by key, loud if the registry renamed one. */
+function pick(
+  source: Record<string, ResourceField>,
+  keys: readonly string[],
+  entityType: string
+): Record<string, ResourceField> {
+  const picked: Record<string, ResourceField> = {}
+  for (const key of keys) {
+    const field = source[key]
+    if (!field) {
+      throw new Error(`${entityType} registry is missing the key "${key}" (migration 135)`)
+    }
+    picked[key] = field
+  }
+  return picked
+}
+
+/**
+ * Rename the stored label of the code field, so a deposit does not show two
+ * fields both called "Bank Account".
+ *
+ * ⚠️ Guarded on the OLD label rather than written unconditionally. The field is
+ * `configurable: false` so nothing in the product renames it today, but a
+ * migration that overwrites a name it did not write is how a customer's edit
+ * disappears, and 108's `refreshSelectOptions` is the precedent for not doing
+ * that.
+ */
+async function relabelCodeField(
+  db: Database,
+  organizationId: string,
+  entityDefinitionId: string
+): Promise<boolean> {
+  const label = BANK_DEPOSIT_FIELDS.bankAccountCode?.label
+  if (!label) throw new Error('bank_deposit registry is missing bankAccountCode (migration 135)')
+
+  const updated = await db
+    .update(schema.CustomField)
+    .set({ name: label, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.entityDefinitionId, entityDefinitionId),
+        eq(schema.CustomField.systemAttribute, CODE_ATTRIBUTE),
+        eq(schema.CustomField.name, OLD_CODE_LABEL)
+      )
+    )
+    .returning({ id: schema.CustomField.id })
+
+  return updated.length > 0
+}
+
+/** What the backfill managed, and what it refused to guess at. */
+export interface DepositBackfillStats {
+  /** Deposits given a bank account. */
+  linked: number
+  /** Deposits whose code names more than one bank account, left null. */
+  ambiguous: number
+  /** Deposits whose code names no bank account at all, left null. */
+  unmatched: number
+}
+
+/** What the backfill decided about one deposit. */
+export type LinkDecision = 'link' | 'ambiguous' | 'unmatched' | 'skip'
+
+/**
+ * Whether one deposit's posted code names an account to link it to. **Pure, and
+ * no database.**
+ *
+ * 🛑 **More than one candidate is `ambiguous`, never "pick the first".** A chart
+ * code names at most one GL account but MANY bank accounts - two current
+ * accounts both mapped to `1000 Checking` is ordinary. A guess here would attach
+ * the deposit to an account it never went into and then hand that wrong answer
+ * to the removal gate, which is worse than the null it replaces: null reads as
+ * "unknown", and the code - the fact that IS true - stays on the row and on the
+ * posted entry either way.
+ *
+ * Exported and pure so the rule is tested without a database, the way 118's
+ * `resolveLabel` is.
+ */
+export function resolveLinkDecision(
+  code: string | null | undefined,
+  candidates: readonly string[] | undefined
+): LinkDecision {
+  if (!code?.trim()) return 'skip'
+  if (!candidates || candidates.length === 0) return 'unmatched'
+  if (candidates.length > 1) return 'ambiguous'
+  return 'link'
+}
+
+/** Which defs and field the backfill works across. */
+interface BackfillTargets {
+  depositDefId: string
+  accountDefId: string
+  relationFieldId: string
+}
+
+/**
+ * Link every deposit whose posted code names EXACTLY ONE bank account.
+ *
+ * 🛑 **Through `UnifiedCrudHandler.bulkUpdate`, never a raw `FieldValue` insert.**
+ * A relationship is TWO rows - the owning side on the deposit and the inverse on
+ * the account - and only the handler writes both. A hand-rolled insert of the
+ * owning row alone leaves `bank_account.deposits` reading empty, which is
+ * exactly the surface the removal gate is about to depend on. It is also one
+ * write session, one permission assertion and one cache warm for the whole set
+ * rather than per row.
+ *
+ * Exported so the selection can be exercised on its own, the way 134's backfill is.
+ */
+export async function backfillDepositBankAccount(
+  db: Database,
+  organizationId: string,
+  targets: BackfillTargets
+): Promise<DepositBackfillStats> {
+  const stats: DepositBackfillStats = { linked: 0, ambiguous: 0, unmatched: 0 }
+
+  const codeField = await findFieldByAttribute(db, organizationId, CODE_ATTRIBUTE)
+  const glField = await findFieldByAttribute(db, organizationId, GL_ACCOUNT_ATTRIBUTE)
+  if (!codeField || !glField) return stats
+
+  // 🛑 LIVE deposits only. An archived deposit is one whose posting the ledger
+  // refused - `rollbackDeposit` archives it - so there is nothing to put in the
+  // gate, and `bulkUpdate` refuses it as "Entity not found" anyway. Without this
+  // filter the backfill re-attempts them on EVERY run, logs an error per row,
+  // and reports a `linked` count that does not add up to the candidates it took.
+  const deposits = await db
+    .select({ entityId: schema.FieldValue.entityId, code: schema.FieldValue.valueText })
+    .from(schema.FieldValue)
+    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, codeField),
+        isNotNull(schema.FieldValue.valueText),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+  if (deposits.length === 0) return stats
+
+  // Skip anything already linked: this migration is re-runnable, and a deposit
+  // corrected by hand after an ambiguous first pass must not be overwritten.
+  const present = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, targets.relationFieldId),
+        inArray(
+          schema.FieldValue.entityId,
+          deposits.map((row) => row.entityId)
+        )
+      )
+    )
+  const alreadyLinked = new Set(present.map((row) => row.entityId))
+
+  const accountsByCode = await mapAccountsByCode(db, organizationId, glField)
+
+  const updates: { recordId: ReturnType<typeof toRecordId>; values: Record<string, unknown> }[] = []
+  for (const deposit of deposits) {
+    if (alreadyLinked.has(deposit.entityId)) continue
+    const code = deposit.code?.trim()
+    const candidates = code ? accountsByCode.get(code) : undefined
+    const decision = resolveLinkDecision(code, candidates)
+    if (decision === 'skip') continue
+    if (decision === 'unmatched') {
+      stats.unmatched++
+      continue
+    }
+    if (decision === 'ambiguous') {
+      stats.ambiguous++
+      continue
+    }
+    updates.push({
+      recordId: toRecordId(targets.depositDefId, deposit.entityId),
+      values: {
+        bank_deposit_bank_account_record: toRecordId(targets.accountDefId, candidates![0]!),
+      },
+    })
+  }
+  if (updates.length === 0) return stats
+
+  const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+  const handler = new UnifiedCrudHandler(organizationId, systemUserId, db, undefined, {
+    session: seedSession('bank deposit bank account backfill'),
+  })
+  const result = await handler.bulkUpdate(updates)
+  stats.linked = result.updated
+  // ⚠️ Reported, not thrown. A deposit that would not take the link is one row
+  // left where it already was - with its code intact - and failing the whole
+  // migration over it would leave the field half-created for every other org.
+  for (const failure of result.errors) {
+    logger.error('Migration 135 could not link a deposit to its bank account', {
+      organizationId,
+      recordId: failure.recordId,
+      error: failure.error,
+    })
+  }
+  return stats
+}
+
+/**
+ * Every LIVE bank account in the org, bucketed by the chart code it is mapped to.
+ *
+ * A LIST per code, not one account: several bank accounts legitimately share a
+ * mapping, and collapsing them here is how the backfill would come to guess.
+ *
+ * 🛑 Archived accounts are excluded, and that is not a tidiness choice.
+ * `createBankDeposit` REFUSES to bank into an archived account, so an archived
+ * account is not a thing a deposit can be linked to - counting one as a
+ * candidate only makes a code ambiguous that has exactly one real answer, and
+ * the deposit then stays unlinked and outside the removal gate. Found on dev,
+ * where an archived duplicate left by a drive script shared `1000` with the
+ * account every deposit had actually gone into.
+ */
+async function mapAccountsByCode(
+  db: Database,
+  organizationId: string,
+  glFieldId: string
+): Promise<Map<string, string[]>> {
+  const mappings = await db
+    .select({ accountId: schema.FieldValue.entityId, code: schema.FieldValue.valueText })
+    .from(schema.FieldValue)
+    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, glFieldId),
+        isNotNull(schema.FieldValue.valueText),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+
+  const byCode = new Map<string, string[]>()
+  for (const row of mappings) {
+    const code = row.code?.trim()
+    if (!code) continue
+    const bucket = byCode.get(code)
+    if (bucket) bucket.push(row.accountId)
+    else byCode.set(code, [row.accountId])
+  }
+  return byCode
+}
+
+/** One `CustomField.id` by its `systemAttribute`, or null when the org lacks it. */
+async function findFieldByAttribute(
+  db: Database,
+  organizationId: string,
+  systemAttribute: string
+): Promise<string | null> {
+  const [row] = await db
+    .select({ id: schema.CustomField.id })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.systemAttribute, systemAttribute)
+      )
+    )
+    .limit(1)
+  return row?.id ?? null
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -715,7 +715,8 @@ export const SYSTEM_ATTRIBUTES = [
   // together once the `bank_transaction` def exists.
   'bank_deposit_number', // RecordSequence `DEP-0001`; the posting's docNumber keys on it
   'bank_deposit_date', // THE accounting date
-  'bank_deposit_bank_account', // GL account CODE; becomes a relationship with `bank_account`
+  'bank_deposit_bank_account', // the GL account CODE the entry POSTED to, frozen at build time
+  'bank_deposit_bank_account_record', // the bank account it was banked INTO; belongs_to bank_account
   'bank_deposit_reference',
   'bank_deposit_status', // pending | cleared
   'bank_deposit_total', // integer minor units; must equal the sum of the payments
@@ -779,6 +780,7 @@ export const SYSTEM_ATTRIBUTES = [
   // (plans/bank-connection/08-removing-a-bank-account.md §5.1)
   'bank_account_has_posted',
   'bank_account_transactions', // inverse of bank_transaction_bank_account
+  'bank_account_deposits', // inverse of bank_deposit_bank_account_record
 
   // Connector-owned (raw). The feed may correct any of these.
   'bank_transaction_external_id', // the dedupe key, across BOTH the feed and file import


### PR DESCRIPTION
Closes **D3, D4 and D5** in `plans/bank-connection/09-data-connector-debt.md`. (That file and the `08`/`02` updates are in `plans/`, which is gitignored, so the reasoning lives locally rather than in this diff.)

## D5 is the substance, and it is not what the plan asked for

`bank_deposit_bank_account` held a GL account **code** (`'1000'`). The registry has said since migration 125 that a later migration converts it to a relationship. **This does not convert it — it adds the relationship beside it**, because the two are different facts:

| | means | mutable? |
|---|---|---|
| `bankAccount` (new, `belongs_to`) | which account the money was banked **into** | the truth; what the removal gate reads |
| `bankAccountCode` (existing) | which chart account the entry **posted to** | frozen when the entry was built |

**Neither is derivable from the other**, which is why converting would have been wrong in both directions:

- `bank_account_gl_account` is the one field on a bank account with **no guard at all** (`banking/writes.ts:255` — not even the connected-account refusal). Deriving the code from the relationship means remapping an account silently restates every deposit that already posted to the old code: the slip says `1015`, the `GlPosting` says `1000`, nothing flags it. Same rule `08` §3(1) states about `GlPostingLine` snapshotting code and name with no FK to the instance.
- Deriving the relationship from the code cannot be done at all. Several bank accounts legitimately map to one chart code — in the first org that had deposits, **three** shared the `1000` all its deposits carried.

## The API change is the actual fix

`createBankDeposit` now takes a **bank account id**, not a code. The feed posts every line on an account against that account's mapping, so a freely-chosen code puts the deposit and the statement line it exists to match into two different accounts — and nothing downstream catches it, because match candidates are found by amount and date. The deposits page already worked this way; the API accepting a bare code was the hole.

## The removal gate gains no term

A posted deposit stamps `bank_account_has_posted`, the write-once mark a posted bank line already stamps. So `08` §5.1's "ONE term decides" still holds. **Behaviour change: an account with a posted deposit now archives rather than deletes.**

## Migration 135

Creates both halves of the pair, relabels the code field to "Bank Account Code", and backfills **only where a code names exactly one live bank account**. It refuses to guess — a wrong link hands the gate a wrong answer, which is worse than the null it replaces, since the code stays on the row and on the entry either way.

Three ordering/correctness constraints, each found by running it rather than reading it:

1. **The relabel runs before the field is created.** `CustomField` is unique on `(name, org, modelType, entityDefinitionId)` and the new field is labelled "Bank Account" — the name the code field still held. Creating first is a 23505 on every org.
2. **The backfill goes through `UnifiedCrudHandler.bulkUpdate`, not a raw `FieldValue` insert.** A relationship is *two* rows; only the handler writes the inverse. A hand-rolled insert leaves `bank_account.deposits` empty — exactly the surface the gate depends on.
3. **Archived rows are excluded on both sides.** An archived account cannot be banked into, so counting one makes a code ambiguous that has one real answer; an archived deposit is a rolled-back one, and attempting it makes `bulkUpdate` log an error every run.

## D3 and D4

- **D3** — the `Credential.type` Phase 2 coupling is named in the reaper's predicate *and* in the column's own schema comment. That predicate only ever **narrows**, so a stale match reports a healthy sweep releasing nothing while every account keeps billing.
- **D4** — the bespoke FC webhook is recorded as a deviation, not changed. An FC event carries no records, so the engine's record-delivery trigger would mean inventing one.

## Verification

- Full `@auxx/lib` suite green on this tree: **1233 files, 17345 tests, exit 0**. Typecheck ratchet clean for `lib` and `web`. Lint clean.
- Migration 135 ran over **28 dev orgs**, reported `0 changed` on re-run, both halves linked in every org.
- The backfill's **link** path is exercised, not just its refusal: it linked DEP-0001/DEP-0002 to the right account and wrote both sides.
- `drive-bank-deposit.ts` drove a deposit end to end; the result carried the owning row, the inverse row, and `bank_account_has_posted: true`.

## Not done

**The deposits page has not been clicked.** The mutation payload changed from `bankAccountCode` to `bankAccountId`; types agree and the server path is driven, but the UI itself is unexercised. Worth a manual pass before merge.

Deposits recorded before 135 whose code was ambiguous carry no link and are outside the gate until someone says which account they went into.

https://claude.ai/code/session_01C6C187t31Sd5hMxmmbUuG2
