### PR TITLE
fix(accounting): clear the ledger page's two permanent loading states

### DIFF
--- a/apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
+++ b/apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
@@ -102,12 +102,41 @@ export function useLedgerEntryActions({
   const previewMutate = previewMonth.mutate
   const requestedRef = useRef<string | null>(null)
 
+  /**
+   * The ONE call site for `previewMonthEnd`, so the fire on arrival and the
+   * Rebuild button fail identically.
+   *
+   * 🛑 `requestedRef` is CLEARED on failure. It is set before the call so the
+   * effect stays at one request per month, which means leaving it latched after
+   * a transport failure would retire that month for the life of the component -
+   * an empty Entries section, forever, with nothing said about why.
+   *
+   * 🛑 And a failure has to be said out loud. Every business refusal arrives on
+   * `EntryPreview.blockedBy` and is rendered by the screen, so `onError` here is
+   * only ever a genuine transport or 500 failure - the one outcome that has no
+   * other way to reach anybody.
+   */
+  const firePreview = useCallback(
+    (month: string) => {
+      requestedRef.current = month
+      previewMutate(
+        { periodKey: month },
+        {
+          onError: (error) => {
+            requestedRef.current = null
+            toastError({ title: 'Could not build the entry', description: error.message })
+          },
+        }
+      )
+    },
+    [previewMutate]
+  )
+
   useEffect(() => {
     if (!enabled || !periodKey) return
     if (requestedRef.current === periodKey) return
-    requestedRef.current = periodKey
-    previewMutate({ periodKey })
-  }, [enabled, periodKey, previewMutate])
+    firePreview(periodKey)
+  }, [enabled, periodKey, firePreview])
 
   /** Everything the books-level reads show changes the moment a month lands. */
   const refreshBooks = useCallback(() => {
@@ -118,15 +147,8 @@ export function useLedgerEntryActions({
 
   const runPreview = useCallback(() => {
     if (!periodKey) return
-    requestedRef.current = periodKey
-    previewMutate(
-      { periodKey },
-      {
-        onError: (error) =>
-          toastError({ title: 'Could not build the entry', description: error.message }),
-      }
-    )
-  }, [periodKey, previewMutate])
+    firePreview(periodKey)
+  }, [firePreview, periodKey])
 
   const postMutate = postMonth.mutate
   const runPost = useCallback(() => {

--- a/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
@@ -16,6 +16,7 @@ import {
   ClipboardCheck,
   Clock3,
   Layers,
+  Loader2,
   Lock,
   LockOpen,
   Plus,
@@ -147,8 +148,19 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
   // The month on screen rides along so the sweep can answer the COMPLETENESS
   // question too - what this month still owes the ledger. Without it the counts
   // come back `null` and the Books section renders the balance half alone.
+  // 🛑 `||`, not `??`. `activePeriodKey` is `''` - not undefined - while
+  // `ledger.periods` is in flight, and PERMANENTLY for a finalized org whose
+  // cutoff is still ahead of the wall clock (the case `optionalMonthKey` exists
+  // for). `??` lets the empty string through and the month regex refuses it, so
+  // the sweep 400s and the Books section skeletons forever.
+  //
+  // ⚠️ Deliberately NOT gated on a month. Balance is a WHOLE-LEDGER fact and the
+  // month only adds the completeness half; `countIncompleteRevenue` answers with
+  // `null`s when none was asked and `CompletenessLines` renders nothing for
+  // them. An `enabled: !!activePeriodKey` here would withhold an answer that is
+  // available, and leave the same permanent skeleton behind.
   const balanceQuery = api.ledger.verifyBalance.useQuery({
-    periodKey: activePeriodKey ?? undefined,
+    periodKey: activePeriodKey || undefined,
   })
   const roleMapQuery = api.ledger.roleMap.useQuery()
 
@@ -434,13 +446,22 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
                 actions={
                   <div className='flex items-center gap-1'>
                     {!!activePeriodKey && !isPostedPeriod && (
-                      <Button
-                        variant='ghost'
-                        size='sm'
-                        loading={actions.isPreviewing}
-                        loadingText='Building...'
-                        onClick={actions.runPreview}>
-                        Rebuild preview
+                      /* 🛑 The spinner is rendered here rather than through
+                         `loading`, because `Button` DISABLES a loading button -
+                         and a preview that never settles would then leave the
+                         only affordance that can refire it disabled, with a
+                         reload as the sole way out. Refiring is free:
+                         `previewMonthEnd` persists nothing, and the second
+                         answer replaces the first. */
+                      <Button variant='ghost' size='sm' onClick={actions.runPreview}>
+                        {actions.isPreviewing ? (
+                          <>
+                            <Loader2 className='animate-spin' />
+                            Building...
+                          </>
+                        ) : (
+                          'Rebuild preview'
+                        )}
                       </Button>
                     )}
                     {/* 🛑 NOT gated on a period. This is the only door to a
@@ -608,6 +629,15 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
                 collapsible={false}>
                 {balanceQuery.data ? (
                   <BooksBalanceLine report={balanceQuery.data} />
+                ) : balanceQuery.isError ? (
+                  /* 🛑 A failed sweep and a running one are not the same state.
+                     Rendering both as a skeleton hides the one that never
+                     resolves, which is how a refused sweep read as "still
+                     loading" indefinitely. */
+                  <p className='text-sm text-destructive'>
+                    The balance sweep could not run, so nothing here has been checked.{' '}
+                    {balanceQuery.error.message}
+                  </p>
                 ) : (
                   <Skeleton className='h-6 w-64' />
                 )}


### PR DESCRIPTION
Two spots on `/app/accounting` could sit in a loading state that nothing ever resolved. In both cases the state was hiding a failure rather than waiting on one, so the screen looked busy instead of broken.

## Entries — "Building..." forever

Reproduced on a live tab: `button "Building..." busy disabled`, with the server answering `previewMonthEnd` for that org and month in 25ms.

`Button` sets `disabled={loading || props.disabled}`, so `loading={actions.isPreviewing}` disabled the one control that can refire a preview. A mutation that never settles — a request killed mid-flight by a dev-server recompile, for instance — then left the button spinning and unclickable, with a page reload as the only way out. The spinner is rendered inline now so the button stays clickable. Refiring is free: `previewMonthEnd` persists nothing and the second answer replaces the first.

The same section could also go silently empty, for two reasons that compound:

- the preview fired on arrival passed no `onError`, so a genuine transport failure said nothing at all (only the manual `runPreview` had a toast)
- `requestedRef` was set to the month *before* the call and never released on failure, so that month was retired for the life of the component

Both fires now go through one `firePreview`, whose `onError` raises the toast and clears the ref.

## Books — a skeleton forever

```ts
periodKey: activePeriodKey ?? undefined
```

`activePeriodKey` is `''`, not undefined, while `ledger.periods` is in flight — and *permanently* for a finalized org whose cutoff is still ahead of the wall clock, which is the exact case `optionalMonthKey` was written for. `??` let the empty string through and the month regex refused it:

```
400  "periodKey must be a YYYY-MM month"
```

Captured on every load of the page, one failing call followed by a good one once periods resolved:

```json
[{"idx":13,"input":{"json":{"periodKey":""}},        "hasError":true},
 {"idx":2,  "input":{"json":{"periodKey":"2026-01"}}, "hasError":false}]
```

Since line 619 renders a skeleton whenever `data` is missing, an org that never resolves a month showed a skeleton with no error. `||` instead, matching what `EntriesList` already does 380 lines below in the same file.

Deliberately **not** gated on a month. Balance is a whole-ledger fact; the month only adds the completeness half, and `countIncompleteRevenue` already answers with `null`s while `CompletenessLines` renders nothing for them. An `enabled: !!activePeriodKey` would hold `data` undefined and leave the same permanent skeleton behind.

A failed sweep also no longer renders as a skeleton — it says the sweep could not run and gives the reason.

## Not in scope

`ledger.verifyBalance` itself is healthy and unchanged. Measured against the dev DB before touching anything: 21ms cold / 5ms warm over 99 postings, `balanced: true`, and both indexes its JSDoc claims (`GlPosting_org_status_idx`, `GlPostingLine_glPostingId_idx`) exist.

The JE drawer's identical "Building..." button is left alone: it is only ever user-initiated, and closing the drawer already recovers it.

## Verification

- `pnpm --filter @auxx/web typecheck` — exit 0, no new errors
- `vitest run src/components/accounting` — 7 files, 85 tests passing
- In the browser: the button loads enabled, shows spinner + "Building..." with `disabled: false` throughout, and resolves in ~600ms; after the fix the first `verifyBalance` call goes out as `periodKey: undefined` and returns 200 instead of 400

https://claude.ai/code/session_01FW9XuUhGynetCv4y78EnWj
