### PR TITLE
feat(accounting): somewhere to put rent, and the report the accountant asks for first

### DIFF
--- a/apps/web/src/app/(protected)/app/accounting/reports/[report]/page.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/reports/[report]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import type { ComponentType } from 'react'
 import { AgingReportPage } from '~/components/accounting/ui/reports/aging-report'
 import { BalanceSheetReportPage } from '~/components/accounting/ui/reports/balance-sheet'
+import { GeneralLedgerReportPage } from '~/components/accounting/ui/reports/general-ledger'
 import { ProfitAndLossReportPage } from '~/components/accounting/ui/reports/profit-and-loss'
 import { TrialBalanceReportPage } from '~/components/accounting/ui/reports/trial-balance'
 import { Vendor1099ReportPage } from '~/components/accounting/ui/reports/vendor-1099-report'
@@ -12,6 +13,9 @@ const REPORT_PAGES: Record<string, ComponentType> = {
   'trial-balance': TrialBalanceReportPage,
   'balance-sheet': BalanceSheetReportPage,
   'profit-and-loss': ProfitAndLossReportPage,
+  // tasks/21 §5: the sixth statement, and the one a filing accountant asks
+  // for first.
+  'general-ledger': GeneralLedgerReportPage,
   // HANDOFF slot 2H
   'ar-aging': () => <AgingReportPage side='receivable' />,
   'ap-aging': () => <AgingReportPage side='payable' />,

--- a/apps/web/src/app/(protected)/app/accounting/reports/layout.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/reports/layout.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import { MainPageContent } from '@auxx/ui/components/main-page'
-import { Building2, FileText, ListChecks, Scale, TrendingUp, Users } from 'lucide-react'
+import { BookOpen, Building2, FileText, ListChecks, Scale, TrendingUp, Users } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import SidebarSecondary from '~/components/global/sidebar-secondary'
 import type { SidebarProps } from '~/constants/menu'
@@ -12,7 +12,8 @@ import type { SidebarProps } from '~/constants/menu'
  * Reports navigation (`plans/accounting/ui-plan.md` §1.2, §2.4): a
  * `SidebarSecondary`, the same idiom `accounting/settings/layout.tsx` uses.
  * Wave 1E shipped the three financial statements; wave 2H (this pass) adds
- * A/R aging, A/P aging and the 1099 summary on the same parts. Clearing
+ * A/R aging, A/P aging and the 1099 summary on the same parts; tasks/21 §5
+ * adds the general ledger, the sixth statement. Clearing
  * (2G phase C's payout report) stays a commented placeholder - left as code,
  * not a wired route, so the next agent finds the slot rather than
  * reinventing it.
@@ -43,6 +44,13 @@ const REPORTS_NAV: SidebarProps[] = [
         slug: 'profit-and-loss',
         icon: <TrendingUp />,
         description: 'Revenue and expense over a range',
+      },
+      {
+        id: 'accounting-reports-general-ledger',
+        label: 'General ledger',
+        slug: 'general-ledger',
+        icon: <BookOpen />,
+        description: 'Every posted line over a range, grouped by account',
       },
       {
         id: 'accounting-reports-ar-aging',

--- a/apps/web/src/components/accounting/ui/reports/general-ledger.tsx
+++ b/apps/web/src/components/accounting/ui/reports/general-ledger.tsx
@@ -1,0 +1,262 @@
+// apps/web/src/components/accounting/ui/reports/general-ledger.tsx
+
+'use client'
+
+import { GENERAL_LEDGER_COLUMNS, toCsvRows } from '@auxx/lib/postings/client'
+import { Button } from '@auxx/ui/components/button'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { BookOpen, TriangleAlert } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useQueryState } from 'nuqs'
+import { useMemo } from 'react'
+import { useLedgerPeriod } from '~/components/accounting/hooks/use-ledger-period'
+import { EmptyState } from '~/components/global/empty-state'
+import { downloadCsv } from '~/lib/csv'
+import { api } from '~/trpc/react'
+import { CompletenessBanner } from './completeness-banner'
+import { ReportErrorCard } from './report-error-card'
+import {
+  periodEndDate,
+  periodKeyFromDate,
+  periodStartDate,
+  toStatementTableRows,
+} from './report-helpers'
+import { ReportToolbar } from './report-toolbar'
+import { StatementTable } from './statement-table'
+
+/**
+ * What a truncated ledger says on the screen.
+ *
+ * 🛑 This is the THIRD place the same fact is stated, not the only one.
+ * `toGeneralLedgerRows` prepends its own `INCOMPLETE` row ahead of every
+ * account, so the warning is already row 1 of the table, row 1 of the CSV and
+ * row 1 of the PDF - the exports carry it because they render the same rows
+ * this page does. This card and the verdict strip below the table are the
+ * screen's own, louder copies, because a person scanning figures reads a
+ * bordered red card and does not read row 1.
+ */
+const TRUNCATED_HEADLINE = 'This general ledger is incomplete'
+
+/**
+ * `/app/accounting/reports/general-ledger` (`plans/accounting/tasks/
+ * 21-the-books-stand-alone.md` §5) - the sixth statement, and the one a
+ * filing accountant asks for first.
+ *
+ * A from/to RANGE like the P&L, not an as-of point: a general ledger is every
+ * posted line over a period, one section per account, each with its opening
+ * balance, its lines and its ending balance. The row model, the toolbar, the
+ * completeness banner and the drill-down are all the siblings' - see
+ * `trial-balance.tsx` for the shape.
+ *
+ * 🛑 The one thing this report does that the other five do not is
+ * `truncated`. Every other statement is bounded by the CHART; this one is
+ * bounded by TRANSACTION VOLUME, so a wide range hits the router's
+ * `GENERAL_LEDGER_MAX_LINES` cap and comes back partial - and a partial
+ * general ledger does not tie to the trial balance for the same range, with
+ * nothing in the figures to say why. It is stated FOUR times when it happens:
+ * the adapter's own `INCOMPLETE` first row (which is what reaches the CSV and
+ * the PDF), `TruncatedBanner` above the table, the verdict strip below it, and
+ * the `-INCOMPLETE` suffix on the CSV filename.
+ */
+export function GeneralLedgerReportPage() {
+  const period = useLedgerPeriod()
+  const router = useRouter()
+  const [fromParam, setFromParam] = useQueryState('from')
+  const [toParam, setToParam] = useQueryState('to')
+
+  // The current period, same default the P&L takes - the month a person is
+  // working in is the range they almost always want, and it is also the range
+  // least likely to truncate.
+  const fallbackKey = period.resolvedPeriodKey
+  const from = fromParam || (fallbackKey ? periodStartDate(fallbackKey) : '')
+  const to = toParam || (fallbackKey ? periodEndDate(fallbackKey) : '')
+
+  const query = api.ledgerReports.generalLedger.useQuery({ from, to }, { enabled: !!from && !!to })
+  const renderPdf = api.ledgerReports.renderStatementPdf.useMutation({
+    onError: (error) => toastError({ title: 'Error generating PDF', description: error.message }),
+  })
+
+  const truncated = !!query.data?.truncated
+
+  function handleDownloadPdf() {
+    renderPdf.mutate(
+      { kind: 'general-ledger', from, to },
+      {
+        onSuccess: ({ assetId }) =>
+          window.open(`/api/files/download/asset:${assetId}`, '_blank', 'noopener,noreferrer'),
+      }
+    )
+  }
+
+  function handleDownloadCsv() {
+    if (!query.data) return
+    // `rows[0]` is already the adapter's `INCOMPLETE` row when the read
+    // truncated, so the warning is in the file without anything being added
+    // here. The FILENAME is this page's own contribution: a file that gets
+    // forwarded, renamed or attached is read by its name long before anyone
+    // opens it.
+    downloadCsv(
+      toCsvRows(query.data.rows, GENERAL_LEDGER_COLUMNS, period.currencyCode),
+      `general-ledger-${from}-to-${to}${truncated ? '-INCOMPLETE' : ''}.csv`
+    )
+  }
+
+  const rows = query.data ? toStatementTableRows(query.data.rows) : []
+  const isEmpty = !!query.data && query.data.accounts.length === 0
+  const txnDateByPostingId = useMemo(() => buildTxnDateIndex(query.data?.accounts), [query.data])
+
+  // One `MainPageContent` per screen, and it is the reports LAYOUT's - see
+  // `accounting/settings/layout.tsx` for the same split. A second one here
+  // nested a `PanelFrame` inside a `PanelFrame`, which doubled the border and
+  // the padding on every report.
+  return (
+    <div className='flex h-full min-h-0 w-full flex-1 flex-col'>
+      <ReportToolbar
+        mode='range'
+        periodOptions={period.options}
+        fromPeriodKey={from ? periodKeyFromDate(from) : undefined}
+        toPeriodKey={to ? periodKeyFromDate(to) : undefined}
+        onSelectFrom={(key) => void setFromParam(periodStartDate(key))}
+        onSelectTo={(key) => void setToParam(periodEndDate(key))}
+        onDownloadPdf={handleDownloadPdf}
+        onDownloadCsv={handleDownloadCsv}
+        isDownloadingPdf={renderPdf.isPending}
+        // 🛑 Both exports stay ENABLED while the ledger is truncated, and that
+        // is a deliberate call. `renderStatementPdf` reads under the SAME
+        // `GENERAL_LEDGER_MAX_LINES` cap and renders through the SAME
+        // `toGeneralLedgerRows`, so the printed copy opens on the identical
+        // `INCOMPLETE` row the screen does - the export cannot leave the
+        // building looking finished. Disabling them would only push a person
+        // toward screenshotting a partial ledger instead, which carries no
+        // warning at all.
+        disabled={!from || !to}
+      />
+      <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
+        <div className='mx-auto flex w-full max-w-5xl flex-1 flex-col gap-3 p-4'>
+          {truncated && <TruncatedBanner maxLines={query.data?.maxLines} />}
+          <CompletenessBanner asOf={to} />
+          {period.isLoading ? (
+            <Skeleton className='h-64 w-full' />
+          ) : !from || !to ? (
+            // No periods exist for this org at all - setup was never
+            // finalized, so there is no month for a ledger to cover. Distinct
+            // from `isEmpty` below (periods exist, nothing posted in the
+            // range), and see `trial-balance.tsx`'s matching branch.
+            <EmptyState
+              icon={BookOpen}
+              title='Nothing has posted yet'
+              description='The general ledger has no lines to show until the ledger is set up and something posts to it.'
+              button={
+                <Button asChild variant='outline' size='sm'>
+                  <Link href='/app/accounting'>Go to the ledger</Link>
+                </Button>
+              }
+            />
+          ) : query.isPending ? (
+            <Skeleton className='h-64 w-full' />
+          ) : query.error ? (
+            <ReportErrorCard message={query.error.message} />
+          ) : isEmpty ? (
+            // Not an error and not a setup problem: the books are fine, this
+            // range simply has no posted lines in it.
+            <EmptyState
+              icon={BookOpen}
+              title='No posted lines in this range'
+              description='Nothing posted between these two dates. Widen the range, or pick a month with activity.'
+            />
+          ) : (
+            <StatementTable
+              columns={GENERAL_LEDGER_COLUMNS}
+              rows={rows}
+              currency={period.currencyCode}
+              searchable
+              expandAllByDefault
+              verdict={
+                query.data
+                  ? truncated
+                    ? {
+                        label: TRUNCATED_HEADLINE,
+                        ok: false,
+                        detail: 'Debits and credits cannot tie on a partial read.',
+                      }
+                    : { label: 'Debits = Credits', ok: query.data.balanced }
+                  : undefined
+              }
+              onRowClick={(row) => {
+                const glPostingId = row.meta?.glPostingId
+                if (!glPostingId) return
+                const txnDate = txnDateByPostingId.get(glPostingId)
+                if (!txnDate) return
+                // The same destination `AccountLinesDialog`'s doc-number links
+                // use: the posting, open on the ledger page for the month the
+                // line actually landed in.
+                router.push(`/app/accounting/${periodKeyFromDate(txnDate)}?posting=${glPostingId}`)
+              }}
+            />
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}
+
+/**
+ * `glPostingId` -> the date that posting landed on, for the drill-down route.
+ *
+ * The row carries the posting id itself on `meta.glPostingId`
+ * (`toGeneralLedgerRows` sets it), so the only thing still missing is the
+ * month to open the ledger page at. That comes from the SAME typed response,
+ * keyed on a real id rather than on a composed row-id string.
+ *
+ * ⚠️ An earlier version keyed this map on the adapter's row `id`
+ * (`account:posting:date:docNumber`), which coupled this file to a string
+ * shape assembled in lib. `meta.glPostingId` was added to the row contract to
+ * retire that; do not reintroduce id parsing here.
+ *
+ * The opening-balance and "Ending balance" rows never appear: they carry no
+ * `glPostingId` because they are positions, not entries, and there is nothing
+ * to open.
+ */
+function buildTxnDateIndex(
+  accounts: readonly { lines: readonly { glPostingId: string; txnDate: string }[] }[] | undefined
+): Map<string, string> {
+  const index = new Map<string, string>()
+  for (const account of accounts ?? []) {
+    for (const line of account.lines) index.set(line.glPostingId, line.txnDate)
+  }
+  return index
+}
+
+/**
+ * The warning above the table.
+ *
+ * `ReportErrorCard`'s destructive tone rather than `CompletenessBanner`'s
+ * neutral one, and deliberately: completeness says "here is what this report
+ * does not cover", which is context. This says "the numbers under this are
+ * wrong", which is a refusal to be read past. It sits ABOVE the completeness
+ * banner for the same reason.
+ */
+function TruncatedBanner({ maxLines }: { maxLines?: number }) {
+  return (
+    <div className='flex items-start gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4'>
+      <TriangleAlert className='mt-0.5 size-5 shrink-0 text-destructive' />
+      <div className='flex flex-col gap-1'>
+        <span className='font-medium'>{TRUNCATED_HEADLINE}</span>
+        <p className='text-sm'>
+          This range is bigger than one read can return
+          {maxLines ? `, so it stopped at ${maxLines.toLocaleString('en-US')} lines` : ''}. The
+          accounts and figures below are only part of the ledger, and they will not tie to the trial
+          balance for the same range.{' '}
+          <span className='font-medium'>Narrow the range - a month at a time always fits.</span>
+        </p>
+        <p className='text-muted-foreground text-sm'>
+          The CSV and the PDF are still available and carry this same warning as their first row,
+          but neither one is a ledger you can file against until the range fits.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/reports/report-helpers.ts
+++ b/apps/web/src/components/accounting/ui/reports/report-helpers.ts
@@ -172,6 +172,7 @@ export function toStatementTableRows(rows: readonly LibStatementRow[]): Statemen
           accountType: row.meta.accountType,
           recordId:
             row.meta.recordId && isRecordId(row.meta.recordId) ? row.meta.recordId : undefined,
+          glPostingId: row.meta.glPostingId,
           badge: row.meta.badge,
           note: row.meta.note,
         }

--- a/apps/web/src/components/accounting/ui/reports/statement-table.tsx
+++ b/apps/web/src/components/accounting/ui/reports/statement-table.tsx
@@ -50,6 +50,12 @@ export interface StatementRow {
     /** Statement classification - the row's icon, via `GL_ACCOUNT_TYPE_META`. */
     accountType?: string
     recordId?: RecordId
+    /**
+     * The `GlPosting` behind this row, when the row IS one posting's line.
+     * The general ledger's drill-down key; see `rows.ts` in lib for why a
+     * posting fits neither `glAccountId` nor `recordId`.
+     */
+    glPostingId?: string
     badge?: ReactNode
     note?: string
   }

--- a/apps/web/src/server/api/routers/ledger-reports.ts
+++ b/apps/web/src/server/api/routers/ledger-reports.ts
@@ -1,8 +1,9 @@
 // apps/web/src/server/api/routers/ledger-reports.ts
 //
 // Statements: trial balance, balance sheet, profit and loss, completeness,
-// account drill-down and the statement PDF (plans/accounting/HANDOFF.md slot
-// 1E; aging in 2H). Mounted as `ledgerReports` in `root.ts` by wave 0.
+// account drill-down, the general ledger and the statement PDF
+// (plans/accounting/HANDOFF.md slot 1E; aging in 2H; the general ledger is
+// task 21 §5). Mounted as `ledgerReports` in `root.ts` by wave 0.
 //
 // Every procedure is `ledgerView` - even `renderStatementPdf`, which writes a
 // file but writes nothing to the LEDGER. Zod here checks SHAPE only
@@ -17,10 +18,13 @@ import { PermissionKey } from '@auxx/lib/permissions'
 import {
   AGING_COLUMNS,
   balanceSheetColumns,
+  GENERAL_LEDGER_COLUMNS,
+  GENERAL_LEDGER_MAX_LINES,
   readAccountLines,
   readAging,
   readBalanceSheet,
   readCompleteness,
+  readGeneralLedger,
   readProfitAndLoss,
   readTrialBalance,
   readVendor1099Summary,
@@ -28,6 +32,7 @@ import {
   TRIAL_BALANCE_COLUMNS,
   toAgingRows,
   toBalanceSheetRows,
+  toGeneralLedgerRows,
   toProfitAndLossRows,
   toTrialBalanceRows,
   toVendor1099Rows,
@@ -150,6 +155,39 @@ export const ledgerReportsRouter = createTRPCRouter({
     }),
 
   /**
+   * The general ledger over `[from, to]`: every posted line, grouped by
+   * account, with each account's brought-forward opening balance and a running
+   * natural-sign balance. The report a filing accountant asks for FIRST, and
+   * until now the only one that existed in no form at all.
+   *
+   * 🛑 **`truncated` is load-bearing.** Unlike every other statement on this
+   * router - all of which are bounded by the CHART - this one is bounded by
+   * TRANSACTION VOLUME, so it is read under a server-side line cap. The cap is
+   * deliberately NOT an input: a limit the caller chooses is not a limit. When
+   * it fires, `truncated` comes back `true`, `maxLines` says where it stopped,
+   * and `rows[0]` is an INCOMPLETE banner that survives into the CSV and the
+   * PDF. A truncated ledger does not tie to `trialBalance` for the same range,
+   * and `balanced` must not be read as a tie-out unless `truncated` is false.
+   */
+  generalLedger: permissionProcedure(PermissionKey.ledgerView)
+    .input(z.object({ from: dateKey, to: dateKey }))
+    .query(async ({ ctx, input }) => {
+      const result = await readGeneralLedger(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        from: input.from,
+        to: input.to,
+        maxLines: GENERAL_LEDGER_MAX_LINES,
+      })
+      if (result.isErr()) throw result.error
+      return {
+        ...result.value,
+        maxLines: GENERAL_LEDGER_MAX_LINES,
+        columns: GENERAL_LEDGER_COLUMNS,
+        rows: toGeneralLedgerRows(result.value),
+      }
+    }),
+
+  /**
    * Render one statement to PDF and store it as a 24-hour `MediaAsset`
    * (`postings/reports/pdf/render-statement-pdf.ts`, modelled on
    * `documents/preview-pdf.ts`). The `StatementRow[]` payload is computed by
@@ -176,6 +214,10 @@ export const ledgerReportsRouter = createTRPCRouter({
         z.object({ kind: z.literal('ar-aging'), asOf: dateKey }),
         z.object({ kind: z.literal('ap-aging'), asOf: dateKey }),
         z.object({ kind: z.literal('vendor-1099'), year: z.number().int() }),
+        // Task 21 §5: the general ledger, under the same server-side line cap
+        // the `generalLedger` query above applies - so the printed copy and the
+        // page stop in the same place.
+        z.object({ kind: z.literal('general-ledger'), from: dateKey, to: dateKey }),
       ])
     )
     .mutation(async ({ ctx, input }) => {
@@ -206,6 +248,14 @@ export const ledgerReportsRouter = createTRPCRouter({
           actorId: userId,
           kind: input.kind,
           params: { from: input.from, to: input.to, compare: input.compare },
+        })
+      }
+      if (input.kind === 'general-ledger') {
+        return renderStatementPdf({
+          organizationId,
+          actorId: userId,
+          kind: input.kind,
+          params: { from: input.from, to: input.to },
         })
       }
       if (input.kind === 'ar-aging' || input.kind === 'ap-aging') {

--- a/packages/lib/src/postings/__tests__/default-chart.test.ts
+++ b/packages/lib/src/postings/__tests__/default-chart.test.ts
@@ -14,6 +14,13 @@
 // `DEFAULT_CHART_OF_ACCOUNTS` (every pack flattened); the per-pack pins are
 // what stop a role drifting from the pack whose builders drive it.
 //
+// Brief 21 §4.2 then grew the core and added three ROLE-LESS packs (`payroll`,
+// `fixed_assets`, `debt`). That flipped the majority of the chart to role-less,
+// so the pins about roles say less than they used to and the pins about WHICH
+// PACK and WHICH SIDE OF THE BALANCE SHEET carry the weight instead - the two
+// mistakes those accounts invite are merging `2120` into `2110` and filing
+// `1400` with the customer-side `prepayments` pack.
+//
 // Only an EXACT-set assertion catches a removal; a subset assertion passes
 // forever.
 
@@ -127,13 +134,21 @@ describe('the union of every pack', () => {
     }
   })
 
-  it('totals thirty-three accounts: thirteen core, five, two, nine and four', () => {
-    expect(codesOf('core')).toHaveLength(13)
+  // The per-pack sizes, so an account cannot be added to a pack without
+  // somebody saying which pack. The core grew from 13 to 27 in brief 21 §4.2 -
+  // fourteen role-less accounts (prepaid, two owner-equity, eleven operating
+  // expenses) - and `payroll`, `fixed_assets` and `debt` arrived in the same
+  // pass. The number itself is not the point; being made to state it is.
+  it('totals fifty-eight accounts: twenty-seven core, then five, two, nine, four, five, three and three', () => {
+    expect(codesOf('core')).toHaveLength(27)
     expect(codesOf('card_rail')).toHaveLength(5)
     expect(codesOf('prepayments')).toHaveLength(2)
     expect(codesOf('inventory')).toHaveLength(9)
     expect(codesOf('purchasing')).toHaveLength(4)
-    expect(DEFAULT_CHART_OF_ACCOUNTS).toHaveLength(33)
+    expect(codesOf('payroll')).toHaveLength(5)
+    expect(codesOf('fixed_assets')).toHaveLength(3)
+    expect(codesOf('debt')).toHaveLength(3)
+    expect(DEFAULT_CHART_OF_ACCOUNTS).toHaveLength(58)
   })
 })
 
@@ -160,22 +175,63 @@ describe('the core', () => {
     )
   })
 
-  it('is exactly the thirteen accounts §1.3 names', () => {
+  // 16 §1.3's thirteen, plus the fourteen role-less accounts 21 §4.2 added so
+  // that a coded bank line, an owner's deposit and a prepaid premium have
+  // somewhere to go. Exact list, in code order.
+  it('is 16 §1.3s thirteen plus the operating, prepaid and owner accounts of 21 §4.2', () => {
     expect(codesOf('core')).toEqual([
       '1000',
       '1050',
       '1100',
+      '1400',
       '2000',
       '2200',
       '3000',
+      '3010',
+      '3020',
       '3100',
       '3900',
       '4000',
       '4020',
       '4030',
       '4090',
+      '6000',
+      '6010',
+      '6020',
+      '6030',
+      '6040',
+      '6050',
+      '6060',
+      '6070',
+      '6080',
+      '6090',
       '6300',
+      '6900',
     ])
+  })
+
+  // 🛑 `1400` is the company's OWN prepayment - an asset, money we paid a
+  // vendor early. The `prepayments` PACK is `2300`/`2350`, money a customer
+  // paid US early, which is a liability. Same word, opposite side of the
+  // balance sheet; pinned so a later edit cannot tidy the two together.
+  it('keeps 1400 Prepaid Expenses an asset in the core, not in the prepayments pack', () => {
+    expect(byCode.get('1400')?.accountType).toBe(GlAccountType.ASSET)
+    expect(codesOf('core')).toContain('1400')
+    expect(codesOf('prepayments')).toEqual(['2300', '2350'])
+    for (const code of codesOf('prepayments')) {
+      expect(byCode.get(code)?.accountType, code).toBe(GlAccountType.LIABILITY)
+    }
+  })
+
+  // Owner contributions and draws are CORE, not the `debt` pack: a founder's
+  // deposit is a first-week bank line for every company and a loan drawdown is
+  // not (21 §4.2). A draw is a return of capital, so it is equity and never an
+  // expense - the most common small-company coding error there is.
+  it('puts owner contributions and draws in the core, as equity', () => {
+    for (const code of ['3010', '3020']) {
+      expect(codesOf('core'), code).toContain(code)
+      expect(byCode.get(code)?.accountType, code).toBe(GlAccountType.EQUITY)
+    }
   })
 
   // `cash` retired as a posting role (brief 13 §2): `1000 Cash` is kept as an
@@ -228,6 +284,11 @@ describe('the other packs', () => {
         ACCOUNT_ROLES.PPV,
       ].sort()
     )
+    // And the three packs brief 21 added drive no role at all - they exist so a
+    // person has an account to name in a journal, not so a builder does.
+    expect(rolesOf('payroll')).toEqual([])
+    expect(rolesOf('fixed_assets')).toEqual([])
+    expect(rolesOf('debt')).toEqual([])
   })
 
   // `G12`: count/shrinkage value must land somewhere OTHER than purchase price
@@ -278,10 +339,13 @@ describe('the other packs', () => {
   // account a role, or parks every role-less one in the core, has to argue
   // with a test.
   it('leaves role-less accounts in more than one pack', () => {
-    const roleless = DEFAULT_CHART_OF_ACCOUNTS.filter((account) => !account.role)
-    expect(roleless.map((account) => account.code).sort()).toEqual(
-      ['1000', '3000', '5010', '5030', '6105'].sort()
-    )
+    // Was an exact list of five. Brief 21 §4.2 made role-less the MAJORITY of
+    // the chart - thirty of fifty-eight - so listing them all would pin nothing
+    // but arithmetic. The five that were arguable when the packs were declared
+    // are still pinned by code; the "no new roles" half is the test below.
+    for (const code of ['1000', '3000', '5010', '5030', '6105']) {
+      expect(byCode.get(code)?.role, code).toBeUndefined()
+    }
     const packsWithRoleless = new Set(
       CHART_PACK_KEYS.filter((key) => CHART_PACKS[key].accounts.some((a) => !a.role))
     )
@@ -289,6 +353,73 @@ describe('the other packs', () => {
     expect(packsWithRoleless).toContain('core')
     expect(packsWithRoleless).toContain('inventory')
     expect(packsWithRoleless).toContain('card_rail')
+  })
+
+  // 🛑 21 §9. `ACCOUNT_ROLES` is a closed vocabulary tied to builders: a role
+  // is what lets a builder name an account without knowing the org's numbering,
+  // and no builder emits rent, payroll, depreciation or interest. So every
+  // account brief 21 added carries NO role, and one acquiring one by reflex has
+  // to argue with this test - it would also have to widen `ACCOUNT_ROLES`,
+  // `ROLE_ACCOUNT_TYPES` and `ACCOUNT_ROLE_LABELS` together.
+  it('gives no role to a single account brief 21 added', () => {
+    const added = [
+      '1400',
+      '3010',
+      '3020',
+      '6000',
+      '6010',
+      '6020',
+      '6030',
+      '6040',
+      '6050',
+      '6060',
+      '6070',
+      '6080',
+      '6090',
+      '6900',
+      ...codesOf('payroll'),
+      ...codesOf('fixed_assets'),
+      ...codesOf('debt'),
+    ]
+    for (const code of added) {
+      expect(byCode.get(code), code).toBeDefined()
+      expect(byCode.get(code)?.role, code).toBeUndefined()
+    }
+  })
+
+  // 🛑 21 §2.3 and §0.5. `2110 Payroll Clearing` is the manufacturing labour
+  // absorption pool and `build-month-end-inventory.ts` only ever CREDITS it;
+  // `2120 Net Pay Clearing` holds net pay between the gross-up entry and the
+  // bank line. Merging them gives one balance two meanings and no report can
+  // separate unabsorbed labour from unpaid net pay again.
+  it('keeps the payroll pack clear of 2110, the inventory labour pool', () => {
+    expect(codesOf('payroll')).not.toContain('2110')
+    expect(codesOf('inventory')).toContain('2110')
+    expect(byCode.get('2120')?.name).toBe('Net Pay Clearing')
+    expect(byCode.get('2110')?.name).toBe('Payroll Clearing')
+  })
+
+  // Accumulated depreciation is a contra-ASSET: it runs credit-normal but it is
+  // filed with the assets it reduces, the same reading `4090` gets as a
+  // contra-revenue. `GlAccountType` has no contra classification on purpose.
+  it('files accumulated depreciation as an asset beside the cost account', () => {
+    for (const code of ['1500', '1590']) {
+      expect(byCode.get(code)?.accountType, code).toBe(GlAccountType.ASSET)
+      expect(byCode.get(code)?.subtype, code).toBe('fixed_asset')
+    }
+    expect(byCode.get('6500')?.accountType).toBe(GlAccountType.EXPENSE)
+    // Not COGS: the P&L puts anything that is not `cost_of_goods_sold` below
+    // gross profit, which is where depreciation belongs.
+    expect(byCode.get('6500')?.subtype).toBeUndefined()
+  })
+
+  // The current / non-current split is what `GlAccountType`'s five-way collapse
+  // loses, so the chart carries it as two accounts rather than one.
+  it('splits loans payable current from long term, and keeps interest with them', () => {
+    expect(codesOf('debt')).toEqual(['2500', '2800', '6600'])
+    expect(byCode.get('2500')?.accountType).toBe(GlAccountType.LIABILITY)
+    expect(byCode.get('2800')?.accountType).toBe(GlAccountType.LIABILITY)
+    expect(byCode.get('6600')?.accountType).toBe(GlAccountType.EXPENSE)
   })
 })
 
@@ -345,6 +476,18 @@ describe('packState', () => {
     const roles = rolesOf('card_rail')
     const map = roles.map((role, i) => row(role, i === 0 ? 'unmapped' : 'suggested'))
     expect(packState('card_rail', map)).toBe('partial')
+  })
+
+  // 🛑 A role-less pack is invisible to the role map, so it reads `absent`
+  // however full the map is. `provisioned` would be the expensive answer: the
+  // dialog disables a provisioned row, and a pack that carries no role could
+  // then never be added at all. Re-walking an idempotent seed costs nothing.
+  it('reads a pack with no roles at all as absent, never provisioned', () => {
+    for (const pack of ['payroll', 'fixed_assets', 'debt'] as const) {
+      expect(rolesOf(pack), pack).toEqual([])
+      expect(packState(pack, allAs('confirmed')), pack).toBe('absent')
+      expect(packState(pack, []), pack).toBe('absent')
+    }
   })
 
   it('reads only its own roles', () => {

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -258,14 +258,24 @@ export type { AccountLineRow, AccountLines } from './reports/account-lines'
 // or react-pdf/S3 and stay server-only, exported from `./index` only. ────────
 export {
   balanceSheetColumns,
+  GENERAL_LEDGER_COLUMNS,
   TRIAL_BALANCE_COLUMNS,
   toBalanceSheetRows,
+  toGeneralLedgerRows,
   toProfitAndLossRows,
   toTrialBalanceRows,
 } from './reports/adapters'
 export type { BalanceSheet, BalanceSheetRow, BalanceSheetSnapshot } from './reports/balance-sheet'
 export type { Completeness, CompletenessItem } from './reports/completeness'
 export { fiscalYearStart, previousCalendarDay } from './reports/fiscal-year'
+// The general ledger (task 21 §5). Types only: `readGeneralLedger` and its
+// `GENERAL_LEDGER_MAX_LINES` guard are a db read and a server policy, and stay
+// on `./index`. `toGeneralLedgerRows`/`GENERAL_LEDGER_COLUMNS` are pure and
+// come through the adapters block above, like every other statement's.
+export type {
+  GeneralLedger,
+  GeneralLedgerAccount,
+} from './reports/general-ledger'
 export type {
   RenderStatementPdfOptions,
   RenderStatementPdfParamsByKind,

--- a/packages/lib/src/postings/default-chart.ts
+++ b/packages/lib/src/postings/default-chart.ts
@@ -22,6 +22,27 @@
 // 28 roles lives in exactly one pack; `packForRole` is the lookup and the union
 // test in `__tests__/default-chart.test.ts` is the proof.
 //
+// ## Why the core then grew, and three more packs arrived
+//
+// Brief 21 §0.4 read the same table back and found the other half of the
+// problem: the ONLY expense accounts in the whole catalogue were two merchant
+// fee lines, bad debt and six COGS accounts. `bank_transaction` is a live
+// posting type and a coded bank line posts against an account the operator
+// PICKS, so no org could code a rent payment, a utility bill or an insurance
+// premium without hand-creating the account first - one at a time, through
+// `chartAccountCreate`, because the catalogue picker validates against this
+// same table. A chart that cannot express rent is not a chart.
+//
+// So the ordinary operating expenses, `1400 Prepaid Expenses` and the two
+// owner-equity movement accounts are CORE (21 DECIDED E): every org has them,
+// and none of them carries a role, because no builder emits them. `payroll`,
+// `fixed_assets` and `debt` are packs for the same reason `inventory` is - an
+// org with no employees should not carry withholding accounts.
+//
+// 🟢 The accounting subsystem is not live (21 DECIDED 2): `GlPosting` is empty
+// and entity migration 142 wiped every seeded chart, so all of that grew with
+// no migration, no backfill and no compatibility path.
+//
 // Four accounts that were in the old list are in NO pack (`1190 Allowance for
 // Doubtful Accounts`, `2100 Accrued Payroll`, `2400 Returns Reserve`, `6200
 // Fulfillment Labor`): role-less, one company's bookkeeping, added by hand in
@@ -100,12 +121,20 @@ export interface DefaultChartAccount {
 }
 
 /**
- * The five packs, by key. `core` is always provisioned; the other four are
+ * The eight packs, by key. `core` is always provisioned; the other seven are
  * chosen by a person in the wizard's pack picker or the Roles tab's Add
  * accounts action (16 §3). Never provisioned silently off a plan event, an app
  * install or a payout sync (16 §3.3).
  */
-export type ChartPackKey = 'core' | 'card_rail' | 'prepayments' | 'inventory' | 'purchasing'
+export type ChartPackKey =
+  | 'core'
+  | 'card_rail'
+  | 'prepayments'
+  | 'inventory'
+  | 'purchasing'
+  | 'payroll'
+  | 'fixed_assets'
+  | 'debt'
 
 /** One provisionable slice of the default chart. */
 export interface ChartPack {
@@ -120,12 +149,17 @@ export interface ChartPack {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// The core: thirteen accounts, eleven roles (16 §1.3)
+// The core: twenty-seven accounts, eleven roles (16 §1.3, 21 §4.2)
 // ─────────────────────────────────────────────────────────────────────────────
 //
-// Every role here is reachable by an ENABLED posting type on any org that sends
-// an invoice, takes a payment, ships an order, issues a credit memo or writes
-// something off (16 §0.2). Why each of the arguable ones is here:
+// Two different arguments put an account here, and only the FIRST is about
+// roles. Every role here is reachable by an ENABLED posting type on any org
+// that sends an invoice, takes a payment, ships an order, issues a credit memo
+// or writes something off (16 §0.2). The other fourteen accounts carry no role
+// at all: they are here because a coded bank line, an owner's deposit or a
+// prepaid insurance premium has nowhere else to go, and hand-creating an
+// account per bank line is not a chart (21 DECIDED E). Why each of the arguable
+// role-bearing ones is here:
 //
 // - `2000 Accounts Payable`: `vendor_bill` is not enabled, but A/P aging reads
 //   the role, a manual journal to a payable by id is ordinary bookkeeping, and
@@ -181,6 +215,22 @@ const CORE_ACCOUNTS: readonly DefaultChartAccount[] = [
     role: 'accounts_receivable',
     subtype: GlAccountSubtype.ACCOUNTS_RECEIVABLE,
   },
+  {
+    // The company's OWN prepayments: insurance billed annually, a year of
+    // software paid up front, a deposit lodged with a landlord. Held as an
+    // asset and amortised into expense monthly, which is a recurring journal
+    // template's exact shape (21 §1.7).
+    //
+    // 🛑 NOT the `prepayments` pack, and not a variant of it. That pack is
+    // `2300 Deferred Revenue` and `2350 Customer Deposits` - money a CUSTOMER
+    // paid us before we delivered, so we owe them either goods or the money
+    // back. This is money WE paid a vendor before they delivered, so THEY owe
+    // US. Opposite party, opposite side of the balance sheet; the only thing
+    // the two share is the English word "prepaid".
+    code: '1400',
+    name: 'Prepaid Expenses',
+    accountType: GlAccountType.ASSET,
+  },
 
   // ── Liabilities ─────────────────────────────────────────────────────────
   {
@@ -212,6 +262,30 @@ const CORE_ACCOUNTS: readonly DefaultChartAccount[] = [
     // statement reader groups it by type.
     code: '3000',
     name: "Owner's Equity",
+    accountType: GlAccountType.EQUITY,
+  },
+  // 3010 and 3020 added by 21 §4.2, and CORE rather than the `debt` pack or one
+  // of their own. An owner putting personal money into the business is one of
+  // the first bank lines a new company ever has, and a founder's deposit with
+  // nowhere to land is the same gap as rent with nowhere to land - the argument
+  // that made the operating expenses core (21 DECIDED E). A loan is not: a
+  // company may never take one, which is why the debt accounts are a pack and
+  // these are not. 3000 is already core, so the equity story stays in one place.
+  {
+    // Money the owner put IN. Its own account rather than a credit straight to
+    // 3000 so the year's movement is visible; a bookkeeper closes it to 3000 at
+    // year end if they want to, exactly as they clear 3900.
+    code: '3010',
+    name: 'Owner Contributions',
+    accountType: GlAccountType.EQUITY,
+  },
+  {
+    // Money the owner took OUT. 🛑 A draw is a return of capital and never
+    // appears on the P&L - coding one to an expense account is the single most
+    // common small-company bookkeeping error, and the account existing by name
+    // is the cheapest thing that prevents it.
+    code: '3020',
+    name: 'Owner Draws',
     accountType: GlAccountType.EQUITY,
   },
   {
@@ -291,6 +365,78 @@ const CORE_ACCOUNTS: readonly DefaultChartAccount[] = [
   },
 
   // ── Operating expenses ──────────────────────────────────────────────────
+  // 6000 to 6090 and 6900 added by 21 §4.2. The smallest set that lets a real
+  // small company code a bank feed from end to end without inventing an
+  // account; an org that wants a finer breakdown adds its own, which is what a
+  // default chart is for (`G7`). None of them carries a role and that is the
+  // ordinary case, not a gap: no builder emits any of them, the statement
+  // reader groups them by type, and `ACCOUNT_ROLES` is a closed vocabulary tied
+  // to builders (16 §4.2), so a role invented here would name nothing.
+  {
+    // Its own line rather than folded into 6900. For most orgs auxx serves this
+    // is the largest operating expense there is, and an expense nobody can see
+    // is one nobody manages - the argument 4090 makes about return rates.
+    code: '6000',
+    name: 'Advertising and Marketing',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    code: '6010',
+    name: 'Rent',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    code: '6020',
+    name: 'Utilities',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    // The company's own general cover. Employee health cover is a cost of
+    // employing somebody and belongs to `6420` in the payroll pack.
+    code: '6030',
+    name: 'Insurance',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    code: '6040',
+    name: 'Software and Subscriptions',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    // Accountants, lawyers, outside consultants. A contractor doing the work of
+    // an employee is still a professional fee and never payroll: no
+    // withholding, no employer tax, nothing for the payroll pack to clear.
+    code: '6050',
+    name: 'Professional Fees',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    code: '6060',
+    name: 'Office Supplies',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    // ONE account, not travel and meals apart. The meals deduction split is a
+    // tax-return question the firm answers at year end off a memo, and asking
+    // an operator to route a card line correctly for it buys nothing.
+    code: '6070',
+    name: 'Travel and Meals',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    code: '6080',
+    name: 'Repairs and Maintenance',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    // What the BANK charges: account fees, wires, returned items. Numbered
+    // beside `6100 Merchant Fees - Cards` so the two read as a pair in a sorted
+    // chart, but core rather than `card_rail` - every org has a bank account
+    // and only a card merchant has 6100.
+    code: '6090',
+    name: 'Bank Charges',
+    accountType: GlAccountType.EXPENSE,
+  },
   {
     // The `write_off` entry's debit leg. `1190 Allowance for Doubtful Accounts`
     // is the contra-asset the reserve method would credit; the direct
@@ -299,6 +445,15 @@ const CORE_ACCOUNTS: readonly DefaultChartAccount[] = [
     name: 'Bad Debt Expense',
     accountType: GlAccountType.EXPENSE,
     role: 'bad_debt_expense',
+  },
+  {
+    // The catch-all, numbered at the end of the band so it sorts last. A coded
+    // bank line must always have somewhere to go; the alternative to this
+    // account is an operator inventing one per unfamiliar charge, which is how
+    // a chart becomes forty accounts nobody agreed to.
+    code: '6900',
+    name: 'Other Operating Expense',
+    accountType: GlAccountType.EXPENSE,
   },
 ]
 
@@ -550,8 +705,187 @@ const PURCHASING_ACCOUNTS: readonly DefaultChartAccount[] = [
   },
 ]
 
+// ─────────────────────────────────────────────────────────────────────────────
+// payroll: the gross-up entry and what it owes (21 §2, §4.2)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// ⚠️ A BOOKKEEPING CONVENTION, not a payroll integration. Nothing in auxx reads
+// ADP or Gusto and nothing here should - a person types the figures off the
+// payroll provider's own report as a journal entry (21 §2.4). This pack exists
+// so those figures have named accounts to land on.
+//
+// The reconciliation it is shaped for (21 §2.1). The cash leg is already
+// correct and already single-writer: the bank feed owns it, and a journal that
+// names no bank account cannot double-count it.
+//
+//   Bank feed, coded:  Dr 2120 Net Pay Clearing            (net cash)
+//                          Cr <bank account>               (net cash)
+//   Gross-up entry:    Dr 6400 Wages and Salaries          (gross)
+//                      Dr 6410 Employer Payroll Taxes
+//                          Cr 2130 Payroll Withholdings Payable
+//                          Cr 2120 Net Pay Clearing        (net cash)
+//
+// 2120 nets to zero once both halves are in, and 2130 nets to zero when the
+// remittance clears the bank. The account BALANCE is the reconciliation, and
+// the trial balance already reports it.
+//
+// ⚠️ `2100 Accrued Payroll` is deliberately not revived here. It is one of the
+// four accounts brief 16 dropped from every pack (see the file header), and
+// `default-chart.test.ts` pins its absence; an org that wants a period-end
+// payroll accrual adds it in the chart editor.
+//
+// No role on any of these: no builder emits a payroll entry, so a role would
+// name nothing and would have to be added to the closed `ACCOUNT_ROLES`
+// vocabulary to compile at all.
+const PAYROLL_ACCOUNTS: readonly DefaultChartAccount[] = [
+  // ── Liabilities ─────────────────────────────────────────────────────────
+  {
+    // 🛑 NOT `2110 Payroll Clearing`, which is a different account answering a
+    // different question. 2110 is the manufacturing labour absorption pool in
+    // the `inventory` pack: `build-month-end-inventory.ts:277` only ever
+    // CREDITS it, by the labour absorbed into inventory. This one holds NET PAY
+    // between the gross-up entry and the bank line that paid it.
+    //
+    // Pointing both stories at one balance means neither can be read - the
+    // residual would be unabsorbed labour plus unpaid net pay with nothing able
+    // to separate them, which is the shape of the defect 21 §0.5 already
+    // describes on 2110 alone (21 §2.3, reversible per 21 §7.6).
+    code: '2120',
+    name: 'Net Pay Clearing',
+    accountType: GlAccountType.LIABILITY,
+  },
+  {
+    // Employee withholdings and the employer's own share, from the run until
+    // the remittance clears the bank. ONE account, not one per authority: the
+    // split lives on the payroll provider's report, and an org that wants
+    // federal and state apart adds two of its own.
+    code: '2130',
+    name: 'Payroll Withholdings Payable',
+    accountType: GlAccountType.LIABILITY,
+  },
+
+  // ── Operating expenses ──────────────────────────────────────────────────
+  {
+    // GROSS, not net. The net figure is a cash fact and belongs to 2120.
+    code: '6400',
+    name: 'Wages and Salaries',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    // The EMPLOYER's share only. The employee's share was withheld out of gross
+    // pay, so it is already inside 6400; posting it here as well would overstate
+    // the cost of employing somebody by the whole withholding.
+    code: '6410',
+    name: 'Employer Payroll Taxes',
+    accountType: GlAccountType.EXPENSE,
+  },
+  {
+    // Health cover, retirement match, the rest. Separate from `6030 Insurance`,
+    // which is the company's own general cover and is not a cost of employing
+    // anyone.
+    code: '6420',
+    name: 'Employee Benefits',
+    accountType: GlAccountType.EXPENSE,
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// fixed_assets: assets at cost, what has depreciated off them, the expense
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Three accounts and no register (21 DECIDED B, §1.7). Straight-line
+// depreciation is `Dr 6500 / Cr 1590`, the same figure every month for a known
+// number of months, which is a recurring journal template's exact shape. What a
+// register would add is the arithmetic and the year-end schedule a firm asks
+// for, and there is no fixed-asset entity anywhere in the repo; until a
+// customer asks, a person types the monthly figure the way they already type
+// the opening trial balance.
+const FIXED_ASSET_ACCOUNTS: readonly DefaultChartAccount[] = [
+  // ── Assets ──────────────────────────────────────────────────────────────
+  {
+    // ONE account at cost, not one per class. A chart that splits vehicles,
+    // equipment and leasehold improvements on day one is three rows an org has
+    // to route to correctly for a purchase it makes twice a year; an org that
+    // needs the split adds it, and 15.2's sort keeps the numbers together.
+    code: '1500',
+    name: 'Fixed Assets at Cost',
+    accountType: GlAccountType.ASSET,
+    subtype: GlAccountSubtype.FIXED_ASSET,
+  },
+  {
+    // A contra-asset: an ASSET that runs credit-normal, the same reading `4090`
+    // gets as a contra-revenue and `1190` got before it was dropped.
+    // `GlAccountType` has no contra classification and does not need one -
+    // contra is a presentation attribute, not a posting rule. Numbered 1590 so
+    // it sorts directly under the cost account it reduces.
+    code: '1590',
+    name: 'Accumulated Depreciation',
+    accountType: GlAccountType.ASSET,
+    subtype: GlAccountSubtype.FIXED_ASSET,
+  },
+
+  // ── Operating expenses ──────────────────────────────────────────────────
+  {
+    // No subtype, deliberately: depreciation is an operating expense, and
+    // `profit-and-loss.ts` puts everything that is not `cost_of_goods_sold`
+    // below gross profit. A manufacturer that depreciates production equipment
+    // into overhead absorbs it through `5020` instead and leaves this alone.
+    code: '6500',
+    name: 'Depreciation Expense',
+    accountType: GlAccountType.EXPENSE,
+  },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// debt: money the company borrowed, and what it costs (21 §4.2)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// A pack rather than core because a company may simply never borrow, and two
+// payable accounts it can never use are two rows on a screen for nothing - the
+// same test `inventory` and `payroll` pass.
+//
+// ⚠️ The owner side of "where did the money come from" is NOT here. `3010
+// Owner Contributions` and `3020 Owner Draws` are core, because a founder's
+// deposit is a first-week bank line for every company and a loan drawdown is
+// not. Named `debt` rather than `equity_and_debt` for exactly that reason.
+const DEBT_ACCOUNTS: readonly DefaultChartAccount[] = [
+  // ── Liabilities ─────────────────────────────────────────────────────────
+  {
+    // The principal falling due inside twelve months. TWO accounts rather than
+    // one because `GlAccountType`'s five-way collapse loses the current /
+    // non-current split (see this file's note 2 below), and that split is most
+    // of the difference between a balance sheet a lender will read and one it
+    // will not. A person moves the current portion at year end with a journal.
+    code: '2500',
+    name: 'Loans Payable - Current',
+    accountType: GlAccountType.LIABILITY,
+  },
+  {
+    // Everything falling due after twelve months. Numbered clear of the 2xxx
+    // current block so a sorted chart reads current, then long term.
+    code: '2800',
+    name: 'Loans Payable - Long Term',
+    accountType: GlAccountType.LIABILITY,
+  },
+
+  // ── Operating expenses ──────────────────────────────────────────────────
+  {
+    // Interest only. 🛑 The principal half of a loan payment is a debit to 2500
+    // and touches no expense account at all; coding a whole payment here is the
+    // error this account's existence has to survive.
+    //
+    // 21 §4.2 sketched this in the operating list. It rides with the debt it
+    // comes from instead, so an org that never borrows does not carry it.
+    // `6090 Bank Charges` is what the bank charges for the account itself and
+    // is a different thing.
+    code: '6600',
+    name: 'Interest Expense',
+    accountType: GlAccountType.EXPENSE,
+  },
+]
+
 /**
- * The default chart of accounts, as five packs.
+ * The default chart of accounts, as eight packs.
  *
  * ## What this is, and what it is NOT
  *
@@ -579,6 +913,14 @@ const PURCHASING_ACCOUNTS: readonly DefaultChartAccount[] = [
  * added 2026-09-04 once the opening trial balance and the balance sheet needed
  * somewhere to land (plans/accounting/HANDOFF.md decision 6.4), with `1050`,
  * `4020` and `6300` in the same pass.
+ *
+ * Brief 21 §4.2 closed the largest remaining gap in that presumption: the
+ * ordinary operating expenses, `1400 Prepaid Expenses` and the two owner-equity
+ * movement accounts are now core, and `payroll`, `fixed_assets` and `debt` are
+ * packs. It is still not a complete chart - there is no credit-card liability,
+ * no per-class asset breakdown and no jurisdiction split on withholdings -
+ * because each of those is an account a person adds once, in the editor, when
+ * they know the answer.
  *
  * ## The two things to check before this is seeded
  *
@@ -633,6 +975,26 @@ export const CHART_PACKS: Record<ChartPackKey, ChartPack> = {
     requires: ['inventory'],
     accounts: PURCHASING_ACCOUNTS,
   },
+  payroll: {
+    key: 'payroll',
+    label: 'Payroll',
+    description:
+      'Wages, employer taxes and benefits, with the withholding and net-pay accounts a payroll run clears through.',
+    accounts: PAYROLL_ACCOUNTS,
+  },
+  fixed_assets: {
+    key: 'fixed_assets',
+    label: 'Fixed assets and depreciation',
+    description:
+      'Assets held at cost, the depreciation taken off them, and the monthly depreciation expense.',
+    accounts: FIXED_ASSET_ACCOUNTS,
+  },
+  debt: {
+    key: 'debt',
+    label: 'Loans and interest',
+    description: 'Loans payable, split current and long term, and the interest they cost.',
+    accounts: DEBT_ACCOUNTS,
+  },
 }
 
 /**
@@ -645,6 +1007,9 @@ export const CHART_PACK_KEYS = [
   'prepayments',
   'inventory',
   'purchasing',
+  'payroll',
+  'fixed_assets',
+  'debt',
 ] as const satisfies readonly ChartPackKey[]
 
 /**
@@ -675,6 +1040,17 @@ export function packForRole(role: AccountRole): ChartPackKey {
  * role, which is the thing an absent row says nobody has. A role missing from
  * `roleMap` altogether is read as `unmapped`, though `listRoleMap` returns
  * every role.
+ *
+ * 🛑 **A pack with NO roles always reads `absent`, and that is a deliberate
+ * lie in the safe direction.** `payroll`, `fixed_assets` and `debt` (21 §4.2)
+ * carry no role at all - no builder emits rent, wages, depreciation or
+ * interest - so the role map cannot see whether their accounts exist, and the
+ * empty filter below would otherwise report `provisioned`. That answer is the
+ * expensive one: `chart-packs-dialog.tsx` disables a `provisioned` row, so a
+ * pack nobody had ever added could never be added. `absent` costs at worst one
+ * re-walk of an idempotent seed. Answering it properly means asking the CHART
+ * for the codes rather than the role map for the roles, which is a query the
+ * dialog does not make today.
  */
 export function packState(
   pack: ChartPackKey,
@@ -683,6 +1059,7 @@ export function packState(
   const roles = CHART_PACKS[pack].accounts.flatMap((account) =>
     account.role ? [account.role] : []
   )
+  if (roles.length === 0) return 'absent'
   const stateByRole = new Map(roleMap.map((row) => [row.role, row.state]))
   const unmapped = roles.filter((role) => (stateByRole.get(role) ?? 'unmapped') === 'unmapped')
   if (unmapped.length === 0) return 'provisioned'

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -332,8 +332,10 @@ export {
 } from './reports/account-lines'
 export {
   balanceSheetColumns,
+  GENERAL_LEDGER_COLUMNS,
   TRIAL_BALANCE_COLUMNS,
   toBalanceSheetRows,
+  toGeneralLedgerRows,
   toProfitAndLossRows,
   toTrialBalanceRows,
 } from './reports/adapters'
@@ -371,6 +373,14 @@ export {
   readDimensionBreakdown,
 } from './reports/dimension-breakdown'
 export { fiscalYearStart, previousCalendarDay } from './reports/fiscal-year'
+// ── The general ledger (task 21 §5): the sixth statement ────────────────────
+export {
+  GENERAL_LEDGER_MAX_LINES,
+  type GeneralLedger,
+  type GeneralLedgerAccount,
+  type ReadGeneralLedgerOptions,
+  readGeneralLedger,
+} from './reports/general-ledger'
 export {
   type RenderStatementPdfOptions,
   type RenderStatementPdfParamsByKind,

--- a/packages/lib/src/postings/reports/__tests__/general-ledger.test.ts
+++ b/packages/lib/src/postings/reports/__tests__/general-ledger.test.ts
@@ -1,0 +1,551 @@
+// packages/lib/src/postings/reports/__tests__/general-ledger.test.ts
+//
+// `readGeneralLedger` composes the same two collaborators `readTrialBalance`
+// and `readAccountLines` do - `listChartAccounts` (mocked; its own decode is
+// covered by `role-map.test.ts`) and two grouped/ordered SQL reads, stubbed as
+// a hand-written thenable chain for the same reason those files stub theirs:
+// the interesting cases are about the SHAPE Postgres hands back (string
+// aggregates) and about what this read does with it.
+//
+// The stub also CAPTURES the `where` condition and the `limit`, because two of
+// the properties that matter here are not visible in the rows: that `to` is
+// bound INCLUSIVELY, and that the size guard is applied in SQL rather than by
+// slicing a result set the driver already materialised.
+
+import type { Database } from '@auxx/database'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { ok } from 'neverthrow'
+import { describe, expect, it, vi } from 'vitest'
+import type { ChartAccountRow } from '../../types'
+
+vi.mock('../../role-map', () => ({ listChartAccounts: vi.fn() }))
+
+import { listChartAccounts } from '../../role-map'
+import { toGeneralLedgerRows } from '../adapters'
+import { GENERAL_LEDGER_MAX_LINES, readGeneralLedger } from '../general-ledger'
+
+const ORG = 'org_1'
+
+/** What `PgDialect.sqlToQuery` takes - a captured `where` condition, re-typed. */
+type SqlCondition = Parameters<PgDialect['sqlToQuery']>[0]
+
+interface Capture {
+  /** The `where` condition of each `db.select()`, in call order. */
+  where: unknown[]
+  /** The `limit` argument of each `db.select()`, `undefined` where none was applied. */
+  limit: Array<number | undefined>
+}
+
+/**
+ * `readGeneralLedger` issues `db.select()` twice, always in this order: the
+ * one-shot opening-balance aggregate, then the line list. Each gets its own
+ * row set.
+ */
+function stubDb(rowSets: unknown[][], capture?: Capture): Database {
+  let call = 0
+  return {
+    select: () => {
+      const index = call
+      call += 1
+      capture?.limit.push(undefined)
+      const chain: Record<string, unknown> = {}
+      const passthrough = () => chain
+      for (const method of ['from', 'innerJoin', 'groupBy', 'orderBy']) chain[method] = passthrough
+      chain.where = (condition: unknown) => {
+        capture?.where.push(condition)
+        return chain
+      }
+      chain.limit = (value: number) => {
+        if (capture) capture.limit[index] = value
+        return chain
+      }
+      // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
+      chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+        Promise.resolve(rowSets[index] ?? []).then(resolve, reject)
+      return chain
+    },
+  } as unknown as Database
+}
+
+function account(overrides: Partial<ChartAccountRow> & { code: string | null }): ChartAccountRow {
+  return {
+    id: `id_${overrides.code}`,
+    name: '',
+    accountType: 'asset',
+    subtype: null,
+    isActive: true,
+    ...overrides,
+  }
+}
+
+function opening(glAccountId: string, debit: number, credit: number) {
+  return { glAccountId, debitMinor: String(debit), creditMinor: String(credit) }
+}
+
+function line(input: {
+  glAccountId: string
+  txnDate: string
+  direction: 'debit' | 'credit'
+  amountMinor: number
+  docNumber?: string
+  glPostingId?: string
+  memo?: string | null
+}) {
+  return {
+    glPostingId: input.glPostingId ?? `gl_${input.docNumber ?? input.txnDate}`,
+    docNumber: input.docNumber ?? 'JNL-0001',
+    memo: input.memo ?? null,
+    ...input,
+    amountMinor: String(input.amountMinor),
+  }
+}
+
+const RANGE = { from: '2026-08-01', to: '2026-08-31' } as const
+
+describe('readGeneralLedger', () => {
+  it('groups by account IDENTITY, so a renumbered account is still ONE section', async () => {
+    // The chart says this id is `1150` today. Whatever code its older lines
+    // carried is never read - which is the whole point of task 15 §3, and the
+    // reason this read cannot be written as `GROUP BY accountCode`.
+    vi.mocked(listChartAccounts).mockResolvedValue(
+      ok([
+        account({ id: 'id_prepaid', code: '1150', name: 'Prepaid Expenses' }),
+        account({ id: 'id_cash', code: '1000', name: 'Cash' }),
+      ])
+    )
+
+    const result = await readGeneralLedger(
+      stubDb([
+        [],
+        [
+          // Posted while the account was still `1100`...
+          line({
+            glAccountId: 'id_prepaid',
+            txnDate: '2026-08-02',
+            direction: 'debit',
+            amountMinor: 30_000,
+            docNumber: 'JNL-0001',
+          }),
+          // ...and after it was renumbered to `1150`.
+          line({
+            glAccountId: 'id_prepaid',
+            txnDate: '2026-08-20',
+            direction: 'credit',
+            amountMinor: 10_000,
+            docNumber: 'JNL-0009',
+          }),
+          line({
+            glAccountId: 'id_cash',
+            txnDate: '2026-08-02',
+            direction: 'credit',
+            amountMinor: 30_000,
+            docNumber: 'JNL-0001',
+          }),
+        ],
+      ]),
+      { organizationId: ORG, ...RANGE }
+    )
+
+    const gl = result._unsafeUnwrap()
+    const prepaid = gl.accounts.filter((a) => a.glAccountId === 'id_prepaid')
+    expect(prepaid).toHaveLength(1)
+    expect(prepaid[0]?.accountCode).toBe('1150')
+    expect(prepaid[0]?.lines).toHaveLength(2)
+    expect(prepaid[0]?.endingBalanceMinor).toBe(20_000)
+    // Two accounts, in the trial balance's own statement-then-code order.
+    expect(gl.accounts.map((a) => a.accountCode)).toEqual(['1000', '1150'])
+  })
+
+  it('carries the opening balance into the FIRST line`s running balance', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(
+      ok([account({ id: 'id_cash', code: '1000', name: 'Cash', accountType: 'asset' })])
+    )
+
+    const result = await readGeneralLedger(
+      stubDb([
+        [opening('id_cash', 50_000, 0)],
+        [
+          line({
+            glAccountId: 'id_cash',
+            txnDate: '2026-08-10',
+            direction: 'debit',
+            amountMinor: 5_000,
+          }),
+          line({
+            glAccountId: 'id_cash',
+            txnDate: '2026-08-12',
+            direction: 'credit',
+            amountMinor: 2_000,
+            docNumber: 'JNL-0002',
+          }),
+        ],
+      ]),
+      { organizationId: ORG, ...RANGE }
+    )
+
+    const cash = result._unsafeUnwrap().accounts[0]
+    expect(cash?.openingBalanceMinor).toBe(50_000)
+    expect(cash?.lines.map((l) => l.runningBalanceMinor)).toEqual([55_000, 53_000])
+    expect(cash?.endingBalanceMinor).toBe(53_000)
+    expect(cash?.debitMinor).toBe(5_000)
+    expect(cash?.creditMinor).toBe(2_000)
+  })
+
+  it('signs the opening balance credit-natural for a liability account', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(
+      ok([account({ id: 'id_ap', code: '2000', name: 'A/P', accountType: 'liability' })])
+    )
+
+    const result = await readGeneralLedger(
+      stubDb([
+        [opening('id_ap', 0, 40_000)],
+        [
+          line({
+            glAccountId: 'id_ap',
+            txnDate: '2026-08-04',
+            direction: 'debit',
+            amountMinor: 15_000,
+          }),
+        ],
+      ]),
+      { organizationId: ORG, ...RANGE }
+    )
+
+    const ap = result._unsafeUnwrap().accounts[0]
+    expect(ap?.openingBalanceMinor).toBe(40_000)
+    expect(ap?.lines[0]?.runningBalanceMinor).toBe(25_000)
+  })
+
+  it('keeps an account that has an opening balance but NO lines in the range', async () => {
+    // The account is quiet this month, not gone. Its brought-forward position
+    // is what an accountant is reconciling against, so dropping it would make
+    // the ledger disagree with the balance sheet for the same date.
+    vi.mocked(listChartAccounts).mockResolvedValue(
+      ok([
+        account({ id: 'id_cash', code: '1000', name: 'Cash' }),
+        account({ id: 'id_equip', code: '1500', name: 'Equipment' }),
+      ])
+    )
+
+    const result = await readGeneralLedger(
+      stubDb([
+        [opening('id_equip', 250_000, 0)],
+        [
+          line({
+            glAccountId: 'id_cash',
+            txnDate: '2026-08-10',
+            direction: 'debit',
+            amountMinor: 1_000,
+          }),
+        ],
+      ]),
+      { organizationId: ORG, ...RANGE }
+    )
+
+    const equipment = result._unsafeUnwrap().accounts.find((a) => a.glAccountId === 'id_equip')
+    expect(equipment).toBeDefined()
+    expect(equipment?.lines).toEqual([])
+    expect(equipment?.openingBalanceMinor).toBe(250_000)
+    expect(equipment?.endingBalanceMinor).toBe(250_000)
+    expect(equipment?.debitMinor).toBe(0)
+  })
+
+  it('omits an account that is both untouched in the range and flat before it', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(
+      ok([account({ id: 'id_cash', code: '1000' }), account({ id: 'id_susp', code: '1999' })])
+    )
+
+    const result = await readGeneralLedger(
+      stubDb([
+        // A suspense account that has netted to zero: nothing to say about it.
+        [opening('id_susp', 10_000, 10_000)],
+        [
+          line({
+            glAccountId: 'id_cash',
+            txnDate: '2026-08-10',
+            direction: 'debit',
+            amountMinor: 1_000,
+          }),
+        ],
+      ]),
+      { organizationId: ORG, ...RANGE }
+    )
+
+    expect(result._unsafeUnwrap().accounts.map((a) => a.glAccountId)).toEqual(['id_cash'])
+  })
+
+  it('is balanced over a real posted set, and says so when it is not', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(
+      ok([
+        account({ id: 'id_cash', code: '1000', name: 'Cash', accountType: 'asset' }),
+        account({ id: 'id_rev', code: '4000', name: 'Sales', accountType: 'revenue' }),
+      ])
+    )
+
+    const balancedLines = [
+      line({
+        glAccountId: 'id_cash',
+        txnDate: '2026-08-03',
+        direction: 'debit',
+        amountMinor: 120_000,
+      }),
+      line({
+        glAccountId: 'id_rev',
+        txnDate: '2026-08-03',
+        direction: 'credit',
+        amountMinor: 120_000,
+      }),
+    ]
+
+    const balanced = await readGeneralLedger(stubDb([[], balancedLines]), {
+      organizationId: ORG,
+      ...RANGE,
+    })
+    const gl = balanced._unsafeUnwrap()
+    expect(gl.totalDebitMinor).toBe(120_000)
+    expect(gl.totalCreditMinor).toBe(120_000)
+    expect(gl.balanced).toBe(true)
+    expect(gl.truncated).toBe(false)
+
+    const lopsided = await readGeneralLedger(stubDb([[], [balancedLines[0]]]), {
+      organizationId: ORG,
+      ...RANGE,
+    })
+    expect(lopsided._unsafeUnwrap().balanced).toBe(false)
+  })
+
+  it('bounds the range INCLUSIVELY on `to`, so the last day of the month is in it', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(ok([account({ id: 'id_cash', code: '1000' })]))
+    const capture: Capture = { where: [], limit: [] }
+
+    await readGeneralLedger(stubDb([[], []], capture), { organizationId: ORG, ...RANGE })
+
+    const dialect = new PgDialect()
+    // The lines query is the second `select()`. Serialized, its bounds have to
+    // read `>= from` and `<= to` - a `<` on `to` would silently drop every
+    // entry posted on the closing day, which is the busiest day of a month.
+    const lines = dialect.sqlToQuery(capture.where[1] as SqlCondition)
+    expect(lines.params).toEqual([ORG, 'posted', 'reversed', RANGE.from, RANGE.to])
+    expect(lines.sql).toContain('>= $4')
+    expect(lines.sql).toContain('<= $5')
+    expect(lines.sql).not.toContain('< $5')
+
+    // And the opening aggregate stops the day BEFORE `from`, so no line is
+    // counted on both sides of the boundary.
+    const openingQuery = dialect.sqlToQuery(capture.where[0] as SqlCondition)
+    expect(openingQuery.params).toEqual([ORG, 'posted', 'reversed', '2026-07-31'])
+    expect(openingQuery.sql).toContain('<= $4')
+  })
+
+  it('sets `truncated` and stops at `maxLines`, applying the cap in SQL', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(ok([account({ id: 'id_cash', code: '1000' })]))
+    const capture: Capture = { where: [], limit: [] }
+
+    const four = [1, 2, 3, 4].map((n) =>
+      line({
+        glAccountId: 'id_cash',
+        txnDate: `2026-08-0${n}`,
+        direction: 'debit',
+        amountMinor: 1_000,
+        docNumber: `JNL-000${n}`,
+      })
+    )
+
+    const result = await readGeneralLedger(stubDb([[], four], capture), {
+      organizationId: ORG,
+      ...RANGE,
+      maxLines: 3,
+    })
+
+    const gl = result._unsafeUnwrap()
+    expect(gl.truncated).toBe(true)
+    expect(gl.accounts[0]?.lines).toHaveLength(3)
+    // 🛑 `maxLines + 1` in SQL: the extra row is what distinguishes "there was
+    // more" from "that was exactly all of it", and a `LIMIT` is what keeps the
+    // guard a guard rather than a post-hoc slice of rows already in memory.
+    expect(capture.limit[1]).toBe(4)
+  })
+
+  it('does NOT set `truncated` when the range ends exactly at `maxLines`', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(ok([account({ id: 'id_cash', code: '1000' })]))
+
+    const three = [1, 2, 3].map((n) =>
+      line({
+        glAccountId: 'id_cash',
+        txnDate: `2026-08-0${n}`,
+        direction: 'debit',
+        amountMinor: 1_000,
+        docNumber: `JNL-000${n}`,
+      })
+    )
+
+    const result = await readGeneralLedger(stubDb([[], three]), {
+      organizationId: ORG,
+      ...RANGE,
+      maxLines: 3,
+    })
+
+    expect(result._unsafeUnwrap().truncated).toBe(false)
+    expect(result._unsafeUnwrap().accounts[0]?.lines).toHaveLength(3)
+  })
+
+  it('applies no LIMIT at all when `maxLines` is omitted', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(ok([account({ id: 'id_cash', code: '1000' })]))
+    const capture: Capture = { where: [], limit: [] }
+
+    await readGeneralLedger(stubDb([[], []], capture), { organizationId: ORG, ...RANGE })
+
+    expect(capture.limit[1]).toBeUndefined()
+  })
+
+  it('still shows an account that has been DELETED from the chart, unsigned', async () => {
+    // Decision P2: a line stores an account id with no foreign key, so the
+    // ledger outlives the chart. Dropping the section would lose posted
+    // history and break the tie-out with the trial balance, which keeps it.
+    vi.mocked(listChartAccounts).mockResolvedValue(ok([]))
+
+    const result = await readGeneralLedger(
+      stubDb([
+        [opening('id_gone', 7_000, 0)],
+        [
+          line({
+            glAccountId: 'id_gone',
+            txnDate: '2026-08-09',
+            direction: 'credit',
+            amountMinor: 2_000,
+          }),
+        ],
+      ]),
+      { organizationId: ORG, ...RANGE }
+    )
+
+    const gone = result._unsafeUnwrap().accounts[0]
+    expect(gone?.glAccountId).toBe('id_gone')
+    expect(gone?.accountType).toBeNull()
+    expect(gone?.accountName).toBe('')
+    expect(gone?.accountCode).toBeNull()
+    // Unsigned: debit minus credit, because there is no natural side left.
+    expect(gone?.openingBalanceMinor).toBe(7_000)
+    expect(gone?.lines[0]?.runningBalanceMinor).toBe(5_000)
+  })
+
+  it('refuses a range whose `to` is before its `from`', async () => {
+    vi.mocked(listChartAccounts).mockResolvedValue(ok([]))
+
+    const result = await readGeneralLedger(stubDb([[], []]), {
+      organizationId: ORG,
+      from: '2026-08-31',
+      to: '2026-08-01',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('before')
+  })
+
+  it('the cap is a real number, and generous enough that a small company never meets it', () => {
+    expect(GENERAL_LEDGER_MAX_LINES).toBeGreaterThanOrEqual(10_000)
+  })
+})
+
+describe('toGeneralLedgerRows', () => {
+  const gl = {
+    organizationId: ORG,
+    from: RANGE.from,
+    to: RANGE.to,
+    accounts: [
+      {
+        glAccountId: 'id_cash',
+        accountCode: '1000',
+        accountName: 'Cash',
+        accountType: 'asset' as const,
+        openingBalanceMinor: 50_000,
+        lines: [
+          {
+            glPostingId: 'gl_1',
+            docNumber: 'JNL-0001',
+            txnDate: '2026-08-10',
+            memo: 'Deposit',
+            direction: 'debit' as const,
+            amountMinor: 5_000,
+            runningBalanceMinor: 55_000,
+          },
+          {
+            glPostingId: 'gl_2',
+            docNumber: 'JNL-0002',
+            txnDate: '2026-08-12',
+            memo: null,
+            direction: 'credit' as const,
+            amountMinor: 2_000,
+            runningBalanceMinor: 53_000,
+          },
+        ],
+        endingBalanceMinor: 53_000,
+        debitMinor: 5_000,
+        creditMinor: 2_000,
+      },
+    ],
+    totalDebitMinor: 5_000,
+    totalCreditMinor: 2_000,
+    balanced: false,
+    truncated: false,
+  }
+
+  it('renders one section per account, opening first and ending last', () => {
+    const rows = toGeneralLedgerRows(gl)
+    expect(rows.map((r) => r.id)).toEqual(['id_cash', 'total'])
+
+    const section = rows[0]
+    expect(section?.kind).toBe('section')
+    expect(section?.label).toBe('1000 Cash')
+    expect(section?.children?.map((c) => c.label)).toEqual([
+      'Opening balance',
+      '2026-08-10  JNL-0001',
+      '2026-08-12  JNL-0002',
+      'Ending balance',
+    ])
+    // The memo has no column of its own (see `GENERAL_LEDGER_COLUMNS`), so it
+    // rides the row as its description.
+    expect(section?.children?.[1]?.meta?.note).toBe('Deposit')
+    // Debit and credit in their own columns, the running balance in the third.
+    expect(section?.children?.[1]?.values).toEqual([5_000, null, 55_000])
+    expect(section?.children?.[2]?.values).toEqual([null, 2_000, 53_000])
+  })
+
+  it('never SUMS the running-balance column - the section and its closing row carry the ENDING balance', () => {
+    // `statementSection` sums every column, which is right for debit and credit
+    // and nonsense for a balance: 55,000 + 53,000 is not a position.
+    const rows = toGeneralLedgerRows(gl)
+    const section = rows[0]
+    expect(section?.values).toEqual([5_000, 2_000, 53_000])
+    const closing = section?.children?.at(-1)
+    expect(closing?.values).toEqual([5_000, 2_000, 53_000])
+  })
+
+  it('prints an INCOMPLETE banner as the FIRST row when the ledger is truncated', () => {
+    // 🛑 A `truncated: true` field on a JSON response never reaches the person
+    // reading the CSV or the PDF. A row does.
+    const rows = toGeneralLedgerRows({ ...gl, truncated: true })
+    expect(rows[0]?.id).toBe('truncated')
+    expect(rows[0]?.label).toContain('INCOMPLETE')
+    expect(rows[0]?.label).toContain('2 lines')
+    expect(rows[0]?.label).toContain('does not tie')
+    expect(rows.map((r) => r.id)).toEqual(['truncated', 'id_cash', 'total'])
+  })
+
+  it('labels a deleted account by its id, and flags it', () => {
+    const rows = toGeneralLedgerRows({
+      ...gl,
+      accounts: [
+        {
+          ...gl.accounts[0]!,
+          glAccountId: 'id_gone',
+          accountCode: null,
+          accountName: '',
+          accountType: null,
+        },
+      ],
+    })
+    expect(rows[0]?.label).toBe('id_gone')
+    expect(rows[0]?.meta?.note).toContain('deleted from the current chart')
+  })
+})

--- a/packages/lib/src/postings/reports/adapters.ts
+++ b/packages/lib/src/postings/reports/adapters.ts
@@ -11,8 +11,16 @@
 // `rows: StatementRow[]`" means in practice - see `ledger-reports.ts`.
 
 import type { BalanceSheetRow, BalanceSheetSnapshot } from './balance-sheet'
+import type { GeneralLedger } from './general-ledger'
 import type { ProfitAndLossRow, ProfitAndLossSnapshot } from './profit-and-loss'
-import { computedRow, type StatementColumn, type StatementRow, totalRow } from './rows'
+import {
+  computedRow,
+  type StatementColumn,
+  type StatementLineInput,
+  type StatementRow,
+  statementSection,
+  totalRow,
+} from './rows'
 import type { TrialBalance } from './trial-balance'
 
 /** The trial balance's own columns, in the order `toTrialBalanceRows` fills them. */
@@ -333,4 +341,116 @@ export function toProfitAndLossRows(
   )
 
   return [revenueSection, cogsSection, grossProfit, opexSection, netIncome]
+}
+
+/**
+ * The general ledger's own columns.
+ *
+ * 🛑 Three columns, not the six ("date, document, memo, debit, credit,
+ * balance") a firm's printed ledger has, because **`StatementRow.values` is
+ * `Array<number | null>`** - every renderer this shape feeds
+ * (`StatementTable`, `GroupedRowsTable`, `toCsvRows`) formats a cell as
+ * CURRENCY. There is no text column to put a date, a document number or a memo
+ * in, and faking one with a number would print `$2,026.08`.
+ *
+ * So the three text facts ride the row instead, exactly as `toAgingRows`
+ * carries a due date: the DATE and DOCUMENT NUMBER are the line's `label`, and
+ * the MEMO is `meta.note`, which the table renders as the row's description and
+ * `toCsvRows` folds into nothing - a CSV reader gets `2026-08-04  JNL-0002` in
+ * the Label column, which is what a spreadsheet needs to sort and filter on.
+ *
+ * Adding real text columns is a change to `StatementRow` and to all three
+ * renderers; it is not something this adapter can do on its own.
+ */
+export const GENERAL_LEDGER_COLUMNS: StatementColumn[] = [
+  { key: 'debit', label: 'Debit', align: 'right' },
+  { key: 'credit', label: 'Credit', align: 'right' },
+  { key: 'balance', label: 'Balance', align: 'right', signed: true },
+]
+
+/** Where the running-balance column sits, for the two cells `statementSection` cannot compute. */
+const BALANCE_COLUMN = 2
+
+/**
+ * One section per account - `statementSection`'s parent-plus-children shape -
+ * with a brought-forward opening row, one line per posted line, and a closing
+ * "Ending balance" row.
+ *
+ * 🛑 Two cells are overwritten after `statementSection` builds the section, and
+ * both are the same cell: the Balance column. `statementSection` SUMS every
+ * column across its lines, which is right for debit and credit and meaningless
+ * for a running balance - a running balance is a POSITION at a moment, and the
+ * sum of an account's positions is not a number. Both the section header and
+ * its own total row therefore carry `endingBalanceMinor` instead.
+ *
+ * When {@link GeneralLedger.truncated} is set, a `'computed'` row goes FIRST,
+ * ahead of every account, saying so in the label - so it survives into the CSV
+ * and the PDF, where a `truncated: true` field on a JSON response does not
+ * reach the person actually reading the ledger.
+ */
+export function toGeneralLedgerRows(gl: GeneralLedger): StatementRow[] {
+  const sections = gl.accounts.map((account) => {
+    const label = account.accountName
+      ? [account.accountCode, account.accountName].filter(Boolean).join(' ')
+      : (account.accountCode ?? account.glAccountId)
+
+    const lines: StatementLineInput[] = [
+      {
+        id: `${account.glAccountId}:opening`,
+        label: 'Opening balance',
+        // Null, not zero, in Debit and Credit: the brought-forward figure is
+        // not activity, and a zero here would print `$0.00` under a column the
+        // section header totals.
+        values: [null, null, account.openingBalanceMinor],
+      },
+      ...account.lines.map((line) => ({
+        id: `${account.glAccountId}:${line.glPostingId}:${line.txnDate}:${line.docNumber}`,
+        // The drill-down key, carried as DATA rather than left to be parsed
+        // back out of `id` above. A GL line's destination is its posting.
+        glPostingId: line.glPostingId,
+        // The date and the document number, because there is no column for
+        // either - see `GENERAL_LEDGER_COLUMNS`.
+        label: `${line.txnDate}  ${line.docNumber}`,
+        values: [
+          line.direction === 'debit' ? line.amountMinor : null,
+          line.direction === 'credit' ? line.amountMinor : null,
+          line.runningBalanceMinor,
+        ],
+        note: line.memo ?? undefined,
+      })),
+    ]
+
+    const section = statementSection(account.glAccountId, label, lines, {
+      totalLabel: 'Ending balance',
+    })
+    section.values[BALANCE_COLUMN] = account.endingBalanceMinor
+    const closing = section.children?.[section.children.length - 1]
+    if (closing) closing.values[BALANCE_COLUMN] = account.endingBalanceMinor
+    section.meta = {
+      glAccountId: account.glAccountId,
+      accountCode: account.accountCode,
+      accountName: account.accountName,
+      accountType: account.accountType ?? undefined,
+      note: account.accountType
+        ? undefined
+        : 'This account has posted lines but has been deleted from the current chart of accounts.',
+    }
+    return section
+  })
+
+  const rows: StatementRow[] = []
+  if (gl.truncated) {
+    const shown = gl.accounts.reduce((count, account) => count + account.lines.length, 0)
+    rows.push(
+      computedRow(
+        'truncated',
+        `INCOMPLETE - stopped at ${shown.toLocaleString('en-US')} lines. This ledger does not tie to the trial balance; run a shorter date range.`,
+        [null, null, null],
+        'The size guard fired. Everything below is a partial ledger.'
+      )
+    )
+  }
+  rows.push(...sections)
+  rows.push(totalRow('total', 'Total', [gl.totalDebitMinor, gl.totalCreditMinor, null]))
+  return rows
 }

--- a/packages/lib/src/postings/reports/general-ledger.ts
+++ b/packages/lib/src/postings/reports/general-ledger.ts
@@ -1,0 +1,390 @@
+// packages/lib/src/postings/reports/general-ledger.ts
+//
+// Every posted line in a date range, grouped by account. The sixth statement.
+//
+// ## Why this exists, when `account-lines.ts` already reads one account
+//
+// Because a filing accountant asks for the general ledger FIRST, and today it
+// is the one report that exists in no form at all. `readAccountLines` answers
+// "show me this account" from a drill-down dialog; producing a general ledger
+// out of it means opening that dialog once per account and copying each one
+// out of the browser by hand.
+//
+// This is the same query without the `glAccountId` filter, grouped. The shapes
+// below deliberately mirror `AccountLines` / `AccountLineRow` so that the two
+// stay recognisably the same report at two zoom levels.
+//
+// ## 🛑 The one way this report is unlike the other five
+//
+// Every other statement is bounded by the CHART: a trial balance has as many
+// rows as the org has accounts. **A general ledger is bounded by TRANSACTION
+// VOLUME**, and a year of a real company's is tens of thousands of lines.
+// `toCsvRows` (`reports/rows.ts`) materialises the whole array and the PDF path
+// is worse.
+//
+// `listPostings` hit this same wall and answered it with a hard cap of 200
+// (`list-postings.ts:47`). **That is exactly the wrong answer here**: a
+// truncated general ledger does not tie to the trial balance, and the
+// accountant reading it has no way to know why. Chunk the range or stream;
+// never silently cap. {@link GeneralLedger.truncated} is how a caller that
+// cannot finish says so out loud.
+//
+// @see plans/accounting/tasks/21-the-books-stand-alone.md §5
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, asc, eq, gte, inArray, lte, sql } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError, UnprocessableEntityError } from '../../errors'
+import { compareAccountsByCodeThenName } from '../account-label'
+import { GL_ACCOUNT_TYPES, type GlAccountTypeValue } from '../default-chart'
+import { listChartAccounts } from '../role-map'
+import type { ChartAccountRow, PostingDirection } from '../types'
+import type { AccountLineRow } from './account-lines'
+import { previousCalendarDay } from './fiscal-year'
+import { NATURAL_BALANCE_DIRECTION, signedBalance } from './statement-math'
+
+const logger = createScopedLogger('postings:reports:general-ledger')
+
+/** Only a posted entry counts - `verify-balance.ts` says why `pending`/`failed` do not. */
+const POSTED_STATUSES = ['posted', 'reversed'] as const
+
+/**
+ * Statement order (asset, liability, equity, revenue, expense) as a rank map -
+ * the trial balance's own 15.2 sort, so the two reports list the same accounts
+ * in the same order and an accountant can read them side by side.
+ */
+const STATEMENT_ORDER = new Map(GL_ACCOUNT_TYPES.map((type, index) => [type, index]))
+
+const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * 🛑 The router's size guard, and the number the PDF render uses too, so the
+ * page, the CSV and the PDF can never stop at three different places.
+ *
+ * ~25,000 lines is roughly 6,000 postings at four lines each: a company
+ * posting 500 entries a month reads a FULL YEAR under it and never sees the
+ * flag, while a busy shop asking for a year gets a ledger that stops - loudly -
+ * instead of a request that eats the process. It is a safety valve on the
+ * server, deliberately NOT a client input: a cap a caller can raise is not a
+ * cap.
+ */
+export const GENERAL_LEDGER_MAX_LINES = 25_000
+
+/**
+ * One account's section of the ledger: the account, where it started, every
+ * posted line in the range, and where it ended.
+ *
+ * `lines` reuses {@link AccountLineRow} unchanged - same fields, same
+ * natural-sign `runningBalanceMinor` applied line by line - so a reader who
+ * knows the drill-down knows this.
+ */
+export interface GeneralLedgerAccount {
+  /** The `gl_account` `EntityInstance` id. The IDENTITY (task 15), never a code. */
+  glAccountId: string
+  /** The account's CURRENT code, read from the live chart by id. `null` when deleted or code-less. */
+  accountCode: string | null
+  /** `''` when the account has been deleted from this org's chart. */
+  accountName: string
+  /** `null` when the account has been deleted - the running balance is then unsigned. */
+  accountType: GlAccountTypeValue | null
+  /** The natural-sign balance immediately before `from`, carried into `lines[0].runningBalanceMinor`. */
+  openingBalanceMinor: number
+  /** Oldest first. */
+  lines: AccountLineRow[]
+  /** The last line's `runningBalanceMinor`, or `openingBalanceMinor` when there are no lines. */
+  endingBalanceMinor: number
+  debitMinor: number
+  creditMinor: number
+}
+
+export interface GeneralLedger {
+  organizationId: string
+  /** `YYYY-MM-DD`. */
+  from: string
+  /** `YYYY-MM-DD`, inclusive. */
+  to: string
+  /**
+   * Accounts with at least one line in the range, or a non-zero opening
+   * balance. An account that was untouched and started at zero is omitted:
+   * a general ledger listing every empty account is unreadable, and the trial
+   * balance is where "every account" belongs.
+   */
+  accounts: GeneralLedgerAccount[]
+  totalDebitMinor: number
+  totalCreditMinor: number
+  /** `totalDebitMinor === totalCreditMinor`. Ties to the trial balance for the same range. */
+  balanced: boolean
+  /**
+   * 🛑 `true` when {@link ReadGeneralLedgerOptions.maxLines} was reached and
+   * the ledger below is INCOMPLETE.
+   *
+   * A caller must never render a truncated ledger as a finished one: it will
+   * not tie, and the person reading it is reconciling against something else.
+   * Say so on the screen and in the export, or narrow the range.
+   */
+  truncated: boolean
+}
+
+export interface ReadGeneralLedgerOptions {
+  organizationId: string
+  /** `YYYY-MM-DD`. Required - a general ledger is always a range, never cumulative. */
+  from: string
+  /** `YYYY-MM-DD`, inclusive. */
+  to: string
+  /**
+   * Stop after this many LINES and set {@link GeneralLedger.truncated}.
+   *
+   * A safety valve, not a page size: the intended use is a range small enough
+   * that it never fires. Omit for no limit.
+   */
+  maxLines?: number
+}
+
+/**
+ * Every posted line in `[from, to]`, grouped by account, oldest first within
+ * each account, with a running natural-sign balance per account.
+ *
+ * Filtered to `POSTED_STATUSES` like every other statement, and grouped by
+ * `glAccountId` - the identity - so renumbering an account never splits its
+ * history across two sections.
+ *
+ * Opening balances are computed by summing every posted line before `from`,
+ * so each account's running balance starts from its true position rather than
+ * from zero. That is one extra aggregate over the same table, not one query
+ * per account.
+ */
+export async function readGeneralLedger(
+  db: Database,
+  options: ReadGeneralLedgerOptions
+): Promise<Result<GeneralLedger, Error>> {
+  const { organizationId, from, to, maxLines } = options
+
+  try {
+    assertDayFormat(from, 'from')
+    assertDayFormat(to, 'to')
+    if (to < from) {
+      throw new UnprocessableEntityError(`"to" (${to}) is before "from" (${from})`, { from, to })
+    }
+
+    const chartResult = await listChartAccounts(db, organizationId)
+    if (chartResult.isErr()) return err(chartResult.error)
+    const chartById = new Map(chartResult.value.map((account) => [account.id, account]))
+
+    const opening = await readOpeningBalances(db, organizationId, previousCalendarDay(from))
+
+    // 🛑 `limit` is applied in SQL, not after the fact. The guard exists to
+    // protect the PROCESS, and a JS `.slice()` over a result set the driver
+    // already materialised protects nothing. `maxLines + 1` is what makes
+    // "there was more" distinguishable from "that was exactly all of it".
+    const linesQuery = db
+      .select({
+        glAccountId: schema.GlPostingLine.glAccountId,
+        glPostingId: schema.GlPosting.id,
+        docNumber: schema.GlPosting.docNumber,
+        txnDate: schema.GlPosting.txnDate,
+        memo: schema.GlPostingLine.memo,
+        direction: schema.GlPostingLine.direction,
+        amountMinor: schema.GlPostingLine.amountMinor,
+      })
+      .from(schema.GlPostingLine)
+      .innerJoin(schema.GlPosting, eq(schema.GlPosting.id, schema.GlPostingLine.glPostingId))
+      .where(
+        and(
+          eq(schema.GlPosting.organizationId, organizationId),
+          inArray(schema.GlPosting.status, [...POSTED_STATUSES]),
+          gte(schema.GlPosting.txnDate, from),
+          lte(schema.GlPosting.txnDate, to)
+        )
+      )
+      // Account first, then chronological within the account: the cut, when it
+      // comes, lands at an account boundary far more often than it lands mid
+      // account, and every account BEFORE it is whole.
+      .orderBy(
+        asc(schema.GlPostingLine.glAccountId),
+        asc(schema.GlPosting.txnDate),
+        asc(schema.GlPosting.docNumber),
+        asc(schema.GlPostingLine.lineNumber)
+      )
+
+    const rawLines = await (maxLines === undefined ? linesQuery : linesQuery.limit(maxLines + 1))
+
+    const truncated = maxLines !== undefined && rawLines.length > maxLines
+    const usableLines = truncated ? rawLines.slice(0, maxLines) : rawLines
+
+    const byAccount = new Map<string, typeof usableLines>()
+    for (const line of usableLines) {
+      const bucket = byAccount.get(line.glAccountId)
+      if (bucket) bucket.push(line)
+      else byAccount.set(line.glAccountId, [line])
+    }
+
+    // "Accounts with at least one line in the range, OR a non-zero opening
+    // balance" - the union, so an account that only carries a brought-forward
+    // figure still shows the reader where it stands.
+    const glAccountIds = new Set<string>(byAccount.keys())
+    for (const [glAccountId, sums] of opening) {
+      if (sums.debitMinor !== sums.creditMinor) glAccountIds.add(glAccountId)
+    }
+
+    const accounts: GeneralLedgerAccount[] = []
+    for (const glAccountId of glAccountIds) {
+      accounts.push(
+        buildAccount(glAccountId, chartById.get(glAccountId), opening.get(glAccountId), [
+          ...(byAccount.get(glAccountId) ?? []),
+        ])
+      )
+    }
+    accounts.sort(compareSections)
+
+    const totalDebitMinor = accounts.reduce((sum, account) => sum + account.debitMinor, 0)
+    const totalCreditMinor = accounts.reduce((sum, account) => sum + account.creditMinor, 0)
+
+    return ok({
+      organizationId,
+      from,
+      to,
+      accounts,
+      totalDebitMinor,
+      totalCreditMinor,
+      // The literal definition this interface documents. ⚠️ It is only a
+      // TIE-OUT when `truncated` is false - a partial ledger's two sides can
+      // agree by luck - so a caller reads `truncated` FIRST.
+      balanced: totalDebitMinor === totalCreditMinor,
+      truncated,
+    })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to read the general ledger', { error, organizationId, from, to })
+    return err(new AuxxError('Internal error'))
+  }
+}
+
+/** One raw joined line, before it becomes an {@link AccountLineRow}. */
+interface RawLedgerLine {
+  glAccountId: string
+  glPostingId: string
+  docNumber: string
+  txnDate: string
+  memo: string | null
+  direction: string
+  amountMinor: string | number
+}
+
+/**
+ * One account's section: the running natural-sign balance walked line by line
+ * from its opening position, exactly as `readAccountLines` walks one account -
+ * the two reports are the same report at two zoom levels and must agree line
+ * for line.
+ */
+function buildAccount(
+  glAccountId: string,
+  account: ChartAccountRow | undefined,
+  openingSums: { debitMinor: number; creditMinor: number } | undefined,
+  rawLines: readonly RawLedgerLine[]
+): GeneralLedgerAccount {
+  const openingDebit = openingSums?.debitMinor ?? 0
+  const openingCredit = openingSums?.creditMinor ?? 0
+  // A deleted account has no natural side left to sign against, so its balance
+  // is the unsigned debit-minus-credit `readAccountLines` falls back to.
+  const openingBalanceMinor = account
+    ? signedBalance(openingDebit, openingCredit, account.accountType)
+    : openingDebit - openingCredit
+  const naturalDirection = account ? NATURAL_BALANCE_DIRECTION[account.accountType] : 'debit'
+
+  let running = openingBalanceMinor
+  let debitMinor = 0
+  let creditMinor = 0
+  const lines: AccountLineRow[] = rawLines.map((line) => {
+    const amountMinor = toMinor(line.amountMinor)
+    const direction = line.direction as PostingDirection
+    if (direction === 'debit') debitMinor += amountMinor
+    else creditMinor += amountMinor
+    running += direction === naturalDirection ? amountMinor : -amountMinor
+    return {
+      glPostingId: line.glPostingId,
+      docNumber: line.docNumber,
+      txnDate: line.txnDate,
+      memo: line.memo,
+      direction,
+      amountMinor,
+      runningBalanceMinor: running,
+    }
+  })
+
+  return {
+    glAccountId,
+    // The CURRENT code, or null - never the snapshot a line happened to carry.
+    // A DELETED account is identified by its id in the section label instead,
+    // which is what an empty `accountName` tells the adapter to do.
+    accountCode: account ? account.code : null,
+    accountName: account?.name ?? '',
+    accountType: account?.accountType ?? null,
+    openingBalanceMinor,
+    lines,
+    endingBalanceMinor: lines.length > 0 ? running : openingBalanceMinor,
+    debitMinor,
+    creditMinor,
+  }
+}
+
+/**
+ * Every account's `SUM(debit)`/`SUM(credit)` through `through`, in ONE
+ * aggregate.
+ *
+ * 🛑 One query, not one per account. `readAccountLines` can afford a
+ * per-account opening sum because it reads one account; a general ledger over
+ * a full chart would turn that into a hundred round trips for a figure a
+ * single `GROUP BY` already has.
+ */
+async function readOpeningBalances(
+  db: Database,
+  organizationId: string,
+  through: string
+): Promise<Map<string, { debitMinor: number; creditMinor: number }>> {
+  const rows = await db
+    .select({
+      glAccountId: schema.GlPostingLine.glAccountId,
+      debitMinor: sql<string>`coalesce(sum(${schema.GlPostingLine.amountMinor}) filter (where ${schema.GlPostingLine.direction} = 'debit'), 0)`,
+      creditMinor: sql<string>`coalesce(sum(${schema.GlPostingLine.amountMinor}) filter (where ${schema.GlPostingLine.direction} = 'credit'), 0)`,
+    })
+    .from(schema.GlPostingLine)
+    .innerJoin(schema.GlPosting, eq(schema.GlPosting.id, schema.GlPostingLine.glPostingId))
+    .where(
+      and(
+        eq(schema.GlPosting.organizationId, organizationId),
+        inArray(schema.GlPosting.status, [...POSTED_STATUSES]),
+        lte(schema.GlPosting.txnDate, through)
+      )
+    )
+    .groupBy(schema.GlPostingLine.glAccountId)
+
+  return new Map(
+    rows.map((row) => [
+      row.glAccountId,
+      { debitMinor: toMinor(row.debitMinor), creditMinor: toMinor(row.creditMinor) },
+    ])
+  )
+}
+
+/** The trial balance's 15.2 order: statement type first, then code, then name. */
+function compareSections(a: GeneralLedgerAccount, b: GeneralLedgerAccount): number {
+  const orderA = a.accountType ? (STATEMENT_ORDER.get(a.accountType) ?? 0) : STATEMENT_ORDER.size
+  const orderB = b.accountType ? (STATEMENT_ORDER.get(b.accountType) ?? 0) : STATEMENT_ORDER.size
+  if (orderA !== orderB) return orderA - orderB
+  return compareAccountsByCodeThenName(
+    { code: a.accountCode, name: a.accountName },
+    { code: b.accountCode, name: b.accountName }
+  )
+}
+
+function assertDayFormat(date: string, label: string): void {
+  if (!DAY_PATTERN.test(date)) {
+    throw new UnprocessableEntityError(`${label} must be YYYY-MM-DD, got "${date}"`, { date })
+  }
+}
+
+/** `SUM(bigint)` arrives as a `numeric` string - coerce once here, as every other statement does. */
+function toMinor(value: string | number): number {
+  return typeof value === 'number' ? value : Number(value)
+}

--- a/packages/lib/src/postings/reports/pdf/render-statement-pdf.ts
+++ b/packages/lib/src/postings/reports/pdf/render-statement-pdf.ts
@@ -25,14 +25,17 @@ import { createS3StoragePort } from '../../../files/storage/ports'
 import { createStorageManager } from '../../../files/storage/storage-manager'
 import {
   balanceSheetColumns,
+  GENERAL_LEDGER_COLUMNS,
   TRIAL_BALANCE_COLUMNS,
   toBalanceSheetRows,
+  toGeneralLedgerRows,
   toProfitAndLossRows,
   toTrialBalanceRows,
 } from '../adapters'
 import { AGING_COLUMNS, readAging, toAgingRows } from '../aging'
 import { readBalanceSheet } from '../balance-sheet'
 import { readCompleteness } from '../completeness'
+import { GENERAL_LEDGER_MAX_LINES, readGeneralLedger } from '../general-ledger'
 import { readProfitAndLoss } from '../profit-and-loss'
 import type { StatementColumn, StatementRow } from '../rows'
 import { readTrialBalance } from '../trial-balance'
@@ -49,6 +52,7 @@ export type StatementKind =
   | 'ar-aging'
   | 'ap-aging'
   | 'vendor-1099'
+  | 'general-ledger'
 
 /** One kind's own parameter shape - each report's own `from`/`to`/`asOf`/`compare`. */
 export interface RenderStatementPdfParamsByKind {
@@ -58,6 +62,7 @@ export interface RenderStatementPdfParamsByKind {
   'ar-aging': { asOf: string }
   'ap-aging': { asOf: string }
   'vendor-1099': { year: number }
+  'general-ledger': { from: string; to: string }
 }
 
 export interface RenderStatementPdfOptions<K extends StatementKind = StatementKind> {
@@ -79,6 +84,7 @@ const STATEMENT_NAMES: Record<StatementKind, string> = {
   'ar-aging': 'A/R Aging',
   'ap-aging': 'A/P Aging',
   'vendor-1099': '1099 Summary',
+  'general-ledger': 'General Ledger',
 }
 
 interface StatementPayload {
@@ -140,6 +146,31 @@ async function buildPayload<K extends StatementKind>(
           ]
         : [{ key: 'primary', label: `${from} to ${to}`, align: 'right', signed: true }],
       rows: toProfitAndLossRows(result.value, result.value.compare),
+      completenessAsOf: to,
+    }
+  }
+
+  if (kind === 'general-ledger') {
+    const { from, to } = params as RenderStatementPdfParamsByKind['general-ledger']
+    // 🛑 The SAME `GENERAL_LEDGER_MAX_LINES` the router hands the screen read.
+    // A PDF that stopped at a different line than the page it was rendered from
+    // is the one thing this file's header promises can never happen - and an
+    // uncapped render here is the path that actually eats the process, since
+    // react-pdf holds the whole document tree in memory. `toGeneralLedgerRows`
+    // prints the INCOMPLETE banner as the first row when it fires, so the
+    // printed copy says so as loudly as the screen does.
+    const result = await readGeneralLedger(db, {
+      organizationId,
+      from,
+      to,
+      maxLines: GENERAL_LEDGER_MAX_LINES,
+    })
+    if (result.isErr()) throw result.error
+    return {
+      rangeLabel: `${from} to ${to}`,
+      asOfForKey: to,
+      columns: GENERAL_LEDGER_COLUMNS,
+      rows: toGeneralLedgerRows(result.value),
       completenessAsOf: to,
     }
   }

--- a/packages/lib/src/postings/reports/rows.ts
+++ b/packages/lib/src/postings/reports/rows.ts
@@ -48,6 +48,16 @@ export interface StatementRow {
      */
     accountType?: string
     recordId?: string
+    /**
+     * The `GlPosting` this row came from, when the row IS one posting's line -
+     * the general ledger's drill-down key.
+     *
+     * A `GlPosting` is neither a `gl_account` nor an `EntityInstance`, so it
+     * fits neither `glAccountId` nor `recordId`. Without it the only way to
+     * route a general-ledger line to its entry is to re-parse the row `id`,
+     * which silently stops working the day an adapter changes its id shape.
+     */
+    glPostingId?: string
     badge?: string
     note?: string
   }
@@ -63,6 +73,8 @@ export interface StatementLineInput {
   values: Array<number | null>
   accountCode?: string | null
   accountName?: string
+  /** Carried onto the row's `meta`. See {@link StatementRow.meta.glPostingId}. */
+  glPostingId?: string
   note?: string
 }
 
@@ -95,8 +107,13 @@ export function statementSection(
     kind: 'line',
     values: line.values,
     meta:
-      line.accountCode || line.accountName || line.note
-        ? { accountCode: line.accountCode, accountName: line.accountName, note: line.note }
+      line.accountCode || line.accountName || line.note || line.glPostingId
+        ? {
+            accountCode: line.accountCode,
+            accountName: line.accountName,
+            glPostingId: line.glPostingId,
+            note: line.note,
+          }
         : undefined,
   }))
 

--- a/packages/lib/src/seed/gl-account-chart.test.ts
+++ b/packages/lib/src/seed/gl-account-chart.test.ts
@@ -175,32 +175,35 @@ describe('seedChartPacks', () => {
     expect(result.packs).toEqual(['core', 'inventory', 'purchasing'])
   })
 
-  it("['core'] creates 13 and assigns 11", async () => {
+  // 27 since brief 21 §4.2 grew the core by fourteen role-less accounts (the
+  // operating expenses, prepaid and the two owner-equity movements). The role
+  // count is untouched at 11: none of the fourteen carries one.
+  it("['core'] creates 27 and assigns 11", async () => {
     const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core'])
 
     expect(result.packs).toEqual(['core'])
-    expect(result.created).toBe(13)
+    expect(result.created).toBe(27)
     expect(result.created).toBe(CORE_CODES.length)
     expect(result.rolesAssigned).toBe(11)
     expect(result.rolesAssigned).toBe(CORE_ROLES.length)
-    expect(h.creates).toHaveLength(13)
+    expect(h.creates).toHaveLength(27)
   })
 
-  it("['core', 'inventory'] creates 22 and assigns 18", async () => {
+  it("['core', 'inventory'] creates 36 and assigns 18", async () => {
     const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core', 'inventory'])
 
     expect(result.packs).toEqual(['core', 'inventory'])
-    expect(result.created).toBe(22)
+    expect(result.created).toBe(36)
     expect(result.created).toBe(CORE_PLUS_INVENTORY_ACCOUNTS.length)
     expect(result.rolesAssigned).toBe(18)
     expect(result.rolesAssigned).toBe(CORE_PLUS_INVENTORY_ROLES.length)
   })
 
-  it("['purchasing'] alone walks core, then inventory, then purchasing, landing 26 accounts and 22 roles", async () => {
+  it("['purchasing'] alone walks core, then inventory, then purchasing, landing 40 accounts and 22 roles", async () => {
     const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['purchasing'])
 
     expect(result.packs).toEqual(['core', 'inventory', 'purchasing'])
-    expect(result.created).toBe(26)
+    expect(result.created).toBe(40)
     expect(result.created).toBe(CORE_INVENTORY_PURCHASING_ACCOUNTS.length)
     expect(result.rolesAssigned).toBe(22)
     expect(result.rolesAssigned).toBe(CORE_INVENTORY_PURCHASING_ROLES.length)
@@ -351,7 +354,7 @@ describe('seedDefaultChartOfAccounts', () => {
     const result = await seedDefaultChartOfAccounts(stubDb([]), 'org-1', DEF_ID)
 
     expect(result.packs).toEqual(['core'])
-    expect(result.created).toBe(13)
+    expect(result.created).toBe(27)
     expect(result.rolesAssigned).toBe(11)
   })
 })


### PR DESCRIPTION
Two halves of the same problem: **a company should be able to keep its books in auxx without connecting QuickBooks, and today it cannot.**

---

# 1. The chart had no operating expenses

33 accounts, and the only expense accounts in the entire catalogue were two merchant-fee lines, bad debt, and six COGS/variance accounts. No rent, no utilities, no insurance, no wages, no withholdings, no fixed assets, no accumulated depreciation, no loans, no interest, no owner accounts, and no prepaid *expenses*.

🛑 **This was not a someday gap.** `bank_transaction` is a live posting type and a coded bank line posts against an account the operator picks. So **no org could code a rent payment**, Auxx-Lift included, and the only workaround was hand-creating accounts one at a time in the chart editor.

## What changed

**33 accounts → 58. Five packs → eight.** Nothing renumbered, renamed or deleted; no new roles, no new subtypes.

| | |
|---|---|
| **Core** (13 → 27) | `1400 Prepaid Expenses`, `3010/3020` owner contributions and draws, and eleven `6xxx` operating expenses: advertising, rent, utilities, insurance, software, professional fees, office, travel, repairs, bank charges, other |
| **`payroll`** | `2120 Net Pay Clearing`, `2130 Payroll Withholdings Payable`, `6400/6410/6420` wages, employer taxes, benefits |
| **`fixed_assets`** | `1500 Fixed Assets at Cost`, `1590 Accumulated Depreciation`, `6500 Depreciation Expense` |
| **`debt`** | `2500` current, `2800` long-term, `6600 Interest Expense` |

Every one carries **no role**. `ACCOUNT_ROLES` is a closed vocabulary tied to builders; the role-totality tests pass untouched.

## Three calls worth reviewing

**`2120 Net Pay Clearing` is a new account, not `2110`.** `2110 Payroll Clearing` is the manufacturing labour absorption pool that `build-month-end-inventory.ts:277` only ever *credits*. Sharing it would give one balance two meanings and leave no report able to separate unabsorbed labour from unpaid net pay.

**`1400 Prepaid Expenses` is core, not the `prepayments` pack.** That pack is customer deposits and deferred revenue — money a customer paid *us*, a liability. This is money we paid a vendor, an asset. Same English word, opposite side of the balance sheet. A test pins both.

**Owner contributions and draws went to core, not `debt`.** A founder's deposit is a first-week bank line for every company; a loan drawdown is not. Same argument that put rent in core, and it's why the pack is named `debt` rather than `equity_and_debt`.

## One bug found in passing

`packState` returned `'provisioned'` for a pack with **no roles** (empty filter → zero unmapped). All three new packs would have rendered as already-added and permanently unaddable in the pack picker. It now returns `'absent'`, with a comment saying that's a deliberate lie in the safe direction — the role map cannot see a role-less pack, and re-walking an idempotent seed costs nothing.

Answering it properly means asking the chart for codes, a query the dialog doesn't make today. Flagged for whoever owns that dialog.

---

# 2. The general ledger existed in no form at all

A filing accountant asks for six things. Five already export to CSV and PDF. **The general ledger is the one they ask for first**, and `readAccountLines` is one account per call from a drill-down dialog — so producing a GL meant opening that dialog once per account and copying each one out of the browser by hand.

`readGeneralLedger` is that same query without the account filter, grouped by `glAccountId` (the identity, so renumbering never splits a section), with opening balances from **one extra aggregate** rather than one query per account.

## 🛑 The size guard, which is the interesting part

Every other statement is bounded by the **chart** — a trial balance has as many rows as you have accounts. This one is bounded by **transaction volume**, and `toCsvRows` materialises the whole array while the PDF holds the whole tree.

`listPostings` hit this exact wall and answered with a hard cap of 200. **That is the wrong answer for an export**: a truncated general ledger does not tie to the trial balance, and the accountant reconciling against it cannot tell why.

So:

- `GENERAL_LEDGER_MAX_LINES = 25_000`, enforced as a SQL **`LIMIT maxLines + 1`**, not a post-hoc `.slice()` — the extra row is what distinguishes *"there was more"* from *"that was exactly all"*.
- **Not a client input.** A cap the caller can raise is not a cap. The router and the PDF pass the same constant, so screen, CSV and PDF always stop in the same place.
- ~25,000 lines is ~6,000 postings at four lines each: 500 entries a month reads a full year without ever seeing the flag.

**Truncation is impossible to mistake for a finished read.** The adapter prepends an `INCOMPLETE - stopped at N lines...` row **first**, so it reaches the CSV and the PDF, not just the screen. The page adds a banner, an `-INCOMPLETE` CSV filename, and swaps the balanced verdict — because `balanced` is literally `totalDebit === totalCredit` and **two partial sides can agree by luck**, which would otherwise print a green tick over a partial ledger.

Exports stay enabled while truncated, deliberately: disabling them only pushes someone toward screenshotting a partial ledger, which carries no warning at all.

## Three columns, not six

`StatementRow.values` is `Array<number | null>` and all three renderers format a cell as currency — a date in a value slot prints `$2,026.08`. So date and document number ride the row `label`, the memo rides `meta.note`, exactly as `toAgingRows` carries a due date. Real text columns are a change to `StatementRow` and every renderer, not something an adapter can fake. Three columns also trips the landscape threshold on its own.

## `meta.glPostingId` is new on the row contract

A general-ledger line's drill-down target is a `GlPosting`, which is neither a `gl_account` (`meta.glAccountId`) nor an `EntityInstance` (`meta.recordId`). Without a field for it, the only route from a rendered line back to its entry was re-parsing the composed row id — a coupling that breaks silently the day an adapter changes its id shape.

Threaded through `StatementLineInput` → `statementSection` → the adapter → `report-helpers` → the web's own `StatementRow` (a separate type with `RecordId` and `ReactNode`).

---

# Verification

| Check | Result |
|---|---|
| `src/postings` + `src/seed` | **2049 pass**, 106 files |
| `src/postings/reports` | 122 pass, 14 files |
| web `src/components/accounting` | 115 pass, 10 files |
| `@auxx/web` typecheck | clean |
| web ratchet | no new errors (0, baseline 0) |
| lib ratchet | no new errors from this branch |
| biome | clean |

**Tests updated, each because it asserted a number:** `default-chart.test.ts` (33 → 58 with per-pack sizes, so an account still cannot be added without stating its pack) and `seed/gl-account-chart.test.ts` (seed counts 13/22/26 → 27/36/40). **Role counts are untouched at 11/18/22**, which is the check proving none of the new accounts smuggled in a role.

New pins: `1400` vs the `prepayments` pack, owner equity in core as equity, the payroll pack clear of `2110`, accumulated depreciation as an asset, the current/long-term loan split, the three new packs driving zero roles, and `packState` reading a role-less pack as absent.

🟢 **No migration or backfill.** The accounting subsystem is not live, `GlPosting` is empty across dev orgs, and entity migration 142 wiped every seeded chart.

https://claude.ai/code/session_01SnnNtETzUo1YEyeuKw1SoK
