### PR TITLE
feat(banking): take a bank line apart, and find every line like it

### DIFF
--- a/apps/web/src/components/accounting/ui/banking/review/analyze-panel.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/analyze-panel.tsx
@@ -1,0 +1,317 @@
+// apps/web/src/components/accounting/ui/banking/review/analyze-panel.tsx
+
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import { parseBankDescriptor } from '@auxx/lib/banking/client'
+import type { BankTransactionRow } from '@auxx/lib/banking/review/client'
+import {
+  BANK_RULE_MATCH_FIELDS,
+  BANK_RULE_MATCH_OPERATORS,
+  type BankRuleMatchField,
+  type BankRuleMatchOperator,
+  isSafeRegexPattern,
+} from '@auxx/lib/banking/rules/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { EmptySection } from '@auxx/ui/components/section'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { SearchX, Wand2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { api } from '~/trpc/react'
+import { useChartAccounts } from '../../gl-account-picker'
+import { EMPTY_CELL, formatSignedMinor } from '../../ledger/format'
+import { BankRuleDialog } from '../rules/bank-rule-dialog'
+import {
+  firstValue,
+  MATCH_FIELD_OPTIONS,
+  MATCH_OPERATOR_OPTIONS,
+  TRIGGER_PROPS,
+} from '../rules/bank-rule-options'
+
+interface AnalyzePanelProps {
+  line: BankTransactionRow
+  currencyCode: string
+}
+
+/**
+ * Take one bank line apart, and find every other line like it.
+ *
+ * Stripe Financial Connections ships a `description` and nothing else - no
+ * merchant name, no category - so what a line IS has to be read off its own
+ * text. Most of that text is structure: `SHOPIFY DES:TRANSFER
+ * ID:ST-F1K0R8X3L3D5 CO ID:SHOPIFYPMT WEB` is an originator, an entry
+ * description, a per-payment reference and an ACH entry class, and only one of
+ * those four is worth matching on.
+ *
+ * 🛑 **The bank's own line is never edited, hidden or replaced.** It is shown
+ * verbatim at the top and the parts below are a reading of it, not a
+ * replacement for it. `matchKey` appears as a part too, so a reviewer can see
+ * what grouping actually has to work with.
+ *
+ * ⚠️ What this builds is a `bank_rule`'s matching half exactly - the same
+ * field, the same four operators, the same value, drawn from the same
+ * `bank-rule-options` vocabularies the rule dialog uses. So the count shown
+ * here is the count the rule will act on, and Create rule opens the real dialog
+ * seeded rather than a second form that could drift from it.
+ */
+export function AnalyzePanel({ line, currencyCode }: AnalyzePanelProps) {
+  const parsed = useMemo(() => parseBankDescriptor(line.description), [line.description])
+  const { accounts } = useChartAccounts()
+
+  const [matchField, setMatchField] = useState<BankRuleMatchField>('description')
+  const [matchOperator, setMatchOperator] = useState<BankRuleMatchOperator>('contains')
+  const [matchValue, setMatchValue] = useState('')
+  const [ruleOpen, setRuleOpen] = useState(false)
+
+  /**
+   * The opening pattern: the most identifying part of the line.
+   *
+   * An ACH originator id (`CO ID`) is the bank's own stable identifier for who
+   * sent the money, and it survives every per-payment reference printed around
+   * it. Failing that the originator's printed name, and failing that the match
+   * key - never the raw line, which contains the reference that makes it
+   * unique and would open on a pattern matching exactly one row.
+   */
+  useEffect(() => {
+    const originator = parsed.tags.find(
+      (tag) => tag.label === 'CO ID' || tag.label === 'ORIG ID'
+    )?.value
+    const opening = originator || parsed.lead
+    setMatchField(opening ? 'description' : 'matchKey')
+    setMatchOperator('contains')
+    setMatchValue(opening || line.matchKey || '')
+  }, [parsed, line.matchKey])
+
+  // The preview is a person typing, so it waits for them to stop.
+  const [debounced, setDebounced] = useState('')
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(matchValue), 250)
+    return () => clearTimeout(timer)
+  }, [matchValue])
+
+  const regexRefused =
+    matchOperator === 'regex' && !!debounced.trim() && !isSafeRegexPattern(debounced)
+  const canPreview = !!debounced.trim() && !regexRefused
+
+  const preview = api.bankingRules.previewPattern.useQuery(
+    { matchField, matchOperator, matchValue: debounced },
+    { enabled: canPreview }
+  )
+
+  const accountLabel = (glAccountId: string) => {
+    const account = accounts.find((item) => item.id === glAccountId)
+    return account ? `${account.code} ${account.name}` : glAccountId
+  }
+
+  const searchFor = (value: string, field: BankRuleMatchField) => {
+    setMatchField(field)
+    setMatchOperator('contains')
+    setMatchValue(value)
+  }
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {/* The bank's line, verbatim. Everything below is a reading of it, and
+          this is what any of it can be checked against. */}
+      <p className='break-words rounded-lg border bg-muted/40 p-2.5 font-mono text-[11px] leading-relaxed'>
+        {line.description || EMPTY_CELL}
+      </p>
+
+      <div className='flex flex-col gap-1.5'>
+        <span className='text-muted-foreground text-xs'>
+          Click a part to search for it. Faded parts change on every payment.
+        </span>
+        <div className='flex flex-wrap gap-1'>
+          {parsed.lead && (
+            <LinePart
+              label='Payee'
+              value={parsed.lead}
+              onClick={() => searchFor(parsed.lead, 'description')}
+            />
+          )}
+          {parsed.tags.map((tag, index) => (
+            <LinePart
+              // Duplicate labels are real: a wire carries two `ID:` tags, one
+              // for the beneficiary and one for their bank.
+              key={`${tag.label}-${index}`}
+              label={tag.label}
+              value={tag.value}
+              varies={tag.isReference}
+              onClick={() => searchFor(tag.value, 'description')}
+            />
+          ))}
+          {parsed.sec && <LinePart label='ACH class' value={parsed.sec} />}
+          {line.matchKey && (
+            <LinePart
+              label='Match key'
+              value={line.matchKey}
+              onClick={() => searchFor(line.matchKey ?? '', 'matchKey')}
+            />
+          )}
+        </div>
+      </div>
+
+      <FieldPanel className='p-0' breakpoint='md' resizeId='bank-analyze'>
+        <FieldPanelRow
+          title='Search in'
+          type={BaseType.STRING}
+          showIcon
+          description='The match key is the description with dates, reference numbers and card digits stripped out.'>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            fieldOptions={{ options: MATCH_FIELD_OPTIONS }}
+            triggerProps={TRIGGER_PROPS}
+            value={matchField}
+            onChange={(value) => {
+              const next = firstValue(value)
+              if (BANK_RULE_MATCH_FIELDS.includes(next as BankRuleMatchField)) {
+                setMatchField(next as BankRuleMatchField)
+              }
+            }}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Operator' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            fieldOptions={{ options: MATCH_OPERATOR_OPTIONS }}
+            triggerProps={TRIGGER_PROPS}
+            value={matchOperator}
+            onChange={(value) => {
+              const next = firstValue(value)
+              if (BANK_RULE_MATCH_OPERATORS.includes(next as BankRuleMatchOperator)) {
+                setMatchOperator(next as BankRuleMatchOperator)
+              }
+            }}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Pattern'
+          type={BaseType.STRING}
+          showIcon
+          isLastRow
+          // `isSafeRegexPattern` is the guard the rule writer applies, so a
+          // pattern refused here is refused at create time too. Said now,
+          // rather than after the person has chosen an action for it.
+          validationError={
+            regexRefused
+              ? 'Over 200 characters, or a quantifier nested inside a quantified group. Refused before it can run against a live feed.'
+              : undefined
+          }>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={matchValue}
+            placeholder='SHOPIFYPMT'
+            onChange={(value) => setMatchValue(String(value ?? ''))}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
+
+      {canPreview &&
+        (preview.isPending ? (
+          <div className='flex flex-col gap-2'>
+            <Skeleton className='h-8 w-full' />
+            <Skeleton className='h-8 w-2/3' />
+          </div>
+        ) : preview.data?.matchCount === 0 ? (
+          <EmptySection
+            icon={<SearchX className='size-5' />}
+            title='No lines match'
+            description='Try a shorter pattern, or a part of the line that does not change between payments.'
+          />
+        ) : preview.data ? (
+          <div className='flex flex-col gap-2'>
+            <div className='flex flex-wrap items-center gap-1.5'>
+              <span className='font-medium text-sm'>
+                {preview.data.matchCount} {preview.data.matchCount === 1 ? 'line' : 'lines'}
+              </span>
+              {/* The rule-mining signal: a pattern whose matches are already
+                  coded the same way is a rule somebody has been writing by
+                  hand, one line at a time. */}
+              {preview.data.codedByAccount.length === 0 ? (
+                <span className='text-muted-foreground text-xs'>none coded yet</span>
+              ) : (
+                preview.data.codedByAccount.slice(0, 3).map((entry) => (
+                  <Badge key={entry.glAccountId} variant='teal' size='xs'>
+                    {entry.count} × {accountLabel(entry.glAccountId)}
+                  </Badge>
+                ))
+              )}
+              {preview.data.truncated && (
+                <Badge variant='amber' size='xs'>
+                  first 5,000 lines only
+                </Badge>
+              )}
+            </div>
+
+            <ol className='flex flex-col gap-0'>
+              {preview.data.sample.map((row) => (
+                <li
+                  key={row.id}
+                  className={`flex items-baseline gap-3 border-border border-l py-1 ps-4 text-xs ${
+                    row.id === line.id ? 'font-medium' : 'text-muted-foreground'
+                  }`}>
+                  <span className='w-[5.5rem] shrink-0 tabular-nums'>
+                    {row.postedAt ?? EMPTY_CELL}
+                  </span>
+                  <span className='w-[6rem] shrink-0 text-right tabular-nums'>
+                    {formatSignedMinor(row.amountMinor, currencyCode)}
+                  </span>
+                  <span className='truncate font-mono text-[11px]'>{row.description}</span>
+                </li>
+              ))}
+            </ol>
+
+            <Button variant='outline' size='sm' className='w-fit' onClick={() => setRuleOpen(true)}>
+              <Wand2 />
+              Create rule from this pattern
+            </Button>
+          </div>
+        ) : null)}
+
+      <BankRuleDialog
+        open={ruleOpen}
+        onClose={() => setRuleOpen(false)}
+        seed={{ name: parsed.lead || line.matchKey || '', matchField, matchOperator, matchValue }}
+      />
+    </div>
+  )
+}
+
+/**
+ * One part of the bank's line, as a clickable token.
+ *
+ * ⚠️ `varies` is not decoration. A reviewer who builds a pattern out of a trace
+ * number gets a rule that matches exactly one line forever, and the fading is
+ * the only warning before the preview says "1 line".
+ */
+function LinePart({
+  label,
+  value,
+  varies,
+  onClick,
+}: {
+  label: string
+  value: string
+  varies?: boolean
+  onClick?: () => void
+}) {
+  if (!value) return null
+  const badge = (
+    <Badge variant='outline' size='sm' className={varies ? 'opacity-50' : undefined}>
+      <span className='uppercase opacity-60'>{label}</span>
+      <span className='font-mono'>{value}</span>
+    </Badge>
+  )
+  if (!onClick) return badge
+  return (
+    <button type='button' onClick={onClick} className='rounded-md hover:opacity-80'>
+      {badge}
+    </button>
+  )
+}

--- a/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
@@ -7,6 +7,7 @@ import {
   MATCHED_RECORD_TYPE_LABELS,
   REVIEW_STATUS_LABELS,
 } from '@auxx/lib/banking/review/client'
+import { isRecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
@@ -17,11 +18,13 @@ import { Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Ban, Landmark, Undo2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import DrawerComments from '~/components/global/comments/drawer-comments'
 import { api } from '~/trpc/react'
 import { BankAccountBadge } from '../../bank-account-badge'
 import { useChartAccounts } from '../../gl-account-picker'
 import { EntryBlockers, type LedgerBlocker } from '../../ledger/entry-blockers'
 import { EMPTY_CELL, formatMinor } from '../../ledger/format'
+import { AnalyzePanel } from './analyze-panel'
 import { CodePanel } from './code-panel'
 import { ExcludePanel } from './exclude-panel'
 import { HistoryPanel } from './history-panel'
@@ -314,6 +317,32 @@ export function ReviewDrawer({
                 {!settled && (
                   <Section title='Exclude' collapsible initialOpen={false}>
                     <ExcludePanel key={line.id} line={line} onDone={() => close(false)} />
+                  </Section>
+                )}
+                {/* Reading the line, and finding every other line like it. Below
+                    the treatment because it answers "what IS this", which is the
+                    question you have when the treatment is not obvious - not a
+                    step on the way to a decision you have already made. */}
+                <Section title='Analyze' collapsible initialOpen={false}>
+                  <AnalyzePanel key={line.id} line={line} currencyCode={currencyCode} />
+                </Section>
+                {/* 🛑 Notes on a bank line are COMMENTS, not a field. A bank
+                    transaction is an `EntityInstance` and already carries a
+                    `recordId`, so the org's one comment thread works here with
+                    no new column - and unlike a field it keeps who wrote it and
+                    when, which is the whole point of "remind ourselves what this
+                    was" eighteen months later.
+                    ⚠️ A note here is about THIS line. Knowledge about the payee
+                    belongs in a rule, or it gets retyped on all 42 of them. */}
+                {isRecordId(line.recordId) && (
+                  <Section title='Notes' collapsible initialOpen={false}>
+                    <DrawerComments
+                      recordId={line.recordId}
+                      emptyTitle='No notes on this line'
+                      emptyDescription='Leave a note about what this transaction was.'
+                      headerTitle='Notes'
+                      composerPlaceholder='What was this?'
+                    />
                   </Section>
                 )}
                 <Section title='History' collapsible initialOpen={false}>

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-configure-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-configure-page.tsx
@@ -20,16 +20,13 @@ import { BankAccountPicker } from '~/components/accounting/ui/bank-account-picke
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { RuleActionsSummaryRow } from '~/components/rules/ui/rule-actions-summary-row'
-import { DIRECTION_OPTIONS, MATCH_FIELD_OPTIONS, MATCH_OPERATOR_OPTIONS } from './bank-rule-options'
-
-/** Flush-in-a-FieldPanelRow trigger sizing, the same one the rule editors share. */
-const TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' } as const
-
-/** SINGLE_SELECT adapters emit arrays; take the first value. */
-function firstValue(value: unknown): string {
-  const v = Array.isArray(value) ? value[0] : value
-  return typeof v === 'string' ? v : ''
-}
+import {
+  DIRECTION_OPTIONS,
+  firstValue,
+  MATCH_FIELD_OPTIONS,
+  MATCH_OPERATOR_OPTIONS,
+  TRIGGER_PROPS,
+} from './bank-rule-options'
 
 interface BankRuleConfigurePageProps {
   name: string

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-dialog.tsx
@@ -24,6 +24,16 @@ interface BankRuleDialogProps {
   onClose: () => void
   /** Null ⇒ create. */
   rule?: BankRuleRecord | null
+  /**
+   * Opening values for a CREATE, from the analyze panel's previewed pattern.
+   *
+   * ⚠️ Ignored when `rule` is set. A seed is where a new rule starts; an edit
+   * starts from the rule, and letting a seed override stored values would let a
+   * drawer quietly rewrite a rule somebody opened to read.
+   */
+  seed?: Partial<
+    Pick<BankRuleRecord, 'name' | 'matchField' | 'matchOperator' | 'matchValue' | 'direction'>
+  >
 }
 
 /**
@@ -34,7 +44,7 @@ interface BankRuleDialogProps {
  * This dialog owns all form state; the shell owns navigation only, exactly like
  * `RecordRuleDialog` and `MailFilterDialog`.
  */
-export function BankRuleDialog({ open, onClose, rule }: BankRuleDialogProps) {
+export function BankRuleDialog({ open, onClose, rule, seed }: BankRuleDialogProps) {
   const utils = api.useUtils()
 
   const [page, setPage] = useState<'configure' | 'action'>('configure')
@@ -54,18 +64,18 @@ export function BankRuleDialog({ open, onClose, rule }: BankRuleDialogProps) {
   useEffect(() => {
     if (!open) return
     setPage('configure')
-    setName(rule?.name ?? '')
-    setMatchField(rule?.matchField ?? 'matchKey')
-    setMatchOperator(rule?.matchOperator ?? 'contains')
-    setMatchValue(rule?.matchValue ?? '')
-    setDirection(rule?.direction ?? 'any')
+    setName(rule?.name ?? seed?.name ?? '')
+    setMatchField(rule?.matchField ?? seed?.matchField ?? 'matchKey')
+    setMatchOperator(rule?.matchOperator ?? seed?.matchOperator ?? 'contains')
+    setMatchValue(rule?.matchValue ?? seed?.matchValue ?? '')
+    setDirection(rule?.direction ?? seed?.direction ?? 'any')
     setBankAccountId(rule?.bankAccountId ?? '')
     setAutoApply(rule?.autoApply ?? false)
     setAction(rule?.action ?? 'code')
     setGlAccountId(rule?.glAccountId ?? '')
     setCounterpartBankAccountId(rule?.counterpartBankAccountId ?? '')
     setMemo(rule?.memo ?? '')
-  }, [open, rule])
+  }, [open, rule, seed])
 
   // Each page owns its own `BankAccountPicker`; the list is read here only to
   // name the chosen counterpart in the action summary row - so archived rows

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-options.ts
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-options.ts
@@ -5,8 +5,10 @@
  * screen needs: the compact one under a rule's name in the list, and the
  * action-only one on the dialog's drill-in row.
  *
- * Shared by `rules-page.tsx`, `bank-rule-configure-page.tsx` and
- * `bank-rule-action-page.tsx` so a rule reads the same wherever it is shown.
+ * Shared by `rules-page.tsx`, `bank-rule-configure-page.tsx`,
+ * `bank-rule-action-page.tsx` and the review drawer's `analyze-panel.tsx` so a
+ * rule reads the same wherever it is shown - including where one is being
+ * drafted out of a bank line that has not become a rule yet.
  */
 
 import type {
@@ -17,6 +19,15 @@ import type {
   BankRuleRecord,
 } from '@auxx/lib/banking/rules/client'
 import type { SelectOption } from '@auxx/types/custom-field'
+
+/** Flush-in-a-FieldPanelRow trigger sizing, the same one the rule editors share. */
+export const TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' } as const
+
+/** SINGLE_SELECT adapters emit arrays; take the first value. */
+export function firstValue(value: unknown): string {
+  const v = Array.isArray(value) ? value[0] : value
+  return typeof v === 'string' ? v : ''
+}
 
 export const MATCH_FIELD_OPTIONS: SelectOption[] = [
   { value: 'matchKey', label: 'Match key (normalised)', color: 'blue' },

--- a/apps/web/src/server/api/routers/banking-rules.ts
+++ b/apps/web/src/server/api/routers/banking-rules.ts
@@ -21,6 +21,7 @@ import {
   deleteRule,
   getBankRule,
   listBankRules,
+  previewRulePattern,
   runSuggestionsForAccount,
   updateRule,
 } from '@auxx/lib/banking/rules'
@@ -59,6 +60,45 @@ export const bankingRulesRouter = createTRPCRouter({
     if (result.isErr()) throw result.error
     return result.value
   }),
+
+  /**
+   * Count and sample the lines a pattern WOULD match, without creating a rule.
+   *
+   * 🛑 `ledgerView`, not `ledgerPost`. It creates nothing and changes nothing;
+   * it answers "how many lines look like this one", which is the same question
+   * the queue itself answers and is gated the same way.
+   *
+   * The conditions mirror `ruleFields`' matching half exactly, so whatever the
+   * analyze panel previewed is what `create` accepts a moment later.
+   */
+  previewPattern: permissionProcedure(PermissionKey.ledgerView)
+    .input(
+      z.object({
+        matchField: z.enum(BANK_RULE_MATCH_FIELDS),
+        matchOperator: z.enum(BANK_RULE_MATCH_OPERATORS),
+        matchValue: z.string().max(400),
+        amountMinMinor: z.number().int().nonnegative().nullish(),
+        amountMaxMinor: z.number().int().nonnegative().nullish(),
+        direction: z.enum(BANK_RULE_DIRECTIONS).optional(),
+        bankAccountId: z.string().nullish(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const result = await previewRulePattern(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        conditions: {
+          matchField: input.matchField,
+          matchOperator: input.matchOperator,
+          matchValue: input.matchValue,
+          amountMinMinor: input.amountMinMinor ?? null,
+          amountMaxMinor: input.amountMaxMinor ?? null,
+          direction: input.direction ?? 'any',
+          bankAccountId: input.bankAccountId ?? null,
+        },
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
 
   get: permissionProcedure(PermissionKey.ledgerView)
     .input(z.object({ id: z.string().min(1) }))

--- a/packages/lib/src/banking/client.ts
+++ b/packages/lib/src/banking/client.ts
@@ -346,6 +346,16 @@ export interface BankAccountCoverage {
  * browser bundle even though `feed/actions.ts` reaches Drizzle and the Stripe SDK.
  */
 export type { BankConnectionStart } from './feed/actions'
+// `descriptor.ts` is pure and dependency-free for the same reason, and the analyze
+// panel needs it in the browser: dissecting the line a reviewer is looking at is a
+// rendering concern, and a roundtrip per keystroke to learn where `CO ID:` starts
+// would be absurd. 🛑 Nothing it produces is ever stored - see its own header.
+export type {
+  BankDescriptorKind,
+  BankDescriptorTag,
+  ParsedBankDescriptor,
+} from './feed/descriptor'
+export { displayDescription, findDescriptorTag, parseBankDescriptor } from './feed/descriptor'
 // ── The Stripe Financial Connections feed (HANDOFF slot 3A) ───────────────────
 //
 // `normalizeMatchKey` is pure and dependency-free, and the review queue's browser code

--- a/packages/lib/src/banking/feed/__tests__/descriptor.test.ts
+++ b/packages/lib/src/banking/feed/__tests__/descriptor.test.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/banking/feed/__tests__/descriptor.test.ts
+//
+// Every fixture here is a REAL Bank of America line, taken from a 489-line
+// production feed. That matters more than usual: the parser's whole job is to
+// know where a bank puts the seams, and a made-up descriptor would only pin
+// what its author already believed.
+//
+// The two properties that carry the feature are asserted directly at the
+// bottom: a reference value is recognised as one, and the parts a person would
+// build a rule from survive intact.
+
+import { describe, expect, it } from 'vitest'
+import { displayDescription, findDescriptorTag, parseBankDescriptor } from '../descriptor'
+
+/** Column padding included, exactly as the bank prints it. */
+const SHOPIFY_PAYOUT =
+  'shopify          DES:TRANSFER   ID:ST-S4W6Z4N9S0E5           INDN:LFK ENGINEERING         CO ID:XXXXX65600 CCD'
+const SHOPIFY_PMT =
+  'SHOPIFY          DES:TRANSFER   ID:SHOPIFY                   INDN:UNKNOWN                 CO ID:SHOPIFYPMT WEB'
+const FEDEX =
+  'FEDERAL EXPRESS  DES:DEBIT      ID:EPA59327850               INDN:LFK Machinery LLC       CO ID:XXXXX27007 WEB'
+const ADP_TAX =
+  'ADP Tax          DES:ADP Tax    ID:L5GVU 090418A01           INDN:LFK ENGINEERING         CO ID:XXXXX11111 CCD'
+const WIRE =
+  'WIRE TYPE:INTL OUT DATE:260908 TIME:1255 ET                 TRN:XXXXXXXXXX763339 SERVICE REF::55:20                     BNF:1/HDMANN INDUSTRY CO., LIM ID:XXXXXXXXXX19472           BNF BK:OCBC BANK LIMITED ID:XXXXX0090638 PMT DET:630761374 LFK INVOICE'
+
+describe('parseBankDescriptor', () => {
+  it('reads an ACH descriptor into its parts', () => {
+    const parsed = parseBankDescriptor(SHOPIFY_PAYOUT)
+    expect(parsed.kind).toBe('ach')
+    expect(parsed.lead).toBe('shopify')
+    expect(parsed.sec).toBe('CCD')
+    expect(findDescriptorTag(parsed, 'DES')?.value).toBe('TRANSFER')
+    expect(findDescriptorTag(parsed, 'ID')?.value).toBe('ST-S4W6Z4N9S0E5')
+    expect(findDescriptorTag(parsed, 'INDN')?.value).toBe('LFK ENGINEERING')
+    // 🛑 The SEC code came off the CO ID's value, not out of the middle of the
+    // string. Leaving `XXXXX65600 CCD` here would make the originator id differ
+    // from the same originator's next line whenever the entry class changed.
+    expect(findDescriptorTag(parsed, 'CO ID')?.value).toBe('XXXXX65600')
+  })
+
+  it('prefers CO ID over a bare ID at the same position', () => {
+    // ⚠️ Alternation is leftmost-first, so `CO ID` has to precede `ID` in the
+    // label list. Get this wrong and an ACH originator id parses as a trace
+    // number and the one stable identifier on the line is lost.
+    const parsed = parseBankDescriptor(SHOPIFY_PMT)
+    expect(findDescriptorTag(parsed, 'CO ID')?.value).toBe('SHOPIFYPMT')
+    expect(findDescriptorTag(parsed, 'ID')?.value).toBe('SHOPIFY')
+    expect(parsed.sec).toBe('WEB')
+  })
+
+  it('keeps a wire’s two ID tags apart, in order', () => {
+    // A wire carries the beneficiary's id and then the beneficiary BANK's. A
+    // record would silently drop the second; the array keeps both.
+    const parsed = parseBankDescriptor(WIRE)
+    expect(parsed.kind).toBe('wire')
+    expect(parsed.tags.filter((tag) => tag.label === 'ID')).toHaveLength(2)
+    expect(findDescriptorTag(parsed, 'BNF')?.value).toBe('1/HDMANN INDUSTRY CO., LIM')
+    expect(findDescriptorTag(parsed, 'BNF BK')?.value).toBe('OCBC BANK LIMITED')
+    expect(findDescriptorTag(parsed, 'WIRE TYPE')?.value).toBe('INTL OUT')
+  })
+
+  it('collapses the bank’s column padding without reordering anything', () => {
+    const parsed = parseBankDescriptor(FEDEX)
+    expect(parsed.text).not.toMatch(/ {2}/)
+    expect(parsed.text.startsWith('FEDERAL EXPRESS DES:DEBIT')).toBe(true)
+  })
+
+  it('parses an untagged merchant line to a lead and nothing else', () => {
+    // 43% of the real feed. One lead, no tags, and that is a complete answer.
+    const parsed = parseBankDescriptor('TABOOLA.COM LTD')
+    expect(parsed.lead).toBe('TABOOLA.COM LTD')
+    expect(parsed.tags).toEqual([])
+    expect(parsed.sec).toBeNull()
+    expect(parsed.kind).toBe('plain')
+  })
+
+  it('classifies the non-ACH shapes', () => {
+    expect(parseBankDescriptor('Check 1660').kind).toBe('check')
+    expect(parseBankDescriptor('Zelle payment to Carolin Klooth Conf# i9xceggk3').kind).toBe(
+      'zelle'
+    )
+    expect(parseBankDescriptor('Wire Transfer Fee').kind).toBe('fee')
+    expect(parseBankDescriptor('CHECKCARD 0912 AMZN MKTP US*2Y4XK9').kind).toBe('card')
+  })
+
+  it('never throws on nothing', () => {
+    for (const input of ['', '   ', null, undefined]) {
+      const parsed = parseBankDescriptor(input)
+      expect(parsed.tags).toEqual([])
+      expect(parsed.lead).toBe('')
+    }
+  })
+
+  it('marks per-payment references as varying and payee names as not', () => {
+    // 🛑 The property the UI depends on. A reviewer who builds a pattern out of
+    // `ID:ST-S4W6Z4N9S0E5` gets a rule that matches exactly one line forever,
+    // and this flag is the only warning before that happens.
+    const parsed = parseBankDescriptor(SHOPIFY_PAYOUT)
+    expect(findDescriptorTag(parsed, 'ID')?.isReference).toBe(true)
+    expect(findDescriptorTag(parsed, 'CO ID')?.isReference).toBe(false)
+    expect(findDescriptorTag(parsed, 'INDN')?.isReference).toBe(false)
+    expect(findDescriptorTag(parsed, 'DES')?.isReference).toBe(false)
+  })
+})
+
+describe('displayDescription', () => {
+  it('names the originator and what the entry was', () => {
+    expect(displayDescription(FEDEX)).toBe('FEDERAL EXPRESS · DEBIT')
+    expect(displayDescription(SHOPIFY_PAYOUT)).toBe('shopify · TRANSFER')
+  })
+
+  it('does not repeat an entry description that is just the payee again', () => {
+    expect(displayDescription(ADP_TAX)).toBe('ADP Tax')
+  })
+
+  it('names a wire by its type and beneficiary', () => {
+    expect(displayDescription(WIRE)).toBe('Intl out · 1/HDMANN INDUSTRY CO., LIM')
+  })
+
+  it('returns null when the bank’s own string is already the best label', () => {
+    // 🛑 Callers render `displayDescription(d) ?? d`. Returning a mangled
+    // version of `TABOOLA.COM LTD` would be strictly worse than returning the
+    // line itself.
+    expect(displayDescription('TABOOLA.COM LTD')).toBeNull()
+    expect(displayDescription('Check 1660')).toBeNull()
+    expect(displayDescription('')).toBeNull()
+    expect(displayDescription(null)).toBeNull()
+  })
+})

--- a/packages/lib/src/banking/feed/descriptor.ts
+++ b/packages/lib/src/banking/feed/descriptor.ts
@@ -1,0 +1,271 @@
+// packages/lib/src/banking/feed/descriptor.ts
+
+/**
+ * `description` → its STRUCTURE. The read-time counterpart to
+ * `normalizeMatchKey`, and deliberately the opposite kind of function.
+ *
+ * `normalizeMatchKey` throws information away to produce a stable grouping key.
+ * This keeps all of it and only says where the seams are, so the review drawer
+ * can show a reviewer what a line is made of and let them build a rule out of
+ * one part of it.
+ *
+ * 🛑 **Nothing here is ever stored.** `matchKey` is computed once at ingest and
+ * never recomputed, which is why every improvement to it needs a backfill to
+ * reach rows already in the table. A second stored derivation would double that
+ * debt for something that is pure presentation, so this runs at read time in
+ * both the browser and the server and improves for every existing row the
+ * moment it changes.
+ *
+ * Pure and dependency-free, like its neighbour, so `banking/client.ts` can
+ * re-export it to browser code.
+ *
+ * ## What the shapes are
+ *
+ * US banks print two families of descriptor. The tagged family is a run of
+ * `LABEL:value` pairs padded into fixed columns, which is what ACH and wire
+ * lines look like:
+ *
+ * ```
+ * FEDERAL EXPRESS  DES:DEBIT      ID:EPA59327850   INDN:LFK Machinery LLC  CO ID:XXXXX27007 WEB
+ * ```
+ *
+ * The untagged family is a merchant string and nothing else (`TABOOLA.COM LTD`,
+ * `GOOGLE *ADS3197812385`). There is no delimiter and no quoting in either, so a
+ * tag's value is "everything until the next tag starts" and that is the only
+ * rule that works.
+ */
+
+/** The NACHA SEC codes a US bank prints at the end of an ACH descriptor. */
+const SEC_CODES = [
+  'WEB',
+  'PPD',
+  'CCD',
+  'CTX',
+  'TEL',
+  'ARC',
+  'BOC',
+  'POP',
+  'RCK',
+  'IAT',
+  'MTE',
+  'POS',
+  'SHR',
+]
+
+/**
+ * Tag labels, LONGEST FIRST at any shared prefix.
+ *
+ * ⚠️ The ordering is load-bearing and pinned by tests: regex alternation is
+ * leftmost-first at each scan position, so `CO ID` has to precede `ID` and
+ * `BNF BK` has to precede `BNF`, or a wire's beneficiary bank is read as the
+ * beneficiary and an ACH originator id is read as a trace number.
+ */
+const TAG_LABELS = [
+  'ORIG CO NAME',
+  'CO ENTRY DESCR',
+  'CONFIRMATION#',
+  'CONFIRMATION',
+  'SERVICE REF',
+  'DESC DATE',
+  'PMT INFO',
+  'PMT DET',
+  'IND NAME',
+  'WIRE TYPE',
+  'SND BNK',
+  'ORIG ID',
+  'BNF BK',
+  'IND ID',
+  'CO ID',
+  'TRACE',
+  'CONF#',
+  'CONF',
+  'DATE',
+  'TIME',
+  'INDN',
+  'ORIG',
+  'TRN',
+  'SEQ',
+  'RFB',
+  'OBI',
+  'BNF',
+  'DES',
+  'SEC',
+  'EED',
+  'REF',
+  'ID',
+]
+
+/**
+ * Labels whose value is a per-payment MACHINE REFERENCE rather than something a
+ * human reads. These are what {@link displayDescription} drops, and what makes
+ * two occurrences of the same payee look like different lines.
+ */
+const REFERENCE_LABELS = new Set([
+  'ID',
+  'IND ID',
+  'ORIG ID',
+  'TRACE',
+  'TRN',
+  'SEQ',
+  'REF',
+  'SERVICE REF',
+  'DESC DATE',
+  'DATE',
+  'TIME',
+  'EED',
+  'CONF',
+  'CONF#',
+  'CONFIRMATION',
+  'CONFIRMATION#',
+  'PMT INFO',
+])
+
+/** One `LABEL:value` pair, in the order the bank printed it. */
+export interface BankDescriptorTag {
+  /** Uppercased, internal whitespace collapsed. `CO ID`, never `CO  id`. */
+  label: string
+  value: string
+  /** `true` when the value is a per-payment reference rather than a name. */
+  isReference: boolean
+}
+
+export type BankDescriptorKind = 'ach' | 'wire' | 'card' | 'check' | 'zelle' | 'fee' | 'plain'
+
+export interface ParsedBankDescriptor {
+  /** The bank's line with runs of column padding collapsed. Never re-ordered. */
+  text: string
+  /** Everything before the first tag. The originator's own name, usually. */
+  lead: string
+  /**
+   * Ordered, and duplicates are KEPT: a wire carries two `ID:` tags, one for
+   * the beneficiary and one for their bank, and collapsing them into a record
+   * silently discards the second.
+   */
+  tags: BankDescriptorTag[]
+  /** The trailing NACHA entry class, when the line ends in one. */
+  sec: string | null
+  kind: BankDescriptorKind
+}
+
+const TAG_PATTERN = TAG_LABELS.map((label) =>
+  label.replace(/ /g, '\\s+').replace(/#/g, '\\#')
+).join('|')
+
+const CARD_RE = /^(CHECKCARD|PURCHASE|POS |DEBIT CARD|CREDIT CARD|VISA|MASTERCARD|ATM)\b/i
+const CHECK_RE = /^(CHECK|CHK)\s*#?\s*\d+\s*$/i
+const ZELLE_RE = /\bZELLE\b/i
+const FEE_RE = /\b(FEE|SERVICE CHARGE|WAIVER|INTEREST|REWARDS?|RWDS)\b/i
+
+/** Find the first tag with `label`, or `null`. Labels are uppercase. */
+export function findDescriptorTag(
+  parsed: ParsedBankDescriptor,
+  label: string
+): BankDescriptorTag | null {
+  return parsed.tags.find((tag) => tag.label === label) ?? null
+}
+
+/**
+ * Split a bank `description` into its leading text and its `LABEL:value` tags.
+ *
+ * Never throws and never returns null: an untagged merchant string parses to
+ * one lead and no tags, which is a legitimate answer and the common one (43% of
+ * the real feed this was written against).
+ */
+export function parseBankDescriptor(description: string | null | undefined): ParsedBankDescriptor {
+  const text = (description ?? '').replace(/\s+/g, ' ').trim()
+  if (!text) return { text: '', lead: '', tags: [], sec: null, kind: 'plain' }
+
+  const matcher = new RegExp(`(?:^|\\s|\\b)(${TAG_PATTERN})\\s*:`, 'gi')
+  const hits: { label: string; start: number; end: number }[] = []
+  for (let match = matcher.exec(text); match; match = matcher.exec(text)) {
+    const raw = match[1] ?? ''
+    const label = raw.toUpperCase().replace(/\s+/g, ' ')
+    hits.push({ label, start: match.index + match[0].indexOf(raw), end: matcher.lastIndex })
+  }
+
+  const first = hits[0]
+  const lead = (first ? text.slice(0, first.start) : text).trim()
+  const tags: BankDescriptorTag[] = hits.map((hit, index) => ({
+    label: hit.label,
+    value: text.slice(hit.end, hits[index + 1]?.start ?? text.length).trim(),
+    isReference: REFERENCE_LABELS.has(hit.label),
+  }))
+
+  // The SEC code trails the LAST tag's value, not the raw string, so it is
+  // pulled off that value and the value is shortened to match. Requiring a
+  // space in the value first is what stops a bare `CO ID:WEB` losing its whole
+  // value to a code that was never there.
+  let sec: string | null = null
+  const last = tags[tags.length - 1]
+  const tail = last ? last.value : lead
+  const lastToken = tail.split(' ').pop() ?? ''
+  if (lastToken && SEC_CODES.includes(lastToken.toUpperCase()) && tail.includes(' ')) {
+    sec = lastToken.toUpperCase()
+    const trimmed = tail.slice(0, tail.length - lastToken.length).trim()
+    if (last) last.value = trimmed
+  }
+
+  return { text, lead, tags, sec, kind: classifyDescriptor({ lead, tags, sec, text }) }
+}
+
+function classifyDescriptor(parts: {
+  lead: string
+  tags: BankDescriptorTag[]
+  sec: string | null
+  text: string
+}): BankDescriptorKind {
+  const has = (label: string) => parts.tags.some((tag) => tag.label === label)
+  if (has('WIRE TYPE') || has('TRN') || has('BNF')) return 'wire'
+  if (has('CO ID') || has('DES') || has('INDN') || has('ORIG CO NAME') || parts.sec) return 'ach'
+  if (ZELLE_RE.test(parts.text)) return 'zelle'
+  if (CHECK_RE.test(parts.text)) return 'check'
+  if (CARD_RE.test(parts.text)) return 'card'
+  if (FEE_RE.test(parts.text)) return 'fee'
+  return 'plain'
+}
+
+/**
+ * The line with its machine references removed, for DISPLAY only.
+ *
+ * Returns `null` when there is nothing better to show than the bank's own
+ * string, which is the honest answer for the untagged half of a feed:
+ * `TABOOLA.COM LTD` is already the best available label. 🛑 Callers render
+ * `displayDescription(d) ?? d` and never drop the original.
+ *
+ * ⚠️ Never a grouping key and never something to reconcile against. Two
+ * different originators can produce the same display string; that is fine for a
+ * label and would be a miscoding as a key. {@link parseBankDescriptor} is the
+ * seam a rule is built from, and `normalizeMatchKey` is the key.
+ */
+export function displayDescription(description: string | null | undefined): string | null {
+  const parsed = parseBankDescriptor(description)
+  if (!parsed.text) return null
+
+  if (parsed.kind === 'wire') {
+    const party = findDescriptorTag(parsed, 'BNF') ?? findDescriptorTag(parsed, 'ORIG')
+    const type = findDescriptorTag(parsed, 'WIRE TYPE')
+    const label = type ? titleish(type.value) : 'Wire'
+    return party?.value ? `${label} · ${party.value}` : label
+  }
+
+  if (parsed.kind === 'ach' && parsed.lead) {
+    const entry = findDescriptorTag(parsed, 'DES') ?? findDescriptorTag(parsed, 'CO ENTRY DESCR')
+    // A `DES` that merely repeats the originator's name adds nothing:
+    // `ADP Tax DES:ADP Tax` should read `ADP Tax`, not `ADP Tax · ADP Tax`.
+    if (!entry?.value || sameish(entry.value, parsed.lead)) return parsed.lead
+    return `${parsed.lead} · ${entry.value}`
+  }
+
+  return null
+}
+
+/** `WIRE OUT` → `Wire out`. Only ever applied to the bank's own fixed vocabulary. */
+function titleish(value: string): string {
+  const lower = value.toLowerCase()
+  return lower.charAt(0).toUpperCase() + lower.slice(1)
+}
+
+function sameish(a: string, b: string): boolean {
+  const fold = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, '')
+  return fold(a) === fold(b)
+}

--- a/packages/lib/src/banking/rules/client.ts
+++ b/packages/lib/src/banking/rules/client.ts
@@ -42,15 +42,17 @@ export const TRANSFER_MATCH_WINDOW_DAYS = 3
 /** A safety limit on a hand-typed regex rule. See {@link isSafeRegexPattern}. */
 export const MAX_REGEX_PATTERN_LENGTH = 200
 
-/** A `bank_rule` record, as the UI and `evaluateRules` see it. */
-export interface BankRuleRecord {
-  id: string
-  recordId: string
-  name: string
-  enabled: boolean
-  autoApply: boolean
-  /** Lower runs first. `evaluateRules` treats a missing priority as `0`. */
-  priority: number
+/**
+ * The conditions half of a rule: everything that decides WHETHER a rule fires,
+ * with nothing about what it then does.
+ *
+ * Split out so that the review drawer's analyze panel can preview a pattern
+ * against the book before any rule exists. 🛑 One predicate
+ * (`matchesRuleConditions`) serves both the preview and ingest, because a
+ * preview that counted differently from `evaluateRules` would be worse than no
+ * preview: it would be a confident wrong number a person creates a rule from.
+ */
+export interface BankRuleConditions {
   matchField: BankRuleMatchField
   matchOperator: BankRuleMatchOperator
   matchValue: string
@@ -60,6 +62,17 @@ export interface BankRuleRecord {
   direction: BankRuleDirection
   /** A `bank_account` entity-instance id, or `null` to match any account. */
   bankAccountId: string | null
+}
+
+/** A `bank_rule` record, as the UI and `evaluateRules` see it. */
+export interface BankRuleRecord extends BankRuleConditions {
+  id: string
+  recordId: string
+  name: string
+  enabled: boolean
+  autoApply: boolean
+  /** Lower runs first. `evaluateRules` treats a missing priority as `0`. */
+  priority: number
   action: BankRuleAction
   /** The `gl_account` id a `code` action proposes (task 15 §4). Never a code. */
   glAccountId: string | null

--- a/packages/lib/src/banking/rules/evaluate.ts
+++ b/packages/lib/src/banking/rules/evaluate.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  type BankRuleConditions,
   type BankRuleRecord,
   compileSafeRegex,
   type RuleMatchInput,
@@ -39,32 +40,47 @@ export function evaluateRules(
     .sort((a, b) => (a.rule.priority || 0) - (b.rule.priority || 0) || a.index - b.index)
 
   for (const { rule } of ordered) {
-    if (ruleMatches(rule, transaction)) return rule
+    if (matchesRuleConditions(rule, transaction)) return rule
   }
   return null
 }
 
-/** Whether one rule matches one transaction. Every condition must pass. */
-function ruleMatches(rule: BankRuleRecord, transaction: RuleMatchInput): boolean {
+/**
+ * Whether one set of conditions matches one transaction. Every condition must
+ * pass.
+ *
+ * 🛑 **This is the only place a rule's match is decided**, and it is exported so
+ * that the analyze panel's preview counts the same rows ingest will act on. A
+ * second implementation - a `~*` in SQL, say - would disagree the first time a
+ * pattern used a lookahead, and the person creating the rule would never find
+ * out until it silently coded the wrong lines.
+ */
+export function matchesRuleConditions(
+  rule: BankRuleConditions,
+  transaction: RuleMatchInput
+): boolean {
   if (rule.bankAccountId && rule.bankAccountId !== transaction.bankAccountId) return false
   if (!directionMatches(rule.direction, transaction.amountMinor)) return false
   if (!amountMatches(rule, transaction.amountMinor)) return false
   return fieldMatches(rule, transaction)
 }
 
-function directionMatches(direction: BankRuleRecord['direction'], amountMinor: number): boolean {
+function directionMatches(
+  direction: BankRuleConditions['direction'],
+  amountMinor: number
+): boolean {
   if (direction === 'any') return true
   return direction === resolveDirection(amountMinor)
 }
 
-function amountMatches(rule: BankRuleRecord, amountMinor: number): boolean {
+function amountMatches(rule: BankRuleConditions, amountMinor: number): boolean {
   const magnitude = Math.abs(amountMinor)
   if (rule.amountMinMinor != null && magnitude < rule.amountMinMinor) return false
   if (rule.amountMaxMinor != null && magnitude > rule.amountMaxMinor) return false
   return true
 }
 
-function fieldMatches(rule: BankRuleRecord, transaction: RuleMatchInput): boolean {
+function fieldMatches(rule: BankRuleConditions, transaction: RuleMatchInput): boolean {
   const value = rule.matchField === 'description' ? transaction.description : transaction.matchKey
   if (!value) return false
 

--- a/packages/lib/src/banking/rules/index.ts
+++ b/packages/lib/src/banking/rules/index.ts
@@ -9,6 +9,7 @@
 
 export type {
   BankRuleAction,
+  BankRuleConditions,
   BankRuleDirection,
   BankRuleMatchField,
   BankRuleMatchOperator,
@@ -30,9 +31,11 @@ export {
   SUGGESTION_SOURCES,
   TRANSFER_MATCH_WINDOW_DAYS,
 } from './client'
-export { evaluateRules } from './evaluate'
+export { evaluateRules, matchesRuleConditions } from './evaluate'
 export type {
   BankRuleFieldContext,
+  RulePatternPreview,
+  RulePatternPreviewLine,
   RuleTransactionFieldContext,
   TransactionMatchRow,
 } from './reads'
@@ -45,6 +48,7 @@ export {
   listHistoryMatches,
   loadBankRuleFieldContext,
   loadRuleTransactionFieldContext,
+  previewRulePattern,
   requireBankRuleFieldContext,
   requireRuleTransactionFieldContext,
 } from './reads'

--- a/packages/lib/src/banking/rules/reads.ts
+++ b/packages/lib/src/banking/rules/reads.ts
@@ -10,7 +10,7 @@
  */
 
 import { type Database, schema } from '@auxx/database'
-import { and, asc, eq, inArray, isNull } from 'drizzle-orm'
+import { and, asc, eq, ilike, inArray, isNull } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { getCachedEntityDefId, getOrgCache } from '../../cache'
 import { UnprocessableEntityError } from '../../errors'
@@ -18,6 +18,7 @@ import { toRecordId } from '../../resources/resource-id'
 import { daysBetween, toDateKey } from '../client'
 import {
   type BankRuleAction,
+  type BankRuleConditions,
   type BankRuleDirection,
   type BankRuleMatchField,
   type BankRuleMatchOperator,
@@ -25,6 +26,7 @@ import {
   HISTORY_SAMPLE_SIZE,
   TRANSFER_MATCH_WINDOW_DAYS,
 } from './client'
+import { matchesRuleConditions } from './evaluate'
 import { guard } from './guard'
 
 // ─── bank_rule field context ─────────────────────────────────────────────
@@ -595,4 +597,178 @@ async function readTxMatchRows(
     reviewStatus: read(id, 'bank_transaction_review_status')?.optionId ?? null,
     glAccountId: read(id, 'bank_transaction_gl_account')?.valueText ?? null,
   }))
+}
+
+// ─── pattern preview ─────────────────────────────────────────────────────
+
+/**
+ * The most `bank_transaction` rows one preview will hydrate.
+ *
+ * A preview is a person typing into a box, so it has to answer fast and it has
+ * to answer honestly when it cannot see the whole book. The cap is on the
+ * CANDIDATE set, and {@link RulePatternPreview.truncated} says when it bit -
+ * silently counting 5,000 of 12,000 would be a confident wrong number, which is
+ * the one thing this feature must not produce.
+ */
+const MAX_PREVIEW_CANDIDATES = 5_000
+
+/** How many example lines a preview returns. Enough to recognise a mistake. */
+const PREVIEW_SAMPLE_SIZE = 12
+
+/** One line in a preview's sample. */
+export interface RulePatternPreviewLine {
+  id: string
+  postedAt: string | null
+  description: string | null
+  matchKey: string | null
+  amountMinor: number
+  reviewStatus: string | null
+  glAccountId: string | null
+}
+
+export interface RulePatternPreview {
+  /** How many lines in the org the conditions match. */
+  matchCount: number
+  /** Of those, how many are already `coded`. */
+  codedCount: number
+  /**
+   * How the already-coded matches were coded, commonest first. This is the
+   * rule-mining signal: "31 lines match, 27 of them are already 6100" is the
+   * evidence that the rule is worth writing.
+   */
+  codedByAccount: { glAccountId: string; count: number }[]
+  /** Newest first, capped at {@link PREVIEW_SAMPLE_SIZE}. */
+  sample: RulePatternPreviewLine[]
+  /** `true` when the candidate set hit {@link MAX_PREVIEW_CANDIDATES}. */
+  truncated: boolean
+}
+
+/**
+ * Count and sample the lines a set of rule conditions would match, without
+ * creating a rule.
+ *
+ * 🛑 **The final filter is {@link matchesRuleConditions}, in JavaScript, for
+ * every operator** - the same function `evaluateRules` runs at ingest. SQL is
+ * used only to NARROW, and only where it can do so as a strict superset:
+ *
+ * - `contains` / `equals` / `starts_with` narrow with `ILIKE` on the matched
+ *   field, with the user's `%` and `_` escaped so a pasted pattern cannot turn
+ *   itself into a wildcard.
+ * - `regex` cannot narrow at all. Postgres `~*` is POSIX - no lookarounds, and
+ *   different escaping - so a `~*` pre-filter would drop rows the JavaScript
+ *   pattern matches. It scans the def instead, bounded by
+ *   {@link MAX_PREVIEW_CANDIDATES}.
+ *
+ * ⚠️ This is a deliberate exception to the review queue's "every filter runs in
+ * SQL" rule, and the reason is that agreeing with ingest matters more here than
+ * the roundtrip does. Do not "optimise" the regex branch into `~*`.
+ */
+export async function previewRulePattern(
+  db: Database,
+  params: { organizationId: string; conditions: BankRuleConditions }
+): Promise<Result<RulePatternPreview, Error>> {
+  const { organizationId, conditions } = params
+  return guard(
+    async () => {
+      const empty: RulePatternPreview = {
+        matchCount: 0,
+        codedCount: 0,
+        codedByAccount: [],
+        sample: [],
+        truncated: false,
+      }
+      if (!conditions.matchValue.trim()) return empty
+
+      const ctx = await loadRuleTransactionFieldContext(organizationId)
+      if (!ctx) return empty
+      const fieldAttribute =
+        conditions.matchField === 'description'
+          ? 'bank_transaction_description'
+          : 'bank_transaction_match_key'
+      const matchedField = ctx.fields[fieldAttribute]
+      if (!matchedField) return empty
+
+      const candidateRows = await db
+        .select({ entityId: schema.FieldValue.entityId })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            eq(schema.FieldValue.fieldId, matchedField.id),
+            ...narrowByOperator(conditions)
+          )
+        )
+        .limit(MAX_PREVIEW_CANDIDATES + 1)
+
+      const truncated = candidateRows.length > MAX_PREVIEW_CANDIDATES
+      const candidateIds = candidateRows.slice(0, MAX_PREVIEW_CANDIDATES).map((row) => row.entityId)
+      if (candidateIds.length === 0) return empty
+
+      const rows = await readTxMatchRows(db, organizationId, ctx, candidateIds)
+      const matched = rows.filter((row) => matchesRuleConditions(conditions, row))
+
+      const byAccount = new Map<string, number>()
+      for (const row of matched) {
+        if (row.reviewStatus !== 'coded' || !row.glAccountId) continue
+        byAccount.set(row.glAccountId, (byAccount.get(row.glAccountId) ?? 0) + 1)
+      }
+
+      // `postedAt` is a `YYYY-MM-DD` day key, so a string compare IS the date
+      // order. A line the bank never dated sorts last rather than first.
+      const sample = [...matched]
+        .sort((a, b) => (b.postedAt ?? '').localeCompare(a.postedAt ?? ''))
+        .slice(0, PREVIEW_SAMPLE_SIZE)
+        .map((row) => ({
+          id: row.id,
+          postedAt: row.postedAt,
+          description: row.description,
+          matchKey: row.matchKey,
+          amountMinor: row.amountMinor,
+          reviewStatus: row.reviewStatus,
+          glAccountId: row.glAccountId,
+        }))
+
+      return {
+        matchCount: matched.length,
+        codedCount: [...byAccount.values()].reduce((total, count) => total + count, 0),
+        codedByAccount: [...byAccount.entries()]
+          .map(([glAccountId, count]) => ({ glAccountId, count }))
+          .sort((a, b) => b.count - a.count),
+        sample,
+        truncated,
+      }
+    },
+    'Failed to preview a bank rule pattern',
+    { organizationId, matchField: conditions.matchField, matchOperator: conditions.matchOperator }
+  )
+}
+
+/**
+ * The SQL half of the preview: a strict SUPERSET of what
+ * {@link matchesRuleConditions} will accept, or nothing at all for `regex`.
+ */
+function narrowByOperator(conditions: BankRuleConditions) {
+  const escaped = escapeLikePattern(conditions.matchValue)
+  switch (conditions.matchOperator) {
+    case 'contains':
+      return [ilike(schema.FieldValue.valueText, `%${escaped}%`)]
+    case 'equals':
+      return [ilike(schema.FieldValue.valueText, escaped)]
+    case 'starts_with':
+      return [ilike(schema.FieldValue.valueText, `${escaped}%`)]
+    default:
+      return []
+  }
+}
+
+/**
+ * Neutralise `LIKE`'s own metacharacters in a user-typed value.
+ *
+ * Without this, a pattern containing `%` matches far more than the person meant
+ * and the preview's count is larger than what the rule will ever do - the exact
+ * shape of lie this feature exists to avoid. The backslash is doubled first, or
+ * escaping `%` would leave a dangling escape of its own.
+ */
+function escapeLikePattern(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/[%_]/g, (char) => `\\${char}`)
 }


### PR DESCRIPTION
## Why

Stripe Financial Connections ships a `description` and nothing else — no merchant name, no category. So what a bank line *is* has to be read off its own text. Most of that text is structure:

```
SHOPIFY  DES:TRANSFER  ID:ST-F1K0R8X3L3D5  INDN:LFK ENGINEERING  CO ID:SHOPIFYPMT WEB
   ↑          ↑              ↑                     ↑                    ↑        ↑
originator  entry      per-payment ref        receiver          originator id  ACH class
```

Only some of those are worth matching on. Today a reviewer sees the whole string and has no way to ask "how many other lines look like this one" short of typing a rule and finding out afterwards.

Measured against a real 489-line feed, the per-payment reference is what breaks grouping: the 68 Shopify payouts, worth $2.29M in, carry 68 distinct `matchKey`s because `ID:ST-F1K0R8X3L3D5` changes every time and isn't a run of four digits, so the normaliser's `\d{4,}` rule never fires on it.

## What

An **Analyze** section in the review drawer:

- the bank's line verbatim, then its parts as clickable tokens — per-payment references faded, because a pattern built out of a trace number matches exactly one line forever
- field / operator / pattern, using the same `bank-rule-options` vocabularies the rule dialog uses
- a live count, the already-coded breakdown (the rule-mining signal: *"31 lines match, 27 already 6100"*), and a sample
- **Create rule from this pattern**, which opens the existing dialog seeded rather than a second form that could drift from it

Plus a **Notes** section, answering a separate question that came up: there is no note field on `bank_transaction`, and the `memo` in the code/transfer panels is not one — it's written into the *GL entry's* memo, so it doesn't exist until you code the line. A bank transaction is an `EntityInstance` and already carries a `recordId`, so the org's comment thread works with no new column, and keeps who wrote the note and when.

## Design notes worth reviewing

**Nothing the parser produces is stored.** `matchKey` is the cautionary tale — computed once at ingest, never recomputed, so improving it needs a backfill to reach existing rows. A second stored derivation would double that debt for something that's pure presentation. `displayDescription` runs at read time, improves for every existing row the moment it changes, and returns `null` when the bank's own string is already the best label. Callers render `displayDescription(d) ?? d`; the raw line is never replaced.

**One matcher, not two.** `matchesRuleConditions` is extracted out of `evaluateRules` and exported, so the preview and ingest cannot disagree.

**The regex branch does not narrow in SQL, on purpose.** `contains`/`equals`/`starts_with` narrow with `ILIKE` (user `%` and `_` escaped, so a pasted pattern can't turn itself into a wildcard). `regex` scans, bounded at 5,000 candidates with a `truncated` flag. Postgres `~*` is POSIX — no lookarounds, different escaping — so a `~*` pre-filter would silently drop rows the JavaScript pattern matches. This is a deliberate exception to the queue's SQL-only rule and it's commented as one: a preview that counted differently from ingest would be a confident wrong number somebody creates a rule from.

## Verification

- 12 new parser tests, **every fixture a real line from the production feed** (`packages/lib/src/banking/feed/__tests__/descriptor.test.ts`)
- 355/355 banking tests pass, including `evaluate` after the extraction
- `pnpm lint` clean; typecheck ratchet clean on `web` and `lib`
- Run against the real 489-line feed, the panel's opening pattern reaches: `SHOPIFYPMT` → 42 lines, `XXXXX55505` → 8 (ADP), `XXXXX27007` → 6 (FedEx), `TABOOLA.COM LTD` → 70

## Not in this PR

- **Fixing `normalizeMatchKey` itself.** The same analysis says one added strip rule for mixed-alphanumeric reference tokens takes the real feed from 65.2% to 83.4% of lines landing in a group of 2+, and 170 singleton keys down to 81. That's a separate change with a backfill attached.
- **`Check 1660` normalises to `check`**, so all 11 checks share one key to 11 different payees — once anything is coded, `suggestFromHistory` will sample six of them and propose the majority for an unrelated check. Own fix.
- **Registering the card on the generic `bank_transaction` record drawer** (`'bank_transaction:analyze'` in `DRAWER_TAB_CARD_COMPONENTS`). The review queue is deliberately not a `BaseEntityDrawer`, so this only mounts in the review drawer today.

https://claude.ai/code/session_015NoHrbPhjYcr6rjLqFRw7M
