### PR TITLE
fix(accounting): sum every inventory role on one account, and the three owed step-8 tests

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/opening-tb-grid.tsx
+++ b/apps/web/src/components/accounting/ui/settings/opening-tb-grid.tsx
@@ -131,12 +131,24 @@ export function overlayInventorySettings(
 ): OpeningTrialBalanceRow[] {
   return rows.map((row) => {
     if (!row.lockedByRole) return row
-    const minor = minorByRole[row.lockedByRole]
-    // `undefined` is a role this caller knows nothing about; `null` is a store
-    // that may simply not have loaded the key. Neither may overwrite.
-    if (minor === undefined || minor === null) return row
+    // 🛑 SUM every role on this account, not just one. All three roles share one
+    // account on any chart imported from QuickBooks, and reading a single role
+    // here left the grid short by the other two - the browser half of the same
+    // defect `reads.ts` had (brief 19's DRIVEN block). `lockedRoles` is the
+    // authority; `lockedByRole` is only the badge's label.
+    const roles = row.lockedRoles ?? [row.lockedByRole]
+    let total = 0
+    for (const role of roles) {
+      const minor = minorByRole[role]
+      // `undefined` is a role this caller knows nothing about; `null` is a store
+      // that may simply not have loaded the key. Neither may overwrite - and one
+      // unknown role poisons the whole sum, because a partial total would claim
+      // a number nobody supplied.
+      if (minor === undefined || minor === null) return row
+      total += minor
+    }
     // An inventory account is an asset: its opening balance is a debit.
-    return { ...row, debitMinor: minor, creditMinor: null }
+    return { ...row, debitMinor: total, creditMinor: null }
   })
 }
 

--- a/apps/web/src/components/list-selection/store.test.tsx
+++ b/apps/web/src/components/list-selection/store.test.tsx
@@ -1,0 +1,111 @@
+// apps/web/src/components/list-selection/store.test.tsx
+//
+// `setItemIds` and its pruning, which nothing asserted before.
+//
+// 🛑 This store is shared. Ten lists call `setItemIds` - workflows, connectors,
+// knowledge bases, datasets, agents, groups, dashboards, opening stock, the
+// chart of accounts - and exactly ONE of them
+// (`accounting/ui/settings/chart-list.tsx:175`) passes
+// `pruneSelection: false`. So the default and the opt-out are two different
+// contracts held by two different sets of callers, and until this file neither
+// was covered: flipping the default would have left every suite green while
+// silently destroying the pick-a-few-per-search flow on nine screens, or
+// destroying the delete-clears-the-selection behaviour on the tenth.
+//
+// Driven through the real provider rather than the unexported store factory,
+// the way `use-bulk-runner.test.tsx` does - the hooks ARE the surface every
+// caller uses, and a test that reached past them could pass over a broken one.
+
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+import { ListSelectionProvider, useListSelection } from './store'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ListSelectionProvider>{children}</ListSelectionProvider>
+}
+
+/** The whole store, so a test can arrange with one action and assert on another. */
+function useSubject() {
+  return useListSelection((s) => s)
+}
+
+/** Put `ids` on screen and select `selected` from them. */
+function arrange(
+  result: { current: ReturnType<typeof useSubject> },
+  ids: string[],
+  selected: string[]
+) {
+  act(() => result.current.setItemIds(ids))
+  act(() => {
+    for (const id of selected) result.current.toggle(id)
+  })
+}
+
+describe('setItemIds', () => {
+  it('prunes a selected id that is no longer on screen', () => {
+    const { result } = renderHook(useSubject, { wrapper })
+    arrange(result, ['a', 'b', 'c'], ['a', 'b', 'c'])
+    expect(result.current.selectedIds).toEqual(['a', 'b', 'c'])
+
+    // `b` was deleted: it is gone, not hidden, so forgetting it was selected is
+    // the correct answer.
+    act(() => result.current.setItemIds(['a', 'c']))
+
+    expect(result.current.selectedIds).toEqual(['a', 'c'])
+    expect(result.current.itemIds).toEqual(['a', 'c'])
+  })
+
+  it('keeps a hidden id selected when the caller opts out', () => {
+    const { result } = renderHook(useSubject, { wrapper })
+    arrange(result, ['a', 'b', 'c'], ['a', 'b'])
+
+    // The chart list's case: a search narrowed the visible set. `a` and `b` are
+    // hidden, not gone, and pruning here is what destroys picking three rows,
+    // searching again, and picking two more.
+    act(() => result.current.setItemIds(['c'], { pruneSelection: false }))
+
+    expect(result.current.selectedIds).toEqual(['a', 'b'])
+    expect(result.current.itemIds).toEqual(['c'])
+  })
+
+  it('prunes pending ids even when the selection is spared', () => {
+    const { result } = renderHook(useSubject, { wrapper })
+    arrange(result, ['a', 'b'], ['a', 'b'])
+    act(() => result.current.addPending('a'))
+    act(() => result.current.addPending('b'))
+
+    act(() => result.current.setItemIds(['b'], { pruneSelection: false }))
+
+    // 🛑 `pruneSelection` governs the SELECTION only. A pending marker is an
+    // overlay on a row that is on screen, so a row that left has no overlay to
+    // keep - and the opt-out must not be read as "keep everything".
+    expect(result.current.pendingIds).toEqual(['b'])
+    expect(result.current.selectedIds).toEqual(['a', 'b'])
+  })
+
+  it('never prunes on an empty list', () => {
+    const { result } = renderHook(useSubject, { wrapper })
+    arrange(result, ['a', 'b'], ['a', 'b'])
+    act(() => result.current.addPending('a'))
+
+    // A list that is loading reports no rows. Pruning against it would clear a
+    // selection the reader is about to see again.
+    act(() => result.current.setItemIds([]))
+
+    expect(result.current.selectedIds).toEqual(['a', 'b'])
+    expect(result.current.pendingIds).toEqual(['a'])
+    expect(result.current.itemIds).toEqual([])
+  })
+
+  it('leaves a selection alone when every id is still on screen', () => {
+    const { result } = renderHook(useSubject, { wrapper })
+    arrange(result, ['a', 'b', 'c'], ['b'])
+
+    // A reorder, not a removal.
+    act(() => result.current.setItemIds(['c', 'b', 'a']))
+
+    expect(result.current.selectedIds).toEqual(['b'])
+    expect(result.current.itemIds).toEqual(['c', 'b', 'a'])
+  })
+})

--- a/apps/web/src/server/api/routers/chart-account-catalogue.test.ts
+++ b/apps/web/src/server/api/routers/chart-account-catalogue.test.ts
@@ -1,0 +1,363 @@
+// apps/web/src/server/api/routers/chart-account-catalogue.test.ts
+//
+// `ledger.adoptChartAccounts` and `ledger.chartAccountRestore`, driven through a
+// real tRPC caller (the `label-channel-authority.test.ts` harness shape).
+//
+// Two procedures, two different kinds of contract:
+//
+// - `adoptChartAccounts` owns REAL LOGIC in the router - a catalogue lookup, a
+//   refusal that names the offending codes, and a de-duplication whose only
+//   observable effect is the `skipped` count the reader is shown. None of it
+//   was covered, and all of it is the kind of thing a later refactor quietly
+//   changes: a refusal that stops naming codes still refuses, and a lost
+//   `new Set` still creates the right accounts.
+//
+// - `chartAccountRestore` is a thin delegate, so what is worth pinning is the
+//   part a delegate can get wrong: that it scopes to the CALLER's org rather
+//   than to anything in the input, that it names the caller as the actor, and
+//   that an `isErr()` result throws instead of being returned as a value.
+//
+// Both sit on `ledgerControl` (§ the accountant-permissions build), which the
+// harness really enforces rather than stubbing inert - a procedure demoted to a
+// weaker rung fails here rather than in production.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const LEDGER_CONTROL = 'ledger.control'
+
+const hoisted = vi.hoisted(() => {
+  const ORG_ID = 'org_cuid000000000000000000000'
+  const USER_ID = 'usr_member00000000000000000'
+  const ACCOUNT_ID = 'gla_removed0000000000000000'
+
+  const world = {
+    /** Capability keys the caller holds. Empty is the interesting case. */
+    capabilities: new Set<string>(),
+    /** What `getCachedEntityDefId` answers. `undefined` = the def is missing. */
+    glAccountDefId: 'def_gl_account' as string | undefined,
+    /** Make `restoreChartAccount` fail with this error. */
+    restoreError: undefined as Error | undefined,
+  }
+
+  /** Capability keys `permissionProcedure` asserted, in order. */
+  const gate: string[] = []
+
+  /** The two fields `auxxErrorMiddleware` maps on, hand-rolled above the import graph. */
+  const failure = (name: string, statusCode: number, message: string): Error => {
+    const error = new Error(message)
+    error.name = name
+    ;(error as Error & { statusCode: number }).statusCode = statusCode
+    return error
+  }
+
+  const ok = <T>(value: T) => ({ isOk: () => true, isErr: () => false, value })
+  const errResult = (error: Error) => ({ isOk: () => false, isErr: () => true, error })
+
+  const seedChartAccounts = vi.fn(async () => ({ created: 0, skipped: 0, rolesAssigned: 0 }))
+  const restoreChartAccount = vi.fn(async () =>
+    world.restoreError ? errResult(world.restoreError) : ok({ id: ACCOUNT_ID })
+  )
+
+  return {
+    ORG_ID,
+    USER_ID,
+    ACCOUNT_ID,
+    world,
+    gate,
+    failure,
+    seedChartAccounts,
+    restoreChartAccount,
+  }
+})
+
+const { ORG_ID, USER_ID, ACCOUNT_ID, world, gate, seedChartAccounts, restoreChartAccount } = hoisted
+
+/**
+ * The catalogue, as small as the tests need and shaped like the real one.
+ *
+ * ⚠️ Stubbed rather than imported, deliberately. A test that read the real
+ * `DEFAULT_CHART_OF_ACCOUNTS` would assert on whichever codes that file happens
+ * to contain today, so adding an account to the catalogue would break tests
+ * about the ROUTER. What is under test is "a code not in the catalogue is
+ * refused by name", which needs a catalogue, not this catalogue.
+ */
+vi.mock('@auxx/lib/postings', () => ({
+  DEFAULT_CHART_OF_ACCOUNTS: [
+    { code: '1000', name: 'Cash', accountType: 'asset' },
+    { code: '1100', name: 'Accounts Receivable', accountType: 'asset' },
+    { code: '2000', name: 'Accounts Payable', accountType: 'liability' },
+  ],
+  restoreChartAccount: hoisted.restoreChartAccount,
+  // Everything else the router imports from this module. Present so the import
+  // resolves; never called by the two procedures under test.
+  ACCOUNT_ROLES: {},
+  CHART_PACK_KEYS: [],
+  GL_ACCOUNT_SUBTYPES: ['cost_of_goods_sold'],
+  GL_ACCOUNT_TYPES: ['asset', 'liability', 'equity', 'revenue', 'expense'],
+  POSTING_TYPES: [],
+  assertAccountingSetupUnfrozen: vi.fn(),
+  buildEntry: vi.fn(),
+  confirmSuggestedIdentities: vi.fn(),
+  createChartAccount: vi.fn(),
+  createJournalEntry: vi.fn(),
+  discardJournalEntry: vi.fn(),
+  findDuplicateBankMovements: vi.fn(),
+  getJournalEntry: vi.fn(),
+  getPosting: vi.fn(),
+  importChartFromProvider: vi.fn(),
+  listAccountIdentities: vi.fn(),
+  listChartAccountUsage: vi.fn(),
+  listChartAccounts: vi.fn(),
+  listClosePeriods: vi.fn(),
+  listFailedExports: vi.fn(),
+  listJournalEntries: vi.fn(),
+  listPostings: vi.fn(),
+  listPostingsForSource: vi.fn(),
+  listRoleMap: vi.fn(),
+  postEntry: vi.fn(),
+  postJournalEntry: vi.fn(),
+  postMonthEnd: vi.fn(),
+  previewEntry: vi.fn(),
+  previewJournalEntry: vi.fn(),
+  previewMonthEnd: vi.fn(),
+  removeChartAccount: vi.fn(),
+  resolvePeriodLock: vi.fn(),
+  retryExport: vi.fn(),
+  reverseEntry: vi.fn(),
+  reverseJournalEntry: vi.fn(),
+  setAccountIdentity: vi.fn(),
+  setRoleAssignment: vi.fn(),
+  updateChartAccount: vi.fn(),
+  updateJournalEntry: vi.fn(),
+  verifyBooksBalance: vi.fn(),
+}))
+
+vi.mock('@auxx/lib/seed', () => ({
+  seedChartAccounts: hoisted.seedChartAccounts,
+  seedChartPacks: vi.fn(),
+  seedDefaultPaymentGateways: vi.fn(),
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedEntityDefId: vi.fn(async () => hoisted.world.glAccountDefId),
+  getCachedInstalledApps: vi.fn(async () => []),
+  onCacheEvent: vi.fn(),
+}))
+
+vi.mock('@auxx/lib/errors', () => ({
+  BadRequestError: class extends Error {
+    statusCode = 400
+    constructor(message: string) {
+      super(message)
+      this.name = 'BadRequestError'
+    }
+  },
+  UnprocessableEntityError: class extends Error {
+    statusCode = 422
+    constructor(message: string) {
+      super(message)
+      this.name = 'UnprocessableEntityError'
+    }
+  },
+}))
+
+vi.mock('@auxx/lib/money', () => ({ getPaymentAccount: vi.fn() }))
+vi.mock('@auxx/lib/permissions', () => ({
+  PermissionKey: {
+    ledgerControl: LEDGER_CONTROL,
+    ledgerView: 'ledger.view',
+    ledgerPost: 'ledger.post',
+  },
+}))
+vi.mock('@auxx/lib/settings', () => ({ updateOrganizationSetting: vi.fn() }))
+vi.mock('~/server/api/audit-context', () => ({ recordAuditFromCtx: vi.fn() }))
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    protectedProcedure: t.procedure,
+    /**
+     * A middleware FACTORY, used as `.use(notDemo('lock a period'))` - not a
+     * procedure. Inert here: neither procedure under test is demo-gated, and a
+     * demo-org refusal is a different file's subject.
+     */
+    notDemo:
+      () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+    /** Really enforces, and records the key, so a demotion fails here. */
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ next }) => {
+        hoisted.gate.push(key)
+        if (!hoisted.world.capabilities.has(key)) {
+          throw hoisted.failure('ForbiddenError', 403, `You don't have permission: ${key}`)
+        }
+        return next()
+      }),
+  }
+})
+
+const { ledgerRouter } = await import('./ledger')
+
+/** `ctx.db` is a sentinel: what matters is that it is FORWARDED, not what it is. */
+const db = { __marker: 'ctx.db' }
+
+const invoke = (procedure: string, input?: unknown): Promise<unknown> => {
+  const caller = ledgerRouter.createCaller({
+    db,
+    session: { userId: USER_ID, organizationId: ORG_ID, user: { id: USER_ID } },
+  } as never)
+  const fn = (caller as unknown as Record<string, (arg?: unknown) => Promise<unknown>>)[procedure]
+  if (!fn) throw new Error(`ledger router has no procedure "${procedure}"`)
+  return fn(input)
+}
+
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+beforeEach(() => {
+  world.capabilities.clear()
+  world.glAccountDefId = 'def_gl_account'
+  world.restoreError = undefined
+  gate.length = 0
+  seedChartAccounts.mockClear()
+  restoreChartAccount.mockClear()
+})
+
+describe('ledger.adoptChartAccounts', () => {
+  it('refuses a caller without ledger.control', async () => {
+    await expect(invoke('adoptChartAccounts', { codes: ['1000'] })).rejects.toMatchObject(FORBIDDEN)
+    expect(gate).toEqual([LEDGER_CONTROL])
+    expect(seedChartAccounts).not.toHaveBeenCalled()
+  })
+
+  it('refuses an unknown code BY NAME, and seeds nothing', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+
+    // 🛑 The message is the contract, not just the refusal. This is the reader's
+    // only clue about which of the codes they sent is wrong, and a rewrite that
+    // refuses with "one or more codes are invalid" is strictly worse while still
+    // being a refusal.
+    await expect(
+      invoke('adoptChartAccounts', { codes: ['1000', '9999', '8888'] })
+    ).rejects.toMatchObject({ cause: { name: 'BadRequestError', statusCode: 400 } })
+
+    await expect(invoke('adoptChartAccounts', { codes: ['1000', '9999', '8888'] })).rejects.toThrow(
+      /9999, 8888/
+    )
+
+    // All-or-nothing: one bad code means the whole call is refused, rather than
+    // the good ones being adopted and the reader left to notice.
+    expect(seedChartAccounts).not.toHaveBeenCalled()
+  })
+
+  it('uses the singular when exactly one code is unknown', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+    await expect(invoke('adoptChartAccounts', { codes: ['9999'] })).rejects.toThrow(
+      /9999 is not an account in the catalogue\./
+    )
+  })
+
+  it('de-duplicates a repeated code before seeding', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+
+    await invoke('adoptChartAccounts', { codes: ['1000', '1000', '2000'] })
+
+    // 🛑 The duplicate would be filtered to one `missing` row by
+    // `seedChartAccounts` anyway, so the accounts created are the same either
+    // way. What the `new Set` protects is `skipped`, which is REPORTED: without
+    // it the second `1000` comes back as a code the org already held, and the
+    // reader is told an account was already there when it was merely named
+    // twice.
+    const accounts = seedChartAccounts.mock.calls[0]?.[3] as Array<{ code: string }>
+    expect(accounts.map((a) => a.code)).toEqual(['1000', '2000'])
+  })
+
+  it('forwards the caller org, the def and the catalogue source', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+
+    await invoke('adoptChartAccounts', { codes: ['1100'] })
+
+    const call = seedChartAccounts.mock.calls[0] as unknown[]
+    expect(call[0]).toBe(db)
+    expect(call[1]).toBe(ORG_ID)
+    expect(call[2]).toBe('def_gl_account')
+    expect(call[4]).toEqual({ source: 'catalogue' })
+  })
+
+  it('resolves the catalogue entry, not just the code', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+
+    await invoke('adoptChartAccounts', { codes: ['2000'] })
+
+    // The router hands `seedChartAccounts` whole catalogue rows. A refactor that
+    // passed bare codes would typecheck against a loose signature and seed
+    // accounts with no name or type.
+    expect(seedChartAccounts.mock.calls[0]?.[3]).toEqual([
+      { code: '2000', name: 'Accounts Payable', accountType: 'liability' },
+    ])
+  })
+
+  it('refuses when the org has no gl_account definition', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+    world.glAccountDefId = undefined
+
+    await expect(invoke('adoptChartAccounts', { codes: ['1000'] })).rejects.toMatchObject({
+      cause: { name: 'UnprocessableEntityError', statusCode: 422 },
+    })
+    expect(seedChartAccounts).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty code list before any work', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+    // Zod's `.min(1)`, so this never reaches the handler at all.
+    await expect(invoke('adoptChartAccounts', { codes: [] })).rejects.toThrow()
+    expect(seedChartAccounts).not.toHaveBeenCalled()
+  })
+})
+
+describe('ledger.chartAccountRestore', () => {
+  it('refuses a caller without ledger.control', async () => {
+    await expect(invoke('chartAccountRestore', { id: ACCOUNT_ID })).rejects.toMatchObject(FORBIDDEN)
+    expect(gate).toEqual([LEDGER_CONTROL])
+    expect(restoreChartAccount).not.toHaveBeenCalled()
+  })
+
+  it('scopes to the caller org and names the caller as the actor', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+
+    await invoke('chartAccountRestore', { id: ACCOUNT_ID })
+
+    // 🛑 `organizationId` comes from the SESSION and nowhere else. It is the only
+    // thing standing between this procedure and un-archiving an account id
+    // belonging to another org, and a thin delegate is exactly where that gets
+    // dropped.
+    expect(restoreChartAccount).toHaveBeenCalledWith(db, {
+      organizationId: ORG_ID,
+      accountId: ACCOUNT_ID,
+      actorUserId: USER_ID,
+    })
+  })
+
+  it('throws the lib refusal rather than returning it', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+    const refusal = Object.assign(new Error('That account is not archived.'), {
+      name: 'ConflictError',
+      statusCode: 409,
+    })
+    world.restoreError = refusal
+
+    // An `isErr()` result returned as a value would reach the client as a 200
+    // carrying an error object, and the mutation's `onSuccess` would fire.
+    await expect(invoke('chartAccountRestore', { id: ACCOUNT_ID })).rejects.toMatchObject({
+      cause: { name: 'ConflictError', statusCode: 409 },
+    })
+  })
+
+  it('rejects a blank id before any work', async () => {
+    world.capabilities.add(LEDGER_CONTROL)
+    await expect(invoke('chartAccountRestore', { id: '' })).rejects.toThrow()
+    expect(restoreChartAccount).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/money/quickbooks/__tests__/account-map.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/account-map.test.ts
@@ -1,0 +1,242 @@
+// packages/lib/src/money/quickbooks/__tests__/account-map.test.ts
+//
+// A removed QuickBooks-synced account stays removed across a Refresh.
+//
+// 🛑 THIS IS THE TEST FOR A CORRECTNESS THAT IS CURRENTLY ACCIDENTAL, and the
+// reason the file exists at all. The chain is:
+//
+//   importChartFromProvider
+//     -> provider.listAccountMappings
+//          -> readQuickbooksAccountMap          <- HERE
+//     -> planChartImport(providerAccounts, _, existingIdentities, _)
+//          -> provider account found in the map => `alreadyImported`, not `create`
+//
+// `readQuickbooksAccountMap` selects `FieldValue` rows with **no join to
+// `EntityInstance` and no `archivedAt` filter**. That looks like an oversight.
+// It is load-bearing: an archived `gl_account` keeps its `qboAccountId`, so
+// `planChartImport` still recognises the provider account as one it already has
+// and files it under `alreadyImported` instead of creating it again.
+//
+// Add the filter that looks obviously missing and **every account a person
+// removed silently comes back on the next Refresh**, with no other test in the
+// repo failing. That is what this file is here to stop.
+//
+// The same rule, stated the other way round, is already written down one layer
+// over in `seed/gl-account-chart.ts:222`: `seedChartAccounts` reads existing
+// codes "ARCHIVED ROWS INCLUDED", because "someone who archived an account did
+// not ask for it back". Two doors onto a chart, one answer.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The drizzle chain `readQuickbooksAccountMap` builds, reduced to what it
+ * actually consumes: `findFirst` for the `CustomField`, and
+ * `select().from().where()` awaited for the `FieldValue` rows.
+ *
+ * `rowsFor` records the `where` it was handed so a test can assert on the
+ * SHAPE of the query rather than only on its result - a filter added inside the
+ * `and(...)` is the mutation this file guards against, and it is visible here.
+ */
+const world = {
+  field: { id: 'fld_qbo_account_id' } as { id: string } | undefined,
+  rows: [] as Array<{ entityId: string; valueText: string | null }>,
+  /** Every table `.from()` was called with, in order. */
+  fromTables: [] as string[],
+  /** Every table joined onto it. Empty is the invariant - see the tripwire test. */
+  joins: [] as string[],
+}
+
+const database = {
+  query: {
+    CustomField: {
+      findFirst: vi.fn(async () => world.field),
+    },
+  },
+  select: vi.fn(() => ({
+    from: (table: { _name?: string }) => {
+      world.fromTables.push(table?._name ?? 'unknown')
+      // `innerJoin`/`leftJoin` are present so that ADDING one fails on the
+      // assertion below rather than on a `TypeError`. A stub that simply lacked
+      // the method would still catch the change, but the failure would read as a
+      // broken test rather than as the deliberate refusal it is.
+      const chain = {
+        innerJoin: (joined: { _name?: string }) => {
+          world.joins.push(joined?._name ?? 'unknown')
+          return chain
+        },
+        leftJoin: (joined: { _name?: string }) => {
+          world.joins.push(joined?._name ?? 'unknown')
+          return chain
+        },
+        where: async () => world.rows,
+      }
+      return chain
+    },
+  })),
+}
+
+vi.mock('@auxx/database', () => ({
+  database,
+  schema: {
+    CustomField: {
+      _name: 'CustomField',
+      organizationId: 'CustomField.organizationId',
+      appInstallationId: 'CustomField.appInstallationId',
+      connectionId: 'CustomField.connectionId',
+      appFieldKey: 'CustomField.appFieldKey',
+    },
+    FieldValue: {
+      _name: 'FieldValue',
+      organizationId: 'FieldValue.organizationId',
+      fieldId: 'FieldValue.fieldId',
+      entityId: 'FieldValue.entityId',
+      valueText: 'FieldValue.valueText',
+    },
+    EntityInstance: {
+      _name: 'EntityInstance',
+      id: 'EntityInstance.id',
+      archivedAt: 'EntityInstance.archivedAt',
+    },
+  },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => ({ op: 'and', parts }),
+  eq: (a: unknown, b: unknown) => ({ op: 'eq', a, b }),
+  isNotNull: (a: unknown) => ({ op: 'isNotNull', a }),
+  isNull: (a: unknown) => ({ op: 'isNull', a }),
+}))
+
+vi.mock('../../../cache', () => ({ getCachedEntityDefId: vi.fn() }))
+vi.mock('../../../field-values/field-value-service', () => ({ FieldValueService: class {} }))
+vi.mock('../../../identity', () => ({ deleteRecordIdentity: vi.fn() }))
+vi.mock('../identity-field', () => ({
+  QUICKBOOKS_SOURCE: 'quickbooks',
+  writeQuickbooksIdField: vi.fn(),
+}))
+
+const { readQuickbooksAccountMap } = await import('../account-map')
+const { planChartImport } = await import('../../../postings/chart-import-plan')
+
+const PARAMS = { organizationId: 'org1', installationId: 'inst1', connectionId: 'conn1' }
+
+/** The account somebody removed from the chart. Archived, still QuickBooks-linked. */
+const ARCHIVED_GL_ACCOUNT = 'gla_archived'
+/** Its counterpart in the provider's chart, which Refresh will hand us again. */
+const ARCHIVED_PROVIDER_ID = '84'
+const LIVE_GL_ACCOUNT = 'gla_live'
+const LIVE_PROVIDER_ID = '12'
+
+beforeEach(() => {
+  world.field = { id: 'fld_qbo_account_id' }
+  world.rows = []
+  world.fromTables = []
+  world.joins = []
+})
+
+describe('readQuickbooksAccountMap', () => {
+  it('includes an archived account, so a Refresh cannot resurrect it', async () => {
+    // The read returns the cell for BOTH accounts, because it does not filter on
+    // the instance at all. That is the behaviour under test.
+    world.rows = [
+      { entityId: LIVE_GL_ACCOUNT, valueText: LIVE_PROVIDER_ID },
+      { entityId: ARCHIVED_GL_ACCOUNT, valueText: ARCHIVED_PROVIDER_ID },
+    ]
+
+    const map = await readQuickbooksAccountMap(PARAMS)
+
+    expect(map.get(ARCHIVED_GL_ACCOUNT)).toBe(ARCHIVED_PROVIDER_ID)
+    expect(map.size).toBe(2)
+  })
+
+  it('reads FieldValue alone and never joins EntityInstance', async () => {
+    world.rows = [{ entityId: LIVE_GL_ACCOUNT, valueText: LIVE_PROVIDER_ID }]
+
+    await readQuickbooksAccountMap(PARAMS)
+
+    // 🛑 The tripwire. A join onto `EntityInstance` is how the `archivedAt`
+    // filter would arrive, and the moment it does, every removed account
+    // returns on the next Refresh. If this assertion is failing because you
+    // added the join deliberately, read this file's header first: the removal
+    // needs somewhere else to be remembered before the filter is safe.
+    expect(world.fromTables).toEqual(['FieldValue'])
+    expect(world.joins).toEqual([])
+  })
+
+  it('answers an empty map when the field is not provisioned', async () => {
+    world.field = undefined
+
+    const map = await readQuickbooksAccountMap(PARAMS)
+
+    expect(map.size).toBe(0)
+    // Nothing is read at all - a connection with no `qboAccountId` field has no
+    // map to build, and querying `FieldValue` on a null field id would match
+    // every cell in the org.
+    expect(world.fromTables).toEqual([])
+  })
+
+  it('skips a cell that is blank or whitespace', async () => {
+    world.rows = [
+      { entityId: LIVE_GL_ACCOUNT, valueText: '  ' },
+      { entityId: 'gla_null', valueText: null },
+      { entityId: ARCHIVED_GL_ACCOUNT, valueText: `  ${ARCHIVED_PROVIDER_ID}  ` },
+    ]
+
+    const map = await readQuickbooksAccountMap(PARAMS)
+
+    expect(map.size).toBe(1)
+    // Trimmed, so a padded cell still matches the provider id it names.
+    expect(map.get(ARCHIVED_GL_ACCOUNT)).toBe(ARCHIVED_PROVIDER_ID)
+  })
+})
+
+describe('a removed account across a Refresh', () => {
+  /** One provider account, as `list_quickbooks_accounts` hands it back. */
+  const providerAccount = (id: string, name: string) => ({
+    id,
+    name,
+    // Required, and not optional in `ProviderAccount`: `matchesDeclaredName`
+    // reads its last `:` segment, so a fixture without it throws rather than
+    // failing an assertion.
+    fullyQualifiedName: name,
+    number: null,
+    classification: 'expense' as const,
+    accountType: 'Expense',
+    active: true,
+  })
+
+  it('is not recreated, because the map still names it', async () => {
+    world.rows = [{ entityId: ARCHIVED_GL_ACCOUNT, valueText: ARCHIVED_PROVIDER_ID }]
+    const identities = await readQuickbooksAccountMap(PARAMS)
+
+    // Refresh: the provider still has the account, and always will - removing it
+    // here is OUR decision about OUR chart, not a change to theirs.
+    const plan = planChartImport(
+      [providerAccount(ARCHIVED_PROVIDER_ID, 'Job Materials')],
+      [],
+      identities,
+      []
+    )
+
+    expect(plan.create).toEqual([])
+    expect(plan.alreadyImported.map((row) => row.glAccountId)).toEqual([ARCHIVED_GL_ACCOUNT])
+  })
+
+  it('IS recreated once its mapping is gone, which is the other half of the contract', async () => {
+    // Nothing links the provider account to anything of ours any more - the
+    // account was hard-deleted, or the org reconnected to a different realm
+    // (the field is connection-scoped). Then it is genuinely new.
+    world.rows = []
+    const identities = await readQuickbooksAccountMap(PARAMS)
+
+    const plan = planChartImport(
+      [providerAccount(ARCHIVED_PROVIDER_ID, 'Job Materials')],
+      [],
+      identities,
+      []
+    )
+
+    expect(plan.create.map((row) => row.name)).toEqual(['Job Materials'])
+    expect(plan.alreadyImported).toEqual([])
+  })
+})

--- a/packages/lib/src/postings/opening-trial-balance/__tests__/opening-trial-balance.test.ts
+++ b/packages/lib/src/postings/opening-trial-balance/__tests__/opening-trial-balance.test.ts
@@ -250,6 +250,44 @@ describe('readOpeningTrialBalance', () => {
     expect(rows.find((r) => r.accountCode === '1310')?.debitMinor).toBeNull()
   })
 
+  it('SUMS every role that lands on one account, which is the QuickBooks-imported case', async () => {
+    // 🛑 The regression this exists for. QuickBooks ships a single `Inventory
+    // Asset`, so an imported chart puts all three roles on one account. Keying
+    // the lock map by account and `set`ting per role kept only the last one, the
+    // row rendered 250_00 instead of 350_00, and the trial balance was short by
+    // the other two - so Finalize could not be reached on any imported chart.
+    // Found by driving on 2026-09-10, not by a test; brief 19's DRIVEN block.
+    h.roleAccounts = new Map([
+      ['inventory_raw_materials', { glAccountId: 'a3', code: '1310', name: 'Inventory Asset' }],
+      ['inventory_wip', { glAccountId: 'a3', code: '1310', name: 'Inventory Asset' }],
+      ['inventory_finished_goods', { glAccountId: 'a3', code: '1310', name: 'Inventory Asset' }],
+    ])
+    const { rows } = (await readOpeningTrialBalance(db, ORG))._unsafeUnwrap()
+    const inventory = rows.find((r) => r.accountCode === '1310')
+    expect(inventory?.debitMinor).toBe(350_00) // 100_00 + 0 + 250_00
+    expect(inventory?.lockedRoles).toEqual([
+      'inventory_raw_materials',
+      'inventory_wip',
+      'inventory_finished_goods',
+    ])
+    // The representative role survives for the badge and the divergence label.
+    expect(inventory?.lockedByRole).toBe('inventory_raw_materials')
+  })
+
+  it('leaves a shared account NULL while any contributing role is unset', async () => {
+    // ⚠️ `null` is "nobody entered this", never zero. A partial sum would claim
+    // a number nobody supplied; `set-opening-balances` is the requirement that
+    // names the gap instead.
+    h.roleAccounts = new Map([
+      ['inventory_raw_materials', { glAccountId: 'a3', code: '1310', name: 'Inventory Asset' }],
+      ['inventory_wip', { glAccountId: 'a3', code: '1310', name: 'Inventory Asset' }],
+      ['inventory_finished_goods', { glAccountId: 'a3', code: '1310', name: 'Inventory Asset' }],
+    ])
+    h.settings.delete('accounting.openingFinishedGoods')
+    const { rows } = (await readOpeningTrialBalance(db, ORG))._unsafeUnwrap()
+    expect(rows.find((r) => r.accountCode === '1310')?.debitMinor).toBeNull()
+  })
+
   it('reads a FRACTIONAL inventory setting as null - the close would refuse it anyway', async () => {
     h.settings.set('accounting.openingRawMaterials', 12.5)
     const { rows } = (await readOpeningTrialBalance(db, ORG))._unsafeUnwrap()

--- a/packages/lib/src/postings/opening-trial-balance/client.ts
+++ b/packages/lib/src/postings/opening-trial-balance/client.ts
@@ -50,6 +50,20 @@ export interface OpeningTrialBalanceRow {
    * onto one number is how the ledger and the subledger start disagreeing.
    */
   lockedByRole?: string
+  /**
+   * EVERY inventory role that lands on this account, in `INVENTORY_ROLES`
+   * order. Present whenever {@link lockedByRole} is.
+   *
+   * 🛑 More than one role on one account is the COMMON case, not the exotic
+   * one: QuickBooks ships a single `Inventory Asset`, so every chart imported
+   * from it has all three roles pointing at the same account. The row's amount
+   * is then the SUM of the three settings, and a reader that took one role's
+   * figure would leave the trial balance short by the other two - which it did,
+   * found by driving on 2026-09-10 (brief 19's DRIVEN block). `lockedByRole`
+   * survives as the representative role for the lock badge and the divergence
+   * label; anything computing an AMOUNT must read this instead.
+   */
+  lockedRoles?: readonly string[]
   /** Integer minor units, or null for a row with no opening balance. */
   debitMinor: number | null
   creditMinor: number | null

--- a/packages/lib/src/postings/opening-trial-balance/reads.ts
+++ b/packages/lib/src/postings/opening-trial-balance/reads.ts
@@ -125,7 +125,17 @@ export async function readOpeningTrialBalance(
       // role -> the id THIS org gave the account, and the settings value that
       // owns that row. `G8` read backwards: the account differs per org, so the
       // lock has to be resolved rather than hardcoded to three fixed accounts.
-      const inventoryById = new Map<string, { role: string; minor: number | null }>()
+      // 🛑 COLLECTED, never overwritten. Keyed by account, and more than one
+      // role lands on one account in the COMMON case: QuickBooks ships a single
+      // `Inventory Asset`, so every chart imported from it has all three roles
+      // pointing there. A `Map.set` per role kept only the last one, the row
+      // rendered that role's figure instead of the sum, and the trial balance
+      // was short by the other two - so Finalize could not be reached on any
+      // imported chart at all. Found by driving on 2026-09-10; brief 19's
+      // DRIVEN block has the reproduction. This is the same collect-not-
+      // overwrite rule §0.6 already demanded of the PROVIDER map, one layer
+      // over in the ROLE map.
+      const inventoryById = new Map<string, { roles: string[]; minor: number | null }>()
       // Keyed off `ACCOUNT_ROLES`, never off `INVENTORY_ROLES`'s ordering: the
       // three settings and the three roles are paired by NAME in
       // `OPENING_BASELINE_SETTING_KEYS`, and pairing them by array index would
@@ -136,7 +146,21 @@ export async function readOpeningTrialBalance(
         [ACCOUNT_ROLES.INVENTORY_FINISHED_GOODS]: minor(finishedGoods),
       }
       for (const [role, account] of inventoryAccounts) {
-        inventoryById.set(account.glAccountId, { role, minor: settingsByRole[role] ?? null })
+        const existing = inventoryById.get(account.glAccountId)
+        const roleMinor = settingsByRole[role] ?? null
+        if (!existing) {
+          inventoryById.set(account.glAccountId, { roles: [role], minor: roleMinor })
+          continue
+        }
+        existing.roles.push(role)
+        // ⚠️ `null` is "nobody entered this", NOT zero - the distinction this
+        // whole module is built on. So a sum is only a claim about money once
+        // EVERY contributing role has a number; until then the row stays empty
+        // and `resolveSetupReadiness`'s `set-opening-balances` requirement is
+        // what names the gap, in its own words, rather than this row showing a
+        // partial total nobody supplied.
+        existing.minor =
+          existing.minor === null || roleMinor === null ? null : existing.minor + roleMinor
       }
 
       const byId = collectLinesById(entry?.lines ?? [])
@@ -158,7 +182,7 @@ export async function readOpeningTrialBalance(
           accountName: account.name,
           accountType: account.accountType,
           isActive: account.isActive,
-          ...(locked ? { lockedByRole: locked.role } : {}),
+          ...(locked ? { lockedByRole: locked.roles[0], lockedRoles: locked.roles } : {}),
           debitMinor,
           creditMinor,
         }

--- a/packages/lib/src/postings/reports/adapters.ts
+++ b/packages/lib/src/postings/reports/adapters.ts
@@ -44,6 +44,13 @@ export function toTrialBalanceRows(tb: TrialBalance): StatementRow[] {
       glAccountId: row.glAccountId,
       accountCode: row.accountCode,
       accountName: row.accountName,
+      // 🛑 The trial balance is FLAT - no sections, by design (see above) - so
+      // the row's icon is the only thing on the screen saying which statement
+      // an account belongs to. Without this every row wore the same fallback
+      // glyph while the chart of accounts two clicks away grouped the same
+      // accounts under five different ones. Null for an account whose type the
+      // chart no longer holds, which `glAccountTypeMeta` handles.
+      accountType: row.accountType ?? undefined,
       note: row.inChart
         ? undefined
         : 'This account has posted lines but has been deleted from the current chart of accounts.',


### PR DESCRIPTION
Two things: a real bug in the opening trial balance, and the three testable items owed from step 8.

---

## 1. Every inventory role that lands on one account is summed

**Not authored in this session** — picked up from the working tree at MK's request and committed as-is, with the checks below added.

QuickBooks ships a **single** `Inventory Asset` account, so every chart imported from it has all three inventory roles pointing at the same account. That's the common case, not the exotic one.

`readOpeningTrialBalance` keyed its lock map by account and wrote it with `Map.set` once per role, so **only the last role survived**. The row rendered that one role's figure instead of the sum of three, the opening trial balance came out short by the other two, and **Finalize could not be reached on any imported chart at all**. `overlayInventorySettings` had the same defect in the browser half.

The row now carries `lockedRoles` — every inventory role on the account, in `INVENTORY_ROLES` order — and both halves sum it. `lockedByRole` survives as the representative role for the lock badge and the divergence label; anything computing an **amount** reads `lockedRoles`.

`null` is "nobody entered this", not zero, which is the distinction this module is built on. So a sum is only a claim about money once **every** contributing role has a number: one unknown role poisons the total and the row stays empty rather than showing a partial figure nobody supplied. `resolveSetupReadiness`'s `set-opening-balances` requirement names that gap in its own words.

Found by driving on 2026-09-10; brief 19's DRIVEN block has the reproduction.

---

## 2. The three owed step-8 tests

From `HANDOFF-2026-09-10` §7. **The fourth item was never a test** — `suggest-account-identities.test.ts` already covers the logic, and what's missing is that nobody has seen the `Suggested` badge or the per-row accept button render. That's a drive, it mutates an org's chart, and it stays open.

### Every test verified by mutation

Passing tests prove nothing for this item — its entire subject is a correctness that holds by accident. So each source was broken the way a later refactor would break it, the test confirmed to fail, and the source restored:

| mutation | caught by |
| --- | --- |
| always prune, ignoring the opt-out | 2 failures |
| never prune the selection | 1 failure |
| `innerJoin` + `isNull(archivedAt)` on the account map | the join tripwire |
| lose the `new Set` dedup | the dedup test |
| drop `organizationId` from restore | the scoping test |
| a refusal that stops naming the codes | 2 failures |

### `readQuickbooksAccountMap` — the one to care about

It selects `FieldValue` rows with **no join to `EntityInstance` and no `archivedAt` filter**, so an archived `gl_account` keeps its `qboAccountId` and `planChartImport` files the provider account under `alreadyImported` instead of creating it again. That looks like an oversight. It is load-bearing: add the filter and **every account a person removed silently returns on the next Refresh**, with nothing else in the repo failing.

The tripwire is `expect(world.joins).toEqual([])`. My first stub had no `innerJoin` at all, which would have caught the change by `TypeError` — a failure that reads as a broken test rather than a deliberate refusal. The stub now carries `innerJoin`/`leftJoin` on purpose so the change fails on the assertion, with the reason attached.

Carried through `planChartImport` to `alreadyImported`, plus the other half of the contract: once the mapping is genuinely gone (a hard delete, or a reconnect to another realm, since the field is connection-scoped) the account **is** recreated.

### `setItemIds` / `pruneSelection`

Ten lists call it; exactly one (`chart-list.tsx:175`) opts out. The default and the opt-out are two contracts held by two different sets of callers, and neither was covered. Also pins the asymmetry that reads like a bug and isn't: `pruneSelection` governs the **selection only**, and `pendingIds` is pruned either way, because a row that left the screen has no overlay to keep.

### The two chart procedures

Driven through a real tRPC caller (the `label-channel-authority.test.ts` harness shape), with a `permissionProcedure` that really enforces — a demotion off `ledgerControl` fails here rather than in production.

`adoptChartAccounts` owns real router logic: a catalogue lookup, a refusal naming the offending codes, and a dedup whose only observable effect is the `skipped` count the reader is shown. `chartAccountRestore` is a delegate, so what's pinned is what a delegate drops — `organizationId` from the **session** and nowhere else, and an `isErr()` thrown rather than returned as a 200 carrying an error object.

The catalogue is **stubbed rather than imported**, so adding an account to `DEFAULT_CHART_OF_ACCOUNTS` doesn't break tests about the router.

---

## 3. One line of production code

`toTrialBalanceRows` now passes `accountType` through to `meta`. The trial balance is flat by design, so the row icon is the only thing on that screen saying which statement an account belongs to — every row wore the same fallback glyph while the chart of accounts two clicks away grouped the same accounts under five different ones. Verified in the browser after a dev-server restart: 6 assets `landmark`, 5 liabilities `credit-card`, 2 equity `piggy-bank`, Total none.

---

## Checks

- `@auxx/web` typecheck 0 errors; lib ratchet clean (27, baseline 27).
- 115 web accounting tests, 139 across all affected web areas, 43/44 in `opening-trial-balance/`.
- The one failure is `fill-from-provider.test.ts` expecting `broadcastUserKeys` on an `org.settings.changed` payload — pre-existing from #2110, in a file this PR does not touch.

`HANDOFF-2026-09-10.md` §4 item 0 / §7 and `ui-plan.md` §4.1 / new §4.6 are updated on disk, but `plans/` is gitignored so they aren't in this diff.

https://claude.ai/code/session_01Wz8drEv9Gg8UnvMQXX3QBa
