### PR TITLE
fix(apps): give a webhook handler the connection it is bound to

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -3,6 +3,7 @@
 import { decryptValue } from '@auxx/credentials'
 import { database, schema } from '@auxx/database'
 import { invokeLambdaExecutor, prepareLambdaContext } from '@auxx/lib/apps'
+import { resolveConnectionForRuntime } from '@auxx/lib/connections'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
 import {
   dedupeWebhookEvent,
@@ -370,7 +371,26 @@ async function handleWebhookRequest(c: any) {
 
     log.info('Invoking Lambda for webhook execution', { handlerId })
 
-    // 5. Build context and invoke Lambda via shared helper
+    // 5. Resolve the connection this handler is bound to, so the handler can read its
+    //    connection variables off `connection.fields`. A webhook verifies its own
+    //    signature, and the secret it verifies with (Slack's signing secret, Meta's app
+    //    secret) is a per-connection value — without this the handler sees no connection
+    //    at all and every delivery fails closed.
+    const connectionResult = await resolveConnectionForRuntime({
+      appId: installation.appId,
+      connectionId: handler.connectionId ?? undefined,
+      organizationId: installation.organizationId,
+      userId: undefined,
+    })
+    if (connectionResult.isErr()) {
+      log.warn('Could not resolve webhook connection', {
+        installationId,
+        handlerId,
+        error: connectionResult.error.message,
+      })
+    }
+
+    // 6. Build context and invoke Lambda via shared helper
     const context = prepareLambdaContext({
       appId: installation.appId,
       installationId,
@@ -379,6 +399,9 @@ async function handleWebhookRequest(c: any) {
       userId: 'system',
       userEmail: null,
       userName: null,
+      organizationConnection: connectionResult.isOk()
+        ? connectionResult.value.organizationConnection
+        : undefined,
     })
 
     const lambdaResult = await invokeLambdaExecutor({
@@ -401,7 +424,7 @@ async function handleWebhookRequest(c: any) {
 
     const result = lambdaResult.value
 
-    // 6. Return handler's response to third-party service
+    // 7. Return handler's response to third-party service
     const handlerExecutionResult = result.execution_result
 
     log.info('Webhook execution completed', {
@@ -410,7 +433,7 @@ async function handleWebhookRequest(c: any) {
       handlerId,
     })
 
-    // 7. If handler returned trigger data and handler has a triggerId, enqueue
+    // 8. If handler returned trigger data and handler has a triggerId, enqueue
     //    dispatch jobs. One emit → two consumers (workflows + agents). Mirrors
     //    the polling-trigger-job side; see plans/kopilot/apps/app-triggers-brainstorm.md §2.
     if (handlerExecutionResult.triggerData && handler.triggerId) {


### PR DESCRIPTION
## What

`handleWebhookRequest` (`apps/api/src/routes/webhooks.ts`) built its lambda context with no `organizationConnection`, so `getConnection()` returned `undefined` inside every app webhook handler and `connection.fields` was unreachable there.

This resolves the handler's bound connection through `resolveConnectionForRuntime` and threads it into the context.

## Why

That is exactly where it is needed. A webhook verifies its own delivery, and the secret it verifies with is a **per-connection** value:

| app | handler | verifies with |
| --- | --- | --- |
| Slack | `slack-events` | signing secret |
| WhatsApp | `whatsapp-events` | Meta app secret |

Both are moving from plaintext `AppSetting` rows to `secret: true` **connection variables** — which encrypts them and pairs each with the token it belongs to, instead of leaving a Slack signing secret in a clear-text `jsonb` column beside the encrypted credential store built for exactly that.

On the old context that move would have been worse than inert: both apps would have read `undefined` and failed closed on every inbound delivery with *"signing secret not configured"*.

## How

The route already knows which connection the handler is bound to — `handler.connectionId`, used today for handler lookup and trigger dispatch. Nothing new is looked up.

- a handler **with** a bound connection resolves that credential (both Slack and WhatsApp register theirs with `connectionId: connection.id`)
- a handler **without** one falls back to the app's org-scoped credential via `appId`
- a resolve **failure** is logged and passes `undefined`, which is the behaviour every handler has today — so this cannot make an existing webhook worse

## Testing

- `pnpm --filter @auxx/api typecheck` — exit 0
- `pnpm exec biome check apps/api/src/routes/webhooks.ts` — clean

⚠️ Not yet driven against a live delivery: the two apps that need it are not pushed, and neither has a live connection. Plan and rollout order in `plans/apps/app-settings/` (untracked).

https://claude.ai/code/session_01U81QmFQA9BnM8zLFPBXhJP