### PR TITLE
feat(shipments): shared shipment and parcel entities, hidden and multi-app

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/custom-fields/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/custom-fields/page.tsx
@@ -37,8 +37,24 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 const BASE_URL = `/app/settings/custom-fields`
 
-/** Entity types that shouldn't appear in the custom fields list */
-const HIDDEN_ENTITY_TYPES = ['signature', 'inbox', 'personal_inbox', 'entity_group', 'tag']
+/**
+ * Entity types that shouldn't appear in the custom fields list.
+ *
+ * `EntityDefinition.isVisible: false` does NOT cover this screen - this is an
+ * independent hard-coded list, which is why hidden defs have to be named here
+ * as well (every other hidden native, `line_item` and `gl_account` included,
+ * does still appear here today).
+ */
+const HIDDEN_ENTITY_TYPES = [
+  'signature',
+  'inbox',
+  'personal_inbox',
+  'entity_group',
+  'tag',
+  // plans/apps/shipstation/shared-shipment-entities-proposal.md §7 step 10.
+  'shipment',
+  'parcel',
+]
 
 export default function CustomFieldsPage() {
   // Reachable by any def-admin (not just OWNER/ADMIN) — the list is filtered to

--- a/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
@@ -182,8 +182,19 @@ function AppConfigSource({ connector }: { connector: Connector }) {
   )
 }
 
-/** Map a JSON-Schema config node to the platform `FieldType` that renders it. */
+/**
+ * Map a JSON-Schema config node to the platform `FieldType` that renders it.
+ *
+ * `format` is checked BEFORE `type`, because a date is a `string` in JSON Schema
+ * and the format is the only thing that distinguishes it. Without this branch an
+ * app author who declares `z.iso.datetime()` still gets a free-text box, which
+ * accepts "last week" at save time and only fails when the sync runs.
+ */
 function fieldTypeFor(entry: FieldEntry): FieldTypeValue {
+  if (entry.node.type === 'string') {
+    if (entry.node.format === 'date-time') return FieldType.DATETIME
+    if (entry.node.format === 'date') return FieldType.DATE
+  }
   switch (entry.node.type) {
     case 'boolean':
       return FieldType.CHECKBOX
@@ -199,6 +210,8 @@ function fieldTypeFor(entry: FieldEntry): FieldTypeValue {
 function baseTypeFor(fieldType: FieldTypeValue): BaseType {
   if (fieldType === FieldType.CHECKBOX) return BaseType.BOOLEAN
   if (fieldType === FieldType.NUMBER) return BaseType.NUMBER
+  if (fieldType === FieldType.DATETIME) return BaseType.DATETIME
+  if (fieldType === FieldType.DATE) return BaseType.DATE
   return BaseType.STRING
 }
 

--- a/apps/web/src/components/global/schema-form/types.ts
+++ b/apps/web/src/components/global/schema-form/types.ts
@@ -21,6 +21,13 @@ export interface FieldNode {
   /** JSON-Schema node-level label/description (zod→JSON-Schema config nodes). */
   title?: string
   description?: string
+  /**
+   * JSON-Schema string `format` (`date-time`, `date`, `email`, …), as emitted by
+   * zod→JSON-Schema for `z.iso.datetime()` and friends. Carries the only signal
+   * that distinguishes a date from any other string, so a config field can be
+   * rendered with a real picker instead of a free-text box.
+   */
+  format?: string
 }
 
 export interface FieldEntry {

--- a/docs/app-fields-and-entities-guide.md
+++ b/docs/app-fields-and-entities-guide.md
@@ -198,16 +198,29 @@ Each field carries:
 
 ### `targetEntity` kinds
 
-`EntityRefKind` (`packages/sdk/src/root/tools/types.ts`), verified 2026-09-02, is today:
+`EntityRefKind` (`packages/sdk/src/root/tools/types.ts`), re-verified 2026-09-10, is today:
 
 ```
-contact · company · ticket · article · thread · order · invoice · catalog_item ·
-part · product · build · purchase_order · vendor_bill · gl_account
+contact · company · ticket · article · thread · order · invoice · line_item ·
+catalog_item · part · product · build · purchase_order · vendor_bill ·
+gl_account · credit_memo · credit_memo_line · credit_memo_application ·
+tax_line · shipment · parcel
 ```
 
-The apps plan's Phase 1 item 3.10 adds **`line_item`** to this union: the Shopify brief's line
-columns (§5 there) need it. This guide's worked examples in §5 already use `line_item` as the target
-state.
+`line_item` landed as the apps plan's Phase 1 item 3.10 (the Shopify brief's line columns, §5
+there); this guide's worked examples in §5 already use it. The four credit-memo and tax kinds
+arrived with entity migration 136, and `shipment` / `parcel` with 149.
+
+**Seven of those kinds are `isVisible: false`** and were admitted anyway: `line_item`,
+`credit_memo_line`, `tax_line`, `credit_memo_application`, `shipment` and `parcel`. That is not a
+loophole in the narrowness rule below, it is the rule's actual shape. The union's own doc comment
+records that the first three were admitted **precisely so a channel connector could address them**,
+and the same argument admitted the last two: a parcel is one physical box with one tracking number,
+which is the fact a support agent needs, and no single app owns it. See
+`plans/apps/shipstation/shared-shipment-entities-proposal.md` §2.
+
+What matters for admission is not visibility, it is whether a migration has seeded the kind into
+EXISTING orgs. A kind that lives only in `SYSTEM_ENTITIES` reaches new orgs and nothing else.
 
 One correction to the plan text: it frames a `gl_posting` kind as still to be decided ("add it or
 drop the QuickBooks field, decide in the same edit"). Verified against `tools/types.ts` on
@@ -379,6 +392,25 @@ mergeStrategy?, type?, name? }`:
   one contact, so `primary_email` stays `match: true` and both bind; two variants sharing a SKU are
   different things colliding, so `part_sku` is `match: 'exclusive'` and the second is skipped.
   Uniqueness cannot separate the two cases (both fields are unique), so the author has to say.
+
+  🛑 **Match candidates are OR'd, not ANDed, so every extra `match` field WIDENS the match.** The
+  intuition most authors bring to this is backwards, and until 2026-09-10 both the SDK's own
+  docblock and `IdentityRole` said the opposite. A connector's lookup goes through
+  `UnifiedCrudHandler.lookupByField`, which never passes the opt-in `matchAll` flag on
+  `lookupEntitiesByFieldValue` ("Default `false` (OR / first-wins, today's behaviour)"). Shopify's
+  contact mapping carries both `primary_email` and `phone` as `match: true`: an incoming
+  `jane@example.com` / `+15550001` against a stored `jane@example.com` / `+19998888` merges into
+  the existing Jane on the email hit. It does not create a second Jane because the phone disagrees.
+
+  The corollary is that **a composite key is unavailable to a connector.** Guarding a match on a
+  value a provider reuses (a carrier tracking number) with a second field such as a ship date is
+  not possible, because that candidate only widens the match. If a value cannot carry a match on
+  its own, do not declare `match` on it. `(part, supplier)` is the true composite key `matchAll`
+  exists for, and no connector can express it.
+
+  Ambiguity is not an error here: `lookupByField` passes `onAmbiguous: 'first'`, because a sync
+  must not fail on data the user can only fix by merging. Two hits take the first and file a
+  `DuplicateSuggestion`.
 - **`mergeStrategy`** is the sink's `FieldMergeStrategy` (`overwrite` default, `fill_blank`,
   `connector_owned_only`, `manual_review`, `ignore`), now declared by the author instead of set as a
   per-merchant click in the mapping editor.

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -176,6 +176,12 @@ export const ModelTypeValues = [
   // (plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md §5.3). Entity
   // migration 146.
   'payment_gateway',
+  // One dispatch of goods and the physical boxes it went out in
+  // (plans/apps/shipstation/shared-shipment-entities-proposal.md §6). Both are
+  // hidden (`isVisible: false`) and several apps contribute to them: ShipStation
+  // writes structure, the carrier apps write status.
+  'shipment',
+  'parcel',
 ] as const
 
 /**
@@ -235,6 +241,8 @@ export const ModelTypes = {
   TARIFF_RATE: 'tariff_rate',
   JOURNAL_ENTRY: 'journal_entry',
   PAYMENT_GATEWAY: 'payment_gateway',
+  SHIPMENT: 'shipment',
+  PARCEL: 'parcel',
 } as const
 
 /**
@@ -703,6 +711,29 @@ export const ModelTypeMeta: Record<
     // The door is Accounting > Settings > Payment gateways (task 13 §5.3), a
     // master-detail settings page. There is no `/app/payment-gateways/[id]`
     // route, same reasoning as `bank_account`.
+    hasDetailPage: false,
+  },
+  shipment: {
+    label: 'Shipment',
+    plural: 'Shipments',
+    icon: 'truck',
+    color: 'amber',
+    apiSlug: 'shipments',
+    dbTable: 'EntityInstance',
+    // Hidden entity, no route folder was authored (proposal §3, §7). There is
+    // no `/app/shipments/[id]` route, and claiming one here puts a fullscreen
+    // button on the drawer that 404s.
+    hasDetailPage: false,
+  },
+  parcel: {
+    label: 'Parcel',
+    plural: 'Parcels',
+    icon: 'box',
+    color: 'orange',
+    apiSlug: 'parcels',
+    dbTable: 'EntityInstance',
+    // Same as `shipment`: there is no `/app/parcels/[id]` route, and claiming
+    // one here puts a fullscreen button on the drawer that 404s.
     hasDetailPage: false,
   },
 }

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -166,6 +166,9 @@ function buildRegistry(): DataMigrationDef[] {
     // 107 to 130 are ENTITY migrations and own those ids in the shared
     // sequence; they arrive via ALL_ENTITY_MIGRATIONS above.
     migration131ReseedPlatformProvidersBankFeed,
+    // 132 to 149 are ENTITY migrations and own those ids too, arriving the same
+    // way. Nothing to add here for one: registering it in
+    // `entity-migrations/index.ts` is what puts it in this registry.
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -954,3 +954,116 @@ export const PaymentGatewayStatus = {
     { value: 'closed', label: 'Closed', color: 'gray' },
   ] satisfies FieldOptionItem[],
 } as const
+
+/**
+ * Parcel Tracking Status - one physical box, one tracking number
+ * `plans/apps/shipstation/shared-shipment-entities-proposal.md` §6.
+ *
+ * Lifted from the byte-identical enums already duplicated in
+ * `auxxai-apps/apps/fedex/src/tools/shared/shipment-schema.ts` and its UPS
+ * twin, so this consolidates an existing duplication rather than inventing a
+ * third vocabulary.
+ *
+ * `ready_for_pickup`, `attempted_delivery` and `delayed` are additions to the
+ * FedEx/UPS eight, taken from Shopify's `FulfillmentEventStatus`. Each earns
+ * its place by driving a support action `exception` cannot express: collect it,
+ * arrange redelivery, requote the date. `delayed` is the important one, because
+ * FedEx and UPS collapse a weather delay into `exception`, so an agent
+ * escalates a shipment that needs nothing but a new ETA.
+ *
+ * The label lifecycle (void, reprint) is deliberately NOT in this enum: it
+ * lives in the `parcel_voided` / `parcel_voided_at` booleans. With no second
+ * axis inside the enum, one shared vocabulary is correct here rather than the
+ * two-axis split {@link PurchaseOrderStatus} warns about.
+ *
+ * Colors follow {@link PurchaseOrderReceiptStatus}: grey for nothing yet or
+ * unknown, amber for the state somebody has to chase, green for complete, red
+ * for broken.
+ */
+export const ParcelTrackingStatus = {
+  LABEL_CREATED: 'label_created',
+  PICKED_UP: 'picked_up',
+  IN_TRANSIT: 'in_transit',
+  OUT_FOR_DELIVERY: 'out_for_delivery',
+  READY_FOR_PICKUP: 'ready_for_pickup',
+  ATTEMPTED_DELIVERY: 'attempted_delivery',
+  DELAYED: 'delayed',
+  DELIVERED: 'delivered',
+  EXCEPTION: 'exception',
+  RETURNED_TO_SHIPPER: 'returned_to_shipper',
+  UNKNOWN: 'unknown',
+
+  values: [
+    { value: 'label_created', label: 'Label Created', color: 'gray' },
+    { value: 'picked_up', label: 'Picked Up', color: 'blue' },
+    { value: 'in_transit', label: 'In Transit', color: 'blue' },
+    { value: 'out_for_delivery', label: 'Out for Delivery', color: 'indigo' },
+    { value: 'ready_for_pickup', label: 'Ready for Pickup', color: 'teal' },
+    { value: 'attempted_delivery', label: 'Attempted Delivery', color: 'amber' },
+    { value: 'delayed', label: 'Delayed', color: 'amber' },
+    { value: 'delivered', label: 'Delivered', color: 'green' },
+    { value: 'exception', label: 'Exception', color: 'red' },
+    { value: 'returned_to_shipper', label: 'Returned to Shipper', color: 'orange' },
+    { value: 'unknown', label: 'Unknown', color: 'gray' },
+  ] satisfies FieldOptionItem[],
+} as const
+
+/**
+ * Shipment Status - the roll-up over a shipment's boxes
+ * `plans/apps/shipstation/shared-shipment-entities-proposal.md` §6.
+ *
+ * The eleven {@link ParcelTrackingStatus} values plus `partially_delivered`,
+ * which is the one state a single box cannot be in. DERIVED by the connector
+ * over the shipment's active parcels and never hand-set, so like
+ * {@link PurchaseOrderReceiptStatus} it carries no `not_applicable` escape
+ * hatch.
+ *
+ * Roll-up rule. Voided parcels are excluded entirely. A shipment with no active
+ * parcels is `unknown`. Otherwise the shipment takes the highest-precedence
+ * status present, attention-first, so the box needing a human wins over the
+ * merely-common one (three boxes `in_transit` and one `exception` is an
+ * `exception` shipment):
+ *
+ * ```
+ * exception > returned_to_shipper > attempted_delivery > delayed
+ * > partially_delivered > delivered > ready_for_pickup > out_for_delivery
+ * > in_transit > picked_up > label_created > unknown
+ * ```
+ *
+ * `delivered` applies only when EVERY active parcel is delivered, so any mix of
+ * delivered and not-delivered is `partially_delivered`.
+ *
+ * Attention-first was CONFIRMED by the owner on 2026-09-10, closing the open
+ * item in §8. The alternative was progress-first, where the same shipment reads
+ * `partially_delivered` and the problem box stays invisible until somebody opens
+ * the shipment.
+ */
+export const ShipmentStatus = {
+  LABEL_CREATED: 'label_created',
+  PICKED_UP: 'picked_up',
+  IN_TRANSIT: 'in_transit',
+  OUT_FOR_DELIVERY: 'out_for_delivery',
+  READY_FOR_PICKUP: 'ready_for_pickup',
+  ATTEMPTED_DELIVERY: 'attempted_delivery',
+  DELAYED: 'delayed',
+  PARTIALLY_DELIVERED: 'partially_delivered',
+  DELIVERED: 'delivered',
+  EXCEPTION: 'exception',
+  RETURNED_TO_SHIPPER: 'returned_to_shipper',
+  UNKNOWN: 'unknown',
+
+  values: [
+    { value: 'label_created', label: 'Label Created', color: 'gray' },
+    { value: 'picked_up', label: 'Picked Up', color: 'blue' },
+    { value: 'in_transit', label: 'In Transit', color: 'blue' },
+    { value: 'out_for_delivery', label: 'Out for Delivery', color: 'indigo' },
+    { value: 'ready_for_pickup', label: 'Ready for Pickup', color: 'teal' },
+    { value: 'attempted_delivery', label: 'Attempted Delivery', color: 'amber' },
+    { value: 'delayed', label: 'Delayed', color: 'amber' },
+    { value: 'partially_delivered', label: 'Partially Delivered', color: 'amber' },
+    { value: 'delivered', label: 'Delivered', color: 'green' },
+    { value: 'exception', label: 'Exception', color: 'red' },
+    { value: 'returned_to_shipper', label: 'Returned to Shipper', color: 'orange' },
+    { value: 'unknown', label: 'Unknown', color: 'gray' },
+  ] satisfies FieldOptionItem[],
+} as const

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -27,6 +27,7 @@ import { LINE_ITEM_FIELDS } from './resources/line-item-fields'
 import { MEETING_FIELDS } from './resources/meeting-fields'
 import { MESSAGE_FIELDS } from './resources/message-fields'
 import { ORDER_FIELDS } from './resources/order-fields'
+import { PARCEL_FIELDS } from './resources/parcel-fields'
 import { PART_FIELDS } from './resources/part-fields'
 import { PARTICIPANT_FIELDS } from './resources/participant-fields'
 import { PAYMENT_FIELDS } from './resources/payment-fields'
@@ -38,6 +39,7 @@ import { PURCHASE_ORDER_FIELDS } from './resources/purchase-order-fields'
 import { PURCHASE_ORDER_LINE_FIELDS } from './resources/purchase-order-line-fields'
 import { QUOTE_FIELDS } from './resources/quote-fields'
 import { SERVICE_REQUEST_FIELDS } from './resources/service-request-fields'
+import { SHIPMENT_FIELDS } from './resources/shipment-fields'
 import { SIGNATURE_FIELDS } from './resources/signature-fields'
 import { STOCK_MOVEMENT_FIELDS } from './resources/stock-movement-fields'
 import { SUBPART_FIELDS } from './resources/subpart-fields'
@@ -174,6 +176,10 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   credit_memo_line: CREDIT_MEMO_LINE_FIELDS,
   credit_memo_application: CREDIT_MEMO_APPLICATION_FIELDS,
   tax_line: TAX_LINE_FIELDS,
+  // Hidden, multi-app: ShipStation contributes structure, the carrier apps
+  // contribute status (shared-shipment-entities-proposal.md). Entity migration 149.
+  shipment: SHIPMENT_FIELDS,
+  parcel: PARCEL_FIELDS,
 }
 
 /**

--- a/packages/lib/src/resources/registry/resources/order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/order-fields.ts
@@ -852,6 +852,56 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
       'jurisdiction answerable',
   },
 
+  // Reverse relationship: shipments (from shipment.order). The `shipment` side
+  // lands with entity migration 149
+  // (plans/apps/shipstation/shared-shipment-entities-proposal.md §6).
+  //
+  // ⚠️ DISTINCT from `fulfillments` above. That JSON field is the ACCOUNTING
+  // fulfillment record - what quantity was recognised and which GL posting it
+  // produced. A shipment is the PHYSICAL dispatch, with per-box tracking.
+  //
+  // `unlink`, not `cascade`: a shipment is a record of a physical dispatch that
+  // ShipStation minted and still owns, so deleting the auxx order record must
+  // not delete the other system's shipment and its parcels. Contrast
+  // `creditMemos` directly above, which cascades because a channel credit memo
+  // is fanned out of the order payload and has no life without it.
+  //
+  // 🛑 This edge CANNOT be populated yet (proposal §4). `linkMode: 'reference'`
+  // cannot cross connectors - `findItemByDef` filters `dataConnectorId` with
+  // hard equality (`data-connectors/relationship-pass.ts`) - so a ShipStation
+  // reference to a Shopify-created order resolves nothing, and unresolved edges
+  // never expire: they go back on `stillPending` and retry every run.
+  // Populating this needs a native `match` on a column Shopify already writes,
+  // or the platform resolver in the ShipStation build plan §6.
+  shipments: {
+    id: toFieldId('shipments'),
+    key: 'shipments',
+    label: 'Shipments',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'order_shipments',
+    systemSortOrder: 'aO',
+    showInPanel: false, // has_many inverse; surfaced from the shipment side
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'shipment:order' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'unlink',
+      isInverse: true,
+    },
+    description:
+      'Physical dispatches of this order - one per shipment, each carrying its own parcels ' +
+      'and tracking numbers',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/resources/registry/resources/parcel-fields.ts
+++ b/packages/lib/src/resources/registry/resources/parcel-fields.ts
@@ -1,0 +1,585 @@
+// packages/lib/src/resources/registry/resources/parcel-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import { ParcelTrackingStatus } from '../enum-values'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Parcel resource
+ * (`plans/apps/shipstation/shared-shipment-entities-proposal.md` §6, grounded in
+ * the live probe `plans/apps/shipstation/api-probe-2026-09-10.md` §2 and §3).
+ *
+ * ## What a parcel is
+ *
+ * ONE physical box with ONE tracking number. That is the grain a customer
+ * actually asks about ("where is my box"), and no single app owns it today.
+ * Ships `isVisible: false`, with no route folder, no list page and no create
+ * dialog, and it lands with **no writers at all** (§9 step 2): the registry
+ * definitions, the migration and the tests go first, nothing observable
+ * changes, and the connectors are pointed at it afterwards.
+ *
+ * ## Why this earns its own entity rather than living on the shipment
+ *
+ * Proposal §6, "Cross-vocabulary grounding", checked against the Shopify Admin
+ * GraphQL API on 2026-09-10: **Shopify has no parcel concept at all.**
+ * `Fulfillment.trackingInfo` is a bare `[FulfillmentTrackingInfo!]!` list of
+ * `{ company, number, url }` hung off the fulfillment, with no per-box
+ * identity, sequence, weight or status. Multi-box in Shopify is a list of
+ * numbers and nothing else, so Shopify can contribute tracking numbers and can
+ * never contribute per-box status. That gap is exactly what ShipStation fills,
+ * and it is why the box is a row rather than a repeated column on `shipment`.
+ *
+ * ## The ownership split (§5)
+ *
+ * **ShipStation owns structure** ({@link sequence}, {@link isMaster},
+ * {@link weight}/{@link weightUnit}, {@link length}/{@link width}/
+ * {@link height}/{@link dimUnit}, {@link voided}/{@link voidedAt}). **The
+ * carrier app owns status** ({@link status}, {@link statusCode},
+ * {@link statusDescription}, {@link estimatedDelivery}, {@link deliveredAt},
+ * {@link receivedBy}). Disjoint field sets on one row, which is what makes
+ * multi-app contribution safe here: no field ever has two `overwrite` writers,
+ * so the mutual-drift ping-pong in §4 (two connectors each reading the other's
+ * `FieldValue.managedByConnectorId` as drift and rewriting forever, silently)
+ * cannot start. And a parcel has exactly one carrier, so FedEx and UPS write
+ * disjoint sets of ROWS and never touch each other at all.
+ *
+ * ## Convergence goes through the tracking number
+ *
+ * {@link trackingNumber} is a native column precisely because it has to be a
+ * legal `match` target. App fields cannot be `match` targets at all:
+ * `buildContributingMatchBindings`
+ * (`packages/lib/src/data-connectors/app-catalog.ts:223-249`) binds a native
+ * `target` column only. That is why ShipStation's own parcel identity, the
+ * `label_id:package_id` external id, stays in an app field and is NOT the join
+ * key, while the tracking number is native.
+ *
+ * Carrier apps MATCH on that number and mint nothing, which is the second
+ * protection: `effectiveOrphanBehavior`
+ * (`packages/lib/src/data-connectors/reconciliation.ts:186-193`) degrades a
+ * declared `archive` to `mark_deleted` for any record a connector merely
+ * matched rather than created, so a carrier's reconciliation pass can never
+ * archive ShipStation's rows.
+ */
+export const PARCEL_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique parcel identifier',
+  },
+
+  /**
+   * ### Tracking numbers are treated as UNIQUE (§8b, owner's call 2026-09-10)
+   *
+   * This field carries the cross-app match on its own, with no date guard.
+   *
+   * The counter-evidence, written down so nobody rediscovers it: carriers DO
+   * reuse tracking numbers after long intervals, and the FedEx app already
+   * accepts `shipDateBegin`/`shipDateEnd` specifically to disambiguate reused
+   * ones. It is an acceptable risk rather than a latent corruption bug for
+   * three reasons:
+   *
+   * 1. **ShipStation is unaffected.** Its parcel identity is its own external
+   *    id (`label_id:package_id`) in an app field, not this number, so the
+   *    structural fields are never at risk of a mis-merge.
+   * 2. **Only the carrier apps match on it,** and only to write status.
+   * 3. **The failure is visible.** `lookupByField` runs under
+   *    `onAmbiguous: 'first'`: two rows sharing a number means status may land
+   *    on the older parcel, which is wrong but files a `DuplicateSuggestion`
+   *    and is repairable, not silent structural damage.
+   *
+   * A composite guard is unavailable to a connector anyway (§8a): match
+   * candidates are OR'd, not AND'd, so adding a ship-date candidate would only
+   * WIDEN the match. The `IdentityRole` docblock claiming otherwise is wrong.
+   *
+   * `nullable: false` because this is the primary display field and
+   * `computeDisplayValue` has no fallback.
+   */
+  trackingNumber: {
+    id: toFieldId('trackingNumber'),
+    key: 'trackingNumber',
+    label: 'Tracking Number',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'parcel_tracking_number',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter tracking number',
+    description:
+      'THE cross-app match key and the display field. Written by ShipStation; matched on by ' +
+      'the carrier apps, which mint nothing. Native rather than an app field because only a ' +
+      'native column can be a `match` target.',
+  },
+
+  sequence: {
+    id: toFieldId('sequence'),
+    key: 'sequence',
+    label: 'Sequence',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'parcel_sequence',
+    systemSortOrder: 'a2',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter sequence',
+    description:
+      "The box's position within its label, as ShipStation reports it. Use this for " +
+      'presentation whenever it is present: probe §2 found the packages returned in ' +
+      'sequence order 3, 2, 1, so array position carries no meaning.',
+  },
+
+  isMaster: {
+    id: toFieldId('isMaster'),
+    key: 'isMaster',
+    label: 'Master Parcel',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'parcel_is_master',
+    systemSortOrder: 'a3',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'The master box of a multi-package label. Probe §2: the master is the package with ' +
+      '`sequence` 1, and in the observed three-box label it was returned LAST in the array. ' +
+      'Never assume array index zero is the master.',
+  },
+
+  weight: {
+    id: toFieldId('weight'),
+    key: 'weight',
+    label: 'Weight',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'parcel_weight',
+    systemSortOrder: 'a4',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter weight',
+    description:
+      'Box weight in whatever {@link weightUnit} says. ShipStation returned OUNCES in the ' +
+      'probe (a 3-box label reported 1280, 464 and 704), so this number is meaningless on ' +
+      'its own. Never render it without the unit.',
+  },
+
+  weightUnit: {
+    id: toFieldId('weightUnit'),
+    key: 'weightUnit',
+    label: 'Weight Unit',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'parcel_weight_unit',
+    systemSortOrder: 'a5',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'ounce',
+    description:
+      'The unit {@link weight} is expressed in. Not decorative: ShipStation reports ounces, ' +
+      'not pounds, and a reader that assumes pounds is off by a factor of sixteen.',
+  },
+
+  length: {
+    id: toFieldId('length'),
+    key: 'length',
+    label: 'Length',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'parcel_length',
+    systemSortOrder: 'a6',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter length',
+    description: 'Box length in whatever {@link dimUnit} says. ShipStation returned inches.',
+  },
+
+  width: {
+    id: toFieldId('width'),
+    key: 'width',
+    label: 'Width',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'parcel_width',
+    systemSortOrder: 'a7',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter width',
+    description: 'Box width in whatever {@link dimUnit} says. ShipStation returned inches.',
+  },
+
+  height: {
+    id: toFieldId('height'),
+    key: 'height',
+    label: 'Height',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'parcel_height',
+    systemSortOrder: 'a8',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter height',
+    description: 'Box height in whatever {@link dimUnit} says. ShipStation returned inches.',
+  },
+
+  dimUnit: {
+    id: toFieldId('dimUnit'),
+    key: 'dimUnit',
+    label: 'Dimension Unit',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'parcel_dim_unit',
+    systemSortOrder: 'a9',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'inch',
+    description:
+      'The unit {@link length}, {@link width} and {@link height} are expressed in. The probe ' +
+      'observed inches (26 x 50 x 4, 96 x 4 x 4, 71 x 6 x 13), but like {@link weightUnit} ' +
+      'this is carried rather than assumed.',
+  },
+
+  voided: {
+    id: toFieldId('voided'),
+    key: 'voided',
+    label: 'Voided',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'parcel_voided',
+    systemSortOrder: 'aA',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Label lifecycle, NOT transit state. A void and reprint becomes this flag plus new ' +
+      'parcel rows, which is why there is no native `label` entity (§6) and why the label ' +
+      'lifecycle is deliberately absent from `ParcelTrackingStatus`. A voided parcel is ' +
+      'excluded from the shipment status roll-up ENTIRELY. Probe §3: voided labels still ' +
+      "carried a `tracking_status` of `in_transit`, so a carrier's status says nothing about " +
+      'whether the label is live and the two must be preserved independently.',
+  },
+
+  voidedAt: {
+    id: toFieldId('voidedAt'),
+    key: 'voidedAt',
+    label: 'Voided At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'parcel_voided_at',
+    systemSortOrder: 'aB',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'When the label carrying this box was voided. Keeps the void history rather than ' +
+      'deleting the row, which is how relabel history survives without a `label` entity.',
+  },
+
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'parcel_status',
+    systemSortOrder: 'aC',
+    nullable: true,
+    options: { options: ParcelTrackingStatus.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select status',
+    description:
+      'Normalized transit state for this one box. The carrier apps are the writers, and ' +
+      'neither FedEx nor UPS has a connector today, so this stays NULL in the first pass. ' +
+      'That is expected, not a gap: the ownership split in §5 is designed for their arrival, ' +
+      'not dependent on it.',
+  },
+
+  statusCode: {
+    id: toFieldId('statusCode'),
+    key: 'statusCode',
+    label: 'Status Code',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'parcel_status_code',
+    systemSortOrder: 'aD',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter status code',
+    description:
+      "The carrier's own raw code, kept beside the normalized {@link status} so the " +
+      "normalization is auditable. Carrier app writes it (probe §3 saw FedEx's `NY`).",
+  },
+
+  statusDescription: {
+    id: toFieldId('statusDescription'),
+    key: 'statusDescription',
+    label: 'Status Description',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'parcel_status_description',
+    systemSortOrder: 'aE',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter status description',
+    description:
+      "The carrier's human-readable text for {@link statusCode} (probe §3 saw `Not Yet In " +
+      'System`). Carrier app writes it.',
+  },
+
+  estimatedDelivery: {
+    id: toFieldId('estimatedDelivery'),
+    key: 'estimatedDelivery',
+    label: 'Estimated Delivery',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'parcel_estimated_delivery',
+    systemSortOrder: 'aF',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      "The carrier's current ETA for this box. Carrier app writes it. This is what an agent " +
+      'requotes when a box reads `delayed` rather than `exception`.',
+  },
+
+  deliveredAt: {
+    id: toFieldId('deliveredAt'),
+    key: 'deliveredAt',
+    label: 'Delivered At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'parcel_delivered_at',
+    systemSortOrder: 'aG',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'When the carrier reports this box was delivered. Carrier app writes it.',
+  },
+
+  receivedBy: {
+    id: toFieldId('receivedBy'),
+    key: 'receivedBy',
+    label: 'Received By',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'parcel_received_by',
+    systemSortOrder: 'aH',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter recipient name',
+    description:
+      'Who the carrier says signed for this box. Carrier app writes it; per box, because a ' +
+      'multi-box shipment can be signed for by different people on different days.',
+  },
+
+  shipment: {
+    id: toFieldId('shipment'),
+    key: 'shipment',
+    label: 'Shipment',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'parcel_shipment',
+    systemSortOrder: 'aI',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'shipment:parcels' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'shipment',
+      relationshipType: 'belongs_to',
+      inverseName: 'Parcels',
+      inverseSystemAttribute: 'shipment_parcels',
+    },
+    description:
+      'The dispatch this box was part of. Declaration only in the first pass. No `onDelete` ' +
+      'here by rule: a `belongs_to` never declares one, the has_many side ' +
+      '(`shipment.parcels`) owns that answer.',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the parcel is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the parcel is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/shipment-fields.ts
+++ b/packages/lib/src/resources/registry/resources/shipment-fields.ts
@@ -1,0 +1,441 @@
+// packages/lib/src/resources/registry/resources/shipment-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import { ShipmentStatus } from '../enum-values'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Shipment resource
+ * (`plans/apps/shipstation/shared-shipment-entities-proposal.md` §6, grounded in
+ * the live probe at `plans/apps/shipstation/api-probe-2026-09-10.md` §2).
+ *
+ * ## What a shipment is
+ *
+ * One dispatch of goods. Its boxes are `parcel` records
+ * ({@link parcels}), one per physical box with one tracking number each.
+ *
+ * Hidden system entity (`isVisible: false`) with **no route folder** under
+ * `apps/web/src/app/(protected)/app/`, so there is no list page and no create
+ * dialog. Per proposal §3, `isVisible: false` only suppresses the Records
+ * sidebar group, the kbar create action, the kbar record-search scope and the
+ * AI entity catalog; the absent route folder is what actually keeps it off the
+ * list pages. This lands with **no writers at all**. The ShipStation connector
+ * arrives afterwards (§9 step 3), so every field below is null on every row
+ * until it does. Nothing observable changes when this ships.
+ *
+ * ## Why NATIVE rather than app-owned (§2)
+ *
+ * Three apps know different things about the same object. ShipStation knows
+ * what was dispatched: shipments, which boxes belong together, void and relabel
+ * history. FedEx and UPS know where each parcel is: status, scans, delivery.
+ * Shopify knows which order it belongs to. App-owned entities would give each
+ * of them its own table, with no way to join a ShipStation box to the FedEx
+ * status of that same box. The normalized carrier status enum is already
+ * duplicated byte-for-byte between the FedEx and UPS apps; ShipStation would
+ * have been a third copy.
+ *
+ * ## The ownership split that makes multi-app writing safe (§5)
+ *
+ * Every drift and collision hazard in §4 is a consequence of **two writers on
+ * one field**, so this design removes that by construction:
+ *
+ * - **ShipStation owns structure, the carrier apps own status.** Disjoint field
+ *   sets on one row. No field ever has two `overwrite` writers, so the
+ *   mutual-drift ping-pong in §4 cannot start.
+ * - A parcel has exactly one carrier, so FedEx and UPS never touch the same row.
+ *
+ * This split is load-bearing, not a convention. Any later contributor must take
+ * `fill_blank`, `connector_owned_only` or `ignore` on fields it does not own, or
+ * route its value to its own namespaced app field instead. A second `overwrite`
+ * writer starts the ping-pong silently: nothing errors, both connectors rewrite
+ * and re-stamp every field every run, forever.
+ *
+ * ## Per-app external ids stay in APP fields
+ *
+ * ShipStation's `shipmentId` (the probe observed `se-428778294`) lives in an app
+ * field, which is namespaced by `appSlug` and therefore cannot collide with
+ * another app's id for the same row. These are deliberately **not** native
+ * columns here: a native id column would have to be claimed by one app, and it
+ * would still be useless as a cross-app join key because `match` cannot bind an
+ * `appField` (§4).
+ *
+ * ## ⚠️ `shipment` is NOT `order_fulfillments`
+ *
+ * `order_fulfillments` is a JSON field on `order`, authored in
+ * `order-fields.ts`. That is the **accounting** fulfillment record: what was
+ * shipped and the GL posting it produced. This entity is the **physical**
+ * dispatch and its boxes. They answer different questions, they have different
+ * writers, and one is not derivable from the other. Do not conflate them, and
+ * do not replace either with the other.
+ */
+export const SHIPMENT_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique shipment identifier',
+  },
+
+  number: {
+    id: toFieldId('number'),
+    key: 'number',
+    label: 'Shipment Number',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'shipment_number',
+    systemSortOrder: 'a1',
+    // 🛑 NULLABLE, and it has to be. ShipStation's docs on `shipment_number` are
+    // explicit that it is "optional, mutable, and does not require uniqueness,
+    // allowing multiple shipments to share the same value" - deliberately, so
+    // partial shipments and re-created canceled orders can share a number.
+    //
+    // An earlier version of this field was `nullable: false`, reasoned from the
+    // consequence (this is the primary display field and `computeDisplayValue`
+    // has no fallback, so a null renders the row nameless) rather than from the
+    // provider. The consequence is real; the requirement was not ours to make.
+    // A shipment with no number is a legitimate shipment and renders nameless,
+    // which is honest.
+    //
+    // Two corollaries follow from the same doc and are load-bearing elsewhere:
+    // MUTABLE, so this could never be the external id (that is the app's
+    // `shipmentId`), and NOT UNIQUE, so it must never carry a `match`.
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: '14530',
+    description:
+      "ShipStation's shipment number, which is the merchant's ORDER number - the same value " +
+      "as v1's `orderNumber` and the Order Number in the ShipStation UI, not a tracking " +
+      'number and not an internal id. Free-form text: the probe observed `14530`, the docs ' +
+      'also show `ORDER-2024-001`. Optional, mutable and non-unique at the source. ' +
+      '⚠️ NOT carried on the label payload - it lives on the shipment resource, so the ' +
+      'label stream alone leaves it empty.',
+  },
+
+  /**
+   * The tracking number of this shipment's ACTIVE label's master parcel,
+   * denormalized onto the shipment so it can be the display value.
+   *
+   * ## Why this is denormalized rather than read through the relationship
+   *
+   * `computeDisplayValue` reads a field on the ROW, and a tracking number lives
+   * on a `parcel`. There is no way to point a display field at a related
+   * record's column, so the value has to exist here.
+   *
+   * ## Why it is not fetched from the shipment endpoint
+   *
+   * Checked against the V2 docs on 2026-09-10: `GET /v2/shipments/{id}` returns
+   * NO tracking number, at the top level or inside its `packages[]` (those carry
+   * `package_code`, `weight`, `dimensions` and `label_messages` only). The live
+   * probe found the same thing. Labels are the only source of tracking numbers,
+   * and the label stream already holds the master, so the connector writes this
+   * at no extra request. (`GET /v2/shipments/{id}/labels` does return a
+   * shipment-level `tracking_number`, but that is one request per shipment for
+   * something already in hand.)
+   *
+   * ## Which master, when there is more than one
+   *
+   * The ACTIVE label's. A void plus its reprint puts two masters on one
+   * shipment - 6 of 135 shipments in the first real sync - and exactly one is
+   * live in each case. When every label is voided (1 of 135) the connector
+   * writes the voided master rather than nothing: a number a person can still
+   * search beats a nameless row.
+   *
+   * ⚠️ NOT STABLE. A reprint replaces this with the new label's master, so the
+   * shipment's display name changes. That is intended - it is the number the
+   * customer is quoting today - but it means this must never be used as an
+   * identity or a match key.
+   */
+  masterTrackingNumber: {
+    id: toFieldId('masterTrackingNumber'),
+    key: 'masterTrackingNumber',
+    label: 'Master Tracking Number',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'shipment_master_tracking_number',
+    systemSortOrder: 'a1a',
+    // Nullable like everything else the provider does not guarantee. The first
+    // real sync filled it on 135 of 135 shipments, but that is evidence, not a
+    // contract, and `shipment_number` is the cautionary tale: a `nullable:
+    // false` argued from "it is the display field" rather than from the source.
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: '383646550733',
+    description:
+      "The master parcel's tracking number on this shipment's active label, copied here by " +
+      'the connector so the shipment has a name a support agent can search. Free-form text: ' +
+      'FedEx is 12 digits, UPS is `1Z` plus 16 alphanumeric, USPS is 20 to 22 digits. ' +
+      'Changes when a label is voided and reprinted, so never match on it.',
+  },
+
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'shipment_status',
+    systemSortOrder: 'a2',
+    nullable: true,
+    options: { options: ShipmentStatus.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select status',
+    description:
+      "DERIVED, never typed by a person. A roll-up over this shipment's ACTIVE (non-voided) " +
+      'parcels, computed by the connector (§8d: the mapping has no transform hook, so the ' +
+      'connector server emits an already-normalized value). Voided parcels are excluded ' +
+      'entirely; a shipment with no active parcels is `unknown`; `delivered` applies only ' +
+      'when EVERY active parcel is delivered, any mix being `partially_delivered`. The ' +
+      'precedence is attention-first, so one exception box among three in-transit ones reads ' +
+      '`exception` rather than hiding the problem behind progress. That ordering was ' +
+      'confirmed by the owner on 2026-09-10, closing the open item in §8.',
+  },
+
+  carrier: {
+    id: toFieldId('carrier'),
+    key: 'carrier',
+    label: 'Carrier',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'shipment_carrier',
+    systemSortOrder: 'a3',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'fedex',
+    description:
+      'Which carrier moved this shipment: `fedex`, `ups`, `usps`. Free TEXT rather than an ' +
+      'enum, because the carrier list is account configuration and a new connection must not ' +
+      'need a registry edit. ShipStation owns this field.',
+  },
+
+  service: {
+    id: toFieldId('service'),
+    key: 'service',
+    label: 'Service',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'shipment_service',
+    systemSortOrder: 'a4',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'fedex_home_delivery',
+    description:
+      "The carrier service code, e.g. `fedex_home_delivery` from the probe's three-box " +
+      'example. Per-carrier vocabulary, so TEXT for the same reason as carrier.',
+  },
+
+  shipDate: {
+    id: toFieldId('shipDate'),
+    key: 'shipDate',
+    label: 'Ship Date',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'shipment_ship_date',
+    systemSortOrder: 'a5',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'When the shipment was dispatched. The probe found the shipment and its label disagree ' +
+      '(`2026-09-10T00:00:00Z` against `2026-09-10T07:00:00Z`) and did not establish the ' +
+      'timezone contract, so whichever the connector picks must be written down there. This ' +
+      'never replaces the accounting fulfillment date on the order.',
+  },
+
+  parcelCount: {
+    id: toFieldId('parcelCount'),
+    key: 'parcelCount',
+    label: 'Parcel Count',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'shipment_parcel_count',
+    systemSortOrder: 'a6',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'How many boxes the provider reported for this shipment. Multi-box is the common case, ' +
+      'not the edge: 34 of the 50 labels in the probe carried more than one package, up to ' +
+      'ten. Carried as its own number so a count is available before the parcel rows are.',
+  },
+
+  parcels: {
+    id: toFieldId('parcels'),
+    key: 'parcels',
+    label: 'Parcels',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'shipment_parcels',
+    systemSortOrder: 'a7',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'parcel:shipment' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    },
+    description:
+      'The physical boxes in this shipment. `cascade` because a parcel is an owned child: it ' +
+      'has no meaning without its shipment, and a voided label survives as a voided parcel ' +
+      'rather than as an orphan. The has_many side declares the behavior; the belongs_to side ' +
+      'on `parcel` declares nothing.',
+  },
+
+  order: {
+    id: toFieldId('order'),
+    key: 'order',
+    label: 'Order',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'shipment_order',
+    systemSortOrder: 'a8',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'order:shipments' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'order',
+      relationshipType: 'belongs_to',
+      inverseName: 'Shipments',
+      inverseSystemAttribute: 'order_shipments',
+    },
+    description:
+      'The order this dispatch fulfils. One order has many shipments, one shipment has one ' +
+      "order (Shopify's `Fulfillment.order` is `Order!`, singular and non-null). " +
+      '⚠️ Declared here but **not populatable by a ShipStation reference mapping**: per §4, ' +
+      "`linkMode: 'reference'` cannot cross connectors, because `findItemByDef` filters " +
+      '`dataConnectorId` with hard equality, so a ShipStation reference to a Shopify-created ' +
+      'order resolves nothing and is retried every run forever. Populating this needs either ' +
+      'a native `match` on a column Shopify already writes, or the platform resolver in build ' +
+      'plan §6. Neither blocks this entity: the parcel data is useful before any order is ' +
+      'matched.',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the shipment is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the shipment is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -105,6 +105,7 @@ import { migration145RetireInstanceRoles } from './migrations/145-retire-instanc
 import { migration146PaymentGateway } from './migrations/146-payment-gateway'
 import { migration147BackfillBankMatchKeys } from './migrations/147-backfill-bank-match-keys'
 import { migration148RecurringJournalEntries } from './migrations/148-recurring-journal-entries'
+import { migration149ShipmentParcel } from './migrations/149-shipment-parcel'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -347,6 +348,18 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // reads only bank_transaction.description and rewrites only matchKey.
   migration147BackfillBankMatchKeys,
   migration148RecurringJournalEntries,
+  // The hidden `shipment` and `parcel` defs, their fields and the
+  // `order_shipments` inverse
+  // (plans/apps/shipstation/shared-shipment-entities-proposal.md §7).
+  //
+  // MUST sort after 107, which creates `order`: this widens that def with the
+  // has_many inverse of `shipment_order`. An org short of 107 is a SKIP, not a
+  // failure.
+  //
+  // No ordering constraint against anything else. It creates two defs nothing
+  // else references and lands with NO writers - the ShipStation connector comes
+  // next, and the carrier apps after that.
+  migration149ShipmentParcel,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/107-order.test.ts
@@ -86,6 +86,11 @@ describe('order entity registration wiring', () => {
       'number',
       'paymentGateways',
       'placedAt',
+      // added by migration 149 - inverse of shipment_order, `unlink` not
+      // `cascade` (apps/shipstation/shared-shipment-entities-proposal.md §6).
+      // NOT the same thing as `fulfillments` above, which is the accounting
+      // shipment log; this is the physical dispatch and its boxes.
+      'shipments',
       'shippingAddress',
       'shippingTotal', // added by migration 122 — money plan 37 §6/§8
       'subtotal',

--- a/packages/lib/src/seed/entity-migrations/migrations/149-shipment-parcel.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/149-shipment-parcel.test.ts
@@ -1,0 +1,295 @@
+// packages/lib/src/seed/entity-migrations/migrations/149-shipment-parcel.test.ts
+//
+// A new entity type is a hand-edit across several files (`enums.ts`,
+// `enum-values.ts`, `field-registry.ts`, `create-fields.ts`, `constants.ts`,
+// `types/resource/utils.ts`, the system-attribute union, the SDK union), and
+// getting one wrong creates a def the app can half see: the records path
+// resolves it and the seeder does not, or the reverse. 146's test pins that
+// checklist for `payment_gateway`; this pins it for BOTH halves of
+// `plans/apps/shipstation/shared-shipment-entities-proposal.md`, and adds the
+// thing that proposal makes load-bearing: the relationship edges and their
+// `onDelete` answers.
+
+import { ModelTypeMeta, ModelTypes, ModelTypeValues } from '@auxx/database/enums'
+import { ENTITY_DEFINITION_TYPES } from '@auxx/types/resource'
+import { SYSTEM_ATTRIBUTES } from '@auxx/types/system-attribute'
+import { describe, expect, it } from 'vitest'
+import { ALL_DATA_MIGRATIONS } from '../../../data-migrations/registry'
+import { ParcelTrackingStatus, ShipmentStatus } from '../../../resources/registry/enum-values'
+import { RESOURCE_FIELD_REGISTRY } from '../../../resources/registry/field-registry'
+import { ORDER_FIELDS } from '../../../resources/registry/resources/order-fields'
+import { PARCEL_FIELDS } from '../../../resources/registry/resources/parcel-fields'
+import { SHIPMENT_FIELDS } from '../../../resources/registry/resources/shipment-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { DISPLAY_FIELD_CONFIG, SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import { FIELD_REGISTRY } from '../../entity-seeder/create-fields'
+import { migration149ShipmentParcel } from './149-shipment-parcel'
+
+const MIGRATION_ID = '149-shipment-parcel'
+
+describe('migration 149 registration', () => {
+  it('is registered exactly once, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('leaves every registered id on a distinct number, and 149 is its own', () => {
+    const numbers = ALL_ENTITY_MIGRATIONS.map((m) => m.id.split('-')[0])
+    expect(new Set(numbers).size).toBe(numbers.length)
+    expect(ALL_ENTITY_MIGRATIONS.filter((m) => m.id.split('-')[0] === '149')).toHaveLength(1)
+  })
+
+  it('exports the migration it registers', () => {
+    expect(ALL_ENTITY_MIGRATIONS).toContain(migration149ShipmentParcel)
+  })
+
+  it('reaches the shared data-migration registry without an entry of its own', () => {
+    // `buildRegistry` spreads `ALL_ENTITY_MIGRATIONS.map(wrapEntityMigration)`,
+    // so registering above is the whole job. A hand-written entry in
+    // `data-migrations/registry.ts` would be a DUPLICATE id, which
+    // `assertUniqueMigrationIds` throws on at module load.
+    expect(ALL_DATA_MIGRATIONS.filter((m) => m.id === MIGRATION_ID)).toHaveLength(1)
+  })
+
+  it('sorts after 107, which creates the order def this migration widens', () => {
+    const ids = ALL_DATA_MIGRATIONS.map((m) => m.id)
+    const order = ids.findIndex((id) => id.startsWith('107-'))
+    expect(order).toBeGreaterThanOrEqual(0)
+    expect(ids.indexOf(MIGRATION_ID)).toBeGreaterThan(order)
+  })
+})
+
+describe.each([
+  ['shipment', 'shipments', 'Shipment', SHIPMENT_FIELDS],
+  ['parcel', 'parcels', 'Parcel', PARCEL_FIELDS],
+] as const)('%s is registered everywhere a def has to be', (type, apiSlug, singular, fields) => {
+  it('is a ModelTypeValues entry, mapped in ModelTypes, with EntityInstance meta', () => {
+    expect(ModelTypeValues).toContain(type)
+    expect(ModelTypes[type.toUpperCase() as 'SHIPMENT' | 'PARCEL']).toBe(type)
+    expect(ModelTypeMeta[type].apiSlug).toBe(apiSlug)
+    expect(ModelTypeMeta[type].label).toBe(singular)
+    expect(ModelTypeMeta[type].dbTable).toBe('EntityInstance')
+    // No `/app/shipments/[id]` or `/app/parcels/[id]` route exists; claiming
+    // one puts a fullscreen button on the drawer that 404s.
+    expect(ModelTypeMeta[type].hasDetailPage).toBe(false)
+  })
+
+  it('is an EntityDefinitionType, so a <type>:<id> RecordId canonicalizes', () => {
+    expect(ENTITY_DEFINITION_TYPES).toContain(type)
+  })
+
+  it('resolves the SAME field map in both registries used by the two seeders', () => {
+    // Object identity, not deep equality: `createAllFields` iterates
+    // FIELD_REGISTRY while `createEntityDefinitions` iterates SYSTEM_ENTITIES,
+    // so a type in the second and not the first lands on a new org as a
+    // definition with ZERO fields and `UnifiedCrudHandler` silently drops every
+    // value with only a logged warning. `bank_rule` shipped that way.
+    expect(RESOURCE_FIELD_REGISTRY[type]).toBe(fields)
+    expect(FIELD_REGISTRY[type]).toBe(fields)
+  })
+
+  it('is a HIDDEN SYSTEM_ENTITIES entry - no sidebar group, and no route folder', () => {
+    const entity = SYSTEM_ENTITIES.find((e) => e.entityType === type)
+    expect(entity).toBeDefined()
+    expect(entity?.apiSlug).toBe(apiSlug)
+    expect(entity?.isVisible).toBe(false)
+  })
+
+  it('every field carries a systemAttribute in the shared union', () => {
+    for (const field of Object.values(fields)) {
+      expect(SYSTEM_ATTRIBUTES).toContain(field.systemAttribute)
+    }
+  })
+
+  it('displays as fields that exist on the def', () => {
+    const config = DISPLAY_FIELD_CONFIG[type]
+    expect(config).toBeDefined()
+    expect(fields[config!.primaryDisplayField]).toBeDefined()
+    expect(fields[config!.secondaryDisplayField!]).toBeDefined()
+  })
+})
+
+describe('the fields the proposal makes load-bearing', () => {
+  it('names BOTH by a tracking number, and the shipment NOT by its number', () => {
+    // The shipment's display is the master tracking number, not
+    // `shipment_number`. Two reasons, both from the provider rather than from
+    // what would read nicely:
+    //
+    //  1. `shipment_number` is not on the label payload at all - it lives on the
+    //     shipment resource - so the label stream left it empty on 135 of 135
+    //     shipments in the first real sync and every one rendered nameless.
+    //  2. ShipStation documents it as "optional, mutable, and does not require
+    //     uniqueness", so it is not something to lean on.
+    //
+    // The master tracking number filled 135 of 135 in that same sync, and it is
+    // what a support agent actually arrives holding.
+    expect(DISPLAY_FIELD_CONFIG.shipment?.primaryDisplayField).toBe('masterTrackingNumber')
+    expect(DISPLAY_FIELD_CONFIG.shipment?.primaryDisplayField).not.toBe('number')
+    expect(DISPLAY_FIELD_CONFIG.parcel?.primaryDisplayField).toBe('trackingNumber')
+  })
+
+  it('denormalizes the master tracking number onto the shipment, never matching on it', () => {
+    const f = SHIPMENT_FIELDS.masterTrackingNumber
+    expect(f).toBeDefined()
+    expect(f?.systemAttribute).toBe('shipment_master_tracking_number')
+    expect(f?.fieldType).toBe('TEXT')
+    // Nullable: the provider guarantees nothing, and `shipment_number` is the
+    // cautionary tale for arguing a requirement from "it is the display field".
+    expect(f?.nullable).toBe(true)
+    // It CHANGES on a void-and-reprint, so it can never be an identity.
+    expect(f?.type).not.toBe('RELATION')
+  })
+
+  it('requires the parcel tracking number and NOT the shipment number', () => {
+    // Asymmetric on purpose, and both halves come from the provider rather than
+    // from what would be convenient for the display.
+    //
+    // A parcel without a tracking number is not a parcel: the number is the
+    // cross-app match key every carrier app converges on.
+    //
+    // `shipment_number` is the merchant's ORDER number, and ShipStation
+    // documents it as "optional, mutable, and does not require uniqueness".
+    // Requiring it would be auxx inventing a constraint the source does not
+    // have - and the label stream does not even carry the field, so every
+    // synced shipment would violate it.
+    expect(PARCEL_FIELDS.trackingNumber?.nullable).toBe(false)
+    expect(SHIPMENT_FIELDS.number?.nullable).toBe(true)
+  })
+
+  it('keeps parcel_tracking_number a plain native TEXT column, the only legal match key', () => {
+    // §4: `buildContributingMatchBindings` binds a native `target` column only,
+    // so a provider id held in an APP field can never be a cross-app join key.
+    // This is why convergence goes through this column and not ShipStation's
+    // `label_id:package_id` external id.
+    expect(PARCEL_FIELDS.trackingNumber?.fieldType).toBe('TEXT')
+    expect(PARCEL_FIELDS.trackingNumber?.systemAttribute).toBe('parcel_tracking_number')
+    expect(PARCEL_FIELDS.trackingNumber?.nullable).toBe(false)
+  })
+
+  it('leaves every carrier-owned status field nullable, because neither app has a connector', () => {
+    // §5 and the §8 decision: FedEx and UPS get connectors later, so these have
+    // no writer in the first pass. Null is the expected state, not a gap.
+    for (const key of [
+      'status',
+      'statusCode',
+      'statusDescription',
+      'estimatedDelivery',
+      'deliveredAt',
+      'receivedBy',
+    ]) {
+      expect(PARCEL_FIELDS[key]?.nullable).toBe(true)
+    }
+  })
+
+  it('carries the label lifecycle in booleans, never inside the status enum', () => {
+    // §6: a void and reprint becomes lifecycle on the parcel plus new parcel
+    // rows, which is what lets one shared vocabulary serve both grains instead
+    // of the two-axis split `PurchaseOrderStatus` warns about.
+    expect(PARCEL_FIELDS.voided?.fieldType).toBe('CHECKBOX')
+    expect(PARCEL_FIELDS.voidedAt?.fieldType).toBe('DATETIME')
+    const parcelValues = ParcelTrackingStatus.values.map((v) => v.value)
+    expect(parcelValues).not.toContain('voided')
+    expect(parcelValues).not.toContain('label_voided')
+  })
+
+  it('keeps the unit fields, because ShipStation reports ounces and inches', () => {
+    expect(PARCEL_FIELDS.weightUnit).toBeDefined()
+    expect(PARCEL_FIELDS.dimUnit).toBeDefined()
+  })
+})
+
+describe('the relationship edges', () => {
+  it('gives shipment.parcels the cascade, and parcel.shipment no onDelete at all', () => {
+    // A belongs_to never declares anything: the has_many side owns the answer
+    // and the engine reads the STORED value copied from there.
+    expect(SHIPMENT_FIELDS.parcels?.relationship).toMatchObject({
+      inverseResourceFieldId: 'parcel:shipment',
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    })
+    expect(PARCEL_FIELDS.shipment?.relationship?.relationshipType).toBe('belongs_to')
+    expect(PARCEL_FIELDS.shipment?.relationship?.onDelete).toBeUndefined()
+    expect(PARCEL_FIELDS.shipment?.relationshipConfig?.relatedEntityType).toBe('shipment')
+  })
+
+  it('unlinks order.shipments rather than cascading, so deleting an order keeps the boxes', () => {
+    // Owner's call: a shipment is a physical dispatch ShipStation minted and
+    // still owns. Contrast `order.creditMemos`, which cascades because a channel
+    // credit memo is fanned out of the order payload and has no life without it.
+    expect(ORDER_FIELDS.shipments?.relationship).toMatchObject({
+      inverseResourceFieldId: 'shipment:order',
+      relationshipType: 'has_many',
+      onDelete: 'unlink',
+      isInverse: true,
+    })
+    expect(ORDER_FIELDS.creditMemos?.relationship?.onDelete).toBe('cascade')
+  })
+
+  it('points shipment.order at the inverse order.shipments declares', () => {
+    expect(SHIPMENT_FIELDS.order?.relationship?.inverseResourceFieldId).toBe('order:shipments')
+    expect(SHIPMENT_FIELDS.order?.relationship?.relationshipType).toBe('belongs_to')
+    expect(SHIPMENT_FIELDS.order?.relationshipConfig?.inverseSystemAttribute).toBe(
+      'order_shipments'
+    )
+    // Declared but not yet populatable (§4): `linkMode: 'reference'` cannot
+    // cross connectors, so this stays null until a native match or the
+    // platform resolver lands. Nullable is what makes that survivable.
+    expect(SHIPMENT_FIELDS.order?.nullable).toBe(true)
+  })
+
+  it('gives order.shipments a sortOrder that collides with no other order field', () => {
+    const orders = Object.values(ORDER_FIELDS)
+      .map((f) => f.systemSortOrder)
+      .filter((s): s is string => typeof s === 'string')
+    expect(new Set(orders).size).toBe(orders.length)
+  })
+})
+
+describe('the shared status vocabulary', () => {
+  const PARCEL_VALUES = [
+    'label_created',
+    'picked_up',
+    'in_transit',
+    'out_for_delivery',
+    'ready_for_pickup',
+    'attempted_delivery',
+    'delayed',
+    'delivered',
+    'exception',
+    'returned_to_shipper',
+    'unknown',
+  ]
+
+  it('lists exactly the eleven ParcelTrackingStatus values', () => {
+    expect(ParcelTrackingStatus.values.map((v) => v.value)).toEqual(PARCEL_VALUES)
+  })
+
+  it('is ShipmentStatus plus partially_delivered, the one state a single box cannot be in', () => {
+    const shipmentValues = ShipmentStatus.values.map((v) => v.value)
+    expect(shipmentValues).toContain('partially_delivered')
+    expect(new Set(shipmentValues)).toEqual(new Set([...PARCEL_VALUES, 'partially_delivered']))
+  })
+
+  it('carries an explicit unknown case in both, so nothing has to be guessed', () => {
+    // §8d rule 2: anything the connector does not recognise maps here, never to
+    // a guess. That is the whole reason the case exists.
+    expect(ParcelTrackingStatus.values.map((v) => v.value)).toContain('unknown')
+    expect(ShipmentStatus.values.map((v) => v.value)).toContain('unknown')
+  })
+
+  it('binds both status fields to their preset enum', () => {
+    expect(PARCEL_FIELDS.status?.fieldType).toBe('SINGLE_SELECT')
+    expect(PARCEL_FIELDS.status?.options?.options).toBe(ParcelTrackingStatus.values)
+    expect(SHIPMENT_FIELDS.status?.fieldType).toBe('SINGLE_SELECT')
+    expect(SHIPMENT_FIELDS.status?.options?.options).toBe(ShipmentStatus.values)
+  })
+
+  it('gives every value a label and a colour', () => {
+    for (const item of [...ParcelTrackingStatus.values, ...ShipmentStatus.values]) {
+      expect(item.label).toBeTruthy()
+      expect(item.color).toBeTruthy()
+    }
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/149-shipment-parcel.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/149-shipment-parcel.ts
@@ -1,0 +1,241 @@
+// packages/lib/src/seed/entity-migrations/migrations/149-shipment-parcel.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
+import { getOrgCache } from '../../../cache'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { ORDER_FIELDS } from '../../../resources/registry/resources/order-fields'
+import { PARCEL_FIELDS } from '../../../resources/registry/resources/parcel-fields'
+import { SHIPMENT_FIELDS } from '../../../resources/registry/resources/shipment-fields'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import {
+  ensureCustomFields,
+  ensureEntityDefinitions,
+  linkDisplayFields,
+  linkNewRelationships,
+  loadExistingState,
+} from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:149')
+
+/** What {@link ensureCustomFields} returns, keyed `<entityType>:<field id>`. */
+type EnsuredFieldMap = Awaited<ReturnType<typeof ensureCustomFields>>
+
+/** The two defs this migration creates. Both hidden, both with no route folder. */
+const NEW_ENTITY_TYPES = ['shipment', 'parcel'] as const
+
+/** The registry field map for each new def. */
+const NEW_DEF_FIELDS: Record<string, Record<string, ResourceField>> = {
+  shipment: SHIPMENT_FIELDS,
+  parcel: PARCEL_FIELDS,
+}
+
+/**
+ * Every relationship half this migration must LINK, paired with the inverse it
+ * points at.
+ *
+ * Checked explicitly after {@link linkNewRelationships} rather than trusted,
+ * because that helper only logs a DEBUG line when it cannot resolve an inverse.
+ * Entity migration 135 is why, and 136 restates it: an UNLINKED relationship is
+ * worse than a missing one. The field exists so writes are accepted, but with no
+ * inverse the other side reads empty and every consumer silently sees nothing.
+ *
+ * Both halves of each pair are listed. `shipment_parcels` is the edge the delete
+ * engine acts on, so an unlinked `parcel.shipment` would also mean a deleted
+ * shipment leaves its parcels behind.
+ */
+const RELATIONSHIP_PAIRS: readonly { owning: string; inverse: string }[] = [
+  { owning: `parcel:${PARCEL_FIELDS.shipment?.id}`, inverse: 'shipment:parcels' },
+  { owning: `shipment:${SHIPMENT_FIELDS.parcels?.id}`, inverse: 'parcel:shipment' },
+  { owning: `shipment:${SHIPMENT_FIELDS.order?.id}`, inverse: 'order:shipments' },
+  { owning: `order:${ORDER_FIELDS.shipments?.id}`, inverse: 'shipment:order' },
+]
+
+/**
+ * A new def and a new field are invisible to every read path that serves them
+ * until the org's caches are dropped. `runEntityMigrationsForOrg` does this after
+ * the whole batch, but `up()` can also be called directly.
+ */
+const CACHE_KEYS = ['entityDefs', 'entityDefSlugs', 'customFields', 'resources'] as const
+
+/**
+ * Migration 149: the `shipment` and `parcel` defs, their fields, and the
+ * `order_shipments` inverse
+ * (`plans/apps/shipstation/shared-shipment-entities-proposal.md` §7).
+ *
+ * ## Why this migration is the whole point
+ *
+ * `ensureEntityDefinitions` is a plain insert that skips any org already holding
+ * the def, so `SYSTEM_ENTITIES` and `FIELD_REGISTRY` alone reach FRESH orgs and
+ * nothing else. This is what reaches the ones that already exist, and the SDK's
+ * `EntityRefKind` union depends on it: its standing condition is that every kind
+ * in it be seeded into EXISTING orgs by a migration, because `provisionAppField`
+ * warns-and-skips when `getCachedEntityDefId` returns nothing, and an app author
+ * who declares a field against an unseeded kind sees no error and gets nothing.
+ *
+ * Registered in `entity-migrations/index.ts`, which is also what puts it in the
+ * shared `ALL_DATA_MIGRATIONS` registry: `buildRegistry` spreads
+ * `ALL_ENTITY_MIGRATIONS.map(wrapEntityMigration)`, so a hand-written entry
+ * there would be a duplicate id that `assertUniqueMigrationIds` throws on at
+ * module load.
+ *
+ * ## What it adds
+ *
+ * - **`shipment`** - one dispatch of goods: number, carrier, service, ship date,
+ *   parcel count, its parcels, and the order it belongs to.
+ * - **`parcel`** - one physical box with one tracking number: sequence, master
+ *   flag, weight, dimensions, void state, and the carrier status fields.
+ * - **`order_shipments`** - the has_many inverse of `shipment_order`, on a def
+ *   that already exists.
+ *
+ * ## Why native rather than app-owned (proposal §2)
+ *
+ * Three apps know different things about the same object: ShipStation knows what
+ * was dispatched, FedEx and UPS know where each parcel is, Shopify knows which
+ * order it belongs to. `apps/fedex/.../shipment-schema.ts` and its UPS twin
+ * already declare a byte-for-byte identical parcel shape, and ShipStation would
+ * be a third copy. App-owned entities would make that a third TABLE as well,
+ * with no way to join a ShipStation box to the FedEx status of that same box.
+ *
+ * ## Both defs are HIDDEN
+ *
+ * `isVisible: false` in `SYSTEM_ENTITIES`, which `ensureEntityDefinitions` reads
+ * from directly here rather than restating (the pattern in 146, so the two halves
+ * cannot disagree). That flag suppresses four gates: the Records sidebar group,
+ * the kbar create action, the kbar record-search scope and the AI entity catalog.
+ * It suppresses NOTHING on the server, and the list page is absent because no
+ * route folder was authored, not because anything declares it hidden. The
+ * custom-fields settings screen is a separate hard-coded list and both types are
+ * named there too.
+ *
+ * ## No writers
+ *
+ * This lands with nothing writing to either def. The ShipStation connector comes
+ * next, and the carrier apps after that. `parcel_status` simply stays null until
+ * FedEx or UPS has a connector, which is expected rather than a gap.
+ *
+ * ## Ordering
+ *
+ * MUST sort after 107, which creates `order`. An org short of it is a SKIP, not
+ * a failure: the seeder creates all of this with the rest of the registry.
+ *
+ * Idempotent: `ensureEntityDefinitions` and `ensureCustomFields` are INSERT-only
+ * and skip whatever the org already holds, and `linkNewRelationships` only writes
+ * an inverse that is currently unset.
+ */
+export const migration149ShipmentParcel: EntityMigration = {
+  id: '149-shipment-parcel',
+  description:
+    'Adds the hidden shipment and parcel defs with their fields and the order_shipments ' +
+    'inverse - one dispatch of goods and one physical box with one tracking number, native ' +
+    'rather than app-owned so ShipStation can contribute structure and the carrier apps can ' +
+    'contribute status to the same row (shared-shipment-entities-proposal.md)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    const existing = await loadExistingState(db, organizationId)
+
+    // Absent rather than failed: an org short of 107 has no `order`, and the
+    // seeder creates all of this with the rest of the registry.
+    const orderDef = existing.entityDefs.get('order')
+    if (!orderDef) {
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    const entityDefIds = await ensureEntityDefinitions(
+      db,
+      organizationId,
+      SYSTEM_ENTITIES.filter((e) => (NEW_ENTITY_TYPES as readonly string[]).includes(e.entityType)),
+      existing,
+      state
+    )
+    entityDefIds.set('order', orderDef.id)
+
+    // 🛑 ONE field map spanning both new defs AND the widened `order`.
+    // `linkNewRelationships` resolves an inverse out of this map by
+    // `<entityType>:<field id>`, so linking the halves of a pair in separate
+    // calls would leave each unable to see the other and skip the pair with
+    // nothing louder than a debug line (the 135 lesson, restated by 136).
+    const fieldMap: EnsuredFieldMap = new Map()
+
+    for (const entityType of NEW_ENTITY_TYPES) {
+      const defId = entityDefIds.get(entityType)
+      if (!defId) continue
+      const created = await ensureCustomFields(
+        db,
+        organizationId,
+        entityType,
+        defId,
+        NEW_DEF_FIELDS[entityType]!,
+        existing,
+        state
+      )
+      for (const [key, value] of created) fieldMap.set(key, value)
+    }
+
+    const orderShipments = ORDER_FIELDS.shipments
+    if (!orderShipments) {
+      throw new Error('order registry is missing the key "shipments" (migration 149)')
+    }
+    const widenedOrder = await ensureCustomFields(
+      db,
+      organizationId,
+      'order',
+      orderDef.id,
+      { shipments: orderShipments },
+      existing,
+      state
+    )
+    for (const [key, value] of widenedOrder) fieldMap.set(key, value)
+
+    await linkNewRelationships(db, fieldMap, entityDefIds, state)
+    await assertInversesLinked(db, fieldMap)
+
+    await linkDisplayFields(db, [...NEW_ENTITY_TYPES], entityDefIds, fieldMap)
+
+    const changed =
+      state.entityDefsCreated > 0 || state.fieldsCreated > 0 || state.relationshipsLinked > 0
+
+    if (changed) {
+      await getOrgCache().invalidateAndRecompute(organizationId, [...CACHE_KEYS])
+      logger.info('Migration 149 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}
+
+/**
+ * Fail loudly when a relationship half was created but never linked.
+ *
+ * `linkNewRelationships` skips an unresolvable inverse with a debug line, which
+ * on this migration would mean a `shipment` that accepts parcel writes nobody can
+ * read back, and a delete engine that cannot see the `cascade` edge it is meant
+ * to act on.
+ */
+async function assertInversesLinked(
+  db: Database,
+  fieldMap: Map<string, { id: string }>
+): Promise<void> {
+  for (const { owning, inverse } of RELATIONSHIP_PAIRS) {
+    const field = fieldMap.get(owning)
+    if (!field) {
+      throw new Error(`migration 149 could not resolve the field ${owning}`)
+    }
+    const row = await db.query.CustomField.findFirst({
+      where: eq(schema.CustomField.id, field.id),
+      columns: { options: true },
+    })
+    const inverseId = (row?.options as { relationship?: { inverseResourceFieldId?: string } })
+      ?.relationship?.inverseResourceFieldId
+    if (!inverseId) {
+      throw new Error(
+        `migration 149 created ${owning} but could not link it to ${inverse} - the inverse half ` +
+          'is missing, and an unlinked relationship writes rows the other side cannot see'
+      )
+    }
+  }
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -457,6 +457,52 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     isVisible: false,
   },
   {
+    // One dispatch of goods, and one physical box within it
+    // (`plans/apps/shipstation/shared-shipment-entities-proposal.md` §6).
+    // Entity migration 149.
+    //
+    // NATIVE rather than app-owned because three apps know different things
+    // about the same object: ShipStation knows what was dispatched, FedEx and
+    // UPS know where each parcel is, Shopify knows which order it belongs to
+    // (§2). App-owned entities would make that three tables with no way to join
+    // a ShipStation box to the FedEx status of that same box.
+    //
+    // `isVisible: false` AND no route folder under `app/shipments/`. Hiding is
+    // the sum of six independent mechanisms (§3) and this flag covers four of
+    // them: the sidebar group, the kbar create action, the kbar record-search
+    // scope and the AI entity catalog. It suppresses NOTHING on the server, and
+    // the list page is absent by omission rather than by declaration.
+    //
+    // 🛑 This line reaches FRESH orgs only. `ensureEntityDefinitions` is a plain
+    // insert that skips an org already holding the def, so `isVisible` is only
+    // ever evaluated when the row is CREATED. Existing orgs are reached by
+    // migration 149, which is DELIBERATELY NOT REGISTERED yet.
+    entityType: 'shipment',
+    apiSlug: 'shipments',
+    singular: 'Shipment',
+    plural: 'Shipments',
+    icon: 'truck',
+    color: 'amber',
+    isVisible: false,
+  },
+  {
+    // One physical box with one tracking number: the grain a support agent
+    // actually asks about, and the thing no single app owns today. Shopify has
+    // no parcel concept at all (`Fulfillment.trackingInfo` is a bare list of
+    // numbers with no per-box identity, sequence, weight or status), which is
+    // the gap this fills and why it earns its own def rather than a JSON blob
+    // on the shipment.
+    //
+    // Same hiding treatment as `shipment` above, and same insert-only caveat.
+    entityType: 'parcel',
+    apiSlug: 'parcels',
+    singular: 'Parcel',
+    plural: 'Parcels',
+    icon: 'box',
+    color: 'orange',
+    isVisible: false,
+  },
+  {
     // Suggest-from-history is the PRIMARY categorisation mechanism (bank plan
     // 03 §4 - Stripe FC has no merchant enrichment and no categories); a
     // bank_rule is the opt-in, ordered layer on top of it. Entity migration
@@ -789,6 +835,33 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
   payment_gateway: {
     primaryDisplayField: 'name',
     secondaryDisplayField: 'settlementSource',
+  },
+  // The MASTER TRACKING NUMBER, not `shipment_number`.
+  //
+  // `shipment_number` is the obvious choice and was the first one, but it is
+  // wrong twice over. ShipStation documents it as "optional, mutable, and does
+  // not require uniqueness", so it is not a thing to require; and it is not
+  // carried on the label payload at all - it lives on the shipment resource -
+  // so the label stream left it empty on 135 of 135 shipments and every one
+  // rendered nameless.
+  //
+  // The master tracking number filled on 135 of 135 in the same sync, and it is
+  // what a support agent actually arrives holding. It is denormalized onto the
+  // shipment precisely so it can be this: `computeDisplayValue` reads a field on
+  // the row, and a tracking number otherwise lives only on a `parcel`.
+  //
+  // `status` stays the secondary because it is always present. `number` becomes
+  // the better secondary once a shipments stream sources it.
+  shipment: {
+    primaryDisplayField: 'masterTrackingNumber',
+    secondaryDisplayField: 'status',
+  },
+  // The tracking number IS the parcel's public identity and the cross-app match
+  // key, and it is `nullable: false` for the same display reason. `status` stays
+  // null until FedEx or UPS gets a connector, so it is only ever the secondary.
+  parcel: {
+    primaryDisplayField: 'trackingNumber',
+    secondaryDisplayField: 'status',
   },
   bank_account: {
     primaryDisplayField: 'name',

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -24,6 +24,7 @@ import { JOURNAL_ENTRY_FIELDS } from '../../resources/registry/resources/journal
 import { LINE_ITEM_FIELDS } from '../../resources/registry/resources/line-item-fields'
 import { MEETING_FIELDS } from '../../resources/registry/resources/meeting-fields'
 import { ORDER_FIELDS } from '../../resources/registry/resources/order-fields'
+import { PARCEL_FIELDS } from '../../resources/registry/resources/parcel-fields'
 import { PART_FIELDS } from '../../resources/registry/resources/part-fields'
 import { PAYMENT_FIELDS } from '../../resources/registry/resources/payment-fields'
 import { PAYMENT_GATEWAY_FIELDS } from '../../resources/registry/resources/payment-gateway-fields'
@@ -34,6 +35,7 @@ import { PURCHASE_ORDER_FIELDS } from '../../resources/registry/resources/purcha
 import { PURCHASE_ORDER_LINE_FIELDS } from '../../resources/registry/resources/purchase-order-line-fields'
 import { QUOTE_FIELDS } from '../../resources/registry/resources/quote-fields'
 import { SERVICE_REQUEST_FIELDS } from '../../resources/registry/resources/service-request-fields'
+import { SHIPMENT_FIELDS } from '../../resources/registry/resources/shipment-fields'
 import { SIGNATURE_FIELDS } from '../../resources/registry/resources/signature-fields'
 import { STOCK_MOVEMENT_FIELDS } from '../../resources/registry/resources/stock-movement-fields'
 import { SUBPART_FIELDS } from '../../resources/registry/resources/subpart-fields'
@@ -109,6 +111,12 @@ export const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   credit_memo_line: CREDIT_MEMO_LINE_FIELDS,
   credit_memo_application: CREDIT_MEMO_APPLICATION_FIELDS,
   tax_line: TAX_LINE_FIELDS,
+  // Both halves of shared-shipment-entities-proposal.md. A type present in
+  // SYSTEM_ENTITIES but missing HERE lands on a new org as a definition with
+  // ZERO fields, and a create through UnifiedCrudHandler then drops every value
+  // with only a logged warning. `bank_rule` shipped that way and nothing failed.
+  shipment: SHIPMENT_FIELDS,
+  parcel: PARCEL_FIELDS,
 }
 
 /**

--- a/packages/lib/src/write-policy/types.ts
+++ b/packages/lib/src/write-policy/types.ts
@@ -45,8 +45,18 @@ export type FieldMergeStrategy =
  *
  * - `externalId`, this field is (part of) the upstream stable id used for
  *   re-identification. `order` sequences a first-non-null fallback CHAIN.
- * - `match`, a match key. More than one column carrying `match` **is** the
- *   composite key, with no new concepts: the candidates are ANDed.
+ * - `match`, a match key. 🛑 More than one column carrying `match` is NOT a
+ *   composite key: the candidates are **OR'd**, so each one is another
+ *   independent chance to merge and every extra key WIDENS the match. An
+ *   earlier version of this comment claimed they were ANDed and was wrong;
+ *   `lookupEntitiesByFieldValue` ANDs only under its opt-in `matchAll` flag
+ *   ("Default `false` (OR / first-wins, today's behaviour)"), and neither the
+ *   importer nor `UnifiedCrudHandler.lookupByField` - the path the connector
+ *   sink takes - ever passes it. The true composite key, `(part, supplier)`,
+ *   is exactly what `matchAll` was added for and is unavailable to a
+ *   connector. Ambiguity is not an error here either: `lookupByField` passes
+ *   `onAmbiguous: 'first'`, takes the first hit and files a
+ *   `DuplicateSuggestion`.
  *   `exclusive` says two source records of one mapping hitting the same
  *   record are a collision of different things (two Shopify variants sharing
  *   a SKU), so the second is skipped and never bound. Absent, they are the

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -142,7 +142,29 @@ interface ConnectorContributingFieldBase extends ConnectorContributingFieldCommo
    * Secondary identity-match key (today's `matchFieldKeys`) — merges an
    * incoming record into an existing entity on first link. The external id
    * (from `appField`, when that field is `identity: true`) is always the
-   * primary key; more than one `match: true` field is an ANDed composite key.
+   * primary key.
+   *
+   * 🛑 **Candidates are OR'd, not ANDed, so each extra `match: true` field
+   * WIDENS the match.** The intuition most authors bring to this is backwards.
+   * A connector's lookup runs `lookupByField`, which never passes the opt-in
+   * `matchAll` flag, so the first candidate that hits wins. Worked example,
+   * Shopify's contact mapping with `primary_email` and `phone` both
+   * `match: true`, against an existing contact `jane@example.com` /
+   * `+19998888` receiving `jane@example.com` / `+15550001`: the email hits, so
+   * the record merges into the existing Jane. It does NOT create a second Jane
+   * because the phone disagrees. Declare a second match key only when you want
+   * another independent chance to merge.
+   *
+   * The corollary is that **a composite key is unavailable to a connector.**
+   * Guarding a match on an id that a provider reuses (a carrier tracking
+   * number, say) with a second field such as a date is not possible: adding
+   * that candidate only widens the match. If a value is not unique enough to
+   * carry a match on its own, do not declare `match` on it at all.
+   *
+   * Ambiguity is not an error on this path: the lookup runs under
+   * `onAmbiguous: 'first'`, because a sync must not fail on data the user can
+   * only fix by merging. Two matches take the first and file a
+   * `DuplicateSuggestion`.
    *
    * `'exclusive'` is a match key whose hits are different things colliding, not
    * one thing seen twice: when a second source record of this mapping resolves
@@ -260,6 +282,19 @@ interface ConnectorMappingBase {
    * `'system:<systemAttribute>'` value names a pre-existing SYSTEM
    * relationship field on a contributing parent def; nothing is provisioned
    * for it.
+   *
+   * ⚠️ **A `system:` key that does not resolve is dropped, not rejected.**
+   * `resolveRelationshipFieldKeyFromFields` looks the `systemAttribute` up on
+   * the PARENT def's fields at install time; a typo, or a parent that is owned
+   * rather than contributing, logs a warning and returns null. The mapping
+   * still lands and still writes its fields, edge-less, so the child records
+   * appear with nothing linking them to their parent and no error anywhere the
+   * author will see. Check the attribute against the parent's registry field
+   * file before shipping.
+   *
+   * Note the direction: the key resolves against the PARENT, so a parcel hung
+   * off a shipment is `'system:shipment_parcels'` (the has_many on the parent),
+   * never `'system:parcel_shipment'` (the belongs_to on the child).
    */
   readonly relationshipFieldKey?: string
   /**

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -134,6 +134,21 @@ export interface ToolActionContext {
  * condition: 136 seeds all four into EXISTING orgs, so these are not union
  * entries that no org resolves. `refund` / `refund_line` were the earlier
  * names of the first two and were renamed before the SDK ever published them.
+ *
+ * `shipment` and `parcel` were ADDED 2026-09-10
+ * (plans/apps/shipstation/shared-shipment-entities-proposal.md §6, §7). They
+ * follow `line_item` / `tax_line` / `credit_memo_line`'s precedent exactly:
+ * both are `isVisible: false` and they are admitted here PRECISELY so a
+ * connector can address them. That is the whole point (proposal §2) -
+ * ShipStation contributes structure (which boxes belong together, weights,
+ * dimensions, void state), FedEx and UPS contribute carrier status onto the
+ * same parcel row, and no single app owns a parcel.
+ *
+ * They satisfy the standing condition above: entity migration
+ * `149-shipment-parcel` seeds both defs, their fields and the `order_shipments`
+ * inverse into EXISTING orgs, so these are not union entries that no org
+ * resolves. Nothing WRITES to either yet - the ShipStation connector comes
+ * next - but the defs resolve, which is what `provisionAppField` needs.
  */
 export type EntityRefKind =
   | 'contact'
@@ -155,6 +170,8 @@ export type EntityRefKind =
   | 'credit_memo_line'
   | 'credit_memo_application'
   | 'tax_line'
+  | 'shipment'
+  | 'parcel'
 
 /**
  * Per-tool configuration. See plans/kopilot/apps/README.md §4.2.

--- a/packages/types/resource/utils.ts
+++ b/packages/types/resource/utils.ts
@@ -181,6 +181,11 @@ export const ENTITY_DEFINITION_TYPES = [
   // A record carrying its clearing account, never a role
   // (plans/accounting/tasks/13-cash-accounts-and-the-qbo-seam.md §5.3).
   'payment_gateway',
+  // plans/apps/shipstation/shared-shipment-entities-proposal.md §6. Both are
+  // EntityInstance-backed, so a `shipment:<id>` / `parcel:<id>` relationship
+  // RecordId canonicalizes to the org's def CUID like every other entry here.
+  'shipment',
+  'parcel',
 ] as const
 
 /** Type for system entity types stored in EntityDefinition */

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -489,6 +489,10 @@ export const SYSTEM_ATTRIBUTES = [
   // nothing links to it, and the accounting copy is already normalised in
   // `GlPostingLine`.
   'order_fulfillments',
+  // Added by entity migration 149. Inverse of `shipment_order`
+  // (plans/apps/shipstation/shared-shipment-entities-proposal.md §6). One
+  // order, many shipments: `Fulfillment.order` is singular and non-null.
+  'order_shipments',
 
   // ─── Tax line (plans/money/tasks/48-shopify-tax-data.md §4.1) ────
   // One jurisdiction's share of one order's tax, as the sales channel computed
@@ -1072,6 +1076,56 @@ export const SYSTEM_ATTRIBUTES = [
   // `SystemAttribute` values.
   'signature_name',
   'signature_body',
+
+  // ─── Shipment and parcel ───────────────────────────────
+  // Native, app-agnostic, both hidden (`isVisible: false`). Entity migration
+  // 149 (plans/apps/shipstation/shared-shipment-entities-proposal.md §6).
+  // A `shipment` is one dispatch of goods; a `parcel` is one physical box with
+  // one tracking number, which is the grain the customer actually asks about.
+  // There is deliberately no `label` entity: a void and reprint is lifecycle on
+  // the parcel, not a record of its own.
+  'shipment_number',
+  // The active label's master parcel tracking number, denormalized onto the
+  // shipment: `computeDisplayValue` reads a field on the ROW, and a tracking
+  // number otherwise lives only on a `parcel`.
+  'shipment_master_tracking_number',
+  // DERIVED roll-up over the shipment's active (non-voided) parcels, computed
+  // by the connector and never hand-set. See `ShipmentStatus` for the
+  // precedence order.
+  'shipment_status',
+  'shipment_carrier', // fedex | ups | usps
+  'shipment_service', // the carrier's own service name, as supplied
+  'shipment_ship_date',
+  'shipment_parcel_count',
+  'shipment_parcels', // inverse of parcel_shipment, has_many, onDelete cascade
+  'shipment_order', // inverse of order_shipments
+
+  // Parcel. `parcel_tracking_number` is the cross-app match key: the carrier
+  // apps find the box by it, so it is treated as unique (§8b).
+  'parcel_tracking_number',
+  'parcel_sequence', // box N of M, as the label prints it
+  'parcel_is_master', // the master tracking number of a multi-box label
+  // ShipStation reports weight in OUNCES (one 3-box label returned 1280,
+  // 464 and 704) and dimensions in INCHES, so neither unit field is decorative.
+  'parcel_weight',
+  'parcel_weight_unit',
+  'parcel_length',
+  'parcel_width',
+  'parcel_height',
+  'parcel_dim_unit',
+  // The label lifecycle, kept OUT of `parcel_status` on purpose: that is what
+  // lets one shared status vocabulary describe both grains.
+  'parcel_voided',
+  'parcel_voided_at',
+  // Carrier-app owned from here down. `parcel_status` is the normalized
+  // `ParcelTrackingStatus`; the raw pair beside it is what the carrier said.
+  'parcel_status',
+  'parcel_status_code',
+  'parcel_status_description',
+  'parcel_estimated_delivery',
+  'parcel_delivered_at',
+  'parcel_received_by', // signature name, when the carrier reports one
+  'parcel_shipment', // inverse of shipment_parcels
 ] as const
 
 /** Union type of all valid system attribute identifiers */


### PR DESCRIPTION
Implements `plans/apps/shipstation/shared-shipment-entities-proposal.md`.

Two native entity kinds, `shipment` and `parcel`, hidden from the UI, that several apps write into. A parcel is one physical box with one tracking number, which is the fact a support agent needs and no single app owns today.

## Why native rather than app-owned

Three apps know different things about the same object: ShipStation knows what was dispatched, FedEx and UPS know where each parcel is, Shopify knows which order it belongs to.

The normalized carrier status enum is **already duplicated byte-for-byte** between `apps/fedex` and `apps/ups`, and ShipStation would have been a third copy. App-owned entities would have made that a third *table* as well, with no way to join a ShipStation box to the FedEx status of that same box.

## What lands

- `shipment` and `parcel` field maps, both `isVisible: false` with no route folder, plus the `order_shipments` inverse on `order`.
- `ParcelTrackingStatus` and `ShipmentStatus`, consolidating the FedEx/UPS duplication and adding three Shopify states, each of which drives a support action `exception` cannot express. `delayed` is the important one: both carriers collapse a weather delay into `exception`, so an agent escalates a shipment that needs nothing but a new ETA.
- Entity migration **149**, registered. It also reaches `ALL_DATA_MIGRATIONS` through `wrapEntityMigration`, so it needs no entry of its own there.
- Both kinds through the full checklist: `ModelTypeValues`, `ModelTypeMeta`, `ENTITY_DEFINITION_TYPES`, `SYSTEM_ATTRIBUTES`, both field registries, `SYSTEM_ENTITIES`, `DISPLAY_FIELD_CONFIG`, `HIDDEN_ENTITY_TYPES`, and the SDK's `EntityRefKind`.

## The ownership split is load-bearing

ShipStation owns structure, the carrier apps own status: disjoint field sets on one row, so no field ever has two `overwrite` writers and the mutual-drift ping-pong cannot start. Convergence goes through `parcel_tracking_number`, the only legal `match` target, and the carrier apps mint nothing, so `effectiveOrphanBehavior` protects ShipStation's rows from their reconciliation.

`onDelete` answers sit on the has_many sides only: `shipment_parcels` cascades (a parcel is an owned child), `order_shipments` unlinks (a shipment is a dispatch ShipStation minted and still owns).

## Two docblocks corrected

`IdentityRole` and the SDK's `match` both claimed multiple match candidates form an **ANDed** composite key. They are **OR'd**: `lookupByField` never passes the opt-in `matchAll` flag, so every extra match key *widens* the match and a composite key is unavailable to a connector. That is the exact trap this design had to avoid on a reused tracking number. `docs/app-fields-and-entities-guide.md` gets the same correction plus a current `EntityRefKind` list (it was six kinds stale).

## Two UI fixes found by driving a real sync

- Connector config fields now render a date picker when the JSON Schema says `format: date-time`. Previously every non-boolean, non-number config field fell through to `TEXT`, so **no app could ever get one**.
- `FieldNode` keeps the `format` it was silently dropping at the type level.

## Verification

Against a live ShipStation account: **135 shipments, 482 parcels**, every parcel linked to its shipment in both directions (482 edges each way, 0 pending), tracking numbers all distinct, voided labels carried with their void state, 0 failures and 0 rate-limit waits.

Migration 149 applied to all 28 local orgs: both defs hidden, display fields linked, `onDelete` stamped on the has_many sides only.

Tests: 33 in `149-shipment-parcel.test.ts`, plus the registry's `relationship-on-delete` coverage test which picks up all three new edges with no manual edit. Typecheck adds no new errors in `lib` or `web`.

## Note for reviewers

`packages/lib/scripts/probe-shipstation-packages.ts` is deliberately **not** in this PR. It predates this work, is untracked, and carries three type errors that would trip the ratchet.

https://claude.ai/code/session_018YePsd1TQMixvCPKbMLfgh