### PR TITLE
feat(accounting): payouts become match candidates, and a duplicate movement detector

### DIFF
--- a/apps/web/src/components/accounting/ui/banking/payouts/payouts-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/payouts/payouts-page.tsx
@@ -88,6 +88,17 @@ export function PayoutsPage() {
     ...(onlyUnidentified ? { onlyUnidentified: true } : {}),
     limit: 200,
   })
+  // The gateway named on the row's `secondary` (brief 18 §1.1 b). Payout
+  // ingestion is Stripe Connect only today (HANDOFF §0.3), so the settlement
+  // source is what picks the row rather than a field on the payout itself;
+  // 'Stripe' is the fallback for an org with no gateway record yet.
+  const gatewaysQuery = api.paymentGateway.list.useQuery()
+  const stripeGatewayName = useMemo(() => {
+    const stripeGateway = (gatewaysQuery.data ?? []).find(
+      (gateway) => gateway.settlementSource === 'stripe'
+    )
+    return stripeGateway?.name ?? 'Stripe'
+  }, [gatewaysQuery.data])
   const utils = api.useUtils()
   const syncNow = api.money.payout.syncNow.useMutation({
     onSuccess: () => {
@@ -223,7 +234,7 @@ export function PayoutsPage() {
               <div className='flex flex-col gap-1.5'>
                 <TreeRow
                   title={payout.number ?? EMPTY_CELL}
-                  secondary={payout.paidAt ?? 'Not settled yet'}
+                  secondary={`${stripeGatewayName} · ${payout.paidAt ?? 'Not settled yet'}`}
                   icon={<Landmark />}
                   trailing={
                     <div className='flex items-center gap-3'>
@@ -239,6 +250,20 @@ export function PayoutsPage() {
                       <Badge variant={STATUS_TONE[payout.status] ?? 'secondary'} size='sm'>
                         {STATUS_LABEL[payout.status] ?? payout.status}
                       </Badge>
+                      {/* 🛑 Brief 18 §1: a `paid` payout with no bank line is a
+                          real signal - either the deposit has not landed or
+                          somebody coded it by hand instead of matching it. */}
+                      {payout.bankTransactionId ? (
+                        <Badge variant='green' size='sm'>
+                          matched
+                        </Badge>
+                      ) : (
+                        payout.status === 'paid' && (
+                          <Badge variant='outline' size='sm'>
+                            unmatched
+                          </Badge>
+                        )
+                      )}
                     </div>
                   }
                 />

--- a/apps/web/src/components/accounting/ui/banking/review/match-panel.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/match-panel.tsx
@@ -6,17 +6,32 @@ import {
   type BankTransactionRow,
   MATCH_RECORD_TYPE_LABELS,
   type MatchCandidate,
+  type MatchRecordType,
 } from '@auxx/lib/banking/review/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
-import { FileCheck2, Link2 } from 'lucide-react'
+import { FileCheck2, Landmark, Link2, type LucideIcon } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '~/trpc/react'
 import { EntryBlockers, type LedgerBlocker } from '../../ledger/entry-blockers'
 import { formatMinor } from '../../ledger/format'
+
+/**
+ * Every other candidate is a document; a payout is the gateway settlement
+ * itself, so it gets the bank icon rather than the generic document check
+ * (brief 18 §1.1 a).
+ */
+const RECORD_TYPE_ICONS: Record<MatchRecordType, LucideIcon> = {
+  vendor_payment: FileCheck2,
+  payment_transaction: FileCheck2,
+  bank_deposit: FileCheck2,
+  vendor_bill: FileCheck2,
+  payout: Landmark,
+  bank_transaction: FileCheck2,
+}
 
 interface MatchPanelProps {
   line: BankTransactionRow
@@ -90,10 +105,11 @@ export function MatchPanel({ line, currencyCode, onDone }: MatchPanelProps) {
           renderRow={(row: MatchCandidate) => {
             const takenBy = row.matchedToBankTransactionId
             const taken = !!takenBy && takenBy !== line.id
+            const Icon = RECORD_TYPE_ICONS[row.recordType]
             return (
               <TreeRow
                 className={TREE_SECONDARY_NOTRUNCATE}
-                icon={<FileCheck2 className='size-4' />}
+                icon={<Icon className='size-4' />}
                 title={<span className='truncate text-sm'>{row.label}</span>}
                 secondary={
                   <span className='flex flex-wrap items-center gap-1.5'>
@@ -132,7 +148,8 @@ export function MatchPanel({ line, currencyCode, onDone }: MatchPanelProps) {
                           | 'vendor_payment'
                           | 'payment_transaction'
                           | 'bank_deposit'
-                          | 'vendor_bill',
+                          | 'vendor_bill'
+                          | 'payout',
                         recordId: row.recordId,
                       })
                     }>

--- a/apps/web/src/components/accounting/ui/ledger/books-health.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/books-health.tsx
@@ -2,14 +2,21 @@
 
 'use client'
 
-import type { BooksBalanceReport, FailedExport } from '@auxx/lib/postings/client'
+import type {
+  BooksBalanceReport,
+  DuplicateMovementFinding,
+  FailedExport,
+} from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
-import { CircleAlert, Loader, RefreshCw, Scale } from 'lucide-react'
+import { CircleAlert, Loader, RefreshCw, Scale, TriangleAlert } from 'lucide-react'
+import { useState } from 'react'
+import { AccountLabel } from '~/components/accounting/ui/account-label'
+import { PostingLinesDialog } from '~/components/accounting/ui/ledger-card'
 import { api } from '~/trpc/react'
-import { formatPeriodLabel } from './format'
+import { formatAccountingDate, formatMinor, formatPeriodLabel } from './format'
 
 interface BooksBalanceLineProps {
   report: BooksBalanceReport
@@ -213,6 +220,106 @@ export function FailedExportsBanner({ exports: owed }: FailedExportsBannerProps)
           </div>
         ))}
       </div>
+    </div>
+  )
+}
+
+/** `'bank_transaction'` reads `'bank coding'` - what a person did, not the enum. */
+const SOURCE_TYPE_LABELS: Record<string, string> = {
+  payout: 'payout',
+  bank_transaction: 'bank coding',
+  bank_deposit: 'bank deposit',
+}
+
+function sourceTypeLabel(sourceType: string): string {
+  return SOURCE_TYPE_LABELS[sourceType] ?? sourceType.replace(/_/g, ' ')
+}
+
+interface DuplicateMovementsCardProps {
+  findings: DuplicateMovementFinding[]
+  currencyCode: string
+  bookTimeZone: string
+}
+
+/**
+ * The duplicate detector's card (plans/accounting/tasks/18-two-feeds-one-
+ * author.md §1, DECIDED "no matter what"): two or more posted lines that moved
+ * one bank account by the same amount, in the same direction, from more than
+ * one source, within a couple of days of each other.
+ *
+ * 🛑 **Never auto-fixed, and there is no action button beyond opening a
+ * posting.** A detector that "resolved" a duplicate would have guessed which
+ * entry was real; the remedy is a person choosing to reverse one in auxx or
+ * delete one in QuickBooks (§1.1 c's mockup, verbatim in the closing sentence
+ * below). A CARD, never a toast - `FailedExportsBanner` above follows the same
+ * rule and for the same reason: this is a finding on ledger surfaces, not a
+ * transient notice.
+ */
+export function DuplicateMovementsCard({
+  findings,
+  currencyCode,
+  bookTimeZone,
+}: DuplicateMovementsCardProps) {
+  const [openPostingId, setOpenPostingId] = useState<string | null>(null)
+
+  if (findings.length === 0) return null
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {findings.map((finding) => {
+        const key = `${finding.glAccountId}-${finding.amountMinor}-${finding.direction}-${finding.entries[0]?.glPostingId ?? ''}`
+        return (
+          <div
+            key={key}
+            className='flex flex-col gap-3 rounded-xl border border-amber-500/40 bg-amber-500/5 p-4'>
+            <div className='flex items-start gap-2'>
+              <TriangleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
+              <div className='flex min-w-0 flex-col gap-1'>
+                <span className='flex flex-wrap items-baseline gap-1 font-medium'>
+                  Possible duplicate
+                  <span className='text-muted-foreground'>-</span>
+                  <AccountLabel
+                    account={{ code: finding.accountCode, name: finding.accountName }}
+                    density='compact'
+                  />
+                </span>
+                <p className='text-sm text-muted-foreground'>
+                  {finding.entries.length} entries move this account by{' '}
+                  {formatMinor(finding.amountMinor, currencyCode)} from different sources.
+                </p>
+              </div>
+            </div>
+
+            <div className='flex flex-col gap-1.5'>
+              {finding.entries.map((entry) => (
+                <button
+                  key={entry.glPostingId}
+                  type='button'
+                  className='flex flex-wrap items-center gap-2 rounded-lg border bg-background px-3 py-2 text-left text-sm hover:bg-muted/40'
+                  onClick={() => setOpenPostingId(entry.glPostingId)}>
+                  <span className='font-mono'>{entry.docNumber}</span>
+                  <span className='text-xs text-muted-foreground'>
+                    {sourceTypeLabel(entry.sourceType)}
+                  </span>
+                  <span className='ml-auto text-xs text-muted-foreground'>
+                    posted {formatAccountingDate(entry.txnDate, bookTimeZone)}
+                  </span>
+                </button>
+              ))}
+            </div>
+
+            <p className='text-xs text-muted-foreground'>
+              Nothing was changed. Reverse one, or delete it in QuickBooks.
+            </p>
+          </div>
+        )
+      })}
+
+      <PostingLinesDialog
+        postingId={openPostingId}
+        onOpenChange={(open) => !open && setOpenPostingId(null)}
+        currencyCode={currencyCode}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
@@ -44,7 +44,7 @@ import {
 } from '~/providers/dehydrated-state-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
-import { BooksBalanceLine, FailedExportsBanner } from './books-health'
+import { BooksBalanceLine, DuplicateMovementsCard, FailedExportsBanner } from './books-health'
 import { type CountAdjustmentRow, CountEvidenceSection } from './count-evidence-section'
 import { EntryBlockers, type LedgerBlocker } from './entry-blockers'
 import { EntryJournal, journalLinesFromDetail } from './entry-journal'
@@ -166,6 +166,13 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
   // them. An `enabled: !!activePeriodKey` here would withhold an answer that is
   // available, and leave the same permanent skeleton behind.
   const balanceQuery = api.ledger.verifyBalance.useQuery({
+    periodKey: activePeriodKey || undefined,
+  })
+  // The duplicate detector (plans/accounting/tasks/18-two-feeds-one-author.md
+  // §1). Same month, same `||` (not `??`) reasoning as `balanceQuery` above -
+  // `activePeriodKey` is `''` while periods are loading and permanently for a
+  // finalized org whose cutoff is still ahead of the wall clock.
+  const duplicateMovementsQuery = api.ledger.duplicateMovements.useQuery({
     periodKey: activePeriodKey || undefined,
   })
   const roleMapQuery = api.ledger.roleMap.useQuery()
@@ -681,6 +688,19 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
                   </p>
                 ) : (
                   <Skeleton className='h-6 w-64' />
+                )}
+
+                {/* The duplicate detector (brief 18 §1). Renders nothing while
+                    loading or clean - unlike the balance sweep above, a
+                    running or empty read here is not itself news. */}
+                {!!duplicateMovementsQuery.data?.length && (
+                  <div className='mt-3'>
+                    <DuplicateMovementsCard
+                      findings={duplicateMovementsQuery.data}
+                      currencyCode={currencyCode}
+                      bookTimeZone={bookTimeZone}
+                    />
+                  </div>
                 )}
               </Section>
             </>

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -11,6 +11,7 @@ import {
   createChartAccount,
   createJournalEntry,
   discardJournalEntry,
+  findDuplicateBankMovements,
   GL_ACCOUNT_SUBTYPES,
   GL_ACCOUNT_TYPES,
   getJournalEntry,
@@ -840,6 +841,30 @@ export const ledgerRouter = createTRPCRouter({
     .input(optionalMonthKey.optional())
     .query(async ({ ctx, input }) => {
       const result = await verifyBooksBalance(ctx.db, ctx.session.organizationId, {
+        month: input?.periodKey,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * The duplicate detector (plans/accounting/tasks/18-two-feeds-one-author.md
+   * §1, DECIDED "no matter what"): two or more posted lines that moved one
+   * bank account by the same amount, in the same direction, from more than one
+   * `sourceType`, within a couple of days of each other - a payout and a bank
+   * line coded to it, most commonly. Rendered as a card beside
+   * `BooksBalanceLine`, never auto-fixed - the remedy is a person reversing one
+   * entry or deleting one in QuickBooks.
+   *
+   * Same optional month input as {@link verifyBalance}, for the same reason:
+   * the close console asks about the month on screen, and a malformed value is
+   * still refused by the regex.
+   */
+  duplicateMovements: permissionProcedure(PermissionKey.ledgerView)
+    .input(optionalMonthKey.optional())
+    .query(async ({ ctx, input }) => {
+      const result = await findDuplicateBankMovements(ctx.db, {
+        organizationId: ctx.session.organizationId,
         month: input?.periodKey,
       })
       if (result.isErr()) throw result.error

--- a/packages/lib/src/banking/review/__tests__/reads-payout-candidates.test.ts
+++ b/packages/lib/src/banking/review/__tests__/reads-payout-candidates.test.ts
@@ -8,7 +8,7 @@
 // second time (HANDOFF §0.2).
 //
 // 🛑 The property that matters most: a payout already matched to a DIFFERENT
-// bank line is not offered again, unlike `bank_deposit`/`vendor_payment`
+// bank line is not offered again, unlike deposit and vendor payment
 // candidates, which stay visible-but-disabled. A payout confirms exactly one
 // bank line; relisting it invites a second line to claim money that only
 // arrived once.

--- a/packages/lib/src/banking/review/__tests__/reads-payout-candidates.test.ts
+++ b/packages/lib/src/banking/review/__tests__/reads-payout-candidates.test.ts
@@ -1,0 +1,236 @@
+// packages/lib/src/banking/review/__tests__/reads-payout-candidates.test.ts
+//
+// `readPayoutCandidates` (brief 18 §1, plans/accounting/tasks/18-two-feeds-one-author.md):
+// payouts become match candidates for an inbound bank line, which is the whole
+// argument for shipping this half of the duplicate detector alone. Before this,
+// `listMatchCandidates` offered a Stripe payout's own bank line NOTHING to
+// match, so the reviewer's only door was Code - which credits clearing a
+// second time (HANDOFF §0.2).
+//
+// 🛑 The property that matters most: a payout already matched to a DIFFERENT
+// bank line is not offered again, unlike `bank_deposit`/`vendor_payment`
+// candidates, which stay visible-but-disabled. A payout confirms exactly one
+// bank line; relisting it invites a second line to claim money that only
+// arrived once.
+
+import { schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORG = 'org_1'
+const LINE_ID = 'txn_1'
+const BT_DEF = 'def_bt'
+const PAYOUT_DEF = 'def_payout'
+const DEPOSIT_DEF = 'def_deposit'
+
+/** The outer bank_transaction's own fields, read through `getOrgCache` - never the CustomField table. */
+const BT_FIELDS: Record<string, { id: string }> = {
+  bank_transaction_external_id: { id: 'f_ext' },
+  bank_transaction_bank_account: { id: 'f_acct' },
+  bank_transaction_posted_at: { id: 'f_posted' },
+  bank_transaction_description: { id: 'f_desc' },
+  bank_transaction_amount: { id: 'f_amount' },
+  bank_transaction_bank_status: { id: 'f_bank_status' },
+  bank_transaction_match_key: { id: 'f_key' },
+  bank_transaction_source: { id: 'f_source' },
+  bank_transaction_import_batch_id: { id: 'f_batch' },
+  bank_transaction_review_status: { id: 'f_review' },
+  bank_transaction_gl_account: { id: 'f_gl' },
+  bank_transaction_matched_record_id: { id: 'f_matched_id' },
+  bank_transaction_matched_record_type: { id: 'f_matched_type' },
+  bank_transaction_exclude_reason: { id: 'f_exclude' },
+  bank_transaction_reviewed_at: { id: 'f_reviewed_at' },
+  bank_transaction_reviewed_by_user_id: { id: 'f_reviewed_by' },
+  bank_transaction_gl_posting_id: { id: 'f_posting' },
+  bank_transaction_rule_id: { id: 'f_rule' },
+}
+
+/** The candidate entities' own attributes, read through the `CustomField` table. */
+const PAYOUT_FIELD_IDS: Record<string, string> = {
+  payout_deposited: 'pf_deposited',
+  payout_paid_at: 'pf_paid_at',
+  payout_bank_transaction_id: 'pf_bank_txn',
+  payout_status: 'pf_status',
+}
+const DEPOSIT_FIELD_IDS: Record<string, string> = {
+  bank_deposit_total: 'df_total',
+  bank_deposit_date: 'df_date',
+  bank_deposit_bank_transaction_id: 'df_bank_txn',
+  bank_deposit_reference: 'df_reference',
+}
+
+vi.mock('../../../cache', () => ({
+  getCachedEntityDefId: async (_org: string, entityType: string) => {
+    if (entityType === 'bank_transaction') return BT_DEF
+    if (entityType === 'payout') return PAYOUT_DEF
+    if (entityType === 'bank_deposit') return DEPOSIT_DEF
+    return null
+  },
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(attrs.map((attr) => [attr, BT_FIELDS[attr] ?? null])),
+    }),
+  }),
+}))
+
+vi.mock('../../reads', () => ({
+  listBankAccounts: async () => ({ isOk: () => true, isErr: () => false, value: [] }),
+  readCoverage: async () => ({ isOk: () => true, isErr: () => false, value: null }),
+}))
+
+const { listMatchCandidates } = await import('../reads')
+
+/**
+ * One `Database` whose every `select().from(<real schema table>)` resolves to
+ * a fixed row set keyed by TABLE IDENTITY, not by the query's own filters -
+ * `.where()`/`.innerJoin()` are no-ops that return the same chain.
+ *
+ * 🛑 Because every query against one table shares its row set regardless of
+ * which caller issued it, an entity that does not carry a given attribute
+ * reads back `amountMinor: 0` for it and is dropped by the ordinary
+ * zero-amount guard - which is what keeps the bank line's own row (and the
+ * OTHER candidate type's rows) from leaking into a reader that was never
+ * meant to see them.
+ */
+function stubDb(rows: {
+  entityInstance: unknown[]
+  fieldValue: unknown[]
+  customField: unknown[]
+}) {
+  const chain = (data: unknown[]): Record<string, unknown> => {
+    const c: Record<string, unknown> = {}
+    for (const method of ['innerJoin', 'leftJoin', 'where', 'limit', 'groupBy', 'orderBy']) {
+      c[method] = () => chain(data)
+    }
+    // biome-ignore lint/suspicious/noThenProperty: chainable drizzle query-builder stub
+    c.then = (resolve: (value: unknown) => unknown, reject?: (error: unknown) => unknown) =>
+      Promise.resolve(data).then(resolve, reject)
+    return c
+  }
+  return {
+    select: () => ({
+      from: (target: unknown) => {
+        if (target === schema.EntityInstance) return chain(rows.entityInstance)
+        if (target === schema.FieldValue) return chain(rows.fieldValue)
+        if (target === schema.CustomField) return chain(rows.customField)
+        return chain([])
+      },
+    }),
+  } as never
+}
+
+/** The bank line under review: money IN, $5,483.00, on 2026-09-09. */
+function bankLineFieldValues() {
+  return [
+    { entityId: LINE_ID, fieldId: 'f_amount', valueNumber: 548_300 },
+    { entityId: LINE_ID, fieldId: 'f_posted', valueDate: '2026-09-09T00:00:00.000Z' },
+    { entityId: LINE_ID, fieldId: 'f_review', optionId: 'for_review' },
+    { entityId: LINE_ID, fieldId: 'f_bank_status', optionId: 'posted' },
+  ]
+}
+
+function customFieldRows() {
+  return [
+    ...Object.entries(PAYOUT_FIELD_IDS).map(([attr, id]) => ({ id, attr })),
+    ...Object.entries(DEPOSIT_FIELD_IDS).map(([attr, id]) => ({ id, attr })),
+  ]
+}
+
+function payoutFieldValues(over: Record<string, unknown>[] = []) {
+  return [
+    { entityId: 'payout_1', fieldId: 'pf_deposited', valueNumber: 548_300 },
+    { entityId: 'payout_1', fieldId: 'pf_paid_at', valueDate: '2026-09-09T00:00:00.000Z' },
+    { entityId: 'payout_1', fieldId: 'pf_status', optionId: 'paid' },
+    ...over,
+  ]
+}
+
+/** A deposit within the window but NOT an exact amount match, to compare scores against. */
+function depositFieldValues() {
+  return [
+    { entityId: 'deposit_1', fieldId: 'df_total', valueNumber: 547_000 },
+    { entityId: 'deposit_1', fieldId: 'df_date', valueDate: '2026-09-08T00:00:00.000Z' },
+  ]
+}
+
+function entityInstanceRows() {
+  // 🛑 The LINE's own row MUST come first: `readBankTransaction` takes the
+  // first row back from its own (unfiltered, by this stub) query.
+  return [
+    { id: LINE_ID, createdAt: new Date('2026-09-10T00:00:00Z') },
+    { id: 'payout_1', displayName: 'PAY-0004' },
+    { id: 'deposit_1', displayName: 'DEP-0007' },
+  ]
+}
+
+async function allCandidates(fieldValueRows: unknown[]) {
+  const db = stubDb({
+    entityInstance: entityInstanceRows(),
+    fieldValue: fieldValueRows,
+    customField: customFieldRows(),
+  })
+  const result = await listMatchCandidates(db, { organizationId: ORG, transactionId: LINE_ID })
+  if (result.isErr()) throw result.error
+  return result.value
+}
+
+async function payoutCandidates(fieldValueRows: unknown[]) {
+  return (await allCandidates(fieldValueRows)).filter((c) => c.recordType === 'payout')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('readPayoutCandidates', () => {
+  it('offers a payout of the same deposited amount and date for an inbound line', async () => {
+    const found = await payoutCandidates([...bankLineFieldValues(), ...payoutFieldValues()])
+    expect(found).toHaveLength(1)
+    expect(found[0]).toMatchObject({
+      recordType: 'payout',
+      recordId: 'payout_1',
+      label: 'PAY-0004',
+      amountMinor: 548_300,
+      dateKey: '2026-09-09',
+    })
+  })
+
+  it('scores an exact-amount payout above a deposit of a different amount', async () => {
+    const found = await allCandidates([
+      ...bankLineFieldValues(),
+      ...payoutFieldValues(),
+      ...depositFieldValues(),
+    ])
+    const payout = found.find((c) => c.recordType === 'payout')
+    const deposit = found.find((c) => c.recordType === 'bank_deposit')
+    expect(payout).toBeDefined()
+    expect(deposit).toBeDefined()
+    expect(payout?.score).toBeGreaterThan(deposit?.score ?? 0)
+  })
+
+  it('excludes a payout that is not paid or in transit', async () => {
+    const found = await payoutCandidates([
+      ...bankLineFieldValues(),
+      ...payoutFieldValues([{ entityId: 'payout_1', fieldId: 'pf_status', optionId: 'failed' }]),
+    ])
+    expect(found).toHaveLength(0)
+  })
+
+  it('🛑 does not offer a payout already matched to a DIFFERENT bank line', async () => {
+    const found = await payoutCandidates([
+      ...bankLineFieldValues(),
+      ...payoutFieldValues([
+        { entityId: 'payout_1', fieldId: 'pf_bank_txn', valueText: 'txn_other' },
+      ]),
+    ])
+    expect(found).toHaveLength(0)
+  })
+
+  it('still offers a payout already matched to THIS line', async () => {
+    const found = await payoutCandidates([
+      ...bankLineFieldValues(),
+      ...payoutFieldValues([{ entityId: 'payout_1', fieldId: 'pf_bank_txn', valueText: LINE_ID }]),
+    ])
+    expect(found).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/banking/review/__tests__/writes.test.ts
+++ b/packages/lib/src/banking/review/__tests__/writes.test.ts
@@ -906,6 +906,65 @@ describe('matching a customer payment', () => {
   })
 })
 
+// ── Matching a payout posts nothing (brief 18 §1, prevention half) ──────────
+//
+// 🛑 Before this, `listMatchCandidates` offered a Stripe payout's own bank line
+// NOTHING to match, so the only door was Code - which credits clearing a
+// second time (HANDOFF §0.2). Matching a payout has to behave exactly like
+// matching a deposit: link, date, post NOTHING, because the payout's own sync
+// already posted `Dr bank / Cr clearing`.
+describe('matching a payout', () => {
+  it('🛑 posts NOTHING and stamps payout_bank_transaction_id', async () => {
+    row({ amountMinor: 548_300 })
+    h.selectRows = [{ defId: 'def_payout' }]
+    const result = await matchTransaction(db, {
+      organizationId: ORG,
+      actorUserId: ACTOR,
+      transactionId: 'txn_1',
+      recordType: 'payout',
+      recordId: 'payout_1',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(h.postEntry).not.toHaveBeenCalled()
+    if (result.isOk()) expect(result.value.post).toBeNull()
+    expect(updateFor('def_payout:payout_1')).toMatchObject({
+      payout_bank_transaction_id: 'txn_1',
+    })
+  })
+
+  it('refuses a payout already matched to a different bank line, naming it', async () => {
+    row({ amountMinor: 548_300 })
+    h.selectRows = [{ valueText: 'txn_other' }]
+    const result = await matchTransaction(db, {
+      organizationId: ORG,
+      actorUserId: ACTOR,
+      transactionId: 'txn_1',
+      recordType: 'payout',
+      recordId: 'payout_1',
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.message).toMatch(/txn_other/)
+    expect(h.crudUpdate).not.toHaveBeenCalled()
+  })
+
+  it('undo clears payout_bank_transaction_id', async () => {
+    row({
+      reviewStatus: 'matched',
+      matchedRecordId: 'payout_1',
+      matchedRecordType: 'payout',
+    })
+    h.selectRows = [{ defId: 'def_payout' }]
+    const result = await undoReview(db, {
+      organizationId: ORG,
+      actorUserId: ACTOR,
+      transactionId: 'txn_1',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(h.reverseEntry).not.toHaveBeenCalled()
+    expect(updateFor('def_payout:payout_1')).toEqual({ payout_bank_transaction_id: null })
+  })
+})
+
 describe('🛑 bank_account_has_posted - the write-once removal gate', () => {
   /**
    * §5.1 of plans/bank-connection/08-removing-a-bank-account.md, and the reason

--- a/packages/lib/src/banking/review/client.ts
+++ b/packages/lib/src/banking/review/client.ts
@@ -50,6 +50,7 @@ export const MATCH_RECORD_TYPES = [
   'payment_transaction',
   'bank_deposit',
   'vendor_bill',
+  'payout',
   'bank_transaction',
 ] as const
 export type MatchRecordType = (typeof MATCH_RECORD_TYPES)[number]
@@ -83,6 +84,7 @@ export const MATCH_RECORD_TYPE_LABELS: Record<MatchRecordType, string> = {
   payment_transaction: 'Customer payment',
   bank_deposit: 'Bank deposit',
   vendor_bill: 'Vendor bill',
+  payout: 'Payout',
   bank_transaction: 'Bank line',
 }
 

--- a/packages/lib/src/banking/review/reads.ts
+++ b/packages/lib/src/banking/review/reads.ts
@@ -540,6 +540,7 @@ export async function listMatchCandidates(
             ]
           : [
               readBankDepositCandidates(db, organizationId, dateKey, absMinor, search),
+              readPayoutCandidates(db, organizationId, dateKey, absMinor, transactionId, search),
               readTransactionCandidates(db, organizationId, dateKey, absMinor, 'charge', search),
             ]
       )
@@ -740,7 +741,7 @@ function windowDates(dateKey: string, days = CANDIDATE_DAY_WINDOW) {
 async function readEntityCandidates(params: {
   db: Database
   organizationId: string
-  entityType: 'vendor_payment' | 'vendor_bill' | 'bank_deposit'
+  entityType: 'vendor_payment' | 'vendor_bill' | 'bank_deposit' | 'payout'
   recordType: MatchRecordType
   amountAttribute: string
   dateAttribute: string
@@ -749,6 +750,13 @@ async function readEntityCandidates(params: {
   dateKey: string
   absMinor: number
   search?: string
+  /**
+   * A single-select attribute the candidate must carry an allowed option for,
+   * or the row is skipped. Read in memory, same as the amount tolerance below
+   * - the day window has already cut the set to a handful of rows.
+   */
+  statusAttribute?: string | null
+  allowedStatuses?: readonly string[]
 }): Promise<MatchCandidate[]> {
   const { db, organizationId, entityType, dateKey, absMinor, search } = params
   const defId = await getCachedEntityDefId(organizationId, entityType)
@@ -759,6 +767,7 @@ async function readEntityCandidates(params: {
     params.dateAttribute,
     params.linkAttribute,
     params.secondaryAttribute,
+    params.statusAttribute,
   ].filter((attr): attr is string => !!attr)
 
   const fieldRows = await db
@@ -834,6 +843,7 @@ async function readEntityCandidates(params: {
       valueNumber: schema.FieldValue.valueNumber,
       valueDate: schema.FieldValue.valueDate,
       relatedEntityId: schema.FieldValue.relatedEntityId,
+      optionId: schema.FieldValue.optionId,
     })
     .from(schema.FieldValue)
     .where(
@@ -860,6 +870,10 @@ async function readEntityCandidates(params: {
       if (!attr) return null
       const fieldId = fieldIdByAttr.get(attr)
       return fieldId ? (perInstance.get(id)?.get(fieldId) ?? null) : null
+    }
+    if (params.statusAttribute && params.allowedStatuses) {
+      const status = read(params.statusAttribute)?.optionId
+      if (!status || !params.allowedStatuses.includes(status)) continue
     }
     const amountMinor = Math.round(read(params.amountAttribute)?.valueNumber ?? 0)
     if (amountMinor === 0) continue
@@ -960,6 +974,53 @@ function readBankDepositCandidates(
     absMinor,
     search,
   })
+}
+
+/**
+ * Payouts as match candidates for an INBOUND line (brief 18 §1, the half of the
+ * duplicate detector that ships as prevention).
+ *
+ * 🛑 **Restricted to `paid` and `in_transit`.** A `failed` or `reversed` payout
+ * never reached the bank, or was clawed back after arriving - offering it here
+ * would let a reviewer match a real deposit to money that is not actually
+ * sitting in the account.
+ *
+ * ⚠️ **Excluded once matched to a DIFFERENT bank line**, not merely greyed out
+ * the way `bank_deposit` and `vendor_payment` candidates are. A payout has
+ * exactly one bank line that confirms it, and it has already been offered once;
+ * relisting it invites a second reviewer to match a second line to money that
+ * only arrived once. Still offered for THIS line, so re-opening the drawer on a
+ * line already matched to this payout does not read as "nothing here".
+ */
+function readPayoutCandidates(
+  db: Database,
+  organizationId: string,
+  dateKey: string,
+  absMinor: number,
+  transactionId: string,
+  search?: string
+): Promise<MatchCandidate[]> {
+  return readEntityCandidates({
+    db,
+    organizationId,
+    entityType: 'payout',
+    recordType: 'payout',
+    amountAttribute: 'payout_deposited',
+    dateAttribute: 'payout_paid_at',
+    linkAttribute: 'payout_bank_transaction_id',
+    secondaryAttribute: null,
+    statusAttribute: 'payout_status',
+    allowedStatuses: ['paid', 'in_transit'],
+    dateKey,
+    absMinor,
+    search,
+  }).then((candidates) =>
+    candidates.filter(
+      (candidate) =>
+        !candidate.matchedToBankTransactionId ||
+        candidate.matchedToBankTransactionId === transactionId
+    )
+  )
 }
 
 /**
@@ -1199,6 +1260,7 @@ function narrowMatchRecordType(value: string | null | undefined): MatchedRecordT
     case 'payment_transaction':
     case 'bank_deposit':
     case 'vendor_bill':
+    case 'payout':
     case 'bank_transaction':
     // 🛑 `bank_account` belongs here. It is what a transfer with no counterpart
     // yet stamps, and narrowing it away made every stranded first leg read as

--- a/packages/lib/src/banking/review/writes.ts
+++ b/packages/lib/src/banking/review/writes.ts
@@ -963,7 +963,9 @@ async function readDocumentLink(
       ? 'vendor_payment_bank_transaction_id'
       : recordType === 'bank_deposit'
         ? 'bank_deposit_bank_transaction_id'
-        : null
+        : recordType === 'payout'
+          ? 'payout_bank_transaction_id'
+          : null
   if (!attribute) {
     // 🛑 `vendor_bill` has no pointer field of its own - `paid_source` records
     // THAT a bank line confirmed it, never WHICH one - so the only record of the
@@ -1080,6 +1082,16 @@ async function stampDocument(
     await crud.update(toRecordId(defId, recordId), {
       vendor_bill_paid_source: 'bank_import',
     })
+    return
+  }
+  if (recordType === 'payout') {
+    // 🛑 Prevention half of the duplicate detector (brief 18 §1). A matched
+    // payout posts nothing of its own - the payout's own sync already posted
+    // `Dr bank / Cr clearing`, and this bank line is confirmation, not a second
+    // event.
+    await crud.update(toRecordId(defId, recordId), {
+      payout_bank_transaction_id: transactionId,
+    })
   }
 }
 
@@ -1139,6 +1151,10 @@ async function unstampDocument(
   }
   if (recordType === 'vendor_bill') {
     await crud.update(toRecordId(defId, recordId), { vendor_bill_paid_source: null })
+    return
+  }
+  if (recordType === 'payout') {
+    await crud.update(toRecordId(defId, recordId), { payout_bank_transaction_id: null })
   }
 }
 

--- a/packages/lib/src/money/payouts/__tests__/reads.test.ts
+++ b/packages/lib/src/money/payouts/__tests__/reads.test.ts
@@ -26,7 +26,8 @@ vi.mock('../../../cache', () => ({
 }))
 
 import type { Database } from '@auxx/database'
-import { findBankAccountByStripeExternalAccountId } from '../reads'
+import { schema } from '@auxx/database'
+import { findBankAccountByStripeExternalAccountId, listPayouts } from '../reads'
 
 const ORG = 'org_1'
 const BANK_ACCOUNT_DEF = 'def_bank_account'
@@ -123,5 +124,73 @@ describe('findBankAccountByStripeExternalAccountId', () => {
 
     const result = await findBankAccountByStripeExternalAccountId(db, ORG, 'ba_confirmed')
     expect(result).toEqual({ bankAccountId: 'ba_row_1', glAccountId: null })
+  })
+})
+
+// ── `bankTransactionId` (brief 18 §1: payouts become match candidates) ──────
+//
+// Set only by `matchTransaction` (`banking/review/writes.ts`) once a reviewer
+// matches this payout to its bank line. A `paid` payout carrying null here is
+// the payouts page's own `unmatched` signal.
+describe('listPayouts', () => {
+  const PAYOUT_DEF = 'def_payout'
+  const FIELD_IDS: Record<string, string> = {
+    payout_gateway_id: 'f_gateway',
+    payout_status: 'f_status',
+    payout_bank_transaction_id: 'f_bank_txn',
+  }
+
+  /** Every `select().from(<table>)` resolves to a fixed row set by table identity. */
+  function stubPayoutsDb(rows: { entityInstance: unknown[]; fieldValue: unknown[] }): Database {
+    const chain = (data: unknown[]): Record<string, unknown> => {
+      const c: Record<string, unknown> = {}
+      for (const method of ['innerJoin', 'where', 'orderBy', 'limit', 'offset', '$dynamic']) {
+        c[method] = () => chain(data)
+      }
+      // biome-ignore lint/suspicious/noThenProperty: chainable drizzle query-builder stub
+      c.then = (resolve: (value: unknown) => unknown, reject?: (error: unknown) => unknown) =>
+        Promise.resolve(data).then(resolve, reject)
+      return c
+    }
+    return {
+      select: () => ({
+        from: (target: unknown) =>
+          target === schema.EntityInstance ? chain(rows.entityInstance) : chain(rows.fieldValue),
+      }),
+    } as unknown as Database
+  }
+
+  beforeEach(() => {
+    h.getCachedEntityDefId.mockResolvedValue(PAYOUT_DEF)
+    h.bySystemAttributes.mockResolvedValue(
+      Object.fromEntries(Object.entries(FIELD_IDS).map(([attr, id]) => [attr, { id }]))
+    )
+  })
+
+  it('carries bankTransactionId through from payout_bank_transaction_id', async () => {
+    const db = stubPayoutsDb({
+      entityInstance: [{ id: 'payout_1', createdAt: new Date('2026-09-10') }],
+      fieldValue: [
+        { entityId: 'payout_1', fieldId: FIELD_IDS.payout_gateway_id, valueText: 'po_1' },
+        { entityId: 'payout_1', fieldId: FIELD_IDS.payout_status, optionId: 'paid' },
+        { entityId: 'payout_1', fieldId: FIELD_IDS.payout_bank_transaction_id, valueText: 'txn_1' },
+      ],
+    })
+    const result = await listPayouts(db, { organizationId: ORG })
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value[0]?.bankTransactionId).toBe('txn_1')
+  })
+
+  it('is null - the payouts page unmatched signal - until a reviewer matches it', async () => {
+    const db = stubPayoutsDb({
+      entityInstance: [{ id: 'payout_1', createdAt: new Date('2026-09-10') }],
+      fieldValue: [
+        { entityId: 'payout_1', fieldId: FIELD_IDS.payout_gateway_id, valueText: 'po_1' },
+        { entityId: 'payout_1', fieldId: FIELD_IDS.payout_status, optionId: 'paid' },
+      ],
+    })
+    const result = await listPayouts(db, { organizationId: ORG })
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value[0]?.bankTransactionId).toBeNull()
   })
 })

--- a/packages/lib/src/money/payouts/reads.ts
+++ b/packages/lib/src/money/payouts/reads.ts
@@ -37,6 +37,7 @@ const PAYOUT_ATTRIBUTES = [
   'payout_unrecognised_count',
   'payout_gl_posting_id',
   'payout_blocked_reason',
+  'payout_bank_transaction_id',
 ] as const
 
 type PayoutAttribute = (typeof PAYOUT_ATTRIBUTES)[number]
@@ -343,6 +344,7 @@ async function hydrate(
       unrecognisedCount: money('payout_unrecognised_count'),
       glPostingId: read('payout_gl_posting_id')?.valueText ?? null,
       blockedReason: read('payout_blocked_reason')?.valueText ?? null,
+      bankTransactionId: read('payout_bank_transaction_id')?.valueText ?? null,
       createdAt: row.createdAt,
     }
   })

--- a/packages/lib/src/money/payouts/types.ts
+++ b/packages/lib/src/money/payouts/types.ts
@@ -34,6 +34,15 @@ export interface PayoutRecord {
    * and the remedy. Null once posted, or if it never blocked.
    */
   blockedReason: string | null
+  /**
+   * The bank line that confirmed this payout (brief 18 §1, the duplicate
+   * detector's prevention half). Set only by `matchTransaction`
+   * (`banking/review/writes.ts`) when a reviewer matches the payout to its
+   * bank line; cleared by `undoReview`. A `paid` payout with no bank line yet
+   * is a real signal on the payouts page - either the deposit has not landed
+   * or somebody coded it by hand instead of matching it.
+   */
+  bankTransactionId: string | null
   createdAt: Date
 }
 

--- a/packages/lib/src/postings/__tests__/duplicate-movements.test.ts
+++ b/packages/lib/src/postings/__tests__/duplicate-movements.test.ts
@@ -1,0 +1,272 @@
+// packages/lib/src/postings/__tests__/duplicate-movements.test.ts
+//
+// The duplicate detector (plans/accounting/tasks/18-two-feeds-one-author.md
+// §1). `listChartAccounts` is mocked, the same way `account-identities.test.ts`
+// mocks it - what is under test here is the grouping and windowing over the
+// posted lines, not the chart read `role-map.test.ts` already covers.
+//
+// The database is a hand-written stub rather than a mock chain, for
+// `verify-balance.test.ts`'s reason: the module makes one grouped join, and the
+// stub only needs to be awaitable once with a fixed row set - the WHERE clause
+// itself (in particular `status = 'posted'`, which is what actually excludes a
+// reversed original in production) is a SQL concern this file does not
+// re-verify. What IS verified here is that the module's OWN grouping - by
+// account, amount and direction - never puts a reversal's opposite-direction
+// line in the same bucket as the entry it backs out, even if both rows
+// somehow reached it.
+
+const listChartAccounts = vi.fn()
+vi.mock('../role-map', () => ({
+  listChartAccounts: (...a: unknown[]) => listChartAccounts(...a),
+}))
+
+import type { Database } from '@auxx/database'
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { findDuplicateBankMovements } from '../duplicate-movements'
+import type { ChartAccountRow } from '../types'
+
+const ORG = 'org_1'
+
+const BANK_ACCOUNT: ChartAccountRow = {
+  id: 'gl_bank_1010',
+  code: '1010',
+  name: 'Operating Bank',
+  accountType: 'asset',
+  subtype: 'bank',
+  isActive: true,
+}
+
+const NON_BANK_ACCOUNT: ChartAccountRow = {
+  id: 'gl_6100',
+  code: '6100',
+  name: 'Bank Fees',
+  accountType: 'expense',
+  subtype: null,
+  isActive: true,
+}
+
+/** One row as the join in `duplicate-movements.ts` selects it. */
+function candidateRow(overrides: {
+  glPostingId: string
+  docNumber: string
+  txnDate: string
+  glAccountId?: string
+  amountMinor?: number
+  direction?: 'debit' | 'credit'
+  sourceType: string
+}) {
+  return {
+    glPostingId: overrides.glPostingId,
+    docNumber: overrides.docNumber,
+    txnDate: overrides.txnDate,
+    glAccountId: overrides.glAccountId ?? BANK_ACCOUNT.id,
+    amountMinor: overrides.amountMinor ?? 548_300,
+    direction: overrides.direction ?? 'debit',
+    sourceType: overrides.sourceType,
+  }
+}
+
+/**
+ * A stub `Database` that answers whatever chain is built with one row set -
+ * `verify-balance.test.ts`'s stub, copied: the module here makes one join and
+ * does not care whether the caller reaches the rows via `.innerJoin()` or
+ * `.orderBy()`, only that it is awaitable exactly once.
+ */
+function stubDb(rows: unknown[]) {
+  const chain: Record<string, unknown> = {}
+  const passthrough = () => chain
+  for (const method of ['from', 'leftJoin', 'innerJoin', 'where', 'groupBy', 'orderBy', 'limit']) {
+    chain[method] = passthrough
+  }
+  // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
+  chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(rows).then(resolve, reject)
+
+  return { select: () => chain } as unknown as Database
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('findDuplicateBankMovements', () => {
+  it('flags a payout entry and a coded bank line of the same amount, two days apart', async () => {
+    listChartAccounts.mockResolvedValue(ok([BANK_ACCOUNT]))
+
+    const result = await findDuplicateBankMovements(
+      stubDb([
+        candidateRow({
+          glPostingId: 'gl_payout',
+          docNumber: 'PAY-0004',
+          txnDate: '2026-09-09',
+          sourceType: 'payout',
+        }),
+        candidateRow({
+          glPostingId: 'gl_coded',
+          docNumber: 'BNK-0112',
+          txnDate: '2026-09-11',
+          sourceType: 'bank_transaction',
+        }),
+      ]),
+      { organizationId: ORG }
+    )
+
+    const findings = result._unsafeUnwrap()
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      glAccountId: BANK_ACCOUNT.id,
+      accountCode: '1010',
+      accountName: 'Operating Bank',
+      amountMinor: 548_300,
+      direction: 'debit',
+    })
+    expect(findings[0]?.entries.map((entry) => entry.docNumber)).toEqual(['PAY-0004', 'BNK-0112'])
+  })
+
+  it('finds nothing once the line was matched instead of coded, so no second posting exists', async () => {
+    // `matchTransaction` (B5) links a bank line to a document and posts
+    // nothing, so the payout is the only line the query would ever see.
+    listChartAccounts.mockResolvedValue(ok([BANK_ACCOUNT]))
+
+    const result = await findDuplicateBankMovements(
+      stubDb([
+        candidateRow({
+          glPostingId: 'gl_payout',
+          docNumber: 'PAY-0004',
+          txnDate: '2026-09-09',
+          sourceType: 'payout',
+        }),
+      ]),
+      { organizationId: ORG }
+    )
+
+    expect(result._unsafeUnwrap()).toEqual([])
+  })
+
+  it('does not flag two same-amount same-day deposits from one source', async () => {
+    // The `sourceType` guard: two ordinary deposits from the same connector
+    // are not a duplicate, they are two events that happen to be the same size.
+    listChartAccounts.mockResolvedValue(ok([BANK_ACCOUNT]))
+
+    const result = await findDuplicateBankMovements(
+      stubDb([
+        candidateRow({
+          glPostingId: 'gl_dep_1',
+          docNumber: 'DEP-0007',
+          txnDate: '2026-09-10',
+          sourceType: 'bank_deposit',
+        }),
+        candidateRow({
+          glPostingId: 'gl_dep_2',
+          docNumber: 'DEP-0008',
+          txnDate: '2026-09-10',
+          sourceType: 'bank_deposit',
+        }),
+      ]),
+      { organizationId: ORG }
+    )
+
+    expect(result._unsafeUnwrap()).toEqual([])
+  })
+
+  it('does not cross-flag a reversal and the entry it backs out', async () => {
+    // A reversal flips `direction` (decision G4), so even if both rows reached
+    // this module - production's `status = 'posted'` filter should already
+    // have excluded the reversed original - grouping by direction keeps them
+    // in separate buckets.
+    listChartAccounts.mockResolvedValue(ok([BANK_ACCOUNT]))
+
+    const result = await findDuplicateBankMovements(
+      stubDb([
+        candidateRow({
+          glPostingId: 'gl_orig',
+          docNumber: 'PAY-0005',
+          txnDate: '2026-09-09',
+          direction: 'debit',
+          sourceType: 'payout',
+        }),
+        candidateRow({
+          glPostingId: 'gl_rev',
+          docNumber: 'PAY-0005-R1',
+          txnDate: '2026-09-09',
+          direction: 'credit',
+          sourceType: 'payout',
+        }),
+      ]),
+      { organizationId: ORG }
+    )
+
+    expect(result._unsafeUnwrap()).toEqual([])
+  })
+
+  it('never flags lines on a non-bank account, even with a matching amount and two sources', async () => {
+    // The real query filters to `glAccountId IN (<bank account ids>)`, so a
+    // non-bank account's lines never reach the row set at all. This proves the
+    // module's OWN guard as a second line of defence: an id that is not in the
+    // bank-account map it built from the chart is silently skipped rather than
+    // flagged, even when the rows LOOK like a duplicate on their own.
+    listChartAccounts.mockResolvedValue(ok([BANK_ACCOUNT]))
+
+    const result = await findDuplicateBankMovements(
+      stubDb([
+        candidateRow({
+          glPostingId: 'gl_a',
+          docNumber: 'JNL-0001',
+          txnDate: '2026-09-09',
+          glAccountId: NON_BANK_ACCOUNT.id,
+          sourceType: 'vendor_bill',
+        }),
+        candidateRow({
+          glPostingId: 'gl_b',
+          docNumber: 'JNL-0002',
+          txnDate: '2026-09-10',
+          glAccountId: NON_BANK_ACCOUNT.id,
+          sourceType: 'manual_journal',
+        }),
+      ]),
+      { organizationId: ORG }
+    )
+
+    expect(result._unsafeUnwrap()).toEqual([])
+  })
+
+  it('returns ok([]) without querying when the chart has no bank-typed account', async () => {
+    listChartAccounts.mockResolvedValue(ok([NON_BANK_ACCOUNT]))
+
+    const db = { select: vi.fn() } as unknown as Database
+    const result = await findDuplicateBankMovements(db, { organizationId: ORG })
+
+    expect(result._unsafeUnwrap()).toEqual([])
+    expect(db.select).not.toHaveBeenCalled()
+  })
+
+  it('returns err rather than throwing when the chart read fails', async () => {
+    listChartAccounts.mockResolvedValue(err(new Error('chart read broke')))
+
+    const result = await findDuplicateBankMovements(stubDb([]), { organizationId: ORG })
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('returns err rather than throwing when the ledger read fails', async () => {
+    listChartAccounts.mockResolvedValue(ok([BANK_ACCOUNT]))
+    const throwingDb = {
+      select: () => {
+        throw new Error('connection reset')
+      },
+    } as unknown as Database
+
+    const result = await findDuplicateBankMovements(throwingDb, { organizationId: ORG })
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('refuses a malformed month rather than silently matching nothing', async () => {
+    listChartAccounts.mockResolvedValue(ok([BANK_ACCOUNT]))
+
+    const result = await findDuplicateBankMovements(stubDb([]), {
+      organizationId: ORG,
+      month: 'not-a-month',
+    })
+    expect(result.isErr()).toBe(true)
+  })
+})

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -169,6 +169,10 @@ export {
   requiresAssertions,
   reverseAssertions,
 } from './draft'
+// ── plans/accounting/tasks/18: two feeds, one author, unit 1 ───────────────
+// Types only - the read touches `@auxx/database` and stays server-only,
+// exported from `./index`. The close console's card renders this shape.
+export type { DuplicateMovementEntry, DuplicateMovementFinding } from './duplicate-movements'
 export {
   JOURNAL_ENTRY_POSTING_TYPE,
   type JournalEntryKindValue,

--- a/packages/lib/src/postings/duplicate-movements.ts
+++ b/packages/lib/src/postings/duplicate-movements.ts
@@ -1,0 +1,299 @@
+// packages/lib/src/postings/duplicate-movements.ts
+//
+// The duplicate detector (plans/accounting/tasks/18-two-feeds-one-author.md
+// §1, DECIDED by MK "no matter what"). One read over the posted ledger: has
+// more than one door written the same bank account by the same amount, in the
+// same direction, within a few days of each other?
+//
+// ## The failure this catches
+//
+// `postPayoutEntry` debits the bank account a payout lands in. If nobody
+// matches the resulting bank-feed line to that payout (`readPayoutCandidates`
+// is the other half of brief 18 §1, and is not this file), the reviewer's only
+// door is to CODE the line - and `codeTransaction` posts a second entry that
+// debits the same bank account for the same amount a day or two later. Both
+// entries balance. The trial balance balances. Nothing downstream can tell the
+// difference between "the payout landed and was coded twice" and "two
+// unrelated deposits of the same size arrived two days apart" except a human
+// looking at both doc numbers - which is exactly what this read hands them.
+//
+// This is also what closes the `TODO(brief 13 §2.5)` in `regime.ts`:
+// `SINGLE_WRITER_ROLES` could only ever declare a table over ROLES, and a bank
+// account is named by `glAccountId`, never a role, since `13` §2 retired
+// `cash`. A single-writer guard over bank-account ids would have to be
+// declared the same way `findWriterConflicts` is - which posting types may
+// write a given bank account - and that table does not exist because nothing
+// in this codebase enumerates "every posting type that might touch some
+// bank account" the way it enumerates the three inventory roles. Grouping the
+// POSTED LINES themselves, by account and amount and direction, answers the
+// same question - "is more than one door moving this account by this much" -
+// without needing that table at all, and it catches a duplicate a single-writer
+// table could not: two different DOCUMENTS of the same enabled type (a payout
+// and a manually coded fee) both correctly allowed to write the account, that
+// nonetheless collided on one real event.
+//
+// ## Why grouping by (account, amount, direction) already excludes a reversal
+//
+// A reversal (decision G4, `reverse-entry.ts`) is a second, opposite entry:
+// every line's `direction` is flipped from the line it backs out, and the
+// entry it backs out flips to `GlPosting.status = 'reversed'` in the same
+// transaction that posts the reversal. So at any moment at most ONE of a
+// reversal pair carries `status = 'posted'`, and the one that does has the
+// OPPOSITE direction from the one that does not. Filtering to `status =
+// 'posted'` and grouping by `direction` therefore never puts a reversal
+// pair in the same bucket - there is nothing extra to exclude by revision or
+// by `reversesId`.
+//
+// ## Why a coded `bank_transaction` line needs no second read
+//
+// Brief 18 §1 asks about "bank-typed `bank_transaction` codings not yet linked
+// to an entry" as a possible second shape. Reading `codeTransaction`
+// (`banking/review/writes.ts`) settles it: the record's
+// `bank_transaction_gl_account` and `bank_transaction_gl_posting_id` fields are
+// stamped ONLY when `postEntry` returns a status in `ACCEPTED_POST_STATUSES`
+// (`posted`, `already_posted`, `healed`, `not_connected`, `disabled`) - every
+// one of which either wrote a `GlPostingLine` or means there was no ledger to
+// write to. A refused post (an unmapped account, a locked period) leaves the
+// line un-stamped and un-posted. So a coded line with a `gl_account` on it
+// ALWAYS has a matching `GlPostingLine`, and the read below already sees it
+// through that line. There is no second population of "coded but unposted"
+// lines to read separately, and this module does not add one.
+//
+// No permission checks here. The router asserts (`docs/lib-module-guide.md` §6).
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, asc, eq, gte, inArray, lte } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError, BadRequestError } from '../errors'
+import { GlAccountSubtype } from '../resources/registry/enum-values'
+import { parsePeriodKey } from './periods'
+import { listChartAccounts } from './role-map'
+import type { PostingDirection } from './types'
+
+const logger = createScopedLogger('postings:duplicate-movements')
+
+/** How many days apart two lines may post and still count as "the same event". */
+const WINDOW_DAYS = 2
+const MS_PER_DAY = 86_400_000
+
+/** One posted line inside a finding - enough to open the posting from a click. */
+export interface DuplicateMovementEntry {
+  glPostingId: string
+  docNumber: string
+  /** `'payout'`, `'bank_transaction'` - the two shapes brief 18 §0.2 names. */
+  sourceType: string
+  /** `YYYY-MM-DD`, as posted. */
+  txnDate: string
+}
+
+/**
+ * Two or more posted lines that moved one bank account by the same amount, in
+ * the same direction, from more than one `sourceType`, within
+ * {@link WINDOW_DAYS} days of each other.
+ *
+ * Never resolved automatically (brief 18 §1: "a detector that resolves a
+ * duplicate has guessed which one was real"). The remedy is a person choosing
+ * to reverse one entry in auxx or delete one in QuickBooks.
+ */
+export interface DuplicateMovementFinding {
+  glAccountId: string
+  /** Snapshot of the chart as it reads NOW - a finding is a today question. */
+  accountCode: string | null
+  accountName: string
+  amountMinor: number
+  direction: PostingDirection
+  /** Two or more, sorted oldest first. */
+  entries: DuplicateMovementEntry[]
+}
+
+export interface FindDuplicateBankMovementsOptions {
+  organizationId: string
+  /**
+   * `YYYY-MM`. Narrows the read to that month, widened by {@link WINDOW_DAYS}
+   * days on each side so a cluster straddling a month boundary is not cut in
+   * half. Absent scans every posted line ever written to a bank account.
+   */
+  month?: string
+}
+
+/** One candidate row, as the join returns it. */
+interface CandidateLine {
+  glPostingId: string
+  docNumber: string
+  txnDate: string
+  glAccountId: string
+  amountMinor: number
+  direction: PostingDirection
+  sourceType: string
+}
+
+/**
+ * Find every cluster of posted lines that may be the same bank movement
+ * recorded twice (plans/accounting/tasks/18-two-feeds-one-author.md §1).
+ *
+ * **One SQL grouping query, one small in-memory window pass.** The account,
+ * amount and direction grouping - and the `status = 'posted'` filter that
+ * excludes a reversed original - is done by the WHERE clause and read in one
+ * shot; only the "within two days of each other" clustering happens in
+ * TypeScript, because expressing a rolling two-day window as a `GROUP BY` would
+ * need a self-join or a window function per candidate pair for a query this
+ * module runs on close-console page loads, not a monthly close. At roughly
+ * thirty postings a month per organization the candidate set this reads is
+ * small enough that the in-memory pass costs nothing worth optimising away.
+ *
+ * Bank accounts are read from {@link listChartAccounts} rather than
+ * hardcoded: `subtype: 'bank'` is the chart's own declaration of which
+ * accounts a bank feed can land money on (task 15 §5, `13` §3), so an org that
+ * has renamed or added a bank account is covered without this file changing.
+ */
+export async function findDuplicateBankMovements(
+  db: Database,
+  options: FindDuplicateBankMovementsOptions
+): Promise<Result<DuplicateMovementFinding[], Error>> {
+  const { organizationId, month } = options
+
+  try {
+    const chart = await listChartAccounts(db, organizationId)
+    if (chart.isErr()) return err(chart.error)
+
+    const bankAccounts = new Map(
+      chart.value
+        .filter((account) => account.subtype === GlAccountSubtype.BANK)
+        .map((account) => [account.id, account] as const)
+    )
+    // No bank-typed account in this org's chart - nothing to find, and no
+    // point building a query with an empty `IN ()`.
+    if (bankAccounts.size === 0) return ok([])
+
+    const conditions = [
+      eq(schema.GlPosting.organizationId, organizationId),
+      // Excludes a reversed ORIGINAL - see the file header on why that is the
+      // whole of what excluding a reversal pair takes.
+      eq(schema.GlPosting.status, 'posted'),
+      inArray(schema.GlPostingLine.glAccountId, [...bankAccounts.keys()]),
+    ]
+
+    if (month) {
+      const window = monthWindow(month)
+      conditions.push(gte(schema.GlPosting.txnDate, window.from))
+      conditions.push(lte(schema.GlPosting.txnDate, window.to))
+    }
+
+    const rows: CandidateLine[] = await db
+      .select({
+        glPostingId: schema.GlPosting.id,
+        docNumber: schema.GlPosting.docNumber,
+        txnDate: schema.GlPosting.txnDate,
+        glAccountId: schema.GlPostingLine.glAccountId,
+        amountMinor: schema.GlPostingLine.amountMinor,
+        direction: schema.GlPostingLine.direction,
+        sourceType: schema.GlPostingLine.sourceType,
+      })
+      .from(schema.GlPostingLine)
+      .innerJoin(schema.GlPosting, eq(schema.GlPosting.id, schema.GlPostingLine.glPostingId))
+      .where(and(...conditions))
+      .orderBy(asc(schema.GlPosting.txnDate))
+
+    const findings: DuplicateMovementFinding[] = []
+    for (const group of groupByAccountAmountDirection(rows)) {
+      for (const cluster of clusterByWindow(group)) {
+        const sourceTypes = new Set(cluster.map((row) => row.sourceType))
+        // The `sourceType` guard: two lines from the SAME door (two ordinary
+        // same-day deposits from one connector) are not a duplicate, they are
+        // two events that happen to be the same size.
+        if (sourceTypes.size < 2) continue
+
+        const first = cluster[0]
+        if (!first) continue
+        const account = bankAccounts.get(first.glAccountId)
+        if (!account) continue
+
+        findings.push({
+          glAccountId: first.glAccountId,
+          accountCode: account.code,
+          accountName: account.name,
+          amountMinor: first.amountMinor,
+          direction: first.direction,
+          entries: cluster.map((row) => ({
+            glPostingId: row.glPostingId,
+            docNumber: row.docNumber,
+            sourceType: row.sourceType,
+            txnDate: row.txnDate,
+          })),
+        })
+      }
+    }
+
+    return ok(findings)
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to find duplicate bank movements', { error, organizationId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/** Bucket rows sharing one (account, amount, direction) key. Order preserved. */
+function groupByAccountAmountDirection(rows: CandidateLine[]): CandidateLine[][] {
+  const groups = new Map<string, CandidateLine[]>()
+  for (const row of rows) {
+    const key = `${row.glAccountId} ${row.amountMinor} ${row.direction}`
+    const bucket = groups.get(key)
+    if (bucket) bucket.push(row)
+    else groups.set(key, [row])
+  }
+  return [...groups.values()]
+}
+
+/**
+ * Split one (account, amount, direction) group, already sorted by `txnDate`,
+ * into runs where each row is within {@link WINDOW_DAYS} days of the row
+ * before it.
+ *
+ * A chained window rather than an all-pairs comparison: three deposits nine
+ * days apart each from the next are three separate events even though the
+ * first and third are eighteen days apart, but two events four days apart with
+ * one two days from each of them are plausibly one story told twice. Chaining
+ * is the cheap approximation of that and matches every case brief 18 §1 names.
+ */
+function clusterByWindow(sorted: CandidateLine[]): CandidateLine[][] {
+  const clusters: CandidateLine[][] = []
+  let current: CandidateLine[] = []
+
+  for (const row of sorted) {
+    const prev = current.at(-1)
+    if (prev && daysBetween(prev.txnDate, row.txnDate) > WINDOW_DAYS) {
+      clusters.push(current)
+      current = []
+    }
+    current.push(row)
+  }
+  if (current.length > 0) clusters.push(current)
+
+  return clusters
+}
+
+function daysBetween(a: string, b: string): number {
+  return Math.abs(Date.parse(`${a}T00:00:00Z`) - Date.parse(`${b}T00:00:00Z`)) / MS_PER_DAY
+}
+
+/** `'2026-08'` widened by {@link WINDOW_DAYS} days on each side, as date keys. */
+function monthWindow(month: string): { from: string; to: string } {
+  const parsed = parsePeriodKey(month)
+  if (parsed.granularity !== 'month') {
+    throw new BadRequestError(`Expected a YYYY-MM month, got "${month}"`, { month })
+  }
+
+  const start = new Date(Date.UTC(parsed.year, parsed.month - 1, 1))
+  start.setUTCDate(start.getUTCDate() - WINDOW_DAYS)
+
+  // Day 0 of the NEXT month index is the last day of this one.
+  const end = new Date(Date.UTC(parsed.year, parsed.month, 0))
+  end.setUTCDate(end.getUTCDate() + WINDOW_DAYS)
+
+  return { from: toDateKey(start), to: toDateKey(end) }
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -185,6 +185,13 @@ export {
   requiresAssertions,
   reverseAssertions,
 } from './draft'
+// ── plans/accounting/tasks/18: two feeds, one author, unit 1 ───────────────
+export {
+  type DuplicateMovementEntry,
+  type DuplicateMovementFinding,
+  type FindDuplicateBankMovementsOptions,
+  findDuplicateBankMovements,
+} from './duplicate-movements'
 export { gatherMonthEndInventoryInputs } from './gather-month-end-inventory'
 export {
   type CreateJournalEntryInput,

--- a/packages/lib/src/postings/regime.ts
+++ b/packages/lib/src/postings/regime.ts
@@ -23,9 +23,10 @@
 // role, and every cash-touching builder now names a `bank_account`'s own
 // `gl_account` id directly, which this guard cannot see by construction (it
 // only reads `accountRole` lines). `SINGLE_WRITER_ROLES` is back to exactly the
-// three inventory accounts - the guard it can still make mechanically. A
-// single-writer check over bank-account ids is a real gap this leaves open;
-// see the TODO below `SINGLE_WRITER_ROLES`.
+// three inventory accounts - the guard it can still make mechanically. The gap
+// that leaves over bank-account ids is closed by `duplicate-movements.ts`
+// (brief 18 §1) reading what was actually POSTED instead - see the note below
+// `SINGLE_WRITER_ROLES`.
 //
 // `receipt` and `vendor_bill` are present in `POSTING_TYPES` and in the pgEnum,
 // and `buildReceiptEntry` / `buildVendorBillEntry` are written and tested - they
@@ -97,18 +98,16 @@ export const INVENTORY_ROLES: readonly AccountRole[] = [
  * those three are asserted monthly and a hand-keyed line would be reversed by
  * the next close.
  *
- * 🛑 TODO(brief 13 §2.5): a single-writer guard over bank-account
- * `glAccountId`s is still wanted - "is more than one enabled posting type
- * writing this bank account" is a real question now that `cash` is gone as a
- * role, and nothing here answers it. It is deliberately not added in this
- * pass: it needs a table declared over bank-account ids rather than roles
- * (`payout`, `bank_deposit` and the `cash` payment route all write a
- * `bank_account` by id now), which is more than a small function to add
- * honestly - see the header on why this guard being DECLARED rather than
- * derived is the whole point. A later pass adds
- * `findBankAccountWriterConflicts` beside {@link findWriterConflicts}, over its
- * own declared table, once `13` §3's `bank` subtype makes "these ids are bank
- * accounts" answerable without walking the registry.
+ * Closed by brief 18 §1: {@link findDuplicateBankMovements} in
+ * `duplicate-movements.ts` answers "is more than one door writing this bank
+ * account" over the POSTED LINES themselves - grouped by account, amount,
+ * direction and a two-day window - rather than over a declared table of
+ * posting types. A single-writer table never arrived because nothing here
+ * enumerates every posting type that might touch some bank account the way it
+ * enumerates the three inventory roles; reading what was actually posted
+ * answers the same question without one, and catches a duplicate a
+ * single-writer table could not (two different documents of the same enabled
+ * type colliding on one real event).
  */
 export const SINGLE_WRITER_ROLES: readonly AccountRole[] = INVENTORY_ROLES
 
@@ -143,8 +142,8 @@ export const SINGLE_WRITER_ROLES_BY_POSTING_TYPE: Record<PostingType, readonly A
   // `Dr <the chosen bank account> Cr undeposited_funds`, one line per bank run.
   // Names the bank account by its own `glAccountId`, never a role (brief 13
   // §2), so this guard cannot see it on the wire at all - `[]` is now exactly
-  // what the builder emits, not an exemption. See the header's TODO on the
-  // bank-account guard this leaves open.
+  // what the builder emits, not an exemption. See the header's note on
+  // `duplicate-movements.ts`, which is what watches bank accounts instead.
   bank_deposit: [],
   // A matched bank line posts nothing (B5). A CODED line drives the
   // `bank_account`'s own GL account by code, never a role - the bank feed's


### PR DESCRIPTION
## Why

Step 6 of `plans/accounting/HANDOFF-2026-09-10.md`: brief 18 §1, decided "no matter what" (HANDOFF §25.7). auxx could double-count cash on its own: the review drawer never offered a payout for its bank line, so the reviewer could only code it, and coding it to clearing credited that account a second time. Both entries balance, so nothing downstream could see it.

## What

**Prevention.** A payout is now a match candidate for an inbound bank line (`readPayoutCandidates` beside the deposit reader, `payout` on `MATCH_RECORD_TYPES` with its label and icon). Confirming writes `payout_bank_transaction_id` and posts nothing, exactly like a matched deposit; undo clears it. Scoring reuses the existing amount and date weighting, so an exact-amount same-day payout outranks a deposit that is off on either. The payouts page shows the gateway on each row (from the `payment_gateway` record with settlement source `stripe`) and a `matched` or `unmatched` badge, because a paid but unmatched payout means either the deposit has not landed or somebody coded it by hand.

**Detection.** `findDuplicateBankMovements(db, { organizationId, month? })` reads posted lines on `subtype: 'bank'` accounts in one query, groups by account, amount and direction, clusters within two days, and flags a cluster carrying more than one `sourceType`. A reversal never pairs with its original: it flips direction and the original is no longer `posted`. A coded bank line always has a posting when it has an account, so the second pass brief 18 mentions is covered by the ledger read. Rendered as a `DuplicateMovementsCard` on the close console beside the books balance line, naming both doc numbers with a click to open each posting and the sentence "Nothing was changed. Reverse one, or delete it in QuickBooks." Never auto-fixed. This is the guard over bank account ids that retiring `cash` in #2101 left owed; `regime.ts` now points at it.

## Verification

- Biome clean on every changed file, zero em dashes added.
- Web typecheck 0 errors, ratchet baseline 0. Lib ratchet 27 of 27.
- Lib `postings`, `banking` and `money/payouts` suites: 85 files pass. Web accounting and router tests: 56 of 57 files pass; the one failure is the pre-existing file-attachment drizzle mock.
- Not driven in a browser yet; the drive is being attempted after the chart-of-accounts work lands.

https://claude.ai/code/session_01BQLTmsB1p3k7Ki8rWAqzt4
