### PR TITLE
fix(ui): commit the useViewportFill hook the banking pages import

### DIFF
--- a/apps/web/src/hooks/use-viewport-fill.ts
+++ b/apps/web/src/hooks/use-viewport-fill.ts
@@ -1,0 +1,65 @@
+// apps/web/src/hooks/use-viewport-fill.ts
+
+'use client'
+
+import { type RefObject, useLayoutEffect, useState } from 'react'
+
+/** No frame is filled below this, however short the viewport is. */
+const DEFAULT_MIN_HEIGHT = 200
+
+/**
+ * The height that makes `ref`'s element end exactly where its surrounding
+ * `ScrollArea` viewport does, in px - or `undefined` until the first measure.
+ *
+ * ## Why a page inside `SettingsPage` needs this at all
+ *
+ * `SettingsPage` IS a `ScrollArea`. Its content wrapper is `min-h-full` with an
+ * **auto** height, and `flex-1` does not cap a child of an auto-height flex
+ * column: per flexbox, a grow item's max-content contribution is what sizes the
+ * container, so `flex min-h-0 flex-1` grows to the list instead of to the
+ * viewport. A nested `ScrollArea` inside it then gets a root as tall as its own
+ * content, never scrolls, and the OUTER viewport scrolls the whole page - two
+ * scroll areas where only the inner one was meant to move. A definite pixel
+ * height on the frame is what makes the inner scroller a scroller.
+ *
+ * ⚠️ `--settings-sticky-top` is not the whole offset. It measures the sticky
+ * title/tabs block only; the breadcrumb bar above it is a separate, non-sticky
+ * sibling, so `viewportHeight - stickyTop` overshoots by the breadcrumb's height
+ * and the page gains a scrollbar exactly that tall. What is honest is the
+ * element's own offset inside the scroll content - everything above it, sticky
+ * or not, has already been laid out.
+ */
+export function useViewportFill(
+  ref: RefObject<HTMLElement | null>,
+  minHeight: number = DEFAULT_MIN_HEIGHT
+): number | undefined {
+  const [height, setHeight] = useState<number | undefined>(undefined)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const viewport = el.closest<HTMLElement>('[data-slot="scroll-area-viewport"]')
+    if (!viewport) return
+
+    const measure = () => {
+      const offset =
+        el.getBoundingClientRect().top - viewport.getBoundingClientRect().top + viewport.scrollTop
+      setHeight(Math.max(minHeight, viewport.clientHeight - offset))
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(viewport)
+    // Everything laid out above the frame - the breadcrumb bar and the sticky
+    // header, both of which grow a line when a description wraps at narrow
+    // widths, and neither of which resizes the viewport when it happens. Never
+    // the frame itself nor an ancestor of it: this effect sets that height, so
+    // observing it would loop.
+    for (const sibling of viewport.firstElementChild?.children ?? []) {
+      if (!sibling.contains(el)) observer.observe(sibling)
+    }
+    return () => observer.disconnect()
+  }, [ref, minHeight])
+
+  return height
+}


### PR DESCRIPTION
## What

Adds `apps/web/src/hooks/use-viewport-fill.ts`. One new file, no other changes.

## Why

#2095 landed three call sites for this hook, but the module itself was never committed:

```
apps/web/src/components/accounting/ui/banking/review-queue-page.tsx:57
apps/web/src/components/accounting/ui/banking/rules/rules-page.tsx:51
apps/web/src/components/accounting/ui/banking/deposits/deposits-page.tsx:60
    import { useViewportFill } from '~/hooks/use-viewport-fill'
```

Main does not resolve that import today.

## What the hook is for

`SettingsPage` **is** a `ScrollArea`, and its content wrapper is `min-h-full` with an **auto** height. A grow item of an auto-height flex column is sized by its own max-content contribution, not capped by the container - so `flex-1` on a page frame grows to the list, a nested `ScrollArea` inside it becomes as tall as its own contents and never scrolls, and the outer settings viewport scrolls the whole page instead. Two scroll areas where only the inner one was meant to move.

A definite pixel height on the frame is what makes the inner scroller a scroller, and this measures it: the element's own offset inside the scroll viewport, subtracted from the viewport's height.

`--settings-sticky-top` alone is not that offset - it measures the sticky title block only, and the breadcrumb bar above it is a separate non-sticky sibling, so `viewportHeight - stickyTop` overshoots by the breadcrumb's height and the page gains a scrollbar exactly that tall.

## Provenance

Not new logic. This body existed twice in #2054 - `useViewportFill` in `rules-page.tsx` and `useFillViewportHeight` in `deposits-page.tsx`, same measurement under two names - and #2095 deleted both local copies in favour of this import. Merging them made the minimum height a parameter (rules 200, deposits 320, review queue 260) and corrected one thing:

The sibling loop now walks the scroll **content wrapper's** children rather than the viewport's, so it observes the breadcrumb bar and the sticky header - the two elements that shift the frame's offset when they reflow, and neither of which resizes the viewport when it happens. Rules' copy iterated `viewport.children`, whose single child *contains* the frame, so its `!sibling.contains(el)` guard skipped every candidate and it observed nothing. Deposits' copy guarded on `sibling !== el` and so observed an ancestor of the very element whose height the effect sets.

## Test

`pnpm --filter @auxx/web typecheck` clean, `biome check` clean. Verified in the browser on `/app/accounting/banking`: the frame resolves to 746.27px (873 viewport - 39.6 breadcrumb - 86.2 sticky header - 1 sentinel) and the outer viewport reads 873/873, i.e. no page scroll.

https://claude.ai/code/session_01CJQfxiueFWrWLRUndj8eVD