### PR TITLE
feat(accounting): say whether each account is linked, and accept a suggestion from the row

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -337,6 +337,34 @@ export function AccountingAccountsSettingsPage() {
     [setIdentity, utils]
   )
 
+  /**
+   * Accept ONE row's suggestion, from the list.
+   *
+   * 🛑 Toasts rather than surfacing the refusal on a field, which is the
+   * opposite of what `handleSetIdentity`'s caller in the editor does. The rule is
+   * the same one the bulk confirm follows: a message goes where the reader can
+   * act on it, and a list row has no field to hold a sentence. The row is on
+   * screen, so the toast names the account.
+   */
+  const [acceptingAccountId, setAcceptingAccountId] = useState<string | null>(null)
+
+  const handleAcceptSuggestion = useCallback(
+    async (glAccountId: string, providerAccountId: string) => {
+      setAcceptingAccountId(glAccountId)
+      try {
+        await handleSetIdentity(glAccountId, providerAccountId)
+      } catch (error) {
+        toastError({
+          title: 'Error linking the account',
+          description: error instanceof Error ? error.message : 'Could not save the mapping.',
+        })
+      } finally {
+        setAcceptingAccountId(null)
+      }
+    },
+    [handleSetIdentity]
+  )
+
   const confirmSuggested = api.ledger.confirmSuggestedAccounts.useMutation({
     onSuccess: async (result) => {
       await utils.ledger.accountMap.invalidate()
@@ -477,6 +505,10 @@ export function AccountingAccountsSettingsPage() {
             accounts={accounts}
             isLoading={chart.isPending}
             selectedId={selectedAccountId}
+            onAcceptSuggestion={(glAccountId, providerAccountId) => {
+              void handleAcceptSuggestion(glAccountId, providerAccountId)
+            }}
+            acceptingAccountId={acceptingAccountId}
             onSelect={handleSelectAccount}
             rolesByAccountId={rolesByAccountId}
             draft={chartDraft}

--- a/apps/web/src/components/accounting/ui/settings/accounts-types.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounts-types.ts
@@ -152,6 +152,39 @@ export function isMappingBroken(row: AccountIdentityRow): boolean {
 }
 
 /**
+ * What a chart row's provider link amounts to, in one word.
+ *
+ * 🛑 Derived, never stored. `account-identities.ts` emits only `confirmed` and
+ * `unmapped` (the `suggested` member of `AccountIdentityState` is declared but
+ * nothing produces it), and "is this link still valid" is a THIRD question that
+ * `isMappingBroken` answers separately. Folding all three into one word here is
+ * what lets the list render a single badge per row instead of leaving a reader
+ * to infer state from which badges happen to be absent.
+ *
+ * 🛑 "Linked" is deliberately the Chart tab's word, where the Roles tab says
+ * "mapped". They are different questions - which QuickBooks account THIS account
+ * corresponds to, versus which of our accounts a posting ROLE points at - and
+ * they used to share the string "Not mapped" on two tabs of one page.
+ */
+export type AccountLinkState = 'linked' | 'suggested' | 'broken' | 'unlinked'
+
+/**
+ * Fold one map row onto its {@link AccountLinkState}.
+ *
+ * `undefined` (an account created moments ago, before the invalidated
+ * `accountMap` came back) reads as `unlinked`, which is what it is.
+ *
+ * @param row - The account's map row, if the map has one for it
+ * @returns The single word the row's badge renders
+ */
+export function accountLinkState(row: AccountIdentityRow | undefined): AccountLinkState {
+  if (!row) return 'unlinked'
+  if (isMappingBroken(row)) return 'broken'
+  if (row.state === 'confirmed') return 'linked'
+  return row.suggestion ? 'suggested' : 'unlinked'
+}
+
+/**
  * The two roles nothing emits under the L1 regime, and which are therefore the
  * expected candidates for being marked unused.
  *

--- a/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
@@ -776,12 +776,12 @@ function ProviderAccountField({
     return (
       <div className='flex min-w-0 flex-col gap-1.5'>
         <p className='flex min-h-8 items-center truncate text-sm'>
-          {identity.providerAccountId ? selectedLabel : 'Not mapped'}
+          {identity.providerAccountId ? selectedLabel : 'Not linked'}
         </p>
         {broken && (
           <p className='text-destructive text-xs'>
             The account this points at has been removed, deactivated or moved to a different
-            section. Every close refuses until it is re-mapped.
+            section. Every close refuses until it is re-linked.
           </p>
         )}
       </div>
@@ -840,7 +840,7 @@ function ProviderAccountField({
       {broken && (
         <p className='text-destructive text-xs'>
           The account this points at has been removed, deactivated or moved to a different section.
-          Every close refuses until it is re-mapped.
+          Every close refuses until it is re-linked.
         </p>
       )}
     </div>

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -34,18 +34,21 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
-import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Landmark, Plus, Sparkles, TriangleAlert } from 'lucide-react'
+import { Landmark, Link2, Plus, Sparkles, TriangleAlert } from 'lucide-react'
 import { useState } from 'react'
 import { AccountLabel } from '../account-label'
 import { accountMatchesSearch } from '../account-label-format'
 import {
+  ACCOUNT_SUGGESTION_REASON_COPY,
+  type AccountLinkState,
+  accountLinkState,
   accountTypeColor,
   accountTypeLabel,
   type ChartDraftHandle,
   type ChartMapView,
-  isMappingBroken,
+  formatProviderAccount,
 } from './accounts-types'
 
 interface ChartListProps {
@@ -65,6 +68,10 @@ interface ChartListProps {
   /** Confirms every suggested mapping at once. */
   onConfirmSuggested: () => void
   confirming: boolean
+  /** Confirms ONE row's suggestion, from the row itself. */
+  onAcceptSuggestion: (glAccountId: string, providerAccountId: string) => void
+  /** The account id whose single-row accept is in flight, if any. */
+  acceptingAccountId: string | null
   /** `PermissionKey.ledgerControl`. False hides every write affordance this
    *  list owns (Add account, Accept N) - the read path stays fully usable. */
   canControl: boolean
@@ -81,13 +88,15 @@ export function ChartList({
   map,
   onConfirmSuggested,
   confirming,
+  onAcceptSuggestion,
+  acceptingAccountId,
   canControl,
 }: ChartListProps) {
   const [search, setSearch] = useState('')
 
   // 29 rows, recomputed per keystroke of the search box. A `useMemo` here would
   // cost more to read than the loop costs to run.
-  const mapped = accounts.filter(
+  const linked = accounts.filter(
     (account) => map.byAccountId.get(account.id)?.state === 'confirmed'
   ).length
 
@@ -117,15 +126,14 @@ export function ChartList({
       </div>
 
       {/* 🛑 Gate on the PROVIDER, never on an empty map. "Nothing is connected"
-          and "connected but nothing mapped" are different answers needing
-          different actions, and collapsing them would tell somebody to map a
-          chart with nothing to map it against. With nothing connected this whole
-          strip is absent and the chart is unchanged - the explanation lives in
-          the detail pane, on the row it is about. */}
+          and "connected but nothing linked" are different answers needing
+          different actions, and collapsing them would tell somebody to link a
+          chart with nothing to link it to. With nothing connected this counter is
+          absent and the chart is unchanged; the line directly below says why. */}
       {map.connected && (
         <div className='flex flex-wrap items-center gap-2'>
           <span className='text-muted-foreground text-xs tabular-nums'>
-            {mapped} of {accounts.length} mapped to {map.providerLabel ?? 'your accounting system'}
+            {linked} of {accounts.length} linked to {map.providerLabel ?? 'your accounting system'}
           </span>
           {canControl && map.suggested > 0 && (
             <Button
@@ -141,6 +149,24 @@ export function ChartList({
         </div>
       )}
 
+      {/* 🛑 LOADING is tested before "nothing connected", the same order
+          `chart-account-editor.tsx`'s map block argues for: `connected` is false
+          for the whole of the provider round trip, so testing it first would tell
+          every reader their accounting system is disconnected for as long as it
+          takes to answer.
+
+          This line exists because every row now wears a link badge when
+          connected. With nothing connected there are no badges at all, and
+          without a sentence "no accounting system", "still loading" and
+          "connected but nothing linked" would all render as the same silence. */}
+      {!map.isPending && (map.isError || !map.connected) && (
+        <span className='text-muted-foreground text-xs'>
+          {map.isError
+            ? 'Could not read the account map. Everything below is unaffected.'
+            : 'No accounting system connected, so nothing here is linked. Entries are still built, balanced and stored in Auxx.'}
+        </span>
+      )}
+
       {/* A dangling mapping is a REPAIR, not a mapping, and `G19` requires every
           close to refuse on exactly these - so it leads the tab rather than
           waiting to be found by selecting the right row. */}
@@ -149,7 +175,7 @@ export function ChartList({
           <TriangleAlert className='mt-0.5 size-4 shrink-0 text-destructive' />
           <div className='min-w-0'>
             <p className='font-medium text-sm'>
-              {map.broken.length} mapping{map.broken.length === 1 ? '' : 's'} no longer valid
+              {map.broken.length} link{map.broken.length === 1 ? '' : 's'} no longer valid
             </p>
             <p className='text-muted-foreground text-xs'>
               {map.broken.join(', ')}{' '}
@@ -157,7 +183,7 @@ export function ChartList({
                 ? 'points at an account that has'
                 : 'point at accounts that have'}{' '}
               been removed, deactivated or moved to a different section. Every close refuses until{' '}
-              {map.broken.length === 1 ? 'it is' : 'they are'} re-mapped.
+              {map.broken.length === 1 ? 'it is' : 'they are'} re-linked.
             </p>
           </div>
         </div>
@@ -212,6 +238,10 @@ export function ChartList({
           {filtered.map((account) => {
             const roles = rolesByAccountId.get(account.id) ?? []
             const identity = map.byAccountId.get(account.id)
+            // Gated on the LOADED map for the same reason the badge is: a row
+            // action derived from a round trip that has not answered yet is an
+            // offer the server may be about to refuse.
+            const suggestion = map.connected && !map.isPending ? identity?.suggestion : undefined
             return (
               <TreeRow
                 key={account.id}
@@ -224,6 +254,29 @@ export function ChartList({
                   selectedId === account.id && 'bg-primary-100 ring-1 ring-primary-200',
                   !account.isActive && 'opacity-60'
                 )}
+                // 🛑 `persistent`, and ONLY on a row that has a suggestion.
+                // `TreeRowButton` is hover-revealed by default, which is right for
+                // an action every row carries and wrong for one that exists on
+                // three rows out of twenty-nine - the reader would have to hover
+                // each row in turn to find them. The other rows get no button at
+                // all rather than a disabled one: there is nothing to accept.
+                //
+                // 🛑 The tooltip NAMES the account and says how it was matched.
+                // `G19` makes the confirming person the last line of defence (a
+                // wrong account id still balances, so nothing downstream catches
+                // it), and a bare check mark would ask them to agree to something
+                // they cannot see. Same pairing the editor's Confirm button makes.
+                actions={
+                  suggestion && canControl ? (
+                    <TreeRowButton
+                      persistent
+                      tooltipText={`Link ${formatProviderAccount(suggestion.account)} - ${ACCOUNT_SUGGESTION_REASON_COPY[suggestion.reason]}`}
+                      disabled={acceptingAccountId === account.id}
+                      onClick={() => onAcceptSuggestion(account.id, suggestion.account.id)}>
+                      <Link2 />
+                    </TreeRowButton>
+                  ) : undefined
+                }
                 secondary={
                   <span className='flex items-center gap-1.5 text-muted-foreground text-xs'>
                     <Badge variant={accountTypeColor(account.accountType)} size='xs'>
@@ -234,23 +287,19 @@ export function ChartList({
                         Inactive
                       </Badge>
                     )}
-                    {/* Only ever rendered against a LOADED map. An unmapped
-                        badge on rows the provider round trip has not answered
-                        for yet is a claim about the org, and rendering it
-                        mid-load makes it a false one. */}
-                    {map.connected && !map.isPending && identity && isMappingBroken(identity) && (
-                      <Badge variant='destructive' size='xs'>
-                        Re-map
-                      </Badge>
+                    {/* Only ever rendered against a LOADED map. A link badge on
+                        rows the provider round trip has not answered for yet is
+                        a claim about the org, and rendering it mid-load makes it
+                        a false one.
+
+                        🛑 One badge, ALWAYS present once the map has loaded -
+                        never a set of conditional badges whose absence has to be
+                        interpreted. This used to render only two of the four
+                        states, so a row with a pending suggestion looked exactly
+                        like a linked one: silence. */}
+                    {map.connected && !map.isPending && (
+                      <AccountLinkBadge state={accountLinkState(identity)} />
                     )}
-                    {map.connected &&
-                      !map.isPending &&
-                      identity?.state === 'unmapped' &&
-                      !identity.suggestion && (
-                        <Badge variant='outline' size='xs'>
-                          Not mapped
-                        </Badge>
-                      )}
                     {roles.length > 0 && (
                       <span>
                         {roles.length} {roles.length === 1 ? 'role' : 'roles'}
@@ -265,4 +314,48 @@ export function ChartList({
       )}
     </div>
   )
+}
+
+/**
+ * The one badge that answers "is this account linked to the accounting system?".
+ *
+ * 🛑 Every state renders something. A reader must never have to work out that
+ * "no badge" meant linked - which is what the previous two-conditional-badges
+ * shape asked of them, and it could not distinguish a linked account from one
+ * with an unconfirmed suggestion at all.
+ *
+ * 🛑 `Suggested` is amber and wears the `Sparkles` mark, the same pair
+ * `role-map-editor.tsx` already uses for a proposed role assignment. `G19`
+ * requires a suggestion to read visibly differently from a confirmed mapping,
+ * and the page should not have two vocabularies for one distinction.
+ */
+function AccountLinkBadge({ state }: { state: AccountLinkState }) {
+  switch (state) {
+    case 'broken':
+      return (
+        <Badge variant='destructive' size='xs'>
+          Re-link
+        </Badge>
+      )
+    case 'suggested':
+      return (
+        <Badge variant='amber' size='xs'>
+          <Sparkles />
+          Suggested
+        </Badge>
+      )
+    case 'linked':
+      return (
+        <Badge variant='secondary' size='xs'>
+          <Link2 />
+          Linked
+        </Badge>
+      )
+    default:
+      return (
+        <Badge variant='outline' size='xs'>
+          Not linked
+        </Badge>
+      )
+  }
 }

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -151,7 +151,7 @@ export function ChartList({
               the signal that this chart was either imported or hand-mapped, so a
               refresh has something to add to rather than nothing to compare
               against (brief 16 §2.3). */}
-          {canControl && mapped > 0 && <ImportChartButton mode='chart' connected={map.connected} />}
+          {canControl && linked > 0 && <ImportChartButton mode='chart' connected={map.connected} />}
         </div>
       )}
 
@@ -263,8 +263,8 @@ export function ChartList({
                 // 🛑 `persistent`, and ONLY on a row that has a suggestion.
                 // `TreeRowButton` is hover-revealed by default, which is right for
                 // an action every row carries and wrong for one that exists on
-                // three rows out of twenty-nine - the reader would have to hover
-                // each row in turn to find them. The other rows get no button at
+                // the handful that the matcher happened to propose - the reader
+                // would have to hover each row in turn to find them. The other rows get no button at
                 // all rather than a disabled one: there is nothing to accept.
                 //
                 // 🛑 The tooltip NAMES the account and says how it was matched.

--- a/apps/web/src/components/accounting/ui/settings/payment-gateway-add-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateway-add-dialog.tsx
@@ -19,7 +19,7 @@ import {
 } from '@auxx/ui/components/dialog'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { GlAccountPicker } from '~/components/accounting/ui/gl-account-picker'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
@@ -73,6 +73,20 @@ export function PaymentGatewayAddDialog({
     },
   })
 
+  // 🛑 The option set is DERIVED from the values. `payment_gateway_handles` is an
+  // OPEN, value-keyed TAGS field - the registry declares `options: { options: [] }`
+  // and the write stores the raw string - so a stored handle matches no option row.
+  // Handing the picker a literal `[]` made every handle resolve `unknown`: the
+  // trigger rendered it italic-grey as "not in this field's option set", and it
+  // never appeared in the popover at all, so it could not be unchecked. Nothing is
+  // wrong with what is stored; the input has to be told the values ARE the options.
+  // The `useMemo` is load-bearing too - a fresh `[]` each render re-fired
+  // `MultiSelectPicker`'s options sync and wiped the tag being typed.
+  const handleOptions = useMemo(
+    () => draft.handles.map((handle) => ({ label: handle, value: handle })),
+    [draft.handles]
+  )
+
   const canSubmit = draft.name.trim() && draft.handles.length > 0 && draft.clearingAccountId
 
   return (
@@ -114,9 +128,10 @@ export function PaymentGatewayAddDialog({
             description='Every stored value this rail is seen under.'>
             <FieldInputAdapter
               fieldType={FieldType.TAGS}
-              fieldOptions={{ options: [] }}
+              fieldOptions={{ options: handleOptions }}
               useValueAsLabel
               value={draft.handles}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
               placeholder='Add a handle'
               disabled={create.isPending}
               onChange={(value) =>

--- a/apps/web/src/components/accounting/ui/settings/payment-gateway-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateway-editor.tsx
@@ -27,7 +27,7 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
 import { CreditCard } from 'lucide-react'
-import { useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { GlAccountPicker } from '~/components/accounting/ui/gl-account-picker'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
@@ -98,6 +98,20 @@ function PaymentGatewayForm({
     if (value.trim()) onPatch({ name: value })
   }, TEXT_COMMIT_DELAY_MS)
 
+  // 🛑 The option set is DERIVED from the values. `payment_gateway_handles` is an
+  // OPEN, value-keyed TAGS field - the registry declares `options: { options: [] }`
+  // and the write stores the raw string - so a stored handle matches no option row.
+  // Handing the picker a literal `[]` made every handle resolve `unknown`: the
+  // trigger rendered it italic-grey as "not in this field's option set", and it
+  // never appeared in the popover at all, so it could not be unchecked. Nothing is
+  // wrong with what is stored; the input has to be told the values ARE the options.
+  // The `useMemo` is load-bearing too - a fresh `[]` each render re-fired
+  // `MultiSelectPicker`'s options sync and wiped the tag being typed.
+  const handleOptions = useMemo(
+    () => gateway.handles.map((handle) => ({ label: handle, value: handle })),
+    [gateway.handles]
+  )
+
   const isClosed = gateway.status === 'closed'
 
   return (
@@ -140,9 +154,16 @@ function PaymentGatewayForm({
           description='Every stored value this rail is seen under. Two spellings of the same rail (authorize_net / authorize.net) both belong here.'>
           <FieldInputAdapter
             fieldType={FieldType.TAGS}
-            fieldOptions={{ options: [] }}
+            fieldOptions={{ options: handleOptions }}
             useValueAsLabel
             value={gateway.handles}
+            // 🛑 `showClear: false` - the trigger's X is a CLEAR ALL, and a
+            // gateway with no handle is refused by `updatePaymentGateway`
+            // ("at least one handle"), so the button could only ever be a
+            // silent no-op: the guard below drops the write and the next
+            // render puts every tag straight back. A control that cannot
+            // succeed does not belong on the row.
+            triggerProps={{ className: 'w-full ps-0 pe-1', showClear: false }}
             placeholder='Add a handle'
             onChange={(value) => {
               const handles = Array.isArray(value) ? (value as string[]) : []
@@ -157,11 +178,18 @@ function PaymentGatewayForm({
           showIcon
           isRequired
           description='Where this gateway settles. Two gateways sharing one account is fine - this only says which account, it never mints a new one.'>
+          {/* 🛑 `showClear: false`, same argument as Gateway handles above: the
+              clearing account is REQUIRED - it is where this rail's money lands
+              on the balance sheet - so `onChange(null)` is dropped by the guard
+              and the X could only ever be a no-op. The fee account below keeps
+              its X, because null there is a real answer (fall back to the
+              default merchant-fees account). */}
           <GlAccountPicker
             value={gateway.clearingGlAccountId}
             selectBy='id'
             filterTypes={['asset']}
             placeholder='Select account…'
+            triggerProps={{ showClear: false }}
             onChange={(id) => id && onPatch({ clearingAccountId: id })}
           />
         </FieldPanelRow>

--- a/apps/web/src/components/accounting/ui/settings/payment-gateways-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateways-list.tsx
@@ -70,7 +70,7 @@ export function PaymentGatewaysList({
   }, [gateways, search])
 
   const addButton = (
-    <Button variant='outline' size='sm' onClick={onAdd}>
+    <Button variant='outline' size='sm' className='shrink-0' onClick={onAdd}>
       <Plus />
       Add gateway
     </Button>
@@ -78,26 +78,34 @@ export function PaymentGatewaysList({
 
   return (
     <div className='flex flex-col gap-3 p-3'>
+      {/* One row, `chart-list.tsx`'s shape: a SINGLE button beside the search
+          still leaves the box room, which is exactly what stopped
+          `bank-accounts-list.tsx` from doing the same (it carries two, and two
+          squeeze the input to about forty pixels). Never `flex-wrap` either -
+          `InputSearch` wraps its input in a `relative flex flex-1` div, so on a
+          second line that wrapper stretches full width and swallows the
+          button's clicks. */}
       {gateways.length > 0 && (
-        <>
-          <div className='flex items-center gap-2'>{addButton}</div>
-          <div className='flex items-center gap-2'>
-            <InputSearch
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder='Search gateways...'
+        <div className='flex items-center gap-2'>
+          <InputSearch
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder='Search gateways...'
+            className='flex-1'
+          />
+          {/* Offered only when there is something behind it - an always-present
+              toggle over an empty set advertises a state most orgs never reach. */}
+          {closedCount > 0 && (
+            <ButtonSwitch
+              label={`Show closed (${closedCount})`}
+              size='xs'
+              checked={showArchived}
+              onCheckedChange={onShowArchivedChange}
+              className='shrink-0'
             />
-            {closedCount > 0 && (
-              <ButtonSwitch
-                label={`Show closed (${closedCount})`}
-                size='xs'
-                checked={showArchived}
-                onCheckedChange={onShowArchivedChange}
-                className='shrink-0'
-              />
-            )}
-          </div>
-        </>
+          )}
+          {addButton}
+        </div>
       )}
 
       {isLoading ? (


### PR DESCRIPTION
## Why

The Chart tab's row badge answered "is this account linked to the accounting system" for only two of its four states. A row whose QuickBooks match was merely SUGGESTED rendered exactly like a confirmed one - silence - because the badge was suppressed whenever `identity.suggestion` was set, to avoid doubling up with the header's bulk Accept. The one state that needs a decision was the one the list would not show.

## What

**One badge per row, always present once the map has loaded**: `Linked`, `Suggested` (amber + Sparkles, the mark `role-map-editor.tsx` already uses), `Not linked`, `Re-link`. `accountLinkState` folds the three separate questions the row used to ask (`state`, `suggestion`, `isMappingBroken`) into one word, so nothing is inferred from which badges happen to be absent.

**A persistent `TreeRowButton` accepts one row's suggestion** - the per-row counterpart to the header's bulk confirm. Only on rows that have a suggestion, and only with `ledgerControl`. Hover-reveal is right for an action every row carries and wrong for one that exists on the handful the matcher proposed. Its tooltip names the account and the match reason, the same pairing the editor's Confirm button makes: `G19` puts the confirming person last in line, and a wrong account id still balances.

**A muted line when the map is unreadable or nothing is connected**, tested after `isPending` for the reason `chart-account-editor.tsx` gives. Without it "no accounting system", "still loading" and "connected but nothing linked" all render as the same silence now that badges carry the answer.

**The Chart tab says "linked", the Roles tab keeps "mapped".** Different questions - which provider account THIS account corresponds to, versus which of our accounts a posting ROLE points at - that used to share the string "Not mapped" on two tabs of one page. #2104's own copy stays consistent with the split: "Refresh from QuickBooks" carries no noun, and its "uncoded and unmapped" is about roles.

**Payment gateways**: Add gateway moves beside the search. Gateway handles renders its stored values as real tags - `payment_gateway_handles` is an open, value-keyed TAGS field, so passing the input a literal `[]` made every stored handle resolve `unknown` (italic grey, "not in this field's option set") and left it absent from the popover, so it could not be removed. Options are derived from the values, memoised so the picker's sync effect does not wipe the tag being typed. Verified against the stored rows: `optionId` holds `affirm`, `shopify_payments` - storage was always correct, only the input was wrong. Clear is hidden on the two required rows, where the server refuses an empty value and the X could only ever be a no-op.

## The merge with #2104

This branch was cut before #2104 landed and touches three of the same files. The merge itself was conflict-free, which is the problem worth flagging: **#2104's Refresh-from-QuickBooks button is gated on `mapped > 0`, and this branch renamed that variable to `linked`.** Git merged both hunks happily and produced a file that does not compile. Repaired in `edc2cbe8e`, which is also why that commit is separate - it is the merge's damage, not the feature.

## Verification

- Web typecheck 0 errors. Biome clean on all 29 files under `ui/settings`.
- `apps/web` accounting settings tests 29 of 29 pass, including #2104's new `chart-copy.test.ts` (which is why "twenty-nine" left a comment) and `pack-picker.test.ts`.
- Driven in the browser against the dev server on this branch. Chart tab renders "5 of 13 linked to QuickBooks Online" beside #2104's Refresh button - which only appears because the repaired `linked > 0` gate is live. Roles tab renders #2104's Add accounts beside the role map's own "Not mapped". No console errors on either tab.
- **The `Suggested` badge and the accept button are unverified visually** - the dev org has no pending suggestions, so no amber badge and no row button could be produced to look at. They go through the same `setAccountIdentity` call the editor's Confirm button already uses.

https://claude.ai/code/session_017vTsQzHQFhLUPMqx7LABA7
