### PR TITLE
feat(accounting): one AccountLabel for every GL account on screen

### DIFF
--- a/apps/web/src/components/accounting/ui/__tests__/account-label-format.test.ts
+++ b/apps/web/src/components/accounting/ui/__tests__/account-label-format.test.ts
@@ -1,0 +1,46 @@
+// apps/web/src/components/accounting/ui/__tests__/account-label-format.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { accountChipText, accountMatchesSearch, formatAccountLabel } from '../account-label-format'
+
+const numbered = { code: '1310', name: 'Inventory Raw Materials' }
+const unnumbered = { code: null, name: 'Bank Fees' }
+
+describe('formatAccountLabel', () => {
+  it('joins code and name with a middot', () => {
+    expect(formatAccountLabel(numbered)).toBe('1310 · Inventory Raw Materials')
+  })
+
+  it('renders the name alone when the code is null, undefined or blank', () => {
+    expect(formatAccountLabel(unnumbered)).toBe('Bank Fees')
+    expect(formatAccountLabel({ name: 'Bank Fees' })).toBe('Bank Fees')
+    expect(formatAccountLabel({ code: '  ', name: 'Bank Fees' })).toBe('Bank Fees')
+  })
+
+  it('is empty for nothing', () => {
+    expect(formatAccountLabel(null)).toBe('')
+    expect(formatAccountLabel(undefined)).toBe('')
+  })
+})
+
+describe('accountChipText', () => {
+  it('prefers the code and falls back to the name', () => {
+    expect(accountChipText(numbered)).toBe('1310')
+    expect(accountChipText(unnumbered)).toBe('Bank Fees')
+  })
+})
+
+describe('accountMatchesSearch', () => {
+  it('matches on either half, case-insensitively', () => {
+    expect(accountMatchesSearch(numbered, '13')).toBe(true)
+    expect(accountMatchesSearch(numbered, 'raw mat')).toBe(true)
+    expect(accountMatchesSearch(numbered, 'RAW')).toBe(true)
+    expect(accountMatchesSearch(numbered, '9999')).toBe(false)
+  })
+
+  it('does not throw on a null code and matches everything on an empty search', () => {
+    expect(accountMatchesSearch(unnumbered, '13')).toBe(false)
+    expect(accountMatchesSearch(unnumbered, 'fees')).toBe(true)
+    expect(accountMatchesSearch(unnumbered, '   ')).toBe(true)
+  })
+})

--- a/apps/web/src/components/accounting/ui/account-label-format.ts
+++ b/apps/web/src/components/accounting/ui/account-label-format.ts
@@ -1,0 +1,48 @@
+// apps/web/src/components/accounting/ui/account-label-format.ts
+//
+// The pure half of `account-label.tsx`: string forms of a GL account with no
+// React and no chart fetch, so `accounts-types.ts` (which the picker imports)
+// can use them without a module cycle, and so they are unit-testable bare.
+
+/**
+ * The two facts a label needs. `code` is typed nullable ahead of task 15 §5,
+ * where `gl_account.code` becomes optional: an account imported from
+ * QuickBooks has a name and no number, and every renderer must read correctly
+ * for it today so that change touches no screen.
+ */
+export interface LabelAccount {
+  code?: string | null
+  name: string
+}
+
+/**
+ * `1310 · Inventory Raw Materials`, or `Inventory Raw Materials` when the
+ * account has no code. The one string form of an account, for tooltips,
+ * `title` attributes, dialog titles, confirm copy, option labels and search
+ * indexes. Never a bare code: a code alone identifies nothing to a reader who
+ * did not number the chart.
+ */
+export function formatAccountLabel(account: LabelAccount | null | undefined): string {
+  if (!account) return ''
+  const code = account.code?.trim()
+  return code ? `${code} · ${account.name}` : account.name
+}
+
+/**
+ * The shortest token that still names the account: the code when there is one
+ * (four characters, which is what a chip or a badge has room for), else the
+ * name. The caller pairs it with {@link formatAccountLabel} in a tooltip.
+ */
+export function accountChipText(account: LabelAccount): string {
+  return account.code?.trim() || account.name
+}
+
+/** Case-insensitive match over code and name, null-safe on the code. */
+export function accountMatchesSearch(account: LabelAccount, search: string): boolean {
+  const needle = search.trim().toLowerCase()
+  if (!needle) return true
+  return (
+    account.name.toLowerCase().includes(needle) ||
+    (account.code?.toLowerCase().includes(needle) ?? false)
+  )
+}

--- a/apps/web/src/components/accounting/ui/account-label.tsx
+++ b/apps/web/src/components/accounting/ui/account-label.tsx
@@ -1,0 +1,112 @@
+// apps/web/src/components/accounting/ui/account-label.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  accountChipText,
+  accountMatchesSearch,
+  formatAccountLabel,
+  type LabelAccount,
+} from './account-label-format'
+import { useChartAccounts } from './use-chart-accounts'
+
+export { accountChipText, accountMatchesSearch, formatAccountLabel, type LabelAccount }
+
+/**
+ * Resolve one chart account by id against the one `ledger.chartAccounts`
+ * fetch every picker on the screen shares. Null while the chart is loading
+ * and for an id the chart no longer holds.
+ */
+export function useChartAccount(glAccountId: string | null | undefined) {
+  const { accounts, isLoading } = useChartAccounts()
+  const account = glAccountId ? (accounts.find((row) => row.id === glAccountId) ?? null) : null
+  return { account, isLoading }
+}
+
+export type AccountLabelDensity = 'full' | 'compact' | 'chip'
+
+interface AccountLabelProps {
+  /** The account itself, when the caller already holds it. Skips the lookup. */
+  account?: LabelAccount | null
+  /** Resolved against the shared chart fetch when `account` is not given. */
+  glAccountId?: string | null
+  /**
+   * `full`: muted code, then the name. Tables, tree rows, anywhere with a
+   * column to itself.
+   *
+   * `compact`: the name alone, with the code in the tooltip. Secondary lines
+   * at `text-xs`, picker triggers inside a `FieldPanelRow`, and any slot where
+   * a code that survives while the name is clipped to `Inventory Ra…` is
+   * worse than no code at all.
+   *
+   * `chip`: {@link accountChipText}, clamped, for a badge or a 10px chip. The
+   * caller supplies the chrome.
+   */
+  density?: AccountLabelDensity
+  /** Rendered when nothing resolves. Defaults to the raw id, then nothing. */
+  fallback?: string
+  className?: string
+}
+
+/**
+ * A GL account as an inline label. Every screen that names an account renders
+ * through this so the layout decision - which part yields when the row is
+ * narrow - is made once.
+ *
+ * In every density the name is the part that keeps the room. The code is a
+ * hint: four characters that sort a chart and that a bookkeeper who numbered
+ * it recognises, but not what identifies the account to anyone else. The full
+ * `code · name` always sits in `title`, so hovering answers what a clamp hid.
+ *
+ * @example
+ * <AccountLabel account={line} />                             // 1310 · Inventory Raw Materials
+ * <AccountLabel glAccountId={rule.glAccountId} density='compact' />
+ * <Badge variant='outline' size='xs'><AccountLabel account={mapped} density='chip' /></Badge>
+ */
+export function AccountLabel({
+  account,
+  glAccountId,
+  density = 'full',
+  fallback,
+  className,
+}: AccountLabelProps) {
+  const resolved = useChartAccount(account ? null : glAccountId)
+  const target = account ?? resolved.account
+
+  if (!target) {
+    const text = fallback ?? glAccountId ?? ''
+    if (!text) return null
+    return <span className={cn('truncate', className)}>{text}</span>
+  }
+
+  const full = formatAccountLabel(target)
+  const code = target.code?.trim() || null
+
+  if (density === 'chip') {
+    return (
+      <span className={cn('inline-block max-w-24 truncate align-bottom', className)} title={full}>
+        {accountChipText(target)}
+      </span>
+    )
+  }
+
+  if (density === 'compact') {
+    return (
+      <span className={cn('truncate', className)} title={full}>
+        {target.name}
+      </span>
+    )
+  }
+
+  return (
+    <span className={cn('flex min-w-0 items-baseline gap-1.5', className)} title={full}>
+      {code && (
+        <span className='shrink-0 font-mono text-muted-foreground text-xs tabular-nums'>
+          {code}
+        </span>
+      )}
+      <span className='truncate'>{target.name}</span>
+    </span>
+  )
+}

--- a/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
@@ -58,8 +58,8 @@ import { useViewportFill } from '~/hooks/use-viewport-fill'
 import { useAccess, useRequireCapability } from '~/providers/capabilities-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
+import { AccountLabel } from '../account-label'
 import { BankAccountBadge } from '../bank-account-badge'
-import { useChartAccounts } from '../gl-account-picker'
 import { EMPTY_CELL, formatMinor } from '../ledger/format'
 import { ReviewBulkBar } from './review/review-bulk-bar'
 import { ReviewDrawer } from './review/review-drawer'
@@ -200,13 +200,8 @@ export function BankingReviewQueuePage() {
   )
 
   // `glAccountId`/`suggestedGlAccountId` on a row are `gl_account` ids (task 15
-  // §4), never codes - resolved once here against the one chart fetch, never
-  // per row.
-  const { accounts: chartAccounts } = useChartAccounts()
-  const chartAccountById = useMemo(
-    () => new Map(chartAccounts.map((chartAccount) => [chartAccount.id, chartAccount])),
-    [chartAccounts]
-  )
+  // §4), never codes - rendered through `AccountLabel`, which resolves each one
+  // against the one chart fetch every picker on this page shares.
 
   /**
    * A bookmarked `?account=` for an account that has since been archived or
@@ -523,14 +518,13 @@ export function BankingReviewQueuePage() {
                         )}
                         {row.suggestedGlAccountId && row.reviewStatus !== 'coded' && (
                           <Badge variant='blue' size='xs'>
-                            Code:{' '}
-                            {chartAccountById.get(row.suggestedGlAccountId)?.code ??
-                              row.suggestedGlAccountId}
+                            Suggested{' '}
+                            <AccountLabel glAccountId={row.suggestedGlAccountId} density='chip' />
                           </Badge>
                         )}
                         {row.glAccountId && (
                           <Badge variant='outline' size='xs' className='font-mono'>
-                            {chartAccountById.get(row.glAccountId)?.code ?? row.glAccountId}
+                            <AccountLabel glAccountId={row.glAccountId} density='chip' />
                           </Badge>
                         )}
                         <span className='flex items-center gap-1 text-muted-foreground text-xs'>

--- a/apps/web/src/components/accounting/ui/banking/review/analyze-panel.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/analyze-panel.tsx
@@ -22,6 +22,7 @@ import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapte
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
 import { api } from '~/trpc/react'
+import { formatAccountLabel } from '../../account-label'
 import { useChartAccounts } from '../../gl-account-picker'
 import { EMPTY_CELL, formatSignedMinor } from '../../ledger/format'
 import { BankRuleDialog } from '../rules/bank-rule-dialog'
@@ -104,7 +105,7 @@ export function AnalyzePanel({ line, currencyCode }: AnalyzePanelProps) {
 
   const accountLabel = (glAccountId: string) => {
     const account = accounts.find((item) => item.id === glAccountId)
-    return account ? `${account.code} ${account.name}` : glAccountId
+    return account ? formatAccountLabel(account) : glAccountId
   }
 
   const searchFor = (value: string, field: BankRuleMatchField) => {

--- a/apps/web/src/components/accounting/ui/banking/review/code-panel.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/code-panel.tsx
@@ -14,6 +14,7 @@ import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapte
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
 import { api } from '~/trpc/react'
+import { formatAccountLabel } from '../../account-label'
 import { GlAccountPicker, useChartAccounts } from '../../gl-account-picker'
 import { EntryBlockers, type LedgerBlocker } from '../../ledger/entry-blockers'
 import { EntryJournal } from '../../ledger/entry-journal'
@@ -169,7 +170,8 @@ export function CodePanel({ line, currencyCode, onDone }: CodePanelProps) {
                 className='flex w-fit items-center gap-1.5 text-muted-foreground text-xs hover:text-foreground'
                 onClick={() => setAccountId(line.suggestedGlAccountId)}>
                 <Lightbulb className='size-3' />
-                Use the suggestion{suggestedAccount ? `, ${suggestedAccount.code}` : ''}
+                Use the suggestion
+                {suggestedAccount ? `, ${formatAccountLabel(suggestedAccount)}` : ''}
               </button>
             )}
             {canCreateRule && (

--- a/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
@@ -20,6 +20,7 @@ import { Ban, Landmark, Undo2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import DrawerComments from '~/components/global/comments/drawer-comments'
 import { api } from '~/trpc/react'
+import { formatAccountLabel } from '../../account-label'
 import { BankAccountBadge } from '../../bank-account-badge'
 import { useChartAccounts } from '../../gl-account-picker'
 import { EntryBlockers, type LedgerBlocker } from '../../ledger/entry-blockers'
@@ -252,7 +253,7 @@ export function ReviewDrawer({
                         </span>
                         <span className='truncate text-muted-foreground text-xs'>
                           {line.reviewStatus === 'coded'
-                            ? `Coded to ${codedAccount ? `${codedAccount.code} ${codedAccount.name}` : (line.glAccountId ?? '')}`
+                            ? `Coded to ${codedAccount ? formatAccountLabel(codedAccount) : (line.glAccountId ?? '')}`
                             : line.reviewStatus === 'excluded'
                               ? (line.excludeReason ?? '')
                               : matchedLabel(line)}

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-dialog.tsx
@@ -120,8 +120,7 @@ export function BankRuleDialog({ open, onClose, rule, seed }: BankRuleDialogProp
   const actionLabel = describeActionDetail({
     action,
     glAccountId,
-    glAccountCode: selectedGlAccount?.code,
-    glAccountName: selectedGlAccount?.name,
+    glAccount: selectedGlAccount,
     counterpartName: counterpart ? bankAccountLabel(counterpart) : undefined,
   })
 

--- a/apps/web/src/components/accounting/ui/banking/rules/bank-rule-options.ts
+++ b/apps/web/src/components/accounting/ui/banking/rules/bank-rule-options.ts
@@ -19,6 +19,7 @@ import type {
   BankRuleRecord,
 } from '@auxx/lib/banking/rules/client'
 import type { SelectOption } from '@auxx/types/custom-field'
+import { formatAccountLabel, type LabelAccount } from '../../account-label-format'
 
 /** Flush-in-a-FieldPanelRow trigger sizing, the same one the rule editors share. */
 export const TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' } as const
@@ -78,7 +79,7 @@ export function describeRuleAction(
   rule: Pick<BankRuleRecord, 'action' | 'glAccountId' | 'counterpartBankAccountId'>,
   resolveAccountName: (id: string) => string | undefined,
   /** `rule.glAccountId` (task 15 §4) resolved against the chart, for display. */
-  resolveGlAccountCode: (id: string) => string | undefined
+  resolveGlAccountLabel: (id: string) => string | undefined
 ): string {
   if (rule.action === 'exclude') return 'Exclude'
   if (rule.action === 'transfer') {
@@ -88,7 +89,7 @@ export function describeRuleAction(
     return name ? `Transfer to ${name}` : 'Transfer'
   }
   if (!rule.glAccountId) return 'Code'
-  return `Code ${resolveGlAccountCode(rule.glAccountId) ?? rule.glAccountId}`
+  return `Code ${resolveGlAccountLabel(rule.glAccountId) ?? rule.glAccountId}`
 }
 
 /**
@@ -99,8 +100,7 @@ export function describeActionDetail(input: {
   action: BankRuleAction
   /** The `gl_account` id a `code` action proposes (task 15 §4). Never a code. */
   glAccountId: string
-  glAccountCode?: string
-  glAccountName?: string
+  glAccount?: LabelAccount | null
   counterpartName?: string
 }): string {
   if (input.action === 'exclude') return 'Exclude'
@@ -108,8 +108,8 @@ export function describeActionDetail(input: {
     return input.counterpartName ? `Transfer to ${input.counterpartName}` : 'Transfer'
   }
   if (!input.glAccountId) return 'Code to an account'
-  const label = input.glAccountCode ?? input.glAccountId
-  return input.glAccountName ? `Code to ${label} · ${input.glAccountName}` : `Code to ${label}`
+  const label = input.glAccount ? formatAccountLabel(input.glAccount) : input.glAccountId
+  return `Code to ${label}`
 }
 
 /**
@@ -119,7 +119,7 @@ export function describeActionDetail(input: {
 export function describeRule(
   rule: BankRuleRecord,
   resolveAccountName: (id: string) => string | undefined,
-  resolveGlAccountCode: (id: string) => string | undefined
+  resolveGlAccountLabel: (id: string) => string | undefined
 ): string {
   const parts = [
     `${MATCH_FIELD_LABELS[rule.matchField]} ${MATCH_OPERATOR_LABELS[rule.matchOperator]} "${rule.matchValue}"`,
@@ -129,6 +129,6 @@ export function describeRule(
     const name = resolveAccountName(rule.bankAccountId)
     if (name) parts.push(name)
   }
-  parts.push(describeRuleAction(rule, resolveAccountName, resolveGlAccountCode))
+  parts.push(describeRuleAction(rule, resolveAccountName, resolveGlAccountLabel))
   return parts.join(' · ')
 }

--- a/apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx
@@ -51,6 +51,7 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { useViewportFill } from '~/hooks/use-viewport-fill'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
+import { formatAccountLabel } from '../../account-label'
 import { useChartAccounts } from '../../gl-account-picker'
 import { BankRuleDialog } from './bank-rule-dialog'
 import { describeRule } from './bank-rule-options'
@@ -94,8 +95,11 @@ export function BankingRulesPage() {
   // `rule.glAccountId` is the `gl_account` id (task 15 §4), never a code -
   // resolved once here against the one chart fetch every picker shares.
   const { accounts: chartAccounts } = useChartAccounts()
-  const resolveGlAccountCode = useCallback(
-    (id: string) => chartAccounts.find((account) => account.id === id)?.code ?? undefined,
+  const resolveGlAccountLabel = useCallback(
+    (id: string) => {
+      const account = chartAccounts.find((candidate) => candidate.id === id)
+      return account ? formatAccountLabel(account) : undefined
+    },
     [chartAccounts]
   )
 
@@ -182,7 +186,7 @@ export function BankingRulesPage() {
                       secondary={
                         <span className='flex flex-wrap items-center gap-1.5'>
                           <span className='text-muted-foreground text-xs'>
-                            {describeRule(rule, resolveAccountName, resolveGlAccountCode)}
+                            {describeRule(rule, resolveAccountName, resolveGlAccountLabel)}
                           </span>
                           {rule.autoApply && (
                             <Badge variant='amber' size='xs'>

--- a/apps/web/src/components/accounting/ui/gl-account-picker.tsx
+++ b/apps/web/src/components/accounting/ui/gl-account-picker.tsx
@@ -18,28 +18,16 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { useMemo, useState } from 'react'
+import { AccountLabel } from '~/components/accounting/ui/account-label'
+import {
+  accountMatchesSearch,
+  formatAccountLabel,
+} from '~/components/accounting/ui/account-label-format'
 import { accountTypeLabel } from '~/components/accounting/ui/settings/accounts-types'
 import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
-import { api } from '~/trpc/react'
+import { useChartAccounts } from './use-chart-accounts'
 
-/**
- * Reads the org's chart of accounts through `ledger.chartAccounts`.
- *
- * ⚠️ `listChartAccounts` (the lib read behind this procedure) filters
- * `archivedAt IS NULL` server-side, so an archived `gl_account` never reaches
- * this hook at all: there is no per-row flag to check for it. The only
- * "disabled for a reason" case this data can express is `isActive: false`
- * (deactivated but not archived), which is what {@link GlAccountPicker}
- * renders disabled below.
- */
-export function useChartAccounts() {
-  const query = api.ledger.chartAccounts.useQuery()
-  return {
-    accounts: (query.data ?? []) as ChartAccountRow[],
-    isLoading: query.isLoading,
-    isError: query.isError,
-  }
-}
+export { useChartAccounts }
 
 export interface GlAccountPickerProps {
   /** The selected account's CODE or id, depending on {@link selectBy}. */
@@ -70,7 +58,8 @@ export interface GlAccountPickerProps {
  * A single-select combobox over the org's chart of accounts
  * (`ledger.chartAccounts`), grouped by statement classification in the
  * standard order ({@link GL_ACCOUNT_TYPES}: asset, liability, equity,
- * revenue, expense). Option label is `code · name`. Value in and out is the
+ * revenue, expense). The option label comes from `formatAccountLabel` and
+ * reads name-only when the account has no code. Value in and out is the
  * account CODE by default - what `resolveRoles` and the manual entry builder
  * take (decision `P2`: a posting line names an account by code with no
  * foreign key) - or the account ID when `selectBy="id"` is passed, for the
@@ -145,14 +134,7 @@ export function GlAccountPicker({
           }}
           asCombobox
           className={cn('h-auto min-h-8 w-full ps-0 pe-1', className, triggerProps?.className)}>
-          {selected && (
-            <span className='flex min-w-0 items-center gap-1.5 truncate text-sm'>
-              <span className='shrink-0 font-mono text-muted-foreground text-xs'>
-                {selected.code}
-              </span>
-              <span className='truncate'>{selected.name}</span>
-            </span>
-          )}
+          {selected && <AccountLabel account={selected} className='text-sm' />}
         </PickerTrigger>
       </PopoverTrigger>
       <PopoverContent
@@ -175,7 +157,7 @@ export function GlAccountPicker({
                     <CommandDetailItem
                       key={account.id}
                       value={account.id}
-                      title={`${account.code} · ${account.name}`}
+                      title={formatAccountLabel(account)}
                       description={
                         account.isActive
                           ? undefined
@@ -222,16 +204,13 @@ export function groupAccountsByType(
   search: string
 ): AccountGroup[] {
   const allowed = filterTypes ? new Set(filterTypes) : null
-  const needle = search.trim().toLowerCase()
-  const matches = (account: ChartAccountRow) =>
-    !needle ||
-    account.code.toLowerCase().includes(needle) ||
-    account.name.toLowerCase().includes(needle)
 
   return GL_ACCOUNT_TYPES.filter((type) => !allowed || allowed.has(type))
     .map((type) => ({
       type,
-      accounts: accounts.filter((account) => account.accountType === type && matches(account)),
+      accounts: accounts.filter(
+        (account) => account.accountType === type && accountMatchesSearch(account, search)
+      ),
     }))
     .filter((group) => group.accounts.length > 0)
 }

--- a/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from '@auxx/ui/lib/utils'
 import { CheckCircle2, Search, TriangleAlert } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
+import { AccountLabel, formatAccountLabel } from '../account-label'
 import { formatMinor } from './format'
 
 interface EntryJournalProps {
@@ -66,19 +67,18 @@ export function EntryJournal({ lines, currencyCode, onDrillDown }: EntryJournalP
         </TableHeader>
         <TableBody>
           {[...debits, ...credits].map((line) => (
-            <TableRow key={`${line.direction}-${line.accountCode}-${line.sortOrder}`}>
+            <TableRow key={`${line.direction}-${line.glAccountId}-${line.sortOrder}`}>
               <TableCell className={cn('align-top', line.direction === 'credit' && 'ps-8')}>
                 <div className='flex items-center gap-2'>
-                  <span className='font-mono text-xs text-muted-foreground'>
-                    {line.accountCode}
-                  </span>
-                  <span>{line.accountName ?? line.accountCode}</span>
+                  <AccountLabel
+                    account={{ code: line.accountCode, name: line.accountName ?? '' }}
+                  />
                   {onDrillDown && (
                     <Tooltip content='What is behind this number'>
                       <Button
                         variant='ghost'
                         size='icon-xs'
-                        aria-label={`What is behind account ${line.accountCode}`}
+                        aria-label={`What is behind account ${formatAccountLabel({ code: line.accountCode, name: line.accountName ?? '' })}`}
                         onClick={() => onDrillDown(line.accountCode, line.accountName)}>
                         <Search />
                       </Button>

--- a/apps/web/src/components/accounting/ui/ledger/entry-roll-forward.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-roll-forward.tsx
@@ -15,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from '@auxx/ui/components/table'
+import { AccountLabel } from '../account-label'
 import { EMPTY_CELL, formatMinor, formatSignedMinor } from './format'
 
 /** The three balances a `month_end_inventory` snapshot asserts, in statement order. */
@@ -34,8 +35,8 @@ const ACTIVITY_ROWS = [
 interface EntryRollForwardProps {
   assertions: PostingAssertions
   currencyCode: string
-  /** Account code per role, from the org's own chart. Optional: labels stand alone. */
-  accountCodeByRole?: Partial<Record<AccountRole, string>>
+  /** Account per role, from the org's own chart. Optional: labels stand alone. */
+  accountByRole?: Partial<Record<AccountRole, { code: string | null; name: string }>>
 }
 
 /**
@@ -59,7 +60,7 @@ interface EntryRollForwardProps {
 export function EntryRollForward({
   assertions,
   currencyCode,
-  accountCodeByRole,
+  accountByRole,
 }: EntryRollForwardProps) {
   const { before, after } = assertions
 
@@ -78,14 +79,12 @@ export function EntryRollForward({
           {BALANCE_ROLES.map((role) => {
             const opening = before.balances[role]
             const closing = after.balances[role]
-            const code = accountCodeByRole?.[role]
+            const account = accountByRole?.[role]
             return (
               <TableRow key={role}>
                 <TableCell>
                   <div className='flex items-center gap-2'>
-                    {code && (
-                      <span className='font-mono text-xs text-muted-foreground'>{code}</span>
-                    )}
+                    {account && <AccountLabel account={account} />}
                     <span>{ACCOUNT_ROLE_LABELS[role]}</span>
                   </div>
                 </TableCell>

--- a/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
@@ -170,9 +170,10 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
   })
   const roleMapQuery = api.ledger.roleMap.useQuery()
 
-  const accountCodeByRole: Partial<Record<AccountRole, string>> = {}
+  const accountByRole: Partial<Record<AccountRole, { code: string | null; name: string }>> = {}
   for (const row of roleMapQuery.data ?? []) {
-    if (row.account) accountCodeByRole[row.role as AccountRole] = row.account.code
+    if (row.account)
+      accountByRole[row.role as AccountRole] = { code: row.account.code, name: row.account.name }
   }
 
   const revisionEntries = [postedDetail, reversedQuery.data]
@@ -587,7 +588,7 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
                   <EntryRollForward
                     assertions={assertions}
                     currencyCode={currencyCode}
-                    accountCodeByRole={accountCodeByRole}
+                    accountByRole={accountByRole}
                   />
                 </Section>
               )}

--- a/apps/web/src/components/accounting/ui/ledger/line-drill-down.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/line-drill-down.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from '@auxx/ui/components/table'
 import { FileSearch } from 'lucide-react'
+import { formatAccountLabel } from '../account-label'
 import { formatAccountingDate, formatMinor, formatSignedMinor } from './format'
 
 export interface LineDrillDownTarget {
@@ -87,7 +88,8 @@ export function LineDrillDown({
       <DialogContent size='xl'>
         <DialogHeader>
           <DialogTitle>
-            {target?.accountCode} {target?.accountName ?? ''}
+            {target &&
+              formatAccountLabel({ code: target.accountCode, name: target.accountName ?? '' })}
           </DialogTitle>
           <DialogDescription>
             The subledger rows behind this line for {periodLabel}. The posting line itself records

--- a/apps/web/src/components/accounting/ui/reports/account-lines-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/reports/account-lines-dialog.tsx
@@ -22,6 +22,7 @@ import {
 import { FileSearch } from 'lucide-react'
 import Link from 'next/link'
 import { api } from '~/trpc/react'
+import { formatAccountLabel } from '../account-label'
 import { formatAccountingDate, formatMinor, formatSignedMinor } from '../ledger/format'
 import { periodKeyFromDate } from './report-helpers'
 
@@ -66,7 +67,9 @@ export function AccountLinesDialog({
     <Dialog open={!!target} onOpenChange={onOpenChange}>
       <DialogContent size='xl'>
         <DialogHeader>
-          <DialogTitle>{data ? `${data.accountCode} ${data.accountName}`.trim() : ''}</DialogTitle>
+          <DialogTitle>
+            {data ? formatAccountLabel({ code: data.accountCode, name: data.accountName }) : ''}
+          </DialogTitle>
           <DialogDescription>
             Every posted line against this account in the range, oldest first, with a running
             balance.

--- a/apps/web/src/components/accounting/ui/reports/report-helpers.ts
+++ b/apps/web/src/components/accounting/ui/reports/report-helpers.ts
@@ -168,6 +168,7 @@ export function toStatementTableRows(rows: readonly LibStatementRow[]): Statemen
       ? {
           glAccountId: row.meta.glAccountId,
           accountCode: row.meta.accountCode,
+          accountName: row.meta.accountName,
           recordId:
             row.meta.recordId && isRecordId(row.meta.recordId) ? row.meta.recordId : undefined,
           badge: row.meta.badge,

--- a/apps/web/src/components/accounting/ui/reports/statement-table.tsx
+++ b/apps/web/src/components/accounting/ui/reports/statement-table.tsx
@@ -18,6 +18,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { CheckCircle2, ChevronRight, TriangleAlert } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
+import { AccountLabel } from '../account-label'
 import { EMPTY_CELL, formatMinor, formatSignedMinor } from '../ledger/format'
 
 /**
@@ -40,6 +41,7 @@ export interface StatementRow {
     /** The `gl_account` `EntityInstance` id (task 15) - the drill-down key. `accountCode` is display only. */
     glAccountId?: string
     accountCode?: string
+    accountName?: string
     recordId?: RecordId
     badge?: ReactNode
     note?: string
@@ -272,7 +274,14 @@ function RowLabel({
       ) : (
         <span className='size-4 shrink-0' />
       )}
-      <span className='min-w-0 truncate'>{row.label}</span>
+      {row.meta?.accountName ? (
+        <AccountLabel
+          account={{ code: row.meta.accountCode ?? null, name: row.meta.accountName }}
+          className='min-w-0'
+        />
+      ) : (
+        <span className='min-w-0 truncate'>{row.label}</span>
+      )}
       {row.meta?.badge}
       {row.meta?.note && <TooltipExplanation text={row.meta.note} />}
     </div>

--- a/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
@@ -58,6 +58,8 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Check, Landmark, Link2, Sparkles, TriangleAlert, X } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '~/trpc/react'
+import { AccountLabel } from '../account-label'
+import { accountMatchesSearch } from '../account-label-format'
 import {
   ACCOUNT_SUGGESTION_REASON_COPY,
   accountTypeColor,
@@ -153,12 +155,7 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
 
   const visible = (
     compact ? rows.filter((row) => row.state !== 'confirmed' || isMappingBroken(row)) : rows
-  ).filter(
-    (row) =>
-      !search ||
-      row.account.name.toLowerCase().includes(search.toLowerCase()) ||
-      row.account.code.includes(search)
-  )
+  ).filter((row) => accountMatchesSearch(row.account, search))
 
   return (
     <div className='flex flex-col gap-3 p-3'>
@@ -230,14 +227,7 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
               <TreeRow
                 key={row.account.id}
                 icon={<Landmark className='size-4 text-muted-foreground' />}
-                title={
-                  <span className='flex items-baseline gap-2'>
-                    <span className='text-muted-foreground text-xs tabular-nums'>
-                      {row.account.code}
-                    </span>
-                    <span className='text-sm'>{row.account.name}</span>
-                  </span>
-                }
+                title={<AccountLabel account={row.account} className='text-sm' />}
                 secondaryFill
                 rowClassName={cn(
                   'bg-primary-100/50 hover:bg-primary-100',

--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -56,6 +56,7 @@ import { useAccess, useRequireCapability } from '~/providers/capabilities-provid
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
+import { formatAccountLabel } from '../account-label-format'
 import type { ChartDraftHandle, ChartMapView } from './accounts-types'
 import { ChartAccountEditor } from './chart-account-editor'
 import { ChartList } from './chart-list'
@@ -313,7 +314,7 @@ export function AccountingAccountsSettingsPage() {
       const account = accounts.find((row) => row.id === id)
       const confirmed = await confirm({
         title: 'Remove account?',
-        description: `${account ? `${account.code} ${account.name} ` : 'This account '}comes out of the chart. Entries already posted keep the code and the name they were written with, and a re-seed will not bring it back.`,
+        description: `${account ? `${formatAccountLabel(account)} ` : 'This account '}comes out of the chart. Entries already posted keep the code and the name they were written with, and a re-seed will not bring it back.`,
         confirmText: 'Remove',
         cancelText: 'Cancel',
         destructive: true,

--- a/apps/web/src/components/accounting/ui/settings/accounts-types.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounts-types.ts
@@ -19,6 +19,7 @@ import type {
   ProviderAccount,
 } from '@auxx/lib/postings/client'
 import type { SelectOptionColor } from '@auxx/types/custom-field'
+import { formatAccountLabel } from '../account-label-format'
 
 /**
  * The five statement classifications.
@@ -144,10 +145,13 @@ export function isMappingBroken(row: AccountIdentityRow): boolean {
  */
 export const DEFAULT_UNUSED_ROLES: AccountRole[] = ['ppv', 'inventory_wip']
 
-/** `1310 · Inventory Raw Materials`, the way an account reads in a row. */
+/**
+ * `1310 · Inventory Raw Materials`, the way an account reads in a row, or the
+ * name alone when the account has no code. Delegates to `formatAccountLabel`
+ * in `../account-label.tsx`, the one string form every screen shares.
+ */
 export function formatAccount(account: ChartAccountRow | null | undefined): string {
-  if (!account) return ''
-  return `${account.code} · ${account.name}`
+  return formatAccountLabel(account)
 }
 
 /**

--- a/apps/web/src/components/accounting/ui/settings/bank-accounts-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-accounts-list.tsx
@@ -40,6 +40,7 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
+import { AccountLabel } from '~/components/accounting/ui/account-label'
 import { BankInstitutionIcon } from '~/components/accounting/ui/bank-institution-icon'
 import { useChartAccounts } from '~/components/accounting/ui/gl-account-picker'
 import { asConnectorStatus } from '~/components/data-connectors/ui/connector-status'
@@ -330,7 +331,7 @@ export function BankAccountsList({
                           if (mapped) {
                             return (
                               <Badge variant='outline' size='xs' className='font-mono'>
-                                {mapped.code}
+                                <AccountLabel account={mapped} density='chip' />
                               </Badge>
                             )
                           }

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -38,6 +38,8 @@ import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row
 import { cn } from '@auxx/ui/lib/utils'
 import { Landmark, Plus, Sparkles, TriangleAlert } from 'lucide-react'
 import { useState } from 'react'
+import { AccountLabel } from '../account-label'
+import { accountMatchesSearch } from '../account-label-format'
 import {
   accountTypeColor,
   accountTypeLabel,
@@ -90,10 +92,7 @@ export function ChartList({
   ).length
 
   const filtered = search
-    ? accounts.filter(
-        (account) =>
-          account.name.toLowerCase().includes(search.toLowerCase()) || account.code.includes(search)
-      )
+    ? accounts.filter((account) => accountMatchesSearch(account, search))
     : accounts
 
   // Hidden once `recordId` is stamped: the real row arrived with the invalidated
@@ -193,12 +192,10 @@ export function ChartList({
               key={phantom.draftId}
               icon={<Landmark className='size-4 text-muted-foreground' />}
               title={
-                <span className='flex items-baseline gap-2'>
-                  <span className='text-muted-foreground text-xs tabular-nums'>
-                    {phantom.code || '—'}
-                  </span>
-                  <span className='text-sm'>{phantom.name || 'New account'}</span>
-                </span>
+                <AccountLabel
+                  account={{ code: phantom.code || null, name: phantom.name || 'New account' }}
+                  className='text-sm'
+                />
               }
               secondaryFill
               onToggleOpen={() => onSelect(phantom.draftId)}
@@ -219,14 +216,7 @@ export function ChartList({
               <TreeRow
                 key={account.id}
                 icon={<Landmark className='size-4 text-muted-foreground' />}
-                title={
-                  <span className='flex items-baseline gap-2'>
-                    <span className='text-muted-foreground text-xs tabular-nums'>
-                      {account.code}
-                    </span>
-                    <span className='text-sm'>{account.name}</span>
-                  </span>
-                }
+                title={<AccountLabel account={account} className='text-sm' />}
                 secondaryFill
                 onToggleOpen={() => onSelect(account.id)}
                 rowClassName={cn(

--- a/apps/web/src/components/accounting/ui/settings/opening-tb-grid.tsx
+++ b/apps/web/src/components/accounting/ui/settings/opening-tb-grid.tsx
@@ -22,6 +22,7 @@
 
 import type { GlAccountTypeValue, OpeningTrialBalanceRow } from '@auxx/lib/postings/client'
 import { GL_ACCOUNT_TYPES } from '@auxx/lib/postings/client'
+import { formatAccountLabel } from '../account-label-format'
 import { formatMinor } from '../ledger/format'
 import type { StatementColumn, StatementRow } from '../reports/statement-table'
 import { StatementTable } from '../reports/statement-table'
@@ -250,7 +251,7 @@ function toStatementRows(
       sectionCredit += row.creditMinor ?? 0
       out.push({
         id: `${ACCOUNT_ROW_PREFIX}${row.accountCode}`,
-        label: `${row.accountCode} ${row.accountName}`,
+        label: formatAccountLabel({ code: row.accountCode, name: row.accountName }),
         depth: 1,
         // 🛑 `computed`, not `line`, is what makes a locked row read-only:
         // `StatementTable`'s edit mode puts a `CurrencyInput` in a `line` and

--- a/apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
@@ -33,6 +33,8 @@ import { Ban, Check, RotateCcw, Sparkles } from 'lucide-react'
 import { useState } from 'react'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
+import { AccountLabel } from '../account-label'
+import { accountMatchesSearch } from '../account-label-format'
 import { accountTypeLabel, DEFAULT_UNUSED_ROLES, formatAccount } from './accounts-types'
 
 interface RoleMapEditorProps {
@@ -77,10 +79,7 @@ export function RoleMapEditor({
 
   const eligible = accounts.filter((account) => account.accountType === expectedType)
   const filtered = search
-    ? eligible.filter(
-        (account) =>
-          account.name.toLowerCase().includes(search.toLowerCase()) || account.code.includes(search)
-      )
+    ? eligible.filter((account) => accountMatchesSearch(account, search))
     : eligible
 
   const isDefaultUnused = DEFAULT_UNUSED_ROLES.includes(role)
@@ -232,10 +231,7 @@ export function RoleMapEditor({
                       'hover:bg-primary-100 disabled:opacity-60',
                       currentId === account.id && 'bg-primary-100 ring-1 ring-primary-200'
                     )}>
-                    <span className='w-14 shrink-0 text-muted-foreground tabular-nums'>
-                      {account.code}
-                    </span>
-                    <span className='min-w-0 flex-1 truncate'>{account.name}</span>
+                    <AccountLabel account={account} className='min-w-0 flex-1' />
                     {!account.isActive && (
                       <Badge variant='outline' size='xs' className='shrink-0'>
                         Inactive

--- a/apps/web/src/components/accounting/ui/settings/role-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/role-map-list.tsx
@@ -39,7 +39,8 @@ import { EmptySection, Section } from '@auxx/ui/components/section'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { Ban, Coins, CreditCard, Pencil, Receipt, RotateCcw, Sparkles } from 'lucide-react'
-import { ACCOUNT_TYPE_OPTIONS, formatAccount } from './accounts-types'
+import { AccountLabel } from '../account-label'
+import { ACCOUNT_TYPE_OPTIONS } from './accounts-types'
 
 /** Statement-section icon, one per group. */
 const GROUP_ICONS: Record<string, typeof Coins> = {
@@ -241,14 +242,20 @@ function AssignmentSecondary({ row }: { row: RoleAssignmentRow }) {
           <Sparkles className='size-3' />
           Suggested
         </Badge>
-        <span className='truncate text-amber-700 dark:text-amber-400'>
-          {formatAccount(row.account)}
-        </span>
+        <AccountLabel
+          account={row.account}
+          density='compact'
+          className='text-amber-700 dark:text-amber-400'
+        />
       </span>
     )
   }
 
   return (
-    <span className='truncate text-muted-foreground text-xs'>{formatAccount(row.account)}</span>
+    <AccountLabel
+      account={row.account}
+      density='compact'
+      className='text-muted-foreground text-xs'
+    />
   )
 }

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
@@ -12,7 +12,7 @@ import { EmptySection } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
 import { ArrowUpRight } from 'lucide-react'
 import Link from 'next/link'
-import { formatAccount } from '~/components/accounting/ui/settings/accounts-types'
+import { AccountLabel } from '~/components/accounting/ui/account-label'
 import { api } from '~/trpc/react'
 
 const ROLES_HREF = '/app/accounting/settings/accounts?s=roles'
@@ -163,8 +163,13 @@ export function WizardAccountsPage() {
                   <span className='min-w-0 flex-1 truncate'>
                     {ACCOUNT_ROLE_LABELS[row.role as AccountRole] ?? row.role}
                   </span>
-                  <span className='hidden min-w-0 flex-1 truncate text-muted-foreground sm:block'>
-                    {formatAccount(row.account) || '-'}
+                  <span className='hidden min-w-0 flex-1 sm:block'>
+                    <AccountLabel
+                      account={row.account}
+                      density='compact'
+                      fallback='-'
+                      className='text-muted-foreground'
+                    />
                   </span>
                   <Badge variant={STATE_BADGE[row.state].variant} size='sm' className='shrink-0'>
                     {STATE_BADGE[row.state].label}

--- a/apps/web/src/components/accounting/ui/use-chart-accounts.ts
+++ b/apps/web/src/components/accounting/ui/use-chart-accounts.ts
@@ -1,0 +1,30 @@
+// apps/web/src/components/accounting/ui/use-chart-accounts.ts
+
+'use client'
+
+import type { ChartAccountRow } from '@auxx/lib/postings/client'
+import { api } from '~/trpc/react'
+
+/**
+ * Reads the org's chart of accounts through `ledger.chartAccounts`.
+ *
+ * Lives on its own so `account-label.tsx` and `gl-account-picker.tsx` can
+ * both read it without importing each other. The picker re-exports it, so
+ * every existing `import { useChartAccounts } from '../gl-account-picker'`
+ * keeps working.
+ *
+ * `listChartAccounts` (the lib read behind this procedure) filters
+ * `archivedAt IS NULL` server-side, so an archived `gl_account` never reaches
+ * this hook at all: there is no per-row flag to check for it. The only
+ * "disabled for a reason" case this data can express is `isActive: false`
+ * (deactivated but not archived), which is what `GlAccountPicker` renders
+ * disabled.
+ */
+export function useChartAccounts() {
+  const query = api.ledger.chartAccounts.useQuery()
+  return {
+    accounts: (query.data ?? []) as ChartAccountRow[],
+    isLoading: query.isLoading,
+    isError: query.isError,
+  }
+}

--- a/apps/web/src/components/manufacturing/ui/settings/opening-stock-list.tsx
+++ b/apps/web/src/components/manufacturing/ui/settings/opening-stock-list.tsx
@@ -480,7 +480,9 @@ const OpeningStockRowLine = memo(function OpeningStockRowLine({
         <Tooltip
           key='account'
           content={`${row.accountLabel}. The inventory account this opening balance will be stamped with, frozen on the movement, which is append-only.`}>
-          <span className='cursor-default text-xs tabular-nums'>{row.accountCode}</span>
+          <span className='cursor-default truncate text-xs tabular-nums'>
+            {row.accountCode || row.accountLabel}
+          </span>
         </Tooltip>,
 
         <EditableCell key='quantity' className='w-full'>

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -71,7 +71,12 @@ import {
   X,
 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
-import { GlAccountPicker, useChartAccounts } from '~/components/accounting/ui/gl-account-picker'
+import {
+  AccountLabel,
+  formatAccountLabel,
+  useChartAccount,
+} from '~/components/accounting/ui/account-label'
+import { GlAccountPicker } from '~/components/accounting/ui/gl-account-picker'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import type { CatalogGroup } from '~/components/money/hooks/use-catalog-groups'
 import type { CatalogItem } from '~/components/money/hooks/use-catalog-items'
@@ -2039,17 +2044,19 @@ function WeightChip({ weight, onClick }: { weight: number | null; onClick?: () =
  * renders as itself, the same posture `EntryJournal`'s snapshot rows take).
  */
 function GlAccountChip({ glAccountId, onClick }: { glAccountId: string; onClick?: () => void }) {
-  const { accounts } = useChartAccounts()
-  const account = accounts.find((candidate) => candidate.id === glAccountId)
-  const label = account ? account.code : glAccountId
+  const { account } = useChartAccount(glAccountId)
   const content = (
     <span className='shrink-0 rounded-sm bg-primary-100 px-1.5 py-0.5 text-[10px] text-muted-foreground leading-none tabular-nums dark:bg-primary-100/60'>
-      {label}
+      <AccountLabel account={account} glAccountId={glAccountId} density='chip' />
     </span>
   )
-  if (!onClick) return <SimpleTooltip content='GL account'>{content}</SimpleTooltip>
+  if (!onClick) {
+    return (
+      <SimpleTooltip content={formatAccountLabel(account) || 'GL account'}>{content}</SimpleTooltip>
+    )
+  }
   return (
-    <SimpleTooltip content='GL account — click to change'>
+    <SimpleTooltip content={`${formatAccountLabel(account) || 'GL account'} - click to change`}>
       <button
         type='button'
         tabIndex={-1}

--- a/packages/lib/src/postings/reports/adapters.ts
+++ b/packages/lib/src/postings/reports/adapters.ts
@@ -34,13 +34,16 @@ export function toTrialBalanceRows(tb: TrialBalance): StatementRow[] {
     // The IDENTITY (task 15), not the code: two rows can no longer collide
     // because an account was renumbered mid-history.
     id: row.glAccountId,
-    label: row.inChart ? `${row.accountCode} ${row.accountName}` : `${row.accountCode}`,
+    label: row.inChart
+      ? [row.accountCode, row.accountName].filter(Boolean).join(' ')
+      : row.accountCode || row.accountName || row.glAccountId,
     depth: 0,
     kind: 'line',
     values: [row.debitMinor, row.creditMinor, row.balanceMinor],
     meta: {
       glAccountId: row.glAccountId,
       accountCode: row.accountCode,
+      accountName: row.accountName,
       note: row.inChart
         ? undefined
         : 'This account has posted lines but has been deleted from the current chart of accounts.',
@@ -101,13 +104,16 @@ export function toBalanceSheetRows(
     const children: StatementRow[] = rows.map((row) => ({
       // The IDENTITY (task 15), not the code - see `toTrialBalanceRows`.
       id: row.glAccountId,
-      label: row.inChart ? `${row.accountCode} ${row.accountName}` : row.accountCode,
+      label: row.inChart
+        ? [row.accountCode, row.accountName].filter(Boolean).join(' ')
+        : row.accountCode || row.accountName || row.glAccountId,
       depth: 1,
       kind: 'line',
       values: two(row.balanceMinor, compareRows, row.glAccountId),
       meta: {
         glAccountId: row.glAccountId,
         accountCode: row.accountCode,
+        accountName: row.accountName,
         note: row.inChart
           ? undefined
           : 'This account has posted lines but has been deleted from the current chart of accounts.',
@@ -227,13 +233,16 @@ export function toProfitAndLossRows(
     rows.map((row) => ({
       // The IDENTITY (task 15), not the code - see `toTrialBalanceRows`.
       id: row.glAccountId,
-      label: row.inChart ? `${row.accountCode} ${row.accountName}` : row.accountCode,
+      label: row.inChart
+        ? [row.accountCode, row.accountName].filter(Boolean).join(' ')
+        : row.accountCode || row.accountName || row.glAccountId,
       depth: 1,
       kind: 'line' as const,
       values: two(row.balanceMinor, compareRows, row.glAccountId),
       meta: {
         glAccountId: row.glAccountId,
         accountCode: row.accountCode,
+        accountName: row.accountName,
         note: row.inChart
           ? undefined
           : 'This account has posted lines but has been deleted from the current chart of accounts.',

--- a/packages/lib/src/postings/reports/rows.ts
+++ b/packages/lib/src/postings/reports/rows.ts
@@ -39,6 +39,7 @@ export interface StatementRow {
     /** The `gl_account` `EntityInstance` id (task 15) - the drill-down key. `accountCode` is display only. */
     glAccountId?: string
     accountCode?: string
+    accountName?: string
     recordId?: string
     badge?: string
     note?: string
@@ -54,6 +55,7 @@ export interface StatementLineInput {
   /** Minor units, one per column, in column order. */
   values: Array<number | null>
   accountCode?: string
+  accountName?: string
   note?: string
 }
 
@@ -86,8 +88,8 @@ export function statementSection(
     kind: 'line',
     values: line.values,
     meta:
-      line.accountCode || line.note
-        ? { accountCode: line.accountCode, note: line.note }
+      line.accountCode || line.accountName || line.note
+        ? { accountCode: line.accountCode, accountName: line.accountName, note: line.note }
         : undefined,
   }))
 


### PR DESCRIPTION
## Why

Every screen that named a GL account composed its own label. Most put the code first and let the name truncate; several showed the code alone in a chip with no name anywhere. With task 15 §5 about to make `gl_account.code` optional, each of those sites would have gone blank or shown a raw id.

## What

- **New `AccountLabel`** (`apps/web/src/components/accounting/ui/account-label.tsx`) with three densities. `full` renders a muted mono code then a truncating name. `compact` renders the name alone. `chip` renders the code when present, else a clamped name, with the caller supplying the badge chrome. Every density puts the full `code · name` in `title`. All three render correctly for a null code.
- **Pure helpers** `formatAccountLabel`, `accountChipText`, `accountMatchesSearch` in `account-label-format.ts`, with unit tests for the null-code cases. `formatAccount` in the settings types delegates to it.
- **Code-only sites now carry the name**: the vendor bill line chip, both review queue badges, the bank account list badge, rule sentences, the code panel suggestion, the review drawer, the analyze panel.
- **Code-first sites let the name keep the room**: the picker trigger and options, chart list, account map, role map list and editor, wizard, entry journal, roll-forward, drill-down header, account lines dialog, delete confirm copy, the opening grid.
- **Statements**: lib rows carry `meta.accountName` beside `meta.accountCode`, so the statement table renders through the component while the PDF and CSV keep the code-first joined label. Label composition in `adapters.ts` is null-safe.
- **Null-code crash guards**: every `code.includes` search filter goes through `accountMatchesSearch`; entry journal rows key on `glAccountId`, not the code.
- `useChartAccounts` moves to `use-chart-accounts.ts`, re-exported by the picker, to avoid a picker to label import cycle.

## Not in this PR

The schema change itself (`gl_account.code` and `GlPostingLine.accountCode` stay non-null), the P&L COGS classification by code prefix in `profit-and-loss.ts`, and the chart editor's code requirement. Those are step 3 proper in `plans/accounting/HANDOFF-2026-09-10.md`.

## Verification

- Biome clean on every changed file, zero em dashes added.
- Web typecheck 0 errors, ratchet baseline 0. Lib typecheck ratchet 27 of 27, none in postings.
- `packages/lib` `postings/reports`: 95 tests pass. Web accounting tests: 91 pass, plus 6 new.
- `receipt-input.test.ts` fails on main already; untouched here.
- Not driven in a browser. The §7 drive in the handoff is still owed.

https://claude.ai/code/session_01BQLTmsB1p3k7Ki8rWAqzt4
