### PR TITLE
fix(accounting): put the journal memo under its account instead of in a narrow column

### DIFF
--- a/apps/web/src/components/accounting/ui/ledger-card.tsx
+++ b/apps/web/src/components/accounting/ui/ledger-card.tsx
@@ -23,7 +23,6 @@ import type {
 } from '@auxx/lib/postings/client'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@auxx/ui/components/dialog'
-import { Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
@@ -196,15 +195,7 @@ function PostingLinesDialog({
         ) : !detail ? (
           <p className='text-muted-foreground text-sm'>No posting matches this link.</p>
         ) : (
-          <Section
-            title='Journal entry'
-            icon={<BookOpenCheck className='size-4' />}
-            collapsible={false}>
-            <EntryJournal
-              lines={journalLinesFromDetail(detail.lines)}
-              currencyCode={currencyCode}
-            />
-          </Section>
+          <EntryJournal lines={journalLinesFromDetail(detail.lines)} currencyCode={currencyCode} />
         )}
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
@@ -59,8 +59,7 @@ export function EntryJournal({ lines, currencyCode, onDrillDown }: EntryJournalP
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className='w-[45%]'>Account</TableHead>
-            <TableHead>Memo</TableHead>
+            <TableHead>Account</TableHead>
             <TableHead className='w-32 text-right'>Debit</TableHead>
             <TableHead className='w-32 text-right'>Credit</TableHead>
           </TableRow>
@@ -86,8 +85,8 @@ export function EntryJournal({ lines, currencyCode, onDrillDown }: EntryJournalP
                     </Tooltip>
                   )}
                 </div>
+                {line.memo && <p className='mt-0.5 text-muted-foreground text-xs'>{line.memo}</p>}
               </TableCell>
-              <TableCell className='align-top text-muted-foreground'>{line.memo}</TableCell>
               <TableCell className='text-right font-mono tabular-nums align-top'>
                 {line.direction === 'debit' ? formatMinor(line.amount, currencyCode) : null}
               </TableCell>
@@ -99,7 +98,7 @@ export function EntryJournal({ lines, currencyCode, onDrillDown }: EntryJournalP
         </TableBody>
         <TableFooter>
           <TableRow>
-            <TableCell colSpan={2}>Totals</TableCell>
+            <TableCell>Totals</TableCell>
             <TableCell className='text-right font-mono tabular-nums'>
               {formatMinor(totalDebit, currencyCode)}
             </TableCell>


### PR DESCRIPTION
## What

The journal entry table (`EntryJournal`) gave the memo its own column, squeezed between a 45%-wide Account column and two fixed `w-32` amount columns. Any real memo wrapped over several lines, so every row in the entry rendered tall.

The memo now renders as a muted second line inside the account cell, directly under `1100 Accounts Receivable`, with the full width of the column. Account loses its `w-[45%]` cap and takes whatever the two amount columns don't.

Also drops the `Journal entry` `Section` wrapper from the `LedgerCard` posting dialog: the dialog title already reads `Posting AUXX-FUL-…`, so the section heading was repeating it. The unused `Section` import goes with it.

## Where this shows up

`EntryJournal` is shared, so this lands on every surface that renders it:

- `PostingDrawer` on the ledger page (`?posting=<id>`)
- the `PostingLinesDialog` in `LedgerCard` (the Ledger tab on order / invoice / payment / bank deposit / build records)
- the ledger page's own posted-entry panel
- the three builder-preview callers: banking review code panel, setup wizard done page, invoice write-off dialog

## Notes

No behavior change to the numbers. Debits still render flush left with credits indented, amounts stay unsigned with `direction` carrying the sign, and the balanced verdict is untouched. The Totals footer cell drops its `colSpan={2}` now that there are three columns.

https://claude.ai/code/session_01TL4yWVFWJiCGBQsPpmegyG