### PR TITLE
feat(accounting): reports and pointers on the account id, and the not_enabled gate

### DIFF
--- a/apps/web/src/components/accounting/ui/banking/deposits/deposits-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/deposits/deposits-page.tsx
@@ -48,7 +48,7 @@ import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
 import { Banknote, FileDown, Landmark } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
@@ -57,6 +57,7 @@ import SettingsPage from '~/components/global/settings-page'
 import { useDocumentSendActions } from '~/components/money/ui/use-document-send-actions'
 import { RecordsView } from '~/components/records/records-view'
 import { BaseType } from '~/components/workflow/types'
+import { useViewportFill } from '~/hooks/use-viewport-fill'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { BankAccountPicker, bankAccountLabel, useBankAccounts } from '../../bank-account-picker'
@@ -116,50 +117,6 @@ function formatDay(day: string): string {
 /** Below this the framed split is not worth filling - it just scrolls with the page. */
 const MIN_FRAME_HEIGHT = 320
 
-/**
- * The height that makes this element end exactly where `SettingsPage`'s scroll
- * viewport does, so the split fills the page without adding a scrollbar.
- *
- * ⚠️ `--settings-sticky-top` is NOT the whole story. It measures the sticky
- * title/tabs block only; the breadcrumb bar above it is a separate, non-sticky
- * sibling, so `viewport - stickyTop` overshoots by the breadcrumb's height and
- * the page gains a scrollbar exactly that tall. What is honest is the element's
- * own offset inside the scroll content: everything above it, sticky or not, has
- * already been laid out, so `viewportHeight - offsetTop` is the room that is
- * actually left. Re-measured when the viewport or anything above it resizes -
- * the header grows a line when the description wraps at narrow widths.
- */
-function useFillViewportHeight() {
-  const ref = useRef<HTMLDivElement>(null)
-  const [height, setHeight] = useState<number | null>(null)
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const viewport = el.closest('[data-slot="scroll-area-viewport"]')
-    if (!(viewport instanceof HTMLElement)) return
-
-    const measure = () => {
-      const offsetTop =
-        el.getBoundingClientRect().top - viewport.getBoundingClientRect().top + viewport.scrollTop
-      setHeight(Math.max(MIN_FRAME_HEIGHT, viewport.clientHeight - offsetTop))
-    }
-
-    measure()
-    const observer = new ResizeObserver(measure)
-    observer.observe(viewport)
-    // Everything above this element inside the scroll content - the breadcrumb
-    // bar and the sticky header. Not `el` itself: observing what this effect
-    // resizes is a loop.
-    for (const sibling of viewport.children) {
-      if (sibling !== el) observer.observe(sibling)
-    }
-    return () => observer.disconnect()
-  }, [])
-
-  return { ref, height }
-}
-
 const METHOD_LABELS: Record<string, string> = {
   cash: 'Cash',
   check: 'Check',
@@ -199,19 +156,20 @@ export function DepositsPage() {
 
   // ── The account it is banked INTO ─────────────────────────────────────────
   //
-  // 🛑 The operator picks a BANK ACCOUNT and the ledger code is read off that
+  // 🛑 The operator picks a BANK ACCOUNT and the ledger id is read off that
   // account's own mapping, never chosen from the chart. `createBankDeposit`
-  // debits whatever code it is handed, and the bank feed posts every
-  // transaction on this account against `bank_account.glAccountCode` - so a
-  // free choice from the chart puts the deposit and the statement line it
-  // exists to match into two different accounts. Nothing catches that: match
-  // candidates are found by amount and date, not by account.
+  // debits whatever id it is handed, and the bank feed posts every
+  // transaction on this account against `bank_account.glAccount` (task 15
+  // §4, a `gl_account` id) - so a free choice from the chart puts the deposit
+  // and the statement line it exists to match into two different accounts.
+  // Nothing catches that: match candidates are found by amount and date, not
+  // by account.
   const { accounts: bankAccounts, isLoading: bankAccountsLoading } = useBankAccounts()
   const bankAccount = useMemo(
     () => bankAccounts.find((account) => account.id === bankAccountId) ?? null,
     [bankAccounts, bankAccountId]
   )
-  const bankAccountCode = bankAccount?.glAccountCode?.trim() || null
+  const bankAccountGlAccountId = bankAccount?.glAccountId?.trim() || null
 
   /**
    * What is missing before a deposit can name an account at all.
@@ -233,7 +191,7 @@ export function DepositsPage() {
     }
     // Only once one is CHOSEN. Listing every unmapped account up front would
     // shout about accounts this deposit was never going to touch.
-    if (bankAccount && !bankAccountCode) {
+    if (bankAccount && !bankAccountGlAccountId) {
       return [
         {
           status: 'bank_account_unmapped',
@@ -242,7 +200,7 @@ export function DepositsPage() {
       ]
     }
     return []
-  }, [bankAccountsLoading, bankAccounts, bankAccount, bankAccountCode])
+  }, [bankAccountsLoading, bankAccounts, bankAccount, bankAccountGlAccountId])
 
   const createDeposit = api.money.bankDeposit.create.useMutation({
     onSuccess: async (result) => {
@@ -290,9 +248,11 @@ export function DepositsPage() {
     )
   }, [])
 
-  // `bankAccountId` as well as its code: the mutation sends the id, and the
-  // code is only what proves the account is mapped well enough to post.
-  const canRecord = selectedIds.length > 0 && !!bankAccountId && !!bankAccountCode && !!depositDate
+  // `bankAccountId` as well as its `gl_account` id: the mutation sends the
+  // bank account id, and the mapping is only what proves the account is
+  // mapped well enough to post.
+  const canRecord =
+    selectedIds.length > 0 && !!bankAccountId && !!bankAccountGlAccountId && !!depositDate
 
   /** The selection, once {@link canRecord} has proved every part of it is there. */
   const recordDeposit = () => {
@@ -305,7 +265,8 @@ export function DepositsPage() {
     })
   }
 
-  const { ref: frameRef, height: frameHeight } = useFillViewportHeight()
+  const frameRef = useRef<HTMLDivElement>(null)
+  const frameHeight = useViewportFill(frameRef, MIN_FRAME_HEIGHT)
 
   return (
     <SettingsPage

--- a/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
@@ -48,16 +48,18 @@ import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
 import { Inbox, Landmark, ListChecks } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRegisterDockedPanels } from '~/components/global/docked-panels-outlet'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useMedia } from '~/hooks/use-media'
+import { useViewportFill } from '~/hooks/use-viewport-fill'
 import { useAccess, useRequireCapability } from '~/providers/capabilities-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import { BankAccountBadge } from '../bank-account-badge'
+import { useChartAccounts } from '../gl-account-picker'
 import { EMPTY_CELL, formatMinor } from '../ledger/format'
 import { ReviewBulkBar } from './review/review-bulk-bar'
 import { ReviewDrawer } from './review/review-drawer'
@@ -78,6 +80,20 @@ const PAGE_DESCRIPTION =
  * display currency is that constant rather than a read.
  */
 const DISPLAY_CURRENCY = 'USD'
+
+/** The queue never collapses below this, however short the window is. */
+const MIN_FRAME_HEIGHT = 260
+
+/**
+ * Consecutive pages the sentinel may pull without the reviewer scrolling again.
+ *
+ * The sentinel sits at the end of the list, so a page that does not fill the
+ * viewport leaves it still on screen and it fires straight away. That is
+ * correct once or twice - it is how a short first page catches up to a tall
+ * window - but unbounded it walks the whole queue on mount. Reset on scroll,
+ * the same guard `mail-thread-list.tsx` uses.
+ */
+const MAX_AUTO_FETCHES = 5
 
 /** What one "apply rules" run reports back, as `applySuggestions` returns it. */
 interface RunCounts {
@@ -183,6 +199,15 @@ export function BankingReviewQueuePage() {
     [accountsQuery.data]
   )
 
+  // `glAccountId`/`suggestedGlAccountId` on a row are `gl_account` ids (task 15
+  // §4), never codes - resolved once here against the one chart fetch, never
+  // per row.
+  const { accounts: chartAccounts } = useChartAccounts()
+  const chartAccountById = useMemo(
+    () => new Map(chartAccounts.map((chartAccount) => [chartAccount.id, chartAccount])),
+    [chartAccounts]
+  )
+
   /**
    * A bookmarked `?account=` for an account that has since been archived or
    * deleted is an ordinary state, not an error - `getBankAccount` takes the same
@@ -207,12 +232,17 @@ export function BankingReviewQueuePage() {
     [filters]
   )
 
-  const list = api.bankingReview.list.useQuery(listInput)
+  const list = api.bankingReview.list.useInfiniteQuery(listInput, {
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  })
   const stats = api.bankingReview.stats.useQuery({
     bankAccountId: filters.bankAccountId ?? undefined,
   })
 
-  const rows = list.data ?? []
+  const rows = useMemo(
+    () => list.data?.pages.flatMap((page) => page.items) ?? [],
+    [list.data?.pages]
+  )
 
   const toggle = useCallback((id: string) => {
     setSelectedIds((current) =>
@@ -338,9 +368,71 @@ export function BankingReviewQueuePage() {
   )
   useRegisterDockedPanels(dockedPanels)
 
+  /**
+   * 🛑 The frame needs a DEFINITE height, and `flex-1` is not one here.
+   *
+   * `SettingsPage` is itself a `ScrollArea` whose content wrapper is
+   * `min-h-full` with an auto height, and a grow item of an auto-height flex
+   * column is sized by its own content, not by the container. Left on `flex-1`
+   * this frame grew to the full list, the `ScrollArea` below it became as tall
+   * as its contents and never scrolled, and the settings viewport scrolled the
+   * whole page instead - the stat strip and the toolbar scrolled away with it.
+   * `rules-page.tsx` and `deposits-page.tsx` measure the same way.
+   */
+  const frameRef = useRef<HTMLDivElement>(null)
+  const frameHeight = useViewportFill(frameRef, MIN_FRAME_HEIGHT)
+
+  // ── Infinite scroll ─────────────────────────────────────────────────────
+  //
+  // The queue pages 50 at a time. Refs rather than deps so the observer is
+  // built once per viewport instead of being torn down on every fetch.
+  const [listViewport, setListViewport] = useState<HTMLDivElement | null>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const nextPage = useRef({ fetch: list.fetchNextPage, has: false, fetching: false })
+  nextPage.current = {
+    fetch: list.fetchNextPage,
+    has: list.hasNextPage,
+    fetching: list.isFetchingNextPage,
+  }
+  const autoFetches = useRef(0)
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!listViewport || !sentinel) return
+
+    const reset = () => {
+      autoFetches.current = 0
+    }
+    listViewport.addEventListener('scroll', reset, { passive: true })
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const { has, fetching, fetch } = nextPage.current
+        if (!entry?.isIntersecting || !has || fetching) return
+        if (autoFetches.current >= MAX_AUTO_FETCHES) return
+        autoFetches.current++
+        void fetch()
+      },
+      { root: listViewport, threshold: 0 }
+    )
+    observer.observe(sentinel)
+
+    return () => {
+      listViewport.removeEventListener('scroll', reset)
+      observer.disconnect()
+    }
+  }, [listViewport])
+
+  /** A new view is a new pile - the auto-fetch budget starts over with it. */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the filters are the trigger
+  useEffect(() => {
+    autoFetches.current = 0
+    listViewport?.scrollTo({ top: 0 })
+  }, [listInput])
+
   return (
     <SettingsPage title='Review queue' description={PAGE_DESCRIPTION} breadcrumbs={BREADCRUMBS}>
-      <div className='flex min-h-0 flex-1 flex-col'>
+      <div ref={frameRef} className='flex min-h-0 flex-col' style={{ height: frameHeight }}>
         <ReviewStats
           stats={stats.data}
           loading={stats.isPending}
@@ -381,7 +473,7 @@ export function BankingReviewQueuePage() {
             }
           />
         ) : (
-          <ScrollArea className='min-h-0 flex-1'>
+          <ScrollArea className='min-h-0 flex-1' viewportRef={setListViewport}>
             <div className='flex flex-col gap-1 p-4 pb-24'>
               <TreeRowList
                 items={rows}
@@ -429,14 +521,16 @@ export function BankingReviewQueuePage() {
                             Void
                           </Badge>
                         )}
-                        {row.suggestedGlAccount && row.reviewStatus !== 'coded' && (
+                        {row.suggestedGlAccountId && row.reviewStatus !== 'coded' && (
                           <Badge variant='blue' size='xs'>
-                            Code: {row.suggestedGlAccount}
+                            Code:{' '}
+                            {chartAccountById.get(row.suggestedGlAccountId)?.code ??
+                              row.suggestedGlAccountId}
                           </Badge>
                         )}
-                        {row.glAccountCode && (
+                        {row.glAccountId && (
                           <Badge variant='outline' size='xs' className='font-mono'>
-                            {row.glAccountCode}
+                            {chartAccountById.get(row.glAccountId)?.code ?? row.glAccountId}
                           </Badge>
                         )}
                         <span className='flex items-center gap-1 text-muted-foreground text-xs'>
@@ -459,6 +553,31 @@ export function BankingReviewQueuePage() {
                   />
                 )}
               />
+
+              {/* The trigger for the next page. It sits INSIDE the padded
+                  wrapper so `pb-24` keeps it clear of the bulk bar; the
+                  observer's root is the viewport above, not the window. */}
+              <div ref={sentinelRef} className='h-px shrink-0' aria-hidden />
+              {list.isFetchingNextPage && (
+                <div className='py-3 text-center text-muted-foreground text-xs'>
+                  Loading more lines...
+                </div>
+              )}
+              {/* The budget only runs out on a viewport the pages do not fill,
+                  which is exactly when there is nothing to scroll to reset it. */}
+              {list.hasNextPage && !list.isFetchingNextPage && (
+                <div className='flex justify-center py-3'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() => {
+                      autoFetches.current = 0
+                      void list.fetchNextPage()
+                    }}>
+                    Load more
+                  </Button>
+                </div>
+              )}
             </div>
           </ScrollArea>
         )}

--- a/apps/web/src/components/accounting/ui/banking/review/code-panel.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/code-panel.tsx
@@ -48,7 +48,9 @@ interface CodePanelProps {
 export function CodePanel({ line, currencyCode, onDone }: CodePanelProps) {
   const utils = api.useUtils()
   const { accounts } = useChartAccounts()
-  const [code, setCode] = useState<string | null>(line.glAccountCode ?? line.suggestedGlAccount)
+  const [accountId, setAccountId] = useState<string | null>(
+    line.glAccountId ?? line.suggestedGlAccountId
+  )
   const [memo, setMemo] = useState('')
   const [createRule, setCreateRule] = useState(false)
   const [blockers, setBlockers] = useState<LedgerBlocker[]>([])
@@ -90,23 +92,23 @@ export function CodePanel({ line, currencyCode, onDone }: CodePanelProps) {
   })
 
   const preview = useMemo<ResolvedPostingLine[]>(() => {
-    if (!code || !line.bankAccountCode || line.amountMinor === 0) return []
-    const find = (accountCode: string) => accounts.find((account) => account.code === accountCode)
+    if (!accountId || !line.bankAccountGlAccountId || line.amountMinor === 0) return []
+    const find = (id: string) => accounts.find((account) => account.id === id)
     const amount = Math.abs(line.amountMinor)
     const outbound = line.amountMinor < 0
-    const debitCode = outbound ? code : line.bankAccountCode
-    const creditCode = outbound ? line.bankAccountCode : code
+    const debitId = outbound ? accountId : line.bankAccountGlAccountId
+    const creditId = outbound ? line.bankAccountGlAccountId : accountId
     // A browser-composed preview, not a server resolution - see the file
     // header. Both accounts come from the same chart the picker offered, so
     // a miss means the chart is still loading; render nothing rather than a
     // line whose identity is a guess.
-    const debit = find(debitCode)
-    const credit = find(creditCode)
+    const debit = find(debitId)
+    const credit = find(creditId)
     if (!debit || !credit) return []
     return [
       {
         glAccountId: debit.id,
-        accountCode: debitCode,
+        accountCode: debit.code,
         accountName: debit.name,
         direction: 'debit',
         amount,
@@ -117,7 +119,7 @@ export function CodePanel({ line, currencyCode, onDone }: CodePanelProps) {
       },
       {
         glAccountId: credit.id,
-        accountCode: creditCode,
+        accountCode: credit.code,
         accountName: credit.name,
         direction: 'credit',
         amount,
@@ -127,9 +129,20 @@ export function CodePanel({ line, currencyCode, onDone }: CodePanelProps) {
         sortOrder: 1,
       },
     ]
-  }, [accounts, code, line.amountMinor, line.bankAccountCode, line.description, line.id, memo])
+  }, [
+    accounts,
+    accountId,
+    line.amountMinor,
+    line.bankAccountGlAccountId,
+    line.description,
+    line.id,
+    memo,
+  ])
 
-  const unmapped = !line.bankAccountCode
+  const unmapped = !line.bankAccountGlAccountId
+  const suggestedAccount = line.suggestedGlAccountId
+    ? accounts.find((account) => account.id === line.suggestedGlAccountId)
+    : null
 
   return (
     <div className='flex flex-col gap-4'>
@@ -144,14 +157,19 @@ export function CodePanel({ line, currencyCode, onDone }: CodePanelProps) {
             'The account this money belongs in. The bank side of the entry comes from the account mapping.'
           }>
           <div className='flex flex-col gap-1.5'>
-            <GlAccountPicker value={code} onChange={setCode} placeholder='Choose an account…' />
-            {line.suggestedGlAccount && line.suggestedGlAccount !== code && (
+            <GlAccountPicker
+              value={accountId}
+              selectBy='id'
+              onChange={setAccountId}
+              placeholder='Choose an account…'
+            />
+            {line.suggestedGlAccountId && line.suggestedGlAccountId !== accountId && (
               <button
                 type='button'
                 className='flex w-fit items-center gap-1.5 text-muted-foreground text-xs hover:text-foreground'
-                onClick={() => setCode(line.suggestedGlAccount)}>
+                onClick={() => setAccountId(line.suggestedGlAccountId)}>
                 <Lightbulb className='size-3' />
-                Use the suggestion, {line.suggestedGlAccount}
+                Use the suggestion{suggestedAccount ? `, ${suggestedAccount.code}` : ''}
               </button>
             )}
             {canCreateRule && (
@@ -193,12 +211,12 @@ export function CodePanel({ line, currencyCode, onDone }: CodePanelProps) {
       <EntryBlockers blockers={blockers} />
 
       <Button
-        disabled={!code || unmapped || codeTransaction.isPending}
+        disabled={!accountId || unmapped || codeTransaction.isPending}
         loading={codeTransaction.isPending}
         onClick={() =>
           codeTransaction.mutate({
             id: line.id,
-            glAccountCode: code ?? '',
+            glAccountId: accountId ?? '',
             memo: memo.trim() || undefined,
           })
         }>

--- a/apps/web/src/components/accounting/ui/banking/review/review-bulk-bar.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-bulk-bar.tsx
@@ -43,7 +43,7 @@ export function ReviewBulkBar({ selectedIds, onClear, onDone }: ReviewBulkBarPro
   const utils = api.useUtils()
   const [dialog, setDialog] = useState<'exclude' | 'assign' | null>(null)
   const [reason, setReason] = useState('')
-  const [code, setCode] = useState<string | null>(null)
+  const [accountId, setAccountId] = useState<string | null>(null)
   const [blockers, setBlockers] = useState<LedgerBlocker[]>([])
 
   const count = selectedIds.length
@@ -183,17 +183,22 @@ export function ReviewBulkBar({ selectedIds, onClear, onDone }: ReviewBulkBarPro
               other. Money out debits the account; money in credits it.
             </DialogDescription>
           </DialogHeader>
-          <GlAccountPicker value={code} onChange={setCode} placeholder='Choose an account…' />
+          <GlAccountPicker
+            value={accountId}
+            selectBy='id'
+            onChange={setAccountId}
+            placeholder='Choose an account…'
+          />
           <EntryBlockers blockers={blockers} />
           <DialogFooter>
             <Button variant='outline' onClick={() => setDialog(null)}>
               Cancel
             </Button>
             <Button
-              disabled={!code || busy}
+              disabled={!accountId || busy}
               loading={bulkAssign.isPending}
               onClick={() =>
-                bulkAssign.mutate({ ids: selectedIds.slice(0, 100), glAccountCode: code ?? '' })
+                bulkAssign.mutate({ ids: selectedIds.slice(0, 100), glAccountId: accountId ?? '' })
               }>
               Post
             </Button>

--- a/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
@@ -16,9 +16,10 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Ban, Landmark, Undo2 } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
 import { BankAccountBadge } from '../../bank-account-badge'
+import { useChartAccounts } from '../../gl-account-picker'
 import { EntryBlockers, type LedgerBlocker } from '../../ledger/entry-blockers'
 import { EMPTY_CELL, formatMinor } from '../../ledger/format'
 import { CodePanel } from './code-panel'
@@ -142,6 +143,17 @@ export function ReviewDrawer({
       line.reviewStatus === 'coded' ||
       line.reviewStatus === 'excluded')
 
+  // `glAccountId` is the `gl_account` id (task 15 §4), never a code - resolve
+  // it against the one chart fetch every picker on this page already shares.
+  const { accounts: chartAccounts } = useChartAccounts()
+  const codedAccount = useMemo(
+    () =>
+      line?.glAccountId
+        ? (chartAccounts.find((account) => account.id === line.glAccountId) ?? null)
+        : null,
+    [chartAccounts, line?.glAccountId]
+  )
+
   return (
     <DockableDrawer
       open={!!transactionId}
@@ -237,7 +249,7 @@ export function ReviewDrawer({
                         </span>
                         <span className='truncate text-muted-foreground text-xs'>
                           {line.reviewStatus === 'coded'
-                            ? `Coded to ${line.glAccountCode ?? ''}`
+                            ? `Coded to ${codedAccount ? `${codedAccount.code} ${codedAccount.name}` : (line.glAccountId ?? '')}`
                             : line.reviewStatus === 'excluded'
                               ? (line.excludeReason ?? '')
                               : matchedLabel(line)}

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-action-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-action-page.tsx
@@ -27,9 +27,9 @@ function firstValue(value: unknown): string {
 interface BankRuleActionPageProps {
   action: BankRuleAction
   onActionChange: (value: BankRuleAction) => void
-  /** GL account CODE, never an id - what a posting line names an account by. */
-  glAccountCode: string
-  onGlAccountChange: (code: string) => void
+  /** The `gl_account` id a "code" action proposes (task 15 §4). Never a code. */
+  glAccountId: string
+  onGlAccountChange: (id: string) => void
   counterpartBankAccountId: string
   onCounterpartChange: (id: string) => void
   memo: string
@@ -48,7 +48,7 @@ interface BankRuleActionPageProps {
 export function BankRuleActionPage({
   action,
   onActionChange,
-  glAccountCode,
+  glAccountId,
   onGlAccountChange,
   counterpartBankAccountId,
   onCounterpartChange,
@@ -88,10 +88,11 @@ export function BankRuleActionPage({
           {action === 'code' && (
             <FieldPanelRow title='GL account' isRequired>
               <GlAccountPicker
-                value={glAccountCode || null}
+                value={glAccountId || null}
+                selectBy='id'
                 disabled={isPending}
                 placeholder='Select account…'
-                onChange={(code) => onGlAccountChange(code ?? '')}
+                onChange={(id) => onGlAccountChange(id ?? '')}
               />
             </FieldPanelRow>
           )}

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-dialog.tsx
@@ -46,7 +46,7 @@ export function BankRuleDialog({ open, onClose, rule }: BankRuleDialogProps) {
   const [bankAccountId, setBankAccountId] = useState('')
   const [autoApply, setAutoApply] = useState(false)
   const [action, setAction] = useState<BankRuleAction>('code')
-  const [glAccountCode, setGlAccountCode] = useState('')
+  const [glAccountId, setGlAccountId] = useState('')
   const [counterpartBankAccountId, setCounterpartBankAccountId] = useState('')
   const [memo, setMemo] = useState('')
 
@@ -62,7 +62,7 @@ export function BankRuleDialog({ open, onClose, rule }: BankRuleDialogProps) {
     setBankAccountId(rule?.bankAccountId ?? '')
     setAutoApply(rule?.autoApply ?? false)
     setAction(rule?.action ?? 'code')
-    setGlAccountCode(rule?.glAccountCode ?? '')
+    setGlAccountId(rule?.glAccountId ?? '')
     setCounterpartBankAccountId(rule?.counterpartBankAccountId ?? '')
     setMemo(rule?.memo ?? '')
   }, [open, rule])
@@ -99,17 +99,19 @@ export function BankRuleDialog({ open, onClose, rule }: BankRuleDialogProps) {
     name.trim().length > 0 &&
     matchValue.trim().length > 0 &&
     (action === 'code'
-      ? glAccountCode.length > 0
+      ? glAccountId.length > 0
       : action === 'transfer'
         ? counterpartBankAccountId.length > 0
         : true)
 
   const counterpart = bankAccounts.find((account) => account.id === counterpartBankAccountId)
 
+  const selectedGlAccount = chartAccounts.find((a) => a.id === glAccountId)
   const actionLabel = describeActionDetail({
     action,
-    glAccountCode,
-    glAccountName: chartAccounts.find((a) => a.code === glAccountCode)?.name,
+    glAccountId,
+    glAccountCode: selectedGlAccount?.code,
+    glAccountName: selectedGlAccount?.name,
     counterpartName: counterpart ? bankAccountLabel(counterpart) : undefined,
   })
 
@@ -122,7 +124,7 @@ export function BankRuleDialog({ open, onClose, rule }: BankRuleDialogProps) {
       direction,
       bankAccountId: bankAccountId || null,
       action,
-      glAccountCode: action === 'code' ? glAccountCode : null,
+      glAccountId: action === 'code' ? glAccountId : null,
       counterpartBankAccountId: action === 'transfer' ? counterpartBankAccountId : null,
       memo: memo.trim() || null,
       autoApply,
@@ -184,8 +186,8 @@ export function BankRuleDialog({ open, onClose, rule }: BankRuleDialogProps) {
             <BankRuleActionPage
               action={action}
               onActionChange={setAction}
-              glAccountCode={glAccountCode}
-              onGlAccountChange={setGlAccountCode}
+              glAccountId={glAccountId}
+              onGlAccountChange={setGlAccountId}
               counterpartBankAccountId={counterpartBankAccountId}
               onCounterpartChange={setCounterpartBankAccountId}
               memo={memo}

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-options.ts
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-options.ts
@@ -64,8 +64,10 @@ const DIRECTION_LABELS: Record<Exclude<BankRuleDirection, 'any'>, string> = {
 
 /** The action half of a rule, as it appears in the list: `Code 6100`. */
 export function describeRuleAction(
-  rule: Pick<BankRuleRecord, 'action' | 'glAccountCode' | 'counterpartBankAccountId'>,
-  resolveAccountName: (id: string) => string | undefined
+  rule: Pick<BankRuleRecord, 'action' | 'glAccountId' | 'counterpartBankAccountId'>,
+  resolveAccountName: (id: string) => string | undefined,
+  /** `rule.glAccountId` (task 15 §4) resolved against the chart, for display. */
+  resolveGlAccountCode: (id: string) => string | undefined
 ): string {
   if (rule.action === 'exclude') return 'Exclude'
   if (rule.action === 'transfer') {
@@ -74,7 +76,8 @@ export function describeRuleAction(
       : undefined
     return name ? `Transfer to ${name}` : 'Transfer'
   }
-  return rule.glAccountCode ? `Code ${rule.glAccountCode}` : 'Code'
+  if (!rule.glAccountId) return 'Code'
+  return `Code ${resolveGlAccountCode(rule.glAccountId) ?? rule.glAccountId}`
 }
 
 /**
@@ -83,7 +86,9 @@ export function describeRuleAction(
  */
 export function describeActionDetail(input: {
   action: BankRuleAction
-  glAccountCode: string
+  /** The `gl_account` id a `code` action proposes (task 15 §4). Never a code. */
+  glAccountId: string
+  glAccountCode?: string
   glAccountName?: string
   counterpartName?: string
 }): string {
@@ -91,10 +96,9 @@ export function describeActionDetail(input: {
   if (input.action === 'transfer') {
     return input.counterpartName ? `Transfer to ${input.counterpartName}` : 'Transfer'
   }
-  if (!input.glAccountCode) return 'Code to an account'
-  return input.glAccountName
-    ? `Code to ${input.glAccountCode} · ${input.glAccountName}`
-    : `Code to ${input.glAccountCode}`
+  if (!input.glAccountId) return 'Code to an account'
+  const label = input.glAccountCode ?? input.glAccountId
+  return input.glAccountName ? `Code to ${label} · ${input.glAccountName}` : `Code to ${label}`
 }
 
 /**
@@ -103,7 +107,8 @@ export function describeActionDetail(input: {
  */
 export function describeRule(
   rule: BankRuleRecord,
-  resolveAccountName: (id: string) => string | undefined
+  resolveAccountName: (id: string) => string | undefined,
+  resolveGlAccountCode: (id: string) => string | undefined
 ): string {
   const parts = [
     `${MATCH_FIELD_LABELS[rule.matchField]} ${MATCH_OPERATOR_LABELS[rule.matchOperator]} "${rule.matchValue}"`,
@@ -113,6 +118,6 @@ export function describeRule(
     const name = resolveAccountName(rule.bankAccountId)
     if (name) parts.push(name)
   }
-  parts.push(describeRuleAction(rule, resolveAccountName))
+  parts.push(describeRuleAction(rule, resolveAccountName, resolveGlAccountCode))
   return parts.join(' · ')
 }

--- a/apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx
@@ -44,12 +44,14 @@ import { toastError } from '@auxx/ui/components/toast'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { ListChecks, Pencil, Plus, Power, Trash2 } from 'lucide-react'
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useViewportFill } from '~/hooks/use-viewport-fill'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
+import { useChartAccounts } from '../../gl-account-picker'
 import { BankRuleDialog } from './bank-rule-dialog'
 import { describeRule } from './bank-rule-options'
 
@@ -65,46 +67,6 @@ const PAGE_DESCRIPTION =
 /** The list frame never collapses below this, however short the viewport is. */
 const MIN_FRAME_HEIGHT = 200
 
-/**
- * The exact room left under `SettingsPage`'s sticky header, in px.
- *
- * `SettingsPage` publishes `--settings-viewport-h` and `--settings-sticky-top`
- * on its scroll viewport, but the breadcrumb bar sits ABOVE the sticky block and
- * is in neither number - subtracting only the sticky top overshoots by the
- * breadcrumb's height and the page grows a scrollbar it should not have. So the
- * offset is measured from the element itself: its distance from the viewport's
- * scrolled top is breadcrumbs + header, whatever they happen to be on this page.
- */
-function useViewportFill(ref: React.RefObject<HTMLDivElement | null>): number | undefined {
-  const [height, setHeight] = useState<number | undefined>(undefined)
-
-  useLayoutEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const viewport = el.closest<HTMLElement>('[data-slot="scroll-area-viewport"]')
-    if (!viewport) return
-
-    const measure = () => {
-      const offset =
-        el.getBoundingClientRect().top - viewport.getBoundingClientRect().top + viewport.scrollTop
-      setHeight(Math.max(MIN_FRAME_HEIGHT, viewport.clientHeight - offset))
-    }
-
-    measure()
-    const observer = new ResizeObserver(measure)
-    observer.observe(viewport)
-    // The breadcrumb bar and the sticky header both shift the offset when they
-    // reflow (a wrapped description, a narrower window), and neither resizes the
-    // viewport when it happens. Observing this element itself would loop.
-    for (const sibling of Array.from(viewport.children)) {
-      if (!sibling.contains(el)) observer.observe(sibling)
-    }
-    return () => observer.disconnect()
-  }, [ref])
-
-  return height
-}
-
 export function BankingRulesPage() {
   useRequireCapability(PermissionKey.ledgerView)
   const utils = api.useUtils()
@@ -114,7 +76,7 @@ export function BankingRulesPage() {
   const [editing, setEditing] = useState<BankRuleRecord | null>(null)
 
   const frameRef = useRef<HTMLDivElement>(null)
-  const frameHeight = useViewportFill(frameRef)
+  const frameHeight = useViewportFill(frameRef, MIN_FRAME_HEIGHT)
 
   const rulesQuery = api.bankingRules.list.useQuery()
   const rules = useMemo(() => rulesQuery.data ?? [], [rulesQuery.data])
@@ -127,6 +89,14 @@ export function BankingRulesPage() {
     (id: string) =>
       (accountsQuery.data ?? []).find((account) => account.id === id)?.name ?? undefined,
     [accountsQuery.data]
+  )
+
+  // `rule.glAccountId` is the `gl_account` id (task 15 §4), never a code -
+  // resolved once here against the one chart fetch every picker shares.
+  const { accounts: chartAccounts } = useChartAccounts()
+  const resolveGlAccountCode = useCallback(
+    (id: string) => chartAccounts.find((account) => account.id === id)?.code ?? undefined,
+    [chartAccounts]
   )
 
   const updateRule = api.bankingRules.update.useMutation({
@@ -212,7 +182,7 @@ export function BankingRulesPage() {
                       secondary={
                         <span className='flex flex-wrap items-center gap-1.5'>
                           <span className='text-muted-foreground text-xs'>
-                            {describeRule(rule, resolveAccountName)}
+                            {describeRule(rule, resolveAccountName, resolveGlAccountCode)}
                           </span>
                           {rule.autoApply && (
                             <Badge variant='amber' size='xs'>

--- a/apps/web/src/components/accounting/ui/gl-account-picker.tsx
+++ b/apps/web/src/components/accounting/ui/gl-account-picker.tsx
@@ -42,12 +42,22 @@ export function useChartAccounts() {
 }
 
 export interface GlAccountPickerProps {
-  /** The selected account's CODE, or null. Never an id. */
+  /** The selected account's CODE or id, depending on {@link selectBy}. */
   value: string | null
-  /** Fires with the chosen account's CODE, or null on clear. */
-  onChange: (code: string | null) => void
+  /** Fires with the chosen account's CODE or id (per {@link selectBy}), or null on clear. */
+  onChange: (value: string | null) => void
   /** Restrict the list to these statement classifications. */
   filterTypes?: GlAccountTypeValue[]
+  /**
+   * What `value`/`onChange` carry. Defaults to `'code'`, which is every caller
+   * that still names an account the `P2` way (a manual journal line, a
+   * write-off). Pass `'id'` for the six registry pointers converted by
+   * `plans/accounting/tasks/15-the-account-id-is-the-identity.md` §4
+   * (`bank_account.glAccount`, `bank_rule.glAccount`,
+   * `bank_transaction.glAccount`/`suggestedGlAccount`,
+   * `vendor_bill_line.glAccount`), which store the `gl_account` instance id.
+   */
+  selectBy?: 'code' | 'id'
   disabled?: boolean
   placeholder?: string
   className?: string
@@ -61,9 +71,10 @@ export interface GlAccountPickerProps {
  * (`ledger.chartAccounts`), grouped by statement classification in the
  * standard order ({@link GL_ACCOUNT_TYPES}: asset, liability, equity,
  * revenue, expense). Option label is `code · name`. Value in and out is the
- * account CODE, never an id - that is what `resolveRoles` and the manual
- * entry builder take (decision `P2`: a posting line names an account by code
- * with no foreign key).
+ * account CODE by default - what `resolveRoles` and the manual entry builder
+ * take (decision `P2`: a posting line names an account by code with no
+ * foreign key) - or the account ID when `selectBy="id"` is passed, for the
+ * six registry pointers task 15 §4 converted to hold an id instead.
  *
  * 🛑 A deactivated account renders in its group, disabled, with the reason
  * as a visible tooltip, never simply dropped from the list. This is the
@@ -85,6 +96,7 @@ export function GlAccountPicker({
   value,
   onChange,
   filterTypes,
+  selectBy = 'code',
   disabled = false,
   placeholder = 'Select account…',
   className,
@@ -100,8 +112,9 @@ export function GlAccountPicker({
   )
 
   const selected = useMemo(
-    () => accounts.find((account) => account.code === value) ?? null,
-    [accounts, value]
+    () =>
+      accounts.find((account) => (selectBy === 'id' ? account.id : account.code) === value) ?? null,
+    [accounts, value, selectBy]
   )
 
   function handleOpenChange(next: boolean) {
@@ -156,27 +169,30 @@ export function GlAccountPicker({
             <CommandEmpty>{isLoading ? 'Loading…' : 'No accounts match.'}</CommandEmpty>
             {groups.map((group) => (
               <CommandGroup key={group.type} heading={accountTypeLabel(group.type)}>
-                {group.accounts.map((account) => (
-                  <CommandDetailItem
-                    key={account.code}
-                    value={account.code}
-                    title={`${account.code} · ${account.name}`}
-                    description={
-                      account.isActive
-                        ? undefined
-                        : 'This account is inactive and cannot be posted to.'
-                    }
-                    disabled={!account.isActive}
-                    selected={account.code === value}
-                    selectionMode='check'
-                    className={cn(!account.isActive && 'opacity-60')}
-                    onSelect={() => {
-                      if (!account.isActive) return
-                      onChange(account.code)
-                      handleOpenChange(false)
-                    }}
-                  />
-                ))}
+                {group.accounts.map((account) => {
+                  const optionValue = selectBy === 'id' ? account.id : account.code
+                  return (
+                    <CommandDetailItem
+                      key={account.id}
+                      value={account.id}
+                      title={`${account.code} · ${account.name}`}
+                      description={
+                        account.isActive
+                          ? undefined
+                          : 'This account is inactive and cannot be posted to.'
+                      }
+                      disabled={!account.isActive}
+                      selected={optionValue === value}
+                      selectionMode='check'
+                      className={cn(!account.isActive && 'opacity-60')}
+                      onSelect={() => {
+                        if (!account.isActive) return
+                        onChange(optionValue)
+                        handleOpenChange(false)
+                      }}
+                    />
+                  )
+                })}
               </CommandGroup>
             ))}
           </CommandList>

--- a/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
@@ -86,6 +86,13 @@ const OUTCOMES: Record<PostResultStatus, OutcomeCopy> = {
       'The entry is built, balanced and recorded here exactly as it would be with a provider. There is simply nowhere to push it.',
     tone: 'success',
   },
+  not_enabled: {
+    icon: PlugZap,
+    title: 'Nothing posted. Accounting is not enabled for this organization',
+    detail:
+      'The ledger is off for this organization, so no entry was built or recorded. Enable the accounting module and run its setup to start posting.',
+    tone: 'neutral',
+  },
   disabled: {
     icon: CircleSlash,
     title: 'Posted. Export is switched off',

--- a/apps/web/src/components/accounting/ui/reports/account-lines-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/reports/account-lines-dialog.tsx
@@ -26,7 +26,8 @@ import { formatAccountingDate, formatMinor, formatSignedMinor } from '../ledger/
 import { periodKeyFromDate } from './report-helpers'
 
 export interface AccountLinesDialogTarget {
-  accountCode: string
+  /** The `gl_account` `EntityInstance` id - task 15's identity, not a code. */
+  glAccountId: string
   /** `YYYY-MM-DD`, both optional - an omitted bound reads cumulative-from-the-beginning. */
   from?: string
   to?: string
@@ -57,7 +58,7 @@ export function AccountLinesDialog({
   bookTimeZone,
 }: AccountLinesDialogProps) {
   const { data, isPending } = api.ledgerReports.accountLines.useQuery(
-    { accountCode: target?.accountCode ?? '', from: target?.from, to: target?.to },
+    { glAccountId: target?.glAccountId ?? '', from: target?.from, to: target?.to },
     { enabled: !!target }
   )
 
@@ -65,9 +66,7 @@ export function AccountLinesDialog({
     <Dialog open={!!target} onOpenChange={onOpenChange}>
       <DialogContent size='xl'>
         <DialogHeader>
-          <DialogTitle>
-            {data ? `${data.accountCode} ${data.accountName}`.trim() : target?.accountCode}
-          </DialogTitle>
+          <DialogTitle>{data ? `${data.accountCode} ${data.accountName}`.trim() : ''}</DialogTitle>
           <DialogDescription>
             Every posted line against this account in the range, oldest first, with a running
             balance.

--- a/apps/web/src/components/accounting/ui/reports/balance-sheet.tsx
+++ b/apps/web/src/components/accounting/ui/reports/balance-sheet.tsx
@@ -140,8 +140,8 @@ export function BalanceSheetReportPage() {
                   : undefined
               }
               onRowClick={(row) =>
-                row.meta?.accountCode
-                  ? setDrillDown({ accountCode: row.meta.accountCode, to: asOf })
+                row.meta?.glAccountId
+                  ? setDrillDown({ glAccountId: row.meta.glAccountId, to: asOf })
                   : undefined
               }
             />

--- a/apps/web/src/components/accounting/ui/reports/profit-and-loss.tsx
+++ b/apps/web/src/components/accounting/ui/reports/profit-and-loss.tsx
@@ -146,8 +146,8 @@ export function ProfitAndLossReportPage() {
               rows={rows}
               currency={period.currencyCode}
               onRowClick={(row) =>
-                row.meta?.accountCode
-                  ? setDrillDown({ accountCode: row.meta.accountCode, from, to })
+                row.meta?.glAccountId
+                  ? setDrillDown({ glAccountId: row.meta.glAccountId, from, to })
                   : undefined
               }
             />

--- a/apps/web/src/components/accounting/ui/reports/report-helpers.ts
+++ b/apps/web/src/components/accounting/ui/reports/report-helpers.ts
@@ -166,6 +166,7 @@ export function toStatementTableRows(rows: readonly LibStatementRow[]): Statemen
     values: row.values,
     meta: row.meta
       ? {
+          glAccountId: row.meta.glAccountId,
           accountCode: row.meta.accountCode,
           recordId:
             row.meta.recordId && isRecordId(row.meta.recordId) ? row.meta.recordId : undefined,

--- a/apps/web/src/components/accounting/ui/reports/statement-table.tsx
+++ b/apps/web/src/components/accounting/ui/reports/statement-table.tsx
@@ -36,7 +36,14 @@ export interface StatementRow {
   kind: 'section' | 'line' | 'subtotal' | 'total' | 'computed'
   /** Minor units, one per column. `null` renders {@link EMPTY_CELL}. */
   values: (number | null)[]
-  meta?: { accountCode?: string; recordId?: RecordId; badge?: ReactNode; note?: string }
+  meta?: {
+    /** The `gl_account` `EntityInstance` id (task 15) - the drill-down key. `accountCode` is display only. */
+    glAccountId?: string
+    accountCode?: string
+    recordId?: RecordId
+    badge?: ReactNode
+    note?: string
+  }
   /** Aging drill-down: documents behind a contact, revealed on expand. */
   children?: StatementRow[]
 }

--- a/apps/web/src/components/accounting/ui/reports/trial-balance.tsx
+++ b/apps/web/src/components/accounting/ui/reports/trial-balance.tsx
@@ -128,8 +128,8 @@ export function TrialBalanceReportPage() {
                 query.data ? { label: 'Debits = Credits', ok: query.data.balanced } : undefined
               }
               onRowClick={(row) =>
-                row.meta?.accountCode
-                  ? setDrillDown({ accountCode: row.meta.accountCode, to: asOf })
+                row.meta?.glAccountId
+                  ? setDrillDown({ glAccountId: row.meta.glAccountId, to: asOf })
                   : undefined
               }
             />

--- a/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
@@ -110,7 +110,8 @@ export interface BankAccountPatch {
   last4?: string | null
   type?: 'depository' | 'credit'
   currency?: string | null
-  glAccountCode?: string | null
+  /** The `gl_account` instance id this account maps to (task 15 §4). Never a code. */
+  glAccountId?: string | null
   feedStartDate?: string | null
 }
 
@@ -366,10 +367,11 @@ function BankAccountForm({
               : 'Where this account’s money lives in your chart. Every reconciliation and the cash figure on your balance sheet read this.'
           }>
           <GlAccountPicker
-            value={account.glAccountCode}
+            value={account.glAccountId}
+            selectBy='id'
             filterTypes={glFilterTypes}
             placeholder='Map to an account…'
-            onChange={(code) => onPatch({ glAccountCode: code })}
+            onChange={(id) => onPatch({ glAccountId: id })}
           />
         </FieldPanelRow>
 

--- a/apps/web/src/components/accounting/ui/settings/bank-accounts-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-accounts-list.tsx
@@ -41,6 +41,7 @@ import {
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 import { BankInstitutionIcon } from '~/components/accounting/ui/bank-institution-icon'
+import { useChartAccounts } from '~/components/accounting/ui/gl-account-picker'
 import { asConnectorStatus } from '~/components/data-connectors/ui/connector-status'
 import { ConnectorStatusLine } from '~/components/data-connectors/ui/connector-status-line'
 import { EmptyState } from '~/components/global/empty-state'
@@ -107,6 +108,15 @@ export function BankAccountsList({
   const [collapsed, setCollapsed] = useState<string[]>([])
 
   const groups = useMemo(() => groupByInstitution(accounts, search), [accounts, search])
+
+  // 🛑 `glAccount` is stored as the `gl_account` id, not a code (task 15 §4), so
+  // the badge below has to resolve it. One `ledger.chartAccounts` fetch for the
+  // whole list, React-Query cached - never a lookup per row.
+  const { accounts: chartAccounts } = useChartAccounts()
+  const chartAccountById = useMemo(
+    () => new Map(chartAccounts.map((account) => [account.id, account])),
+    [chartAccounts]
+  )
 
   const toggleInstitution = (institution: string) =>
     setCollapsed((current) =>
@@ -313,15 +323,30 @@ export function BankAccountsList({
                         ) : (
                           <BankAccountStatusChip account={account} />
                         )}
-                        {account.glAccountCode ? (
-                          <Badge variant='outline' size='xs' className='font-mono'>
-                            {account.glAccountCode}
-                          </Badge>
-                        ) : (
-                          <Badge variant='destructive' size='xs'>
-                            Unmapped
-                          </Badge>
-                        )}
+                        {(() => {
+                          const mapped = account.glAccountId
+                            ? chartAccountById.get(account.glAccountId)
+                            : null
+                          if (mapped) {
+                            return (
+                              <Badge variant='outline' size='xs' className='font-mono'>
+                                {mapped.code}
+                              </Badge>
+                            )
+                          }
+                          if (account.glAccountId) {
+                            return (
+                              <Badge variant='destructive' size='xs'>
+                                Account not found
+                              </Badge>
+                            )
+                          }
+                          return (
+                            <Badge variant='destructive' size='xs'>
+                              Unmapped
+                            </Badge>
+                          )
+                        })()}
                       </span>
                     }
                   />

--- a/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
@@ -117,7 +117,7 @@ interface ChartAccountEditorProps {
   accounts: ChartAccountRow[]
   /** Posting roles currently pointed at the selected account. */
   roles: AccountRole[]
-  /** Posted lines per account CODE, from `ledger.chartAccountUsage`. */
+  /** Posted lines per account id (task 15), from `ledger.chartAccountUsage`. */
   usage: Record<string, number>
   /** Phantom draft for this tab, owned by `accounts-settings-page.tsx`. */
   draft: ChartDraftHandle | null
@@ -143,21 +143,19 @@ interface ChartAccountEditorProps {
 }
 
 /**
- * ⚠️ Renumbering does NOT rewrite history, and this pane says so because a person
- * reading a code here is the person who would go and change it. A posting line
- * names an account by CODE with no foreign key, deliberately, so the ledger
- * outlives the chart - which means a renumber leaves every line already posted
- * holding the old code.
+ * A posting line stores the account's ID, not its code (task 15) - renumbering
+ * no longer detaches history from this account at all, so this pane can say
+ * exactly that rather than caution about it.
  *
- * Stated with a COUNT (`ledger.chartAccountUsage`): "142 posted lines carry 1310"
- * is a fact about this account, where a general caution is something to scroll
- * past.
+ * Stated with a COUNT (`ledger.chartAccountUsage`, keyed on `glAccountId`):
+ * "142 posted lines carry this account" is a fact about this account, where a
+ * general caution is something to scroll past.
  */
-function codeDescription(code: string, postedLines: number): string {
+function codeDescription(postedLines: number): string {
   if (postedLines === 0) {
-    return 'The account number. Unique across the chart, and yours to change. Nothing has posted to this code yet, so renumbering costs nothing today.'
+    return 'The account number. Unique across the chart, and yours to change. Nothing has posted to this account yet.'
   }
-  return `${postedLines} posted ${postedLines === 1 ? 'line carries' : 'lines carry'} ${code}. A posted line stores the account code with no foreign key, on purpose, so the ledger outlives the chart - renumbering leaves every one of them holding the old code.`
+  return `${postedLines} posted ${postedLines === 1 ? 'line carries' : 'lines carry'} this account. A posted line stores the account's id, not its code, so renumbering it - unlike deleting it - never affects the ledger.`
 }
 
 export function ChartAccountEditor({
@@ -220,7 +218,7 @@ export function ChartAccountEditor({
       key={account.id}
       account={account}
       roles={roles}
-      postedLines={usage[account.code] ?? 0}
+      postedLines={usage[account.id] ?? 0}
       onDraftChange={onDraftChange}
       onCreate={onCreate}
       onDraftCommitted={onDraftCommitted}
@@ -454,7 +452,7 @@ function ChartAccountForm({
             type={BaseType.STRING}
             showIcon
             isRequired
-            description={codeDescription(values.code, postedLines)}>
+            description={codeDescription(postedLines)}>
             <FieldInputAdapter
               fieldType={FieldType.TEXT}
               value={values.code}

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -71,6 +71,7 @@ import {
   X,
 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { GlAccountPicker, useChartAccounts } from '~/components/accounting/ui/gl-account-picker'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import type { CatalogGroup } from '~/components/money/hooks/use-catalog-groups'
 import type { CatalogItem } from '~/components/money/hooks/use-catalog-items'
@@ -1773,36 +1774,27 @@ function LinePartCellView({
     )
   }
 
-  // GL account edit mode — an account CODE ('2160', '5090'), free text by
-  // registry (`vendor_bill_line.glAccount` is TEXT with a `2160` placeholder),
-  // so a plain input rather than the options menu the category badge uses.
+  // GL account edit mode - `vendor_bill_line.glAccount` holds the `gl_account`
+  // instance id now, not a code (task 15 §4), so a picker replaces the plain
+  // input a code could once be typed into. Writes through on select, the same
+  // "nothing to cancel" rule the match-key editor below already follows -
+  // there is no free text to lose by picking the wrong option twice.
   if (edit?.field === 'glAccount') {
     return (
       <div ref={rootRef} className='flex min-w-0 flex-1 items-center gap-1 py-1'>
-        <input
-          aria-label='GL account'
-          value={edit.value}
-          onChange={(e) => setEdit({ field: 'glAccount', value: e.target.value })}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              confirmText()
-            }
-            if (e.key === 'Escape') setEdit(null)
-          }}
-          autoFocus
-          placeholder='2160'
-          className='h-7 min-w-0 flex-1 rounded-sm border border-primary-200/60 bg-transparent px-2 text-sm tabular-nums outline-none'
-        />
-        <TreeRowButton persistent tooltipText='Save GL account' onClick={confirmText}>
+        <div className='min-w-0 flex-1'>
+          <GlAccountPicker
+            value={edit.value || null}
+            selectBy='id'
+            onChange={(id) => {
+              setEdit(null)
+              onCommitGlAccount(id)
+            }}
+            placeholder='Choose an account…'
+          />
+        </div>
+        <TreeRowButton persistent tooltipText='Done' onClick={() => setEdit(null)}>
           <Check />
-        </TreeRowButton>
-        <TreeRowButton
-          persistent
-          variant='destructive'
-          tooltipText='Cancel'
-          onClick={() => setEdit(null)}>
-          <X />
         </TreeRowButton>
       </div>
     )
@@ -1879,7 +1871,7 @@ function LinePartCellView({
             <Link2 className='size-3.5 shrink-0 text-muted-foreground' />
           </SimpleTooltip>
         )}
-        {glAccount && <GlAccountChip code={glAccount} />}
+        {glAccount && <GlAccountChip glAccountId={glAccount} />}
         {weight !== null && <WeightChip weight={weight} />}
         {chips}
       </div>
@@ -1940,7 +1932,7 @@ function LinePartCellView({
 
       {showGlAccount && glAccount && (
         <GlAccountChip
-          code={glAccount}
+          glAccountId={glAccount}
           onClick={() => setEdit({ field: 'glAccount', value: glAccount })}
         />
       )}
@@ -2037,11 +2029,22 @@ function WeightChip({ weight, onClick }: { weight: number | null; onClick?: () =
   )
 }
 
-/** The account code as a standing chip — set-only, like the category badge. */
-function GlAccountChip({ code, onClick }: { code: string; onClick?: () => void }) {
+/**
+ * The account as a standing chip - set-only, like the category badge.
+ *
+ * `glAccountId` is the `gl_account` instance id (task 15 §4), never a code -
+ * resolved for display against the one chart fetch every picker on this page
+ * shares, and rendered as the raw id only when the chart has not answered yet
+ * or the account cannot be found (an id with no matching account still
+ * renders as itself, the same posture `EntryJournal`'s snapshot rows take).
+ */
+function GlAccountChip({ glAccountId, onClick }: { glAccountId: string; onClick?: () => void }) {
+  const { accounts } = useChartAccounts()
+  const account = accounts.find((candidate) => candidate.id === glAccountId)
+  const label = account ? account.code : glAccountId
   const content = (
     <span className='shrink-0 rounded-sm bg-primary-100 px-1.5 py-0.5 text-[10px] text-muted-foreground leading-none tabular-nums dark:bg-primary-100/60'>
-      {code}
+      {label}
     </span>
   )
   if (!onClick) return <SimpleTooltip content='GL account'>{content}</SimpleTooltip>

--- a/apps/web/src/components/purchasing/vendor-bill/bill-lines-from-purchase-order.test.ts
+++ b/apps/web/src/components/purchasing/vendor-bill/bill-lines-from-purchase-order.test.ts
@@ -15,7 +15,6 @@ import type { PurchaseOrderLineRow } from '../purchase-order/use-purchase-order-
 import {
   billLinesFromPurchaseOrder,
   billLineValuesFromPurchaseOrderLine,
-  GRNI_ACCOUNT_CODE,
   selectBillableLines,
 } from './bill-lines-from-purchase-order'
 
@@ -91,9 +90,12 @@ describe('what a created line carries', () => {
     expect(values.vendor_bill_line_description).toBe('M6 hex bolt')
   })
 
-  it('codes a PO-matched line to GRNI', () => {
-    expect(values.vendor_bill_line_gl_account).toBe(GRNI_ACCOUNT_CODE)
-    expect(GRNI_ACCOUNT_CODE).toBe('2160')
+  // 🛑 task 15 §4: `glAccount` holds a `gl_account` id now, and this function
+  // is pure - it has no org to resolve the `grni` role's account against. A
+  // hardcoded code here would write a value that can never resolve, which is
+  // worse than leaving the field for a human to pick.
+  it('leaves the GL account for a human to pick, rather than write an unresolvable value', () => {
+    expect(values).not.toHaveProperty('vendor_bill_line_gl_account')
   })
 
   // 🛑 THE assertion in this file. Both arms of the three-way match must arrive

--- a/apps/web/src/components/purchasing/vendor-bill/bill-lines-from-purchase-order.ts
+++ b/apps/web/src/components/purchasing/vendor-bill/bill-lines-from-purchase-order.ts
@@ -22,7 +22,12 @@
 //   prefilled  part               the registry already says "STAMPED from the PO
 //                                 line at write, not hand-set"
 //   prefilled  description        not a match input
-//   prefilled  glAccount          `2160` GRNI for a PO-matched line (01 §5.2)
+//   BLANK      glAccount          GRNI for a PO-matched line (01 §5.2), by a
+//                                 `gl_account` id now (task 15 §4) - this
+//                                 pure function has no org to resolve the
+//                                 `grni` role's account against, so it leaves
+//                                 the field for a human to pick rather than
+//                                 write a value that can never resolve
 //   BLANK      quantityBilled     compared against `quantityReceived`
 //   BLANK      unitPrice          compared against `expectedUnitPrice`
 //   BLANK      lineTotal          derived from the two above
@@ -47,8 +52,14 @@
 import type { RecordId } from '@auxx/types/resource'
 import type { PurchaseOrderLineRow } from '../purchase-order/use-purchase-order-lines'
 
-/** GRNI. A PO-matched bill line relieves the accrual the receipt raised (01 §5.2). */
-export const GRNI_ACCOUNT_CODE = '2160'
+// GRNI. A PO-matched bill line relieves the accrual the receipt raised
+// (01 §5.2). `vendor_bill_line.glAccount` holds the `gl_account` instance id
+// now, not a code (task 15 §4), and this file is pure - no db, no org - so it
+// cannot resolve the `grni` role to an account here. A hardcoded code (this
+// used to be `GRNI_ACCOUNT_CODE = '2160'`) would now write a value that can
+// never resolve to any account, which is worse than the renumbering defect it
+// already carried. Left BLANK for a human to pick until a caller with org
+// access resolves the role and passes an id in.
 
 /**
  * The purchase order lines this bill can still be filled from.
@@ -119,7 +130,6 @@ export function billLineValuesFromPurchaseOrderLine(
   const values: Record<string, unknown> = {
     vendor_bill_line_vendor_bill: billRecordId,
     vendor_bill_line_purchase_order_line: line.lineRecordId,
-    vendor_bill_line_gl_account: GRNI_ACCOUNT_CODE,
     vendor_bill_line_sort_order: sortOrder,
   }
   if (line.partRecordId) values.vendor_bill_line_part = line.partRecordId

--- a/apps/web/src/server/api/routers/banking-review.ts
+++ b/apps/web/src/server/api/routers/banking-review.ts
@@ -58,20 +58,39 @@ const listInput = z.object({
   amountMin: z.number().int().optional(),
   amountMax: z.number().int().optional(),
   limit: z.number().int().min(1).max(500).optional(),
-  offset: z.number().int().min(0).optional(),
+  /**
+   * The row offset the next page starts at, as `useInfiniteQuery` hands it
+   * back. Offset paging rather than a keyset cursor because the queue is
+   * ordered on `postedAt` with a `createdAt` tiebreak and both are hydrated
+   * from `FieldValue` joins, so there is no single indexed column to seek on.
+   */
+  cursor: z.number().int().min(0).optional(),
 })
+
+/** Rows per page. The real book reaches 2,390 lines, so the queue must page. */
+const PAGE_SIZE = 50
 
 export const bankingReviewRouter = createTRPCRouter({
   /** The queue itself, newest bank date first. */
   list: permissionProcedure(PermissionKey.ledgerView)
     .input(listInput)
     .query(async ({ ctx, input }) => {
+      const { cursor, limit, ...filters } = input
+      const pageSize = limit ?? PAGE_SIZE
+      const offset = cursor ?? 0
       const result = await listForReview(ctx.db, {
         organizationId: ctx.session.organizationId,
-        ...input,
+        ...filters,
+        limit: pageSize,
+        offset,
       })
       if (result.isErr()) throw result.error
-      return result.value
+      // A full page means there MAY be more; a short one is the end. One extra
+      // empty round trip at an exact multiple beats counting the whole queue.
+      return {
+        items: result.value,
+        nextCursor: result.value.length === pageSize ? offset + pageSize : undefined,
+      }
     }),
 
   /** The stat strip. Scoped to one account when the toolbar has one selected. */
@@ -150,12 +169,12 @@ export const bankingReviewRouter = createTRPCRouter({
       return result.value
     }),
 
-  /** Post `Dr <code> / Cr <bank account>` and stamp the line `coded`. */
+  /** Post `Dr <the coded account> / Cr <bank account>` and stamp the line `coded`. */
   code: permissionProcedure(PermissionKey.ledgerPost)
     .input(
       z.object({
         id: transactionId,
-        glAccountCode: z.string().min(1).max(64),
+        glAccountId: z.string().min(1).max(64),
         contactRecordId: z.string().min(1).optional(),
         memo: z.string().max(1000).optional(),
       })
@@ -165,7 +184,7 @@ export const bankingReviewRouter = createTRPCRouter({
         organizationId: ctx.session.organizationId,
         actorUserId: ctx.session.user.id,
         transactionId: input.id,
-        glAccountCode: input.glAccountCode,
+        glAccountId: input.glAccountId,
         contactRecordId: input.contactRecordId,
         memo: input.memo,
       })
@@ -246,7 +265,7 @@ export const bankingReviewRouter = createTRPCRouter({
           results.push({ id, ok: false, message: line.error.message })
           continue
         }
-        const suggested = line.value?.suggestedGlAccount
+        const suggested = line.value?.suggestedGlAccountId
         if (!suggested) {
           results.push({
             id,
@@ -259,7 +278,7 @@ export const bankingReviewRouter = createTRPCRouter({
           organizationId,
           actorUserId,
           transactionId: id,
-          glAccountCode: suggested,
+          glAccountId: suggested,
           memo: line.value?.suggestionReason ?? undefined,
         })
         results.push(toBulkOutcome(id, coded))
@@ -298,7 +317,7 @@ export const bankingReviewRouter = createTRPCRouter({
     .input(
       z.object({
         ids: z.array(transactionId).min(1).max(100),
-        glAccountCode: z.string().min(1).max(64),
+        glAccountId: z.string().min(1).max(64),
         memo: z.string().max(1000).optional(),
       })
     )
@@ -309,7 +328,7 @@ export const bankingReviewRouter = createTRPCRouter({
           organizationId: ctx.session.organizationId,
           actorUserId: ctx.session.user.id,
           transactionId: id,
-          glAccountCode: input.glAccountCode,
+          glAccountId: input.glAccountId,
           memo: input.memo,
         })
         results.push(toBulkOutcome(id, result))

--- a/apps/web/src/server/api/routers/banking-rules.ts
+++ b/apps/web/src/server/api/routers/banking-rules.ts
@@ -47,7 +47,7 @@ const ruleFields = {
   direction: z.enum(BANK_RULE_DIRECTIONS).optional(),
   bankAccountId: z.string().nullish(),
   action: z.enum(BANK_RULE_ACTIONS),
-  glAccountCode: z.string().max(64).nullish(),
+  glAccountId: z.string().max(64).nullish(),
   counterpartBankAccountId: z.string().nullish(),
   contactId: z.string().nullish(),
   memo: z.string().max(4000).nullish(),
@@ -99,7 +99,7 @@ export const bankingRulesRouter = createTRPCRouter({
         direction: ruleFields.direction,
         bankAccountId: ruleFields.bankAccountId,
         action: ruleFields.action.optional(),
-        glAccountCode: ruleFields.glAccountCode,
+        glAccountId: ruleFields.glAccountId,
         counterpartBankAccountId: ruleFields.counterpartBankAccountId,
         contactId: ruleFields.contactId,
         memo: ruleFields.memo,
@@ -134,7 +134,7 @@ export const bankingRulesRouter = createTRPCRouter({
     .input(
       z.object({
         transactionId: z.string().min(1),
-        glAccountCode: z.string().min(1).max(64),
+        glAccountId: z.string().min(1).max(64),
         name: z.string().max(200).optional(),
       })
     )

--- a/apps/web/src/server/api/routers/banking.ts
+++ b/apps/web/src/server/api/routers/banking.ts
@@ -55,8 +55,9 @@ const dateKey = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
  * Deliberately thin. `last4` is a plain string here and the lib refuses
  * anything but up to four digits with a sentence saying so, because a Zod issue
  * reads `last4: invalid` where the writer explains that `**5381` was pasted with
- * its mask still on. Same for `glAccountCode`: `resolveRoles` refuses an unknown
- * or wrongly-typed code at POST time, naming the account.
+ * its mask still on. Same for `glAccountId`: it names a `gl_account` instance id
+ * (task 15 §4), and the review-queue and posting readers refuse an unknown,
+ * archived or wrongly-typed one at read time, naming the account.
  */
 const bankAccountFields = {
   name: z.string().min(1).max(200),
@@ -64,7 +65,7 @@ const bankAccountFields = {
   last4: z.string().max(8).nullish(),
   type: z.enum(BANK_ACCOUNT_TYPES),
   currency: z.string().max(8).nullish(),
-  glAccountCode: z.string().max(64).nullish(),
+  glAccountId: z.string().max(64).nullish(),
   feedStartDate: dateKey.nullish(),
 }
 
@@ -138,7 +139,7 @@ export const bankingRouter = createTRPCRouter({
           last4: bankAccountFields.last4,
           type: bankAccountFields.type.optional(),
           currency: bankAccountFields.currency,
-          glAccountCode: bankAccountFields.glAccountCode,
+          glAccountId: bankAccountFields.glAccountId,
           feedStartDate: bankAccountFields.feedStartDate,
         })
       )
@@ -159,7 +160,7 @@ export const bankingRouter = createTRPCRouter({
      * `disconnected` and keeps every row, since a coded and posted bank line is
      * the source document of a journal entry.
      *
-     * Gated on `ledgerControl`: `glAccountCode` decides where cash lands, same
+     * Gated on `ledgerControl`: `glAccountId` decides where cash lands, same
      * reasoning as {@link create} above. `status` rides along on the same
      * procedure rather than splitting the write in two.
      */
@@ -172,7 +173,7 @@ export const bankingRouter = createTRPCRouter({
           last4: bankAccountFields.last4,
           type: bankAccountFields.type.optional(),
           currency: bankAccountFields.currency,
-          glAccountCode: bankAccountFields.glAccountCode,
+          glAccountId: bankAccountFields.glAccountId,
           feedStartDate: bankAccountFields.feedStartDate,
           status: z.enum(BANK_ACCOUNT_STATUSES).optional(),
         })

--- a/apps/web/src/server/api/routers/ledger-reports.ts
+++ b/apps/web/src/server/api/routers/ledger-reports.ts
@@ -125,14 +125,15 @@ export const ledgerReportsRouter = createTRPCRouter({
     }),
 
   /**
-   * The drill-down behind one account code - every posted line in the range,
+   * The drill-down behind one account - every posted line in the range,
    * oldest first, with a running natural-sign balance. What a row click on
-   * any statement opens.
+   * any statement opens. Keyed on `glAccountId` (task 15), not a code, so a
+   * renumbered account's history still opens as one drill-down.
    */
   accountLines: permissionProcedure(PermissionKey.ledgerView)
     .input(
       z.object({
-        accountCode: z.string().min(1),
+        glAccountId: z.string().min(1),
         from: dateKey.optional(),
         to: dateKey.optional(),
       })
@@ -140,7 +141,7 @@ export const ledgerReportsRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const result = await readAccountLines(ctx.db, {
         organizationId: ctx.session.organizationId,
-        accountCode: input.accountCode,
+        glAccountId: input.glAccountId,
         from: input.from,
         to: input.to,
       })

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -535,11 +535,11 @@ export const ledgerRouter = createTRPCRouter({
   }),
 
   /**
-   * How many posted lines carry each account CODE.
+   * How many posted lines landed on each account, keyed on `glAccountId` (task 15).
    *
-   * Read by the Chart of accounts tab alone, to turn the renumber caution into a
-   * number: a posting line names an account by code with no foreign key (`P2`),
-   * so renumbering leaves every line already posted holding the old one.
+   * Read by the Chart of accounts tab alone. A posting line stores the
+   * account's id with no foreign key, so a deleted account still reports its
+   * true count - renumbering an account no longer affects this number at all.
    */
   chartAccountUsage: permissionProcedure(PermissionKey.ledgerView).query(async ({ ctx }) => {
     const result = await listChartAccountUsage(ctx.db, ctx.session.organizationId)

--- a/packages/lib/scripts/drive-bank-deposit.ts
+++ b/packages/lib/scripts/drive-bank-deposit.ts
@@ -44,9 +44,9 @@ async function main() {
   // the drive has to pick a mapped one the way the picker does.
   const accounts = await listBankAccounts(database, { organizationId })
   if (accounts.isErr()) throw accounts.error
-  const target = accounts.value.find((account) => !!account.glAccountCode?.trim())
+  const target = accounts.value.find((account) => !!account.glAccountId?.trim())
   if (!target) throw new Error('that organization has no bank account mapped to the chart')
-  console.log(`RESULT bankAccount=${target.name} code=${target.glAccountCode}`)
+  console.log(`RESULT bankAccount=${target.name} glAccountId=${target.glAccountId}`)
 
   const created = await createBankDeposit(database, {
     organizationId,

--- a/packages/lib/scripts/drive-bank-review.ts
+++ b/packages/lib/scripts/drive-bank-review.ts
@@ -78,22 +78,37 @@ async function main() {
     console.log(`RESULT chart 6100=${created.isErr() ? created.error.message : 'created'}`)
   }
 
+  // The registry pointers hold the gl_account instance id now, not a code
+  // (task 15 §4) - re-read the chart so any account just created above is in
+  // the map, and resolve every code this drive uses to an id up front.
+  const refreshedChart = await listChartAccounts(database, organizationId)
+  if (refreshedChart.isErr()) throw refreshedChart.error
+  const chartByCode = new Map(refreshedChart.value.map((account) => [account.code, account.id]))
+  const idForCode = (code: string) => {
+    const id = chartByCode.get(code)
+    if (!id) throw new Error(`This organization's chart has no account coded ${code}`)
+    return id
+  }
+  const cashAccountId = idForCode('1000')
+  const savingsAccountId = idForCode('1010')
+  const feesAccountId = idForCode('6100')
+
   const existing = await listBankAccounts(database, { organizationId })
   if (existing.isErr()) throw existing.error
   let accounts = existing.value
 
-  const ensureAccount = async (name: string, last4: string, glAccountCode: string) => {
+  const ensureAccount = async (name: string, last4: string, glAccountId: string) => {
     const found = accounts.find((account) => account.last4 === last4)
     if (found) {
       // An account another slot's script created may carry no mapping, and an
       // unmapped account is exactly what refuses every code with "there is
       // nothing to credit". Map it rather than leaving the drive half-run.
-      if (found.glAccountCode) return found
+      if (found.glAccountId) return found
       const mapped = await updateBankAccount(database, {
         organizationId,
         actorUserId,
         bankAccountId: found.id,
-        glAccountCode,
+        glAccountId,
       })
       if (mapped.isErr()) throw mapped.error
       accounts = accounts.map((account) => (account.id === found.id ? mapped.value : account))
@@ -106,7 +121,7 @@ async function main() {
       institution: name.split(' ')[0],
       last4,
       type: 'depository',
-      glAccountCode,
+      glAccountId,
       feedStartDate: day(-30),
     })
     if (created.isErr()) throw created.error
@@ -114,10 +129,10 @@ async function main() {
     return created.value
   }
 
-  const primary = await ensureAccount('Bank of America Business Adv', '5381', '1000')
-  const savings = await ensureAccount('Wells Fargo Savings', '6670', '1010')
+  const primary = await ensureAccount('Bank of America Business Adv', '5381', cashAccountId)
+  const savings = await ensureAccount('Wells Fargo Savings', '6670', savingsAccountId)
   console.log(
-    `RESULT accounts primary=${primary.id}(${primary.glAccountCode}) savings=${savings.id}(${savings.glAccountCode})`
+    `RESULT accounts primary=${primary.id}(${primary.glAccountId}) savings=${savings.id}(${savings.glAccountId})`
   )
 
   // ── 2. Statement lines ───────────────────────────────────────────────────
@@ -286,7 +301,7 @@ async function main() {
       organizationId,
       actorUserId,
       transactionId: feeLineId,
-      glAccountCode: '6100',
+      glAccountId: feesAccountId,
       memo: 'Monthly maintenance fee',
     })
     console.log(
@@ -300,7 +315,7 @@ async function main() {
       organizationId,
       actorUserId,
       transactionId: feeLineId,
-      glAccountCode: '6100',
+      glAccountId: feesAccountId,
     })
     console.log(`RESULT recode=${again.isErr() ? again.error.message : 'NOT REFUSED'}`)
   }
@@ -373,14 +388,14 @@ async function main() {
     console.log(
       undone.isErr()
         ? `RESULT undo=REFUSED ${undone.error.message}`
-        : `RESULT undo=${undone.value.transaction.reviewStatus} reversal=${undone.value.post?.status} account=${undone.value.transaction.glAccountCode ?? 'cleared'}`
+        : `RESULT undo=${undone.value.transaction.reviewStatus} reversal=${undone.value.post?.status} account=${undone.value.transaction.glAccountId ?? 'cleared'}`
     )
     // Re-code it, so the org is left with a coded line to look at in the browser.
     const recoded = await codeTransaction(database, {
       organizationId,
       actorUserId,
       transactionId: feeLineId,
-      glAccountCode: '6100',
+      glAccountId: feesAccountId,
       memo: 'Monthly maintenance fee',
     })
     console.log(

--- a/packages/lib/scripts/drive-bank-rules.ts
+++ b/packages/lib/scripts/drive-bank-rules.ts
@@ -10,7 +10,7 @@
 
 import { closePools, database, schema } from '@auxx/database'
 import { eq } from 'drizzle-orm'
-import { createBankAccount, getBankAccount } from '../src/banking'
+import { createBankAccount } from '../src/banking'
 import { codeTransaction } from '../src/banking/review/writes'
 import {
   applySuggestions,
@@ -20,6 +20,7 @@ import {
   suggestFromHistory,
 } from '../src/banking/rules'
 import { getCachedEntityDefId } from '../src/cache'
+import { listChartAccounts } from '../src/postings/role-map'
 import { UnifiedCrudHandler } from '../src/resources/crud/unified-handler'
 import { toRecordId } from '../src/resources/resource-id'
 
@@ -35,15 +36,27 @@ async function main() {
   if (!member) throw new Error('DemoOrg1 has no members')
   const actorUserId = member.userId
 
+  // The registry pointers hold the gl_account instance id now, not a code
+  // (task 15 §4) - resolve the org's own chart codes to ids before using them.
+  const chart = await listChartAccounts(database, ORGANIZATION_ID)
+  if (chart.isErr()) throw chart.error
+  const findByCode = (code: string) => {
+    const found = chart.value.find((a) => a.code === code)
+    if (!found) throw new Error(`DemoOrg1's chart has no account coded ${code}`)
+    return found.id
+  }
+  const cashAccountId = findByCode('1000')
+  const expenseAccountId = findByCode('6100')
+
   // ── 1. A manual bank account, mapped to cash ─────────────────────────
   const account = await createBankAccount(database, {
     organizationId: ORGANIZATION_ID,
     actorUserId,
     name: 'Drive Test Checking (3C)',
-    glAccountCode: '1000',
+    glAccountId: cashAccountId,
   })
   if (account.isErr()) throw account.error
-  console.log(`RESULT account=${account.value.id} gl=${account.value.glAccountCode}`)
+  console.log(`RESULT account=${account.value.id} gl=${account.value.glAccountId}`)
 
   // ── 2. Four bank_transaction lines sharing a matchKey ────────────────
   const bankTransactionDefId = await getCachedEntityDefId(ORGANIZATION_ID, 'bank_transaction')
@@ -77,7 +90,7 @@ async function main() {
       organizationId: ORGANIZATION_ID,
       actorUserId,
       transactionId,
-      glAccountCode: '6100',
+      glAccountId: expenseAccountId,
     })
     if (outcome.isErr()) throw outcome.error
     console.log(
@@ -104,7 +117,7 @@ async function main() {
     matchValue: MATCH_KEY,
     direction: 'any',
     action: 'code',
-    glAccountCode: '6100',
+    glAccountId: expenseAccountId,
     autoApply: false,
   })
   if (rule.isErr()) throw rule.error
@@ -138,7 +151,7 @@ async function main() {
   })
   if (after.isErr() || !after.value) throw new Error('fourth row missing after apply')
   console.log(
-    `RESULT afterApply=reviewStatus:${after.value.reviewStatus} glAccount:${after.value.glAccountCode}`
+    `RESULT afterApply=reviewStatus:${after.value.reviewStatus} glAccount:${after.value.glAccountId}`
   )
 
   // Confirm the standalone suggestion fields on the record, not just the

--- a/packages/lib/src/banking/__tests__/removal-writes.test.ts
+++ b/packages/lib/src/banking/__tests__/removal-writes.test.ts
@@ -126,7 +126,7 @@ function account(partial: Partial<BankAccountRow> = {}): BankAccountRow {
     last4: '5381',
     type: 'depository',
     currency: 'USD',
-    glAccountCode: '1010',
+    glAccountId: '1010',
     feedStartDate: null,
     coverageFrom: '2026-01-01',
     coverageGaps: [],
@@ -390,7 +390,7 @@ describe('archiveBankAccount', () => {
     // GL code and `GlPostingLine` snapshots the code with no foreign key back
     // here, so archiving cannot move the trial balance by a cent. The only way it
     // could is if this path started writing to the chart or the ledger.
-    h.account = account({ hasEverPosted: true, glAccountCode: '1010' })
+    h.account = account({ hasEverPosted: true, glAccountId: '1010' })
     h.linesByState.set('for_review', [{ id: 'txn_a' }])
 
     await archiveBankAccount(fakeDb(), {

--- a/packages/lib/src/banking/client.ts
+++ b/packages/lib/src/banking/client.ts
@@ -249,7 +249,8 @@ export interface BankAccountRow {
   last4: string | null
   type: BankAccountType
   currency: string | null
-  glAccountCode: string | null
+  /** The `gl_account` instance id this account maps to (task 15 §4). No foreign key. */
+  glAccountId: string | null
   feedStartDate: string | null
   coverageFrom: string | null
   coverageGaps: CoverageGap[]

--- a/packages/lib/src/banking/reads.ts
+++ b/packages/lib/src/banking/reads.ts
@@ -702,7 +702,7 @@ async function hydrateBankAccounts(
       last4: read(row.id, 'bank_account_last4')?.valueText ?? null,
       type: resolveBankAccountType(read(row.id, 'bank_account_type')?.optionId),
       currency: read(row.id, 'bank_account_currency')?.valueText ?? null,
-      glAccountCode: read(row.id, 'bank_account_gl_account')?.valueText ?? null,
+      glAccountId: read(row.id, 'bank_account_gl_account')?.valueText ?? null,
       feedStartDate: feedStartDate ? toDateKey(feedStartDate) : null,
       coverageFrom: coverageFrom ? toDateKey(coverageFrom) : null,
       coverageGaps: normalizeCoverageGaps(read(row.id, 'bank_account_coverage_gaps')?.valueJson),

--- a/packages/lib/src/banking/review/__tests__/build-entry.test.ts
+++ b/packages/lib/src/banking/review/__tests__/build-entry.test.ts
@@ -16,14 +16,14 @@ const BASE = {
   transactionId: 'txn_1',
   periodKey: 'BNK-00A1B2',
   txnDate: '2026-09-10',
-  glAccountCode: '6100',
-  bankAccountCode: '1000',
+  glAccountId: 'gla_6100',
+  bankAccountGlAccountId: 'gla_1000',
 }
 
 function side(entry: ReturnType<typeof buildCodedBankEntry>, direction: 'debit' | 'credit') {
   const line = entry.lines.find((candidate) => candidate.direction === direction)
   if (!line) throw new Error(`no ${direction} line`)
-  return line as { accountCode: string; amount: number; memo?: string; sortOrder: number }
+  return line as { glAccountId: string; amount: number; memo?: string; sortOrder: number }
 }
 
 describe('buildCodedBankEntry', () => {
@@ -31,8 +31,8 @@ describe('buildCodedBankEntry', () => {
     const entry = buildCodedBankEntry({ ...BASE, amountMinor: -12_345 })
 
     it('debits the coded account and credits the bank account', () => {
-      expect(side(entry, 'debit').accountCode).toBe('6100')
-      expect(side(entry, 'credit').accountCode).toBe('1000')
+      expect(side(entry, 'debit').glAccountId).toBe('gla_6100')
+      expect(side(entry, 'credit').glAccountId).toBe('gla_1000')
     })
 
     it('discards the sign - the amount is positive and direction carries it', () => {
@@ -48,17 +48,21 @@ describe('buildCodedBankEntry', () => {
   })
 
   describe('money IN', () => {
-    const entry = buildCodedBankEntry({ ...BASE, glAccountCode: '4000', amountMinor: 12_345 })
+    const entry = buildCodedBankEntry({ ...BASE, glAccountId: 'gla_4000', amountMinor: 12_345 })
 
     it('debits the bank account and credits the coded account', () => {
-      expect(side(entry, 'debit').accountCode).toBe('1000')
-      expect(side(entry, 'credit').accountCode).toBe('4000')
+      expect(side(entry, 'debit').glAccountId).toBe('gla_1000')
+      expect(side(entry, 'credit').glAccountId).toBe('gla_4000')
     })
 
     it('is the exact mirror of the outbound entry', () => {
-      const outbound = buildCodedBankEntry({ ...BASE, glAccountCode: '4000', amountMinor: -12_345 })
-      expect(side(entry, 'debit').accountCode).toBe(side(outbound, 'credit').accountCode)
-      expect(side(entry, 'credit').accountCode).toBe(side(outbound, 'debit').accountCode)
+      const outbound = buildCodedBankEntry({
+        ...BASE,
+        glAccountId: 'gla_4000',
+        amountMinor: -12_345,
+      })
+      expect(side(entry, 'debit').glAccountId).toBe(side(outbound, 'credit').glAccountId)
+      expect(side(entry, 'credit').glAccountId).toBe(side(outbound, 'debit').glAccountId)
     })
   })
 
@@ -93,13 +97,13 @@ describe('buildCodedBankEntry', () => {
   })
 
   it('refuses an unmapped bank account, naming the remedy', () => {
-    expect(() => buildCodedBankEntry({ ...BASE, bankAccountCode: '', amountMinor: -100 })).toThrow(
-      /not mapped to a GL account/
-    )
+    expect(() =>
+      buildCodedBankEntry({ ...BASE, bankAccountGlAccountId: '', amountMinor: -100 })
+    ).toThrow(/not mapped to a GL account/)
   })
 
   it('refuses a blank coded account', () => {
-    expect(() => buildCodedBankEntry({ ...BASE, glAccountCode: '  ', amountMinor: -100 })).toThrow(
+    expect(() => buildCodedBankEntry({ ...BASE, glAccountId: '  ', amountMinor: -100 })).toThrow(
       /name the account/
     )
   })
@@ -108,19 +112,19 @@ describe('buildCodedBankEntry', () => {
     // Debiting and crediting one account nets to nothing and hides which side
     // was meant to be different.
     expect(() =>
-      buildCodedBankEntry({ ...BASE, glAccountCode: '1000', amountMinor: -100 })
+      buildCodedBankEntry({ ...BASE, glAccountId: 'gla_1000', amountMinor: -100 })
     ).toThrow(/nets to nothing/)
   })
 
-  it('trims the codes it is handed', () => {
+  it('trims the ids it is handed', () => {
     const entry = buildCodedBankEntry({
       ...BASE,
-      glAccountCode: ' 6100 ',
-      bankAccountCode: ' 1000 ',
+      glAccountId: ' gla_6100 ',
+      bankAccountGlAccountId: ' gla_1000 ',
       amountMinor: -100,
     })
-    expect(side(entry, 'debit').accountCode).toBe('6100')
-    expect(side(entry, 'credit').accountCode).toBe('1000')
+    expect(side(entry, 'debit').glAccountId).toBe('gla_6100')
+    expect(side(entry, 'credit').glAccountId).toBe('gla_1000')
   })
 })
 
@@ -130,20 +134,20 @@ describe('buildTransferEntry', () => {
     periodKey: 'BNK-00C3D4',
     txnDate: '2026-09-10',
     amountMinor: -250_000,
-    fromAccountCode: '1000',
-    toAccountCode: '1010',
+    fromAccountId: 'gla_1000',
+    toAccountId: 'gla_1010',
   }
 
   it('debits the destination and credits the source', () => {
     const entry = buildTransferEntry(TRANSFER)
-    expect(side(entry, 'debit').accountCode).toBe('1010')
-    expect(side(entry, 'credit').accountCode).toBe('1000')
+    expect(side(entry, 'debit').glAccountId).toBe('gla_1010')
+    expect(side(entry, 'credit').glAccountId).toBe('gla_1000')
   })
 
-  it('never touches a revenue or expense account - only the two named codes appear', () => {
+  it('never touches a revenue or expense account - only the two named ids appear', () => {
     const entry = buildTransferEntry(TRANSFER)
-    expect(entry.lines.map((line) => (line as { accountCode: string }).accountCode).sort()).toEqual(
-      ['1000', '1010']
+    expect(entry.lines.map((line) => (line as { glAccountId: string }).glAccountId).sort()).toEqual(
+      ['gla_1000', 'gla_1010']
     )
   })
 
@@ -156,18 +160,18 @@ describe('buildTransferEntry', () => {
     const fromIncoming = buildTransferEntry({ ...TRANSFER, amountMinor: 250_000 })
     expect(fromOutgoing.totalDebit).toBe(250_000)
     expect(fromIncoming.totalDebit).toBe(250_000)
-    expect(side(fromIncoming, 'debit').accountCode).toBe('1010')
+    expect(side(fromIncoming, 'debit').glAccountId).toBe('gla_1010')
   })
 
-  it('refuses two accounts mapped to one GL code', () => {
-    expect(() => buildTransferEntry({ ...TRANSFER, toAccountCode: '1000' })).toThrow(
+  it('refuses two accounts mapped to one GL account', () => {
+    expect(() => buildTransferEntry({ ...TRANSFER, toAccountId: 'gla_1000' })).toThrow(
       /cannot be reconciled apart/
     )
   })
 
   it('refuses when either account is unmapped', () => {
-    expect(() => buildTransferEntry({ ...TRANSFER, fromAccountCode: '' })).toThrow(/both accounts/)
-    expect(() => buildTransferEntry({ ...TRANSFER, toAccountCode: '' })).toThrow(/both accounts/)
+    expect(() => buildTransferEntry({ ...TRANSFER, fromAccountId: '' })).toThrow(/both accounts/)
+    expect(() => buildTransferEntry({ ...TRANSFER, toAccountId: '' })).toThrow(/both accounts/)
   })
 
   it('refuses a zero transfer', () => {

--- a/packages/lib/src/banking/review/__tests__/writes.test.ts
+++ b/packages/lib/src/banking/review/__tests__/writes.test.ts
@@ -62,7 +62,7 @@ vi.mock('../../reads', () => ({
   getBankAccount: async (_db: unknown, params: { bankAccountId: string }) => ({
     isErr: () => false,
     isOk: () => true,
-    value: { id: params.bankAccountId, name: 'Counterpart', glAccountCode: '1010' },
+    value: { id: params.bankAccountId, name: 'Counterpart', glAccountId: '1010' },
   }),
   // The write-once posting high-water mark is stamped on the ACCOUNT beside the
   // line's own `gl_posting_id`, so the treatments resolve the bank_account def
@@ -137,7 +137,7 @@ function row(over: Partial<BankTransactionRow> = {}): BankTransactionRow {
     externalId: 'bt-0001',
     bankAccountId: 'acct_1',
     bankAccountName: 'BoA ···5381',
-    bankAccountCode: '1000',
+    bankAccountGlAccountId: '1000',
     bankAccountConnectorId: null,
     postedAt: '2026-09-10',
     description: 'WIRE FEE',
@@ -147,7 +147,7 @@ function row(over: Partial<BankTransactionRow> = {}): BankTransactionRow {
     source: 'import',
     importBatchId: null,
     reviewStatus: 'for_review',
-    glAccountCode: null,
+    glAccountId: null,
     matchedRecordId: null,
     matchedRecordType: null,
     excludeReason: null,
@@ -155,7 +155,7 @@ function row(over: Partial<BankTransactionRow> = {}): BankTransactionRow {
     reviewedByUserId: null,
     glPostingId: null,
     ruleId: null,
-    suggestedGlAccount: null,
+    suggestedGlAccountId: null,
     suggestionReason: null,
     createdAt: new Date('2026-09-10T00:00:00Z'),
     ...over,
@@ -320,7 +320,7 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     expect(result.isOk()).toBe(true)
     expect(h.postEntry).toHaveBeenCalledTimes(1)
@@ -337,7 +337,7 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     const entry = h.postEntry.mock.calls[0]?.[1].entry
     expect(entry.txnDate).toBe('2026-07-31')
@@ -350,10 +350,10 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     const out = h.postEntry.mock.calls[0]?.[1].entry.lines
-    expect(out.find((l: { direction: string }) => l.direction === 'debit').accountCode).toBe('6100')
+    expect(out.find((l: { direction: string }) => l.direction === 'debit').glAccountId).toBe('6100')
 
     vi.clearAllMocks()
     h.postEntry.mockResolvedValue({ status: 'posted', glPostingId: 'post_3' })
@@ -362,10 +362,10 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_2',
-      glAccountCode: '4000',
+      glAccountId: '4000',
     })
     const inbound = h.postEntry.mock.calls[0]?.[1].entry.lines
-    expect(inbound.find((l: { direction: string }) => l.direction === 'credit').accountCode).toBe(
+    expect(inbound.find((l: { direction: string }) => l.direction === 'credit').glAccountId).toBe(
       '4000'
     )
   })
@@ -377,7 +377,7 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     expect(result.isOk()).toBe(true)
     if (result.isOk()) expect(result.value.post?.status).toBe('period_closed')
@@ -393,7 +393,7 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     expect(h.pin).toHaveBeenCalledWith(
       expect.anything(),
@@ -407,7 +407,7 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_manual',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     expect(h.pin).not.toHaveBeenCalled()
   })
@@ -418,7 +418,7 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     expect(result.isErr()).toBe(true)
     expect(h.postEntry).not.toHaveBeenCalled()
@@ -430,7 +430,7 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     expect(result.isErr()).toBe(true)
     if (result.isErr()) expect(result.error.message).toMatch(/post_0/)
@@ -443,7 +443,7 @@ describe('codeTransaction', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     expect(result.isErr()).toBe(true)
     expect(h.postEntry).not.toHaveBeenCalled()
@@ -458,7 +458,7 @@ describe('transferTransaction', () => {
         id: 'txn_in',
         recordId: 'def_bt:txn_in',
         bankAccountId: 'acct_2',
-        bankAccountCode: '1010',
+        bankAccountGlAccountId: '1010',
         amountMinor: 250_000,
       }),
     ]
@@ -496,10 +496,10 @@ describe('transferTransaction', () => {
       counterpartBankAccountId: 'acct_2',
     })
     const lines = h.postEntry.mock.calls[0]?.[1].entry.lines
-    expect(lines.find((l: { direction: string }) => l.direction === 'debit').accountCode).toBe(
+    expect(lines.find((l: { direction: string }) => l.direction === 'debit').glAccountId).toBe(
       '1010'
     )
-    expect(lines.find((l: { direction: string }) => l.direction === 'credit').accountCode).toBe(
+    expect(lines.find((l: { direction: string }) => l.direction === 'credit').glAccountId).toBe(
       '1000'
     )
   })
@@ -532,7 +532,7 @@ describe('transferTransaction', () => {
         id: 'txn_first',
         recordId: 'def_bt:txn_first',
         bankAccountId: 'acct_2',
-        bankAccountCode: '1010',
+        bankAccountGlAccountId: '1010',
         amountMinor: -250_000,
         reviewStatus: 'coded',
         matchedRecordId: 'acct_1',
@@ -578,7 +578,7 @@ describe('transferTransaction', () => {
         id: 'txn_other',
         recordId: 'def_bt:txn_other',
         bankAccountId: 'acct_2',
-        bankAccountCode: '1010',
+        bankAccountGlAccountId: '1010',
         amountMinor: -250_000,
         reviewStatus: 'coded',
         matchedRecordId: 'acct_9',
@@ -653,7 +653,7 @@ describe('excludeTransaction', () => {
 
 describe('undoReview', () => {
   it('reverses a coded line and puts it back in the queue', async () => {
-    row({ reviewStatus: 'coded', glAccountCode: '6100', glPostingId: 'post_1' })
+    row({ reviewStatus: 'coded', glAccountId: '6100', glPostingId: 'post_1' })
     const result = await undoReview(db, {
       organizationId: ORG,
       actorUserId: ACTOR,
@@ -928,7 +928,7 @@ describe('🛑 bank_account_has_posted - the write-once removal gate', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     expect(result.isOk()).toBe(true)
     expect(updateFor('def_ba:acct_1')).toEqual({ bank_account_has_posted: true })
@@ -955,14 +955,14 @@ describe('🛑 bank_account_has_posted - the write-once removal gate', () => {
       organizationId: ORG,
       actorUserId: ACTOR,
       transactionId: 'txn_1',
-      glAccountCode: '6100',
+      glAccountId: '6100',
     })
     // Nothing reached the books, so nothing may claim it did.
     expect(updateFor('def_ba:acct_1')).toBeUndefined()
   })
 
   it('survives undoReview on the only coded row', async () => {
-    row({ reviewStatus: 'coded', glAccountCode: '6100', glPostingId: 'post_1' })
+    row({ reviewStatus: 'coded', glAccountId: '6100', glPostingId: 'post_1' })
     const result = await undoReview(db, {
       organizationId: ORG,
       actorUserId: ACTOR,
@@ -984,7 +984,7 @@ describe('🛑 bank_account_has_posted - the write-once removal gate', () => {
   })
 
   it('survives the posting reversal undoReview performs', async () => {
-    row({ reviewStatus: 'coded', glAccountCode: '6100', glPostingId: 'post_1' })
+    row({ reviewStatus: 'coded', glAccountId: '6100', glPostingId: 'post_1' })
     await undoReview(db, { organizationId: ORG, actorUserId: ACTOR, transactionId: 'txn_1' })
     // The reversal really did run - it is a SECOND GlPosting, so there is more in
     // the books afterwards, not less - and the flag is still untouched.

--- a/packages/lib/src/banking/review/build-entry.ts
+++ b/packages/lib/src/banking/review/build-entry.ts
@@ -20,20 +20,24 @@
  * both ours and where the alternative is recording an expense and an income
  * that never happened (03 §3.3).
  *
- * ## Why this names accounts by CODE and not by role
+ * ## Why this names accounts by ID and not by role
  *
  * `G8` makes a builder emit a ROLE because a builder cannot know what number
  * this org gave an account. A person coding a bank line is doing the opposite:
  * they are picking a specific account out of THEIR OWN chart, looking at it as
- * it stands right now. That is the same act as a manual journal entry, and it
- * gets the same shape - `build-manual-entry.ts`'s reasoning applies verbatim.
- * The bank side of the entry is the `bank_account` record's mapped code, which
- * a person also chose, on the settings page.
+ * it stands right now. That is the same act as a manual journal entry, except
+ * this one is written in bulk by the review queue over thousands of rows
+ * (`plans/accounting/tasks/15-the-account-id-is-the-identity.md` §4), which is
+ * why the coded account and the bank account's own mapping are both carried as
+ * `gl_account` instance ids rather than codes - a text id with no foreign key,
+ * the same shape `GlRoleAssignment.glAccountId` already uses. The bank side of
+ * the entry is the `bank_account` record's mapped id, which a person also
+ * chose, on the settings page.
  *
- * 🛑 **The resolver is not cheaper for being a code.** `resolveAccountLines`
- * validates both codes against the org's chart with the same five refusals, so
- * an unmapped bank account or a typo'd expense code fails closed at
- * `previewEntry` time with a sentence naming the account.
+ * 🛑 **The resolver is not cheaper for being an id.** `resolveAccountLines`
+ * validates both ids against the org's chart with the same five refusals, so
+ * an unmapped bank account or a coded account that has since been archived
+ * fails closed at `previewEntry` time with a sentence naming the account.
  */
 
 import { UnprocessableEntityError } from '../../errors'
@@ -53,10 +57,10 @@ export interface BuildCodedBankEntryInput {
   txnDate: string
   /** Integer minor units, SIGNED, exactly as the bank said it. */
   amountMinor: number
-  /** The account a person coded this line to, from the org's own chart. */
-  glAccountCode: string
-  /** The `bank_account` record's mapped GL code. The cash side. */
-  bankAccountCode: string
+  /** The `gl_account` id a person coded this line to, from the org's own chart. */
+  glAccountId: string
+  /** The `bank_account` record's mapped `gl_account` id. The cash side. */
+  bankAccountGlAccountId: string
   memo?: string
 }
 
@@ -83,38 +87,38 @@ export interface BuildCodedBankEntryInput {
  * still debits the expense and credits the card, which is what this produces.
  *
  * @throws {UnprocessableEntityError} on a zero, non-integer or non-finite
- *   amount, on a blank account code either side, or when the two codes are the
- *   same account (an entry that nets to nothing and hides which side was wrong).
+ *   amount, a blank account id either side, or when the two ids are the same
+ *   account (an entry that nets to nothing and hides which side was wrong).
  */
 export function buildCodedBankEntry(input: BuildCodedBankEntryInput): BuiltEntry {
   const { transactionId, periodKey, txnDate, amountMinor, memo } = input
-  const glAccountCode = input.glAccountCode?.trim()
-  const bankAccountCode = input.bankAccountCode?.trim()
+  const glAccountId = input.glAccountId?.trim()
+  const bankAccountGlAccountId = input.bankAccountGlAccountId?.trim()
 
   assertPostableAmount(amountMinor)
-  if (!glAccountCode) {
+  if (!glAccountId) {
     throw new UnprocessableEntityError(
       'Coding a bank line has to name the account it belongs in. Pick one from the chart.'
     )
   }
-  if (!bankAccountCode) {
+  if (!bankAccountGlAccountId) {
     throw new UnprocessableEntityError(
       'This bank account is not mapped to a GL account, so there is nothing to credit. ' +
         'Map it on Accounting > Settings > Bank accounts first.'
     )
   }
-  if (glAccountCode === bankAccountCode) {
+  if (glAccountId === bankAccountGlAccountId) {
     throw new UnprocessableEntityError(
-      `Coding this line to ${glAccountCode} would debit and credit the same account, which ` +
-        'nets to nothing. Pick the expense or income account the money actually belongs in.'
+      'Coding this line to the same account it would credit or debit nets to nothing. Pick ' +
+        'the expense or income account the money actually belongs in.'
     )
   }
 
   const amount = Math.abs(amountMinor)
   const outbound = bankLineFlow(amountMinor) === 'out'
   const lines: GlPostingLineInput[] = [
-    line(outbound ? glAccountCode : bankAccountCode, 'debit', amount, transactionId, memo, 0),
-    line(outbound ? bankAccountCode : glAccountCode, 'credit', amount, transactionId, memo, 1),
+    line(outbound ? glAccountId : bankAccountGlAccountId, 'debit', amount, transactionId, memo, 0),
+    line(outbound ? bankAccountGlAccountId : glAccountId, 'credit', amount, transactionId, memo, 1),
   ]
 
   return buildEntry({
@@ -132,10 +136,10 @@ export interface BuildTransferEntryInput {
   txnDate: string
   /** Integer minor units, signed, off the leg the entry is filed on. */
   amountMinor: number
-  /** The GL code of the account the money LEFT. */
-  fromAccountCode: string
-  /** The GL code of the account the money ARRIVED in. */
-  toAccountCode: string
+  /** The `gl_account` id of the account the money LEFT. */
+  fromAccountId: string
+  /** The `gl_account` id of the account the money ARRIVED in. */
+  toAccountId: string
   memo?: string
 }
 
@@ -154,24 +158,24 @@ export interface BuildTransferEntryInput {
  * every month.
  *
  * @throws {UnprocessableEntityError} on a zero or non-integer amount, a blank
- *   code either side, or the same account on both sides.
+ *   id either side, or the same account on both sides.
  */
 export function buildTransferEntry(input: BuildTransferEntryInput): BuiltEntry {
   const { transactionId, periodKey, txnDate, amountMinor, memo } = input
-  const fromAccountCode = input.fromAccountCode?.trim()
-  const toAccountCode = input.toAccountCode?.trim()
+  const fromAccountId = input.fromAccountId?.trim()
+  const toAccountId = input.toAccountId?.trim()
 
   assertPostableAmount(amountMinor)
-  if (!fromAccountCode || !toAccountCode) {
+  if (!fromAccountId || !toAccountId) {
     throw new UnprocessableEntityError(
       'A transfer needs both accounts mapped to a GL account. Map them on ' +
         'Accounting > Settings > Bank accounts first.'
     )
   }
-  if (fromAccountCode === toAccountCode) {
+  if (fromAccountId === toAccountId) {
     throw new UnprocessableEntityError(
-      `Both sides of this transfer resolve to ${fromAccountCode}. Two bank accounts mapped to ` +
-        'one GL code cannot be reconciled apart - map them to separate accounts.'
+      'Both sides of this transfer resolve to the same account. Two bank accounts mapped to ' +
+        'one GL account cannot be reconciled apart - map them to separate accounts.'
     )
   }
 
@@ -181,15 +185,15 @@ export function buildTransferEntry(input: BuildTransferEntryInput): BuiltEntry {
     periodKey,
     txnDate,
     lines: [
-      line(toAccountCode, 'debit', amount, transactionId, memo, 0),
-      line(fromAccountCode, 'credit', amount, transactionId, memo, 1),
+      line(toAccountId, 'debit', amount, transactionId, memo, 0),
+      line(fromAccountId, 'credit', amount, transactionId, memo, 1),
     ],
   })
 }
 
-/** One code line, in the shape `GlPostingLineInput`'s code leg takes. */
+/** One line, in the shape `GlPostingLineInput`'s id leg takes (task 15 §4). */
 function line(
-  accountCode: string,
+  glAccountId: string,
   direction: 'debit' | 'credit',
   amount: number,
   sourceId: string,
@@ -197,7 +201,7 @@ function line(
   sortOrder: number
 ): GlPostingLineInput {
   return {
-    accountCode,
+    glAccountId,
     direction,
     amount,
     memo,

--- a/packages/lib/src/banking/review/client.ts
+++ b/packages/lib/src/banking/review/client.ts
@@ -330,8 +330,11 @@ export interface BankTransactionRow {
   externalId: string | null
   bankAccountId: string | null
   bankAccountName: string | null
-  /** The bank account's mapped GL code. The other half of every coded entry. */
-  bankAccountCode: string | null
+  /**
+   * The bank account's mapped `gl_account` id (task 15 §4). The other half of
+   * every coded entry. Never a code - resolve through the chart for display.
+   */
+  bankAccountGlAccountId: string | null
   /**
    * The `DataConnector` behind the account, or null for a manual one.
    *
@@ -350,7 +353,8 @@ export interface BankTransactionRow {
   source: string | null
   importBatchId: string | null
   reviewStatus: ReviewStatus
-  glAccountCode: string | null
+  /** The `gl_account` id a coded line posted to (task 15 §4). Never a code. */
+  glAccountId: string | null
   matchedRecordId: string | null
   /** Includes `bank_account` - see {@link MATCHED_RECORD_TYPES}. */
   matchedRecordType: MatchedRecordType | null
@@ -359,8 +363,11 @@ export interface BankTransactionRow {
   reviewedByUserId: string | null
   glPostingId: string | null
   ruleId: string | null
-  /** 3C's stored suggestion, or null when 3C has not landed its fields. */
-  suggestedGlAccount: string | null
+  /**
+   * 3C's stored suggestion, or null when 3C has not landed its fields. The
+   * `gl_account` id a "code" suggestion proposes (task 15 §4).
+   */
+  suggestedGlAccountId: string | null
   suggestionReason: string | null
   createdAt: Date | null
 }

--- a/packages/lib/src/banking/review/reads.ts
+++ b/packages/lib/src/banking/review/reads.ts
@@ -24,6 +24,7 @@ import { alias } from 'drizzle-orm/pg-core'
 import type { Result } from 'neverthrow'
 import { getCachedEntityDefId, getOrgCache } from '../../cache'
 import { NotFoundError, UnprocessableEntityError } from '../../errors'
+import { loadChartAccountsById } from '../../postings/chart-accounts'
 import { toRecordId } from '../../resources/resource-id'
 import { type BankAccountRow, toDateKey } from '../client'
 import { guard } from '../guard'
@@ -666,7 +667,7 @@ async function describeReview(
   line: BankTransactionRow
 ): Promise<string | null> {
   if (line.reviewStatus === 'excluded') return line.excludeReason
-  if (line.reviewStatus === 'coded') return line.glAccountCode
+  if (line.reviewStatus === 'coded') return describeGlAccount(db, organizationId, line.glAccountId)
   if (line.reviewStatus === 'matched' && line.matchedRecordId) {
     const [instance] = await db
       .select({ displayName: schema.EntityInstance.displayName })
@@ -681,6 +682,34 @@ async function describeReview(
     return instance?.displayName ?? line.matchedRecordId
   }
   return null
+}
+
+/**
+ * `code name` for one `gl_account` id, for a single history row.
+ *
+ * One id, not a list: a resolver called for a WHOLE queue page belongs in
+ * `hydrateTransactions` below, batched, never here. Swallows a missing chart -
+ * an org whose accounting was never provisioned still has bank history to read
+ * - and falls back to the raw id rather than throwing.
+ */
+async function describeGlAccount(
+  db: Database,
+  organizationId: string,
+  glAccountId: string | null
+): Promise<string | null> {
+  if (!glAccountId) return null
+  try {
+    const { accounts } = await loadChartAccountsById(
+      db,
+      organizationId,
+      [glAccountId],
+      'This organization has no chart of accounts provisioned'
+    )
+    const account = accounts.get(glAccountId)
+    return account ? `${account.code} ${account.name}`.trim() : glAccountId
+  } catch {
+    return glAccountId
+  }
 }
 
 // ── Candidate sources ───────────────────────────────────────────────────────
@@ -1099,7 +1128,7 @@ async function hydrateTransactions(
       externalId: read(row.id, 'bank_transaction_external_id')?.valueText ?? null,
       bankAccountId,
       bankAccountName: account?.name ?? null,
-      bankAccountCode: account?.glAccountCode ?? null,
+      bankAccountGlAccountId: account?.glAccountId ?? null,
       bankAccountConnectorId: account?.connectorId ?? null,
       postedAt: postedAt ? toDateKey(postedAt) : null,
       description: read(row.id, 'bank_transaction_description')?.valueText ?? null,
@@ -1111,7 +1140,7 @@ async function hydrateTransactions(
       source: read(row.id, 'bank_transaction_source')?.optionId ?? null,
       importBatchId: read(row.id, 'bank_transaction_import_batch_id')?.valueText ?? null,
       reviewStatus: narrowReviewStatus(read(row.id, 'bank_transaction_review_status')?.optionId),
-      glAccountCode: read(row.id, 'bank_transaction_gl_account')?.valueText ?? null,
+      glAccountId: read(row.id, 'bank_transaction_gl_account')?.valueText ?? null,
       matchedRecordId: read(row.id, 'bank_transaction_matched_record_id')?.valueText ?? null,
       matchedRecordType: narrowMatchRecordType(
         read(row.id, 'bank_transaction_matched_record_type')?.valueText
@@ -1121,7 +1150,7 @@ async function hydrateTransactions(
       reviewedByUserId: read(row.id, 'bank_transaction_reviewed_by_user_id')?.valueText ?? null,
       glPostingId: read(row.id, 'bank_transaction_gl_posting_id')?.valueText ?? null,
       ruleId: read(row.id, 'bank_transaction_rule_id')?.valueText ?? null,
-      suggestedGlAccount:
+      suggestedGlAccountId:
         readSuggestion(row.id, 'bank_transaction_suggested_gl_account')?.valueText ?? null,
       suggestionReason:
         readSuggestion(row.id, 'bank_transaction_suggestion_reason')?.valueText ?? null,

--- a/packages/lib/src/banking/review/writes.ts
+++ b/packages/lib/src/banking/review/writes.ts
@@ -204,8 +204,8 @@ export async function matchTransaction(
 // ── Code ────────────────────────────────────────────────────────────────────
 
 export interface CodeTransactionInput extends ActorParams {
-  /** An account CODE from the org's own chart, e.g. `'6100'`. */
-  glAccountCode: string
+  /** A `gl_account` id from the org's own chart (task 15 §4). */
+  glAccountId: string
   /**
    * The vendor or customer this line is with.
    *
@@ -240,7 +240,7 @@ export async function codeTransaction(
   db: Database,
   input: CodeTransactionInput
 ): Promise<Result<ReviewOutcome, Error>> {
-  const { organizationId, actorUserId, transactionId, glAccountCode, memo } = input
+  const { organizationId, actorUserId, transactionId, glAccountId, memo } = input
   return guard(
     async () => {
       const ctx = await requireReviewFieldContext(organizationId)
@@ -266,8 +266,8 @@ export async function codeTransaction(
         }),
         txnDate,
         amountMinor: line.amountMinor,
-        glAccountCode,
-        bankAccountCode: line.bankAccountCode ?? '',
+        glAccountId,
+        bankAccountGlAccountId: line.bankAccountGlAccountId ?? '',
         memo: memo ?? line.description ?? undefined,
       })
       if (input.contactRecordId) {
@@ -302,7 +302,7 @@ export async function codeTransaction(
       const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
       await crud.update(toRecordId(ctx.bankTransactionDefId, transactionId), {
         bank_transaction_review_status: 'coded',
-        bank_transaction_gl_account: glAccountCode.trim(),
+        bank_transaction_gl_account: glAccountId.trim(),
         bank_transaction_gl_posting_id: post.glPostingId ?? undefined,
         bank_transaction_reviewed_at: new Date().toISOString(),
         bank_transaction_reviewed_by_user_id: actorUserId,
@@ -324,7 +324,7 @@ export async function codeTransaction(
       logger.info('Coded a bank line', {
         organizationId,
         transactionId,
-        glAccountCode,
+        glAccountId,
         docNumber: post.docNumber,
         pinnedCells: pinned,
       })
@@ -335,7 +335,7 @@ export async function codeTransaction(
       } satisfies ReviewOutcome
     },
     'Failed to code a bank line',
-    { organizationId, transactionId, glAccountCode }
+    { organizationId, transactionId, glAccountId }
   )
 }
 
@@ -479,12 +479,12 @@ export async function transferTransaction(
       // `undoReview` always knows where to look for the posting.
       const filedOn = opposite && !outgoing ? opposite : line
       const other = filedOn === line ? opposite : line
-      const fromAccountCode = outgoing
-        ? line.bankAccountCode
-        : (opposite?.bankAccountCode ?? counterpart.value.glAccountCode)
-      const toAccountCode = outgoing
-        ? (opposite?.bankAccountCode ?? counterpart.value.glAccountCode)
-        : line.bankAccountCode
+      const fromAccountId = outgoing
+        ? line.bankAccountGlAccountId
+        : (opposite?.bankAccountGlAccountId ?? counterpart.value.glAccountId)
+      const toAccountId = outgoing
+        ? (opposite?.bankAccountGlAccountId ?? counterpart.value.glAccountId)
+        : line.bankAccountGlAccountId
 
       const attempt = await countBankTransactionPostings(db, {
         organizationId,
@@ -500,8 +500,8 @@ export async function transferTransaction(
         }),
         txnDate: filedOn.postedAt ?? txnDate,
         amountMinor: filedOn.amountMinor,
-        fromAccountCode: fromAccountCode ?? '',
-        toAccountCode: toAccountCode ?? '',
+        fromAccountId: fromAccountId ?? '',
+        toAccountId: toAccountId ?? '',
         memo: memo ?? `Transfer ${line.description ?? ''}`.trim(),
       })
 
@@ -528,7 +528,7 @@ export async function transferTransaction(
         bank_transaction_review_status: other ? 'matched' : 'coded',
         bank_transaction_matched_record_id: other?.id ?? counterpartBankAccountId,
         bank_transaction_matched_record_type: other ? 'bank_transaction' : 'bank_account',
-        bank_transaction_gl_account: other ? undefined : (toAccountCode ?? undefined),
+        bank_transaction_gl_account: other ? undefined : (toAccountId ?? undefined),
         bank_transaction_gl_posting_id: post.glPostingId ?? undefined,
         bank_transaction_reviewed_at: now,
         bank_transaction_reviewed_by_user_id: actorUserId,

--- a/packages/lib/src/banking/rules/__tests__/apply-suggestions.test.ts
+++ b/packages/lib/src/banking/rules/__tests__/apply-suggestions.test.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
     id: 'rule_1',
     name: 'Wire fees',
     action: 'code',
-    glAccountCode: '6100',
+    glAccountId: '6100',
     autoApply: true,
     memo: null,
     counterpartBankAccountId: null,

--- a/packages/lib/src/banking/rules/__tests__/evaluate.test.ts
+++ b/packages/lib/src/banking/rules/__tests__/evaluate.test.ts
@@ -22,7 +22,7 @@ function rule(overrides: Partial<BankRuleRecord> = {}): BankRuleRecord {
     direction: 'any',
     bankAccountId: null,
     action: 'code',
-    glAccountCode: '6100',
+    glAccountId: '6100',
     counterpartBankAccountId: null,
     contactId: null,
     memo: null,
@@ -175,8 +175,8 @@ describe('evaluateRules', () => {
   describe('priority', () => {
     it('runs lower priority first, and the first match wins', () => {
       const rules = [
-        rule({ id: 'low_priority', priority: 10, glAccountCode: '6200' }),
-        rule({ id: 'high_priority', priority: 1, glAccountCode: '6100' }),
+        rule({ id: 'low_priority', priority: 10, glAccountId: '6200' }),
+        rule({ id: 'high_priority', priority: 1, glAccountId: '6100' }),
       ]
       expect(evaluateRules(rules, txn())?.id).toBe('high_priority')
     })

--- a/packages/lib/src/banking/rules/__tests__/suggest.test.ts
+++ b/packages/lib/src/banking/rules/__tests__/suggest.test.ts
@@ -27,7 +27,7 @@ function baseRow(overrides: Partial<TransactionMatchRow> = {}): TransactionMatch
     matchKey: 'MONTHLY SVC FEE',
     amountMinor: -1500,
     reviewStatus: 'for_review',
-    glAccountCode: null,
+    glAccountId: null,
     ...overrides,
   }
 }
@@ -66,7 +66,7 @@ describe('suggestFromHistory', () => {
     expect(result.isOk()).toBe(true)
     expect(result._unsafeUnwrap()).toEqual({
       source: 'transfer',
-      glAccountCode: null,
+      glAccountId: null,
       recordId: 'acct_2',
       recordType: 'bank_account',
       reason: expect.stringContaining('opposite-sign'),
@@ -89,7 +89,7 @@ describe('suggestFromHistory', () => {
     vi.mocked(reads.getTransactionMatchRow).mockResolvedValue(ok(baseRow()))
     vi.mocked(reads.findTransferCandidate).mockResolvedValue(ok(null))
     vi.mocked(reads.listHistoryMatches).mockResolvedValue(
-      ok([{ glAccountCode: '6100', postedAt: '2026-08-01' }])
+      ok([{ glAccountId: '6100', postedAt: '2026-08-01' }])
     )
 
     const result = await suggestFromHistory(db, { organizationId: 'org_1', transactionId: 'txn_1' })
@@ -101,17 +101,17 @@ describe('suggestFromHistory', () => {
     vi.mocked(reads.findTransferCandidate).mockResolvedValue(ok(null))
     vi.mocked(reads.listHistoryMatches).mockResolvedValue(
       ok([
-        { glAccountCode: '6100', postedAt: '2026-08-01' },
-        { glAccountCode: '6100', postedAt: '2026-07-01' },
-        { glAccountCode: '6100', postedAt: '2026-06-01' },
-        { glAccountCode: '6200', postedAt: '2026-05-01' },
+        { glAccountId: '6100', postedAt: '2026-08-01' },
+        { glAccountId: '6100', postedAt: '2026-07-01' },
+        { glAccountId: '6100', postedAt: '2026-06-01' },
+        { glAccountId: '6200', postedAt: '2026-05-01' },
       ])
     )
 
     const result = await suggestFromHistory(db, { organizationId: 'org_1', transactionId: 'txn_1' })
     expect(result._unsafeUnwrap()).toEqual({
       source: 'history',
-      glAccountCode: '6100',
+      glAccountId: '6100',
       recordId: null,
       recordType: null,
       reason: 'The last 3 lines matching this key were coded to 6100.',
@@ -124,14 +124,14 @@ describe('suggestFromHistory', () => {
     vi.mocked(reads.findTransferCandidate).mockResolvedValue(ok(null))
     vi.mocked(reads.listHistoryMatches).mockResolvedValue(
       ok([
-        { glAccountCode: null, postedAt: '2026-08-10' },
-        { glAccountCode: '6100', postedAt: '2026-08-01' },
-        { glAccountCode: '6100', postedAt: '2026-07-01' },
+        { glAccountId: null, postedAt: '2026-08-10' },
+        { glAccountId: '6100', postedAt: '2026-08-01' },
+        { glAccountId: '6100', postedAt: '2026-07-01' },
       ])
     )
 
     const result = await suggestFromHistory(db, { organizationId: 'org_1', transactionId: 'txn_1' })
-    expect(result._unsafeUnwrap()?.glAccountCode).toBe('6100')
+    expect(result._unsafeUnwrap()?.glAccountId).toBe('6100')
     expect(result._unsafeUnwrap()?.reason).toContain('2 lines')
   })
 

--- a/packages/lib/src/banking/rules/client.ts
+++ b/packages/lib/src/banking/rules/client.ts
@@ -61,7 +61,8 @@ export interface BankRuleRecord {
   /** A `bank_account` entity-instance id, or `null` to match any account. */
   bankAccountId: string | null
   action: BankRuleAction
-  glAccountCode: string | null
+  /** The `gl_account` id a `code` action proposes (task 15 §4). Never a code. */
+  glAccountId: string | null
   /** A `bank_account` entity-instance id, required when `action` is `transfer`. */
   counterpartBankAccountId: string | null
   /** A `contact` entity-instance id, optional context for a `code` action. */
@@ -124,7 +125,8 @@ export function compileSafeRegex(pattern: string): RegExp | null {
 /** What `suggestFromHistory` and a matching rule both produce, before it is written. */
 export interface SuggestionResult {
   source: SuggestionSource
-  glAccountCode: string | null
+  /** The `gl_account` id a "code" suggestion proposes (task 15 §4). Never a code. */
+  glAccountId: string | null
   recordId: string | null
   recordType: string | null
   reason: string

--- a/packages/lib/src/banking/rules/reads.ts
+++ b/packages/lib/src/banking/rules/reads.ts
@@ -216,7 +216,7 @@ async function hydrateRules(
     direction: (read(row.id, 'bank_rule_direction')?.optionId ?? 'any') as BankRuleDirection,
     bankAccountId: read(row.id, 'bank_rule_bank_account')?.valueText ?? null,
     action: (read(row.id, 'bank_rule_action')?.optionId ?? 'code') as BankRuleAction,
-    glAccountCode: read(row.id, 'bank_rule_gl_account')?.valueText ?? null,
+    glAccountId: read(row.id, 'bank_rule_gl_account')?.valueText ?? null,
     counterpartBankAccountId: read(row.id, 'bank_rule_counterpart_bank_account')?.valueText ?? null,
     contactId: read(row.id, 'bank_rule_contact')?.valueText ?? null,
     memo: read(row.id, 'bank_rule_memo')?.valueText ?? null,
@@ -290,7 +290,7 @@ export interface TransactionMatchRow {
   /** Integer minor units, signed. */
   amountMinor: number
   reviewStatus: string | null
-  glAccountCode: string | null
+  glAccountId: string | null
 }
 
 /** One transaction's matching-relevant fields, or `null` when it does not exist. */
@@ -376,7 +376,7 @@ export async function listHistoryMatches(
     matchKey: string
     excludeTransactionId: string
   }
-): Promise<Result<{ glAccountCode: string | null; postedAt: string | null }[], Error>> {
+): Promise<Result<{ glAccountId: string | null; postedAt: string | null }[], Error>> {
   const { organizationId, bankAccountId, matchKey, excludeTransactionId } = params
   return guard(
     async () => {
@@ -431,7 +431,7 @@ export async function listHistoryMatches(
         .filter((row): row is TransactionMatchRow & { postedAt: string } => row.postedAt != null)
         .sort((a, b) => (a.postedAt < b.postedAt ? 1 : a.postedAt > b.postedAt ? -1 : 0))
         .slice(0, HISTORY_SAMPLE_SIZE)
-        .map((row) => ({ glAccountCode: row.glAccountCode, postedAt: row.postedAt }))
+        .map((row) => ({ glAccountId: row.glAccountId, postedAt: row.postedAt }))
     },
     'Failed to read bank transaction history',
     { organizationId, bankAccountId, matchKey }
@@ -593,6 +593,6 @@ async function readTxMatchRows(
     matchKey: read(id, 'bank_transaction_match_key')?.valueText ?? null,
     amountMinor: Math.round(read(id, 'bank_transaction_amount')?.valueNumber ?? 0),
     reviewStatus: read(id, 'bank_transaction_review_status')?.optionId ?? null,
-    glAccountCode: read(id, 'bank_transaction_gl_account')?.valueText ?? null,
+    glAccountId: read(id, 'bank_transaction_gl_account')?.valueText ?? null,
   }))
 }

--- a/packages/lib/src/banking/rules/suggest.ts
+++ b/packages/lib/src/banking/rules/suggest.ts
@@ -12,7 +12,7 @@
  *    within {@link TRANSFER_MATCH_WINDOW_DAYS} is a structural signal a text
  *    match cannot fake, so it is checked first - miscoding a real transfer as
  *    an expense is worse than missing a category suggestion.
- * 2. **History.** The majority GL code among the last
+ * 2. **History.** The majority `gl_account` id among the last
  *    {@link HISTORY_SAMPLE_SIZE} `coded` or `matched` lines sharing this
  *    line's `matchKey` and account.
  */
@@ -20,6 +20,7 @@
 import type { Database } from '@auxx/database'
 import { err, ok, type Result } from 'neverthrow'
 import { NotFoundError } from '../../errors'
+import { loadChartAccountsById } from '../../postings/chart-accounts'
 import { HISTORY_SAMPLE_SIZE, MIN_HISTORY_MATCHES, type SuggestionResult } from './client'
 import { findTransferCandidate, getTransactionMatchRow, listHistoryMatches } from './reads'
 
@@ -50,7 +51,7 @@ export async function suggestFromHistory(
   if (transfer.value) {
     return ok({
       source: 'transfer',
-      glAccountCode: null,
+      glAccountId: null,
       recordId: transfer.value.bankAccountId,
       recordType: 'bank_account',
       reason: 'A matching opposite-sign line was found on another connected account within 3 days.',
@@ -68,37 +69,64 @@ export async function suggestFromHistory(
   })
   if (historyResult.isErr()) return err(historyResult.error)
 
-  const majority = pickMajorityCode(historyResult.value.map((line) => line.glAccountCode))
+  const majority = pickMajorityAccount(historyResult.value.map((line) => line.glAccountId))
   if (!majority || majority.count < MIN_HISTORY_MATCHES) return ok(null)
 
+  const label = await describeGlAccountForReason(db, organizationId, majority.accountId)
   return ok({
     source: 'history',
-    glAccountCode: majority.code,
+    glAccountId: majority.accountId,
     recordId: null,
     recordType: null,
-    reason: `The last ${majority.count} lines matching this key were coded to ${majority.code}.`,
+    reason: `The last ${majority.count} lines matching this key were coded to ${label}.`,
     ruleId: null,
   })
 }
 
 /**
- * The most frequent non-null code, ties broken by whichever appears first
- * (the sample already arrives newest-first, so a tie favours the more recent
- * occurrence). `null` when nothing in the sample carries a code.
+ * The most frequent non-null `gl_account` id, ties broken by whichever appears
+ * first (the sample already arrives newest-first, so a tie favours the more
+ * recent occurrence). `null` when nothing in the sample carries one.
  */
-function pickMajorityCode(codes: (string | null)[]): { code: string; count: number } | null {
+function pickMajorityAccount(
+  accountIds: (string | null)[]
+): { accountId: string; count: number } | null {
   const counts = new Map<string, number>()
-  for (const code of codes) {
-    if (!code) continue
-    counts.set(code, (counts.get(code) ?? 0) + 1)
+  for (const accountId of accountIds) {
+    if (!accountId) continue
+    counts.set(accountId, (counts.get(accountId) ?? 0) + 1)
   }
-  let best: { code: string; count: number } | null = null
-  for (const code of codes) {
-    if (!code) continue
-    const count = counts.get(code)!
-    if (!best || count > best.count) best = { code, count }
+  let best: { accountId: string; count: number } | null = null
+  for (const accountId of accountIds) {
+    if (!accountId) continue
+    const count = counts.get(accountId)!
+    if (!best || count > best.count) best = { accountId, count }
   }
   return best
+}
+
+/**
+ * `code name` for one `gl_account` id, for the suggestion's explanation
+ * sentence. One id, never a list - this runs per transaction. Falls back to
+ * the raw id rather than throwing when the chart cannot be read.
+ */
+async function describeGlAccountForReason(
+  db: Database,
+  organizationId: string,
+  glAccountId: string
+): Promise<string> {
+  try {
+    const { accounts } = await loadChartAccountsById(
+      db,
+      organizationId,
+      [glAccountId],
+      'This organization has no chart of accounts provisioned'
+    )
+    const account = accounts.get(glAccountId)
+    return account ? `${account.code} ${account.name}`.trim() : glAccountId
+  } catch {
+    return glAccountId
+  }
 }
 
 /** Exported for tests: the sample width `listHistoryMatches` is bounded to. */

--- a/packages/lib/src/banking/rules/writes.ts
+++ b/packages/lib/src/banking/rules/writes.ts
@@ -74,7 +74,7 @@ export interface CreateRuleInput {
   direction?: BankRuleDirection
   bankAccountId?: string | null
   action: BankRuleAction
-  glAccountCode?: string | null
+  glAccountId?: string | null
   counterpartBankAccountId?: string | null
   contactId?: string | null
   memo?: string | null
@@ -96,7 +96,7 @@ export interface UpdateRuleInput {
   direction?: BankRuleDirection
   bankAccountId?: string | null
   action?: BankRuleAction
-  glAccountCode?: string | null
+  glAccountId?: string | null
   counterpartBankAccountId?: string | null
   contactId?: string | null
   memo?: string | null
@@ -116,7 +116,7 @@ export async function createRule(
       assertVocabulary('match field', BANK_RULE_MATCH_FIELDS, input.matchField)
       assertVocabulary('direction', BANK_RULE_DIRECTIONS, input.direction ?? 'any')
       assertMatchValue(input.matchOperator, input.matchValue)
-      assertActionPayload(input.action, input.glAccountCode, input.counterpartBankAccountId)
+      assertActionPayload(input.action, input.glAccountId, input.counterpartBankAccountId)
 
       const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
       const created = await crud.create(ctx.bankRuleDefId, {
@@ -132,7 +132,7 @@ export async function createRule(
         bank_rule_direction: input.direction ?? 'any',
         bank_rule_bank_account: input.bankAccountId || undefined,
         bank_rule_action: input.action,
-        bank_rule_gl_account: input.glAccountCode?.trim() || undefined,
+        bank_rule_gl_account: input.glAccountId?.trim() || undefined,
         bank_rule_counterpart_bank_account: input.counterpartBankAccountId || undefined,
         bank_rule_contact: input.contactId || undefined,
         bank_rule_memo: input.memo?.trim() || undefined,
@@ -175,13 +175,13 @@ export async function updateRule(
       assertMatchValue(matchOperator, matchValue)
 
       const action = input.action ?? existing.value.action
-      const glAccountCode =
-        input.glAccountCode !== undefined ? input.glAccountCode : existing.value.glAccountCode
+      const glAccountId =
+        input.glAccountId !== undefined ? input.glAccountId : existing.value.glAccountId
       const counterpart =
         input.counterpartBankAccountId !== undefined
           ? input.counterpartBankAccountId
           : existing.value.counterpartBankAccountId
-      assertActionPayload(action, glAccountCode, counterpart)
+      assertActionPayload(action, glAccountId, counterpart)
 
       const patch: Record<string, unknown> = {}
       if (input.name !== undefined) {
@@ -200,8 +200,8 @@ export async function updateRule(
       if (input.direction !== undefined) patch.bank_rule_direction = input.direction
       if (input.bankAccountId !== undefined) patch.bank_rule_bank_account = input.bankAccountId
       if (input.action !== undefined) patch.bank_rule_action = input.action
-      if (input.glAccountCode !== undefined) {
-        patch.bank_rule_gl_account = input.glAccountCode?.trim() || null
+      if (input.glAccountId !== undefined) {
+        patch.bank_rule_gl_account = input.glAccountId?.trim() || null
       }
       if (input.counterpartBankAccountId !== undefined) {
         patch.bank_rule_counterpart_bank_account = input.counterpartBankAccountId
@@ -264,11 +264,11 @@ export async function createRuleFromTransaction(
     organizationId: string
     actorUserId: string
     transactionId: string
-    glAccountCode: string
+    glAccountId: string
     name?: string
   }
 ): Promise<Result<BankRuleRecord, Error>> {
-  const { organizationId, actorUserId, transactionId, glAccountCode } = params
+  const { organizationId, actorUserId, transactionId, glAccountId } = params
   return guard(
     async () => {
       const rowResult = await getTransactionMatchRow(db, { organizationId, transactionId })
@@ -278,8 +278,8 @@ export async function createRuleFromTransaction(
       if (!row.matchKey) {
         throw new BadRequestError('This line has no match key to build a rule from')
       }
-      const code = glAccountCode.trim()
-      if (!code) throw new BadRequestError('A code rule needs a GL account')
+      const accountId = glAccountId.trim()
+      if (!accountId) throw new BadRequestError('A code rule needs a GL account')
 
       const created = await createRule(db, {
         organizationId,
@@ -291,7 +291,7 @@ export async function createRuleFromTransaction(
         direction: 'any',
         bankAccountId: row.bankAccountId ?? undefined,
         action: 'code',
-        glAccountCode: code,
+        glAccountId: accountId,
       })
       if (created.isErr()) throw created.error
       return created.value
@@ -397,7 +397,7 @@ export async function applySuggestions(
         }
 
         await crud.update(toRecordId(txCtx.bankTransactionDefId, transactionId), {
-          bank_transaction_suggested_gl_account: suggestion.glAccountCode ?? null,
+          bank_transaction_suggested_gl_account: suggestion.glAccountId ?? null,
           bank_transaction_suggested_record_id: suggestion.recordId ?? null,
           bank_transaction_suggested_record_type: suggestion.recordType ?? null,
           bank_transaction_suggestion_reason: suggestion.reason,
@@ -449,12 +449,12 @@ async function tryAutoApplyAction(
   const { organizationId, actorUserId, transactionId, rule } = params
 
   if (rule.action === 'code') {
-    if (!rule.glAccountCode) return false
+    if (!rule.glAccountId) return false
     const outcome = await codeTransaction(db, {
       organizationId,
       actorUserId,
       transactionId,
-      glAccountCode: rule.glAccountCode,
+      glAccountId: rule.glAccountId,
       memo: rule.memo ?? undefined,
     })
     if (outcome.isErr() || outcome.value.transaction.reviewStatus !== 'coded') return false
@@ -510,10 +510,10 @@ async function bumpRuleApplied(
 
 function ruleToSuggestion(rule: BankRuleRecord): SuggestionResult | null {
   if (rule.action === 'code') {
-    if (!rule.glAccountCode) return null
+    if (!rule.glAccountId) return null
     return {
       source: 'rule',
-      glAccountCode: rule.glAccountCode,
+      glAccountId: rule.glAccountId,
       recordId: null,
       recordType: null,
       reason: `Rule "${rule.name}" matched.`,
@@ -524,7 +524,7 @@ function ruleToSuggestion(rule: BankRuleRecord): SuggestionResult | null {
     if (!rule.counterpartBankAccountId) return null
     return {
       source: 'rule',
-      glAccountCode: null,
+      glAccountId: null,
       recordId: rule.counterpartBankAccountId,
       recordType: 'bank_account',
       reason: `Rule "${rule.name}" matched.`,
@@ -534,7 +534,7 @@ function ruleToSuggestion(rule: BankRuleRecord): SuggestionResult | null {
   // exclude
   return {
     source: 'rule',
-    glAccountCode: null,
+    glAccountId: null,
     recordId: null,
     recordType: null,
     reason: `Rule "${rule.name}" matched.`,
@@ -565,13 +565,13 @@ function assertMatchValue(operator: BankRuleMatchOperator, value: string): void 
 
 function assertActionPayload(
   action: BankRuleAction,
-  glAccountCode: string | null | undefined,
+  glAccountId: string | null | undefined,
   counterpartBankAccountId: string | null | undefined
 ): void {
   if (!BANK_RULE_ACTIONS.includes(action)) {
     throw new BadRequestError(`"${action}" is not an action. Use ${BANK_RULE_ACTIONS.join(', ')}`)
   }
-  if (action === 'code' && !glAccountCode?.trim()) {
+  if (action === 'code' && !glAccountId?.trim()) {
     throw new BadRequestError('A code rule needs a GL account')
   }
   if (action === 'transfer' && !counterpartBankAccountId) {

--- a/packages/lib/src/banking/writes.ts
+++ b/packages/lib/src/banking/writes.ts
@@ -101,7 +101,8 @@ export interface CreateBankAccountInput {
   last4?: string | null
   type?: BankAccountType
   currency?: string | null
-  glAccountCode?: string | null
+  /** The `gl_account` instance id this account maps to (task 15 §4). Never a code. */
+  glAccountId?: string | null
   feedStartDate?: string | null
 }
 
@@ -115,7 +116,8 @@ export interface UpdateBankAccountInput {
   last4?: string | null
   type?: BankAccountType
   currency?: string | null
-  glAccountCode?: string | null
+  /** The `gl_account` instance id this account maps to (task 15 §4). Never a code. */
+  glAccountId?: string | null
   feedStartDate?: string | null
   status?: BankAccountStatus
 }
@@ -162,7 +164,7 @@ export async function createBankAccount(
         bank_account_last4: last4 ?? undefined,
         bank_account_type: type,
         bank_account_currency: input.currency?.trim().toUpperCase() || 'USD',
-        bank_account_gl_account: input.glAccountCode?.trim() || undefined,
+        bank_account_gl_account: input.glAccountId?.trim() || undefined,
         bank_account_feed_start_date: input.feedStartDate || undefined,
         bank_account_status: 'manual',
       })
@@ -198,14 +200,14 @@ export async function createBankAccount(
  * account they are the only source there is, so they are editable.
  *
  * `glAccount`, `feedStartDate` and `status` are always auxx's and always
- * editable. Mapping an account to a code is the whole point of the entity, and
- * a connected account is exactly the one that most needs mapping.
+ * editable. Mapping an account to a `gl_account` is the whole point of the
+ * entity, and a connected account is exactly the one that most needs mapping.
  *
- * ⚠️ `glAccountCode` is NOT validated against the org's chart here. The router
- * hands down a code the `GlAccountPicker` sourced from `ledger.chartAccounts`,
- * and `resolveRoles` refuses an unknown or wrongly-typed code at POST time with
- * a sentence naming the account - which is the message worth surfacing. A second
- * authority here would drift from it.
+ * ⚠️ `glAccountId` is NOT validated against the org's chart here. The router
+ * hands down an id the `GlAccountPicker` sourced from `ledger.chartAccounts`,
+ * and `resolveAccountLines`/the review-queue readers refuse an unknown, archived
+ * or wrongly-typed id at read time with a sentence naming the account - which is
+ * the message worth surfacing. A second authority here would drift from it.
  */
 export async function updateBankAccount(
   db: Database,
@@ -253,8 +255,8 @@ export async function updateBankAccount(
         patch.bank_account_currency = input.currency?.trim().toUpperCase() || null
       }
 
-      if (input.glAccountCode !== undefined) {
-        patch.bank_account_gl_account = input.glAccountCode?.trim() || null
+      if (input.glAccountId !== undefined) {
+        patch.bank_account_gl_account = input.glAccountId?.trim() || null
       }
       if (input.feedStartDate !== undefined) {
         patch.bank_account_feed_start_date = input.feedStartDate || null

--- a/packages/lib/src/documents/payload.ts
+++ b/packages/lib/src/documents/payload.ts
@@ -1378,7 +1378,11 @@ export interface BankDepositPdfPayload {
   /** ISO date the deposit hits the bank. THE accounting date. */
   issuedAt: string
   status: string
-  /** GL account CODE the money lands in. */
+  /**
+   * The GL account CODE the money lands in, resolved for display from the
+   * `gl_account` id frozen on the deposit (task 15 §4). Falls back to the raw
+   * id when the account cannot be resolved.
+   */
   bankAccountCode: string
   /** The account's name from the org's chart, when it resolves. */
   bankAccountName: string | null
@@ -1417,10 +1421,11 @@ const DEPOSIT_METHOD_LABELS: Record<string, string> = {
  * the one place that knows a payment's link is the OWNING side - reading the
  * `bank_deposit_payments` inverse here would be a second, staler answer.
  *
- * The bank account's NAME is resolved from the org's chart for legibility only;
- * the CODE is what identifies it, and a code with no matching account still
- * prints (an account can be archived after a deposit was banked, and the slip
- * must still render what actually happened).
+ * The bank account's CODE and NAME are resolved from the org's chart by the
+ * `gl_account` id frozen on the deposit (task 15 §4) - the id is what
+ * identifies it, and an id with no matching account still prints as itself
+ * (an account can be archived after a deposit was banked, and the slip must
+ * still render what actually happened).
  */
 export async function buildBankDepositPdfPayload(params: {
   organizationId: string
@@ -1440,12 +1445,13 @@ export async function buildBankDepositPdfPayload(params: {
     listChartAccounts(database, organizationId),
   ])
 
-  // A chart that will not read is not a reason to refuse a slip: the CODE is
-  // what identifies the account and it is already on the record. The name is
-  // legibility only.
-  const bankAccountName = accounts.isOk()
-    ? (accounts.value.find((account) => account.code === deposit.bankAccountCode)?.name ?? null)
-    : null
+  // A chart that will not read is not a reason to refuse a slip: the ID is
+  // what identifies the account and it is already on the record. The code and
+  // name are legibility only, resolved by id - never derived from a code.
+  const matchedAccount =
+    accounts.isOk() && deposit.bankAccountGlAccountId
+      ? (accounts.value.find((account) => account.id === deposit.bankAccountGlAccountId) ?? null)
+      : null
 
   const payload: BankDepositPdfPayload = {
     documentType: 'bank_deposit',
@@ -1455,8 +1461,8 @@ export async function buildBankDepositPdfPayload(params: {
     // slip on every open (the MQ2 lesson).
     issuedAt: deposit.depositDate ?? deposit.createdAt.toISOString().slice(0, 10),
     status: deposit.status,
-    bankAccountCode: deposit.bankAccountCode ?? '',
-    bankAccountName,
+    bankAccountCode: matchedAccount?.code ?? deposit.bankAccountGlAccountId ?? '',
+    bankAccountName: matchedAccount?.name ?? null,
     reference: deposit.reference,
     contact: { name: '', email: null, phone: null, city: null, region: null, country: null },
     lines: deposit.payments.map((payment) => ({

--- a/packages/lib/src/money/bank-deposits/__tests__/writes.test.ts
+++ b/packages/lib/src/money/bank-deposits/__tests__/writes.test.ts
@@ -37,11 +37,15 @@ const h = vi.hoisted(() => ({
   readWith: [] as unknown[],
   /** What `readDepositBankAccount` answers. Null stands in for "no such account". */
   bankAccount: null as Record<string, unknown> | null,
+  isAccountingEnabled: vi.fn(),
 }))
 
 vi.mock('../../../cache', () => ({
   getOrgCache: () => ({ get: async () => h.settings }),
   getCachedEntityDefId: async () => 'def_bank_deposit',
+}))
+vi.mock('../../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
 }))
 
 vi.mock('../reads', () => ({
@@ -161,7 +165,7 @@ function deposit(overrides: Record<string, unknown> = {}) {
     number: 'DEP-0001',
     depositDate: '2026-09-03',
     bankAccountId: 'acct_1',
-    bankAccountCode: '1000',
+    bankAccountGlAccountId: '1000',
     reference: null,
     status: 'pending',
     totalMinor: 100_00,
@@ -188,7 +192,7 @@ function bankAccount(overrides: Record<string, unknown> = {}) {
   const id = (overrides.id as string) ?? 'acct_1'
   return {
     name: 'Business Checking',
-    glAccountCode: '1000',
+    glAccountId: '1000',
     archivedAt: null,
     ...overrides,
     id,
@@ -210,6 +214,8 @@ beforeEach(() => {
   h.calls = []
   h.readWith = []
   h.bankAccount = bankAccount()
+  h.isAccountingEnabled.mockReset()
+  h.isAccountingEnabled.mockResolvedValue(true)
 })
 
 describe('createBankDeposit refusals', () => {
@@ -246,7 +252,7 @@ describe('createBankDeposit refusals', () => {
   // 🛑 The whole reason the input is an id: an unmapped account has no code to
   // debit, and the alternative to refusing is posting to one nobody named.
   it('refuses a bank account with no chart mapping, and posts nothing', async () => {
-    h.bankAccount = bankAccount({ glAccountCode: null })
+    h.bankAccount = bankAccount({ glAccountId: null })
     const result = await createBankDeposit(db, input)
     expect(result._unsafeUnwrapErr().message).toMatch(/not mapped to an account in the chart/i)
     expect(h.created).toHaveLength(0)
@@ -298,7 +304,7 @@ describe('createBankDeposit refusals', () => {
 })
 
 describe('createBankDeposit posts one cash line', () => {
-  it('posts Dr <the chosen bank account, by code> Cr undeposited_funds for the summed total', async () => {
+  it('posts Dr <the chosen bank account, by id> Cr undeposited_funds for the summed total', async () => {
     h.payments = [
       payment({ paymentId: 'pay_1', amountMinor: 100_00 }),
       payment({ paymentId: 'pay_2', recordId: 'def_payment:pay_2', amountMinor: 250_00 }),
@@ -320,13 +326,13 @@ describe('createBankDeposit posts one cash line', () => {
     expect(entry.periodKey).toBe('DEP-0001')
     expect(entry.txnDate).toBe('2026-09-03')
     expect(entry.lines).toHaveLength(2)
-    // 🛑 A CODE line, not the `cash` role. The role resolves to exactly one
-    // account, so an org with `1000 Checking` and `1020 Savings` would post
-    // every deposit into whichever one the role names and never move the other,
-    // with the entry balancing either way and the field the operator filled in
-    // surviving only in the memo.
+    // 🛑 An ID line, not the `cash` role (task 15 §4). The role resolves to
+    // exactly one account, so an org with `1000 Checking` and `1020 Savings`
+    // would post every deposit into whichever one the role names and never
+    // move the other, with the entry balancing either way and the field the
+    // operator filled in surviving only in the memo.
     expect(entry.lines[0]).toMatchObject({
-      accountCode: '1000',
+      glAccountId: '1000',
       direction: 'debit',
       amount: 350_00,
       sourceId: 'dep_1',
@@ -340,13 +346,13 @@ describe('createBankDeposit posts one cash line', () => {
   })
 
   it('banks into the SECOND bank account when that is the one named', async () => {
-    h.bankAccount = bankAccount({ id: 'acct_2', glAccountCode: '1020' })
+    h.bankAccount = bankAccount({ id: 'acct_2', glAccountId: '1020' })
     await createBankDeposit(db, { ...input, bankAccountId: 'acct_2' })
 
     const entry = h.postedEntries[0] as {
-      lines: Array<{ accountCode?: string; accountRole?: string; memo?: string }>
+      lines: Array<{ glAccountId?: string; accountRole?: string; memo?: string }>
     }
-    expect(entry.lines[0]?.accountCode).toBe('1020')
+    expect(entry.lines[0]?.glAccountId).toBe('1020')
     expect(entry.lines[0]?.memo).toContain('1020')
     expect(h.created[0]?.values.bank_deposit_bank_account).toBe('1020')
   })
@@ -381,6 +387,20 @@ describe('createBankDeposit posts one cash line', () => {
     const result = await createBankDeposit(db, input)
     expect(result.isOk()).toBe(true)
     expect(h.archived).toHaveLength(0)
+  })
+
+  // 🛑 task 17 §3: an org that has never turned accounting on still banks its
+  // payments - the deposit is real whether or not the ledger exists.
+  it('groups the deposit and answers not_enabled without building or posting an entry', async () => {
+    h.isAccountingEnabled.mockResolvedValue(false)
+    const result = await createBankDeposit(db, input)
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().post).toEqual({ status: 'not_enabled' })
+    expect(h.postedEntries).toHaveLength(0)
+    expect(h.created).toHaveLength(1)
+    expect(h.archived).toHaveLength(0)
+    // Nothing posted, so the write-once high-water mark must not be stamped.
+    expect(h.updated.some((u) => 'bank_account_has_posted' in u.values)).toBe(false)
   })
 
   it('rolls the deposit back when the ledger refuses the entry', async () => {
@@ -521,7 +541,7 @@ describe('clearBankDeposit', () => {
 
 describe('updateBankDeposit', () => {
   it('edits reference and account while the deposit is still pending', async () => {
-    h.bankAccount = bankAccount({ id: 'acct_2', glAccountCode: '1010' })
+    h.bankAccount = bankAccount({ id: 'acct_2', glAccountId: '1010' })
     const result = await updateBankDeposit(db, {
       organizationId: ORG,
       actorUserId: USER,

--- a/packages/lib/src/money/bank-deposits/reads.ts
+++ b/packages/lib/src/money/bank-deposits/reads.ts
@@ -111,8 +111,8 @@ export interface DepositBankAccount {
   id: string
   recordId: RecordId
   name: string | null
-  /** Its mapping in the chart, trimmed. Null when the account is unmapped. */
-  glAccountCode: string | null
+  /** Its `gl_account` mapping, trimmed. Null when the account is unmapped. Never a code. */
+  glAccountId: string | null
   archivedAt: Date | null
 }
 
@@ -281,7 +281,7 @@ export async function readDepositBankAccount(
     id: instance.id,
     recordId: toRecordId(ctx.bankAccountDefId, instance.id),
     name: read('bank_account_name')?.trim() || null,
-    glAccountCode: read('bank_account_gl_account')?.trim() || null,
+    glAccountId: read('bank_account_gl_account')?.trim() || null,
     archivedAt: instance.archivedAt,
   }
 }
@@ -817,7 +817,7 @@ async function hydrateDeposits(
       number: read('bank_deposit_number')?.valueText ?? null,
       depositDate: toIsoDay(read('bank_deposit_date')?.valueDate),
       bankAccountId: read('bank_deposit_bank_account_record')?.relatedEntityId ?? null,
-      bankAccountCode: read('bank_deposit_bank_account')?.valueText ?? null,
+      bankAccountGlAccountId: read('bank_deposit_bank_account')?.valueText ?? null,
       reference: read('bank_deposit_reference')?.valueText ?? null,
       status: resolveBankDepositStatus(read('bank_deposit_status')?.optionId),
       totalMinor: Math.round(read('bank_deposit_total')?.valueNumber ?? 0),

--- a/packages/lib/src/money/bank-deposits/types.ts
+++ b/packages/lib/src/money/bank-deposits/types.ts
@@ -51,12 +51,14 @@ export interface BankDepositRecord {
    */
   bankAccountId: string | null
   /**
-   * The GL account CODE the entry POSTED to, frozen when it was built.
+   * The `gl_account` id the entry POSTED to, frozen when it was built (task 15
+   * §4). Never a code.
    *
    * 🛑 Not derived from {@link bankAccountId}: re-mapping a bank account to a
-   * different chart code must not restate a deposit that posted to the old one.
+   * different chart account must not restate a deposit that posted to the old
+   * one.
    */
-  bankAccountCode: string | null
+  bankAccountGlAccountId: string | null
   reference: string | null
   status: BankDepositStatus
   /** Integer minor units. Equals the sum of {@link BankDepositDetail.payments}. */

--- a/packages/lib/src/money/bank-deposits/writes.ts
+++ b/packages/lib/src/money/bank-deposits/writes.ts
@@ -13,13 +13,14 @@
  * ```
  *   payment received                 ->  Dr undeposited_funds  Cr accounts_receivable
  *   payments grouped into a deposit  ->  (no posting - grouping only)
- *   deposit hits the bank            ->  Dr <the chosen bank account, by CODE>
+ *   deposit hits the bank            ->  Dr <the chosen bank account, by gl_account ID>
  *                                             Cr undeposited_funds
  *                                             ^ ONE line, matches ONE bank line
  * ```
  *
- * 🛑 **The debit is the bank account the operator picked, by CODE, not the
- * `cash` role.** An org with two bank accounts (`1000 Checking`, `1020 Savings`)
+ * 🛑 **The debit is the bank account the operator picked, by `gl_account` id
+ * (task 15 §4), not the `cash` role.** An org with two bank accounts (`1000
+ * Checking`, `1020 Savings`)
  * banks into whichever one it names on the slip, and the role resolves to
  * exactly one of them; posting the role would put every deposit into `1000` and
  * `1020` would never move, while the entry balanced and the field the operator
@@ -44,7 +45,9 @@ import { and, asc, eq, inArray } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { getOrgCache } from '../../cache'
 import { BadRequestError, ConflictError, UnprocessableEntityError } from '../../errors'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import { ACCOUNT_ROLES, buildEntry } from '../../postings/build-entry'
+import { loadChartAccountsById } from '../../postings/chart-accounts'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { LEDGER_CURRENCY, postEntry } from '../../postings/post-entry'
 import type { PostResult } from '../../postings/types'
@@ -96,6 +99,11 @@ const ACCEPTED_POST_STATUSES = new Set([
   'healed',
   'not_connected',
   'disabled',
+  // The org has never turned accounting on (task 17 §3). The deposit itself is
+  // real - grouping payments and banking them happens whether or not the org
+  // ever enables the ledger - so this is a success like `not_connected`, not a
+  // refusal to roll back.
+  'not_enabled',
 ])
 
 /** `YYYY-MM-DD`, and nothing else. A posting's date is a contract, not a hint. */
@@ -141,7 +149,7 @@ async function lockPayments(
 
 /**
  * Group N received payments into one bank deposit and post
- * `Dr <bank account code> Cr undeposited_funds`.
+ * `Dr <bank account's gl_account id> Cr undeposited_funds`.
  *
  * ## What it refuses, and why each refusal exists
  *
@@ -177,11 +185,11 @@ async function lockPayments(
  * the link the first one wrote.
  *
  * 🛑 **A refused post is rolled back.** If the ledger will not take the entry -
- * a locked period, a bank account code that is not in this chart - the deposit is
- * archived and the payments are unlinked, so the refusal leaves no half-state and
- * the same cheques can be grouped again once the operator has fixed what the
- * message names. That is NOT a correct-by-editing exception: nothing was posted,
- * so there is nothing to reverse.
+ * a locked period, a bank account mapped to an id that is not in this chart -
+ * the deposit is archived and the payments are unlinked, so the refusal leaves
+ * no half-state and the same cheques can be grouped again once the operator
+ * has fixed what the message names. That is NOT a correct-by-editing
+ * exception: nothing was posted, so there is nothing to reverse.
  */
 export async function createBankDeposit(
   db: Database,
@@ -196,7 +204,7 @@ export async function createBankDeposit(
         throw new BadRequestError('A deposit must name the bank account the money lands in')
       }
       const bankAccount = await requireDepositTarget(db, organizationId, bankAccountId.trim())
-      const bankAccountCode = bankAccount.glAccountCode
+      const bankAccountGlAccountId = bankAccount.glAccountId
       const uniqueIds = [...new Set(paymentIds)]
       if (uniqueIds.length === 0) {
         throw new BadRequestError('Select at least one payment to bank')
@@ -276,7 +284,7 @@ export async function createBankDeposit(
         const crud = new UnifiedCrudHandler(organizationId, actorUserId, txDb)
         const created = await crud.create(depositCtx.depositDefId, {
           bank_deposit_date: depositDate,
-          bank_deposit_bank_account: bankAccountCode,
+          bank_deposit_bank_account: bankAccountGlAccountId,
           bank_deposit_bank_account_record: bankAccount.recordId,
           bank_deposit_reference: reference?.trim() || undefined,
           bank_deposit_status: 'pending',
@@ -298,52 +306,67 @@ export async function createBankDeposit(
         throw new UnprocessableEntityError('The bank deposit could not be read back after writing')
       }
 
-      // ── The posting, after the commit ──────────────────────────────────
-      //
-      // `periodKey` is the deposit's own NUMBER, not a date: two deposits can be
-      // banked on one day, and a date key would collide them into one entry
-      // whose total ties to neither bank line (`postings/doc-number.ts`).
-      const entry = buildEntry({
-        postingType: 'bank_deposit',
-        periodKey: deposit.number ?? depositId,
-        txnDate: depositDate,
-        lines: [
-          {
-            // 🛑 The account the operator NAMED, by code, not the `cash` role.
-            // An org with `1000 Checking` and `1020 Savings` maps the role to
-            // one of them; the role would send every deposit there and leave
-            // the other account dead, with the entry balancing either way.
-            // `resolveAccountLines` validates the code against this org's own
-            // chart and refuses by name when it is missing, inactive or
-            // ambiguous, so a bad code is a rolled-back refusal, not a bad post.
-            accountCode: bankAccountCode,
-            direction: 'debit',
-            amount: totalMinor,
-            memo: `Bank deposit ${deposit.number ?? ''} to ${bankAccountCode}`.trim(),
-            sourceType: BANK_DEPOSIT_SOURCE_TYPE,
-            sourceId: depositId,
-            sortOrder: 0,
-          },
-          {
-            accountRole: ACCOUNT_ROLES.UNDEPOSITED_FUNDS,
-            direction: 'credit',
-            amount: totalMinor,
-            memo: `${paymentCount} payment${paymentCount === 1 ? '' : 's'} banked`,
-            sourceType: BANK_DEPOSIT_SOURCE_TYPE,
-            sourceId: depositId,
-            sortOrder: 1,
-          },
-        ],
-      })
+      // 🛑 The org's own accounting-off case is checked FIRST, before the build
+      // and the post below that exist only to reach the ledger (task 17 §3):
+      // grouping payments into a deposit and banking them is real whether or
+      // not the org has ever turned accounting on.
+      let post: PostResult
+      if (!(await isAccountingEnabled(db, organizationId))) {
+        post = { status: 'not_enabled' }
+      } else {
+        // Resolved once, for the memo only - never posted as a label. A miss
+        // (the account was deleted between the read above and here) falls back
+        // to the id rather than blocking the entry; `resolveAccountLines`
+        // still validates the id itself before anything is claimed.
+        const debitLabel = await describeDebitAccount(db, organizationId, bankAccountGlAccountId)
 
-      const lock = await resolvePeriodLock(organizationId)
-      const post = await postEntry(db, {
-        organizationId,
-        entry,
-        actorUserId,
-        lock,
-        memo: reference ? `Deposit slip ${reference}` : undefined,
-      })
+        // ── The posting, after the commit ────────────────────────────────
+        //
+        // `periodKey` is the deposit's own NUMBER, not a date: two deposits can
+        // be banked on one day, and a date key would collide them into one
+        // entry whose total ties to neither bank line (`postings/doc-number.ts`).
+        const entry = buildEntry({
+          postingType: 'bank_deposit',
+          periodKey: deposit.number ?? depositId,
+          txnDate: depositDate,
+          lines: [
+            {
+              // 🛑 The account the operator NAMED, by id, not the `cash` role.
+              // An org with `1000 Checking` and `1020 Savings` maps the role to
+              // one of them; the role would send every deposit there and leave
+              // the other account dead, with the entry balancing either way.
+              // `resolveAccountLines` validates the id against this org's own
+              // chart and refuses by name when it is missing, inactive or
+              // archived, so a bad id is a rolled-back refusal, not a bad post.
+              glAccountId: bankAccountGlAccountId,
+              direction: 'debit',
+              amount: totalMinor,
+              memo: `Bank deposit ${deposit.number ?? ''} to ${debitLabel}`.trim(),
+              sourceType: BANK_DEPOSIT_SOURCE_TYPE,
+              sourceId: depositId,
+              sortOrder: 0,
+            },
+            {
+              accountRole: ACCOUNT_ROLES.UNDEPOSITED_FUNDS,
+              direction: 'credit',
+              amount: totalMinor,
+              memo: `${paymentCount} payment${paymentCount === 1 ? '' : 's'} banked`,
+              sourceType: BANK_DEPOSIT_SOURCE_TYPE,
+              sourceId: depositId,
+              sortOrder: 1,
+            },
+          ],
+        })
+
+        const lock = await resolvePeriodLock(organizationId)
+        post = await postEntry(db, {
+          organizationId,
+          entry,
+          actorUserId,
+          lock,
+          memo: reference ? `Deposit slip ${reference}` : undefined,
+        })
+      }
 
       if (!ACCEPTED_POST_STATUSES.has(post.status)) {
         await rollbackDeposit(db, organizationId, actorUserId, deposit)
@@ -361,7 +384,13 @@ export async function createBankDeposit(
         await crud.update(deposit.recordId, { bank_deposit_gl_posting_id: post.glPostingId })
       }
 
-      await stampBankAccountHasPosted(db, organizationId, actorUserId, bankAccount)
+      // 🛑 Only when the entry actually posted. `not_enabled`/`not_connected`
+      // leave nothing on the ledger for this account, so stamping the
+      // write-once high-water mark for either would make an account with
+      // nothing on it permanently un-deletable.
+      if (post.glPostingId) {
+        await stampBankAccountHasPosted(db, organizationId, actorUserId, bankAccount)
+      }
 
       logger.info('Recorded bank deposit', {
         organizationId,
@@ -383,13 +412,13 @@ export async function createBankDeposit(
 /**
  * The account this deposit is banked into, refused by name when it cannot take one.
  *
- * 🛑 **An ACCOUNT is named and the CODE is read off it, never the other way
- * round.** The bank feed posts every line on an account against that account's
- * `glAccountCode`, so a code chosen freely from the chart puts the deposit and
- * the statement line it exists to match into two different accounts. Nothing
- * downstream catches it - match candidates are found by amount and date, not by
- * account. The deposit picker has always worked this way; taking the id here is
- * what stops any other caller working differently.
+ * 🛑 **An ACCOUNT is named and the `gl_account` id is read off it, never the
+ * other way round.** The bank feed posts every line on an account against that
+ * account's `glAccountId`, so an id chosen freely from the chart puts the
+ * deposit and the statement line it exists to match into two different
+ * accounts. Nothing downstream catches it - match candidates are found by
+ * amount and date, not by account. The deposit picker has always worked this
+ * way; taking the id here is what stops any other caller working differently.
  *
  * ⚠️ Both refusals are `UnprocessableEntityError` and both name the account,
  * because both are fixed somewhere else in the product rather than by retrying.
@@ -398,7 +427,7 @@ async function requireDepositTarget(
   db: Database,
   organizationId: string,
   bankAccountId: string
-): Promise<DepositBankAccount & { glAccountCode: string }> {
+): Promise<DepositBankAccount & { glAccountId: string }> {
   const ctx = await requireDepositBankAccountContext(organizationId)
   const account = await readDepositBankAccount(db, organizationId, ctx, bankAccountId)
   if (!account) {
@@ -410,13 +439,40 @@ async function requireDepositTarget(
         'Restore it, or pick another account.'
     )
   }
-  if (!account.glAccountCode) {
+  if (!account.glAccountId) {
     throw new UnprocessableEntityError(
       `${account.name ?? 'That bank account'} is not mapped to an account in the chart of ` +
         'accounts, so there is no account to debit. Map it under Banking first.'
     )
   }
-  return { ...account, glAccountCode: account.glAccountCode }
+  return { ...account, glAccountId: account.glAccountId }
+}
+
+/**
+ * `code name` for one `gl_account` id, for a memo or a refusal sentence.
+ *
+ * One id, never a list - this runs once per deposit write, not per row of a
+ * list. Falls back to the raw id rather than throwing: the id itself is what
+ * `resolveAccountLines` validates before anything is claimed, so a display
+ * miss here must never block the write.
+ */
+async function describeDebitAccount(
+  db: Database,
+  organizationId: string,
+  glAccountId: string
+): Promise<string> {
+  try {
+    const { accounts } = await loadChartAccountsById(
+      db,
+      organizationId,
+      [glAccountId],
+      'This organization has no chart of accounts provisioned'
+    )
+    const account = accounts.get(glAccountId)
+    return account ? `${account.code} ${account.name}`.trim() : glAccountId
+  } catch {
+    return glAccountId
+  }
 }
 
 /**
@@ -609,19 +665,22 @@ export async function updateBankDeposit(
           throw new BadRequestError('A deposit must name the bank account the money lands in')
         }
         if (deposit.glPostingId) {
+          const label = deposit.bankAccountGlAccountId
+            ? await describeDebitAccount(db, organizationId, deposit.bankAccountGlAccountId)
+            : 'its bank account'
           throw new ConflictError(
-            `Deposit ${deposit.number ?? depositId} has already posted to ` +
-              `${deposit.bankAccountCode ?? 'its bank account'}, and that account is the debit ` +
-              'leg of an immutable entry. Reverse the posting and regroup to bank it elsewhere.',
+            `Deposit ${deposit.number ?? depositId} has already posted to ${label}, and that ` +
+              'account is the debit leg of an immutable entry. Reverse the posting and regroup ' +
+              'to bank it elsewhere.',
             { glPostingId: deposit.glPostingId }
           )
         }
-        // Only reachable before the entry posts, so the code has nothing frozen
+        // Only reachable before the entry posts, so the id has nothing frozen
         // to disagree with yet and both halves move together. After it posts the
         // branch above refuses, which is what keeps them from ever diverging.
         const account = await requireDepositTarget(db, organizationId, bankAccountId.trim())
         values.bank_deposit_bank_account_record = account.recordId
-        values.bank_deposit_bank_account = account.glAccountCode
+        values.bank_deposit_bank_account = account.glAccountId
       }
       if (reference !== undefined) values.bank_deposit_reference = reference.trim() || null
 

--- a/packages/lib/src/money/credit-memos/__tests__/writes.test.ts
+++ b/packages/lib/src/money/credit-memos/__tests__/writes.test.ts
@@ -1,0 +1,178 @@
+// packages/lib/src/money/credit-memos/__tests__/writes.test.ts
+//
+// plans/accounting/tasks/17-accounting-is-opt-in.md section 3: `issueCreditMemo`
+// checks the accounting-off case before `orderHadFulfillmentBefore` (a read
+// that exists only to decide the builder's `reverseRevenue`) and before the
+// builder itself - so a native credit memo issues on an org that has never
+// turned accounting on exactly as it would on one that has.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  isAccountingEnabled: vi.fn(async () => true),
+  memo: {} as Record<string, unknown>,
+  lines: [] as unknown[],
+  orderHadFulfillmentBefore: vi.fn(async () => false),
+  buildCreditMemoEntry: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  postEntry: vi.fn(),
+  setValuesForEntity: vi.fn(),
+  settleCreditMemo: vi.fn(async () => ({ status: 'issued' })),
+  recomputeTotals: vi.fn(async () => {}),
+}))
+
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../../../database/src/db/schema/index')
+  const enums = await import('../../../../../database/src/enums')
+  return { schema, ...enums, database: {} }
+})
+vi.mock('../../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
+}))
+vi.mock('../../../cache', () => ({
+  getEntityDefIdResolver: async () => (type: string) => type,
+}))
+vi.mock('../../../postings/build-credit-memo-entry', () => ({
+  CREDIT_MEMO_POSTING_TYPE: 'credit_memo',
+  CREDIT_MEMO_SOURCE_TYPE: 'credit_memo',
+  buildCreditMemoEntry: h.buildCreditMemoEntry,
+}))
+vi.mock('../../../postings/list-postings', () => ({
+  listPostingsForSource: vi.fn(async () => ({ isOk: () => true, value: [] })),
+}))
+vi.mock('../../../postings/period-lock', () => ({
+  resolvePeriodLock: h.resolvePeriodLock,
+}))
+vi.mock('../../../postings/post-entry', () => ({
+  LEDGER_CURRENCY: 'USD',
+  postEntry: h.postEntry,
+  previewEntry: vi.fn(),
+}))
+vi.mock('../../../postings/reverse-entry', () => ({ reverseEntry: vi.fn() }))
+vi.mock('../../../settings/settings-service', () => ({
+  getOrganizationSetting: async () => null,
+}))
+vi.mock('../../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    setValuesForEntity = h.setValuesForEntity
+  },
+}))
+vi.mock('../../totals-hooks', () => ({ recomputeTotals: h.recomputeTotals }))
+vi.mock('../reads', () => ({
+  requireCreditMemo: async () => h.memo,
+  loadCreditMemoLines: async () => h.lines,
+  orderHadFulfillmentBefore: h.orderHadFulfillmentBefore,
+  loadInvoiceForCredit: vi.fn(),
+  loadInvoiceLinesForCredit: vi.fn(),
+  sumCreditMemoApplications: vi.fn(async () => 0),
+  sumSucceededCreditMemoRefunds: vi.fn(async () => 0),
+}))
+vi.mock('../settle', () => ({
+  CREDIT_MEMO_STATUS_BYPASS: new Set(['credit_memo_status']),
+  settleCreditMemo: h.settleCreditMemo,
+}))
+
+import type { Database } from '@auxx/database'
+import { issueCreditMemo } from '../writes'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+const MEMO_ID = 'cm_1'
+const db = {} as Database
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isAccountingEnabled.mockResolvedValue(true)
+  h.memo = {
+    id: MEMO_ID,
+    number: 'CM-0001',
+    status: 'draft',
+    source: 'native',
+    reason: null,
+    issuedAt: '2026-09-01',
+    note: null,
+    contactInstanceId: 'contact_1',
+    invoiceInstanceId: null,
+    orderInstanceId: null,
+    subtotalMinor: 100_00,
+    taxTotalMinor: 0,
+    totalMinor: 100_00,
+    amountAppliedMinor: 0,
+    amountRefundedMinor: 0,
+    balanceMinor: 100_00,
+    lineIds: ['line_1'],
+    hasSettlementFields: true,
+  }
+  h.lines = [
+    {
+      id: 'line_1',
+      description: 'Widget',
+      qty: 1,
+      unitPriceMinor: 100_00,
+      subtotalMinor: 100_00,
+      taxTotalMinor: null,
+      disposition: null,
+      lineItemInstanceId: null,
+      sortOrder: 0,
+    },
+  ]
+  h.orderHadFulfillmentBefore.mockResolvedValue(false)
+  h.buildCreditMemoEntry.mockReturnValue({
+    entry: { postingType: 'credit_memo', periodKey: 'CM-0001', txnDate: '2026-09-01', lines: [] },
+  })
+  h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
+  h.postEntry.mockResolvedValue({
+    status: 'posted',
+    glPostingId: 'gl_1',
+    docNumber: 'AUXX-CRM-0001',
+  })
+  h.settleCreditMemo.mockResolvedValue({ status: 'issued' })
+})
+
+describe('accounting not enabled', () => {
+  beforeEach(() => {
+    h.isAccountingEnabled.mockResolvedValue(false)
+  })
+
+  it('issues the memo without building, locking, or posting an entry', async () => {
+    const result = await issueCreditMemo(db, {
+      organizationId: ORG,
+      userId: USER,
+      creditMemoInstanceId: MEMO_ID,
+    })
+
+    expect(result.postingId).toBeNull()
+    expect(result.docNumber).toBeNull()
+    expect(h.buildCreditMemoEntry).not.toHaveBeenCalled()
+    expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+    // The read that exists only to decide the builder's `reverseRevenue`.
+    expect(h.orderHadFulfillmentBefore).not.toHaveBeenCalled()
+  })
+
+  it('still flips the status to issued', async () => {
+    await issueCreditMemo(db, {
+      organizationId: ORG,
+      userId: USER,
+      creditMemoInstanceId: MEMO_ID,
+    })
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+    const write = h.setValuesForEntity.mock.calls[0]![0]
+    expect(write.values).toContainEqual({ fieldId: 'credit_memo_status', value: 'issued' })
+  })
+})
+
+describe('accounting enabled', () => {
+  it('builds, locks, and posts before flipping the status', async () => {
+    const result = await issueCreditMemo(db, {
+      organizationId: ORG,
+      userId: USER,
+      creditMemoInstanceId: MEMO_ID,
+    })
+
+    expect(h.buildCreditMemoEntry).toHaveBeenCalledTimes(1)
+    expect(h.postEntry).toHaveBeenCalledTimes(1)
+    expect(result.postingId).toBe('gl_1')
+  })
+})

--- a/packages/lib/src/money/credit-memos/writes.ts
+++ b/packages/lib/src/money/credit-memos/writes.ts
@@ -16,6 +16,7 @@ import { toRecordId } from '@auxx/types/resource'
 import { getEntityDefIdResolver } from '../../cache'
 import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../../errors'
 import { FieldValueService } from '../../field-values/field-value-service'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
   type BuiltCreditMemoEntry,
   buildCreditMemoEntry,
@@ -29,7 +30,7 @@ import { periodKeyForDate } from '../../postings/periods'
 import { LEDGER_CURRENCY, postEntry, previewEntry } from '../../postings/post-entry'
 import { reverseEntry } from '../../postings/reverse-entry'
 import { OPENING_BASELINE_SETTING_KEYS } from '../../postings/setup-readiness'
-import type { EntryPreview } from '../../postings/types'
+import type { EntryPreview, PostResult } from '../../postings/types'
 import { UnifiedCrudHandler } from '../../resources/crud'
 import { getOrganizationSetting } from '../../settings/settings-service'
 import { roundCents } from '../totals'
@@ -53,6 +54,12 @@ import { CREDIT_MEMO_STATUS_BYPASS, settleCreditMemo } from './settle'
  * The statuses that mean the LEDGER took the entry. The same set
  * `postInvoiceIssuance` accepts, for the same reasons: a refused EXPORT still
  * returns `posted`, and an org with no accounting system is a first-class case.
+ *
+ * `not_enabled` is in for the newest reason: an org that has never turned the
+ * accounting module on is a first-class case too (task 17 section 3). In
+ * practice {@link issueCreditMemo} never reaches this set with `not_enabled` -
+ * it short-circuits before the ledger is ever asked - but the value is here so
+ * this set stays the complete list decision P1 and task 17 promise.
  */
 const ACCEPTED_POST_STATUSES = new Set<string>([
   'posted',
@@ -60,6 +67,7 @@ const ACCEPTED_POST_STATUSES = new Set<string>([
   'healed',
   'not_connected',
   'disabled',
+  'not_enabled',
 ])
 
 /** The statuses that mean a reversal landed. Same set as `reverseInvoiceIssuance`. */
@@ -398,21 +406,37 @@ interface ResolvedIssue {
   memo: CreditMemoRecord
   lines: CreditMemoLineRecord[]
   issuedAt: string
-  built: BuiltCreditMemoEntry
+  /**
+   * Absent when the caller asked to skip it (`resolveIssue`'s `buildEntry: false`)
+   * because the org has never enabled accounting - see the call site in
+   * {@link issueCreditMemo}. {@link previewIssueCreditMemo} always asks for it.
+   */
+  built: BuiltCreditMemoEntry | undefined
 }
 
 /**
- * Refuse an issue that cannot be made, resolve its date and both legs, and
- * build the entry. Shared by {@link issueCreditMemo} and
- * {@link previewIssueCreditMemo} so the two can never disagree about what is
- * refusable before the ledger is asked.
+ * Refuse an issue that cannot be made, resolve its date and both legs, and -
+ * unless the caller says otherwise - build the entry. Shared by
+ * {@link issueCreditMemo} and {@link previewIssueCreditMemo} so the two can
+ * never disagree about what is refusable before the ledger is asked.
  *
  * The totals the entry carries are summed from the LINES here, not read off
  * the memo's mirrors, so a preview of a draft whose reconciler drain has not
  * run yet still shows the right numbers; `issueCreditMemo` recomputes the
  * mirrors before calling this so the stored totals match what posts.
+ *
+ * `buildEntry: false` skips `orderHadFulfillmentBefore` (a read that exists
+ * only to decide the builder's `reverseRevenue`) and the builder call itself -
+ * {@link issueCreditMemo} passes it when the org has never turned accounting
+ * on (task 17 section 3), so a credit memo can still issue with none of that
+ * work done and no ledger-specific refusal (a foreign currency, say) reachable
+ * for an org this module does nothing for.
  */
-async function resolveIssue(db: Database, input: IssueCreditMemoInput): Promise<ResolvedIssue> {
+async function resolveIssue(
+  db: Database,
+  input: IssueCreditMemoInput,
+  options: { buildEntry: boolean } = { buildEntry: true }
+): Promise<ResolvedIssue> {
   const { organizationId, creditMemoInstanceId } = input
   const memo = await requireCreditMemo(db, organizationId, creditMemoInstanceId)
 
@@ -471,6 +495,10 @@ async function resolveIssue(db: Database, input: IssueCreditMemoInput): Promise<
     })
   }
 
+  if (!options.buildEntry) {
+    return { memo, lines, issuedAt, built: undefined }
+  }
+
   // Native: always reverses revenue, because it exists only where an invoice
   // was issued. Channel: only when the order shipped before the memo's date,
   // because `build-fulfillment-entry.ts` recognised nothing otherwise.
@@ -517,9 +545,11 @@ export async function previewIssueCreditMemo(
   input: IssueCreditMemoInput
 ): Promise<EntryPreview> {
   const { organizationId } = input
-  const { built } = await resolveIssue(db, input)
+  // Always asks for the entry - a preview with nothing to preview is not a
+  // preview - so `built` is always present here.
+  const { built } = await resolveIssue(db, input, { buildEntry: true })
   const lock = await resolvePeriodLock(organizationId)
-  return previewEntry(db, { organizationId, entry: built.entry, lock })
+  return previewEntry(db, { organizationId, entry: built!.entry, lock })
 }
 
 /**
@@ -555,16 +585,26 @@ export async function issueCreditMemo(
     db,
   })
 
-  const { memo, issuedAt, built } = await resolveIssue(db, input)
+  // The org's own accounting-off case is checked FIRST, and passed into
+  // `resolveIssue` so it skips the read and the build that exist only to post
+  // an entry (task 17 section 3) - a credit memo issues on an org that has
+  // never turned accounting on exactly as it would on one that has.
+  const accountingEnabled = await isAccountingEnabled(db, organizationId)
+  const { memo, issuedAt, built } = await resolveIssue(db, input, { buildEntry: accountingEnabled })
 
-  const lock = await resolvePeriodLock(organizationId)
-  const post = await postEntry(db, {
-    organizationId,
-    entry: built.entry,
-    actorUserId: userId,
-    lock,
-    memo: `Credit memo ${memo.number} issued`,
-  })
+  let post: PostResult
+  if (accountingEnabled) {
+    const lock = await resolvePeriodLock(organizationId)
+    post = await postEntry(db, {
+      organizationId,
+      entry: built!.entry,
+      actorUserId: userId,
+      lock,
+      memo: `Credit memo ${memo.number} issued`,
+    })
+  } else {
+    post = { status: 'not_enabled' }
+  }
   if (!ACCEPTED_POST_STATUSES.has(post.status)) {
     throw new BadRequestError(
       `This credit memo could not be posted to the general ledger` +

--- a/packages/lib/src/money/fulfillment-posting/__tests__/run.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/run.test.ts
@@ -40,19 +40,31 @@ const h = vi.hoisted(() => ({
   }>,
   stampThrowsFor: null as string | null,
   systemUserId: 'usr_system',
+  isAccountingEnabled: vi.fn(async () => true),
+  readUnpostedShipmentsCalls: 0,
+  readSettingsCalls: 0,
+}))
+
+vi.mock('../../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
 }))
 
 vi.mock('../reads', async () => {
   const { ok, err } = await import('neverthrow')
   return {
-    readUnpostedShipments: async () => (h.shipmentsError ? err(h.shipmentsError) : ok(h.shipments)),
-    readFulfillmentPostingSettings: async () =>
-      ok({
+    readUnpostedShipments: async () => {
+      h.readUnpostedShipmentsCalls++
+      return h.shipmentsError ? err(h.shipmentsError) : ok(h.shipments)
+    },
+    readFulfillmentPostingSettings: async () => {
+      h.readSettingsCalls++
+      return ok({
         cutoffPeriod: (h.settings['accounting.cutoffPeriod'] as string | null) ?? null,
         lockedThroughMonth: null,
         timeZone: (h.settings['accounting.bookTimeZone'] as string | null) ?? null,
         ledgerCurrency: 'USD',
-      }),
+      })
+    },
   }
 })
 
@@ -172,6 +184,25 @@ beforeEach(() => {
   h.postCalls = []
   h.stamps = []
   h.stampThrowsFor = null
+  h.isAccountingEnabled.mockResolvedValue(true)
+  h.readUnpostedShipmentsCalls = 0
+  h.readSettingsCalls = 0
+})
+
+// task 17 section 3: checked ONCE per org, before the settings read and the
+// shipment netting read - this run has no use for either when the org has
+// never turned accounting on.
+describe('accounting not enabled', () => {
+  it('reads nothing, builds nothing, posts nothing, and returns an empty summary', async () => {
+    h.isAccountingEnabled.mockResolvedValue(false)
+
+    const summary = await runFulfillmentPosting(stubDb(), REQUEST)
+
+    expect(summary).toEqual({ posted: [], skipped: [], failed: [], exclusions: [] })
+    expect(h.readSettingsCalls).toBe(0)
+    expect(h.readUnpostedShipmentsCalls).toBe(0)
+    expect(h.postCalls).toEqual([])
+  })
 })
 
 describe('the refusals', () => {

--- a/packages/lib/src/money/fulfillment-posting/run.ts
+++ b/packages/lib/src/money/fulfillment-posting/run.ts
@@ -49,6 +49,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { and, eq, like, ne, or } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { getOrgCache } from '../../cache'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import { buildFulfillmentBatchEntry } from '../../postings/build-fulfillment-batch-entry'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { postEntry } from '../../postings/post-entry'
@@ -78,8 +79,19 @@ const logger = createScopedLogger('money-fulfillment-posting')
  * accounting provider connected is a first-class case (decision P1) - the entry
  * is built, balanced and persisted identically and simply never pushed, so its
  * shipments are posted and must be stamped.
+ *
+ * `not_enabled` is in for completeness (task 17 section 3): in practice this
+ * run never reaches {@link executeGroup} for an org that has never turned
+ * accounting on - {@link runFulfillmentPosting} checks it once, before the
+ * plan is even read.
  */
-const POSTED_STATUSES = new Set<string>(['posted', 'healed', 'not_connected', 'disabled'])
+const POSTED_STATUSES = new Set<string>([
+  'posted',
+  'healed',
+  'not_connected',
+  'disabled',
+  'not_enabled',
+])
 
 /** One progress line per this many groups, so a long run is observable. */
 const PROGRESS_EVERY = 10
@@ -140,6 +152,16 @@ export async function runFulfillmentPosting(
   }
 
   try {
+    // 🛑 Checked ONCE per org, before the settings read, the shipment netting
+    // read and the plan - none of which this run has any use for when the org
+    // has never turned accounting on (task 17 section 3). A first-class silent
+    // case, like an org whose Stripe account is not connected: nothing is
+    // read, nothing is built, nothing is logged, and the summary comes back
+    // exactly as empty as "nothing to post".
+    if (!(await isAccountingEnabled(db, organizationId))) {
+      return summary
+    }
+
     const prepared = await prepare(db, request)
     if (prepared.refusal) {
       // 🛑 A run-level refusal has no group to hang on, and the summary type is

--- a/packages/lib/src/money/invoices/__tests__/post-invoice.test.ts
+++ b/packages/lib/src/money/invoices/__tests__/post-invoice.test.ts
@@ -1,0 +1,103 @@
+// packages/lib/src/money/invoices/__tests__/post-invoice.test.ts
+//
+// plans/accounting/tasks/17-accounting-is-opt-in.md section 3: `postInvoiceIssuance`
+// is a pure ledger writer with no other side effect, so the accounting-off case
+// is checked before ANY read - including the one that loads the invoice's own
+// totals, which exists only to build the entry.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  isAccountingEnabled: vi.fn(async () => true),
+  bySystemAttributes: vi.fn(),
+  buildInvoiceEntry: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  postEntry: vi.fn(),
+}))
+
+vi.mock('../../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
+}))
+vi.mock('../../../cache', () => ({
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../../postings/build-invoice-entry', () => ({
+  INVOICE_ISSUED_POSTING_TYPE: 'invoice_issued',
+  INVOICE_SOURCE_TYPE: 'invoice',
+  buildInvoiceEntry: h.buildInvoiceEntry,
+}))
+vi.mock('../../../postings/period-lock', () => ({
+  resolvePeriodLock: h.resolvePeriodLock,
+}))
+vi.mock('../../../postings/post-entry', () => ({
+  postEntry: h.postEntry,
+}))
+vi.mock('../../../settings/settings-service', () => ({
+  getOrganizationSetting: async () => null,
+}))
+
+import type { Database } from '@auxx/database'
+import { postInvoiceIssuance } from '../post-invoice'
+
+const ORG = 'org_1'
+const INVOICE = 'inv_1'
+
+function stubDb(): Database {
+  const chain: Record<string, unknown> = {}
+  for (const method of ['from', 'where']) chain[method] = () => chain
+  // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve([]).then(resolve)
+  return { select: () => chain } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isAccountingEnabled.mockResolvedValue(true)
+  h.bySystemAttributes.mockResolvedValue({
+    invoice_number: { id: 'f-number' },
+    invoice_issued_at: { id: 'f-issued' },
+    invoice_subtotal: { id: 'f-subtotal' },
+    invoice_tax_total: { id: 'f-tax' },
+    invoice_total: { id: 'f-total' },
+  })
+  h.buildInvoiceEntry.mockReturnValue({
+    entry: {
+      postingType: 'invoice_issued',
+      periodKey: 'INV-0001',
+      txnDate: '2026-09-01',
+      lines: [],
+    },
+  })
+  h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
+  h.postEntry.mockResolvedValue({
+    status: 'posted',
+    glPostingId: 'gl_1',
+    docNumber: 'AUXX-INI-0001',
+  })
+})
+
+describe('accounting not enabled', () => {
+  beforeEach(() => {
+    h.isAccountingEnabled.mockResolvedValue(false)
+  })
+
+  it('returns not_enabled without reading the invoice, building, locking, or posting', async () => {
+    const result = await postInvoiceIssuance(stubDb(), { organizationId: ORG, invoiceId: INVOICE })
+
+    expect(result).toEqual({ status: 'not_enabled' })
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+    expect(h.buildInvoiceEntry).not.toHaveBeenCalled()
+    expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+  })
+})
+
+describe('accounting enabled', () => {
+  it('loads the invoice, builds, locks, and posts', async () => {
+    const result = await postInvoiceIssuance(stubDb(), { organizationId: ORG, invoiceId: INVOICE })
+
+    expect(h.buildInvoiceEntry).toHaveBeenCalledTimes(1)
+    expect(h.postEntry).toHaveBeenCalledTimes(1)
+    expect(result.status).toBe('posted')
+  })
+})

--- a/packages/lib/src/money/invoices/__tests__/write-off.test.ts
+++ b/packages/lib/src/money/invoices/__tests__/write-off.test.ts
@@ -21,10 +21,14 @@ const h = vi.hoisted(() => ({
   getOrganizationSetting: vi.fn(),
   setValuesForEntity: vi.fn(),
   fieldValueServiceArgs: [] as unknown[][],
+  isAccountingEnabled: vi.fn(),
 }))
 
 vi.mock('../../../cache', () => ({
   getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+vi.mock('../../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
 }))
 vi.mock('../../../postings/period-lock', () => ({
   resolvePeriodLock: h.resolvePeriodLock,
@@ -148,6 +152,7 @@ beforeEach(() => {
   writeOffPostings = []
   h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
   h.getOrganizationSetting.mockResolvedValue('UTC')
+  h.isAccountingEnabled.mockResolvedValue(true)
 })
 
 describe('writeOffInvoice - refusals before the ledger is ever asked', () => {
@@ -510,6 +515,55 @@ describe('writeOffInvoice - a partial write-off can be topped up', () => {
 
     const write = h.setValuesForEntity.mock.calls[0]![0]
     expect(write.values).toEqual([{ fieldId: 'invoice_balance', value: 30_000 }])
+  })
+})
+
+// task 17 section 3: accounting is opt-in, and a write-off must land on the
+// invoice's balance whether or not the org has ever turned it on.
+describe('writeOffInvoice - accounting not enabled', () => {
+  it('returns not_enabled, never reads the period lock or posts, and still writes off the invoice', async () => {
+    wireInvoice('sent', { balanceMinor: 50_000 })
+    h.isAccountingEnabled.mockResolvedValue(false)
+
+    const result = await writeOffInvoice(stubDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      invoiceId: INVOICE,
+      reason: 'Customer bankrupt',
+    })
+
+    expect(result).toEqual({ status: 'not_enabled' })
+    expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+
+    expect(h.setValuesForEntity).toHaveBeenCalledTimes(1)
+    const write = h.setValuesForEntity.mock.calls[0]![0]
+    expect(write.values).toEqual(
+      expect.arrayContaining([
+        { fieldId: 'invoice_status', value: 'written_off' },
+        { fieldId: 'invoice_balance', value: 0 },
+      ])
+    )
+  })
+
+  it('writes off part of the balance exactly as it would with accounting on', async () => {
+    wireInvoice('partially_paid', { balanceMinor: 50_000 })
+    h.isAccountingEnabled.mockResolvedValue(false)
+
+    await writeOffInvoice(stubDb(), {
+      organizationId: ORG,
+      actorUserId: USER,
+      invoiceId: INVOICE,
+      amountMinor: 20_000,
+      reason: 'Partial settlement',
+    })
+
+    expect(h.postEntry).not.toHaveBeenCalled()
+    const write = h.setValuesForEntity.mock.calls[0]![0]
+    expect(write.values).toEqual([
+      { fieldId: 'invoice_balance', value: 30_000 },
+      { fieldId: 'invoice_written_off', value: 20_000 },
+    ])
   })
 })
 

--- a/packages/lib/src/money/invoices/post-invoice.ts
+++ b/packages/lib/src/money/invoices/post-invoice.ts
@@ -31,6 +31,7 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
   buildInvoiceEntry,
   INVOICE_ISSUED_POSTING_TYPE,
@@ -58,6 +59,9 @@ const logger = createScopedLogger('money-invoice-ledger')
  *
  * `not_connected` and `disabled` are in for the older reason: an org with no
  * accounting system is a first-class case, not a degraded one (decision P1).
+ *
+ * `not_enabled` is in for the newest reason: an org that has never turned the
+ * accounting module on is a first-class case too (task 17 section 3).
  */
 const ACCEPTED_POST_STATUSES = new Set<string>([
   'posted',
@@ -65,6 +69,7 @@ const ACCEPTED_POST_STATUSES = new Set<string>([
   'healed',
   'not_connected',
   'disabled',
+  'not_enabled',
 ])
 
 /**
@@ -207,6 +212,10 @@ export async function postInvoiceIssuance(
   input: PostInvoiceIssuanceInput
 ): Promise<PostResult> {
   const { organizationId, invoiceId, actorUserId } = input
+
+  if (!(await isAccountingEnabled(db, organizationId))) {
+    return { status: 'not_enabled' }
+  }
 
   try {
     const invoice = await loadInvoiceForIssuance(db, organizationId, invoiceId)

--- a/packages/lib/src/money/invoices/write-off.ts
+++ b/packages/lib/src/money/invoices/write-off.ts
@@ -22,6 +22,7 @@ import { and, eq, inArray } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
 import { BadRequestError, NotFoundError } from '../../errors'
 import { FieldValueService } from '../../field-values/field-value-service'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
   type BuildWriteOffEntryInput,
   buildWriteOffEntry,
@@ -459,34 +460,44 @@ export async function writeOffInvoice(
   assertWriteOffAllowed(invoice, invoiceId)
   const amount = resolveWriteOffAmount(invoice, invoiceId, amountMinor)
 
-  const [txnDate, attempt] = await Promise.all([
-    todayInBookTimeZone(organizationId),
-    countWriteOffPostings(db, organizationId, invoiceId),
-  ])
-  const entry = buildWriteOffEntry({
-    invoiceId,
-    invoiceNumber: invoice.number,
-    attempt,
-    amountMinor: amount,
-    txnDate,
-    expenseAccountCode,
-    memo: reason,
-  } satisfies BuildWriteOffEntryInput)
+  // 🛑 The org's own accounting-off case is checked FIRST, before the reads and
+  // the build below that exist only to post an entry (task 17 section 3): a
+  // write-off must land on the invoice's balance whether or not the org has
+  // ever turned accounting on.
+  let result: PostResult
+  if (!(await isAccountingEnabled(db, organizationId))) {
+    result = { status: 'not_enabled' }
+  } else {
+    const [txnDate, attempt] = await Promise.all([
+      todayInBookTimeZone(organizationId),
+      countWriteOffPostings(db, organizationId, invoiceId),
+    ])
+    const entry = buildWriteOffEntry({
+      invoiceId,
+      invoiceNumber: invoice.number,
+      attempt,
+      amountMinor: amount,
+      txnDate,
+      expenseAccountCode,
+      memo: reason,
+    } satisfies BuildWriteOffEntryInput)
 
-  const lock = await resolvePeriodLock(organizationId)
-  const result = await postEntry(db, {
-    organizationId,
-    entry,
-    actorUserId,
-    memo: reason,
-    lock,
-  })
+    const lock = await resolvePeriodLock(organizationId)
+    result = await postEntry(db, {
+      organizationId,
+      entry,
+      actorUserId,
+      memo: reason,
+      lock,
+    })
+  }
 
   const posted =
     result.status === 'posted' ||
     result.status === 'already_posted' ||
     result.status === 'not_connected' ||
-    result.status === 'disabled'
+    result.status === 'disabled' ||
+    result.status === 'not_enabled'
   if (!posted) return result
 
   const remainingBalanceMinor = invoice.outstandingMinor - amount

--- a/packages/lib/src/money/orders/__tests__/fulfill.test.ts
+++ b/packages/lib/src/money/orders/__tests__/fulfill.test.ts
@@ -30,6 +30,11 @@ const h = vi.hoisted(() => ({
   locks: 0,
   /** What `buildFulfillmentEntry` was handed, so the per-line tax is assertable. */
   built: [] as Array<{ shippedLines: Array<{ lineId: string; taxMinor?: number }> }>,
+  isAccountingEnabled: vi.fn(async () => true),
+}))
+
+vi.mock('../../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
 }))
 
 vi.mock('../reads', async () => {
@@ -48,24 +53,31 @@ vi.mock('../reads', async () => {
   }
 })
 
-vi.mock('../../../postings/build-fulfillment-entry', () => ({
-  buildFulfillmentEntry: (input: {
-    shippedLines: Array<{ lineId: string; taxMinor?: number }>
-  }) => {
-    h.built.push({ shippedLines: input.shippedLines })
-    return {
-      entry: {
-        postingType: 'fulfillment',
-        periodKey: 'ORD0012F1',
-        txnDate: '2026-09-03',
-        lines: [],
-      },
-      totalMinor: 50_00,
-      shippingMinor: 0,
-      revenueRole: 'revenue_dtc',
-    }
-  },
-}))
+vi.mock('../../../postings/build-fulfillment-entry', async (importOriginal) => {
+  // `computeShipmentTotals` stays REAL: the not-enabled path calls it directly
+  // (never the mocked builder below), and its arithmetic is what the
+  // "accounting not enabled" tests below assert against.
+  const actual = await importOriginal<typeof import('../../../postings/build-fulfillment-entry')>()
+  return {
+    computeShipmentTotals: actual.computeShipmentTotals,
+    buildFulfillmentEntry: (input: {
+      shippedLines: Array<{ lineId: string; taxMinor?: number }>
+    }) => {
+      h.built.push({ shippedLines: input.shippedLines })
+      return {
+        entry: {
+          postingType: 'fulfillment',
+          periodKey: 'ORD0012F1',
+          txnDate: '2026-09-03',
+          lines: [],
+        },
+        totalMinor: 50_00,
+        shippingMinor: 0,
+        revenueRole: 'revenue_dtc',
+      }
+    },
+  }
+})
 
 vi.mock('../../../postings/post-entry', () => ({
   LEDGER_CURRENCY: 'USD',
@@ -186,6 +198,7 @@ beforeEach(() => {
   h.updated = []
   h.locks = 0
   h.built = []
+  h.isAccountingEnabled.mockResolvedValue(true)
 })
 
 describe('the append re-reads the stored log under a lock', () => {
@@ -275,6 +288,54 @@ describe('the rollback removes THIS shipment, not everything since the pre-read'
 // all-or-nothing by design - one line with no tax sends the WHOLE entry back to
 // allocating the order's total - which is why the two cases below are what
 // matters rather than the arithmetic.
+// task 17 section 3: an org that has never turned accounting on is a
+// first-class silent case, exactly like `not_connected` - the shipment must
+// stand, and the ledger-only builder (which resolves a revenue role and
+// refuses a foreign currency) must never run for it.
+describe('accounting not enabled', () => {
+  beforeEach(() => {
+    h.isAccountingEnabled.mockResolvedValue(false)
+  })
+
+  it('records the shipment, does not roll it back, and reports not_enabled', async () => {
+    h.storedReads = [stored([]), stored([shipment({ sequence: 1, glPostingId: null })])]
+
+    const result = await fulfillOrder(stubDb(), input)
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.post).toEqual({ status: 'not_enabled' })
+    expect(value.fulfillmentStatus).not.toBe('unfulfilled')
+
+    const log = lastLog()
+    expect(log).toHaveLength(1)
+    expect(log[0]?.glPostingId).toBeNull()
+    expect(log[0]?.docNumber).toBeNull()
+  })
+
+  it('never calls the ledger entry builder', async () => {
+    h.storedReads = [stored([]), stored([shipment({ sequence: 1, glPostingId: null })])]
+
+    await fulfillOrder(stubDb(), input)
+
+    expect(h.built).toHaveLength(0)
+  })
+
+  it('still computes real amounts for the shipment log, via the shared arithmetic', async () => {
+    h.storedReads = [stored([]), stored([shipment({ sequence: 1, glPostingId: null })])]
+
+    await fulfillOrder(stubDb(), input)
+
+    // 3 units of a 10_00 line, per `input.shippedLines` - the APPEND write,
+    // which carries the amounts this attempt computed (the stamp that follows
+    // only patches `glPostingId`/`docNumber` onto the stored row).
+    const appended = h.updated[0]?.values.order_fulfillments as {
+      fulfillments: OrderFulfillment[]
+    }
+    expect(appended.fulfillments[0]?.totalMinor).toBe(30_00)
+  })
+})
+
 describe('the per-line tax reaches the builder', () => {
   it('passes a full-line shipment its whole stored tax', async () => {
     ;(h.order.lines as Array<Record<string, unknown>>)[0]!.lineTaxMinor = 875

--- a/packages/lib/src/money/orders/fulfill.ts
+++ b/packages/lib/src/money/orders/fulfill.ts
@@ -40,9 +40,12 @@ import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { BadRequestError, ConflictError, UnprocessableEntityError } from '../../errors'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
   type BuiltFulfillmentEntry,
   buildFulfillmentEntry,
+  computeShipmentTotals,
+  type ShipmentTotals,
 } from '../../postings/build-fulfillment-entry'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { LEDGER_CURRENCY, postEntry, previewEntry } from '../../postings/post-entry'
@@ -74,6 +77,10 @@ const logger = createScopedLogger('money-orders')
  * accounting system connected is a first-class case, not a degraded one
  * (decision P1). The entry is built, balanced and persisted the same way; it is
  * simply never pushed.
+ *
+ * `not_enabled` is in for the newest reason: an org that has never turned the
+ * accounting module on is a first-class case too, and a shipment must never be
+ * rolled back for it (task 17 section 3).
  */
 const ACCEPTED_POST_STATUSES = new Set<string>([
   'posted',
@@ -81,6 +88,7 @@ const ACCEPTED_POST_STATUSES = new Set<string>([
   'healed',
   'not_connected',
   'disabled',
+  'not_enabled',
 ])
 
 /** One line, and how much of it the caller says went out. */
@@ -327,18 +335,56 @@ export async function fulfillOrder(
       if (read.isErr()) throw read.error
       const order = read.value
 
-      // Everything that can refuse, refused BEFORE anything is written: the
-      // channel, the currency, the quantities and the document-number keyspace
-      // all throw out of here, and none of them can be fixed by retrying.
-      const { built, lines: shipped } = buildForOrder(order, shippedLines, shippedAt)
+      // The quantities are validated regardless of accounting: shipping more
+      // than remains is a business error, not a ledger one.
+      const shipped = resolveShippedLines(order, shippedLines)
+
+      // 🛑 The org's own accounting-off case is checked FIRST, before the
+      // ledger entry is built (task 17 section 3): `buildFulfillmentEntry`
+      // refuses a foreign-currency order and resolves a revenue role, both of
+      // which are ledger-only concerns that must not block a shipment for an
+      // org this module does nothing for. `computeShipmentTotals` is the same
+      // arithmetic with none of that - the shared implementation the batch
+      // builder also calls - so the shipment log still carries real amounts.
+      const accountingEnabled = await isAccountingEnabled(db, organizationId)
+      const built = accountingEnabled
+        ? buildFulfillmentEntry({
+            orderId: order.orderId,
+            orderNumber: order.number ?? '',
+            sequence: order.nextSequence,
+            channel: order.channel,
+            currency: order.currency,
+            ledgerCurrency: LEDGER_CURRENCY,
+            txnDate: shippedAt,
+            shippedLines: shipped,
+            orderSubtotalMinor: order.subtotalMinor,
+            orderTaxTotalMinor: order.taxTotalMinor,
+            orderShippingTotalMinor: order.shippingTotalMinor,
+            priorShipmentsSubtotalMinor: shippedSubtotalMinor(order.fulfillments),
+            includeShipping: order.shippingOwed,
+            includeCogs: false,
+          })
+        : undefined
+      const amounts: ShipmentTotals =
+        built ??
+        computeShipmentTotals({
+          label: `order ${order.number ?? order.orderId}`,
+          lines: shipped,
+          orderSubtotalMinor: order.subtotalMinor,
+          orderTaxTotalMinor: order.taxTotalMinor,
+          priorShipmentsSubtotalMinor: shippedSubtotalMinor(order.fulfillments),
+          orderShippingTotalMinor: order.shippingTotalMinor,
+          includeShipping: order.shippingOwed,
+          context: { orderId: order.orderId },
+        })
 
       const fulfillment: OrderFulfillment = {
         sequence: order.nextSequence,
         shippedAt,
         lines: shipped.map((line) => ({ lineId: line.lineId, quantity: line.quantity })),
-        subtotalMinor: built.subtotalMinor,
-        totalMinor: built.totalMinor,
-        shippingRecognised: built.shippingMinor > 0,
+        subtotalMinor: amounts.subtotalMinor,
+        totalMinor: amounts.totalMinor,
+        shippingRecognised: amounts.shippingMinor > 0,
         glPostingId: null,
         docNumber: null,
         recordedAt: new Date().toISOString(),
@@ -392,14 +438,19 @@ export async function fulfillOrder(
       })
 
       // ── The posting, after the commit ──────────────────────────────────
-      const lock = await resolvePeriodLock(organizationId)
-      const post = await postEntry(db, {
-        organizationId,
-        entry: built.entry,
-        actorUserId,
-        lock,
-        memo: memo ?? `Fulfilled ${order.number ?? orderId} shipment ${order.nextSequence}`,
-      })
+      let post: PostResult
+      if (accountingEnabled && built) {
+        const lock = await resolvePeriodLock(organizationId)
+        post = await postEntry(db, {
+          organizationId,
+          entry: built.entry,
+          actorUserId,
+          lock,
+          memo: memo ?? `Fulfilled ${order.number ?? orderId} shipment ${order.nextSequence}`,
+        })
+      } else {
+        post = { status: 'not_enabled' }
+      }
 
       if (!ACCEPTED_POST_STATUSES.has(post.status)) {
         await rollbackFulfillment(db, organizationId, actorUserId, order, order.nextSequence)
@@ -439,7 +490,7 @@ export async function fulfillOrder(
         number: order.number,
         sequence: settled.sequence,
         totalMinor: settled.totalMinor,
-        revenueRole: built.revenueRole,
+        revenueRole: built?.revenueRole ?? null,
         status: post.status,
       })
 

--- a/packages/lib/src/money/payments/__tests__/post-transaction.test.ts
+++ b/packages/lib/src/money/payments/__tests__/post-transaction.test.ts
@@ -1,0 +1,118 @@
+// packages/lib/src/money/payments/__tests__/post-transaction.test.ts
+//
+// plans/accounting/tasks/17-accounting-is-opt-in.md section 3: the
+// accounting-off case is checked before the org-settings read that exists only
+// to resolve the payment route for the builder.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  isAccountingEnabled: vi.fn(async () => true),
+  getOrgCache: vi.fn(async () => ({})),
+  resolvePaymentRoute: vi.fn(() => 'cash'),
+  buildPaymentEntry: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  postEntry: vi.fn(),
+}))
+
+vi.mock('../../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
+}))
+vi.mock('../../../cache', () => ({
+  getOrgCache: () => ({ get: h.getOrgCache }),
+}))
+vi.mock('../../../postings/build-payment-entry', () => ({
+  PAYMENT_SOURCE_TYPE: 'payment_transaction',
+  paymentPeriodKey: (id: string) => `PMT-${id}`,
+  buildPaymentEntry: h.buildPaymentEntry,
+}))
+vi.mock('../../../postings/period-lock', () => ({
+  resolvePeriodLock: h.resolvePeriodLock,
+}))
+vi.mock('../../../postings/post-entry', () => ({
+  LEDGER_CURRENCY: 'USD',
+  postEntry: h.postEntry,
+}))
+vi.mock('../../../postings/read-posting', () => ({
+  readPostingLineSourceIds: vi.fn(),
+}))
+vi.mock('../../bank-deposits/client', () => ({
+  resolvePaymentRoute: h.resolvePaymentRoute,
+}))
+
+import type { Database, PaymentTransactionEntity } from '@auxx/database'
+import { postPaymentTransaction } from '../post-transaction'
+
+const ORG = 'org_1'
+const db = {} as Database
+
+function transaction(overrides: Partial<PaymentTransactionEntity> = {}): PaymentTransactionEntity {
+  return {
+    id: 'txn_1',
+    kind: 'charge',
+    status: 'succeeded',
+    amount: 5_000,
+    method: 'card',
+    currency: 'USD',
+    reference: null,
+    metadata: null,
+    createdAt: new Date('2026-09-01T00:00:00.000Z'),
+    ...overrides,
+  } as PaymentTransactionEntity
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isAccountingEnabled.mockResolvedValue(true)
+  h.getOrgCache.mockResolvedValue({})
+  h.resolvePaymentRoute.mockReturnValue('cash')
+  h.buildPaymentEntry.mockReturnValue({
+    entry: { postingType: 'payment', periodKey: 'PMT-txn_1', txnDate: '2026-09-01', lines: [] },
+  })
+  h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
+  h.postEntry.mockResolvedValue({ status: 'posted', glPostingId: 'gl_1', docNumber: 'AUXX-PMT-1' })
+})
+
+describe('accounting not enabled', () => {
+  beforeEach(() => {
+    h.isAccountingEnabled.mockResolvedValue(false)
+  })
+
+  it('returns not_enabled without reading settings, building, locking, or posting', async () => {
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(result).toEqual({ status: 'not_enabled' })
+    expect(h.getOrgCache).not.toHaveBeenCalled()
+    expect(h.buildPaymentEntry).not.toHaveBeenCalled()
+    expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+  })
+
+  it('still refuses a non-postable status first, before the gate matters', async () => {
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction({ status: 'pending' }),
+      allocatedMinor: 5_000,
+    })
+
+    expect(result.status).toBe('nothing_to_close')
+  })
+})
+
+describe('accounting enabled', () => {
+  it('resolves the route, builds, locks, and posts', async () => {
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(h.buildPaymentEntry).toHaveBeenCalledTimes(1)
+    expect(h.postEntry).toHaveBeenCalledTimes(1)
+    expect(result.status).toBe('posted')
+  })
+})

--- a/packages/lib/src/money/payments/post-deposit-application.test.ts
+++ b/packages/lib/src/money/payments/post-deposit-application.test.ts
@@ -31,6 +31,11 @@ const h = vi.hoisted(() => ({
   }>,
   postResults: [] as Array<{ status: string; error?: string }>,
   posted: [] as Array<{ periodKey: string; txnDate: string; totalMinor: number }>,
+  isAccountingEnabled: vi.fn(async () => true),
+}))
+
+vi.mock('../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
 }))
 
 function tableProxy(name: string) {
@@ -113,6 +118,43 @@ beforeEach(() => {
   h.allocations = []
   h.postResults = []
   h.posted = []
+  h.isAccountingEnabled.mockResolvedValue(true)
+})
+
+// plans/accounting/tasks/17-accounting-is-opt-in.md section 3.
+describe('accounting not enabled', () => {
+  it('returns [{status: not_enabled}] without reading allocations or posting', async () => {
+    const { database } = await import('@auxx/database')
+    h.isAccountingEnabled.mockResolvedValue(false)
+    h.allocations = [
+      {
+        id: 'alloc-1',
+        amount: 300_000,
+        appliedAt: '2026-09-04T15:00:00.000Z',
+        invoiceInstanceId: 'inv-1',
+      },
+    ]
+
+    const results = await postDepositApplications(database, {
+      organizationId: ORG,
+      transaction: charge(),
+    })
+
+    expect(results).toEqual([{ status: 'not_enabled' }])
+    expect(h.posted).toEqual([])
+  })
+
+  it('still returns [] for a refund, before the gate matters', async () => {
+    const { database } = await import('@auxx/database')
+    h.isAccountingEnabled.mockResolvedValue(false)
+
+    const results = await postDepositApplications(database, {
+      organizationId: ORG,
+      transaction: charge({ kind: 'refund' }),
+    })
+
+    expect(results).toEqual([])
+  })
 })
 
 describe('a held deposit later applied to an invoice', () => {

--- a/packages/lib/src/money/payments/post-deposit-application.ts
+++ b/packages/lib/src/money/payments/post-deposit-application.ts
@@ -49,6 +49,7 @@
 import { type Database, type PaymentTransactionEntity, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, eq, inArray } from 'drizzle-orm'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
   buildDepositApplicationEntry,
   DEPOSIT_APPLICATION_POSTING_TYPE,
@@ -76,6 +77,9 @@ const logger = createScopedLogger('money-payments-ledger')
  *
  * `not_connected` and `disabled` are in for the older reason: an org with no
  * accounting system is a first-class case, not a degraded one (decision P1).
+ *
+ * `not_enabled` is in for the newest reason: an org that has never turned the
+ * accounting module on is a first-class case too (task 17 section 3).
  */
 const ACCEPTED_POST_STATUSES = new Set<string>([
   'posted',
@@ -83,6 +87,7 @@ const ACCEPTED_POST_STATUSES = new Set<string>([
   'healed',
   'not_connected',
   'disabled',
+  'not_enabled',
 ])
 
 /**
@@ -208,6 +213,7 @@ export async function postDepositApplications(
 
   if (transaction.kind !== 'charge') return []
   if (transaction.status !== 'succeeded' && transaction.status !== 'disputed') return []
+  if (!(await isAccountingEnabled(db, organizationId))) return [{ status: 'not_enabled' }]
 
   try {
     const allocations = await db

--- a/packages/lib/src/money/payments/post-transaction.ts
+++ b/packages/lib/src/money/payments/post-transaction.ts
@@ -33,6 +33,7 @@ import { type Database, type PaymentTransactionEntity, schema } from '@auxx/data
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
   buildPaymentEntry,
   PAYMENT_SOURCE_TYPE,
@@ -66,6 +67,9 @@ export const PAYMENT_POSTING_TYPE: PostingType = 'payment'
  *
  * `not_connected` and `disabled` are in for the older reason: an org with no
  * accounting system is a first-class case, not a degraded one (decision P1).
+ *
+ * `not_enabled` is in for the newest reason: an org that has never turned the
+ * accounting module on is a first-class case too (task 17 section 3).
  */
 const ACCEPTED_POST_STATUSES = new Set<string>([
   'posted',
@@ -73,6 +77,7 @@ const ACCEPTED_POST_STATUSES = new Set<string>([
   'healed',
   'not_connected',
   'disabled',
+  'not_enabled',
 ])
 
 /**
@@ -129,6 +134,10 @@ export async function postPaymentTransaction(
       status: 'nothing_to_close',
       error: `Payment ${transaction.id} is ${transaction.status}, which moved no money.`,
     }
+  }
+
+  if (!(await isAccountingEnabled(db, organizationId))) {
+    return { status: 'not_enabled' }
   }
 
   try {

--- a/packages/lib/src/money/payouts/__tests__/sync.test.ts
+++ b/packages/lib/src/money/payouts/__tests__/sync.test.ts
@@ -1,0 +1,74 @@
+// packages/lib/src/money/payouts/__tests__/sync.test.ts
+//
+// plans/accounting/tasks/17-accounting-is-opt-in.md section 3. `syncPayouts`
+// runs nightly for every org with a live Stripe connection (`payoutSyncJob` ->
+// `sweepPayouts`), so the gate sits here, once per org, before the Stripe
+// account lookup - not only inside `postPayoutEntry`, which this test does not
+// even need to mock to prove the point: the run never gets that far.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  isAccountingEnabled: vi.fn(async () => true),
+  requirePayoutFieldContext: vi.fn(async () => ({}) as never),
+  getPaymentAccount: vi.fn(async () => null as { stripeAccountId: string } | null),
+}))
+
+vi.mock('../../../postings/accounting-enabled', () => ({
+  isAccountingEnabled: h.isAccountingEnabled,
+}))
+vi.mock('../reads', () => ({
+  requirePayoutFieldContext: h.requirePayoutFieldContext,
+  findPayoutByGatewayId: vi.fn(),
+}))
+vi.mock('../../payments/account-state', () => ({
+  getPaymentAccount: h.getPaymentAccount,
+}))
+
+import type { Database } from '@auxx/database'
+import { syncPayouts } from '../sync'
+
+const ORG = 'org_1'
+const db = {} as Database
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isAccountingEnabled.mockResolvedValue(true)
+  h.getPaymentAccount.mockResolvedValue(null)
+})
+
+describe('accounting not enabled', () => {
+  it('never looks up the payout field context or the Stripe account, and returns an empty result', async () => {
+    h.isAccountingEnabled.mockResolvedValue(false)
+
+    const result = await syncPayouts(db, { organizationId: ORG })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual({
+      seen: 0,
+      created: 0,
+      posted: 0,
+      alreadyPosted: 0,
+      refused: [],
+    })
+    expect(h.requirePayoutFieldContext).not.toHaveBeenCalled()
+    expect(h.getPaymentAccount).not.toHaveBeenCalled()
+  })
+})
+
+describe('accounting enabled', () => {
+  it('proceeds past the gate to the ordinary no-connected-Stripe-account case', async () => {
+    const result = await syncPayouts(db, { organizationId: ORG })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual({
+      seen: 0,
+      created: 0,
+      posted: 0,
+      alreadyPosted: 0,
+      refused: [],
+    })
+    expect(h.requirePayoutFieldContext).toHaveBeenCalledTimes(1)
+    expect(h.getPaymentAccount).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/money/payouts/sync.ts
+++ b/packages/lib/src/money/payouts/sync.ts
@@ -40,6 +40,7 @@ import { and, asc, eq } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import type Stripe from 'stripe'
 import { UnprocessableEntityError } from '../../errors'
+import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import { ACCOUNT_ROLES } from '../../postings/build-entry'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { postPayoutEntry } from '../../postings/post-payout-entry'
@@ -82,6 +83,19 @@ export async function syncPayouts(
 
   return guard(
     async () => {
+      // 🛑 Checked ONCE per org, before the Stripe account lookup, the payout
+      // list and the payout record writes - none of which this sync has any
+      // use for when the org has never turned accounting on (task 17 section
+      // 3): a payout record exists to reconcile a clearing account this org
+      // does not have. The gate lives here rather than only in
+      // `postPayoutEntry` because `payoutSyncJob` runs this nightly for every
+      // org with a live Stripe connection, and that is the loop the brief
+      // means by "where it costs least" - skipping here also skips the Stripe
+      // API call and the `payout` entity write, not just the posting.
+      if (!(await isAccountingEnabled(db, organizationId))) {
+        return { seen: 0, created: 0, posted: 0, alreadyPosted: 0, refused: [] }
+      }
+
       const ctx = await requirePayoutFieldContext(organizationId)
 
       const account = await getPaymentAccount(organizationId)

--- a/packages/lib/src/money/quickbooks/__tests__/quickbooks-accounting-provider.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/quickbooks-accounting-provider.test.ts
@@ -82,11 +82,13 @@ const CHART = [
 ]
 
 /** The org's OWN chart - what a posting line's `accountCode` names. */
+// Ids match what `baseInput`'s lines carry (`glAccountId`) - task 15's
+// identity is what `resolveMappedAccounts` now keys on, not the code.
 const OUR_CHART = [
-  { id: 'gl1310', code: '1310', name: 'Inventory', accountType: 'asset', isActive: true },
-  { id: 'gl2160', code: '2160', name: 'GRNI', accountType: 'liability', isActive: true },
-  { id: 'gl5090', code: '5090', name: 'PPV', accountType: 'expense', isActive: true },
-  { id: 'gl9999', code: '9999', name: 'Retired', accountType: 'asset', isActive: true },
+  { id: 'acct_1310', code: '1310', name: 'Inventory', accountType: 'asset', isActive: true },
+  { id: 'acct_2160', code: '2160', name: 'GRNI', accountType: 'liability', isActive: true },
+  { id: 'acct_5090', code: '5090', name: 'PPV', accountType: 'expense', isActive: true },
+  { id: 'acct_9999', code: '9999', name: 'Retired', accountType: 'asset', isActive: true },
 ]
 
 /**
@@ -95,9 +97,9 @@ const OUR_CHART = [
  * ONLY reason a code fails to resolve. There is no matching left to miss.
  */
 const ACCOUNT_MAP = new Map([
-  ['gl1310', '92'],
-  ['gl2160', '79'],
-  ['gl9999', '11'],
+  ['acct_1310', '92'],
+  ['acct_2160', '79'],
+  ['acct_9999', '11'],
 ])
 
 function baseInput(over: Partial<PostEntryInput> = {}): PostEntryInput {
@@ -327,6 +329,38 @@ describe('the happy path', () => {
 
     const chartCalls = callTool.mock.calls.filter(([id]) => id === 'list_quickbooks_accounts')
     expect(chartCalls).toHaveLength(1)
+  })
+
+  // Task 15 §2.3: a replay (`retry-export.ts`) hands `postEntry` the ORIGINAL
+  // `ResolvedPostingLine`s straight off `GlPostingLine`, whose `accountCode`
+  // is the FROZEN snapshot from when it posted - '1310' here, even though the
+  // account was renumbered to '1150' in our own chart since. Resolution goes
+  // by `glAccountId`, which the renumber never touched, so the replay resolves
+  // and exports rather than refusing with "no account has the code 1310".
+  it('resolves a replayed line by id, even though its frozen code no longer matches the chart', async () => {
+    const callTool = connect({
+      create_quickbooks_journal_entry: () => ({ journalEntry: { journalEntryId: '201' } }),
+    })
+    // `connect()` stubs `listChartAccounts` to `OUR_CHART` - override it with
+    // the renumbered chart AFTER `connect()`, same id, different code.
+    listChartAccounts.mockResolvedValue(
+      ok([
+        { id: 'acct_1310', code: '1150', name: 'Inventory', accountType: 'asset', isActive: true },
+        OUR_CHART[1],
+        OUR_CHART[2],
+        OUR_CHART[3],
+      ])
+    )
+
+    const result = await provider.postEntry(baseInput())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ status: 'posted', externalId: '201' })
+    expect(createCallOf(callTool)?.lines).toContainEqual({
+      amountMinor: 124999,
+      postingType: 'Debit',
+      accountId: '92',
+      accountName: 'Inventory',
+    })
   })
 })
 
@@ -604,7 +638,7 @@ describe('resolveAccount - the only place a code becomes a provider id', () => {
 
   it('refuses a mapping whose target has vanished from the provider chart', async () => {
     connect()
-    readQuickbooksAccountMap.mockResolvedValue(new Map([['gl1310', 'deleted-99']]))
+    readQuickbooksAccountMap.mockResolvedValue(new Map([['acct_1310', 'deleted-99']]))
 
     const result = await provider.resolveAccount(ORG_ID, '1310')
 
@@ -616,7 +650,7 @@ describe('resolveAccount - the only place a code becomes a provider id', () => {
     // The one failure no downstream reader can catch: an entry posted to a
     // revenue account instead of an asset one still BALANCES.
     connect()
-    readQuickbooksAccountMap.mockResolvedValue(new Map([['gl1310', '79']]))
+    readQuickbooksAccountMap.mockResolvedValue(new Map([['acct_1310', '79']]))
 
     const result = await provider.resolveAccount(ORG_ID, '1310')
 

--- a/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
+++ b/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
@@ -4,10 +4,13 @@
 // QuickBooks' and nobody else's.
 //
 // The provider-agnostic core (`postings/post-entry.ts`) owns resolve, claim,
-// persist and record. It hands this adapter a balanced entry whose lines already
-// carry account CODES from the org's own chart, and it writes back whatever id
-// comes out. This file owns three things the core cannot: turning a code into a
-// QuickBooks account id, QuickBooks' `DocNumber`, and QuickBooks' `requestid`.
+// persist and record. It hands this adapter a balanced entry whose lines carry
+// the org's own account CODE, name and `glAccountId` - task 15's IDENTITY, and
+// the key this file resolves by (`resolveMappedAccounts`) so a replay
+// (`retry-export.ts`) cannot be tripped up by a renumber that happened since -
+// and it writes back whatever provider id comes out. This file owns three
+// things the core cannot: turning an account into a QuickBooks account id,
+// QuickBooks' `DocNumber`, and QuickBooks' `requestid`.
 //
 // Registered from the APP layer via `registerAccountingProvider`, never imported
 // by `packages/lib` itself. That direction is decision P1: the ledger is ours
@@ -285,8 +288,8 @@ async function fetchChart(ctx: QuickbooksToolContext): Promise<ProviderAccount[]
 }
 
 /**
- * Resolve every account CODE an entry names to a QuickBooks account id, through
- * the `G19` account map.
+ * Resolve every account an entry names, by `glAccountId`, to a QuickBooks
+ * account id, through the `G19` account map.
  *
  * 🛑 **There is no matching here, and that is the point.** This used to compare
  * our code against `Account.AcctNum` and take the single hit. That looked like a
@@ -296,6 +299,13 @@ async function fetchChart(ctx: QuickbooksToolContext): Promise<ProviderAccount[]
  * silently moved where a role posted. `G19` replaced it with a confirmation a
  * person makes once - "this account IS that account" - which is what the map
  * below reads.
+ *
+ * 🛑 **Keyed on `glAccountId` (task 15 §2.3), not on the account code.** A
+ * replayed line (`retry-export.ts`) carries the id it was posted with; looking
+ * it up by the FROZEN code used to miss the moment the account was renumbered
+ * in our own chart, refusing a retry with "no account has the code X" for an
+ * account that plainly exists. The id is exactly what the line already carries
+ * for this reason - see `ResolvedPostingLine.glAccountId`.
  *
  * Every mapping is revalidated on every entry against the chart just fetched:
  * the target must still exist, still be active, and still sit in the same
@@ -307,7 +317,7 @@ async function fetchChart(ctx: QuickbooksToolContext): Promise<ProviderAccount[]
  */
 async function resolveMappedAccounts(
   ctx: QuickbooksToolContext,
-  codes: readonly string[]
+  glAccountIds: readonly string[]
 ): Promise<Result<Map<string, ProviderAccount>, Error>> {
   const [chart, ourChart] = await Promise.all([
     fetchChart(ctx),
@@ -321,16 +331,16 @@ async function resolveMappedAccounts(
     connectionId: ctx.connectionId,
   })
 
-  const byCode = new Map(ourChart.value.map((row) => [norm(row.code), row]))
+  const byId = new Map(ourChart.value.map((row) => [row.id, row]))
   const byProviderId = new Map(chart.map((account) => [account.id, account]))
 
   const resolved = new Map<string, ProviderAccount>()
   const problems: string[] = []
 
-  for (const code of new Set(codes)) {
-    const account = byCode.get(norm(code))
+  for (const glAccountId of new Set(glAccountIds)) {
+    const account = byId.get(glAccountId)
     if (!account) {
-      problems.push(`No account in this organization's chart has the code '${code}'.`)
+      problems.push(`No account in this organization's chart has the id '${glAccountId}'.`)
       continue
     }
 
@@ -350,7 +360,7 @@ async function resolveMappedAccounts(
     }
 
     // `validateProviderMapping` returns null only when `live` is present.
-    resolved.set(code, live as ProviderAccount)
+    resolved.set(glAccountId, live as ProviderAccount)
   }
 
   if (problems.length > 0) {
@@ -404,6 +414,12 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
    * a `ResolvedPostingLine` - may hold one, because that is what would make the
    * ledger un-replayable against a different provider three years later.
    *
+   * The code is our own caller's vocabulary (a human keying a manual entry
+   * looks at the chart, not at ids), so it is translated to the account's
+   * `glAccountId` here, then handed to {@link resolveMappedAccounts} - the same
+   * by-id door `postEntry` below uses, so the two paths cannot disagree about
+   * what one account resolves to.
+   *
    * NOT cached across calls. The provider instance is a process-lifetime
    * singleton, so an instance-level cache would keep serving an account id after
    * the mapping was changed or its target deactivated in QuickBooks, with no
@@ -423,18 +439,24 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
       )
     }
 
+    const notResolved = () =>
+      err(
+        new UnprocessableEntityError(
+          `Account code '${code}' could not be resolved to a QuickBooks account.`,
+          { accountCode: code }
+        )
+      )
+
     try {
-      const accounts = await resolveMappedAccounts(resolved.context, [code])
+      const ourChart = await listChartAccounts(database, orgId)
+      if (ourChart.isErr()) return err(ourChart.error)
+      const ourAccount = ourChart.value.find((row) => norm(row.code) === norm(code))
+      if (!ourAccount) return notResolved()
+
+      const accounts = await resolveMappedAccounts(resolved.context, [ourAccount.id])
       if (accounts.isErr()) return err(accounts.error)
-      const account = accounts.value.get(code)
-      return account
-        ? ok(account.id)
-        : err(
-            new UnprocessableEntityError(
-              `Account code '${code}' could not be resolved to a QuickBooks account.`,
-              { accountCode: code }
-            )
-          )
+      const account = accounts.value.get(ourAccount.id)
+      return account ? ok(account.id) : notResolved()
     } catch (error) {
       return err(
         new UnprocessableEntityError(
@@ -605,13 +627,14 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
       }
       const ctx = resolved.context
 
-      // ── Resolve every account code before anything is written ────────────
-      // One call for the whole entry, and it collects every problem rather than
-      // stopping at the first: naming all the offending codes at once matters,
-      // because fixing them one failed post at a time is how a close slips a day.
+      // ── Resolve every account before anything is written ─────────────────
+      // By `glAccountId` (task 15 §2.3), not by the frozen code: one call for
+      // the whole entry, collecting every problem rather than stopping at the
+      // first, and immune to a renumber that happened after this line posted -
+      // exactly what a `retry-export.ts` replay needs.
       const accounts = await resolveMappedAccounts(
         ctx,
-        input.lines.map((line) => line.accountCode)
+        input.lines.map((line) => line.glAccountId)
       )
       if (accounts.isErr()) {
         return err(
@@ -624,9 +647,9 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
 
       const lines: QboJournalLine[] = []
       for (const line of [...input.lines].sort((a, b) => a.sortOrder - b.sortOrder)) {
-        // `resolveMappedAccounts` refuses unless every code resolved, so a miss
+        // `resolveMappedAccounts` refuses unless every id resolved, so a miss
         // here is unreachable rather than merely unlikely.
-        const account = accounts.value.get(line.accountCode)
+        const account = accounts.value.get(line.glAccountId)
         if (!account) continue
         lines.push({
           amountMinor: line.amount,

--- a/packages/lib/src/postings/__tests__/accounting-enabled-triggers.test.ts
+++ b/packages/lib/src/postings/__tests__/accounting-enabled-triggers.test.ts
@@ -1,0 +1,47 @@
+// packages/lib/src/postings/__tests__/accounting-enabled-triggers.test.ts
+//
+// plans/accounting/tasks/17-accounting-is-opt-in.md section 3, and the exact-set
+// model of `types.test.ts`: every document-driven posting trigger the brief
+// names must import `isAccountingEnabled` and check it before it builds an
+// entry. A source scan rather than a runtime call, so a new trigger copied from
+// an old one (the way this codebase grows a fifth `build*Entry` builder) fails
+// loudly here instead of quietly shipping without the gate.
+//
+// 🛑 This is a floor, not a ceiling: importing the helper is necessary but not
+// sufficient (a file could import it and never call it). The per-trigger tests
+// beside each file are what prove the call actually short-circuits the build,
+// the period lock and the post.
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every document-driven posting trigger (task 17 section 3's own list), as a
+ * path relative to `packages/lib/src`.
+ */
+const TRIGGER_FILES = [
+  'money/invoices/post-invoice.ts',
+  'money/orders/fulfill.ts',
+  'money/fulfillment-posting/run.ts',
+  'money/payments/post-transaction.ts',
+  'money/payments/post-deposit-application.ts',
+  'money/invoices/write-off.ts',
+  'money/credit-memos/writes.ts',
+  'money/bank-deposits/writes.ts',
+  'postings/post-payout-entry.ts',
+  // The per-org gate for the payout sync, which never even lets
+  // `post-payout-entry.ts` see a payout for an org that has not enabled
+  // accounting (task 17 section 3's payout-path decision).
+  'money/payouts/sync.ts',
+] as const
+
+const SRC_ROOT = join(__dirname, '..', '..')
+
+describe('every posting trigger imports the accounting-enabled gate', () => {
+  it.each(TRIGGER_FILES)('%s', (relativePath) => {
+    const source = readFileSync(join(SRC_ROOT, relativePath), 'utf8')
+    expect(source).toMatch(/isAccountingEnabled/)
+    expect(source).toMatch(/from ['"].*accounting-enabled['"]/)
+  })
+})

--- a/packages/lib/src/postings/__tests__/accounting-enabled.test.ts
+++ b/packages/lib/src/postings/__tests__/accounting-enabled.test.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/postings/__tests__/accounting-enabled.test.ts
+//
+// plans/accounting/tasks/17-accounting-is-opt-in.md section 3.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  isSelfHosted: vi.fn(() => false),
+  getOrRecompute: vi.fn(),
+}))
+
+vi.mock('@auxx/deployment', () => ({ isSelfHosted: h.isSelfHosted }))
+vi.mock('../../cache', () => ({ getOrgCache: () => ({ getOrRecompute: h.getOrRecompute }) }))
+
+import { FeatureKey } from '../../permissions/types'
+import { isAccountingEnabled } from '../accounting-enabled'
+
+const ORG = 'org_1'
+const db = {} as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isSelfHosted.mockReturnValue(false)
+})
+
+describe('isAccountingEnabled', () => {
+  it('is true when the cached feature map carries accounting: true', async () => {
+    h.getOrRecompute.mockResolvedValue({ features: { [FeatureKey.accounting]: true } })
+    expect(await isAccountingEnabled(db, ORG)).toBe(true)
+  })
+
+  it('is false when the feature map says accounting: false', async () => {
+    h.getOrRecompute.mockResolvedValue({ features: { [FeatureKey.accounting]: false } })
+    expect(await isAccountingEnabled(db, ORG)).toBe(false)
+  })
+
+  it('is false when the feature map says accounting: 0', async () => {
+    h.getOrRecompute.mockResolvedValue({ features: { [FeatureKey.accounting]: 0 } })
+    expect(await isAccountingEnabled(db, ORG)).toBe(false)
+  })
+
+  it('is false when the feature is absent from the map', async () => {
+    h.getOrRecompute.mockResolvedValue({ features: { mail: '+' } })
+    expect(await isAccountingEnabled(db, ORG)).toBe(false)
+  })
+
+  it('is false when there is no feature map at all', async () => {
+    h.getOrRecompute.mockResolvedValue({ features: null })
+    expect(await isAccountingEnabled(db, ORG)).toBe(false)
+  })
+
+  it('is true on a self-hosted install regardless of the feature map', async () => {
+    h.isSelfHosted.mockReturnValue(true)
+    expect(await isAccountingEnabled(db, ORG)).toBe(true)
+  })
+})

--- a/packages/lib/src/postings/__tests__/chart-write.test.ts
+++ b/packages/lib/src/postings/__tests__/chart-write.test.ts
@@ -518,9 +518,10 @@ describe('updateChartAccount', () => {
     expect(h.updates[0]?.recordId).toBe(`${DEF}:${GRNI_ACCOUNT.id}`)
   })
 
-  // ⚠️ `G7`: the chart is the org's document. A renumber detaches posted lines
-  // from the row on screen, which is `P2` working as designed, and refusing it
-  // would be this module deciding it knows better.
+  // ⚠️ `G7`: the chart is the org's document. Since task 15 a renumber no
+  // longer detaches anything at all - `GlPostingLine.glAccountId` is the
+  // identity - and refusing it anyway would be this module deciding it knows
+  // better than the org about its own numbering.
   it('renumbers without complaint, even with a role pointing at the account', async () => {
     const db = stubDb([GRNI_ACCOUNT], [{ role: 'grni', glAccountId: GRNI_ACCOUNT.id }])
 

--- a/packages/lib/src/postings/__tests__/post-payout-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/post-payout-entry.test.ts
@@ -1,0 +1,79 @@
+// packages/lib/src/postings/__tests__/post-payout-entry.test.ts
+//
+// plans/accounting/tasks/17-accounting-is-opt-in.md section 3: the accounting-off
+// case is checked FIRST, before the builder, the period-lock read and the post.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  isAccountingEnabled: vi.fn(async () => true),
+  buildPayoutEntry: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  postEntry: vi.fn(),
+}))
+
+vi.mock('../accounting-enabled', () => ({ isAccountingEnabled: h.isAccountingEnabled }))
+vi.mock('../build-payout-entry', () => ({ buildPayoutEntry: h.buildPayoutEntry }))
+vi.mock('../period-lock', () => ({ resolvePeriodLock: h.resolvePeriodLock }))
+vi.mock('../post-entry', () => ({ postEntry: h.postEntry }))
+
+import type { Database } from '@auxx/database'
+import { ACCOUNT_ROLES } from '../build-entry'
+import { postPayoutEntry } from '../post-payout-entry'
+
+const ORG = 'org_1'
+const db = {} as Database
+
+const OPTIONS = {
+  organizationId: ORG,
+  actorUserId: 'user_1',
+  payoutId: 'po_1',
+  payoutNumber: 'PO-0007',
+  grossMinor: 500_000,
+  feesMinor: 14_800,
+  netMinor: 485_200,
+  clearingRole: ACCOUNT_ROLES.CLEARING_CARD,
+  paidAt: '2026-09-04',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.isAccountingEnabled.mockResolvedValue(true)
+  h.resolvePeriodLock.mockResolvedValue({ lockedThroughMonth: null })
+  h.buildPayoutEntry.mockReturnValue({
+    entry: { postingType: 'payout', periodKey: 'PO0007', txnDate: '2026-09-04', lines: [] },
+    periodKey: 'PO0007',
+    grossMinor: 500_000,
+  })
+  h.postEntry.mockResolvedValue({
+    status: 'posted',
+    glPostingId: 'gl_1',
+    docNumber: 'AUXX-PAY-PO0007',
+  })
+})
+
+describe('accounting enabled', () => {
+  it('builds, resolves the period lock, and posts', async () => {
+    const result = await postPayoutEntry(db, OPTIONS)
+
+    expect(h.buildPayoutEntry).toHaveBeenCalledTimes(1)
+    expect(h.resolvePeriodLock).toHaveBeenCalledTimes(1)
+    expect(h.postEntry).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ status: 'posted', glPostingId: 'gl_1', docNumber: 'AUXX-PAY-PO0007' })
+  })
+})
+
+describe('accounting not enabled', () => {
+  beforeEach(() => {
+    h.isAccountingEnabled.mockResolvedValue(false)
+  })
+
+  it('returns not_enabled without building, locking, or posting', async () => {
+    const result = await postPayoutEntry(db, OPTIONS)
+
+    expect(result).toEqual({ status: 'not_enabled' })
+    expect(h.buildPayoutEntry).not.toHaveBeenCalled()
+    expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/postings/__tests__/resolve-roles.test.ts
+++ b/packages/lib/src/postings/__tests__/resolve-roles.test.ts
@@ -413,6 +413,78 @@ function codeLine(accountCode: string, sortOrder = 0): GlPostingLineInput {
   }
 }
 
+function idLine(glAccountId: string, sortOrder = 0): GlPostingLineInput {
+  return {
+    glAccountId,
+    direction: sortOrder === 0 ? 'debit' : 'credit',
+    amount: 1000,
+    sourceType: 'gl_posting',
+    sourceId: 'gp_1',
+    sortOrder,
+  }
+}
+
+// ── Task 15: id lines ─────────────────────────────────────────────────────
+//
+// A reversal names the account the original LANDED on, by id, so a role that
+// was remapped in between cannot send the reversal somewhere else.
+
+describe('resolveAccountLines - id lines', () => {
+  it('resolves an id to the account the chart holds under it', async () => {
+    const db = stubLineDb([], [EXPENSE])
+    const result = await resolveAccountLines(db, ORG, [idLine('acct_bad_debt')])
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual([
+      {
+        glAccountId: 'acct_bad_debt',
+        code: '6300',
+        name: 'Bad Debt Expense',
+        accountType: 'expense',
+        isActive: true,
+      },
+    ])
+  })
+
+  it('refuses an id the chart does not hold, naming the row', async () => {
+    const db = stubLineDb([], [])
+    const result = await resolveAccountLines(db, ORG, [idLine('acct_gone')])
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain(
+      "Row 1: this organization's chart has no active account with id 'acct_gone'"
+    )
+  })
+
+  it('refuses an inactive account, naming it', async () => {
+    const db = stubLineDb([], [{ ...EXPENSE, isActive: false }])
+    const result = await resolveAccountLines(db, ORG, [idLine('acct_bad_debt')])
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('6300 Bad Debt Expense is not active')
+  })
+
+  it('mixes id, code and role lines and keeps the input order', async () => {
+    const db = stubLineDb([{ role: 'bad_debt_expense', glAccountId: 'acct_bad_debt' }], [EXPENSE])
+    const result = await resolveAccountLines(db, ORG, [
+      idLine('acct_bad_debt', 0),
+      codeLine('6300', 1),
+      {
+        ...codeLine('6300', 2),
+        accountCode: undefined,
+        accountRole: 'bad_debt_expense',
+      } as GlPostingLineInput,
+    ])
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().map((a) => a.glAccountId)).toEqual([
+      'acct_bad_debt',
+      'acct_bad_debt',
+      'acct_bad_debt',
+    ])
+  })
+})
+
 describe('resolveAccountLines - code lines', () => {
   it('resolves a code to the account the chart holds under it', async () => {
     const db = stubLineDb([], [EXPENSE])
@@ -502,7 +574,7 @@ describe('resolveAccountLines - code lines', () => {
     const error = await expectErr(
       resolveAccountLines(db, ORG, [bare as unknown as GlPostingLineInput])
     )
-    expect(error.message).toMatch(/neither an account role nor an account code/i)
+    expect(error.message).toMatch(/neither an account role, an account code nor an account id/i)
   })
 })
 

--- a/packages/lib/src/postings/__tests__/reverse-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/reverse-entry.test.ts
@@ -11,10 +11,15 @@
 //  2. **`revision`, never a `':rev'` suffix on `periodKey`.** gap-e §9 asked for
 //     the suffix and `parsePeriodKey` throws `BadRequestError` on it - the
 //     module that owns the keyspace rejects the key the design specified.
-//  3. **The reversal lands on the accounts the ORIGINAL posted to.** If the org
-//     repointed a role since, re-resolving would credit a different account and
-//     leave the first one overstated forever - and both entries would still
-//     balance, so nothing downstream could detect it.
+//  3. **The reversal lands on the accounts the ORIGINAL posted to, by
+//     `glAccountId` (task 15).** Before task 15 this rebuilt a role line as
+//     `{ accountRole }` and re-resolved it against the CURRENT chart, so a role
+//     repointed since the original posted credited a different account and left
+//     the first one overstated forever - and both entries would still balance,
+//     so nothing downstream could detect it. Reversing by the line's own stored
+//     id closes that: a role remap or a renumber cannot move a reversal off the
+//     account it is backing out of. The original's `accountRole` rides along
+//     as a snapshot, so the pair reads the same way in the journal.
 
 import { schema } from '@auxx/database'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -289,6 +294,7 @@ function originalLines(overrides: Partial<LineRow>[] = [{}, {}]): LineRow[] {
       organizationId: ORG,
       glPostingId: 'post_1',
       lineNumber: 1,
+      glAccountId: RAW.id,
       accountCode: '1310',
       accountRole: 'inventory_raw_materials',
       accountName: 'Raw Materials Inventory',
@@ -302,6 +308,7 @@ function originalLines(overrides: Partial<LineRow>[] = [{}, {}]): LineRow[] {
       organizationId: ORG,
       glPostingId: 'post_1',
       lineNumber: 2,
+      glAccountId: GRNI.id,
       accountCode: '2160',
       accountRole: 'grni',
       accountName: 'Goods Received Not Invoiced',
@@ -376,6 +383,9 @@ describe('the reversal pair', () => {
     expect(written[0]).toMatchObject({
       lineNumber: 1,
       accountCode: '1310',
+      // The role SNAPSHOT is carried over: the reversal says which account it
+      // was supposed to be, exactly as the original did. The id decided where
+      // it landed.
       accountRole: 'inventory_raw_materials',
       direction: 'credit',
       amountMinor: 125_000,
@@ -384,13 +394,18 @@ describe('the reversal pair', () => {
       sourceType: 'stock_movement',
       sourceId: 'mv_1',
     })
-    expect(written[1]).toMatchObject({ accountCode: '2160', direction: 'debit' })
+    expect(written[1]).toMatchObject({
+      accountCode: '2160',
+      accountRole: 'grni',
+      direction: 'debit',
+    })
   })
 
   it('writes the resolved account id on the reversal, same as any other entry', async () => {
-    // Task 15 §2: the reversal is posted through the same `resolveAccountLines`
-    // path as any other entry (the role names are unchanged, so this re-resolves
-    // to the SAME accounts) - it does not need its own propagation of the id.
+    // Task 15 §3: the reversal is built straight from each line's stored
+    // `glAccountId` and posted through the same `resolveAccountLines` path as
+    // any other entry, which re-confirms the id against the live chart rather
+    // than trusting it blindly.
     const fake = createFakeDb({ postings: [original()], lines: originalLines(), chart: CHART })
     await reverseEntry(fake.db, { organizationId: ORG, glPostingId: 'post_1', lock: OPEN })
 
@@ -434,6 +449,99 @@ describe('the reversal pair', () => {
     expect(second.error).toContain('reversed')
     expect(fake.postings).toHaveLength(2)
   })
+
+  // Before task 15 this was a REFUSAL: a renumber rebuilt the role line as
+  // `{ accountRole }`, re-resolved it against the CURRENT chart, and refused on
+  // the drift between the frozen code and today's. Reversing by `glAccountId`
+  // never re-resolves the role at all, so a renumber cannot be seen from here -
+  // it lands on the same account, and the code snapshot simply reads the
+  // account's CURRENT code, exactly as any other post would.
+  it('does not refuse when the chart renumbered the account - it reverses by id', async () => {
+    const fake = createFakeDb({
+      postings: [original()],
+      lines: originalLines(),
+      // The org renumbered GRNI after the original posted. Same id, new code.
+      chart: [{ role: 'grni', account: { ...GRNI, code: '2155' } }, CHART[1]!],
+    })
+
+    const result = await reverseEntry(fake.db, {
+      organizationId: ORG,
+      glPostingId: 'post_1',
+      lock: OPEN,
+    })
+
+    expect(result.status).toBe('not_connected')
+    const reversalId = fake.postings[1]!.id
+    const written = fake.lines.filter((line) => line.glPostingId === reversalId)
+    expect(written.map((line) => line.glAccountId)).toEqual([RAW.id, GRNI.id])
+    expect(written.find((line) => line.glAccountId === GRNI.id)?.accountCode).toBe('2155')
+  })
+
+  // The finding task 15 §2 recorded for this lane: a role remap between the
+  // post and the reversal used to credit whatever the role points at TODAY.
+  // Reversing by id never asks what the role means today at all, so the
+  // reversal lands on the ORIGINAL account even though `grni` now points
+  // somewhere else entirely.
+  it('reverses to the ORIGINAL account id, not wherever the role points today', async () => {
+    const REPOINTED: Account = {
+      id: 'acct_grni_v2',
+      code: '2170',
+      name: 'GRNI (repointed)',
+      accountType: 'liability',
+    }
+    const fake = createFakeDb({
+      postings: [original()],
+      lines: originalLines(),
+      chart: [
+        // The org repointed `grni` to a brand new account...
+        { role: 'grni', account: REPOINTED },
+        // ...but the account the original entry actually posted to is still
+        // live in the chart, simply no longer mapped to any role.
+        { role: 'grni_retired', account: GRNI },
+        CHART[1]!,
+      ],
+    })
+
+    const result = await reverseEntry(fake.db, {
+      organizationId: ORG,
+      glPostingId: 'post_1',
+      lock: OPEN,
+    })
+
+    expect(result.status).toBe('not_connected')
+    const reversalId = fake.postings[1]!.id
+    const written = fake.lines.filter((line) => line.glPostingId === reversalId)
+    expect(written.map((line) => line.glAccountId)).toEqual([RAW.id, GRNI.id])
+    expect(written.map((line) => line.glAccountId)).not.toContain(REPOINTED.id)
+  })
+
+  // Before HANDOFF slot 1A this was a REFUSAL: a role-less line could not be
+  // expressed as a `BuiltEntry`, which was role-keyed by construction, so
+  // reversing one was impossible and refusing was the only honest answer.
+  // `GlPostingLineInput` now carries both shapes, and since task 15 EVERY line
+  // (role-coded or code-coded) reverses by the same `glAccountId` door, so the
+  // two shapes cannot even drift apart at reversal time.
+  it('reverses every line by id, whether it posted by role or by code', async () => {
+    const fake = createFakeDb({
+      postings: [original()],
+      lines: originalLines([{ accountRole: null }, {}]),
+      chart: CHART,
+    })
+    const result = await reverseEntry(fake.db, {
+      organizationId: ORG,
+      glPostingId: 'post_1',
+      lock: OPEN,
+    })
+
+    expect(result.status).toBe('not_connected')
+    expect(fake.postings).toHaveLength(2)
+    const reversalId = fake.postings[1]!.id
+    const reversalLines = fake.lines.filter((line) => line.glPostingId === reversalId)
+    expect(reversalLines.map((line) => line.accountCode)).toEqual(['1310', '2160'])
+    // Each half keeps the snapshot it posted with: the code-coded line had
+    // none, the role-coded line keeps its role. Neither decided the account.
+    expect(reversalLines.map((line) => line.accountRole)).toEqual([null, 'grni'])
+  })
 })
 
 describe('refusals', () => {
@@ -466,55 +574,6 @@ describe('refusals', () => {
     expect(fake.postings).toHaveLength(1)
   })
 
-  it('refuses when the chart moved under the entry', async () => {
-    const fake = createFakeDb({
-      postings: [original()],
-      lines: originalLines(),
-      // The org renumbered GRNI after the original posted.
-      chart: [{ role: 'grni', account: { ...GRNI, code: '2155' } }, CHART[1]!],
-    })
-
-    const result = await reverseEntry(fake.db, {
-      organizationId: ORG,
-      glPostingId: 'post_1',
-      lock: OPEN,
-    })
-
-    // Reversing into 2155 would leave 2160 overstated forever, and the entry
-    // would still balance - so nothing downstream could detect it.
-    expect(result.status).toBe('error')
-    expect(result.error).toContain('2160')
-    expect(result.error).toContain('2155')
-    expect(result.glPostingId).toBe('post_1')
-    expect(fake.postings).toHaveLength(1)
-  })
-
-  // Before HANDOFF slot 1A this was a REFUSAL: a role-less line could not be
-  // expressed as a `BuiltEntry`, which was role-keyed by construction, so
-  // reversing one was impossible and refusing was the only honest answer. Since
-  // `GlPostingLineInput` carries both shapes, a code line reverses to the SAME
-  // code it posted to - which is what the drift check gives a role line, arrived
-  // at without a mapping to drift.
-  it('reverses a code line to the same code, with no drift check', async () => {
-    const fake = createFakeDb({
-      postings: [original()],
-      lines: originalLines([{ accountRole: null }, {}]),
-      chart: CHART,
-    })
-    const result = await reverseEntry(fake.db, {
-      organizationId: ORG,
-      glPostingId: 'post_1',
-      lock: OPEN,
-    })
-
-    expect(result.status).toBe('not_connected')
-    expect(fake.postings).toHaveLength(2)
-    const reversalLines = fake.lines.filter((line) => line.glPostingId === 'post_2')
-    expect(reversalLines.map((line) => line.accountCode)).toEqual(['1310', '2160'])
-    // The role-less half stays role-less; the other half keeps its role.
-    expect(reversalLines.map((line) => line.accountRole)).toEqual([null, 'grni'])
-  })
-
   it('refuses an entry with no lines', async () => {
     const fake = createFakeDb({ postings: [original()], lines: [], chart: CHART })
     const result = await reverseEntry(fake.db, {
@@ -540,7 +599,10 @@ describe('refusals', () => {
     expect(fake.postings[0]!.status).toBe('posted')
   })
 
-  it('reports an unmapped role rather than reversing into nothing', async () => {
+  it('reports the account gone rather than reversing into nothing', async () => {
+    // Not a role lookup any more - this is `resolveAccountLines`' by-id door
+    // refusing because the id the original line stored ('acct_grni') decodes to
+    // no live account, the same as it would for a deleted or archived one.
     const fake = createFakeDb({
       postings: [original()],
       lines: originalLines(),
@@ -554,7 +616,7 @@ describe('refusals', () => {
 
     expect(result.status).toBe('account_unmapped')
     expect(result.failureClass).toBe('configuration')
-    expect(result.error).toContain('grni')
+    expect(result.error).toContain(GRNI.id)
     expect(fake.postings).toHaveLength(1)
   })
 })

--- a/packages/lib/src/postings/__tests__/role-map.test.ts
+++ b/packages/lib/src/postings/__tests__/role-map.test.ts
@@ -38,7 +38,12 @@ vi.mock('../../cache', () => ({
   }),
 }))
 
-import { listChartAccounts, listRoleMap, setRoleAssignment } from '../role-map'
+import {
+  listChartAccounts,
+  listChartAccountUsage,
+  listRoleMap,
+  setRoleAssignment,
+} from '../role-map'
 
 const ORG = 'org_1'
 const OTHER_ORG = 'org_2'
@@ -719,5 +724,50 @@ describe('setRoleAssignment - marking a role unused', () => {
       setRoleAssignment(stub.db, { organizationId: ORG, role: 'grni', markedUnused: true })
     )
     expect(error).toBeInstanceOf(NotFoundError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listChartAccountUsage - task 15 §3: keyed on glAccountId, not on code
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('listChartAccountUsage', () => {
+  /** A minimal thenable, the way `trial-balance.test.ts` stubs its own grouped read. */
+  function stubUsageDb(rows: { glAccountId: string | null; lines: number }[]): Database {
+    const chain: Record<string, unknown> = {}
+    const passthrough = () => chain
+    chain.from = passthrough
+    chain.where = passthrough
+    chain.groupBy = passthrough
+    // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
+    chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject)
+    return { select: () => chain } as unknown as Database
+  }
+
+  // The number this brief exists to correct: before task 15 this was keyed on
+  // the code a line snapshot carried, which undercounted an account renumbered
+  // partway through its posted history. Grouping on the id it always posted to
+  // reports the true count regardless of how many times the code moved.
+  it('counts posted lines per glAccountId, not per code', async () => {
+    const result = await listChartAccountUsage(
+      stubUsageDb([
+        { glAccountId: 'acct_1310', lines: 142 },
+        { glAccountId: 'acct_2160', lines: 3 },
+      ]),
+      ORG
+    )
+
+    expect(result._unsafeUnwrap()).toEqual({ acct_1310: 142, acct_2160: 3 })
+  })
+
+  it('is empty over a ledger with no posted lines', async () => {
+    const result = await listChartAccountUsage(stubUsageDb([]), ORG)
+    expect(result._unsafeUnwrap()).toEqual({})
+  })
+
+  it('skips a row with no id rather than writing an "undefined" key', async () => {
+    const result = await listChartAccountUsage(stubUsageDb([{ glAccountId: null, lines: 5 }]), ORG)
+    expect(result._unsafeUnwrap()).toEqual({})
   })
 })

--- a/packages/lib/src/postings/accounting-enabled.ts
+++ b/packages/lib/src/postings/accounting-enabled.ts
@@ -1,0 +1,26 @@
+// packages/lib/src/postings/accounting-enabled.ts
+
+import type { Database } from '@auxx/database'
+import { FeaturePermissionService } from '../permissions/feature-permission-service'
+import { FeatureKey } from '../permissions/types'
+
+/**
+ * Has this organization enabled the accounting module at all?
+ *
+ * The gate every document-driven posting trigger checks FIRST
+ * (plans/accounting/tasks/17-accounting-is-opt-in.md section 3). An org that
+ * never turned accounting on is a first-class silent case, like `not_connected`
+ * under decision P1: nothing is built, nothing is claimed, nothing is logged,
+ * and the trigger answers `not_enabled`. It is deliberately distinct from
+ * `accounting.setupState`, which means the module is ON and the wizard was not
+ * finished; that one keeps its `setup_incomplete` refusal and its warning.
+ *
+ * Reads `FeatureKey.accounting` through `FeaturePermissionService`, which is the
+ * same door the ledger router and the nav use, so a trigger and a screen cannot
+ * disagree about whether accounting exists for an org. That service reads the
+ * org cache's `features` key (30-day TTL, invalidated on plan events) and
+ * answers `true` on a self-hosted install, where every feature is on.
+ */
+export async function isAccountingEnabled(db: Database, organizationId: string): Promise<boolean> {
+  return new FeaturePermissionService(db).hasAccess(organizationId, FeatureKey.accounting)
+}

--- a/packages/lib/src/postings/build-entry.ts
+++ b/packages/lib/src/postings/build-entry.ts
@@ -508,27 +508,35 @@ export function buildEntry(input: BuildEntryInput): BuiltEntry {
   let totalCredit = 0
 
   for (const line of lines) {
-    // A line names an account in exactly ONE of the two ways `GlPostingLineInput`
-    // allows - a builder's ROLE or a human's CODE (HANDOFF slot 1A). Neither is
-    // the refusal below; both at once is the other one, and it is refused rather
-    // than resolved by precedence, because a precedence rule would silently post
-    // to whichever of two named accounts this function happened to prefer.
-    // Read through a widened alias: the union's `?: never` legs make TypeScript
-    // prove the both-at-once case away, and a runtime check is still wanted
-    // because a tRPC caller or a JSON round trip can produce it.
-    const shape = line as { accountRole?: string; accountCode?: string }
-    const role = shape.accountRole?.trim()
+    // A line names an account in exactly ONE of the three ways `GlPostingLineInput`
+    // allows - a builder's ROLE, a human's CODE (HANDOFF slot 1A), or the
+    // account's own ID (task 15: what a reversal carries so it lands where the
+    // original did). None is the refusal below; more than one at once is the
+    // other one, and it is refused rather than resolved by precedence, because a
+    // precedence rule would silently post to whichever of two named accounts
+    // this function happened to prefer. Read through a widened alias: the
+    // union's `?: never` legs make TypeScript prove the several-at-once case
+    // away, and a runtime check is still wanted because a tRPC caller or a JSON
+    // round trip can produce it.
+    const shape = line as { accountRole?: string; accountCode?: string; glAccountId?: string }
     const code = shape.accountCode?.trim()
-    const named = role || code
+    const id = shape.glAccountId?.trim()
+    // Beside an id, a role is the SNAPSHOT the id variant lets a reversal carry
+    // (see `GlPostingLineInput`), not a second naming; the id alone resolves.
+    const role = id ? undefined : shape.accountRole?.trim()
+    const named = role || code || id
     if (!named) {
       throw new UnprocessableEntityError(
-        'A posting line must carry an account role or an account code',
+        'A posting line must carry an account role, an account code or an account id',
         { postingType, periodKey }
       )
     }
-    if (role && code) {
+    const namings = [role && `role '${role}'`, code && `code '${code}'`, id && `id '${id}'`].filter(
+      Boolean
+    )
+    if (namings.length > 1) {
       throw new UnprocessableEntityError(
-        `A posting line names both role '${role}' and code '${code}'. It must name one.`,
+        `A posting line names both ${namings.join(' and ')}. It must name one.`,
         { postingType, periodKey }
       )
     }

--- a/packages/lib/src/postings/chart-write.ts
+++ b/packages/lib/src/postings/chart-write.ts
@@ -5,7 +5,7 @@
  *
  * `G7` has said the chart is the org's own document since it was seeded, and
  * every piece of machinery downstream is built on that premise - `G8` exists
- * only because the chart is editable, and `GlPostingLine.accountCode` has no
+ * only because the chart is editable, and `GlPostingLine.glAccountId` has no
  * foreign key only because the chart is editable. Until this file there was no
  * writer but `seedDefaultChartOfAccounts`, which runs once at migration time.
  *
@@ -32,11 +32,12 @@
  * - a RENUMBER cannot touch role resolution - `GlRoleAssignment.glAccountId`
  *   names the INSTANCE, not the code, which is `G8` doing its job
  *
- * What a renumber does do is detach every line already posted from the row on
- * screen, because a posted line stores the code with no foreign key. That is
- * decision `P2` working as designed - the ledger outlives the chart - and it is
- * not this module's business to refuse it. It is the UI's business to say so,
- * with a count (`listChartAccountUsage` in `role-map.ts`).
+ * 🛑 **Since task 15, a RENUMBER no longer detaches anything either.** A posted
+ * line stores `glAccountId` - the account's IDENTITY - with no foreign key, so
+ * every line ever posted to this account keeps reading as one row on every
+ * statement no matter what its code becomes. Only ARCHIVING or deleting the
+ * account detaches its history (`listChartAccountUsage` in `role-map.ts` is the
+ * count for THAT caution, not for a renumber - see `Remove` below).
  *
  * ## Removal is ARCHIVE, never delete
  *

--- a/packages/lib/src/postings/post-payout-entry.ts
+++ b/packages/lib/src/postings/post-payout-entry.ts
@@ -28,6 +28,7 @@
 
 import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { isAccountingEnabled } from './accounting-enabled'
 import { type BuildPayoutEntryInput, buildPayoutEntry } from './build-payout-entry'
 import { resolvePeriodLock } from './period-lock'
 import { postEntry } from './post-entry'
@@ -48,12 +49,24 @@ export interface PostPayoutEntryOptions extends BuildPayoutEntryInput {
  * comes back as `{ status: 'error' }` with the builder's own message, which is
  * what `EntryBlockers` renders. Everything `postEntry` can answer passes
  * through unchanged.
+ *
+ * Checked FIRST, before the builder: an org that has never turned accounting on
+ * gets `{ status: 'not_enabled' }` with no build, no period-lock read and no
+ * log line (task 17 section 3) - the same first-class silent case as
+ * `not_connected`. `money/payouts/sync.ts` also short-circuits per org before
+ * it ever calls this, which is where the real saving is (it skips the Stripe
+ * payout list and the record write too); the check is repeated here so this
+ * function is correct on its own for any future caller.
  */
 export async function postPayoutEntry(
   db: Database,
   options: PostPayoutEntryOptions
 ): Promise<PostResult> {
   const { organizationId, actorUserId, ...input } = options
+
+  if (!(await isAccountingEnabled(db, organizationId))) {
+    return { status: 'not_enabled' }
+  }
 
   try {
     const built = buildPayoutEntry(input)

--- a/packages/lib/src/postings/reports/__tests__/account-lines.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/account-lines.test.ts
@@ -81,7 +81,7 @@ describe('readAccountLines', () => {
           }),
         ],
       ]),
-      { organizationId: ORG, accountCode: '1000' }
+      { organizationId: ORG, glAccountId: 'id_1000' }
     )
 
     const lines = result._unsafeUnwrap()
@@ -110,7 +110,7 @@ describe('readAccountLines', () => {
           }),
         ],
       ]),
-      { organizationId: ORG, accountCode: '1000', from: '2026-08-01', to: '2026-08-31' }
+      { organizationId: ORG, glAccountId: 'id_1000', from: '2026-08-01', to: '2026-08-31' }
     )
 
     const lines = result._unsafeUnwrap()
@@ -136,18 +136,18 @@ describe('readAccountLines', () => {
           }),
         ],
       ]),
-      { organizationId: ORG, accountCode: '2000' }
+      { organizationId: ORG, glAccountId: 'id_2000' }
     )
 
     expect(result._unsafeUnwrap().lines[0]?.runningBalanceMinor).toBe(1_000)
   })
 
-  it('reports accountType null and an empty name when the code is not in the chart', async () => {
+  it('reports accountType null and an empty name when the id is not in the chart', async () => {
     vi.mocked(listChartAccounts).mockResolvedValue(ok([]))
 
     const result = await readAccountLines(sequentialDb([[]]), {
       organizationId: ORG,
-      accountCode: '9999',
+      glAccountId: 'id_9999',
     })
     const lines = result._unsafeUnwrap()
 

--- a/packages/lib/src/postings/reports/__tests__/adapters.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/adapters.test.ts
@@ -17,6 +17,7 @@ const trialBalance: TrialBalance = {
   to: '2026-08-31',
   rows: [
     {
+      glAccountId: 'acct_1000',
       accountCode: '1000',
       accountName: 'Cash',
       accountType: 'asset',
@@ -35,7 +36,9 @@ describe('toTrialBalanceRows', () => {
   it('one line per account, plus a total row', () => {
     const rows = toTrialBalanceRows(trialBalance)
     expect(rows).toHaveLength(2)
-    expect(rows[0]).toMatchObject({ id: '1000', kind: 'line', values: [100_000, 0, 100_000] })
+    // The row id is the account's IDENTITY (task 15), not its code.
+    expect(rows[0]).toMatchObject({ id: 'acct_1000', kind: 'line', values: [100_000, 0, 100_000] })
+    expect(rows[0]?.meta).toMatchObject({ glAccountId: 'acct_1000', accountCode: '1000' })
     expect(rows[1]).toMatchObject({ id: 'total', kind: 'total', values: [100_000, 100_000, null] })
   })
 })
@@ -44,6 +47,7 @@ const balanceSheet: BalanceSheetSnapshot = {
   asOf: '2026-08-31',
   assets: [
     {
+      glAccountId: 'acct_1000',
       accountCode: '1000',
       accountName: 'Cash',
       accountType: 'asset',
@@ -53,6 +57,7 @@ const balanceSheet: BalanceSheetSnapshot = {
   ],
   liabilities: [
     {
+      glAccountId: 'acct_2000',
       accountCode: '2000',
       accountName: 'A/P',
       accountType: 'liability',
@@ -62,6 +67,7 @@ const balanceSheet: BalanceSheetSnapshot = {
   ],
   equity: [
     {
+      glAccountId: 'acct_3000',
       accountCode: '3000',
       accountName: "Owner's Equity",
       accountType: 'equity',
@@ -164,6 +170,7 @@ const profitAndLoss: ProfitAndLossSnapshot = {
   to: '2026-08-31',
   revenue: [
     {
+      glAccountId: 'acct_4000',
       accountCode: '4000',
       accountName: 'Product Revenue',
       accountType: 'revenue',
@@ -174,6 +181,7 @@ const profitAndLoss: ProfitAndLossSnapshot = {
   totalRevenueMinor: 500_000,
   cogs: [
     {
+      glAccountId: 'acct_5000',
       accountCode: '5000',
       accountName: 'COGS',
       accountType: 'expense',
@@ -185,6 +193,7 @@ const profitAndLoss: ProfitAndLossSnapshot = {
   grossProfitMinor: 300_000,
   operatingExpenses: [
     {
+      glAccountId: 'acct_6100',
       accountCode: '6100',
       accountName: 'Merchant Fees',
       accountType: 'expense',

--- a/packages/lib/src/postings/reports/__tests__/aging.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/aging.test.ts
@@ -340,6 +340,7 @@ describe('readAging', () => {
         to: '2026-08-31',
         rows: [
           {
+            glAccountId: 'a1',
             accountCode: '1100',
             accountName: 'A/R',
             accountType: 'asset',
@@ -406,6 +407,7 @@ describe('readAging', () => {
         to: '2026-08-31',
         rows: [
           {
+            glAccountId: 'a1',
             accountCode: '1100',
             accountName: 'A/R',
             accountType: 'asset',
@@ -505,6 +507,7 @@ describe('readAging', () => {
         to: '2026-08-31',
         rows: [
           {
+            glAccountId: 'a2',
             accountCode: '2000',
             accountName: 'A/P',
             accountType: 'liability',
@@ -559,6 +562,7 @@ describe('readAging', () => {
         to: '2026-08-31',
         rows: [
           {
+            glAccountId: 'a1',
             accountCode: '1100',
             accountName: 'A/R',
             accountType: 'asset',
@@ -618,6 +622,7 @@ describe('readAging', () => {
         to: '2026-08-31',
         rows: [
           {
+            glAccountId: 'a1',
             accountCode: '1100',
             accountName: 'A/R',
             accountType: 'asset',

--- a/packages/lib/src/postings/reports/__tests__/balance-sheet.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/balance-sheet.test.ts
@@ -26,8 +26,10 @@ import { readTrialBalance } from '../trial-balance'
 
 const ORG = 'org_1'
 
+/** `glAccountId` defaults to `id_<accountCode>` - matches `mockRetainedEarningsRole`'s `id_3100`. */
 function row(overrides: Partial<TrialBalanceRow> & { accountCode: string }): TrialBalanceRow {
   return {
+    glAccountId: `id_${overrides.accountCode}`,
     accountName: '',
     accountType: 'asset',
     debitMinor: 0,

--- a/packages/lib/src/postings/reports/__tests__/groups-by-identity.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/groups-by-identity.test.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/postings/reports/__tests__/groups-by-identity.test.ts
+//
+// Task 15 §3's own negative: a report groups posted lines by `glAccountId` -
+// the account's IDENTITY - never by `accountCode`, which is a label the org
+// may rename or renumber at will. This is the test that stops the change
+// being half-applied: a single report file reverting to `GROUP BY accountCode`
+// (or filtering a chart-scoped read by it) would silently re-fragment that
+// account's history the moment somebody renumbers it, exactly as `trial-
+// balance.test.ts`'s renumber regression demonstrates the read itself no
+// longer does.
+//
+// `walkTsFiles` borrows the house style from
+// `seed/entity-migrations/migrations/108-purchasing.test.ts`'s own source
+// scan (the "inert payment entities stay inert" pin).
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    // `__tests__` is excluded so this file's own description of the pattern
+    // (in prose, above) can never trip its own scan.
+    if (entry === '__tests__' || entry === 'node_modules' || entry === 'dist') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walkTsFiles(full, out)
+    else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Matches a Drizzle `.groupBy(...)` call, or an `eq(...)`/`inArray(...)`
+ * filter, whose argument names `GlPostingLine.accountCode` - the shape a
+ * report read used before task 15, and the shape a regression would look
+ * exactly like again. `[^)]*` spans newlines (it excludes only the closing
+ * paren), so a call formatted across several lines still matches.
+ */
+const GROUPS_OR_FILTERS_BY_CODE = /\.(?:groupBy|eq|inArray)\(\s*[^)]*GlPostingLine\.accountCode/
+
+describe('no report under postings/reports/ groups or filters by accountCode (task 15 §3)', () => {
+  it('every chart-scoped read keys on glAccountId, the identity, not the label', () => {
+    const reportsDir = join(fileURLToPath(new URL('.', import.meta.url)), '..')
+    const offenders: string[] = []
+
+    for (const file of walkTsFiles(reportsDir)) {
+      const source = readFileSync(file, 'utf8')
+      if (GROUPS_OR_FILTERS_BY_CODE.test(source)) {
+        offenders.push(file)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/lib/src/postings/reports/__tests__/net-income-matches-retained-earnings.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/net-income-matches-retained-earnings.test.ts
@@ -25,8 +25,10 @@ import { readTrialBalance } from '../trial-balance'
 
 const ORG = 'org_1'
 
+/** `glAccountId` defaults to `id_<accountCode>` - see `balance-sheet.test.ts`'s own helper. */
 function row(overrides: Partial<TrialBalanceRow> & { accountCode: string }): TrialBalanceRow {
   return {
+    glAccountId: `id_${overrides.accountCode}`,
     accountName: '',
     accountType: 'asset',
     debitMinor: 0,

--- a/packages/lib/src/postings/reports/__tests__/profit-and-loss.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/profit-and-loss.test.ts
@@ -16,8 +16,10 @@ import { readTrialBalance } from '../trial-balance'
 
 const ORG = 'org_1'
 
+/** `glAccountId` defaults to `id_<accountCode>`. */
 function row(overrides: Partial<TrialBalanceRow> & { accountCode: string }): TrialBalanceRow {
   return {
+    glAccountId: `id_${overrides.accountCode}`,
     accountName: '',
     accountType: 'revenue',
     debitMinor: 0,

--- a/packages/lib/src/postings/reports/__tests__/trial-balance.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/trial-balance.test.ts
@@ -32,8 +32,14 @@ function stubDb(rows: unknown[]) {
   return { select: () => chain } as unknown as Database
 }
 
-function groupedRow(accountCode: string, debit: number, credit: number) {
-  return { accountCode, debitMinor: String(debit), creditMinor: String(credit) }
+/** `glAccountId` defaults to `id_<accountCode>`, matching the `account()` helper below. */
+function groupedRow(
+  accountCode: string,
+  debit: number,
+  credit: number,
+  glAccountId = `id_${accountCode}`
+) {
+  return { glAccountId, accountCode, debitMinor: String(debit), creditMinor: String(credit) }
 }
 
 function account(overrides: Partial<ChartAccountRow> & { code: string }): ChartAccountRow {
@@ -63,6 +69,7 @@ describe('readTrialBalance', () => {
     const tb = result._unsafeUnwrap()
     expect(tb.rows).toEqual([
       {
+        glAccountId: 'id_1000',
         accountCode: '1000',
         accountName: 'Cash',
         accountType: 'asset',
@@ -72,6 +79,7 @@ describe('readTrialBalance', () => {
         inChart: true,
       },
       {
+        glAccountId: 'id_2000',
         accountCode: '2000',
         accountName: 'Accounts Payable',
         accountType: 'liability',
@@ -102,7 +110,7 @@ describe('readTrialBalance', () => {
     expect(result._unsafeUnwrap().balanced).toBe(true)
   })
 
-  it('flags an account code with posted lines but no live chart row', async () => {
+  it('flags an id with posted lines but no live chart row (the account was deleted)', async () => {
     vi.mocked(listChartAccounts).mockResolvedValue(ok([]))
 
     const result = await readTrialBalance(stubDb([groupedRow('9999', 100, 0)]), {
@@ -112,10 +120,59 @@ describe('readTrialBalance', () => {
 
     const row = result._unsafeUnwrap().rows[0]
     expect(row).toMatchObject({
+      glAccountId: 'id_9999',
+      // Falls back to the line's own snapshot code - the only identifying
+      // label left once the account is gone from the chart.
       accountCode: '9999',
       accountType: null,
       inChart: false,
       balanceMinor: 0,
+    })
+  })
+
+  // The regression task 15 names: a renumber must not split one account's
+  // history into two trial-balance rows.
+  it('reads as ONE row with the CURRENT code when the account has been renumbered', async () => {
+    // The account posted to as '1100'; it has since been renumbered to '1150'.
+    vi.mocked(listChartAccounts).mockResolvedValue(
+      ok([
+        account({ id: 'id_1100', code: '1150', name: 'Cash (renumbered)', accountType: 'asset' }),
+      ])
+    )
+
+    const result = await readTrialBalance(stubDb([groupedRow('1100', 125_000, 0, 'id_1100')]), {
+      organizationId: ORG,
+      to: '2026-08-31',
+    })
+
+    const tb = result._unsafeUnwrap()
+    expect(tb.rows).toHaveLength(1)
+    expect(tb.rows[0]).toMatchObject({
+      glAccountId: 'id_1100',
+      // The CURRENT code and name, not the '1100' snapshot the line carries.
+      accountCode: '1150',
+      accountName: 'Cash (renumbered)',
+      balanceMinor: 125_000,
+      inChart: true,
+    })
+  })
+
+  // Same rule for a RENAME: a statement reads the chart, never the snapshot -
+  // §3's exception is the journal view of one entry (out of this lane's scope),
+  // which keeps showing the name it was posted under.
+  it('shows the CURRENT name when the account has been renamed', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(
+      ok([account({ id: 'id_1000', code: '1000', name: 'Operating Cash', accountType: 'asset' })])
+    )
+
+    const result = await readTrialBalance(stubDb([groupedRow('1000', 100_000, 0, 'id_1000')]), {
+      organizationId: ORG,
+      to: '2026-08-31',
+    })
+
+    expect(result._unsafeUnwrap().rows[0]).toMatchObject({
+      glAccountId: 'id_1000',
+      accountName: 'Operating Cash',
     })
   })
 

--- a/packages/lib/src/postings/reports/account-lines.ts
+++ b/packages/lib/src/postings/reports/account-lines.ts
@@ -1,8 +1,13 @@
 // packages/lib/src/postings/reports/account-lines.ts
 //
-// The drill-down behind one account code: every posted line, in date order,
-// with a running natural-sign balance. What a click on a trial-balance,
-// balance-sheet or P&L row opens.
+// The drill-down behind one account: every posted line, in date order, with a
+// running natural-sign balance. What a click on a trial-balance, balance-sheet
+// or P&L row opens.
+//
+// Keyed on `glAccountId`, not `accountCode` (task 15 §3): a statement row's
+// `id` is now the account's IDENTITY, so its drill-down must open by the same
+// key or a renumbered account's history would split across two drill-downs
+// exactly the way it used to split across two trial-balance rows.
 //
 // No permission checks here. The router asserts (`docs/lib-module-guide.md` §6).
 
@@ -36,10 +41,13 @@ export interface AccountLineRow {
 
 export interface AccountLines {
   organizationId: string
+  /** The `gl_account` `EntityInstance` id this drill-down is keyed on. The IDENTITY (task 15). */
+  glAccountId: string
+  /** The account's CURRENT code, read from the live chart by id. `''` when the account has been deleted. */
   accountCode: string
-  /** `''` when the code names no live account in this org's chart. */
+  /** `''` when the account has been deleted from this org's chart. */
   accountName: string
-  /** `null` when the code names no live account - the running balance is then unsigned (raw debit). */
+  /** `null` when the account has been deleted - the running balance is then unsigned (raw debit). */
   accountType: GlAccountTypeValue | null
   /** `null` when the read is unbounded on the start - the balance sheet's own cumulative range. */
   from: string | null
@@ -53,7 +61,8 @@ export interface AccountLines {
 
 export interface ReadAccountLinesOptions {
   organizationId: string
-  accountCode: string
+  /** The `gl_account` `EntityInstance` id - task 15's identity, not a code. */
+  glAccountId: string
   /** `YYYY-MM-DD`. Omit for a cumulative-from-the-beginning read. */
   from?: string
   /** `YYYY-MM-DD`, inclusive. Omit for open-ended. */
@@ -61,7 +70,7 @@ export interface ReadAccountLinesOptions {
 }
 
 /**
- * Every posted line against `accountCode`, oldest first, with a running
+ * Every posted line against `glAccountId`, oldest first, with a running
  * natural-sign balance - `signedBalance` applied line by line rather than
  * once over a sum, so a reader can see the balance AT any line, not just at
  * the end.
@@ -74,17 +83,17 @@ export async function readAccountLines(
   db: Database,
   options: ReadAccountLinesOptions
 ): Promise<Result<AccountLines, Error>> {
-  const { organizationId, accountCode, from, to } = options
+  const { organizationId, glAccountId, from, to } = options
 
   try {
     const chartResult = await listChartAccounts(db, organizationId)
     if (chartResult.isErr()) return err(chartResult.error)
-    const account = chartResult.value.find((row) => row.code === accountCode) ?? null
+    const account = chartResult.value.find((row) => row.id === glAccountId) ?? null
     const naturalDirection = account ? NATURAL_BALANCE_DIRECTION[account.accountType] : 'debit'
 
     let openingBalanceMinor = 0
     if (from) {
-      const before = await sumDebitCredit(db, organizationId, accountCode, {
+      const before = await sumDebitCredit(db, organizationId, glAccountId, {
         to: previousCalendarDay(from),
       })
       openingBalanceMinor = account
@@ -95,7 +104,7 @@ export async function readAccountLines(
     const bounds = [
       eq(schema.GlPosting.organizationId, organizationId),
       inArray(schema.GlPosting.status, [...POSTED_STATUSES]),
-      eq(schema.GlPostingLine.accountCode, accountCode),
+      eq(schema.GlPostingLine.glAccountId, glAccountId),
     ]
     if (from) bounds.push(gte(schema.GlPosting.txnDate, from))
     if (to) bounds.push(lte(schema.GlPosting.txnDate, to))
@@ -137,7 +146,8 @@ export async function readAccountLines(
 
     return ok({
       organizationId,
-      accountCode,
+      glAccountId,
+      accountCode: account?.code ?? '',
       accountName: account?.name ?? '',
       accountType: account?.accountType ?? null,
       from: from ?? null,
@@ -151,16 +161,16 @@ export async function readAccountLines(
     })
   } catch (error) {
     if (error instanceof AuxxError) return err(error)
-    logger.error('Failed to read account lines', { error, organizationId, accountCode, from, to })
+    logger.error('Failed to read account lines', { error, organizationId, glAccountId, from, to })
     return err(new AuxxError('Internal error'))
   }
 }
 
-/** `SUM(debit)` / `SUM(credit)` for one account code, bounded only by `to` - the opening-balance query. */
+/** `SUM(debit)` / `SUM(credit)` for one account id, bounded only by `to` - the opening-balance query. */
 async function sumDebitCredit(
   db: Database,
   organizationId: string,
-  accountCode: string,
+  glAccountId: string,
   bounds: { to: string }
 ): Promise<{ debitMinor: number; creditMinor: number }> {
   const [row] = await db
@@ -174,7 +184,7 @@ async function sumDebitCredit(
       and(
         eq(schema.GlPosting.organizationId, organizationId),
         inArray(schema.GlPosting.status, [...POSTED_STATUSES]),
-        eq(schema.GlPostingLine.accountCode, accountCode),
+        eq(schema.GlPostingLine.glAccountId, glAccountId),
         lte(schema.GlPosting.txnDate, bounds.to)
       )
     )

--- a/packages/lib/src/postings/reports/adapters.ts
+++ b/packages/lib/src/postings/reports/adapters.ts
@@ -23,24 +23,27 @@ export const TRIAL_BALANCE_COLUMNS: StatementColumn[] = [
 ]
 
 /**
- * One `'line'` row per account code, in the trial balance's own order, plus a
+ * One `'line'` row per account, in the trial balance's own order, plus a
  * `'total'` row. Flat rather than sectioned by `accountType`, matching the
- * read itself (`GROUP BY accountCode`, no statement grouping) - a screen that
+ * read itself (`GROUP BY glAccountId`, no statement grouping) - a screen that
  * wants sections filters by `accountType` on the underlying `TrialBalance`
  * rather than on this shape.
  */
 export function toTrialBalanceRows(tb: TrialBalance): StatementRow[] {
   const lines: StatementRow[] = tb.rows.map((row) => ({
-    id: row.accountCode,
+    // The IDENTITY (task 15), not the code: two rows can no longer collide
+    // because an account was renumbered mid-history.
+    id: row.glAccountId,
     label: row.inChart ? `${row.accountCode} ${row.accountName}` : `${row.accountCode}`,
     depth: 0,
     kind: 'line',
     values: [row.debitMinor, row.creditMinor, row.balanceMinor],
     meta: {
+      glAccountId: row.glAccountId,
       accountCode: row.accountCode,
       note: row.inChart
         ? undefined
-        : 'This code has posted lines but is not in the current chart of accounts.',
+        : 'This account has posted lines but has been deleted from the current chart of accounts.',
     },
   }))
 
@@ -60,11 +63,12 @@ export function balanceSheetColumns(bs: {
   return columns
 }
 
+/** Match the compare snapshot's row by `glAccountId` (task 15), never by code - a renumber between the two reads must not miss. */
 function findCompare(
-  rows: readonly { accountCode: string; balanceMinor: number }[],
-  code: string
+  rows: readonly { glAccountId: string; balanceMinor: number }[],
+  glAccountId: string
 ): number | null {
-  return rows.find((row) => row.accountCode === code)?.balanceMinor ?? null
+  return rows.find((row) => row.glAccountId === glAccountId)?.balanceMinor ?? null
 }
 
 /**
@@ -80,9 +84,9 @@ export function toBalanceSheetRows(
 ): StatementRow[] {
   const two = (
     value: number,
-    rows: readonly { accountCode: string; balanceMinor: number }[],
-    code: string
-  ) => (compare ? [value, findCompare(rows, code)] : [value])
+    rows: readonly { glAccountId: string; balanceMinor: number }[],
+    glAccountId: string
+  ) => (compare ? [value, findCompare(rows, glAccountId)] : [value])
 
   const section = (
     id: string,
@@ -95,16 +99,18 @@ export function toBalanceSheetRows(
     extraChildren: StatementRow[] = []
   ): StatementRow => {
     const children: StatementRow[] = rows.map((row) => ({
-      id: row.accountCode,
+      // The IDENTITY (task 15), not the code - see `toTrialBalanceRows`.
+      id: row.glAccountId,
       label: row.inChart ? `${row.accountCode} ${row.accountName}` : row.accountCode,
       depth: 1,
       kind: 'line',
-      values: two(row.balanceMinor, compareRows, row.accountCode),
+      values: two(row.balanceMinor, compareRows, row.glAccountId),
       meta: {
+        glAccountId: row.glAccountId,
         accountCode: row.accountCode,
         note: row.inChart
           ? undefined
-          : 'This code has posted lines but is not in the current chart of accounts.',
+          : 'This account has posted lines but has been deleted from the current chart of accounts.',
       },
     }))
     children.push(...extraChildren)
@@ -210,25 +216,27 @@ export function toProfitAndLossRows(
 ): StatementRow[] {
   const two = (
     value: number,
-    rows: readonly { accountCode: string; balanceMinor: number }[],
-    code: string
-  ) => (compare ? [value, findCompare(rows, code)] : [value])
+    rows: readonly { glAccountId: string; balanceMinor: number }[],
+    glAccountId: string
+  ) => (compare ? [value, findCompare(rows, glAccountId)] : [value])
 
   const lines = (
     rows: readonly ProfitAndLossRow[],
     compareRows: readonly ProfitAndLossRow[]
   ): StatementRow[] =>
     rows.map((row) => ({
-      id: row.accountCode,
+      // The IDENTITY (task 15), not the code - see `toTrialBalanceRows`.
+      id: row.glAccountId,
       label: row.inChart ? `${row.accountCode} ${row.accountName}` : row.accountCode,
       depth: 1,
       kind: 'line' as const,
-      values: two(row.balanceMinor, compareRows, row.accountCode),
+      values: two(row.balanceMinor, compareRows, row.glAccountId),
       meta: {
+        glAccountId: row.glAccountId,
         accountCode: row.accountCode,
         note: row.inChart
           ? undefined
-          : 'This code has posted lines but is not in the current chart of accounts.',
+          : 'This account has posted lines but has been deleted from the current chart of accounts.',
       },
     }))
 

--- a/packages/lib/src/postings/reports/aging.ts
+++ b/packages/lib/src/postings/reports/aging.ts
@@ -271,7 +271,9 @@ export async function readAging(
         and(
           eq(schema.GlPosting.organizationId, organizationId),
           inArray(schema.GlPosting.status, [...POSTED_STATUSES]),
-          eq(schema.GlPostingLine.accountCode, account.code),
+          // By id (task 15), not by code: a renumber of the A/R or A/P account
+          // between two postings must not split its open documents in two.
+          eq(schema.GlPostingLine.glAccountId, account.glAccountId),
           lte(schema.GlPosting.txnDate, asOf)
         )
       )
@@ -536,7 +538,7 @@ export async function readAging(
     const tbResult = await readTrialBalance(db, { organizationId, to: asOf })
     if (tbResult.isErr()) return err(tbResult.error)
     const balanceSheetMinor =
-      tbResult.value.rows.find((row) => row.accountCode === account.code)?.balanceMinor ?? 0
+      tbResult.value.rows.find((row) => row.glAccountId === account.glAccountId)?.balanceMinor ?? 0
     const differenceMinor = totalMinor - balanceSheetMinor
 
     return ok({

--- a/packages/lib/src/postings/reports/balance-sheet.ts
+++ b/packages/lib/src/postings/reports/balance-sheet.ts
@@ -23,6 +23,9 @@ const logger = createScopedLogger('postings:reports:balance-sheet')
 
 /** One balance-sheet account line - a `TrialBalanceRow` narrowed to the three balance-sheet types. */
 export interface BalanceSheetRow {
+  /** The `gl_account` `EntityInstance` id this row groups on. The IDENTITY (task 15). */
+  glAccountId: string
+  /** The account's CURRENT code - a snapshot only when `inChart` is `false`. See `TrialBalanceRow`. */
   accountCode: string
   accountName: string
   accountType: 'asset' | 'liability' | 'equity'
@@ -77,6 +80,7 @@ function toBalanceSheetRow(row: TrialBalanceRow): BalanceSheetRow {
   // Only ever called on a row whose accountType is already known to be one of
   // the three balance-sheet types - see the filter above every call site.
   return {
+    glAccountId: row.glAccountId,
     accountCode: row.accountCode,
     accountName: row.accountName,
     accountType: row.accountType as BalanceSheetRow['accountType'],
@@ -172,11 +176,17 @@ async function computeSnapshot(
   if (priorYearsResult.isErr()) return err(priorYearsResult.error)
   if (currentFyResult.isErr()) return err(currentFyResult.error)
 
-  const retainedEarningsCode =
-    retainedEarningsAccounts.get(ACCOUNT_ROLES.EQUITY_RETAINED_EARNINGS)?.code ?? null
+  const retainedEarningsAccount = retainedEarningsAccounts.get(
+    ACCOUNT_ROLES.EQUITY_RETAINED_EARNINGS
+  )
+  const retainedEarningsGlAccountId = retainedEarningsAccount?.glAccountId ?? null
+  const retainedEarningsCode = retainedEarningsAccount?.code ?? null
 
-  const priorPostedRow = retainedEarningsCode
-    ? priorYearsResult.value.rows.find((row) => row.accountCode === retainedEarningsCode)
+  // Matched by id, not by code (task 15): the role could have been repointed,
+  // or the account renumbered, between the two trial-balance reads this
+  // function makes over one call, and the id is the only fact both agree on.
+  const priorPostedRow = retainedEarningsGlAccountId
+    ? priorYearsResult.value.rows.find((row) => row.glAccountId === retainedEarningsGlAccountId)
     : undefined
   const postedRetainedEarningsBalance =
     priorPostedRow && priorPostedRow.balanceMinor !== 0 ? priorPostedRow.balanceMinor : null

--- a/packages/lib/src/postings/reports/profit-and-loss.ts
+++ b/packages/lib/src/postings/reports/profit-and-loss.ts
@@ -26,6 +26,9 @@ const logger = createScopedLogger('postings:reports:profit-and-loss')
 
 /** One revenue or expense account's activity over the requested period. */
 export interface ProfitAndLossRow {
+  /** The `gl_account` `EntityInstance` id this row groups on. The IDENTITY (task 15). */
+  glAccountId: string
+  /** The account's CURRENT code - a snapshot only when `inChart` is `false`. See `TrialBalanceRow`. */
   accountCode: string
   accountName: string
   accountType: 'revenue' | 'expense'
@@ -70,6 +73,7 @@ const COGS_PREFIX = '5'
 
 function toRow(row: TrialBalanceRow): ProfitAndLossRow {
   return {
+    glAccountId: row.glAccountId,
     accountCode: row.accountCode,
     accountName: row.accountName,
     accountType: row.accountType as 'revenue' | 'expense',

--- a/packages/lib/src/postings/reports/rows.ts
+++ b/packages/lib/src/postings/reports/rows.ts
@@ -35,7 +35,14 @@ export interface StatementRow {
   kind: 'section' | 'line' | 'subtotal' | 'total' | 'computed'
   /** Minor units, one per column. `null` renders `EMPTY_CELL`. */
   values: Array<number | null>
-  meta?: { accountCode?: string; recordId?: string; badge?: string; note?: string }
+  meta?: {
+    /** The `gl_account` `EntityInstance` id (task 15) - the drill-down key. `accountCode` is display only. */
+    glAccountId?: string
+    accountCode?: string
+    recordId?: string
+    badge?: string
+    note?: string
+  }
   /** Aging's drill-down; empty for the three financial statements. */
   children?: StatementRow[]
 }

--- a/packages/lib/src/postings/reports/trial-balance.ts
+++ b/packages/lib/src/postings/reports/trial-balance.ts
@@ -34,21 +34,36 @@ const POSTED_STATUSES = ['posted', 'reversed'] as const
 
 /** One account's balance over the requested range. */
 export interface TrialBalanceRow {
+  /**
+   * The `gl_account` `EntityInstance` id this row groups on. The IDENTITY
+   * (task 15) - what makes one account read as one row no matter how many
+   * times it has been renumbered since something posted to it.
+   */
+  glAccountId: string
+  /**
+   * The account's CURRENT code, read from the live chart by `glAccountId` -
+   * never the snapshot a line happened to carry. Renumbering `1100` to `1150`
+   * no longer splits its history into two rows; this is simply `1150` for
+   * every line ever posted to that account. Falls back to the most recent
+   * snapshot on the lines themselves only when `inChart` is `false` (the
+   * account has been deleted), so a dropped account is still identifiable.
+   */
   accountCode: string
-  /** `''` when the code names no live account in this org's chart - see `inChart`. */
+  /** `''` when the account is not in the org's current chart - see `inChart`. */
   accountName: string
-  /** `null` when the code names no live account - there is no natural side to sign against. */
+  /** `null` when the account is not in the org's current chart - there is no natural side to sign against. */
   accountType: GlAccountTypeValue | null
   debitMinor: number
   creditMinor: number
   /** Natural-sign balance via `signedBalance`. `0` when `accountType` is `null`. */
   balanceMinor: number
   /**
-   * `false` when posted lines name a code the org's chart does not currently
-   * hold live - the account was renumbered, archived, or deleted after
-   * something posted to it (decision P2: a line stores a code with no foreign
-   * key, deliberately, so the ledger outlives the chart). The row still
-   * appears, flagged, rather than being silently dropped.
+   * `false` when `glAccountId` names no account the org's chart currently
+   * holds live - the account was DELETED (archived or removed) after
+   * something posted to it (decision P2: a line stores an id with no foreign
+   * key, deliberately, so the ledger outlives the chart). Renumbering no
+   * longer produces `false` here - see the note on `accountCode`. The row
+   * still appears, flagged, rather than being silently dropped.
    */
   inChart: boolean
 }
@@ -85,13 +100,15 @@ export interface ReadTrialBalanceOptions {
 
 /**
  * `SUM(amountMinor) FILTER (WHERE direction = 'debit')` / `'credit'`, grouped by
- * `accountCode`, over posted `GlPostingLine`s in `[from, to]` - `verifyBooksBalance`'s
- * own query with `GROUP BY accountCode` in place of `GROUP BY postingId`.
+ * `glAccountId`, over posted `GlPostingLine`s in `[from, to]` - `verifyBooksBalance`'s
+ * own query with `GROUP BY glAccountId` in place of `GROUP BY postingId`.
  *
  * Joined to the org's live chart (`listChartAccounts`, the same read
- * `resolveRoles` and the role map share) for name and `accountType`. A code
- * with posted lines but no live chart row still appears, with `inChart: false`
- * and `accountType: null` - see {@link TrialBalanceRow}.
+ * `resolveRoles` and the role map share) BY ID for name, `accountType` and the
+ * CURRENT code - task 15 §3. An id with posted lines but no live chart row
+ * still appears, with `inChart: false`, `accountType: null`, and `accountCode`
+ * falling back to the most recent snapshot on its own lines - see
+ * {@link TrialBalanceRow}.
  */
 export async function readTrialBalance(
   db: Database,
@@ -106,7 +123,7 @@ export async function readTrialBalance(
       if (chartResult.isErr()) return err(chartResult.error)
       chart = chartResult.value
     }
-    const chartByCode = new Map(chart.map((account) => [account.code, account]))
+    const chartById = new Map(chart.map((account) => [account.id, account]))
 
     const bounds = [
       eq(schema.GlPosting.organizationId, organizationId),
@@ -117,22 +134,29 @@ export async function readTrialBalance(
 
     const grouped = await db
       .select({
-        accountCode: schema.GlPostingLine.accountCode,
+        glAccountId: schema.GlPostingLine.glAccountId,
+        // The most recent snapshot on the group's own lines - used only as the
+        // `inChart: false` fallback below, never when the id still resolves.
+        accountCode: sql<string>`max(${schema.GlPostingLine.accountCode})`,
         debitMinor: sql<string>`coalesce(sum(${schema.GlPostingLine.amountMinor}) filter (where ${schema.GlPostingLine.direction} = 'debit'), 0)`,
         creditMinor: sql<string>`coalesce(sum(${schema.GlPostingLine.amountMinor}) filter (where ${schema.GlPostingLine.direction} = 'credit'), 0)`,
       })
       .from(schema.GlPostingLine)
       .innerJoin(schema.GlPosting, eq(schema.GlPosting.id, schema.GlPostingLine.glPostingId))
       .where(and(...bounds))
-      .groupBy(schema.GlPostingLine.accountCode)
+      .groupBy(schema.GlPostingLine.glAccountId)
 
     const rows: TrialBalanceRow[] = grouped
       .map((row) => {
-        const account = chartByCode.get(row.accountCode)
+        const account = chartById.get(row.glAccountId)
         const debitMinor = toMinor(row.debitMinor)
         const creditMinor = toMinor(row.creditMinor)
         return {
-          accountCode: row.accountCode,
+          glAccountId: row.glAccountId,
+          // The CURRENT code and name when the account is still live - a
+          // statement reads the chart, not the snapshot (§3's rule). Falls back
+          // to the snapshot only for a deleted account, so it stays identifiable.
+          accountCode: account?.code ?? row.accountCode,
           accountName: account?.name ?? '',
           accountType: account?.accountType ?? null,
           debitMinor,
@@ -141,7 +165,8 @@ export async function readTrialBalance(
           inChart: Boolean(account),
         }
       })
-      .sort((a, b) => a.accountCode.localeCompare(b.accountCode))
+      // Null-safe ahead of task 15 §5, where `accountCode` becomes optional.
+      .sort((a, b) => (a.accountCode ?? '').localeCompare(b.accountCode ?? ''))
 
     const totalDebitMinor = rows.reduce((sum, row) => sum + row.debitMinor, 0)
     const totalCreditMinor = rows.reduce((sum, row) => sum + row.creditMinor, 0)

--- a/packages/lib/src/postings/resolve-roles.ts
+++ b/packages/lib/src/postings/resolve-roles.ts
@@ -310,6 +310,7 @@ export async function resolveAccountLines(
     const codes = [
       ...new Set(lines.map((line) => line.accountCode).filter((c): c is string => !!c)),
     ]
+    const ids = [...new Set(lines.map((line) => line.glAccountId).filter((i): i is string => !!i))]
 
     const problems: string[] = []
 
@@ -325,8 +326,32 @@ export async function resolveAccountLines(
     const byCode =
       codes.length > 0 ? await loadAccountsByCode(db, organizationId, codes) : new Map()
 
+    // ID lines go through the same by-id door a role's assignment does, so an
+    // id and the role that points at it cannot disagree about what the account
+    // says. Archived reads as missing, exactly as it does for a code (task 15).
+    const byId =
+      ids.length > 0
+        ? await loadAccounts(db, organizationId, ids)
+        : new Map<string, ResolvedAccount>()
+
     for (const [index, line] of lines.entries()) {
       const row = index + 1
+      if (line.glAccountId) {
+        const account = byId.get(line.glAccountId)
+        if (!account) {
+          problems.push(
+            `Row ${row}: this organization's chart has no active account with id '${line.glAccountId}'. ` +
+              'It may have been archived or deleted since the line it reverses was posted.'
+          )
+          continue
+        }
+        if (!account.isActive) {
+          problems.push(
+            `Row ${row}: ${account.code} ${account.name} is not active. Reactivate it before posting to it again.`
+          )
+        }
+        continue
+      }
       if (line.accountCode) {
         const found = byCode.get(line.accountCode)
         if (!found) {
@@ -354,7 +379,9 @@ export async function resolveAccountLines(
       // A line with neither shape is `buildEntry`'s refusal to make, not this
       // one's - but it must not silently resolve to nothing either.
       if (!line.accountRole) {
-        problems.push(`Row ${row}: the line names neither an account role nor an account code.`)
+        problems.push(
+          `Row ${row}: the line names neither an account role, an account code nor an account id.`
+        )
       }
     }
 
@@ -369,9 +396,11 @@ export async function resolveAccountLines(
 
     const resolvedLines: ResolvedAccount[] = []
     for (const [index, line] of lines.entries()) {
-      const account = line.accountCode
-        ? byCode.get(line.accountCode)?.[0]
-        : byRole.get(line.accountRole as string)
+      const account = line.glAccountId
+        ? byId.get(line.glAccountId)
+        : line.accountCode
+          ? byCode.get(line.accountCode)?.[0]
+          : byRole.get(line.accountRole as string)
       if (!account) {
         // Unreachable: every line either resolved above or produced a problem.
         // Asserted because the alternative is a ledger line with no account.

--- a/packages/lib/src/postings/reverse-entry.ts
+++ b/packages/lib/src/postings/reverse-entry.ts
@@ -30,7 +30,6 @@ import { buildEntry } from './build-entry'
 import { parsePostingDraft, requiresAssertions, reverseAssertions } from './draft'
 import type { PeriodLock } from './periods'
 import { postEntry } from './post-entry'
-import { resolveRoles } from './resolve-roles'
 import type { GlPostingLineInput, PostingType, PostResult } from './types'
 
 const logger = createScopedLogger('postings:reverse-entry')
@@ -63,19 +62,24 @@ function refuse(error: string, glPostingId?: string): PostResult {
  * is updated. The provider's register ends up holding both halves, which is
  * what a bookkeeper expects to see and what makes the pair auditable.
  *
- * ## Why this re-resolves the roles and then checks them against the original
+ * ## Why this reverses by `glAccountId`, not by role or code
  *
- * A reversal must land on the SAME accounts as the entry it backs out. If the
- * org repointed `grni` from `2160` to `2155` since the original posted, blindly
- * re-resolving would credit `2155` and leave `2160` overstated forever - and
- * both entries would still balance, so nothing downstream could detect it.
+ * A reversal must land on the SAME account as the entry it backs out. Before
+ * task 15, this rebuilt a role line as `{ accountRole }` and re-resolved it
+ * against the CURRENT chart, so a role remapped between the post and the
+ * reversal (`grni` from `2160` to `2155`, say) credited `2155` and left `2160`
+ * overstated forever - and both entries still balanced, so nothing downstream
+ * could detect it.
  *
- * The frozen `accountCode` on the original's lines is therefore the authority,
- * and the re-resolution exists only to compare against it. On any drift this
- * refuses and names the role, the code the entry posted to, and the code the
- * role means today. That is a decision for a person: repointing the role back
- * and reversing, or posting a manual correcting entry, are different answers to
- * different questions.
+ * `glAccountId` is the IDENTITY (`GlPostingLineInput`'s third variant,
+ * plans/accounting/tasks/15-the-account-id-is-the-identity.md), and every
+ * reversed line is built from the original's stored id rather than its role or
+ * code. `resolveAccountLines` still validates the id against the org's chart -
+ * archived reads as missing, inactive refuses - so a reversal fails closed the
+ * same way a post does; it simply can no longer drift to a DIFFERENT account
+ * than the one it is backing out. The original's `accountRole` is copied onto
+ * the reversed line as the snapshot it is, so the pair reads the same way in
+ * the journal.
  */
 export async function reverseEntry(
   db: Database,
@@ -124,7 +128,8 @@ export async function reverseEntry(
     const lines = await db
       .select({
         lineNumber: schema.GlPostingLine.lineNumber,
-        accountCode: schema.GlPostingLine.accountCode,
+        glAccountId: schema.GlPostingLine.glAccountId,
+        // The role SNAPSHOT, copied onto the reversed line; the id decides the account.
         accountRole: schema.GlPostingLine.accountRole,
         direction: schema.GlPostingLine.direction,
         amountMinor: schema.GlPostingLine.amountMinor,
@@ -148,59 +153,24 @@ export async function reverseEntry(
       )
     }
 
-    // ── The drift check, for ROLE lines only ───────────────────────────────
-    //
-    // 🛑 A CODE line has no drift to check and is deliberately exempt.
-    // `accountRole` is nullable: a manual or opening entry names accounts by
-    // code, and the code IS the authority - there is no mapping between the
-    // entry and the account for the chart to move underneath. Re-resolving one
-    // would be inventing a role the person never chose. So a code line is
-    // reversed to the same code it posted to, verbatim, which is precisely what
-    // the drift check exists to guarantee for a role line.
-    //
-    // (Before slot 1A this function REFUSED a role-less entry outright, which
-    // was correct while `BuiltEntry` was role-keyed by construction. It is not
-    // any more: `GlPostingLineInput` carries both shapes.)
-    const roles = [
-      ...new Set(lines.map((line) => line.accountRole).filter((r): r is string => !!r)),
-    ]
-    const resolved = await resolveRoles(db, organizationId, roles)
-    if (resolved.isErr()) {
-      return {
-        status: 'account_unmapped',
-        failureClass: 'configuration',
-        retryable: false,
-        error: resolved.error.message,
-        glPostingId: original.id,
-      }
-    }
-
-    const drift: string[] = []
-    for (const line of lines) {
-      if (!line.accountRole) continue
-      const account = resolved.value.get(line.accountRole)
-      if (account && account.code !== line.accountCode) {
-        drift.push(
-          `'${line.accountRole}' posted to ${line.accountCode} but now maps to ${account.code}`
-        )
-      }
-    }
-    if (drift.length > 0) {
-      return refuse(
-        `Cannot reverse ${original.docNumber}: the chart moved under it. ${drift.join('; ')}. ` +
-          'Reversing would credit an account the entry never touched. Repoint the role, or post a manual correcting entry.',
-        original.id
-      )
-    }
-
     // ── The opposite entry ─────────────────────────────────────────────────
     // Same accounts, same amounts, same audit pair, flipped direction. Built
     // through `buildEntry` so the reversal is subject to the same balance and
     // minor-unit assertions as anything else that reaches the ledger.
+    //
+    // Every line reverses by `glAccountId` - the IDENTITY - not by the role or
+    // code it was originally coded with. `resolveAccountLines` still validates
+    // the id against the org's live chart (archived reads as missing, inactive
+    // refuses), so this fails closed exactly as a role or code line would; it
+    // just cannot land on a DIFFERENT account than the one it is backing out.
+    //
+    // The role rides along as a SNAPSHOT only (the id variant allows it for
+    // exactly this): the reversal's stored line says which account it was
+    // SUPPOSED to be, the same way the original's does, while the id alone
+    // decides where it lands.
     const reversedLines: GlPostingLineInput[] = lines.map((line, index) => ({
-      // The shape the original carried, kept: a role line reverses as a role
-      // line, a code line as the same code.
-      ...(line.accountRole ? { accountRole: line.accountRole } : { accountCode: line.accountCode }),
+      glAccountId: line.glAccountId,
+      accountRole: line.accountRole ?? undefined,
       direction: line.direction === 'debit' ? 'credit' : 'debit',
       amount: line.amountMinor,
       memo: line.memo ?? undefined,

--- a/packages/lib/src/postings/role-map.ts
+++ b/packages/lib/src/postings/role-map.ts
@@ -248,21 +248,23 @@ export async function listChartAccounts(
 }
 
 /**
- * How many posted lines name each account CODE.
+ * How many posted lines landed on each account, by `glAccountId`.
  *
  * The one number the chart's renumber warning needs. A posting line stores the
- * account code with **no foreign key** (`P2`), deliberately, so the ledger
- * outlives the chart - which means renumbering an account leaves every line
- * already posted holding the old code. That is a feature, and it is also the
- * kind of feature a person should be told about with a NUMBER rather than a
- * caution: "142 posted lines carry 1310" is what makes the trade concrete.
+ * account id with **no foreign key** (task 15: the IDENTITY), so a line
+ * outlives the chart row it was posted against - which means a deleted account
+ * can still carry posted history. That is a feature, and it is also the kind
+ * of feature a person should be told about with a NUMBER rather than a
+ * caution: "142 posted lines carry this account" is what makes the trade
+ * concrete.
  *
- * ⚠️ **Keyed on CODE, not on account id**, because a code is what a posted line
- * actually stores. Two consequences, both correct: an account never posted to
- * reports nothing, and an account whose code was PREVIOUSLY carried by a
- * different account reports that history too. The question the number answers is
- * "how many posted lines say `1310`", which is exactly the question somebody
- * about to renumber is asking.
+ * ⚠️ **Keyed on `glAccountId`, not on code**, because renumbering no longer
+ * fragments an account's history (task 15 §3) - "how many posted lines landed
+ * on THIS account" is exactly the question a renumber warning has to answer,
+ * and the id answers it precisely where a code answer used to undercount an
+ * account renumbered since some of its lines posted. An account never posted
+ * to reports nothing; a deleted account whose id is no longer in the live
+ * chart still reports its true count, findable by whoever kept the id.
  *
  * 🛑 Deliberately NOT folded into {@link listChartAccounts}. `ChartAccountRow` is
  * shared with `resolveRoles`' path and decoded by every reader of this chart; a
@@ -275,16 +277,16 @@ export async function listChartAccountUsage(
   try {
     const rows = await db
       .select({
-        accountCode: schema.GlPostingLine.accountCode,
+        glAccountId: schema.GlPostingLine.glAccountId,
         lines: count(),
       })
       .from(schema.GlPostingLine)
       .where(eq(schema.GlPostingLine.organizationId, organizationId))
-      .groupBy(schema.GlPostingLine.accountCode)
+      .groupBy(schema.GlPostingLine.glAccountId)
 
     const usage: Record<string, number> = {}
     for (const row of rows) {
-      if (row.accountCode) usage[row.accountCode] = Number(row.lines) || 0
+      if (row.glAccountId) usage[row.glAccountId] = Number(row.lines) || 0
     }
     return ok(usage)
   } catch (error) {

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -163,6 +163,7 @@ export type GlPostingLineInput =
        */
       accountRole: string
       accountCode?: never
+      glAccountId?: never
     })
   | (GlPostingLineBase & {
       /**
@@ -171,6 +172,25 @@ export type GlPostingLineInput =
        */
       accountCode: string
       accountRole?: never
+      glAccountId?: never
+    })
+  | (GlPostingLineBase & {
+      /**
+       * A `gl_account` instance ID out of this org's own chart. The IDENTITY
+       * (task 15): a line that must land on exactly the account another line
+       * landed on, whatever the chart has since been renamed or renumbered to.
+       * A reversal uses it, so the original is backed out of the account it
+       * went into rather than out of whatever its role resolves to today.
+       */
+      glAccountId: string
+      /**
+       * The role SNAPSHOT to stamp on the stored line, carried verbatim from
+       * the line being reversed. Never resolved: the id decides the account,
+       * this only records which account the line was SUPPOSED to be, so a
+       * reversal reads the same way in the journal as the entry it backs out.
+       */
+      accountRole?: string
+      accountCode?: never
     })
 
 /**
@@ -405,6 +425,12 @@ export type PostResultStatus =
   | 'unbalanced'
   | 'nothing_to_close'
   | 'setup_incomplete'
+  // The org has never enabled the accounting module (`FeatureKey.accounting`
+  // is off). A first-class silent case like `not_connected`, never a warning:
+  // nothing is built, nothing is claimed, nothing is logged (task 17 section 3).
+  // Distinct from `setup_incomplete`, which means the module is on and the
+  // wizard was not finished, and from `disabled`, which is a provider switch.
+  | 'not_enabled'
   // Wave 1 (HANDOFF slot 1A). A manual or opening entry named one of the three
   // inventory accounts by code; the remedy is the close console, which is the
   // only writer of those balances.

--- a/packages/lib/src/resources/registry/resources/bank-account-fields.ts
+++ b/packages/lib/src/resources/registry/resources/bank-account-fields.ts
@@ -62,17 +62,20 @@ export const BANK_ACCOUNT_STATUS_OPTIONS = [
  * two accounts under one login share a credential and hold two connector ids
  * (plans/accounting/implementation-review.md §2).
  *
- * ## `glAccount` is a CODE as TEXT, not a relationship
+ * ## `glAccount` is the `gl_account` EntityInstance id, as TEXT, no relationship
  *
- * 🛑 The bank plan (02 §6) asks for a RELATIONSHIP to `gl_account`, on the
- * argument that an org that renumbers Cash from `1000` to `1010` must not break
- * the feed. That argument is right and this field still departs from it, for the
- * reason `bank_deposit.bankAccount` and `vendor_bill_line.glAccount` already
- * departed: **there is no `gl_account` relationship precedent anywhere in the
- * registry** - every GL pointer in the money subsystem is a code as TEXT, and
- * `resolveRoles` takes a code with no foreign key (decision `P2`). One
- * inconsistent field would be worse than one consistent departure. A single
- * later migration converts every one of them together.
+ * (`plans/accounting/tasks/15-the-account-id-is-the-identity.md` §4, DECIDED
+ * 2026-09-09.) Renumbering Cash from `1000` to `1010` must not break the feed,
+ * which is the argument for an identity rather than a mutable label - but the
+ * identity is stored as plain `text()` with no `references()`, the shape
+ * `GlRoleAssignment.glAccountId` already uses: no foreign key, validated for
+ * existence, active status and type on every read, fail closed. A registry
+ * relationship was considered and rejected here on purpose - it buys nothing a
+ * read-time check does not already have to do, and this field is written in
+ * bulk by the review queue over thousands of rows. Migration
+ * `143-gl-pointers-hold-ids` converted every stored value from a code to the
+ * matching account's id, together with the other five pointers this brief
+ * names.
  *
  * ## Coverage
  *
@@ -246,11 +249,11 @@ export const BANK_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    placeholder: '1000',
+    placeholder: 'Select account',
     description:
-      'The GL account CODE this account maps to, from the org own chart. THE point of this ' +
-      'entity. TEXT rather than a RELATIONSHIP because every GL pointer in the money ' +
-      'subsystem is a code (decision P2); one later migration converts them all together',
+      'The gl_account id this account maps to, from the org own chart. THE point of this ' +
+      'entity. TEXT with no foreign key, not a RELATIONSHIP - validated for existence, ' +
+      'active status and type on every read, fail closed',
   },
 
   feedStartDate: {

--- a/packages/lib/src/resources/registry/resources/bank-deposit-fields.ts
+++ b/packages/lib/src/resources/registry/resources/bank-deposit-fields.ts
@@ -160,9 +160,15 @@ export const BANK_DEPOSIT_FIELDS: Record<string, ResourceField> = {
     // renaming it would orphan them; the key is only how this file reads.
     // `linkNewRelationships` resolves an inverse by ID, which is why the pair is
     // declared as `bank_deposit:bankAccountRecord` on the account side.
+    //
+    // 🛑 Corrected by task 15 §4 (2026-09-10): this field still holds the
+    // FROZEN pointer a deposit posted to, but that pointer is now the
+    // `gl_account` instance id, not a code - the id and key stay exactly as
+    // they were (a materialised field cannot be renamed without reshaping
+    // every org's stored rows), only what the stored TEXT value MEANS changed.
     id: toFieldId('bankAccount'),
     key: 'bankAccountCode',
-    label: 'Bank Account Code',
+    label: 'Bank Account GL Account',
     type: BaseType.STRING,
     fieldType: FieldType.TEXT,
     isSystem: true,
@@ -176,12 +182,12 @@ export const BANK_DEPOSIT_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    placeholder: '1000',
+    placeholder: 'Select account',
     description:
-      'The GL account CODE this deposit was POSTED to, copied off ' +
-      'bankAccount.glAccountCode when the entry was built and frozen there. Kept beside the ' +
+      'The gl_account id this deposit was POSTED to, copied off ' +
+      'bankAccount.glAccount when the entry was built and frozen there. Kept beside the ' +
       'relationship rather than derived from it, because re-mapping a bank account to a ' +
-      'different code must not restate a deposit that already posted to the old one',
+      'different account must not restate a deposit that already posted to the old one',
   },
 
   bankAccount: {

--- a/packages/lib/src/resources/registry/resources/bank-rule-fields.ts
+++ b/packages/lib/src/resources/registry/resources/bank-rule-fields.ts
@@ -81,9 +81,9 @@ export const BANK_RULE_ACTION_OPTIONS = [
  * departure `bank_transaction.matchedRecordId` already takes for exactly this
  * reason, and it costs nothing at read time: `banking/rules/` resolves the id
  * directly, and the Rules UI builds its own picker against `bank_account`/
- * `contact` records rather than the generic RELATIONSHIP input. One later
- * migration can convert all of these together, the `bank_account.glAccount`
- * precedent (decision `P2`).
+ * `contact` records rather than the generic RELATIONSHIP input. It is also
+ * what `glAccount` below became: an id, TEXT, no relationship
+ * (`plans/accounting/tasks/15-the-account-id-is-the-identity.md` §4).
  *
  * `contact` is chosen over a second `company` field per this slot's "pick one
  * or document": a coded line's payee is a vendor or a customer, and both are
@@ -428,8 +428,8 @@ export const BANK_RULE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    placeholder: '6100',
-    description: 'The account CODE a code action proposes, from the org own chart',
+    placeholder: 'Select account',
+    description: 'The gl_account id a code action proposes, from the org own chart',
   },
 
   counterpartBankAccount: {

--- a/packages/lib/src/resources/registry/resources/bank-transaction-fields.ts
+++ b/packages/lib/src/resources/registry/resources/bank-transaction-fields.ts
@@ -415,10 +415,12 @@ export const BANK_TRANSACTION_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    placeholder: '6100',
+    placeholder: 'Select account',
     description:
-      'The account CODE a coded line posts to, from the org own chart. The bank_account ' +
-      'side of the entry comes from the account mapping, not from here',
+      'The gl_account id a coded line posts to, from the org own chart. TEXT with no ' +
+      'foreign key, not a RELATIONSHIP - written in bulk by the review queue over ' +
+      'thousands of rows and validated on read. The bank_account side of the entry comes ' +
+      'from the account mapping, not from here',
   },
 
   matchedRecordId: {
@@ -602,9 +604,9 @@ export const BANK_TRANSACTION_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    placeholder: '6100',
+    placeholder: 'Select account',
     description:
-      'The account CODE a "code" suggestion proposes, from the org own chart. Set by a ' +
+      'The gl_account id a "code" suggestion proposes, from the org own chart. Set by a ' +
       'matching bank_rule or by suggestFromHistory; null for a transfer suggestion',
   },
 

--- a/packages/lib/src/resources/registry/resources/vendor-bill-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/vendor-bill-line-fields.ts
@@ -234,17 +234,18 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
     },
   },
 
-  // An account CODE — '2160', '5090' — never a provider account id (P2). The
-  // ledger is ours and the accounting system is an exporter; the provider's id
-  // for an account lives on `gl_account`, where it can change without touching
-  // a single line.
+  // The `gl_account` instance id (task 15 §4) - a text id with no foreign
+  // key, never a provider account id (P2). The ledger is ours and the
+  // accounting system is an exporter; the provider's id for an account lives
+  // on `gl_account`, where it can change without touching a single line.
   /**
-   * The account this bill line is coded to, as a **CODE** (`'2160'`).
+   * The account this bill line is coded to, as an **ID**, not a code and not
+   * a role.
    *
    * 🛑 Deliberately NOT a role, and this is the one place in the purchasing
-   * subsystem where a code is the right answer — so the difference from
-   * `stock_movement.glAccount` (which stores a `G8` ROLE) is stated here rather
-   * than left to be rediscovered.
+   * subsystem where a bookkeeper's own pick is the right answer - so the
+   * difference from `stock_movement.glAccount` (which stores a `G8` ROLE) is
+   * stated here rather than left to be rediscovered.
    *
    * Two things separate them:
    *
@@ -257,11 +258,15 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
    *     transcription of a document that a human corrects. The movement's role
    *     is frozen precisely because it can never be corrected.
    *
+   * `id as TEXT, no FK, validated on read` is the decision
+   * (`plans/accounting/tasks/15-the-account-id-is-the-identity.md` §4) - the
+   * same shape `GlRoleAssignment.glAccountId` already uses.
+   *
    * ⚠️ What is still wrong: `bill-lines-from-purchase-order.ts` hardcodes
    * `GRNI_ACCOUNT_CODE = '2160'` to prefill a PO-matched line. That IS a `G8`
    * violation — the prefill should resolve the `grni` role through the org's
-   * own `gl_account` chart and use whatever code it finds. It is a prefill and
-   * a human can overtype it, which is why it is a defect rather than a
+   * own `gl_account` chart and use whatever account it finds. It is a prefill
+   * and a human can overtype it, which is why it is a defect rather than a
    * corruption, but it breaks for any org that renumbers GRNI.
    */
   glAccount: {
@@ -281,9 +286,9 @@ export const VENDOR_BILL_LINE_FIELDS: Record<string, ResourceField> = {
       updatable: true,
       configurable: false,
     },
-    placeholder: '2160',
+    placeholder: 'Select account',
     description:
-      "The account code this line is coded to, in the organization's own chart of accounts. A code, not an auxx posting role: most of a chart plays no part in an auxx posting.",
+      "The gl_account id this line is coded to, in the organization's own chart of accounts. TEXT with no foreign key, not a code and not an auxx posting role: most of a chart plays no part in an auxx posting.",
   },
 
   sortOrder: {

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -99,6 +99,7 @@ import { migration139TaxLineOrderWritable } from './migrations/139-tax-line-orde
 import { migration140IntegrationsView } from './migrations/140-integrations-view'
 import { migration141BuildBatchRun } from './migrations/141-build-batch-run'
 import { migration142WipeSeededCharts } from './migrations/142-wipe-seeded-charts'
+import { migration143GlPointersHoldIds } from './migrations/143-gl-pointers-hold-ids'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -312,6 +313,12 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // reads whatever `gl_account` / `journal_entry` rows exist regardless of
   // which migration wrote them.
   migration142WipeSeededCharts,
+  // The six registry GL pointers hold the gl_account instance id instead of a
+  // code (plans/accounting/tasks/15-the-account-id-is-the-identity.md §4).
+  // No ordering constraint against 142: it reads whatever gl_account rows
+  // exist today, and 142 having just wiped them all is exactly the case its
+  // own docblock plans for (every stored value nulls out).
+  migration143GlPointersHoldIds,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/142-wipe-seeded-charts.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/142-wipe-seeded-charts.test.ts
@@ -130,11 +130,15 @@ function stubDb(rows: {
 }
 
 describe('migration 142 registration', () => {
-  it('is registered exactly once, with a unique id, last in the list', () => {
+  // No longer asserted "last in the list": migration 143
+  // (gl-pointers-hold-ids) reads whatever gl_account rows exist regardless of
+  // which migration wrote them and has no ordering constraint against this
+  // one, so it registers after 142 without disturbing anything this file
+  // pins about 142 itself.
+  it('is registered exactly once, with a unique id', () => {
     const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
     expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
     expect(new Set(ids).size).toBe(ids.length)
-    expect(ids.at(-1)).toBe(MIGRATION_ID)
     expect(migration142WipeSeededCharts.id).toBe(MIGRATION_ID)
   })
 })

--- a/packages/lib/src/seed/entity-migrations/migrations/143-gl-pointers-hold-ids.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/143-gl-pointers-hold-ids.test.ts
@@ -1,0 +1,557 @@
+// packages/lib/src/seed/entity-migrations/migrations/143-gl-pointers-hold-ids.test.ts
+//
+// Migration 143 rewrites `FieldValue.valueText` on six registry pointers from a
+// chart CODE to the `gl_account` instance id. What is pinned here:
+//
+//  - `TARGET_FIELDS` names exactly the six pairs task 15 §4 converts, and
+//    excludes `stock_movement.glAccount` (a `G8` ROLE, not a code);
+//  - `buildCodeIndex` and `partitionPointerValues` (pure, no db) do the actual
+//    matching: already-an-id, resolve-one-live-code (grouped for one bulk
+//    UPDATE), no match, and an ambiguous code shared by two accounts;
+//  - `up()` against a stub `Database` modelled on
+//    `142-wipe-seeded-charts.test.ts`'s `stubDb` (fixed rows per table,
+//    `.where()` unevaluated - the schema's own column objects carry no usable
+//    data in this test environment, the same reason that file's stub never
+//    interprets a condition either): converts a resolvable code, nulls an
+//    unresolvable one (the ordinary case once migration 142 has wiped every
+//    chart), leaves an already-converted id alone and is a no-op on a second
+//    run - verified by inspecting the store's own `fieldValues` afterward,
+//    never through the log line.
+
+import { schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `getOrgCache` is a Redis round trip the stub `Database` below has nothing to
+// back - the same reason `142-wipe-seeded-charts.test.ts` stubs it.
+const invalidateAndRecompute = vi.fn(async () => {})
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getOrgCache: () => ({ invalidateAndRecompute }),
+}))
+
+const { migration143GlPointersHoldIds, TARGET_FIELDS, buildCodeIndex, partitionPointerValues } =
+  await import('./143-gl-pointers-hold-ids')
+const { ALL_ENTITY_MIGRATIONS } = await import('../../entity-migrations')
+
+const MIGRATION_ID = '143-gl-pointers-hold-ids'
+const ORG = 'org_1'
+
+// ─── The stub store ────────────────────────────────────────────────────────
+
+interface EntityDefRow {
+  id: string
+  organizationId: string
+  entityType: string
+}
+interface CustomFieldRow {
+  id: string
+  organizationId: string
+  entityDefinitionId: string
+  systemAttribute: string
+  options: Record<string, unknown>
+}
+interface EntityInstanceRow {
+  id: string
+  organizationId: string
+  entityDefinitionId: string
+  archivedAt: Date | null
+}
+interface FieldValueRow {
+  id: string
+  organizationId: string
+  fieldId: string
+  entityId: string
+  valueText: string | null
+}
+
+type Row = Record<string, unknown>
+
+/**
+ * An in-memory `Database`, modelled directly on
+ * `142-wipe-seeded-charts.test.ts`'s `stubDb`: `.select().from(table).where()`
+ * resolves the pre-seeded row set for that TABLE, ignoring the condition
+ * object entirely (the schema's column exports carry no usable data in this
+ * package's test environment - `142`'s own stub takes the identical posture,
+ * one row set per table, and callers configure it already scoped to the
+ * query under test). `.update()` finds the id list from the real `inArray()`
+ * condition's VALUE, which is a plain array this migration built itself and
+ * needs no column resolution to read back, and mutates matching rows in
+ * place so the test can inspect the store afterward.
+ */
+function makeStore(seed: {
+  entityDefs?: EntityDefRow[]
+  customFields?: CustomFieldRow[]
+  entityInstances?: EntityInstanceRow[]
+  fieldValues?: FieldValueRow[]
+}) {
+  const state = {
+    entityDefs: seed.entityDefs ?? [],
+    customFields: seed.customFields ?? [],
+    entityInstances: seed.entityInstances ?? [],
+    fieldValues: seed.fieldValues ?? [],
+  }
+  const updateCalls: { table: string; values: Row; matched: number }[] = []
+
+  const rowsFor = (table: unknown): Row[] => {
+    if (table === schema.EntityDefinition) return state.entityDefs as unknown as Row[]
+    if (table === schema.CustomField) return state.customFields as unknown as Row[]
+    if (table === schema.EntityInstance) return state.entityInstances as unknown as Row[]
+    if (table === schema.FieldValue) return state.fieldValues as unknown as Row[]
+    throw new Error('Unknown table in test stub')
+  }
+  const tableName = (table: unknown): string => {
+    if (table === schema.EntityDefinition) return 'EntityDefinition'
+    if (table === schema.CustomField) return 'CustomField'
+    if (table === schema.EntityInstance) return 'EntityInstance'
+    if (table === schema.FieldValue) return 'FieldValue'
+    return 'unknown'
+  }
+
+  /** Find the array `inArray(FieldValue.id, ids)` was built with, wherever it sits in the tree. */
+  const idsFromCondition = (cond: unknown): string[] => {
+    const chunks = (cond as { queryChunks?: unknown[] } | null)?.queryChunks
+    if (!Array.isArray(chunks)) return []
+    if (chunks.length === 5) {
+      const op = chunks[2] as { value?: unknown[] } | undefined
+      if (Array.isArray(op?.value) && op.value[0] === ' in ' && Array.isArray(chunks[3])) {
+        return chunks[3] as string[]
+      }
+    }
+    for (const chunk of chunks) {
+      const found = idsFromCondition(chunk)
+      if (found.length > 0) return found
+    }
+    return []
+  }
+
+  const db = {
+    select: (_cols: unknown) => ({
+      from: (table: unknown) => ({
+        where: () => Promise.resolve(rowsFor(table)),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Row) => ({
+        where: (cond: unknown) => {
+          const ids = idsFromCondition(cond)
+          let matched = 0
+          for (const row of rowsFor(table)) {
+            if (ids.includes(row.id as string)) {
+              Object.assign(row, values)
+              matched++
+            }
+          }
+          updateCalls.push({ table: tableName(table), values, matched })
+          return Promise.resolve({ rowCount: matched })
+        },
+      }),
+    }),
+  }
+
+  return { db: db as never, state, updateCalls }
+}
+
+const GL_ACCOUNT_DEF = 'def-gl_account'
+const BANK_ACCOUNT_DEF = 'def-bank_account'
+const BANK_TRANSACTION_DEF = 'def-bank_transaction'
+
+const CODE_FIELD = 'field-gl_account_code'
+const BANK_ACCOUNT_GL_FIELD = 'field-bank_account_gl_account'
+const BANK_TX_GL_FIELD = 'field-bank_transaction_gl_account'
+const BANK_TX_SUGGESTED_FIELD = 'field-bank_transaction_suggested_gl_account'
+
+function baseDefs(): EntityDefRow[] {
+  return [
+    { id: GL_ACCOUNT_DEF, organizationId: ORG, entityType: 'gl_account' },
+    { id: BANK_ACCOUNT_DEF, organizationId: ORG, entityType: 'bank_account' },
+    { id: BANK_TRANSACTION_DEF, organizationId: ORG, entityType: 'bank_transaction' },
+  ]
+}
+
+function baseFields(): CustomFieldRow[] {
+  return [
+    {
+      id: CODE_FIELD,
+      organizationId: ORG,
+      entityDefinitionId: GL_ACCOUNT_DEF,
+      systemAttribute: 'gl_account_code',
+      options: {},
+    },
+    {
+      id: BANK_ACCOUNT_GL_FIELD,
+      organizationId: ORG,
+      entityDefinitionId: BANK_ACCOUNT_DEF,
+      systemAttribute: 'bank_account_gl_account',
+      options: {},
+    },
+    {
+      id: BANK_TX_GL_FIELD,
+      organizationId: ORG,
+      entityDefinitionId: BANK_TRANSACTION_DEF,
+      systemAttribute: 'bank_transaction_gl_account',
+      options: {},
+    },
+    {
+      id: BANK_TX_SUGGESTED_FIELD,
+      organizationId: ORG,
+      entityDefinitionId: BANK_TRANSACTION_DEF,
+      systemAttribute: 'bank_transaction_suggested_gl_account',
+      options: {},
+    },
+  ]
+}
+
+beforeEach(() => {
+  invalidateAndRecompute.mockClear()
+})
+
+describe('migration 143 registration', () => {
+  it('is registered exactly once, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(migration143GlPointersHoldIds.id).toBe(MIGRATION_ID)
+  })
+})
+
+describe('TARGET_FIELDS', () => {
+  it('names exactly the six converted pairs', () => {
+    expect(TARGET_FIELDS).toEqual([
+      { entityType: 'bank_account', systemAttribute: 'bank_account_gl_account' },
+      { entityType: 'bank_rule', systemAttribute: 'bank_rule_gl_account' },
+      { entityType: 'bank_transaction', systemAttribute: 'bank_transaction_gl_account' },
+      { entityType: 'bank_transaction', systemAttribute: 'bank_transaction_suggested_gl_account' },
+      { entityType: 'vendor_bill_line', systemAttribute: 'vendor_bill_line_gl_account' },
+      { entityType: 'bank_deposit', systemAttribute: 'bank_deposit_bank_account' },
+    ])
+  })
+
+  // Corrected 2026-09-10: stock_movement.glAccount stores a G8 ROLE, not a
+  // code (stock-movement-fields.ts:333-360), and is not converted.
+  it('excludes stock_movement.glAccount', () => {
+    expect(TARGET_FIELDS.some((f) => f.entityType === 'stock_movement')).toBe(false)
+  })
+})
+
+describe('buildCodeIndex', () => {
+  const CODE_FIELD_ID = 'fld_code'
+
+  it('indexes a live account by its code', () => {
+    const index = buildCodeIndex(
+      [{ id: 'fv_1', fieldId: CODE_FIELD_ID, entityId: 'acct_1', valueText: '1000' }],
+      CODE_FIELD_ID,
+      new Set(['acct_1'])
+    )
+    expect(index.get('1000')).toEqual(['acct_1'])
+  })
+
+  it('excludes an archived account even though it carries the code', () => {
+    const index = buildCodeIndex(
+      [{ id: 'fv_1', fieldId: CODE_FIELD_ID, entityId: 'acct_archived', valueText: '1000' }],
+      CODE_FIELD_ID,
+      new Set() // nothing live
+    )
+    expect(index.has('1000')).toBe(false)
+  })
+
+  it('ignores rows on a different field', () => {
+    const index = buildCodeIndex(
+      [{ id: 'fv_1', fieldId: 'some_other_field', entityId: 'acct_1', valueText: '1000' }],
+      CODE_FIELD_ID,
+      new Set(['acct_1'])
+    )
+    expect(index.size).toBe(0)
+  })
+
+  it('collects two live accounts sharing one code, for the ambiguity check downstream', () => {
+    const index = buildCodeIndex(
+      [
+        { id: 'fv_1', fieldId: CODE_FIELD_ID, entityId: 'acct_1', valueText: '1000' },
+        { id: 'fv_2', fieldId: CODE_FIELD_ID, entityId: 'acct_2', valueText: '1000' },
+      ],
+      CODE_FIELD_ID,
+      new Set(['acct_1', 'acct_2'])
+    )
+    expect(index.get('1000')).toEqual(['acct_1', 'acct_2'])
+  })
+})
+
+describe('partitionPointerValues', () => {
+  it('leaves a value alone that already looks like a gl_account id', () => {
+    const result = partitionPointerValues(
+      [{ id: 'fv_1', valueText: 'acct_1' }],
+      new Map(),
+      new Set(['acct_1'])
+    )
+    expect(result.alreadyIds).toBe(1)
+    expect(result.convertGroups.size).toBe(0)
+    expect(result.toNullIds).toEqual([])
+  })
+
+  it('converts a value that matches exactly one live code', () => {
+    const result = partitionPointerValues(
+      [{ id: 'fv_1', valueText: '1000' }],
+      new Map([['1000', ['acct_1']]]),
+      new Set()
+    )
+    expect(result.convertGroups.get('acct_1')).toEqual(['fv_1'])
+    expect(result.toNullIds).toEqual([])
+    expect(result.alreadyIds).toBe(0)
+  })
+
+  it('groups every row that resolves to the same account into one bulk conversion', () => {
+    const result = partitionPointerValues(
+      [
+        { id: 'fv_1', valueText: '6100' },
+        { id: 'fv_2', valueText: '6100' },
+        { id: 'fv_3', valueText: '6100' },
+      ],
+      new Map([['6100', ['acct_office']]]),
+      new Set()
+    )
+    expect(result.convertGroups.size).toBe(1)
+    expect(result.convertGroups.get('acct_office')).toEqual(['fv_1', 'fv_2', 'fv_3'])
+  })
+
+  it('nulls a value with no matching code', () => {
+    const result = partitionPointerValues(
+      [{ id: 'fv_1', valueText: '9999' }],
+      new Map([['1000', ['acct_1']]]),
+      new Set()
+    )
+    expect(result.toNullIds).toEqual(['fv_1'])
+    expect(result.convertGroups.size).toBe(0)
+  })
+
+  it('nulls a code shared by two live accounts rather than guessing', () => {
+    const result = partitionPointerValues(
+      [{ id: 'fv_1', valueText: '1000' }],
+      new Map([['1000', ['acct_1', 'acct_2']]]),
+      new Set()
+    )
+    expect(result.toNullIds).toEqual(['fv_1'])
+    expect(result.convertGroups.size).toBe(0)
+  })
+
+  it('skips a null valueText defensively', () => {
+    const result = partitionPointerValues([{ id: 'fv_1', valueText: null }], new Map(), new Set())
+    expect(result.alreadyIds).toBe(0)
+    expect(result.toNullIds).toEqual([])
+    expect(result.convertGroups.size).toBe(0)
+  })
+})
+
+describe('up() against a stub store', () => {
+  it('reports alreadyUpToDate when none of the six fields are provisioned', async () => {
+    const { db } = makeStore({})
+    const result = await migration143GlPointersHoldIds.up(db, ORG)
+    expect(result.alreadyUpToDate).toBe(true)
+    expect(invalidateAndRecompute).not.toHaveBeenCalled()
+  })
+
+  it('converts a stored code to the one live account holding it', async () => {
+    const { db, state } = makeStore({
+      entityDefs: baseDefs(),
+      customFields: baseFields(),
+      entityInstances: [
+        { id: 'acct_1', organizationId: ORG, entityDefinitionId: GL_ACCOUNT_DEF, archivedAt: null },
+      ],
+      fieldValues: [
+        {
+          id: 'code_fv',
+          organizationId: ORG,
+          fieldId: CODE_FIELD,
+          entityId: 'acct_1',
+          valueText: '1000',
+        },
+        {
+          id: 'ba_fv',
+          organizationId: ORG,
+          fieldId: BANK_ACCOUNT_GL_FIELD,
+          entityId: 'bank_1',
+          valueText: '1000',
+        },
+      ],
+    })
+
+    const result = await migration143GlPointersHoldIds.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(state.fieldValues.find((r) => r.id === 'ba_fv')?.valueText).toBe('acct_1')
+    expect(invalidateAndRecompute).toHaveBeenCalledWith(ORG, ['customFields', 'resources'])
+  })
+
+  // The ordinary case on the database this ships against: migration 142 wiped
+  // every chart first, so every stored code resolves to nothing.
+  it('nulls a stored code when the org has no chart to resolve it against', async () => {
+    const { db, state } = makeStore({
+      entityDefs: baseDefs(),
+      customFields: baseFields(),
+      fieldValues: [
+        {
+          id: 'tx_fv',
+          organizationId: ORG,
+          fieldId: BANK_TX_GL_FIELD,
+          entityId: 'txn_1',
+          valueText: '6100',
+        },
+      ],
+    })
+
+    const result = await migration143GlPointersHoldIds.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(state.fieldValues.find((r) => r.id === 'tx_fv')?.valueText).toBeNull()
+  })
+
+  it('leaves an already-converted id alone, and a second run is a no-op', async () => {
+    const seed = {
+      entityDefs: baseDefs(),
+      customFields: baseFields(),
+      entityInstances: [
+        { id: 'acct_1', organizationId: ORG, entityDefinitionId: GL_ACCOUNT_DEF, archivedAt: null },
+      ],
+      fieldValues: [
+        {
+          id: 'rule_fv',
+          organizationId: ORG,
+          fieldId: BANK_ACCOUNT_GL_FIELD,
+          entityId: 'bank_1',
+          valueText: 'acct_1',
+        },
+      ],
+    }
+    const { db, state } = makeStore(seed)
+
+    const first = await migration143GlPointersHoldIds.up(db, ORG)
+    expect(first.alreadyUpToDate).toBe(true)
+    expect(state.fieldValues.find((r) => r.id === 'rule_fv')?.valueText).toBe('acct_1')
+
+    const second = await migration143GlPointersHoldIds.up(db, ORG)
+    expect(second.alreadyUpToDate).toBe(true)
+  })
+
+  it('excludes an archived account from code resolution, but still recognises its id', async () => {
+    const { db, state } = makeStore({
+      entityDefs: baseDefs(),
+      customFields: baseFields(),
+      entityInstances: [
+        {
+          id: 'acct_archived',
+          organizationId: ORG,
+          entityDefinitionId: GL_ACCOUNT_DEF,
+          archivedAt: new Date('2026-01-01'),
+        },
+      ],
+      fieldValues: [
+        {
+          id: 'code_fv',
+          organizationId: ORG,
+          fieldId: CODE_FIELD,
+          entityId: 'acct_archived',
+          valueText: '1000',
+        },
+        // Still carries the CODE - the archived account cannot be resolved TO.
+        {
+          id: 'by_code_fv',
+          organizationId: ORG,
+          fieldId: BANK_ACCOUNT_GL_FIELD,
+          entityId: 'bank_1',
+          valueText: '1000',
+        },
+        // Already holds the archived account's ID - left alone.
+        {
+          id: 'by_id_fv',
+          organizationId: ORG,
+          fieldId: BANK_TX_GL_FIELD,
+          entityId: 'txn_1',
+          valueText: 'acct_archived',
+        },
+      ],
+    })
+
+    await migration143GlPointersHoldIds.up(db, ORG)
+
+    expect(state.fieldValues.find((r) => r.id === 'by_code_fv')?.valueText).toBeNull()
+    expect(state.fieldValues.find((r) => r.id === 'by_id_fv')?.valueText).toBe('acct_archived')
+  })
+
+  it('converts across more than one target field in the same run', async () => {
+    const { db, state } = makeStore({
+      entityDefs: baseDefs(),
+      customFields: baseFields(),
+      entityInstances: [
+        { id: 'acct_1', organizationId: ORG, entityDefinitionId: GL_ACCOUNT_DEF, archivedAt: null },
+      ],
+      fieldValues: [
+        {
+          id: 'code_fv',
+          organizationId: ORG,
+          fieldId: CODE_FIELD,
+          entityId: 'acct_1',
+          valueText: '4000',
+        },
+        {
+          id: 'tx_fv',
+          organizationId: ORG,
+          fieldId: BANK_TX_GL_FIELD,
+          entityId: 'txn_1',
+          valueText: '4000',
+        },
+        {
+          id: 'suggested_fv',
+          organizationId: ORG,
+          fieldId: BANK_TX_SUGGESTED_FIELD,
+          entityId: 'txn_1',
+          valueText: '4000',
+        },
+      ],
+    })
+
+    const result = await migration143GlPointersHoldIds.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(state.fieldValues.find((r) => r.id === 'tx_fv')?.valueText).toBe('acct_1')
+    expect(state.fieldValues.find((r) => r.id === 'suggested_fv')?.valueText).toBe('acct_1')
+  })
+
+  it('issues one bulk UPDATE for a whole group, never one per row', async () => {
+    const fieldValues: FieldValueRow[] = [
+      {
+        id: 'code_fv',
+        organizationId: ORG,
+        fieldId: CODE_FIELD,
+        entityId: 'acct_1',
+        valueText: '6100',
+      },
+    ]
+    for (let i = 0; i < 25; i++) {
+      fieldValues.push({
+        id: `tx_fv_${i}`,
+        organizationId: ORG,
+        fieldId: BANK_TX_GL_FIELD,
+        entityId: `txn_${i}`,
+        valueText: '6100',
+      })
+    }
+    const { db, state, updateCalls } = makeStore({
+      entityDefs: baseDefs(),
+      customFields: baseFields(),
+      entityInstances: [
+        { id: 'acct_1', organizationId: ORG, entityDefinitionId: GL_ACCOUNT_DEF, archivedAt: null },
+      ],
+      fieldValues,
+    })
+
+    await migration143GlPointersHoldIds.up(db, ORG)
+
+    // The 25 bank_transaction rows converted; the chart's own code row (on a
+    // field this migration never writes) is untouched.
+    expect(state.fieldValues.filter((r) => r.valueText === 'acct_1')).toHaveLength(25)
+    expect(state.fieldValues.find((r) => r.id === 'code_fv')?.valueText).toBe('6100')
+    // One UPDATE call converting the whole group of 25, not 25 calls.
+    const conversionCalls = updateCalls.filter((c) => c.values.valueText === 'acct_1')
+    expect(conversionCalls).toHaveLength(1)
+    expect(conversionCalls[0]?.matched).toBe(25)
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/143-gl-pointers-hold-ids.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/143-gl-pointers-hold-ids.ts
@@ -1,0 +1,341 @@
+// packages/lib/src/seed/entity-migrations/migrations/143-gl-pointers-hold-ids.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import { fieldKey, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:143')
+
+/** The def the chart lives on, and the field its code is stored in. */
+const GL_ACCOUNT_ENTITY_TYPE = 'gl_account'
+const GL_ACCOUNT_CODE_ATTRIBUTE = 'gl_account_code'
+
+/**
+ * The six registry pointers converted together, one representation
+ * (`plans/accounting/tasks/15-the-account-id-is-the-identity.md` §4, DECIDED
+ * 2026-09-09). `stock_movement.glAccount` stores a `G8` ROLE, not a code
+ * (`stock-movement-fields.ts:333-360`), and is deliberately absent.
+ */
+export const TARGET_FIELDS: ReadonlyArray<{ entityType: string; systemAttribute: string }> = [
+  { entityType: 'bank_account', systemAttribute: 'bank_account_gl_account' },
+  { entityType: 'bank_rule', systemAttribute: 'bank_rule_gl_account' },
+  { entityType: 'bank_transaction', systemAttribute: 'bank_transaction_gl_account' },
+  { entityType: 'bank_transaction', systemAttribute: 'bank_transaction_suggested_gl_account' },
+  { entityType: 'vendor_bill_line', systemAttribute: 'vendor_bill_line_gl_account' },
+  // The frozen GL code a deposit posted to. Becomes the frozen id.
+  { entityType: 'bank_deposit', systemAttribute: 'bank_deposit_bank_account' },
+] as const
+
+/** One target field, resolved to its id for this org. */
+interface ResolvedTarget {
+  systemAttribute: string
+  fieldId: string
+}
+
+/** Per-field counters this migration reports, never a per-row loop. */
+interface FieldOutcome {
+  converted: number
+  nulled: number
+  alreadyIds: number
+}
+
+/** One `FieldValue` row, as narrow as the partition step needs it. */
+interface PointerRow {
+  id: string
+  fieldId: string
+  entityId: string
+  valueText: string | null
+}
+
+const CACHE_KEYS = ['customFields', 'resources'] as const
+
+/**
+ * Migration 143: the six registry GL pointers hold the `gl_account`
+ * EntityInstance id, as TEXT, instead of an account CODE
+ * (`plans/accounting/tasks/15-the-account-id-is-the-identity.md` §4).
+ *
+ * ## What it does, per field, per org
+ *
+ * For every stored value on one of {@link TARGET_FIELDS}:
+ *
+ * - Already looks like an id (equals a `gl_account` instance id in the SAME
+ *   org, any archived status) → left alone. This is what makes a second run
+ *   a no-op.
+ * - Equals the `gl_account_code` of EXACTLY ONE live (non-archived) account in
+ *   the same org → rewritten to that account's instance id.
+ * - Anything else - no match, or an ambiguous code shared by more than one
+ *   account - is set NULL and counted. Every org's chart was wiped by
+ *   migration 142 before this lands (HANDOFF §25.6), so on the database this
+ *   ships against, that is expected to be every row today: there is no live
+ *   `gl_account` to resolve a code against yet, and a value that cannot be
+ *   proven to be the right account is not guessed at.
+ *
+ * `stock_movement.glAccount` stores a `G8` ROLE, not a code
+ * (`stock-movement-fields.ts:333-360`), and is not in {@link TARGET_FIELDS} -
+ * brief 15 §0.5 was wrong to list it and the DECIDED block at the top of task
+ * 15 says so.
+ *
+ * ## Bulk, never a per-row loop
+ *
+ * One SELECT reads every `gl_account` instance in the org (bounded by chart
+ * size), and one SELECT reads every non-null value across the chart's code
+ * field AND every target field present on this org, in a single
+ * `fieldId IN (...)` - never one round trip per field, let alone per row.
+ * Matching a code to an account, spotting an already-converted id, and
+ * grouping rows onto one of a handful of target accounts all happen in
+ * memory. The writes that follow are one `UPDATE ... WHERE id IN (...)` per
+ * distinct target account plus one for every row being nulled, per field: at
+ * most a few statements total, however many thousand `bank_transaction` rows
+ * point at one of these fields.
+ *
+ * ## Self-sufficient and idempotent
+ *
+ * No resolution step depends on `postings/chart-accounts.ts` or any other
+ * runtime reader - the decode here is deliberately its own, narrow copy
+ * (`gl_account_code`, non-archived, this org only), because a migration must
+ * still make sense years after the reader it might have shared has changed.
+ * A second run finds every remaining value already an id (skipped) or already
+ * null (nothing to touch) and reports `alreadyUpToDate`.
+ */
+export const migration143GlPointersHoldIds: EntityMigration = {
+  id: '143-gl-pointers-hold-ids',
+  description:
+    'Converts the six bank/purchasing registry fields that named a gl_account by CODE ' +
+    '(bank_account.glAccount, bank_rule.glAccount, bank_transaction.glAccount/' +
+    'suggestedGlAccount, vendor_bill_line.glAccount, bank_deposit.bankAccountCode) to hold ' +
+    'the gl_account instance id instead, matching GlRoleAssignment.glAccountId and ' +
+    'GlPostingLine.glAccountId (plans/accounting/tasks/15-the-account-id-is-the-identity.md §4)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const glAccountDef = existing.entityDefs.get(GL_ACCOUNT_ENTITY_TYPE)
+    const codeField = glAccountDef
+      ? existing.fields.get(fieldKey(glAccountDef.id, GL_ACCOUNT_CODE_ATTRIBUTE))
+      : undefined
+
+    const targets: ResolvedTarget[] = []
+    for (const { entityType, systemAttribute } of TARGET_FIELDS) {
+      const def = existing.entityDefs.get(entityType)
+      if (!def) continue // org has not reached the entity type yet
+      const field = existing.fields.get(fieldKey(def.id, systemAttribute))
+      if (!field) continue // field does not exist yet on this org
+      targets.push({ systemAttribute, fieldId: field.id })
+    }
+
+    if (targets.length === 0) {
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    // Every gl_account instance in this org, live or archived. `allAccountIds`
+    // (any status) is the "already looks like an id" set - an id converted by
+    // an earlier run must stay put even if the account it names has since
+    // been archived. `liveAccountIds` scopes CODE resolution: only a live
+    // account's code is trusted to name it.
+    const instances = glAccountDef ? await readInstances(db, organizationId, glAccountDef.id) : []
+    const allAccountIds = new Set(instances.map((row) => row.id))
+    const liveAccountIds = new Set(
+      instances.filter((row) => row.archivedAt == null).map((row) => row.id)
+    )
+
+    // One read for the chart's codes and every target field's values together.
+    const fieldIds = [...(codeField ? [codeField.id] : []), ...targets.map((t) => t.fieldId)]
+    const rows = await readFieldValues(db, organizationId, fieldIds)
+
+    const codeToLiveIds = codeField
+      ? buildCodeIndex(rows, codeField.id, liveAccountIds)
+      : new Map<string, string[]>()
+
+    const outcomes: Record<string, FieldOutcome> = {}
+    let totalConverted = 0
+    let totalNulled = 0
+    let totalAlreadyIds = 0
+
+    for (const target of targets) {
+      const targetRows = rows.filter((row) => row.fieldId === target.fieldId)
+      const outcome = await applyConversion(
+        db,
+        organizationId,
+        targetRows,
+        codeToLiveIds,
+        allAccountIds
+      )
+      outcomes[target.systemAttribute] = outcome
+      totalConverted += outcome.converted
+      totalNulled += outcome.nulled
+      totalAlreadyIds += outcome.alreadyIds
+    }
+
+    const alreadyUpToDate = totalConverted === 0 && totalNulled === 0
+
+    if (!alreadyUpToDate) {
+      await getOrgCache().invalidateAndRecompute(organizationId, [...CACHE_KEYS])
+      logger.info('Migration 143 applied', {
+        organizationId,
+        converted: totalConverted,
+        nulled: totalNulled,
+        alreadyIds: totalAlreadyIds,
+        byField: outcomes,
+      })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}
+
+/** Every `EntityInstance` under one entity definition, in this org - id and archived status. */
+export async function readInstances(
+  db: Database,
+  organizationId: string,
+  entityDefinitionId: string
+): Promise<{ id: string; archivedAt: Date | null }[]> {
+  return db
+    .select({ id: schema.EntityInstance.id, archivedAt: schema.EntityInstance.archivedAt })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, entityDefinitionId)
+      )
+    )
+}
+
+/**
+ * Every non-null value on any of `fieldIds`, in this org - the chart's own
+ * code field and every present target field, in ONE round trip.
+ */
+export async function readFieldValues(
+  db: Database,
+  organizationId: string,
+  fieldIds: string[]
+): Promise<PointerRow[]> {
+  if (fieldIds.length === 0) return []
+  const rows = await db
+    .select({
+      id: schema.FieldValue.id,
+      fieldId: schema.FieldValue.fieldId,
+      entityId: schema.FieldValue.entityId,
+      valueText: schema.FieldValue.valueText,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.fieldId, fieldIds)
+      )
+    )
+  return rows.filter((row) => row.valueText != null)
+}
+
+/**
+ * `code -> [instance ids]` for every LIVE (non-archived) `gl_account` in this
+ * org that carries one. More than one id for a code means the chart itself is
+ * ambiguous - resolution refuses it rather than guessing. Pure - no db.
+ */
+export function buildCodeIndex(
+  rows: readonly PointerRow[],
+  codeFieldId: string,
+  liveAccountIds: ReadonlySet<string>
+): Map<string, string[]> {
+  const map = new Map<string, string[]>()
+  for (const row of rows) {
+    if (row.fieldId !== codeFieldId) continue
+    if (!row.valueText) continue
+    if (!liveAccountIds.has(row.entityId)) continue
+    const list = map.get(row.valueText) ?? []
+    list.push(row.entityId)
+    map.set(row.valueText, list)
+  }
+  return map
+}
+
+/**
+ * Convert (or null) one field's already-fetched rows, in this org.
+ *
+ * The partition is pure JS ({@link partitionPointerValues}); the writes that
+ * follow are one `UPDATE ... WHERE id IN (...)` per distinct target account
+ * and one for every row being nulled - never one statement per row.
+ */
+export async function applyConversion(
+  db: Database,
+  organizationId: string,
+  rows: readonly PointerRow[],
+  codeToLiveIds: Map<string, string[]>,
+  allAccountIds: Set<string>
+): Promise<FieldOutcome> {
+  if (rows.length === 0) return { converted: 0, nulled: 0, alreadyIds: 0 }
+
+  const { convertGroups, toNullIds, alreadyIds } = partitionPointerValues(
+    rows,
+    codeToLiveIds,
+    allAccountIds
+  )
+
+  let converted = 0
+  const now = new Date()
+  for (const [targetAccountId, rowIds] of convertGroups) {
+    await db
+      .update(schema.FieldValue)
+      .set({ valueText: targetAccountId, updatedAt: now })
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          inArray(schema.FieldValue.id, rowIds)
+        )
+      )
+    converted += rowIds.length
+  }
+
+  if (toNullIds.length > 0) {
+    await db
+      .update(schema.FieldValue)
+      .set({ valueText: null, updatedAt: now })
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          inArray(schema.FieldValue.id, toNullIds)
+        )
+      )
+  }
+
+  return { converted, nulled: toNullIds.length, alreadyIds }
+}
+
+/**
+ * Pure: sort every row into "already an id" (untouched), "convert to this
+ * account id" (grouped, one bulk UPDATE per group), or "null" (no match, or
+ * an ambiguous code). No db, no clock - fully testable without a database.
+ */
+export function partitionPointerValues(
+  rows: readonly { id: string; valueText: string | null }[],
+  codeToLiveIds: Map<string, string[]>,
+  allAccountIds: Set<string>
+): { convertGroups: Map<string, string[]>; toNullIds: string[]; alreadyIds: number } {
+  const convertGroups = new Map<string, string[]>()
+  const toNullIds: string[] = []
+  let alreadyIds = 0
+
+  for (const row of rows) {
+    const value = row.valueText
+    if (!value) continue // readFieldValues already filters this server-side; defensive here
+    if (allAccountIds.has(value)) {
+      alreadyIds++
+      continue
+    }
+    const matches = codeToLiveIds.get(value)
+    if (matches && matches.length === 1) {
+      const targetAccountId = matches[0]!
+      const group = convertGroups.get(targetAccountId) ?? []
+      group.push(row.id)
+      convertGroups.set(targetAccountId, group)
+    } else {
+      toNullIds.push(row.id)
+    }
+  }
+
+  return { convertGroups, toNullIds, alreadyIds }
+}


### PR DESCRIPTION
Step 2 of `plans/accounting/tasks/15` and `17` (HANDOFF §25), built as three lanes partitioned by file. Follows #2094.

## Reports and reversals read the id (15 §3, §2.3)

- Every statement groups by `GlPostingLine.glAccountId` and renders code and name from the **current** chart. Renumbering an account no longer splits its history into two trial-balance rows; `inChart: false` now means deleted. The account drill-down, the chart usage count behind the renumber warning, the aging tie-out and the retained-earnings lookup all key on the id. A source-scan test fails if any report file groups by `accountCode` again.
- The journal view of one entry keeps its snapshot, deliberately.
- A reversal is rebuilt from each stored line's id, so a role remapped between the post and the reversal cannot move the reversal off the account it backs out. The original's `accountRole` rides along as a snapshot. `GlPostingLineInput` gains a third variant, `{ glAccountId }`, accepted by `buildEntry` and resolved by `resolveAccountLines`.
- The QuickBooks adapter resolves a replayed line by id, so a renumbered account no longer refuses a retry.

## The GL pointer fields hold ids (15 §4)

`bank_account.glAccount`, `bank_rule.glAccount`, `bank_transaction.glAccount` and its suggestion, `vendor_bill_line.glAccount`, and `bank_deposit.bankAccountCode` (the frozen account a deposit posted to) hold the `gl_account` instance id as TEXT with **no foreign key**, the representation `GlRoleAssignment` and the posting line already use. Field ids, keys and system attributes are unchanged. `stock_movement.glAccount` stores a role and is untouched (brief 15 §0.5 was wrong about it).

- Entity migration 143 converts a stored code where exactly one live account carries it and nulls the rest, in bulk statements, idempotent.
- Bank coding and the deposit writer emit `{ glAccountId }` lines. Pickers select by id. The vendor bill line uses the picker instead of a typed code, and the hardcoded `2160` GRNI prefill is removed rather than left writing a code into an id field.

## The `not_enabled` gate (17 §3)

Every document-driven posting trigger checks `isAccountingEnabled` first (`FeatureKey.accounting`, the same door the router and nav use) and answers `not_enabled`: nothing built, nothing claimed, nothing logged, and the document transition proceeds. A fulfillment is not rolled back; the shipment log still gets real amounts from the shared arithmetic. The payout sync skips the Stripe call for an org without accounting. `setup_incomplete` keeps its meaning and its warning for an org that turned accounting on and did not finish the wizard. A source-scan test asserts every trigger gates.

## Verified

- Dev DB: migration 143 applied on every org; all six pointer fields read null, as expected after #2094 wiped the charts.
- `packages/lib` full suite: 1282 files passed, 4 skipped, none failing. `packages/database` by hand: 30/30.
- Typecheck ratchet: lib 27/27 baseline, web 0/0. Biome clean; no em dashes in added lines.

## Not in this PR

15 §5 (the code becomes optional) is step 3. Plans 13, 14 and 18 wait behind it.

https://claude.ai/code/session_01YTGYmqzXCTYAYJFfDXRTKp