### PR TITLE
feat(money): model Shopify refunds and channel-computed tax

### DIFF
--- a/packages/lib/scripts/probe-shopify-refunds.ts
+++ b/packages/lib/scripts/probe-shopify-refunds.ts
@@ -299,6 +299,41 @@ async function refundShape(shop: string, token: string) {
       )
     }
   }
+
+  // §6.2: does Shopify hand back the tax it charged, per refunded line? auxx
+  // does no tax arithmetic, so the refund's tax leg exists only if this is
+  // populated. Scans EVERY line item — §4 above samples refunds[0], which on
+  // this store carries no lines at all and reads `undefined` for a sampling
+  // reason, not an absence one.
+  console.log('\n=== 7. Per-line tax, transcribable? (task 47 section 6.2) ===')
+  let lineCount = 0
+  let taxPresent = 0
+  let taxNonZero = 0
+  const taxValues: string[] = []
+  for (const order of withRefunds) {
+    for (const r of order.refunds ?? []) {
+      for (const li of r.refund_line_items ?? []) {
+        lineCount++
+        const raw = li.total_tax
+        if (raw !== undefined && raw !== null) {
+          taxPresent++
+          taxValues.push(`${JSON.stringify(raw)} (${typeof raw})`)
+          if (Math.abs(Number(raw)) > 0) taxNonZero++
+        }
+        const set = li.total_tax_set?.shop_money?.amount
+        if (set !== undefined)
+          taxValues.push(`  total_tax_set.shop_money.amount=${JSON.stringify(set)}`)
+      }
+    }
+  }
+  console.log(`  refund line items: ${lineCount}`)
+  console.log(`  carrying total_tax at all: ${taxPresent}`)
+  console.log(`  carrying a NON-ZERO total_tax: ${taxNonZero}`)
+  console.log(`  values: ${taxValues.join(', ') || '(none)'}`)
+  console.log(
+    '  Non-zero => the tax leg is transcribable. All-zero => Shopify says these\n' +
+      '  lines carried no tax, and transcribing correctly reverses nothing.'
+  )
 }
 
 async function main() {

--- a/packages/lib/src/postings/build-entry.ts
+++ b/packages/lib/src/postings/build-entry.ts
@@ -294,6 +294,27 @@ export const ACCOUNT_ROLES = {
    */
   REVENUE_SERVICE: 'revenue_service',
   /**
+   * Sales returns and allowances (default `4090`). The contra-revenue account a
+   * refund reverses recognised revenue through.
+   *
+   * 🛑 **Not a debit back to `revenue_dtc` / `revenue_dealer` / `revenue_service`.**
+   * QuickBooks defaults to the original income account; auxx does not
+   * (task 47 §6.1), because netting the reversal into the account the sale was
+   * credited to leaves the return rate invisible on the P&L, and a return rate
+   * nobody can see is one nobody manages.
+   *
+   * ⚠️ The role covers ALLOWANCES as well as returns, and the allowance is the
+   * common case: a post-sale price reduction where the customer keeps the goods
+   * (47 §3.1). Nothing comes back and nothing restocks - the transaction price
+   * changed. Reading this role as "returns" would put concessions somewhere
+   * else and split one figure across two accounts.
+   *
+   * ⚠️ A REVENUE account that runs debit-normal. `GlAccountType` has no contra
+   * classification and does not need one, the same reading `1190 Allowance for
+   * Doubtful Accounts` gets: contra is presentation, not a posting rule.
+   */
+  REVENUE_RETURNS_ALLOWANCES: 'revenue_returns_allowances',
+  /**
    * Payment processing fees (default `6100`). What the processor withheld from
    * a payout. NOT `money/payments/fees.ts`, which is the Connect application
    * fee auxx charges, a different number.
@@ -350,6 +371,7 @@ export const ROLE_ACCOUNT_TYPES: Record<AccountRole, GlAccountTypeValue> = {
   revenue_dealer: 'revenue',
   revenue_shipping: 'revenue',
   revenue_service: 'revenue',
+  revenue_returns_allowances: 'revenue',
   payment_processing_fees: 'expense',
   bad_debt_expense: 'expense',
 }
@@ -391,6 +413,7 @@ export const ACCOUNT_ROLE_LABELS: Record<AccountRole, string> = {
   revenue_dealer: 'Product Revenue - Dealer',
   revenue_shipping: 'Shipping Revenue',
   revenue_service: 'Service Revenue',
+  revenue_returns_allowances: 'Sales Returns and Allowances',
   payment_processing_fees: 'Payment Processing Fees',
   bad_debt_expense: 'Bad Debt Expense',
 }

--- a/packages/lib/src/postings/default-chart.ts
+++ b/packages/lib/src/postings/default-chart.ts
@@ -356,6 +356,28 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     accountType: GlAccountType.REVENUE,
     role: 'revenue_service',
   },
+  {
+    // A contra-revenue account, and its own account rather than a debit back
+    // to the revenue account the sale was credited to - which is what
+    // QuickBooks defaults to (task 47 §6.1). Netting the reversal into `4000`
+    // leaves a return rate that never appears on the P&L, and a return rate
+    // nobody can see is one nobody manages.
+    //
+    // 🛑 **"and Allowances" is carrying weight, not padding.** The dominant
+    // case by count is a CONCESSION - a post-sale price reduction where the
+    // customer keeps the goods (47 §3.1) - which is an allowance, not a
+    // return. A name that said only "Returns" would misdescribe most of what
+    // lands here.
+    //
+    // `GlAccountType` has no contra classification and does not need one, the
+    // same reading `1190 Allowance for Doubtful Accounts` gets: contra is a
+    // presentation attribute, not a posting rule. The account is REVENUE and
+    // simply runs debit-normal.
+    code: '4090',
+    name: 'Sales Returns and Allowances',
+    accountType: GlAccountType.REVENUE,
+    role: 'revenue_returns_allowances',
+  },
 
   // ── Cost of goods sold ──────────────────────────────────────────────────
   // `GlAccountType` has no COGS classification; all five map to `expense`.

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -33,12 +33,15 @@ import { PRODUCT_FIELDS } from './resources/product-fields'
 import { PURCHASE_ORDER_FIELDS } from './resources/purchase-order-fields'
 import { PURCHASE_ORDER_LINE_FIELDS } from './resources/purchase-order-line-fields'
 import { QUOTE_FIELDS } from './resources/quote-fields'
+import { REFUND_FIELDS } from './resources/refund-fields'
+import { REFUND_LINE_FIELDS } from './resources/refund-line-fields'
 import { SERVICE_REQUEST_FIELDS } from './resources/service-request-fields'
 import { SIGNATURE_FIELDS } from './resources/signature-fields'
 import { STOCK_MOVEMENT_FIELDS } from './resources/stock-movement-fields'
 import { SUBPART_FIELDS } from './resources/subpart-fields'
 import { TARIFF_CODE_FIELDS } from './resources/tariff-code-fields'
 import { TARIFF_RATE_FIELDS } from './resources/tariff-rate-fields'
+import { TAX_LINE_FIELDS } from './resources/tax-line-fields'
 import { THREAD_FIELDS } from './resources/thread-fields'
 import { TICKET_FIELDS } from './resources/ticket-fields'
 import { USER_FIELDS } from './resources/user-fields'
@@ -164,6 +167,9 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   bank_rule: BANK_RULE_FIELDS,
   tariff_code: TARIFF_CODE_FIELDS,
   tariff_rate: TARIFF_RATE_FIELDS,
+  refund: REFUND_FIELDS,
+  refund_line: REFUND_LINE_FIELDS,
+  tax_line: TAX_LINE_FIELDS,
 }
 
 /**

--- a/packages/lib/src/resources/registry/resources/contact-fields.ts
+++ b/packages/lib/src/resources/registry/resources/contact-fields.ts
@@ -795,5 +795,44 @@ export const CONTACT_FIELDS: Record<string, ResourceField> = {
     description: 'Opaque token used to invalidate the contact billing overview',
   },
 
+  // Whether this customer buys tax exempt
+  // (plans/money/tasks/48-shopify-tax-data.md §4.4). 24 of 250 orders measured
+  // 2026-09-08 were to exempt customers, and until this field existed nothing
+  // in the repo distinguished a resale-exempt dealer from a sale that simply
+  // was never taxed - the two look identical, and for a dealer business the
+  // difference is the whole point.
+  //
+  // 🛑 THE FLAG ONLY. Shopify's `tax_exemptions[]` was EMPTY on every order
+  // measured, so the exemption REASON and the certificate are not available
+  // from the provider. Certificate storage, expiry and validation are a
+  // compliance surface and explicitly out of scope (48 §7); this field records
+  // that the customer is exempt, never why, and never proves it.
+  //
+  // ⚠️ Nullable with no default, unlike `line_item_taxable`. 48 §8.2: "we were
+  // told this customer is not exempt" and "we were told nothing" are different
+  // facts, and defaulting to false silently turns the second into the first.
+  taxExempt: {
+    id: toFieldId('taxExempt'),
+    key: 'taxExempt',
+    label: 'Tax Exempt',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'contact_tax_exempt',
+    systemSortOrder: 'aJ',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Whether this customer buys tax exempt, as the sales channel reported it. The FLAG ' +
+      'only - the exemption reason and the resale certificate are not supplied by the ' +
+      'provider and are not tracked here',
+  },
+
   createdBy: CREATED_BY_FIELD,
 }

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -192,6 +192,86 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     defaultValue: true,
   },
 
+  // The provider's per-line tax, as ONE number
+  // (plans/money/tasks/48-shopify-tax-data.md §4.2). Deliberately asymmetric
+  // with the order side, which fans `tax_lines[]` out into `tax_line` records:
+  // per-line-per-jurisdiction detail answers no question anybody has, because
+  // filing needs the breakdown per ORDER and the fulfillment builder needs one
+  // number per LINE. Fanning it out too would multiply roughly 63k records over
+  // the full order history to serve nothing.
+  //
+  // ✅ This is what lets `buildFulfillmentEntry` populate its per-line
+  // `taxMinor` and REPLACE the pro-rata approximation with exact figures on
+  // split shipments. It accepts a per-line tax today and never receives one, so
+  // it always falls back to allocating the order total across shipments
+  // (`build-fulfillment-entry.ts:180`, `:214`).
+  //
+  // 🛑 No default. 48 §8.2: "not supplied" and "supplied as zero" are different
+  // states - a null FieldValue against a row holding 0 - and both post nothing,
+  // which is exactly why they get collapsed if nobody writes it down. Defaulting
+  // this to 0 would tell the ledger the provider said there was no tax, when in
+  // fact it said nothing at all.
+  taxTotal: {
+    id: toFieldId('taxTotal'),
+    key: 'taxTotal',
+    label: 'Tax Total',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'line_item_tax_total',
+    systemSortOrder: 'a7a',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Integer minor units. The tax the provider computed for THIS line, carried and never ' +
+      'derived. Null means no tax figure was supplied for the line, which is not the same ' +
+      'as a supplied zero',
+  },
+
+  // Reverse relationship: the refund lines that sent part of this line back
+  // (plans/money/tasks/47-shopify-refunds.md §2.2). The counterpart of the
+  // owning `refund_line_line_item`, and declared for the same reason
+  // `part_line_items` is: an inverse a relationship POINTS AT but that does not
+  // exist leaves the edge unlinked, and an unlinked relationship accepts writes
+  // while this side reads empty (the trap entity migration 135 asserts against).
+  refundLines: {
+    id: toFieldId('refundLines'),
+    key: 'refundLines',
+    label: 'Refund Lines',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'line_item_refund_lines',
+    systemSortOrder: 'a7b',
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'refund_line:lineItem' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description: 'Refund lines that returned or cancelled part of this line',
+  },
+
   optional: {
     id: toFieldId('optional'),
     key: 'optional',

--- a/packages/lib/src/resources/registry/resources/order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/order-fields.ts
@@ -773,6 +773,76 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
       "build's own stamp to show that the order changed after the build was raised",
   },
 
+  // Reverse relationship: refunds (from refund.order). The `refund` side lands
+  // with entity migration 136; both halves are created in that one pass, so
+  // `linkNewRelationships` resolves this immediately.
+  //
+  // A refund is INGESTED, never originated here - the connector fans
+  // `refunds[]` out of the order payload it already fetches, the same way
+  // `line_items[]` works (plans/money/tasks/47-shopify-refunds.md §2). This is
+  // the relationship that fan-out writes through.
+  refunds: {
+    id: toFieldId('refunds'),
+    key: 'refunds',
+    label: 'Refunds',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'order_refunds',
+    systemSortOrder: 'aM',
+    showInPanel: false, // has_many inverse; surfaced from the refund side
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'refund:order' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description: 'Refunds recorded against this order - money returned, goods returned, or both',
+  },
+
+  // Reverse relationship: taxLines (from tax_line.order). The `tax_line` side
+  // lands with entity migration 136 alongside `refund`.
+  //
+  // Records rather than a JSON blob because the question this exists to answer
+  // is tax by jurisdiction over a period, and an aggregation wants rows
+  // (plans/money/tasks/48-shopify-tax-data.md §4.1). Per-LINE tax stays a
+  // scalar on `line_item` - fanning that out too would multiply records to
+  // serve nothing.
+  taxLines: {
+    id: toFieldId('taxLines'),
+    key: 'taxLines',
+    label: 'Tax Lines',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'order_tax_lines',
+    systemSortOrder: 'aN',
+    showInPanel: false, // has_many inverse; surfaced from the tax-line side
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'tax_line:order' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description:
+      'One row per taxing jurisdiction, as the provider computed it - what makes tax by ' +
+      'jurisdiction answerable',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/resources/registry/resources/refund-fields.ts
+++ b/packages/lib/src/resources/registry/resources/refund-fields.ts
@@ -1,0 +1,308 @@
+// packages/lib/src/resources/registry/resources/refund-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Refund resource
+ * (plans/money/tasks/47-shopify-refunds.md §2, §2.1).
+ *
+ * ## Why this entity exists at all
+ *
+ * Revenue booked at fulfillment is never reversed, because nothing in auxx
+ * holds a refund. An order flips to `refunded` in Shopify and auxx learns only
+ * that *something* was refunded, with no amount, no date and no lines (§0.1).
+ * This is the native record that carries the fact.
+ *
+ * ## Native entity, not a JSON dump
+ *
+ * The refund is projected out of the order payload the connector already
+ * fetches, as a `refunds[]` fan-out, and every money value is scaled through
+ * `decimalToMinorUnits` on the way in (§4). Letting the posting builder read
+ * `raw.refunds` instead would put unscaled provider strings at the ledger,
+ * which is where the 100x bug of money plan 37 §2.4 lived. It is also `G16`'s
+ * rule: Shopify maps into this contract, and the accounting code never reads
+ * Shopify fields directly.
+ *
+ * A refund is append-only at the source: the Shopify Refund resource has no
+ * delete, void, cancel or reverse (§5.3.2). It can still CHANGE, so re-ingest
+ * rewrites the record on a content-hash difference.
+ *
+ * ## A refund is three legs, not one
+ *
+ * Goods (`refund_line_items[]`), money (`transactions[]`) and adjustments
+ * (`order_adjustments[]`) are separate facts and only the first is modelled
+ * here as a child record. 8 of the 11 refunds measured on a live store moved
+ * money with NO line items at all (§3), so a lines-only model would have missed
+ * most of them.
+ *
+ * Money is integer minor units.
+ */
+export const REFUND_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique refund identifier',
+  },
+
+  /**
+   * When the refund happened AT SHOPIFY, bound from the refund's own
+   * `created_at`.
+   *
+   * 🛑 **THE accounting date. `build-refund-entry.ts` dates the ledger entry
+   * from this field and never from ingest time** (§5.3). The Shopify connector
+   * is manual-only (§0.9), so the gap between a refund happening and auxx
+   * seeing it is unbounded and can cross a period close: taking the ingest
+   * timestamp would post a July refund into September.
+   *
+   * Not nullable for the same reason. A null here would silently fall back to
+   * whenever the row was written, which is the one behaviour this field exists
+   * to prevent.
+   */
+  refundedAt: {
+    id: toFieldId('refundedAt'),
+    key: 'refundedAt',
+    label: 'Refunded At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'refund_created_at',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'When the refund happened at the provider. THE accounting date - the refund entry is ' +
+      'dated from this, never from when auxx ingested it, because the connector is ' +
+      'manual-only and the lag can cross a period close',
+  },
+
+  /**
+   * The refund `note`, and the only free text the payload carries.
+   *
+   * ⚠️ `G16`'s structured "reason" requirement is **not satisfiable from this
+   * payload** (§3.2). `order_adjustments[].reason` holds only Shopify's own
+   * generated labels (`Refund discrepancy`, `Pending refund discrepancy`) and
+   * there is no human-entered reason anywhere in the object. So the reason is
+   * either this free text, or a field a person fills in on review.
+   */
+  note: {
+    id: toFieldId('note'),
+    key: 'note',
+    label: 'Note',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'refund_note',
+    systemSortOrder: 'a2',
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter a note',
+    description:
+      'The provider note on the refund. The only free-text reason supplied - there is no ' +
+      'structured reason field anywhere in the payload',
+  },
+
+  /**
+   * The money that actually moved on this refund, in integer minor units.
+   *
+   * 🛑 **DERIVED, and named for it.** There is NO total on a Shopify refund
+   * (§2.1): the top-level properties are `created_at`, `duties`, `id`, `note`,
+   * `order_adjustments`, `processed_at`, `refund_duties`, `refund_line_items`,
+   * `refund_shipping_lines`, `restock`, `transactions` and `user_id`, and the
+   * live payload matches exactly. A field called `refund_total` was in an
+   * earlier version of the plan and would have been **null on every refund**,
+   * silently, because the projection emits `undefined` and the sink writes
+   * nothing.
+   *
+   * The connector projection computes it as
+   * `Σ transactions[] where kind == 'refund' and status == 'success'` - the
+   * money that actually moved. That is defensible where the tax proration of
+   * §6.2 was not: it aggregates facts that each stand on their own record, it
+   * invents no rate and allocates nothing, and every leg it sums stays
+   * individually inspectable.
+   *
+   * 🛑 **Do not rename this to `refund_total`.** The name carries the
+   * distinction between a number transcribed from the provider and a number
+   * auxx computed, and a list of refunds with no amount column is not usable.
+   *
+   * Null is not zero. Null means the provider supplied no transaction legs to
+   * sum, which is a knowable gap rather than a refund of nothing (§6.2a, §9
+   * rule 3); zero means legs exist and none of them succeeded.
+   */
+  amountRefunded: {
+    id: toFieldId('amountRefunded'),
+    key: 'amountRefunded',
+    label: 'Amount Refunded',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'refund_amount_refunded',
+    systemSortOrder: 'a3',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Integer minor units. DERIVED by the connector projection as the sum of the successful ' +
+      'refund transactions, because the provider supplies no total on a refund at all. Null ' +
+      'means no transaction legs were supplied, which is not the same as a refund of zero',
+  },
+
+  /** The order this refund was taken against. The owning side of `order_refunds`. */
+  order: {
+    id: toFieldId('order'),
+    key: 'order',
+    label: 'Order',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'refund_order',
+    systemSortOrder: 'a4',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'order:refunds' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'order',
+      relationshipType: 'belongs_to',
+      inverseName: 'Refunds',
+      inverseSystemAttribute: 'order_refunds',
+    },
+    description:
+      'The order this refund was taken against. Also the discriminator the entry builder ' +
+      "needs: the order's first fulfillment date against this refund's date is what decides " +
+      'whether any revenue was ever posted to reverse',
+  },
+
+  /**
+   * The goods leg: one child record per refunded line.
+   *
+   * Empty is the ordinary case, not a defect. A concession (a post-sale price
+   * reduction on goods the customer kept) and a shipping-only refund both carry
+   * zero lines, and those were 8 of 11 refunds in the measured window (§3).
+   */
+  lines: {
+    id: toFieldId('lines'),
+    key: 'lines',
+    label: 'Refund Lines',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'refund_lines',
+    systemSortOrder: 'a5',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'refund_line:refund' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description:
+      'The goods coming back on this refund, one record per refunded line. Empty on a ' +
+      'concession or a shipping-only refund, which is the common case',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Automatically set when the refund record is created in auxx. This is INGEST time and ' +
+      'never the accounting date - see refundedAt',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the refund is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/refund-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/refund-line-fields.ts
@@ -1,0 +1,342 @@
+// packages/lib/src/resources/registry/resources/refund-line-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import type { ResourceField } from '../field-types'
+
+/**
+ * What happened to the goods on a refunded line
+ * (plans/money/tasks/47-shopify-refunds.md §3, §9).
+ *
+ * 🛑 **Provider-neutral by construction, and this is load-bearing.** Shopify's
+ * own token is `restock_type`; the vocabulary below is auxx's, and the
+ * connector maps into it. Rule 1 of §9: no provider's vocabulary is ever stored
+ * as a value. The cost of getting this backwards is on record - entity
+ * migration 132 had to rename `1200 Shopify Clearing` to `1200 Card Clearing`
+ * because a provider's name had been baked into the chart.
+ *
+ * The Shopify mapping, recorded here and nowhere in the data:
+ *
+ * | disposition | Shopify `restock_type` |
+ * |---|---|
+ * | `returned` | `return`, `legacy_restock` |
+ * | `not_returned` | `no_restock` |
+ * | `cancelled` | `cancel` |
+ *
+ * `not_returned` is a concession or allowance: the money went back and the
+ * customer kept the goods. `cancelled` never shipped, which is why the
+ * distinction matters to the entry builder - a cancellation before fulfillment
+ * has no revenue to reverse, because none was ever posted (§3.1).
+ */
+export const REFUND_LINE_DISPOSITION_OPTIONS = [
+  { label: 'Returned', value: 'returned', color: 'green' },
+  { label: 'Not returned', value: 'not_returned', color: 'amber' },
+  { label: 'Cancelled', value: 'cancelled', color: 'gray' },
+] as const
+
+/**
+ * Field definitions for the Refund Line resource
+ * (plans/money/tasks/47-shopify-refunds.md §2.2).
+ *
+ * The goods leg of a refund: one record per refunded line, projected out of
+ * `refunds[].refund_line_items[]` as a fan-out under {@link REFUND_FIELDS}.
+ *
+ * The field set below comes from the measured payload keys - `[id, line_item,
+ * line_item_id, location_id, quantity, restock_type, subtotal, subtotal_set,
+ * total_tax, total_tax_set]` - not from guesswork. Two are deliberately absent:
+ *
+ * 🛑 **`restock` is NOT bound.** It is deprecated in favour of `restock_type`,
+ * and it sits at the refund level where the fact is per line. It is in the
+ * payload, so it will look bindable.
+ *
+ * 🔀 **`location_id` is deliberately omitted.** Nothing consumes which location
+ * goods returned to until the inventory leg exists, and §5.3 defers that leg.
+ * Add it with the leg, not before.
+ *
+ * Money is integer minor units, scaled through `decimalToMinorUnits` in the
+ * projection (§4).
+ */
+export const REFUND_LINE_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique refund line identifier',
+  },
+
+  /** How many units of the order line came off, bound from `quantity`. */
+  qty: {
+    id: toFieldId('qty'),
+    key: 'qty',
+    label: 'Qty',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'refund_line_qty',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'The quantity refunded on this line',
+  },
+
+  /**
+   * The goods amount refunded on this line, in integer minor units.
+   *
+   * ⚠️ Bound from `subtotal_set.shop_money.amount`, the STRING form, for the
+   * same reason {@link REFUND_LINE_FIELDS.taxTotal} is (§4.1): the `_set` form
+   * is the one that carries a currency code, and it keeps every refund money
+   * value on the single `decimalToMinorUnits` path.
+   */
+  subtotal: {
+    id: toFieldId('subtotal'),
+    key: 'subtotal',
+    label: 'Subtotal',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'refund_line_subtotal',
+    systemSortOrder: 'a2',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Integer minor units. The goods amount refunded on this line, bound from the ' +
+      '_set.shop_money.amount string so it scales on the one money path',
+  },
+
+  /**
+   * The tax reversed on this line, in integer minor units.
+   *
+   * 🛑 **Bind `total_tax_set.shop_money.amount`, the STRING. NEVER the sibling
+   * `total_tax`, which is a NUMBER** (§4.1). The same object carries the same
+   * value as two different types:
+   *
+   * ```
+   * total_tax                        = 202.23     <- NUMBER
+   * total_tax_set.shop_money.amount  = "202.23"   <- STRING
+   * ```
+   *
+   * Every other money field on the refund is a string and goes through
+   * `decimalToMinorUnits`. Binding the bare scalar opens a SECOND numeric code
+   * path into the ledger, which is exactly where the 100x bug lived last time -
+   * 139 Shopify money rows stored a hundredfold low (money plan 37 §2.4). The
+   * `_set` form is also the only one that carries a currency code.
+   *
+   * 🛑 **Null is not zero, and they must not collapse** (§6.2a). The provider is
+   * TRANSCRIBED and never prorated (§6.2), so with arithmetic ruled out there is
+   * no way to derive a tax that was not supplied. Zero means *post no tax
+   * reversal, this is correct*; null means *post no tax reversal and say so*,
+   * because `2200` is then knowably overstated by an unknown amount. Shopify
+   * answers zero on every adjustment on the measured store, which is a real
+   * answer; another provider may answer nothing at all.
+   */
+  taxTotal: {
+    id: toFieldId('taxTotal'),
+    key: 'taxTotal',
+    label: 'Tax Total',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'refund_line_tax_total',
+    systemSortOrder: 'a3',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Integer minor units, transcribed from the provider and never prorated. Bound from ' +
+      'total_tax_set.shop_money.amount (a string), never the sibling total_tax (a number). ' +
+      'Null means the provider supplied no tax, which is not the same as a supplied zero',
+  },
+
+  /**
+   * What happened to the goods on this line. See
+   * {@link REFUND_LINE_DISPOSITION_OPTIONS} for the values and the provider
+   * mapping.
+   *
+   * This is `G16`'s "disposition" requirement, and it is what decides whether a
+   * refund moves `stock_movement` or only reverses revenue. Null means the
+   * provider said nothing, which is distinct from any of the three answers.
+   */
+  disposition: {
+    id: toFieldId('disposition'),
+    key: 'disposition',
+    label: 'Disposition',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'refund_line_disposition',
+    systemSortOrder: 'a4',
+    nullable: true,
+    options: { options: [...REFUND_LINE_DISPOSITION_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select disposition',
+    description:
+      'What happened to the goods: returned, kept (a concession), or never shipped. ' +
+      'Provider-neutral - the connector maps its own vocabulary into these values',
+  },
+
+  /** The refund this line belongs to. The owning side of `refund_lines`. */
+  refund: {
+    id: toFieldId('refund'),
+    key: 'refund',
+    label: 'Refund',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'refund_line_refund',
+    systemSortOrder: 'a5',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'refund:lines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'refund',
+      relationshipType: 'belongs_to',
+      inverseName: 'Refund Lines',
+      inverseSystemAttribute: 'refund_lines',
+    },
+    description: 'The refund this line belongs to',
+  },
+
+  /**
+   * The order line that came back, bound from `line_item_id` in `reference`
+   * link mode: the line item already exists as its own record from the order
+   * fan-out, so this points at it rather than restating it.
+   */
+  lineItem: {
+    id: toFieldId('lineItem'),
+    key: 'lineItem',
+    label: 'Line Item',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'refund_line_line_item',
+    systemSortOrder: 'a6',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'line_item:refundLines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'line_item',
+      relationshipType: 'belongs_to',
+      inverseName: 'Refund Lines',
+      inverseSystemAttribute: 'line_item_refund_lines',
+    },
+    description: 'The order line item this refund line reversed',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the refund line is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the refund line is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/tax-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/tax-line-fields.ts
@@ -1,0 +1,286 @@
+// packages/lib/src/resources/registry/resources/tax-line-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Tax Line resource - one jurisdiction's share of one
+ * order's tax, exactly as the sales channel computed it
+ * (plans/money/tasks/48-shopify-tax-data.md §4.1).
+ *
+ * ## 🛑 auxx does not calculate tax, and this entity is not a step towards it
+ *
+ * 48's banner and `plans/accounting/gap-analysis.md` §5.2 settle it: US sales
+ * tax is state + county + city + special district with product-level
+ * taxability, exemption certificates, nexus thresholds and filing calendars,
+ * and nobody builds it, QuickBooks included. The provider has ALREADY computed
+ * the tax. These rows CARRY that answer. Any arithmetic that derives an amount
+ * from {@link TAX_LINE_FIELDS.rate} is out of scope by construction.
+ *
+ * ## Why this is a record and not a rate on the order
+ *
+ * `order_tax_rate` exists and is deliberately unbound. 48 §2 measured why: of
+ * 123 taxed orders in one 250-order window, **104 carried more than one tax
+ * line - 85%**. A single scalar rate can represent 19 of 123, and binding it
+ * would be worse than leaving it empty, because a partial answer reads as a
+ * complete one. Nine states plus special districts appeared in that one window.
+ *
+ * Multi-jurisdiction is the NORM, so the breakdown has to be rows. The purpose
+ * is *tax by jurisdiction over a period*, which is an aggregation, and an
+ * aggregation wants rows - a JSON blob would store the data and answer none of
+ * the questions it was stored for.
+ *
+ * ⚠️ Not every row is a tax. `Colorado Retail Delivery Fee` is a flat
+ * per-delivery fee with its own remittance rules and it arrives in the same
+ * array, one of them carrying a rate of literally `0`. The jurisdiction name is
+ * what preserves the distinction (48 §6.3).
+ *
+ * ## Additive by construction
+ *
+ * `sum(tax_lines.price) == total_tax` held on **250 of 250** orders measured,
+ * so these rows tie to the `order_tax_total` already being imported. Nothing
+ * that posts today changes when they land.
+ *
+ * `EntityInstance`-backed, no new Drizzle tables - the `line_item` and
+ * `purchase_order_line` precedent. Money is integer minor units
+ * ({@link TAX_LINE_FIELDS.price}).
+ */
+export const TAX_LINE_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique tax line identifier',
+  },
+
+  title: {
+    id: toFieldId('title'),
+    key: 'title',
+    label: 'Title',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'tax_line_title',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'CA State Tax',
+    description:
+      'The JURISDICTION this line is owed to, as the provider named it - "Texas State Tax", ' +
+      '"Ventura Co Local Tax Sl", "Dallas Mta Transit". It is what a tax-by-jurisdiction ' +
+      'report groups by, and the only thing that distinguishes a genuine tax from a fee ' +
+      'riding in the same array, such as the Colorado Retail Delivery Fee',
+  },
+
+  rate: {
+    id: toFieldId('rate'),
+    key: 'rate',
+    label: 'Rate',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'tax_line_rate',
+    systemSortOrder: 'a2',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'The rate exactly as the provider supplied it. 🛑 NEVER used to compute anything - ' +
+      'auxx does not calculate tax, and the amount is carried on price. Display and filing ' +
+      'only. A flat fee can legitimately arrive with a rate of 0, which is another reason ' +
+      'the amount is never derived from this',
+  },
+
+  // 🛑 Bind `price_set.shop_money.amount` (a STRING), never the bare numeric
+  // sibling (48 §8.1, measured 2026-09-08). The same Shopify object carries the
+  // same value as two different types: `total_tax = 202.23` is a NUMBER while
+  // `total_tax_set.shop_money.amount = "202.23"` is a STRING. "Shopify sends
+  // decimals as strings" is NOT uniformly true. The `_set` form is the shape
+  // `decimalToMinorUnits` already expects, it is what every other money binding
+  // uses, and it is the only one carrying a currency code. Binding the bare
+  // scalar opens a second numeric path into the ledger, which is where the 100x
+  // bug lived (money plan 37 §2.4, 139 rows).
+  //
+  // 🛑 And no default. 48 §8.2: "not supplied" and "supplied as zero" are
+  // DIFFERENT states - a null FieldValue against a row holding 0. Both post
+  // nothing, which is exactly why they get collapsed if nobody writes it down,
+  // and collapsing them turns a flagged gap into a silent one.
+  price: {
+    id: toFieldId('price'),
+    key: 'price',
+    label: 'Price',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'tax_line_price',
+    systemSortOrder: 'a3',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Integer minor units. The tax this jurisdiction charged on this order, as computed ' +
+      'by the provider and never by us',
+  },
+
+  // 🛑 `channelLiable` is the one field on this record the LEDGER BRANCHES ON
+  // (48 §3, answered in §6.4). Crediting a `channel_liable: true` line to
+  // `2200 Sales Tax Payable` books a liability the business does not owe and
+  // will never pay down: it balances, it looks right, and the account grows
+  // forever.
+  //
+  // Counted 2026-09-08 over 250 orders: 1,212 lines / $59,941.96 are
+  // channel-liable FALSE (we remit) against 6 lines / $272.08 TRUE (the channel
+  // remits). 0.5% of lines is precisely the frequency at which nobody catches
+  // it by eye, and the error grows with every marketplace order.
+  //
+  // The true lines still get rows - the money was collected and it is part of
+  // the order total - they simply create no liability for this business.
+  //
+  // ⚠️ No default value, deliberately. Defaulting an unsupplied flag to false
+  // is the same silent overstatement arrived at from the other direction: it
+  // would credit 2200 for a provider that never told us who remits.
+  channelLiable: {
+    id: toFieldId('channelLiable'),
+    key: 'channelLiable',
+    label: 'Channel Liable',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'tax_line_channel_liable',
+    systemSortOrder: 'a4',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Whether a marketplace facilitator remits this tax instead of the merchant. 🛑 A ' +
+      'POSTING INPUT, not decoration: only a false line credits 2200 Sales Tax Payable. A ' +
+      'true line means the channel already remitted it and this business owes nothing',
+  },
+
+  order: {
+    id: toFieldId('order'),
+    key: 'order',
+    label: 'Order',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'tax_line_order',
+    systemSortOrder: 'a5',
+    showInPanel: false, // tax lines are read in the context of their order
+    nullable: false,
+    required: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: false,
+      required: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'order:taxLines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'order',
+      relationshipType: 'belongs_to',
+      inverseName: 'Tax Lines',
+      inverseSystemAttribute: 'order_tax_lines',
+    },
+    description:
+      'The order this jurisdiction charged. Fanned out of the order payload the way ' +
+      'line items already are; a tax line has no life of its own',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the tax line is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the tax line is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -92,6 +92,7 @@ import { migration132CardClearingRename } from './migrations/132-card-clearing-r
 import { migration133Payout } from './migrations/133-payout'
 import { migration134BankAccountHasPosted } from './migrations/134-bank-account-has-posted'
 import { migration135BankDepositBankAccount } from './migrations/135-bank-deposit-bank-account'
+import { migration136RefundsAndTaxLines } from './migrations/136-refunds-and-tax-lines'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -269,6 +270,11 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // MUST sort after 125, which owns the `bank_account` def it widens.
   migration134BankAccountHasPosted,
   migration135BankDepositBankAccount,
+  // Refunds and channel-computed tax, landed together because they share one
+  // connector field batch and one per-org remap (48 §5). MUST sort after 107,
+  // which creates the `order` and `line_item` defs it widens, and after 108,
+  // which owns the chart `4090 Sales Returns and Allowances` is added to.
+  migration136RefundsAndTaxLines,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
@@ -85,10 +85,12 @@ describe('order entity registration wiring', () => {
       'number',
       'paymentGateways',
       'placedAt',
+      'refunds', // added by migration 136 - inverse of refund_order (money/tasks/47 §2)
       'shippingAddress',
       'shippingTotal', // added by migration 122 — money plan 37 §6/§8
       'subtotal',
       'tags',
+      'taxLines', // added by migration 136 - inverse of tax_line_order (money/tasks/48 §4.1)
       'taxName', // folded into 108 (see the note below) — the LineBuilder writes it with taxRate
       'taxRate',
       'taxTotal',

--- a/packages/lib/src/seed/entity-migrations/migrations/136-refunds-and-tax-lines.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/136-refunds-and-tax-lines.ts
@@ -1,0 +1,269 @@
+// packages/lib/src/seed/entity-migrations/migrations/136-refunds-and-tax-lines.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { CONTACT_FIELDS } from '../../../resources/registry/resources/contact-fields'
+import { LINE_ITEM_FIELDS } from '../../../resources/registry/resources/line-item-fields'
+import { ORDER_FIELDS } from '../../../resources/registry/resources/order-fields'
+import { REFUND_FIELDS } from '../../../resources/registry/resources/refund-fields'
+import { REFUND_LINE_FIELDS } from '../../../resources/registry/resources/refund-line-fields'
+import { TAX_LINE_FIELDS } from '../../../resources/registry/resources/tax-line-fields'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import { seedDefaultChartOfAccounts } from '../../gl-account-chart'
+import {
+  ensureCustomFields,
+  ensureEntityDefinitions,
+  linkDisplayFields,
+  linkNewRelationships,
+  loadExistingState,
+} from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:136')
+
+/** What {@link ensureCustomFields} returns, keyed `<entityType>:<field id>`. */
+type EnsuredFieldMap = Awaited<ReturnType<typeof ensureCustomFields>>
+
+/** The three defs this migration creates. All hidden: they render inside the order. */
+const NEW_ENTITY_TYPES = ['refund', 'refund_line', 'tax_line'] as const
+
+/** The def the chart addition needs. Absent means the org has no chart at all. */
+const GL_ACCOUNT_ENTITY_TYPE = 'gl_account'
+
+/**
+ * Every relationship pair this migration must LINK, as
+ * `<owning entityType>:<field id>` paired with the inverse it points at.
+ *
+ * Checked explicitly after {@link linkNewRelationships} rather than trusted,
+ * because that helper only logs a debug line when it cannot resolve an inverse.
+ * Entity migration 135 is why: an UNLINKED relationship is worse than a missing
+ * one - the field exists so writes are accepted, but with no inverse the other
+ * side reads empty and every consumer of it silently sees nothing.
+ */
+const RELATIONSHIP_PAIRS: readonly { owning: string; inverse: string }[] = [
+  { owning: `refund:${REFUND_FIELDS.order?.id}`, inverse: 'order:refunds' },
+  { owning: `refund_line:${REFUND_LINE_FIELDS.refund?.id}`, inverse: 'refund:lines' },
+  { owning: `refund_line:${REFUND_LINE_FIELDS.lineItem?.id}`, inverse: 'line_item:refundLines' },
+  { owning: `tax_line:${TAX_LINE_FIELDS.order?.id}`, inverse: 'order:taxLines' },
+]
+
+/** New fields added to defs that ALREADY exist, by entity type. */
+const WIDENED: readonly {
+  entityType: string
+  source: Record<string, ResourceField>
+  keys: string[]
+}[] = [
+  { entityType: 'order', source: ORDER_FIELDS, keys: ['refunds', 'taxLines'] },
+  { entityType: 'line_item', source: LINE_ITEM_FIELDS, keys: ['taxTotal', 'refundLines'] },
+  { entityType: 'contact', source: CONTACT_FIELDS, keys: ['taxExempt'] },
+]
+
+/**
+ * Migration 136: refunds and channel-computed tax.
+ *
+ * Two plans land together because they share one connector field batch and one
+ * per-org remap, and the remap cost is per batch: doing them separately pays it
+ * twice (plans/money/tasks/48-shopify-tax-data.md §5).
+ *
+ * ## What it adds
+ *
+ * - **`refund` + `refund_line`** (47 §2, §5.1) - a refund that already happened
+ *   at the sales channel, ingested as a FACT. Never originated here: the
+ *   existing `refundTransaction` calls Stripe's API and the ledger refuses
+ *   anything else, which is the opposite direction (47 §0.4).
+ * - **`tax_line`** (48 §4.1) - one jurisdiction's share of one order's tax, as
+ *   a ROW. Multi-jurisdiction is the norm, so a single rate on the order can
+ *   never represent it, and the question being asked is tax by jurisdiction over
+ *   a period, which is an aggregation and wants rows.
+ * - **Four relationship pairs**, plus `line_item_tax_total` and
+ *   `contact_tax_exempt` on defs that already exist.
+ * - **`4090 Sales Returns and Allowances`** with its
+ *   `revenue_returns_allowances` role (47 §6.1).
+ *
+ * ## What it deliberately does NOT do
+ *
+ * 🛑 **No backfill, and none is possible.** Every field here is filled by the
+ * connector, and the refund and tax data does not exist anywhere in auxx today
+ * to backfill FROM - 47 §0.1: the connector carries 25 `order_*` attributes and
+ * not one is a refund. The rows arrive on the next sync after the connector
+ * bindings and the remap land, which is a separate change in a separate repo.
+ *
+ * ⚠️ **`4090` ships with a role that nothing emits yet.** `build-refund-entry.ts`
+ * is 47 §5.3 and waits on decisions still open there. The `ACCOUNT_ROLES` header
+ * names this exact state as a hazard - a role nothing emits is a mapping a
+ * bookkeeper can make wrongly with no way to find out - so the builder should
+ * follow closely rather than eventually.
+ *
+ * ## Ordering
+ *
+ * MUST sort after 107 (which creates `order` and `line_item`) and after 108
+ * (which owns the chart). An org short of either is a skip, not a failure.
+ *
+ * Idempotent: `ensureCustomFields` is INSERT-only and skips a field that exists,
+ * `linkNewRelationships` only writes an unset inverse, and
+ * `seedDefaultChartOfAccounts` is idempotent on `code` with its role insert
+ * `ON CONFLICT DO NOTHING`.
+ */
+export const migration136RefundsAndTaxLines: EntityMigration = {
+  id: '136-refunds-and-tax-lines',
+  description:
+    'Adds the refund, refund_line and tax_line defs with their relationships to order and ' +
+    'line_item, line_item_tax_total and contact_tax_exempt, and 4090 Sales Returns and ' +
+    'Allowances - the records the channel connector fills for refund and tax posting',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    // Absent rather than failed: an org short of 107 has no order or line_item,
+    // and the seeder creates all of this with the rest of the registry.
+    const orderDef = existing.entityDefs.get('order')
+    const lineItemDef = existing.entityDefs.get('line_item')
+    const contactDef = existing.entityDefs.get('contact')
+    if (!orderDef || !lineItemDef || !contactDef) return { ...state, alreadyUpToDate: true }
+
+    const entityDefIds = await ensureEntityDefinitions(
+      db,
+      organizationId,
+      SYSTEM_ENTITIES.filter((e) => (NEW_ENTITY_TYPES as readonly string[]).includes(e.entityType)),
+      existing,
+      state
+    )
+    entityDefIds.set('order', orderDef.id)
+    entityDefIds.set('line_item', lineItemDef.id)
+    entityDefIds.set('contact', contactDef.id)
+
+    // 🛑 ONE field map spanning EVERY def, new and widened alike.
+    // `linkNewRelationships` resolves an inverse out of this map by
+    // `<entityType>:<field id>`, so linking the halves of a pair in separate
+    // calls would leave each unable to see the other and skip the pair with
+    // nothing louder than a debug line (the 135 lesson).
+    const fieldMap: EnsuredFieldMap = new Map()
+
+    const newDefFields: Record<string, Record<string, ResourceField>> = {
+      refund: REFUND_FIELDS,
+      refund_line: REFUND_LINE_FIELDS,
+      tax_line: TAX_LINE_FIELDS,
+    }
+    for (const entityType of NEW_ENTITY_TYPES) {
+      const defId = entityDefIds.get(entityType)
+      if (!defId) continue
+      const created = await ensureCustomFields(
+        db,
+        organizationId,
+        entityType,
+        defId,
+        newDefFields[entityType]!,
+        existing,
+        state
+      )
+      for (const [key, value] of created) fieldMap.set(key, value)
+    }
+
+    for (const { entityType, source, keys } of WIDENED) {
+      const defId = entityDefIds.get(entityType)
+      if (!defId) continue
+      const created = await ensureCustomFields(
+        db,
+        organizationId,
+        entityType,
+        defId,
+        pick(source, keys, entityType),
+        existing,
+        state
+      )
+      for (const [key, value] of created) fieldMap.set(key, value)
+    }
+
+    await linkNewRelationships(db, fieldMap, entityDefIds, state)
+    await assertInversesLinked(db, fieldMap)
+
+    await linkDisplayFields(db, [...NEW_ENTITY_TYPES], entityDefIds, fieldMap)
+
+    // Idempotent on `code`; its role insert is ON CONFLICT DO NOTHING. An org
+    // short of 108 has no chart def and gets no chart work, the way 133 skips.
+    const glAccountDefId = existing.entityDefs.get(GL_ACCOUNT_ENTITY_TYPE)?.id
+    const chart = glAccountDefId
+      ? await seedDefaultChartOfAccounts(db, organizationId, glAccountDefId)
+      : { created: 0, rolesAssigned: 0 }
+
+    const changed =
+      state.entityDefsCreated > 0 ||
+      state.fieldsCreated > 0 ||
+      state.relationshipsLinked > 0 ||
+      chart.created > 0 ||
+      chart.rolesAssigned > 0
+
+    if (changed) {
+      // A new def and a new field are invisible to every read path that serves
+      // them until the per-org caches are dropped. `runEntityMigrationsForOrg`
+      // does this after the whole batch, but `up()` can also be called directly.
+      await getOrgCache().invalidateAndRecompute(organizationId, [
+        'entityDefs',
+        'entityDefSlugs',
+        'customFields',
+        'resources',
+      ])
+      logger.info('Migration 136 applied', {
+        organizationId,
+        ...state,
+        accountsCreated: chart.created,
+        rolesAssigned: chart.rolesAssigned,
+      })
+    }
+
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}
+
+/** The registry fields this migration adds to an existing def, loud if one was renamed. */
+function pick(
+  source: Record<string, ResourceField>,
+  keys: readonly string[],
+  entityType: string
+): Record<string, ResourceField> {
+  const picked: Record<string, ResourceField> = {}
+  for (const key of keys) {
+    const field = source[key]
+    if (!field) {
+      throw new Error(`${entityType} registry is missing the key "${key}" (migration 136)`)
+    }
+    picked[key] = field
+  }
+  return picked
+}
+
+/**
+ * Verify every pair in {@link RELATIONSHIP_PAIRS} actually resolved its inverse.
+ *
+ * 🛑 Not a formality. `linkNewRelationships` skips an unresolvable pair with a
+ * debug line, so without this the migration reports success having created four
+ * relationship fields that accept writes the other side cannot see. Entity
+ * migration 135 added the same assertion for one pair after exactly that.
+ */
+async function assertInversesLinked(
+  db: Database,
+  fieldMap: Map<string, { id: string }>
+): Promise<void> {
+  for (const { owning, inverse } of RELATIONSHIP_PAIRS) {
+    const field = fieldMap.get(owning)
+    if (!field) {
+      throw new Error(`migration 136 could not resolve the field ${owning}`)
+    }
+    const row = await db.query.CustomField.findFirst({
+      where: eq(schema.CustomField.id, field.id),
+      columns: { options: true },
+    })
+    const inverseId = (row?.options as { relationship?: { inverseResourceFieldId?: string } })
+      ?.relationship?.inverseResourceFieldId
+    if (!inverseId) {
+      throw new Error(
+        `migration 136 created ${owning} but could not link it to ${inverse} - the inverse half ` +
+          'is missing, and an unlinked relationship writes rows the other side cannot see'
+      )
+    }
+  }
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -500,6 +500,39 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     color: 'teal',
     isVisible: false,
   },
+  {
+    // A refund that already happened at the sales channel, ingested as a FACT
+    // and never originated here (plans/money/tasks/47-shopify-refunds.md §0.4).
+    entityType: 'refund',
+    apiSlug: 'refunds',
+    singular: 'Refund',
+    plural: 'Refunds',
+    icon: 'rotate-ccw',
+    color: 'red',
+    isVisible: false, // Internal entity, managed from the order
+  },
+  {
+    entityType: 'refund_line',
+    apiSlug: 'refund-lines',
+    singular: 'Refund Line',
+    plural: 'Refund Lines',
+    icon: 'list',
+    color: 'red',
+    isVisible: false, // Internal entity, managed from the refund
+  },
+  {
+    // One jurisdiction's tax on one order, as a ROW rather than a rate: the
+    // question is tax by jurisdiction over a period, and an aggregation wants
+    // rows (plans/money/tasks/48-shopify-tax-data.md §4.1). auxx never computes
+    // these, it carries what the channel already computed.
+    entityType: 'tax_line',
+    apiSlug: 'tax-lines',
+    singular: 'Tax Line',
+    plural: 'Tax Lines',
+    icon: 'percent',
+    color: 'amber',
+    isVisible: false, // Internal entity, managed from the order
+  },
 ]
 
 /**
@@ -660,6 +693,25 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
   tariff_rate: {
     primaryDisplayField: 'tariffCode',
     secondaryDisplayField: 'effectiveFrom',
+  },
+  // `refundedAt` leads and the amount follows, because `computeDisplayValue`
+  // has no fallback and only `refundedAt` is non-nullable: a refund whose
+  // transaction legs have not settled has no amount to sum yet
+  // (plans/money/tasks/47-shopify-refunds.md §2.1), and would otherwise render
+  // blank. Same reasoning as `journal_entry` putting `memo` second.
+  refund: {
+    primaryDisplayField: 'refundedAt',
+    secondaryDisplayField: 'amountRefunded',
+  },
+  refund_line: {
+    primaryDisplayField: 'qty',
+    secondaryDisplayField: 'subtotal',
+  },
+  // The jurisdiction leads: it is the one field on a tax line that is always
+  // present, and it is what the by-jurisdiction report groups on (§4.1).
+  tax_line: {
+    primaryDisplayField: 'title',
+    secondaryDisplayField: 'price',
   },
   gl_account: {
     primaryDisplayField: 'code',

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -29,6 +29,8 @@ import { PRODUCT_FIELDS } from '../../resources/registry/resources/product-field
 import { PURCHASE_ORDER_FIELDS } from '../../resources/registry/resources/purchase-order-fields'
 import { PURCHASE_ORDER_LINE_FIELDS } from '../../resources/registry/resources/purchase-order-line-fields'
 import { QUOTE_FIELDS } from '../../resources/registry/resources/quote-fields'
+import { REFUND_FIELDS } from '../../resources/registry/resources/refund-fields'
+import { REFUND_LINE_FIELDS } from '../../resources/registry/resources/refund-line-fields'
 import { SERVICE_REQUEST_FIELDS } from '../../resources/registry/resources/service-request-fields'
 import { SIGNATURE_FIELDS } from '../../resources/registry/resources/signature-fields'
 import { STOCK_MOVEMENT_FIELDS } from '../../resources/registry/resources/stock-movement-fields'
@@ -36,6 +38,7 @@ import { SUBPART_FIELDS } from '../../resources/registry/resources/subpart-field
 import { TAG_FIELDS } from '../../resources/registry/resources/tag-fields'
 import { TARIFF_CODE_FIELDS } from '../../resources/registry/resources/tariff-code-fields'
 import { TARIFF_RATE_FIELDS } from '../../resources/registry/resources/tariff-rate-fields'
+import { TAX_LINE_FIELDS } from '../../resources/registry/resources/tax-line-fields'
 import { THREAD_FIELDS } from '../../resources/registry/resources/thread-fields'
 import { TICKET_FIELDS } from '../../resources/registry/resources/ticket-fields'
 import { VENDOR_BILL_FIELDS } from '../../resources/registry/resources/vendor-bill-fields'
@@ -99,6 +102,9 @@ export const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   bank_rule: BANK_RULE_FIELDS,
   tariff_code: TARIFF_CODE_FIELDS,
   tariff_rate: TARIFF_RATE_FIELDS,
+  refund: REFUND_FIELDS,
+  refund_line: REFUND_LINE_FIELDS,
+  tax_line: TAX_LINE_FIELDS,
 }
 
 /**

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -119,6 +119,17 @@ export interface ToolActionContext {
  * record" case the union exists for. Note this also widens `ref.entity(kind)`,
  * the app TOOL surface, which is the part of the trade worth revisiting if the
  * rule is ever tightened.
+ *
+ * ✅ `refund`, `refund_line` and `tax_line` were ADDED 2026-09-08 with entity
+ * migration 136 (plans/money/tasks/47-shopify-refunds.md §2,
+ * plans/money/tasks/48-shopify-tax-data.md §4.1). They follow `line_item`'s
+ * precedent rather than the "an entity a user thinks about and could open"
+ * rule: all three are `isVisible: false` and render inside the order, and all
+ * three exist precisely so a channel connector can address them - a refund and
+ * a refund line carry the provider's own ids, and a tax line carries a
+ * SYNTHETIC `${orderId}:${title}` key because Shopify tax lines ship no id at
+ * all. Admitting them satisfies the standing condition: 136 seeds all three
+ * into EXISTING orgs, so these are not union entries that no org resolves.
  */
 export type EntityRefKind =
   | 'contact'
@@ -136,6 +147,9 @@ export type EntityRefKind =
   | 'purchase_order'
   | 'vendor_bill'
   | 'gl_account'
+  | 'refund'
+  | 'refund_line'
+  | 'tax_line'
 
 /**
  * Per-tool configuration. See plans/kopilot/apps/README.md §4.2.

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -205,6 +205,10 @@ export const SYSTEM_ATTRIBUTES = [
   'contact_balance_due',
   'contact_uninvoiced_amount',
   'contact_billing_revision',
+  // plans/money/tasks/48-shopify-tax-data.md §4.4. The FLAG only: Shopify's
+  // `tax_exemptions[]` was empty on every order measured, so the exemption
+  // reason and the resale certificate are not available and are not tracked.
+  'contact_tax_exempt',
 
   // ─── Company fields ────────────────────────────────────────────
   'company_name',
@@ -329,6 +333,10 @@ export const SYSTEM_ATTRIBUTES = [
   'line_item_unit_price',
   'line_item_line_total',
   'line_item_taxable',
+  // plans/money/tasks/48-shopify-tax-data.md §4.2. Deliberately a SCALAR and
+  // not a fan-out: this is what lets `buildFulfillmentEntry` use exact per-line
+  // tax instead of allocating the order total pro rata across shipments.
+  'line_item_tax_total',
   'line_item_optional',
   'line_item_optional_selected',
   'line_item_category',
@@ -343,6 +351,7 @@ export const SYSTEM_ATTRIBUTES = [
   'line_item_order',
   'line_item_part', // stamped from the line's catalog item, not hand-set (08 §6.2)
   'line_item_photos', // scouting/line-level photos (plan 37b §1)
+  'line_item_refund_lines', // inverse of refund_line_line_item (47 §2.2)
 
   // ─── Catalog Item fields ────────────────────────────────────────
   'catalog_item_name',
@@ -452,6 +461,8 @@ export const SYSTEM_ATTRIBUTES = [
   'order_shipping_total',
   'order_total',
   'order_line_items', // inverse of line_item_order
+  'order_tax_lines', // inverse of tax_line_order
+  'order_refunds', // inverse of refund_order (47 §2)
   'order_work_orders', // inverse of work_order_order
   // Added by migration 125 (plans/accounting/HANDOFF.md slot 2G). The
   // shipment log `money.fulfillOrder` appends to, and the ONLY thing that
@@ -461,6 +472,47 @@ export const SYSTEM_ATTRIBUTES = [
   // nothing links to it, and the accounting copy is already normalised in
   // `GlPostingLine`.
   'order_fulfillments',
+
+  // ─── Tax line (plans/money/tasks/48-shopify-tax-data.md §4.1) ────
+  // One jurisdiction's share of one order's tax, as the sales channel computed
+  // it. Records rather than a rate on the order because multi-jurisdiction is
+  // the NORM: 104 of the 123 taxed orders measured carried more than one tax
+  // line (§2), so a single `order_tax_rate` can represent 19 of 123.
+  'tax_line_title', // the jurisdiction, e.g. "CA State Tax"
+  'tax_line_rate', // as supplied; never used to compute anything
+  'tax_line_price', // integer minor units, from `price_set.shop_money.amount` (§8.1)
+  // 🛑 A POSTING INPUT, not decoration (§3, answered in §6.4): only a `false`
+  // line credits 2200 Sales Tax Payable. A `true` line means the marketplace
+  // remitted the tax and this business owes nothing.
+  'tax_line_channel_liable',
+  'tax_line_order', // owning side; inverse of order_tax_lines
+
+  // ─── Refund (plans/money/tasks/47-shopify-refunds.md §2) ─────────
+  // A refund that already happened at the sales channel, ingested as a FACT.
+  // Never originated here: `refundTransaction` calls Stripe and the ledger
+  // refuses anything else, which is the opposite direction (§0.4).
+  'refund_created_at', // when it happened AT the channel; the ledger dates from this, never ingest (§5.3)
+  'refund_note', // the ONLY free-text reason the payload carries (§3.2)
+  // 🛑 DERIVED, not transcribed. A Shopify refund object carries no total at
+  // all (§2.1) - the money lives only on the three legs - so this is the sum
+  // of successful refund transactions. Do not rename it to `refund_total`.
+  'refund_amount_refunded',
+  'refund_order', // owning side; inverse of order_refunds
+  'refund_lines', // inverse of refund_line_refund
+
+  // ─── Refund line (47 §2.2) ──────────────────────────────────────
+  'refund_line_qty',
+  'refund_line_subtotal', // integer minor units
+  // 🛑 Bind from `total_tax_set.shop_money.amount` (a STRING), never the
+  // sibling `total_tax` (a NUMBER) - §4.1. The payload is inconsistent about
+  // money types and the numeric path is where a 100x bug lived.
+  'refund_line_tax_total',
+  // Provider-NEUTRAL disposition, never Shopify's `restock_type` token (§9).
+  // The precedent for getting this wrong is migration 132 renaming
+  // `1200 Shopify Clearing`.
+  'refund_line_disposition',
+  'refund_line_refund', // owning side; inverse of refund_lines
+  'refund_line_line_item', // owning side; inverse of line_item_refund_lines
 
   // ─── Receiving: cost, date and provenance on stock_movement ──────
   // plans/purchasing/01-build-plan.md §2. Every one of these is


### PR DESCRIPTION
Ingest half of money plans **47** (Shopify refunds) and **48** (channel-computed tax), batched into **one** entity migration and one connector field batch, because the per-org remap cost is per batch and doing them separately pays it twice.

## Entity migration 136

Three new defs, all `isVisible: false` and rendered inside the order, following the `line_item` / `payment` precedent:

| def | what it is |
|---|---|
| `refund` | a refund that already happened at the sales channel, ingested as a **fact** |
| `refund_line` | what came back, carrying a provider-neutral disposition |
| `tax_line` | one jurisdiction's share of one order's tax, as a **row** |

Plus four relationship pairs, `line_item_tax_total`, `contact_tax_exempt`, and `4090 Sales Returns and Allowances` with its `revenue_returns_allowances` role.

**Never originated here.** `refundTransaction` calls Stripe's API and the ledger refuses anything else; a channel refund already happened and is ingested, which is the opposite direction.

**Records, not a rate on the order.** Multi-jurisdiction is the norm, so a single `order_tax_rate` can never represent it — and the question being asked is tax by jurisdiction over a period, which is an aggregation and wants rows.

## auxx does not calculate tax

Shopify hands the tax back per refunded line, so it is transcribed, never prorated. Measured on live data: **5/5** refund line items carry `total_tax`, 4 of them non-zero. `line_item_tax_total` is what lets `buildFulfillmentEntry` use exact per-line tax instead of the pro-rata approximation it does today.

🛑 **Money types in this payload are inconsistent** — `total_tax` is a `NUMBER` while `total_tax_set.shop_money.amount` is a `STRING`. Every money field binds the `_set` string form through `decimalToMinorUnits`; the numeric path is where a known 100x bug lived (139 rows).

## SDK

`EntityRefKind` gains the three kinds, following `line_item`'s precedent: all three are hidden, and all three exist precisely so a channel connector can address them.

⚠️ **Requires an `@auxx/sdk` patch release after merge** (`sdk-publish.yml`, `workflow_dispatch`, main only). Until then no machine but the author's can build a connector app against these kinds — the apps repo currently resolves the SDK through a local `link:`.

## No backfill

None is possible: nothing in auxx holds refund or tax data to backfill from. Rows arrive on the next sync after the connector bindings and the per-org remap land.

## Still outstanding

- **Connector side is a separate PR** in `auxxai-apps` (projection, mappings, app fields) and needs the SDK release to build anywhere else.
- **The per-org remap** — a deployed connector field does not reach an existing connector.
- **`build-refund-entry.ts` is not built.** Blocked on two decisions: where the auto-post line sits, and what a period close does with an unreviewed draft. The entry is designed as a reviewable **draft**, not an automatic posting.
- ⚠️ **`4090` ships with a role nothing emits yet.** The `ACCOUNT_ROLES` header names this as a hazard; the builder should follow closely.
- 🛑 **`order` deletion does not cascade to `refund` / `tax_line`.** Latent today (zero rows exist), and tracked in `plans/relationships/01-delete-semantics.md` as one instance of a broader gap in relationship delete semantics.

## Verification

- typecheck ratchet: no new errors (27 total, baseline 27)
- `src/seed` 589 · `src/resources` + `src/postings` 1,706 · SDK 87 — all passing
- Biome clean

https://claude.ai/code/session_01VCyH5K8C27hLtmRjwkYuSN
