### PR TITLE
fix(connectors): publish a parked run's manifest, so its finalize passes run

### DIFF
--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -164,16 +164,34 @@ export interface ConnectorSyncSourceDeps {
 export interface ConnectorSyncSource extends SyncSource {
   finalizeSteady(): Promise<void>
   /**
-   * The park-time relationship pass (plans/money/tasks/39 §3.6). A run parked at the
-   * ingest ceiling or a sample cap never reaches the connector-level finalize, so
-   * without this every edge whose target has already synced stays pending while the
-   * stream cards read "done". Same ctx and `relationshipCrud` session as the finalize
-   * (events fire the same way) and the same counter fold; unresolved edges stay
-   * pending and count as relationship warnings. The pass is idempotent, so the later
-   * finalize re-checks the same edges at the cost of one bulk pre-read. Call it BEFORE
-   * the run is marked `partial`.
+   * Everything a PARKED run must do for itself, because it never reaches the
+   * connector-level finalize. Called from all three park sites (the ingest ceiling and
+   * both sample-cap doors), always on the last stream, always BEFORE the run is marked
+   * `partial`.
+   *
+   * Two duties, and they were added for the same reason a year apart:
+   *
+   * 1. **The relationship pass** (plans/money/tasks/39 §3.6). Without it every edge
+   *    whose target has already synced stays pending while the stream cards read
+   *    "done". Same ctx and `relationshipCrud` session as the finalize (events fire the
+   *    same way) and the same counter fold; unresolved edges stay pending and count as
+   *    relationship warnings. Idempotent, so a later finalize re-checks the same edges
+   *    at the cost of one bulk pre-read.
+   * 2. **Publishing the run's manifest** (plans/money/tasks/51 §8). `publishSyncRecordsChanged`
+   *    otherwise fires only at the last stream's finalize, so a parked run's manifest
+   *    was persisted, never consumed, and nothing anywhere would ever consume it —
+   *    `sync:records:changed` is the only door to the finalize integrity passes, so
+   *    EVERY one of them silently skipped for the parked slice: document totals,
+   *    address normalization, phone geo, order demand, interactions and the derived
+   *    fulfillment log. Measured on the first real Shopify sync: eight runs, seven
+   *    parks, seven orphaned manifests, and 2,686 of 13,185 fulfilled orders carrying a
+   *    shipment log — the last run's eighth and nothing else.
+   *
+   * 🛑 Publish LAST. The manifest has to hold duty 1's writes before anything consumes
+   * it, and consumption is atomically once-only (`claimRunManifestConsumed`), so there
+   * is no second chance to include them.
    */
-  resolveRelationshipsAtPark(): Promise<void>
+  finalizeAtPark(): Promise<void>
 }
 
 class ConnectorStreamSyncSource implements ConnectorSyncSource {
@@ -346,14 +364,14 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
         dataConnectorId: this.deps.connector.id,
         sampleLimit: this.deps.sampleLimit,
         startedAt: this.deps.run.startedAt,
-        beforePark: () => this.resolveRelationshipsAtPark(),
+        beforePark: () => this.finalizeAtPark(),
       })
       return
     }
     await this.finalizeConnectorLevel({ closeRun: true, clearResync: true, phase: 'backfill' })
   }
 
-  async resolveRelationshipsAtPark(): Promise<void> {
+  async finalizeAtPark(): Promise<void> {
     const counters = newRunCounters()
     // The pass resolves across ALL streams (an order's contact came from a sibling
     // stream), so warm every target def, exactly as the finalize does.
@@ -371,6 +389,16 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
       errorSample: counters.errorSample,
     })
     await this.persistManifest(syncCtx)
+
+    // The parked run's ONLY door to the finalize integrity passes (51 §8). Strictly
+    // after `persistManifest`, so the manifest the consumer claims already holds the
+    // relationship pass's writes. Best-effort by contract — it never throws, so a
+    // publish failure cannot turn a clean park into a failed run.
+    await publishSyncRecordsChanged(this.deps.db, {
+      organizationId: this.deps.organizationId,
+      dataConnectorId: this.deps.connector.id,
+      runId: this.deps.run.id,
+    })
   }
 
   /**

--- a/packages/lib/src/data-connectors/slice-orchestrator-park-links.test.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator-park-links.test.ts
@@ -80,6 +80,16 @@ const world = {
   linkWrites: [] as LinkWrite[],
   /** Counters handed to the run ledger by the park-time pass and the finalize. */
   ledgerFolds: [] as { runId: string; relationshipWarnings: number }[],
+  /**
+   * Every `sync:records:changed` publish, with the state at the moment it happened:
+   * the run's status (a park must publish BEFORE `partial`) and how many link writes
+   * had landed (the manifest must already hold the pass's writes).
+   */
+  manifestPublishes: [] as {
+    runId: string
+    runStatus: FakeRun['status'] | undefined
+    linkWritesAtPublish: number
+  }[],
 }
 
 const PAGE_SIZE = 500
@@ -98,6 +108,7 @@ function resetWorld() {
   world.items.clear()
   world.linkWrites.length = 0
   world.ledgerFolds.length = 0
+  world.manifestPublishes.length = 0
   world.connector = {
     id: 'dc1',
     organizationId: 'org1',
@@ -296,7 +307,13 @@ vi.mock('./service', async (importOriginal) => {
     foldRunManifest: async () => {},
     markRunManifestDegraded: async () => {},
     getRunManifest: async () => null,
-    publishSyncRecordsChanged: async () => {},
+    publishSyncRecordsChanged: async (_db: unknown, input: { runId: string }) => {
+      world.manifestPublishes.push({
+        runId: input.runId,
+        runStatus: currentRun(input.runId)?.status,
+        linkWritesAtPublish: world.linkWrites.length,
+      })
+    },
     setRunRateLimited: async () => {},
     parkConnectorSampleIfLastStream: async () => {},
     // The relationship pass's reads and writes, over the in-memory items.
@@ -610,5 +627,43 @@ describe('relationship pass at the ingest-ceiling park (§3.6)', () => {
 
     for (const item of world.items.values()) expect(item.pendingRelations).toBeNull()
     expect(await pendingLinks()).toEqual([])
+  })
+})
+
+describe('manifest publish at the ingest-ceiling park (51 §8)', () => {
+  it('publishes the parked run manifest, before the park and after the pass wrote its edges', async () => {
+    await startConnectorSync(DB, 'org1', 'dc1', { trigger: 'manual' })
+    await drainSlices()
+
+    expect(world.parkedAtCeiling).toEqual(['run1'])
+
+    // Exactly one publish, for the run that parked. Before the fix this was zero:
+    // `publishSyncRecordsChanged` fired only at the last stream's finalize, which a
+    // parked run never reaches, so the manifest was persisted and never consumed.
+    expect(world.manifestPublishes).toHaveLength(1)
+    expect(world.manifestPublishes[0]?.runId).toBe('run1')
+
+    // Two orderings the consumer depends on, and neither is observable downstream —
+    // consumption is atomically once-only, so a manifest published too early is
+    // consumed too early and there is no second chance.
+    //
+    // 1. BEFORE the park marks the run `partial`, alongside the relationship pass.
+    expect(world.manifestPublishes[0]?.runStatus).toBe('running')
+    // 2. AFTER the pass folded its 20 link writes, so the manifest the consumer
+    //    claims already holds them.
+    expect(world.manifestPublishes[0]?.linkWritesAtPublish).toBe(20)
+  })
+
+  it('publishes once per run across a park and its resume, never twice for the same run', async () => {
+    await startConnectorSync(DB, 'org1', 'dc1', { trigger: 'manual' })
+    await drainSlices()
+    await startConnectorSync(DB, 'org1', 'dc1', { trigger: 'manual' })
+    await drainSlices()
+
+    // Run 1 parked and published at the park; run 2 completed and published at the
+    // connector-level finalize. A resume mints a NEW run, so the parked run's manifest
+    // is final the moment it parks and nothing re-publishes it.
+    expect(world.runs[1]?.status).toBe('completed')
+    expect(world.manifestPublishes.map((p) => p.runId)).toEqual(['run1', 'run2'])
   })
 })

--- a/packages/lib/src/data-connectors/slice-orchestrator.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator.ts
@@ -641,9 +641,10 @@ export async function runBackfillSlice(
           dataConnectorId: connectorId,
           sampleLimit: run.sampleLimit,
           startedAt: run.startedAt,
-          // The last stream links what the sample can link before the run parks
-          // (plans/money/tasks/39 §3.6), so the review shows related records related.
-          beforePark: () => source.resolveRelationshipsAtPark(),
+          // The last stream links what the sample can link and publishes the run's
+          // manifest before the run parks (39 §3.6, 51 §8), so the review shows related
+          // records related AND with their derived values.
+          beforePark: () => source.finalizeAtPark(),
         })
         await publishConnectorSync(db, organizationId, connectorId, 'run-finished')
         return
@@ -663,11 +664,12 @@ export async function runBackfillSlice(
           fetched,
           ceiling: MAX_BACKFILL_RECORDS,
         })
-        // A parked run never reaches the connector-level finalize, so link what this
-        // run can link BEFORE the run is marked partial (plans/money/tasks/39 §3.6).
-        // Edges whose target is still unsynced stay pending; the resumed run's
-        // finalize resolves them. The pass logs its resolved / still-pending counts.
-        await source.resolveRelationshipsAtPark()
+        // A parked run never reaches the connector-level finalize, so it does that
+        // work for itself BEFORE the run is marked partial: link what this run can
+        // link (39 §3.6) and publish its manifest (51 §8). Edges whose target is still
+        // unsynced stay pending; the resumed run's finalize resolves them. The pass
+        // logs its resolved / still-pending counts.
+        await source.finalizeAtPark()
         await parkBackfillAtCeiling(db, {
           runId,
           dataConnectorId: connectorId,


### PR DESCRIPTION
## The defect

`publishSyncRecordsChanged` fires at exactly one place in the bulk path: the last
stream's connector-level finalize, past the backfill latch. A run parked at the
ingest ceiling or a sample cap **never reaches it**, so its manifest is persisted
with `manifestConsumedAt` NULL and nothing anywhere will ever consume it. A later
run does not re-publish an older run's manifest.

`sync:records:changed` is the **only** door to the finalize integrity passes, so
all of them silently skipped for the parked slice:

| pass | what was skipped |
| --- | --- |
| 1 | document totals recompute |
| 2 | address normalize + geocode |
| 3 | phone geo |
| 4 | order demand |
| 5 | interactions |
| 6 | the derived fulfillment log |
| 7 | auto fulfillment posting |

## Measured

First real Shopify sync, DemoOrg1, connector `ikabouv0noy067s3p3cbgep4`:

```
run                       status     fetched  manifest  manifestConsumedAt
xe9e6nzi0bf2ub973lfdq2z6  partial     10928    yes       NULL
j2in3i78faybdc0moinff7di  partial     10624    yes       NULL
hxozmmgp09urfpgdwshlesld  partial     10935    yes       NULL
zbcpy3k8tj3n5w7833cbalaa  partial     10308    yes       NULL
nq830uw2pvn9iyustdhtfzv1  partial      9831    yes       NULL
krxc4mzkfoqby7godcognca6  partial      9921    yes       NULL
xjl2iqjkstzxyhycu8dk4ysp  partial     10776    yes       NULL
lffcoxo5fupwbwpkzh0boy6e  completed    9692    yes       2026-09-09 18:58:33
```

Eight runs, seven parks, seven orphaned manifests. **2,686 of 13,185 fulfilled
orders carry a shipment log** - the last run's eighth, and nothing else.

Carrying the backfill to completion does **not** repair this. It finalizes the
last slice only.

## The fix was a missing sibling, not a new mechanism

The park site already had the shape:

```ts
// A parked run never reaches the connector-level finalize, so link what this
// run can link BEFORE the run is marked partial (plans/money/tasks/39 §3.6).
await source.resolveRelationshipsAtPark()
```

Plan 39 §3.6 noticed the same class of omission and repaired the **relationship
pass**. It did not repair the **manifest publish**, which is the same omission in
the same method for the same reason. This is that fix's second half.

`resolveRelationshipsAtPark` is renamed **`finalizeAtPark`**: it now has two
duties, and the next person will have a third. It is reached from all three park
doors (ingest ceiling, and both sample-cap doors), always on the last stream,
always before the run is marked `partial`.

### The sample park was affected too

Not previously recorded. A trial sync **parks by construction**, so every trial
sync skipped every finalize pass: the review screen showed related records
related (39 §3.6) but with no derived totals, no normalized addresses and no
shipment log. The same call fixes it.

## Ordering is load-bearing

```
resolveRelationships(stage: 'park')   writes the edges
persistManifest(syncCtx)              folds them into the manifest
publishSyncRecordsChanged(...)        ONLY THEN
parkBackfillAtCeiling(...)            run becomes `partial`
```

The publish must be **last of the three and before the park**. Consumption is
atomically once-only (`claimRunManifestConsumed`), so a manifest published before
the fold is consumed *without* the park pass's writes and there is no second
chance.

Both orderings are asserted in `slice-orchestrator-park-links.test.ts`
(`runStatus === 'running'`, `linkWritesAtPublish === 20`), plus one publish per
run across a park and its resume. **Both new tests were confirmed to fail with
the publish removed**, with exactly those assertions:

```
AssertionError: expected [] to have a length of 1 but got +0
AssertionError: expected [ 'run2' ] to deeply equal [ 'run1', 'run2' ]
```

## Not in this PR

The seven **already-orphaned** manifests are not replayed. That is a separate
repair and it is currently blocked: publishing `sync:records:changed` for an old
run is a full re-delivery of that run's changes, and `handle-sync-record-rules`
fires record rules first, which by their own docblock "carry no idempotency of
their own". DemoOrg1 has a leftover `set-field` rule on contact-created that the
replay would fire over 20,869 created contacts. Details in
`plans/money/tasks/51-first-sync-defects.md` §9.3.

## Verification

- `pnpm exec vitest run src/data-connectors`: **638 passing, 64 files**
- Typecheck ratchet: **no new type errors** (27 total, baseline 27)

Context: `plans/money/tasks/51-first-sync-defects.md` §8 and §9, and plan 39 §3.6.

https://claude.ai/code/session_018jUmzuukfVb116bjUQ2Rty
