### PR TITLE
fix(accounting): a refund leaves by the door its sale came in, and the issue dialog can send a date

### DIFF
--- a/apps/web/src/components/money/ui/credit-memo/issue-credit-memo-dialog.tsx
+++ b/apps/web/src/components/money/ui/credit-memo/issue-credit-memo-dialog.tsx
@@ -8,6 +8,7 @@
 // dialog uses, from `creditMemo.previewIssue`, which persists nothing.
 
 import { FieldType } from '@auxx/database/enums'
+import { normalizeCalendarDayIso, toCalendarDayIso } from '@auxx/lib/field-values/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -43,8 +44,29 @@ interface IssueCreditMemoDialogProps {
   onIssued?: () => void
 }
 
-function todayIso(): string {
-  return new Date().toISOString()
+/**
+ * A bare `YYYY-MM-DD`, which is what `creditMemo.previewIssue` and
+ * `creditMemo.issue` accept (`z.iso.date()`).
+ *
+ * 🛑 **Through `normalizeCalendarDayIso` rather than by hand**, the same door
+ * `use-opening-stock.ts` uses: it rounds to the NEAREST UTC midnight, so a
+ * stored instant from either side of UTC lands on the day that was meant.
+ * Truncating is off by one for every writer east of UTC.
+ *
+ * This exists because the dialog used to pass the raw value straight through -
+ * a channel memo's stored `2018-01-13 08:03:34+00`, or `todayIso()`'s full
+ * `2026-09-11T04:57:33.123Z`. Neither is a calendar day, so the router refused
+ * both, `previewQuery` never resolved, and the Issue button stayed disabled
+ * with nothing on screen to say why. No credit memo had ever been issued
+ * through this dialog.
+ */
+function toCalendarDay(value: unknown): string | null {
+  return normalizeCalendarDayIso(value)?.slice(0, 10) ?? null
+}
+
+/** Today as a bare calendar day, in the VIEWER's zone - the day they see. */
+function todayCalendarDay(): string {
+  return toCalendarDayIso(new Date()).slice(0, 10)
 }
 
 export function IssueCreditMemoDialog({
@@ -55,13 +77,13 @@ export function IssueCreditMemoDialog({
   currencyCode,
   onIssued,
 }: IssueCreditMemoDialogProps) {
-  const [date, setDate] = useState<string>(issuedAt ?? todayIso())
+  const [date, setDate] = useState<string>(toCalendarDay(issuedAt) ?? todayCalendarDay())
 
   // Reset the date to a fresh prefill every time the dialog opens.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-init only when the dialog opens.
   useEffect(() => {
     if (!open) return
-    setDate(issuedAt ?? todayIso())
+    setDate(toCalendarDay(issuedAt) ?? todayCalendarDay())
   }, [open])
 
   // A plain `useQuery`, not debounced: the date is picked once and reviewed,
@@ -114,7 +136,10 @@ export function IssueCreditMemoDialog({
             <FieldInputAdapter
               fieldType={FieldType.DATE}
               value={date}
-              onChange={(val) => setDate(val as string)}
+              // The adapter hands back a full ISO instant; the router wants a
+              // day. Normalised here rather than at the call so `date` is
+              // always exactly what gets sent.
+              onChange={(val) => setDate(toCalendarDay(val) ?? date)}
               disabled={issue.isPending}
             />
           </FieldPanelRow>
@@ -123,6 +148,17 @@ export function IssueCreditMemoDialog({
         {preview && <EntryJournal lines={preview.lines} currencyCode={currencyCode} />}
 
         {blockers.length > 0 && <EntryBlockers blockers={blockers} />}
+
+        {/* 🛑 A REFUSED preview used to render nothing at all, so a disabled
+            Issue button was indistinguishable from one still loading - which is
+            how a malformed date went unnoticed until somebody asked why the
+            button would not light up. A blocker is the entry saying no; this is
+            the request saying no, and both have to be visible. */}
+        {previewQuery.isError && (
+          <p className='text-destructive text-xs'>
+            This memo cannot be previewed: {previewQuery.error.message}
+          </p>
+        )}
 
         <DialogFooter>
           <Button

--- a/apps/web/src/server/api/routers/availability.ts
+++ b/apps/web/src/server/api/routers/availability.ts
@@ -13,7 +13,7 @@ import { PermissionKey } from '@auxx/lib/permissions'
 import { z } from 'zod'
 import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
 
-const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected an ISO date (YYYY-MM-DD)')
+const isoDate = z.iso.date({ error: 'Expected an ISO date (YYYY-MM-DD)' })
 
 const minute = z.number().int().min(0).max(1440)
 

--- a/apps/web/src/server/api/routers/banking-review.ts
+++ b/apps/web/src/server/api/routers/banking-review.ts
@@ -35,9 +35,6 @@ import { PermissionKey } from '@auxx/lib/permissions'
 import { z } from 'zod'
 import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
 
-/** `YYYY-MM-DD`. Shape only; the lib decides what is a sensible date. */
-const dateKey = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
-
 const transactionId = z.string().min(1)
 
 /**
@@ -53,8 +50,8 @@ const listInput = z.object({
   bankAccountId: z.string().min(1).optional(),
   state: z.enum(REVIEW_QUEUE_STATES).optional(),
   search: z.string().max(200).optional(),
-  from: dateKey.optional(),
-  to: dateKey.optional(),
+  from: z.iso.date().optional(),
+  to: z.iso.date().optional(),
   amountMin: z.number().int().optional(),
   amountMax: z.number().int().optional(),
   limit: z.number().int().min(1).max(500).optional(),

--- a/apps/web/src/server/api/routers/banking.ts
+++ b/apps/web/src/server/api/routers/banking.ts
@@ -46,9 +46,6 @@ import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
 // of it is a merge conflict looking for somewhere to happen.
 import { bankingImportRouter } from './banking-import'
 
-/** `YYYY-MM-DD`. Shape only; the lib decides what is a sensible date. */
-const dateKey = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
-
 /**
  * The fields a person may set on a bank account.
  *
@@ -68,7 +65,7 @@ const bankAccountFields = {
   glAccountId: z.string().max(64).nullish(),
   /** The Stripe `ba_…` / `card_…` destination id a person confirms once (brief 13 §2.3). */
   stripeExternalAccountId: z.string().max(64).nullish(),
-  feedStartDate: dateKey.nullish(),
+  feedStartDate: z.iso.date().nullish(),
 }
 
 export const bankingRouter = createTRPCRouter({

--- a/apps/web/src/server/api/routers/credit-memo.ts
+++ b/apps/web/src/server/api/routers/credit-memo.ts
@@ -31,7 +31,7 @@ import { parseRecordId, recordIdSchema, toRecordId } from '@auxx/types/resource'
 import { z } from 'zod'
 import { createTRPCRouter, permissionProcedure } from '../trpc'
 
-const calendarDaySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected YYYY-MM-DD')
+const calendarDaySchema = z.iso.date({ error: 'Expected YYYY-MM-DD' })
 
 export const creditMemoRouter = createTRPCRouter({
   /**

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -407,7 +407,7 @@ export const dispatchRouter = createTRPCRouter({
       z.object({
         from: z.date(),
         to: z.date(),
-        dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        dateKey: z.iso.date(),
         workerIds: z.array(z.string()).optional(),
       })
     )
@@ -422,7 +422,7 @@ export const dispatchRouter = createTRPCRouter({
       z.object({
         from: z.date(),
         to: z.date(),
-        dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        dateKey: z.iso.date(),
         assigneeWorkerId: z.string(),
       })
     )
@@ -438,7 +438,7 @@ export const dispatchRouter = createTRPCRouter({
         assigneeWorkerId: z.string(),
         from: z.date(),
         to: z.date(),
-        dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        dateKey: z.iso.date(),
         visitIds: z.array(z.string()),
       })
     )
@@ -460,7 +460,7 @@ export const dispatchRouter = createTRPCRouter({
     .input(
       z.object({
         assigneeWorkerId: z.string(),
-        dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        dateKey: z.iso.date(),
         firstDeparture: z.date(),
         visitIds: z.array(z.string()).min(1),
       })
@@ -896,10 +896,7 @@ export const dispatchRouter = createTRPCRouter({
     .input(
       z.object({
         workOrderRecordId: recordIdSchema,
-        until: z
-          .string()
-          .regex(/^\d{4}-\d{2}-\d{2}$/)
-          .nullable(),
+        until: z.iso.date().nullable(),
       })
     )
     .mutation(async ({ ctx, input }) => {

--- a/apps/web/src/server/api/routers/ledger-reports.ts
+++ b/apps/web/src/server/api/routers/ledger-reports.ts
@@ -43,7 +43,7 @@ import { z } from 'zod'
 import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
 
 /** `YYYY-MM-DD`. Every date bound on this router is this shape - the lib reads own the range validity. */
-const dateKey = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected YYYY-MM-DD')
+const dateKey = z.iso.date({ error: 'Expected YYYY-MM-DD' })
 
 export const ledgerReportsRouter = createTRPCRouter({
   /**

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -173,7 +173,7 @@ const draftEntry = z.object({
    * passes it through untouched and a provider handed a malformed date falls
    * back to its own server date, which silently books the entry on the wrong day.
    */
-  txnDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'txnDate must be YYYY-MM-DD'),
+  txnDate: z.iso.date({ error: 'txnDate must be YYYY-MM-DD' }),
   /**
    * Bounded rather than merely non-empty. The cap is far above any entry this
    * poster produces - a month-end inventory entry is one line per account role -
@@ -1067,7 +1067,7 @@ export const ledgerRouter = createTRPCRouter({
     .input(
       z.object({
         /** `YYYY-MM-DD`. Both sides are read as of this same day. */
-        asOf: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'asOf must be YYYY-MM-DD'),
+        asOf: z.iso.date({ error: 'asOf must be YYYY-MM-DD' }),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -1152,12 +1152,9 @@ export const ledgerRouter = createTRPCRouter({
     .input(
       z.object({
         /** `YYYY-MM-DD`. Omitted means the cutover floor - see above. */
-        from: z
-          .string()
-          .regex(/^\d{4}-\d{2}-\d{2}$/, 'from must be YYYY-MM-DD')
-          .optional(),
+        from: z.iso.date({ error: 'from must be YYYY-MM-DD' }).optional(),
         /** `YYYY-MM-DD`, inclusive. Usually today in the book timezone. */
-        to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'to must be YYYY-MM-DD'),
+        to: z.iso.date({ error: 'to must be YYYY-MM-DD' }),
       })
     )
     .use(notDemo('sync the accounting provider ledger'))
@@ -1266,7 +1263,7 @@ export const ledgerRouter = createTRPCRouter({
           // hand would either omit them (refused) or claim a slot the sweep
           // would then raise a second entry for.
           kind: z.enum(['manual', 'opening_balance', 'recurring_template']).optional(),
-          date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD'),
+          date: z.iso.date({ error: 'date must be YYYY-MM-DD' }),
           memo: z.string().max(4000).optional(),
           lines: z.array(journalEntryLine).max(200).optional(),
         })
@@ -1291,10 +1288,7 @@ export const ledgerRouter = createTRPCRouter({
       .input(
         z.object({
           id: z.string().min(1),
-          date: z
-            .string()
-            .regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD')
-            .optional(),
+          date: z.iso.date({ error: 'date must be YYYY-MM-DD' }).optional(),
           /** An empty string CLEARS the memo; omitting the key leaves it alone. */
           memo: z.string().max(4000).optional(),
           lines: z.array(journalEntryLine).max(200).optional(),
@@ -1371,10 +1365,7 @@ export const ledgerRouter = createTRPCRouter({
       .input(
         z.object({
           id: z.string().min(1),
-          date: z
-            .string()
-            .regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD')
-            .optional(),
+          date: z.iso.date({ error: 'date must be YYYY-MM-DD' }).optional(),
           memo: z.string().max(4000).optional(),
           lines: z.array(journalEntryLine).max(200).optional(),
         })
@@ -1504,10 +1495,7 @@ export const ledgerRouter = createTRPCRouter({
         z.object({
           templateId: z.string().min(1),
           pattern: recurrencePatternSchema,
-          anchor: z
-            .string()
-            .regex(/^\d{4}-\d{2}-\d{2}$/, 'anchor must be YYYY-MM-DD')
-            .optional(),
+          anchor: z.iso.date({ error: 'anchor must be YYYY-MM-DD' }).optional(),
         })
       )
       .mutation(async ({ ctx, input }) => {

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -196,8 +196,8 @@ const FULFILLMENT_POSTING_GROUPING_VALUES = [
  * decision that is not the browser's to make.
  */
 const fulfillmentPostingShape = {
-  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  from: z.iso.date(),
+  to: z.iso.date(),
   grouping: z.enum(FULFILLMENT_POSTING_GROUPING_VALUES),
 }
 
@@ -784,10 +784,7 @@ export const moneyRouter = createTRPCRouter({
           .array(z.object({ lineId: z.string().min(1), quantity: z.number().positive() }))
           .min(1)
           .max(200),
-        shippedAt: z
-          .string()
-          .regex(/^\d{4}-\d{2}-\d{2}$/)
-          .optional(),
+        shippedAt: z.iso.date().optional(),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -822,10 +819,7 @@ export const moneyRouter = createTRPCRouter({
           .array(z.object({ lineId: z.string().min(1), quantity: z.number().positive() }))
           .min(1)
           .max(200),
-        shippedAt: z
-          .string()
-          .regex(/^\d{4}-\d{2}-\d{2}$/)
-          .optional(),
+        shippedAt: z.iso.date().optional(),
         memo: z.string().max(4000).optional(),
       })
     )
@@ -945,14 +939,8 @@ export const moneyRouter = createTRPCRouter({
         z
           .object({
             method: z.string().min(1).optional(),
-            from: z
-              .string()
-              .regex(/^\d{4}-\d{2}-\d{2}$/)
-              .optional(),
-            to: z
-              .string()
-              .regex(/^\d{4}-\d{2}-\d{2}$/)
-              .optional(),
+            from: z.iso.date().optional(),
+            to: z.iso.date().optional(),
             limit: z.number().int().min(1).max(500).optional(),
           })
           .optional()
@@ -1010,7 +998,7 @@ export const moneyRouter = createTRPCRouter({
       .input(
         z.object({
           paymentIds: z.array(z.string().min(1)).min(1).max(500),
-          depositDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+          depositDate: z.iso.date(),
           // 🛑 The ACCOUNT, not a chart code. The code is read off the account's
           // own mapping, because the feed posts every line on it against that
           // mapping - a free code puts the deposit and the statement line it
@@ -1060,10 +1048,7 @@ export const moneyRouter = createTRPCRouter({
       .input(
         z.object({
           depositId: z.string().min(1),
-          depositDate: z
-            .string()
-            .regex(/^\d{4}-\d{2}-\d{2}$/)
-            .optional(),
+          depositDate: z.iso.date().optional(),
           bankAccountId: z.string().min(1).max(64).optional(),
           reference: z.string().max(120).optional(),
         })

--- a/apps/web/src/server/api/routers/payment-gateways.ts
+++ b/apps/web/src/server/api/routers/payment-gateways.ts
@@ -27,7 +27,7 @@ import { z } from 'zod'
 import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
 
 /** `YYYY-MM-DD`. Shape only; the lib decides what is a sensible date. */
-const dateKey = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
+const dateKey = z.iso.date()
 
 /**
  * The fields a person may set on a payment gateway. Deliberately thin -

--- a/apps/web/src/server/api/routers/purchasing.ts
+++ b/apps/web/src/server/api/routers/purchasing.ts
@@ -55,7 +55,7 @@ import { capabilityProcedure, createTRPCRouter, permissionProcedure } from '~/se
 const minorUnits = z.number().int()
 
 /** A calendar day, the shape every accounting date crosses the wire in. */
-const calendarDaySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected YYYY-MM-DD')
+const calendarDaySchema = z.iso.date({ error: 'Expected YYYY-MM-DD' })
 
 /**
  * A RATE - money per one of something (`unitCost`, `vendorUnitPrice`, a line's

--- a/packages/lib/src/money/credit-memos/reads.ts
+++ b/packages/lib/src/money/credit-memos/reads.ts
@@ -689,6 +689,53 @@ export async function loadInvoiceLinesForCredit(
 // ─── The order ──────────────────────────────────────────────────────────────
 
 /**
+ * Every gateway `order_payment_gateways` holds for one order, raw.
+ *
+ * 🛑 Read for the REFUND's account, not the sale's. `issueCreditMemo` matches
+ * these against the org's `payment_gateway` records so a channel refund credits
+ * the account its sale debited - see `CreditMemoSettlement`. Before 2026-09-11
+ * the refund was hardcoded to `clearing_card`, which was correct only while
+ * every rail shared one clearing account.
+ *
+ * ⚠️ **TAGS, so the value is in `optionId`**, not `valueText` - one row per
+ * gateway, each an option KEY that for a connector-provisioned option set IS
+ * the gateway's name (`readOrderFacts` says the same). Reading `valueText`
+ * here returns nothing at all and every refund falls back to the role, which
+ * is the silent version of the bug this read exists to fix.
+ *
+ * Empty when the field is unprovisioned or the order names no gateway: the
+ * caller then takes the `clearing_card` default, which is what the fulfillment
+ * debit fork does with the same input.
+ */
+export async function readOrderGateways(
+  db: Database,
+  organizationId: string,
+  orderId: string
+): Promise<string[]> {
+  const fields = (await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['order_payment_gateways'])) as FieldMap<'order_payment_gateways'>
+  const field = fields.order_payment_gateways
+  if (!field) return []
+
+  const rows = await db
+    .select({ optionId: schema.FieldValue.optionId, valueText: schema.FieldValue.valueText })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, orderId),
+        eq(schema.FieldValue.fieldId, field.id)
+      )
+    )
+
+  return rows.flatMap((row) => {
+    const value = row.optionId ?? row.valueText
+    return value ? [value] : []
+  })
+}
+
+/**
  * Whether the order had a fulfillment shipped on or before `issuedAt`.
  *
  * Read from the order's shipment log (`order_fulfillments`, the same JSON

--- a/packages/lib/src/money/credit-memos/writes.ts
+++ b/packages/lib/src/money/credit-memos/writes.ts
@@ -16,6 +16,8 @@ import { toRecordId } from '@auxx/types/resource'
 import { getEntityDefIdResolver } from '../../cache'
 import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../../errors'
 import { FieldValueService } from '../../field-values/field-value-service'
+import { matchGatewayRoute, toGatewayRoutes } from '../../payment-gateways/client'
+import { listPaymentGateways } from '../../payment-gateways/reads'
 import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import {
   type BuiltCreditMemoEntry,
@@ -44,6 +46,7 @@ import {
   loadInvoiceForCredit,
   loadInvoiceLinesForCredit,
   orderHadFulfillmentBefore,
+  readOrderGateways,
   requireCreditMemo,
   sumCreditMemoApplications,
   sumSucceededCreditMemoRefunds,
@@ -512,9 +515,18 @@ async function resolveIssue(
   // The channel money leg: what Shopify already paid back, mirrored out of
   // clearing (section 3.2). A native memo's money moves as a
   // `PaymentTransaction` and posts through the payment builder instead.
+  //
+  // 🛑 It must come out of the account the SALE debited. A `payment_gateway`
+  // record routes a non-card rail to its own clearing account by id, so an
+  // Affirm sale debits `1210` while `clearing_card` is `1200`; crediting the
+  // role here would leave `1210` overstated forever in an entry that balances.
+  // Same matcher the fulfillment debit fork uses, so the two cannot drift.
   const settlement: CreditMemoSettlementLeg | undefined =
     memo.source === 'channel' && memo.amountRefundedMinor > 0
-      ? { role: 'clearing_card', amount: Math.round(memo.amountRefundedMinor) }
+      ? {
+          ...(await resolveSettlementAccount(db, organizationId, memo.orderInstanceId)),
+          amount: Math.round(memo.amountRefundedMinor),
+        }
       : undefined
 
   const currency = await organizationCurrency(organizationId)
@@ -534,6 +546,42 @@ async function resolveIssue(
   })
 
   return { memo, lines, issuedAt, built }
+}
+
+/**
+ * Where a channel refund comes back out of: a `payment_gateway` record's own
+ * clearing account, or `clearing_card`.
+ *
+ * The mirror of `resolveFulfillmentDebit`'s gateway branch, and deliberately
+ * only that branch - a refund asks "which account did this order's money land
+ * in", never "is this order paid", so the financial-status fork has no part in
+ * it. `matchGatewayRoute` is shared with the sale side so one gateway cannot
+ * resolve two ways.
+ *
+ * Falls back to the role on every uncertainty - no order, no gateway, no
+ * matching record, two records claiming one handle - because `clearing_card` is
+ * where a wrong answer fails to reconcile visibly rather than quietly.
+ *
+ * ⚠️ An order with TWO gateways takes the role too. The fulfillment fork
+ * excludes that shipment outright as `gateway-ambiguous`; a refund cannot
+ * refuse (the money has already moved), so it lands in the account a person
+ * reconciling the rail is looking at anyway.
+ */
+async function resolveSettlementAccount(
+  db: Database,
+  organizationId: string,
+  orderInstanceId: string | null
+): Promise<{ role: 'clearing_card' } | { glAccountId: string }> {
+  const fallback = { role: 'clearing_card' } as const
+  if (!orderInstanceId) return fallback
+
+  const gateways = await readOrderGateways(db, organizationId, orderInstanceId)
+  if (gateways.length !== 1) return fallback
+
+  const result = await listPaymentGateways(db, organizationId)
+  const routes = result.isOk() ? toGatewayRoutes(result.value) : []
+  const glAccountId = matchGatewayRoute(gateways[0] as string, routes)
+  return glAccountId ? { glAccountId } : fallback
 }
 
 /**

--- a/packages/lib/src/payment-gateways/client.ts
+++ b/packages/lib/src/payment-gateways/client.ts
@@ -161,3 +161,42 @@ export function toGatewayRoutes(rows: readonly PaymentGatewayRow[]): GatewayRout
     active: row.status === 'active',
   }))
 }
+
+/**
+ * Which route's clearing account one gateway names, when EXACTLY ONE claims it.
+ *
+ * 🛑 **The single matcher.** Every posting path that turns a gateway into an
+ * account goes through this one function, because two copies that disagree put
+ * a sale and its refund in different accounts - which balances, and is
+ * therefore undetectable downstream. `build-fulfillment-batch-entry.ts`
+ * (the sale) and `money/credit-memos/writes.ts` (the refund) are the two
+ * callers; they used to be a private copy and a hardcoded `clearing_card`
+ * respectively.
+ *
+ * Both sides are normalised with {@link normaliseGatewayHandle}, so `'Affirm'`,
+ * `' affirm '` and `'AFFIRM'` are one gateway.
+ *
+ * Returns undefined - meaning *fall back to the role default* - on:
+ *
+ * - **zero matches.** The record has nothing to say about this gateway yet.
+ * - **more than one match.** Two routes claiming one handle is a state the
+ *   record's own write path should never allow, and guessing which is right
+ *   would put real money in one of two accounts. Refusing to choose leaves it
+ *   in `clearing_card`, where a wrong answer fails to reconcile visibly.
+ *
+ * ⚠️ A CLOSED route still matches. Its past orders are still in the ledger and
+ * must keep reconciling; treating `active: false` as absent would silently move
+ * a rail's money the moment somebody marked it closed, which is a posting
+ * change disguised as a settings edit.
+ */
+export function matchGatewayRoute(
+  gateway: string,
+  routes: readonly GatewayRoute[] = []
+): string | undefined {
+  const wanted = normaliseGatewayHandle(gateway)
+  if (!wanted) return undefined
+  const matches = routes.filter((route) =>
+    route.handles.some((handle) => normaliseGatewayHandle(handle) === wanted)
+  )
+  return matches.length === 1 ? matches[0]?.clearingGlAccountId : undefined
+}

--- a/packages/lib/src/postings/__tests__/build-credit-memo-entry.test.ts
+++ b/packages/lib/src/postings/__tests__/build-credit-memo-entry.test.ts
@@ -210,6 +210,45 @@ describe('a channel credit memo with a settlement', () => {
     expect(built.settlementMinor).toBe(12_990)
   })
 
+  /**
+   * 🛑 The refund must come out of the account the SALE debited.
+   *
+   * A `payment_gateway` record routes a non-card rail to its own clearing
+   * account by id, so an Affirm sale debits `1210` while `clearing_card` is
+   * `1200`. Crediting the role for that refund leaves `1210` overstated
+   * forever - in an entry that balances perfectly, so nothing downstream
+   * detects it. This was the shape until 2026-09-11.
+   */
+  it('credits the gateway route BY ID when the sale was routed to one', () => {
+    const built = buildCreditMemoEntry({
+      ...BASE,
+      settlement: { glAccountId: 'acct_affirm', amount: 12_990 },
+    })
+
+    const clearing = built.entry.lines.find((row) => row.glAccountId === 'acct_affirm')
+    expect(clearing).toMatchObject({ direction: 'credit', amount: 12_990 })
+    // ...and NOT through the role, which is a different account.
+    expect(lines(built, ACCOUNT_ROLES.CLEARING_CARD)).toHaveLength(0)
+    expect(clearing?.accountRole).toBeUndefined()
+    expect(built.entry.totalDebit).toBe(built.entry.totalCredit)
+  })
+
+  it('still balances on the pre-fulfillment branch with an id-routed settlement', () => {
+    const built = buildCreditMemoEntry({
+      ...BASE,
+      reverseRevenue: false,
+      settlement: { glAccountId: 'acct_affirm', amount: 12_990 },
+    })
+
+    expect(built.entry.lines).toHaveLength(2)
+    expect(built.entry.totalDebit).toBe(12_990)
+    expect(built.entry.totalCredit).toBe(12_990)
+    expect(built.entry.lines.find((row) => row.glAccountId === 'acct_affirm')).toMatchObject({
+      direction: 'credit',
+      amount: 12_990,
+    })
+  })
+
   it('allows a settlement smaller than the total', () => {
     const built = buildCreditMemoEntry({
       ...BASE,

--- a/packages/lib/src/postings/build-credit-memo-entry.ts
+++ b/packages/lib/src/postings/build-credit-memo-entry.ts
@@ -71,18 +71,28 @@ export const CREDIT_MEMO_SOURCE_TYPE = 'credit_memo'
 export const CREDIT_MEMO_POSTING_TYPE = 'credit_memo' as const
 
 /**
- * The money leg of a channel memo.
+ * The money leg of a channel memo: WHERE the refund comes back out of.
  *
- * `role` is a discriminator with one member today: `clearing_card` is the ONE
- * clearing role, the account the channel receipt debited gross at the sale and
- * the payout entry drains. When a second clearing role lands, this grows a
- * member rather than the builder growing a parameter.
+ * 🛑 **It has to be the account the SALE debited, whatever that was.** A
+ * `payment_gateway` record routes a non-card rail to its own clearing account
+ * by id (brief 13 §5.3), so an Affirm sale debits `1210` while `clearing_card`
+ * is `1200`. A refund hardcoded to the role would credit `1200` for money that
+ * never entered it and leave `1210` overstated forever - and since the entry
+ * balances either way, nothing downstream could detect it. This was the shape
+ * until 2026-09-11; the two members exist so a refund can mirror its sale.
+ *
+ * | Member | When |
+ * | --- | --- |
+ * | `{ role: 'clearing_card' }` | no `payment_gateway` record names the order's gateway - the same default the fulfillment debit fork takes |
+ * | `{ glAccountId }` | exactly one record claims it, and the sale debited that account |
+ *
+ * `amount` is integer minor units, > 0 and at most `total` - what the channel
+ * actually paid back.
  */
-export interface CreditMemoSettlement {
-  role: 'clearing_card'
-  /** Integer minor units, > 0 and at most `total`. What the channel paid back. */
-  amount: number
-}
+export type CreditMemoSettlement = { amount: number } & (
+  | { role: 'clearing_card'; glAccountId?: never }
+  | { glAccountId: string; role?: never }
+)
 
 export interface BuildCreditMemoEntryInput {
   /** The `credit_memo` EntityInstance id. Becomes every line's `sourceId`. */
@@ -303,7 +313,12 @@ export function buildCreditMemoEntry(input: BuildCreditMemoEntryInput): BuiltCre
     })
     lines.push({
       ...source,
-      accountRole: ACCOUNT_ROLES.CLEARING_CARD,
+      // By ID when a `payment_gateway` record routed the sale, by ROLE
+      // otherwise - see {@link CreditMemoSettlement}. The two are mutually
+      // exclusive on the type, so exactly one of these keys is ever set.
+      ...(settlement.glAccountId
+        ? { glAccountId: settlement.glAccountId }
+        : { accountRole: ACCOUNT_ROLES.CLEARING_CARD }),
       direction: 'credit',
       amount: settlementMinor,
       memo: `${lineMemo} refunded`,

--- a/packages/lib/src/postings/build-fulfillment-batch-entry.ts
+++ b/packages/lib/src/postings/build-fulfillment-batch-entry.ts
@@ -61,6 +61,7 @@ import type {
   UnpostedShipmentLine,
 } from '../money/fulfillment-posting/types'
 import { FULFILLMENT_BATCH_SOURCE_TYPE } from '../money/fulfillment-posting/types'
+import { matchGatewayRoute } from '../payment-gateways/client'
 import { ACCOUNT_ROLES, type AccountRole, buildEntry } from './build-entry'
 import {
   CHANNEL_KEYS,
@@ -156,6 +157,10 @@ export const FULFILLMENT_GATEWAY_DEBIT: Readonly<
  * gateway's past shipments still post to its own clearing account so it keeps
  * reconciling, and "should this route still be offered" is lane 4's plan.ts
  * concern, not this match's.
+ *
+ * Structurally `GatewayRoute` from `payment-gateways/client.ts`, which is where
+ * the matcher lives - see {@link matchGatewayRoute}. Kept as a named type here
+ * because this builder's signature is the contract lane 4 was written against.
  */
 export interface FulfillmentGatewayRoute {
   handles: readonly string[]
@@ -193,26 +198,6 @@ function normaliseGateways(gateways: readonly string[]): string[] {
     out.push(value)
   }
   return out
-}
-
-/**
- * Which `payment_gateway` record's clearing account a normalised gateway
- * names, when EXACTLY ONE route's `handles` matches it case-insensitively.
- *
- * Zero matches falls back to {@link FULFILLMENT_GATEWAY_DEBIT}'s role table -
- * the record has nothing to say about this gateway yet. More than one match
- * (two routes both claiming the same handle, which the record's own write
- * path should never allow) falls back the same way rather than guessing which
- * route is right.
- */
-function matchGatewayRoute(
-  gateway: string,
-  routes: readonly FulfillmentGatewayRoute[] = []
-): string | undefined {
-  const matches = routes.filter((route) =>
-    route.handles.some((handle) => handle.trim().toLowerCase() === gateway)
-  )
-  return matches.length === 1 ? matches[0]?.clearingGlAccountId : undefined
 }
 
 /**


### PR DESCRIPTION
Two bugs found by driving a month-end close on a dev org, plus the cleanup the second one turned up.

## 1. The settlement leg named a role, so a refund could leave the wrong account

`issueCreditMemo` built the channel money leg as a hardcoded role:

```js
? { role: 'clearing_card', amount: Math.round(memo.amountRefundedMinor) }
```

Since brief 13 §5.3 a `payment_gateway` record routes a non-card rail to its **own** clearing account by id — so an Affirm sale debits `1210` while `clearing_card` is `1200`. The refund credited `1200` for money that never entered it and left `1210` overstated forever.

🛑 **The entry balances either way, so nothing downstream could ever detect it.** Same failure mode `ROLE_ACCOUNT_TYPES` and `resolveRoles` exist to prevent from the other direction.

**`CreditMemoSettlement` becomes the two-member union `FulfillmentDebit` already had** — a role, or a `glAccountId`. Supporting changes:

- **`matchGatewayRoute` moves into `payment-gateways/client.ts` as the single matcher.** The sale side (`build-fulfillment-batch-entry.ts`) had a private copy; two copies that disagree put a sale and its refund in different accounts, which is the bug one level up.
- **`readOrderGateways`** reads `order_payment_gateways`, which is **TAGS** — the value is in `optionId`. Reading `valueText` returns nothing at all and every refund falls silently back to the role, the quiet version of the same bug.
- Falls back to `clearing_card` on every uncertainty: no order, no gateway, no matching record, two records claiming one handle, two gateways on the order. That's where a wrong answer fails to reconcile *visibly*.

## 2. The issue dialog could not send a date the router would accept

`creditMemo.previewIssue` takes a calendar day. The dialog sent a timestamp, from two places:

```json
{"issuedAt":"2018-01-13 08:03:34+00"}      // prefill from credit_memo_issued_at (a DATETIME)
{"issuedAt":"2018-01-13T00:00:00.000Z"}    // FieldInputAdapter's onChange
```

Neither is `YYYY-MM-DD`, so the procedure refused its input, `previewQuery` never resolved, and `canSave = !!date && !!preview && !preview.blockedBy` stayed false. **Issue was disabled with nothing on screen to say why** — a dead button indistinguishable from a loading one.

⚠️ **Not a channel-memo problem.** `todayIso()` returned a full ISO instant too, so a native memo failed identically. **No credit memo had ever been issued through this dialog** — zero `credit_memo` postings existed in the database before this was found.

Both doors now go through `normalizeCalendarDayIso(...)?.slice(0, 10)`, the helper `use-opening-stock.ts` already uses: it rounds to the **nearest** UTC midnight, where truncating is off by one for every writer east of UTC. And a refused preview now renders its error — a blocker is the *entry* saying no, this is the *request* saying no, and both have to be visible.

## 3. `z.iso.date()`

The schema was doing its job in #2 — it caught a genuinely wrong value. But it was hand-rolled **28 times across 10 routers**, three behind local aliases. Zod 4 has `z.iso.date()` and this repo is on **4.1.5**; `z.iso` was already used elsewhere.

Verified identical before swapping: `2026-01-13` passes, both malformed forms above are refused, `.optional()` works.

`dateKey` is deleted (a bare alias of a shorter call). **`calendarDaySchema` and `isoDate` stay** — they carry `'Expected YYYY-MM-DD'`, more useful to an API caller than zod's `"Invalid ISO date"`, and are used 2–6 times each, so inlining would repeat the message rather than remove duplication.

## Verified

Both fixes driven against a dev org, not only unit-tested.

**#1** — 14 channel credit memos issued through `issueCreditMemo`; the clearing credit landed with `accountRole: NULL` and `accountCode: 1200`, routed **by account id** through the Authorize.Net gateway record. 13 of 14 reversed revenue; the 14th correctly posted only the money leg (its order had no shipment before the memo date).

**#2** — the dialog now loads its preview and enables Issue:

```
Account                      Debit      Credit
Accounts Receivable (A/R)   $250.00
1200 Card Clearing                      $250.00
Totals                      $250.00     $250.00
Balanced. Debits equal credits.
```

Two new builder tests pin that an id-routed settlement credits the account and emits **no** `clearing_card` line, on both the revenue-reversing and money-only branches.

`packages/lib` postings/money/payment-gateways: **2,317 pass**. Both typecheck ratchets clean. Biome clean.

## Not included

`packages/lib/scripts/issue-channel-credit-memos.ts` is left untracked — it writes to the ledger and isn't part of the fix.

https://claude.ai/code/session_01PKDDRhkBUjEyi3GKigfLYn
