### PR TITLE
feat(banking): put the bank-account selection and Show archived in the URL

### DIFF
--- a/apps/api/public/app-runtime/index.html
+++ b/apps/api/public/app-runtime/index.html
@@ -73,7 +73,7 @@
 
     <!-- Platform Runtime Bundle (same for ALL extensions) -->
     <!-- Hash is replaced during build: platform.{HASH}.js -->
-    <script src="/api/v1/app-runtime/platform.91ca73b8.js"></script>
+    <script src="/api/v1/app-runtime/platform.fb59f1ab.js"></script>
 
     <!-- Extension bundle will be loaded dynamically by platform runtime -->
   </body>

--- a/apps/web/src/components/accounting/ui/settings/bank-accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-accounts-settings-page.tsx
@@ -28,6 +28,7 @@
 import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { Lock } from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import { MasterDetailSplit } from '~/components/global/master-detail-split'
@@ -59,11 +60,20 @@ export function BankAccountsSettingsPage() {
   const { hasAccess } = useFeatureFlags()
   const utils = api.useUtils()
 
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  // 🛑 The row selection lives in the URL, like the chart's does on
+  // `settings/accounts`. This is the screen people are sent to ("map the
+  // checking account to 1010"), and a pane that vanishes on refresh cannot be
+  // linked to.
+  const [accountParam, setSelectedId] = useQueryState('account')
   const [manualOpen, setManualOpen] = useState(false)
   const [connectOpen, setConnectOpen] = useState(false)
   const [reconnectingId, setReconnectingId] = useState<string | null>(null)
-  const [showArchived, setShowArchived] = useState(false)
+  // In the URL too, for the same reason: "here is the archived one I mean" is a
+  // link somebody sends, and the row it names is not on the list without this.
+  const [showArchived, setShowArchived] = useQueryState(
+    'archived',
+    parseAsBoolean.withDefault(false)
+  )
   const [confirm, ConfirmDialog] = useConfirm()
 
   // 🛑 Archived rows are FETCHED always and filtered here, on the same query key
@@ -75,6 +85,14 @@ export function BankAccountsSettingsPage() {
     () => (showArchived ? rows : rows.filter((row) => !row.archivedAt)),
     [rows, showArchived]
   )
+
+  // 🛑 The param is only REJECTED once the list has arrived. Validating while
+  // the query is pending would drop the selection on every refresh - the URL is
+  // read before the data is, so the row it names does not exist yet.
+  const selectedId =
+    accountParam && (accounts.isPending || rows.some((row) => row.id === accountParam))
+      ? accountParam
+      : null
   // Selected from ALL rows, not the visible ones: archiving the open account
   // must leave its pane readable long enough to say what happened and offer the
   // restore, rather than blanking under the person who pressed the button.
@@ -173,7 +191,7 @@ export function BankAccountsSettingsPage() {
       setReconnectingId(null)
       if (accounts > 0) setSelectedId(null)
     },
-    [invalidate]
+    [invalidate, setSelectedId]
   )
 
   const handlePatch = useCallback(

--- a/packages/lib/scripts/probe-shopify-refunds.ts
+++ b/packages/lib/scripts/probe-shopify-refunds.ts
@@ -1,0 +1,332 @@
+// packages/lib/scripts/probe-shopify-refunds.ts
+//
+// Read-only probe for plans/money/tasks/47-shopify-refunds.md §3 and §0.3.
+//
+// Answers two questions the brief cannot be built without:
+//   1. Is the order history we hold complete, or did the backfill stop early?
+//      (`backfillComplete: false` with `phase: 'steady'` on the order stream)
+//   2. What does a real `refunds[]` payload actually contain - which legs are
+//      present, and is `restock_type` populated?
+//
+// 🛑 These are REAL customer orders under Shopify's Protected Customer Data
+// rules. This script prints SHAPES, COUNTS, IDS, AMOUNTS and DATES only. Every
+// field that can carry personal data is dropped by `safeKeys`, and no payload is
+// ever dumped wholesale. Do not "temporarily" print a raw order.
+//
+// Usage:
+//   npx dotenv -- npx tsx packages/lib/scripts/probe-shopify-refunds.ts
+//   SHOP=storage-system.myshopify.com npx dotenv -- npx tsx ...
+//   SHOPIFY_PROBE_TOKEN=shpat_... SHOP=... npx dotenv -- npx tsx ...   (skip DB lookup)
+
+import { decryptSecrets } from '@auxx/credentials'
+import { database as db, schema } from '@auxx/database'
+
+const API = process.env.SHOPIFY_PROBE_API_VERSION || '2024-10'
+const WANT_SHOP = process.env.SHOP || 'storage-system.myshopify.com'
+
+type Blob = Record<string, any>
+
+/** Personal-data keys that must never reach stdout, at any nesting level. */
+const PII = new Set([
+  'customer',
+  'email',
+  'contact_email',
+  'phone',
+  'billing_address',
+  'shipping_address',
+  'name',
+  'first_name',
+  'last_name',
+  'address1',
+  'address2',
+  'client_details',
+  'browser_ip',
+  'note',
+  'note_attributes',
+  'payment_details',
+  'customer_locale',
+  'landing_site',
+  'referring_site',
+  'checkout_token',
+  'token',
+  'cart_token',
+])
+
+/** Key names only, PII stripped - the whole point of this script. */
+function safeKeys(obj: unknown): string[] {
+  if (!obj || typeof obj !== 'object') return []
+  return Object.keys(obj as Blob)
+    .filter((k) => !PII.has(k))
+    .sort()
+}
+
+async function shopify(shop: string, token: string, path: string) {
+  const res = await fetch(`https://${shop}/admin/api/${API}${path}`, {
+    headers: { 'X-Shopify-Access-Token': token },
+  })
+  const text = await res.text()
+  let json: any = null
+  try {
+    json = JSON.parse(text)
+  } catch {}
+  return { status: res.status, json, text: text.slice(0, 300) }
+}
+
+async function resolveToken(): Promise<{ shop: string; token: string } | null> {
+  if (process.env.SHOPIFY_PROBE_TOKEN) {
+    return { shop: WANT_SHOP, token: process.env.SHOPIFY_PROBE_TOKEN }
+  }
+  const rows = await db.select().from(schema.Credential)
+  for (const row of rows) {
+    let blob: Blob = {}
+    try {
+      blob = decryptSecrets(row.encryptedSecrets)
+    } catch {
+      continue
+    }
+    const md = (row.metadata ?? {}) as Blob
+    const shop =
+      md.shopDomain ||
+      (md.connectionVariables?.shop ? `${md.connectionVariables.shop}.myshopify.com` : null) ||
+      (blob.metadata?.connectionVariables?.shop
+        ? `${blob.metadata.connectionVariables.shop}.myshopify.com`
+        : null)
+    const token = blob.accessToken || blob.access_token || blob.token
+    if (shop === WANT_SHOP && token) {
+      console.log(`credential ${row.id} org=${row.organizationId} shop=${shop}`)
+      return { shop, token }
+    }
+  }
+  return null
+}
+
+/** §0.3: is the order history we hold complete, or did the crawl stop early? */
+async function coverage(shop: string, token: string) {
+  console.log('\n=== 1. Coverage (task 47 section 0.3) ===')
+
+  const total = await shopify(shop, token, '/orders/count.json?status=any')
+  console.log(`  total orders at Shopify (status=any): ${total.json?.count ?? total.text}`)
+
+  const oldest = await shopify(
+    shop,
+    token,
+    '/orders.json?status=any&limit=1&order=created_at+asc&fields=id,order_number,created_at'
+  )
+  const o = oldest.json?.orders?.[0]
+  console.log(
+    o
+      ? `  oldest reachable order: #${o.order_number} created_at=${o.created_at}`
+      : `  oldest: ${oldest.text}`
+  )
+  console.log('  auxx holds 542 orders spanning 2026-07-06 to 2026-09-04.')
+  console.log('  If the oldest above predates 2026-07-06, the backfill stopped early.')
+}
+
+/** §3: what is actually inside `refunds[]`. */
+async function refundShape(shop: string, token: string) {
+  console.log('\n=== 2. Refund volume ===')
+  for (const status of ['refunded', 'partially_refunded', 'voided']) {
+    const c = await shopify(shop, token, `/orders/count.json?status=any&financial_status=${status}`)
+    console.log(`  financial_status=${status}: ${c.json?.count ?? c.text}`)
+  }
+
+  // Pull refunded orders directly rather than crawling everything.
+  const withRefunds: any[] = []
+  for (const status of ['refunded', 'partially_refunded']) {
+    const page = await shopify(
+      shop,
+      token,
+      `/orders.json?status=any&financial_status=${status}&limit=250`
+    )
+    for (const order of page.json?.orders ?? []) {
+      if ((order.refunds ?? []).length > 0) withRefunds.push(order)
+    }
+  }
+
+  console.log(`\n=== 3. Refund payload shape (${withRefunds.length} orders carrying refunds) ===`)
+  if (!withRefunds.length) {
+    console.log('  none returned - nothing further to inspect')
+    return
+  }
+
+  const dates = withRefunds
+    .flatMap((o) => (o.refunds ?? []).map((r: any) => r.created_at))
+    .filter(Boolean)
+    .sort()
+  console.log(`  refund dates span ${dates[0]} to ${dates[dates.length - 1]}`)
+
+  const refundKeys = new Set<string>()
+  const lineKeys = new Set<string>()
+  const txnKeys = new Set<string>()
+  const adjKeys = new Set<string>()
+  const restock = new Map<string, number>()
+  const txnKind = new Map<string, number>()
+  const adjKind = new Map<string, number>()
+  let refunds = 0
+  let withLines = 0
+  let withTxns = 0
+  let withAdjs = 0
+
+  for (const order of withRefunds) {
+    for (const r of order.refunds ?? []) {
+      refunds++
+      for (const k of safeKeys(r)) refundKeys.add(k)
+
+      const lines = r.refund_line_items ?? []
+      if (lines.length) withLines++
+      for (const li of lines) {
+        for (const k of safeKeys(li)) lineKeys.add(k)
+        const rt = String(li.restock_type ?? 'ABSENT')
+        restock.set(rt, (restock.get(rt) ?? 0) + 1)
+      }
+
+      const txns = r.transactions ?? []
+      if (txns.length) withTxns++
+      for (const t of txns) {
+        for (const k of safeKeys(t)) txnKeys.add(k)
+        const kind = `${t.kind ?? '?'}/${t.status ?? '?'}/${t.gateway ?? '?'}`
+        txnKind.set(kind, (txnKind.get(kind) ?? 0) + 1)
+      }
+
+      const adjs = r.order_adjustments ?? []
+      if (adjs.length) withAdjs++
+      for (const a of adjs) {
+        for (const k of safeKeys(a)) adjKeys.add(k)
+        const kind = String(a.kind ?? '?')
+        adjKind.set(kind, (adjKind.get(kind) ?? 0) + 1)
+      }
+    }
+  }
+
+  console.log(`\n  ${refunds} refund objects total`)
+  console.log(`  refund keys: [${[...refundKeys].join(', ')}]`)
+
+  console.log(`\n  -- leg 1: refund_line_items (present on ${withLines}/${refunds} refunds) --`)
+  console.log(`  keys: [${[...lineKeys].join(', ')}]`)
+  console.log('  restock_type distribution (G16 "disposition"):')
+  for (const [k, v] of [...restock].sort((a, b) => b[1] - a[1])) console.log(`    ${k}: ${v}`)
+
+  console.log(`\n  -- leg 2: transactions (present on ${withTxns}/${refunds} refunds) --`)
+  console.log(`  keys: [${[...txnKeys].join(', ')}]`)
+  for (const [k, v] of [...txnKind].sort((a, b) => b[1] - a[1])) console.log(`    ${k}: ${v}`)
+
+  console.log(`\n  -- leg 3: order_adjustments (present on ${withAdjs}/${refunds} refunds) --`)
+  console.log(`  keys: [${[...adjKeys].join(', ')}]`)
+  for (const [k, v] of [...adjKind].sort((a, b) => b[1] - a[1])) console.log(`    ${k}: ${v}`)
+
+  // §4: the money-scaling trap. Confirm these are decimal strings, not minor units.
+  console.log('\n=== 4. Money shape (task 47 section 4) ===')
+  const first = withRefunds[0].refunds[0]
+  const li = first.refund_line_items?.[0]
+  const tx = first.transactions?.[0]
+  const adj = first.order_adjustments?.[0]
+  console.log(
+    `  refund_line_items[0].subtotal = ${JSON.stringify(li?.subtotal)} (${typeof li?.subtotal})`
+  )
+  console.log(`  refund_line_items[0].total_tax = ${JSON.stringify(li?.total_tax)}`)
+  console.log(`  transactions[0].amount = ${JSON.stringify(tx?.amount)} (${typeof tx?.amount})`)
+  console.log(`  order_adjustments[0].amount = ${JSON.stringify(adj?.amount)}`)
+  console.log('  Strings => must go through decimalToMinorUnits when bound (37 section 2.4).')
+
+  // How often do the legs disagree - the case that kills a lines-only model.
+  let goodsNoMoney = 0
+  let moneyNoGoods = 0
+  for (const order of withRefunds) {
+    for (const r of order.refunds ?? []) {
+      const hasLines = (r.refund_line_items ?? []).length > 0
+      const money = (r.transactions ?? []).some((t: any) => Number(t.amount) > 0)
+      if (hasLines && !money) goodsNoMoney++
+      if (!hasLines && money) moneyNoGoods++
+    }
+  }
+  console.log('\n=== 5. Do the legs disagree? (task 47 section 3) ===')
+  console.log(`  goods returned, no money back (store credit): ${goodsNoMoney}`)
+  console.log(`  money back, no goods (shipping/goodwill):     ${moneyNoGoods}`)
+
+  // MK's hypothesis: most refunds are goodwill concessions ("$100 off for an
+  // angry customer"), not returns. If true, the dominant leg is an ADJUSTMENT
+  // and the inventory leg is rare - which decides v1's scope.
+  console.log('\n=== 6. Concession or return? ===')
+  const reasons = new Map<string, number>()
+  const amounts: number[] = []
+  let adjTaxed = 0
+  let adjUntaxed = 0
+  for (const order of withRefunds) {
+    for (const r of order.refunds ?? []) {
+      for (const a of r.order_adjustments ?? []) {
+        const reason = a.reason ? String(a.reason) : '(empty)'
+        reasons.set(reason, (reasons.get(reason) ?? 0) + 1)
+        const amt = Math.abs(Number(a.amount ?? 0))
+        if (amt > 0) amounts.push(amt)
+        if (Math.abs(Number(a.tax_amount ?? 0)) > 0) adjTaxed++
+        else adjUntaxed++
+      }
+    }
+  }
+  console.log('  order_adjustments[].reason:')
+  for (const [k, v] of [...reasons].sort((a, b) => b[1] - a[1])) console.log(`    ${k}: ${v}`)
+  console.log(
+    `  adjustments carrying a non-zero tax_amount: ${adjTaxed}, zero/absent: ${adjUntaxed}`
+  )
+
+  amounts.sort((a, b) => a - b)
+  const round = amounts.filter((a) => a % 50 === 0).length
+  console.log(`\n  adjustment amounts (n=${amounts.length}):`)
+  console.log(
+    `    min=${amounts[0]} median=${amounts[Math.floor(amounts.length / 2)]} max=${amounts[amounts.length - 1]}`
+  )
+  console.log(`    exact multiples of 50 (concession-shaped): ${round}/${amounts.length}`)
+  console.log(`    all: ${amounts.join(', ')}`)
+
+  // A concession refunds money against an order whose goods were kept, so the
+  // refund total is a fraction of the order total. A return is closer to 1.0.
+  console.log('\n  refunded fraction of order total:')
+  for (const order of withRefunds) {
+    const total = Number(order.total_price ?? 0)
+    const refunded = (order.refunds ?? []).reduce(
+      (sum: number, r: any) =>
+        sum + (r.transactions ?? []).reduce((t: number, x: any) => t + Number(x.amount ?? 0), 0),
+      0
+    )
+    if (total > 0) {
+      const lines = (order.refunds ?? []).reduce(
+        (n: number, r: any) => n + (r.refund_line_items ?? []).length,
+        0
+      )
+      console.log(
+        `    #${order.order_number}: refunded ${refunded.toFixed(2)} of ${total.toFixed(2)} ` +
+          `(${((refunded / total) * 100).toFixed(0)}%), ${lines} line item(s), status=${order.financial_status}`
+      )
+    }
+  }
+}
+
+async function main() {
+  const resolved = await resolveToken()
+  if (!resolved) {
+    console.log(`No usable credential for ${WANT_SHOP}. Pass SHOPIFY_PROBE_TOKEN to override.`)
+    process.exit(1)
+  }
+  const { shop, token } = resolved
+
+  const live = await shopify(shop, token, '/shop.json')
+  console.log(`\nGET /shop.json -> ${live.status}`)
+  if (live.status !== 200) {
+    console.log(`  ${live.text}`)
+    process.exit(1)
+  }
+
+  const scopes = await shopify(shop, token, '/oauth/access_scopes.json')
+  console.log(
+    `granted scopes: ${(scopes.json?.access_scopes ?? []).map((s: any) => s.handle).join(', ')}`
+  )
+
+  await coverage(shop, token)
+  await refundShape(shop, token)
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error('threw:', e?.message ?? e)
+  process.exit(1)
+})

--- a/packages/lib/scripts/probe-shopify-tax.ts
+++ b/packages/lib/scripts/probe-shopify-tax.ts
@@ -1,0 +1,190 @@
+// packages/lib/scripts/probe-shopify-tax.ts
+//
+// Read-only probe for plans/money/tasks/48-shopify-tax-data.md.
+//
+// Answers: what tax data does Shopify actually hand us, and does this store
+// exercise it? The connector binds `order_tax_total` and nothing else, so the
+// question is what is being left on the table.
+//
+// 🛑 Real customer orders under Protected Customer Data rules. Prints COUNTS,
+// RATES, JURISDICTION TITLES and FLAGS only. `tax_exempt` is reported as a
+// distribution, never against an identifiable customer.
+//
+// Usage: npx dotenv -- npx tsx packages/lib/scripts/probe-shopify-tax.ts
+
+import { decryptSecrets } from '@auxx/credentials'
+import { database as db, schema } from '@auxx/database'
+
+const API = process.env.SHOPIFY_PROBE_API_VERSION || '2024-10'
+const WANT_SHOP = process.env.SHOP || 'storage-system.myshopify.com'
+
+type Blob = Record<string, any>
+
+async function shopify(shop: string, token: string, path: string) {
+  const res = await fetch(`https://${shop}/admin/api/${API}${path}`, {
+    headers: { 'X-Shopify-Access-Token': token },
+  })
+  const text = await res.text()
+  try {
+    return { status: res.status, json: JSON.parse(text) }
+  } catch {
+    return { status: res.status, json: null as any, text: text.slice(0, 200) }
+  }
+}
+
+/** Same three-way resolution the refunds probe uses. */
+async function resolveToken(): Promise<{ shop: string; token: string } | null> {
+  if (process.env.SHOPIFY_PROBE_TOKEN) {
+    return { shop: WANT_SHOP, token: process.env.SHOPIFY_PROBE_TOKEN }
+  }
+  for (const row of await db.select().from(schema.Credential)) {
+    let blob: Blob = {}
+    try {
+      blob = decryptSecrets(row.encryptedSecrets)
+    } catch {
+      continue
+    }
+    const md = (row.metadata ?? {}) as Blob
+    const shop =
+      md.shopDomain ||
+      (md.connectionVariables?.shop ? `${md.connectionVariables.shop}.myshopify.com` : null) ||
+      (blob.metadata?.connectionVariables?.shop
+        ? `${blob.metadata.connectionVariables.shop}.myshopify.com`
+        : null)
+    const token = blob.accessToken || blob.access_token || blob.token
+    if (shop === WANT_SHOP && token) return { shop, token }
+  }
+  return null
+}
+
+function bump(m: Map<string, number>, k: string) {
+  m.set(k, (m.get(k) ?? 0) + 1)
+}
+
+async function main() {
+  const resolved = await resolveToken()
+  if (!resolved) {
+    console.log(`No usable credential for ${WANT_SHOP}.`)
+    process.exit(1)
+  }
+  const { shop, token } = resolved
+
+  const page = await shopify(shop, token, '/orders.json?status=any&limit=250')
+  const orders: any[] = page.json?.orders ?? []
+  console.log(`\n=== ${orders.length} orders in the readable window ===`)
+  if (!orders.length) {
+    console.log('  nothing to inspect')
+    process.exit(0)
+  }
+
+  // 1. Does this store charge tax at all?
+  const taxed = orders.filter((o) => Number(o.total_tax ?? 0) > 0)
+  console.log(`\n=== 1. Tax incidence ===`)
+  console.log(`  orders with total_tax > 0: ${taxed.length}/${orders.length}`)
+  console.log(`  taxes_included=true: ${orders.filter((o) => o.taxes_included === true).length}`)
+
+  // 2. tax_lines shape - the thing order_tax_name/order_tax_rate cannot hold.
+  const titles = new Map<string, number>()
+  const rates = new Map<string, number>()
+  const perOrderCount = new Map<string, number>()
+  let orderLevel = 0
+  for (const o of orders) {
+    const tl = o.tax_lines ?? []
+    if (tl.length) orderLevel++
+    bump(perOrderCount, String(tl.length))
+    for (const t of tl) {
+      bump(titles, String(t.title ?? '?'))
+      bump(rates, String(t.rate ?? '?'))
+    }
+  }
+  console.log(`\n=== 2. Order-level tax_lines (present on ${orderLevel}/${orders.length}) ===`)
+  console.log('  lines per order:')
+  for (const [k, v] of [...perOrderCount].sort()) console.log(`    ${k} line(s): ${v} orders`)
+  console.log('  jurisdiction titles:')
+  for (const [k, v] of [...titles].sort((a, b) => b[1] - a[1]).slice(0, 15)) {
+    console.log(`    ${k}: ${v}`)
+  }
+  console.log('  distinct rates:')
+  for (const [k, v] of [...rates].sort((a, b) => b[1] - a[1]).slice(0, 15)) {
+    console.log(`    ${k}: ${v}`)
+  }
+  const sampleTl = orders.find((o) => (o.tax_lines ?? []).length)?.tax_lines?.[0]
+  if (sampleTl) console.log(`  tax_line keys: [${Object.keys(sampleTl).sort().join(', ')}]`)
+
+  // channel_liable: when true a marketplace facilitator remits, not the
+  // merchant, so the line must NOT credit sales_tax_payable (48 section 3).
+  const liable = new Map<string, number>()
+  let liableAmount = 0
+  let ownAmount = 0
+  for (const o of orders) {
+    for (const t of [
+      ...(o.tax_lines ?? []),
+      ...(o.line_items ?? []).flatMap((li: any) => li.tax_lines ?? []),
+    ]) {
+      bump(liable, String(t.channel_liable ?? 'absent'))
+      if (t.channel_liable === true) liableAmount += Number(t.price ?? 0)
+      else ownAmount += Number(t.price ?? 0)
+    }
+  }
+  console.log('\n=== 2b. channel_liable (48 section 3) ===')
+  for (const [k, v] of [...liable].sort((a, b) => b[1] - a[1])) console.log(`    ${k}: ${v} lines`)
+  console.log(`  tax the CHANNEL remits: ${liableAmount.toFixed(2)}`)
+  console.log(`  tax WE remit:           ${ownAmount.toFixed(2)}`)
+
+  // 3. Per-line tax - what buildFulfillmentEntry's `taxMinor` would need.
+  let linesWithTax = 0
+  let linesTotal = 0
+  let taxableTrue = 0
+  const liTaxKeys = new Set<string>()
+  for (const o of orders) {
+    for (const li of o.line_items ?? []) {
+      linesTotal++
+      if (li.taxable === true) taxableTrue++
+      const tl = li.tax_lines ?? []
+      if (tl.length) {
+        linesWithTax++
+        for (const k of Object.keys(tl[0] ?? {})) liTaxKeys.add(k)
+      }
+    }
+  }
+  console.log(`\n=== 3. Per-line tax (buildFulfillmentEntry taxMinor) ===`)
+  console.log(`  line items carrying tax_lines: ${linesWithTax}/${linesTotal}`)
+  console.log(`  line items with taxable=true:  ${taxableTrue}/${linesTotal}`)
+  console.log(`  line tax_line keys: [${[...liTaxKeys].sort().join(', ')}]`)
+
+  // 4. Exemption - the dealer/resale case, which has no home in the repo.
+  const exempt = new Map<string, number>()
+  const reasons = new Map<string, number>()
+  for (const o of orders) {
+    const c = o.customer
+    bump(exempt, c ? String(c.tax_exempt ?? 'absent') : 'no customer')
+    for (const r of c?.tax_exemptions ?? []) bump(reasons, String(r))
+  }
+  console.log(`\n=== 4. Customer tax_exempt (counts only, no identifiers) ===`)
+  for (const [k, v] of [...exempt].sort((a, b) => b[1] - a[1])) console.log(`    ${k}: ${v}`)
+  if (reasons.size) {
+    console.log('  tax_exemptions codes:')
+    for (const [k, v] of [...reasons].sort((a, b) => b[1] - a[1])) console.log(`    ${k}: ${v}`)
+  } else {
+    console.log('  tax_exemptions: none present on any order')
+  }
+
+  // 5. Does the order-level total reconcile to the lines?
+  let agree = 0
+  let disagree = 0
+  for (const o of orders) {
+    const fromLines = (o.tax_lines ?? []).reduce((s: number, t: any) => s + Number(t.price ?? 0), 0)
+    const total = Number(o.total_tax ?? 0)
+    if (Math.abs(fromLines - total) < 0.005) agree++
+    else disagree++
+  }
+  console.log(`\n=== 5. Does sum(tax_lines.price) equal total_tax? ===`)
+  console.log(`  agree: ${agree}, disagree: ${disagree}`)
+
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error('threw:', e?.message ?? e)
+  process.exit(1)
+})


### PR DESCRIPTION
Selecting a bank account on **Accounting > Settings > Bank accounts** was local component state, so a refresh dropped the pane and the screen could not be linked to - which is the one thing it is for ("map the checking account to 1010"). Both bits of state move to nuqs, matching the shape `settings/accounts` already uses.

## What changed

- **`?account=<id>`** for the open row. Validated against the list only once the list has **arrived** - validating while the query is pending would drop the selection on every refresh, since the URL is read before the data is.
- **`?archived=true`** for the Show archived toggle, via `parseAsBoolean.withDefault(false)`, so the param only appears when it is on. That makes `?account=<id>&archived=true` a working deep link to an archived row: the account param alone would land on a list the row is not in.

Delete already cleared the selection and now strips the param with it. Archive still keeps it, deliberately - that is what puts Restore in front of whoever just realised they did not mean it.

`handleConnected` gains `setSelectedId` in its dep list: a `useState` setter is stable and Biome knows it, a nuqs setter is not.

## Known edges, both fine

- **Archived row with `archived=false`.** The pane stays open on a row that is not in the visible list, and survives a refresh, because the list query fetches `includeArchived: true` and the selection is resolved from all rows. The deep link works; the row just is not highlighted until you flip the toggle.
- **A stale `account=`** (an old link, or another session deleted the row) resolves to no selection once the list loads, but the dead param lingers in the URL. Cosmetic, and `settings/accounts` behaves the same way.

## Also in here, unrelated

- Two read-only Shopify probes for `plans/money/tasks/47-shopify-refunds.md` and `48-shopify-tax-data.md` - what a real `refunds[]` payload contains, and what tax data the store actually exercises. Both print shapes, counts, ids, amounts and rates only; every personal-data key is dropped before stdout, under Protected Customer Data rules.
- The app-runtime platform bundle hash.

## Testing

`pnpm --filter @auxx/web typecheck` adds no errors, and Biome is clean on the changed file. Not exercised in the browser.

https://claude.ai/code/session_01Q5G5VnWUXwS7WsNkmtiHpq
