### PR TITLE
fix(accounting): stop asking a standalone org for QuickBooks figures

### DIFF
--- a/apps/web/src/components/accounting/hooks/use-journal-entry-draft.ts
+++ b/apps/web/src/components/accounting/hooks/use-journal-entry-draft.ts
@@ -19,6 +19,7 @@ const POSTED_STATUSES = new Set<PostResultStatus>([
   'healed',
   'not_connected',
   'disabled',
+  'not_exported',
 ])
 
 export interface UseJournalEntryDraftOptions {

--- a/apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
+++ b/apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
@@ -10,11 +10,15 @@ import { api } from '~/trpc/react'
 /**
  * The statuses that mean a `GlPosting` row now exists for the month.
  *
- * 🛑 Five of them, not one. `not_connected` and `disabled` are first-class
- * successes under decision `P1` - the entry is built, balanced and persisted
- * identically, there is simply nowhere to push it - and `already_posted` and
- * `healed` are converged re-runs. Treating any of the five as a failure is the
- * single most common way this screen could be got wrong.
+ * 🛑 Six of them, not one. `not_connected`, `disabled` and `not_exported` are
+ * first-class successes under decision `P1` - the entry is built, balanced and
+ * persisted identically, there is simply nowhere to push it - and
+ * `already_posted` and `healed` are converged re-runs. Treating any of the six
+ * as a failure is the single most common way this screen could be got wrong.
+ *
+ * `not_exported` is the newest and the narrowest: the posting TYPE routes to
+ * `'none'`, so it never pushes whatever the org has connected. It reaches this
+ * screen through a reversal, which inherits its original's posting type.
  *
  * Everything else (`period_closed`, `account_unmapped`, `unbalanced`,
  * `nothing_to_close`, `setup_incomplete`, `error`) wrote nothing, and all six
@@ -26,6 +30,7 @@ const POSTED_STATUSES = new Set<PostResultStatus>([
   'healed',
   'not_connected',
   'disabled',
+  'not_exported',
 ])
 
 interface UseLedgerEntryActionsOptions {

--- a/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
@@ -29,7 +29,17 @@ import { JournalEntryAttachment } from './journal-entry-attachment'
 import { JournalLines, JournalLinesTotals } from './journal-lines'
 import { firstDayOfPeriod, nextOpenPeriodAfter, periodKeyForEntryDate } from './period-helpers'
 
-const POSTED_STATUSES = new Set(['posted', 'already_posted', 'healed', 'not_connected', 'disabled'])
+// `not_exported` is here for the opening entry and its reversal: both are
+// `journal_entry` records whose posting type routes to `'none'`, so they never
+// push and always land on it. The set means "a GlPosting row now exists".
+const POSTED_STATUSES = new Set([
+  'posted',
+  'already_posted',
+  'healed',
+  'not_connected',
+  'disabled',
+  'not_exported',
+])
 
 interface JournalEntryDrawerProps {
   /** The record id, or `null` while `isNew` and the empty draft has not landed yet. */

--- a/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
@@ -86,6 +86,19 @@ const OUTCOMES: Record<PostResultStatus, OutcomeCopy> = {
       'The entry is built, balanced and recorded here exactly as it would be with a provider. There is simply nowhere to push it.',
     tone: 'success',
   },
+  // 🛑 NOT `not_connected`, and the difference is the whole point of the value.
+  // This entry's posting type is never exported - an opening balance or an
+  // entry read back off the provider's own ledger - so the org's connection is
+  // irrelevant and may well be healthy. Saying "no accounting system is
+  // connected" here sent a reader to debug a working QuickBooks link on
+  // DemoOrg1's first wizard drive. Brief 22 §5.
+  not_exported: {
+    icon: CheckCircle2,
+    title: 'Posted. This entry is not exported',
+    detail:
+      'An opening balance and an entry synced from your accounting system are both kept here only. Pushing either back would hand the provider a second copy of a figure it already has.',
+    tone: 'success',
+  },
   not_enabled: {
     icon: PlugZap,
     title: 'Nothing posted. Accounting is not enabled for this organization',

--- a/apps/web/src/components/accounting/ui/ledger/posting-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/posting-drawer.tsx
@@ -2,7 +2,8 @@
 
 'use client'
 
-import type { PostingDetail, PostResult } from '@auxx/lib/postings/client'
+import type { PostingDetail, PostingType, PostResult } from '@auxx/lib/postings/client'
+import { EXPORT_ROUTE_BY_POSTING_TYPE } from '@auxx/lib/postings/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
@@ -244,9 +245,15 @@ const STATUS_LABEL: Record<PostingDetail['status'], string> = {
  * produced it: `posted`, `already_posted` and `healed` all leave the same row
  * behind, so this reports `posted` for all three. It never invents a failure -
  * `failureReason` is rendered verbatim when the row actually failed - and it
- * keeps `not_connected` and `disabled` apart, which is the distinction decision
- * `P1` cares about: one is a missing integration, the other is a setting
- * somebody can flip, and merging them makes the remedy unguessable.
+ * keeps `not_connected`, `disabled` and `not_exported` apart, which is the
+ * distinction decision `P1` cares about: a missing integration, a setting
+ * somebody can flip, and a posting type that is never exported at all have
+ * three different remedies, and merging them makes the remedy unguessable.
+ *
+ * 🛑 `not_exported` is checked FIRST among the three, because a `'none'`-routed
+ * row is indistinguishable from a disconnected org by `providerId` alone: both
+ * store `'none'`. Only the posting type separates them, which is why this reads
+ * the route table rather than guessing from the row (brief 22 §5).
  *
  * 🛑 Reads `exportStatus`, NOT `status`. It used to branch on
  * `status === 'failed'`, which is now unreachable - `status` says what the
@@ -257,6 +264,7 @@ const STATUS_LABEL: Record<PostingDetail['status'], string> = {
 function providerResultFromDetail(detail: {
   exportStatus: string
   docNumber: string
+  postingType: string
   providerId: string | null
   providerEntryId: string | null
   failureReason: string | null
@@ -269,6 +277,9 @@ function providerResultFromDetail(detail: {
   }
   if (detail.providerEntryId) {
     return { ...base, status: 'posted', providerEntryId: detail.providerEntryId }
+  }
+  if (EXPORT_ROUTE_BY_POSTING_TYPE[detail.postingType as PostingType] === 'none') {
+    return { ...base, status: 'not_exported' }
   }
   if (detail.exportStatus === 'not_required' && (!providerId || providerId === 'none')) {
     return { ...base, status: 'not_connected' }

--- a/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/general-settings-page.tsx
@@ -39,6 +39,7 @@ import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
 import {
   FREEZE_REASON,
   useAccountingSettingsFreeze,
@@ -128,9 +129,17 @@ export function AccountingGeneralSettingsPage() {
   const { frozen } = useAccountingSettingsFreeze()
 
   // The shared predicate, over the settings record. No query.
+  //
+  // ⚠️ This is the SECOND Finalize door (see `wizard-done-page`), so it has to
+  // answer `providerConnected` the same way the wizard does or the two doors
+  // disagree about the same org. A load reads as connected for the reason given
+  // there: erring toward one requirement briefly unmet beats enabling Finalize
+  // against a baseline nobody reconciled (brief 22 §2.5).
+  const providerStatus = useAccountingProviderStatus()
+  const providerConnected = providerStatus.loading || providerStatus.connected
   const readiness = useMemo(
-    () => resolveSetupReadiness(buildReadinessRecord(getSetting)),
-    [getSetting]
+    () => resolveSetupReadiness(buildReadinessRecord(getSetting), { providerConnected }),
+    [getSetting, providerConnected]
   )
 
   // ── Section 1: accounting period ─────────────────────────────────────────

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-done-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-done-page.tsx
@@ -15,6 +15,7 @@ import {
   useDehydratedStateContext,
 } from '~/providers/dehydrated-state-provider'
 import { api } from '~/trpc/react'
+import { useAccountingProviderStatus } from '../../hooks/use-accounting-provider-status'
 import { EntryBlockers, type LedgerBlocker } from '../ledger/entry-blockers'
 import { EntryJournal } from '../ledger/entry-journal'
 
@@ -66,6 +67,7 @@ export function WizardDonePage({ onFinish }: WizardDonePageProps) {
   // ordering to be had from a fire-and-forget call. The local settings store is
   // patched by hand afterwards, which is exactly what `useSettings` does.
   const finalizeSettings = api.setting.batchUpdateOrganizationSettings.useMutation()
+  const providerStatus = useAccountingProviderStatus()
   const opening = api.ledgerOpening.get.useQuery()
   const preview = api.ledgerOpening.preview.useMutation()
   const post = api.ledgerOpening.post.useMutation()
@@ -78,10 +80,19 @@ export function WizardDonePage({ onFinish }: WizardDonePageProps) {
   // The trial balance is the one requirement that is not a setting, so it is
   // passed in. An absent summary reads as met - see `SetupReadinessContext` -
   // which is why the query's own loading state is not a blocker here.
-  const readiness = resolveSetupReadiness(
-    record,
-    opening.data ? { openingTrialBalance: opening.data.summary } : {}
-  )
+  //
+  // ⚠️ `providerConnected` takes the opposite treatment while loading, and the
+  // asymmetry is the point. `useAccountingProviderStatus` reports
+  // `connected: false` for a beat after `installed` turns true, so passing it
+  // raw would drop the provider snapshot from the requirements and ENABLE
+  // Finalize on a connected org for that beat. Reading a load as connected
+  // errs toward one extra requirement briefly showing unmet, which resolves
+  // itself; the other direction posts an opening entry against a baseline
+  // nobody reconciled (brief 22 §2.5).
+  const readiness = resolveSetupReadiness(record, {
+    ...(opening.data ? { openingTrialBalance: opening.data.summary } : {}),
+    providerConnected: providerStatus.loading || providerStatus.connected,
+  })
   const unmet = readiness.requirements.filter((requirement) => !requirement.met)
 
   // Preview once the query has an entry, so the journal below shows the lines

--- a/packages/lib/scripts/reset-bank-and-journals.ts
+++ b/packages/lib/scripts/reset-bank-and-journals.ts
@@ -1,0 +1,228 @@
+// packages/lib/scripts/reset-bank-and-journals.ts
+//
+// Delete an org's bank transactions and journal entries, and NOTHING else.
+//
+//     npx dotenv -- node --conditions source --import tsx/esm \
+//       packages/lib/scripts/reset-bank-and-journals.ts DemoOrg1 --confirm
+//
+// Read-only without `--confirm`.
+//
+// ── Why this exists next to reset-org-books.ts ──────────────────────────────
+//
+// `reset-org-books.ts` is all-or-nothing: its `DELETE_WAVES` take orders, line
+// items, credit memos and parts' connector bindings with them. That is right
+// for a full re-drive and wrong when the demo data is the point and only the
+// ledger inputs need clearing. This is the narrow version: two entity types,
+// their connector bindings, and the streams that produced them.
+//
+// ── It uses the same low-level delete, and bypasses the same guards ─────────
+//
+// `deleteEntityInstances` sweeps `FieldValue` on BOTH ends of every relation
+// plus the record's `TimelineEvent` rows, and `RecordIdentity` cascades behind
+// it. The guard chain lives one layer up in `bulkDeleteEntities` and would
+// refuse a posted journal entry on purpose — correct in the product, wrong in
+// a dev reset, which is why this is a script.
+//
+// ── The bindings go with the records, deliberately ─────────────────────────
+//
+// `DataConnectorItem`'s instance pointers are ON DELETE **SET NULL**, not
+// cascade. Left alone, the binding outlives the record with a NULL instance
+// and its `contentHash` still matches, so the next sync counts the record
+// `skipped` and re-creates nothing. So the binding is deleted too and the
+// stream is put back to backfill, which is what makes these records able to
+// come back. The parts-SKU guard in `reset-org-books.ts` does not apply: the
+// part mapping is untouched here, and a bank transaction is matched on its own
+// external id, not a SKU.
+
+import { database as db, schema } from '@auxx/database'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { getOrgCache } from '../src/cache'
+import { onCacheEvent } from '../src/cache/invalidate'
+import { deleteEntityInstances } from '../src/entity-instances'
+
+/** The only types this script touches. Order matters: nothing here points at the other. */
+const TYPES = ['bank_transaction', 'journal_entry'] as const
+
+const args = process.argv.slice(2)
+const ORG_ARG = args.find((a) => !a.startsWith('--'))
+const CONFIRM = args.includes('--confirm')
+const KEEP_CONNECTOR_ITEMS = args.includes('--keep-connector-items')
+
+if (!ORG_ARG) {
+  console.error(
+    'usage: reset-bank-and-journals.ts <organizationId|name> [options]\n\n' +
+      '  options:\n' +
+      '    --keep-connector-items  leave DataConnectorItem + stream watermarks alone.\n' +
+      '                            🛑 Deleted records then do NOT come back on the\n' +
+      '                            next sync.\n' +
+      '    --confirm               actually write. Without it this is a dry run.\n'
+  )
+  process.exit(1)
+}
+
+async function resolveOrg(arg: string): Promise<{ id: string; name: string | null }> {
+  const [byId] = await db
+    .select({ id: schema.Organization.id, name: schema.Organization.name })
+    .from(schema.Organization)
+    .where(eq(schema.Organization.id, arg))
+    .limit(1)
+  if (byId) return byId
+
+  const [byName] = await db
+    .select({ id: schema.Organization.id, name: schema.Organization.name })
+    .from(schema.Organization)
+    .where(eq(schema.Organization.name, arg))
+    .limit(1)
+  if (byName) return byName
+
+  console.error(`no organization matched "${arg}"`)
+  process.exit(1)
+}
+
+async function main() {
+  const org = await resolveOrg(ORG_ARG!)
+
+  console.log(`organization ${org.name} (${org.id})`)
+  console.log(`scope        ${TYPES.join(' + ')}`)
+  console.log(`mode         ${CONFIRM ? 'DELETE' : 'dry run (pass --confirm to write)'}\n`)
+
+  const idsByType = new Map<string, string[]>()
+  for (const type of TYPES) {
+    const rows = await db
+      .select({ id: schema.EntityInstance.id })
+      .from(schema.EntityInstance)
+      .innerJoin(
+        schema.EntityDefinition,
+        eq(schema.EntityDefinition.id, schema.EntityInstance.entityDefinitionId)
+      )
+      .where(
+        and(
+          eq(schema.EntityDefinition.organizationId, org.id),
+          eq(schema.EntityDefinition.entityType, type)
+        )
+      )
+    idsByType.set(
+      type,
+      rows.map((r) => r.id)
+    )
+    console.log(`  ${type.padEnd(18)} ${rows.length}`)
+  }
+
+  const allIds = [...idsByType.values()].flat()
+  if (allIds.length === 0) {
+    console.log('\nnothing to delete.\n')
+    process.exit(0)
+  }
+
+  // A GlPosting against one of these is a posted entry. The product refuses to
+  // delete it; this script does not, but it must SAY so rather than surprise.
+  const [postings] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(schema.GlPosting)
+    .where(eq(schema.GlPosting.organizationId, org.id))
+  console.log(`\n  GlPosting on this org: ${postings?.n ?? 0}`)
+
+  const bindings = await db
+    .select({ id: schema.DataConnectorItem.id })
+    .from(schema.DataConnectorItem)
+    .where(
+      and(
+        eq(schema.DataConnectorItem.organizationId, org.id),
+        inArray(schema.DataConnectorItem.entityInstanceId, allIds)
+      )
+    )
+  console.log(`  connector bindings on these records: ${bindings.length}`)
+
+  const streamRows = bindings.length
+    ? await db
+        .selectDistinct({
+          id: schema.DataConnectorStream.id,
+          streamKey: schema.DataConnectorStream.streamKey,
+          state: schema.DataConnectorStream.state,
+          connectorName: schema.DataConnector.name,
+        })
+        .from(schema.DataConnectorItem)
+        // `DataConnectorItem` points at the CONNECTOR, not at the stream, so
+        // the stream is reached through the connector. Joining on a
+        // `dataConnectorStreamId` that does not exist is how the first run of
+        // this script reported zero streams while deleting 270 bindings.
+        .innerJoin(
+          schema.DataConnectorStream,
+          eq(schema.DataConnectorStream.dataConnectorId, schema.DataConnectorItem.dataConnectorId)
+        )
+        .innerJoin(
+          schema.DataConnector,
+          eq(schema.DataConnector.id, schema.DataConnectorStream.dataConnectorId)
+        )
+        .where(
+          and(
+            eq(schema.DataConnectorItem.organizationId, org.id),
+            inArray(schema.DataConnectorItem.entityInstanceId, allIds)
+          )
+        )
+    : []
+  for (const s of streamRows) {
+    console.log(`    stream ${s.connectorName} · ${s.streamKey ?? '(no key)'}`)
+  }
+
+  if (!CONFIRM) {
+    console.log('\ndry run — nothing was written. Re-run with --confirm.\n')
+    process.exit(0)
+  }
+
+  // No foreign key onto the instance, so it is cleared explicitly.
+  await db
+    .delete(schema.RecordRuleRun)
+    .where(
+      and(
+        eq(schema.RecordRuleRun.organizationId, org.id),
+        inArray(schema.RecordRuleRun.entityInstanceId, allIds)
+      )
+    )
+
+  if (!KEEP_CONNECTOR_ITEMS && bindings.length > 0) {
+    await db.delete(schema.DataConnectorItem).where(
+      inArray(
+        schema.DataConnectorItem.id,
+        bindings.map((b) => b.id)
+      )
+    )
+    console.log(`deleted ${bindings.length} connector binding(s)`)
+  } else if (KEEP_CONNECTOR_ITEMS) {
+    console.log('--keep-connector-items: bindings left alone.')
+    console.log('🛑 These records will NOT come back on the next sync.')
+  }
+
+  let deleted = 0
+  for (const type of TYPES) {
+    const ids = idsByType.get(type) ?? []
+    if (ids.length === 0) continue
+    const result = await deleteEntityInstances({ ids, organizationId: org.id })
+    if (result.isErr()) {
+      console.error(`\n🛑 failed on ${type}: ${result.error.message}`)
+      process.exit(1)
+    }
+    deleted += result.value.count
+    console.log(`deleted ${result.value.count} ${type} record(s)`)
+  }
+
+  // The records are gone; anything that cached a count or a list of them is
+  // now wrong. `resources` and `customFields` carry per-def counts.
+  await onCacheEvent('org.settings.changed', { orgId: org.id, broadcastUserKeys: true })
+  await getOrgCache().invalidateAndRecompute(org.id, ['resources', 'customFields', 'orgSettings'])
+  console.log('org cache invalidated')
+
+  console.log(`\ndone. ${deleted} record(s) deleted.`)
+  if (!KEEP_CONNECTOR_ITEMS && streamRows.length > 0) {
+    console.log(
+      `${streamRows.length} stream(s) still hold their watermark — re-run the connector's\n` +
+        'backfill if these records should come back.'
+    )
+  }
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/lib/scripts/reset-gl-chart.ts
+++ b/packages/lib/scripts/reset-gl-chart.ts
@@ -172,8 +172,39 @@ async function resetOrg(organizationId: string): Promise<OrgResult | null> {
   }
 }
 
+/**
+ * Optional organization filter (id or name). Without it this stays what it has
+ * always been: every org in the database. With it, one org - because a dev
+ * machine now holds charts belonging to more than one demo org, and wiping a
+ * neighbour's to reset your own is a surprise, not a reset.
+ */
+const ORG_ARG = process.argv.slice(2).find((a) => !a.startsWith('--'))
+
+async function selectOrgs(): Promise<{ id: string }[]> {
+  if (!ORG_ARG) {
+    return database.select({ id: schema.Organization.id }).from(schema.Organization)
+  }
+  const [byId] = await database
+    .select({ id: schema.Organization.id })
+    .from(schema.Organization)
+    .where(eq(schema.Organization.id, ORG_ARG))
+    .limit(1)
+  if (byId) return [byId]
+
+  const [byName] = await database
+    .select({ id: schema.Organization.id })
+    .from(schema.Organization)
+    .where(eq(schema.Organization.name, ORG_ARG))
+    .limit(1)
+  if (byName) return [byName]
+
+  console.error(`no organization matched "${ORG_ARG}"`)
+  process.exit(1)
+}
+
 async function main() {
-  const orgs = await database.select({ id: schema.Organization.id }).from(schema.Organization)
+  const orgs = await selectOrgs()
+  console.log(ORG_ARG ? `scope: ${ORG_ARG}` : 'scope: EVERY organization')
 
   let touched = 0
   let accountsRemoved = 0

--- a/packages/lib/src/getting-started/signals.ts
+++ b/packages/lib/src/getting-started/signals.ts
@@ -17,6 +17,7 @@ import {
   getCachedMembers,
   getOrgCache,
 } from '../cache'
+import { NONE_PROVIDER_ID, resolveAccountingProvider } from '../postings/provider'
 import { ENABLED_POSTING_TYPES, INVENTORY_ROLES_BY_POSTING_TYPE } from '../postings/regime'
 import { resolveSetupReadiness } from '../postings/setup-readiness'
 import type { ChecklistId, GoalKey } from './client'
@@ -175,10 +176,33 @@ async function hasScheduledVisit(ctx: GettingStartedContext): Promise<boolean> {
 // ⚠️ None of these gate Post. `previewMonthEnd`'s `blockedBy` does. A checklist
 // says "set up costing"; a refusal names the part with no standard cost.
 
+/**
+ * Is an accounting system connected?
+ *
+ * ⚠️ Resolved rather than defaulted. `SetupReadinessContext.providerConnected`
+ * treats absent as NOT connected, so passing nothing here would tell a
+ * QuickBooks-connected org that its provider snapshot is not required while the
+ * wizard - which does know - still demanded it. That is exactly the checklist /
+ * wizard disagreement the comment above says this module exists to prevent.
+ *
+ * Fails safe: `resolveAccountingProvider` answers `NONE_ACCOUNTING_PROVIDER`
+ * when no resolver is installed, when the org has connected nothing, and when
+ * it names a provider that is not registered.
+ */
+async function isAccountingProviderConnected(ctx: GettingStartedContext): Promise<boolean> {
+  const provider = await resolveAccountingProvider(ctx.organizationId)
+  return provider.id !== NONE_PROVIDER_ID
+}
+
 /** One settings-derived requirement from the shared predicate. */
 async function settingsRequirementMet(ctx: GettingStartedContext, key: string): Promise<boolean> {
-  const settings = await getOrgCache().get(ctx.organizationId, 'orgSettings')
-  const readiness = resolveSetupReadiness(settings as Record<string, unknown>)
+  const [settings, providerConnected] = await Promise.all([
+    getOrgCache().get(ctx.organizationId, 'orgSettings'),
+    isAccountingProviderConnected(ctx),
+  ])
+  const readiness = resolveSetupReadiness(settings as Record<string, unknown>, {
+    providerConnected,
+  })
   return readiness.requirements.find((r) => r.key === key)?.met ?? false
 }
 

--- a/packages/lib/src/postings/__tests__/post-entry-export-route.test.ts
+++ b/packages/lib/src/postings/__tests__/post-entry-export-route.test.ts
@@ -285,11 +285,43 @@ describe('opening_balance never reaches the connected provider', () => {
     })
 
     expect(fakePostEntry).not.toHaveBeenCalled()
-    expect(result.status).toBe('not_connected')
+    // 🛑 `not_exported`, NOT `not_connected`. A provider IS connected here -
+    // `registerFakeProvider` above - and this entry is skipped because of its
+    // posting TYPE. Reporting `not_connected` made the close console tell a
+    // connected org it had no accounting system (brief 22 §5).
+    expect(result.status).toBe('not_exported')
     expect(result.providerId).toBe('none')
     // The ledger still took the entry - only the export is skipped.
     expect(fake.postings).toHaveLength(1)
     expect(fake.lines).toHaveLength(2)
+  })
+
+  it('distinguishes a none ROUTE from an org with nothing connected', async () => {
+    // The pair that gives the value its meaning. Same posting type is not
+    // enough: what separates them is whether a provider exists at all, and a
+    // reader has to be able to tell, because one has a remedy and the other
+    // does not.
+    const routed = createFakeDb(CHART)
+    registerFakeProvider('stub', async (_input: PostEntryInput) =>
+      ok({ status: 'posted' as const, externalId: 'qb_3', providerId: 'stub' })
+    )
+    const withProvider = await postEntry(routed.db, {
+      organizationId: ORG,
+      entry: codedEntry('opening_balance', ['1000', '3900']),
+      lock: OPEN,
+    })
+    expect(withProvider.status).toBe('not_exported')
+
+    __resetAccountingProvidersForTests()
+
+    const bare = createFakeDb(CHART)
+    const nothingConnected = await postEntry(bare.db, {
+      organizationId: ORG,
+      entry: codedEntry('manual_journal', ['6200', '2100'], { periodKey: 'JNL-0002' }),
+      lock: OPEN,
+    })
+    expect(nothingConnected.status).toBe('not_connected')
+    expect(nothingConnected.exportStatus).toBe('not_required')
   })
 
   it('proves the branch: a manual_journal through the SAME fake provider IS called once', async () => {

--- a/packages/lib/src/postings/__tests__/post-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/post-entry.test.ts
@@ -1274,7 +1274,13 @@ describe('code-based entries', () => {
       lock: OPEN,
     })
 
-    expect(result.status).toBe('not_connected')
+    // `not_exported`, not `not_connected`, even though the resolver above
+    // answers `null`: both reasons apply here and the ROUTE short-circuits
+    // first. That is the right precedence - the type-level fact is the durable
+    // one, and connecting a provider tomorrow would not make this entry export.
+    // What this test is actually about is the line below: the cash-account
+    // guard does not refuse the entry (brief 22 §5).
+    expect(result.status).toBe('not_exported')
     expect(fake.lines.map((line) => line.accountCode)).toEqual(['1000', '2100'])
   })
 

--- a/packages/lib/src/postings/__tests__/setup-readiness.test.ts
+++ b/packages/lib/src/postings/__tests__/setup-readiness.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from 'vitest'
 import {
   openingTrialBalanceDifference,
   resolveSetupReadiness,
+  SETUP_READINESS_SETTING_KEYS,
   type SettingsRecord,
   summariseOpeningTrialBalance,
 } from '../setup-readiness'
@@ -178,5 +179,109 @@ describe('resolveSetupReadiness: the three requirements that already existed', (
       openingTrialBalance: { debitMinor: 1, creditMinor: 0, rows: 1 },
     })
     expect(readiness.settingsReady).toBe(false)
+  })
+})
+
+// ── brief 22: the provider snapshot is asked for only when there is a provider ──
+//
+// 🛑 Every case below was reachable before and none was covered: the `qbo*`
+// keys and the journal reference appeared only in the happy fixture above, so
+// the two gates that blocked DemoOrg1's first wizard drive had no test of their
+// own. That is why a live drive found them and 960 test files did not.
+
+/** A standalone org: every auxx key set, every provider key absent. */
+function standalone(overrides: SettingsRecord = {}): SettingsRecord {
+  return settings({
+    'accounting.qboOpeningRawMaterials': null,
+    'accounting.qboOpeningWip': null,
+    'accounting.qboOpeningFinishedGoods': null,
+    'accounting.qboOpeningJournalRef': null,
+    ...overrides,
+  })
+}
+
+describe('resolveSetupReadiness: opening balances are provider-conditional', () => {
+  it('an org with nothing connected is READY on its own three balances alone', () => {
+    // `21` DECIDED 1: a company must never be forced to connect QuickBooks to
+    // get a correct balance sheet. Before this, Finalize stayed disabled until
+    // somebody typed three QuickBooks balances for a system they do not have.
+    const readiness = resolveSetupReadiness(standalone())
+    expect(requirement(readiness, 'set-opening-balances').met).toBe(true)
+    expect(readiness.settingsReady).toBe(true)
+  })
+
+  it('the SAME settings are not ready once a provider is connected', () => {
+    const readiness = resolveSetupReadiness(standalone(), { providerConnected: true })
+    const row = requirement(readiness, 'set-opening-balances')
+    expect(row.met).toBe(false)
+    expect(row.reason).toMatch(/Some opening balances are not set/)
+    expect(readiness.settingsReady).toBe(false)
+  })
+
+  it('absent providerConnected reads as NOT connected', () => {
+    // The opposite default to `openingTrialBalance`, deliberately: demanding a
+    // QuickBooks figure on the strength of a connection nobody looked up is the
+    // defect, not the safeguard.
+    expect(resolveSetupReadiness(standalone()).settingsReady).toBe(true)
+    expect(resolveSetupReadiness(standalone(), {}).settingsReady).toBe(true)
+  })
+
+  it('still refuses a connected org whose two snapshots disagree', () => {
+    const readiness = resolveSetupReadiness(
+      settings({ 'accounting.qboOpeningRawMaterials': 999_00 }),
+      { providerConnected: true }
+    )
+    const row = requirement(readiness, 'set-opening-balances')
+    expect(row.met).toBe(false)
+    expect(row.reason).toMatch(/do not agree/)
+  })
+
+  it('never reports a disagreement for a standalone org, because there is none to have', () => {
+    // `openingDifference` skips a pair whose either side is null, so it returns
+    // 0 regardless - the old gate made a standalone org type its own figures
+    // into a second column so a subtraction against a copy of itself could come
+    // out zero. It proved nothing and refused until it was done.
+    const readiness = resolveSetupReadiness(standalone())
+    expect(requirement(readiness, 'set-opening-balances').reason).toBeUndefined()
+  })
+
+  it('still refuses a fractional provider balance, but only when connected', () => {
+    const fractional = settings({ 'accounting.qboOpeningWip': 12.5 })
+    expect(
+      requirement(
+        resolveSetupReadiness(fractional, { providerConnected: true }),
+        'set-opening-balances'
+      ).reason
+    ).toMatch(/whole number of cents/)
+    expect(requirement(resolveSetupReadiness(fractional), 'set-opening-balances').met).toBe(true)
+  })
+
+  it('still refuses an org missing one of its OWN balances, connected or not', () => {
+    const missing = standalone({ 'accounting.openingWip': null })
+    for (const context of [{}, { providerConnected: true }]) {
+      expect(requirement(resolveSetupReadiness(missing, context), 'set-opening-balances').met).toBe(
+        false
+      )
+    }
+  })
+})
+
+describe('resolveSetupReadiness: the journal reference is not a gate', () => {
+  it('is ready with no QuickBooks opening journal reference, even when connected', () => {
+    // Nothing reads it. `opening-baseline.ts` lists it under "What this reader
+    // deliberately does NOT read", and `settled-periods.ts` excludes it from
+    // the frozen keys because it "feeds no comparison". A value not worth
+    // protecting after finalize is not worth refusing to finalize over.
+    const readiness = resolveSetupReadiness(settings({ 'accounting.qboOpeningJournalRef': null }), {
+      providerConnected: true,
+    })
+    expect(requirement(readiness, 'set-opening-balances').met).toBe(true)
+    expect(readiness.settingsReady).toBe(true)
+  })
+
+  it('is not one of the keys the predicate declares it reads', () => {
+    // `buildReadinessRecord` feeds the predicate from this array, so a key left
+    // here would keep being collected for a rule that no longer exists.
+    expect(SETUP_READINESS_SETTING_KEYS).not.toContain('accounting.qboOpeningJournalRef')
   })
 })

--- a/packages/lib/src/postings/journal-entries/writes.ts
+++ b/packages/lib/src/postings/journal-entries/writes.ts
@@ -411,7 +411,13 @@ export async function reverseJournalEntry(
         result.status === 'already_posted' ||
         result.status === 'healed' ||
         result.status === 'not_connected' ||
-        result.status === 'disabled'
+        result.status === 'disabled' ||
+        // A reversal inherits the original's posting type (`reverse-entry.ts`),
+        // so reversing the opening entry - a `journal_entry` record of kind
+        // `opening_balance`, posted, with a `glPostingId`, and nothing here
+        // refuses it - produces a `'none'`-routed reversal. Without this the
+        // ledger would hold the reversal while the record still read `posted`.
+        result.status === 'not_exported'
 
       if (landed) {
         const crud = new UnifiedCrudHandler(organizationId, userId, db)

--- a/packages/lib/src/postings/post-entry.ts
+++ b/packages/lib/src/postings/post-entry.ts
@@ -50,6 +50,7 @@ import { loadRoleAccountCodes, resolveAccountLines } from './resolve-roles'
 import type {
   BuiltEntry,
   PostEntryInput,
+  PostEntryStatus,
   PostFailureClass,
   PostingExportStatus,
   PostingType,
@@ -746,10 +747,10 @@ export async function postEntry(db: Database, options: PostEntryOptions): Promis
     // org's connected one, so a route never reaches this file's own provider
     // call. Do not branch other posting types here - the route table is the
     // one place that decides this.
-    const provider =
-      EXPORT_ROUTE_BY_POSTING_TYPE[entry.postingType] === 'none'
-        ? NONE_ACCOUNTING_PROVIDER
-        : await resolveAccountingProvider(organizationId)
+    const routedToNone = EXPORT_ROUTE_BY_POSTING_TYPE[entry.postingType] === 'none'
+    const provider = routedToNone
+      ? NONE_ACCOUNTING_PROVIDER
+      : await resolveAccountingProvider(organizationId)
     const input: PostEntryInput = {
       organizationId,
       glPostingId,
@@ -806,9 +807,27 @@ export async function postEntry(db: Database, options: PostEntryOptions): Promis
     }
 
     const result = pushed.value
-    // `not_connected` and `disabled` pushed nothing and are owed nothing.
+
+    // 🛑 A `'none'` ROUTE is not a missing integration, and must not say it is.
+    //
+    // `NONE_ACCOUNTING_PROVIDER` answers `not_connected` because from its own
+    // point of view that is true - it has nothing to push to. But it was handed
+    // this entry by the route table, not by the org's lack of a provider, and
+    // the org may well have QuickBooks connected. Reporting `not_connected`
+    // there made the close console tell a connected org it had no accounting
+    // system, sending a reader to debug a healthy connection (brief 22 §5).
+    //
+    // The translation lives HERE because this is the only place that knows
+    // which of the two reasons applied: the provider cannot tell, and the row
+    // records the same `exportStatus` either way.
+    const status: PostEntryStatus =
+      routedToNone && result.status === 'not_connected' ? 'not_exported' : result.status
+
+    // Nothing was pushed and nothing is owed. `not_exported` joins the set for
+    // the same reason it exists - it pushed nothing BY DESIGN, so an export is
+    // not merely absent, it is never coming.
     const exportStatus =
-      result.status === 'not_connected' || result.status === 'disabled'
+      status === 'not_connected' || status === 'disabled' || status === 'not_exported'
         ? ('not_required' as const)
         : ('exported' as const)
     await stampOutcome(organizationId, glPostingId, () =>
@@ -831,7 +850,7 @@ export async function postEntry(db: Database, options: PostEntryOptions): Promis
     })
 
     return {
-      status: result.status,
+      status,
       exportStatus,
       glPostingId,
       docNumber,

--- a/packages/lib/src/postings/provider-sync/writes.ts
+++ b/packages/lib/src/postings/provider-sync/writes.ts
@@ -255,7 +255,12 @@ function isPosted(result: PostResult): result is PostResult & { glPostingId: str
       result.status === 'already_posted' ||
       result.status === 'healed' ||
       result.status === 'not_connected' ||
-      result.status === 'disabled') &&
+      result.status === 'disabled' ||
+      // 🛑 The status EVERY entry on this path now gets. `provider_sync` is one
+      // of the two `'none'` routes in `EXPORT_ROUTE_BY_POSTING_TYPE` - that is
+      // this module's loop guard - so a synced entry never pushes and always
+      // lands here. Omitting it would make the sync record nothing at all.
+      result.status === 'not_exported') &&
     Boolean(result.glPostingId)
   )
 }

--- a/packages/lib/src/postings/retry-export.ts
+++ b/packages/lib/src/postings/retry-export.ts
@@ -23,7 +23,14 @@ import { and, asc, eq, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { ConflictError, NotFoundError } from '../errors'
 import { resolveAccountingProvider } from './provider'
-import type { CounterpartyType, PostEntryInput, PostResult, ResolvedPostingLine } from './types'
+import { EXPORT_ROUTE_BY_POSTING_TYPE } from './regime'
+import type {
+  CounterpartyType,
+  PostEntryInput,
+  PostingType,
+  PostResult,
+  ResolvedPostingLine,
+} from './types'
 
 const logger = createScopedLogger('postings-retry-export')
 
@@ -97,10 +104,20 @@ export async function retryExport(
     // would resolve the `none` provider and stamp `not_required` again, which
     // reads to the operator as "I tried and it worked" when nothing was tried.
     if (row.exportStatus === 'not_required') {
+      // ⚠️ Three reasons produce `not_required` and only two of them are about
+      // the organization. A `'none'`-routed posting type is never exported at
+      // all, so telling the operator to check a connection they may well have
+      // sends them to debug something healthy - the same defect as the close
+      // console's `not_connected` copy (brief 22 §5).
+      const routedToNone = EXPORT_ROUTE_BY_POSTING_TYPE[row.postingType as PostingType] === 'none'
       return err(
         new ConflictError(
-          `${row.docNumber} has no export to retry: this organization has no accounting ` +
-            'system connected, or posting journal entries to it is switched off.',
+          routedToNone
+            ? `${row.docNumber} is never exported. An opening balance and an entry synced ` +
+                'from your accounting system are both kept here only, because pushing either ' +
+                'back would hand the provider a second copy of a figure it already has.'
+            : `${row.docNumber} has no export to retry: this organization has no accounting ` +
+                'system connected, or posting journal entries to it is switched off.',
           { glPostingId }
         )
       )

--- a/packages/lib/src/postings/setup-readiness.ts
+++ b/packages/lib/src/postings/setup-readiness.ts
@@ -68,13 +68,23 @@ export const ABSORPTION_RATE_SETTING_KEYS = {
   overhead: 'manufacturing.overheadCostPerUnit',
 } as const
 
-/** Every setting key this predicate reads. Handy for scoping a settings draft. */
+/**
+ * Every setting key this predicate reads. Handy for scoping a settings draft.
+ *
+ * 🛑 `accounting.qboOpeningJournalRef` is deliberately NOT here. It is written
+ * by the wizard and read by nothing: `opening-baseline.ts` names it under
+ * "What this reader deliberately does NOT read", and
+ * `settled-periods.ts`'s `FROZEN_SETUP_SETTING_KEYS` excludes it because - in
+ * that file's own test name - it "feeds no comparison". A value not worth
+ * protecting after finalize is not worth refusing to finalize over, so it is
+ * optional provenance on the settings page and not a requirement here
+ * (brief 22 §1).
+ */
 export const SETUP_READINESS_SETTING_KEYS = [
   ...Object.values(OPENING_BASELINE_SETTING_KEYS),
   'accounting.qboOpeningRawMaterials',
   'accounting.qboOpeningWip',
   'accounting.qboOpeningFinishedGoods',
-  'accounting.qboOpeningJournalRef',
   ...Object.values(ABSORPTION_RATE_SETTING_KEYS),
 ] as const
 
@@ -137,6 +147,22 @@ export interface OpeningTrialBalanceSummary {
  */
 export interface SetupReadinessContext {
   openingTrialBalance?: OpeningTrialBalanceSummary
+  /**
+   * Whether an accounting system is connected.
+   *
+   * 🛑 **Absent reads as NOT connected**, which is the opposite default to
+   * `openingTrialBalance` above, and deliberately so. That field defaults to
+   * met because reporting a failure on a fact the caller never looked up is
+   * worse than being permissive. The same instinct points the other way here:
+   * demanding a QuickBooks figure from an organization whose connection nobody
+   * looked up is precisely the defect this flag exists to fix (brief 22 §2.4).
+   *
+   * ⚠️ Both callers answer it truthfully, so the checklist and the wizard
+   * cannot drift the way `:169` warns about: the wizard and `settings/opening`
+   * pass `useAccountingProviderStatus().connected`, and
+   * `getting-started/signals.ts` resolves the provider for the org.
+   */
+  providerConnected?: boolean
 }
 
 /**
@@ -266,24 +292,33 @@ export function resolveSetupReadiness(
     'accounting.qboOpeningWip',
     'accounting.qboOpeningFinishedGoods',
   ]
-  const missingBalance = [...auxxKeys, ...qboKeys].some(
-    (k) => readSettingMinorUnits(settings[k]) === null
-  )
-  const fractional = [...auxxKeys, ...qboKeys].some(
+
+  // 🛑 The provider's snapshot is asked for ONLY when there is a provider.
+  //
+  // `21` DECIDED 1: a company must never be forced to connect QuickBooks to get
+  // a correct balance sheet. Requiring `qboOpening*` unconditionally forced a
+  // standalone organization to fill in three QuickBooks balances for a system
+  // it does not have, and Finalize stayed disabled until it did.
+  //
+  // The comparison those keys exist for is also vacuous without a provider:
+  // `openingDifference` skips a pair whose either side is null, so it returns 0
+  // regardless. The old gate made a standalone org type its own figures into a
+  // second column so a subtraction of a number against a copy of itself could
+  // come out zero. It proved nothing and refused until it was done (brief 22 §2).
+  const compared = context.providerConnected ? [...auxxKeys, ...qboKeys] : auxxKeys
+  const missingBalance = compared.some((k) => readSettingMinorUnits(settings[k]) === null)
+  const fractional = compared.some(
     (k) => readSettingMinorUnits(settings[k]) !== null && !isWholeMinorUnits(settings[k])
   )
-  const journalRef = readSettingText(settings['accounting.qboOpeningJournalRef'])
   const difference = openingDifference(settings)
 
   const openingReason = missingBalance
     ? 'Some opening balances are not set. Zero is a real balance; unset is not.'
     : fractional
       ? 'An opening balance is not a whole number of cents.'
-      : !journalRef
-        ? 'No QuickBooks opening journal reference.'
-        : difference !== 0
-          ? 'The auxx and QuickBooks opening snapshots do not agree.'
-          : undefined
+      : context.providerConnected && difference !== 0
+        ? 'The auxx and QuickBooks opening snapshots do not agree.'
+        : undefined
 
   const labor = readSettingMinorUnits(settings[R.assemblyLabor])
   const overhead = readSettingMinorUnits(settings[R.overhead])

--- a/packages/lib/src/postings/types.ts
+++ b/packages/lib/src/postings/types.ts
@@ -365,8 +365,27 @@ export interface PostEntryInput {
  *   other is a missing integration, and the close console has to tell a reader
  *   which of the two it is looking at. Leaving them merged would make the remedy
  *   unguessable from the record.
+ * - `not_exported` - this POSTING TYPE is never pushed, whatever the org has
+ *   connected. `EXPORT_ROUTE_BY_POSTING_TYPE` routes `opening_balance` and
+ *   `provider_sync` to `'none'`, both because an entry that came FROM the
+ *   provider must never be handed back at it.
+ *
+ *   🛑 It exists for the same reason `disabled` does, and it was found the same
+ *   way `disabled` would have been. Before it, a `'none'`-routed entry borrowed
+ *   `not_connected` and the close console told an org with QuickBooks connected
+ *   that **no accounting system is connected** - observed on DemoOrg1's first
+ *   wizard drive, two pages after the wizard itself displayed the company name.
+ *   The remedy for `not_connected` is "connect one"; the remedy for this is
+ *   nothing at all, because it is working. A reader cannot guess which they are
+ *   looking at if the two share a value (brief 22 §5).
  */
-export type PostEntryStatus = 'posted' | 'already_posted' | 'healed' | 'not_connected' | 'disabled'
+export type PostEntryStatus =
+  | 'posted'
+  | 'already_posted'
+  | 'healed'
+  | 'not_connected'
+  | 'disabled'
+  | 'not_exported'
 
 /**
  * What the export of one entry to the accounting provider did.


### PR DESCRIPTION
The first end-to-end drive of the accounting setup wizard, on a freshly reset DemoOrg1. It found three rules the code states correctly and applies to the wrong set of organizations. All three shipped under green tests; none of them is a broken test.

Written up as `plans/accounting/tasks/22-the-gate-asks-for-quickbooks.md`.

## 1. The journal reference gated Finalize and nothing reads it

`accounting.qboOpeningJournalRef` is written by the wizard, refused on at `setup-readiness.ts`, and consumed by no code at all. Two places in the tree already said so:

- `opening-baseline.ts` lists it under the heading **"What this reader deliberately does NOT read"**.
- `settled-periods.test.ts`'s test *name* is "does NOT freeze `accounting.qboOpeningJournalRef`, **which feeds no comparison**". Every other opening key is frozen once an entry stands in the books; this one is excluded because there is no arithmetic behind it to protect.

A value not worth protecting after finalize is not worth refusing to finalize over. Dropped from the gate; still on the settings page as optional provenance.

The `qboOpening*` **balances** keep their gate — `openingDifference()` compares them against our snapshot, and a difference falling into January's balancing plug would classify a cutover problem as January COGS.

## 2. The gate was not provider-conditional

There was no branch on whether a provider is connected anywhere in `setup-readiness.ts`. An org that had connected nothing still had to supply three `accounting.qboOpening*` balances, and Finalize stayed disabled until it did — brief 21's decision that **auxx.ai must be a complete set of books on its own** failing at the first gate.

The comparison it forced was vacuous as well: `openingDifference()` skips any pair where either side is null, so it returns `0` regardless. A standalone org was typing its own figures into a second column so that a subtraction against a copy of itself could come out zero.

| | connected | standalone |
|---|---|---|
| `accounting.opening*` | required | required |
| `accounting.qboOpening*` | required | **not asked** |
| `openingDifference() === 0` | enforced | **not enforced** |
| journal reference | optional (§1) | not asked |

`SetupReadinessContext.providerConnected` carries the fact. **Absent reads as NOT connected** — the opposite default to `openingTrialBalance`, because demanding a QuickBooks figure on the strength of a connection nobody looked up is the defect, not the safeguard.

All three callers answer truthfully, so the checklist and the two Finalize doors cannot drift:

- `getting-started/signals.ts` resolves the provider — `settingsRequirementMet` was already async and already held `ctx.organizationId`, so no signature change.
- `wizard-done-page.tsx` and `general-settings-page.tsx` pass `loading || connected`. The hook's own docs say `connected` is `false` for a beat after `installed` flips; one requirement briefly showing unmet beats briefly enabling Finalize against a baseline nobody reconciled.

## 3. `not_connected` told a connected org it had no provider

`EXPORT_ROUTE_BY_POSTING_TYPE` routes `opening_balance` and `provider_sync` to `'none'` by posting **type** — an entry that came from the provider must never be pushed back. So the poster hands them to `NONE_ACCOUNTING_PROVIDER`, which answers `not_connected` by definition. On DemoOrg1 the close console said **"Posted. No accounting system is connected"** two pages after the wizard displayed "Connected · Sandbox Company_US_1".

New `not_exported` status, emitted only when the route rather than a missing provider is the reason. The remedy for `not_connected` is "connect one"; the remedy for this is nothing, because it is working.

**Two of its call sites were load-bearing and neither was reachable by typecheck** — both are string comparisons inside a boolean:

- `provider-sync/writes.ts`'s `isPosted`. `provider_sync` is the *other* `'none'` route, so every synced entry now returns `not_exported`; omitting it would have made the inbound sync silently record nothing.
- `journal-entries/writes.ts`'s `landed`. A reversal inherits its original's posting type and nothing refuses reversing the opening entry, so the ledger would have held the reversal while the record still read `posted`.

`retry-export.ts`'s refusal message and `posting-drawer.tsx` repeated the same false claim and now name the real reason. The drawer needed the route table rather than the row, because a `'none'`-routed posting and a disconnected org both store `providerId: 'none'`.

## Tests

Both gates in §1 and §2 had **no tests of their own** — they existed only inside a happy fixture. That is why a live drive found them and 960 test files did not.

- 9 new readiness cases: standalone is ready on its own three balances; the same settings are not ready once connected; absent reads as not connected; a connected org whose snapshots disagree is still refused; a standalone org never reports a disagreement; fractional still refused but only when connected; a missing *own* balance still refused either way.
- 1 new export-route case pairing a `'none'` route against an org with nothing connected.
- 2 assertions changed rather than added, both of which had encoded the defect — `post-entry-export-route.test.ts` asserted `not_connected` *with a provider registered*.

`packages/lib` postings: 1426 pass. Full `packages/lib`: 18,726 pass (one unrelated flake, `076-mail-category-rework.test.ts`, a 30s timeout importing the data-migrations registry; passes alone in 10s). Typecheck ratchet clean for `web` and `lib`.

Verified live on DemoOrg1's real opening entry: the drawer now reads "Posted. This entry is not exported".

## Also in here

A narrower pair of dev reset scripts, written because `reset-org-books.ts` is the wrong tool for resetting a ledger: it is all-or-nothing (13,523 orders and 20,443 line items go with the books) and refuses up front over connector-bound parts with blank SKUs, with both ways past that guard lossy.

- `reset-bank-and-journals.ts` — bank transactions and journal entries only, through the same `deleteEntityInstances` engine, deleting the connector bindings alongside so the records can come back.
- `reset-gl-chart.ts` — takes an org argument now. It previously wiped every organization's chart with no way to scope it.

Dev-only, no runtime impact. Happy to split them out if you'd rather.

https://claude.ai/code/session_01D4cgUS19PCyVYS6Piq4ugb
