### PR TITLE
fix(apps): ask for the whole app list on both settings screens

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
@@ -22,7 +22,14 @@ export default function AppsInstalledListPage() {
     },
     { staleTime: ORG_STATIC_STALE_TIME }
   )
-  const { data: results } = api.apps.list.useQuery({}, { staleTime: ORG_STATIC_STALE_TIME })
+  // Every installation is joined against this list below, and an installation whose app is
+  // missing from it is dropped entirely. The default limit is 20 and `getAvailableApps`
+  // appends unpublished dev apps AFTER all published ones, so without an explicit limit a
+  // freshly deployed dev app is installed, returned by `listInstalled`, and still invisible.
+  const { data: results } = api.apps.list.useQuery(
+    { limit: 100 },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
   const { uninstallApp, ConfirmDialog } = useUninstallApp()
 
   // Collapse dev+production installs of the same app to one entry (see helper).

--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -60,8 +60,12 @@ export default function IntegrationList() {
   const { hasAccess } = useFeatureFlags()
   const hasMcpAccess = hasAccess(FeatureKey.mcp)
   const { uninstallApp, ConfirmDialog } = useUninstallApp()
+  // This screen groups every app by category and has no pagination control, so it must
+  // ask for the whole list. The default limit is 20, and `getAvailableApps` appends
+  // unpublished dev apps AFTER all published ones before slicing — so on an org with 20
+  // published apps, a dev app the developer just deployed silently never renders.
   const { data: results } = api.apps.list.useQuery(
-    {},
+    { limit: 100 },
     { enabled: isAdminOrOwner, staleTime: ORG_STATIC_STALE_TIME }
   )
   const { data: installedResult } = api.apps.listInstalled.useQuery(


### PR DESCRIPTION
## Problem

`api.apps.list` is validated by `listAppsQuerySchema`, whose `limit` **defaults to 20** (max 100). `getAvailableApps` builds its result in a fixed order — published apps from the cache first, then unpublished dev apps targeting this org, then installations not already seen — and only slices for pagination at the very end.

Neither of the two apps settings screens paginates, so both were silently truncated at 20:

- `settings/apps/page.tsx` groups every app by category with no pagination control. On an org with 20 published apps, a dev app the developer just deployed never renders.
- `settings/apps/installed/page.tsx` joins each installation against this same list and **drops an installation whose app is missing from it**. So a freshly deployed dev app is installed, is returned by `listInstalled`, and is still invisible.

## Fix

Both queries now pass `{ limit: 100 }` — the schema's maximum. Comments at each call site record why the explicit limit is load-bearing so it does not get tidied away.

https://claude.ai/code/session_012QtMYeSuoicyEYQFTuM334