### PR TITLE
feat(accounting): create an account in the provider and link it, from the row

### DIFF
--- a/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/accounts-settings-page.tsx
@@ -185,6 +185,7 @@ export function AccountingAccountsSettingsPage() {
       providerAccounts: accountMap.data?.providerAccounts ?? [],
       broken: accountMap.data?.broken ?? [],
       suggested: rows.filter((row) => row.suggestion).length,
+      canCreate: accountMap.data?.canCreateProviderAccounts ?? false,
       providerLabel: provider.providerLabel,
       isPending: accountMap.isPending,
       isError: accountMap.isError,
@@ -423,6 +424,66 @@ export function AccountingAccountsSettingsPage() {
     [handleSetIdentity]
   )
 
+  /**
+   * Create ONE row's account in the connected system and link it.
+   *
+   * 🛑 Confirms first, and the confirm is not a formality: every other write on
+   * this page changes something of ours, and this one adds an account to
+   * somebody's real books. QuickBooks cannot delete an account - the most anyone
+   * can do afterwards is deactivate it - so "are you sure" is the last point at
+   * which a misclick is free.
+   *
+   * Toasts its refusal, like `handleAcceptSuggestion` and for the same reason: a
+   * list row has no field for a sentence to land on, and the row is on screen so
+   * the message can name the account.
+   */
+  const [creatingAccountId, setCreatingAccountId] = useState<string | null>(null)
+  const createInProvider = api.ledger.createProviderAccount.useMutation()
+
+  const handleCreateInProvider = useCallback(
+    async (glAccountId: string) => {
+      const account = accounts.find((row) => row.id === glAccountId)
+      const where = mapView.providerLabel ?? 'the connected accounting system'
+      const confirmed = await confirm({
+        title: `Create this account in ${where}?`,
+        description: `${formatAccountLabel(account)} will be added to ${where}'s chart of accounts and linked to this one. ${where} cannot delete an account once it exists - it can only be made inactive.`,
+        confirmText: 'Create and link',
+        cancelText: 'Cancel',
+      })
+      if (!confirmed) return
+
+      setCreatingAccountId(glAccountId)
+      try {
+        const result = await createInProvider.mutateAsync({ glAccountId })
+        await utils.ledger.accountMap.invalidate()
+        // ⚠️ Not a success toast - the page has none, and the link badge flipping
+        // to Linked is the confirmation. These are the two outcomes that are NOT
+        // what the button said it would do, so they are worth a sentence: the
+        // account already existed and nothing was created, or the code did not
+        // survive because the company keeps no account numbers.
+        if (result.outcome === 'existing') {
+          toastError({
+            title: `${where} already had this account`,
+            description: `Linked to '${result.row.providerAccountName}'. Nothing was created.`,
+          })
+        } else if (result.numberDropped) {
+          toastError({
+            title: 'Linked, but without the account number',
+            description: `${where} has account numbers turned off, so '${formatAccountLabel(account)}' was created by name only.`,
+          })
+        }
+      } catch (error) {
+        toastError({
+          title: `Error creating the account in ${where}`,
+          description: error instanceof Error ? error.message : 'Could not create the account.',
+        })
+      } finally {
+        setCreatingAccountId(null)
+      }
+    },
+    [accounts, confirm, createInProvider, mapView.providerLabel, utils]
+  )
+
   const confirmSuggested = api.ledger.confirmSuggestedAccounts.useMutation({
     onSuccess: async (result) => {
       await utils.ledger.accountMap.invalidate()
@@ -582,6 +643,10 @@ export function AccountingAccountsSettingsPage() {
                 void handleAcceptSuggestion(glAccountId, providerAccountId)
               }}
               acceptingAccountId={acceptingAccountId}
+              onCreateInProvider={(glAccountId) => {
+                void handleCreateInProvider(glAccountId)
+              }}
+              creatingAccountId={creatingAccountId}
               onSelect={handleSelectAccount}
               rolesByAccountId={rolesByAccountId}
               draft={chartDraft}

--- a/apps/web/src/components/accounting/ui/settings/accounts-types.ts
+++ b/apps/web/src/components/accounting/ui/settings/accounts-types.ts
@@ -135,6 +135,17 @@ export interface ChartMapView {
   suggested: number
   /** `'QuickBooks Online'`, or null with nothing connected. Never hardcode it. */
   providerLabel: string | null
+  /**
+   * The connected system will accept accounts CREATED in it, so an unlinked row
+   * can offer create-and-link and not only a picker.
+   *
+   * 🛑 The server's answer, never this screen's guess. It is the presence of the
+   * adapter's optional `createProviderAccount`, so a provider that cannot do it
+   * makes the button ABSENT rather than present-and-failing. False while the map
+   * is still loading and false with nothing connected, both of which are the
+   * honest answer to "can we?" at that moment.
+   */
+  canCreate: boolean
   /** The provider round trip is in flight. The chart does not wait on it. */
   isPending: boolean
   /** The provider round trip failed. One muted line, not a page-level error. */

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -48,6 +48,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import {
   BookOpen,
   ChevronDown,
+  CloudUpload,
   Landmark,
   Link2,
   Plus,
@@ -106,6 +107,10 @@ interface ChartListProps {
   onAcceptSuggestion: (glAccountId: string, providerAccountId: string) => void
   /** The account id whose single-row accept is in flight, if any. */
   acceptingAccountId: string | null
+  /** Creates ONE row's account in the connected system and links it. */
+  onCreateInProvider: (glAccountId: string) => void
+  /** The account id whose create-and-link is in flight, if any. */
+  creatingAccountId: string | null
   /** `PermissionKey.ledgerControl`. False hides every write affordance this
    *  list owns (Add account, Accept N) - the read path stays fully usable. */
   canControl: boolean
@@ -129,6 +134,8 @@ export function ChartList({
   confirming,
   onAcceptSuggestion,
   acceptingAccountId,
+  onCreateInProvider,
+  creatingAccountId,
   canControl,
 }: ChartListProps) {
   const [search, setSearch] = useState('')
@@ -428,6 +435,8 @@ export function ChartList({
                       onSelect={onSelect}
                       onAcceptSuggestion={onAcceptSuggestion}
                       acceptingAccountId={acceptingAccountId}
+                      onCreateInProvider={onCreateInProvider}
+                      creatingAccountId={creatingAccountId}
                       onRemoveAccount={onRemoveAccount}
                       onRestoreAccount={onRestoreAccount}
                       canControl={canControl}
@@ -495,6 +504,8 @@ interface ChartAccountListRowProps {
   onSelect: (id: string | null) => void
   onAcceptSuggestion: (glAccountId: string, providerAccountId: string) => void
   acceptingAccountId: string | null
+  onCreateInProvider: (glAccountId: string) => void
+  creatingAccountId: string | null
   onRemoveAccount: (id: string) => void
   onRestoreAccount: (id: string) => void
   canControl: boolean
@@ -516,6 +527,8 @@ function ChartAccountListRow({
   onSelect,
   onAcceptSuggestion,
   acceptingAccountId,
+  onCreateInProvider,
+  creatingAccountId,
   onRemoveAccount,
   onRestoreAccount,
   canControl,
@@ -530,6 +543,13 @@ function ChartAccountListRow({
   // row action derived from a round trip that has not answered
   // yet is an offer the server may be about to refuse.
   const suggestion = map.connected && !map.isPending ? identity?.suggestion : undefined
+  // 🛑 Offered ONLY where there is no candidate to link. A row the matcher found
+  // something for should link the account that already exists - creating a
+  // second one beside it is how a chart ends up with two "Card Clearing"s, which
+  // split a balance in half with no error anywhere. The two buttons are never
+  // both on a row, and which one appears is this line.
+  const canCreateHere =
+    map.connected && !map.isPending && map.canCreate && !suggestion && !identity?.providerAccountId
   const AccountIcon = accountTypeIcon(account.accountType)
   return (
     <TreeRow
@@ -591,6 +611,28 @@ function ChartAccountListRow({
                     disabled={acceptingAccountId === account.id}
                     onClick={() => onAcceptSuggestion(account.id, suggestion.account.id)}>
                     <Link2 />
+                  </TreeRowButton>
+                )}
+                {/* 🛑 A DIFFERENT action from the one above, not a
+                  variant of it, which is why it wears a different
+                  glyph. That one agrees to a pairing the matcher
+                  proposed; this one ADDS an account to somebody's
+                  real books. They are mutually exclusive by
+                  `canCreateHere`, so no row ever shows both and
+                  nobody has to work out which is which.
+                  🛑 `persistent`, like the accept button and for
+                  the same reason: it exists on a subset of rows,
+                  and hover-hunting to find which ones is exactly
+                  what pinning avoids. The tooltip NAMES the
+                  provider - "create it in QuickBooks" is a
+                  sentence somebody can decline; "create" is not. */}
+                {canCreateHere && (
+                  <TreeRowButton
+                    persistent
+                    tooltipText={`Create this account in ${map.providerLabel ?? 'the accounting system'} and link it`}
+                    disabled={creatingAccountId === account.id}
+                    onClick={() => onCreateInProvider(account.id)}>
+                    <CloudUpload />
                   </TreeRowButton>
                 )}
                 {/* 🛑 NOT `persistent`, unlike the accept button

--- a/apps/web/src/server/api/routers/ledger.ts
+++ b/apps/web/src/server/api/routers/ledger.ts
@@ -10,6 +10,7 @@ import {
   buildEntry,
   CHART_PACK_KEYS,
   confirmSuggestedIdentities,
+  createAndLinkProviderAccount,
   createChartAccount,
   createJournalEntry,
   DEFAULT_CHART_OF_ACCOUNTS,
@@ -628,6 +629,33 @@ export const ledgerRouter = createTRPCRouter({
         organizationId: ctx.session.organizationId,
         glAccountId: input.glAccountId,
         providerAccountId: input.providerAccountId,
+        actorUserId: ctx.session.userId,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
+    }),
+
+  /**
+   * Create the counterpart of one of our accounts in the connected system, then
+   * link the two - the seam run BACKWARDS.
+   *
+   * The accounts auxx creates itself (a clearing account per card rail, the
+   * role-bearing core) exist on one side only, so the matcher has nothing to
+   * offer for them and {@link setAccountIdentity} has nothing to point at. This
+   * is how they stop blocking the export without somebody retyping each one
+   * into QuickBooks by hand.
+   *
+   * Same rung as `setAccountIdentity` and for a stronger version of its reason:
+   * this does not only decide which external account real money lands in, it
+   * ADDS that account to somebody's books. `accountMap.canCreateProviderAccounts`
+   * says whether the connected system can be asked at all.
+   */
+  createProviderAccount: permissionProcedure(PermissionKey.ledgerControl)
+    .input(z.object({ glAccountId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const result = await createAndLinkProviderAccount(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        glAccountId: input.glAccountId,
         actorUserId: ctx.session.userId,
       })
       if (result.isErr()) throw result.error

--- a/packages/lib/src/money/quickbooks/__tests__/account-types.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/account-types.test.ts
@@ -1,0 +1,68 @@
+// packages/lib/src/money/quickbooks/__tests__/account-types.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { GL_ACCOUNT_SUBTYPES } from '../../../postings/account-subtype'
+import { GL_ACCOUNT_TYPES } from '../../../postings/default-chart'
+import { quickbooksAccountType } from '../account-types'
+
+describe('quickbooksAccountType', () => {
+  it('always returns BOTH halves, for every classification and subtype', () => {
+    // 🛑 The invariant the whole file exists for. QuickBooks accepts an
+    // AccountType alone and then invents a subtype of its own - probed
+    // 2026-09-10, an `Other Current Asset` came back as `EmployeeCashAdvances` -
+    // and the subtype is what their reports group by. A pair with an empty half
+    // is therefore not a partial answer, it is a wrong one.
+    for (const classification of GL_ACCOUNT_TYPES) {
+      for (const subtype of [null, ...GL_ACCOUNT_SUBTYPES]) {
+        const pair = quickbooksAccountType(classification, subtype)
+        expect(pair.accountType, `${classification}/${subtype}`).toBeTruthy()
+        expect(pair.accountSubType, `${classification}/${subtype}`).toBeTruthy()
+      }
+    }
+  })
+
+  it('prefers the subtype when it agrees with the classification', () => {
+    expect(quickbooksAccountType('asset', 'bank')).toEqual({
+      accountType: 'Bank',
+      accountSubType: 'Checking',
+    })
+    expect(quickbooksAccountType('expense', 'cost_of_goods_sold')).toEqual({
+      accountType: 'Cost of Goods Sold',
+      accountSubType: 'SuppliesMaterialsCogs',
+    })
+  })
+
+  it('falls back to the classification for `other` and for no subtype', () => {
+    // `other` means "no second fact", so it must not resolve to a pair of its
+    // own - it has to read exactly like the null case.
+    expect(quickbooksAccountType('asset', 'other')).toEqual(quickbooksAccountType('asset', null))
+    expect(quickbooksAccountType('liability', null)).toEqual({
+      accountType: 'Other Current Liability',
+      accountSubType: 'OtherCurrentLiabilities',
+    })
+  })
+
+  it('lets the CLASSIFICATION win when the two fields disagree', () => {
+    // 🛑 The guard, not a formality. `subtype` and `accountType` are two
+    // independently edited fields and nothing stops a `revenue` account carrying
+    // `subtype: bank`. Sending `Bank` would create a real asset account in
+    // somebody's books that our ledger then posts revenue into.
+    expect(quickbooksAccountType('revenue', 'bank')).toEqual({
+      accountType: 'Income',
+      accountSubType: 'SalesOfProductIncome',
+    })
+    expect(quickbooksAccountType('asset', 'accounts_payable')).toEqual({
+      accountType: 'Other Current Asset',
+      accountSubType: 'OtherCurrentAssets',
+    })
+  })
+
+  it('never defaults equity to one of QuickBooks own special accounts', () => {
+    // Opening Balance Equity and Retained Earnings both have meanings Intuit
+    // assigns itself; landing a chart account on either would be worse than
+    // refusing.
+    const equity = quickbooksAccountType('equity', null)
+    expect(equity.accountSubType).not.toBe('OpeningBalanceEquity')
+    expect(equity.accountSubType).not.toBe('RetainedEarnings')
+  })
+})

--- a/packages/lib/src/money/quickbooks/__tests__/quickbooks-accounting-provider.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/quickbooks-accounting-provider.test.ts
@@ -923,3 +923,130 @@ describe('resolveAccount - the only place a code becomes a provider id', () => {
     expect(callTool).not.toHaveBeenCalledWith('find_quickbooks_journal_entry', expect.anything())
   })
 })
+
+describe('createProviderAccount - the seam run backwards', () => {
+  /** What `create_quickbooks_account` came back with, in the tool's own shape. */
+  const CREATED = {
+    id: '104',
+    name: 'Card Clearing',
+    fullyQualifiedName: 'Card Clearing',
+    acctNum: '1200',
+    accountType: 'Other Current Asset',
+    accountSubType: 'OtherCurrentAssets',
+    classification: 'Asset',
+    active: true,
+  }
+
+  function connectCreate(over: Record<string, unknown> = {}) {
+    return connect({
+      create_quickbooks_account: () => ({
+        account: CREATED,
+        outcome: 'created',
+        acctNumDropped: false,
+        ...over,
+      }),
+    })
+  }
+
+  function createCall(callTool: ReturnType<typeof vi.fn>) {
+    return callTool.mock.calls.find(([toolId]) => toolId === 'create_quickbooks_account')?.[1]
+  }
+
+  const input = {
+    orgId: ORG_ID,
+    glAccountId: 'acct_1200',
+    name: 'Card Clearing',
+    code: '1200',
+    classification: 'asset' as const,
+    subtype: null,
+  }
+
+  it('sends BOTH type columns, never a bare AccountType', () => {
+    // 🛑 The one thing this method must not get wrong. QuickBooks accepts a type
+    // alone and then files the account under a subtype of its own choosing -
+    // probed 2026-09-10, an `Other Current Asset` came back as
+    // `EmployeeCashAdvances` - and the subtype is what their reports group by.
+    const callTool = connectCreate()
+    return provider.createProviderAccount(input).then(() => {
+      expect(createCall(callTool)).toMatchObject({
+        name: 'Card Clearing',
+        acctNum: '1200',
+        accountType: 'Other Current Asset',
+        accountSubType: 'OtherCurrentAssets',
+      })
+    })
+  })
+
+  it('translates OUR subtype into the provider type pair', async () => {
+    const callTool = connectCreate()
+    await provider.createProviderAccount({
+      ...input,
+      classification: 'liability',
+      subtype: 'accounts_payable',
+    })
+    expect(createCall(callTool)).toMatchObject({
+      accountType: 'Accounts Payable',
+      accountSubType: 'AccountsPayable',
+    })
+  })
+
+  it('omits acctNum entirely for an uncoded account rather than sending an empty one', async () => {
+    const callTool = connectCreate()
+    await provider.createProviderAccount({ ...input, code: null })
+    expect(createCall(callTool)).not.toHaveProperty('acctNum')
+  })
+
+  it('returns the account in the same shape the chart read speaks', async () => {
+    connectCreate()
+    const result = await provider.createProviderAccount(input)
+    expect(result._unsafeUnwrap().account).toEqual({
+      id: '104',
+      name: 'Card Clearing',
+      fullyQualifiedName: 'Card Clearing',
+      number: '1200',
+      accountType: 'Other Current Asset',
+      classification: 'asset',
+      active: true,
+    })
+    expect(result._unsafeUnwrap().outcome).toBe('created')
+    expect(result._unsafeUnwrap().numberDropped).toBe(false)
+  })
+
+  it('carries the tool `existing` / `acctNumDropped` answers through unchanged', async () => {
+    connectCreate({
+      account: { ...CREATED, acctNum: null },
+      outcome: 'existing',
+      acctNumDropped: true,
+    })
+    const result = await provider.createProviderAccount(input)
+    expect(result._unsafeUnwrap().outcome).toBe('existing')
+    expect(result._unsafeUnwrap().numberDropped).toBe(true)
+    expect(result._unsafeUnwrap().account.number).toBeNull()
+  })
+
+  it('refuses an account whose classification it cannot read, rather than defaulting it', async () => {
+    connectCreate({ account: { ...CREATED, classification: 'Nonsense' } })
+    const result = await provider.createProviderAccount(input)
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('unreadable classification')
+  })
+
+  it("turns the tool's refusal into an error naming the account", async () => {
+    connect({
+      create_quickbooks_account: () => {
+        throw new Error('The name supplied already exists.')
+      },
+    })
+    const result = await provider.createProviderAccount(input)
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('Card Clearing')
+    expect(result._unsafeUnwrapErr().message).toContain('already exists')
+  })
+
+  it('refuses with nothing connected instead of reporting a silent success', async () => {
+    resolveQuickbooksContext.mockResolvedValue({ connected: false })
+    const result = await provider.createProviderAccount(input)
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('not connected')
+  })
+})

--- a/packages/lib/src/money/quickbooks/account-map.ts
+++ b/packages/lib/src/money/quickbooks/account-map.ts
@@ -53,8 +53,8 @@ export const QBO_ACCOUNT_ID_FIELD = 'qboAccountId'
 /** The system entity type slug the map hangs on. Not the definition's UUID. */
 const GL_ACCOUNT_ENTITY_TYPE = 'gl_account'
 
-/** `list_quickbooks_accounts`, as this module consumes it. */
-interface MappedAccount {
+/** `list_quickbooks_accounts` and `create_quickbooks_account`, as this module consumes them. */
+export interface MappedAccount {
   id: string
   name: string
   fullyQualifiedName: string
@@ -101,25 +101,45 @@ export async function listQuickbooksProviderAccounts(
 
   const accounts: ProviderAccount[] = []
   for (const account of raw) {
-    const classification = CLASSIFICATION[account.classification]
-    if (!classification) {
+    const mapped = toProviderAccount(account)
+    if (!mapped) {
       logger.warn('Skipping a QuickBooks account with an unreadable classification', {
         providerAccountId: account.id,
         classification: account.classification,
       })
       continue
     }
-    accounts.push({
-      id: String(account.id),
-      name: account.name,
-      fullyQualifiedName: account.fullyQualifiedName || account.name,
-      number: account.acctNum?.trim() || null,
-      accountType: account.accountType,
-      classification,
-      active: account.active !== false,
-    })
+    accounts.push(mapped)
   }
   return accounts
+}
+
+/**
+ * One tool-shaped account as the provider-neutral {@link ProviderAccount}, or
+ * null when its classification is not one of the five sections.
+ *
+ * 🛑 ONE conversion, two callers - the chart read above and
+ * `createProviderAccount`'s answer, which comes back in the same shape from a
+ * different tool. They used to be the same six lines written twice, which is
+ * the arrangement where one of them learns about a field and the other does
+ * not.
+ *
+ * Null rather than a default, for the reason {@link CLASSIFICATION} gives: an
+ * account whose statement section we cannot read must never be offered as a
+ * candidate for one of ours.
+ */
+export function toProviderAccount(account: MappedAccount): ProviderAccount | null {
+  const classification = CLASSIFICATION[account.classification]
+  if (!classification) return null
+  return {
+    id: String(account.id),
+    name: account.name,
+    fullyQualifiedName: account.fullyQualifiedName || account.name,
+    number: account.acctNum?.trim() || null,
+    accountType: account.accountType,
+    classification,
+    active: account.active !== false,
+  }
 }
 
 /**

--- a/packages/lib/src/money/quickbooks/account-types.ts
+++ b/packages/lib/src/money/quickbooks/account-types.ts
@@ -1,0 +1,144 @@
+// packages/lib/src/money/quickbooks/account-types.ts
+
+/**
+ * How one of OUR accounts should be described to QuickBooks when auxx asks it
+ * to create the counterpart - the OUTBOUND half of the type vocabulary.
+ *
+ * `suggest-account-identities.ts`'s `SUBTYPE_PROVIDER_ACCOUNT_TYPES` is the
+ * inbound half, and the two are not mirror images: inbound asks "may this
+ * provider account satisfy that subtype of ours", which is a permissive
+ * many-to-one check, while this one has to pick exactly one pair to send. A
+ * table that tried to do both would end up either refusing legal imports or
+ * inventing a creation it could not justify.
+ *
+ * ## Why both columns are always sent
+ *
+ * QuickBooks accepts an `AccountType` on its own - and then invents an
+ * `AccountSubType` of its own choosing. Probed against realm 9341453857213446
+ * on 2026-09-10: an account created as `Other Current Asset` with no subtype
+ * came back filed under **`EmployeeCashAdvances`**. The subtype is what QBO's
+ * own reports group by, so a clearing account left to Intuit's default lands in
+ * a section nobody chose and reads as an employee advance on their books. Every
+ * row below therefore names both, and `quickbooksAccountType` never returns a
+ * pair with the subtype missing.
+ *
+ * ## Where the strings come from
+ *
+ * Read off a real company's chart rather than transcribed from documentation -
+ * the exact spellings Intuit round-trips (`OtherCurrentAssets` with the plural,
+ * `SuppliesMaterialsCogs` with the suffix) are what a create must send, and a
+ * near-miss is a fault rather than a silent default. Two values below are the
+ * exception and are marked: they are standard Intuit members that the sandbox
+ * company happens to hold no example of.
+ */
+
+import type { GlAccountSubtypeValue } from '../../postings/account-subtype'
+import type { GlAccountTypeValue } from '../../postings/default-chart'
+
+/** One QuickBooks type pair, both halves always present. */
+export interface QuickbooksAccountType {
+  /** `Account.AccountType` - 'Other Current Asset', 'Bank', 'Income'. */
+  accountType: string
+  /** `Account.AccountSubType` - 'OtherCurrentAssets', 'Checking'. */
+  accountSubType: string
+}
+
+/**
+ * The answer when the account's statement classification is all we know.
+ *
+ * 🛑 Each of these is the deliberately GENERIC member of its section, never the
+ * most common one. `Expense`/`OtherMiscellaneousServiceCost` is Intuit's own
+ * "Other Business Expenses"; `Income`/`SalesOfProductIncome` is the plain sales
+ * line. The temptation is to pick something more specific because it is what a
+ * chart usually holds - but a wrong specific subtype is invisible (the account
+ * still posts, it just groups oddly on their reports), while a generic one is
+ * merely unremarkable and can be corrected in QuickBooks in one click.
+ *
+ * ⚠️ `equity` is the one row with no example in the probed company, which held
+ * only the two special equity accounts (`OpeningBalanceEquity`,
+ * `RetainedEarnings`) - and defaulting to either of THOSE would be actively
+ * wrong, because QuickBooks gives both of them meanings of its own. Intuit
+ * rejects an unknown subtype with a fault naming the field, so a mistake here
+ * surfaces as a refusal a person can read rather than as a misfiled account.
+ */
+const BY_CLASSIFICATION: Record<GlAccountTypeValue, QuickbooksAccountType> = {
+  asset: { accountType: 'Other Current Asset', accountSubType: 'OtherCurrentAssets' },
+  liability: { accountType: 'Other Current Liability', accountSubType: 'OtherCurrentLiabilities' },
+  equity: { accountType: 'Equity', accountSubType: 'OwnersEquity' },
+  revenue: { accountType: 'Income', accountSubType: 'SalesOfProductIncome' },
+  expense: { accountType: 'Expense', accountSubType: 'OtherMiscellaneousServiceCost' },
+}
+
+/**
+ * The answer when the account carries one of our eight subtypes, which is a
+ * better one - our subtype is a statement about what the account IS, and it
+ * lines up with a QuickBooks detail type almost exactly.
+ *
+ * `other` is absent deliberately: it means "no second fact", so it must fall
+ * through to the classification rather than resolve to some generic pair of its
+ * own. A subtype whose classification disagrees with the account's is refused
+ * by {@link quickbooksAccountType} rather than silently preferred.
+ *
+ * ⚠️ `fixed_asset` is the second unobserved row - the probed company held only
+ * `Vehicles` and `AccumulatedDepreciation`, both too specific to default to.
+ */
+const BY_SUBTYPE: Partial<Record<GlAccountSubtypeValue, QuickbooksAccountType>> = {
+  bank: { accountType: 'Bank', accountSubType: 'Checking' },
+  accounts_receivable: {
+    accountType: 'Accounts Receivable',
+    accountSubType: 'AccountsReceivable',
+  },
+  accounts_payable: { accountType: 'Accounts Payable', accountSubType: 'AccountsPayable' },
+  credit_card: { accountType: 'Credit Card', accountSubType: 'CreditCard' },
+  inventory: { accountType: 'Other Current Asset', accountSubType: 'Inventory' },
+  fixed_asset: { accountType: 'Fixed Asset', accountSubType: 'OtherFixedAssets' },
+  cost_of_goods_sold: {
+    accountType: 'Cost of Goods Sold',
+    accountSubType: 'SuppliesMaterialsCogs',
+  },
+}
+
+/**
+ * Which statement section each subtype's pair belongs to, so a subtype can
+ * never drag an account into the wrong half of the balance sheet.
+ *
+ * 🛑 This guard is the reason the subtype is not simply trusted. Our `subtype`
+ * and our `accountType` are two independently edited fields on one
+ * `gl_account`, and nothing in the chart editor stops somebody saving a
+ * `revenue` account carrying `subtype: bank`. Sending `Bank` for it would
+ * create a real asset account in somebody's books that our ledger then posts
+ * revenue into - an entry that balances and misstates the balance sheet, which
+ * is exactly the failure class `suggest-account-identities.ts` refuses to make
+ * in the other direction. When the two disagree the CLASSIFICATION wins: it is
+ * the field every report already groups by.
+ */
+const SUBTYPE_CLASSIFICATION: Partial<Record<GlAccountSubtypeValue, GlAccountTypeValue>> = {
+  bank: 'asset',
+  accounts_receivable: 'asset',
+  accounts_payable: 'liability',
+  credit_card: 'liability',
+  inventory: 'asset',
+  fixed_asset: 'asset',
+  cost_of_goods_sold: 'expense',
+}
+
+/**
+ * The QuickBooks type pair to create one of our accounts as.
+ *
+ * Subtype first when it agrees with the classification, classification
+ * otherwise. Never returns a partial pair - see the file header on why sending
+ * a type without a subtype is worse than it looks.
+ *
+ * @param classification - the account's statement section, the field that wins
+ * @param subtype - our second fact, or null
+ */
+export function quickbooksAccountType(
+  classification: GlAccountTypeValue,
+  subtype: GlAccountSubtypeValue | null
+): QuickbooksAccountType {
+  if (subtype && SUBTYPE_CLASSIFICATION[subtype] === classification) {
+    const bySubtype = BY_SUBTYPE[subtype]
+    if (bySubtype) return bySubtype
+  }
+  return BY_CLASSIFICATION[classification]
+}

--- a/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
+++ b/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
@@ -74,6 +74,8 @@ import { accountLabel } from '../../postings/account-label'
 import type {
   AccountingProvider,
   ClearAccountMappingInput,
+  CreateProviderAccountInput,
+  CreateProviderAccountResult,
   SetAccountMappingInput,
 } from '../../postings/provider'
 import type { ProviderLedger } from '../../postings/provider-sync/client'
@@ -94,9 +96,12 @@ import { getOrganizationSetting } from '../../settings/settings-service'
 import {
   clearQuickbooksAccountMapping,
   listQuickbooksProviderAccounts,
+  type MappedAccount,
   readQuickbooksAccountMap,
   setQuickbooksAccountMapping,
+  toProviderAccount,
 } from './account-map'
+import { quickbooksAccountType } from './account-types'
 import { readQuickbooksIdField } from './identity-field'
 import { type QuickbooksToolContext, resolveQuickbooksContext } from './invoke-quickbooks-tool'
 
@@ -114,6 +119,8 @@ const TOOL_CREATE_JOURNAL_ENTRY = 'create_quickbooks_journal_entry'
 const TOOL_GET_BALANCE_SHEET = 'get_quickbooks_balance_sheet'
 /** Brief 20 section 5.1: the inbound half's one report read. */
 const TOOL_GET_GENERAL_LEDGER = 'get_quickbooks_general_ledger'
+/** The one call that runs the seam BACKWARDS - see `createProviderAccount`. */
+const TOOL_CREATE_ACCOUNT = 'create_quickbooks_account'
 
 /** QuickBooks caps `PrivateNote` at 4000 characters and rejects a longer one. */
 const PRIVATE_NOTE_MAX_LENGTH = 4000
@@ -811,6 +818,101 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
             organizationId: input.orgId,
             glAccountId: input.glAccountId,
           }
+        )
+      )
+    }
+  }
+
+  /**
+   * Create the QuickBooks counterpart of one of our accounts.
+   *
+   * The only method here that WRITES to QuickBooks outside a journal entry, and
+   * the reason it exists is §8.5 of the 2026-09-10 handoff: the accounts auxx
+   * creates itself - a clearing account per card rail, the role-bearing core -
+   * have no counterpart to match, so no suggestion is ever produced for them and
+   * the export refuses on every one. Linking them meant retyping each into
+   * QuickBooks by hand.
+   *
+   * ## Both type columns, always
+   *
+   * `quickbooksAccountType` returns a complete pair and this sends both.
+   * QuickBooks will accept an `AccountType` alone and then invent a subtype -
+   * probed on 2026-09-10, an `Other Current Asset` came back filed under
+   * `EmployeeCashAdvances` - and the subtype is what their reports group by.
+   * See `account-types.ts`.
+   *
+   * ## The tool refuses a duplicate; this does not re-decide that
+   *
+   * `create_quickbooks_account` looks by number then by name before writing and
+   * answers `outcome: 'existing'` rather than creating a second account, which
+   * is the guarantee the interface asks for. Its ambiguity refusal arrives here
+   * as a thrown `INVALID_INPUT` and becomes an `UnprocessableEntityError`
+   * carrying Intuit's own sentence - a person has to settle a duplicate in
+   * QuickBooks, and there is nothing useful this layer could add to that.
+   *
+   * 🛑 The mapping is NOT written here. `createAndLinkProviderAccount` re-checks
+   * that what came back is actually mappable before confirming it, so a
+   * surprising answer from the tool cannot become a silent pairing.
+   */
+  async createProviderAccount(
+    input: CreateProviderAccountInput
+  ): Promise<Result<CreateProviderAccountResult, Error>> {
+    const resolved = await resolveQuickbooksContext({
+      organizationId: input.orgId,
+      actorUserId: input.actorUserId,
+    })
+    if (!resolved.connected) {
+      return err(
+        new UnprocessableEntityError(
+          'QuickBooks is not connected, so an account cannot be created in it.',
+          { organizationId: input.orgId, glAccountId: input.glAccountId }
+        )
+      )
+    }
+
+    const { accountType, accountSubType } = quickbooksAccountType(
+      input.classification,
+      input.subtype
+    )
+
+    try {
+      const result = (await resolved.context.callTool(TOOL_CREATE_ACCOUNT, {
+        name: input.name,
+        ...(input.code ? { acctNum: input.code } : {}),
+        accountType,
+        accountSubType,
+      })) as {
+        account: MappedAccount
+        outcome: 'created' | 'existing'
+        acctNumDropped: boolean
+      }
+
+      // The same conversion `listProviderAccounts` uses, so an account read back
+      // from the chart and one just created cannot come out differently shaped.
+      const account = toProviderAccount(result.account)
+      if (!account) {
+        // Unreadable rather than wrong: we asked for a section and got back an
+        // account whose section we cannot parse, so we cannot say the pairing is
+        // safe. Refusing leaves an account in their chart with no mapping, which
+        // a person can link by hand; guessing would post money through it.
+        return err(
+          new UnprocessableEntityError(
+            `QuickBooks returned account '${result.account.fullyQualifiedName}' with an unreadable classification '${result.account.classification}'. Link it by hand.`,
+            { organizationId: input.orgId, glAccountId: input.glAccountId }
+          )
+        )
+      }
+
+      return ok({
+        account,
+        outcome: result.outcome,
+        numberDropped: Boolean(result.acctNumDropped),
+      })
+    } catch (error) {
+      return err(
+        new UnprocessableEntityError(
+          `Could not create '${input.name}' in QuickBooks: ${errorMessage(error)}`,
+          { organizationId: input.orgId, glAccountId: input.glAccountId, accountType }
         )
       )
     }

--- a/packages/lib/src/postings/__tests__/account-identities.test.ts
+++ b/packages/lib/src/postings/__tests__/account-identities.test.ts
@@ -15,6 +15,11 @@ vi.mock('../role-map', () => ({
 const resolveAccountingProvider = vi.fn()
 vi.mock('../provider', () => ({
   resolveAccountingProvider: (...a: unknown[]) => resolveAccountingProvider(...a),
+  // The real one, not a stub: it is three characters of logic over the provider
+  // the test already supplies, and a `vi.fn()` here would let the capability
+  // flag agree with whatever the test wanted rather than with the double.
+  supportsCreatingProviderAccounts: (provider: { createProviderAccount?: unknown }) =>
+    typeof provider.createProviderAccount === 'function',
 }))
 
 import type { Database } from '@auxx/database'

--- a/packages/lib/src/postings/__tests__/create-provider-account.test.ts
+++ b/packages/lib/src/postings/__tests__/create-provider-account.test.ts
@@ -1,0 +1,258 @@
+// packages/lib/src/postings/__tests__/create-provider-account.test.ts
+//
+// `create-provider-account.ts` runs the seam BACKWARDS, and like
+// `account-identities.ts` it is provider-neutral - what is stubbed here is an
+// `AccountingProvider`, never QuickBooks. The QuickBooks-shaped half of this
+// (which account type a create asks for) is `money/quickbooks/account-types.ts`
+// and is tested beside it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const listChartAccounts = vi.fn()
+vi.mock('../role-map', () => ({
+  listChartAccounts: (...a: unknown[]) => listChartAccounts(...a),
+}))
+
+const resolveAccountingProvider = vi.fn()
+vi.mock('../provider', () => ({
+  resolveAccountingProvider: (...a: unknown[]) => resolveAccountingProvider(...a),
+  supportsCreatingProviderAccounts: (provider: { createProviderAccount?: unknown }) =>
+    typeof provider.createProviderAccount === 'function',
+}))
+
+import type { Database } from '@auxx/database'
+import { err, ok } from 'neverthrow'
+import { createAndLinkProviderAccount } from '../create-provider-account'
+import type { ChartAccountRow, ProviderAccount } from '../types'
+
+const ORG = 'org1'
+const db = {} as Database
+
+const CLEARING: ChartAccountRow = {
+  id: 'gl1200',
+  code: '1200',
+  name: 'Card Clearing',
+  accountType: 'asset',
+  isActive: true,
+  subtype: null,
+}
+
+const CREATED: ProviderAccount = {
+  id: 'qbo104',
+  name: 'Card Clearing',
+  fullyQualifiedName: 'Card Clearing',
+  number: '1200',
+  accountType: 'Other Current Asset',
+  classification: 'asset',
+  active: true,
+}
+
+/** A provider that can create, with every call spied on. */
+function provider(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'stub',
+    listAccountMappings: vi.fn(async () => ok(new Map<string, string>())),
+    setAccountMapping: vi.fn(async () => ok(undefined)),
+    createProviderAccount: vi.fn(async () =>
+      ok({ account: CREATED, outcome: 'created' as const, numberDropped: false })
+    ),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  listChartAccounts.mockResolvedValue(ok([CLEARING]))
+})
+
+describe('createAndLinkProviderAccount - the happy path', () => {
+  it('describes the account in OUR vocabulary and links what comes back', async () => {
+    const p = provider()
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    const result = await createAndLinkProviderAccount(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1200',
+      actorUserId: 'user1',
+    })
+
+    expect(result.isOk()).toBe(true)
+    // 🛑 The whole of `P2` in one assertion: what crosses into the adapter is
+    // name/code/classification/subtype and nothing that names a provider's own
+    // type vocabulary. A field like `accountSubType` appearing here would mean
+    // QuickBooks had leaked one layer up.
+    expect(p.createProviderAccount).toHaveBeenCalledWith({
+      orgId: ORG,
+      glAccountId: 'gl1200',
+      name: 'Card Clearing',
+      code: '1200',
+      classification: 'asset',
+      subtype: null,
+      actorUserId: 'user1',
+    })
+    expect(p.setAccountMapping).toHaveBeenCalledWith({
+      orgId: ORG,
+      glAccountId: 'gl1200',
+      providerAccountId: 'qbo104',
+      actorUserId: 'user1',
+    })
+
+    const value = result._unsafeUnwrap()
+    expect(value.row.state).toBe('confirmed')
+    expect(value.row.providerAccountId).toBe('qbo104')
+    expect(value.outcome).toBe('created')
+  })
+
+  it('carries `existing` and `numberDropped` through instead of flattening them', async () => {
+    // Both are true and the call still SUCCEEDS - neither is a failure. They
+    // exist so the screen can say something other than "created it", which is
+    // what it would otherwise have to imply.
+    const p = provider({
+      createProviderAccount: vi.fn(async () =>
+        ok({
+          account: { ...CREATED, number: null },
+          outcome: 'existing' as const,
+          numberDropped: true,
+        })
+      ),
+    })
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    const result = await createAndLinkProviderAccount(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1200',
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().outcome).toBe('existing')
+    expect(result._unsafeUnwrap().numberDropped).toBe(true)
+    expect(p.setAccountMapping).toHaveBeenCalled()
+  })
+
+  it('sends a null code rather than inventing one for an uncoded account', async () => {
+    listChartAccounts.mockResolvedValue(ok([{ ...CLEARING, code: null }]))
+    const p = provider()
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    await createAndLinkProviderAccount(db, { organizationId: ORG, glAccountId: 'gl1200' })
+
+    expect(p.createProviderAccount).toHaveBeenCalledWith(expect.objectContaining({ code: null }))
+  })
+})
+
+describe('createAndLinkProviderAccount - what it refuses, and writes nothing', () => {
+  it('refuses a provider that cannot create accounts at all', async () => {
+    // The optional method absent IS the capability answer. Nothing is attempted.
+    const p = provider({ createProviderAccount: undefined })
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    const result = await createAndLinkProviderAccount(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1200',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('cannot have accounts added')
+    expect(p.setAccountMapping).not.toHaveBeenCalled()
+  })
+
+  it('refuses an account that is not in this org chart', async () => {
+    const p = provider()
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    const result = await createAndLinkProviderAccount(db, {
+      organizationId: ORG,
+      glAccountId: 'gl9999',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('gl9999')
+    expect(p.createProviderAccount).not.toHaveBeenCalled()
+  })
+
+  it('refuses an account that is ALREADY linked, before asking the provider', async () => {
+    // 🛑 The double-click guard. Without it a second click asks for a second
+    // counterpart to an account that has one, and whether that ends as a
+    // duplicate in somebody's books depends on the adapter being careful.
+    const p = provider({
+      listAccountMappings: vi.fn(async () => ok(new Map([['gl1200', 'qbo55']]))),
+    })
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    const result = await createAndLinkProviderAccount(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1200',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('already linked')
+    expect(p.createProviderAccount).not.toHaveBeenCalled()
+  })
+
+  it('does NOT link an account whose statement section disagrees with ours', async () => {
+    // The case that matters: the adapter REUSED an account it matched by name,
+    // and the match is in the wrong half of the books. Linking it would post
+    // asset movements into a revenue account - an entry that balances and
+    // misstates the P&L, which nothing downstream can catch.
+    const p = provider({
+      createProviderAccount: vi.fn(async () =>
+        ok({
+          account: { ...CREATED, classification: 'revenue' as const },
+          outcome: 'existing' as const,
+          numberDropped: false,
+        })
+      ),
+    })
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    const result = await createAndLinkProviderAccount(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1200',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('balance')
+    expect(p.setAccountMapping).not.toHaveBeenCalled()
+  })
+
+  it('does NOT link an inactive account the provider handed back', async () => {
+    const p = provider({
+      createProviderAccount: vi.fn(async () =>
+        ok({
+          account: { ...CREATED, active: false },
+          outcome: 'existing' as const,
+          numberDropped: false,
+        })
+      ),
+    })
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    const result = await createAndLinkProviderAccount(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1200',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('deactivated')
+    expect(p.setAccountMapping).not.toHaveBeenCalled()
+  })
+
+  it("surfaces the adapter's own refusal verbatim rather than a generic one", async () => {
+    // A duplicate the adapter could not settle reads as Intuit's sentence,
+    // because "resolve this in QuickBooks" is advice only that sentence carries.
+    const p = provider({
+      createProviderAccount: vi.fn(async () =>
+        err(new Error('2 QuickBooks accounts already match by name'))
+      ),
+    })
+    resolveAccountingProvider.mockResolvedValue(p)
+
+    const result = await createAndLinkProviderAccount(db, {
+      organizationId: ORG,
+      glAccountId: 'gl1200',
+    })
+
+    expect(result._unsafeUnwrapErr().message).toContain('already match by name')
+    expect(p.setAccountMapping).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/postings/account-identities.ts
+++ b/packages/lib/src/postings/account-identities.ts
@@ -35,7 +35,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, UnprocessableEntityError } from '../errors'
 import { accountLabel } from './account-label'
-import { resolveAccountingProvider } from './provider'
+import { resolveAccountingProvider, supportsCreatingProviderAccounts } from './provider'
 import { listChartAccounts } from './role-map'
 import {
   classificationArticle,
@@ -51,6 +51,16 @@ const logger = createScopedLogger('postings:account-identities')
 export interface AccountIdentityMap {
   /** The connected provider's id, or `'none'`. */
   providerId: string
+  /**
+   * The provider can be asked to ADD an account to its own chart, so an unlinked
+   * row may offer create-and-link rather than only a picker.
+   *
+   * 🛑 A capability, not a permission - it says what the connected system is
+   * able to do, and says nothing about whether this person may do it. The router
+   * still asserts `ledgerControl`. Always false with nothing connected, which is
+   * what keeps the button off a screen with no provider at all.
+   */
+  canCreateProviderAccounts: boolean
   /** One row per live `gl_account`, mapped or not. */
   rows: AccountIdentityRow[]
   /** The provider's own chart, for a picker. Empty when nothing is connected. */
@@ -153,7 +163,13 @@ export async function listAccountIdentities(
       }
     })
 
-    return ok({ providerId: provider.id, rows, providerAccounts, broken })
+    return ok({
+      providerId: provider.id,
+      canCreateProviderAccounts: supportsCreatingProviderAccounts(provider),
+      rows,
+      providerAccounts,
+      broken,
+    })
   } catch (error) {
     if (error instanceof AuxxError) return err(error)
     logger.error('Failed to list the account map', { error, organizationId })

--- a/packages/lib/src/postings/create-provider-account.ts
+++ b/packages/lib/src/postings/create-provider-account.ts
@@ -1,0 +1,200 @@
+// packages/lib/src/postings/create-provider-account.ts
+
+/**
+ * The seam run BACKWARDS: create one of our accounts in the connected
+ * provider's chart, then link the two.
+ *
+ * `account-identities.ts` handles the case where both charts already hold the
+ * account and only the correspondence is missing. This file handles the case it
+ * cannot: an account that exists on exactly ONE side, because auxx created it.
+ * A clearing account per card rail, the role-bearing core `chart-import.ts` adds
+ * when the provider has no counterpart - the matcher has nothing to offer for
+ * any of them, no suggestion is ever produced, and every export refuses.
+ *
+ * ## Two acts, not one
+ *
+ * 🛑 Creating the counterpart and confirming the pairing are deliberately
+ * separate, with a validation between them. The adapter is trusted to write to
+ * the provider; it is NOT trusted to decide that what came back is a legal
+ * mapping. `isMappableTo` runs on the result exactly as it runs on a pairing a
+ * person picked in the picker, so an adapter that returned a surprising account
+ * - a reused one whose section disagrees, an inactive one - leaves an unlinked
+ * account in the provider's chart rather than a confirmed mapping to the wrong
+ * place. An account nobody linked is a visible loose end; a wrong mapping posts
+ * money and balances.
+ *
+ * ## Nothing here knows what QuickBooks is
+ *
+ * Same rule as `account-identities.ts`, and the same reason: the provider's own
+ * type vocabulary never crosses this line. `CreateProviderAccountInput` says
+ * what the account IS - name, code, classification, subtype - and translating
+ * that into one system's account types is the adapter's job. A module that
+ * reached for QuickBooks' `AccountSubType` here would make QuickBooks the only
+ * provider this could ever work for.
+ *
+ * No permission checks. The router asserts `ledgerControl` (`docs/lib-module-guide.md` §6).
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError, UnprocessableEntityError } from '../errors'
+import { accountLabel } from './account-label'
+import { resolveAccountingProvider, supportsCreatingProviderAccounts } from './provider'
+import { listChartAccounts } from './role-map'
+import { isMappableTo, validateProviderMapping } from './suggest-account-identities'
+import type { AccountIdentityRow } from './types'
+
+const logger = createScopedLogger('postings:create-provider-account')
+
+export interface CreateAndLinkOptions {
+  organizationId: string
+  /** The `gl_account` to give a counterpart. */
+  glAccountId: string
+  actorUserId?: string
+}
+
+/** The linked row, plus what actually happened on the provider's side. */
+export interface CreateAndLinkResult {
+  row: AccountIdentityRow
+  /**
+   * `existing` means the provider already had this account and created nothing.
+   *
+   * Surfaced all the way to the screen rather than collapsed into success: "we
+   * linked the account QuickBooks already had" and "we added an account to
+   * QuickBooks" are different events, and a person told the second when the
+   * first happened goes looking for a duplicate that is not there.
+   */
+  outcome: 'created' | 'existing'
+  /**
+   * Our code was sent and the provider kept no number for it - the company has
+   * account numbers turned off.
+   *
+   * ⚠️ Not a failure and not a reason to refuse: the mapping is by id and is
+   * perfectly sound. It matters because the person is looking at a chart
+   * organised by code and has just been shown an account that does not carry
+   * one, and because every future suggestion for this company falls back to
+   * name matching. The screen says so once rather than letting them find out.
+   */
+  numberDropped: boolean
+}
+
+/**
+ * Create the counterpart of one account in the connected provider, then confirm
+ * the pairing.
+ *
+ * Refuses, rather than creating, when:
+ * - nothing is connected, or the provider cannot create accounts at all
+ * - the account is not in this org's live chart, or is archived
+ * - it is ALREADY linked - see below
+ * - what came back is not a legal mapping target
+ *
+ * 🛑 The already-linked refusal is the one that matters. Without it, a
+ * double-clicked button asks the provider for a second counterpart to an
+ * account that has one, and whether that ends as a duplicate in their books
+ * depends entirely on the adapter's reuse check. Refusing here does not depend
+ * on an adapter being careful.
+ */
+export async function createAndLinkProviderAccount(
+  db: Database,
+  options: CreateAndLinkOptions
+): Promise<Result<CreateAndLinkResult, Error>> {
+  const { organizationId, glAccountId, actorUserId } = options
+
+  try {
+    const provider = await resolveAccountingProvider(organizationId)
+    if (!supportsCreatingProviderAccounts(provider) || !provider.createProviderAccount) {
+      throw new UnprocessableEntityError(
+        'The connected accounting system cannot have accounts added to it from auxx. Create the account there, then link it here.',
+        { organizationId, providerId: provider.id }
+      )
+    }
+
+    const chart = await listChartAccounts(db, organizationId)
+    if (chart.isErr()) return err(chart.error)
+
+    const account = chart.value.find((row) => row.id === glAccountId)
+    if (!account) {
+      throw new UnprocessableEntityError(
+        `Account ${glAccountId} does not exist in this organization, or has been archived.`,
+        { organizationId, glAccountId }
+      )
+    }
+
+    const mappings = await provider.listAccountMappings(organizationId)
+    if (mappings.isErr()) return err(mappings.error)
+    const existingMapping = mappings.value.get(glAccountId)
+    if (existingMapping) {
+      throw new UnprocessableEntityError(
+        `${accountLabel(account)} is already linked to an account in the connected accounting system. Unlink it first if it should point somewhere else.`,
+        { organizationId, glAccountId, providerAccountId: existingMapping }
+      )
+    }
+
+    const created = await provider.createProviderAccount({
+      orgId: organizationId,
+      glAccountId,
+      name: account.name,
+      code: account.code,
+      classification: account.accountType,
+      subtype: account.subtype ?? null,
+      actorUserId,
+    })
+    if (created.isErr()) return err(created.error)
+    const target = created.value.account
+
+    // 🛑 The same gate the picker's confirmation passes through. Reached mainly
+    // when the adapter REUSED an account rather than creating one - a create we
+    // fully specified comes back in the section we asked for, but a match on
+    // name alone can be anything. Refusing leaves an unlinked account behind,
+    // which is recoverable; confirming a wrong one is not.
+    if (!isMappableTo(account, target)) {
+      const message =
+        validateProviderMapping(account, target, target.id) ??
+        `${accountLabel(account)} cannot be linked to '${target.fullyQualifiedName}'.`
+      logger.warn('Created or matched a provider account that is not a legal mapping target', {
+        organizationId,
+        glAccountId,
+        providerAccountId: target.id,
+        outcome: created.value.outcome,
+      })
+      throw new UnprocessableEntityError(message, {
+        organizationId,
+        glAccountId,
+        providerAccountId: target.id,
+      })
+    }
+
+    const written = await provider.setAccountMapping({
+      orgId: organizationId,
+      glAccountId,
+      providerAccountId: target.id,
+      actorUserId,
+    })
+    if (written.isErr()) return err(written.error)
+
+    return ok({
+      row: {
+        account,
+        state: 'confirmed',
+        providerAccountId: target.id,
+        providerAccountName: target.fullyQualifiedName,
+        providerAccountNumber: target.number,
+        source: 'human',
+        confirmedAt: new Date().toISOString(),
+        liveProviderAccount: target,
+        suggestion: null,
+      },
+      outcome: created.value.outcome,
+      numberDropped: created.value.numberDropped,
+    })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to create and link a provider account', {
+      error,
+      organizationId,
+      glAccountId,
+    })
+    return err(new AuxxError('Internal error'))
+  }
+}

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -186,6 +186,11 @@ export {
 } from './close-month'
 export { listClosePeriods } from './close-periods'
 export {
+  type CreateAndLinkOptions,
+  type CreateAndLinkResult,
+  createAndLinkProviderAccount,
+} from './create-provider-account'
+export {
   CHART_PACK_KEYS,
   CHART_PACKS,
   type ChartPack,
@@ -302,6 +307,8 @@ export {
   type AccountingProvider,
   type AccountingProviderFactory,
   type ConnectedProviderResolver,
+  type CreateProviderAccountInput,
+  type CreateProviderAccountResult,
   getAccountingProvider,
   listAccountingProviderIds,
   NONE_ACCOUNTING_PROVIDER,
@@ -309,6 +316,7 @@ export {
   registerAccountingProvider,
   resolveAccountingProvider,
   setConnectedProviderResolver,
+  supportsCreatingProviderAccounts,
 } from './provider'
 // ── plans/accounting/tasks/20 §8: do our books and theirs agree, pure ───────
 export {

--- a/packages/lib/src/postings/provider.ts
+++ b/packages/lib/src/postings/provider.ts
@@ -17,6 +17,8 @@
 import { createScopedLogger } from '@auxx/logger'
 import { err, ok, type Result } from 'neverthrow'
 import { NotFoundError, UnprocessableEntityError } from '../errors'
+import type { GlAccountSubtypeValue } from './account-subtype'
+import type { GlAccountTypeValue } from './default-chart'
 import type { ProviderLedger } from './provider-sync/client'
 import type {
   PostEntryInput,
@@ -162,6 +164,111 @@ export interface AccountingProvider {
 
   /** Withdraw a confirmation. The account goes back to unmapped. */
   clearAccountMapping(input: ClearAccountMappingInput): Promise<Result<void, Error>>
+
+  /**
+   * Create the counterpart of one of OUR accounts in the provider's own chart -
+   * the only method on this interface that runs the seam backwards.
+   *
+   * ## Why this exists
+   *
+   * Every other method assumes both charts already contain the account and only
+   * the correspondence is missing. That assumption does not hold for the
+   * accounts auxx itself creates: a clearing account per card rail, the
+   * role-bearing core `chart-import.ts` adds because the provider had no
+   * counterpart for it. Those exist on exactly one side, so
+   * {@link listProviderAccounts} has nothing to offer the matcher, no suggestion
+   * is ever produced, and the only way to link them was for a person to retype
+   * each one into QuickBooks by hand.
+   *
+   * ## 🛑 OPTIONAL, and its absence is the capability flag
+   *
+   * Not every accounting system lets an API add to the chart, and some that do
+   * should not be asked to. An adapter that cannot simply does not implement
+   * this, and `supportsCreatingProviderAccounts` is how a screen asks - so the
+   * button is absent rather than present-and-failing. Do NOT add a stub that
+   * returns an error; that is the same outcome one round trip later and after
+   * the person has already been told the feature is there.
+   *
+   * ## What an implementation must guarantee
+   *
+   * REUSE BEFORE CREATE. A duplicate account in somebody's real books is worse
+   * than a refusal: two accounts with one name split a balance in half with no
+   * error anywhere, and nothing notices until a reconciliation does not tie out.
+   * An adapter looks for an existing counterpart first and reports
+   * `outcome: 'existing'` rather than writing. Ambiguity - several plausible
+   * matches - is a REFUSAL, never a create: the chart already holds a question
+   * only a person can settle, and a third account settles nothing.
+   *
+   * The input is provider-NEUTRAL, which is the whole of `P2` applied to this
+   * direction. It says what the account IS - name, our code, its statement
+   * classification, our subtype - and never what the provider should call any of
+   * that. Translating those into one system's own type vocabulary is the
+   * adapter's job and nobody else's.
+   *
+   * 🛑 This does NOT write the mapping. Creating the counterpart and recording
+   * the correspondence are separate acts, and `createAndLinkProviderAccount`
+   * does the second through {@link setAccountMapping} after re-checking the
+   * result is mappable - so an adapter that returned a surprising account
+   * cannot quietly become a confirmed pairing.
+   */
+  createProviderAccount?(
+    input: CreateProviderAccountInput
+  ): Promise<Result<CreateProviderAccountResult, Error>>
+}
+
+/**
+ * One account to create in the provider's chart, described in OUR vocabulary.
+ *
+ * Deliberately the same four facts a `gl_account` carries and not one more: a
+ * provider's own type strings, its nesting, its detail types are the adapter's
+ * business. See {@link AccountingProvider.createProviderAccount}.
+ */
+export interface CreateProviderAccountInput {
+  orgId: string
+  /** The `gl_account` this will be the counterpart of. Carried for logs and errors. */
+  glAccountId: string
+  name: string
+  /** Our account code, or null - an uncoded account is ordinary (task 15 §5). */
+  code: string | null
+  /** One of the five statement sections. */
+  classification: GlAccountTypeValue
+  /** Our second fact about the account, when it has one. */
+  subtype: GlAccountSubtypeValue | null
+  actorUserId?: string
+}
+
+/** What came back from one create. */
+export interface CreateProviderAccountResult {
+  /** The counterpart, in the same shape {@link AccountingProvider.listProviderAccounts} speaks. */
+  account: ProviderAccount
+  /**
+   * `existing` means the provider already had this account and NOTHING was
+   * written. Reported rather than hidden because it changes what the screen
+   * should say - "linked to the account already in QuickBooks" is a different
+   * sentence from "created it", and a person who believes they just created an
+   * account that was already there will go looking for a duplicate.
+   */
+  outcome: 'created' | 'existing'
+  /**
+   * True when our `code` was sent and the provider kept no number for it.
+   *
+   * 🛑 Reported, never inferred, and never silently tolerated by a caller.
+   * QuickBooks stores account numbers only when the company has them switched
+   * on; with them off it accepts the create and drops the number with no fault
+   * at all. A caller that assumed the code landed would be matching forever
+   * after on a field that is permanently null.
+   */
+  numberDropped: boolean
+}
+
+/**
+ * Can this provider be asked to add to its own chart?
+ *
+ * The presence of the optional method IS the answer - there is no capability
+ * table to keep in step with what the adapters actually implement.
+ */
+export function supportsCreatingProviderAccounts(provider: AccountingProvider): boolean {
+  return typeof provider.createProviderAccount === 'function'
 }
 
 /** One confirmed pairing, as {@link AccountingProvider.setAccountMapping} takes it. */


### PR DESCRIPTION
Pairs with **auxxai-apps#76**, which adds the `create_quickbooks_account` tool this calls.

## Why

The account map ran one way. `importChartFromProvider` brings their chart into ours, `suggestAccountIdentities` proposes a pairing, `setAccountIdentity` records one a person confirms. All three assume the account already exists on both sides and only the correspondence is missing.

That does not hold for the accounts auxx creates itself: a clearing account per card rail, the role-bearing core `chart-import.ts` adds when the provider has no counterpart. Those exist on exactly one side, so the matcher has nothing to offer, no suggestion is ever produced, and every export refuses with "not mapped".

On DemoOrg1 that is the 26 unlinked accounts in the handoff, and it is also why that screen never showed an **Accept N suggestions** button: `suggestAccountIdentities` found zero, correctly. It was never a matching problem. The only fix was retyping each account into the QuickBooks UI by hand.

## The shape

**`AccountingProvider.createProviderAccount?`** is a ninth method and the only optional one. Its presence **is** the capability flag: `supportsCreatingProviderAccounts` reads it, `listAccountIdentities` returns `canCreateProviderAccounts`, and a provider that cannot do this gets no button rather than a button that fails. A stub returning an error would be the same outcome one round trip later, after the person had been told the feature was there. `NoneAccountingProvider` implements nothing, so an org with nothing connected gets `false` for free.

`CreateProviderAccountInput` is provider-neutral: name, code, classification, subtype, and nothing naming one system's own type vocabulary. That is `P2` applied to this direction, and there is a test asserting exactly that payload as the regression guard.

**`money/quickbooks/account-types.ts`** is the translation, and two rules govern it:

- **Both type columns, always.** QuickBooks accepts an `AccountType` alone and then invents a subtype. Probed against realm `9341453857213446`: an account created as `Other Current Asset` with no subtype came back filed under `EmployeeCashAdvances`. The subtype is what their reports group by, so a clearing account left to Intuit's default lands in a section nobody chose.
- **The classification wins when the two disagree.** `subtype` and `accountType` are independently edited fields on one `gl_account` and nothing stops a `revenue` account carrying `subtype: bank`. Sending `Bank` would create a real asset account that our ledger then posts revenue into, an entry that balances and misstates the balance sheet.

The strings were read off a live company's chart rather than transcribed from documentation, so the exact spellings Intuit round-trips (`OtherCurrentAssets` plural, `SuppliesMaterialsCogs` suffixed) are what a create sends.

**`createAndLinkProviderAccount`** keeps creating and linking as two acts with a validation between them. `isMappableTo` runs on whatever comes back, exactly as it runs on a pairing a person picked in the picker, so an adapter that returned a surprising account (a reused one whose section disagrees, an inactive one) leaves an *unlinked* account in their chart rather than a confirmed mapping to the wrong place. An account nobody linked is a visible loose end; a wrong mapping posts money and balances.

It also refuses an already-linked account **before** asking the provider. That is the double-click guard, and it must not depend on the adapter's own reuse check being careful.

**On the row**, the button is excluded from any row that has a suggestion. Those are different actions: a row the matcher found something for should link the account that already exists, and creating a second one beside it is how a chart ends up with two "Card Clearing"s. No row shows both. It confirms first (QuickBooks cannot delete an account, only deactivate it) and toasts only the two outcomes that are *not* what the button promised: the account already existed, or the company keeps no account numbers so the code did not survive.

Per-row only. No bulk header action, by decision.

## Testing

- 2,321 `postings` + `money` tests pass, 23 of them new: the neutral-payload assertion, every refusal path, and a table test that walks every classification x subtype pair asserting neither half of the type is ever empty.
- Both typecheck ratchets clean.
- One thing to know if you touch it: adding the `supportsCreatingProviderAccounts` import broke `account-identities.test.ts`'s partial `vi.mock('../provider')`, which only listed `resolveAccountingProvider`. 13 tests went to "Internal error". The mock factory now supplies it.

## Driven on DemoOrg1

Unlinked rows show the button, linked rows do not, and the confirm names the provider.

| Account | Landed in QuickBooks as |
| --- | --- |
| `1200 Card Clearing` | `1200 · Other Current Asset / OtherCurrentAssets` |
| `5000 COGS - Product Cost` | `5000 · Cost of Goods Sold / SuppliesMaterialsCogs` |

The second is the table earning its keep: the classification default would have filed it under `Expense / OtherMiscellaneousServiceCost`, the wrong P&L section. 24 links remain on that org.

## Known, and deliberate

- **auxxai-apps#76 must be published first.** The tool is on DemoOrg1's development deployment only. `canCreateProviderAccounts` cannot detect that, because it only knows the adapter implements the method.
- **`OwnersEquity` and `OtherFixedAssets` are unverified.** The probed company held no example of either, so those two come from Intuit's standard set rather than from observation, and DemoOrg1's equity group is fully linked so neither path has run. A wrong value is a clean refusal naming the field, not a misfiled account.

https://claude.ai/code/session_014EqKqpcGc61XzboLkwJMP5