### PR TITLE
feat(accounting): do our books and theirs agree, and if not, where

### DIFF
--- a/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
@@ -41,6 +41,7 @@ export type LedgerBlockerStatus =
   | 'bank_account_unmapped'
   | 'no_bank_accounts'
   | 'suggestion_incomplete'
+  | 'agreement_refused'
 
 /** One reason a preview, a post or a discard refused, as the console renders it. */
 export interface LedgerBlocker {
@@ -220,6 +221,20 @@ const REMEDIES: Partial<Record<LedgerBlockerStatus, BlockerRemedy>> = {
     title: 'The suggestion does not balance yet',
     guidance:
       'What is still missing is below, with its amount. Nothing has been posted and every cell in the grid can be edited.',
+  },
+  // plans/accounting/tasks/20-two-authors-one-ledger.md §8.2. Nothing in the
+  // schema enforces that the provider link is one-to-one, so two of our accounts
+  // can claim the same QuickBooks account - and there is then no single figure
+  // to compare that account against. A refusal naming both, never a guess about
+  // which one the money belongs to.
+  agreement_refused: {
+    tone: 'failure',
+    icon: Unlink,
+    title: 'The two charts cannot be lined up',
+    guidance:
+      'One account in the connected system is claimed by more than one account in this chart, so its balance has no single counterpart here. Withdraw one of the two mappings on the account map and check again. Nothing was changed.',
+    href: '/app/accounting/settings/accounts',
+    actionLabel: 'Open the account map',
   },
 }
 

--- a/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
@@ -11,6 +11,7 @@ import { Separator } from '@auxx/ui/components/separator'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import {
+  ArrowLeftRight,
   BookOpenCheck,
   CalendarCheck2,
   CircleSlash,
@@ -34,6 +35,7 @@ import { AccountingChecklistPanel } from '~/components/accounting/ui/checklist/a
 import { EntriesList } from '~/components/accounting/ui/journal/entries-list'
 import { JournalEntryDrawer } from '~/components/accounting/ui/journal/journal-entry-drawer'
 import { lastDayOfPeriod, today } from '~/components/accounting/ui/journal/period-helpers'
+import { ProviderAgreementPanel } from '~/components/accounting/ui/provider-agreement/provider-agreement-panel'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useMedia } from '~/hooks/use-media'
 import { useSettings } from '~/hooks/use-settings'
@@ -703,6 +705,22 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
                   </div>
                 )}
               </Section>
+
+              {/* The OTHER sweep (brief 20 §8.3): the one above proves our own
+                  rows balance, this one asks whether the connected system
+                  agrees with them. On the period already on screen, as of its
+                  last day, and only when somebody presses the button - the read
+                  costs a round trip to QuickBooks and the drift it finds is
+                  made at close, not on a Tuesday. */}
+              {!!activePeriodKey && (
+                <Section
+                  title={`Does ${providerLabel} agree?`}
+                  icon={<ArrowLeftRight className='size-4' />}
+                  description='Our balances and theirs as of the last day of this month, account by account. A comparison only - nothing here posts, and no statement reads it.'
+                  collapsible={false}>
+                  <ProviderAgreementPanel asOf={lastDayOfPeriod(activePeriodKey)} />
+                </Section>
+              )}
             </>
           )}
         </div>

--- a/apps/web/src/components/accounting/ui/provider-agreement/provider-agreement-panel.tsx
+++ b/apps/web/src/components/accounting/ui/provider-agreement/provider-agreement-panel.tsx
@@ -1,0 +1,210 @@
+// apps/web/src/components/accounting/ui/provider-agreement/provider-agreement-panel.tsx
+
+'use client'
+
+// "Do our books and theirs agree as of this date, and if not, where"
+// (plans/accounting/tasks/20-two-authors-one-ledger.md §8.3), as one component
+// behind both doors: the close console renders it on the period already on
+// screen, and Accounting > Settings renders it with a date field for an
+// arbitrary date.
+//
+// 🛑 ON DEMAND ONLY. `ledger.providerAgreement` reaches the connected system
+// over the app Lambda, and the drift it detects is caused by the accountant's
+// adjusting work, which happens at close - so there is no polling, no refetch
+// interval, no refetch on focus or on mount, and no background job (§8.3). The
+// query does not run until somebody presses the button. If the button turns out
+// to be pressed constantly, that is the signal to tighten the cadence, and by
+// then there is data to justify it.
+//
+// 🛑 Reports its outcome INLINE, never as a toast - the same rule the rest of
+// the accounting module follows (ground rule 9, `entry-blockers.tsx`). A
+// refusal here names two accounts and where to go and unpick them; a toast
+// would take that away three seconds later.
+
+import { FieldType } from '@auxx/database/enums'
+import { Button } from '@auxx/ui/components/button'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { Scale } from 'lucide-react'
+import { useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
+import { EntryBlockers } from '../ledger/entry-blockers'
+import { ProviderAgreementTable } from './provider-agreement-table'
+
+/** What `quickbooks-section.tsx` says about a disconnected org, said the same way. */
+const NOT_CONNECTED_COPY =
+  'No accounting system is connected, so there is nothing to compare against. The books are kept ' +
+  'here either way and nothing is blocked by this.'
+
+export interface ProviderAgreementPanelProps {
+  /** `YYYY-MM-DD`. Both sides are read as of this day. */
+  asOf: string
+  /**
+   * Given, the panel renders a date field beside the button and the caller owns
+   * the date - the settings door, where the date is arbitrary. Omitted, the date
+   * is fixed by the caller and no field renders - the close console, where it is
+   * the end of the period already on screen.
+   */
+  onAsOfChange?: (asOf: string) => void
+  className?: string
+}
+
+/**
+ * The agreement view: a button, and whatever the last press answered.
+ *
+ * Four outcomes, and the first three must never be flattened into each other:
+ *
+ *   1. Nothing is connected -> {@link NOT_CONNECTED_COPY}, and the button is
+ *      disabled. Known without asking, from `useAccountingProviderStatus`, and
+ *      confirmed by the server's own `not_connected` for the org that installed
+ *      the app but never authorized it.
+ *   2. Connected, empty company -> `ProviderAgreementTable` says so.
+ *   3. Connected, zero difference -> the table says the books AGREE.
+ *   4. A refusal (one provider account claimed by two of ours) -> an
+ *      `EntryBlockers` card carrying the server's message verbatim, which is
+ *      what names both accounts.
+ */
+export function ProviderAgreementPanel({
+  asOf,
+  onAsOfChange,
+  className,
+}: ProviderAgreementPanelProps) {
+  const provider = useAccountingProviderStatus()
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const currency = (getSetting('organization.currency') as string) || 'USD'
+
+  /**
+   * The date the last press asked about, or `null` for "nothing has been asked".
+   *
+   * 🛑 This is what keeps the read on demand. `enabled` is false until somebody
+   * presses the button, and moving the date field clears it again rather than
+   * leaving February's answer on screen under a March heading.
+   */
+  const [runAsOf, setRunAsOf] = useState<string | null>(null)
+
+  const agreementQuery = api.ledger.providerAgreement.useQuery(
+    { asOf: runAsOf ?? asOf },
+    {
+      enabled: runAsOf !== null,
+      // 🛑 Every one of these is load-bearing, not defensive tuning: this read
+      // costs a round trip to the connected system, so nothing but the button
+      // may cause it to happen (§8.3).
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchInterval: false,
+      staleTime: Number.POSITIVE_INFINITY,
+      retry: false,
+    }
+  )
+
+  const providerLabel = provider.providerLabel ?? 'QuickBooks'
+  const isCurrent = runAsOf === asOf
+  const isRunning = agreementQuery.isFetching
+
+  function run() {
+    // Re-asking the SAME date has to go through `refetch` - the query key has
+    // not changed, so `setRunAsOf` alone would be a no-op and the button would
+    // do nothing at all on its second press.
+    if (isCurrent) void agreementQuery.refetch()
+    else setRunAsOf(asOf)
+  }
+
+  const data = isCurrent ? agreementQuery.data : undefined
+  const error = isCurrent ? agreementQuery.error : null
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <div className='flex flex-wrap items-center gap-2'>
+        {onAsOfChange && (
+          <>
+            <span className='text-muted-foreground text-sm'>As of</span>
+            <div className='w-44'>
+              {/* The date is held as `YYYY-MM-DD` (that is what the procedure
+                  takes), so it is widened to an instant on the way in and
+                  sliced back on the way out - the same round trip the JE drawer
+                  and the deposit form do. */}
+              <FieldInputAdapter
+                fieldType={FieldType.DATE}
+                value={`${asOf}T00:00:00.000Z`}
+                onChange={(value) => {
+                  const iso = value as string | null
+                  if (!iso) return
+                  onAsOfChange(iso.slice(0, 10))
+                  // The answer on screen belongs to the old date. Drop it rather
+                  // than relabel it.
+                  setRunAsOf(null)
+                }}
+                disabled={isRunning}
+                triggerProps={{ className: 'w-full' }}
+              />
+            </div>
+          </>
+        )}
+
+        <Button
+          variant='outline'
+          size='sm'
+          disabled={!provider.connected}
+          loading={isRunning}
+          loadingText={`Reading ${providerLabel}...`}
+          onClick={run}>
+          <Scale />
+          {isCurrent && data ? 'Check again' : 'Check agreement'}
+        </Button>
+
+        {isCurrent && data?.status === 'ok' && (
+          <span className='text-muted-foreground text-xs'>
+            Compared as of {data.agreement.asOf}.
+          </span>
+        )}
+      </div>
+
+      {!provider.connected && !provider.loading && (
+        <p className='text-muted-foreground text-xs'>{NOT_CONNECTED_COPY}</p>
+      )}
+
+      {/*
+        🛑 Two different failures, and only one of them is a REFUSAL. A provider
+        account claimed by two of ours comes back 422 with a message naming both,
+        and that gets the blocker card with the remedy on it. Anything else - the
+        Lambda timed out, QuickBooks faulted, the token expired - is a read that
+        did not run, and dressing it up as "the two charts cannot be lined up"
+        would send somebody to unpick a mapping that is fine. Same distinction
+        the close console's balance sweep draws between a failed read and a
+        running one.
+      */}
+      {error &&
+        (error.data?.httpStatus === 422 ? (
+          <EntryBlockers blockers={[{ status: 'agreement_refused', error: error.message }]} />
+        ) : (
+          <p className='text-destructive text-sm'>
+            The comparison could not run, so nothing has been checked. {error.message}
+          </p>
+        ))}
+
+      {isRunning && !data && <Skeleton className='h-40 w-full' />}
+
+      {/* The server's own "nothing is connected", which is a different fact
+          from the browser's: an org that installed the app but never authorized
+          it reads `connected: false` above AND reaches the adapter, which
+          answers `not_connected`. Both say the same thing, so both say it the
+          same way. */}
+      {data?.status === 'not_connected' && (
+        <p className='text-muted-foreground text-sm'>{NOT_CONNECTED_COPY}</p>
+      )}
+
+      {data?.status === 'ok' && (
+        <ProviderAgreementTable
+          agreement={data.agreement}
+          currency={currency}
+          providerCurrency={data.providerCurrency}
+          providerLabel={providerLabel}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/provider-agreement/provider-agreement-table.tsx
+++ b/apps/web/src/components/accounting/ui/provider-agreement/provider-agreement-table.tsx
@@ -1,0 +1,241 @@
+// apps/web/src/components/accounting/ui/provider-agreement/provider-agreement-table.tsx
+
+'use client'
+
+// The reconciliation view's table: our balance, their balance and the
+// difference, account by account, as of one date
+// (plans/accounting/tasks/20-two-authors-one-ledger.md §8.3).
+//
+// 🛑 ONE table, two doors. The close console renders it on the period already on
+// screen and Accounting > Settings renders it for a date somebody picked, and
+// both go through this component - the same rule `OpeningFillButton` follows for
+// the same reason (brief 19 §4.7): a comparison that looked different depending
+// on where you asked it from would be read as two different answers.
+//
+// 🛑 This renders a COMPARISON and never becomes a statement source. Every
+// report in `reports/` reads our own rows and only our own rows (§0.7), and
+// nothing here changes that. What closes the gap is the sync WRITING rows
+// (§5 to §7), not a statement learning to read a provider.
+
+import type { ProviderAgreement, ProviderAgreementStatus } from '@auxx/lib/postings/client'
+import type { BadgeProps } from '@auxx/ui/components/badge'
+import { Badge } from '@auxx/ui/components/badge'
+import { EmptySection } from '@auxx/ui/components/section'
+import { BookX, TriangleAlert } from 'lucide-react'
+import { formatMinor } from '../ledger/format'
+import type { StatementColumn, StatementRow } from '../reports/statement-table'
+import { StatementTable } from '../reports/statement-table'
+
+/**
+ * Three columns, debit-positive throughout.
+ *
+ * 🛑 Debit-positive on BOTH sides - `ProviderAgreementRow` is built that way
+ * (its own header explains why) and this table only renders what it is given.
+ * The moment one column were natural-sign, every liability, equity and revenue
+ * row would read as disagreeing with itself.
+ */
+const AGREEMENT_COLUMNS: StatementColumn[] = [
+  { key: 'ours', label: 'auxx.ai', align: 'right' },
+  { key: 'theirs', label: 'QuickBooks', align: 'right' },
+  { key: 'difference', label: 'Difference', align: 'right', signed: true },
+]
+
+/**
+ * How each status reads, and the order the rows come in.
+ *
+ * 🛑 `only_theirs` is FIRST and it is the loudest, because it is the whole
+ * reason brief 20 exists: an account the provider carries a balance on that our
+ * ledger has never posted to is work authored somewhere we do not look. A screen
+ * that sorted these by account code would bury the one row type nothing else in
+ * the product can tell you about.
+ */
+const STATUS_META: Record<
+  ProviderAgreementStatus,
+  { rank: number; label: string; variant: BadgeProps['variant']; note?: string }
+> = {
+  only_theirs: {
+    rank: 0,
+    label: 'Only in QuickBooks',
+    variant: 'amber',
+    note: 'No account in this chart is mapped to it, so this ledger has never carried its balance.',
+  },
+  differs: { rank: 1, label: 'Differs', variant: 'red' },
+  only_ours: {
+    // ⚠️ NOT "QuickBooks has no balance on it". A mapped account missing from
+    // their report is a `differs` against zero - the report carries non-zero
+    // rows only. `only_ours` means UNMAPPED, so the whole of our balance shows
+    // in the difference column because there is nothing to net it against.
+    rank: 2,
+    label: 'Not mapped',
+    variant: 'blue',
+    note: 'Not linked to any QuickBooks account, so there is nothing to compare it against.',
+  },
+  match: { rank: 3, label: 'Agrees', variant: 'outline' },
+}
+
+/** A row with no name on either side still has to be identifiable in the table. */
+function rowLabel(name: string, providerAccountId: string | null): string {
+  return name.trim() || providerAccountId || 'Unnamed account'
+}
+
+/** `only_theirs` first, then the other differences, then the accounts that agree. */
+function toAgreementRows(agreement: ProviderAgreement): StatementRow[] {
+  return [...agreement.rows]
+    .sort((a, b) => {
+      const byStatus = STATUS_META[a.status].rank - STATUS_META[b.status].rank
+      if (byStatus !== 0) return byStatus
+      // Within a status, the biggest difference first - a reconciliation is read
+      // from the top, and an account code sort would put the pennies above the
+      // thousands.
+      const bySize = Math.abs(b.differenceMinor) - Math.abs(a.differenceMinor)
+      if (bySize !== 0) return bySize
+      return a.accountName.localeCompare(b.accountName)
+    })
+    .map((row, index) => {
+      const meta = STATUS_META[row.status]
+      const name = rowLabel(row.accountName, row.providerAccountId)
+      return {
+        // ⚠️ The INDEX is in the key deliberately. A provider `account` row with
+        // no id is carried through with both ids null (the planner's last loop),
+        // and a company file with two of them would otherwise produce two rows
+        // keyed `only_theirs::`.
+        id: `${row.status}:${row.glAccountId ?? ''}:${row.providerAccountId ?? ''}:${index}`,
+        // Never read while `meta.accountName` is set, which it always is here.
+        // Present because `StatementRow` requires it.
+        label: name,
+        depth: 0 as const,
+        kind: 'line' as const,
+        values: [row.oursMinor, row.theirsMinor, row.differenceMinor],
+        meta: {
+          // 🛑 The account is rendered by `AccountLabel` through these two
+          // fields. Never compose `${code} ${name}` here - the code track, the
+          // truncation and the hover title are decisions that file makes once.
+          ...(row.glAccountId ? { glAccountId: row.glAccountId } : {}),
+          accountCode: row.accountCode,
+          accountName: name,
+          badge: (
+            <Badge variant={meta.variant} size='xs'>
+              {meta.label}
+            </Badge>
+          ),
+          ...(meta.note ? { note: meta.note } : {}),
+        },
+      }
+    })
+}
+
+export interface ProviderAgreementTableProps {
+  agreement: ProviderAgreement
+  /** The ORG's ledger currency - what both columns are rendered in. */
+  currency: string
+  /** The provider's own reporting currency, so a mismatch can be said out loud. */
+  providerCurrency: string
+  /** 'QuickBooks Online', for the copy. */
+  providerLabel: string
+}
+
+/**
+ * The agreement, as of one date.
+ *
+ * 🛑 Three answers that must never be flattened into each other, and this
+ * component owns two of them (the third, "nothing is connected", is the panel's
+ * - it is the only one that can be known without asking):
+ *
+ *   1. `providerHasData: false` - connected, and the provider answered with an
+ *      empty company. Rendering that as "everything agrees" would report a
+ *      clean close over a company file nobody has posted to.
+ *   2. `totalDifferenceMinor === 0` - the books AGREE, said in as many words.
+ *   3. anything else - the rows, `only_theirs` first.
+ */
+export function ProviderAgreementTable({
+  agreement,
+  currency,
+  providerCurrency,
+  providerLabel,
+}: ProviderAgreementTableProps) {
+  if (!agreement.providerHasData) {
+    return (
+      <EmptySection
+        icon={<BookX className='size-5' />}
+        title={`${providerLabel} has no balances as of ${agreement.asOf}`}
+        description={
+          'The connection worked and the company file reported nothing to compare against. That ' +
+          'is not agreement - it is an empty set of books on their side.'
+        }
+      />
+    )
+  }
+
+  const rows = toAgreementRows(agreement)
+  const differing = agreement.rows.filter((row) => row.differenceMinor !== 0)
+  const onlyTheirs = agreement.rows.filter((row) => row.status === 'only_theirs')
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {/*
+        The finding card, on `DuplicateMovementsCard`'s pattern and for the same
+        reason: this is a finding on a ledger surface, not a transient notice. It
+        names the accounts rather than counting them - "3 accounts" sends
+        somebody hunting through the table below for which three.
+      */}
+      {onlyTheirs.length > 0 && (
+        <div className='flex flex-col gap-2 rounded-xl border border-amber-500/40 bg-amber-500/5 p-4'>
+          <div className='flex items-start gap-2'>
+            <TriangleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
+            <div className='flex min-w-0 flex-col gap-1'>
+              <span className='font-medium'>
+                {onlyTheirs.length === 1
+                  ? 'One account carries a balance only in QuickBooks'
+                  : `${onlyTheirs.length} accounts carry a balance only in QuickBooks`}
+              </span>
+              <p className='text-muted-foreground text-sm'>
+                {onlyTheirs
+                  .map((row) => rowLabel(row.accountName, row.providerAccountId))
+                  .join(', ')}
+                . No account in this chart is mapped to {onlyTheirs.length === 1 ? 'it' : 'them'},
+                so whatever put the balance there was authored in {providerLabel} and this ledger
+                has never seen it. Either the account is simply unmapped, or the work behind it has
+                no counterpart here. Nothing was changed.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {providerCurrency !== currency && (
+        <p className='text-destructive text-sm'>
+          {providerLabel} reports in {providerCurrency} and this ledger is kept in {currency}. The
+          two columns below are not comparable and nothing here converts them.
+        </p>
+      )}
+
+      <StatementTable
+        columns={AGREEMENT_COLUMNS}
+        rows={rows}
+        currency={currency}
+        searchable
+        labelHeading='Account'
+        verdict={
+          agreement.hasDifferences
+            ? {
+                ok: false,
+                // The SUM OF ABSOLUTE differences, which is what
+                // `totalDifferenceMinor` is - never the difference of the two
+                // column totals. Two accounts off by equal and opposite amounts
+                // net to zero on the second and are not a clean set of books.
+                label: `${formatMinor(agreement.totalDifferenceMinor, currency)} apart.`,
+                detail:
+                  differing.length === 1
+                    ? 'One account does not line up as of this date.'
+                    : `${differing.length} accounts do not line up as of this date.`,
+              }
+            : {
+                ok: true,
+                label: 'The books agree.',
+                detail: `Every account either side carries is on the other, at the same figure, as of ${agreement.asOf}.`,
+              }
+        }
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
@@ -55,6 +55,7 @@ import {
   readText,
 } from './accounting-settings-keys'
 import { FrozenLock } from './frozen-lock'
+import { ProviderAgreementSettingsSection } from './provider-agreement-section'
 import { QuickbooksSettingsSection } from './quickbooks-section'
 import { SetupStatusSection } from './setup-status-section'
 
@@ -424,6 +425,15 @@ export function AccountingGeneralSettingsPage() {
               read as missing.
             */}
             <QuickbooksSettingsSection />
+
+            {/*
+              Directly under the provider it asks about, and after it: there is
+              nothing to compare until something is connected, and the section
+              itself says so rather than disappearing (brief 20 §8.3). It owns no
+              settings values either, so it stays out of all three draft slices
+              and adds nothing to `DRAFT_KEYS`, exactly like the section above.
+            */}
+            <ProviderAgreementSettingsSection />
           </div>
         </div>
 

--- a/apps/web/src/components/accounting/ui/settings/provider-agreement-section.tsx
+++ b/apps/web/src/components/accounting/ui/settings/provider-agreement-section.tsx
@@ -1,0 +1,45 @@
+// apps/web/src/components/accounting/ui/settings/provider-agreement-section.tsx
+
+'use client'
+
+// Accounting > Settings > General, under the QuickBooks section: the second
+// door onto the agreement view (plans/accounting/tasks/20-two-authors-one-
+// ledger.md §8.3), for a date somebody picks rather than the period a close
+// console happens to be showing.
+//
+// 🛑 The TABLE is not built here. This file is a heading, a default date and a
+// place to put them; `ProviderAgreementPanel` is the whole of the behaviour and
+// the close console renders the same one. Two copies of a reconciliation table
+// is two answers to one question.
+
+import { ArrowLeftRight } from 'lucide-react'
+import { useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
+import { useSettings } from '~/hooks/use-settings'
+import { today } from '../journal/period-helpers'
+import { ProviderAgreementPanel } from '../provider-agreement/provider-agreement-panel'
+
+/** Same fallback `useLedgerPeriod` uses when the book timezone is unset. */
+const FALLBACK_BOOK_TIME_ZONE = 'UTC'
+
+/**
+ * "Does QuickBooks agree?", for an arbitrary date.
+ *
+ * Defaults to today in the BOOK timezone, not the browser's: an accounting date
+ * is a calendar day in the books' own zone, and defaulting to the viewer's would
+ * put a bookkeeper in Auckland a day ahead of their own ledger.
+ */
+export function ProviderAgreementSettingsSection() {
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const bookTimeZone = (getSetting('accounting.bookTimeZone') as string) || FALLBACK_BOOK_TIME_ZONE
+  const [asOf, setAsOf] = useState(() => today(bookTimeZone))
+
+  return (
+    <SettingsSection
+      icon={ArrowLeftRight}
+      title='Does QuickBooks agree?'
+      description='Compare every account balance here against the connected system, as of any date. A read only - nothing posts, and no statement reads the answer.'>
+      <ProviderAgreementPanel asOf={asOf} onAsOfChange={setAsOf} className='mt-1' />
+    </SettingsSection>
+  )
+}

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -37,7 +37,9 @@ import {
   previewEntry,
   previewJournalEntry,
   previewMonthEnd,
+  readTrialBalance,
   removeChartAccount,
+  resolveAccountingProvider,
   resolvePeriodLock,
   restoreChartAccount,
   retryExport,
@@ -49,6 +51,10 @@ import {
   updateJournalEntry,
   verifyBooksBalance,
 } from '@auxx/lib/postings'
+// The comparison itself is PURE (brief 20 §8.2), so it lives on the client-safe
+// leaf beside the other planners and is imported from there rather than being
+// re-exported through the server barrel for one call site.
+import { planProviderAgreement } from '@auxx/lib/postings/client'
 import { seedChartAccounts, seedChartPacks, seedDefaultPaymentGateways } from '@auxx/lib/seed'
 import { updateOrganizationSetting } from '@auxx/lib/settings'
 import { z } from 'zod'
@@ -1017,6 +1023,88 @@ export const ledgerRouter = createTRPCRouter({
       })
       if (result.isErr()) throw result.error
       return result.value
+    }),
+
+  /**
+   * Do our books and theirs agree as of one date, and if not, where
+   * (plans/accounting/tasks/20-two-authors-one-ledger.md §8).
+   *
+   * Reads the provider's balance sheet and OUR trial balance as of the same
+   * date, joins them through the `qboAccountId` links `chart-import.ts` stamps,
+   * and hands both sides to the pure `planProviderAgreement`. Writes nothing,
+   * posts nothing, and never becomes a statement source - §0.7 holds, this is a
+   * COMPARISON beside the statements and the sync is what will make the
+   * statements complete.
+   *
+   * ⚠️ **This one reaches the provider**, the same caveat {@link accountMap}
+   * carries: it fetches a balance sheet over the app Lambda, so it is slow
+   * relative to its neighbours. Cadence is at close and on demand, never
+   * continuous (§8.3) - do not put it behind a component that runs on mount.
+   *
+   * 🛑 Three outcomes a screen has to be able to tell apart, and only one of
+   * them is an error:
+   *
+   *   1. `not_connected` - nothing is authorized. A complete answer to a read
+   *      (`P1`), not a failure and not an empty agreement.
+   *   2. `ok` with `agreement.providerHasData: false` - connected, and the
+   *      provider answered with an empty company. Distinct from agreement.
+   *   3. `ok` with `agreement.totalDifferenceMinor === 0` - the books agree.
+   *
+   * The only refusal is a provider id claimed by more than one of our accounts,
+   * which `planProviderAgreement` returns as an `err` naming BOTH accounts
+   * (§8.2). It is thrown straight through - there is deliberately no `try/catch`
+   * here, because catching and rethrowing is the only way an `AuxxError` gets
+   * flattened into a generic 500 on its way to `auxxErrorMiddleware`.
+   */
+  providerAgreement: permissionProcedure(PermissionKey.ledgerView)
+    .input(
+      z.object({
+        /** `YYYY-MM-DD`. Both sides are read as of this same day. */
+        asOf: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'asOf must be YYYY-MM-DD'),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const provider = await resolveAccountingProvider(organizationId)
+
+      // Asked FIRST, and on its own: an org with nothing connected has nothing
+      // to compare against, so there is no reason to read our own trial balance
+      // or the account map for it.
+      const sheetResult = await provider.readProviderBalances(organizationId, input.asOf)
+      if (sheetResult.isErr()) throw sheetResult.error
+      const sheet = sheetResult.value
+      if (!sheet) return { status: 'not_connected' as const, asOf: input.asOf }
+
+      const [ours, mappings] = await Promise.all([
+        // Cumulative from the beginning of time - `from` is deliberately
+        // omitted. A balance as of a date is what the provider's balance sheet
+        // reports, and an activity-only window would compare a period's
+        // movement against a running balance.
+        readTrialBalance(ctx.db, { organizationId, to: input.asOf }),
+        provider.listAccountMappings(organizationId),
+      ])
+      if (ours.isErr()) throw ours.error
+      if (mappings.isErr()) throw mappings.error
+
+      const planned = planProviderAgreement({
+        provider: sheet.rows,
+        ours: ours.value.rows,
+        accountMap: mappings.value,
+        // The provider's own `Header.EndPeriod`, already asserted equal to the
+        // `asOf` that was asked for. Echoing the request instead would let a
+        // report the provider silently re-dated render under the wrong day.
+        asOf: sheet.asOf,
+        providerHasData: sheet.hasData,
+      })
+      if (planned.isErr()) throw planned.error
+
+      return {
+        status: 'ok' as const,
+        providerId: provider.id,
+        /** Their reporting currency. Compared against ours by the screen, never converted. */
+        providerCurrency: sheet.currency,
+        agreement: planned.value,
+      }
     }),
 
   /**

--- a/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
+++ b/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
@@ -104,7 +104,9 @@ const logger = createScopedLogger('quickbooks-accounting-provider')
 /** The id this adapter registers under. Must match the connected-provider resolver. */
 export const QUICKBOOKS_PROVIDER_ID = 'quickbooks'
 
-const TOOL_LIST_ACCOUNTS = 'list_quickbooks_accounts'
+// `list_quickbooks_accounts` is NOT declared here: the only caller is
+// `account-map.ts:99`, which owns the string and documents the response shape
+// beside it. A second copy in this file was dead and could only drift.
 const TOOL_FIND_JOURNAL_ENTRY = 'find_quickbooks_journal_entry'
 const TOOL_CREATE_JOURNAL_ENTRY = 'create_quickbooks_journal_entry'
 /** Brief 19 section 3: the opening-balance suggestion's one report read. */
@@ -644,14 +646,15 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
   }
 
   /**
-   * The connected company's balance sheet as of `asOf`, for the
-   * opening-balance suggestion (brief 19).
+   * The connected company's balance sheet as of `asOf` - any date, not just a
+   * cutover. The opening-balance fill (brief 19) is one caller; the agreement
+   * view (brief 20 §8) is another, asking as of a period end.
    *
    * The tool has already normalized sign to debit-positive, parsed money into
    * integer minor units and asserted `Header.EndPeriod === asOf` (brief 19
    * section 3.3) - this adapter does not touch the rows, only the call.
    */
-  async readProviderOpeningBalances(
+  async readProviderBalances(
     orgId: string,
     asOf: string
   ): Promise<Result<ProviderBalanceSheet | null, Error>> {

--- a/packages/lib/src/postings/__tests__/post-entry-export-route.test.ts
+++ b/packages/lib/src/postings/__tests__/post-entry-export-route.test.ts
@@ -238,7 +238,7 @@ function codedEntry(
 /** The account-map half of `AccountingProvider`, stubbed to "nothing mapped, nothing to map". */
 const NO_ACCOUNT_MAP = {
   listProviderAccounts: async () => ok([]),
-  readProviderOpeningBalances: async () => ok(null),
+  readProviderBalances: async () => ok(null),
   listAccountMappings: async () => ok(new Map<string, string>()),
   setAccountMapping: async () => ok(undefined),
   clearAccountMapping: async () => ok(undefined),

--- a/packages/lib/src/postings/__tests__/post-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/post-entry.test.ts
@@ -443,7 +443,7 @@ beforeEach(() => {
  */
 const NO_ACCOUNT_MAP = {
   listProviderAccounts: async () => ok([]),
-  readProviderOpeningBalances: async () => ok(null),
+  readProviderBalances: async () => ok(null),
   listAccountMappings: async () => ok(new Map<string, string>()),
   setAccountMapping: async () => ok(undefined),
   clearAccountMapping: async () => ok(undefined),

--- a/packages/lib/src/postings/__tests__/provider-agreement.test.ts
+++ b/packages/lib/src/postings/__tests__/provider-agreement.test.ts
@@ -1,0 +1,462 @@
+// packages/lib/src/postings/__tests__/provider-agreement.test.ts
+//
+// `planProviderAgreement` is pure - no database, no doubles - so every test
+// here hands it hand-built provider rows and trial-balance rows and reads the
+// comparison back. Sibling of `opening-fill-plan.test.ts`, same shape.
+//
+// The test that matters most is the last describe: our side is
+// `debitMinor - creditMinor`, NEVER `TrialBalanceRow.balanceMinor`, which is
+// natural-sign and would report a matching liability as double its balance.
+
+import { describe, expect, it } from 'vitest'
+import { UnprocessableEntityError } from '../../errors'
+import { planProviderAgreement } from '../provider-agreement'
+import { signedBalance } from '../reports/statement-math'
+import type { TrialBalanceRow } from '../reports/trial-balance'
+import type { ProviderBalanceRow } from '../types'
+
+function ourRow(over: Partial<TrialBalanceRow> = {}): TrialBalanceRow {
+  const base: TrialBalanceRow = {
+    glAccountId: 'acc',
+    accountCode: null,
+    accountName: 'Account',
+    accountType: 'asset',
+    subtype: null,
+    debitMinor: 0,
+    creditMinor: 0,
+    balanceMinor: 0,
+    inChart: true,
+    ...over,
+  }
+  // Keep the fixture honest: `balanceMinor` is whatever the real read would
+  // have computed, so a test that accidentally used it would still pass on an
+  // asset row and fail loudly on a liability one.
+  return {
+    ...base,
+    balanceMinor: base.accountType
+      ? signedBalance(base.debitMinor, base.creditMinor, base.accountType)
+      : 0,
+  }
+}
+
+function theirRow(over: Partial<ProviderBalanceRow> = {}): ProviderBalanceRow {
+  return {
+    providerAccountId: 'p1',
+    name: 'Account',
+    kind: 'account',
+    minorSigned: 0,
+    ...over,
+  }
+}
+
+const ASOF = '2025-12-31'
+
+function plan(input: {
+  provider?: readonly ProviderBalanceRow[]
+  ours?: readonly TrialBalanceRow[]
+  accountMap?: ReadonlyMap<string, string>
+  providerHasData?: boolean
+}) {
+  return planProviderAgreement({
+    provider: input.provider ?? [],
+    ours: input.ours ?? [],
+    accountMap: input.accountMap ?? new Map(),
+    asOf: ASOF,
+    providerHasData: input.providerHasData ?? true,
+  })
+}
+
+describe('a clean match', () => {
+  it('reports zero difference and keeps the agreeing rows', () => {
+    const result = plan({
+      ours: [
+        ourRow({
+          glAccountId: 'checking',
+          accountCode: '1000',
+          accountName: 'Checking',
+          debitMinor: 250_00,
+        }),
+        ourRow({
+          glAccountId: 'ap',
+          accountCode: '2000',
+          accountName: 'Accounts Payable',
+          accountType: 'liability',
+          creditMinor: 90_00,
+        }),
+      ],
+      accountMap: new Map([
+        ['checking', 'p-checking'],
+        ['ap', 'p-ap'],
+      ]),
+      provider: [
+        theirRow({ providerAccountId: 'p-checking', name: 'Checking', minorSigned: 250_00 }),
+        theirRow({ providerAccountId: 'p-ap', name: 'Accounts Payable', minorSigned: -90_00 }),
+      ],
+    })
+
+    expect(result.isOk()).toBe(true)
+    const agreement = result._unsafeUnwrap()
+    expect(agreement.asOf).toBe(ASOF)
+    expect(agreement.totalDifferenceMinor).toBe(0)
+    expect(agreement.hasDifferences).toBe(false)
+    expect(agreement.providerHasData).toBe(true)
+    // `rows` carries the matching accounts too - a screen that only listed
+    // differences could not tell "they agree" from "we read nothing".
+    expect(agreement.rows).toHaveLength(2)
+    expect(agreement.rows.every((row) => row.status === 'match')).toBe(true)
+    expect(agreement.rows.map((row) => row.accountCode)).toEqual(['1000', '2000'])
+  })
+})
+
+describe('a one-account difference', () => {
+  it('names only the account that differs and totals it', () => {
+    const result = plan({
+      ours: [
+        ourRow({
+          glAccountId: 'checking',
+          accountCode: '1000',
+          accountName: 'Checking',
+          debitMinor: 250_00,
+        }),
+        ourRow({
+          glAccountId: 'prepaid',
+          accountCode: '1400',
+          accountName: 'Prepaid Insurance',
+          debitMinor: 1_200_00,
+        }),
+      ],
+      accountMap: new Map([
+        ['checking', 'p-checking'],
+        ['prepaid', 'p-prepaid'],
+      ]),
+      provider: [
+        theirRow({ providerAccountId: 'p-checking', name: 'Checking', minorSigned: 250_00 }),
+        // The accountant amortized a month in QuickBooks and we did not.
+        theirRow({
+          providerAccountId: 'p-prepaid',
+          name: 'Prepaid Insurance',
+          minorSigned: 1_100_00,
+        }),
+      ],
+    })
+
+    const agreement = result._unsafeUnwrap()
+    expect(agreement.totalDifferenceMinor).toBe(100_00)
+    expect(agreement.hasDifferences).toBe(true)
+
+    const prepaid = agreement.rows.find((row) => row.glAccountId === 'prepaid')
+    expect(prepaid).toMatchObject({
+      status: 'differs',
+      providerAccountId: 'p-prepaid',
+      oursMinor: 1_200_00,
+      theirsMinor: 1_100_00,
+      differenceMinor: 100_00,
+    })
+    expect(agreement.rows.find((row) => row.glAccountId === 'checking')?.status).toBe('match')
+  })
+})
+
+describe('a row only they have', () => {
+  it('carries it as only_theirs with no account of ours', () => {
+    const result = plan({
+      ours: [
+        ourRow({
+          glAccountId: 'checking',
+          accountCode: '1000',
+          accountName: 'Checking',
+          debitMinor: 250_00,
+        }),
+      ],
+      accountMap: new Map([['checking', 'p-checking']]),
+      provider: [
+        theirRow({ providerAccountId: 'p-checking', name: 'Checking', minorSigned: 250_00 }),
+        // Depreciation the firm authored, against an account we never mapped.
+        theirRow({
+          providerAccountId: 'p-accum-dep',
+          name: 'Accumulated Depreciation',
+          minorSigned: -4_000_00,
+        }),
+      ],
+    })
+
+    const agreement = result._unsafeUnwrap()
+    const theirs = agreement.rows.find((row) => row.providerAccountId === 'p-accum-dep')
+    expect(theirs).toMatchObject({
+      glAccountId: null,
+      accountCode: null,
+      accountName: 'Accumulated Depreciation',
+      status: 'only_theirs',
+      oursMinor: 0,
+      theirsMinor: -4_000_00,
+      differenceMinor: 4_000_00,
+    })
+    expect(agreement.totalDifferenceMinor).toBe(4_000_00)
+  })
+
+  it('sums two report rows onto one provider account rather than keeping the last', () => {
+    const result = plan({
+      provider: [
+        theirRow({ providerAccountId: 'p-x', name: 'Shared', minorSigned: 10_00 }),
+        theirRow({ providerAccountId: 'p-x', name: 'Shared', minorSigned: 5_00 }),
+      ],
+    })
+
+    const agreement = result._unsafeUnwrap()
+    expect(agreement.rows).toHaveLength(1)
+    expect(agreement.rows[0]?.theirsMinor).toBe(15_00)
+  })
+
+  it('excludes the computed net_income row, which carries no account', () => {
+    const result = plan({
+      provider: [
+        theirRow({ providerAccountId: 'p-checking', name: 'Checking', minorSigned: 250_00 }),
+        { providerAccountId: null, name: 'Net Income', kind: 'net_income', minorSigned: -99_00 },
+      ],
+    })
+
+    const agreement = result._unsafeUnwrap()
+    expect(agreement.rows).toHaveLength(1)
+    expect(agreement.rows[0]?.providerAccountId).toBe('p-checking')
+    expect(agreement.totalDifferenceMinor).toBe(250_00)
+  })
+})
+
+describe('a row only we have', () => {
+  it('carries an unmapped account of ours as only_ours', () => {
+    const result = plan({
+      ours: [
+        ourRow({
+          glAccountId: 'wip',
+          accountCode: '1320',
+          accountName: 'Work in Process',
+          debitMinor: 3_000_00,
+        }),
+      ],
+      provider: [],
+    })
+
+    const agreement = result._unsafeUnwrap()
+    expect(agreement.rows).toHaveLength(1)
+    expect(agreement.rows[0]).toMatchObject({
+      glAccountId: 'wip',
+      providerAccountId: null,
+      accountCode: '1320',
+      accountName: 'Work in Process',
+      status: 'only_ours',
+      oursMinor: 3_000_00,
+      theirsMinor: 0,
+      differenceMinor: 3_000_00,
+    })
+    expect(agreement.totalDifferenceMinor).toBe(3_000_00)
+  })
+
+  it('reads a mapped account the report omits as a difference, not as only_ours', () => {
+    // The provider emits non-zero rows only, so a mapped account missing from
+    // the report is a zero balance over there - a comparison that came out to
+    // a difference, not an account they lack.
+    const result = plan({
+      ours: [
+        ourRow({
+          glAccountId: 'suspense',
+          accountCode: '1999',
+          accountName: 'Suspense',
+          debitMinor: 42_00,
+        }),
+      ],
+      accountMap: new Map([['suspense', 'p-suspense']]),
+      provider: [],
+    })
+
+    expect(result._unsafeUnwrap().rows[0]).toMatchObject({
+      status: 'differs',
+      providerAccountId: 'p-suspense',
+      theirsMinor: 0,
+      differenceMinor: 42_00,
+    })
+  })
+})
+
+describe('a provider id claimed by two of our accounts', () => {
+  it('refuses, naming both of our accounts and the provider id', () => {
+    const result = plan({
+      ours: [
+        ourRow({
+          glAccountId: 'raw',
+          accountCode: '1310',
+          accountName: 'Raw Materials',
+          debitMinor: 1_000_00,
+        }),
+        ourRow({
+          glAccountId: 'fg',
+          accountCode: '1330',
+          accountName: 'Finished Goods',
+          debitMinor: 2_000_00,
+        }),
+      ],
+      accountMap: new Map([
+        ['raw', 'p-inventory'],
+        ['fg', 'p-inventory'],
+      ]),
+      provider: [
+        theirRow({ providerAccountId: 'p-inventory', name: 'Inventory', minorSigned: 3_000_00 }),
+      ],
+    })
+
+    expect(result.isErr()).toBe(true)
+    const error = result._unsafeUnwrapErr()
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toContain('p-inventory')
+    expect(error.message).toContain('1310 Raw Materials')
+    expect(error.message).toContain('1330 Finished Goods')
+  })
+
+  it('falls back to the raw id for a claimant with no trial-balance row', () => {
+    const result = plan({
+      ours: [
+        ourRow({
+          glAccountId: 'raw',
+          accountCode: '1310',
+          accountName: 'Raw Materials',
+          debitMinor: 1_000_00,
+        }),
+      ],
+      accountMap: new Map([
+        ['raw', 'p-inventory'],
+        ['never-posted', 'p-inventory'],
+      ]),
+    })
+
+    const error = result._unsafeUnwrapErr()
+    expect(error.message).toContain('1310 Raw Materials')
+    expect(error.message).toContain('never-posted')
+  })
+})
+
+describe('an empty provider answer', () => {
+  it('is ok with providerHasData false, never an error', () => {
+    const result = plan({
+      ours: [
+        ourRow({
+          glAccountId: 'checking',
+          accountCode: '1000',
+          accountName: 'Checking',
+          debitMinor: 250_00,
+        }),
+      ],
+      accountMap: new Map([['checking', 'p-checking']]),
+      provider: [],
+      providerHasData: false,
+    })
+
+    expect(result.isOk()).toBe(true)
+    const agreement = result._unsafeUnwrap()
+    expect(agreement.providerHasData).toBe(false)
+    // An empty company must not be able to read as "everything agrees".
+    expect(agreement.hasDifferences).toBe(true)
+    expect(agreement.totalDifferenceMinor).toBe(250_00)
+  })
+
+  it('is ok with nothing on either side', () => {
+    const agreement = plan({ providerHasData: false })._unsafeUnwrap()
+    expect(agreement.rows).toEqual([])
+    expect(agreement.totalDifferenceMinor).toBe(0)
+    expect(agreement.hasDifferences).toBe(false)
+    expect(agreement.providerHasData).toBe(false)
+  })
+})
+
+describe('debit-positive on both sides', () => {
+  // 🛑 The regression test. `TrialBalanceRow.balanceMinor` is NATURAL-sign, so
+  // for a liability, equity or revenue account it is the exact negative of the
+  // debit-positive number the provider sends. Using it would report every
+  // agreeing credit-natured account as double its balance.
+  it('agrees with the provider on a liability the two sides both credit', () => {
+    const ap = ourRow({
+      glAccountId: 'ap',
+      accountCode: '2000',
+      accountName: 'Accounts Payable',
+      accountType: 'liability',
+      debitMinor: 10_00,
+      creditMinor: 1_510_00,
+    })
+    // The trap: natural-sign is +1500_00, debit-positive is -1500_00.
+    expect(ap.balanceMinor).toBe(1_500_00)
+
+    const agreement = plan({
+      ours: [ap],
+      accountMap: new Map([['ap', 'p-ap']]),
+      provider: [
+        theirRow({ providerAccountId: 'p-ap', name: 'Accounts Payable', minorSigned: -1_500_00 }),
+      ],
+    })._unsafeUnwrap()
+
+    expect(agreement.rows[0]?.oursMinor).toBe(-1_500_00)
+    expect(agreement.rows[0]?.theirsMinor).toBe(-1_500_00)
+    expect(agreement.rows[0]?.differenceMinor).toBe(0)
+    expect(agreement.rows[0]?.status).toBe('match')
+    expect(agreement.totalDifferenceMinor).toBe(0)
+  })
+
+  it('agrees with the provider on a revenue account', () => {
+    const sales = ourRow({
+      glAccountId: 'sales',
+      accountCode: '4000',
+      accountName: 'Sales',
+      accountType: 'revenue',
+      creditMinor: 80_000_00,
+    })
+    expect(sales.balanceMinor).toBe(80_000_00)
+
+    const agreement = plan({
+      ours: [sales],
+      accountMap: new Map([['sales', 'p-sales']]),
+      provider: [
+        theirRow({ providerAccountId: 'p-sales', name: 'Sales', minorSigned: -80_000_00 }),
+      ],
+    })._unsafeUnwrap()
+
+    expect(agreement.rows[0]?.oursMinor).toBe(-80_000_00)
+    expect(agreement.rows[0]?.differenceMinor).toBe(0)
+    expect(agreement.hasDifferences).toBe(false)
+  })
+
+  it('still finds a real difference on a credit-natured account', () => {
+    const equity = ourRow({
+      glAccountId: 'equity',
+      accountCode: '3000',
+      accountName: 'Retained Earnings',
+      accountType: 'equity',
+      creditMinor: 5_000_00,
+    })
+
+    const agreement = plan({
+      ours: [equity],
+      accountMap: new Map([['equity', 'p-equity']]),
+      provider: [
+        theirRow({
+          providerAccountId: 'p-equity',
+          name: 'Retained Earnings',
+          minorSigned: -4_400_00,
+        }),
+      ],
+    })._unsafeUnwrap()
+
+    expect(agreement.rows[0]?.differenceMinor).toBe(-600_00)
+    expect(agreement.totalDifferenceMinor).toBe(600_00)
+    expect(agreement.rows[0]?.status).toBe('differs')
+  })
+})
+
+describe('the row order', () => {
+  it('sorts by code then name, uncoded rows last', () => {
+    const agreement = plan({
+      ours: [
+        ourRow({ glAccountId: 'b', accountCode: '2000', accountName: 'Bravo', debitMinor: 1 }),
+        ourRow({ glAccountId: 'a', accountCode: '1000', accountName: 'Alpha', debitMinor: 1 }),
+      ],
+      provider: [theirRow({ providerAccountId: 'p-z', name: 'Zulu', minorSigned: 1 })],
+    })._unsafeUnwrap()
+
+    expect(agreement.rows.map((row) => row.accountName)).toEqual(['Alpha', 'Bravo', 'Zulu'])
+  })
+})

--- a/packages/lib/src/postings/__tests__/retry-export.test.ts
+++ b/packages/lib/src/postings/__tests__/retry-export.test.ts
@@ -110,7 +110,7 @@ function stubProvider(answer: (input: PostEntryInput) => Result<PostEntryResult,
   registerAccountingProvider('stub', async () => ({
     id: 'stub',
     listProviderAccounts: async () => ok([]),
-    readProviderOpeningBalances: async () => ok(null),
+    readProviderBalances: async () => ok(null),
     listAccountMappings: async () => ok(new Map<string, string>()),
     setAccountMapping: async () => ok(undefined),
     clearAccountMapping: async () => ok(undefined),

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -232,6 +232,16 @@ export {
   periodKeyForDate,
   periodMonth,
 } from './periods'
+// ── plans/accounting/tasks/20 §8: do our books and theirs agree ─────────────
+// PURE. No database, no io, no clock - reaches only `errors`, `account-label`
+// and two type-only imports. See provider-agreement.ts's own header.
+export {
+  type PlanProviderAgreementInput,
+  type ProviderAgreement,
+  type ProviderAgreementRow,
+  type ProviderAgreementStatus,
+  planProviderAgreement,
+} from './provider-agreement'
 export {
   ENABLED_POSTING_TYPES,
   EXPORT_ROUTE_BY_POSTING_TYPE,

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -301,6 +301,14 @@ export {
   resolveAccountingProvider,
   setConnectedProviderResolver,
 } from './provider'
+// ── plans/accounting/tasks/20 §8: do our books and theirs agree, pure ───────
+export {
+  type PlanProviderAgreementInput,
+  type ProviderAgreement,
+  type ProviderAgreementRow,
+  type ProviderAgreementStatus,
+  planProviderAgreement,
+} from './provider-agreement'
 export { getPosting, readPostingLineSourceIds } from './read-posting'
 export {
   ENABLED_POSTING_TYPES,

--- a/packages/lib/src/postings/opening-trial-balance/__tests__/fill-from-provider.test.ts
+++ b/packages/lib/src/postings/opening-trial-balance/__tests__/fill-from-provider.test.ts
@@ -45,7 +45,7 @@ vi.mock('../../../cache/invalidate', () => ({
 vi.mock('../../provider', () => ({
   resolveAccountingProvider: async () => ({
     id: 'quickbooks',
-    readProviderOpeningBalances: async () => ({ isErr: () => false, value: h.sheet }),
+    readProviderBalances: async () => ({ isErr: () => false, value: h.sheet }),
     listAccountMappings: async () => ({ isErr: () => false, value: h.accountMap }),
   }),
 }))
@@ -241,7 +241,9 @@ describe('fillOpeningTrialBalanceFromProvider', () => {
         ]),
       })
     )
-    expect(h.cacheEvents).toEqual([['org.settings.changed', { orgId: ORG }]])
+    expect(h.cacheEvents).toEqual([
+      ['org.settings.changed', { orgId: ORG, broadcastUserKeys: true }],
+    ])
   })
 
   it('refuses when nothing is connected', async () => {

--- a/packages/lib/src/postings/opening-trial-balance/fill-from-provider.ts
+++ b/packages/lib/src/postings/opening-trial-balance/fill-from-provider.ts
@@ -86,7 +86,7 @@ export async function fillOpeningTrialBalanceFromProvider(
       if (view.isErr()) throw view.error
 
       const provider = await resolveAccountingProvider(organizationId)
-      const sheetResult = await provider.readProviderOpeningBalances(organizationId, cutoverDate)
+      const sheetResult = await provider.readProviderBalances(organizationId, cutoverDate)
       if (sheetResult.isErr()) throw sheetResult.error
       const sheet = sheetResult.value
 

--- a/packages/lib/src/postings/provider-agreement.ts
+++ b/packages/lib/src/postings/provider-agreement.ts
@@ -1,0 +1,311 @@
+// packages/lib/src/postings/provider-agreement.ts
+//
+// Do our books and theirs agree, and if not, where.
+//
+// PURE. No database, no provider, no clock, no io. Same inputs in, same answer
+// out, forever - the same contract `chart-import-plan.ts` and
+// `opening-fill-plan.ts` hold, and for the same reason: this is the piece a
+// person has to trust, so it is the piece that must be testable without a
+// connection.
+//
+// 🛑 This renders a COMPARISON. It never becomes a statement source.
+// `postings/reports/*` read our own rows and only our own rows (brief 20 §0.7),
+// and nothing here changes that. What closes the gap is the sync WRITING rows
+// (§5 to §7), not a report learning to read a provider.
+//
+// @see plans/accounting/tasks/20-two-authors-one-ledger.md §8.2
+
+import { err, ok, type Result } from 'neverthrow'
+import { UnprocessableEntityError } from '../errors'
+import { accountLabel, compareAccountsByCodeThenName } from './account-label'
+import type { TrialBalanceRow } from './reports/trial-balance'
+import type { ProviderBalanceRow } from './types'
+
+/**
+ * How one account came out of the comparison.
+ *
+ * `only_theirs` is the interesting one and it is the whole reason brief 20
+ * exists: an account the provider carries a balance on that our ledger has
+ * never posted to is, by definition, work authored somewhere we do not look.
+ */
+export type ProviderAgreementStatus = 'match' | 'differs' | 'only_ours' | 'only_theirs'
+
+/**
+ * What each status actually asserts, since two of the four are easy to misread:
+ *
+ * | status | means |
+ * |---|---|
+ * | `match` | mapped, both sides read, and they agree |
+ * | `differs` | mapped, both sides read, and they do not - **including when theirs is a genuine zero** |
+ * | `only_ours` | **UNMAPPED.** We hold no provider link, so no comparison was possible. Not "they lack this account" |
+ * | `only_theirs` | a provider row nothing on our side claims - the §1 gap, made visible |
+ */
+
+/**
+ * One account, both sides, debit-positive.
+ *
+ * 🛑 **Debit-positive on BOTH sides, always.** `ProviderBalanceRow.minorSigned`
+ * already arrives that way from the apps-repo tool; our own side is
+ * `debitMinor - creditMinor`, NEVER `TrialBalanceRow.balanceMinor`, which is
+ * natural-sign and would invert every liability, equity and revenue row against
+ * theirs. One convention beats four.
+ */
+export interface ProviderAgreementRow {
+  /** Our `gl_account` instance id. `null` only when the provider row is unmapped. */
+  glAccountId: string | null
+  /**
+   * Their `Account.Id`. `null` when we hold no link for this account.
+   *
+   * ⚠️ **That is "we cannot name their account", not "they do not have one."**
+   * An unmapped account of ours may well exist over there under a name nothing
+   * has joined it to; the comparison cannot see the difference and must not
+   * claim to. {@link ProviderAgreementRow.status} carries the observable fact.
+   */
+  providerAccountId: string | null
+  /** Our current code when we know the account, else null. */
+  accountCode: string | null
+  /** Our name when we know the account, otherwise the provider's rendered name. */
+  accountName: string
+  /** Debit-positive minor units, our side. `0` for `only_theirs`. */
+  oursMinor: number
+  /**
+   * Debit-positive minor units, their side. `0` for `only_ours`.
+   *
+   * ⚠️ `0` here does NOT imply `only_ours`. The provider emits **non-zero rows
+   * only**, so a MAPPED account absent from their report has a genuine zero
+   * balance over there and is a `differs` with `theirsMinor: 0`. That is a real
+   * disagreement worth showing, not a missing account.
+   */
+  theirsMinor: number
+  /** `oursMinor - theirsMinor`. Positive means we carry more debit than they do. */
+  differenceMinor: number
+  status: ProviderAgreementStatus
+}
+
+/**
+ * The whole comparison, as of one date.
+ *
+ * `rows` carries every account either side knows about, including the ones that
+ * agree - a screen that only listed differences could not distinguish "they
+ * agree" from "we failed to read anything".
+ */
+export interface ProviderAgreement {
+  /** The date both sides were read as of, echoed from the provider's own header. */
+  asOf: string
+  rows: readonly ProviderAgreementRow[]
+  /** Sum of `|differenceMinor|` across every row. `0` means the books agree. */
+  totalDifferenceMinor: number
+  /** Convenience: `totalDifferenceMinor !== 0`. */
+  hasDifferences: boolean
+  /**
+   * `ProviderBalanceSheet.hasData`, carried through. `false` means the provider
+   * answered with an empty company, which must render as its own state and
+   * never as "everything agrees" - §8.4's rule, one layer out.
+   */
+  providerHasData: boolean
+}
+
+export interface PlanProviderAgreementInput {
+  /** `ProviderBalanceSheet.rows`. `kind: 'net_income'` rows carry no account and are excluded. */
+  provider: readonly ProviderBalanceRow[]
+  /** `readTrialBalance(...).rows` for the same date, cumulative from the beginning. */
+  ours: readonly TrialBalanceRow[]
+  /** `glAccountId` -> `providerAccountId`, from the links `chart-import.ts` stamps. */
+  accountMap: ReadonlyMap<string, string>
+  /** Echoed onto the result. */
+  asOf: string
+  /** `ProviderBalanceSheet.hasData`. */
+  providerHasData: boolean
+}
+
+/**
+ * Compare a provider's balances against our trial balance, account by account.
+ *
+ * 🛑 **Builds the inverse map by COLLECTING, not overwriting.** Nothing in the
+ * schema enforces that the provider link is one-to-one:
+ * `setQuickbooksAccountMapping` writes one cell on one record and never checks
+ * whether another `gl_account` already claims the same `providerAccountId`
+ * (brief 19 §0.6 found this and it is still unfixed). A provider id claimed by
+ * more than one of our accounts is a **refusal naming both**, never a guess
+ * about which one the money belongs to.
+ *
+ * This is the same correction the opening-trial-balance overlay needed one
+ * layer over, in the ROLE map, where `set`-per-role silently dropped every
+ * inventory role but the last on a shared account (#2112). Collect and sum;
+ * never `set` in a loop over something that can repeat.
+ *
+ * @returns `err` only for a double-claimed provider id. An empty provider
+ *   answer is a valid result with `providerHasData: false`, not an error.
+ */
+export function planProviderAgreement(
+  input: PlanProviderAgreementInput
+): Result<ProviderAgreement, Error> {
+  const { provider, ours, accountMap, asOf, providerHasData } = input
+
+  // Our side, debit-positive, by account id. NEVER `balanceMinor` - that is
+  // natural-sign, so it would arrive positive for a liability, an equity or a
+  // revenue account and read as the exact negative of theirs on every one of
+  // them. `debitMinor - creditMinor` is the one convention both sides share.
+  const oursMinorById = new Map<string, number>()
+  const ourRowById = new Map<string, TrialBalanceRow>()
+  for (const row of ours) {
+    oursMinorById.set(
+      row.glAccountId,
+      (oursMinorById.get(row.glAccountId) ?? 0) + ourDebitPositive(row)
+    )
+    ourRowById.set(row.glAccountId, row)
+  }
+
+  // §8.2: invert the account map by COLLECTING, never `set`-per-iteration.
+  // Nothing in the schema stops two of our accounts naming one provider
+  // account, and the one thing this must not do is pick a winner.
+  const glAccountIdsByProviderId = new Map<string, string[]>()
+  for (const [glAccountId, providerAccountId] of accountMap) {
+    const claimants = glAccountIdsByProviderId.get(providerAccountId) ?? []
+    claimants.push(glAccountId)
+    glAccountIdsByProviderId.set(providerAccountId, claimants)
+  }
+  for (const [providerAccountId, claimants] of glAccountIdsByProviderId) {
+    if (claimants.length < 2) continue
+    const labels = claimants.map((id) => ourAccountLabel(ourRowById.get(id), id))
+    return err(
+      new UnprocessableEntityError(
+        `Provider account '${providerAccountId}' is mapped from more than one account in your ` +
+          `chart: ${labels.join(' and ')}. Fix the extra mapping on the Account map page before ` +
+          'comparing - the comparison cannot guess which one the money belongs to.',
+        { providerAccountId, glAccountIds: claimants.join(',') }
+      )
+    )
+  }
+
+  // Their side, summed by provider account id. The same collect-and-sum rule:
+  // a report that renders one account across two rows must not lose one.
+  // `net_income` is computed and carries no account, so it is not comparable
+  // and is excluded rather than folded anywhere.
+  const theirsMinorById = new Map<string, number>()
+  const theirNameById = new Map<string, string>()
+  const unidentifiedTheirs: ProviderBalanceRow[] = []
+  for (const row of provider) {
+    if (row.kind === 'net_income') continue
+    if (row.providerAccountId === null) {
+      unidentifiedTheirs.push(row)
+      continue
+    }
+    const id = row.providerAccountId
+    theirsMinorById.set(id, (theirsMinorById.get(id) ?? 0) + row.minorSigned)
+    if (!theirNameById.has(id)) theirNameById.set(id, row.name)
+  }
+
+  const rows: ProviderAgreementRow[] = []
+  const claimedProviderIds = new Set<string>()
+
+  // Every account of ours that has a trial-balance row, plus every account of
+  // ours that is linked to a provider account the report carries - the second
+  // is the account we have never posted to, which reads `0` against their
+  // balance and is the whole point of the view.
+  const ourAccountIds = new Set<string>([...oursMinorById.keys()])
+  for (const [glAccountId, providerAccountId] of accountMap) {
+    if (theirsMinorById.has(providerAccountId)) ourAccountIds.add(glAccountId)
+  }
+
+  for (const glAccountId of ourAccountIds) {
+    const ourRow = ourRowById.get(glAccountId)
+    const providerAccountId = accountMap.get(glAccountId) ?? null
+    const oursMinor = oursMinorById.get(glAccountId) ?? 0
+    // A MAPPING is what makes the two sides comparable, not a row in the
+    // report: the report carries non-zero rows only, so a mapped account
+    // missing from it has a zero balance over there, which is a comparison
+    // that came out to a difference rather than an account they lack. Only an
+    // UNMAPPED account is `only_ours` - there we genuinely cannot say.
+    if (providerAccountId !== null) claimedProviderIds.add(providerAccountId)
+    const theirsMinor =
+      providerAccountId !== null ? (theirsMinorById.get(providerAccountId) ?? 0) : 0
+    const differenceMinor = oursMinor - theirsMinor
+    rows.push({
+      glAccountId,
+      providerAccountId,
+      accountCode: ourRow?.accountCode ?? null,
+      accountName:
+        ourRow?.accountName ||
+        (providerAccountId !== null ? (theirNameById.get(providerAccountId) ?? '') : ''),
+      oursMinor,
+      theirsMinor,
+      differenceMinor,
+      status:
+        providerAccountId === null ? 'only_ours' : differenceMinor === 0 ? 'match' : 'differs',
+    })
+  }
+
+  // Theirs, unclaimed by any account of ours.
+  for (const [providerAccountId, theirsMinor] of theirsMinorById) {
+    if (claimedProviderIds.has(providerAccountId)) continue
+    rows.push({
+      glAccountId: null,
+      providerAccountId,
+      accountCode: null,
+      accountName: theirNameById.get(providerAccountId) ?? providerAccountId,
+      oursMinor: 0,
+      theirsMinor,
+      differenceMinor: -theirsMinor,
+      status: 'only_theirs',
+    })
+  }
+
+  // An `account` row with no id is out of the provider contract, but dropping
+  // it would silently shrink the difference. It is carried as theirs, named,
+  // with both ids null - `status` is what disambiguates it from a row of ours.
+  for (const row of unidentifiedTheirs) {
+    rows.push({
+      glAccountId: null,
+      providerAccountId: null,
+      accountCode: null,
+      accountName: row.name,
+      oursMinor: 0,
+      theirsMinor: row.minorSigned,
+      differenceMinor: -row.minorSigned,
+      status: 'only_theirs',
+    })
+  }
+
+  rows.sort(compareAgreementRows)
+
+  const totalDifferenceMinor = rows.reduce((sum, row) => sum + Math.abs(row.differenceMinor), 0)
+
+  return ok({
+    asOf,
+    rows,
+    totalDifferenceMinor,
+    hasDifferences: totalDifferenceMinor !== 0,
+    providerHasData,
+  })
+}
+
+/**
+ * 🛑 Debit-positive, from the two raw sums. `TrialBalanceRow.balanceMinor` is
+ * natural-sign and is the wrong number here - see {@link ProviderAgreementRow}.
+ */
+function ourDebitPositive(row: TrialBalanceRow): number {
+  return row.debitMinor - row.creditMinor
+}
+
+/** How one of our accounts is named in the refusal. Falls back to the raw id. */
+function ourAccountLabel(row: TrialBalanceRow | undefined, glAccountId: string): string {
+  if (!row || !row.accountName) return glAccountId
+  return accountLabel({ code: row.accountCode, name: row.accountName })
+}
+
+/**
+ * Task 15 §5's one sort - code, then name, uncoded last - with the two ids as
+ * a final tiebreak so the order is total. Two accounts may legitimately share
+ * a name, and a comparison a person re-runs must come back in the same order.
+ */
+function compareAgreementRows(a: ProviderAgreementRow, b: ProviderAgreementRow): number {
+  const byAccount = compareAccountsByCodeThenName(
+    { code: a.accountCode, name: a.accountName },
+    { code: b.accountCode, name: b.accountName }
+  )
+  if (byAccount !== 0) return byAccount
+  const byOurs = (a.glAccountId ?? '').localeCompare(b.glAccountId ?? '')
+  if (byOurs !== 0) return byOurs
+  return (a.providerAccountId ?? '').localeCompare(b.providerAccountId ?? '')
+}

--- a/packages/lib/src/postings/provider.ts
+++ b/packages/lib/src/postings/provider.ts
@@ -36,8 +36,8 @@ export const NONE_PROVIDER_ID = 'none'
  * methods" this docblock used to claim went stale when `G19`'s account-mapping
  * and identity work grew the interface, and brief 19 adds one more on top:
  * resolve a code, post an entry, read the provider's own chart, read and write
- * its account map, and read its balance sheet for the opening-balance
- * suggestion. Everything else an accounting integration does - customers,
+ * its account map, and read its balance sheet as of a date. Everything else an
+ * accounting integration does - customers,
  * invoices, payments - still belongs to the app that owns that integration;
  * this interface is only the posting and chart-mapping seam.
  */
@@ -86,12 +86,19 @@ export interface AccountingProvider {
   listProviderAccounts(orgId: string): Promise<Result<ProviderAccount[], Error>>
 
   /**
-   * The connected system's balance sheet as of one date, for the
-   * opening-balance suggestion (brief 19). Null means nothing is connected,
-   * which is a complete answer to a read - the same argument
-   * {@link listProviderAccounts} makes.
+   * The connected system's balance sheet as of ANY date.
+   *
+   * 🛑 Not opening-specific, which is why the name no longer says so. The
+   * opening-balance fill (brief 19) is one caller, asking as of the cutover
+   * date; the agreement view (brief 20 §8) is another, asking as of a period
+   * end or an arbitrary date a person picked. Two provider methods differing
+   * only in what the caller intends to do with the answer is the duplication
+   * that gets one of them fixed and not the other.
+   *
+   * Null means nothing is connected, which is a complete answer to a read -
+   * the same argument {@link listProviderAccounts} makes.
    */
-  readProviderOpeningBalances(
+  readProviderBalances(
     orgId: string,
     asOf: string
   ): Promise<Result<ProviderBalanceSheet | null, Error>>
@@ -183,7 +190,7 @@ class NoneAccountingProvider implements AccountingProvider {
    * connected" is a complete answer to a read, not a setup step somebody has
    * skipped.
    */
-  async readProviderOpeningBalances(): Promise<Result<ProviderBalanceSheet | null, Error>> {
+  async readProviderBalances(): Promise<Result<ProviderBalanceSheet | null, Error>> {
     return ok(null)
   }
 

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -839,9 +839,9 @@ export interface ProviderBalanceRow {
 
 /**
  * A connected provider's balance sheet as of one date - the source for the
- * opening-balance suggestion (plans/accounting/tasks/19 section 3.3), and what
- * `AccountingProvider.readProviderOpeningBalances` returns unchanged from the
- * tool.
+ * opening-balance suggestion (plans/accounting/tasks/19 section 3.3) and for
+ * the agreement view (plans/accounting/tasks/20 section 8), and what
+ * `AccountingProvider.readProviderBalances` returns unchanged from the tool.
  */
 export interface ProviderBalanceSheet {
   /** `Header.EndPeriod`, asserted equal to the `asOf` that was asked for. */


### PR DESCRIPTION
The QuickBooks seam has only ever written. #2110 opened the first inbound read; this is the first thing built on it.

**One question: do our books and theirs agree, and if not, where.** No writes, no new posting type, no chart mapping beyond the `qboAccountId` links the chart import already stamps.

## The rename

`readProviderOpeningBalances` → `readProviderBalances`, across 8 files, no deprecated alias.

The method was never opening-specific: it takes an arbitrary `asOf` and always did. Two provider methods differing only in what the caller intends to do with the answer is the duplication that gets one of them fixed and not the other. The accounting subsystem is not live, so a clean rename beats a compatibility shim.

## The planner

`packages/lib/src/postings/provider-agreement.ts` is pure - no db, no io, no clock - and tested the way `chart-import-plan.ts` and `opening-fill-plan.ts` are. Two things in it are load-bearing:

**Debit-positive on both sides.** Theirs (`minorSigned`) already is. Ours is `debitMinor - creditMinor`, and **never** `TrialBalanceRow.balanceMinor`, which is natural-sign and would invert every liability, equity and revenue row against theirs. Three regression tests (liability, revenue, equity) fail loudly if anyone reaches for it, and their fixtures compute `balanceMinor` with the real `signedBalance` so the trap is honest rather than staged.

**The inverse provider map is built by collecting, not overwriting.** Nothing enforces that the provider link is one-to-one - `setQuickbooksAccountMapping` writes one cell and never checks whether another `gl_account` already claims the same `providerAccountId`. So a provider id claimed by two of our accounts is a **refusal naming both**, never a guess about which one the money belongs to.

That is the same correction #2112 had to make one layer over, in the *role* map, where `set`-per-role silently dropped every inventory role but the last on a shared account. Same shape, same fix: never `set` in a loop over something that can repeat.

## `only_ours` means unmapped

Worth calling out because it is easy to misread and easy to ship wrong. The provider emits **non-zero rows only**, so a *mapped* account absent from their report has a genuine zero balance over there - that is a `differs` with `theirsMinor: 0`, not an account they lack.

`only_ours` therefore means we hold no provider link and **no comparison was possible**. The badge reads "Not mapped". Labelling it "Only in auxx.ai" would have been a lie, and the type now documents the distinction.

## The procedure and the screen

`ledger.providerAgreement`, on `PermissionKey.ledgerView` like every sibling accounting read. It reads the provider first and alone, then our trial balance (cumulative, no `from` - a balance sheet is a position, not a period's movement) and the account map.

No `try`/`catch`: every refusal is an `AuxxError` thrown straight through to `auxxErrorMiddleware`, so there is no rethrow to flatten. The double-claim refusal reaches the browser verbatim, naming both accounts, and renders as a blocker with a link to the account map.

**Three empty states stay distinguishable**, because a screen that conflates them is worse than no screen:

| State | Renders as |
|---|---|
| Nothing connected | the connect copy, button disabled |
| Empty company on their side (`providerHasData: false`) | "no balances as of `<date>` … that is not agreement, it is an empty set of books on their side" |
| Genuine agreement | "The books agree", with the rows |

Rows sort `only_theirs` first, largest difference first, and the finding card **names** those accounts rather than counting them. A balance the provider carries that our ledger has never posted to is work authored somewhere we do not look, which is the entire point of the feature.

Cadence is on demand only - no polling, no job, no refetch interval. The drift this detects is the accountant's adjusting work, and that happens at close, not on a Tuesday.

Accounts render through `AccountLabel`; no `${code} ${name}` composition anywhere.

## Also

Drops a dead `TOOL_LIST_ACCOUNTS`. The only caller is `account-map.ts:99`, which owns the string beside the response shape it documents; the second copy could only drift.

## Verification

| Check | Result |
|---|---|
| `vitest run src/postings` | **1262/1262**, 65 files |
| `vitest run src/money/quickbooks` | 52/52 |
| `provider-agreement.test.ts` | 15 tests |
| `pnpm --filter @auxx/web typecheck` | clean |
| lib ratchet | no new errors (27, baseline 27) |
| web ratchet | no new errors (0, baseline 0) |
| biome | clean |

## Known gaps, deliberate

- **`ProviderAgreement` carries no currency.** The procedure returns `providerCurrency` alongside and the panel states a mismatch out loud rather than comparing silently. The opening-balance fill *refuses* on mismatch because it writes; a read warns. If that split is wrong the fix is a field on the type.
- **`totalDifferenceMinor` is a sum of absolute differences**, so no "Total" row is rendered - its third cell would not equal cell 1 minus cell 2. The verdict strip says it in words.
- **Rows have no stable key.** A provider row with a null id yields both ids null, so two would collide; the UI keys on the sorted index, which is safe only because the sort is total.

https://claude.ai/code/session_01SnnNtETzUo1YEyeuKw1SoK
