### PR TITLE
feat(accounting): retire the instance-shaped roles, dimensions on the line, payment gateways

### DIFF
--- a/apps/web/src/app/(protected)/app/accounting/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/settings/layout.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import { MainPageContent } from '@auxx/ui/components/main-page'
-import { Building2, Landmark, Scale, SlidersHorizontal } from 'lucide-react'
+import { Building2, CreditCard, Landmark, Scale, SlidersHorizontal } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import SidebarSecondary from '~/components/global/sidebar-secondary'
 import type { SidebarProps } from '~/constants/menu'
@@ -49,6 +49,14 @@ const ACCOUNTING_SETTINGS: SidebarProps[] = [
         icon: <Building2 />,
         description: 'Which chart account each bank account maps to, and its coverage',
         keywords: ['bank', 'feed', 'statement', 'reconcile'],
+      },
+      {
+        id: 'accounting-settings-payment-gateways',
+        label: 'Payment gateways',
+        slug: 'payment-gateways',
+        icon: <CreditCard />,
+        description: 'Which chart account each payment rail clears into',
+        keywords: ['gateway', 'stripe', 'affirm', 'shopify payments', 'clearing'],
       },
     ],
   },

--- a/apps/web/src/app/(protected)/app/accounting/settings/payment-gateways/page.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/settings/payment-gateways/page.tsx
@@ -1,0 +1,7 @@
+// apps/web/src/app/(protected)/app/accounting/settings/payment-gateways/page.tsx
+
+import { PaymentGatewaysSettingsPage } from '~/components/accounting/ui/settings/payment-gateways-settings-page'
+
+export default function Page() {
+  return <PaymentGatewaysSettingsPage />
+}

--- a/apps/web/src/components/accounting/ui/banking/payouts/payouts-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/payouts/payouts-page.tsx
@@ -220,27 +220,38 @@ export function PayoutsPage() {
             items={payouts}
             getKey={(payout) => payout.payoutId}
             renderRow={(payout) => (
-              <TreeRow
-                title={payout.number ?? EMPTY_CELL}
-                secondary={payout.paidAt ?? 'Not settled yet'}
-                icon={<Landmark />}
-                trailing={
-                  <div className='flex items-center gap-3'>
-                    {payout.unrecognisedNetMinor > 0 && (
-                      <Badge variant='outline' size='sm'>
-                        {formatMinor(payout.unrecognisedNetMinor, DISPLAY_CURRENCY)} unidentified
-                        {payout.unrecognisedCount > 0 ? ` (${payout.unrecognisedCount})` : ''}
+              <div className='flex flex-col gap-1.5'>
+                <TreeRow
+                  title={payout.number ?? EMPTY_CELL}
+                  secondary={payout.paidAt ?? 'Not settled yet'}
+                  icon={<Landmark />}
+                  trailing={
+                    <div className='flex items-center gap-3'>
+                      {payout.unrecognisedNetMinor > 0 && (
+                        <Badge variant='outline' size='sm'>
+                          {formatMinor(payout.unrecognisedNetMinor, DISPLAY_CURRENCY)} unidentified
+                          {payout.unrecognisedCount > 0 ? ` (${payout.unrecognisedCount})` : ''}
+                        </Badge>
+                      )}
+                      <span className='font-mono text-sm tabular-nums'>
+                        {formatMinor(payout.depositedMinor, DISPLAY_CURRENCY)}
+                      </span>
+                      <Badge variant={STATUS_TONE[payout.status] ?? 'secondary'} size='sm'>
+                        {STATUS_LABEL[payout.status] ?? payout.status}
                       </Badge>
-                    )}
-                    <span className='font-mono text-sm tabular-nums'>
-                      {formatMinor(payout.depositedMinor, DISPLAY_CURRENCY)}
-                    </span>
-                    <Badge variant={STATUS_TONE[payout.status] ?? 'secondary'} size='sm'>
-                      {STATUS_LABEL[payout.status] ?? payout.status}
-                    </Badge>
-                  </div>
-                }
-              />
+                    </div>
+                  }
+                />
+                {/* 🛑 Brief 13 §2.3: a payout debits a bank account, not a role, and
+                    refuses to post until its Stripe destination is confirmed on
+                    one. `bank_account_unmapped` is the same shape the deposit's
+                    own unmapped-account refusal uses (`deposits-page.tsx`). */}
+                {payout.blockedReason && (
+                  <EntryBlockers
+                    blockers={[{ status: 'bank_account_unmapped', error: payout.blockedReason }]}
+                  />
+                )}
+              </div>
             )}
           />
         )}

--- a/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
@@ -47,6 +47,7 @@
 // person from being offered a choice that would be refused; it does not replace
 // the refusal.
 
+import { isMappableTo } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Combobox } from '@auxx/ui/components/combobox'
@@ -218,9 +219,7 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
           {visible.map((row) => {
             const brokenRow = isMappingBroken(row)
             const options = providerAccounts
-              .filter(
-                (account) => account.active && account.classification === row.account.accountType
-              )
+              .filter((account) => isMappableTo(row.account, account))
               .map((account) => ({ value: account.id, label: formatProviderAccount(account) }))
 
             return (

--- a/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounting-settings-keys.ts
@@ -31,6 +31,9 @@ export const ACCOUNTING_KEYS = {
   qboOpeningWip: 'accounting.qboOpeningWip',
   qboOpeningFinishedGoods: 'accounting.qboOpeningFinishedGoods',
   qboOpeningJournalRef: 'accounting.qboOpeningJournalRef',
+  // The bank_account a `cash`-routed payment banks into (brief 13 §2.4). `cash`
+  // stopped being a posting ROLE, so this is the one setting that names it.
+  cashBankAccountId: 'accounting.cashBankAccountId',
   assemblyLaborCostPerUnit: 'manufacturing.assemblyLaborCostPerUnit',
   overheadCostPerUnit: 'manufacturing.overheadCostPerUnit',
   autoRollFirstStandard: 'manufacturing.autoRollFirstStandard',

--- a/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-account-editor.tsx
@@ -112,6 +112,8 @@ export interface BankAccountPatch {
   currency?: string | null
   /** The `gl_account` instance id this account maps to (task 15 §4). Never a code. */
   glAccountId?: string | null
+  /** The Stripe destination id, confirmed once by a person (brief 13 §2.3). */
+  stripeExternalAccountId?: string | null
   feedStartDate?: string | null
 }
 
@@ -197,6 +199,7 @@ interface TextValues {
   institution: string
   last4: string
   currency: string
+  stripeExternalAccountId: string
 }
 
 function BankAccountForm({
@@ -221,6 +224,7 @@ function BankAccountForm({
     institution: account.institution ?? '',
     last4: account.last4 ?? '',
     currency: account.currency ?? '',
+    stripeExternalAccountId: account.stripeExternalAccountId ?? '',
   })
 
   // The debounced writer reads the merged values through a ref: two rows edited
@@ -248,6 +252,10 @@ function BankAccountForm({
   )
   const commitCurrency = useDebouncedCallback(
     (value: string) => onPatch({ currency: value || null }),
+    TEXT_COMMIT_DELAY_MS
+  )
+  const commitStripeExternalAccountId = useDebouncedCallback(
+    (value: string) => onPatch({ stripeExternalAccountId: value || null }),
     TEXT_COMMIT_DELAY_MS
   )
 
@@ -372,6 +380,23 @@ function BankAccountForm({
             filterTypes={glFilterTypes}
             placeholder='Map to an account…'
             onChange={(id) => onPatch({ glAccountId: id })}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Stripe external account'
+          type={BaseType.STRING}
+          showIcon
+          description='The Stripe destination id (ba_… or card_…) this account settles payouts to, confirmed once so a payout can be attributed here. Never matched on last four.'>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={values.stripeExternalAccountId}
+            placeholder='ba_1AbCdEf...'
+            onChange={(value) => {
+              const next = (value as string) ?? ''
+              bufferText('stripeExternalAccountId', next)
+              commitStripeExternalAccountId(next)
+            }}
           />
         </FieldPanelRow>
 

--- a/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
@@ -58,6 +58,7 @@ import {
   type ChartAccountRow,
   type GlAccountSubtypeValue,
   type GlAccountTypeValue,
+  isMappableTo,
 } from '@auxx/lib/postings/client'
 import { Button } from '@auxx/ui/components/button'
 import { Combobox } from '@auxx/ui/components/combobox'
@@ -588,6 +589,7 @@ function ChartAccountForm({
               <ProviderAccountField
                 map={map}
                 accountType={values.accountType}
+                subtype={values.subtype}
                 identity={
                   recordIdRef.current ? map.byAccountId.get(recordIdRef.current) : undefined
                 }
@@ -682,6 +684,7 @@ const PROVIDER_ROW_DESCRIPTION =
 function ProviderAccountField({
   map,
   accountType,
+  subtype,
   identity,
   pending,
   onSet,
@@ -690,6 +693,8 @@ function ProviderAccountField({
   map: ChartMapView
   /** The LIVE local value, not the saved one - see the filter below. */
   accountType: GlAccountTypeValue | null
+  /** The LIVE local value too, for the same reason (task 13 §3). */
+  subtype: GlAccountSubtypeValue | null
   identity: AccountIdentityRow | undefined
   pending: boolean
   onSet: (providerAccountId: string | null) => Promise<void>
@@ -736,18 +741,23 @@ function ProviderAccountField({
     )
   }
 
-  // 🛑 Filtered by the LIVE `accountType`, not by `identity.account.accountType`.
-  // Somebody who has just changed this account's type is picking for what it is
-  // NOW; offering candidates for the type it used to be would hand them a
-  // mapping the server is about to refuse.
+  // 🛑 Filtered by the LIVE `accountType` and `subtype`, not by
+  // `identity.account`'s saved values. Somebody who has just changed this
+  // account's type or subtype is picking for what it is NOW; offering
+  // candidates for what it used to be would hand them a mapping the server is
+  // about to refuse.
   //
   // ⚠️ Type compatibility is a FILTER, not a tiebreak. A candidate in the wrong
   // statement section is never offered at any confidence: mapping a liability to
   // a revenue account balances AND misstates the P&L, and the number somebody
-  // recognises gives them no way to tell.
-  const options = map.providerAccounts
-    .filter((account) => account.active && account.classification === accountType)
-    .map((account) => ({ value: account.id, label: formatProviderAccount(account) }))
+  // recognises gives them no way to tell. `isMappableTo` (task 13 §3) adds the
+  // same rule for subtype: a `bank` account is never offered a candidate whose
+  // provider `accountType` is not `Bank`, even one in the right section.
+  const options = accountType
+    ? map.providerAccounts
+        .filter((account) => isMappableTo({ accountType, subtype }, account))
+        .map((account) => ({ value: account.id, label: formatProviderAccount(account) }))
+    : []
 
   const suggestion = identity.suggestion
   const broken = isMappingBroken(identity)

--- a/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
@@ -27,6 +27,7 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Banknote, CalendarRange, ExternalLink, Lock, Scale } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo } from 'react'
+import { BankAccountPicker } from '~/components/accounting/ui/bank-account-picker'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel } from '~/components/global/forms/field-panel'
@@ -94,8 +95,17 @@ const PAYMENT_ROUTE_ROWS = [
   },
 ] as const
 
-/** The five keys this page's route slice owns. Derived, never retyped. */
-const PAYMENT_ROUTE_DRAFT_KEYS = PAYMENT_ROUTE_ROWS.map((row) => row.key)
+/**
+ * The five route keys, plus the one bank account a `cash` route needs.
+ *
+ * `cashBankAccountId` rides in the same draft slice as the routes it depends
+ * on: they save and discard together, and a row shown only while a route
+ * above reads `cash` has nothing sensible to save on its own.
+ */
+const PAYMENT_ROUTE_DRAFT_KEYS = [
+  ...PAYMENT_ROUTE_ROWS.map((row) => row.key),
+  ACCOUNTING_KEYS.cashBankAccountId,
+]
 
 const BREADCRUMBS = [
   { title: 'Accounting', href: '/app/accounting' },
@@ -141,6 +151,10 @@ export function AccountingGeneralSettingsPage() {
   // Its own slice, like every other section on this page: the route table
   // validates nothing and could later save through a different mutation.
   const routes = useAccountingSetupDraft(PAYMENT_ROUTE_DRAFT_KEYS)
+  // Shown only while at least one route reads `cash` (brief 13 §2.4): `cash`
+  // is no longer a role, so the bank account it lands in has to be named
+  // somewhere, and there is nothing to name while nothing routes there.
+  const anyRouteIsCash = PAYMENT_ROUTE_ROWS.some((row) => routes.draft[row.key] === 'cash')
 
   // ── Section 3: absorption rates ──────────────────────────────────────────
   const absorption = useAccountingSetupDraft(ABSORPTION_DRAFT_KEYS)
@@ -281,6 +295,22 @@ export function AccountingGeneralSettingsPage() {
                     {...routes.controlled(row.key)}
                   />
                 ))}
+
+                {anyRouteIsCash && (
+                  <SettingsFieldRow
+                    settingKey={ACCOUNTING_KEYS.cashBankAccountId}
+                    title='Cash bank account'
+                    description='Where a payment routed to cash is banked. A cash-routed payment refuses to post until this is set.'>
+                    <BankAccountPicker
+                      value={readText(routes.draft[ACCOUNTING_KEYS.cashBankAccountId])}
+                      onChange={(id) =>
+                        routes.patch({
+                          [ACCOUNTING_KEYS.cashBankAccountId]: id as SettingValue,
+                        })
+                      }
+                    />
+                  </SettingsFieldRow>
+                )}
               </FieldPanel>
 
               <p className='text-muted-foreground text-xs'>

--- a/apps/web/src/components/accounting/ui/settings/payment-gateway-add-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateway-add-dialog.tsx
@@ -1,0 +1,168 @@
+// apps/web/src/components/accounting/ui/settings/payment-gateway-add-dialog.tsx
+'use client'
+
+// "Add gateway" - the only door that creates a `payment_gateway` record
+// (task 13 §5.3). Copies `bank-account-manual-dialog.tsx`'s shape: a small
+// `FieldPanel` in a dialog, extracted so the fields and the refusal handling
+// live in one place.
+
+import { FieldType } from '@auxx/database/enums'
+import type { PaymentGatewayRow } from '@auxx/lib/payment-gateways/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError } from '@auxx/ui/components/toast'
+import { useState } from 'react'
+import { GlAccountPicker } from '~/components/accounting/ui/gl-account-picker'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { api } from '~/trpc/react'
+
+/** The dialog's fields, as it holds them before the write. */
+interface AddDraft {
+  name: string
+  handles: string[]
+  clearingAccountId: string | null
+}
+
+const EMPTY_DRAFT: AddDraft = { name: '', handles: [], clearingAccountId: null }
+
+export interface PaymentGatewayAddDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /**
+   * The gateway that was just written. `paymentGateway.list` is already
+   * invalidated by the time this fires, so a caller only has to select it.
+   */
+  onCreated?: (gateway: PaymentGatewayRow) => void
+}
+
+/**
+ * PaymentGatewayAddDialog
+ *
+ * Collects the three fields `createPaymentGateway` requires - name, at least
+ * one handle, and an active asset clearing account - before enabling Add.
+ * Fee account and settlement source are left to the editor, since they are
+ * optional and `manual`/null are already correct defaults for most rails.
+ */
+export function PaymentGatewayAddDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: PaymentGatewayAddDialogProps) {
+  const utils = api.useUtils()
+  const [draft, setDraft] = useState<AddDraft>(EMPTY_DRAFT)
+
+  const create = api.paymentGateway.create.useMutation({
+    onSuccess: async (gateway) => {
+      await utils.paymentGateway.list.invalidate()
+      onOpenChange(false)
+      setDraft(EMPTY_DRAFT)
+      onCreated?.(gateway)
+    },
+    onError: (error) => {
+      toastError({ title: 'Error adding the gateway', description: error.message })
+    },
+  })
+
+  const canSubmit = draft.name.trim() && draft.handles.length > 0 && draft.clearingAccountId
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next)
+        if (!next) setDraft(EMPTY_DRAFT)
+      }}>
+      <DialogContent position='tc'>
+        <DialogHeader>
+          <DialogTitle>Add a payment gateway</DialogTitle>
+          <DialogDescription>
+            A record carrying its own clearing account - never a role. Two rails can share one
+            account; this only says which account, it never mints a new one.
+          </DialogDescription>
+        </DialogHeader>
+
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='accounting-payment-gateway-add'
+          defaultLabelWidth={140}
+          className='p-0'>
+          <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={draft.name}
+              placeholder='Authorize.Net'
+              disabled={create.isPending}
+              onChange={(value) => setDraft({ ...draft, name: (value as string) ?? '' })}
+            />
+          </FieldPanelRow>
+          <FieldPanelRow
+            title='Gateway handles'
+            type={BaseType.STRING}
+            showIcon
+            isRequired
+            description='Every stored value this rail is seen under.'>
+            <FieldInputAdapter
+              fieldType={FieldType.TAGS}
+              fieldOptions={{ options: [] }}
+              useValueAsLabel
+              value={draft.handles}
+              placeholder='Add a handle'
+              disabled={create.isPending}
+              onChange={(value) =>
+                setDraft({ ...draft, handles: Array.isArray(value) ? (value as string[]) : [] })
+              }
+            />
+          </FieldPanelRow>
+          <FieldPanelRow title='Clearing account' type={BaseType.STRING} showIcon isRequired>
+            <GlAccountPicker
+              value={draft.clearingAccountId}
+              selectBy='id'
+              filterTypes={['asset']}
+              placeholder='Select account…'
+              disabled={create.isPending}
+              onChange={(id) => setDraft({ ...draft, clearingAccountId: id })}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={create.isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            loading={create.isPending}
+            loadingText='Adding...'
+            disabled={!canSubmit}
+            onClick={() =>
+              create.mutate({
+                name: draft.name.trim(),
+                handles: draft.handles,
+                clearingAccountId: draft.clearingAccountId as string,
+              })
+            }
+            data-dialog-submit>
+            Add gateway <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/payment-gateway-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateway-editor.tsx
@@ -1,0 +1,247 @@
+// apps/web/src/components/accounting/ui/settings/payment-gateway-editor.tsx
+'use client'
+
+// The right pane of Accounting > Settings > Payment gateways (task 13 §5.3).
+//
+// 🛑 Copies `bank-account-editor.tsx`'s ONE SAVE MODEL: every row commits on
+// change, no `Save` button, no dirty guard. See that file's header for why -
+// the same argument holds here unchanged (a record editor beside a master
+// list, not a section-shaped settings form).
+//
+// 🛑 Handles is a TAG input, not a text field (§5.1's census: two rails arrive
+// under two spellings each, and a single-string field re-creates the exact
+// problem this record exists to solve). Rendered through `FieldInputAdapter`
+// with `FieldType.TAGS`, the same idiom `order_payment_gateways` uses.
+//
+// 🛑 Clearing account is filtered to `asset`, fee account to `expense` - the
+// picker is a convenience; `writes.ts`'s refusal sentence is the actual
+// defence, and it is surfaced verbatim on save.
+
+import { FieldType } from '@auxx/database/enums'
+import type { PaymentGatewayRow } from '@auxx/lib/payment-gateways/client'
+import {
+  PAYMENT_GATEWAY_SETTLEMENT_SOURCE_LABELS,
+  PAYMENT_GATEWAY_SETTLEMENT_SOURCES,
+} from '@auxx/lib/payment-gateways/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { Section } from '@auxx/ui/components/section'
+import { CreditCard } from 'lucide-react'
+import { useRef, useState } from 'react'
+import { GlAccountPicker } from '~/components/accounting/ui/gl-account-picker'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+
+const SETTLEMENT_SOURCE_OPTIONS = PAYMENT_GATEWAY_SETTLEMENT_SOURCES.map((value) => ({
+  value,
+  label: PAYMENT_GATEWAY_SETTLEMENT_SOURCE_LABELS[value],
+  color: value === 'manual' ? ('gray' as const) : ('green' as const),
+}))
+
+/** How long a text row waits after the last keystroke before it writes. */
+const TEXT_COMMIT_DELAY_MS = 500
+
+export interface PaymentGatewayPatch {
+  name?: string
+  handles?: string[]
+  clearingAccountId?: string
+  feeAccountId?: string | null
+  settlementSource?: PaymentGatewayRow['settlementSource']
+  lastSettlementAt?: string | null
+}
+
+/**
+ * Cancels the scroll container's `p-3` so a `Section` sits FLUSH with the
+ * panel. See `bank-account-editor.tsx`'s `SECTION_BLEED` for the full reason.
+ */
+const SECTION_BLEED = '-mx-3'
+
+interface PaymentGatewayEditorProps {
+  gateway: PaymentGatewayRow | null
+  /** True while an `update` is in flight. */
+  pending: boolean
+  /** True while the close is in flight. */
+  closing?: boolean
+  onPatch: (patch: PaymentGatewayPatch) => void
+  /** Mark the gateway closed. Disabled while it already is. */
+  onClose: () => void
+}
+
+export function PaymentGatewayEditor({ gateway, ...rest }: PaymentGatewayEditorProps) {
+  if (!gateway) {
+    return (
+      <div className='p-4 text-muted-foreground text-sm'>
+        Select a gateway to map it to your chart, or add one.
+      </div>
+    )
+  }
+  // Keyed on the gateway: the name row holds local state so an in-flight
+  // write cannot flicker a half-typed field back to its stored value, and
+  // selecting a different gateway has to reseed that state rather than carry
+  // it across.
+  return <PaymentGatewayForm key={gateway.id} gateway={gateway} {...rest} />
+}
+
+function PaymentGatewayForm({
+  gateway,
+  pending,
+  closing = false,
+  onPatch,
+  onClose,
+}: PaymentGatewayEditorProps & { gateway: PaymentGatewayRow }) {
+  const [name, setName] = useState(gateway.name)
+  const nameRef = useRef(name)
+
+  const commitName = useDebouncedCallback((value: string) => {
+    if (value.trim()) onPatch({ name: value })
+  }, TEXT_COMMIT_DELAY_MS)
+
+  const isClosed = gateway.status === 'closed'
+
+  return (
+    <div className='flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-3'>
+      <div className='flex min-w-0 flex-col gap-1'>
+        <span className='flex items-center gap-2 truncate font-medium text-sm'>
+          <CreditCard className='size-4 text-muted-foreground' />
+          {gateway.name || 'Untitled gateway'}
+        </span>
+        <span className='text-muted-foreground text-xs'>
+          {isClosed
+            ? 'Closed. Its history still routes to this clearing account, but a merchant would add a new gateway for a new rail.'
+            : 'A record carrying its own clearing account, never a role - two rails can share one account.'}
+        </span>
+      </div>
+
+      <FieldPanel
+        className='shrink-0 grow-0 p-0'
+        resizeId='accounting-payment-gateway'
+        defaultLabelWidth={150}>
+        <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={name}
+            placeholder='Authorize.Net'
+            onChange={(value) => {
+              const next = (value as string) ?? ''
+              nameRef.current = next
+              setName(next)
+              commitName(next)
+            }}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Gateway handles'
+          type={BaseType.STRING}
+          showIcon
+          isRequired
+          description='Every stored value this rail is seen under. Two spellings of the same rail (authorize_net / authorize.net) both belong here.'>
+          <FieldInputAdapter
+            fieldType={FieldType.TAGS}
+            fieldOptions={{ options: [] }}
+            useValueAsLabel
+            value={gateway.handles}
+            placeholder='Add a handle'
+            onChange={(value) => {
+              const handles = Array.isArray(value) ? (value as string[]) : []
+              if (handles.length > 0) onPatch({ handles })
+            }}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Clearing account'
+          type={BaseType.STRING}
+          showIcon
+          isRequired
+          description='Where this gateway settles. Two gateways sharing one account is fine - this only says which account, it never mints a new one.'>
+          <GlAccountPicker
+            value={gateway.clearingGlAccountId}
+            selectBy='id'
+            filterTypes={['asset']}
+            placeholder='Select account…'
+            onChange={(id) => id && onPatch({ clearingAccountId: id })}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Fee account'
+          type={BaseType.STRING}
+          showIcon
+          description='Where the processor’s withheld fee lands. Falls back to your default merchant-fees account until you set one.'>
+          <GlAccountPicker
+            value={gateway.feeGlAccountId}
+            selectBy='id'
+            filterTypes={['expense']}
+            placeholder='Select account…'
+            onChange={(id) => onPatch({ feeAccountId: id })}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Settlement source'
+          type={BaseType.ENUM}
+          showIcon
+          description='Automatic reads a real payout feed. By hand is what Affirm and every historical rail correctly are.'>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            fieldOptions={{ options: SETTLEMENT_SOURCE_OPTIONS }}
+            value={gateway.settlementSource}
+            triggerProps={{ className: 'w-full ps-0 pe-1' }}
+            placeholder='Select settlement source'
+            onChange={(value) => {
+              const next = Array.isArray(value) ? value[0] : value
+              if (next === 'stripe' || next === 'shopify_payments' || next === 'manual') {
+                onPatch({ settlementSource: next })
+              }
+            }}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Status' type={BaseType.ENUM} showIcon>
+          <div className='flex min-h-8 items-center'>
+            <Badge variant={isClosed ? 'secondary' : 'outline'} size='sm'>
+              {isClosed ? 'Closed' : 'Active'}
+            </Badge>
+          </div>
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title='Last settlement'
+          type={BaseType.DATE}
+          showIcon
+          description='Informational only - nothing in posting reads this.'>
+          <FieldInputAdapter
+            fieldType={FieldType.DATE}
+            value={gateway.lastSettlementAt ? `${gateway.lastSettlementAt}T00:00:00.000Z` : null}
+            onChange={(value) => {
+              const iso = value as string | null
+              onPatch({ lastSettlementAt: iso ? iso.slice(0, 10) : null })
+            }}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
+
+      <div className='min-h-4 text-muted-foreground text-xs'>{pending ? 'Saving…' : null}</div>
+
+      {!isClosed && (
+        <Section title='Danger zone' initialOpen={false} className={SECTION_BLEED}>
+          <div className='flex flex-col gap-2 p-1'>
+            <p className='text-muted-foreground text-xs'>
+              Closing keeps every shipment that ever routed here posting to this same clearing
+              account, so its balance still winds down correctly. It just stops offering this
+              gateway as the answer for a new order.
+            </p>
+            <div>
+              <Button variant='destructive' size='sm' loading={closing} onClick={onClose}>
+                Close gateway
+              </Button>
+            </div>
+          </div>
+        </Section>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/payment-gateways-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateways-list.tsx
@@ -1,0 +1,173 @@
+// apps/web/src/components/accounting/ui/settings/payment-gateways-list.tsx
+'use client'
+
+// The left column of Accounting > Settings > Payment gateways (task 13 §5.3).
+// Copies `bank-accounts-list.tsx` almost exactly, minus the institution
+// grouping - a gateway has no login to group by, so this is one flat list.
+//
+// 🛑 The clearing-account badge is on the ROW, not only in the editor. Same
+// argument as the bank account list: which account a gateway reconciles
+// into is the one thing this screen exists to answer, and a state that can
+// only be discovered by selecting each row in turn stays unfinished.
+
+import type { PaymentGatewayRow } from '@auxx/lib/payment-gateways/client'
+import { PAYMENT_GATEWAY_SETTLEMENT_SOURCE_LABELS } from '@auxx/lib/payment-gateways/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { EmptySection } from '@auxx/ui/components/section'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
+import { cn } from '@auxx/ui/lib/utils'
+import { CreditCard, Plus } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { AccountLabel } from '~/components/accounting/ui/account-label'
+import { useChartAccounts } from '~/components/accounting/ui/gl-account-picker'
+import { EmptyState } from '~/components/global/empty-state'
+
+interface PaymentGatewaysListProps {
+  gateways: PaymentGatewayRow[]
+  isLoading: boolean
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+  onAdd: () => void
+  showArchived: boolean
+  onShowArchivedChange: (next: boolean) => void
+  /** How many closed gateways the org holds, so the toggle can say so. */
+  closedCount: number
+}
+
+export function PaymentGatewaysList({
+  gateways,
+  isLoading,
+  selectedId,
+  onSelect,
+  onAdd,
+  showArchived,
+  onShowArchivedChange,
+  closedCount,
+}: PaymentGatewaysListProps) {
+  const [search, setSearch] = useState('')
+
+  // `clearingGlAccountId` is stored as the `gl_account` id (task 15 §4 shape),
+  // so the badge below has to resolve it. One `ledger.chartAccounts` fetch for
+  // the whole list, React-Query cached - never a lookup per row.
+  const { accounts: chartAccounts } = useChartAccounts()
+  const chartAccountById = useMemo(
+    () => new Map(chartAccounts.map((account) => [account.id, account])),
+    [chartAccounts]
+  )
+
+  const visible = useMemo(() => {
+    const needle = search.trim().toLowerCase()
+    if (!needle) return gateways
+    return gateways.filter(
+      (gateway) =>
+        gateway.name.toLowerCase().includes(needle) ||
+        gateway.handles.some((handle) => handle.toLowerCase().includes(needle))
+    )
+  }, [gateways, search])
+
+  const addButton = (
+    <Button variant='outline' size='sm' onClick={onAdd}>
+      <Plus />
+      Add gateway
+    </Button>
+  )
+
+  return (
+    <div className='flex flex-col gap-3 p-3'>
+      {gateways.length > 0 && (
+        <>
+          <div className='flex items-center gap-2'>{addButton}</div>
+          <div className='flex items-center gap-2'>
+            <InputSearch
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder='Search gateways...'
+            />
+            {closedCount > 0 && (
+              <ButtonSwitch
+                label={`Show closed (${closedCount})`}
+                size='xs'
+                checked={showArchived}
+                onCheckedChange={onShowArchivedChange}
+                className='shrink-0'
+              />
+            )}
+          </div>
+        </>
+      )}
+
+      {isLoading ? (
+        <EmptySection loading />
+      ) : gateways.length === 0 ? (
+        <EmptyState
+          icon={CreditCard}
+          title='No payment gateways yet'
+          description={
+            <>
+              A payment gateway is a record carrying its own clearing account - Shopify Payments,
+              Affirm, or any rail this store has ever run. Add one to route its shipments there
+              instead of the default card clearing account.
+            </>
+          }
+          button={addButton}
+        />
+      ) : visible.length === 0 ? (
+        <EmptySection icon={<CreditCard className='size-5' />} title='No matches' />
+      ) : (
+        <div className={cn('flex flex-col gap-0.5', TREE_SECONDARY_NOTRUNCATE)}>
+          <TreeRowList
+            items={visible}
+            getKey={(gateway: PaymentGatewayRow) => gateway.id}
+            renderRow={(gateway: PaymentGatewayRow) => {
+              const mapped = chartAccountById.get(gateway.clearingGlAccountId)
+              return (
+                <TreeRow
+                  icon={<CreditCard className='size-4 text-muted-foreground' />}
+                  title={
+                    <span className='truncate text-sm'>{gateway.name || 'Untitled gateway'}</span>
+                  }
+                  onToggleOpen={() => onSelect(gateway.id)}
+                  rowClassName={cn(
+                    'bg-primary-100/50 hover:bg-primary-100',
+                    gateway.status === 'closed' && 'opacity-60',
+                    selectedId === gateway.id && 'bg-primary-100 ring-1 ring-primary-200'
+                  )}
+                  secondary={
+                    <span className='flex flex-wrap items-center gap-1.5 text-muted-foreground text-xs'>
+                      {gateway.handles.map((handle) => (
+                        <Badge key={handle} variant='secondary' size='xs' className='font-mono'>
+                          {handle}
+                        </Badge>
+                      ))}
+                      {mapped ? (
+                        <Badge variant='outline' size='xs' className='font-mono'>
+                          <AccountLabel account={mapped} density='compact' />
+                        </Badge>
+                      ) : (
+                        <Badge variant='destructive' size='xs'>
+                          Account not found
+                        </Badge>
+                      )}
+                      <Badge
+                        variant={gateway.status === 'active' ? 'outline' : 'secondary'}
+                        size='xs'>
+                        {gateway.status === 'active' ? 'Active' : 'Closed'}
+                      </Badge>
+                      <Badge variant='outline' size='xs'>
+                        {PAYMENT_GATEWAY_SETTLEMENT_SOURCE_LABELS[gateway.settlementSource]}
+                      </Badge>
+                    </span>
+                  }
+                />
+              )
+            }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/payment-gateways-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateways-settings-page.tsx
@@ -1,0 +1,169 @@
+// apps/web/src/components/accounting/ui/settings/payment-gateways-settings-page.tsx
+'use client'
+
+// Accounting > Settings > Payment gateways (task 13 §5.3). The only NEW
+// screen in the whole payments story - everything else in `18` is an
+// addition to a surface that already exists.
+//
+// Shape B, master-detail: `SettingsPage` + `MasterDetailSplit`, the same
+// `bank-accounts-settings-page.tsx` shape minus the tab strip and the feed
+// actions (a gateway has no connector to sync or disconnect).
+//
+// 🛑 Every write here is `ledgerControl` - a gateway's clearing account
+// decides where card and BNPL money lands on the balance sheet, the same rung
+// `bank-accounts-settings-page.tsx` argues for its own mapping.
+
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
+import { toastError } from '@auxx/ui/components/toast'
+import { Lock } from 'lucide-react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useCallback, useMemo, useState } from 'react'
+import { EmptyState } from '~/components/global/empty-state'
+import { MasterDetailSplit } from '~/components/global/master-detail-split'
+import SettingsPage from '~/components/global/settings-page'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useRequireCapability } from '~/providers/capabilities-provider'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { api } from '~/trpc/react'
+import { PaymentGatewayAddDialog } from './payment-gateway-add-dialog'
+import { PaymentGatewayEditor, type PaymentGatewayPatch } from './payment-gateway-editor'
+import { PaymentGatewaysList } from './payment-gateways-list'
+
+const BREADCRUMBS = [
+  { title: 'Accounting', href: '/app/accounting' },
+  { title: 'Settings' },
+  { title: 'Payment gateways' },
+]
+
+const PAGE_DESCRIPTION =
+  'The rails that have ever taken money for an order, and which account in your chart each one clears into. A gateway carries its own clearing account - it never needs a role, and two rails can share one account.'
+
+export function PaymentGatewaysSettingsPage() {
+  // 🛑 `ledgerControl`, not `ledgerView`. Every control on this page is a
+  // WRITE - the mapping, the add, the close - and the page has no read-only
+  // rendering, so a lower gate handed a viewer live controls the server then
+  // refused one by one. Same rung `bank-accounts-settings-page.tsx` argues.
+  useRequireCapability(PermissionKey.ledgerControl)
+  const { hasAccess } = useFeatureFlags()
+  const utils = api.useUtils()
+
+  // 🛑 The row selection lives in the URL, like the bank accounts screen's
+  // does. This is the screen people are sent to ("map Authorize.Net to
+  // 1200"), and a pane that vanishes on refresh cannot be linked to.
+  const [gatewayParam, setSelectedId] = useQueryState('gateway')
+  const [addOpen, setAddOpen] = useState(false)
+  const [showClosed, setShowClosed] = useQueryState('closed', parseAsBoolean.withDefault(false))
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const gateways = api.paymentGateway.list.useQuery({ includeArchived: true })
+  const rows = useMemo(() => gateways.data ?? [], [gateways.data])
+  const visibleRows = useMemo(
+    () => (showClosed ? rows : rows.filter((row) => row.status !== 'closed')),
+    [rows, showClosed]
+  )
+
+  const selectedId =
+    gatewayParam && (gateways.isPending || rows.some((row) => row.id === gatewayParam))
+      ? gatewayParam
+      : null
+  const selected = useMemo(
+    () => rows.find((row) => row.id === selectedId) ?? null,
+    [rows, selectedId]
+  )
+
+  const invalidate = useCallback(async () => {
+    await utils.paymentGateway.list.invalidate()
+  }, [utils])
+
+  // 🛑 Refusals are surfaced VERBATIM. `updatePaymentGateway` says which
+  // account or handle is wrong; "Could not save" throws that away.
+  const update = api.paymentGateway.update.useMutation({
+    onSuccess: invalidate,
+    onError: (error) => {
+      toastError({ title: 'Error saving the gateway', description: error.message })
+    },
+  })
+
+  const archive = api.paymentGateway.archive.useMutation({
+    onSuccess: invalidate,
+    onError: (error) => {
+      toastError({ title: 'Error closing the gateway', description: error.message })
+    },
+  })
+
+  const handlePatch = useCallback(
+    (patch: PaymentGatewayPatch) => {
+      if (!selectedId) return
+      update.mutate({ id: selectedId, ...patch })
+    },
+    [selectedId, update]
+  )
+
+  const handleClose = useCallback(async () => {
+    if (!selected) return
+    const confirmed = await confirm({
+      title: `Close ${selected.name?.trim() || 'this gateway'}?`,
+      description:
+        'Every shipment that ever routed here keeps posting to this same clearing account, so its balance still winds down correctly. It just stops being offered for a new order. You are not deleting anything.',
+      confirmText: 'Close',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    archive.mutate({ id: selected.id })
+  }, [selected, confirm, archive])
+
+  if (!hasAccess(FeatureKey.accounting)) {
+    return (
+      <SettingsPage
+        title='Payment gateways'
+        description={PAGE_DESCRIPTION}
+        breadcrumbs={BREADCRUMBS}>
+        <EmptyState
+          icon={Lock}
+          title='Accounting Not Available'
+          description='Upgrade your plan to keep books in Auxx.'
+          button={<div className='h-12' />}
+        />
+      </SettingsPage>
+    )
+  }
+
+  return (
+    <SettingsPage title='Payment gateways' description={PAGE_DESCRIPTION} breadcrumbs={BREADCRUMBS}>
+      <MasterDetailSplit
+        id='accounting-payment-gateways'
+        pane={
+          <PaymentGatewayEditor
+            gateway={selected}
+            pending={update.isPending}
+            closing={archive.isPending}
+            onPatch={handlePatch}
+            onClose={handleClose}
+          />
+        }
+        paneTitle='Payment gateway'
+        paneOpen={!!selected}
+        onPaneClose={() => setSelectedId(null)}>
+        <PaymentGatewaysList
+          gateways={visibleRows}
+          isLoading={gateways.isPending}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          onAdd={() => setAddOpen(true)}
+          showArchived={showClosed}
+          onShowArchivedChange={setShowClosed}
+          closedCount={rows.filter((row) => row.status === 'closed').length}
+        />
+      </MasterDetailSplit>
+
+      <PaymentGatewayAddDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        onCreated={(gateway) => setSelectedId(gateway.id)}
+      />
+
+      <ConfirmDialog />
+    </SettingsPage>
+  )
+}

--- a/apps/web/src/components/money/ui/fulfillment-posting/fulfillment-plan-table.tsx
+++ b/apps/web/src/components/money/ui/fulfillment-posting/fulfillment-plan-table.tsx
@@ -40,26 +40,55 @@ import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useState } from 'react'
 import { formatMinor } from '~/components/accounting/ui/ledger/format'
 
-/** The account each debit role names, spelled out where there is room for it. */
+/**
+ * The account each debit role names, spelled out where there is room for it.
+ *
+ * `gateway` (brief 13 §5.3) is the generic fallback for an id-based debit -
+ * one shipment can route to a different `payment_gateway` record than the
+ * next one under the same role, so there is no single name to put here. Use
+ * {@link debitLabel} for a shipment ROW, which prefers the actual gateway's
+ * name when the caller supplies {@link FulfillmentPlanTableProps.gatewayNames}.
+ */
 export const DEBIT_ROLE_LABEL: Record<FulfillmentDebitRole, string> = {
   clearing_card: 'Card clearing',
   clearing_affirm: 'Affirm clearing',
   accounts_receivable: 'Accounts receivable',
+  gateway: 'Gateway clearing',
 }
 
-/** The same three, short enough for a column head. */
+/** The same, short enough for a column head. */
 const DEBIT_ROLE_COLUMN: Record<FulfillmentDebitRole, string> = {
   clearing_card: 'Card',
   clearing_affirm: 'Affirm',
   accounts_receivable: 'A/R',
+  gateway: 'Gateway',
 }
 
 /** The order the debit columns are read in. Card first: it is the common case. */
 const DEBIT_ROLE_ORDER: readonly FulfillmentDebitRole[] = [
   'clearing_card',
   'clearing_affirm',
+  'gateway',
   'accounts_receivable',
 ]
+
+/**
+ * The label one shipment ROW shows for its debit.
+ *
+ * `role === 'gateway'` means the debit is a `payment_gateway` record's own
+ * clearing account id (`amounts.debitGlAccountId`), not one of the three
+ * declared roles - `DEBIT_ROLE_LABEL.gateway` alone cannot say WHICH gateway,
+ * so this prefers the name from `gatewayNames` (keyed by that same id) and
+ * falls back to the generic label when the caller has not supplied one.
+ */
+function debitLabel(
+  role: FulfillmentDebitRole,
+  debitGlAccountId: string | undefined,
+  gatewayNames: Readonly<Record<string, string>>
+): string {
+  if (role !== 'gateway') return DEBIT_ROLE_LABEL[role]
+  return (debitGlAccountId && gatewayNames[debitGlAccountId]) || DEBIT_ROLE_LABEL.gateway
+}
 
 /**
  * How a shipment's tax was arrived at.
@@ -78,9 +107,23 @@ const TAX_BASIS_LABEL: Record<PlannedShipment['amounts']['taxBasis'], string> = 
 interface FulfillmentPlanTableProps {
   plan: FulfillmentPostingPlan
   currencyCode: string
+  /**
+   * `payment_gateway.clearingAccount` id -> the gateway's name, so a shipment
+   * routed there by `resolveFulfillmentDebit` (brief 13 §5.3) shows which
+   * gateway rather than the generic "Gateway clearing" fallback. Optional -
+   * a caller that has not wired `paymentGateway.list` gets the fallback
+   * everywhere, which is still correct, just less specific.
+   */
+  gatewayNames?: Readonly<Record<string, string>>
 }
 
-export function FulfillmentPlanTable({ plan, currencyCode }: FulfillmentPlanTableProps) {
+const EMPTY_GATEWAY_NAMES: Readonly<Record<string, string>> = {}
+
+export function FulfillmentPlanTable({
+  plan,
+  currencyCode,
+  gatewayNames = EMPTY_GATEWAY_NAMES,
+}: FulfillmentPlanTableProps) {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set<string>())
 
   if (plan.groups.length === 0) {
@@ -125,6 +168,7 @@ export function FulfillmentPlanTable({ plan, currencyCode }: FulfillmentPlanTabl
               key={group.groupKey}
               group={group}
               currencyCode={currencyCode}
+              gatewayNames={gatewayNames}
               open={expanded.has(group.groupKey)}
               onToggle={() => toggle(group.groupKey)}
             />
@@ -139,11 +183,13 @@ export function FulfillmentPlanTable({ plan, currencyCode }: FulfillmentPlanTabl
 function GroupRows({
   group,
   currencyCode,
+  gatewayNames,
   open,
   onToggle,
 }: {
   group: FulfillmentPostingGroup
   currencyCode: string
+  gatewayNames: Readonly<Record<string, string>>
   open: boolean
   onToggle: () => void
 }) {
@@ -194,8 +240,13 @@ function GroupRows({
             <TableCell className='text-xs'>
               <span className='block ps-4 truncate'>{shipment.orderNumber}</span>
               <span className='block ps-4 text-[11px] text-muted-foreground'>
-                Shipment {shipment.sequence} · {DEBIT_ROLE_LABEL[shipment.amounts.debitRole]} ·{' '}
-                {TAX_BASIS_LABEL[shipment.amounts.taxBasis]}
+                Shipment {shipment.sequence} ·{' '}
+                {debitLabel(
+                  shipment.amounts.debitRole,
+                  shipment.amounts.debitGlAccountId,
+                  gatewayNames
+                )}{' '}
+                · {TAX_BASIS_LABEL[shipment.amounts.taxBasis]}
               </span>
             </TableCell>
             <TableCell className='text-muted-foreground text-xs'>

--- a/apps/web/src/components/money/ui/fulfillment-posting/post-fulfillments-dialog.tsx
+++ b/apps/web/src/components/money/ui/fulfillment-posting/post-fulfillments-dialog.tsx
@@ -125,6 +125,19 @@ export function PostFulfillmentsDialog({
   )
 
   const plan = preview.data?.plan ?? null
+
+  // Gateway names keyed by clearing account id, so a shipment routed through a
+  // `payment_gateway` record reads as "Affirm" rather than "Gateway clearing"
+  // (brief 13 §5.3). Two rails may share one clearing account; the last one
+  // listed wins the label, which is a display choice and never a posting one.
+  const gatewaysQuery = api.paymentGateway.list.useQuery(undefined, { enabled: open })
+  const gatewayNames = useMemo(() => {
+    const names: Record<string, string> = {}
+    for (const gateway of gatewaysQuery.data ?? []) {
+      names[gateway.clearingGlAccountId] = gateway.name
+    }
+    return names
+  }, [gatewaysQuery.data])
   const refusal = preview.data?.refusal ?? null
 
   const post = api.money.runFulfillmentPosting.useMutation({
@@ -245,7 +258,11 @@ export function PostFulfillmentsDialog({
                           ? 'flex flex-col gap-4 opacity-60 transition-opacity'
                           : 'flex flex-col gap-4 transition-opacity'
                       }>
-                      <FulfillmentPlanTable plan={plan} currencyCode={currencyCode} />
+                      <FulfillmentPlanTable
+                        plan={plan}
+                        currencyCode={currencyCode}
+                        gatewayNames={gatewayNames}
+                      />
 
                       <FulfillmentExclusions exclusions={plan.exclusions} />
 

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -74,6 +74,7 @@ import { moneyRouter } from './routers/money'
 import { notificationRouter } from './routers/notification'
 import { organizationRouter } from './routers/organization'
 import { participantRouter } from './routers/participant'
+import { paymentGatewaysRouter } from './routers/payment-gateways'
 import { permissionsRouter } from './routers/permissions'
 import { procedureRouter } from './routers/procedure'
 import { promptTemplateRouter } from './routers/promptTemplate'
@@ -184,6 +185,7 @@ export const appRouter = createTRPCRouter({
   notification: notificationRouter,
   organization: organizationRouter,
   participant: participantRouter,
+  paymentGateway: paymentGatewaysRouter,
   permissions: permissionsRouter,
   procedure: procedureRouter,
   promptTemplate: promptTemplateRouter,

--- a/apps/web/src/server/api/routers/banking.ts
+++ b/apps/web/src/server/api/routers/banking.ts
@@ -66,6 +66,8 @@ const bankAccountFields = {
   type: z.enum(BANK_ACCOUNT_TYPES),
   currency: z.string().max(8).nullish(),
   glAccountId: z.string().max(64).nullish(),
+  /** The Stripe `ba_…` / `card_…` destination id a person confirms once (brief 13 §2.3). */
+  stripeExternalAccountId: z.string().max(64).nullish(),
   feedStartDate: dateKey.nullish(),
 }
 
@@ -140,6 +142,7 @@ export const bankingRouter = createTRPCRouter({
           type: bankAccountFields.type.optional(),
           currency: bankAccountFields.currency,
           glAccountId: bankAccountFields.glAccountId,
+          stripeExternalAccountId: bankAccountFields.stripeExternalAccountId,
           feedStartDate: bankAccountFields.feedStartDate,
         })
       )
@@ -174,6 +177,7 @@ export const bankingRouter = createTRPCRouter({
           type: bankAccountFields.type.optional(),
           currency: bankAccountFields.currency,
           glAccountId: bankAccountFields.glAccountId,
+          stripeExternalAccountId: bankAccountFields.stripeExternalAccountId,
           feedStartDate: bankAccountFields.feedStartDate,
           status: z.enum(BANK_ACCOUNT_STATUSES).optional(),
         })

--- a/apps/web/src/server/api/routers/ledger-permissions.test.ts
+++ b/apps/web/src/server/api/routers/ledger-permissions.test.ts
@@ -42,6 +42,12 @@ vi.mock('@auxx/lib/seed', async () => {
   return {
     ...actual,
     seedDefaultChartOfAccounts: vi.fn(async () => ({ created: 0, assigned: 0 })),
+    // Task 13 §5.3: `provisionChart` seeds the two default payment gateways
+    // right after the chart. Mocked the same way its neighbour above is - the
+    // "admit" case only needs `provisionChart` to resolve, not to exercise
+    // `seedDefaultPaymentGateways`'s own `GlRoleAssignment` read against a db
+    // double this file does not otherwise stub.
+    seedDefaultPaymentGateways: vi.fn(async () => ({ created: 0, skipped: 0 })),
   }
 })
 

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -42,7 +42,7 @@ import {
   updateJournalEntry,
   verifyBooksBalance,
 } from '@auxx/lib/postings'
-import { seedDefaultChartOfAccounts } from '@auxx/lib/seed'
+import { seedDefaultChartOfAccounts, seedDefaultPaymentGateways } from '@auxx/lib/seed'
 import { updateOrganizationSetting } from '@auxx/lib/settings'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
@@ -664,7 +664,15 @@ export const ledgerRouter = createTRPCRouter({
       )
     }
 
-    return await seedDefaultChartOfAccounts(ctx.db, organizationId, glAccountDefId)
+    const chart = await seedDefaultChartOfAccounts(ctx.db, organizationId, glAccountDefId)
+
+    // Task 13 §5.3: the two default `payment_gateway` records the census
+    // names. Runs AFTER the chart on purpose - the clearing accounts these
+    // defaults point at (`clearing_card` / `clearing_affirm`) only exist once
+    // the chart above has just created or confirmed them.
+    const paymentGateways = await seedDefaultPaymentGateways(ctx.db, organizationId)
+
+    return { ...chart, paymentGateways }
   }),
 
   /**

--- a/apps/web/src/server/api/routers/payment-gateways.ts
+++ b/apps/web/src/server/api/routers/payment-gateways.ts
@@ -1,0 +1,126 @@
+// apps/web/src/server/api/routers/payment-gateways.ts
+//
+// Payment gateways: a record carrying its own clearing account, never a role
+// (plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md §5.3). Mounted
+// as `paymentGateway` in `root.ts`.
+//
+// 🛑 Reads are `ledgerView`. Writes are `ledgerControl`, the same rung
+// `banking.ts`'s `bankAccount.create`/`update` use: a gateway's clearing
+// account decides where card and BNPL money lands on the balance sheet, which
+// is a rung above ordinary bookkeeping (`ledgerPost`).
+//
+// 🛑 Every refusal reaches the browser as an `AuxxError` verbatim (HANDOFF
+// ground rule 9). `assertClearingAccount`/`assertHandlesAvailable` in
+// `writes.ts` already say which account or which handle is wrong; a second
+// authority here would drift from it.
+
+import {
+  archivePaymentGateway,
+  createPaymentGateway,
+  listPaymentGateways,
+  PAYMENT_GATEWAY_SETTLEMENT_SOURCES,
+  updatePaymentGateway,
+} from '@auxx/lib/payment-gateways'
+import { PermissionKey } from '@auxx/lib/permissions'
+import { z } from 'zod'
+import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
+
+/** `YYYY-MM-DD`. Shape only; the lib decides what is a sensible date. */
+const dateKey = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
+
+/**
+ * The fields a person may set on a payment gateway. Deliberately thin -
+ * `clearingAccountId`/`feeAccountId` name a `gl_account` instance id (task 15
+ * §4 shape), and the lib refuses an unknown, inactive or wrongly-typed one at
+ * write time, naming the account.
+ */
+const paymentGatewayFields = {
+  name: z.string().min(1).max(200),
+  handles: z.array(z.string().min(1).max(64)).min(1),
+  clearingAccountId: z.string().min(1).max(64),
+  feeAccountId: z.string().max(64).nullish(),
+  settlementSource: z.enum(PAYMENT_GATEWAY_SETTLEMENT_SOURCES),
+  lastSettlementAt: dateKey.nullish(),
+}
+
+export const paymentGatewaysRouter = createTRPCRouter({
+  /** Every payment gateway in the org, oldest first. */
+  list: permissionProcedure(PermissionKey.ledgerView)
+    .input(z.object({ includeArchived: z.boolean().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      const result = await listPaymentGateways(ctx.db, ctx.session.organizationId, {
+        includeArchived: input?.includeArchived,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Add a gateway by hand.
+   *
+   * Gated on `ledgerControl`: the clearing account decides where cash lands,
+   * the same reasoning `banking.ts`'s `bankAccount.create` gives.
+   */
+  create: permissionProcedure(PermissionKey.ledgerControl)
+    .input(
+      z.object({
+        name: paymentGatewayFields.name,
+        handles: paymentGatewayFields.handles,
+        clearingAccountId: paymentGatewayFields.clearingAccountId,
+        feeAccountId: paymentGatewayFields.feeAccountId,
+        settlementSource: paymentGatewayFields.settlementSource.optional(),
+        lastSettlementAt: paymentGatewayFields.lastSettlementAt,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const result = await createPaymentGateway(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+        ...input,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /** Edit a gateway. Gated on `ledgerControl`, same reasoning as {@link create}. */
+  update: permissionProcedure(PermissionKey.ledgerControl)
+    .input(
+      z.object({
+        id: z.string().min(1),
+        name: paymentGatewayFields.name.optional(),
+        handles: paymentGatewayFields.handles.optional(),
+        clearingAccountId: paymentGatewayFields.clearingAccountId.optional(),
+        feeAccountId: paymentGatewayFields.feeAccountId,
+        settlementSource: paymentGatewayFields.settlementSource.optional(),
+        lastSettlementAt: paymentGatewayFields.lastSettlementAt,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...patch } = input
+      const result = await updatePaymentGateway(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+        paymentGatewayId: id,
+        ...patch,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Mark a gateway closed. Not a delete - a rail is not permanent (§5.1:
+   * Authorize.Net closed May 2026 with a clearing balance still winding down),
+   * and a closed gateway still routes its own posting history.
+   */
+  archive: permissionProcedure(PermissionKey.ledgerControl)
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const result = await archivePaymentGateway(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+        paymentGatewayId: input.id,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+})

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -172,6 +172,10 @@ export const ModelTypeValues = [
   // The draft of a hand-authored posting, and the holder of the opening trial
   // balance (plans/accounting/tasks/02-manual-journal-entry.md).
   'journal_entry',
+  // A record carrying its clearing account, never a role
+  // (plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md §5.3). Entity
+  // migration 146.
+  'payment_gateway',
 ] as const
 
 /**
@@ -230,6 +234,7 @@ export const ModelTypes = {
   TARIFF_CODE: 'tariff_code',
   TARIFF_RATE: 'tariff_rate',
   JOURNAL_ENTRY: 'journal_entry',
+  PAYMENT_GATEWAY: 'payment_gateway',
 } as const
 
 /**
@@ -686,6 +691,18 @@ export const ModelTypeMeta: Record<
     // The drawer on the ledger page is the door (`?je=`), not a hand-authored
     // `/app/journal-entries/[id]` route. There is none, and claiming one here
     // puts a fullscreen button on the drawer that 404s.
+    hasDetailPage: false,
+  },
+  payment_gateway: {
+    label: 'Payment Gateway',
+    plural: 'Payment Gateways',
+    icon: 'credit-card',
+    color: 'indigo',
+    apiSlug: 'payment-gateways',
+    dbTable: 'EntityInstance',
+    // The door is Accounting > Settings > Payment gateways (task 13 §5.3), a
+    // master-detail settings page. There is no `/app/payment-gateways/[id]`
+    // route, same reasoning as `bank_account`.
     hasDetailPage: false,
   },
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1036,6 +1036,18 @@
       "import": "./dist/participants/search/index.mjs",
       "default": "./src/participants/search/index.ts"
     },
+    "./payment-gateways": {
+      "types": "./src/payment-gateways/index.ts",
+      "source": "./src/payment-gateways/index.ts",
+      "import": "./dist/payment-gateways/index.mjs",
+      "default": "./src/payment-gateways/index.ts"
+    },
+    "./payment-gateways/client": {
+      "types": "./src/payment-gateways/client.ts",
+      "source": "./src/payment-gateways/client.ts",
+      "import": "./dist/payment-gateways/client.mjs",
+      "default": "./src/payment-gateways/client.ts"
+    },
     "./permissions": {
       "types": "./src/permissions/index.ts",
       "source": "./src/permissions/index.ts",

--- a/packages/lib/src/banking/__tests__/removal-writes.test.ts
+++ b/packages/lib/src/banking/__tests__/removal-writes.test.ts
@@ -127,6 +127,7 @@ function account(partial: Partial<BankAccountRow> = {}): BankAccountRow {
     type: 'depository',
     currency: 'USD',
     glAccountId: '1010',
+    stripeExternalAccountId: null,
     feedStartDate: null,
     coverageFrom: '2026-01-01',
     coverageGaps: [],

--- a/packages/lib/src/banking/client.ts
+++ b/packages/lib/src/banking/client.ts
@@ -251,6 +251,12 @@ export interface BankAccountRow {
   currency: string | null
   /** The `gl_account` instance id this account maps to (task 15 §4). No foreign key. */
   glAccountId: string | null
+  /**
+   * The Stripe `ba_…` / `card_…` destination id, confirmed once by a person
+   * (brief 13 §2.3). Null until confirmed - a payout settling here refuses to
+   * post rather than matching on `last4`.
+   */
+  stripeExternalAccountId: string | null
   feedStartDate: string | null
   coverageFrom: string | null
   coverageGaps: CoverageGap[]

--- a/packages/lib/src/banking/reads.ts
+++ b/packages/lib/src/banking/reads.ts
@@ -50,6 +50,7 @@ const BANK_ACCOUNT_ATTRIBUTES = [
   'bank_account_type',
   'bank_account_currency',
   'bank_account_gl_account',
+  'bank_account_stripe_external_account_id',
   'bank_account_feed_start_date',
   'bank_account_coverage_from',
   'bank_account_coverage_gaps',
@@ -703,6 +704,8 @@ async function hydrateBankAccounts(
       type: resolveBankAccountType(read(row.id, 'bank_account_type')?.optionId),
       currency: read(row.id, 'bank_account_currency')?.valueText ?? null,
       glAccountId: read(row.id, 'bank_account_gl_account')?.valueText ?? null,
+      stripeExternalAccountId:
+        read(row.id, 'bank_account_stripe_external_account_id')?.valueText ?? null,
       feedStartDate: feedStartDate ? toDateKey(feedStartDate) : null,
       coverageFrom: coverageFrom ? toDateKey(coverageFrom) : null,
       coverageGaps: normalizeCoverageGaps(read(row.id, 'bank_account_coverage_gaps')?.valueJson),

--- a/packages/lib/src/banking/writes.ts
+++ b/packages/lib/src/banking/writes.ts
@@ -103,6 +103,8 @@ export interface CreateBankAccountInput {
   currency?: string | null
   /** The `gl_account` instance id this account maps to (task 15 §4). Never a code. */
   glAccountId?: string | null
+  /** The Stripe destination id, confirmed once by a person (brief 13 §2.3). */
+  stripeExternalAccountId?: string | null
   feedStartDate?: string | null
 }
 
@@ -118,6 +120,8 @@ export interface UpdateBankAccountInput {
   currency?: string | null
   /** The `gl_account` instance id this account maps to (task 15 §4). Never a code. */
   glAccountId?: string | null
+  /** The Stripe destination id, confirmed once by a person (brief 13 §2.3). */
+  stripeExternalAccountId?: string | null
   feedStartDate?: string | null
   status?: BankAccountStatus
 }
@@ -165,6 +169,7 @@ export async function createBankAccount(
         bank_account_type: type,
         bank_account_currency: input.currency?.trim().toUpperCase() || 'USD',
         bank_account_gl_account: input.glAccountId?.trim() || undefined,
+        bank_account_stripe_external_account_id: input.stripeExternalAccountId?.trim() || undefined,
         bank_account_feed_start_date: input.feedStartDate || undefined,
         bank_account_status: 'manual',
       })
@@ -257,6 +262,10 @@ export async function updateBankAccount(
 
       if (input.glAccountId !== undefined) {
         patch.bank_account_gl_account = input.glAccountId?.trim() || null
+      }
+      if (input.stripeExternalAccountId !== undefined) {
+        patch.bank_account_stripe_external_account_id =
+          input.stripeExternalAccountId?.trim() || null
       }
       if (input.feedStartDate !== undefined) {
         patch.bank_account_feed_start_date = input.feedStartDate || null

--- a/packages/lib/src/money/fulfillment-posting/__tests__/load-gateway-routes.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/load-gateway-routes.test.ts
@@ -1,0 +1,66 @@
+// packages/lib/src/money/fulfillment-posting/__tests__/load-gateway-routes.test.ts
+//
+// `loadGatewayRoutesForPlan` is the one database read `planFulfillmentPosting`
+// itself must never take on (this file's own header: PURE, no db). It is a
+// thin wrapper over `payment-gateways/reads.ts` + `client.ts`'s
+// `toGatewayRoutes`, so this only pins the two edges: an org with no
+// `payment_gateway` rows (or an unmigrated one) gets an empty table rather
+// than a throw.
+
+import { describe, expect, it, vi } from 'vitest'
+
+interface FakeResult {
+  isOk: () => boolean
+  isErr: () => boolean
+  value: unknown[]
+}
+
+const h = vi.hoisted(() => ({
+  result: { isOk: () => true, isErr: () => false, value: [] } as FakeResult,
+}))
+
+vi.mock('../../../payment-gateways', () => ({
+  listPaymentGateways: async () => h.result,
+  toGatewayRoutes: (rows: { handles: string[]; clearingGlAccountId: string; status: string }[]) =>
+    rows.map((row) => ({
+      handles: row.handles,
+      clearingGlAccountId: row.clearingGlAccountId,
+      active: row.status === 'active',
+    })),
+}))
+
+const { loadGatewayRoutesForPlan } = await import('../plan')
+
+describe('loadGatewayRoutesForPlan', () => {
+  it('returns an empty table when the org has no payment gateways', async () => {
+    h.result = { isOk: () => true, isErr: () => false, value: [] }
+    const routes = await loadGatewayRoutesForPlan({} as never, 'org_1')
+    expect(routes).toEqual([])
+  })
+
+  it('returns an empty table rather than throwing when the read fails', async () => {
+    h.result = { isOk: () => false, isErr: () => true, value: [] }
+    const routes = await loadGatewayRoutesForPlan({} as never, 'org_1')
+    expect(routes).toEqual([])
+  })
+
+  it('maps rows through toGatewayRoutes, active and closed alike', async () => {
+    h.result = {
+      isOk: () => true,
+      isErr: () => false,
+      value: [
+        {
+          handles: ['authorize_net', 'authorize.net'],
+          clearingGlAccountId: 'acct_1',
+          status: 'closed',
+        },
+        { handles: ['affirm'], clearingGlAccountId: 'acct_2', status: 'active' },
+      ],
+    }
+    const routes = await loadGatewayRoutesForPlan({} as never, 'org_1')
+    expect(routes).toEqual([
+      { handles: ['authorize_net', 'authorize.net'], clearingGlAccountId: 'acct_1', active: false },
+      { handles: ['affirm'], clearingGlAccountId: 'acct_2', active: true },
+    ])
+  })
+})

--- a/packages/lib/src/money/fulfillment-posting/__tests__/plan.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/plan.test.ts
@@ -13,6 +13,7 @@
 // Amounts are integer minor units: 12_000 = $120.00.
 
 import { describe, expect, it } from 'vitest'
+import type { GatewayRoute } from '../../../payment-gateways/client'
 import { groupKeyFor, isoWeekKey, planFulfillmentPosting } from '../plan'
 import type {
   FulfillmentPostingGrouping,
@@ -48,13 +49,16 @@ function shipment(overrides: Partial<UnpostedShipment> = {}): UnpostedShipment {
     priorShipmentsSubtotalMinor: 0,
     includeShipping: false,
     contactId: 'ct_1',
+    taxLines: [],
     ...overrides,
   }
 }
 
 function plan(
   shipments: UnpostedShipment[],
-  overrides: Partial<Omit<FulfillmentPostingPlanInput, 'shipments'>> = {}
+  overrides: Partial<
+    Omit<FulfillmentPostingPlanInput, 'shipments'> & { gatewayRoutes: readonly GatewayRoute[] }
+  > = {}
 ) {
   return planFulfillmentPosting({
     shipments,
@@ -358,6 +362,7 @@ describe('totals and the debit split', () => {
       clearing_card: 10_000,
       clearing_affirm: 10_000,
       accounts_receivable: 10_000,
+      gateway: 0,
     })
   })
 
@@ -515,5 +520,54 @@ describe('what the plan does NOT know', () => {
     const reoffered = plan([shipment({ orderId: 'a', orderNumber: '#1' })])
 
     expect(reoffered).toEqual(fresh)
+  })
+})
+
+describe('gatewayRoutes (brief 13 §5.3)', () => {
+  const authNetRoute: GatewayRoute = {
+    handles: ['authorize_net', 'authorize.net'],
+    clearingGlAccountId: 'acct_authnet_clearing',
+    active: false,
+  }
+
+  it('debits a payment_gateway route instead of the role default when exactly one route matches', () => {
+    const result = plan(
+      [shipment({ orderId: 'a', orderNumber: '#1', gateways: ['Authorize.Net'] })],
+      { gatewayRoutes: [authNetRoute] }
+    )
+
+    const posted = result.groups[0]?.shipments[0]
+    expect(posted?.amounts.debitRole).toBe('gateway')
+    expect(posted?.amounts.debitGlAccountId).toBe('acct_authnet_clearing')
+    // The role buckets stay zero; the id-based debit is counted under `gateway`.
+    expect(result.groups[0]?.totals.byDebitRole).toEqual({
+      clearing_card: 0,
+      clearing_affirm: 0,
+      accounts_receivable: 0,
+      gateway: 10_000,
+    })
+  })
+
+  it('a closed route still routes its own history (active does not gate the match)', () => {
+    const result = plan(
+      [shipment({ orderId: 'a', orderNumber: '#1', gateways: ['authorize_net'] })],
+      { gatewayRoutes: [authNetRoute] }
+    )
+    expect(result.groups[0]?.shipments[0]?.amounts.debitGlAccountId).toBe('acct_authnet_clearing')
+  })
+
+  it('falls back to the role default when no route names the gateway', () => {
+    const result = plan([shipment({ orderId: 'a', orderNumber: '#1' })], {
+      gatewayRoutes: [authNetRoute],
+    })
+    const posted = result.groups[0]?.shipments[0]
+    expect(posted?.amounts.debitRole).toBe('clearing_card')
+    expect(posted?.amounts.debitGlAccountId).toBeUndefined()
+  })
+
+  it('omitting gatewayRoutes entirely reproduces the role-only plan', () => {
+    const withRoutes = plan([shipment({ orderId: 'a', orderNumber: '#1' })], { gatewayRoutes: [] })
+    const withoutRoutes = plan([shipment({ orderId: 'a', orderNumber: '#1' })])
+    expect(withRoutes).toEqual(withoutRoutes)
   })
 })

--- a/packages/lib/src/money/fulfillment-posting/__tests__/reads.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/reads.test.ts
@@ -20,6 +20,8 @@ const h = vi.hoisted(() => ({
   executeRows: [] as unknown[],
   selects: [] as unknown[][],
   contextMissing: false,
+  // brief 13 §5: per-order tax lines the mocked `readOrderTaxLines` returns.
+  taxLinesByOrder: new Map<string, Array<{ title: string; priceMinor: number }>>(),
 }))
 
 const FIELD_IDS = {
@@ -64,6 +66,10 @@ vi.mock('../../orders/reads', async () => {
       const all = Object.fromEntries(entries)
       return { orderDefId: 'def_order', order: all, line: all }
     },
+    // Empty by default (brief 13 §5) - no test in this file is about the
+    // jurisdiction split, which `split-tax-by-jurisdiction.test.ts` owns. A
+    // test that cares sets `h.taxLinesByOrder`.
+    readOrderTaxLines: async () => h.taxLinesByOrder,
   }
 })
 
@@ -191,6 +197,7 @@ beforeEach(() => {
   h.executeRows = []
   h.selects = []
   h.contextMissing = false
+  h.taxLinesByOrder = new Map()
 })
 
 describe('the netting statement', () => {
@@ -288,7 +295,33 @@ describe('readUnpostedShipments', () => {
         priorShipmentsSubtotalMinor: 0,
         includeShipping: false,
         contactId: 'ct_1',
+        // Empty: the mocked `readOrderTaxLines` returns nothing (brief 13 §5).
+        taxLines: [],
       },
+    ])
+  })
+
+  // brief 13 §5: the bulk tax-line read is threaded onto the shipment it
+  // belongs to, verbatim - the split itself is `splitTaxByJurisdiction`'s job.
+  it('carries the order own tax lines onto its shipment', async () => {
+    h.taxLinesByOrder = new Map([
+      [
+        'ord_1',
+        [
+          { title: 'CA State Tax', priceMinor: 600 },
+          { title: 'CA District Tax', priceMinor: 200 },
+        ],
+      ],
+    ])
+
+    const result = await readUnpostedShipments(stubDb(), {
+      organizationId: ORG,
+      range: { from: '2026-07-01', to: '2026-08-01' },
+    })
+
+    expect(result._unsafeUnwrap()[0]?.taxLines).toEqual([
+      { title: 'CA State Tax', priceMinor: 600 },
+      { title: 'CA District Tax', priceMinor: 200 },
     ])
   })
 

--- a/packages/lib/src/money/fulfillment-posting/__tests__/run.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/run.test.ts
@@ -146,6 +146,7 @@ function shipment(overrides: Partial<UnpostedShipment> = {}): UnpostedShipment {
     priorShipmentsSubtotalMinor: 0,
     includeShipping: false,
     contactId: null,
+    taxLines: [],
     ...overrides,
   }
 }

--- a/packages/lib/src/money/fulfillment-posting/plan.ts
+++ b/packages/lib/src/money/fulfillment-posting/plan.ts
@@ -42,11 +42,15 @@
  * local is how a shipment moves a day and lands in the wrong month.
  */
 
+import type { Database } from '@auxx/database'
+import { listPaymentGateways, toGatewayRoutes } from '../../payment-gateways'
+import type { GatewayRoute } from '../../payment-gateways/client'
 import {
   computeShipmentAmounts,
   resolveFulfillmentDebit,
 } from '../../postings/build-fulfillment-batch-entry'
 import type {
+  FulfillmentDebit,
   FulfillmentDebitRole,
   FulfillmentPostingExclusion,
   FulfillmentPostingGroup,
@@ -56,6 +60,31 @@ import type {
   PlannedShipment,
   UnpostedShipment,
 } from './types'
+
+/**
+ * Load the org's `payment_gateway` routing table, for
+ * {@link planFulfillmentPosting}'s `gatewayRoutes` input (brief 13 §5.3).
+ *
+ * 🛑 **Not part of the pure planner.** `planFulfillmentPosting` stays PURE -
+ * no db, no clock, no settings read (this file's own header) - so the ONE
+ * database read this contract needs lives here, in a function a caller awaits
+ * ONCE PER PLAN and passes the result into the pure call, never inside a loop
+ * over shipments. `reads.ts`'s `previewFulfillmentPosting` and `run.ts`'s
+ * runner are the two callers; both already load `readFulfillmentPostingSettings`
+ * the same way beside this.
+ *
+ * Empty on any read failure or on an org that has not provisioned
+ * `payment_gateway` yet (entity migration 146) - `resolveFulfillmentDebit`'s
+ * `gatewayRoutes` is optional and an empty table falls every gateway back to
+ * its role default, which is exactly today's behaviour.
+ */
+export async function loadGatewayRoutesForPlan(
+  db: Database,
+  organizationId: string
+): Promise<readonly GatewayRoute[]> {
+  const result = await listPaymentGateways(db, organizationId)
+  return result.isOk() ? toGatewayRoutes(result.value) : []
+}
 
 /**
  * Decide what the run would post.
@@ -69,9 +98,17 @@ import type {
  * or an unparseable date: an amount the builder refuses to compute is reported
  * as an exclusion rather than taken out on the rest of the range. That matters
  * more here than in the single-order door, where one refusal costs one order.
+ *
+ * `gatewayRoutes` (brief 13 §5.3) is optional and not part of
+ * `FulfillmentPostingPlanInput` itself - it is threaded straight through to
+ * {@link resolveFulfillmentDebit} unchanged, so a caller that omits it (or
+ * whose `payment_gateway` def is not provisioned yet) gets exactly today's
+ * role-only behaviour. Load it once per plan with {@link loadGatewayRoutesForPlan}.
  */
-export function planFulfillmentPosting(input: FulfillmentPostingPlanInput): FulfillmentPostingPlan {
-  const { grouping, cutoffPeriod, lockedThroughMonth, ledgerCurrency } = input
+export function planFulfillmentPosting(
+  input: FulfillmentPostingPlanInput & { gatewayRoutes?: readonly GatewayRoute[] }
+): FulfillmentPostingPlan {
+  const { grouping, cutoffPeriod, lockedThroughMonth, ledgerCurrency, gatewayRoutes } = input
 
   const exclusions: FulfillmentPostingExclusion[] = []
   const byGroupKey = new Map<string, PlannedShipment[]>()
@@ -98,13 +135,18 @@ export function planFulfillmentPosting(input: FulfillmentPostingPlanInput): Fulf
     const debit = resolveFulfillmentDebit({
       financialStatus: shipment.financialStatus,
       gateways: shipment.gateways,
+      gatewayRoutes,
     })
     if (debit.kind === 'exclude') {
       exclusions.push(exclude(shipment, debit.reason, debit.detail))
       continue
     }
 
-    const computed = computeAmounts(shipment, debit.role)
+    // Strip the `kind` discriminant `resolveFulfillmentDebit` adds -
+    // `computeShipmentAmounts` takes the bare `FulfillmentDebit` union.
+    const debitInput: FulfillmentDebit =
+      'glAccountId' in debit ? { glAccountId: debit.glAccountId } : { role: debit.role }
+    const computed = computeAmounts(shipment, debitInput)
     if (!computed.ok) {
       // 🛑 Classified as `zero-value` on purpose. The reason set is CLOSED
       // (types.ts), and a shipment whose amounts cannot be computed contributes
@@ -202,6 +244,10 @@ function toGroup(groupKey: string, shipments: PlannedShipment[]): FulfillmentPos
     clearing_card: 0,
     clearing_affirm: 0,
     accounts_receivable: 0,
+    // Every id-based (`payment_gateway` route) debit lands here, whichever
+    // account it named - the account id itself rides on the shipment's own
+    // `amounts.debitGlAccountId` (brief 13 §5.3, types.ts's header).
+    gateway: 0,
   }
   let subtotalMinor = 0
   let taxMinor = 0
@@ -246,10 +292,10 @@ function toGroup(groupKey: string, shipments: PlannedShipment[]): FulfillmentPos
  */
 function computeAmounts(
   shipment: UnpostedShipment,
-  role: FulfillmentDebitRole
+  debit: FulfillmentDebit
 ): { ok: true; amounts: PlannedShipment['amounts'] } | { ok: false; reason: string } {
   try {
-    return { ok: true, amounts: computeShipmentAmounts(shipment, role) }
+    return { ok: true, amounts: computeShipmentAmounts(shipment, debit) }
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) }
   }

--- a/packages/lib/src/money/fulfillment-posting/reads.ts
+++ b/packages/lib/src/money/fulfillment-posting/reads.ts
@@ -48,10 +48,11 @@ import { getOrganizationSetting } from '../../settings/settings-service'
 import {
   type OrderFieldContext,
   parseFulfillments,
+  readOrderTaxLines,
   requireOrderFieldContext,
 } from '../orders/reads'
 import { guard } from './guard'
-import { planFulfillmentPosting } from './plan'
+import { loadGatewayRoutesForPlan, planFulfillmentPosting } from './plan'
 import type {
   FulfillmentPostingExclusionReason,
   FulfillmentPostingPlan,
@@ -229,9 +230,11 @@ export async function readUnpostedShipments(
       const logLines = rows.map((row) => parseLogLines(row.lines))
       const lineIds = [...new Set(logLines.flatMap((lines) => lines.map((line) => line.lineId)))]
 
-      const [orders, lines] = await Promise.all([
+      const [orders, lines, taxLinesByOrder] = await Promise.all([
         readOrderFacts(db, organizationId, ctx, orderIds),
         readLineFacts(db, organizationId, ctx, lineIds),
+        // ONE bulk read for the whole batch, never per order (brief 13 §5).
+        readOrderTaxLines(db, organizationId, orderIds),
       ])
 
       const shipments: UnpostedShipment[] = []
@@ -261,6 +264,7 @@ export async function readUnpostedShipments(
           priorShipmentsSubtotalMinor: finite(row.prior_subtotal_minor),
           includeShipping: row.shipping_recognised === true,
           contactId: order.contactId,
+          taxLines: taxLinesByOrder.get(row.order_id) ?? [],
         })
       }
       return shipments
@@ -316,10 +320,14 @@ export async function countUnpostedShipments(
       })
       if (shipments.isErr()) throw shipments.error
       if (shipments.value.length === 0) return 0
-      const settings = await readFulfillmentPostingSettings(db, organizationId)
+      const [settings, gatewayRoutes] = await Promise.all([
+        readFulfillmentPostingSettings(db, organizationId),
+        loadGatewayRoutesForPlan(db, organizationId),
+      ])
       if (settings.isErr()) throw settings.error
       const plan = planFulfillmentPosting({
         shipments: shipments.value,
+        gatewayRoutes,
         grouping: 'day',
         cutoffPeriod: settings.value.cutoffPeriod,
         lockedThroughMonth: settings.value.lockedThroughMonth,

--- a/packages/lib/src/money/fulfillment-posting/run.ts
+++ b/packages/lib/src/money/fulfillment-posting/run.ts
@@ -60,7 +60,7 @@ import {
 import { getOrganizationSetting } from '../../settings/settings-service'
 import { stampFulfillment } from '../orders/fulfill'
 import { guard } from './guard'
-import { planFulfillmentPosting } from './plan'
+import { loadGatewayRoutesForPlan, planFulfillmentPosting } from './plan'
 import { readFulfillmentPostingSettings, readUnpostedShipments } from './reads'
 import type {
   FulfillmentPostingGroup,
@@ -270,11 +270,15 @@ async function prepare(db: Database, request: FulfillmentPostingRequest): Promis
 
   const refusal = resolveRefusal(setupState, settings.timeZone)
 
-  const shipmentsResult = await readUnpostedShipments(db, { organizationId, range })
+  const [shipmentsResult, gatewayRoutes] = await Promise.all([
+    readUnpostedShipments(db, { organizationId, range }),
+    loadGatewayRoutesForPlan(db, organizationId),
+  ])
   if (shipmentsResult.isErr()) throw shipmentsResult.error
 
   const plan = planFulfillmentPosting({
     shipments: shipmentsResult.value,
+    gatewayRoutes,
     grouping,
     cutoffPeriod: settings.cutoffPeriod,
     lockedThroughMonth: settings.lockedThroughMonth,

--- a/packages/lib/src/money/fulfillment-posting/types.ts
+++ b/packages/lib/src/money/fulfillment-posting/types.ts
@@ -34,8 +34,30 @@ export const FULFILLMENT_POSTING_GROUPINGS: readonly FulfillmentPostingGrouping[
  * Decided per shipment from the order's financial status and gateways, never
  * from the channel. A card order was paid at checkout and the payout entry
  * drains clearing; a terms order owes, and aging names the debtor.
+ *
+ * 🛑 **`'gateway'`, added by brief 13 §5.3, is not a fourth account.** It is
+ * the bucket a shipment falls into when its gateway resolved to a
+ * `payment_gateway` record's own clearing account id rather than to one of the
+ * three roles below - see {@link FulfillmentDebit}. `byDebitRole` summaries
+ * (this file's own `FulfillmentPostingGroup.totals.byDebitRole` and the
+ * builder's `BuiltFulfillmentBatchEntry.totals.byDebitRole`) keep working
+ * unchanged by counting every id-based debit under this one key; the actual
+ * account id rides on `ShipmentAmounts.debitGlAccountId`.
  */
-export type FulfillmentDebitRole = 'clearing_card' | 'clearing_affirm' | 'accounts_receivable'
+export type FulfillmentDebitRole =
+  | 'clearing_card'
+  | 'clearing_affirm'
+  | 'accounts_receivable'
+  | 'gateway'
+
+/**
+ * What a shipment debits: a declared ROLE, or a `payment_gateway` record's own
+ * clearing account id (brief 13 §5.3's contract - `build-entry.ts`'s header:
+ * "a gateway does not get a role").
+ */
+export type FulfillmentDebit =
+  | { role: Exclude<FulfillmentDebitRole, 'gateway'> }
+  | { glAccountId: string }
 
 /**
  * Why a shipment in the range produces no posting.
@@ -117,6 +139,14 @@ export interface UnpostedShipment {
    * `accounts_receivable` line - never onto a summarised line.
    */
   contactId: string | null
+  /**
+   * The order's own `tax_line` rows - one per jurisdiction (brief 13 §5).
+   * Empty when the org has none, or the org predates entity migration for
+   * `tax_line`. Used to split this shipment's `sales_tax_payable` credit
+   * across jurisdictions when they tie to `orderTaxTotalMinor` - see
+   * `postings/split-tax-by-jurisdiction.ts`.
+   */
+  taxLines: readonly { title: string; priceMinor: number }[]
 }
 
 /** Everything the pure plan is allowed to see. No db, no clock, no settings. */
@@ -136,8 +166,21 @@ export interface FulfillmentPostingPlanInput {
 /** The amounts one shipment contributes, all integer minor units. */
 export interface ShipmentAmounts {
   debitRole: FulfillmentDebitRole
+  /**
+   * The `payment_gateway` record's own clearing account id, set only when
+   * `debitRole` is `'gateway'` (brief 13 §5.3). Absent for the three declared
+   * roles.
+   */
+  debitGlAccountId?: string
   subtotalMinor: number
   taxMinor: number
+  /**
+   * `taxMinor` split across jurisdictions, when the order's own `tax_line`
+   * rows tie to its total (brief 13 §5). Absent when there is nothing to
+   * split or the split does not tie - the caller then credits `taxMinor` as
+   * one undimensioned line, same as before this existed.
+   */
+  taxByJurisdiction?: Array<{ jurisdiction: string; amountMinor: number }>
   shippingMinor: number
   totalMinor: number
   taxBasis: 'per_line' | 'allocated'

--- a/packages/lib/src/money/orders/fulfill.ts
+++ b/packages/lib/src/money/orders/fulfill.ts
@@ -307,6 +307,7 @@ function buildForOrder(
     priorShipmentsSubtotalMinor: shippedSubtotalMinor(order.fulfillments),
     includeShipping: order.shippingOwed,
     contactInstanceId: order.contactInstanceId,
+    taxLines: order.taxLines,
     // 🛑 DARK. See `build-fulfillment-entry.ts`'s header: a per-fulfillment COGS
     // leg is a second writer of `inventory_finished_goods`, which the L1
     // month-end entry asserts. It turns on with the rest of L3, as ONE change.
@@ -365,6 +366,7 @@ export async function fulfillOrder(
             includeShipping: order.shippingOwed,
             includeCogs: false,
             contactInstanceId: order.contactInstanceId,
+            taxLines: order.taxLines,
           })
         : undefined
       const amounts: ShipmentTotals =

--- a/packages/lib/src/money/orders/reads.ts
+++ b/packages/lib/src/money/orders/reads.ts
@@ -76,6 +76,16 @@ const LINE_ATTRIBUTES = [
 type OrderAttribute = (typeof ORDER_ATTRIBUTES)[number]
 type LineAttribute = (typeof LINE_ATTRIBUTES)[number]
 
+/** Every `tax_line` attribute the jurisdiction split reads (brief 13 §5). */
+const TAX_LINE_ATTRIBUTES = ['tax_line_title', 'tax_line_price', 'tax_line_order'] as const
+type TaxLineAttribute = (typeof TAX_LINE_ATTRIBUTES)[number]
+
+/** One order's jurisdiction, as `splitTaxByJurisdiction` wants it. */
+export interface OrderTaxLine {
+  title: string
+  priceMinor: number
+}
+
 /**
  * The resolved def and fields every order read needs.
  *
@@ -157,6 +167,103 @@ export interface OrderForFulfillment {
    * the fulfillment entry's `accounts_receivable` line (brief 13 §1.2).
    */
   contactInstanceId: string | null
+  /**
+   * The order's own `tax_line` rows - one per jurisdiction (brief 13 §5).
+   * Empty when the org has none, or predates entity migration 136. Splits the
+   * `sales_tax_payable` credit across jurisdictions when they tie to
+   * `taxTotalMinor` - see `postings/split-tax-by-jurisdiction.ts`.
+   */
+  taxLines: OrderTaxLine[]
+}
+
+/**
+ * Every named order's own tax lines, in ONE bulk read - never one query per
+ * order (brief 13 §5).
+ *
+ * Two statements regardless of how many orders are asked for: the first finds
+ * which `tax_line` instances belong to these orders (the `tax_line_order`
+ * edge), the second reads `title` and `price` for exactly those instances.
+ * Both are empty reads, not refusals, when the org has no `tax_line` def yet
+ * (pre-migration-136) - the caller then falls back to the single undimensioned
+ * tax line, which is `splitTaxByJurisdiction`'s documented behaviour for "no
+ * tax lines at all".
+ */
+export async function readOrderTaxLines(
+  db: Database,
+  organizationId: string,
+  orderIds: readonly string[]
+): Promise<Map<string, OrderTaxLine[]>> {
+  const byOrder = new Map<string, OrderTaxLine[]>()
+  if (orderIds.length === 0) return byOrder
+
+  const fields = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...TAX_LINE_ATTRIBUTES])
+  const attrs = fields as Record<TaxLineAttribute, CustomFieldEntity | null>
+  const titleField = attrs.tax_line_title
+  const priceField = attrs.tax_line_price
+  const orderField = attrs.tax_line_order
+  if (!titleField || !priceField || !orderField) return byOrder
+
+  // Hop 1: which tax_line instances belong to these orders.
+  const edgeRows = await db
+    .select({
+      taxLineId: schema.FieldValue.entityId,
+      orderId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, orderField.id),
+        inArray(schema.FieldValue.relatedEntityId, [...orderIds])
+      )
+    )
+  if (edgeRows.length === 0) return byOrder
+
+  const orderIdByTaxLine = new Map<string, string>()
+  for (const row of edgeRows) {
+    if (row.orderId) orderIdByTaxLine.set(row.taxLineId, row.orderId)
+  }
+  const taxLineIds = [...orderIdByTaxLine.keys()]
+  if (taxLineIds.length === 0) return byOrder
+
+  // Hop 2: title and price for exactly those tax lines, in one query.
+  const valueRows = await db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+      valueNumber: schema.FieldValue.valueNumber,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.entityId, taxLineIds),
+        inArray(schema.FieldValue.fieldId, [titleField.id, priceField.id])
+      )
+    )
+
+  const byTaxLine = new Map<string, { title?: string; priceMinor?: number }>()
+  for (const row of valueRows) {
+    const entry = byTaxLine.get(row.entityId) ?? {}
+    if (row.fieldId === titleField.id) entry.title = row.valueText ?? undefined
+    if (row.fieldId === priceField.id) entry.priceMinor = row.valueNumber ?? undefined
+    byTaxLine.set(row.entityId, entry)
+  }
+
+  for (const [taxLineId, orderId] of orderIdByTaxLine) {
+    const values = byTaxLine.get(taxLineId)
+    // A tax line missing either value cannot enter the split - it would
+    // silently understate the total it has to tie to.
+    if (!values?.title?.trim() || values.priceMinor == null) continue
+    const line: OrderTaxLine = { title: values.title, priceMinor: values.priceMinor }
+    const list = byOrder.get(orderId)
+    if (list) list.push(line)
+    else byOrder.set(orderId, [line])
+  }
+  return byOrder
 }
 
 /**
@@ -290,6 +397,7 @@ export async function readOrderForFulfillment(
         .map((row) => row.relatedEntityId)
         .filter((id): id is string => !!id)
       const lines = await readOrderLines(db, organizationId, ctx, lineIds, shipped)
+      const taxLines = (await readOrderTaxLines(db, organizationId, [orderId])).get(orderId) ?? []
 
       return {
         orderId,
@@ -308,6 +416,7 @@ export async function readOrderForFulfillment(
         nextSequence: nextFulfillmentSequence(fulfillments),
         shippingOwed: shippingStillOwed(fulfillments),
         contactInstanceId: cell('order_contact')?.relatedEntityId ?? null,
+        taxLines,
       }
     },
     'Failed to read an order for fulfillment',

--- a/packages/lib/src/money/payments/__tests__/post-transaction.test.ts
+++ b/packages/lib/src/money/payments/__tests__/post-transaction.test.ts
@@ -3,13 +3,24 @@
 // plans/accounting/tasks/17-accounting-is-opt-in.md section 3: the
 // accounting-off case is checked before the org-settings read that exists only
 // to resolve the payment route for the builder.
+//
+// plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md §2.4: the `cash`
+// route names a bank account, never a role, so it is resolved and refused
+// BEFORE the build - `resolveCashBankAccountGlAccountId` is exercised here
+// directly against a stub `Database`, never mocked away, because it is the one
+// piece of new logic this file exists to pin.
 
+import { schema } from '@auxx/database'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const h = vi.hoisted(() => ({
   isAccountingEnabled: vi.fn(async () => true),
   getOrgCache: vi.fn(async () => ({})),
-  resolvePaymentRoute: vi.fn(() => 'cash'),
+  getCachedEntityDefId: vi.fn(async () => null as string | null),
+  bySystemAttributes: vi.fn(
+    async () => ({ bank_account_gl_account: null }) as Record<string, unknown>
+  ),
+  resolvePaymentRoute: vi.fn(() => 'undeposited_funds'),
   buildPaymentEntry: vi.fn(),
   resolvePeriodLock: vi.fn(),
   postEntry: vi.fn(),
@@ -19,7 +30,11 @@ vi.mock('../../../postings/accounting-enabled', () => ({
   isAccountingEnabled: h.isAccountingEnabled,
 }))
 vi.mock('../../../cache', () => ({
-  getOrgCache: () => ({ get: h.getOrgCache }),
+  getOrgCache: () => ({
+    get: h.getOrgCache,
+    from: () => ({ bySystemAttributes: h.bySystemAttributes }),
+  }),
+  getCachedEntityDefId: h.getCachedEntityDefId,
 }))
 vi.mock('../../../postings/build-payment-entry', () => ({
   PAYMENT_SOURCE_TYPE: 'payment_transaction',
@@ -44,7 +59,6 @@ import type { Database, PaymentTransactionEntity } from '@auxx/database'
 import { postPaymentTransaction } from '../post-transaction'
 
 const ORG = 'org_1'
-const db = {} as Database
 
 function transaction(overrides: Partial<PaymentTransactionEntity> = {}): PaymentTransactionEntity {
   return {
@@ -61,11 +75,45 @@ function transaction(overrides: Partial<PaymentTransactionEntity> = {}): Payment
   } as PaymentTransactionEntity
 }
 
+/**
+ * A `Database` answering the two selects `resolveCashBankAccountGlAccountId`
+ * issues - the `bank_account` instance (by id, org and def) and its
+ * `bank_account_gl_account` field value. `.where()` is unevaluated, the same
+ * posture `143`/`144`'s migration stubs take: the caller already scoped the
+ * seed to the query under test.
+ */
+function makeDb(opts: {
+  instance?: { id: string; archivedAt: Date | null } | null
+  fieldValue?: { valueText: string | null } | null
+}): Database {
+  return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: () => {
+            if (table === schema.EntityInstance) {
+              return Promise.resolve(opts.instance ? [opts.instance] : [])
+            }
+            if (table === schema.FieldValue) {
+              return Promise.resolve(opts.fieldValue ? [opts.fieldValue] : [])
+            }
+            return Promise.resolve([])
+          },
+        }),
+      }),
+    }),
+  } as unknown as Database
+}
+
+const NO_DB = {} as Database
+
 beforeEach(() => {
   vi.clearAllMocks()
   h.isAccountingEnabled.mockResolvedValue(true)
   h.getOrgCache.mockResolvedValue({})
-  h.resolvePaymentRoute.mockReturnValue('cash')
+  h.getCachedEntityDefId.mockResolvedValue(null)
+  h.bySystemAttributes.mockResolvedValue({ bank_account_gl_account: null })
+  h.resolvePaymentRoute.mockReturnValue('undeposited_funds')
   h.buildPaymentEntry.mockReturnValue({
     entry: { postingType: 'payment', periodKey: 'PMT-txn_1', txnDate: '2026-09-01', lines: [] },
   })
@@ -79,7 +127,7 @@ describe('accounting not enabled', () => {
   })
 
   it('returns not_enabled without reading settings, building, locking, or posting', async () => {
-    const result = await postPaymentTransaction(db, {
+    const result = await postPaymentTransaction(NO_DB, {
       organizationId: ORG,
       transaction: transaction(),
       allocatedMinor: 5_000,
@@ -93,7 +141,7 @@ describe('accounting not enabled', () => {
   })
 
   it('still refuses a non-postable status first, before the gate matters', async () => {
-    const result = await postPaymentTransaction(db, {
+    const result = await postPaymentTransaction(NO_DB, {
       organizationId: ORG,
       transaction: transaction({ status: 'pending' }),
       allocatedMinor: 5_000,
@@ -103,15 +151,103 @@ describe('accounting not enabled', () => {
   })
 })
 
-describe('accounting enabled', () => {
-  it('resolves the route, builds, locks, and posts', async () => {
-    const result = await postPaymentTransaction(db, {
+describe('accounting enabled, a role-based route', () => {
+  it('resolves the route, builds with no bank account, locks, and posts', async () => {
+    const result = await postPaymentTransaction(NO_DB, {
       organizationId: ORG,
       transaction: transaction(),
       allocatedMinor: 5_000,
     })
 
     expect(h.buildPaymentEntry).toHaveBeenCalledTimes(1)
+    expect(h.buildPaymentEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ bankAccountGlAccountId: null })
+    )
+    expect(h.postEntry).toHaveBeenCalledTimes(1)
+    expect(result.status).toBe('posted')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The `cash` route names a bank account, never a role (brief 13 §2.4)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('accounting enabled, the cash route', () => {
+  beforeEach(() => {
+    h.resolvePaymentRoute.mockReturnValue('cash')
+  })
+
+  it('refuses with account_unmapped when no bank account is configured, and never builds', async () => {
+    h.getOrgCache.mockResolvedValue({})
+
+    const result = await postPaymentTransaction(NO_DB, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(result).toMatchObject({ status: 'account_unmapped', failureClass: 'configuration' })
+    expect(result.error).toMatch(/no bank account is configured/)
+    expect(h.buildPaymentEntry).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+    // The short-circuit is before any cache or db read for the bank account.
+    expect(h.getCachedEntityDefId).not.toHaveBeenCalled()
+  })
+
+  it('refuses with account_unmapped when the configured bank account has no gl_account mapping', async () => {
+    h.getOrgCache.mockResolvedValue({ 'accounting.cashBankAccountId': 'ba_1' })
+    h.getCachedEntityDefId.mockResolvedValue('def_bank_account')
+    h.bySystemAttributes.mockResolvedValue({ bank_account_gl_account: { id: 'fld_gl' } })
+
+    const db = makeDb({ instance: { id: 'ba_1', archivedAt: null }, fieldValue: null })
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(result).toMatchObject({ status: 'account_unmapped', failureClass: 'configuration' })
+    expect(result.error).toMatch(/is not mapped to a chart account/)
+    expect(h.buildPaymentEntry).not.toHaveBeenCalled()
+  })
+
+  it('refuses with account_unmapped when the configured bank account is archived', async () => {
+    h.getOrgCache.mockResolvedValue({ 'accounting.cashBankAccountId': 'ba_1' })
+    h.getCachedEntityDefId.mockResolvedValue('def_bank_account')
+    h.bySystemAttributes.mockResolvedValue({ bank_account_gl_account: { id: 'fld_gl' } })
+
+    const db = makeDb({
+      instance: { id: 'ba_1', archivedAt: new Date('2026-01-01') },
+      fieldValue: { valueText: 'gl_1000' },
+    })
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(result.status).toBe('account_unmapped')
+    expect(h.buildPaymentEntry).not.toHaveBeenCalled()
+  })
+
+  it('resolves the mapped bank account and builds with its gl_account id', async () => {
+    h.getOrgCache.mockResolvedValue({ 'accounting.cashBankAccountId': 'ba_1' })
+    h.getCachedEntityDefId.mockResolvedValue('def_bank_account')
+    h.bySystemAttributes.mockResolvedValue({ bank_account_gl_account: { id: 'fld_gl' } })
+
+    const db = makeDb({
+      instance: { id: 'ba_1', archivedAt: null },
+      fieldValue: { valueText: 'gl_1000' },
+    })
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(h.buildPaymentEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ bankAccountGlAccountId: 'gl_1000' })
+    )
     expect(h.postEntry).toHaveBeenCalledTimes(1)
     expect(result.status).toBe('posted')
   })

--- a/packages/lib/src/money/payments/post-transaction.ts
+++ b/packages/lib/src/money/payments/post-transaction.ts
@@ -27,12 +27,23 @@
  * Nothing here throws. Every outcome is a `PostResult`, so `syncTransaction`
  * can call it without a try/catch of its own and a failed post can never fail
  * the payment that produced it.
+ *
+ * ## 🛑 The `cash` route names a bank account, never a role (brief 13 §2.4)
+ *
+ * `accounting.cashBankAccountId` names the `bank_account` a `cash`-routed
+ * payment banks into; {@link resolveCashBankAccountGlAccountId} reads its
+ * `bank_account_gl_account` id directly off the entity layer, mirroring
+ * `money/bank-deposits/reads.ts`'s `readDepositBankAccount` rather than
+ * importing `banking/` - the same anti-cycle reason that file gives. Unset or
+ * unmapped refuses with `account_unmapped` before the entry is even built,
+ * the same configuration-class refusal `createBankDeposit` gives for a
+ * deposit's own unmapped bank account.
  */
 
 import { type Database, type PaymentTransactionEntity, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
-import { getOrgCache } from '../../cache'
+import { getCachedEntityDefId, getOrgCache } from '../../cache'
 import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
   buildPaymentEntry,
@@ -93,6 +104,65 @@ const ACCEPTED_POST_STATUSES = new Set<string>([
 const POSTABLE_STATUSES = new Set(['succeeded', 'disputed'])
 
 /**
+ * The `gl_account` id `accounting.cashBankAccountId` resolves to, or `null`
+ * when it is unset or the account it names has none.
+ *
+ * Read through the entity layer directly rather than by importing `banking/` -
+ * `money/bank-deposits/reads.ts` gives the same reason for its own
+ * `readDepositBankAccount`: a `bank_account` is an `EntityInstance` like any
+ * other, and a `money -> banking` import risks a cycle back through
+ * `banking/`'s own writers.
+ */
+async function resolveCashBankAccountGlAccountId(
+  db: Database,
+  organizationId: string,
+  settings: Record<string, unknown>
+): Promise<{ glAccountId: string | null; bankAccountId: string | null }> {
+  const raw = settings['accounting.cashBankAccountId']
+  const bankAccountId = typeof raw === 'string' ? raw.trim() : ''
+  if (!bankAccountId) return { glAccountId: null, bankAccountId: null }
+
+  const bankAccountDefId = await getCachedEntityDefId(organizationId, 'bank_account')
+  if (!bankAccountDefId) return { glAccountId: null, bankAccountId }
+
+  const glAccountField = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['bank_account_gl_account'])
+  const fieldId = glAccountField.bank_account_gl_account?.id
+  if (!fieldId) return { glAccountId: null, bankAccountId }
+
+  const [instance] = await db
+    .select({ id: schema.EntityInstance.id, archivedAt: schema.EntityInstance.archivedAt })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, bankAccountDefId),
+        eq(schema.EntityInstance.id, bankAccountId)
+      )
+    )
+    .limit(1)
+  // Archived is treated as unmapped: nothing can be banked into an archived
+  // account (`money/bank-deposits/writes.ts`'s `requireDepositTarget` refuses
+  // the same way).
+  if (!instance || instance.archivedAt) return { glAccountId: null, bankAccountId }
+
+  const [value] = await db
+    .select({ valueText: schema.FieldValue.valueText })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, instance.id),
+        eq(schema.FieldValue.fieldId, fieldId)
+      )
+    )
+    .limit(1)
+
+  return { glAccountId: value?.valueText?.trim() || null, bankAccountId }
+}
+
+/**
  * Post one `PaymentTransaction` to the ledger, or explain why it was not.
  *
  * **Never throws.** Every refusal is a {@link PostResult} status:
@@ -144,6 +214,29 @@ export async function postPaymentTransaction(
     const settings = await getOrgCache().get(organizationId, 'orgSettings')
     const route = resolvePaymentRoute(transaction.method, settings)
 
+    // 🛑 `cash` names a bank account, never a role (brief 13 §2.4). Resolved
+    // and refused BEFORE the build, the same shape as the account-role refusal
+    // `postEntry` returns for a role - no entry is built and nothing is claimed.
+    let bankAccountGlAccountId: string | null = null
+    if (route === 'cash') {
+      const resolved = await resolveCashBankAccountGlAccountId(db, organizationId, settings)
+      if (!resolved.glAccountId) {
+        const message = resolved.bankAccountId
+          ? `Payment ${transaction.id} routes to cash, but the bank account it is configured to ` +
+            'bank into is not mapped to a chart account. Map it under Accounting > Settings > ' +
+            'Bank accounts.'
+          : `Payment ${transaction.id} routes to cash, but no bank account is configured for ` +
+            'cash payments. Set one under Accounting > Settings > General.'
+        logger.warn('Payment refused: the cash route has no mapped bank account', {
+          organizationId,
+          transactionId: transaction.id,
+          bankAccountId: resolved.bankAccountId,
+        })
+        return { status: 'account_unmapped', failureClass: 'configuration', error: message }
+      }
+      bankAccountGlAccountId = resolved.glAccountId
+    }
+
     // The user-picked (possibly backdated) date rides in `metadata.date`; the
     // row's own `createdAt` is when it was KEYED, which is not the accounting
     // date. `recordManualPayment` is the writer of that metadata.
@@ -155,6 +248,7 @@ export async function postPaymentTransaction(
 
     const built = buildPaymentEntry({
       postingType: PAYMENT_POSTING_TYPE,
+      bankAccountGlAccountId,
       transaction: {
         id: transaction.id,
         kind: transaction.kind === 'refund' ? 'refund' : 'charge',

--- a/packages/lib/src/money/payouts/__tests__/reads.test.ts
+++ b/packages/lib/src/money/payouts/__tests__/reads.test.ts
@@ -1,0 +1,127 @@
+// packages/lib/src/money/payouts/__tests__/reads.test.ts
+//
+// `findBankAccountByStripeExternalAccountId` (brief 13 §2.3): a payout's
+// Stripe destination resolves to the org's own `bank_account` through a
+// CONFIRMED `stripeExternalAccountId` identity, never `last4`. What is pinned
+// here:
+//
+//  - `null` when the org has no `bank_account` def yet, or the identity field
+//    has never been provisioned - both are "nothing to match against", not a
+//    crash;
+//  - `null` when no live bank account carries the destination;
+//  - the matched account's `gl_account` id, when it has one;
+//  - `null` glAccountId (not a crash) when the matched account carries no
+//    chart mapping at all.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  getCachedEntityDefId: vi.fn(async () => null as string | null),
+  bySystemAttributes: vi.fn(async () => ({}) as Record<string, { id: string } | null>),
+}))
+
+vi.mock('../../../cache', () => ({
+  getCachedEntityDefId: h.getCachedEntityDefId,
+  getOrgCache: () => ({ from: () => ({ bySystemAttributes: h.bySystemAttributes }) }),
+}))
+
+import type { Database } from '@auxx/database'
+import { findBankAccountByStripeExternalAccountId } from '../reads'
+
+const ORG = 'org_1'
+const BANK_ACCOUNT_DEF = 'def_bank_account'
+const STRIPE_FIELD = 'field_stripe_external_account_id'
+const GL_FIELD = 'field_gl_account'
+
+/**
+ * A `Database` answering the two selects in call order: the join query that
+ * finds the matching account (call 1), then the `gl_account` field value on
+ * it (call 2). `.where()`/`.innerJoin()` are unevaluated - the caller already
+ * scoped the seed to the query under test, the same posture the migration
+ * stubs in this package take.
+ */
+function stubDb(opts: {
+  matchRows?: { entityId: string }[]
+  valueRows?: { valueText: string | null }[]
+}): Database {
+  let call = 0
+  const chain = (rows: unknown[]): any => ({
+    innerJoin: () => chain(rows),
+    where: () => chain(rows),
+    limit: () => Promise.resolve(rows),
+  })
+  return {
+    select: () => ({
+      from: () => {
+        call++
+        return call === 1 ? chain(opts.matchRows ?? []) : chain(opts.valueRows ?? [])
+      },
+    }),
+  } as unknown as Database
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getCachedEntityDefId.mockResolvedValue(BANK_ACCOUNT_DEF)
+  h.bySystemAttributes.mockResolvedValue({
+    bank_account_stripe_external_account_id: { id: STRIPE_FIELD },
+    bank_account_gl_account: { id: GL_FIELD },
+  })
+})
+
+describe('findBankAccountByStripeExternalAccountId', () => {
+  it('returns null when the org has no bank_account def yet', async () => {
+    h.getCachedEntityDefId.mockResolvedValue(null)
+    const db = stubDb({})
+
+    const result = await findBankAccountByStripeExternalAccountId(db, ORG, 'ba_1')
+    expect(result).toBeNull()
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the identity field has never been provisioned', async () => {
+    h.bySystemAttributes.mockResolvedValue({ bank_account_stripe_external_account_id: null })
+    const db = stubDb({})
+
+    const result = await findBankAccountByStripeExternalAccountId(db, ORG, 'ba_1')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when no live bank account carries the destination', async () => {
+    const db = stubDb({ matchRows: [] })
+
+    const result = await findBankAccountByStripeExternalAccountId(db, ORG, 'ba_unknown')
+    expect(result).toBeNull()
+  })
+
+  it('resolves the matched account and its gl_account mapping', async () => {
+    const db = stubDb({
+      matchRows: [{ entityId: 'ba_row_1' }],
+      valueRows: [{ valueText: 'gl_1000' }],
+    })
+
+    const result = await findBankAccountByStripeExternalAccountId(db, ORG, 'ba_confirmed')
+    expect(result).toEqual({ bankAccountId: 'ba_row_1', glAccountId: 'gl_1000' })
+  })
+
+  it('resolves the account with a null glAccountId when it carries no chart mapping', async () => {
+    const db = stubDb({
+      matchRows: [{ entityId: 'ba_row_1' }],
+      valueRows: [],
+    })
+
+    const result = await findBankAccountByStripeExternalAccountId(db, ORG, 'ba_confirmed')
+    expect(result).toEqual({ bankAccountId: 'ba_row_1', glAccountId: null })
+  })
+
+  it('resolves the account with a null glAccountId when the gl_account field has never been provisioned', async () => {
+    h.bySystemAttributes.mockResolvedValue({
+      bank_account_stripe_external_account_id: { id: STRIPE_FIELD },
+      bank_account_gl_account: null,
+    })
+    const db = stubDb({ matchRows: [{ entityId: 'ba_row_1' }] })
+
+    const result = await findBankAccountByStripeExternalAccountId(db, ORG, 'ba_confirmed')
+    expect(result).toEqual({ bankAccountId: 'ba_row_1', glAccountId: null })
+  })
+})

--- a/packages/lib/src/money/payouts/__tests__/sync.test.ts
+++ b/packages/lib/src/money/payouts/__tests__/sync.test.ts
@@ -12,6 +12,9 @@ const h = vi.hoisted(() => ({
   isAccountingEnabled: vi.fn(async () => true),
   requirePayoutFieldContext: vi.fn(async () => ({}) as never),
   getPaymentAccount: vi.fn(async () => null as { stripeAccountId: string } | null),
+  findBankAccountByStripeExternalAccountId: vi.fn(
+    async () => null as { bankAccountId: string; glAccountId: string | null } | null
+  ),
 }))
 
 vi.mock('../../../postings/accounting-enabled', () => ({
@@ -20,13 +23,14 @@ vi.mock('../../../postings/accounting-enabled', () => ({
 vi.mock('../reads', () => ({
   requirePayoutFieldContext: h.requirePayoutFieldContext,
   findPayoutByGatewayId: vi.fn(),
+  findBankAccountByStripeExternalAccountId: h.findBankAccountByStripeExternalAccountId,
 }))
 vi.mock('../../payments/account-state', () => ({
   getPaymentAccount: h.getPaymentAccount,
 }))
 
 import type { Database } from '@auxx/database'
-import { syncPayouts } from '../sync'
+import { resolvePayoutBankAccount, syncPayouts } from '../sync'
 
 const ORG = 'org_1'
 const db = {} as Database
@@ -70,5 +74,52 @@ describe('accounting enabled', () => {
     })
     expect(h.requirePayoutFieldContext).toHaveBeenCalledTimes(1)
     expect(h.getPaymentAccount).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// brief 13 §2.3: a payout debits a bank account, resolved through a CONFIRMED
+// Stripe identity, never a role and never `last4`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('resolvePayoutBankAccount', () => {
+  it('blocks with no build when Stripe reported no destination at all', async () => {
+    const result = await resolvePayoutBankAccount(db, ORG, null, 'PAY-0001')
+
+    expect(result.blockedReason).toMatch(/no destination reported by Stripe/)
+    expect(result.glAccountId).toBeUndefined()
+    expect(h.findBankAccountByStripeExternalAccountId).not.toHaveBeenCalled()
+  })
+
+  it('blocks, naming the payout and the destination, when no bank account carries that identity', async () => {
+    h.findBankAccountByStripeExternalAccountId.mockResolvedValue(null)
+
+    const result = await resolvePayoutBankAccount(db, ORG, 'ba_unknown', 'PAY-0001')
+
+    expect(result.blockedReason).toContain('PAY-0001')
+    expect(result.blockedReason).toContain('ba_unknown')
+    expect(result.blockedReason).toMatch(/not confirmed on any bank account/)
+  })
+
+  it('blocks when the matched bank account has no chart mapping', async () => {
+    h.findBankAccountByStripeExternalAccountId.mockResolvedValue({
+      bankAccountId: 'ba_row_1',
+      glAccountId: null,
+    })
+
+    const result = await resolvePayoutBankAccount(db, ORG, 'ba_confirmed', 'PAY-0001')
+
+    expect(result.blockedReason).toBeTruthy()
+  })
+
+  it('resolves the gl_account id of a confirmed bank account, and blocks nothing', async () => {
+    h.findBankAccountByStripeExternalAccountId.mockResolvedValue({
+      bankAccountId: 'ba_row_1',
+      glAccountId: 'gl_1000',
+    })
+
+    const result = await resolvePayoutBankAccount(db, ORG, 'ba_confirmed', 'PAY-0001')
+
+    expect(result).toEqual({ blockedReason: null, glAccountId: 'gl_1000' })
   })
 })

--- a/packages/lib/src/money/payouts/gather.ts
+++ b/packages/lib/src/money/payouts/gather.ts
@@ -54,6 +54,14 @@ export interface GatheredPayout {
   depositedMinor: number
   /** Stripe's own status: `paid`, `in_transit`, `failed`, `canceled`. */
   gatewayStatus: string
+  /**
+   * The Stripe external-account id this payout settled to (brief 13 §2.3),
+   * or `null` when Stripe reports none. `payout.destination` is a string when
+   * not expanded (the ordinary case here - this gatherer never expands it)
+   * and an object with its own `id` when it is; either shape resolves to the
+   * bare id. Never Stripe's `last4` - see `sync.ts` on why.
+   */
+  destination: string | null
   split: PayoutSplit
 }
 
@@ -91,8 +99,19 @@ export async function gatherPayout(
     currency: payout.currency,
     depositedMinor: payout.amount,
     gatewayStatus: payout.status,
+    destination: resolveDestinationId(payout.destination),
     split,
   }
+}
+
+/**
+ * The bare external-account id off `payout.destination`, whatever shape it
+ * arrived in. A string when unexpanded (this gatherer never expands it); an
+ * object carrying its own `id` when a future caller does.
+ */
+function resolveDestinationId(destination: Stripe.Payout['destination']): string | null {
+  if (!destination) return null
+  return typeof destination === 'string' ? destination : destination.id
 }
 
 /**

--- a/packages/lib/src/money/payouts/reads.ts
+++ b/packages/lib/src/money/payouts/reads.ts
@@ -36,6 +36,7 @@ const PAYOUT_ATTRIBUTES = [
   'payout_unrecognised_net',
   'payout_unrecognised_count',
   'payout_gl_posting_id',
+  'payout_blocked_reason',
 ] as const
 
 type PayoutAttribute = (typeof PAYOUT_ATTRIBUTES)[number]
@@ -128,6 +129,89 @@ export async function findPayoutByGatewayId(
   if (!row) return null
   const [record] = await hydrate(db, organizationId, ctx, [row])
   return record ?? null
+}
+
+/**
+ * The `bank_account` attributes {@link findBankAccountByStripeExternalAccountId}
+ * reads. Read through the entity layer directly rather than by importing
+ * `banking/` - the same anti-cycle reason `money/bank-deposits/reads.ts` gives
+ * for its own `readDepositBankAccount`: a `bank_account` is an `EntityInstance`
+ * like any other, and `banking/` may in principle reach back into `money/`.
+ */
+const PAYOUT_BANK_ACCOUNT_ATTRIBUTES = [
+  'bank_account_stripe_external_account_id',
+  'bank_account_gl_account',
+] as const
+
+type PayoutBankAccountAttribute = (typeof PAYOUT_BANK_ACCOUNT_ATTRIBUTES)[number]
+type PayoutBankAccountFields = Record<PayoutBankAccountAttribute, { id: string } | null>
+
+/** What a payout's Stripe destination resolves to. */
+export interface PayoutBankAccountMatch {
+  bankAccountId: string
+  /** Null when the matched account carries no chart mapping. */
+  glAccountId: string | null
+}
+
+/**
+ * Resolve a Stripe payout's `destination` to the org's own `bank_account`,
+ * through its CONFIRMED `stripeExternalAccountId` identity (brief 13 §2.3).
+ *
+ * 🛑 Never matched on `last4` - a four-digit string is strong evidence and not
+ * proof, and two accounts at one bank can share one (the same argument
+ * `resolveMappedAccounts:291-298` makes about QuickBooks' `AcctNum`).
+ *
+ * `null` when no LIVE (non-archived) bank account in this org carries that
+ * identity - the caller refuses to post rather than guessing which account.
+ */
+export async function findBankAccountByStripeExternalAccountId(
+  db: Database,
+  organizationId: string,
+  destination: string
+): Promise<PayoutBankAccountMatch | null> {
+  const bankAccountDefId = await getCachedEntityDefId(organizationId, 'bank_account')
+  if (!bankAccountDefId) return null
+
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...PAYOUT_BANK_ACCOUNT_ATTRIBUTES])) as PayoutBankAccountFields
+  const stripeField = fields.bank_account_stripe_external_account_id
+  if (!stripeField) return null
+
+  const [match] = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, stripeField.id),
+        eq(schema.FieldValue.valueText, destination),
+        eq(schema.EntityInstance.entityDefinitionId, bankAccountDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .limit(1)
+  if (!match) return null
+
+  const glField = fields.bank_account_gl_account
+  let glAccountId: string | null = null
+  if (glField) {
+    const [value] = await db
+      .select({ valueText: schema.FieldValue.valueText })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          eq(schema.FieldValue.entityId, match.entityId),
+          eq(schema.FieldValue.fieldId, glField.id)
+        )
+      )
+      .limit(1)
+    glAccountId = value?.valueText?.trim() || null
+  }
+
+  return { bankAccountId: match.entityId, glAccountId }
 }
 
 /** One page of payouts, newest first. */
@@ -258,6 +342,7 @@ async function hydrate(
       unrecognisedNetMinor: money('payout_unrecognised_net'),
       unrecognisedCount: money('payout_unrecognised_count'),
       glPostingId: read('payout_gl_posting_id')?.valueText ?? null,
+      blockedReason: read('payout_blocked_reason')?.valueText ?? null,
       createdAt: row.createdAt,
     }
   })

--- a/packages/lib/src/money/payouts/sync.ts
+++ b/packages/lib/src/money/payouts/sync.ts
@@ -32,6 +32,15 @@
  * `SYNC_LOOKBACK_DAYS` bounds an ordinary run; {@link syncPayouts} refuses to
  * reach further back than the org's first sync, recorded as the earliest payout
  * record it holds.
+ *
+ * 🛑 **A payout debits a bank account, never a role (brief 13 §2.3).**
+ * `ingestOne` resolves the payout's own Stripe `destination` against the org's
+ * `bank_account` rows through a CONFIRMED `stripeExternalAccountId` identity -
+ * never `last4`, which is strong evidence and not proof. Until a person
+ * confirms that identity on exactly one bank account, the payout is raised
+ * (so its number is minted and it is visible) but its entry refuses to post:
+ * `payout_blocked_reason` names the payout, the destination and the remedy,
+ * and `postPayoutEntry` is never even called - see `resolvePayoutBankAccount`.
  */
 
 import { type Database, schema } from '@auxx/database'
@@ -43,8 +52,9 @@ import { UnprocessableEntityError } from '../../errors'
 import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import { ACCOUNT_ROLES } from '../../postings/build-entry'
 import { resolvePeriodLock } from '../../postings/period-lock'
-import { postPayoutEntry } from '../../postings/post-payout-entry'
+import { payoutAccountUnmappedResult, postPayoutEntry } from '../../postings/post-payout-entry'
 import { reverseEntry } from '../../postings/reverse-entry'
+import type { PostResult } from '../../postings/types'
 import { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
 import { toRecordId } from '../../resources/resource-id'
 import { SystemUserService } from '../../users/system-user-service'
@@ -52,7 +62,12 @@ import { getPaymentAccount } from '../payments/account-state'
 import { getStripeConnectClient } from '../payments/connect-client'
 import { type GatheredPayout, gatherPayout } from './gather'
 import { guard } from './guard'
-import { findPayoutByGatewayId, type PayoutFieldContext, requirePayoutFieldContext } from './reads'
+import {
+  findBankAccountByStripeExternalAccountId,
+  findPayoutByGatewayId,
+  type PayoutFieldContext,
+  requirePayoutFieldContext,
+} from './reads'
 import type { SyncPayoutsResult } from './types'
 
 const logger = createScopedLogger('payouts:sync')
@@ -218,19 +233,40 @@ async function ingestOne(
     }
   }
 
-  const post = await postPayoutEntry(db, {
-    organizationId,
-    actorUserId,
-    payoutId: payout.id,
-    payoutNumber: number,
-    grossMinor: gathered.split.grossMinor,
-    feesMinor: gathered.split.feesMinor,
-    netMinor: gathered.split.netMinor,
-    unrecognisedNetMinor: gathered.split.unrecognisedNetMinor,
-    clearingRole: ACCOUNT_ROLES.CLEARING_CARD,
-    paidAt: gathered.paidAt,
-    memo: `Payout ${number}`,
-  })
+  // 🛑 Resolved and refused BEFORE the build (brief 13 §2.3): a bank account is
+  // not a role, so the payout's own Stripe destination has to name one of the
+  // org's `bank_account` rows through a CONFIRMED `stripeExternalAccountId`
+  // identity - never `last4`. No entry is built and nothing is claimed when it
+  // cannot.
+  const resolved = await resolvePayoutBankAccount(db, organizationId, gathered.destination, number)
+
+  let post: PostResult
+  if (resolved.blockedReason !== null) {
+    logger.warn('Payout blocked: its destination is not a confirmed bank account', {
+      organizationId,
+      payoutId: payout.id,
+      destination: gathered.destination,
+    })
+    await crud.update(toRecordId(ctx.payoutDefId, instanceId), {
+      payout_blocked_reason: resolved.blockedReason,
+    })
+    post = payoutAccountUnmappedResult(resolved.blockedReason)
+  } else {
+    post = await postPayoutEntry(db, {
+      organizationId,
+      actorUserId,
+      payoutId: payout.id,
+      payoutNumber: number,
+      bankAccountGlAccountId: resolved.glAccountId,
+      grossMinor: gathered.split.grossMinor,
+      feesMinor: gathered.split.feesMinor,
+      netMinor: gathered.split.netMinor,
+      unrecognisedNetMinor: gathered.split.unrecognisedNetMinor,
+      clearingRole: ACCOUNT_ROLES.CLEARING_CARD,
+      paidAt: gathered.paidAt,
+      memo: `Payout ${number}`,
+    })
+  }
 
   if (post.status !== 'posted' && post.status !== 'already_posted') {
     return {
@@ -243,6 +279,9 @@ async function ingestOne(
 
   await crud.update(toRecordId(ctx.payoutDefId, instanceId), {
     payout_status: 'paid',
+    // Cleared on success: a payout that was blocked on a prior run and has
+    // since been confirmed must not keep showing the blocker banner.
+    payout_blocked_reason: null,
     ...(post.glPostingId ? { payout_gl_posting_id: post.glPostingId } : {}),
   })
 
@@ -253,12 +292,50 @@ async function ingestOne(
   }
 }
 
+/** Either the resolved `gl_account` id, or the sentence a blocked payout carries. Never both. */
+export type ResolvedPayoutBankAccount =
+  | { blockedReason: null; glAccountId: string }
+  | { blockedReason: string; glAccountId?: never }
+
+/**
+ * Resolve a payout's Stripe `destination` to the org's own `bank_account`, or
+ * name why it cannot be posted.
+ *
+ * Exported for direct testing - `ingestOne` is not, because reaching it
+ * exercises the whole Stripe-backed gatherer this function is deliberately
+ * factored out of.
+ */
+export async function resolvePayoutBankAccount(
+  db: Database,
+  organizationId: string,
+  destination: string | null,
+  payoutNumber: string
+): Promise<ResolvedPayoutBankAccount> {
+  if (!destination) {
+    return {
+      blockedReason:
+        `Payout ${payoutNumber} settled with no destination reported by Stripe, so there is no ` +
+        'bank account to debit. Confirm its bank account on Accounting > Settings > Bank accounts.',
+    }
+  }
+  const match = await findBankAccountByStripeExternalAccountId(db, organizationId, destination)
+  if (!match?.glAccountId) {
+    return {
+      blockedReason:
+        `Payout ${payoutNumber} settled to ${destination}, which is not confirmed on any bank ` +
+        'account. Confirm it on Accounting > Settings > Bank accounts.',
+    }
+  }
+  return { blockedReason: null, glAccountId: match.glAccountId }
+}
+
 /** The field payload a payout record carries, from one gathered payout. */
 function payoutValues(gathered: GatheredPayout): Record<string, unknown> {
   return {
     payout_gateway_id: gathered.payoutId,
     payout_status: gathered.gatewayStatus === 'paid' ? 'paid' : 'in_transit',
     payout_paid_at: gathered.paidAt,
+    payout_destination: gathered.destination ?? undefined,
     payout_currency: gathered.currency,
     payout_deposited: gathered.depositedMinor,
     payout_gross: gathered.split.grossMinor,

--- a/packages/lib/src/money/payouts/types.ts
+++ b/packages/lib/src/money/payouts/types.ts
@@ -28,6 +28,12 @@ export interface PayoutRecord {
   unrecognisedCount: number
   /** The posting this payout became, or null while it has none. */
   glPostingId: string | null
+  /**
+   * Set when this payout could not be posted for lack of a confirmed
+   * bank-account identity (brief 13 §2.3). Names the payout, the destination
+   * and the remedy. Null once posted, or if it never blocked.
+   */
+  blockedReason: string | null
   createdAt: Date
 }
 

--- a/packages/lib/src/payment-gateways/__tests__/reads.test.ts
+++ b/packages/lib/src/payment-gateways/__tests__/reads.test.ts
@@ -1,0 +1,118 @@
+// packages/lib/src/payment-gateways/__tests__/reads.test.ts
+//
+// The one thing this hydration does that `banking/reads.ts`'s does not:
+// `handles` is a multi-value TAGS field, one `FieldValue` row per handle, so
+// the byInstance map has to group by (entityId, fieldId) into ARRAYS rather
+// than keep the single row `hydrateBankAccounts` does for every scalar field.
+// Uses the same double `banking/__tests__/reads-archived.test.ts` does
+// (`docs/lib-module-guide.md` §9's "copy the reference module" rule, applied
+// to its tests too).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  /** The rows each successive `db.select()` resolves to, in call order. */
+  script: [] as unknown[][],
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: async (_org: string, entityType: string) =>
+    entityType === 'payment_gateway' ? 'def_pg' : null,
+  getOrgCache: () => ({
+    from: () => ({
+      // Every attribute resolves to a field whose id IS the attribute name.
+      bySystemAttributes: async (attrs: string[]) =>
+        Object.fromEntries(attrs.map((attr) => [attr, { id: attr }])),
+    }),
+  }),
+}))
+
+/** One query stage: chainable and awaitable, resolving to `rows`. */
+function stage(rows: unknown[]): unknown {
+  const chain: Record<string, unknown> = {}
+  for (const method of ['from', 'orderBy', 'limit', 'where']) {
+    chain[method] = () => stage(rows)
+  }
+  return Object.assign(Promise.resolve(rows), chain)
+}
+
+function fakeDb() {
+  let call = 0
+  return { select: () => stage(state.script[call++] ?? []) } as never
+}
+
+const ORG = 'org_1'
+
+beforeEach(() => {
+  state.script.length = 0
+})
+
+const { getPaymentGateway, listPaymentGateways } = await import('../reads')
+
+describe('listPaymentGateways', () => {
+  it('groups a multi-value TAGS field (handles) into an array per instance', async () => {
+    state.script.push([{ id: 'pg_1', createdAt: null, updatedAt: null }])
+    state.script.push([
+      { entityId: 'pg_1', fieldId: 'payment_gateway_name', valueText: 'Authorize.Net' },
+      { entityId: 'pg_1', fieldId: 'payment_gateway_handles', optionId: 'authorize_net' },
+      { entityId: 'pg_1', fieldId: 'payment_gateway_handles', optionId: 'authorize.net' },
+      {
+        entityId: 'pg_1',
+        fieldId: 'payment_gateway_clearing_account',
+        valueText: 'acct_card_clearing',
+      },
+      { entityId: 'pg_1', fieldId: 'payment_gateway_settlement_source', optionId: 'manual' },
+      { entityId: 'pg_1', fieldId: 'payment_gateway_status', optionId: 'closed' },
+    ])
+
+    const result = await listPaymentGateways(fakeDb(), ORG)
+    expect(result.isOk()).toBe(true)
+    if (!result.isOk()) return
+    expect(result.value).toHaveLength(1)
+    expect(result.value[0]?.handles).toEqual(['authorize_net', 'authorize.net'])
+    expect(result.value[0]?.status).toBe('closed')
+    expect(result.value[0]?.settlementSource).toBe('manual')
+    expect(result.value[0]?.clearingGlAccountId).toBe('acct_card_clearing')
+  })
+
+  it('falls back to valueText for a handle with no optionId, and drops a truly empty row', async () => {
+    state.script.push([{ id: 'pg_1', createdAt: null, updatedAt: null }])
+    state.script.push([
+      { entityId: 'pg_1', fieldId: 'payment_gateway_name', valueText: 'Shopify Payments' },
+      { entityId: 'pg_1', fieldId: 'payment_gateway_handles', valueText: 'shopify_payments' },
+      { entityId: 'pg_1', fieldId: 'payment_gateway_handles', optionId: null, valueText: null },
+      {
+        entityId: 'pg_1',
+        fieldId: 'payment_gateway_clearing_account',
+        valueText: 'acct_card_clearing',
+      },
+    ])
+
+    const result = await listPaymentGateways(fakeDb(), ORG)
+    if (!result.isOk()) throw result.error
+    expect(result.value[0]?.handles).toEqual(['shopify_payments'])
+  })
+
+  it('defaults settlementSource to manual and status to active when the fields carry nothing', async () => {
+    state.script.push([{ id: 'pg_1', createdAt: null, updatedAt: null }])
+    state.script.push([
+      { entityId: 'pg_1', fieldId: 'payment_gateway_name', valueText: 'Affirm' },
+      { entityId: 'pg_1', fieldId: 'payment_gateway_clearing_account', valueText: 'acct_affirm' },
+    ])
+
+    const result = await listPaymentGateways(fakeDb(), ORG)
+    if (!result.isOk()) throw result.error
+    expect(result.value[0]?.settlementSource).toBe('manual')
+    expect(result.value[0]?.status).toBe('active')
+    expect(result.value[0]?.feeGlAccountId).toBeNull()
+  })
+})
+
+describe('getPaymentGateway', () => {
+  it('returns null when the instance does not exist', async () => {
+    state.script.push([])
+    const result = await getPaymentGateway(fakeDb(), ORG, 'gone')
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value).toBeNull()
+  })
+})

--- a/packages/lib/src/payment-gateways/__tests__/writes.test.ts
+++ b/packages/lib/src/payment-gateways/__tests__/writes.test.ts
@@ -1,0 +1,237 @@
+// packages/lib/src/payment-gateways/__tests__/writes.test.ts
+//
+// The two refusals §5.3 names explicitly: two records sharing a normalised
+// handle, and a clearing account that is not an active asset account. Mocks
+// `./reads` and `../postings/chart-accounts` rather than a live db, the same
+// boundary `banking/__tests__` draws around `UnifiedCrudHandler`.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PaymentGatewayRow } from '../client'
+
+const state = vi.hoisted(() => ({
+  existing: [] as PaymentGatewayRow[],
+  createCalls: [] as unknown[],
+  updateCalls: [] as unknown[],
+  chartAccounts: new Map<
+    string,
+    { id: string; accountType: string; isActive: boolean; name: string }
+  >(),
+}))
+
+function baseRow(overrides: Partial<PaymentGatewayRow> = {}): PaymentGatewayRow {
+  return {
+    id: 'pg_existing',
+    recordId: 'payment_gateway:pg_existing',
+    name: 'Affirm',
+    handles: ['affirm'],
+    clearingGlAccountId: 'acct_affirm',
+    feeGlAccountId: null,
+    settlementSource: 'manual',
+    status: 'active',
+    lastSettlementAt: null,
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  }
+}
+
+vi.mock('../reads', () => ({
+  requirePaymentGatewayFieldContext: async () => ({
+    paymentGatewayDefId: 'def_pg',
+    fields: {},
+  }),
+  listPaymentGateways: async () => ({
+    isErr: () => false,
+    isOk: () => true,
+    value: state.existing,
+  }),
+  getPaymentGateway: async (_db: unknown, _org: string, id: string) => {
+    const row = state.existing.find((r) => r.id === id) ?? {
+      ...baseRow({ id: 'pg_new', name: 'New gateway' }),
+    }
+    return { isErr: () => false, isOk: () => true, value: row }
+  },
+}))
+
+vi.mock('../../postings/chart-accounts', () => ({
+  loadChartAccountsById: async (_db: unknown, _org: string, ids: string[]) => {
+    const accounts = new Map()
+    for (const id of ids) {
+      const account = state.chartAccounts.get(id)
+      if (account) accounts.set(id, account)
+    }
+    return { accounts, malformed: ids.filter((id) => !state.chartAccounts.has(id)) }
+  },
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    async create(_defId: string, values: unknown) {
+      state.createCalls.push(values)
+      return { instance: { id: 'pg_new' } }
+    }
+    async update(recordId: unknown, values: unknown) {
+      state.updateCalls.push({ recordId, values })
+    }
+  },
+}))
+
+const { createPaymentGateway, updatePaymentGateway } = await import('../writes')
+
+const ORG = 'org_1'
+const ASSET_ACCOUNT = {
+  id: 'acct_card_clearing',
+  accountType: 'asset',
+  isActive: true,
+  name: '1200 Card Clearing',
+}
+const EXPENSE_ACCOUNT = {
+  id: 'acct_fees',
+  accountType: 'expense',
+  isActive: true,
+  name: '6100 Merchant Fees',
+}
+const LIABILITY_ACCOUNT = {
+  id: 'acct_ap',
+  accountType: 'liability',
+  isActive: true,
+  name: '2000 A/P',
+}
+
+beforeEach(() => {
+  state.existing = []
+  state.createCalls.length = 0
+  state.updateCalls.length = 0
+  state.chartAccounts = new Map([
+    [ASSET_ACCOUNT.id, ASSET_ACCOUNT],
+    [EXPENSE_ACCOUNT.id, EXPENSE_ACCOUNT],
+    [LIABILITY_ACCOUNT.id, LIABILITY_ACCOUNT],
+  ])
+})
+
+describe('createPaymentGateway', () => {
+  it('refuses a clearing account that is not an active asset account', async () => {
+    const result = await createPaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      name: 'Stripe',
+      handles: ['stripe'],
+      clearingAccountId: LIABILITY_ACCOUNT.id,
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.message).toContain('liability')
+  })
+
+  it('refuses a clearing account that does not exist in the chart', async () => {
+    const result = await createPaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      name: 'Stripe',
+      handles: ['stripe'],
+      clearingAccountId: 'acct_missing',
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.message).toContain('does not exist')
+  })
+
+  it('refuses two records sharing a normalised handle, naming both', async () => {
+    state.existing = [baseRow({ id: 'pg_1', name: 'Authorize.Net', handles: ['authorize_net'] })]
+    const result = await createPaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      name: 'Authorize.Net (dup)',
+      // Same handle, different case - must still collide (trimmed + lower-cased).
+      handles: [' Authorize_Net '],
+      clearingAccountId: ASSET_ACCOUNT.id,
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.message).toContain('Authorize.Net (dup)')
+      expect(result.error.message).toContain('Authorize.Net')
+    }
+  })
+
+  it('creates a gateway with a valid asset clearing account and expense fee account', async () => {
+    const result = await createPaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      name: 'Shopify Payments',
+      handles: ['shopify_payments'],
+      clearingAccountId: ASSET_ACCOUNT.id,
+      feeAccountId: EXPENSE_ACCOUNT.id,
+      settlementSource: 'shopify_payments',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(state.createCalls).toHaveLength(1)
+    expect(state.createCalls[0]).toMatchObject({
+      payment_gateway_name: 'Shopify Payments',
+      payment_gateway_handles: ['shopify_payments'],
+      payment_gateway_clearing_account: ASSET_ACCOUNT.id,
+      payment_gateway_fee_account: EXPENSE_ACCOUNT.id,
+      payment_gateway_settlement_source: 'shopify_payments',
+    })
+  })
+
+  it('refuses a fee account that is not an expense account', async () => {
+    const result = await createPaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      name: 'Shopify Payments',
+      handles: ['shopify_payments'],
+      clearingAccountId: ASSET_ACCOUNT.id,
+      feeAccountId: ASSET_ACCOUNT.id,
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.message).toContain('asset')
+  })
+
+  it('refuses an empty handle list', async () => {
+    const result = await createPaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      name: 'Nothing',
+      handles: ['   '],
+      clearingAccountId: ASSET_ACCOUNT.id,
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.message).toContain('at least one handle')
+  })
+})
+
+describe('updatePaymentGateway', () => {
+  it('re-validates the clearing account on every write', async () => {
+    state.existing = [baseRow()]
+    const result = await updatePaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      paymentGatewayId: 'pg_existing',
+      clearingAccountId: LIABILITY_ACCOUNT.id,
+    })
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('allows renaming without touching handles or accounts', async () => {
+    state.existing = [baseRow()]
+    const result = await updatePaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      paymentGatewayId: 'pg_existing',
+      name: 'Affirm (BNPL)',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(state.updateCalls[0]).toMatchObject({
+      values: { payment_gateway_name: 'Affirm (BNPL)' },
+    })
+  })
+
+  it('does not collide with itself when its own handle is unchanged', async () => {
+    state.existing = [baseRow()]
+    const result = await updatePaymentGateway({} as never, {
+      organizationId: ORG,
+      actorUserId: 'user_1',
+      paymentGatewayId: 'pg_existing',
+      handles: ['affirm', 'Affirm'],
+    })
+    expect(result.isOk()).toBe(true)
+  })
+})

--- a/packages/lib/src/payment-gateways/client.ts
+++ b/packages/lib/src/payment-gateways/client.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/payment-gateways/client.ts
+
+/**
+ * The client-safe half of `payment-gateways/`: the vocabularies, the read
+ * model and the pure handle/route arithmetic (`docs/lib-module-guide.md` §7).
+ *
+ * `plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §5.3: a
+ * gateway is a RECORD carrying its own clearing account, never a role.
+ * §5.1's census is why: `authorize_net`/`authorize.net` and `Affirm`/`affirm`
+ * are each one rail arriving under two spellings, a rail is not permanent
+ * (Authorize.Net closed May 2026 mid-book), and role-per-gateway costs a role,
+ * an account and a chart migration per rail.
+ *
+ * Imports nothing server-only, and carries no `'use client'` directive -
+ * server code (the fulfillment planner, the chart seeder) imports this file
+ * too, and the directive would turn every export into a client-reference
+ * proxy there.
+ *
+ * ⚠️ Browser code must import `@auxx/lib/payment-gateways/client`, never
+ * `@auxx/lib/payment-gateways`. The barrel reaches Drizzle and the org cache.
+ */
+
+/** How a gateway drains. Mirrors `PaymentGatewaySettlementSource` (enum-values.ts). */
+export const PAYMENT_GATEWAY_SETTLEMENT_SOURCES = ['stripe', 'shopify_payments', 'manual'] as const
+export type PaymentGatewaySettlementSourceValue =
+  (typeof PAYMENT_GATEWAY_SETTLEMENT_SOURCES)[number]
+
+/** Whether a rail is still taking charges. Mirrors `PaymentGatewayStatus` (enum-values.ts). */
+export const PAYMENT_GATEWAY_STATUSES = ['active', 'closed'] as const
+export type PaymentGatewayStatusValue = (typeof PAYMENT_GATEWAY_STATUSES)[number]
+
+/** Human labels, so the picker and the badge agree without a second table. */
+export const PAYMENT_GATEWAY_SETTLEMENT_SOURCE_LABELS: Record<
+  PaymentGatewaySettlementSourceValue,
+  string
+> = {
+  stripe: 'Stripe',
+  shopify_payments: 'Shopify Payments',
+  manual: 'By hand',
+}
+
+export const PAYMENT_GATEWAY_STATUS_LABELS: Record<PaymentGatewayStatusValue, string> = {
+  active: 'Active',
+  closed: 'Closed',
+}
+
+/** Narrow an unknown option value to a {@link PaymentGatewaySettlementSourceValue}. */
+export function resolvePaymentGatewaySettlementSource(
+  value: string | null | undefined
+): PaymentGatewaySettlementSourceValue {
+  return value === 'stripe' || value === 'shopify_payments' ? value : 'manual'
+}
+
+/** Narrow an unknown option value to a {@link PaymentGatewayStatusValue}. */
+export function resolvePaymentGatewayStatus(
+  value: string | null | undefined
+): PaymentGatewayStatusValue {
+  return value === 'closed' ? 'closed' : 'active'
+}
+
+/**
+ * Trim and lower-case one gateway handle, so `'Affirm'` and `' affirm '`
+ * compare equal.
+ *
+ * Mirrors `normaliseGateways` in `postings/build-fulfillment-batch-entry.ts`
+ * exactly - two normalisers that disagreed by a stripped character would let
+ * a `payment_gateway` record silently stop matching the handle posting
+ * actually sees.
+ */
+export function normaliseGatewayHandle(handle: string): string {
+  return handle.trim().toLowerCase()
+}
+
+/**
+ * One `payment_gateway` record, as the settings screen and the fulfillment
+ * planner both read it.
+ */
+export interface PaymentGatewayRow {
+  id: string
+  recordId: string
+  name: string
+  /** Every stored `order_payment_gateways` value this rail answers to. Raw, not normalised. */
+  handles: string[]
+  /** The `gl_account` id this gateway settles into (task 15 §4 shape). No foreign key. */
+  clearingGlAccountId: string
+  /** The `gl_account` id the processor withholds its fee into, or null (`6100` is the fallback). */
+  feeGlAccountId: string | null
+  settlementSource: PaymentGatewaySettlementSourceValue
+  status: PaymentGatewayStatusValue
+  /** `YYYY-MM-DD`, or null. Informational only - nothing in posting reads it. */
+  lastSettlementAt: string | null
+  createdAt: Date | null
+  updatedAt: Date | null
+}
+
+/**
+ * What `resolveFulfillmentDebit` reads to answer a gateway with an id instead
+ * of a role (HANDOFF step 5 / task 13 §5.3's replacement for
+ * `FULFILLMENT_GATEWAY_DEBIT`).
+ *
+ * `handles` are RAW (not normalised) - the caller normalises both sides at
+ * match time with {@link normaliseGatewayHandle}, the same way
+ * `normaliseGateways` already does for the order's own gateway list.
+ */
+export interface GatewayRoute {
+  handles: readonly string[]
+  clearingGlAccountId: string
+  /** False for a closed rail. A closed rail still routes its OWN history - see below. */
+  active: boolean
+}
+
+/**
+ * Every route `resolveFulfillmentDebit` can match a normalised gateway
+ * against, from ACTIVE and CLOSED rows alike.
+ *
+ * 🛑 **Closed rows are included on purpose.** Authorize.Net is closed as of
+ * May 2026 but its orders are still in the ledger; excluding a closed
+ * gateway's route would silently fall the fulfillment debit fork back to its
+ * `clearing_card` default the moment somebody marks the rail closed, which is
+ * a posting change disguised as a settings edit. `active` rides along on the
+ * route so a caller that wants to treat closed differently (a report, a
+ * warning) can, without a second query.
+ */
+export function toGatewayRoutes(rows: readonly PaymentGatewayRow[]): GatewayRoute[] {
+  return rows.map((row) => ({
+    handles: row.handles,
+    clearingGlAccountId: row.clearingGlAccountId,
+    active: row.status === 'active',
+  }))
+}

--- a/packages/lib/src/payment-gateways/guard.ts
+++ b/packages/lib/src/payment-gateways/guard.ts
@@ -1,0 +1,29 @@
+// packages/lib/src/payment-gateways/guard.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError } from '../errors'
+
+const logger = createScopedLogger('payment-gateways')
+
+/**
+ * Run an imperative body that may `throw` an {@link AuxxError} for a known
+ * business-rule refusal, and convert the outcome into a neverthrow `Result`.
+ *
+ * Copied from `banking/guard.ts` per `docs/lib-module-guide.md` §3 - small
+ * enough that duplicating it beats a shared abstraction, and duplicating it is
+ * what lets this module bind its own logger scope.
+ */
+export async function guard<T>(
+  fn: () => Promise<T>,
+  logMessage: string,
+  meta: Record<string, unknown> = {}
+): Promise<Result<T, AuxxError>> {
+  try {
+    return ok(await fn())
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error(logMessage, { error, ...meta })
+    return err(new AuxxError('Internal error'))
+  }
+}

--- a/packages/lib/src/payment-gateways/index.ts
+++ b/packages/lib/src/payment-gateways/index.ts
@@ -1,0 +1,40 @@
+// packages/lib/src/payment-gateways/index.ts
+
+/**
+ * Payment gateways: a record carrying its own clearing account, never a role
+ * (`plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §5.3).
+ *
+ * 🛑 Server-only. Client code imports `@auxx/lib/payment-gateways/client`,
+ * which carries the vocabularies, the read model and the pure handle/route
+ * arithmetic.
+ */
+
+export type {
+  GatewayRoute,
+  PaymentGatewayRow,
+  PaymentGatewaySettlementSourceValue,
+  PaymentGatewayStatusValue,
+} from './client'
+export {
+  normaliseGatewayHandle,
+  PAYMENT_GATEWAY_SETTLEMENT_SOURCE_LABELS,
+  PAYMENT_GATEWAY_SETTLEMENT_SOURCES,
+  PAYMENT_GATEWAY_STATUS_LABELS,
+  PAYMENT_GATEWAY_STATUSES,
+  resolvePaymentGatewaySettlementSource,
+  resolvePaymentGatewayStatus,
+  toGatewayRoutes,
+} from './client'
+export type { PaymentGatewayFieldContext } from './reads'
+export {
+  getPaymentGateway,
+  listPaymentGateways,
+  loadPaymentGatewayFieldContext,
+  requirePaymentGatewayFieldContext,
+} from './reads'
+export type {
+  ArchivePaymentGatewayInput,
+  CreatePaymentGatewayInput,
+  UpdatePaymentGatewayInput,
+} from './writes'
+export { archivePaymentGateway, createPaymentGateway, updatePaymentGateway } from './writes'

--- a/packages/lib/src/payment-gateways/reads.ts
+++ b/packages/lib/src/payment-gateways/reads.ts
@@ -1,0 +1,252 @@
+// packages/lib/src/payment-gateways/reads.ts
+
+/**
+ * Every READ over `payment_gateway` records
+ * (`plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §5.3).
+ *
+ * Reads only. The writes the settings page needs live in `writes.ts`, because
+ * a file that both queries and mutates is the first step back toward a
+ * service class (`docs/lib-module-guide.md` §5).
+ *
+ * No permission checks anywhere in this file. The router asserts `ledgerView`
+ * or `ledgerControl` and hands the narrowed filters down.
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, asc, eq, inArray, isNull } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { getCachedEntityDefId, getOrgCache } from '../cache'
+import { UnprocessableEntityError } from '../errors'
+import { toRecordId } from '../resources/resource-id'
+import {
+  type PaymentGatewayRow,
+  resolvePaymentGatewaySettlementSource,
+  resolvePaymentGatewayStatus,
+} from './client'
+import { guard } from './guard'
+
+/** Every `payment_gateway` attribute a {@link PaymentGatewayRow} is assembled from. */
+const PAYMENT_GATEWAY_ATTRIBUTES = [
+  'payment_gateway_name',
+  'payment_gateway_handles',
+  'payment_gateway_clearing_account',
+  'payment_gateway_fee_account',
+  'payment_gateway_settlement_source',
+  'payment_gateway_status',
+  'payment_gateway_last_settlement_at',
+] as const
+
+type PaymentGatewayAttribute = (typeof PAYMENT_GATEWAY_ATTRIBUTES)[number]
+type PaymentGatewayFields = Record<PaymentGatewayAttribute, { id: string } | null>
+
+/** The resolved def and field ids every payment-gateway read needs. */
+export interface PaymentGatewayFieldContext {
+  paymentGatewayDefId: string
+  fields: PaymentGatewayFields
+}
+
+/**
+ * Resolve the `payment_gateway` def and its fields, or `null` when the org has
+ * not run entity migration 146 yet.
+ *
+ * `null` rather than a throw so a caller that only wants to know whether the
+ * feature is provisioned (the fulfillment planner, which has nothing to route
+ * without it) gets an empty answer instead of a 500. Write paths call
+ * {@link requirePaymentGatewayFieldContext} instead.
+ */
+export async function loadPaymentGatewayFieldContext(
+  organizationId: string
+): Promise<PaymentGatewayFieldContext | null> {
+  const paymentGatewayDefId = await getCachedEntityDefId(organizationId, 'payment_gateway')
+  if (!paymentGatewayDefId) return null
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([...PAYMENT_GATEWAY_ATTRIBUTES])) as PaymentGatewayFields
+  // Without `name` and `clearingAccount` there is no gateway at all: the
+  // display value and the one thing this entity exists to say are both gone.
+  if (!fields.payment_gateway_name || !fields.payment_gateway_clearing_account) return null
+  return { paymentGatewayDefId, fields }
+}
+
+/** {@link loadPaymentGatewayFieldContext}, as the refusal a write path needs. */
+export async function requirePaymentGatewayFieldContext(
+  organizationId: string
+): Promise<PaymentGatewayFieldContext> {
+  const ctx = await loadPaymentGatewayFieldContext(organizationId)
+  if (!ctx) {
+    throw new UnprocessableEntityError(
+      'Payment gateways are not available until the payment_gateway entity and its fields are ' +
+        'provisioned (entity migration 146)'
+    )
+  }
+  return ctx
+}
+
+/**
+ * Every payment gateway in the org, oldest first.
+ *
+ * ⚠️ **One query for the instances, one for their field values.** Never one
+ * per row - a handful of gateways is the normal case, but there is no reason
+ * this should degrade linearly for the org that adds a tenth.
+ */
+export async function listPaymentGateways(
+  db: Database,
+  organizationId: string,
+  params: { includeArchived?: boolean } = {}
+): Promise<Result<PaymentGatewayRow[], Error>> {
+  const { includeArchived = false } = params
+  return guard(
+    async () => {
+      const ctx = await loadPaymentGatewayFieldContext(organizationId)
+      if (!ctx) return []
+
+      const instances = await db
+        .select({
+          id: schema.EntityInstance.id,
+          createdAt: schema.EntityInstance.createdAt,
+          updatedAt: schema.EntityInstance.updatedAt,
+        })
+        .from(schema.EntityInstance)
+        .where(
+          and(
+            eq(schema.EntityInstance.organizationId, organizationId),
+            eq(schema.EntityInstance.entityDefinitionId, ctx.paymentGatewayDefId),
+            ...(includeArchived ? [] : [isNull(schema.EntityInstance.archivedAt)])
+          )
+        )
+        .orderBy(asc(schema.EntityInstance.createdAt))
+
+      if (instances.length === 0) return []
+      return hydratePaymentGateways(db, organizationId, ctx, instances)
+    },
+    'Failed to list payment gateways',
+    { organizationId }
+  )
+}
+
+/**
+ * One payment gateway by id, or `null` when it does not exist, is archived, or
+ * belongs to another org.
+ */
+export async function getPaymentGateway(
+  db: Database,
+  organizationId: string,
+  paymentGatewayId: string,
+  params: { includeArchived?: boolean } = {}
+): Promise<Result<PaymentGatewayRow | null, Error>> {
+  const { includeArchived = false } = params
+  return guard(
+    async () => {
+      const ctx = await loadPaymentGatewayFieldContext(organizationId)
+      if (!ctx) return null
+
+      const [instance] = await db
+        .select({
+          id: schema.EntityInstance.id,
+          createdAt: schema.EntityInstance.createdAt,
+          updatedAt: schema.EntityInstance.updatedAt,
+        })
+        .from(schema.EntityInstance)
+        .where(
+          and(
+            eq(schema.EntityInstance.id, paymentGatewayId),
+            eq(schema.EntityInstance.organizationId, organizationId),
+            eq(schema.EntityInstance.entityDefinitionId, ctx.paymentGatewayDefId),
+            ...(includeArchived ? [] : [isNull(schema.EntityInstance.archivedAt)])
+          )
+        )
+        .limit(1)
+
+      if (!instance) return null
+      const [row] = await hydratePaymentGateways(db, organizationId, ctx, [instance])
+      return row ?? null
+    },
+    'Failed to read payment gateway',
+    { organizationId, paymentGatewayId }
+  )
+}
+
+/**
+ * Turn a page of payment-gateway instance ids into full rows with exactly one
+ * query for their field values.
+ *
+ * `handles` is the one multi-value field here (TAGS - one `FieldValue` row per
+ * handle), so this groups values by `(entityId, fieldId)` into arrays rather
+ * than the single-row-per-field map {@link listBankAccounts}'s hydrate uses.
+ * Free-text tags (`options: { options: [] }`, the same shape
+ * `order_payment_gateways` declares) are written with the typed text AS the
+ * `optionId` - `valueText` is read as a defensive fallback only, mirroring
+ * `readOrderFacts` in `money/fulfillment-posting/reads.ts`.
+ */
+async function hydratePaymentGateways(
+  db: Database,
+  organizationId: string,
+  ctx: PaymentGatewayFieldContext,
+  page: { id: string; createdAt: Date | null; updatedAt: Date | null }[]
+): Promise<PaymentGatewayRow[]> {
+  const ids = page.map((row) => row.id)
+  const fieldIds = Object.values(ctx.fields)
+    .filter((field): field is { id: string } => field != null)
+    .map((field) => field.id)
+
+  const values = fieldIds.length
+    ? await db
+        .select({
+          entityId: schema.FieldValue.entityId,
+          fieldId: schema.FieldValue.fieldId,
+          valueText: schema.FieldValue.valueText,
+          valueDate: schema.FieldValue.valueDate,
+          optionId: schema.FieldValue.optionId,
+        })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            inArray(schema.FieldValue.entityId, ids),
+            inArray(schema.FieldValue.fieldId, fieldIds)
+          )
+        )
+    : []
+
+  const byInstance = new Map<string, Map<string, (typeof values)[number][]>>()
+  for (const value of values) {
+    let bucket = byInstance.get(value.entityId)
+    if (!bucket) {
+      bucket = new Map()
+      byInstance.set(value.entityId, bucket)
+    }
+    const rows = bucket.get(value.fieldId) ?? []
+    rows.push(value)
+    bucket.set(value.fieldId, rows)
+  }
+
+  const readOne = (instanceId: string, attr: PaymentGatewayAttribute) => {
+    const id = ctx.fields[attr]?.id
+    return id ? (byInstance.get(instanceId)?.get(id)?.[0] ?? null) : null
+  }
+  const readMany = (instanceId: string, attr: PaymentGatewayAttribute) => {
+    const id = ctx.fields[attr]?.id
+    return id ? (byInstance.get(instanceId)?.get(id) ?? []) : []
+  }
+
+  return page.map((row) => {
+    const lastSettlementAt = readOne(row.id, 'payment_gateway_last_settlement_at')?.valueDate
+    return {
+      id: row.id,
+      recordId: toRecordId(ctx.paymentGatewayDefId, row.id),
+      name: readOne(row.id, 'payment_gateway_name')?.valueText ?? '',
+      handles: readMany(row.id, 'payment_gateway_handles')
+        .map((value) => value.optionId ?? value.valueText)
+        .filter((handle): handle is string => !!handle),
+      clearingGlAccountId: readOne(row.id, 'payment_gateway_clearing_account')?.valueText ?? '',
+      feeGlAccountId: readOne(row.id, 'payment_gateway_fee_account')?.valueText ?? null,
+      settlementSource: resolvePaymentGatewaySettlementSource(
+        readOne(row.id, 'payment_gateway_settlement_source')?.optionId
+      ),
+      status: resolvePaymentGatewayStatus(readOne(row.id, 'payment_gateway_status')?.optionId),
+      lastSettlementAt: lastSettlementAt ? lastSettlementAt.slice(0, 10) : null,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    } satisfies PaymentGatewayRow
+  })
+}

--- a/packages/lib/src/payment-gateways/writes.ts
+++ b/packages/lib/src/payment-gateways/writes.ts
@@ -1,0 +1,389 @@
+// packages/lib/src/payment-gateways/writes.ts
+
+/**
+ * The three writes the payment gateways settings page needs: adding a
+ * gateway, editing one, and archiving one
+ * (`plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §5.3).
+ *
+ * Writes only; the reads live in `reads.ts`. No permission checks - the router
+ * asserts `ledgerControl` (`docs/lib-module-guide.md` §6).
+ *
+ * No delete. A gateway can carry posting history the moment a fulfillment
+ * batch routes a shipment to its clearing account, and the removal question
+ * this brief answers is `status: 'closed'` (§5.1: a rail is not permanent, and
+ * a closed one still winds down its balance) - the same shape `bank_account`
+ * chose over a hard delete for exactly this reason.
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { Result } from 'neverthrow'
+import { BadRequestError, ConflictError, NotFoundError } from '../errors'
+import { loadChartAccountsById } from '../postings/chart-accounts'
+import { UnifiedCrudHandler } from '../resources/crud'
+import { toRecordId } from '../resources/resource-id'
+import {
+  normaliseGatewayHandle,
+  PAYMENT_GATEWAY_SETTLEMENT_SOURCES,
+  PAYMENT_GATEWAY_STATUSES,
+  type PaymentGatewayRow,
+  type PaymentGatewaySettlementSourceValue,
+  type PaymentGatewayStatusValue,
+} from './client'
+import { guard } from './guard'
+import { getPaymentGateway, listPaymentGateways, requirePaymentGatewayFieldContext } from './reads'
+
+const logger = createScopedLogger('payment-gateways')
+
+/** What `createPaymentGateway` accepts. */
+export interface CreatePaymentGatewayInput {
+  organizationId: string
+  actorUserId: string
+  name: string
+  handles: string[]
+  /** The `gl_account` id this gateway settles into. Must be an active asset account. */
+  clearingAccountId: string
+  /** The `gl_account` id the processor withholds its fee into, or null. */
+  feeAccountId?: string | null
+  settlementSource?: PaymentGatewaySettlementSourceValue
+  status?: PaymentGatewayStatusValue
+  lastSettlementAt?: string | null
+}
+
+/** What `updatePaymentGateway` accepts. Undefined means "leave it alone". */
+export interface UpdatePaymentGatewayInput {
+  organizationId: string
+  actorUserId: string
+  paymentGatewayId: string
+  name?: string
+  handles?: string[]
+  clearingAccountId?: string
+  feeAccountId?: string | null
+  settlementSource?: PaymentGatewaySettlementSourceValue
+  status?: PaymentGatewayStatusValue
+  lastSettlementAt?: string | null
+}
+
+/** What `archivePaymentGateway` accepts. */
+export interface ArchivePaymentGatewayInput {
+  organizationId: string
+  actorUserId: string
+  paymentGatewayId: string
+}
+
+/**
+ * Add a gateway by hand.
+ *
+ * 🛑 **What it must NOT do: mint an account per gateway.** `clearingAccountId`
+ * names an EXISTING chart account (§5.3's explicit rule); this never creates
+ * one. Two rails sharing a clearing account is ordinary - `1200` already is
+ * that for every gateway `FULFILLMENT_GATEWAY_DEBIT` does not recognise.
+ */
+export async function createPaymentGateway(
+  db: Database,
+  input: CreatePaymentGatewayInput
+): Promise<Result<PaymentGatewayRow, Error>> {
+  const { organizationId, actorUserId } = input
+  return guard(
+    async () => {
+      const ctx = await requirePaymentGatewayFieldContext(organizationId)
+
+      const name = input.name?.trim()
+      if (!name) {
+        throw new BadRequestError('A payment gateway needs a name')
+      }
+
+      const handles = normaliseHandleList(input.handles)
+      if (handles.length === 0) {
+        throw new BadRequestError('A payment gateway needs at least one handle')
+      }
+
+      const settlementSource = input.settlementSource ?? 'manual'
+      assertSettlementSource(settlementSource)
+      const status = input.status ?? 'active'
+      assertStatus(status)
+
+      await assertHandlesAvailable(db, organizationId, name, handles)
+      await assertClearingAccount(db, organizationId, input.clearingAccountId)
+      if (input.feeAccountId) {
+        await assertFeeAccount(db, organizationId, input.feeAccountId)
+      }
+
+      const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+      const created = await crud.create(ctx.paymentGatewayDefId, {
+        payment_gateway_name: name,
+        payment_gateway_handles: handles,
+        payment_gateway_clearing_account: input.clearingAccountId.trim(),
+        payment_gateway_fee_account: input.feeAccountId?.trim() || undefined,
+        payment_gateway_settlement_source: settlementSource,
+        payment_gateway_status: status,
+        payment_gateway_last_settlement_at: input.lastSettlementAt || undefined,
+      })
+
+      const row = await getPaymentGateway(db, organizationId, created.instance.id)
+      if (row.isErr()) throw row.error
+      if (!row.value) {
+        throw new NotFoundError('The payment gateway could not be read back after writing')
+      }
+
+      logger.info('Created a payment gateway', {
+        organizationId,
+        paymentGatewayId: created.instance.id,
+        handles,
+      })
+      return row.value
+    },
+    'Failed to create payment gateway',
+    { organizationId }
+  )
+}
+
+/**
+ * Edit a gateway.
+ *
+ * ⚠️ `clearingAccountId` and `feeAccountId` are re-validated on every write,
+ * not only at create time - a bookkeeper can archive a chart account after a
+ * gateway was pointed at it, and an edit is the moment that surfaces rather
+ * than a silent posting-time refusal months later.
+ */
+export async function updatePaymentGateway(
+  db: Database,
+  input: UpdatePaymentGatewayInput
+): Promise<Result<PaymentGatewayRow, Error>> {
+  const { organizationId, actorUserId, paymentGatewayId } = input
+  return guard(
+    async () => {
+      const ctx = await requirePaymentGatewayFieldContext(organizationId)
+
+      const existing = await getPaymentGateway(db, organizationId, paymentGatewayId)
+      if (existing.isErr()) throw existing.error
+      if (!existing.value) {
+        throw new NotFoundError(`Payment gateway ${paymentGatewayId} was not found`)
+      }
+
+      const patch: Record<string, unknown> = {}
+
+      if (input.name !== undefined) {
+        const name = input.name.trim()
+        if (!name) throw new BadRequestError('A payment gateway needs a name')
+        patch.payment_gateway_name = name
+      }
+
+      let handles: string[] | undefined
+      if (input.handles !== undefined) {
+        handles = normaliseHandleList(input.handles)
+        if (handles.length === 0) {
+          throw new BadRequestError('A payment gateway needs at least one handle')
+        }
+        patch.payment_gateway_handles = handles
+      }
+      if (handles) {
+        await assertHandlesAvailable(
+          db,
+          organizationId,
+          input.name?.trim() || existing.value.name,
+          handles,
+          paymentGatewayId
+        )
+      }
+
+      if (input.clearingAccountId !== undefined) {
+        await assertClearingAccount(db, organizationId, input.clearingAccountId)
+        patch.payment_gateway_clearing_account = input.clearingAccountId.trim()
+      }
+      if (input.feeAccountId !== undefined) {
+        if (input.feeAccountId) {
+          await assertFeeAccount(db, organizationId, input.feeAccountId)
+        }
+        patch.payment_gateway_fee_account = input.feeAccountId?.trim() || null
+      }
+      if (input.settlementSource !== undefined) {
+        assertSettlementSource(input.settlementSource)
+        patch.payment_gateway_settlement_source = input.settlementSource
+      }
+      if (input.status !== undefined) {
+        assertStatus(input.status)
+        patch.payment_gateway_status = input.status
+      }
+      if (input.lastSettlementAt !== undefined) {
+        patch.payment_gateway_last_settlement_at = input.lastSettlementAt || null
+      }
+
+      if (Object.keys(patch).length > 0) {
+        const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+        await crud.update(toRecordId(ctx.paymentGatewayDefId, paymentGatewayId), patch)
+      }
+
+      const row = await getPaymentGateway(db, organizationId, paymentGatewayId)
+      if (row.isErr()) throw row.error
+      if (!row.value) {
+        throw new NotFoundError('The payment gateway could not be read back after writing')
+      }
+
+      logger.info('Updated a payment gateway', {
+        organizationId,
+        paymentGatewayId,
+        fields: Object.keys(patch),
+      })
+      return row.value
+    },
+    'Failed to update payment gateway',
+    { organizationId, paymentGatewayId }
+  )
+}
+
+/**
+ * Mark a gateway closed. Not a delete (see the file header) - a closed rail
+ * still routes its own history (`toGatewayRoutes` in `client.ts` reads active
+ * AND closed rows) and its clearing balance still has to wind down to zero.
+ */
+export async function archivePaymentGateway(
+  db: Database,
+  input: ArchivePaymentGatewayInput
+): Promise<Result<PaymentGatewayRow, Error>> {
+  const { organizationId, actorUserId, paymentGatewayId } = input
+  return guard(
+    async () => {
+      const ctx = await requirePaymentGatewayFieldContext(organizationId)
+      const existing = await getPaymentGateway(db, organizationId, paymentGatewayId)
+      if (existing.isErr()) throw existing.error
+      if (!existing.value) {
+        throw new NotFoundError(`Payment gateway ${paymentGatewayId} was not found`)
+      }
+      if (existing.value.status === 'closed') {
+        throw new ConflictError('That payment gateway is already closed.')
+      }
+
+      const crud = new UnifiedCrudHandler(organizationId, actorUserId, db)
+      await crud.update(toRecordId(ctx.paymentGatewayDefId, paymentGatewayId), {
+        payment_gateway_status: 'closed',
+      })
+
+      const row = await getPaymentGateway(db, organizationId, paymentGatewayId)
+      if (row.isErr()) throw row.error
+      if (!row.value) {
+        throw new NotFoundError('The payment gateway could not be read back after closing')
+      }
+
+      logger.info('Closed a payment gateway', { organizationId, paymentGatewayId })
+      return row.value
+    },
+    'Failed to close payment gateway',
+    { organizationId, paymentGatewayId }
+  )
+}
+
+/** Trim every handle, drop blanks, and de-duplicate case-sensitively (the stored value keeps its casing). */
+function normaliseHandleList(handles: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const raw of handles) {
+    const trimmed = raw?.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    out.push(trimmed)
+  }
+  return out
+}
+
+function assertSettlementSource(
+  value: string
+): asserts value is PaymentGatewaySettlementSourceValue {
+  if (!PAYMENT_GATEWAY_SETTLEMENT_SOURCES.includes(value as PaymentGatewaySettlementSourceValue)) {
+    throw new BadRequestError(
+      `"${value}" is not a settlement source. Use ${PAYMENT_GATEWAY_SETTLEMENT_SOURCES.join(', ')}`
+    )
+  }
+}
+
+function assertStatus(value: string): asserts value is PaymentGatewayStatusValue {
+  if (!PAYMENT_GATEWAY_STATUSES.includes(value as PaymentGatewayStatusValue)) {
+    throw new BadRequestError(
+      `"${value}" is not a status. Use ${PAYMENT_GATEWAY_STATUSES.join(' or ')}`
+    )
+  }
+}
+
+/**
+ * Refuse two records sharing a normalised handle, naming both.
+ *
+ * §5.1's census is why this exists: `authorize_net`/`authorize.net` and
+ * `Affirm`/`affirm` are each one rail under two spellings, and a
+ * `payment_gateway` keyed on the handle needs both mapped to ONE row - so a
+ * second record claiming a handle the first already holds is never a valid
+ * state, whichever spelling it arrives under.
+ */
+async function assertHandlesAvailable(
+  db: Database,
+  organizationId: string,
+  name: string,
+  handles: readonly string[],
+  excludeId?: string
+): Promise<void> {
+  const existing = await listPaymentGateways(db, organizationId)
+  if (existing.isErr()) throw existing.error
+
+  const wanted = new Set(handles.map(normaliseGatewayHandle))
+  for (const gateway of existing.value) {
+    if (gateway.id === excludeId) continue
+    for (const handle of gateway.handles) {
+      if (wanted.has(normaliseGatewayHandle(handle))) {
+        throw new ConflictError(
+          `"${handle}" is already a handle on ${gateway.name || 'another gateway'} - ` +
+            `${name} and ${gateway.name || 'that gateway'} cannot share a handle.`
+        )
+      }
+    }
+  }
+}
+
+/** The clearing account must exist, be active, and be an asset account. */
+async function assertClearingAccount(
+  db: Database,
+  organizationId: string,
+  clearingAccountId: string
+): Promise<void> {
+  const id = clearingAccountId?.trim()
+  if (!id) throw new BadRequestError('A payment gateway needs a clearing account')
+  await assertAccount(db, organizationId, id, 'asset', 'clearing account')
+}
+
+/** The fee account, when given, must exist, be active, and be an expense account. */
+async function assertFeeAccount(
+  db: Database,
+  organizationId: string,
+  feeAccountId: string
+): Promise<void> {
+  const id = feeAccountId?.trim()
+  if (!id) return
+  await assertAccount(db, organizationId, id, 'expense', 'fee account')
+}
+
+async function assertAccount(
+  db: Database,
+  organizationId: string,
+  accountId: string,
+  wantType: 'asset' | 'expense',
+  label: string
+): Promise<void> {
+  const { accounts, malformed } = await loadChartAccountsById(
+    db,
+    organizationId,
+    [accountId],
+    'Payment gateways cannot be mapped until the chart of accounts is provisioned'
+  )
+  const account = accounts.get(accountId)
+  if (!account || malformed.includes(accountId)) {
+    throw new BadRequestError(`The ${label} does not exist in your chart, or has been removed.`)
+  }
+  if (!account.isActive) {
+    throw new BadRequestError(
+      `"${account.name || account.code}" is inactive and cannot be a ${label}.`
+    )
+  }
+  if (account.accountType !== wantType) {
+    throw new BadRequestError(
+      `"${account.name || account.code}" is a ${account.accountType} account. A ${label} must be ${wantType === 'asset' ? 'an asset' : 'an expense'} account.`
+    )
+  }
+}

--- a/packages/lib/src/postings/__tests__/account-identities.test.ts
+++ b/packages/lib/src/postings/__tests__/account-identities.test.ts
@@ -164,6 +164,35 @@ describe('listAccountIdentities - the checklist', () => {
     expect(map.providerAccounts).toEqual([])
     expect(map.rows.every((row) => row.suggestion === null)).toBe(true)
   })
+
+  // Task 13 §3: the broken sweep goes through the same `isMappableTo` as the
+  // confirm - a mapping that was valid by classification alone and is now
+  // invalid by subtype must show as broken, the same as any other lapsed one.
+  it('reports a bank account mapped to a same-section, wrong-subtype account as broken', async () => {
+    const bankAccount: ChartAccountRow = {
+      id: 'gl1010',
+      code: '1010',
+      name: 'Wells Fargo Checking',
+      accountType: 'asset',
+      isActive: true,
+      subtype: 'bank',
+    }
+    listChartAccounts.mockResolvedValue(ok([bankAccount]))
+    const arProviderAccount = providerAccount({
+      id: '50',
+      accountType: 'Accounts Receivable',
+      fullyQualifiedName: 'Accounts Receivable (A/R)',
+      classification: 'asset', // same classification - only the subtype disagrees
+    })
+    stubProvider({
+      accounts: [arProviderAccount],
+      mappings: new Map([['gl1010', '50']]),
+    })
+
+    const map = (await listAccountIdentities(db, ORG))._unsafeUnwrap()
+
+    expect(map.broken).toEqual(['1010 Wells Fargo Checking'])
+  })
 })
 
 describe('setAccountIdentity - the confirmation', () => {
@@ -211,7 +240,9 @@ describe('setAccountIdentity - the confirmation', () => {
     })
 
     expect(result.isErr()).toBe(true)
-    expect(result._unsafeUnwrapErr().message).toContain('not active')
+    // `validateProviderMapping`'s wording, task 13 §3 - the same sentence
+    // `resolveProviderAccountIds` already uses for the identical fact.
+    expect(result._unsafeUnwrapErr().message).toContain('deactivated')
     expect(set).not.toHaveBeenCalled()
   })
 
@@ -240,6 +271,65 @@ describe('setAccountIdentity - the confirmation', () => {
 
     expect(result.isErr()).toBe(true)
     expect(set).not.toHaveBeenCalled()
+  })
+
+  // Task 13 §3: a bank account may only map to a bank account, even when the
+  // classification agrees.
+  it('refuses a bank account mapped to Accounts Receivable, naming both in the sentence', async () => {
+    const bankAccount: ChartAccountRow = {
+      id: 'gl1010',
+      code: '1010',
+      name: 'Wells Fargo Checking',
+      accountType: 'asset',
+      isActive: true,
+      subtype: 'bank',
+    }
+    listChartAccounts.mockResolvedValue(ok([bankAccount]))
+    const arProviderAccount = providerAccount({
+      id: '50',
+      accountType: 'Accounts Receivable',
+      fullyQualifiedName: 'Accounts Receivable (A/R)',
+      classification: 'asset',
+    })
+    const { set } = stubProvider({ accounts: [arProviderAccount] })
+
+    const result = await setAccountIdentity(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1010',
+      providerAccountId: '50',
+    })
+
+    expect(result.isErr()).toBe(true)
+    const message = result._unsafeUnwrapErr().message
+    expect(message).toContain('1010 Wells Fargo Checking')
+    expect(message).toContain('bank account')
+    expect(message).toContain('Accounts Receivable (A/R)')
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('confirms a bank account mapped to a Bank provider account', async () => {
+    const bankAccount: ChartAccountRow = {
+      id: 'gl1010',
+      code: '1010',
+      name: 'Wells Fargo Checking',
+      accountType: 'asset',
+      isActive: true,
+      subtype: 'bank',
+    }
+    listChartAccounts.mockResolvedValue(ok([bankAccount]))
+    const bankProviderAccount = providerAccount({ id: '50', accountType: 'Bank' })
+    const { set } = stubProvider({ accounts: [bankProviderAccount] })
+
+    const result = await setAccountIdentity(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1010',
+      providerAccountId: '50',
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ glAccountId: 'gl1010', providerAccountId: '50' })
+    )
   })
 
   it('clears the mapping when the provider account id is null', async () => {

--- a/packages/lib/src/postings/__tests__/build-credit-memo-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-credit-memo-entry.test.ts
@@ -67,7 +67,7 @@ describe('a native credit memo (reverseRevenue, no settlement)', () => {
     const [debit] = lines(built, ACCOUNT_ROLES.REVENUE_RETURNS_ALLOWANCES)
     expect(debit).toMatchObject({ direction: 'debit', amount: 12_000 })
     expect(lines(built, ACCOUNT_ROLES.REVENUE_SERVICE)).toHaveLength(0)
-    expect(lines(built, ACCOUNT_ROLES.REVENUE_DTC)).toHaveLength(0)
+    expect(lines(built, ACCOUNT_ROLES.REVENUE_PRODUCT)).toHaveLength(0)
   })
 
   it('debits sales tax payable for the transcribed tax', () => {

--- a/packages/lib/src/postings/__tests__/build-deposit-application-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-deposit-application-entry.test.ts
@@ -46,11 +46,7 @@ describe('the reclass', () => {
 
   it('moves no cash: neither leg touches an account money passes through', () => {
     const built = buildDepositApplicationEntry(BASE)
-    for (const role of [
-      ACCOUNT_ROLES.CASH,
-      ACCOUNT_ROLES.UNDEPOSITED_FUNDS,
-      ACCOUNT_ROLES.CLEARING_CARD,
-    ]) {
+    for (const role of [ACCOUNT_ROLES.UNDEPOSITED_FUNDS, ACCOUNT_ROLES.CLEARING_CARD]) {
       expect(line(built.entry, role)).toBeUndefined()
     }
   })

--- a/packages/lib/src/postings/__tests__/build-fulfillment-batch-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-fulfillment-batch-entry.test.ts
@@ -65,6 +65,7 @@ function shipment(overrides: Partial<UnpostedShipment> = {}): UnpostedShipment {
     priorShipmentsSubtotalMinor: 0,
     includeShipping: true,
     contactId: 'contact-1',
+    taxLines: [],
     ...overrides,
   }
 }
@@ -74,7 +75,8 @@ function planned(overrides: Partial<UnpostedShipment> = {}): PlannedShipment {
   const base = shipment(overrides)
   const debit = resolveFulfillmentDebit(base)
   if (debit.kind !== 'debit') throw new Error(`fixture excluded: ${debit.reason}`)
-  return { ...base, amounts: computeShipmentAmounts(base, debit.role) }
+  const { kind: _kind, ...rest } = debit
+  return { ...base, amounts: computeShipmentAmounts(base, rest) }
 }
 
 /** Total a group the way the plan does, so the builder gets a realistic input. */
@@ -83,6 +85,7 @@ function group(shipments: PlannedShipment[], groupKey = '2026-07-06'): Fulfillme
     clearing_card: 0,
     clearing_affirm: 0,
     accounts_receivable: 0,
+    gateway: 0,
   }
   let subtotalMinor = 0
   let taxMinor = 0
@@ -116,6 +119,16 @@ function linesFor(entry: Entry, role: string) {
 function amountFor(entry: Entry, role: string): number | undefined {
   const found = linesFor(entry, role)
   return found.length === 0 ? undefined : found.reduce((sum, line) => sum + line.amount, 0)
+}
+
+/** The amount on the one `role` line carrying `{ [dimension]: value }` - brief 13 §5. */
+function dimensionAmountFor(
+  entry: Entry,
+  role: string,
+  dimension: string,
+  value: string
+): number | undefined {
+  return linesFor(entry, role).find((line) => line.dimensions?.[dimension] === value)?.amount
 }
 
 // ── 1. The debit fork ───────────────────────────────────────────────────────
@@ -223,7 +236,7 @@ describe('computeShipmentAmounts', () => {
         orderTaxTotalMinor: 1_650,
         orderShippingTotalMinor: 0,
       }),
-      'clearing_card'
+      { role: 'clearing_card' }
     )
     expect(amounts).toMatchObject({
       debitRole: 'clearing_card',
@@ -260,7 +273,7 @@ describe('computeShipmentAmounts', () => {
         orderTaxTotalMinor: 1_650,
         orderShippingTotalMinor: 0,
       }),
-      'clearing_card'
+      { role: 'clearing_card' }
     )
     expect(amounts.taxBasis).toBe('allocated')
     expect(amounts.taxMinor).toBe(1_650)
@@ -283,7 +296,7 @@ describe('computeShipmentAmounts', () => {
         orderTaxTotalMinor: 400,
         orderShippingTotalMinor: 0,
       }),
-      'clearing_card'
+      { role: 'clearing_card' }
     )
     expect(amounts).toMatchObject({ subtotalMinor: 3_000, taxMinor: 300, taxBasis: 'per_line' })
   })
@@ -304,7 +317,7 @@ describe('computeShipmentAmounts', () => {
         orderTaxTotalMinor: 400,
         orderShippingTotalMinor: 0,
       }),
-      'clearing_card'
+      { role: 'clearing_card' }
     )
     expect(amounts.taxMinor).toBe(400)
   })
@@ -326,7 +339,7 @@ describe('computeShipmentAmounts', () => {
         orderShippingTotalMinor: 0,
         priorShipmentsSubtotalMinor: 0,
       }),
-      'clearing_card'
+      { role: 'clearing_card' }
     )
     const second = computeShipmentAmounts(
       shipment({
@@ -344,7 +357,7 @@ describe('computeShipmentAmounts', () => {
         orderShippingTotalMinor: 0,
         priorShipmentsSubtotalMinor: 10_000,
       }),
-      'clearing_card'
+      { role: 'clearing_card' }
     )
     expect(first.taxMinor).toBe(770)
     expect(second.taxMinor).toBe(1_540)
@@ -354,11 +367,11 @@ describe('computeShipmentAmounts', () => {
   it('recognises shipping once, on the shipment that carries the flag', () => {
     const carries = computeShipmentAmounts(
       shipment({ orderShippingTotalMinor: 1_500, includeShipping: true }),
-      'clearing_card'
+      { role: 'clearing_card' }
     )
     const does_not = computeShipmentAmounts(
       shipment({ orderShippingTotalMinor: 1_500, includeShipping: false }),
-      'clearing_card'
+      { role: 'clearing_card' }
     )
     expect(carries.shippingMinor).toBe(1_500)
     expect(does_not.shippingMinor).toBe(0)
@@ -378,7 +391,7 @@ describe('computeShipmentAmounts', () => {
             },
           ],
         }),
-        'clearing_card'
+        { role: 'clearing_card' }
       )
     ).toThrowError(UnprocessableEntityError)
   })
@@ -478,7 +491,11 @@ describe('buildFulfillmentBatchEntry', () => {
       card.amounts.totalMinor + exempt.amounts.totalMinor
     )
     expect(amountFor(entry, ACCOUNT_ROLES.CLEARING_AFFIRM)).toBe(affirm.amounts.totalMinor)
-    expect(amountFor(entry, ACCOUNT_ROLES.REVENUE_DEALER)).toBe(termsOther.amounts.subtotalMinor)
+    // Channel is a dimension on ONE revenue_product account now (brief 13 §5),
+    // never a second account - the dealer order's share is the dealer-dimensioned line.
+    expect(dimensionAmountFor(entry, ACCOUNT_ROLES.REVENUE_PRODUCT, 'channel', 'dealer')).toBe(
+      termsOther.amounts.subtotalMinor
+    )
   })
 
   it('emits ONE receivable line per order, sourced on the order', () => {
@@ -596,7 +613,7 @@ describe('buildFulfillmentBatchEntry', () => {
     expect(entry.lines.map((line) => line.accountRole)).toEqual([
       ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
       ACCOUNT_ROLES.CLEARING_CARD,
-      ACCOUNT_ROLES.REVENUE_DTC,
+      ACCOUNT_ROLES.REVENUE_PRODUCT,
     ])
     expect(entry.lines.map((line) => line.sortOrder)).toEqual([0, 1, 2])
   })
@@ -646,8 +663,14 @@ describe('buildFulfillmentBatchEntry', () => {
       ledgerCurrency: 'USD',
       attempt: 0,
     })
-    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DTC)).toBe(built.totals.subtotalMinor)
-    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DEALER)).toBeUndefined()
+    // One revenue_product line, dimensioned `dtc` - never a dealer line.
+    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_PRODUCT)).toBe(built.totals.subtotalMinor)
+    expect(dimensionAmountFor(built.entry, ACCOUNT_ROLES.REVENUE_PRODUCT, 'channel', 'dtc')).toBe(
+      built.totals.subtotalMinor
+    )
+    expect(
+      dimensionAmountFor(built.entry, ACCOUNT_ROLES.REVENUE_PRODUCT, 'channel', 'dealer')
+    ).toBeUndefined()
   })
 
   it('carries the memo onto the summarised lines and the order number onto the A/R ones', () => {

--- a/packages/lib/src/postings/__tests__/build-fulfillment-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-fulfillment-entry.test.ts
@@ -12,6 +12,8 @@
 //     consumer line. 49 §8.4 decision 5 reversed it: `order_channel` is
 //     human-set and unbound, so the refusal recognised no imported revenue at
 //     all, and unrecognised revenue is the less visible of the two errors.
+//     Since brief 13 §5, the channel is a `dimensions.channel` value on the
+//     ONE `revenue_product` line, never a second account.
 //  2. **A second shipment must not re-recognise the first.** That is what the
 //     shipped-lines input and the `includeShipping` flag exist for, and it is
 //     asserted by summing two entries against the order total.
@@ -22,7 +24,7 @@ import { UnprocessableEntityError } from '../../errors'
 import { ACCOUNT_ROLES } from '../build-entry'
 import {
   buildFulfillmentEntry,
-  CHANNEL_REVENUE_ROLE,
+  CHANNEL_KEYS,
   extendRateToAmount,
   FULFILLMENT_SOURCE_TYPE,
   fulfillmentPeriodKey,
@@ -58,15 +60,35 @@ function amountFor(
   return entry.lines.find((line) => line.accountRole === role)?.amount
 }
 
-describe('the channel table', () => {
-  it('has exactly four rows and refuses none of them', () => {
-    expect(Object.keys(CHANNEL_REVENUE_ROLE).sort()).toEqual(['dealer', 'dtc', 'manual', 'null'])
+/** The amount on the revenue_product line carrying `{ channel: value }`. */
+function channelAmountFor(
+  entry: ReturnType<typeof buildFulfillmentEntry>['entry'],
+  value: string
+): number | undefined {
+  return entry.lines.find(
+    (line) =>
+      line.accountRole === ACCOUNT_ROLES.REVENUE_PRODUCT && line.dimensions?.channel === value
+  )?.amount
+}
+
+/** Every jurisdiction dimension the sales_tax_payable lines carry, in order. */
+function jurisdictionLines(
+  entry: ReturnType<typeof buildFulfillmentEntry>['entry']
+): Array<{ jurisdiction: string | undefined; amount: number }> {
+  return entry.lines
+    .filter((line) => line.accountRole === ACCOUNT_ROLES.SALES_TAX_PAYABLE)
+    .map((line) => ({ jurisdiction: line.dimensions?.jurisdiction, amount: line.amount }))
+}
+
+describe('the channel keyspace', () => {
+  it('has exactly four rows and every dimension value is dtc or dealer', () => {
+    expect(Object.keys(CHANNEL_KEYS).sort()).toEqual(['dealer', 'dtc', 'manual', 'null'])
     // ⤵️ Both used to be 'refuse'. 49 §8.4 decision 5: `order_channel` is
     // human-set and no connector binds it, so the refusal did not protect the
     // DTC/dealer split - it refused every imported order and recognised nothing.
-    expect(CHANNEL_REVENUE_ROLE.manual).toBe(ACCOUNT_ROLES.REVENUE_DTC)
-    expect(CHANNEL_REVENUE_ROLE.null).toBe(ACCOUNT_ROLES.REVENUE_DTC)
-    expect(Object.values(CHANNEL_REVENUE_ROLE)).not.toContain('refuse')
+    expect(CHANNEL_KEYS.manual).toBe('dtc')
+    expect(CHANNEL_KEYS.null).toBe('dtc')
+    expect(Object.values(CHANNEL_KEYS)).not.toContain('refuse')
   })
 
   it('normalises an absent or unrecognised channel to the null row', () => {
@@ -77,15 +99,21 @@ describe('the channel table', () => {
     expect(toChannelKey('dealer')).toBe('dealer')
   })
 
-  it('books dtc to revenue_dtc and dealer to revenue_dealer', () => {
+  it('books dtc and dealer onto the SAME revenue_product role, dimensioned by channel', () => {
     const dtc = buildFulfillmentEntry({ ...BASE, shippedLines: WHOLE_ORDER })
-    expect(dtc.revenueRole).toBe(ACCOUNT_ROLES.REVENUE_DTC)
+    expect(dtc.revenueRole).toBe(ACCOUNT_ROLES.REVENUE_PRODUCT)
+    expect(dtc.channelDimension).toBe('dtc')
     const dealer = buildFulfillmentEntry({
       ...BASE,
       channel: 'dealer',
       shippedLines: WHOLE_ORDER,
     })
-    expect(dealer.revenueRole).toBe(ACCOUNT_ROLES.REVENUE_DEALER)
+    expect(dealer.revenueRole).toBe(ACCOUNT_ROLES.REVENUE_PRODUCT)
+    expect(dealer.channelDimension).toBe('dealer')
+    // One role total, exactly two accounts is what this unit set out to undo.
+    expect(
+      dtc.entry.lines.filter((l) => l.accountRole === ACCOUNT_ROLES.REVENUE_PRODUCT)
+    ).toHaveLength(1)
   })
 
   it.each([
@@ -95,18 +123,19 @@ describe('the channel table', () => {
     ['  '],
   ])('books channel %s to consumer revenue rather than refusing it', (channel) => {
     const built = buildFulfillmentEntry({ ...BASE, channel, shippedLines: WHOLE_ORDER })
-    expect(built.revenueRole).toBe(ACCOUNT_ROLES.REVENUE_DTC)
+    expect(built.channelDimension).toBe('dtc')
     // The whole subtotal reaches 4000. The point of failing open is that the
     // revenue is ON the books, in a line a person can move, not missing.
-    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DTC)).toBe(100_000)
+    expect(channelAmountFor(built.entry, 'dtc')).toBe(100_000)
   })
 
-  it('still books an explicit dealer order to the dealer line', () => {
+  it('still books an explicit dealer order to the dealer dimension', () => {
     // Failing open must not collapse the split it was protecting: the moment a
     // person says `dealer`, the default stops being reached.
     const built = buildFulfillmentEntry({ ...BASE, channel: 'dealer', shippedLines: WHOLE_ORDER })
-    expect(built.revenueRole).toBe(ACCOUNT_ROLES.REVENUE_DEALER)
-    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DTC)).toBeUndefined()
+    expect(built.channelDimension).toBe('dealer')
+    expect(channelAmountFor(built.entry, 'dtc')).toBeUndefined()
+    expect(channelAmountFor(built.entry, 'dealer')).toBe(100_000)
   })
 })
 
@@ -120,7 +149,7 @@ describe('the entry', () => {
     expect(built.totalMinor).toBe(109_500)
 
     expect(amountFor(built.entry, ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE)).toBe(109_500)
-    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_DTC)).toBe(100_000)
+    expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_PRODUCT)).toBe(100_000)
     expect(amountFor(built.entry, ACCOUNT_ROLES.SALES_TAX_PAYABLE)).toBe(8_000)
     expect(amountFor(built.entry, ACCOUNT_ROLES.REVENUE_SHIPPING)).toBe(1_500)
     expect(built.entry.totalDebit).toBe(built.entry.totalCredit)
@@ -196,7 +225,9 @@ describe('the counterparty (brief 13 §1.2)', () => {
       counterpartyType: 'customer',
       counterpartyId: 'ei_contact_1',
     })
-    const revenue = built.entry.lines.find((line) => line.accountRole === ACCOUNT_ROLES.REVENUE_DTC)
+    const revenue = built.entry.lines.find(
+      (line) => line.accountRole === ACCOUNT_ROLES.REVENUE_PRODUCT
+    )
     expect(revenue?.counterpartyId).toBeUndefined()
   })
 
@@ -206,6 +237,65 @@ describe('the counterparty (brief 13 §1.2)', () => {
       (line) => line.accountRole === ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE
     )
     expect(receivable?.counterpartyId).toBeUndefined()
+  })
+})
+
+describe('the jurisdiction split (brief 13 §5)', () => {
+  const TAX_LINES = [
+    { title: 'CA State Tax', priceMinor: 6_000 },
+    { title: 'CA District Tax', priceMinor: 2_000 },
+  ]
+
+  it('splits the tax credit across jurisdictions when the tax lines tie to the order total', () => {
+    const built = buildFulfillmentEntry({ ...BASE, shippedLines: WHOLE_ORDER, taxLines: TAX_LINES })
+    const lines = jurisdictionLines(built.entry)
+    expect(lines).toEqual(
+      expect.arrayContaining([
+        { jurisdiction: 'CA State Tax', amount: 6_000 },
+        { jurisdiction: 'CA District Tax', amount: 2_000 },
+      ])
+    )
+    expect(lines).toHaveLength(2)
+    expect(lines.reduce((sum, line) => sum + line.amount, 0)).toBe(8_000)
+  })
+
+  it('falls back to one undimensioned line when the tax lines do not tie to the order total', () => {
+    // A partial breakdown reads as a complete one - see split-tax-by-jurisdiction.ts.
+    const built = buildFulfillmentEntry({
+      ...BASE,
+      shippedLines: WHOLE_ORDER,
+      taxLines: [{ title: 'CA State Tax', priceMinor: 5_000 }],
+    })
+    expect(jurisdictionLines(built.entry)).toEqual([{ jurisdiction: undefined, amount: 8_000 }])
+  })
+
+  it('falls back to one undimensioned line when there are no tax lines at all', () => {
+    const built = buildFulfillmentEntry({ ...BASE, shippedLines: WHOLE_ORDER })
+    expect(jurisdictionLines(built.entry)).toEqual([{ jurisdiction: undefined, amount: 8_000 }])
+  })
+
+  it('splits THIS shipment tax pro rata to the tax lines, with largest-remainder rounding', () => {
+    // Order-level weights (A:B = 77:154 = 1:2) applied to this shipment's own
+    // $0.77 of tax, not to the order's $2.31 - a `tax_line` has no per-shipment
+    // granularity of its own (brief 13 §5.3).
+    const built = buildFulfillmentEntry({
+      ...BASE,
+      orderSubtotalMinor: 3_000,
+      orderTaxTotalMinor: 231,
+      orderShippingTotalMinor: 0,
+      shippedLines: [{ lineId: 'l1', quantity: 1, unitPriceMinor: 1_000 }],
+      taxLines: [
+        { title: 'A', priceMinor: 77 },
+        { title: 'B', priceMinor: 154 },
+      ],
+    })
+    expect(built.taxMinor).toBe(77)
+    expect(jurisdictionLines(built.entry)).toEqual(
+      expect.arrayContaining([
+        { jurisdiction: 'A', amount: 26 },
+        { jurisdiction: 'B', amount: 51 },
+      ])
+    )
   })
 })
 

--- a/packages/lib/src/postings/__tests__/build-payment-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-payment-entry.test.ts
@@ -53,29 +53,67 @@ function line(entry: ReturnType<typeof buildPaymentEntry>['entry'], role: string
   return entry.lines.find((row) => row.accountRole === role)
 }
 
+/** The `cash` route's leg, named by `glAccountId` - never a role (brief 13 §2.4). */
+function bankLine(entry: ReturnType<typeof buildPaymentEntry>['entry'], glAccountId: string) {
+  return entry.lines.find((row) => row.glAccountId === glAccountId)
+}
+
+const BANK_ACCOUNT_GL_ID = 'gl-1000'
+
 describe('the route table', () => {
-  it('maps all three routes and sends clearing to the one clearing role', () => {
+  it('maps all three routes, cash to a bank account and the rest to roles', () => {
     expect(Object.keys(PAYMENT_ROUTE_ROLE).sort()).toEqual([
       'cash',
       'clearing',
       'undeposited_funds',
     ])
-    expect(PAYMENT_ROUTE_ROLE.undeposited_funds).toBe(ACCOUNT_ROLES.UNDEPOSITED_FUNDS)
-    expect(PAYMENT_ROUTE_ROLE.cash).toBe(ACCOUNT_ROLES.CASH)
-    expect(PAYMENT_ROUTE_ROLE.clearing).toBe(ACCOUNT_ROLES.CLEARING_CARD)
+    expect(PAYMENT_ROUTE_ROLE.undeposited_funds).toEqual({
+      kind: 'role',
+      role: ACCOUNT_ROLES.UNDEPOSITED_FUNDS,
+    })
+    expect(PAYMENT_ROUTE_ROLE.cash).toEqual({ kind: 'bank_account' })
+    expect(PAYMENT_ROUTE_ROLE.clearing).toEqual({ kind: 'role', role: ACCOUNT_ROLES.CLEARING_CARD })
   })
 
   it.each([
     'undeposited_funds',
-    'cash',
     'clearing',
-  ] as const)('debits the %s account and credits A/R for a charge', (route) => {
+  ] as const)('debits the %s role and credits A/R for a charge', (route) => {
     const built = buildPaymentEntry({ ...BASE, route })
-    expect(built.routeRole).toBe(PAYMENT_ROUTE_ROLE[route])
-    expect(line(built.entry, PAYMENT_ROUTE_ROLE[route])?.direction).toBe('debit')
+    const expectedRole = PAYMENT_ROUTE_ROLE[route]
+    if (expectedRole.kind !== 'role') throw new Error('test setup error')
+    expect(built.routeRole).toBe(expectedRole.role)
+    expect(built.routeGlAccountId).toBeNull()
+    expect(line(built.entry, expectedRole.role)?.direction).toBe('debit')
     expect(line(built.entry, ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE)?.direction).toBe('credit')
     expect(built.entry.totalDebit).toBe(55_500)
     expect(built.entry.totalDebit).toBe(built.entry.totalCredit)
+  })
+
+  it('debits the named bank account for the cash route, not a role', () => {
+    const built = buildPaymentEntry({
+      ...BASE,
+      route: 'cash',
+      bankAccountGlAccountId: BANK_ACCOUNT_GL_ID,
+    })
+    expect(built.routeRole).toBeNull()
+    expect(built.routeGlAccountId).toBe(BANK_ACCOUNT_GL_ID)
+    expect(bankLine(built.entry, BANK_ACCOUNT_GL_ID)).toMatchObject({
+      direction: 'debit',
+      amount: 55_500,
+    })
+    for (const row of built.entry.lines) expect(row.accountRole).not.toBe('cash')
+    expect(line(built.entry, ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE)?.direction).toBe('credit')
+    expect(built.entry.totalDebit).toBe(built.entry.totalCredit)
+  })
+
+  it('refuses the cash route with no bank account, naming the remedy', () => {
+    expect(() => buildPaymentEntry({ ...BASE, route: 'cash' })).toThrowError(
+      /routes to a bank account/
+    )
+    expect(() =>
+      buildPaymentEntry({ ...BASE, route: 'cash', bankAccountGlAccountId: '  ' })
+    ).toThrowError(UnprocessableEntityError)
   })
 })
 

--- a/packages/lib/src/postings/__tests__/build-payout-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-payout-entry.test.ts
@@ -16,6 +16,7 @@ import { buildDocNumber } from '../doc-number'
 const BASE = {
   payoutId: 'po_1AbCdEfGhIjKlMnOpQrStUvW',
   payoutNumber: 'PO-0007',
+  bankAccountGlAccountId: 'gl-1000',
   grossMinor: 500_000,
   feesMinor: 14_800,
   netMinor: 485_200,
@@ -27,11 +28,16 @@ function line(entry: ReturnType<typeof buildPayoutEntry>['entry'], role: string)
   return entry.lines.find((row) => row.accountRole === role)
 }
 
+/** The bank-account debit leg, named by `glAccountId` - never a role (brief 13 §2). */
+function bankLine(entry: ReturnType<typeof buildPayoutEntry>['entry']) {
+  return entry.lines.find((row) => row.glAccountId === BASE.bankAccountGlAccountId)
+}
+
 describe('the entry', () => {
-  it('debits cash net, debits fees, and credits clearing gross', () => {
+  it('debits the settlement bank account net, debits fees, and credits clearing gross', () => {
     const built = buildPayoutEntry(BASE)
 
-    expect(line(built.entry, ACCOUNT_ROLES.CASH)).toMatchObject({
+    expect(bankLine(built.entry)).toMatchObject({
       direction: 'debit',
       amount: 485_200,
     })
@@ -45,6 +51,14 @@ describe('the entry', () => {
     })
     expect(built.entry.totalDebit).toBe(built.entry.totalCredit)
     expect(built.entry.postingType).toBe('payout')
+  })
+
+  it('names the bank account by id, never by the retired cash role', () => {
+    const built = buildPayoutEntry(BASE)
+    expect(bankLine(built.entry)?.accountRole).toBeUndefined()
+    for (const row of built.entry.lines) {
+      expect(row.accountRole).not.toBe('cash')
+    }
   })
 
   it('keys the period on the payout number, never on a date', () => {
@@ -109,13 +123,25 @@ describe('refusals', () => {
     )
   })
 
+  it('refuses a missing bank account, naming the remedy', () => {
+    expect(() => buildPayoutEntry({ ...BASE, bankAccountGlAccountId: '' })).toThrowError(
+      /no bank account to debit/
+    )
+  })
+
+  it('refuses a blank bank account id', () => {
+    expect(() => buildPayoutEntry({ ...BASE, bankAccountGlAccountId: '   ' })).toThrowError(
+      UnprocessableEntityError
+    )
+  })
+
   it('refuses a role that is not a clearing account', () => {
     // Affirm-gateway settlements are invisible to the payouts API, so `1200`
     // can never reconcile if they are folded into it - one payout drains ONE
     // clearing account, and this is the guard that says which.
-    expect(() => buildPayoutEntry({ ...BASE, clearingRole: ACCOUNT_ROLES.CASH })).toThrowError(
-      /not a clearing account/
-    )
+    expect(() =>
+      buildPayoutEntry({ ...BASE, clearingRole: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE })
+    ).toThrowError(/not a clearing account/)
   })
 })
 
@@ -154,10 +180,10 @@ describe('the unrecognised remainder', () => {
     })
   })
 
-  it('debits cash the WHOLE deposit, which is what the bank line shows', () => {
+  it('debits the bank account the WHOLE deposit, which is what the bank line shows', () => {
     const built = buildPayoutEntry({ ...BASE, unrecognisedNetMinor: 58_000 })
 
-    expect(line(built.entry, ACCOUNT_ROLES.CASH)).toMatchObject({
+    expect(bankLine(built.entry)).toMatchObject({
       direction: 'debit',
       amount: 543_200,
     })
@@ -167,7 +193,7 @@ describe('the unrecognised remainder', () => {
   it('still balances with the fourth leg', () => {
     const built = buildPayoutEntry({ ...BASE, unrecognisedNetMinor: 58_000 })
     expect(built.entry.totalDebit).toBe(built.entry.totalCredit)
-    // 543,200 cash + 14,800 fees = 500,000 clearing + 58,000 unidentified.
+    // 543,200 bank account + 14,800 fees = 500,000 clearing + 58,000 unidentified.
     expect(built.entry.totalDebit).toBe(558_000)
   })
 

--- a/packages/lib/src/postings/__tests__/chart-write.test.ts
+++ b/packages/lib/src/postings/__tests__/chart-write.test.ts
@@ -713,7 +713,7 @@ describe('I1: a type change may not break a role that posts here', () => {
       accountType: 'asset',
       isActive: true,
     }
-    const db = stubDb([cash], [{ role: 'cash', glAccountId: cash.id }])
+    const db = stubDb([cash], [{ role: 'undeposited_funds', glAccountId: cash.id }])
 
     const error = (
       await updateChartAccount(db, {
@@ -729,7 +729,7 @@ describe('I1: a type change may not break a role that posts here', () => {
   })
 
   it('allows a type change the role still accepts', async () => {
-    // `cash` wants an asset; 1000 is an asset and stays one.
+    // `undeposited_funds` wants an asset; 1050 is an asset and stays one.
     const cash: Account = {
       id: 'acct_cash',
       code: '1000',
@@ -737,7 +737,7 @@ describe('I1: a type change may not break a role that posts here', () => {
       accountType: 'asset',
       isActive: true,
     }
-    const db = stubDb([cash], [{ role: 'cash', glAccountId: cash.id }])
+    const db = stubDb([cash], [{ role: 'undeposited_funds', glAccountId: cash.id }])
 
     const result = await updateChartAccount(db, {
       organizationId: ORG,

--- a/packages/lib/src/postings/__tests__/default-chart.test.ts
+++ b/packages/lib/src/postings/__tests__/default-chart.test.ts
@@ -129,13 +129,20 @@ describe('the default chart', () => {
     expect(byCode.get('5030')?.role).toBeUndefined()
   })
 
-  it('carries the five accounts the accrual plan does not list but a builder needs', () => {
+  it('carries the four accounts the accrual plan does not list but a builder needs', () => {
     const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
-    expect(byCode.get('1000')?.role).toBe(ACCOUNT_ROLES.CASH)
     expect(byCode.get('2000')?.role).toBe(ACCOUNT_ROLES.ACCOUNTS_PAYABLE)
     expect(byCode.get('2160')?.role).toBe(ACCOUNT_ROLES.GRNI)
     expect(byCode.get('2170')?.role).toBe(ACCOUNT_ROLES.DUTIES_ACCRUAL)
     expect(byCode.get('5095')?.role).toBe(ACCOUNT_ROLES.INVENTORY_COUNT_VARIANCE)
+  })
+
+  // `cash` retired as a posting role (brief 13 §2): `1000 Cash` is kept as an
+  // ordinary bank account, mappable like any other, and carries no role at all.
+  it('keeps 1000 Cash as a plain bank account, with no role', () => {
+    const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
+    expect(byCode.get('1000')?.role).toBeUndefined()
+    expect(byCode.get('1000')?.subtype).toBe('bank')
   })
 
   // `G12`: count/shrinkage value must land somewhere OTHER than purchase price

--- a/packages/lib/src/postings/__tests__/post-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/post-entry.test.ts
@@ -608,6 +608,32 @@ describe('the counterparty column', () => {
   })
 })
 
+// ── The dimensions column (brief 13 §5) ─────────────────────────────────────
+
+describe('the dimensions column', () => {
+  it('stores the dimensions carried on the input line', async () => {
+    const fake = createFakeDb(FULL_CHART)
+    const entry = receiptEntry()
+    entry.lines[0]!.dimensions = { channel: 'dealer' }
+
+    await postEntry(fake.db, { organizationId: ORG, entry, lock: OPEN })
+
+    expect(fake.lines[0]).toMatchObject({ dimensions: { channel: 'dealer' } })
+    // Absent on the input line becomes null on the stored row, never undefined.
+    expect(fake.lines[1]).toMatchObject({ dimensions: null })
+  })
+
+  it('leaves the column null when no line carries a dimension', async () => {
+    const fake = createFakeDb(FULL_CHART)
+    await postEntry(fake.db, { organizationId: ORG, entry: receiptEntry(), lock: OPEN })
+
+    expect(fake.lines.map((line) => (line as { dimensions?: unknown }).dimensions)).toEqual([
+      null,
+      null,
+    ])
+  })
+})
+
 // ── Convergence ────────────────────────────────────────────────────────────
 
 describe('the claim', () => {

--- a/packages/lib/src/postings/__tests__/post-payout-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/post-payout-entry.test.ts
@@ -19,7 +19,7 @@ vi.mock('../post-entry', () => ({ postEntry: h.postEntry }))
 
 import type { Database } from '@auxx/database'
 import { ACCOUNT_ROLES } from '../build-entry'
-import { postPayoutEntry } from '../post-payout-entry'
+import { payoutAccountUnmappedResult, postPayoutEntry } from '../post-payout-entry'
 
 const ORG = 'org_1'
 const db = {} as Database
@@ -29,6 +29,7 @@ const OPTIONS = {
   actorUserId: 'user_1',
   payoutId: 'po_1',
   payoutNumber: 'PO-0007',
+  bankAccountGlAccountId: 'gl-1000',
   grossMinor: 500_000,
   feesMinor: 14_800,
   netMinor: 485_200,
@@ -74,6 +75,25 @@ describe('accounting not enabled', () => {
     expect(result).toEqual({ status: 'not_enabled' })
     expect(h.buildPayoutEntry).not.toHaveBeenCalled()
     expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+  })
+})
+
+// brief 13 §2.3: the caller (`money/payouts/sync.ts`) constructs this directly
+// and never calls `postPayoutEntry` at all when a payout's destination cannot
+// be resolved to a confirmed bank account.
+describe('payoutAccountUnmappedResult', () => {
+  it('is a pre-claim account_unmapped refusal, never built or posted', () => {
+    const result = payoutAccountUnmappedResult(
+      'Payout PO-0007 names ba_unknown, which is not confirmed on any bank account.'
+    )
+
+    expect(result).toEqual({
+      status: 'account_unmapped',
+      failureClass: 'configuration',
+      error: 'Payout PO-0007 names ba_unknown, which is not confirmed on any bank account.',
+    })
+    expect(h.buildPayoutEntry).not.toHaveBeenCalled()
     expect(h.postEntry).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/postings/__tests__/read-posting.test.ts
+++ b/packages/lib/src/postings/__tests__/read-posting.test.ts
@@ -68,6 +68,7 @@ interface LineRow {
   sourceId: string
   counterpartyType: string | null
   counterpartyId: string | null
+  dimensions: Record<string, string> | null
 }
 
 /**
@@ -196,6 +197,7 @@ function line(overrides: Partial<LineRow> & { lineNumber: number }): LineRow {
     sourceId: 'sm_1',
     counterpartyType: null,
     counterpartyId: null,
+    dimensions: null,
     ...overrides,
   }
 }
@@ -368,6 +370,24 @@ describe('getPosting - the lines', () => {
     expect(detail.lines[0]?.counterpartyId).toBeNull()
   })
 
+  // Brief 13 §5: the reporting dimensions frozen on the line at post time.
+  it('returns the dimensions stored on a line', async () => {
+    const stub = stubDb({
+      postings: [POSTING],
+      lines: [line({ lineNumber: 1, dimensions: { channel: 'dealer' } })],
+    })
+    const detail = (await getPosting(stub.db, ORG, 'gp_1'))._unsafeUnwrap()
+
+    expect(detail.lines[0]?.dimensions).toEqual({ channel: 'dealer' })
+  })
+
+  it('returns null, not undefined, on a line with no dimensions', async () => {
+    const stub = stubDb({ postings: [POSTING], lines: [line({ lineNumber: 1 })] })
+    const detail = (await getPosting(stub.db, ORG, 'gp_1'))._unsafeUnwrap()
+
+    expect(detail.lines[0]?.dimensions).toBeNull()
+  })
+
   // Two reads: the header, then all of its lines. A third would mean either an
   // N+1 over the lines or a join to the live chart, and both are forbidden.
   it('issues exactly two reads, whatever the line count', async () => {
@@ -507,6 +527,7 @@ function paymentLine(sourceId: string, lineNumber: number): LineRow {
     memo: null,
     sourceType: 'payment_transaction',
     sourceId,
+    dimensions: null,
     counterpartyType: null,
     counterpartyId: null,
   }

--- a/packages/lib/src/postings/__tests__/regime.test.ts
+++ b/packages/lib/src/postings/__tests__/regime.test.ts
@@ -7,7 +7,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_PAYMENT_ROUTES,
-  type PaymentRoute,
   type PaymentRouteMethod,
   resolvePaymentRoute,
 } from '../../money/bank-deposits/route'
@@ -105,89 +104,42 @@ describe('the declaration cannot drift from the vocabulary', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// `cash`, and the hole the guard deliberately does not see
-//
-// `SINGLE_WRITER_ROLES_BY_POSTING_TYPE.payment` is `[]` even though the `cash`
-// payment ROUTE emits the `CASH` role and `bank_deposit` declares `[CASH]`. The
-// guard is per TYPE, not per route, so `[CASH]` there would flag a conflict that
-// is not one. These tests pin the reasoning mechanically instead of leaving it
-// to the comment.
-//
-// ⚠️ "No payment method routes to `cash` while `bank_deposit` is enabled" is NOT
-// the invariant, and asserting it would fail on a stock install:
-// `DEFAULT_PAYMENT_ROUTES.bank` is `cash` by design (an ACH or wire arrives at
-// the bank as its own line). What actually keeps `cash` single-writer is that
-// the routes are DISJOINT destinations for one payment - money that goes to
-// `cash` never also passes through `undeposited_funds`, which is the only money
-// `bank_deposit` ever banks.
+// `cash` retired as a posting role (brief 13 §2). It named a bank account by
+// its own `glAccountId` from the start of this pass, so there is no role for
+// this guard to see and no exemption left to reason about: `bank_deposit` and
+// `payment` are genuinely `[]` now, not `[]` standing in for `[CASH]`.
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('cash has exactly one enabled writer', () => {
-  it('declares `cash` a single-writer role at all', () => {
-    expect(SINGLE_WRITER_ROLES).toContain(ACCOUNT_ROLES.CASH)
+describe('cash is gone as a role, and the guard is narrowed back to inventory', () => {
+  it('SINGLE_WRITER_ROLES is exactly the three inventory roles', () => {
+    expect([...SINGLE_WRITER_ROLES].sort()).toEqual([...INVENTORY_ROLES].sort())
   })
 
-  it('is `bank_deposit`, and only `bank_deposit`, among the ENABLED types', () => {
-    const cashWriters = ENABLED_POSTING_TYPES.filter((type) =>
-      SINGLE_WRITER_ROLES_BY_POSTING_TYPE[type].includes(ACCOUNT_ROLES.CASH)
-    )
-    expect(cashWriters).toEqual(['bank_deposit'])
+  it('no posting type declares a non-inventory single-writer role', () => {
+    const valid = new Set<string>(INVENTORY_ROLES)
+    for (const roles of Object.values(SINGLE_WRITER_ROLES_BY_POSTING_TYPE)) {
+      for (const role of roles) expect(valid.has(role)).toBe(true)
+    }
+  })
+
+  it('`bank_deposit` and `payment` declare no single-writer role at all', () => {
+    expect(SINGLE_WRITER_ROLES_BY_POSTING_TYPE.bank_deposit).toEqual([])
+    expect(SINGLE_WRITER_ROLES_BY_POSTING_TYPE.payment).toEqual([])
+  })
+
+  it('the enabled regime still has no writer conflict', () => {
     expect(findWriterConflicts()).toEqual([])
   })
 
-  it('the detector WOULD bite if `payment` were ever declared a cash writer', () => {
-    // The `[]` on `payment` is an exemption, not a broken detector. Declaring it
-    // a cash writer is a one-line edit in `regime.ts`, and this is what would
-    // happen if somebody made it: the guard is looking, it is simply being told
-    // there is nothing to see.
-    const asIfPaymentDrovecash = {
-      ...SINGLE_WRITER_ROLES_BY_POSTING_TYPE,
-      payment: [ACCOUNT_ROLES.CASH],
-    }
-    const writers = ['bank_deposit', 'payment'].filter((type) =>
-      asIfPaymentDrovecash[type as keyof typeof asIfPaymentDrovecash].includes(ACCOUNT_ROLES.CASH)
-    )
-    expect(writers).toEqual(['bank_deposit', 'payment'])
-  })
-})
-
-describe('the payment routes are disjoint destinations, which is what makes the exemption safe', () => {
-  const methods = Object.keys(DEFAULT_PAYMENT_ROUTES) as PaymentRouteMethod[]
-
-  it('maps each route to a DIFFERENT account role - one payment cannot land in two', () => {
-    const roles = Object.values(PAYMENT_ROUTE_ROLE)
-    expect(new Set(roles).size).toBe(roles.length)
-    expect(PAYMENT_ROUTE_ROLE.cash).toBe(ACCOUNT_ROLES.CASH)
-    expect(PAYMENT_ROUTE_ROLE.undeposited_funds).toBe(ACCOUNT_ROLES.UNDEPOSITED_FUNDS)
-    expect(PAYMENT_ROUTE_ROLE.undeposited_funds).not.toBe(PAYMENT_ROUTE_ROLE.cash)
+  it('the `cash` payment route resolves to a bank account, not a role', () => {
+    expect(PAYMENT_ROUTE_ROLE.cash).toEqual({ kind: 'bank_account' })
   })
 
-  it('routes every method to exactly one of the three destinations, on defaults and on settings', () => {
+  it('every default payment route still resolves to exactly one destination', () => {
+    const methods = Object.keys(DEFAULT_PAYMENT_ROUTES) as PaymentRouteMethod[]
     for (const method of methods) {
       expect(resolvePaymentRoute(method, null)).toBe(DEFAULT_PAYMENT_ROUTES[method])
     }
-    // And an org that has routed EVERYTHING to cash still has one cash writer
-    // per payment: `bank_deposit` banks undeposited funds, and there are none.
-    const allCash = Object.fromEntries(
-      methods.map((method) => [`accounting.paymentRoute.${method}`, 'cash'])
-    )
-    for (const method of methods) {
-      expect(resolvePaymentRoute(method, allCash)).toBe('cash' satisfies PaymentRoute)
-    }
-  })
-
-  it('a method routed to `cash` is never also banked by a deposit, because a deposit only drains undeposited funds', () => {
-    // The `bank_deposit` entry is `Dr cash Cr undeposited_funds`, so the money
-    // it moves is exactly the money the `undeposited_funds` route parked. A
-    // `cash`-routed payment never enters that account, so the two writers never
-    // touch the same money even though both name `cash`.
-    expect(SINGLE_WRITER_ROLES_BY_POSTING_TYPE.bank_deposit).toEqual([ACCOUNT_ROLES.CASH])
-    const cashRouted = methods.filter((method) => resolvePaymentRoute(method, null) === 'cash')
-    const undeposited = methods.filter(
-      (method) => resolvePaymentRoute(method, null) === 'undeposited_funds'
-    )
-    expect(cashRouted.length).toBeGreaterThan(0)
-    for (const method of cashRouted) expect(undeposited).not.toContain(method)
   })
 })
 

--- a/packages/lib/src/postings/__tests__/resolve-roles.test.ts
+++ b/packages/lib/src/postings/__tests__/resolve-roles.test.ts
@@ -287,7 +287,14 @@ describe('resolveRoles — it answers for the whole set at once', () => {
   // the night of a close.
   it('names every failing role in a single error', async () => {
     const db = stubDb([], [])
-    const roles = ['grni', 'ppv', 'cash', 'inventory_wip', 'cogs_product_cost', 'applied_overhead']
+    const roles = [
+      'grni',
+      'ppv',
+      'undeposited_funds',
+      'inventory_wip',
+      'cogs_product_cost',
+      'applied_overhead',
+    ]
     const error = await expectErr(resolveRoles(db, ORG, roles))
 
     for (const role of roles) expect(error.message, role).toContain(`'${role}'`)
@@ -307,15 +314,15 @@ describe('resolveRoles — it answers for the whole set at once', () => {
     const db = stubDb(
       [
         { role: 'ppv', glAccountId: 'acct_ppv', markedUnused: true },
-        { role: 'cash', glAccountId: 'acct_cash' },
+        { role: 'undeposited_funds', glAccountId: 'acct_cash' },
       ],
       [{ id: 'acct_cash', code: '1000', name: 'Cash', accountType: 'liability', isActive: true }]
     )
-    const error = await expectErr(resolveRoles(db, ORG, ['grni', 'ppv', 'cash']))
+    const error = await expectErr(resolveRoles(db, ORG, ['grni', 'ppv', 'undeposited_funds']))
 
     expect(error.message).toMatch(/'grni' is not mapped/i)
     expect(error.message).toMatch(/'ppv' is marked as unused/i)
-    expect(error.message).toMatch(/'cash' must be mapped to a asset account/i)
+    expect(error.message).toMatch(/'undeposited_funds' must be mapped to a asset account/i)
   })
 })
 

--- a/packages/lib/src/postings/__tests__/retry-export.test.ts
+++ b/packages/lib/src/postings/__tests__/retry-export.test.ts
@@ -222,6 +222,17 @@ describe('retryExport', () => {
     })
   })
 
+  it('replays the dimensions frozen on the line (brief 13 §5)', async () => {
+    const fake = createFakeDb(postingRow(), [line({ dimensions: { channel: 'dealer' } })])
+    const seen = stubProvider(() =>
+      ok({ status: 'posted', externalId: 'qb_9', providerId: 'stub' })
+    )
+
+    await retryExport(fake.db, { organizationId: ORG, glPostingId: POSTING })
+
+    expect(seen[0]?.lines[0]?.dimensions).toEqual({ channel: 'dealer' })
+  })
+
   it('replays the stored glAccountId - the identity, alongside the code snapshot', async () => {
     // Task 15 §2: `glAccountId` is what a `gl_posting_line` row stores as its
     // identity now. The replay must carry it through unchanged, the same way it

--- a/packages/lib/src/postings/__tests__/reverse-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/reverse-entry.test.ts
@@ -81,6 +81,7 @@ interface LineRow {
   sourceId: string
   counterpartyType?: string | null
   counterpartyId?: string | null
+  dimensions?: Record<string, string> | null
 }
 
 interface Account {
@@ -442,6 +443,24 @@ describe('the reversal pair', () => {
     const written = fake.lines.filter((line) => line.glPostingId === reversalId)
     expect(written[0]).toMatchObject({ counterpartyType: 'customer', counterpartyId: 'contact_1' })
     expect(written[1]).toMatchObject({ counterpartyType: null, counterpartyId: null })
+  })
+
+  // Brief 13 §5: a reversal carries the original's dimensions - reporting-wise
+  // the same line, backwards.
+  it('carries the dimensions onto the reversed line', async () => {
+    const fake = createFakeDb({
+      postings: [original()],
+      lines: originalLines([{ dimensions: { channel: 'dealer' } }, {}]),
+      chart: CHART,
+    })
+    await reverseEntry(fake.db, { organizationId: ORG, glPostingId: 'post_1', lock: OPEN })
+
+    const reversalId = fake.postings[1]!.id
+    const written = fake.lines.filter((line) => line.glPostingId === reversalId)
+    expect(written[0]).toMatchObject({ dimensions: { channel: 'dealer' } })
+    // Normalised to null at the storage layer (`post-entry.ts`'s claim), same
+    // as every other absent-on-input column.
+    expect(written[1]?.dimensions).toBeNull()
   })
 
   // Task 15 §5: a line whose account carries no code reverses exactly like

--- a/packages/lib/src/postings/__tests__/split-tax-by-jurisdiction.test.ts
+++ b/packages/lib/src/postings/__tests__/split-tax-by-jurisdiction.test.ts
@@ -1,0 +1,131 @@
+// packages/lib/src/postings/__tests__/split-tax-by-jurisdiction.test.ts
+//
+// The tie check is the load-bearing rule (brief 13 §5): a partial or
+// mismatched jurisdiction breakdown must fall back to `null` rather than
+// guess, because a partial split reads as a complete one. Everything else is
+// the largest-remainder rounding that makes the shares sum exactly to the
+// amount handed in.
+
+import { describe, expect, it } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import { splitTaxByJurisdiction } from '../split-tax-by-jurisdiction'
+
+describe('splitTaxByJurisdiction', () => {
+  it('splits an amount across jurisdictions pro rata to their weights', () => {
+    const shares = splitTaxByJurisdiction({
+      taxMinor: 8_000,
+      taxLines: [
+        { title: 'CA State Tax', priceMinor: 6_000 },
+        { title: 'CA District Tax', priceMinor: 2_000 },
+      ],
+      orderTaxTotalMinor: 8_000,
+    })
+    expect(shares).toEqual(
+      expect.arrayContaining([
+        { jurisdiction: 'CA State Tax', amountMinor: 6_000 },
+        { jurisdiction: 'CA District Tax', amountMinor: 2_000 },
+      ])
+    )
+    expect(shares).toHaveLength(2)
+  })
+
+  it('uses largest-remainder rounding so the shares sum exactly to taxMinor', () => {
+    // Weights 1:2 applied to 77 cents: exact shares are 25.667 and 51.333.
+    // The remainder cent goes to the larger fractional remainder (A).
+    const shares = splitTaxByJurisdiction({
+      taxMinor: 77,
+      taxLines: [
+        { title: 'A', priceMinor: 77 },
+        { title: 'B', priceMinor: 154 },
+      ],
+      orderTaxTotalMinor: 231,
+    })
+    expect(shares).toEqual(
+      expect.arrayContaining([
+        { jurisdiction: 'A', amountMinor: 26 },
+        { jurisdiction: 'B', amountMinor: 51 },
+      ])
+    )
+    expect(shares?.reduce((sum, s) => sum + s.amountMinor, 0)).toBe(77)
+  })
+
+  it('returns null when there are no tax lines at all', () => {
+    expect(
+      splitTaxByJurisdiction({ taxMinor: 100, taxLines: [], orderTaxTotalMinor: 100 })
+    ).toBeNull()
+  })
+
+  it('returns null when taxMinor is zero, without even looking at the lines', () => {
+    expect(
+      splitTaxByJurisdiction({
+        taxMinor: 0,
+        taxLines: [{ title: 'A', priceMinor: 100 }],
+        orderTaxTotalMinor: 100,
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when the tax lines do not sum to the order total - a partial breakdown reads as complete', () => {
+    expect(
+      splitTaxByJurisdiction({
+        taxMinor: 100,
+        taxLines: [{ title: 'A', priceMinor: 60 }],
+        orderTaxTotalMinor: 100,
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when every tax line title is blank', () => {
+    expect(
+      splitTaxByJurisdiction({
+        taxMinor: 100,
+        taxLines: [{ title: '   ', priceMinor: 100 }],
+        orderTaxTotalMinor: 100,
+      })
+    ).toBeNull()
+  })
+
+  it('sums multiple lines that share one jurisdiction title before splitting', () => {
+    const shares = splitTaxByJurisdiction({
+      taxMinor: 100,
+      taxLines: [
+        { title: 'CA State Tax', priceMinor: 40 },
+        { title: 'CA State Tax', priceMinor: 60 },
+      ],
+      orderTaxTotalMinor: 100,
+    })
+    expect(shares).toEqual([{ jurisdiction: 'CA State Tax', amountMinor: 100 }])
+  })
+
+  it('drops a zero-amount jurisdiction share rather than posting a zero line', () => {
+    const shares = splitTaxByJurisdiction({
+      taxMinor: 100,
+      taxLines: [
+        { title: 'A', priceMinor: 100 },
+        { title: 'B', priceMinor: 0 },
+      ],
+      orderTaxTotalMinor: 100,
+    })
+    expect(shares).toEqual([{ jurisdiction: 'A', amountMinor: 100 }])
+  })
+
+  it('refuses a fractional tax line price rather than absorbing it', () => {
+    expect(() =>
+      splitTaxByJurisdiction({
+        taxMinor: 100,
+        taxLines: [{ title: 'A', priceMinor: 99.5 }],
+        orderTaxTotalMinor: 100,
+      })
+    ).toThrowError(UnprocessableEntityError)
+  })
+
+  it('refuses a fractional order tax total rather than absorbing it', () => {
+    expect(() =>
+      splitTaxByJurisdiction({
+        taxMinor: 100,
+        taxLines: [{ title: 'A', priceMinor: 100 }],
+        orderTaxTotalMinor: 100.5,
+      })
+    ).toThrowError(UnprocessableEntityError)
+  })
+})

--- a/packages/lib/src/postings/__tests__/suggest-account-identities.test.ts
+++ b/packages/lib/src/postings/__tests__/suggest-account-identities.test.ts
@@ -210,3 +210,85 @@ describe('isMappableTo - what a picker may offer', () => {
     expect(isMappableTo(ours(), theirs({ classification: 'expense' }))).toBe(false)
   })
 })
+
+// Task 13 §3: a bank account may only map to a bank account. This is the
+// filter on the CONFIRM, not a rank on the propose - see the ranking pin
+// below.
+describe('isMappableTo - subtype (task 13 §3)', () => {
+  it('confirms a bank account to a provider account QuickBooks types as Bank', () => {
+    const bankAccount = ours({ subtype: 'bank' })
+    const bankProviderAccount = theirs({ accountType: 'Bank' })
+    expect(isMappableTo(bankAccount, bankProviderAccount)).toBe(true)
+  })
+
+  it('refuses a bank account mapped to Accounts Receivable, same classification and all', () => {
+    const bankAccount = ours({ subtype: 'bank' })
+    // Same `classification` ('asset') as the default `theirs()` - only the
+    // provider's own `accountType` distinguishes them.
+    const arProviderAccount = theirs({
+      accountType: 'Accounts Receivable',
+      fullyQualifiedName: 'Accounts Receivable (A/R)',
+    })
+    expect(isMappableTo(bankAccount, arProviderAccount)).toBe(false)
+  })
+
+  it('compares case- and whitespace-insensitively', () => {
+    const bankAccount = ours({ subtype: 'bank' })
+    expect(isMappableTo(bankAccount, theirs({ accountType: ' bank ' }))).toBe(true)
+  })
+
+  it('keeps a null subtype on classification alone, so no existing mapping breaks', () => {
+    const noSubtype = ours({ subtype: null })
+    const arProviderAccount = theirs({ accountType: 'Accounts Receivable' })
+    expect(isMappableTo(noSubtype, arProviderAccount)).toBe(true)
+  })
+
+  it('imposes nothing for subtype "other"', () => {
+    const otherAccount = ours({ subtype: 'other' })
+    const arProviderAccount = theirs({ accountType: 'Accounts Receivable' })
+    expect(isMappableTo(otherAccount, arProviderAccount)).toBe(true)
+  })
+})
+
+describe('validateProviderMapping - subtype (task 13 §3)', () => {
+  it('names the account, the subtype and the provider type in the register', () => {
+    const wellsFargo = ours({
+      code: '1010',
+      name: 'Wells Fargo Checking',
+      subtype: 'bank',
+    })
+    const arProviderAccount = theirs({
+      accountType: 'Accounts Receivable',
+      fullyQualifiedName: 'Accounts Receivable (A/R)',
+    })
+    const message = validateProviderMapping(wellsFargo, arProviderAccount, '92')
+    expect(message).toContain('1010 Wells Fargo Checking')
+    expect(message).toContain('bank account')
+    expect(message).toContain('Accounts Receivable (A/R)')
+    expect(message).toContain('Accounts Receivable')
+    expect(message).toContain('balance')
+  })
+
+  it('passes a bank account mapped to a Bank provider account', () => {
+    const wellsFargo = ours({ code: '1010', name: 'Wells Fargo Checking', subtype: 'bank' })
+    expect(validateProviderMapping(wellsFargo, theirs({ accountType: 'Bank' }), '92')).toBeNull()
+  })
+
+  it('keeps a null subtype on classification alone', () => {
+    expect(
+      validateProviderMapping(ours(), theirs({ accountType: 'Accounts Receivable' }), '92')
+    ).toBeNull()
+  })
+})
+
+// 13 §3.3: subtype is a filter on the confirm, never a rank on the propose.
+describe('suggestAccountIdentities is unaffected by subtype', () => {
+  it('still suggests by number when a subtype is set on our side', () => {
+    const [suggestion] = suggestAccountIdentities(
+      [ours({ subtype: 'bank' })],
+      [theirs({ number: '1310', accountType: 'Other Current Asset' })]
+    )
+    expect(suggestion?.glAccountId).toBe('gl1')
+    expect(suggestion?.reason).toBe('number')
+  })
+})

--- a/packages/lib/src/postings/account-identities.ts
+++ b/packages/lib/src/postings/account-identities.ts
@@ -41,6 +41,7 @@ import {
   classificationArticle,
   isMappableTo,
   suggestAccountIdentities,
+  validateProviderMapping,
 } from './suggest-account-identities'
 import type { AccountIdentityRow, ChartAccountRow, ProviderAccount } from './types'
 
@@ -130,8 +131,12 @@ export async function listAccountIdentities(
       // A populated mapping IS a confirmation - the suggester never writes, so
       // the only thing that could have put this here is a person. See
       // `money/quickbooks/account-map.ts` on why there is no stored flag.
+      //
+      // `isMappableTo`, not a hand-rolled check: a mapping that was valid by
+      // classification alone and is now invalid by subtype (`13` §3.2) must
+      // show as broken here, the same as any other lapsed mapping.
       const live = byProviderId.get(providerAccountId) ?? null
-      if (!live || !live.active || live.classification !== account.accountType) {
+      if (!live || !isMappableTo(account, live)) {
         broken.push(accountLabel(account))
       }
 
@@ -229,13 +234,20 @@ export async function setAccountIdentity(
       )
     }
 
+    // `validateProviderMapping`, not a hand-rolled sentence: it is the one place
+    // that knows how to word each way a pairing can fail - inactive, wrong
+    // section, or (task 13 §3) wrong subtype - and `isMappableTo` is the same
+    // check as a boolean, so the two can never disagree about what "mappable"
+    // means.
     if (!isMappableTo(account, target)) {
-      throw new UnprocessableEntityError(
-        target.active
-          ? `${accountLabel(account)} is ${classificationArticle(account.accountType)} account, but '${target.fullyQualifiedName}' is ${target.classification}. Posting to it would balance and still be wrong.`
-          : `'${target.fullyQualifiedName}' is not active in the connected accounting system. Reactivate it there, or choose another account.`,
-        { organizationId, glAccountId, providerAccountId }
-      )
+      const message =
+        validateProviderMapping(account, target, providerAccountId) ??
+        `${accountLabel(account)} cannot be mapped to '${target.fullyQualifiedName}'.`
+      throw new UnprocessableEntityError(message, {
+        organizationId,
+        glAccountId,
+        providerAccountId,
+      })
     }
 
     const written = await provider.setAccountMapping({

--- a/packages/lib/src/postings/build-entry.ts
+++ b/packages/lib/src/postings/build-entry.ts
@@ -85,9 +85,21 @@ import type { BuiltEntry, CounterpartyType, GlPostingLineInput, PostingType } fr
  * design only, which account each leg lands on is still open, and a role nothing
  * emits is a mapping a bookkeeper can make wrongly with no way to find out.
  */
+/*
+ * Two rules about what a role is NOT (brief 13 §2 and §5, 2026-09-10):
+ *
+ * - **A bank account is not a role.** A role answers which account fulfils an
+ *   accounting FUNCTION; an org has several bank accounts and they are
+ *   instances. `cash` was retired for this reason. A builder that moves money
+ *   into or out of a bank account takes the `bank_account`'s own
+ *   `glAccountId` and emits a `{ glAccountId }` line, the way the deposit does.
+ * - **A gateway does not get a role, and a channel does not get an account.**
+ *   `clearing_affirm` is the one exception and it is grandfathered; the third
+ *   gateway is a `payment_gateway` record carrying its clearing account, and a
+ *   channel is a `dimensions` entry on the revenue line, never a second
+ *   revenue role.
+ */
 export const ACCOUNT_ROLES = {
-  /** Cash (default `1000`). Credited when a bill is paid in ledger mode (decision P12). */
-  CASH: 'cash',
   /**
    * Raw materials inventory (default `1310`). Debited at LANDED cost when a
    * component or a subassembly is received - `partKind` maps BOTH to this role
@@ -293,10 +305,13 @@ export const ACCOUNT_ROLES = {
    * role a builder ever emits.
    */
   EQUITY_OPENING_BALANCE: 'equity_opening_balance',
-  /** Product revenue, DTC channel (default `4000`). */
-  REVENUE_DTC: 'revenue_dtc',
-  /** Product revenue, dealer channel (default `4010`). */
-  REVENUE_DEALER: 'revenue_dealer',
+  /**
+   * Product revenue (default `4000`), every channel. The channel is a
+   * `dimensions.channel` value on the line (brief 13 §5), never a second
+   * role or a second account: `revenue_dtc` and `revenue_dealer` were retired
+   * into this one on 2026-09-10.
+   */
+  REVENUE_PRODUCT: 'revenue_product',
   /** Shipping revenue (default `4020`). Its own account per handoff decision 6.3. */
   REVENUE_SHIPPING: 'revenue_shipping',
   /**
@@ -365,7 +380,6 @@ export type AccountRole = (typeof ACCOUNT_ROLES)[keyof typeof ACCOUNT_ROLES]
  * declared type would otherwise pass validation unchecked.
  */
 export const ROLE_ACCOUNT_TYPES: Record<AccountRole, GlAccountTypeValue> = {
-  cash: 'asset',
   inventory_raw_materials: 'asset',
   inventory_wip: 'asset',
   inventory_finished_goods: 'asset',
@@ -388,8 +402,7 @@ export const ROLE_ACCOUNT_TYPES: Record<AccountRole, GlAccountTypeValue> = {
   customer_deposits: 'liability',
   equity_retained_earnings: 'equity',
   equity_opening_balance: 'equity',
-  revenue_dtc: 'revenue',
-  revenue_dealer: 'revenue',
+  revenue_product: 'revenue',
   revenue_shipping: 'revenue',
   revenue_service: 'revenue',
   revenue_returns_allowances: 'revenue',
@@ -408,7 +421,6 @@ export const ROLE_ACCOUNT_TYPES: Record<AccountRole, GlAccountTypeValue> = {
  * this file has no db, no logger and no io.
  */
 export const ACCOUNT_ROLE_LABELS: Record<AccountRole, string> = {
-  cash: 'Cash',
   inventory_raw_materials: 'Inventory — Raw Materials',
   inventory_wip: 'Inventory — Work in Process',
   inventory_finished_goods: 'Inventory — Finished Goods',
@@ -431,8 +443,7 @@ export const ACCOUNT_ROLE_LABELS: Record<AccountRole, string> = {
   customer_deposits: 'Customer Deposits',
   equity_retained_earnings: 'Retained Earnings',
   equity_opening_balance: 'Opening Balance Equity',
-  revenue_dtc: 'Product Revenue - DTC',
-  revenue_dealer: 'Product Revenue - Dealer',
+  revenue_product: 'Product Revenue',
   revenue_shipping: 'Shipping Revenue',
   revenue_service: 'Service Revenue',
   revenue_returns_allowances: 'Sales Returns and Allowances',

--- a/packages/lib/src/postings/build-fulfillment-batch-entry.ts
+++ b/packages/lib/src/postings/build-fulfillment-batch-entry.ts
@@ -11,9 +11,9 @@
  *   Dr accounts_receivable   ONE LINE PER ORDER   that order's terms shipments
  *   Dr clearing_card         summarised           every card shipment's total
  *   Dr clearing_affirm       summarised           every Affirm shipment's total
- *       Cr revenue_dtc       summarised             Σ subtotal, consumer channel
- *       Cr revenue_dealer    summarised             Σ subtotal, dealer channel
- *       Cr sales_tax_payable summarised             Σ tax
+ *   Dr <gateway's own account>  summarised, per id  every routed-gateway shipment's total
+ *       Cr revenue_product   summarised, per channel dimension  Σ subtotal
+ *       Cr sales_tax_payable summarised, per jurisdiction dimension (when it ties)  Σ tax
  *       Cr revenue_shipping  summarised             Σ shipping
  * ```
  *
@@ -53,6 +53,7 @@
 
 import { UnprocessableEntityError } from '../errors'
 import type {
+  FulfillmentDebit,
   FulfillmentDebitRole,
   FulfillmentPostingExclusionReason,
   FulfillmentPostingGroup,
@@ -63,13 +64,14 @@ import type {
 import { FULFILLMENT_BATCH_SOURCE_TYPE } from '../money/fulfillment-posting/types'
 import { ACCOUNT_ROLES, type AccountRole, buildEntry } from './build-entry'
 import {
-  CHANNEL_REVENUE_ROLE,
+  CHANNEL_KEYS,
   computeShipmentTotals,
   FULFILLMENT_SOURCE_TYPE,
   toAmountMinor,
   toChannelKey,
 } from './build-fulfillment-entry'
 import { DOC_NUMBER_MAX_LENGTH, DOC_NUMBER_PREFIX } from './doc-number'
+import { splitTaxByJurisdiction } from './split-tax-by-jurisdiction'
 import type { BuiltEntry, GlPostingLineInput } from './types'
 
 // ── The debit fork ──────────────────────────────────────────────────────────
@@ -121,9 +123,29 @@ const MANUAL_GATEWAY = 'manual'
  * `clearing_card` leaves that account with a residual no payout can ever
  * relieve - it balances, and `1200` simply stops reconciling to zero.
  */
-export const FULFILLMENT_GATEWAY_DEBIT: Readonly<Record<string, FulfillmentDebitRole>> = {
+export const FULFILLMENT_GATEWAY_DEBIT: Readonly<
+  Record<string, Exclude<FulfillmentDebitRole, 'gateway'>>
+> = {
   shopify_payments: 'clearing_card',
   affirm: 'clearing_affirm',
+}
+
+/**
+ * A `payment_gateway` record's own clearing route, as far as this pure builder
+ * needs to see it (brief 13 §5.3, lane 4's `money/fulfillment-posting/`).
+ *
+ * `handles` is a SET, never one string - the census that motivated this found
+ * two rails arriving under two spellings each (`authorize_net` /
+ * `authorize.net`, `Affirm` / `affirm`), so the record's key has to be a set to
+ * describe one rail. `active` rides along but is NOT read here: a closed
+ * gateway's past shipments still post to its own clearing account so it keeps
+ * reconciling, and "should this route still be offered" is lane 4's plan.ts
+ * concern, not this match's.
+ */
+export interface FulfillmentGatewayRoute {
+  handles: readonly string[]
+  clearingGlAccountId: string
+  active: boolean
 }
 
 /** The exclusions the debit fork itself can produce. A subset of lane B's closed set. */
@@ -132,9 +154,17 @@ export type FulfillmentDebitExclusionReason = Extract<
   'gateway-ambiguous' | 'test-gateway'
 >
 
-/** What {@link resolveFulfillmentDebit} answers: an account, or a reason not to post. */
+/**
+ * What {@link resolveFulfillmentDebit} answers: an account, or a reason not to
+ * post.
+ *
+ * The `debit` branch is {@link FulfillmentDebit} widened with the `kind`
+ * discriminant every posting-plan answer in this file carries - a role for the
+ * three declared accounts, or a `payment_gateway` record's own id when exactly
+ * one route named the gateway (brief 13 §5.3).
+ */
 export type FulfillmentDebitResolution =
-  | { kind: 'debit'; role: FulfillmentDebitRole }
+  | ({ kind: 'debit' } & FulfillmentDebit)
   | { kind: 'exclude'; reason: FulfillmentDebitExclusionReason; detail: string }
 
 /** Trim, lower-case and de-duplicate a gateway list, preserving first-seen order. */
@@ -151,7 +181,28 @@ function normaliseGateways(gateways: readonly string[]): string[] {
 }
 
 /**
- * Which account a shipment DEBITS: a clearing account, or the receivable.
+ * Which `payment_gateway` record's clearing account a normalised gateway
+ * names, when EXACTLY ONE route's `handles` matches it case-insensitively.
+ *
+ * Zero matches falls back to {@link FULFILLMENT_GATEWAY_DEBIT}'s role table -
+ * the record has nothing to say about this gateway yet. More than one match
+ * (two routes both claiming the same handle, which the record's own write
+ * path should never allow) falls back the same way rather than guessing which
+ * route is right.
+ */
+function matchGatewayRoute(
+  gateway: string,
+  routes: readonly FulfillmentGatewayRoute[] = []
+): string | undefined {
+  const matches = routes.filter((route) =>
+    route.handles.some((handle) => handle.trim().toLowerCase() === gateway)
+  )
+  return matches.length === 1 ? matches[0]?.clearingGlAccountId : undefined
+}
+
+/**
+ * Which account a shipment DEBITS: a `payment_gateway` route, a clearing role,
+ * or the receivable.
  *
  * PURE and total. Gateway names are compared case-insensitively after trim, so
  * `'Affirm'` and `' affirm '` are one gateway.
@@ -164,7 +215,8 @@ function normaliseGateways(gateways: readonly string[]): string[] {
  * | financial status is not `paid`, `partially_refunded` or `refunded` | `accounts_receivable` |
  * | any gateway is `manual` | `accounts_receivable` |
  * | no gateways at all | `accounts_receivable` |
- * | exactly one gateway | {@link FULFILLMENT_GATEWAY_DEBIT}, defaulting to `clearing_card` |
+ * | exactly one gateway, and exactly one `gatewayRoutes` entry names it | that route's `clearingGlAccountId` |
+ * | exactly one gateway, otherwise | {@link FULFILLMENT_GATEWAY_DEBIT}, defaulting to `clearing_card` |
  * | two or more distinct gateways | exclude, `gateway-ambiguous`, detail is the list |
  *
  * ⚠️ **`bogus` is checked before the status, and the build contract listed it
@@ -182,11 +234,20 @@ function normaliseGateways(gateways: readonly string[]): string[] {
  * TWO gateways is different in kind - the money split, and no single line can
  * describe it - so that one refuses.
  *
+ * ## `gatewayRoutes` (brief 13 §5.3, the contract with lane 4)
+ *
+ * Optional and empty by default, so every existing caller (and every test in
+ * this file) is unaffected. `money/fulfillment-posting/plan.ts` reads the
+ * org's `payment_gateway` records and passes them in; this function stays
+ * pure and does not read them itself.
+ *
  * @see plans/money/tasks/49-bulk-fulfillment-posting.md §3.2, §8.4 decision 6
+ * @see plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md §5.3
  */
 export function resolveFulfillmentDebit(input: {
   financialStatus: string | null
   gateways: readonly string[]
+  gatewayRoutes?: readonly FulfillmentGatewayRoute[]
 }): FulfillmentDebitResolution {
   const gateways = normaliseGateways(input.gateways)
   const listed = gateways.join(', ')
@@ -207,6 +268,8 @@ export function resolveFulfillmentDebit(input: {
 
   if (gateways.length === 1) {
     const gateway = gateways[0] as string
+    const glAccountId = matchGatewayRoute(gateway, input.gatewayRoutes)
+    if (glAccountId) return { kind: 'debit', glAccountId }
     return { kind: 'debit', role: FULFILLMENT_GATEWAY_DEBIT[gateway] ?? 'clearing_card' }
   }
 
@@ -240,16 +303,27 @@ function scaleLineTax(line: UnpostedShipmentLine, label: string): number | null 
  * `build-fulfillment-entry.ts` - subtotal from the lines, tax per line when
  * EVERY line carries one and cumulatively allocated otherwise, shipping in full
  * exactly once - so the batch entry and a single order's entry cannot drift.
- * The only thing added here is {@link scaleLineTax}, because an
- * `UnpostedShipmentLine` carries the whole LINE's tax while
- * `computeShipmentTotals` wants THIS shipment's.
+ * Two things are added here:
+ *
+ * - {@link scaleLineTax}, because an `UnpostedShipmentLine` carries the whole
+ *   LINE's tax while `computeShipmentTotals` wants THIS shipment's.
+ * - The jurisdiction split (brief 13 §5), from `shipment.taxLines` - see
+ *   `splitTaxByJurisdiction`.
+ *
+ * `debit` is {@link FulfillmentDebit} (a role, or a `payment_gateway` route's
+ * own account id from `resolveFulfillmentDebit`) - or a bare
+ * {@link FulfillmentDebitRole} string, accepted for
+ * `money/fulfillment-posting/plan.ts`'s own current call until it is updated
+ * to pass the route-aware answer through (brief 13 §5.3). An id-based debit
+ * becomes `debitRole: 'gateway'` plus `debitGlAccountId`, so `byDebitRole`
+ * summaries keep working unchanged.
  *
  * @throws {UnprocessableEntityError} on a non-positive quantity or a stored
  *   amount that is not whole minor units.
  */
 export function computeShipmentAmounts(
   shipment: UnpostedShipment,
-  debitRole: FulfillmentDebitRole
+  debit: FulfillmentDebit | FulfillmentDebitRole
 ): ShipmentAmounts {
   const label = `order ${shipment.orderNumber}`
   const totals = computeShipmentTotals({
@@ -267,7 +341,30 @@ export function computeShipmentAmounts(
     includeShipping: shipment.includeShipping,
     context: { orderId: shipment.orderId, sequence: String(shipment.sequence) },
   })
-  return { debitRole, ...totals }
+  const taxByJurisdiction =
+    totals.taxMinor !== 0
+      ? (splitTaxByJurisdiction({
+          taxMinor: totals.taxMinor,
+          taxLines: shipment.taxLines ?? [],
+          orderTaxTotalMinor: shipment.orderTaxTotalMinor,
+        }) ?? undefined)
+      : undefined
+
+  // 🛑 Accepts a bare ROLE STRING too, not only `FulfillmentDebit` - back
+  // compat with `money/fulfillment-posting/plan.ts`'s current call
+  // (`computeAmounts(shipment, debit.role)`), which still passes a plain
+  // string until lane 4 updates it to pass the full `resolveFulfillmentDebit`
+  // answer through (brief 13 §5.3's contract). Widening the parameter rather
+  // than requiring the wrapped shape means plan.ts's RUNTIME behaviour is
+  // unchanged even though its TYPECHECK is red until that update lands.
+  const debitFields: { debitRole: FulfillmentDebitRole; debitGlAccountId?: string } =
+    typeof debit === 'string'
+      ? { debitRole: debit }
+      : 'glAccountId' in debit
+        ? { debitRole: 'gateway', debitGlAccountId: debit.glAccountId }
+        : { debitRole: debit.role }
+
+  return { ...debitFields, ...totals, taxByJurisdiction }
 }
 
 // ── The period key ──────────────────────────────────────────────────────────
@@ -391,8 +488,17 @@ export interface FulfillmentBatchSource {
   amounts: ShipmentAmounts
 }
 
-/** Which posting role each debit answer resolves to. DECLARED, one row each. */
-export const FULFILLMENT_DEBIT_ACCOUNT_ROLE: Readonly<Record<FulfillmentDebitRole, AccountRole>> = {
+/**
+ * Which posting role each ROLE-based debit answer resolves to. DECLARED, one
+ * row each.
+ *
+ * 🛑 **`'gateway'` is deliberately absent.** An id-based debit (brief 13 §5.3)
+ * names a `payment_gateway` record's own account directly - there is no role
+ * to look up, which is the whole point of the record existing.
+ */
+export const FULFILLMENT_DEBIT_ACCOUNT_ROLE: Readonly<
+  Record<Exclude<FulfillmentDebitRole, 'gateway'>, AccountRole>
+> = {
   clearing_card: ACCOUNT_ROLES.CLEARING_CARD,
   clearing_affirm: ACCOUNT_ROLES.CLEARING_AFFIRM,
   accounts_receivable: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
@@ -454,10 +560,15 @@ function assertWholeMinor(value: number, label: string, context: Record<string, 
  * 1. `Dr accounts_receivable`, **one line per order**, `sourceType: 'order'`,
  *    `sourceId: <orderId>`, memo `<orderNumber>`. Aging has to name the debtor,
  *    and `listPostingsForSource` on an order still finds this one.
- * 2. `Dr clearing_card`, `Dr clearing_affirm` - summarised.
- * 3. `Cr revenue_dtc`, `Cr revenue_dealer` - summarised, split on the order's
- *    channel through the fail-open {@link CHANNEL_REVENUE_ROLE} table.
- * 4. `Cr sales_tax_payable` - summarised. 5. `Cr revenue_shipping` - summarised.
+ * 2. `Dr clearing_card`, `Dr clearing_affirm`, `Dr <gateway route's account>` -
+ *    summarised, the last one per distinct account id (brief 13 §5.3).
+ * 3. `Cr revenue_product` - summarised PER CHANNEL, one line per
+ *    `dimensions.channel` value, through the fail-open {@link CHANNEL_KEYS}
+ *    table (brief 13 §5).
+ * 4. `Cr sales_tax_payable` - summarised PER JURISDICTION when a shipment's
+ *    tax lines tie to its order's total, plus one undimensioned line for
+ *    whatever does not (brief 13 §5, `splitTaxByJurisdiction`).
+ * 5. `Cr revenue_shipping` - summarised.
  *
  * Every summarised line carries `sourceType: 'fulfillment_batch'` and
  * `sourceId: <periodKey>`, which is what keeps aging free of a branch: an A/R
@@ -491,8 +602,16 @@ export function buildFulfillmentBatchEntry(
     clearing_card: 0,
     clearing_affirm: 0,
     accounts_receivable: 0,
+    gateway: 0,
   }
-  const revenueByRole = new Map<AccountRole, number>()
+  /** A `payment_gateway` route's own clearing account id -> its summarised debit. */
+  const byGatewayAccount = new Map<string, number>()
+  /** `dimensions.channel` value -> summarised revenue_product credit. */
+  const revenueByChannel = new Map<string, number>()
+  /** `dimensions.jurisdiction` value -> summarised sales_tax_payable credit. */
+  const taxByJurisdiction = new Map<string, number>()
+  /** Tax that could not be tied to a jurisdiction - one undimensioned line. */
+  let taxWithoutJurisdictionMinor = 0
   const sources: FulfillmentBatchSource[] = []
   let subtotalMinor = 0
   let taxMinor = 0
@@ -544,9 +663,40 @@ export function buildFulfillmentBatchEntry(
       })
     }
     byDebitRole[amounts.debitRole] += amounts.totalMinor
+    if (amounts.debitRole === 'gateway') {
+      const glAccountId = amounts.debitGlAccountId
+      if (!glAccountId) {
+        // Unreachable through `computeShipmentAmounts`, which always sets one
+        // alongside `debitRole: 'gateway'` - asserted so a hand-built
+        // `ShipmentAmounts` cannot silently drop the debit's destination.
+        throw new UnprocessableEntityError(
+          `Shipment ${shipment.sequence} of order ${shipment.orderNumber} resolved to a gateway ` +
+            'debit with no account id.',
+          context
+        )
+      }
+      byGatewayAccount.set(
+        glAccountId,
+        (byGatewayAccount.get(glAccountId) ?? 0) + amounts.totalMinor
+      )
+    }
 
-    const revenueRole = CHANNEL_REVENUE_ROLE[toChannelKey(shipment.channel)]
-    revenueByRole.set(revenueRole, (revenueByRole.get(revenueRole) ?? 0) + amounts.subtotalMinor)
+    const channelDimension = CHANNEL_KEYS[toChannelKey(shipment.channel)]
+    revenueByChannel.set(
+      channelDimension,
+      (revenueByChannel.get(channelDimension) ?? 0) + amounts.subtotalMinor
+    )
+
+    if (amounts.taxByJurisdiction && amounts.taxByJurisdiction.length > 0) {
+      for (const { jurisdiction, amountMinor } of amounts.taxByJurisdiction) {
+        taxByJurisdiction.set(
+          jurisdiction,
+          (taxByJurisdiction.get(jurisdiction) ?? 0) + amountMinor
+        )
+      }
+    } else {
+      taxWithoutJurisdictionMinor += amounts.taxMinor
+    }
 
     subtotalMinor += amounts.subtotalMinor
     taxMinor += amounts.taxMinor
@@ -587,7 +737,8 @@ export function buildFulfillmentBatchEntry(
     })
   }
 
-  // 2. The clearing accounts, summarised.
+  // 2. The clearing accounts, summarised - by ROLE, or by a gateway route's
+  //    own account id (brief 13 §5.3).
   if (byDebitRole.clearing_card !== 0) {
     push({
       ...summarised,
@@ -606,39 +757,56 @@ export function buildFulfillmentBatchEntry(
       memo: describe('Affirm clearing'),
     })
   }
-
-  // 3. Revenue, summarised per channel.
-  const dtcMinor = revenueByRole.get(ACCOUNT_ROLES.REVENUE_DTC) ?? 0
-  const dealerMinor = revenueByRole.get(ACCOUNT_ROLES.REVENUE_DEALER) ?? 0
-  if (dtcMinor !== 0) {
+  for (const [glAccountId, amount] of byGatewayAccount) {
+    if (amount === 0) continue
     push({
       ...summarised,
-      accountRole: ACCOUNT_ROLES.REVENUE_DTC,
-      direction: 'credit',
-      amount: dtcMinor,
-      memo: describe('product revenue, direct to consumer'),
-    })
-  }
-  if (dealerMinor !== 0) {
-    push({
-      ...summarised,
-      accountRole: ACCOUNT_ROLES.REVENUE_DEALER,
-      direction: 'credit',
-      amount: dealerMinor,
-      memo: describe('product revenue, dealer'),
+      glAccountId,
+      direction: 'debit',
+      amount,
+      memo: describe('gateway clearing'),
     })
   }
 
-  // 4 and 5. Tax and shipping, summarised.
-  if (taxMinor !== 0) {
+  // 3. Revenue, summarised PER CHANNEL - the channel is a dimension on one
+  //    `revenue_product` account, never a second account (brief 13 §5).
+  for (const [channel, amount] of revenueByChannel) {
+    if (amount === 0) continue
+    push({
+      ...summarised,
+      accountRole: ACCOUNT_ROLES.REVENUE_PRODUCT,
+      direction: 'credit',
+      amount,
+      memo: describe(`product revenue, ${channel === 'dealer' ? 'dealer' : 'direct to consumer'}`),
+      dimensions: { channel },
+    })
+  }
+
+  // 4. Tax, summarised PER JURISDICTION when it ties, plus one undimensioned
+  //    line for whatever does not (brief 13 §5 - a partial breakdown would
+  //    read as a complete one).
+  for (const [jurisdiction, amount] of taxByJurisdiction) {
+    if (amount === 0) continue
     push({
       ...summarised,
       accountRole: ACCOUNT_ROLES.SALES_TAX_PAYABLE,
       direction: 'credit',
-      amount: taxMinor,
+      amount,
+      memo: describe(`sales tax, ${jurisdiction}`),
+      dimensions: { jurisdiction },
+    })
+  }
+  if (taxWithoutJurisdictionMinor !== 0) {
+    push({
+      ...summarised,
+      accountRole: ACCOUNT_ROLES.SALES_TAX_PAYABLE,
+      direction: 'credit',
+      amount: taxWithoutJurisdictionMinor,
       memo: describe('sales tax'),
     })
   }
+
+  // 5. Shipping, summarised.
   if (shippingMinor !== 0) {
     push({
       ...summarised,

--- a/packages/lib/src/postings/build-fulfillment-entry.ts
+++ b/packages/lib/src/postings/build-fulfillment-entry.ts
@@ -10,8 +10,9 @@
  *
  * ```
  *   Dr accounts_receivable                     this shipment's total
- *       Cr revenue_dtc | revenue_dealer          this shipment's subtotal
- *       Cr sales_tax_payable                     this shipment's tax
+ *       Cr revenue_product   (channel dimension)  this shipment's subtotal
+ *       Cr sales_tax_payable (jurisdiction dimension, when it ties)
+ *                                                  this shipment's tax
  *       Cr revenue_shipping                      the order's shipping, ONCE
  *
  *   Dr cogs_product_cost      extended cost of what shipped   <- DARK, see below
@@ -52,7 +53,7 @@
  * builders are one policy read on two document families, and they cannot
  * double-count, because `invoice` and `order` are disjoint - no order field on
  * an invoice, no invoice field on an order, in either direction. Product
- * revenue lands on `4000`/`4010` from here; service revenue lands on `4030`
+ * revenue lands on `4000` from here; service revenue lands on `4030`
  * from there.
  *
  * @see plans/accounting/tasks/01-post-revenue-to-the-ledger.md
@@ -61,6 +62,8 @@
 import { UnprocessableEntityError } from '../errors'
 import { ACCOUNT_ROLES, type AccountRole, buildEntry } from './build-entry'
 import { DOC_NUMBER_MAX_LENGTH } from './doc-number'
+import type { JurisdictionTaxLine } from './split-tax-by-jurisdiction'
+import { splitTaxByJurisdiction } from './split-tax-by-jurisdiction'
 import type { BuiltEntry, GlPostingLineInput } from './types'
 
 /** The `sourceType` every fulfillment line carries: the `order` record. */
@@ -79,15 +82,22 @@ export const FULFILLMENT_SOURCE_TYPE = 'order'
 export type OrderChannelKey = 'dtc' | 'dealer' | 'manual' | 'null'
 
 /**
- * Which revenue role each order channel books to. DECLARED, never derived.
+ * Which `dimensions.channel` value each order channel writes onto the
+ * `revenue_product` line. DECLARED, never derived.
+ *
+ * 🛑 **This used to be a role map** (`revenue_dtc` | `revenue_dealer`) and it
+ * is a keyspace now (brief 13 §5): channel is a reporting DIMENSION on one
+ * `revenue_product` account, never a second account. The P&L still splits
+ * revenue by channel - now by grouping on `dimensions.channel` instead of by
+ * account - which is exactly the acceptance this table exists to keep true.
  *
  * ## ⤵️ It fails OPEN, and it used to fail closed
  *
- * `manual` and `null` used to REFUSE, on the argument that `4000` and `4010` are
- * two revenue accounts and a default to DTC puts a dealer sale in the consumer
- * line, where it balances and is invisible until somebody reads the P&L by
- * channel. The argument is sound and the answer was still wrong, for a reason
- * the data settled (49 §4.6, §8.1 item 6, §8.4 decision 5):
+ * `manual` and `null` used to REFUSE, on the argument that `4000` and `4010`
+ * (now retired) were two revenue accounts and a default to `dtc` puts a dealer
+ * sale in the consumer line, where it balances and is invisible until somebody
+ * reads the P&L by channel. The argument is sound and the answer was still
+ * wrong, for a reason the data settled (49 §4.6, §8.1 item 6, §8.4 decision 5):
  *
  * - `order_channel` is **human-set, never derived**, and no connector binds it.
  *   535 of 545 orders on the reference org carry the registry DEFAULT, `manual`.
@@ -98,22 +108,23 @@ export type OrderChannelKey = 'dtc' | 'dealer' | 'manual' | 'null'
  *
  * A default that recognises consumer revenue is the honest reading of *"nobody
  * has said"* for a business whose unmarked orders are Shopify checkouts. It is
- * also **correctable**: an order booked to the wrong revenue line is fixed by
+ * also **correctable**: an order booked to the wrong dimension is fixed by
  * setting the channel and posting a compensating entry, whereas revenue that
  * was never recognised at all is invisible. When the dealer signal lands, the
  * `dealer` row is already here and the default stops being reached.
  *
- * Widening this table is a one-line edit here plus a role in `ACCOUNT_ROLES`.
- * Deriving it from `paymentGateways` or tags was tried and cannot work: a manual
- * sale has neither.
+ * Widening this table is a one-line edit here - no role, no chart migration,
+ * no builder change beyond the value written. Deriving it from
+ * `paymentGateways` or tags was tried and cannot work: a manual sale has
+ * neither.
  */
-export const CHANNEL_REVENUE_ROLE: Record<OrderChannelKey, AccountRole> = {
-  dtc: ACCOUNT_ROLES.REVENUE_DTC,
-  dealer: ACCOUNT_ROLES.REVENUE_DEALER,
+export const CHANNEL_KEYS: Record<OrderChannelKey, string> = {
+  dtc: 'dtc',
+  dealer: 'dealer',
   // "Somebody typed manual" and "nobody has said" are still two different facts
   // - see `OrderChannelKey` - and they simply have the same answer today.
-  manual: ACCOUNT_ROLES.REVENUE_DTC,
-  null: ACCOUNT_ROLES.REVENUE_DTC,
+  manual: 'dtc',
+  null: 'dtc',
 }
 
 /** Normalise a stored `order_channel` value - anything unrecognised is `'null'`. */
@@ -356,7 +367,7 @@ export interface BuildFulfillmentEntryInput {
   sequence: number
   /**
    * `order_channel`, verbatim. `manual` and absent both recognise as CONSUMER
-   * revenue - the table fails open. See {@link CHANNEL_REVENUE_ROLE}.
+   * revenue - the table fails open. See {@link CHANNEL_KEYS}.
    */
   channel: string | null | undefined
   /** `order_currency`, verbatim. Anything but `ledgerCurrency` REFUSES. */
@@ -427,6 +438,16 @@ export interface BuildFulfillmentEntryInput {
    * still posts; the export is what refuses a receivable line with none.
    */
   contactInstanceId?: string | null
+  /**
+   * The order's own tax lines - one row per jurisdiction (brief 13 §5,
+   * `tax_line` EntityInstances). When present and they SUM to
+   * `orderTaxTotalMinor`, the `sales_tax_payable` credit is split pro rata
+   * across them with a `jurisdiction` dimension per line - see
+   * {@link splitTaxByJurisdiction}. Absent, empty, or not tying to the order's
+   * own tax total falls back to today's single undimensioned line: a partial
+   * breakdown would read as a complete one.
+   */
+  taxLines?: readonly JurisdictionTaxLine[]
   /** The entry memo, carried onto every line with none of its own. */
   memo?: string
 }
@@ -436,8 +457,15 @@ export interface BuiltFulfillmentEntry {
   entry: BuiltEntry
   /** `ORD-0012-F1`. Also `BuiltEntry.periodKey`. */
   periodKey: string
-  /** Which revenue account the channel resolved to. */
+  /**
+   * `ACCOUNT_ROLES.REVENUE_PRODUCT`, always, now that channel is a dimension
+   * rather than a second role (brief 13 §5). Kept as a field, rather than
+   * removed, so `money/orders/fulfill.ts` keeps a stable shape to log; the
+   * channel itself is on {@link channelDimension}.
+   */
   revenueRole: AccountRole
+  /** The `dimensions.channel` value the revenue line carries - see {@link CHANNEL_KEYS}. */
+  channelDimension: string
   /** This shipment's share of the order, all in integer minor units. */
   subtotalMinor: number
   taxMinor: number
@@ -530,7 +558,7 @@ export function fulfillmentPeriodKey(orderNumber: string, sequence: number): str
  * @throws {UnprocessableEntityError} on a foreign currency, no shipped lines, a
  *   non-positive quantity, a fractional stored amount, an over-long order
  *   number, or an entry with no value on either side. NOT on an unset channel:
- *   see {@link CHANNEL_REVENUE_ROLE}.
+ *   see {@link CHANNEL_KEYS}.
  */
 export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltFulfillmentEntry {
   const {
@@ -546,6 +574,7 @@ export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltF
     includeCogs = false,
     cogsMinor,
     contactInstanceId,
+    taxLines,
     memo,
   } = input
 
@@ -564,9 +593,9 @@ export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltF
 
   // ── The channel, from the DECLARED table ─────────────────────────────────
   // Fails OPEN: an unset channel recognises as consumer revenue rather than
-  // refusing the shipment. See CHANNEL_REVENUE_ROLE for why that changed.
+  // refusing the shipment. See CHANNEL_KEYS for why that changed.
   const channelKey = toChannelKey(channel)
-  const revenueRole = CHANNEL_REVENUE_ROLE[channelKey]
+  const channelDimension = CHANNEL_KEYS[channelKey]
 
   if (shippedLines.length === 0) {
     throw new UnprocessableEntityError(
@@ -602,50 +631,72 @@ export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltF
   const source = { sourceType: FULFILLMENT_SOURCE_TYPE, sourceId: orderId }
   const shipmentLabel = `${orderNumber} shipment ${sequence}`
 
-  const lines: GlPostingLineInput[] = [
-    {
-      ...source,
-      accountRole: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
-      direction: 'debit',
-      amount: totalMinor,
-      memo: memo ?? shipmentLabel,
-      sortOrder: 0,
-      ...(contactInstanceId
-        ? { counterpartyType: 'customer' as const, counterpartyId: contactInstanceId }
-        : {}),
-    },
-    {
-      ...source,
-      accountRole: revenueRole,
-      direction: 'credit',
-      amount: subtotalMinor,
-      memo: `${shipmentLabel} - ${shippedLines.length} line${shippedLines.length === 1 ? '' : 's'}`,
-      sortOrder: 1,
-    },
-  ]
+  const lines: GlPostingLineInput[] = []
+  let sortOrder = 0
+  const push = (line: Omit<GlPostingLineInput, 'sortOrder'>): void => {
+    lines.push({ ...line, sortOrder: sortOrder++ } as GlPostingLineInput)
+  }
+
+  push({
+    ...source,
+    accountRole: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
+    direction: 'debit',
+    amount: totalMinor,
+    memo: memo ?? shipmentLabel,
+    ...(contactInstanceId
+      ? { counterpartyType: 'customer' as const, counterpartyId: contactInstanceId }
+      : {}),
+  })
+  push({
+    ...source,
+    accountRole: ACCOUNT_ROLES.REVENUE_PRODUCT,
+    direction: 'credit',
+    amount: subtotalMinor,
+    memo: `${shipmentLabel} - ${shippedLines.length} line${shippedLines.length === 1 ? '' : 's'}`,
+    dimensions: { channel: channelDimension },
+  })
 
   // Zero legs are DROPPED rather than posted at zero. An org that charges no
   // tax has no reason to have mapped `sales_tax_payable`, and a zero line
   // against an unmapped role fails the resolver for no information at all -
   // the same rule `materialize` follows in `build-entry.ts`.
   if (taxMinor !== 0) {
-    lines.push({
-      ...source,
-      accountRole: ACCOUNT_ROLES.SALES_TAX_PAYABLE,
-      direction: 'credit',
-      amount: taxMinor,
-      memo: `${shipmentLabel} - sales tax (${taxBasis === 'per_line' ? 'per line' : 'allocated'})`,
-      sortOrder: 2,
+    const taxLabel = taxBasis === 'per_line' ? 'per line' : 'allocated'
+    // Split by jurisdiction when the order's own tax lines tie to its total
+    // (brief 13 §5) - otherwise the single undimensioned line, unchanged.
+    const split = splitTaxByJurisdiction({
+      taxMinor,
+      taxLines: taxLines ?? [],
+      orderTaxTotalMinor: input.orderTaxTotalMinor,
     })
+    if (split) {
+      for (const { jurisdiction, amountMinor } of split) {
+        push({
+          ...source,
+          accountRole: ACCOUNT_ROLES.SALES_TAX_PAYABLE,
+          direction: 'credit',
+          amount: amountMinor,
+          memo: `${shipmentLabel} - sales tax, ${jurisdiction} (${taxLabel})`,
+          dimensions: { jurisdiction },
+        })
+      }
+    } else {
+      push({
+        ...source,
+        accountRole: ACCOUNT_ROLES.SALES_TAX_PAYABLE,
+        direction: 'credit',
+        amount: taxMinor,
+        memo: `${shipmentLabel} - sales tax (${taxLabel})`,
+      })
+    }
   }
   if (shippingMinor !== 0) {
-    lines.push({
+    push({
       ...source,
       accountRole: ACCOUNT_ROLES.REVENUE_SHIPPING,
       direction: 'credit',
       amount: shippingMinor,
       memo: `${orderNumber} - shipping, recognised once on the first fulfillment`,
-      sortOrder: 3,
     })
   }
 
@@ -659,24 +710,20 @@ export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltF
         { orderNumber, cogsMinor: String(cost) }
       )
     }
-    lines.push(
-      {
-        ...source,
-        accountRole: ACCOUNT_ROLES.COGS_PRODUCT_COST,
-        direction: 'debit',
-        amount: cost,
-        memo: `${shipmentLabel} - cost of goods shipped`,
-        sortOrder: 4,
-      },
-      {
-        ...source,
-        accountRole: ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS,
-        direction: 'credit',
-        amount: cost,
-        memo: `${shipmentLabel} - relieved from finished goods`,
-        sortOrder: 5,
-      }
-    )
+    push({
+      ...source,
+      accountRole: ACCOUNT_ROLES.COGS_PRODUCT_COST,
+      direction: 'debit',
+      amount: cost,
+      memo: `${shipmentLabel} - cost of goods shipped`,
+    })
+    push({
+      ...source,
+      accountRole: ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS,
+      direction: 'credit',
+      amount: cost,
+      memo: `${shipmentLabel} - relieved from finished goods`,
+    })
   }
 
   const entry = buildEntry({ postingType: 'fulfillment', periodKey, txnDate, lines })
@@ -684,7 +731,8 @@ export function buildFulfillmentEntry(input: BuildFulfillmentEntryInput): BuiltF
   return {
     entry,
     periodKey,
-    revenueRole,
+    revenueRole: ACCOUNT_ROLES.REVENUE_PRODUCT,
+    channelDimension,
     subtotalMinor,
     taxMinor,
     shippingMinor,

--- a/packages/lib/src/postings/build-payment-entry.ts
+++ b/packages/lib/src/postings/build-payment-entry.ts
@@ -50,10 +50,13 @@
  * every wrong answer still balances:
  *
  * - **Cheque and cash** are banked in a RUN. Five cheques arrive at the bank as
- *   ONE line, so five separate cash postings can never match it. They wait in
- *   `undeposited_funds` until a `bank_deposit` posts the single cash line.
+ *   ONE line, so five separate postings can never match it. They wait in
+ *   `undeposited_funds` until a `bank_deposit` posts the single line.
  * - **ACH and wire** arrive alone and match their own bank line, so they go
- *   straight to cash.
+ *   straight to a NAMED bank account - the `cash` route, resolved to a
+ *   `bank_account` id (brief 13 §2.4), never to a role. An org with two bank
+ *   accounts banks an ACH into whichever one it names, and the account is
+ *   {@link BuildPaymentEntryInput.bankAccountGlAccountId}.
  * - **Card** settles as a NET payout days later. It goes to a clearing account
  *   which `buildPayoutEntry` drains; routing it through undeposited funds would
  *   assert a gross deposit the bank never credited.
@@ -74,6 +77,10 @@
  *    has to tell the two apart, {@link PAYMENT_ROUTE_ROLE} grows a discriminator
  *    on the GATEWAY rather than on the method, the way `resolveFulfillmentDebit`
  *    already does.
+ * 3. **Which bank account.** A bank account is not a role (brief 13 §2), so the
+ *    `cash` row of {@link PAYMENT_ROUTE_ROLE} carries no role to look up - the
+ *    caller resolves `accounting.cashBankAccountId` to a `gl_account` id and
+ *    passes it in, and this file refuses to post the route with none.
  *
  * @see plans/accounting/tasks/01-post-revenue-to-the-ledger.md §1.2
  * @see plans/accounting/tasks/06-deposit-grouping.md §2.3
@@ -95,17 +102,30 @@ import type { BuiltEntry, GlPostingLineInput, PostingType } from './types'
 export const PAYMENT_SOURCE_TYPE = 'payment_transaction'
 
 /**
+ * What a route resolves to: either a ROLE (an accounting function, one account
+ * org-wide) or a specific BANK ACCOUNT (an instance, resolved by the caller).
+ *
+ * A bank account is not a role (brief 13 §2.4) - an org has several, and the
+ * `cash` route is the one place a payment names one directly rather than
+ * through a function like `clearing_card`.
+ */
+export type PaymentRouteAccount = { kind: 'role'; role: AccountRole } | { kind: 'bank_account' }
+
+/**
  * Where each route's money sits in the chart. DECLARED, one row per route.
  *
  * Type-only import of `PaymentRoute` so `postings/` gains no runtime edge into
  * `money/` - the dependency runs the other way and a second copy of the union
  * would be free to drift.
  */
-export const PAYMENT_ROUTE_ROLE: Record<PaymentRoute, AccountRole> = {
-  undeposited_funds: ACCOUNT_ROLES.UNDEPOSITED_FUNDS,
-  cash: ACCOUNT_ROLES.CASH,
+export const PAYMENT_ROUTE_ROLE: Record<PaymentRoute, PaymentRouteAccount> = {
+  undeposited_funds: { kind: 'role', role: ACCOUNT_ROLES.UNDEPOSITED_FUNDS },
+  // 🛑 No role. The caller resolves `accounting.cashBankAccountId` to a
+  // `bank_account`'s `glAccountId` and passes it as
+  // {@link BuildPaymentEntryInput.bankAccountGlAccountId} - see the file header.
+  cash: { kind: 'bank_account' },
   // One clearing role exists today. See the file header on `1210 Affirm Clearing`.
-  clearing: ACCOUNT_ROLES.CLEARING_CARD,
+  clearing: { kind: 'role', role: ACCOUNT_ROLES.CLEARING_CARD },
 }
 
 /** The `PaymentTransaction` fields an entry is built from. Nothing else is read. */
@@ -148,6 +168,13 @@ export interface BuildPaymentEntryInput {
   /** From `resolvePaymentRoute(method, settings)`. Never inferred here. */
   route: PaymentRoute
   /**
+   * The `gl_account` id of the `bank_account` the caller resolved from
+   * `accounting.cashBankAccountId`, required exactly when `route` is `cash`
+   * (brief 13 §2.4). Ignored for every other route. `null`/absent on a `cash`
+   * route is a refusal, never a guess at which account.
+   */
+  bankAccountGlAccountId?: string | null
+  /**
    * `PaymentTransaction.id` is a cuid and blows the 21-character document-number
    * cap outright, so the key is minted - {@link paymentPeriodKey}.
    */
@@ -174,8 +201,14 @@ export interface BuildPaymentEntryInput {
 export interface BuiltPaymentEntry {
   entry: BuiltEntry
   periodKey: string
-  /** The account the money landed in (a charge) or came back out of (a refund). */
-  routeRole: AccountRole
+  /**
+   * The role the money landed in or out of, when the route resolves to a role.
+   * `null` for the `cash` route, which names a `bank_account` id instead - see
+   * {@link routeGlAccountId}.
+   */
+  routeRole: AccountRole | null
+  /** The `gl_account` id the money landed in or out of, when the route is `cash`. `null` otherwise. */
+  routeGlAccountId: string | null
   /** Integer minor units, always positive - `direction` carries the sign. */
   amountMinor: number
   /** The part of {@link amountMinor} that relieved a receivable. */
@@ -219,8 +252,9 @@ export function paymentPeriodKey(transactionId: string): string {
  * account the money left from.
  *
  * @throws {UnprocessableEntityError} on a foreign currency, an amount that is
- *   not a positive whole number of minor units, or an `allocatedMinor` that is
- *   negative, fractional or larger than the amount received.
+ *   not a positive whole number of minor units, an `allocatedMinor` that is
+ *   negative, fractional or larger than the amount received, or a `cash` route
+ *   with no `bankAccountGlAccountId`.
  */
 export function buildPaymentEntry(input: BuildPaymentEntryInput): BuiltPaymentEntry {
   const { postingType, transaction, route, periodKey, ledgerCurrency, allocatedMinor, memo } = input
@@ -263,7 +297,16 @@ export function buildPaymentEntry(input: BuildPaymentEntryInput): BuiltPaymentEn
     )
   }
 
-  const routeRole = PAYMENT_ROUTE_ROLE[route]
+  const routeAccount = PAYMENT_ROUTE_ROLE[route]
+  const bankAccountGlAccountId = input.bankAccountGlAccountId?.trim() || null
+  if (routeAccount.kind === 'bank_account' && !bankAccountGlAccountId) {
+    throw new UnprocessableEntityError(
+      `Payment ${id} routes to a bank account (the ${route} route) but names none. Set ` +
+        'accounting.cashBankAccountId to a mapped bank account before posting to it.',
+      { transactionId: id, route }
+    )
+  }
+
   const source = { sourceType: PAYMENT_SOURCE_TYPE, sourceId: id }
   const label = `${kind === 'refund' ? 'Refund' : 'Payment'}${method ? ` (${method})` : ''}${
     reference ? ` ${reference}` : ''
@@ -286,16 +329,29 @@ export function buildPaymentEntry(input: BuildPaymentEntryInput): BuiltPaymentEn
   // Route, receivable, deposits. A zero leg is omitted rather than posted:
   // `buildEntry` refuses a line that moves nothing, and a two-line entry is
   // what a fully applied payment and a wholly held deposit each are.
-  const lines: GlPostingLineInput[] = [
-    {
-      ...source,
-      accountRole: routeRole,
-      direction: routeDirection,
-      amount: amountMinor,
-      memo: memo ?? label,
-      sortOrder: 0,
-    },
-  ]
+  //
+  // 🛑 The route leg names its account in ONE of two ways, never both: a ROLE
+  // for `undeposited_funds`/`clearing`, or the `bank_account`'s own `glAccountId`
+  // for `cash` (brief 13 §2.4). A bank account is not a role.
+  const routeLine: GlPostingLineInput =
+    routeAccount.kind === 'bank_account'
+      ? {
+          ...source,
+          glAccountId: bankAccountGlAccountId as string,
+          direction: routeDirection,
+          amount: amountMinor,
+          memo: memo ?? label,
+          sortOrder: 0,
+        }
+      : {
+          ...source,
+          accountRole: routeAccount.role,
+          direction: routeDirection,
+          amount: amountMinor,
+          memo: memo ?? label,
+          sortOrder: 0,
+        }
+  const lines: GlPostingLineInput[] = [routeLine]
 
   if (receivableMinor > 0) {
     lines.push({
@@ -323,5 +379,16 @@ export function buildPaymentEntry(input: BuildPaymentEntryInput): BuiltPaymentEn
 
   const entry = buildEntry({ postingType, periodKey, txnDate: receivedAt, lines })
 
-  return { entry, periodKey, routeRole, amountMinor, receivableMinor, depositMinor }
+  const routeRole = routeAccount.kind === 'role' ? routeAccount.role : null
+  const routeGlAccountId = routeAccount.kind === 'bank_account' ? bankAccountGlAccountId : null
+
+  return {
+    entry,
+    periodKey,
+    routeRole,
+    routeGlAccountId,
+    amountMinor,
+    receivableMinor,
+    depositMinor,
+  }
 }

--- a/packages/lib/src/postings/build-payout-entry.ts
+++ b/packages/lib/src/postings/build-payout-entry.ts
@@ -7,18 +7,31 @@
  * PURE. No database, no clock, no chart.
  *
  * ```
- *   Dr cash                        the whole deposit that reached the bank
- *   Dr payment_processing_fees     fees withheld on the RECOGNISED charges
- *       Cr clearing_card                 RECOGNISED gross
- *       Cr unidentified_receipts         the unrecognised remainder, net
+ *   Dr <the settlement's own bank account>   the whole deposit that reached the bank
+ *   Dr payment_processing_fees               fees withheld on the RECOGNISED charges
+ *       Cr clearing_card                           RECOGNISED gross
+ *       Cr unidentified_receipts                   the unrecognised remainder, net
  * ```
  *
  * This is the entry that makes `1200 Card Clearing` reconcilable. A card
  * receipt DEBITS the clearing account gross at the sale (`buildPaymentEntry`
- * with route `clearing`), and this entry credits it gross again, net to cash
- * and the difference to fees. A settled batch therefore leaves the clearing
- * account at zero, and a non-zero balance is a list of sales the gateway has
- * not paid out yet - which is a useful control on its own.
+ * with route `clearing`), and this entry credits it gross again, net to the
+ * bank account the payout settled into and the difference to fees. A settled
+ * batch therefore leaves the clearing account at zero, and a non-zero balance
+ * is a list of sales the gateway has not paid out yet - which is a useful
+ * control on its own.
+ *
+ * ## 🛑 A bank account is not a role (brief 13 §2)
+ *
+ * The debit used to be `ACCOUNT_ROLES.CASH`, which resolved to whichever
+ * single account held the role - so a payout settling into Wells Fargo
+ * Checking and the bank feed's own line for the same money could land in two
+ * different accounts and still balance, with nothing comparing them. The debit
+ * is now the SETTLEMENT'S OWN bank account, resolved by the caller from the
+ * payout's Stripe destination (`money/payouts/sync.ts`) and passed in as
+ * {@link BuildPayoutEntryInput.bankAccountGlAccountId}. This file never reads a
+ * `bank_account` itself - it stays PURE - it only takes the id the caller
+ * already resolved and confirmed.
  *
  * ## 🛑 The fourth leg, and why it is not optional
  *
@@ -27,13 +40,15 @@
  * subscription on the same account, a terminal. Those were never debited to
  * `clearing_card`, so crediting the payout's full gross to clearing drives that
  * account permanently negative by the amount auxx never took. Relieving only
- * the recognised part and debiting cash to match would keep clearing right and
- * break the bank instead: the bank feed shows ONE deposit for the whole payout.
+ * the recognised part and debiting the bank account to match would keep
+ * clearing right and break the bank instead: the bank feed shows ONE deposit
+ * for the whole payout.
  *
  * So all three of the following hold at once, and only this shape gets all
  * three:
  *
- * - **cash takes the WHOLE deposit**, so the entry matches the bank line;
+ * - **the bank account takes the WHOLE deposit**, so the entry matches the
+ *   bank line;
  * - **clearing is relieved of exactly what auxx put in it**, so it still
  *   reconciles to zero;
  * - **the remainder is visible in one account somebody must work**
@@ -105,6 +120,16 @@ export interface BuildPayoutEntryInput {
   /** The gateway's own payout id. Every line's `sourceId`. */
   payoutId: string
   /**
+   * The `gl_account` id of the `bank_account` this payout settled into,
+   * resolved by the caller from the payout's Stripe destination against a
+   * CONFIRMED `bank_account.stripeExternalAccountId` (brief 13 §2.3). Never a
+   * role: an org has several bank accounts and the payout settles into exactly
+   * one of them, so a role would send every payout to whichever single account
+   * happened to hold it. The caller refuses to call this function at all when
+   * the destination cannot be resolved - see `money/payouts/sync.ts`.
+   */
+  bankAccountGlAccountId: string
+  /**
    * The short, human key the document number is built on.
    *
    * 🛑 **`doc-number.ts` says `payout` keys on the payout id, and that rule
@@ -123,7 +148,8 @@ export interface BuildPayoutEntryInput {
   /**
    * What actually reached the bank, integer minor units. The RECOGNISED net -
    * `grossMinor - feesMinor` - NOT the payout's total. The whole deposit is
-   * `netMinor + unrecognisedNetMinor`, and that is what lands on cash.
+   * `netMinor + unrecognisedNetMinor`, and that is what lands on
+   * {@link bankAccountGlAccountId}.
    */
   netMinor: number
   /**
@@ -150,7 +176,7 @@ export interface BuiltPayoutEntry {
   feesMinor: number
   netMinor: number
   unrecognisedNetMinor: number
-  /** What hit the bank: `netMinor + unrecognisedNetMinor`. The cash leg. */
+  /** What hit the bank: `netMinor + unrecognisedNetMinor`. The bank-account debit leg. */
   depositedMinor: number
 }
 
@@ -176,11 +202,13 @@ function assertMinor(value: number, label: string, payoutNumber: string): number
  * account that can never reach zero for reasons nobody can reconstruct.
  *
  * @throws {UnprocessableEntityError} on a fractional or negative amount, an
- *   arithmetic disagreement, an over-long payout number, or a `clearingRole`
- *   that is not a clearing account.
+ *   arithmetic disagreement, an over-long payout number, a missing
+ *   `bankAccountGlAccountId`, or a `clearingRole` that is not a clearing
+ *   account.
  */
 export function buildPayoutEntry(input: BuildPayoutEntryInput): BuiltPayoutEntry {
   const { payoutId, payoutNumber, clearingRole, paidAt, memo } = input
+  const bankAccountGlAccountId = input.bankAccountGlAccountId?.trim()
 
   const number = payoutNumber.trim()
   if (!number) {
@@ -189,6 +217,14 @@ export function buildPayoutEntry(input: BuildPayoutEntryInput): BuiltPayoutEntry
         'gateway id, which is over the 21-character cap, and never a date, because two payouts ' +
         'can settle on one day.',
       { payoutId }
+    )
+  }
+  if (!bankAccountGlAccountId) {
+    throw new UnprocessableEntityError(
+      `Payout ${number} has no bank account to debit. A payout settles into a specific bank ` +
+        "account, never a role - resolve the payout's Stripe destination to a confirmed " +
+        'bank_account first.',
+      { payoutId, payoutNumber: number }
     )
   }
   const compact = number.replace(/-/g, '')
@@ -264,7 +300,9 @@ export function buildPayoutEntry(input: BuildPayoutEntryInput): BuiltPayoutEntry
   const lines: GlPostingLineInput[] = [
     {
       ...source,
-      accountRole: ACCOUNT_ROLES.CASH,
+      // 🛑 The settlement's OWN bank account, by id - never the `cash` role
+      // (brief 13 §2). The caller resolved and confirmed it before calling in.
+      glAccountId: bankAccountGlAccountId,
       // 🛑 The WHOLE deposit, not the recognised net. This leg is what the bank
       // line matches against, and the bank shows one figure for the payout.
       direction: 'debit',

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -77,7 +77,7 @@ export {
   type BuildFulfillmentEntryInput,
   type BuiltFulfillmentEntry,
   buildFulfillmentEntry,
-  CHANNEL_REVENUE_ROLE,
+  CHANNEL_KEYS,
   computeShipmentTotals,
   extendRateToAmount,
   FULFILLMENT_SOURCE_TYPE,
@@ -292,6 +292,7 @@ export {
 export {
   type AccountSuggestion,
   isMappableTo,
+  SUBTYPE_PROVIDER_ACCOUNT_TYPES,
   suggestAccountIdentities,
   validateProviderMapping,
 } from './suggest-account-identities'

--- a/packages/lib/src/postings/default-chart.ts
+++ b/packages/lib/src/postings/default-chart.ts
@@ -129,7 +129,9 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     code: '1000',
     name: 'Cash',
     accountType: GlAccountType.ASSET,
-    role: 'cash',
+    // No role since brief 13 §2: a bank account is an instance, not a
+    // function. An org maps this as a bank account like any other, or `16`
+    // stops seeding it.
     subtype: GlAccountSubtype.BANK,
   },
   {
@@ -231,7 +233,7 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
   },
   {
     code: '2110',
-    name: 'Payroll Clearing (ADP)',
+    name: 'Payroll Clearing',
     accountType: GlAccountType.LIABILITY,
     role: 'payroll_clearing',
   },
@@ -350,15 +352,9 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     // shift in channel mix looks like a margin problem with no visible cause
     // (accrual plan §3).
     code: '4000',
-    name: 'Product Revenue - DTC',
+    name: 'Product Revenue',
     accountType: GlAccountType.REVENUE,
-    role: 'revenue_dtc',
-  },
-  {
-    code: '4010',
-    name: 'Product Revenue - Dealer',
-    accountType: GlAccountType.REVENUE,
-    role: 'revenue_dealer',
+    role: 'revenue_product',
   },
   {
     // Its own account rather than folded into product revenue (handoff

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -78,7 +78,7 @@ export {
   type BuildFulfillmentEntryInput,
   type BuiltFulfillmentEntry,
   buildFulfillmentEntry,
-  CHANNEL_REVENUE_ROLE,
+  CHANNEL_KEYS,
   computeShipmentTotals,
   extendRateToAmount,
   FULFILLMENT_SOURCE_TYPE,
@@ -322,6 +322,11 @@ export {
   type ReadCompletenessOptions,
   readCompleteness,
 } from './reports/completeness'
+export {
+  type DimensionBreakdownRow,
+  type ReadDimensionBreakdownOptions,
+  readDimensionBreakdown,
+} from './reports/dimension-breakdown'
 export { fiscalYearStart, previousCalendarDay } from './reports/fiscal-year'
 export {
   type RenderStatementPdfOptions,
@@ -398,6 +403,7 @@ export {
 export {
   type AccountSuggestion,
   isMappableTo,
+  SUBTYPE_PROVIDER_ACCOUNT_TYPES,
   suggestAccountIdentities,
   validateProviderMapping,
 } from './suggest-account-identities'

--- a/packages/lib/src/postings/post-entry.ts
+++ b/packages/lib/src/postings/post-entry.ts
@@ -397,6 +397,10 @@ async function prepareEntry(
           // one re-resolved after a merge or a rename.
           counterpartyType: line.counterpartyType,
           counterpartyId: line.counterpartyId,
+          // Carried from the input verbatim (brief 13 §5) - a reporting
+          // dimension is never resolved against the chart, it just rides
+          // along to the stored line.
+          dimensions: line.dimensions,
         },
       })
     }
@@ -1056,6 +1060,9 @@ async function claimPeriod(
           // it even if the record is later merged or renamed.
           counterpartyType: line.resolved.counterpartyType ?? null,
           counterpartyId: line.resolved.counterpartyId ?? null,
+          // Reporting dimensions (brief 13 §5) - `{ channel: 'dealer' }` and
+          // the like. Never a lookup key, never resolved, just stored.
+          dimensions: line.resolved.dimensions ?? null,
         }))
       )
     }

--- a/packages/lib/src/postings/post-payout-entry.ts
+++ b/packages/lib/src/postings/post-payout-entry.ts
@@ -4,26 +4,12 @@
  * The writer for `buildPayoutEntry`. Resolves the period lock and hands the
  * entry to `postEntry`; the accounting is all in the builder.
  *
- * ## ⚠️ There is still no trigger, and that is the honest state
- *
- * auxx stores no payout: there is no `payout` entity, no Stripe payout ingest,
- * no `payout.*` webhook case in `applyStripeEvent`, and no balance-transaction
- * row carrying the fee the processor withheld (`money/payments/fees.ts` is the
- * Connect APPLICATION fee, a different number - `implementation-review.md` §1
- * corrects the brief on this). So the GATHERER for this entry is still not
- * written.
- *
- * 🛑 The reason is no longer "the data cannot be reached". A 2026-09-04 survey
- * of the Stripe surface found the credentials already in place - see
- * `build-payout-entry.ts`'s scope section, which names the three things that
- * are actually missing and the one that is a product decision rather than code
- * (charges settled in a payout that auxx never posted to clearing). Do not read
- * this file as saying a gatherer is impossible; read it as saying nobody has
- * decided what the clearing account should do about money auxx did not take.
- *
- * What ships is the pure builder and this writer, so the day a payout source
- * lands the only new code is the read that fills
- * `{ payoutId, payoutNumber, gross, fees, net }`.
+ * `money/payouts/sync.ts` is the gatherer and the trigger: it lists an org's
+ * Stripe payouts, resolves each payout's destination to a confirmed
+ * `bank_account` (brief 13 §2.3), and calls this function once it has a
+ * `bankAccountGlAccountId` to pass in. See {@link payoutAccountUnmappedResult}
+ * for the shape it returns INSTEAD of calling this function when that
+ * resolution fails - no entry is built and nothing is claimed.
  */
 
 import type { Database } from '@auxx/database'
@@ -39,6 +25,22 @@ const logger = createScopedLogger('postings:payout')
 export interface PostPayoutEntryOptions extends BuildPayoutEntryInput {
   organizationId: string
   actorUserId?: string
+}
+
+/**
+ * The `PostResult` a payout carries when its Stripe destination cannot be
+ * resolved to a confirmed bank account (brief 13 §2.3).
+ *
+ * 🛑 Never reached through {@link postPayoutEntry} - the caller (`money/payouts/
+ * sync.ts`) constructs this DIRECTLY and skips the call, because there is no
+ * `bankAccountGlAccountId` to build with. `account_unmapped` is the same
+ * status `postEntry` returns for an unresolved ROLE (`post-entry.ts`); this is
+ * the closest existing status for an unresolved bank-account IDENTITY, and
+ * brief 13 §2.4's DECIDED block says not to add a new one. Pre-claim, like
+ * every `account_unmapped`: nothing is built, nothing is written.
+ */
+export function payoutAccountUnmappedResult(message: string): PostResult {
+  return { status: 'account_unmapped', failureClass: 'configuration', error: message }
 }
 
 /**

--- a/packages/lib/src/postings/read-posting.ts
+++ b/packages/lib/src/postings/read-posting.ts
@@ -127,6 +127,7 @@ export async function getPosting(
         sourceId: schema.GlPostingLine.sourceId,
         counterpartyType: schema.GlPostingLine.counterpartyType,
         counterpartyId: schema.GlPostingLine.counterpartyId,
+        dimensions: schema.GlPostingLine.dimensions,
       })
       .from(schema.GlPostingLine)
       .where(
@@ -154,6 +155,9 @@ export async function getPosting(
       // Never re-resolved here, for the same reason `accountName` is not.
       counterpartyType: (row.counterpartyType as PostingDetailLine['counterpartyType']) ?? null,
       counterpartyId: row.counterpartyId ?? null,
+      // The reporting dimensions as stored (brief 13 §5) - `{ channel: 'dealer' }`
+      // and the like. Null on most lines.
+      dimensions: (row.dimensions as Record<string, string> | null) ?? null,
     }))
 
     return ok({

--- a/packages/lib/src/postings/regime.ts
+++ b/packages/lib/src/postings/regime.ts
@@ -5,7 +5,9 @@
 // This file exists for one assertion, and the assertion is the only mechanical
 // guard that two writers are not driving one balance-asserted account
 // (plans/money/04-books.md §2.2, gap-e risk E5; generalised to `cash` by
-// plans/bank-connection/README.md §2.1 and plans/accounting/HANDOFF.md slot 0C).
+// plans/bank-connection/README.md §2.1 and plans/accounting/HANDOFF.md slot 0C,
+// and narrowed back to the three inventory accounts by brief 13 §2.5 when
+// `cash` retired as a role).
 //
 // ── The failure it prevents ─────────────────────────────────────────────────
 //
@@ -17,12 +19,13 @@
 // it reads exactly like consumption. Both entries balance. Both claim cleanly.
 // Nothing in the engine can tell the difference.
 //
-// `cash` has the same shape one level over. A bank deposit that posts
-// `Dr cash Cr undeposited_funds` and a bank-feed line that posts the SAME
-// deposit again as `Dr cash Cr something` both balance, and the cash account is
-// overstated by the deposit with nothing to flag it. So `cash` has ONE
-// role-emitting writer, `bank_deposit`; a matched bank line links and posts
-// nothing (bank plan decision B5).
+// 🛑 `cash` retired as a posting role (brief 13 §2): a bank account is not a
+// role, and every cash-touching builder now names a `bank_account`'s own
+// `gl_account` id directly, which this guard cannot see by construction (it
+// only reads `accountRole` lines). `SINGLE_WRITER_ROLES` is back to exactly the
+// three inventory accounts - the guard it can still make mechanically. A
+// single-writer check over bank-account ids is a real gap this leaves open;
+// see the TODO below `SINGLE_WRITER_ROLES`.
 //
 // `receipt` and `vendor_bill` are present in `POSTING_TYPES` and in the pgEnum,
 // and `buildReceiptEntry` / `buildVendorBillEntry` are written and tested - they
@@ -86,16 +89,28 @@ export const INVENTORY_ROLES: readonly AccountRole[] = [
 
 /**
  * Every role that may have at most ONE enabled role-emitting writer: the three
- * inventory accounts, and `cash`.
+ * inventory accounts.
  *
  * A manual journal or an opening entry names accounts by CODE and carries no
- * role, so it is invisible to this guard by construction. That is deliberate
- * for `cash` (an opening bank balance IS a manual cash line) and is why the
+ * role, so it is invisible to this guard by construction - which is why the
  * manual builder refuses the {@link INVENTORY_ROLES} accounts by name instead:
  * those three are asserted monthly and a hand-keyed line would be reversed by
  * the next close.
+ *
+ * 🛑 TODO(brief 13 §2.5): a single-writer guard over bank-account
+ * `glAccountId`s is still wanted - "is more than one enabled posting type
+ * writing this bank account" is a real question now that `cash` is gone as a
+ * role, and nothing here answers it. It is deliberately not added in this
+ * pass: it needs a table declared over bank-account ids rather than roles
+ * (`payout`, `bank_deposit` and the `cash` payment route all write a
+ * `bank_account` by id now), which is more than a small function to add
+ * honestly - see the header on why this guard being DECLARED rather than
+ * derived is the whole point. A later pass adds
+ * `findBankAccountWriterConflicts` beside {@link findWriterConflicts}, over its
+ * own declared table, once `13` §3's `bank` subtype makes "these ids are bank
+ * accounts" answerable without walking the registry.
  */
-export const SINGLE_WRITER_ROLES: readonly AccountRole[] = [...INVENTORY_ROLES, ACCOUNT_ROLES.CASH]
+export const SINGLE_WRITER_ROLES: readonly AccountRole[] = INVENTORY_ROLES
 
 /**
  * Which single-writer roles each posting type can put on a line.
@@ -125,32 +140,19 @@ export const SINGLE_WRITER_ROLES_BY_POSTING_TYPE: Record<PostingType, readonly A
   // inventory refusal for these two lives in the manual builder, by name.
   manual_journal: [],
   opening_balance: [],
-  // The ONE cash writer: `Dr <the chosen bank account> Cr undeposited_funds`,
-  // one line per bank run.
-  //
-  // ⚠️ Since the deposit learned to bank into a NAMED account, its debit is a
-  // CODE line carrying the `bank_account`'s own GL code, not the `cash` role,
-  // so `findWriterConflicts` cannot see it on the wire. `[CASH]` stays anyway,
-  // and is not vacuous: this map is DECLARED, never derived (see its header).
-  // The declaration is a human saying "this type drives cash", which is what
-  // makes the guard bite the day a SECOND type says the same thing. Emptying it
-  // to match what the builder now emits would turn the check tautological in
-  // exactly the way the header warns against, and would silently drop cash's
-  // only protection.
-  bank_deposit: [ACCOUNT_ROLES.CASH],
+  // `Dr <the chosen bank account> Cr undeposited_funds`, one line per bank run.
+  // Names the bank account by its own `glAccountId`, never a role (brief 13
+  // §2), so this guard cannot see it on the wire at all - `[]` is now exactly
+  // what the builder emits, not an exemption. See the header's TODO on the
+  // bank-account guard this leaves open.
+  bank_deposit: [],
   // A matched bank line posts nothing (B5). A CODED line drives the
-  // `bank_account`'s own GL account by code, never the `cash` role - the bank
-  // feed's wave re-plans this entry if that changes.
+  // `bank_account`'s own GL account by code, never a role - the bank feed's
+  // wave re-plans this entry if that changes.
   bank_transaction: [],
   write_off: [],
-  // Drives cash ONLY on the `cash` payment route (an ACH or wire that arrives
-  // at the bank alone), chosen per method in `accounting.paymentRoute.*`. The
-  // same money never also passes through `bank_deposit` (that is the
-  // `undeposited_funds` route), and a bank-feed line that matches a payment
-  // posts nothing (bank plan B5), so there is no second writer of the same
-  // event. Declared `[]` because this guard is per TYPE, not per route, and
-  // `[CASH]` here beside `bank_deposit` would flag a conflict that is not one.
-  // If the guard ever becomes route-aware, this is the entry to revisit.
+  // The `cash` route names a bank account by id (brief 13 §2.4), never a role,
+  // so this stays `[]` for the same reason `bank_deposit` above does.
   payment: [],
   // Revenue, receivables and sales tax. No inventory account and no cash: an
   // invoice is issued long before its money arrives, and the payment entry is

--- a/packages/lib/src/postings/reports/__tests__/dimension-breakdown.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/dimension-breakdown.test.ts
@@ -1,0 +1,118 @@
+// packages/lib/src/postings/reports/__tests__/dimension-breakdown.test.ts
+//
+// The acceptance in brief 13 §5.5: the P&L can still split revenue by channel,
+// now by grouping on `GlPostingLine.dimensions` instead of reading a second
+// account. This is the read half only - no screen in this pass.
+
+import type { Database } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { AuxxError } from '../../../errors'
+import { readDimensionBreakdown } from '../dimension-breakdown'
+
+const ORG = 'org_1'
+const ACCOUNT = 'gla_4000'
+
+/** One `readDimensionBreakdown` query: a single `.groupBy()` read. */
+function stubDb(rows: unknown[]): Database {
+  const chain: Record<string, unknown> = {}
+  const passthrough = () => chain
+  for (const method of ['from', 'innerJoin', 'where', 'groupBy']) chain[method] = passthrough
+  // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
+  chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject)
+  return { select: () => chain } as unknown as Database
+}
+
+function row(value: string | null, debitMinor: number, creditMinor: number) {
+  return { value, debitMinor: String(debitMinor), creditMinor: String(creditMinor) }
+}
+
+describe('readDimensionBreakdown', () => {
+  it('returns one row per dimension value, with a raw (not natural-signed) balance', async () => {
+    const db = stubDb([row('dtc', 0, 80_000), row('dealer', 0, 20_000)])
+
+    const result = await readDimensionBreakdown(db, {
+      organizationId: ORG,
+      glAccountId: ACCOUNT,
+      dimension: 'channel',
+    })
+
+    expect(result.isOk()).toBe(true)
+    const rows = result._unsafeUnwrap()
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { value: 'dtc', debitMinor: 0, creditMinor: 80_000, balanceMinor: -80_000 },
+        { value: 'dealer', debitMinor: 0, creditMinor: 20_000, balanceMinor: -20_000 },
+      ])
+    )
+  })
+
+  it('carries a null bucket for lines with no such dimension at all', async () => {
+    const db = stubDb([row('dtc', 0, 80_000), row(null, 0, 5_000)])
+
+    const rows = (
+      await readDimensionBreakdown(db, {
+        organizationId: ORG,
+        glAccountId: ACCOUNT,
+        dimension: 'channel',
+      })
+    )._unsafeUnwrap()
+
+    expect(rows.find((r) => r.value === null)).toEqual({
+      value: null,
+      debitMinor: 0,
+      creditMinor: 5_000,
+      balanceMinor: -5_000,
+    })
+  })
+
+  it('sorts named values alphabetically, with the null bucket last', async () => {
+    const db = stubDb([row(null, 0, 1), row('dtc', 0, 1), row('dealer', 0, 1)])
+
+    const rows = (
+      await readDimensionBreakdown(db, {
+        organizationId: ORG,
+        glAccountId: ACCOUNT,
+        dimension: 'channel',
+      })
+    )._unsafeUnwrap()
+
+    expect(rows.map((r) => r.value)).toEqual(['dealer', 'dtc', null])
+  })
+
+  it('coerces numeric string aggregates the driver may hand back', async () => {
+    const db = stubDb([{ value: 'dtc', debitMinor: '12345', creditMinor: '0' }])
+
+    const rows = (
+      await readDimensionBreakdown(db, {
+        organizationId: ORG,
+        glAccountId: ACCOUNT,
+        dimension: 'channel',
+      })
+    )._unsafeUnwrap()
+
+    expect(rows[0]).toEqual({
+      value: 'dtc',
+      debitMinor: 12_345,
+      creditMinor: 0,
+      balanceMinor: 12_345,
+    })
+  })
+
+  it('never throws - a driver failure becomes an AuxxError result', async () => {
+    const db = {
+      select: () => {
+        throw new Error('connection terminated')
+      },
+    } as unknown as Database
+
+    const result = await readDimensionBreakdown(db, {
+      organizationId: ORG,
+      glAccountId: ACCOUNT,
+      dimension: 'channel',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(AuxxError)
+  })
+})

--- a/packages/lib/src/postings/reports/dimension-breakdown.ts
+++ b/packages/lib/src/postings/reports/dimension-breakdown.ts
@@ -1,0 +1,131 @@
+// packages/lib/src/postings/reports/dimension-breakdown.ts
+//
+// One dimension value's totals on one account, over a window - the read that
+// makes brief 13 §5's acceptance true: the P&L can still split revenue by
+// channel, now by grouping on `GlPostingLine.dimensions` rather than by
+// reading a second account.
+//
+// No screen reads this in this pass (brief 13 §5.5 says so explicitly) - this
+// is the read half only, so the next screen does not have to invent the query.
+//
+// No permission checks here. The router asserts (`docs/lib-module-guide.md` §6).
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, gte, inArray, lte, sql } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError } from '../../errors'
+
+const logger = createScopedLogger('postings:reports:dimension-breakdown')
+
+/**
+ * Both statuses, like every other statement read in this folder
+ * (`account-lines.ts`, `trial-balance.ts`): a reversed entry's PAIR of lines
+ * both count, so the two net to zero rather than one side vanishing from the
+ * breakdown.
+ */
+const POSTED_STATUSES = ['posted', 'reversed'] as const
+
+/** One dimension value's totals on one account. Raw, not natural-signed. */
+export interface DimensionBreakdownRow {
+  /**
+   * The dimension's value on the line - `'dtc'`, `'CO'`. `null` groups every
+   * line on the account with NO such dimension at all (the column is null, or
+   * it holds an object with no such key) - which is most lines on most
+   * accounts, and a real row rather than an omission.
+   */
+  value: string | null
+  debitMinor: number
+  creditMinor: number
+  /** `debitMinor - creditMinor`. Raw: the caller applies its own account's natural sign. */
+  balanceMinor: number
+}
+
+export interface ReadDimensionBreakdownOptions {
+  organizationId: string
+  /** The `gl_account` EntityInstance id - task 15's identity, not a code. */
+  glAccountId: string
+  /** The `dimensions` key to group by - `'channel'`, `'jurisdiction'`. */
+  dimension: string
+  /** `YYYY-MM-DD`. Omit for a cumulative-from-the-beginning read. */
+  from?: string
+  /** `YYYY-MM-DD`, inclusive. Omit for open-ended. */
+  to?: string
+}
+
+/**
+ * Sum debits and credits on one account, grouped by one `dimensions` key.
+ *
+ * `dimensions ->> dimension` is a Postgres jsonb text-extraction: it reads
+ * `null` for a line whose `dimensions` column is null OR simply does not carry
+ * that key, so the null bucket below needs no `coalesce` of its own to mean
+ * "no dimension" rather than "dimension explicitly blank".
+ *
+ * Sorted with the null bucket last and every named value alphabetically
+ * before it, so a screen rendering this list in order never has to sort it
+ * again or explain why "no channel" appears in the middle.
+ */
+export async function readDimensionBreakdown(
+  db: Database,
+  options: ReadDimensionBreakdownOptions
+): Promise<Result<DimensionBreakdownRow[], Error>> {
+  const { organizationId, glAccountId, dimension, from, to } = options
+
+  try {
+    const value = sql<string | null>`${schema.GlPostingLine.dimensions} ->> ${dimension}`
+
+    const bounds = [
+      eq(schema.GlPosting.organizationId, organizationId),
+      inArray(schema.GlPosting.status, [...POSTED_STATUSES]),
+      eq(schema.GlPostingLine.glAccountId, glAccountId),
+    ]
+    if (from) bounds.push(gte(schema.GlPosting.txnDate, from))
+    if (to) bounds.push(lte(schema.GlPosting.txnDate, to))
+
+    const rows = await db
+      .select({
+        value,
+        debitMinor: sql<string>`coalesce(sum(${schema.GlPostingLine.amountMinor}) filter (where ${schema.GlPostingLine.direction} = 'debit'), 0)`,
+        creditMinor: sql<string>`coalesce(sum(${schema.GlPostingLine.amountMinor}) filter (where ${schema.GlPostingLine.direction} = 'credit'), 0)`,
+      })
+      .from(schema.GlPostingLine)
+      .innerJoin(schema.GlPosting, eq(schema.GlPosting.id, schema.GlPostingLine.glPostingId))
+      .where(and(...bounds))
+      .groupBy(value)
+
+    const breakdown = rows.map((row) => {
+      const debitMinor = toMinor(row.debitMinor)
+      const creditMinor = toMinor(row.creditMinor)
+      return {
+        value: row.value ?? null,
+        debitMinor,
+        creditMinor,
+        balanceMinor: debitMinor - creditMinor,
+      }
+    })
+    breakdown.sort((a, b) => {
+      if (a.value === b.value) return 0
+      if (a.value === null) return 1
+      if (b.value === null) return -1
+      return a.value < b.value ? -1 : 1
+    })
+
+    return ok(breakdown)
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to read a dimension breakdown', {
+      error,
+      organizationId,
+      glAccountId,
+      dimension,
+      from,
+      to,
+    })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/** A number the driver may have handed back as text. */
+function toMinor(value: string | number): number {
+  return typeof value === 'number' ? value : Number(value)
+}

--- a/packages/lib/src/postings/retry-export.ts
+++ b/packages/lib/src/postings/retry-export.ts
@@ -119,6 +119,7 @@ export async function retryExport(
         lineNumber: schema.GlPostingLine.lineNumber,
         counterpartyType: schema.GlPostingLine.counterpartyType,
         counterpartyId: schema.GlPostingLine.counterpartyId,
+        dimensions: schema.GlPostingLine.dimensions,
       })
       .from(schema.GlPostingLine)
       .where(
@@ -157,6 +158,10 @@ export async function retryExport(
       // posted, not whatever the record has since been renamed or merged to.
       counterpartyType: (line.counterpartyType as CounterpartyType | null) ?? undefined,
       counterpartyId: line.counterpartyId ?? undefined,
+      // Replayed too (brief 13 §5). QuickBooks has no seam for it yet - the
+      // adapter simply ignores a field it does not read - so this is inert
+      // until the ClassRef/DepartmentRef hop exists, which is not this unit.
+      dimensions: (line.dimensions as Record<string, string> | null) ?? undefined,
     }))
 
     const draft = (row.draft ?? {}) as { memo?: unknown }

--- a/packages/lib/src/postings/reverse-entry.ts
+++ b/packages/lib/src/postings/reverse-entry.ts
@@ -142,6 +142,9 @@ export async function reverseEntry(
         // original did, not one re-resolved today.
         counterpartyType: schema.GlPostingLine.counterpartyType,
         counterpartyId: schema.GlPostingLine.counterpartyId,
+        // Carried onto the reversed line unchanged too (brief 13 §5): the
+        // reversal is reporting-wise the same line as the original, backwards.
+        dimensions: schema.GlPostingLine.dimensions,
       })
       .from(schema.GlPostingLine)
       .where(
@@ -190,6 +193,9 @@ export async function reverseEntry(
       // customer or vendor's balance.
       counterpartyType: (line.counterpartyType as CounterpartyType | null) ?? undefined,
       counterpartyId: line.counterpartyId ?? undefined,
+      // And the dimensions ride along too (brief 13 §5): the reversal is
+      // reporting-wise the same line as the original, backwards.
+      dimensions: (line.dimensions as Record<string, string> | null) ?? undefined,
     }))
 
     const entry = buildEntry({

--- a/packages/lib/src/postings/split-tax-by-jurisdiction.ts
+++ b/packages/lib/src/postings/split-tax-by-jurisdiction.ts
@@ -1,0 +1,139 @@
+// packages/lib/src/postings/split-tax-by-jurisdiction.ts
+
+/**
+ * Split a `sales_tax_payable` credit across jurisdictions, pro rata to an
+ * order's own `tax_line` rows (brief 13 §5.3 - jurisdiction becomes a
+ * `dimensions` entry on the line, sourced from `tax_line` rather than a
+ * second role).
+ *
+ * PURE. No database, no clock, no chart - the same property every builder in
+ * `postings/` has, which is what lets the largest-remainder rounding below be
+ * tested exhaustively.
+ *
+ * 🛑 **Does NOT import from `build-fulfillment-entry.ts` or
+ * `build-fulfillment-batch-entry.ts`.** Both of those import THIS file, and a
+ * cycle back would be silent until a bundler or a test runner tripped over it.
+ * The whole-cents assertion below is therefore a small, deliberate duplicate of
+ * `toAmountMinor` rather than a shared import.
+ */
+
+import { UnprocessableEntityError } from '../errors'
+
+/** One order's tax line, as `tax-line-fields.ts` stores it. */
+export interface JurisdictionTaxLine {
+  /** `tax_line_title` - the jurisdiction name, e.g. "CA State Tax". */
+  title: string
+  /** `tax_line_price`, integer minor units - this jurisdiction's share of the order's tax. */
+  priceMinor: number
+}
+
+/** One jurisdiction's share of a `sales_tax_payable` credit. */
+export interface TaxJurisdictionShare {
+  jurisdiction: string
+  amountMinor: number
+}
+
+/**
+ * A stored money amount, asserted to be whole minor units.
+ *
+ * Deliberately a small local copy of `toAmountMinor` (`build-fulfillment-entry.ts`)
+ * rather than an import from it - that file imports THIS one for the split, and
+ * an import back would be a cycle.
+ */
+function wholeMinor(value: number, label: string): number {
+  if (!Number.isFinite(value)) {
+    throw new UnprocessableEntityError(`${label} is ${String(value)}, which is not a number`, {
+      label,
+      value: String(value),
+    })
+  }
+  const rounded = Math.round(value)
+  if (Math.abs(value - rounded) > 1e-6) {
+    throw new UnprocessableEntityError(
+      `${label} is ${value}, which is not a whole number of cents. A ledger line is whole cents.`,
+      { label, value: String(value) }
+    )
+  }
+  return rounded
+}
+
+/**
+ * Split `taxMinor` across the jurisdictions named on `taxLines`, using
+ * largest-remainder rounding so the shares sum EXACTLY to `taxMinor`.
+ *
+ * The weights are the order's tax lines, whatever `taxMinor` itself is - a
+ * partial shipment's own tax is still split in the ratio the whole order's
+ * jurisdictions established, because a `tax_line` carries no per-shipment
+ * granularity of its own. Multiple lines sharing one jurisdiction (unusual, but
+ * not forbidden by the registry) are summed before the split.
+ *
+ * Returns `null`, never throws, when the breakdown cannot be trusted:
+ *
+ * - `taxMinor` is zero (nothing to split),
+ * - there are no tax lines, or every title is blank,
+ * - the tax lines do NOT sum to the order's own `orderTaxTotalMinor`.
+ *
+ * 🛑 **The tie check is the load-bearing rule (brief 13 §5).** An order whose
+ * tax lines do not sum to its own total gets today's single undimensioned
+ * line, on purpose: a partial jurisdiction breakdown reads as a complete one,
+ * and a bookkeeper reading the P&L by jurisdiction has no way to tell the
+ * difference from a line that is simply short.
+ *
+ * @throws {UnprocessableEntityError} on a non-finite or fractional tax line
+ *   price or order tax total - the same refusal `toAmountMinor` gives every
+ *   other stored amount that turns out not to be whole cents.
+ */
+export function splitTaxByJurisdiction(input: {
+  /** This shipment's (or this batch's) `sales_tax_payable` credit to split. */
+  taxMinor: number
+  /** The order's own tax lines - one row per jurisdiction. */
+  taxLines: readonly JurisdictionTaxLine[]
+  /** `order_tax_total`, integer minor units - what the tax lines must tie to. */
+  orderTaxTotalMinor: number
+}): TaxJurisdictionShare[] | null {
+  const { taxMinor, taxLines } = input
+  if (taxMinor === 0 || taxLines.length === 0) return null
+
+  const orderTaxTotalMinor = wholeMinor(input.orderTaxTotalMinor, 'Order tax total')
+
+  const byTitle = new Map<string, number>()
+  for (const [index, line] of taxLines.entries()) {
+    const title = line.title?.trim()
+    if (!title) continue
+    const priceMinor = wholeMinor(line.priceMinor, `Tax line ${index + 1} (${title})`)
+    byTitle.set(title, (byTitle.get(title) ?? 0) + priceMinor)
+  }
+  if (byTitle.size === 0) return null
+
+  const totalWeight = [...byTitle.values()].reduce((sum, value) => sum + value, 0)
+  // A partial or mismatched breakdown reads as a complete one - see the file
+  // header - so anything that does not tie falls back to the single line
+  // rather than guessing at a split.
+  if (totalWeight !== orderTaxTotalMinor || totalWeight <= 0) return null
+
+  interface Share {
+    jurisdiction: string
+    amountMinor: number
+    remainder: number
+  }
+  const shares: Share[] = [...byTitle.entries()].map(([jurisdiction, weight]) => {
+    const exact = (taxMinor * weight) / totalWeight
+    const floor = Math.floor(exact)
+    return { jurisdiction, amountMinor: floor, remainder: exact - floor }
+  })
+
+  // The remainder cents go to the largest fractional remainders first, ties
+  // broken by the order the jurisdictions were first seen in - deterministic,
+  // and the same idea `computeShipmentTotals` uses for the tax allocation.
+  let remaining = taxMinor - shares.reduce((sum, share) => sum + share.amountMinor, 0)
+  const byRemainderDesc = [...shares].sort((a, b) => b.remainder - a.remainder)
+  for (const share of byRemainderDesc) {
+    if (remaining <= 0) break
+    share.amountMinor += 1
+    remaining -= 1
+  }
+
+  return shares
+    .filter((share) => share.amountMinor !== 0)
+    .map((share) => ({ jurisdiction: share.jurisdiction, amountMinor: share.amountMinor }))
+}

--- a/packages/lib/src/postings/suggest-account-identities.ts
+++ b/packages/lib/src/postings/suggest-account-identities.ts
@@ -30,7 +30,50 @@
  */
 
 import { accountLabel } from './account-label'
+import { accountSubtypeLabel, type GlAccountSubtypeValue } from './account-subtype'
 import type { AccountSuggestionReason, ChartAccountRow, ProviderAccount } from './types'
+
+/**
+ * Which provider `accountType` strings a subtype may map to (`13` §3.2).
+ *
+ * This is our second fact about an account, `subtype`, compared against the
+ * provider's own detail-type string - QuickBooks' `Bank`, `Accounts
+ * Receivable`, and so on - not against `classification`, which is the
+ * five-way statement section already checked separately. `other` and a null
+ * subtype impose nothing here; every account still passes the
+ * classification-only check above.
+ *
+ * Compared case-insensitively after trim (`norm`), so a provider sending
+ * `' bank '` still matches `'Bank'`.
+ */
+export const SUBTYPE_PROVIDER_ACCOUNT_TYPES: Partial<
+  Record<GlAccountSubtypeValue, readonly string[]>
+> = {
+  bank: ['Bank'],
+  accounts_receivable: ['Accounts Receivable'],
+  accounts_payable: ['Accounts Payable'],
+  credit_card: ['Credit Card'],
+  inventory: ['Other Current Asset'],
+  fixed_asset: ['Fixed Asset'],
+  cost_of_goods_sold: ['Cost of Goods Sold'],
+}
+
+/**
+ * Does `providerAccount.accountType` satisfy `subtype`'s allowed list?
+ *
+ * A null or `other` subtype (no entry in the table) imposes nothing - the
+ * classification-only check is all that applies.
+ */
+function subtypeAllows(
+  subtype: GlAccountSubtypeValue | null | undefined,
+  providerAccountType: string
+): boolean {
+  if (!subtype) return true
+  const allowed = SUBTYPE_PROVIDER_ACCOUNT_TYPES[subtype]
+  if (!allowed) return true
+  const wanted = norm(providerAccountType)
+  return allowed.some((type) => norm(type) === wanted)
+}
 
 /** One proposal: our account, their account, and the evidence for the pairing. */
 export interface AccountSuggestion {
@@ -196,13 +239,21 @@ export function validateProviderMapping(
   if (providerAccount.classification !== account.accountType) {
     return `${accountLabel(account)} is ${classificationArticle(account.accountType)} account but is mapped to '${providerAccount.fullyQualifiedName}', which is ${providerAccount.classification}. Posting to it would balance and still be wrong.`
   }
+  if (!subtypeAllows(account.subtype, providerAccount.accountType)) {
+    const subtypeLabel = accountSubtypeLabel(account.subtype as GlAccountSubtypeValue).toLowerCase()
+    return `${accountLabel(account)} is ${classificationArticle(subtypeLabel)} account but is mapped to '${providerAccount.fullyQualifiedName}', which QuickBooks types as ${providerAccount.accountType}. Posting to it would balance and still be wrong.`
+  }
   return null
 }
 
 /** Type-compatible, active, and therefore offerable in a picker for `account`. */
 export function isMappableTo(
-  account: Pick<ChartAccountRow, 'accountType'>,
+  account: Pick<ChartAccountRow, 'accountType' | 'subtype'>,
   providerAccount: ProviderAccount
 ): boolean {
-  return providerAccount.active && providerAccount.classification === account.accountType
+  return (
+    providerAccount.active &&
+    providerAccount.classification === account.accountType &&
+    subtypeAllows(account.subtype, providerAccount.accountType)
+  )
 }

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -148,6 +148,15 @@ export interface GlPostingLineBase {
    */
   counterpartyType?: CounterpartyType
   counterpartyId?: string
+  /**
+   * Reporting dimensions on the line, `{ channel: 'dealer' }` or
+   * `{ jurisdiction: 'CO' }`, written to `GlPostingLine.dimensions` (brief 13
+   * §5). A dimension is an attribute of a line, never a reason to split an
+   * account: revenue by channel is one account with this key on each line.
+   * Ours, and reportable from our own statements; the QuickBooks class hop is
+   * a separate piece of work and is not done here. Absent on most lines.
+   */
+  dimensions?: Record<string, string>
 }
 
 /**
@@ -662,6 +671,8 @@ export interface PostingDetailLine {
   /** The counterparty frozen on the line at post time (brief 13 §1.1). Null on most lines. */
   counterpartyType: CounterpartyType | null
   counterpartyId: string | null
+  /** The line's reporting dimensions as stored, `{ channel: 'dealer' }`. Null on most lines. */
+  dimensions: Record<string, string> | null
 }
 
 /**

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -900,3 +900,38 @@ export const JournalEntryKind = {
     { value: 'recurring_template', label: 'Recurring Template', color: 'purple' },
   ] satisfies FieldOptionItem[],
 } as const
+
+/**
+ * How a `payment_gateway` drains (`plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md`
+ * §5.3). The three answers that exist: `stripe` and `shopify_payments` read a
+ * real payout feed, `manual` is worked by hand. `manual` is not a gap - it is
+ * what Affirm and every historical rail correctly are.
+ */
+export const PaymentGatewaySettlementSource = {
+  STRIPE: 'stripe',
+  SHOPIFY_PAYMENTS: 'shopify_payments',
+  MANUAL: 'manual',
+
+  values: [
+    { value: 'stripe', label: 'Stripe', color: 'purple' },
+    { value: 'shopify_payments', label: 'Shopify Payments', color: 'green' },
+    { value: 'manual', label: 'By hand', color: 'gray' },
+  ] satisfies FieldOptionItem[],
+} as const
+
+/**
+ * Whether a `payment_gateway` rail is still taking charges
+ * (`plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §5.1). A rail
+ * is not permanent - Authorize.Net closed May 2026 with a clearing balance
+ * still winding down to zero - so `closed` marks a gateway retired without
+ * deleting it: `toGatewayRoutes` still routes a closed rail's history.
+ */
+export const PaymentGatewayStatus = {
+  ACTIVE: 'active',
+  CLOSED: 'closed',
+
+  values: [
+    { value: 'active', label: 'Active', color: 'green' },
+    { value: 'closed', label: 'Closed', color: 'gray' },
+  ] satisfies FieldOptionItem[],
+} as const

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -30,6 +30,7 @@ import { ORDER_FIELDS } from './resources/order-fields'
 import { PART_FIELDS } from './resources/part-fields'
 import { PARTICIPANT_FIELDS } from './resources/participant-fields'
 import { PAYMENT_FIELDS } from './resources/payment-fields'
+import { PAYMENT_GATEWAY_FIELDS } from './resources/payment-gateway-fields'
 import { PAYOUT_FIELDS } from './resources/payout-fields'
 import { PERSONAL_INBOX_FIELDS } from './resources/personal-inbox-fields'
 import { PRODUCT_FIELDS } from './resources/product-fields'
@@ -166,6 +167,7 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   bank_account: BANK_ACCOUNT_FIELDS,
   bank_transaction: BANK_TRANSACTION_FIELDS,
   bank_rule: BANK_RULE_FIELDS,
+  payment_gateway: PAYMENT_GATEWAY_FIELDS,
   tariff_code: TARIFF_CODE_FIELDS,
   tariff_rate: TARIFF_RATE_FIELDS,
   credit_memo: CREDIT_MEMO_FIELDS,

--- a/packages/lib/src/resources/registry/resources/bank-account-fields.ts
+++ b/packages/lib/src/resources/registry/resources/bank-account-fields.ts
@@ -256,6 +256,31 @@ export const BANK_ACCOUNT_FIELDS: Record<string, ResourceField> = {
       'active status and type on every read, fail closed',
   },
 
+  stripeExternalAccountId: {
+    id: toFieldId('stripeExternalAccountId'),
+    key: 'stripeExternalAccountId',
+    label: 'Stripe external account',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'bank_account_stripe_external_account_id',
+    systemSortOrder: 'a6a',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'ba_1AbCdEf...',
+    description:
+      "The Stripe ba_… or card_… destination id a person confirms once, so a payout's " +
+      'settlement can be attributed to this account. Brief 13 §2.3: never matched on last4 - ' +
+      'a four-digit string is strong evidence and not proof, and two accounts at one bank can ' +
+      'share it',
+  },
+
   feedStartDate: {
     id: toFieldId('feedStartDate'),
     key: 'feedStartDate',

--- a/packages/lib/src/resources/registry/resources/payment-gateway-fields.ts
+++ b/packages/lib/src/resources/registry/resources/payment-gateway-fields.ts
@@ -1,0 +1,294 @@
+// packages/lib/src/resources/registry/resources/payment-gateway-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import { PaymentGatewaySettlementSource, PaymentGatewayStatus } from '../enum-values'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Payment Gateway resource
+ * (`plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §5.3, HANDOFF
+ * step 5).
+ *
+ * ## Why this entity exists
+ *
+ * `13` §5.1's gateway census counted eleven distinct handles across five card
+ * rails on one store's history, and the pattern that had already been applied
+ * once (`clearing_affirm`, entity migration 137) does not survive a second
+ * application: role-per-gateway costs a role, an account and a chart migration
+ * per rail, and a rail is not permanent (the store cut over from
+ * Authorize.Net to Shopify Payments mid-book). A `payment_gateway` record is a
+ * ROW instead: a gateway is a fact about the business, never a function the
+ * chart has to grow a role for.
+ *
+ * 🛑 **This does NOT mint an account per gateway.** {@link clearingAccount} and
+ * {@link feeAccount} name WHICH account a gateway settles into; two rails
+ * sharing one clearing account is normal (`1200` already is that for every
+ * unrecognised card rail) and this entity does not demand a new one. A gateway
+ * whose settlements auxx can see gets its own so it reconciles independently;
+ * a dead one can share.
+ *
+ * ## `clearingAccount` / `feeAccount` are `gl_account` EntityInstance ids, as
+ * TEXT, no relationship
+ *
+ * The same call `bank_account.glAccount` makes
+ * (`plans/accounting/tasks/15-the-account-id-is-the-identity.md` §4): plain
+ * `text()`, no `references()`, validated for existence, active status and
+ * type on every read, fail closed. A registry relationship buys nothing a
+ * read-time check does not already have to do.
+ *
+ * ## `handles` is a SET, not one string
+ *
+ * §5.1's census: `authorize_net` / `authorize.net` and `Affirm` / `affirm` are
+ * each one rail arriving under two spellings. A `payment_gateway` keyed on a
+ * single handle would need two rows for one rail; `handles` is a TAGS field so
+ * one record can claim every spelling a gateway is seen under.  Compared
+ * case-insensitively and trimmed at write time and at match time
+ * (`normaliseGatewayHandle` in `payment-gateways/client.ts`), mirroring
+ * `normaliseGateways` in `postings/build-fulfillment-batch-entry.ts`.
+ *
+ * Hidden system entity (`isVisible: false`) - the door is Accounting >
+ * Settings > Payment gateways, a master-detail settings page, the same shape
+ * `bank_account` uses and for the same reason: a purpose-built screen is a
+ * better door than an auto-linked sidebar entry.
+ */
+export const PAYMENT_GATEWAY_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique payment gateway identifier',
+  },
+
+  name: {
+    id: toFieldId('name'),
+    key: 'name',
+    label: 'Name',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'payment_gateway_name',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Shopify Payments',
+    description: 'What the settings screen calls this gateway. The display field.',
+  },
+
+  handles: {
+    id: toFieldId('handles'),
+    key: 'handles',
+    label: 'Gateway handles',
+    type: BaseType.TAGS,
+    fieldType: FieldType.TAGS,
+    isSystem: true,
+    systemAttribute: 'payment_gateway_handles',
+    systemSortOrder: 'a2',
+    nullable: false,
+    options: { options: [] },
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Add a gateway handle',
+    description:
+      'Every stored `order_payment_gateways` value this rail is seen under - a SET, because ' +
+      'two rails arrive under two spellings each (`authorize_net`/`authorize.net`, ' +
+      '`Affirm`/`affirm`). Compared trimmed and lower-cased, never one string.',
+  },
+
+  clearingAccount: {
+    id: toFieldId('clearingAccount'),
+    key: 'clearingAccount',
+    label: 'Clearing account',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'payment_gateway_clearing_account',
+    systemSortOrder: 'a3',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select account',
+    description:
+      'The `gl_account` id this gateway settles into. THE point of this entity - TEXT with ' +
+      'no foreign key, not a RELATIONSHIP, validated for existence, active status and asset ' +
+      'type on every read, fail closed.',
+  },
+
+  feeAccount: {
+    id: toFieldId('feeAccount'),
+    key: 'feeAccount',
+    label: 'Fee account',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'payment_gateway_fee_account',
+    systemSortOrder: 'a4',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select account',
+    description:
+      'The `gl_account` id the processor withholds its fee into. `6100` is the fallback for ' +
+      'every gateway today, but the fee is per-rail in principle and this is where that stops ' +
+      'being a constant. Same TEXT-id-no-relationship shape as clearingAccount.',
+  },
+
+  settlementSource: {
+    id: toFieldId('settlementSource'),
+    key: 'settlementSource',
+    label: 'Settlement source',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'payment_gateway_settlement_source',
+    systemSortOrder: 'a5',
+    nullable: false,
+    options: { options: PaymentGatewaySettlementSource.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select settlement source',
+    defaultValue: 'manual',
+    description:
+      'How this gateway drains: `stripe` or `shopify_payments` read a real payout feed, ' +
+      '`manual` is worked by hand. `manual` is not a gap - it is what Affirm and every ' +
+      'historical rail correctly are.',
+  },
+
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'payment_gateway_status',
+    systemSortOrder: 'a6',
+    nullable: false,
+    options: { options: PaymentGatewayStatus.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select status',
+    defaultValue: 'active',
+    description:
+      'A rail is not permanent (§5.1: Authorize.Net closed May 2026, its clearing balance ' +
+      'still winding down to zero). `closed` marks it retired; a closed rail still routes its ' +
+      'history, because `toGatewayRoutes` reads active AND closed rows.',
+  },
+
+  lastSettlementAt: {
+    id: toFieldId('lastSettlementAt'),
+    key: 'lastSettlementAt',
+    label: 'Last settlement',
+    type: BaseType.DATE,
+    fieldType: FieldType.DATE,
+    isSystem: true,
+    systemAttribute: 'payment_gateway_last_settlement_at',
+    systemSortOrder: 'a7',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'The last date this rail is known to have settled. Informational - nothing in posting ' +
+      'reads it today - and what the screen shows under a closed gateway to say why it is ' +
+      'still worth seeing.',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the gateway is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the gateway is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/payout-fields.ts
+++ b/packages/lib/src/resources/registry/resources/payout-fields.ts
@@ -364,6 +364,54 @@ export const PAYOUT_FIELDS: Record<string, ResourceField> = {
       'Drizzle table with no EntityDefinition to point at - the journal_entry precedent',
   },
 
+  destination: {
+    id: toFieldId('destination'),
+    key: 'destination',
+    label: 'Destination',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'payout_destination',
+    systemSortOrder: 'aE',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    placeholder: 'ba_1AbCdEf...',
+    description:
+      "The gateway's own external-account id this payout settled to (brief 13 §2.3). Resolved " +
+      "against a bank account's confirmed stripeExternalAccountId to find which gl_account to " +
+      'debit - never last4',
+  },
+
+  blockedReason: {
+    id: toFieldId('blockedReason'),
+    key: 'blockedReason',
+    label: 'Blocked Reason',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'payout_blocked_reason',
+    systemSortOrder: 'aF',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Set when this payout could not be posted for lack of a confirmed bank-account identity ' +
+      '(brief 13 §2.3). Names the payout, the destination id and the remedy. Null once posted',
+  },
+
   bankTransactionId: {
     id: toFieldId('bankTransactionId'),
     key: 'bankTransactionId',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -101,6 +101,8 @@ import { migration141BuildBatchRun } from './migrations/141-build-batch-run'
 import { migration142WipeSeededCharts } from './migrations/142-wipe-seeded-charts'
 import { migration143GlPointersHoldIds } from './migrations/143-gl-pointers-hold-ids'
 import { migration144GlAccountCodeOptionalAndSubtype } from './migrations/144-gl-account-code-optional-and-subtype'
+import { migration145RetireInstanceRoles } from './migrations/145-retire-instance-roles'
+import { migration146PaymentGateway } from './migrations/146-payment-gateway'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -326,6 +328,16 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // ordering constraint against 143: it reads whatever gl_account rows exist
   // regardless of what shape their pointer fields are in.
   migration144GlAccountCodeOptionalAndSubtype,
+  // Deletes the cash and revenue_dealer role assignments, moves revenue_dtc
+  // onto revenue_product, renames "Payroll Clearing (ADP)" to "Payroll
+  // Clearing", and provisions bank_account.stripeExternalAccountId /
+  // payout.destination / payout.blockedReason (brief 13 §2, §5). No ordering
+  // constraint against 143/144: it reads whatever gl_account and
+  // GlRoleAssignment rows exist regardless of their pointer shape.
+  migration145RetireInstanceRoles,
+  // No ordering constraint against it or against 108/133/142/143/144/145 - it
+  // only creates the payment_gateway def and its fields (task 13 §5.3).
+  migration146PaymentGateway,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/145-retire-instance-roles.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/145-retire-instance-roles.test.ts
@@ -1,0 +1,426 @@
+// packages/lib/src/seed/entity-migrations/migrations/145-retire-instance-roles.test.ts
+//
+// Migration 145 retires `cash` and `revenue_dealer` as roles, moves
+// `revenue_dtc` onto `revenue_product`, renames "Payroll Clearing (ADP)" to
+// "Payroll Clearing", and provisions the three new fields brief 13 §2/§5
+// reads. What is pinned here:
+//
+//  - registration: unique id, between 144 and 146;
+//  - `cash` and `revenue_dealer` GlRoleAssignment rows are deleted, an
+//    unrelated role is left alone;
+//  - `revenue_dtc` moves onto `revenue_product` in place when no
+//    `revenue_product` row exists yet, and is deleted instead when one
+//    already does (the unique-index collision `132`'s `moveRole` guards
+//    against);
+//  - the `gl_account` named EXACTLY "Payroll Clearing (ADP)" is renamed to
+//    "Payroll Clearing", and an account a bookkeeper already renamed is left
+//    alone;
+//  - `bank_account.stripeExternalAccountId` and `payout.destination` /
+//    `payout.blockedReason` are created when missing and skipped when an
+//    earlier pass already created them;
+//  - a second run over a fully-migrated org reports `alreadyUpToDate`.
+
+import { schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const invalidateAndRecompute = vi.fn(async () => {})
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getOrgCache: () => ({ invalidateAndRecompute }),
+}))
+
+const { migration145RetireInstanceRoles } = await import('./145-retire-instance-roles')
+const { ALL_ENTITY_MIGRATIONS } = await import('../../entity-migrations')
+
+const MIGRATION_ID = '145-retire-instance-roles'
+const ORG = 'org_1'
+
+const GL_ACCOUNT_DEF = 'def-gl_account'
+const BANK_ACCOUNT_DEF = 'def-bank_account'
+const PAYOUT_DEF = 'def-payout'
+
+const NAME_FIELD = 'field-gl_account_name'
+const BANK_STRIPE_FIELD = 'field-bank_account_stripe_external_account_id'
+const PAYOUT_DESTINATION_FIELD = 'field-payout_destination'
+const PAYOUT_BLOCKED_REASON_FIELD = 'field-payout_blocked_reason'
+
+interface EntityDefRow {
+  id: string
+  organizationId: string
+  entityType: string
+}
+interface CustomFieldRow {
+  id: string
+  organizationId: string
+  entityDefinitionId: string
+  systemAttribute: string
+  options: Record<string, unknown>
+}
+interface RoleAssignmentRow {
+  id: string
+  organizationId: string
+  role: string
+  glAccountId: string
+}
+interface FieldValueRow {
+  id: string
+  organizationId: string
+  entityDefinitionId: string
+  fieldId: string
+  entityId: string
+  valueText: string | null
+}
+
+type Row = Record<string, unknown>
+
+/** Every scalar the module put into a `where` clause, flattened. See role-map.test.ts. */
+function whereValues(node: unknown, out: string[] = [], depth = 0): string[] {
+  if (depth > 12 || node === null || node === undefined) return out
+  if (typeof node === 'string') {
+    out.push(node)
+    return out
+  }
+  if (typeof node !== 'object') return out
+  if (Array.isArray(node)) {
+    for (const child of node) whereValues(child, out, depth + 1)
+    return out
+  }
+  const obj = node as Record<string, unknown>
+  if ('value' in obj) whereValues(obj.value, out, depth + 1)
+  if (Array.isArray(obj.queryChunks)) whereValues(obj.queryChunks, out, depth + 1)
+  return out
+}
+
+/**
+ * An in-memory `Database`, modelled on `144-gl-account-code-optional-and-
+ * subtype.test.ts`'s `makeStore`: `EntityDefinition` and `CustomField` are
+ * whole-table-for-org reads (`loadExistingState`'s own shape, unfiltered by
+ * anything but org). `GlRoleAssignment` and `FieldValue` are filtered for
+ * real, by `id` or by `(organizationId, role)` / `(organizationId, fieldId,
+ * entityId-or-valueText)` respectively - this migration issues several
+ * distinct queries against each of those two tables in one run, and an
+ * unfiltered stub would let one answer leak into another.
+ */
+function makeStore(seed: {
+  entityDefs?: EntityDefRow[]
+  customFields?: CustomFieldRow[]
+  roleAssignments?: RoleAssignmentRow[]
+  fieldValues?: FieldValueRow[]
+}) {
+  const state = {
+    entityDefs: seed.entityDefs ?? [],
+    customFields: seed.customFields ?? [],
+    roleAssignments: seed.roleAssignments ?? [],
+    fieldValues: seed.fieldValues ?? [],
+  }
+  let nextCustomFieldId = 1
+
+  const matchesRole = (r: RoleAssignmentRow, params: string[]) =>
+    params.includes(r.id) || (params.includes(r.organizationId) && params.includes(r.role))
+
+  const matchesFieldValue = (fv: FieldValueRow, params: string[]) =>
+    params.includes(fv.id) ||
+    (params.includes(fv.organizationId) &&
+      params.includes(fv.fieldId) &&
+      (params.includes(fv.entityId) || (fv.valueText != null && params.includes(fv.valueText))))
+
+  const rowsFor = (table: unknown, params: string[]): Row[] => {
+    if (table === schema.EntityDefinition) {
+      return state.entityDefs.filter((d) => params.includes(d.organizationId)) as unknown as Row[]
+    }
+    if (table === schema.CustomField) {
+      return state.customFields.filter((f) => params.includes(f.organizationId)) as unknown as Row[]
+    }
+    if (table === schema.GlRoleAssignment) {
+      return state.roleAssignments.filter((r) => matchesRole(r, params)) as unknown as Row[]
+    }
+    if (table === schema.FieldValue) {
+      return state.fieldValues.filter((fv) => matchesFieldValue(fv, params)) as unknown as Row[]
+    }
+    throw new Error('Unknown table in test stub')
+  }
+
+  /** Awaitable directly, and also `.returning()`-able - the migration uses both shapes. */
+  function awaitableReturning(matched: Row[]) {
+    return {
+      returning: async () => matched.map((row) => ({ id: row.id })),
+      // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
+      then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+        Promise.resolve(undefined).then(resolve, reject),
+    }
+  }
+
+  const db = {
+    select: (_cols: unknown) => ({
+      from: (table: unknown) => {
+        let params: string[] = []
+        const chain: any = {
+          where: (cond: unknown) => {
+            params = whereValues(cond)
+            return chain
+          },
+          limit: () => chain,
+          // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
+          then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+            Promise.resolve(rowsFor(table, params)).then(resolve, reject),
+        }
+        return chain
+      },
+    }),
+    delete: (table: unknown) => ({
+      where: (cond: unknown) => {
+        const params = whereValues(cond)
+        const matched = rowsFor(table, params)
+        if (table === schema.GlRoleAssignment) {
+          const ids = new Set(matched.map((r) => r.id))
+          state.roleAssignments = state.roleAssignments.filter((r) => !ids.has(r.id))
+        }
+        return awaitableReturning(matched)
+      },
+    }),
+    update: (table: unknown) => ({
+      set: (values: Row) => ({
+        where: (cond: unknown) => {
+          const params = whereValues(cond)
+          const matched = rowsFor(table, params)
+          for (const row of matched) Object.assign(row, values)
+          return awaitableReturning(matched)
+        },
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (v: Row) => {
+        if (table !== schema.CustomField) throw new Error('unexpected insert table')
+        const created = { id: `new_field_${nextCustomFieldId++}`, organizationId: ORG, ...v }
+        state.customFields.push(created as unknown as CustomFieldRow)
+        return { returning: async () => [created] }
+      },
+    }),
+  }
+
+  return { db: db as never, state }
+}
+
+function role(r: string, glAccountId: string): RoleAssignmentRow {
+  return { id: `assign_${r}`, organizationId: ORG, role: r, glAccountId }
+}
+
+function nameField(): CustomFieldRow {
+  return {
+    id: NAME_FIELD,
+    organizationId: ORG,
+    entityDefinitionId: GL_ACCOUNT_DEF,
+    systemAttribute: 'gl_account_name',
+    options: {},
+  }
+}
+
+function nameValue(entityId: string, name: string): FieldValueRow {
+  return {
+    id: `name_${entityId}`,
+    organizationId: ORG,
+    entityDefinitionId: GL_ACCOUNT_DEF,
+    fieldId: NAME_FIELD,
+    entityId,
+    valueText: name,
+  }
+}
+
+function bankStripeField(): CustomFieldRow {
+  return {
+    id: BANK_STRIPE_FIELD,
+    organizationId: ORG,
+    entityDefinitionId: BANK_ACCOUNT_DEF,
+    systemAttribute: 'bank_account_stripe_external_account_id',
+    options: {},
+  }
+}
+
+function payoutFields(): CustomFieldRow[] {
+  return [
+    {
+      id: PAYOUT_DESTINATION_FIELD,
+      organizationId: ORG,
+      entityDefinitionId: PAYOUT_DEF,
+      systemAttribute: 'payout_destination',
+      options: {},
+    },
+    {
+      id: PAYOUT_BLOCKED_REASON_FIELD,
+      organizationId: ORG,
+      entityDefinitionId: PAYOUT_DEF,
+      systemAttribute: 'payout_blocked_reason',
+      options: {},
+    },
+  ]
+}
+
+beforeEach(() => {
+  invalidateAndRecompute.mockClear()
+})
+
+describe('migration 145 registration', () => {
+  it('is registered exactly once, with a unique id, between 144 and 146', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf(MIGRATION_ID)).toBeGreaterThan(
+      ids.indexOf('144-gl-account-code-optional-and-subtype')
+    )
+    expect(ids.indexOf(MIGRATION_ID)).toBeLessThan(ids.indexOf('146-payment-gateway'))
+    expect(migration145RetireInstanceRoles.id).toBe(MIGRATION_ID)
+  })
+})
+
+describe('up() against a stub store', () => {
+  it('is a no-op over an org with nothing to change', async () => {
+    const { db } = makeStore({ entityDefs: [], customFields: [], roleAssignments: [] })
+    const result = await migration145RetireInstanceRoles.up(db, ORG)
+    expect(result.alreadyUpToDate).toBe(true)
+    expect(invalidateAndRecompute).not.toHaveBeenCalled()
+  })
+
+  it('deletes cash and revenue_dealer, leaving an unrelated role alone', async () => {
+    const { db, state } = makeStore({
+      roleAssignments: [
+        role('cash', 'acct_1000'),
+        role('revenue_dealer', 'acct_4000'),
+        role('grni', 'acct_2160'),
+      ],
+    })
+
+    const result = await migration145RetireInstanceRoles.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(state.roleAssignments.map((r) => r.role).sort()).toEqual(['grni'])
+    expect(invalidateAndRecompute).toHaveBeenCalledWith(ORG, ['resources', 'customFields'])
+  })
+
+  it('moves revenue_dtc onto revenue_product, keeping the same account', async () => {
+    const { db, state } = makeStore({
+      roleAssignments: [role('revenue_dtc', 'acct_4000')],
+    })
+
+    await migration145RetireInstanceRoles.up(db, ORG)
+
+    expect(state.roleAssignments).toHaveLength(1)
+    expect(state.roleAssignments[0]).toMatchObject({
+      role: 'revenue_product',
+      glAccountId: 'acct_4000',
+    })
+  })
+
+  it('deletes the stale revenue_dtc row rather than colliding when revenue_product already exists', async () => {
+    const { db, state } = makeStore({
+      roleAssignments: [role('revenue_dtc', 'acct_old'), role('revenue_product', 'acct_new')],
+    })
+
+    await migration145RetireInstanceRoles.up(db, ORG)
+
+    expect(state.roleAssignments).toHaveLength(1)
+    expect(state.roleAssignments[0]).toMatchObject({
+      role: 'revenue_product',
+      glAccountId: 'acct_new',
+    })
+  })
+
+  it('renames "Payroll Clearing (ADP)" to "Payroll Clearing"', async () => {
+    const { db, state } = makeStore({
+      entityDefs: [{ id: GL_ACCOUNT_DEF, organizationId: ORG, entityType: 'gl_account' }],
+      customFields: [nameField()],
+      fieldValues: [nameValue('acct_2110', 'Payroll Clearing (ADP)')],
+    })
+
+    const result = await migration145RetireInstanceRoles.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(state.fieldValues.find((fv) => fv.entityId === 'acct_2110')?.valueText).toBe(
+      'Payroll Clearing'
+    )
+  })
+
+  it('leaves an account a bookkeeper already renamed untouched', async () => {
+    const { db, state } = makeStore({
+      entityDefs: [{ id: GL_ACCOUNT_DEF, organizationId: ORG, entityType: 'gl_account' }],
+      customFields: [nameField()],
+      fieldValues: [nameValue('acct_2110', 'Payroll (renamed by us)')],
+    })
+
+    const result = await migration145RetireInstanceRoles.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(true)
+    expect(state.fieldValues[0]?.valueText).toBe('Payroll (renamed by us)')
+  })
+
+  it('creates the three new fields when the defs exist and the fields do not', async () => {
+    const { db, state } = makeStore({
+      entityDefs: [
+        { id: BANK_ACCOUNT_DEF, organizationId: ORG, entityType: 'bank_account' },
+        { id: PAYOUT_DEF, organizationId: ORG, entityType: 'payout' },
+      ],
+      customFields: [],
+    })
+
+    const result = await migration145RetireInstanceRoles.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(result.fieldsCreated).toBe(3)
+    expect(
+      state.customFields.find(
+        (f) => f.systemAttribute === 'bank_account_stripe_external_account_id'
+      )
+    ).toBeDefined()
+    expect(state.customFields.find((f) => f.systemAttribute === 'payout_destination')).toBeDefined()
+    expect(
+      state.customFields.find((f) => f.systemAttribute === 'payout_blocked_reason')
+    ).toBeDefined()
+  })
+
+  it('is a no-op on the fields when a def does not exist yet', async () => {
+    const { db, state } = makeStore({ entityDefs: [], customFields: [] })
+    const result = await migration145RetireInstanceRoles.up(db, ORG)
+    expect(result.fieldsCreated).toBe(0)
+    expect(state.customFields).toHaveLength(0)
+  })
+
+  it('is idempotent: a second run over a fully-migrated org reports alreadyUpToDate', async () => {
+    const { db } = makeStore({
+      entityDefs: [
+        { id: GL_ACCOUNT_DEF, organizationId: ORG, entityType: 'gl_account' },
+        { id: BANK_ACCOUNT_DEF, organizationId: ORG, entityType: 'bank_account' },
+        { id: PAYOUT_DEF, organizationId: ORG, entityType: 'payout' },
+      ],
+      customFields: [nameField(), bankStripeField(), ...payoutFields()],
+      roleAssignments: [role('grni', 'acct_2160'), role('revenue_product', 'acct_4000')],
+      fieldValues: [nameValue('acct_2110', 'Payroll Clearing')],
+    })
+
+    const result = await migration145RetireInstanceRoles.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(true)
+    expect(invalidateAndRecompute).not.toHaveBeenCalled()
+  })
+
+  it('runs every change together and reports it once', async () => {
+    const { db, state } = makeStore({
+      entityDefs: [
+        { id: GL_ACCOUNT_DEF, organizationId: ORG, entityType: 'gl_account' },
+        { id: BANK_ACCOUNT_DEF, organizationId: ORG, entityType: 'bank_account' },
+        { id: PAYOUT_DEF, organizationId: ORG, entityType: 'payout' },
+      ],
+      customFields: [nameField()],
+      roleAssignments: [role('cash', 'acct_1000'), role('revenue_dtc', 'acct_4000')],
+      fieldValues: [nameValue('acct_2110', 'Payroll Clearing (ADP)')],
+    })
+
+    const result = await migration145RetireInstanceRoles.up(db, ORG)
+
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(result.fieldsCreated).toBe(3)
+    expect(state.roleAssignments.map((r) => r.role).sort()).toEqual(['revenue_product'])
+    expect(state.fieldValues.find((fv) => fv.entityId === 'acct_2110')?.valueText).toBe(
+      'Payroll Clearing'
+    )
+    expect(invalidateAndRecompute).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/145-retire-instance-roles.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/145-retire-instance-roles.ts
@@ -1,0 +1,292 @@
+// packages/lib/src/seed/entity-migrations/migrations/145-retire-instance-roles.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import { BANK_ACCOUNT_FIELDS } from '../../../resources/registry/resources/bank-account-fields'
+import { PAYOUT_FIELDS } from '../../../resources/registry/resources/payout-fields'
+import { ensureCustomFields, fieldKey, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:145')
+
+const GL_ACCOUNT_ENTITY_TYPE = 'gl_account'
+const BANK_ACCOUNT_ENTITY_TYPE = 'bank_account'
+const PAYOUT_ENTITY_TYPE = 'payout'
+
+/** Roles brief 13 §2 retires outright: a bank account is not a role. */
+const RETIRED_ROLES = ['cash', 'revenue_dealer'] as const
+
+/** The channel role folded into the single product-revenue role (brief 13 §5). */
+const OLD_REVENUE_ROLE = 'revenue_dtc'
+const NEW_REVENUE_ROLE = 'revenue_product'
+
+/**
+ * The name to replace, and only this one - a bookkeeper who already renamed
+ * the account keeps their name (chart rule 3, the same guard `132` uses for
+ * `1200 Shopify Clearing`).
+ */
+const OLD_PAYROLL_CLEARING_NAME = 'Payroll Clearing (ADP)'
+const NEW_PAYROLL_CLEARING_NAME = 'Payroll Clearing'
+
+/** A moved role, a renamed account or a new field are all invisible until this drops. */
+const CACHE_KEYS = ['resources', 'customFields'] as const
+
+/**
+ * Migration 145: retires the instance-shaped roles `13` §2 and §5 argue
+ * against, and provisions the three fields their replacements need.
+ *
+ * `plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §2, §5.
+ *
+ * ## What it does, per org, in order
+ *
+ * (a) **Deletes** every `GlRoleAssignment` row whose `role` is `cash` or
+ *     `revenue_dealer`. Neither survives as a role: `cash` because a bank
+ *     account is an instance, several of which an org holds, never a
+ *     function one role can name; `revenue_dealer` because the channel it
+ *     named is now a `dimensions.channel` value on the line, folded into
+ *     {@link NEW_REVENUE_ROLE} by (b) below. Deleting rather than repointing
+ *     is correct here because nothing replaces `cash` as a role at all - the
+ *     builders that used to emit it now carry a `bank_account`'s own
+ *     `glAccountId` directly, and a `GlRoleAssignment` row for a role no
+ *     builder emits is not a mapping, it is debris a role-map screen would
+ *     render forever.
+ * (b) **Moves** `revenue_dtc` to `revenue_product`, in place - the account the
+ *     assignment points at is unchanged, only the role name is, mirroring
+ *     `132-card-clearing-rename.ts`'s `moveRole`. When an org already holds a
+ *     `revenue_product` row (a fresh seed ran after this shipped, or a
+ *     previous partial run of this migration already moved it), the stale
+ *     `revenue_dtc` row is DELETED instead of renamed, because
+ *     `GlRoleAssignment` is uniquely indexed on `(organizationId, role)` and
+ *     the rename would collide.
+ * (c) **Renames** every non-archived `gl_account` whose `gl_account_name` is
+ *     EXACTLY `"Payroll Clearing (ADP)"` to `"Payroll Clearing"` - the same
+ *     provider-in-the-name defect entity migration 132 fixed for `1200`
+ *     (`default-chart.ts`'s own header on `2110`). The code and the role
+ *     (`payroll_clearing`) do not move; only the label does, and only when it
+ *     still reads exactly the old default.
+ * (d) **Provisions** the three fields the new posting shape reads: a nullable
+ *     `bank_account.stripeExternalAccountId` (the confirmed Stripe
+ *     destination identity, brief 13 §2.3), and nullable
+ *     `payout.destination` / `payout.blockedReason` (the gateway's own
+ *     destination id, and the sentence a payout carries when it cannot be
+ *     resolved to one). `ensureCustomFields` creates whichever of the three
+ *     is missing and leaves the rest alone - a fresh org that ran the
+ *     registry after this shipped already has them all.
+ *
+ * ## What it deliberately does NOT touch
+ *
+ * **Posted `GlPostingLine` rows.** `accountRole` and `accountName` on an
+ * already-posted line are SNAPSHOTS, the same rule `132`'s header states for
+ * `clearing_shopify` / `"Shopify Clearing"`: an entry posted under
+ * `revenue_dtc` keeps saying `revenue_dtc` in the register forever, because
+ * rewriting history the moment a vocabulary moves is exactly the thing a
+ * snapshot exists to prevent. Nothing reads those columns to resolve an
+ * account - `resolveRoles` goes through `GlRoleAssignment` alone - so the
+ * stale strings cost nothing but literal accuracy about a name that has since
+ * moved on.
+ *
+ * ## Self-sufficient and idempotent
+ *
+ * Every write is narrowed to rows that still need it, so a re-run reports
+ * `alreadyUpToDate: true`. Verified by `SELECT` over more than one org, never
+ * by the log - see the migration's own test and the report this task owes.
+ * Safe to re-apply with
+ * `packages/lib/scripts/run-entity-migration.ts --id 145-retire-instance-roles`.
+ */
+export const migration145RetireInstanceRoles: EntityMigration = {
+  id: '145-retire-instance-roles',
+  description:
+    'Deletes the cash and revenue_dealer role assignments, moves revenue_dtc onto ' +
+    'revenue_product, renames "Payroll Clearing (ADP)" to "Payroll Clearing", and provisions ' +
+    'bank_account.stripeExternalAccountId / payout.destination / payout.blockedReason ' +
+    '(brief 13 §2, §5)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const rolesDeleted = await deleteRetiredRoles(db, organizationId)
+    const revenueMoved = await moveRevenueDtcRole(db, organizationId)
+    const accountsRenamed = await renamePayrollClearing(db, organizationId, existing)
+    const fieldsCreated = await ensureNewFields(db, organizationId, existing, state)
+
+    const changed = rolesDeleted > 0 || revenueMoved > 0 || accountsRenamed > 0 || fieldsCreated > 0
+
+    if (changed) {
+      await getOrgCache().invalidateAndRecompute(organizationId, [...CACHE_KEYS])
+      logger.info('Migration 145 applied', {
+        organizationId,
+        rolesDeleted,
+        revenueMoved,
+        accountsRenamed,
+        fieldsCreated,
+      })
+    }
+
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}
+
+/** Delete every `GlRoleAssignment` row naming a role brief 13 §2 retires outright. */
+async function deleteRetiredRoles(db: Database, organizationId: string): Promise<number> {
+  const deleted = await db
+    .delete(schema.GlRoleAssignment)
+    .where(
+      and(
+        eq(schema.GlRoleAssignment.organizationId, organizationId),
+        inArray(schema.GlRoleAssignment.role, [...RETIRED_ROLES])
+      )
+    )
+    .returning({ id: schema.GlRoleAssignment.id })
+  return deleted.length
+}
+
+/**
+ * Move the `revenue_dtc` assignment onto `revenue_product`, keeping the
+ * account it points at - mirrors `132-card-clearing-rename.ts`'s `moveRole`.
+ * Returns how many rows changed (0 or 1).
+ */
+async function moveRevenueDtcRole(db: Database, organizationId: string): Promise<number> {
+  const [old] = await db
+    .select({ id: schema.GlRoleAssignment.id })
+    .from(schema.GlRoleAssignment)
+    .where(
+      and(
+        eq(schema.GlRoleAssignment.organizationId, organizationId),
+        eq(schema.GlRoleAssignment.role, OLD_REVENUE_ROLE)
+      )
+    )
+    .limit(1)
+  if (!old) return 0
+
+  const [already] = await db
+    .select({ id: schema.GlRoleAssignment.id })
+    .from(schema.GlRoleAssignment)
+    .where(
+      and(
+        eq(schema.GlRoleAssignment.organizationId, organizationId),
+        eq(schema.GlRoleAssignment.role, NEW_REVENUE_ROLE)
+      )
+    )
+    .limit(1)
+
+  // 🛑 `(organizationId, role)` is uniquely indexed, so renaming onto a row
+  // that already exists would throw. The new row is the authority; the old
+  // one is a leftover nothing resolves any more.
+  if (already) {
+    await db.delete(schema.GlRoleAssignment).where(eq(schema.GlRoleAssignment.id, old.id))
+    return 1
+  }
+
+  await db
+    .update(schema.GlRoleAssignment)
+    .set({ role: NEW_REVENUE_ROLE })
+    .where(eq(schema.GlRoleAssignment.id, old.id))
+  return 1
+}
+
+/**
+ * Rename every non-archived `gl_account` whose name is exactly
+ * `"Payroll Clearing (ADP)"` to `"Payroll Clearing"`. The code and the role
+ * are untouched - only the label moves, and only when it still reads exactly
+ * the old default (chart rule 3).
+ */
+async function renamePayrollClearing(
+  db: Database,
+  organizationId: string,
+  existing: Awaited<ReturnType<typeof loadExistingState>>
+): Promise<number> {
+  const glAccountDef = existing.entityDefs.get(GL_ACCOUNT_ENTITY_TYPE)
+  if (!glAccountDef) return 0
+
+  const nameFieldId = existing.fields.get(fieldKey(glAccountDef.id, 'gl_account_name'))?.id
+  if (!nameFieldId) return 0
+
+  const matches = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, nameFieldId),
+        eq(schema.FieldValue.valueText, OLD_PAYROLL_CLEARING_NAME)
+      )
+    )
+  if (matches.length === 0) return 0
+
+  const updated = await db
+    .update(schema.FieldValue)
+    .set({ valueText: NEW_PAYROLL_CLEARING_NAME, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, nameFieldId),
+        inArray(
+          schema.FieldValue.entityId,
+          matches.map((row) => row.entityId)
+        ),
+        eq(schema.FieldValue.valueText, OLD_PAYROLL_CLEARING_NAME)
+      )
+    )
+    .returning({ id: schema.FieldValue.id })
+
+  return updated.length
+}
+
+/**
+ * `ensureCustomFields` for the three new fields, on whichever of `bank_account`
+ * / `payout` already exists in this org. An org short of either def has
+ * nothing to provision yet - it picks the fields up when the def itself is
+ * created (migrations 125, 133).
+ */
+async function ensureNewFields(
+  db: Database,
+  organizationId: string,
+  existing: Awaited<ReturnType<typeof loadExistingState>>,
+  state: { entityDefsCreated: number; fieldsCreated: number; relationshipsLinked: number }
+): Promise<number> {
+  const before = state.fieldsCreated
+
+  const bankAccountDef = existing.entityDefs.get(BANK_ACCOUNT_ENTITY_TYPE)
+  if (bankAccountDef) {
+    const stripeExternalAccountId = BANK_ACCOUNT_FIELDS.stripeExternalAccountId
+    if (!stripeExternalAccountId) {
+      throw new Error(
+        "bank-account-fields registry is missing the key 'stripeExternalAccountId' (migration 145)"
+      )
+    }
+    await ensureCustomFields(
+      db,
+      organizationId,
+      BANK_ACCOUNT_ENTITY_TYPE,
+      bankAccountDef.id,
+      { stripeExternalAccountId },
+      existing,
+      state
+    )
+  }
+
+  const payoutDef = existing.entityDefs.get(PAYOUT_ENTITY_TYPE)
+  if (payoutDef) {
+    const destination = PAYOUT_FIELDS.destination
+    const blockedReason = PAYOUT_FIELDS.blockedReason
+    if (!destination || !blockedReason) {
+      throw new Error(
+        "payout-fields registry is missing 'destination' or 'blockedReason' (migration 145)"
+      )
+    }
+    await ensureCustomFields(
+      db,
+      organizationId,
+      PAYOUT_ENTITY_TYPE,
+      payoutDef.id,
+      { destination, blockedReason },
+      existing,
+      state
+    )
+  }
+
+  return state.fieldsCreated - before
+}

--- a/packages/lib/src/seed/entity-migrations/migrations/146-payment-gateway.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/146-payment-gateway.test.ts
@@ -1,0 +1,105 @@
+// packages/lib/src/seed/entity-migrations/migrations/146-payment-gateway.test.ts
+//
+// A new entity type is a hand-edit across several files (`enums.ts`,
+// `enum-values.ts`, `field-registry.ts`, `create-fields.ts`, `constants.ts`,
+// `types/resource/utils.ts`, the system-attribute union), and getting one
+// wrong creates a def the app can half see: the records path resolves it and
+// the seeder does not, or the reverse. 125's test pins the same checklist for
+// its five new entity types; this pins it for `payment_gateway`.
+
+import { ModelTypeMeta, ModelTypes, ModelTypeValues } from '@auxx/database/enums'
+import { ENTITY_DEFINITION_TYPES } from '@auxx/types/resource'
+import { SYSTEM_ATTRIBUTES } from '@auxx/types/system-attribute'
+import { describe, expect, it } from 'vitest'
+import { RESOURCE_FIELD_REGISTRY } from '../../../resources/registry/field-registry'
+import { PAYMENT_GATEWAY_FIELDS } from '../../../resources/registry/resources/payment-gateway-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { DISPLAY_FIELD_CONFIG, SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import { FIELD_REGISTRY } from '../../entity-seeder/create-fields'
+import { migration146PaymentGateway } from './146-payment-gateway'
+
+const MIGRATION_ID = '146-payment-gateway'
+
+describe('migration 146 registration', () => {
+  it('is registered exactly once, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('leaves every registered id on a distinct number, and 146 is free', () => {
+    const numbers = ALL_ENTITY_MIGRATIONS.map((m) => m.id.split('-')[0])
+    expect(new Set(numbers).size).toBe(numbers.length)
+    expect(ALL_ENTITY_MIGRATIONS.filter((m) => m.id.split('-')[0] === '146')).toHaveLength(1)
+  })
+
+  it('exports the migration it registers', () => {
+    expect(ALL_ENTITY_MIGRATIONS).toContain(migration146PaymentGateway)
+  })
+})
+
+describe('payment_gateway is registered everywhere a def has to be', () => {
+  it('is a ModelTypeValues entry, mapped in ModelTypes, with EntityInstance meta', () => {
+    expect(ModelTypeValues).toContain('payment_gateway')
+    expect(ModelTypes.PAYMENT_GATEWAY).toBe('payment_gateway')
+    expect(ModelTypeMeta.payment_gateway.apiSlug).toBe('payment-gateways')
+    expect(ModelTypeMeta.payment_gateway.dbTable).toBe('EntityInstance')
+    // No `/app/payment-gateways/[id]` route exists; claiming one puts a
+    // fullscreen button on the drawer that 404s.
+    expect(ModelTypeMeta.payment_gateway.hasDetailPage).toBe(false)
+  })
+
+  it('is an EntityDefinitionType, so a payment_gateway:<id> RecordId canonicalizes', () => {
+    expect(ENTITY_DEFINITION_TYPES).toContain('payment_gateway')
+  })
+
+  it('resolves the SAME field map in both registries used by the two seeders', () => {
+    expect(RESOURCE_FIELD_REGISTRY.payment_gateway).toBe(PAYMENT_GATEWAY_FIELDS)
+    expect(FIELD_REGISTRY.payment_gateway).toBe(PAYMENT_GATEWAY_FIELDS)
+  })
+
+  it('is a hidden SYSTEM_ENTITIES entry - the door is the settings screen, not a sidebar', () => {
+    const entity = SYSTEM_ENTITIES.find((e) => e.entityType === 'payment_gateway')
+    expect(entity).toBeDefined()
+    expect(entity?.apiSlug).toBe('payment-gateways')
+    expect(entity?.isVisible).toBe(false)
+  })
+
+  it('every field carries a systemAttribute in the shared union', () => {
+    for (const field of Object.values(PAYMENT_GATEWAY_FIELDS)) {
+      expect(SYSTEM_ATTRIBUTES).toContain(field.systemAttribute)
+    }
+  })
+
+  it('displays as fields that exist, and name and settlementSource are never null', () => {
+    const config = DISPLAY_FIELD_CONFIG.payment_gateway
+    expect(config).toEqual({
+      primaryDisplayField: 'name',
+      secondaryDisplayField: 'settlementSource',
+    })
+    expect(PAYMENT_GATEWAY_FIELDS[config!.primaryDisplayField]).toBeDefined()
+    expect(PAYMENT_GATEWAY_FIELDS[config!.secondaryDisplayField!]).toBeDefined()
+  })
+
+  it('keeps name, handles and clearingAccount required; feeAccount and lastSettlementAt nullable', () => {
+    expect(PAYMENT_GATEWAY_FIELDS.name?.nullable).toBe(false)
+    expect(PAYMENT_GATEWAY_FIELDS.handles?.nullable).toBe(false)
+    expect(PAYMENT_GATEWAY_FIELDS.clearingAccount?.nullable).toBe(false)
+    expect(PAYMENT_GATEWAY_FIELDS.feeAccount?.nullable).toBe(true)
+    expect(PAYMENT_GATEWAY_FIELDS.lastSettlementAt?.nullable).toBe(true)
+  })
+
+  it('stores clearingAccount and feeAccount as plain TEXT ids, never a RELATIONSHIP', () => {
+    expect(PAYMENT_GATEWAY_FIELDS.clearingAccount?.type).not.toBe('RELATION')
+    expect(PAYMENT_GATEWAY_FIELDS.feeAccount?.type).not.toBe('RELATION')
+  })
+
+  it('gives handles a TAGS shape, so two spellings of one rail can share a row', () => {
+    expect(PAYMENT_GATEWAY_FIELDS.handles?.fieldType).toBe('TAGS')
+  })
+
+  it('defaults settlementSource to manual and status to active', () => {
+    expect(PAYMENT_GATEWAY_FIELDS.settlementSource?.defaultValue).toBe('manual')
+    expect(PAYMENT_GATEWAY_FIELDS.status?.defaultValue).toBe('active')
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/146-payment-gateway.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/146-payment-gateway.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/seed/entity-migrations/migrations/146-payment-gateway.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getOrgCache } from '../../../cache'
+import { PAYMENT_GATEWAY_FIELDS } from '../../../resources/registry/resources/payment-gateway-fields'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import {
+  ensureCustomFields,
+  ensureEntityDefinitions,
+  linkDisplayFields,
+  loadExistingState,
+} from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:146')
+
+/** The def this migration creates. */
+const PAYMENT_GATEWAY_ENTITY_TYPE = 'payment_gateway'
+
+/**
+ * A new def is invisible to every read path that serves it until the org's
+ * `resources` cache is dropped.
+ */
+const CACHE_KEYS = ['resources'] as const
+
+/**
+ * Migration 146: the `payment_gateway` def and its fields
+ * (`plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §5.3, HANDOFF
+ * step 5).
+ *
+ * ## Why
+ *
+ * §5.1's gateway census found eleven distinct handles across five card rails on
+ * one store's history, and the pattern already applied once for a second
+ * gateway (`clearing_affirm`, entity migration 137) does not survive a third:
+ * role-per-gateway costs a role, an account and a chart migration per rail.
+ * This migration creates the record instead - a gateway carries its own
+ * clearing account, fee account and settlement source, and is a row a merchant
+ * can add without an engineer.
+ *
+ * Independent of the chart (`gl_account`): the two default rows the census
+ * names (`Shopify Payments`, `Affirm`) are seeded by `seedDefaultPaymentGateways`
+ * in `seed/gl-account-chart.ts`, once the org has PROVISIONED a chart and the
+ * clearing accounts those defaults point at actually exist - this migration
+ * only creates the def and its fields, so it has no ordering constraint
+ * against 108, 133, 142, 143 or 144.
+ *
+ * Idempotent: `ensureEntityDefinitions` / `ensureCustomFields` skip whatever the
+ * org already holds.
+ */
+export const migration146PaymentGateway: EntityMigration = {
+  id: '146-payment-gateway',
+  description:
+    'Adds the payment_gateway def and its fields - a record carrying its own clearing account, ' +
+    'never a role (task 13 §5.3)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    const existing = await loadExistingState(db, organizationId)
+
+    const entityDefIds = await ensureEntityDefinitions(
+      db,
+      organizationId,
+      SYSTEM_ENTITIES.filter((e) => e.entityType === PAYMENT_GATEWAY_ENTITY_TYPE),
+      existing,
+      state
+    )
+
+    const defId = entityDefIds.get(PAYMENT_GATEWAY_ENTITY_TYPE)
+    if (defId) {
+      const fieldMap = await ensureCustomFields(
+        db,
+        organizationId,
+        PAYMENT_GATEWAY_ENTITY_TYPE,
+        defId,
+        PAYMENT_GATEWAY_FIELDS,
+        existing,
+        state
+      )
+      await linkDisplayFields(db, [PAYMENT_GATEWAY_ENTITY_TYPE], entityDefIds, fieldMap)
+    }
+
+    const changed = state.entityDefsCreated > 0 || state.fieldsCreated > 0
+
+    if (changed) {
+      await getOrgCache().invalidateAndRecompute(organizationId, [...CACHE_KEYS])
+      logger.info('Migration 146 applied', {
+        organizationId,
+        entityDefsCreated: state.entityDefsCreated,
+        fieldsCreated: state.fieldsCreated,
+      })
+    }
+
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -441,6 +441,22 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     isVisible: false,
   },
   {
+    // A record carrying its clearing account, never a role
+    // (`plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md` §5.3,
+    // HANDOFF step 5). Entity migration 146.
+    //
+    // `isVisible: false`: the door is Accounting > Settings > Payment
+    // gateways, a master-detail settings page - the same shape `bank_account`
+    // uses and for the same reason.
+    entityType: 'payment_gateway',
+    apiSlug: 'payment-gateways',
+    singular: 'Payment Gateway',
+    plural: 'Payment Gateways',
+    icon: 'credit-card',
+    color: 'indigo',
+    isVisible: false,
+  },
+  {
     // Suggest-from-history is the PRIMARY categorisation mechanism (bank plan
     // 03 §4 - Stripe FC has no merchant enrichment and no categories); a
     // bank_rule is the opt-in, ordered layer on top of it. Entity migration
@@ -770,6 +786,10 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
   // `name` is required and `institution` is not, which is the right way round:
   // `computeDisplayValue` has no fallback, so a null PRIMARY renders the row
   // nameless while a null secondary just renders nothing.
+  payment_gateway: {
+    primaryDisplayField: 'name',
+    secondaryDisplayField: 'settlementSource',
+  },
   bank_account: {
     primaryDisplayField: 'name',
     secondaryDisplayField: 'institution',

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -26,6 +26,7 @@ import { MEETING_FIELDS } from '../../resources/registry/resources/meeting-field
 import { ORDER_FIELDS } from '../../resources/registry/resources/order-fields'
 import { PART_FIELDS } from '../../resources/registry/resources/part-fields'
 import { PAYMENT_FIELDS } from '../../resources/registry/resources/payment-fields'
+import { PAYMENT_GATEWAY_FIELDS } from '../../resources/registry/resources/payment-gateway-fields'
 import { PAYOUT_FIELDS } from '../../resources/registry/resources/payout-fields'
 import { PERSONAL_INBOX_FIELDS } from '../../resources/registry/resources/personal-inbox-fields'
 import { PRODUCT_FIELDS } from '../../resources/registry/resources/product-fields'
@@ -101,6 +102,7 @@ export const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   bank_account: BANK_ACCOUNT_FIELDS,
   bank_transaction: BANK_TRANSACTION_FIELDS,
   bank_rule: BANK_RULE_FIELDS,
+  payment_gateway: PAYMENT_GATEWAY_FIELDS,
   tariff_code: TARIFF_CODE_FIELDS,
   tariff_rate: TARIFF_RATE_FIELDS,
   credit_memo: CREDIT_MEMO_FIELDS,

--- a/packages/lib/src/seed/gl-account-chart-payment-gateways.test.ts
+++ b/packages/lib/src/seed/gl-account-chart-payment-gateways.test.ts
@@ -1,0 +1,135 @@
+// packages/lib/src/seed/gl-account-chart-payment-gateways.test.ts
+//
+// `seedDefaultPaymentGateways` (task 13 §5.3): the two default records the
+// census names, seeded once the chart's clearing accounts exist. Separate
+// file from `gl-account-chart.test.ts` because that one mocks
+// `../resources/crud` directly, while this exercises the boundary one layer
+// up - `../payment-gateways` itself - so a change to the write path's
+// internals cannot silently desync the two doubles.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  defId: 'def-payment-gateway' as string | null,
+  roleRows: [] as { role: string; glAccountId: string }[],
+  existingGateways: [] as { id: string; handles: string[] }[],
+  createCalls: [] as unknown[],
+}))
+
+vi.mock('../cache', () => ({
+  getCachedEntityDefId: async (_org: string, entityType: string) =>
+    entityType === 'payment_gateway' ? h.defId : 'def-gl-account',
+}))
+
+vi.mock('../users/system-user-service', () => ({
+  SystemUserService: { getSystemUserForActions: async () => 'system-user-1' },
+}))
+
+vi.mock('../payment-gateways', () => ({
+  normaliseGatewayHandle: (value: string) => value.trim().toLowerCase(),
+  listPaymentGateways: async () => ({
+    isOk: () => true,
+    isErr: () => false,
+    value: h.existingGateways,
+  }),
+  createPaymentGateway: async (_db: unknown, input: unknown) => {
+    h.createCalls.push(input)
+    return { isOk: () => true, isErr: () => false, value: { id: 'pg_new' } }
+  },
+}))
+
+import { seedDefaultPaymentGateways } from './gl-account-chart'
+
+/** A stub `Database` that answers the `GlRoleAssignment` select with `h.roleRows`. */
+function stubDb() {
+  return {
+    select: () => ({
+      from: () => ({
+        where: async () => h.roleRows,
+      }),
+    }),
+  } as never
+}
+
+beforeEach(() => {
+  h.defId = 'def-payment-gateway'
+  h.roleRows = []
+  h.existingGateways = []
+  h.createCalls.length = 0
+})
+
+describe('seedDefaultPaymentGateways', () => {
+  it('is a no-op when the org has no payment_gateway def yet', async () => {
+    h.defId = null
+    const result = await seedDefaultPaymentGateways(stubDb(), 'org-1')
+    expect(result).toEqual({ created: 0, skipped: 0 })
+    expect(h.createCalls).toEqual([])
+  })
+
+  it('creates Shopify Payments and Affirm when both clearing roles are mapped', async () => {
+    h.roleRows = [
+      { role: 'clearing_card', glAccountId: 'acct_1200' },
+      { role: 'clearing_affirm', glAccountId: 'acct_1210' },
+      { role: 'payment_processing_fees', glAccountId: 'acct_6100' },
+    ]
+
+    const result = await seedDefaultPaymentGateways(stubDb(), 'org-1')
+
+    expect(result.created).toBe(2)
+    expect(h.createCalls).toHaveLength(2)
+    expect(h.createCalls[0]).toMatchObject({
+      name: 'Shopify Payments',
+      handles: ['shopify_payments'],
+      clearingAccountId: 'acct_1200',
+      feeAccountId: 'acct_6100',
+      settlementSource: 'shopify_payments',
+      status: 'active',
+    })
+    expect(h.createCalls[1]).toMatchObject({
+      name: 'Affirm',
+      handles: ['affirm'],
+      clearingAccountId: 'acct_1210',
+      settlementSource: 'manual',
+      status: 'active',
+    })
+  })
+
+  it('skips a default whose clearing role is unmapped, rather than guessing an account', async () => {
+    h.roleRows = [{ role: 'clearing_card', glAccountId: 'acct_1200' }]
+
+    const result = await seedDefaultPaymentGateways(stubDb(), 'org-1')
+
+    expect(result.created).toBe(1)
+    expect(result.skipped).toBe(1)
+    expect(h.createCalls).toHaveLength(1)
+    expect(h.createCalls[0]).toMatchObject({ name: 'Shopify Payments' })
+  })
+
+  it('is idempotent by handle - skips a default a record already claims', async () => {
+    h.roleRows = [
+      { role: 'clearing_card', glAccountId: 'acct_1200' },
+      { role: 'clearing_affirm', glAccountId: 'acct_1210' },
+    ]
+    h.existingGateways = [{ id: 'pg_existing', handles: ['Affirm'] }]
+
+    const result = await seedDefaultPaymentGateways(stubDb(), 'org-1')
+
+    expect(result.created).toBe(1)
+    expect(result.skipped).toBe(1)
+    expect(h.createCalls).toHaveLength(1)
+    expect(h.createCalls[0]).toMatchObject({ name: 'Shopify Payments' })
+  })
+
+  it('never seeds Authorize.Net - a merchant adds it, auxx does not guess it', async () => {
+    h.roleRows = [
+      { role: 'clearing_card', glAccountId: 'acct_1200' },
+      { role: 'clearing_affirm', glAccountId: 'acct_1210' },
+    ]
+
+    await seedDefaultPaymentGateways(stubDb(), 'org-1')
+
+    expect(h.createCalls.some((call) => (call as { name?: string }).name === 'Authorize.Net')).toBe(
+      false
+    )
+  })
+})

--- a/packages/lib/src/seed/gl-account-chart.ts
+++ b/packages/lib/src/seed/gl-account-chart.ts
@@ -57,7 +57,13 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getCachedEntityDefId } from '../cache'
+import {
+  createPaymentGateway,
+  listPaymentGateways,
+  normaliseGatewayHandle,
+} from '../payment-gateways'
 import { DEFAULT_CHART_OF_ACCOUNTS } from '../postings/default-chart'
 import { seedSession, UnifiedCrudHandler } from '../resources/crud'
 import { SystemUserService } from '../users/system-user-service'
@@ -223,4 +229,121 @@ async function assignSeededRoles(
     .returning({ id: schema.GlRoleAssignment.id })
 
   return inserted.length
+}
+
+// ─── The two default payment gateways (task 13 §5.3, §5.1's census) ────────
+
+/** What one pass of {@link seedDefaultPaymentGateways} did. */
+export interface PaymentGatewaySeedResult {
+  created: number
+  skipped: number
+}
+
+/**
+ * Seed the two default `payment_gateway` records the census names, idempotent
+ * by handle.
+ *
+ * ⚠️ **Runs AFTER the chart**, not alongside it - the clearing accounts these
+ * defaults point at only exist once the chart is provisioned, and
+ * `payment_gateway.clearingAccount` is required and validated (`writes.ts`'s
+ * `assertClearingAccount`). Call this from wherever the chart is seeded
+ * (`ledger.provisionChart`), never before {@link seedDefaultChartOfAccounts}
+ * has run.
+ *
+ * 🛑 **Does not mint `clearing_authnet`.** Authorize.Net is a rail a merchant
+ * ADDS (§5.1); auxx does not know a store ran it until they say so. The two
+ * seeded here are the only ones every org's default chart actually names a
+ * role for: `shopify_payments` (settlement source `shopify_payments`, fee
+ * account = whichever account carries `payment_processing_fees`, `6100` by
+ * default) and `affirm` (settlement source `manual` - `18` §2.1 codes its
+ * relief by hand, because no payout API sees an Affirm settlement).
+ *
+ * Idempotent by HANDLE, not by name: a re-provision (or a second org whose
+ * chart already exists) skips a default whose handle some record - seeded or
+ * hand-added - already claims, rather than creating a second `Affirm` row.
+ *
+ * A missing role assignment (`clearing_card` / `clearing_affirm` unmapped)
+ * skips that default rather than guessing an account - the same tolerance
+ * {@link assignSeededRoles} has for a chart that does not match
+ * `DEFAULT_CHART_OF_ACCOUNTS`.
+ */
+export async function seedDefaultPaymentGateways(
+  db: Database,
+  organizationId: string
+): Promise<PaymentGatewaySeedResult> {
+  const empty: PaymentGatewaySeedResult = { created: 0, skipped: 0 }
+
+  const paymentGatewayDefId = await getCachedEntityDefId(organizationId, 'payment_gateway')
+  if (!paymentGatewayDefId) return empty
+
+  const existingResult = await listPaymentGateways(db, organizationId, { includeArchived: true })
+  const existingHandles = new Set(
+    existingResult.isOk()
+      ? existingResult.value.flatMap((gateway) => gateway.handles.map(normaliseGatewayHandle))
+      : []
+  )
+
+  const roleRows = await db
+    .select({
+      role: schema.GlRoleAssignment.role,
+      glAccountId: schema.GlRoleAssignment.glAccountId,
+    })
+    .from(schema.GlRoleAssignment)
+    .where(
+      and(
+        eq(schema.GlRoleAssignment.organizationId, organizationId),
+        inArray(schema.GlRoleAssignment.role, [
+          'clearing_card',
+          'clearing_affirm',
+          'payment_processing_fees',
+        ])
+      )
+    )
+  const byRole = new Map(roleRows.map((row) => [row.role, row.glAccountId]))
+
+  const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+
+  let created = 0
+  let skipped = 0
+
+  const clearingCard = byRole.get('clearing_card')
+  if (!existingHandles.has('shopify_payments') && clearingCard) {
+    const result = await createPaymentGateway(db, {
+      organizationId,
+      actorUserId: systemUserId,
+      name: 'Shopify Payments',
+      handles: ['shopify_payments'],
+      clearingAccountId: clearingCard,
+      feeAccountId: byRole.get('payment_processing_fees') ?? null,
+      settlementSource: 'shopify_payments',
+      status: 'active',
+    })
+    if (result.isOk()) created++
+    else skipped++
+  } else {
+    skipped++
+  }
+
+  const clearingAffirm = byRole.get('clearing_affirm')
+  if (!existingHandles.has('affirm') && clearingAffirm) {
+    const result = await createPaymentGateway(db, {
+      organizationId,
+      actorUserId: systemUserId,
+      name: 'Affirm',
+      handles: ['affirm'],
+      clearingAccountId: clearingAffirm,
+      settlementSource: 'manual',
+      status: 'active',
+    })
+    if (result.isOk()) created++
+    else skipped++
+  } else {
+    skipped++
+  }
+
+  if (created > 0) {
+    logger.info('Seeded default payment gateways', { organizationId, created, skipped })
+  }
+
+  return { created, skipped }
 }

--- a/packages/lib/src/seed/index.ts
+++ b/packages/lib/src/seed/index.ts
@@ -4,7 +4,12 @@ export type { EntityDefMap, EntityDefRecord, FieldMap, FieldRecord } from './ent
 export { EntitySeeder } from './entity-seeder'
 // Entity Seeder (multi-pass implementation)
 export { deletePristineSeededDashboards } from './entity-seeder/create-default-dashboards'
-export { type ChartSeedResult, seedDefaultChartOfAccounts } from './gl-account-chart'
+export {
+  type ChartSeedResult,
+  type PaymentGatewaySeedResult,
+  seedDefaultChartOfAccounts,
+  seedDefaultPaymentGateways,
+} from './gl-account-chart'
 export { seedNewUserDatabase } from './new-user'
 export { OrganizationSeeder, type SeedOrganizationOptions } from './organization-seeder'
 export { UserSeeder, type UserSeedOptions, type UserSeedResult } from './user-seeder'

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -1195,6 +1195,19 @@ export const SETTINGS_CATALOG = {
       'Where a payment of any other method lands. Defaults to undeposited funds: the safe ' +
       'unknown is money visible in a clearing account, not cash the bank has never seen.',
   },
+  // 🛑 `cash` retired as a posting ROLE (brief 13 §2): a payment routed to
+  // `cash` now names a specific `bank_account` id, the same as a payout's
+  // settlement destination. Null until a person picks one, and a `cash`-routed
+  // payment refuses to post rather than guessing which account.
+  'accounting.cashBankAccountId': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'TEXT',
+    defaultValue: null,
+    description:
+      'The bank_account a payment routed to `cash` is banked into. Shown only when one of the ' +
+      'payment routes above is set to cash.',
+  },
 
   // ── Remembered statement-import column mappings ────────────────────────────
   //

--- a/packages/types/resource/utils.ts
+++ b/packages/types/resource/utils.ts
@@ -178,6 +178,9 @@ export const ENTITY_DEFINITION_TYPES = [
   'credit_memo',
   'credit_memo_line',
   'credit_memo_application',
+  // A record carrying its clearing account, never a role
+  // (plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md §5.3).
+  'payment_gateway',
 ] as const
 
 /** Type for system entity types stored in EntityDefinition */

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -861,6 +861,11 @@ export const SYSTEM_ATTRIBUTES = [
   'payout_unrecognised_count',
   'payout_gl_posting_id', // denormalized backlink; the posting is the authority
   'payout_bank_transaction_id', // the bank_deposit / vendor_payment twin, by name and meaning
+  'payout_destination', // the gateway's own external-account id (brief 13 §2.3), never last4
+  // 🛑 Set only when the payout could not be posted for lack of a confirmed
+  // bank-account identity. Never a role; naming the payout, the destination and
+  // the remedy (brief 13 §2.3).
+  'payout_blocked_reason',
 
   // ─── Bank feed (plans/bank-connection/02-connection-architecture.md §6) ──
   // Entity migration 125. `bank_account` is where the feed meets the chart of
@@ -885,8 +890,26 @@ export const SYSTEM_ATTRIBUTES = [
   // bank-account removal gate: false deletes, true archives
   // (plans/bank-connection/08-removing-a-bank-account.md §5.1)
   'bank_account_has_posted',
+  // 🛑 The Stripe `ba_…` / `card_…` destination id, confirmed once by a person.
+  // Never matched on last4 (brief 13 §2.3): a four-digit string is strong
+  // evidence and not proof, and two accounts at one bank can share it.
+  'bank_account_stripe_external_account_id',
   'bank_account_transactions', // inverse of bank_transaction_bank_account
   'bank_account_deposits', // inverse of bank_deposit_bank_account_record
+
+  // ─── Payment gateway (task 13 §5.3) ──────────────────────────────
+  // A record carrying its clearing account, never a role. Entity migration
+  // 146. `payment_gateway_handles` is a SET (TAGS): two rails arrive under
+  // two spellings each (`authorize_net`/`authorize.net`, `Affirm`/`affirm`).
+  'payment_gateway_name',
+  'payment_gateway_handles',
+  // 🛑 The `gl_account` id this gateway settles into, TEXT with no foreign
+  // key - the same call `bank_account_gl_account` makes.
+  'payment_gateway_clearing_account',
+  'payment_gateway_fee_account',
+  'payment_gateway_settlement_source', // stripe | shopify_payments | manual
+  'payment_gateway_status', // active | closed
+  'payment_gateway_last_settlement_at',
 
   // Connector-owned (raw). The feed may correct any of these.
   'bank_transaction_external_id', // the dedupe key, across BOTH the feed and file import


### PR DESCRIPTION
## Why

Step 5 of `plans/accounting/HANDOFF-2026-09-10.md`: brief 13 §2, §3 and §5 in one pass. A role answers which account fulfils an accounting function. A bank account, a payment gateway and a sales channel are instances, and each had been given a role: `cash`, `clearing_affirm`, `revenue_dtc` and `revenue_dealer`. With no org holding a ledger this is the cheapest moment to take them back.

## What

**§2, `cash` is not a role.**
- A payout debits the bank account whose confirmed Stripe external-account id matches the payout's `destination`. New fields `bank_account_stripe_external_account_id` (set in the bank account editor), `payout_destination` and `payout_blocked_reason`. Until a person confirms the identity the payout refuses with `bank_account_unmapped`, the reason is stored on the record, and the payouts page renders the blocker. Never matched on last4.
- The `cash` payment route takes the bank account named by the new `accounting.cashBankAccountId` setting (a picker on the general settings page, shown when any route is `cash`) and refuses `account_unmapped` when unset. `PAYMENT_ROUTE_ROLE` is a discriminated union.
- Both emit `{ glAccountId }` lines. `SINGLE_WRITER_ROLES` is the three inventory roles again and `bank_deposit` declares none. A guard over bank account ids is a TODO in `regime.ts` (brief 13 §2.5's escape hatch).

**§3, subtype validation.** `isMappableTo` and `validateProviderMapping` read `subtype`: `bank` maps only to a QuickBooks Bank account, `accounts_receivable` only to Accounts Receivable, `accounts_payable` only to Accounts Payable, and so on for the other subtypes. A null subtype keeps the classification-only check. The account map picker and the chart editor's provider field stop offering what the confirm would refuse. The suggestion ranking is unchanged and pinned.

**§5, dimensions.**
- One `revenue_product` role replaces `revenue_dtc` and `revenue_dealer`. The channel is `dimensions.channel` on the revenue line; `CHANNEL_KEYS` is the declared keyspace with the `manual`/`null` fail-open rule intact.
- Sales tax splits by jurisdiction from the order's `tax_line` rows (one bulk read per batch, largest-remainder rounding, one undimensioned line when the rows do not tie to the order's tax total, because a partial breakdown reads as a complete one).
- `GlPostingLine.dimensions`, written by nothing since wave 0, is written by post, carried by read, retry and reversal, and reportable through `readDimensionBreakdown`. No QuickBooks class hop, no screen in this pass.
- `4010` leaves the default chart, `4000` is `Product Revenue`, `2110` is `Payroll Clearing`.

**§5.3, a gateway is a record.** `payment_gateway` def (name, a set of handles as TAGS, clearing account, fee account, settlement source `stripe | shopify_payments | manual`, status `active | closed`, last settlement), lib module under `packages/lib/src/payment-gateways/`, `paymentGateway` router, and Accounting > Settings > Payment gateways copied from the bank accounts screen. Two defaults (Shopify Payments, Affirm) seed with the chart; Authorize.Net is not seeded. The fulfillment plan loads routes from the records and emits the record's clearing account by id; `FULFILLMENT_GATEWAY_DEBIT` stays only as the fallback for an unnamed rail. The plan table shows the gateway's name.

**Migrations.** Entity migration 145 clears `cash` and `revenue_dealer` assignments, remaps `revenue_dtc` to `revenue_product`, renames 2110, and stamps the three new fields. Entity migration 146 creates the `payment_gateway` def. Both ran on all 28 dev orgs and were verified by SELECT. No drizzle migration.

## Verification

- Biome clean on every changed file, zero em dashes added, no reference to a retired role outside one historical comment.
- Web typecheck 0 errors, ratchet baseline 0. Lib ratchet 27 of 27. Worker tsc 0 errors.
- `packages/database` suite pass. Lib full suite 1291 of 1292 files pass; the one failure is a rate-limiter pacer timing test that passes alone and is untouched. Web accounting, money and router tests 59 of 60 files pass; the one failure is the pre-existing file-attachment drizzle mock.
- Not driven in a browser. The §7 drive in the handoff is still owed and now includes the payout refusal, the cash route setting, the gateway screen, and a fulfillment plan with a gateway-routed shipment.

https://claude.ai/code/session_01BQLTmsB1p3k7Ki8rWAqzt4
