### PR TITLE
feat(accounting): a catalogue picker for the chart, and bulk remove/restore

### DIFF
--- a/apps/web/src/components/accounting/ui/provider-account-picker.tsx
+++ b/apps/web/src/components/accounting/ui/provider-account-picker.tsx
@@ -1,0 +1,231 @@
+// apps/web/src/components/accounting/ui/provider-account-picker.tsx
+
+'use client'
+
+import type { ChartAccountRow, ProviderAccount } from '@auxx/lib/postings/client'
+import { GL_ACCOUNT_TYPES, type GlAccountTypeValue, isMappableTo } from '@auxx/lib/postings/client'
+import {
+  Command,
+  CommandDetailItem,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandList,
+} from '@auxx/ui/components/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { cn } from '@auxx/ui/lib/utils'
+import { useMemo, useState } from 'react'
+import {
+  accountTypeLabel,
+  formatProviderAccount,
+} from '~/components/accounting/ui/settings/accounts-types'
+import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
+
+export interface ProviderAccountPickerProps {
+  /** The paired provider account's id, or null while unmapped. */
+  value: string | null
+  /** Fires with the chosen provider account's id, or null on clear (the unmap). */
+  onChange: (value: string | null) => void
+  /** The connected provider's whole chart. Empty with nothing connected. */
+  accounts: readonly ProviderAccount[]
+  /**
+   * The LIVE local type and subtype being edited, not the saved ones. Somebody
+   * who has just changed this account's type is picking for what it is NOW;
+   * offering candidates for what it used to be would hand them a pairing the
+   * server is about to refuse.
+   */
+  target: { accountType: GlAccountTypeValue | null; subtype: ChartAccountRow['subtype'] }
+  disabled?: boolean
+  placeholder?: string
+  className?: string
+  triggerProps?: PickerTriggerOptions
+}
+
+/**
+ * ProviderAccountPicker
+ *
+ * A single-select combobox over the CONNECTED PROVIDER's chart, grouped by the
+ * five statement classifications, for pairing one `gl_account` with one
+ * provider account.
+ *
+ * 🛑 The sibling of `GlAccountPicker`, deliberately, and not a `Combobox`. Both
+ * pickers sit on the same pane and perform the same act - name an account - so
+ * a plain `CommandItem` list on one and a headed `CommandDetailItem` list on the
+ * other made one screen read as two. This is the same `Command` +
+ * `CommandDetailItem` + `PickerTrigger asCombobox` composition, so the trigger,
+ * the grouping and the option shape all match.
+ *
+ * 🛑 An INCOMPATIBLE account renders in its group, disabled, with the reason
+ * visible - never silently dropped. This is `GlAccountPicker`'s documented trap
+ * turned around to face the provider: somebody looking for `1310 Inventory
+ * Asset` needs to see that it exists and is off-limits, not wonder why it is
+ * missing and assume the import lost it.
+ *
+ * ⚠️ Compatibility is a FILTER on what can be CHOSEN, never a tiebreak. A
+ * candidate in the wrong statement section is unselectable at any confidence:
+ * pairing a liability with a revenue account produces entries that BALANCE and
+ * misstate the P&L, and the number somebody recognises gives them no way to
+ * tell. `isMappableTo` is the one authority (`suggest-account-identities.ts`),
+ * shared with the resolver, so the picker and the close cannot disagree.
+ */
+export function ProviderAccountPicker({
+  value,
+  onChange,
+  accounts,
+  target,
+  disabled = false,
+  placeholder = 'Select account…',
+  className,
+  triggerProps,
+}: ProviderAccountPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+
+  const groups = useMemo(() => groupProviderAccountsByType(accounts, search), [accounts, search])
+
+  const selected = useMemo(
+    () => accounts.find((account) => account.id === value) ?? null,
+    [accounts, value]
+  )
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    if (!next) setSearch('')
+  }
+
+  return (
+    <Popover open={disabled ? false : open} onOpenChange={disabled ? undefined : handleOpenChange}>
+      <PopoverTrigger asChild>
+        <PickerTrigger
+          open={open}
+          disabled={disabled}
+          variant={triggerProps?.variant ?? 'transparent'}
+          size={triggerProps?.size}
+          hasValue={!!selected}
+          placeholder={placeholder}
+          // The clear IS the unmap: `null` is what `setAccountIdentity` takes to
+          // mean "this pairing is off". A separate Unmap button would be a
+          // second control for one act.
+          showClear={triggerProps?.showClear ?? true}
+          onClear={(e) => {
+            e.stopPropagation()
+            onChange(null)
+          }}
+          asCombobox
+          className={cn('h-auto min-h-8 w-full ps-0 pe-1', className, triggerProps?.className)}>
+          {selected && <span className='truncate text-sm'>{formatProviderAccount(selected)}</span>}
+        </PickerTrigger>
+      </PopoverTrigger>
+      <PopoverContent
+        className='min-w-[max(var(--radix-popover-trigger-width),20rem)] p-0'
+        align='start'>
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder='Search the accounting system…'
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            <CommandEmpty>No accounts match.</CommandEmpty>
+            {groups.map((group) => (
+              <CommandGroup key={group.type} heading={accountTypeLabel(group.type)}>
+                {group.accounts.map((account) => {
+                  // 🛑 An account with no type yet makes NOTHING selectable.
+                  // Every candidate is judged against the target's type, so
+                  // treating "no type" as "anything goes" would offer the whole
+                  // provider chart and let somebody pick a pairing the server
+                  // refuses the moment the type is filled in.
+                  const mappable = target.accountType
+                    ? isMappableTo(
+                        { accountType: target.accountType, subtype: target.subtype },
+                        account
+                      )
+                    : false
+                  return (
+                    <CommandDetailItem
+                      key={account.id}
+                      value={account.id}
+                      title={account.fullyQualifiedName}
+                      // The provider's own number and type, which is what makes
+                      // two same-named accounts tellable apart - and what says
+                      // why an unselectable one is unselectable.
+                      description={describeProviderAccount(account, mappable, target.accountType)}
+                      disabled={!mappable}
+                      selected={account.id === value}
+                      selectionMode='check'
+                      className={cn(!mappable && 'opacity-60')}
+                      onSelect={() => {
+                        if (!mappable) return
+                        onChange(account.id)
+                        handleOpenChange(false)
+                      }}
+                    />
+                  )
+                })}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/** One statement-classification section of the picker's option list. */
+interface ProviderAccountGroup {
+  type: GlAccountTypeValue
+  accounts: ProviderAccount[]
+}
+
+/**
+ * The provider's chart in {@link GL_ACCOUNT_TYPES} (statement) order, with a
+ * case-insensitive number/name search applied. Empty groups are dropped rather
+ * than rendered with a heading and nothing under it.
+ *
+ * 🛑 Groups by the provider's `classification`, which is the field the
+ * compatibility check reads. Grouping by its finer `accountType` would put an
+ * account in a section the check does not consult, so a reader could not tell
+ * from the heading whether a row was selectable.
+ *
+ * Pure and exported so grouping/ordering can be unit-tested without a provider.
+ */
+export function groupProviderAccountsByType(
+  accounts: readonly ProviderAccount[],
+  search: string
+): ProviderAccountGroup[] {
+  const needle = search.trim().toLowerCase()
+  const matches = (account: ProviderAccount) =>
+    !needle ||
+    account.fullyQualifiedName.toLowerCase().includes(needle) ||
+    (account.number ?? '').toLowerCase().includes(needle) ||
+    account.accountType.toLowerCase().includes(needle)
+
+  return GL_ACCOUNT_TYPES.map((type) => ({
+    type,
+    accounts: accounts.filter(
+      (account) => account.classification === type && account.active && matches(account)
+    ),
+  })).filter((group) => group.accounts.length > 0)
+}
+
+/**
+ * The detail line under a provider account: its number and the provider's own
+ * type, plus the reason when it cannot be chosen.
+ *
+ * ⚠️ Says what is WRONG, never just "unavailable". "QuickBooks types this as
+ * Other Current Asset" tells somebody which account to look for instead; a bare
+ * disabled row tells them the picker is broken.
+ */
+function describeProviderAccount(
+  account: ProviderAccount,
+  mappable: boolean,
+  targetType: GlAccountTypeValue | null
+): string {
+  const facts = [account.number?.trim(), account.accountType].filter(Boolean).join(' · ')
+  if (mappable) return facts
+  if (!targetType) return `${facts} — choose this account's type first`
+  if (account.classification !== targetType) {
+    return `${facts} — ${account.classification} in the accounting system, so it cannot hold ${accountTypeLabel(targetType).toLowerCase()} postings`
+  }
+  return `${facts} — this type cannot hold the subtype of the account you are mapping`
+}

--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -41,11 +41,12 @@ import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { toastError } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils'
 import { Landmark, Lock, Waypoints } from 'lucide-react'
-import { useQueryState } from 'nuqs'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import { MasterDetailSplit } from '~/components/global/master-detail-split'
 import SettingsPage from '~/components/global/settings-page'
+import { ListSelectionProvider } from '~/components/list-selection'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useAccess, useRequireCapability } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
@@ -58,6 +59,7 @@ import {
   type ChartAccountPatch,
   type NewChartAccount,
 } from './chart-account-editor'
+import { ChartAccountsBulkBar } from './chart-accounts-bulk-bar'
 import { ChartList } from './chart-list'
 import { ChartPacksDialog } from './chart-packs-dialog'
 import { RoleMapEditor } from './role-map-editor'
@@ -96,7 +98,10 @@ export function AccountingAccountsSettingsPage() {
   const activeTab: AccountsTab = tab === 'chart' ? 'chart' : 'roles'
 
   const roleMap = api.ledger.roleMap.useQuery()
-  const chart = api.ledger.chartAccounts.useQuery()
+  // 🛑 Always asks for archived rows, and the LIST decides what to show. Making
+  // the query follow the toggle would refetch the whole chart on every flip and
+  // leave the count with nothing to count while it was off.
+  const chart = api.ledger.chartAccounts.useQuery({ includeArchived: true })
   // Chart tab only: how many posted lines carry each CODE, for the renumber
   // note. A separate read rather than a field on `ChartAccountRow`, which is
   // shared with the resolver's path and decoded by every reader of this chart.
@@ -122,6 +127,12 @@ export function AccountingAccountsSettingsPage() {
   // An untouched draft is dropped on selecting another row, on adding another
   // draft, or on switching tabs - never on a mere re-render.
   const [chartDraft, setChartDraft] = useState<ChartDraftHandle | null>(null)
+  // 🛑 In the URL, like every other selection on this page. "Where did 1310 go"
+  // is a question somebody sends a link about.
+  const [showArchived, setShowArchived] = useQueryState(
+    'archived',
+    parseAsBoolean.withDefault(false)
+  )
   const [confirm, ConfirmDialog] = useConfirm()
   // The Roles tab's "Add accounts" action (brief 16 §3.2) - provisions a named
   // chart pack without going back through the wizard.
@@ -320,6 +331,49 @@ export function AccountingAccountsSettingsPage() {
     [accounts, confirm, removeAccount, invalidateChart, selectedAccountId, setSelectedAccountId]
   )
 
+  /**
+   * Remove, from the LIST row rather than from the editor.
+   *
+   * 🛑 Toasts the refusal, where the editor's call surfaces it on the form.
+   * Same rule `handleAcceptSuggestion` follows: a message goes where the reader
+   * can act on it, and a list row has no field to hold a sentence. The refusal
+   * that matters here - a role still posts to this account - names the role, so
+   * it is surfaced verbatim rather than collapsed into "Could not remove".
+   *
+   * The confirm, the write, the invalidate and the deselect are all
+   * `handleRemoveAccount`'s already; this only decides where the failure lands.
+   */
+  const handleRemoveAccountFromRow = useCallback(
+    async (id: string) => {
+      try {
+        await handleRemoveAccount(id)
+      } catch (error) {
+        toastError({
+          title: 'Error removing the account',
+          description: error instanceof Error ? error.message : 'Could not remove the account.',
+        })
+      }
+    },
+    [handleRemoveAccount]
+  )
+
+  const restoreAccount = api.ledger.chartAccountRestore.useMutation()
+
+  const handleRestoreAccount = useCallback(
+    async (id: string) => {
+      try {
+        await restoreAccount.mutateAsync({ id })
+        await invalidateChart()
+      } catch (error) {
+        toastError({
+          title: 'Error restoring the account',
+          description: error instanceof Error ? error.message : 'Could not restore the account.',
+        })
+      }
+    },
+    [restoreAccount, invalidateChart]
+  )
+
   // ── The account map writes ──────────────────────────────────────────────
   //
   // 🛑 Both are on `ledgerPost`, the same rung as the chart's own writes and for
@@ -506,23 +560,38 @@ export function AccountingAccountsSettingsPage() {
             canControl={canControl}
           />
         ) : (
-          <ChartList
-            accounts={accounts}
-            isLoading={chart.isPending}
-            selectedId={selectedAccountId}
-            onAcceptSuggestion={(glAccountId, providerAccountId) => {
-              void handleAcceptSuggestion(glAccountId, providerAccountId)
-            }}
-            acceptingAccountId={acceptingAccountId}
-            onSelect={handleSelectAccount}
-            rolesByAccountId={rolesByAccountId}
-            draft={chartDraft}
-            onAddDraft={handleAddChartDraft}
-            map={mapView}
-            onConfirmSuggested={() => confirmSuggested.mutate()}
-            confirming={confirmSuggested.isPending}
-            canControl={canControl}
-          />
+          // 🛑 The provider wraps ONLY the chart list, not the page: the store
+          // is per-list by design, and a selection that survived a tab switch
+          // would let the Roles tab's bulk bar act on chart rows nobody can see.
+          <ListSelectionProvider>
+            <ChartAccountsBulkBar />
+            <ChartList
+              accounts={accounts}
+              isLoading={chart.isPending}
+              selectedId={selectedAccountId}
+              onAddFromCatalogue={() => setAddAccountsOpen(true)}
+              onRemoveAccount={(id) => {
+                void handleRemoveAccountFromRow(id)
+              }}
+              onRestoreAccount={(id) => {
+                void handleRestoreAccount(id)
+              }}
+              showArchived={showArchived}
+              onShowArchivedChange={setShowArchived}
+              onAcceptSuggestion={(glAccountId, providerAccountId) => {
+                void handleAcceptSuggestion(glAccountId, providerAccountId)
+              }}
+              acceptingAccountId={acceptingAccountId}
+              onSelect={handleSelectAccount}
+              rolesByAccountId={rolesByAccountId}
+              draft={chartDraft}
+              onAddDraft={handleAddChartDraft}
+              map={mapView}
+              onConfirmSuggested={() => confirmSuggested.mutate()}
+              confirming={confirmSuggested.isPending}
+              canControl={canControl}
+            />
+          </ListSelectionProvider>
         )}
       </MasterDetailSplit>
 
@@ -530,7 +599,7 @@ export function AccountingAccountsSettingsPage() {
       <ChartPacksDialog
         open={addAccountsOpen}
         onOpenChange={setAddAccountsOpen}
-        roleMap={roleRows}
+        accounts={accounts}
       />
     </SettingsPage>
   )

--- a/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-account-editor.tsx
@@ -58,17 +58,15 @@ import {
   type ChartAccountRow,
   type GlAccountSubtypeValue,
   type GlAccountTypeValue,
-  isMappableTo,
 } from '@auxx/lib/postings/client'
 import { Button } from '@auxx/ui/components/button'
-import { Combobox } from '@auxx/ui/components/combobox'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection } from '@auxx/ui/components/section'
 import { Check, Landmark, Trash2 } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
+import { ProviderAccountPicker } from '~/components/accounting/ui/provider-account-picker'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
-import { PickerTrigger } from '~/components/ui/picker-trigger'
 import { BaseType } from '~/components/workflow/types'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
 import {
@@ -741,24 +739,6 @@ function ProviderAccountField({
     )
   }
 
-  // 🛑 Filtered by the LIVE `accountType` and `subtype`, not by
-  // `identity.account`'s saved values. Somebody who has just changed this
-  // account's type or subtype is picking for what it is NOW; offering
-  // candidates for what it used to be would hand them a mapping the server is
-  // about to refuse.
-  //
-  // ⚠️ Type compatibility is a FILTER, not a tiebreak. A candidate in the wrong
-  // statement section is never offered at any confidence: mapping a liability to
-  // a revenue account balances AND misstates the P&L, and the number somebody
-  // recognises gives them no way to tell. `isMappableTo` (task 13 §3) adds the
-  // same rule for subtype: a `bank` account is never offered a candidate whose
-  // provider `accountType` is not `Bank`, even one in the right section.
-  const options = accountType
-    ? map.providerAccounts
-        .filter((account) => isMappableTo({ accountType, subtype }, account))
-        .map((account) => ({ value: account.id, label: formatProviderAccount(account) }))
-    : []
-
   const suggestion = identity.suggestion
   const broken = isMappingBroken(identity)
 
@@ -790,34 +770,24 @@ function ProviderAccountField({
 
   return (
     <div className='flex min-w-0 flex-col gap-1.5'>
-      {/* 🛑 `PickerTrigger`, not the Combobox's own default button. Every other
-          picker in a `FieldPanelRow` is a transparent full-width trigger with the
-          chevron at the end - the Type row directly above this one included - and
-          an outline button here would read as the one control on the pane that
-          came from somewhere else.
+      {/* 🛑 `ProviderAccountPicker`, the sibling of the `GlAccountPicker` two
+          rows up this same pane. Both name an account; a plain `CommandItem`
+          list on one and a headed `CommandDetailItem` list on the other made one
+          screen read as two, and the flat list could not say WHY an account it
+          had silently dropped was missing.
 
           Its clear affordance IS the unmap: `onClear` writes `null`, which is
           what `setAccountIdentity` takes to mean "this pairing is off". A
           separate Unmap button would be a second control for one act. */}
-      <Combobox
-        placeholder='Select account'
-        emptyText='No compatible account'
-        value={identity.providerAccountId ?? undefined}
-        options={options}
+      <ProviderAccountPicker
+        value={identity.providerAccountId}
+        accounts={map.providerAccounts}
+        // 🛑 The LIVE local values, not `identity.account`'s saved ones - see
+        // the note on `options` below, which this replaced.
+        target={{ accountType, subtype }}
         disabled={pending}
-        onChangeValue={(value) => void onSet(value)}
-        trigger={
-          <PickerTrigger
-            asCombobox
-            disabled={pending}
-            className='w-full ps-0 pe-1'
-            hasValue={!!identity.providerAccountId}
-            placeholder='Select account'
-            showClear
-            onClear={() => void onSet(null)}>
-            <span className='truncate text-sm'>{selectedLabel}</span>
-          </PickerTrigger>
-        }
+        placeholder='Select account'
+        onChange={(next) => void onSet(next)}
       />
 
       {suggestion && (

--- a/apps/web/src/components/accounting/ui/settings/chart-accounts-bulk-bar.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-accounts-bulk-bar.tsx
@@ -1,0 +1,135 @@
+// apps/web/src/components/accounting/ui/settings/chart-accounts-bulk-bar.tsx
+'use client'
+
+// The floating bulk bar for the Chart of accounts tab: remove a set of accounts,
+// or put a set of removed ones back.
+//
+// 🛑 TWO actions over ONE selection, each acting on the SUBSET it applies to.
+// A chart list showing archived rows can hold a mixed selection, and the honest
+// answer is not to forbid that - it is for Remove to name how many of the picked
+// rows are actually removable and Restore to name how many are actually
+// restorable. Disabling both on any mixed selection would make "select all,
+// clean up" impossible, which is the one thing a bulk bar is for.
+//
+// 🛑 Every refusal is the SERVER's. `removeChartAccount` refuses while a live
+// role still posts to an account, naming the role; `useBulkRunner` counts the
+// failures and says how many of how many. A client-side pre-check of that rule
+// would be a second authority over where money lands.
+
+import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
+import { RotateCcw, Trash2 } from 'lucide-react'
+import { useMemo } from 'react'
+import {
+  useBulkMode,
+  useBulkRunner,
+  useListSelection,
+  useSelectionCount,
+  useSelectionIds,
+} from '~/components/list-selection'
+import { api } from '~/trpc/react'
+
+export function ChartAccountsBulkBar() {
+  const ids = useSelectionIds()
+  const count = useSelectionCount()
+  const bulkMode = useBulkMode()
+  const exit = useListSelection((state) => state.exit)
+  const utils = api.useUtils()
+  const { ConfirmDialog, run, isRunning } = useBulkRunner()
+
+  // The same query key the page holds, so this is the cache and not a refetch.
+  const chart = api.ledger.chartAccounts.useQuery({ includeArchived: true })
+
+  const removeAccount = api.ledger.chartAccountRemove.useMutation()
+  const restoreAccount = api.ledger.chartAccountRestore.useMutation()
+
+  const { live, archived } = useMemo(() => {
+    const byId = new Map((chart.data ?? []).map((account) => [account.id, account]))
+    const live: string[] = []
+    const archived: string[] = []
+    for (const id of ids) {
+      const account = byId.get(id)
+      if (!account) continue
+      if (account.isArchived) archived.push(id)
+      else live.push(id)
+    }
+    return { live, archived }
+  }, [ids, chart.data])
+
+  const invalidate = () => {
+    void utils.ledger.chartAccounts.invalidate()
+    void utils.ledger.roleMap.invalidate()
+    void utils.ledger.accountMap.invalidate()
+  }
+
+  const handleRemove = () =>
+    run(live, (id) => removeAccount.mutateAsync({ id }), {
+      title: `Remove ${live.length} account${live.length === 1 ? '' : 's'}?`,
+      description:
+        'They come out of the chart. Entries already posted keep the code and the name they were written with, and you can put them back from Show archived.',
+      confirmText: 'Remove',
+      failureTitle: 'Some accounts could not be removed',
+      pendingLabel: 'Removing…',
+      onDone: () => {
+        invalidate()
+        exit()
+      },
+    })
+
+  const handleRestore = () =>
+    run(archived, (id) => restoreAccount.mutateAsync({ id }), {
+      title: `Put ${archived.length} account${archived.length === 1 ? '' : 's'} back?`,
+      description:
+        'They return to the chart with their code, their name and their link to the accounting system. No posting role is re-pointed at them.',
+      confirmText: 'Restore',
+      destructive: false,
+      // The row STAYS - it is only un-dimmed - so the pending marker has to be
+      // cleared on settle rather than left for a refetch to remove the row.
+      removesItem: false,
+      failureTitle: 'Some accounts could not be restored',
+      pendingLabel: 'Restoring…',
+      onDone: () => {
+        invalidate()
+        exit()
+      },
+    })
+
+  const actions: ActionBarAction[] = [
+    {
+      id: 'restore',
+      label: archived.length === count ? 'Restore' : `Restore ${archived.length}`,
+      icon: RotateCcw,
+      variant: 'outline',
+      tooltip: 'Put the removed accounts back in the chart',
+      // Hidden rather than disabled when nothing in the selection is archived:
+      // most selections are all-live, and a permanently dead Restore button
+      // beside Remove is one more thing to read past.
+      hidden: archived.length === 0,
+      disabled: isRunning,
+      onClick: () => void handleRestore(),
+    },
+    {
+      id: 'remove',
+      label: live.length === count ? 'Remove' : `Remove ${live.length}`,
+      icon: Trash2,
+      variant: 'destructive',
+      tooltip: 'Take the selected accounts out of the chart',
+      hidden: live.length === 0,
+      disabled: isRunning,
+      onClick: () => void handleRemove(),
+    },
+  ]
+
+  return (
+    <>
+      <ConfirmDialog />
+      <ActionBar
+        open={bulkMode || count > 0}
+        onOpenChange={(open) => !open && exit()}
+        selectedCount={count}
+        selectedLabel='selected'
+        actions={actions}
+        showClose
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -29,23 +29,47 @@
 // from `accounts` and stays fully usable while `map.isPending`, while
 // `map.isError`, and with no provider connected at all.
 
-import type { AccountRole, ChartAccountRow } from '@auxx/lib/postings/client'
+import type { AccountRole, ChartAccountRow, GlAccountTypeValue } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
+import { Skeleton } from '@auxx/ui/components/skeleton'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
-import { Landmark, Link2, Plus, Sparkles, TriangleAlert } from 'lucide-react'
-import { useState } from 'react'
+import {
+  BookOpen,
+  ChevronDown,
+  Landmark,
+  Link2,
+  Plus,
+  RotateCcw,
+  Sparkles,
+  Trash2,
+  TriangleAlert,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  useBulkMode,
+  useIsPending,
+  useIsSelected,
+  useListSelection,
+} from '~/components/list-selection'
 import { AccountLabel } from '../account-label'
 import { accountMatchesSearch } from '../account-label-format'
 import {
   ACCOUNT_SUGGESTION_REASON_COPY,
+  ACCOUNT_TYPE_OPTIONS,
   type AccountLinkState,
   accountLinkState,
-  accountTypeColor,
-  accountTypeLabel,
   type ChartDraftHandle,
   type ChartMapView,
   formatProviderAccount,
@@ -64,6 +88,14 @@ interface ChartListProps {
   /** The uncommitted draft, if any. Rendered as a phantom row at the top. */
   draft: ChartDraftHandle | null
   onAddDraft: () => void
+  /** Opens the catalogue picker (`chart-packs-dialog.tsx`). */
+  onAddFromCatalogue: () => void
+  /** Archives one account. Confirms and reports its own refusal. */
+  onRemoveAccount: (id: string) => void
+  /** Puts a removed account back. */
+  onRestoreAccount: (id: string) => void
+  showArchived: boolean
+  onShowArchivedChange: (next: boolean) => void
   /** The account map, decorating the rows. Never the source of them. */
   map: ChartMapView
   /** Confirms every suggested mapping at once. */
@@ -86,6 +118,11 @@ export function ChartList({
   rolesByAccountId,
   draft,
   onAddDraft,
+  onAddFromCatalogue,
+  onRemoveAccount,
+  onRestoreAccount,
+  showArchived,
+  onShowArchivedChange,
   map,
   onConfirmSuggested,
   confirming,
@@ -94,16 +131,48 @@ export function ChartList({
   canControl,
 }: ChartListProps) {
   const [search, setSearch] = useState('')
+  // Collapsed groups by statement type. Open is the default - the chart is what
+  // this tab is for, and a group that starts shut hides the link badges the
+  // rows exist to carry.
+  const [collapsed, setCollapsed] = useState<GlAccountTypeValue[]>([])
+
+  const toggleGroup = (type: GlAccountTypeValue) =>
+    setCollapsed((prev) => (prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type]))
 
   // 29 rows, recomputed per keystroke of the search box. A `useMemo` here would
   // cost more to read than the loop costs to run.
-  const linked = accounts.filter(
+  // 🛑 `accounts` arrives WITH archived rows (the query always asks), so every
+  // count below has to say which set it means. `live` is the chart; archived
+  // rows are removed accounts kept for their history and their provider
+  // identity, and counting them as chart would overstate it on every line.
+  const live = accounts.filter((account) => !account.isArchived)
+  const archivedCount = accounts.length - live.length
+
+  const linked = live.filter(
     (account) => map.byAccountId.get(account.id)?.state === 'confirmed'
   ).length
 
+  const visible = showArchived ? accounts : live
   const filtered = search
-    ? accounts.filter((account) => accountMatchesSearch(account, search))
-    : accounts
+    ? visible.filter((account) => accountMatchesSearch(account, search))
+    : visible
+
+  // 🛑 The selection store's idea of "every item" is what shift-range and Cmd+A
+  // read, so it tracks what is actually ON SCREEN - filtered by the search and
+  // by the archived toggle, in render order. Feeding it the whole chart would
+  // let Cmd+A select rows the reader cannot see.
+  //
+  // 🛑 `pruneSelection: false` because this list HIDES rows rather than losing
+  // them. Typing in the search narrows the visible set, and the default pruning
+  // would read that as "those rows are gone" and silently drop them from the
+  // selection - so picking two accounts, searching for a third and picking it
+  // left one selected. A row that a bulk action really does remove leaves the
+  // selection when the bar calls `exit()` on done.
+  const setItemIds = useListSelection((state) => state.setItemIds)
+  const visibleIds = useMemo(() => filtered.map((account) => account.id), [filtered])
+  useEffect(() => {
+    setItemIds(visibleIds, { pruneSelection: false })
+  }, [visibleIds, setItemIds])
 
   // Hidden once `recordId` is stamped: the real row arrived with the invalidated
   // query, and rendering both would show the same account twice.
@@ -118,60 +187,116 @@ export function ChartList({
           placeholder='Search accounts...'
           className='flex-1'
         />
+        {/* Offered only when there is something behind it. An always-present
+            toggle over an empty set advertises a state most orgs never reach,
+            and removal is meant to be quiet rather than a mode. */}
+        {archivedCount > 0 && (
+          <ButtonSwitch
+            label={`Show archived (${archivedCount})`}
+            size='xs'
+            checked={showArchived}
+            onCheckedChange={onShowArchivedChange}
+            className='shrink-0'
+          />
+        )}
+        {/* 🛑 ONE control, two answers. Two sibling buttons is exactly what
+            forced `bank-accounts-list.tsx` to split its toolbar across two rows
+            (a second button squeezes `InputSearch` to about forty pixels), and
+            "add an account" is one intent with two routes rather than two
+            intents.
+            🛑 The catalogue is listed FIRST. Most of what a person reaches for
+            here is a standard account that already exists in the catalogue, and
+            leading with the blank row sends them off to type a code and a type
+            that were written down already. Same order `tariff-codes-list.tsx`
+            puts From catalogue in front of Add code. */}
         {canControl && (
-          <Button variant='outline' size='sm' onClick={onAddDraft}>
-            <Plus />
-            Add account
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant='outline' size='sm' className='shrink-0'>
+                <Plus />
+                Add account
+                <ChevronDown />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end' className='min-w-[15rem]'>
+              <DropdownMenuItem onSelect={onAddFromCatalogue}>
+                <BookOpen />
+                <span className='flex min-w-0 flex-col'>
+                  <span>From catalogue</span>
+                  <span className='text-muted-foreground text-xs'>
+                    Pick from the standard chart
+                  </span>
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={onAddDraft}>
+                <Plus />
+                <span className='flex min-w-0 flex-col'>
+                  <span>Blank account</span>
+                  <span className='text-muted-foreground text-xs'>Name and number it yourself</span>
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
       </div>
 
-      {/* 🛑 Gate on the PROVIDER, never on an empty map. "Nothing is connected"
+      {/* 🛑 ONE row, and its height is CONSTANT - `h-7`, the tallest thing it can
+          hold (a `size='sm'` Button). This strip used to be two blocks that each
+          rendered or did not, so the provider round trip landing shoved the whole
+          chart down the page under the reader's cursor. A fixed box that holds a
+          skeleton while pending cannot shift, whatever it resolves to.
+
+          🛑 LOADING is tested before "nothing connected", the order
+          `chart-account-editor.tsx`'s map block argues for: `connected` is false
+          for the whole of the round trip, so testing it first would tell every
+          reader their accounting system is disconnected for as long as it takes
+          to answer - a claim about the org, made false by the render order.
+
+          🛑 Gate on the PROVIDER, never on an empty map. "Nothing is connected"
           and "connected but nothing linked" are different answers needing
           different actions, and collapsing them would tell somebody to link a
-          chart with nothing to link it to. With nothing connected this counter is
-          absent and the chart is unchanged; the line directly below says why. */}
-      {map.connected && (
-        <div className='flex flex-wrap items-center gap-2'>
-          <span className='text-muted-foreground text-xs tabular-nums'>
-            {linked} of {accounts.length} linked to {map.providerLabel ?? 'your accounting system'}
+          chart with nothing to link it to. */}
+      <div className='flex h-7 shrink-0 items-center gap-2'>
+        {map.isPending ? (
+          <Skeleton className='h-4 w-52' />
+        ) : map.isError ? (
+          <span className='truncate text-muted-foreground text-xs'>
+            Could not read the account map. Everything below is unaffected.
           </span>
-          {canControl && map.suggested > 0 && (
-            <Button
-              variant='outline'
-              size='xs'
-              loading={confirming}
-              loadingText='Confirming...'
-              onClick={onConfirmSuggested}>
-              <Sparkles />
-              Accept {map.suggested}
-            </Button>
-          )}
-          {/* Refresh only once the chart holds at least one CONFIRMED mapping -
-              the signal that this chart was either imported or hand-mapped, so a
-              refresh has something to add to rather than nothing to compare
-              against (brief 16 §2.3). */}
-          {canControl && linked > 0 && <ImportChartButton mode='chart' connected={map.connected} />}
-        </div>
-      )}
-
-      {/* 🛑 LOADING is tested before "nothing connected", the same order
-          `chart-account-editor.tsx`'s map block argues for: `connected` is false
-          for the whole of the provider round trip, so testing it first would tell
-          every reader their accounting system is disconnected for as long as it
-          takes to answer.
-
-          This line exists because every row now wears a link badge when
-          connected. With nothing connected there are no badges at all, and
-          without a sentence "no accounting system", "still loading" and
-          "connected but nothing linked" would all render as the same silence. */}
-      {!map.isPending && (map.isError || !map.connected) && (
-        <span className='text-muted-foreground text-xs'>
-          {map.isError
-            ? 'Could not read the account map. Everything below is unaffected.'
-            : 'No accounting system connected, so nothing here is linked. Entries are still built, balanced and stored in Auxx.'}
-        </span>
-      )}
+        ) : !map.connected ? (
+          // ⚠️ The reassurance that used to follow this ("entries are still
+          // built, balanced and stored") is deliberately not here: it does not
+          // fit one line, and the detail pane already says it on the row it is
+          // about (`chart-account-editor.tsx`'s not-connected branch).
+          <span className='truncate text-muted-foreground text-xs'>
+            No accounting system connected, so nothing here is linked.
+          </span>
+        ) : (
+          <>
+            <span className='shrink-0 text-muted-foreground text-xs tabular-nums'>
+              {linked} of {live.length} linked to {map.providerLabel ?? 'your accounting system'}
+            </span>
+            {canControl && map.suggested > 0 && (
+              <Button
+                variant='outline'
+                size='xs'
+                loading={confirming}
+                loadingText='Confirming...'
+                onClick={onConfirmSuggested}>
+                <Sparkles />
+                Accept {map.suggested}
+              </Button>
+            )}
+            {/* Refresh only once the chart holds at least one CONFIRMED mapping -
+                the signal that this chart was either imported or hand-mapped, so
+                a refresh has something to add to rather than nothing to compare
+                against (brief 16 §2.3). */}
+            {canControl && linked > 0 && (
+              <ImportChartButton mode='chart' connected={map.connected} />
+            )}
+          </>
+        )}
+      </div>
 
       {/* A dangling mapping is a REPAIR, not a mapping, and `G19` requires every
           close to refuse on exactly these - so it leads the tab rather than
@@ -241,79 +366,66 @@ export function ChartList({
             />
           )}
 
-          {filtered.map((account) => {
-            const roles = rolesByAccountId.get(account.id) ?? []
-            const identity = map.byAccountId.get(account.id)
-            // Gated on the LOADED map for the same reason the badge is: a row
-            // action derived from a round trip that has not answered yet is an
-            // offer the server may be about to refuse.
-            const suggestion = map.connected && !map.isPending ? identity?.suggestion : undefined
+          {/* 🛑 Grouped by STATEMENT TYPE, which is how QuickBooks sections its
+              own chart and how `gl-account-picker.tsx` has always rendered this
+              same list. Flat, the only ordering was
+              `compareAccountsByCodeThenName` - whose own docstring says it is
+              "applied AFTER the caller has ordered by statement type", which no
+              caller did. An imported chart makes that visible: accounts with no
+              number sort into one alphabetical run with liabilities between
+              expenses.
+
+              🛑 A `TreeRow` parent, not a `Section`, for the reason
+              `role-map-list.tsx` gives: both levels are then the same primitive
+              and the connector draws the nesting. */}
+          {ACCOUNT_TYPE_OPTIONS.map(({ value: type, label }) => {
+            const group = filtered.filter((account) => account.accountType === type)
+            // An empty group headed "no accounts here" is noise. A chart that
+            // has no equity accounts should read as four groups, not five.
+            if (group.length === 0) return null
+
+            const groupLinked = group.filter(
+              (account) => map.byAccountId.get(account.id)?.state === 'confirmed'
+            ).length
+
             return (
               <TreeRow
-                key={account.id}
+                key={type}
+                expandable
+                // 🛑 A search FORCES every group open, for the reason the Roles
+                // tab gives: `filtered` has already dropped what does not match,
+                // so a collapsed group would hide the hits and read as nothing
+                // found while holding some.
+                isOpen={!!search || !collapsed.includes(type)}
+                onToggleOpen={() => toggleGroup(type)}
                 icon={<Landmark className='size-4 text-muted-foreground' />}
-                title={<AccountLabel account={account} className='text-sm' />}
-                secondaryFill
-                onToggleOpen={() => onSelect(account.id)}
-                rowClassName={cn(
-                  'bg-primary-100/50 hover:bg-primary-100',
-                  selectedId === account.id && 'bg-primary-100 ring-1 ring-primary-200',
-                  !account.isActive && 'opacity-60'
-                )}
-                // 🛑 `persistent`, and ONLY on a row that has a suggestion.
-                // `TreeRowButton` is hover-revealed by default, which is right for
-                // an action every row carries and wrong for one that exists on
-                // the handful that the matcher happened to propose - the reader
-                // would have to hover each row in turn to find them. The other rows get no button at
-                // all rather than a disabled one: there is nothing to accept.
-                //
-                // 🛑 The tooltip NAMES the account and says how it was matched.
-                // `G19` makes the confirming person the last line of defence (a
-                // wrong account id still balances, so nothing downstream catches
-                // it), and a bare check mark would ask them to agree to something
-                // they cannot see. Same pairing the editor's Confirm button makes.
-                actions={
-                  suggestion && canControl ? (
-                    <TreeRowButton
-                      persistent
-                      tooltipText={`Link ${formatProviderAccount(suggestion.account)} - ${ACCOUNT_SUGGESTION_REASON_COPY[suggestion.reason]}`}
-                      disabled={acceptingAccountId === account.id}
-                      onClick={() => onAcceptSuggestion(account.id, suggestion.account.id)}>
-                      <Link2 />
-                    </TreeRowButton>
-                  ) : undefined
-                }
+                title={<span className='truncate font-medium text-sm'>{label}</span>}
                 secondary={
-                  <span className='flex items-center gap-1.5 text-muted-foreground text-xs'>
-                    <Badge variant={accountTypeColor(account.accountType)} size='xs'>
-                      {accountTypeLabel(account.accountType)}
-                    </Badge>
-                    {!account.isActive && (
-                      <Badge variant='outline' size='xs'>
-                        Inactive
-                      </Badge>
-                    )}
-                    {/* Only ever rendered against a LOADED map. A link badge on
-                        rows the provider round trip has not answered for yet is
-                        a claim about the org, and rendering it mid-load makes it
-                        a false one.
-
-                        🛑 One badge, ALWAYS present once the map has loaded -
-                        never a set of conditional badges whose absence has to be
-                        interpreted. This used to render only two of the four
-                        states, so a row with a pending suggestion looked exactly
-                        like a linked one: silence. */}
-                    {map.connected && !map.isPending && (
-                      <AccountLinkBadge state={accountLinkState(identity)} />
-                    )}
-                    {roles.length > 0 && (
-                      <span>
-                        {roles.length} {roles.length === 1 ? 'role' : 'roles'}
-                      </span>
-                    )}
+                  <span className='text-muted-foreground text-xs tabular-nums'>
+                    {group.length} {group.length === 1 ? 'account' : 'accounts'}
+                    {map.connected && !map.isPending ? ` · ${groupLinked} linked` : ''}
                   </span>
-                }
-              />
+                }>
+                <TreeRowList
+                  items={group}
+                  getKey={(account: ChartAccountRow) => account.id}
+                  renderRow={(account: ChartAccountRow) => (
+                    <ChartAccountListRow
+                      key={account.id}
+                      account={account}
+                      roles={rolesByAccountId.get(account.id) ?? []}
+                      map={map}
+                      selectedId={selectedId}
+                      onSelect={onSelect}
+                      onAcceptSuggestion={onAcceptSuggestion}
+                      acceptingAccountId={acceptingAccountId}
+                      onRemoveAccount={onRemoveAccount}
+                      onRestoreAccount={onRestoreAccount}
+                      canControl={canControl}
+                    />
+                  )}
+                />
+              </TreeRow>
             )
           })}
         </div>
@@ -364,4 +476,180 @@ function AccountLinkBadge({ state }: { state: AccountLinkState }) {
         </Badge>
       )
   }
+}
+
+interface ChartAccountListRowProps {
+  account: ChartAccountRow
+  roles: AccountRole[]
+  map: ChartMapView
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+  onAcceptSuggestion: (glAccountId: string, providerAccountId: string) => void
+  acceptingAccountId: string | null
+  onRemoveAccount: (id: string) => void
+  onRestoreAccount: (id: string) => void
+  canControl: boolean
+}
+
+/**
+ * One account in the chart list.
+ *
+ * 🛑 A COMPONENT, not a `renderRow` closure, because it calls `useIsSelected`.
+ * A hook inside a render callback runs in the PARENT's hook order, and this list
+ * filters - so the hook count would change between renders the moment somebody
+ * typed in the search box.
+ */
+function ChartAccountListRow({
+  account,
+  roles,
+  map,
+  selectedId,
+  onSelect,
+  onAcceptSuggestion,
+  acceptingAccountId,
+  onRemoveAccount,
+  onRestoreAccount,
+  canControl,
+}: ChartAccountListRowProps) {
+  const selecting = useBulkMode()
+  const isSelected = useIsSelected(account.id)
+  const toggle = useListSelection((state) => state.toggle)
+  const isPending = useIsPending(account.id)
+
+  const identity = map.byAccountId.get(account.id)
+  // Gated on the LOADED map for the same reason the badge is: a
+  // row action derived from a round trip that has not answered
+  // yet is an offer the server may be about to refuse.
+  const suggestion = map.connected && !map.isPending ? identity?.suggestion : undefined
+  return (
+    <TreeRow
+      depth={1}
+      icon={<Landmark className='size-4 text-muted-foreground' />}
+      title={<AccountLabel account={account} className='text-sm' />}
+      // 🛑 Selection is always AVAILABLE and only PINNED in bulk mode: the
+      // checkbox cross-fades with the row's icon on hover, so an ordinary reader
+      // never sees one and a person mid-selection sees them all.
+      selectable
+      selecting={selecting}
+      selected={isSelected}
+      onSelectChange={(_next, event) => toggle(account.id, { shiftKey: event.shiftKey })}
+      selectLabel={`Select ${account.code ? `${account.code} ` : ''}${account.name}`}
+      secondaryFill
+      onToggleOpen={() => onSelect(account.id)}
+      rowClassName={cn(
+        'bg-primary-100/50 hover:bg-primary-100',
+        selectedId === account.id && 'bg-primary-100 ring-1 ring-primary-200',
+        (!account.isActive || account.isArchived) && 'opacity-60',
+        // The bulk runner is working on this row. Without it a long batch reads
+        // as a frozen list.
+        isPending && 'pointer-events-none animate-pulse opacity-50'
+      )}
+      // 🛑 `persistent`, and ONLY on a row that has a
+      // suggestion. `TreeRowButton` is hover-revealed by
+      // default, which is right for an action every row carries
+      // and wrong for one that exists on the handful the matcher
+      // happened to propose - the reader would have to hover
+      // each row in turn to find them. The other rows get no
+      // button rather than a disabled one: nothing to accept.
+      //
+      // 🛑 The tooltip NAMES the account and says how it was
+      // matched. `G19` makes the confirming person the last line
+      // of defence (a wrong account id still balances, so
+      // nothing downstream catches it), and a bare check mark
+      // would ask them to agree to something they cannot see.
+      actions={
+        canControl ? (
+          <>
+            {/* 🛑 An archived row offers RESTORE and nothing
+                  else. Removing what is already removed does
+                  nothing, and accepting a suggestion for it
+                  would map a provider account onto a row the
+                  chart does not contain. */}
+            {account.isArchived ? (
+              <TreeRowButton
+                persistent
+                tooltipText='Put this account back in the chart'
+                onClick={() => onRestoreAccount(account.id)}>
+                <RotateCcw />
+              </TreeRowButton>
+            ) : (
+              <>
+                {suggestion && (
+                  <TreeRowButton
+                    persistent
+                    tooltipText={`Link ${formatProviderAccount(suggestion.account)} - ${ACCOUNT_SUGGESTION_REASON_COPY[suggestion.reason]}`}
+                    disabled={acceptingAccountId === account.id}
+                    onClick={() => onAcceptSuggestion(account.id, suggestion.account.id)}>
+                    <Link2 />
+                  </TreeRowButton>
+                )}
+                {/* 🛑 NOT `persistent`, unlike the accept button
+                  beside it. Remove is destructive and belongs to
+                  every row, so pinning it visible would put a
+                  hundred delete buttons on screen; hover-reveal
+                  is exactly what the default variant is for. The
+                  accept button is pinned because it exists on
+                  only the handful of rows the matcher proposed,
+                  and hover-hunting those is the thing to avoid.
+                  🛑 The confirm and the refusal both live in
+                  `accounts-settings-page.tsx`. A role still
+                  posting here is the server's answer, and a
+                  client-side copy of that check would be a second
+                  authority over the one question this page must
+                  not get wrong. */}
+                <TreeRowButton
+                  variant='destructive'
+                  tooltipText='Remove from the chart'
+                  onClick={() => onRemoveAccount(account.id)}>
+                  <Trash2 />
+                </TreeRowButton>
+              </>
+            )}
+          </>
+        ) : undefined
+      }
+      secondary={
+        <span className='flex items-center gap-1.5 text-muted-foreground text-xs'>
+          {/* ⚠️ NO type badge. The group header this row sits
+                under already says the statement type, and
+                repeating it on every row under it is the badge
+                saying what the heading just said. */}
+          {/* ⚠️ Archived and inactive are different states and
+                must not read the same. Inactive is an account
+                the org keeps but will not post to; archived is
+                one it took out of the chart entirely. */}
+          {account.isArchived ? (
+            <Badge variant='secondary' size='xs'>
+              Removed
+            </Badge>
+          ) : (
+            !account.isActive && (
+              <Badge variant='outline' size='xs'>
+                Inactive
+              </Badge>
+            )
+          )}
+          {/* Only ever rendered against a LOADED map. A link
+                badge on rows the provider round trip has not
+                answered for yet is a claim about the org, and
+                rendering it mid-load makes it a false one.
+
+                🛑 One badge, ALWAYS present once the map has
+                loaded - never a set of conditional badges whose
+                absence has to be interpreted. This used to render
+                only two of the four states, so a row with a
+                pending suggestion looked exactly like a linked
+                one: silence. */}
+          {map.connected && !map.isPending && (
+            <AccountLinkBadge state={accountLinkState(identity)} />
+          )}
+          {roles.length > 0 && (
+            <span>
+              {roles.length} {roles.length === 1 ? 'role' : 'roles'}
+            </span>
+          )}
+        </span>
+      }
+    />
+  )
 }

--- a/apps/web/src/components/accounting/ui/settings/chart-packs-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-packs-dialog.tsx
@@ -1,72 +1,91 @@
 // apps/web/src/components/accounting/ui/settings/chart-packs-dialog.tsx
 'use client'
 
-// "Add accounts" on the Roles tab (brief 16 §3.2): pick one or more chart
-// packs and provision them, without going through the wizard again.
+// "From catalogue" - the door onto the standard chart, from both tabs of
+// Accounting > Settings > Accounts (brief 16 §3.2).
 //
-// One `TreeRow` per `CHART_PACK_KEYS` entry, in declaration order (`core`
-// first - though `core` reads `provisioned` on any org that has ever mapped a
-// role and therefore never renders a checkbox). `packState` (from
-// `@auxx/lib/postings/client`, derived on the client from `roleMap` and
-// `CHART_PACKS` - no new query) decides how a row reads:
+// 🛑 SELECTION IS BY ACCOUNT, NOT BY PACK. A pack is the unit the SEEDER walks
+// and the unit `provisionChart` takes; it is not a fine enough unit for a
+// person who wants Deferred Revenue and not Customer Deposits. Checking a pack
+// row is shorthand for checking every account under it - the footer counts
+// accounts, and `ledger.adoptChartAccounts` takes codes. The pack pages remain
+// how the catalogue is ORGANISED, which is a different job from how it is
+// chosen.
 //
-// - `provisioned` - disabled, with a check. Nothing left for this pack to add.
-// - `partial` - a sentence naming which of its roles are still unmapped, and a
-//   checkbox: re-provisioning is a no-op on what is already mapped
-//   (`seedChartPacks`'s rules 1, 3, 4) and fills only the gap.
-// - `absent` - a plain checkbox.
+// 🛑 Two pages through `DialogNavPages` (ui-design-guide §6), never conditional
+// rendering under a hand-rolled header: the packs list, and one pack's
+// accounts. Drilling in is what makes per-account selection possible at all -
+// the whole catalogue as one flat ungrouped list is something nobody reads,
+// and a pack row that cannot be opened cannot tell you what you are accepting.
 //
-// 🛑 `requires` is explained ON the row, not hidden in a tooltip - checking
-// `purchasing` submits `inventory` too (`resolveSelectedPacks`,
-// `accounts-types.ts`), and a person choosing it needs to see that BEFORE
-// pressing Confirm, not discover it afterwards on the chart.
+// 🛑 `requires` is stated ON the row and resolved on selection, not hidden in a
+// tooltip: checking Purchase orders also checks Inventory's accounts
+// (`resolveSelectedPacks`, `accounts-types.ts`), and a person needs to see that
+// before pressing Add, not discover it afterwards on the chart.
 //
-// 🛑 No success toast (CLAUDE.md). Provisioning is additive and idempotent, so
-// there is nothing here for `useConfirm` to gate.
+// 🛑 No success toast (CLAUDE.md). Adopting is additive and idempotent, so
+// there is nothing here for `useConfirm` to gate either.
 
+import type { ChartAccountRow } from '@auxx/lib/postings/client'
 import {
   ACCOUNT_ROLE_LABELS,
   CHART_PACK_KEYS,
   CHART_PACKS,
   type ChartPackKey,
-  packState,
-  type RoleAssignmentRow,
+  type DefaultChartAccount,
 } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { Checkbox } from '@auxx/ui/components/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
-import { DialogNav } from '@auxx/ui/components/dialog-nav'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
-import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { Check, Landmark } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
-import { forcedPacks, resolveSelectedPacks } from './accounts-types'
+import { accountTypeColor, accountTypeLabel, forcedPacks } from './accounts-types'
 
 interface ChartPacksDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  roleMap: RoleAssignmentRow[]
+  /**
+   * The org's live chart. Which catalogue codes are ALREADY here is read from
+   * this rather than from the role map: a code is either in the chart or it is
+   * not, where a role can be mapped to an account the catalogue never named.
+   */
+  accounts: ChartAccountRow[]
 }
 
-export function ChartPacksDialog({ open, onOpenChange, roleMap }: ChartPacksDialogProps) {
-  const utils = api.useUtils()
-  const [selected, setSelected] = useState<Set<ChartPackKey>>(new Set())
+/** `'packs'` is the list; anything else is that pack's accounts. */
+type Page = 'packs' | ChartPackKey
 
-  // A fresh open starts with nothing picked - the picker does not remember
-  // what somebody chose and cancelled last time.
+export function ChartPacksDialog({ open, onOpenChange, accounts }: ChartPacksDialogProps) {
+  const utils = api.useUtils()
+  const [page, setPage] = useState<Page>('packs')
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  // A fresh open starts on the list with nothing picked - the dialog does not
+  // remember what somebody chose and cancelled last time (ui-design-guide §6).
   useEffect(() => {
-    if (open) setSelected(new Set())
+    if (open) {
+      setPage('packs')
+      setSelected(new Set())
+    }
   }, [open])
 
-  const provisionChart = api.ledger.provisionChart.useMutation({
+  /** Every catalogue code the org already holds. */
+  const present = useMemo(
+    () => new Set(accounts.flatMap((account) => (account.code ? [account.code] : []))),
+    [accounts]
+  )
+
+  const adopt = api.ledger.adoptChartAccounts.useMutation({
     onSuccess: async () => {
       await Promise.all([
-        utils.ledger.roleMap.invalidate(),
         utils.ledger.chartAccounts.invalidate(),
+        utils.ledger.roleMap.invalidate(),
       ])
       onOpenChange(false)
     },
@@ -75,58 +94,138 @@ export function ChartPacksDialog({ open, onOpenChange, roleMap }: ChartPacksDial
     },
   })
 
-  const forced = forcedPacks(selected)
-  const packsToSubmit = resolveSelectedPacks(selected)
+  /**
+   * Which packs a selection implies, so `requires` can be honoured on a
+   * per-account picker: any account of `purchasing` checked means `inventory`
+   * comes too. Derived from the SELECTION rather than from checked pack rows,
+   * because a person can reach the same state either way.
+   */
+  const impliedPacks = useMemo(() => {
+    const packs = new Set<ChartPackKey>()
+    for (const key of CHART_PACK_KEYS) {
+      if (CHART_PACKS[key].accounts.some((account) => selected.has(account.code))) packs.add(key)
+    }
+    return packs
+  }, [selected])
 
-  function toggle(key: ChartPackKey, checked: boolean) {
+  const forced = useMemo(() => forcedPacks(impliedPacks), [impliedPacks])
+
+  /**
+   * The codes actually sent: everything checked, plus every still-missing
+   * account of a pack forced on by `requires`.
+   *
+   * 🛑 Resolved HERE and not on the server, so the count in the footer and the
+   * write can never disagree - the same reason `resolveSelectedPacks` resolves
+   * the pack cascade on the client.
+   */
+  const codesToSubmit = useMemo(() => {
+    const codes = new Set(selected)
+    for (const key of forced) {
+      for (const account of CHART_PACKS[key].accounts) {
+        if (!present.has(account.code)) codes.add(account.code)
+      }
+    }
+    return [...codes]
+  }, [selected, forced, present])
+
+  function toggleCodes(codes: readonly string[], checked: boolean) {
     setSelected((prev) => {
       const next = new Set(prev)
-      if (checked) next.add(key)
-      else next.delete(key)
+      for (const code of codes) {
+        if (checked) next.add(code)
+        else next.delete(code)
+      }
       return next
     })
   }
 
+  const openPack = page === 'packs' ? null : CHART_PACKS[page]
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size='md' position='tc' innerClassName='p-0'>
+      <DialogContent size='content' position='tc' innerClassName='p-0'>
         <DialogNav
-          title='Add accounts'
-          description='Provision a chart pack. Each pack points its roles at new accounts and never touches one you already mapped.'
-          crumbs={[{ label: 'Add accounts' }]}
+          title='Add accounts from the catalogue'
+          description='The standard chart, grouped the way it is provisioned. Take a whole group or pick single accounts - nothing you already have is touched.'
+          crumbs={[
+            {
+              label: 'Catalogue',
+              onClick: page === 'packs' ? undefined : () => setPage('packs'),
+            },
+            ...(openPack ? [{ label: openPack.label }] : []),
+          ]}
         />
 
-        <div className={cn('flex flex-col gap-0.5 p-3', TREE_SECONDARY_NOTRUNCATE)}>
-          {CHART_PACK_KEYS.map((key) => (
-            <PackRow
-              key={key}
-              packKey={key}
-              roleMap={roleMap}
-              checked={selected.has(key) || forced.has(key)}
-              forced={forced.has(key)}
-              onToggle={(checked) => toggle(key, checked)}
-            />
-          ))}
-        </div>
+        <DialogNavPages value={page}>
+          <DialogNavPage value='packs' size='md'>
+            <div className='flex flex-col gap-0.5 px-2 pt-4'>
+              {CHART_PACK_KEYS.map((key) => (
+                <PackRow
+                  key={key}
+                  packKey={key}
+                  present={present}
+                  selected={selected}
+                  forced={forced.has(key)}
+                  selecting={selected.size > 0}
+                  onToggle={(checked) =>
+                    toggleCodes(
+                      CHART_PACKS[key].accounts
+                        .filter((account) => !present.has(account.code))
+                        .map((account) => account.code),
+                      checked
+                    )
+                  }
+                  onOpen={() => setPage(key)}
+                />
+              ))}
+            </div>
+          </DialogNavPage>
 
-        <DialogFooter>
+          {CHART_PACK_KEYS.map((key) => (
+            <DialogNavPage key={key} value={key} size='md'>
+              <div className='flex flex-col gap-0.5 px-2 pt-4'>
+                {CHART_PACKS[key].accounts.map((account) => (
+                  <AccountRow
+                    key={account.code}
+                    account={account}
+                    here={present.has(account.code)}
+                    selected={selected.has(account.code)}
+                    selecting={selected.size > 0}
+                    onToggle={(checked) => toggleCodes([account.code], checked)}
+                  />
+                ))}
+              </div>
+            </DialogNavPage>
+          ))}
+        </DialogNavPages>
+
+        {/* 🛑 A SIBLING of `DialogNavPages`, and therefore gutterless unless it
+            says so. `DialogFooter` carries only `pt-4`; its side and bottom
+            padding normally comes from `DialogContent`'s inner `p-4`, which
+            `innerClassName='p-0'` removes - and that is mandatory for
+            `DialogNavPages` to own the width/height spring. `footerGutter` does
+            NOT cover this case: it re-applies the gutter to a footer nested
+            INSIDE a page, and this one deliberately is not. It sits outside so
+            the running count holds still while the pages animate under it. */}
+        <DialogFooter className='px-4 pb-4'>
           <Button
             type='button'
             variant='ghost'
             size='sm'
             onClick={() => onOpenChange(false)}
-            disabled={provisionChart.isPending}>
+            disabled={adopt.isPending}>
             Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
           </Button>
           <Button
-            onClick={() => provisionChart.mutate({ packs: packsToSubmit })}
+            onClick={() => adopt.mutate({ codes: codesToSubmit })}
             variant='outline'
             size='sm'
-            loading={provisionChart.isPending}
+            loading={adopt.isPending}
             loadingText='Adding...'
-            disabled={packsToSubmit.length === 0}
+            disabled={codesToSubmit.length === 0}
             data-dialog-submit>
-            Add accounts <KbdSubmit variant='outline' size='sm' />
+            {codesToSubmit.length === 1 ? 'Add 1 account' : `Add ${codesToSubmit.length} accounts`}
+            <KbdSubmit variant='outline' size='sm' />
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -136,63 +235,132 @@ export function ChartPacksDialog({ open, onOpenChange, roleMap }: ChartPacksDial
 
 interface PackRowProps {
   packKey: ChartPackKey
-  roleMap: RoleAssignmentRow[]
-  /** Checked because it was picked directly, or forced on by `requires`. */
-  checked: boolean
-  /** Forced on by another selected pack's `requires` - shown checked, not toggleable. */
+  present: Set<string>
+  selected: Set<string>
+  /** Pulled in by another pack's `requires` - shown checked, not toggleable. */
   forced: boolean
+  /** Anything selected anywhere → checkboxes are pinned rather than hover-revealed. */
+  selecting: boolean
   onToggle: (checked: boolean) => void
+  onOpen: () => void
 }
 
-function PackRow({ packKey, roleMap, checked, forced, onToggle }: PackRowProps) {
+function PackRow({
+  packKey,
+  present,
+  selected,
+  forced,
+  selecting,
+  onToggle,
+  onOpen,
+}: PackRowProps) {
   const pack = CHART_PACKS[packKey]
-  const state = packState(packKey, roleMap)
+  const missing = pack.accounts.filter((account) => !present.has(account.code))
+  const here = pack.accounts.length - missing.length
+  const picked = missing.filter((account) => selected.has(account.code)).length
 
-  const roles = pack.accounts.flatMap((account) => (account.role ? [account.role] : []))
-  const rowsByRole = new Map(roleMap.map((row) => [row.role, row]))
-  const unmapped = roles.filter(
-    (role) => (rowsByRole.get(role)?.state ?? 'unmapped') === 'unmapped'
-  )
+  // 🛑 Three states, not two. A partly-picked pack renders the dash box rather
+  // than an empty one, or drilling in, checking one account and coming back
+  // would read as "nothing selected here".
+  const checked: boolean | 'indeterminate' =
+    forced || (missing.length > 0 && picked === missing.length)
+      ? true
+      : picked > 0
+        ? 'indeterminate'
+        : false
 
-  const requiresNote =
-    pack.requires && pack.requires.length > 0
-      ? `Also adds ${pack.requires.map((req) => CHART_PACKS[req].label).join(', ')}.`
-      : null
-
-  const secondaryParts: string[] = []
-  if (state === 'partial') {
-    secondaryParts.push(
-      `Not mapped: ${unmapped.map((role) => ACCOUNT_ROLE_LABELS[role]).join(', ')}`
-    )
-  } else {
-    secondaryParts.push(`${pack.accounts.length} accounts`)
+  const parts: string[] = []
+  if (missing.length === 0) parts.push('All here')
+  else parts.push(`${missing.length} of ${pack.accounts.length} to add`)
+  if (here > 0 && missing.length > 0) parts.push(`${here} already here`)
+  if (pack.requires?.length) {
+    parts.push(`Also adds ${pack.requires.map((req) => CHART_PACKS[req].label).join(', ')}`)
   }
-  if (requiresNote) secondaryParts.push(requiresNote)
 
   return (
     <TreeRow
       icon={<Landmark className='size-4 text-muted-foreground' />}
       title={pack.label}
       description={pack.description}
+      // Nothing left to add → no checkbox at all. A disabled one on a settled
+      // pack is a control that can never do anything, and the badge already
+      // says why.
+      selectable={missing.length > 0 && !forced}
+      selecting={selecting && missing.length > 0}
+      selected={checked}
+      onSelectChange={(next) => onToggle(next)}
+      selectLabel={`Add every account in ${pack.label}`}
+      // Drilling in is the row click. `onToggleOpen` rather than `onDrill` so
+      // the whole row opens the pack: the checkbox stops its own bubble, so a
+      // click on it still only selects.
+      onToggleOpen={onOpen}
+      onDrill={onOpen}
+      // ⚠️ NO `TREE_SECONDARY_NOTRUNCATE` here, unlike the chart lists. That
+      // class exists for a BADGE-shaped secondary whose pill edges get clipped;
+      // this secondary is a sentence, and letting a sentence refuse to truncate
+      // pushed the row's own checkbox off the edge.
+      secondary={<span className='text-muted-foreground text-xs'>{parts.join(' · ')}</span>}
+      secondaryFill
+      rowClassName={cn('hover:bg-primary-100', missing.length === 0 && 'opacity-70')}
+      actions={
+        missing.length === 0 ? (
+          <Badge variant='green' size='xs'>
+            <Check />
+            All here
+          </Badge>
+        ) : undefined
+      }
+    />
+  )
+}
+
+interface AccountRowProps {
+  account: DefaultChartAccount
+  /** The org's chart already holds this code. */
+  here: boolean
+  selected: boolean
+  selecting: boolean
+  onToggle: (checked: boolean) => void
+}
+
+function AccountRow({ account, here, selected, selecting, onToggle }: AccountRowProps) {
+  return (
+    <TreeRow
+      icon={<Landmark className='size-4 text-muted-foreground' />}
+      title={
+        <span className='truncate text-sm'>
+          <span className='text-muted-foreground tabular-nums'>{account.code}</span> {account.name}
+        </span>
+      }
+      // The role is why an account is not optional in practice - a role with
+      // nowhere to post refuses every preview - so it rides beside the title as
+      // the row's help tooltip rather than competing with the type badge for
+      // the secondary slot.
+      description={account.role ? ACCOUNT_ROLE_LABELS[account.role] : undefined}
+      selectable={!here}
+      selecting={selecting && !here}
+      selected={selected}
+      onSelectChange={(next) => onToggle(next)}
+      selectLabel={`Add ${account.code} ${account.name}`}
+      // The row toggles its own checkbox - a picker where only the box is a
+      // target is a picker people miss.
+      onToggleOpen={here ? undefined : () => onToggle(!selected)}
       secondary={
-        <span className='text-muted-foreground text-xs'>{secondaryParts.join(' · ')}</span>
+        <span className='flex items-center gap-1.5 p-[1px]'>
+          <Badge variant={accountTypeColor(account.accountType)} size='xs'>
+            {accountTypeLabel(account.accountType)}
+          </Badge>
+        </span>
       }
       secondaryFill
-      rowClassName={cn('hover:bg-primary-100', state === 'provisioned' && 'opacity-70')}
+      rowClassName={cn('hover:bg-primary-100', here && 'opacity-70')}
       actions={
-        state === 'provisioned' ? (
+        here ? (
           <Badge variant='green' size='xs'>
-            <Check className='size-3' />
-            Provisioned
+            <Check />
+            Here
           </Badge>
-        ) : (
-          <Checkbox
-            checked={checked}
-            disabled={forced}
-            onCheckedChange={(value) => onToggle(value === true)}
-            aria-label={`Add the ${pack.label} pack`}
-          />
-        )
+        ) : undefined
       }
     />
   )

--- a/apps/web/src/components/accounting/ui/settings/role-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/role-map-list.tsx
@@ -5,15 +5,18 @@
 // of them, across five chart packs - brief 16 §1), grouped by the statement
 // classification each one's account must carry (13-accounting-ui.md §5.4).
 //
-// 🛑 A `Section` per group with a FLAT `TreeRow` list, not nested `TreeRow`
-// depth. The tree is two levels and a parent row would add a chevron that
-// answers nothing.
+// 🛑 A `TreeRow` PARENT per group with its rows nested inside it, not a
+// `Section` wrapping a flat list. Both levels are then the same primitive, so
+// the connector line draws the nesting instead of leaving it to be inferred
+// from padding - and the group collapses, which a fixed `Section` header could
+// not. The Chart tab is built the same way, for the same reason.
 //
 // ⚠️ Grouping is derived from `ROLE_ACCOUNT_TYPES`, which already declares the
-// expected type per role, so no new constant is needed. Note what it yields
-// today: asset 4, liability 5, expense 4. There are no revenue and no equity
-// roles, so only three of the five groups render. The loop is written over all
-// five anyway, so the day a revenue role is added it appears on its own.
+// expected type per role, so no new constant is needed. The loop is written
+// over all five statement types and drops the empty ones, so a type that has
+// no roles today appears on its own the day one is added - which is why this
+// comment does not name a count per group. It used to, and the counts were
+// wrong within a release.
 //
 // 🛑 There are NO phantom drafts on this tab. The roles are a fixed vocabulary
 // and a person cannot create one; adding a role is a code change to
@@ -26,25 +29,30 @@
 // this component renders whatever it is handed rather than filtering.
 //
 // ⚠️ No `TREE_SECONDARY_NOTRUNCATE` here, unlike the chart list. This list's
-// `secondary` slot carries a SENTENCE ("Every preview refuses until this is
-// set"), and the class turns the slot's truncation off - which would let the
+// `secondary` slot carries SENTENCES ("The account this role names is archived
+// or gone"), and the class turns the slot's truncation off - which would let a
 // sentence push the row wide instead of ellipsing. It belongs on a badge-shaped
 // secondary only.
 
 import {
   ACCOUNT_ROLE_LABELS,
   type AccountRole,
+  type GlAccountTypeValue,
   ROLE_ACCOUNT_TYPES,
   type RoleAssignmentRow,
 } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { EmptySection, Section } from '@auxx/ui/components/section'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { EmptySection } from '@auxx/ui/components/section'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
 import { Ban, Coins, CreditCard, Pencil, Plus, Receipt, RotateCcw, Sparkles } from 'lucide-react'
+import { useState } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
 import { AccountLabel } from '../account-label'
-import { ACCOUNT_TYPE_OPTIONS } from './accounts-types'
+import { ACCOUNT_TYPE_OPTIONS, formatAccount } from './accounts-types'
 
 /** Statement-section icon, one per group. */
 const GROUP_ICONS: Record<string, typeof Coins> = {
@@ -79,6 +87,15 @@ export function RoleMapList({
   onAddAccounts,
   canControl,
 }: RoleMapListProps) {
+  const [search, setSearch] = useState('')
+  // Collapsed groups by statement type. Open is the default: a role that needs
+  // an account is the whole point of this screen, and a group that starts shut
+  // hides the "Not mapped" badge the list exists to surface.
+  const [collapsed, setCollapsed] = useState<GlAccountTypeValue[]>([])
+
+  const toggleGroup = (type: GlAccountTypeValue) =>
+    setCollapsed((prev) => (prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type]))
+
   if (isLoading) {
     // 🛑 A spinner, never every role rendered `unmapped`. "Not mapped - every preview
     // refuses until this is set" is an assertion about the organization, and
@@ -90,50 +107,104 @@ export function RoleMapList({
     )
   }
 
+  // One row per role, recomputed per keystroke. A `useMemo` here would cost
+  // more to read than the loop costs to run - same call `chart-list.tsx` makes.
+  const needle = search.trim().toLowerCase()
+  const filtered = needle
+    ? rows.filter((row) => {
+        const label = ACCOUNT_ROLE_LABELS[row.role as AccountRole] ?? row.role
+        // The ACCOUNT is searchable too, not just the role. "which role posts
+        // to 1100" is the question this list is read backwards to answer, and
+        // matching the role name alone cannot answer it.
+        return (
+          label.toLowerCase().includes(needle) ||
+          row.role.toLowerCase().includes(needle) ||
+          formatAccount(row.account).toLowerCase().includes(needle)
+        )
+      })
+    : rows
+
   return (
     <div className='flex flex-col gap-4 p-3'>
-      {canControl && (
-        <div className='flex items-center justify-end'>
-          <Button variant='outline' size='sm' onClick={onAddAccounts}>
+      {/* The Chart tab's toolbar exactly: search fills the row, the one button
+          sits beside it. Two tabs of one page reading differently is what this
+          screen kept doing. */}
+      <div className='flex items-center gap-2'>
+        <InputSearch
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder='Search roles and accounts...'
+          className='flex-1'
+        />
+        {canControl && (
+          <Button variant='outline' size='sm' className='shrink-0' onClick={onAddAccounts}>
             <Plus />
             Add accounts
           </Button>
-        </div>
+        )}
+      </div>
+
+      {/* 🛑 Gate on the SEARCH, not on the row count. An empty result from a
+          search and an org with no roles are different answers, and the second
+          cannot happen - `ledger.roleMap` returns a row per role always. */}
+      {needle && filtered.length === 0 && (
+        <EmptySection icon={<Coins className='size-5' />} title='No matches' />
       )}
-      {ACCOUNT_TYPE_OPTIONS.map(({ value: type, label }) => {
-        const group = rows.filter((row) => ROLE_ACCOUNT_TYPES[row.role as AccountRole] === type)
-        // Equity and revenue have no roles today, and an empty section headed
-        // "no roles here" would be noise rather than information.
-        if (group.length === 0) return null
 
-        const Icon = GROUP_ICONS[type] ?? Coins
-        const needed = group.filter((row) => row.state !== 'unused')
-        const mapped = needed.filter(
-          (row) => row.state === 'confirmed' || row.state === 'suggested'
-        )
+      {/* 🛑 A `TreeRow` parent per statement type, not a `Section`. The rows
+          under it are `TreeRow`s, so a `Section` wrapping them made the group
+          header and its children two different primitives with two different
+          indents and no connector between them - the nesting had to be inferred
+          from the padding. A parent row draws the line to its own children. */}
+      <div className='flex flex-col gap-0.5'>
+        {ACCOUNT_TYPE_OPTIONS.map(({ value: type, label }) => {
+          const group = filtered.filter(
+            (row) => ROLE_ACCOUNT_TYPES[row.role as AccountRole] === type
+          )
+          // Equity and revenue have no roles today, and an empty group headed
+          // "no roles here" would be noise rather than information.
+          if (group.length === 0) return null
 
-        return (
-          <Section
-            key={type}
-            collapsible={false}
-            icon={<Icon className='size-4' />}
-            title={label}
-            secondary={`${mapped.length} of ${needed.length} mapped`}>
-            <div className='flex flex-col gap-0.5'>
-              {group.map((row) => (
-                <RoleRow
-                  key={row.role}
-                  row={row}
-                  selected={selectedRole === row.role}
-                  onSelect={onSelect}
-                  onToggleUnused={onToggleUnused}
-                  canControl={canControl}
-                />
-              ))}
-            </div>
-          </Section>
-        )
-      })}
+          const Icon = GROUP_ICONS[type] ?? Coins
+          const needed = group.filter((row) => row.state !== 'unused')
+          const mapped = needed.filter(
+            (row) => row.state === 'confirmed' || row.state === 'suggested'
+          )
+
+          return (
+            <TreeRow
+              key={type}
+              expandable
+              // 🛑 A search FORCES every group open. `filtered` has already
+              // dropped the rows that do not match, so a collapsed group would
+              // hide the very hits the search just found and read as "no
+              // results" while holding some.
+              isOpen={!!needle || !collapsed.includes(type)}
+              onToggleOpen={() => toggleGroup(type)}
+              icon={<Icon className='size-4 text-muted-foreground' />}
+              title={<span className='truncate font-medium text-sm'>{label}</span>}
+              secondary={
+                <span className='text-muted-foreground text-xs tabular-nums'>
+                  {mapped.length} of {needed.length} mapped
+                </span>
+              }>
+              <TreeRowList
+                items={group}
+                getKey={(row: RoleAssignmentRow) => row.role}
+                renderRow={(row: RoleAssignmentRow) => (
+                  <RoleRow
+                    row={row}
+                    selected={selectedRole === row.role}
+                    onSelect={onSelect}
+                    onToggleUnused={onToggleUnused}
+                    canControl={canControl}
+                  />
+                )}
+              />
+            </TreeRow>
+          )
+        })}
+      </div>
     </div>
   )
 }
@@ -156,6 +227,7 @@ function RoleRow({
 
   return (
     <TreeRow
+      depth={1}
       icon={<Icon className='size-4 text-muted-foreground' />}
       title={ACCOUNT_ROLE_LABELS[role] ?? row.role}
       secondaryFill
@@ -215,13 +287,28 @@ function RoleRow({
  * is the repair `resolveRoles` would otherwise refuse a close over.
  */
 function AssignmentSecondary({ row }: { row: RoleAssignmentRow }) {
+  // 🛑 EVERY state's consequence lives in its badge's tooltip, never beside it.
+  // The badge already says the state and its colour already says the severity;
+  // what a badge cannot carry is WHY, which is what a tooltip is for. Spelling
+  // the consequence out on each row turned the sentences that matter into
+  // wallpaper - on a fresh org most of this list said "every preview refuses
+  // until this is set", one row after another.
+  //
+  // ⚠️ The `p-[1px]` wrapper is load-bearing, not spacing. `Badge` draws its
+  // edge as `ring-1 ring-current/35`, and a ring renders OUTSIDE the box; this
+  // secondary slot is `overflow-hidden` because it truncates, so a badge flush
+  // against the slot loses the ring on whichever side it touches. One pixel
+  // gives the ring somewhere to land.
   if (row.state === 'unused') {
     return (
-      <span className='flex items-center gap-1.5 text-muted-foreground text-xs'>
-        <Badge variant='outline' size='xs'>
-          Unused
-        </Badge>
-        Nothing posts to this role
+      <span className='flex items-center gap-1.5 text-xs'>
+        <Tooltip content='Nothing posts to this role'>
+          <div className='p-[1px]'>
+            <Badge variant='outline' size='xs'>
+              Unused
+            </Badge>
+          </div>
+        </Tooltip>
       </span>
     )
   }
@@ -229,10 +316,13 @@ function AssignmentSecondary({ row }: { row: RoleAssignmentRow }) {
   if (row.state === 'unmapped') {
     return (
       <span className='flex items-center gap-1.5 text-xs'>
-        <Badge variant='destructive' size='xs'>
-          Not mapped
-        </Badge>
-        <span className='text-muted-foreground'>Every preview refuses until this is set</span>
+        <Tooltip content='Every preview refuses until this is set'>
+          <div className='p-[1px]'>
+            <Badge variant='destructive' size='xs'>
+              Not mapped
+            </Badge>
+          </div>
+        </Tooltip>
       </span>
     )
   }
@@ -240,12 +330,13 @@ function AssignmentSecondary({ row }: { row: RoleAssignmentRow }) {
   if (!row.account) {
     return (
       <span className='flex items-center gap-1.5 text-xs'>
-        <Badge variant='destructive' size='xs'>
-          Account missing
-        </Badge>
-        <span className='text-muted-foreground'>
-          The account this role names is archived or gone. Pick another.
-        </span>
+        <Tooltip content='The account this role names is archived or gone. Pick another.'>
+          <div className='p-[1px]'>
+            <Badge variant='destructive' size='xs'>
+              Account missing
+            </Badge>
+          </div>
+        </Tooltip>
       </span>
     )
   }

--- a/apps/web/src/components/list-selection/store.ts
+++ b/apps/web/src/components/list-selection/store.ts
@@ -31,7 +31,16 @@ export interface ListSelectionState {
   pendingLabel: string
 
   setBulkMode: (on: boolean) => void
-  setItemIds: (ids: string[]) => void
+  /**
+   * Tell the store which items are on screen, in display order - what shift-range
+   * and Cmd+A read.
+   *
+   * By default this also PRUNES the selection to what it was handed. Pass
+   * `pruneSelection: false` on a list whose visible set narrows for reasons that
+   * are not "the row is gone" - a search box, a filter toggle - or picking three
+   * rows, searching again and picking two more silently drops the first three.
+   */
+  setItemIds: (ids: string[], options?: { pruneSelection?: boolean }) => void
   /** Toggle one item. Pass `{ shiftKey }` to select the range from the anchor. */
   toggle: (id: string, opts?: { shiftKey?: boolean }) => void
   /** Select every visible item (Cmd/Ctrl+A). */
@@ -65,7 +74,7 @@ function createListSelectionStore() {
           : { bulkMode: false, sticky: false, selectedIds: [], anchorId: null }
       ),
 
-    setItemIds: (ids) => {
+    setItemIds: (ids, options) => {
       // Empty list (e.g. loading) → don't prune selection. Otherwise drop any
       // selected/pending IDs no longer visible (filtered out, or removed by a
       // completed delete), so bulk state only tracks what's on screen.
@@ -77,7 +86,18 @@ function createListSelectionStore() {
       const { selectedIds, pendingIds } = get()
       set({
         itemIds: ids,
-        selectedIds: selectedIds.filter((id) => allow.has(id)),
+        // 🛑 Two different reasons an id leaves `ids`, and only one of them
+        // justifies forgetting it was selected: the row is GONE (a completed
+        // delete), or the row is merely HIDDEN (a search, a filter toggle). A
+        // list that can hide rows opts out, because pruning there destroys the
+        // pick-a-few-per-search flow the selection exists for.
+        selectedIds:
+          options?.pruneSelection === false
+            ? selectedIds
+            : selectedIds.filter((id) => allow.has(id)),
+        // Pending is always pruned. It marks an operation in flight on a row on
+        // screen; a hidden row has no overlay to keep, and the runner clears its
+        // own marker on settle either way.
         pendingIds: pendingIds.filter((id) => allow.has(id)),
       })
     },

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -1,7 +1,7 @@
 // apps/web/src/server/api/routers/ledger.ts
 
 import { getCachedEntityDefId, getCachedInstalledApps, onCacheEvent } from '@auxx/lib/cache'
-import { UnprocessableEntityError } from '@auxx/lib/errors'
+import { BadRequestError, UnprocessableEntityError } from '@auxx/lib/errors'
 import { getPaymentAccount } from '@auxx/lib/money'
 import { PermissionKey } from '@auxx/lib/permissions'
 import {
@@ -12,6 +12,8 @@ import {
   confirmSuggestedIdentities,
   createChartAccount,
   createJournalEntry,
+  DEFAULT_CHART_OF_ACCOUNTS,
+  type DefaultChartAccount,
   discardJournalEntry,
   findDuplicateBankMovements,
   GL_ACCOUNT_SUBTYPES,
@@ -37,6 +39,7 @@ import {
   previewMonthEnd,
   removeChartAccount,
   resolvePeriodLock,
+  restoreChartAccount,
   retryExport,
   reverseEntry,
   reverseJournalEntry,
@@ -46,7 +49,7 @@ import {
   updateJournalEntry,
   verifyBooksBalance,
 } from '@auxx/lib/postings'
-import { seedChartPacks, seedDefaultPaymentGateways } from '@auxx/lib/seed'
+import { seedChartAccounts, seedChartPacks, seedDefaultPaymentGateways } from '@auxx/lib/seed'
 import { updateOrganizationSetting } from '@auxx/lib/settings'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
@@ -544,11 +547,18 @@ export const ledgerRouter = createTRPCRouter({
     }),
 
   /** The organization's chart of accounts - every non-archived `gl_account`. */
-  chartAccounts: permissionProcedure(PermissionKey.ledgerView).query(async ({ ctx }) => {
-    const result = await listChartAccounts(ctx.db, ctx.session.organizationId)
-    if (result.isErr()) throw result.error
-    return result.value
-  }),
+  chartAccounts: permissionProcedure(PermissionKey.ledgerView)
+    .input(z.object({ includeArchived: z.boolean().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      // 🛑 Archived rows are opt-IN, and only the settings list opts in. Every
+      // other caller of this query feeds a picker or a preview, where a removed
+      // account is an account money must not land in.
+      const result = await listChartAccounts(ctx.db, ctx.session.organizationId, {
+        includeArchived: input?.includeArchived,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
 
   /**
    * How many posted lines landed on each account, keyed on `glAccountId` (task 15).
@@ -705,6 +715,60 @@ export const ledgerRouter = createTRPCRouter({
     }),
 
   /**
+   * Adopt named accounts from the catalogue - the Chart tab's From catalogue
+   * picker (brief 16 §3.2), which selects ACCOUNTS where `provisionChart`
+   * selects packs.
+   *
+   * 🛑 A pack is not a fine enough unit for this door. "Add Deferred Revenue"
+   * is a reasonable thing to want, and `provisionChart(['prepayments'])` would
+   * land Customer Deposits alongside it - an account nobody asked for, on a
+   * screen whose whole job is showing what the chart contains.
+   *
+   * 🛑 Codes are validated against the catalogue and an unknown one is
+   * REFUSED, naming itself. The picker only ever sends codes it rendered, so an
+   * unknown code means the client and this deploy disagree about what the
+   * catalogue is; creating an account from a code with no catalogue row behind
+   * it would invent a name, a type and a role out of nothing.
+   *
+   * Same `ledgerControl` rung as `provisionChart`, for the same reason: an
+   * account carrying a role decides where real money lands. And safe to press
+   * twice for the same reason - `seedChartAccounts` keeps all four rules.
+   */
+  adoptChartAccounts: permissionProcedure(PermissionKey.ledgerControl)
+    .input(z.object({ codes: z.array(z.string().min(1)).min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+
+      const glAccountDefId = await getCachedEntityDefId(organizationId, 'gl_account')
+      if (!glAccountDefId) {
+        throw new UnprocessableEntityError(
+          'This organization has no gl_account definition, so there is nothing to seed a chart into. Run the entity migrations.',
+          { organizationId }
+        )
+      }
+
+      const byCode = new Map(DEFAULT_CHART_OF_ACCOUNTS.map((account) => [account.code, account]))
+      const unknown = input.codes.filter((code) => !byCode.has(code))
+      if (unknown.length > 0) {
+        throw new BadRequestError(
+          `${unknown.join(', ')} ${unknown.length === 1 ? 'is not an account' : 'are not accounts'} in the catalogue.`,
+          { organizationId, unknown }
+        )
+      }
+
+      // De-duplicated: a code sent twice would be filtered to one `missing` row
+      // anyway, but `skipped` is reported to the reader and double-counting it
+      // would say a code was already there when it was merely named twice.
+      const accounts = [...new Set(input.codes)].map(
+        (code) => byCode.get(code) as DefaultChartAccount
+      )
+
+      return seedChartAccounts(ctx.db, organizationId, glAccountDefId, accounts, {
+        source: 'catalogue',
+      })
+    }),
+
+  /**
    * Import the connected provider's chart of accounts as the org's own
    * (brief 16 §2). Creates only what the org lacks, sets each new account's
    * identity, assigns the unambiguous roles as `suggested`, and adds the
@@ -831,6 +895,23 @@ export const ledgerRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
       const result = await removeChartAccount(ctx.db, {
+        organizationId,
+        accountId: input.id,
+        actorUserId: userId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Put a removed account back. Same `ledgerControl` rung as the removal - a
+   * restored account becomes postable again the moment a role names it.
+   */
+  chartAccountRestore: permissionProcedure(PermissionKey.ledgerControl)
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const result = await restoreChartAccount(ctx.db, {
         organizationId,
         accountId: input.id,
         actorUserId: userId,

--- a/packages/lib/src/postings/chart-write.ts
+++ b/packages/lib/src/postings/chart-write.ts
@@ -333,6 +333,44 @@ export async function removeChartAccount(
   }
 }
 
+/**
+ * Put a removed account back into the chart.
+ *
+ * The counterpart to {@link removeChartAccount}, and the reason that one
+ * archives rather than deletes: the row, its code, its provider identity and its
+ * posted history are all still there, so coming back is a flag flip rather than
+ * a re-creation.
+ *
+ * 🛑 No role is reassigned. `removeChartAccount` refuses while a live role still
+ * points here, so a restored account arrives role-less by construction, and
+ * quietly re-pointing a role at it would decide where money lands on somebody's
+ * behalf.
+ *
+ * ⚠️ The code uniqueness gate excludes archived rows, so an org that created a
+ * NEW `1310` after removing the old one now holds two - and this restore is what
+ * would surface that. It is allowed on purpose: refusing here would leave the
+ * account unreachable with no way to rename either row. The chart list shows
+ * both, and renaming one is a click.
+ */
+export async function restoreChartAccount(
+  db: Database,
+  options: RemoveChartAccountOptions
+): Promise<Result<{ id: string }, Error>> {
+  const { organizationId, accountId, actorUserId } = options
+
+  try {
+    const { defId } = await loadChartTarget(organizationId)
+    const handler = crudHandler(db, organizationId, actorUserId)
+    await handler.restore(toRecordId(defId, accountId))
+
+    return ok({ id: accountId })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to restore a chart account', { error, organizationId, accountId })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Internals
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -160,6 +160,7 @@ export {
   createChartAccount,
   type RemoveChartAccountOptions,
   removeChartAccount,
+  restoreChartAccount,
   type UpdateChartAccountOptions,
   updateChartAccount,
 } from './chart-write'

--- a/packages/lib/src/postings/role-map.ts
+++ b/packages/lib/src/postings/role-map.ts
@@ -202,9 +202,23 @@ export async function listRoleMap(
  * Ordered by code then name (task 15 §5's 15.2 default): a coded account
  * before an uncoded one, then alphabetically within each.
  */
+/** Options for {@link listChartAccounts}. */
+export interface ListChartAccountsOptions {
+  /**
+   * Include accounts that have been removed (archived). Default false.
+   *
+   * 🛑 The settings list is the ONLY caller that may pass true. An archived
+   * account is removed as far as posting is concerned, and handing one to the
+   * resolver, the role picker or a preview would put money into an account
+   * somebody deliberately took out of the chart.
+   */
+  includeArchived?: boolean
+}
+
 export async function listChartAccounts(
   db: Database,
-  organizationId: string
+  organizationId: string,
+  options: ListChartAccountsOptions = {}
 ): Promise<Result<ChartAccountRow[], Error>> {
   try {
     const fields = await loadChartAccountFields(organizationId, NOT_PROVISIONED)
@@ -220,14 +234,18 @@ export async function listChartAccounts(
       )
     }
 
+    // 🛑 The archived filter is in the QUERY and stays there by default. Every
+    // reader but the settings list depends on it - `resolveRoles` picking a
+    // removed account would post real money into it - so `includeArchived` widens
+    // this one call rather than the readers filtering afterwards.
     const instances = await db
-      .select({ id: schema.EntityInstance.id })
+      .select({ id: schema.EntityInstance.id, archivedAt: schema.EntityInstance.archivedAt })
       .from(schema.EntityInstance)
       .where(
         and(
           eq(schema.EntityInstance.organizationId, organizationId),
           eq(schema.EntityInstance.entityDefinitionId, glAccountDefId),
-          isNull(schema.EntityInstance.archivedAt)
+          ...(options.includeArchived ? [] : [isNull(schema.EntityInstance.archivedAt)])
         )
       )
 
@@ -240,6 +258,16 @@ export async function listChartAccounts(
         fields
       )
     )
+
+    // `archivedAt` lives on the instance, not among the account's attributes, so
+    // the decoder cannot know it. Stamped here, and only when it can be true.
+    if (options.includeArchived) {
+      for (const row of instances) {
+        if (!row.archivedAt) continue
+        const account = accounts.get(row.id)
+        if (account) account.isArchived = true
+      }
+    }
 
     return ok([...accounts.values()].sort(compareAccountsByCodeThenName))
   } catch (error) {

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -747,6 +747,19 @@ export interface ChartAccountRow {
    */
   subtype: GlAccountSubtypeValue | null
   isActive: boolean
+  /**
+   * The account has been removed from the chart (archived - `removeChartAccount`
+   * never deletes). **Absent means not archived**, the same reading `isActive`
+   * gives an absent value, and the same reason: nearly every row is neither.
+   *
+   * 🛑 Only ever set when the caller ASKED for archived rows. Every reader but
+   * the settings list excludes them IN THE QUERY, which is what makes archiving
+   * removal as far as the resolver, the role picker and the close are concerned
+   * (`removeChartAccount`'s reason 1). This field exists so the one screen that
+   * may show them can say which is which - never so a reader can start filtering
+   * archived rows out in memory.
+   */
+  isArchived?: boolean
 }
 
 /**

--- a/packages/lib/src/seed/gl-account-chart.ts
+++ b/packages/lib/src/seed/gl-account-chart.ts
@@ -80,6 +80,19 @@ import { SystemUserService } from '../users/system-user-service'
 
 const logger = createScopedLogger('seed:gl-account-chart')
 
+/**
+ * What one pass over one org did, for a caller that named ACCOUNTS rather than
+ * packs. {@link ChartSeedResult} is this plus the packs that were walked.
+ */
+export interface ChartAccountSeedResult {
+  /** Accounts inserted by this pass. */
+  created: number
+  /** Codes the org already held, left exactly as they were. */
+  skipped: number
+  /** `GlRoleAssignment` rows inserted by this pass. Zero on a settled org. */
+  rolesAssigned: number
+}
+
 /** What one pass over one org did. */
 export interface ChartSeedResult {
   /** Accounts inserted by this pass. */
@@ -146,8 +159,50 @@ export async function seedChartPacks(
   packs: readonly ChartPackKey[]
 ): Promise<ChartSeedResult> {
   const walked = walkPacks(packs)
-  const empty: ChartSeedResult = { created: 0, skipped: 0, rolesAssigned: 0, packs: walked }
-  if (!glAccountDefId) return empty
+  const accounts: readonly DefaultChartAccount[] = walked.flatMap(
+    (key) => CHART_PACKS[key].accounts
+  )
+  const result = await seedChartAccounts(db, organizationId, glAccountDefId, accounts, {
+    packs: walked,
+  })
+  return { ...result, packs: walked }
+}
+
+/**
+ * Seed a named set of catalogue accounts, and their role assignments, into one
+ * org.
+ *
+ * The writer {@link seedChartPacks} is built on, exposed on its own for the
+ * catalogue picker, which selects ACCOUNTS rather than whole packs - "just give
+ * me Deferred Revenue" is not expressible as a pack, and provisioning the pack
+ * that carries it would land the other one too.
+ *
+ * 🛑 Every rule in this file's header is a property of THIS function, not of
+ * the pack walk above it: idempotent on `code` (rule 1), sequential (rule 2),
+ * never touches an account the org already has (rule 3), never repoints a
+ * mapped role (rule 4). A caller that hands over a subset gets all four
+ * unchanged, which is what makes a per-account picker safe to press twice.
+ *
+ * 🛑 It does NOT expand `requires`. That is a statement about PACKS, and a
+ * caller naming accounts one at a time has already decided what it wants. The
+ * picker resolves a checked pack to its accounts on the client and sends those.
+ *
+ * @param glAccountDefId the org's `gl_account` EntityDefinition, or undefined
+ * when it has none - a no-op rather than an error, the same tolerance every
+ * other step of 108 has for a def that is not there yet
+ * @param accounts the catalogue accounts to land, already resolved by the caller
+ * @param meta extra fields for the one log line this writes, so a pack walk can
+ * still say which packs it was
+ */
+export async function seedChartAccounts(
+  db: Database,
+  organizationId: string,
+  glAccountDefId: string | undefined,
+  accounts: readonly DefaultChartAccount[],
+  meta: Record<string, unknown> = {}
+): Promise<ChartAccountSeedResult> {
+  const empty: ChartAccountSeedResult = { created: 0, skipped: 0, rolesAssigned: 0 }
+  if (!glAccountDefId || accounts.length === 0) return empty
 
   // The `code` field has to exist before its values can be read or written. On
   // the very first pass `ensureCustomFields` has just created it; on an org
@@ -188,9 +243,6 @@ export async function seedChartPacks(
     if (row.code) byCode.set(row.code, row.entityId)
   }
 
-  const accounts: readonly DefaultChartAccount[] = walked.flatMap(
-    (key) => CHART_PACKS[key].accounts
-  )
   const missing = accounts.filter((account) => !byCode.has(account.code))
 
   let created = 0
@@ -227,16 +279,16 @@ export async function seedChartPacks(
   const rolesAssigned = await assignSeededRoles(db, organizationId, byCode, accounts)
 
   if (created > 0 || rolesAssigned > 0) {
-    logger.info('Seeded chart packs', {
+    logger.info('Seeded chart accounts', {
       organizationId,
-      packs: walked,
+      ...meta,
       created,
       skipped: accounts.length - created,
       rolesAssigned,
     })
   }
 
-  return { created, skipped: accounts.length - created, rolesAssigned, packs: walked }
+  return { created, skipped: accounts.length - created, rolesAssigned }
 }
 
 /**

--- a/packages/lib/src/seed/index.ts
+++ b/packages/lib/src/seed/index.ts
@@ -5,8 +5,10 @@ export { EntitySeeder } from './entity-seeder'
 // Entity Seeder (multi-pass implementation)
 export { deletePristineSeededDashboards } from './entity-seeder/create-default-dashboards'
 export {
+  type ChartAccountSeedResult,
   type ChartSeedResult,
   type PaymentGatewaySeedResult,
+  seedChartAccounts,
   seedChartPacks,
   seedDefaultChartOfAccounts,
   seedDefaultPaymentGateways,


### PR DESCRIPTION
Follows #2104 (chart packs) and #2105 (link badges). Everything here is on **Accounting → Settings → Accounts**.

## From catalogue

#2104 shipped chart packs behind one door on the **Roles** tab, at pack granularity only: you take all thirteen `core` accounts or none. "Add Deferred Revenue but not Customer Deposits" was not expressible, and the **Chart** tab — where somebody actually goes looking to add an account — had no catalogue door at all.

`ChartPacksDialog` is now a two-level `DialogNavPages` picker reachable from both tabs: the packs, and one pack's accounts. **Selection is by account**; checking a pack row is shorthand for checking every account under it. The footer counts accounts, and `requires` still cascades — resolved on the client so the count and the write cannot disagree.

Behind it, `seedChartAccounts` is split out of `seedChartPacks`: the same writer with the same four rules (idempotent on `code`, sequential, never touch an existing account, never repoint a mapped role), taking accounts rather than packs. `ledger.adoptChartAccounts` validates every code against the catalogue and refuses an unknown one by name.

## The chart is grouped by statement type

`compareAccountsByCodeThenName`'s own docstring says it is *"applied AFTER the caller has ordered by statement type"*. No caller did. Flat, an imported chart puts a liability between two expenses and sorts every uncoded account into one alphabetical run — which is what an org with QuickBooks account numbers off looks like.

Both lists now group under a `TreeRow` parent per type with rows nested at depth 1 — the same primitive at both levels, so the connector draws the nesting instead of leaving it to padding. The Roles tab loses its `Section` headers for the same reason, and gains a search styled like the Chart tab's.

## Removal is visible and reversible

`removeChartAccount` has always archived rather than deleted, but `listChartAccounts` excluded archived rows unconditionally — so a removed account vanished with no way to see it and no way back.

`listChartAccounts` gains `includeArchived` (default **false**: every other reader depends on the exclusion, and a removed account reaching `resolveRoles` would put real money into it). Rows carry `isArchived`, optional, absent meaning not archived. The list gains **Show archived (N)** with a `Removed` badge and a restore action, and `restoreChartAccount` + `ledger.chartAccountRestore` are the door back.

## Bulk select

`TreeRow`'s `selectable` checkbox on every account row, `ListSelectionProvider` around the chart list, and a bulk bar built on the existing `ActionBar` + `useBulkRunner` (same trio as the connectors and workflows bars, so per-item refusals come back as "3 of 7 failed"). A mixed selection is allowed and each action names the subset it applies to — `Restore 1` beside `Remove 1` — because forbidding mixed selections makes "select all, clean up" impossible.

**`setItemIds` gains `pruneSelection`.** It used to drop any selected id no longer visible, conflating two cases: a row **gone** because a delete finished, and a row merely **hidden** by a search. The chart list opts out, so picking two accounts, searching for a third and picking it no longer leaves one selected. Every other list keeps today's behaviour — the store is shared and this is opt-in.

The row became a component (`ChartAccountListRow`) because it calls `useIsSelected`: a hook inside a `renderRow` callback runs in the parent's hook order, and this list filters.

## One picker, not two

The provider-account field was a `Combobox` rendering flat `CommandItem`s, sitting two rows below a `GlAccountPicker` rendering headed `CommandDetailItem`s — one pane, one act, two treatments. `ProviderAccountPicker` is the sibling: grouped by classification, the provider's number and type as the detail line, and an incompatible account rendered **disabled with the reason** rather than silently dropped. That is `GlAccountPicker`'s documented trap turned to face the provider. `isMappableTo` stays the one authority, shared with the resolver.

An account with no type yet makes nothing selectable, rather than treating "no type" as "anything goes".

## Row actions and layout

- Remove moves onto the row as a hover-revealed `TreeRowButton` — **not** `persistent`, unlike accept-suggestion: remove exists on every row and pinning it would put a hundred delete buttons on screen.
- Add account and From catalogue collapse into one dropdown, which also stops a second button squeezing `InputSearch` the way `bank-accounts-list.tsx` documents.
- The map strip becomes a constant-height `h-7` row holding a `Skeleton` while the provider round trip is in flight. It used to be two sibling blocks that each rendered or didn't, so the chart shifted down under the reader when the round trip landed.
- Role badges on the Roles tab move their consequence into a tooltip: `Not mapped` already says the state, and repeating "every preview refuses until this is set" on every row turned the one sentence that matters into wallpaper.

## Verification

- Web typecheck 0 errors. Lib ratchet 27 of 27 (no new). Biome clean.
- `apps/web` accounting settings tests 29 of 29, list-selection 7 of 7, lib seed + default-chart 52 of 52.
- **Driven in the browser against the dev server throughout**: the catalogue picker at both levels, the grouped lists on both tabs, Show archived against a real archived row, bulk remove and restore over a mixed selection, and selection surviving a search.

## Not covered

- No tests for `adoptChartAccounts`, `restoreChartAccount` or the `pruneSelection` flag. The behaviour was checked by hand.
- `chart-copy.test.ts` from #2104 caught two hard-coded counts I wrote into comments; both are gone, but nothing stops the next one.

https://claude.ai/code/session_017vTsQzHQFhLUPMqx7LABA7
