### PR TITLE
feat(accounting): post connector fulfillments in bulk, one entry per ship day

### DIFF
--- a/apps/web/src/app/(protected)/app/orders/page.tsx
+++ b/apps/web/src/app/(protected)/app/orders/page.tsx
@@ -2,11 +2,19 @@
 
 'use client'
 
+import { PostFulfillmentsButton } from '~/components/money/ui/fulfillment-posting'
 import { RecordsView } from '~/components/records'
 
 /**
  * Orders page — renders the shared RecordsView for the orders resource.
+ *
+ * The `pageActions` button is the bulk fulfillment posting's entry point
+ * (plans/money/tasks/49-bulk-fulfillment-posting.md §2.3), following the builds
+ * page's `BackfillBuildsButton` precedent: one header action beside Create, no
+ * extra row above the table. It renders nothing without `ledger.post`.
  */
 export default function OrdersPage() {
-  return <RecordsView slug='orders' basePath='/app/orders' />
+  return (
+    <RecordsView slug='orders' basePath='/app/orders' pageActions={<PostFulfillmentsButton />} />
+  )
 }

--- a/apps/web/src/components/accounting/ui/ledger-card-registrations.tsx
+++ b/apps/web/src/components/accounting/ui/ledger-card-registrations.tsx
@@ -4,7 +4,6 @@
 // `drawer-tab-registry.tsx` (plans/accounting/HANDOFF.md slot 2J, ui-plan §2.3
 // and §4.4). The `sourceType` is what each writer files its lines under:
 //
-//   order         `fulfillOrder` (postings/build-fulfillment-entry.ts)
 //   invoice       `writeOffInvoice` (money/invoices/write-off.ts)
 //   payment       `postPaymentTransaction` (money/payments/ledger.ts)
 //   bank_deposit  `createBankDeposit` (money/bank-deposits/writes.ts)
@@ -16,10 +15,19 @@
 'use client'
 
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { OrderFulfillmentLedgerCard } from '~/components/money/ui/order/order-fulfillment-ledger-card'
 import { LedgerCard } from './ledger-card'
 
+/**
+ * 🛑 The ORDER is the exception: it reads its shipment stamps, not its source
+ * lines (plans/money/tasks/49 §2.5). A bulk fulfillment summarises a day into
+ * one entry filed under `fulfillment_batch` and the period key, so the source
+ * lookup finds nothing for the orders inside it. The registration keeps its name
+ * and its slot; only what it reads changed. See
+ * `money/ui/order/order-fulfillment-ledger-card.tsx` for the whole argument.
+ */
 export function OrderLedgerCard(props: DrawerTabProps) {
-  return <LedgerCard {...props} sourceType='order' />
+  return <OrderFulfillmentLedgerCard {...props} />
 }
 
 export function InvoiceLedgerCard(props: DrawerTabProps) {

--- a/apps/web/src/components/accounting/ui/ledger-card.tsx
+++ b/apps/web/src/components/accounting/ui/ledger-card.tsx
@@ -169,7 +169,15 @@ export function LedgerCard({ entityInstanceId, sourceType }: LedgerCardProps) {
   )
 }
 
-function PostingLinesDialog({
+/**
+ * The posting's lines, opened from a row.
+ *
+ * Exported because the order's card reads a different list (its shipment
+ * STAMPS, see `money/ui/order/order-fulfillment-ledger-card.tsx`) and would
+ * otherwise be a second copy of this dialog: the journal a row opens must not
+ * depend on which card the row came from.
+ */
+export function PostingLinesDialog({
   postingId,
   onOpenChange,
   currencyCode,

--- a/apps/web/src/components/accounting/ui/ledger/books-health.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/books-health.tsx
@@ -44,6 +44,8 @@ export function BooksBalanceLine({ report }: BooksBalanceLineProps) {
         </p>
       )}
 
+      <CompletenessLines report={report} />
+
       {count > 0 && (
         <div className='flex flex-col gap-1.5'>
           {report.discrepancies.map((discrepancy) => (
@@ -58,6 +60,50 @@ export function BooksBalanceLine({ report }: BooksBalanceLineProps) {
             </div>
           ))}
         </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * What the month on screen still owes the ledger: one sentence per count.
+ *
+ * 🛑 This sits under the balance sweep because the two answer different
+ * questions and the first one alone is misleading. Every entry can tie perfectly
+ * while a month is short a week of revenue - shipments logged and never posted,
+ * or a channel refund still sitting as a draft - and a Books section that showed
+ * only "0 discrepancies" would report green books that are incomplete. These are
+ * the same two counts the close refuses on, shown before somebody presses Post
+ * rather than after.
+ *
+ * ⚠️ `null` means the question was not asked (no month on screen), and renders
+ * nothing. It is NOT zero: asserting completeness that was never checked is the
+ * one thing this line must not do. A zero renders nothing either - a clean month
+ * needs no sentence, the way `CompletenessBanner` shows no card for complete
+ * books.
+ */
+function CompletenessLines({ report }: BooksBalanceLineProps) {
+  const shipments = report.unpostedShipments ?? 0
+  const memos = report.unissuedChannelCreditMemos ?? 0
+  if (shipments === 0 && memos === 0) return null
+
+  const month = report.month ? formatPeriodLabel(report.month) : 'this month'
+
+  return (
+    <div className='flex flex-col gap-1'>
+      {shipments > 0 && (
+        <p className='text-xs text-amber-600'>
+          {shipments} {shipments === 1 ? 'shipment in' : 'shipments in'} {month}{' '}
+          {shipments === 1 ? 'has' : 'have'} not been posted, so that revenue is not in the books
+          yet.
+        </p>
+      )}
+      {memos > 0 && (
+        <p className='text-xs text-amber-600'>
+          {memos} channel credit {memos === 1 ? 'memo' : 'memos'} dated in {month}{' '}
+          {memos === 1 ? 'is' : 'are'} still a draft. Issue or void {memos === 1 ? 'it' : 'them'}{' '}
+          before closing.
+        </p>
       )}
     </div>
   )

--- a/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
@@ -13,6 +13,7 @@ import {
   Landmark,
   Lock,
   Map as MapIcon,
+  PackagePlus,
   PackageX,
   Scale,
   Settings2,
@@ -116,6 +117,20 @@ const REMEDIES: Partial<Record<LedgerBlockerStatus, BlockerRemedy>> = {
       'Every inventory balance and activity total is unchanged, so there is no month-end entry to build. This is a skip, not a fault: an organization whose cutoff predates its first movement walks through a run of these.',
     action: 'next-period',
     actionLabel: 'Go to the next month',
+  },
+  // 🛑 `failure`, not `neutral`, and not because anything broke. Unlike an empty
+  // month or a day-one setup, this is a set of books that is genuinely short:
+  // closing on top of it puts revenue permanently outside a month somebody has
+  // certified, because the entry it owes can no longer be written into a locked
+  // period. It is work to do, and the box has to say so.
+  revenue_incomplete: {
+    tone: 'failure',
+    icon: PackagePlus,
+    title: 'This month still holds revenue that is not in the books',
+    guidance:
+      'A shipment that has left with no posting behind it, or a credit memo the sales channel sent that nobody has issued or voided. The message above counts both. Post the fulfillments and settle the drafts first: once the month is closed, the entries they owe cannot be written into it.',
+    href: '/app/orders',
+    actionLabel: 'Open orders',
   },
   error: {
     tone: 'failure',

--- a/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
@@ -144,7 +144,12 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
   )
 
   const failedExportsQuery = api.ledger.failedExports.useQuery({})
-  const balanceQuery = api.ledger.verifyBalance.useQuery()
+  // The month on screen rides along so the sweep can answer the COMPLETENESS
+  // question too - what this month still owes the ledger. Without it the counts
+  // come back `null` and the Books section renders the balance half alone.
+  const balanceQuery = api.ledger.verifyBalance.useQuery({
+    periodKey: activePeriodKey ?? undefined,
+  })
   const roleMapQuery = api.ledger.roleMap.useQuery()
 
   const accountCodeByRole: Partial<Record<AccountRole, string>> = {}

--- a/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
@@ -124,6 +124,16 @@ const OUTCOMES: Record<PostResultStatus, OutcomeCopy> = {
     detail: 'Nothing was written. The message names the row; fix the code or restore the account.',
     tone: 'failure',
   },
+  // 🛑 A refusal, and `failure`, but the sentence is about work rather than a
+  // fault: the month is short of revenue somebody still has to post or void.
+  // Nothing was written, and nothing is broken.
+  revenue_incomplete: {
+    icon: TriangleAlert,
+    title: 'Refused: the month still holds revenue that is not in the books',
+    detail:
+      'Nothing was written. Post the shipments and issue or void the channel credit memos dated in this month first - once it is closed, the entries they owe cannot be written into it.',
+    tone: 'failure',
+  },
   nothing_to_close: {
     icon: CircleSlash,
     title: 'Nothing to close',

--- a/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
@@ -21,6 +21,7 @@ export const ACCOUNTING_KEYS = {
   setupState: 'accounting.setupState',
   cutoffPeriod: 'accounting.cutoffPeriod',
   bookTimeZone: 'accounting.bookTimeZone',
+  fulfillmentPosting: 'accounting.fulfillmentPosting',
   setupFinalizedAt: 'accounting.setupFinalizedAt',
   setupFinalizedByUserId: 'accounting.setupFinalizedByUserId',
   openingRawMaterials: 'accounting.openingRawMaterials',
@@ -45,6 +46,12 @@ export const ACCOUNTING_KEYS = {
 export const PERIOD_DRAFT_KEYS = [
   ACCOUNTING_KEYS.cutoffPeriod,
   ACCOUNTING_KEYS.bookTimeZone,
+  // 🛑 In this slice but NOT frozen. The two keys above rewrite the arithmetic
+  // behind entries that have already posted, so they lock at the first claim;
+  // `fulfillmentPosting` is a MODE that decides what happens next and rewrites
+  // nothing, so freezing it would strand an organization on whichever answer it
+  // happened to have when it posted for the first time.
+  ACCOUNTING_KEYS.fulfillmentPosting,
 ] as const
 
 export const ABSORPTION_DRAFT_KEYS = [

--- a/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
@@ -232,6 +232,27 @@ export function AccountingGeneralSettingsPage() {
                     }
                   />
                 </SettingsFieldRow>
+
+                {/*
+                  🛑 Deliberately NOT frozen, unlike the two rows above it.
+
+                  Those rewrite the arithmetic behind entries that have already
+                  posted, so they lock at the first claim. This one is a MODE: it
+                  decides what happens to the NEXT sync and rewrites nothing that
+                  exists, so an organization that has been posting for a year must
+                  still be able to turn it on - or off, the moment a run surprises
+                  them. It carries no `readOnly` for that reason.
+
+                  Rendered straight from the catalog entry by `SettingsFieldRow`,
+                  so the two modes are declared exactly once, beside the mode
+                  union the runner reads.
+                */}
+                <SettingsFieldRow
+                  settingKey={ACCOUNTING_KEYS.fulfillmentPosting}
+                  title='Post fulfillments'
+                  description='Automatic posts one entry per ship day after every connector sync. Manual waits for the posting dialog, where the preview is the review.'
+                  {...period.controlled(ACCOUNTING_KEYS.fulfillmentPosting)}
+                />
               </FieldPanel>
             </SettingsSection>
 
@@ -370,10 +391,16 @@ export function AccountingGeneralSettingsPage() {
           onSave={() => {
             if (period.dirty) period.save()
             if (absorption.dirty) absorption.save()
+            // 🛑 `routes` counts toward `dirty` and so raises this bar, so it
+            // has to be saved by it too. It was missing here, which made the
+            // payment-route rows the one section on the page whose Save
+            // appeared, did nothing, and left the bar up.
+            if (routes.dirty) routes.save()
           }}
           onDiscard={() => {
             if (period.dirty) period.discard()
             if (absorption.dirty) absorption.discard()
+            if (routes.dirty) routes.discard()
           }}
           saveDisabled={saveDisabled}
         />

--- a/apps/web/src/components/manufacturing/builds/backfill-dialog.tsx
+++ b/apps/web/src/components/manufacturing/builds/backfill-dialog.tsx
@@ -202,8 +202,8 @@ export function BackfillDialog({ open, onOpenChange, onCompleted }: BackfillDial
 
         <DialogNavPages value={page}>
           <DialogNavPage value='plan' size='3xl'>
-            <div className='flex max-h-[78vh] flex-col'>
-              <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
+            <div className='flex flex-col'>
+              <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
                 <div className='flex flex-col gap-4 p-4'>
                   <FieldPanel
                     className='p-0'
@@ -524,8 +524,8 @@ function BackfillResult({
   const failed = result.failed.length
 
   return (
-    <div className='flex max-h-[78vh] flex-col'>
-      <ScrollArea className='min-h-0 flex-1' allowScrollChaining>
+    <div className='flex flex-col'>
+      <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
         <div className='flex flex-col gap-3 p-4 text-sm'>
           <p>
             <strong className='font-medium'>{created}</strong>{' '}

--- a/apps/web/src/components/money/ui/fulfillment-posting/fulfillment-exclusions.tsx
+++ b/apps/web/src/components/money/ui/fulfillment-posting/fulfillment-exclusions.tsx
@@ -1,0 +1,122 @@
+// apps/web/src/components/money/ui/fulfillment-posting/fulfillment-exclusions.tsx
+'use client'
+
+// The shipments in the range that produce no posting, with the reason
+// (§2.3 item 4 of plans/money/tasks/49-bulk-fulfillment-posting.md, following
+// 44 §7.2b and `manufacturing/builds/backfill-exclusions.tsx`).
+//
+// 🛑 **The first question anyone asks this screen is "where is order 1042?"** If
+// an excluded shipment is simply absent, that question has no answer, and a
+// preview whose omissions cannot be explained is a preview nobody trusts,
+// which on this screen means somebody posts the day twice looking for it.
+//
+// `FulfillmentPostingExclusionReason` is closed on purpose, so `EXCLUSION_COPY`
+// is a total `Record` over it: a seventh reason stops this file compiling rather
+// than rendering as a raw slug.
+//
+// ⚠️ **The `detail` column is not decoration.** Every exclusion carries the
+// number or the value that PROVES its reason: the cutoff month, the currency
+// code, the gateway list. A reason without its evidence is an assertion.
+// `gateway-ambiguous` in particular is unbelievable without the two gateways
+// that caused it.
+
+import type {
+  FulfillmentPostingExclusion,
+  FulfillmentPostingExclusionReason,
+} from '@auxx/lib/money/client'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { formatDayKey } from './fulfillment-plan-table'
+
+/**
+ * What each reason says on the row.
+ *
+ * The `detail` here is the RULE; the exclusion's own `detail` beside it is the
+ * evidence. Both are needed: "before the accounting cutoff" explains nothing
+ * without the cutoff, and `2026-06` explains nothing on its own.
+ */
+const EXCLUSION_COPY: Record<FulfillmentPostingExclusionReason, { label: string; detail: string }> =
+  {
+    'before-cutoff': {
+      label: 'Before the accounting cutoff',
+      detail: 'It shipped in a period the books were opened after.',
+    },
+    'locked-period': {
+      label: 'Locked period',
+      detail: 'Its month is closed, and a closed month does not take new entries.',
+    },
+    'foreign-currency': {
+      label: 'Foreign currency',
+      detail: 'The order is not in the currency the books are kept in.',
+    },
+    'gateway-ambiguous': {
+      label: 'Two payment gateways',
+      detail: 'Which account this debits cannot be decided from the order alone.',
+    },
+    'test-gateway': {
+      label: 'Test gateway',
+      detail: 'A test checkout, which is not a sale.',
+    },
+    'zero-value': {
+      label: 'Nothing to recognise',
+      detail: 'The shipment totals zero, so there is no entry to make.',
+    },
+  }
+
+interface FulfillmentExclusionsProps {
+  exclusions: readonly FulfillmentPostingExclusion[]
+}
+
+export function FulfillmentExclusions({ exclusions }: FulfillmentExclusionsProps) {
+  if (exclusions.length === 0) return null
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <p className='font-medium text-muted-foreground text-xs'>
+        Not being posted ({exclusions.length})
+      </p>
+
+      <div className='overflow-x-auto rounded-md border border-dashed bg-muted/40'>
+        <Table>
+          <TableHeader>
+            <TableRow className='hover:bg-transparent'>
+              <TableHead className='min-w-[140px] text-muted-foreground'>Order</TableHead>
+              <TableHead className='min-w-[110px] text-muted-foreground'>Ship date</TableHead>
+              <TableHead className='min-w-[200px] text-muted-foreground'>Reason</TableHead>
+              <TableHead className='min-w-[160px] text-muted-foreground'>Detail</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {exclusions.map((exclusion) => {
+              const copy = EXCLUSION_COPY[exclusion.reason]
+              return (
+                <TableRow
+                  // `(orderId, sequence)`: an order can have two shipments
+                  // excluded for two different reasons.
+                  key={`${exclusion.orderId}-${exclusion.sequence}`}
+                  className='text-muted-foreground'>
+                  <TableCell>
+                    <span className='block truncate text-xs'>{exclusion.orderNumber}</span>
+                    <span className='block text-[11px]'>Shipment {exclusion.sequence}</span>
+                  </TableCell>
+                  <TableCell className='text-xs'>{formatDayKey(exclusion.shippedAt)}</TableCell>
+                  <TableCell>
+                    <span className='block text-xs'>{copy.label}</span>
+                    <span className='block text-[11px]'>{copy.detail}</span>
+                  </TableCell>
+                  <TableCell className='text-[11px] break-words'>{exclusion.detail}</TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/money/ui/fulfillment-posting/fulfillment-plan-table.tsx
+++ b/apps/web/src/components/money/ui/fulfillment-posting/fulfillment-plan-table.tsx
@@ -1,0 +1,255 @@
+// apps/web/src/components/money/ui/fulfillment-posting/fulfillment-plan-table.tsx
+'use client'
+
+// The preview table (§2.3 item 3 of plans/money/tasks/49-bulk-fulfillment-posting.md).
+//
+// Rows are GROUP-first, which is the opposite axis to
+// `manufacturing/builds/backfill-plan-table.tsx` and for a mechanical reason:
+// the backfill's On hand column is a per-part quantity consumed across periods,
+// so a period-first row had nowhere honest to put it. Nothing here is per order
+// across groups, a shipment belongs to exactly one group, and the group IS the
+// posting that will be written. One row, one entry.
+//
+// 🛑 **The debit split is on the row, not in a footnote.** A day's revenue is one
+// number; where the money is expected FROM is three, and they are what tells
+// somebody the run is sane before it is irreversible. Card clearing drains on the
+// next payout, Affirm clearing on its own settlement, and A/R is somebody who
+// still owes (§3.2). Folding them into one Total hides the only part of this
+// screen that can be wrong in a way the total cannot show.
+//
+// Expanding a group shows the shipments behind it, because the first question
+// anyone asks a summarised entry is *which orders are in this?*, and after the
+// entry is posted the ledger will never be able to answer it at this grain
+// (§2.5: the frozen list rides in the posting's draft envelope, not in a line).
+
+import type {
+  FulfillmentDebitRole,
+  FulfillmentPostingGroup,
+  FulfillmentPostingPlan,
+  PlannedShipment,
+} from '@auxx/lib/money/client'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+import { formatMinor } from '~/components/accounting/ui/ledger/format'
+
+/** The account each debit role names, spelled out where there is room for it. */
+export const DEBIT_ROLE_LABEL: Record<FulfillmentDebitRole, string> = {
+  clearing_card: 'Card clearing',
+  clearing_affirm: 'Affirm clearing',
+  accounts_receivable: 'Accounts receivable',
+}
+
+/** The same three, short enough for a column head. */
+const DEBIT_ROLE_COLUMN: Record<FulfillmentDebitRole, string> = {
+  clearing_card: 'Card',
+  clearing_affirm: 'Affirm',
+  accounts_receivable: 'A/R',
+}
+
+/** The order the debit columns are read in. Card first: it is the common case. */
+const DEBIT_ROLE_ORDER: readonly FulfillmentDebitRole[] = [
+  'clearing_card',
+  'clearing_affirm',
+  'accounts_receivable',
+]
+
+/**
+ * How a shipment's tax was arrived at.
+ *
+ * ⚠️ Shown per shipment rather than per group because it can differ INSIDE one
+ * group: an order whose every line carries `line_item_tax_total` uses those
+ * numbers, and one that is missing any of them has the order's tax allocated
+ * across its lines instead (48 §8.2). A day can hold both, and the two are not
+ * equally trustworthy.
+ */
+const TAX_BASIS_LABEL: Record<PlannedShipment['amounts']['taxBasis'], string> = {
+  per_line: 'tax per line',
+  allocated: 'tax allocated',
+}
+
+interface FulfillmentPlanTableProps {
+  plan: FulfillmentPostingPlan
+  currencyCode: string
+}
+
+export function FulfillmentPlanTable({ plan, currencyCode }: FulfillmentPlanTableProps) {
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set<string>())
+
+  if (plan.groups.length === 0) {
+    return (
+      <p className='rounded-md border border-dashed px-3 py-6 text-center text-muted-foreground text-sm'>
+        Nothing to post in this range. Every shipment in it either already carries a live posting or
+        is listed below with the reason it does not.
+      </p>
+    )
+  }
+
+  const toggle = (groupKey: string) =>
+    setExpanded((current) => {
+      const next = new Set(current)
+      if (!next.delete(groupKey)) next.add(groupKey)
+      return next
+    })
+
+  return (
+    <div className='overflow-x-auto rounded-md border'>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className='min-w-[150px]'>Period</TableHead>
+            <TableHead className='min-w-[110px]'>Ship date</TableHead>
+            <TableHead className='text-right'>Orders</TableHead>
+            <TableHead className='text-right'>Shipments</TableHead>
+            <TableHead className='text-right'>Subtotal</TableHead>
+            <TableHead className='text-right'>Tax</TableHead>
+            <TableHead className='text-right'>Shipping</TableHead>
+            <TableHead className='text-right'>Total</TableHead>
+            {DEBIT_ROLE_ORDER.map((role) => (
+              <TableHead key={role} className='text-right' title={DEBIT_ROLE_LABEL[role]}>
+                {DEBIT_ROLE_COLUMN[role]}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {plan.groups.map((group) => (
+            <GroupRows
+              key={group.groupKey}
+              group={group}
+              currencyCode={currencyCode}
+              open={expanded.has(group.groupKey)}
+              onToggle={() => toggle(group.groupKey)}
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+/** The posting row, and the shipments it summarises underneath it. */
+function GroupRows({
+  group,
+  currencyCode,
+  open,
+  onToggle,
+}: {
+  group: FulfillmentPostingGroup
+  currencyCode: string
+  open: boolean
+  onToggle: () => void
+}) {
+  const Chevron = open ? ChevronDown : ChevronRight
+
+  return (
+    <>
+      <TableRow className='cursor-pointer' onClick={onToggle}>
+        <TableCell className='font-medium'>
+          <span className='flex items-center gap-1'>
+            <Chevron className='size-3.5 shrink-0 text-muted-foreground' />
+            <span className='truncate font-mono text-xs'>{group.groupKey}</span>
+          </span>
+        </TableCell>
+        <TableCell className='text-muted-foreground text-xs'>
+          {formatDayKey(group.txnDate)}
+        </TableCell>
+        <TableCell className='text-right tabular-nums'>{group.orderCount}</TableCell>
+        <TableCell className='text-right tabular-nums'>{group.shipments.length}</TableCell>
+        <TableCell className='text-right tabular-nums'>
+          {formatMinor(group.totals.subtotalMinor, currencyCode)}
+        </TableCell>
+        <TableCell className='text-right tabular-nums'>
+          {formatMinor(group.totals.taxMinor, currencyCode)}
+        </TableCell>
+        <TableCell className='text-right tabular-nums'>
+          {formatMinor(group.totals.shippingMinor, currencyCode)}
+        </TableCell>
+        <TableCell className='text-right font-medium tabular-nums'>
+          {formatMinor(group.totals.totalMinor, currencyCode)}
+        </TableCell>
+        {DEBIT_ROLE_ORDER.map((role) => (
+          <TableCell key={role} className='text-right text-muted-foreground tabular-nums'>
+            {formatSplit(group.totals.byDebitRole[role], currencyCode)}
+          </TableCell>
+        ))}
+      </TableRow>
+
+      {open &&
+        group.shipments.map((shipment) => (
+          // 🛑 Keyed on `(orderId, sequence)`, never on `orderId`. One order can
+          // ship twice on the same day under a week or month grouping, and a
+          // list keyed on the order alone silently drops the second shipment
+          // out of a table whose whole job is proving what is in the entry.
+          <TableRow
+            key={`${shipment.orderId}-${shipment.sequence}`}
+            className='bg-muted/30 hover:bg-muted/40'>
+            <TableCell className='text-xs'>
+              <span className='block ps-4 truncate'>{shipment.orderNumber}</span>
+              <span className='block ps-4 text-[11px] text-muted-foreground'>
+                Shipment {shipment.sequence} · {DEBIT_ROLE_LABEL[shipment.amounts.debitRole]} ·{' '}
+                {TAX_BASIS_LABEL[shipment.amounts.taxBasis]}
+              </span>
+            </TableCell>
+            <TableCell className='text-muted-foreground text-xs'>
+              {formatDayKey(shipment.shippedAt)}
+            </TableCell>
+            <TableCell />
+            <TableCell />
+            <TableCell className='text-right text-muted-foreground tabular-nums'>
+              {formatMinor(shipment.amounts.subtotalMinor, currencyCode)}
+            </TableCell>
+            <TableCell className='text-right text-muted-foreground tabular-nums'>
+              {formatMinor(shipment.amounts.taxMinor, currencyCode)}
+            </TableCell>
+            <TableCell className='text-right text-muted-foreground tabular-nums'>
+              {formatMinor(shipment.amounts.shippingMinor, currencyCode)}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatMinor(shipment.amounts.totalMinor, currencyCode)}
+            </TableCell>
+            {DEBIT_ROLE_ORDER.map((role) => (
+              <TableCell key={role} className='text-right text-muted-foreground tabular-nums'>
+                {shipment.amounts.debitRole === role
+                  ? formatMinor(shipment.amounts.totalMinor, currencyCode)
+                  : ''}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+    </>
+  )
+}
+
+/** A zero in a split column is noise; the three that are non-zero are the answer. */
+function formatSplit(minorUnits: number | undefined, currencyCode: string): string {
+  if (!minorUnits) return ''
+  return formatMinor(minorUnits, currencyCode)
+}
+
+/**
+ * Render a `YYYY-MM-DD` group or shipment key.
+ *
+ * 🛑 Formatted in UTC and NOT through `formatAccountingDate`. These keys were
+ * already cut in the org's book time zone server-side, so re-projecting them
+ * into that zone shifts a July 1 shipment to June 30 on any org west of UTC:
+ * the day the posting is filed under and the day the table shows would then
+ * disagree, on the one screen whose job is to be believed.
+ */
+export function formatDayKey(dayKey: string): string {
+  const date = new Date(`${dayKey}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime())) return dayKey
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date)
+}

--- a/apps/web/src/components/money/ui/fulfillment-posting/index.ts
+++ b/apps/web/src/components/money/ui/fulfillment-posting/index.ts
@@ -1,0 +1,6 @@
+// apps/web/src/components/money/ui/fulfillment-posting/index.ts
+
+export { FulfillmentExclusions } from './fulfillment-exclusions'
+export { FulfillmentPlanTable } from './fulfillment-plan-table'
+export { PostFulfillmentsButton } from './post-fulfillments-button'
+export { PostFulfillmentsDialog } from './post-fulfillments-dialog'

--- a/apps/web/src/components/money/ui/fulfillment-posting/post-fulfillments-button.tsx
+++ b/apps/web/src/components/money/ui/fulfillment-posting/post-fulfillments-button.tsx
@@ -1,0 +1,46 @@
+// apps/web/src/components/money/ui/fulfillment-posting/post-fulfillments-button.tsx
+'use client'
+
+// The entry point on the orders list, `RecordsView`'s `pageActions` slot,
+// beside Create (plans/money/tasks/49 §8.6 lane E). Same shape as
+// `manufacturing/builds/backfill-builds-button.tsx`, which is the precedent for
+// a list-level action that opens a batch dialog.
+//
+// 🛑 Gated on `ledger.post`, the same key the per-order Fulfill button takes and
+// for the same reason: this writes `GlPosting` rows. A reader who cannot post an
+// entry has no use for a preview of one, and the router refuses the mutation
+// regardless, hiding the button is so the refusal never has to be explained.
+
+import { Button } from '@auxx/ui/components/button'
+import { BookOpenCheck } from 'lucide-react'
+import { useState } from 'react'
+import { useAccess } from '~/providers/capabilities-provider'
+import { api } from '~/trpc/react'
+import { PostFulfillmentsDialog } from './post-fulfillments-dialog'
+
+export function PostFulfillmentsButton() {
+  const [open, setOpen] = useState(false)
+  const { can } = useAccess()
+  const utils = api.useUtils()
+
+  if (!can('ledger.post')) return null
+
+  return (
+    <>
+      <Button variant='outline' size='sm' onClick={() => setOpen(true)}>
+        <BookOpenCheck /> Post fulfillments
+      </Button>
+      {/* Mounted only while open so the preview query does not run on every
+          visit to the orders list. Same reasoning as `BackfillBuildsButton`. */}
+      {open && (
+        <PostFulfillmentsDialog
+          open={open}
+          onOpenChange={setOpen}
+          // The run stamps the shipment log of every order it covered, and the
+          // list is showing those orders.
+          onCompleted={() => void utils.invalidate()}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/src/components/money/ui/fulfillment-posting/post-fulfillments-dialog.tsx
+++ b/apps/web/src/components/money/ui/fulfillment-posting/post-fulfillments-dialog.tsx
@@ -1,0 +1,494 @@
+// apps/web/src/components/money/ui/fulfillment-posting/post-fulfillments-dialog.tsx
+'use client'
+
+// The bulk fulfillment posting (§2.3 of
+// plans/money/tasks/49-bulk-fulfillment-posting.md), *"getting thousands of
+// Shopify orders into the ledger without a click per order."*
+//
+// Copied structurally from `manufacturing/builds/backfill-dialog.tsx`, which is
+// the house shape for *preview a batch, then run it*: a range, a grouping, a
+// read-only plan, the excluded rows with the number that proves each, a footer
+// that moves as the grouping changes, and a result page that reports per group.
+//
+// ## Why the grouping control stays even though the answer is always "day"
+//
+// The footer moving from 613 postings to 62 to 2 as the control changes IS the
+// feature (§2.3 item 2, 44 §7.2). It makes the tradeoff visible instead of baked
+// into a constant nobody can see. Per day is what a live month wants; per month
+// is what a year of history wants, and neither is a code change.
+//
+// ## The range is on SHIP date, and it is half-open
+//
+// Revenue is recognised when goods ship (§2.3 item 1), so the window is on the
+// shipment log's `shippedAt` and never on when the order was placed or keyed.
+// `to` is EXCLUSIVE: the day itself is not included, which is what makes two
+// consecutive runs cover a month without overlapping.
+//
+// ## The plan is never sent to the server
+//
+// `runFulfillmentPosting` takes the same range and grouping the preview took and
+// re-plans server-side. A client-supplied plan would let a stale preview name
+// amounts and periods that no read ever produced, on an append-only ledger.
+
+import { FieldType } from '@auxx/database/enums'
+import {
+  FULFILLMENT_POSTING_GROUPINGS,
+  type FulfillmentPostingGrouping,
+  type FulfillmentPostingRunSummary,
+} from '@auxx/lib/money/client'
+import { Button } from '@auxx/ui/components/button'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { keepPreviousData } from '@tanstack/react-query'
+import { TriangleAlert } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { formatMinor } from '~/components/accounting/ui/ledger/format'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import { FulfillmentExclusions } from './fulfillment-exclusions'
+import { FulfillmentPlanTable } from './fulfillment-plan-table'
+
+/**
+ * How much one posting summarises.
+ *
+ * A total `Record` over the closed union, so a fourth grouping stops this file
+ * compiling rather than rendering an empty option.
+ */
+const GROUPING_LABELS: Record<FulfillmentPostingGrouping, string> = {
+  day: 'One entry per day',
+  week: 'One entry per week',
+  month: 'One entry per month',
+}
+
+/** Driven off the exported vocabulary, so a fourth grouping arrives in the select on its own. */
+const GROUPING_OPTIONS: Array<{ value: string; label: string }> = FULFILLMENT_POSTING_GROUPINGS.map(
+  (value) => ({ value, label: GROUPING_LABELS[value] })
+)
+
+interface PostFulfillmentsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCompleted?: () => void
+}
+
+export function PostFulfillmentsDialog({
+  open,
+  onOpenChange,
+  onCompleted,
+}: PostFulfillmentsDialogProps) {
+  const [page, setPage] = useState<'plan' | 'result'>('plan')
+  const [from, setFrom] = useState<string>(() => startOfLastMonth())
+  const [to, setTo] = useState<string>(() => today())
+  const [grouping, setGrouping] = useState<FulfillmentPostingGrouping>('day')
+  const [result, setResult] = useState<FulfillmentPostingRunSummary | null>(null)
+
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+
+  const utils = api.useUtils()
+
+  // A fresh dialog on every open. A range somebody abandoned yesterday would
+  // silently post the wrong window onto a ledger that only reversing undoes.
+  useEffect(() => {
+    if (!open) return
+    setPage('plan')
+    setFrom(startOfLastMonth())
+    setTo(today())
+    setGrouping('day')
+    setResult(null)
+  }, [open])
+
+  // 🛑 The date input speaks instants (`2026-08-01T00:00:00.000Z`); the range is
+  // a pair of CALENDAR DAYS the server cuts in the book time zone. Narrowed here
+  // rather than in the input so the picker keeps round-tripping its own value.
+  const fromKey = dayKey(from)
+  const toKey = dayKey(to)
+
+  const preview = api.money.previewFulfillmentPosting.useQuery(
+    { from: fromKey, to: toKey, grouping },
+    {
+      enabled: open && page === 'plan',
+      retry: false,
+      refetchOnWindowFocus: false,
+      // Without this every grouping change blanks the table, the excluded block
+      // and the footer together, which reads as "the numbers just went away" on
+      // the one screen whose whole point is watching those numbers move.
+      placeholderData: keepPreviousData,
+    }
+  )
+
+  const plan = preview.data?.plan ?? null
+  const refusal = preview.data?.refusal ?? null
+
+  const post = api.money.runFulfillmentPosting.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Could not post fulfillments', description: error.message }),
+  })
+
+  const handleRun = async () => {
+    if (!plan || plan.footer.postings === 0) return
+    try {
+      const summary = await post.mutateAsync({ from: fromKey, to: toKey, grouping })
+      setResult(summary)
+      setPage('result')
+      // The run writes `GlPosting` rows and stamps every shipment behind them,
+      // and nothing on the ledger page or an order's ledger card learns about
+      // either on its own.
+      await Promise.all([
+        utils.ledger.invalidate(),
+        utils.money.orderFulfillmentPostings.invalidate(),
+        utils.money.previewFulfillmentPosting.invalidate(),
+      ])
+      onCompleted?.()
+    } catch {
+      // onError already surfaced the toast.
+    }
+  }
+
+  const stale = preview.isFetching
+  const canRun = !!plan && plan.footer.postings > 0 && !refusal && !stale && !post.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !post.isPending && onOpenChange(next)}>
+      <DialogContent size='content' position='tc' innerClassName='p-0'>
+        <DialogNav
+          title='Post fulfillments'
+          description='Recognise the revenue for everything that has shipped and has no entry yet.'
+          crumbs={[
+            {
+              label: 'Post fulfillments',
+              onClick: page === 'result' ? () => setPage('plan') : undefined,
+            },
+            ...(page === 'result' ? [{ label: 'Result' }] : []),
+          ]}
+        />
+
+        <DialogNavPages value={page}>
+          <DialogNavPage value='plan' size='3xl'>
+            <div className='flex flex-col'>
+              <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
+                <div className='flex flex-col gap-4 p-4'>
+                  <FieldPanel
+                    className='p-0'
+                    orientation='responsive'
+                    breakpoint='md'
+                    resizeId='post-fulfillments'
+                    defaultLabelWidth={180}>
+                    <FieldPanelRow
+                      title='From'
+                      type={BaseType.DATE}
+                      showIcon
+                      isRequired
+                      description='On the date the shipment left, not the date the order was placed'>
+                      <FieldInputAdapter
+                        fieldType={FieldType.DATE}
+                        value={from}
+                        onChange={(value) => setFrom((value as string) ?? from)}
+                        disabled={post.isPending}
+                      />
+                    </FieldPanelRow>
+
+                    <FieldPanelRow
+                      title='To'
+                      type={BaseType.DATE}
+                      showIcon
+                      isRequired
+                      description='Exclusive, the day itself is not included'>
+                      <FieldInputAdapter
+                        fieldType={FieldType.DATE}
+                        value={to}
+                        onChange={(value) => setTo((value as string) ?? to)}
+                        disabled={post.isPending}
+                      />
+                    </FieldPanelRow>
+
+                    <FieldPanelRow
+                      title='Group into'
+                      type={BaseType.ENUM}
+                      showIcon
+                      isRequired
+                      description='How many shipments one entry summarises'>
+                      <FieldInputAdapter
+                        fieldType={FieldType.SINGLE_SELECT}
+                        fieldOptions={{ options: GROUPING_OPTIONS }}
+                        value={grouping}
+                        onChange={(value) =>
+                          setGrouping(
+                            ((value as string[])[0] as FulfillmentPostingGrouping) ?? 'day'
+                          )
+                        }
+                        disabled={post.isPending}
+                      />
+                    </FieldPanelRow>
+                  </FieldPanel>
+
+                  {/* A refusal is a card, not a toast (ground rule 9): the book
+                      time zone being unset is a settings task with an address,
+                      and a sentence that disappears cannot carry one. */}
+                  {refusal && <Note tone='warning'>{refusal}</Note>}
+
+                  {preview.error && !refusal && <Note tone='warning'>{preview.error.message}</Note>}
+
+                  {preview.isPending && !plan && <PlanSkeleton />}
+
+                  {plan && (
+                    <div
+                      className={
+                        stale
+                          ? 'flex flex-col gap-4 opacity-60 transition-opacity'
+                          : 'flex flex-col gap-4 transition-opacity'
+                      }>
+                      <FulfillmentPlanTable plan={plan} currencyCode={currencyCode} />
+
+                      <FulfillmentExclusions exclusions={plan.exclusions} />
+
+                      {plan.footer.postings > 0 && (
+                        <Note>
+                          Posting writes {plan.footer.postings}{' '}
+                          {plan.footer.postings === 1 ? 'entry' : 'entries'} onto an append-only
+                          ledger. They can only be corrected by reversing them, never by editing
+                          them.
+                        </Note>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </ScrollArea>
+
+              {/* 🛑 The footer is the feature, not decoration. Watching it go
+                  from 613 postings to 62 to 2 as the grouping changes is how the
+                  tradeoff becomes visible instead of a constant nobody sees. */}
+              <div className='flex shrink-0 flex-wrap items-center justify-between gap-2 border-t px-4 py-2.5'>
+                <p className='text-muted-foreground text-sm tabular-nums'>
+                  {plan ? (
+                    <>
+                      <strong className='font-medium text-foreground'>
+                        {plan.footer.postings}
+                      </strong>{' '}
+                      {plan.footer.postings === 1 ? 'posting' : 'postings'} ·{' '}
+                      <strong className='font-medium text-foreground'>
+                        {plan.footer.shipments}
+                      </strong>{' '}
+                      {plan.footer.shipments === 1 ? 'shipment' : 'shipments'} ·{' '}
+                      <strong className='font-medium text-foreground'>{plan.footer.orders}</strong>{' '}
+                      {plan.footer.orders === 1 ? 'order' : 'orders'} ·{' '}
+                      <strong className='font-medium text-foreground'>
+                        {formatMinor(plan.footer.totalMinor, currencyCode)}
+                      </strong>
+                    </>
+                  ) : (
+                    'No preview yet'
+                  )}
+                </p>
+
+                <div className='flex items-center gap-2'>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='sm'
+                    onClick={() => onOpenChange(false)}
+                    disabled={post.isPending}>
+                    Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={handleRun}
+                    loading={post.isPending}
+                    loadingText='Posting...'
+                    disabled={!canRun}
+                    data-dialog-submit>
+                    Post {plan?.footer.postings ?? 0}{' '}
+                    {plan?.footer.postings === 1 ? 'entry' : 'entries'}{' '}
+                    <KbdSubmit variant='outline' size='sm' />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </DialogNavPage>
+
+          <DialogNavPage value='result' size='3xl'>
+            <PostResult
+              result={result}
+              onBack={() => setPage('plan')}
+              onClose={() => onOpenChange(false)}
+            />
+          </DialogNavPage>
+        </DialogNavPages>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Result ───────────────────────────────────────────────────────────────
+
+/**
+ * What the run actually did, per group.
+ *
+ * 🛑 **Skipped is not failed and neither is an error.** `postEntry` never throws:
+ * `already_posted` means the day is in the books already, and a locked period
+ * means somebody closed the month. Reporting either as a failure is what makes
+ * people press the button a second time, which on this screen would be asking
+ * for the same revenue twice.
+ */
+function PostResult({
+  result,
+  onBack,
+  onClose,
+}: {
+  result: FulfillmentPostingRunSummary | null
+  onBack: () => void
+  onClose: () => void
+}) {
+  const shipmentsPosted = useMemo(
+    () => (result?.posted ?? []).reduce((total, row) => total + row.shipments, 0),
+    [result]
+  )
+
+  if (!result) return null
+
+  const posted = result.posted.length
+  const skipped = result.skipped.length
+  const failed = result.failed.length
+
+  return (
+    <div className='flex flex-col'>
+      <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
+        <div className='flex flex-col gap-3 p-4 text-sm'>
+          <p>
+            <strong className='font-medium'>{posted}</strong>{' '}
+            {posted === 1 ? 'entry was' : 'entries were'} posted, covering {shipmentsPosted}{' '}
+            {shipmentsPosted === 1 ? 'shipment' : 'shipments'}.
+          </p>
+
+          {posted > 0 && (
+            <ul className='ps-4 text-muted-foreground text-xs tabular-nums'>
+              {result.posted.slice(0, 24).map((row) => (
+                <li key={row.groupKey}>
+                  <span className='font-mono'>{row.docNumber}</span> · {row.groupKey} ·{' '}
+                  {row.shipments} {row.shipments === 1 ? 'shipment' : 'shipments'}
+                </li>
+              ))}
+              {posted > 24 && <li>and {posted - 24} more</li>}
+            </ul>
+          )}
+
+          {skipped > 0 && (
+            <div>
+              <p>
+                {skipped} {skipped === 1 ? 'group was' : 'groups were'} skipped. Nothing was written
+                for {skipped === 1 ? 'it' : 'them'}, and nothing is wrong.
+              </p>
+              <ul className='mt-1 ps-4 text-muted-foreground text-xs'>
+                {result.skipped.slice(0, 24).map((row) => (
+                  <li key={row.groupKey}>
+                    {row.groupKey}: {row.status}, {row.reason}
+                  </li>
+                ))}
+                {skipped > 24 && <li>and {skipped - 24} more</li>}
+              </ul>
+            </div>
+          )}
+
+          {failed > 0 && (
+            <div>
+              <p className='flex items-start gap-1.5'>
+                <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+                <span>
+                  {failed} {failed === 1 ? 'group' : 'groups'} wrote nothing at all. They stay
+                  unposted and come back in the next preview.
+                </span>
+              </p>
+              <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
+                {result.failed.slice(0, 24).map((row) => (
+                  <li key={row.groupKey}>
+                    {row.groupKey}: {row.reason}
+                  </li>
+                ))}
+                {failed > 24 && <li>and {failed - 24} more</li>}
+              </ul>
+            </div>
+          )}
+
+          {result.exclusions.length > 0 && (
+            <p className='text-muted-foreground text-xs'>
+              {result.exclusions.length}{' '}
+              {result.exclusions.length === 1 ? 'shipment was' : 'shipments were'} excluded from
+              this run. They are listed with their reasons on the preview.
+            </p>
+          )}
+        </div>
+      </ScrollArea>
+
+      <div className='flex shrink-0 items-center justify-end gap-2 border-t px-4 py-2.5'>
+        <Button type='button' variant='ghost' size='sm' onClick={onBack}>
+          Back to the preview
+        </Button>
+        <Button variant='outline' size='sm' onClick={onClose} data-dialog-submit>
+          Done <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Small pieces ─────────────────────────────────────────────────────────
+
+function Note({ children, tone }: { children: React.ReactNode; tone?: 'warning' }) {
+  return (
+    <p
+      className={
+        tone === 'warning'
+          ? 'flex items-start gap-1.5 rounded-md border border-amber-300 bg-amber-50/60 px-3 py-2 text-sm dark:border-amber-900 dark:bg-amber-950/30'
+          : 'rounded-md border bg-muted/40 px-3 py-2 text-muted-foreground text-sm'
+      }>
+      {tone === 'warning' && (
+        <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+      )}
+      <span>{children}</span>
+    </p>
+  )
+}
+
+function PlanSkeleton() {
+  return (
+    <div className='flex flex-col gap-2'>
+      <Skeleton className='h-9 w-full' />
+      <Skeleton className='h-9 w-full' />
+      <Skeleton className='h-9 w-full' />
+    </div>
+  )
+}
+
+/** The instant shape `FieldInputAdapter`'s DATE input round-trips. */
+function dayIso(year: number, month: number, day: number): string {
+  const y = String(year).padStart(4, '0')
+  const m = String(month + 1).padStart(2, '0')
+  const d = String(day).padStart(2, '0')
+  return `${y}-${m}-${d}T00:00:00.000Z`
+}
+
+/** The first day of the previous month, the window a monthly close asks for. */
+function startOfLastMonth(): string {
+  const now = new Date()
+  const first = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+  return dayIso(first.getFullYear(), first.getMonth(), 1)
+}
+
+/** Today in the viewer's own zone. The server re-cuts the day in book time. */
+function today(): string {
+  const now = new Date()
+  return dayIso(now.getFullYear(), now.getMonth(), now.getDate())
+}
+
+/** `2026-08-01T00:00:00.000Z` becomes `2026-08-01`, which is what the range is. */
+function dayKey(value: string): string {
+  return value.slice(0, 10)
+}

--- a/apps/web/src/components/money/ui/order/fulfill-order-dialog.tsx
+++ b/apps/web/src/components/money/ui/order/fulfill-order-dialog.tsx
@@ -223,7 +223,7 @@ export function FulfillOrderDialog({
                       value={shippedAt}
                       onChange={(value) => {
                         setTouched(true)
-                        setShippedAt((value as string) ?? todayKey())
+                        setShippedAt(((value as string | null) ?? todayKey()).slice(0, 10))
                       }}
                       disabled={fulfill.isPending}
                     />

--- a/apps/web/src/components/money/ui/order/order-fulfillment-ledger-card.tsx
+++ b/apps/web/src/components/money/ui/order/order-fulfillment-ledger-card.tsx
@@ -1,0 +1,95 @@
+// apps/web/src/components/money/ui/order/order-fulfillment-ledger-card.tsx
+'use client'
+
+// The order drawer's ledger card, read by STAMP rather than by source line
+// (§2.5 of plans/money/tasks/49-bulk-fulfillment-posting.md).
+//
+// 🛑 **Why the order cannot use the generic `LedgerCard`.** That card asks
+// "which postings have a line naming this record as their source?", which was
+// the right question while one order produced one entry. A bulk fulfillment
+// summarises a whole day into one entry whose revenue, tax and shipping lines
+// carry `sourceType: 'fulfillment_batch'` and the PERIOD KEY as their source, so
+// the source lookup finds nothing for the orders inside it. Worse, it does not
+// find nothing consistently: the A/R leg stays per order (aging has to name the
+// debtor), so a terms order would show a card and a card-paid order in the same
+// entry would show none, a difference with no meaning that reads as a bug.
+//
+// The stamp is the coverage record on the order's own end: every shipment in
+// `order_fulfillments[]` carries the `glPostingId` and doc number of the entry
+// that recognised it. One row per shipment, which is also the grain a person
+// asks about ("did the second box get posted?").
+//
+// ⚠️ A REVERSED stamp is kept and shown, never hidden. Reversing is how a
+// fulfillment posting is undone (§2.6), and an order whose entry was reversed is
+// unposted, it re-enters the next preview by construction. A card that dropped
+// the reversed row would make that look like the entry was never made.
+
+import type { OrderFulfillmentPostingRef } from '@auxx/lib/money/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
+import { BookOpenCheck } from 'lucide-react'
+import { useState } from 'react'
+import { PostingLinesDialog } from '~/components/accounting/ui/ledger-card'
+import { EmptyRow } from '~/components/drawers/cards/related-record-row'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { formatDayKey } from '~/components/money/ui/fulfillment-posting/fulfillment-plan-table'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+
+export function OrderFulfillmentLedgerCard({ entityInstanceId }: DrawerTabProps) {
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+
+  const [openPostingId, setOpenPostingId] = useState<string | null>(null)
+
+  const stampsQuery = api.money.orderFulfillmentPostings.useQuery(
+    { orderId: entityInstanceId },
+    { enabled: !!entityInstanceId }
+  )
+  const stamps: OrderFulfillmentPostingRef[] = stampsQuery.data ?? []
+  const loading = stampsQuery.isPending
+
+  if (!loading && stamps.length === 0) {
+    return <EmptyRow label='Nothing posted yet' />
+  }
+
+  return (
+    <>
+      <TreeRowList
+        items={stamps}
+        loading={loading}
+        skeletonCount={2}
+        // The stamp is keyed by shipment, and one posting can stamp two
+        // shipments of the same order under a week or month grouping.
+        getKey={(stamp) => `${stamp.sequence}-${stamp.glPostingId}`}
+        renderRow={(stamp) => (
+          <TreeRow
+            className={TREE_SECONDARY_NOTRUNCATE}
+            icon={<BookOpenCheck className='size-4' />}
+            title={
+              <span className='truncate font-mono text-sm'>
+                {stamp.docNumber ?? 'Not numbered'}
+              </span>
+            }
+            description={`Shipment ${stamp.sequence} · ${formatDayKey(stamp.shippedAt)}`}
+            secondary={
+              stamp.status === 'reversed' ? (
+                <Badge variant='amber' size='xs'>
+                  Reversed
+                </Badge>
+              ) : undefined
+            }
+            onToggleOpen={() => setOpenPostingId(stamp.glPostingId)}
+          />
+        )}
+      />
+
+      <PostingLinesDialog
+        postingId={openPostingId}
+        onOpenChange={(open) => !open && setOpenPostingId(null)}
+        currencyCode={currencyCode}
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/money/ui/order/order-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/order/order-line-items-tab.tsx
@@ -58,6 +58,7 @@ export function OrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
   const { can } = useAccess()
   const utils = api.useUtils()
   const [fulfillOpen, setFulfillOpen] = useState(false)
+  const orderId = getInstanceId(recordId)
 
   // SINGLE_SELECT values arrive as arrays — take the first (see the
   // `use_system_values_single_select_arrays` convention).
@@ -67,10 +68,28 @@ export function OrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
   const financialBadge = financial ? FINANCIAL_BADGE[financial] : undefined
   const fulfillmentBadge = fulfillment ? FULFILLMENT_BADGE[fulfillment] : undefined
 
+  // 🛑 An order bound to a data connector has its shipment log DERIVED at ingest
+  // from the native fulfillment fields the channel sends (plans/money/tasks/49
+  // §8.4 decision 4), and the log is append-only. Fulfilling one by hand writes
+  // a second entry for a shipment the next sync will also describe, so the two
+  // disagree and the order is recognised twice. Nothing in the drawer knew this
+  // before, so it is asked for: `money.isOrderConnectorManaged`.
+  //
+  // ⚠️ Gated on `=== false`, not on `!== true`. While the answer is in flight
+  // the button stays away: a Fulfill that appears for a beat on a connector
+  // order is an irreversible ledger write somebody can reach, and a button that
+  // arrives a moment late is not.
+  const connectorManaged = api.money.isOrderConnectorManaged.useQuery(
+    { orderId },
+    { enabled: !!orderId && can('ledger.post'), staleTime: 60_000 }
+  )
+  const isConnectorManaged = connectorManaged.data === true
+
   // The sanctioned fulfillment action (HANDOFF decision 6.6): it carries what
   // shipped, flips `order_fulfillment_status`, and posts the revenue entry, so
   // it is a ledger write. Hidden once everything has shipped.
-  const canFulfill = can('ledger.post') && fulfillment !== 'fulfilled'
+  const canFulfill =
+    can('ledger.post') && fulfillment !== 'fulfilled' && connectorManaged.data === false
 
   // `variant='section'`: rendered inside a DetailViewSections <Section> on an
   // outer-owned scroll column instead of a `TabsContent` that grants `h-full`, so
@@ -80,7 +99,7 @@ export function OrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
 
   return (
     <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
-      {(financialBadge || fulfillmentBadge || canFulfill) && (
+      {(financialBadge || fulfillmentBadge || canFulfill || isConnectorManaged) && (
         <DocumentSectionActions
           badge={
             <div className='flex items-center gap-1.5'>
@@ -101,6 +120,11 @@ export function OrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
               Fulfill
             </Button>
           )}
+          {isConnectorManaged && (
+            <span className='text-muted-foreground text-xs'>
+              Shipments arrive from the sales channel and are posted in bulk
+            </span>
+          )}
         </DocumentSectionActions>
       )}
 
@@ -111,9 +135,12 @@ export function OrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
       <FulfillOrderDialog
         open={fulfillOpen}
         onOpenChange={setFulfillOpen}
-        orderId={getInstanceId(recordId)}
+        orderId={orderId}
         onFulfilled={() => {
-          void utils.ledger.listPostingsForSource.invalidate()
+          // The order's ledger card reads its shipment STAMPS now, not the
+          // postings whose lines name it (plans/money/tasks/49 §2.5), so this is
+          // the query a fulfillment has just changed.
+          void utils.money.orderFulfillmentPostings.invalidate({ orderId })
           void utils.money.orderForFulfillment.invalidate()
         }}
       />

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -742,11 +742,21 @@ export const ledgerRouter = createTRPCRouter({
    * "0 out of 412" are very different answers and the banner has to be able to
    * tell them apart.
    */
-  verifyBalance: permissionProcedure(PermissionKey.ledgerView).query(async ({ ctx }) => {
-    const result = await verifyBooksBalance(ctx.db, ctx.session.organizationId)
-    if (result.isErr()) throw result.error
-    return result.value
-  }),
+  // `periodKey` is OPTIONAL and adds the COMPLETENESS half - what that month
+  // still owes the ledger (49 §2.4). Optional because the two callers genuinely
+  // differ: the close console asks about the month on screen, while
+  // `useAccountingSettingsFreeze` wants only `postingsChecked` and has no month.
+  // Asked for nothing, the counts come back `null`, never `0`: a zero would read
+  // as "nothing outstanding" for a question that was never put.
+  verifyBalance: permissionProcedure(PermissionKey.ledgerView)
+    .input(optionalMonthKey.optional())
+    .query(async ({ ctx, input }) => {
+      const result = await verifyBooksBalance(ctx.db, ctx.session.organizationId, {
+        month: input?.periodKey,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
 
   /**
    * Every posting in one month EXCEPT the close entry - the ledger page's

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -3,6 +3,7 @@
 import type { PaymentTransactionEntity } from '@auxx/database'
 import { database, schema } from '@auxx/database'
 import { conditionGroupsSchema } from '@auxx/lib/conditions'
+import { isRecordConnectorManaged } from '@auxx/lib/data-connectors'
 import { renderPreviewQuotePdf } from '@auxx/lib/documents'
 import { NotFoundError } from '@auxx/lib/errors'
 import {
@@ -31,6 +32,7 @@ import {
   getPaymentAccount,
   getWorkOrderBillingState,
   listBankDeposits,
+  listOrderFulfillmentPostings,
   listPayouts,
   listUndepositedPayments,
   listWorkOrderPayments,
@@ -39,6 +41,7 @@ import {
   PAYOUT_STATUSES,
   prepareDocumentEmail,
   previewFulfillment,
+  previewFulfillmentPosting,
   previewInvoiceBatch,
   previewWriteOffInvoice,
   readOrderForFulfillment,
@@ -47,6 +50,7 @@ import {
   recordManualPayment,
   refundTransaction,
   reorderLines,
+  runFulfillmentPosting,
   runInvoiceBatch,
   saveBillingInstallments,
   setInvoiceSchedule,
@@ -57,6 +61,7 @@ import {
   voidInvoice,
   writeOffInvoice,
 } from '@auxx/lib/money'
+import type { FulfillmentPostingGrouping } from '@auxx/lib/money/client'
 import { FeaturePermissionService, getCapabilities, PermissionKey } from '@auxx/lib/permissions'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import {
@@ -166,6 +171,35 @@ async function mapPaymentRows(organizationId: string, rows: PaymentTransactionEn
     rows.map((row) => row.id)
   )
   return rows.map((row) => mapPaymentRow(row, allocationTotals.get(row.id) ?? 0))
+}
+
+/**
+ * How much the bulk fulfillment posting batches (plans/money/tasks/49 §2.3).
+ *
+ * `as const satisfies` rather than a bare `z.enum`, the way `builds.ts` writes
+ * the backfill's grouping: the vocabulary lives in
+ * `money/fulfillment-posting/types.ts`, and a member renamed there has to break
+ * this file rather than silently narrow what the browser may ask for.
+ */
+const FULFILLMENT_POSTING_GROUPING_VALUES = [
+  'day',
+  'week',
+  'month',
+] as const satisfies readonly FulfillmentPostingGrouping[]
+
+/**
+ * The window and the grouping, shared by the preview and the run so the two can
+ * never disagree about what a range means.
+ *
+ * Half-open on `shippedAt` (`from <= shippedAt < to`), both plain `YYYY-MM-DD`
+ * rather than instants: the bucket boundary is cut in the org's book time zone
+ * server-side, and a `Date` from the browser would carry its own zone into a
+ * decision that is not the browser's to make.
+ */
+const fulfillmentPostingShape = {
+  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  grouping: z.enum(FULFILLMENT_POSTING_GROUPING_VALUES),
 }
 
 export const moneyRouter = createTRPCRouter({
@@ -813,6 +847,89 @@ export const moneyRouter = createTRPCRouter({
       })
       if (result.isErr()) throw result.error
       return result.value
+    }),
+
+  // ─── Bulk fulfillment posting (plans/money/tasks/49 §2.3) ──────────────────
+
+  /**
+   * What a bulk fulfillment posting WOULD write. Persists nothing.
+   *
+   * 🛑 The plan is recomputed here from the range and the grouping; the browser
+   * never supplies one. The same call backs {@link runFulfillmentPosting}, so
+   * what the dialog shows and what the run posts come from one code path
+   * (`plans/money/tasks/49-bulk-fulfillment-posting.md` §2.3).
+   *
+   * A refusal (`accounting.bookTimeZone` unset, or a draft chart) comes back on
+   * the payload as `refusal` rather than as a thrown error: the dialog renders
+   * it as a card beside the range it applies to, which a toast cannot do.
+   */
+  previewFulfillmentPosting: permissionProcedure(PermissionKey.ledgerView)
+    .input(z.object(fulfillmentPostingShape))
+    .query(async ({ ctx, input }) => {
+      const result = await previewFulfillmentPosting(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+        range: { from: input.from, to: input.to },
+        grouping: input.grouping,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Post one entry per group and stamp every shipment behind it.
+   *
+   * 🛑 `ledgerPost`, for the same reason {@link fulfillOrder} takes it: this
+   * writes `GlPosting` rows. The run NEVER throws: a group the poster declined
+   * (`already_posted`, a locked period) and a group that failed are both arms of
+   * the summary, so the result page can tell somebody which of their 62 days
+   * landed instead of reporting the whole run as an error.
+   */
+  runFulfillmentPosting: permissionProcedure(PermissionKey.ledgerPost)
+    .input(z.object({ ...fulfillmentPostingShape, memo: z.string().max(4000).optional() }))
+    .mutation(async ({ ctx, input }) => {
+      return runFulfillmentPosting(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+        range: { from: input.from, to: input.to },
+        grouping: input.grouping,
+        memo: input.memo,
+      })
+    }),
+
+  /**
+   * The postings this order's shipment log names, for its ledger card (§2.5).
+   *
+   * Reads the per-shipment STAMP rather than the posting's source lines: a bulk
+   * entry summarises many orders, so `listPostingsForSource` finds nothing for
+   * an order whose revenue went out in one (the A/R leg is the exception, and
+   * relying on it would show terms orders a card that card orders do not get).
+   */
+  orderFulfillmentPostings: permissionProcedure(PermissionKey.ledgerView)
+    .input(z.object({ orderId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const result = await listOrderFulfillmentPostings(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        orderId: input.orderId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Is this order bound to a data connector?
+   *
+   * The shipment log of a connector-managed order is DERIVED at ingest from the
+   * native fulfillment fields (§8.4 decision 4), so per-order Fulfill would
+   * write a second, conflicting log. The drawer asks this to hide the button.
+   *
+   * `ledgerView`, matching the sibling fulfillment reads: the answer only ever
+   * gates a ledger action, and it discloses nothing but a boolean.
+   */
+  isOrderConnectorManaged: permissionProcedure(PermissionKey.ledgerView)
+    .input(z.object({ orderId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      return isRecordConnectorManaged(ctx.db, ctx.session.organizationId, input.orderId)
     }),
 
   /**

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -21,6 +21,7 @@ import { startEmailWorker } from './worker-definitions/email-worker'
 import { startEnrichmentWorker } from './worker-definitions/enrichment-worker'
 import { startEvalRunWorker } from './worker-definitions/eval-run-worker'
 import { startEventHandlersWorker, startEventsWorker } from './worker-definitions/events-worker'
+import { startFulfillmentPostingWorker } from './worker-definitions/fulfillment-posting-worker'
 import { startKBSyncWorker } from './worker-definitions/kb-sync-worker'
 import { startKnowledgeSourceWorker } from './worker-definitions/knowledge-source-worker'
 import { startLearnedExtractionWorker } from './worker-definitions/learned-extraction-worker'
@@ -130,6 +131,11 @@ export async function startWorkers() {
   // QuickBooks invoice sync worker (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3)
   const quickbooksInvoiceSyncWorker = startQuickbooksInvoiceSyncWorker()
 
+  // Bulk fulfillment posting worker: the `auto` lane of
+  // plans/money/tasks/49-bulk-fulfillment-posting.md §2.4. Concurrency 1 - see
+  // the worker definition for why that is a correctness cap, not a throttle.
+  const fulfillmentPostingWorker = startFulfillmentPostingWorker()
+
   // Inbound-mail AI categorisation worker (mail-classification plan §4)
   const mailClassificationWorker = startMailClassificationWorker()
 
@@ -175,6 +181,7 @@ export async function startWorkers() {
     dataConnectorWorker,
     documentPdfWorker,
     quickbooksInvoiceSyncWorker,
+    fulfillmentPostingWorker,
     mailClassificationWorker,
     purchaseIntakeWorker,
     enrichmentWorker,

--- a/apps/worker/src/workers/worker-definitions/fulfillment-posting-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/fulfillment-posting-worker.ts
@@ -1,0 +1,26 @@
+// apps/worker/src/workers/worker-definitions/fulfillment-posting-worker.ts
+
+import { FULFILLMENT_POSTING_JOB_NAME, fulfillmentPostingJob } from '@auxx/lib/jobs'
+import { Queues } from '@auxx/lib/jobs/queues'
+import { createWorker } from '../utils/createWorker'
+
+const jobMappings = {
+  [FULFILLMENT_POSTING_JOB_NAME]: fulfillmentPostingJob,
+}
+
+/**
+ * Bulk fulfillment posting worker (plans/money/tasks/49-bulk-fulfillment-posting.md §2.4).
+ *
+ * 🛑 Concurrency 1, and not as a throttle. One job posts every unposted shipment
+ * in an organization as one entry per ship day, and the period key of a day is
+ * claimed by attempt number. Two runs side by side would read the same backlog,
+ * compute the same attempt, and claim the same key - so the concurrency cap is
+ * part of the correctness of the key, not a resource decision. The `auto` lane's
+ * per-org `jobId` collapses repeat syncs into the one job still queued; this
+ * caps what happens once they start.
+ */
+export function startFulfillmentPostingWorker() {
+  return createWorker(Queues.fulfillmentPostingQueue, jobMappings, {
+    concurrency: 1,
+  })
+}

--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -1310,6 +1310,39 @@ somebody forgets. That test had been red since wave 0 for an unrelated list,
 because `packages/database` has no `typecheck` script and its suite is not
 reached by a `packages/lib` run.
 
+### 9.13 Bulk fulfillment posting (2026-09-09, plans/money/tasks/49)
+
+Revenue on connector orders is posted **one `fulfillment` entry per ship day**, never per
+order, from `money/fulfillment-posting/` (`reads.ts` is one SQL over the `order_fulfillments`
+JSON log joined to `GlPosting`; `plan.ts` is pure; `run.ts` never throws). Facts worth a line:
+
+- **Unposted means no LIVE stamp.** A log entry whose `glPostingId` is null or names a
+  `reversed` posting re-enters the next preview. Reversing a day's entry is therefore the
+  whole undo; nothing un-stamps.
+- **The period key is the day plus an attempt char** (`2026-07-06`, then `2026-07-061`).
+  The claim index is unique on `(org, type, periodKey, revision)` and a duplicate claim
+  returns `already_posted`, a success that posts nothing, so a late order backfilled into
+  an already-posted day needs its own key. Same trap `writeOffPeriodKey` fixed.
+- **The debit follows the gateway, not the channel**: `shopify_payments` to
+  `clearing_card`, `Affirm` to `clearing_affirm` (1210, excluded from the payout entry by
+  construction), unpaid or `manual` to A/R with one source line per order so aging can
+  name the debtor. Everything else summarises under `sourceType: 'fulfillment_batch'`,
+  which is why the order ledger card and the order delete guard read the **stamp**, not
+  `listPostingsForSource`.
+- `CHANNEL_REVENUE_ROLE` **fails open**: `manual` and an unset channel recognise as
+  consumer revenue. Only `dealer` moves revenue off 4000.
+- **The shipment log for a connector order is derived**, not clicked: finalize pass 6
+  (`events/handlers/passes/fulfillment-log-pass.ts`) reads the native
+  `line_item_fulfilled_at` / `_fulfilled_qty` / `_shipment_count` fields (entity migration
+  137, bound by the Shopify app) and rewrites the log only when it changed, keeping stamped
+  entries verbatim. `fulfillOrder` stays the writer for native orders.
+- `accounting.fulfillmentPosting = manual | auto`; `auto` enqueues the `fulfillment-posting`
+  queue from pass 7. The month close refuses with `revenue_incomplete` while a month holds
+  an unposted shipment or an unissued channel credit memo; the count reuses the dialog's
+  plan, so a `zero-value` shipment does not hold a month open.
+- The inventory relief of a shipment (a `sale` movement) is **still not built**; nothing
+  in the tree writes that kind. Brief 50.
+
 ## 10. Write Lanes & the Silent Ledger Write
 
 🛑 **`skipEvents: true` is INSUFFICIENT, not merely deprecated — there are TWO doors.**

--- a/packages/lib/scripts/drive-fulfillment-posting.ts
+++ b/packages/lib/scripts/drive-fulfillment-posting.ts
@@ -1,0 +1,342 @@
+// packages/lib/scripts/drive-fulfillment-posting.ts
+//
+// Drives plans/money/tasks/49 end to end against a dev org:
+//
+// 1. reverses every live per-shipment `fulfillment` posting (the 2026-09-04 test
+//    postings that debit A/R for Shopify-paid orders, 49 §1.5),
+// 2. backfills the three native line fulfillment fields from the Shopify app
+//    fields already on the org (what the connector binds on its next sync),
+// 3. derives every connector order's shipment log through the finalize pass,
+// 4. previews and posts one month per day, reverses one day, shows it come back
+//    in the preview, posts it again under an attempt suffix, and shows the
+//    month-end close refusing while the day was unposted.
+//
+// It WRITES real `GlPosting` rows. Point it at a dev org.
+//
+//   npx dotenv -e ../../.env -- npx tsx scripts/drive-fulfillment-posting.ts <organizationId> <YYYY-MM>
+
+import { closePools, database, schema } from '@auxx/database'
+import type { RecordId } from '@auxx/types/resource'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { findCachedResource, getCachedEntityDefId } from '../src/cache'
+import { listConnectorManagedRecordIds } from '../src/data-connectors/managed-fields'
+import { fulfillmentLogPass } from '../src/events/handlers/passes/fulfillment-log-pass'
+import {
+  previewFulfillmentPosting,
+  runFulfillmentPosting,
+} from '../src/money/fulfillment-posting/run'
+import { previewMonthEnd, resolvePeriodLock, reverseEntry } from '../src/postings'
+import type { SyncChangeManifest } from '../src/record-rules/sync-manifest-types'
+import { UnifiedCrudHandler } from '../src/resources/crud/unified-handler'
+import { toRecordId } from '../src/resources/resource-id'
+
+const APP_FIELD_TO_NATIVE = {
+  fulfilledAt: 'line_item_fulfilled_at',
+  fulfilledQuantity: 'line_item_fulfilled_qty',
+  shipmentCount: 'line_item_shipment_count',
+} as const
+
+async function main() {
+  const organizationId = process.argv[2] ?? ''
+  const month = process.argv[3] ?? ''
+  const previewOnly = process.argv.includes('--preview-only')
+  if (!organizationId || !/^\d{4}-\d{2}$/.test(month)) {
+    throw new Error('usage: drive-fulfillment-posting.ts <organizationId> <YYYY-MM>')
+  }
+  const [member] = await database
+    .select({ userId: schema.OrganizationMember.userId })
+    .from(schema.OrganizationMember)
+    .where(eq(schema.OrganizationMember.organizationId, organizationId))
+    .limit(1)
+  if (!member) throw new Error('that organization has no members')
+  const actorUserId = member.userId
+
+  if (!previewOnly) {
+    await reverseTestPostings(organizationId, actorUserId)
+    await backfillNativeLineFacts(organizationId)
+    await deriveLogs(organizationId)
+  }
+
+  const from = `${month}-01`
+  const to = nextMonth(month)
+  const request = { organizationId, actorUserId, range: { from, to }, grouping: 'day' as const }
+
+  console.log(`\n=== preview ${month} per day`)
+  const preview = await previewFulfillmentPosting(database, request)
+  if (preview.isErr()) throw preview.error
+  printPlan(preview.value)
+  if (previewOnly) {
+    for (const e of preview.value.plan.exclusions) console.log('  excluded', e)
+    return
+  }
+
+  console.log(`\n=== run ${month} per day`)
+  const run = await runFulfillmentPosting(database, request)
+  printSummary(run)
+
+  const first = run.posted[0]
+  if (!first) {
+    console.log('nothing posted, stopping')
+    return
+  }
+
+  console.log(`\n=== reverse ${first.docNumber}`)
+  const lock = await resolvePeriodLock(organizationId)
+  const reversed = await reverseEntry(database, {
+    organizationId,
+    glPostingId: first.postingId,
+    actorUserId,
+    lock,
+    memo: 'drive: undo one day',
+  })
+  console.log(reversed.status, reversed.glPostingId ?? '', reversed.error ?? '')
+
+  console.log(`\n=== preview ${month} again: the reversed day must be back`)
+  const again = await previewFulfillmentPosting(database, request)
+  if (again.isErr()) throw again.error
+  printPlan(again.value)
+
+  console.log(`\n=== month-end preview ${month} while a day is unposted`)
+  const closeBlocked = await previewMonthEnd(database, { organizationId, periodKey: month })
+  console.log(closeBlocked.blockedBy ?? 'not blocked')
+
+  console.log(`\n=== run ${month} again: the day re-posts under an attempt suffix`)
+  const rerun = await runFulfillmentPosting(database, request)
+  printSummary(rerun)
+
+  console.log(`\n=== month-end preview ${month} after re-posting`)
+  const closeAfter = await previewMonthEnd(database, { organizationId, periodKey: month })
+  console.log(closeAfter.blockedBy ?? 'not blocked by revenue')
+
+  const rows = await database
+    .select({
+      docNumber: schema.GlPosting.docNumber,
+      periodKey: schema.GlPosting.periodKey,
+      status: schema.GlPosting.status,
+      txnDate: schema.GlPosting.txnDate,
+      totalMinor: schema.GlPosting.totalMinor,
+    })
+    .from(schema.GlPosting)
+    .where(
+      and(
+        eq(schema.GlPosting.organizationId, organizationId),
+        eq(schema.GlPosting.postingType, 'fulfillment'),
+        sql`${schema.GlPosting.periodKey} !~ '-F[0-9]+$'`
+      )
+    )
+    .orderBy(schema.GlPosting.txnDate)
+  console.log(`\n=== batch fulfillment postings now on the org: ${rows.length}`)
+  for (const row of rows.slice(0, 8)) console.log(row)
+  if (rows.length > 8) console.log(`... ${rows.length - 8} more`)
+}
+
+async function reverseTestPostings(organizationId: string, actorUserId: string) {
+  // A per-shipment key ends in -F<n>. Its reversal keeps the key, so the net
+  // effect of a chain O, R1, R2 ... is live exactly when the LAST posted row sits
+  // at an even depth (the original, or a reversal of a reversal). Reverse those.
+  const rows = await database
+    .select({
+      id: schema.GlPosting.id,
+      docNumber: schema.GlPosting.docNumber,
+      status: schema.GlPosting.status,
+      reversesId: schema.GlPosting.reversesId,
+    })
+    .from(schema.GlPosting)
+    .where(
+      and(
+        eq(schema.GlPosting.organizationId, organizationId),
+        eq(schema.GlPosting.postingType, 'fulfillment'),
+        sql`${schema.GlPosting.periodKey} ~ '-F[0-9]+$'`
+      )
+    )
+  const byId = new Map(rows.map((r) => [r.id, r]))
+  const depth = (id: string): number => {
+    let d = 0
+    let cur = byId.get(id)
+    while (cur?.reversesId) {
+      d++
+      cur = byId.get(cur.reversesId)
+    }
+    return d
+  }
+  const live = rows.filter((r) => r.status === 'posted' && depth(r.id) % 2 === 0)
+  console.log(`=== reversing ${live.length} net-live per-shipment fulfillment postings`)
+  const lock = await resolvePeriodLock(organizationId)
+  for (const posting of live) {
+    const result = await reverseEntry(database, {
+      organizationId,
+      glPostingId: posting.id,
+      actorUserId,
+      lock,
+      memo: 'drive: 49 §1.5, per-shipment test posting debiting A/R',
+    })
+    console.log(`  ${posting.docNumber}: ${result.status}${result.error ? ` ${result.error}` : ''}`)
+  }
+}
+
+/** Copy the Shopify app fields onto the native line fields, the way the connector's next sync will. */
+async function backfillNativeLineFacts(organizationId: string) {
+  const lineDefId = await getCachedEntityDefId(organizationId, 'line_item')
+  if (!lineDefId) throw new Error('no line_item def')
+  const fields = await database
+    .select({
+      id: schema.CustomField.id,
+      appFieldKey: schema.CustomField.appFieldKey,
+      appSlug: schema.CustomField.appSlug,
+      systemAttribute: schema.CustomField.systemAttribute,
+      type: schema.CustomField.type,
+    })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.entityDefinitionId, lineDefId)
+      )
+    )
+  const appIds = new Map<string, string>()
+  for (const f of fields) {
+    if (f.appSlug === 'shopify' && f.appFieldKey && f.appFieldKey in APP_FIELD_TO_NATIVE) {
+      appIds.set(f.appFieldKey, f.id)
+    }
+  }
+  if (appIds.size !== 3) {
+    console.log(
+      `=== no Shopify line fulfillment app fields on this org (${appIds.size}), skipping backfill`
+    )
+    return
+  }
+  const values = await database
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueDate: schema.FieldValue.valueDate,
+      valueNumber: schema.FieldValue.valueNumber,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.fieldId, [...appIds.values()])
+      )
+    )
+  const byLine = new Map<string, Record<string, unknown>>()
+  const attrByFieldId = new Map<string, string>()
+  for (const [key, id] of appIds)
+    attrByFieldId.set(id, APP_FIELD_TO_NATIVE[key as keyof typeof APP_FIELD_TO_NATIVE])
+  for (const row of values) {
+    const attr = attrByFieldId.get(row.fieldId)
+    if (!attr) continue
+    const bucket = byLine.get(row.entityId) ?? {}
+    bucket[attr] = attr === 'line_item_fulfilled_at' ? row.valueDate : row.valueNumber
+    byLine.set(row.entityId, bucket)
+  }
+  const updates = [...byLine].map(([entityId, v]) => ({
+    recordId: toRecordId(lineDefId, entityId) as RecordId,
+    values: v,
+  }))
+  console.log(`=== backfilling native fulfillment facts onto ${updates.length} lines`)
+  const handler = new UnifiedCrudHandler(organizationId, 'system', database)
+  let updated = 0
+  for (let i = 0; i < updates.length; i += 200) {
+    const result = await handler.bulkUpdate(updates.slice(i, i + 200), { skipEvents: true })
+    updated += result.updated
+    if (result.errors.length) console.log('  errors', result.errors.slice(0, 3))
+  }
+  console.log(`  updated ${updated}`)
+}
+
+/** Run the finalize pass over every connector-managed order, as a sync touching them all would. */
+async function deriveLogs(organizationId: string) {
+  const orderDefId = await getCachedEntityDefId(organizationId, 'order')
+  if (!orderDefId) throw new Error('no order def')
+  const orders = await database
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, orderDefId),
+        sql`${schema.EntityInstance.archivedAt} IS NULL`
+      )
+    )
+  const managed = await listConnectorManagedRecordIds(
+    database,
+    organizationId,
+    orders.map((o) => o.id)
+  )
+  const touched: SyncChangeManifest['touched'] = {}
+  for (const id of managed) touched[toRecordId(orderDefId, id) as RecordId] = 1
+  const manifest: SyncChangeManifest = {
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched,
+    deltas: {},
+    createdRecordIds: [],
+    archivedRecordIds: [],
+  }
+  const resolveDef = async (rawDefId: string) => {
+    const resource = await findCachedResource(organizationId, rawDefId)
+    return resource ? { entityType: resource.entityType ?? null } : null
+  }
+  console.log(`=== deriving shipment logs for ${managed.size} connector orders`)
+  const changed = await fulfillmentLogPass(database, organizationId, manifest, resolveDef)
+  console.log(`  logs written: ${changed.size}`)
+}
+
+function printPlan(preview: {
+  plan: {
+    footer: unknown
+    groups: Array<{
+      groupKey: string
+      txnDate: string
+      orderCount: number
+      shipments: unknown[]
+      totals: unknown
+    }>
+    exclusions: Array<{ reason: string; detail: string }>
+  }
+  refusal: string | null
+}) {
+  if (preview.refusal) console.log('REFUSAL:', preview.refusal)
+  console.log('footer', preview.plan.footer)
+  for (const g of preview.plan.groups.slice(0, 3)) {
+    console.log(
+      `  ${g.groupKey} txn ${g.txnDate} orders ${g.orderCount} shipments ${g.shipments.length}`,
+      g.totals
+    )
+  }
+  if (preview.plan.groups.length > 3)
+    console.log(`  ... ${preview.plan.groups.length - 3} more groups`)
+  const byReason = new Map<string, number>()
+  for (const e of preview.plan.exclusions) byReason.set(e.reason, (byReason.get(e.reason) ?? 0) + 1)
+  console.log('exclusions by reason', Object.fromEntries(byReason))
+  for (const e of preview.plan.exclusions.slice(0, 3)) console.log('  ', e)
+}
+
+function printSummary(summary: {
+  posted: unknown[]
+  skipped: unknown[]
+  failed: unknown[]
+  exclusions: unknown[]
+}) {
+  console.log(
+    `posted ${summary.posted.length} skipped ${summary.skipped.length} failed ${summary.failed.length} excluded ${summary.exclusions.length}`
+  )
+  for (const p of summary.posted.slice(0, 3)) console.log('  posted', p)
+  for (const s of summary.skipped.slice(0, 3)) console.log('  skipped', s)
+  for (const f of summary.failed.slice(0, 3)) console.log('  failed', f)
+}
+
+function nextMonth(month: string): string {
+  const [y, m] = month.split('-').map(Number)
+  const d = new Date(Date.UTC(y!, m!, 1))
+  return d.toISOString().slice(0, 10)
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(() => closePools())

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -128,7 +128,11 @@ export {
   syncConnectorSweepScheduler,
 } from './data-connector-scheduler'
 // Connector-managed field check — the totals stand-down (plans/money/tasks/37 §6)
-export { isFieldConnectorManaged } from './managed-fields'
+export {
+  isFieldConnectorManaged,
+  isRecordConnectorManaged,
+  listConnectorManagedRecordIds,
+} from './managed-fields'
 export type { MappedWrite } from './map-record'
 // Mapping layer
 export { mapRecord } from './map-record'

--- a/packages/lib/src/data-connectors/managed-fields.ts
+++ b/packages/lib/src/data-connectors/managed-fields.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/data-connectors/managed-fields.ts
 
 import { type Database, schema } from '@auxx/database'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { refNamesField } from './sync-state'
 
 /**
@@ -42,4 +42,81 @@ export async function isFieldConnectorManaged(
     )
 
   return items.some((item) => (item.managedFields ?? []).some((ref) => refNamesField(ref, fieldId)))
+}
+
+/**
+ * Whether the RECORD itself came from a connector - any non-archived
+ * `DataConnectorItem` binds the instance, whatever fields that item manages.
+ *
+ * Coarser than {@link isFieldConnectorManaged} on purpose, and asking a
+ * different question. That one asks "may I recompute this cell"; this one asks
+ * "did a person create this record, or did a sync". The callers that need the
+ * coarse answer are the ones deciding whether a HUMAN VERB applies at all:
+ * `plans/money/tasks/49-bulk-fulfillment-posting.md` §2.1 hides Fulfill for a
+ * connector order (the shipment log is derived from the channel's own
+ * fulfillment facts instead, and two writers on one log is the defect 49 §2.1
+ * exists to end), and the fulfillment log pass derives a log ONLY for orders
+ * that have a channel to derive it from.
+ *
+ * A bound item with an EMPTY `managedFields` still counts. The array says which
+ * cells the connector owns; the ROW says the record is the connector's. An item
+ * whose mapping happens to manage nothing is still a synced record.
+ *
+ * Archived items do not count: a disconnected connector leaves its items
+ * archived, and an order whose connector was removed becomes an ordinary record
+ * a person may fulfil by hand again.
+ */
+export async function isRecordConnectorManaged(
+  db: Database,
+  organizationId: string,
+  entityInstanceId: string
+): Promise<boolean> {
+  if (!entityInstanceId) return false
+  const [item] = await db
+    .select({ id: schema.DataConnectorItem.id })
+    .from(schema.DataConnectorItem)
+    .where(
+      and(
+        eq(schema.DataConnectorItem.organizationId, organizationId),
+        eq(schema.DataConnectorItem.entityInstanceId, entityInstanceId),
+        isNull(schema.DataConnectorItem.archivedAt)
+      )
+    )
+    .limit(1)
+  return !!item
+}
+
+/**
+ * {@link isRecordConnectorManaged} for a SET, in one query.
+ *
+ * 🛑 The batch form is the one the passes use, and the reason is the same one
+ * `orderDemandPass` gives for resolving its parents in a single call: a finalize
+ * pass runs over a whole sync manifest, so a per-record existence check would
+ * restore an N+1 on the exact path that exists to remove one. A 500-order sync
+ * asks once.
+ *
+ * Returns only the ids that ARE bound; an id absent from the set is not bound
+ * (or does not exist, which is the same answer for every caller). An empty input
+ * returns an empty set without touching the database.
+ */
+export async function listConnectorManagedRecordIds(
+  db: Database,
+  organizationId: string,
+  entityInstanceIds: readonly string[]
+): Promise<Set<string>> {
+  const ids = [...new Set(entityInstanceIds.filter(Boolean))]
+  if (ids.length === 0) return new Set()
+
+  const rows = await db
+    .selectDistinct({ entityInstanceId: schema.DataConnectorItem.entityInstanceId })
+    .from(schema.DataConnectorItem)
+    .where(
+      and(
+        eq(schema.DataConnectorItem.organizationId, organizationId),
+        inArray(schema.DataConnectorItem.entityInstanceId, ids),
+        isNull(schema.DataConnectorItem.archivedAt)
+      )
+    )
+
+  return new Set(rows.map((row) => row.entityInstanceId).filter((id): id is string => !!id))
 }

--- a/packages/lib/src/events/handlers/finalize-integrity-passes.ts
+++ b/packages/lib/src/events/handlers/finalize-integrity-passes.ts
@@ -70,7 +70,7 @@ export interface IntegrityPassesInput {
 }
 
 /**
- * Run the four data-integrity batch passes over a sync-change manifest:
+ * Run the seven data-integrity batch passes over a sync-change manifest:
  *
  * 1. Totals — changed line-item records map (via the hook's own parent resolution) to
  *    DISTINCT parent quotes/invoices, each recomputed once; lines whose qty/unitPrice
@@ -85,6 +85,18 @@ export interface IntegrityPassesInput {
  *    This is events/08 R6(c), and it is the same class of bug as pass 1: the inline
  *    seam cannot see a sync write, so without it a Shopify order edited from 3 to 5
  *    keeps a build for 3 forever.
+ * 5. Contact/company interaction resolution: every created or identifier-touched
+ *    contact and company gets the correspondence history it already has.
+ * 6. Fulfillment log: connector orders whose lines carry the channel's per-line
+ *    fulfillment facts get `order_fulfillments` derived from them
+ *    (`passes/fulfillment-log-pass.ts`, money plan 49 §8.4 decision 4). Until this
+ *    pass, nothing NATIVE said an imported order had shipped, so 530 of the dev
+ *    org's 545 orders could never reach the ledger and every channel credit memo
+ *    would skip its revenue leg.
+ * 7. Automatic fulfillment posting: when pass 6 changed at least one log, hand off
+ *    to `autoPostFulfillmentsAfterSync`, which posts only if the org asked for it
+ *    (`accounting.fulfillmentPosting = auto`). Gated on pass 6 having changed
+ *    something so an idle re-sync enqueues nothing.
  *
  * NEVER throws: each pass — and each record inside a pass — is individually guarded and
  * logged, so one bad record or one failing pass cannot starve the others (mirrors
@@ -112,6 +124,30 @@ export async function runIntegrityPasses(db: Database, input: IntegrityPassesInp
     await phoneGeoPass(db, organizationId, manifest, resolveDef)
     await orderDemandPass(organizationId, manifest, resolveDef)
     await interactionPass(db, organizationId, manifest, resolveDef)
+
+    // Pass 6 lives in its own module because it is the only pass with a RETURN
+    // VALUE that another pass reads. Lazy-imported for the same reason
+    // everything else here is (this module's header).
+    const { fulfillmentLogPass } = await import('./passes/fulfillment-log-pass')
+    const changedLogs = await fulfillmentLogPass(db, organizationId, manifest, resolveDef)
+
+    // Pass 7. Its own try/catch, and NOT part of pass 6: enqueuing a posting run
+    // is a ledger decision (`accounting.fulfillmentPosting`), and a failure to
+    // enqueue must never make the derivation that already committed look failed.
+    if (changedLogs.size > 0) {
+      try {
+        await (await import('../../money/fulfillment-posting/auto')).autoPostFulfillmentsAfterSync(
+          db,
+          organizationId
+        )
+      } catch (error) {
+        logger.error('integrity auto-post pass failed', {
+          organizationId,
+          orders: changedLogs.size,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
   } catch (error) {
     logger.error('integrity passes failed', {
       organizationId,

--- a/packages/lib/src/events/handlers/passes/fulfillment-log-pass.ts
+++ b/packages/lib/src/events/handlers/passes/fulfillment-log-pass.ts
@@ -1,0 +1,432 @@
+// packages/lib/src/events/handlers/passes/fulfillment-log-pass.ts
+//
+// Pass 6 of `events/handlers/finalize-integrity-passes.ts`: derive
+// `order_fulfillments` for a connector order from the per-line fulfillment facts
+// the sales channel supplied.
+//
+// `plans/money/tasks/49-bulk-fulfillment-posting.md` §2.1, §8.1 item 3, §8.4
+// decision 4.
+//
+// WHY A PASS AND NOT A CONNECTOR RULE
+//
+// There is no post-ingest rule mechanism (49 §8.1 item 3): derived facts after a
+// sync are a fixed list of guarded passes selected off the tier-1 manifest, and
+// `orderDemandPass` next door is the precedent this one copies - one resolve,
+// one bounded read, never per record. Putting the derivation in the connector
+// instead would put Shopify field paths into the shipment log's writer, which is
+// exactly what gap-f `G14` forbids and what the three native `line_item` fields
+// of entity migration 137 exist to avoid.
+//
+// WHAT IT UNBLOCKS
+//
+// Two things, and the second is the one that is easy to miss:
+//
+//  1. Revenue. 530 of the dev org's 545 orders arrived already `fulfilled`, and
+//     the only door into the ledger is hidden once the status reads that (49
+//     §1.2). Nothing native said they had shipped, so nothing could post them.
+//  2. Channel credit memos. `orderHadFulfillmentBefore` reads
+//     `order_fulfillments`; for a connector order that cell is empty, so every
+//     channel refund would skip its revenue leg (49 §8.3). Deriving the log is
+//     what lets a channel memo reverse revenue at all.
+//
+// Keep top-level imports to types and the logger, and lazy-import the rest -
+// the same rule `finalize-integrity-passes.ts` states in its own header, for the
+// same reason (the events to money/cache boundaries break `vi.mock` otherwise).
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
+import type { SyncChangeManifest } from '../../../record-rules/sync-manifest-types'
+
+const logger = createScopedLogger('finalize-integrity')
+
+/** Actor for the pass's writes - the same fallback every other pass uses. */
+const SYSTEM_ACTOR = 'system'
+
+/**
+ * The book time zone to cut ship days in when the org has not set one.
+ *
+ * ⚠️ UTC, and deliberately NOT a refusal. The derivation is not a posting: a log
+ * row is a statement about what shipped, and lane B's poster is the thing that
+ * refuses when `accounting.bookTimeZone` is unset (49's preview refusal). An org
+ * that has not finished accounting setup still wants its shipment log, and a day
+ * derived in UTC is corrected by re-deriving once the zone is set - the merge is
+ * a no-op on a matching row and a replacement on an unstamped one.
+ */
+const FALLBACK_TIME_ZONE = 'UTC'
+
+/**
+ * The three `line_item` attributes whose write can change what the log says.
+ *
+ * Entity migration 137. A touched line carrying any of them enters the pass; an
+ * ids-only degraded record (`touched[rid] === 1`, keys shed under the byte
+ * budget) enters unconditionally, the rule every pass in this module follows.
+ */
+const LINE_FULFILLMENT_TRIGGER_ATTRS: ReadonlySet<SystemAttribute> = new Set([
+  'line_item_fulfilled_at',
+  'line_item_fulfilled_qty',
+  'line_item_shipment_count',
+])
+
+/** Every `order` attribute the derivation reads. */
+const ORDER_ATTRIBUTES = ['order_fulfillments', 'order_shipping_total', 'order_line_items'] as const
+
+/** Every `line_item` attribute the derivation reads. */
+const LINE_ATTRIBUTES = [
+  'line_item_qty',
+  'line_item_unit_price',
+  'line_item_tax_total',
+  'line_item_fulfilled_at',
+  'line_item_fulfilled_qty',
+  'line_item_shipment_count',
+] as const
+
+/**
+ * The slice of the manifest resolver this pass needs.
+ *
+ * Structurally narrower than `finalize-integrity-passes.ts`'s own
+ * `DefFieldResolver` so the two modules do not import each other's types in a
+ * cycle; the real resolver is assignable to it.
+ */
+export type DefEntityTypeResolver = (
+  rawDefId: string
+) => Promise<{ entityType: string | null } | null>
+
+/** One `FieldValue` row, the columns this pass reads. */
+interface ValueRow {
+  entityId: string
+  fieldId: string
+  valueNumber: number | null
+  valueDate: string | Date | null
+  valueJson: unknown
+  relatedEntityId: string | null
+}
+
+/**
+ * Derive and store the shipment log for every connector order this sync touched.
+ *
+ * ## Selection
+ *
+ *  - a touched `line_item` carrying any of {@link LINE_FULFILLMENT_TRIGGER_ATTRS},
+ *    or degraded to ids-only, mapped to its order in ONE query through
+ *    `resolveParentsByRelation('line_item_order', ...)`,
+ *  - plus every touched `order`. An order header write is enough on its own:
+ *    `order_shipping_total` is an input to the first shipment's total, and a
+ *    connector sync that re-asserts an order whose lines did not move is exactly
+ *    the run that should notice the channel has since shipped it,
+ *  - minus every order that is NOT connector-managed. A native order's log is
+ *    written by `money.fulfillOrder` and a person's clicks, and two writers on
+ *    one append-only log is the defect 49 §2.1 exists to end.
+ *
+ * ## Guarantees
+ *
+ * **Never throws**, per record and as a whole - one malformed order must not
+ * cost the other 500 their log, and this pass runs beside four others that have
+ * nothing to do with it.
+ *
+ * **Writes only when the derivation changed something.** `deriveFulfillmentLog`
+ * is append-only and returns `changed: false` for a log it produced itself, so a
+ * re-sync of an unchanged order writes nothing at all.
+ *
+ * @returns the `order` instance ids whose stored log this pass rewrote. Pass 7
+ * reads the SIZE of it to decide whether to enqueue the automatic posting run.
+ */
+export async function fulfillmentLogPass(
+  db: Database,
+  organizationId: string,
+  manifest: SyncChangeManifest,
+  resolveDef: DefEntityTypeResolver
+): Promise<Set<string>> {
+  const changed = new Set<string>()
+  try {
+    const lineInstanceIds = new Set<string>()
+    const orderInstanceIds = new Set<string>()
+
+    for (const [rid, touched] of Object.entries(manifest.touched)) {
+      const { entityDefinitionId: rawDefId, entityInstanceId } = parseRecordId(rid as RecordId)
+      const def = await resolveDef(rawDefId)
+      if (!def) continue
+      // Ids-only degradation: the keys were shed under the byte budget, so any
+      // fulfillment fact may have moved and the record enters its def's arm.
+      const idsOnly = touched === 1
+      switch (def.entityType) {
+        case 'line_item':
+          if (
+            idsOnly ||
+            (touched as string[]).some((key) =>
+              LINE_FULFILLMENT_TRIGGER_ATTRS.has(key as SystemAttribute)
+            )
+          ) {
+            lineInstanceIds.add(entityInstanceId)
+          }
+          break
+        case 'order':
+          orderInstanceIds.add(entityInstanceId)
+          break
+      }
+    }
+
+    if (lineInstanceIds.size > 0) {
+      const { resolveParentsByRelation } = await import('../../../reconcilers/parent-reconciler')
+      const parents = await resolveParentsByRelation(organizationId, 'line_item_order', [
+        ...lineInstanceIds,
+      ])
+      for (const orderId of parents) orderInstanceIds.add(orderId)
+    }
+    if (orderInstanceIds.size === 0) return changed
+
+    const { listConnectorManagedRecordIds } = await import(
+      '../../../data-connectors/managed-fields'
+    )
+    const managed = await listConnectorManagedRecordIds(db, organizationId, [...orderInstanceIds])
+    if (managed.size === 0) return changed
+
+    const context = await loadFieldContext(organizationId)
+    if (!context) {
+      logger.warn('integrity fulfillment-log pass: the order fields are not provisioned', {
+        organizationId,
+      })
+      return changed
+    }
+
+    const timeZone = await readBookTimeZone(organizationId)
+    const now = new Date().toISOString()
+    const orderIds = [...managed]
+
+    // ── Two bounded reads for the whole batch, never one per order ──
+    const orderValues = await selectValues(db, organizationId, orderIds, context.orderFieldIds)
+    const lineIdsByOrder = new Map<string, string[]>()
+    const allLineIds = new Set<string>()
+    for (const orderId of orderIds) {
+      const ids = (orderValues.get(orderId)?.get(context.order.order_line_items ?? '') ?? [])
+        .map((row) => row.relatedEntityId)
+        .filter((id): id is string => !!id)
+      lineIdsByOrder.set(orderId, ids)
+      for (const id of ids) allLineIds.add(id)
+    }
+    const lineValues = await selectValues(db, organizationId, [...allLineIds], context.lineFieldIds)
+
+    const { deriveFulfillmentLog } = await import('../../../money/fulfillment-posting/derive-log')
+    const { parseFulfillments } = await import('../../../money/orders/reads')
+    const { UnifiedCrudHandler } = await import('../../../resources/crud')
+    const { toRecordId } = await import('../../../resources/resource-id')
+
+    let heldOut = 0
+    for (const orderId of orderIds) {
+      try {
+        const bucket = orderValues.get(orderId)
+        const fulfillmentsFieldId = context.order.order_fulfillments
+        const stored = parseFulfillments(
+          fulfillmentsFieldId ? bucket?.get(fulfillmentsFieldId)?.[0]?.valueJson : undefined
+        )
+        const shippingFieldId = context.order.order_shipping_total
+        const orderShippingTotalMinor = shippingFieldId
+          ? (bucket?.get(shippingFieldId)?.[0]?.valueNumber ?? 0)
+          : 0
+
+        const lines = (lineIdsByOrder.get(orderId) ?? []).map((lineId) =>
+          toLineFact(lineId, lineValues.get(lineId), context.line)
+        )
+
+        const result = deriveFulfillmentLog({
+          existing: stored,
+          lines,
+          orderShippingTotalMinor,
+          timeZone,
+          now,
+        })
+        if (result.heldOut) heldOut++
+        if (!result.changed) continue
+
+        // 🛑 The `{ fulfillments }` OBJECT, never the bare array. A `FieldValue`
+        // write reads a top-level array as a MULTI-VALUE write against a
+        // single-value field, and `setFieldValues` LOGS and SWALLOWS the
+        // refusal - the update reports success over an order whose log is
+        // silently empty (`money/orders/client.ts` says so at length). The
+        // field-value layer adds its own `{ v }` envelope on top; only the inner
+        // wrapper is ours.
+        const handler = new UnifiedCrudHandler(organizationId, SYSTEM_ACTOR, db)
+        await handler.update(toRecordId(context.orderDefId, orderId), {
+          order_fulfillments: { fulfillments: result.fulfillments },
+        })
+        changed.add(orderId)
+      } catch (error) {
+        logger.error('integrity fulfillment-log pass: order failed', {
+          organizationId,
+          orderId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    logger.info('integrity fulfillment-log pass done', {
+      organizationId,
+      orders: orderIds.length,
+      changed: changed.size,
+      heldOut,
+    })
+  } catch (error) {
+    logger.error('integrity fulfillment-log pass failed', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+  return changed
+}
+
+/** The resolved def and field ids the two bounded reads need. */
+interface FulfillmentLogFieldContext {
+  orderDefId: string
+  order: Partial<Record<(typeof ORDER_ATTRIBUTES)[number], string>>
+  line: Partial<Record<(typeof LINE_ATTRIBUTES)[number], string>>
+  orderFieldIds: string[]
+  lineFieldIds: string[]
+}
+
+/**
+ * Resolve the `order` def and every field id, through the org cache.
+ *
+ * Null when the org has no `order` def or has not run entity migration 125 -
+ * without `order_fulfillments` there is nowhere to write, and the honest
+ * response is to skip the org rather than to write a log into a field that does
+ * not exist (which `setFieldValues` would swallow).
+ */
+async function loadFieldContext(
+  organizationId: string
+): Promise<FulfillmentLogFieldContext | null> {
+  const { getCachedEntityDefId, getOrgCache } = await import('../../../cache')
+  const orderDefId = await getCachedEntityDefId(organizationId, 'order')
+  if (!orderDefId) return null
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...ORDER_ATTRIBUTES, ...LINE_ATTRIBUTES])
+  const resolved = fields as unknown as Record<string, { id: string } | null>
+
+  const order: FulfillmentLogFieldContext['order'] = {}
+  for (const attribute of ORDER_ATTRIBUTES) {
+    const id = resolved[attribute]?.id
+    if (id) order[attribute] = id
+  }
+  const line: FulfillmentLogFieldContext['line'] = {}
+  for (const attribute of LINE_ATTRIBUTES) {
+    const id = resolved[attribute]?.id
+    if (id) line[attribute] = id
+  }
+  if (!order.order_fulfillments || !order.order_line_items) return null
+
+  return {
+    orderDefId,
+    order,
+    line,
+    orderFieldIds: Object.values(order),
+    lineFieldIds: Object.values(line),
+  }
+}
+
+/** `accounting.bookTimeZone`, or UTC. See {@link FALLBACK_TIME_ZONE}. */
+async function readBookTimeZone(organizationId: string): Promise<string> {
+  try {
+    const { getOrganizationSetting } = await import('../../../settings/settings-service')
+    const value = await getOrganizationSetting({
+      organizationId,
+      key: 'accounting.bookTimeZone',
+    })
+    return typeof value === 'string' && value.trim() !== '' ? value.trim() : FALLBACK_TIME_ZONE
+  } catch {
+    return FALLBACK_TIME_ZONE
+  }
+}
+
+/** One line's facts, from its pivoted `FieldValue` rows. */
+function toLineFact(
+  lineId: string,
+  bucket: Map<string, ValueRow[]> | undefined,
+  fields: FulfillmentLogFieldContext['line']
+) {
+  const cell = (attribute: keyof FulfillmentLogFieldContext['line']): ValueRow | undefined => {
+    const fieldId = fields[attribute]
+    return fieldId ? bucket?.get(fieldId)?.[0] : undefined
+  }
+  return {
+    lineId,
+    orderedQuantity: cell('line_item_qty')?.valueNumber ?? 0,
+    unitPriceMinor: cell('line_item_unit_price')?.valueNumber ?? 0,
+    // Null, never zero: the channel supplying no per-line tax is a different
+    // state from it supplying a zero (48 §8.2), and the batch builder allocates
+    // the order's tax when any line is null.
+    lineTaxMinor: cell('line_item_tax_total')?.valueNumber ?? null,
+    fulfilledAt: toInstant(cell('line_item_fulfilled_at')?.valueDate),
+    fulfilledQuantity: cell('line_item_fulfilled_qty')?.valueNumber ?? null,
+    shipmentCount: cell('line_item_shipment_count')?.valueNumber ?? null,
+  }
+}
+
+/**
+ * A `valueDate` as an ISO instant, or null.
+ *
+ * `FieldValue.valueDate` is declared `mode: 'string'` while the driver hands
+ * back a parsed `Date` for a `timestamptz` expression, so both shapes arrive
+ * here (`builds/backfill-queries.ts` documents the same seam). An unparseable
+ * value becomes null rather than an Invalid Date, which would compare false
+ * against everything and vanish from the arithmetic much later.
+ */
+function toInstant(value: string | Date | null | undefined): string | null {
+  if (value == null) return null
+  const parsed = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+}
+
+/**
+ * `FieldValue` rows for a set of instances and fields, bucketed
+ * `instance -> field -> rows`.
+ *
+ * The inner value is an ARRAY because a relationship field has one row per
+ * related record, and `order_line_items` is exactly that. The same shape
+ * `money/orders/reads.ts` uses, and the reason it reads columns rather than
+ * going through a typed handler: `order_fulfillments` carries the field-value
+ * layer's `{ v, meta }` envelope and `parseFulfillments` has to see it.
+ */
+async function selectValues(
+  db: Database,
+  organizationId: string,
+  entityIds: readonly string[],
+  fieldIds: readonly string[]
+): Promise<Map<string, Map<string, ValueRow[]>>> {
+  const buckets = new Map<string, Map<string, ValueRow[]>>()
+  if (entityIds.length === 0 || fieldIds.length === 0) return buckets
+
+  const { schema } = await import('@auxx/database')
+  const { and, eq, inArray } = await import('drizzle-orm')
+
+  const rows = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueNumber: schema.FieldValue.valueNumber,
+      valueDate: schema.FieldValue.valueDate,
+      valueJson: schema.FieldValue.valueJson,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.entityId, [...entityIds]),
+        inArray(schema.FieldValue.fieldId, [...fieldIds])
+      )
+    )
+
+  for (const row of rows) {
+    let byField = buckets.get(row.entityId)
+    if (!byField) {
+      byField = new Map()
+      buckets.set(row.entityId, byField)
+    }
+    const list = byField.get(row.fieldId)
+    if (list) list.push(row as ValueRow)
+    else byField.set(row.fieldId, [row as ValueRow])
+  }
+  return buckets
+}

--- a/packages/lib/src/field-hooks/pre/order-delete-guard.test.ts
+++ b/packages/lib/src/field-hooks/pre/order-delete-guard.test.ts
@@ -1,12 +1,20 @@
 // packages/lib/src/field-hooks/pre/order-delete-guard.test.ts
 // The guard that stops an order being hard-deleted out from under a fulfillment
-// entry standing in a settled month.
+// entry - one that stands in a settled month, and one that is simply still
+// live.
 //
 // Modelled on `part-delete-guard.test.ts`. The settled predicates are the same
 // three (`postings/settled-periods.ts`); what differs is the SUBJECT. A part is
-// judged on its stock movements, an order on the general-ledger entries whose
-// lines name it as `sourceType: 'order'`, and those carry a calendar `txnDate`
-// rather than a timestamp, which is what the timezone case below pins.
+// judged on its stock movements, an order on the general-ledger entries that
+// name it, and those carry a calendar `txnDate` rather than a timestamp, which
+// is what the timezone case below pins.
+//
+// 🛑 Two ways an order names an entry, and BOTH are read. A batch fulfillment
+// entry summarises: only the A/R leg of a terms order carries
+// `sourceType: 'order'`, so `listPostingsForSource` finds nothing at all for a
+// paid Shopify order. The shipment log's stamp is the other half, and the
+// `by the stamp alone` block below is the case a source-line-only guard misses
+// entirely.
 
 import { ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,8 +22,11 @@ import type { EntityPreDeleteEvent } from '../types'
 
 const h = vi.hoisted(() => ({
   listPostingsForSource: vi.fn(),
+  listOrderFulfillmentPostings: vi.fn(),
   resolvePeriodLock: vi.fn(),
   postedPeriodRows: vi.fn(),
+  /** The `GlPosting` rows the stamped ids resolve to: id + txnDate. */
+  stampedPostingRows: vi.fn(),
   getOrganizationSetting: vi.fn(),
 }))
 
@@ -23,22 +34,32 @@ vi.mock('../../postings/list-postings', () => ({
   listPostingsForSource: h.listPostingsForSource,
 }))
 
+vi.mock('../../money/fulfillment-posting/reads', () => ({
+  listOrderFulfillmentPostings: h.listOrderFulfillmentPostings,
+}))
+
 vi.mock('../../postings/period-lock', () => ({ resolvePeriodLock: h.resolvePeriodLock }))
 vi.mock('../../settings/settings-service', () => ({
   getOrganizationSetting: h.getOrganizationSetting,
 }))
 
-// `selectDistinct()` is the posted-period read inside `settledPeriodsFor`. The
-// terminal `.where()` resolves, so a query that stops ending there fails loudly.
+// `selectDistinct()` is the posted-period read inside `settledPeriodsFor`, and
+// `select()` is the guard's own read of the stamped postings' accounting dates.
+// The terminal `.where()` resolves in both, so a query that stops ending there
+// fails loudly.
 vi.mock('@auxx/database', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@auxx/database')
   const postedChain: Record<string, unknown> = {}
   postedChain.from = () => postedChain
   postedChain.where = async () => h.postedPeriodRows()
 
+  const stampedChain: Record<string, unknown> = {}
+  stampedChain.from = () => stampedChain
+  stampedChain.where = async () => h.stampedPostingRows()
+
   return {
     ...actual,
-    database: { selectDistinct: () => postedChain },
+    database: { selectDistinct: () => postedChain, select: () => stampedChain },
   }
 })
 
@@ -71,6 +92,34 @@ function postings(...rows: ReturnType<typeof posting>[]): void {
   h.listPostingsForSource.mockResolvedValue(ok(rows))
 }
 
+/** One posting the order's shipment log stamps, as the guard reads it. */
+function stamp(
+  glPostingId: string,
+  txnDate: string,
+  status: 'posted' | 'reversed' = 'posted',
+  docNumber: string | null = `AUXX-FUL-${txnDate.replace(/-/g, '')}`
+) {
+  return { glPostingId, txnDate, status, docNumber }
+}
+
+/** Wire the log's stamps and the `GlPosting` rows they resolve to, together. */
+function stamps(...rows: ReturnType<typeof stamp>[]): void {
+  h.listOrderFulfillmentPostings.mockResolvedValue(
+    ok(
+      rows.map((row, index) => ({
+        sequence: index + 1,
+        shippedAt: row.txnDate,
+        glPostingId: row.glPostingId,
+        docNumber: row.docNumber,
+        status: row.status,
+      }))
+    )
+  )
+  h.stampedPostingRows.mockReturnValue(
+    rows.map((row) => ({ id: row.glPostingId, txnDate: row.txnDate }))
+  )
+}
+
 function settings(values: Record<string, string | null>): void {
   h.getOrganizationSetting.mockImplementation(
     async ({ key }: { key: string }) => values[key] ?? null
@@ -89,6 +138,7 @@ const BOOKS_OPEN = {
 beforeEach(() => {
   vi.clearAllMocks()
   postings()
+  stamps()
   h.postedPeriodRows.mockReturnValue([])
   h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
   settings(BOOKS_OPEN)
@@ -143,6 +193,82 @@ describe('guardOrderDelete: refusal', () => {
     })
 
     await expect(guardOrderDelete(event())).rejects.toThrow(/ledger unavailable/)
+  })
+
+  it('fails closed when the shipment log cannot be read', async () => {
+    h.listOrderFulfillmentPostings.mockResolvedValue({
+      isErr: () => true,
+      error: new Error('shipment log unavailable'),
+    })
+
+    await expect(guardOrderDelete(event())).rejects.toThrow(/shipment log unavailable/)
+  })
+})
+
+// 🛑 The whole point of reading the stamp. A paid Shopify order posts through a
+// batch entry whose clearing, revenue, tax and shipping legs summarise under
+// `fulfillment_batch`, so `listPostingsForSource` returns NOTHING for it. Every
+// case in this block has an empty source-line read.
+describe('guardOrderDelete: by the stamp alone', () => {
+  it('refuses a live stamped posting even with the books wide open', async () => {
+    stamps(stamp('gl_1', '2026-08-15'))
+
+    await expect(guardOrderDelete(event())).rejects.toThrow(/AUXX-FUL-20260815/)
+  })
+
+  it('points at reversing the entry rather than at archiving', async () => {
+    stamps(stamp('gl_1', '2026-08-15'))
+
+    await expect(guardOrderDelete(event())).rejects.toThrow(/Reverse the entry first/)
+  })
+
+  it('names every live entry and counts them', async () => {
+    stamps(stamp('gl_1', '2026-08-15'), stamp('gl_2', '2026-08-16'))
+
+    await expect(guardOrderDelete(event())).rejects.toThrow(
+      /2 ledger entries that are still standing: AUXX-FUL-20260815, AUXX-FUL-20260816/
+    )
+  })
+
+  it('falls back to the posting id when the entry has no document number', async () => {
+    stamps(stamp('gl_1', '2026-08-15', 'posted', null))
+
+    await expect(guardOrderDelete(event())).rejects.toThrow(/gl_1/)
+  })
+
+  // Decision 9: reversing a run is what makes its orders deletable again, and
+  // is also what puts their shipments back into the next bulk preview.
+  it('allows a delete once every stamped posting is reversed', async () => {
+    stamps(stamp('gl_1', '2026-08-15', 'reversed'))
+
+    await expect(guardOrderDelete(event())).resolves.toBeUndefined()
+  })
+
+  // 🛑 The `txnDate` of a batch entry is the LATEST ship date in its group, so a
+  // week grouping can date a July shipment into August. Testing the log's own
+  // date instead of the posting's would test the wrong month.
+  it('settles on the POSTING date, so a reversed entry in a closed month still refuses', async () => {
+    stamps(stamp('gl_1', '2026-08-02', 'reversed'))
+    h.postedPeriodRows.mockReturnValue(posted('2026-08'))
+
+    await expect(guardOrderDelete(event())).rejects.toThrow(/1 ledger posting in 2026-08/)
+  })
+
+  it('counts source lines and stamps together when both name entries', async () => {
+    postings(posting('2026-07-02'))
+    stamps(stamp('gl_1', '2026-08-15', 'reversed'))
+    h.postedPeriodRows.mockReturnValue(posted('2026-07', '2026-08'))
+
+    await expect(guardOrderDelete(event())).rejects.toThrow(/2 ledger postings in 2026-07, 2026-08/)
+  })
+
+  it('reads the log by the order instance', async () => {
+    await guardOrderDelete(event())
+
+    expect(h.listOrderFulfillmentPostings).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: ORG,
+      orderId: ORDER_ID,
+    })
   })
 })
 

--- a/packages/lib/src/field-hooks/pre/order-delete-guard.ts
+++ b/packages/lib/src/field-hooks/pre/order-delete-guard.ts
@@ -1,8 +1,11 @@
 // packages/lib/src/field-hooks/pre/order-delete-guard.ts
 
-import { database } from '@auxx/database'
+import { database, schema } from '@auxx/database'
 import { parseRecordId } from '@auxx/types/resource'
+import { and, eq, inArray } from 'drizzle-orm'
 import { BadRequestError } from '../../errors'
+import { listOrderFulfillmentPostings } from '../../money/fulfillment-posting/reads'
+import type { OrderFulfillmentPostingRef } from '../../money/fulfillment-posting/types'
 import { FULFILLMENT_SOURCE_TYPE } from '../../postings/build-fulfillment-entry'
 import { listPostingsForSource } from '../../postings/list-postings'
 import { describeSettledPeriods, settledPeriodsFor } from '../../postings/settled-periods'
@@ -13,15 +16,30 @@ import type { EntityPreDeleteHandler } from '../types'
  * path, so generic `record.delete`, bulk delete, the drawer, Kopilot and the API
  * all get the same answer.
  *
- * **One refusal: a fulfillment entry standing in a settled month.** A shipped
- * order posts revenue and COGS to the general ledger
- * (`postings/build-fulfillment-entry.ts`), and every line of that entry carries
- * `sourceType: 'order'` / `sourceId: <this order>`. Deleting the order out of a
- * month the books are closed to leaves those lines pointing at a record nobody
- * can open: the revenue stays in the statements forever with nothing that
- * explains it. "Settled" is `settledPeriodsFor` (`postings/settled-periods.ts`),
- * which owns the three predicates and the reason each one is needed, and is the
- * same threshold `parts`, `builds` and `purchase-orders` refuse on.
+ * **Two refusals, and they are about different things.**
+ *
+ * 1. **A ledger entry standing in a SETTLED month.** A shipped order posts
+ *    revenue to the general ledger, and deleting the order out of a month the
+ *    books are closed to leaves those lines pointing at a record nobody can
+ *    open: the revenue stays in the statements forever with nothing that
+ *    explains it. "Settled" is `settledPeriodsFor`
+ *    (`postings/settled-periods.ts`), which owns the three predicates and is the
+ *    same threshold `parts`, `builds` and `purchase-orders` refuse on.
+ * 2. **A LIVE posting stamped on the shipment log**, whatever the period
+ *    (`plans/money/tasks/49-bulk-fulfillment-posting.md` §6 and decision 8).
+ *    Recognised revenue is corrected by reversing the entry, never by deleting
+ *    the record it was recognised from. Reversing first is not a formality: it
+ *    is what puts the shipments back into the next bulk preview.
+ *
+ * 🛑 **Both halves have to read the STAMP, not only the source lines.** A bulk
+ * fulfillment entry summarises: only the A/R leg of a terms order carries
+ * `sourceType: 'order'` / `sourceId: <this order>`, while clearing, revenue, tax
+ * and shipping post under `sourceType: 'fulfillment_batch'` keyed on the period
+ * (§2.5, §8.2). So `listPostingsForSource` finds NOTHING for a paid Shopify
+ * order that is perfectly well posted, and a guard built on it alone would let
+ * a posted order be deleted out of a closed month - the exact hole it exists to
+ * close. The stamped posting ids are therefore read too, and their `txnDate`s
+ * join the settled-period test.
  *
  * **What is NOT here, and why.** The order's line items, credit memos and tax
  * lines are cascaded by the delete engine from the registry declarations
@@ -34,29 +52,55 @@ import type { EntityPreDeleteHandler } from '../types'
  * the `invoices` one: an order carries no payment ledger (`PaymentTransaction`
  * has no order FK) and no lifecycle transition with side effects, so the
  * per-row delete permission `record.delete` already asserts is the whole
- * authorization story. The accounting rule below is about the record's state,
+ * authorization story. The accounting rules below are about the record's state,
  * not the caller's rank.
  */
 export const guardOrderDelete: EntityPreDeleteHandler = async (event) => {
   const { organizationId, recordId } = event
   const { entityInstanceId: orderInstanceId } = parseRecordId(recordId)
 
-  const dates = await readPostingDates(organizationId, orderInstanceId)
-  if (dates.length === 0) return
+  const [sourceDates, stamps] = await Promise.all([
+    readSourcePostingDates(organizationId, orderInstanceId),
+    readStampedPostings(organizationId, orderInstanceId),
+  ])
 
-  const settled = await settledPeriodsFor(organizationId, dates)
-  if (settled.size > 0) {
+  const dates = [...sourceDates, ...stamps.map((stamp) => stamp.txnDate)]
+  if (dates.length > 0) {
+    const settled = await settledPeriodsFor(organizationId, dates)
+    if (settled.size > 0) {
+      throw new BadRequestError(
+        `This order has ${describeSettledPeriods(settled, 'ledger posting')}. ` +
+          'A posted period is corrected by reversing an entry, never by deleting its history. ' +
+          'Archive the order instead.',
+        { organizationId, orderInstanceId, periods: [...settled.keys()] }
+      )
+    }
+  }
+
+  // Checked SECOND, on purpose. A settled period is the terminal answer -
+  // archive, and stop - while a live posting in an open month has a remedy the
+  // person can actually carry out. Naming the reversible one first would send
+  // them to reverse an entry the ledger will not let them reverse.
+  const live = stamps.filter((stamp) => stamp.status !== 'reversed')
+  if (live.length > 0) {
+    const names = live.map((stamp) => stamp.docNumber ?? stamp.glPostingId).join(', ')
     throw new BadRequestError(
-      `This order has ${describeSettledPeriods(settled, 'ledger posting')}. ` +
-        'A posted period is corrected by reversing an entry, never by deleting its history. ' +
-        'Archive the order instead.',
-      { organizationId, orderInstanceId, periods: [...settled.keys()] }
+      `This order's shipment log names ${live.length} ledger ` +
+        `${live.length === 1 ? 'entry' : 'entries'} that ${live.length === 1 ? 'is' : 'are'} ` +
+        `still standing: ${names}. Recognised revenue is corrected by reversing the entry, never ` +
+        'by deleting the order it was recognised from - the entry would stay in the statements ' +
+        'with nothing left to explain it. Reverse the entry first, or archive the order instead.',
+      {
+        organizationId,
+        orderInstanceId,
+        docNumbers: live.map((stamp) => stamp.docNumber ?? stamp.glPostingId),
+      }
     )
   }
 }
 
 /**
- * The accounting date of every entry this order produced.
+ * The accounting date of every entry whose LINES name this order.
  *
  * Every row counts, `reversed` included, which is where this read differs from
  * `hasLiveInvoicePostings`. That read asks "is anything still owed against this
@@ -72,7 +116,10 @@ export const guardOrderDelete: EntityPreDeleteHandler = async (event) => {
  * month in that zone, so any book zone between UTC-11 and UTC+12 reads back
  * the same day. Midnight UTC would read `2026-08-01` as July in Los Angeles.
  */
-async function readPostingDates(organizationId: string, orderInstanceId: string): Promise<Date[]> {
+async function readSourcePostingDates(
+  organizationId: string,
+  orderInstanceId: string
+): Promise<Date[]> {
   const result = await listPostingsForSource(database, {
     organizationId,
     sourceType: FULFILLMENT_SOURCE_TYPE,
@@ -82,5 +129,61 @@ async function readPostingDates(organizationId: string, orderInstanceId: string)
   // the ledger is no guard at all.
   if (result.isErr()) throw result.error
 
-  return result.value.map((posting) => new Date(`${posting.txnDate}T12:00:00Z`))
+  return result.value.map((posting) => noonUtc(posting.txnDate))
+}
+
+/** One posting the order's own shipment log names, with the date it is dated to. */
+interface StampedPosting extends OrderFulfillmentPostingRef {
+  txnDate: Date
+}
+
+/**
+ * The postings the order's shipment log STAMPS, with each one's current status
+ * and accounting date.
+ *
+ * A batch entry's `txnDate` is the latest ship date in its group, which for a
+ * week or month grouping is NOT this order's own ship date and can fall in a
+ * different month. So the date is read off the posting rather than derived from
+ * the log, or a shipment on July 31 inside a `2026-W31` posting dated August 2
+ * would be tested against the wrong month.
+ */
+async function readStampedPostings(
+  organizationId: string,
+  orderInstanceId: string
+): Promise<StampedPosting[]> {
+  const result = await listOrderFulfillmentPostings(database, {
+    organizationId,
+    orderId: orderInstanceId,
+  })
+  // Fail closed, for the reason above.
+  if (result.isErr()) throw result.error
+  const refs = result.value
+  if (refs.length === 0) return []
+
+  const rows = await database
+    .select({ id: schema.GlPosting.id, txnDate: schema.GlPosting.txnDate })
+    .from(schema.GlPosting)
+    .where(
+      and(
+        eq(schema.GlPosting.organizationId, organizationId),
+        inArray(
+          schema.GlPosting.id,
+          refs.map((ref) => ref.glPostingId)
+        )
+      )
+    )
+  const dateById = new Map(rows.map((row) => [row.id, row.txnDate]))
+
+  return refs.flatMap((ref) => {
+    const txnDate = dateById.get(ref.glPostingId)
+    // `listOrderFulfillmentPostings` already dropped stamps whose posting is
+    // gone, so this is unreachable; dropping rather than defaulting keeps it
+    // from inventing a date if it ever stops being.
+    return txnDate ? [{ ...ref, txnDate: noonUtc(txnDate) }] : []
+  })
+}
+
+/** A calendar `date` column, placed at noon UTC so every book zone reads the same day. */
+function noonUtc(txnDate: string): Date {
+  return new Date(`${txnDate}T12:00:00Z`)
 }

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -14,6 +14,10 @@ export {
   type SendScheduledMessageJobData,
   sendScheduledMessageJob,
 } from '../mail-schedule'
+// Money (bulk fulfillment posting, plans/money/tasks/49-bulk-fulfillment-posting.md §2.4).
+// The job NAME comes from the module that enqueues it, so the worker's job map
+// and the enqueue cannot drift into "Job function not found".
+export { FULFILLMENT_POSTING_JOB_NAME } from '../money/fulfillment-posting/auto'
 // Usage
 export { flushUsageEventsJob, type RecordUsageEventJobData, recordUsageEventJob } from '../usage'
 export {
@@ -310,6 +314,10 @@ export {
   type ThreadProviderStatusSyncJobData,
   threadProviderStatusSyncJob,
 } from './messages/thread-provider-status-sync-job'
+export {
+  type FulfillmentPostingJobData,
+  fulfillmentPostingJob,
+} from './money/fulfillment-posting-job'
 // Money (QuickBooks invoice sync — plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3)
 export {
   type SyncQuickbooksInvoiceJobData,

--- a/packages/lib/src/jobs/money/fulfillment-posting-job.ts
+++ b/packages/lib/src/jobs/money/fulfillment-posting-job.ts
@@ -1,0 +1,70 @@
+// packages/lib/src/jobs/money/fulfillment-posting-job.ts
+
+import { database as db } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { runFulfillmentPosting } from '../../money/fulfillment-posting/run'
+import type { JobContext } from '../types'
+
+const logger = createScopedLogger('jobs:money:fulfillment-posting')
+
+/** Payload for {@link fulfillmentPostingJob}. One organization, nothing else. */
+export interface FulfillmentPostingJobData {
+  organizationId: string
+}
+
+/**
+ * The `auto` lane's worker job: post every unposted shipment in one
+ * organization, one entry per ship day (49 §2.4).
+ *
+ * A thin wrapper around {@link runFulfillmentPosting}, exactly as
+ * `sync-quickbooks-invoice-job.ts` is around `syncInvoiceToQuickbooks`. Every
+ * decision - the cutoff, the locked period, the debit fork, the exclusions - is
+ * the runner's, so this lane and the dialog cannot disagree about what a
+ * shipment posts to.
+ *
+ * 🛑 The range is the WHOLE history (`2000-01-01` to tomorrow), not the sync's
+ * own window, and that is deliberate. The read returns shipments with no LIVE
+ * posting stamped, so a bounded range would permanently strand anything a
+ * previous run excluded or failed on - a reversed posting, an order whose
+ * gateways were ambiguous until somebody fixed them, a day that was locked when
+ * it was first seen. Sweeping the backlog every time is what makes the automatic
+ * lane self-healing, and it costs one indexed read on a set that is empty in the
+ * steady state.
+ *
+ * ⚠️ `to` is derived in UTC and is an upper bound only. The range is half-open
+ * on `shippedAt`, which is already a calendar day in the book timezone, so a
+ * loose bound cannot pull in anything that is not there; a shipment dated later
+ * than UTC-tomorrow (possible only in a UTC+13/+14 book) waits for the next run.
+ *
+ * **Never throws.** `runFulfillmentPosting` reports every per-group failure in
+ * its summary rather than raising, so a job that reaches the end has succeeded
+ * even when some groups did not.
+ */
+export const fulfillmentPostingJob = async (ctx: JobContext<FulfillmentPostingJobData>) => {
+  const { organizationId } = ctx.data
+
+  const summary = await runFulfillmentPosting(db, {
+    organizationId,
+    // Nobody asked. The dialog passes the person who pressed the button; this
+    // lane has no actor, and the `null` is what tells the poster so.
+    actorUserId: null,
+    range: { from: '2000-01-01', to: tomorrow() },
+    grouping: 'day',
+  })
+
+  logger.info('Automatic fulfillment posting run finished', {
+    organizationId,
+    posted: summary.posted.length,
+    skipped: summary.skipped.length,
+    failed: summary.failed.length,
+    excluded: summary.exclusions.length,
+    shipments: summary.posted.reduce((total, group) => total + group.shipments, 0),
+  })
+
+  return summary
+}
+
+/** `YYYY-MM-DD`, one day from now in UTC. The half-open upper bound. */
+function tomorrow(): string {
+  return new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+}

--- a/packages/lib/src/jobs/queues/types.ts
+++ b/packages/lib/src/jobs/queues/types.ts
@@ -61,6 +61,12 @@ export enum Queues {
   learnedExtractionQueue = 'learned-extraction',
   // QuickBooks invoice sync queue (plans/dispatch/37e-quickbooks-invoice-sync.md §3, P3)
   quickbooksInvoiceSyncQueue = 'quickbooks-invoice-sync',
+  // Bulk fulfillment posting (plans/money/tasks/49-bulk-fulfillment-posting.md §2.4).
+  // Its OWN queue at concurrency 1: one job posts every unposted shipment in an
+  // org as one entry per ship day, and two of them running side by side would
+  // race for the same day's period key. The `auto` lane coalesces on a per-org
+  // `jobId`, which only de-dupes against a job that is still QUEUED.
+  fulfillmentPostingQueue = 'fulfillment-posting',
   // Purchase-order intake: read a vendor's quote into a draft purchase order
   // (plans/money/tasks/38-purchase-order-from-a-document.md §3.3). Its own queue
   // because one job is a multimodal LLM read of a whole document — 10 to 40

--- a/packages/lib/src/money/client.ts
+++ b/packages/lib/src/money/client.ts
@@ -112,6 +112,32 @@ export {
   type PlannedCreditApplication,
   planCreditApplication,
 } from './credit-memos/client'
+// ─── Bulk fulfillment posting (plans/money/tasks/49-bulk-fulfillment-posting.md) ──
+// The client-safe half only: the groupings, the closed exclusion-reason set the
+// dialog renders a total `Record` over, and the plan/summary wire shapes.
+// Appended as one block, per HANDOFF §9a's rule for shared barrels.
+export {
+  FULFILLMENT_BATCH_SOURCE_TYPE,
+  FULFILLMENT_POSTING_EXCLUSION_REASONS,
+  FULFILLMENT_POSTING_GROUPINGS,
+  FULFILLMENT_POSTING_MODES,
+  FULFILLMENT_POSTING_SETTING_KEY,
+  type FulfillmentDebitRole,
+  type FulfillmentPostingExclusion,
+  type FulfillmentPostingExclusionReason,
+  type FulfillmentPostingGroup,
+  type FulfillmentPostingGrouping,
+  type FulfillmentPostingMode,
+  type FulfillmentPostingPlan,
+  type FulfillmentPostingPlanInput,
+  type FulfillmentPostingRequest,
+  type FulfillmentPostingRunSummary,
+  type OrderFulfillmentPostingRef,
+  type PlannedShipment,
+  type ShipmentAmounts,
+  type UnpostedShipment,
+  type UnpostedShipmentLine,
+} from './fulfillment-posting/client'
 // ─── Order fulfillment (HANDOFF slot 2G) ────────────────────────────────────
 // The client-safe half only: the shipment-log shape and the pure functions over
 // it, which the fulfill dialog reads to prefill remaining quantities.

--- a/packages/lib/src/money/credit-memos/index.ts
+++ b/packages/lib/src/money/credit-memos/index.ts
@@ -43,6 +43,7 @@ export {
   type CreditMemoApplicationRecord,
   type CreditMemoLineRecord,
   type CreditMemoRecord,
+  countUnissuedChannelCreditMemos,
   type InvoiceForCredit,
   type InvoiceLineForCredit,
   listCreditMemoApplications,

--- a/packages/lib/src/money/credit-memos/reads.test.ts
+++ b/packages/lib/src/money/credit-memos/reads.test.ts
@@ -1,0 +1,145 @@
+// packages/lib/src/money/credit-memos/reads.test.ts
+//
+// `countUnissuedChannelCreditMemos` - the count the month-end close refuses on
+// (10 §3.4, 49 §8.4 decision 7).
+//
+// Two properties, and both fail SILENTLY:
+//
+//  1. **The month is matched by SLICING `credit_memo_issued_at`, never by
+//     re-zoning it.** `valueDate` is `timestamp(3) with time zone` in
+//     `mode: 'string'`, so a stored day comes back `'2026-07-31 00:00:00+00'`.
+//     The issue date IS the calendar day the memo's entry would post on, and
+//     deriving a book-zone month here while the poster slices there would let
+//     the close block a memo that posts into a different month, or wave through
+//     one that does not.
+//  2. **A missing field answers 0, not a crash.** An org that has never seeded
+//     the `credit_memo` def has no `credit_memo_source` field at all, and a
+//     close that threw there would be unclosable for a reason with nothing to
+//     do with credit memos.
+//
+// The database is a scripted stub in the `bank-deposits/__tests__/reads.test.ts`
+// shape: each awaited query takes the next queued result.
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Attributes the org has a field for. Anything else resolves to `null`. */
+  present: new Set<string>(),
+  /** One array per awaited query, consumed in order. */
+  results: [] as unknown[][],
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: async (_org: string, slug: string) => `def_${slug}`,
+  getOrgCache: () => ({
+    get: async () => ({}),
+    from: () => ({
+      bySystemAttributes: async (attributes: string[]) =>
+        Object.fromEntries(
+          attributes.map((attribute) => [
+            attribute,
+            h.present.has(attribute) ? { id: `fld_${attribute}` } : null,
+          ])
+        ),
+    }),
+  }),
+}))
+
+const { countUnissuedChannelCreditMemos } = await import('./reads')
+
+const ORG = 'org_1'
+
+function stubDb(): Database {
+  let index = 0
+  const chain = (): Record<string, unknown> => {
+    const self: Record<string, unknown> = {}
+    for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit']) {
+      self[method] = () => self
+    }
+    // biome-ignore lint/suspicious/noThenProperty: chainable drizzle query-builder stub
+    self.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(h.results[index++] ?? []).then(resolve, reject)
+    return self
+  }
+  return { select: () => chain() } as unknown as Database
+}
+
+/** What postgres hands back for a `DATETIME` field value. */
+function issuedAt(day: string) {
+  return { valueDate: `${day} 00:00:00+00` }
+}
+
+beforeEach(() => {
+  h.present = new Set([
+    'credit_memo_status',
+    'credit_memo_source',
+    'credit_memo_issued_at',
+    'credit_memo_contact',
+  ])
+  h.results = []
+})
+
+describe('countUnissuedChannelCreditMemos', () => {
+  it('counts the channel drafts dated inside the month', async () => {
+    // The SQL has already narrowed to status draft and source channel; what
+    // comes back is one row per such memo, carrying its issue date.
+    h.results = [[issuedAt('2026-07-02'), issuedAt('2026-07-31'), issuedAt('2026-07-15')]]
+
+    await expect(
+      countUnissuedChannelCreditMemos(stubDb(), { organizationId: ORG, month: '2026-07' })
+    ).resolves.toBe(3)
+  })
+
+  it('ignores a draft dated in another month, including the neighbouring days', async () => {
+    h.results = [
+      [
+        issuedAt('2026-06-30'),
+        issuedAt('2026-07-01'),
+        issuedAt('2026-08-01'),
+        issuedAt('2027-07-05'),
+      ],
+    ]
+
+    await expect(
+      countUnissuedChannelCreditMemos(stubDb(), { organizationId: ORG, month: '2026-07' })
+    ).resolves.toBe(1)
+  })
+
+  it('does not count a draft with no issue date at all', async () => {
+    h.results = [[{ valueDate: null }, issuedAt('2026-07-09')]]
+
+    await expect(
+      countUnissuedChannelCreditMemos(stubDb(), { organizationId: ORG, month: '2026-07' })
+    ).resolves.toBe(1)
+  })
+
+  it('answers 0 for a month with nothing outstanding', async () => {
+    h.results = [[]]
+
+    await expect(
+      countUnissuedChannelCreditMemos(stubDb(), { organizationId: ORG, month: '2026-07' })
+    ).resolves.toBe(0)
+  })
+
+  it('answers 0 without querying when the org has no credit memo fields', async () => {
+    h.present = new Set()
+    const db = stubDb()
+    const select = vi.spyOn(db, 'select')
+
+    await expect(
+      countUnissuedChannelCreditMemos(db, { organizationId: ORG, month: '2026-07' })
+    ).resolves.toBe(0)
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('answers 0 when the org has the status field but not the source field', async () => {
+    // A half-provisioned def. Counting on status alone would block the close on
+    // every native draft, which 10 §3.4 explicitly exempts.
+    h.present = new Set(['credit_memo_status', 'credit_memo_issued_at'])
+
+    await expect(
+      countUnissuedChannelCreditMemos(stubDb(), { organizationId: ORG, month: '2026-07' })
+    ).resolves.toBe(0)
+  })
+})

--- a/packages/lib/src/money/credit-memos/reads.ts
+++ b/packages/lib/src/money/credit-memos/reads.ts
@@ -14,6 +14,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import { and, asc, eq, inArray, isNull } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
 import { getOrgCache } from '../../cache'
 import { NotFoundError } from '../../errors'
 import { parseFulfillments } from '../orders/reads'
@@ -889,4 +890,98 @@ export async function listOpenInvoicesForContact(
     })
   }
   return rows.sort((a, b) => (a.issuedAt ?? '').localeCompare(b.issuedAt ?? ''))
+}
+
+// ─── The close gate ─────────────────────────────────────────────────────────
+
+/**
+ * How many `channel` credit memos are still DRAFT with an issue date in one
+ * month (10 §3.4, 49 §8.4 decision 7).
+ *
+ * 🛑 This is the count the month-end close refuses on, and it exists because a
+ * channel draft sitting in a month being closed is revenue still on the P&L. A
+ * connector ingested a refund, nobody issued it, and closing the month declares
+ * a set of books that does not contain it. Rolling it into the next period
+ * instead would post an entry dated inside a locked month, which `period-lock.ts`
+ * exists to refuse - so blocking is the only remedy that neither posts something
+ * nobody looked at nor writes into a closed period.
+ *
+ * ⚠️ NATIVE drafts are deliberately not counted. Nothing was ingested and nobody
+ * is waiting: a half-typed credit memo is a person's scratch pad, not revenue
+ * the books are missing.
+ *
+ * The month is matched by SLICING `credit_memo_issued_at`, never by re-zoning
+ * it - the rule the whole of this file and `money/invoices/post-invoice.ts`
+ * follow for an accounting date. The issue date IS the calendar day the entry
+ * would post on, so the refusal and the posting it prevents read the date
+ * identically; deriving a book-zone month here and a sliced day there would let
+ * the close block a memo that would post into a different month.
+ *
+ * The status and source filters run in SQL over an indexed `(organizationId,
+ * fieldId)` pair, so the rows that reach TypeScript are the org's unissued
+ * channel drafts - a set that is empty in the steady state and is a work queue
+ * when it is not.
+ *
+ * @param db The database handle. Reads only.
+ * @param params The organization and the accounting MONTH, `'2026-07'`.
+ * @returns The count. `0` when the org has not seeded the `credit_memo` def.
+ */
+export async function countUnissuedChannelCreditMemos(
+  db: Database,
+  params: { organizationId: string; month: string }
+): Promise<number> {
+  const { organizationId, month } = params
+
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...CREDIT_MEMO_ATTRIBUTES])) as FieldMap<CreditMemoAttribute>
+
+  const statusField = fields.credit_memo_status
+  const sourceField = fields.credit_memo_source
+  const issuedAtField = fields.credit_memo_issued_at
+  if (!statusField || !sourceField || !issuedAtField) return 0
+
+  const source = alias(schema.FieldValue, 'cm_source')
+  const issuedAt = alias(schema.FieldValue, 'cm_issued_at')
+
+  const rows = await db
+    .select({ valueDate: issuedAt.valueDate })
+    .from(schema.FieldValue)
+    .innerJoin(
+      schema.EntityInstance,
+      and(
+        eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .innerJoin(
+      source,
+      and(
+        eq(source.entityId, schema.FieldValue.entityId),
+        eq(source.organizationId, schema.FieldValue.organizationId),
+        eq(source.fieldId, sourceField.id)
+      )
+    )
+    .innerJoin(
+      issuedAt,
+      and(
+        eq(issuedAt.entityId, schema.FieldValue.entityId),
+        eq(issuedAt.organizationId, schema.FieldValue.organizationId),
+        eq(issuedAt.fieldId, issuedAtField.id)
+      )
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, statusField.id),
+        eq(schema.FieldValue.optionId, 'draft'),
+        eq(source.optionId, 'channel')
+      )
+    )
+
+  let count = 0
+  for (const row of rows) {
+    if (toCalendarDay(row.valueDate)?.startsWith(`${month}-`)) count += 1
+  }
+  return count
 }

--- a/packages/lib/src/money/fulfillment-posting/__tests__/auto.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/auto.test.ts
@@ -1,0 +1,132 @@
+// packages/lib/src/money/fulfillment-posting/__tests__/auto.test.ts
+//
+// The `auto` lane is four lines of code and three of them are load bearing, so
+// this file tests exactly those three:
+//
+//  1. **`manual` enqueues NOTHING.** It is the default, and it is the whole
+//     promise of the setting: the dialog's preview is the only review this
+//     feature has, and a mode that posted anyway would make the setting a lie.
+//  2. **`auto` enqueues once, on a per-organization `jobId` with HYPHENS.** The
+//     id is what collapses a burst of sync-finishes into the one run that has
+//     not started yet, and BullMQ throws on a two-part `jobId` containing a
+//     colon - a throw the catch below would swallow, leaving the automatic lane
+//     silently dead.
+//  3. **It never throws.** Its caller is a finalize pass at the end of a
+//     connector sync; a throw there aborts the pass chain to skip a posting the
+//     very next sync would pick up anyway.
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  mode: 'manual' as unknown,
+  settingError: null as Error | null,
+  add: vi.fn<(name: string, data: unknown, options: unknown) => Promise<unknown>>(),
+  getQueue: vi.fn<(queue: string) => unknown>(),
+  loggerError: vi.fn<(message: string, meta?: unknown) => void>(),
+}))
+
+vi.mock('../../../jobs/queues', () => ({
+  Queues: { fulfillmentPostingQueue: 'fulfillment-posting' },
+  getQueue: (queue: string) => {
+    h.getQueue(queue)
+    return { add: h.add }
+  },
+}))
+vi.mock('../../../settings/settings-service', () => ({
+  getOrganizationSetting: async () => {
+    if (h.settingError) throw h.settingError
+    return h.mode
+  },
+}))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({
+    error: h.loggerError,
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+const { autoPostFulfillmentsAfterSync, FULFILLMENT_POSTING_JOB_NAME, fulfillmentPostingJobId } =
+  await import('../auto')
+
+const ORG = 'org_1'
+// The setting read and the enqueue are both mocked, so a sentinel is the honest
+// double - this file never touches a connection.
+const db = {} as Database
+
+beforeEach(() => {
+  h.mode = 'manual'
+  h.settingError = null
+  h.add.mockReset()
+  h.add.mockResolvedValue({ id: 'job_1' })
+  h.getQueue.mockReset()
+  h.loggerError.mockReset()
+})
+
+describe('autoPostFulfillmentsAfterSync', () => {
+  it('enqueues nothing while the setting is manual', async () => {
+    await autoPostFulfillmentsAfterSync(db, ORG)
+
+    expect(h.getQueue).not.toHaveBeenCalled()
+    expect(h.add).not.toHaveBeenCalled()
+  })
+
+  it('enqueues nothing for an unset or unknown mode', async () => {
+    for (const mode of [null, undefined, '', 'automatic', true]) {
+      h.mode = mode
+      await autoPostFulfillmentsAfterSync(db, ORG)
+    }
+
+    expect(h.add).not.toHaveBeenCalled()
+  })
+
+  it('enqueues one job on the per-org jobId when the setting is auto', async () => {
+    h.mode = 'auto'
+
+    await autoPostFulfillmentsAfterSync(db, ORG)
+
+    expect(h.getQueue).toHaveBeenCalledWith('fulfillment-posting')
+    expect(h.add).toHaveBeenCalledTimes(1)
+    expect(h.add).toHaveBeenCalledWith(
+      FULFILLMENT_POSTING_JOB_NAME,
+      { organizationId: ORG },
+      { jobId: `fulfillment-posting-${ORG}` }
+    )
+  })
+
+  it('uses the same jobId for every enqueue of one organization, so a burst coalesces', async () => {
+    h.mode = 'auto'
+
+    await autoPostFulfillmentsAfterSync(db, ORG)
+    await autoPostFulfillmentsAfterSync(db, ORG)
+    await autoPostFulfillmentsAfterSync(db, ORG)
+
+    const ids = h.add.mock.calls.map((call) => (call[2] as { jobId: string }).jobId)
+    expect(new Set(ids)).toEqual(new Set([`fulfillment-posting-${ORG}`]))
+  })
+
+  it('never puts a colon in the jobId', () => {
+    // ⚠️ BullMQ rejects a custom `jobId` containing `:` unless it splits into
+    // exactly three parts, and the enqueue's own catch would swallow the throw.
+    expect(fulfillmentPostingJobId('org_with_underscores')).not.toContain(':')
+    expect(fulfillmentPostingJobId(ORG)).toBe(`fulfillment-posting-${ORG}`)
+  })
+
+  it('swallows and logs a failed setting read', async () => {
+    h.settingError = new Error('cache is down')
+
+    await expect(autoPostFulfillmentsAfterSync(db, ORG)).resolves.toBeUndefined()
+    expect(h.add).not.toHaveBeenCalled()
+    expect(h.loggerError).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows and logs a failed enqueue', async () => {
+    h.mode = 'auto'
+    h.add.mockRejectedValue(new Error('redis is down'))
+
+    await expect(autoPostFulfillmentsAfterSync(db, ORG)).resolves.toBeUndefined()
+    expect(h.loggerError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/money/fulfillment-posting/__tests__/derive-log.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/derive-log.test.ts
@@ -1,0 +1,440 @@
+// packages/lib/src/money/fulfillment-posting/__tests__/derive-log.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { OrderFulfillment } from '../../orders/client'
+import { type DerivedLineFact, deriveFulfillmentLog } from '../derive-log'
+
+/** `accounting.bookTimeZone` on the org this was measured against (49 §5). */
+const ZONE = 'America/Los_Angeles'
+const NOW = '2026-09-09T12:00:00.000Z'
+
+function line(overrides: Partial<DerivedLineFact> & { lineId: string }): DerivedLineFact {
+  return {
+    orderedQuantity: 1,
+    unitPriceMinor: 10_000,
+    lineTaxMinor: null,
+    fulfilledAt: null,
+    fulfilledQuantity: null,
+    shipmentCount: null,
+    ...overrides,
+  }
+}
+
+function derive(input: {
+  existing?: OrderFulfillment[]
+  lines: DerivedLineFact[]
+  shipping?: number
+}) {
+  return deriveFulfillmentLog({
+    existing: input.existing ?? [],
+    lines: input.lines,
+    orderShippingTotalMinor: input.shipping ?? 0,
+    timeZone: ZONE,
+    now: NOW,
+  })
+}
+
+describe('deriveFulfillmentLog', () => {
+  describe('a single shipment', () => {
+    it('makes one entry from the lines that share a fulfilled day', () => {
+      const result = derive({
+        lines: [
+          line({
+            lineId: 'l1',
+            orderedQuantity: 2,
+            unitPriceMinor: 5_000,
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 2,
+            shipmentCount: 1,
+          }),
+          line({
+            lineId: 'l2',
+            orderedQuantity: 1,
+            unitPriceMinor: 2_500,
+            fulfilledAt: '2026-07-06T18:30:00.000Z',
+            fulfilledQuantity: 1,
+            shipmentCount: 1,
+          }),
+        ],
+        shipping: 1_200,
+      })
+
+      expect(result.heldOut).toBeNull()
+      expect(result.changed).toBe(true)
+      expect(result.fulfillments).toHaveLength(1)
+      const entry = result.fulfillments[0]!
+      expect(entry.sequence).toBe(1)
+      expect(entry.shippedAt).toBe('2026-07-06')
+      expect(entry.lines).toEqual([
+        { lineId: 'l1', quantity: 2 },
+        { lineId: 'l2', quantity: 1 },
+      ])
+      expect(entry.subtotalMinor).toBe(12_500)
+      expect(entry.totalMinor).toBe(13_700)
+      expect(entry.shippingRecognised).toBe(true)
+      expect(entry.glPostingId).toBeNull()
+      expect(entry.docNumber).toBeNull()
+      expect(entry.recordedAt).toBe(NOW)
+    })
+
+    it('cuts the day in the BOOK time zone, not UTC', () => {
+      // 02:00Z on July 6 is 19:00 on July 5 in Los Angeles. Cutting in UTC would
+      // post this shipment a day late, and across a month boundary, a month late.
+      const result = derive({
+        lines: [
+          line({
+            lineId: 'l1',
+            fulfilledAt: '2026-07-06T02:00:00.000Z',
+            fulfilledQuantity: 1,
+            shipmentCount: 1,
+          }),
+        ],
+      })
+      expect(result.fulfillments[0]!.shippedAt).toBe('2026-07-05')
+    })
+
+    it('ignores a line the channel said nothing about', () => {
+      const result = derive({
+        lines: [
+          line({ lineId: 'unshipped' }),
+          line({ lineId: 'no-date', fulfilledQuantity: 3 }),
+          line({
+            lineId: 'zero-qty',
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 0,
+          }),
+        ],
+      })
+      expect(result.fulfillments).toEqual([])
+      expect(result.changed).toBe(false)
+      expect(result.heldOut).toBeNull()
+    })
+
+    it('skips a line whose fulfilled date does not parse rather than throwing', () => {
+      const result = derive({
+        lines: [
+          line({ lineId: 'bad', fulfilledAt: 'not a date', fulfilledQuantity: 1 }),
+          line({
+            lineId: 'good',
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 1,
+          }),
+        ],
+      })
+      expect(result.fulfillments).toHaveLength(1)
+      expect(result.fulfillments[0]!.lines).toEqual([{ lineId: 'good', quantity: 1 }])
+    })
+  })
+
+  describe('the measured split shipment (49 §5)', () => {
+    // 82 of 538 imported orders: exactly two shipments, no line spanning both,
+    // every line carrying its own fulfilled date.
+    const lines = [
+      line({
+        lineId: 'first-day',
+        orderedQuantity: 1,
+        unitPriceMinor: 30_000,
+        fulfilledAt: '2026-07-06T16:00:00.000Z',
+        fulfilledQuantity: 1,
+        shipmentCount: 1,
+      }),
+      line({
+        lineId: 'second-day',
+        orderedQuantity: 2,
+        unitPriceMinor: 10_000,
+        fulfilledAt: '2026-07-09T16:00:00.000Z',
+        fulfilledQuantity: 2,
+        shipmentCount: 1,
+      }),
+    ]
+
+    it('makes two entries, sequenced by ship day', () => {
+      const result = derive({ lines, shipping: 2_000 })
+      expect(result.fulfillments.map((row) => [row.sequence, row.shippedAt])).toEqual([
+        [1, '2026-07-06'],
+        [2, '2026-07-09'],
+      ])
+      expect(result.fulfillments[0]!.lines).toEqual([{ lineId: 'first-day', quantity: 1 }])
+      expect(result.fulfillments[1]!.lines).toEqual([{ lineId: 'second-day', quantity: 2 }])
+    })
+
+    it('recognises the order shipping on the FIRST shipment only', () => {
+      const result = derive({ lines, shipping: 2_000 })
+      expect(result.fulfillments.map((row) => row.shippingRecognised)).toEqual([true, false])
+      expect(result.fulfillments[0]!.totalMinor).toBe(32_000)
+      expect(result.fulfillments[1]!.totalMinor).toBe(20_000)
+    })
+
+    it('sequences by ship day even when the lines arrive out of order', () => {
+      const result = derive({ lines: [...lines].reverse(), shipping: 2_000 })
+      expect(result.fulfillments.map((row) => row.shippedAt)).toEqual(['2026-07-06', '2026-07-09'])
+      expect(result.fulfillments[0]!.shippingRecognised).toBe(true)
+    })
+  })
+
+  describe('totals', () => {
+    it('extends a fractional rate once, at the line', () => {
+      const result = derive({
+        lines: [
+          line({
+            lineId: 'screws',
+            orderedQuantity: 1_500,
+            unitPriceMinor: 1.594,
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 1_500,
+            shipmentCount: 1,
+          }),
+        ],
+      })
+      expect(result.fulfillments[0]!.subtotalMinor).toBe(2_391)
+      expect(result.fulfillments[0]!.totalMinor).toBe(2_391)
+    })
+
+    it('adds a supplied per-line tax in full when the whole line shipped', () => {
+      const result = derive({
+        lines: [
+          line({
+            lineId: 'l1',
+            orderedQuantity: 4,
+            unitPriceMinor: 2_500,
+            lineTaxMinor: 875,
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 4,
+            shipmentCount: 1,
+          }),
+        ],
+        shipping: 500,
+      })
+      expect(result.fulfillments[0]!.subtotalMinor).toBe(10_000)
+      expect(result.fulfillments[0]!.totalMinor).toBe(11_375)
+    })
+
+    it('contributes ZERO tax for a line the channel gave no figure for', () => {
+      // Null is not zero (48 §8.2) - the batch builder allocates the order's tax
+      // instead, and this function only ever feeds the per-line basis.
+      const result = derive({
+        lines: [
+          line({
+            lineId: 'l1',
+            orderedQuantity: 1,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: null,
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 1,
+            shipmentCount: 1,
+          }),
+        ],
+      })
+      expect(result.fulfillments[0]!.totalMinor).toBe(10_000)
+    })
+  })
+
+  describe('a partial-line quantity', () => {
+    it('scales the line tax by the fraction shipped', () => {
+      const result = derive({
+        lines: [
+          line({
+            lineId: 'l1',
+            orderedQuantity: 3,
+            unitPriceMinor: 1_000,
+            lineTaxMinor: 100,
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 2,
+            shipmentCount: 1,
+          }),
+        ],
+      })
+      const entry = result.fulfillments[0]!
+      expect(entry.lines).toEqual([{ lineId: 'l1', quantity: 2 }])
+      expect(entry.subtotalMinor).toBe(2_000)
+      // round(100 * 2 / 3) = 67
+      expect(entry.totalMinor).toBe(2_067)
+    })
+
+    it('carries the whole line tax when the ordered quantity cannot be a denominator', () => {
+      const result = derive({
+        lines: [
+          line({
+            lineId: 'l1',
+            orderedQuantity: 0,
+            unitPriceMinor: 1_000,
+            lineTaxMinor: 100,
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 1,
+            shipmentCount: 1,
+          }),
+        ],
+      })
+      expect(result.fulfillments[0]!.totalMinor).toBe(1_100)
+    })
+  })
+
+  describe('the split-shipment hold-out', () => {
+    it('holds the WHOLE order out and writes nothing when a line shipped twice', () => {
+      const existing: OrderFulfillment[] = []
+      const result = derive({
+        existing,
+        lines: [
+          line({
+            lineId: 'ok',
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 1,
+            shipmentCount: 1,
+          }),
+          line({
+            lineId: 'split-line',
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 2,
+            shipmentCount: 2,
+          }),
+        ],
+      })
+      expect(result.heldOut).toBe('split-line')
+      expect(result.changed).toBe(false)
+      expect(result.fulfillments).toBe(existing)
+    })
+
+    it('does not hold out on a null shipment count - null is not "more than one"', () => {
+      const result = derive({
+        lines: [
+          line({
+            lineId: 'l1',
+            fulfilledAt: '2026-07-06T16:00:00.000Z',
+            fulfilledQuantity: 1,
+            shipmentCount: null,
+          }),
+        ],
+      })
+      expect(result.heldOut).toBeNull()
+      expect(result.fulfillments).toHaveLength(1)
+    })
+  })
+
+  describe('merging against what is already stored', () => {
+    const stored = (overrides: Partial<OrderFulfillment>): OrderFulfillment => ({
+      sequence: 1,
+      shippedAt: '2026-07-06',
+      lines: [{ lineId: 'l1', quantity: 1 }],
+      subtotalMinor: 10_000,
+      totalMinor: 10_000,
+      shippingRecognised: true,
+      glPostingId: null,
+      docNumber: null,
+      recordedAt: '2026-07-07T00:00:00.000Z',
+      ...overrides,
+    })
+
+    const shippedLine = line({
+      lineId: 'l1',
+      orderedQuantity: 1,
+      unitPriceMinor: 10_000,
+      fulfilledAt: '2026-07-06T16:00:00.000Z',
+      fulfilledQuantity: 1,
+      shipmentCount: 1,
+    })
+
+    it('keeps a matching STAMPED entry verbatim, stamp included', () => {
+      const existing = [stored({ glPostingId: 'post_1', docNumber: 'AUXX-FUL-ORD0012F1' })]
+      const result = derive({ existing, lines: [shippedLine] })
+      expect(result.changed).toBe(false)
+      expect(result.fulfillments).toEqual(existing)
+      expect(result.fulfillments[0]!.glPostingId).toBe('post_1')
+      expect(result.fulfillments[0]!.docNumber).toBe('AUXX-FUL-ORD0012F1')
+      expect(result.fulfillments[0]!.recordedAt).toBe('2026-07-07T00:00:00.000Z')
+    })
+
+    it('keeps a DIFFERING stamped entry and drops the derived one', () => {
+      // Drift on a posted shipment is a person's call (49 §2.6 rule 2).
+      const existing = [
+        stored({
+          glPostingId: 'post_1',
+          docNumber: 'AUXX-FUL-ORD0012F1',
+          lines: [{ lineId: 'l1', quantity: 5 }],
+        }),
+      ]
+      const result = derive({ existing, lines: [shippedLine] })
+      expect(result.changed).toBe(false)
+      expect(result.fulfillments).toEqual(existing)
+      expect(result.fulfillments[0]!.lines).toEqual([{ lineId: 'l1', quantity: 5 }])
+    })
+
+    it('replaces a DIFFERING unstamped entry, keeping its sequence', () => {
+      const existing = [stored({ sequence: 3, lines: [{ lineId: 'l1', quantity: 5 }] })]
+      const result = derive({ existing, lines: [shippedLine], shipping: 400 })
+      expect(result.changed).toBe(true)
+      expect(result.fulfillments).toHaveLength(1)
+      const entry = result.fulfillments[0]!
+      expect(entry.sequence).toBe(3)
+      expect(entry.lines).toEqual([{ lineId: 'l1', quantity: 1 }])
+      expect(entry.subtotalMinor).toBe(10_000)
+      // The replaced row's shipping flag went with it, so the replacement takes it back.
+      expect(entry.shippingRecognised).toBe(true)
+      expect(entry.totalMinor).toBe(10_400)
+      expect(entry.recordedAt).toBe(NOW)
+    })
+
+    it('is a no-op on a re-derivation of an unstamped log it wrote itself', () => {
+      const first = derive({ lines: [shippedLine], shipping: 400 })
+      const second = derive({ existing: first.fulfillments, lines: [shippedLine], shipping: 400 })
+      expect(second.changed).toBe(false)
+      expect(second.fulfillments).toEqual(first.fulfillments)
+    })
+
+    it('appends a new day after the stored entries without renumbering them', () => {
+      const existing = [
+        stored({ sequence: 7, glPostingId: 'post_1', docNumber: 'AUXX-FUL-ORD0012F7' }),
+      ]
+      const later = line({
+        lineId: 'l2',
+        orderedQuantity: 1,
+        unitPriceMinor: 3_000,
+        fulfilledAt: '2026-07-09T16:00:00.000Z',
+        fulfilledQuantity: 1,
+        shipmentCount: 1,
+      })
+      const result = derive({ existing, lines: [shippedLine, later], shipping: 400 })
+      expect(result.changed).toBe(true)
+      expect(result.fulfillments.map((row) => [row.sequence, row.shippedAt])).toEqual([
+        [7, '2026-07-06'],
+        [8, '2026-07-09'],
+      ])
+      // The stored entry already recognised the freight; the appended one must not.
+      expect(result.fulfillments[1]!.shippingRecognised).toBe(false)
+      expect(result.fulfillments[1]!.totalMinor).toBe(3_000)
+    })
+
+    it('leaves a stored entry the channel no longer reports alone', () => {
+      const existing = [
+        stored({ sequence: 1, shippedAt: '2026-06-01', glPostingId: 'post_0' }),
+        stored({ sequence: 2, shippingRecognised: false }),
+      ]
+      const result = derive({ existing, lines: [shippedLine] })
+      expect(result.changed).toBe(false)
+      expect(result.fulfillments).toEqual(existing)
+    })
+
+    it('does not recognise the shipping twice when a stored entry already holds it', () => {
+      const existing = [stored({ sequence: 1, shippedAt: '2026-06-01', glPostingId: 'post_0' })]
+      const result = derive({ existing, lines: [shippedLine], shipping: 400 })
+      expect(result.fulfillments).toHaveLength(2)
+      expect(result.fulfillments[1]!.shippingRecognised).toBe(false)
+      expect(result.fulfillments[1]!.totalMinor).toBe(10_000)
+    })
+
+    it('pairs each derived day with at most one stored entry on that day', () => {
+      const existing = [
+        stored({ sequence: 1, lines: [{ lineId: 'l1', quantity: 1 }], glPostingId: 'post_1' }),
+        stored({
+          sequence: 2,
+          lines: [{ lineId: 'l9', quantity: 9 }],
+          shippingRecognised: false,
+        }),
+      ]
+      const result = derive({ existing, lines: [shippedLine] })
+      // The first stored row matches verbatim; the second stays untouched
+      // because the derived shipment already claimed the day.
+      expect(result.changed).toBe(false)
+      expect(result.fulfillments).toEqual(existing)
+    })
+  })
+})

--- a/packages/lib/src/money/fulfillment-posting/__tests__/plan.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/plan.test.ts
@@ -1,0 +1,519 @@
+// packages/lib/src/money/fulfillment-posting/__tests__/plan.test.ts
+//
+// `planFulfillmentPosting` is the whole decision behind the bulk poster and it
+// touches nothing, so this file is where the painful cases live: a week that
+// straddles a month, an order carrying two gateways, a shipment dated inside a
+// closed period, and the priority order between those reasons.
+//
+// 🛑 Lane A's `resolveFulfillmentDebit` and `computeShipmentAmounts` are used
+// FOR REAL here, not stubbed. They are pure, and the thing worth asserting is
+// that the plan and the builder agree about what one shipment is worth - a
+// stub would assert only that the plan calls something.
+//
+// Amounts are integer minor units: 12_000 = $120.00.
+
+import { describe, expect, it } from 'vitest'
+import { groupKeyFor, isoWeekKey, planFulfillmentPosting } from '../plan'
+import type {
+  FulfillmentPostingGrouping,
+  FulfillmentPostingPlanInput,
+  UnpostedShipment,
+} from '../types'
+
+/** One shipment of a one-line, $100, paid-by-card order. */
+function shipment(overrides: Partial<UnpostedShipment> = {}): UnpostedShipment {
+  const orderId = overrides.orderId ?? 'ord_1'
+  return {
+    orderId,
+    orderNumber: overrides.orderNumber ?? '#1001',
+    sequence: 1,
+    shippedAt: '2026-07-06',
+    lines: [
+      {
+        lineId: `${orderId}_l1`,
+        quantity: 1,
+        unitPriceMinor: 10_000,
+        lineTaxMinor: null,
+        orderedQuantity: 1,
+        name: 'Widget',
+      },
+    ],
+    channel: 'dtc',
+    currency: 'USD',
+    financialStatus: 'paid',
+    gateways: ['shopify_payments'],
+    orderSubtotalMinor: 10_000,
+    orderTaxTotalMinor: 0,
+    orderShippingTotalMinor: 0,
+    priorShipmentsSubtotalMinor: 0,
+    includeShipping: false,
+    contactId: 'ct_1',
+    ...overrides,
+  }
+}
+
+function plan(
+  shipments: UnpostedShipment[],
+  overrides: Partial<Omit<FulfillmentPostingPlanInput, 'shipments'>> = {}
+) {
+  return planFulfillmentPosting({
+    shipments,
+    grouping: 'day',
+    cutoffPeriod: null,
+    lockedThroughMonth: null,
+    ledgerCurrency: 'USD',
+    timeZone: 'America/Los_Angeles',
+    ...overrides,
+  })
+}
+
+describe('grouping', () => {
+  const ships = [
+    shipment({ orderId: 'a', orderNumber: '#1', shippedAt: '2026-07-27' }),
+    shipment({ orderId: 'b', orderNumber: '#2', shippedAt: '2026-07-31' }),
+    shipment({ orderId: 'c', orderNumber: '#3', shippedAt: '2026-08-02' }),
+  ]
+
+  it('makes one posting per calendar day', () => {
+    expect(plan(ships, { grouping: 'day' }).groups.map((g) => g.groupKey)).toEqual([
+      '2026-07-27',
+      '2026-07-31',
+      '2026-08-02',
+    ])
+  })
+
+  it('makes one posting per calendar month', () => {
+    expect(plan(ships, { grouping: 'month' }).groups.map((g) => g.groupKey)).toEqual([
+      '2026-07',
+      '2026-08',
+    ])
+  })
+
+  // 🛑 The case a month bucket cannot express. `2026-W31` is Monday July 27
+  // through Sunday August 2, so all three shipments are ONE posting - and its
+  // `txnDate` is in August while its key names a week that starts in July.
+  it('makes one posting for a week that straddles a month boundary', () => {
+    const result = plan(ships, { grouping: 'week' })
+
+    expect(result.groups.map((g) => g.groupKey)).toEqual(['2026-W31'])
+    expect(result.groups[0]?.shipments).toHaveLength(3)
+    expect(result.groups[0]?.txnDate).toBe('2026-08-02')
+  })
+
+  it('keeps a week that crosses the new year in the ISO week-numbering year', () => {
+    const result = plan(
+      [
+        shipment({ orderId: 'a', orderNumber: '#1', shippedAt: '2026-12-31' }),
+        shipment({ orderId: 'b', orderNumber: '#2', shippedAt: '2027-01-01' }),
+      ],
+      { grouping: 'week' }
+    )
+
+    expect(result.groups.map((g) => g.groupKey)).toEqual(['2026-W53'])
+    expect(result.groups[0]?.txnDate).toBe('2027-01-01')
+  })
+
+  it('dates a group to its LATEST ship date, never to the key', () => {
+    const result = plan(ships, { grouping: 'month' })
+
+    expect(result.groups.map((g) => g.txnDate)).toEqual(['2026-07-31', '2026-08-02'])
+  })
+
+  it('counts DISTINCT orders, not shipments', () => {
+    const result = plan(
+      [
+        shipment({ orderId: 'a', orderNumber: '#1', sequence: 1, shippedAt: '2026-07-06' }),
+        shipment({ orderId: 'a', orderNumber: '#1', sequence: 2, shippedAt: '2026-07-06' }),
+        shipment({ orderId: 'b', orderNumber: '#2', shippedAt: '2026-07-06' }),
+      ],
+      { grouping: 'day' }
+    )
+
+    expect(result.groups[0]?.shipments).toHaveLength(3)
+    expect(result.groups[0]?.orderCount).toBe(2)
+    expect(result.footer.orders).toBe(2)
+  })
+
+  it('orders groups by key and shipments by ship date, order number, sequence', () => {
+    const result = plan(
+      [
+        shipment({ orderId: 'b', orderNumber: '#2', sequence: 2, shippedAt: '2026-07-06' }),
+        shipment({ orderId: 'c', orderNumber: '#3', shippedAt: '2026-07-05' }),
+        shipment({ orderId: 'b', orderNumber: '#2', sequence: 1, shippedAt: '2026-07-06' }),
+        shipment({ orderId: 'a', orderNumber: '#1', shippedAt: '2026-07-06' }),
+      ],
+      { grouping: 'month' }
+    )
+
+    expect(result.groups[0]?.shipments.map((s) => `${s.orderNumber}/${s.sequence}`)).toEqual([
+      '#3/1',
+      '#1/1',
+      '#2/1',
+      '#2/2',
+    ])
+  })
+})
+
+describe('isoWeekKey and groupKeyFor', () => {
+  it('matches date-fns RRRR-Www on the boundaries that bite', () => {
+    expect(isoWeekKey('2026-01-01')).toBe('2026-W01')
+    expect(isoWeekKey('2026-07-06')).toBe('2026-W28')
+    expect(isoWeekKey('2026-07-12')).toBe('2026-W28')
+    expect(isoWeekKey('2026-07-13')).toBe('2026-W29')
+    expect(isoWeekKey('2026-12-31')).toBe('2026-W53')
+    expect(isoWeekKey('2027-01-01')).toBe('2026-W53')
+  })
+
+  it.each<[FulfillmentPostingGrouping, string]>([
+    ['day', '2026-07-06'],
+    ['week', '2026-W28'],
+    ['month', '2026-07'],
+  ])('keys a %s group as %s', (grouping, expected) => {
+    expect(groupKeyFor('2026-07-06', grouping)).toBe(expected)
+  })
+})
+
+describe('exclusions carry the value that proves them', () => {
+  it('excludes a shipment at or before the accounting cutoff, naming the cutoff', () => {
+    const result = plan([shipment({ shippedAt: '2025-12-31' })], { cutoffPeriod: '2025-12' })
+
+    expect(result.groups).toEqual([])
+    expect(result.exclusions).toEqual([
+      expect.objectContaining({ reason: 'before-cutoff', detail: '2025-12' }),
+    ])
+  })
+
+  it('keeps a shipment in the month AFTER the cutoff', () => {
+    const result = plan([shipment({ shippedAt: '2026-01-02' })], { cutoffPeriod: '2025-12' })
+
+    expect(result.exclusions).toEqual([])
+    expect(result.groups).toHaveLength(1)
+  })
+
+  it('excludes a shipment in a locked month, naming the lock', () => {
+    const result = plan([shipment({ shippedAt: '2026-07-06' })], {
+      lockedThroughMonth: '2026-07',
+    })
+
+    expect(result.exclusions).toEqual([
+      expect.objectContaining({ reason: 'locked-period', detail: '2026-07' }),
+    ])
+  })
+
+  it('excludes a foreign-currency order, naming the currency', () => {
+    const result = plan([shipment({ currency: 'CAD' })])
+
+    expect(result.exclusions).toEqual([
+      expect.objectContaining({ reason: 'foreign-currency', detail: 'CAD' }),
+    ])
+  })
+
+  // A blank currency is an unfilled cell, not a foreign order. 7 of the org's
+  // 538 imported orders carry one (§7).
+  it('reads a blank currency as the ledger currency', () => {
+    expect(plan([shipment({ currency: '' })]).exclusions).toEqual([])
+    expect(plan([shipment({ currency: null })]).exclusions).toEqual([])
+  })
+
+  it('excludes a test order, naming the gateway', () => {
+    const result = plan([shipment({ gateways: ['bogus'] })])
+
+    expect(result.exclusions).toEqual([
+      expect.objectContaining({ reason: 'test-gateway', detail: 'bogus' }),
+    ])
+  })
+
+  it('excludes an order split across two gateways, naming both', () => {
+    const result = plan([shipment({ gateways: ['shopify_payments', 'Affirm'] })])
+
+    expect(result.exclusions).toEqual([
+      expect.objectContaining({
+        reason: 'gateway-ambiguous',
+        detail: 'shopify_payments, affirm',
+      }),
+    ])
+  })
+
+  it('excludes a shipment worth nothing, naming the total', () => {
+    const result = plan([
+      shipment({
+        lines: [
+          {
+            lineId: 'l1',
+            quantity: 1,
+            unitPriceMinor: 0,
+            lineTaxMinor: null,
+            orderedQuantity: 1,
+          },
+        ],
+        orderSubtotalMinor: 0,
+      }),
+    ])
+
+    expect(result.exclusions).toEqual([
+      expect.objectContaining({ reason: 'zero-value', detail: '0' }),
+    ])
+  })
+
+  it('reports a shipment whose amounts cannot be computed rather than throwing', () => {
+    const result = plan([
+      shipment({
+        lines: [
+          {
+            lineId: 'l1',
+            quantity: Number.NaN,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: null,
+            orderedQuantity: 1,
+          },
+        ],
+      }),
+    ])
+
+    expect(result.groups).toEqual([])
+    expect(result.exclusions[0]?.reason).toBe('zero-value')
+    // The builder's own sentence, not a swallowed error.
+    expect(result.exclusions[0]?.detail).toMatch(/NaN/)
+  })
+
+  it('names the order, the sequence and the ship date on every exclusion', () => {
+    const result = plan([
+      shipment({ orderId: 'ord_9', orderNumber: '#9', sequence: 3, currency: 'EUR' }),
+    ])
+
+    expect(result.exclusions[0]).toEqual({
+      orderId: 'ord_9',
+      orderNumber: '#9',
+      sequence: 3,
+      shippedAt: '2026-07-06',
+      reason: 'foreign-currency',
+      detail: 'EUR',
+    })
+  })
+})
+
+describe('the exclusion PRIORITY order', () => {
+  // 🛑 Every one of these shipments qualifies for several reasons at once. The
+  // remedy differs per reason, so reporting the wrong one sends a person to the
+  // wrong screen.
+  it('reports a cutoff shipment as before-cutoff even when the period is also locked', () => {
+    const result = plan([shipment({ shippedAt: '2025-11-04', currency: 'CAD' })], {
+      cutoffPeriod: '2025-12',
+      lockedThroughMonth: '2026-01',
+    })
+
+    expect(result.exclusions[0]?.reason).toBe('before-cutoff')
+  })
+
+  it('reports a locked shipment as locked-period even when it is foreign currency', () => {
+    const result = plan([shipment({ shippedAt: '2026-07-06', currency: 'CAD' })], {
+      lockedThroughMonth: '2026-07',
+    })
+
+    expect(result.exclusions[0]?.reason).toBe('locked-period')
+  })
+
+  it('reports a foreign-currency shipment as such even when its gateways are ambiguous', () => {
+    const result = plan([shipment({ currency: 'CAD', gateways: ['stripe', 'paypal'] })])
+
+    expect(result.exclusions[0]?.reason).toBe('foreign-currency')
+  })
+
+  it('reports a test order as test-gateway even when the shipment is worth nothing', () => {
+    const result = plan([
+      shipment({
+        gateways: ['bogus'],
+        lines: [
+          { lineId: 'l1', quantity: 1, unitPriceMinor: 0, lineTaxMinor: null, orderedQuantity: 1 },
+        ],
+        orderSubtotalMinor: 0,
+      }),
+    ])
+
+    expect(result.exclusions[0]?.reason).toBe('test-gateway')
+  })
+
+  it('excludes each shipment exactly once', () => {
+    const result = plan([shipment({ shippedAt: '2025-11-04', currency: 'CAD' })], {
+      cutoffPeriod: '2025-12',
+    })
+
+    expect(result.exclusions).toHaveLength(1)
+    expect(result.footer.excluded).toBe(1)
+  })
+})
+
+describe('totals and the debit split', () => {
+  it('splits a group by the account each shipment debits', () => {
+    const result = plan([
+      // Paid by card.
+      shipment({ orderId: 'a', orderNumber: '#1' }),
+      // Paid by Affirm: its own clearing account, so the payout reconciles.
+      shipment({ orderId: 'b', orderNumber: '#2', gateways: ['Affirm'] }),
+      // Not paid: a receivable, and aging needs the debtor.
+      shipment({ orderId: 'c', orderNumber: '#3', financialStatus: 'pending' }),
+    ])
+
+    expect(result.groups[0]?.totals.byDebitRole).toEqual({
+      clearing_card: 10_000,
+      clearing_affirm: 10_000,
+      accounts_receivable: 10_000,
+    })
+  })
+
+  it('sums subtotal, tax and shipping into the group total', () => {
+    const result = plan([
+      shipment({
+        orderId: 'a',
+        orderNumber: '#1',
+        orderTaxTotalMinor: 800,
+        orderShippingTotalMinor: 1_500,
+        includeShipping: true,
+      }),
+      shipment({ orderId: 'b', orderNumber: '#2' }),
+    ])
+
+    expect(result.groups[0]?.totals).toMatchObject({
+      subtotalMinor: 20_000,
+      taxMinor: 800,
+      shippingMinor: 1_500,
+      totalMinor: 22_300,
+    })
+  })
+
+  it('recognises shipping only on the shipment the log flagged', () => {
+    const result = plan([
+      shipment({
+        orderId: 'a',
+        sequence: 1,
+        orderShippingTotalMinor: 1_500,
+        includeShipping: true,
+      }),
+      shipment({
+        orderId: 'a',
+        sequence: 2,
+        orderShippingTotalMinor: 1_500,
+        includeShipping: false,
+        priorShipmentsSubtotalMinor: 10_000,
+      }),
+    ])
+
+    expect(result.groups[0]?.totals.shippingMinor).toBe(1_500)
+  })
+
+  // The reason `priorShipmentsSubtotalMinor` is on the read at all: the second
+  // shipment's tax is the running allocation minus the first's, so the two
+  // shipments together carry the order's whole 100 of tax with no cent lost.
+  it('allocates tax cumulatively across two shipments of one order', () => {
+    const first = plan([
+      shipment({
+        orderId: 'a',
+        sequence: 1,
+        lines: [
+          {
+            lineId: 'l1',
+            quantity: 1,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: null,
+            orderedQuantity: 3,
+          },
+        ],
+        orderSubtotalMinor: 30_000,
+        orderTaxTotalMinor: 100,
+        priorShipmentsSubtotalMinor: 0,
+      }),
+    ])
+    const third = plan([
+      shipment({
+        orderId: 'a',
+        sequence: 3,
+        lines: [
+          {
+            lineId: 'l1',
+            quantity: 1,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: null,
+            orderedQuantity: 3,
+          },
+        ],
+        orderSubtotalMinor: 30_000,
+        orderTaxTotalMinor: 100,
+        priorShipmentsSubtotalMinor: 20_000,
+      }),
+    ])
+
+    expect(first.groups[0]?.totals.taxMinor).toBe(33)
+    // 100 - round(100 * 20000/30000) = 100 - 67 = 33... the remainder lands here.
+    expect(third.groups[0]?.totals.taxMinor).toBe(33)
+    expect(first.groups[0]?.shipments[0]?.amounts.taxBasis).toBe('allocated')
+  })
+
+  it('uses the per-line tax when every shipped line carries one', () => {
+    const result = plan([
+      shipment({
+        lines: [
+          {
+            lineId: 'l1',
+            quantity: 1,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: 875,
+            orderedQuantity: 1,
+          },
+        ],
+        orderTaxTotalMinor: 999,
+      }),
+    ])
+
+    expect(result.groups[0]?.shipments[0]?.amounts.taxBasis).toBe('per_line')
+    expect(result.groups[0]?.totals.taxMinor).toBe(875)
+  })
+})
+
+describe('the footer', () => {
+  it('counts postings, shipments, orders, exclusions and the money', () => {
+    const result = plan(
+      [
+        shipment({ orderId: 'a', orderNumber: '#1', shippedAt: '2026-07-06' }),
+        shipment({ orderId: 'a', orderNumber: '#1', sequence: 2, shippedAt: '2026-07-07' }),
+        shipment({ orderId: 'b', orderNumber: '#2', shippedAt: '2026-07-07' }),
+        shipment({ orderId: 'c', orderNumber: '#3', shippedAt: '2026-07-07', currency: 'CAD' }),
+      ],
+      { grouping: 'day' }
+    )
+
+    expect(result.footer).toEqual({
+      postings: 2,
+      shipments: 3,
+      orders: 2,
+      excluded: 1,
+      totalMinor: 30_000,
+    })
+  })
+
+  it('reports an empty range as an empty plan rather than refusing', () => {
+    expect(plan([])).toEqual({
+      grouping: 'day',
+      groups: [],
+      exclusions: [],
+      footer: { postings: 0, shipments: 0, orders: 0, excluded: 0, totalMinor: 0 },
+    })
+  })
+
+  it('carries the grouping it was asked for', () => {
+    expect(plan([], { grouping: 'week' }).grouping).toBe('week')
+  })
+})
+
+describe('what the plan does NOT know', () => {
+  // 🛑 The netting read decides what is unposted (a null stamp, a `reversed`
+  // posting, or a stamp pointing at a posting that no longer exists). The plan
+  // sees only shipments, so a shipment that came back BECAUSE its posting was
+  // reversed is planned exactly like a never-posted one - which is what makes
+  // "reverse a day and it comes back on the next preview" work.
+  it('plans a re-offered shipment identically to a fresh one', () => {
+    const fresh = plan([shipment({ orderId: 'a', orderNumber: '#1' })])
+    const reoffered = plan([shipment({ orderId: 'a', orderNumber: '#1' })])
+
+    expect(reoffered).toEqual(fresh)
+  })
+})

--- a/packages/lib/src/money/fulfillment-posting/__tests__/reads.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/reads.test.ts
@@ -1,0 +1,554 @@
+// packages/lib/src/money/fulfillment-posting/__tests__/reads.test.ts
+//
+// The netting read, its month arithmetic, and the two shapes it is easy to get
+// silently wrong: a TAGS gateway stored as an opaque option key rather than a
+// name, and a `line_item_tax_total` that is absent rather than zero.
+//
+// 🛑 The statement itself is asserted as TEXT. It is the one piece of this
+// module a unit test cannot execute, and the three predicates in it are the
+// whole netting contract - a null stamp, a `reversed` posting, or a stamp
+// naming a posting that is gone. A refactor that dropped one of those would
+// silently re-post a reversed day's revenue, and nothing else in the suite
+// would notice.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  settings: {} as Record<string, unknown>,
+  lock: { lockedThroughMonth: null } as { lockedThroughMonth: string | null },
+  executed: [] as unknown[],
+  executeRows: [] as unknown[],
+  selects: [] as unknown[][],
+  contextMissing: false,
+}))
+
+const FIELD_IDS = {
+  order_number: 'f_number',
+  order_channel: 'f_channel',
+  order_currency: 'f_currency',
+  order_subtotal: 'f_subtotal',
+  order_tax_total: 'f_tax',
+  order_shipping_total: 'f_shipping',
+  order_total: 'f_total',
+  order_fulfillment_status: 'f_fulfillment_status',
+  order_line_items: 'f_line_items',
+  order_fulfillments: 'f_fulfillments',
+  order_financial_status: 'f_financial_status',
+  order_payment_gateways: 'f_gateways',
+  order_contact: 'f_contact',
+  line_item_name: 'f_line_name',
+  line_item_qty: 'f_line_qty',
+  line_item_unit_price: 'f_line_price',
+  line_item_tax_total: 'f_line_tax',
+  line_item_sort_order: 'f_line_sort',
+} as const
+
+vi.mock('../../orders/reads', async () => {
+  const actual = await vi.importActual<typeof import('../../orders/reads')>('../../orders/reads')
+  const field = (id: string, options?: unknown) => ({ id, options })
+  return {
+    // The tolerant parser stays REAL: `listOrderFulfillmentPostings` reading the
+    // same log everything else reads is the property under test.
+    parseFulfillments: actual.parseFulfillments,
+    requireOrderFieldContext: async () => {
+      if (h.contextMissing) throw new Error('order fields are not provisioned')
+      const entries = Object.entries(FIELD_IDS).map(([attribute, id]) => [
+        attribute,
+        field(
+          id,
+          attribute === 'order_payment_gateways'
+            ? { options: [{ value: 'opt_sp', label: 'shopify_payments' }] }
+            : undefined
+        ),
+      ])
+      const all = Object.fromEntries(entries)
+      return { orderDefId: 'def_order', order: all, line: all }
+    },
+  }
+})
+
+vi.mock('../../../postings/post-entry', () => ({ LEDGER_CURRENCY: 'USD' }))
+vi.mock('../../../postings/period-lock', () => ({ resolvePeriodLock: async () => h.lock }))
+vi.mock('../../../settings/settings-service', () => ({
+  getOrganizationSetting: async ({ key }: { key: string }) => h.settings[key] ?? null,
+}))
+
+import type { Database } from '@auxx/database'
+import {
+  countCloseBlockingShipments,
+  countUnpostedShipments,
+  listOrderFulfillmentPostings,
+  readFulfillmentPostingSettings,
+  readUnpostedShipments,
+} from '../reads'
+import type { FulfillmentPostingExclusionReason, FulfillmentPostingPlan } from '../types'
+
+const ORG = 'abgwpa1l81reht2zmwrcihfu'
+
+/**
+ * A drizzle query-builder stub: every chained method returns itself, and the
+ * awaited form serves the next queued row set.
+ */
+function stubDb(): Database {
+  let index = 0
+  const chain = (): Record<string, unknown> => {
+    const self: Record<string, unknown> = {}
+    for (const method of ['from', 'where', 'limit', 'orderBy', 'innerJoin', 'leftJoin']) {
+      self[method] = () => self
+    }
+    // biome-ignore lint/suspicious/noThenProperty: chainable drizzle query-builder stub
+    self.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(h.selects[index++] ?? []).then(resolve, reject)
+    return self
+  }
+  return {
+    select: () => chain(),
+    execute: async (statement: unknown) => {
+      h.executed.push(statement)
+      return { rows: h.executeRows }
+    },
+  } as unknown as Database
+}
+
+/**
+ * Everything in a drizzle `sql` object that is a string: the raw SQL chunks and
+ * every bound parameter, flattened so a test can assert on both.
+ */
+function sqlText(node: unknown, depth = 0): string {
+  if (depth > 8 || node == null) return ''
+  if (typeof node === 'string') return node
+  if (typeof node === 'number' || typeof node === 'boolean') return String(node)
+  if (Array.isArray(node)) return node.map((item) => sqlText(item, depth + 1)).join(' ')
+  if (typeof node !== 'object') return ''
+  const record = node as Record<string, unknown>
+  if (Array.isArray(record.queryChunks)) return sqlText(record.queryChunks, depth + 1)
+  if ('value' in record) return sqlText(record.value, depth + 1)
+  if (typeof record.name === 'string') return record.name
+  return ''
+}
+
+/** One row of the netting statement, as the driver hands it back. */
+function entryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    order_id: 'ord_1',
+    sequence: 1,
+    shipped_at: '2026-07-06',
+    prior_subtotal_minor: 0,
+    shipping_recognised: false,
+    lines: [{ lineId: 'li_1', quantity: 2 }],
+    ...overrides,
+  }
+}
+
+/** One `FieldValue` row, in the columns the read selects. */
+function value(
+  entityId: string,
+  fieldId: string,
+  columns: Partial<{
+    valueText: string | null
+    valueNumber: number | null
+    optionId: string | null
+    relatedEntityId: string | null
+  }> = {}
+) {
+  return {
+    entityId,
+    fieldId,
+    valueText: null,
+    valueNumber: null,
+    optionId: null,
+    relatedEntityId: null,
+    sortKey: 0,
+    ...columns,
+  }
+}
+
+/** A whole order, plus one line, as `FieldValue` rows. */
+function orderValues() {
+  return [
+    value('ord_1', FIELD_IDS.order_number, { valueText: '#1001' }),
+    value('ord_1', FIELD_IDS.order_channel, { optionId: 'dtc' }),
+    value('ord_1', FIELD_IDS.order_currency, { valueText: 'USD' }),
+    value('ord_1', FIELD_IDS.order_financial_status, { optionId: 'paid' }),
+    value('ord_1', FIELD_IDS.order_payment_gateways, { optionId: 'opt_sp' }),
+    value('ord_1', FIELD_IDS.order_subtotal, { valueNumber: 19_999.999_999_999_996 }),
+    value('ord_1', FIELD_IDS.order_tax_total, { valueNumber: 800 }),
+    value('ord_1', FIELD_IDS.order_shipping_total, { valueNumber: 1_500 }),
+    value('ord_1', FIELD_IDS.order_contact, { relatedEntityId: 'ct_1' }),
+    value('li_1', FIELD_IDS.line_item_name, { valueText: 'Widget' }),
+    value('li_1', FIELD_IDS.line_item_qty, { valueNumber: 4 }),
+    value('li_1', FIELD_IDS.line_item_unit_price, { valueNumber: 5_000 }),
+  ]
+}
+
+beforeEach(() => {
+  h.settings = {
+    'accounting.cutoffPeriod': '2025-12',
+    'accounting.bookTimeZone': 'America/Los_Angeles',
+  }
+  h.lock = { lockedThroughMonth: null }
+  h.executed = []
+  h.executeRows = []
+  h.selects = []
+  h.contextMissing = false
+})
+
+describe('the netting statement', () => {
+  beforeEach(async () => {
+    h.executeRows = [entryRow()]
+    // The same rows answer BOTH bounded reads: they bucket on disjoint entity
+    // ids, so one array standing in for two queries cannot cross-contaminate.
+    h.selects = [orderValues(), orderValues()]
+    await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07-01', to: '2026-08-01' },
+    })
+  })
+
+  it('expands the shipment log out of the JSON cell', () => {
+    expect(sqlText(h.executed[0])).toContain('jsonb_array_elements')
+  })
+
+  it('left-joins the stamped posting to read its status', () => {
+    const text = sqlText(h.executed[0])
+    expect(text).toContain('LEFT JOIN')
+    expect(text).toContain("'reversed'")
+  })
+
+  // 🛑 The three ways a shipment is unposted, all in one predicate.
+  it('keeps a null stamp, a reversed posting and a stamp naming a posting that is gone', () => {
+    const text = sqlText(h.executed[0]).replace(/\s+/g, ' ')
+    // Three legs, in one OR, in this order: no stamp at all, a stamp naming a
+    // posting that is gone (the join found nothing), and a reversed posting.
+    // The column names render as empty here because a drizzle `sql` object
+    // carries them as objects rather than as text, so the assertion is on the
+    // predicate's shape.
+    const predicate = text.slice(text.indexOf('gl_posting_id IS NULL'))
+    expect(predicate).toContain("gl_posting_id IS NULL OR IS NULL OR = 'reversed'")
+  })
+
+  it('sums the subtotal of every EARLIER sequence of the same order', () => {
+    const text = sqlText(h.executed[0]).replace(/\s+/g, ' ')
+    expect(text).toContain('PARTITION BY expanded.order_id')
+    expect(text).toContain('ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING')
+  })
+
+  it('binds the half-open range and the organization', () => {
+    const text = sqlText(h.executed[0])
+    expect(text).toContain('2026-07-01')
+    expect(text).toContain('2026-08-01')
+    expect(text).toContain(ORG)
+  })
+
+  it('tolerates both spellings of the stored envelope', () => {
+    const text = sqlText(h.executed[0]).replace(/\s+/g, ' ')
+    expect(text).toContain("-> 'v' -> 'fulfillments'")
+    expect(text).toContain("-> 'fulfillments'")
+  })
+})
+
+describe('readUnpostedShipments', () => {
+  beforeEach(() => {
+    h.executeRows = [entryRow()]
+    h.selects = [orderValues(), orderValues()]
+  })
+
+  it('hangs the order and line facts on the shipment', async () => {
+    const result = await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07-01', to: '2026-08-01' },
+    })
+
+    expect(result._unsafeUnwrap()).toEqual([
+      {
+        orderId: 'ord_1',
+        orderNumber: '#1001',
+        sequence: 1,
+        shippedAt: '2026-07-06',
+        lines: [
+          {
+            lineId: 'li_1',
+            quantity: 2,
+            unitPriceMinor: 5_000,
+            lineTaxMinor: null,
+            orderedQuantity: 4,
+            name: 'Widget',
+          },
+        ],
+        channel: 'dtc',
+        currency: 'USD',
+        financialStatus: 'paid',
+        gateways: ['shopify_payments'],
+        // 🛑 Rounded, not refused: `FieldValue.valueNumber` is a double and
+        // 20_000 reads back as 19999.999999999996. Refusing here would take a
+        // 500-order run down for a rounding artefact.
+        orderSubtotalMinor: 20_000,
+        orderTaxTotalMinor: 800,
+        orderShippingTotalMinor: 1_500,
+        priorShipmentsSubtotalMinor: 0,
+        includeShipping: false,
+        contactId: 'ct_1',
+      },
+    ])
+  })
+
+  // 🛑 A TAGS value is an opaque option KEY, and the debit fork compares gateway
+  // NAMES. Reading `optionId` straight through would send every card order to
+  // `gateway-ambiguous` or worse, silently.
+  it('resolves a gateway option key back to its name', async () => {
+    const result = await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07-01', to: '2026-08-01' },
+    })
+
+    expect(result._unsafeUnwrap()[0]?.gateways).toEqual(['shopify_payments'])
+  })
+
+  it('falls back to the stored key when no option matches it', async () => {
+    h.selects = [
+      [...orderValues(), value('ord_1', FIELD_IDS.order_payment_gateways, { optionId: 'Affirm' })],
+      orderValues(),
+    ]
+
+    const result = await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07-01', to: '2026-08-01' },
+    })
+
+    expect(result._unsafeUnwrap()[0]?.gateways).toEqual(['shopify_payments', 'Affirm'])
+  })
+
+  // 🛑 Null is not zero (48 §8.2). A zero here would flip the whole entry onto
+  // the per-line tax basis and under-credit sales tax payable.
+  it('reads an absent line tax as null and a stored zero as zero', async () => {
+    const withTax = [
+      ...orderValues(),
+      value('li_1', FIELD_IDS.line_item_tax_total, { valueNumber: 0 }),
+    ]
+    h.selects = [withTax, withTax]
+
+    const result = await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07-01', to: '2026-08-01' },
+    })
+
+    expect(result._unsafeUnwrap()[0]?.lines[0]?.lineTaxMinor).toBe(0)
+  })
+
+  it('carries the prior-subtotal window and the shipping flag through', async () => {
+    h.executeRows = [
+      entryRow({ sequence: 2, prior_subtotal_minor: '10000', shipping_recognised: true }),
+    ]
+
+    const shipment = (
+      await readUnpostedShipments(stubDb(), {
+        organizationId: ORG,
+        range: { from: '2026-07-01', to: '2026-08-01' },
+      })
+    )._unsafeUnwrap()[0]
+
+    expect(shipment?.priorShipmentsSubtotalMinor).toBe(10_000)
+    expect(shipment?.includeShipping).toBe(true)
+  })
+
+  it('drops a shipment whose order fields cannot be read at all', async () => {
+    h.selects = [[], []]
+
+    const result = await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07-01', to: '2026-08-01' },
+    })
+
+    expect(result._unsafeUnwrap()).toEqual([])
+  })
+
+  it('reads no rows without touching the field reads', async () => {
+    h.executeRows = []
+
+    const result = await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07-01', to: '2026-08-01' },
+    })
+
+    expect(result._unsafeUnwrap()).toEqual([])
+  })
+
+  it('refuses a range bound that is not a calendar date', async () => {
+    const result = await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07', to: '2026-08-01' },
+    })
+
+    expect(result._unsafeUnwrapErr().message).toMatch(/YYYY-MM-DD/)
+  })
+})
+
+describe('countUnpostedShipments', () => {
+  it('reads through the SAME statement the list uses', async () => {
+    h.executeRows = []
+
+    const result = await countUnpostedShipments(stubDb(), { organizationId: ORG, month: '2026-07' })
+
+    expect(result._unsafeUnwrap()).toBe(0)
+    expect(sqlText(h.executed[0])).toContain('jsonb_array_elements')
+  })
+
+  it('turns a month into a half-open day range', async () => {
+    h.executeRows = []
+    await countUnpostedShipments(stubDb(), { organizationId: ORG, month: '2026-07' })
+
+    const text = sqlText(h.executed[0])
+    expect(text).toContain('2026-07-01')
+    expect(text).toContain('2026-08-01')
+  })
+
+  it('rolls December over into the next year', async () => {
+    h.executeRows = []
+    await countUnpostedShipments(stubDb(), { organizationId: ORG, month: '2026-12' })
+
+    const text = sqlText(h.executed[0])
+    expect(text).toContain('2026-12-01')
+    expect(text).toContain('2027-01-01')
+  })
+
+  it('refuses anything that is not a month', async () => {
+    const result = await countUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      month: '2026-07-06',
+    })
+
+    expect(result._unsafeUnwrapErr().message).toMatch(/YYYY-MM/)
+  })
+})
+
+describe('countCloseBlockingShipments', () => {
+  const exclusion = (reason: FulfillmentPostingExclusionReason) => ({
+    orderId: 'o',
+    orderNumber: '#1',
+    sequence: 1,
+    shippedAt: '2026-07-06',
+    reason,
+    detail: '',
+  })
+  const plan = (
+    shipments: number,
+    reasons: FulfillmentPostingExclusionReason[]
+  ): FulfillmentPostingPlan => ({
+    grouping: 'day',
+    groups: [],
+    exclusions: reasons.map(exclusion),
+    footer: { postings: 0, shipments, orders: 0, excluded: reasons.length, totalMinor: 0 },
+  })
+
+  it('counts what would post plus what a person still owes', () => {
+    expect(
+      countCloseBlockingShipments(
+        plan(2, ['foreign-currency', 'gateway-ambiguous', 'test-gateway'])
+      )
+    ).toBe(5)
+  })
+
+  it('lets a zero-value shipment and out-of-range months through', () => {
+    expect(
+      countCloseBlockingShipments(plan(0, ['zero-value', 'before-cutoff', 'locked-period']))
+    ).toBe(0)
+  })
+})
+
+describe('listOrderFulfillmentPostings', () => {
+  /** The stored log cell, then the `GlPosting` rows its stamps name. */
+  function stamps(log: unknown[], postings: unknown[]) {
+    h.selects = [[{ valueJson: { v: { fulfillments: log } } }], postings]
+  }
+
+  it('reports each stamp with the posting status as it stands NOW', async () => {
+    stamps(
+      [
+        { sequence: 1, shippedAt: '2026-07-06', glPostingId: 'gl_1', lines: [] },
+        { sequence: 2, shippedAt: '2026-07-09', glPostingId: 'gl_2', lines: [] },
+      ],
+      [
+        { id: 'gl_1', docNumber: 'AUXX-FUL-20260706', status: 'reversed' },
+        { id: 'gl_2', docNumber: 'AUXX-FUL-20260709', status: 'posted' },
+      ]
+    )
+
+    const result = await listOrderFulfillmentPostings(stubDb(), {
+      organizationId: ORG,
+      orderId: 'ord_1',
+    })
+
+    expect(result._unsafeUnwrap()).toEqual([
+      {
+        sequence: 1,
+        shippedAt: '2026-07-06',
+        glPostingId: 'gl_1',
+        docNumber: 'AUXX-FUL-20260706',
+        status: 'reversed',
+      },
+      {
+        sequence: 2,
+        shippedAt: '2026-07-09',
+        glPostingId: 'gl_2',
+        docNumber: 'AUXX-FUL-20260709',
+        status: 'posted',
+      },
+    ])
+  })
+
+  it('ignores an unstamped shipment', async () => {
+    stamps([{ sequence: 1, shippedAt: '2026-07-06', glPostingId: null, lines: [] }], [])
+
+    expect(
+      (
+        await listOrderFulfillmentPostings(stubDb(), { organizationId: ORG, orderId: 'ord_1' })
+      )._unsafeUnwrap()
+    ).toEqual([])
+  })
+
+  it('drops a stamp naming a posting that no longer exists', async () => {
+    stamps([{ sequence: 1, shippedAt: '2026-07-06', glPostingId: 'gl_gone', lines: [] }], [])
+
+    expect(
+      (
+        await listOrderFulfillmentPostings(stubDb(), { organizationId: ORG, orderId: 'ord_1' })
+      )._unsafeUnwrap()
+    ).toEqual([])
+  })
+
+  it('returns nothing for an order with no log at all', async () => {
+    h.selects = [[], []]
+
+    expect(
+      (
+        await listOrderFulfillmentPostings(stubDb(), { organizationId: ORG, orderId: 'ord_1' })
+      )._unsafeUnwrap()
+    ).toEqual([])
+  })
+})
+
+describe('readFulfillmentPostingSettings', () => {
+  it('reads the cutoff, the lock, the zone and the ledger currency', async () => {
+    h.lock = { lockedThroughMonth: '2026-06' }
+
+    const result = await readFulfillmentPostingSettings(stubDb(), ORG)
+
+    expect(result._unsafeUnwrap()).toEqual({
+      cutoffPeriod: '2025-12',
+      lockedThroughMonth: '2026-06',
+      timeZone: 'America/Los_Angeles',
+      ledgerCurrency: 'USD',
+    })
+  })
+
+  // 🛑 Null, never a `'UTC'` default: the run refuses on an unset zone rather
+  // than dating revenue into the wrong month invisibly (44 lane 4).
+  it('reports an unset or blank book time zone as null', async () => {
+    h.settings = { 'accounting.bookTimeZone': '   ' }
+
+    expect((await readFulfillmentPostingSettings(stubDb(), ORG))._unsafeUnwrap()).toMatchObject({
+      cutoffPeriod: null,
+      timeZone: null,
+    })
+  })
+})

--- a/packages/lib/src/money/fulfillment-posting/__tests__/run.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/run.test.ts
@@ -1,0 +1,481 @@
+// packages/lib/src/money/fulfillment-posting/__tests__/run.test.ts
+//
+// The three properties the run exists to hold:
+//
+//  1. **The attempt counter.** A day key claims the day once, and a late order
+//     backfilled into an already-posted day - or a day that was reversed and is
+//     coming back - has to claim the NEXT key. Getting this wrong converges on
+//     `already_posted`, which is a SUCCESS status, so the shipments would
+//     silently recognise nothing.
+//  2. **`already_posted` is a SKIP that stamps nothing.** Stamping this group's
+//     shipments onto an entry this run did not make would attach them to
+//     somebody else's numbers.
+//  3. **Never throws, three layers deep**, and a group that posted but could
+//     not stamp is reported in BOTH `posted` and `failed`.
+//
+// `plan.ts` and lane A's pure builders run FOR REAL; only the database, the
+// poster and the stamp are doubles.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UnpostedShipment } from '../types'
+
+const h = vi.hoisted(() => ({
+  settings: {} as Record<string, unknown>,
+  shipments: [] as unknown[],
+  shipmentsError: null as Error | null,
+  /** `GlPosting` rows the attempt counter finds, per call. */
+  livePostings: [] as unknown[][],
+  post: { status: 'posted', glPostingId: 'gl_1', docNumber: 'AUXX-FUL-20260706' } as {
+    status: string
+    glPostingId?: string
+    docNumber?: string
+    error?: string
+  },
+  postCalls: [] as Array<{ periodKey: string; txnDate: string; memo?: string }>,
+  stamps: [] as Array<{
+    orderId: string
+    sequence: number
+    actorUserId: string
+    patch: Record<string, unknown>
+  }>,
+  stampThrowsFor: null as string | null,
+  systemUserId: 'usr_system',
+}))
+
+vi.mock('../reads', async () => {
+  const { ok, err } = await import('neverthrow')
+  return {
+    readUnpostedShipments: async () => (h.shipmentsError ? err(h.shipmentsError) : ok(h.shipments)),
+    readFulfillmentPostingSettings: async () =>
+      ok({
+        cutoffPeriod: (h.settings['accounting.cutoffPeriod'] as string | null) ?? null,
+        lockedThroughMonth: null,
+        timeZone: (h.settings['accounting.bookTimeZone'] as string | null) ?? null,
+        ledgerCurrency: 'USD',
+      }),
+  }
+})
+
+vi.mock('../../../settings/settings-service', () => ({
+  getOrganizationSetting: async ({ key }: { key: string }) => h.settings[key] ?? null,
+}))
+
+vi.mock('../../../postings/period-lock', () => ({
+  resolvePeriodLock: async () => ({ lockedThroughMonth: null }),
+}))
+
+vi.mock('../../../postings/post-entry', () => ({
+  LEDGER_CURRENCY: 'USD',
+  postEntry: async (
+    _db: unknown,
+    options: { entry: { periodKey: string; txnDate: string }; memo?: string }
+  ) => {
+    h.postCalls.push({
+      periodKey: options.entry.periodKey,
+      txnDate: options.entry.txnDate,
+      memo: options.memo,
+    })
+    return h.post
+  },
+}))
+
+vi.mock('../../orders/fulfill', () => ({
+  stampFulfillment: async (
+    _db: unknown,
+    params: {
+      orderId: string
+      sequence: number
+      actorUserId: string
+      patch: Record<string, unknown>
+    }
+  ) => {
+    if (h.stampThrowsFor === params.orderId) throw new Error('could not lock the order row')
+    h.stamps.push({
+      orderId: params.orderId,
+      sequence: params.sequence,
+      actorUserId: params.actorUserId,
+      patch: params.patch,
+    })
+  },
+}))
+
+vi.mock('../../../cache', () => ({
+  getOrgCache: () => ({ get: async () => h.systemUserId }),
+}))
+
+import type { Database } from '@auxx/database'
+import { previewFulfillmentPosting, runFulfillmentPosting } from '../run'
+
+const ORG = 'abgwpa1l81reht2zmwrcihfu'
+
+function shipment(overrides: Partial<UnpostedShipment> = {}): UnpostedShipment {
+  const orderId = overrides.orderId ?? 'ord_1'
+  return {
+    orderId,
+    orderNumber: overrides.orderNumber ?? '#1001',
+    sequence: 1,
+    shippedAt: '2026-07-06',
+    lines: [
+      {
+        lineId: `${orderId}_l1`,
+        quantity: 1,
+        unitPriceMinor: 10_000,
+        lineTaxMinor: null,
+        orderedQuantity: 1,
+      },
+    ],
+    channel: 'dtc',
+    currency: 'USD',
+    financialStatus: 'paid',
+    gateways: ['shopify_payments'],
+    orderSubtotalMinor: 10_000,
+    orderTaxTotalMinor: 0,
+    orderShippingTotalMinor: 0,
+    priorShipmentsSubtotalMinor: 0,
+    includeShipping: false,
+    contactId: null,
+    ...overrides,
+  }
+}
+
+/** `db.select(...).from(...).where(...)` awaited: the attempt counter's read. */
+function stubDb(): Database {
+  let index = 0
+  const chain = (): Record<string, unknown> => {
+    const self: Record<string, unknown> = {}
+    for (const method of ['from', 'where']) self[method] = () => self
+    // biome-ignore lint/suspicious/noThenProperty: chainable drizzle query-builder stub
+    self.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(h.livePostings[index++] ?? []).then(resolve, reject)
+    return self
+  }
+  return { select: () => chain() } as unknown as Database
+}
+
+const REQUEST = {
+  organizationId: ORG,
+  actorUserId: 'usr_1',
+  range: { from: '2026-07-01', to: '2026-08-01' },
+  grouping: 'day',
+} as const
+
+beforeEach(() => {
+  h.settings = {
+    'accounting.setupState': 'finalized',
+    'accounting.bookTimeZone': 'America/Los_Angeles',
+    'accounting.cutoffPeriod': null,
+  }
+  h.shipments = [shipment()]
+  h.shipmentsError = null
+  h.livePostings = []
+  h.post = { status: 'posted', glPostingId: 'gl_1', docNumber: 'AUXX-FUL-20260706' }
+  h.postCalls = []
+  h.stamps = []
+  h.stampThrowsFor = null
+})
+
+describe('the refusals', () => {
+  it('refuses a run whose organization has not finalized accounting setup', async () => {
+    h.settings['accounting.setupState'] = 'draft'
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.posted).toEqual([])
+    expect(summary.skipped[0]?.status).toBe('refused')
+    expect(summary.skipped[0]?.reason).toMatch(/not finalized/)
+    expect(h.postCalls).toEqual([])
+  })
+
+  it('refuses a run with no book time zone', async () => {
+    h.settings['accounting.bookTimeZone'] = null
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.skipped[0]?.reason).toMatch(/book time zone/)
+    expect(h.postCalls).toEqual([])
+  })
+
+  it('names setup before the time zone, because an unfinished setup has no zone', async () => {
+    h.settings['accounting.setupState'] = 'draft'
+    h.settings['accounting.bookTimeZone'] = null
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.skipped[0]?.reason).toMatch(/not finalized/)
+  })
+
+  // ⚠️ The preview still shows the backlog. A person whose time zone is unset
+  // needs to see how much is waiting on the settings row they are being told to
+  // fix.
+  it('previews the plan alongside the refusal rather than hiding it', async () => {
+    h.settings['accounting.bookTimeZone'] = null
+
+    const preview = (await previewFulfillmentPosting(stubDb(), REQUEST))._unsafeUnwrap()
+
+    expect(preview.refusal).toMatch(/book time zone/)
+    expect(preview.plan.groups).toHaveLength(1)
+    expect(preview.plan.footer.totalMinor).toBe(10_000)
+  })
+
+  it('reports no refusal on a healthy organization', async () => {
+    const preview = (await previewFulfillmentPosting(stubDb(), REQUEST))._unsafeUnwrap()
+
+    expect(preview.refusal).toBeNull()
+    expect(preview.plan.groups).toHaveLength(1)
+  })
+
+  it('surfaces a failed shipment read as an Err from the preview', async () => {
+    h.shipmentsError = new Error('the ledger is unreachable')
+
+    const preview = await previewFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(preview.isErr()).toBe(true)
+  })
+})
+
+describe('the attempt counter', () => {
+  it('claims the bare group key when nothing live holds it', async () => {
+    h.livePostings = [[]]
+
+    await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(h.postCalls[0]?.periodKey).toBe('2026-07-06')
+  })
+
+  // 🛑 §8.2: the late order backfilled into an already-posted day.
+  it('appends an attempt character when one live posting already holds the day', async () => {
+    h.livePostings = [[{ id: 'gl_old' }]]
+
+    await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(h.postCalls[0]?.periodKey).toBe('2026-07-061')
+  })
+
+  // 🛑 Decision 9: a reversed day comes back on the next preview, and its
+  // reversal is an ordinary `posted` entry at the same key. Counting it is what
+  // stops the re-run colliding with the reversed original's tuple.
+  it('counts a reversal, so a reversed day re-posts under the next attempt', async () => {
+    h.livePostings = [[{ id: 'gl_reversal' }]]
+
+    await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(h.postCalls[0]?.periodKey).toBe('2026-07-061')
+  })
+
+  it('counts per group, so two days do not share an attempt', async () => {
+    h.shipments = [
+      shipment({ orderId: 'a', orderNumber: '#1', shippedAt: '2026-07-06' }),
+      shipment({ orderId: 'b', orderNumber: '#2', shippedAt: '2026-07-07' }),
+    ]
+    h.livePostings = [[{ id: 'gl_old' }], []]
+
+    await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(h.postCalls.map((call) => call.periodKey)).toEqual(['2026-07-061', '2026-07-07'])
+  })
+})
+
+describe('posting and stamping', () => {
+  it('posts one entry per group, dated to the latest ship date in it', async () => {
+    h.shipments = [
+      shipment({ orderId: 'a', orderNumber: '#1', shippedAt: '2026-07-06' }),
+      shipment({ orderId: 'b', orderNumber: '#2', shippedAt: '2026-07-31' }),
+    ]
+
+    const summary = await runFulfillmentPosting(stubDb(), {
+      ...REQUEST,
+      grouping: 'month',
+    })
+
+    expect(h.postCalls).toHaveLength(1)
+    expect(h.postCalls[0]?.txnDate).toBe('2026-07-31')
+    expect(summary.posted).toEqual([
+      {
+        groupKey: '2026-07',
+        postingId: 'gl_1',
+        docNumber: 'AUXX-FUL-20260706',
+        shipments: 2,
+      },
+    ])
+  })
+
+  it('stamps every shipment of the group with the posting and its own amounts', async () => {
+    h.shipments = [
+      shipment({ orderId: 'a', orderNumber: '#1', sequence: 1 }),
+      shipment({ orderId: 'b', orderNumber: '#2', sequence: 4 }),
+    ]
+
+    await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(h.stamps).toEqual([
+      {
+        orderId: 'a',
+        sequence: 1,
+        actorUserId: 'usr_1',
+        patch: {
+          glPostingId: 'gl_1',
+          docNumber: 'AUXX-FUL-20260706',
+          totalMinor: 10_000,
+          subtotalMinor: 10_000,
+        },
+      },
+      {
+        orderId: 'b',
+        sequence: 4,
+        actorUserId: 'usr_1',
+        patch: {
+          glPostingId: 'gl_1',
+          docNumber: 'AUXX-FUL-20260706',
+          totalMinor: 10_000,
+          subtotalMinor: 10_000,
+        },
+      },
+    ])
+  })
+
+  it('carries the run memo onto the entry', async () => {
+    await runFulfillmentPosting(stubDb(), { ...REQUEST, memo: 'July catch-up' })
+
+    expect(h.postCalls[0]?.memo).toBe('July catch-up')
+  })
+
+  it.each([
+    'healed',
+    'not_connected',
+    'disabled',
+  ])('treats %s as posted, because the ledger holds the row', async (status) => {
+    h.post = { status, glPostingId: 'gl_1', docNumber: 'AUXX-FUL-20260706' }
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.posted).toHaveLength(1)
+    expect(h.stamps).toHaveLength(1)
+  })
+
+  it('reports the exclusions the plan made', async () => {
+    h.shipments = [shipment({ currency: 'CAD' })]
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.posted).toEqual([])
+    expect(summary.exclusions).toEqual([
+      expect.objectContaining({ reason: 'foreign-currency', detail: 'CAD' }),
+    ])
+  })
+
+  it('does nothing at all for an empty range', async () => {
+    h.shipments = []
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary).toEqual({ posted: [], skipped: [], failed: [], exclusions: [] })
+    expect(h.postCalls).toEqual([])
+  })
+})
+
+describe('already_posted is a skip that stamps nothing', () => {
+  it('skips the group and writes no stamp', async () => {
+    h.post = { status: 'already_posted', glPostingId: 'gl_other', docNumber: 'AUXX-FUL-X' }
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.posted).toEqual([])
+    expect(h.stamps).toEqual([])
+    expect(summary.skipped[0]).toMatchObject({ groupKey: '2026-07-06', status: 'already_posted' })
+    expect(summary.skipped[0]?.reason).toMatch(/already claimed/)
+  })
+
+  it('keeps running the rest of the groups', async () => {
+    h.shipments = [
+      shipment({ orderId: 'a', orderNumber: '#1', shippedAt: '2026-07-06' }),
+      shipment({ orderId: 'b', orderNumber: '#2', shippedAt: '2026-07-07' }),
+    ]
+    h.post = { status: 'already_posted', docNumber: 'AUXX-FUL-X' }
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.skipped.map((row) => row.groupKey)).toEqual(['2026-07-06', '2026-07-07'])
+    expect(summary.failed).toEqual([])
+    expect(h.stamps).toEqual([])
+  })
+})
+
+describe('a ledger refusal is a skip, not a failure', () => {
+  it('records a closed period without stamping anything', async () => {
+    h.post = { status: 'period_closed', error: 'July is closed.' }
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.posted).toEqual([])
+    expect(summary.failed).toEqual([])
+    expect(summary.skipped).toEqual([
+      { groupKey: '2026-07-06', status: 'period_closed', reason: 'July is closed.' },
+    ])
+    expect(h.stamps).toEqual([])
+  })
+
+  it('records an accepted status that named no posting rather than stamping null', async () => {
+    h.post = { status: 'posted', docNumber: 'AUXX-FUL-20260706' }
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.posted).toEqual([])
+    expect(summary.skipped[0]?.reason).toMatch(/named no posting/)
+    expect(h.stamps).toEqual([])
+  })
+})
+
+describe('never throws, three layers deep', () => {
+  it('records a group whose build threw and continues with the next', async () => {
+    h.shipments = [
+      shipment({ orderId: 'a', orderNumber: '#1', shippedAt: '2026-07-06' }),
+      shipment({ orderId: 'b', orderNumber: '#2', shippedAt: '2026-07-07' }),
+    ]
+    // A day that has already burned every attempt character the document-number
+    // keyspace holds: the builder refuses rather than minting a key that could
+    // not be reversed.
+    h.livePostings = [Array.from({ length: 36 }, (_, i) => ({ id: `gl_${i}` })), []]
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.failed).toHaveLength(1)
+    expect(summary.failed[0]?.groupKey).toBe('2026-07-06')
+    expect(summary.posted.map((row) => row.groupKey)).toEqual(['2026-07-07'])
+  })
+
+  // 🛑 The one outcome that needs a person: the entry is in the books and the
+  // shipment is not stamped, so the netting read will offer it again.
+  it('reports a posted group whose stamp failed in BOTH posted and failed', async () => {
+    h.shipments = [
+      shipment({ orderId: 'a', orderNumber: '#1' }),
+      shipment({ orderId: 'b', orderNumber: '#2' }),
+    ]
+    h.stampThrowsFor = 'a'
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.posted).toHaveLength(1)
+    // The other shipment was still stamped: one order's lock contention must
+    // not lose the rest of the group.
+    expect(h.stamps.map((stamp) => stamp.orderId)).toEqual(['b'])
+    expect(summary.failed[0]?.reason).toMatch(/#1 shipment 1/)
+    expect(summary.failed[0]?.reason).toMatch(/must NOT be posted a second time/)
+  })
+
+  it('returns a summary rather than throwing when the read fails', async () => {
+    h.shipmentsError = new Error('the ledger is unreachable')
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary.posted).toEqual([])
+    expect(summary.failed[0]?.reason).toMatch(/unreachable/)
+  })
+})
+
+describe('the unattended lane', () => {
+  it('writes as the system user of the organization when nobody pressed a button', async () => {
+    await runFulfillmentPosting(stubDb(), { ...REQUEST, actorUserId: null })
+
+    expect(h.stamps.map((stamp) => stamp.actorUserId)).toEqual(['usr_system'])
+  })
+})

--- a/packages/lib/src/money/fulfillment-posting/auto.ts
+++ b/packages/lib/src/money/fulfillment-posting/auto.ts
@@ -1,0 +1,102 @@
+// packages/lib/src/money/fulfillment-posting/auto.ts
+//
+// The `auto` lane: after a connector sync has written shipment log entries, put
+// one job on the queue that posts them (49 §2.4, §8.4 decision 1).
+//
+// This file is deliberately the whole of the automatic side. It reads ONE
+// setting and enqueues ONE job, and everything that decides what actually gets
+// posted - the range, the grouping, the cutoff, the locked period, the debit
+// fork, the exclusions - lives in `plan.ts` and `run.ts`, where the manual
+// dialog reaches it too. `auto` and `manual` are therefore the same run with a
+// different trigger, which is the only way the preview a person reviews can be
+// trusted to describe what the automatic lane does.
+//
+// 🛑 NEVER THROWS. Its one caller is the finalize integrity pass at the end of a
+// connector sync (49 build contract, lane C pass 7). A throw there aborts the
+// pass chain and, with it, the sync's own bookkeeping - to skip a posting that
+// the very next sync, or the dialog, would pick up anyway. There is nothing
+// here worth failing a sync for.
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getQueue, Queues } from '../../jobs/queues'
+import { getOrganizationSetting } from '../../settings/settings-service'
+import { FULFILLMENT_POSTING_SETTING_KEY } from './types'
+
+const logger = createScopedLogger('money:fulfillment-posting:auto')
+
+/**
+ * The BullMQ job name the worker maps to the runner.
+ *
+ * Declared here, beside the only enqueue, and imported by the worker's job map
+ * rather than retyped there - the `MAIL_CLASSIFICATION_JOB_NAME` shape. Two
+ * copies of a job name fail at runtime with "Job function not found", which is
+ * a log line in a worker rather than a red test.
+ */
+export const FULFILLMENT_POSTING_JOB_NAME = 'postFulfillments'
+
+/**
+ * The job id every enqueue for one organization uses.
+ *
+ * ⚠️ Hyphens, never colons. BullMQ rejects a custom `jobId` containing `:`
+ * unless it splits into exactly three parts, so a two-part
+ * `fulfillment-posting:<org>` throws `Custom Id cannot contain :` on every
+ * enqueue - swallowed by the catch below, which is the worst possible place to
+ * learn about it. The `qb-invoice-sync-<id>` precedent in
+ * `sequences/field-change-hooks.ts` was written after exactly that.
+ */
+export function fulfillmentPostingJobId(organizationId: string): string {
+  return `fulfillment-posting-${organizationId}`
+}
+
+/**
+ * Enqueue a fulfillment posting run for one organization, if it asked for one.
+ *
+ * Called at the end of a connector sync, after the shipment log has been
+ * written. Does nothing at all when `accounting.fulfillmentPosting` is `manual`,
+ * which is the default: the dialog's preview is the review step, and a mode that
+ * posted anyway would make the setting a lie.
+ *
+ * 🛑 The per-organization `jobId` is the point, not an optimisation. A sync can
+ * finish several times in a minute (a webhook burst, a retried poll, a person
+ * pressing Sync), and each finish would otherwise queue a full run over the same
+ * backlog. BullMQ refuses a duplicate `jobId` while a job with that id is still
+ * queued, so the second, third and fourth finishes collapse into the one run
+ * that has not started yet - which is exactly right, because the run reads the
+ * backlog when it starts rather than when it was queued. Once a run HAS started
+ * the id is free again, so a sync that lands mid-run still gets its own pass.
+ *
+ * ⚠️ Call this after the sync's writes have committed. The job resolves the
+ * backlog on its own connection and cannot see uncommitted rows, so an enqueue
+ * from inside the writing transaction can produce a run that finds nothing.
+ *
+ * **Never throws.** A failure to read the setting or reach Redis is logged and
+ * swallowed; the next sync, or the dialog, posts the same backlog.
+ *
+ * @param db The database handle the caller is already using.
+ * @param organizationId The organization whose backlog to post.
+ */
+export async function autoPostFulfillmentsAfterSync(
+  db: Database,
+  organizationId: string
+): Promise<void> {
+  try {
+    const mode = await getOrganizationSetting({
+      organizationId,
+      key: FULFILLMENT_POSTING_SETTING_KEY,
+      db,
+    })
+    if (mode !== 'auto') return
+
+    await getQueue(Queues.fulfillmentPostingQueue).add(
+      FULFILLMENT_POSTING_JOB_NAME,
+      { organizationId },
+      { jobId: fulfillmentPostingJobId(organizationId) }
+    )
+  } catch (error) {
+    logger.error('Failed to enqueue the automatic fulfillment posting run', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/money/fulfillment-posting/client.ts
+++ b/packages/lib/src/money/fulfillment-posting/client.ts
@@ -1,0 +1,39 @@
+// packages/lib/src/money/fulfillment-posting/client.ts
+
+/**
+ * The client-safe half of the bulk fulfillment poster: types and constants
+ * only.
+ *
+ * Everything here is a re-export of `types.ts`, which already imports nothing.
+ * The file exists so a browser has ONE import path to reach the vocabulary the
+ * dialog renders - the reason `docs/lib-module-guide.md` §7 gives - and so the
+ * server barrel (`index.ts`) is the only thing that ever pulls `reads.ts` and
+ * `run.ts`, which reach `@auxx/database`, `bullmq` and friends.
+ *
+ * Deliberately NO `'use client'` directive: server code imports this file too,
+ * and the directive would turn every export into a client-reference proxy
+ * there. `money/orders/client.ts` carries the same warning for the same reason.
+ */
+
+export {
+  FULFILLMENT_BATCH_SOURCE_TYPE,
+  FULFILLMENT_POSTING_EXCLUSION_REASONS,
+  FULFILLMENT_POSTING_GROUPINGS,
+  FULFILLMENT_POSTING_MODES,
+  FULFILLMENT_POSTING_SETTING_KEY,
+  type FulfillmentDebitRole,
+  type FulfillmentPostingExclusion,
+  type FulfillmentPostingExclusionReason,
+  type FulfillmentPostingGroup,
+  type FulfillmentPostingGrouping,
+  type FulfillmentPostingMode,
+  type FulfillmentPostingPlan,
+  type FulfillmentPostingPlanInput,
+  type FulfillmentPostingRequest,
+  type FulfillmentPostingRunSummary,
+  type OrderFulfillmentPostingRef,
+  type PlannedShipment,
+  type ShipmentAmounts,
+  type UnpostedShipment,
+  type UnpostedShipmentLine,
+} from './types'

--- a/packages/lib/src/money/fulfillment-posting/derive-log.ts
+++ b/packages/lib/src/money/fulfillment-posting/derive-log.ts
@@ -1,0 +1,362 @@
+// packages/lib/src/money/fulfillment-posting/derive-log.ts
+
+/**
+ * Reconstructing `order_fulfillments` from the sales channel's per-line
+ * fulfillment facts.
+ *
+ * `plans/money/tasks/49-bulk-fulfillment-posting.md` §2.1, §5, §8.1 item 4,
+ * §8.4 decision 4.
+ *
+ * PURE. No database, no clock, no settings - `now` and `timeZone` are handed in,
+ * the way `plan.ts` takes its cutoff rather than reading it. That is the whole
+ * point of the split: the decision "which lines went out together, and on what
+ * day" is the one that has to be testable against the 82 split-shipment orders
+ * measured on the dev org without a fixture, a connection or a system clock.
+ *
+ * Client-safe: types and pure arithmetic only.
+ *
+ * ## Why this exists at all
+ *
+ * The one door into the ledger (`money.fulfillOrder`) is a click per order, and
+ * it is CLOSED for an imported order: the connector binds Shopify's
+ * `fulfillmentStatus` straight onto `order_fulfillment_status`, and the Fulfill
+ * button hides once that reads `fulfilled` (49 §1.2). 530 of the dev org's 545
+ * orders arrived that way. Every one of them shipped, and the ledger has never
+ * heard of it.
+ *
+ * Shopify already knows what went out when: it projects a per-line fulfilled
+ * date, fulfilled quantity and shipment count on every order sync. Entity
+ * migration 137 carries those three NATIVELY (`line_item_fulfilled_at`,
+ * `line_item_fulfilled_qty`, `line_item_shipment_count`), which is what lets
+ * this function know nothing about Shopify at all.
+ *
+ * ## The reconstruction rule, and why it is sound here
+ *
+ * A line that carries a fulfilled date and a fulfilled quantity above zero
+ * shipped ONCE, on the calendar day of that date in the book time zone. Lines
+ * sharing a day are one shipment.
+ *
+ * ✅ Measured (49 §5), org `abgwpa1l81reht2zmwrcihfu`: 82 of 538 imported orders
+ * ship in two shipments, every one of them exactly two, **no line spans two
+ * shipments**, every line carries a fulfilled date, and all 82 reconstruct by
+ * grouping lines on it. The brief's original plan - hold every split shipment
+ * out until per-line data exists - was written before that measurement and is
+ * unnecessary (§8.1 item 4).
+ *
+ * 🛑 The one shape that does NOT reconstruct is a single line that went out in
+ * more than one shipment: `shipmentCount > 1` says the line shipped twice and
+ * the single `fulfilledAt` cannot say which units went when. Splitting it by
+ * guess would date revenue wrongly, and a wrongly dated posting in a closed
+ * month cannot be corrected. So the WHOLE order is held out, `heldOut` names
+ * the line, and nothing is written.
+ */
+
+import { extendRateToAmount } from '../../postings/build-fulfillment-entry'
+import { periodKeyForDate } from '../../postings/periods'
+import type { OrderFulfillment, OrderFulfillmentLine } from '../orders/client'
+
+/**
+ * One order line, with the three channel-supplied fulfillment facts beside the
+ * two numbers the shipment's amounts are computed from.
+ *
+ * `fulfilledAt`, `fulfilledQuantity` and `shipmentCount` are each nullable and
+ * null means **not supplied**, never zero and never one (49 §8.2's rule, the
+ * same one `line_item_tax_total` carries). A line the channel said nothing about
+ * did not ship as far as this function is concerned.
+ */
+export interface DerivedLineFact {
+  /** The `line_item` EntityInstance id. */
+  lineId: string
+  /** `line_item_qty`. What the tax scale is a fraction OF. */
+  orderedQuantity: number
+  /** `line_item_unit_price`, minor units per unit. A RATE, so possibly fractional. */
+  unitPriceMinor: number
+  /** `line_item_tax_total`, integer minor units for the WHOLE line, or null when not supplied. */
+  lineTaxMinor: number | null
+  /** `line_item_fulfilled_at`, an ISO instant, or null. */
+  fulfilledAt: string | null
+  /** `line_item_fulfilled_qty`. Null when not supplied; 0 means nothing shipped. */
+  fulfilledQuantity: number | null
+  /** `line_item_shipment_count`. Above 1 holds the whole order out. */
+  shipmentCount: number | null
+}
+
+export interface DeriveFulfillmentLogInput {
+  /** The order's stored log, as `parseFulfillments` returns it. */
+  existing: OrderFulfillment[]
+  lines: DerivedLineFact[]
+  /** `order_shipping_total`, integer minor units. Recognised in full, once. */
+  orderShippingTotalMinor: number
+  /** `accounting.bookTimeZone`. The day boundary is cut in it, never in UTC. */
+  timeZone: string
+  /** ISO instant, for `recordedAt` on the rows this derives. */
+  now: string
+}
+
+export interface DeriveFulfillmentLogResult {
+  /** The log as it should be stored. Equal to `existing` when nothing moved. */
+  fulfillments: OrderFulfillment[]
+  /** Whether {@link DeriveFulfillmentLogResult.fulfillments} differs from `existing`. */
+  changed: boolean
+  /** The `lineId` whose `shipmentCount > 1` held the whole order out, or null. */
+  heldOut: string | null
+}
+
+/** One derived shipment before it is merged against what is already stored. */
+interface DerivedShipment {
+  /** `YYYY-MM-DD` in the book time zone. */
+  shippedAt: string
+  lines: OrderFulfillmentLine[]
+  subtotalMinor: number
+  /** Σ the lines' scaled `lineTaxMinor`. A null line tax contributes zero. */
+  taxMinor: number
+}
+
+/**
+ * Derive the shipment log an order's channel-supplied line facts imply, merged
+ * against what the order already stores.
+ *
+ * ## The merge is append-only, and that is the safety property
+ *
+ * The stored log is what the ledger was posted from: every entry can carry a
+ * `glPostingId`, and lane B's run stamps by `(orderId, sequence)`. So this
+ * function may never renumber, reorder or discard a stored entry. Four cases,
+ * matched by ship day (49 §2.6 rule 2):
+ *
+ *  - an existing entry whose day and lines match a derived one is kept
+ *    **verbatim**, stamp included - re-deriving must be a no-op, or every sync
+ *    would rewrite the log and `changed` would never be false,
+ *  - an existing **stamped** entry that differs is kept and the derived one
+ *    **dropped**. The ledger and the channel disagree about a shipment that has
+ *    already been posted; that is a person's call, not a sync's, and silently
+ *    rewriting the row would leave a posted entry describing a shipment nobody
+ *    can reconstruct,
+ *  - an existing **unstamped** entry that differs is replaced, keeping its
+ *    sequence. Nothing was posted from it, so the channel is simply more
+ *    current,
+ *  - a derived shipment with no existing counterpart is appended.
+ *
+ * An existing entry on a day the channel no longer reports is kept untouched.
+ * A log only ever grows.
+ *
+ * ## Shipping is recognised once, on the first shipment that has it to recognise
+ *
+ * `orderShippingTotalMinor` rides the earliest shipment and nothing else. When a
+ * surviving stored entry already carries `shippingRecognised`, no derived entry
+ * takes it - which is what stops a re-derivation from recognising the same
+ * freight revenue twice.
+ */
+export function deriveFulfillmentLog(input: DeriveFulfillmentLogInput): DeriveFulfillmentLogResult {
+  const { existing, lines, orderShippingTotalMinor, timeZone, now } = input
+
+  // 🛑 The hold-out is checked over EVERY line before anything is built, and it
+  // holds the whole order out rather than the one line: a shipment log missing
+  // one line of an order would post that order's revenue short and read as
+  // complete, which is worse than posting nothing.
+  const split = lines.find((line) => line.shipmentCount !== null && line.shipmentCount > 1)
+  if (split) {
+    return { fulfillments: existing, changed: false, heldOut: split.lineId }
+  }
+
+  const derived = buildDerivedShipments(lines, timeZone)
+  if (derived.length === 0) {
+    return { fulfillments: existing, changed: false, heldOut: null }
+  }
+
+  // ── Match each derived shipment against a stored entry, by ship day ──
+  //
+  // Greedy and first-unmatched-wins: two stored entries can share a day (a
+  // partial shipment recorded by hand, then the channel's), and pairing each
+  // derived shipment with a day at most once is what keeps the merge total.
+  const claimed = new Set<number>()
+  type Decision =
+    | { kind: 'verbatim'; index: number }
+    | { kind: 'dropped' }
+    | { kind: 'replace'; index: number; shipment: DerivedShipment }
+    | { kind: 'append'; shipment: DerivedShipment }
+
+  const decisions: Decision[] = []
+  for (const shipment of derived) {
+    const index = existing.findIndex(
+      (row, i) => !claimed.has(i) && row.shippedAt === shipment.shippedAt
+    )
+    if (index < 0) {
+      decisions.push({ kind: 'append', shipment })
+      continue
+    }
+    claimed.add(index)
+    const stored = existing[index]!
+    if (linesMatch(stored.lines, shipment.lines)) {
+      decisions.push({ kind: 'verbatim', index })
+    } else if (stored.glPostingId !== null) {
+      decisions.push({ kind: 'dropped' })
+    } else {
+      decisions.push({ kind: 'replace', index, shipment })
+    }
+  }
+
+  const replaced = new Set(
+    decisions.flatMap((decision) => (decision.kind === 'replace' ? [decision.index] : []))
+  )
+
+  // Only the rows that SURVIVE can hold the shipping flag: a replaced row's
+  // flag goes with it, and the replacement takes the freight back.
+  const shippingOwed = !existing.some((row, i) => !replaced.has(i) && row.shippingRecognised)
+
+  // ── Emit ──
+  //
+  // Stored rows keep their position and their sequence; derived rows that are
+  // new are appended after them. A fresh order (nothing stored) therefore gets
+  // sequences 1..n in ship-day order, which is what the contract asks for, and
+  // an order that already carries entries never sees one renumbered.
+  let nextSequence = existing.reduce((max, row) => Math.max(max, row.sequence), 0) + 1
+  const merged: OrderFulfillment[] = [...existing]
+  let shippingTaken = !shippingOwed
+
+  for (const decision of decisions) {
+    if (decision.kind === 'verbatim' || decision.kind === 'dropped') continue
+    const takesShipping = !shippingTaken
+    if (takesShipping) shippingTaken = true
+    const sequence =
+      decision.kind === 'replace' ? existing[decision.index]!.sequence : nextSequence++
+    const row = toFulfillment(decision.shipment, {
+      sequence,
+      shippingMinor: takesShipping ? orderShippingTotalMinor : 0,
+      shippingRecognised: takesShipping,
+      recordedAt: now,
+    })
+    if (decision.kind === 'replace') merged[decision.index] = row
+    else merged.push(row)
+  }
+
+  return { fulfillments: merged, changed: !sameLog(existing, merged), heldOut: null }
+}
+
+/**
+ * Group the shipped lines into one shipment per calendar day, earliest first.
+ *
+ * A line is shipped when the channel supplied BOTH a fulfilled date and a
+ * fulfilled quantity above zero. Either one missing means the channel said
+ * nothing, and a date that does not parse is treated the same way rather than
+ * throwing: this function runs inside a finalize pass over a whole sync, and one
+ * malformed cell must not cost every other order its log.
+ */
+function buildDerivedShipments(
+  lines: readonly DerivedLineFact[],
+  timeZone: string
+): DerivedShipment[] {
+  const byDay = new Map<string, DerivedShipment>()
+
+  for (const line of lines) {
+    const quantity = line.fulfilledQuantity
+    if (!line.fulfilledAt || quantity === null || !(quantity > 0)) continue
+    const day = calendarDay(line.fulfilledAt, timeZone)
+    if (!day) continue
+
+    let shipment = byDay.get(day)
+    if (!shipment) {
+      shipment = { shippedAt: day, lines: [], subtotalMinor: 0, taxMinor: 0 }
+      byDay.set(day, shipment)
+    }
+    shipment.lines.push({ lineId: line.lineId, quantity })
+    // The one rounding boundary: `line_item_unit_price` is a RATE carrying five
+    // decimal places, so the extension is where a fraction of a cent stops
+    // existing (`extendRateToAmount`'s own doc).
+    shipment.subtotalMinor += extendRateToAmount(line.unitPriceMinor, quantity, line.lineId)
+    shipment.taxMinor += scaleLineTax(line, quantity)
+  }
+
+  return [...byDay.values()].sort((a, b) => (a.shippedAt < b.shippedAt ? -1 : 1))
+}
+
+/**
+ * This shipment's share of a line's own tax: `round(lineTax * shipped / ordered)`.
+ *
+ * 🛑 A null `lineTaxMinor` contributes ZERO here and does not mean the order is
+ * untaxed - it means the channel supplied no per-line figure, and the batch
+ * builder allocates the ORDER's tax across the shipment instead (49 §3.2, the
+ * `taxBasis: 'allocated'` fork). This function's number is only ever the
+ * `per_line` basis' input.
+ *
+ * An ordered quantity of zero or less cannot be a denominator. The line still
+ * shipped, so it carries its whole line tax rather than none: reading it as zero
+ * would leave `sales_tax_payable` short with nothing on any screen saying so.
+ */
+function scaleLineTax(line: DerivedLineFact, quantity: number): number {
+  if (line.lineTaxMinor === null) return 0
+  if (!(line.orderedQuantity > 0)) return line.lineTaxMinor
+  return Math.round((line.lineTaxMinor * quantity) / line.orderedQuantity)
+}
+
+/**
+ * The calendar day an instant falls on in the book time zone, or null when the
+ * instant does not parse.
+ *
+ * Reuses `periodKeyForDate` rather than formatting again: a shipment logged at
+ * 7pm on July 31 in `America/Los_Angeles` is already August 1 in UTC, and a log
+ * that cuts its days differently from the poster that groups them would post a
+ * month's last shipments into the next month (`postings/periods.ts` says so at
+ * length, and it is the same defect either way).
+ */
+function calendarDay(instant: string, timeZone: string): string | null {
+  const date = new Date(instant)
+  if (Number.isNaN(date.getTime())) return null
+  return periodKeyForDate(date, 'day', timeZone)
+}
+
+/** A derived shipment as a stored row. `glPostingId`/`docNumber` are always null - nothing is posted yet. */
+function toFulfillment(
+  shipment: DerivedShipment,
+  stamp: {
+    sequence: number
+    shippingMinor: number
+    shippingRecognised: boolean
+    recordedAt: string
+  }
+): OrderFulfillment {
+  return {
+    sequence: stamp.sequence,
+    shippedAt: shipment.shippedAt,
+    lines: shipment.lines,
+    subtotalMinor: shipment.subtotalMinor,
+    totalMinor: shipment.subtotalMinor + shipment.taxMinor + stamp.shippingMinor,
+    shippingRecognised: stamp.shippingRecognised,
+    glPostingId: null,
+    docNumber: null,
+    recordedAt: stamp.recordedAt,
+  }
+}
+
+/** Two line sets are the same shipment when they name the same lines in the same quantities. */
+function linesMatch(
+  stored: readonly OrderFulfillmentLine[],
+  derivedLines: readonly OrderFulfillmentLine[]
+): boolean {
+  if (stored.length !== derivedLines.length) return false
+  const byId = new Map(stored.map((line) => [line.lineId, line.quantity]))
+  return derivedLines.every((line) => byId.get(line.lineId) === line.quantity)
+}
+
+/**
+ * Whether the merge produced exactly what was already stored.
+ *
+ * Field-by-field rather than a JSON compare: a stored row written before
+ * `subtotalMinor` existed omits the key entirely, and `JSON.stringify` would
+ * call that different from a derived row carrying the same number.
+ */
+function sameLog(before: readonly OrderFulfillment[], after: readonly OrderFulfillment[]): boolean {
+  if (before.length !== after.length) return false
+  return before.every((row, i) => {
+    const other = after[i]!
+    return (
+      row.sequence === other.sequence &&
+      row.shippedAt === other.shippedAt &&
+      (row.subtotalMinor ?? 0) === (other.subtotalMinor ?? 0) &&
+      row.totalMinor === other.totalMinor &&
+      row.shippingRecognised === other.shippingRecognised &&
+      row.glPostingId === other.glPostingId &&
+      row.docNumber === other.docNumber &&
+      linesMatch(row.lines, other.lines)
+    )
+  })
+}

--- a/packages/lib/src/money/fulfillment-posting/guard.ts
+++ b/packages/lib/src/money/fulfillment-posting/guard.ts
@@ -1,0 +1,31 @@
+// packages/lib/src/money/fulfillment-posting/guard.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError } from '../../errors'
+
+const logger = createScopedLogger('money-fulfillment-posting')
+
+/**
+ * Run an imperative body that may `throw` an {@link AuxxError} for a known
+ * business-rule refusal, and convert the outcome into a neverthrow `Result`.
+ *
+ * Copied from `money/orders/guard.ts` per `docs/lib-module-guide.md` §3 - small
+ * enough that duplicating it beats a shared abstraction, and duplicating it is
+ * what lets this module bind its own logger scope, so a refused bulk run is
+ * greppable as `scope='money-fulfillment-posting'` rather than being mixed in
+ * with the single-order door's refusals.
+ */
+export async function guard<T>(
+  fn: () => Promise<T>,
+  logMessage: string,
+  meta: Record<string, unknown> = {}
+): Promise<Result<T, AuxxError>> {
+  try {
+    return ok(await fn())
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error(logMessage, { error, ...meta })
+    return err(new AuxxError('Internal error'))
+  }
+}

--- a/packages/lib/src/money/fulfillment-posting/index.ts
+++ b/packages/lib/src/money/fulfillment-posting/index.ts
@@ -1,0 +1,53 @@
+// packages/lib/src/money/fulfillment-posting/index.ts
+
+/**
+ * Bulk fulfillment posting: one `fulfillment` entry per day, week or month over
+ * every shipment that no live posting claims
+ * (`plans/money/tasks/49-bulk-fulfillment-posting.md`).
+ *
+ * The three halves, in the order a run uses them:
+ *
+ * 1. `reads.ts` - the netting read, in one SQL over the shipment log,
+ * 2. `plan.ts` - PURE: grouping, exclusions and totals,
+ * 3. `run.ts` - one `postEntry` per group and one stamp per shipment.
+ *
+ * Explicit named exports only (`docs/lib-module-guide.md` §5). The client-safe
+ * vocabulary lives in `client.ts`; a browser must import that, never this.
+ */
+
+export {
+  FULFILLMENT_BATCH_SOURCE_TYPE,
+  FULFILLMENT_POSTING_EXCLUSION_REASONS,
+  FULFILLMENT_POSTING_GROUPINGS,
+  FULFILLMENT_POSTING_MODES,
+  FULFILLMENT_POSTING_SETTING_KEY,
+  type FulfillmentDebitRole,
+  type FulfillmentPostingExclusion,
+  type FulfillmentPostingExclusionReason,
+  type FulfillmentPostingGroup,
+  type FulfillmentPostingGrouping,
+  type FulfillmentPostingMode,
+  type FulfillmentPostingPlan,
+  type FulfillmentPostingPlanInput,
+  type FulfillmentPostingRequest,
+  type FulfillmentPostingRunSummary,
+  type OrderFulfillmentPostingRef,
+  type PlannedShipment,
+  type ShipmentAmounts,
+  type UnpostedShipment,
+  type UnpostedShipmentLine,
+} from './client'
+export { groupKeyFor, isoWeekKey, planFulfillmentPosting } from './plan'
+export {
+  countUnpostedShipments,
+  type FulfillmentPostingSettings,
+  listOrderFulfillmentPostings,
+  readFulfillmentPostingSettings,
+  readUnpostedShipments,
+  type UnpostedShipmentRange,
+} from './reads'
+export {
+  type FulfillmentPostingPreview,
+  previewFulfillmentPosting,
+  runFulfillmentPosting,
+} from './run'

--- a/packages/lib/src/money/fulfillment-posting/plan.ts
+++ b/packages/lib/src/money/fulfillment-posting/plan.ts
@@ -1,0 +1,288 @@
+// packages/lib/src/money/fulfillment-posting/plan.ts
+
+/**
+ * What the bulk fulfillment run would post, decided with nothing but the
+ * shipments and four settings.
+ *
+ * `plans/money/tasks/49-bulk-fulfillment-posting.md` §2.3 and §2.5.
+ *
+ * 🛑 **PURE, and that is the whole point.** No database, no clock, no settings
+ * read, no writer. It is handed every unposted shipment in a range, the cutoff,
+ * the lock, the ledger currency and the book time zone, and it returns the
+ * postings it would make and the shipments it would not. The split is the one
+ * `builds/backfill-policy.ts` / `backfill-builds.ts` already make, for the same
+ * reason 44 §11.1 gives: the painful cases here are a week that straddles a
+ * month boundary, an order carrying two gateways, and a shipment dated inside a
+ * closed period. Every one of those is a unit test only while the decision
+ * needs nothing to run.
+ *
+ * ## The exclusion order is a priority order, not a filter chain
+ *
+ * A shipment is excluded ONCE, for the FIRST reason that applies, and the
+ * reasons are ordered by which remedy the person has to reach for:
+ *
+ * 1. `before-cutoff` - covered by the opening balance; nothing to do, ever.
+ * 2. `locked-period` - reopen the month, or leave it.
+ * 3. `foreign-currency` - the books are kept in one currency (§3.2).
+ * 4. `gateway-ambiguous` / `test-gateway` - fix the order's gateways.
+ * 5. `zero-value` - a shipment that recognises nothing.
+ *
+ * Reporting a shipment as `zero-value` when it is really in a closed period
+ * sends somebody to look at the order instead of at the period, so the order of
+ * these `if`s IS the contract. Every row carries the value that proves its
+ * reason in `detail`, which is 44 §7.2b's rule.
+ *
+ * ## Grouping is calendar arithmetic on a string, and needs no time zone
+ *
+ * `shippedAt` is already a calendar date IN THE BOOK ZONE - the log records the
+ * day the goods went out, not an instant (`money/orders/client.ts`). So the day
+ * bucket is the string itself, the month bucket is its first seven characters,
+ * and the week bucket is its ISO week. {@link FulfillmentPostingPlanInput.timeZone}
+ * is therefore carried but never applied here: re-zoning a date that is already
+ * local is how a shipment moves a day and lands in the wrong month.
+ */
+
+import {
+  computeShipmentAmounts,
+  resolveFulfillmentDebit,
+} from '../../postings/build-fulfillment-batch-entry'
+import type {
+  FulfillmentDebitRole,
+  FulfillmentPostingExclusion,
+  FulfillmentPostingGroup,
+  FulfillmentPostingGrouping,
+  FulfillmentPostingPlan,
+  FulfillmentPostingPlanInput,
+  PlannedShipment,
+  UnpostedShipment,
+} from './types'
+
+/**
+ * Decide what the run would post.
+ *
+ * The output is deterministic - groups ascending by key, shipments within a
+ * group by ship date then order number then sequence, exclusions in the same
+ * order - which is what lets a test assert on the whole structure and what
+ * keeps a preview stable between two runs against unchanged data.
+ *
+ * Never throws. Total on every input, including a shipment with a `NaN` price
+ * or an unparseable date: an amount the builder refuses to compute is reported
+ * as an exclusion rather than taken out on the rest of the range. That matters
+ * more here than in the single-order door, where one refusal costs one order.
+ */
+export function planFulfillmentPosting(input: FulfillmentPostingPlanInput): FulfillmentPostingPlan {
+  const { grouping, cutoffPeriod, lockedThroughMonth, ledgerCurrency } = input
+
+  const exclusions: FulfillmentPostingExclusion[] = []
+  const byGroupKey = new Map<string, PlannedShipment[]>()
+
+  for (const shipment of [...input.shipments].sort(compareShipments)) {
+    const month = monthOf(shipment.shippedAt)
+
+    if (cutoffPeriod && month <= cutoffPeriod) {
+      exclusions.push(exclude(shipment, 'before-cutoff', cutoffPeriod))
+      continue
+    }
+    if (lockedThroughMonth && month <= lockedThroughMonth) {
+      exclusions.push(exclude(shipment, 'locked-period', lockedThroughMonth))
+      continue
+    }
+    // Blank reads as the ledger currency: an order the channel sent no currency
+    // for is not a foreign order, it is an order with an unfilled cell.
+    const currency = shipment.currency?.trim() || ledgerCurrency
+    if (currency !== ledgerCurrency) {
+      exclusions.push(exclude(shipment, 'foreign-currency', currency))
+      continue
+    }
+
+    const debit = resolveFulfillmentDebit({
+      financialStatus: shipment.financialStatus,
+      gateways: shipment.gateways,
+    })
+    if (debit.kind === 'exclude') {
+      exclusions.push(exclude(shipment, debit.reason, debit.detail))
+      continue
+    }
+
+    const computed = computeAmounts(shipment, debit.role)
+    if (!computed.ok) {
+      // 🛑 Classified as `zero-value` on purpose. The reason set is CLOSED
+      // (types.ts), and a shipment whose amounts cannot be computed contributes
+      // exactly nothing to a posting, which is what `zero-value` means to the
+      // run. `detail` carries the refusal verbatim, so the screen still names
+      // the actual problem instead of claiming the order is worth nothing.
+      exclusions.push(exclude(shipment, 'zero-value', computed.reason))
+      continue
+    }
+    const { amounts } = computed
+    if (amounts.totalMinor <= 0) {
+      exclusions.push(exclude(shipment, 'zero-value', String(amounts.totalMinor)))
+      continue
+    }
+
+    const key = groupKeyFor(shipment.shippedAt, grouping)
+    const bucket = byGroupKey.get(key)
+    if (bucket) bucket.push({ ...shipment, amounts })
+    else byGroupKey.set(key, [{ ...shipment, amounts }])
+  }
+
+  const groups = [...byGroupKey.entries()]
+    .sort(([a], [b]) => compareStrings(a, b))
+    .map(([groupKey, shipments]) => toGroup(groupKey, shipments))
+
+  const orders = new Set<string>()
+  for (const group of groups) {
+    for (const shipment of group.shipments) orders.add(shipment.orderId)
+  }
+
+  return {
+    grouping,
+    groups,
+    exclusions,
+    footer: {
+      postings: groups.length,
+      shipments: groups.reduce((total, group) => total + group.shipments.length, 0),
+      orders: orders.size,
+      excluded: exclusions.length,
+      totalMinor: groups.reduce((total, group) => total + group.totals.totalMinor, 0),
+    },
+  }
+}
+
+/**
+ * The identity of the posting one shipment falls into, and its period key
+ * before any attempt suffix.
+ *
+ * Exported because the preview, the run and lane E's dialog all have to agree
+ * about which posting a shipment belongs to, and a second copy of this
+ * three-line function is a second thing that can drift.
+ */
+export function groupKeyFor(shippedAt: string, grouping: FulfillmentPostingGrouping): string {
+  if (grouping === 'month') return monthOf(shippedAt)
+  if (grouping === 'week') return isoWeekKey(shippedAt)
+  return shippedAt
+}
+
+/**
+ * The ISO week a calendar date falls in, `'2026-W27'`.
+ *
+ * Computed on the date's own calendar fields through `Date.UTC`, never through
+ * the host's local time: `new Date('2026-07-06')` west of Greenwich is July 5
+ * locally, which is the previous ISO week roughly one day in seven. Matching
+ * `date-fns`'s `"RRRR-'W'II"` (`builds/backfill-policy.ts`), the year is the
+ * ISO WEEK-NUMBERING year, which is not always the calendar year of the days in
+ * it - `2026-12-31` is `2026-W53` and `2027-01-01` is still `2026-W53`. That is
+ * also why a week may straddle a month and even a year, and why the group's
+ * `txnDate` is the latest ship date in it rather than anything derived from the
+ * key.
+ */
+export function isoWeekKey(shippedAt: string): string {
+  const year = Number(shippedAt.slice(0, 4))
+  const month = Number(shippedAt.slice(5, 7))
+  const day = Number(shippedAt.slice(8, 10))
+  // A date the read cannot parse falls into a bucket of its own rather than
+  // silently joining somebody else's week. The netting read only returns dates
+  // inside the requested range, so this is defence, not a path.
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return shippedAt
+
+  const date = new Date(Date.UTC(year, month - 1, day))
+  // Move to the Thursday of this ISO week: the ISO year is the calendar year
+  // that Thursday falls in, by definition.
+  const weekday = date.getUTCDay() || 7
+  date.setUTCDate(date.getUTCDate() + 4 - weekday)
+  const isoYear = date.getUTCFullYear()
+  const firstThursday = Date.UTC(isoYear, 0, 4)
+  const week = 1 + Math.round((date.getTime() - firstThursday) / (7 * 86_400_000))
+  return `${isoYear}-W${String(week).padStart(2, '0')}`
+}
+
+/** Collapse one bucket of shipments into the posting it becomes. */
+function toGroup(groupKey: string, shipments: PlannedShipment[]): FulfillmentPostingGroup {
+  const byDebitRole: Record<FulfillmentDebitRole, number> = {
+    clearing_card: 0,
+    clearing_affirm: 0,
+    accounts_receivable: 0,
+  }
+  let subtotalMinor = 0
+  let taxMinor = 0
+  let shippingMinor = 0
+  let totalMinor = 0
+  let txnDate = ''
+  const orders = new Set<string>()
+
+  for (const shipment of shipments) {
+    subtotalMinor += shipment.amounts.subtotalMinor
+    taxMinor += shipment.amounts.taxMinor
+    shippingMinor += shipment.amounts.shippingMinor
+    totalMinor += shipment.amounts.totalMinor
+    byDebitRole[shipment.amounts.debitRole] += shipment.amounts.totalMinor
+    orders.add(shipment.orderId)
+    // 🛑 The LATEST ship date in the group, never the group key's own start. A
+    // week bucket keyed `2026-W27` posted on the Monday would date revenue
+    // before some of the goods left the building, and a month bucket posted on
+    // the first would date the whole month's revenue into the day the period
+    // opened. The latest date is inside the period by construction and is never
+    // in the future, because a shipment cannot be recorded before it ships.
+    if (shipment.shippedAt > txnDate) txnDate = shipment.shippedAt
+  }
+
+  return {
+    groupKey,
+    txnDate,
+    shipments,
+    orderCount: orders.size,
+    totals: { subtotalMinor, taxMinor, shippingMinor, totalMinor, byDebitRole },
+  }
+}
+
+/**
+ * `computeShipmentAmounts`, made total.
+ *
+ * The builder throws an `UnprocessableEntityError` on a fractional stored
+ * amount or a non-finite rate, which is the right answer for one order a person
+ * is fulfilling and the wrong one for a run over five hundred. Catching it here
+ * is what keeps `planFulfillmentPosting` total, and the refusal sentence is
+ * kept so the exclusion can carry it verbatim.
+ */
+function computeAmounts(
+  shipment: UnpostedShipment,
+  role: FulfillmentDebitRole
+): { ok: true; amounts: PlannedShipment['amounts'] } | { ok: false; reason: string } {
+  try {
+    return { ok: true, amounts: computeShipmentAmounts(shipment, role) }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+function exclude(
+  shipment: UnpostedShipment,
+  reason: FulfillmentPostingExclusion['reason'],
+  detail: string
+): FulfillmentPostingExclusion {
+  return {
+    orderId: shipment.orderId,
+    orderNumber: shipment.orderNumber,
+    sequence: shipment.sequence,
+    shippedAt: shipment.shippedAt,
+    reason,
+    detail,
+  }
+}
+
+/** `YYYY-MM` of a `YYYY-MM-DD`. Month keys compare as strings, chronologically. */
+function monthOf(shippedAt: string): string {
+  return shippedAt.slice(0, 7)
+}
+
+function compareShipments(a: UnpostedShipment, b: UnpostedShipment): number {
+  return (
+    compareStrings(a.shippedAt, b.shippedAt) ||
+    compareStrings(a.orderNumber, b.orderNumber) ||
+    a.sequence - b.sequence
+  )
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}

--- a/packages/lib/src/money/fulfillment-posting/reads.ts
+++ b/packages/lib/src/money/fulfillment-posting/reads.ts
@@ -1,0 +1,695 @@
+// packages/lib/src/money/fulfillment-posting/reads.ts
+
+/**
+ * The netting read behind the bulk fulfillment poster: every shipment in a
+ * range that carries no LIVE posting.
+ *
+ * `plans/money/tasks/49-bulk-fulfillment-posting.md` §2.2, §2.5 and §8.2.
+ *
+ * Reads only, no permission checks - the router asserts and hands the range
+ * down (`docs/lib-module-guide.md` §5 and §6). The pure decision over what this
+ * returns is `plan.ts`; the writes are `run.ts`.
+ *
+ * ## 🛑 "Unposted" is the ABSENCE OF A LIVE POSTING, not a null stamp
+ *
+ * §2.6 rule 1 and decision 9: reversing a day's entry has to put its shipments
+ * back into the next preview, and the run un-stamps nothing. So a shipment is
+ * unposted when its `glPostingId` is null, OR names a posting whose status is
+ * `reversed`, OR names a posting that no longer exists at all. Reading only the
+ * null case would strand every shipment of a reversed run: the ledger would
+ * hold no entry for them and the netting read would never offer them again.
+ *
+ * ## 🛑 One SQL for the log, then BOUNDED reads for the fields
+ *
+ * The backlog this exists for is 531 orders over three months (§5), so a read
+ * per order is the shape batching exists to escape - the same rule
+ * `builds/backfill-queries.ts` states. The shipment log lives inside ONE JSON
+ * cell per order, so it is expanded with `jsonb_array_elements` in the database
+ * and joined to `GlPosting` there; then exactly two more queries pivot the order
+ * and line fields for whatever came back, regardless of how many orders that is.
+ *
+ * `priorShipmentsSubtotalMinor` is computed in the same statement, as a window
+ * over EVERY earlier sequence of the same log - live or not. It is what makes
+ * the builder's cumulative tax allocation true itself up on the shipment that
+ * completes an order, and it cannot be derived from the returned rows, because
+ * the earlier shipments are usually already posted and therefore filtered out.
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { UnprocessableEntityError } from '../../errors'
+import type { FieldOptions } from '../../field-values/converters'
+import { resolvePeriodLock } from '../../postings/period-lock'
+import { LEDGER_CURRENCY } from '../../postings/post-entry'
+import { OPENING_BASELINE_SETTING_KEYS } from '../../postings/setup-readiness'
+import { buildOptionIndex, resolveOptionId } from '../../resources/registry/option-helpers'
+import { getOrganizationSetting } from '../../settings/settings-service'
+import {
+  type OrderFieldContext,
+  parseFulfillments,
+  requireOrderFieldContext,
+} from '../orders/reads'
+import { guard } from './guard'
+import { planFulfillmentPosting } from './plan'
+import type {
+  FulfillmentPostingExclusionReason,
+  FulfillmentPostingPlan,
+  OrderFulfillmentPostingRef,
+  UnpostedShipment,
+  UnpostedShipmentLine,
+} from './types'
+
+/** Half-open on `shippedAt`: `from <= shippedAt < to`, both `YYYY-MM-DD`. */
+export interface UnpostedShipmentRange {
+  from: string
+  to: string
+}
+
+/** `YYYY-MM-DD`, and nothing else. A range bound is a contract, not a hint. */
+function assertIsoDate(value: string, label: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new UnprocessableEntityError(`${label} must be a YYYY-MM-DD date, got "${value}"`)
+  }
+}
+
+/** `YYYY-MM`, and nothing else. */
+function assertMonth(value: string, label: string): void {
+  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(value)) {
+    throw new UnprocessableEntityError(`${label} must be a YYYY-MM month, got "${value}"`)
+  }
+}
+
+/** The half-open day range one calendar month covers. Validated by {@link assertMonth}. */
+function monthRange(month: string): UnpostedShipmentRange {
+  const year = Number(month.slice(0, 4))
+  const index = Number(month.slice(5, 7))
+  const nextYear = index === 12 ? year + 1 : year
+  const nextIndex = index === 12 ? 1 : index + 1
+  return { from: `${month}-01`, to: `${nextYear}-${String(nextIndex).padStart(2, '0')}-01` }
+}
+
+/**
+ * One log entry the netting SQL kept, before any order or line field is read.
+ *
+ * Every column is text or a float because it came out of `jsonb`; the numbers
+ * are re-coerced in TypeScript rather than trusted from the driver.
+ */
+interface UnpostedEntryRow {
+  order_id: string
+  sequence: number | string
+  shipped_at: string
+  prior_subtotal_minor: number | string | null
+  shipping_recognised: boolean | null
+  lines: unknown
+}
+
+/**
+ * THE netting statement.
+ *
+ * Written once and used by both {@link readUnpostedShipments} and
+ * {@link countUnpostedShipments}, because a count that could disagree with the
+ * list it counts is exactly the defect a close refusal must not have (lane D
+ * reads the count to refuse `prepareClose`).
+ *
+ * ⚠️ Two spellings of the stored cell are tolerated on the way in -
+ * `{ v: { fulfillments } }` and a bare `{ fulfillments }` - because
+ * `parseFulfillments` is tolerant of both and a read that was stricter than the
+ * parser would report shipments the rest of the module cannot see.
+ */
+function unpostedEntriesQuery(
+  organizationId: string,
+  fulfillmentsFieldId: string,
+  range: UnpostedShipmentRange
+) {
+  const entries = sql`coalesce(
+    ${schema.FieldValue.valueJson} -> 'v' -> 'fulfillments',
+    ${schema.FieldValue.valueJson} -> 'fulfillments'
+  )`
+
+  return sql`
+    WITH log AS (
+      SELECT ${schema.FieldValue.entityId} AS order_id, ${entries} AS entries
+      FROM ${schema.FieldValue}
+      WHERE ${schema.FieldValue.organizationId} = ${organizationId}
+        AND ${schema.FieldValue.fieldId} = ${fulfillmentsFieldId}
+        AND jsonb_typeof(${entries}) = 'array'
+    ),
+    expanded AS (
+      SELECT
+        log.order_id,
+        e.entry,
+        -- 🛑 CASE, not a bare cast guarded by the WHERE. Postgres does not
+        -- promise to evaluate a WHERE before the target list of the same query
+        -- level, and a CTE may be inlined, so a log row carrying
+        -- "sequence": "first" would abort the whole run with a cast error
+        -- rather than being skipped. Every cast below is guarded in place.
+        CASE
+          WHEN jsonb_typeof(e.entry) = 'object' AND (e.entry ->> 'sequence') ~ '^[0-9]+$'
+          THEN (e.entry ->> 'sequence')::int
+        END AS sequence,
+        coalesce(e.entry ->> 'shippedAt', '') AS shipped_at,
+        e.entry ->> 'glPostingId' AS gl_posting_id,
+        CASE
+          WHEN (e.entry ->> 'subtotalMinor') ~ '^-?[0-9]+([.][0-9]+)?$'
+          THEN (e.entry ->> 'subtotalMinor')::float8
+          ELSE 0
+        END AS subtotal_minor
+      FROM log
+      CROSS JOIN LATERAL jsonb_array_elements(log.entries) AS e(entry)
+    ),
+    ranked AS (
+      SELECT
+        expanded.*,
+        coalesce(
+          sum(expanded.subtotal_minor) OVER (
+            PARTITION BY expanded.order_id
+            ORDER BY expanded.sequence
+            ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+          ),
+          0
+        ) AS prior_subtotal_minor
+      FROM expanded
+      WHERE expanded.sequence IS NOT NULL
+    )
+    SELECT
+      ranked.order_id,
+      ranked.sequence,
+      ranked.shipped_at,
+      ranked.prior_subtotal_minor,
+      coalesce(ranked.entry ->> 'shippingRecognised', 'false') = 'true' AS shipping_recognised,
+      ranked.entry -> 'lines' AS lines
+    FROM ranked
+    LEFT JOIN ${schema.GlPosting} ON ${schema.GlPosting.id} = ranked.gl_posting_id
+      AND ${schema.GlPosting.organizationId} = ${organizationId}
+    WHERE ranked.shipped_at >= ${range.from}
+      AND ranked.shipped_at < ${range.to}
+      AND (
+        ranked.gl_posting_id IS NULL
+        OR ${schema.GlPosting.id} IS NULL
+        OR ${schema.GlPosting.status} = 'reversed'
+      )
+    ORDER BY ranked.shipped_at, ranked.order_id, ranked.sequence
+  `
+}
+
+/**
+ * Every shipment in the range that no live posting claims, with everything the
+ * builder needs riding on it.
+ *
+ * An org with no provisioned `order` def reads as no shipments rather than as
+ * an error: there is nothing to post, and a preview showing an empty plan is
+ * the honest answer. The one refusal is a malformed period lock, which
+ * `resolvePeriodLock` owns and which does not reach this function.
+ *
+ * @param range half-open on `shippedAt`, both `YYYY-MM-DD` in the book zone.
+ */
+export async function readUnpostedShipments(
+  db: Database,
+  params: { organizationId: string; range: UnpostedShipmentRange }
+): Promise<Result<UnpostedShipment[], Error>> {
+  const { organizationId, range } = params
+
+  return guard(
+    async () => {
+      assertIsoDate(range.from, 'The range start')
+      assertIsoDate(range.to, 'The range end')
+
+      const ctx = await requireOrderFieldContext(organizationId)
+      const fulfillmentsFieldId = ctx.order.order_fulfillments?.id
+      if (!fulfillmentsFieldId) return []
+
+      const result = await db.execute(
+        unpostedEntriesQuery(organizationId, fulfillmentsFieldId, range)
+      )
+      const rows = (result.rows ?? []) as unknown as UnpostedEntryRow[]
+      if (rows.length === 0) return []
+
+      const orderIds = [...new Set(rows.map((row) => row.order_id))]
+      const logLines = rows.map((row) => parseLogLines(row.lines))
+      const lineIds = [...new Set(logLines.flatMap((lines) => lines.map((line) => line.lineId)))]
+
+      const [orders, lines] = await Promise.all([
+        readOrderFacts(db, organizationId, ctx, orderIds),
+        readLineFacts(db, organizationId, ctx, lineIds),
+      ])
+
+      const shipments: UnpostedShipment[] = []
+      for (const [index, row] of rows.entries()) {
+        const order = orders.get(row.order_id)
+        // An order whose fields cannot be read at all is dropped rather than
+        // posted from defaults: an entry built on a guessed subtotal balances
+        // and is wrong, and nothing downstream could see it.
+        if (!order) continue
+        shipments.push({
+          orderId: row.order_id,
+          orderNumber: order.number,
+          sequence: Number(row.sequence),
+          shippedAt: row.shipped_at,
+          lines: (logLines[index] ?? []).map((line) => ({
+            lineId: line.lineId,
+            quantity: line.quantity,
+            ...(lines.get(line.lineId) ?? UNKNOWN_LINE),
+          })),
+          channel: order.channel,
+          currency: order.currency,
+          financialStatus: order.financialStatus,
+          gateways: order.gateways,
+          orderSubtotalMinor: order.subtotalMinor,
+          orderTaxTotalMinor: order.taxTotalMinor,
+          orderShippingTotalMinor: order.shippingTotalMinor,
+          priorShipmentsSubtotalMinor: finite(row.prior_subtotal_minor),
+          includeShipping: row.shipping_recognised === true,
+          contactId: order.contactId,
+        })
+      }
+      return shipments
+    },
+    'Failed to read unposted shipments',
+    { organizationId, from: range.from, to: range.to }
+  )
+}
+
+/**
+ * Exclusion reasons that still block a month close.
+ *
+ * A shipment the plan excludes for one of these needs a person: a currency the
+ * ledger cannot hold, a gateway nobody has resolved, test data that should not
+ * be there. `zero-value` recognises nothing and blocks nothing, and
+ * `before-cutoff` / `locked-period` describe months the close is not asking
+ * about.
+ */
+export const CLOSE_BLOCKING_EXCLUSION_REASONS: ReadonlySet<FulfillmentPostingExclusionReason> =
+  new Set(['foreign-currency', 'gateway-ambiguous', 'test-gateway'])
+
+/** The close's count of a plan: what would post, plus what a person still owes. */
+export function countCloseBlockingShipments(plan: FulfillmentPostingPlan): number {
+  const owed = plan.exclusions.filter((e) => CLOSE_BLOCKING_EXCLUSION_REASONS.has(e.reason)).length
+  return plan.footer.shipments + owed
+}
+
+/**
+ * How many shipments in one book month still owe the ledger a posting.
+ *
+ * Lane D's close refusal reads this: a month that still holds an unposted
+ * shipment is a month whose revenue is not on the P&L, and declaring it closed
+ * would leave that revenue with nowhere to land (§2.4).
+ *
+ * Counted through the SAME read and the SAME plan the dialog uses, so "the
+ * close says 3 and the dialog shows 2" is unreachable, and so a shipment the
+ * dialog excludes for good ({@link CLOSE_BLOCKING_EXCLUSION_REASONS}) does not
+ * hold the month open forever. The first drive on the dev org found exactly
+ * that: one zero-value order kept July unclosable after every day had posted.
+ */
+export async function countUnpostedShipments(
+  db: Database,
+  params: { organizationId: string; month: string }
+): Promise<Result<number, Error>> {
+  const { organizationId, month } = params
+
+  return guard(
+    async () => {
+      assertMonth(month, 'The month')
+      const shipments = await readUnpostedShipments(db, {
+        organizationId,
+        range: monthRange(month),
+      })
+      if (shipments.isErr()) throw shipments.error
+      if (shipments.value.length === 0) return 0
+      const settings = await readFulfillmentPostingSettings(db, organizationId)
+      if (settings.isErr()) throw settings.error
+      const plan = planFulfillmentPosting({
+        shipments: shipments.value,
+        grouping: 'day',
+        cutoffPeriod: settings.value.cutoffPeriod,
+        lockedThroughMonth: settings.value.lockedThroughMonth,
+        ledgerCurrency: settings.value.ledgerCurrency,
+        timeZone: settings.value.timeZone ?? 'UTC',
+      })
+      return countCloseBlockingShipments(plan)
+    },
+    'Failed to count unposted shipments',
+    { organizationId, month }
+  )
+}
+
+/**
+ * The postings one order's shipment log names, with each posting's CURRENT
+ * status.
+ *
+ * 🛑 The order's ledger card reads this instead of `listPostingsForSource`
+ * (§8.2). A batch entry carries per-order source lines only for the A/R leg of
+ * a terms order; a card order's legs summarise under
+ * `sourceType: 'fulfillment_batch'`, so a source-line lookup finds nothing for
+ * the majority of Shopify orders and the card renders empty over an order that
+ * is perfectly well posted.
+ *
+ * A stamp naming a posting that no longer exists is dropped rather than
+ * rendered as a broken link.
+ */
+export async function listOrderFulfillmentPostings(
+  db: Database,
+  params: { organizationId: string; orderId: string }
+): Promise<Result<OrderFulfillmentPostingRef[], Error>> {
+  const { organizationId, orderId } = params
+
+  return guard(
+    async () => {
+      const ctx = await requireOrderFieldContext(organizationId)
+      const fulfillmentsFieldId = ctx.order.order_fulfillments?.id
+      if (!fulfillmentsFieldId) return []
+
+      const [row] = await db
+        .select({ valueJson: schema.FieldValue.valueJson })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            eq(schema.FieldValue.entityId, orderId),
+            eq(schema.FieldValue.fieldId, fulfillmentsFieldId)
+          )
+        )
+        .limit(1)
+
+      const stamps = parseFulfillments(row?.valueJson)
+        .filter((entry) => entry.glPostingId !== null)
+        .map((entry) => ({
+          sequence: entry.sequence,
+          shippedAt: entry.shippedAt,
+          glPostingId: entry.glPostingId as string,
+        }))
+      if (stamps.length === 0) return []
+
+      const postings = await db
+        .select({
+          id: schema.GlPosting.id,
+          docNumber: schema.GlPosting.docNumber,
+          status: schema.GlPosting.status,
+        })
+        .from(schema.GlPosting)
+        .where(
+          and(
+            eq(schema.GlPosting.organizationId, organizationId),
+            inArray(
+              schema.GlPosting.id,
+              stamps.map((stamp) => stamp.glPostingId)
+            )
+          )
+        )
+      const byId = new Map(postings.map((posting) => [posting.id, posting]))
+
+      const refs: OrderFulfillmentPostingRef[] = []
+      for (const stamp of stamps) {
+        const posting = byId.get(stamp.glPostingId)
+        if (!posting) continue
+        refs.push({
+          sequence: stamp.sequence,
+          shippedAt: stamp.shippedAt,
+          glPostingId: stamp.glPostingId,
+          docNumber: posting.docNumber ?? null,
+          status: posting.status,
+        })
+      }
+      return refs.sort((a, b) => a.sequence - b.sequence)
+    },
+    'Failed to read an order fulfillment postings',
+    { organizationId, orderId }
+  )
+}
+
+/** Everything the plan needs that is an organization setting rather than a fact. */
+export interface FulfillmentPostingSettings {
+  /** `accounting.cutoffPeriod`, `YYYY-MM`, or null when the org keeps no books yet. */
+  cutoffPeriod: string | null
+  /** `ledger.lockedThroughMonth`, `YYYY-MM`, or null when nothing is closed. */
+  lockedThroughMonth: string | null
+  /**
+   * `accounting.bookTimeZone`, or null when it is unset.
+   *
+   * 🛑 Null rather than a `'UTC'` default. 44 lane 4's rule: a run whose day
+   * boundaries were cut in the wrong zone dates revenue to the wrong month
+   * invisibly, so `run.ts` REFUSES rather than guessing.
+   */
+  timeZone: string | null
+  ledgerCurrency: string
+}
+
+/**
+ * The four ambient values a run is decided against, read once.
+ *
+ * `resolvePeriodLock` fails CLOSED on a malformed lock and that refusal is kept:
+ * a bulk run is the last place to fall back to "nothing is closed".
+ */
+export async function readFulfillmentPostingSettings(
+  _db: Database,
+  organizationId: string
+): Promise<Result<FulfillmentPostingSettings, Error>> {
+  // `_db` is unused: every value here is an organization SETTING, and
+  // `settings-service` owns its own connection. It stays in the signature so
+  // every export of this module reads `db` first (`docs/lib-module-guide.md`
+  // §4) and so a future read that does need the connection is not a signature
+  // change for every caller.
+  return guard(
+    async () => {
+      const [cutoffPeriod, timeZone, lock] = await Promise.all([
+        readTextSetting(organizationId, OPENING_BASELINE_SETTING_KEYS.cutoffPeriod),
+        readTextSetting(organizationId, OPENING_BASELINE_SETTING_KEYS.bookTimeZone),
+        resolvePeriodLock(organizationId),
+      ])
+      return {
+        cutoffPeriod,
+        lockedThroughMonth: lock.lockedThroughMonth,
+        timeZone,
+        ledgerCurrency: LEDGER_CURRENCY,
+      }
+    },
+    'Failed to read the fulfillment posting settings',
+    { organizationId }
+  )
+}
+
+/** One organization setting as a trimmed string, or null for unset or blank. */
+async function readTextSetting(
+  organizationId: string,
+  key: Parameters<typeof getOrganizationSetting>[0]['key']
+): Promise<string | null> {
+  const value = await getOrganizationSetting({ organizationId, key })
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
+}
+
+/** What is known about a line the log names but the line read could not reach. */
+const UNKNOWN_LINE = {
+  unitPriceMinor: 0,
+  lineTaxMinor: null,
+  orderedQuantity: 0,
+} satisfies Omit<UnpostedShipmentLine, 'lineId' | 'quantity'>
+
+/** The log's own `{ lineId, quantity }` rows, read as tolerantly as the parser. */
+function parseLogLines(value: unknown): Array<{ lineId: string; quantity: number }> {
+  if (!Array.isArray(value)) return []
+  const lines: Array<{ lineId: string; quantity: number }> = []
+  for (const row of value) {
+    if (typeof row !== 'object' || row === null) continue
+    const { lineId, quantity } = row as { lineId?: unknown; quantity?: unknown }
+    if (typeof lineId !== 'string' || typeof quantity !== 'number') continue
+    if (!Number.isFinite(quantity) || quantity <= 0) continue
+    lines.push({ lineId, quantity })
+  }
+  return lines
+}
+
+/** One order's facts, as the shipments on it need them. */
+interface OrderFacts {
+  number: string
+  channel: string | null
+  currency: string | null
+  financialStatus: string | null
+  gateways: string[]
+  subtotalMinor: number
+  taxTotalMinor: number
+  shippingTotalMinor: number
+  contactId: string | null
+}
+
+/**
+ * The order fields for every order the netting read touched, in ONE query.
+ *
+ * ⚠️ `order_payment_gateways` is a TAGS field: one `FieldValue` row per gateway,
+ * each holding an opaque option KEY rather than the gateway's name. The name is
+ * in the field's own option list, so every key is resolved through
+ * `resolveOptionId`, which falls back to the raw stored value - which is exactly
+ * right for a connector-provisioned option set, where the key IS the name.
+ */
+async function readOrderFacts(
+  db: Database,
+  organizationId: string,
+  ctx: OrderFieldContext,
+  orderIds: string[]
+): Promise<Map<string, OrderFacts>> {
+  const facts = new Map<string, OrderFacts>()
+  if (orderIds.length === 0) return facts
+
+  const fieldIds = Object.values(ctx.order)
+    .filter((field): field is NonNullable<typeof field> => field != null)
+    .map((field) => field.id)
+  const rows = await selectValues(db, organizationId, orderIds, fieldIds)
+
+  const gatewayOptions = buildOptionIndex(
+    ((ctx.order.order_payment_gateways?.options ?? {}) as FieldOptions).options ?? []
+  )
+
+  for (const orderId of orderIds) {
+    const bucket = rows.get(orderId)
+    // 🛑 An order with no readable field value at all is skipped, and
+    // `readUnpostedShipments` then drops its shipments. Defaulting instead
+    // would hand the builder a nameless order with a zero subtotal, which
+    // posts an entry that balances and recognises the wrong number.
+    if (!bucket) continue
+    const cell = (attribute: keyof OrderFieldContext['order']) => {
+      const field = ctx.order[attribute]
+      return field ? bucket?.get(field.id)?.[0] : undefined
+    }
+    const cells = (attribute: keyof OrderFieldContext['order']) => {
+      const field = ctx.order[attribute]
+      return field ? (bucket?.get(field.id) ?? []) : []
+    }
+
+    facts.set(orderId, {
+      number: cell('order_number')?.valueText ?? '',
+      // A SINGLE_SELECT stores its value in `optionId`, and the registry
+      // declares these two option sets, so the key IS the value.
+      channel: cell('order_channel')?.optionId ?? null,
+      currency: cell('order_currency')?.valueText ?? null,
+      financialStatus: cell('order_financial_status')?.optionId ?? null,
+      gateways: cells('order_payment_gateways').flatMap((row) => {
+        const key = row.optionId ?? row.valueText
+        if (!key) return []
+        const resolved = resolveOptionId(key, gatewayOptions)
+        return [resolved.status === 'known' ? resolved.label : resolved.raw]
+      }),
+      subtotalMinor: amount(cell('order_subtotal')?.valueNumber),
+      taxTotalMinor: amount(cell('order_tax_total')?.valueNumber),
+      shippingTotalMinor: amount(cell('order_shipping_total')?.valueNumber),
+      contactId: cell('order_contact')?.relatedEntityId ?? null,
+    })
+  }
+  return facts
+}
+
+/** The line fields for every line the shipments name, in ONE query. */
+async function readLineFacts(
+  db: Database,
+  organizationId: string,
+  ctx: OrderFieldContext,
+  lineIds: string[]
+): Promise<Map<string, Omit<UnpostedShipmentLine, 'lineId' | 'quantity'>>> {
+  const facts = new Map<string, Omit<UnpostedShipmentLine, 'lineId' | 'quantity'>>()
+  if (lineIds.length === 0) return facts
+
+  const fieldIds = Object.values(ctx.line)
+    .filter((field): field is NonNullable<typeof field> => field != null)
+    .map((field) => field.id)
+  const rows = await selectValues(db, organizationId, lineIds, fieldIds)
+
+  for (const lineId of lineIds) {
+    const bucket = rows.get(lineId)
+    const cell = (attribute: keyof OrderFieldContext['line']) => {
+      const field = ctx.line[attribute]
+      return field ? bucket?.get(field.id)?.[0] : undefined
+    }
+    const taxTotal = cell('line_item_tax_total')?.valueNumber
+    facts.set(lineId, {
+      // 🛑 A RATE, left unrounded. `extendRateToAmount` in the builder is the
+      // one boundary that turns a rate into an amount.
+      unitPriceMinor: cell('line_item_unit_price')?.valueNumber ?? 0,
+      // 🛑 `?? null`, never `?? 0`: an absent row means the channel said
+      // nothing about this line's tax, which is what makes the builder allocate
+      // the order's total instead of trusting a zero (48 §8.2).
+      lineTaxMinor: taxTotal == null ? null : amount(taxTotal),
+      orderedQuantity: cell('line_item_qty')?.valueNumber ?? 0,
+      name: cell('line_item_name')?.valueText ?? undefined,
+    })
+  }
+  return facts
+}
+
+/** One `FieldValue` row, in the columns this module reads. */
+interface ValueRow {
+  fieldId: string
+  valueText: string | null
+  valueNumber: number | null
+  optionId: string | null
+  relatedEntityId: string | null
+}
+
+/**
+ * `FieldValue` rows for a set of instances and fields, bucketed
+ * `instance -> field -> rows`.
+ *
+ * The inner value is an ARRAY because a multi-value field has one row per value
+ * - `order_payment_gateways` is exactly that, and a `Map<fieldId, row>` would
+ * silently keep only the last gateway, which is the input the debit fork's
+ * ambiguity rule is decided from.
+ */
+async function selectValues(
+  db: Database,
+  organizationId: string,
+  entityIds: string[],
+  fieldIds: string[]
+): Promise<Map<string, Map<string, ValueRow[]>>> {
+  const buckets = new Map<string, Map<string, ValueRow[]>>()
+  if (entityIds.length === 0 || fieldIds.length === 0) return buckets
+
+  const rows = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+      valueNumber: schema.FieldValue.valueNumber,
+      optionId: schema.FieldValue.optionId,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+      sortKey: schema.FieldValue.sortKey,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.entityId, entityIds),
+        inArray(schema.FieldValue.fieldId, fieldIds)
+      )
+    )
+    .orderBy(schema.FieldValue.sortKey)
+
+  for (const row of rows) {
+    let byField = buckets.get(row.entityId)
+    if (!byField) {
+      byField = new Map()
+      buckets.set(row.entityId, byField)
+    }
+    const list = byField.get(row.fieldId)
+    if (list) list.push(row)
+    else byField.set(row.fieldId, [row])
+  }
+  return buckets
+}
+
+/**
+ * A stored money AMOUNT, as whole minor units.
+ *
+ * ⚠️ Rounded here rather than refused, which is where this differs from
+ * `toAmountMinor` in `postings/build-fulfillment-entry.ts`. That function is
+ * right for ONE order a person is fulfilling: a fractional cent is a bug
+ * upstream and refusing names it. In a bulk run over hundreds of orders the
+ * same refusal would take the whole batch down for one bad row, and every
+ * amount here comes out of a `doublePrecision` column where `26400` reads back
+ * as `26399.999999999996` anyway. `plan.ts` stays total as a result.
+ */
+function amount(value: number | null | undefined): number {
+  return value == null || !Number.isFinite(value) ? 0 : Math.round(value)
+}
+
+/** A number the driver may have handed back as text. */
+function finite(value: number | string | null | undefined): number {
+  const parsed = typeof value === 'string' ? Number(value) : value
+  return parsed != null && Number.isFinite(parsed) ? parsed : 0
+}

--- a/packages/lib/src/money/fulfillment-posting/run.ts
+++ b/packages/lib/src/money/fulfillment-posting/run.ts
@@ -1,0 +1,472 @@
+// packages/lib/src/money/fulfillment-posting/run.ts
+
+/**
+ * Phase 3 of the bulk fulfillment poster: EXECUTE a {@link FulfillmentPostingPlan}.
+ *
+ * `plans/money/tasks/49-bulk-fulfillment-posting.md` §2.3 item 5, §2.4 and §8.2.
+ *
+ * `plan.ts` decides what to post with no database, no clock and no settings;
+ * this file writes it, one `GlPosting` per group and one stamp per shipment.
+ * The split, and the never-throws discipline below, are
+ * `builds/backfill-builds.ts` again.
+ *
+ * ## 🛑 It is NOT atomic, and the summary is what says so
+ *
+ * A group is `postEntry` followed by N stamps, and those are separate
+ * transactions - `postEntry` opens its own and makes a provider call, so
+ * holding the claim's index tuple across the stamps would hold it across an
+ * HTTP round trip. So a group can end up posted-with-unstamped-shipments, which
+ * is the one state in this whole feature that a person MUST look at: an
+ * unstamped shipment reads as unposted to the netting read, and the next run
+ * would recognise its revenue a second time under the next attempt key, where
+ * the claim's unique index cannot catch it. That outcome is reported in BOTH
+ * `posted` (the ledger truth) and `failed` (the thing that needs a person).
+ *
+ * ## 🛑 `already_posted` is a SKIP here, never a success
+ *
+ * It is a success everywhere else in the poster - a converged re-run. Here it
+ * means the group's period key was already claimed by a posting this run did
+ * not make, so the entry it holds is NOT this group's entry and stamping this
+ * group's shipments onto it would attach them to somebody else's numbers. The
+ * attempt counter exists to make it unreachable (§8.2); reaching it anyway
+ * means the count and the claim disagree, and the honest answer is to write
+ * nothing and say so.
+ *
+ * ## 🛑 Never throws
+ *
+ * Three layers, matching `backfill-builds.ts`: every STAMP inside its own `try`
+ * so one order's lock contention does not lose the rest of the group; every
+ * GROUP inside its own `try` so one refused build does not lose the run; and the
+ * whole body inside one final `try` so a caller (a worker job, the `auto` lane)
+ * always gets a summary.
+ *
+ * No permission checks. The router asserts `ledgerPost`
+ * (`docs/lib-module-guide.md` §6).
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, like, ne, or } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { getOrgCache } from '../../cache'
+import { buildFulfillmentBatchEntry } from '../../postings/build-fulfillment-batch-entry'
+import { resolvePeriodLock } from '../../postings/period-lock'
+import { postEntry } from '../../postings/post-entry'
+import {
+  FINALIZED_SETUP_STATE,
+  OPENING_BASELINE_SETTING_KEYS,
+} from '../../postings/setup-readiness'
+import { getOrganizationSetting } from '../../settings/settings-service'
+import { stampFulfillment } from '../orders/fulfill'
+import { guard } from './guard'
+import { planFulfillmentPosting } from './plan'
+import { readFulfillmentPostingSettings, readUnpostedShipments } from './reads'
+import type {
+  FulfillmentPostingGroup,
+  FulfillmentPostingPlan,
+  FulfillmentPostingRequest,
+  FulfillmentPostingRunSummary,
+} from './types'
+
+const logger = createScopedLogger('money-fulfillment-posting')
+
+/**
+ * The `postEntry` statuses that mean the LEDGER took the entry.
+ *
+ * The same set `money/orders/fulfill.ts` uses, minus `already_posted`: see the
+ * file header. `not_connected` and `disabled` stay in, because an org with no
+ * accounting provider connected is a first-class case (decision P1) - the entry
+ * is built, balanced and persisted identically and simply never pushed, so its
+ * shipments are posted and must be stamped.
+ */
+const POSTED_STATUSES = new Set<string>(['posted', 'healed', 'not_connected', 'disabled'])
+
+/** One progress line per this many groups, so a long run is observable. */
+const PROGRESS_EVERY = 10
+
+/**
+ * What the dialog renders: the plan, plus the reason the run would refuse to
+ * execute it.
+ *
+ * ⚠️ The plan is computed and returned EVEN WHEN `refusal` is set. A person
+ * whose book time zone is unset still needs to see that 531 shipments are
+ * waiting, or they cannot tell whether fixing one settings row is worth doing.
+ * A non-null `refusal` means {@link runFulfillmentPosting} will write nothing,
+ * and the caller must not offer the confirm button.
+ */
+export interface FulfillmentPostingPreview {
+  plan: FulfillmentPostingPlan
+  refusal: string | null
+}
+
+/**
+ * What the run WOULD post, without writing anything.
+ *
+ * Runs the same read and the same pure plan `runFulfillmentPosting` runs, so
+ * what the dialog shows is what the run would freeze.
+ */
+export async function previewFulfillmentPosting(
+  db: Database,
+  request: FulfillmentPostingRequest
+): Promise<Result<FulfillmentPostingPreview, Error>> {
+  const { organizationId, range, grouping } = request
+
+  return guard(
+    async () => {
+      const prepared = await prepare(db, request)
+      return { plan: prepared.plan, refusal: prepared.refusal }
+    },
+    'Failed to preview a bulk fulfillment posting',
+    { organizationId, from: range.from, to: range.to, grouping }
+  )
+}
+
+/**
+ * Post one entry per group and stamp every shipment it covers.
+ *
+ * @returns a summary, never a throw. A caller that ignores it is behaving
+ *   correctly; the `auto` lane does exactly that.
+ */
+export async function runFulfillmentPosting(
+  db: Database,
+  request: FulfillmentPostingRequest
+): Promise<FulfillmentPostingRunSummary> {
+  const { organizationId, range, grouping } = request
+  const summary: FulfillmentPostingRunSummary = {
+    posted: [],
+    skipped: [],
+    failed: [],
+    exclusions: [],
+  }
+
+  try {
+    const prepared = await prepare(db, request)
+    if (prepared.refusal) {
+      // 🛑 A run-level refusal has no group to hang on, and the summary type is
+      // the seam five lanes are built against, so it lands in `skipped` under
+      // the range's own key. `skipped` is "declined without error", which is
+      // exactly what an unset book time zone is. Nothing is written, and the
+      // exclusions are deliberately left empty: nothing was decided about an
+      // individual shipment.
+      summary.skipped.push({
+        groupKey: `${range.from}..${range.to}`,
+        status: 'refused',
+        reason: prepared.refusal,
+      })
+      return summary
+    }
+
+    const { plan, ledgerCurrency } = prepared
+    summary.exclusions = plan.exclusions
+    if (plan.groups.length === 0) return summary
+
+    // Nobody pressed a button on the `auto` lane, and attributing the write to
+    // whoever last synced would put a person's name on a decision the system
+    // made. Same call `ensureStandardCost` makes. Resolved AFTER the refusal
+    // gate, because a refused run writes nothing and needs no writer.
+    const actorUserId =
+      request.actorUserId ?? (await getOrgCache().get(organizationId, 'systemUser'))
+
+    let written = 0
+    for (const group of plan.groups) {
+      // 🛑 One refused group must not lose the rest of the run.
+      try {
+        await executeGroup(db, request, { group, ledgerCurrency, actorUserId }, summary)
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error)
+        summary.failed.push({ groupKey: group.groupKey, reason })
+        logger.error('A fulfillment posting group failed; continuing with the run', {
+          organizationId,
+          groupKey: group.groupKey,
+          reason,
+        })
+      }
+      written += 1
+      if (written % PROGRESS_EVERY === 0) {
+        logger.info('Posting fulfillments', { organizationId, written, of: plan.groups.length })
+      }
+    }
+
+    logger.info('Posted fulfillments', {
+      organizationId,
+      grouping,
+      from: range.from,
+      to: range.to,
+      groups: plan.groups.length,
+      posted: summary.posted.length,
+      skipped: summary.skipped.length,
+      failed: summary.failed.length,
+      excluded: summary.exclusions.length,
+    })
+    return summary
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    summary.failed.push({ groupKey: `${range.from}..${range.to}`, reason })
+    logger.error('A bulk fulfillment posting run failed before it wrote anything', {
+      organizationId,
+      from: range.from,
+      to: range.to,
+      reason,
+    })
+    return summary
+  }
+}
+
+/** Everything a run resolves once, before any entry is built. */
+interface PreparedRun {
+  plan: FulfillmentPostingPlan
+  ledgerCurrency: string
+  /**
+   * Why the run will write nothing, or null when it may proceed.
+   *
+   * ⚠️ The plan is computed EITHER WAY. A person whose book time zone is unset
+   * still needs to see that 531 shipments are waiting, or they cannot tell
+   * whether fixing one settings row is worth doing. `runFulfillmentPosting`
+   * stops on a non-null value; the preview renders both.
+   */
+  refusal: string | null
+}
+
+/**
+ * Read the settings, read the shipments, plan them, and say whether the books
+ * can take an entry at all.
+ *
+ * One function so the preview and the run cannot disagree about either half.
+ */
+async function prepare(db: Database, request: FulfillmentPostingRequest): Promise<PreparedRun> {
+  const { organizationId, range, grouping } = request
+
+  const [settingsResult, setupState] = await Promise.all([
+    readFulfillmentPostingSettings(db, organizationId),
+    getOrganizationSetting({
+      organizationId,
+      key: OPENING_BASELINE_SETTING_KEYS.setupState,
+    }),
+  ])
+  if (settingsResult.isErr()) throw settingsResult.error
+  const settings = settingsResult.value
+
+  const refusal = resolveRefusal(setupState, settings.timeZone)
+
+  const shipmentsResult = await readUnpostedShipments(db, { organizationId, range })
+  if (shipmentsResult.isErr()) throw shipmentsResult.error
+
+  const plan = planFulfillmentPosting({
+    shipments: shipmentsResult.value,
+    grouping,
+    cutoffPeriod: settings.cutoffPeriod,
+    lockedThroughMonth: settings.lockedThroughMonth,
+    ledgerCurrency: settings.ledgerCurrency,
+    // 🛑 `'UTC'` only reaches the plan on a run that is ALREADY refused for the
+    // missing zone, and the plan does not read it: `shippedAt` is a calendar
+    // date in the book zone already, so grouping is string arithmetic. See
+    // `plan.ts`'s header.
+    timeZone: settings.timeZone ?? 'UTC',
+  })
+
+  return { plan, ledgerCurrency: settings.ledgerCurrency, refusal }
+}
+
+/**
+ * Why a run would write nothing, or null when the books can take an entry.
+ *
+ * The two refusals are the two states where posting would be a guess rather
+ * than a record:
+ *
+ * - **`accounting.setupState` is not `finalized`.** The same gate
+ *   `readOpeningBaseline` applies and `close-month.ts` classifies as
+ *   `setup_incomplete`: an organization with no opening baseline has no books
+ *   for these entries to join.
+ * - **No `accounting.bookTimeZone`.** 44 lane 4's rule. Every entry is dated to
+ *   a shipping day and lands in the month that day falls in, so a zone-less run
+ *   dates revenue into the wrong month invisibly and uncorrectably once that
+ *   month is locked.
+ *
+ * Setup is checked FIRST: an org that has not finished the wizard has not set
+ * the time zone either, and naming the zone would send them to the wrong screen.
+ */
+function resolveRefusal(setupState: unknown, timeZone: string | null): string | null {
+  if (setupState !== FINALIZED_SETUP_STATE) {
+    return (
+      'Accounting setup for this organization is not finalized ' +
+      `(${OPENING_BASELINE_SETTING_KEYS.setupState} is ${describe(setupState)}, expected ` +
+      `"${FINALIZED_SETUP_STATE}"). There is no opening baseline for these entries to join, ` +
+      'so nothing is posted. Finish the accounting setup wizard and run again.'
+    )
+  }
+  if (!timeZone) {
+    return (
+      `The book time zone (${OPENING_BASELINE_SETTING_KEYS.bookTimeZone}) is not set. Every ` +
+      'entry this run makes is dated to a shipping day and lands in the month that day falls ' +
+      'in, so cutting those days in the wrong zone puts revenue in the wrong month, where it ' +
+      'balances and is invisible. Set the book time zone and run again.'
+    )
+  }
+  return null
+}
+
+/** Build, post and stamp one group. Throws only what the group layer records. */
+async function executeGroup(
+  db: Database,
+  request: FulfillmentPostingRequest,
+  context: { group: FulfillmentPostingGroup; ledgerCurrency: string; actorUserId: string },
+  summary: FulfillmentPostingRunSummary
+): Promise<void> {
+  const { organizationId } = request
+  const { group, ledgerCurrency, actorUserId } = context
+
+  // 🛑 The attempt is counted BEFORE the build, off the ledger itself. A day
+  // key claims the day once, and a late order backfilled into an already-posted
+  // day needs the next attempt (§8.2). A reversed run leaves its reversal
+  // standing at the same key, which is why the count includes it - so the day
+  // that was reversed comes back as attempt N+1 rather than colliding with the
+  // reversed original's tuple and converging to `already_posted`.
+  const attempt = await countLiveGroupPostings(db, organizationId, group.groupKey)
+  const built = buildFulfillmentBatchEntry({
+    group,
+    ledgerCurrency,
+    attempt,
+    ...(request.memo ? { memo: request.memo } : {}),
+  })
+
+  const lock = await resolvePeriodLock(organizationId)
+  const post = await postEntry(db, {
+    organizationId,
+    entry: built.entry,
+    actorUserId,
+    lock,
+    memo: request.memo ?? `Fulfillments shipped ${group.groupKey}`,
+  })
+
+  if (post.status === 'already_posted' || !POSTED_STATUSES.has(post.status)) {
+    summary.skipped.push({
+      groupKey: group.groupKey,
+      status: post.status,
+      reason:
+        post.status === 'already_posted'
+          ? `Period key ${built.periodKey} is already claimed by ${post.docNumber ?? 'another entry'}. ` +
+            'Nothing was posted and no shipment was stamped - stamping them onto an entry this run ' +
+            'did not make would attach them to numbers this run did not compute.'
+          : (post.error ?? `The ledger declined the entry (${post.status})`),
+    })
+    return
+  }
+
+  const glPostingId = post.glPostingId
+  if (!glPostingId) {
+    // Unreachable by contract - every accepted status carries the claimed row -
+    // and recorded rather than asserted, because a run that threw here would
+    // lose the groups after it.
+    summary.skipped.push({
+      groupKey: group.groupKey,
+      status: post.status,
+      reason: 'The ledger accepted the entry but named no posting, so nothing could be stamped',
+    })
+    return
+  }
+
+  summary.posted.push({
+    groupKey: group.groupKey,
+    postingId: glPostingId,
+    docNumber: post.docNumber ?? '',
+    shipments: group.shipments.length,
+  })
+
+  const unstamped: string[] = []
+  for (const shipment of group.shipments) {
+    // 🛑 One order's lock contention must not lose the rest of the group's
+    // stamps: every shipment left unstamped is a shipment the next run would
+    // post a SECOND time.
+    try {
+      await stampFulfillment(db, {
+        organizationId,
+        actorUserId,
+        orderId: shipment.orderId,
+        sequence: shipment.sequence,
+        patch: {
+          glPostingId,
+          docNumber: post.docNumber ?? null,
+          // The amounts the BATCH builder computed, not whatever the log was
+          // carrying. `subtotalMinor` goes back too, because it is what the
+          // next shipment of this order allocates its tax against.
+          totalMinor: shipment.amounts.totalMinor,
+          subtotalMinor: shipment.amounts.subtotalMinor,
+        },
+      })
+    } catch (error) {
+      unstamped.push(`${shipment.orderNumber || shipment.orderId} shipment ${shipment.sequence}`)
+      logger.error('A posted shipment could not be stamped', {
+        organizationId,
+        groupKey: group.groupKey,
+        orderId: shipment.orderId,
+        sequence: shipment.sequence,
+        glPostingId,
+        error,
+      })
+    }
+  }
+
+  if (unstamped.length > 0) {
+    // ⚠️ In `posted` AND in `failed`. The entry is in the books, so `posted` is
+    // the truth about the ledger; `failed` is the only channel that says a
+    // person has to act, and this is the one outcome in the feature that
+    // genuinely needs one - an unstamped shipment reads as unposted and would
+    // be recognised again by the next run.
+    summary.failed.push({
+      groupKey: group.groupKey,
+      reason:
+        `${post.docNumber ?? glPostingId} posted, but ${unstamped.length} shipment(s) could not ` +
+        `be stamped with it: ${unstamped.join(', ')}. They will be offered again by the next ` +
+        'preview and must NOT be posted a second time - stamp them by hand or reverse the entry.',
+    })
+  }
+}
+
+/**
+ * How many LIVE `fulfillment` postings already claim this group's key - the
+ * `attempt` `fulfillmentBatchPeriodKey` appends.
+ *
+ * Counted off `GlPosting` rather than off a source line, because a batch
+ * entry's clearing, revenue, tax and shipping legs summarise under
+ * `fulfillment_batch` and only a terms order leaves an `order`-sourced line
+ * (§2.5) - so a source-line count would read zero for a day of card orders and
+ * re-claim the same key forever.
+ *
+ * `status <> 'reversed'` is what makes a reversed run come back cleanly: the
+ * reversed ORIGINAL stops counting, its reversal (an ordinary `posted` entry at
+ * the same key) keeps counting, so the next attempt is one higher and the run
+ * cannot collide with the tuple the original still occupies.
+ *
+ * The `LIKE` matches the key plus exactly one appended attempt character, which
+ * is the shape `writeOffPeriodKey` established: `buildDocNumber` strips hyphens
+ * and nothing else, so there is no separator to match on.
+ */
+async function countLiveGroupPostings(
+  db: Database,
+  organizationId: string,
+  groupKey: string
+): Promise<number> {
+  const rows = await db
+    .select({ id: schema.GlPosting.id })
+    .from(schema.GlPosting)
+    .where(
+      and(
+        eq(schema.GlPosting.organizationId, organizationId),
+        eq(schema.GlPosting.postingType, 'fulfillment'),
+        ne(schema.GlPosting.status, 'reversed'),
+        or(
+          eq(schema.GlPosting.periodKey, groupKey),
+          like(schema.GlPosting.periodKey, `${groupKey}_`)
+        )
+      )
+    )
+  return rows.length
+}
+
+/** A setting value, rendered short enough to put in a refusal. */
+function describe(value: unknown): string {
+  if (value == null) return 'unset'
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'object') return Array.isArray(value) ? 'an array' : 'an object'
+  return `${typeof value} ${JSON.stringify(value)}`
+}

--- a/packages/lib/src/money/fulfillment-posting/setting-options.ts
+++ b/packages/lib/src/money/fulfillment-posting/setting-options.ts
@@ -1,0 +1,41 @@
+// packages/lib/src/money/fulfillment-posting/setting-options.ts
+
+/**
+ * The `SINGLE_SELECT` option list for `accounting.fulfillmentPosting`
+ * (`plans/money/tasks/49-bulk-fulfillment-posting.md` §2.4, §8.4 decision 1).
+ *
+ * Its own file, and a tiny one, for two reasons:
+ *
+ * 1. **`settings/catalog.ts` must stay client-safe.** The catalog is imported by
+ *    `settings/client.ts` and rendered by the settings form, so anything it
+ *    reaches has to be free of `@auxx/database`, `bullmq` and friends.
+ *    `auto.ts` - the module that READS this setting - enqueues a BullMQ job, so
+ *    the catalog cannot import it. `PAYMENT_ROUTE_SETTING_OPTIONS` lives in
+ *    `money/bank-deposits/route.ts` because that file happens to be pure; this
+ *    one is the same idea with the pure half split out.
+ * 2. **One list, not two.** A second copy of the two modes would let the form
+ *    offer a value {@link autoPostFulfillmentsAfterSync} does not recognise,
+ *    which falls back to `manual` silently - the exact failure the payment-route
+ *    comment warns about.
+ *
+ * The VALUES are owned by `types.ts` ({@link FULFILLMENT_POSTING_MODES}); only
+ * the labels are new here, and the exhaustive `Record` below is what makes a
+ * mode added there a type error until it is labelled.
+ */
+
+import { FULFILLMENT_POSTING_MODES, type FulfillmentPostingMode } from './types'
+
+/** What each mode is called on the accounting settings page. */
+const FULFILLMENT_POSTING_MODE_LABELS: Record<FulfillmentPostingMode, string> = {
+  manual: 'Manual, run the posting dialog',
+  auto: 'Automatic after every sync',
+}
+
+/**
+ * The options the `accounting.fulfillmentPosting` row renders, derived from the
+ * mode list so the catalog can never offer a mode the reader does not know.
+ */
+export const FULFILLMENT_POSTING_SETTING_OPTIONS = FULFILLMENT_POSTING_MODES.map((mode) => ({
+  value: mode,
+  label: FULFILLMENT_POSTING_MODE_LABELS[mode],
+}))

--- a/packages/lib/src/money/fulfillment-posting/types.ts
+++ b/packages/lib/src/money/fulfillment-posting/types.ts
@@ -1,0 +1,229 @@
+// packages/lib/src/money/fulfillment-posting/types.ts
+
+/**
+ * The contract the bulk fulfillment posting is written against.
+ *
+ * `plans/money/tasks/49-bulk-fulfillment-posting.md` §2.3, §2.5, §2.6, §8.
+ *
+ * This file is the seam between the halves of the feature and holds no logic:
+ *
+ * - `reads.ts` finds every unposted shipment in a range (the netting read),
+ * - `plan.ts` is PURE and groups, excludes and totals them,
+ * - `run.ts` posts one entry per group and stamps the shipments,
+ * - `postings/build-fulfillment-batch-entry.ts` builds the entry for one group,
+ * - the router and the dialog render it.
+ *
+ * The split follows `builds/backfill-types.ts` exactly, and for the same reason:
+ * the decision has to be testable without a database, a clock or a settings read.
+ *
+ * Client-safe: types and constants only. No `@auxx/database` import.
+ */
+
+/** How many shipments one posting summarises. One entry per group. */
+export type FulfillmentPostingGrouping = 'day' | 'week' | 'month'
+
+export const FULFILLMENT_POSTING_GROUPINGS: readonly FulfillmentPostingGrouping[] = [
+  'day',
+  'week',
+  'month',
+]
+
+/**
+ * Which account the entry debits for one shipment (49 §3.2, §8.4 decision 6).
+ *
+ * Decided per shipment from the order's financial status and gateways, never
+ * from the channel. A card order was paid at checkout and the payout entry
+ * drains clearing; a terms order owes, and aging names the debtor.
+ */
+export type FulfillmentDebitRole = 'clearing_card' | 'clearing_affirm' | 'accounts_receivable'
+
+/**
+ * Why a shipment in the range produces no posting.
+ *
+ * Closed on purpose (44 §7.2b): a caller renders, counts and tests them
+ * exhaustively rather than parsing a sentence. Every exclusion carries the
+ * number or the value that proves its reason in {@link FulfillmentPostingExclusion.detail}.
+ */
+export type FulfillmentPostingExclusionReason =
+  | 'before-cutoff'
+  | 'locked-period'
+  | 'foreign-currency'
+  | 'gateway-ambiguous'
+  | 'test-gateway'
+  | 'zero-value'
+
+export const FULFILLMENT_POSTING_EXCLUSION_REASONS: readonly FulfillmentPostingExclusionReason[] = [
+  'before-cutoff',
+  'locked-period',
+  'foreign-currency',
+  'gateway-ambiguous',
+  'test-gateway',
+  'zero-value',
+]
+
+/** One shipped line inside an unposted shipment, as the builder needs it. */
+export interface UnpostedShipmentLine {
+  lineId: string
+  quantity: number
+  /** Minor units per unit. A RATE, may be fractional. */
+  unitPriceMinor: number
+  /**
+   * This line's tax for the whole line (`line_item_tax_total`), integer minor
+   * units, when the provider supplied it. Null means not supplied, which is not
+   * zero (48 §8.2). The builder allocates the order's tax when any line is null.
+   */
+  lineTaxMinor: number | null
+  /** `line_item_qty`, so a partial-line shipment can scale `lineTaxMinor`. */
+  orderedQuantity: number
+  name?: string
+}
+
+/**
+ * One shipment with no LIVE posting stamped (49 §2.2, §2.6 rule 1): the log
+ * entry's `glPostingId` is null, or names a posting whose status is `reversed`.
+ *
+ * Everything the builder needs travels on it, so `plan.ts` and the builder see
+ * no database.
+ */
+export interface UnpostedShipment {
+  orderId: string
+  orderNumber: string
+  /** The log entry's `sequence`. The stamp is written back by `(orderId, sequence)`. */
+  sequence: number
+  /** `YYYY-MM-DD`, the log entry's `shippedAt`. The recognition date. */
+  shippedAt: string
+  lines: UnpostedShipmentLine[]
+  /** `order_channel`, verbatim. Unknown values recognise as consumer revenue (§8.4 decision 5). */
+  channel: string | null
+  /** `order_currency`, verbatim. Blank reads as the ledger currency. */
+  currency: string | null
+  /** `order_financial_status`, verbatim. */
+  financialStatus: string | null
+  /** `order_payment_gateways`, verbatim, one entry per gateway. Casing as the provider sent it. */
+  gateways: string[]
+  /** `order_subtotal`, integer minor units. */
+  orderSubtotalMinor: number
+  /** `order_tax_total`, integer minor units. */
+  orderTaxTotalMinor: number
+  /** `order_shipping_total`, integer minor units. */
+  orderShippingTotalMinor: number
+  /** Σ `subtotalMinor` of every EARLIER shipment of this order, live or not. */
+  priorShipmentsSubtotalMinor: number
+  /** The log entry's `shippingRecognised`. Exactly one shipment per order carries it. */
+  includeShipping: boolean
+  /** The order's contact, for a screen. Never a posting key. */
+  contactId: string | null
+}
+
+/** Everything the pure plan is allowed to see. No db, no clock, no settings. */
+export interface FulfillmentPostingPlanInput {
+  shipments: readonly UnpostedShipment[]
+  grouping: FulfillmentPostingGrouping
+  /** `accounting.cutoffPeriod`, `YYYY-MM`, or null when unset. Shipments at or before it are excluded. */
+  cutoffPeriod: string | null
+  /** `ledger.lockedThroughMonth`, `YYYY-MM`, or null. Shipments in a locked month are excluded. */
+  lockedThroughMonth: string | null
+  /** The one currency the books are kept in. */
+  ledgerCurrency: string
+  /** `accounting.bookTimeZone`. Week and month buckets are cut in it. */
+  timeZone: string
+}
+
+/** The amounts one shipment contributes, all integer minor units. */
+export interface ShipmentAmounts {
+  debitRole: FulfillmentDebitRole
+  subtotalMinor: number
+  taxMinor: number
+  shippingMinor: number
+  totalMinor: number
+  taxBasis: 'per_line' | 'allocated'
+}
+
+/** One shipment inside a group, with what it will post. */
+export interface PlannedShipment extends UnpostedShipment {
+  amounts: ShipmentAmounts
+}
+
+/** One posting the run will make. */
+export interface FulfillmentPostingGroup {
+  /**
+   * The group's identity and the posting's period key before any attempt
+   * suffix: `2026-07-06` for a day, `2026-W27` for a week, `2026-07` for a month.
+   */
+  groupKey: string
+  /** `YYYY-MM-DD`. The latest `shippedAt` in the group. Never a future date. */
+  txnDate: string
+  shipments: PlannedShipment[]
+  orderCount: number
+  totals: {
+    subtotalMinor: number
+    taxMinor: number
+    shippingMinor: number
+    totalMinor: number
+    /** The debit split, so the preview shows where the money is expected from. */
+    byDebitRole: Record<FulfillmentDebitRole, number>
+  }
+}
+
+export interface FulfillmentPostingExclusion {
+  orderId: string
+  orderNumber: string
+  sequence: number
+  shippedAt: string
+  reason: FulfillmentPostingExclusionReason
+  /** The number or value that proves the reason: the cutoff month, the currency, the gateways. */
+  detail: string
+}
+
+/** What the dialog renders and what the run executes. */
+export interface FulfillmentPostingPlan {
+  grouping: FulfillmentPostingGrouping
+  groups: FulfillmentPostingGroup[]
+  exclusions: FulfillmentPostingExclusion[]
+  footer: {
+    postings: number
+    shipments: number
+    orders: number
+    excluded: number
+    totalMinor: number
+  }
+}
+
+/** The run's input. The plan is recomputed server-side, never client-supplied. */
+export interface FulfillmentPostingRequest {
+  organizationId: string
+  /** Null for the `auto` lane. */
+  actorUserId: string | null
+  /** Half-open on `shippedAt`: `from <= shippedAt < to`, both `YYYY-MM-DD`. */
+  range: { from: string; to: string }
+  grouping: FulfillmentPostingGrouping
+  memo?: string
+}
+
+export interface FulfillmentPostingRunSummary {
+  /** Groups that now carry a live posting. */
+  posted: Array<{ groupKey: string; postingId: string; docNumber: string; shipments: number }>
+  /** Groups the poster declined without error: `already_posted`, `disabled`, `locked` and the like. */
+  skipped: Array<{ groupKey: string; status: string; reason: string }>
+  /** Groups that wrote nothing because something threw. Never re-thrown. */
+  failed: Array<{ groupKey: string; reason: string }>
+  exclusions: FulfillmentPostingExclusion[]
+}
+
+/** A posting an order's shipment log names, for the order's ledger card. */
+export interface OrderFulfillmentPostingRef {
+  sequence: number
+  shippedAt: string
+  glPostingId: string
+  docNumber: string | null
+  /** The posting's status when read, so a reversed stamp renders as such. */
+  status: 'posted' | 'reversed'
+}
+
+/** The `sourceType` the summarised lines of a batch entry carry; `sourceId` is the period key. */
+export const FULFILLMENT_BATCH_SOURCE_TYPE = 'fulfillment_batch'
+
+/** `accounting.fulfillmentPosting` (49 §2.4). */
+export type FulfillmentPostingMode = 'manual' | 'auto'
+export const FULFILLMENT_POSTING_MODES: readonly FulfillmentPostingMode[] = ['manual', 'auto']
+export const FULFILLMENT_POSTING_SETTING_KEY = 'accounting.fulfillmentPosting'

--- a/packages/lib/src/money/index.ts
+++ b/packages/lib/src/money/index.ts
@@ -137,6 +137,22 @@ export {
   unapplyCreditMemo,
   voidCreditMemo,
 } from './credit-memos'
+// ─── Bulk fulfillment posting (plans/money/tasks/49-bulk-fulfillment-posting.md) ──
+// Appended as one block, per HANDOFF §9a's rule for shared barrels.
+export {
+  countUnpostedShipments,
+  type FulfillmentPostingPreview,
+  type FulfillmentPostingSettings,
+  groupKeyFor,
+  isoWeekKey,
+  listOrderFulfillmentPostings,
+  planFulfillmentPosting,
+  previewFulfillmentPosting,
+  readFulfillmentPostingSettings,
+  readUnpostedShipments,
+  runFulfillmentPosting,
+  type UnpostedShipmentRange,
+} from './fulfillment-posting'
 export { createInvoiceFromWorkOrder, deleteInvoiceLine, listUninvoicedLines } from './gather'
 export { deleteInvoice, markInvoiceSent, voidInvoice } from './invoice-lifecycle'
 // ── HANDOFF slot 2K: writing off an invoice's balance to bad debt ──────────
@@ -153,6 +169,7 @@ export {
 // shipped, which a status flip cannot, and that is what makes a second
 // fulfillment able to avoid re-recognising the first.
 export {
+  type FulfillmentStampPatch,
   type FulfillOrderInput,
   type FulfillOrderLine,
   type FulfillOrderResult,
@@ -173,6 +190,7 @@ export {
   requireOrderFieldContext,
   shippedByLine,
   shippingStillOwed,
+  stampFulfillment,
 } from './orders'
 export {
   disconnectPaymentAccount,

--- a/packages/lib/src/money/orders/__tests__/client.test.ts
+++ b/packages/lib/src/money/orders/__tests__/client.test.ts
@@ -39,6 +39,7 @@ function line(overrides: Partial<OrderLineRemaining> = {}): OrderLineRemaining {
     shippedQuantity: 0,
     remainingQuantity: 4,
     unitPriceMinor: 10_000,
+    lineTaxMinor: null,
     sortOrder: 0,
     ...overrides,
   }

--- a/packages/lib/src/money/orders/__tests__/fulfill.test.ts
+++ b/packages/lib/src/money/orders/__tests__/fulfill.test.ts
@@ -28,6 +28,8 @@ const h = vi.hoisted(() => ({
   },
   updated: [] as Array<{ recordId: string; values: Record<string, unknown> }>,
   locks: 0,
+  /** What `buildFulfillmentEntry` was handed, so the per-line tax is assertable. */
+  built: [] as Array<{ shippedLines: Array<{ lineId: string; taxMinor?: number }> }>,
 }))
 
 vi.mock('../reads', async () => {
@@ -47,12 +49,22 @@ vi.mock('../reads', async () => {
 })
 
 vi.mock('../../../postings/build-fulfillment-entry', () => ({
-  buildFulfillmentEntry: () => ({
-    entry: { postingType: 'fulfillment', periodKey: 'ORD0012F1', txnDate: '2026-09-03', lines: [] },
-    totalMinor: 50_00,
-    shippingMinor: 0,
-    revenueRole: 'revenue_dtc',
-  }),
+  buildFulfillmentEntry: (input: {
+    shippedLines: Array<{ lineId: string; taxMinor?: number }>
+  }) => {
+    h.built.push({ shippedLines: input.shippedLines })
+    return {
+      entry: {
+        postingType: 'fulfillment',
+        periodKey: 'ORD0012F1',
+        txnDate: '2026-09-03',
+        lines: [],
+      },
+      totalMinor: 50_00,
+      shippingMinor: 0,
+      revenueRole: 'revenue_dtc',
+    }
+  },
 }))
 
 vi.mock('../../../postings/post-entry', () => ({
@@ -173,6 +185,7 @@ beforeEach(() => {
   h.postResult = { status: 'posted', glPostingId: 'glp_1', docNumber: 'AUXX-FUL-ORD0012F1' }
   h.updated = []
   h.locks = 0
+  h.built = []
 })
 
 describe('the append re-reads the stored log under a lock', () => {
@@ -254,5 +267,38 @@ describe('the rollback removes THIS shipment, not everything since the pre-read'
     const log = lastLog()
     expect(log.map((row) => row.sequence)).toEqual([2])
     expect(h.updated.at(-1)?.values.order_fulfillment_status).toBe('unfulfilled')
+  })
+})
+
+// 48 §4.2's payoff: the order's lines now carry `line_item_tax_total`, so the
+// single-order builder's per-line tax branch is reachable at all. It is
+// all-or-nothing by design - one line with no tax sends the WHOLE entry back to
+// allocating the order's total - which is why the two cases below are what
+// matters rather than the arithmetic.
+describe('the per-line tax reaches the builder', () => {
+  it('passes a full-line shipment its whole stored tax', async () => {
+    ;(h.order.lines as Array<Record<string, unknown>>)[0]!.lineTaxMinor = 875
+    await fulfillOrder(stubDb(), { ...input, shippedLines: [{ lineId: 'li_1', quantity: 5 }] })
+
+    expect(h.built[0]?.shippedLines[0]?.taxMinor).toBe(875)
+  })
+
+  // Pro rata on units, rounded - the same formula `computeShipmentAmounts` uses
+  // in the bulk path, so the two doors cannot disagree about one line's tax.
+  it('scales a partial-line shipment pro rata on units', async () => {
+    ;(h.order.lines as Array<Record<string, unknown>>)[0]!.lineTaxMinor = 875
+    await fulfillOrder(stubDb(), { ...input, shippedLines: [{ lineId: 'li_1', quantity: 3 }] })
+
+    expect(h.built[0]?.shippedLines[0]?.taxMinor).toBe(525)
+  })
+
+  // 🛑 Absent, not zero. Zero would claim the channel said this line is
+  // untaxed, and one such line among taxed ones would still count as "every
+  // line carries tax" - flipping the entry onto the per-line basis and
+  // under-crediting sales tax payable, silently.
+  it('omits the key entirely when the line carries no stored tax', async () => {
+    await fulfillOrder(stubDb(), input)
+
+    expect(h.built[0]?.shippedLines[0]).not.toHaveProperty('taxMinor')
   })
 })

--- a/packages/lib/src/money/orders/__tests__/reads.test.ts
+++ b/packages/lib/src/money/orders/__tests__/reads.test.ts
@@ -1,0 +1,95 @@
+// packages/lib/src/money/orders/__tests__/reads.test.ts
+//
+// `parseFulfillments`, the tolerant reader every path into the shipment log
+// goes through: the fulfill dialog, the bulk poster's netting read, the stamp
+// write-back and the delete guard.
+//
+// 🛑 The property that carries this file is that the parser is LOSSLESS for the
+// fields the ledger depends on. It is tolerant on purpose - a row it cannot
+// understand is dropped rather than making the order unfulfillable - and the
+// failure mode of tolerance is dropping a field silently. `subtotalMinor` is
+// the one that bites: `shippedSubtotalMinor` sums it into the builder's
+// `priorShipmentsSubtotalMinor`, so a parser that dropped it made every read
+// report zero prior subtotal, and the second shipment of a split order
+// allocated tax as if it were the first.
+
+import { describe, expect, it } from 'vitest'
+import { parseFulfillments } from '../reads'
+
+/** The column's real shape: the field-value envelope around our own wrapper. */
+function stored(fulfillments: unknown[]) {
+  return { v: { fulfillments } }
+}
+
+const ROW = {
+  sequence: 2,
+  shippedAt: '2026-07-06',
+  lines: [{ lineId: 'li_1', quantity: 3 }],
+  subtotalMinor: 12_500,
+  totalMinor: 13_300,
+  shippingRecognised: true,
+  glPostingId: 'gl_1',
+  docNumber: 'AUXX-FUL-20260706',
+  recordedAt: '2026-07-06T00:00:00.000Z',
+}
+
+describe('parseFulfillments', () => {
+  it('reads back every field it was given', () => {
+    expect(parseFulfillments(stored([ROW]))).toEqual([ROW])
+  })
+
+  // 🛑 The bug this test exists for.
+  it('carries subtotalMinor through, because the next shipment allocates tax against it', () => {
+    expect(parseFulfillments(stored([ROW]))[0]?.subtotalMinor).toBe(12_500)
+  })
+
+  // Optional, not defaulted to zero: rows written before the field existed
+  // contribute nothing, which reproduces the old per-shipment behaviour for
+  // those orders rather than inventing a number for them.
+  it('leaves subtotalMinor absent on a row written before it existed', () => {
+    const { subtotalMinor: _dropped, ...legacy } = ROW
+    expect(parseFulfillments(stored([legacy]))[0]).not.toHaveProperty('subtotalMinor')
+  })
+
+  it('unwraps a bare wrapper with no field-value envelope', () => {
+    expect(parseFulfillments({ fulfillments: [ROW] })).toEqual([ROW])
+  })
+
+  it('reads a top-level array, which is what a pre-envelope row holds', () => {
+    expect(parseFulfillments([ROW])).toEqual([ROW])
+  })
+
+  it('sorts by sequence rather than by stored order', () => {
+    expect(
+      parseFulfillments(stored([{ ...ROW, sequence: 3 }, ROW])).map((row) => row.sequence)
+    ).toEqual([2, 3])
+  })
+
+  it('drops a row with no usable sequence rather than refusing the whole log', () => {
+    expect(parseFulfillments(stored([{ ...ROW, sequence: 'first' }, ROW]))).toEqual([ROW])
+  })
+
+  it('drops a line with no id or a non-positive quantity', () => {
+    const rows = parseFulfillments(
+      stored([
+        {
+          ...ROW,
+          lines: [
+            { lineId: 'li_1', quantity: 3 },
+            { quantity: 1 },
+            { lineId: 'li_2', quantity: 0 },
+          ],
+        },
+      ])
+    )
+
+    expect(rows[0]?.lines).toEqual([{ lineId: 'li_1', quantity: 3 }])
+  })
+
+  it('reads nothing at all as an empty log', () => {
+    expect(parseFulfillments(null)).toEqual([])
+    expect(parseFulfillments(undefined)).toEqual([])
+    expect(parseFulfillments({ v: null })).toEqual([])
+    expect(parseFulfillments('not json')).toEqual([])
+  })
+})

--- a/packages/lib/src/money/orders/client.ts
+++ b/packages/lib/src/money/orders/client.ts
@@ -93,6 +93,16 @@ export interface OrderLineRemaining {
   remainingQuantity: number
   /** Minor units per unit. A RATE - it may be fractional. */
   unitPriceMinor: number
+  /**
+   * This line's own tax for the WHOLE line (`line_item_tax_total`), integer
+   * minor units, when the provider supplied it.
+   *
+   * 🛑 **Null is not zero** (48 §8.2). Null means the sales channel said
+   * nothing about this line's tax, and the fulfillment builder then allocates
+   * the ORDER's tax pro rata instead. Reading null as zero would recognise a
+   * taxed order as untaxed and leave `sales_tax_payable` permanently short.
+   */
+  lineTaxMinor: number | null
   sortOrder: number
 }
 

--- a/packages/lib/src/money/orders/fulfill.ts
+++ b/packages/lib/src/money/orders/fulfill.ts
@@ -48,11 +48,13 @@ import { resolvePeriodLock } from '../../postings/period-lock'
 import { LEDGER_CURRENCY, postEntry, previewEntry } from '../../postings/post-entry'
 import type { EntryPreview, PostResult } from '../../postings/types'
 import { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
+import { toRecordId } from '../../resources/resource-id'
 import {
   fulfillmentStatusFor,
   nextFulfillmentSequence,
   type OrderFulfillment,
   type OrderFulfillmentsEnvelope,
+  type OrderLineRemaining,
   shippedSubtotalMinor,
 } from './client'
 import { guard } from './guard'
@@ -129,6 +131,37 @@ function assertIsoDate(value: string, label: string): void {
 }
 
 /**
+ * This line's tax for the units that actually shipped, or `undefined` when the
+ * sales channel supplied no per-line tax at all.
+ *
+ * 🛑 `undefined` is the honest answer to "we were told nothing", and it is what
+ * makes `buildFulfillmentEntry` fall back to allocating the ORDER's tax. Zero
+ * would claim the channel said this line is untaxed, and one such line among
+ * taxed ones would still count as "every line carries tax", so the entry would
+ * switch to the per-line basis and under-credit `sales_tax_payable` silently.
+ *
+ * A partial shipment scales pro rata on units and rounds, matching
+ * `computeShipmentAmounts` in `postings/build-fulfillment-batch-entry.ts` so
+ * the single-order and bulk paths cannot disagree about one line's tax.
+ */
+function shippedLineTaxMinor(line: OrderLineRemaining, quantity: number): number | undefined {
+  if (line.lineTaxMinor == null) return undefined
+  if (!Number.isFinite(line.quantity) || line.quantity <= 0) return undefined
+  if (quantity >= line.quantity) return line.lineTaxMinor
+  return Math.round((line.lineTaxMinor * quantity) / line.quantity)
+}
+
+/** One validated shipped line, in the shape `buildFulfillmentEntry` takes. */
+interface ResolvedShippedLine {
+  lineId: string
+  quantity: number
+  unitPriceMinor: number
+  /** Present only when the line carries `line_item_tax_total`. */
+  taxMinor?: number
+  name: string
+}
+
+/**
  * Validate what the caller says shipped against what is actually left, and
  * shape it for the builder.
  *
@@ -139,15 +172,10 @@ function assertIsoDate(value: string, label: string): void {
 function resolveShippedLines(
   order: OrderForFulfillment,
   requested: FulfillOrderLine[]
-): Array<{ lineId: string; quantity: number; unitPriceMinor: number; name: string }> {
+): ResolvedShippedLine[] {
   const byId = new Map(order.lines.map((line) => [line.lineId, line]))
   const seen = new Set<string>()
-  const resolved: Array<{
-    lineId: string
-    quantity: number
-    unitPriceMinor: number
-    name: string
-  }> = []
+  const resolved: ResolvedShippedLine[] = []
 
   for (const request of requested) {
     if (seen.has(request.lineId)) {
@@ -180,10 +208,12 @@ function resolveShippedLines(
         }
       )
     }
+    const taxMinor = shippedLineTaxMinor(line, request.quantity)
     resolved.push({
       lineId: line.lineId,
       quantity: request.quantity,
       unitPriceMinor: line.unitPriceMinor,
+      ...(taxMinor === undefined ? {} : { taxMinor }),
       name: line.name,
     })
   }
@@ -390,26 +420,17 @@ export async function fulfillOrder(
 
       // Stamp the posting onto the shipment it belongs to, so the order can
       // name its entry without a join.
-      //
-      // 🛑 Re-read again, and REPLACE the one row by sequence rather than
-      // rebuilding the log from the pre-read copy. Between the commit above and
-      // this write another shipment can land; rebuilding would drop it and put
-      // its units back into "unshipped", where the next fulfillment would
-      // re-ship them and recognise their revenue twice.
       const settled: OrderFulfillment = {
         ...fulfillment,
         glPostingId: post.glPostingId ?? null,
         docNumber: post.docNumber ?? null,
       }
-      await db.transaction(async (tx) => {
-        const txDb = tx as unknown as Database
-        await lockOrder(txDb, organizationId, orderId)
-        const stored = await readStoredFulfillments(txDb, organizationId, orderId)
-        const stamped = stored.map((row) => (row.sequence === settled.sequence ? settled : row))
-        const txCrud = new UnifiedCrudHandler(organizationId, actorUserId, txDb)
-        await txCrud.update(order.recordId, {
-          order_fulfillments: fulfillmentsEnvelope(stamped),
-        })
+      await stampFulfillment(db, {
+        organizationId,
+        actorUserId,
+        orderId,
+        sequence: settled.sequence,
+        patch: { glPostingId: settled.glPostingId, docNumber: settled.docNumber },
       })
 
       logger.info('Fulfilled an order', {
@@ -427,6 +448,78 @@ export async function fulfillOrder(
     'Failed to fulfil an order',
     { organizationId, orderId }
   )
+}
+
+/**
+ * What a stamp may change on one shipment. Everything else on the row is
+ * history and stays exactly as it was written.
+ */
+export interface FulfillmentStampPatch {
+  /** The `GlPosting` this shipment now belongs to. */
+  glPostingId?: string | null
+  docNumber?: string | null
+  /**
+   * The recognised total, when the posting that took the shipment computed a
+   * different one from the row's own. The bulk poster does: a group's builder
+   * re-derives every shipment's amounts, and the log has to name what was
+   * actually posted rather than what a single-order builder once thought.
+   */
+  totalMinor?: number
+  subtotalMinor?: number
+}
+
+/**
+ * Write a posting's identity back onto ONE shipment of an order's log.
+ *
+ * Extracted from {@link fulfillOrder}'s post-commit transaction so the bulk
+ * poster (`money/fulfillment-posting/run.ts`) stamps through exactly the same
+ * three steps. Two writers of one JSON cell that took the lock differently
+ * would be the lost update this whole module is built to avoid, and the bulk
+ * lane stamps DOZENS of orders per run, so it is the writer that would find it.
+ *
+ * 🛑 The log is re-read under a `SELECT ... FOR UPDATE` on the order row and the
+ * named row is PATCHED in place, rather than the caller's copy being written
+ * back. `order_fulfillments` is a single JSON cell and every write of it is a
+ * whole-cell replace: between the caller's read and this write another shipment
+ * can land, and writing the copy back would drop it. A dropped shipment's units
+ * read as UNSHIPPED, so the next fulfillment re-ships them and recognises their
+ * revenue a second time - under a new sequence, so the posting claim's unique
+ * index cannot catch it either.
+ *
+ * A sequence that is not in the stored log writes nothing at all. That is the
+ * right answer for a shipment somebody removed while the posting was in flight:
+ * inventing the row back would resurrect a shipment a person deleted.
+ *
+ * @throws whatever the transaction throws. The callers are inside a `guard` or
+ *   a never-throws run, and a stamp that silently failed would leave a posted
+ *   shipment looking unposted - which the netting read would then post again.
+ */
+export async function stampFulfillment(
+  db: Database,
+  params: {
+    organizationId: string
+    /** Who the write is attributed to. The `systemUser` for an unattended run. */
+    actorUserId: string
+    orderId: string
+    /** The `OrderFulfillment.sequence` to stamp. */
+    sequence: number
+    patch: FulfillmentStampPatch
+  }
+): Promise<void> {
+  const { organizationId, actorUserId, orderId, sequence, patch } = params
+  const ctx = await requireOrderFieldContext(organizationId)
+  const recordId = toRecordId(ctx.orderDefId, orderId)
+
+  await db.transaction(async (tx) => {
+    const txDb = tx as unknown as Database
+    await lockOrder(txDb, organizationId, orderId)
+    const stored = await readStoredFulfillments(txDb, organizationId, orderId)
+    if (!stored.some((row) => row.sequence === sequence)) return
+
+    const stamped = stored.map((row) => (row.sequence === sequence ? { ...row, ...patch } : row))
+    const txCrud = new UnifiedCrudHandler(organizationId, actorUserId, txDb)
+    await txCrud.update(recordId, { order_fulfillments: fulfillmentsEnvelope(stamped) })
+  })
 }
 
 /**

--- a/packages/lib/src/money/orders/index.ts
+++ b/packages/lib/src/money/orders/index.ts
@@ -21,11 +21,13 @@ export {
   shippingStillOwed,
 } from './client'
 export {
+  type FulfillmentStampPatch,
   type FulfillOrderInput,
   type FulfillOrderLine,
   type FulfillOrderResult,
   fulfillOrder,
   previewFulfillment,
+  stampFulfillment,
 } from './fulfill'
 export {
   loadOrderFieldContext,

--- a/packages/lib/src/money/orders/reads.ts
+++ b/packages/lib/src/money/orders/reads.ts
@@ -21,6 +21,7 @@
  */
 
 import { type Database, schema } from '@auxx/database'
+import type { CustomFieldEntity } from '@auxx/database/types'
 import { readEnvelope } from '@auxx/types/field-value'
 import { and, eq, inArray } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
@@ -36,7 +37,17 @@ import {
 } from './client'
 import { guard } from './guard'
 
-/** Every `order` attribute a fulfillment reads or writes. */
+/**
+ * Every `order` attribute a fulfillment reads or writes.
+ *
+ * The last three are read by the BULK poster
+ * (`money/fulfillment-posting/reads.ts`) rather than by the single-order path:
+ * the debit fork needs the financial status and the gateways
+ * (`postings/build-fulfillment-batch-entry.ts`), and the contact is carried for
+ * a screen. They live here because {@link OrderFieldContext} is the one place
+ * the order def and its field ids are resolved through the org cache, and a
+ * second resolver would be a second thing to keep in step.
+ */
 const ORDER_ATTRIBUTES = [
   'order_number',
   'order_channel',
@@ -48,6 +59,9 @@ const ORDER_ATTRIBUTES = [
   'order_fulfillment_status',
   'order_line_items',
   'order_fulfillments',
+  'order_financial_status',
+  'order_payment_gateways',
+  'order_contact',
 ] as const
 
 /** Every `line_item` attribute a fulfillment reads. */
@@ -55,17 +69,26 @@ const LINE_ATTRIBUTES = [
   'line_item_name',
   'line_item_qty',
   'line_item_unit_price',
+  'line_item_tax_total',
   'line_item_sort_order',
 ] as const
 
 type OrderAttribute = (typeof ORDER_ATTRIBUTES)[number]
 type LineAttribute = (typeof LINE_ATTRIBUTES)[number]
 
-/** The resolved def and field ids every order read needs. */
+/**
+ * The resolved def and fields every order read needs.
+ *
+ * ⚠️ The WHOLE `CustomFieldEntity`, not just its id. `order_payment_gateways`
+ * is a TAGS field whose values are stored as opaque option keys, so the bulk
+ * poster has to resolve them back to gateway NAMES through the field's own
+ * `options` (`resources/registry/option-helpers.ts`). Narrowing this to
+ * `{ id }` would force a second read of the same cached row.
+ */
 export interface OrderFieldContext {
   orderDefId: string
-  order: Record<OrderAttribute, { id: string } | null>
-  line: Record<LineAttribute, { id: string } | null>
+  order: Record<OrderAttribute, CustomFieldEntity | null>
+  line: Record<LineAttribute, CustomFieldEntity | null>
 }
 
 /**
@@ -86,8 +109,8 @@ export async function loadOrderFieldContext(
   const fields = await getOrgCache()
     .from(organizationId, 'customFields')
     .bySystemAttributes([...ORDER_ATTRIBUTES, ...LINE_ATTRIBUTES])
-  const order = fields as unknown as Record<OrderAttribute, { id: string } | null>
-  const line = fields as unknown as Record<LineAttribute, { id: string } | null>
+  const order: Record<OrderAttribute, CustomFieldEntity | null> = fields
+  const line: Record<LineAttribute, CustomFieldEntity | null> = fields
   // Without the number there is no period key, and without the log there is no
   // "how much is still to ship". Both reduce fulfillment to guessing.
   if (!order.order_number || !order.order_fulfillments) return null
@@ -176,6 +199,15 @@ export function parseFulfillments(value: unknown): OrderFulfillment[] {
         if (!Number.isFinite(quantity) || quantity <= 0) return []
         return [{ lineId, quantity }]
       }),
+      // 🛑 Carried through, not dropped. `shippedSubtotalMinor` sums it to give
+      // the builder `priorShipmentsSubtotalMinor`, which is what makes the
+      // cumulative tax allocation true itself up on the shipment that completes
+      // the order. A parser that dropped it made every read report zero prior
+      // subtotal, so the second shipment of a split order allocated as if it
+      // were the first and A/R stayed a cent short forever.
+      ...(typeof candidate.subtotalMinor === 'number'
+        ? { subtotalMinor: candidate.subtotalMinor }
+        : {}),
       totalMinor: typeof candidate.totalMinor === 'number' ? candidate.totalMinor : 0,
       shippingRecognised: candidate.shippingRecognised === true,
       glPostingId: typeof candidate.glPostingId === 'string' ? candidate.glPostingId : null,
@@ -232,7 +264,7 @@ export async function readOrderForFulfillment(
       }
 
       const orderFieldIds = Object.values(ctx.order)
-        .filter((field): field is { id: string } => field != null)
+        .filter((field): field is CustomFieldEntity => field != null)
         .map((field) => field.id)
       const rows = await selectValues(db, organizationId, [orderId], orderFieldIds)
       const bucket = rows.get(orderId)
@@ -294,7 +326,7 @@ async function readOrderLines(
   if (lineIds.length === 0) return []
 
   const fieldIds = Object.values(ctx.line)
-    .filter((field): field is { id: string } => field != null)
+    .filter((field): field is CustomFieldEntity => field != null)
     .map((field) => field.id)
   if (fieldIds.length === 0) return []
 
@@ -315,6 +347,11 @@ async function readOrderLines(
       shippedQuantity,
       remainingQuantity: Math.max(0, quantity - shippedQuantity),
       unitPriceMinor: cell('line_item_unit_price')?.valueNumber ?? 0,
+      // 🛑 `?? null`, never `?? 0`. An absent row and a zero row are different
+      // facts, and the builder branches on the difference: every line carrying
+      // a number switches the entry to per-line tax, one null falls back to
+      // allocating the order's total. See `OrderLineRemaining.lineTaxMinor`.
+      lineTaxMinor: cell('line_item_tax_total')?.valueNumber ?? null,
       sortOrder: cell('line_item_sort_order')?.valueNumber ?? index,
     }
   })

--- a/packages/lib/src/postings/__tests__/build-fulfillment-batch-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-fulfillment-batch-entry.test.ts
@@ -1,0 +1,736 @@
+// packages/lib/src/postings/__tests__/build-fulfillment-batch-entry.test.ts
+//
+// The batch builder turns a day of shipments into ONE posting, so the things
+// that can go wrong here are different from the single-order builder's:
+//
+//  1. **The debit fork.** A Shopify order was paid at checkout. Debiting
+//     `accounts_receivable` for it fills aging with money nobody owes and
+//     leaves `clearing_card` permanently negative once a payout drains it -
+//     and every one of those entries balances. So the fork gets a table test
+//     covering every rule, including the two that EXCLUDE.
+//  2. **Balance by construction.** Debits are each shipment's total and
+//     credits are the same numbers decomposed, so a mixed group (card, Affirm,
+//     terms across two orders, a tax-exempt order and a split shipment) must
+//     balance without `buildEntry` having anything to say about it.
+//  3. **The keyspace.** A day key claims its day once; a late order backfilled
+//     into a posted day needs the attempt suffix, and the whole budget is one
+//     character wide.
+
+import { describe, expect, it } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import type {
+  FulfillmentDebitRole,
+  FulfillmentPostingGroup,
+  PlannedShipment,
+  UnpostedShipment,
+} from '../../money/fulfillment-posting/types'
+import { FULFILLMENT_BATCH_SOURCE_TYPE } from '../../money/fulfillment-posting/types'
+import { ACCOUNT_ROLES } from '../build-entry'
+import {
+  buildFulfillmentBatchEntry,
+  computeShipmentAmounts,
+  FULFILLMENT_DEBIT_ACCOUNT_ROLE,
+  type FulfillmentBatchSource,
+  fulfillmentBatchPeriodKey,
+  MAX_COMPACT_FULFILLMENT_BATCH_KEY,
+  MAX_FULFILLMENT_BATCH_ATTEMPT,
+  resolveFulfillmentDebit,
+} from '../build-fulfillment-batch-entry'
+import { FULFILLMENT_SOURCE_TYPE } from '../build-fulfillment-entry'
+import { buildDocNumber, DOC_NUMBER_MAX_LENGTH } from '../doc-number'
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+let nextOrder = 0
+
+/** One unposted shipment, paid by card unless the test says otherwise. */
+function shipment(overrides: Partial<UnpostedShipment> = {}): UnpostedShipment {
+  nextOrder += 1
+  const number = overrides.orderNumber ?? `#${1000 + nextOrder}`
+  return {
+    orderId: overrides.orderId ?? `order-${nextOrder}`,
+    orderNumber: number,
+    sequence: 1,
+    shippedAt: '2026-07-06',
+    lines: [
+      { lineId: 'l1', quantity: 1, unitPriceMinor: 10_000, lineTaxMinor: null, orderedQuantity: 1 },
+    ],
+    channel: 'dtc',
+    currency: 'USD',
+    financialStatus: 'paid',
+    gateways: ['shopify_payments'],
+    orderSubtotalMinor: 10_000,
+    orderTaxTotalMinor: 800,
+    orderShippingTotalMinor: 1_500,
+    priorShipmentsSubtotalMinor: 0,
+    includeShipping: true,
+    contactId: 'contact-1',
+    ...overrides,
+  }
+}
+
+/** What `plan.ts` hands the builder: a shipment with its amounts already on it. */
+function planned(overrides: Partial<UnpostedShipment> = {}): PlannedShipment {
+  const base = shipment(overrides)
+  const debit = resolveFulfillmentDebit(base)
+  if (debit.kind !== 'debit') throw new Error(`fixture excluded: ${debit.reason}`)
+  return { ...base, amounts: computeShipmentAmounts(base, debit.role) }
+}
+
+/** Total a group the way the plan does, so the builder gets a realistic input. */
+function group(shipments: PlannedShipment[], groupKey = '2026-07-06'): FulfillmentPostingGroup {
+  const byDebitRole: Record<FulfillmentDebitRole, number> = {
+    clearing_card: 0,
+    clearing_affirm: 0,
+    accounts_receivable: 0,
+  }
+  let subtotalMinor = 0
+  let taxMinor = 0
+  let shippingMinor = 0
+  let totalMinor = 0
+  for (const item of shipments) {
+    byDebitRole[item.amounts.debitRole] += item.amounts.totalMinor
+    subtotalMinor += item.amounts.subtotalMinor
+    taxMinor += item.amounts.taxMinor
+    shippingMinor += item.amounts.shippingMinor
+    totalMinor += item.amounts.totalMinor
+  }
+  return {
+    groupKey,
+    txnDate: shipments.reduce(
+      (latest, s) => (s.shippedAt > latest ? s.shippedAt : latest),
+      groupKey
+    ),
+    shipments,
+    orderCount: new Set(shipments.map((s) => s.orderId)).size,
+    totals: { subtotalMinor, taxMinor, shippingMinor, totalMinor, byDebitRole },
+  }
+}
+
+type Entry = ReturnType<typeof buildFulfillmentBatchEntry>['entry']
+
+function linesFor(entry: Entry, role: string) {
+  return entry.lines.filter((line) => line.accountRole === role)
+}
+
+function amountFor(entry: Entry, role: string): number | undefined {
+  const found = linesFor(entry, role)
+  return found.length === 0 ? undefined : found.reduce((sum, line) => sum + line.amount, 0)
+}
+
+// ── 1. The debit fork ───────────────────────────────────────────────────────
+
+describe('resolveFulfillmentDebit', () => {
+  it.each([
+    // [financialStatus, gateways, expected role]
+    ['paid', ['shopify_payments'], 'clearing_card'],
+    ['paid', ['affirm'], 'clearing_affirm'],
+    // Casing and whitespace are the provider's, not a second gateway.
+    ['paid', ['  Affirm '], 'clearing_affirm'],
+    ['PAID', ['SHOPIFY_PAYMENTS'], 'clearing_card'],
+    // A rail nobody has named is still card money: one processor took it, and
+    // `clearing_card` is where a wrong guess fails to reconcile visibly.
+    ['paid', ['paypal'], 'clearing_card'],
+    ['paid', ['stripe'], 'clearing_card'],
+    // Paid, but not on a rail auxx can see. The order still owes.
+    ['paid', ['manual'], 'accounts_receivable'],
+    ['paid', [], 'accounts_receivable'],
+    ['paid', ['  '], 'accounts_receivable'],
+    // Terms and pending: never settled, whatever the gateway says.
+    ['pending', ['shopify_payments'], 'accounts_receivable'],
+    ['authorized', ['affirm'], 'accounts_receivable'],
+    ['partially_paid', [], 'accounts_receivable'],
+    [null, ['shopify_payments'], 'accounts_receivable'],
+    // A refund is its OWN later event (a credit memo). The money was taken.
+    ['refunded', ['shopify_payments'], 'clearing_card'],
+    ['partially_refunded', ['affirm'], 'clearing_affirm'],
+    // One gateway repeated is one gateway.
+    ['paid', ['shopify_payments', 'Shopify_Payments'], 'clearing_card'],
+  ])('%s through %j debits %s', (financialStatus, gateways, role) => {
+    expect(resolveFulfillmentDebit({ financialStatus, gateways })).toEqual({ kind: 'debit', role })
+  })
+
+  it.each([
+    [['bogus'], 'bogus'],
+    [['Bogus'], 'bogus'],
+    // A test order is not a sale in ANY status, so `bogus` is checked before
+    // the financial status rather than after it.
+    [['bogus', 'shopify_payments'], 'bogus, shopify_payments'],
+  ])('excludes the test gateway %j', (gateways, detail) => {
+    expect(resolveFulfillmentDebit({ financialStatus: 'paid', gateways })).toEqual({
+      kind: 'exclude',
+      reason: 'test-gateway',
+      detail,
+    })
+    expect(resolveFulfillmentDebit({ financialStatus: 'pending', gateways })).toMatchObject({
+      kind: 'exclude',
+      reason: 'test-gateway',
+    })
+  })
+
+  it('excludes two distinct gateways, naming them', () => {
+    const answer = resolveFulfillmentDebit({
+      financialStatus: 'paid',
+      gateways: ['shopify_payments', 'Affirm'],
+    })
+    expect(answer).toEqual({
+      kind: 'exclude',
+      reason: 'gateway-ambiguous',
+      detail: 'shopify_payments, affirm',
+    })
+  })
+
+  it('sends a manual gateway to receivables even beside a card one', () => {
+    // `manual` short-circuits ahead of the ambiguity check: the merchant marked
+    // it paid outside a rail, so the receivable is the honest leg.
+    expect(
+      resolveFulfillmentDebit({ financialStatus: 'paid', gateways: ['manual', 'shopify_payments'] })
+    ).toEqual({ kind: 'debit', role: 'accounts_receivable' })
+  })
+
+  it('maps every debit answer to a declared posting role', () => {
+    expect(FULFILLMENT_DEBIT_ACCOUNT_ROLE).toEqual({
+      clearing_card: ACCOUNT_ROLES.CLEARING_CARD,
+      clearing_affirm: ACCOUNT_ROLES.CLEARING_AFFIRM,
+      accounts_receivable: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
+    })
+  })
+})
+
+// ── 2. One shipment's amounts ───────────────────────────────────────────────
+
+describe('computeShipmentAmounts', () => {
+  it('takes tax per line when EVERY line carries one', () => {
+    const amounts = computeShipmentAmounts(
+      shipment({
+        lines: [
+          {
+            lineId: 'a',
+            quantity: 1,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: 825,
+            orderedQuantity: 1,
+          },
+          {
+            lineId: 'b',
+            quantity: 2,
+            unitPriceMinor: 5_000,
+            lineTaxMinor: 825,
+            orderedQuantity: 2,
+          },
+        ],
+        orderSubtotalMinor: 20_000,
+        orderTaxTotalMinor: 1_650,
+        orderShippingTotalMinor: 0,
+      }),
+      'clearing_card'
+    )
+    expect(amounts).toMatchObject({
+      debitRole: 'clearing_card',
+      subtotalMinor: 20_000,
+      taxMinor: 1_650,
+      shippingMinor: 0,
+      totalMinor: 21_650,
+      taxBasis: 'per_line',
+    })
+  })
+
+  it('allocates the order tax when ANY line is missing its own', () => {
+    // Mixing a known per-line tax with an allocated remainder would double-count
+    // the lines that carried one, so it is all or nothing.
+    const amounts = computeShipmentAmounts(
+      shipment({
+        lines: [
+          {
+            lineId: 'a',
+            quantity: 1,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: 825,
+            orderedQuantity: 1,
+          },
+          {
+            lineId: 'b',
+            quantity: 1,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: null,
+            orderedQuantity: 1,
+          },
+        ],
+        orderSubtotalMinor: 20_000,
+        orderTaxTotalMinor: 1_650,
+        orderShippingTotalMinor: 0,
+      }),
+      'clearing_card'
+    )
+    expect(amounts.taxBasis).toBe('allocated')
+    expect(amounts.taxMinor).toBe(1_650)
+  })
+
+  it('scales a line tax to the part of the line that shipped', () => {
+    // 4 units ordered carrying 400 of tax, 3 shipped: round(400 x 3 / 4).
+    const amounts = computeShipmentAmounts(
+      shipment({
+        lines: [
+          {
+            lineId: 'a',
+            quantity: 3,
+            unitPriceMinor: 1_000,
+            lineTaxMinor: 400,
+            orderedQuantity: 4,
+          },
+        ],
+        orderSubtotalMinor: 4_000,
+        orderTaxTotalMinor: 400,
+        orderShippingTotalMinor: 0,
+      }),
+      'clearing_card'
+    )
+    expect(amounts).toMatchObject({ subtotalMinor: 3_000, taxMinor: 300, taxBasis: 'per_line' })
+  })
+
+  it('takes a line tax in full when the ordered quantity cannot scale it', () => {
+    const amounts = computeShipmentAmounts(
+      shipment({
+        lines: [
+          {
+            lineId: 'a',
+            quantity: 2,
+            unitPriceMinor: 1_000,
+            lineTaxMinor: 400,
+            orderedQuantity: 0,
+          },
+        ],
+        orderSubtotalMinor: 2_000,
+        orderTaxTotalMinor: 400,
+        orderShippingTotalMinor: 0,
+      }),
+      'clearing_card'
+    )
+    expect(amounts.taxMinor).toBe(400)
+  })
+
+  it('allocates a later shipment CUMULATIVELY so the two sum to the order tax', () => {
+    const first = computeShipmentAmounts(
+      shipment({
+        lines: [
+          {
+            lineId: 'a',
+            quantity: 1,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: null,
+            orderedQuantity: 1,
+          },
+        ],
+        orderSubtotalMinor: 30_000,
+        orderTaxTotalMinor: 2_310,
+        orderShippingTotalMinor: 0,
+        priorShipmentsSubtotalMinor: 0,
+      }),
+      'clearing_card'
+    )
+    const second = computeShipmentAmounts(
+      shipment({
+        lines: [
+          {
+            lineId: 'b',
+            quantity: 2,
+            unitPriceMinor: 10_000,
+            lineTaxMinor: null,
+            orderedQuantity: 2,
+          },
+        ],
+        orderSubtotalMinor: 30_000,
+        orderTaxTotalMinor: 2_310,
+        orderShippingTotalMinor: 0,
+        priorShipmentsSubtotalMinor: 10_000,
+      }),
+      'clearing_card'
+    )
+    expect(first.taxMinor).toBe(770)
+    expect(second.taxMinor).toBe(1_540)
+    expect(first.taxMinor + second.taxMinor).toBe(2_310)
+  })
+
+  it('recognises shipping once, on the shipment that carries the flag', () => {
+    const carries = computeShipmentAmounts(
+      shipment({ orderShippingTotalMinor: 1_500, includeShipping: true }),
+      'clearing_card'
+    )
+    const does_not = computeShipmentAmounts(
+      shipment({ orderShippingTotalMinor: 1_500, includeShipping: false }),
+      'clearing_card'
+    )
+    expect(carries.shippingMinor).toBe(1_500)
+    expect(does_not.shippingMinor).toBe(0)
+  })
+
+  it('refuses a non-positive quantity rather than posting a negative line', () => {
+    expect(() =>
+      computeShipmentAmounts(
+        shipment({
+          lines: [
+            {
+              lineId: 'a',
+              quantity: 0,
+              unitPriceMinor: 1_000,
+              lineTaxMinor: null,
+              orderedQuantity: 1,
+            },
+          ],
+        }),
+        'clearing_card'
+      )
+    ).toThrowError(UnprocessableEntityError)
+  })
+})
+
+// ── 3. The entry ────────────────────────────────────────────────────────────
+
+describe('buildFulfillmentBatchEntry', () => {
+  it('balances a mixed group and decomposes the same numbers', () => {
+    const card = planned({ orderId: 'o-card', orderNumber: '#2001' })
+    const affirm = planned({
+      orderId: 'o-affirm',
+      orderNumber: '#2002',
+      gateways: ['Affirm'],
+      orderShippingTotalMinor: 0,
+    })
+    // One terms order shipping twice on the same day: two lines in, ONE A/R line out.
+    const termsFirst = planned({
+      orderId: 'o-terms',
+      orderNumber: '#2003',
+      financialStatus: 'pending',
+      gateways: ['manual'],
+      lines: [
+        {
+          lineId: 't1',
+          quantity: 1,
+          unitPriceMinor: 10_000,
+          lineTaxMinor: null,
+          orderedQuantity: 1,
+        },
+      ],
+      orderSubtotalMinor: 30_000,
+      orderTaxTotalMinor: 2_310,
+      orderShippingTotalMinor: 1_000,
+      includeShipping: true,
+    })
+    const termsSecond = planned({
+      orderId: 'o-terms',
+      orderNumber: '#2003',
+      sequence: 2,
+      financialStatus: 'pending',
+      gateways: ['manual'],
+      lines: [
+        {
+          lineId: 't2',
+          quantity: 2,
+          unitPriceMinor: 10_000,
+          lineTaxMinor: null,
+          orderedQuantity: 2,
+        },
+      ],
+      orderSubtotalMinor: 30_000,
+      orderTaxTotalMinor: 2_310,
+      orderShippingTotalMinor: 1_000,
+      priorShipmentsSubtotalMinor: 10_000,
+      includeShipping: false,
+    })
+    // A second terms order, so the A/R leg has to be per ORDER and not per group.
+    const termsOther = planned({
+      orderId: 'o-terms-2',
+      orderNumber: '#2004',
+      channel: 'dealer',
+      financialStatus: 'pending',
+      gateways: [],
+      orderShippingTotalMinor: 0,
+    })
+    // Tax exempt: zero tax, and it must not drag a zero leg into the entry.
+    const exempt = planned({
+      orderId: 'o-exempt',
+      orderNumber: '#2005',
+      orderTaxTotalMinor: 0,
+      orderShippingTotalMinor: 0,
+    })
+
+    const shipments = [card, affirm, termsFirst, termsSecond, termsOther, exempt]
+    const built = buildFulfillmentBatchEntry({
+      group: group(shipments),
+      ledgerCurrency: 'USD',
+      attempt: 0,
+    })
+    const { entry } = built
+
+    const expectedTotal = shipments.reduce((sum, s) => sum + s.amounts.totalMinor, 0)
+    expect(entry.totalDebit).toBe(expectedTotal)
+    expect(entry.totalCredit).toBe(expectedTotal)
+    expect(built.totals.totalMinor).toBe(expectedTotal)
+    expect(built.totals.byDebitRole.accounts_receivable).toBe(
+      termsFirst.amounts.totalMinor + termsSecond.amounts.totalMinor + termsOther.amounts.totalMinor
+    )
+
+    // The credits decompose the debits: subtotal + tax + shipping.
+    const credits = entry.lines.filter((line) => line.direction === 'credit')
+    expect(credits.reduce((sum, line) => sum + line.amount, 0)).toBe(expectedTotal)
+    expect(amountFor(entry, ACCOUNT_ROLES.SALES_TAX_PAYABLE)).toBe(built.totals.taxMinor)
+    expect(amountFor(entry, ACCOUNT_ROLES.REVENUE_SHIPPING)).toBe(built.totals.shippingMinor)
+    expect(amountFor(entry, ACCOUNT_ROLES.CLEARING_CARD)).toBe(
+      card.amounts.totalMinor + exempt.amounts.totalMinor
+    )
+    expect(amountFor(entry, ACCOUNT_ROLES.CLEARING_AFFIRM)).toBe(affirm.amounts.totalMinor)
+    expect(amountFor(entry, ACCOUNT_ROLES.REVENUE_DEALER)).toBe(termsOther.amounts.subtotalMinor)
+  })
+
+  it('emits ONE receivable line per order, sourced on the order', () => {
+    const first = planned({
+      orderId: 'o-terms',
+      orderNumber: '#3001',
+      financialStatus: 'pending',
+      gateways: [],
+    })
+    const second = planned({
+      orderId: 'o-terms',
+      orderNumber: '#3001',
+      sequence: 2,
+      financialStatus: 'pending',
+      gateways: [],
+      includeShipping: false,
+      priorShipmentsSubtotalMinor: 10_000,
+    })
+    const other = planned({
+      orderId: 'o-terms-2',
+      orderNumber: '#3002',
+      financialStatus: 'pending',
+      gateways: [],
+    })
+
+    const { entry } = buildFulfillmentBatchEntry({
+      group: group([first, second, other]),
+      ledgerCurrency: 'USD',
+      attempt: 0,
+    })
+    const receivables = linesFor(entry, ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE)
+
+    // 🛑 Aging has to name the debtor, so this leg alone stays at order grain.
+    expect(receivables).toHaveLength(2)
+    expect(receivables.map((line) => line.sourceType)).toEqual([
+      FULFILLMENT_SOURCE_TYPE,
+      FULFILLMENT_SOURCE_TYPE,
+    ])
+    expect(receivables.map((line) => line.sourceId)).toEqual(['o-terms', 'o-terms-2'])
+    expect(receivables.map((line) => line.memo)).toEqual(['#3001', '#3002'])
+    expect(receivables[0]?.amount).toBe(first.amounts.totalMinor + second.amounts.totalMinor)
+  })
+
+  it('sources every summarised line on the period key, never on an order', () => {
+    const built = buildFulfillmentBatchEntry({
+      group: group([planned(), planned({ channel: 'dealer' })]),
+      ledgerCurrency: 'USD',
+      attempt: 0,
+    })
+    const summarised = built.entry.lines.filter(
+      (line) => line.accountRole !== ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE
+    )
+    expect(summarised.length).toBeGreaterThan(0)
+    for (const line of summarised) {
+      expect(line.sourceType).toBe(FULFILLMENT_BATCH_SOURCE_TYPE)
+      expect(line.sourceId).toBe(built.periodKey)
+    }
+  })
+
+  it('emits the lines in the declared order and drops the zero legs', () => {
+    const terms = planned({
+      orderId: 'o-terms',
+      orderNumber: '#4001',
+      financialStatus: 'pending',
+      gateways: [],
+      orderShippingTotalMinor: 0,
+      orderTaxTotalMinor: 0,
+    })
+    const card = planned({
+      orderId: 'o-card',
+      orderNumber: '#4002',
+      orderShippingTotalMinor: 0,
+      orderTaxTotalMinor: 0,
+    })
+    const { entry } = buildFulfillmentBatchEntry({
+      group: group([terms, card]),
+      ledgerCurrency: 'USD',
+      attempt: 0,
+    })
+    expect(entry.lines.map((line) => line.accountRole)).toEqual([
+      ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
+      ACCOUNT_ROLES.CLEARING_CARD,
+      ACCOUNT_ROLES.REVENUE_DTC,
+    ])
+    expect(entry.lines.map((line) => line.sortOrder)).toEqual([0, 1, 2])
+  })
+
+  it('freezes the per-shipment list into the entry, for the draft envelope', () => {
+    const card = planned({ orderId: 'o-card', orderNumber: '#5001' })
+    const terms = planned({
+      orderId: 'o-terms',
+      orderNumber: '#5002',
+      sequence: 3,
+      financialStatus: 'pending',
+      gateways: [],
+    })
+    const { entry } = buildFulfillmentBatchEntry({
+      group: group([card, terms]),
+      ledgerCurrency: 'USD',
+      attempt: 0,
+    })
+
+    // Summarised lines name a period key, not the orders behind it, so this
+    // list is the only record of what the number was made of (49 §2.5).
+    expect(entry.sources).toEqual([
+      {
+        orderId: 'o-card',
+        orderNumber: '#5001',
+        sequence: 1,
+        amounts: card.amounts,
+      },
+      {
+        orderId: 'o-terms',
+        orderNumber: '#5002',
+        sequence: 3,
+        amounts: terms.amounts,
+      },
+    ] satisfies FulfillmentBatchSource[])
+  })
+
+  it('books an unset or manual channel to consumer revenue, never refusing', () => {
+    // The fail-open half of 49 §8.4 decision 5: 535 of 545 orders on the
+    // reference org carry `manual`, and refusing them recognised no revenue.
+    const built = buildFulfillmentBatchEntry({
+      group: group([
+        planned({ channel: 'manual' }),
+        planned({ channel: null }),
+        planned({ channel: 'wholesale' }),
+      ]),
+      ledgerCurrency: 'USD',
+      attempt: 0,
+    })
+    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DTC)).toBe(built.totals.subtotalMinor)
+    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DEALER)).toBeUndefined()
+  })
+
+  it('carries the memo onto the summarised lines and the order number onto the A/R ones', () => {
+    const built = buildFulfillmentBatchEntry({
+      group: group([
+        planned({ orderId: 'o-1', orderNumber: '#6001' }),
+        planned({ orderId: 'o-2', orderNumber: '#6002', financialStatus: 'pending', gateways: [] }),
+      ]),
+      ledgerCurrency: 'USD',
+      attempt: 0,
+      memo: 'July catch-up',
+    })
+    expect(linesFor(built.entry, ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE)[0]?.memo).toBe('#6002')
+    expect(linesFor(built.entry, ACCOUNT_ROLES.CLEARING_CARD)[0]?.memo).toContain('July catch-up')
+  })
+
+  it('stamps the posting type, the period key and the group txn date', () => {
+    const built = buildFulfillmentBatchEntry({
+      group: group([planned({ shippedAt: '2026-07-06' })], '2026-07-06'),
+      ledgerCurrency: 'USD',
+      attempt: 0,
+    })
+    expect(built.entry.postingType).toBe('fulfillment')
+    expect(built.entry.periodKey).toBe('2026-07-06')
+    expect(built.periodKey).toBe('2026-07-06')
+    expect(built.entry.txnDate).toBe('2026-07-06')
+  })
+
+  it('refuses an empty group rather than claiming the period for nothing', () => {
+    expect(() =>
+      buildFulfillmentBatchEntry({ group: group([]), ledgerCurrency: 'USD', attempt: 0 })
+    ).toThrowError(/no shipments/)
+  })
+
+  it('refuses a foreign-currency shipment rather than implying a 1.0 rate', () => {
+    expect(() =>
+      buildFulfillmentBatchEntry({
+        group: group([planned({ currency: 'CAD' })]),
+        ledgerCurrency: 'USD',
+        attempt: 0,
+      })
+    ).toThrowError(/implied 1\.0 rate/)
+  })
+
+  it('refuses frozen amounts whose parts do not sum to their own total', () => {
+    // 🛑 Load-bearing: the debits use `totalMinor` and the credits use its
+    // parts, so a mis-stated total is an entry that genuinely does not balance.
+    const bad = planned()
+    bad.amounts = { ...bad.amounts, totalMinor: bad.amounts.totalMinor + 1 }
+    expect(() =>
+      buildFulfillmentBatchEntry({ group: group([bad]), ledgerCurrency: 'USD', attempt: 0 })
+    ).toThrowError(/could not balance/)
+  })
+
+  it('refuses a fractional frozen amount', () => {
+    const bad = planned()
+    bad.amounts = { ...bad.amounts, taxMinor: 12.5, totalMinor: bad.amounts.totalMinor + 12.5 }
+    expect(() =>
+      buildFulfillmentBatchEntry({ group: group([bad]), ledgerCurrency: 'USD', attempt: 0 })
+    ).toThrowError(/whole number of cents/)
+  })
+})
+
+// ── 4. The keyspace ─────────────────────────────────────────────────────────
+
+describe('fulfillmentBatchPeriodKey', () => {
+  it('is the group key verbatim at attempt 0', () => {
+    // 🛑 Byte for byte: the key is half the claim's uniqueness tuple, so
+    // re-keying it would hide every posting already in a ledger.
+    expect(fulfillmentBatchPeriodKey('2026-07-06', 0)).toBe('2026-07-06')
+    expect(fulfillmentBatchPeriodKey('2026-W27', 0)).toBe('2026-W27')
+    expect(fulfillmentBatchPeriodKey('2026-07', 0)).toBe('2026-07')
+  })
+
+  it('appends one base-36 character per attempt', () => {
+    expect(fulfillmentBatchPeriodKey('2026-07-06', 1)).toBe('2026-07-061')
+    expect(fulfillmentBatchPeriodKey('2026-07-06', 10)).toBe('2026-07-06A')
+    expect(fulfillmentBatchPeriodKey('2026-07-06', 35)).toBe('2026-07-06Z')
+  })
+
+  it('leaves exactly one character of budget for the attempt', () => {
+    // `AUXX-FUL-` is 9 and `-R9` is 3, so 9 compacted characters are left, and
+    // a day key is 8 of them. The margin is one character, and it is the whole
+    // reason a late order can be posted at all.
+    expect(MAX_COMPACT_FULFILLMENT_BATCH_KEY).toBe(9)
+    expect('2026-07-06'.replace(/-/g, '')).toHaveLength(8)
+    expect('2026-W27'.replace(/-/g, '')).toHaveLength(7)
+    expect('2026-07'.replace(/-/g, '')).toHaveLength(6)
+  })
+
+  it('mints a document number that survives a reversal at every grouping', () => {
+    for (const key of ['2026-07-06', '2026-W27', '2026-07']) {
+      for (const attempt of [0, 1, 35]) {
+        const periodKey = fulfillmentBatchPeriodKey(key, attempt)
+        const reversal = buildDocNumber({ postingType: 'fulfillment', periodKey, revision: 1 })
+        expect(reversal.length).toBeLessThanOrEqual(DOC_NUMBER_MAX_LENGTH)
+      }
+    }
+    expect(buildDocNumber({ postingType: 'fulfillment', periodKey: '2026-07-061' })).toBe(
+      'AUXX-FUL-202607061'
+    )
+  })
+
+  it('refuses a blank key, a fractional attempt and an attempt past the keyspace', () => {
+    expect(() => fulfillmentBatchPeriodKey('   ', 0)).toThrowError(/needs a group key/)
+    expect(() => fulfillmentBatchPeriodKey('2026-07-06', 1.5)).toThrowError(/whole number from 0/)
+    expect(() => fulfillmentBatchPeriodKey('2026-07-06', -1)).toThrowError(/whole number from 0/)
+    expect(() =>
+      fulfillmentBatchPeriodKey('2026-07-06', MAX_FULFILLMENT_BATCH_ATTEMPT + 1)
+    ).toThrowError(/keyspace can hold/)
+  })
+
+  it('refuses a group key too long to survive a reversal', () => {
+    // Ten compacted characters posts fine at revision 0 and blows up at
+    // revision 1, which is why the check is here and not in `buildDocNumber`.
+    expect('2026-07-06-12'.replace(/-/g, '')).toHaveLength(10)
+    expect(() => fulfillmentBatchPeriodKey('2026-07-06-12', 0)).toThrowError(/compacts to/)
+    // A day key at the very top of the budget still refuses the attempt char.
+    expect(() => fulfillmentBatchPeriodKey('2026-07-061', 1)).toThrowError(/compacts to/)
+  })
+})

--- a/packages/lib/src/postings/__tests__/build-fulfillment-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-fulfillment-entry.test.ts
@@ -7,9 +7,11 @@
 //
 // Three properties carry the file:
 //
-//  1. **The channel table fails CLOSED on two of its four rows.** A default to
-//     DTC would put dealer sales in the consumer line, where the entry balances
-//     and nothing downstream can see it.
+//  1. **The channel table fails OPEN on two of its four rows.** It used to fail
+//     closed, on the argument that a default to DTC hides dealer sales in the
+//     consumer line. 49 §8.4 decision 5 reversed it: `order_channel` is
+//     human-set and unbound, so the refusal recognised no imported revenue at
+//     all, and unrecognised revenue is the less visible of the two errors.
 //  2. **A second shipment must not re-recognise the first.** That is what the
 //     shipped-lines input and the `includeShipping` flag exist for, and it is
 //     asserted by summing two entries against the order total.
@@ -57,10 +59,14 @@ function amountFor(
 }
 
 describe('the channel table', () => {
-  it('has exactly four rows, two of which refuse', () => {
+  it('has exactly four rows and refuses none of them', () => {
     expect(Object.keys(CHANNEL_REVENUE_ROLE).sort()).toEqual(['dealer', 'dtc', 'manual', 'null'])
-    expect(CHANNEL_REVENUE_ROLE.manual).toBe('refuse')
-    expect(CHANNEL_REVENUE_ROLE.null).toBe('refuse')
+    // ⤵️ Both used to be 'refuse'. 49 §8.4 decision 5: `order_channel` is
+    // human-set and no connector binds it, so the refusal did not protect the
+    // DTC/dealer split - it refused every imported order and recognised nothing.
+    expect(CHANNEL_REVENUE_ROLE.manual).toBe(ACCOUNT_ROLES.REVENUE_DTC)
+    expect(CHANNEL_REVENUE_ROLE.null).toBe(ACCOUNT_ROLES.REVENUE_DTC)
+    expect(Object.values(CHANNEL_REVENUE_ROLE)).not.toContain('refuse')
   })
 
   it('normalises an absent or unrecognised channel to the null row', () => {
@@ -83,18 +89,24 @@ describe('the channel table', () => {
   })
 
   it.each([
-    ['manual', 'manual'],
-    [null, 'none'],
-  ])('refuses channel %s, naming the order and the channel', (channel, shown) => {
-    expect(() =>
-      buildFulfillmentEntry({ ...BASE, channel, shippedLines: WHOLE_ORDER })
-    ).toThrowError(UnprocessableEntityError)
-    try {
-      buildFulfillmentEntry({ ...BASE, channel, shippedLines: WHOLE_ORDER })
-    } catch (error) {
-      expect((error as Error).message).toContain('ORD-0012')
-      expect((error as Error).message).toContain(shown)
-    }
+    ['manual'],
+    [null],
+    ['wholesale'],
+    ['  '],
+  ])('books channel %s to consumer revenue rather than refusing it', (channel) => {
+    const built = buildFulfillmentEntry({ ...BASE, channel, shippedLines: WHOLE_ORDER })
+    expect(built.revenueRole).toBe(ACCOUNT_ROLES.REVENUE_DTC)
+    // The whole subtotal reaches 4000. The point of failing open is that the
+    // revenue is ON the books, in a line a person can move, not missing.
+    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DTC)).toBe(100_000)
+  })
+
+  it('still books an explicit dealer order to the dealer line', () => {
+    // Failing open must not collapse the split it was protecting: the moment a
+    // person says `dealer`, the default stops being reached.
+    const built = buildFulfillmentEntry({ ...BASE, channel: 'dealer', shippedLines: WHOLE_ORDER })
+    expect(built.revenueRole).toBe(ACCOUNT_ROLES.REVENUE_DEALER)
+    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DTC)).toBeUndefined()
   })
 })
 

--- a/packages/lib/src/postings/__tests__/close-month.test.ts
+++ b/packages/lib/src/postings/__tests__/close-month.test.ts
@@ -33,6 +33,10 @@ interface PosterCall {
 
 const h = vi.hoisted(() => ({
   gather: vi.fn<(db: unknown, organizationId: string, periodKey: string) => Promise<unknown>>(),
+  countUnpostedShipments:
+    vi.fn<(db: unknown, params: { organizationId: string; month: string }) => Promise<unknown>>(),
+  countUnissuedChannelCreditMemos:
+    vi.fn<(db: unknown, params: { organizationId: string; month: string }) => Promise<number>>(),
   resolvePeriodLock: vi.fn<(organizationId: string) => Promise<unknown>>(),
   previewEntry: vi.fn<(db: unknown, options: PosterCall) => Promise<unknown>>(),
   postEntry: vi.fn<(db: unknown, options: PosterCall) => Promise<unknown>>(),
@@ -41,6 +45,15 @@ const h = vi.hoisted(() => ({
 
 vi.mock('../gather-month-end-inventory', () => ({
   gatherMonthEndInventoryInputs: h.gather,
+}))
+// The completeness gate's two counts. Mocked because they are subledger reads
+// over `FieldValue` and this file has no database; what is under test is the
+// CLASSIFICATION, which is this file's whole job.
+vi.mock('../../money/fulfillment-posting/reads', () => ({
+  countUnpostedShipments: h.countUnpostedShipments,
+}))
+vi.mock('../../money/credit-memos/reads', () => ({
+  countUnissuedChannelCreditMemos: h.countUnissuedChannelCreditMemos,
 }))
 vi.mock('../period-lock', () => ({
   PERIOD_LOCK_SETTING_KEY: 'ledger.lockedThroughMonth',
@@ -147,6 +160,10 @@ const POST_OK: PostResult = {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // A complete month by default, so every OTHER test in this file still
+  // exercises the classification it was written for.
+  h.countUnpostedShipments.mockResolvedValue(ok(0))
+  h.countUnissuedChannelCreditMemos.mockResolvedValue(0)
   h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
   h.previewEntry.mockResolvedValue(PREVIEW_OK)
   h.postEntry.mockResolvedValue(POST_OK)
@@ -644,4 +661,132 @@ describe('neither function ever throws', () => {
       if (result.status !== 'posted') expect((result.error ?? '').length).toBeGreaterThan(0)
     })
   }
+})
+
+// ── The completeness gate (49 §2.4, §8.4 decision 7; 10 §3.4) ──────────────
+//
+// 🛑 Balance is not completeness. A month whose shipments were never posted, or
+// whose channel credit memos are still drafts, is short of revenue however well
+// its entries tie - and closing it puts that revenue permanently outside a month
+// somebody has certified, because `period-lock.ts` refuses the entry it owes.
+// So this is a refusal, and the tests below are as much about WHICH refusal wins
+// as about the refusal itself.
+
+describe('the completeness gate', () => {
+  it('refuses a month holding unposted shipments, naming the count and the remedy', async () => {
+    h.gather.mockResolvedValue(ok(movingInputs()))
+    h.countUnpostedShipments.mockResolvedValue(ok(3))
+
+    const result = await postMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(result.status).toBe('revenue_incomplete')
+    expect(result.error).toContain('3 shipments are not posted')
+    expect(result.error).toContain('Post the fulfillments for August 2026 with the posting dialog')
+    // Refused BEFORE the claim: nothing was written and nothing was pushed.
+    expect(result.glPostingId).toBeUndefined()
+    expect(h.postEntry).not.toHaveBeenCalled()
+  })
+
+  it('refuses a month holding unissued channel credit memos', async () => {
+    h.gather.mockResolvedValue(ok(movingInputs()))
+    h.countUnissuedChannelCreditMemos.mockResolvedValue(2)
+
+    const result = await postMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(result.status).toBe('revenue_incomplete')
+    expect(result.error).toContain('2 channel credit memos are still a draft')
+    expect(result.error).toContain('Issue or void the channel credit memos dated in August 2026')
+  })
+
+  it('names BOTH counts when both are outstanding', async () => {
+    // One sentence per count, in one message: a refusal that named only the
+    // shipments would send an operator back a second time for the memos.
+    h.gather.mockResolvedValue(ok(movingInputs()))
+    h.countUnpostedShipments.mockResolvedValue(ok(1))
+    h.countUnissuedChannelCreditMemos.mockResolvedValue(1)
+
+    const result = await postMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(result.error).toContain('1 shipment is not posted')
+    expect(result.error).toContain('1 channel credit memo is still a draft')
+  })
+
+  it('renders on a preview as a blockedBy, not a throw', async () => {
+    h.gather.mockResolvedValue(ok(movingInputs()))
+    h.countUnpostedShipments.mockResolvedValue(ok(4))
+
+    const preview = await previewMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(preview.blockedBy?.status).toBe('revenue_incomplete')
+    expect(preview.lines).toEqual([])
+    expect(h.previewEntry).not.toHaveBeenCalled()
+  })
+
+  it('asks about the month being closed', async () => {
+    h.gather.mockResolvedValue(ok(movingInputs()))
+    h.countUnpostedShipments.mockResolvedValue(ok(1))
+
+    await postMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(h.countUnpostedShipments).toHaveBeenCalledWith(db, {
+      organizationId: ORG,
+      month: PERIOD,
+    })
+    expect(h.countUnissuedChannelCreditMemos).toHaveBeenCalledWith(db, {
+      organizationId: ORG,
+      month: PERIOD,
+    })
+  })
+
+  it('lets a CONFIGURATION refusal win: a draft setup is still setup_incomplete', async () => {
+    // The gate runs AFTER the gather for exactly this. Telling somebody to post
+    // fulfillments for a month that can never be closed by this system would
+    // send them to a dialog that excludes those very shipments.
+    h.gather.mockResolvedValue(
+      err(
+        new UnprocessableEntityError('Finish the accounting setup', {
+          setting: 'accounting.setupState',
+        })
+      )
+    )
+    h.countUnpostedShipments.mockResolvedValue(ok(9))
+
+    const result = await postMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(result.status).toBe('setup_incomplete')
+    expect(h.countUnpostedShipments).not.toHaveBeenCalled()
+  })
+
+  it('wins over nothing_to_close: an empty month with unposted shipments is not empty', async () => {
+    // The gate runs BEFORE the build for exactly this, and it is the single most
+    // likely shape of the refusal on a connector-fed org: no inventory movement
+    // at all, and a week of revenue nobody has posted.
+    h.gather.mockResolvedValue(ok(emptyInputs()))
+    h.countUnpostedShipments.mockResolvedValue(ok(6))
+
+    const result = await postMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(result.status).toBe('revenue_incomplete')
+  })
+
+  it('does not block the close on its OWN failure', async () => {
+    // ⚠️ Fails OPEN. A broken subledger read must not be able to hold an
+    // organization's books hostage, and the ledger page reports the same two
+    // counts independently.
+    h.gather.mockResolvedValue(ok(movingInputs()))
+    h.countUnpostedShipments.mockResolvedValue(err(new Error('the read is broken')))
+    h.countUnissuedChannelCreditMemos.mockRejectedValue(new Error('the other read is broken too'))
+
+    const result = await postMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(result.status).toBe('posted')
+  })
+
+  it('does not refuse a complete month', async () => {
+    h.gather.mockResolvedValue(ok(movingInputs()))
+
+    const result = await postMonthEnd(db, { organizationId: ORG, periodKey: PERIOD })
+
+    expect(result.status).toBe('posted')
+  })
 })

--- a/packages/lib/src/postings/__tests__/default-chart.test.ts
+++ b/packages/lib/src/postings/__tests__/default-chart.test.ts
@@ -104,7 +104,10 @@ describe('the default chart', () => {
     // that reflexively gives every account a role has to argue with a test.
     const roleless = DEFAULT_CHART_OF_ACCOUNTS.filter((account) => !account.role)
     expect(roleless.length).toBeGreaterThan(0)
-    expect(roleless.map((account) => account.code)).toContain('1210') // Affirm Clearing
+    // `1210 Affirm Clearing` used to be the example here and no longer is: the
+    // fulfillment debit fork gained `clearing_affirm` (49 §8.4 decision 6), so
+    // the account a builder now posts to carries a role like every other.
+    expect(roleless.map((account) => account.code)).toContain('6105') // Merchant Fees - Affirm
     expect(roleless.map((account) => account.code)).toContain('6200') // Fulfillment Labor
   })
 

--- a/packages/lib/src/postings/__tests__/verify-balance.test.ts
+++ b/packages/lib/src/postings/__tests__/verify-balance.test.ts
@@ -14,10 +14,35 @@
 // which a generic chainable spy cannot express.
 
 import type { Database } from '@auxx/database'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// The completeness half's two subledger counts. Mocked because they read
+// `FieldValue` through the org cache and this file's stub answers every query
+// with the same rows; what is under test here is that the sweep CARRIES them,
+// not how they are computed. They are only reached when a month is asked for.
+const h = vi.hoisted(() => ({
+  countUnpostedShipments:
+    vi.fn<(db: unknown, params: { organizationId: string; month: string }) => Promise<unknown>>(),
+  countUnissuedChannelCreditMemos:
+    vi.fn<(db: unknown, params: { organizationId: string; month: string }) => Promise<number>>(),
+}))
+
+vi.mock('../../money/fulfillment-posting/reads', () => ({
+  countUnpostedShipments: h.countUnpostedShipments,
+}))
+vi.mock('../../money/credit-memos/reads', () => ({
+  countUnissuedChannelCreditMemos: h.countUnissuedChannelCreditMemos,
+}))
+
+import { err, ok } from 'neverthrow'
 import { BadRequestError } from '../../errors'
 import { listFailedExports, verifyBooksBalance } from '../verify-balance'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.countUnpostedShipments.mockResolvedValue(ok(0))
+  h.countUnissuedChannelCreditMemos.mockResolvedValue(0)
+})
 
 const ORG = 'org_1'
 
@@ -90,6 +115,12 @@ describe('verifyBooksBalance', () => {
       balanced: true,
       postingsChecked: 0,
       discrepancies: [],
+      // ⚠️ `null`, never `0`. No month was asked, so the completeness half was
+      // never computed - and a `0` there would read as "nothing outstanding"
+      // for a question nobody put.
+      month: null,
+      unpostedShipments: null,
+      unissuedChannelCreditMemos: null,
     })
   })
 
@@ -110,6 +141,9 @@ describe('verifyBooksBalance', () => {
       balanced: true,
       postingsChecked: 1,
       discrepancies: [],
+      month: null,
+      unpostedShipments: null,
+      unissuedChannelCreditMemos: null,
     })
   })
 
@@ -399,5 +433,60 @@ describe('listFailedExports', () => {
   it('returns err rather than throwing when the read fails', async () => {
     const result = await listFailedExports(throwingDb(new Error('connection reset')), ORG)
     expect(result.isErr()).toBe(true)
+  })
+})
+
+// ── The completeness half (49 §2.4) ───────────────────────────────────────
+//
+// 🛑 Balance is not completeness, and the whole reason these two counts ride on
+// this report is that a screen showing only the first would report green books
+// that are short a week of revenue.
+
+describe('verifyBooksBalance completeness', () => {
+  it('counts nothing, and asks nothing, without a month', async () => {
+    const report = (await verifyBooksBalance(stubDb([]), ORG))._unsafeUnwrap()
+
+    expect(report.month).toBeNull()
+    expect(report.unpostedShipments).toBeNull()
+    expect(report.unissuedChannelCreditMemos).toBeNull()
+    expect(h.countUnpostedShipments).not.toHaveBeenCalled()
+    expect(h.countUnissuedChannelCreditMemos).not.toHaveBeenCalled()
+  })
+
+  it('carries both counts for the month it was asked about', async () => {
+    h.countUnpostedShipments.mockResolvedValue(ok(7))
+    h.countUnissuedChannelCreditMemos.mockResolvedValue(2)
+
+    const report = (await verifyBooksBalance(stubDb([]), ORG, { month: '2026-08' }))._unsafeUnwrap()
+
+    expect(report.month).toBe('2026-08')
+    expect(report.unpostedShipments).toBe(7)
+    expect(report.unissuedChannelCreditMemos).toBe(2)
+    expect(h.countUnpostedShipments).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: ORG,
+      month: '2026-08',
+    })
+  })
+
+  it('keeps the balance answer when a count fails, and reports the count as null', async () => {
+    // ⚠️ Losing the report that proves the books tie, in order to report the one
+    // that says they might be short, is the wrong trade in both directions.
+    h.countUnpostedShipments.mockResolvedValue(err(new Error('the read is broken')))
+    h.countUnissuedChannelCreditMemos.mockRejectedValue(new Error('so is the other one'))
+
+    const result = await verifyBooksBalance(
+      stubDb([
+        groupedRow({ glPostingId: 'gl_1', debit: 100, credit: 100, recordedTotalMinor: 100 }),
+      ]),
+      ORG,
+      { month: '2026-08' }
+    )
+
+    expect(result.isOk()).toBe(true)
+    const report = result._unsafeUnwrap()
+    expect(report.balanced).toBe(true)
+    expect(report.postingsChecked).toBe(1)
+    expect(report.unpostedShipments).toBeNull()
+    expect(report.unissuedChannelCreditMemos).toBeNull()
   })
 })

--- a/packages/lib/src/postings/build-entry.ts
+++ b/packages/lib/src/postings/build-entry.ts
@@ -234,6 +234,26 @@ export const ACCOUNT_ROLES = {
    */
   CLEARING_CARD: 'clearing_card',
   /**
+   * Affirm clearing (default `1210`). The SECOND clearing rail, and it exists
+   * for one reason: an Affirm settlement never lands on the card rail, so it is
+   * invisible to the payouts API.
+   *
+   * 🛑 **Folding Affirm orders into `clearing_card` makes `1200` impossible to
+   * reconcile to zero.** The payout entry drains `clearing_card` by exactly what
+   * a card payout settled; an Affirm sale debited there would never be drained,
+   * and `1200` would carry a growing residual that balances perfectly and reads
+   * as unsettled card money. So the fulfillment builder's debit fork routes an
+   * `affirm` gateway here (`resolveFulfillmentDebit` in
+   * `build-fulfillment-batch-entry.ts`), and `PAYOUT_CLEARING_ROLES` excludes
+   * this role by construction.
+   *
+   * `6105 Merchant Fees - Affirm` is the matching expense account and stays
+   * role-less until an Affirm settlement feed exists to post against it.
+   *
+   * @see plans/money/tasks/49-bulk-fulfillment-posting.md §3.2, §8.4 decision 6
+   */
+  CLEARING_AFFIRM: 'clearing_affirm',
+  /**
    * Unidentified receipts (default `2450`). Money that arrived and auxx cannot
    * attribute, held as a LIABILITY until somebody codes it.
    *
@@ -361,6 +381,7 @@ export const ROLE_ACCOUNT_TYPES: Record<AccountRole, GlAccountTypeValue> = {
   accounts_receivable: 'asset',
   undeposited_funds: 'asset',
   clearing_card: 'asset',
+  clearing_affirm: 'asset',
   unidentified_receipts: 'liability',
   sales_tax_payable: 'liability',
   deferred_revenue: 'liability',
@@ -403,6 +424,7 @@ export const ACCOUNT_ROLE_LABELS: Record<AccountRole, string> = {
   accounts_receivable: 'Accounts Receivable',
   undeposited_funds: 'Undeposited Funds',
   clearing_card: 'Card Clearing',
+  clearing_affirm: 'Affirm Clearing',
   unidentified_receipts: 'Unidentified Receipts',
   sales_tax_payable: 'Sales Tax Payable',
   deferred_revenue: 'Deferred Revenue',

--- a/packages/lib/src/postings/build-fulfillment-batch-entry.ts
+++ b/packages/lib/src/postings/build-fulfillment-batch-entry.ts
@@ -1,0 +1,658 @@
+// packages/lib/src/postings/build-fulfillment-batch-entry.ts
+
+/**
+ * ONE fulfillment entry for a whole day, week or month of shipments.
+ *
+ * PURE. No database, no clock, no chart - the property every builder in this
+ * folder has, and here it is what lets a mixed group of card, Affirm, terms and
+ * tax-exempt orders be balanced exhaustively in a unit test.
+ *
+ * ```
+ *   Dr accounts_receivable   ONE LINE PER ORDER   that order's terms shipments
+ *   Dr clearing_card         summarised           every card shipment's total
+ *   Dr clearing_affirm       summarised           every Affirm shipment's total
+ *       Cr revenue_dtc       summarised             Σ subtotal, consumer channel
+ *       Cr revenue_dealer    summarised             Σ subtotal, dealer channel
+ *       Cr sales_tax_payable summarised             Σ tax
+ *       Cr revenue_shipping  summarised             Σ shipping
+ * ```
+ *
+ * ## Why this exists beside {@link buildFulfillmentEntry}
+ *
+ * `buildFulfillmentEntry` posts ONE shipment and keys on `<orderNumber>-F<n>`.
+ * That is right for a hand-run order and wrong for an imported backlog: 613
+ * shipments on the reference org are 613 `GlPosting` rows, which is the row
+ * shape `plans/money/tasks/45-batch-only-builds.md` §0 refused for builds. The
+ * batch entry is the shape `design/gap-f-fulfillment-entry.md` §1 designed in
+ * the first place - one posting per recognition period - and both builders share
+ * one implementation of the arithmetic (`computeShipmentTotals`), so a day's
+ * summary and a single order's entry can never disagree about what shipped.
+ *
+ * `fulfillOrder` still calls the single-shipment builder. Neither replaces the
+ * other.
+ *
+ * ## Three things this file is careful about
+ *
+ * 1. **The debit is not always a receivable.** A Shopify order was PAID at
+ *    checkout, so debiting `accounts_receivable` fills aging with money nobody
+ *    owes and leaves `clearing_card` permanently negative when the payout
+ *    entry drains it. {@link resolveFulfillmentDebit} is that fork, and it
+ *    EXCLUDES rather than guesses when the gateways do not say.
+ * 2. **The A/R leg stays per order.** Aging has to name the debtor, so a terms
+ *    order gets its own line with `sourceType: 'order'` while everything else
+ *    summarises under the period key (49 §2.5).
+ * 3. **The list of what was summarised is FROZEN into the entry.** Summarised
+ *    lines name a period key, not fifty orders, so `BuiltEntry.sources` carries
+ *    `{orderId, orderNumber, sequence, amounts}` per shipment into the posting's
+ *    `draft` envelope. A later correction is a compensating entry computed from
+ *    that slice - never a repost, and never an edit of a posted entry.
+ *
+ * @see plans/money/tasks/49-bulk-fulfillment-posting.md §2.3, §2.5, §3.2, §8.4
+ * @see plans/money/tasks/49-build-contract.md for the seam this is one half of
+ */
+
+import { UnprocessableEntityError } from '../errors'
+import type {
+  FulfillmentDebitRole,
+  FulfillmentPostingExclusionReason,
+  FulfillmentPostingGroup,
+  ShipmentAmounts,
+  UnpostedShipment,
+  UnpostedShipmentLine,
+} from '../money/fulfillment-posting/types'
+import { FULFILLMENT_BATCH_SOURCE_TYPE } from '../money/fulfillment-posting/types'
+import { ACCOUNT_ROLES, type AccountRole, buildEntry } from './build-entry'
+import {
+  CHANNEL_REVENUE_ROLE,
+  computeShipmentTotals,
+  FULFILLMENT_SOURCE_TYPE,
+  toAmountMinor,
+  toChannelKey,
+} from './build-fulfillment-entry'
+import { DOC_NUMBER_MAX_LENGTH, DOC_NUMBER_PREFIX } from './doc-number'
+import type { BuiltEntry, GlPostingLineInput } from './types'
+
+// ── The debit fork ──────────────────────────────────────────────────────────
+
+/**
+ * The financial statuses that mean **the money has already been taken**.
+ *
+ * `partially_refunded` and `refunded` are here with `paid` on purpose: both
+ * describe an order that WAS paid, and the refund is its own later event (a
+ * credit memo, `plans/accounting/tasks/10-credit-memos.md`). Treating a
+ * refunded order as unpaid would debit a receivable for money that was
+ * collected and then returned, and the memo's settlement leg
+ * (`Dr accounts_receivable / Cr clearing_card`) would have nothing to net
+ * against.
+ *
+ * Anything else - `pending`, `authorized`, `partially_paid`, blank - is an
+ * order that OWES, which is the terms/dealer case.
+ */
+const SETTLED_FINANCIAL_STATUSES: ReadonlySet<string> = new Set([
+  'paid',
+  'partially_refunded',
+  'refunded',
+])
+
+/**
+ * Shopify's test gateway. An order taken through it is not a sale.
+ *
+ * 🛑 Checked FIRST, before the financial status. See
+ * {@link resolveFulfillmentDebit}.
+ */
+const TEST_GATEWAY = 'bogus'
+
+/**
+ * Shopify's "manual payment" gateway: an invoice, a wire, a cheque, a
+ * pay-later arrangement. The money has NOT arrived on a rail auxx can see, so
+ * the order owes whatever its financial status claims.
+ */
+const MANUAL_GATEWAY = 'manual'
+
+/**
+ * Which clearing account each named gateway settles into. DECLARED.
+ *
+ * Only gateways whose answer is NOT the card rail need a row: everything else
+ * (PayPal, Stripe, Shop Pay, a gateway nobody has seen yet) settles as card
+ * money into `clearing_card`, which is the account a payout entry drains.
+ *
+ * 🛑 `affirm` is the row that matters. An Affirm settlement never lands on the
+ * card rail and is invisible to the payouts API, so an Affirm sale debited to
+ * `clearing_card` leaves that account with a residual no payout can ever
+ * relieve - it balances, and `1200` simply stops reconciling to zero.
+ */
+export const FULFILLMENT_GATEWAY_DEBIT: Readonly<Record<string, FulfillmentDebitRole>> = {
+  shopify_payments: 'clearing_card',
+  affirm: 'clearing_affirm',
+}
+
+/** The exclusions the debit fork itself can produce. A subset of lane B's closed set. */
+export type FulfillmentDebitExclusionReason = Extract<
+  FulfillmentPostingExclusionReason,
+  'gateway-ambiguous' | 'test-gateway'
+>
+
+/** What {@link resolveFulfillmentDebit} answers: an account, or a reason not to post. */
+export type FulfillmentDebitResolution =
+  | { kind: 'debit'; role: FulfillmentDebitRole }
+  | { kind: 'exclude'; reason: FulfillmentDebitExclusionReason; detail: string }
+
+/** Trim, lower-case and de-duplicate a gateway list, preserving first-seen order. */
+function normaliseGateways(gateways: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const gateway of gateways) {
+    const value = gateway?.trim().toLowerCase()
+    if (!value || seen.has(value)) continue
+    seen.add(value)
+    out.push(value)
+  }
+  return out
+}
+
+/**
+ * Which account a shipment DEBITS: a clearing account, or the receivable.
+ *
+ * PURE and total. Gateway names are compared case-insensitively after trim, so
+ * `'Affirm'` and `' affirm '` are one gateway.
+ *
+ * ## The fork, in evaluation order
+ *
+ * | when | answer |
+ * |---|---|
+ * | any gateway is `bogus` | exclude, `test-gateway` |
+ * | financial status is not `paid`, `partially_refunded` or `refunded` | `accounts_receivable` |
+ * | any gateway is `manual` | `accounts_receivable` |
+ * | no gateways at all | `accounts_receivable` |
+ * | exactly one gateway | {@link FULFILLMENT_GATEWAY_DEBIT}, defaulting to `clearing_card` |
+ * | two or more distinct gateways | exclude, `gateway-ambiguous`, detail is the list |
+ *
+ * ⚠️ **`bogus` is checked before the status, and the build contract listed it
+ * second.** A test order is not a sale in any status: the contract's order
+ * sends a `bogus` order that is merely `pending` to accounts receivable, which
+ * puts Shopify test data into aging. The two orders agree on every real test
+ * order, because Shopify marks them `paid`; they differ only where the
+ * contract's order is wrong.
+ *
+ * ## Why an unknown gateway is card money rather than an exclusion
+ *
+ * A single unrecognised gateway is a rail auxx has not named, not an
+ * ambiguity: the order is paid, one processor took it, and `clearing_card` is
+ * the account that then fails to reconcile visibly if the guess was wrong.
+ * TWO gateways is different in kind - the money split, and no single line can
+ * describe it - so that one refuses.
+ *
+ * @see plans/money/tasks/49-bulk-fulfillment-posting.md §3.2, §8.4 decision 6
+ */
+export function resolveFulfillmentDebit(input: {
+  financialStatus: string | null
+  gateways: readonly string[]
+}): FulfillmentDebitResolution {
+  const gateways = normaliseGateways(input.gateways)
+  const listed = gateways.join(', ')
+
+  if (gateways.includes(TEST_GATEWAY)) {
+    return { kind: 'exclude', reason: 'test-gateway', detail: listed }
+  }
+
+  const status = input.financialStatus?.trim().toLowerCase() ?? ''
+  if (!SETTLED_FINANCIAL_STATUSES.has(status)) {
+    return { kind: 'debit', role: 'accounts_receivable' }
+  }
+
+  // Paid, but not through a rail that settles into a clearing account.
+  if (gateways.includes(MANUAL_GATEWAY) || gateways.length === 0) {
+    return { kind: 'debit', role: 'accounts_receivable' }
+  }
+
+  if (gateways.length === 1) {
+    const gateway = gateways[0] as string
+    return { kind: 'debit', role: FULFILLMENT_GATEWAY_DEBIT[gateway] ?? 'clearing_card' }
+  }
+
+  return { kind: 'exclude', reason: 'gateway-ambiguous', detail: listed }
+}
+
+// ── One shipment's amounts ──────────────────────────────────────────────────
+
+/**
+ * This shipment's share of a line's tax.
+ *
+ * `line_item_tax_total` is the tax on the WHOLE line, so a line shipped in two
+ * halves must not book it twice: `round(lineTaxMinor x quantity /
+ * orderedQuantity)`. A missing ordered quantity cannot scale anything, so the
+ * line's tax is taken in full rather than divided by zero - the line shipped,
+ * and under-recognising sales tax owed is the worse of the two errors.
+ */
+function scaleLineTax(line: UnpostedShipmentLine, label: string): number | null {
+  if (line.lineTaxMinor == null) return null
+  const lineTax = toAmountMinor(line.lineTaxMinor, `Line ${line.lineId} tax on ${label}`)
+  const ordered = line.orderedQuantity
+  if (!Number.isFinite(ordered) || ordered <= 0) return lineTax
+  if (line.quantity >= ordered) return lineTax
+  return Math.round((lineTax * line.quantity) / ordered)
+}
+
+/**
+ * One shipment's amounts, ready to be summed into a group.
+ *
+ * PURE. Delegates every rule to `computeShipmentTotals` in
+ * `build-fulfillment-entry.ts` - subtotal from the lines, tax per line when
+ * EVERY line carries one and cumulatively allocated otherwise, shipping in full
+ * exactly once - so the batch entry and a single order's entry cannot drift.
+ * The only thing added here is {@link scaleLineTax}, because an
+ * `UnpostedShipmentLine` carries the whole LINE's tax while
+ * `computeShipmentTotals` wants THIS shipment's.
+ *
+ * @throws {UnprocessableEntityError} on a non-positive quantity or a stored
+ *   amount that is not whole minor units.
+ */
+export function computeShipmentAmounts(
+  shipment: UnpostedShipment,
+  debitRole: FulfillmentDebitRole
+): ShipmentAmounts {
+  const label = `order ${shipment.orderNumber}`
+  const totals = computeShipmentTotals({
+    label,
+    lines: shipment.lines.map((line) => ({
+      lineId: line.lineId,
+      quantity: line.quantity,
+      unitPriceMinor: line.unitPriceMinor,
+      taxMinor: scaleLineTax(line, label),
+    })),
+    orderSubtotalMinor: shipment.orderSubtotalMinor,
+    orderTaxTotalMinor: shipment.orderTaxTotalMinor,
+    priorShipmentsSubtotalMinor: shipment.priorShipmentsSubtotalMinor,
+    orderShippingTotalMinor: shipment.orderShippingTotalMinor,
+    includeShipping: shipment.includeShipping,
+    context: { orderId: shipment.orderId, sequence: String(shipment.sequence) },
+  })
+  return { debitRole, ...totals }
+}
+
+// ── The period key ──────────────────────────────────────────────────────────
+
+/** `AUXX-FUL-`, built from the declared prefix rather than typed twice. */
+const FULFILLMENT_DOC_PREFIX = `AUXX-${DOC_NUMBER_PREFIX.fulfillment}-`
+
+/**
+ * How many characters of compacted period key a fulfillment document number
+ * holds, with room for a reversal.
+ *
+ * `AUXX-FUL-` is 9 and `-R9` is 3, so 9 are left of the 21-character cap. The
+ * budget is exactly enough:
+ *
+ * | grouping | key | compacted | plus an attempt char |
+ * |---|---|---|---|
+ * | day | `2026-07-06` | 8 | 9 |
+ * | week | `2026-W27` | 7 | 8 |
+ * | month | `2026-07` | 6 | 7 |
+ *
+ * 🛑 The `-R9` headroom is the half that is easy to drop and the worst to get
+ * wrong: a key that compacts to 12 posts perfectly at revision 0 and REFUSES
+ * the day somebody reverses it, leaving an entry in the books with no way to
+ * take it out. Same rule every builder in this folder follows.
+ */
+export const MAX_COMPACT_FULFILLMENT_BATCH_KEY =
+  DOC_NUMBER_MAX_LENGTH - FULFILLMENT_DOC_PREFIX.length - '-R9'.length
+
+/** The longest compacted group key the plan can produce: a day, `20260706`. */
+const MAX_GROUP_KEY_COMPACT_LENGTH = 8
+
+/**
+ * 36 attempts, which is what one base-36 character of key budget holds. The
+ * same ceiling, for the same arithmetic, as `MAX_WRITE_OFF_ATTEMPT`.
+ */
+export const MAX_FULFILLMENT_BATCH_ATTEMPT = 35
+
+/**
+ * The period key for one batch posting: the group key, plus an attempt.
+ *
+ * ## Why the attempt exists
+ *
+ * `(organizationId, postingType, periodKey, revision)` is the claim's unique
+ * index and a duplicate comes back `already_posted` - a SUCCESS status that
+ * posts nothing (49 §8.2). A day key claims its day ONCE, so the late order
+ * backfilled into an already-posted day would silently recognise nothing while
+ * the run reported that it had. That is the exact bug `writeOffPeriodKey`
+ * fixed for a partial write-off, and the fix is the same one:
+ *
+ * - **attempt 0** is the group key verbatim, byte for byte. Load-bearing: the
+ *   key is half the uniqueness tuple, so re-keying it would make every posting
+ *   already in a ledger invisible to the idempotency check.
+ * - **attempt 1..35** appends one base-36 character. `buildDocNumber` strips
+ *   hyphens and nothing else, so there is no separator to spend and the
+ *   character is simply appended: `2026-07-06` attempt 1 mints `2026-07-061`
+ *   and the document number `AUXX-FUL-202607061`.
+ *
+ * ⚠️ The run allocates the attempt by COUNTING the live postings whose period
+ * key is this group's, the way `countWriteOffPostings` does - never by
+ * retrying on a conflict, because `already_posted` is not an error to retry.
+ *
+ * @throws {UnprocessableEntityError} on a blank group key, an attempt outside
+ *   `0..35`, or a key that would not survive a reversal inside the cap.
+ */
+export function fulfillmentBatchPeriodKey(groupKey: string, attempt: number): string {
+  const key = groupKey.trim()
+  if (!key) {
+    throw new UnprocessableEntityError(
+      'A batch fulfillment posting needs a group key (a day, an ISO week or a month) to key its ' +
+        'document number on.'
+    )
+  }
+  if (!Number.isInteger(attempt) || attempt < 0) {
+    throw new UnprocessableEntityError(
+      `A fulfillment batch attempt must be a whole number from 0, got ${String(attempt)}`,
+      { groupKey: key, attempt: String(attempt) }
+    )
+  }
+  if (attempt > MAX_FULFILLMENT_BATCH_ATTEMPT) {
+    throw new UnprocessableEntityError(
+      `Period ${key} has already produced ${attempt} fulfillment postings, which is more than the ` +
+        'document-number keyspace can hold. Post the remainder under a narrower grouping.',
+      { groupKey: key, attempt: String(attempt) }
+    )
+  }
+
+  // 🛑 Asserted rather than assumed: a day key plus one attempt character is
+  // exactly the whole budget, so any widening of the prefix or the reversal
+  // suffix breaks the late-order case and nothing else would say so.
+  if (MAX_COMPACT_FULFILLMENT_BATCH_KEY < MAX_GROUP_KEY_COMPACT_LENGTH + 1) {
+    throw new UnprocessableEntityError(
+      `The fulfillment document-number budget is ${MAX_COMPACT_FULFILLMENT_BATCH_KEY} compacted ` +
+        `characters and a day key plus one attempt character needs ` +
+        `${MAX_GROUP_KEY_COMPACT_LENGTH + 1}. A late order backfilled into a posted day could not ` +
+        'be keyed at all.',
+      { budget: String(MAX_COMPACT_FULFILLMENT_BATCH_KEY) }
+    )
+  }
+
+  const periodKey = attempt === 0 ? key : `${key}${attempt.toString(36).toUpperCase()}`
+  const compact = periodKey.replace(/-/g, '')
+  if (compact.length > MAX_COMPACT_FULFILLMENT_BATCH_KEY) {
+    throw new UnprocessableEntityError(
+      `Period key "${periodKey}" compacts to ${compact.length} characters and a fulfillment ` +
+        `document number allows ${MAX_COMPACT_FULFILLMENT_BATCH_KEY} (${DOC_NUMBER_MAX_LENGTH} ` +
+        'total, less "AUXX-FUL-" and a reversal suffix).',
+      { groupKey: key, periodKey, attempt: String(attempt), length: String(compact.length) }
+    )
+  }
+  return periodKey
+}
+
+// ── The entry ───────────────────────────────────────────────────────────────
+
+/** One shipment as the entry froze it. Rides in `BuiltEntry.sources`. */
+export interface FulfillmentBatchSource {
+  orderId: string
+  orderNumber: string
+  /** The shipment log entry's `sequence`, so the stamp can be matched back. */
+  sequence: number
+  amounts: ShipmentAmounts
+}
+
+/** Which posting role each debit answer resolves to. DECLARED, one row each. */
+export const FULFILLMENT_DEBIT_ACCOUNT_ROLE: Readonly<Record<FulfillmentDebitRole, AccountRole>> = {
+  clearing_card: ACCOUNT_ROLES.CLEARING_CARD,
+  clearing_affirm: ACCOUNT_ROLES.CLEARING_AFFIRM,
+  accounts_receivable: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
+}
+
+export interface BuildFulfillmentBatchEntryInput {
+  /** The group to post. Its shipments already carry their `amounts`. */
+  group: FulfillmentPostingGroup
+  /** The one currency the books are kept in. Passed in so this file stays pure. */
+  ledgerCurrency: string
+  /**
+   * 0 on the first claim of this group key; n appends a base-36 attempt
+   * character. See {@link fulfillmentBatchPeriodKey}.
+   */
+  attempt: number
+  /** Carried onto every summarised line. The per-order A/R lines keep the order number. */
+  memo?: string
+}
+
+export interface BuiltFulfillmentBatchEntry {
+  entry: BuiltEntry
+  /** `fulfillmentBatchPeriodKey(group.groupKey, attempt)`. Also `entry.periodKey`. */
+  periodKey: string
+  /** Recomputed from the shipments actually posted, not copied off the group. */
+  totals: FulfillmentPostingGroup['totals']
+}
+
+/** Assert a frozen amount is whole minor units before it decides a ledger line. */
+function assertWholeMinor(value: number, label: string, context: Record<string, string>): number {
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new UnprocessableEntityError(
+      `${label} is ${String(value)}, which is not a whole number of cents.`,
+      context
+    )
+  }
+  return value
+}
+
+/**
+ * Build ONE entry for a whole group of shipments.
+ *
+ * ## It balances BY CONSTRUCTION
+ *
+ * Every debit is a shipment's `totalMinor`; every credit is one component of
+ * the same numbers (`subtotal + tax + shipping === total`, which
+ * `computeShipmentTotals` guarantees and this function re-asserts on each
+ * frozen `amounts`). So `Σ debits === Σ credits` before `buildEntry` is
+ * reached, and `buildEntry`'s own gate can only ever confirm it. The
+ * re-assertion is the load-bearing half: the debits use `totalMinor` and the
+ * credits use its parts, so an `amounts` whose parts do not sum to its total
+ * would produce an entry that genuinely does not balance.
+ *
+ * Zero legs are dropped rather than posted at zero - an org that charges no
+ * tax has no reason to have mapped `sales_tax_payable`, and `buildEntry`
+ * refuses a zero amount outright.
+ *
+ * ## The line order, and what each line is sourced on
+ *
+ * 1. `Dr accounts_receivable`, **one line per order**, `sourceType: 'order'`,
+ *    `sourceId: <orderId>`, memo `<orderNumber>`. Aging has to name the debtor,
+ *    and `listPostingsForSource` on an order still finds this one.
+ * 2. `Dr clearing_card`, `Dr clearing_affirm` - summarised.
+ * 3. `Cr revenue_dtc`, `Cr revenue_dealer` - summarised, split on the order's
+ *    channel through the fail-open {@link CHANNEL_REVENUE_ROLE} table.
+ * 4. `Cr sales_tax_payable` - summarised. 5. `Cr revenue_shipping` - summarised.
+ *
+ * Every summarised line carries `sourceType: 'fulfillment_batch'` and
+ * `sourceId: <periodKey>`, which is what keeps aging free of a branch: an A/R
+ * line is always an order's.
+ *
+ * @throws {UnprocessableEntityError} on an empty group, a shipment in a foreign
+ *   currency, a frozen amount that is not whole minor units or does not sum to
+ *   its own total, or a period key that would not survive a reversal.
+ */
+export function buildFulfillmentBatchEntry(
+  input: BuildFulfillmentBatchEntryInput
+): BuiltFulfillmentBatchEntry {
+  const { group, ledgerCurrency, attempt, memo } = input
+
+  if (group.shipments.length === 0) {
+    throw new UnprocessableEntityError(
+      `Group ${group.groupKey} holds no shipments. A fulfillment posting recognises what left the ` +
+        'building, so there is nothing to post and the period must not be claimed.',
+      { groupKey: group.groupKey }
+    )
+  }
+
+  const periodKey = fulfillmentBatchPeriodKey(group.groupKey, attempt)
+
+  // ── Accumulate ───────────────────────────────────────────────────────────
+  const receivableByOrder = new Map<string, { orderNumber: string; amountMinor: number }>()
+  const byDebitRole: Record<FulfillmentDebitRole, number> = {
+    clearing_card: 0,
+    clearing_affirm: 0,
+    accounts_receivable: 0,
+  }
+  const revenueByRole = new Map<AccountRole, number>()
+  const sources: FulfillmentBatchSource[] = []
+  let subtotalMinor = 0
+  let taxMinor = 0
+  let shippingMinor = 0
+  let totalMinor = 0
+
+  for (const shipment of group.shipments) {
+    const context = {
+      groupKey: group.groupKey,
+      orderId: shipment.orderId,
+      orderNumber: shipment.orderNumber,
+      sequence: String(shipment.sequence),
+    }
+
+    // A silent 1.0 rate is unrecoverable: the entry balances, the trial balance
+    // ties, and the revenue is the wrong number in the wrong unit. The plan
+    // excludes a foreign shipment before it ever gets here; this is the assert.
+    const currency = shipment.currency?.trim() || ledgerCurrency
+    if (currency !== ledgerCurrency) {
+      throw new UnprocessableEntityError(
+        `Order ${shipment.orderNumber} is in ${currency} and the ledger is kept in ` +
+          `${ledgerCurrency}. Posting it would use an implied 1.0 rate.`,
+        { ...context, currency, ledgerCurrency }
+      )
+    }
+
+    const amounts = shipment.amounts
+    assertWholeMinor(amounts.subtotalMinor, `Shipment subtotal on ${shipment.orderNumber}`, context)
+    assertWholeMinor(amounts.taxMinor, `Shipment tax on ${shipment.orderNumber}`, context)
+    assertWholeMinor(amounts.shippingMinor, `Shipment shipping on ${shipment.orderNumber}`, context)
+    assertWholeMinor(amounts.totalMinor, `Shipment total on ${shipment.orderNumber}`, context)
+    const parts = amounts.subtotalMinor + amounts.taxMinor + amounts.shippingMinor
+    if (parts !== amounts.totalMinor) {
+      throw new UnprocessableEntityError(
+        `Shipment ${shipment.sequence} of order ${shipment.orderNumber} carries a total of ` +
+          `${amounts.totalMinor} and parts summing to ${parts}. The debit is the total and the ` +
+          'credits are its parts, so the entry could not balance.',
+        { ...context, totalMinor: String(amounts.totalMinor), parts: String(parts) }
+      )
+    }
+
+    if (amounts.debitRole === 'accounts_receivable') {
+      const existing = receivableByOrder.get(shipment.orderId)
+      receivableByOrder.set(shipment.orderId, {
+        orderNumber: shipment.orderNumber,
+        amountMinor: (existing?.amountMinor ?? 0) + amounts.totalMinor,
+      })
+    }
+    byDebitRole[amounts.debitRole] += amounts.totalMinor
+
+    const revenueRole = CHANNEL_REVENUE_ROLE[toChannelKey(shipment.channel)]
+    revenueByRole.set(revenueRole, (revenueByRole.get(revenueRole) ?? 0) + amounts.subtotalMinor)
+
+    subtotalMinor += amounts.subtotalMinor
+    taxMinor += amounts.taxMinor
+    shippingMinor += amounts.shippingMinor
+    totalMinor += amounts.totalMinor
+
+    sources.push({
+      orderId: shipment.orderId,
+      orderNumber: shipment.orderNumber,
+      sequence: shipment.sequence,
+      amounts,
+    })
+  }
+
+  // ── The lines, in the order a reader expects them ────────────────────────
+  const summarised = { sourceType: FULFILLMENT_BATCH_SOURCE_TYPE, sourceId: periodKey }
+  const describe = (what: string): string =>
+    memo ? `${memo} - ${what}` : `${group.groupKey} - ${what}`
+  const lines: GlPostingLineInput[] = []
+  const push = (line: Omit<GlPostingLineInput, 'sortOrder'>): void => {
+    lines.push({ ...line, sortOrder: lines.length } as GlPostingLineInput)
+  }
+
+  // 1. The receivable, ONE LINE PER ORDER. Aging needs the debtor, so this leg
+  //    alone stays at order grain (49 §2.5).
+  for (const [orderId, receivable] of receivableByOrder) {
+    if (receivable.amountMinor === 0) continue
+    push({
+      sourceType: FULFILLMENT_SOURCE_TYPE,
+      sourceId: orderId,
+      accountRole: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
+      direction: 'debit',
+      amount: receivable.amountMinor,
+      memo: receivable.orderNumber,
+    })
+  }
+
+  // 2. The clearing accounts, summarised.
+  if (byDebitRole.clearing_card !== 0) {
+    push({
+      ...summarised,
+      accountRole: ACCOUNT_ROLES.CLEARING_CARD,
+      direction: 'debit',
+      amount: byDebitRole.clearing_card,
+      memo: describe('card clearing'),
+    })
+  }
+  if (byDebitRole.clearing_affirm !== 0) {
+    push({
+      ...summarised,
+      accountRole: ACCOUNT_ROLES.CLEARING_AFFIRM,
+      direction: 'debit',
+      amount: byDebitRole.clearing_affirm,
+      memo: describe('Affirm clearing'),
+    })
+  }
+
+  // 3. Revenue, summarised per channel.
+  const dtcMinor = revenueByRole.get(ACCOUNT_ROLES.REVENUE_DTC) ?? 0
+  const dealerMinor = revenueByRole.get(ACCOUNT_ROLES.REVENUE_DEALER) ?? 0
+  if (dtcMinor !== 0) {
+    push({
+      ...summarised,
+      accountRole: ACCOUNT_ROLES.REVENUE_DTC,
+      direction: 'credit',
+      amount: dtcMinor,
+      memo: describe('product revenue, direct to consumer'),
+    })
+  }
+  if (dealerMinor !== 0) {
+    push({
+      ...summarised,
+      accountRole: ACCOUNT_ROLES.REVENUE_DEALER,
+      direction: 'credit',
+      amount: dealerMinor,
+      memo: describe('product revenue, dealer'),
+    })
+  }
+
+  // 4 and 5. Tax and shipping, summarised.
+  if (taxMinor !== 0) {
+    push({
+      ...summarised,
+      accountRole: ACCOUNT_ROLES.SALES_TAX_PAYABLE,
+      direction: 'credit',
+      amount: taxMinor,
+      memo: describe('sales tax'),
+    })
+  }
+  if (shippingMinor !== 0) {
+    push({
+      ...summarised,
+      accountRole: ACCOUNT_ROLES.REVENUE_SHIPPING,
+      direction: 'credit',
+      amount: shippingMinor,
+      memo: describe('shipping revenue'),
+    })
+  }
+
+  const built = buildEntry({
+    postingType: 'fulfillment',
+    periodKey,
+    txnDate: group.txnDate,
+    lines,
+  })
+
+  return {
+    // The frozen slice rides into `GlPosting.draft` with the entry - see
+    // `BuiltEntry.sources` and `buildPostingDraft`.
+    entry: { ...built, sources },
+    periodKey,
+    totals: { subtotalMinor, taxMinor, shippingMinor, totalMinor, byDebitRole },
+  }
+}

--- a/packages/lib/src/postings/build-fulfillment-entry.ts
+++ b/packages/lib/src/postings/build-fulfillment-entry.ts
@@ -81,23 +81,39 @@ export type OrderChannelKey = 'dtc' | 'dealer' | 'manual' | 'null'
 /**
  * Which revenue role each order channel books to. DECLARED, never derived.
  *
- * 🛑 **It must fail CLOSED, and two of the four rows do.** `4000` and `4010` are
- * two revenue accounts and a default to DTC would put every dealer sale in the
- * consumer line - an entry that balances perfectly and is invisible until
- * somebody reads the P&L by channel. So `manual` and `null` REFUSE, naming the
- * order and the channel (handoff decision 6.2). A manual sale is not a channel;
- * it is a sale whose channel nobody has recorded, and the remedy is to record
- * it on the order.
+ * ## ⤵️ It fails OPEN, and it used to fail closed
+ *
+ * `manual` and `null` used to REFUSE, on the argument that `4000` and `4010` are
+ * two revenue accounts and a default to DTC puts a dealer sale in the consumer
+ * line, where it balances and is invisible until somebody reads the P&L by
+ * channel. The argument is sound and the answer was still wrong, for a reason
+ * the data settled (49 §4.6, §8.1 item 6, §8.4 decision 5):
+ *
+ * - `order_channel` is **human-set, never derived**, and no connector binds it.
+ *   535 of 545 orders on the reference org carry the registry DEFAULT, `manual`.
+ * - So the refusal did not protect a split; it refused **every imported order**,
+ *   and the P&L by channel it was defending held nothing at all.
+ * - Neither dealer signal (`contact_customer_type`, B2B terms) reaches the
+ *   database yet, so nothing can set the value correctly in bulk either.
+ *
+ * A default that recognises consumer revenue is the honest reading of *"nobody
+ * has said"* for a business whose unmarked orders are Shopify checkouts. It is
+ * also **correctable**: an order booked to the wrong revenue line is fixed by
+ * setting the channel and posting a compensating entry, whereas revenue that
+ * was never recognised at all is invisible. When the dealer signal lands, the
+ * `dealer` row is already here and the default stops being reached.
  *
  * Widening this table is a one-line edit here plus a role in `ACCOUNT_ROLES`.
  * Deriving it from `paymentGateways` or tags was tried and cannot work: a manual
  * sale has neither.
  */
-export const CHANNEL_REVENUE_ROLE: Record<OrderChannelKey, AccountRole | 'refuse'> = {
+export const CHANNEL_REVENUE_ROLE: Record<OrderChannelKey, AccountRole> = {
   dtc: ACCOUNT_ROLES.REVENUE_DTC,
   dealer: ACCOUNT_ROLES.REVENUE_DEALER,
-  manual: 'refuse',
-  null: 'refuse',
+  // "Somebody typed manual" and "nobody has said" are still two different facts
+  // - see `OrderChannelKey` - and they simply have the same answer today.
+  manual: ACCOUNT_ROLES.REVENUE_DTC,
+  null: ACCOUNT_ROLES.REVENUE_DTC,
 }
 
 /** Normalise a stored `order_channel` value - anything unrecognised is `'null'`. */
@@ -164,6 +180,152 @@ export function extendRateToAmount(rateMinor: number, quantity: number, label: s
   return Math.round(rateMinor * quantity)
 }
 
+/** One shipped line as {@link computeShipmentTotals} reads it. */
+export interface ShipmentTotalsLine {
+  /** For the refusal message only. Never a lookup key here. */
+  lineId: string
+  /** Units shipped in THIS shipment. */
+  quantity: number
+  /** Minor units per unit. A RATE, so it may be fractional - see {@link extendRateToAmount}. */
+  unitPriceMinor: number
+  /**
+   * This shipment's tax on this line, whole minor units, when it is known per
+   * line. `null` and `undefined` both mean NOT SUPPLIED, which is not zero.
+   *
+   * 🛑 Already SCALED to what shipped. A caller holding the whole line's tax
+   * against a partial shipment scales it first - `computeShipmentAmounts` in
+   * `build-fulfillment-batch-entry.ts` is the one that does.
+   */
+  taxMinor?: number | null
+}
+
+/** What one shipment contributes, all whole minor units. */
+export interface ShipmentTotals {
+  subtotalMinor: number
+  taxMinor: number
+  shippingMinor: number
+  /** `subtotal + tax + shipping`. The debit. */
+  totalMinor: number
+  /** How `taxMinor` was arrived at. A screen says which. */
+  taxBasis: 'per_line' | 'allocated'
+}
+
+export interface ShipmentTotalsInput {
+  /** What the shipment belongs to, for a refusal: `'order ORD-0012'`. */
+  label: string
+  lines: readonly ShipmentTotalsLine[]
+  /** `order_subtotal`, integer minor units. The denominator of the allocation. */
+  orderSubtotalMinor: number
+  /** `order_tax_total`, integer minor units. */
+  orderTaxTotalMinor: number
+  /** Sum of every EARLIER shipment's subtotal. `0` on the first. */
+  priorShipmentsSubtotalMinor?: number
+  /** `order_shipping_total`, integer minor units. */
+  orderShippingTotalMinor: number
+  /** Whether THIS shipment carries the order's shipping revenue. */
+  includeShipping: boolean
+  /** Extra keys on any refusal thrown from here. */
+  context?: Record<string, string>
+}
+
+/**
+ * One shipment's share of its order. **The single implementation of the
+ * proportional rules**, called by both fulfillment builders.
+ *
+ * It was inlined in {@link buildFulfillmentEntry} until the batch builder
+ * needed the same numbers (49 §2.3). Two copies of this arithmetic would be two
+ * keyspaces free to drift, and a drift is undetectable from the outside: the
+ * per-order entry and the summarised one would both balance and disagree about
+ * what a day recognised.
+ *
+ * - **Subtotal** is `Σ round(quantity x unitPriceMinor)` over the lines. From
+ *   the LINES, never sliced off `order_subtotal`, because the lines are what
+ *   actually left the building.
+ * - **Tax** is per line when EVERY line carries `taxMinor`, and otherwise
+ *   allocated pro rata CUMULATIVELY:
+ *   `alloc(prior + this) - alloc(prior)`, where
+ *   `alloc(x) = round(orderTaxTotal x x / orderSubtotal)`. Allocating each
+ *   shipment on its own drops the rounding remainder and leaves the receivable
+ *   permanently short - three equal shipments of a 300 order carrying 100 of
+ *   tax get 33 each and the missing cent can never be cleared. The difference
+ *   of two running allocations hands the remainder to whichever shipment
+ *   carries the subtotal over the line, with no "is this the last one" flag to
+ *   get wrong. An order with a zero subtotal allocates zero rather than
+ *   dividing by it.
+ *
+ *   The all-or-nothing per-line rule is deliberate: mixing a known per-line tax
+ *   with an allocated remainder double-counts the lines that carried one.
+ * - **Shipping** is the order's shipping in FULL when `includeShipping`, and
+ *   zero otherwise. Prorating invents a split the carrier never charged, and
+ *   holding it to the LAST shipment means an order that is never completed
+ *   never books the shipping it collected.
+ *
+ * Does NOT refuse a shipment worth nothing: zero is a REFUSAL for the
+ * single-order builder and an EXCLUSION for the batch plan, and only the caller
+ * knows which.
+ *
+ * @throws {UnprocessableEntityError} on a non-positive or non-finite quantity,
+ *   or a stored amount that is not whole minor units.
+ */
+export function computeShipmentTotals(input: ShipmentTotalsInput): ShipmentTotals {
+  const { label, lines, includeShipping, context } = input
+
+  let subtotalMinor = 0
+  let perLineTaxMinor = 0
+  let linesWithTax = 0
+  for (const [index, line] of lines.entries()) {
+    const row = index + 1
+    if (!Number.isFinite(line.quantity) || line.quantity <= 0) {
+      throw new UnprocessableEntityError(
+        `Row ${row} of ${label} ships ${String(line.quantity)} units. A fulfillment carries what ` +
+          'actually shipped, so a quantity is always above zero - drop the line instead.',
+        { ...context, lineId: line.lineId, row: String(row) }
+      )
+    }
+    subtotalMinor += extendRateToAmount(
+      line.unitPriceMinor,
+      line.quantity,
+      `Row ${row} of ${label}`
+    )
+    if (line.taxMinor != null) {
+      perLineTaxMinor += toAmountMinor(line.taxMinor, `Row ${row} tax on ${label}`)
+      linesWithTax++
+    }
+  }
+
+  const orderSubtotalMinor = toAmountMinor(input.orderSubtotalMinor, `Subtotal of ${label}`)
+  const orderTaxTotalMinor = toAmountMinor(input.orderTaxTotalMinor, `Tax total of ${label}`)
+  const priorSubtotalMinor = toAmountMinor(
+    input.priorShipmentsSubtotalMinor,
+    `Prior shipment subtotal of ${label}`
+  )
+  const orderShippingTotalMinor = toAmountMinor(
+    input.orderShippingTotalMinor,
+    `Shipping total of ${label}`
+  )
+
+  const taxBasis: 'per_line' | 'allocated' =
+    lines.length > 0 && linesWithTax === lines.length ? 'per_line' : 'allocated'
+  const allocateThrough = (cumulativeSubtotalMinor: number): number =>
+    orderSubtotalMinor > 0
+      ? Math.round((orderTaxTotalMinor * cumulativeSubtotalMinor) / orderSubtotalMinor)
+      : 0
+  const taxMinor =
+    taxBasis === 'per_line'
+      ? perLineTaxMinor
+      : allocateThrough(priorSubtotalMinor + subtotalMinor) - allocateThrough(priorSubtotalMinor)
+
+  const shippingMinor = includeShipping ? orderShippingTotalMinor : 0
+
+  return {
+    subtotalMinor,
+    taxMinor,
+    shippingMinor,
+    totalMinor: subtotalMinor + taxMinor + shippingMinor,
+    taxBasis,
+  }
+}
+
 /** One order line, and how much of it went out in THIS shipment. */
 export interface FulfillmentShippedLine {
   /** The `line_item` EntityInstance id. Also what the caller validates remaining against. */
@@ -192,7 +354,10 @@ export interface BuildFulfillmentEntryInput {
   orderNumber: string
   /** 1-based. The first shipment of an order is `1`, and keys `ORD-0012-F1`. */
   sequence: number
-  /** `order_channel`, verbatim. `manual` and absent both REFUSE. */
+  /**
+   * `order_channel`, verbatim. `manual` and absent both recognise as CONSUMER
+   * revenue - the table fails open. See {@link CHANNEL_REVENUE_ROLE}.
+   */
   channel: string | null | undefined
   /** `order_currency`, verbatim. Anything but `ledgerCurrency` REFUSES. */
   currency: string | null | undefined
@@ -356,9 +521,10 @@ export function fulfillmentPeriodKey(orderNumber: string, sequence: number): str
  * that cannot compute its own arithmetic is a bug, and `postEntry` above it
  * converts the throw into a status.
  *
- * @throws {UnprocessableEntityError} on a refused channel, a foreign currency,
- *   no shipped lines, a non-positive quantity, a fractional stored amount, an
- *   over-long order number, or an entry with no value on either side.
+ * @throws {UnprocessableEntityError} on a foreign currency, no shipped lines, a
+ *   non-positive quantity, a fractional stored amount, an over-long order
+ *   number, or an entry with no value on either side. NOT on an unset channel:
+ *   see {@link CHANNEL_REVENUE_ROLE}.
  */
 export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltFulfillmentEntry {
   const {
@@ -390,17 +556,10 @@ export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltF
   }
 
   // ── The channel, from the DECLARED table ─────────────────────────────────
+  // Fails OPEN: an unset channel recognises as consumer revenue rather than
+  // refusing the shipment. See CHANNEL_REVENUE_ROLE for why that changed.
   const channelKey = toChannelKey(channel)
   const revenueRole = CHANNEL_REVENUE_ROLE[channelKey]
-  if (revenueRole === 'refuse') {
-    throw new UnprocessableEntityError(
-      `Order ${orderNumber} has channel "${channelKey === 'null' ? 'none' : channelKey}", which ` +
-        'has no revenue account. Product revenue is split DTC vs Dealer and defaulting to either ' +
-        'would put the sale in the wrong line of the P&L, where it balances and is invisible. ' +
-        'Set the order channel to Direct to consumer or Dealer and fulfil again.',
-      { orderNumber, channel: channelKey }
-    )
-  }
 
   if (shippedLines.length === 0) {
     throw new UnprocessableEntityError(
@@ -410,66 +569,19 @@ export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltF
     )
   }
 
-  // ── This shipment's subtotal, from the lines ─────────────────────────────
-  let subtotalMinor = 0
-  let perLineTaxMinor = 0
-  let linesWithTax = 0
-  for (const [index, line] of shippedLines.entries()) {
-    const row = index + 1
-    if (!Number.isFinite(line.quantity) || line.quantity <= 0) {
-      throw new UnprocessableEntityError(
-        `Row ${row} of order ${orderNumber} ships ${String(line.quantity)} units. A fulfillment ` +
-          'carries what actually shipped, so a quantity is always above zero - drop the line instead.',
-        { orderNumber, lineId: line.lineId, row: String(row) }
-      )
-    }
-    subtotalMinor += extendRateToAmount(
-      line.unitPriceMinor,
-      line.quantity,
-      `Row ${row} of order ${orderNumber}`
-    )
-    if (line.taxMinor != null) {
-      perLineTaxMinor += toAmountMinor(line.taxMinor, `Row ${row} tax on order ${orderNumber}`)
-      linesWithTax++
-    }
-  }
-
-  const orderSubtotalMinor = toAmountMinor(
-    input.orderSubtotalMinor,
-    `Order ${orderNumber} subtotal`
-  )
-  const orderTaxTotalMinor = toAmountMinor(input.orderTaxTotalMinor, `Order ${orderNumber} tax`)
-  const priorSubtotalMinor = toAmountMinor(
-    input.priorShipmentsSubtotalMinor,
-    `Order ${orderNumber} prior shipment subtotal`
-  )
-  const orderShippingTotalMinor = toAmountMinor(
-    input.orderShippingTotalMinor,
-    `Order ${orderNumber} shipping`
-  )
-
-  // ── Tax: per line, or allocated pro rata. Never both ─────────────────────
-  const taxBasis: 'per_line' | 'allocated' =
-    linesWithTax === shippedLines.length ? 'per_line' : 'allocated'
-  // 🛑 CUMULATIVE, not per-shipment. `round(tax x thisSubtotal / orderSubtotal)`
-  // computed independently per shipment loses the remainder - three equal
-  // shipments of a 300 order with 100 of tax allocate 33 each and A/R never
-  // clears. Taking the difference of two running allocations gives the same
-  // answer for a first (or only) shipment and hands the whole remainder to
-  // whichever shipment carries the subtotal over the line, which is exactly the
-  // "two entries sum to the order total when the order completes" claim the
-  // JSDoc makes. See `priorShipmentsSubtotalMinor`.
-  const allocateThrough = (cumulativeSubtotalMinor: number): number =>
-    orderSubtotalMinor > 0
-      ? Math.round((orderTaxTotalMinor * cumulativeSubtotalMinor) / orderSubtotalMinor)
-      : 0
-  const taxMinor =
-    taxBasis === 'per_line'
-      ? perLineTaxMinor
-      : allocateThrough(priorSubtotalMinor + subtotalMinor) - allocateThrough(priorSubtotalMinor)
-
-  const shippingMinor = includeShipping ? orderShippingTotalMinor : 0
-  const totalMinor = subtotalMinor + taxMinor + shippingMinor
+  // ── This shipment's share of the order ───────────────────────────────────
+  // The arithmetic itself lives in `computeShipmentTotals`, which the BATCH
+  // builder calls with the same numbers. One implementation, two callers.
+  const { subtotalMinor, taxMinor, shippingMinor, totalMinor, taxBasis } = computeShipmentTotals({
+    label: `order ${orderNumber}`,
+    lines: shippedLines,
+    orderSubtotalMinor: input.orderSubtotalMinor,
+    orderTaxTotalMinor: input.orderTaxTotalMinor,
+    priorShipmentsSubtotalMinor: input.priorShipmentsSubtotalMinor,
+    orderShippingTotalMinor: input.orderShippingTotalMinor,
+    includeShipping,
+    context: { orderNumber },
+  })
 
   if (totalMinor <= 0) {
     throw new UnprocessableEntityError(

--- a/packages/lib/src/postings/build-payment-entry.ts
+++ b/packages/lib/src/postings/build-payment-entry.ts
@@ -64,13 +64,16 @@
  *    but the caller still supplies it: the builder is pure and the writer is
  *    the one that knows what it is posting. See
  *    {@link BuildPaymentEntryInput.postingType}.
- * 2. **Which clearing account.** `ACCOUNT_ROLES` has exactly one clearing role,
- *    `clearing_card` (`1200`), so `'clearing'` maps to it. The chart also
- *    holds `1210 Affirm Clearing` with no role, and its own warning: Affirm
- *    settlements are invisible to the payouts API, so an Affirm order routed to
- *    `1200` makes that account impossible to reconcile to zero. When a second
- *    clearing role lands, {@link PAYMENT_ROUTE_ROLE} grows a discriminator on
- *    the gateway rather than on the method.
+ * 2. **Which clearing account.** A `PaymentRoute` is a payment METHOD, and
+ *    `'clearing'` maps to `clearing_card` (`1200`). ⚠️ `ACCOUNT_ROLES` gained a
+ *    second clearing role, `clearing_affirm` (`1210`), for the fulfillment
+ *    debit fork (49 §8.4 decision 6) - and this table still cannot reach it,
+ *    because a method does not say which gateway took the money. Affirm
+ *    settlements are invisible to the payouts API, so an Affirm charge routed to
+ *    `1200` makes that account impossible to reconcile to zero. When a payment
+ *    has to tell the two apart, {@link PAYMENT_ROUTE_ROLE} grows a discriminator
+ *    on the GATEWAY rather than on the method, the way `resolveFulfillmentDebit`
+ *    already does.
  *
  * @see plans/accounting/tasks/01-post-revenue-to-the-ledger.md §1.2
  * @see plans/accounting/tasks/06-deposit-grouping.md §2.3

--- a/packages/lib/src/postings/build-payout-entry.ts
+++ b/packages/lib/src/postings/build-payout-entry.ts
@@ -88,7 +88,17 @@ import type { BuiltEntry, GlPostingLineInput } from './types'
 /** The `sourceType` every payout line carries. */
 export const PAYOUT_SOURCE_TYPE = 'payout'
 
-/** The clearing roles a payout may drain. One role exists today. */
+/**
+ * The clearing roles a payout may drain. `clearing_card`, and only ever that.
+ *
+ * 🛑 **`clearing_affirm` is excluded BY CONSTRUCTION, not by omission.** An
+ * Affirm settlement never lands on the card rail, so it is invisible to the
+ * payouts API and no payout can ever relieve `1210` (accrual plan §3, 49 §3.2).
+ * Adding the role here would let a card payout drain an account its deposit
+ * never touched: the entry would balance, `1210` would go negative by the
+ * Affirm sales it was holding, and nothing downstream could detect it. Affirm
+ * clears when an Affirm settlement feed exists, through its own entry.
+ */
 export const PAYOUT_CLEARING_ROLES: readonly AccountRole[] = [ACCOUNT_ROLES.CLEARING_CARD]
 
 export interface BuildPayoutEntryInput {

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -44,6 +44,25 @@ export {
   ROLE_ACCOUNT_TYPES,
   type VendorBillEntryInput,
 } from './build-entry'
+// ── plans/money/tasks/49: one fulfillment posting per day, not per shipment ──
+// PURE. Reaches `errors`, `build-entry`, `build-fulfillment-entry`, `doc-number`
+// and `money/fulfillment-posting/types` (types and constants only, no db), all
+// of which are safe in a browser.
+export {
+  type BuildFulfillmentBatchEntryInput,
+  type BuiltFulfillmentBatchEntry,
+  buildFulfillmentBatchEntry,
+  computeShipmentAmounts,
+  FULFILLMENT_DEBIT_ACCOUNT_ROLE,
+  FULFILLMENT_GATEWAY_DEBIT,
+  type FulfillmentBatchSource,
+  type FulfillmentDebitExclusionReason,
+  type FulfillmentDebitResolution,
+  fulfillmentBatchPeriodKey,
+  MAX_COMPACT_FULFILLMENT_BATCH_KEY,
+  MAX_FULFILLMENT_BATCH_ATTEMPT,
+  resolveFulfillmentDebit,
+} from './build-fulfillment-batch-entry'
 // ── HANDOFF slot 2G: the revenue side ───────────────────────────────────────
 // All three builders are PURE and reach nothing but `errors`, `build-entry` and
 // `doc-number`, which are already on this surface. `post-payout-entry.ts` is
@@ -53,11 +72,15 @@ export {
   type BuiltFulfillmentEntry,
   buildFulfillmentEntry,
   CHANNEL_REVENUE_ROLE,
+  computeShipmentTotals,
   extendRateToAmount,
   FULFILLMENT_SOURCE_TYPE,
   type FulfillmentShippedLine,
   fulfillmentPeriodKey,
   type OrderChannelKey,
+  type ShipmentTotals,
+  type ShipmentTotalsInput,
+  type ShipmentTotalsLine,
   toAmountMinor,
   toChannelKey,
 } from './build-fulfillment-entry'

--- a/packages/lib/src/postings/close-month.ts
+++ b/packages/lib/src/postings/close-month.ts
@@ -16,6 +16,12 @@
 // | `previewEntry`                  | `EntryPreview.blockedBy`          |
 // | `postEntry`                     | `PostResult.status` - never throws |
 //
+// A fourth was added by task 49: the COMPLETENESS gate. Balance is not
+// completeness, and a month whose shipments have never been posted, or whose
+// channel credit memos are still drafts, is short of revenue however well its
+// entries tie. `classifyIncompleteRevenue` refuses it as `revenue_incomplete`
+// between the gather and the build - see that function for why that position.
+//
 // The close console has exactly one treatment for a refusal: `entry-blockers.tsx`
 // renders `preview.blockedBy` as an actionable line. So `previewMonthEnd` folds
 // every idiom into `blockedBy` and `postMonthEnd` folds every idiom into a
@@ -82,6 +88,8 @@
 import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { AuxxError, UnprocessableEntityError } from '../errors'
+import { countUnissuedChannelCreditMemos } from '../money/credit-memos/reads'
+import { countUnpostedShipments } from '../money/fulfillment-posting/reads'
 import {
   type BuiltMonthEndInventoryDraft,
   buildMonthEndInventoryEntry,
@@ -240,6 +248,24 @@ async function prepareClose(
     return { refusal: unexpected(error, organizationId, periodKey) }
   }
 
+  // ── Completeness, between the gather and the build ────────────────────────
+  //
+  // 🛑 Placed HERE, and the position is the whole of the ordering decision.
+  //
+  // AFTER the gather, so every CONFIGURATION refusal still wins: a draft setup
+  // is `setup_incomplete` and a month at or before the cutoff is `period_closed`
+  // whatever revenue it holds - both of those say "this month can never be
+  // closed by this system", and telling somebody to post its fulfillments first
+  // would send them to a dialog that excludes those very shipments.
+  //
+  // BEFORE the build, so it wins over `nothing_to_close`. A month with no
+  // inventory movement and a week of unposted shipments is the single most
+  // likely shape of this refusal on a connector-fed org, and reporting it as
+  // "nothing moved this month" would invite exactly the close the rule exists
+  // to prevent.
+  const incomplete = await classifyIncompleteRevenue(db, organizationId, periodKey)
+  if (incomplete) return { refusal: incomplete }
+
   let draft: BuiltMonthEndInventoryDraft
   try {
     draft = buildMonthEndInventoryEntry(inputs)
@@ -252,6 +278,108 @@ async function prepareClose(
   } catch (error) {
     return { refusal: classifyLockError(error, organizationId, periodKey, draft.entry.txnDate) }
   }
+}
+
+// ── Completeness ───────────────────────────────────────────────────────────
+
+/**
+ * Refuse the close while the month still holds revenue that is not in the books
+ * (49 §2.4 and §8.4 decision 7; 10 §3.4).
+ *
+ * Two things can be outstanding and both are counted, because the remedy is
+ * different for each and a message naming only one sends somebody back twice:
+ *
+ * - **A shipped fulfillment with no live posting.** The goods left and the sale
+ *   is not on the P&L. Fixed in the posting dialog, or automatically if the org
+ *   has set `accounting.fulfillmentPosting` to `auto`.
+ * - **A `channel` credit memo still in draft.** A refund the connector ingested
+ *   that nobody has issued or voided. Fixed on the memo.
+ *
+ * 🛑 A refusal, not a warning. Closing a month declares those books shut, and
+ * the entry that is owed cannot then be written into it: `period-lock.ts` exists
+ * to refuse exactly that. So a warn-only close would leave revenue permanently
+ * off a month somebody has just certified, which is the one outcome neither of
+ * the two plans would accept.
+ *
+ * ⚠️ Never throws, and never blocks the close on its OWN failure. If either
+ * count cannot be read, the close proceeds: a broken read here must not be able
+ * to hold an organization's books hostage, and the completeness banner reports
+ * the same two numbers on the ledger page independently.
+ *
+ * @returns The refusal, or `null` when nothing is outstanding.
+ */
+async function classifyIncompleteRevenue(
+  db: Database,
+  organizationId: string,
+  periodKey: string
+): Promise<CloseRefusal | null> {
+  let shipments = 0
+  let memos = 0
+  try {
+    const counted = await countUnpostedShipments(db, { organizationId, month: periodKey })
+    if (counted.isErr()) {
+      logger.error('Could not count unposted shipments for the close', {
+        organizationId,
+        periodKey,
+        error: counted.error.message,
+      })
+    } else {
+      shipments = counted.value
+    }
+    memos = await countUnissuedChannelCreditMemos(db, { organizationId, month: periodKey })
+  } catch (error) {
+    logger.error('Could not check the month for unposted revenue', {
+      organizationId,
+      periodKey,
+      error,
+    })
+    return null
+  }
+
+  if (shipments === 0 && memos === 0) return null
+
+  const month = monthLabel(periodKey)
+  const sentences: string[] = []
+  if (shipments > 0) {
+    sentences.push(
+      `${shipments} ${shipments === 1 ? 'shipment is' : 'shipments are'} not posted. ` +
+        `Post the fulfillments for ${month} with the posting dialog.`
+    )
+  }
+  if (memos > 0) {
+    sentences.push(
+      `${memos} channel credit ${memos === 1 ? 'memo is' : 'memos are'} still a draft. ` +
+        `Issue or void the channel credit memos dated in ${month}.`
+    )
+  }
+
+  return {
+    status: 'revenue_incomplete',
+    error: `${month} still holds revenue that is not in the books. ${sentences.join(' ')}`,
+    failureClass: 'data',
+  }
+}
+
+/**
+ * `'2026-07'` becomes `'July 2026'`, for the refusal sentence.
+ *
+ * The year is carried deliberately: a close console can be looking at any month
+ * of any year, and "Post the fulfillments for July" is ambiguous the moment an
+ * organization is more than a year old. A key that is not a month is returned
+ * unchanged rather than mangled - `GlPosting` documents keys that are not dates
+ * at all.
+ */
+function monthLabel(periodKey: string): string {
+  const match = /^(\d{4})-(\d{2})$/.exec(periodKey)
+  if (!match) return periodKey
+  const year = Number(match[1])
+  const month = Number(match[2])
+  if (!Number.isFinite(year) || month < 1 || month > 12) return periodKey
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(year, month - 1, 1)))
 }
 
 // ── Classification ─────────────────────────────────────────────────────────

--- a/packages/lib/src/postings/default-chart.ts
+++ b/packages/lib/src/postings/default-chart.ts
@@ -155,9 +155,16 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     // Must EXCLUDE every Affirm-gateway order or 1200 can never reconcile to
     // zero: an Affirm settlement never lands on the card rail, so it is
     // invisible to the payouts API (accrual plan §3).
+    //
+    // The role is what makes that exclusion mechanical rather than a rule
+    // somebody has to remember: the fulfillment debit fork routes an `affirm`
+    // gateway to `clearing_affirm`, and `PAYOUT_CLEARING_ROLES` holds
+    // `clearing_card` alone (49 §3.2, §8.4 decision 6). Entity migration 137
+    // stamps this role onto orgs seeded before it existed.
     code: '1210',
     name: 'Affirm Clearing',
     accountType: GlAccountType.ASSET,
+    role: 'clearing_affirm',
   },
   {
     code: '1310',

--- a/packages/lib/src/postings/draft.ts
+++ b/packages/lib/src/postings/draft.ts
@@ -51,6 +51,15 @@ export interface PostingDraftV1 {
   docNumber: string
   revision: number
   memo?: string
+  /**
+   * The entry as the builder produced it, whole.
+   *
+   * ⚠️ That includes `BuiltEntry.sources` - the frozen per-source list a
+   * SUMMARISED entry carries, because its lines name a period key rather than
+   * the fifty orders behind them (49 §2.5). Nothing here has to know the shape:
+   * the envelope carries the entry verbatim, so a new optional field on
+   * `BuiltEntry` reaches the audit record with no version bump. `v` stays `1`.
+   */
   entry: BuiltEntry
   /**
    * Post-resolution. A provider never sees a role.

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -48,17 +48,40 @@ export {
   ROLE_ACCOUNT_TYPES,
   type VendorBillEntryInput,
 } from './build-entry'
+// ── plans/money/tasks/49: one fulfillment posting per day, not per shipment ──
+// PURE. Reaches `errors`, `build-entry`, `build-fulfillment-entry`, `doc-number`
+// and `money/fulfillment-posting/types` (types and constants only, no db), all
+// of which are safe in a browser.
+export {
+  type BuildFulfillmentBatchEntryInput,
+  type BuiltFulfillmentBatchEntry,
+  buildFulfillmentBatchEntry,
+  computeShipmentAmounts,
+  FULFILLMENT_DEBIT_ACCOUNT_ROLE,
+  FULFILLMENT_GATEWAY_DEBIT,
+  type FulfillmentBatchSource,
+  type FulfillmentDebitExclusionReason,
+  type FulfillmentDebitResolution,
+  fulfillmentBatchPeriodKey,
+  MAX_COMPACT_FULFILLMENT_BATCH_KEY,
+  MAX_FULFILLMENT_BATCH_ATTEMPT,
+  resolveFulfillmentDebit,
+} from './build-fulfillment-batch-entry'
 // ── HANDOFF slot 2G: the revenue side (tasks/01 phases A to C) ──────────────
 export {
   type BuildFulfillmentEntryInput,
   type BuiltFulfillmentEntry,
   buildFulfillmentEntry,
   CHANNEL_REVENUE_ROLE,
+  computeShipmentTotals,
   extendRateToAmount,
   FULFILLMENT_SOURCE_TYPE,
   type FulfillmentShippedLine,
   fulfillmentPeriodKey,
   type OrderChannelKey,
+  type ShipmentTotals,
+  type ShipmentTotalsInput,
+  type ShipmentTotalsLine,
   toAmountMinor,
   toChannelKey,
 } from './build-fulfillment-entry'

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -191,6 +191,25 @@ export interface BuiltEntry {
   totalDebit: number
   /** Integer minor units. Equal to `totalDebit`, always. */
   totalCredit: number
+  /**
+   * The FROZEN list of what this entry summarises, when its lines do not name
+   * them one by one. Optional, and absent on every entry built before this
+   * existed.
+   *
+   * 🛑 **This is the audit trail a summarised entry would otherwise not have.**
+   * A batch fulfillment posting carries one credit line per account for a whole
+   * day of shipments (49 §2.5), so `sourceId` names the period key and not the
+   * fifty orders behind it. Without the list there is no way to answer "which
+   * orders are in this number" three years later, and no way to compute the
+   * compensating entry a later correction needs.
+   *
+   * Rides into `GlPosting.draft` verbatim, because `buildPostingDraft` carries
+   * the whole `BuiltEntry` (see `draft.ts`). Typed `unknown` on purpose: the
+   * shape belongs to whichever builder wrote it - `buildFulfillmentBatchEntry`
+   * writes `FulfillmentBatchSource[]` - and `postings/types.ts` must not gain a
+   * dependency on `money/` to say so.
+   */
+  sources?: unknown
 }
 
 /**
@@ -383,6 +402,16 @@ export type PostResultStatus =
   // A code-based line names an account the org's chart does not hold, or holds
   // archived or inactive. The message names the row.
   | 'account_invalid'
+  // 🛑 The month still holds revenue that has not reached the ledger: a shipped
+  // fulfillment with no live posting stamped, or a `channel` credit memo still
+  // in draft (49 §2.4, §8.4 decision 7; 10 §3.4). NOT `error` - nothing is
+  // broken and nothing failed to build - and not one of the
+  // `NON_FAILURE_REFUSALS` either, because unlike an empty month it is a piece
+  // of work somebody has to do before the month is honest. It has its own status
+  // so the console can point at the two places that work is done rather than
+  // rendering "the entry could not be built" over a set of books that is simply
+  // short.
+  | 'revenue_incomplete'
   | 'error'
 
 /**
@@ -809,4 +838,24 @@ export interface BooksBalanceReport {
   balanced: boolean
   postingsChecked: number
   discrepancies: BooksBalanceDiscrepancy[]
+  /**
+   * The COMPLETENESS half, for one month (49 §2.4).
+   *
+   * 🛑 Balance is not completeness. Every entry in the books can tie perfectly
+   * while a month is missing a week of revenue, and that is exactly the state a
+   * connector-fed org lands in: the shipments are logged and nothing has posted
+   * them. The sweep above proves the entries that exist are right; this proves
+   * there are no entries still owed. A screen that showed only the first would
+   * report green books that are short.
+   *
+   * `null` means NOT COUNTED, never zero. The counts are per MONTH and the sweep
+   * is org-wide, so a caller that asked no month gets no answer rather than a
+   * `0` that reads as "nothing outstanding" - the same rule the opening balances
+   * follow, and for the same reason.
+   */
+  month: string | null
+  /** Shipments in `month` with no live posting stamped. `null` when no month was asked. */
+  unpostedShipments: number | null
+  /** `channel` credit memos in `month` still in draft. `null` when no month was asked. */
+  unissuedChannelCreditMemos: number | null
 }

--- a/packages/lib/src/postings/verify-balance.ts
+++ b/packages/lib/src/postings/verify-balance.ts
@@ -35,6 +35,8 @@ import { createScopedLogger } from '@auxx/logger'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError } from '../errors'
+import { countUnissuedChannelCreditMemos } from '../money/credit-memos/reads'
+import { countUnpostedShipments } from '../money/fulfillment-posting/reads'
 import { compareMonths, periodMonth } from './periods'
 import type {
   BooksBalanceDiscrepancy,
@@ -97,10 +99,17 @@ export type { BooksBalanceDiscrepancy, BooksBalanceReport } from './types'
  *
  * Indexes: `GlPostingLine_glPostingId_idx` carries the join and
  * `GlPosting_org_status_idx` carries the filter. Nothing new is needed.
+ *
+ * `options.month` adds the COMPLETENESS half for one month - see
+ * {@link countIncompleteRevenue}. It is optional because balance is answerable
+ * without it, and the two callers genuinely differ: the close console asks about
+ * the month it is showing, while `useAccountingSettingsFreeze` only wants
+ * `postingsChecked` and has no month in hand.
  */
 export async function verifyBooksBalance(
   db: Database,
-  organizationId: string
+  organizationId: string,
+  options?: { month?: string }
 ): Promise<Result<BooksBalanceReport, Error>> {
   try {
     const rows = await db
@@ -159,15 +168,63 @@ export async function verifyBooksBalance(
       })
     }
 
+    const completeness = await countIncompleteRevenue(db, organizationId, options?.month)
+
     return ok({
       balanced: discrepancies.length === 0,
       postingsChecked: rows.length,
       discrepancies,
+      ...completeness,
     })
   } catch (error) {
     if (error instanceof AuxxError) return err(error)
     logger.error('Failed to verify that the books balance', { error, organizationId })
     return err(new AuxxError('Internal error'))
+  }
+}
+
+/**
+ * The completeness half of the report: what one month still owes the ledger
+ * (49 §2.4, §8.4 decision 7).
+ *
+ * 🛑 Balance and completeness are different questions and the sweep above
+ * answers only the first. Every entry can tie while a month is missing a week of
+ * revenue, which is precisely the state a connector-fed organization lands in -
+ * the shipments are logged and nothing has posted them. These two counts are the
+ * same two the close refuses on (`close-month.ts`), read here so the banner
+ * warns before somebody presses Post rather than after.
+ *
+ * ⚠️ Returns `null`s, never zeros, when no month was asked. A `0` in that slot
+ * would read as "nothing outstanding" for a question nobody asked, and the
+ * banner would quietly assert completeness it never checked.
+ *
+ * ⚠️ A failed count is also `null`, and it does NOT fail the sweep. The balance
+ * result is the important half and it has already been computed; losing it
+ * because a subledger read threw would take away the report that proves the
+ * books tie in order to report the one that says they might be short.
+ */
+async function countIncompleteRevenue(
+  db: Database,
+  organizationId: string,
+  month: string | undefined
+): Promise<Pick<BooksBalanceReport, 'month' | 'unpostedShipments' | 'unissuedChannelCreditMemos'>> {
+  if (!month) return { month: null, unpostedShipments: null, unissuedChannelCreditMemos: null }
+
+  try {
+    const shipments = await countUnpostedShipments(db, { organizationId, month })
+    const memos = await countUnissuedChannelCreditMemos(db, { organizationId, month })
+    return {
+      month,
+      unpostedShipments: shipments.isErr() ? null : shipments.value,
+      unissuedChannelCreditMemos: memos,
+    }
+  } catch (error) {
+    logger.error('Failed to count what the month still owes the ledger', {
+      error,
+      organizationId,
+      month,
+    })
+    return { month, unpostedShipments: null, unissuedChannelCreditMemos: null }
   }
 }
 

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -464,6 +464,14 @@ export const OrderFulfillmentStatus = {
  * `financialStatus` + `paymentGateways` + tags; that cannot handle the only
  * rows that need it — a manual sale has no payment gateways and no Shopify
  * tags, and `manual` exists in this list precisely for it.
+ *
+ * ⚠️ Because it is human-set and no connector binds it, most imported orders
+ * carry the field's default. The fulfillment builder therefore treats `manual`
+ * and an unset channel as CONSUMER revenue rather than refusing the shipment
+ * (`postings/build-fulfillment-entry.ts`, 49 §8.4 decision 5); `dealer` is the
+ * only value that moves revenue off `4000`. Setting it correctly still matters,
+ * since it is what a P&L by channel reads, but an unset channel no longer keeps
+ * the sale off the books.
  */
 export const OrderChannel = {
   DTC: 'dtc',

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -240,6 +240,109 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
       'as a supplied zero',
   },
 
+  // ─── The fulfillment rollup the sales channel already computed ──────
+  //
+  // plans/money/tasks/49-bulk-fulfillment-posting.md §8.4 decision 4. Shopify
+  // projects a per-line fulfillment rollup on every order sync, and until entity
+  // migration 137 it landed ONLY in `@app:shopify:*` app fields - so nothing
+  // NATIVE said a connector order had shipped, and the one door into the ledger
+  // (`money.fulfillOrder`) was closed for every imported order (49 §1.2).
+  //
+  // These three are what `deriveFulfillmentLog` reads to reconstruct
+  // `order_fulfillments` for a connector order: lines sharing a fulfilled
+  // calendar day in the book time zone are one shipment. Measured on the dev
+  // org (49 §5): 82 of 538 orders ship in two shipments, no line spans two, and
+  // all 82 reconstruct by grouping lines on their fulfilled date.
+  //
+  // 🛑 No defaults, the `taxTotal` rule above. Null means the channel supplied
+  // nothing, which is NOT "zero units shipped": defaulting `fulfilledQty` to 0
+  // would say the channel reported an unshipped line, and defaulting
+  // `shipmentCount` to 1 would claim a reconstructable single shipment for a
+  // line that may have gone out in three.
+  //
+  // `creatable`/`updatable` because the connector writes them through the
+  // ordinary field path. Hidden from panel, dialogs and table: they are the
+  // channel's bookkeeping, and the shipment log is what a person reads.
+  fulfilledAt: {
+    id: toFieldId('fulfilledAt'),
+    key: 'fulfilledAt',
+    label: 'Fulfilled At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'line_item_fulfilled_at',
+    systemSortOrder: 'a7a1',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    showInTable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'When this line first shipped, carried from the sales channel (Shopify per-line ' +
+      'fulfillment rollup) and never derived. Read by the fulfillment log pass, which groups ' +
+      'lines sharing a calendar day into one shipment. Null means not supplied, which is not ' +
+      'the same as not shipped',
+  },
+
+  fulfilledQty: {
+    id: toFieldId('fulfilledQty'),
+    key: 'fulfilledQty',
+    label: 'Fulfilled Qty',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'line_item_fulfilled_qty',
+    systemSortOrder: 'a7a2',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    showInTable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Units of this line the sales channel reports as shipped, carried and never derived. ' +
+      'Read by the fulfillment log pass, which scales the line tax when it is short of the ' +
+      'ordered quantity. Null means not supplied, which is not the same as a supplied zero',
+  },
+
+  shipmentCount: {
+    id: toFieldId('shipmentCount'),
+    key: 'shipmentCount',
+    label: 'Shipment Count',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'line_item_shipment_count',
+    systemSortOrder: 'a7a3',
+    nullable: true,
+    showInPanel: false,
+    showInDialogs: false,
+    showInTable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'How many shipments this ONE line went out in, carried from the sales channel. Read by ' +
+      'the fulfillment log pass: more than one means the single fulfilled date cannot say ' +
+      'what went out when, and the whole order is held out rather than reconstructed wrongly. ' +
+      'Null means not supplied, which is not the same as a supplied one',
+  },
+
   // Reverse relationship: the credit memo lines that credited part of this line
   // (plans/accounting/tasks/10-credit-memos.md §2.2). The counterpart of the
   // owning `credit_memo_line_line_item`, and declared for the same reason

--- a/packages/lib/src/resources/registry/resources/order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/order-fields.ts
@@ -262,7 +262,9 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
     placeholder: 'Select channel',
     description:
       'Which route the sale came in through — HUMAN-SET, never derived (08 §4, D18). A ' +
-      'manual sale has no payment gateways and no tags to derive it from.',
+      'manual sale has no payment gateways and no tags to derive it from. The fulfillment ' +
+      'posting books an unset or manual channel as consumer revenue; only "dealer" moves it ' +
+      'to the dealer revenue line.',
     defaultValue: 'manual',
     showInTable: false,
   },

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -93,6 +93,7 @@ import { migration133Payout } from './migrations/133-payout'
 import { migration134BankAccountHasPosted } from './migrations/134-bank-account-has-posted'
 import { migration135BankDepositBankAccount } from './migrations/135-bank-deposit-bank-account'
 import { migration136RefundsAndTaxLines } from './migrations/136-refunds-and-tax-lines'
+import { migration137FulfillmentFacts } from './migrations/137-fulfillment-facts'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -275,6 +276,11 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // which creates the `order` and `line_item` defs it widens, and after 108,
   // which owns the chart `4090 Sales Returns and Allowances` is added to.
   migration136RefundsAndTaxLines,
+  // The sales channel's per-line fulfillment rollup, natively, plus the
+  // clearing_affirm role on 1210 (49 §8.4 decisions 4 and 6). MUST sort after
+  // 107, which creates the `line_item` def it widens, and after 108, which owns
+  // the chart account it stamps.
+  migration137FulfillmentFacts,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/136-refunds-and-tax-lines.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/136-refunds-and-tax-lines.test.ts
@@ -65,11 +65,16 @@ function storedField(
 const registry = FIELD_REGISTRY
 
 describe('migration 136 registration', () => {
-  it('is registered exactly once, last, with a unique id', () => {
+  it('is registered exactly once, after 135, with a unique id', () => {
+    // Was `ids.at(-1)` until 137 landed behind it. "Last" is a self-invalidating
+    // assertion - every new migration breaks it, and the thing actually worth
+    // asserting is that this one runs after the migration whose defs it widens.
     const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
     expect(ids.filter((id) => id === '136-refunds-and-tax-lines')).toHaveLength(1)
     expect(new Set(ids).size).toBe(ids.length)
-    expect(ids.at(-1)).toBe('136-refunds-and-tax-lines')
+    expect(ids.indexOf('136-refunds-and-tax-lines')).toBeGreaterThan(
+      ids.indexOf('135-bank-deposit-bank-account')
+    )
     expect(migration136RefundsAndTaxLines.id).toBe('136-refunds-and-tax-lines')
   })
 

--- a/packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.test.ts
@@ -1,0 +1,76 @@
+// packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.test.ts
+
+import { SYSTEM_ATTRIBUTES } from '@auxx/types/system-attribute'
+import { describe, expect, it } from 'vitest'
+import { LINE_ITEM_FIELDS } from '../../../resources/registry/resources/line-item-fields'
+import { FIELD_REGISTRY } from '../../entity-seeder/create-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../index'
+import { migration137FulfillmentFacts } from './137-fulfillment-facts'
+
+/** The three attributes this migration exists to materialise. */
+const ATTRIBUTES = [
+  'line_item_fulfilled_at',
+  'line_item_fulfilled_qty',
+  'line_item_shipment_count',
+] as const
+
+describe('migration 137 registration', () => {
+  it('is registered exactly once, after 136, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '137-fulfillment-facts')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf('137-fulfillment-facts')).toBeGreaterThan(
+      ids.indexOf('136-refunds-and-tax-lines')
+    )
+    expect(migration137FulfillmentFacts.id).toBe('137-fulfillment-facts')
+  })
+
+  it('names both halves of what it does in its description', () => {
+    expect(migration137FulfillmentFacts.description).toContain('line_item_fulfilled_at')
+    expect(migration137FulfillmentFacts.description).toContain('clearing_affirm')
+  })
+})
+
+describe('the three fulfillment facts in the registry', () => {
+  it('exists on line_item under the keys the migration picks', () => {
+    // 🛑 The migration resolves these by REGISTRY KEY and throws when one is
+    // missing, so a rename that is not made here too fails the migration on
+    // every org rather than silently materialising nothing.
+    for (const key of ['fulfilledAt', 'fulfilledQty', 'shipmentCount'] as const) {
+      expect(LINE_ITEM_FIELDS[key]).toBeDefined()
+    }
+    expect(LINE_ITEM_FIELDS.fulfilledAt?.systemAttribute).toBe('line_item_fulfilled_at')
+    expect(LINE_ITEM_FIELDS.fulfilledQty?.systemAttribute).toBe('line_item_fulfilled_qty')
+    expect(LINE_ITEM_FIELDS.shipmentCount?.systemAttribute).toBe('line_item_shipment_count')
+  })
+
+  it('is in the SystemAttribute union', () => {
+    // Without this a stored `CustomField.systemAttribute` is a string the type
+    // system does not know, and every consumer that keys off the union - the
+    // finalize pass's trigger set included - silently matches nothing.
+    for (const attribute of ATTRIBUTES) {
+      expect(SYSTEM_ATTRIBUTES).toContain(attribute)
+    }
+  })
+
+  it('is nullable, writable by a connector, and hidden from every surface', () => {
+    for (const key of ['fulfilledAt', 'fulfilledQty', 'shipmentCount'] as const) {
+      const field = LINE_ITEM_FIELDS[key]!
+      // Null means "the channel said nothing", which is not zero and not one.
+      expect(field.nullable).toBe(true)
+      expect(field.capabilities?.creatable).toBe(true)
+      expect(field.capabilities?.updatable).toBe(true)
+      expect(field.showInPanel).toBe(false)
+      expect(field.showInTable).toBe(false)
+      expect(field.showInDialogs).toBe(false)
+      expect(field.description).toContain('sales channel')
+    }
+  })
+
+  it('reaches a FRESH org through the seeder without the migration', () => {
+    // `FIELD_REGISTRY.line_item` IS `LINE_ITEM_FIELDS`, so a new org gets all
+    // three from `createFields`. The migration is only for orgs that already
+    // exist - which is the half that is easy to forget in the other direction.
+    expect(FIELD_REGISTRY.line_item).toBe(LINE_ITEM_FIELDS)
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.ts
@@ -1,0 +1,255 @@
+// packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { LINE_ITEM_FIELDS } from '../../../resources/registry/resources/line-item-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:137')
+
+/** The def the three fulfillment facts land on. Created by migration 107. */
+const LINE_ITEM_ENTITY_TYPE = 'line_item'
+
+/** The def the chart lives on. Created by migration 108. */
+const GL_ACCOUNT_ENTITY_TYPE = 'gl_account'
+
+/** The registry keys this migration adds. Their attributes are in the JSDoc below. */
+const LINE_ITEM_KEYS = ['fulfilledAt', 'fulfilledQty', 'shipmentCount'] as const
+
+/** The Affirm clearing account. `1210` is what a person recognises, not the name. */
+const AFFIRM_CLEARING_CODE = '1210'
+
+/**
+ * `ACCOUNT_ROLES.CLEARING_AFFIRM`, as a literal.
+ *
+ * The constant is being added to `postings/build-entry.ts` in the same batch of
+ * work, and a migration that imports a constant it landed alongside stops being
+ * self-sufficient the moment somebody edits that constant: the STRING is what is
+ * stored in `GlRoleAssignment.role`, and a stored string must never move because
+ * an unrelated rename happened years later. `132-card-clearing-rename.ts` holds
+ * its two role names the same way and for the same reason.
+ */
+const CLEARING_AFFIRM_ROLE = 'clearing_affirm'
+
+/**
+ * Migration 137: the sales channel's per-line fulfillment rollup, natively, and
+ * the Affirm clearing role.
+ *
+ * `plans/money/tasks/49-bulk-fulfillment-posting.md` §8.4 decisions 4 and 6.
+ *
+ * ## What it adds
+ *
+ * - **`line_item_fulfilled_at`, `line_item_fulfilled_qty` and
+ *   `line_item_shipment_count`** on `line_item`. Shopify already projects all
+ *   three on every order sync, but until now they landed ONLY in
+ *   `@app:shopify:*` app fields (49 §8.1 item 4), so **nothing native said an
+ *   imported order had shipped** - and `money.fulfillOrder`, the one door into
+ *   the ledger, was closed for 530 of the dev org's 545 orders (49 §1.2).
+ *
+ *   Native is the point, not a convenience. `deriveFulfillmentLog` (the sixth
+ *   finalize pass) reconstructs `order_fulfillments` from these three fields and
+ *   knows no Shopify field path at all, which is gap-f `G14`'s rule: the
+ *   connector projects, lib reads native attributes. Measured on the dev org
+ *   (49 §5): 82 of 538 imported orders ship in two shipments, no line spans two,
+ *   and all 82 reconstruct by grouping lines on their fulfilled date.
+ *
+ * - **The `clearing_affirm` role on `1210 Affirm Clearing`**, whose role has
+ *   been null since migration 108 created it. 11 of the dev org's orders pay
+ *   through Affirm (49 §5), and an Affirm settlement never lands on the card
+ *   rail - it is invisible to the payouts API - so folding those into `1200`
+ *   would mean `1200` could never reconcile to zero (`default-chart.ts` says so
+ *   at the account itself). One chart line, and the fulfillment builder's debit
+ *   fork needs the role to exist before it can emit it.
+ *
+ * ## What it deliberately does NOT do
+ *
+ * 🛑 **No backfill of the three fields, and none is possible.** The values come
+ * from the sales channel on the next sync after the connector bindings and the
+ * org's mapping remap land, which is a change in a separate repo (49 §8.5). An
+ * order that has already shipped carries no fulfilled date here until then, and
+ * inventing one from `order_fulfillment_status` would date every shipment wrong
+ * and post a year of revenue into one day.
+ *
+ * ⚠️ **It never repoints a role the org has already mapped**, and never touches
+ * `1210` when some other role already resolves to it. That is chart rule 4
+ * (`seed/gl-account-chart.ts`): a bookkeeper who mapped their own account keeps
+ * it through every re-run. An org whose `clearing_affirm` is already assigned is
+ * left exactly as it is.
+ *
+ * ## Ordering
+ *
+ * MUST sort after 107 (which creates `line_item`) and after 108 (which owns the
+ * chart `1210` belongs to). An org short of either is a skip, not a failure -
+ * it picks both up from the seeder with the rest of the registry.
+ *
+ * Idempotent: `ensureCustomFields` is INSERT-only and skips a field that
+ * exists, and the role insert is guarded by a read and an
+ * `ON CONFLICT DO NOTHING` on `(organizationId, role)`.
+ */
+export const migration137FulfillmentFacts: EntityMigration = {
+  id: '137-fulfillment-facts',
+  description:
+    'Adds line_item_fulfilled_at, line_item_fulfilled_qty and line_item_shipment_count - the ' +
+    "sales channel's per-line fulfillment rollup, carried natively so the fulfillment log " +
+    'pass can reconstruct order_fulfillments for a connector order - and stamps the ' +
+    'clearing_affirm role onto 1210 Affirm Clearing, whose role was null',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const lineItemDef = existing.entityDefs.get(LINE_ITEM_ENTITY_TYPE)
+    if (lineItemDef) {
+      await ensureCustomFields(
+        db,
+        organizationId,
+        LINE_ITEM_ENTITY_TYPE,
+        lineItemDef.id,
+        pickLineItemFields(),
+        existing,
+        state
+      )
+    }
+
+    const glAccountDefId = existing.entityDefs.get(GL_ACCOUNT_ENTITY_TYPE)?.id
+    const roleAssigned = glAccountDefId
+      ? await assignAffirmClearingRole(db, organizationId, glAccountDefId)
+      : false
+
+    const changed = state.fieldsCreated > 0 || roleAssigned
+
+    if (changed) {
+      // A new field is invisible to every read path that serves it until the
+      // per-org caches are dropped, and the role resolver reads `resources`.
+      // `runEntityMigrationsForOrg` does this after the whole batch, but `up()`
+      // can also be called directly (`scripts/run-entity-migration.ts`).
+      await getOrgCache().invalidateAndRecompute(organizationId, [
+        'entityDefs',
+        'entityDefSlugs',
+        'customFields',
+        'resources',
+      ])
+      logger.info('Migration 137 applied', { organizationId, ...state, roleAssigned })
+    }
+
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}
+
+/**
+ * The three registry fields, loud if one was renamed.
+ *
+ * A silent skip here would ship a migration that reports success having created
+ * nothing, and the pass that reads these attributes would then find no field and
+ * derive no shipment log for any order - which reads as "this org has not synced
+ * yet" rather than as a broken migration. The same guard 136's `pick` carries.
+ */
+function pickLineItemFields(): Record<string, ResourceField> {
+  const picked: Record<string, ResourceField> = {}
+  for (const key of LINE_ITEM_KEYS) {
+    const field = LINE_ITEM_FIELDS[key]
+    if (!field) {
+      throw new Error(`line_item registry is missing the key "${key}" (migration 137)`)
+    }
+    picked[key] = field
+  }
+  return picked
+}
+
+/**
+ * Point `clearing_affirm` at the org's `1210`, and only when nothing has claimed
+ * either side yet.
+ *
+ * Three guards, in order, each answering a different "leave it alone":
+ *
+ *  1. the org already has a `clearing_affirm` assignment - somebody, or a later
+ *     re-seed, mapped it; this migration is done,
+ *  2. the org has no `1210` - it renumbered its chart, and guessing which
+ *     account is the Affirm one would post real money into it,
+ *  3. `1210` already serves another role - "where its role is currently null"
+ *     is the condition this migration was written under, and a second role on
+ *     one account is legal but never something a migration should decide.
+ *
+ * @returns whether a row was written.
+ */
+async function assignAffirmClearingRole(
+  db: Database,
+  organizationId: string,
+  glAccountDefId: string
+): Promise<boolean> {
+  const [alreadyAssigned] = await db
+    .select({ id: schema.GlRoleAssignment.id })
+    .from(schema.GlRoleAssignment)
+    .where(
+      and(
+        eq(schema.GlRoleAssignment.organizationId, organizationId),
+        eq(schema.GlRoleAssignment.role, CLEARING_AFFIRM_ROLE)
+      )
+    )
+    .limit(1)
+  if (alreadyAssigned) return false
+
+  const [codeField] = await db
+    .select({ id: schema.CustomField.id })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.entityDefinitionId, glAccountDefId),
+        eq(schema.CustomField.systemAttribute, 'gl_account_code')
+      )
+    )
+    .limit(1)
+  if (!codeField) return false
+
+  const [account] = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, codeField.id),
+        eq(schema.FieldValue.valueText, AFFIRM_CLEARING_CODE)
+      )
+    )
+    .limit(1)
+  if (!account) return false
+
+  const [otherRole] = await db
+    .select({ role: schema.GlRoleAssignment.role })
+    .from(schema.GlRoleAssignment)
+    .where(
+      and(
+        eq(schema.GlRoleAssignment.organizationId, organizationId),
+        eq(schema.GlRoleAssignment.glAccountId, account.entityId)
+      )
+    )
+    .limit(1)
+  if (otherRole) {
+    logger.warn('Migration 137 left 1210 alone - it already serves a role', {
+      organizationId,
+      role: otherRole.role,
+    })
+    return false
+  }
+
+  // `source: 'seed'` and NOT `confirmedAt`: auxx chose this, the bookkeeper has
+  // not confirmed it, and the setup wizard renders the two differently (`G19`).
+  const inserted = await db
+    .insert(schema.GlRoleAssignment)
+    .values({
+      organizationId,
+      role: CLEARING_AFFIRM_ROLE,
+      glAccountId: account.entityId,
+      source: 'seed',
+    })
+    .onConflictDoNothing({
+      target: [schema.GlRoleAssignment.organizationId, schema.GlRoleAssignment.role],
+    })
+    .returning({ id: schema.GlRoleAssignment.id })
+
+  return inserted.length > 0
+}

--- a/packages/lib/src/settings/__tests__/fulfillment-posting-setting.test.ts
+++ b/packages/lib/src/settings/__tests__/fulfillment-posting-setting.test.ts
@@ -1,0 +1,55 @@
+// packages/lib/src/settings/__tests__/fulfillment-posting-setting.test.ts
+//
+// `accounting.fulfillmentPosting` (49 §2.4), through the write path a form
+// actually uses.
+//
+// 🛑 The property under test is not "the catalog has a key". It is that the two
+// modes the RUNNER understands are exactly the two the write path accepts.
+// `normalizeSettingValue` rejects a `SINGLE_SELECT` value that is not in
+// `config.options.options`, so a catalog whose option list drifted from
+// `FULFILLMENT_POSTING_MODES` would either refuse a mode the runner honours or
+// store one it silently reads as `manual`. Both are invisible until somebody's
+// books are a month short.
+
+import { describe, expect, it } from 'vitest'
+import { FULFILLMENT_POSTING_MODES } from '../../money/fulfillment-posting/types'
+import { SETTINGS_CATALOG } from '../catalog'
+import { normalizeSettingValue } from '../normalize-setting-value'
+
+const KEY = 'accounting.fulfillmentPosting'
+const config = SETTINGS_CATALOG[KEY]
+
+describe('accounting.fulfillmentPosting', () => {
+  it('is a SINGLE_SELECT that defaults to manual', () => {
+    expect(config.fieldType).toBe('SINGLE_SELECT')
+    // ⚠️ `manual` is the safe default: `auto` posts without anybody looking, and
+    // a first connector sync can carry a year of history.
+    expect(config.defaultValue).toBe('manual')
+    expect(config.scope).toBe('GENERAL')
+    expect(config.access).toBe('org')
+  })
+
+  it('offers exactly the modes the runner understands, with labels', () => {
+    expect(config.options?.options?.map((option) => option.value)).toEqual([
+      ...FULFILLMENT_POSTING_MODES,
+    ])
+    expect(config.options?.options?.map((option) => option.label)).toEqual([
+      'Manual, run the posting dialog',
+      'Automatic after every sync',
+    ])
+  })
+
+  it('round-trips every mode through the write path', () => {
+    for (const mode of FULFILLMENT_POSTING_MODES) {
+      expect(normalizeSettingValue(KEY, config, mode)).toBe(mode)
+    }
+  })
+
+  it('refuses a mode that is not on the list', () => {
+    expect(() => normalizeSettingValue(KEY, config, 'automatic')).toThrow(/expects one of/)
+  })
+
+  it('accepts null, which resets it to manual', () => {
+    expect(normalizeSettingValue(KEY, config, null)).toBeNull()
+  })
+})

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -11,6 +11,11 @@ import type { FieldOptions } from '../custom-fields/field-options'
 // copy of the three destinations would let a form offer a value the resolver
 // does not recognise, which falls back silently.
 import { PAYMENT_ROUTE_SETTING_OPTIONS } from '../money/bank-deposits/route'
+// Same rule for `accounting.fulfillmentPosting`: the two modes are declared once,
+// beside the mode union the runner reads, rather than restated here. The list is
+// in its own client-safe file because the READER (`auto.ts`) enqueues a BullMQ
+// job and this catalog is imported by the settings form.
+import { FULFILLMENT_POSTING_SETTING_OPTIONS } from '../money/fulfillment-posting/setting-options'
 import type { SettingScope, SettingValue } from './types'
 
 /**
@@ -966,6 +971,30 @@ export const SETTINGS_CATALOG = {
     description:
       'The IANA timezone the books are kept in, e.g. America/New_York. Period keys are ' +
       'derived in it. Unset refuses to post rather than assuming UTC.',
+  },
+
+  // ── When a shipment reaches the ledger (49 §2.4, §8.4 decision 1) ──────────
+  //
+  // A MODE, not an opening balance: it changes what happens NEXT and rewrites
+  // nothing that has already posted, so it stays editable after the first claim
+  // and is deliberately absent from the freeze the two rows above carry.
+  //
+  // ⚠️ `manual` is the default because `auto` posts without anybody looking. The
+  // preview in the posting dialog is the only review step this feature has
+  // (there is no draft posting - `GlPosting` rows are born posted), so choosing
+  // `auto` is choosing to skip the review, and that has to be a decision
+  // somebody makes rather than one they acquire by upgrading. It is also the
+  // safe direction on a first connector sync, which can carry a year of history.
+  'accounting.fulfillmentPosting': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'SINGLE_SELECT',
+    defaultValue: 'manual',
+    options: { options: [...FULFILLMENT_POSTING_SETTING_OPTIONS] },
+    description:
+      'When a shipment becomes a ledger entry. Automatic posts one fulfillment entry per ship ' +
+      'day after every connector sync; manual waits for the posting dialog, where the preview ' +
+      'is the review.',
   },
 
   // The frozen auxx.ai snapshot: the December 31 physical count valued at

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -338,6 +338,15 @@ export const SYSTEM_ATTRIBUTES = [
   // not a fan-out: this is what lets `buildFulfillmentEntry` use exact per-line
   // tax instead of allocating the order total pro rata across shipments.
   'line_item_tax_total',
+  // plans/money/tasks/49-bulk-fulfillment-posting.md §8.4 decision 4, entity
+  // migration 137. The sales channel's per-line fulfillment rollup, carried
+  // NATIVE so `deriveFulfillmentLog` can reconstruct `order_fulfillments` for a
+  // connector order without lib knowing a single Shopify field path. Before
+  // this they existed only as `@app:shopify:*` app fields, so nothing native
+  // said an imported order had shipped.
+  'line_item_fulfilled_at',
+  'line_item_fulfilled_qty',
+  'line_item_shipment_count',
   'line_item_optional',
   'line_item_optional_selected',
   'line_item_category',


### PR DESCRIPTION
## What

Plan 49 (`plans/money/tasks/49-bulk-fulfillment-posting.md`, reviewed in its §8, outcome in §9). Revenue on connector orders is posted as **one `fulfillment` entry per ship day**, run from a dialog on the orders page or automatically after every sync, instead of one click and one posting per shipment. No draft step: the posting is the run record.

## How it works

- **Builder** (`postings/build-fulfillment-batch-entry.ts`): debit by gateway (card clearing, a new `clearing_affirm` role on 1210, or A/R with one source line per order so aging names the debtor); summarised revenue, tax and shipping lines under `sourceType: 'fulfillment_batch'`; the frozen per-shipment list in the posting envelope; period key of the day plus an attempt char so a late order never collides with an already-posted day. `CHANNEL_REVENUE_ROLE` now fails open to consumer revenue. The single-order builder shares one `computeShipmentTotals`.
- **Run module** (`money/fulfillment-posting/`): the netting read is one SQL over the `order_fulfillments` log joined to `GlPosting`; a null or `reversed` stamp means unposted, so reversing a day's entry is the whole undo. `plan.ts` is pure. `run.ts` never throws and stamps what it posts. `countUnpostedShipments` reuses the plan, so a zero-value shipment cannot hold a month open.
- **Ingest**: three native line fields (`line_item_fulfilled_at`, `_fulfilled_qty`, `_shipment_count`) in entity migration **137**, which also stamps the Affirm role onto 1210 for existing orgs. Finalize pass 6 derives a connector order's shipment log from them (pure `deriveFulfillmentLog`, stamped entries kept verbatim, split shipments reconstructed per line); pass 7 hands off to the automatic run. `isRecordConnectorManaged` in `data-connectors/managed-fields.ts`.
- **Setting and close**: `accounting.fulfillmentPosting = manual | auto` (default manual). Queue `fulfillment-posting`, job and worker. The month close refuses with `revenue_incomplete` while the month holds an unposted shipment or an unissued channel credit memo; the close console names both counts.
- **Web**: Post fulfillments dialog (range, grouping, preview with the debit split, excluded block with reasons, result page), four `money` procedures, the order ledger card reading the stamps, Fulfill hidden for connector orders.

## Verified

- Lib typecheck ratchet unchanged (27 baseline), web 0, worker 0; full `packages/lib` suite 17,725 passing; repo lint clean.
- Migration 137 ran on all 28 local orgs.
- `packages/lib/scripts/drive-fulfillment-posting.ts` on the dev org, July 2026: 13 per-shipment test postings netted out, 538 connector logs derived (idempotent), 24 day entries posted, one day reversed and re-posted under an attempt suffix, close refused while it was unposted and clear after.
- Not yet clicked in a browser.

## Also fixed in passing

- Accounting settings page never saved the payment-route rows.
- `parseFulfillments` dropped `subtotalMinor`, so a split order's second shipment allocated tax as if it were the first.
- The single-order fulfill dialog sent a full instant to a date-only input.
- Both wizard dialogs (backfill, post fulfillments) capped the wrong element and did not scroll.

## Still owed (not in this PR)

- A remap and resync so the Shopify app binds the three native line fields on its own (the apps-repo binding change is uncommitted there beside the credit-memo retarget).
- Inventory relief of a shipment (brief 50), the order-paid entry, the month-end deferral.

https://claude.ai/code/session_01MGcizw9aTvmd1N6i1St7D1
