### PR TITLE
feat(accounting): centre the report empty states, and a review queue that reads down its columns

### DIFF
--- a/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review-queue-page.tsx
@@ -40,13 +40,12 @@ import { type BankTransactionRow, REVIEW_QUEUE_STATES } from '@auxx/lib/banking/
 import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { Checkbox } from '@auxx/ui/components/checkbox'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { toastError } from '@auxx/ui/components/toast'
-import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
-import { Inbox, Landmark, ListChecks } from 'lucide-react'
+import { Inbox, Landmark, ListChecks, PanelRight } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRegisterDockedPanels } from '~/components/global/docked-panels-outlet'
@@ -244,6 +243,13 @@ export function BankingReviewQueuePage() {
       current.includes(id) ? current.filter((value) => value !== id) : [...current, id]
     )
   }, [])
+
+  /**
+   * Anything selected → the list is in SELECTING mode: the checkboxes are
+   * pinned and a row click picks that row rather than opening it. Clearing the
+   * selection hands the row click back to the drawer.
+   */
+  const selecting = selectedIds.length > 0
 
   const hasAccounts = accounts.length > 0
 
@@ -474,42 +480,51 @@ export function BankingReviewQueuePage() {
                 items={rows}
                 loading={list.isPending}
                 skeletonCount={6}
+                /* A hairline between rows. The selected row draws a `ring-1`,
+                   which paints OUTSIDE its border box - flush against the next
+                   row, whose background paints later and clips the ring's
+                   bottom edge. One pixel of gap is enough to keep it whole. */
+                className='gap-px'
                 getKey={(row: BankTransactionRow) => row.id}
                 renderRow={(row: BankTransactionRow) => (
                   <TreeRow
                     className={TREE_SECONDARY_NOTRUNCATE}
-                    icon={
-                      <Checkbox
-                        checked={selectedIds.includes(row.id)}
-                        onClick={(event) => event.stopPropagation()}
-                        onCheckedChange={() => toggle(row.id)}
-                        aria-label={`Select ${row.description ?? row.id}`}
-                      />
-                    }
+                    icon={<Landmark className='size-4 text-muted-foreground' />}
+                    /* 🛑 Selection is always AVAILABLE and only PINNED once
+                       something is selected - the same idiom the chart list
+                       uses. A pinned column of empty boxes is what a list of
+                       270 lines looks like before anyone has decided anything;
+                       the box belongs on the row you are pointing at, and on
+                       every row only once you are actually picking. */
+                    selectable
+                    selecting={selecting}
+                    selected={selectedIds.includes(row.id)}
+                    onSelectChange={() => toggle(row.id)}
+                    selectLabel={`Select ${row.description ?? row.id}`}
+                    /* Direction, then date, then the description - all three
+                       inside `title`, so every row starts on the same two
+                       fixed-width columns and the eye reads straight down them.
+                       The In/Out badge is width-pinned for exactly that reason:
+                       left to its content, "Out" and "In" differ by ~8px and
+                       every date after them sits at a different x. */
                     title={
-                      <span className='truncate text-sm' title={row.matchKey ?? undefined}>
-                        {row.description || EMPTY_CELL}
+                      <span className='flex min-w-0 items-center gap-1.5'>
+                        <Badge
+                          variant={row.amountMinor < 0 ? 'outline' : 'green'}
+                          size='xs'
+                          className='w-9 shrink-0 justify-center'>
+                          {row.amountMinor < 0 ? 'Out' : 'In'}
+                        </Badge>
+                        <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
+                          {row.postedAt ?? EMPTY_CELL}
+                        </span>
+                        <span className='truncate text-sm' title={row.matchKey ?? undefined}>
+                          {row.description || EMPTY_CELL}
+                        </span>
                       </span>
                     }
                     secondary={
                       <span className='flex flex-wrap items-center gap-1.5'>
-                        <span className='font-mono text-xs tabular-nums text-muted-foreground'>
-                          {row.postedAt ?? EMPTY_CELL}
-                        </span>
-                        {/* Amounts are unsigned with the direction in its own
-                            badge, the same rule the ledger's own tables keep. */}
-                        <span
-                          className={cn(
-                            'font-mono text-xs tabular-nums',
-                            row.amountMinor < 0
-                              ? 'text-foreground'
-                              : 'text-green-700 dark:text-green-400'
-                          )}>
-                          {formatMinor(Math.abs(row.amountMinor), DISPLAY_CURRENCY)}
-                        </span>
-                        <Badge variant='outline' size='xs'>
-                          {row.amountMinor < 0 ? 'Out' : 'In'}
-                        </Badge>
                         <BankAccountBadge bankAccountId={row.bankAccountId} size='sm' />
                         {row.bankStatus === 'void' && (
                           <Badge variant='outline' size='xs'>
@@ -527,6 +542,27 @@ export function BankingReviewQueuePage() {
                             <AccountLabel glAccountId={row.glAccountId} density='chip' />
                           </Badge>
                         )}
+                      </span>
+                    }
+                    /* The status is where a row ENDS, not another chip in the
+                       middle of it: right-aligned it lands at the same x on
+                       every row, so a column of "for review" reads as one thing
+                       to clear rather than six labels at six positions. */
+                    actions={
+                      <div className='flex items-center gap-2'>
+                        {/* Amounts are unsigned with the direction in its own
+                            badge, the same rule the ledger's own tables keep.
+                            It leads the trailing cluster because the money is
+                            what a reviewer scans a queue for. */}
+                        <span
+                          className={cn(
+                            'font-mono text-xs tabular-nums',
+                            row.amountMinor < 0
+                              ? 'text-foreground'
+                              : 'text-green-700 dark:text-green-400'
+                          )}>
+                          {formatMinor(Math.abs(row.amountMinor), DISPLAY_CURRENCY)}
+                        </span>
                         <span className='flex items-center gap-1 text-muted-foreground text-xs'>
                           <span
                             className={cn(
@@ -537,12 +573,44 @@ export function BankingReviewQueuePage() {
                           />
                           {row.reviewStatus.replace('_', ' ')}
                         </span>
-                      </span>
+                        {/* 🛑 `persistent`, not the hover-revealed default. Once
+                            anything is selected a row click extends the
+                            selection, so this button is the ONLY way into a
+                            line's detail - an affordance you have to discover by
+                            hovering is not one at that point. */}
+                        <TreeRowButton
+                          persistent
+                          tooltipText='Open details'
+                          onClick={() => void setTxn(row.id)}>
+                          <PanelRight />
+                        </TreeRowButton>
+                      </div>
                     }
-                    onToggleOpen={() => void setTxn(row.id)}
+                    /* 🛑 Mid-selection, a row click EXTENDS the selection - it
+                       does not open the drawer. Picking the next of forty lines
+                       is a click on the row, not a click on a 16px box, and a
+                       drawer thrown open over the list every time somebody
+                       missed the box is how a bulk pass gets abandoned. The
+                       drawer comes back the moment the selection clears. */
+                    onToggleOpen={() => (selecting ? toggle(row.id) : void setTxn(row.id))}
                     rowClassName={cn(
                       'bg-primary-100/50 hover:bg-primary-100',
-                      txn === row.id && 'bg-primary-100 ring-1 ring-primary-200'
+                      txn === row.id && 'bg-primary-100 ring-1 ring-primary-200',
+                      // Picked for a bulk action - a DIFFERENT state from "open
+                      // in the drawer", and the app already separates the two by
+                      // hue: `info` is what a multi-selection wears on
+                      // `ListCard` and in the mail list, while `primary-*` stays
+                      // the row you are looking AT. Last in the merge, so a row
+                      // that is both keeps the drawer's ring and takes the
+                      // selection's tint.
+                      selectedIds.includes(row.id) &&
+                        cn(
+                          'bg-info/10 hover:bg-info/15 dark:bg-info/20 dark:hover:bg-info/25',
+                          // Open AND picked: the ring turns info too, so the two
+                          // states read as one row rather than a blue fill
+                          // wearing a grey outline from the other palette.
+                          txn === row.id && 'ring-info/40'
+                        )
                     )}
                   />
                 )}

--- a/apps/web/src/components/accounting/ui/banking/review/review-bulk-bar.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-bulk-bar.tsx
@@ -12,6 +12,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Label } from '@auxx/ui/components/label'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { Ban, Sparkles, Tags } from 'lucide-react'
 import { useState } from 'react'
@@ -143,7 +145,7 @@ export function ReviewBulkBar({ selectedIds, onClear, onDone }: ReviewBulkBarPro
       />
 
       <Dialog open={dialog === 'exclude'} onOpenChange={(open) => !open && setDialog(null)}>
-        <DialogContent>
+        <DialogContent position='tc' size='sm'>
           <DialogHeader>
             <DialogTitle>Exclude {count} bank lines</DialogTitle>
             <DialogDescription>
@@ -151,31 +153,48 @@ export function ReviewBulkBar({ selectedIds, onClear, onDone }: ReviewBulkBarPro
               like an unreviewed line to the next person.
             </DialogDescription>
           </DialogHeader>
-          <Textarea
-            value={reason}
-            rows={3}
-            placeholder='Personal charges on the company card'
-            onChange={(event) => setReason(event.target.value)}
-          />
+
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='bulk-exclude-reason'>Reason</Label>
+            <Textarea
+              id='bulk-exclude-reason'
+              value={reason}
+              rows={3}
+              autoFocus
+              placeholder='Personal charges on the company card'
+              onChange={(event) => setReason(event.target.value)}
+            />
+          </div>
+
           <EntryBlockers blockers={blockers} />
+
           <DialogFooter>
-            <Button variant='outline' onClick={() => setDialog(null)}>
-              Cancel
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={() => setDialog(null)}
+              disabled={busy}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
             </Button>
             <Button
+              variant='outline'
+              size='sm'
               disabled={!reason.trim() || busy}
               loading={bulkExclude.isPending}
+              loadingText='Excluding...'
               onClick={() =>
                 bulkExclude.mutate({ ids: selectedIds.slice(0, 200), reason: reason.trim() })
-              }>
-              Exclude
+              }
+              data-dialog-submit>
+              Exclude <KbdSubmit variant='outline' size='sm' />
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
       <Dialog open={dialog === 'assign'} onOpenChange={(open) => !open && setDialog(null)}>
-        <DialogContent>
+        <DialogContent position='tc' size='sm'>
           <DialogHeader>
             <DialogTitle>Code {count} bank lines</DialogTitle>
             <DialogDescription>
@@ -183,24 +202,41 @@ export function ReviewBulkBar({ selectedIds, onClear, onDone }: ReviewBulkBarPro
               other. Money out debits the account; money in credits it.
             </DialogDescription>
           </DialogHeader>
-          <GlAccountPicker
-            value={accountId}
-            selectBy='id'
-            onChange={setAccountId}
-            placeholder='Choose an account…'
-          />
+
+          <div className='flex flex-col gap-2'>
+            {/* No `htmlFor`: the picker is a combobox button, not a control
+                with an id to point at. */}
+            <Label>Account</Label>
+            <GlAccountPicker
+              value={accountId}
+              selectBy='id'
+              onChange={setAccountId}
+              placeholder='Choose an account…'
+            />
+          </div>
+
           <EntryBlockers blockers={blockers} />
+
           <DialogFooter>
-            <Button variant='outline' onClick={() => setDialog(null)}>
-              Cancel
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={() => setDialog(null)}
+              disabled={busy}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
             </Button>
             <Button
+              variant='outline'
+              size='sm'
               disabled={!accountId || busy}
               loading={bulkAssign.isPending}
+              loadingText='Posting...'
               onClick={() =>
                 bulkAssign.mutate({ ids: selectedIds.slice(0, 100), glAccountId: accountId ?? '' })
-              }>
-              Post
+              }
+              data-dialog-submit>
+              Post <KbdSubmit variant='outline' size='sm' />
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
@@ -16,7 +16,7 @@ import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { Ban, Landmark, Undo2 } from 'lucide-react'
+import { ArrowLeftRight, Ban, Landmark, Link2, type LucideIcon, Tag, Undo2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import DrawerComments from '~/components/global/comments/drawer-comments'
 import { api } from '~/trpc/react'
@@ -35,10 +35,10 @@ import { TransferPanel } from './transfer-panel'
 /** The reviewer's FIRST decision, per bank plan 03 §3. */
 type Treatment = 'match' | 'code' | 'transfer'
 
-const TREATMENTS: { value: Treatment; label: string }[] = [
-  { value: 'match', label: 'Match' },
-  { value: 'code', label: 'Code' },
-  { value: 'transfer', label: 'Transfer' },
+const TREATMENTS: { value: Treatment; label: string; icon: LucideIcon }[] = [
+  { value: 'match', label: 'Match', icon: Link2 },
+  { value: 'code', label: 'Code', icon: Tag },
+  { value: 'transfer', label: 'Transfer', icon: ArrowLeftRight },
 ]
 
 /**
@@ -276,6 +276,7 @@ export function ReviewDrawer({
                         size='sm'>
                         {TREATMENTS.map((item) => (
                           <RadioTabItem key={item.value} value={item.value}>
+                            <item.icon />
                             {item.label}
                           </RadioTabItem>
                         ))}

--- a/apps/web/src/components/accounting/ui/banking/review/review-toolbar.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-toolbar.tsx
@@ -11,7 +11,7 @@ import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { Separator } from '@auxx/ui/components/separator'
 import { format } from 'date-fns'
-import { CircleX } from 'lucide-react'
+import { Ban, CircleX, Inbox, Link2, List, type LucideIcon, Sparkles, Tag } from 'lucide-react'
 import { BankAccountPicker } from '~/components/accounting/ui/bank-account-picker'
 
 /** Every filter the queue narrows on. All of them run in SQL. */
@@ -36,14 +36,20 @@ export const EMPTY_REVIEW_FILTERS: ReviewFilters = {
   amountMax: '',
 }
 
-/** The five statuses plus "everything", in the order a reviewer works through them. */
-const STATES: { value: ReviewQueueState; label: string }[] = [
-  { value: 'for_review', label: REVIEW_STATUS_LABELS.for_review },
-  { value: 'suggested', label: REVIEW_STATUS_LABELS.suggested },
-  { value: 'matched', label: REVIEW_STATUS_LABELS.matched },
-  { value: 'coded', label: REVIEW_STATUS_LABELS.coded },
-  { value: 'excluded', label: REVIEW_STATUS_LABELS.excluded },
-  { value: 'all', label: 'All' },
+/**
+ * The five statuses plus "everything", in the order a reviewer works through
+ * them. The icons pair with the drawer's treatment tabs on purpose - `Link2`
+ * is "matched to a document" and `Tag` is "coded to an account" in both
+ * places, so the pile you filtered to and the decision that fills it read as
+ * the same word.
+ */
+const STATES: { value: ReviewQueueState; label: string; icon: LucideIcon }[] = [
+  { value: 'for_review', label: REVIEW_STATUS_LABELS.for_review, icon: Inbox },
+  { value: 'suggested', label: REVIEW_STATUS_LABELS.suggested, icon: Sparkles },
+  { value: 'matched', label: REVIEW_STATUS_LABELS.matched, icon: Link2 },
+  { value: 'coded', label: REVIEW_STATUS_LABELS.coded, icon: Tag },
+  { value: 'excluded', label: REVIEW_STATUS_LABELS.excluded, icon: Ban },
+  { value: 'all', label: 'All', icon: List },
 ]
 
 interface ReviewToolbarProps {
@@ -149,6 +155,7 @@ export function ReviewToolbar({ filters, onChange, actions }: ReviewToolbarProps
             size='sm'>
             {STATES.map((state) => (
               <RadioTabItem key={state.value} value={state.value}>
+                <state.icon />
                 {state.label}
               </RadioTabItem>
             ))}

--- a/apps/web/src/components/accounting/ui/reports/aging-report.tsx
+++ b/apps/web/src/components/accounting/ui/reports/aging-report.tsx
@@ -100,7 +100,7 @@ export function AgingReportPage({ side }: AgingReportPageProps) {
         disabled={!asOf}
       />
       <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
-        <div className='mx-auto flex w-full max-w-5xl flex-col gap-3 p-4'>
+        <div className='mx-auto flex w-full max-w-5xl flex-1 flex-col gap-3 p-4'>
           <CompletenessBanner asOf={asOf} />
           {period.isLoading ? (
             <Skeleton className='h-64 w-full' />

--- a/apps/web/src/components/accounting/ui/reports/balance-sheet.tsx
+++ b/apps/web/src/components/accounting/ui/reports/balance-sheet.tsx
@@ -97,7 +97,7 @@ export function BalanceSheetReportPage() {
         disabled={!asOf}
       />
       <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
-        <div className='mx-auto flex w-full max-w-5xl flex-col gap-3 p-4'>
+        <div className='mx-auto flex w-full max-w-5xl flex-1 flex-col gap-3 p-4'>
           <CompletenessBanner asOf={asOf} />
           {period.isLoading ? (
             <Skeleton className='h-64 w-full' />

--- a/apps/web/src/components/accounting/ui/reports/profit-and-loss.tsx
+++ b/apps/web/src/components/accounting/ui/reports/profit-and-loss.tsx
@@ -108,7 +108,7 @@ export function ProfitAndLossReportPage() {
         disabled={!from || !to}
       />
       <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
-        <div className='mx-auto flex w-full max-w-5xl flex-col gap-3 p-4'>
+        <div className='mx-auto flex w-full max-w-5xl flex-1 flex-col gap-3 p-4'>
           <CompletenessBanner asOf={to} />
           {period.isLoading ? (
             <Skeleton className='h-64 w-full' />

--- a/apps/web/src/components/accounting/ui/reports/trial-balance.tsx
+++ b/apps/web/src/components/accounting/ui/reports/trial-balance.tsx
@@ -85,7 +85,7 @@ export function TrialBalanceReportPage() {
         disabled={!asOf}
       />
       <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
-        <div className='mx-auto flex w-full max-w-5xl flex-col gap-3 p-4'>
+        <div className='mx-auto flex w-full max-w-5xl flex-1 flex-col gap-3 p-4'>
           <CompletenessBanner asOf={asOf} />
           {period.isLoading ? (
             <Skeleton className='h-64 w-full' />

--- a/apps/web/src/components/accounting/ui/reports/vendor-1099-report.tsx
+++ b/apps/web/src/components/accounting/ui/reports/vendor-1099-report.tsx
@@ -107,7 +107,7 @@ export function Vendor1099ReportPage() {
         </Button>
       </div>
       <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
-        <div className='mx-auto flex w-full max-w-5xl flex-col gap-3 p-4'>
+        <div className='mx-auto flex w-full max-w-5xl flex-1 flex-col gap-3 p-4'>
           <CompletenessBanner asOf={`${year}-12-31`} />
           {query.isPending ? (
             <Skeleton className='h-64 w-full' />


### PR DESCRIPTION
UI pass over Accounting > Reports and Accounting > Banking > Review queue.

## Reports (all five statements)

The "Nothing has posted yet" empty state hugged the top of the page instead of centring. `EmptyState` centres itself with `flex flex-1 items-center justify-center`, but the content wrapper inside the `ScrollArea` was a content-height column, so that `flex-1` had nothing to grow into. The `ScrollArea` viewport's content node already carries `min-h-full flex flex-col`, so the height chain was intact right up to that one div. Added `flex-1` to the wrapper in `trial-balance`, `balance-sheet`, `profit-and-loss`, `aging-report` and `vendor-1099-report`.

## Review queue rows

**Order.** Direction, date, then the description, all three inside `title`, so every row starts on the same two fixed-width columns. The In/Out badge is `w-9` for exactly that reason: left to its content, "Out" and "In" differ by ~8px and every date after them sat at a different x. Its colours now match the drawer header (`green` for In, `outline` for Out).

**Trailing cluster.** The amount moved out of `secondary` to lead `actions`, followed by the status and a new "Open details" `TreeRowButton`.

**Selection**, now the same idiom as the chart list: a `Landmark` at rest, cross-fading to a checkbox on row hover, pinned across every row once anything is selected. Two behaviours on top of that:

- While selecting, a row click extends the selection instead of opening the drawer. Picking the next of forty lines is a click on the row, not on a 16px box.
- Which is why the open button is `persistent` rather than hover-revealed: mid-selection it is the only way into a line's detail.

**Colour.** Selected rows take `bg-info/10`, the tint `ListCard` and the mail list already use for a multi-selection, while `primary-*` stays the row you are looking at. A row that is both open and selected keeps the drawer's ring, tinted `info` so the two states read as one row.

**A hairline between rows** (`gap-px` on the `TreeRowList`). The selected row draws a `ring-1`, which paints outside its border box; flush against the next row, whose background paints later, its bottom edge was clipped.

## Bulk bar dialogs

Both "Code N bank lines" and "Exclude N bank lines" were off `docs/ui-design-guide.md` §6: no `position`/`size`, an `outline` Cancel and a solid-fill submit, no `Kbd` hints, no labels on the controls, and no `data-dialog-submit`, so Cmd/Ctrl+Enter silently did nothing. All fixed. The Account label carries no `htmlFor` because `GlAccountPicker` takes no `id` prop; noted in a comment.

## Tabs

The banking state tabs and the drawer's treatment tabs now carry icons, paired deliberately: `Link2` is "matched to a document" and `Tag` is "coded to an account" in both places, so the pile you filtered to and the decision that fills it read as the same word.

## Testing

Each change verified in the running app with Chrome DevTools, including the full selection cycle (check one row, click two more, watch the URL stay clean, clear the selection, confirm the row click opens the drawer again) and both dialogs. `pnpm --filter @auxx/web typecheck` adds no errors; biome clean.

## Known ragged edge

The amount right-aligns cleanly only while every row shares a status. The status label is variable width ("for review" vs "coded"), so in a genuinely mixed view it pushes the amount to a different x per row. A fixed width on the status span would pin it into a real column; left out of this PR as a design call.

https://claude.ai/code/session_01YKLSbp2FuWX8iXLFSX1MCB
