### PR TITLE
feat(accounting): a way to actually run the sync, and a PDF that admits its lag

### DIFF
--- a/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
@@ -9,6 +9,7 @@ import {
   Ban,
   CircleSlash,
   CircleX,
+  CloudOff,
   KeyRound,
   Landmark,
   Lock,
@@ -42,6 +43,7 @@ export type LedgerBlockerStatus =
   | 'no_bank_accounts'
   | 'suggestion_incomplete'
   | 'agreement_refused'
+  | 'sync_refused'
 
 /** One reason a preview, a post or a discard refused, as the console renders it. */
 export interface LedgerBlocker {
@@ -235,6 +237,19 @@ const REMEDIES: Partial<Record<LedgerBlockerStatus, BlockerRemedy>> = {
       'One account in the connected system is claimed by more than one account in this chart, so its balance has no single counterpart here. Withdraw one of the two mappings on the account map and check again. Nothing was changed.',
     href: '/app/accounting/settings/accounts',
     actionLabel: 'Open the account map',
+  },
+  // plans/accounting/tasks/20-two-authors-one-ledger.md §7.4. The INBOUND sync
+  // refused before it walked - most often the cutover floor (§5.4), which names
+  // both the date that was asked for and the earliest the sync may read. That
+  // floor is what stops brief 19's opening entry being imported a second time
+  // and the whole opening position doubling, so its message is the remedy and
+  // is carried verbatim.
+  sync_refused: {
+    tone: 'failure',
+    icon: CloudOff,
+    title: 'The sync did not run',
+    guidance:
+      'Nothing was read and nothing was written - the refusal happened before the first request went out. The reason above names the dates or the setting involved. A range the sync may not read is never quietly moved to one it may.',
   },
 }
 

--- a/apps/web/src/components/accounting/ui/provider-sync/__tests__/provider-sync-report.test.ts
+++ b/apps/web/src/components/accounting/ui/provider-sync/__tests__/provider-sync-report.test.ts
@@ -1,0 +1,79 @@
+// apps/web/src/components/accounting/ui/provider-sync/__tests__/provider-sync-report.test.ts
+//
+// The two readings the sync report is built on
+// (plans/accounting/tasks/20-two-authors-one-ledger.md §7.3, §7.4).
+//
+// 🛑 `syncedThrough` short of the `to` that was asked for is the one thing on
+// this screen that must be said loudly: it means the walk hit a month it could
+// not bring across, latched, and never read the months after it. A report that
+// rendered "done" over a half-finished walk would be the trust problem §7.3
+// exists to prevent, with the arrows reversed.
+
+import { describe, expect, it } from 'vitest'
+import {
+  groupDeferredMonths,
+  type ProviderSyncOutcome,
+  readSyncedThrough,
+} from '../provider-sync-report'
+
+function outcome(over: Partial<ProviderSyncOutcome>): ProviderSyncOutcome {
+  return {
+    from: '2026-01-01',
+    to: '2026-11-30',
+    providerId: 'quickbooks',
+    currency: 'USD',
+    chunks: [],
+    written: 0,
+    alreadyPosted: 0,
+    reversed: 0,
+    deferredToClosedMonths: [],
+    refusals: [],
+    syncedThrough: '2026-11-30',
+    ...over,
+  } as ProviderSyncOutcome
+}
+
+describe('readSyncedThrough', () => {
+  it('reads the whole range as complete', () => {
+    expect(readSyncedThrough(outcome({}))).toBe('complete')
+  })
+
+  it('reads a marker behind the requested end as short', () => {
+    expect(readSyncedThrough(outcome({ syncedThrough: '2026-03-31' }))).toBe('short')
+  })
+
+  // Null is NOT "nothing happened": entries may well have been written. It
+  // means no chunk came back clean, so the stored marker was left where it was.
+  it('reads a marker that never advanced as its own case', () => {
+    expect(readSyncedThrough(outcome({ syncedThrough: null, written: 12 }))).toBe('never_advanced')
+  })
+})
+
+describe('groupDeferredMonths', () => {
+  const deferred = (month: string, action: 'write' | 'reverse', txnId: string) => ({
+    month,
+    txnType: 'Journal Entry',
+    txnId,
+    txnDate: `${month}-15`,
+    totalMinor: 1000,
+    action,
+  })
+
+  it('counts writes and reversals separately, oldest month first', () => {
+    expect(
+      groupDeferredMonths([
+        deferred('2026-03', 'write', '1'),
+        deferred('2026-01', 'write', '2'),
+        deferred('2026-01', 'reverse', '3'),
+        deferred('2026-01', 'write', '4'),
+      ])
+    ).toEqual([
+      { month: '2026-01', writes: 2, reverses: 1 },
+      { month: '2026-03', writes: 1, reverses: 0 },
+    ])
+  })
+
+  it('is empty when nothing is waiting on a closed month', () => {
+    expect(groupDeferredMonths([])).toEqual([])
+  })
+})

--- a/apps/web/src/components/accounting/ui/provider-sync/provider-sync-panel.tsx
+++ b/apps/web/src/components/accounting/ui/provider-sync/provider-sync-panel.tsx
@@ -1,0 +1,279 @@
+// apps/web/src/components/accounting/ui/provider-sync/provider-sync-panel.tsx
+
+'use client'
+
+// "Read what my accountant authored in QuickBooks and put it in my books"
+// (plans/accounting/tasks/20-two-authors-one-ledger.md §5-§7, §7.4).
+//
+// 🛑 A BUTTON, AND ONLY A BUTTON. §7.4 is explicit that the button comes before
+// the schedule: there is no cron, no worker job, no run-on-mount and no
+// auto-run after the agreement check. The first run of this against a real
+// company file wants a person watching it, and the drift it collects is the
+// accountant's adjusting work, which happens at close rather than on a Tuesday
+// (§8.3, the same argument the agreement view made).
+//
+// 🛑 THE RANGE IS NOT CLAMPED HERE. `from` empty means "everything the sync is
+// allowed to see", which starts at the month after `accounting.cutoffPeriod`.
+// A `from` below that floor is a REFUSAL from lib naming both dates, and it is
+// surfaced verbatim - it is what stops the opening period being read back and
+// the entire opening position being doubled. This file must never quietly move
+// a date up to the floor to make the button work.
+//
+// ⚠️ IT IS SLOW, AND IT SAYS SO. Report endpoints do not paginate (§4.8), so
+// the sync issues one provider call per calendar month. Eleven months is eleven
+// round trips over the app Lambda and can run for minutes. tRPC gives one
+// request and one answer, so there is no per-chunk progress to stream - what
+// this can honestly show is the work it has taken on (the month count, from the
+// same pure `planSyncChunks` the server walks with) and that time is passing.
+
+import { FieldType } from '@auxx/database/enums'
+import { PermissionKey } from '@auxx/lib/permissions/client'
+import { planSyncChunks } from '@auxx/lib/postings/client'
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { RefreshCw } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { useAccess } from '~/providers/capabilities-provider'
+import type { RouterOutputs } from '~/trpc/react'
+import { api } from '~/trpc/react'
+import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
+import { EntryBlockers } from '../ledger/entry-blockers'
+import { ProviderSyncReport } from './provider-sync-report'
+
+type SyncOutcome = RouterOutputs['ledger']['syncProviderLedger']
+
+/** What `quickbooks-section.tsx` says about a disconnected org, said the same way. */
+const NOT_CONNECTED_COPY =
+  'No accounting system is connected, so there is no ledger to read. The books are kept here ' +
+  'either way and nothing is blocked by this.'
+
+export interface ProviderSyncPanelProps {
+  /** `accounting.cutoffPeriod`, `YYYY-MM`. Empty until setup has one. */
+  cutoffPeriod: string
+  /** The org's own reporting currency, for the mismatch warning. */
+  orgCurrency: string
+  /** Today in the BOOK timezone - the default `to`. */
+  todayInBooks: string
+  className?: string
+}
+
+/** `m:ss`, so a run that has been going for four minutes reads as one. */
+function elapsedLabel(seconds: number): string {
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`
+}
+
+/**
+ * The inbound sync: a range, a button, and everything the last press found.
+ *
+ * The date fields are `YYYY-MM-DD` strings because that is what the procedure
+ * takes; they are widened to an instant on the way into `FieldInputAdapter` and
+ * sliced back on the way out, the same round trip the agreement panel and the
+ * JE drawer do.
+ */
+export function ProviderSyncPanel({
+  cutoffPeriod,
+  orgCurrency,
+  todayInBooks,
+  className,
+}: ProviderSyncPanelProps) {
+  const provider = useAccountingProviderStatus()
+  const { can } = useAccess()
+  const utils = api.useUtils()
+
+  // Empty means the floor. Deliberately NOT pre-filled with the floor date: a
+  // pre-filled value is a value somebody edits, and the one edit that matters
+  // here is the one that must be refused.
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState(todayInBooks)
+  const [outcome, setOutcome] = useState<SyncOutcome | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [elapsed, setElapsed] = useState(0)
+
+  /**
+   * 🛑 `ledgerControl`, the same rung the procedure asserts and the same one
+   * `setLockedThrough` takes. This sync restates prior months - it writes into
+   * closed periods and reverses entries that have vanished - so a `ledgerView`
+   * reader is shown the range and the last answer, and no button.
+   */
+  const canSync = can(PermissionKey.ledgerControl)
+
+  /**
+   * How many provider calls this press will make, off the SAME pure walker the
+   * server uses. Null when the range cannot be planned in the browser (no
+   * cutoff yet, a `from` below the floor, a `to` before `from`) - the server is
+   * still the authority on all three, so the button stays live and the real
+   * refusal comes back with the message that names the dates.
+   */
+  const chunks = useMemo(() => {
+    if (!cutoffPeriod) return null
+    const planned = planSyncChunks({ cutoffPeriod, from: from || undefined, to })
+    return planned.isOk() ? planned.value : null
+  }, [cutoffPeriod, from, to])
+
+  const sync = api.ledger.syncProviderLedger.useMutation({
+    onSuccess: (result) => {
+      setOutcome(result)
+      setError(null)
+      // The marker every statement page renders moved, and so did the ledger.
+      utils.ledgerReports.providerSyncMarker.invalidate()
+      utils.ledger.listPostings.invalidate()
+      utils.ledger.verifyBalance.invalidate()
+    },
+    onError: (mutationError) => {
+      setError(mutationError.message)
+      setOutcome(null)
+    },
+  })
+
+  // The one honest thing a single-request mutation can show while it walks
+  // eleven months: that it is still going, and for how long.
+  const isPending = sync.isPending
+  const startedAt = useRef(0)
+  useEffect(() => {
+    if (!isPending) return
+    startedAt.current = Date.now()
+    setElapsed(0)
+    const timer = setInterval(
+      () => setElapsed(Math.floor((Date.now() - startedAt.current) / 1000)),
+      1000
+    )
+    return () => clearInterval(timer)
+  }, [isPending])
+
+  const providerLabel = provider.providerLabel ?? 'QuickBooks'
+  const monthCount = chunks?.length ?? null
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <div className='flex flex-wrap items-end gap-2'>
+        <DateField
+          label='From'
+          value={from}
+          placeholderNote='cutover'
+          disabled={isPending || !canSync}
+          onChange={(next) => {
+            setFrom(next)
+            setOutcome(null)
+          }}
+        />
+        <DateField
+          label='To'
+          value={to}
+          disabled={isPending || !canSync}
+          onChange={(next) => {
+            if (!next) return
+            setTo(next)
+            setOutcome(null)
+          }}
+        />
+
+        {canSync && (
+          <Button
+            variant='outline'
+            size='sm'
+            disabled={!provider.connected}
+            loading={isPending}
+            loadingText={
+              monthCount === null
+                ? `Reading ${providerLabel}...`
+                : `Reading ${monthCount} ${monthCount === 1 ? 'month' : 'months'}...`
+            }
+            onClick={() => sync.mutate({ from: from || undefined, to })}>
+            <RefreshCw />
+            {outcome ? 'Sync again' : 'Sync from ' + providerLabel}
+          </Button>
+        )}
+      </div>
+
+      {/*
+        🛑 What an empty `From` means, said out loud. It is not "no start date":
+        it is the cutover floor, the earliest date the sync may ever read, and
+        the reason a date below it comes back refused rather than quietly moved.
+      */}
+      <p className='text-muted-foreground text-xs'>
+        Leave <span className='font-medium'>From</span> empty to read everything this sync is
+        allowed to see, which starts the month after your accounting cutoff. Anything before that is
+        already in the books as the single opening entry, so a date earlier than the cutover is
+        refused rather than moved forward.
+      </p>
+
+      {!canSync && (
+        <p className='text-muted-foreground text-xs'>
+          Reading the provider's ledger restates prior months, so it needs ledger control - the same
+          authority that closes and reopens a period.
+        </p>
+      )}
+
+      {/*
+        The pending line. `loadingText` alone would be a spinner that says
+        nothing while eleven separate provider calls go out, which is worse than
+        no button at all - so the work is named, and the clock says it is still
+        moving.
+      */}
+      {isPending && (
+        <p className='text-muted-foreground text-xs'>
+          {monthCount === null
+            ? `Reading ${providerLabel} one month at a time.`
+            : `Reading ${from || 'the cutover'} to ${to} as ${monthCount} separate ${
+                monthCount === 1 ? 'request' : 'requests'
+              }, one per month - report endpoints cannot be paged, so the month is the only lever.`}{' '}
+          Nothing is written until a month has been read whole. {elapsedLabel(elapsed)} elapsed.
+        </p>
+      )}
+
+      {!provider.connected && !provider.loading && (
+        <p className='text-muted-foreground text-xs'>{NOT_CONNECTED_COPY}</p>
+      )}
+
+      {/*
+        Every refusal from lib is an `AuxxError` and arrives here with its own
+        message - the cutover floor naming both dates, a missing cutoff month, a
+        provider that answered for a range nobody asked for. The card carries it
+        verbatim: paraphrasing throws away the only part that says what to do.
+      */}
+      {error && <EntryBlockers blockers={[{ status: 'sync_refused', error }]} />}
+
+      {outcome && (
+        <ProviderSyncReport
+          outcome={outcome}
+          orgCurrency={orgCurrency}
+          providerLabel={providerLabel}
+        />
+      )}
+    </div>
+  )
+}
+
+/** One `YYYY-MM-DD` field. `''` is a real value here - it means "the floor". */
+function DateField({
+  label,
+  value,
+  placeholderNote,
+  disabled,
+  onChange,
+}: {
+  label: string
+  value: string
+  placeholderNote?: string
+  disabled: boolean
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className='flex flex-col gap-1'>
+      <span className='text-muted-foreground text-xs'>
+        {label}
+        {placeholderNote && !value && ` (${placeholderNote})`}
+      </span>
+      <div className='w-44'>
+        <FieldInputAdapter
+          fieldType={FieldType.DATE}
+          value={value ? `${value}T00:00:00.000Z` : null}
+          onChange={(next) => onChange(typeof next === 'string' ? next.slice(0, 10) : '')}
+          disabled={disabled}
+          triggerProps={{ className: 'w-full' }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/provider-sync/provider-sync-report.tsx
+++ b/apps/web/src/components/accounting/ui/provider-sync/provider-sync-report.tsx
@@ -1,0 +1,355 @@
+// apps/web/src/components/accounting/ui/provider-sync/provider-sync-report.tsx
+
+'use client'
+
+// What one run of the inbound sync actually did
+// (plans/accounting/tasks/20-two-authors-one-ledger.md §7.4).
+//
+// 🛑 A COUNT IS NOT AN ANSWER. The mutation returns the whole
+// `ProviderSyncOutcome` rather than a success boolean precisely because four
+// different questions have to be answerable afterwards, and three of them are
+// about things that did NOT reach the books:
+//
+//   1. What came across      - `written`, `alreadyPosted`, `reversed`.
+//   2. What was REFUSED      - every message, verbatim. An entry that was
+//      refused is an entry the accountant authored and this org does not have,
+//      and a silent count of them is worse than useless.
+//   3. What is waiting on a PERSON - `deferredToClosedMonths`. §7.2: the sync
+//      reopens nothing on its own, ever. It names the months and somebody with
+//      `ledgerControl` decides.
+//   4. How far it GOT        - `syncedThrough`. Short of the `to` that was
+//      asked for means the walk stopped at an unclean chunk and the months
+//      after it were never read.
+//
+// 🛑 Reported INLINE, never as a toast - the same rule the rest of the
+// accounting module follows (ground rule 9, `entry-blockers.tsx`). A refusal
+// here names a transaction on the accountant's side; a toast would take that
+// away three seconds later.
+
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import { CircleAlert, Coins, Lock, Scale, TriangleAlert } from 'lucide-react'
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { formatMoney } from '~/components/money/ui/settings/format-money'
+import type { RouterOutputs } from '~/trpc/react'
+
+export type ProviderSyncOutcome = RouterOutputs['ledger']['syncProviderLedger']
+type DeferredEntry = ProviderSyncOutcome['deferredToClosedMonths'][number]
+
+export interface ProviderSyncReportProps {
+  outcome: ProviderSyncOutcome
+  /** The org's own reporting currency, for the mismatch warning (decision 12). */
+  orgCurrency: string
+  /** `'QuickBooks Online'`, or whatever is connected. */
+  providerLabel: string
+  className?: string
+}
+
+/** One closed month, with what the sync wanted to do inside it. */
+interface DeferredMonth {
+  month: string
+  writes: number
+  reverses: number
+}
+
+/** `2026-01` -> `January 2026`. Built off a fixed UTC day so no zone can shift it. */
+function monthName(month: string): string {
+  const [year, index] = month.split('-')
+  if (!year || !index) return month
+  const date = new Date(Date.UTC(Number(year), Number(index) - 1, 15))
+  return Number.isNaN(date.getTime())
+    ? month
+    : date.toLocaleDateString(undefined, { month: 'long', year: 'numeric', timeZone: 'UTC' })
+}
+
+/** Group the deferrals by the month they are waiting on, oldest first. */
+export function groupDeferredMonths(rows: readonly DeferredEntry[]): DeferredMonth[] {
+  const byMonth = new Map<string, DeferredMonth>()
+  for (const row of rows) {
+    const existing = byMonth.get(row.month) ?? { month: row.month, writes: 0, reverses: 0 }
+    if (row.action === 'reverse') existing.reverses += 1
+    else existing.writes += 1
+    byMonth.set(row.month, existing)
+  }
+  return [...byMonth.values()].sort((a, b) => a.month.localeCompare(b.month))
+}
+
+/**
+ * The three readings of `syncedThrough`, which are NOT the same fact.
+ *
+ * 🛑 `null` is not "nothing happened". The marker advances per CLEAN chunk and
+ * latches shut on the first unclean one, so `null` means not one chunk of this
+ * run came back clean - and the STORED marker is then left exactly where it
+ * was, because "this run read nothing new" is not "nothing has ever been read".
+ *
+ * ⚠️ `null` also covers a clean chunk whose marker WRITE failed, which the
+ * outcome does not distinguish. Both readings say the same true thing here -
+ * the marker did not move - so neither overstates coverage.
+ */
+export function readSyncedThrough(
+  outcome: ProviderSyncOutcome
+): 'complete' | 'short' | 'never_advanced' {
+  if (outcome.syncedThrough === null) return 'never_advanced'
+  return outcome.syncedThrough < outcome.to ? 'short' : 'complete'
+}
+
+/** A bordered block in the section's own vocabulary. `alarm` is only for a fault. */
+function ReportCard({
+  tone,
+  icon,
+  title,
+  children,
+}: {
+  tone: 'neutral' | 'warn' | 'alarm'
+  icon: ReactNode
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-2 rounded-xl border p-4',
+        tone === 'neutral' && 'border-border bg-muted/40',
+        tone === 'warn' && 'border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-400',
+        tone === 'alarm' && 'border-destructive/40 bg-destructive/5'
+      )}>
+      <div className='flex items-center gap-2'>
+        <span className={cn('shrink-0', tone === 'alarm' && 'text-destructive')}>{icon}</span>
+        <span className='font-medium text-sm'>{title}</span>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Everything one press of Sync found and did.
+ *
+ * Order is deliberate: what the run is worth reading as comes FIRST (a walk
+ * that stopped early makes every number under it a partial answer), then what
+ * came across, then the two lists a person has to act on.
+ */
+export function ProviderSyncReport({
+  outcome,
+  orgCurrency,
+  providerLabel,
+  className,
+}: ProviderSyncReportProps) {
+  const currency = outcome.currency ?? orgCurrency
+  const coverage = readSyncedThrough(outcome)
+  const deferredMonths = groupDeferredMonths(outcome.deferredToClosedMonths)
+  const unbalanced = outcome.chunks.flatMap((chunk) => chunk.unbalanced)
+  const divergent = outcome.chunks
+    .flatMap((chunk) => chunk.ourChecks)
+    .filter((check) => check.verdict !== 'matches')
+  const currencyMismatch = outcome.currency !== null && outcome.currency !== orgCurrency
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      {/*
+        ⚠️ THE LOUD ONE, and it goes first. The walk stops advancing the marker
+        at the first chunk that did not bring everything across, and it never
+        resumes past it - so a run that was asked for eleven months and marked
+        three read eight months it cannot vouch for. Every count below is then a
+        partial answer, and saying so after them would be saying it too late.
+      */}
+      {coverage === 'short' && (
+        <ReportCard
+          tone='alarm'
+          icon={<CircleAlert className='size-4' />}
+          title={`Only read through ${outcome.syncedThrough} - the walk stopped early`}>
+          <p className='text-sm'>
+            You asked for {outcome.from} to {outcome.to}, and {providerLabel} has only been read
+            through {outcome.syncedThrough}. The month after that came back with something this sync
+            could not bring across, and the marker never advances past an unclean month - a later
+            clean month cannot vouch for an earlier broken one. Fix what is listed below and run it
+            again; everything already brought across stays.
+          </p>
+        </ReportCard>
+      )}
+
+      {coverage === 'never_advanced' && (
+        <ReportCard
+          tone='alarm'
+          icon={<CircleAlert className='size-4' />}
+          title='The synced-through marker did not move'>
+          <p className='text-sm'>
+            Not one month of {outcome.from} to {outcome.to} came back clean, so the marker is left
+            exactly where it was rather than claiming this range has been read. Anything that DID
+            come across is in the books - this is about what the statements are allowed to say about
+            themselves, not about what was written.
+          </p>
+        </ReportCard>
+      )}
+
+      {coverage === 'complete' && (
+        <p className='text-muted-foreground text-xs'>
+          Read {outcome.from} to {outcome.to} in {outcome.chunks.length}{' '}
+          {outcome.chunks.length === 1 ? 'month' : 'months'}. Statements are now synced through{' '}
+          {outcome.syncedThrough}.
+        </p>
+      )}
+
+      {/* ── 1. What came across ─────────────────────────────────────────── */}
+      <div className='grid grid-cols-2 gap-2 sm:grid-cols-4'>
+        <Figure label='Written' value={outcome.written} hint='Entries your accountant authored' />
+        <Figure
+          label='Already there'
+          value={outcome.alreadyPosted}
+          hint='Held from an earlier run'
+        />
+        <Figure
+          label='Reversed'
+          value={outcome.reversed}
+          hint='Gone from their side, backed out here'
+        />
+        <Figure
+          label='Months read'
+          value={outcome.chunks.length}
+          hint={`${outcome.from} to ${outcome.to}`}
+        />
+      </div>
+
+      {/*
+        Decision 12: a currency mismatch WARNS, it does not refuse. Brief 19's
+        fill path refuses because it WRITES an opening position; this reads, and
+        a sync that brought nothing across because the currencies differ is less
+        useful than one that brought the entries and says the figures are not
+        directly comparable.
+      */}
+      {currencyMismatch && (
+        <ReportCard
+          tone='warn'
+          icon={<Coins className='size-4' />}
+          title={`${providerLabel} reports in ${outcome.currency}, these books are in ${orgCurrency}`}>
+          <p className='text-sm text-muted-foreground'>
+            Nothing was converted and nothing was refused. The amounts brought across are the
+            provider's own figures, so any statement mixing them with {orgCurrency} entries is
+            adding two currencies together.
+          </p>
+        </ReportCard>
+      )}
+
+      {/* ── 2. What was refused. Every one of them, verbatim ─────────────── */}
+      {outcome.refusals.length > 0 && (
+        <ReportCard
+          tone='alarm'
+          icon={<TriangleAlert className='size-4' />}
+          title={`${outcome.refusals.length} ${outcome.refusals.length === 1 ? 'entry was' : 'entries were'} refused and are NOT in your books`}>
+          <ul className='flex list-disc flex-col gap-1.5 pl-5 text-sm'>
+            {outcome.refusals.map((refusal) => (
+              <li key={refusal}>{refusal}</li>
+            ))}
+          </ul>
+        </ReportCard>
+      )}
+
+      {/*
+        Also "did not come across", and for the one reason that is never
+        negotiable: an unbalanced entry in the ledger is worse than a missing
+        one, because it silently breaks every statement that ties. Listed
+        separately from the refusals because the remedy is on their side.
+      */}
+      {unbalanced.length > 0 && (
+        <ReportCard
+          tone='alarm'
+          icon={<Scale className='size-4' />}
+          title={`${unbalanced.length} ${unbalanced.length === 1 ? 'entry does' : 'entries do'} not balance in ${providerLabel}`}>
+          <p className='text-sm text-muted-foreground'>
+            Never written. An entry whose debits and credits disagree would break every statement
+            that ties, so it is left where it is and named here instead.
+          </p>
+          <ul className='flex flex-col gap-1 text-sm'>
+            {unbalanced.map((entry) => (
+              <li key={`${entry.txnType}-${entry.txnId}`} className='flex flex-wrap gap-x-2'>
+                <span className='font-medium'>
+                  {entry.txnType} {entry.txnId}
+                </span>
+                <span className='text-muted-foreground'>{entry.txnDate}</span>
+                <span className='tabular-nums text-muted-foreground'>
+                  {formatMoney(entry.totalDebitMinor, currency)} debit vs{' '}
+                  {formatMoney(entry.totalCreditMinor, currency)} credit
+                </span>
+              </li>
+            ))}
+          </ul>
+        </ReportCard>
+      )}
+
+      {/*
+        §5.3, verify on read. Our OWN entries, compared against their copy
+        before ours is kept. 🛑 REPORTED, never repaired: deciding that their
+        edit wins, or that ours does, makes one entry answer to two authors,
+        which is exactly what the single-writer rule exists to prevent.
+      */}
+      {divergent.length > 0 && (
+        <ReportCard
+          tone='warn'
+          icon={<TriangleAlert className='size-4' />}
+          title={`${divergent.length} of your own ${divergent.length === 1 ? 'entry no longer matches' : 'entries no longer match'} ${providerLabel}`}>
+          <p className='text-sm text-muted-foreground'>
+            Nothing was changed on either side. An entry auxx authored has one author forever, so a
+            difference here is something to go and look at, not something this sync may settle.
+          </p>
+          <ul className='flex flex-col gap-1 text-sm'>
+            {divergent.map((check) => (
+              <li key={check.glPostingId} className='flex flex-wrap items-center gap-x-2'>
+                <span className='font-medium'>{check.docNumber}</span>
+                <Badge variant='outline' size='xs'>
+                  {check.verdict}
+                </Badge>
+                <span className='text-muted-foreground'>
+                  {check.differences.join('; ') || 'not present in their ledger for this range'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </ReportCard>
+      )}
+
+      {/* ── 3. What is waiting on a person ──────────────────────────────── */}
+      {deferredMonths.length > 0 && (
+        <ReportCard
+          tone='warn'
+          icon={<Lock className='size-4' />}
+          title={`${outcome.deferredToClosedMonths.length} ${outcome.deferredToClosedMonths.length === 1 ? 'entry is' : 'entries are'} waiting on a closed month`}>
+          <p className='text-sm text-muted-foreground'>
+            This is the ordinary case, not a fault: December's adjusting entry arriving in February.
+            The sync reopens nothing on its own. Somebody holding ledger control has to reopen the
+            month and then run this again, which keeps the reopen in the audit log next to a person.
+          </p>
+          <ul className='flex flex-col gap-1 text-sm'>
+            {deferredMonths.map((month) => (
+              <li key={month.month} className='flex flex-wrap items-center gap-x-2'>
+                <Link
+                  href={`/app/accounting/${month.month}`}
+                  className='font-medium hover:underline'>
+                  {monthName(month.month)}
+                </Link>
+                <span className='text-muted-foreground'>
+                  {month.writes > 0 &&
+                    `${month.writes} ${month.writes === 1 ? 'entry' : 'entries'} to write`}
+                  {month.writes > 0 && month.reverses > 0 && ', '}
+                  {month.reverses > 0 &&
+                    `${month.reverses} to reverse (gone from ${providerLabel})`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </ReportCard>
+      )}
+    </div>
+  )
+}
+
+/** One count, with what it counts. A bare number here is a number nobody can act on. */
+function Figure({ label, value, hint }: { label: string; value: number; hint: string }) {
+  return (
+    <div className='flex flex-col gap-0.5 rounded-lg border border-border bg-muted/40 p-3'>
+      <span className='font-medium text-lg tabular-nums'>{value}</span>
+      <span className='text-xs'>{label}</span>
+      <span className='text-[11px] text-muted-foreground leading-tight'>{hint}</span>
+    </div>
+  )
+}

--- a/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
@@ -56,6 +56,7 @@ import {
 } from './accounting-settings-keys'
 import { FrozenLock } from './frozen-lock'
 import { ProviderAgreementSettingsSection } from './provider-agreement-section'
+import { ProviderSyncSettingsSection } from './provider-sync-section'
 import { QuickbooksSettingsSection } from './quickbooks-section'
 import { SetupStatusSection } from './setup-status-section'
 
@@ -434,6 +435,16 @@ export function AccountingGeneralSettingsPage() {
               and adds nothing to `DRAFT_KEYS`, exactly like the section above.
             */}
             <ProviderAgreementSettingsSection />
+
+            {/*
+              The inbound half, last, and after the agreement view for one
+              reason: the agreement view asks whether the two sets of books
+              agree, and this is what makes them agree (brief 20 §8.5 - after a
+              sync of a period, the difference for that period should be zero).
+              It owns no settings values either, so it stays out of all three
+              draft slices and adds nothing to `DRAFT_KEYS`.
+            */}
+            <ProviderSyncSettingsSection />
           </div>
         </div>
 

--- a/apps/web/src/components/accounting/ui/settings/provider-sync-section.tsx
+++ b/apps/web/src/components/accounting/ui/settings/provider-sync-section.tsx
@@ -1,0 +1,54 @@
+// apps/web/src/components/accounting/ui/settings/provider-sync-section.tsx
+
+'use client'
+
+// Accounting > Settings > General, under the QuickBooks section and beside the
+// agreement view: the one door onto the INBOUND half of the seam
+// (plans/accounting/tasks/20-two-authors-one-ledger.md §7.4).
+//
+// The pair is deliberate and they read in this order: the agreement view asks
+// "do our books and theirs agree", and this is what makes them agree. §8.5
+// makes that the acceptance test - after a sync of a period, the difference for
+// that period should be zero.
+//
+// 🛑 The behaviour is not built here. This file is a heading, the two settings
+// the panel needs, and a place to put it; `ProviderSyncPanel` is the whole of
+// it, exactly the way `provider-agreement-section.tsx` defers to its panel.
+
+import { CloudDownload } from 'lucide-react'
+import { SettingsSection } from '~/components/global/settings-page'
+import { useSettings } from '~/hooks/use-settings'
+import { today } from '../journal/period-helpers'
+import { ProviderSyncPanel } from '../provider-sync/provider-sync-panel'
+
+/** Same fallback `useLedgerPeriod` uses when the book timezone is unset. */
+const FALLBACK_BOOK_TIME_ZONE = 'UTC'
+
+/**
+ * "Bring in what your accountant authored", for a range somebody picks.
+ *
+ * `to` defaults to today in the BOOK timezone rather than the browser's, for
+ * the agreement section's reason: an accounting date is a calendar day in the
+ * books' own zone, and defaulting to the viewer's would put a bookkeeper in
+ * Auckland a day ahead of their own ledger.
+ */
+export function ProviderSyncSettingsSection() {
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const bookTimeZone = (getSetting('accounting.bookTimeZone') as string) || FALLBACK_BOOK_TIME_ZONE
+  const cutoffPeriod = (getSetting('accounting.cutoffPeriod') as string) || ''
+  const orgCurrency = (getSetting('organization.currency') as string) || 'USD'
+
+  return (
+    <SettingsSection
+      icon={CloudDownload}
+      title='Bring in entries from QuickBooks'
+      description="Read the connected system's general ledger and write everything your accountant authored there into these books. Depreciation, accruals, reclasses and payroll - the entries that are never authored here.">
+      <ProviderSyncPanel
+        cutoffPeriod={cutoffPeriod}
+        orgCurrency={orgCurrency}
+        todayInBooks={today(bookTimeZone)}
+        className='mt-1'
+      />
+    </SettingsSection>
+  )
+}

--- a/apps/web/src/server/api/routers/ledger-permissions.test.ts
+++ b/apps/web/src/server/api/routers/ledger-permissions.test.ts
@@ -34,6 +34,26 @@ vi.mock('@auxx/lib/postings', async () => {
     assertAccountingSetupUnfrozen: vi.fn(async () => undefined),
     createChartAccount: vi.fn(async () => okResult({ id: 'acc_cuid000000000000000000000' })),
     setRoleAssignment: vi.fn(async () => okResult({ role: 'cash', glAccountId: 'acc_1' })),
+    // Brief 20 §7.4. The inbound sync RESTATES prior months - it writes into
+    // closed periods and reverses entries that have vanished from the provider
+    // - so it sits on `ledgerControl` beside `setLockedThrough` rather than on
+    // `ledgerPost`. Mocked to an `ok`, because the only thing under test here
+    // is which rung reaches the resolver body at all.
+    syncProviderLedger: vi.fn(async () =>
+      okResult({
+        from: '2026-01-01',
+        to: '2026-01-31',
+        providerId: 'quickbooks',
+        currency: 'USD',
+        chunks: [],
+        written: 0,
+        alreadyPosted: 0,
+        reversed: 0,
+        deferredToClosedMonths: [],
+        refusals: [],
+        syncedThrough: '2026-01-31',
+      })
+    ),
   }
 })
 
@@ -194,6 +214,31 @@ describe('ledger.setLockedThrough', () => {
     await expect(
       ledgerCaller(ledgerFull()).setLockedThrough({ periodKey: '2026-08' })
     ).resolves.toMatchObject({ success: true })
+  })
+})
+
+describe('ledger.syncProviderLedger', () => {
+  // 🛑 Not `ledgerPost`. A bookkeeper holding `ledgerPost` posts what is in
+  // front of them; this walks from the cutover forward and decides that last
+  // December is now different. Deleting the `ledgerControl` assert from the
+  // router makes this case reach the mocked lib call and pass, which is what
+  // makes it behavioral rather than a mock-call count.
+  it('refuses ledger: Edit', async () => {
+    await expect(
+      ledgerCaller(ledgerEdit()).syncProviderLedger({ to: '2026-01-31' })
+    ).rejects.toMatchObject(FORBIDDEN)
+  })
+
+  it('admits ledger: Full', async () => {
+    await expect(
+      ledgerCaller(ledgerFull()).syncProviderLedger({ to: '2026-01-31' })
+    ).resolves.toMatchObject({ syncedThrough: '2026-01-31' })
+  })
+
+  it('refuses a caller with settingsManage but not ledgerControl', async () => {
+    await expect(
+      ledgerCaller(settingsManageOnly()).syncProviderLedger({ to: '2026-01-31' })
+    ).rejects.toMatchObject(FORBIDDEN)
   })
 })
 

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -47,6 +47,7 @@ import {
   reverseJournalEntry,
   setAccountIdentity,
   setRoleAssignment,
+  syncProviderLedger,
   updateChartAccount,
   updateJournalEntry,
   verifyBooksBalance,
@@ -201,6 +202,7 @@ const draftEntry = z.object({
  * | `post`            | `ledger.post` |
  * | `reverse`         | `ledger.post` |
  * | `setLockedThrough` | `ledger.control` |
+ * | `syncProviderLedger` | `ledger.control` |
  *
  * `ledger` is its own L2 area rather than a corner of `billing`: `billing`
  * governs what auxx charges this org, this governs what the org's own books say
@@ -1111,6 +1113,63 @@ export const ledgerRouter = createTRPCRouter({
         providerCurrency: sheet.currency,
         agreement: planned.value,
       }
+    }),
+
+  /**
+   * Read the connected provider's general ledger and bring everything the
+   * accountant authored into our books
+   * (plans/accounting/tasks/20-two-authors-one-ledger.md §5-§7, §7.4).
+   *
+   * 🛑 **`ledgerControl`, not `ledgerPost` and not `ledgerView`.** This is not
+   * "post an entry": the sync walks from the cutover forward and RESTATES PRIOR
+   * MONTHS - it writes entries dated into months that are already closed (which
+   * it defers, §7.2) and REVERSES entries whose provider id has stopped
+   * appearing (§7.1). That is the same class of authority `setLockedThrough`
+   * takes, and a bookkeeper holding `ledgerPost` posts what is in front of them
+   * rather than deciding that last December is now different.
+   *
+   * ⚠️ **Long-running and it reaches the provider.** One call per calendar
+   * month, because report endpoints do not paginate (§4.8) so the date range is
+   * the only lever there is. Eleven months is eleven round trips over the app
+   * Lambda. On demand only - §7.4 is explicit that the button comes before the
+   * schedule, because the first run of this against a real company file wants a
+   * person watching it.
+   *
+   * The WHOLE outcome comes back, not a count and not a success boolean: a
+   * person has to see the refusals (entries that did not come across), the
+   * closed months waiting on somebody with this same key to reopen them, and
+   * how far the "synced through" marker actually got.
+   *
+   * `from` is optional and means "everything the sync is allowed to see",
+   * starting the month after `accounting.cutoffPeriod`. 🛑 A `from` BELOW that
+   * floor is a refusal from `planSyncChunks`, never a clamp - reading the
+   * opening period back would import the balances brief 19's opening entry was
+   * derived from and double the entire opening position. It is thrown straight
+   * through, with no `try/catch`, for {@link providerAgreement}'s reason:
+   * catching and rethrowing is the only way an `AuxxError` gets flattened into
+   * a generic 500 on its way to `auxxErrorMiddleware`.
+   */
+  syncProviderLedger: permissionProcedure(PermissionKey.ledgerControl)
+    .input(
+      z.object({
+        /** `YYYY-MM-DD`. Omitted means the cutover floor - see above. */
+        from: z
+          .string()
+          .regex(/^\d{4}-\d{2}-\d{2}$/, 'from must be YYYY-MM-DD')
+          .optional(),
+        /** `YYYY-MM-DD`, inclusive. Usually today in the book timezone. */
+        to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'to must be YYYY-MM-DD'),
+      })
+    )
+    .use(notDemo('sync the accounting provider ledger'))
+    .mutation(async ({ ctx, input }) => {
+      const result = await syncProviderLedger(ctx.db, ctx.session.organizationId, {
+        from: input.from,
+        to: input.to,
+        actorUserId: ctx.session.userId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
     }),
 
   /**

--- a/packages/lib/src/postings/reports/pdf/__tests__/provider-sync-block.test.ts
+++ b/packages/lib/src/postings/reports/pdf/__tests__/provider-sync-block.test.ts
@@ -1,0 +1,171 @@
+// packages/lib/src/postings/reports/pdf/__tests__/provider-sync-block.test.ts
+//
+// The "synced through" marker on the PRINTED statement - brief 20 §7.3.
+//
+// 🛑 **The property under test is that the PDF and the screen cannot disagree.**
+// The firm posts December's depreciation in February, so auxx's December balance
+// sheet is incomplete until the sync restates it. The screen at least has a
+// person in front of it; the PDF is the copy that gets emailed to an accountant
+// and then read months later. Two implementations of "is this statement
+// complete" is exactly the bug the feature exists to prevent, so every assertion
+// below is written against `describeProviderSyncCoverage`'s own answer rather
+// than against a literal sentence copied out of the component.
+//
+// The parts are plain functions returning react-pdf elements, so they are called
+// directly and their element tree walked. No renderer, no per-row work, and
+// nothing here needs a database.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProviderSyncMarker, ProviderSyncReading } from '../../../provider-sync/client'
+
+type Client = typeof import('../../../provider-sync/client')
+
+/**
+ * The one function, wrapped in a spy. It delegates to the real implementation
+ * for every test but one, which makes it answer something no statement could
+ * produce to prove the page prints whatever it says.
+ */
+const describeCoverage = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../provider-sync/client', async (importOriginal) => {
+  const actual = await importOriginal<Client>()
+  return { ...actual, describeProviderSyncCoverage: describeCoverage }
+})
+
+const { describeProviderSyncCoverage } = await vi.importActual<Client>(
+  '../../../provider-sync/client'
+)
+const { ProviderSyncBlock, providerSyncFooterNotice } = await import('../statement-parts')
+
+/** Every string the element tree would print, flattened. */
+function printedText(node: unknown): string {
+  if (node === null || node === undefined || typeof node === 'boolean') return ''
+  if (typeof node === 'string') return node
+  if (typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(printedText).join(' ')
+  if (typeof node === 'object' && 'props' in node) {
+    const { children } = (node as { props: { children?: unknown } }).props
+    return printedText(children)
+  }
+  return ''
+}
+
+const CONNECTED: ProviderSyncMarker = {
+  connected: true,
+  providerId: 'quickbooks',
+  syncedThrough: '2026-11-30',
+}
+
+beforeEach(() => {
+  describeCoverage.mockReset()
+  describeCoverage.mockImplementation(describeProviderSyncCoverage)
+})
+
+describe('the four states, on the printed page', () => {
+  it('🛑 prints NOTHING at all for an org with no provider', () => {
+    const marker: ProviderSyncMarker = {
+      connected: false,
+      providerId: 'none',
+      syncedThrough: null,
+    }
+
+    // Not "synced through: never", not an empty strip, and no footer stamp
+    // either: a marker on an unconnected org implies a connection exists.
+    expect(ProviderSyncBlock({ marker, through: '2026-12-31' })).toBeNull()
+    expect(providerSyncFooterNotice(marker, '2026-12-31')).toBeNull()
+  })
+
+  it('prints nothing when the marker could not be read at all', () => {
+    // Same rule, different cause. A missing line is a much smaller problem than
+    // a wrong one, which is `CompletenessBanner`'s rule and this follows it.
+    expect(ProviderSyncBlock({ marker: null, through: '2026-12-31' })).toBeNull()
+    expect(providerSyncFooterNotice(null, '2026-12-31')).toBeNull()
+  })
+
+  it('names the never-synced case, and stamps every page with it', () => {
+    const marker: ProviderSyncMarker = {
+      connected: true,
+      providerId: 'quickbooks',
+      syncedThrough: null,
+    }
+    const reading = describeProviderSyncCoverage(marker, '2026-12-31')
+    expect(reading.coverage).toBe('never_synced')
+
+    const printed = printedText(ProviderSyncBlock({ marker, through: '2026-12-31' }))
+
+    expect(printed).toContain('STATEMENT INCOMPLETE')
+    expect(printed).toContain(reading.headline ?? '')
+    expect(printed).toContain(reading.detail ?? '')
+    expect(providerSyncFooterNotice(marker, '2026-12-31')).toBe(reading.headline)
+  })
+
+  it('🛑 carries the incomplete reading when the range ends AFTER the marker', () => {
+    // The case the feature exists for: a 31 December balance sheet on an org
+    // read through 30 November is missing every entry the accountant authored in
+    // between, and its figures will change when the sync catches up.
+    const reading = describeProviderSyncCoverage(CONNECTED, '2026-12-31')
+    expect(reading.coverage).toBe('behind')
+
+    const printed = printedText(ProviderSyncBlock({ marker: CONNECTED, through: '2026-12-31' }))
+
+    expect(printed).toContain(reading.headline ?? '')
+    expect(printed).toContain(reading.detail ?? '')
+    // The kicker is the PDF's own affordance, not a second reading: with no
+    // colour to lean on, the box is inverted and captioned rather than tinted.
+    expect(printed).toContain('STATEMENT INCOMPLETE')
+    // And it repeats on every page, because a statement is flipped to the page
+    // holding the number somebody cares about, not read from the top.
+    expect(providerSyncFooterNotice(CONNECTED, '2026-12-31')).toBe(reading.headline)
+  })
+
+  it('confirms quietly when the marker reaches the end of the range', () => {
+    const reading = describeProviderSyncCoverage(CONNECTED, '2026-11-30')
+    expect(reading.coverage).toBe('current')
+
+    const printed = printedText(ProviderSyncBlock({ marker: CONNECTED, through: '2026-11-30' }))
+
+    expect(printed).toBe(reading.headline)
+    // One quiet line, deliberately NOT the box: a complete statement should not
+    // carry a warning telling it so, and it does not stamp every page either.
+    expect(printed).not.toContain('STATEMENT INCOMPLETE')
+    expect(providerSyncFooterNotice(CONNECTED, '2026-11-30')).toBeNull()
+    // A statement ending BEFORE the marker is covered by the same reading.
+    expect(printedText(ProviderSyncBlock({ marker: CONNECTED, through: '2026-06-30' }))).toBe(
+      describeProviderSyncCoverage(CONNECTED, '2026-06-30').headline
+    )
+  })
+})
+
+describe('the PDF and the screen cannot disagree', () => {
+  it('🛑 prints whatever describeProviderSyncCoverage says, and computes nothing itself', () => {
+    // If the PDF ever grew its own thresholds or its own wording, this fails:
+    // the one function is made to answer something no statement could produce,
+    // and the page must still print exactly that.
+    const sentinel: ProviderSyncReading = {
+      coverage: 'behind',
+      headline: 'HEADLINE-FROM-THE-ONE-FUNCTION',
+      detail: 'DETAIL-FROM-THE-ONE-FUNCTION',
+    }
+    describeCoverage.mockReturnValue(sentinel)
+
+    const printed = printedText(ProviderSyncBlock({ marker: CONNECTED, through: '2026-12-31' }))
+
+    expect(printed).toContain(sentinel.headline ?? '')
+    expect(printed).toContain(sentinel.detail ?? '')
+    expect(providerSyncFooterNotice(CONNECTED, '2026-12-31')).toBe(sentinel.headline)
+    // Judged against the statement's own through-date, not the run date and not
+    // the range start.
+    expect(describeCoverage).toHaveBeenCalledWith(CONNECTED, '2026-12-31')
+  })
+
+  it('renders nothing whenever the one function declines to, whatever the reason', () => {
+    describeCoverage.mockReturnValue({
+      coverage: 'not_connected',
+      headline: null,
+      detail: null,
+    } satisfies ProviderSyncReading)
+
+    expect(ProviderSyncBlock({ marker: CONNECTED, through: '2026-12-31' })).toBeNull()
+    expect(providerSyncFooterNotice(CONNECTED, '2026-12-31')).toBeNull()
+  })
+})

--- a/packages/lib/src/postings/reports/pdf/render-statement-pdf.ts
+++ b/packages/lib/src/postings/reports/pdf/render-statement-pdf.ts
@@ -23,6 +23,8 @@ import { getAssetContent } from '../../../files/assets/content'
 import { defaultDatabase } from '../../../files/default-database'
 import { createS3StoragePort } from '../../../files/storage/ports'
 import { createStorageManager } from '../../../files/storage/storage-manager'
+import type { ProviderSyncMarker } from '../../provider-sync/client'
+import { readProviderSyncMarker } from '../../provider-sync/marker-reads'
 import {
   balanceSheetColumns,
   GENERAL_LEDGER_COLUMNS,
@@ -93,7 +95,22 @@ interface StatementPayload {
   asOfForKey: string
   columns: StatementColumn[]
   rows: StatementRow[]
-  completenessAsOf: string
+  /**
+   * The LAST date this statement covers, and the ONE date two different readers
+   * of "how complete is this" are judged against: `readCompleteness`'s `asOf`
+   * and the provider sync marker's `statementThrough` (brief 20 §7.3).
+   *
+   * 🛑 One field, not two. A statement that bounded its completeness banner by
+   * one date and its "synced through" reading by another could print both a
+   * clean banner and a stale marker for the same page, which is the disagreement
+   * the whole marker exists to prevent.
+   *
+   * Per kind: `to` for the trial balance, the P&L and the general ledger; `asOf`
+   * for the balance sheet and both agings; and for the 1099 summary - which is
+   * not a GL read and has no `asOf` at all - the last day of the filing year,
+   * the closest calendar meaning "as of" has for a year-shaped report.
+   */
+  statementThrough: string
 }
 
 async function buildPayload<K extends StatementKind>(
@@ -110,7 +127,7 @@ async function buildPayload<K extends StatementKind>(
       asOfForKey: to,
       columns: TRIAL_BALANCE_COLUMNS,
       rows: toTrialBalanceRows(result.value),
-      completenessAsOf: to,
+      statementThrough: to,
     }
   }
 
@@ -123,7 +140,7 @@ async function buildPayload<K extends StatementKind>(
       asOfForKey: asOf,
       columns: balanceSheetColumns(result.value),
       rows: toBalanceSheetRows(result.value, result.value.compare),
-      completenessAsOf: asOf,
+      statementThrough: asOf,
     }
   }
 
@@ -146,7 +163,7 @@ async function buildPayload<K extends StatementKind>(
           ]
         : [{ key: 'primary', label: `${from} to ${to}`, align: 'right', signed: true }],
       rows: toProfitAndLossRows(result.value, result.value.compare),
-      completenessAsOf: to,
+      statementThrough: to,
     }
   }
 
@@ -171,7 +188,7 @@ async function buildPayload<K extends StatementKind>(
       asOfForKey: to,
       columns: GENERAL_LEDGER_COLUMNS,
       rows: toGeneralLedgerRows(result.value),
-      completenessAsOf: to,
+      statementThrough: to,
     }
   }
 
@@ -185,7 +202,7 @@ async function buildPayload<K extends StatementKind>(
       asOfForKey: asOf,
       columns: AGING_COLUMNS,
       rows: toAgingRows(result.value),
-      completenessAsOf: asOf,
+      statementThrough: asOf,
     }
   }
 
@@ -193,7 +210,7 @@ async function buildPayload<K extends StatementKind>(
   // no `asOf` to bound completeness by, so this uses the last day of the
   // filing year, the closest calendar meaning "as of" has for a year-shaped report.
   const { year } = params as RenderStatementPdfParamsByKind['vendor-1099']
-  const asOfForCompleteness = `${String(year).padStart(4, '0')}-12-31`
+  const lastDayOfFilingYear = `${String(year).padStart(4, '0')}-12-31`
   const result = await readVendor1099Summary(db, { organizationId, year })
   if (result.isErr()) throw result.error
   return {
@@ -201,7 +218,7 @@ async function buildPayload<K extends StatementKind>(
     asOfForKey: String(year),
     columns: VENDOR_1099_COLUMNS,
     rows: toVendor1099Rows(result.value),
-    completenessAsOf: asOfForCompleteness,
+    statementThrough: lastDayOfFilingYear,
   }
 }
 
@@ -216,14 +233,26 @@ export async function renderStatementPdf<K extends StatementKind>(
 ): Promise<RenderStatementPdfResult> {
   const { organizationId, actorId, kind, params } = options
 
-  const [settings, payload] = await Promise.all([
+  // The marker is read HERE rather than handed in by the router, for the same
+  // reason `readCompleteness` below is: it is an org-scoped read that answers
+  // "what should this statement say about itself", it takes no `db` (the org
+  // cache and the provider registry answer both halves), and a second channel
+  // for it would let the PDF's reading drift from the screen's.
+  const [settings, payload, marker] = await Promise.all([
     resolveDocumentSettings(organizationId),
     buildPayload(organizationId, kind, params),
+    readProviderSyncMarker(organizationId),
   ])
+
+  // ⚠️ Fails SOFT, exactly as the screen does. `readProviderSyncMarker` errs
+  // only on an unreachable settings store, and a statement that refused to
+  // render because a display line could not be resolved would be a much bigger
+  // problem than one that prints without it.
+  const providerSyncMarker: ProviderSyncMarker | null = marker.isOk() ? marker.value : null
 
   const completeness = await readCompleteness(db, {
     organizationId,
-    asOf: payload.completenessAsOf,
+    asOf: payload.statementThrough,
   })
   if (completeness.isErr()) throw completeness.error
 
@@ -251,6 +280,8 @@ export async function renderStatementPdf<K extends StatementKind>(
     columns: payload.columns,
     rows: payload.rows,
     completeness: completeness.value.items,
+    providerSyncMarker,
+    statementThrough: payload.statementThrough,
   })
   // Same type shim `documents/render.ts` carries: `renderToBuffer` types its
   // argument as `ReactElement<DocumentProps>` (the root `<Document>`), but

--- a/packages/lib/src/postings/reports/pdf/statement-document.tsx
+++ b/packages/lib/src/postings/reports/pdf/statement-document.tsx
@@ -5,11 +5,14 @@
 import { Document, Page } from '@react-pdf/renderer'
 import { createDocumentStyles, pageSizeFor } from '../../../documents/pdf/theme'
 import type { ResolvedDocumentSettings } from '../../../documents/resolve-settings'
+import type { ProviderSyncMarker } from '../../provider-sync/client'
 import type { CompletenessItem } from '../completeness'
 import type { StatementColumn, StatementRow } from '../rows'
 import {
   CompletenessBlock,
   GroupedRowsTable,
+  ProviderSyncBlock,
+  providerSyncFooterNotice,
   StatementFooter,
   StatementTitleBlock,
 } from './statement-parts'
@@ -27,6 +30,13 @@ export function StatementPdfDocument(props: {
   columns: StatementColumn[]
   rows: StatementRow[]
   completeness: readonly CompletenessItem[]
+  /**
+   * How far the inbound provider sync has read, or null when the org has none
+   * and when the marker could not be read (brief 20 §7.3).
+   */
+  providerSyncMarker: ProviderSyncMarker | null
+  /** The LAST date this statement covers, which is what the marker is judged against. */
+  statementThrough: string
 }) {
   const {
     settings,
@@ -38,6 +48,8 @@ export function StatementPdfDocument(props: {
     columns,
     rows,
     completeness,
+    providerSyncMarker,
+    statementThrough,
   } = props
   const styles = createDocumentStyles(settings)
   const orientation = columns.length > LANDSCAPE_COLUMN_THRESHOLD ? 'landscape' : 'portrait'
@@ -57,9 +69,15 @@ export function StatementPdfDocument(props: {
           currencyCode={settings.currency}
           logoBytes={logoBytes}
         />
+        {/* Above the completeness box on purpose: "these figures will change"
+            outranks "here is what is not in them yet". */}
+        <ProviderSyncBlock marker={providerSyncMarker} through={statementThrough} />
         <CompletenessBlock items={completeness} />
         <GroupedRowsTable rows={rows} columns={columns} currencyCode={settings.currency} />
-        <StatementFooter dateLabel={runDateLabel} />
+        <StatementFooter
+          dateLabel={runDateLabel}
+          notice={providerSyncFooterNotice(providerSyncMarker, statementThrough)}
+        />
       </Page>
     </Document>
   )

--- a/packages/lib/src/postings/reports/pdf/statement-parts.tsx
+++ b/packages/lib/src/postings/reports/pdf/statement-parts.tsx
@@ -18,6 +18,7 @@ import { formatCurrency } from '@auxx/utils/currency'
 import { Image, StyleSheet, Text, View } from '@react-pdf/renderer'
 import type { ReactNode } from 'react'
 import type { createDocumentStyles } from '../../../documents/pdf/theme'
+import { describeProviderSyncCoverage, type ProviderSyncMarker } from '../../provider-sync/client'
 import type { CompletenessItem } from '../completeness'
 import type { StatementColumn, StatementRow } from '../rows'
 
@@ -41,6 +42,31 @@ const statementStyles = StyleSheet.create({
   },
   completenessTitle: { fontSize: 8, fontWeight: 'bold', color: '#374151', marginBottom: 3 },
   completenessItem: { fontSize: 8, color: '#6b7280', marginBottom: 1 },
+  // 🛑 INVERTED, not tinted. The screen leans on amber and a PDF has no colour
+  // affordance to lean on - it is printed, photocopied and read in greyscale.
+  // A near-black fill with white type is the one treatment that survives all
+  // three, and it is deliberately unlike anything else on the page: the
+  // completeness box below is a hairline grey box with 8pt grey type.
+  syncWarningBox: {
+    marginTop: 12,
+    marginBottom: 4,
+    padding: 10,
+    borderWidth: 2,
+    borderColor: '#111827',
+    borderRadius: 3,
+    backgroundColor: '#111827',
+  },
+  syncWarningKicker: {
+    fontSize: 7,
+    fontWeight: 'bold',
+    color: '#ffffff',
+    letterSpacing: 1.5,
+    marginBottom: 4,
+  },
+  syncWarningHeadline: { fontSize: 12, fontWeight: 'bold', color: '#ffffff', marginBottom: 4 },
+  syncWarningDetail: { fontSize: 9, color: '#e5e7eb', lineHeight: 1.4 },
+  syncedLine: { fontSize: 8, color: '#6b7280', marginTop: 8 },
+  footerNotice: { fontSize: 8, fontWeight: 'bold', color: '#111827' },
   table: { marginTop: 8 },
   sectionRow: { flexDirection: 'row', paddingTop: 10, paddingBottom: 2 },
   sectionLabel: { fontSize: 9, fontWeight: 'bold' },
@@ -115,6 +141,78 @@ export function CompletenessBlock(props: { items: readonly CompletenessItem[] })
       ))}
     </View>
   )
+}
+
+/**
+ * The "synced through" marker, printed - brief 20 §7.3.
+ *
+ * The accounting firm posts December's depreciation in February, so auxx's
+ * December balance sheet is incomplete until the sync runs and restates it, and
+ * then it changes. 🛑 **The PDF is the copy that gets emailed to an accountant**
+ * - a screen at least has a person in front of it who can go and look again,
+ * and a saved file does not. So the printed statement has to carry its own lag
+ * more loudly than the screen does, not less.
+ *
+ * The four states are {@link describeProviderSyncCoverage}'s and NOT this
+ * file's. Two implementations of "is this statement complete" is exactly the
+ * bug the feature exists to prevent, so the wording, the thresholds and the
+ * render-nothing case all come from that one pure function, the same one
+ * `ProviderSyncMarker` on screen calls.
+ *
+ *   * **not connected** - `null`. Nothing at all, not "synced through: never".
+ *   * **never synced** - the inverted box: everything of theirs is missing.
+ *   * **behind** - the inverted box. The case this exists for.
+ *   * **current** - one quiet grey line, deliberately not a box.
+ *
+ * @param marker null when the marker could not be read at all, which renders
+ *   nothing for the same reason `not_connected` does: a missing line is a much
+ *   smaller problem than a wrong one.
+ * @param through the LAST date this statement covers
+ */
+export function ProviderSyncBlock(props: { marker: ProviderSyncMarker | null; through: string }) {
+  const { marker, through } = props
+  if (!marker) return null
+
+  const reading = describeProviderSyncCoverage(marker, through)
+  if (!reading.headline) return null
+
+  if (reading.coverage === 'current') {
+    return <Text style={statementStyles.syncedLine}>{reading.headline}</Text>
+  }
+
+  return (
+    <View style={statementStyles.syncWarningBox} wrap={false}>
+      <Text style={statementStyles.syncWarningKicker}>STATEMENT INCOMPLETE</Text>
+      <Text style={statementStyles.syncWarningHeadline}>{reading.headline}</Text>
+      {reading.detail ? (
+        <Text style={statementStyles.syncWarningDetail}>{reading.detail}</Text>
+      ) : null}
+    </View>
+  )
+}
+
+/**
+ * The same reading, condensed to the one line the footer repeats on every page.
+ *
+ * The box above is read once, at the top of page one, and a statement is often
+ * flipped to the page holding the number somebody cares about. `StatementFooter`
+ * is already `fixed` and absolutely positioned, so carrying the headline there
+ * costs no flow space and no per-page work while making the warning impossible
+ * to page past - which, with no colour to lean on, is the other half of what
+ * makes it unmissable.
+ *
+ * Null for `current` as well as for the two silent states: a complete statement
+ * does not stamp every page with a note saying so.
+ */
+export function providerSyncFooterNotice(
+  marker: ProviderSyncMarker | null,
+  through: string
+): string | null {
+  if (!marker) return null
+  const reading = describeProviderSyncCoverage(marker, through)
+  return reading.coverage === 'behind' || reading.coverage === 'never_synced'
+    ? reading.headline
+    : null
 }
 
 /**
@@ -205,12 +303,20 @@ export function GroupedRowsTable(props: {
   )
 }
 
-/** The statement footer: run date on the left, `Page X of Y` on the right - `PrintFooter`'s defaults, self-contained. */
-export function StatementFooter(props: { dateLabel: string }) {
-  const { dateLabel } = props
+/**
+ * The statement footer: run date on the left, `Page X of Y` on the right -
+ * `PrintFooter`'s defaults, self-contained.
+ *
+ * `notice` is {@link providerSyncFooterNotice}'s one line, printed between them
+ * in dark bold against the band's grey. The band is `fixed`, so it repeats on
+ * every page for free.
+ */
+export function StatementFooter(props: { dateLabel: string; notice?: string | null }) {
+  const { dateLabel, notice } = props
   return (
     <View style={statementStyles.footerBand} fixed>
       <Text>{dateLabel}</Text>
+      {notice ? <Text style={statementStyles.footerNotice}>{notice}</Text> : null}
       <Text render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`} />
     </View>
   )


### PR DESCRIPTION
Two gaps the inbound sync shipped with in #2115 and #2116.

---

# 1. 🛑 The sync had no caller

`syncProviderLedger` merged, was exported from `postings/index.ts`, and **nothing invoked it**. No mutation, no job, no button — `grep` found the name only in a settings-catalog comment, the barrel export, and a router comment.

So the whole inbound half was unreachable:

- Brief 20 §8.5's acceptance test — *"after a sync, the difference for that period is zero"* — could not be run.
- §5.3's verify-on-read had never compared a real entry.
- The synced-through marker correctly read *"nothing has been read from QuickBooks yet"* on every org, forever.

## `ledger.syncProviderLedger`, on `ledgerControl`

**Not `ledgerPost`.** The sync *restates prior months*: it writes entries dated into closed periods and reverses ones whose provider id has stopped appearing. A bookkeeper with `ledgerPost` posts what is in front of them; they do not decide that last December is now different. That is `setLockedThrough`'s class of authority, and it takes `notDemo` for the same reason that one does.

Three cases in `ledger-permissions.test.ts` pin it behaviourally — deleting the assert makes the "refuses" cases reach the mocked lib call and fail, rather than silently passing.

## The screen answers four questions, and "it worked" is not one of them

| | rendered as |
|---|---|
| What came across | `written`, `alreadyPosted`, `reversed`, months read, with the **effective** `from`..`to` — which is where an omitted `from` reveals the floor |
| 🔴 What was **refused** | every `refusals` string **verbatim**, plus `unbalanced` entries naming `txnType`/`txnId`/date and both totals. A refusal is an entry that did *not* come across; a silent count is useless |
| 🔴 What waits on a person | `deferredToClosedMonths` grouped and linked per month, with the sentence that the sync reopens nothing and somebody with ledger control has to |
| How far it got | see below |

Plus a currency card when theirs differs from the org's (decision 12: **warns**, does not refuse), and `ourChecks` with a non-`matches` verdict — §5.3's verify-on-read, labelled "reported, never repaired".

## Two decisions worth reviewing

**`from` is deliberately not pre-filled with the cutover floor.** A pre-filled value is a value somebody edits, and that is the one edit that must be refused — reading below the floor re-imports the balances brief 19's opening entry was derived from and **doubles the whole opening position**. A muted line says what empty means and that an earlier date is refused rather than moved. The refusal comes back inline as a blocker card carrying the server's message verbatim.

**A short `syncedThrough` renders first, above every count.** A walk that stopped early makes each number under it a partial answer, and saying so afterwards is saying it too late. It names both dates, says the marker never advances past an unclean month, and says everything already brought across stays.

**Pending state** reuses the same pure `planSyncChunks` the server walks with, so it can say *"reading 2026-02-01 to 2026-12-31 as 11 separate requests, one per month"* with an elapsed counter. tRPC gives one request and one answer, so there is no real per-chunk progress to stream — this is the honest maximum rather than a spinner that says nothing for eleven months.

## 🛑 No schedule

No cron, no worker job, no run-on-mount, no auto-run after the agreement check. §7.4 is explicit: the button comes before the automation, because the first run against a real company file wants a person watching it.

---

# 2. The PDF said nothing about its own lag

The marker shipped on all six screens and not in the PDF. That is the wrong way round — a screen has a person in front of it, and **the PDF is the copy that gets emailed to an accountant.**

## One field, not two

`StatementPayload.completenessAsOf` was already exactly *"the last date this statement covers"* for all seven kinds, so it is renamed `statementThrough` and feeds the completeness banner and the sync reading alike.

⚠️ A statement that bounded one by one date and the other by another could print a clean banner beside a stale marker — **this feature's own failure mode reproduced inside it.**

Per kind: `to` for trial-balance, P&L and general-ledger (not `compare.to`); `asOf` for balance-sheet and both agings (not `compareAsOf` — the comparison column is a prior-period restatement, the statement still runs to `asOf`); `<year>-12-31` for the 1099 summary.

No router plumbing was needed: `readProviderSyncMarker` takes no `db`, so the renderer calls it in the `Promise.all` it already runs for completeness. It fails soft exactly as the screen does — an unreachable settings store renders **nothing**, on the rule that a missing line is a smaller problem than a wrong one.

## Unmissable without colour

**Inverted, not tinted** — near-black fill, white bold, an all-caps `STATEMENT INCOMPLETE` kicker, deliberately unlike the hairline-grey completeness box beside it. A PDF gets printed and photocopied, and inversion is the one treatment that survives greyscale.

**And it repeats on every page**, through the footer that is already `fixed`, so it costs no flow space and no per-page work. A statement is flipped to the page holding the number somebody cares about, not read from the top. A complete statement gets one quiet grey line and no footer stamp — a finished statement should not carry a box telling it so.

Both paths read through the same `describeProviderSyncCoverage`, so the PDF and the screen **cannot disagree** about whether a statement is complete. The test proves that by mocking it to return a sentinel reading no statement could produce and asserting the page prints exactly it — text equality alone would not have shown that the PDF computes nothing itself.

---

# Verification

| Check | Result |
|---|---|
| postings + purchasing + settings | **1746 pass**, 93 files |
| `@auxx/web` typecheck | clean |
| lib / web ratchets | no new errors |
| biome, 12 files | clean |

A real `renderToBuffer` smoke render confirmed `letterSpacing` and the filled-`View` treatment do not fault react-pdf — a crash there would have broken **every** statement PDF, not just the marker.

# Known

- ⚠️ **`unbalanced` and `ourChecks` are per-chunk only**, not aggregated at the top level like `refusals` and `deferredToClosedMonths` — so the UI has to `flatMap`, and a short `syncedThrough` is often explained by a value the top level does not carry.
- ⚠️ **`syncedThrough: null` conflates two things**: no chunk came back clean, and a clean chunk's marker write failed. Both read as "the marker did not move", which is true and never overstates coverage, so one message covers both.
- ⚠️ `describeProviderSyncCoverage` reads an empty `through` as `current`. Unreachable in both paths today; a future statement kind with no resolvable end date would silently print "Synced through" on a statement that could be behind. The JSDoc says so.
- 🔴 **Still not driven in a browser.** Green tests over screens nobody has opened.

https://claude.ai/code/session_01SnnNtETzUo1YEyeuKw1SoK
