### PR TITLE
feat(accounting): a role may not name a vendor, and an account in use may not be removed

### DIFF
--- a/apps/web/src/components/money/ui/fulfillment-posting/fulfillment-plan-table.tsx
+++ b/apps/web/src/components/money/ui/fulfillment-posting/fulfillment-plan-table.tsx
@@ -51,7 +51,6 @@ import { formatMinor } from '~/components/accounting/ui/ledger/format'
  */
 export const DEBIT_ROLE_LABEL: Record<FulfillmentDebitRole, string> = {
   clearing_card: 'Card clearing',
-  clearing_affirm: 'Affirm clearing',
   accounts_receivable: 'Accounts receivable',
   gateway: 'Gateway clearing',
 }
@@ -59,7 +58,6 @@ export const DEBIT_ROLE_LABEL: Record<FulfillmentDebitRole, string> = {
 /** The same, short enough for a column head. */
 const DEBIT_ROLE_COLUMN: Record<FulfillmentDebitRole, string> = {
   clearing_card: 'Card',
-  clearing_affirm: 'Affirm',
   accounts_receivable: 'A/R',
   gateway: 'Gateway',
 }
@@ -67,7 +65,6 @@ const DEBIT_ROLE_COLUMN: Record<FulfillmentDebitRole, string> = {
 /** The order the debit columns are read in. Card first: it is the common case. */
 const DEBIT_ROLE_ORDER: readonly FulfillmentDebitRole[] = [
   'clearing_card',
-  'clearing_affirm',
   'gateway',
   'accounts_receivable',
 ]
@@ -76,7 +73,7 @@ const DEBIT_ROLE_ORDER: readonly FulfillmentDebitRole[] = [
  * The label one shipment ROW shows for its debit.
  *
  * `role === 'gateway'` means the debit is a `payment_gateway` record's own
- * clearing account id (`amounts.debitGlAccountId`), not one of the three
+ * clearing account id (`amounts.debitGlAccountId`), not one of the two
  * declared roles - `DEBIT_ROLE_LABEL.gateway` alone cannot say WHICH gateway,
  * so this prefers the name from `gatewayNames` (keyed by that same id) and
  * falls back to the generic label when the caller has not supplied one.

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -714,13 +714,12 @@ export const ledgerRouter = createTRPCRouter({
 
       const chart = await seedChartPacks(ctx.db, organizationId, glAccountDefId, input.packs)
 
-      // Task 13 §5.3: the two default `payment_gateway` records the census
-      // names. Runs AFTER the chart on purpose - the clearing accounts these
-      // defaults point at (`clearing_card` / `clearing_affirm`) only exist once
-      // the chart above has just created or confirmed them. Brief 16 §1.5 ties
-      // them to the `card_rail` pack; gated on the WALKED packs, not the
-      // requested ones, so `requires` expansion is honoured (though nothing
-      // requires `card_rail` today, so the two currently agree).
+      // Task 13 §5.3: the one default `payment_gateway` record. Runs AFTER the
+      // chart on purpose - the clearing account it points at (`clearing_card`)
+      // only exists once the chart above has just created or confirmed it.
+      // Brief 16 §1.5 ties it to the `card_rail` pack; gated on the WALKED
+      // packs, not the requested ones, so `requires` expansion is honoured
+      // (though nothing requires `card_rail` today, so the two currently agree).
       const paymentGateways = chart.packs.includes('card_rail')
         ? await seedDefaultPaymentGateways(ctx.db, organizationId)
         : null

--- a/packages/lib/scripts/drive-fulfillment-posting-preview.ts
+++ b/packages/lib/scripts/drive-fulfillment-posting-preview.ts
@@ -1,0 +1,124 @@
+// packages/lib/scripts/drive-fulfillment-posting-preview.ts
+//
+// READ-ONLY. Drives the real bulk-fulfillment plan for one month and reports
+// what it WOULD post: the debit split, the exclusions, and - the point of the
+// script - whether every account each group names actually resolves.
+//
+// Written to answer "the close says 439 shipments are unposted; what happens if
+// I post them?" without posting them. `previewFulfillmentPosting` is the same
+// call the dialog makes, and `resolveAccountLines` is the same door
+// `postEntry` walks, so a refusal here is the refusal the real post would give.
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/drive-fulfillment-posting-preview.ts <organizationId> <YYYY-MM>
+
+import { closePools, database, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { previewFulfillmentPosting } from '../src/money/fulfillment-posting'
+import { listPaymentGateways } from '../src/payment-gateways'
+import { buildFulfillmentBatchEntry } from '../src/postings/build-fulfillment-batch-entry'
+import { resolveAccountLines } from '../src/postings/resolve-roles'
+
+function usd(minor: number): string {
+  return `$${(minor / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`
+}
+
+async function main() {
+  const organizationId = process.argv[2]
+  const month = process.argv[3]
+  if (!organizationId || !month) {
+    throw new Error('usage: drive-fulfillment-posting-preview.ts <organizationId> <YYYY-MM>')
+  }
+
+  // `previewFulfillmentPosting` wants an actor even though it writes nothing.
+  const [member] = await database
+    .select({ userId: schema.OrganizationMember.userId })
+    .from(schema.OrganizationMember)
+    .where(eq(schema.OrganizationMember.organizationId, organizationId))
+    .limit(1)
+  if (!member) throw new Error('that organization has no members')
+
+  // ── The gateway records, because they decide every clearing debit ─────────
+  const gateways = await listPaymentGateways(database, organizationId, { includeArchived: true })
+  if (gateways.isErr()) throw gateways.error
+  console.log(`\n=== payment_gateway records (${gateways.value.length}) ===`)
+  for (const gw of gateways.value) {
+    console.log(
+      `  ${gw.name}: handles=[${gw.handles.join(', ')}] clearing=${gw.clearingGlAccountId} ` +
+        `settlement=${gw.settlementSource} status=${gw.status}`
+    )
+  }
+
+  // ── The plan, exactly as the dialog builds it ─────────────────────────────
+  const preview = await previewFulfillmentPosting(database, {
+    organizationId,
+    range: { from: `${month}-01`, to: `${month}-31` },
+    grouping: 'month',
+    actorUserId: member.userId,
+  })
+  if (preview.isErr()) throw preview.error
+  const { plan, refusal } = preview.value
+  if (refusal) console.log(`\n  REFUSAL: ${refusal}`)
+
+  console.log(`\n=== plan for ${month} ===`)
+  console.log(
+    `  postings=${plan.footer.postings} shipments=${plan.footer.shipments} ` +
+      `orders=${plan.footer.orders} excluded=${plan.footer.excluded} total=${usd(plan.footer.totalMinor)}`
+  )
+  for (const ex of plan.exclusions.slice(0, 10)) {
+    console.log(`  EXCLUDED ${ex.orderNumber}: ${ex.reason} - ${ex.detail}`)
+  }
+
+  // ── What each group would actually post, and whether it resolves ──────────
+  for (const group of plan.groups) {
+    console.log(`\n=== group ${group.groupKey} (${group.shipments.length} shipments) ===`)
+    console.log(`  total=${usd(group.totals.totalMinor)}`)
+    for (const [role, amount] of Object.entries(group.totals.byDebitRole)) {
+      if (amount !== 0) console.log(`  debit ${role}: ${usd(amount as number)}`)
+    }
+
+    // The distinct id-based debits, which bypass the role table entirely.
+    const byAccount = new Map<string, number>()
+    for (const s of group.shipments) {
+      const id = s.amounts.debitGlAccountId
+      if (id) byAccount.set(id, (byAccount.get(id) ?? 0) + s.amounts.totalMinor)
+    }
+    for (const [id, amount] of byAccount) {
+      console.log(`  debit BY ID ${id}: ${usd(amount)}`)
+    }
+
+    let built: ReturnType<typeof buildFulfillmentBatchEntry>
+    try {
+      built = buildFulfillmentBatchEntry({ group, ledgerCurrency: 'USD', attempt: 0 })
+    } catch (error) {
+      console.log(`  🛑 BUILD REFUSED: ${(error as Error).message}`)
+      continue
+    }
+
+    console.log(
+      `  lines=${built.entry.lines.length} balanced=${
+        built.entry.totalDebit === built.entry.totalCredit
+      } (${usd(built.entry.totalDebit)})`
+    )
+
+    // 🛑 The real test. `postEntry` calls this exact function, so a problem
+    // here is a problem the post would hit.
+    const resolved = await resolveAccountLines(database, organizationId, built.entry.lines)
+    if (resolved.isErr()) {
+      console.log(
+        `  🛑 WOULD REFUSE TO POST:\n     ${resolved.error.message.replace(/\n/g, '\n     ')}`
+      )
+    } else {
+      console.log('  ✅ every account resolves - this group would post')
+      for (const account of resolved.value) {
+        console.log(`     ${account.code ?? '(no code)'} ${account.name}`)
+      }
+    }
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(closePools)

--- a/packages/lib/scripts/reset-gl-chart.ts
+++ b/packages/lib/scripts/reset-gl-chart.ts
@@ -30,6 +30,14 @@
 //
 //   - 784 `gl_account` rows, 28 accounts x 28 orgs.
 //   - 0 `FieldValue` rows pointing AT a `gl_account` instance.
+//     ⚠️ That survey, and the guard below, originally looked at
+//     `relatedEntityId` ALONE - the relationship column. Task 15's pointers are
+//     plain TEXT (`bank_account.glAccount`, `payment_gateway.clearingAccount`
+//     and six more), so they live in `valueText` and were invisible to both.
+//     On 2026-09-11 this script wiped a chart that a `payment_gateway` was
+//     pointing at, reported success, and left a REQUIRED field naming an id
+//     that existed nowhere; the next fulfillment post refused. The guard now
+//     asks `findGlAccountPointers`, which checks both columns.
 //   - 0 `RecordIdentity` rows on a `gl_account` instance - no provider's own
 //     account id is lost.
 //   - 0 `GlPosting` / `GlPostingLine` rows.
@@ -49,6 +57,7 @@
 import { database, schema } from '@auxx/database'
 import { and, eq, inArray } from 'drizzle-orm'
 import { getOrgCache } from '../src/cache'
+import { findGlAccountPointers } from '../src/postings/gl-account-pointers'
 
 const RETIRED_ROLE_ATTRIBUTE = 'gl_account_role'
 
@@ -108,6 +117,17 @@ async function resetOrg(organizationId: string): Promise<OrgResult | null> {
       throw new Error(
         `Organization ${organizationId} has ${referencing.length}+ FieldValue row(s) pointing at a gl_account instance; refusing to wipe the chart. It was expected to be unreferenced (verified 2026-08-28). Repoint or clear these values first. Fields: ${referencing
           .map((r) => r.fieldId)
+          .join(', ')}`
+      )
+    }
+
+    // 🛑 The same question asked of the TEXT pointers, which the query above
+    // cannot see. See the header note: this is the half that was missing.
+    const textPointers = await findGlAccountPointers(database, organizationId, accountIds)
+    if (textPointers.length > 0) {
+      throw new Error(
+        `Organization ${organizationId} has ${textPointers.length}+ record(s) holding a gl_account id in a TEXT field; refusing to wipe the chart. These carry no foreign key, so wiping leaves them naming an account that does not exist and the next posting that needs one refuses. Repoint them first: ${textPointers
+          .map((pointer) => `${pointer.attribute} on ${pointer.entityId}`)
           .join(', ')}`
       )
     }

--- a/packages/lib/src/money/fulfillment-posting/__tests__/plan.test.ts
+++ b/packages/lib/src/money/fulfillment-posting/__tests__/plan.test.ts
@@ -349,19 +349,42 @@ describe('the exclusion PRIORITY order', () => {
 
 describe('totals and the debit split', () => {
   it('splits a group by the account each shipment debits', () => {
-    const result = plan([
-      // Paid by card.
-      shipment({ orderId: 'a', orderNumber: '#1' }),
-      // Paid by Affirm: its own clearing account, so the payout reconciles.
-      shipment({ orderId: 'b', orderNumber: '#2', gateways: ['Affirm'] }),
-      // Not paid: a receivable, and aging needs the debtor.
-      shipment({ orderId: 'c', orderNumber: '#3', financialStatus: 'pending' }),
-    ])
+    const result = plan(
+      [
+        // Paid by card.
+        shipment({ orderId: 'a', orderNumber: '#1' }),
+        // Paid by Affirm: its own clearing account via a `payment_gateway`
+        // record, so the card payout still reconciles to zero. This was the
+        // `clearing_affirm` ROLE until 2026-09-10 - a role may not name a
+        // vendor, so it became a record and lands in the `gateway` bucket.
+        shipment({ orderId: 'b', orderNumber: '#2', gateways: ['Affirm'] }),
+        // Not paid: a receivable, and aging needs the debtor.
+        shipment({ orderId: 'c', orderNumber: '#3', financialStatus: 'pending' }),
+      ],
+      {
+        gatewayRoutes: [
+          { handles: ['affirm'], clearingGlAccountId: 'acct_affirm_clearing', active: true },
+        ],
+      }
+    )
 
     expect(result.groups[0]?.totals.byDebitRole).toEqual({
       clearing_card: 10_000,
-      clearing_affirm: 10_000,
       accounts_receivable: 10_000,
+      gateway: 10_000,
+    })
+  })
+
+  it('folds a non-card rail into card clearing when no record routes it', () => {
+    // 🛑 The cost of deleting `clearing_affirm`, pinned rather than left
+    // implicit: `1200` now carries a residual no card payout can relieve. The
+    // gateway settings page is where that is paid, and it is the same cost
+    // Authorize.Net has always carried.
+    const result = plan([shipment({ orderId: 'b', orderNumber: '#2', gateways: ['Affirm'] })])
+
+    expect(result.groups[0]?.totals.byDebitRole).toEqual({
+      clearing_card: 10_000,
+      accounts_receivable: 0,
       gateway: 0,
     })
   })
@@ -542,7 +565,6 @@ describe('gatewayRoutes (brief 13 §5.3)', () => {
     // The role buckets stay zero; the id-based debit is counted under `gateway`.
     expect(result.groups[0]?.totals.byDebitRole).toEqual({
       clearing_card: 0,
-      clearing_affirm: 0,
       accounts_receivable: 0,
       gateway: 10_000,
     })

--- a/packages/lib/src/money/fulfillment-posting/plan.ts
+++ b/packages/lib/src/money/fulfillment-posting/plan.ts
@@ -242,7 +242,6 @@ export function isoWeekKey(shippedAt: string): string {
 function toGroup(groupKey: string, shipments: PlannedShipment[]): FulfillmentPostingGroup {
   const byDebitRole: Record<FulfillmentDebitRole, number> = {
     clearing_card: 0,
-    clearing_affirm: 0,
     accounts_receivable: 0,
     // Every id-based (`payment_gateway` route) debit lands here, whichever
     // account it named - the account id itself rides on the shipment's own

--- a/packages/lib/src/money/fulfillment-posting/types.ts
+++ b/packages/lib/src/money/fulfillment-posting/types.ts
@@ -35,20 +35,17 @@ export const FULFILLMENT_POSTING_GROUPINGS: readonly FulfillmentPostingGrouping[
  * from the channel. A card order was paid at checkout and the payout entry
  * drains clearing; a terms order owes, and aging names the debtor.
  *
- * 🛑 **`'gateway'`, added by brief 13 §5.3, is not a fourth account.** It is
+ * 🛑 **`'gateway'`, added by brief 13 §5.3, is not a third account.** It is
  * the bucket a shipment falls into when its gateway resolved to a
  * `payment_gateway` record's own clearing account id rather than to one of the
- * three roles below - see {@link FulfillmentDebit}. `byDebitRole` summaries
+ * two roles below - see {@link FulfillmentDebit}. Every non-card rail lands
+ * here since `clearing_affirm` was deleted on 2026-09-10. `byDebitRole` summaries
  * (this file's own `FulfillmentPostingGroup.totals.byDebitRole` and the
  * builder's `BuiltFulfillmentBatchEntry.totals.byDebitRole`) keep working
  * unchanged by counting every id-based debit under this one key; the actual
  * account id rides on `ShipmentAmounts.debitGlAccountId`.
  */
-export type FulfillmentDebitRole =
-  | 'clearing_card'
-  | 'clearing_affirm'
-  | 'accounts_receivable'
-  | 'gateway'
+export type FulfillmentDebitRole = 'clearing_card' | 'accounts_receivable' | 'gateway'
 
 /**
  * What a shipment debits: a declared ROLE, or a `payment_gateway` record's own

--- a/packages/lib/src/postings/__tests__/build-fulfillment-batch-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-fulfillment-batch-entry.test.ts
@@ -30,7 +30,9 @@ import {
   buildFulfillmentBatchEntry,
   computeShipmentAmounts,
   FULFILLMENT_DEBIT_ACCOUNT_ROLE,
+  FULFILLMENT_GATEWAY_DEBIT,
   type FulfillmentBatchSource,
+  type FulfillmentGatewayRoute,
   fulfillmentBatchPeriodKey,
   MAX_COMPACT_FULFILLMENT_BATCH_KEY,
   MAX_FULFILLMENT_BATCH_ATTEMPT,
@@ -71,9 +73,12 @@ function shipment(overrides: Partial<UnpostedShipment> = {}): UnpostedShipment {
 }
 
 /** What `plan.ts` hands the builder: a shipment with its amounts already on it. */
-function planned(overrides: Partial<UnpostedShipment> = {}): PlannedShipment {
+function planned(
+  overrides: Partial<UnpostedShipment> = {},
+  gatewayRoutes: readonly FulfillmentGatewayRoute[] = []
+): PlannedShipment {
   const base = shipment(overrides)
-  const debit = resolveFulfillmentDebit(base)
+  const debit = resolveFulfillmentDebit({ ...base, gatewayRoutes })
   if (debit.kind !== 'debit') throw new Error(`fixture excluded: ${debit.reason}`)
   const { kind: _kind, ...rest } = debit
   return { ...base, amounts: computeShipmentAmounts(base, rest) }
@@ -83,7 +88,6 @@ function planned(overrides: Partial<UnpostedShipment> = {}): PlannedShipment {
 function group(shipments: PlannedShipment[], groupKey = '2026-07-06'): FulfillmentPostingGroup {
   const byDebitRole: Record<FulfillmentDebitRole, number> = {
     clearing_card: 0,
-    clearing_affirm: 0,
     accounts_receivable: 0,
     gateway: 0,
   }
@@ -121,6 +125,12 @@ function amountFor(entry: Entry, role: string): number | undefined {
   return found.length === 0 ? undefined : found.reduce((sum, line) => sum + line.amount, 0)
 }
 
+/** Σ of the lines debiting one `gl_account` id directly - a `payment_gateway` route. */
+function amountForAccount(entry: Entry, glAccountId: string): number | undefined {
+  const found = entry.lines.filter((line) => line.glAccountId === glAccountId)
+  return found.length === 0 ? undefined : found.reduce((sum, line) => sum + line.amount, 0)
+}
+
 /** The amount on the one `role` line carrying `{ [dimension]: value }` - brief 13 §5. */
 function dimensionAmountFor(
   entry: Entry,
@@ -131,15 +141,24 @@ function dimensionAmountFor(
   return linesFor(entry, role).find((line) => line.dimensions?.[dimension] === value)?.amount
 }
 
+/** A `payment_gateway` record's clearing account, as an id the fixtures share. */
+const AFFIRM_ACCOUNT = 'acct_gw_affirm'
+
 // ── 1. The debit fork ───────────────────────────────────────────────────────
 
 describe('resolveFulfillmentDebit', () => {
   it.each([
     // [financialStatus, gateways, expected role]
     ['paid', ['shopify_payments'], 'clearing_card'],
-    ['paid', ['affirm'], 'clearing_affirm'],
+    // 🛑 `affirm` with NO `payment_gateway` route is card money now. It had a
+    // role of its own until 2026-09-10; a role may not name a vendor, so the
+    // answer moved to a record and the fallback is the ordinary one. This is
+    // the residual `1200` carries when an Affirm store never adds the record -
+    // see `resolves a routed gateway to the record's own account` below for
+    // the path that prevents it.
+    ['paid', ['affirm'], 'clearing_card'],
     // Casing and whitespace are the provider's, not a second gateway.
-    ['paid', ['  Affirm '], 'clearing_affirm'],
+    ['paid', ['  Affirm '], 'clearing_card'],
     ['PAID', ['SHOPIFY_PAYMENTS'], 'clearing_card'],
     // A rail nobody has named is still card money: one processor took it, and
     // `clearing_card` is where a wrong guess fails to reconcile visibly.
@@ -156,7 +175,7 @@ describe('resolveFulfillmentDebit', () => {
     [null, ['shopify_payments'], 'accounts_receivable'],
     // A refund is its OWN later event (a credit memo). The money was taken.
     ['refunded', ['shopify_payments'], 'clearing_card'],
-    ['partially_refunded', ['affirm'], 'clearing_affirm'],
+    ['partially_refunded', ['affirm'], 'clearing_card'],
     // One gateway repeated is one gateway.
     ['paid', ['shopify_payments', 'Shopify_Payments'], 'clearing_card'],
   ])('%s through %j debits %s', (financialStatus, gateways, role) => {
@@ -204,9 +223,97 @@ describe('resolveFulfillmentDebit', () => {
   it('maps every debit answer to a declared posting role', () => {
     expect(FULFILLMENT_DEBIT_ACCOUNT_ROLE).toEqual({
       clearing_card: ACCOUNT_ROLES.CLEARING_CARD,
-      clearing_affirm: ACCOUNT_ROLES.CLEARING_AFFIRM,
       accounts_receivable: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
     })
+  })
+
+  it('names no gateway in the role table - a role must not name a vendor', () => {
+    // `build-entry.ts`'s second rule. `affirm` was the one exception and it was
+    // retired on 2026-09-10; the card RAIL is not a vendor, so it stays.
+    expect(Object.keys(FULFILLMENT_GATEWAY_DEBIT)).toEqual(['shopify_payments'])
+  })
+
+  // ── The `payment_gateway` record path (brief 13 §5.3) ─────────────────────
+  //
+  // 🛑 Load-bearing since `clearing_affirm` was deleted. This is now the ONLY
+  // mechanism keeping a non-card rail out of `clearing_card`, and a rail that
+  // lands there can never be drained: `PAYOUT_CLEARING_ROLES` relieves
+  // `clearing_card` by exactly what a card payout settled, so an Affirm sale
+  // sitting in `1200` is a residual that balances and never clears.
+
+  it("resolves a routed gateway to the record's own account, not to a role", () => {
+    expect(
+      resolveFulfillmentDebit({
+        financialStatus: 'paid',
+        gateways: ['affirm'],
+        gatewayRoutes: [
+          { handles: ['Affirm', 'affirm'], clearingGlAccountId: 'acct_affirm', active: true },
+        ],
+      })
+    ).toEqual({ kind: 'debit', glAccountId: 'acct_affirm' })
+  })
+
+  it('matches a route handle case- and whitespace-insensitively', () => {
+    expect(
+      resolveFulfillmentDebit({
+        financialStatus: 'paid',
+        gateways: ['  AFFIRM '],
+        gatewayRoutes: [
+          { handles: ['  Affirm  '], clearingGlAccountId: 'acct_affirm', active: true },
+        ],
+      })
+    ).toEqual({ kind: 'debit', glAccountId: 'acct_affirm' })
+  })
+
+  it('routes a CLOSED gateway too - its past shipments still have to reconcile', () => {
+    expect(
+      resolveFulfillmentDebit({
+        financialStatus: 'paid',
+        gateways: ['authorize_net'],
+        gatewayRoutes: [
+          { handles: ['authorize_net'], clearingGlAccountId: 'acct_authnet', active: false },
+        ],
+      })
+    ).toEqual({ kind: 'debit', glAccountId: 'acct_authnet' })
+  })
+
+  it('falls back to the role table when no route names the gateway', () => {
+    expect(
+      resolveFulfillmentDebit({
+        financialStatus: 'paid',
+        gateways: ['affirm'],
+        gatewayRoutes: [
+          { handles: ['authorize_net'], clearingGlAccountId: 'acct_authnet', active: true },
+        ],
+      })
+    ).toEqual({ kind: 'debit', role: 'clearing_card' })
+  })
+
+  it('refuses to choose when two routes claim the same handle', () => {
+    // The record's own write path should never allow this. Guessing which of
+    // two accounts is right would put real money in one of them.
+    expect(
+      resolveFulfillmentDebit({
+        financialStatus: 'paid',
+        gateways: ['affirm'],
+        gatewayRoutes: [
+          { handles: ['affirm'], clearingGlAccountId: 'acct_a', active: true },
+          { handles: ['Affirm'], clearingGlAccountId: 'acct_b', active: true },
+        ],
+      })
+    ).toEqual({ kind: 'debit', role: 'clearing_card' })
+  })
+
+  it('never routes an unpaid order, however well its gateway matches', () => {
+    // The status fork runs first: a terms order owes whoever it owes, and
+    // aging has to name the debtor.
+    expect(
+      resolveFulfillmentDebit({
+        financialStatus: 'pending',
+        gateways: ['affirm'],
+        gatewayRoutes: [{ handles: ['affirm'], clearingGlAccountId: 'acct_affirm', active: true }],
+      })
+    ).toEqual({ kind: 'debit', role: 'accounts_receivable' })
   })
 })
 
@@ -402,12 +509,19 @@ describe('computeShipmentAmounts', () => {
 describe('buildFulfillmentBatchEntry', () => {
   it('balances a mixed group and decomposes the same numbers', () => {
     const card = planned({ orderId: 'o-card', orderNumber: '#2001' })
-    const affirm = planned({
-      orderId: 'o-affirm',
-      orderNumber: '#2002',
-      gateways: ['Affirm'],
-      orderShippingTotalMinor: 0,
-    })
+    // A non-card rail, routed by a `payment_gateway` record to its OWN clearing
+    // account. This used to be the `clearing_affirm` role; since 2026-09-10 the
+    // record is the only way a rail stays out of `1200`, so the mixed group
+    // exercises it end to end.
+    const affirm = planned(
+      {
+        orderId: 'o-affirm',
+        orderNumber: '#2002',
+        gateways: ['Affirm'],
+        orderShippingTotalMinor: 0,
+      },
+      [{ handles: ['affirm'], clearingGlAccountId: AFFIRM_ACCOUNT, active: true }]
+    )
     // One terms order shipping twice on the same day: two lines in, ONE A/R line out.
     const termsFirst = planned({
       orderId: 'o-terms',
@@ -490,7 +604,11 @@ describe('buildFulfillmentBatchEntry', () => {
     expect(amountFor(entry, ACCOUNT_ROLES.CLEARING_CARD)).toBe(
       card.amounts.totalMinor + exempt.amounts.totalMinor
     )
-    expect(amountFor(entry, ACCOUNT_ROLES.CLEARING_AFFIRM)).toBe(affirm.amounts.totalMinor)
+    // 🛑 By ACCOUNT ID, not by role, and NOT folded into `clearing_card` - a
+    // rail that lands in `1200` can never be drained, because a payout relieves
+    // that account by exactly what a CARD payout settled.
+    expect(amountForAccount(entry, AFFIRM_ACCOUNT)).toBe(affirm.amounts.totalMinor)
+    expect(built.totals.byDebitRole.gateway).toBe(affirm.amounts.totalMinor)
     // Channel is a dimension on ONE revenue_product account now (brief 13 §5),
     // never a second account - the dealer order's share is the dealer-dimensioned line.
     expect(dimensionAmountFor(entry, ACCOUNT_ROLES.REVENUE_PRODUCT, 'channel', 'dealer')).toBe(

--- a/packages/lib/src/postings/__tests__/chart-write.test.ts
+++ b/packages/lib/src/postings/__tests__/chart-write.test.ts
@@ -37,6 +37,12 @@ const h = vi.hoisted(() => ({
   writeError: null as Error | null,
   /** The instance id `create` hands back. */
   createdId: 'acct_new',
+  /**
+   * What `findGlAccountPointers` (the I4 guard) finds. Empty by default: the
+   * ROLE cases below are about roles, and a fixture that silently carried a
+   * payment gateway would be testing the wrong refusal.
+   */
+  pointers: [] as { attribute: string; entityId: string; glAccountId: string }[],
 }))
 
 vi.mock('../../cache', () => ({
@@ -194,6 +200,16 @@ function stubDb(accounts: Account[], assignments: Assignment[] = []): Database {
           limit: () => chain,
           orderBy: () => chain,
           groupBy: () => chain,
+          // `findGlAccountPointers` (the I4 guard) joins FieldValue to
+          // CustomField. This stub models no TEXT pointer at all, so the join
+          // resolves to nothing and the guard passes - which is the right
+          // default here: these cases are about ROLES, and a fixture that
+          // silently grew a payment gateway would be testing the wrong thing.
+          // The guard's own behaviour is covered in `gl-account-pointers.test.ts`.
+          innerJoin: () => ({
+            ...chain,
+            where: () => ({ ...chain, limit: async () => h.pointers }),
+          }),
           // biome-ignore lint/suspicious/noThenProperty: the stub must be awaitable
           then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
             Promise.resolve(rowsFor(table, params)).then(resolve, reject),
@@ -225,6 +241,7 @@ beforeEach(() => {
   h.deletes = []
   h.writeError = null
   h.createdId = 'acct_new'
+  h.pointers = []
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -831,6 +848,97 @@ describe('I2: deactivating an account a role still posts to', () => {
     })
 
     expect(result.isOk()).toBe(true)
+  })
+})
+
+/**
+ * I4 - the guard that `assertNoLiveRole` is not.
+ *
+ * 🛑 This became reachable on 2026-09-10. `clearing_affirm` had been doing
+ * double duty: routing Affirm money AND, through `assertNoLiveRole`, keeping
+ * `1210 Affirm Clearing` from being removed. Deleting the role moved the
+ * routing to a `payment_gateway` record and silently dropped the protection -
+ * so the Chart tab would happily archive an account a live gateway named, and
+ * the next Affirm posting would refuse with "no active account with id ...".
+ */
+describe('I4: removing or deactivating an account a TEXT pointer still names', () => {
+  const gatewayPointer = {
+    attribute: 'payment_gateway_clearing_account',
+    entityId: 'pg_affirm',
+    glAccountId: GRNI_ACCOUNT.id,
+  }
+
+  it('refuses removal, naming WHAT points there rather than only that something does', async () => {
+    h.pointers = [gatewayPointer]
+    const db = stubDb([GRNI_ACCOUNT], [])
+
+    const error = (
+      await removeChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        actorUserId: USER,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error.message).toContain('a payment gateway (clearing account)')
+    expect(error.message).toContain('still points at it')
+    // 🛑 Refused means NOTHING was archived. A guard that refuses after the
+    // write is not a guard.
+    expect(h.archives).toEqual([])
+  })
+
+  it('refuses deactivation too - every chart reader treats inactive as unusable', async () => {
+    h.pointers = [gatewayPointer]
+    const db = stubDb([GRNI_ACCOUNT], [])
+
+    const error = (
+      await updateChartAccount(db, {
+        organizationId: ORG,
+        accountId: GRNI_ACCOUNT.id,
+        actorUserId: USER,
+        isActive: false,
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error.message).toContain('a payment gateway (clearing account)')
+    expect(h.updates).toEqual([])
+  })
+
+  it('allows removal once nothing points there', async () => {
+    h.pointers = []
+    const db = stubDb([GRNI_ACCOUNT], [])
+
+    expect(
+      (
+        await removeChartAccount(db, {
+          organizationId: ORG,
+          accountId: GRNI_ACCOUNT.id,
+          actorUserId: USER,
+        })
+      ).isOk()
+    ).toBe(true)
+    expect(h.archives).toHaveLength(1)
+  })
+
+  // A RENUMBER or a RENAME is safe by construction - the pointer holds the
+  // INSTANCE id, which is the whole point of task 15 - so the guard must not
+  // fire on one. Firing here would make a pointed-at account uneditable.
+  it('does not fire on a renumber, a rename or a reactivation', async () => {
+    h.pointers = [gatewayPointer]
+    const db = stubDb([GRNI_ACCOUNT], [])
+
+    expect(
+      (
+        await updateChartAccount(db, {
+          organizationId: ORG,
+          accountId: GRNI_ACCOUNT.id,
+          actorUserId: USER,
+          code: '2165',
+          name: 'GRNI renamed',
+        })
+      ).isOk()
+    ).toBe(true)
+    expect(h.updates).toHaveLength(1)
   })
 })
 

--- a/packages/lib/src/postings/__tests__/default-chart.test.ts
+++ b/packages/lib/src/postings/__tests__/default-chart.test.ts
@@ -138,17 +138,20 @@ describe('the union of every pack', () => {
   // somebody saying which pack. The core grew from 13 to 27 in brief 21 §4.2 -
   // fourteen role-less accounts (prepaid, two owner-equity, eleven operating
   // expenses) - and `payroll`, `fixed_assets` and `debt` arrived in the same
-  // pass. The number itself is not the point; being made to state it is.
-  it('totals fifty-eight accounts: twenty-seven core, then five, two, nine, four, five, three and three', () => {
+  // pass. `card_rail` then shrank from five to three on 2026-09-10, when
+  // `1210 Affirm Clearing` and `6105 Merchant Fees - Affirm` left with the
+  // `clearing_affirm` role: a default chart must not name a vendor.
+  // The number itself is not the point; being made to state it is.
+  it('totals fifty-six accounts: twenty-seven core, then three, two, nine, four, five, three and three', () => {
     expect(codesOf('core')).toHaveLength(27)
-    expect(codesOf('card_rail')).toHaveLength(5)
+    expect(codesOf('card_rail')).toHaveLength(3)
     expect(codesOf('prepayments')).toHaveLength(2)
     expect(codesOf('inventory')).toHaveLength(9)
     expect(codesOf('purchasing')).toHaveLength(4)
     expect(codesOf('payroll')).toHaveLength(5)
     expect(codesOf('fixed_assets')).toHaveLength(3)
     expect(codesOf('debt')).toHaveLength(3)
-    expect(DEFAULT_CHART_OF_ACCOUNTS).toHaveLength(58)
+    expect(DEFAULT_CHART_OF_ACCOUNTS).toHaveLength(56)
   })
 })
 
@@ -157,7 +160,7 @@ describe('the core', () => {
   // every one of these is reachable by an ENABLED posting type on any org that
   // sends an invoice, takes a payment, ships an order, issues a credit memo or
   // writes something off. Exact set.
-  it('carries exactly the eleven roles every org can reach', () => {
+  it('carries exactly the ten roles every org can reach', () => {
     expect([...rolesOf('core')].sort()).toEqual(
       [
         ACCOUNT_ROLES.UNDEPOSITED_FUNDS,
@@ -165,7 +168,6 @@ describe('the core', () => {
         ACCOUNT_ROLES.ACCOUNTS_PAYABLE,
         ACCOUNT_ROLES.SALES_TAX_PAYABLE,
         ACCOUNT_ROLES.EQUITY_RETAINED_EARNINGS,
-        ACCOUNT_ROLES.EQUITY_OPENING_BALANCE,
         ACCOUNT_ROLES.REVENUE_PRODUCT,
         ACCOUNT_ROLES.REVENUE_SHIPPING,
         ACCOUNT_ROLES.REVENUE_SERVICE,
@@ -257,14 +259,14 @@ describe('the other packs', () => {
     expect([...rolesOf('card_rail')].sort()).toEqual(
       [
         ACCOUNT_ROLES.CLEARING_CARD,
-        ACCOUNT_ROLES.CLEARING_AFFIRM,
         ACCOUNT_ROLES.UNIDENTIFIED_RECEIPTS,
         ACCOUNT_ROLES.PAYMENT_PROCESSING_FEES,
       ].sort()
     )
-    expect([...rolesOf('prepayments')].sort()).toEqual(
-      [ACCOUNT_ROLES.DEFERRED_REVENUE, ACCOUNT_ROLES.CUSTOMER_DEPOSITS].sort()
-    )
+    // `2300 Deferred Revenue` is in this pack and carries no role: the
+    // month-end deferral builder that would emit one was never written, so
+    // `deferred_revenue` was deleted on 2026-09-10.
+    expect([...rolesOf('prepayments')].sort()).toEqual([ACCOUNT_ROLES.CUSTOMER_DEPOSITS].sort())
     expect([...rolesOf('inventory')].sort()).toEqual(
       [
         ACCOUNT_ROLES.INVENTORY_RAW_MATERIALS,
@@ -334,16 +336,18 @@ describe('the other packs', () => {
 
   // Role-less is the ORDINARY case, not a gap, and it is not a core-only case
   // either: `5010`/`5030` ride with inventory because the P&L groups COGS by
-  // subtype, `6105` with the card rail because Affirm's fees clear `1210`
-  // (16 §1.6). Pinned so that a future edit that reflexively gives every
-  // account a role, or parks every role-less one in the core, has to argue
-  // with a test.
+  // subtype, and `2300`/`3900` are role-less in packs full of roles. Pinned so
+  // that a future edit that reflexively gives every account a role, or parks
+  // every role-less one in the core, has to argue with a test.
   it('leaves role-less accounts in more than one pack', () => {
     // Was an exact list of five. Brief 21 §4.2 made role-less the MAJORITY of
     // the chart - thirty of fifty-eight - so listing them all would pin nothing
     // but arithmetic. The five that were arguable when the packs were declared
     // are still pinned by code; the "no new roles" half is the test below.
-    for (const code of ['1000', '3000', '5010', '5030', '6105']) {
+    // `6105 Merchant Fees - Affirm` was in this list until 2026-09-10, when it
+    // left the chart with `1210` and the `clearing_affirm` role. `2300` and
+    // `3900` took its place: both kept their ACCOUNT and lost their role.
+    for (const code of ['1000', '3000', '5010', '5030', '2300', '3900']) {
       expect(byCode.get(code)?.role, code).toBeUndefined()
     }
     const packsWithRoleless = new Set(
@@ -352,7 +356,10 @@ describe('the other packs', () => {
     expect(packsWithRoleless.size).toBeGreaterThan(1)
     expect(packsWithRoleless).toContain('core')
     expect(packsWithRoleless).toContain('inventory')
-    expect(packsWithRoleless).toContain('card_rail')
+    // `card_rail` was here until 2026-09-10: its only role-less account was
+    // `6105`, which left the chart with `1210`. Every account it still carries
+    // bears a role. `prepayments` took its place, via role-less `2300`.
+    expect(packsWithRoleless).toContain('prepayments')
   })
 
   // 🛑 21 §9. `ACCOUNT_ROLES` is a closed vocabulary tied to builders: a role

--- a/packages/lib/src/postings/__tests__/gl-account-pointers.test.ts
+++ b/packages/lib/src/postings/__tests__/gl-account-pointers.test.ts
@@ -1,0 +1,189 @@
+// packages/lib/src/postings/__tests__/gl-account-pointers.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { RESOURCE_FIELD_REGISTRY } from '../../resources/registry/field-registry'
+import {
+  describeGlAccountPointers,
+  findGlAccountPointers,
+  GL_ACCOUNT_POINTER_ATTRIBUTES,
+  type GlAccountPointer,
+} from '../gl-account-pointers'
+
+/**
+ * Every registry attribute that LOOKS like a pointer at a `gl_account`: a TEXT
+ * field whose name ends in `_gl_account`, plus the two `payment_gateway`
+ * account fields, which are named for their ROLE on the gateway rather than for
+ * what they point at.
+ *
+ * 🛑 Deliberately not "anything ending in `_account`" - that sweeps in
+ * `*_bank_account`, which names a `bank_account` instance. Those are a
+ * different pointer with a different referent and wiping the CHART does not
+ * touch them.
+ */
+function registryPointerAttributes(): string[] {
+  const found = new Set<string>()
+  for (const fields of Object.values(RESOURCE_FIELD_REGISTRY)) {
+    for (const field of Object.values(fields ?? {})) {
+      const attribute = field?.systemAttribute
+      if (!attribute) continue
+      if (field.fieldType !== 'TEXT') continue
+      const isGlPointer = attribute.endsWith('_gl_account')
+      const isGatewayAccount =
+        attribute === 'payment_gateway_clearing_account' ||
+        attribute === 'payment_gateway_fee_account'
+      if (isGlPointer || isGatewayAccount) found.add(attribute)
+    }
+  }
+  return [...found].sort()
+}
+
+describe('GL_ACCOUNT_POINTER_ATTRIBUTES', () => {
+  // 🛑 THE point of this file. A pointer added to the registry and forgotten
+  // here is a field `chart-write.ts` will not refuse over and
+  // `reset-gl-chart.ts` will wipe straight through - which is exactly how a
+  // `payment_gateway` ended up naming an account that did not exist
+  // (2026-09-11). One row here is the whole fix; this test is what makes
+  // forgetting it loud.
+  it('covers every TEXT gl_account pointer in the registry', () => {
+    expect(Object.keys(GL_ACCOUNT_POINTER_ATTRIBUTES).sort()).toEqual(registryPointerAttributes())
+  })
+
+  it('names something human for each, so a refusal can say what to repoint', () => {
+    for (const [attribute, label] of Object.entries(GL_ACCOUNT_POINTER_ATTRIBUTES)) {
+      expect(label, attribute).toBeTruthy()
+      expect(label, attribute).not.toBe(attribute)
+    }
+  })
+
+  // The account's OWN attributes are not pointers at an account. Including one
+  // would make the chart refuse to remove every account in it.
+  it('excludes gl_account attributes and bank_account pointers', () => {
+    const keys = Object.keys(GL_ACCOUNT_POINTER_ATTRIBUTES)
+    expect(keys).not.toContain('gl_account_code')
+    expect(keys).not.toContain('gl_account_name')
+    expect(keys).not.toContain('gl_account_type')
+    expect(keys).not.toContain('bank_deposit_bank_account')
+    expect(keys).not.toContain('bank_transaction_bank_account')
+  })
+
+  it('includes the two payment_gateway accounts, which brief 13 §5.3 added', () => {
+    expect(Object.keys(GL_ACCOUNT_POINTER_ATTRIBUTES)).toEqual(
+      expect.arrayContaining(['payment_gateway_clearing_account', 'payment_gateway_fee_account'])
+    )
+  })
+})
+
+describe('findGlAccountPointers', () => {
+  /** A db stub that records the query and answers with `rows`. */
+  function stubDb(rows: unknown[]) {
+    const calls: { limit?: number } = {}
+    const chain = {
+      from: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      limit: (n: number) => {
+        calls.limit = n
+        return Promise.resolve(rows)
+      },
+    }
+    return { db: { select: () => chain } as never, calls }
+  }
+
+  it('asks nothing of the database for an empty account list', async () => {
+    let queried = false
+    const db = {
+      select: () => {
+        queried = true
+        return {}
+      },
+    } as never
+    expect(await findGlAccountPointers(db, 'org-1', [])).toEqual([])
+    expect(queried).toBe(false)
+  })
+
+  it('maps a row onto its human label', async () => {
+    const { db } = stubDb([
+      {
+        attribute: 'payment_gateway_clearing_account',
+        entityId: 'pg_1',
+        glAccountId: 'acct_1210',
+      },
+    ])
+    expect(await findGlAccountPointers(db, 'org-1', ['acct_1210'])).toEqual([
+      {
+        attribute: 'payment_gateway_clearing_account',
+        label: 'a payment gateway (clearing account)',
+        entityId: 'pg_1',
+        glAccountId: 'acct_1210',
+      },
+    ])
+  })
+
+  // Both columns are nullable in the schema even though the query filters on
+  // them. Dropping the row beats asserting and throwing inside a guard whose
+  // whole job is to refuse cleanly.
+  it('drops a row with no attribute or no id rather than throwing', async () => {
+    const { db } = stubDb([
+      { attribute: null, entityId: 'x', glAccountId: 'acct_1210' },
+      { attribute: 'bank_account_gl_account', entityId: 'y', glAccountId: null },
+      { attribute: 'bank_account_gl_account', entityId: 'z', glAccountId: 'acct_1210' },
+    ])
+    const found = await findGlAccountPointers(db, 'org-1', ['acct_1210'])
+    expect(found).toHaveLength(1)
+    expect(found[0]?.entityId).toBe('z')
+  })
+
+  it('caps the rows it reads - a refusal needs examples, not every row', async () => {
+    const { db, calls } = stubDb([])
+    await findGlAccountPointers(db, 'org-1', ['acct_1210'])
+    expect(calls.limit).toBe(5)
+    await findGlAccountPointers(db, 'org-1', ['acct_1210'], 500)
+    expect(calls.limit).toBe(500)
+  })
+
+  it('falls back to the raw attribute when one carries no label', async () => {
+    const { db } = stubDb([
+      { attribute: 'some_future_gl_account', entityId: 'q', glAccountId: 'acct_1210' },
+    ])
+    const found = await findGlAccountPointers(db, 'org-1', ['acct_1210'])
+    expect(found[0]?.label).toBe('some_future_gl_account')
+  })
+})
+
+describe('describeGlAccountPointers', () => {
+  const pointer = (label: string): GlAccountPointer => ({
+    attribute: 'x',
+    label,
+    entityId: 'e',
+    glAccountId: 'a',
+  })
+
+  it('is null for nothing, so a caller can treat it as the whole question', () => {
+    expect(describeGlAccountPointers([])).toBeNull()
+  })
+
+  it('names one', () => {
+    expect(describeGlAccountPointers([pointer('a payment gateway (clearing account)')])).toBe(
+      'a payment gateway (clearing account)'
+    )
+  })
+
+  // Two gateways pointing at one account is ORDINARY - the entity's own header
+  // says two rails can share a clearing account - so the sentence must not
+  // repeat itself.
+  it('collapses duplicates', () => {
+    expect(describeGlAccountPointers([pointer('a bank rule'), pointer('a bank rule')])).toBe(
+      'a bank rule'
+    )
+  })
+
+  it('joins several readably', () => {
+    expect(
+      describeGlAccountPointers([
+        pointer('a bank account'),
+        pointer('a bank rule'),
+        pointer('a stock movement'),
+      ])
+    ).toBe('a bank account, a bank rule and a stock movement')
+  })
+})

--- a/packages/lib/src/postings/build-entry.ts
+++ b/packages/lib/src/postings/build-entry.ts
@@ -74,16 +74,27 @@ import type { BuiltEntry, CounterpartyType, GlPostingLineInput, PostingType } fr
  * pinned to this constant by `__tests__/build-entry.test.ts`. There is no
  * options migration, because there are no options.
  *
- * ## Scope
+ * ## Scope: a role exists only if a builder emits it
  *
- * These thirteen cover what the code posts to today - the receipt and vendor
- * bill builders below - plus the L1 month-end inventory entry that is the
- * January 1 deliverable (`plans/money/04-books.md` §2.1). The designed-but-unbuilt
- * builders (fulfillment, payout, build, month-end deferral) will need roles for
- * revenue, the clearing accounts, sales tax, deferred revenue, merchant fees,
- * freight-out and receivables. Those are deliberately absent: their entries are
- * design only, which account each leg lands on is still open, and a role nothing
- * emits is a mapping a bookkeeper can make wrongly with no way to find out.
+ * That is the admission test, and it is the reason three roles were deleted on
+ * 2026-09-10 rather than left to sit on the checklist:
+ *
+ * | Deleted | Why |
+ * | --- | --- |
+ * | `deferred_revenue` | no builder, not even an unwired one. `2300` stays in the `prepayments` pack as a plain account. |
+ * | `equity_opening_balance` | `buildOpeningBalanceEntry` takes the account ids a person typed into the grid, so it emits no role at all. `3900` stays in the chart. |
+ * | `clearing_affirm` | a role must not name a vendor - see the two rules below. Affirm is a `payment_gateway` record now, and `1210` left the `card_rail` pack with it. |
+ *
+ * Four roles are declared with no reachable emitter, and they stay: `grni`,
+ * `freight_accrual` and `duties_accrual` are emitted by {@link buildReceiptEntry},
+ * `ppv` by {@link buildVendorBillEntry}. Both builders are written and tested;
+ * neither has a caller yet, because receiving does not post under L1 (see
+ * `regime.ts`). Deleting the roles would mean deleting the builders.
+ *
+ * 🛑 An unmapped role costs nothing until a builder emits it - `resolveRoles`
+ * fails closed and names it. So the argument for deleting one is never
+ * correctness; it is that every declared role is a row on a bookkeeper's
+ * checklist, and a row nothing can ever post to is a question with no answer.
  */
 /*
  * Two rules about what a role is NOT (brief 13 §2 and §5, 2026-09-10):
@@ -94,10 +105,11 @@ import type { BuiltEntry, CounterpartyType, GlPostingLineInput, PostingType } fr
  *   into or out of a bank account takes the `bank_account`'s own
  *   `glAccountId` and emits a `{ glAccountId }` line, the way the deposit does.
  * - **A gateway does not get a role, and a channel does not get an account.**
- *   `clearing_affirm` is the one exception and it is grandfathered; the third
- *   gateway is a `payment_gateway` record carrying its clearing account, and a
- *   channel is a `dimensions` entry on the revenue line, never a second
- *   revenue role.
+ *   There is no exception any more: `clearing_affirm` was the one, and it was
+ *   retired on 2026-09-10. EVERY gateway past the card rail is a
+ *   `payment_gateway` record carrying its own clearing account, Affirm
+ *   included, and a channel is a `dimensions` entry on the revenue line, never
+ *   a second revenue role.
  */
 export const ACCOUNT_ROLES = {
   /**
@@ -246,26 +258,6 @@ export const ACCOUNT_ROLES = {
    */
   CLEARING_CARD: 'clearing_card',
   /**
-   * Affirm clearing (default `1210`). The SECOND clearing rail, and it exists
-   * for one reason: an Affirm settlement never lands on the card rail, so it is
-   * invisible to the payouts API.
-   *
-   * 🛑 **Folding Affirm orders into `clearing_card` makes `1200` impossible to
-   * reconcile to zero.** The payout entry drains `clearing_card` by exactly what
-   * a card payout settled; an Affirm sale debited there would never be drained,
-   * and `1200` would carry a growing residual that balances perfectly and reads
-   * as unsettled card money. So the fulfillment builder's debit fork routes an
-   * `affirm` gateway here (`resolveFulfillmentDebit` in
-   * `build-fulfillment-batch-entry.ts`), and `PAYOUT_CLEARING_ROLES` excludes
-   * this role by construction.
-   *
-   * `6105 Merchant Fees - Affirm` is the matching expense account and stays
-   * role-less until an Affirm settlement feed exists to post against it.
-   *
-   * @see plans/money/tasks/49-bulk-fulfillment-posting.md §3.2, §8.4 decision 6
-   */
-  CLEARING_AFFIRM: 'clearing_affirm',
-  /**
    * Unidentified receipts (default `2450`). Money that arrived and auxx cannot
    * attribute, held as a LIABILITY until somebody codes it.
    *
@@ -285,8 +277,6 @@ export const ACCOUNT_ROLES = {
   UNIDENTIFIED_RECEIPTS: 'unidentified_receipts',
   /** Sales tax payable (default `2200`). A pass-through liability, never revenue. */
   SALES_TAX_PAYABLE: 'sales_tax_payable',
-  /** Deferred revenue (default `2300`). Month-end deferral and its reversal. */
-  DEFERRED_REVENUE: 'deferred_revenue',
   /**
    * Customer deposits (default `2350`). Money taken BEFORE delivery, a
    * liability. `money/payments/deposit.ts` is this concept; a BANK deposit is
@@ -299,12 +289,6 @@ export const ACCOUNT_ROLES = {
    * knowing the org's numbering.
    */
   EQUITY_RETAINED_EARNINGS: 'equity_retained_earnings',
-  /**
-   * Opening balance equity (default `3900`). The balancing leg of the opening
-   * trial balance entry (`opening_balance` posting type), and the only equity
-   * role a builder ever emits.
-   */
-  EQUITY_OPENING_BALANCE: 'equity_opening_balance',
   /**
    * Product revenue (default `4000`), every channel. The channel is a
    * `dimensions.channel` value on the line (brief 13 §5), never a second
@@ -395,13 +379,10 @@ export const ROLE_ACCOUNT_TYPES: Record<AccountRole, GlAccountTypeValue> = {
   accounts_receivable: 'asset',
   undeposited_funds: 'asset',
   clearing_card: 'asset',
-  clearing_affirm: 'asset',
   unidentified_receipts: 'liability',
   sales_tax_payable: 'liability',
-  deferred_revenue: 'liability',
   customer_deposits: 'liability',
   equity_retained_earnings: 'equity',
-  equity_opening_balance: 'equity',
   revenue_product: 'revenue',
   revenue_shipping: 'revenue',
   revenue_service: 'revenue',
@@ -436,13 +417,10 @@ export const ACCOUNT_ROLE_LABELS: Record<AccountRole, string> = {
   accounts_receivable: 'Accounts Receivable',
   undeposited_funds: 'Undeposited Funds',
   clearing_card: 'Card Clearing',
-  clearing_affirm: 'Affirm Clearing',
   unidentified_receipts: 'Unidentified Receipts',
   sales_tax_payable: 'Sales Tax Payable',
-  deferred_revenue: 'Deferred Revenue',
   customer_deposits: 'Customer Deposits',
   equity_retained_earnings: 'Retained Earnings',
-  equity_opening_balance: 'Opening Balance Equity',
   revenue_product: 'Product Revenue',
   revenue_shipping: 'Shipping Revenue',
   revenue_service: 'Service Revenue',

--- a/packages/lib/src/postings/build-fulfillment-batch-entry.ts
+++ b/packages/lib/src/postings/build-fulfillment-batch-entry.ts
@@ -4,13 +4,12 @@
  * ONE fulfillment entry for a whole day, week or month of shipments.
  *
  * PURE. No database, no clock, no chart - the property every builder in this
- * folder has, and here it is what lets a mixed group of card, Affirm, terms and
- * tax-exempt orders be balanced exhaustively in a unit test.
+ * folder has, and here it is what lets a mixed group of card, routed-gateway,
+ * terms and tax-exempt orders be balanced exhaustively in a unit test.
  *
  * ```
  *   Dr accounts_receivable   ONE LINE PER ORDER   that order's terms shipments
  *   Dr clearing_card         summarised           every card shipment's total
- *   Dr clearing_affirm       summarised           every Affirm shipment's total
  *   Dr <gateway's own account>  summarised, per id  every routed-gateway shipment's total
  *       Cr revenue_product   summarised, per channel dimension  Σ subtotal
  *       Cr sales_tax_payable summarised, per jurisdiction dimension (when it ties)  Σ tax
@@ -112,22 +111,38 @@ const TEST_GATEWAY = 'bogus'
 const MANUAL_GATEWAY = 'manual'
 
 /**
- * Which clearing account each named gateway settles into. DECLARED.
+ * Which clearing account each named gateway settles into BY ROLE. DECLARED.
  *
- * Only gateways whose answer is NOT the card rail need a row: everything else
- * (PayPal, Stripe, Shop Pay, a gateway nobody has seen yet) settles as card
- * money into `clearing_card`, which is the account a payout entry drains.
+ * Only gateways whose answer is NOT the card rail would need a row, and since
+ * 2026-09-10 there are none: everything (PayPal, Stripe, Shop Pay, a gateway
+ * nobody has seen yet) settles as card money into `clearing_card`, which is the
+ * account a payout entry drains.
  *
- * 🛑 `affirm` is the row that matters. An Affirm settlement never lands on the
- * card rail and is invisible to the payouts API, so an Affirm sale debited to
- * `clearing_card` leaves that account with a residual no payout can ever
- * relieve - it balances, and `1200` simply stops reconciling to zero.
+ * 🛑 **`affirm` used to be the row that matters, and it is now a
+ * `payment_gateway` record instead.** The fact behind it is unchanged: an
+ * Affirm settlement never lands on the card rail and is invisible to the
+ * payouts API, so an Affirm sale debited to `clearing_card` leaves that account
+ * with a residual no payout can ever relieve - it balances, and `1200` simply
+ * stops reconciling to zero. What changed is WHERE the exclusion is declared. A
+ * role named a vendor, which `build-entry.ts` forbids; a record does not, and
+ * {@link matchGatewayRoute} routes the gateway to that record's own account by
+ * id before this table is ever consulted. The safety property survives because
+ * an id-routed debit is not `clearing_card` and `PAYOUT_CLEARING_ROLES` drains
+ * `clearing_card` alone.
+ *
+ * ⚠️ **An Affirm store with no `payment_gateway` record falls through to
+ * `clearing_card` and the residual comes back.** That is the cost of deleting
+ * the role, it is the same cost Authorize.Net has always carried, and the
+ * gateway settings page is where it is paid.
+ *
+ * The table is kept - rather than collapsed into the `clearing_card` default -
+ * because it is the declaration site a future non-card rail would be added to
+ * if one ever earns a role rather than a record.
  */
 export const FULFILLMENT_GATEWAY_DEBIT: Readonly<
   Record<string, Exclude<FulfillmentDebitRole, 'gateway'>>
 > = {
   shopify_payments: 'clearing_card',
-  affirm: 'clearing_affirm',
 }
 
 /**
@@ -500,7 +515,6 @@ export const FULFILLMENT_DEBIT_ACCOUNT_ROLE: Readonly<
   Record<Exclude<FulfillmentDebitRole, 'gateway'>, AccountRole>
 > = {
   clearing_card: ACCOUNT_ROLES.CLEARING_CARD,
-  clearing_affirm: ACCOUNT_ROLES.CLEARING_AFFIRM,
   accounts_receivable: ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE,
 }
 
@@ -560,8 +574,8 @@ function assertWholeMinor(value: number, label: string, context: Record<string, 
  * 1. `Dr accounts_receivable`, **one line per order**, `sourceType: 'order'`,
  *    `sourceId: <orderId>`, memo `<orderNumber>`. Aging has to name the debtor,
  *    and `listPostingsForSource` on an order still finds this one.
- * 2. `Dr clearing_card`, `Dr clearing_affirm`, `Dr <gateway route's account>` -
- *    summarised, the last one per distinct account id (brief 13 §5.3).
+ * 2. `Dr clearing_card` and `Dr <gateway route's account>` - summarised, the
+ *    second one per distinct account id (brief 13 §5.3).
  * 3. `Cr revenue_product` - summarised PER CHANNEL, one line per
  *    `dimensions.channel` value, through the fail-open {@link CHANNEL_KEYS}
  *    table (brief 13 §5).
@@ -600,7 +614,6 @@ export function buildFulfillmentBatchEntry(
   >()
   const byDebitRole: Record<FulfillmentDebitRole, number> = {
     clearing_card: 0,
-    clearing_affirm: 0,
     accounts_receivable: 0,
     gateway: 0,
   }
@@ -746,15 +759,6 @@ export function buildFulfillmentBatchEntry(
       direction: 'debit',
       amount: byDebitRole.clearing_card,
       memo: describe('card clearing'),
-    })
-  }
-  if (byDebitRole.clearing_affirm !== 0) {
-    push({
-      ...summarised,
-      accountRole: ACCOUNT_ROLES.CLEARING_AFFIRM,
-      direction: 'debit',
-      amount: byDebitRole.clearing_affirm,
-      memo: describe('Affirm clearing'),
     })
   }
   for (const [glAccountId, amount] of byGatewayAccount) {

--- a/packages/lib/src/postings/build-payment-entry.ts
+++ b/packages/lib/src/postings/build-payment-entry.ts
@@ -68,15 +68,16 @@
  *    the one that knows what it is posting. See
  *    {@link BuildPaymentEntryInput.postingType}.
  * 2. **Which clearing account.** A `PaymentRoute` is a payment METHOD, and
- *    `'clearing'` maps to `clearing_card` (`1200`). ⚠️ `ACCOUNT_ROLES` gained a
- *    second clearing role, `clearing_affirm` (`1210`), for the fulfillment
- *    debit fork (49 §8.4 decision 6) - and this table still cannot reach it,
- *    because a method does not say which gateway took the money. Affirm
- *    settlements are invisible to the payouts API, so an Affirm charge routed to
+ *    `'clearing'` maps to `clearing_card` (`1200`) - the only clearing ROLE
+ *    there is. ⚠️ It cannot reach a non-card rail, because a method does not say
+ *    which gateway took the money, and a non-card rail has no role to reach:
+ *    it is a `payment_gateway` record carrying its own clearing account
+ *    (`clearing_affirm` was deleted on 2026-09-10). That matters because such a
+ *    settlement is invisible to the payouts API, so a charge on one routed to
  *    `1200` makes that account impossible to reconcile to zero. When a payment
- *    has to tell the two apart, {@link PAYMENT_ROUTE_ROLE} grows a discriminator
- *    on the GATEWAY rather than on the method, the way `resolveFulfillmentDebit`
- *    already does.
+ *    has to tell them apart, {@link PAYMENT_ROUTE_ROLE} grows a discriminator on
+ *    the GATEWAY rather than on the method, resolving to a record's account id
+ *    the way `resolveFulfillmentDebit` already does.
  * 3. **Which bank account.** A bank account is not a role (brief 13 §2), so the
  *    `cash` row of {@link PAYMENT_ROUTE_ROLE} carries no role to look up - the
  *    caller resolves `accounting.cashBankAccountId` to a `gl_account` id and

--- a/packages/lib/src/postings/build-payout-entry.ts
+++ b/packages/lib/src/postings/build-payout-entry.ts
@@ -106,13 +106,20 @@ export const PAYOUT_SOURCE_TYPE = 'payout'
 /**
  * The clearing roles a payout may drain. `clearing_card`, and only ever that.
  *
- * 🛑 **`clearing_affirm` is excluded BY CONSTRUCTION, not by omission.** An
+ * 🛑 **Every non-card rail is excluded BY CONSTRUCTION, not by omission.** An
  * Affirm settlement never lands on the card rail, so it is invisible to the
- * payouts API and no payout can ever relieve `1210` (accrual plan §3, 49 §3.2).
- * Adding the role here would let a card payout drain an account its deposit
- * never touched: the entry would balance, `1210` would go negative by the
- * Affirm sales it was holding, and nothing downstream could detect it. Affirm
- * clears when an Affirm settlement feed exists, through its own entry.
+ * payouts API and no payout can ever relieve the account holding it (accrual
+ * plan §3, 49 §3.2). Widening this list would let a card payout drain an
+ * account its deposit never touched: the entry would balance, that account
+ * would go negative by the sales it was holding, and nothing downstream could
+ * detect it.
+ *
+ * This list is roles, and a non-card rail no longer HAS a role - it is a
+ * `payment_gateway` record whose clearing account the fulfillment entry debits
+ * by id (`clearing_affirm` was deleted on 2026-09-10). So the exclusion is now
+ * structural rather than a name left off a list: an id-routed debit is not
+ * `clearing_card`, and `clearing_card` is the only thing here. Each such rail
+ * clears when a settlement feed for it exists, through its own entry.
  */
 export const PAYOUT_CLEARING_ROLES: readonly AccountRole[] = [ACCOUNT_ROLES.CLEARING_CARD]
 

--- a/packages/lib/src/postings/chart-import-plan.ts
+++ b/packages/lib/src/postings/chart-import-plan.ts
@@ -44,7 +44,10 @@ export const ROLE_IMPORT_MATCH: Partial<
   undeposited_funds: { names: ['Undeposited Funds'] },
   sales_tax_payable: { names: ['Sales Tax Payable'] },
   equity_retained_earnings: { names: ['Retained Earnings'] },
-  equity_opening_balance: { names: ['Opening Balance Equity'] },
+  // 🛑 No `equity_opening_balance` row: the role was deleted on 2026-09-10
+  // because no builder emitted it. `3900 Opening Balance Equity` still arrives
+  // from QuickBooks and still lands in the chart - it just carries no role, so
+  // there is nothing here to match it to.
   bad_debt_expense: { names: ['Bad Debt', 'Bad Debts', 'Bad Debt Expense'] },
 }
 

--- a/packages/lib/src/postings/chart-write.ts
+++ b/packages/lib/src/postings/chart-write.ts
@@ -69,6 +69,7 @@ import {
   readChartAccountValues,
 } from './chart-accounts'
 import type { GlAccountTypeValue } from './default-chart'
+import { describeGlAccountPointers, findGlAccountPointers } from './gl-account-pointers'
 import type { ChartAccountRow } from './types'
 
 const logger = createScopedLogger('postings:chart-write')
@@ -258,6 +259,7 @@ export async function updateChartAccount(
           'deactivate',
           'Reactivating it later is a click; a refused close is not.'
         )
+        await assertNoPointer(db, organizationId, accountId, account, 'deactivate')
       }
       values.gl_account_is_active = options.isActive
     }
@@ -321,6 +323,9 @@ export async function removeChartAccount(
       'remove',
       'A role pointing at a removed account fails the close closed, naming the role.'
     )
+
+    // ── I4: removing an account a TEXT pointer still names ───────────────────
+    await assertNoPointer(db, organizationId, accountId, account, 'remove')
 
     const handler = crudHandler(db, organizationId, actorUserId)
     await handler.archive(toRecordId(defId, accountId))
@@ -659,6 +664,54 @@ async function liveRolesFor(
  * standard the role map's refusals already set - "Could not save" throws away the
  * only sentence that says what to do.
  */
+/**
+ * Refuse while a `payment_gateway`, bank account, rule or line still NAMES this
+ * account (I4).
+ *
+ * 🛑 **The sibling of {@link assertNoLiveRole}, and it exists because that one
+ * is not enough.** `assertNoLiveRole` reads `GlRoleAssignment`, which is the
+ * only pointer the chart used to have. Since brief 13 §5.3 a `payment_gateway`
+ * carries its own clearing account, and task 15 gave bank accounts, rules,
+ * transactions, stock movements and vendor bill lines the same shape - eight
+ * fields holding a `gl_account` id, none of them a role and none of them a
+ * relationship.
+ *
+ * Removing here is an ARCHIVE, and every reader of the chart excludes archived
+ * rows in the query, so an archived account reads to `loadChartAccountsById` as
+ * *missing*. A gateway left naming one therefore fails at POST time with
+ * "the chart has no active account with id ...", which is a refused close
+ * standing in for a refused click - the trade `assertNoLiveRole`'s own comment
+ * describes, made once more.
+ *
+ * ⚠️ This became reachable for `1210 Affirm Clearing` on 2026-09-10, when
+ * `clearing_affirm` was deleted: the role had been doing double duty, routing
+ * Affirm money AND protecting its account from removal. Moving the routing to a
+ * `payment_gateway` record moved the first and silently dropped the second.
+ * That is the bug this guard closes.
+ */
+async function assertNoPointer(
+  db: Database,
+  organizationId: string,
+  accountId: string,
+  account: ChartAccountRow,
+  verb: 'deactivate' | 'remove'
+): Promise<void> {
+  const pointers = await findGlAccountPointers(db, organizationId, [accountId])
+  const named = describeGlAccountPointers(pointers)
+  if (!named) return
+
+  throw new UnprocessableEntityError(
+    `Cannot ${verb} ${accountLabel(account)}: ${named} still points at it. ` +
+      `Repoint it first - an account that is ${verb === 'remove' ? 'removed' : 'inactive'} reads as missing to ` +
+      'every chart reader, so the next posting that needs it refuses.',
+    {
+      organizationId,
+      accountId,
+      pointers: pointers.map((pointer) => `${pointer.attribute}:${pointer.entityId}`).join(','),
+    }
+  )
+}
+
 async function assertNoLiveRole(
   db: Database,
   organizationId: string,

--- a/packages/lib/src/postings/default-chart.ts
+++ b/packages/lib/src/postings/default-chart.ts
@@ -165,11 +165,10 @@ export interface ChartPack {
 //   the role, a manual journal to a payable by id is ordinary bookkeeping, and
 //   every business owes somebody. Its subtype is what the QuickBooks seam uses
 //   to demand a vendor on the line (13 §1).
-// - `3900 Opening Balance Equity`: no builder emits the role and nothing reads
-//   it, but the opening trial-balance grid needs the account to balance
-//   against and QuickBooks has the account of the same name. The role stays
-//   because the vocabulary is closed and a role no pack carried would fail the
-//   union test.
+// - `3900 Opening Balance Equity`: the opening trial-balance grid needs an
+//   account to balance against and QuickBooks has one of the same name. It
+//   carries NO role - `equity_opening_balance` was deleted on 2026-09-10, since
+//   no builder emitted it and nothing read it.
 // - `4000`, `4020`: `fulfillment` is enabled for every org and drops a zero
 //   shipping leg, so an org that never ships simply never posts to them.
 // - `6300`, `4090`, `4020`: one account each, driven by enabled types every org
@@ -300,10 +299,14 @@ const CORE_ACCOUNTS: readonly DefaultChartAccount[] = [
     // The balancing leg of the opening entry. A bookkeeper clears it to 3000
     // or 3100 with a manual journal once the opening balances are agreed -
     // exactly what QuickBooks does with the account of the same name.
+    //
+    // 🛑 Role-less since 2026-09-10. `buildOpeningBalanceEntry` takes the
+    // account ids a person typed into the trial-balance grid, so it never
+    // emitted `equity_opening_balance` and nothing ever read it. The account
+    // does the work; the role was decoration.
     code: '3900',
     name: 'Opening Balance Equity',
     accountType: GlAccountType.EQUITY,
-    role: 'equity_opening_balance',
   },
 
   // ── Revenue ─────────────────────────────────────────────────────────────
@@ -458,13 +461,22 @@ const CORE_ACCOUNTS: readonly DefaultChartAccount[] = [
 ]
 
 // ─────────────────────────────────────────────────────────────────────────────
-// card_rail: Stripe Connect, Shopify Payments, Affirm (16 §1.4)
+// card_rail: Stripe Connect, Shopify Payments (16 §1.4)
 // ─────────────────────────────────────────────────────────────────────────────
 //
 // `seedDefaultPaymentGateways` runs after this pack, never after the core: the
-// two default gateway records point at `clearing_card` / `clearing_affirm`,
-// which only exist once this pack has landed (13 §5.3, 16 §1.5). `6105` rides
-// with the rail because Affirm's fees clear `1210` (16 §1.6).
+// default gateway record points at `clearing_card`, which only exists once this
+// pack has landed (13 §5.3, 16 §1.5).
+//
+// 🛑 **Affirm is not in here, and no rail past the card rail ever will be.**
+// `1210 Affirm Clearing` and `6105 Merchant Fees - Affirm` were removed on
+// 2026-09-10 along with the `clearing_affirm` role: a default chart every org
+// gets must not name a vendor most of them have never heard of. Affirm is now
+// what Authorize.Net already was - a rail the merchant ADDS, as a
+// `payment_gateway` record pointing at a clearing account they create. The
+// exclusion from `1200` still happens, and still mechanically: an id-routed
+// gateway debit never reaches `clearing_card`, which is the only role
+// `PAYOUT_CLEARING_ROLES` drains.
 const CARD_RAIL_ACCOUNTS: readonly DefaultChartAccount[] = [
   {
     // Named for the RAIL. Was `Shopify Clearing` / `clearing_shopify` until
@@ -475,21 +487,6 @@ const CARD_RAIL_ACCOUNTS: readonly DefaultChartAccount[] = [
     name: 'Card Clearing',
     accountType: GlAccountType.ASSET,
     role: 'clearing_card',
-  },
-  {
-    // Must EXCLUDE every Affirm-gateway order or 1200 can never reconcile to
-    // zero: an Affirm settlement never lands on the card rail, so it is
-    // invisible to the payouts API (accrual plan §3).
-    //
-    // The role is what makes that exclusion mechanical rather than a rule
-    // somebody has to remember: the fulfillment debit fork routes an `affirm`
-    // gateway to `clearing_affirm`, and `PAYOUT_CLEARING_ROLES` holds
-    // `clearing_card` alone (49 §3.2, §8.4 decision 6). Entity migration 137
-    // stamps this role onto orgs seeded before it existed.
-    code: '1210',
-    name: 'Affirm Clearing',
-    accountType: GlAccountType.ASSET,
-    role: 'clearing_affirm',
   },
   {
     // Money that arrived and auxx cannot attribute. The payout entry's fourth
@@ -511,14 +508,6 @@ const CARD_RAIL_ACCOUNTS: readonly DefaultChartAccount[] = [
     accountType: GlAccountType.EXPENSE,
     role: 'payment_processing_fees',
   },
-  {
-    // Kept separate from 6100 for RECONCILIATION, not optimisation: Affirm
-    // settles in its own deposit, so its fees have to be separable to clear
-    // 1210 (accrual plan §3).
-    code: '6105',
-    name: 'Merchant Fees - Affirm',
-    accountType: GlAccountType.EXPENSE,
-  },
 ]
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -526,11 +515,14 @@ const CARD_RAIL_ACCOUNTS: readonly DefaultChartAccount[] = [
 // ─────────────────────────────────────────────────────────────────────────────
 const PREPAYMENTS_ACCOUNTS: readonly DefaultChartAccount[] = [
   {
+    // 🛑 Role-less. `deferred_revenue` was deleted on 2026-09-10: the month-end
+    // deferral builder that would have emitted it was never written, and a role
+    // nothing emits is a checklist row with no answer. The ACCOUNT is real and
+    // stays - a manual journal defers revenue to it by id, which is ordinary
+    // bookkeeping. Give it a role again when a builder needs one.
     code: '2300',
     name: 'Deferred Revenue',
     accountType: GlAccountType.LIABILITY,
-    // Month-end only, reversed on day one of the next month.
-    role: 'deferred_revenue',
   },
   {
     // Money taken BEFORE delivery - `money/payments/deposit.ts`. A BANK deposit

--- a/packages/lib/src/postings/gl-account-pointers.ts
+++ b/packages/lib/src/postings/gl-account-pointers.ts
@@ -1,0 +1,155 @@
+// packages/lib/src/postings/gl-account-pointers.ts
+
+/**
+ * Every registry field that holds a `gl_account` EntityInstance id **as TEXT**,
+ * and the read that finds what is pointing at one account.
+ *
+ * ## Why this file has to exist
+ *
+ * Task 15 decided these pointers are plain `text()` with no `references()` -
+ * the shape `GlRoleAssignment.glAccountId` and `GlPostingLine.glAccountId`
+ * already use, so a posted line outlives the chart row it was posted against
+ * and a renumber restates nothing (`bank-account-fields.ts`, DECIDED
+ * 2026-09-09). That decision is sound and this file does not reopen it.
+ *
+ * 🛑 What the decision costs is that **the id lives in `FieldValue.valueText`,
+ * not in `FieldValue.relatedEntityId`** - so every guard written against the
+ * relationship column is blind to all of them. Two such guards existed and both
+ * were blind:
+ *
+ *  - `scripts/reset-gl-chart.ts` refuses to wipe a chart anything points at,
+ *    and queried `relatedEntityId` only. It wiped a referenced chart on
+ *    2026-09-11, reported success, and left `payment_gateway.clearingAccount`
+ *    naming an id that existed nowhere. The next fulfillment post refused.
+ *  - `chart-write.ts`'s `assertNoLiveRole` refuses to remove or deactivate an
+ *    account a ROLE points at, and reads `GlRoleAssignment` only. Nothing
+ *    stopped a person removing an account a payment gateway or a bank account
+ *    named.
+ *
+ * Both now go through {@link findGlAccountPointers}, so a pointer added to the
+ * registry is protected by adding one row to {@link GL_ACCOUNT_POINTER_ATTRIBUTES}
+ * rather than by remembering two call sites.
+ *
+ * ⚠️ **This is not a substitute for the read-time check.** Nothing here makes a
+ * dangling id impossible - a direct SQL delete still produces one, and
+ * `resolveAccountLines` still has to fail closed on it. This closes the doors
+ * auxx itself owns.
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+
+/**
+ * The `systemAttribute` of every TEXT field holding a `gl_account` id, with the
+ * human name of what carries it.
+ *
+ * 🛑 **Add a row here when the registry gains a pointer.** The coverage test in
+ * `__tests__/gl-account-pointers.test.ts` walks the registry for TEXT fields
+ * whose attribute ends in `_gl_account`, plus the two `payment_gateway` account
+ * fields (named for their ROLE on the gateway rather than for what they point
+ * at), and fails when one is missing - so this cannot silently fall behind.
+ *
+ * Deliberately NOT here:
+ *
+ * - `gl_account_code` / `gl_account_name` / `gl_account_type` - attributes OF an
+ *   account, not pointers AT one.
+ * - `*_bank_account` (`bank_deposit_bank_account`, `bank_rule_bank_account`,
+ *   `bank_rule_counterpart_bank_account`, `bank_transaction_bank_account`) -
+ *   these name a `bank_account` instance, not a `gl_account`. A bank account's
+ *   own `bank_account_gl_account` is the pointer, and it IS here.
+ */
+export const GL_ACCOUNT_POINTER_ATTRIBUTES: Readonly<Record<string, string>> = {
+  bank_account_gl_account: 'a bank account',
+  bank_rule_gl_account: 'a bank rule',
+  bank_transaction_gl_account: 'a bank transaction',
+  bank_transaction_suggested_gl_account: 'a bank transaction suggestion',
+  payment_gateway_clearing_account: 'a payment gateway (clearing account)',
+  payment_gateway_fee_account: 'a payment gateway (fee account)',
+  stock_movement_gl_account: 'a stock movement',
+  vendor_bill_line_gl_account: 'a vendor bill line',
+}
+
+/** One thing found pointing at an account. */
+export interface GlAccountPointer {
+  /** The `systemAttribute` that holds the id. */
+  attribute: string
+  /** What carries it, in words - {@link GL_ACCOUNT_POINTER_ATTRIBUTES}'s value. */
+  label: string
+  /** The `EntityInstance` doing the pointing. */
+  entityId: string
+  /** Which account of `accountIds` it names. */
+  glAccountId: string
+}
+
+/**
+ * Everything in this org pointing at any of `accountIds`, through a TEXT field.
+ *
+ * One query, whatever the number of accounts: the pointer fields are found by
+ * `systemAttribute` across every definition the org has, then matched against
+ * the ids in the same statement. Never per-account, because the chart wipe asks
+ * about a hundred accounts at once.
+ *
+ * ⚠️ **Archived pointers count.** An archived `bank_transaction` still holds
+ * the id, and un-archiving it after the account went would resurrect exactly
+ * the dangling state this exists to prevent. A caller that genuinely wants live
+ * rows only must filter the result itself.
+ *
+ * @param limit caps the rows returned - a refusal needs a few examples and a
+ *   count, never every row. Pass a larger number to enumerate.
+ */
+export async function findGlAccountPointers(
+  db: Database,
+  organizationId: string,
+  accountIds: readonly string[],
+  limit = 5
+): Promise<GlAccountPointer[]> {
+  if (accountIds.length === 0) return []
+
+  const attributes = Object.keys(GL_ACCOUNT_POINTER_ATTRIBUTES)
+
+  const rows = await db
+    .select({
+      attribute: schema.CustomField.systemAttribute,
+      entityId: schema.FieldValue.entityId,
+      glAccountId: schema.FieldValue.valueText,
+    })
+    .from(schema.FieldValue)
+    .innerJoin(schema.CustomField, eq(schema.CustomField.id, schema.FieldValue.fieldId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.CustomField.systemAttribute, attributes),
+        inArray(schema.FieldValue.valueText, [...accountIds])
+      )
+    )
+    .limit(limit)
+
+  return rows.flatMap((row) => {
+    // Both columns are nullable in the schema and neither can be null here -
+    // the `inArray`s filtered on them. Narrowed rather than asserted.
+    if (!row.attribute || !row.glAccountId) return []
+    return [
+      {
+        attribute: row.attribute,
+        label: GL_ACCOUNT_POINTER_ATTRIBUTES[row.attribute] ?? row.attribute,
+        entityId: row.entityId,
+        glAccountId: row.glAccountId,
+      },
+    ]
+  })
+}
+
+/**
+ * The refusal sentence for a set of pointers, or null when there are none.
+ *
+ * Names WHAT points here rather than only that something does: "a payment
+ * gateway (clearing account)" sends somebody to a screen, "this account is in
+ * use" sends them to the logs.
+ */
+export function describeGlAccountPointers(pointers: readonly GlAccountPointer[]): string | null {
+  if (pointers.length === 0) return null
+  const labels = [...new Set(pointers.map((pointer) => pointer.label))]
+  return labels.length === 1
+    ? (labels[0] ?? null)
+    : `${labels.slice(0, -1).join(', ')} and ${labels.at(-1)}`
+}

--- a/packages/lib/src/resources/registry/resources/payment-gateway-fields.ts
+++ b/packages/lib/src/resources/registry/resources/payment-gateway-fields.ts
@@ -16,12 +16,13 @@ import type { ResourceField } from '../field-types'
  *
  * `13` §5.1's gateway census counted eleven distinct handles across five card
  * rails on one store's history, and the pattern that had already been applied
- * once (`clearing_affirm`, entity migration 137) does not survive a second
+ * once (`clearing_affirm`, entity migration 137) did not survive a second
  * application: role-per-gateway costs a role, an account and a chart migration
  * per rail, and a rail is not permanent (the store cut over from
  * Authorize.Net to Shopify Payments mid-book). A `payment_gateway` record is a
  * ROW instead: a gateway is a fact about the business, never a function the
- * chart has to grow a role for.
+ * chart has to grow a role for. `clearing_affirm` was retired into a record on
+ * 2026-09-10 and `ACCOUNT_ROLES` now names no gateway at all.
  *
  * 🛑 **This does NOT mint an account per gateway.** {@link clearingAccount} and
  * {@link feeAccount} name WHICH account a gateway settles into; two rails

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -288,10 +288,10 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // which creates the `order` and `line_item` defs it widens, and after 108,
   // which owns the chart `4090 Sales Returns and Allowances` is added to.
   migration136RefundsAndTaxLines,
-  // The sales channel's per-line fulfillment rollup, natively, plus the
-  // clearing_affirm role on 1210 (49 §8.4 decisions 4 and 6). MUST sort after
-  // 107, which creates the `line_item` def it widens, and after 108, which owns
-  // the chart account it stamps.
+  // The sales channel's per-line fulfillment rollup, natively (49 §8.4
+  // decision 4). MUST sort after 107, which creates the `line_item` def it
+  // widens. Its second half - a clearing_affirm role on 1210 - was removed with
+  // the role on 2026-09-10, so it no longer depends on 108.
   migration137FulfillmentFacts,
   // Backfills the bookkeeper system permission profile into every existing org
   // (plans/accounting/tasks/12-accountant-permissions.md §4.2, §6). Leaves a

--- a/packages/lib/src/seed/entity-migrations/migrations/125-accounting-books.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/125-accounting-books.test.ts
@@ -95,11 +95,16 @@ describe('the chart carries what step 1 seeds', () => {
     expect(byCode.get(RECEIVABLE_CODE)?.role).toBe(ACCOUNT_ROLES.ACCOUNTS_RECEIVABLE)
   })
 
-  it('puts the two equity roles on equity accounts and leaves 3000 role-less', () => {
+  it('puts the one equity role on an equity account and leaves 3000 and 3900 role-less', () => {
     expect(byCode.get('3100')?.role).toBe(ACCOUNT_ROLES.EQUITY_RETAINED_EARNINGS)
-    expect(byCode.get('3900')?.role).toBe(ACCOUNT_ROLES.EQUITY_OPENING_BALANCE)
     expect(byCode.get('3000')?.accountType).toBe('equity')
     expect(byCode.get('3000')?.role).toBeUndefined()
+    // `3900` carried `equity_opening_balance` until 2026-09-10. The ACCOUNT is
+    // what the opening trial-balance grid balances against and it stays;
+    // `buildOpeningBalanceEntry` takes the ids a person typed, so it never
+    // emitted the role and nothing ever read it.
+    expect(byCode.get('3900')?.accountType).toBe('equity')
+    expect(byCode.get('3900')?.role).toBeUndefined()
   })
 
   it('routes cheques through undeposited funds and fees through 6100', () => {

--- a/packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.test.ts
@@ -25,9 +25,13 @@ describe('migration 137 registration', () => {
     expect(migration137FulfillmentFacts.id).toBe('137-fulfillment-facts')
   })
 
-  it('names both halves of what it does in its description', () => {
+  it('names what it does in its description, and no longer a role it dropped', () => {
     expect(migration137FulfillmentFacts.description).toContain('line_item_fulfilled_at')
-    expect(migration137FulfillmentFacts.description).toContain('clearing_affirm')
+    // It stamped a `clearing_affirm` role onto 1210 until 2026-09-10. The role
+    // was deleted (a role may not name a vendor) and that half went with it;
+    // the migration was edited in place rather than compensated, which is only
+    // safe because accounting has never been deployed.
+    expect(migration137FulfillmentFacts.description).not.toContain('clearing_affirm')
   })
 })
 

--- a/packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.ts
@@ -1,8 +1,7 @@
 // packages/lib/src/seed/entity-migrations/migrations/137-fulfillment-facts.ts
 
-import { type Database, schema } from '@auxx/database'
+import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
 import { getOrgCache } from '../../../cache'
 import type { ResourceField } from '../../../resources/registry/field-types'
 import { LINE_ITEM_FIELDS } from '../../../resources/registry/resources/line-item-fields'
@@ -14,32 +13,13 @@ const logger = createScopedLogger('entity-migrations:137')
 /** The def the three fulfillment facts land on. Created by migration 107. */
 const LINE_ITEM_ENTITY_TYPE = 'line_item'
 
-/** The def the chart lives on. Created by migration 108. */
-const GL_ACCOUNT_ENTITY_TYPE = 'gl_account'
-
 /** The registry keys this migration adds. Their attributes are in the JSDoc below. */
 const LINE_ITEM_KEYS = ['fulfilledAt', 'fulfilledQty', 'shipmentCount'] as const
 
-/** The Affirm clearing account. `1210` is what a person recognises, not the name. */
-const AFFIRM_CLEARING_CODE = '1210'
-
 /**
- * `ACCOUNT_ROLES.CLEARING_AFFIRM`, as a literal.
+ * Migration 137: the sales channel's per-line fulfillment rollup, natively.
  *
- * The constant is being added to `postings/build-entry.ts` in the same batch of
- * work, and a migration that imports a constant it landed alongside stops being
- * self-sufficient the moment somebody edits that constant: the STRING is what is
- * stored in `GlRoleAssignment.role`, and a stored string must never move because
- * an unrelated rename happened years later. `132-card-clearing-rename.ts` holds
- * its two role names the same way and for the same reason.
- */
-const CLEARING_AFFIRM_ROLE = 'clearing_affirm'
-
-/**
- * Migration 137: the sales channel's per-line fulfillment rollup, natively, and
- * the Affirm clearing role.
- *
- * `plans/money/tasks/49-bulk-fulfillment-posting.md` §8.4 decisions 4 and 6.
+ * `plans/money/tasks/49-bulk-fulfillment-posting.md` §8.4 decision 4.
  *
  * ## What it adds
  *
@@ -57,14 +37,6 @@ const CLEARING_AFFIRM_ROLE = 'clearing_affirm'
  *   (49 §5): 82 of 538 imported orders ship in two shipments, no line spans two,
  *   and all 82 reconstruct by grouping lines on their fulfilled date.
  *
- * - **The `clearing_affirm` role on `1210 Affirm Clearing`**, whose role has
- *   been null since migration 108 created it. 11 of the dev org's orders pay
- *   through Affirm (49 §5), and an Affirm settlement never lands on the card
- *   rail - it is invisible to the payouts API - so folding those into `1200`
- *   would mean `1200` could never reconcile to zero (`default-chart.ts` says so
- *   at the account itself). One chart line, and the fulfillment builder's debit
- *   fork needs the role to exist before it can emit it.
- *
  * ## What it deliberately does NOT do
  *
  * 🛑 **No backfill of the three fields, and none is possible.** The values come
@@ -74,29 +46,31 @@ const CLEARING_AFFIRM_ROLE = 'clearing_affirm'
  * inventing one from `order_fulfillment_status` would date every shipment wrong
  * and post a year of revenue into one day.
  *
- * ⚠️ **It never repoints a role the org has already mapped**, and never touches
- * `1210` when some other role already resolves to it. That is chart rule 4
- * (`seed/gl-account-chart.ts`): a bookkeeper who mapped their own account keeps
- * it through every re-run. An org whose `clearing_affirm` is already assigned is
- * left exactly as it is.
+ * 🛑 **It no longer stamps a `clearing_affirm` role onto `1210`.** It did when
+ * it landed, and that half was removed on 2026-09-10 along with the role and
+ * both Affirm accounts: a role may not name a vendor, so Affirm became a
+ * `payment_gateway` record the merchant adds (see `build-entry.ts`'s two rules
+ * and `default-chart.ts`'s `card_rail` header). Editing this migration in place
+ * rather than writing a compensating one is only safe because accounting has
+ * never been deployed - an org that already ran the old 137 keeps an inert
+ * `clearing_affirm` assignment row, which `listRoleMap` no longer lists and
+ * `resolveRoles` is never asked for.
  *
  * ## Ordering
  *
- * MUST sort after 107 (which creates `line_item`) and after 108 (which owns the
- * chart `1210` belongs to). An org short of either is a skip, not a failure -
- * it picks both up from the seeder with the rest of the registry.
+ * MUST sort after 107, which creates `line_item`. An org without it is a skip,
+ * not a failure - it picks the def up from the seeder with the rest of the
+ * registry.
  *
  * Idempotent: `ensureCustomFields` is INSERT-only and skips a field that
- * exists, and the role insert is guarded by a read and an
- * `ON CONFLICT DO NOTHING` on `(organizationId, role)`.
+ * exists.
  */
 export const migration137FulfillmentFacts: EntityMigration = {
   id: '137-fulfillment-facts',
   description:
     'Adds line_item_fulfilled_at, line_item_fulfilled_qty and line_item_shipment_count - the ' +
     "sales channel's per-line fulfillment rollup, carried natively so the fulfillment log " +
-    'pass can reconstruct order_fulfillments for a connector order - and stamps the ' +
-    'clearing_affirm role onto 1210 Affirm Clearing, whose role was null',
+    'pass can reconstruct order_fulfillments for a connector order',
 
   async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
     const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
@@ -115,25 +89,20 @@ export const migration137FulfillmentFacts: EntityMigration = {
       )
     }
 
-    const glAccountDefId = existing.entityDefs.get(GL_ACCOUNT_ENTITY_TYPE)?.id
-    const roleAssigned = glAccountDefId
-      ? await assignAffirmClearingRole(db, organizationId, glAccountDefId)
-      : false
-
-    const changed = state.fieldsCreated > 0 || roleAssigned
+    const changed = state.fieldsCreated > 0
 
     if (changed) {
       // A new field is invisible to every read path that serves it until the
-      // per-org caches are dropped, and the role resolver reads `resources`.
-      // `runEntityMigrationsForOrg` does this after the whole batch, but `up()`
-      // can also be called directly (`scripts/run-entity-migration.ts`).
+      // per-org caches are dropped. `runEntityMigrationsForOrg` does this after
+      // the whole batch, but `up()` can also be called directly
+      // (`scripts/run-entity-migration.ts`).
       await getOrgCache().invalidateAndRecompute(organizationId, [
         'entityDefs',
         'entityDefSlugs',
         'customFields',
         'resources',
       ])
-      logger.info('Migration 137 applied', { organizationId, ...state, roleAssigned })
+      logger.info('Migration 137 applied', { organizationId, ...state })
     }
 
     return { ...state, alreadyUpToDate: !changed }
@@ -158,98 +127,4 @@ function pickLineItemFields(): Record<string, ResourceField> {
     picked[key] = field
   }
   return picked
-}
-
-/**
- * Point `clearing_affirm` at the org's `1210`, and only when nothing has claimed
- * either side yet.
- *
- * Three guards, in order, each answering a different "leave it alone":
- *
- *  1. the org already has a `clearing_affirm` assignment - somebody, or a later
- *     re-seed, mapped it; this migration is done,
- *  2. the org has no `1210` - it renumbered its chart, and guessing which
- *     account is the Affirm one would post real money into it,
- *  3. `1210` already serves another role - "where its role is currently null"
- *     is the condition this migration was written under, and a second role on
- *     one account is legal but never something a migration should decide.
- *
- * @returns whether a row was written.
- */
-async function assignAffirmClearingRole(
-  db: Database,
-  organizationId: string,
-  glAccountDefId: string
-): Promise<boolean> {
-  const [alreadyAssigned] = await db
-    .select({ id: schema.GlRoleAssignment.id })
-    .from(schema.GlRoleAssignment)
-    .where(
-      and(
-        eq(schema.GlRoleAssignment.organizationId, organizationId),
-        eq(schema.GlRoleAssignment.role, CLEARING_AFFIRM_ROLE)
-      )
-    )
-    .limit(1)
-  if (alreadyAssigned) return false
-
-  const [codeField] = await db
-    .select({ id: schema.CustomField.id })
-    .from(schema.CustomField)
-    .where(
-      and(
-        eq(schema.CustomField.entityDefinitionId, glAccountDefId),
-        eq(schema.CustomField.systemAttribute, 'gl_account_code')
-      )
-    )
-    .limit(1)
-  if (!codeField) return false
-
-  const [account] = await db
-    .select({ entityId: schema.FieldValue.entityId })
-    .from(schema.FieldValue)
-    .where(
-      and(
-        eq(schema.FieldValue.organizationId, organizationId),
-        eq(schema.FieldValue.fieldId, codeField.id),
-        eq(schema.FieldValue.valueText, AFFIRM_CLEARING_CODE)
-      )
-    )
-    .limit(1)
-  if (!account) return false
-
-  const [otherRole] = await db
-    .select({ role: schema.GlRoleAssignment.role })
-    .from(schema.GlRoleAssignment)
-    .where(
-      and(
-        eq(schema.GlRoleAssignment.organizationId, organizationId),
-        eq(schema.GlRoleAssignment.glAccountId, account.entityId)
-      )
-    )
-    .limit(1)
-  if (otherRole) {
-    logger.warn('Migration 137 left 1210 alone - it already serves a role', {
-      organizationId,
-      role: otherRole.role,
-    })
-    return false
-  }
-
-  // `source: 'seed'` and NOT `confirmedAt`: auxx chose this, the bookkeeper has
-  // not confirmed it, and the setup wizard renders the two differently (`G19`).
-  const inserted = await db
-    .insert(schema.GlRoleAssignment)
-    .values({
-      organizationId,
-      role: CLEARING_AFFIRM_ROLE,
-      glAccountId: account.entityId,
-      source: 'seed',
-    })
-    .onConflictDoNothing({
-      target: [schema.GlRoleAssignment.organizationId, schema.GlRoleAssignment.role],
-    })
-    .returning({ id: schema.GlRoleAssignment.id })
-
-  return inserted.length > 0
 }

--- a/packages/lib/src/seed/entity-migrations/migrations/146-payment-gateway.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/146-payment-gateway.ts
@@ -33,18 +33,19 @@ const CACHE_KEYS = ['resources'] as const
  *
  * §5.1's gateway census found eleven distinct handles across five card rails on
  * one store's history, and the pattern already applied once for a second
- * gateway (`clearing_affirm`, entity migration 137) does not survive a third:
+ * gateway (`clearing_affirm`, entity migration 137) did not survive a third:
  * role-per-gateway costs a role, an account and a chart migration per rail.
  * This migration creates the record instead - a gateway carries its own
  * clearing account, fee account and settlement source, and is a row a merchant
- * can add without an engineer.
+ * can add without an engineer. `clearing_affirm` was itself retired into a
+ * record on 2026-09-10, so the card rail is the only one left with a role.
  *
- * Independent of the chart (`gl_account`): the two default rows the census
- * names (`Shopify Payments`, `Affirm`) are seeded by `seedDefaultPaymentGateways`
- * in `seed/gl-account-chart.ts`, once the org has PROVISIONED a chart and the
- * clearing accounts those defaults point at actually exist - this migration
- * only creates the def and its fields, so it has no ordering constraint
- * against 108, 133, 142, 143 or 144.
+ * Independent of the chart (`gl_account`): the one default row
+ * (`Shopify Payments`) is seeded by `seedDefaultPaymentGateways` in
+ * `seed/gl-account-chart.ts`, once the org has PROVISIONED a chart and the
+ * clearing account it points at actually exists - this migration only creates
+ * the def and its fields, so it has no ordering constraint against 108, 133,
+ * 142, 143 or 144.
  *
  * Idempotent: `ensureEntityDefinitions` / `ensureCustomFields` skip whatever the
  * org already holds.

--- a/packages/lib/src/seed/gl-account-chart-payment-gateways.test.ts
+++ b/packages/lib/src/seed/gl-account-chart-payment-gateways.test.ts
@@ -78,17 +78,16 @@ describe('seedDefaultPaymentGateways', () => {
     expect(h.createCalls).toEqual([])
   })
 
-  it('creates Shopify Payments and Affirm when both clearing roles are mapped', async () => {
+  it('creates Shopify Payments when the card clearing role is mapped', async () => {
     h.roleRows = [
       { role: 'clearing_card', glAccountId: 'acct_1200' },
-      { role: 'clearing_affirm', glAccountId: 'acct_1210' },
       { role: 'payment_processing_fees', glAccountId: 'acct_6100' },
     ]
 
     const result = await seedDefaultPaymentGateways(stubDb(), 'org-1')
 
-    expect(result.created).toBe(2)
-    expect(h.createCalls).toHaveLength(2)
+    expect(result.created).toBe(1)
+    expect(h.createCalls).toHaveLength(1)
     expect(h.createCalls[0]).toMatchObject({
       name: 'Shopify Payments',
       handles: ['shopify_payments'],
@@ -97,51 +96,44 @@ describe('seedDefaultPaymentGateways', () => {
       settlementSource: 'shopify_payments',
       status: 'active',
     })
-    expect(h.createCalls[1]).toMatchObject({
-      name: 'Affirm',
-      handles: ['affirm'],
-      clearingAccountId: 'acct_1210',
-      settlementSource: 'manual',
-      status: 'active',
-    })
   })
 
-  it('skips a default whose clearing role is unmapped, rather than guessing an account', async () => {
-    h.roleRows = [{ role: 'clearing_card', glAccountId: 'acct_1200' }]
+  it('skips the default when its clearing role is unmapped, rather than guessing an account', async () => {
+    h.roleRows = [{ role: 'payment_processing_fees', glAccountId: 'acct_6100' }]
 
     const result = await seedDefaultPaymentGateways(stubDb(), 'org-1')
 
-    expect(result.created).toBe(1)
+    expect(result.created).toBe(0)
     expect(result.skipped).toBe(1)
-    expect(h.createCalls).toHaveLength(1)
-    expect(h.createCalls[0]).toMatchObject({ name: 'Shopify Payments' })
+    expect(h.createCalls).toEqual([])
   })
 
   it('is idempotent by handle - skips a default a record already claims', async () => {
-    h.roleRows = [
-      { role: 'clearing_card', glAccountId: 'acct_1200' },
-      { role: 'clearing_affirm', glAccountId: 'acct_1210' },
-    ]
-    h.existingGateways = [{ id: 'pg_existing', handles: ['Affirm'] }]
+    h.roleRows = [{ role: 'clearing_card', glAccountId: 'acct_1200' }]
+    h.existingGateways = [{ id: 'pg_existing', handles: ['Shopify_Payments'] }]
 
     const result = await seedDefaultPaymentGateways(stubDb(), 'org-1')
 
-    expect(result.created).toBe(1)
+    expect(result.created).toBe(0)
     expect(result.skipped).toBe(1)
-    expect(h.createCalls).toHaveLength(1)
-    expect(h.createCalls[0]).toMatchObject({ name: 'Shopify Payments' })
+    expect(h.createCalls).toEqual([])
   })
 
-  it('never seeds Authorize.Net - a merchant adds it, auxx does not guess it', async () => {
+  // 🛑 The whole list, pinned. A rail auxx seeds is one every org's default
+  // chart names a role for, and `clearing_card` is the only clearing role there
+  // is. Affirm joined Authorize.Net here on 2026-09-10: seeding it meant `1210`,
+  // `6105` and a `clearing_affirm` role in the chart of every org, naming a
+  // vendor most of them have never taken a payment through.
+  it('seeds the card rail and nothing else - a merchant adds every other rail', async () => {
     h.roleRows = [
       { role: 'clearing_card', glAccountId: 'acct_1200' },
-      { role: 'clearing_affirm', glAccountId: 'acct_1210' },
+      { role: 'payment_processing_fees', glAccountId: 'acct_6100' },
     ]
 
     await seedDefaultPaymentGateways(stubDb(), 'org-1')
 
-    expect(h.createCalls.some((call) => (call as { name?: string }).name === 'Authorize.Net')).toBe(
-      false
-    )
+    expect(h.createCalls.map((call) => (call as { name?: string }).name)).toEqual([
+      'Shopify Payments',
+    ])
   })
 })

--- a/packages/lib/src/seed/gl-account-chart.test.ts
+++ b/packages/lib/src/seed/gl-account-chart.test.ts
@@ -178,34 +178,34 @@ describe('seedChartPacks', () => {
   // 27 since brief 21 §4.2 grew the core by fourteen role-less accounts (the
   // operating expenses, prepaid and the two owner-equity movements). The role
   // count is untouched at 11: none of the fourteen carries one.
-  it("['core'] creates 27 and assigns 11", async () => {
+  it("['core'] creates 27 and assigns 10", async () => {
     const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core'])
 
     expect(result.packs).toEqual(['core'])
     expect(result.created).toBe(27)
     expect(result.created).toBe(CORE_CODES.length)
-    expect(result.rolesAssigned).toBe(11)
+    expect(result.rolesAssigned).toBe(10)
     expect(result.rolesAssigned).toBe(CORE_ROLES.length)
     expect(h.creates).toHaveLength(27)
   })
 
-  it("['core', 'inventory'] creates 36 and assigns 18", async () => {
+  it("['core', 'inventory'] creates 36 and assigns 17", async () => {
     const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['core', 'inventory'])
 
     expect(result.packs).toEqual(['core', 'inventory'])
     expect(result.created).toBe(36)
     expect(result.created).toBe(CORE_PLUS_INVENTORY_ACCOUNTS.length)
-    expect(result.rolesAssigned).toBe(18)
+    expect(result.rolesAssigned).toBe(17)
     expect(result.rolesAssigned).toBe(CORE_PLUS_INVENTORY_ROLES.length)
   })
 
-  it("['purchasing'] alone walks core, then inventory, then purchasing, landing 40 accounts and 22 roles", async () => {
+  it("['purchasing'] alone walks core, then inventory, then purchasing, landing 40 accounts and 21 roles", async () => {
     const result = await seedChartPacks(stubDb([]), 'org-1', DEF_ID, ['purchasing'])
 
     expect(result.packs).toEqual(['core', 'inventory', 'purchasing'])
     expect(result.created).toBe(40)
     expect(result.created).toBe(CORE_INVENTORY_PURCHASING_ACCOUNTS.length)
-    expect(result.rolesAssigned).toBe(22)
+    expect(result.rolesAssigned).toBe(21)
     expect(result.rolesAssigned).toBe(CORE_INVENTORY_PURCHASING_ROLES.length)
   })
 
@@ -355,6 +355,6 @@ describe('seedDefaultChartOfAccounts', () => {
 
     expect(result.packs).toEqual(['core'])
     expect(result.created).toBe(27)
-    expect(result.rolesAssigned).toBe(11)
+    expect(result.rolesAssigned).toBe(10)
   })
 })

--- a/packages/lib/src/seed/gl-account-chart.ts
+++ b/packages/lib/src/seed/gl-account-chart.ts
@@ -360,33 +360,38 @@ export interface PaymentGatewaySeedResult {
 }
 
 /**
- * Seed the two default `payment_gateway` records the census names, idempotent
- * by handle.
+ * Seed the ONE default `payment_gateway` record, idempotent by handle.
  *
- * ⚠️ **Runs AFTER the chart**, not alongside it - the clearing accounts these
- * defaults point at only exist once the `card_rail` pack is provisioned, and
+ * ⚠️ **Runs AFTER the chart**, not alongside it - the clearing account this
+ * default points at only exists once the `card_rail` pack is provisioned, and
  * `payment_gateway.clearingAccount` is required and validated (`writes.ts`'s
  * `assertClearingAccount`). Call this from wherever the chart is seeded
  * (`ledger.provisionChart`), never before {@link seedChartPacks} has walked
  * `card_rail`, and never from {@link seedChartPacks} itself - the core walk
  * never seeds a gateway (16 §1.5).
  *
- * 🛑 **Does not mint `clearing_authnet`.** Authorize.Net is a rail a merchant
- * ADDS (§5.1); auxx does not know a store ran it until they say so. The two
- * seeded here are the only ones every org's default chart actually names a
- * role for: `shopify_payments` (settlement source `shopify_payments`, fee
- * account = whichever account carries `payment_processing_fees`, `6100` by
- * default) and `affirm` (settlement source `manual` - `18` §2.1 codes its
- * relief by hand, because no payout API sees an Affirm settlement).
+ * 🛑 **Mints `shopify_payments` and nothing else.** A rail auxx seeds is one
+ * every org's default chart already names a role for, and after 2026-09-10
+ * `clearing_card` is the only clearing role there is. So `shopify_payments`
+ * (settlement source `shopify_payments`, fee account = whichever account
+ * carries `payment_processing_fees`, `6100` by default) is the whole list.
+ *
+ * ⚠️ **Affirm is no longer seeded**, and joins Authorize.Net on the same
+ * footing (§5.1): a rail the merchant ADDS, because auxx does not know a store
+ * ran it until they say so. Seeding it meant `1210 Affirm Clearing`, `6105
+ * Merchant Fees - Affirm` and a `clearing_affirm` role in every org's chart,
+ * naming a vendor most of them have never taken a payment through. A store that
+ * does run Affirm creates its clearing account and adds the gateway record
+ * pointing at it - two steps, once, on the settings page, and the fulfillment
+ * debit fork routes to it by id from then on.
  *
  * Idempotent by HANDLE, not by name: a re-provision (or a second org whose
  * chart already exists) skips a default whose handle some record - seeded or
- * hand-added - already claims, rather than creating a second `Affirm` row.
+ * hand-added - already claims, rather than creating a second row.
  *
- * A missing role assignment (`clearing_card` / `clearing_affirm` unmapped)
- * skips that default rather than guessing an account - the same tolerance
- * {@link assignSeededRoles} has for a chart that does not match the packs
- * walked.
+ * A missing `clearing_card` assignment skips the default rather than guessing
+ * an account - the same tolerance {@link assignSeededRoles} has for a chart that
+ * does not match the packs walked.
  */
 export async function seedDefaultPaymentGateways(
   db: Database,
@@ -413,11 +418,7 @@ export async function seedDefaultPaymentGateways(
     .where(
       and(
         eq(schema.GlRoleAssignment.organizationId, organizationId),
-        inArray(schema.GlRoleAssignment.role, [
-          'clearing_card',
-          'clearing_affirm',
-          'payment_processing_fees',
-        ])
+        inArray(schema.GlRoleAssignment.role, ['clearing_card', 'payment_processing_fees'])
       )
     )
   const byRole = new Map(roleRows.map((row) => [row.role, row.glAccountId]))
@@ -445,25 +446,8 @@ export async function seedDefaultPaymentGateways(
     skipped++
   }
 
-  const clearingAffirm = byRole.get('clearing_affirm')
-  if (!existingHandles.has('affirm') && clearingAffirm) {
-    const result = await createPaymentGateway(db, {
-      organizationId,
-      actorUserId: systemUserId,
-      name: 'Affirm',
-      handles: ['affirm'],
-      clearingAccountId: clearingAffirm,
-      settlementSource: 'manual',
-      status: 'active',
-    })
-    if (result.isOk()) created++
-    else skipped++
-  } else {
-    skipped++
-  }
-
   if (created > 0) {
-    logger.info('Seeded default payment gateways', { organizationId, created, skipped })
+    logger.info('Seeded the default payment gateway', { organizationId, created, skipped })
   }
 
   return { created, skipped }


### PR DESCRIPTION
## Why

The Roles tab on **Accounting → Settings → Accounts** lists every declared posting role as a checklist row. An unmapped role costs nothing until a builder emits it — `resolveRoles` fails closed and names it — so the argument for deleting one is never correctness. It is that **a row nothing can ever post to is a question with no answer**, and one of them named a vendor most orgs have never taken a payment through.

## The audit

Every one of the 28 `ACCOUNT_ROLES`, traced to the builder that emits it and then to whether that builder has a production caller.

**22 are live.** `accounts_receivable` (7 builders), `sales_tax_payable` (4), the seven inventory/COGS roles via `close-month`, and so on.

**Three are deleted:**

| Role | Why |
| --- | --- |
| `deferred_revenue` | No builder at all, not even an unwired one. The month-end deferral entry was never written. |
| `equity_opening_balance` | `buildOpeningBalanceEntry` takes the account ids a person typed into the trial-balance grid, so it emitted no role. `ROLE_IMPORT_MATCH` auto-assigned it on QBO import and nothing ever read it. |
| `clearing_affirm` | A role may not name a vendor. `build-entry.ts` already said so and called this one *"grandfathered"*; migration 146 had built the replacement. |

`2300 Deferred Revenue` and `3900 Opening Balance Equity` keep their **account** and lose only the role.

**Four stay, deliberately.** `grni`, `freight_accrual` and `duties_accrual` come from `buildReceiptEntry`, `ppv` from `buildVendorBillEntry`. Neither builder is invoked outside tests — receiving does not post under L1 — but both are written and tested, and deleting the roles means deleting the builders.

## Affirm becomes what Authorize.Net always was

`1210 Affirm Clearing` and `6105 Merchant Fees - Affirm` leave the `card_rail` pack (5 accounts → 3; default chart 58 → 56), and `seedDefaultPaymentGateways` now mints `Shopify Payments` and nothing else. The JSDoc's own argument for refusing to mint `clearing_authnet` — *"a rail a merchant ADDS; auxx does not know a store ran it until they say so"* — now covers Affirm too.

The replacement was already built (brief 13 §5.3: `matchGatewayRoute`, the `{ glAccountId }` debit, the `gateway` bucket) and had **zero test coverage**. It has six now, because after this change it is the only thing keeping a non-card rail out of `1200`.

⚠️ **The cost, stated and pinned.** An Affirm store with no `payment_gateway` record falls through to `clearing_card`, and `1200` then carries a residual no card payout can relieve. Same cost Authorize.Net has always carried. `plan.test.ts`'s *"folds a non-card rail into card clearing when no record routes it"* exists so nobody rediscovers it in a reconciliation.

Migration 137 is **edited in place** rather than compensated, which is only safe because accounting has never been deployed.

## The second bug, caused by the first

Driving this on a dev org surfaced something the unit tests could not.

`chart-write.ts` guarded remove/deactivate with `assertNoLiveRole` alone, which reads `GlRoleAssignment` and filters rows through `ROLE_ACCOUNT_TYPES`. **`clearing_affirm` had been doing double duty** — routing Affirm money *and* protecting `1210` from removal. Deleting the role left nothing refusing: the Chart tab would archive an account a live gateway named, every chart reader excludes archived rows, and the next Affirm posting would refuse with *"no active account with id ..."*.

Task 15's eight `gl_account` pointers are plain `TEXT` by decision (DECIDED 2026-09-09) — a foreign key cannot check `isActive` or `accountType`, which the read must do anyway. **That decision is not reopened here.** What it costs is that the id lives in `FieldValue.valueText`, so every guard written against `relatedEntityId` is blind to all eight — and both guards that existed were:

- `chart-write.ts` read roles only → new `assertNoPointer` (I4), on remove **and** deactivate, naming what points there
- `scripts/reset-gl-chart.ts` queried `relatedEntityId` only → now finally keeps its own promise not to wipe a referenced chart

`postings/gl-account-pointers.ts` declares the eight once, with a coverage test that walks the registry and fails when a pointer is added without a row.

## Verified on real data

`scripts/drive-fulfillment-posting-preview.ts` (new, **read-only**) runs `previewFulfillmentPosting` and puts each built entry through `resolveAccountLines` — the same door `postEntry` walks.

415 January orders across two rails → one balanced 192-line entry, both clearing debits routed **by account id**:

```
debit BY ID rj2yvjsvas6r9vnbfcglor09  $1,300,474.25  -> 1200 Card Clearing
debit BY ID k1oc92kc0gxn8lpy8duq9qhu     $26,798.15  -> 1210 Affirm Clearing
                                      -------------
                              total   $1,327,272.40   balanced, 192 lines
```

The `clearing_card` bucket is empty — the separation the role used to give, with no vendor in any other org's chart. And `1200`/`1210` both refuse removal while a gateway names them, while `1310 Raw Materials` stays removable.

## Tests

**18,754 pass, 0 fail** across `packages/lib`. Both typecheck ratchets clean.

17 new: 13 for the pointer declaration and query, 4 for the guard's wiring — including that a refusal writes **nothing**, and that a renumber or rename still succeeds while a pointer exists (the pointer holds the instance id, so renaming is safe by construction; a guard that blocked it would make any pointed-at account uneditable).

## Reviewer notes

- **No migration is owed for the role deletion.** No org relied on Affirm and the accounting system has had no users but us. A stale `clearing_affirm` assignment row is inert — `listRoleMap` walks `ACCOUNT_ROLES`, so it is not rendered, and `resolveRoles` is never asked for it.
- `payment_gateway.feeAccount` is read, typed, rendered, and **consumed by nothing** — `buildPayoutEntry` takes its expense leg from the `payment_processing_fees` role. Left alone; flagged for whenever a payout builder resolves fees per-gateway.
- **Not a substitute for the read-time check.** A direct SQL delete still produces a dangling id and `resolveAccountLines` must still fail closed. This closes the doors auxx itself owns.

https://claude.ai/code/session_01PKDDRhkBUjEyi3GKigfLYn
