### PR TITLE
Dock the recurring template drawer and rebuild its lines grid

### DIFF
--- a/apps/web/src/app/(protected)/app/accounting/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/accounting/settings/layout.tsx
@@ -12,6 +12,10 @@ import {
   SlidersHorizontal,
 } from 'lucide-react'
 import { usePathname } from 'next/navigation'
+import {
+  DockedPanelsOutletProvider,
+  useDockedPanelsOutlet,
+} from '~/components/global/docked-panels-outlet'
 import SidebarSecondary from '~/components/global/sidebar-secondary'
 import type { SidebarProps } from '~/constants/menu'
 
@@ -77,13 +81,21 @@ const ACCOUNTING_SETTINGS: SidebarProps[] = [
   },
 ]
 
-export default function AccountingSettingsLayout({ children }: { children: React.ReactNode }) {
+/**
+ * The layout owns the one `MainPageContent`, so a page below it (Recurring
+ * templates' journal-entry drawer) docks a panel by publishing it to the
+ * outlet rather than by passing a prop it cannot reach — same reason
+ * `accounting/banking/layout.tsx` does this. The other five settings pages
+ * publish nothing, so they keep getting an empty `dockedPanels` array.
+ */
+function AccountingSettingsLayoutFrame({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const pages = pathname.split('/')
   const page = pages[pages.length - 1]
+  const dockedPanels = useDockedPanelsOutlet()
 
   return (
-    <MainPageContent>
+    <MainPageContent dockedPanels={dockedPanels}>
       {/* `md:` must match SidebarSecondary's own breakpoint — at `sm:` the sidebar is
           still in mobile-disclosure mode with no fixed width and collapses to a sliver. */}
       <div className='flex flex-col md:flex-row h-full flex-1 overflow-hidden'>
@@ -96,5 +108,13 @@ export default function AccountingSettingsLayout({ children }: { children: React
         <div className='relative flex h-full w-full flex-1 grow overflow-hidden'>{children}</div>
       </div>
     </MainPageContent>
+  )
+}
+
+export default function AccountingSettingsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <DockedPanelsOutletProvider>
+      <AccountingSettingsLayoutFrame>{children}</AccountingSettingsLayoutFrame>
+    </DockedPanelsOutletProvider>
   )
 }

--- a/apps/web/src/components/accounting/ui/gl-account-picker.tsx
+++ b/apps/web/src/components/accounting/ui/gl-account-picker.tsx
@@ -29,6 +29,153 @@ import { useChartAccounts } from './use-chart-accounts'
 
 export { useChartAccounts }
 
+/** What a caller's `value`/`onChange`/`onSelect` carries - see {@link GlAccountPickerProps.selectBy}. */
+export type GlAccountSelectBy = 'code' | 'id'
+
+/**
+ * Props shared by every account list/body variant below - everything
+ * `GlAccountList` needs to render one filtered, grouped, disabled-aware list.
+ */
+export interface GlAccountListProps {
+  accounts: ChartAccountRow[]
+  isLoading: boolean
+  /** Search text - the caller owns the input (`CommandInput` in {@link GlAccountPickerBody}, or an external one in a spreadsheet-cell caller). */
+  search: string
+  filterTypes?: GlAccountTypeValue[]
+  selectBy?: GlAccountSelectBy
+  /** The selected account's code or id, per {@link selectBy}. */
+  value: string | null
+  /** Fires with the picked account's code or id, per {@link selectBy}. Never called for an inactive account. */
+  onSelect: (value: string) => void
+}
+
+/**
+ * The list portion alone - grouped `CommandGroup`s of `CommandDetailItem`s,
+ * no `CommandInput` and no `<Command>` shell. Exposed so a caller with its
+ * OWN search surface (an external `<input>`, not cmdk's) can drop this
+ * straight into whatever `<Command>` it already owns - `journal-lines.tsx`'s
+ * spreadsheet-cell account picker does exactly this.
+ */
+export function GlAccountList({
+  accounts,
+  isLoading,
+  search,
+  filterTypes,
+  selectBy = 'code',
+  value,
+  onSelect,
+}: GlAccountListProps) {
+  const groups = useMemo(
+    () => groupAccountsByType(accounts, filterTypes, search),
+    [accounts, filterTypes, search]
+  )
+
+  return (
+    <CommandList>
+      <CommandEmpty>{isLoading ? 'Loading…' : 'No accounts match.'}</CommandEmpty>
+      {groups.map((group) => (
+        <CommandGroup key={group.type} heading={accountTypeLabel(group.type)}>
+          {group.accounts.map((account) => {
+            const optionValue = selectBy === 'id' ? account.id : account.code
+            return (
+              <CommandDetailItem
+                key={account.id}
+                value={account.id}
+                title={formatAccountLabel(account)}
+                description={
+                  account.isActive ? undefined : 'This account is inactive and cannot be posted to.'
+                }
+                disabled={!account.isActive}
+                selected={optionValue === value}
+                selectionMode='check'
+                className={cn(!account.isActive && 'opacity-60')}
+                onSelect={() => {
+                  // `optionValue` is null only for a `selectBy='code'` caller
+                  // hitting an account with no code - nothing to select by.
+                  if (!account.isActive || !optionValue) return
+                  onSelect(optionValue)
+                }}
+              />
+            )
+          })}
+        </CommandGroup>
+      ))}
+    </CommandList>
+  )
+}
+
+/**
+ * Search input + {@link GlAccountList} - WITHOUT a surrounding `<Command>`
+ * shell. Exposed (the `ResourceCommandBody` idiom) so a caller that already
+ * owns a `<Command>` can embed the input-plus-list pair without nesting two
+ * `Command`s. {@link GlAccountPickerContent} is the standalone wrapper around
+ * this for the ordinary popover-trigger case.
+ */
+export function GlAccountPickerBody({
+  accounts,
+  isLoading,
+  search,
+  onSearchChange,
+  filterTypes,
+  selectBy,
+  value,
+  onSelect,
+  autoFocus,
+}: Omit<GlAccountListProps, 'search'> & {
+  search: string
+  onSearchChange: (search: string) => void
+  autoFocus?: boolean
+}) {
+  return (
+    <>
+      <CommandInput
+        autoFocus={autoFocus}
+        placeholder='Search accounts…'
+        value={search}
+        onValueChange={onSearchChange}
+        loading={isLoading}
+      />
+      <GlAccountList
+        accounts={accounts}
+        isLoading={isLoading}
+        search={search}
+        filterTypes={filterTypes}
+        selectBy={selectBy}
+        value={value}
+        onSelect={onSelect}
+      />
+    </>
+  )
+}
+
+/**
+ * {@link GlAccountPickerBody} wrapped in its own `<Command>` shell - a
+ * complete, standalone "search + pick" surface for a caller that isn't
+ * threading it into a popover (or wants its own positioning around it).
+ * {@link GlAccountPicker} is this behind a `PickerTrigger` popover, which is
+ * what nearly every caller actually wants.
+ */
+export function GlAccountPickerContent({
+  className,
+  ...props
+}: Omit<GlAccountListProps, 'search'> & {
+  className?: string
+  search?: string
+  onSearchChange?: (search: string) => void
+  autoFocus?: boolean
+}) {
+  const [internalSearch, setInternalSearch] = useState('')
+  return (
+    <Command shouldFilter={false} className={className}>
+      <GlAccountPickerBody
+        {...props}
+        search={props.search ?? internalSearch}
+        onSearchChange={props.onSearchChange ?? setInternalSearch}
+      />
+    </Command>
+  )
+}
+
 export interface GlAccountPickerProps {
   /** The selected account's CODE or id, depending on {@link selectBy}. */
   value: string | null
@@ -45,7 +192,7 @@ export interface GlAccountPickerProps {
    * `bank_transaction.glAccount`/`suggestedGlAccount`,
    * `vendor_bill_line.glAccount`), which store the `gl_account` instance id.
    */
-  selectBy?: 'code' | 'id'
+  selectBy?: GlAccountSelectBy
   disabled?: boolean
   placeholder?: string
   className?: string
@@ -80,6 +227,12 @@ export interface GlAccountPickerProps {
  * shared picker for one caller. Composed directly from the same `Command` +
  * `PickerTrigger asCombobox` primitives those pickers already use, so the
  * trigger and popover chrome still match every other picker in the app.
+ *
+ * `GlAccountPickerContent`/`GlAccountPickerBody`/`GlAccountList` above are
+ * this picker's own `ResourcePickerContent`/`ResourceCommandBody` split -
+ * peel one back whenever a caller needs the search+list without this
+ * particular button-and-popover shell (`journal-lines.tsx`'s spreadsheet
+ * cell uses `GlAccountList` directly, behind its own inline `<input>`).
  */
 export function GlAccountPicker({
   value,
@@ -93,12 +246,6 @@ export function GlAccountPicker({
 }: GlAccountPickerProps) {
   const { accounts, isLoading } = useChartAccounts()
   const [open, setOpen] = useState(false)
-  const [search, setSearch] = useState('')
-
-  const groups = useMemo(
-    () => groupAccountsByType(accounts, filterTypes, search),
-    [accounts, filterTypes, search]
-  )
 
   const selected = useMemo(
     () =>
@@ -108,7 +255,6 @@ export function GlAccountPicker({
 
   function handleOpenChange(next: boolean) {
     setOpen(next)
-    if (!next) setSearch('')
   }
 
   return (
@@ -140,45 +286,17 @@ export function GlAccountPicker({
       <PopoverContent
         className='min-w-[max(var(--radix-popover-trigger-width),18rem)] p-0'
         align='start'>
-        <Command shouldFilter={false}>
-          <CommandInput
-            placeholder='Search accounts…'
-            value={search}
-            onValueChange={setSearch}
-            loading={isLoading}
-          />
-          <CommandList>
-            <CommandEmpty>{isLoading ? 'Loading…' : 'No accounts match.'}</CommandEmpty>
-            {groups.map((group) => (
-              <CommandGroup key={group.type} heading={accountTypeLabel(group.type)}>
-                {group.accounts.map((account) => {
-                  const optionValue = selectBy === 'id' ? account.id : account.code
-                  return (
-                    <CommandDetailItem
-                      key={account.id}
-                      value={account.id}
-                      title={formatAccountLabel(account)}
-                      description={
-                        account.isActive
-                          ? undefined
-                          : 'This account is inactive and cannot be posted to.'
-                      }
-                      disabled={!account.isActive}
-                      selected={optionValue === value}
-                      selectionMode='check'
-                      className={cn(!account.isActive && 'opacity-60')}
-                      onSelect={() => {
-                        if (!account.isActive) return
-                        onChange(optionValue)
-                        handleOpenChange(false)
-                      }}
-                    />
-                  )
-                })}
-              </CommandGroup>
-            ))}
-          </CommandList>
-        </Command>
+        <GlAccountPickerContent
+          accounts={accounts}
+          isLoading={isLoading}
+          filterTypes={filterTypes}
+          selectBy={selectBy}
+          value={value}
+          onSelect={(next) => {
+            onChange(next)
+            handleOpenChange(false)
+          }}
+        />
       </PopoverContent>
     </Popover>
   )

--- a/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
@@ -29,6 +29,13 @@ import { JournalEntryAttachment } from './journal-entry-attachment'
 import { JournalLines, JournalLinesTotals } from './journal-lines'
 import { firstDayOfPeriod, nextOpenPeriodAfter, periodKeyForEntryDate } from './period-helpers'
 
+/**
+ * Cancels the scroll content's `p-3` so `Section` sits FLUSH with the drawer.
+ * `Section` draws its own `p-3` and a full-width `border-b`, a divider meant
+ * to run edge to edge (see `bank-account-editor.tsx`'s own copy of this).
+ */
+const SECTION_BLEED = '-mx-3'
+
 // `not_exported` is here for the opening entry and its reversal: both are
 // `journal_entry` records whose posting type routes to `'none'`, so they never
 // push and always land on it. The set means "a GlPosting row now exists".
@@ -336,7 +343,8 @@ export function JournalEntryDrawer({
               <Section
                 title='Lines'
                 icon={<BookOpenCheck className='size-4' />}
-                collapsible={false}>
+                collapsible={false}
+                className={SECTION_BLEED}>
                 <div className='flex flex-col gap-3'>
                   <JournalLines
                     rows={draft.lines}

--- a/apps/web/src/components/accounting/ui/journal/journal-lines.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-lines.tsx
@@ -4,15 +4,54 @@
 
 import type { ChartAccountRow, CounterpartyType, JournalEntryLine } from '@auxx/lib/postings/client'
 import { parseRecordId, toRecordId } from '@auxx/lib/resources/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { Input } from '@auxx/ui/components/input'
-import { CurrencyInput, CurrencyInputField } from '@auxx/ui/components/input-currency'
-import { InputGroup } from '@auxx/ui/components/input-group'
+import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import { generateId } from '@auxx/utils'
-import { CheckCircle2, Trash2, TriangleAlert, X } from 'lucide-react'
-import { useState } from 'react'
-import { GlAccountPicker, useChartAccounts } from '~/components/accounting/ui/gl-account-picker'
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import {
+  CheckCircle2,
+  Ellipsis,
+  GripVertical,
+  Plus,
+  StickyNote,
+  Trash2,
+  TriangleAlert,
+  X,
+} from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { formatAccountLabel } from '~/components/accounting/ui/account-label-format'
+import {
+  GlAccountPickerContent,
+  useChartAccounts,
+} from '~/components/accounting/ui/gl-account-picker'
 import { formatMinor } from '~/components/accounting/ui/ledger/format'
+import { CurrencyCellInput } from '~/components/money/ui/line-builder/line-rows'
+import { useLineNav } from '~/components/money/ui/line-builder/use-line-nav'
 import { RecordPicker } from '~/components/pickers/record-picker/record-picker'
 import { useResource } from '~/components/resources'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
@@ -32,15 +71,19 @@ import { RecordBadge } from '~/components/resources/ui/record-badge'
  * `LineBuilder` was never designed to hold.
  *
  * So this is a thin, purpose-built grid instead: same LOOK (a trailing phantom
- * draft row that materializes on first keystroke, Enter moves to the next row),
- * none of `LineBuilder`'s record-per-line machinery. State lives one level up
- * (`use-journal-entry-draft.ts`) as a plain array and is saved wholesale, which
- * is exactly what the draft's own storage shape wants.
+ * draft row that materializes on first keystroke), reusing every piece of
+ * `LineBuilder` that has no record assumptions - `useLineNav`'s spreadsheet
+ * keyboard nav (`data-line-row`/`data-line-col`) and `CurrencyCellInput`'s
+ * chromeless cell (both exported from `line-rows.tsx` for this) - plus a drag
+ * grip and a row `⋯` menu in `LineBuilder`'s visual idiom. `LineNameCellView`,
+ * `useLineHotkeys` and `LINE_SCHEMAS` are the pieces that stay out: hard-wired
+ * to catalog items or a full record schema, and do not fit a plain array with
+ * no per-line record.
  */
 
 /** One row as the grid edits it. Debit and credit are mutually exclusive UI slots. */
 export interface JournalLineDraft {
-  /** Client-only identity for React keys and keyboard nav. Never sent to the server. */
+  /** Client-only identity for React keys, drag-and-drop and keyboard nav. Never sent to the server. */
   key: string
   glAccountId: string | null
   memo: string
@@ -134,8 +177,13 @@ export function computeJournalLineTotals(rows: JournalLineDraft[]): JournalLineT
   }
 }
 
-/** `minmax(14rem,1fr) minmax(10rem,1fr) 7rem 7rem` from ui-plan.md §2.1, plus a delete column. */
-const GRID_COLS = 'minmax(14rem,1fr) minmax(10rem,1fr) 7rem 7rem 2rem'
+/**
+ * Grip · Account · Debit · Credit · menu - the same column shape `LineBuilder`
+ * uses (`LINE_COLS` in `line-rows.tsx`), sized for this grid's own cells.
+ * Memo has no standing column - there is no room for it beside Account at
+ * drawer width, so it lives behind the row menu instead (see `JournalLineRow`).
+ */
+const GRID_COLS = '1.5rem minmax(14rem,1fr) 7rem 7rem 2rem'
 
 /**
  * Which counterparty kind an account's subtype demands, per brief 13 §1.4 -
@@ -207,6 +255,325 @@ function CounterpartyCell({
   )
 }
 
+/**
+ * The Account cell: a real, always-present `<input>` (not a button that
+ * merely opens a picker) - `useLineNav` moves keyboard focus straight onto
+ * it, and a plain button has nothing for a keystroke to land in. At rest it
+ * shows the selected account's formatted label; on focus it clears to a live
+ * search that filters the dropdown below as you type - `LineNameCellView`'s
+ * reveal pattern, adapted for a value with no free-text form of its own.
+ * Nothing commits except a real pick (`onChange` fires only from a
+ * `CommandDetailItem.onSelect`), so a search that matches nothing, or that
+ * the caller never finishes, simply reverts - never a wrong account.
+ *
+ * 🛑 Focus moves INTO the popover's own search box the moment it opens,
+ * rather than staying pinned on the row's `<input>`. A first attempt kept
+ * focus outside so `useLineNav` and the dropdown could both read the same
+ * keystrokes - but `useLineNav` listens in the CAPTURE phase, so it always
+ * intercepts Up/Down/Enter before cmdk's own root ever sees them, and
+ * `focusCell` moving focus to the NEXT row re-opens a fresh, unfiltered
+ * dropdown there instead of moving the highlight in this one. `useLineNav`
+ * already has the fix for this - `isInsidePopper()` bails out entirely while
+ * focus sits inside a Radix popper - and it only works when focus genuinely
+ * IS inside the popper, which is exactly the LineBuilder catalog `/` picker's
+ * own arrangement. The one cost is the row's `<input>` is a trigger, not the
+ * typing surface itself - `readOnly`, and its own Tab/arrow-nav focus is what
+ * opens the popover and immediately hands focus to the real search box.
+ */
+function AccountCell({
+  value,
+  onChange,
+  disabled,
+  placeholder = 'Account…',
+}: {
+  value: string | null
+  onChange: (id: string | null) => void
+  disabled?: boolean
+  placeholder?: string
+}) {
+  const { accounts, isLoading } = useChartAccounts()
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  // 🛑 Refocusing the trigger below (so the NEXT Tab/arrow-key has somewhere
+  // to move from) fires that same input's own `onFocus` synchronously, which
+  // would reopen the popover it was just told to close - the exact
+  // close-then-refocus race the memo editor and `GlAccountPicker`'s dropped
+  // `openOnFocus` attempt both hit. Suppressed for the one `.focus()` call.
+  const suppressReopenRef = useRef(false)
+
+  const selected = useMemo(() => accounts.find((a) => a.id === value) ?? null, [accounts, value])
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    if (!next) {
+      setSearch('')
+      requestAnimationFrame(() => {
+        suppressReopenRef.current = true
+        inputRef.current?.focus()
+        suppressReopenRef.current = false
+      })
+    }
+  }
+
+  function commit(id: string) {
+    onChange(id)
+    handleOpenChange(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverAnchor asChild>
+        <input
+          ref={inputRef}
+          data-cell-focusable
+          readOnly
+          role='combobox'
+          aria-expanded={open}
+          value={selected ? formatAccountLabel(selected) : ''}
+          onFocus={() => {
+            if (suppressReopenRef.current) return
+            setOpen(true)
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+          className='h-8 w-full min-w-0 cursor-default rounded-sm border-none bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground'
+        />
+      </PopoverAnchor>
+      <PopoverContent
+        className='min-w-[max(var(--radix-popover-trigger-width),18rem)] p-0'
+        align='start'
+        onCloseAutoFocus={(e) => e.preventDefault()}>
+        <GlAccountPickerContent
+          accounts={accounts}
+          isLoading={isLoading}
+          search={search}
+          onSearchChange={setSearch}
+          selectBy='id'
+          value={value}
+          onSelect={commit}
+          autoFocus
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+interface JournalLineRowProps {
+  row: JournalLineDraft
+  rowIndex: number
+  /** The trailing blank row - no grip, no menu, nothing to act on yet. */
+  isPhantom: boolean
+  disabled?: boolean
+  currencyCode: string
+  account: ChartAccountRow | undefined
+  contactEntityDefinitionId: string | null
+  companyEntityDefinitionId: string | null
+  editingMemo: boolean
+  onEditMemo: () => void
+  onStopEditingMemo: () => void
+  onPatch: (patch: Partial<JournalLineDraft>) => void
+  onAccountChange: (glAccountId: string | null) => void
+  onRemove: () => void
+}
+
+/**
+ * One line's grid row. `useSortable` is called unconditionally (with
+ * `disabled` for the phantom) rather than only for real rows, because
+ * materializing the phantom keeps its React key - the SAME component instance
+ * flips from `isPhantom: true` to `false` between renders, and a hook cannot
+ * appear only on one side of that.
+ */
+function JournalLineRow({
+  row,
+  rowIndex,
+  isPhantom,
+  disabled,
+  currencyCode,
+  account,
+  contactEntityDefinitionId,
+  companyEntityDefinitionId,
+  editingMemo,
+  onEditMemo,
+  onStopEditingMemo,
+  onPatch,
+  onAccountChange,
+  onRemove,
+}: JournalLineRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: row.key,
+    disabled: isPhantom || disabled,
+  })
+
+  const requiredKind = requiredCounterpartyKind(account?.subtype ?? null)
+  const hasMemo = row.memo.trim().length > 0
+
+  // 🛑 `autoFocus` alone loses this race: `onEditMemo` fires from inside the
+  // `⋯` menu's `onSelect`, and Radix's own focus cleanup for that closing
+  // menu runs a tick later and steals focus back to `<body>` even with
+  // `onCloseAutoFocus` prevented on the menu content. Deferring one frame -
+  // the same fix `line-rows.tsx` uses before opening a second Radix layer
+  // from this same menu - lets that cleanup finish first.
+  const memoInputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (!editingMemo) return
+    const frame = requestAnimationFrame(() => memoInputRef.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [editingMemo])
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn('group/tree-row relative text-sm', isDragging && 'z-10 opacity-80')}>
+      {/* Hover background - a standalone layer behind the grid columns, same
+          treatment `LineGridRow` uses. */}
+      <div className='absolute inset-0 rounded-md transition-colors group-hover/tree-row:bg-background' />
+
+      <div
+        className='relative grid min-h-9 items-stretch gap-2 px-1'
+        style={{ gridTemplateColumns: GRID_COLS }}>
+        <div className='flex items-center justify-center'>
+          {!isPhantom && (
+            <button
+              type='button'
+              aria-label='Reorder line'
+              disabled={disabled}
+              {...attributes}
+              {...listeners}
+              className='flex size-5 cursor-grab items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity group-hover/tree-row:opacity-100 disabled:opacity-0'>
+              <GripVertical className='size-3.5' />
+            </button>
+          )}
+        </div>
+
+        <div
+          data-line-row={rowIndex}
+          data-line-col={0}
+          className='flex min-w-0 flex-col justify-center gap-1'>
+          {editingMemo ? (
+            <Input
+              ref={memoInputRef}
+              value={row.memo}
+              onChange={(e) => onPatch({ memo: e.target.value })}
+              onBlur={onStopEditingMemo}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === 'Escape') {
+                  e.preventDefault()
+                  onStopEditingMemo()
+                }
+              }}
+              placeholder='Memo'
+              disabled={disabled}
+              className='h-8'
+            />
+          ) : (
+            <>
+              <div className='flex items-center gap-1'>
+                <div className='min-w-0 flex-1'>
+                  <AccountCell
+                    value={row.glAccountId}
+                    onChange={onAccountChange}
+                    disabled={disabled}
+                    placeholder='Account…'
+                  />
+                </div>
+                {hasMemo && (
+                  <SimpleTooltip content={row.memo}>
+                    <button
+                      type='button'
+                      aria-label='Edit memo'
+                      disabled={disabled}
+                      onClick={onEditMemo}
+                      className='flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-accent disabled:opacity-50'>
+                      <StickyNote className='size-3.5' />
+                    </button>
+                  </SimpleTooltip>
+                )}
+              </div>
+              {requiredKind && (
+                <CounterpartyCell
+                  kind={requiredKind}
+                  entityDefinitionId={
+                    requiredKind === 'customer'
+                      ? contactEntityDefinitionId
+                      : companyEntityDefinitionId
+                  }
+                  recordInstanceId={row.counterpartyId}
+                  disabled={disabled}
+                  onSelect={(id) => onPatch({ counterpartyType: requiredKind, counterpartyId: id })}
+                  onClear={() => onPatch({ counterpartyType: null, counterpartyId: null })}
+                />
+              )}
+            </>
+          )}
+        </div>
+
+        <div data-line-row={rowIndex} data-line-col={1} className='flex items-center'>
+          <CurrencyCellInput
+            value={row.debitMinor}
+            readOnly={!!disabled}
+            currencyCode={currencyCode}
+            ariaLabel='Debit'
+            // Commit per keystroke, not just on blur - `onPatch` is cheap
+            // local state (the whole entry saves wholesale on Save draft), and
+            // the balance strip below should move as you type, not only once
+            // you tab away.
+            live
+            onCommit={(next) =>
+              onPatch({ debitMinor: next, creditMinor: next ? null : row.creditMinor })
+            }
+          />
+        </div>
+
+        <div data-line-row={rowIndex} data-line-col={2} className='flex items-center'>
+          <CurrencyCellInput
+            value={row.creditMinor}
+            readOnly={!!disabled}
+            currencyCode={currencyCode}
+            ariaLabel='Credit'
+            live
+            onCommit={(next) =>
+              onPatch({ creditMinor: next, debitMinor: next ? null : row.debitMinor })
+            }
+          />
+        </div>
+
+        <div className='flex items-center justify-center'>
+          {!isPhantom && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type='button'
+                  aria-label='Line actions'
+                  disabled={disabled}
+                  className='flex size-6 items-center justify-center rounded-full text-muted-foreground hover:bg-accent disabled:opacity-50'>
+                  <Ellipsis className='size-3.5' />
+                </button>
+              </DropdownMenuTrigger>
+              {/* `onCloseAutoFocus` prevented: without it Radix returns focus to
+                  this (mouse-only) trigger right after the menu closes, which
+                  steals the memo input's `autoFocus` a tick after it mounts -
+                  `LineRowMenu` guards the same way for its description field. */}
+              <DropdownMenuContent align='end' onCloseAutoFocus={(e) => e.preventDefault()}>
+                <DropdownMenuItem onSelect={onEditMemo}>
+                  <StickyNote />
+                  {hasMemo ? 'Edit memo' : 'Add memo'}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant='destructive' onSelect={onRemove}>
+                  <Trash2 />
+                  Delete line
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 interface JournalLinesProps {
   /** Real (materialized) rows only - never includes the trailing phantom. */
   rows: JournalLineDraft[]
@@ -216,14 +583,15 @@ interface JournalLinesProps {
 }
 
 /**
- * The lines grid: Account · Memo · Debit · Credit, plus a trailing phantom row
- * that materializes into a real row the moment anything is typed into it.
+ * The lines grid: a drag grip, Account (Memo lives behind its row menu, see
+ * below), Debit, Credit, plus a trailing phantom row that materializes into a
+ * real row the moment anything is typed into it.
  *
- * Keyboard nav is intentionally modest next to `LineBuilder`'s: Enter in a
- * Memo/Debit/Credit cell moves focus to the same column one row down (creating
- * the next phantom row along the way when the current one just materialized).
- * `GlAccountPicker` is a popover trigger with no exposed ref, so the account
- * cell is not part of the Enter chain - Tab already reaches it in DOM order.
+ * Keyboard nav is `LineBuilder`'s own `useLineNav` - it has no record
+ * assumptions, just `data-line-row`/`data-line-col` cells, so it works
+ * unmodified here. `GlAccountPicker` is a `PickerTrigger asCombobox`
+ * (`role="combobox"`), which is exactly what `useLineNav`'s focus matcher
+ * already looks for.
  */
 export function JournalLines({ rows, onChange, currencyCode, disabled }: JournalLinesProps) {
   // The phantom row's key is held in state, not regenerated every render, so
@@ -243,9 +611,14 @@ export function JournalLines({ rows, onChange, currencyCode, disabled }: Journal
   }
   const displayRows = [...rows, phantom]
 
+  /** Which row (by key) is currently showing the memo editor in its Account cell. */
+  const [editingMemoKey, setEditingMemoKey] = useState<string | null>(null)
+
   const { accounts } = useChartAccounts()
   const { resource: contactResource } = useResource('contact')
   const { resource: companyResource } = useResource('company')
+
+  const rowsContainerRef = useRef<HTMLDivElement>(null)
 
   function patchRow(index: number, patch: Partial<JournalLineDraft>) {
     if (index === rows.length) {
@@ -277,152 +650,105 @@ export function JournalLines({ rows, onChange, currencyCode, disabled }: Journal
   }
 
   function removeRow(index: number) {
+    const removedKey = rows[index]?.key
     onChange(rows.filter((_, i) => i !== index))
+    if (editingMemoKey === removedKey) setEditingMemoKey(null)
   }
 
-  function focusNext(index: number, col: 'memo' | 'debit' | 'credit') {
-    const target = document.querySelector<HTMLElement>(
-      `[data-je-row="${index + 1}"][data-je-col="${col}"]`
-    )
-    target?.focus()
+  /** Header "+" button - materializes today's phantom row as-is, same as `LineBuilder`'s `addLine`. */
+  function addBlankRow() {
+    patchRow(rows.length, {})
   }
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = rows.findIndex((row) => row.key === active.id)
+    const newIndex = rows.findIndex((row) => row.key === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+    onChange(arrayMove(rows, oldIndex, newIndex))
+  }
+
+  // Spreadsheet keyboard nav across the rows container (account → debit →
+  // credit). `onAddRow` is a no-op: the trailing phantom is always already
+  // there as "the next blank line," so nav past it has nothing to add.
+  useLineNav({
+    containerRef: rowsContainerRef,
+    rowCount: displayRows.length,
+    colCount: 3,
+    onAddRow: () => {},
+    readOnly: !!disabled,
+  })
 
   return (
-    <div className='overflow-hidden rounded-lg border'>
+    <div
+      data-slot='line-builder-frame'
+      className='rounded-lg border border-primary-200/50 dark:border-[#1e2227]'>
+      {/* Header - same grid template as the rows, so the labels sit over
+          their columns, `LineBuilder`'s own header treatment. */}
       <div
-        className='grid gap-2 border-b bg-muted/40 px-2 py-1.5 text-xs font-medium text-muted-foreground'
+        className='sticky top-0 z-10 grid rounded-t-lg border-primary-200/50 border-b bg-primary-50 px-1 py-2 text-muted-foreground text-sm dark:border-[#1e2227] dark:bg-background'
         style={{ gridTemplateColumns: GRID_COLS }}>
-        <span>Account</span>
-        <span>Memo</span>
-        <span className='text-right'>Debit</span>
-        <span className='text-right'>Credit</span>
-        <span />
+        <div />
+        <div className='flex items-center gap-1 pl-2'>
+          Account
+          {!disabled && (
+            <SimpleTooltip content='Add line item' side='right'>
+              <Button
+                variant='ghost'
+                size='icon-xs'
+                className='ml-1 size-5 rounded-md bg-primary-100 hover:bg-primary-200 dark:bg-background'
+                onClick={addBlankRow}
+                aria-label='Add line item'>
+                <Plus className='size-3' />
+              </Button>
+            </SimpleTooltip>
+          )}
+        </div>
+        <div className='px-2 text-right'>Debit</div>
+        <div className='px-2 text-right'>Credit</div>
+        <div />
       </div>
 
-      <div className='flex flex-col divide-y'>
-        {displayRows.map((row, index) => {
-          const isPhantom = index === rows.length
-          const account = row.glAccountId
-            ? accounts.find((a: ChartAccountRow) => a.id === row.glAccountId)
-            : undefined
-          const requiredKind = requiredCounterpartyKind(account?.subtype ?? null)
-          return (
-            <div
-              key={row.key}
-              className='grid items-start gap-2 px-2 py-1.5'
-              style={{ gridTemplateColumns: GRID_COLS }}>
-              <div className='flex flex-col gap-1'>
-                <GlAccountPicker
-                  value={row.glAccountId}
-                  onChange={(id) => handleAccountChange(index, id)}
-                  selectBy='id'
+      <div ref={rowsContainerRef}>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          modifiers={[restrictToVerticalAxis]}>
+          <SortableContext
+            items={rows.map((row) => row.key)}
+            strategy={verticalListSortingStrategy}
+            disabled={disabled}>
+            {displayRows.map((row, index) => {
+              const isPhantom = index === rows.length
+              const account = row.glAccountId
+                ? accounts.find((a: ChartAccountRow) => a.id === row.glAccountId)
+                : undefined
+              return (
+                <JournalLineRow
+                  key={row.key}
+                  row={row}
+                  rowIndex={index}
+                  isPhantom={isPhantom}
                   disabled={disabled}
-                  placeholder='Account…'
-                  // The one caller that overrides the transparent default: this is a
-                  // grid cell sitting beside bordered `Input`s, so a borderless
-                  // trigger reads as a gap in the row rather than a field.
-                  triggerProps={{ variant: 'outline', size: 'sm' }}
+                  currencyCode={currencyCode}
+                  account={account}
+                  contactEntityDefinitionId={contactResource?.id ?? null}
+                  companyEntityDefinitionId={companyResource?.id ?? null}
+                  editingMemo={editingMemoKey === row.key}
+                  onEditMemo={() => setEditingMemoKey(row.key)}
+                  onStopEditingMemo={() => setEditingMemoKey(null)}
+                  onPatch={(patch) => patchRow(index, patch)}
+                  onAccountChange={(id) => handleAccountChange(index, id)}
+                  onRemove={() => removeRow(index)}
                 />
-                {requiredKind && (
-                  <CounterpartyCell
-                    kind={requiredKind}
-                    entityDefinitionId={
-                      (requiredKind === 'customer' ? contactResource?.id : companyResource?.id) ??
-                      null
-                    }
-                    recordInstanceId={row.counterpartyId}
-                    disabled={disabled}
-                    onSelect={(id) =>
-                      patchRow(index, { counterpartyType: requiredKind, counterpartyId: id })
-                    }
-                    onClear={() =>
-                      patchRow(index, { counterpartyType: null, counterpartyId: null })
-                    }
-                  />
-                )}
-              </div>
-
-              <Input
-                data-je-row={index}
-                data-je-col='memo'
-                value={row.memo}
-                onChange={(e) => patchRow(index, { memo: e.target.value })}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault()
-                    focusNext(index, 'memo')
-                  }
-                }}
-                placeholder='Memo'
-                disabled={disabled}
-                className='h-8'
-              />
-
-              <CurrencyInput
-                value={row.debitMinor}
-                currencyCode={currencyCode}
-                disabled={disabled}
-                onValueChange={(next) =>
-                  patchRow(index, {
-                    debitMinor: next ?? null,
-                    creditMinor: next ? null : row.creditMinor,
-                  })
-                }>
-                <InputGroup className='h-8 border shadow-none'>
-                  <CurrencyInputField
-                    data-je-row={index}
-                    data-je-col='debit'
-                    className='text-right'
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        focusNext(index, 'debit')
-                      }
-                    }}
-                  />
-                </InputGroup>
-              </CurrencyInput>
-
-              <CurrencyInput
-                value={row.creditMinor}
-                currencyCode={currencyCode}
-                disabled={disabled}
-                onValueChange={(next) =>
-                  patchRow(index, {
-                    creditMinor: next ?? null,
-                    debitMinor: next ? null : row.debitMinor,
-                  })
-                }>
-                <InputGroup className='h-8 border shadow-none'>
-                  <CurrencyInputField
-                    data-je-row={index}
-                    data-je-col='credit'
-                    className='text-right'
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        focusNext(index, 'credit')
-                      }
-                    }}
-                  />
-                </InputGroup>
-              </CurrencyInput>
-
-              {isPhantom ? (
-                <span />
-              ) : (
-                <button
-                  type='button'
-                  aria-label='Remove line'
-                  disabled={disabled}
-                  onClick={() => removeRow(index)}
-                  className='flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-50'>
-                  <Trash2 className='size-3.5' />
-                </button>
-              )}
-            </div>
-          )
-        })}
+              )
+            })}
+          </SortableContext>
+        </DndContext>
       </div>
     </div>
   )

--- a/apps/web/src/components/accounting/ui/settings/recurring-template-schedule-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/recurring-template-schedule-editor.tsx
@@ -22,6 +22,13 @@ import { defaultCustomPattern } from '~/components/global/recurrence/recurrence-
 import { formatPeriodLabel } from '../ledger/format'
 import type { RecurringTemplateRow } from './recurring-templates-list'
 
+/**
+ * Cancels the pane's `p-3` so `Section` sits FLUSH with it. `Section` draws
+ * its own `p-3` and a full-width `border-b`, a divider meant to run edge to
+ * edge (see `bank-account-editor.tsx`'s own copy of this).
+ */
+const SECTION_BLEED = '-mx-3'
+
 interface RecurringTemplateScheduleEditorProps {
   row: RecurringTemplateRow | null
   weekStartIndex: 0 | 1 | 6
@@ -73,11 +80,13 @@ export function RecurringTemplateScheduleEditor({
 
   if (!row || !pattern) {
     return (
-      <EmptySection
-        icon={<CalendarClock className='size-5' />}
-        title='Pick a template'
-        description='Its schedule, and what it currently owes, show here.'
-      />
+      <div className='p-3'>
+        <EmptySection
+          icon={<CalendarClock className='size-5' />}
+          title='Pick a template'
+          description='Its schedule, and what it currently owes, show here.'
+        />
+      </div>
     )
   }
 
@@ -86,11 +95,12 @@ export function RecurringTemplateScheduleEditor({
   const dirty = JSON.stringify(pattern) !== JSON.stringify(row.rule?.pattern ?? null)
 
   return (
-    <div className='flex flex-col gap-3 p-3'>
+    <div className='flex flex-col p-3'>
       <Section
         title='This template'
         icon={<CalendarClock className='size-4' />}
-        collapsible={false}>
+        collapsible={false}
+        className={SECTION_BLEED}>
         <div className='flex flex-col gap-2 text-sm'>
           <div className='flex flex-wrap items-center gap-2'>
             <span className='font-medium'>
@@ -118,7 +128,11 @@ export function RecurringTemplateScheduleEditor({
         </div>
       </Section>
 
-      <Section title='Repeats' icon={<Repeat className='size-4' />} collapsible={false}>
+      <Section
+        title='Repeats'
+        icon={<Repeat className='size-4' />}
+        collapsible={false}
+        className={SECTION_BLEED}>
         <div className='flex flex-col gap-3'>
           <RecurrencePatternFields
             value={pattern}
@@ -159,7 +173,7 @@ export function RecurringTemplateScheduleEditor({
           entry still OWED, not one skipped. The sweep is holding its cursor on
           that occurrence, so nothing is lost while they decide. */}
       {held && (
-        <div className='flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50/60 p-3 text-sm dark:border-amber-900 dark:bg-amber-950/30'>
+        <div className='mt-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50/60 p-3 text-sm dark:border-amber-900 dark:bg-amber-950/30'>
           <TriangleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
           <div className='flex flex-col gap-1'>
             <span className='font-medium'>
@@ -175,7 +189,7 @@ export function RecurringTemplateScheduleEditor({
       )}
 
       {!held && due > 0 && (
-        <div className='rounded-lg border bg-muted/40 p-3 text-muted-foreground text-sm'>
+        <div className='mt-3 rounded-lg border bg-muted/40 p-3 text-muted-foreground text-sm'>
           {due} {due === 1 ? 'entry is' : 'entries are'} due and will be generated on the next
           nightly sweep.
         </div>

--- a/apps/web/src/components/accounting/ui/settings/recurring-templates-settings-page.tsx
+++ b/apps/web/src/components/accounting/ui/settings/recurring-templates-settings-page.tsx
@@ -19,14 +19,18 @@ import type { RecurrencePattern } from '@auxx/lib/recurrence/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { Lock } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useRegisterDockedPanels } from '~/components/global/docked-panels-outlet'
 import { EmptyState } from '~/components/global/empty-state'
 import { MasterDetailSplit } from '~/components/global/master-detail-split'
 import SettingsPage from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useSettings } from '~/hooks/use-settings'
 import { useRequireCapability } from '~/providers/capabilities-provider'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import { JournalEntryDrawer } from '../journal/journal-entry-drawer'
 import { RecurringTemplateScheduleEditor } from './recurring-template-schedule-editor'
@@ -57,7 +61,11 @@ export function RecurringTemplatesSettingsPage() {
   // are sent to, and a pane that vanishes on refresh cannot be linked to.
   const [editParam, setEdit] = useQueryState('edit')
   const [confirm, ConfirmDialog] = useConfirm()
-  const [drawerWidth, setDrawerWidth] = useState(560)
+  // Shared with the ledger page's own `JournalEntryDrawer` so a resize on one
+  // screen carries to the other.
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
 
   const templates = api.ledger.recurringTemplate.list.useQuery()
   const rows = useMemo(() => (templates.data ?? []) as RecurringTemplateRow[], [templates.data])
@@ -120,6 +128,60 @@ export function RecurringTemplatesSettingsPage() {
     clearSchedule.mutate({ templateId: selected.template.id })
   }, [selected, confirm, clearSchedule])
 
+  // The SAME drawer the ledger page uses, in template mode: it hides Preview
+  // and Post, because `postJournalEntry` refuses a stencil by name. The
+  // schedule is not in it - a rule needs a saved record to hang off and the
+  // drawer defers its create to the first edit, so the repeat editor lives in
+  // the pane behind this.
+  const drawer = useMemo(
+    () => (
+      <JournalEntryDrawer
+        journalEntryId={editParam && editParam !== 'new' ? editParam : null}
+        isNew={editParam === 'new'}
+        open={!!editParam}
+        onOpenChange={(open) => {
+          if (!open) void setEdit(null)
+        }}
+        isDocked={isDocked}
+        width={dockedWidth}
+        onWidthChange={setDockedWidth}
+        currencyCode='USD'
+        defaultDate={new Date().toISOString().slice(0, 10)}
+        kind='recurring_template'
+        onCreated={(id) => {
+          void setEdit(id)
+          void setSelectedId(id)
+          void invalidate()
+        }}
+        onPosted={() => {}}
+        onOpenPosting={() => {}}
+        onDiscarded={() => {
+          void setEdit(null)
+          void setSelectedId(null)
+          void invalidate()
+        }}
+      />
+    ),
+    [editParam, isDocked, dockedWidth, setDockedWidth, setEdit, setSelectedId, invalidate]
+  )
+
+  // The Accounting settings LAYOUT owns the one `MainPageContent`, so the
+  // docked panel is published to its outlet rather than passed as a prop
+  // (`docked-panels-outlet.tsx`) - same recipe `review-queue-page.tsx` uses.
+  const panels = useMemo(
+    () => [
+      {
+        key: 'recurring-je',
+        open: !!editParam,
+        content: drawer,
+        width: { value: dockedWidth, set: setDockedWidth, min: 420, max: 800 },
+      },
+    ],
+    [editParam, drawer, dockedWidth, setDockedWidth]
+  )
+  const { dockedPanels, overlays } = useDockedPanels(panels)
+  useRegisterDockedPanels(dockedPanels)
+
   if (!hasAccess(FeatureKey.accounting)) {
     return (
       <SettingsPage
@@ -168,37 +230,7 @@ export function RecurringTemplatesSettingsPage() {
         />
       </MasterDetailSplit>
 
-      {/* The SAME drawer the ledger page uses, in template mode: it hides
-          Preview and Post, because `postJournalEntry` refuses a stencil by
-          name. The schedule is not in it - a rule needs a saved record to hang
-          off and the drawer defers its create to the first edit, so the
-          repeat editor lives in the pane behind this. */}
-      <JournalEntryDrawer
-        journalEntryId={editParam && editParam !== 'new' ? editParam : null}
-        isNew={editParam === 'new'}
-        open={!!editParam}
-        onOpenChange={(open) => {
-          if (!open) void setEdit(null)
-        }}
-        isDocked={false}
-        width={drawerWidth}
-        onWidthChange={setDrawerWidth}
-        currencyCode='USD'
-        defaultDate={new Date().toISOString().slice(0, 10)}
-        kind='recurring_template'
-        onCreated={(id) => {
-          void setEdit(id)
-          void setSelectedId(id)
-          void invalidate()
-        }}
-        onPosted={() => {}}
-        onOpenPosting={() => {}}
-        onDiscarded={() => {
-          void setEdit(null)
-          void setSelectedId(null)
-          void invalidate()
-        }}
-      />
+      {overlays}
 
       <ConfirmDialog />
     </SettingsPage>

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -941,13 +941,14 @@ function PriceCellView(props: {
  * round-trip" comparison can still drift on a five-place value across a double's
  * floating-point rounding.
  */
-function CurrencyCellInput({
+export function CurrencyCellInput({
   value,
   readOnly,
   currencyCode,
   decimals,
   onCommit,
   ariaLabel,
+  live = false,
 }: {
   value: number | null
   readOnly: boolean
@@ -956,6 +957,16 @@ function CurrencyCellInput({
   decimals?: number
   onCommit: (next: number | null) => void
   ariaLabel?: string
+  /**
+   * Also commit on every keystroke that parses cleanly, not only on blur.
+   * Off by default: every existing caller's `onCommit` is a `record.update`
+   * mutation, and committing per keystroke would flood the network with one
+   * write per character. Turn it on only where `onCommit` is cheap local
+   * state with no network write of its own - e.g. a running total elsewhere
+   * on the page that a person expects to move as they type, not only once
+   * they tab away.
+   */
+  live?: boolean
 }) {
   const [draft, setDraft] = useState<string | null>(null)
   // Set only by onChange, cleared on focus/commit - whether the draft was
@@ -964,13 +975,7 @@ function CurrencyCellInput({
 
   const display = formatCurrency(value ?? null, currencyCode, decimals)
 
-  const commit = () => {
-    if (draft === null) return
-    const wasEdited = dirtyRef.current
-    const raw = draft
-    setDraft(null)
-    dirtyRef.current = false
-    if (!wasEdited) return
+  const commitRaw = (raw: string) => {
     const trimmed = raw.trim()
     if (trimmed === '') {
       if (value === null || value === undefined) return
@@ -981,6 +986,16 @@ function CurrencyCellInput({
     if (next === null) return
     if (next === (value ?? null)) return
     onCommit(next)
+  }
+
+  const commit = () => {
+    if (draft === null) return
+    const wasEdited = dirtyRef.current
+    const raw = draft
+    setDraft(null)
+    dirtyRef.current = false
+    if (!wasEdited) return
+    commitRaw(raw)
   }
 
   if (readOnly) {
@@ -994,6 +1009,7 @@ function CurrencyCellInput({
       onChange={(e) => {
         setDraft(e.target.value)
         dirtyRef.current = true
+        if (live) commitRaw(e.target.value)
       }}
       onFocus={() => {
         // Full stored precision, never the display-rounded string - otherwise a


### PR DESCRIPTION
## Summary
- Docks the recurring-template journal-entry drawer as a real side panel (wired via `DockedPanelsOutletProvider`, matching the banking layout's precedent) instead of it floating as an overlay, and fixes `Section` edge-to-edge bleed / double gap between sibling sections in the drawer and the schedule editor pane.
- Rebuilds `JournalLines` on `LineBuilder`'s record-free pieces: `useLineNav` for real spreadsheet keyboard nav, and `CurrencyCellInput` (with an additive `live` mode so the balance footer moves while typing, not just on blur) for chromeless debit/credit cells. Adds drag-reorder and a row `⋯` menu (delete, add/edit memo); memo moves off its own standing column into a menu-triggered reveal over the Account cell.
- Replaces the Account cell's button-that-opens-a-popover with a real `<input role="combobox">` that live-filters and arrow-key-navigates on focus, splitting `gl-account-picker.tsx` into `GlAccountList`/`GlAccountPickerBody`/`GlAccountPickerContent` (the `ResourcePickerContent`/`ResourceCommandBody` idiom) so the popover-triggered `GlAccountPicker` and this inline cell share one implementation.

## Test plan
- [x] `pnpm exec biome check` clean on all touched files
- [x] `node scripts/ci/typecheck-ratchet.js --package web` — no new type errors
- [x] Manually verified in a running dev instance: drawer docks on desktop; Starts/date edits don't save-and-close; Lines/This-template/Repeats sections reach their edges with no double gap; drag-reorder; row `⋯` menu add/edit memo (reveal + collapse to icon) and delete; Account cell opens on focus, live-filters by typing, arrow-key highlight moves within the same cell (not across rows), Enter commits without reopening; Debit/Credit footer totals update live while typing

https://claude.ai/code/session_018vuGrZZamKvQSnCRs7zrd1