### PR TITLE
feat(accounting): chart packs, a QuickBooks chart import, and features that bring their accounts

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/__tests__/chart-copy.test.ts
+++ b/apps/web/src/components/accounting/ui/settings/__tests__/chart-copy.test.ts
@@ -1,0 +1,53 @@
+// apps/web/src/components/accounting/ui/settings/__tests__/chart-copy.test.ts
+//
+// Brief 16 §0.7: every screen used to say the default chart was 29 accounts
+// (wrong since migration 125) or that the role map was "the thirteen posting
+// roles" (wrong since the packs split it across five). Both numbers are gone
+// now that the chart is packs, not a flat list - this pins it so a copy-pasted
+// sentence cannot bring either back.
+//
+// `walkTsFiles` follows the pattern in
+// `packages/lib/src/seed/entity-migrations/migrations/108-purchasing.test.ts`.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.next') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walkTsFiles(full, out)
+    else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) out.push(full)
+  }
+  return out
+}
+
+const FORBIDDEN = ['29-account', '29 accounts', 'thirteen', 'all thirteen']
+
+describe('no accounting screen still claims 29 accounts or thirteen roles (16 §5)', () => {
+  it('has none of the retired phrases anywhere under ui/accounting', () => {
+    // `fileURLToPath` is given the STRING, not a `new URL(...)` instance - under
+    // `environment: 'jsdom'` (this package's vitest config) the global `URL`
+    // constructor is jsdom's, and Node's `fileURLToPath` rejects an instance
+    // that is not its own WHATWG URL. Passing the raw string sidesteps that.
+    const here = dirname(fileURLToPath(import.meta.url))
+    const root = join(here, '..', '..', '..') // apps/web/src/components/accounting
+    const offenders: Array<{ file: string; phrase: string }> = []
+
+    for (const file of walkTsFiles(root)) {
+      const rel = relative(root, file).split(sep).join('/')
+      // This file itself names the retired phrases as DATA (the `FORBIDDEN`
+      // list) - it is not a screen and must not fail itself.
+      if (rel.endsWith('.test.ts') || rel.endsWith('.test.tsx')) continue
+      const source = readFileSync(file, 'utf8')
+      const lower = source.toLowerCase()
+      for (const phrase of FORBIDDEN) {
+        if (lower.includes(phrase.toLowerCase())) offenders.push({ file: rel, phrase })
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/apps/web/src/components/accounting/ui/settings/__tests__/pack-picker.test.ts
+++ b/apps/web/src/components/accounting/ui/settings/__tests__/pack-picker.test.ts
@@ -1,0 +1,81 @@
+// apps/web/src/components/accounting/ui/settings/__tests__/pack-picker.test.ts
+//
+// The pure functions behind the pack picker (brief 16 §3.2): the `requires`
+// cascade (`forcedPacks` / `resolveSelectedPacks`) that both the wizard's
+// checkbox card and `chart-packs-dialog.tsx` read, and the wizard's `card_rail`
+// pre-check (`defaultSelectedPacks`). No query, no component - each is total
+// over `CHART_PACKS`.
+
+import { describe, expect, it } from 'vitest'
+import { defaultSelectedPacks, forcedPacks, resolveSelectedPacks } from '../accounts-types'
+
+describe('forcedPacks', () => {
+  it('is empty for a selection with no requires', () => {
+    expect(forcedPacks(new Set(['core']))).toEqual(new Set())
+    expect(forcedPacks(new Set(['core', 'card_rail']))).toEqual(new Set())
+  })
+
+  it('forces inventory on when purchasing is selected (purchasing requires inventory)', () => {
+    expect(forcedPacks(new Set(['purchasing']))).toEqual(new Set(['inventory']))
+  })
+
+  it('does not include a pack already selected directly', () => {
+    // inventory is BOTH directly selected and forced by purchasing - it still
+    // comes back from `forcedPacks` (the caller unions it with `selected`
+    // itself), this just proves selecting it directly does not suppress it.
+    expect(forcedPacks(new Set(['purchasing', 'inventory']))).toEqual(new Set(['inventory']))
+  })
+
+  it('is empty for an empty selection', () => {
+    expect(forcedPacks(new Set())).toEqual(new Set())
+  })
+})
+
+describe('resolveSelectedPacks', () => {
+  it('returns the selection unchanged when nothing is forced', () => {
+    expect(resolveSelectedPacks(new Set(['core', 'card_rail']))).toEqual(['core', 'card_rail'])
+  })
+
+  it('adds the forced pack, so choosing purchasing submits inventory too', () => {
+    expect(resolveSelectedPacks(new Set(['purchasing']))).toEqual(['inventory', 'purchasing'])
+  })
+
+  it('orders the result by CHART_PACK_KEYS declaration order, not selection order', () => {
+    expect(resolveSelectedPacks(new Set(['purchasing', 'core']))).toEqual([
+      'core',
+      'inventory',
+      'purchasing',
+    ])
+  })
+
+  it('is empty for an empty selection', () => {
+    expect(resolveSelectedPacks(new Set())).toEqual([])
+  })
+})
+
+describe('defaultSelectedPacks', () => {
+  it('is core alone with neither card rail signal present', () => {
+    expect(defaultSelectedPacks({ stripeConnect: false, shopify: false })).toEqual(['core'])
+  })
+
+  it('pre-checks card_rail when a Stripe Connect account exists', () => {
+    expect(defaultSelectedPacks({ stripeConnect: true, shopify: false })).toEqual([
+      'core',
+      'card_rail',
+    ])
+  })
+
+  it('pre-checks card_rail when the Shopify app is installed', () => {
+    expect(defaultSelectedPacks({ stripeConnect: false, shopify: true })).toEqual([
+      'core',
+      'card_rail',
+    ])
+  })
+
+  it('pre-checks card_rail once when both signals are present', () => {
+    expect(defaultSelectedPacks({ stripeConnect: true, shopify: true })).toEqual([
+      'core',
+      'card_rail',
+    ])
+  })
+})

--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -59,6 +59,7 @@ import {
   type NewChartAccount,
 } from './chart-account-editor'
 import { ChartList } from './chart-list'
+import { ChartPacksDialog } from './chart-packs-dialog'
 import { RoleMapEditor } from './role-map-editor'
 import { RoleMapList } from './role-map-list'
 
@@ -122,6 +123,9 @@ export function AccountingAccountsSettingsPage() {
   // draft, or on switching tabs - never on a mere re-render.
   const [chartDraft, setChartDraft] = useState<ChartDraftHandle | null>(null)
   const [confirm, ConfirmDialog] = useConfirm()
+  // The Roles tab's "Add accounts" action (brief 16 §3.2) - provisions a named
+  // chart pack without going back through the wizard.
+  const [addAccountsOpen, setAddAccountsOpen] = useState(false)
 
   const roleRows = useMemo<RoleAssignmentRow[]>(() => roleMap.data ?? [], [roleMap.data])
   const accounts = useMemo(() => chart.data ?? [], [chart.data])
@@ -462,7 +466,7 @@ export function AccountingAccountsSettingsPage() {
         {activeTab === 'roles' ? (
           <RoleMapList
             rows={roleRows}
-            // 🛑 Gate on the query, never on an empty array. Thirteen rows
+            // 🛑 Gate on the query, never on an empty array. Every role
             // reading "Not mapped - every preview refuses until this is set"
             // is a CLAIM about the org, and rendering it mid-load makes it a
             // false one.
@@ -470,6 +474,7 @@ export function AccountingAccountsSettingsPage() {
             selectedRole={selectedRole}
             onSelect={setSelectedRole}
             onToggleUnused={handleToggleUnused}
+            onAddAccounts={() => setAddAccountsOpen(true)}
             canControl={canControl}
           />
         ) : (
@@ -490,6 +495,11 @@ export function AccountingAccountsSettingsPage() {
       </MasterDetailSplit>
 
       <ConfirmDialog />
+      <ChartPacksDialog
+        open={addAccountsOpen}
+        onOpenChange={setAddAccountsOpen}
+        roleMap={roleRows}
+      />
     </SettingsPage>
   )
 }

--- a/apps/web/src/components/accounting/ui/settings/accounts-types.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounts-types.ts
@@ -15,7 +15,10 @@ import {
   type AccountRole,
   type AccountSuggestionReason,
   accountSubtypeLabel,
+  CHART_PACK_KEYS,
+  CHART_PACKS,
   type ChartAccountRow,
+  type ChartPackKey,
   GL_ACCOUNT_SUBTYPES,
   type GlAccountSubtypeValue,
   type GlAccountTypeValue,
@@ -158,7 +161,7 @@ export function isMappingBroken(row: AccountIdentityRow): boolean {
  * `ppv` is a report rather than a posting (nothing accumulates in 5090 during
  * the year), and `inventory_wip` is structurally unreachable because
  * `resolveInventoryRoleForPartKind`'s range is raw materials and finished goods
- * only. A map that demanded all thirteen would block Preview on two roles
+ * only. A map that demanded every role would block Preview on two roles
  * nothing can ever post to.
  *
  * ⚠️ Advisory only. The server decides what a role's state IS - this list only
@@ -173,6 +176,54 @@ export const DEFAULT_UNUSED_ROLES: AccountRole[] = ['ppv', 'inventory_wip']
  */
 export function formatAccount(account: ChartAccountRow | null | undefined): string {
   return formatAccountLabel(account)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The pack picker (brief 16 §3.2) - pure, shared by the wizard's checkbox card
+// and the Roles tab's `chart-packs-dialog.tsx`. `CHART_PACKS.requires` is the
+// one declared table (16 §1.6: never derived from the builders), so both
+// pickers read it through these two functions rather than each hand-rolling
+// the cascade.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Which packs a chosen set forces on via `requires` - choosing `purchasing`
+ * forces `inventory` (16 §1.4). Never includes a key already in `selected`
+ * itself; a picker checks AND disables a row that comes back here, because
+ * the person did not choose it directly and cannot un-choose it directly
+ * either.
+ */
+export function forcedPacks(selected: ReadonlySet<ChartPackKey>): Set<ChartPackKey> {
+  const forced = new Set<ChartPackKey>()
+  for (const key of selected) {
+    for (const req of CHART_PACKS[key].requires ?? []) forced.add(req)
+  }
+  return forced
+}
+
+/**
+ * `selected` plus everything it forces on, in `CHART_PACK_KEYS` order - what a
+ * picker actually sends to `provisionChart`. `seedChartPacks` walks `requires`
+ * itself and is idempotent, so sending the forced packs explicitly costs
+ * nothing extra; it is done here so the picker's own "this also adds
+ * Inventory" copy and the packs it submits can never disagree.
+ */
+export function resolveSelectedPacks(selected: ReadonlySet<ChartPackKey>): ChartPackKey[] {
+  const forced = forcedPacks(selected)
+  return CHART_PACK_KEYS.filter((key) => selected.has(key) || forced.has(key))
+}
+
+/**
+ * The wizard picker's initial selection: `core` always, `card_rail`
+ * pre-checked when either card-rail signal is present (16 §3.2,
+ * `ledger.paymentRailsPresent`). Pure so the pre-check rule is one function,
+ * tested without mounting the query that feeds it.
+ */
+export function defaultSelectedPacks(railsPresent: {
+  stripeConnect: boolean
+  shopify: boolean
+}): ChartPackKey[] {
+  return railsPresent.stripeConnect || railsPresent.shopify ? ['core', 'card_rail'] : ['core']
 }
 
 /**

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -47,6 +47,7 @@ import {
   type ChartMapView,
   isMappingBroken,
 } from './accounts-types'
+import { ImportChartButton } from './import-chart-button'
 
 interface ChartListProps {
   accounts: ChartAccountRow[]
@@ -138,6 +139,11 @@ export function ChartList({
               Accept {map.suggested}
             </Button>
           )}
+          {/* Refresh only once the chart holds at least one CONFIRMED mapping -
+              the signal that this chart was either imported or hand-mapped, so a
+              refresh has something to add to rather than nothing to compare
+              against (brief 16 §2.3). */}
+          {canControl && mapped > 0 && <ImportChartButton mode='chart' connected={map.connected} />}
         </div>
       )}
 
@@ -176,7 +182,7 @@ export function ChartList({
           description={
             search
               ? undefined
-              : 'Add accounts here, or let the accounting setup create the 29-account default chart for you.'
+              : 'Add accounts here, or let the accounting setup create the default chart for you.'
           }
         />
       ) : (

--- a/apps/web/src/components/accounting/ui/settings/chart-packs-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-packs-dialog.tsx
@@ -1,0 +1,199 @@
+// apps/web/src/components/accounting/ui/settings/chart-packs-dialog.tsx
+'use client'
+
+// "Add accounts" on the Roles tab (brief 16 §3.2): pick one or more chart
+// packs and provision them, without going through the wizard again.
+//
+// One `TreeRow` per `CHART_PACK_KEYS` entry, in declaration order (`core`
+// first - though `core` reads `provisioned` on any org that has ever mapped a
+// role and therefore never renders a checkbox). `packState` (from
+// `@auxx/lib/postings/client`, derived on the client from `roleMap` and
+// `CHART_PACKS` - no new query) decides how a row reads:
+//
+// - `provisioned` - disabled, with a check. Nothing left for this pack to add.
+// - `partial` - a sentence naming which of its roles are still unmapped, and a
+//   checkbox: re-provisioning is a no-op on what is already mapped
+//   (`seedChartPacks`'s rules 1, 3, 4) and fills only the gap.
+// - `absent` - a plain checkbox.
+//
+// 🛑 `requires` is explained ON the row, not hidden in a tooltip - checking
+// `purchasing` submits `inventory` too (`resolveSelectedPacks`,
+// `accounts-types.ts`), and a person choosing it needs to see that BEFORE
+// pressing Confirm, not discover it afterwards on the chart.
+//
+// 🛑 No success toast (CLAUDE.md). Provisioning is additive and idempotent, so
+// there is nothing here for `useConfirm` to gate.
+
+import {
+  ACCOUNT_ROLE_LABELS,
+  CHART_PACK_KEYS,
+  CHART_PACKS,
+  type ChartPackKey,
+  packState,
+  type RoleAssignmentRow,
+} from '@auxx/lib/postings/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
+import { DialogNav } from '@auxx/ui/components/dialog-nav'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError } from '@auxx/ui/components/toast'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Check, Landmark } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { api } from '~/trpc/react'
+import { forcedPacks, resolveSelectedPacks } from './accounts-types'
+
+interface ChartPacksDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  roleMap: RoleAssignmentRow[]
+}
+
+export function ChartPacksDialog({ open, onOpenChange, roleMap }: ChartPacksDialogProps) {
+  const utils = api.useUtils()
+  const [selected, setSelected] = useState<Set<ChartPackKey>>(new Set())
+
+  // A fresh open starts with nothing picked - the picker does not remember
+  // what somebody chose and cancelled last time.
+  useEffect(() => {
+    if (open) setSelected(new Set())
+  }, [open])
+
+  const provisionChart = api.ledger.provisionChart.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.ledger.roleMap.invalidate(),
+        utils.ledger.chartAccounts.invalidate(),
+      ])
+      onOpenChange(false)
+    },
+    onError: (error) => {
+      toastError({ title: 'Error adding accounts', description: error.message })
+    },
+  })
+
+  const forced = forcedPacks(selected)
+  const packsToSubmit = resolveSelectedPacks(selected)
+
+  function toggle(key: ChartPackKey, checked: boolean) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(key)
+      else next.delete(key)
+      return next
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size='md' position='tc' innerClassName='p-0'>
+        <DialogNav
+          title='Add accounts'
+          description='Provision a chart pack. Each pack points its roles at new accounts and never touches one you already mapped.'
+          crumbs={[{ label: 'Add accounts' }]}
+        />
+
+        <div className={cn('flex flex-col gap-0.5 p-3', TREE_SECONDARY_NOTRUNCATE)}>
+          {CHART_PACK_KEYS.map((key) => (
+            <PackRow
+              key={key}
+              packKey={key}
+              roleMap={roleMap}
+              checked={selected.has(key) || forced.has(key)}
+              forced={forced.has(key)}
+              onToggle={(checked) => toggle(key, checked)}
+            />
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={provisionChart.isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            onClick={() => provisionChart.mutate({ packs: packsToSubmit })}
+            variant='outline'
+            size='sm'
+            loading={provisionChart.isPending}
+            loadingText='Adding...'
+            disabled={packsToSubmit.length === 0}
+            data-dialog-submit>
+            Add accounts <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface PackRowProps {
+  packKey: ChartPackKey
+  roleMap: RoleAssignmentRow[]
+  /** Checked because it was picked directly, or forced on by `requires`. */
+  checked: boolean
+  /** Forced on by another selected pack's `requires` - shown checked, not toggleable. */
+  forced: boolean
+  onToggle: (checked: boolean) => void
+}
+
+function PackRow({ packKey, roleMap, checked, forced, onToggle }: PackRowProps) {
+  const pack = CHART_PACKS[packKey]
+  const state = packState(packKey, roleMap)
+
+  const roles = pack.accounts.flatMap((account) => (account.role ? [account.role] : []))
+  const rowsByRole = new Map(roleMap.map((row) => [row.role, row]))
+  const unmapped = roles.filter(
+    (role) => (rowsByRole.get(role)?.state ?? 'unmapped') === 'unmapped'
+  )
+
+  const requiresNote =
+    pack.requires && pack.requires.length > 0
+      ? `Also adds ${pack.requires.map((req) => CHART_PACKS[req].label).join(', ')}.`
+      : null
+
+  const secondaryParts: string[] = []
+  if (state === 'partial') {
+    secondaryParts.push(
+      `Not mapped: ${unmapped.map((role) => ACCOUNT_ROLE_LABELS[role]).join(', ')}`
+    )
+  } else {
+    secondaryParts.push(`${pack.accounts.length} accounts`)
+  }
+  if (requiresNote) secondaryParts.push(requiresNote)
+
+  return (
+    <TreeRow
+      icon={<Landmark className='size-4 text-muted-foreground' />}
+      title={pack.label}
+      description={pack.description}
+      secondary={
+        <span className='text-muted-foreground text-xs'>{secondaryParts.join(' · ')}</span>
+      }
+      secondaryFill
+      rowClassName={cn('hover:bg-primary-100', state === 'provisioned' && 'opacity-70')}
+      actions={
+        state === 'provisioned' ? (
+          <Badge variant='green' size='xs'>
+            <Check className='size-3' />
+            Provisioned
+          </Badge>
+        ) : (
+          <Checkbox
+            checked={checked}
+            disabled={forced}
+            onCheckedChange={(value) => onToggle(value === true)}
+            aria-label={`Add the ${pack.label} pack`}
+          />
+        )
+      }
+    />
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/import-chart-button.tsx
+++ b/apps/web/src/components/accounting/ui/settings/import-chart-button.tsx
@@ -1,0 +1,136 @@
+// apps/web/src/components/accounting/ui/settings/import-chart-button.tsx
+'use client'
+
+// One component, two doors onto the same mutation (brief 16 §2.2, §2.3):
+//
+// - `mode='wizard'` is the card the accounts page offers over an EMPTY chart,
+//   right next to the pack picker - "take the org's real QuickBooks chart as
+//   the source" instead of a template. Never asks mid-import (16 DECIDED):
+//   the role-bearing core accounts QuickBooks lacks are created uncoded and
+//   unmapped, not held up for a person to answer a question first.
+// - `mode='chart'` is the Chart tab's toolbar action, only ever offered once a
+//   chart already exists and at least one account is confirmed against the
+//   provider - `refreshOnly: true`, so it only ADDS what the provider gained
+//   since the last import and never touches the missing-core accounts again.
+//
+// Both report the result INLINE, never as a success toast (CLAUDE.md - errors
+// only) - "12 added, 41 already here" is the whole point of the mutation and
+// belongs next to the button that triggered it.
+
+import type { ChartImportResult } from '@auxx/lib/postings/client'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { CloudDownload } from 'lucide-react'
+import { useState } from 'react'
+import { api } from '~/trpc/react'
+
+export interface ImportChartButtonProps {
+  /** `'wizard'` renders the accounts-page card; `'chart'` renders the toolbar action. */
+  mode: 'wizard' | 'chart'
+  /** `useAccountingProviderStatus().connected`. Neither mode calls the hook itself - the caller
+   *  already reads it for other reasons, and this keeps the component free of that dependency. */
+  connected: boolean
+  /**
+   * Wizard mode's own `chartIsEmpty` gate, passed through rather than re-derived.
+   * The wizard's card is only ever supposed to render over an empty chart (16
+   * §2.4); when a caller passes `false` here this renders nothing rather than
+   * trust the caller to have gated it out already. Ignored in `'chart'` mode,
+   * where the Refresh action is exactly the opposite case - a chart that
+   * already exists.
+   */
+  chartIsEmpty?: boolean
+  /** Called after a successful import or refresh, in addition to this component's own invalidation. */
+  onImported?: (result: ChartImportResult) => void
+}
+
+/** "12 added, 41 already here" - counts, never a list of rows. */
+function summarise(result: ChartImportResult): string {
+  const added = result.created + result.coreCreated.length
+  return `${added} added, ${result.alreadyImported} already here`
+}
+
+/**
+ * Import (or refresh from) the connected provider's chart of accounts.
+ *
+ * `refreshOnly` follows `mode` directly: the wizard's first import may create
+ * the role-bearing core accounts QuickBooks lacks, the Chart tab's refresh
+ * never does (16 §2.2 step 5).
+ */
+export function ImportChartButton({
+  mode,
+  connected,
+  chartIsEmpty,
+  onImported,
+}: ImportChartButtonProps) {
+  const utils = api.useUtils()
+  const [summary, setSummary] = useState<string | null>(null)
+
+  const importChart = api.ledger.importChartFromProvider.useMutation({
+    onSuccess: async (result) => {
+      setSummary(summarise(result))
+      await Promise.all([
+        utils.ledger.chartAccounts.invalidate(),
+        utils.ledger.roleMap.invalidate(),
+        utils.ledger.accountMap.invalidate(),
+      ])
+      onImported?.(result)
+    },
+    onError: (error) => {
+      toastError({
+        title: mode === 'chart' ? 'Error refreshing from QuickBooks' : 'Error importing the chart',
+        description: error.message,
+      })
+    },
+  })
+
+  if (mode === 'wizard' && chartIsEmpty === false) return null
+  if (mode === 'chart' && !connected) return null
+
+  if (mode === 'chart') {
+    return (
+      <div className='flex flex-wrap items-center gap-2'>
+        <Button
+          variant='outline'
+          size='sm'
+          loading={importChart.isPending}
+          loadingText='Refreshing...'
+          onClick={() => importChart.mutate({ refreshOnly: true })}>
+          <CloudDownload />
+          Refresh from QuickBooks
+        </Button>
+        {summary && <span className='text-muted-foreground text-xs'>{summary}</span>}
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-2 rounded-xl border p-3'>
+      <p className='font-medium text-sm'>Import from QuickBooks</p>
+      {connected ? (
+        <>
+          <p className='text-muted-foreground text-xs'>
+            Bring in every account from your connected QuickBooks company. Accounts it lacks for a
+            posting role are added uncoded and unmapped, ready to map or fill in over there.
+          </p>
+          <div>
+            <Button
+              variant='outline'
+              size='sm'
+              loading={importChart.isPending}
+              loadingText='Importing...'
+              onClick={() => importChart.mutate({ refreshOnly: false })}>
+              <CloudDownload />
+              Import from QuickBooks
+            </Button>
+          </div>
+          {summary && <p className='text-muted-foreground text-xs'>{summary}</p>}
+        </>
+      ) : (
+        <p className='text-muted-foreground text-xs'>
+          Connect QuickBooks on the previous page to import its chart instead of starting from the
+          default one.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
@@ -167,7 +167,7 @@ export function RoleMapEditor({
                 'during the year, so no builder ever emits this role.'
               : 'Work in process is structurally zero. A received part maps to raw materials or ' +
                 'to finished goods and never to work in process, so no movement can reach it.'}{' '}
-            Marking it unused is the expected choice. A map that demanded all thirteen would block
+            Marking it unused is the expected choice. A map that demanded every role would block
             every preview on two roles nothing can post to.
           </p>
         </div>

--- a/apps/web/src/components/accounting/ui/settings/role-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/role-map-list.tsx
@@ -1,7 +1,8 @@
 // apps/web/src/components/accounting/ui/settings/role-map-list.tsx
 'use client'
 
-// The `G19` role map: the thirteen posting roles, grouped by the statement
+// The `G19` role map: every posting role (`Object.values(ACCOUNT_ROLES).length`
+// of them, across five chart packs - brief 16 §1), grouped by the statement
 // classification each one's account must carry (13-accounting-ui.md §5.4).
 //
 // 🛑 A `Section` per group with a FLAT `TreeRow` list, not nested `TreeRow`
@@ -14,9 +15,11 @@
 // roles, so only three of the five groups render. The loop is written over all
 // five anyway, so the day a revenue role is added it appears on its own.
 //
-// 🛑 There are NO phantom drafts on this tab. The thirteen roles are a fixed
-// vocabulary and a person cannot create one; adding a role is a code change to
-// `ACCOUNT_ROLES`.
+// 🛑 There are NO phantom drafts on this tab. The roles are a fixed vocabulary
+// and a person cannot create one; adding a role is a code change to
+// `ACCOUNT_ROLES`. What a person CAN do is provision the accounts a role's pack
+// needs - the "Add accounts" button above the list, opening
+// `chart-packs-dialog.tsx` (brief 16 §3.2).
 //
 // 🛑 The rows come from `ledger.roleMap`, which returns one row for EVERY role
 // whether or not an assignment exists. That is what makes this a checklist, so
@@ -35,10 +38,11 @@ import {
   type RoleAssignmentRow,
 } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
 import { EmptySection, Section } from '@auxx/ui/components/section'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Ban, Coins, CreditCard, Pencil, Receipt, RotateCcw, Sparkles } from 'lucide-react'
+import { Ban, Coins, CreditCard, Pencil, Plus, Receipt, RotateCcw, Sparkles } from 'lucide-react'
 import { AccountLabel } from '../account-label'
 import { ACCOUNT_TYPE_OPTIONS } from './accounts-types'
 
@@ -58,9 +62,11 @@ interface RoleMapListProps {
   selectedRole: AccountRole | null
   onSelect: (role: AccountRole) => void
   onToggleUnused: (role: AccountRole) => void
+  /** Opens `chart-packs-dialog.tsx` (brief 16 §3.2). */
+  onAddAccounts: () => void
   /** `PermissionKey.ledgerControl`. False hides the inline "Change account" /
-   *  "Mark unused" / "Mark used again" `TreeRowButton`s - selecting a row to
-   *  read it stays available. */
+   *  "Mark unused" / "Mark used again" `TreeRowButton`s, and the "Add accounts"
+   *  toolbar button - selecting a row to read it stays available. */
   canControl: boolean
 }
 
@@ -70,10 +76,11 @@ export function RoleMapList({
   selectedRole,
   onSelect,
   onToggleUnused,
+  onAddAccounts,
   canControl,
 }: RoleMapListProps) {
   if (isLoading) {
-    // 🛑 A spinner, never thirteen `unmapped` rows. "Not mapped - every preview
+    // 🛑 A spinner, never every role rendered `unmapped`. "Not mapped - every preview
     // refuses until this is set" is an assertion about the organization, and
     // rendering it before the answer arrives makes it a false one.
     return (
@@ -85,6 +92,14 @@ export function RoleMapList({
 
   return (
     <div className='flex flex-col gap-4 p-3'>
+      {canControl && (
+        <div className='flex items-center justify-end'>
+          <Button variant='outline' size='sm' onClick={onAddAccounts}>
+            <Plus />
+            Add accounts
+          </Button>
+        </div>
+      )}
       {ACCOUNT_TYPE_OPTIONS.map(({ value: type, label }) => {
         const group = rows.filter((row) => ROLE_ACCOUNT_TYPES[row.role as AccountRole] === type)
         // Equity and revenue have no roles today, and an empty section headed

--- a/apps/web/src/components/accounting/ui/setup-wizard/accounting-setup-wizard.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/accounting-setup-wizard.tsx
@@ -17,11 +17,12 @@ import { WizardPeriodPage } from './wizard-period-page'
 import type { WizardLeaveDirection, WizardStepHandle } from './wizard-step-handle'
 import { WizardWelcomePage } from './wizard-welcome-page'
 
-// 🛑 `connect` sits immediately before `accountMap`, and the order is the whole
-// point of the pair: the mapping page cannot render a single row until a
-// provider chart exists to map against. `accounts` (the role map) stays BEFORE
-// both, because a role has to point at one of our accounts before that account
-// has anything to be paired with.
+// 🛑 `connect` moved ahead of `accounts` (brief 16 §1.5, §2.3): the provider's
+// chart can now be the SOURCE of ours (`ImportChartButton mode='wizard'` on the
+// accounts page), so connecting has to happen before the accounts page can
+// offer it. `connect` still sits immediately before `accountMap`, and that pair
+// is unchanged - the mapping page cannot render a single row until a provider
+// chart exists to map against.
 const PAGES = [
   'welcome',
   'period',
@@ -32,8 +33,8 @@ const PAGES = [
   // first and those rows would be blank with no way to fill them.
   'openingTrialBalance',
   'costing',
-  'accounts',
   'connect',
+  'accounts',
   'accountMap',
   'done',
 ] as const
@@ -163,11 +164,11 @@ export function AccountingSetupWizard({ open, onOpenChange }: AccountingSetupWiz
           <DialogNavPage value='costing' size='lg'>
             <WizardCostingPage ref={costingRef} />
           </DialogNavPage>
-          <DialogNavPage value='accounts' size='lg'>
-            <WizardAccountsPage />
-          </DialogNavPage>
           <DialogNavPage value='connect' size='lg'>
             <WizardConnectPage />
+          </DialogNavPage>
+          <DialogNavPage value='accounts' size='lg'>
+            <WizardAccountsPage />
           </DialogNavPage>
           <DialogNavPage value='accountMap' size='xl'>
             <WizardAccountMapPage />

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
@@ -4,16 +4,24 @@
 import {
   ACCOUNT_ROLE_LABELS,
   type AccountRole,
+  CHART_PACK_KEYS,
+  CHART_PACKS,
+  type ChartPackKey,
   type RoleAssignmentState,
 } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
 import { EmptySection } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
 import { ArrowUpRight } from 'lucide-react'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 import { AccountLabel } from '~/components/accounting/ui/account-label'
 import { api } from '~/trpc/react'
+import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
+import { defaultSelectedPacks, forcedPacks, resolveSelectedPacks } from '../settings/accounts-types'
+import { ImportChartButton } from '../settings/import-chart-button'
 
 const ROLES_HREF = '/app/accounting/settings/accounts?s=roles'
 const CHART_HREF = '/app/accounting/settings/accounts?s=chart'
@@ -45,19 +53,49 @@ const STATE_ORDER: Record<RoleAssignmentState, number> = {
  *
  * ⚠️ Two roles typically ship excused rather than unmapped, and that is a decision. Nothing emits
  * `ppv` under L1 (purchase price variance is a report, not a posting) and `inventory_wip` is
- * structurally unreachable, so a map that demanded all thirteen would block every Preview on two
+ * structurally unreachable, so a map that demanded every role would block every Preview on two
  * roles nothing can ever post to.
  *
  * 🛑 `ledger.roleMap` returns a row for EVERY role, mapped or not, so the counts below are a
  * checklist rather than a tally of the rows that happen to exist. The list is not rendered until
- * the query answers: "0 of 13 confirmed" is a claim about the organization, and showing it during
+ * the query answers: "0 confirmed" is a claim about the organization, and showing it during
  * the load would be a false one on the one screen whose whole job is telling somebody what is left
  * to do.
+ *
+ * Over an EMPTY chart (`chartIsEmpty` below), this renders two cards instead: import the org's
+ * real QuickBooks chart (`ImportChartButton mode='wizard'`), or provision a picked set of chart
+ * packs (brief 16 §3.2) - `core` always, `card_rail` pre-checked when a card rail already exists.
  */
 export function WizardAccountsPage() {
   const roleMap = api.ledger.roleMap.useQuery()
   const chart = api.ledger.chartAccounts.useQuery()
   const utils = api.useUtils()
+  const provider = useAccountingProviderStatus()
+  const paymentRailsPresent = api.ledger.paymentRailsPresent.useQuery()
+
+  // The pack picker's selection. `core` is always in it (checked and disabled
+  // below); `card_rail` is added once, the moment `paymentRailsPresent`
+  // answers, so unchecking it afterwards is never fought by this effect.
+  const [selectedPacks, setSelectedPacks] = useState<Set<ChartPackKey>>(() => new Set(['core']))
+  const [railsChecked, setRailsChecked] = useState(false)
+  useEffect(() => {
+    if (railsChecked || !paymentRailsPresent.data) return
+    setRailsChecked(true)
+    setSelectedPacks((prev) => {
+      const next = new Set(prev)
+      for (const key of defaultSelectedPacks(paymentRailsPresent.data)) next.add(key)
+      return next
+    })
+  }, [railsChecked, paymentRailsPresent.data])
+
+  function togglePack(key: ChartPackKey, checked: boolean) {
+    setSelectedPacks((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(key)
+      else next.delete(key)
+      return next
+    })
+  }
 
   const provisionChart = api.ledger.provisionChart.useMutation({
     onSuccess: async () => {
@@ -70,6 +108,10 @@ export function WizardAccountsPage() {
       toastError({ title: 'Error creating the chart', description: error.message })
     },
   })
+
+  async function handleImported() {
+    await Promise.all([utils.ledger.chartAccounts.invalidate(), utils.ledger.roleMap.invalidate()])
+  }
 
   const rows = [...(roleMap.data ?? [])].sort(
     (a, b) =>
@@ -90,6 +132,9 @@ export function WizardAccountsPage() {
   const chartIsEmpty = !chart.isPending && !chart.isError && (chart.data?.length ?? 0) === 0
 
   if (chartIsEmpty) {
+    const forced = forcedPacks(selectedPacks)
+    const packsToSubmit = resolveSelectedPacks(selectedPacks)
+
     return (
       <div className='flex flex-col gap-4 p-4'>
         <p className='text-muted-foreground text-sm'>
@@ -97,22 +142,63 @@ export function WizardAccountsPage() {
           real account in your chart. This organization has no chart yet.
         </p>
 
-        <div className='flex flex-col gap-2 rounded-xl border p-3'>
-          <p className='font-medium text-sm'>Create the default chart of accounts</p>
-          <p className='text-muted-foreground text-xs'>
-            29 accounts, with each posting role pointed at the one that fulfils it. It is a starting
-            template, not a standard - rename, renumber and add your own afterwards, and nothing
-            here is overwritten if you run this again.
-          </p>
-          <div>
-            <Button
-              variant='outline'
-              size='sm'
-              loading={provisionChart.isPending}
-              loadingText='Creating...'
-              onClick={() => provisionChart.mutate()}>
-              Create the default chart
-            </Button>
+        <div className='flex flex-col gap-4 sm:flex-row'>
+          <div className='flex-1'>
+            <ImportChartButton
+              mode='wizard'
+              connected={provider.connected}
+              chartIsEmpty
+              onImported={() => void handleImported()}
+            />
+          </div>
+
+          <div className='flex flex-1 flex-col gap-2 rounded-xl border p-3'>
+            <p className='font-medium text-sm'>Create the default chart of accounts</p>
+            <p className='text-muted-foreground text-xs'>
+              A starting template, not a standard - rename, renumber and add your own afterwards,
+              and nothing here is overwritten if you run this again.
+            </p>
+
+            <div className='flex flex-col gap-1'>
+              {CHART_PACK_KEYS.map((key) => {
+                const pack = CHART_PACKS[key]
+                const isCore = key === 'core'
+                const checked = isCore || selectedPacks.has(key) || forced.has(key)
+                const disabled = isCore || forced.has(key)
+                return (
+                  <label
+                    key={key}
+                    className='flex items-start gap-2 rounded-md p-1 hover:bg-muted/50'>
+                    <Checkbox
+                      className='mt-0.5'
+                      checked={checked}
+                      disabled={disabled}
+                      onCheckedChange={(value) => togglePack(key, value === true)}
+                    />
+                    <span className='flex min-w-0 flex-col'>
+                      <span className='text-sm'>
+                        {pack.label}{' '}
+                        <span className='text-muted-foreground text-xs'>
+                          · {pack.accounts.length} accounts
+                        </span>
+                      </span>
+                      <span className='text-muted-foreground text-xs'>{pack.description}</span>
+                    </span>
+                  </label>
+                )
+              })}
+            </div>
+
+            <div>
+              <Button
+                variant='outline'
+                size='sm'
+                loading={provisionChart.isPending}
+                loadingText='Creating...'
+                onClick={() => provisionChart.mutate({ packs: packsToSubmit })}>
+                Create the default chart
+              </Button>
+            </div>
           </div>
         </div>
 

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-connect-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-connect-page.tsx
@@ -12,9 +12,13 @@
 // same reason, and `getting-started.ts` records that `connect-quickbooks` is
 // deliberately not a checklist goal.
 //
-// What the step DOES earn its place with is ordering. The next page cannot show
-// a single row until a provider chart exists to map against, so connecting has
-// to happen before it rather than in a settings page somebody visits later.
+// What the step DOES earn its place with is ordering, and brief 16 §2.3 doubled
+// the reason for it: the very next page ("accounts") can now offer "Import from
+// QuickBooks" as the source of the org's chart, which needs a connection to say
+// anything about, so connecting has to come first. The account map two pages
+// later still cannot show a single row until a provider chart exists to map
+// against, so it keeps following `connect` too - the pair just has "accounts"
+// between them now instead of sitting back to back.
 //
 // 🛑 CONNECT AND MANAGE OPEN `AppSettingsDialog`, they do not navigate - the
 // same call `quickbooks-section.tsx` makes. Sending somebody to
@@ -71,8 +75,8 @@ export function WizardConnectPage() {
           {status.connected ? (
             <>
               <p className='text-muted-foreground text-xs'>
-                {status.connection?.label ?? 'Connected'}. On the next page you will say which
-                account in QuickBooks each of your accounts corresponds to.
+                {status.connection?.label ?? 'Connected'}. On the next page you can import your
+                QuickBooks chart, or start from the default one.
               </p>
               <div>
                 <Button variant='outline' size='sm' onClick={() => setDialogOpen(true)}>

--- a/apps/web/src/server/api/routers/ledger-permissions.test.ts
+++ b/apps/web/src/server/api/routers/ledger-permissions.test.ts
@@ -41,9 +41,22 @@ vi.mock('@auxx/lib/seed', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@auxx/lib/seed')
   return {
     ...actual,
-    seedDefaultChartOfAccounts: vi.fn(async () => ({ created: 0, assigned: 0 })),
-    // Task 13 §5.3: `provisionChart` seeds the two default payment gateways
-    // right after the chart. Mocked the same way its neighbour above is - the
+    // Echoes `packs` back as the walked set rather than actually expanding
+    // `requires` - none of the packs this file provisions in a test need a
+    // dependency walked in, and `chart-import-plan.test.ts` / the lib-side
+    // `gl-account-chart.test.ts` are where `requires` expansion itself is
+    // pinned. Brief 16 §1.5.
+    seedChartPacks: vi.fn(
+      async (_db: unknown, _orgId: string, _defId: string, packs: string[]) => ({
+        created: 0,
+        skipped: 0,
+        rolesAssigned: 0,
+        packs,
+      })
+    ),
+    // Task 13 §5.3 / brief 16 §1.5: `provisionChart` seeds the two default
+    // payment gateways right after the chart, gated on the walked packs
+    // including `card_rail`. Mocked the same way its neighbour above is - the
     // "admit" case only needs `provisionChart` to resolve, not to exercise
     // `seedDefaultPaymentGateways`'s own `GlRoleAssignment` read against a db
     // double this file does not otherwise stub.
@@ -115,6 +128,7 @@ const { bankingRouter } = await import('./banking')
 const { settingsRouter } = await import('./setting')
 const { GL_ACCOUNT_TYPES, ACCOUNT_ROLES } = await import('@auxx/lib/postings')
 const { BANK_ACCOUNT_TYPES } = await import('@auxx/lib/banking')
+const { seedDefaultPaymentGateways } = await import('@auxx/lib/seed')
 
 type Capabilities = InstanceType<typeof CapabilitySet>
 
@@ -228,6 +242,21 @@ describe('ledger chart-structure writes: Edit refused, Full admitted', () => {
 
   it('provisionChart admits ledger: Full', async () => {
     await expect(ledgerCaller(ledgerFull()).provisionChart()).resolves.toBeDefined()
+  })
+
+  // Brief 16 §1.5: `seedDefaultPaymentGateways` is gated on the WALKED packs
+  // including `card_rail`, never called from the core walk alone. This is a
+  // router-level gate (`ledger.ts`'s `provisionChart`), not something
+  // `seedChartPacks` itself decides, so it is pinned here rather than in
+  // `seed/gl-account-chart-payment-gateways.test.ts`.
+  it('never seeds payment gateways after provisioning only core', async () => {
+    await ledgerCaller(ledgerFull()).provisionChart({ packs: ['core'] })
+    expect(seedDefaultPaymentGateways).not.toHaveBeenCalled()
+  })
+
+  it('seeds payment gateways after provisioning card_rail', async () => {
+    await ledgerCaller(ledgerFull()).provisionChart({ packs: ['card_rail'] })
+    expect(seedDefaultPaymentGateways).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -1,12 +1,14 @@
 // apps/web/src/server/api/routers/ledger.ts
 
-import { getCachedEntityDefId, onCacheEvent } from '@auxx/lib/cache'
+import { getCachedEntityDefId, getCachedInstalledApps, onCacheEvent } from '@auxx/lib/cache'
 import { UnprocessableEntityError } from '@auxx/lib/errors'
+import { getPaymentAccount } from '@auxx/lib/money'
 import { PermissionKey } from '@auxx/lib/permissions'
 import {
   ACCOUNT_ROLES,
   assertAccountingSetupUnfrozen,
   buildEntry,
+  CHART_PACK_KEYS,
   confirmSuggestedIdentities,
   createChartAccount,
   createJournalEntry,
@@ -16,6 +18,7 @@ import {
   GL_ACCOUNT_TYPES,
   getJournalEntry,
   getPosting,
+  importChartFromProvider,
   listAccountIdentities,
   listChartAccounts,
   listChartAccountUsage,
@@ -43,7 +46,7 @@ import {
   updateJournalEntry,
   verifyBooksBalance,
 } from '@auxx/lib/postings'
-import { seedDefaultChartOfAccounts, seedDefaultPaymentGateways } from '@auxx/lib/seed'
+import { seedChartPacks, seedDefaultPaymentGateways } from '@auxx/lib/seed'
 import { updateOrganizationSetting } from '@auxx/lib/settings'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
@@ -630,50 +633,114 @@ export const ledgerRouter = createTRPCRouter({
   ),
 
   /**
-   * Write the 29-account default chart, and point each role at the account that
-   * fulfils it.
+   * Write the requested chart PACKS, and point each role at the account that
+   * fulfils it (brief 16 §1.5).
+   *
+   * `packs` defaults to `['core']`, and `core` is walked whether or not it is
+   * named: a bare `provisionChart()` - what the wizard's button sent before
+   * the pack picker existed - still means the core, and the picker and the
+   * Roles tab's Add accounts action both name their packs explicitly. A
+   * pack's own `requires` is expanded transitively before the walk runs, so
+   * `{ packs: ['purchasing'] }` also lands `inventory`.
    *
    * ── Why this is a BUTTON and not part of creating an organization ──
    *
    * `gl_account`'s DEFINITION ships with every org (`SYSTEM_ENTITIES`), but its
-   * ROWS do not, deliberately: most orgs never open the accounting module, and 29
-   * `EntityInstance`s plus 13 `GlRoleAssignment`s each is a chart nobody asked for
-   * in a table everybody has to scan. Provisioning is the first step of setting
-   * accounting up, so it lives where somebody has said they want accounting.
+   * ROWS do not, deliberately: most orgs never open the accounting module, and
+   * a chart nobody asked for is a table everybody has to scan. Provisioning is
+   * the first step of setting accounting up, so it lives where somebody has
+   * said they want accounting.
    *
-   * 🛑 It also closes a real hole. `seedDefaultChartOfAccounts`' only other caller
-   * is entity migration 108, which reaches production through the DataMigration
+   * 🛑 It also closes a real hole. `seedChartPacks`' only other caller is
+   * entity migration 108, which reaches production through the DataMigration
    * ledger - and `DataMigration.id` is the PRIMARY KEY, one global row, no
    * `organizationId`. Once 108 is `applied` it never runs again, so **every org
-   * created after that deploy would have had a def, no accounts, thirteen
-   * unmapped roles and no way to fix it.** This is that way.
+   * created after that deploy would have had a def, no accounts, and every core
+   * role unmapped with no way to fix it.** This is that way.
    *
-   * Safe to press twice: the seed is idempotent on `code` and its assignments are
-   * `ON CONFLICT (organizationId, role) DO NOTHING`, so a second press reports
-   * `created: 0` and cannot disturb an account or a mapping somebody has edited.
-   * That is `seedDefaultChartOfAccounts`' rules 1, 3 and 4, and they are the whole
-   * reason this can be offered as a button at all.
+   * Safe to press twice, for any set of packs: the seed is idempotent on `code`
+   * and its assignments are `ON CONFLICT (organizationId, role) DO NOTHING`, so
+   * a second press over an already-provisioned pack reports `created: 0` and
+   * cannot disturb an account or a mapping somebody has edited. That is
+   * `seedChartPacks`' rules 1, 3 and 4, and they are the whole reason this can
+   * be offered as a button at all - and the whole reason the Roles tab's Add
+   * accounts action can re-walk a `partial` pack without asking which rows are
+   * already there.
    */
-  provisionChart: permissionProcedure(PermissionKey.ledgerControl).mutation(async ({ ctx }) => {
+  provisionChart: permissionProcedure(PermissionKey.ledgerControl)
+    .input(
+      // Brief 16 §1.5. The outer `.default` keeps a bare `provisionChart()`
+      // meaning the core, which is what the wizard's button sent before the
+      // pack picker existed; the picker and the Roles tab's Add accounts both
+      // name their packs explicitly.
+      z
+        .object({ packs: z.array(z.enum(CHART_PACK_KEYS)).default(['core']) })
+        .default({ packs: ['core'] })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+
+      const glAccountDefId = await getCachedEntityDefId(organizationId, 'gl_account')
+      if (!glAccountDefId) {
+        throw new UnprocessableEntityError(
+          'This organization has no gl_account definition, so there is nothing to seed a chart into. Run the entity migrations.',
+          { organizationId }
+        )
+      }
+
+      const chart = await seedChartPacks(ctx.db, organizationId, glAccountDefId, input.packs)
+
+      // Task 13 §5.3: the two default `payment_gateway` records the census
+      // names. Runs AFTER the chart on purpose - the clearing accounts these
+      // defaults point at (`clearing_card` / `clearing_affirm`) only exist once
+      // the chart above has just created or confirmed them. Brief 16 §1.5 ties
+      // them to the `card_rail` pack; gated on the WALKED packs, not the
+      // requested ones, so `requires` expansion is honoured (though nothing
+      // requires `card_rail` today, so the two currently agree).
+      const paymentGateways = chart.packs.includes('card_rail')
+        ? await seedDefaultPaymentGateways(ctx.db, organizationId)
+        : null
+
+      return { ...chart, paymentGateways }
+    }),
+
+  /**
+   * Import the connected provider's chart of accounts as the org's own
+   * (brief 16 §2). Creates only what the org lacks, sets each new account's
+   * identity, assigns the unambiguous roles as `suggested`, and adds the
+   * role-bearing core accounts the provider has no counterpart for.
+   *
+   * Same rung as `provisionChart`: this decides where money lands.
+   * `refreshOnly` is the Chart tab's door and never creates the missing core.
+   */
+  importChartFromProvider: permissionProcedure(PermissionKey.ledgerControl)
+    .input(z.object({ refreshOnly: z.boolean().optional() }))
+    .mutation(async ({ ctx, input }) => {
+      const result = await importChartFromProvider(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        actorUserId: ctx.session.userId,
+        refreshOnly: input.refreshOnly,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Which card rails this org already has, so the wizard can pre-check the
+   * `card_rail` pack (brief 16 §3.2). Facts about the org, not switches: a
+   * Stripe Connect account is the read the payouts sync makes, and the Shopify
+   * app is the `installedApps` cache. Nothing provisions off either (16 §3.3).
+   */
+  paymentRailsPresent: permissionProcedure(PermissionKey.ledgerView).query(async ({ ctx }) => {
     const { organizationId } = ctx.session
-
-    const glAccountDefId = await getCachedEntityDefId(organizationId, 'gl_account')
-    if (!glAccountDefId) {
-      throw new UnprocessableEntityError(
-        'This organization has no gl_account definition, so there is nothing to seed a chart into. Run the entity migrations.',
-        { organizationId }
-      )
+    const [account, installedApps] = await Promise.all([
+      getPaymentAccount(organizationId),
+      getCachedInstalledApps(organizationId),
+    ])
+    return {
+      stripeConnect: Boolean(account?.stripeAccountId),
+      shopify: installedApps.some((installed) => installed.app.slug === 'shopify'),
     }
-
-    const chart = await seedDefaultChartOfAccounts(ctx.db, organizationId, glAccountDefId)
-
-    // Task 13 §5.3: the two default `payment_gateway` records the census
-    // names. Runs AFTER the chart on purpose - the clearing accounts these
-    // defaults point at (`clearing_card` / `clearing_affirm`) only exist once
-    // the chart above has just created or confirmed them.
-    const paymentGateways = await seedDefaultPaymentGateways(ctx.db, organizationId)
-
-    return { ...chart, paymentGateways }
   }),
 
   /**

--- a/packages/lib/scripts/reset-gl-chart.ts
+++ b/packages/lib/scripts/reset-gl-chart.ts
@@ -16,8 +16,9 @@
 // ── Why this is a script and NOT the entity migration itself ────────────────
 //
 // `gl_account` has never existed anywhere but this machine in the exact shape
-// this script corrects (no `role` field, 29 accounts, `2150` broadened, `5095`
-// added); entity migration 108, which created the def in that shape, has only
+// this script corrects (no `role` field, the pre-packs 37-account flat chart,
+// `2150` broadened, `5095` added); entity migration 108, which created the def
+// in that shape, has only
 // ever run against local dev and is `applied` in the local `DataMigration`
 // ledger and nowhere else (confirmed 2026-08-28). Migration 142 wipes the
 // chart everywhere, including here; this script exists for the same reason it
@@ -29,7 +30,7 @@
 //
 //   - 784 `gl_account` rows, 28 accounts x 28 orgs.
 //   - 0 `FieldValue` rows pointing AT a `gl_account` instance.
-//   - 0 `RecordIdentity` rows on a `gl_account` instance — no provider's own
+//   - 0 `RecordIdentity` rows on a `gl_account` instance - no provider's own
 //     account id is lost.
 //   - 0 `GlPosting` / `GlPostingLine` rows.
 //   - No human edits: the 336 rows with `updatedAt > createdAt` were all touched
@@ -119,7 +120,7 @@ async function resetOrg(organizationId: string): Promise<OrgResult | null> {
 
     if (identities.length > 0) {
       throw new Error(
-        `Organization ${organizationId} has ${identities.length}+ RecordIdentity row(s) on a gl_account instance; refusing to wipe the chart. Those carry a connected provider's own account id (decision P2) and cascade away with the instance — wiping them is unrecoverable. Re-import the chart from the provider instead.`
+        `Organization ${organizationId} has ${identities.length}+ RecordIdentity row(s) on a gl_account instance; refusing to wipe the chart. Those carry a connected provider's own account id (decision P2) and cascade away with the instance - wiping them is unrecoverable. Re-import the chart from the provider instead.`
       )
     }
   }
@@ -134,7 +135,7 @@ async function resetOrg(organizationId: string): Promise<OrgResult | null> {
   // ── 2. The chart itself ──────────────────────────────────────────────────
   //
   // `FieldValue` has no foreign key to `EntityInstance`, so its rows are deleted
-  // explicitly and FIRST — bottom-up, the order entity migration 114 uses. An
+  // explicitly and FIRST - bottom-up, the order entity migration 114 uses. An
   // orphaned value row would otherwise outlive its instance and become
   // unreachable rather than merely wrong.
   if (accountIds.length > 0) {
@@ -195,7 +196,7 @@ async function main() {
       'setup wizard is the way back.'
   )
   console.log(
-    "Verify in Postgres — this script's own counts are not the witness:\n" +
+    "Verify in Postgres - this script's own counts are not the witness:\n" +
       '  SELECT count(*) FROM "CustomField" WHERE "systemAttribute" = \'gl_account_role\';  -- 0\n' +
       '  SELECT count(*) FROM "GlRoleAssignment";                                          -- 0 per org'
   )

--- a/packages/lib/src/postings/__tests__/chart-import-plan.test.ts
+++ b/packages/lib/src/postings/__tests__/chart-import-plan.test.ts
@@ -1,0 +1,248 @@
+// packages/lib/src/postings/__tests__/chart-import-plan.test.ts
+//
+// `planChartImport` is pure - no database, no doubles - so every test here
+// hands it plain arrays and a map and reads the plan back.
+
+import { describe, expect, it } from 'vitest'
+import {
+  PROVIDER_ACCOUNT_TYPE_SUBTYPE,
+  planChartImport,
+  ROLE_IMPORT_MATCH,
+} from '../chart-import-plan'
+import { CHART_PACKS } from '../default-chart'
+import { SUBTYPE_PROVIDER_ACCOUNT_TYPES } from '../suggest-account-identities'
+import type { ChartAccountRow, ProviderAccount, RoleAssignmentRow } from '../types'
+
+function providerAccount(over: Partial<ProviderAccount> = {}): ProviderAccount {
+  return {
+    id: 'p1',
+    name: 'Checking',
+    fullyQualifiedName: 'Checking',
+    number: null,
+    accountType: 'Bank',
+    classification: 'asset',
+    active: true,
+    ...over,
+  }
+}
+
+/** Every declared role, `unmapped` unless overridden. */
+function roleMap(overrides: Record<string, RoleAssignmentRow['state']> = {}): RoleAssignmentRow[] {
+  const roles = new Set<string>(Object.keys(ROLE_IMPORT_MATCH))
+  for (const account of CHART_PACKS.core.accounts) {
+    if (account.role) roles.add(account.role)
+  }
+  return [...roles].map((role) => ({
+    role,
+    state: overrides[role] ?? 'unmapped',
+    accountId: null,
+    account: null,
+    source: null,
+    confirmedAt: null,
+  }))
+}
+
+const EMPTY_CHART: readonly ChartAccountRow[] = []
+
+describe('PROVIDER_ACCOUNT_TYPE_SUBTYPE is consistent with SUBTYPE_PROVIDER_ACCOUNT_TYPES', () => {
+  it('maps every entry to a subtype whose allowed list contains that provider type', () => {
+    for (const [providerType, subtype] of Object.entries(PROVIDER_ACCOUNT_TYPE_SUBTYPE)) {
+      const allowed = SUBTYPE_PROVIDER_ACCOUNT_TYPES[subtype] ?? []
+      expect(allowed, `${providerType} -> ${subtype}`).toContain(providerType)
+    }
+  })
+
+  it('deliberately omits Other Current Asset', () => {
+    expect(PROVIDER_ACCOUNT_TYPE_SUBTYPE['Other Current Asset']).toBeUndefined()
+  })
+})
+
+describe('create', () => {
+  it('turns the provider number into the code, and a missing number into null', () => {
+    const plan = planChartImport(
+      [
+        providerAccount({ id: 'p1', number: '1000' }),
+        providerAccount({ id: 'p2', number: null, name: 'No Number' }),
+      ],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+
+    expect(plan.create.find((c) => c.providerAccount.id === 'p1')?.code).toBe('1000')
+    expect(plan.create.find((c) => c.providerAccount.id === 'p2')?.code).toBeNull()
+  })
+
+  it('stamps classification as accountType and the declared inverse as subtype', () => {
+    const plan = planChartImport(
+      [providerAccount({ id: 'p1', accountType: 'Bank', classification: 'asset' })],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+
+    const created = plan.create[0]!
+    expect(created.accountType).toBe('asset')
+    expect(created.subtype).toBe('bank')
+  })
+
+  it('leaves the subtype null for an ambiguous provider type', () => {
+    const plan = planChartImport(
+      [providerAccount({ id: 'p1', accountType: 'Other Current Asset' })],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+
+    expect(plan.create[0]?.subtype).toBeNull()
+  })
+
+  it('skips an inactive account entirely', () => {
+    const plan = planChartImport(
+      [providerAccount({ id: 'p1', active: false })],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+
+    expect(plan.create).toHaveLength(0)
+    expect(plan.skippedInactive.map((a) => a.id)).toEqual(['p1'])
+  })
+
+  it('reports an already-imported account by provider id, even when renamed', () => {
+    const plan = planChartImport(
+      [providerAccount({ id: 'p1', name: 'Renamed Since Import' })],
+      EMPTY_CHART,
+      new Map([['gl1', 'p1']]),
+      roleMap()
+    )
+
+    expect(plan.create).toHaveLength(0)
+    expect(plan.alreadyImported).toEqual([
+      {
+        providerAccount: expect.objectContaining({ id: 'p1', name: 'Renamed Since Import' }),
+        glAccountId: 'gl1',
+      },
+    ])
+  })
+})
+
+describe('roleCandidates', () => {
+  it('resolves accounts_receivable to the one Accounts Receivable subtype account', () => {
+    const plan = planChartImport(
+      [
+        providerAccount({
+          id: 'ar1',
+          accountType: 'Accounts Receivable',
+          classification: 'asset',
+        }),
+      ],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+
+    expect(plan.roleCandidates).toContainEqual({
+      role: 'accounts_receivable',
+      match: 'subtype',
+      providerAccountId: 'ar1',
+    })
+  })
+
+  it('leaves the role unresolved when two candidates tie', () => {
+    const plan = planChartImport(
+      [
+        providerAccount({ id: 'ar1', accountType: 'Accounts Receivable', classification: 'asset' }),
+        providerAccount({ id: 'ar2', accountType: 'Accounts Receivable', classification: 'asset' }),
+      ],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+
+    expect(plan.roleCandidates.some((c) => c.role === 'accounts_receivable')).toBe(false)
+  })
+
+  it('never proposes a candidate for a role that is already mapped', () => {
+    const plan = planChartImport(
+      [providerAccount({ id: 'ar1', accountType: 'Accounts Receivable', classification: 'asset' })],
+      EMPTY_CHART,
+      new Map(),
+      roleMap({ accounts_receivable: 'confirmed' })
+    )
+
+    expect(plan.roleCandidates.some((c) => c.role === 'accounts_receivable')).toBe(false)
+  })
+
+  it('matches Undeposited Funds by plain name and by a fully-qualified one', () => {
+    const plainPlan = planChartImport(
+      [
+        providerAccount({
+          id: 'u1',
+          name: 'Undeposited Funds',
+          accountType: 'Other Current Asset',
+        }),
+      ],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+    expect(plainPlan.roleCandidates).toContainEqual({
+      role: 'undeposited_funds',
+      match: 'name',
+      providerAccountId: 'u1',
+    })
+
+    const qualifiedPlan = planChartImport(
+      [
+        providerAccount({
+          id: 'u2',
+          name: 'Undeposited Funds',
+          fullyQualifiedName: 'Bank:Undeposited Funds',
+          accountType: 'Other Current Asset',
+        }),
+      ],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+    expect(qualifiedPlan.roleCandidates).toContainEqual({
+      role: 'undeposited_funds',
+      match: 'name',
+      providerAccountId: 'u2',
+    })
+  })
+})
+
+describe('missingCore', () => {
+  it('lists each core role-bearing account with no candidate, and nothing else', () => {
+    // Nothing in the provider chart resolves any role, so every core
+    // role-bearing account is missing.
+    const plan = planChartImport(
+      [providerAccount({ id: 'p1', name: 'Something Unrelated', accountType: 'Fixed Asset' })],
+      EMPTY_CHART,
+      new Map(),
+      roleMap()
+    )
+
+    const expectedRoles = CHART_PACKS.core.accounts.flatMap((a) => (a.role ? [a.role] : []))
+    expect(plan.missingCore.map((a) => a.role).sort()).toEqual(expectedRoles.sort())
+    // Nothing else - every entry comes from the core pack alone.
+    for (const account of plan.missingCore) {
+      expect(CHART_PACKS.core.accounts).toContain(account)
+    }
+  })
+
+  it('excludes a core role a candidate resolved, and one already mapped', () => {
+    const plan = planChartImport(
+      [providerAccount({ id: 'ar1', accountType: 'Accounts Receivable', classification: 'asset' })],
+      EMPTY_CHART,
+      new Map(),
+      roleMap({ accounts_payable: 'confirmed' })
+    )
+
+    const roles = plan.missingCore.map((a) => a.role)
+    expect(roles).not.toContain('accounts_receivable')
+    expect(roles).not.toContain('accounts_payable')
+  })
+})

--- a/packages/lib/src/postings/__tests__/chart-import.test.ts
+++ b/packages/lib/src/postings/__tests__/chart-import.test.ts
@@ -1,0 +1,307 @@
+// packages/lib/src/postings/__tests__/chart-import.test.ts
+//
+// `chart-import.ts` is the WRITER half; everything it reads or writes through a
+// collaborator is stubbed the way `chart-write.test.ts` and
+// `account-identities.test.ts` stub theirs - an `AccountingProvider` double for
+// the provider seam, `../role-map` and `../chart-write` mocked at the module
+// boundary, and a hand-written `db` for the one raw write this file makes
+// itself: the `GlRoleAssignment` insert. `chart-import-plan.ts` is NOT mocked -
+// the real planner runs, so these tests exercise the actual ordering and
+// idempotency the writer promises on top of it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const listChartAccounts = vi.fn()
+const listRoleMap = vi.fn()
+vi.mock('../role-map', () => ({
+  listChartAccounts: (...a: unknown[]) => listChartAccounts(...a),
+  listRoleMap: (...a: unknown[]) => listRoleMap(...a),
+}))
+
+const createChartAccountMock = vi.fn()
+vi.mock('../chart-write', () => ({
+  createChartAccount: (...a: unknown[]) => createChartAccountMock(...a),
+}))
+
+const resolveAccountingProvider = vi.fn()
+vi.mock('../provider', () => ({
+  resolveAccountingProvider: (...a: unknown[]) => resolveAccountingProvider(...a),
+  NONE_PROVIDER_ID: 'none',
+}))
+
+import type { Database } from '@auxx/database'
+import { err, ok, type Result } from 'neverthrow'
+import { UniqueValueConflictError, UnprocessableEntityError } from '../../errors'
+import { importChartFromProvider } from '../chart-import'
+import type { ChartAccountRow, ProviderAccount, RoleAssignmentRow } from '../types'
+
+const ORG = 'org1'
+const USER = 'user1'
+
+function providerAccount(over: Partial<ProviderAccount> = {}): ProviderAccount {
+  return {
+    id: 'p1',
+    name: 'Checking',
+    fullyQualifiedName: 'Checking',
+    number: null,
+    accountType: 'Bank',
+    classification: 'asset',
+    active: true,
+    ...over,
+  }
+}
+
+/** Every declared role this module cares about, `unmapped` unless overridden. */
+function roleMapRows(
+  overrides: Record<string, RoleAssignmentRow['state']> = {}
+): RoleAssignmentRow[] {
+  const roles = [
+    'accounts_receivable',
+    'accounts_payable',
+    'undeposited_funds',
+    'sales_tax_payable',
+    'equity_retained_earnings',
+    'equity_opening_balance',
+    'bad_debt_expense',
+    'revenue_product',
+    'revenue_shipping',
+    'revenue_service',
+    'revenue_returns_allowances',
+  ]
+  return roles.map((role) => ({
+    role,
+    state: overrides[role] ?? 'unmapped',
+    accountId: null,
+    account: null,
+    source: null,
+    confirmedAt: null,
+  }))
+}
+
+/** A provider whose relevant methods answer from the arguments given. */
+function stubProvider(
+  options: { id?: string; accounts?: ProviderAccount[]; mappings?: Map<string, string> } = {}
+) {
+  const setAccountMapping = vi.fn<() => Promise<Result<void, Error>>>(async () => ok(undefined))
+  const provider = {
+    id: options.id ?? 'stub',
+    listProviderAccounts: async () => ok(options.accounts ?? []),
+    listAccountMappings: async () => ok(options.mappings ?? new Map<string, string>()),
+    setAccountMapping,
+  }
+  resolveAccountingProvider.mockResolvedValue(provider)
+  return { setAccountMapping }
+}
+
+/** A `db` whose only real job is the `GlRoleAssignment` insert this module makes itself. */
+function stubDb(alreadyAssigned: Set<string> = new Set()) {
+  const insertedRows: {
+    organizationId: string
+    role: string
+    glAccountId: string
+    source: string
+  }[] = []
+  const db = {
+    insert: () => ({
+      values: (row: {
+        organizationId: string
+        role: string
+        glAccountId: string
+        source: string
+      }) => ({
+        onConflictDoNothing: () => ({
+          returning: async () => {
+            const key = `${row.organizationId}:${row.role}`
+            if (alreadyAssigned.has(key)) return []
+            alreadyAssigned.add(key)
+            insertedRows.push(row)
+            return [{ id: `assignment_${row.role}` }]
+          },
+        }),
+      }),
+    }),
+  } as unknown as Database
+  return { db, insertedRows }
+}
+
+let callLog: string[]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  callLog = []
+  createChartAccountMock.mockImplementation(
+    async (_db: Database, opts: Record<string, unknown>) => {
+      const name = opts.name as string
+      callLog.push(`create:${name}:${opts.code ?? 'null'}`)
+      return ok({
+        id: `gl_${name.replace(/\s+/g, '_').toLowerCase()}`,
+        code: (opts.code as string | null) ?? null,
+        name,
+        accountType: opts.accountType,
+        subtype: (opts.subtype as string | null) ?? null,
+        isActive: true,
+      } as ChartAccountRow)
+    }
+  )
+  listChartAccounts.mockResolvedValue(ok<ChartAccountRow[]>([]))
+})
+
+describe('nothing connected', () => {
+  it('refuses with UnprocessableEntityError rather than reporting an empty success', async () => {
+    stubProvider({ id: 'none', accounts: [] })
+    listRoleMap.mockResolvedValue(ok(roleMapRows()))
+    const { db } = stubDb()
+
+    const result = await importChartFromProvider(db, { organizationId: ORG, actorUserId: USER })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UnprocessableEntityError)
+  })
+})
+
+describe('a normal import', () => {
+  it('creates in provider order, sets each identity right after its create, and assigns unmapped roles as import', async () => {
+    const ar = providerAccount({
+      id: 'p_ar',
+      name: 'Accounts Receivable',
+      accountType: 'Accounts Receivable',
+      classification: 'asset',
+    })
+    const other = providerAccount({ id: 'p_other', name: 'Checking', accountType: 'Bank' })
+    const { setAccountMapping } = stubProvider({ accounts: [other, ar] })
+    listRoleMap.mockResolvedValue(ok(roleMapRows()))
+    const { db, insertedRows } = stubDb()
+
+    const result = await importChartFromProvider(db, { organizationId: ORG, actorUserId: USER })
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.created).toBe(2)
+    expect(value.alreadyImported).toBe(0)
+    expect(value.skippedInactive).toBe(0)
+    expect(value.rolesAssigned).toEqual(['accounts_receivable'])
+
+    // Created in provider order, and each identity set right after its own create -
+    // the missing-core creates (asserted below via `coreCreated`) land after both.
+    expect(callLog.slice(0, 2)).toEqual(['create:Checking:null', 'create:Accounts Receivable:null'])
+    expect(setAccountMapping).toHaveBeenNthCalledWith(1, {
+      orgId: ORG,
+      glAccountId: 'gl_checking',
+      providerAccountId: 'p_other',
+      actorUserId: USER,
+    })
+    expect(setAccountMapping).toHaveBeenNthCalledWith(2, {
+      orgId: ORG,
+      glAccountId: 'gl_accounts_receivable',
+      providerAccountId: 'p_ar',
+      actorUserId: USER,
+    })
+
+    // The import-assigned role.
+    expect(insertedRows).toContainEqual({
+      organizationId: ORG,
+      role: 'accounts_receivable',
+      glAccountId: 'gl_accounts_receivable',
+      source: 'import',
+    })
+
+    // Every other core role-bearing account with no candidate was created,
+    // uncoded, with no identity - `setAccountMapping` was never called for them.
+    const coreOnlyCalls = value.coreCreated.map((a) => a.role)
+    expect(coreOnlyCalls).not.toContain('accounts_receivable')
+    expect(coreOnlyCalls.length).toBeGreaterThan(0)
+    for (const account of value.coreCreated) {
+      expect(insertedRows).toContainEqual(
+        expect.objectContaining({ role: account.role, source: 'seed' })
+      )
+    }
+    expect(setAccountMapping).toHaveBeenCalledTimes(2)
+  })
+
+  it('never touches a role that is already mapped', async () => {
+    const ar = providerAccount({
+      id: 'p_ar',
+      name: 'Accounts Receivable',
+      accountType: 'Accounts Receivable',
+      classification: 'asset',
+    })
+    stubProvider({ accounts: [ar] })
+    listRoleMap.mockResolvedValue(ok(roleMapRows({ accounts_receivable: 'confirmed' })))
+    const { db, insertedRows } = stubDb()
+
+    const result = await importChartFromProvider(db, { organizationId: ORG, actorUserId: USER })
+
+    expect(result._unsafeUnwrap().rolesAssigned).toEqual([])
+    expect(insertedRows.some((row) => row.role === 'accounts_receivable')).toBe(false)
+  })
+})
+
+describe('a code collision', () => {
+  it('creates the account without a code, logs it, and completes the run', async () => {
+    createChartAccountMock.mockImplementation(
+      async (_db: Database, opts: Record<string, unknown>) => {
+        const name = opts.name as string
+        const code = opts.code as string | null
+        callLog.push(`create:${name}:${code ?? 'null'}`)
+        if (code) {
+          return err(
+            new UniqueValueConflictError({
+              message: `${code} is already in use.`,
+              conflictingValue: code,
+              fieldId: 'fld_code',
+            })
+          )
+        }
+        return ok({
+          id: `gl_${name.replace(/\s+/g, '_').toLowerCase()}`,
+          code: null,
+          name,
+          accountType: opts.accountType,
+          subtype: (opts.subtype as string | null) ?? null,
+          isActive: true,
+        } as ChartAccountRow)
+      }
+    )
+
+    const account = providerAccount({ id: 'p1', number: '1000', name: 'Cash Overseas' })
+    const { setAccountMapping } = stubProvider({ accounts: [account] })
+    listRoleMap.mockResolvedValue(ok(roleMapRows()))
+    const { db } = stubDb()
+
+    const result = await importChartFromProvider(db, { organizationId: ORG, actorUserId: USER })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().created).toBe(1)
+    expect(callLog.slice(0, 2)).toEqual(['create:Cash Overseas:1000', 'create:Cash Overseas:null'])
+    expect(setAccountMapping).toHaveBeenCalledWith(
+      expect.objectContaining({ glAccountId: 'gl_cash_overseas', providerAccountId: 'p1' })
+    )
+  })
+})
+
+describe('refreshOnly', () => {
+  it('never creates the missing core', async () => {
+    const ar = providerAccount({
+      id: 'p_ar',
+      name: 'Accounts Receivable',
+      accountType: 'Accounts Receivable',
+      classification: 'asset',
+    })
+    stubProvider({ accounts: [ar] })
+    listRoleMap.mockResolvedValue(ok(roleMapRows()))
+    const { db } = stubDb()
+
+    const result = await importChartFromProvider(db, {
+      organizationId: ORG,
+      actorUserId: USER,
+      refreshOnly: true,
+    })
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.coreCreated).toEqual([])
+    // Only the one provider account was created - no core accounts.
+    expect(value.created).toBe(1)
+    expect(value.rolesAssigned).toEqual(['accounts_receivable'])
+  })
+})

--- a/packages/lib/src/postings/__tests__/default-chart.test.ts
+++ b/packages/lib/src/postings/__tests__/default-chart.test.ts
@@ -10,15 +10,34 @@
 // drift instead: `ROLE_ACCOUNT_TYPES` and `ACCOUNT_ROLE_LABELS`, both keyed by
 // role, and both of which a new role must be added to in the same change.
 //
+// Brief 16 split the chart into packs. The union pins below run over
+// `DEFAULT_CHART_OF_ACCOUNTS` (every pack flattened); the per-pack pins are
+// what stop a role drifting from the pack whose builders drive it.
+//
 // Only an EXACT-set assertion catches a removal; a subset assertion passes
 // forever.
 
 import { describe, expect, it } from 'vitest'
 import { GlAccountType } from '../../resources/registry/enum-values'
 import { ACCOUNT_ROLE_LABELS, ACCOUNT_ROLES, ROLE_ACCOUNT_TYPES } from '../build-entry'
-import { DEFAULT_CHART_OF_ACCOUNTS } from '../default-chart'
+import {
+  CHART_PACK_KEYS,
+  CHART_PACKS,
+  type ChartPackKey,
+  DEFAULT_CHART_OF_ACCOUNTS,
+  packForRole,
+  packState,
+} from '../default-chart'
+import type { RoleAssignmentRow } from '../types'
 
 const CODE_ROLE_VALUES = Object.values(ACCOUNT_ROLES)
+
+const rolesOf = (pack: ChartPackKey) =>
+  CHART_PACKS[pack].accounts.flatMap((account) => (account.role ? [account.role] : []))
+
+const codesOf = (pack: ChartPackKey) => CHART_PACKS[pack].accounts.map((account) => account.code)
+
+const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
 
 describe('the role vocabulary is one vocabulary', () => {
   it('declares no role twice', () => {
@@ -62,7 +81,15 @@ describe('the chart agrees with the declared account types', () => {
   })
 })
 
-describe('the default chart', () => {
+describe('the union of every pack', () => {
+  it('is the packs flattened in declaration order, core first', () => {
+    expect(CHART_PACK_KEYS[0]).toBe('core')
+    expect(CHART_PACK_KEYS).toEqual(Object.keys(CHART_PACKS))
+    expect(DEFAULT_CHART_OF_ACCOUNTS).toEqual(
+      CHART_PACK_KEYS.flatMap(codesOf).map((c) => byCode.get(c))
+    )
+  })
+
   it('has a unique code per account - `code` is the org-unique identity', () => {
     const codes = DEFAULT_CHART_OF_ACCOUNTS.map((account) => account.code)
     expect(new Set(codes).size).toBe(codes.length)
@@ -78,91 +105,154 @@ describe('the default chart', () => {
   })
 
   // THE uniqueness rule the `role` field's `unique: true` capability enforces at
-  // the write door. Asserted on the seed data too, because the seeder is a
-  // single writer and a duplicate here would be written before any gate runs.
-  it('assigns each role to AT MOST one account', () => {
+  // the write door, and the other half: a role no account carries is a builder
+  // that cannot post. `assertAccountRolesResolve` would fail the entry with
+  // `account_unmapped` before the period was claimed - correct behaviour, but it
+  // should never be reachable from the DEFAULT chart, which is the whole point
+  // of shipping the roles pre-assigned (`G8`). Exact set, both directions.
+  it('assigns every role in ACCOUNT_ROLES exactly once', () => {
     const assigned = DEFAULT_CHART_OF_ACCOUNTS.flatMap((account) =>
       account.role ? [account.role] : []
     )
     expect(new Set(assigned).size).toBe(assigned.length)
+    expect([...assigned].sort()).toEqual([...CODE_ROLE_VALUES].sort())
   })
 
-  // The other half: a role no account carries is a builder that cannot post.
-  // `assertAccountRolesResolve` would fail the entry with `account_unmapped`
-  // before the period was claimed - correct behaviour, but it should never be
-  // reachable from the DEFAULT chart, which is the whole point of shipping the
-  // roles pre-assigned (`G8`).
-  it('assigns EVERY role the builders can emit', () => {
-    const assigned = new Set(
-      DEFAULT_CHART_OF_ACCOUNTS.flatMap((account) => (account.role ? [account.role] : []))
+  // The four LFK-only accounts brief 16 dropped (DECIDED, 16.3). Role-less and
+  // one company's bookkeeping; an org adds them by hand where wanted. Pinned so
+  // they are not quietly parked in a pack.
+  it('carries none of the four dropped accounts', () => {
+    for (const code of ['1190', '2100', '2400', '6200']) {
+      expect(byCode.has(code), code).toBe(false)
+    }
+  })
+
+  it('totals thirty-three accounts: thirteen core, five, two, nine and four', () => {
+    expect(codesOf('core')).toHaveLength(13)
+    expect(codesOf('card_rail')).toHaveLength(5)
+    expect(codesOf('prepayments')).toHaveLength(2)
+    expect(codesOf('inventory')).toHaveLength(9)
+    expect(codesOf('purchasing')).toHaveLength(4)
+    expect(DEFAULT_CHART_OF_ACCOUNTS).toHaveLength(33)
+  })
+})
+
+describe('the core', () => {
+  // Brief 16 §1.3. A role added to the core later has to argue with this test:
+  // every one of these is reachable by an ENABLED posting type on any org that
+  // sends an invoice, takes a payment, ships an order, issues a credit memo or
+  // writes something off. Exact set.
+  it('carries exactly the eleven roles every org can reach', () => {
+    expect([...rolesOf('core')].sort()).toEqual(
+      [
+        ACCOUNT_ROLES.UNDEPOSITED_FUNDS,
+        ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
+        ACCOUNT_ROLES.ACCOUNTS_PAYABLE,
+        ACCOUNT_ROLES.SALES_TAX_PAYABLE,
+        ACCOUNT_ROLES.EQUITY_RETAINED_EARNINGS,
+        ACCOUNT_ROLES.EQUITY_OPENING_BALANCE,
+        ACCOUNT_ROLES.REVENUE_PRODUCT,
+        ACCOUNT_ROLES.REVENUE_SHIPPING,
+        ACCOUNT_ROLES.REVENUE_SERVICE,
+        ACCOUNT_ROLES.REVENUE_RETURNS_ALLOWANCES,
+        ACCOUNT_ROLES.BAD_DEBT_EXPENSE,
+      ].sort()
     )
-    expect([...CODE_ROLE_VALUES].filter((role) => !assigned.has(role))).toEqual([])
   })
 
-  it('leaves the accounts auxx does not post to role-less', () => {
-    // Role-less is the ORDINARY case, not a gap. Pinned so that a future edit
-    // that reflexively gives every account a role has to argue with a test.
-    const roleless = DEFAULT_CHART_OF_ACCOUNTS.filter((account) => !account.role)
-    expect(roleless.length).toBeGreaterThan(0)
-    // `1210 Affirm Clearing` used to be the example here and no longer is: the
-    // fulfillment debit fork gained `clearing_affirm` (49 §8.4 decision 6), so
-    // the account a builder now posts to carries a role like every other.
-    expect(roleless.map((account) => account.code)).toContain('6105') // Merchant Fees - Affirm
-    expect(roleless.map((account) => account.code)).toContain('6200') // Fulfillment Labor
-  })
-
-  // 2110 Payroll Clearing carries assembly labour that CAPITALISES into
-  // inventory; 6200 Fulfillment Labor is pick/pack/receive and explicitly does
-  // NOT. Collapsing them into one "labour" role would misstate COGS, so the
-  // split is pinned rather than left to a reader's care.
-  it('keeps capitalised assembly labour and non-inventory fulfilment labour apart', () => {
-    const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
-    expect(byCode.get('2110')?.role).toBe(ACCOUNT_ROLES.PAYROLL_CLEARING)
-    expect(byCode.get('6200')?.role).toBeUndefined()
-  })
-
-  // Inbound freight is CAPITALISED into landed cost and accrues to a liability;
-  // outbound freight is an expense above gross profit. Two different freights.
-  it('does not point the freight accrual role at outbound freight', () => {
-    const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
-    expect(byCode.get('2150')?.role).toBe(ACCOUNT_ROLES.FREIGHT_ACCRUAL)
-    expect(byCode.get('5030')?.role).toBeUndefined()
-  })
-
-  it('carries the four accounts the accrual plan does not list but a builder needs', () => {
-    const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
-    expect(byCode.get('2000')?.role).toBe(ACCOUNT_ROLES.ACCOUNTS_PAYABLE)
-    expect(byCode.get('2160')?.role).toBe(ACCOUNT_ROLES.GRNI)
-    expect(byCode.get('2170')?.role).toBe(ACCOUNT_ROLES.DUTIES_ACCRUAL)
-    expect(byCode.get('5095')?.role).toBe(ACCOUNT_ROLES.INVENTORY_COUNT_VARIANCE)
+  it('is exactly the thirteen accounts §1.3 names', () => {
+    expect(codesOf('core')).toEqual([
+      '1000',
+      '1050',
+      '1100',
+      '2000',
+      '2200',
+      '3000',
+      '3100',
+      '3900',
+      '4000',
+      '4020',
+      '4030',
+      '4090',
+      '6300',
+    ])
   })
 
   // `cash` retired as a posting role (brief 13 §2): `1000 Cash` is kept as an
   // ordinary bank account, mappable like any other, and carries no role at all.
   it('keeps 1000 Cash as a plain bank account, with no role', () => {
-    const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
     expect(byCode.get('1000')?.role).toBeUndefined()
     expect(byCode.get('1000')?.subtype).toBe('bank')
   })
 
+  it('stamps the receivable and payable subtypes the QuickBooks seam reads', () => {
+    expect(byCode.get('1100')?.subtype).toBe('accounts_receivable')
+    expect(byCode.get('2000')?.subtype).toBe('accounts_payable')
+  })
+
+  it('names 1100 plainly - one receivable whatever the channel (handoff 6.1)', () => {
+    expect(byCode.get('1100')?.name).toBe('Accounts Receivable')
+    expect(byCode.get('1100')?.role).toBe(ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE)
+  })
+})
+
+describe('the other packs', () => {
+  it('put every non-core role in the pack whose builders drive it', () => {
+    expect([...rolesOf('card_rail')].sort()).toEqual(
+      [
+        ACCOUNT_ROLES.CLEARING_CARD,
+        ACCOUNT_ROLES.CLEARING_AFFIRM,
+        ACCOUNT_ROLES.UNIDENTIFIED_RECEIPTS,
+        ACCOUNT_ROLES.PAYMENT_PROCESSING_FEES,
+      ].sort()
+    )
+    expect([...rolesOf('prepayments')].sort()).toEqual(
+      [ACCOUNT_ROLES.DEFERRED_REVENUE, ACCOUNT_ROLES.CUSTOMER_DEPOSITS].sort()
+    )
+    expect([...rolesOf('inventory')].sort()).toEqual(
+      [
+        ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS,
+        ACCOUNT_ROLES.INVENTORY_WIP,
+        ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS,
+        ACCOUNT_ROLES.PAYROLL_CLEARING,
+        ACCOUNT_ROLES.COGS_PRODUCT_COST,
+        ACCOUNT_ROLES.APPLIED_OVERHEAD,
+        ACCOUNT_ROLES.INVENTORY_COUNT_VARIANCE,
+      ].sort()
+    )
+    expect([...rolesOf('purchasing')].sort()).toEqual(
+      [
+        ACCOUNT_ROLES.FREIGHT_ACCRUAL,
+        ACCOUNT_ROLES.GRNI,
+        ACCOUNT_ROLES.DUTIES_ACCRUAL,
+        ACCOUNT_ROLES.PPV,
+      ].sort()
+    )
+  })
+
   // `G12`: count/shrinkage value must land somewhere OTHER than purchase price
-  // variance. One account holding both makes the two indistinguishable in every
-  // period total, which is the whole reason the second account exists.
-  it('keeps purchase price variance and inventory count variance apart', () => {
-    const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
+  // variance. Different owner, different remedy - so different packs, and the
+  // refusal an unmapped role produces names a different pack for each.
+  it('keeps 5090 in purchasing and 5095 in inventory', () => {
+    expect(codesOf('purchasing')).toContain('5090')
+    expect(codesOf('inventory')).toContain('5095')
     expect(byCode.get('5090')?.role).toBe(ACCOUNT_ROLES.PPV)
     expect(byCode.get('5095')?.role).toBe(ACCOUNT_ROLES.INVENTORY_COUNT_VARIANCE)
-    expect(byCode.get('5090')?.role).not.toBe(byCode.get('5095')?.role)
+  })
+
+  // Inbound freight is CAPITALISED into landed cost and accrues to a liability;
+  // outbound freight is an expense above gross profit. Two different freights.
+  it('does not point the freight accrual role at outbound freight', () => {
+    expect(byCode.get('2150')?.role).toBe(ACCOUNT_ROLES.FREIGHT_ACCRUAL)
+    expect(byCode.get('5030')?.role).toBeUndefined()
   })
 
   // `G17`: a customs broker's service charge is landed cost and clears through
   // 2150, not through 2170. Three files used to say otherwise. The account NAME
-  // is what a bookkeeper reads, so it is the thing pinned here — the ROLE stays
+  // is what a bookkeeper reads, so it is the thing pinned here; the ROLE stays
   // `freight_accrual` on purpose.
   it('names 2150 for brokerage as well as freight', () => {
-    const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((a) => [a.code, a]))
     expect(byCode.get('2150')?.name).toBe('Inbound Freight & Brokerage Accrual')
-    expect(byCode.get('2150')?.role).toBe(ACCOUNT_ROLES.FREIGHT_ACCRUAL)
     expect(byCode.get('2170')?.name).toBe('Duties Accrual')
   })
 
@@ -170,7 +260,96 @@ describe('the default chart', () => {
   // `partKind` table maps to it. That is a rule about receipts, not about the
   // chart: the L1 month-end inventory entry moves all three inventory accounts.
   it('seeds WIP even though no receipt ever debits it', () => {
-    const wip = DEFAULT_CHART_OF_ACCOUNTS.find((a) => a.code === '1320')
-    expect(wip?.role).toBe(ACCOUNT_ROLES.INVENTORY_WIP)
+    expect(byCode.get('1320')?.role).toBe(ACCOUNT_ROLES.INVENTORY_WIP)
+    expect(codesOf('inventory')).toContain('1320')
+  })
+
+  // 2110 Payroll Clearing carries assembly labour that CAPITALISES into
+  // inventory, which is why it rides with the inventory pack and not the core.
+  it('keeps payroll clearing with inventory', () => {
+    expect(byCode.get('2110')?.role).toBe(ACCOUNT_ROLES.PAYROLL_CLEARING)
+    expect(codesOf('inventory')).toContain('2110')
+  })
+
+  // Role-less is the ORDINARY case, not a gap, and it is not a core-only case
+  // either: `5010`/`5030` ride with inventory because the P&L groups COGS by
+  // subtype, `6105` with the card rail because Affirm's fees clear `1210`
+  // (16 §1.6). Pinned so that a future edit that reflexively gives every
+  // account a role, or parks every role-less one in the core, has to argue
+  // with a test.
+  it('leaves role-less accounts in more than one pack', () => {
+    const roleless = DEFAULT_CHART_OF_ACCOUNTS.filter((account) => !account.role)
+    expect(roleless.map((account) => account.code).sort()).toEqual(
+      ['1000', '3000', '5010', '5030', '6105'].sort()
+    )
+    const packsWithRoleless = new Set(
+      CHART_PACK_KEYS.filter((key) => CHART_PACKS[key].accounts.some((a) => !a.role))
+    )
+    expect(packsWithRoleless.size).toBeGreaterThan(1)
+    expect(packsWithRoleless).toContain('core')
+    expect(packsWithRoleless).toContain('inventory')
+    expect(packsWithRoleless).toContain('card_rail')
+  })
+})
+
+describe('packForRole', () => {
+  it('is total and agrees with the tables', () => {
+    for (const role of CODE_ROLE_VALUES) {
+      const pack = packForRole(role)
+      expect(CHART_PACK_KEYS, role).toContain(pack)
+      expect(rolesOf(pack), `${role} -> ${pack}`).toContain(role)
+    }
+  })
+})
+
+describe('requires', () => {
+  it('is acyclic and names only declared packs', () => {
+    const visit = (key: ChartPackKey, trail: ChartPackKey[]) => {
+      expect(trail, `cycle through ${key}`).not.toContain(key)
+      for (const required of CHART_PACKS[key].requires ?? []) {
+        expect(CHART_PACK_KEYS).toContain(required)
+        visit(required, [...trail, key])
+      }
+    }
+    for (const key of CHART_PACK_KEYS) visit(key, [])
+  })
+
+  // A receipt debits an inventory role, so a purchasing pack without the
+  // inventory pack would refuse on its first receipt.
+  it('makes purchasing require inventory, and nothing require the core', () => {
+    expect(CHART_PACKS.purchasing.requires).toEqual(['inventory'])
+    for (const key of CHART_PACK_KEYS) {
+      expect(CHART_PACKS[key].requires ?? []).not.toContain('core')
+    }
+  })
+})
+
+describe('packState', () => {
+  const row = (role: string, state: RoleAssignmentRow['state']) => ({ role, state })
+  const allAs = (state: RoleAssignmentRow['state']) =>
+    CODE_ROLE_VALUES.map((role) => row(role, state))
+
+  it('reads a pack with no unmapped role as provisioned', () => {
+    expect(packState('core', allAs('suggested'))).toBe('provisioned')
+    expect(packState('core', allAs('confirmed'))).toBe('provisioned')
+    // `unused` is a person's answer, not an absence.
+    expect(packState('inventory', allAs('unused'))).toBe('provisioned')
+  })
+
+  it('reads a pack with every role unmapped as absent, and an empty map as absent', () => {
+    expect(packState('purchasing', allAs('unmapped'))).toBe('absent')
+    expect(packState('purchasing', [])).toBe('absent')
+  })
+
+  it('reads a pack with some roles unmapped as partial', () => {
+    const roles = rolesOf('card_rail')
+    const map = roles.map((role, i) => row(role, i === 0 ? 'unmapped' : 'suggested'))
+    expect(packState('card_rail', map)).toBe('partial')
+  })
+
+  it('reads only its own roles', () => {
+    const coreMapped = rolesOf('core').map((role) => row(role, 'confirmed'))
+    expect(packState('core', coreMapped)).toBe('provisioned')
+    expect(packState('card_rail', coreMapped)).toBe('absent')
   })
 })

--- a/packages/lib/src/postings/__tests__/resolve-roles.test.ts
+++ b/packages/lib/src/postings/__tests__/resolve-roles.test.ts
@@ -3,7 +3,7 @@
 // The resolver is the single door from a builder's ROLE to an org's own account,
 // and it is the last thing standing between an entry and the wrong account. The
 // entry would still BALANCE if it resolved wrongly, so nothing downstream could
-// detect it — which is why every one of these is a refusal test.
+// detect it - which is why every one of these is a refusal test.
 //
 // Two properties carry the file:
 //
@@ -14,7 +14,7 @@
 //     three different actions by three different people. Collapsing them into
 //     "not mapped" is the cheap version and it is wrong.
 //  2. **It is a BATCH.** Six unmapped roles must fail ONCE naming six, not six
-//     times naming one — a bookkeeper fixing a close needs the list.
+//     times naming one - a bookkeeper fixing a close needs the list.
 //
 // The database is a hand-written stub rather than a mock chain: this module
 // issues three distinct reads and each has to answer differently, which a
@@ -37,6 +37,7 @@ vi.mock('../../cache', () => ({
   }),
 }))
 
+import { CHART_PACKS, packForRole } from '../default-chart'
 import { loadRoleAccountCodes, resolveAccountLines, resolveRoles } from '../resolve-roles'
 import type { GlPostingLineInput } from '../types'
 
@@ -67,8 +68,8 @@ interface Account {
  * A stub `Database` answering this module's three reads in the order it makes
  * them: assignments, live instances, then field values.
  *
- * `assignmentsOverride` exists for the one case Postgres makes unreachable — two
- * rows for one role — which the module asserts anyway.
+ * `assignmentsOverride` exists for the one case Postgres makes unreachable - two
+ * rows for one role - which the module asserts anyway.
  */
 function stubDb(assignments: Assignment[], accounts: Account[]) {
   let call = 0
@@ -146,7 +147,7 @@ async function expectErr(
   return result._unsafeUnwrapErr()
 }
 
-describe('resolveRoles — the happy path', () => {
+describe('resolveRoles - the happy path', () => {
   it('resolves a mapped role to its code, name and type', async () => {
     const db = stubDb([GRNI_ASSIGNMENT], [GRNI_ACCOUNT])
     const result = await resolveRoles(db, ORG, ['grni'])
@@ -175,7 +176,7 @@ describe('resolveRoles — the happy path', () => {
 
   // 🛑 The exact case `G19` names, and the reason this is a table rather than a
   // `unique: true` SINGLE_SELECT on `gl_account`: a role resolves to ONE account
-  // (enforced) but an account may serve MANY roles (permitted, ordinary — an org
+  // (enforced) but an account may serve MANY roles (permitted, ordinary - an org
   // that runs DTC and dealer revenue through one account).
   it('lets two roles share one account', async () => {
     const db = stubDb(
@@ -202,19 +203,34 @@ describe('resolveRoles — the happy path', () => {
   })
 })
 
-describe('resolveRoles — the five refusals, each with its own message', () => {
-  it('1. refuses a role nobody ever mapped', async () => {
+describe('resolveRoles - the five refusals, each with its own message', () => {
+  it('1. refuses a role nobody ever mapped, naming the role and its pack (16 §3.2)', async () => {
     const db = stubDb([], [])
     const error = await expectErr(resolveRoles(db, ORG, ['grni']))
     expect(error.message).toContain("'grni'")
     expect(error.message).toMatch(/not mapped to any account/i)
+    // The refusal names the role's label and the pack that would provision
+    // it, so the person reading it knows what to add and where.
+    expect(error.message).toContain('(Goods Received Not Invoiced)')
+    expect(error.message).toContain(CHART_PACKS[packForRole('grni')].label)
+    expect(error.message).toMatch(/Accounting > Settings > Accounts > Roles/)
+  })
+
+  it('falls back to the plain sentence for an undeclared role with no assignment', async () => {
+    // An invented role has no ACCOUNT_ROLE_LABELS entry and no pack, so the
+    // rich sentence cannot be built - it must not throw indexing CHART_PACKS
+    // with `undefined`.
+    const db = stubDb([], [])
+    const error = await expectErr(resolveRoles(db, ORG, ['invented']))
+    expect(error.message).toContain("'invented'")
+    expect(error.message).toMatch(/not mapped to any account\. Map it in the chart of accounts/i)
   })
 
   it('2. refuses a role the org marked unused, and says the books disagree', async () => {
     const db = stubDb([{ ...GRNI_ASSIGNMENT, markedUnused: true }], [GRNI_ACCOUNT])
     const error = await expectErr(resolveRoles(db, ORG, ['grni']))
     expect(error.message).toMatch(/marked as unused/i)
-    // NOT the "never mapped" sentence — the two call for different actions.
+    // NOT the "never mapped" sentence - the two call for different actions.
     expect(error.message).not.toMatch(/not mapped to any account/i)
   })
 
@@ -281,7 +297,7 @@ describe('resolveRoles — the five refusals, each with its own message', () => 
   })
 })
 
-describe('resolveRoles — it answers for the whole set at once', () => {
+describe('resolveRoles - it answers for the whole set at once', () => {
   // 🛑 A month-end entry naming six roles on an org that mapped none must fail
   // ONCE, naming all six. Six failures naming one each is a treasure hunt on
   // the night of a close.
@@ -320,13 +336,14 @@ describe('resolveRoles — it answers for the whole set at once', () => {
     )
     const error = await expectErr(resolveRoles(db, ORG, ['grni', 'ppv', 'undeposited_funds']))
 
-    expect(error.message).toMatch(/'grni' is not mapped/i)
+    expect(error.message).toContain("'grni'")
+    expect(error.message).toMatch(/is not mapped to any account/i)
     expect(error.message).toMatch(/'ppv' is marked as unused/i)
     expect(error.message).toMatch(/'undeposited_funds' must be mapped to a asset account/i)
   })
 })
 
-describe('resolveRoles — the impossible case, asserted anyway', () => {
+describe('resolveRoles - the impossible case, asserted anyway', () => {
   // `GlRoleAssignment_org_role_key` makes this unreachable. It is asserted
   // because the ONE failure this module must never have is picking arbitrarily
   // between two accounts: the entry would balance, and nothing downstream could
@@ -642,7 +659,8 @@ describe('resolveAccountLines - role lines and mixed entries', () => {
         },
       ])
     )
-    expect(error.message).toMatch(/'grni' is not mapped to any account/i)
+    expect(error.message).toContain("'grni'")
+    expect(error.message).toMatch(/is not mapped to any account/i)
   })
 })
 

--- a/packages/lib/src/postings/__tests__/role-map.test.ts
+++ b/packages/lib/src/postings/__tests__/role-map.test.ts
@@ -292,6 +292,22 @@ describe('listRoleMap - the four derived states', () => {
     })
   })
 
+  it('derives suggested from a source: import row with no confirmation (16 §2.4)', async () => {
+    // The import writes `source: 'import'` deliberately, never `confirmedAt`
+    // (16 §2.4, G19): state is derived from `confirmedAt` alone, so an
+    // import-assigned role renders exactly like a seed-assigned one until a
+    // person confirms it.
+    const stub = stubDb(
+      [{ role: 'grni', glAccountId: 'acct_grni', source: 'import' }],
+      [GRNI_ACCOUNT]
+    )
+    const row = (await listRoleMap(stub.db, ORG))._unsafeUnwrap().find((r) => r.role === 'grni')
+
+    expect(row?.state).toBe('suggested')
+    expect(row?.source).toBe('import')
+    expect(row?.confirmedAt).toBeNull()
+  })
+
   it('derives confirmed from a confirmedAt stamp, serialised as ISO', async () => {
     const stub = stubDb(
       [

--- a/packages/lib/src/postings/chart-import-plan.ts
+++ b/packages/lib/src/postings/chart-import-plan.ts
@@ -1,0 +1,173 @@
+// packages/lib/src/postings/chart-import-plan.ts
+//
+// The PURE half of importing a provider's chart of accounts (brief 16 §2.2):
+// given what the provider reports, what the org already has, which provider
+// accounts are already somebody's identity and which roles are already mapped,
+// decide what to create, what to skip and which roles can be assigned without
+// asking. No database, no io, client-safe. The writer that executes a plan is
+// `chart-import.ts`. The two tables here are DECLARED, not derived: the
+// subtype inverse is deliberately narrower than the mechanical inverse of
+// `SUBTYPE_PROVIDER_ACCOUNT_TYPES`, and the role match list is short on
+// purpose (revenue is the person's call, 16 §2.2).
+
+import type { GlAccountSubtypeValue } from './account-subtype'
+import type { AccountRole } from './build-entry'
+import { CHART_PACKS } from './default-chart'
+import type { ChartAccountRow, ChartImportPlan, ProviderAccount, RoleAssignmentRow } from './types'
+
+/** QuickBooks `AccountType` -> our subtype, where the answer is unambiguous. */
+export const PROVIDER_ACCOUNT_TYPE_SUBTYPE: Readonly<Record<string, GlAccountSubtypeValue>> = {
+  Bank: 'bank',
+  'Accounts Receivable': 'accounts_receivable',
+  'Accounts Payable': 'accounts_payable',
+  'Credit Card': 'credit_card',
+  'Fixed Asset': 'fixed_asset',
+  'Cost of Goods Sold': 'cost_of_goods_sold',
+  // 'Other Current Asset' deliberately absent: Undeposited Funds, prepaids and
+  // Inventory Asset all arrive under it (map-account.ts sends no AccountSubType).
+}
+
+/**
+ * How a role finds its account among imported ones. Exactly one hit, or nothing.
+ *
+ * Every other role is left for the Roles tab. Revenue is deliberately absent:
+ * QuickBooks ships `Sales`, `Sales of Product Income`, `Services` and a company
+ * adds more, and "which of these is product revenue" is the person's call.
+ * Names compare through the same `normName` the suggester uses; a plain name
+ * or a fully-qualified one both count.
+ */
+export const ROLE_IMPORT_MATCH: Partial<
+  Record<AccountRole, { subtype: GlAccountSubtypeValue } | { names: readonly string[] }>
+> = {
+  accounts_receivable: { subtype: 'accounts_receivable' },
+  accounts_payable: { subtype: 'accounts_payable' },
+  undeposited_funds: { names: ['Undeposited Funds'] },
+  sales_tax_payable: { names: ['Sales Tax Payable'] },
+  equity_retained_earnings: { names: ['Retained Earnings'] },
+  equity_opening_balance: { names: ['Opening Balance Equity'] },
+  bad_debt_expense: { names: ['Bad Debt', 'Bad Debts', 'Bad Debt Expense'] },
+}
+
+/**
+ * Case- and whitespace-insensitive compare, then strip the punctuation and
+ * filler that differ between two charts describing the same account.
+ *
+ * A private copy of `suggest-account-identities.ts`'s `normName`, not an
+ * import of it: that file is outside this lane's files (brief 16 §4) and this
+ * is five lines, small enough that duplicating beats reaching across a lane
+ * boundary for it.
+ */
+function normName(value: string | null | undefined): string {
+  return (value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[-_/&,.()]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Does `account` carry one of `names`, as a plain name, a fully-qualified one,
+ * or the last `Parent:Name` segment of a fully-qualified one?
+ *
+ * The last check is what makes `'Undeposited Funds'` match a provider account
+ * reported only as `'Bank:Undeposited Funds'` when its own `name` field
+ * happens to carry the full path too.
+ */
+function matchesDeclaredName(account: ProviderAccount, names: readonly string[]): boolean {
+  const wanted = new Set(names.map(normName))
+  const lastSegment = account.fullyQualifiedName.split(':').pop() ?? account.fullyQualifiedName
+  return (
+    wanted.has(normName(account.name)) ||
+    wanted.has(normName(account.fullyQualifiedName)) ||
+    wanted.has(normName(lastSegment))
+  )
+}
+
+/** The single item matching a predicate, or null when none or several do. */
+function pickOne<T>(items: readonly T[], predicate: (item: T) => boolean): T | null {
+  const hits = items.filter(predicate)
+  return hits.length === 1 ? hits[0]! : null
+}
+
+/**
+ * Plan an import of the provider's chart over the org's current one.
+ *
+ * `existingIdentities` maps `glAccountId -> providerAccountId`, the read
+ * `listAccountIdentities` already makes. Pure and total: never throws on data,
+ * and ambiguity (two candidates for one role) yields no candidate.
+ *
+ * `existingChart` is accepted for the same reason the writer reads it before
+ * calling this - it is the caller's context, not this function's - but the
+ * plan itself needs nothing from it beyond what `existingRoles` already
+ * encodes: a role's current state and the account (if any) behind it.
+ */
+export function planChartImport(
+  providerAccounts: readonly ProviderAccount[],
+  _existingChart: readonly ChartAccountRow[],
+  existingIdentities: ReadonlyMap<string, string>,
+  existingRoles: readonly RoleAssignmentRow[]
+): ChartImportPlan {
+  const glAccountIdByProviderId = new Map<string, string>()
+  for (const [glAccountId, providerAccountId] of existingIdentities) {
+    glAccountIdByProviderId.set(providerAccountId, glAccountId)
+  }
+
+  const skippedInactive: ProviderAccount[] = []
+  const active: ProviderAccount[] = []
+  for (const account of providerAccounts) {
+    if (account.active) active.push(account)
+    else skippedInactive.push(account)
+  }
+
+  const create: ChartImportPlan['create'] = []
+  const alreadyImported: ChartImportPlan['alreadyImported'] = []
+  for (const account of active) {
+    const glAccountId = glAccountIdByProviderId.get(account.id)
+    if (glAccountId) {
+      alreadyImported.push({ providerAccount: account, glAccountId })
+      continue
+    }
+    create.push({
+      providerAccount: account,
+      code: account.number?.trim() || null,
+      name: account.name,
+      accountType: account.classification,
+      subtype: PROVIDER_ACCOUNT_TYPE_SUBTYPE[account.accountType] ?? null,
+    })
+  }
+
+  // Every candidate for a role - whether already imported or about to be
+  // created - is fair game: both will carry a `gl_account` once the writer is
+  // done, and the plan is made before either happens.
+  const stateByRole = new Map(existingRoles.map((row) => [row.role, row.state]))
+  const roleCandidates: ChartImportPlan['roleCandidates'] = []
+  for (const role of Object.keys(ROLE_IMPORT_MATCH) as AccountRole[]) {
+    if ((stateByRole.get(role) ?? 'unmapped') !== 'unmapped') continue
+
+    const match = ROLE_IMPORT_MATCH[role]
+    if (!match) continue
+
+    const candidate =
+      'subtype' in match
+        ? pickOne(active, (a) => PROVIDER_ACCOUNT_TYPE_SUBTYPE[a.accountType] === match.subtype)
+        : pickOne(active, (a) => matchesDeclaredName(a, match.names))
+
+    if (candidate) {
+      roleCandidates.push({
+        role,
+        match: 'subtype' in match ? 'subtype' : 'name',
+        providerAccountId: candidate.id,
+      })
+    }
+  }
+
+  const resolvedRoles = new Set(roleCandidates.map((candidate) => candidate.role))
+  const missingCore = CHART_PACKS.core.accounts.filter((account) => {
+    if (!account.role) return false
+    if (resolvedRoles.has(account.role)) return false
+    return (stateByRole.get(account.role) ?? 'unmapped') === 'unmapped'
+  })
+
+  return { create, skippedInactive, alreadyImported, roleCandidates, missingCore }
+}

--- a/packages/lib/src/postings/chart-import.ts
+++ b/packages/lib/src/postings/chart-import.ts
@@ -1,0 +1,236 @@
+// packages/lib/src/postings/chart-import.ts
+//
+// The WRITER half of importing a provider's chart of accounts (brief 16 §2.2):
+// resolves the connected provider, reads its chart and the org's, runs the pure
+// `planChartImport`, creates each planned account through `createChartAccount`
+// and sets its identity right after, assigns the unambiguous roles with
+// `source: 'import'`, then (unless `refreshOnly`) creates the role-bearing core
+// accounts the provider lacks, uncoded and with no identity. `db` first,
+// `Result` from neverthrow, no permission checks: the router asserts
+// `ledgerControl` and calls.
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError, UniqueValueConflictError, UnprocessableEntityError } from '../errors'
+import type { GlAccountSubtypeValue } from './account-subtype'
+import type { AccountRole } from './build-entry'
+import { planChartImport } from './chart-import-plan'
+import { createChartAccount } from './chart-write'
+import type { DefaultChartAccount, GlAccountTypeValue } from './default-chart'
+import { NONE_PROVIDER_ID, resolveAccountingProvider } from './provider'
+import { listChartAccounts, listRoleMap } from './role-map'
+import type { ChartImportResult } from './types'
+
+const logger = createScopedLogger('postings:chart-import')
+
+export interface ImportChartOptions {
+  organizationId: string
+  actorUserId: string
+  /** `true` on the Chart tab's refresh: adds, never creates the missing core. */
+  refreshOnly?: boolean
+}
+
+/** What one call to `createChartAccount` needs, stripped of plan bookkeeping. */
+interface CreateAccountInput {
+  code: string | null
+  name: string
+  accountType: GlAccountTypeValue
+  subtype: GlAccountSubtypeValue | null
+}
+
+/**
+ * Import the connected provider's chart into the org's, creating only what the
+ * org does not already have. Idempotent: a second run creates nothing and
+ * reports `alreadyImported`. Refuses `UnprocessableEntityError` when nothing is
+ * connected, because an empty import is not a success.
+ */
+export async function importChartFromProvider(
+  db: Database,
+  options: ImportChartOptions
+): Promise<Result<ChartImportResult, Error>> {
+  const { organizationId, actorUserId, refreshOnly } = options
+
+  try {
+    const provider = await resolveAccountingProvider(organizationId)
+
+    const providerChart = await provider.listProviderAccounts(organizationId)
+    if (providerChart.isErr()) return err(providerChart.error)
+    const providerAccounts = providerChart.value
+
+    // An empty import is not a success (16 §2.2) - whether because nothing is
+    // connected (the null provider always answers `ok([])`) or because a
+    // connected provider's chart happens to be empty, there is nothing to do
+    // and saying so beats silently reporting zero of everything.
+    if (providerAccounts.length === 0) {
+      throw new UnprocessableEntityError(
+        provider.id === NONE_PROVIDER_ID
+          ? 'No accounting system is connected. Connect one before importing its chart of accounts.'
+          : 'The connected accounting system reports no accounts to import.',
+        { organizationId, providerId: provider.id }
+      )
+    }
+
+    const [mappings, chart, roleMap] = await Promise.all([
+      provider.listAccountMappings(organizationId),
+      listChartAccounts(db, organizationId),
+      listRoleMap(db, organizationId),
+    ])
+    if (mappings.isErr()) return err(mappings.error)
+    if (chart.isErr()) return err(chart.error)
+    if (roleMap.isErr()) return err(roleMap.error)
+
+    const plan = planChartImport(providerAccounts, chart.value, mappings.value, roleMap.value)
+
+    // `providerAccountId -> glAccountId`, seeded with what already existed and
+    // grown as this run creates accounts - a role candidate resolved against a
+    // provider account created moments ago needs to find it here too.
+    const glAccountIdByProviderId = new Map<string, string>(
+      plan.alreadyImported.map((row) => [row.providerAccount.id, row.glAccountId])
+    )
+
+    let created = 0
+    for (const item of plan.create) {
+      const glAccountId = await createAccount(db, organizationId, actorUserId, item)
+      glAccountIdByProviderId.set(item.providerAccount.id, glAccountId)
+      created++
+
+      const mapped = await provider.setAccountMapping({
+        orgId: organizationId,
+        glAccountId,
+        providerAccountId: item.providerAccount.id,
+        actorUserId,
+      })
+      if (mapped.isErr()) return err(mapped.error)
+    }
+
+    // Roles this run can resolve without asking - `source: 'import'`, only for
+    // a role `planChartImport` already filtered to `unmapped`. `ON CONFLICT DO
+    // NOTHING` (inside `insertRoleAssignment`) is what makes this idempotent
+    // against a concurrent editor, the same guarantee `assignSeededRoles` gives
+    // the provisioner.
+    const rolesAssigned: AccountRole[] = []
+    for (const candidate of plan.roleCandidates) {
+      const glAccountId = glAccountIdByProviderId.get(candidate.providerAccountId)
+      if (!glAccountId) continue
+      const inserted = await insertRoleAssignment(
+        db,
+        organizationId,
+        candidate.role,
+        glAccountId,
+        'import'
+      )
+      if (inserted) rolesAssigned.push(candidate.role)
+    }
+
+    // The role-bearing core accounts QuickBooks lacks (16 DECIDED): created
+    // uncoded, with no identity, `source: 'seed'` - never on a refresh, which
+    // only adds what the provider already has.
+    const coreCreated: DefaultChartAccount[] = []
+    if (!refreshOnly) {
+      for (const account of plan.missingCore) {
+        if (!account.role) continue
+        const glAccountId = await createAccount(db, organizationId, actorUserId, {
+          code: null,
+          name: account.name,
+          accountType: account.accountType,
+          subtype: account.subtype ?? null,
+        })
+        const inserted = await insertRoleAssignment(
+          db,
+          organizationId,
+          account.role,
+          glAccountId,
+          'seed'
+        )
+        if (inserted) coreCreated.push(account)
+      }
+    }
+
+    return ok({
+      created,
+      alreadyImported: plan.alreadyImported.length,
+      skippedInactive: plan.skippedInactive.length,
+      rolesAssigned,
+      coreCreated,
+    })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to import the provider chart', { error, organizationId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/**
+ * Create one account, falling back to no code on a collision.
+ *
+ * 🛑 **A duplicated `AcctNum` in the provider's chart must not abort the whole
+ * import.** `createChartAccount`'s code gate is check-then-write (`chart-write.ts`);
+ * on a collision this creates the account anyway, without the code, and logs a
+ * warning naming it - reported to the caller only as one more row under
+ * `created`, per brief 16 §2.2, because `ChartImportResult` carries counts, not
+ * a list of what went almost right.
+ */
+async function createAccount(
+  db: Database,
+  organizationId: string,
+  actorUserId: string,
+  input: CreateAccountInput
+): Promise<string> {
+  const result = await createChartAccount(db, {
+    organizationId,
+    actorUserId,
+    code: input.code,
+    name: input.name,
+    accountType: input.accountType,
+    subtype: input.subtype,
+  })
+  if (result.isOk()) return result.value.id
+
+  if (input.code && result.error instanceof UniqueValueConflictError) {
+    logger.warn('Chart import: code collision, created the account without a code', {
+      organizationId,
+      code: input.code,
+      name: input.name,
+    })
+    const retried = await createChartAccount(db, {
+      organizationId,
+      actorUserId,
+      code: null,
+      name: input.name,
+      accountType: input.accountType,
+      subtype: input.subtype,
+    })
+    if (retried.isOk()) return retried.value.id
+    throw retried.error
+  }
+
+  throw result.error
+}
+
+/**
+ * Point one role at one account, `ON CONFLICT (organizationId, role) DO
+ * NOTHING` - the same upsert-free insert `assignSeededRoles` uses, for the
+ * same reason: the unique index that makes the resolver's answer unambiguous
+ * is the same index that makes this safe to repeat.
+ *
+ * @returns whether a row was actually inserted - false means the role was
+ * already mapped by the time this ran, and the caller must not count it.
+ */
+async function insertRoleAssignment(
+  db: Database,
+  organizationId: string,
+  role: AccountRole,
+  glAccountId: string,
+  source: 'import' | 'seed'
+): Promise<boolean> {
+  const inserted = await db
+    .insert(schema.GlRoleAssignment)
+    .values({ organizationId, role, glAccountId, source })
+    .onConflictDoNothing({
+      target: [schema.GlRoleAssignment.organizationId, schema.GlRoleAssignment.role],
+    })
+    .returning({ id: schema.GlRoleAssignment.id })
+
+  return inserted.length > 0
+}

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -149,11 +149,24 @@ export {
   PAYOUT_CLEARING_ROLES,
   PAYOUT_SOURCE_TYPE,
 } from './build-payout-entry'
+// ── plans/accounting/tasks/16: the chart import, pure half ─────────────────
+// PURE. The two declared tables and the planner reach nothing but types.
 export {
+  PROVIDER_ACCOUNT_TYPE_SUBTYPE,
+  planChartImport,
+  ROLE_IMPORT_MATCH,
+} from './chart-import-plan'
+export {
+  CHART_PACK_KEYS,
+  CHART_PACKS,
+  type ChartPack,
+  type ChartPackKey,
   DEFAULT_CHART_OF_ACCOUNTS,
   type DefaultChartAccount,
   GL_ACCOUNT_TYPES,
   type GlAccountTypeValue,
+  packForRole,
+  packState,
 } from './default-chart'
 export {
   buildDocNumber,
@@ -308,6 +321,8 @@ export {
   type BooksBalanceReport,
   type BuiltEntry,
   type ChartAccountRow,
+  type ChartImportPlan,
+  type ChartImportResult,
   type ClosePeriod,
   type CounterpartyType,
   type EntryPreview,

--- a/packages/lib/src/postings/default-chart.ts
+++ b/packages/lib/src/postings/default-chart.ts
@@ -1,12 +1,37 @@
 // packages/lib/src/postings/default-chart.ts
 //
-// The default chart of accounts auxx.ai seeds into an organization.
+// The default chart of accounts auxx.ai seeds into an organization, declared
+// as PACKS (plans/accounting/tasks/16-the-chart-of-accounts.md §1 and §3.2).
 //
 // PURE DATA. No database, no io - `postings/` already owns the account
 // vocabulary (`ACCOUNT_ROLES` in build-entry.ts), the period keyspace and the
 // provider seam, so the chart that vocabulary maps onto belongs here rather
-// than in `seed/`. The entity migration that writes these rows imports this
-// constant; `seed -> lib` is the sanctioned direction and `lib -> seed` is not.
+// than in `seed/`. The seeder that writes these rows imports this module;
+// `seed -> lib` is the sanctioned direction and `lib -> seed` is not.
+//
+// ## Why packs
+//
+// The flat 37-account list this file used to export was one company's chart:
+// nine accounts carried no role at all and sixteen carried roles only a
+// manufacturer, a purchaser or a card merchant ever drives. Brief 16 §1 splits
+// the same table by WHO reaches it: a `core` every org gets (the eleven roles an
+// enabled posting type can put on a line for any org that sends an invoice,
+// takes a payment, ships an order, issues a credit memo or writes something
+// off), and four packs an org adds when it starts doing the thing that needs
+// them: `card_rail`, `prepayments`, `inventory`, `purchasing`. Every one of the
+// 28 roles lives in exactly one pack; `packForRole` is the lookup and the union
+// test in `__tests__/default-chart.test.ts` is the proof.
+//
+// Four accounts that were in the old list are in NO pack (`1190 Allowance for
+// Doubtful Accounts`, `2100 Accrued Payroll`, `2400 Returns Reserve`, `6200
+// Fulfillment Labor`): role-less, one company's bookkeeping, added by hand in
+// the chart editor where wanted (16 DECIDED, 16.3). An org provisioned before
+// packs existed keeps them; nothing here renumbers, renames or deletes.
+//
+// Packs are DECLARED, not derived from the builders or from
+// `SINGLE_WRITER_ROLES_BY_POSTING_TYPE` (16 §1.6): a declared table is what a
+// human comes to and says so; a derived one follows whatever a builder started
+// emitting.
 //
 // The account CODE is optional on a `gl_account` now (task 15 §5) - a chart
 // imported from a provider that ships with account numbers off has none, and
@@ -17,6 +42,7 @@
 import { GlAccountSubtype, GlAccountType } from '../resources/registry/enum-values'
 import type { GlAccountSubtypeValue } from './account-subtype'
 import type { AccountRole } from './build-entry'
+import type { RoleAssignmentRow } from './types'
 
 /**
  * The five statement classifications, as a literal union.
@@ -74,53 +100,48 @@ export interface DefaultChartAccount {
 }
 
 /**
- * The default chart of accounts, seeded into every organization.
- *
- * ## What this is, and what it is NOT
- *
- * **It is a DEFAULT, not a standard** (decision `G7`). Charts of accounts are
- * not standardised: US GAAP mandates no numbering at all, QuickBooks' own
- * default chart varies by country and by industry and is routinely edited on
- * day one, and some jurisdictions mandate an entirely different one - France's
- * PCG, Germany's SKR03/04. So auxx seeds this, and a person changes it: renames
- * an account, renumbers one, deactivates one at year end, adds twenty of their
- * own.
- *
- * **That editability is exactly why nothing in the code may name a number.**
- * The `role` column is the load-bearing part of every row here (decision `G8`).
- * A builder emits `ACCOUNT_ROLES.GRNI`; the resolver reads THIS org's chart to
- * learn that GRNI is `2160` here and `2155` at the customer who renumbered it.
- * Change a `code` below and posting still works. Change a `role` and it stops -
- * which is why the role field is where the care goes.
- *
- * **It is not a complete chart.** The source (`plans/money/accrual-accounting-plan.html`
- * §2) is titled *"Accounts to add in QuickBooks"* - it presumes an existing
- * book with bank accounts, equity, retained earnings, operating expenses and the
- * rest already in place. Five accounts the posting builders need are added on
- * top of it (`1000`, `2000`, `2160`, `2170`, `5095`), because the accrual plan's
- * table does not list them. Three equity accounts (`3000`, `3100`, `3900`) were
- * added 2026-09-04 once the opening trial balance and the balance sheet needed
- * somewhere to land (plans/accounting/HANDOFF.md decision 6.4), with `1050`,
- * `4020` and `6300` in the same pass.
- *
- * ## The two things to check before this is seeded
- *
- * 1. **The numbering.** It is the accrual plan's, which was written against one
- *    company's QuickBooks. A new org gets it as a starting point.
- * 2. **The type mapping.** The accrual plan's *Type* column carries QuickBooks
- *    DETAIL types (`Other Current Asset`, `Cost of Goods Sold`, `Income`,
- *    `Accounts Receivable`, `contra-asset`). `GlAccountType` is the five-way
- *    statement classification, so they are collapsed: Income -> `revenue`, Cost
- *    of Goods Sold and Expense -> `expense`, every asset flavour -> `asset`,
- *    Other Current Liability -> `liability`. The
- *    collapse loses the current/non-current split and the contra-asset marking
- *    on `1190`; that is a presentation concern for the provider's own chart,
- *    not something a posting reads.
- *
- * @see ACCOUNT_ROLES in `build-entry.ts` for what each role means
- * @see plans/money/accrual-accounting-plan.html §2 for the accounting argument
+ * The five packs, by key. `core` is always provisioned; the other four are
+ * chosen by a person in the wizard's pack picker or the Roles tab's Add
+ * accounts action (16 §3). Never provisioned silently off a plan event, an app
+ * install or a payout sync (16 §3.3).
  */
-export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
+export type ChartPackKey = 'core' | 'card_rail' | 'prepayments' | 'inventory' | 'purchasing'
+
+/** One provisionable slice of the default chart. */
+export interface ChartPack {
+  key: ChartPackKey
+  /** Rendered in the picker: 'Card payments and payouts'. */
+  label: string
+  /** One sentence, rendered in the picker under the label. */
+  description: string
+  /** A pack whose roles this one's builders also drive. Provisioned first. */
+  requires?: readonly ChartPackKey[]
+  accounts: readonly DefaultChartAccount[]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The core: thirteen accounts, eleven roles (16 §1.3)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Every role here is reachable by an ENABLED posting type on any org that sends
+// an invoice, takes a payment, ships an order, issues a credit memo or writes
+// something off (16 §0.2). Why each of the arguable ones is here:
+//
+// - `2000 Accounts Payable`: `vendor_bill` is not enabled, but A/P aging reads
+//   the role, a manual journal to a payable by id is ordinary bookkeeping, and
+//   every business owes somebody. Its subtype is what the QuickBooks seam uses
+//   to demand a vendor on the line (13 §1).
+// - `3900 Opening Balance Equity`: no builder emits the role and nothing reads
+//   it, but the opening trial-balance grid needs the account to balance
+//   against and QuickBooks has the account of the same name. The role stays
+//   because the vocabulary is closed and a role no pack carried would fail the
+//   union test.
+// - `4000`, `4020`: `fulfillment` is enabled for every org and drops a zero
+//   shipping leg, so an org that never ships simply never posts to them.
+// - `6300`, `4090`, `4020`: one account each, driven by enabled types every org
+//   reaches; an unmapped `bad_debt_expense` would turn a forty-dollar write-off
+//   into a refusal that names a pack (16 DECIDED).
+const CORE_ACCOUNTS: readonly DefaultChartAccount[] = [
   // ── Assets ──────────────────────────────────────────────────────────────
   {
     // Not in the accrual plan's table - added because `buildBillPaymentEntry`
@@ -132,6 +153,12 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     // No role since brief 13 §2: a bank account is an instance, not a
     // function. An org maps this as a bank account like any other, or `16`
     // stops seeding it.
+    //
+    // 16.1 kept it seeded: a `bank_account` must point at a `gl_account` id,
+    // the `cash` payment route needs `accounting.cashBankAccountId` to name
+    // one, and the opening trial balance needs somewhere for cash to land. An
+    // org that imports from QuickBooks gets its real bank accounts instead and
+    // never sees `1000`.
     subtype: GlAccountSubtype.BANK,
   },
   {
@@ -154,63 +181,6 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     role: 'accounts_receivable',
     subtype: GlAccountSubtype.ACCOUNTS_RECEIVABLE,
   },
-  {
-    code: '1190',
-    name: 'Allowance for Doubtful Accounts',
-    // A contra-asset. `GlAccountType` has no contra classification and does not
-    // need one - it is a presentation attribute, not a posting rule.
-    accountType: GlAccountType.ASSET,
-  },
-  {
-    // Named for the RAIL. Was `Shopify Clearing` / `clearing_shopify` until
-    // entity migration 132 - there is no Shopify payment rail in auxx, so the
-    // Stripe money sitting here was in an account named for a provider it never
-    // touched. The code is unchanged; only the name and the role moved.
-    code: '1200',
-    name: 'Card Clearing',
-    accountType: GlAccountType.ASSET,
-    role: 'clearing_card',
-  },
-  {
-    // Must EXCLUDE every Affirm-gateway order or 1200 can never reconcile to
-    // zero: an Affirm settlement never lands on the card rail, so it is
-    // invisible to the payouts API (accrual plan §3).
-    //
-    // The role is what makes that exclusion mechanical rather than a rule
-    // somebody has to remember: the fulfillment debit fork routes an `affirm`
-    // gateway to `clearing_affirm`, and `PAYOUT_CLEARING_ROLES` holds
-    // `clearing_card` alone (49 §3.2, §8.4 decision 6). Entity migration 137
-    // stamps this role onto orgs seeded before it existed.
-    code: '1210',
-    name: 'Affirm Clearing',
-    accountType: GlAccountType.ASSET,
-    role: 'clearing_affirm',
-  },
-  {
-    code: '1310',
-    name: 'Raw Materials / Parts',
-    accountType: GlAccountType.ASSET,
-    role: 'inventory_raw_materials',
-    subtype: GlAccountSubtype.INVENTORY,
-  },
-  {
-    // Receipts never touch this - nothing in the `partKind` table maps to WIP.
-    // It is here because the L1 month-end inventory entry moves all THREE
-    // inventory accounts to the balance the subledger computes (04-books §2.1),
-    // and that entry is the January 1 deliverable.
-    code: '1320',
-    name: 'Work in Process',
-    accountType: GlAccountType.ASSET,
-    role: 'inventory_wip',
-    subtype: GlAccountSubtype.INVENTORY,
-  },
-  {
-    code: '1330',
-    name: 'Finished Goods',
-    accountType: GlAccountType.ASSET,
-    role: 'inventory_finished_goods',
-    subtype: GlAccountSubtype.INVENTORY,
-  },
 
   // ── Liabilities ─────────────────────────────────────────────────────────
   {
@@ -225,96 +195,12 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     subtype: GlAccountSubtype.ACCOUNTS_PAYABLE,
   },
   {
-    code: '2100',
-    name: 'Accrued Payroll',
-    accountType: GlAccountType.LIABILITY,
-    // Straddling pay periods. Distinct from 2110 - this one is an accrual, that
-    // one is a clearing pool. Not a role: no builder writes it.
-  },
-  {
-    code: '2110',
-    name: 'Payroll Clearing',
-    accountType: GlAccountType.LIABILITY,
-    role: 'payroll_clearing',
-  },
-  {
-    // BROADER than "carrier freight", deliberately (`G17`). A customs broker's
-    // service charge is attributable to a shipment, so it is landed cost and it
-    // clears here — NOT through 2170, which is duty owed to the government. The
-    // internal role stays `freight_accrual`: `G17` explicitly permits the name
-    // and the role to differ, and renaming a role is a vocabulary migration
-    // across the ledger for no behavioural gain.
-    code: '2150',
-    name: 'Inbound Freight & Brokerage Accrual',
-    accountType: GlAccountType.LIABILITY,
-    role: 'freight_accrual',
-  },
-  {
-    // Not in the accrual plan's table. The single most load-bearing account in
-    // the purchasing subledger: credited on receipt at the VENDOR unit price,
-    // debited when the vendor's bill arrives.
-    code: '2160',
-    name: 'Goods Received Not Invoiced',
-    accountType: GlAccountType.LIABILITY,
-    role: 'grni',
-  },
-  {
-    // Not in the accrual plan's table. Tariffs and customs duties owed
-    // SEPARATELY TO THE U.S. GOVERNMENT.
-    //
-    // 🛑 NOT the customs broker's share. This file, `build-entry.ts` and the
-    // (now deleted) registry enum all used to say it held "the customs broker's
-    // share"; all three were wrong. A broker sells a service on a shipment, so
-    // their charge is inbound freight's problem and clears through 2150.
-    //
-    // Only ever carries a balance when a receipt had a non-zero tariff portion;
-    // build plan phase 0.1 asks whether `tariffRate` is ever non-zero at all. An
-    // org that never imports can deactivate it and no posting will ever
-    // reference it.
-    code: '2170',
-    name: 'Duties Accrual',
-    accountType: GlAccountType.LIABILITY,
-    role: 'duties_accrual',
-  },
-  {
     // Sales tax is NEVER revenue and never an expense - a pass-through
     // liability from the moment Shopify collects it (accrual plan §1).
     code: '2200',
     name: 'Sales Tax Payable',
     accountType: GlAccountType.LIABILITY,
     role: 'sales_tax_payable',
-  },
-  {
-    code: '2300',
-    name: 'Deferred Revenue',
-    accountType: GlAccountType.LIABILITY,
-    // Month-end only, reversed on day one of the next month.
-    role: 'deferred_revenue',
-  },
-  {
-    // Money taken BEFORE delivery - `money/payments/deposit.ts`. A BANK deposit
-    // is a different thing entirely and lands on `cash`.
-    code: '2350',
-    name: 'Customer Deposits',
-    accountType: GlAccountType.LIABILITY,
-    role: 'customer_deposits',
-  },
-  {
-    code: '2400',
-    name: 'Returns Reserve',
-    accountType: GlAccountType.LIABILITY,
-  },
-  {
-    // Money that arrived and auxx cannot attribute. The payout entry's fourth
-    // leg: a gateway payout settles charges the merchant took OUTSIDE auxx too,
-    // and those were never debited to `1200`. Held as a liability - until it is
-    // attributed, "we hold money we cannot explain" is the true statement, and
-    // recognising it as revenue would book income on the strength of not
-    // knowing what it is.
-    code: '2450',
-    name: 'Unidentified Receipts',
-    accountType: GlAccountType.LIABILITY,
-    role: 'unidentified_receipts',
   },
 
   // ── Equity ──────────────────────────────────────────────────────────────
@@ -404,6 +290,149 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     role: 'revenue_returns_allowances',
   },
 
+  // ── Operating expenses ──────────────────────────────────────────────────
+  {
+    // The `write_off` entry's debit leg. `1190 Allowance for Doubtful Accounts`
+    // is the contra-asset the reserve method would credit; the direct
+    // write-off posts here and credits receivables.
+    code: '6300',
+    name: 'Bad Debt Expense',
+    accountType: GlAccountType.EXPENSE,
+    role: 'bad_debt_expense',
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// card_rail: Stripe Connect, Shopify Payments, Affirm (16 §1.4)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `seedDefaultPaymentGateways` runs after this pack, never after the core: the
+// two default gateway records point at `clearing_card` / `clearing_affirm`,
+// which only exist once this pack has landed (13 §5.3, 16 §1.5). `6105` rides
+// with the rail because Affirm's fees clear `1210` (16 §1.6).
+const CARD_RAIL_ACCOUNTS: readonly DefaultChartAccount[] = [
+  {
+    // Named for the RAIL. Was `Shopify Clearing` / `clearing_shopify` until
+    // entity migration 132 - there is no Shopify payment rail in auxx, so the
+    // Stripe money sitting here was in an account named for a provider it never
+    // touched. The code is unchanged; only the name and the role moved.
+    code: '1200',
+    name: 'Card Clearing',
+    accountType: GlAccountType.ASSET,
+    role: 'clearing_card',
+  },
+  {
+    // Must EXCLUDE every Affirm-gateway order or 1200 can never reconcile to
+    // zero: an Affirm settlement never lands on the card rail, so it is
+    // invisible to the payouts API (accrual plan §3).
+    //
+    // The role is what makes that exclusion mechanical rather than a rule
+    // somebody has to remember: the fulfillment debit fork routes an `affirm`
+    // gateway to `clearing_affirm`, and `PAYOUT_CLEARING_ROLES` holds
+    // `clearing_card` alone (49 §3.2, §8.4 decision 6). Entity migration 137
+    // stamps this role onto orgs seeded before it existed.
+    code: '1210',
+    name: 'Affirm Clearing',
+    accountType: GlAccountType.ASSET,
+    role: 'clearing_affirm',
+  },
+  {
+    // Money that arrived and auxx cannot attribute. The payout entry's fourth
+    // leg: a gateway payout settles charges the merchant took OUTSIDE auxx too,
+    // and those were never debited to `1200`. Held as a liability - until it is
+    // attributed, "we hold money we cannot explain" is the true statement, and
+    // recognising it as revenue would book income on the strength of not
+    // knowing what it is.
+    code: '2450',
+    name: 'Unidentified Receipts',
+    accountType: GlAccountType.LIABILITY,
+    role: 'unidentified_receipts',
+  },
+  {
+    // What the processor withheld from a payout. The payout entry's expense
+    // leg. NOT the Connect application fee in `money/payments/fees.ts`.
+    code: '6100',
+    name: 'Merchant Fees - Cards',
+    accountType: GlAccountType.EXPENSE,
+    role: 'payment_processing_fees',
+  },
+  {
+    // Kept separate from 6100 for RECONCILIATION, not optimisation: Affirm
+    // settles in its own deposit, so its fees have to be separable to clear
+    // 1210 (accrual plan §3).
+    code: '6105',
+    name: 'Merchant Fees - Affirm',
+    accountType: GlAccountType.EXPENSE,
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// prepayments: deposits and deferred revenue (16 §1.4)
+// ─────────────────────────────────────────────────────────────────────────────
+const PREPAYMENTS_ACCOUNTS: readonly DefaultChartAccount[] = [
+  {
+    code: '2300',
+    name: 'Deferred Revenue',
+    accountType: GlAccountType.LIABILITY,
+    // Month-end only, reversed on day one of the next month.
+    role: 'deferred_revenue',
+  },
+  {
+    // Money taken BEFORE delivery - `money/payments/deposit.ts`. A BANK deposit
+    // is a different thing entirely and lands on `cash`.
+    code: '2350',
+    name: 'Customer Deposits',
+    accountType: GlAccountType.LIABILITY,
+    role: 'customer_deposits',
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// inventory: the L1 month-end close (16 §1.4)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `month_end_inventory` IS an enabled posting type, but on an org with no parts
+// it refuses with "Nothing moved" before any role is resolved (16 §0.2), so
+// its seven roles cost a knowledge-base org nothing except seven rows on the
+// Roles tab and seven accounts in the chart. That is why they are a pack.
+// `5010` and `5030` ride along because they are COGS and the P&L groups them by
+// subtype (16 §1.6).
+const INVENTORY_ACCOUNTS: readonly DefaultChartAccount[] = [
+  // ── Assets ──────────────────────────────────────────────────────────────
+  {
+    code: '1310',
+    name: 'Raw Materials / Parts',
+    accountType: GlAccountType.ASSET,
+    role: 'inventory_raw_materials',
+    subtype: GlAccountSubtype.INVENTORY,
+  },
+  {
+    // Receipts never touch this - nothing in the `partKind` table maps to WIP.
+    // It is here because the L1 month-end inventory entry moves all THREE
+    // inventory accounts to the balance the subledger computes (04-books §2.1),
+    // and that entry is the January 1 deliverable.
+    code: '1320',
+    name: 'Work in Process',
+    accountType: GlAccountType.ASSET,
+    role: 'inventory_wip',
+    subtype: GlAccountSubtype.INVENTORY,
+  },
+  {
+    code: '1330',
+    name: 'Finished Goods',
+    accountType: GlAccountType.ASSET,
+    role: 'inventory_finished_goods',
+    subtype: GlAccountSubtype.INVENTORY,
+  },
+
+  // ── Liabilities ─────────────────────────────────────────────────────────
+  {
+    code: '2110',
+    name: 'Payroll Clearing',
+    accountType: GlAccountType.LIABILITY,
+    role: 'payroll_clearing',
+  },
+
   // ── Cost of goods sold ──────────────────────────────────────────────────
   // `GlAccountType` has no COGS classification; all five map to `expense`.
   {
@@ -445,17 +474,10 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     // landed cost. Two different freights; do not point one role at both.
   },
   {
-    code: '5090',
-    name: 'Inventory / Purchase Price Variance',
-    accountType: GlAccountType.EXPENSE,
-    role: 'ppv',
-    subtype: GlAccountSubtype.COST_OF_GOODS_SOLD,
-  },
-  {
     // 🛑 A SIBLING of 5090, not a merge with it (`G12`). 5090 answers "the
     // vendor billed something other than what we accrued"; this one answers
     // "the shelf disagrees with the ledger". Different owner, different remedy,
-    // different trend — one account holding both answers neither, and the L1
+    // different trend - one account holding both answers neither, and the L1
     // month-end assertion would absorb count variance into the COGS plug, which
     // is precisely the separation `G12` exists to get.
     //
@@ -466,37 +488,204 @@ export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = [
     role: 'inventory_count_variance',
     subtype: GlAccountSubtype.COST_OF_GOODS_SOLD,
   },
+]
 
-  // ── Operating expenses ──────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// purchasing: purchase orders, receiving and vendor bills (16 §1.4)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Requires `inventory`: a receipt debits an inventory role (`build-entry.ts`,
+// the receipt builder), so provisioning this pack alone walks `inventory`
+// first. `5090` sits HERE and `5095` in `inventory` because `G12` gives them
+// different owners and different remedies.
+const PURCHASING_ACCOUNTS: readonly DefaultChartAccount[] = [
+  // ── Liabilities ─────────────────────────────────────────────────────────
   {
-    // What the processor withheld from a payout. The payout entry's expense
-    // leg. NOT the Connect application fee in `money/payments/fees.ts`.
-    code: '6100',
-    name: 'Merchant Fees - Cards',
-    accountType: GlAccountType.EXPENSE,
-    role: 'payment_processing_fees',
+    // BROADER than "carrier freight", deliberately (`G17`). A customs broker's
+    // service charge is attributable to a shipment, so it is landed cost and it
+    // clears here - NOT through 2170, which is duty owed to the government. The
+    // internal role stays `freight_accrual`: `G17` explicitly permits the name
+    // and the role to differ, and renaming a role is a vocabulary migration
+    // across the ledger for no behavioural gain.
+    code: '2150',
+    name: 'Inbound Freight & Brokerage Accrual',
+    accountType: GlAccountType.LIABILITY,
+    role: 'freight_accrual',
   },
   {
-    // Kept separate from 6100 for RECONCILIATION, not optimisation: Affirm
-    // settles in its own deposit, so its fees have to be separable to clear
-    // 1210 (accrual plan §3).
-    code: '6105',
-    name: 'Merchant Fees - Affirm',
-    accountType: GlAccountType.EXPENSE,
+    // Not in the accrual plan's table. The single most load-bearing account in
+    // the purchasing subledger: credited on receipt at the VENDOR unit price,
+    // debited when the vendor's bill arrives.
+    code: '2160',
+    name: 'Goods Received Not Invoiced',
+    accountType: GlAccountType.LIABILITY,
+    role: 'grni',
   },
   {
-    // Pick/pack/receive labour - explicitly NOT inventory (accrual plan §2).
-    code: '6200',
-    name: 'Fulfillment Labor',
-    accountType: GlAccountType.EXPENSE,
+    // Not in the accrual plan's table. Tariffs and customs duties owed
+    // SEPARATELY TO THE U.S. GOVERNMENT.
+    //
+    // 🛑 NOT the customs broker's share. This file, `build-entry.ts` and the
+    // (now deleted) registry enum all used to say it held "the customs broker's
+    // share"; all three were wrong. A broker sells a service on a shipment, so
+    // their charge is inbound freight's problem and clears through 2150.
+    //
+    // Only ever carries a balance when a receipt had a non-zero tariff portion;
+    // build plan phase 0.1 asks whether `tariffRate` is ever non-zero at all. An
+    // org that never imports can deactivate it and no posting will ever
+    // reference it.
+    code: '2170',
+    name: 'Duties Accrual',
+    accountType: GlAccountType.LIABILITY,
+    role: 'duties_accrual',
   },
+
+  // ── Cost of goods sold ──────────────────────────────────────────────────
   {
-    // The `write_off` entry's debit leg. `1190 Allowance for Doubtful Accounts`
-    // is the contra-asset the reserve method would credit; the direct
-    // write-off posts here and credits receivables.
-    code: '6300',
-    name: 'Bad Debt Expense',
+    code: '5090',
+    name: 'Inventory / Purchase Price Variance',
     accountType: GlAccountType.EXPENSE,
-    role: 'bad_debt_expense',
+    role: 'ppv',
+    subtype: GlAccountSubtype.COST_OF_GOODS_SOLD,
   },
 ]
+
+/**
+ * The default chart of accounts, as five packs.
+ *
+ * ## What this is, and what it is NOT
+ *
+ * **It is a DEFAULT, not a standard** (decision `G7`). Charts of accounts are
+ * not standardised: US GAAP mandates no numbering at all, QuickBooks' own
+ * default chart varies by country and by industry and is routinely edited on
+ * day one, and some jurisdictions mandate an entirely different one - France's
+ * PCG, Germany's SKR03/04. So auxx seeds this, and a person changes it: renames
+ * an account, renumbers one, deactivates one at year end, adds twenty of their
+ * own. A pack is still data a person edits afterwards.
+ *
+ * **That editability is exactly why nothing in the code may name a number.**
+ * The `role` column is the load-bearing part of every row here (decision `G8`).
+ * A builder emits `ACCOUNT_ROLES.GRNI`; the resolver reads THIS org's chart to
+ * learn that GRNI is `2160` here and `2155` at the customer who renumbered it.
+ * Change a `code` below and posting still works. Change a `role` and it stops -
+ * which is why the role field is where the care goes.
+ *
+ * **It is not a complete chart.** The source (`plans/money/accrual-accounting-plan.html`
+ * §2) is titled *"Accounts to add in QuickBooks"* - it presumes an existing
+ * book with bank accounts, equity, retained earnings, operating expenses and the
+ * rest already in place. Five accounts the posting builders need are added on
+ * top of it (`1000`, `2000`, `2160`, `2170`, `5095`), because the accrual plan's
+ * table does not list them. Three equity accounts (`3000`, `3100`, `3900`) were
+ * added 2026-09-04 once the opening trial balance and the balance sheet needed
+ * somewhere to land (plans/accounting/HANDOFF.md decision 6.4), with `1050`,
+ * `4020` and `6300` in the same pass.
+ *
+ * ## The two things to check before this is seeded
+ *
+ * 1. **The numbering.** It is the accrual plan's, which was written against one
+ *    company's QuickBooks. A new org gets it as a starting point.
+ * 2. **The type mapping.** The accrual plan's *Type* column carries QuickBooks
+ *    DETAIL types (`Other Current Asset`, `Cost of Goods Sold`, `Income`,
+ *    `Accounts Receivable`, `contra-asset`). `GlAccountType` is the five-way
+ *    statement classification, so they are collapsed: Income -> `revenue`, Cost
+ *    of Goods Sold and Expense -> `expense`, every asset flavour -> `asset`,
+ *    Other Current Liability -> `liability`. The collapse loses the
+ *    current/non-current split and any contra marking; that is a presentation
+ *    concern for the provider's own chart, not something a posting reads.
+ *
+ * @see ACCOUNT_ROLES in `build-entry.ts` for what each role means
+ * @see plans/money/accrual-accounting-plan.html §2 for the accounting argument
+ * @see plans/accounting/tasks/16-the-chart-of-accounts.md §1 for the packs
+ */
+export const CHART_PACKS: Record<ChartPackKey, ChartPack> = {
+  core: {
+    key: 'core',
+    label: 'Core',
+    description:
+      'Receivables, payables, sales tax, equity, revenue and bad debt. Every organization gets these.',
+    accounts: CORE_ACCOUNTS,
+  },
+  card_rail: {
+    key: 'card_rail',
+    label: 'Card payments and payouts',
+    description:
+      'Clearing and fee accounts for Stripe Connect, Shopify Payments and Affirm settlements.',
+    accounts: CARD_RAIL_ACCOUNTS,
+  },
+  prepayments: {
+    key: 'prepayments',
+    label: 'Deposits and deferred revenue',
+    description: 'Customer deposits taken before delivery, and revenue deferred at month end.',
+    accounts: PREPAYMENTS_ACCOUNTS,
+  },
+  inventory: {
+    key: 'inventory',
+    label: 'Inventory and manufacturing',
+    description:
+      'Raw materials, work in process, finished goods, payroll clearing and cost of goods sold.',
+    accounts: INVENTORY_ACCOUNTS,
+  },
+  purchasing: {
+    key: 'purchasing',
+    label: 'Purchase orders, receiving and vendor bills',
+    description:
+      'Goods received not invoiced, inbound freight and duties accruals, and purchase price variance.',
+    requires: ['inventory'],
+    accounts: PURCHASING_ACCOUNTS,
+  },
+}
+
+/**
+ * Every pack key in declaration order, `core` first. A tuple rather than
+ * `Object.keys(CHART_PACKS)` so a `z.enum` can be built from it.
+ */
+export const CHART_PACK_KEYS = [
+  'core',
+  'card_rail',
+  'prepayments',
+  'inventory',
+  'purchasing',
+] as const satisfies readonly ChartPackKey[]
+
+/**
+ * Every pack flattened, in pack order. What the union tests and the old
+ * importers read; the seeder walks packs instead (16 §1.5).
+ */
+export const DEFAULT_CHART_OF_ACCOUNTS: readonly DefaultChartAccount[] = CHART_PACK_KEYS.flatMap(
+  (key) => CHART_PACKS[key].accounts
+)
+
+/** `role -> pack`, built once from the tables. The union test proves it total. */
+const PACK_BY_ROLE = Object.fromEntries(
+  CHART_PACK_KEYS.flatMap((key) =>
+    CHART_PACKS[key].accounts.flatMap((account) => (account.role ? [[account.role, key]] : []))
+  )
+) as Record<AccountRole, ChartPackKey>
+
+/** The pack whose accounts carry this role. Every role is in exactly one. */
+export function packForRole(role: AccountRole): ChartPackKey {
+  return PACK_BY_ROLE[role]
+}
+
+/**
+ * A pack is provisioned when none of its roles is `unmapped`.
+ *
+ * Derived on the client from `ledger.roleMap` and `CHART_PACKS`; no new query.
+ * `unused` and `suggested` both count as present: a person has looked at the
+ * role, which is the thing an absent row says nobody has. A role missing from
+ * `roleMap` altogether is read as `unmapped`, though `listRoleMap` returns
+ * every role.
+ */
+export function packState(
+  pack: ChartPackKey,
+  roleMap: readonly Pick<RoleAssignmentRow, 'role' | 'state'>[]
+): 'provisioned' | 'partial' | 'absent' {
+  const roles = CHART_PACKS[pack].accounts.flatMap((account) =>
+    account.role ? [account.role] : []
+  )
+  const stateByRole = new Map(roleMap.map((row) => [row.role, row.state]))
+  const unmapped = roles.filter((role) => (stateByRole.get(role) ?? 'unmapped') === 'unmapped')
+  if (unmapped.length === 0) return 'provisioned'
+  if (unmapped.length === roles.length) return 'absent'
+  return 'partial'
+}

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -148,6 +148,13 @@ export {
   WRITE_OFF_SOURCE_TYPE,
   writeOffPeriodKey,
 } from './build-write-off-entry'
+// ── plans/accounting/tasks/16: the chart import ─────────────────────────────
+export { type ImportChartOptions, importChartFromProvider } from './chart-import'
+export {
+  PROVIDER_ACCOUNT_TYPE_SUBTYPE,
+  planChartImport,
+  ROLE_IMPORT_MATCH,
+} from './chart-import-plan'
 export {
   type CreateChartAccountOptions,
   createChartAccount,
@@ -164,10 +171,16 @@ export {
 } from './close-month'
 export { listClosePeriods } from './close-periods'
 export {
+  CHART_PACK_KEYS,
+  CHART_PACKS,
+  type ChartPack,
+  type ChartPackKey,
   DEFAULT_CHART_OF_ACCOUNTS,
   type DefaultChartAccount,
   GL_ACCOUNT_TYPES,
   type GlAccountTypeValue,
+  packForRole,
+  packState,
 } from './default-chart'
 export {
   buildDocNumber,
@@ -420,6 +433,8 @@ export {
   type AccountSuggestionReason,
   type BuiltEntry,
   type ChartAccountRow,
+  type ChartImportPlan,
+  type ChartImportResult,
   type ClosePeriod,
   type CounterpartyType,
   type GlPostingLineInput,

--- a/packages/lib/src/postings/resolve-roles.ts
+++ b/packages/lib/src/postings/resolve-roles.ts
@@ -22,7 +22,7 @@
  * **It is a BATCH.** `resolveRoles` takes the whole set of roles an entry
  * names and answers once. A month-end entry touching six roles on an org that
  * has mapped none of them must fail ONCE, naming all six, not six times naming
- * one — a bookkeeper fixing a close needs the list, not a treasure hunt. The
+ * one - a bookkeeper fixing a close needs the list, not a treasure hunt. The
  * `G19` setup wizard needs exactly the same batch answer.
  *
  * **It fails CLOSED, on five distinct conditions, with five distinct messages.**
@@ -38,18 +38,18 @@
  * `(organizationId, role)` makes `>1 match` unreachable; §"the impossible case"
  * below asserts it anyway.
  *
- * ## Not cached, deliberately — read this before adding a cache key
+ * ## Not cached, deliberately - read this before adding a cache key
  *
  * The obvious move is an `OrgCacheDataMap` key. It was considered and rejected
  * for now, because the invalidation doors this would need do not exist:
  * `gl_account` is an `EntityInstance`, and there is no per-entity-type record
- * event in `INVALIDATION_GRAPH` — only `entity-def.*` and `custom-field.*`,
+ * event in `INVALIDATION_GRAPH` - only `entity-def.*` and `custom-field.*`,
  * neither of which fires when a bookkeeper renames or archives an ACCOUNT. A
  * cached key wired to the doors that DO exist is correct for an hour and then
  * posts to the account somebody renamed, and it fails OPEN: the entry balances.
  *
  * The cost of not caching is two indexed reads on a path that runs at a close or
- * per posted event — not a hot request path. When the `G19` wizard lands and
+ * per posted event - not a hot request path. When the `G19` wizard lands and
  * gives assignment writes an explicit event of their own, cache it then, and
  * wire `gl_account` create/update/archive at the same time or not at all.
  *
@@ -62,9 +62,9 @@ import { and, eq, inArray } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, UnprocessableEntityError } from '../errors'
 import { accountLabel } from './account-label'
-import { type AccountRole, ROLE_ACCOUNT_TYPES } from './build-entry'
+import { ACCOUNT_ROLE_LABELS, type AccountRole, ROLE_ACCOUNT_TYPES } from './build-entry'
 import { loadChartAccountFields, loadChartAccountsById } from './chart-accounts'
-import type { GlAccountTypeValue } from './default-chart'
+import { CHART_PACKS, type GlAccountTypeValue, packForRole } from './default-chart'
 import type { GlPostingLineInput } from './types'
 
 const logger = createScopedLogger('postings:resolve-roles')
@@ -93,7 +93,7 @@ export interface ResolvedAccount {
   /** The account's name as it stands NOW. Snapshot it; renaming must not restate the ledger. */
   name: string
   accountType: GlAccountTypeValue
-  /** Always `true` on a successful resolution — an inactive account is a refusal. */
+  /** Always `true` on a successful resolution - an inactive account is a refusal. */
   isActive: boolean
 }
 
@@ -101,14 +101,14 @@ export interface ResolvedAccount {
  * Resolve every role in one call, or refuse naming all of them.
  *
  * Duplicate roles in `roles` are collapsed; the returned map is keyed by role.
- * An empty input resolves to an empty map rather than an error — an entry with
+ * An empty input resolves to an empty map rather than an error - an entry with
  * no lines is `buildEntry`'s refusal to make, not this function's.
  *
  * Fails closed on all five `G19` conditions, each with its own message:
  *
  * | Condition | What the reader has to do about it |
  * | --- | --- |
- * | no assignment row | map the role — nobody ever has |
+ * | no assignment row | map the role - nobody ever has |
  * | `markedUnused` | somebody said "we don't use this" and a builder emitted it anyway |
  * | account missing or archived | the chart moved under the mapping; repoint it |
  * | `isActive = false` | reactivate the account, or repoint the role |
@@ -147,7 +147,7 @@ export async function resolveRoles(
       if (byRole.has(row.role)) {
         throw new UnprocessableEntityError(
           `Organization ${organizationId} has more than one account mapped to role '${row.role}'. ` +
-            'Refusing to choose. This should be impossible — GlRoleAssignment_org_role_key is a unique index.',
+            'Refusing to choose. This should be impossible - GlRoleAssignment_org_role_key is a unique index.',
           { organizationId, role: row.role }
         )
       }
@@ -164,8 +164,15 @@ export async function resolveRoles(
       const assignment = byRole.get(role)
 
       if (!assignment) {
+        // A DECLARED role gets the rich sentence naming its label and the pack
+        // that would provision it (16 §3.2). An invented role (caught properly
+        // below as "not a declared posting role") has neither, so it falls back
+        // to the plain sentence rather than indexing `CHART_PACKS` with nothing.
+        const label = ACCOUNT_ROLE_LABELS[role as AccountRole]
         problems.push(
-          `'${role}' is not mapped to any account. Map it in the chart of accounts before posting.`
+          label
+            ? `'${role}' (${label}) is not mapped to any account. Add the ${CHART_PACKS[packForRole(role as AccountRole)].label} accounts under Accounting > Settings > Accounts > Roles, or map it to an account of your own there.`
+            : `'${role}' is not mapped to any account. Map it in the chart of accounts before posting.`
         )
         continue
       }
@@ -199,7 +206,7 @@ export async function resolveRoles(
       // sentence rather than being folded into the type mismatch below.
       if (!expectedType) {
         problems.push(
-          `'${role}' is not a declared posting role. The role vocabulary is closed — see ACCOUNT_ROLES.`
+          `'${role}' is not a declared posting role. The role vocabulary is closed - see ACCOUNT_ROLES.`
         )
         continue
       }

--- a/packages/lib/src/postings/role-map.ts
+++ b/packages/lib/src/postings/role-map.ts
@@ -71,7 +71,7 @@ const NOT_PROVISIONED =
 /** Every declared role, in declaration order. The checklist `listRoleMap` walks. */
 const ALL_ROLES: readonly AccountRole[] = Object.values(ACCOUNT_ROLES)
 
-/** Is `role` one of the thirteen declared roles? The vocabulary is CLOSED. */
+/** Is `role` one of the declared roles - every role in `ACCOUNT_ROLES`, across five chart packs (16 §1)? The vocabulary is CLOSED. */
 function isAccountRole(role: string): role is AccountRole {
   return (ALL_ROLES as readonly string[]).includes(role)
 }
@@ -128,7 +128,7 @@ export async function listRoleMap(
 
     // Only the accounts a mapping actually names. An org with no assignments
     // reads no chart at all, which is what keeps a fresh org's role map a list
-    // of thirteen `unmapped` rows rather than a provisioning error.
+    // of every role `unmapped` rather than a provisioning error.
     const accountIds = [...new Set(assignments.map((row) => row.glAccountId))]
     const accounts = await loadChartAccountsById(db, organizationId, accountIds)
 

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -21,7 +21,8 @@
  * must never be a third. See plans/money/tasks/done/07-align-gl-foundation.md section 6.
  */
 import type { GlAccountSubtypeValue } from './account-subtype'
-import type { GlAccountTypeValue } from './default-chart'
+import type { AccountRole } from './build-entry'
+import type { DefaultChartAccount, GlAccountTypeValue } from './default-chart'
 
 export const POSTING_TYPES = [
   'fulfillment',
@@ -762,7 +763,14 @@ export interface RoleAssignmentRow {
   accountId: string | null
   /** Resolved for display. Null when unmapped, or when the account has vanished. */
   account: ChartAccountRow | null
-  /** `'seed'` | `'human'` | `'suggested'`, or null with no row. */
+  /**
+   * `'seed'` | `'human'` | `'suggested'` | `'import'`, or null with no row.
+   *
+   * `'import'` is written by `importChartFromProvider` for a role it matched
+   * unambiguously on the provider's chart (brief 16 §2.2). It renders as
+   * `suggested` like `'seed'` does, because `state` is derived from
+   * `confirmedAt` alone: the import chose it, nobody has agreed yet.
+   */
   source: string | null
   confirmedAt: string | null
 }
@@ -857,6 +865,48 @@ export interface AccountIdentityRow {
    * something is mapped, and null when nothing plausible matched.
    */
   suggestion: { account: ProviderAccount; reason: AccountSuggestionReason } | null
+}
+
+/**
+ * What an import of the provider's chart would do, before it does it
+ * (brief 16 §2.2). Produced by the pure `planChartImport`, executed by
+ * `importChartFromProvider`.
+ *
+ * `create` carries the code (the provider's `number`, or null), the name, the
+ * five-way type and the subtype the declared inverse table stamps, or null
+ * where the provider type is ambiguous (`Other Current Asset` is deliberately
+ * unmapped: Undeposited Funds, prepaids and Inventory Asset all arrive under
+ * it). `alreadyImported` is every provider account some `gl_account` already
+ * carries as its identity, renamed or not.
+ */
+export interface ChartImportPlan {
+  create: Array<{
+    providerAccount: ProviderAccount
+    code: string | null
+    name: string
+    accountType: GlAccountTypeValue
+    subtype: GlAccountSubtypeValue | null
+  }>
+  skippedInactive: ProviderAccount[]
+  alreadyImported: Array<{ providerAccount: ProviderAccount; glAccountId: string }>
+  /** Roles with exactly one unambiguous candidate, resolved AFTER creation. */
+  roleCandidates: Array<{ role: AccountRole; match: 'subtype' | 'name'; providerAccountId: string }>
+  /** Core role-bearing accounts the provider chart cannot satisfy. */
+  missingCore: DefaultChartAccount[]
+}
+
+/**
+ * What `importChartFromProvider` did (brief 16 §2.2). Counts, never rows: the
+ * screen reports "12 added, 41 already here" and re-reads the chart itself.
+ */
+export interface ChartImportResult {
+  created: number
+  alreadyImported: number
+  skippedInactive: number
+  /** Written with `source: 'import'`, only for roles that were `unmapped`. */
+  rolesAssigned: AccountRole[]
+  /** The uncoded, unmapped core accounts added because the provider lacks them. */
+  coreCreated: DefaultChartAccount[]
 }
 
 /**

--- a/packages/lib/src/seed/gl-account-chart-payment-gateways.test.ts
+++ b/packages/lib/src/seed/gl-account-chart-payment-gateways.test.ts
@@ -6,6 +6,18 @@
 // `../resources/crud` directly, while this exercises the boundary one layer
 // up - `../payment-gateways` itself - so a change to the write path's
 // internals cannot silently desync the two doubles.
+//
+// This function is NOT called from `seedChartPacks`'s core walk (brief 16
+// §1.5) - it is a separate export the router calls only when the walked packs
+// include `card_rail`. That gate is a ROUTER decision, not something this
+// function or `seedChartPacks` can see (neither takes a `packs` argument the
+// other reads), so "gateways seed after `card_rail`, never after `['core']`"
+// is pinned at the router level instead:
+// `apps/web/src/server/api/routers/ledger-permissions.test.ts`'s "never seeds
+// payment gateways after provisioning only core" / "seeds payment gateways
+// after provisioning card_rail" cases. What THIS file still pins is what it
+// always pinned: given a chart whose roles are (or are not) mapped, which
+// gateways get created.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/packages/lib/src/seed/gl-account-chart.test.ts
+++ b/packages/lib/src/seed/gl-account-chart.test.ts
@@ -5,7 +5,7 @@
 // So the properties pinned here are the ones the resolver depends on.
 //
 //  1. **Exactly one account per role, per org.** The resolver must fail CLOSED
-//     on zero or more than one match — never "take the first" — so a chart with
+//     on zero or more than one match - never "take the first" - so a chart with
 //     two accounts claiming `grni` does not put money in an arbitrary place, it
 //     stops every posting. Since decision `G19` that is a Postgres unique index
 //     on `GlRoleAssignment(organizationId, role)`; what this file pins is that
@@ -16,28 +16,32 @@
 //     re-run that inserted a second `1310` would pass validation and break the
 //     resolver for every posting, not just the one that touches 1310.
 //  3. **Never repoint a role the org already mapped.** `ON CONFLICT
-//     (organizationId, role) DO NOTHING` — a bookkeeper who moved `grni` onto
+//     (organizationId, role) DO NOTHING` - a bookkeeper who moved `grni` onto
 //     their own `2155` keeps it through every re-seed.
 //  4. **Never touch an account the org already has.** Not the name, not the
 //     type. A chart is the bookkeeper's document (`G7`).
+//  5. **Packs, not the flat chart** (brief 16 §1.5). `seedChartPacks` always
+//     walks `core` first and expands `requires` transitively, so
+//     `['purchasing']` also lands `inventory`, and the packs actually walked
+//     come back on the result.
 //
-// ✅ The old rule 5, `assertRolesLanded`, is GONE and so is its test. It existed
-// because a role was written as a `gl_account_role` FIELD through
-// `UnifiedCrudHandler`, which resolves fields from the ORG CACHE and SILENTLY
-// DROPS a value whose field it cannot resolve — the defect that wrote 784
-// accounts across 28 orgs with every column populated except the role, and
+// ✅ The old rule that used to sit here, `assertRolesLanded`, is GONE and so is
+// its test. It existed because a role was written as a `gl_account_role` FIELD
+// through `UnifiedCrudHandler`, which resolves fields from the ORG CACHE and
+// SILENTLY DROPS a value whose field it cannot resolve - the defect that wrote
+// 784 accounts across 28 orgs with every column populated except the role, and
 // logged success. `G19` moved the mapping to a table and the insert is now plain
 // Drizzle: no field resolution, no cache, nothing to drop. The failure mode is
 // structurally unavailable rather than guarded against.
 //
-// `UnifiedCrudHandler` is stubbed — a lib-internal module, following the pattern
-// `ai-category-tags.test.ts` set — so the assertions are about the values this
+// `UnifiedCrudHandler` is stubbed - a lib-internal module, following the pattern
+// `ai-category-tags.test.ts` set - so the assertions are about the values this
 // module hands the write path.
 
 import type { Database } from '@auxx/database'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ACCOUNT_ROLES } from '../postings/build-entry'
-import { DEFAULT_CHART_OF_ACCOUNTS } from '../postings/default-chart'
+import { CHART_PACKS } from '../postings/default-chart'
 
 const h = vi.hoisted(() => ({
   creates: [] as { entityDefinitionId: string; values: Record<string, unknown> }[],
@@ -71,20 +75,44 @@ vi.mock('../users/system-user-service', () => ({
   SystemUserService: { getSystemUserForActions: async () => 'system-user-1' },
 }))
 
-import { seedDefaultChartOfAccounts } from './gl-account-chart'
+import { seedChartPacks, seedDefaultChartOfAccounts } from './gl-account-chart'
 
 const DEF_ID = 'def-gl-account'
 const CODE_FIELD_ID = 'field-gl-account-code'
 
+/** Every account in a pack, in pack order, flattened - the shape `seedChartPacks` walks. */
+const CORE_ACCOUNTS = CHART_PACKS.core.accounts
+const INVENTORY_ACCOUNTS = CHART_PACKS.inventory.accounts
+const PURCHASING_ACCOUNTS = CHART_PACKS.purchasing.accounts
+
+const CORE_CODES = CORE_ACCOUNTS.map((a) => a.code)
+const CORE_ROLES = CORE_ACCOUNTS.flatMap((a) => (a.role ? [a.role] : []))
+const CORE_PLUS_INVENTORY_ACCOUNTS = [...CORE_ACCOUNTS, ...INVENTORY_ACCOUNTS]
+const CORE_PLUS_INVENTORY_ROLES = CORE_PLUS_INVENTORY_ACCOUNTS.flatMap((a) =>
+  a.role ? [a.role] : []
+)
+const CORE_INVENTORY_PURCHASING_ACCOUNTS = [
+  ...CORE_ACCOUNTS,
+  ...INVENTORY_ACCOUNTS,
+  ...PURCHASING_ACCOUNTS,
+]
+const CORE_INVENTORY_PURCHASING_ROLES = CORE_INVENTORY_PURCHASING_ACCOUNTS.flatMap((a) =>
+  a.role ? [a.role] : []
+)
+
 /**
- * A stub `Database` that answers two selects — the `gl_account_code` field and
- * the code values the org already holds — and records the assignment insert.
+ * A stub `Database` that answers two selects - the `gl_account_code` field and
+ * the code values the org already holds - and records the assignment insert.
  *
  * WHERE clauses are ignored: the module scopes in SQL and picks in JS, and
  * evaluating Drizzle conditions is not what this file is about.
  */
-function stubDb(existingCodes: string[], opts: { codeField?: boolean } = {}) {
+function stubDb(
+  existingCodes: string[],
+  opts: { codeField?: boolean; existingRoles?: readonly string[] } = {}
+) {
   let call = 0
+  const existingRoles = new Set(opts.existingRoles ?? [])
   const chain = (rows: unknown[]) => ({
     where: () => chain(rows),
     limit: () => chain(rows),
@@ -112,9 +140,14 @@ function stubDb(existingCodes: string[], opts: { codeField?: boolean } = {}) {
           onConflictDoNothing: (config: unknown) => {
             h.conflictTargets.push(config)
             return {
-              // Every row is treated as inserted; the DO NOTHING behaviour is
-              // Postgres', and asserting it here would be asserting the stub.
-              returning: async () => rows.map((_, index) => ({ id: `assign_${index + 1}` })),
+              // `existingRoles` simulates the ON CONFLICT (organizationId,
+              // role) DO NOTHING a real Postgres index enforces - a role
+              // already held by the org comes back un-returned, same as a
+              // real re-seed. Everything else is treated as inserted.
+              returning: async () =>
+                rows
+                  .filter((row) => !existingRoles.has(row.role as string))
+                  .map((_, index) => ({ id: `assign_${index + 1}` })),
             }
           },
         }
@@ -130,29 +163,68 @@ beforeEach(() => {
   h.conflictTargets.length = 0
 })
 
-/** Every role the default chart declares, which is every role that exists. */
-const CHART_ROLES = DEFAULT_CHART_OF_ACCOUNTS.flatMap((a) => (a.role ? [a.role] : []))
-
-// The chart DATA's own invariants — one account per role, no role twice, no
-// account claiming a role no builder emits — are pinned in
+// The chart DATA's own invariants - one account per role, no role twice, no
+// account claiming a role no builder emits - are pinned in
 // `postings/__tests__/default-chart.test.ts`, next to the constant. This file
 // is only about what the WRITER does with it.
 
-describe('seedDefaultChartOfAccounts', () => {
-  it('creates every account on a first pass over an empty org', async () => {
-    const result = await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+describe('seedChartPacks', () => {
+  it('walks core first, expands requires, and reports the packs actually walked', async () => {
+    const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['purchasing'])
 
-    expect(result.created).toBe(DEFAULT_CHART_OF_ACCOUNTS.length)
-    expect(result.skipped).toBe(0)
-    expect(h.creates).toHaveLength(DEFAULT_CHART_OF_ACCOUNTS.length)
-    expect(h.creates.every((c) => c.entityDefinitionId === DEF_ID)).toBe(true)
+    expect(result.packs).toEqual(['core', 'inventory', 'purchasing'])
   })
 
-  // 🛑 No `gl_account_role`. The field does not exist any more (`G19`), and a
-  // key `UnifiedCrudHandler` cannot resolve is DROPPED rather than rejected — so
-  // re-adding one here would silently write nothing and look correct in review.
+  it("['core'] creates 13 and assigns 11", async () => {
+    const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core'])
+
+    expect(result.packs).toEqual(['core'])
+    expect(result.created).toBe(13)
+    expect(result.created).toBe(CORE_CODES.length)
+    expect(result.rolesAssigned).toBe(11)
+    expect(result.rolesAssigned).toBe(CORE_ROLES.length)
+    expect(h.creates).toHaveLength(13)
+  })
+
+  it("['core', 'inventory'] creates 22 and assigns 18", async () => {
+    const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core', 'inventory'])
+
+    expect(result.packs).toEqual(['core', 'inventory'])
+    expect(result.created).toBe(22)
+    expect(result.created).toBe(CORE_PLUS_INVENTORY_ACCOUNTS.length)
+    expect(result.rolesAssigned).toBe(18)
+    expect(result.rolesAssigned).toBe(CORE_PLUS_INVENTORY_ROLES.length)
+  })
+
+  it("['purchasing'] alone walks core, then inventory, then purchasing, landing 26 accounts and 22 roles", async () => {
+    const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['purchasing'])
+
+    expect(result.packs).toEqual(['core', 'inventory', 'purchasing'])
+    expect(result.created).toBe(26)
+    expect(result.created).toBe(CORE_INVENTORY_PURCHASING_ACCOUNTS.length)
+    expect(result.rolesAssigned).toBe(22)
+    expect(result.rolesAssigned).toBe(CORE_INVENTORY_PURCHASING_ROLES.length)
+  })
+
+  it('a second pass over the same packs creates and assigns nothing', async () => {
+    const heldCodes = CORE_INVENTORY_PURCHASING_ACCOUNTS.map((a) => a.code)
+    const heldRoles = CORE_INVENTORY_PURCHASING_ROLES
+
+    const second = await seedChartPacks(
+      stubDb(heldCodes, { existingRoles: heldRoles }),
+      'org-1',
+      DEF_ID,
+      ['purchasing']
+    )
+
+    expect(second.created).toBe(0)
+    expect(second.rolesAssigned).toBe(0)
+    expect(second.packs).toEqual(['core', 'inventory', 'purchasing'])
+    expect(h.creates).toEqual([])
+  })
+
   it('writes code, name, type and active on every row, and nothing else', async () => {
-    await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+    await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['purchasing'])
 
     const grni = h.creates.find((c) => c.values.gl_account_code === '2160')
     expect(grni?.values).toEqual({
@@ -164,15 +236,15 @@ describe('seedDefaultChartOfAccounts', () => {
   })
 
   it('never writes a gl_account_role key on any account', async () => {
-    await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+    await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['purchasing'])
 
     for (const create of h.creates) {
       expect('gl_account_role' in create.values, String(create.values.gl_account_code)).toBe(false)
     }
   })
 
-  it('seeds the corrected chart — 2150 broadened, 5095 present', async () => {
-    await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+  it('seeds the corrected purchasing accounts - 2150 broadened, 5095 in inventory not purchasing', async () => {
+    await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['purchasing'])
 
     const byCode = new Map(h.creates.map((c) => [c.values.gl_account_code, c.values]))
     expect(byCode.get('2150')?.gl_account_name).toBe('Inbound Freight & Brokerage Accrual')
@@ -182,16 +254,14 @@ describe('seedDefaultChartOfAccounts', () => {
 
   describe('role assignments', () => {
     it('writes exactly one assignment per declared role, pointed at the right account', async () => {
-      const result = await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+      const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['purchasing'])
 
-      expect(result.rolesAssigned).toBe(CHART_ROLES.length)
+      expect(result.rolesAssigned).toBe(CORE_INVENTORY_PURCHASING_ROLES.length)
       expect(h.assignmentBatches).toHaveLength(1)
 
       const rows = h.assignmentBatches[0] ?? []
-      expect(rows.map((r) => r.role).sort()).toEqual([...CHART_ROLES].sort())
+      expect(rows.map((r) => r.role).sort()).toEqual([...CORE_INVENTORY_PURCHASING_ROLES].sort())
 
-      // GRNI is the fifteenth create (index 14), so `acct_15` — the id the
-      // handler stub minted for `2160`.
       const grniIndex = h.creates.findIndex((c) => c.values.gl_account_code === '2160')
       const grni = rows.find((r) => r.role === ACCOUNT_ROLES.GRNI)
       expect(grni?.glAccountId).toBe(`acct_${grniIndex + 1}`)
@@ -201,7 +271,7 @@ describe('seedDefaultChartOfAccounts', () => {
     // setup wizard renders "we chose this for you" differently from "you chose
     // this". Stamping a confirmation nobody gave would erase that on day one.
     it('marks every seeded mapping as source `seed`, and confirms nothing', async () => {
-      await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+      await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core'])
 
       for (const row of h.assignmentBatches[0] ?? []) {
         expect(row.source).toBe('seed')
@@ -214,7 +284,7 @@ describe('seedDefaultChartOfAccounts', () => {
     // index that makes the resolver's answer unambiguous is the same index that
     // makes this insert safe to repeat.
     it('defers to a mapping the org already made', async () => {
-      await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+      await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core'])
 
       expect(h.conflictTargets).toHaveLength(1)
       expect(h.conflictTargets[0]).toMatchObject({ target: expect.any(Array) })
@@ -225,78 +295,63 @@ describe('seedDefaultChartOfAccounts', () => {
     // mid-run, and what a partially-applied seed leaves behind for real. The
     // roles must still be written, pointed at the accounts already there.
     it('assigns roles to accounts it did NOT create', async () => {
-      const held = DEFAULT_CHART_OF_ACCOUNTS.map((a) => a.code)
-      const result = await seedDefaultChartOfAccounts(stubDb(held), 'org-1', DEF_ID)
+      const result = await seedChartPacks(stubDb(CORE_CODES), 'org-1', DEF_ID, ['core'])
 
       expect(result.created).toBe(0)
-      expect(result.rolesAssigned).toBe(CHART_ROLES.length)
+      expect(result.rolesAssigned).toBe(CORE_ROLES.length)
 
       const rows = h.assignmentBatches[0] ?? []
-      const grniIndex = DEFAULT_CHART_OF_ACCOUNTS.findIndex((a) => a.code === '2160')
-      expect(rows.find((r) => r.role === ACCOUNT_ROLES.GRNI)?.glAccountId).toBe(
-        `existing_${grniIndex + 1}`
+      const arIndex = CORE_ACCOUNTS.findIndex((a) => a.code === '1100')
+      expect(rows.find((r) => r.role === ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE)?.glAccountId).toBe(
+        `existing_${arIndex + 1}`
       )
     })
   })
 
-  it('creates nothing on a second pass, and reports it', async () => {
-    const held = DEFAULT_CHART_OF_ACCOUNTS.map((a) => a.code)
-    const result = await seedDefaultChartOfAccounts(stubDb(held), 'org-1', DEF_ID)
-
-    expect(result.created).toBe(0)
-    expect(result.skipped).toBe(DEFAULT_CHART_OF_ACCOUNTS.length)
-    expect(h.creates).toEqual([])
-  })
-
-  // 🛑 The partial case, which is the one that actually happens: a run that
-  // died halfway, or an org that already had `1000` of its own. Re-inserting a
-  // held code is what puts two `1310` rows in a chart, and the unique gate
-  // (check-then-write, archived rows excluded) does not reliably stop it.
   it('inserts only the codes the org is missing', async () => {
-    const result = await seedDefaultChartOfAccounts(
-      stubDb(['1000', '1310', '2160']),
-      'org-1',
-      DEF_ID
-    )
+    const result = await seedChartPacks(stubDb(['1000', '1100', '2200']), 'org-1', DEF_ID, ['core'])
 
-    expect(result.created).toBe(DEFAULT_CHART_OF_ACCOUNTS.length - 3)
+    expect(result.created).toBe(CORE_CODES.length - 3)
     const written = h.creates.map((c) => c.values.gl_account_code)
     expect(written).not.toContain('1000')
-    expect(written).not.toContain('1310')
-    expect(written).not.toContain('2160')
+    expect(written).not.toContain('1100')
+    expect(written).not.toContain('2200')
   })
 
   it('is a no-op when the org has no gl_account def yet', async () => {
-    const result = await seedDefaultChartOfAccounts(stubDb([]), 'org-1', undefined)
+    const result = await seedChartPacks(stubDb([]), 'org-1', undefined, ['core'])
 
-    expect(result).toEqual({ created: 0, skipped: 0, rolesAssigned: 0 })
+    expect(result).toEqual({ created: 0, skipped: 0, rolesAssigned: 0, packs: ['core'] })
     expect(h.creates).toEqual([])
-    expect(h.assignmentBatches).toEqual([])
   })
 
   // The def can exist a moment before its fields do. Writing rows with no code
-  // would give the org a chart whose accounts have no identity at all — and no
+  // would give the org a chart whose accounts have no identity at all - and no
   // second pass could tell them apart to fix it.
   it('is a no-op when gl_account_code has not been materialised', async () => {
-    const result = await seedDefaultChartOfAccounts(
-      stubDb([], { codeField: false }),
-      'org-1',
-      DEF_ID
-    )
+    const result = await seedChartPacks(stubDb([], { codeField: false }), 'org-1', DEF_ID, ['core'])
 
-    expect(result).toEqual({ created: 0, skipped: 0, rolesAssigned: 0 })
+    expect(result).toEqual({ created: 0, skipped: 0, rolesAssigned: 0, packs: ['core'] })
     expect(h.creates).toEqual([])
     expect(h.assignmentBatches).toEqual([])
   })
 
-  // A seed has nobody to notify, and 29 accounts x 28 orgs of cache
-  // invalidations is real time on a cold Redis.
   it('writes through a silent seed session', async () => {
-    await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+    await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core'])
 
     expect(h.constructorOptions).toHaveLength(1)
     expect(h.constructorOptions[0]).toMatchObject({
       session: { origin: { kind: 'seed' } },
     })
+  })
+})
+
+describe('seedDefaultChartOfAccounts', () => {
+  it("is seedChartPacks(..., ['core']) - the one caller that means the core", async () => {
+    const result = await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
+
+    expect(result.packs).toEqual(['core'])
+    expect(result.created).toBe(13)
+    expect(result.rolesAssigned).toBe(11)
   })
 })

--- a/packages/lib/src/seed/gl-account-chart.ts
+++ b/packages/lib/src/seed/gl-account-chart.ts
@@ -1,21 +1,26 @@
 // packages/lib/src/seed/gl-account-chart.ts
 //
-// Seeds `DEFAULT_CHART_OF_ACCOUNTS` into one organization as `gl_account`
-// EntityInstances, and points each posting ROLE at the account that fulfils it
-// via a `GlRoleAssignment` row (decision `G19`).
+// Seeds one or more chart PACKS (`postings/default-chart.ts`'s `CHART_PACKS`,
+// plans/accounting/tasks/16-the-chart-of-accounts.md §1.5) into one
+// organization as `gl_account` EntityInstances, and points each posting ROLE
+// at the account that fulfils it via a `GlRoleAssignment` row (decision
+// `G19`). `seedChartPacks` always walks `core` first and expands a pack's
+// `requires` transitively - `['purchasing']` walks `core`, `inventory`, then
+// `purchasing` - before flattening the walked packs' accounts and running the
+// rules below over that list.
 //
 // WHY THE CHART LIVES IN `lib/postings/` AND THE WRITER LIVES HERE
 //
-// `postings/default-chart.ts` is pure data — no database, no io — because
+// `postings/default-chart.ts` is pure data - no database, no io - because
 // `postings/` already owns the account vocabulary (`ACCOUNT_ROLES`) that the
 // chart's `role` column maps onto. `seed -> lib` is the sanctioned dependency
-// direction and `lib -> seed` is forbidden, so the writer imports the constant
+// direction and `lib -> seed` is forbidden, so the writer imports the packs
 // and never the reverse.
 //
 // ✅ THE HAZARD THIS FILE USED TO CARRY IS GONE
 //
 // Rule 5 used to be `assertRolesLanded`, and it existed because roles were
-// written as a `gl_account_role` FIELD through `UnifiedCrudHandler` — which
+// written as a `gl_account_role` FIELD through `UnifiedCrudHandler` - which
 // resolves fields from the ORG CACHE and SILENTLY DROPS a value whose field it
 // cannot resolve. A field created moments earlier in the same migration pass is
 // invisible to it, so the first run of this seed wrote 784 accounts across 28
@@ -25,12 +30,12 @@
 // `G19` moved the mapping to the `GlRoleAssignment` TABLE, and the assignment
 // insert below is a plain Drizzle write: no field resolution, no org cache, no
 // handler, nothing to drop. The failure mode is structurally unavailable now
-// rather than merely guarded against — which is a real, and easy to miss,
+// rather than merely guarded against - which is a real, and easy to miss,
 // secondary win of the table route.
 //
 // THE FOUR RULES THIS FILE EXISTS TO KEEP
 //
-//  1. **Idempotent on `code`.** A code the org already holds is skipped whole —
+//  1. **Idempotent on `code`.** A code the org already holds is skipped whole  -
 //     never updated, never inserted a second time. `gl_account_code` is unique,
 //     but its gate is a check-then-write `SELECT ... LIMIT 1` with no lock and
 //     no index behind it, and it excludes archived rows. A duplicate `1310`
@@ -40,7 +45,7 @@
 //     parallel fan-out over orgs for the same code: a concurrent race is the
 //     one case the check-then-write gate does not cover.
 //  3. **Never touch an account the org already has.** Not the name, not the
-//     type. A chart is a bookkeeper's document (decision `G7`) — they renumber,
+//     type. A chart is a bookkeeper's document (decision `G7`) - they renumber,
 //     rename and deactivate, and re-running the seed must be a no-op over their
 //     edits.
 //  4. **Never repoint a role the org has already mapped.** The assignment
@@ -64,7 +69,12 @@ import {
   listPaymentGateways,
   normaliseGatewayHandle,
 } from '../payment-gateways'
-import { DEFAULT_CHART_OF_ACCOUNTS } from '../postings/default-chart'
+import {
+  CHART_PACK_KEYS,
+  CHART_PACKS,
+  type ChartPackKey,
+  type DefaultChartAccount,
+} from '../postings/default-chart'
 import { seedSession, UnifiedCrudHandler } from '../resources/crud'
 import { SystemUserService } from '../users/system-user-service'
 
@@ -78,26 +88,65 @@ export interface ChartSeedResult {
   skipped: number
   /** `GlRoleAssignment` rows inserted by this pass. Zero on a settled org. */
   rolesAssigned: number
+  /**
+   * Every pack actually walked, `core` first, in `CHART_PACK_KEYS` order  -
+   * the packs asked for plus every `requires` they pulled in (16 §1.5).
+   */
+  packs: ChartPackKey[]
 }
 
 /**
- * Seed the default chart of accounts, and its role assignments, into one org.
+ * Every pack `packs` needs: `core` always, plus each pack's `requires`
+ * expanded transitively, in `CHART_PACK_KEYS` declaration order.
  *
- * Idempotent: a second pass over the same org creates nothing and reports
- * `created: 0, rolesAssigned: 0`, which is what lets migration 108 keep
- * reporting `alreadyUpToDate` (and therefore skip its org-cache flush) on a
- * re-run.
+ * `['purchasing']` walks `core`, then `inventory` (`purchasing`'s
+ * `requires`), then `purchasing` itself - a receipt debits an inventory role,
+ * so provisioning purchasing alone without inventory would leave that role
+ * unmapped on day one.
+ */
+function walkPacks(packs: readonly ChartPackKey[]): ChartPackKey[] {
+  const wanted = new Set<ChartPackKey>(['core', ...packs])
+
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const key of [...wanted]) {
+      for (const required of CHART_PACKS[key].requires ?? []) {
+        if (!wanted.has(required)) {
+          wanted.add(required)
+          changed = true
+        }
+      }
+    }
+  }
+
+  return CHART_PACK_KEYS.filter((key) => wanted.has(key))
+}
+
+/**
+ * Seed one or more chart packs, and their role assignments, into one org.
+ *
+ * Idempotent: a second pass over the same set of packs creates nothing and
+ * reports `created: 0, rolesAssigned: 0`, which is what lets migration 108
+ * keep reporting `alreadyUpToDate` (and therefore skip its org-cache flush) on
+ * a re-run, and what lets the Roles tab's Add accounts action re-walk a
+ * `partial` pack and land only the rows still missing (16 §3.2).
  *
  * @param glAccountDefId the org's `gl_account` EntityDefinition, or undefined
- * when it has none — in which case this is a no-op rather than an error, the
+ * when it has none - in which case this is a no-op rather than an error, the
  * same tolerance every other step of 108 has for a def that is not there yet.
+ * @param packs the packs to provision. `core` is walked whether or not it is
+ * named, and every pack's `requires` is expanded transitively before the walk
+ * runs (16 §1.5); the packs actually walked come back on the result.
  */
-export async function seedDefaultChartOfAccounts(
+export async function seedChartPacks(
   db: Database,
   organizationId: string,
-  glAccountDefId: string | undefined
+  glAccountDefId: string | undefined,
+  packs: readonly ChartPackKey[]
 ): Promise<ChartSeedResult> {
-  const empty: ChartSeedResult = { created: 0, skipped: 0, rolesAssigned: 0 }
+  const walked = walkPacks(packs)
+  const empty: ChartSeedResult = { created: 0, skipped: 0, rolesAssigned: 0, packs: walked }
   if (!glAccountDefId) return empty
 
   // The `code` field has to exist before its values can be read or written. On
@@ -121,7 +170,7 @@ export async function seedDefaultChartOfAccounts(
   //
   // 🛑 Deliberate, and the opposite of what the unique gate does. The gate
   // ignores archived rows, so re-seeding `1310` over an archived `1310` would
-  // pass validation and leave two — and un-archiving the old one later is a
+  // pass validation and leave two - and un-archiving the old one later is a
   // click. Someone who archived an account did not ask for it back.
   const existing = await db
     .select({ code: schema.FieldValue.valueText, entityId: schema.FieldValue.entityId })
@@ -139,20 +188,23 @@ export async function seedDefaultChartOfAccounts(
     if (row.code) byCode.set(row.code, row.entityId)
   }
 
-  const missing = DEFAULT_CHART_OF_ACCOUNTS.filter((account) => !byCode.has(account.code))
+  const accounts: readonly DefaultChartAccount[] = walked.flatMap(
+    (key) => CHART_PACKS[key].accounts
+  )
+  const missing = accounts.filter((account) => !byCode.has(account.code))
 
   let created = 0
   if (missing.length > 0) {
     const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
 
-    // The seed session's silent lane suppresses events — there is nobody to
-    // notify while an org is being migrated, and 29 accounts x 28 orgs of
+    // The seed session's silent lane suppresses events - there is nobody to
+    // notify while an org is being migrated, and a full pack walk x N orgs of
     // invalidations is real time on a cold Redis.
     const handler = new UnifiedCrudHandler(organizationId, systemUserId, db, undefined, {
       session: seedSession('gl account chart seeding'),
     })
 
-    // Sequential on purpose — see rule 2. `code` is guarded by a
+    // Sequential on purpose - see rule 2. `code` is guarded by a
     // check-then-write uniqueness gate, which two concurrent creates would both
     // pass.
     for (const account of missing) {
@@ -172,18 +224,33 @@ export async function seedDefaultChartOfAccounts(
     }
   }
 
-  const rolesAssigned = await assignSeededRoles(db, organizationId, byCode)
+  const rolesAssigned = await assignSeededRoles(db, organizationId, byCode, accounts)
 
   if (created > 0 || rolesAssigned > 0) {
-    logger.info('Seeded default chart of accounts', {
+    logger.info('Seeded chart packs', {
       organizationId,
+      packs: walked,
       created,
-      skipped: DEFAULT_CHART_OF_ACCOUNTS.length - created,
+      skipped: accounts.length - created,
       rolesAssigned,
     })
   }
 
-  return { created, skipped: DEFAULT_CHART_OF_ACCOUNTS.length - created, rolesAssigned }
+  return { created, skipped: accounts.length - created, rolesAssigned, packs: walked }
+}
+
+/**
+ * Seed the core chart pack, and its role assignments, into one org. Kept as
+ * its own name for the one caller that means exactly the core (entity
+ * migration 108); every other caller names its packs explicitly through
+ * {@link seedChartPacks}.
+ */
+export async function seedDefaultChartOfAccounts(
+  db: Database,
+  organizationId: string,
+  glAccountDefId: string | undefined
+): Promise<ChartSeedResult> {
+  return seedChartPacks(db, organizationId, glAccountDefId, ['core'])
 }
 
 /**
@@ -202,16 +269,17 @@ export async function seedDefaultChartOfAccounts(
  * distinction on day one for every org.
  *
  * A role whose account is missing from `byCode` is skipped rather than written
- * as a dangling id — that can only happen if the chart constant and this org's
+ * as a dangling id - that can only happen if the walked packs and this org's
  * chart disagree, and a mapping pointing at nothing would fail the resolver
  * with a message about an archived account rather than about a broken seed.
  */
 async function assignSeededRoles(
   db: Database,
   organizationId: string,
-  byCode: Map<string, string>
+  byCode: Map<string, string>,
+  accounts: readonly DefaultChartAccount[]
 ): Promise<number> {
-  const rows = DEFAULT_CHART_OF_ACCOUNTS.flatMap((account) => {
+  const rows = accounts.flatMap((account) => {
     if (!account.role) return []
     const glAccountId = byCode.get(account.code)
     if (!glAccountId) return []
@@ -244,11 +312,12 @@ export interface PaymentGatewaySeedResult {
  * by handle.
  *
  * ⚠️ **Runs AFTER the chart**, not alongside it - the clearing accounts these
- * defaults point at only exist once the chart is provisioned, and
+ * defaults point at only exist once the `card_rail` pack is provisioned, and
  * `payment_gateway.clearingAccount` is required and validated (`writes.ts`'s
  * `assertClearingAccount`). Call this from wherever the chart is seeded
- * (`ledger.provisionChart`), never before {@link seedDefaultChartOfAccounts}
- * has run.
+ * (`ledger.provisionChart`), never before {@link seedChartPacks} has walked
+ * `card_rail`, and never from {@link seedChartPacks} itself - the core walk
+ * never seeds a gateway (16 §1.5).
  *
  * 🛑 **Does not mint `clearing_authnet`.** Authorize.Net is a rail a merchant
  * ADDS (§5.1); auxx does not know a store ran it until they say so. The two
@@ -264,8 +333,8 @@ export interface PaymentGatewaySeedResult {
  *
  * A missing role assignment (`clearing_card` / `clearing_affirm` unmapped)
  * skips that default rather than guessing an account - the same tolerance
- * {@link assignSeededRoles} has for a chart that does not match
- * `DEFAULT_CHART_OF_ACCOUNTS`.
+ * {@link assignSeededRoles} has for a chart that does not match the packs
+ * walked.
  */
 export async function seedDefaultPaymentGateways(
   db: Database,

--- a/packages/lib/src/seed/index.ts
+++ b/packages/lib/src/seed/index.ts
@@ -7,6 +7,7 @@ export { deletePristineSeededDashboards } from './entity-seeder/create-default-d
 export {
   type ChartSeedResult,
   type PaymentGatewaySeedResult,
+  seedChartPacks,
   seedDefaultChartOfAccounts,
   seedDefaultPaymentGateways,
 } from './gl-account-chart'


### PR DESCRIPTION
## Why this exists

This is #2103 re-landed onto `main`. Nothing about it is new work.

#2103 was stacked on #2102 and its base was `feat/accounting-duplicate-detector`. #2102 was squash-merged to `main` as `843959c12`, which gave that content a new SHA, so GitHub never retargeted the stacked PR. #2103 merged into the stack branch instead and stopped there: `main` has none of it, and there was no open PR carrying it.

Opening a PR from the stack branch directly would show 47 files and 4,100 insertions, because the merge base is `f0d499bcf` (#2101) and #2102's content would appear again as if new. So this branch is `origin/main` with `db87428b8` cherry-picked onto it: 32 files, exactly the chart-packs work.

**`git diff` between this commit's tree and `db87428b8`'s tree is empty** — the repository trees are byte-identical, so #2103's verification applies to this branch unchanged.

## What it contains

Brief 16 (`plans/accounting/tasks/16-the-chart-of-accounts.md`), step 7 of the handoff.

**Packs.** `default-chart.ts` declares five: `core` (13 accounts, 11 roles), `card_rail`, `prepayments`, `inventory`, `purchasing` (`requires: ['inventory']`). Every role sits in exactly one pack, pinned by a union test. Four role-less accounts that were one company's bookkeeping leave the seed. Nothing renumbers or renames.

**Provisioner.** `seedChartPacks` walks `core` first, expands `requires`, flattens in pack order, idempotent. `ledger.provisionChart` takes `{ packs }`. The two default payment gateways seed only when `card_rail` was walked.

**Import.** `planChartImport` (pure) and `importChartFromProvider` create one `gl_account` per active QuickBooks account, with the `qboAccountId` identity set at import so the account map has nothing to confirm. Roles are assigned only on an unambiguous match, with `source: 'import'`, which renders as suggested and never as confirmed. A code collision creates the account without a code and warns. A second import adds and never duplicates.

**Screens.** Wizard order becomes `... costing, connect, accounts, accountMap, done`. Over an empty chart the accounts page offers Import from QuickBooks beside Create the default chart with a pack picker. The Roles tab gains Add accounts (`ChartPacksDialog`), listing every pack as provisioned / partial / absent. The Chart tab gains Refresh from QuickBooks.

## Verification

Inherited from #2103 on an identical tree: Biome clean, web typecheck 0 errors and ratchet baseline 0, lib ratchet 27 of 27, lib full suite 1,296 files pass, database suite pass. Provisioning verified by SELECT on two fresh dev orgs (`['core']` lands 13 accounts, 11 roles, 0 gateways; `['core', 'card_rail']` lands 18, 15 and 2; a second pass creates nothing). No entity migration, no registry edit; next free id stays 147.

## Open items carried over from #2103

- **Never driven in a browser.** Provisioning was checked by SELECT; the screens have not been clicked through.
- **Eleven defaults were taken without MK**, listed in the brief's §9, each reversible in one line. The two flagged as most consequential: `1000 Cash` stays seeded as a role-less bank account, and the wizard's connect page now precedes the accounts page.
- Touches `accounts-types.ts` and `chart-list.tsx`, which have uncommitted local edits on `main` (the account link badges). Expect a conflict there.

https://claude.ai/code/session_017vTsQzHQFhLUPMqx7LABA7
