### PR TITLE
feat(builds): batch run number, and the undo that makes a run reversible

### DIFF
--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -211,6 +211,14 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     import('../manufacturing/builds/build-ledger-card').then((m) => ({
       default: m.BuildLedgerCard,
     })),
+  // The batch run this build belongs to, and the ONE verb whose scope is the
+  // whole run rather than this build (plans/money/tasks/45 §11). Deliberately
+  // NOT part of `build:run`: every verb there acts on one build, Undo acts on
+  // hundreds. It renders nothing at all for a build carrying no run.
+  'build:batch-run': () =>
+    import('../manufacturing/builds/build-batch-run-card').then((m) => ({
+      default: m.BuildBatchRunCard,
+    })),
 
   // ─────────────────────────────────────────────────────────────────
   // INVOICE OVERVIEW CARDS (money MI1 build spec §J.1 — drawer-only entity,

--- a/apps/web/src/components/manufacturing/builds/build-batch-run-card.tsx
+++ b/apps/web/src/components/manufacturing/builds/build-batch-run-card.tsx
@@ -1,0 +1,258 @@
+// apps/web/src/components/manufacturing/builds/build-batch-run-card.tsx
+'use client'
+
+// `build:batch-run`: the run a build belongs to, and the ONE verb whose blast
+// radius is the whole run (plans/money/tasks/45 §11).
+//
+// 🛑 **Its own card, never folded into `build:run`** (§11.1). Every verb on the
+// lifecycle card (Start / Cancel / Complete / Reverse) acts on the one build in
+// front of you. Undo acts on every build the run raised, which is routinely
+// hundreds. Two scopes, two cards: a run section folded into the lifecycle card
+// would put a four-figure blast radius inside the box a person reads to answer
+// "what is this build doing".
+//
+// 🛑 **Renders nothing when the build carries no run.** An order-raised or
+// hand-raised build belongs to no batch, and `build_batch_run` is null on
+// reversing builds too (§4.1: a reversal must not inherit the run number, or
+// run N would contain its own undo). Returning null hides the whole Section:
+// `base-entity-drawer.tsx` wraps every card in
+// `[&:has([data-slot=section-content]:empty)]:hidden`.
+//
+// A run is not a record (§3.1), so there is no run detail page. This card IS the
+// run's detail view, reached through any of its members.
+
+import type { Operator } from '@auxx/lib/conditions/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { ListFilter, Undo2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { EmptyRow, RowSkeleton } from '~/components/drawers/cards/related-record-row'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
+import { PurchasingSummaryStrip } from '~/components/purchasing/purchasing-summary-strip'
+import { useRecordsSearchStore } from '~/components/records/records-search-store'
+import { useFieldByKey, useResourceProperty } from '~/components/resources'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
+import { api } from '~/trpc/react'
+
+/** Where the builds list lives, and where the "see the run" link goes. */
+const BUILDS_PATH = '/app/builds'
+
+export function BuildBatchRunCard({ entityInstanceId }: DrawerTabProps) {
+  const [confirm, ConfirmDialog] = useConfirm()
+  const router = useRouter()
+  const utils = api.useUtils()
+
+  const buildDefId = useResourceProperty('build', 'id')
+  const movementDefId = useResourceProperty('stock_movement', 'id')
+
+  // The org's own `build_batch_run` field, resolved by system attribute rather
+  // than by key: the builds list filters on the materialized CustomField id, not
+  // on the registry ref, so the link below needs the org's id for it.
+  const batchRunField = useFieldByKey(buildDefId, 'build_batch_run')
+
+  // The client mirror of what `builds.undoBatchRun` asserts (§11.5). Undo
+  // cancels AND reverses, and the reversal arm appends stock movements, so it
+  // takes both halves: edit on `build` and edit on `stock_movement`. The server
+  // enforces regardless; this only avoids a click-then-403.
+  const { canEditEntity } = useAccess()
+  const canUndoRun =
+    !!buildDefId && canEditEntity(buildDefId) && !!movementDefId && canEditEntity(movementDefId)
+
+  const build = api.builds.get.useQuery(
+    { buildId: entityInstanceId },
+    { enabled: !!entityInstanceId, retry: false }
+  )
+  const runNumber = build.data?.batchRun ?? null
+
+  const run = api.builds.getBatchRun.useQuery(
+    { runNumber: runNumber ?? 1 },
+    { enabled: runNumber != null, retry: false }
+  )
+
+  /**
+   * Undo touches every member of the run, so it invalidates the same three reads
+   * `build-run-card.tsx` does rather than just this build's.
+   *
+   * 🛑 The reversing builds are written on the quiet lane and emit no
+   * `record:created` frame, and the cancellations exclude the acting tab from
+   * their own realtime events. Either way the tab that pressed the button is the
+   * one that has to invalidate.
+   */
+  const refresh = async () => {
+    await Promise.all([
+      utils.builds.get.invalidate(),
+      utils.builds.list.invalidate(),
+      utils.builds.getBatchRun.invalidate(),
+      buildDefId
+        ? utils.record.listFiltered.invalidate({ entityDefinitionId: buildDefId })
+        : Promise.resolve(),
+    ])
+  }
+
+  const undoBatchRun = api.builds.undoBatchRun.useMutation({
+    onError: (error) => toastError({ title: 'Failed to undo the run', description: error.message }),
+    onSuccess: refresh,
+  })
+
+  // 🛑 §11.3's first rule, and the reason this returns before any skeleton: the
+  // common build carries no run at all, and a card that flashed a placeholder on
+  // every order-raised build would be the empty section this rule forbids.
+  if (runNumber == null) return null
+  if (run.isPending) return <RowSkeleton />
+  if (!run.data) return <EmptyRow label='This run could not be read' />
+
+  const summary = run.data
+  const nothingToUndo = summary.willCancel === 0 && summary.willReverse === 0
+
+  const handleUndo = async () => {
+    const confirmed = await confirm({
+      title: `Undo run ${runNumber}?`,
+      // 🛑 §11.4: BOTH counts lead, because they differ and only the second one
+      // writes to the ledger. Then §4.2's rule, in §4.2's own words.
+      description:
+        `${plural(summary.willCancel, 'build')} will be cancelled, and ` +
+        `${plural(summary.willReverse, 'completed build')} will be reversed. ` +
+        'Only the reversals touch the ledger: each one appends movements that negate what the ' +
+        "completion wrote, dated TODAY, in today's open period. This does not restate the month " +
+        'the run was dated to. If the run covered January and January is closed, January stays ' +
+        'exactly as posted. Nothing is deleted.',
+      confirmText: `Undo run ${runNumber}`,
+      cancelText: 'Keep the run',
+      destructive: true,
+    })
+    if (confirmed) undoBatchRun.mutate({ runNumber })
+  }
+
+  /**
+   * "See the builds this run raised", which is §4.3's first affordance.
+   *
+   * The context is set before the condition: `RecordsSearchBar` calls
+   * `setContext(entityDefinitionId)` on mount, and that CLEARS the conditions
+   * whenever the key changes. Setting it here first makes the list's own call a
+   * no-op, so the filter survives the navigation.
+   */
+  const openRunInList = () => {
+    if (!buildDefId || !batchRunField) return
+    const store = useRecordsSearchStore.getState()
+    store.setContext(buildDefId)
+    store.setConditions([
+      {
+        id: 'build-batch-run',
+        fieldId: batchRunField.id,
+        operator: 'is' as Operator,
+        value: runNumber,
+      },
+    ])
+    router.push(BUILDS_PATH)
+  }
+
+  return (
+    <div className='space-y-2'>
+      <ConfirmDialog />
+
+      <div className='flex items-center gap-1.5'>
+        <Badge variant='blue' size='xs'>
+          Run {runNumber}
+        </Badge>
+        {summary.ranAt && (
+          <span className='text-muted-foreground text-xs'>Ran {formatDay(summary.ranAt)}</span>
+        )}
+      </div>
+
+      <PurchasingSummaryStrip
+        cells={[
+          { label: 'In this run', value: String(summary.total) },
+          {
+            label: 'Would cancel',
+            value: String(summary.willCancel),
+            tone: summary.willCancel ? 'default' : 'muted',
+          },
+          {
+            // The one figure that writes to the ledger, so it does not read as
+            // flat as the two beside it.
+            label: 'Would reverse',
+            value: String(summary.willReverse),
+            tone: summary.willReverse ? 'warning' : 'muted',
+          },
+        ]}
+      />
+
+      <div className='flex flex-wrap items-center gap-1'>
+        <StatusCount label='Planned' count={summary.planned} variant='secondary' />
+        <StatusCount label='In progress' count={summary.inProgress} variant='blue' />
+        <StatusCount label='Completed' count={summary.completed} variant='green' />
+        <StatusCount label='Canceled' count={summary.canceled} variant='red' />
+      </div>
+
+      {(summary.periodStart || summary.periodEnd) && (
+        <p className='text-muted-foreground text-xs'>
+          Covers {formatDay(summary.periodStart)} to {formatDay(summary.periodEnd)}
+        </p>
+      )}
+
+      <div className='flex flex-col gap-1'>
+        <Button
+          variant='outline'
+          size='xs'
+          className='w-full justify-start'
+          disabled={!buildDefId || !batchRunField}
+          onClick={openRunInList}>
+          <ListFilter />
+          Show all {summary.total} builds in run {runNumber}
+        </Button>
+
+        {canUndoRun &&
+          (nothingToUndo ? (
+            <p className='px-1 text-muted-foreground text-xs'>
+              Every build in this run has already been cancelled or reversed.
+            </p>
+          ) : (
+            // 🛑 §11.4: never a bare "Undo". `build:run`'s Reverse button sits
+            // inches away in the same drawer and undoes THIS build only. Nothing
+            // about their shape says which is which, so the copy has to.
+            <Button
+              variant='outline'
+              size='xs'
+              className='w-full justify-start text-destructive'
+              loading={undoBatchRun.isPending}
+              loadingText={`Undoing run ${runNumber}...`}
+              onClick={handleUndo}>
+              <Undo2 />
+              Undo run {runNumber} ({plural(summary.total, 'build')})
+            </Button>
+          ))}
+      </div>
+    </div>
+  )
+}
+
+/** A status count, dropped entirely when it is zero: a zero is not news. */
+function StatusCount({
+  label,
+  count,
+  variant,
+}: {
+  label: string
+  count: number
+  variant: 'secondary' | 'blue' | 'green' | 'red'
+}) {
+  if (!count) return null
+  return (
+    <Badge variant={variant} size='xs'>
+      {count} {label.toLowerCase()}
+    </Badge>
+  )
+}
+
+/** `1 build` / `412 builds`, so no count in this card reads as a template slot. */
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`
+}
+
+/** A run's period bounds and its timestamp, as a day. The time of day is noise here. */
+function formatDay(value: Date | string | null): string {
+  if (!value) return 'unknown'
+  return new Date(value).toLocaleDateString()
+}

--- a/apps/web/src/components/manufacturing/builds/index.ts
+++ b/apps/web/src/components/manufacturing/builds/index.ts
@@ -2,6 +2,7 @@
 
 export { BackfillBuildsButton } from './backfill-builds-button'
 export { BackfillDialog } from './backfill-dialog'
+export { BuildBatchRunCard } from './build-batch-run-card'
 export { BuildLedgerCard } from './build-ledger-card'
 export { BuildRunCard } from './build-run-card'
 export { CompleteBuildDialog } from './complete-build-dialog'

--- a/apps/web/src/server/api/routers/builds.ts
+++ b/apps/web/src/server/api/routers/builds.ts
@@ -6,6 +6,7 @@ import {
   buildNow,
   cancelBuild,
   completeBuild,
+  computeBackfillPreflight,
   createBuild,
   executeBackfill,
   explodeBuildComponents,
@@ -16,17 +17,20 @@ import {
   planBackfill,
   previewStandardCostRoll,
   readBackfillPlanReads,
+  readBatchRun,
   readBuildDrift,
   readPartQuantitiesOnHand,
   reverseBuild,
   rollStandardCost,
   startBuild,
+  undoBatchRun,
 } from '@auxx/lib/builds'
 import type {
   BackfillExclusion,
   BackfillGrouping,
   BackfillPartPlan,
   BackfillPlan,
+  BackfillPreflight,
   BackfillStatus,
 } from '@auxx/lib/builds/client'
 import { getCachedEntityDefId } from '@auxx/lib/cache'
@@ -134,9 +138,9 @@ const completionShape = {
  * | procedure                              | gate                                      |
  * | -------------------------------------- | ----------------------------------------- |
  * | `previewRoll`, `roll`                  | edit on `part`                            |
- * | `list`, `get`                          | view on `build`                           |
+ * | `list`, `get`, `getBatchRun`           | view on `build`                           |
  * | `create`, `start`, `cancel`            | edit on `build`                           |
- * | `previewCompletion`, `complete`, `reverse`, `buildNow` | edit on `build` AND edit on `stock_movement` |
+ * | `previewCompletion`, `complete`, `reverse`, `buildNow`, `undoBatchRun` | edit on `build` AND edit on `stock_movement` |
  *
  * Three notes on why those, and not something coarser:
  *
@@ -144,7 +148,7 @@ const completionShape = {
  *    server mirror of the `canEditEntity(defId)` the cards run to decide whether
  *    to render a button, so the button the UI hides and the door the server
  *    closes are the same door.
- * 2. **`complete` and `reverse` assert BOTH.** They are the only two paths in
+ * 2. **`complete`, `reverse` and `undoBatchRun` assert BOTH.** They are paths in
  *    this router that write a `stock_movement`, and `stock_movement` is where
  *    the rest of manufacturing puts that authority — `purchasing.receiveStock`,
  *    `adjustStock` and `reverseMovement` all gate on exactly that def. A person
@@ -542,7 +546,7 @@ export const buildsRouter = createTRPCRouter({
       // The contract carries part IDS; a screen somebody has to judge carries
       // part NAMES. Resolved here rather than in the plan because the plan is
       // the thing the writer executes, and a display name has no business in it.
-      const [partNames, preflight] = await Promise.all([
+      const [partNames, preflightResult] = await Promise.all([
         readEntityNames(ctx.db, organizationId, [
           ...plan.parts.map((part: BackfillPartPlan) => part.partId),
           ...plan.excluded.map((exclusion: BackfillExclusion) => exclusion.partId),
@@ -551,6 +555,15 @@ export const buildsRouter = createTRPCRouter({
           ? computeBackfillPreflight(ctx.db, organizationId, plan)
           : Promise.resolve(null),
       ])
+
+      // The preflight fails as a whole rather than per part: it writes nothing,
+      // and one silently omitted part would under-report the consent it exists
+      // to obtain (44 §7.3).
+      let preflight: BackfillPreflight | null = null
+      if (preflightResult) {
+        if (preflightResult.isErr()) throw preflightResult.error
+        preflight = preflightResult.value
+      }
 
       return { cutoff, refusal: null, plan, partNames, preflight }
     }),
@@ -595,6 +608,64 @@ export const buildsRouter = createTRPCRouter({
         grouping: input.grouping,
         status: input.status,
       })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  // ─── The batch run (plans/money/tasks/45 §4, §11) ───────────────────
+
+  /**
+   * One batch run's members, counted by status.
+   *
+   * ⚠️ **A run is not a record** (45 §3.1), so there is no def to gate on and no
+   * detail page to open. This read IS the run's detail view, and the build
+   * drawer's `build:batch-run` card is the surface that renders it: every build
+   * carrying `build_batch_run = N` is a sibling, and the counts are what makes
+   * the Undo button able to state its own blast radius before it is pressed.
+   *
+   * VIEW on `build` and nothing else. It counts builds, discloses no cost, and
+   * anybody who may open one member of the run may count the rest.
+   */
+  getBatchRun: capabilityProcedure
+    .input(z.object({ runNumber: z.number().int().positive() }))
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      ctx.capabilities.assertViewEntity(await requireDefId(organizationId, 'build'))
+
+      const result = await readBatchRun(ctx.db, organizationId, input.runNumber)
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Cancel or reverse every build a batch run raised (45 §4.1).
+   *
+   * 🛑 **The full ledger gate, because `willReverse` writes movements.** A
+   * `planned` or `in_progress` member is cancelled and moves nothing, but a
+   * `completed` one is REVERSED, and a reversal appends the negation of every
+   * consume and produce row the completion wrote. So this takes exactly the pair
+   * {@link assertCanPostBuildLedger} exists for: EDIT on `build` and EDIT on
+   * `stock_movement`. Gating on `build` alone would let somebody who may raise a
+   * run post a four-figure ledger correction through a button whose only other
+   * arm is a cancellation.
+   *
+   * 🛑 **Never a delete**, and never a time machine. `reverseMovement` dates its
+   * rows `new Date()`, so undoing a run that covered a CLOSED month books the
+   * correction in today's open period and leaves that month as posted (§4.2).
+   * The card says so before it asks.
+   *
+   * Per-build isolation: the lib call never throws for one member's failure, it
+   * returns the four buckets (`cancelled`, `reversed`, `skipped`, `failed`).
+   * A run that aborted on the first refusal would report "failed" about builds
+   * it had already undone.
+   */
+  undoBatchRun: capabilityProcedure
+    .input(z.object({ runNumber: z.number().int().positive() }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      await assertCanPostBuildLedger(ctx)
+
+      const result = await undoBatchRun(ctx.db, organizationId, userId, input.runNumber)
       if (result.isErr()) throw result.error
       return result.value
     }),
@@ -645,110 +716,6 @@ async function readBookTimeZone(organizationId: string): Promise<string | null> 
   // kept in UTC has SET the zone, and collapsing the two would refuse it a
   // completed backfill it is entitled to.
   return typeof value === 'string' && value.trim() ? value : null
-}
-
-/**
- * What a `completed` backfill would write, checked before anything is written.
- *
- * §7.3 gates 2, 3 and 4: the consent for a completed run is *"N builds, M stock
- * movements, on an append-only ledger correctable only by reversing"*, and both
- * numbers have to be real. `completeBuild` also aborts per build when a
- * component has no `part_standard_cost`, and discovering that on build 400 of
- * 900 is the wrong time.
- */
-interface BackfillPreflight {
-  /** Builds the run would raise. */
-  buildCount: number
-  /** `build_consume` + `build_produce` rows those builds would append. */
-  movementCount: number
-  /** Parts with no standard cost, which `completeBuild` refuses outright. */
-  unpricedParts: { partId: string; partName: string | null }[]
-  /**
-   * Where the run leaves each consumed component.
-   *
-   * ⚠️ A WARNING's input, never a gate's (§7.3 gate 4). Negative on hand is a
-   * true statement about a ledger missing its receipts, and refusing would make
-   * the backfill unusable on exactly the org that needs it most. The remedy is
-   * opening stock, which is the person's call to make first.
-   */
-  projectedOnHand: {
-    partId: string
-    partName: string | null
-    onHand: number
-    consumed: number
-    projected: number
-  }[]
-}
-
-/**
- * Explode every part in the plan and total what the run would consume.
- *
- * Exploded once per part at its WHOLE range quantity rather than once per
- * bucket: component quantities are linear in the produced quantity, so the total
- * is identical and a twenty-part plan costs twenty round trips instead of
- * ninety-four.
- */
-async function computeBackfillPreflight(
-  db: Database,
-  organizationId: string,
-  plan: BackfillPlan
-): Promise<BackfillPreflight> {
-  const buildCount = plan.buildCount
-  let movementCount = 0
-  const unpriced = new Set<string>()
-  const consumed = new Map<string, number>()
-
-  const explosions = await Promise.all(
-    plan.parts.map((part) =>
-      explodeBuildComponents(db, organizationId, {
-        partId: part.partId,
-        quantityProduced: part.quantityToBuild,
-      })
-    )
-  )
-
-  for (const [index, explosion] of explosions.entries()) {
-    const part = plan.parts[index]
-    if (!part) continue
-    if (explosion.isErr()) throw explosion.error
-    const components = explosion.value.components
-    // One `build_produce` per build, plus one `build_consume` per component per
-    // build. The component set is the same for every bucket of a part.
-    movementCount += part.buckets.length * (components.length + 1)
-    for (const missing of explosion.value.missingStandardPartIds) unpriced.add(missing)
-    for (const line of components) {
-      consumed.set(line.partId, (consumed.get(line.partId) ?? 0) + line.quantityConsumed)
-    }
-  }
-
-  const componentIds = [...consumed.keys()]
-  const [onHand, names] = await Promise.all([
-    readPartQuantitiesOnHand(db, organizationId, componentIds),
-    readEntityNames(db, organizationId, [...componentIds, ...unpriced]),
-  ])
-
-  return {
-    buildCount,
-    movementCount,
-    unpricedParts: [...unpriced].map((partId) => ({
-      partId,
-      partName: names[partId] ?? null,
-    })),
-    projectedOnHand: componentIds
-      .map((partId) => {
-        const available = onHand.get(partId) ?? 0
-        const used = consumed.get(partId) ?? 0
-        return {
-          partId,
-          partName: names[partId] ?? null,
-          onHand: available,
-          consumed: used,
-          projected: available - used,
-        }
-      })
-      // Worst first: the rows that matter are the ones the run drives negative.
-      .sort((a, b) => a.projected - b.projected),
-  }
 }
 
 /**

--- a/packages/lib/scripts/check-pending-data-migrations.ts
+++ b/packages/lib/scripts/check-pending-data-migrations.ts
@@ -1,0 +1,43 @@
+// packages/lib/scripts/check-pending-data-migrations.ts
+
+/**
+ * Which data migrations the registry declares that the ledger has not applied.
+ *
+ * Every entity migration is spread into the same registry by
+ * `data-migrations/registry.ts`, so this covers both halves of the shared NNN id
+ * space. Three answers, and each means something different:
+ *
+ * - **pending**: declared and never run. The worker enqueues a run at boot, so
+ *   this is normally empty and a non-empty list means the worker has not booted
+ *   since the migration landed.
+ * - **non-applied**: in the ledger with a status other than `applied`. A failed
+ *   migration is recorded and never auto-retried; re-running is deliberate.
+ * - **orphan**: in the ledger with no registry entry, i.e. a migration that was
+ *   deleted or renamed after it ran.
+ *
+ * Read-only. Run with `npx dotenv -e ../../.env -- npx tsx scripts/check-pending-data-migrations.ts`.
+ */
+
+import { database, schema } from '@auxx/database'
+import { ALL_DATA_MIGRATIONS } from '../src/data-migrations'
+
+async function main(): Promise<void> {
+  const rows = await database
+    .select({ id: schema.DataMigration.id, status: schema.DataMigration.status })
+    .from(schema.DataMigration)
+
+  const ledger = new Map(rows.map((row) => [row.id, row.status]))
+  const pending = ALL_DATA_MIGRATIONS.filter((m) => !ledger.has(m.id))
+  const nonApplied = rows.filter((row) => row.status !== 'applied')
+  const orphans = rows.filter((row) => !ALL_DATA_MIGRATIONS.some((m) => m.id === row.id))
+
+  console.log(`registry declares ${ALL_DATA_MIGRATIONS.length}, ledger holds ${rows.length}`)
+  console.log(`\npending (never run): ${pending.length}`)
+  for (const m of pending) console.log(`    ${m.id}  ${m.description}`)
+  console.log(`\nnon-applied ledger rows: ${nonApplied.length}`)
+  for (const row of nonApplied) console.log(`    ${row.id}  ${row.status}`)
+  console.log(`\norphan ledger rows (no registry entry): ${orphans.length}`)
+  for (const row of orphans) console.log(`    ${row.id}`)
+}
+
+main().then(() => process.exit(0))

--- a/packages/lib/scripts/reset-org-books.ts
+++ b/packages/lib/scripts/reset-org-books.ts
@@ -146,6 +146,29 @@ const DELETE_WAVES: readonly (readonly string[])[] = [
 const CLEARED_TYPES = DELETE_WAVES.flat()
 
 /**
+ * Every `RecordSequence.scope` this script puts back to 0.
+ *
+ * Almost all of them are entity types, so `CLEARED_TYPES` covers them: the
+ * scope a document numbers under is its own type, and clearing the type is what
+ * makes resetting the counter correct.
+ *
+ * 🛑 `build_batch` is NOT an entity type, so it can never appear in
+ * `DELETE_WAVES` and would never be reset on its own. It is an INTERNAL scope
+ * (`records/record-numbering.ts`'s `INTERNAL_SEQUENCE_SCOPES`), numbering batch
+ * build RUNS rather than records, and the runs it numbered live entirely on the
+ * `build` rows that wave 2 deletes. Leaving it alone means an org with zero
+ * builds opens its next batch run reading "run 14", and 45 §3's whole argument
+ * is that the run number is the handle undo hangs on. See
+ * plans/money/tasks/45-batch-only-builds.md §11.6.
+ *
+ * Listed by hand rather than spread from `INTERNAL_SEQUENCE_SCOPES`, so a later
+ * internal scope that has nothing to do with the books cannot silently join
+ * this reset. Every wave always runs, so `build` is always cleared and this is
+ * unconditional.
+ */
+const CLEARED_SEQUENCE_SCOPES: readonly string[] = [...CLEARED_TYPES, 'build_batch']
+
+/**
  * Drizzle tables cleared before the instances, all org-scoped.
  *
  * The first two carry ON DELETE RESTRICT columns against `EntityInstance` and
@@ -635,7 +658,7 @@ async function main() {
     .where(
       and(
         eq(schema.RecordSequence.organizationId, org.id),
-        inArray(schema.RecordSequence.scope, [...CLEARED_TYPES])
+        inArray(schema.RecordSequence.scope, [...CLEARED_SEQUENCE_SCOPES])
       )
     )
   console.log(`RecordSequence  ${sequences.length} counter(s) back to 0`)
@@ -761,7 +784,7 @@ async function main() {
     .where(
       and(
         eq(schema.RecordSequence.organizationId, org.id),
-        inArray(schema.RecordSequence.scope, [...CLEARED_TYPES])
+        inArray(schema.RecordSequence.scope, [...CLEARED_SEQUENCE_SCOPES])
       )
     )
   console.log(`reset ${sequences.length} record counter(s) to 0`)

--- a/packages/lib/src/builds/__tests__/auto-build-cancel.test.ts
+++ b/packages/lib/src/builds/__tests__/auto-build-cancel.test.ts
@@ -114,6 +114,7 @@ function build(overrides: Partial<BuildRecord> & { buildId: string }): BuildReco
     source: 'order',
     reversalOfBuildId: null,
     orderRevision: null,
+    batchRun: null,
     createdAt: new Date('2026-08-27T00:00:00.000Z'),
     ...overrides,
   }

--- a/packages/lib/src/builds/__tests__/backfill-builds.test.ts
+++ b/packages/lib/src/builds/__tests__/backfill-builds.test.ts
@@ -19,6 +19,10 @@
 //      demand period, in the book timezone, and never from `new Date()`.
 //      Dating eight months of production to today puts all of it in one
 //      month-end entry.
+//   3. 45 §3: the run number is allocated ONCE per run and stamped on every
+//      build the run raises. A run is not a record, so that integer is the only
+//      handle undo has, and allocating it per bucket would quietly turn one
+//      four-hundred-build run into four hundred runs.
 
 import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -37,6 +41,12 @@ const h = vi.hoisted(() => ({
   timeZone: null as string | null,
   /** Which of the two demand-period fields are provisioned. */
   periodFields: { start: true, end: true },
+  /** Whether `build_batch_run` is provisioned (entity migration 141). */
+  batchRunField: true,
+  /** Every `recordNumbering.create` call, as `[organizationId, scope]`. */
+  numberingCalls: [] as [string, string][],
+  /** The counter the `recordNumbering` double increments, per org+scope. */
+  counters: new Map<string, number>(),
   /** Every `createBuild` call, as the `CreateBuildInput` it was handed. */
   createCalls: [] as Record<string, unknown>[],
   startCalls: [] as Record<string, unknown>[],
@@ -60,9 +70,26 @@ vi.mock('../../cache', () => ({
       bySystemAttributes: async () => ({
         build_period_start: h.periodFields.start ? { id: 'f_period_start' } : null,
         build_period_end: h.periodFields.end ? { id: 'f_period_end' } : null,
+        build_batch_run: h.batchRunField ? { id: 'f_batch_run' } : null,
       }),
     }),
   }),
+}))
+
+// The run-number counter, doubled so a test can COUNT the allocations. The real
+// one is an atomic `UPDATE ... RETURNING` against a `RecordSequence` row and
+// needs a database; what this file owns is that it is called ONCE per run
+// (plans/money/tasks/45 §3.2), which a double is the only way to see.
+vi.mock('../../records/record-numbering', () => ({
+  recordNumbering: {
+    create: vi.fn(async (organizationId: string, scope: string) => {
+      h.numberingCalls.push([organizationId, scope])
+      const key = `${organizationId}:${scope}`
+      const next = (h.counters.get(key) ?? 0) + 1
+      h.counters.set(key, next)
+      return { recordNumber: `BR-${String(next).padStart(4, '0')}`, sequenceNumber: next }
+    }),
+  },
 }))
 
 // The three sanctioned writers are doubles: each has its own suite, and what is
@@ -183,6 +210,9 @@ beforeEach(() => {
   vi.useRealTimers()
   h.timeZone = 'UTC'
   h.periodFields = { start: true, end: true }
+  h.batchRunField = true
+  h.numberingCalls = []
+  h.counters = new Map()
   h.createCalls = []
   h.startCalls = []
   h.completeCalls = []
@@ -269,6 +299,7 @@ describe('one bucket, one build', () => {
         start: new Date('2026-01-01T00:00:00.000Z'),
         end: new Date('2026-02-01T00:00:00.000Z'),
       },
+      batchRun: 1,
     })
   })
 
@@ -295,8 +326,91 @@ describe('one bucket, one build', () => {
 
   it('does nothing at all for an empty plan', async () => {
     const summary = (await executeBackfill(db, ORG, USER, planOf(), PLANNED))._unsafeUnwrap()
-    expect(summary).toEqual({ created: [], leftInProgress: [], failed: [] })
+    expect(summary).toEqual({ batchRun: null, created: [], leftInProgress: [], failed: [] })
     expect(h.createCalls).toHaveLength(0)
+  })
+})
+
+// ─── §3: the run number ────────────────────────────────────────────────
+
+// 🛑 A run is not a record (§3.1), so this integer is the only handle
+// `undoBatchRun` has. Two properties make it one: every build a run raised
+// carries the SAME number, and no two runs share one. Both are decided by WHERE
+// the allocation happens, which is why these assert on the call COUNT rather
+// than only on the values that came out.
+describe('🛑 the batch run number is allocated once per run', () => {
+  it('stamps every build in the run with the same number', async () => {
+    const plan = planOf(
+      bucket(),
+      bucket({ periodKey: '2026-02', bucketId: `${LIFT}:2026-02` }),
+      bucket({ partId: HOIST, bucketId: `${HOIST}:2026-01` })
+    )
+
+    const summary = (await executeBackfill(db, ORG, USER, plan, PLANNED))._unsafeUnwrap()
+
+    expect(h.createCalls).toHaveLength(3)
+    expect(h.createCalls.map((call) => call.batchRun)).toEqual([1, 1, 1])
+    expect(summary.batchRun).toBe(1)
+  })
+
+  // The failure this exists to catch: allocating inside the bucket loop. Every
+  // value assertion above still passes when the double hands back a constant,
+  // so the call count is what actually pins the placement down.
+  it('calls the counter once, not once per bucket', async () => {
+    const plan = planOf(
+      bucket(),
+      bucket({ periodKey: '2026-02', bucketId: `${LIFT}:2026-02` }),
+      bucket({ periodKey: '2026-03', bucketId: `${LIFT}:2026-03` })
+    )
+
+    await executeBackfill(db, ORG, USER, plan, PLANNED)
+
+    expect(h.numberingCalls).toEqual([[ORG, 'build_batch']])
+  })
+
+  // 🛑 `prepareRun` is called AFTER the empty-plan return, deliberately. A
+  // counter that skips a number every time somebody runs a range with no demand
+  // in it is the "run 14 in an org with zero builds" mismatch of §10.6.
+  it('burns no number for an empty plan', async () => {
+    const summary = (await executeBackfill(db, ORG, USER, planOf(), PLANNED))._unsafeUnwrap()
+
+    expect(h.numberingCalls).toEqual([])
+    expect(summary.batchRun).toBeNull()
+  })
+
+  it('gives two successive runs two different numbers', async () => {
+    const first = (await executeBackfill(db, ORG, USER, planOf(bucket()), PLANNED))._unsafeUnwrap()
+    const second = (await executeBackfill(db, ORG, USER, planOf(bucket()), PLANNED))._unsafeUnwrap()
+
+    expect(first.batchRun).toBe(1)
+    expect(second.batchRun).toBe(2)
+    expect(h.numberingCalls).toHaveLength(2)
+    // And the second run's build carries the second number, not the first.
+    expect(h.createCalls.map((call) => call.batchRun)).toEqual([1, 2])
+  })
+
+  // Undo takes a run number as INPUT (§4.3) and no read derives it from a
+  // summary that does not carry it, so a caller that cannot tell the person
+  // which run they just made has left them unable to name it again.
+  it('returns the number on the summary', async () => {
+    const result = await executeBackfill(db, ORG, USER, planOf(bucket()), PLANNED)
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().batchRun).toBe(1)
+  })
+
+  // ⚠️ The asymmetry with the two demand-period fields is deliberate: coverage
+  // depends on the period, so a run without it computes the wrong thing, while
+  // nothing about the netting depends on the run number. An org short of entity
+  // migration 141 gets a correct backfill and un-numbered builds, and loses only
+  // undo.
+  it('runs anyway when build_batch_run is not provisioned', async () => {
+    h.batchRunField = false
+
+    const result = await executeBackfill(db, ORG, USER, planOf(bucket()), PLANNED)
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().created).toHaveLength(1)
   })
 })
 

--- a/packages/lib/src/builds/__tests__/backfill-preflight.test.ts
+++ b/packages/lib/src/builds/__tests__/backfill-preflight.test.ts
@@ -1,0 +1,255 @@
+// packages/lib/src/builds/__tests__/backfill-preflight.test.ts
+//
+// §7.3's gates 2, 3 and 4, unit tested.
+//
+// 🛑 **This file is the whole reason the preflight moved out of the router**
+// (44 §11.3, 45 §12.7). The arithmetic here decides the sentence a person reads
+// before appending several hundred rows to an append-only ledger, and while it
+// lived in `routers/builds.ts` the only way to exercise it was a tRPC caller.
+//
+// The two properties that carry the weight:
+//
+//   1. The explosion is per PART at its whole-range quantity, but the movement
+//      count is per BUCKET. Getting that wrong understates the consent by
+//      exactly the factor the person is being asked to agree to.
+//   2. Gate 4 REPORTS and never refuses. Negative projected on hand is a true
+//      statement about a ledger missing its receipts, and refusing on it would
+//      make the backfill unusable on the org that needs it most.
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BackfillPlan } from '../backfill-types'
+
+const ORG = 'org_1'
+const LIFT = 'part_lift'
+const HOIST = 'part_hoist'
+const MOTOR = 'part_motor'
+const BOLT = 'part_bolt'
+
+const h = vi.hoisted(() => ({
+  /** partId -> the components one unit of it consumes. */
+  explosions: new Map<string, { partId: string; quantityConsumed: number }[]>(),
+  /** partId -> the parts its explosion reports as having no standard cost. */
+  missingStandard: new Map<string, string[]>(),
+  /** partIds whose explosion must return an `err`. */
+  explodeRefusals: new Map<string, Error>(),
+  /** partId -> quantity on hand. */
+  onHand: new Map<string, number>(),
+  /** partId -> display name. */
+  names: new Map<string, string>(),
+}))
+
+vi.mock('../build-queries', () => ({
+  explodeBuildComponents: vi.fn(
+    async (_db: unknown, _org: string, input: { partId: string; quantityProduced: number }) => {
+      const refusal = h.explodeRefusals.get(input.partId)
+      if (refusal) return err(refusal)
+      const perUnit = h.explosions.get(input.partId) ?? []
+      return ok({
+        components: perUnit.map((line) => ({
+          partId: line.partId,
+          quantityConsumed: line.quantityConsumed * input.quantityProduced,
+        })),
+        missingStandardPartIds: h.missingStandard.get(input.partId) ?? [],
+      })
+    }
+  ),
+  readPartNames: vi.fn(async (_db: unknown, _org: string, ids: string[]) => {
+    const out = new Map<string, string>()
+    for (const id of ids) {
+      const name = h.names.get(id)
+      if (name) out.set(id, name)
+    }
+    return out
+  }),
+}))
+
+vi.mock('../auto-build-queries', () => ({
+  readPartQuantitiesOnHand: vi.fn(async (_db: unknown, _org: string, ids: string[]) => {
+    const out = new Map<string, number>()
+    for (const id of ids) out.set(id, h.onHand.get(id) ?? 0)
+    return out
+  }),
+}))
+
+import { computeBackfillPreflight } from '../backfill-preflight'
+
+/** A plan with one part per entry, `buckets` counted rather than described. */
+function plan(parts: { partId: string; quantityToBuild: number; buckets: number }[]): BackfillPlan {
+  return {
+    parts: parts.map((part) => ({
+      partId: part.partId,
+      quantityToBuild: part.quantityToBuild,
+      quantityOrdered: part.quantityToBuild,
+      quantityCovered: 0,
+      buckets: Array.from({ length: part.buckets }, (_, index) => ({
+        bucketId: `${part.partId}:${index}`,
+        partId: part.partId,
+        periodKey: `2026-0${index + 1}`,
+        periodStart: new Date('2026-01-01T00:00:00.000Z'),
+        periodEnd: new Date('2026-02-01T00:00:00.000Z'),
+        quantityOrdered: 1,
+        quantityCovered: 0,
+        quantityToBuild: 1,
+        orderIds: [],
+      })),
+    })),
+    excluded: [],
+    buildCount: parts.reduce((sum, part) => sum + part.buckets, 0),
+  } as unknown as BackfillPlan
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.explosions.clear()
+  h.missingStandard.clear()
+  h.explodeRefusals.clear()
+  h.onHand.clear()
+  h.names.clear()
+})
+
+describe('computeBackfillPreflight', () => {
+  it('counts one produce plus one consume per component, per BUCKET', async () => {
+    // One part, two components, three buckets: 3 * (2 + 1) = 9.
+    h.explosions.set(LIFT, [
+      { partId: MOTOR, quantityConsumed: 1 },
+      { partId: BOLT, quantityConsumed: 4 },
+    ])
+
+    const result = await computeBackfillPreflight(
+      {} as never,
+      ORG,
+      plan([{ partId: LIFT, quantityToBuild: 3, buckets: 3 }])
+    )
+
+    expect(result.isOk()).toBe(true)
+    const preflight = result._unsafeUnwrap()
+    expect(preflight.movementCount).toBe(9)
+    expect(preflight.buildCount).toBe(3)
+  })
+
+  it('explodes once per part at the WHOLE range quantity, not once per bucket', async () => {
+    h.explosions.set(LIFT, [{ partId: MOTOR, quantityConsumed: 2 }])
+    const { explodeBuildComponents } = await import('../build-queries')
+
+    const result = await computeBackfillPreflight(
+      {} as never,
+      ORG,
+      plan([{ partId: LIFT, quantityToBuild: 10, buckets: 4 }])
+    )
+
+    // Four buckets, ONE explosion, asked for all ten units at once.
+    expect(explodeBuildComponents).toHaveBeenCalledTimes(1)
+    expect(explodeBuildComponents).toHaveBeenCalledWith({}, ORG, {
+      partId: LIFT,
+      quantityProduced: 10,
+    })
+    expect(result._unsafeUnwrap().projectedOnHand[0]?.consumed).toBe(20)
+  })
+
+  it('totals a shared component across every part that consumes it', async () => {
+    h.explosions.set(LIFT, [{ partId: BOLT, quantityConsumed: 4 }])
+    h.explosions.set(HOIST, [{ partId: BOLT, quantityConsumed: 6 }])
+    h.onHand.set(BOLT, 100)
+
+    const result = await computeBackfillPreflight(
+      {} as never,
+      ORG,
+      plan([
+        { partId: LIFT, quantityToBuild: 2, buckets: 1 },
+        { partId: HOIST, quantityToBuild: 3, buckets: 1 },
+      ])
+    )
+
+    const bolt = result._unsafeUnwrap().projectedOnHand.find((row) => row.partId === BOLT)
+    expect(bolt).toMatchObject({ onHand: 100, consumed: 26, projected: 74 })
+  })
+
+  it('REPORTS a negative projection rather than refusing it (gate 4)', async () => {
+    h.explosions.set(LIFT, [{ partId: MOTOR, quantityConsumed: 5 }])
+    h.onHand.set(MOTOR, 2)
+
+    const result = await computeBackfillPreflight(
+      {} as never,
+      ORG,
+      plan([{ partId: LIFT, quantityToBuild: 10, buckets: 1 }])
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().projectedOnHand[0]).toMatchObject({
+      partId: MOTOR,
+      onHand: 2,
+      consumed: 50,
+      projected: -48,
+    })
+  })
+
+  it('sorts the worst projection first', async () => {
+    h.explosions.set(LIFT, [
+      { partId: MOTOR, quantityConsumed: 1 },
+      { partId: BOLT, quantityConsumed: 50 },
+    ])
+    h.onHand.set(MOTOR, 100)
+    h.onHand.set(BOLT, 1)
+
+    const result = await computeBackfillPreflight(
+      {} as never,
+      ORG,
+      plan([{ partId: LIFT, quantityToBuild: 1, buckets: 1 }])
+    )
+
+    expect(result._unsafeUnwrap().projectedOnHand.map((row) => row.partId)).toEqual([BOLT, MOTOR])
+  })
+
+  it('collects unpriced parts across every explosion, de-duplicated, with names', async () => {
+    h.explosions.set(LIFT, [{ partId: MOTOR, quantityConsumed: 1 }])
+    h.explosions.set(HOIST, [{ partId: MOTOR, quantityConsumed: 1 }])
+    h.missingStandard.set(LIFT, [MOTOR])
+    h.missingStandard.set(HOIST, [MOTOR, BOLT])
+    h.names.set(MOTOR, 'Motor assembly')
+
+    const result = await computeBackfillPreflight(
+      {} as never,
+      ORG,
+      plan([
+        { partId: LIFT, quantityToBuild: 1, buckets: 1 },
+        { partId: HOIST, quantityToBuild: 1, buckets: 1 },
+      ])
+    )
+
+    const unpriced = result._unsafeUnwrap().unpricedParts
+    expect(unpriced).toHaveLength(2)
+    expect(unpriced).toContainEqual({ partId: MOTOR, partName: 'Motor assembly' })
+    // No name row, so `null` rather than the raw cuid leaking into the dialog.
+    expect(unpriced).toContainEqual({ partId: BOLT, partName: null })
+  })
+
+  it('fails as a WHOLE when one part cannot be exploded', async () => {
+    // Unlike `executeBackfill`, which isolates per bucket: this writes nothing,
+    // and a silently omitted part would under-report the consent being asked for.
+    h.explosions.set(LIFT, [{ partId: MOTOR, quantityConsumed: 1 }])
+    h.explodeRefusals.set(HOIST, new Error('no bill of materials'))
+
+    const result = await computeBackfillPreflight(
+      {} as never,
+      ORG,
+      plan([
+        { partId: LIFT, quantityToBuild: 1, buckets: 1 },
+        { partId: HOIST, quantityToBuild: 1, buckets: 1 },
+      ])
+    )
+
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('is empty and does not throw on a plan with no parts', async () => {
+    const result = await computeBackfillPreflight({} as never, ORG, plan([]))
+
+    expect(result._unsafeUnwrap()).toMatchObject({
+      buildCount: 0,
+      movementCount: 0,
+      unpricedParts: [],
+      projectedOnHand: [],
+    })
+  })
+})

--- a/packages/lib/src/builds/__tests__/batch-run-queries.test.ts
+++ b/packages/lib/src/builds/__tests__/batch-run-queries.test.ts
@@ -1,0 +1,331 @@
+// packages/lib/src/builds/__tests__/batch-run-queries.test.ts
+//
+// The two reads behind the Undo card
+// (`plans/money/tasks/45-batch-only-builds.md` sections 10.4 and 11.3), at the
+// thing a db double can actually see: what they make of the rows the query
+// comes back with.
+//
+// ⚠️ **The SQL predicates are NOT under test here and cannot be.**
+// `src/test/setup.ts` mocks `@auxx/database` wholesale, so `schema.Foo` is a
+// memoized `{}` whose COLUMNS are `undefined`, so a `WHERE` is unreadable and an
+// alias is indistinguishable from any other. So "only this org", "only this run
+// number" and "an archived reversal does not count" live in SQL and are asserted
+// against a real database elsewhere; asserting them here would only be asserting
+// the double.
+//
+// What IS here is the fold, which is where the two numbers that matter are
+// decided: 🛑 `willCancel` and `willReverse` differ, and `willReverse` excludes
+// a `completed` build something has ALREADY reversed. Counting that build would
+// promise a ledger write the undo will not make (45 section 11.4).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG = 'org_1'
+const LIFT = 'part_lift'
+
+/** The one projection these reads issue, which is how the double recognises it. */
+const RUN_BUILDS =
+  'buildId|createdAt|runNumber|status|partId|reversalOfBuildId|reversedByBuildId|periodStart|periodEnd'
+
+const h = vi.hoisted(() => ({
+  /** entityType -> `EntityDefinition.id`, for the defs the org has. */
+  defs: new Map<string, string>(),
+  /** systemAttributes the org has materialised. */
+  fields: new Set<string>(),
+  /** projection key -> the rows that read returns. */
+  rows: new Map<string, Record<string, unknown>[]>(),
+  /** projection keys, in the order the reads were issued. */
+  issued: [] as string[],
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(
+          attrs.map((attr) => [attr, h.fields.has(attr) ? { id: `fld_${attr}` } : null])
+        ),
+    }),
+  }),
+}))
+
+import { listBatchRuns, readBatchRun, readBatchRunBuilds } from '../batch-run-queries'
+
+const CHAIN_METHODS = ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'offset']
+
+/** A promise carrying the chain methods, so `await` works anywhere along it. */
+function chain(rows: Record<string, unknown>[]) {
+  const promise = Promise.resolve(rows) as Promise<Record<string, unknown>[]> &
+    Record<string, unknown>
+  for (const method of CHAIN_METHODS) promise[method] = () => promise
+  return promise
+}
+
+const db = {
+  select: (projection: Record<string, unknown>) => {
+    const key = Object.keys(projection).join('|')
+    h.issued.push(key)
+    return chain(h.rows.get(key) ?? [])
+  },
+} as never
+
+const BUILD_ATTRS = [
+  'build_part',
+  'build_status',
+  'build_reversal_of',
+  'build_period_start',
+  'build_period_end',
+  'build_batch_run',
+]
+
+/** One row as the run query returns it. Defaults to a `planned` build of run 7. */
+function runRow(overrides: Record<string, unknown> = {}) {
+  return {
+    buildId: 'bld_1',
+    createdAt: new Date('2026-02-01T10:00:00.000Z'),
+    runNumber: 7,
+    status: 'planned',
+    partId: LIFT,
+    reversalOfBuildId: null,
+    reversedByBuildId: null,
+    periodStart: '2026-01-01T00:00:00.000Z',
+    periodEnd: '2026-02-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function given(rows: Record<string, unknown>[]): void {
+  h.rows.set(RUN_BUILDS, rows)
+}
+
+async function read(runNumber: number) {
+  const result = await readBatchRun(db, ORG, runNumber)
+  if (result.isErr()) throw result.error
+  return result.value
+}
+
+async function list() {
+  const result = await listBatchRuns(db, ORG)
+  if (result.isErr()) throw result.error
+  return result.value
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.defs = new Map([['build', 'def_build']])
+  h.fields = new Set(BUILD_ATTRS)
+  h.rows = new Map()
+  h.issued = []
+})
+
+describe('readBatchRun', () => {
+  it('counts by status, and willCancel is planned plus in progress', async () => {
+    given([
+      runRow({ buildId: 'bld_1', status: 'planned' }),
+      runRow({ buildId: 'bld_2', status: 'in_progress' }),
+      runRow({ buildId: 'bld_3', status: 'completed' }),
+      runRow({ buildId: 'bld_4', status: 'canceled' }),
+    ])
+
+    const summary = await read(7)
+
+    expect(summary).toMatchObject({
+      runNumber: 7,
+      total: 4,
+      planned: 1,
+      inProgress: 1,
+      completed: 1,
+      canceled: 1,
+      willCancel: 2,
+      willReverse: 1,
+    })
+  })
+
+  it('🛑 excludes an ALREADY REVERSED build from willReverse, but not from completed', async () => {
+    // The build is still a completed build of this run and the card says so.
+    // What it is not is work the undo has left to do: `reverseBuild` would
+    // refuse it, so counting it would over-state the ledger writes.
+    given([
+      runRow({ buildId: 'bld_1', status: 'completed' }),
+      runRow({ buildId: 'bld_2', status: 'completed', reversedByBuildId: 'bld_rev' }),
+      runRow({ buildId: 'bld_3', status: 'completed', reversedByBuildId: 'bld_rev_2' }),
+    ])
+
+    const summary = await read(7)
+
+    expect(summary.completed).toBe(3)
+    expect(summary.willReverse).toBe(1)
+    expect(summary.willCancel).toBe(0)
+  })
+
+  it('a run number no build carries is an EMPTY summary, never an error', async () => {
+    // 45 section 10.8: a run whose buckets all failed allocated a number and
+    // wrote nothing. A 404 there reads as "your data is missing".
+    given([])
+
+    const summary = await read(9)
+
+    expect(summary).toEqual({
+      runNumber: 9,
+      total: 0,
+      planned: 0,
+      inProgress: 0,
+      completed: 0,
+      canceled: 0,
+      willCancel: 0,
+      willReverse: 0,
+      periodStart: null,
+      periodEnd: null,
+      ranAt: null,
+    })
+  })
+
+  it('reads empty, and issues no query, when the org has no build_batch_run field', async () => {
+    h.fields.delete('build_batch_run')
+    given([runRow()])
+
+    const summary = await read(7)
+
+    expect(summary.total).toBe(0)
+    expect(h.issued).toEqual([])
+  })
+
+  it('reads empty when the org has no build definition at all', async () => {
+    h.defs = new Map()
+
+    expect((await read(7)).total).toBe(0)
+    expect(h.issued).toEqual([])
+  })
+
+  it('spans the run period and dates it from the FIRST build written', async () => {
+    given([
+      runRow({
+        buildId: 'bld_1',
+        createdAt: new Date('2026-03-01T09:00:00.000Z'),
+        periodStart: '2026-02-01T00:00:00.000Z',
+        periodEnd: '2026-03-01T00:00:00.000Z',
+      }),
+      runRow({
+        buildId: 'bld_2',
+        createdAt: new Date('2026-03-01T08:00:00.000Z'),
+        periodStart: '2026-01-01T00:00:00.000Z',
+        periodEnd: '2026-02-01T00:00:00.000Z',
+      }),
+    ])
+
+    const summary = await read(7)
+
+    expect(summary.periodStart).toEqual(new Date('2026-01-01T00:00:00.000Z'))
+    expect(summary.periodEnd).toEqual(new Date('2026-03-01T00:00:00.000Z'))
+    expect(summary.ranAt).toEqual(new Date('2026-03-01T08:00:00.000Z'))
+  })
+
+  it('counts a build ONCE even when the reversal join fans out', async () => {
+    // Two reversals of one build should never exist, and if they ever did the
+    // total is a number somebody reconciles against a list.
+    given([
+      runRow({ buildId: 'bld_1', status: 'completed', reversedByBuildId: null }),
+      runRow({ buildId: 'bld_1', status: 'completed', reversedByBuildId: 'bld_rev' }),
+    ])
+
+    const summary = await read(7)
+
+    expect(summary.total).toBe(1)
+    expect(summary.willReverse).toBe(0)
+  })
+
+  it('never counts a build whose status is missing as cancellable or reversible', async () => {
+    // `resolveBuildStatus` returns `null` rather than defaulting, and an undo
+    // must not guess: guessing either cancels a live run or reverses one that
+    // wrote nothing.
+    given([runRow({ buildId: 'bld_1', status: null })])
+
+    const summary = await read(7)
+
+    expect(summary.total).toBe(1)
+    expect(summary.willCancel).toBe(0)
+    expect(summary.willReverse).toBe(0)
+  })
+})
+
+describe('listBatchRuns', () => {
+  it('groups every run and returns them newest first', async () => {
+    given([
+      runRow({ buildId: 'bld_1', runNumber: 1, status: 'completed' }),
+      runRow({ buildId: 'bld_2', runNumber: 3, status: 'planned' }),
+      runRow({ buildId: 'bld_3', runNumber: 3, status: 'completed' }),
+      runRow({ buildId: 'bld_4', runNumber: 2, status: 'canceled' }),
+    ])
+
+    const runs = await list()
+
+    expect(runs.map((run) => run.runNumber)).toEqual([3, 2, 1])
+    expect(runs[0]).toMatchObject({
+      total: 2,
+      planned: 1,
+      completed: 1,
+      willCancel: 1,
+      willReverse: 1,
+    })
+    expect(runs[1]).toMatchObject({ total: 1, canceled: 1, willCancel: 0, willReverse: 0 })
+    expect(runs[2]).toMatchObject({ total: 1, completed: 1, willReverse: 1 })
+  })
+
+  it('issues ONE query for every run there is', async () => {
+    given([runRow({ runNumber: 1 }), runRow({ buildId: 'bld_2', runNumber: 2 })])
+
+    await list()
+
+    expect(h.issued).toEqual([RUN_BUILDS])
+  })
+
+  it('is an empty list, not an error, for an org that has never run a batch', async () => {
+    given([])
+    expect(await list()).toEqual([])
+  })
+})
+
+describe('readBatchRunBuilds', () => {
+  it('returns the run oldest first, carrying what the undo classifies on', async () => {
+    given([
+      runRow({
+        buildId: 'bld_late',
+        createdAt: new Date('2026-03-01T10:00:00.000Z'),
+        status: 'completed',
+        reversedByBuildId: 'bld_rev',
+      }),
+      runRow({
+        buildId: 'bld_early',
+        createdAt: new Date('2026-03-01T09:00:00.000Z'),
+        status: 'planned',
+      }),
+    ])
+
+    const result = await readBatchRunBuilds(db, ORG, 7)
+    expect(result.isOk()).toBe(true)
+    const builds = result._unsafeUnwrap()
+
+    // Oldest first, so an interrupted undo has undone a PREFIX of the run.
+    expect(builds.map((build) => build.buildId)).toEqual(['bld_early', 'bld_late'])
+    expect(builds[0]).toMatchObject({
+      status: 'planned',
+      partId: LIFT,
+      alreadyReversed: false,
+      isReversal: false,
+      runNumber: 7,
+    })
+    expect(builds[1]).toMatchObject({ status: 'completed', alreadyReversed: true })
+  })
+
+  it('flags a build that is ITSELF a reversal', async () => {
+    // It should never carry a run number at all (that is what
+    // `reverse-build-batch-run.test.ts` pins), so this is read rather than
+    // assumed, and the undo skips it instead of chaining reversals.
+    given([runRow({ status: 'completed', reversalOfBuildId: 'bld_original' })])
+
+    const result = await readBatchRunBuilds(db, ORG, 7)
+    expect(result._unsafeUnwrap()[0]).toMatchObject({ isReversal: true })
+    expect((await read(7)).willReverse).toBe(0)
+  })
+})

--- a/packages/lib/src/builds/__tests__/build-mutations.test.ts
+++ b/packages/lib/src/builds/__tests__/build-mutations.test.ts
@@ -1,0 +1,260 @@
+// packages/lib/src/builds/__tests__/build-mutations.test.ts
+//
+// What `createBuild` STAMPS, and what it refuses to stamp.
+//
+// The lifecycle writes have their coverage elsewhere (`build-event.test.ts` owns
+// the movement side, `build-status-guard-wiring.int.test.ts` the guard). What
+// this file owns is the three write-once fields a batch build carries:
+// `build_period_start`, `build_period_end` and `build_batch_run`.
+//
+// 🛑 **This is the only thing protecting them.** All three are `updatable:
+// false`, which reads like a schema guarantee and is not one:
+// `field-hooks/register-hooks.ts:523` states the write path NEVER reads
+// `capabilities.updatable`, so the flag is documentation plus a UI and connector
+// gate (plans/money/tasks/45 §10.5). What actually holds the invariant is that
+// `createBuild` is the only writer and stamps them only on a `batch` build, so a
+// test is the belt with no brace behind it.
+//
+// ⚠️ `src/test/setup.ts` mocks `@auxx/database` wholesale, so the db stand-in
+// below only has to answer the one existence probe `createBuild` makes.
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import type { BuildRecord, CreateBuildInput } from '../types'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const PART = 'part_lift'
+const BUILD_DEF = 'def_build'
+
+const h = vi.hoisted(() => ({
+  /** systemAttribute -> provisioned. A missing key models an unmigrated org. */
+  fields: new Set<string>(),
+  /** entityType -> def id. */
+  defs: new Map<string, string>(),
+  /** partId -> stored `part_kind`. */
+  kinds: new Map<string, string>(),
+  /** Whether the part exists in this org. */
+  partExists: true,
+  /** Direct subparts of the part being built. Empty models no bill of materials. */
+  subparts: [] as { childId: string; qty: number }[],
+  /** Every `UnifiedCrudHandler.create`, as the value map it was handed. */
+  created: [] as Record<string, unknown>[],
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(
+          attrs.map((attr) => [attr, h.fields.has(attr) ? { id: `fld_${attr}` } : null])
+        ),
+    }),
+  }),
+}))
+
+vi.mock('../../bom/subpart-graph', () => ({
+  loadDirectSubparts: vi.fn(async () => h.subparts),
+}))
+
+vi.mock('../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    async create(_defId: string, values: Record<string, unknown>) {
+      h.created.push(values)
+      return { instance: { id: 'bld_1' } }
+    }
+  },
+}))
+
+// `readPartKinds` and `getBuild` are reads with their own suites; the def and
+// field resolution is the real one, over `h.fields` above.
+vi.mock('../build-queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../build-queries')>()
+  return {
+    ...actual,
+    readPartKinds: vi.fn(async () => h.kinds),
+    getBuild: vi.fn(async (_db: unknown, _org: string, buildId: string) => ok(raised(buildId))),
+  }
+})
+
+import { createBuild } from '../build-mutations'
+
+/** The one existence probe `assertPartExists` makes, and nothing else. */
+const db = {
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => (h.partExists ? [{ id: PART }] : []),
+      }),
+    }),
+  }),
+} as never
+
+function raised(buildId: string): BuildRecord {
+  return {
+    buildId,
+    recordId: `${BUILD_DEF}:${buildId}`,
+    number: null,
+    partId: PART,
+    status: 'planned',
+    quantityPlanned: 10,
+    quantityProduced: null,
+    quantityScrapped: null,
+    startedAt: null,
+    completedAt: null,
+    materialCost: null,
+    laborCost: null,
+    overheadCost: null,
+    producedValue: null,
+    varianceAmount: null,
+    postedAt: null,
+    notes: null,
+    orderId: null,
+    source: 'batch',
+    reversalOfBuildId: null,
+    orderRevision: null,
+    batchRun: null,
+    createdAt: new Date('2026-09-09T00:00:00.000Z'),
+  } as BuildRecord
+}
+
+/** One batch build over January, with the run number the dialog allocated. */
+function batchInput(over: Partial<CreateBuildInput> = {}): CreateBuildInput {
+  return {
+    partId: PART,
+    quantityPlanned: 10,
+    source: 'batch',
+    period: {
+      start: new Date('2026-01-01T00:00:00.000Z'),
+      end: new Date('2026-02-01T00:00:00.000Z'),
+    },
+    batchRun: 7,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  h.fields = new Set([
+    'build_status',
+    'build_part',
+    'build_period_start',
+    'build_period_end',
+    'build_batch_run',
+  ])
+  h.defs = new Map([
+    ['build', BUILD_DEF],
+    ['part', 'def_part'],
+    ['order', 'def_order'],
+  ])
+  h.kinds = new Map([[PART, 'subassembly']])
+  h.partExists = true
+  h.subparts = [{ childId: 'part_motor', qty: 2 }]
+  h.created = []
+})
+
+// ─── §3: the run number a batch build carries ──────────────────────────
+
+describe('🛑 build_batch_run is written here or never', () => {
+  it('stamps the run number the caller allocated', async () => {
+    const result = await createBuild(db, ORG, USER, batchInput())
+
+    expect(result.isOk()).toBe(true)
+    expect(h.created[0]).toMatchObject({
+      build_source: 'batch',
+      build_batch_run: 7,
+      build_period_start: '2026-01-01T00:00:00.000Z',
+      build_period_end: '2026-02-01T00:00:00.000Z',
+    })
+  })
+
+  // ⚠️ Same rule as the demand period: an order-raised build answers to one
+  // order and a hand-raised one to nobody, so neither belongs to a run, and a
+  // stray number on one would put it inside `undoBatchRun`'s blast radius.
+  it('ignores it on a hand-raised build', async () => {
+    await createBuild(db, ORG, USER, batchInput({ source: 'manual', period: undefined }))
+    expect(h.created[0]).not.toHaveProperty('build_batch_run')
+  })
+
+  it('ignores it on an order-raised build', async () => {
+    await createBuild(db, ORG, USER, batchInput({ source: 'order', period: undefined }))
+    expect(h.created[0]).not.toHaveProperty('build_batch_run')
+  })
+
+  it('writes nothing when the caller allocated no run', async () => {
+    await createBuild(db, ORG, USER, batchInput({ batchRun: undefined }))
+    expect(h.created[0]).not.toHaveProperty('build_batch_run')
+    // The period is unaffected: the two are independent stamps.
+    expect(h.created[0]).toHaveProperty('build_period_start')
+  })
+
+  // 🛑 An org short of entity migration 141 must still be able to backfill. It
+  // gets un-numbered builds, which costs it undo and costs the netting read
+  // nothing, and a 500 here would cost it the whole feature.
+  it('raises the build anyway when the field is not provisioned', async () => {
+    h.fields.delete('build_batch_run')
+
+    const result = await createBuild(db, ORG, USER, batchInput())
+
+    expect(result.isOk()).toBe(true)
+    expect(h.created[0]).not.toHaveProperty('build_batch_run')
+    expect(h.created[0]).toMatchObject({ build_source: 'batch' })
+  })
+})
+
+// ─── §6.2: the demand period, unchanged by the above ───────────────────
+
+describe('the demand period a batch build claims', () => {
+  it('is skipped when the two fields are not provisioned', async () => {
+    h.fields.delete('build_period_end')
+
+    const result = await createBuild(db, ORG, USER, batchInput())
+
+    expect(result.isOk()).toBe(true)
+    expect(h.created[0]).not.toHaveProperty('build_period_start')
+    expect(h.created[0]).not.toHaveProperty('build_period_end')
+    // The run number is independent and still lands.
+    expect(h.created[0]).toMatchObject({ build_batch_run: 7 })
+  })
+
+  it('refuses a period that ends before it starts, writing nothing', async () => {
+    const result = await createBuild(
+      db,
+      ORG,
+      USER,
+      batchInput({
+        period: {
+          start: new Date('2026-02-01T00:00:00.000Z'),
+          end: new Date('2026-01-01T00:00:00.000Z'),
+        },
+      })
+    )
+
+    expect(result.isErr()).toBe(true)
+    expect(h.created).toHaveLength(0)
+  })
+})
+
+// ─── The refusals that must keep working ────────────────────────────────
+
+describe('a batch build is still a build', () => {
+  it('refuses a purchased part', async () => {
+    h.kinds = new Map([[PART, 'component']])
+
+    const result = await createBuild(db, ORG, USER, batchInput())
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.created).toHaveLength(0)
+  })
+
+  it('refuses a part with no bill of materials', async () => {
+    h.subparts = []
+
+    const result = await createBuild(db, ORG, USER, batchInput())
+
+    expect(result.isErr()).toBe(true)
+    expect(h.created).toHaveLength(0)
+  })
+})

--- a/packages/lib/src/builds/__tests__/drift-queries.test.ts
+++ b/packages/lib/src/builds/__tests__/drift-queries.test.ts
@@ -44,6 +44,7 @@ function build(overrides: Partial<BuildRecord> & { buildId: string }): BuildReco
     orderId: 'ord-1',
     source: 'order',
     reversalOfBuildId: null,
+    batchRun: null,
     orderRevision: 'hash-at-raise',
     createdAt: new Date('2026-08-28T00:00:00.000Z'),
     ...overrides,

--- a/packages/lib/src/builds/__tests__/reconcile-policy.test.ts
+++ b/packages/lib/src/builds/__tests__/reconcile-policy.test.ts
@@ -45,6 +45,7 @@ function build(overrides: Partial<BuildRecord> = {}): BuildRecord {
     source: 'order',
     reversalOfBuildId: null,
     orderRevision: null,
+    batchRun: null,
     createdAt: new Date('2026-08-01T00:00:00.000Z'),
     ...overrides,
   }

--- a/packages/lib/src/builds/__tests__/reconcile-queries.test.ts
+++ b/packages/lib/src/builds/__tests__/reconcile-queries.test.ts
@@ -67,6 +67,7 @@ function build(overrides: Partial<BuildRecord> & { buildId: string }): BuildReco
     source: 'order',
     reversalOfBuildId: null,
     orderRevision: null,
+    batchRun: null,
     createdAt: new Date('2026-08-27T00:00:00.000Z'),
     ...overrides,
   }

--- a/packages/lib/src/builds/__tests__/reverse-build-batch-run.test.ts
+++ b/packages/lib/src/builds/__tests__/reverse-build-batch-run.test.ts
@@ -1,0 +1,321 @@
+// packages/lib/src/builds/__tests__/reverse-build-batch-run.test.ts
+//
+// 🛑 THE invariant of `plans/money/tasks/45-batch-only-builds.md` section 4.1:
+// **a reversing build must NOT inherit `build_batch_run`.**
+//
+// `reverse-build.ts`'s `reversalBuildValues` copies `build_source` onto the
+// reversal, so a reversal of a batch build is itself `source: 'batch'`. That is
+// correct and deliberate, and it is also exactly the shape that invites somebody
+// copying the sibling field sitting beside it. If the run number were copied,
+// run N would contain its own undo, and a second `undoBatchRun(N)` would try to
+// reverse the reversals: `reverseBuild` refuses a reversal-of-a-reversal, so the
+// visible symptom would not be a wrong number but a run that can never be
+// cleanly undone twice.
+//
+// 45 section 10.5 is why this file exists rather than a schema flag:
+// `build_batch_run` is declared `updatable: false`, and the write path never
+// reads `capabilities.updatable` (`field-hooks/register-hooks.ts`). So this test
+// is the ONLY protection the rule has, not a belt beside a brace.
+//
+// ⚠️ `reverse-build.ts` is NOT edited by this test. The current code is already
+// correct; this pins it.
+//
+// Harness copied from `build-event.test.ts`: the org cache, the CRUD handler,
+// the quantity-on-hand batch and realtime are doubles, and a db stand-in routes
+// the reads by table identity plus whether the query joined. `src/test/setup.ts`
+// mocks `@auxx/database` wholesale, so no assertion here can name a column and
+// the double ignores every `WHERE`.
+
+import { schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const BUILD = 'bld_1'
+const PART_LIFT = 'part_lift'
+const PART_ASM = 'part_asm'
+const CREATED_AT = new Date('2026-08-01T00:00:00.000Z')
+const BATCH_RUN = 7
+
+/** One stored `FieldValue`, in the widest projection any read here selects. */
+interface ValueRow {
+  entityId: string
+  fieldId: string
+  valueText: string | null
+  valueNumber: number | null
+  valueDate: string | null
+  optionId: string | null
+  relatedEntityId: string | null
+}
+
+const h = vi.hoisted(() => ({
+  instanceRows: [] as { id: string; createdAt: Date; displayName: string | null }[],
+  movementInstances: [] as { id: string }[],
+  valueRows: [] as {
+    entityId: string
+    fieldId: string
+    valueText: string | null
+    valueNumber: number | null
+    valueDate: string | null
+    optionId: string | null
+    relatedEntityId: string | null
+  }[],
+  reversalRows: [] as { id: string }[],
+  materialised: new Set<string>(),
+  defs: new Map<string, string>(),
+  created: [] as { defId: string; id: string; values: Record<string, unknown> }[],
+  nextId: 0,
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => h.defs.get(entityType)),
+  requireCachedEntityDefId: vi.fn(async (_org: string, entityType: string) => {
+    const id = h.defs.get(entityType)
+    if (!id) throw new Error(`EntityDefinition not found for entityType: ${entityType}`)
+    return id
+  }),
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(
+          attrs.map((attr) => [attr, h.materialised.has(attr) ? { id: `fld_${attr}` } : null])
+        ),
+    }),
+  }),
+}))
+
+vi.mock('../../bom/qoh', () => ({
+  batchRecalculateQoH: vi.fn(async () => {}),
+  recalculatePartQoH: vi.fn(async () => {}),
+}))
+
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishFieldValueUpdates: vi.fn(async () => {}),
+  publishRecordsChanged: vi.fn(async () => {}),
+}))
+
+vi.mock('../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    async create(defId: string, values: Record<string, unknown>) {
+      h.nextId += 1
+      const id = defId === h.defs.get('build') ? `bld_new_${h.nextId}` : `mv_new_${h.nextId}`
+      h.created.push({ defId, id, values })
+      return { instance: { id }, recordId: `${defId}:${id}`, values }
+    }
+    async update(recordId: string, values: Record<string, unknown>) {
+      return { id: recordId, values }
+    }
+  },
+}))
+
+import { reverseBuild } from '../reverse-build'
+
+// ─── The db double ──────────────────────────────────────────────────────
+
+interface RowsChain extends PromiseLike<unknown[]> {
+  limit(): RowsChain
+  offset(): RowsChain
+  orderBy(): RowsChain
+  for(): RowsChain
+}
+
+function rowsPromise(rows: unknown[]): RowsChain {
+  return Object.assign(Promise.resolve(rows), {
+    limit: () => rowsPromise(rows),
+    offset: () => rowsPromise(rows),
+    orderBy: () => rowsPromise(rows),
+    for: () => rowsPromise(rows),
+  })
+}
+
+function makeChain() {
+  const state = { table: null as unknown, joined: false }
+  const rows = () => {
+    if (state.table === schema.EntityInstance) {
+      return state.joined ? h.movementInstances : h.instanceRows
+    }
+    return state.joined ? h.reversalRows : h.valueRows
+  }
+  const chain: Record<string, unknown> = {
+    from: (table: unknown) => {
+      state.table = table
+      return chain
+    },
+    innerJoin: () => {
+      state.joined = true
+      return chain
+    },
+    leftJoin: () => chain,
+    $dynamic: () => chain,
+    where: () => rowsPromise(rows()),
+  }
+  return chain
+}
+
+const db = {
+  select: () => makeChain(),
+  transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn(db),
+} as never
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+/**
+ * Every build attribute the org has materialised.
+ *
+ * 🛑 The three `updatable: false` batch fields are HERE deliberately: a fixture
+ * that left them unmaterialised would make this test pass for the wrong reason,
+ * because `reversalBuildValues` can only copy a field the read produced.
+ */
+const BUILD_ATTRS = [
+  'build_number',
+  'build_part',
+  'build_status',
+  'build_quantity_planned',
+  'build_quantity_produced',
+  'build_quantity_scrapped',
+  'build_started_at',
+  'build_completed_at',
+  'build_material_cost',
+  'build_labor_cost',
+  'build_overhead_cost',
+  'build_produced_value',
+  'build_variance_amount',
+  'build_posted_at',
+  'build_notes',
+  'build_order',
+  'build_source',
+  'build_reversal_of',
+  'build_order_revision',
+  'build_period_start',
+  'build_period_end',
+  'build_batch_run',
+]
+
+const MOVEMENT_ATTRS = [
+  'stock_movement_build',
+  'stock_movement_part',
+  'stock_movement_type',
+  'stock_movement_quantity',
+  'stock_movement_unit_cost',
+  'stock_movement_extended_cost',
+  'stock_movement_gl_account',
+  'stock_movement_qty_per_unit',
+  'stock_movement_cost_basis',
+]
+
+function value(entityId: string, attr: string, over: Partial<ValueRow>): ValueRow {
+  return {
+    entityId,
+    fieldId: `fld_${attr}`,
+    valueText: null,
+    valueNumber: null,
+    valueDate: null,
+    optionId: null,
+    relatedEntityId: null,
+    ...over,
+  }
+}
+
+/** A completed build that batch run 7 raised, covering January. */
+function batchBuildRows(): ValueRow[] {
+  return [
+    value(BUILD, 'build_status', { optionId: 'completed' }),
+    value(BUILD, 'build_part', { relatedEntityId: PART_LIFT }),
+    value(BUILD, 'build_quantity_planned', { valueNumber: 10 }),
+    value(BUILD, 'build_quantity_produced', { valueNumber: 10 }),
+    value(BUILD, 'build_material_cost', { valueNumber: 87864 }),
+    value(BUILD, 'build_produced_value', { valueNumber: 80220 }),
+    value(BUILD, 'build_completed_at', { valueDate: '2026-01-31T23:59:59.999Z' }),
+    value(BUILD, 'build_source', { optionId: 'batch' }),
+    value(BUILD, 'build_period_start', { valueDate: '2026-01-01T00:00:00.000Z' }),
+    value(BUILD, 'build_period_end', { valueDate: '2026-02-01T00:00:00.000Z' }),
+    value(BUILD, 'build_batch_run', { valueNumber: BATCH_RUN }),
+  ]
+}
+
+/** The two movements the completion wrote, with their frozen costs. */
+function movementRows(): ValueRow[] {
+  return [
+    value('mv_1', 'stock_movement_part', { relatedEntityId: PART_ASM }),
+    value('mv_1', 'stock_movement_type', { optionId: 'build_consume' }),
+    value('mv_1', 'stock_movement_quantity', { valueNumber: -20 }),
+    value('mv_1', 'stock_movement_unit_cost', { valueNumber: 3661 }),
+    value('mv_1', 'stock_movement_extended_cost', { valueNumber: -73220 }),
+    value('mv_1', 'stock_movement_cost_basis', { optionId: 'standard' }),
+    value('mv_2', 'stock_movement_part', { relatedEntityId: PART_LIFT }),
+    value('mv_2', 'stock_movement_type', { optionId: 'build_produce' }),
+    value('mv_2', 'stock_movement_quantity', { valueNumber: 10 }),
+    value('mv_2', 'stock_movement_unit_cost', { valueNumber: 8022 }),
+    value('mv_2', 'stock_movement_extended_cost', { valueNumber: 80220 }),
+    value('mv_2', 'stock_movement_cost_basis', { optionId: 'standard' }),
+  ]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.materialised = new Set([...BUILD_ATTRS, ...MOVEMENT_ATTRS])
+  h.defs = new Map([
+    ['build', 'def_build'],
+    ['part', 'def_part'],
+    ['stock_movement', 'def_mv'],
+  ])
+  // The build row FIRST: the double ignores `WHERE`, and every detail read takes
+  // `[instance]`, so position is what identifies it.
+  h.instanceRows = [
+    { id: BUILD, createdAt: CREATED_AT, displayName: null },
+    { id: PART_LIFT, createdAt: CREATED_AT, displayName: 'Auxx Lift 400lbs 4x8' },
+  ]
+  h.movementInstances = [{ id: 'mv_1' }, { id: 'mv_2' }]
+  h.reversalRows = []
+  h.valueRows = [...batchBuildRows(), ...movementRows()]
+  h.created = []
+  h.nextId = 0
+})
+
+/** The one `build` the CRUD double was asked to create: the reversal. */
+async function reverseAndReadTheNewBuild(): Promise<Record<string, unknown>> {
+  const result = await reverseBuild(db, ORG, USER, { buildId: BUILD })
+  expect(result.isOk()).toBe(true)
+  const builds = h.created.filter((row) => row.defId === 'def_build')
+  expect(builds).toHaveLength(1)
+  return builds[0]!.values
+}
+
+describe('reverseBuild and build_batch_run', () => {
+  it('does NOT copy the run number onto the reversal', async () => {
+    const reversal = await reverseAndReadTheNewBuild()
+
+    // The whole point. A reversal carrying run 7 would put run 7's own undo
+    // inside run 7.
+    expect(reversal).not.toHaveProperty('build_batch_run')
+    expect(Object.keys(reversal).filter((key) => key.includes('batch'))).toEqual([])
+  })
+
+  it('DOES copy the source, which is what makes the omission deliberate', async () => {
+    // `reverse-build.ts:309`. This assertion is here so the test above cannot
+    // pass vacuously: if the fixture's batch fields never reached
+    // `reversalBuildValues` at all, this would fail too.
+    const reversal = await reverseAndReadTheNewBuild()
+    expect(reversal.build_source).toBe('batch')
+    expect(reversal.build_reversal_of).toBe('def_build:bld_1')
+  })
+
+  it('does not copy the demand period either', async () => {
+    // 45 section 10.7: the missing period copy looks like an oversight and
+    // somebody will "fix" it. It is what keeps the netting read from seeing a
+    // reversal as coverage for the month it undoes.
+    const reversal = await reverseAndReadTheNewBuild()
+    expect(reversal).not.toHaveProperty('build_period_start')
+    expect(reversal).not.toHaveProperty('build_period_end')
+  })
+
+  it('leaves the reversal invisible to a second undo of the same run', async () => {
+    // The property stated the way the feature depends on it: the reversal
+    // carries no run number, so `readBatchRunBuilds(7)` cannot select it and a
+    // second `undoBatchRun(7)` has nothing new to reverse.
+    const reversal = await reverseAndReadTheNewBuild()
+    expect(reversal.build_batch_run).toBeUndefined()
+    expect(reversal.build_status).toBe('completed')
+  })
+})

--- a/packages/lib/src/builds/__tests__/undo-batch-run.test.ts
+++ b/packages/lib/src/builds/__tests__/undo-batch-run.test.ts
@@ -1,0 +1,319 @@
+// packages/lib/src/builds/__tests__/undo-batch-run.test.ts
+//
+// `undoBatchRun`, the rules table of
+// `plans/money/tasks/45-batch-only-builds.md` section 4.1, and the bucket
+// section 10.8 added to it.
+//
+// The two writers are doubles, which is the point: what is under test is the
+// CLASSIFICATION, not what cancelling or reversing does. Three properties, in
+// the order they will bite:
+//
+// 1. 🛑 **`skipped` is not `failed`.** A build that is already cancelled or
+//    already reversed needs nothing from an undo. `reverseBuild` refuses it with
+//    a `ConflictError` and a per-build isolation loop copied from
+//    `executeBackfill` would file that as a failure, and an undo reporting "3
+//    failed" for three builds that are correctly undone is a summary people
+//    learn to ignore.
+// 2. 🛑 **Never a delete.** The movement subledger is append-only, so the only
+//    two verbs are cancel and reverse.
+// 3. ⚠️ **One refused build must not lose the rest of the run.**
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  UnprocessableEntityError,
+} from '../../errors'
+import type { BatchRunBuild } from '../batch-run-queries'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const RUN = 7
+
+const h = vi.hoisted(() => ({
+  /** What the run read returns, or the error it fails with. */
+  builds: [] as unknown[],
+  readError: null as Error | null,
+  cancelCalls: [] as { buildId: string; reason?: string }[],
+  reverseCalls: [] as { buildId: string; reason?: string }[],
+  /** buildId -> the error that writer answers with. Absent means it succeeds. */
+  cancelErrors: new Map<string, Error>(),
+  reverseErrors: new Map<string, Error>(),
+  /** buildId -> an error THROWN rather than returned, which must not escape. */
+  cancelThrows: new Map<string, Error>(),
+}))
+
+vi.mock('../batch-run-queries', () => ({
+  readBatchRunBuilds: vi.fn(async () => {
+    const { err, ok } = await import('neverthrow')
+    return h.readError ? err(h.readError) : ok(h.builds)
+  }),
+}))
+
+vi.mock('../build-mutations', () => ({
+  cancelBuild: vi.fn(
+    async (
+      _db: unknown,
+      _org: string,
+      _user: string,
+      input: { buildId: string; reason?: string }
+    ) => {
+      const { err, ok } = await import('neverthrow')
+      h.cancelCalls.push(input)
+      const thrown = h.cancelThrows.get(input.buildId)
+      if (thrown) throw thrown
+      const failure = h.cancelErrors.get(input.buildId)
+      return failure ? err(failure) : ok({ buildId: input.buildId })
+    }
+  ),
+}))
+
+vi.mock('../reverse-build', () => ({
+  reverseBuild: vi.fn(
+    async (
+      _db: unknown,
+      _org: string,
+      _user: string,
+      input: { buildId: string; reason?: string }
+    ) => {
+      const { err, ok } = await import('neverthrow')
+      h.reverseCalls.push(input)
+      const failure = h.reverseErrors.get(input.buildId)
+      return failure
+        ? err(failure)
+        : ok({
+            buildId: `rev_${input.buildId}`,
+            recordId: `def_build:rev_${input.buildId}`,
+            reversalOfBuildId: input.buildId,
+            movementIds: [],
+            recalculatedPartIds: [],
+          })
+    }
+  ),
+}))
+
+import { undoBatchRun } from '../undo-batch-run'
+
+const db = {} as never
+
+/** One build of the run. `planned`, on the lift, unless told otherwise. */
+function build(overrides: Partial<BatchRunBuild> = {}): BatchRunBuild {
+  return {
+    buildId: 'bld_1',
+    runNumber: RUN,
+    status: 'planned',
+    partId: 'part_lift',
+    alreadyReversed: false,
+    isReversal: false,
+    periodStart: new Date('2026-01-01T00:00:00.000Z'),
+    periodEnd: new Date('2026-02-01T00:00:00.000Z'),
+    createdAt: new Date('2026-02-01T10:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function given(builds: BatchRunBuild[]): void {
+  h.builds = builds
+}
+
+async function undo() {
+  const result = await undoBatchRun(db, ORG, USER, RUN)
+  if (result.isErr()) throw result.error
+  return result.value
+}
+
+/** Every build id in one bucket, so an assertion reads as a set of ids. */
+function ids(entries: { buildId: string }[]): string[] {
+  return entries.map((entry) => entry.buildId)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.builds = []
+  h.readError = null
+  h.cancelCalls = []
+  h.reverseCalls = []
+  h.cancelErrors = new Map()
+  h.reverseErrors = new Map()
+  h.cancelThrows = new Map()
+})
+
+describe('undoBatchRun', () => {
+  it('cancels the open builds, reverses the completed ones and skips the rest', async () => {
+    given([
+      build({ buildId: 'bld_planned', status: 'planned' }),
+      build({ buildId: 'bld_open', status: 'in_progress' }),
+      build({ buildId: 'bld_done', status: 'completed' }),
+      build({ buildId: 'bld_gone', status: 'canceled' }),
+    ])
+
+    const summary = await undo()
+
+    expect(summary.runNumber).toBe(RUN)
+    expect(summary.total).toBe(4)
+    expect(ids(summary.cancelled)).toEqual(['bld_planned', 'bld_open'])
+    expect(ids(summary.reversed)).toEqual(['bld_done'])
+    expect(ids(summary.skipped)).toEqual(['bld_gone'])
+    expect(summary.failed).toEqual([])
+    // 🛑 Cancel and reverse are the only two verbs. There is no delete here and
+    // there must never be one: the ledger is append-only.
+    expect(ids(h.cancelCalls)).toEqual(['bld_planned', 'bld_open'])
+    expect(ids(h.reverseCalls)).toEqual(['bld_done'])
+  })
+
+  it('names the run in the reason it writes on both verbs', async () => {
+    given([
+      build({ buildId: 'bld_planned', status: 'planned' }),
+      build({ buildId: 'bld_done', status: 'completed' }),
+    ])
+
+    await undo()
+
+    expect(h.cancelCalls[0]?.reason).toContain('batch run 7')
+    expect(h.reverseCalls[0]?.reason).toContain('batch run 7')
+  })
+
+  it('carries the reversing build id back on every reversed entry', async () => {
+    given([build({ buildId: 'bld_done', status: 'completed' })])
+
+    const summary = await undo()
+
+    expect(summary.reversed[0]).toMatchObject({
+      buildId: 'bld_done',
+      partId: 'part_lift',
+      outcome: 'reversed',
+      reason: null,
+      reversalBuildId: 'rev_bld_done',
+    })
+  })
+
+  it('🛑 an ALREADY REVERSED build is skipped, not failed, and is never sent to reverseBuild', async () => {
+    given([
+      build({ buildId: 'bld_a', status: 'completed', alreadyReversed: true }),
+      build({ buildId: 'bld_b', status: 'completed', alreadyReversed: true }),
+      build({ buildId: 'bld_c', status: 'completed', alreadyReversed: true }),
+    ])
+
+    const summary = await undo()
+
+    // The defect this rule exists to prevent: "3 failed" for three builds that
+    // are correctly already undone.
+    expect(summary.failed).toEqual([])
+    expect(ids(summary.skipped)).toEqual(['bld_a', 'bld_b', 'bld_c'])
+    // Classified, not caught (45 section 10.8): the writer is never reached.
+    expect(h.reverseCalls).toEqual([])
+  })
+
+  it('skips a build that is itself a reversal, rather than chaining undos', async () => {
+    given([build({ buildId: 'bld_rev', status: 'completed', isReversal: true })])
+
+    const summary = await undo()
+
+    expect(ids(summary.skipped)).toEqual(['bld_rev'])
+    expect(h.reverseCalls).toEqual([])
+  })
+
+  it('classifies the two reverseBuild refusals as skipped even when they come back late', async () => {
+    // The backstop: the pre-check and the write are not one transaction, so a
+    // reversal written in between still has to read as a skip.
+    given([
+      build({ buildId: 'bld_conflict', status: 'completed' }),
+      build({ buildId: 'bld_bad', status: 'completed' }),
+    ])
+    h.reverseErrors.set('bld_conflict', new ConflictError('This build has already been reversed.'))
+    h.reverseErrors.set('bld_bad', new BadRequestError('This build is itself a reversal.'))
+
+    const summary = await undo()
+
+    expect(ids(summary.skipped)).toEqual(['bld_conflict', 'bld_bad'])
+    expect(summary.failed).toEqual([])
+    expect(summary.skipped[0]?.reason).toContain('already been reversed')
+  })
+
+  it('a refusal that is NOT one of those two is a real failure', async () => {
+    given([build({ buildId: 'bld_done', status: 'completed' })])
+    h.reverseErrors.set(
+      'bld_done',
+      new UnprocessableEntityError('This build wrote no stock movements')
+    )
+
+    const summary = await undo()
+
+    expect(summary.skipped).toEqual([])
+    expect(ids(summary.failed)).toEqual(['bld_done'])
+    expect(summary.failed[0]?.reason).toContain('no stock movements')
+  })
+
+  it('⚠️ one failing build does not lose the rest of the run', async () => {
+    given([
+      build({ buildId: 'bld_1', status: 'planned' }),
+      build({ buildId: 'bld_2', status: 'planned' }),
+      build({ buildId: 'bld_3', status: 'completed' }),
+    ])
+    h.cancelErrors.set(
+      'bld_2',
+      new ConflictError('A completed build is reversed, never cancelled.')
+    )
+
+    const summary = await undo()
+
+    expect(ids(summary.cancelled)).toEqual(['bld_1'])
+    expect(ids(summary.failed)).toEqual(['bld_2'])
+    expect(ids(summary.reversed)).toEqual(['bld_3'])
+    expect(summary.total).toBe(3)
+  })
+
+  it('a THROWN error is caught per build, and the run continues', async () => {
+    given([
+      build({ buildId: 'bld_1', status: 'planned' }),
+      build({ buildId: 'bld_2', status: 'planned' }),
+    ])
+    h.cancelThrows.set('bld_1', new NotFoundError('Build bld_1 not found'))
+
+    const summary = await undo()
+
+    expect(ids(summary.failed)).toEqual(['bld_1'])
+    expect(ids(summary.cancelled)).toEqual(['bld_2'])
+  })
+
+  it('⚠️ a run number no build carries is an EMPTY summary, never a NotFoundError', async () => {
+    given([])
+
+    const summary = await undo()
+
+    expect(summary).toEqual({
+      runNumber: RUN,
+      total: 0,
+      cancelled: [],
+      reversed: [],
+      skipped: [],
+      failed: [],
+    })
+    expect(h.cancelCalls).toEqual([])
+    expect(h.reverseCalls).toEqual([])
+  })
+
+  it('fails a build whose status is missing, rather than guessing a verb', async () => {
+    given([build({ buildId: 'bld_odd', status: null })])
+
+    const summary = await undo()
+
+    expect(ids(summary.failed)).toEqual(['bld_odd'])
+    expect(h.cancelCalls).toEqual([])
+    expect(h.reverseCalls).toEqual([])
+  })
+
+  it('refuses as a Result when the run cannot be READ, having written nothing', async () => {
+    // The one refusal: undoing "the builds we managed to see" would leave the
+    // rest of the run standing while reporting a complete undo.
+    h.readError = new UnprocessableEntityError('Builds are not available')
+
+    const result = await undoBatchRun(db, ORG, USER, RUN)
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UnprocessableEntityError)
+    expect(h.cancelCalls).toEqual([])
+    expect(h.reverseCalls).toEqual([])
+  })
+})

--- a/packages/lib/src/builds/backfill-builds.ts
+++ b/packages/lib/src/builds/backfill-builds.ts
@@ -30,6 +30,15 @@
  * {@link resolveBackfillCompletedAt}, which derives it in the organization's
  * `accounting.bookTimeZone` for the same reason `postings/periods.ts` does.
  *
+ * ## 🛑 The run number is allocated ONCE, in {@link prepareRun}
+ *
+ * `plans/money/tasks/45-batch-only-builds.md` section 3. Every build a run
+ * raises carries the same `build_batch_run`, which is the only handle
+ * `undoBatchRun` has, so the allocation belongs where everything else for the
+ * run is resolved and nowhere near the bucket loop. Allocating per build would
+ * burn the sequence and turn one four-hundred-build run into four hundred runs.
+ * An empty plan returns before `prepareRun` and therefore burns no number.
+ *
  * ## 🛑 Never throws
  *
  * Three layers, matching `reconcile-order-builds.ts`: every BUCKET inside its
@@ -67,6 +76,7 @@ import { getOrgCache } from '../cache'
 import { UnprocessableEntityError } from '../errors'
 import { periodKeyForDate } from '../postings/periods'
 import { OPENING_BASELINE_SETTING_KEYS } from '../postings/setup-readiness'
+import { recordNumbering } from '../records/record-numbering'
 import { getOrganizationSetting } from '../settings/settings-service'
 import type {
   BackfillBucket,
@@ -91,6 +101,7 @@ const PROGRESS_EVERY = 25
  * thing the helpers below are handed.
  */
 interface MutableRunSummary {
+  batchRun: number | null
   created: { partId: string; buildId: string; quantity: number; periodKey: string }[]
   leftInProgress: { partId: string; buildId: string; reason: string }[]
   failed: { partId: string; bucketId: string; periodKey: string; reason: string }[]
@@ -102,6 +113,17 @@ interface RunContext {
   timeZone: string
   /** Captured once, so every bucket judges "in the future" against the same instant. */
   now: Date
+  /**
+   * This run's number, stamped onto every build it raises
+   * (plans/money/tasks/45 §3).
+   *
+   * 🛑 **Allocated ONCE, here, and passed down.** `recordNumbering.create`
+   * increments a counter, so allocating it inside the bucket loop would burn the
+   * sequence and give every build its own run: a four-hundred-build backfill
+   * would produce four hundred runs, and undo, whose whole input is one run
+   * number, would have nothing to hang on.
+   */
+  batchRun: number
 }
 
 /**
@@ -133,10 +155,21 @@ export async function executeBackfill(
 ): Promise<Result<BackfillRunSummary, Error>> {
   return guard(
     async () => {
-      const summary: MutableRunSummary = { created: [], leftInProgress: [], failed: [] }
+      const summary: MutableRunSummary = {
+        batchRun: null,
+        created: [],
+        leftInProgress: [],
+        failed: [],
+      }
+      // 🛑 BEFORE `prepareRun`, deliberately: an empty plan writes no build, so
+      // it must burn no run number (plans/money/tasks/45 §3.2). A counter that
+      // skips a number every time somebody previews an empty range is the
+      // "run 14 in an org with zero builds" mismatch §10.6 is already about.
+      // Asserted by a test.
       if (plan.parts.length === 0) return summary
 
       const run = await prepareRun(organizationId)
+      summary.batchRun = run.batchRun
       let written = 0
 
       for (const part of plan.parts) {
@@ -179,6 +212,7 @@ export async function executeBackfill(
 
       logger.info('Backfilled builds', {
         organizationId,
+        batchRun: run.batchRun,
         status: request.status,
         grouping: request.grouping,
         planned: plan.buildCount,
@@ -240,22 +274,44 @@ export function resolveBackfillCompletedAt(bucket: BackfillBucket, timeZone: str
  * org would get the whole range built and then get it all built again on the
  * second pass. Refusing here writes nothing; discovering it on build one has
  * already written one.
+ *
+ * ⚠️ **`build_batch_run` is NOT required, and deliberately so.** The asymmetry
+ * with the two fields above is the point: coverage depends on the period, so a
+ * run without it computes the wrong thing; nothing about the netting depends on
+ * the run number, so an org short of entity migration 141 gets un-numbered
+ * builds and a correct backfill. What it loses is undo, which is worth a warning
+ * and not a refusal (plans/money/tasks/45 §3).
  */
 async function prepareRun(organizationId: string): Promise<RunContext> {
-  const [periodFields, timeZone] = await Promise.all([
+  const [fields, timeZone] = await Promise.all([
     getOrgCache()
       .from(organizationId, 'customFields')
-      .bySystemAttributes(['build_period_start', 'build_period_end'] as const),
+      .bySystemAttributes(['build_period_start', 'build_period_end', 'build_batch_run'] as const),
     readBookTimeZone(organizationId),
   ])
 
-  if (!periodFields.build_period_start || !periodFields.build_period_end) {
+  if (!fields.build_period_start || !fields.build_period_end) {
     throw new UnprocessableEntityError(
       'Backfilling builds is not available until the build demand-period fields are provisioned'
     )
   }
 
-  return { timeZone, now: new Date() }
+  if (!fields.build_batch_run) {
+    logger.warn('This organization has no build_batch_run field, so the run will be un-numbered', {
+      organizationId,
+    })
+  }
+
+  // 🛑 ONCE per run, here, which is the single place everything for a run is
+  // resolved (plans/money/tasks/45 §3.2). `recordNumbering.create` is an atomic
+  // `UPDATE ... RETURNING`, so two concurrent runs can never share a number; the
+  // failure this placement prevents is the other one, allocating inside the
+  // bucket loop, which would burn the sequence and give every build its own run.
+  // `sequenceNumber` is the raw integer `build_batch_run` stores. The formatted
+  // `recordNumber` is cosmetic and nothing renders it.
+  const { sequenceNumber } = await recordNumbering.create(organizationId, 'build_batch')
+
+  return { timeZone, now: new Date(), batchRun: sequenceNumber }
 }
 
 /** Raise one bucket's build, and complete it when the run was asked to. */
@@ -281,16 +337,22 @@ async function executeBucket(
     }
   }
 
-  // 🛑 The period goes in HERE or never: `build_period_start` and
-  // `build_period_end` are `updatable: false`, because moving a claimed period
-  // silently restates what the next netting run believes is already covered
-  // (section 6.2). `createBuild` writes them from `period` at create time, and
-  // ignores them unless the source is `batch`.
+  // 🛑 The period and the run number go in HERE or never: `createBuild` is the
+  // only writer of `build_period_start`, `build_period_end` and
+  // `build_batch_run`, because moving a claimed period silently restates what
+  // the next netting run believes is already covered (section 6.2) and moving a
+  // run number silently rewrites what an undo would touch
+  // (plans/money/tasks/45 §3). All three are written at create time and ignored
+  // unless the source is `batch`.
+  //
+  // `run.batchRun` and never a fresh allocation: every bucket in this run passes
+  // the SAME number, which is what makes "the builds run 2 made" a plain filter.
   const created = await createBuild(db, organizationId, userId, {
     partId: bucket.partId,
     quantityPlanned: bucket.quantityToBuild,
     source: 'batch',
     period: { start: bucket.periodStart, end: bucket.periodEnd },
+    batchRun: run.batchRun,
   })
   // A refused raise wrote nothing at all, so it is a `failed` bucket rather than
   // a build somebody has to go and finish. Thrown, not returned, so the bucket

--- a/packages/lib/src/builds/backfill-preflight.ts
+++ b/packages/lib/src/builds/backfill-preflight.ts
@@ -1,0 +1,121 @@
+// packages/lib/src/builds/backfill-preflight.ts
+
+/**
+ * What a `completed` backfill would write, computed before anything is written.
+ *
+ * `plans/money/tasks/44-auto-build-cutoff-and-backfill.md` §7.3 gates 2, 3 and 4.
+ *
+ * The consent a completed run asks for is *"N builds, M stock movements, on an
+ * append-only ledger correctable only by reversing"*, and both numbers have to
+ * be real or the sentence is theatre. `completeBuild` also aborts per build when
+ * a component has no `part_standard_cost`, and discovering that on build 400 of
+ * 900 is the wrong time to discover it.
+ *
+ * ## Why this lives in lib, and did not
+ *
+ * ⚠️ It was composed in `routers/builds.ts` for the whole of 44's build, from
+ * `explodeBuildComponents` and `readPartQuantitiesOnHand`, because gates 3 and 4
+ * need component-level data the `BackfillPlan` contract does not carry. 44 §11.3
+ * recorded that as misplaced rather than wrong, and 45 §5 carried it forward:
+ * per `docs/lib-module-guide.md` §6 a router asserts and calls, and arithmetic
+ * this load-bearing belongs where it can be unit tested without a tRPC caller.
+ *
+ * ## 🛑 Gate 4 is a WARNING's input, never a gate's
+ *
+ * Negative projected on hand is a true statement about a ledger missing its
+ * receipts, and refusing on it would make the backfill unusable on exactly the
+ * organization that needs it most: one importing history it never had stock
+ * records for. The remedy is opening stock, and that is the person's call to
+ * make first. This function therefore REPORTS and never refuses.
+ *
+ * No permission checks. The router asserts (`docs/lib-module-guide.md` §6).
+ */
+
+import type { Database } from '@auxx/database'
+import type { Result } from 'neverthrow'
+import { readPartQuantitiesOnHand } from './auto-build-queries'
+import type { BackfillPlan, BackfillPreflight } from './backfill-types'
+import { explodeBuildComponents, readPartNames } from './build-queries'
+import { guard } from './guard'
+
+/**
+ * Explode every part in the plan and total what the run would consume.
+ *
+ * ⚠️ **Exploded once per part at its WHOLE range quantity, not once per bucket.**
+ * Component quantities are linear in the produced quantity, so the total is
+ * identical either way and a twenty-part plan costs twenty round trips instead
+ * of ninety-four.
+ *
+ * @param plan what the run would raise, from `planBackfill`.
+ * @returns the counts and the two lists, or `err` when a part cannot be
+ *   exploded. Unlike `executeBackfill` this one DOES fail as a whole: it writes
+ *   nothing, and a preflight that silently omitted a part would under-report the
+ *   consent it exists to obtain.
+ */
+export async function computeBackfillPreflight(
+  db: Database,
+  organizationId: string,
+  plan: BackfillPlan
+): Promise<Result<BackfillPreflight, Error>> {
+  return guard(
+    async () => {
+      let movementCount = 0
+      const unpriced = new Set<string>()
+      const consumed = new Map<string, number>()
+
+      const explosions = await Promise.all(
+        plan.parts.map((part) =>
+          explodeBuildComponents(db, organizationId, {
+            partId: part.partId,
+            quantityProduced: part.quantityToBuild,
+          })
+        )
+      )
+
+      for (const [index, explosion] of explosions.entries()) {
+        const part = plan.parts[index]
+        if (!part) continue
+        if (explosion.isErr()) throw explosion.error
+        const components = explosion.value.components
+        // One `build_produce` per build, plus one `build_consume` per component
+        // per build. The component set is the same for every bucket of a part.
+        movementCount += part.buckets.length * (components.length + 1)
+        for (const missing of explosion.value.missingStandardPartIds) unpriced.add(missing)
+        for (const line of components) {
+          consumed.set(line.partId, (consumed.get(line.partId) ?? 0) + line.quantityConsumed)
+        }
+      }
+
+      const componentIds = [...consumed.keys()]
+      const [onHand, names] = await Promise.all([
+        readPartQuantitiesOnHand(db, organizationId, componentIds),
+        readPartNames(db, organizationId, [...componentIds, ...unpriced]),
+      ])
+
+      return {
+        buildCount: plan.buildCount,
+        movementCount,
+        unpricedParts: [...unpriced].map((partId) => ({
+          partId,
+          partName: names.get(partId) ?? null,
+        })),
+        projectedOnHand: componentIds
+          .map((partId) => {
+            const available = onHand.get(partId) ?? 0
+            const used = consumed.get(partId) ?? 0
+            return {
+              partId,
+              partName: names.get(partId) ?? null,
+              onHand: available,
+              consumed: used,
+              projected: available - used,
+            }
+          })
+          // Worst first: the rows that matter are the ones the run drives negative.
+          .sort((a, b) => a.projected - b.projected),
+      }
+    },
+    'Failed to compute the backfill preflight',
+    { organizationId, parts: plan.parts.length }
+  )
+}

--- a/packages/lib/src/builds/backfill-types.ts
+++ b/packages/lib/src/builds/backfill-types.ts
@@ -253,6 +253,21 @@ export interface BackfillRequest {
 /** What one backfill run did. Never throws; a failure is a row in here. */
 export interface BackfillRunSummary {
   /**
+   * The run number every build this run raised carries
+   * (plans/money/tasks/45 §3), or `null` when the run allocated none.
+   *
+   * 🛑 **It must come back.** A run is not a record (45 §3.1), so this integer
+   * is the ONLY handle undo hangs on: `undoBatchRun(N)` takes it as input, and a
+   * caller that cannot tell the person which run they just created has left them
+   * with no way to name it again.
+   *
+   * `null` means nothing was allocated, which today is one case only: an empty
+   * plan, which must burn no number. A run whose every bucket failed still
+   * carries its number, and `undoBatchRun` answers with an empty summary rather
+   * than a `NotFoundError` (45 §10.8).
+   */
+  batchRun: number | null
+  /**
    * Builds created, in creation order.
    *
    * 🛑 **`created` and {@link leftInProgress} OVERLAP.** A build whose
@@ -272,4 +287,40 @@ export interface BackfillRunSummary {
   leftInProgress: readonly { partId: string; buildId: string; reason: string }[]
   /** Buckets that produced nothing at all, with the reason. Keyed by `bucketId`. */
   failed: readonly { partId: string; bucketId: string; periodKey: string; reason: string }[]
+}
+
+/**
+ * What a `completed` backfill would write, checked before anything is written.
+ *
+ * §7.3 gates 2, 3 and 4: the consent for a completed run is *"N builds, M stock
+ * movements, on an append-only ledger correctable only by reversing"*, and both
+ * numbers have to be real. `completeBuild` also aborts per build when a
+ * component has no `part_standard_cost`, and discovering that on build 400 of
+ * 900 is the wrong time.
+ *
+ * Computed by `backfill-preflight.ts`. It lived in `routers/builds.ts` until
+ * 45's build moved it (44 §11.3, 45 §12.7).
+ */
+export interface BackfillPreflight {
+  /** Builds the run would raise. */
+  buildCount: number
+  /** `build_consume` + `build_produce` rows those builds would append. */
+  movementCount: number
+  /** Parts with no standard cost, which `completeBuild` refuses outright. */
+  unpricedParts: { partId: string; partName: string | null }[]
+  /**
+   * Where the run leaves each consumed component.
+   *
+   * 🛑 A WARNING's input, never a gate's (§7.3 gate 4). Negative on hand is a
+   * true statement about a ledger missing its receipts, and refusing would make
+   * the backfill unusable on exactly the org that needs it most. The remedy is
+   * opening stock, which is the person's call to make first.
+   */
+  projectedOnHand: {
+    partId: string
+    partName: string | null
+    onHand: number
+    consumed: number
+    projected: number
+  }[]
 }

--- a/packages/lib/src/builds/batch-run-queries.ts
+++ b/packages/lib/src/builds/batch-run-queries.ts
@@ -1,0 +1,420 @@
+// packages/lib/src/builds/batch-run-queries.ts
+
+/**
+ * What a batch RUN looks like from outside.
+ *
+ * `plans/money/tasks/45-batch-only-builds.md` sections 4, 10.4 and 11.3.
+ *
+ * ⚠️ **A run is not a record** (45 section 3.1). It is a scalar,
+ * `build_batch_run`, stamped on every build one run raised, and everything a
+ * `batch_run` entity would have stored is recoverable from those builds: the
+ * range off `build_period_start` / `build_period_end`, the statuses off
+ * `build_status`, the timing off `EntityInstance.createdAt`. This file is the
+ * recovery, and section 10.4 is the note that nobody had costed it: the Undo
+ * action takes a run number as INPUT, so without these reads there is no
+ * surface that can name one.
+ *
+ * Two reads:
+ *
+ * - {@link readBatchRun}, the counts for ONE run. The drawer card and the undo
+ *   preview render it, and 45 section 11.3 is explicit that this is the read
+ *   the feature cannot ship without.
+ * - {@link listBatchRuns}, every run this org has, newest first.
+ *
+ * plus {@link readBatchRunBuilds}, the per-build rows both of those fold, which
+ * `undo-batch-run.ts` also loads because it acts on exactly the same set.
+ *
+ * ## 🛑 `willReverse` counts what is NOT already reversed
+ *
+ * `willCancel` and `willReverse` are two different numbers and the second is
+ * the one that WRITES TO THE LEDGER (45 section 11.4), so the confirmation has
+ * to lead with both. A `completed` build that some live build already points its
+ * `build_reversal_of` at needs nothing from an undo: `reverseBuild` would refuse
+ * it, and counting it would promise a ledger write that never happens. So the
+ * incoming reversal edge is LEFT JOINed and asserted absent, the same shape
+ * `hasBuildReversal` uses for one build and the same shape
+ * `backfill-queries.ts` uses to keep reversals out of coverage.
+ *
+ * ## Why the fold is in TypeScript
+ *
+ * One query per call, and the counting happens over the rows. A run is bounded
+ * by the buckets one backfill produced (45 section 10.2: a whole-range monthly
+ * run is on the order of a thousand), and the rows are narrow. Conditional
+ * aggregates in SQL would buy nothing here and would put the `willReverse` rule
+ * somewhere no unit test can read it.
+ *
+ * Reads only, and no permission checks: the router asserts
+ * (`docs/lib-module-guide.md` section 6). The write is `undo-batch-run.ts`.
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, isNotNull, isNull, type SQL } from 'drizzle-orm'
+import { type AnyPgColumn, alias } from 'drizzle-orm/pg-core'
+import type { Result } from 'neverthrow'
+import { loadBuildFieldContext } from './build-queries'
+import { type BuildStatusValue, resolveBuildStatus } from './client'
+import { guard } from './guard'
+import type { BatchRunSummary } from './types'
+
+/**
+ * One build inside a run, at the fields an undo or a count needs.
+ *
+ * Deliberately narrower than a `BuildRecord`: nothing here reads a cost or a
+ * quantity, and hydrating the full row for a thousand builds would be a page of
+ * `FieldValue` per build for six columns nobody looks at.
+ */
+export interface BatchRunBuild {
+  buildId: string
+  /** The run that raised it. Never `null` here: it is what selected the row. */
+  runNumber: number
+  /** `null` on a row whose status value is missing, which is never defaulted. */
+  status: BuildStatusValue | null
+  partId: string | null
+  /**
+   * A LIVE build already points its `build_reversal_of` at this one, so it has
+   * been undone and `reverseBuild` would refuse it (`reverse-build.ts` step 2).
+   * An ARCHIVED reversal does not count, for the reason `hasBuildReversal`
+   * gives: it contributes to no roll-up, so treating it as a standing reversal
+   * would leave the mistake uncorrectable.
+   */
+  alreadyReversed: boolean
+  /**
+   * This build IS a reversal.
+   *
+   * 🛑 Always `false` in practice, and read anyway. `reversalBuildValues` must
+   * not copy `build_batch_run` onto a reversal (45 section 4.1), which is what
+   * `__tests__/reverse-build-batch-run.test.ts` pins: if it ever did, run N
+   * would contain its own undo and this flag is what stops a second undo
+   * reversing the reversals.
+   */
+  isReversal: boolean
+  periodStart: Date | null
+  periodEnd: Date | null
+  createdAt: Date
+}
+
+/** An aliased `FieldValue` table, as `alias()` returns it. */
+type FieldValueAlias = ReturnType<typeof alias<typeof schema.FieldValue, string>>
+
+/**
+ * The counts for ONE run.
+ *
+ * ⚠️ **A run number that matches no build is an EMPTY summary, never a
+ * `NotFoundError`** (45 section 10.8). A run whose buckets all failed allocated
+ * a number that no build carries, and so does an org that is short of the
+ * migration provisioning `build_batch_run`. Both are honest zeroes, and both
+ * would be a 404 that a person reads as "your data is missing".
+ */
+export async function readBatchRun(
+  db: Database,
+  organizationId: string,
+  runNumber: number
+): Promise<Result<BatchRunSummary, Error>> {
+  return guard(
+    async () => {
+      const builds = await queryBatchRunBuilds(db, organizationId, runNumber)
+      return summarize(runNumber, builds)
+    },
+    'Failed to read a batch run',
+    { organizationId, runNumber }
+  )
+}
+
+/**
+ * Every run this organization has, newest first.
+ *
+ * Newest is the HIGHEST run number rather than the latest `createdAt`: the
+ * number comes from an atomic counter, so it orders the runs by when they were
+ * allocated even when two ran close enough together to share a second.
+ */
+export async function listBatchRuns(
+  db: Database,
+  organizationId: string
+): Promise<Result<BatchRunSummary[], Error>> {
+  return guard(
+    async () => {
+      const builds = await queryBatchRunBuilds(db, organizationId, null)
+
+      const byRun = new Map<number, BatchRunBuild[]>()
+      for (const build of builds) {
+        const bucket = byRun.get(build.runNumber)
+        if (bucket) bucket.push(build)
+        else byRun.set(build.runNumber, [build])
+      }
+
+      return [...byRun.entries()]
+        .sort(([left], [right]) => right - left)
+        .map(([runNumber, runBuilds]) => summarize(runNumber, runBuilds))
+    },
+    'Failed to list batch runs',
+    { organizationId }
+  )
+}
+
+/**
+ * The builds one run raised, as the undo acts on them.
+ *
+ * Ordered oldest first, so an interrupted undo has undone a prefix of the run
+ * rather than an arbitrary subset of it.
+ */
+export async function readBatchRunBuilds(
+  db: Database,
+  organizationId: string,
+  runNumber: number
+): Promise<Result<BatchRunBuild[], Error>> {
+  return guard(
+    async () => queryBatchRunBuilds(db, organizationId, runNumber),
+    'Failed to read the builds of a batch run',
+    { organizationId, runNumber }
+  )
+}
+
+/**
+ * ONE query: every build carrying a run number, or carrying THIS one.
+ *
+ * An org with no `build` definition, or one short of the migration that
+ * provisions `build_batch_run`, reads as no builds rather than as an error. It
+ * has never run a batch, so "no runs" is the true answer and a refusal would
+ * only stop a drawer from rendering.
+ */
+async function queryBatchRunBuilds(
+  db: Database,
+  organizationId: string,
+  runNumber: number | null
+): Promise<BatchRunBuild[]> {
+  const ctx = await loadBuildFieldContext(organizationId)
+  const runField = ctx?.fields.build_batch_run
+  if (!ctx || !runField) return []
+
+  const runValue = alias(schema.FieldValue, 'batch_run_v')
+  const statusValue = alias(schema.FieldValue, 'batch_run_status_v')
+  const partValue = alias(schema.FieldValue, 'batch_run_part_v')
+  const reversalOfValue = alias(schema.FieldValue, 'batch_run_reversal_of_v')
+  const periodStartValue = alias(schema.FieldValue, 'batch_run_period_start_v')
+  const periodEndValue = alias(schema.FieldValue, 'batch_run_period_end_v')
+  // The INCOMING edge: some other build naming this one as what it reverses.
+  const reversedByValue = alias(schema.FieldValue, 'batch_run_reversed_by_v')
+  const reversedByInstance = alias(schema.EntityInstance, 'batch_run_reversed_by_ei')
+
+  const reversalFieldId = fieldId(ctx.fields.build_reversal_of)
+
+  const rows = await db
+    .select({
+      buildId: schema.EntityInstance.id,
+      createdAt: schema.EntityInstance.createdAt,
+      runNumber: runValue.valueNumber,
+      status: statusValue.optionId,
+      partId: partValue.relatedEntityId,
+      reversalOfBuildId: reversalOfValue.relatedEntityId,
+      reversedByBuildId: reversedByInstance.id,
+      periodStart: periodStartValue.valueDate,
+      periodEnd: periodEndValue.valueDate,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      runValue,
+      and(
+        ownValue(runValue, schema.EntityInstance.id, organizationId, runField.id),
+        isNotNull(runValue.valueNumber),
+        // A run number of `null` selects every run; a number selects one. Both
+        // are the same query, so the two reads cannot drift apart.
+        ...(runNumber == null ? [] : [eq(runValue.valueNumber, runNumber)])
+      )
+    )
+    .leftJoin(
+      statusValue,
+      ownValue(
+        statusValue,
+        schema.EntityInstance.id,
+        organizationId,
+        fieldId(ctx.fields.build_status)
+      )
+    )
+    .leftJoin(
+      partValue,
+      ownValue(partValue, schema.EntityInstance.id, organizationId, fieldId(ctx.fields.build_part))
+    )
+    .leftJoin(
+      reversalOfValue,
+      ownValue(reversalOfValue, schema.EntityInstance.id, organizationId, reversalFieldId)
+    )
+    .leftJoin(
+      periodStartValue,
+      ownValue(
+        periodStartValue,
+        schema.EntityInstance.id,
+        organizationId,
+        fieldId(ctx.fields.build_period_start)
+      )
+    )
+    .leftJoin(
+      periodEndValue,
+      ownValue(
+        periodEndValue,
+        schema.EntityInstance.id,
+        organizationId,
+        fieldId(ctx.fields.build_period_end)
+      )
+    )
+    // 🛑 The reversal edge read BACKWARDS, which is what `willReverse` turns on.
+    // A LEFT JOIN plus `IS NULL`, so a build nothing has reversed is kept
+    // alongside one whose reversal is archived; an inner join would keep exactly
+    // the builds an undo has nothing to do with.
+    .leftJoin(
+      reversedByValue,
+      and(
+        eq(reversedByValue.organizationId, organizationId),
+        eq(reversedByValue.fieldId, reversalFieldId),
+        eq(reversedByValue.relatedEntityId, schema.EntityInstance.id)
+      )
+    )
+    .leftJoin(
+      reversedByInstance,
+      and(
+        eq(reversedByInstance.id, reversedByValue.entityId),
+        eq(reversedByInstance.organizationId, organizationId),
+        isNull(reversedByInstance.archivedAt)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, ctx.buildDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+
+  // Keyed by build id, because the backwards join fans out: a build with two
+  // reversals (which nothing should ever write) would otherwise be counted
+  // twice, and `total` is a number a person reconciles against a list.
+  const builds = new Map<string, BatchRunBuild>()
+  for (const row of rows) {
+    if (!row.buildId) continue
+    const run = row.runNumber == null ? Number.NaN : Number(row.runNumber)
+    if (!Number.isFinite(run)) continue
+
+    const existing = builds.get(row.buildId)
+    if (existing) {
+      // Only ever widens: one reversal row is enough to say the build is undone.
+      if (row.reversedByBuildId) existing.alreadyReversed = true
+      continue
+    }
+
+    builds.set(row.buildId, {
+      buildId: row.buildId,
+      runNumber: run,
+      status: resolveBuildStatus(row.status),
+      partId: row.partId ?? null,
+      alreadyReversed: Boolean(row.reversedByBuildId),
+      isReversal: Boolean(row.reversalOfBuildId),
+      periodStart: toDate(row.periodStart),
+      periodEnd: toDate(row.periodEnd),
+      createdAt: row.createdAt,
+    })
+  }
+
+  return [...builds.values()].sort(
+    (left, right) => left.createdAt.getTime() - right.createdAt.getTime()
+  )
+}
+
+/**
+ * Fold one run's builds into the shape the card renders.
+ *
+ * 🛑 `willReverse` is `completed` MINUS the already-reversed, never
+ * `summary.completed`. The two are the same number only on a run nobody has
+ * touched, and the moment they differ the larger one is a promise of ledger
+ * writes that will not happen.
+ */
+function summarize(runNumber: number, builds: BatchRunBuild[]): BatchRunSummary {
+  const summary: BatchRunSummary = {
+    runNumber,
+    total: builds.length,
+    planned: 0,
+    inProgress: 0,
+    completed: 0,
+    canceled: 0,
+    willCancel: 0,
+    willReverse: 0,
+    periodStart: null,
+    periodEnd: null,
+    ranAt: null,
+  }
+
+  for (const build of builds) {
+    if (build.status === 'planned') summary.planned += 1
+    else if (build.status === 'in_progress') summary.inProgress += 1
+    else if (build.status === 'completed') summary.completed += 1
+    else if (build.status === 'canceled') summary.canceled += 1
+
+    if (build.status === 'planned' || build.status === 'in_progress') summary.willCancel += 1
+    if (build.status === 'completed' && !build.alreadyReversed && !build.isReversal) {
+      summary.willReverse += 1
+    }
+
+    summary.periodStart = earlier(summary.periodStart, build.periodStart)
+    summary.periodEnd = later(summary.periodEnd, build.periodEnd)
+    summary.ranAt = earlier(summary.ranAt, build.createdAt)
+  }
+
+  return summary
+}
+
+function earlier(current: Date | null, candidate: Date | null): Date | null {
+  if (!candidate) return current
+  if (!current) return candidate
+  return candidate.getTime() < current.getTime() ? candidate : current
+}
+
+function later(current: Date | null, candidate: Date | null): Date | null {
+  if (!candidate) return current
+  if (!current) return candidate
+  return candidate.getTime() > current.getTime() ? candidate : current
+}
+
+/**
+ * Join predicate for "this instance's value of <field>".
+ *
+ * Takes the alias OBJECT and composes with `eq`, so drizzle emits the table as
+ * an identifier. A hand-written `sql` fragment interpolating a table binds it as
+ * a parameter instead, which is a mistake this codebase has already paid for
+ * (`build-queries.ts`).
+ */
+function ownValue(
+  value: FieldValueAlias,
+  ownerId: AnyPgColumn,
+  organizationId: string,
+  fieldId: string
+): SQL | undefined {
+  return and(
+    eq(value.entityId, ownerId),
+    eq(value.organizationId, organizationId),
+    eq(value.fieldId, fieldId)
+  )
+}
+
+/**
+ * A materialised field's id, or a sentinel that matches no row.
+ *
+ * Every field reached through it is on a LEFT JOIN, so joining on an id that
+ * cannot exist gives exactly the behaviour an unmaterialised field should have:
+ * the column reads `null`. `build_batch_run` itself is required above rather
+ * than defaulted, because its absence would WIDEN the answer to every build in
+ * the org. Same rule, same reason, as `backfill-queries.ts`.
+ */
+function fieldId(field: { id: string } | null | undefined): string {
+  return field?.id ?? '__unmaterialised__'
+}
+
+/**
+ * Read a date column back as a `Date`.
+ *
+ * `FieldValue.valueDate` is declared `mode: 'string'`, and an unparseable value
+ * is `null` rather than an Invalid Date: an Invalid Date compares false against
+ * everything, so it would silently vanish from the period arithmetic much later.
+ */
+function toDate(value: string | Date | null | undefined): Date | null {
+  if (value == null) return null
+  const parsed = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}

--- a/packages/lib/src/builds/build-mutations.ts
+++ b/packages/lib/src/builds/build-mutations.ts
@@ -132,10 +132,15 @@ export async function createBuild(
 
       // The demand period a batch build claims (plans/money/tasks/44 §6.2).
       //
-      // 🛑 Written HERE or never: both fields are `updatable: false`, so a
-      // post-create write would be writing a field the schema refuses. That is
-      // deliberate — moving a claimed period restates what the next netting run
-      // believes is already covered.
+      // 🛑 Written HERE or never, and `createBuild` being the ONLY writer is
+      // what actually holds that. This comment used to say the fields being
+      // `updatable: false` made a post-create write impossible. It does not:
+      // `field-hooks/register-hooks.ts:523` states plainly that the write path
+      // NEVER reads `capabilities.updatable`, so the flag is documentation plus
+      // a UI and connector gate, nothing more (plans/money/tasks/45 §10.5). The
+      // invariant is a convention this file keeps, which is why a second writer
+      // would break it in silence: moving a claimed period restates what the
+      // next netting run believes is already covered.
       //
       // Guarded on `source` for the same reason `build_order_revision` is: an
       // order-raised build answers to one order and a hand-raised one to nobody,
@@ -148,6 +153,25 @@ export async function createBuild(
         if (ctx.fields.build_period_start && ctx.fields.build_period_end) {
           values.build_period_start = input.period.start.toISOString()
           values.build_period_end = input.period.end.toISOString()
+        }
+      }
+
+      // Which batch run raised this build (plans/money/tasks/45 §3). Same shape
+      // and the same three rules as the period above: written here or never,
+      // ignored unless the source is `batch`, and skipped when the field is not
+      // provisioned.
+      //
+      // ⚠️ The number is ALLOCATED ONCE PER RUN by `executeBackfill` and passed
+      // down (45 §3.2). Nothing is allocated here, because allocating per build
+      // would burn the sequence and give every build in the run its own run
+      // number, which is exactly the handle undo hangs on.
+      //
+      // 🛑 The provisioning guard is what keeps an org short of entity
+      // migration 141 from a 500. It gets un-numbered builds instead, which
+      // costs it undo and costs the netting read nothing.
+      if (input.batchRun !== undefined && (input.source ?? 'manual') === 'batch') {
+        if (ctx.fields.build_batch_run) {
+          values.build_batch_run = input.batchRun
         }
       }
 
@@ -198,6 +222,7 @@ export async function createBuild(
         partId: input.partId,
         quantityPlanned: input.quantityPlanned,
         source: values.build_source,
+        batchRun: values.build_batch_run ?? null,
       })
 
       return requireBuild(db, organizationId, created.instance.id)

--- a/packages/lib/src/builds/build-queries.ts
+++ b/packages/lib/src/builds/build-queries.ts
@@ -76,6 +76,10 @@ const BUILD_ATTRIBUTES = [
   // which is why every reader guards on them rather than assuming.
   'build_period_start',
   'build_period_end',
+  // Which batch run raised this build (45 §3). `updatable: false` like the two
+  // above, so `createBuild` is the only writer, and absent on an org short of
+  // entity migration 141.
+  'build_batch_run',
 ] as const
 
 type BuildAttribute = (typeof BUILD_ATTRIBUTES)[number]
@@ -481,6 +485,7 @@ function toBuildRecord(
     source: read('build_source')?.optionId ?? null,
     reversalOfBuildId: read('build_reversal_of')?.relatedEntityId ?? null,
     orderRevision: read('build_order_revision')?.valueText ?? null,
+    batchRun: read('build_batch_run')?.valueNumber ?? null,
     createdAt: row.createdAt,
   }
 }

--- a/packages/lib/src/builds/client.ts
+++ b/packages/lib/src/builds/client.ts
@@ -445,6 +445,7 @@ export {
   type BackfillGrouping,
   type BackfillPartPlan,
   type BackfillPlan,
+  type BackfillPreflight,
   type BackfillRequest,
   type BackfillRunSummary,
   type BackfillStatus,

--- a/packages/lib/src/builds/index.ts
+++ b/packages/lib/src/builds/index.ts
@@ -40,6 +40,9 @@ export { CANCEL_AUTO_BUILDS_ON_ORDER_CANCELLED, registerAutoBuildRules } from '.
 export { type AutoBuildSettings, loadAutoBuildSettings } from './auto-build-settings'
 export { executeBackfill, resolveBackfillCompletedAt } from './backfill-builds'
 export { planBackfill } from './backfill-policy'
+// §7.3's gates 2, 3 and 4. Moved out of `routers/builds.ts` (44 §11.3): a router
+// asserts and calls, it does not compose the arithmetic.
+export { computeBackfillPreflight } from './backfill-preflight'
 export { readBackfillPlanReads } from './backfill-queries'
 export {
   BACKFILL_EXCLUSION_REASONS,
@@ -53,10 +56,21 @@ export {
   type BackfillPartPlan,
   type BackfillPlan,
   type BackfillPlanInput,
+  type BackfillPreflight,
   type BackfillRequest,
   type BackfillRunSummary,
   type BackfillStatus,
 } from './backfill-types'
+// The batch run reads (plans/money/tasks/45 §10.4). `readBatchRun` is what the
+// drawer card and the undo preview render; `readBatchRunBuilds` is the per-build
+// set `undoBatchRun` acts on, exported rather than private because reads and
+// writes live in separate files.
+export {
+  type BatchRunBuild,
+  listBatchRuns,
+  readBatchRun,
+  readBatchRunBuilds,
+} from './batch-run-queries'
 export {
   amendPlannedBuildQuantity,
   cancelBuild,
@@ -161,6 +175,7 @@ export {
 } from './standard-cost-roll'
 export type {
   AbsorptionRates,
+  BatchRunSummary,
   BuildComponentLine,
   BuildComponentOverride,
   BuildComponentPlan,
@@ -182,5 +197,11 @@ export type {
   StandardCostRollPlan,
   StandardCostRollResult,
   StartBuildInput,
+  UndoBatchRunEntry,
+  UndoBatchRunSummary,
 } from './types'
+// Undo a whole batch run (plans/money/tasks/45 §4). Cancels what is `planned`
+// or `in_progress` and REVERSES what is `completed`, never deletes, and never
+// throws: per-build isolation, the same discipline `executeBackfill` keeps.
+export { undoBatchRun } from './undo-batch-run'
 export { BUILD_WRITE_LANE_REASON, buildWriteSession } from './write-lane'

--- a/packages/lib/src/builds/types.ts
+++ b/packages/lib/src/builds/types.ts
@@ -224,6 +224,11 @@ export interface BuildRecord {
    * row written before the field existed — both mean *unknown*, never *drifted*.
    */
   orderRevision: string | null
+  /**
+   * The batch run that raised this build (plans/money/tasks/45 §3), or `null`
+   * on an order-raised, hand-raised or REVERSING build.
+   */
+  batchRun: number | null
   createdAt: Date
 }
 
@@ -282,6 +287,79 @@ export interface CreateBuildInput {
    * claims no period: it answers to one order, or to nobody.
    */
   period?: { start: Date; end: Date }
+  /**
+   * The batch run raising this build (plans/money/tasks/45 §3).
+   *
+   * ⚠️ **Allocated ONCE per run and passed down**, never per build: the number
+   * comes from `recordNumbering.create`, which increments a counter, so
+   * allocating inside the loop would burn the sequence and give every build its
+   * own run.
+   *
+   * 🛑 Written here or never, exactly like {@link CreateBuildInput.period}, and
+   * ignored unless `source` is `batch`.
+   */
+  batchRun?: number
+}
+
+/**
+ * One build's outcome inside {@link UndoBatchRunSummary}.
+ *
+ * `cancelled` and `reversed` are the two ways a build is undone; `skipped` is a
+ * build that was ALREADY undone and needs nothing, which is deliberately not a
+ * failure (45 §10.8).
+ */
+export interface UndoBatchRunEntry {
+  buildId: string
+  partId: string | null
+  outcome: 'cancelled' | 'reversed' | 'skipped' | 'failed'
+  /** Why it was skipped or how it failed. `null` on a build that was undone. */
+  reason: string | null
+  /** The reversing build, on `reversed` only. */
+  reversalBuildId?: string
+}
+
+/**
+ * What {@link undoBatchRun} did, per build.
+ *
+ * ⚠️ **Never an error channel.** Per-build isolation, the same discipline
+ * `executeBackfill` keeps: one refused reversal must not lose the rest of the
+ * run, and a caller that ignores a `failed` entry is behaving correctly.
+ */
+export interface UndoBatchRunSummary {
+  runNumber: number
+  /** Every build carrying this run number, before anything was done to it. */
+  total: number
+  cancelled: UndoBatchRunEntry[]
+  reversed: UndoBatchRunEntry[]
+  skipped: UndoBatchRunEntry[]
+  failed: UndoBatchRunEntry[]
+}
+
+/**
+ * What one batch run looks like from outside, for the drawer card and the undo
+ * preview (45 §11.3).
+ *
+ * 🛑 `willReverse` is the count that WRITES TO THE LEDGER and it is not the
+ * same as `willCancel`. The confirmation has to lead with both (45 §11.4).
+ */
+export interface BatchRunSummary {
+  runNumber: number
+  /** Builds carrying this run number. */
+  total: number
+  /** Counts by `build_status`, over that same set. */
+  planned: number
+  inProgress: number
+  completed: number
+  canceled: number
+  /** `planned` + `inProgress`: what an undo would cancel. */
+  willCancel: number
+  /** `completed` and not already reversed: what an undo would REVERSE. */
+  willReverse: number
+  /** Earliest and latest `build_period_start` / `build_period_end` in the run. */
+  periodStart: Date | null
+  periodEnd: Date | null
+  /** When the run's first build was written. */
+  ranAt: Date | null
 }
 
 /** Move a `planned` run to `in_progress`. */

--- a/packages/lib/src/builds/undo-batch-run.ts
+++ b/packages/lib/src/builds/undo-batch-run.ts
@@ -1,0 +1,239 @@
+// packages/lib/src/builds/undo-batch-run.ts
+
+/**
+ * Undo a whole batch run.
+ *
+ * `plans/money/tasks/45-batch-only-builds.md` section 4, and section 10.8 for
+ * why `skipped` is its own bucket.
+ *
+ * Every build carrying `build_batch_run = N`, and one rule per status:
+ *
+ * | status | action |
+ * | --- | --- |
+ * | `planned` | {@link cancelBuild}, reason naming the run |
+ * | `in_progress` | {@link cancelBuild}, same |
+ * | `completed` | {@link reverseBuild} |
+ * | `canceled` | skip, already undone |
+ * | already reversed | skip |
+ *
+ * ## 🛑 Never a delete
+ *
+ * The movement subledger is append-only (`updatable: false` on every field), so
+ * a mistake is corrected by REVERSING and never by editing or removing. That is
+ * the same call the auto-build trigger settled: we took the trigger and refused
+ * the verb. A build that produced movements is corrected by its negation, and
+ * one that produced none is still a record somebody may have looked at.
+ *
+ * ## 🛑 Undoing a COMPLETED run does not restate the original month
+ *
+ * `reverseMovement` and `reverseBuild` date the negation to NOW, so the
+ * reversing movements land in today's open period rather than the period the
+ * run was dated to (45 section 4.2). That is the accounting-correct answer: a
+ * closed month is not reopened and the correction appears where corrections
+ * belong. It also means undo is not a time machine, and the confirmation dialog
+ * has to say so in those words before anybody presses it.
+ *
+ * ## 🛑 `skipped` is NOT `failed`
+ *
+ * `reverseBuild` refuses an already-reversed build with a `ConflictError` and a
+ * reversal-of-a-reversal with a `BadRequestError`. Both are exactly what the
+ * rules above ask for, so both are classified DELIBERATELY, from
+ * {@link BatchRunBuild.alreadyReversed} and {@link BatchRunBuild.isReversal},
+ * before the call is made. The two refusals are caught as a backstop and land in
+ * `skipped` as well, because the pre-check and the write are not one
+ * transaction. An undo reporting "3 failed" for three builds that are correctly
+ * already undone is a summary people learn to ignore.
+ *
+ * ## ⚠️ Never throws, and an unknown run is empty
+ *
+ * Per-build isolation, exactly like `executeBackfill`: every build inside its
+ * own `try`, the whole body inside the module {@link guard}, and a caller that
+ * ignores a `failed` entry is behaving correctly. A run number no build carries
+ * comes back as an EMPTY summary rather than a `NotFoundError` (45 section
+ * 10.8): a run whose buckets all failed allocated a number and wrote nothing.
+ *
+ * ## ⚠️ Undo and the netting read agree, by two different mechanisms
+ *
+ * 45 section 10.7, which is what makes undo-then-rerun safe and is written down
+ * here because neither half is obvious:
+ *
+ * - cancelling a `planned` build drops it out of `COVERAGE_STATUSES`, so the
+ *   next run rebuilds it;
+ * - reversing a `completed` build changes the coverage read not at all, because
+ *   `completed` is deliberately not a coverage status. What makes it visible is
+ *   that the negating movements re-SUM `part_quantity_on_hand`, which the demand
+ *   read subtracts.
+ *
+ * No permission checks. The router asserts (`docs/lib-module-guide.md`
+ * section 6), and it must assert BOTH halves the way `executeBackfill`'s caller
+ * does, because the reversal path writes stock movements.
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { Result } from 'neverthrow'
+import { BadRequestError, ConflictError } from '../errors'
+import { type BatchRunBuild, readBatchRunBuilds } from './batch-run-queries'
+import { cancelBuild } from './build-mutations'
+import { guard } from './guard'
+import { reverseBuild } from './reverse-build'
+import type { UndoBatchRunEntry, UndoBatchRunSummary } from './types'
+
+const logger = createScopedLogger('builds:undo-batch-run')
+
+/** One progress line per this many builds, so a long undo is observable. */
+const PROGRESS_EVERY = 25
+
+/**
+ * Cancel or reverse every build one run raised.
+ *
+ * @param runNumber the `build_batch_run` to undo. A number no build carries is
+ *   an empty summary, never an error.
+ * @returns what happened per build, never a throw. `err` is reserved for the
+ *   failures that touched NOTHING AT ALL, such as a read that could not run.
+ */
+export async function undoBatchRun(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  runNumber: number
+): Promise<Result<UndoBatchRunSummary, Error>> {
+  return guard(
+    async () => {
+      const loaded = await readBatchRunBuilds(db, organizationId, runNumber)
+      // A read that could not run is the one thing this function does refuse:
+      // undoing "the builds we managed to see" would leave the rest of the run
+      // standing while reporting a complete undo.
+      if (loaded.isErr()) throw loaded.error
+      const builds = loaded.value
+
+      const summary: UndoBatchRunSummary = {
+        runNumber,
+        total: builds.length,
+        cancelled: [],
+        reversed: [],
+        skipped: [],
+        failed: [],
+      }
+      if (builds.length === 0) return summary
+
+      let handled = 0
+      for (const build of builds) {
+        // 🛑 One refused build must not lose the rest of the run.
+        try {
+          await undoOneBuild(db, organizationId, userId, runNumber, build, summary)
+        } catch (error) {
+          summary.failed.push(entry(build, 'failed', message(error)))
+          logger.error('Undoing one build failed; continuing with the run', {
+            organizationId,
+            runNumber,
+            buildId: build.buildId,
+            reason: message(error),
+          })
+        }
+        handled += 1
+        if (handled % PROGRESS_EVERY === 0) {
+          logger.info('Undoing a batch run', {
+            organizationId,
+            runNumber,
+            handled,
+            of: builds.length,
+          })
+        }
+      }
+
+      logger.info('Undid a batch run', {
+        organizationId,
+        runNumber,
+        total: summary.total,
+        cancelled: summary.cancelled.length,
+        reversed: summary.reversed.length,
+        skipped: summary.skipped.length,
+        failed: summary.failed.length,
+      })
+
+      return summary
+    },
+    'Undoing a batch run failed',
+    { organizationId, runNumber }
+  )
+}
+
+/** The rules table, for one build. */
+async function undoOneBuild(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  runNumber: number,
+  build: BatchRunBuild,
+  summary: UndoBatchRunSummary
+): Promise<void> {
+  if (build.status === 'canceled') {
+    summary.skipped.push(entry(build, 'skipped', 'This build was already cancelled'))
+    return
+  }
+
+  if (build.status === 'planned' || build.status === 'in_progress') {
+    const cancelled = await cancelBuild(db, organizationId, userId, {
+      buildId: build.buildId,
+      reason: `Cancelled by the undo of batch run ${runNumber}`,
+    })
+    if (cancelled.isErr()) {
+      summary.failed.push(entry(build, 'failed', cancelled.error.message))
+      return
+    }
+    summary.cancelled.push(entry(build, 'cancelled', null))
+    return
+  }
+
+  if (build.status === 'completed') {
+    // 🛑 Classified, not caught (45 section 10.8). Both of these are what the
+    // rules ask for and neither is a failure.
+    if (build.alreadyReversed) {
+      summary.skipped.push(entry(build, 'skipped', 'This build has already been reversed'))
+      return
+    }
+    if (build.isReversal) {
+      summary.skipped.push(entry(build, 'skipped', 'This build is itself a reversal'))
+      return
+    }
+
+    const reversed = await reverseBuild(db, organizationId, userId, {
+      buildId: build.buildId,
+      reason: `Reversed by the undo of batch run ${runNumber}`,
+    })
+    if (reversed.isErr()) {
+      // The backstop: the pre-check above and this call are not one
+      // transaction, so a reversal written in between still reads as a skip.
+      const error = reversed.error
+      if (error instanceof ConflictError || error instanceof BadRequestError) {
+        summary.skipped.push(entry(build, 'skipped', error.message))
+        return
+      }
+      summary.failed.push(entry(build, 'failed', error.message))
+      return
+    }
+
+    const result = entry(build, 'reversed', null)
+    result.reversalBuildId = reversed.value.buildId
+    summary.reversed.push(result)
+    return
+  }
+
+  // A build whose status value is missing entirely. Never defaulted (see
+  // `resolveBuildStatus`), because guessing here would either cancel a run that
+  // is live or reverse one that wrote nothing.
+  summary.failed.push(entry(build, 'failed', 'This build has no status, so it cannot be undone'))
+}
+
+function entry(
+  build: BatchRunBuild,
+  outcome: UndoBatchRunEntry['outcome'],
+  reason: string | null
+): UndoBatchRunEntry {
+  return { buildId: build.buildId, partId: build.partId, outcome, reason }
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/lib/src/records/index.ts
+++ b/packages/lib/src/records/index.ts
@@ -9,5 +9,13 @@ export type {
   NameCaseChange,
 } from './name-case/backfill'
 export { backfillContactNameCasing } from './name-case/backfill'
-export type { SequenceScope } from './record-numbering'
-export { recordNumbering, SEQUENCE_SCOPES } from './record-numbering'
+export type {
+  AnySequenceScope,
+  InternalSequenceScope,
+  SequenceScope,
+} from './record-numbering'
+export {
+  INTERNAL_SEQUENCE_SCOPES,
+  recordNumbering,
+  SEQUENCE_SCOPES,
+} from './record-numbering'

--- a/packages/lib/src/records/record-numbering.ts
+++ b/packages/lib/src/records/record-numbering.ts
@@ -29,10 +29,32 @@ export const SEQUENCE_SCOPES = [
   'credit_memo',
 ] as const
 
-/** Which record kind a `RecordSequence` row counts. */
+/**
+ * Counters that are NOT record kinds, and must never reach the settings UI.
+ *
+ * 🛑 **Deliberately kept out of {@link SEQUENCE_SCOPES}**, because that list is
+ * what `routers/ticketSequence.ts` derives its scope enum from, and that router
+ * exposes `resetCounter` on a bare `protectedProcedure` with no permission
+ * assert. For `ticket` or `invoice` a reset means a duplicate document number,
+ * which is cosmetic. For `build_batch` it means two batch runs SHARE A NUMBER,
+ * and `undoBatchRun(N)` then reverses completed production from a run nobody
+ * asked to undo, writing to the ledger (plans/money/tasks/45 §10.3).
+ *
+ * `recordNumbering.create` accepts these; nothing else does. There is no
+ * configure, no reset and no UI.
+ */
+export const INTERNAL_SEQUENCE_SCOPES = ['build_batch'] as const
+
+/** Which record kind a `RecordSequence` row counts. Configurable by a user. */
 export type SequenceScope = (typeof SEQUENCE_SCOPES)[number]
 
-const SCOPE_DEFAULTS: Record<SequenceScope, { prefix: string }> = {
+/** A counter that is not a record kind. Backend-allocated only. */
+export type InternalSequenceScope = (typeof INTERNAL_SEQUENCE_SCOPES)[number]
+
+/** Anything `recordNumbering.create` will count. */
+export type AnySequenceScope = SequenceScope | InternalSequenceScope
+
+const SCOPE_DEFAULTS: Record<AnySequenceScope, { prefix: string }> = {
   ticket: { prefix: 'TKT' },
   work_order: { prefix: 'WO' },
   service_request: { prefix: 'REQ' },
@@ -63,6 +85,12 @@ const SCOPE_DEFAULTS: Record<SequenceScope, { prefix: string }> = {
   // (`postings/build-credit-memo-entry.ts`), so it stays short for the same
   // reason the three above do (plans/accounting/tasks/10 section 2.1).
   credit_memo: { prefix: 'CM' },
+  // The batch run counter (plans/money/tasks/45 §3.2). The prefix is COSMETIC
+  // here and nothing renders it: the run number is consumed as the raw
+  // `sequenceNumber` integer, because `build_batch_run` is an integer field.
+  // `BR` all the same, so a row somebody stumbles over in the table is legible
+  // and collides with neither `B` (build) nor `BILL` (vendor bill).
+  build_batch: { prefix: 'BR' },
 }
 
 /** Format a record number from a sequence record */
@@ -116,7 +144,7 @@ export const recordNumbering = {
   /** Generate the next number for an org+scope. Atomic — safe under concurrent creates. */
   async create(
     organizationId: string,
-    scope: SequenceScope
+    scope: AnySequenceScope
   ): Promise<{ recordNumber: string; sequenceNumber: number }> {
     // First use: seed the row. onConflictDoNothing keys on the (organizationId, scope) unique.
     await database

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -330,6 +330,11 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // `completeBuild` is a procedure, not a status somebody picks.
     // `ledger` is the only surface for `build_movements`, whose field is
     // `showInPanel: false` (section 1.6: "has_many; a card lists them").
+    // `batch-run` is the run this build belongs to, and the only verb in the
+    // build UI whose scope is not this build (plans/money/tasks/45 §11): Undo
+    // cancels or reverses every build the run raised. It is declared here AND in
+    // `drawer-config.ts` because the two surfaces read the same registry and a
+    // card on one only is invisible until somebody opens the other.
     sidebarCards: [
       { value: 'run', label: 'Run', icon: 'hammer' },
       {
@@ -338,6 +343,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
         icon: 'arrow-left-right',
         recordResource: 'stock_movement',
       },
+      { value: 'batch-run', label: 'Batch run', icon: 'layers' },
     ],
   },
 

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -394,7 +394,7 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
 
   build: {
     entityType: 'build',
-    // Drawer parity with the detail page (detail-view-config.ts): the same two
+    // Drawer parity with the detail page (detail-view-config.ts): the same three
     // cards, from the same `DRAWER_TAB_CARD_COMPONENTS` keys. A build opened
     // from the parts list or an order must offer the same Complete button the
     // page does, or the drawer becomes a read-only view of a run somebody then
@@ -409,6 +409,12 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
           icon: 'arrow-left-right',
           recordResource: 'stock_movement',
         },
+        // The batch run this build belongs to (plans/money/tasks/45 §11). Its own
+        // card and never folded into `run`: every verb on `run` acts on this one
+        // build, and this card's Undo acts on every build the run raised.
+        // It renders NOTHING for a build carrying no `build_batch_run`, which is
+        // every order-raised, hand-raised and reversing build.
+        { value: 'batch-run', label: 'Batch run', icon: 'layers' },
       ],
     },
   },

--- a/packages/lib/src/resources/registry/resources/build-fields.ts
+++ b/packages/lib/src/resources/registry/resources/build-fields.ts
@@ -749,6 +749,51 @@ export const BUILD_FIELDS: Record<string, ResourceField> = {
     description: 'End of the demand period this build covers, exclusive',
   },
 
+  /**
+   * Which batch run raised this build (plans/money/tasks/45 §3).
+   *
+   * A scalar and not a `batch_run` entity, because everything such an entity
+   * would hold is already recoverable from the builds themselves: the range and
+   * grouping off `periodStart` / `periodEnd`, the status off `status`, the
+   * timing off `createdAt` (45 §3.1). The number comes from
+   * `records/record-numbering.ts`'s atomic `UPDATE ... RETURNING`, allocated
+   * ONCE per run and passed down, never `MAX(...) + 1`.
+   *
+   * 🛑 **`null` on order-raised, hand-raised AND reversing builds.** The first
+   * two never belonged to a run. The third is the trap 45 §4.1 names:
+   * `reverse-build.ts` copies `build_source` onto a reversal, so a reversal of
+   * a batch build is itself `source: 'batch'` and the shape invites copying the
+   * field beside it. If it were copied, run N would contain its own undo and a
+   * second `undoBatchRun(N)` would try to reverse the reversals.
+   *
+   * Backend-owned like `periodStart`: `updatable: false` says there is no
+   * INTERACTIVE writer, and `createBuild` is the only writer there is.
+   */
+  batchRun: {
+    id: toFieldId('batchRun'),
+    key: 'batchRun',
+    label: 'Batch Run',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'build_batch_run',
+    systemSortOrder: 'aO',
+    nullable: true,
+    // Filterable is the point: "show me run 2" is a plain filter on this field,
+    // which is what 45 §4.3's first affordance means in practice.
+    showInPanel: true,
+    showInTable: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'The batch run that raised this build',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -97,6 +97,7 @@ import { migration137FulfillmentFacts } from './migrations/137-fulfillment-facts
 import { migration138AccountantPermissions } from './migrations/138-accountant-permissions'
 import { migration139TaxLineOrderWritable } from './migrations/139-tax-line-order-writable'
 import { migration140IntegrationsView } from './migrations/140-integrations-view'
+import { migration141BuildBatchRun } from './migrations/141-build-batch-run'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -298,6 +299,10 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // hiding Settings -> Connections and emptying the connection picker. Touches
   // no entity def, so it has no ordering constraint against any migration above.
   migration140IntegrationsView,
+  // `build_batch_run`, the per-org batch run number every build a batch run
+  // creates carries (plans/money/tasks/45-batch-only-builds.md §3). MUST sort
+  // after 109, which creates the `build` def it widens.
+  migration141BuildBatchRun,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/141-build-batch-run.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/141-build-batch-run.test.ts
@@ -1,0 +1,69 @@
+// packages/lib/src/seed/entity-migrations/migrations/141-build-batch-run.test.ts
+//
+// Migration 141 adds a single `CustomField` row, so what can silently go wrong
+// is the wiring rather than the write:
+//
+//  - the id must be unique across a space shared with `data-migrations/`, which
+//    has already collided once at 103;
+//  - it must run after 109, which creates the `build` def it widens;
+//  - the registry key it names must exist, or it quietly creates nothing while
+//    reporting success;
+//  - the field's shape is what the run number depends on: a filter is how
+//    "show me run 2" is answered, and `updatable: false` is what keeps a run's
+//    membership from being edited out from under an undo.
+
+import { describe, expect, it } from 'vitest'
+import { BUILD_FIELDS } from '../../../resources/registry/resources/build-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { migration141BuildBatchRun } from './141-build-batch-run'
+
+const MIGRATION_ID = '141-build-batch-run'
+
+describe('migration 141 registration', () => {
+  it('is registered exactly once, with a unique id, after 109', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf(MIGRATION_ID)).toBeGreaterThan(ids.indexOf('109-build-and-standard-cost'))
+    expect(migration141BuildBatchRun.id).toBe(MIGRATION_ID)
+  })
+
+  it('sorts after 140, which took the id the brief named', () => {
+    // 45 §5 asked for "a migration 140". `140-integrations-view` landed first,
+    // so this is 141 and must still be the last entry.
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.indexOf(MIGRATION_ID)).toBeGreaterThan(ids.indexOf('140-integrations-view'))
+  })
+})
+
+describe('the batch run field is shaped for filtering and undo', () => {
+  it('is a system NUMBER field on the named attribute', () => {
+    expect(BUILD_FIELDS.batchRun?.systemAttribute).toBe('build_batch_run')
+    expect(BUILD_FIELDS.batchRun?.isSystem).toBe(true)
+    expect(BUILD_FIELDS.batchRun?.fieldType).toBe('NUMBER')
+  })
+
+  it('is nullable, because a manual or order-raised build belongs to no run', () => {
+    expect(BUILD_FIELDS.batchRun?.nullable).toBe(true)
+  })
+
+  it('is set on the insert and never edited afterwards', () => {
+    expect(BUILD_FIELDS.batchRun?.capabilities.creatable).toBe(true)
+    expect(BUILD_FIELDS.batchRun?.capabilities.updatable).toBe(false)
+    // The number is allocated once per run and passed down, so it is not a
+    // question the create dialog asks.
+    expect(BUILD_FIELDS.batchRun?.showInDialogs).toBe(false)
+  })
+
+  it('is filterable, which is how "show me run 2" is answered', () => {
+    expect(BUILD_FIELDS.batchRun?.capabilities.filterable).toBe(true)
+  })
+
+  it('does not collide with an existing sort order on the build def', () => {
+    const collisions = Object.entries(BUILD_FIELDS).filter(
+      ([name, f]) =>
+        name !== 'batchRun' && f.systemSortOrder === BUILD_FIELDS.batchRun?.systemSortOrder
+    )
+    expect(collisions).toEqual([])
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/141-build-batch-run.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/141-build-batch-run.ts
@@ -1,0 +1,127 @@
+// packages/lib/src/seed/entity-migrations/migrations/141-build-batch-run.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getOrgCache } from '../../../cache'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { BUILD_FIELDS } from '../../../resources/registry/resources/build-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:141')
+
+/** The def that receives the field. Created by migration 109, widened by 124. */
+const BUILD_ENTITY_TYPE = 'build'
+
+/**
+ * Listed by REGISTRY KEY rather than taken as "everything new on
+ * `BUILD_FIELDS`", so a later unrelated field cannot silently join this
+ * migration's payload. The same discipline 109, 111, 119 and 124 record.
+ */
+const FIELD_KEYS = ['batchRun'] as const
+
+/**
+ * Migration 141: `build_batch_run`, the per-org run number every build a batch
+ * run creates carries (plans/money/tasks/45-batch-only-builds.md §3).
+ *
+ * ## What it adds
+ *
+ * One `CustomField` row on the `build` def: `build_batch_run`, a nullable
+ * integer, `creatable` and `updatable: false`. Nothing else. There are no
+ * select options to materialize, which is what makes this migration strictly
+ * simpler than 124: only the `ensureCustomFields` half of 124's work applies,
+ * and none of its append-an-option machinery.
+ *
+ * ## 🛑 Why the registry edit alone reaches no existing org
+ *
+ * `build-fields.ts` is the seed for a def's `CustomField` rows, not a live view
+ * of them. `mergeSystemAndCustomFields` reads what is stored on the DB row,
+ * so a field added to the registry today exists only in orgs seeded after
+ * today. 44 §11.2 records this and 109, 111, 119 and 124 all exist for it.
+ * Without this migration the batch builder would write a `build_batch_run`
+ * value against a field that no existing org has, the filter *"show me run 2"*
+ * would have nothing to filter on, and the Undo card (45 §11) would have no
+ * handle to hang on.
+ *
+ * ## Why a scalar and not a `batch_run` entity
+ *
+ * 45 §3.1: almost everything a run entity would store is already recoverable
+ * from the builds themselves (the range and grouping off
+ * `build_period_start` / `build_period_end`, the status off `build_status`, the
+ * timing off `createdAt`), so an entity would be a second copy of an answer the
+ * builds already give. The number is the one thing that is NOT recoverable,
+ * because it is what groups the builds of a single run together, so it is the
+ * one thing that gets stored.
+ *
+ * The value comes from `records/record-numbering.ts` under the internal
+ * `build_batch` scope, allocated ONCE per run before the first build. 45 §3.2:
+ * the increment and read-back are one `UPDATE ... RETURNING`, and a hand-rolled
+ * `MAX(build_batch_run) + 1` would hand two concurrent runs the same number,
+ * which makes undo reverse production nobody asked to undo.
+ *
+ * ## Inert on arrival
+ *
+ * `null` on every order-raised and hand-raised build, and nothing writes it
+ * until the batch builder allocates a run number. The same B10 precedent 109,
+ * 111 and 124 followed: a field with no writer carries no behavioural risk, and
+ * shipping it first is what clears the org-cache and field-exists gates for the
+ * code that follows.
+ *
+ * ## Id space
+ *
+ * 141 is the next free number counted across BOTH `data-migrations/migrations/`
+ * (which reaches 131) and `seed/entity-migrations/migrations/` (which reaches
+ * 140, `140-integrations-view`). The space is shared and has already collided
+ * once, at 103. 45 §5 said 125, then 140; both went stale between the brief
+ * being written and this file existing, which is what 45 §10.9 records. Count
+ * both directories at the moment you create the file.
+ *
+ * **No DDL.** The field is a `CustomField` row on an existing def; nothing here
+ * touches a Postgres table. If a `.sql` file appears under
+ * `packages/database/drizzle/` for this work, something is wrong.
+ *
+ * Idempotent: `ensureCustomFields` skips a field that already exists, so a
+ * re-run reports `alreadyUpToDate` and writes nothing.
+ */
+export const migration141BuildBatchRun: EntityMigration = {
+  id: '141-build-batch-run',
+  description:
+    'Add build_batch_run, the per-org batch run number every build a run creates carries, ' +
+    'so a run can be filtered for and undone as a unit',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const def = existing.entityDefs.get(BUILD_ENTITY_TYPE)
+    // Absent rather than failed: an org short of migration 109 has no `build`
+    // def, and 109 seeds the full registry (this field included), so a later run
+    // picks the whole thing up on its own.
+    if (!def) return { ...state, alreadyUpToDate: true }
+
+    const fields: Record<string, ResourceField> = {}
+    for (const key of FIELD_KEYS) {
+      const field = BUILD_FIELDS[key]
+      // Loud rather than silent: a renamed registry key would otherwise make
+      // this migration quietly create one field fewer than it claims to.
+      if (!field) {
+        throw new Error(`build registry is missing the key "${key}" (migration 141)`)
+      }
+      fields[key] = field
+    }
+
+    await ensureCustomFields(db, organizationId, BUILD_ENTITY_TYPE, def.id, fields, existing, state)
+
+    const alreadyUpToDate = state.fieldsCreated === 0
+
+    // A new field is invisible to every read path until the per-org caches that
+    // serve it are dropped. `runEntityMigrationsForOrg` does this after the
+    // whole batch, but `up()` can also be invoked directly, so it clears its own.
+    if (!alreadyUpToDate) {
+      await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+      logger.info('Migration 141 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -774,6 +774,7 @@ export const SYSTEM_ATTRIBUTES = [
   // September.
   'build_period_start',
   'build_period_end',
+  'build_batch_run',
   // The frozen standard, deliberately separate from the live `part_cost`. The
   // three components are split because the fulfillment COGS entry has to land
   // across 5000 / 5010 / 5020, which it can only do if the finished good's


### PR DESCRIPTION
A batch build run now carries a per-org run number, and a run can be undone from any build it raised.

Implements `plans/money/tasks/45-batch-only-builds.md`.

## Why a scalar and not a `batch_run` entity

Everything such an entity would hold is already recoverable from the builds themselves: the range and grouping off the period fields, the status off `build_status`, the timing off `createdAt`. A record whose fields are a second copy of an answer the builds already give is the two-sources-for-one-number problem this codebase keeps paying for. What is genuinely lost is *who* ran it and the exact instant, which is what the audit log is for.

## What landed

**The field and the number**

- `build_batch_run`, a nullable integer on the build def, `updatable: false`, filterable so *"show me run 2"* is a plain filter. Entity migration **141**.
- The counter reuses `recordNumbering`'s atomic `UPDATE ... RETURNING` rather than a hand-rolled `MAX(...) + 1`, which would hand two concurrent runs the same number and make undo unpredictable.
- Allocated **once per run** in `prepareRun` and passed down. Allocating per build would burn the sequence and turn one four-hundred-build run into four hundred runs. Pinned by a call-count assertion, not a value assertion, which is the only version of the test that catches an allocation moved into the loop.
- An empty plan burns no number.

**`build_batch` is deliberately not a `SequenceScope`**

That list drives `ticketSequence`'s scope enum, whose `resetCounter` is an ungated `protectedProcedure`. For a ticket a reset means a duplicate document number, which is cosmetic. For a run it means two runs share a number and `undoBatchRun` reverses completed production nobody asked to undo, writing to the ledger. `INTERNAL_SEQUENCE_SCOPES` is a separate list `recordNumbering.create` accepts and the router never sees.

**Undo**

- Cancels `planned` and `in_progress`, **reverses** `completed`, and never deletes: the movement subledger is append-only and a mistake is corrected by reversing.
- Never throws. Per-build isolation, the same discipline `executeBackfill` keeps.
- Classifies an already-reversed build as `skipped`, not `failed`, so undo does not report three failures for three builds that are correctly already undone.
- Undo is not a time machine: reversals date to today's open period and do not restate the month the run was dated to. The dialog says so in those words.

**The card**

Its own registered section rather than folded into `build:run`, because every verb there acts on the one build in front of you and Undo acts on every build in the run. The button reads the blast radius, `Undo run 2 (412 builds)`, and the dialog leads with the cancel and reverse counts separately since only the reversals touch the ledger. Declared in both the drawer and detail-view registries; `drawer-card-parity.test.ts` is what proves the declarations resolve to a real component instead of silently rendering nothing.

`undoBatchRun` asserts both halves via `assertCanPostBuildLedger`, the gate `complete` and `reverse` take, because the reversal path writes stock movements.

**`reset-org-books.ts`**

Now clears the `build_batch` counter. It is not an entity type so it could never reach `DELETE_WAVES`, and an org reset to zero builds would otherwise open a card reading "run 14".

## Also, from 44's outstanding list

The backfill preflight moves out of `routers/builds.ts` into `builds/backfill-preflight.ts`. 44 §11.3 recorded it as misplaced rather than wrong; per `docs/lib-module-guide.md` §6 a router asserts and calls. The move is what let it be unit tested, and the tests pin that the explosion is per **part** at whole-range quantity while the movement count is per **bucket**, a pair whose inversion would understate by exactly the factor the person is consenting to.

## The load-bearing test

`reverse-build-batch-run.test.ts`. `reverse-build.ts:309` copies `build_source` onto a reversal, so a reversal of a batch build is itself `source: batch` and the shape actively invites copying the field beside it. If it were copied, run N would contain its own undo and a second undo would try to reverse the reversals.

Nothing in the write path enforces `capabilities.updatable` (`field-hooks/register-hooks.ts:523` says so plainly), so that file is the only protection the rule has. It asserts the reversal **does** carry `source: batch` alongside asserting it does not carry the run number, so it cannot pass for the wrong reason.

## Verification

- `typecheck-ratchet --package lib`: no new errors (27, baseline 27)
- `typecheck-ratchet --package web`: no new errors (0, baseline 0)
- `src/builds`: **487 tests passing**, up from 435
- Full `packages/lib` suite: 17,924 passing. One unrelated failure, `utils/rate-limiter/__tests__/pacer.test.ts`, a timing-sensitive concurrency test that passes in isolation (80/80) and whose file is untouched here.

## Not done

- **Nothing has run against real data.** Every test is a unit test against doubles. Migration 141 is applied and the field is live in 28/28 orgs, so a first `planned` run on the dev org (13,523 orders dated 2017 to today, zero coverage) is the next step. A planned run needs no accounting setup; a completed run fails closed on `accounting.bookTimeZone` and, in practice, on missing standard costs.
- 44 §11.4 is still open: should the range have a lower bound at `accounting.cutoffPeriod`?
- A period row still shows its order count without expanding to name the orders. Accepted for v1.

https://claude.ai/code/session_0163SXDcRZGH6KNTKQ4ETc1J