### PR TITLE
feat(apps): author connection variable types in the developer portal

### DIFF
--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-dialog.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-dialog.tsx
@@ -1,7 +1,8 @@
 // apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-dialog.tsx
 'use client'
 
-import type { ConnectionVariable } from '@auxx/database'
+import type { ConnectionVariable, ConnectionVariableOption } from '@auxx/database'
+import { FieldType } from '@auxx/database/enums'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -20,11 +21,133 @@ import {
 import { Field, FieldDescription, FieldLabel } from '@auxx/ui/components/field'
 import { Input } from '@auxx/ui/components/input'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
 import { Switch } from '@auxx/ui/components/switch'
 import { TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { Edit2, Lock, Plus, Trash2, Variable, X } from 'lucide-react'
 import { useState } from 'react'
 import { toastError } from '~/components/global/toast'
+import { ConnectionVariableOptionsEditor } from './connection-variable-options-editor'
+
+/** Validation constraints as edited here: the `validation` bag of a `ConnectionVariable`. */
+type VariableValidation = NonNullable<ConnectionVariable['validation']>
+
+/**
+ * The four platform field types a connection variable may carry. Masking is the `secret`
+ * flag and multiline is the `multiline` flag, neither is a type. An absent `type` means
+ * TEXT, which is why TEXT is never written to the row.
+ */
+const VARIABLE_TYPES = [
+  { value: FieldType.TEXT, label: 'Text' },
+  { value: FieldType.NUMBER, label: 'Number' },
+  { value: FieldType.CHECKBOX, label: 'Checkbox' },
+  { value: FieldType.SINGLE_SELECT, label: 'Single select' },
+] as const
+
+/** The four `FieldType` members a connection variable may carry. */
+export type ConnectionVariableType = (typeof VARIABLE_TYPES)[number]['value']
+
+type VariableType = ConnectionVariableType
+
+/**
+ * A `ConnectionVariable` as the developer portal authors it: identical to the stored shape
+ * except `type` is narrowed to the four renderable types, matching the router's `z.enum`.
+ */
+export type PortalConnectionVariable = Omit<ConnectionVariable, 'type'> & {
+  type?: ConnectionVariableType
+}
+
+/**
+ * Narrow stored variables to the portal's authorable shape. A `type` outside the four
+ * renderable members is out of contract (see `ConnectionVariable`'s doc comment) and is
+ * dropped, which every renderer reads as TEXT.
+ */
+export function toPortalVariables(variables: ConnectionVariable[]): PortalConnectionVariable[] {
+  return variables.map(({ type, ...rest }) => {
+    const authorable = VARIABLE_TYPES.find((t) => t.value === type)
+    return authorable ? { ...rest, type: authorable.value } : rest
+  })
+}
+
+/** Empty form state for a brand-new variable (a plain required TEXT input). */
+function emptyVariable(): PortalConnectionVariable {
+  return {
+    key: '',
+    label: '',
+    description: '',
+    placeholder: '',
+    required: true,
+    secret: false,
+    type: FieldType.TEXT,
+  }
+}
+
+/** Parse a numeric input back to a number, treating a blank box as "no constraint". */
+function toNumberOrUndefined(raw: string): number | undefined {
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+/** Render a numeric constraint for its input, blank when unset. */
+function numberInputValue(value: number | undefined): string {
+  return value === undefined ? '' : String(value)
+}
+
+/**
+ * Keep only the constraints that mean something for `type`, and drop the bag entirely
+ * when nothing is left, so a variable with no rules serialises without a `validation` key.
+ */
+function cleanValidation(
+  type: VariableType,
+  validation: VariableValidation | undefined
+): VariableValidation | undefined {
+  if (!validation) return undefined
+  const cleaned: VariableValidation = {}
+
+  if (type === FieldType.TEXT) {
+    if (validation.minLength !== undefined) cleaned.minLength = validation.minLength
+    if (validation.maxLength !== undefined) cleaned.maxLength = validation.maxLength
+    const pattern = validation.pattern?.trim()
+    if (pattern) {
+      cleaned.pattern = pattern
+      const message = validation.message?.trim()
+      if (message) cleaned.message = message
+    }
+  }
+
+  if (type === FieldType.NUMBER) {
+    // `port` is a complete range on its own (1-65535), so it replaces min/max rather
+    // than stacking with them, which is also why the form disables those inputs.
+    if (validation.port) {
+      cleaned.port = true
+    } else {
+      if (validation.min !== undefined) cleaned.min = validation.min
+      if (validation.max !== undefined) cleaned.max = validation.max
+    }
+  }
+
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined
+}
+
+/** Trim a select's choices and drop rows the author left completely blank. */
+function cleanOptions(options: ConnectionVariableOption[] | undefined) {
+  return (options ?? [])
+    .map((opt) => ({
+      ...(opt.id ? { id: opt.id } : {}),
+      label: opt.label.trim(),
+      value: opt.value.trim(),
+    }))
+    .filter((opt) => opt.label || opt.value)
+    .map((opt) => ({ ...opt, label: opt.label || opt.value }))
+}
 
 /** Variable definition item row */
 function VariableDefinitionItem({
@@ -32,7 +155,7 @@ function VariableDefinitionItem({
   onEdit,
   onDelete,
 }: {
-  variable: ConnectionVariable
+  variable: PortalConnectionVariable
   onEdit: () => void
   onDelete: () => void
 }) {
@@ -43,6 +166,11 @@ function VariableDefinitionItem({
         <div className='flex items-center gap-2'>
           <span className='text-sm font-medium'>{variable.label}</span>
           {variable.secret && <Lock className='size-3 text-muted-foreground' />}
+          {variable.type && variable.type !== FieldType.TEXT && (
+            <span className='rounded-md bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground'>
+              {VARIABLE_TYPES.find((t) => t.value === variable.type)?.label ?? variable.type}
+            </span>
+          )}
           {variable.required !== false && (
             <span className='text-xs text-muted-foreground'>required</span>
           )}
@@ -76,30 +204,24 @@ export function ConnectionVariableDialog({
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
-  variables: ConnectionVariable[]
-  onChange: (variables: ConnectionVariable[]) => void
+  variables: PortalConnectionVariable[]
+  onChange: (variables: PortalConnectionVariable[]) => void
 }) {
   const [isEditing, setIsEditing] = useState(false)
   const [editingIndex, setEditingIndex] = useState<number | null>(null)
-  const [formData, setFormData] = useState<ConnectionVariable>({
-    key: '',
-    label: '',
-    description: '',
-    placeholder: '',
-    required: true,
-    secret: false,
-  })
+  const [formData, setFormData] = useState<PortalConnectionVariable>(emptyVariable())
+
+  // An existing variable with no stored `type` is a TEXT variable (that is how every
+  // renderer reads it), so the picker resolves an absent type rather than showing blank.
+  const currentType = (formData.type ?? FieldType.TEXT) as VariableType
+  const validation = formData.validation
+
+  const setValidation = (patch: Partial<VariableValidation>) =>
+    setFormData((prev) => ({ ...prev, validation: { ...prev.validation, ...patch } }))
 
   const handleAdd = () => {
     setEditingIndex(null)
-    setFormData({
-      key: '',
-      label: '',
-      description: '',
-      placeholder: '',
-      required: true,
-      secret: false,
-    })
+    setFormData(emptyVariable())
     setIsEditing(true)
   }
 
@@ -141,14 +263,49 @@ export function ConnectionVariableDialog({
       return
     }
 
+    const options = cleanOptions(formData.options)
+    if (currentType === FieldType.SINGLE_SELECT) {
+      if (options.length === 0) {
+        toastError({
+          title: 'Options required',
+          description: 'A single-select variable needs at least one option.',
+        })
+        return
+      }
+      if (options.some((opt) => !opt.value)) {
+        toastError({
+          title: 'Option value required',
+          description: 'Every option needs a value: it is what the connection stores.',
+        })
+        return
+      }
+      const duplicateValue = options.find(
+        (opt, i) => options.findIndex((other) => other.value === opt.value) !== i
+      )
+      if (duplicateValue) {
+        toastError({
+          title: 'Duplicate option value',
+          description: `More than one option uses the value "${duplicateValue.value}".`,
+        })
+        return
+      }
+    }
+
     const updated = [...variables]
-    const cleanedData: ConnectionVariable = {
+    // Conditional spreads keep the stored shape minimal: a plain TEXT variable serialises
+    // exactly as it did before typing existed, and every reader treats an absent `type` as TEXT.
+    const cleanedValidation = cleanValidation(currentType, formData.validation)
+    const cleanedData: PortalConnectionVariable = {
       key: formData.key,
       label: formData.label.trim(),
       ...(formData.description?.trim() && { description: formData.description.trim() }),
       ...(formData.placeholder?.trim() && { placeholder: formData.placeholder.trim() }),
       ...(formData.required === false && { required: false }),
       ...(formData.secret && { secret: true }),
+      ...(currentType !== FieldType.TEXT && { type: currentType }),
+      ...(currentType === FieldType.SINGLE_SELECT && options.length > 0 && { options }),
+      ...(currentType === FieldType.TEXT && formData.multiline === true && { multiline: true }),
+      ...(cleanedValidation && { validation: cleanedValidation }),
     }
 
     if (editingIndex !== null) {
@@ -258,6 +415,37 @@ export function ConnectionVariableDialog({
               </div>
 
               <Field>
+                <FieldLabel htmlFor='cv-type'>Type</FieldLabel>
+                <Select
+                  value={currentType}
+                  onValueChange={(value) =>
+                    setFormData({ ...formData, type: value as VariableType })
+                  }>
+                  <SelectTrigger id='cv-type'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VARIABLE_TYPES.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FieldDescription>
+                  Picks the control the connection form renders. Masking is the Secret switch, not a
+                  type.
+                </FieldDescription>
+              </Field>
+
+              {currentType === FieldType.SINGLE_SELECT && (
+                <ConnectionVariableOptionsEditor
+                  options={formData.options}
+                  onChange={(options) => setFormData({ ...formData, options })}
+                />
+              )}
+
+              <Field>
                 <FieldLabel htmlFor='cv-description'>Description</FieldLabel>
                 <Input
                   id='cv-description'
@@ -298,7 +486,127 @@ export function ConnectionVariableDialog({
                     side='right'
                   />
                 </div>
+                {currentType === FieldType.TEXT && (
+                  <div className='flex items-center gap-2'>
+                    <Switch
+                      id='cv-multiline'
+                      checked={formData.multiline ?? false}
+                      onCheckedChange={(checked) =>
+                        setFormData({ ...formData, multiline: checked })
+                      }
+                    />
+                    <FieldLabel htmlFor='cv-multiline'>Multiline</FieldLabel>
+                    <TooltipExplanation
+                      text='Render the input as an autosizing textarea. Use for pasted values like an SSH private key.'
+                      side='right'
+                    />
+                  </div>
+                )}
               </div>
+
+              {currentType === FieldType.TEXT && (
+                <div className='space-y-3 rounded-lg border bg-background px-2 py-2'>
+                  <span className='text-sm font-medium'>Validation</span>
+                  <div className='grid grid-cols-2 gap-3'>
+                    <Field>
+                      <FieldLabel htmlFor='cv-min-length'>Min length</FieldLabel>
+                      <Input
+                        id='cv-min-length'
+                        type='number'
+                        min={0}
+                        value={numberInputValue(validation?.minLength)}
+                        onChange={(e) =>
+                          setValidation({ minLength: toNumberOrUndefined(e.target.value) })
+                        }
+                        placeholder='0'
+                      />
+                    </Field>
+                    <Field>
+                      <FieldLabel htmlFor='cv-max-length'>Max length</FieldLabel>
+                      <Input
+                        id='cv-max-length'
+                        type='number'
+                        min={0}
+                        value={numberInputValue(validation?.maxLength)}
+                        onChange={(e) =>
+                          setValidation({ maxLength: toNumberOrUndefined(e.target.value) })
+                        }
+                        placeholder='255'
+                      />
+                    </Field>
+                  </div>
+                  <Field>
+                    <FieldLabel htmlFor='cv-pattern'>Pattern</FieldLabel>
+                    <Input
+                      id='cv-pattern'
+                      value={validation?.pattern ?? ''}
+                      onChange={(e) => setValidation({ pattern: e.target.value })}
+                      placeholder='^[a-z0-9-]+$'
+                      className='font-mono'
+                    />
+                    <FieldDescription>
+                      Regular expression the value must match. Leave blank for no pattern.
+                    </FieldDescription>
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor='cv-message'>Pattern message</FieldLabel>
+                    <Input
+                      id='cv-message'
+                      value={validation?.message ?? ''}
+                      onChange={(e) => setValidation({ message: e.target.value })}
+                      placeholder='Use lowercase letters, numbers and dashes.'
+                      disabled={!validation?.pattern?.trim()}
+                    />
+                    <FieldDescription>Shown when the pattern does not match.</FieldDescription>
+                  </Field>
+                </div>
+              )}
+
+              {currentType === FieldType.NUMBER && (
+                <div className='space-y-3 rounded-lg border bg-background px-2 py-2'>
+                  <span className='text-sm font-medium'>Validation</span>
+                  <div className='grid grid-cols-2 gap-3'>
+                    <Field>
+                      <FieldLabel htmlFor='cv-min'>Minimum</FieldLabel>
+                      <Input
+                        id='cv-min'
+                        type='number'
+                        value={numberInputValue(validation?.min)}
+                        onChange={(e) =>
+                          setValidation({ min: toNumberOrUndefined(e.target.value) })
+                        }
+                        placeholder='0'
+                        disabled={validation?.port === true}
+                      />
+                    </Field>
+                    <Field>
+                      <FieldLabel htmlFor='cv-max'>Maximum</FieldLabel>
+                      <Input
+                        id='cv-max'
+                        type='number'
+                        value={numberInputValue(validation?.max)}
+                        onChange={(e) =>
+                          setValidation({ max: toNumberOrUndefined(e.target.value) })
+                        }
+                        placeholder='100'
+                        disabled={validation?.port === true}
+                      />
+                    </Field>
+                  </div>
+                  <div className='flex items-center gap-2'>
+                    <Switch
+                      id='cv-port'
+                      checked={validation?.port ?? false}
+                      onCheckedChange={(checked) => setValidation({ port: checked })}
+                    />
+                    <FieldLabel htmlFor='cv-port'>TCP port</FieldLabel>
+                    <TooltipExplanation
+                      text='Validate the value as a TCP port (1-65535) instead of a custom range.'
+                      side='right'
+                    />
+                  </div>
+                </div>
+              )}
 
               <div className='flex gap-2 justify-end'>
                 <Button variant='ghost' size='sm' onClick={handleCancel}>

--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-options-editor.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-options-editor.tsx
@@ -1,0 +1,86 @@
+// apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-options-editor.tsx
+'use client'
+
+import type { ConnectionVariableOption } from '@auxx/database'
+import { Button } from '@auxx/ui/components/button'
+import { Input } from '@auxx/ui/components/input'
+import { PlusCircle, Trash2 } from 'lucide-react'
+
+/**
+ * Editor for a `SINGLE_SELECT` connection variable's choices: add, edit, remove.
+ *
+ * Fully controlled: `options` is rendered directly and every edit is pushed up through
+ * `onChange`. Unlike the org-side custom-field editor, both `label` and `value` are
+ * editable here: a connection option is authored against the provider's own vocabulary
+ * (an API region, a plan name), so the submitted `value` is the developer's to choose.
+ * An `id` on an existing option is preserved verbatim.
+ */
+export function ConnectionVariableOptionsEditor({
+  options,
+  onChange,
+}: {
+  options?: ConnectionVariableOption[]
+  onChange: (options: ConnectionVariableOption[]) => void
+}) {
+  const items = Array.isArray(options) ? options : []
+
+  const addOption = () => onChange([...items, { label: '', value: '' }])
+
+  const updateOption = (index: number, patch: Partial<ConnectionVariableOption>) =>
+    onChange(items.map((opt, i) => (i === index ? { ...opt, ...patch } : opt)))
+
+  const removeOption = (index: number) => onChange(items.filter((_, i) => i !== index))
+
+  return (
+    <div className='rounded-lg border bg-background px-2 py-2 space-y-2'>
+      <div className='flex items-center justify-between'>
+        <span className='text-sm font-medium'>
+          Options <span className='text-red-500'>*</span>
+        </span>
+        <Button type='button' variant='ghost' size='sm' onClick={addOption}>
+          <PlusCircle />
+          Add Option
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <p className='px-1 text-sm text-muted-foreground'>No options added yet.</p>
+      ) : (
+        <div className='space-y-2'>
+          {items.map((option, index) => (
+            // A connection option has no stable identity while it is being typed
+            // (its `value` is editable), so the row index is the key.
+            <div key={`option-${index}`} className='flex items-center gap-2'>
+              <Input
+                value={option.label}
+                onChange={(e) => updateOption(index, { label: e.target.value })}
+                placeholder='Label'
+                aria-label={`Option ${index + 1} label`}
+              />
+              <Input
+                value={option.value}
+                onChange={(e) => updateOption(index, { value: e.target.value })}
+                placeholder='value'
+                className='font-mono'
+                aria-label={`Option ${index + 1} value`}
+              />
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon-sm'
+                className='text-destructive hover:text-destructive'
+                aria-label={`Remove option ${index + 1}`}
+                onClick={() => removeOption(index)}>
+                <Trash2 />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <p className='px-1 text-xs text-muted-foreground'>
+        The label is shown in the dropdown; the value is what the connection stores.
+      </p>
+    </div>
+  )
+}

--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
@@ -58,7 +58,11 @@ import { z } from 'zod'
 import { toastError } from '~/components/global/toast'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
-import { ConnectionVariableDialog } from './connection-variable-dialog'
+import {
+  ConnectionVariableDialog,
+  type PortalConnectionVariable,
+  toPortalVariables,
+} from './connection-variable-dialog'
 
 /** Slugish method key: lowercase letters/digits/underscore, e.g. 'api_key', 'oauth2'. */
 const KEY_PATTERN = /^[a-z0-9_]+$/
@@ -421,7 +425,7 @@ function MethodEditor({
   } = form
 
   const [showAdvanced, setShowAdvanced] = useState(false)
-  const [connectionVariables, setConnectionVariables] = useState<ConnectionVariable[]>([])
+  const [connectionVariables, setConnectionVariables] = useState<PortalConnectionVariable[]>([])
   const [variableDialogOpen, setVariableDialogOpen] = useState(false)
   const [variablesDirty, setVariablesDirty] = useState(false)
   // Eye toggle flips the input type; it only ever exposes the mask (or what the user typed).
@@ -494,7 +498,9 @@ function MethodEditor({
       })
 
       // Connection variables are a top-level column (shared by oauth2-code and secret)
-      setConnectionVariables((connection.connectionVariables as ConnectionVariable[]) ?? [])
+      setConnectionVariables(
+        toPortalVariables((connection.connectionVariables as ConnectionVariable[]) ?? [])
+      )
 
       // Auto-open advanced section if any advanced field has a value
       if (
@@ -572,7 +578,7 @@ function MethodEditor({
     return keys.filter((k) => !connectionVariables.some((v) => v.key === k))
   }, [mintsToken, authorizeUrl, tokenUrl, clientId, clientSecret, connectionVariables])
 
-  const handleVariablesChange = (vars: ConnectionVariable[]) => {
+  const handleVariablesChange = (vars: PortalConnectionVariable[]) => {
     setConnectionVariables(vars)
     setVariablesDirty(true)
   }

--- a/apps/build/src/server/api/routers/connections.ts
+++ b/apps/build/src/server/api/routers/connections.ts
@@ -46,6 +46,40 @@ const authApplySchema = z.union([
   }),
 ])
 
+/**
+ * One dynamic variable the org supplies at connect time (mirror of the `ConnectionVariable`
+ * column type). `z.object` strips unknown keys, so every authorable field must be declared
+ * here or the portal's edit silently loses it in transit.
+ *
+ * `type` is deliberately narrower than `FieldType`: only these four are meaningful for a
+ * connection variable. Masking is `secret` and multiline is `multiline`, neither is a type.
+ * `default`, `rows` and `displayOptions` are omitted because the portal cannot author them.
+ */
+const connectionVariableSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  placeholder: z.string().optional(),
+  required: z.boolean().optional(),
+  secret: z.boolean().optional(),
+  type: z.enum(['TEXT', 'NUMBER', 'CHECKBOX', 'SINGLE_SELECT']).optional(),
+  options: z
+    .array(z.object({ id: z.string().optional(), label: z.string(), value: z.string() }))
+    .optional(),
+  multiline: z.boolean().optional(),
+  validation: z
+    .object({
+      minLength: z.number().optional(),
+      maxLength: z.number().optional(),
+      min: z.number().optional(),
+      max: z.number().optional(),
+      port: z.boolean().optional(),
+      pattern: z.string().optional(),
+      message: z.string().optional(),
+    })
+    .optional(),
+})
+
 /** Fetch the app and assert the caller is a member of its developer account. */
 async function getAppForMember(db: typeof database, appId: string, userId: string) {
   const [app] = await db.select().from(App).where(eq(App.id, appId)).limit(1)
@@ -156,18 +190,7 @@ const methodFields = {
       callbackMetadataParams: z.array(z.string()).optional(),
     })
     .optional(),
-  connectionVariables: z
-    .array(
-      z.object({
-        key: z.string(),
-        label: z.string(),
-        description: z.string().optional(),
-        placeholder: z.string().optional(),
-        required: z.boolean().optional(),
-        secret: z.boolean().optional(),
-      })
-    )
-    .optional(),
+  connectionVariables: z.array(connectionVariableSchema).optional(),
   // How the resolved credential becomes request auth (null for `none`/non-HTTP methods).
   authApply: authApplySchema.nullable().optional(),
   // Base-URL template the connection contributes to a request origin, interpolated from


### PR DESCRIPTION
## What

The developer portal's **Define Variables** dialog can now set a connection variable's `type`, `options`, `multiline` and `validation`. Before, it could only set six of the schema's fields, so every portal-authored variable was a plain text box.

## Why this was worth doing

A `ConnectionVariable` has always supported these, and the org-side connect form has always rendered them — `connection-variable-fields.tsx` maps all four field types, coerces a CHECKBOX both ways, passes `options` / `multiline` / `pattern`, and `validateValue` enforces the length and range rules.

The proof it works is in the data:

| authored by | variables | **typed** | with `options` |
| --- | --- | --- | --- |
| platform providers, in code (`defs.ts`) | 83 | **18** | 4 |
| **app-owned, through the portal** | 6 | **0** | **0** |

Postgres declares `sshAuthenticateWith` as a SINGLE_SELECT and `ssl` as another; IMAP and SMTP declare `secure` as a CHECKBOX and `port` as a NUMBER. Same schema an app definition uses — just written in a file instead of a form.

So an app author who wanted a boolean got a free-text box the org fills in with the word `true`, and reached for `Settings.boolean()` instead — which is scoped to the *installation*, stores plaintext, and has nothing reacting when it changes. **FedEx is the tell**: the same app declares its client id and secret correctly as connection variables, and its environment flag as an app setting.

## Two doors, and fixing either alone changes nothing

1. `connection-variable-dialog.tsx` assembled `{ key, label, description?, placeholder?, required?, secret? }` and stopped.
2. `connections.ts`'s `connectionVariables` zod object declared **the same six keys** — and `z.object` strips unknown keys, so a fixed dialog would have had `type` **silently dropped in transit**.

Both now carry the new fields.

## Design notes

- **Backwards compatible.** The type picker defaults to TEXT and TEXT is never written, so all 89 existing variables round-trip byte-identical; the connect form already reads an absent type as TEXT.
- **Options editor** is local to `apps/build` (it can't import from `apps/web`), modelled on the org-side one. Both label and value are editable; a connection option has no colour, so no colour picker. An existing `id` is preserved.
- **Conditional UI** — options for SINGLE_SELECT, multiline and length rules for TEXT, numeric rules for NUMBER, nothing for CHECKBOX.
- 🛑 **`default` and `rows` are deliberately left out.** They are in the schema and read by nothing, so authoring them would create controls that silently do nothing — the exact failure mode this change exists to end. `displayOptions.show` is deferred; it needs a key-to-allowed-values editor rather than another input.
- `page.tsx` holds a `PortalConnectionVariable` (the stored shape with `type` narrowed to the four renderable members) to match the router's enum. Consequence: a stored `type` outside those four would be dropped on save. In contract per `ConnectionVariable`'s own doc comment, and app-owned definitions have none.

## Driven

Added `sandbox` as a CHECKBOX on the QuickBooks connect method. `type: CHECKBOX` reached the column, and the org-side connect dialog renders the toggle — confirmed in a browser.

Worth knowing: `shouldOpenConnectDialog` opens on *any* declared variable, so a method that previously went straight to OAuth now prompts first. No web change was needed for that.

## Checks

- `apps/build` has no `typecheck` script — ran `node ../../node_modules/typescript7/bin/tsc --noEmit`, **exit 0**
- `biome check` on all four files, **exit 0**

## Context

This is step 2 of `plans/apps/app-settings/connection-scoped-config.md` — moving connection facts and secrets out of `AppSetting` (installation-scoped, plaintext, no secret type) and onto the connection. The QuickBooks half is the companion PR in `auxxai-apps`.

https://claude.ai/code/session_01Y7HbeooGrtZMEaqrJkXpdD