### PR TITLE
feat(banking): group the payouts a reference number kept apart

### DIFF
--- a/packages/lib/src/banking/feed/__tests__/match-key.test.ts
+++ b/packages/lib/src/banking/feed/__tests__/match-key.test.ts
@@ -80,6 +80,62 @@ describe('normalizeMatchKey', () => {
     expect(normalizeMatchKey('7 ELEVEN 22')).toBe('7 eleven 22')
   })
 
+  it('strips the mixed letter-and-digit token banks use as a per-payment reference', () => {
+    // The single highest-value rule in the normaliser. Every shape below was a
+    // SINGLETON key on the measured feed (task 11's LANDED block), which is why the
+    // suggestion engine had never fired: 68 Shopify payouts worth $2.29M were 68
+    // separate decisions, none of them able to reach MIN_HISTORY_MATCHES.
+    expect(
+      normalizeMatchKey(
+        'SHOPIFY DES:TRANSFER ID:ST-F1K0R8X3L3D5 INDN:LFK ENGINEERING CO ID:XXXXX48598 CCD'
+      )
+    ).toBe('shopify des transfer id st indn lfk engineering co id ccd')
+    expect(normalizeMatchKey('AMAZON MKTPL*5Q9S115H0')).toBe('amazon mktpl')
+    expect(normalizeMatchKey('ZELLE PAYMENT TO JOHN DOE Conf# avnwsy251')).toBe(
+      'zelle payment to john doe conf'
+    )
+  })
+
+  it('collapses two payouts that differ only in their reference onto one key', () => {
+    // The property the rule was added for, stated as the function's own contract.
+    const a = normalizeMatchKey('SHOPIFY DES:TRANSFER ID:ST-F1K0R8X3L3D5 INDN:LFK ENG CCD')
+    const b = normalizeMatchKey('SHOPIFY DES:TRANSFER ID:ST-Q7M2W9B4N1H8 INDN:LFK ENG CCD')
+    expect(a).toBe(b)
+  })
+
+  it('KEEPS a mixed token that is a name rather than a reference', () => {
+    // Under six characters, or fewer than two digits, or fewer than two letters. A
+    // brand with a number in it identifies the merchant exactly as a word would.
+    expect(normalizeMatchKey('WD40 COMPANY')).toBe('wd40 company')
+    expect(normalizeMatchKey('LEVEL3 COMMUNICATIONS')).toBe('level3 communications')
+    expect(normalizeMatchKey('1STDIBS')).toBe('1stdibs')
+  })
+
+  it('leaves the letter stem of a token whose digits are a run of four or more', () => {
+    // ⚠️ This is why the reference rule runs AFTER the digit-run rule and not before,
+    // against the brief's follow-up (1). `PPD` is a NACHA class code and `ADS` an
+    // advertiser stream; both group correctly once only the digits are gone, and
+    // stripping the whole token would throw away the stable part.
+    expect(normalizeMatchKey('ACH CREDIT PPD1234567')).toBe('ach credit ppd')
+    expect(normalizeMatchKey('GOOGLE *ADS3197812385')).toBe('google ads')
+  })
+
+  it('answers no key for a bare check number', () => {
+    // 🛑 All eleven checks in the measured feed shared the key `check`, to eleven
+    // different payees. At eleven lines that is task 11 §4's `strong` band, default
+    // selected for bulk accept, so the first coded check would propose its account for
+    // ten unrelated ones. A check number identifies nothing.
+    expect(normalizeMatchKey('Check 1660')).toBe('')
+    expect(normalizeMatchKey('CHECK 1660')).toBe('')
+    // ⚠️ Three digits survive the digit-run rule, so a short check number reaches the
+    // key intact. It has to answer the same as a long one or the fix is half a fix.
+    expect(normalizeMatchKey('Check 220')).toBe('')
+    expect(normalizeMatchKey('CHECKS 220')).toBe('')
+    // Only as the WHOLE key. A descriptor that says more than "a check happened" keeps
+    // everything it says.
+    expect(normalizeMatchKey('CHECK CARD PURCHASE SHELL OIL')).toBe('check card purchase shell oil')
+  })
+
   it('is idempotent - normalising a key again changes nothing', () => {
     // The review queue groups on stored keys, so a re-run over already-normalised
     // values (a backfill, a reprocess) must not drift them into a second bucket.

--- a/packages/lib/src/banking/feed/match-key.ts
+++ b/packages/lib/src/banking/feed/match-key.ts
@@ -73,14 +73,86 @@ const STRIP_RULES: readonly RegExp[] = [
 ]
 
 /**
+ * A token that mixes letters and digits and is therefore a per-payment reference:
+ * `ST-F1K0R8X3L3D5`, `5Q9S115H0`, `avnwsy251`. Applied by
+ * {@link stripReferenceTokens} after {@link STRIP_RULES}.
+ *
+ * 🛑 **This is the single highest-value rule in the function.** Measured against the
+ * Auxx Ai feed of 2026-09-09 (489 lines, three accounts), the rules above alone put
+ * only 65.2% of lines in a group of two or more - 210 keys, 170 of them singletons.
+ * The cause is one gap: banks put their per-payment reference in a token that mixes
+ * letters with digits, so the digit-run rule above never sees a run long enough to
+ * strip. **Shopify payouts were 68 lines, $2.29M, and 68 distinct keys** - the
+ * largest revenue stream in the book, unable to reach `MIN_HISTORY_MATCHES` even
+ * once. With this rule the same feed yields 127 keys, 81 singletons, 83.4% of lines
+ * in a group of 2+ (plans/accounting/tasks/11-clearing-the-review-queue.md, the
+ * LANDED block).
+ *
+ * ⚠️ **It runs AFTER the `\d{4,}` rule, not before**, which is the opposite of what
+ * the brief's follow-up (1) says. The brief's reasoning - "once the digits are gone
+ * there is no mixed token left to recognise" - is true only of tokens whose digits
+ * form a run of four or more, and those are exactly the ones that must NOT be
+ * stripped whole: `PPD1234567` is a NACHA class code plus a trace number, and
+ * `GOOGLE *ADS3197812385` an advertiser id, and both group correctly once the digits
+ * alone are gone (`ppd`, `google ads`). The tokens this rule exists for -
+ * `F1K0R8X3L3D5`, `5Q9S115H0`, `avnwsy251` - carry no run of four, so they reach it
+ * untouched. Running it first would strip both kinds and lose the stable letter
+ * stem of the first.
+ */
+const REFERENCE_TOKEN = /[a-z0-9]{6,}/g
+
+/** Below this, a mixed token is a name (`WD40`, `1STDIBS`), not a reference. */
+const REFERENCE_MIN_LENGTH = 6
+/** Two of each: one digit is a brand (`LEVEL3`), two is a number. */
+const REFERENCE_MIN_DIGITS = 2
+const REFERENCE_MIN_LETTERS = 2
+
+/**
+ * The whole key names no counterparty and must not group. Anchored at both ends, so
+ * `check card purchase shell oil` is untouched.
+ *
+ * 🛑 `Check 1660` reduces to `check` once the number is stripped, which fused all
+ * eleven checks in the measured feed - **to eleven different payees** - into one key.
+ * At eleven lines that reads as the `strong` confidence band and is default-selected
+ * for bulk accept, so the first coded check would propose its account for ten
+ * unrelated ones. A bare check number identifies nothing; `''` (no key) is the honest
+ * answer and §0.1 above says it is a legitimate one.
+ *
+ * ⚠️ The optional trailing number is what keeps `Check 220` and `Check 1660` the same
+ * answer. The digit-run rule strips four digits and keeps three, so without it a
+ * short check number survives into the key and one door of this fix stays open on
+ * every check numbered under 1000.
+ */
+const NO_COUNTERPARTY_KEY = /^checks?(?: \d{1,3})?$/
+
+/** Is this run of letters and digits a per-payment reference rather than a name? */
+function isReferenceToken(token: string): boolean {
+  if (token.length < REFERENCE_MIN_LENGTH) return false
+  let digits = 0
+  let letters = 0
+  for (const char of token) {
+    if (char >= '0' && char <= '9') digits++
+    else letters++
+  }
+  return digits >= REFERENCE_MIN_DIGITS && letters >= REFERENCE_MIN_LETTERS
+}
+
+/** Replace every {@link isReferenceToken} run with a space. Pure. */
+function stripReferenceTokens(value: string): string {
+  return value.replace(REFERENCE_TOKEN, (token) => (isReferenceToken(token) ? ' ' : token))
+}
+
+/**
  * Normalise a bank `description` into a stable grouping key.
  *
- * Lowercases, strips card suffixes, dates, times and long digit runs, folds every
- * remaining non-alphanumeric character to a single space, and trims.
+ * Lowercases, strips card suffixes, dates, times, long digit runs and mixed
+ * letter-and-digit reference tokens, folds every remaining non-alphanumeric
+ * character to a single space, and trims.
  *
- * Returns `''` for input that is empty or reduces to nothing (a line whose whole
- * description was a trace number). 🛑 The empty string is a legitimate answer and the
- * callers must treat it as "no key", never as a key that groups: matching every
+ * Returns `''` for input that is empty, reduces to nothing (a line whose whole
+ * description was a trace number), or reduces to a {@link NO_COUNTERPARTY_KEY} word
+ * such as `check`. 🛑 The empty string is a legitimate answer and the callers must
+ * treat it as "no key", never as a key that groups: matching every
  * reference-number-only line together would suggest one merchant's coding for all of
  * them.
  */
@@ -90,9 +162,11 @@ export function normalizeMatchKey(description: string | null | undefined): strin
   for (const rule of STRIP_RULES) {
     value = value.replace(rule, ' ')
   }
+  value = stripReferenceTokens(value)
   // Everything that is not a letter, a digit or a space becomes a space. Punctuation
   // varies between two occurrences of the same merchant (`sq *coffee` vs `sq*coffee`)
   // far more often than it distinguishes two merchants.
   value = value.replace(/[^a-z0-9]+/g, ' ')
-  return value.trim().replace(/\s+/g, ' ')
+  const key = value.trim().replace(/\s+/g, ' ')
+  return NO_COUNTERPARTY_KEY.test(key) ? '' : key
 }

--- a/packages/lib/src/data-connectors/connectors/stripe-financial-connections.ts
+++ b/packages/lib/src/data-connectors/connectors/stripe-financial-connections.ts
@@ -285,7 +285,12 @@ export function toTransactionFields(
     // into a positive amount plus a direction happens once, at the builder boundary.
     amountMinor: txn.amount,
     bankStatus: toBankStatus(txn.status),
-    matchKey: normalizeMatchKey(description),
+    // `|| null` because '' is "no key", and the import door already stores it that
+    // way (`banking/import/finalize.ts`). Two doors that disagreed would leave the
+    // empty key groupable through one of them: `readHistoryForMatchKey` matches on
+    // `valueText` equality, so a stored '' would sample every unreadable line in the
+    // account as though they shared a payee.
+    matchKey: normalizeMatchKey(description) || null,
     source: 'feed',
   }
 }

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -103,6 +103,7 @@ import { migration143GlPointersHoldIds } from './migrations/143-gl-pointers-hold
 import { migration144GlAccountCodeOptionalAndSubtype } from './migrations/144-gl-account-code-optional-and-subtype'
 import { migration145RetireInstanceRoles } from './migrations/145-retire-instance-roles'
 import { migration146PaymentGateway } from './migrations/146-payment-gateway'
+import { migration147BackfillBankMatchKeys } from './migrations/147-backfill-bank-match-keys'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -338,6 +339,12 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // No ordering constraint against it or against 108/133/142/143/144/145 - it
   // only creates the payment_gateway def and its fields (task 13 §5.3).
   migration146PaymentGateway,
+  // Recomputes every stored bank_transaction.matchKey from its own description
+  // with the current normalizeMatchKey, so rows ingested before the mixed-token
+  // and bare-check rules landed group the way new ones do (task 11's LANDED
+  // follow-ups 1 and 2). No ordering constraint against anything above: it
+  // reads only bank_transaction.description and rewrites only matchKey.
+  migration147BackfillBankMatchKeys,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/147-backfill-bank-match-keys.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/147-backfill-bank-match-keys.test.ts
@@ -1,0 +1,309 @@
+// packages/lib/src/seed/entity-migrations/migrations/147-backfill-bank-match-keys.test.ts
+//
+// Migration 147 recomputes every stored `bank_transaction.matchKey` from the row's
+// own `description` with the CURRENT `normalizeMatchKey`. What is pinned here:
+//
+//  - `planRecompute` (pure, no db) decides all four outcomes - unchanged, rewritten
+//    (grouped so one UPDATE serves every row landing on the same key), inserted for
+//    an instance that never carried a key, and cleared when the new key is empty -
+//    and leaves an instance with NO description row alone rather than wiping it;
+//  - the plan is expressed against the real normaliser, not a fixture of it, so
+//    these cases fail if the two ever drift;
+//  - `up()` against a stub `Database` modelled on `143-gl-pointers-hold-ids.test.ts`
+//    (fixed rows per table, `.where()` unevaluated) applies the plan and is a no-op
+//    on a second run, verified by inspecting the store rather than the log line.
+
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { migration147BackfillBankMatchKeys, planRecompute } from './147-backfill-bank-match-keys'
+
+const MIGRATION_ID = '147-backfill-bank-match-keys'
+const ORG = 'org_1'
+
+const BANK_TX_DEF = 'def-bank_transaction'
+const DESCRIPTION_FIELD = 'field-description'
+const MATCH_KEY_FIELD = 'field-match_key'
+
+// The shapes the measured feed is actually made of (task 11's LANDED block).
+const SHOPIFY_PAYOUT =
+  'SHOPIFY DES:TRANSFER ID:ST-F1K0R8X3L3D5 INDN:LFK ENGINEERING CO ID:XXXXX48598 CCD'
+const SHOPIFY_KEY = 'shopify des transfer id st indn lfk engineering co id ccd'
+
+interface Row {
+  id: string
+  organizationId: string
+  fieldId: string
+  entityId: string
+  valueText: string | null
+  entityDefinitionId?: string
+  sortKey?: string
+}
+
+/**
+ * An in-memory `Database`, the same posture as `143-gl-pointers-hold-ids.test.ts`:
+ * one row set per TABLE, `.where()` on a select ignored (the schema's column
+ * exports carry no usable data in this package's test environment), and an update's
+ * id list read back out of the `inArray()` condition it was built with.
+ */
+function makeStore(seed: {
+  entityDefs?: { id: string; organizationId: string; entityType: string }[]
+  customFields?: {
+    id: string
+    organizationId: string
+    entityDefinitionId: string
+    systemAttribute: string
+    options: Record<string, unknown>
+  }[]
+  fieldValues?: Row[]
+}) {
+  const state = {
+    entityDefs: seed.entityDefs ?? [],
+    customFields: seed.customFields ?? [],
+    fieldValues: seed.fieldValues ?? [],
+  }
+
+  const rowsFor = (table: unknown): Record<string, unknown>[] => {
+    if (table === schema.EntityDefinition) return state.entityDefs as never
+    if (table === schema.CustomField) return state.customFields as never
+    if (table === schema.FieldValue) return state.fieldValues as never
+    throw new Error('Unknown table in test stub')
+  }
+
+  /** The array `inArray(FieldValue.id, ids)` was built with, wherever it sits. */
+  const idsFromCondition = (cond: unknown): string[] => {
+    const chunks = (cond as { queryChunks?: unknown[] } | null)?.queryChunks
+    if (!Array.isArray(chunks)) return []
+    if (chunks.length === 5) {
+      const op = chunks[2] as { value?: unknown[] } | undefined
+      if (Array.isArray(op?.value) && op.value[0] === ' in ' && Array.isArray(chunks[3])) {
+        return chunks[3] as string[]
+      }
+    }
+    for (const chunk of chunks) {
+      const found = idsFromCondition(chunk)
+      if (found.length > 0) return found
+    }
+    return []
+  }
+
+  const db = {
+    select: (_cols: unknown) => ({
+      from: (table: unknown) => ({ where: () => Promise.resolve(rowsFor(table)) }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (cond: unknown) => {
+          const ids = idsFromCondition(cond)
+          let matched = 0
+          for (const row of rowsFor(table)) {
+            if (ids.includes(row.id as string)) {
+              Object.assign(row, values)
+              matched++
+            }
+          }
+          return Promise.resolve({ rowCount: matched })
+        },
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>[]) => {
+        const target = rowsFor(table)
+        values.forEach((value, index) =>
+          target.push({ id: `inserted-${target.length + index}`, ...value })
+        )
+        return Promise.resolve({ rowCount: values.length })
+      },
+    }),
+  }
+
+  return { db: db as never, state }
+}
+
+function baseSeed(fieldValues: Row[]) {
+  return {
+    entityDefs: [{ id: BANK_TX_DEF, organizationId: ORG, entityType: 'bank_transaction' }],
+    customFields: [
+      {
+        id: DESCRIPTION_FIELD,
+        organizationId: ORG,
+        entityDefinitionId: BANK_TX_DEF,
+        systemAttribute: 'bank_transaction_description',
+        options: {},
+      },
+      {
+        id: MATCH_KEY_FIELD,
+        organizationId: ORG,
+        entityDefinitionId: BANK_TX_DEF,
+        systemAttribute: 'bank_transaction_match_key',
+        options: {},
+      },
+    ],
+    fieldValues,
+  }
+}
+
+function description(entityId: string, value: string): Row {
+  return {
+    id: `d-${entityId}`,
+    organizationId: ORG,
+    fieldId: DESCRIPTION_FIELD,
+    entityId,
+    valueText: value,
+  }
+}
+
+function matchKey(entityId: string, value: string | null): Row {
+  return {
+    id: `k-${entityId}`,
+    organizationId: ORG,
+    fieldId: MATCH_KEY_FIELD,
+    entityId,
+    valueText: value,
+  }
+}
+
+describe('migration 147, planRecompute', () => {
+  it('leaves a row whose stored key already matches the current normaliser', () => {
+    const plan = planRecompute(
+      [description('t1', 'AMAZON WEB SERVICES'), matchKey('t1', 'amazon web services')],
+      DESCRIPTION_FIELD,
+      MATCH_KEY_FIELD
+    )
+    expect(plan.unchanged).toBe(1)
+    expect(plan.rewriteGroups.size).toBe(0)
+    expect(plan.clearIds).toEqual([])
+    expect(plan.inserts).toEqual([])
+  })
+
+  it('groups every row landing on one new key into a single UPDATE', () => {
+    // The whole point of the change: 68 Shopify payouts that were 68 keys become
+    // one, and the write that gets them there is one statement, not 68.
+    const rows = [
+      description('t1', SHOPIFY_PAYOUT),
+      matchKey('t1', 'shopify des transfer id st f1k0r8x3l3d5 indn lfk engineering co id ccd'),
+      description(
+        't2',
+        'SHOPIFY DES:TRANSFER ID:ST-Q7M2W9B4N1H8 INDN:LFK ENGINEERING CO ID:XXXXX48598 CCD'
+      ),
+      matchKey('t2', 'shopify des transfer id st q7m2w9b4n1h8 indn lfk engineering co id ccd'),
+    ]
+    const plan = planRecompute(rows, DESCRIPTION_FIELD, MATCH_KEY_FIELD)
+    expect(plan.rewriteGroups.size).toBe(1)
+    expect(plan.rewriteGroups.get(SHOPIFY_KEY)).toEqual(['k-t1', 'k-t2'])
+  })
+
+  it('clears a stored key whose description now normalises to nothing', () => {
+    // 🛑 A bare check number. Leaving `check` stored would keep all eleven checks
+    // in one group, which is the false-suggestion this fix exists to stop.
+    const plan = planRecompute(
+      [description('t1', 'Check 1660'), matchKey('t1', 'check')],
+      DESCRIPTION_FIELD,
+      MATCH_KEY_FIELD
+    )
+    expect(plan.clearIds).toEqual(['k-t1'])
+    expect(plan.rewriteGroups.size).toBe(0)
+  })
+
+  it('treats a stored empty string as already cleared', () => {
+    // '' and null are the same answer - "no key" - so this must not count as a write
+    // or the migration never reports alreadyUpToDate.
+    const plan = planRecompute(
+      [description('t1', 'Check 1660'), matchKey('t1', '')],
+      DESCRIPTION_FIELD,
+      MATCH_KEY_FIELD
+    )
+    expect(plan.unchanged).toBe(1)
+    expect(plan.clearIds).toEqual([])
+  })
+
+  it('inserts a key for an instance that never carried one', () => {
+    const plan = planRecompute(
+      [description('t1', 'AMAZON WEB SERVICES')],
+      DESCRIPTION_FIELD,
+      MATCH_KEY_FIELD
+    )
+    expect(plan.inserts).toEqual([{ entityId: 't1', matchKey: 'amazon web services' }])
+  })
+
+  it('inserts nothing for an instance with no description and no key', () => {
+    const plan = planRecompute(
+      [description('t1', 'Check 1660')],
+      DESCRIPTION_FIELD,
+      MATCH_KEY_FIELD
+    )
+    expect(plan.inserts).toEqual([])
+  })
+
+  it('⚠️ leaves a stored key alone when the instance has NO description row', () => {
+    // normalizeMatchKey(null) is '', so recomputing a missing description would wipe
+    // the key off every row whose description the feed has not delivered, and the
+    // queue would lose their grouping with nothing to say so.
+    const plan = planRecompute(
+      [matchKey('t1', 'amazon web services')],
+      DESCRIPTION_FIELD,
+      MATCH_KEY_FIELD
+    )
+    expect(plan.clearIds).toEqual([])
+    expect(plan.rewriteGroups.size).toBe(0)
+    expect(plan.unchanged).toBe(0)
+  })
+})
+
+describe('migration 147, up()', () => {
+  it('rewrites, inserts and clears in one pass, then is a no-op on a second run', async () => {
+    const { db, state } = makeStore(
+      baseSeed([
+        // Rewritten: the reference token is gone from the key.
+        description('t1', SHOPIFY_PAYOUT),
+        matchKey('t1', 'shopify des transfer id st f1k0r8x3l3d5 indn lfk engineering co id ccd'),
+        // Cleared: a bare check number is no key at all.
+        description('t2', 'Check 1660'),
+        matchKey('t2', 'check'),
+        // Inserted: no matchKey row existed.
+        description('t3', 'AMAZON WEB SERVICES'),
+        // Unchanged.
+        description('t4', 'HOME DEPOT 442'),
+        matchKey('t4', 'home depot 442'),
+      ])
+    )
+
+    const first = await migration147BackfillBankMatchKeys.up(db, ORG)
+    expect(first.alreadyUpToDate).toBe(false)
+
+    const keyOf = (entityId: string) =>
+      state.fieldValues.find((r) => r.fieldId === MATCH_KEY_FIELD && r.entityId === entityId)
+        ?.valueText
+
+    expect(keyOf('t1')).toBe(SHOPIFY_KEY)
+    expect(keyOf('t2')).toBeNull()
+    expect(keyOf('t3')).toBe('amazon web services')
+    expect(keyOf('t4')).toBe('home depot 442')
+
+    const second = await migration147BackfillBankMatchKeys.up(db, ORG)
+    expect(second.alreadyUpToDate).toBe(true)
+    expect(state.fieldValues.filter((r) => r.fieldId === MATCH_KEY_FIELD)).toHaveLength(4)
+  })
+
+  it('is a no-op on an org that has no bank_transaction def', async () => {
+    const { db } = makeStore({ entityDefs: [], customFields: [], fieldValues: [] })
+    const result = await migration147BackfillBankMatchKeys.up(db, ORG)
+    expect(result.alreadyUpToDate).toBe(true)
+  })
+
+  it('creates no defs, fields or relationships', async () => {
+    const { db } = makeStore(baseSeed([description('t1', 'AMAZON WEB SERVICES')]))
+    const result = await migration147BackfillBankMatchKeys.up(db, ORG)
+    expect(result.entityDefsCreated).toBe(0)
+    expect(result.fieldsCreated).toBe(0)
+    expect(result.relationshipsLinked).toBe(0)
+  })
+})
+
+describe('migration 147, registration', () => {
+  it('is registered exactly once, under its own id', () => {
+    const matches = ALL_ENTITY_MIGRATIONS.filter((m) => m.id === MIGRATION_ID)
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toBe(migration147BackfillBankMatchKeys)
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/147-backfill-bank-match-keys.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/147-backfill-bank-match-keys.ts
@@ -1,0 +1,310 @@
+// packages/lib/src/seed/entity-migrations/migrations/147-backfill-bank-match-keys.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { generateKeyBetween } from '@auxx/utils/fractional-indexing'
+import { and, eq, inArray, like } from 'drizzle-orm'
+import { normalizeMatchKey } from '../../../banking/feed/match-key'
+import { fieldKey, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:147')
+
+const BANK_TRANSACTION_ENTITY_TYPE = 'bank_transaction'
+const DESCRIPTION_ATTRIBUTE = 'bank_transaction_description'
+const MATCH_KEY_ATTRIBUTE = 'bank_transaction_match_key'
+const EXTERNAL_ID_ATTRIBUTE = 'bank_transaction_external_id'
+
+/** The prefix `buildImportedExternalId` stamps on an id it synthesised for a file row. */
+const SYNTHESISED_EXTERNAL_ID_PREFIX = 'imp:'
+
+/** One `FieldValue` row, as narrow as the recompute needs it. */
+interface KeyRow {
+  id: string
+  fieldId: string
+  entityId: string
+  valueText: string | null
+}
+
+/** What this migration reports. Counters, never a per-row loop. */
+interface Outcome {
+  rewritten: number
+  inserted: number
+  cleared: number
+  unchanged: number
+  synthesisedExternalIds: number
+}
+
+/**
+ * Migration 147: every stored `bank_transaction.matchKey` is recomputed from the
+ * row's own `description` with the CURRENT `normalizeMatchKey`
+ * (`plans/accounting/tasks/11-clearing-the-review-queue.md`, the LANDED block's
+ * follow-ups 1 and 2).
+ *
+ * ## Why a backfill exists at all
+ *
+ * `matchKey` is the one derived value in this subsystem that is STORED rather than
+ * computed at read time - written once at ingest by
+ * `data-connectors/connectors/stripe-financial-connections.ts` and
+ * `banking/import/finalize.ts`, and never recomputed. So a rule added to the
+ * normaliser reaches new lines only, and the queue keeps grouping the rows it
+ * already holds by the old keys forever. On the measured feed that is the whole
+ * corpus: 489 lines, all of them ingested before the rule landed.
+ *
+ * ## What it does, per org
+ *
+ * One SELECT reads every `description` and `matchKey` value on the org's
+ * `bank_transaction` rows together. For each instance the new key is
+ * `normalizeMatchKey(description)`, and then:
+ *
+ * - equal to what is stored → left alone (this is what makes a second run a no-op)
+ * - different and non-empty → the `matchKey` row is UPDATEd, or INSERTed when the
+ *   instance never had one
+ * - newly empty (a bare check number, a description that was nothing but a
+ *   reference) → the stored value is set NULL, because '' is "no key" and a
+ *   stored '' would group through `readHistoryForMatchKey`'s equality match
+ *
+ * Writes are grouped: one `UPDATE ... WHERE id IN (...)` per distinct new key, one
+ * for everything being cleared, one INSERT for everything being added. However many
+ * thousand rows an org holds, that is a handful of statements.
+ *
+ * ## 🛑 What it deliberately does NOT do, and what that costs
+ *
+ * `buildImportedExternalId` (`banking/import/match-key.ts`) embeds the match key in
+ * the id it synthesises for a CSV row that arrived without one, so that re-importing
+ * the same file UPDATES its rows instead of duplicating them. Recomputing the key
+ * therefore changes what a re-import of an already-imported file would produce, and
+ * those rows would land as duplicates rather than updates.
+ *
+ * This migration does not rewrite those ids. Rebuilding one means re-deriving the
+ * per-(day, amount, payee) ordinal, and the stored ordinal came from position within
+ * the FILE - an order the database only approximates. Guessing it wrong would
+ * corrupt an identity that is unique across the org, which is worse than the
+ * duplicate it would prevent, and the duplicate is visible: #2102's
+ * `findDuplicateBankMovements` flags exactly this shape.
+ *
+ * It is a live question only if such rows exist. **They do not**: every
+ * `bank_transaction` in the measured production feed is `source: 'feed'` with a
+ * provider `fctxn_…` id, and the dev database holds none either. So the migration
+ * COUNTS them and logs a warning naming the consequence rather than acting on a
+ * case that has never occurred. If that count is ever non-zero, re-import of those
+ * files is what needs looking at.
+ *
+ * ## Self-sufficient, but deliberately NOT a frozen copy
+ *
+ * Migration 143 keeps its own narrow decode on the principle that a migration must
+ * still make sense years after the reader it might have shared has changed. This one
+ * inverts that on purpose: its entire job is to bring stored keys into step with the
+ * CURRENT normaliser, so it imports the live function. A frozen copy would put the
+ * stored keys back out of step the next time a rule is added, which is the exact
+ * debt it exists to pay off.
+ */
+export const migration147BackfillBankMatchKeys: EntityMigration = {
+  id: '147-backfill-bank-match-keys',
+  description:
+    'Recomputes every stored bank_transaction.matchKey from its own description with the ' +
+    'current normalizeMatchKey, so the rows ingested before the mixed-token and bare-check ' +
+    'rules landed group the same way new ones do ' +
+    '(plans/accounting/tasks/11-clearing-the-review-queue.md, LANDED follow-ups 1 and 2)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const def = existing.entityDefs.get(BANK_TRANSACTION_ENTITY_TYPE)
+    if (!def) return { ...state, alreadyUpToDate: true }
+
+    const descriptionField = existing.fields.get(fieldKey(def.id, DESCRIPTION_ATTRIBUTE))
+    const matchKeyField = existing.fields.get(fieldKey(def.id, MATCH_KEY_ATTRIBUTE))
+    if (!descriptionField || !matchKeyField) return { ...state, alreadyUpToDate: true }
+
+    const rows = await readKeyRows(db, organizationId, [descriptionField.id, matchKeyField.id])
+    const plan = planRecompute(rows, descriptionField.id, matchKeyField.id)
+
+    const outcome = await applyRecompute(db, organizationId, def.id, matchKeyField.id, plan)
+
+    const externalIdField = existing.fields.get(fieldKey(def.id, EXTERNAL_ID_ATTRIBUTE))
+    outcome.synthesisedExternalIds = externalIdField
+      ? await countSynthesisedExternalIds(db, organizationId, externalIdField.id)
+      : 0
+
+    const touched = outcome.rewritten + outcome.inserted + outcome.cleared
+    if (touched > 0) {
+      logger.info('Migration 147 applied', { organizationId, ...outcome })
+    }
+    if (touched > 0 && outcome.synthesisedExternalIds > 0) {
+      logger.warn(
+        'Migration 147 left synthesised import external ids untouched - re-importing those ' +
+          'files will duplicate rather than update their rows',
+        { organizationId, synthesisedExternalIds: outcome.synthesisedExternalIds }
+      )
+    }
+
+    return { ...state, alreadyUpToDate: touched === 0 }
+  },
+}
+
+/** Every `description` and `matchKey` value in this org, in ONE round trip. */
+export async function readKeyRows(
+  db: Database,
+  organizationId: string,
+  fieldIds: string[]
+): Promise<KeyRow[]> {
+  return db
+    .select({
+      id: schema.FieldValue.id,
+      fieldId: schema.FieldValue.fieldId,
+      entityId: schema.FieldValue.entityId,
+      valueText: schema.FieldValue.valueText,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.fieldId, fieldIds)
+      )
+    )
+}
+
+/** What {@link applyRecompute} has to write, decided in memory. */
+export interface RecomputePlan {
+  /** `new key -> FieldValue ids to set to it`. Grouped so one UPDATE serves many rows. */
+  rewriteGroups: Map<string, string[]>
+  /** `FieldValue` ids whose new key is empty, to NULL. */
+  clearIds: string[]
+  /** Instances with no `matchKey` row at all and a non-empty new key. */
+  inserts: { entityId: string; matchKey: string }[]
+  unchanged: number
+}
+
+/**
+ * Decide every write from the already-fetched rows. Pure - no db, no clock.
+ *
+ * ⚠️ An instance with a `matchKey` row but NO `description` row is left alone rather
+ * than cleared. `normalizeMatchKey(null)` is `''`, so treating a missing description
+ * as "recompute to empty" would wipe the key off any row whose description the feed
+ * has not delivered yet, and the queue would lose its grouping for them silently.
+ */
+export function planRecompute(
+  rows: readonly KeyRow[],
+  descriptionFieldId: string,
+  matchKeyFieldId: string
+): RecomputePlan {
+  const descriptions = new Map<string, string | null>()
+  const stored = new Map<string, KeyRow>()
+  for (const row of rows) {
+    if (row.fieldId === descriptionFieldId) descriptions.set(row.entityId, row.valueText)
+    else if (row.fieldId === matchKeyFieldId) stored.set(row.entityId, row)
+  }
+
+  const rewriteGroups = new Map<string, string[]>()
+  const clearIds: string[] = []
+  const inserts: { entityId: string; matchKey: string }[] = []
+  let unchanged = 0
+
+  for (const [entityId, description] of descriptions) {
+    const next = normalizeMatchKey(description)
+    const current = stored.get(entityId)
+
+    if (!current) {
+      if (next) inserts.push({ entityId, matchKey: next })
+      continue
+    }
+    // '' and null are the same answer - "no key" - so a stored '' is already clear.
+    const currentValue = current.valueText ?? ''
+    if (currentValue === next) {
+      unchanged++
+      continue
+    }
+    if (!next) {
+      clearIds.push(current.id)
+      continue
+    }
+    const group = rewriteGroups.get(next) ?? []
+    group.push(current.id)
+    rewriteGroups.set(next, group)
+  }
+
+  return { rewriteGroups, clearIds, inserts, unchanged }
+}
+
+/** Execute a {@link RecomputePlan}: one statement per distinct key, never per row. */
+export async function applyRecompute(
+  db: Database,
+  organizationId: string,
+  entityDefinitionId: string,
+  matchKeyFieldId: string,
+  plan: RecomputePlan
+): Promise<Outcome> {
+  const now = new Date()
+  let rewritten = 0
+
+  for (const [matchKey, valueIds] of plan.rewriteGroups) {
+    await db
+      .update(schema.FieldValue)
+      .set({ valueText: matchKey, updatedAt: now })
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          inArray(schema.FieldValue.id, valueIds)
+        )
+      )
+    rewritten += valueIds.length
+  }
+
+  if (plan.clearIds.length > 0) {
+    await db
+      .update(schema.FieldValue)
+      .set({ valueText: null, updatedAt: now })
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          inArray(schema.FieldValue.id, plan.clearIds)
+        )
+      )
+  }
+
+  if (plan.inserts.length > 0) {
+    await db.insert(schema.FieldValue).values(
+      plan.inserts.map((row) => ({
+        organizationId,
+        entityId: row.entityId,
+        entityDefinitionId,
+        fieldId: matchKeyFieldId,
+        sortKey: generateKeyBetween(null, null),
+        valueText: row.matchKey,
+        updatedAt: now,
+      }))
+    )
+  }
+
+  return {
+    rewritten,
+    inserted: plan.inserts.length,
+    cleared: plan.clearIds.length,
+    unchanged: plan.unchanged,
+    synthesisedExternalIds: 0,
+  }
+}
+
+/**
+ * How many rows carry an external id this codebase synthesised from a match key.
+ * Reported, never rewritten - see the docblock above for why.
+ */
+export async function countSynthesisedExternalIds(
+  db: Database,
+  organizationId: string,
+  externalIdFieldId: string
+): Promise<number> {
+  const rows = await db
+    .select({ id: schema.FieldValue.id })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, externalIdFieldId),
+        like(schema.FieldValue.valueText, `${SYNTHESISED_EXTERNAL_ID_PREFIX}%`)
+      )
+    )
+  return rows.length
+}


### PR DESCRIPTION
`normalizeMatchKey` strips runs of four or more digits but not tokens that mix letters with digits, which is exactly where banks put a per-payment reference. Measured against the Auxx Ai feed of 2026-09-09 (489 lines, three accounts) only **65.2% of lines landed in a group of two or more**, and the largest revenue stream in the book, **68 Shopify payouts worth $2.29M, was 68 separate keys** that could never reach `MIN_HISTORY_MATCHES`. With no provider categories at all the match key IS the categorisation signal, so that gap is why the suggestion engine had never fired in anger.

```
shopify DES:TRANSFER ID:ST-F1K0R8X3L3D5 INDN:LFK ENGINEERING CO ID:XXXXX48598 CCD
                        ^^^^^^^^^^^^^^^ different on every payout, survives every rule
```

## The rule

A run of `[a-z0-9]` at least six long holding at least two digits and at least two letters is stripped: `ST-F1K0R8X3L3D5`, `5Q9S115H0`, `avnwsy251`.

⚠️ **It runs AFTER the `\d{4,}` rule, not before.** A token whose digits form a run of four or more keeps its letter stem, so `PPD1234567` still answers `ppd` (a NACHA class code) and `GOOGLE *ADS3197812385` still answers `google ads`, and both group correctly on the stem alone. Running it first strips both kinds and loses the stem.

## The bare check number

`Check 1660` reduced to `check`, which fused all eleven checks in the feed, **to eleven different payees**, into one group that reads as the `strong` confidence band and is default-selected for bulk accept. It now answers no key. The test is anchored at both ends and allows a short trailing number, because the digit-run rule keeps three digits and `Check 220` has to agree with `Check 1660`.

## The backfill

`matchKey` is written once at ingest and never recomputed, so entity migration **147** recomputes every stored key from the row's own description with the **live** normaliser. It imports that function rather than freezing a copy, which inverts migration 143's rule on purpose: its whole job is to be in step with the current rules, and a frozen copy would put the stored keys back out of step on the next change. Writes are grouped, one `UPDATE` per distinct new key.

An instance with a `matchKey` but **no description row** is left alone, because `normalizeMatchKey(null)` is `''` and recomputing it would wipe the key off any row whose description the feed has not delivered yet.

The Stripe FC connector now stores `matchKey || null`, the way the import door already did. `readHistoryForMatchKey` matches on `valueText` equality, so a stored `''` would sample every unreadable line in the account as though they shared a payee.

## 🛑 Not done, deliberately

`buildImportedExternalId` embeds the match key in the id it synthesises for a CSV row that arrived without one, so a re-import of an already-imported file would now duplicate rather than update. Rebuilding one means re-deriving an ordinal that came from position within the **file**, and guessing it wrong corrupts an identity that is unique across the org, which is worse than the duplicate and is exactly what `findDuplicateBankMovements` flags. No such row exists in production or dev; 147 counts them and warns.

The same staleness applies to `bank_rule.matchValue`, which `createRuleFromTransaction` snapshots from a line's key. Zero auto-created rules exist (zero rules on the measured feed; dev's three carry hand-typed values), so nothing rewrites them here.

## Verification

- `packages/lib` full suite: **18,456 passing**, 0 failing
- `packages/database` suite by hand: 31 passing
- ratchets: lib 27/27, web 0/0
- biome clean, zero em dashes
- migration 147 run by hand across **all 28 dev orgs**: `alreadyUpToDate` on every one (dev holds only seeded and Stripe-sandbox descriptions, none carrying a reference token)

**Not verified:** the rewrite path against real Postgres. Dev has no row the migration would change and seeding one was blocked, so the grouped UPDATE/INSERT/clear rests on 11 unit tests over a stub `Database`.

**Not re-measured:** the 83.4%. Every individual shape behind it is now a pinned test case, but the aggregate is inherited from the 2026-09-09 production pull rather than reproduced.

https://claude.ai/code/session_01QV1sbpsZFD2ogp1AE9gNXx
