### PR TITLE
feat(accounting): find the gateway handles on your own orders

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/payment-gateway-add-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateway-add-dialog.tsx
@@ -73,19 +73,37 @@ export function PaymentGatewayAddDialog({
     },
   })
 
-  // 🛑 The option set is DERIVED from the values. `payment_gateway_handles` is an
-  // OPEN, value-keyed TAGS field - the registry declares `options: { options: [] }`
-  // and the write stores the raw string - so a stored handle matches no option row.
-  // Handing the picker a literal `[]` made every handle resolve `unknown`: the
-  // trigger rendered it italic-grey as "not in this field's option set", and it
-  // never appeared in the popover at all, so it could not be unchecked. Nothing is
-  // wrong with what is stored; the input has to be told the values ARE the options.
-  // The `useMemo` is load-bearing too - a fresh `[]` each render re-fired
-  // `MultiSelectPicker`'s options sync and wiped the tag being typed.
-  const handleOptions = useMemo(
-    () => draft.handles.map((handle) => ({ label: handle, value: handle })),
-    [draft.handles]
+  // The handles actually seen on this org's orders. Only the UNCLAIMED ones are
+  // offered: a handle another gateway already holds would be refused by
+  // `assertHandlesAvailable` at write time, so suggesting it is an invitation
+  // to a guaranteed error. Typing it by hand still gets that refusal, verbatim.
+  const observed = api.paymentGateway.observedHandles.useQuery(undefined, { enabled: open })
+  const suggestions = useMemo(
+    () => (observed.data ?? []).filter((row) => !row.claimedBy).map((row) => row.handle),
+    [observed.data]
   )
+
+  // 🛑 The option set is DERIVED from the values, plus the suggestions above.
+  // `payment_gateway_handles` is an OPEN, value-keyed TAGS field - the registry
+  // declares `options: { options: [] }` and the write stores the raw string - so a
+  // stored handle matches no option row. Handing the picker a literal `[]` made
+  // every handle resolve `unknown`: the trigger rendered it italic-grey as "not in
+  // this field's option set", and it never appeared in the popover at all, so it
+  // could not be unchecked. Nothing is wrong with what is stored; the input has to
+  // be told the values ARE the options. The `useMemo` is load-bearing too - a fresh
+  // `[]` each render re-fired `MultiSelectPicker`'s options sync and wiped the tag
+  // being typed.
+  const handleOptions = useMemo(() => {
+    const seen = new Set<string>()
+    const options: { label: string; value: string }[] = []
+    for (const handle of [...suggestions, ...draft.handles]) {
+      const key = handle.trim().toLowerCase()
+      if (!key || seen.has(key)) continue
+      seen.add(key)
+      options.push({ label: handle, value: handle })
+    }
+    return options
+  }, [suggestions, draft.handles])
 
   const canSubmit = draft.name.trim() && draft.handles.length > 0 && draft.clearingAccountId
 
@@ -125,7 +143,13 @@ export function PaymentGatewayAddDialog({
             type={BaseType.STRING}
             showIcon
             isRequired
-            description='Every stored value this rail is seen under.'>
+            description={
+              observed.isPending
+                ? 'Every stored value this rail is seen under.'
+                : suggestions.length > 0
+                  ? 'Every stored value this rail is seen under. The list offers the handles on your orders that no gateway routes yet.'
+                  : 'Every stored value this rail is seen under, exactly as it appears on the order.'
+            }>
             <FieldInputAdapter
               fieldType={FieldType.TAGS}
               fieldOptions={{ options: handleOptions }}

--- a/apps/web/src/components/accounting/ui/settings/payment-gateways-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/payment-gateways-list.tsx
@@ -10,21 +10,23 @@
 // into is the one thing this screen exists to answer, and a state that can
 // only be discovered by selecting each row in turn stays unfinished.
 
-import type { PaymentGatewayRow } from '@auxx/lib/payment-gateways/client'
+import type { ObservedGatewayHandle, PaymentGatewayRow } from '@auxx/lib/payment-gateways/client'
 import { PAYMENT_GATEWAY_SETTLEMENT_SOURCE_LABELS } from '@auxx/lib/payment-gateways/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { ButtonSwitch } from '@auxx/ui/components/button-switch'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { EmptySection } from '@auxx/ui/components/section'
+import { Skeleton } from '@auxx/ui/components/skeleton'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
-import { CreditCard, Plus } from 'lucide-react'
+import { CreditCard, Plus, TriangleAlert } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { AccountLabel } from '~/components/accounting/ui/account-label'
 import { useChartAccounts } from '~/components/accounting/ui/gl-account-picker'
 import { EmptyState } from '~/components/global/empty-state'
+import { api } from '~/trpc/react'
 
 interface PaymentGatewaysListProps {
   gateways: PaymentGatewayRow[]
@@ -49,6 +51,7 @@ export function PaymentGatewaysList({
   closedCount,
 }: PaymentGatewaysListProps) {
   const [search, setSearch] = useState('')
+  const [handlesOpen, setHandlesOpen] = useState(false)
 
   // `clearingGlAccountId` is stored as the `gl_account` id (task 15 §4 shape),
   // so the badge below has to resolve it. One `ledger.chartAccounts` fetch for
@@ -57,6 +60,17 @@ export function PaymentGatewaysList({
   const chartAccountById = useMemo(
     () => new Map(chartAccounts.map((account) => [account.id, account])),
     [chartAccounts]
+  )
+
+  // The handles actually on this org's orders (`listObservedGatewayHandles`).
+  // 🛑 The point of this line is the UNROUTED ones: a handle no record claims
+  // falls back to `clearing_card` inside `resolveFulfillmentDebit` and posts a
+  // balanced entry, so nothing else on this screen - or anywhere downstream -
+  // would ever say it is unrouted.
+  const observed = api.paymentGateway.observedHandles.useQuery()
+  const unrouted = useMemo(
+    () => (observed.data ?? []).filter((row) => !row.claimedBy),
+    [observed.data]
   )
 
   const visible = useMemo(() => {
@@ -76,8 +90,68 @@ export function PaymentGatewaysList({
     </Button>
   )
 
+  const observedCount = observed.data?.length ?? 0
+  const routedCount = observedCount - unrouted.length
+
   return (
     <div className='flex flex-col gap-3 p-3'>
+      {/* The handles census, as a collapsible group - `role-map-list.tsx`'s
+          "{mapped} of {needed} mapped" group, same shape and same reason.
+          🛑 A row renders in EVERY state, including pending and empty. This
+          block resolves on its own query, and letting it disappear or size from
+          its content pushes the whole list down the moment the answer lands. */}
+      {observed.isPending ? (
+        <div className='flex h-8 items-center px-1'>
+          <Skeleton className='h-4 w-56' />
+        </div>
+      ) : observed.isError ? (
+        <div className='flex h-8 items-center px-1'>
+          <span className='truncate text-muted-foreground text-xs'>
+            Could not read the handles on your orders. Everything below is unaffected.
+          </span>
+        </div>
+      ) : (
+        <TreeRow
+          // Nothing to open when every handle is already routed - the count is
+          // the whole answer, and a chevron over an empty list is a dead end.
+          expandable={unrouted.length > 0}
+          isOpen={handlesOpen}
+          onToggleOpen={() => setHandlesOpen((open) => !open)}
+          icon={
+            unrouted.length > 0 ? (
+              <TriangleAlert className='size-4 text-muted-foreground' />
+            ) : (
+              <CreditCard className='size-4 text-muted-foreground' />
+            )
+          }
+          title={<span className='truncate font-medium text-sm'>Gateway handles</span>}
+          secondary={
+            <span className='text-muted-foreground text-xs tabular-nums'>
+              {observedCount === 0
+                ? 'None on your orders yet'
+                : `${routedCount} of ${observedCount} routed`}
+            </span>
+          }>
+          <TreeRowList
+            items={unrouted}
+            getKey={(row: ObservedGatewayHandle) => row.handle}
+            renderRow={(row: ObservedGatewayHandle) => (
+              <TreeRow
+                depth={1}
+                icon={<CreditCard className='size-4 text-muted-foreground' />}
+                title={<span className='truncate font-mono text-sm'>{row.handle}</span>}
+                secondaryFill
+                secondary={
+                  <span className='truncate text-muted-foreground text-xs'>
+                    No gateway routes this, so it clears to the default card account
+                  </span>
+                }
+              />
+            )}
+          />
+        </TreeRow>
+      )}
+
       {/* One row, `chart-list.tsx`'s shape: a SINGLE button beside the search
           still leaves the box room, which is exactly what stopped
           `bank-accounts-list.tsx` from doing the same (it carries two, and two

--- a/apps/web/src/server/api/routers/payment-gateways.ts
+++ b/apps/web/src/server/api/routers/payment-gateways.ts
@@ -17,6 +17,7 @@
 import {
   archivePaymentGateway,
   createPaymentGateway,
+  listObservedGatewayHandles,
   listPaymentGateways,
   PAYMENT_GATEWAY_SETTLEMENT_SOURCES,
   updatePaymentGateway,
@@ -54,6 +55,20 @@ export const paymentGatewaysRouter = createTRPCRouter({
       if (result.isErr()) throw result.error
       return result.value
     }),
+
+  /**
+   * Every gateway handle seen on the org's own orders, with whether a record
+   * already routes it.
+   *
+   * The lookup behind the add dialog's suggestions and the list page's
+   * "routed" line. `ledgerView` like {@link list}: it reads which rails the
+   * store has run, which is bookkeeping context, not a control.
+   */
+  observedHandles: permissionProcedure(PermissionKey.ledgerView).query(async ({ ctx }) => {
+    const result = await listObservedGatewayHandles(ctx.db, ctx.session.organizationId)
+    if (result.isErr()) throw result.error
+    return result.value
+  }),
 
   /**
    * Add a gateway by hand.

--- a/packages/lib/scripts/check-observed-gateway-handles.ts
+++ b/packages/lib/scripts/check-observed-gateway-handles.ts
@@ -1,0 +1,62 @@
+// packages/lib/scripts/check-observed-gateway-handles.ts
+//
+// Diagnostic for `listObservedGatewayHandles`: runs the census straight from
+// SOURCE for every org that has any `order_payment_gateways` value, so a
+// failure here is the read's, not the dev server's stale lib bundle.
+//
+//   npx dotenv -- node --conditions source --import tsx/esm \
+//     packages/lib/scripts/check-observed-gateway-handles.ts
+
+import { database, schema } from '@auxx/database'
+import { eq, sql } from 'drizzle-orm'
+import { listObservedGatewayHandles } from '../src/payment-gateways/reads'
+
+async function main(): Promise<void> {
+  const db = database
+
+  const fields = await db
+    .select({
+      id: schema.CustomField.id,
+      organizationId: schema.CustomField.organizationId,
+      options: schema.CustomField.options,
+    })
+    .from(schema.CustomField)
+    .where(eq(schema.CustomField.systemAttribute, 'order_payment_gateways'))
+
+  console.log(`order_payment_gateways fields: ${fields.length}`)
+
+  for (const field of fields) {
+    const [{ count } = { count: 0 }] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(schema.FieldValue)
+      .where(eq(schema.FieldValue.fieldId, field.id))
+
+    const raw = await db
+      .selectDistinct({
+        optionId: schema.FieldValue.optionId,
+        valueText: schema.FieldValue.valueText,
+      })
+      .from(schema.FieldValue)
+      .where(eq(schema.FieldValue.fieldId, field.id))
+
+    console.log(`\n─── org ${field.organizationId}`)
+    console.log(`  field ${field.id}  values=${count}  distinct=${raw.length}`)
+    console.log(`  options declared: ${JSON.stringify(field.options)?.slice(0, 200)}`)
+    console.log(`  distinct raw: ${JSON.stringify(raw.slice(0, 20))}`)
+
+    const result = await listObservedGatewayHandles(db, field.organizationId)
+    if (result.isErr()) {
+      console.log(`  ❌ census FAILED: ${result.error.message}`)
+      console.log(result.error.stack)
+      continue
+    }
+    console.log(`  ✅ census: ${JSON.stringify(result.value)}`)
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/packages/lib/src/money/payments/__tests__/post-transaction.test.ts
+++ b/packages/lib/src/money/payments/__tests__/post-transaction.test.ts
@@ -85,10 +85,17 @@ function transaction(overrides: Partial<PaymentTransactionEntity> = {}): Payment
 function makeDb(opts: {
   instance?: { id: string; archivedAt: Date | null } | null
   fieldValue?: { valueText: string | null } | null
+  /**
+   * What the sole-mapped-bank-account join answers when the setting is unset.
+   * `resolveSoleMappedBankAccount` awaits `.where()` directly and takes no
+   * `.limit()` - counting the rows exactly is the whole point of it.
+   */
+  mapped?: { bankAccountId: string; glAccountId: string | null }[]
 }): Database {
   return {
     select: () => ({
       from: (table: unknown) => ({
+        innerJoin: () => ({ where: () => Promise.resolve(opts.mapped ?? []) }),
         where: () => ({
           limit: () => {
             if (table === schema.EntityInstance) {
@@ -177,8 +184,75 @@ describe('accounting enabled, the cash route', () => {
     h.resolvePaymentRoute.mockReturnValue('cash')
   })
 
-  it('refuses with account_unmapped when no bank account is configured, and never builds', async () => {
+  // ───────────────────────────────────────────────────────────────────────────
+  // The setting is UNSET. Nothing seeds `accounting.cashBankAccountId` and
+  // `DEFAULT_PAYMENT_ROUTES.bank` is `cash`, so this is the path every org that
+  // never opened the settings page takes - see the file header.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it("falls back to the org's SOLE mapped bank account when the setting is unset", async () => {
     h.getOrgCache.mockResolvedValue({})
+    h.getCachedEntityDefId.mockResolvedValue('def_bank_account')
+    h.bySystemAttributes.mockResolvedValue({ bank_account_gl_account: { id: 'fld_gl' } })
+
+    const db = makeDb({ mapped: [{ bankAccountId: 'ba_1', glAccountId: 'gl_1000' }] })
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(h.buildPaymentEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ bankAccountGlAccountId: 'gl_1000' })
+    )
+    expect(result.status).toBe('posted')
+  })
+
+  it('refuses as ambiguous when the setting is unset and TWO bank accounts are mapped', async () => {
+    h.getOrgCache.mockResolvedValue({})
+    h.getCachedEntityDefId.mockResolvedValue('def_bank_account')
+    h.bySystemAttributes.mockResolvedValue({ bank_account_gl_account: { id: 'fld_gl' } })
+
+    const db = makeDb({
+      mapped: [
+        { bankAccountId: 'ba_1', glAccountId: 'gl_1000' },
+        { bankAccountId: 'ba_2', glAccountId: 'gl_1001' },
+      ],
+    })
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(result).toMatchObject({ status: 'account_unmapped', failureClass: 'configuration' })
+    expect(result.error).toMatch(/no unambiguous answer/)
+    // 🛑 Two mapped accounts is the case the fallback must NOT guess at.
+    expect(h.buildPaymentEntry).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the setting is unset and NO bank account is mapped, and never builds', async () => {
+    h.getOrgCache.mockResolvedValue({})
+    h.getCachedEntityDefId.mockResolvedValue('def_bank_account')
+    h.bySystemAttributes.mockResolvedValue({ bank_account_gl_account: { id: 'fld_gl' } })
+
+    const db = makeDb({ mapped: [] })
+    const result = await postPaymentTransaction(db, {
+      organizationId: ORG,
+      transaction: transaction(),
+      allocatedMinor: 5_000,
+    })
+
+    expect(result).toMatchObject({ status: 'account_unmapped', failureClass: 'configuration' })
+    expect(result.error).toMatch(/none is mapped to a chart account/)
+    expect(h.buildPaymentEntry).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the org has no bank_account definition at all', async () => {
+    h.getOrgCache.mockResolvedValue({})
+    h.getCachedEntityDefId.mockResolvedValue(null)
 
     const result = await postPaymentTransaction(NO_DB, {
       organizationId: ORG,
@@ -187,11 +261,7 @@ describe('accounting enabled, the cash route', () => {
     })
 
     expect(result).toMatchObject({ status: 'account_unmapped', failureClass: 'configuration' })
-    expect(result.error).toMatch(/no bank account is configured/)
     expect(h.buildPaymentEntry).not.toHaveBeenCalled()
-    expect(h.postEntry).not.toHaveBeenCalled()
-    // The short-circuit is before any cache or db read for the bank account.
-    expect(h.getCachedEntityDefId).not.toHaveBeenCalled()
   })
 
   it('refuses with account_unmapped when the configured bank account has no gl_account mapping', async () => {

--- a/packages/lib/src/money/payments/post-transaction.ts
+++ b/packages/lib/src/money/payments/post-transaction.ts
@@ -34,15 +34,20 @@
  * payment banks into; {@link resolveCashBankAccountGlAccountId} reads its
  * `bank_account_gl_account` id directly off the entity layer, mirroring
  * `money/bank-deposits/reads.ts`'s `readDepositBankAccount` rather than
- * importing `banking/` - the same anti-cycle reason that file gives. Unset or
- * unmapped refuses with `account_unmapped` before the entry is even built,
- * the same configuration-class refusal `createBankDeposit` gives for a
- * deposit's own unmapped bank account.
+ * importing `banking/` - the same anti-cycle reason that file gives.
+ *
+ * Nothing seeds that setting, and `DEFAULT_PAYMENT_ROUTES.bank` is `cash`, so
+ * an org that never opened the settings page falls back to its SOLE mapped
+ * bank account - see {@link resolveSoleMappedBankAccount} for why one is an
+ * answer and two is not. Zero, two-or-more, and a configured-but-unmapped
+ * account each refuse with `account_unmapped` and their own sentence before
+ * the entry is even built, the same configuration-class refusal
+ * `createBankDeposit` gives for a deposit's own unmapped bank account.
  */
 
 import { type Database, type PaymentTransactionEntity, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull, ne } from 'drizzle-orm'
 import { getCachedEntityDefId, getOrgCache } from '../../cache'
 import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
@@ -103,9 +108,49 @@ const ACCEPTED_POST_STATUSES = new Set<string>([
  */
 const POSTABLE_STATUSES = new Set(['succeeded', 'disputed'])
 
+/** Why a `cash`-routed payment could not name a bank account to bank into. */
+type CashBankAccountRefusal = 'configured_unmapped' | 'unset_none_mapped' | 'unset_ambiguous'
+
+/** What {@link resolveCashBankAccountGlAccountId} answers. */
+interface CashBankAccountResolution {
+  glAccountId: string | null
+  /** The `bank_account` the answer came from, when there is one. */
+  bankAccountId: string | null
+  /** Why {@link glAccountId} is `null`; `null` when it is not. */
+  refusal: CashBankAccountRefusal | null
+}
+
+/** The refusal sentence for each {@link CashBankAccountRefusal}, minus its subject. */
+const CASH_REFUSAL_MESSAGE: Record<CashBankAccountRefusal, string> = {
+  configured_unmapped:
+    'the bank account it is configured to bank into is not mapped to a chart account. Map it ' +
+    'under Accounting > Settings > Bank accounts.',
+  unset_none_mapped:
+    'no bank account is configured for cash payments and none is mapped to a chart account. ' +
+    'Map one under Accounting > Settings > Bank accounts.',
+  unset_ambiguous:
+    'no bank account is configured for cash payments and more than one is mapped to a chart ' +
+    'account, so there is no unambiguous answer. Name one under Accounting > Settings > General.',
+}
+
 /**
- * The `gl_account` id `accounting.cashBankAccountId` resolves to, or `null`
- * when it is unset or the account it names has none.
+ * The `gl_account` id a `cash`-routed payment banks into.
+ *
+ * `accounting.cashBankAccountId` names it when a person has set it. When they
+ * have NOT, the org's sole mapped `bank_account` is the answer.
+ *
+ * 🛑 **The fallback is not a guess, and it is load-bearing.** The setting has
+ * `defaultValue: null` (`settings/catalog.ts`) and nothing seeds it - not chart
+ * provisioning, not the setup wizard, not entity migration 145, which retired
+ * the `cash` role outright. But `DEFAULT_PAYMENT_ROUTES.bank` is `cash`
+ * (`money/bank-deposits/route.ts`), so ACH and wire route here for every org
+ * that has never opened the settings page. Without the fallback every such org
+ * - including every org that enables accounting from here on - refuses its ACH
+ * receipts with `account_unmapped` and no on-screen signal until somebody
+ * happens to find the picker. Falling back only when EXACTLY ONE bank account
+ * carries a chart mapping keeps that from being a guess: one mapped account is
+ * the only account the money could be banked into. Two is ambiguous and still
+ * refuses, with its own sentence.
  *
  * Read through the entity layer directly rather than by importing `banking/` -
  * `money/bank-deposits/reads.ts` gives the same reason for its own
@@ -117,19 +162,28 @@ async function resolveCashBankAccountGlAccountId(
   db: Database,
   organizationId: string,
   settings: Record<string, unknown>
-): Promise<{ glAccountId: string | null; bankAccountId: string | null }> {
+): Promise<CashBankAccountResolution> {
   const raw = settings['accounting.cashBankAccountId']
-  const bankAccountId = typeof raw === 'string' ? raw.trim() : ''
-  if (!bankAccountId) return { glAccountId: null, bankAccountId: null }
+  const configuredId = typeof raw === 'string' ? raw.trim() : ''
+
+  const unresolvable = (): CashBankAccountResolution => ({
+    glAccountId: null,
+    bankAccountId: configuredId || null,
+    refusal: configuredId ? 'configured_unmapped' : 'unset_none_mapped',
+  })
 
   const bankAccountDefId = await getCachedEntityDefId(organizationId, 'bank_account')
-  if (!bankAccountDefId) return { glAccountId: null, bankAccountId }
+  if (!bankAccountDefId) return unresolvable()
 
   const glAccountField = await getOrgCache()
     .from(organizationId, 'customFields')
     .bySystemAttributes(['bank_account_gl_account'])
   const fieldId = glAccountField.bank_account_gl_account?.id
-  if (!fieldId) return { glAccountId: null, bankAccountId }
+  if (!fieldId) return unresolvable()
+
+  if (!configuredId) {
+    return await resolveSoleMappedBankAccount(db, organizationId, bankAccountDefId, fieldId)
+  }
 
   const [instance] = await db
     .select({ id: schema.EntityInstance.id, archivedAt: schema.EntityInstance.archivedAt })
@@ -138,14 +192,16 @@ async function resolveCashBankAccountGlAccountId(
       and(
         eq(schema.EntityInstance.organizationId, organizationId),
         eq(schema.EntityInstance.entityDefinitionId, bankAccountDefId),
-        eq(schema.EntityInstance.id, bankAccountId)
+        eq(schema.EntityInstance.id, configuredId)
       )
     )
     .limit(1)
   // Archived is treated as unmapped: nothing can be banked into an archived
   // account (`money/bank-deposits/writes.ts`'s `requireDepositTarget` refuses
   // the same way).
-  if (!instance || instance.archivedAt) return { glAccountId: null, bankAccountId }
+  if (!instance || instance.archivedAt) {
+    return { glAccountId: null, bankAccountId: configuredId, refusal: 'configured_unmapped' }
+  }
 
   const [value] = await db
     .select({ valueText: schema.FieldValue.valueText })
@@ -159,7 +215,62 @@ async function resolveCashBankAccountGlAccountId(
     )
     .limit(1)
 
-  return { glAccountId: value?.valueText?.trim() || null, bankAccountId }
+  const glAccountId = value?.valueText?.trim() || null
+  return {
+    glAccountId,
+    bankAccountId: configuredId,
+    refusal: glAccountId ? null : 'configured_unmapped',
+  }
+}
+
+/**
+ * The org's sole non-archived `bank_account` carrying a chart mapping, when
+ * there is exactly one. Zero and two-or-more each refuse with their own reason.
+ *
+ * Deliberately unlimited: an org has a handful of bank accounts, and counting
+ * them exactly is what separates "the only possible answer" from "a guess".
+ */
+async function resolveSoleMappedBankAccount(
+  db: Database,
+  organizationId: string,
+  bankAccountDefId: string,
+  fieldId: string
+): Promise<CashBankAccountResolution> {
+  const rows = await db
+    .select({
+      bankAccountId: schema.EntityInstance.id,
+      glAccountId: schema.FieldValue.valueText,
+    })
+    .from(schema.EntityInstance)
+    .innerJoin(
+      schema.FieldValue,
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, schema.EntityInstance.id),
+        eq(schema.FieldValue.fieldId, fieldId)
+      )
+    )
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, bankAccountDefId),
+        isNull(schema.EntityInstance.archivedAt),
+        ne(schema.FieldValue.valueText, '')
+      )
+    )
+
+  const mapped = rows.flatMap((row) => {
+    const glAccountId = row.glAccountId?.trim()
+    return glAccountId ? [{ bankAccountId: row.bankAccountId, glAccountId }] : []
+  })
+  if (mapped.length > 1) {
+    return { glAccountId: null, bankAccountId: null, refusal: 'unset_ambiguous' }
+  }
+  const [only] = mapped
+  if (!only) {
+    return { glAccountId: null, bankAccountId: null, refusal: 'unset_none_mapped' }
+  }
+  return { glAccountId: only.glAccountId, bankAccountId: only.bankAccountId, refusal: null }
 }
 
 /**
@@ -221,12 +332,8 @@ export async function postPaymentTransaction(
     if (route === 'cash') {
       const resolved = await resolveCashBankAccountGlAccountId(db, organizationId, settings)
       if (!resolved.glAccountId) {
-        const message = resolved.bankAccountId
-          ? `Payment ${transaction.id} routes to cash, but the bank account it is configured to ` +
-            'bank into is not mapped to a chart account. Map it under Accounting > Settings > ' +
-            'Bank accounts.'
-          : `Payment ${transaction.id} routes to cash, but no bank account is configured for ` +
-            'cash payments. Set one under Accounting > Settings > General.'
+        const reason = CASH_REFUSAL_MESSAGE[resolved.refusal ?? 'unset_none_mapped']
+        const message = `Payment ${transaction.id} routes to cash, but ${reason}`
         logger.warn('Payment refused: the cash route has no mapped bank account', {
           organizationId,
           transactionId: transaction.id,

--- a/packages/lib/src/payment-gateways/__tests__/reads.test.ts
+++ b/packages/lib/src/payment-gateways/__tests__/reads.test.ts
@@ -13,6 +13,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const state = vi.hoisted(() => ({
   /** The rows each successive `db.select()` resolves to, in call order. */
   script: [] as unknown[][],
+  /**
+   * `options` hung on `order_payment_gateways`, for the census test that
+   * exercises the connector-provisioned option path rather than free text.
+   */
+  gatewayFieldOptions: null as unknown,
 }))
 
 vi.mock('../../cache', () => ({
@@ -22,7 +27,14 @@ vi.mock('../../cache', () => ({
     from: () => ({
       // Every attribute resolves to a field whose id IS the attribute name.
       bySystemAttributes: async (attrs: string[]) =>
-        Object.fromEntries(attrs.map((attr) => [attr, { id: attr }])),
+        Object.fromEntries(
+          attrs.map((attr) => [
+            attr,
+            attr === 'order_payment_gateways'
+              ? { id: attr, options: state.gatewayFieldOptions }
+              : { id: attr },
+          ])
+        ),
     }),
   }),
 }))
@@ -38,16 +50,22 @@ function stage(rows: unknown[]): unknown {
 
 function fakeDb() {
   let call = 0
-  return { select: () => stage(state.script[call++] ?? []) } as never
+  // `selectDistinct` shares the script counter: `listObservedGatewayHandles`
+  // opens with one, then `listPaymentGateways` takes the next two.
+  const next = () => stage(state.script[call++] ?? [])
+  return { select: next, selectDistinct: next } as never
 }
 
 const ORG = 'org_1'
 
 beforeEach(() => {
   state.script.length = 0
+  state.gatewayFieldOptions = null
 })
 
-const { getPaymentGateway, listPaymentGateways } = await import('../reads')
+const { getPaymentGateway, listObservedGatewayHandles, listPaymentGateways } = await import(
+  '../reads'
+)
 
 describe('listPaymentGateways', () => {
   it('groups a multi-value TAGS field (handles) into an array per instance', async () => {
@@ -114,5 +132,101 @@ describe('getPaymentGateway', () => {
     const result = await getPaymentGateway(fakeDb(), ORG, 'gone')
     expect(result.isOk()).toBe(true)
     if (result.isOk()) expect(result.value).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The census behind the add dialog's suggestions and the list page's
+// "routed" line.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('listObservedGatewayHandles', () => {
+  /** Push the two selects `listPaymentGateways` issues for one claiming gateway. */
+  function claimedBy(id: string, handles: string[]) {
+    state.script.push([{ id, createdAt: null, updatedAt: null }])
+    state.script.push([
+      { entityId: id, fieldId: 'payment_gateway_name', valueText: id },
+      { entityId: id, fieldId: 'payment_gateway_clearing_account', valueText: 'acct_1' },
+      ...handles.map((handle) => ({
+        entityId: id,
+        fieldId: 'payment_gateway_handles',
+        optionId: handle,
+      })),
+    ])
+  }
+
+  it('de-duplicates case-insensitively, drops the reserved handles, and marks what is claimed', async () => {
+    state.script.push([
+      { optionId: 'shopify_payments', valueText: null },
+      // Same rail, different spelling - one row out, the first spelling seen.
+      { optionId: 'Shopify_Payments', valueText: null },
+      { optionId: 'authorize_net', valueText: null },
+      // 🛑 Neither of these ever reaches a route: `manual` debits A/R and
+      // `bogus` excludes the shipment, both before any route is consulted.
+      { optionId: 'manual', valueText: null },
+      { optionId: 'bogus', valueText: null },
+    ])
+    claimedBy('pg_shopify', ['shopify_payments'])
+
+    const result = await listObservedGatewayHandles(fakeDb(), ORG)
+    expect(result.isOk()).toBe(true)
+    if (!result.isOk()) return
+    expect(result.value).toEqual([
+      { handle: 'authorize_net', claimedBy: null },
+      { handle: 'shopify_payments', claimedBy: 'pg_shopify' },
+    ])
+  })
+
+  it('resolves an option-keyed value through the field option list, not the raw key', async () => {
+    // The connector-provisioned case: the stored value is an opaque key and the
+    // label is in the field's own option set. Grouping on the key would offer a
+    // handle that matches nothing a person recognises.
+    state.gatewayFieldOptions = {
+      options: [{ id: 'opt_1', value: 'opt_1', label: 'Authorize.Net' }],
+    }
+    state.script.push([{ optionId: 'opt_1', valueText: null }])
+    state.script.push([])
+
+    const result = await listObservedGatewayHandles(fakeDb(), ORG)
+    expect(result.isOk()).toBe(true)
+    if (!result.isOk()) return
+    expect(result.value).toEqual([{ handle: 'Authorize.Net', claimedBy: null }])
+  })
+
+  it('reads valueText when the row carries no optionId', async () => {
+    state.script.push([{ optionId: null, valueText: 'paypal' }])
+    state.script.push([])
+
+    const result = await listObservedGatewayHandles(fakeDb(), ORG)
+    expect(result.isOk()).toBe(true)
+    if (!result.isOk()) return
+    expect(result.value).toEqual([{ handle: 'paypal', claimedBy: null }])
+  })
+
+  it('is empty when no order carries a gateway, without reading the gateways at all', async () => {
+    state.script.push([])
+
+    const result = await listObservedGatewayHandles(fakeDb(), ORG)
+    expect(result.isOk()).toBe(true)
+    if (!result.isOk()) return
+    expect(result.value).toEqual([])
+  })
+
+  it('counts a CLOSED gateway as claiming its handles', async () => {
+    // `toGatewayRoutes` keeps closed rows on purpose - a closed rail still
+    // routes its own history - so its handles are routed, not orphaned.
+    state.script.push([{ optionId: 'authorize_net', valueText: null }])
+    state.script.push([{ id: 'pg_closed', createdAt: null, updatedAt: null }])
+    state.script.push([
+      { entityId: 'pg_closed', fieldId: 'payment_gateway_name', valueText: 'Authorize.Net' },
+      { entityId: 'pg_closed', fieldId: 'payment_gateway_clearing_account', valueText: 'acct_1' },
+      { entityId: 'pg_closed', fieldId: 'payment_gateway_handles', optionId: 'AUTHORIZE_NET' },
+      { entityId: 'pg_closed', fieldId: 'payment_gateway_status', optionId: 'closed' },
+    ])
+
+    const result = await listObservedGatewayHandles(fakeDb(), ORG)
+    expect(result.isOk()).toBe(true)
+    if (!result.isOk()) return
+    expect(result.value).toEqual([{ handle: 'authorize_net', claimedBy: 'pg_closed' }])
   })
 })

--- a/packages/lib/src/payment-gateways/client.ts
+++ b/packages/lib/src/payment-gateways/client.ts
@@ -72,6 +72,39 @@ export function normaliseGatewayHandle(handle: string): string {
 }
 
 /**
+ * The two handles that never belong to a `payment_gateway` record.
+ *
+ * `resolveFulfillmentDebit` (`postings/build-fulfillment-batch-entry.ts`)
+ * answers both from its own fork, before any route is consulted: `manual` is
+ * money that did not come through a rail at all and debits
+ * `accounts_receivable`, and `bogus` is Shopify's test gateway and excludes the
+ * shipment outright. Neither can ever be "claimed", so the census
+ * ({@link listObservedGatewayHandles}) drops them rather than reporting two
+ * permanently unroutable handles at every org forever.
+ *
+ * 🛑 A deliberate mirror of that file's private `MANUAL_GATEWAY` /
+ * `TEST_GATEWAY`, not an import - `build-fulfillment-batch-entry.ts` imports
+ * THIS file for `GatewayRoute`, and an import back would be a cycle. Same call
+ * {@link normaliseGatewayHandle} makes about `normaliseGateways`.
+ */
+export const RESERVED_GATEWAY_HANDLES: readonly string[] = ['manual', 'bogus']
+
+/**
+ * One gateway handle seen on the org's own orders, and whether a
+ * `payment_gateway` record already claims it.
+ *
+ * Deliberately carries NO order count. The question this answers is "is this
+ * handle routed", which is a yes or a no; a count invites reading the list as
+ * a revenue report, and the number would be stale the moment an order syncs.
+ */
+export interface ObservedGatewayHandle {
+  /** As stored on the order, not normalised - what a person should type. */
+  handle: string
+  /** The `payment_gateway` id claiming it, or `null` when nothing routes it. */
+  claimedBy: string | null
+}
+
+/**
  * One `payment_gateway` record, as the settings screen and the fulfillment
  * planner both read it.
  */

--- a/packages/lib/src/payment-gateways/index.ts
+++ b/packages/lib/src/payment-gateways/index.ts
@@ -11,6 +11,7 @@
 
 export type {
   GatewayRoute,
+  ObservedGatewayHandle,
   PaymentGatewayRow,
   PaymentGatewaySettlementSourceValue,
   PaymentGatewayStatusValue,
@@ -21,6 +22,7 @@ export {
   PAYMENT_GATEWAY_SETTLEMENT_SOURCES,
   PAYMENT_GATEWAY_STATUS_LABELS,
   PAYMENT_GATEWAY_STATUSES,
+  RESERVED_GATEWAY_HANDLES,
   resolvePaymentGatewaySettlementSource,
   resolvePaymentGatewayStatus,
   toGatewayRoutes,
@@ -28,6 +30,7 @@ export {
 export type { PaymentGatewayFieldContext } from './reads'
 export {
   getPaymentGateway,
+  listObservedGatewayHandles,
   listPaymentGateways,
   loadPaymentGatewayFieldContext,
   requirePaymentGatewayFieldContext,

--- a/packages/lib/src/payment-gateways/reads.ts
+++ b/packages/lib/src/payment-gateways/reads.ts
@@ -17,9 +17,14 @@ import { and, asc, eq, inArray, isNull } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { getCachedEntityDefId, getOrgCache } from '../cache'
 import { UnprocessableEntityError } from '../errors'
+import type { FieldOptions } from '../field-values/converters'
+import { buildOptionIndex, resolveOptionId } from '../resources/registry/option-helpers'
 import { toRecordId } from '../resources/resource-id'
 import {
+  normaliseGatewayHandle,
+  type ObservedGatewayHandle,
   type PaymentGatewayRow,
+  RESERVED_GATEWAY_HANDLES,
   resolvePaymentGatewaySettlementSource,
   resolvePaymentGatewayStatus,
 } from './client'
@@ -163,6 +168,100 @@ export async function getPaymentGateway(
     },
     'Failed to read payment gateway',
     { organizationId, paymentGatewayId }
+  )
+}
+
+/**
+ * Every gateway handle that actually appears on this org's orders, and whether
+ * a `payment_gateway` record already routes it.
+ *
+ * ## Why this read exists
+ *
+ * `handles` is a free-text field, and a handle that does not match what
+ * Shopify wrote on the order is INVISIBLE: `resolveFulfillmentDebit` finds no
+ * route, falls back to `clearing_card`, and the entry balances. Nothing
+ * downstream can tell a typo from a rail that legitimately has no record yet.
+ * Before this, the only way to learn the real strings was to query
+ * `order_payment_gateways` by hand - so the "add a gateway" screen asked a
+ * person to type a value they had no way to look up. This is that lookup.
+ *
+ * ## The stored shape
+ *
+ * ⚠️ `order_payment_gateways` is an OPEN, value-keyed TAGS field: one
+ * `FieldValue` row per gateway per order, and a free-text tag is written with
+ * its own text AS the `optionId`. `valueText` is the defensive fallback, and
+ * the connector-provisioned case puts a real option key there instead - which
+ * is why every value goes through {@link resolveOptionId} against the field's
+ * own option list, exactly as `readOrderFacts`
+ * (`money/fulfillment-posting/reads.ts`) does. Grouping on `valueText` alone
+ * silently misses every order whose handle resolved to an option row.
+ *
+ * De-duplicated case-insensitively with {@link normaliseGatewayHandle} - the
+ * same normaliser the matcher uses, so a handle this read offers always
+ * matches. The RAW spelling is what comes back, because that is what a person
+ * should see and what the option list stores.
+ *
+ * {@link RESERVED_GATEWAY_HANDLES} are dropped: `manual` and `bogus` are
+ * answered by the debit fork before any route is consulted, so reporting them
+ * as unclaimed would be noise that never goes away.
+ *
+ * Sorted by handle. No order counts - see {@link ObservedGatewayHandle}.
+ */
+export async function listObservedGatewayHandles(
+  db: Database,
+  organizationId: string
+): Promise<Result<ObservedGatewayHandle[], Error>> {
+  return guard(
+    async () => {
+      const fields = await getOrgCache()
+        .from(organizationId, 'customFields')
+        .bySystemAttributes(['order_payment_gateways'])
+      const field = fields.order_payment_gateways
+      if (!field) return []
+
+      const rows = await db
+        .selectDistinct({
+          optionId: schema.FieldValue.optionId,
+          valueText: schema.FieldValue.valueText,
+        })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            eq(schema.FieldValue.fieldId, field.id)
+          )
+        )
+      if (rows.length === 0) return []
+
+      // Closed rails included: a closed gateway still routes its own history
+      // (`toGatewayRoutes`), so its handles are claimed, not orphaned.
+      const gateways = await listPaymentGateways(db, organizationId, { includeArchived: true })
+      if (gateways.isErr()) throw gateways.error
+      const claimedBy = new Map<string, string>()
+      for (const gateway of gateways.value) {
+        for (const handle of gateway.handles) {
+          const key = normaliseGatewayHandle(handle)
+          if (key && !claimedBy.has(key)) claimedBy.set(key, gateway.id)
+        }
+      }
+
+      const options = buildOptionIndex(((field.options ?? {}) as FieldOptions).options ?? [])
+      const reserved = new Set(RESERVED_GATEWAY_HANDLES)
+      const seen = new Map<string, ObservedGatewayHandle>()
+      for (const row of rows) {
+        const stored = row.optionId ?? row.valueText
+        if (!stored) continue
+        const resolved = resolveOptionId(stored, options)
+        const handle = (resolved.status === 'known' ? resolved.label : resolved.raw).trim()
+        const key = normaliseGatewayHandle(handle)
+        if (!key || reserved.has(key) || seen.has(key)) continue
+        seen.set(key, { handle, claimedBy: claimedBy.get(key) ?? null })
+      }
+
+      return [...seen.values()].sort((a, b) => a.handle.localeCompare(b.handle))
+    },
+    "Failed to read the gateway handles on this organization's orders",
+    { organizationId }
   )
 }
 

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -19,7 +19,7 @@ const badgeVariants = cva(
         secondary:
           'ring-1 ring-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
-          'ring-1 ring-transparent bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/80',
+          'ring-1 ring-destructive/20 bg-destructive/10 text-destructive shadow-sm hover:bg-destructive/80 hover:text-destructive-foreground',
         outline: 'ring-1 ring-border text-foreground',
         pill: 'ring-1 ring-neutral-300 bg-neutral-100 text-neutral-600 dark:text-neutral-100 dark:bg-primary-100 dark:ring-primary-100 px-2  py-0 data-selected:bg-neutral-700 data-selected:ring-neutral-700 dark:data-selected:bg-neutral-200 dark:data-selected:text-neutral-900 dark:data-selected:ring-neutral-200',
         user: 'ring-1 ring-info/20 bg-[#f2f4f7] shadow-xs gap-1 text-foreground/80 dark:bg-[#204684] cursor-pointer py-0',


### PR DESCRIPTION
## Why

The payment-gateway screen asked people to type a handle they had no way to look up. `handles` is free text, and a handle that does not match what Shopify wrote on the order is **invisible**: `resolveFulfillmentDebit` finds no route, falls back to `clearing_card`, and the entry balances. Nothing downstream can tell a typo from a rail that legitimately has no record yet. The only way to learn the real strings was to query `order_payment_gateways` by hand, which is how brief 13 §5.1's census was done in the first place. This ships that lookup.

## What

**`listObservedGatewayHandles(db, orgId)`** (`payment-gateways/reads.ts`) returns `{ handle, claimedBy }[]`. No order counts: the question is "is this handle routed", which is a yes or a no, and a count invites reading the list as a revenue report.

- Every stored value goes through `resolveOptionId` against the field's own option list. Free-text tags store their text **as the `optionId`**; a connector-provisioned set stores a real option key. Grouping on `valueText` alone silently misses the second kind.
- De-duplicated with `normaliseGatewayHandle`, the same normaliser the matcher uses, so a handle this offers always matches. The raw spelling comes back, since that is what a person types.
- `manual` and `bogus` are dropped as `RESERVED_GATEWAY_HANDLES`. The debit fork answers both before any route is consulted, so reporting them as unclaimed is noise that never clears. Mirrored in `client.ts` rather than imported, because `build-fulfillment-batch-entry.ts` imports that file for `GatewayRoute` and an import back would be a cycle.
- Closed gateways still claim their handles, because `toGatewayRoutes` deliberately keeps closed rows routing their own history.

**Two surfaces.** The gateways list grows a collapsible `Gateway handles` group, `role-map-list.tsx`'s shape, whose secondary reads `{routed} of {total} routed` and which opens onto the unrouted ones. `expandable` is conditional: with nothing unrouted the count is the whole answer, and a chevron over an empty list is a dead end. A row renders in **every** state, pending and empty included, so the list below does not move when the query lands. The add dialog offers unclaimed handles as suggestions; claimed ones are withheld because `assertHandlesAvailable` would refuse them, and typing one by hand still gets that refusal verbatim.

**A cash-route refusal fixed on the way past.** `accounting.cashBankAccountId` has `defaultValue: null` and nothing seeds it (not chart provisioning, not the wizard, not entity migration 145), but `DEFAULT_PAYMENT_ROUTES.bank` is `cash`. So every org that never opened the settings page refused its ACH and wire receipts with `account_unmapped` and no on-screen signal, including every org that enables accounting from here on. `resolveCashBankAccountGlAccountId` now falls back to the org's **sole** mapped bank account: exactly one is the only account the money could be banked into, while zero and two-or-more each refuse with their own sentence rather than guess. No migration, because a read-time answer also covers orgs where 145 already deleted the `cash` role row and orgs that do not exist yet.

**Badge.** The `destructive` variant becomes a tinted ring rather than a solid fill, reverting to solid on hover. The gateways list renders one for an unresolvable clearing account, where a solid block read as an error state for the whole row.

## Verification

- Biome clean on all 11 files, zero em dashes added.
- **Lib full suite: 1296 files, 18440 tests, 0 failures.**
- Lib ratchet 27 of 27, baseline unchanged. Web typecheck 0 errors.
- Run against the dev DB: the one org with orders holds 12 distinct values that resolve to 10 handles, `manual` dropped and `affirm` folded into `Affirm`. `authorize_net` and `authorize.net` both survive, which is exactly the two-spellings case `handles` exists for.
- The list and dialog were loaded in the browser. The collapsible group and the suggestions were not driven past that.

## Notes for review

- `packages/lib/scripts/check-observed-gateway-handles.ts` is a diagnostic that runs the census from source for every org. Happy to drop it if it reads as clutter.
- The census reads every `FieldValue` row for `order_payment_gateways` via `selectDistinct`. Postgres does the dedupe so the result is small, but it is still a full scan of that field's rows on each gateways-page load. Fine at current volumes; the fix if it bites is caching per-org, not narrowing the query.
- That dev org shows `shopify_payments` and `Affirm` as **unrouted**, meaning the two seeded default gateways are absent. Plausibly `seedDefaultPaymentGateways` counting a failed create as `skipped` and logging nothing.

https://claude.ai/code/session_01UmMLvHnCBXQopRwHpfq5MN
