### PR TITLE
feat(accounting): sync the customer a receivable names, inside the export

### DIFF
--- a/packages/lib/src/money/quickbooks/__tests__/quickbooks-accounting-provider.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/quickbooks-accounting-provider.test.ts
@@ -44,6 +44,17 @@ vi.mock('../identity-field', () => ({
   readQuickbooksIdField: (...a: unknown[]) => readQuickbooksIdField(...a),
 }))
 
+// The customer find-or-create (task 23). Stubbed here for the same reason
+// `readQuickbooksIdField` is: what this file tests is how the ADAPTER routes a
+// counterparty, not how a customer is resolved - that has its own test file,
+// and reaching the real one would need a `UnifiedCrudHandler` and a database.
+const upsertQuickbooksCustomer = vi.fn()
+const readQuickbooksCustomerFields = vi.fn()
+vi.mock('../upsert-customer', () => ({
+  upsertQuickbooksCustomer: (...a: unknown[]) => upsertQuickbooksCustomer(...a),
+  readQuickbooksCustomerFields: (...a: unknown[]) => readQuickbooksCustomerFields(...a),
+}))
+
 import type { PostEntryInput, ResolvedPostingLine } from '../../../postings/types'
 import { ProviderPostError } from '../../../postings/types'
 import {
@@ -219,6 +230,8 @@ beforeEach(() => {
   getOrganizationSetting.mockResolvedValue(true)
   // Default: nothing synced. Tests that need a resolved counterparty override this.
   readQuickbooksIdField.mockResolvedValue(undefined)
+  readQuickbooksCustomerFields.mockResolvedValue({ firstName: 'Tawni', lastName: 'Donahue' })
+  upsertQuickbooksCustomer.mockResolvedValue('qbo-cust-new')
 })
 
 describe('the exported surface', () => {
@@ -475,9 +488,54 @@ describe('the counterparty (brief 13 §1)', () => {
     )
   })
 
-  it('an A/R line with an unsynced contact refuses with the sentence and configuration', async () => {
+  it('an A/R line with an unsynced contact CREATES the customer and exports (task 23)', async () => {
+    // 🛑 The behaviour task 23 exists to change. This used to refuse with "has
+    // not been synced to QuickBooks yet", which was permanent: nothing in
+    // production had written `qboCustomerId` since the invoice mirror took its
+    // only writer with it in #2100, so every receivable entry was stuck.
+    const callTool = connect({
+      create_quickbooks_journal_entry: () => ({ journalEntry: { journalEntryId: '410' } }),
+    })
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    upsertQuickbooksCustomer.mockResolvedValue('qbo-cust-77')
+
+    const input = counterpartyInput(
+      {},
+      {
+        glAccountId: 'acct_1100',
+        accountCode: '1100',
+        direction: 'debit',
+        amount: 50_000,
+        sourceType: 'invoice',
+        sourceId: 'inv_1',
+        sortOrder: 0,
+        counterpartyType: 'customer',
+        counterpartyId: 'contact_1',
+      }
+    )
+
+    const result = await provider.postEntry(input)
+
+    expect(result._unsafeUnwrap()).toMatchObject({ status: 'posted', externalId: '410' })
+    expect(upsertQuickbooksCustomer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ contactInstanceId: 'contact_1' })
+    )
+    const arLine = createCallOf(callTool)?.lines.find(
+      (l: { accountId?: string }) => l.accountId === '50'
+    )
+    expect(arLine?.entity).toEqual({ type: 'Customer', id: 'qbo-cust-77' })
+  })
+
+  it("carries the upsert's OWN refusal into the export error, not a generic one", async () => {
+    // The upsert's sentences name the contact and the remedy. The old generic
+    // wording implied a sync was pending somewhere, which is never true now:
+    // the sync IS this path, and it has already tried and refused.
     connect()
     readQuickbooksIdField.mockResolvedValue(undefined)
+    upsertQuickbooksCustomer.mockRejectedValue(
+      new Error('The contact on this line (contact_1) has no name and no email')
+    )
 
     const input = counterpartyInput(
       {},
@@ -500,7 +558,63 @@ describe('the counterparty (brief 13 §1)', () => {
     expect(error.failureClass).toBe('configuration')
     expect(error.message).toContain(DOC_NUMBER)
     expect(error.message).toContain('1100 Accounts Receivable')
-    expect(error.message).toContain('has not been synced to QuickBooks yet')
+    expect(error.message).toContain('has no name and no email')
+    expect(error.message).not.toContain('has not been synced to QuickBooks yet')
+  })
+
+  it('collects a refusal per contact rather than failing on the first', async () => {
+    // The rule `resolveMappedAccounts` follows, now covering the upsert too:
+    // one contact that cannot be resolved must not hide the other.
+    connect()
+    readQuickbooksIdField.mockResolvedValue(undefined)
+    upsertQuickbooksCustomer.mockImplementation(
+      async (_ctx: unknown, input: { contactInstanceId: string }) => {
+        throw new Error(`cannot resolve ${input.contactInstanceId}`)
+      }
+    )
+
+    const input = baseInput({
+      lines: [
+        {
+          glAccountId: 'acct_1100',
+          accountCode: '1100',
+          direction: 'debit',
+          amount: 30_000,
+          sourceType: 'invoice',
+          sourceId: 'inv_1',
+          sortOrder: 0,
+          counterpartyType: 'customer',
+          counterpartyId: 'contact_1',
+        },
+        {
+          glAccountId: 'acct_1100',
+          accountCode: '1100',
+          direction: 'debit',
+          amount: 20_000,
+          sourceType: 'invoice',
+          sourceId: 'inv_2',
+          sortOrder: 1,
+          counterpartyType: 'customer',
+          counterpartyId: 'contact_2',
+        },
+        {
+          glAccountId: 'acct_2160',
+          accountCode: '2160',
+          direction: 'credit',
+          amount: 50_000,
+          sourceType: 'invoice',
+          sourceId: 'inv_1',
+          sortOrder: 2,
+        },
+      ],
+    })
+
+    const result = await provider.postEntry(input)
+    const error = result._unsafeUnwrapErr() as ProviderPostError
+
+    expect(error.message).toContain('cannot resolve contact_1')
+    expect(error.message).toContain('cannot resolve contact_2')
+    expect(upsertQuickbooksCustomer).toHaveBeenCalledTimes(2)
   })
 
   it('an A/R line with NO counterparty at all refuses', async () => {
@@ -574,7 +688,12 @@ describe('the counterparty (brief 13 §1)', () => {
       expect.objectContaining({ appFieldKey: 'qboVendorId', recordId: 'company:company_1' })
     )
     expect(error.message).toContain('2000 Accounts Payable')
-    expect(error.message).toContain('has not been synced to QuickBooks yet')
+    expect(error.message).toContain('auxx cannot create one for it')
+    // 🛑 The A/P twin is NOT built (task 23 §4.9). There is no `qboVendorId`
+    // field to write, so there is nothing to create into, and a vendor line
+    // still refuses exactly as it did before. Mirror the customer ladder only
+    // once a vendor bill actually posts; do not build it blind.
+    expect(upsertQuickbooksCustomer).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/lib/src/money/quickbooks/__tests__/upsert-customer.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/upsert-customer.test.ts
@@ -1,6 +1,12 @@
 // packages/lib/src/money/quickbooks/__tests__/upsert-customer.test.ts
+//
+// The ladder from plans/accounting/tasks/23 §2, and above all §2.4's decision
+// table. The test that matters most is "two John Smiths": the brief's own first
+// draft said "on 6240, re-query and adopt the winner", which would have merged
+// two people's receivables under one customer. It balances, the aging foots, and
+// nothing downstream can detect it - so it has to be caught here or nowhere.
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 const readQuickbooksIdField = vi.fn()
 const writeQuickbooksIdField = vi.fn()
@@ -10,13 +16,22 @@ vi.mock('../identity-field', () => ({
 }))
 
 import type { QuickbooksToolContext } from '../invoke-quickbooks-tool'
-import { upsertQuickbooksCustomer } from '../upsert-customer'
+import { customerStamp, upsertQuickbooksCustomer } from '../upsert-customer'
 
 const ORG_ID = 'org1'
-const CONTACT_ID = 'contact1'
-const handler = {} as never // opaque — only threaded through to the mocked identity-field reads
+const CONTACT_ID = 'contact_aaa111bbb222'
+const OTHER_CONTACT_ID = 'contact_zzz999yyy888'
+const handler = {} as never // opaque - only threaded through to the mocked identity-field reads
 
-function buildCtx(callTool = vi.fn()): QuickbooksToolContext {
+/**
+ * The `callTool` double, typed to the tool seam rather than to `vi.fn()`'s
+ * default union - a bare `ReturnType<typeof vi.fn>` is `Mock<Constructable |
+ * Procedure>` and will not satisfy `QuickbooksToolContext`.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: tool payloads are per-tool shapes
+type ToolMock = Mock<(toolId: string, inputs: any) => Promise<any>>
+
+function buildCtx(callTool: ToolMock = vi.fn()): QuickbooksToolContext {
   return {
     organizationId: ORG_ID,
     installationId: 'install1',
@@ -26,42 +41,100 @@ function buildCtx(callTool = vi.fn()): QuickbooksToolContext {
   }
 }
 
+function run(callTool: ToolMock, fields: Record<string, string | undefined>) {
+  return upsertQuickbooksCustomer(buildCtx(callTool), {
+    organizationId: ORG_ID,
+    contactInstanceId: CONTACT_ID,
+    contactFields: fields,
+    handler,
+  })
+}
+
+/** `find_quickbooks_customer`'s "nothing matched" answer. */
+const NOT_FOUND = { found: false, customer: null, notImportedReason: null }
+
+/** One found customer, in the tool's own shape. */
+function found(over: Record<string, unknown> = {}) {
+  return {
+    found: true,
+    customer: {
+      customerId: '99',
+      displayName: 'Jane Doe',
+      email: null,
+      notes: null,
+      active: true,
+      ...over,
+    },
+    notImportedReason: null,
+  }
+}
+
+/** Intuit's duplicate-`DisplayName` fault, as the tool layer surfaces it. */
+function duplicateNameFault() {
+  return Object.assign(new Error('Duplicate Name Exists Error: code 6240'), {
+    code: 'INVALID_INPUT',
+  })
+}
+
+/**
+ * Route `callTool` by tool id and, for finds, by the key being searched - the
+ * ladder asks for several different names in one run, so a positional
+ * `mockResolvedValueOnce` chain becomes unreadable fast.
+ */
+function router(handlers: {
+  byEmail?: Record<string, unknown>
+  byName?: Record<string, unknown>
+  // biome-ignore lint/suspicious/noExplicitAny: tool payloads are per-tool shapes
+  create?: (inputs: any) => unknown
+}): ToolMock {
+  return vi.fn(async (toolId: string, inputs: any) => {
+    if (toolId === 'find_quickbooks_customer') {
+      if (inputs.email) return handlers.byEmail?.[inputs.email] ?? NOT_FOUND
+      return handlers.byName?.[inputs.displayName] ?? NOT_FOUND
+    }
+    if (toolId === 'create_quickbooks_customer') {
+      if (handlers.create) return handlers.create(inputs)
+      return { customerId: '101', displayName: inputs.displayName }
+    }
+    return {}
+  })
+}
+
+function createCalls(callTool: ToolMock) {
+  return callTool.mock.calls.filter(([id]) => id === 'create_quickbooks_customer').map((c) => c[1])
+}
+
 beforeEach(() => {
   readQuickbooksIdField.mockReset()
   writeQuickbooksIdField.mockReset()
+  readQuickbooksIdField.mockResolvedValue(undefined)
 })
 
-describe('upsertQuickbooksCustomer', () => {
-  it('returns the stored id without calling any QuickBooks tool (idempotent fast path)', async () => {
+describe('layer 1 - the stored id', () => {
+  it('returns it without calling any QuickBooks tool', async () => {
     readQuickbooksIdField.mockResolvedValue('qbo-cust-existing')
     const callTool = vi.fn()
 
-    const result = await upsertQuickbooksCustomer(buildCtx(callTool), {
-      organizationId: ORG_ID,
-      contactInstanceId: CONTACT_ID,
-      contactFields: { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' },
-      handler,
-    })
+    const result = await run(callTool, { firstName: 'Jane', lastName: 'Doe' })
 
     expect(result).toBe('qbo-cust-existing')
     expect(callTool).not.toHaveBeenCalled()
     expect(writeQuickbooksIdField).not.toHaveBeenCalled()
   })
+})
 
-  it('finds by exact email and writes the id back — no create call', async () => {
-    readQuickbooksIdField.mockResolvedValue(undefined)
-    const callTool = vi.fn().mockResolvedValue({ found: true, customer: { customerId: '99' } })
+describe('layer 2 - find by email', () => {
+  it('adopts the match and writes the id back, with no create', async () => {
+    const callTool = router({ byEmail: { 'jane@example.com': found({ customerId: '99' }) } })
 
-    const result = await upsertQuickbooksCustomer(buildCtx(callTool), {
-      organizationId: ORG_ID,
-      contactInstanceId: CONTACT_ID,
-      contactFields: { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' },
-      handler,
+    const result = await run(callTool, {
+      firstName: 'Jane',
+      lastName: 'Doe',
+      primaryEmail: 'jane@example.com',
     })
 
     expect(result).toBe('99')
-    expect(callTool).toHaveBeenCalledWith('find_quickbooks_customer', { email: 'jane@example.com' })
-    expect(callTool).not.toHaveBeenCalledWith('create_quickbooks_customer', expect.anything())
+    expect(createCalls(callTool)).toHaveLength(0)
     expect(writeQuickbooksIdField).toHaveBeenCalledWith(
       expect.objectContaining({
         appFieldKey: 'qboCustomerId',
@@ -72,64 +145,302 @@ describe('upsertQuickbooksCustomer', () => {
     )
   })
 
-  it('creates a customer when the email search misses', async () => {
-    readQuickbooksIdField.mockResolvedValue(undefined)
-    const callTool = vi
-      .fn()
-      .mockResolvedValueOnce({ found: false, customer: null, notImportedReason: null })
-      .mockResolvedValueOnce({ customerId: '101', displayName: 'Jane Doe' })
+  it('is the identity rule: two contacts on one email land on one customer', async () => {
+    // §2.5 and §4.3. They are one person and their A/R should aggregate. The
+    // mirror case - one name, two emails - resolves the opposite way below, for
+    // the same reason: the email is the identity, the name is only a label.
+    const callTool = router({ byEmail: { 'shared@example.com': found({ customerId: '55' }) } })
 
-    const result = await upsertQuickbooksCustomer(buildCtx(callTool), {
+    const first = await run(callTool, { firstName: 'Jane', primaryEmail: 'shared@example.com' })
+    const second = await upsertQuickbooksCustomer(buildCtx(callTool), {
       organizationId: ORG_ID,
-      contactInstanceId: CONTACT_ID,
-      contactFields: { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' },
+      contactInstanceId: OTHER_CONTACT_ID,
+      contactFields: { firstName: 'J', lastName: 'Doe', primaryEmail: 'shared@example.com' },
       handler,
+    })
+
+    expect(first).toBe('55')
+    expect(second).toBe('55')
+    expect(createCalls(callTool)).toHaveLength(0)
+  })
+})
+
+describe('layer 3 - find by display name', () => {
+  it('adopts a same-named customer carrying OUR stamp', async () => {
+    // §6 acceptance 6. No email on either side, so the stamp is the only thing
+    // that can say "this is ours" - and it can, because auxx stamps on create.
+    const callTool = router({
+      byName: {
+        'Jane Doe': found({ customerId: '77', notes: `${customerStamp(CONTACT_ID)} do not edit` }),
+      },
+    })
+
+    const result = await run(callTool, { firstName: 'Jane', lastName: 'Doe' })
+
+    expect(result).toBe('77')
+    expect(createCalls(callTool)).toHaveLength(0)
+  })
+
+  it('does NOT create on every attempt for an emailless contact', async () => {
+    // What this arm exists for. Before it, an emailless contact went straight
+    // from "no email" to "create" and made a new customer every single run.
+    const callTool = router({
+      byName: { 'Jane Doe': found({ customerId: '77', notes: customerStamp(CONTACT_ID) }) },
+    })
+
+    await run(callTool, { firstName: 'Jane', lastName: 'Doe' })
+    await run(callTool, { firstName: 'Jane', lastName: 'Doe' })
+
+    expect(createCalls(callTool)).toHaveLength(0)
+  })
+})
+
+describe('layer 4 - create, and the 6240 decision table (§2.4)', () => {
+  it('creates with the plain name and stamps Notes on create only', async () => {
+    const callTool = router({})
+
+    const result = await run(callTool, {
+      firstName: 'Jane',
+      lastName: 'Doe',
+      primaryEmail: 'jane@example.com',
     })
 
     expect(result).toBe('101')
-    expect(callTool).toHaveBeenNthCalledWith(
-      2,
-      'create_quickbooks_customer',
-      expect.objectContaining({
-        displayName: 'Jane Doe',
-        givenName: 'Jane',
-        familyName: 'Doe',
-        email: 'jane@example.com',
-      })
-    )
+    expect(createCalls(callTool)[0]).toMatchObject({
+      displayName: 'Jane Doe',
+      givenName: 'Jane',
+      familyName: 'Doe',
+      email: 'jane@example.com',
+      notes: customerStamp(CONTACT_ID),
+    })
   })
 
-  it('skips the email search and creates directly when the contact has no email', async () => {
-    readQuickbooksIdField.mockResolvedValue(undefined)
-    const callTool = vi.fn().mockResolvedValue({ customerId: '202', displayName: 'Jane Doe' })
-
-    const result = await upsertQuickbooksCustomer(buildCtx(callTool), {
-      organizationId: ORG_ID,
-      contactInstanceId: CONTACT_ID,
-      contactFields: { firstName: 'Jane', lastName: 'Doe' },
-      handler,
+  it('row 1 - adopts when the winner carries OUR email (the concurrent race)', async () => {
+    // Two entries for the same new contact exported at once. One create wins,
+    // ours faults, and the winner is plainly us.
+    let created = false
+    const callTool = vi.fn(async (toolId: string, inputs: any) => {
+      if (toolId === 'find_quickbooks_customer') {
+        if (inputs.email) return NOT_FOUND
+        if (!created) return NOT_FOUND
+        return found({ customerId: '200', email: 'jane@example.com' })
+      }
+      created = true
+      throw duplicateNameFault()
     })
 
-    expect(result).toBe('202')
-    expect(callTool).toHaveBeenCalledTimes(1)
-    expect(callTool).toHaveBeenCalledWith(
-      'create_quickbooks_customer',
-      expect.objectContaining({ displayName: 'Jane Doe' })
+    const result = await run(callTool, {
+      firstName: 'Jane',
+      lastName: 'Doe',
+      primaryEmail: 'jane@example.com',
+    })
+
+    expect(result).toBe('200')
+    expect(writeQuickbooksIdField).toHaveBeenCalledWith(
+      expect.objectContaining({ externalId: '200' })
     )
   })
 
-  it('throws when the contact has neither a name nor an email to create with', async () => {
-    readQuickbooksIdField.mockResolvedValue(undefined)
-    const callTool = vi.fn()
+  it('row 2 - adopts when the winner carries OUR stamp', async () => {
+    let created = false
+    const callTool = vi.fn(async (toolId: string, inputs: any) => {
+      if (toolId === 'find_quickbooks_customer') {
+        if (inputs.email) return NOT_FOUND
+        if (!created) return NOT_FOUND
+        return found({ customerId: '201', notes: customerStamp(CONTACT_ID) })
+      }
+      created = true
+      throw duplicateNameFault()
+    })
+
+    const result = await run(callTool, { firstName: 'Jane', lastName: 'Doe' })
+
+    expect(result).toBe('201')
+  })
+
+  it('🛑 row 3 - TWO John Smiths get TWO customers, never one', async () => {
+    // §6 acceptance 4, and the test that would have caught the brief's own
+    // first draft. The existing Smith carries a different email, which is
+    // positive evidence of a different person, so the label is relabelled and a
+    // SECOND customer is created. Adopting here would merge two people's
+    // receivables and nothing downstream could ever detect it.
+    const callTool = router({
+      byName: {
+        'John Smith': found({
+          customerId: '300',
+          displayName: 'John Smith',
+          email: 'the.other.john@example.com',
+        }),
+      },
+      create: (inputs: any) => ({ customerId: '301', displayName: inputs.displayName }),
+    })
+
+    const result = await run(callTool, {
+      firstName: 'John',
+      lastName: 'Smith',
+      primaryEmail: 'our.john@example.com',
+    })
+
+    expect(result).toBe('301')
+    expect(result).not.toBe('300')
+    // Relabelled by rung 2, so the accountant can still tell them apart.
+    expect(createCalls(callTool)[0].displayName).toBe('John Smith (our.john@example.com)')
+  })
+
+  it('row 3 via the fault - a 6240 winner with a different email is relabelled', async () => {
+    const seen: string[] = []
+    const callTool = vi.fn(async (toolId: string, inputs: any) => {
+      if (toolId === 'find_quickbooks_customer') {
+        if (inputs.email) return NOT_FOUND
+        if (inputs.displayName === 'John Smith' && seen.includes('John Smith')) {
+          return found({ customerId: '300', email: 'stranger@example.com' })
+        }
+        return NOT_FOUND
+      }
+      seen.push(inputs.displayName)
+      if (inputs.displayName === 'John Smith') throw duplicateNameFault()
+      return { customerId: '302', displayName: inputs.displayName }
+    })
+
+    const result = await run(callTool, {
+      firstName: 'John',
+      lastName: 'Smith',
+      primaryEmail: 'our.john@example.com',
+    })
+
+    expect(result).toBe('302')
+    expect(seen).toEqual(['John Smith', 'John Smith (our.john@example.com)'])
+  })
+
+  it('🛑 row 4 - REFUSES a same-named customer with no email and no stamp', async () => {
+    // §6 acceptance 5. A customer the firm typed in by hand, with a common name
+    // and no email, cannot be told apart from a stranger by anything we hold.
+    // Guessing is the whole problem, so this stays a refusal.
+    const callTool = router({
+      byName: { 'John Smith': found({ customerId: '400', displayName: 'John Smith' }) },
+    })
+
+    await expect(run(callTool, { firstName: 'John', lastName: 'Smith' })).rejects.toThrow(
+      /no email address and no mark from auxx/
+    )
+    expect(createCalls(callTool)).toHaveLength(0)
+  })
+})
+
+describe('the label ladder (§2.6)', () => {
+  it('uses the email rung when there is an email', async () => {
+    const callTool = router({
+      byName: { 'Jane Doe': found({ customerId: '1', email: 'someone.else@example.com' }) },
+      create: (inputs: any) => ({ customerId: '500', displayName: inputs.displayName }),
+    })
+
+    await run(callTool, { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' })
+
+    expect(createCalls(callTool)[0].displayName).toBe('Jane Doe (jane@example.com)')
+  })
+
+  it('uses the company rung when there is no email', async () => {
+    const callTool = router({
+      byName: { 'Jane Doe': found({ customerId: '1', email: 'someone.else@example.com' }) },
+      create: (inputs: any) => ({ customerId: '501', displayName: inputs.displayName }),
+    })
+
+    await run(callTool, { firstName: 'Jane', lastName: 'Doe', companyName: 'Acme' })
+
+    expect(createCalls(callTool)[0].displayName).toBe('Jane Doe (Acme)')
+  })
+
+  it('falls back to the contact id, which is a pure function of the CONTACT', async () => {
+    // Never a counter. `John Smith 2` would depend on who exported first, so
+    // the name would not be reproducible and find-by-name would hunt a string
+    // only one particular ordering could have produced.
+    const callTool = router({
+      byName: { 'Jane Doe': found({ customerId: '1', email: 'someone.else@example.com' }) },
+      create: (inputs: any) => ({ customerId: '502', displayName: inputs.displayName }),
+    })
+
+    await run(callTool, { firstName: 'Jane', lastName: 'Doe' })
+
+    expect(createCalls(callTool)[0].displayName).toBe(`Jane Doe (${CONTACT_ID.slice(-6)})`)
+  })
+
+  it('uses the email alone as the label when there is no name', async () => {
+    const callTool = router({})
+
+    await run(callTool, { primaryEmail: 'jane@example.com' })
+
+    expect(createCalls(callTool)[0].displayName).toBe('jane@example.com')
+  })
+
+  it('terminates rather than looping when every rung is taken', async () => {
+    const callTool = router({
+      byName: {
+        'Jane Doe': found({ customerId: '1', email: 'a@x.com' }),
+        'Jane Doe (jane@example.com)': found({ customerId: '2', email: 'b@x.com' }),
+        [`Jane Doe (${CONTACT_ID.slice(-6)})`]: found({ customerId: '3', email: 'c@x.com' }),
+      },
+    })
 
     await expect(
-      upsertQuickbooksCustomer(buildCtx(callTool), {
-        organizationId: ORG_ID,
-        contactInstanceId: CONTACT_ID,
-        contactFields: {},
-        handler,
-      })
-    ).rejects.toThrow(/no name or email/)
+      run(callTool, { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' })
+    ).rejects.toThrow(/Every name auxx could give this contact/)
+    expect(createCalls(callTool)).toHaveLength(0)
+  })
+})
+
+describe('refusals', () => {
+  it('refuses a contact with neither a name nor an email (§4.6)', async () => {
+    const callTool = vi.fn()
+
+    await expect(run(callTool, {})).rejects.toThrow(/has no name and no email/)
     expect(callTool).not.toHaveBeenCalled()
+  })
+
+  it('refuses a deactivated customer rather than reactivating it (§4.2)', async () => {
+    // QuickBooks does not hard-delete a customer, it deactivates one, and it
+    // rejects a receivable line naming an inactive customer. Reactivating would
+    // be an edit to their books nobody asked for.
+    const callTool = router({
+      byEmail: {
+        'jane@example.com': found({ customerId: '600', displayName: 'Jane Doe', active: false }),
+      },
+    })
+
+    await expect(
+      run(callTool, { firstName: 'Jane', lastName: 'Doe', primaryEmail: 'jane@example.com' })
+    ).rejects.toThrow(/has been made inactive/)
+    expect(createCalls(callTool)).toHaveLength(0)
+    expect(writeQuickbooksIdField).not.toHaveBeenCalled()
+  })
+
+  it('rethrows a non-6240 create failure as itself', async () => {
+    const callTool = router({
+      create: () => {
+        throw new Error('QuickBooks is unreachable')
+      },
+    })
+
+    await expect(run(callTool, { firstName: 'Jane', lastName: 'Doe' })).rejects.toThrow(
+      /unreachable/
+    )
+  })
+})
+
+describe('readQuickbooksCustomerFields resolves by systemAttribute (§the near-miss)', () => {
+  it('names the attributes the contact registry actually declares', async () => {
+    // 🛑 The guard on the bug this nearly shipped with. `FieldValue.fieldId`
+    // holds the org's generated `CustomField` id, NOT the registry key - a
+    // field's registry `id` is a brand cast over a plain string and the two are
+    // unrelated. Joining on the key returns zero rows, which would make every
+    // contact look nameless and refuse its own export, silently.
+    //
+    // The module derives these from `CONTACT_FIELDS` so they cannot drift; this
+    // asserts the registry still declares what the SQL is written against.
+    const { CONTACT_FIELDS } = await import('../../../resources/registry/resources/contact-fields')
+
+    expect(CONTACT_FIELDS.firstName?.systemAttribute).toBe('first_name')
+    expect(CONTACT_FIELDS.lastName?.systemAttribute).toBe('last_name')
+    expect(CONTACT_FIELDS.primaryEmail?.systemAttribute).toBe('primary_email')
+    expect(CONTACT_FIELDS.company?.systemAttribute).toBe('contact_company')
   })
 })

--- a/packages/lib/src/money/quickbooks/identity-field.ts
+++ b/packages/lib/src/money/quickbooks/identity-field.ts
@@ -14,11 +14,11 @@
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { extractValue } from '@auxx/types'
-import { type RecordId, toRecordId } from '@auxx/types/resource'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
 import { getCachedEntityDefId } from '../../cache'
 import { FieldValueService } from '../../field-values/field-value-service'
-import { upsertRecordIdentity } from '../../identity'
+import { getRecordIdentitiesForRecords, upsertRecordIdentity } from '../../identity'
 import type { UnifiedCrudHandler } from '../../resources/crud'
 
 const logger = createScopedLogger('quickbooks-identity-field')
@@ -47,7 +47,32 @@ async function findAppField(params: {
 /**
  * Read a QuickBooks id-map field's current value off a record (e.g. does this contact
  * already have a `qboCustomerId`?). Returns `undefined` when the field isn't provisioned or
- * has never been written — both are "no stored id, fall through to find-or-create".
+ * has never been written - both are "no stored id, fall through to find-or-create".
+ *
+ * ## Two places the answer can live, and why the second one matters
+ *
+ * The cell is authoritative. The `RecordIdentity` mirror is the fallback, and it
+ * exists for exactly one state: **the record has been deleted**
+ * (plans/accounting/tasks/23 section 4.1).
+ *
+ * `deleteEntityInstance` calls `sweepEntityFieldValues`, which deletes
+ * `FieldValue` rows. It does NOT touch `RecordIdentity` - verified 2026-09-11,
+ * and the mirror is keyed on `entityInstanceId` rather than joined to a live
+ * instance, so it survives. That asymmetry is what makes this fallback work.
+ *
+ * 🛑 Without it, a posting line whose counterparty was later deleted becomes
+ * permanently unexportable. The line's `counterpartyId` is FROZEN (brief 13
+ * section 1.1 - a retry exports under the attribution the ledger asserted, not
+ * the current record), so it still names the gone contact, but the cell is gone
+ * and there is no name or email left to search or create with. Reading the
+ * mirror lets that entry still export under the customer it was posted for,
+ * which is what "frozen attribution" was supposed to mean in the first place.
+ *
+ * The mirror is a record that a correspondence HAPPENED. Deleting our copy of
+ * one side does not make it un-happen.
+ *
+ * ⚠️ Costs nothing on the normal path: the fallback query only runs when the
+ * cell is absent, which for a live record it never is.
  */
 export async function readQuickbooksIdField(params: {
   organizationId: string
@@ -58,15 +83,53 @@ export async function readQuickbooksIdField(params: {
   handler: UnifiedCrudHandler
 }): Promise<string | undefined> {
   const field = await findAppField(params)
-  if (!field) return undefined
 
-  const values = await params.handler.getFieldValues(params.recordId, [field.id])
-  const entry = values.get(field.id)
-  const typed = Array.isArray(entry) ? entry[0] : entry
-  if (!typed) return undefined
+  if (field) {
+    const values = await params.handler.getFieldValues(params.recordId, [field.id])
+    const entry = values.get(field.id)
+    const typed = Array.isArray(entry) ? entry[0] : entry
+    if (typed) {
+      const value = extractValue(typed)
+      if (typeof value === 'string' && value) return value
+    }
+  }
 
-  const value = extractValue(typed)
-  return typeof value === 'string' && value ? value : undefined
+  return readIdentityMirror(params)
+}
+
+/**
+ * The `RecordIdentity` row for one record and one id kind, or undefined.
+ *
+ * Reads through the identity module's own batch primitive rather than querying
+ * `RecordIdentity` here: that table has two unique indexes with COALESCE'd
+ * expressions and a module that owns the reading of it, and a second hand-rolled
+ * query against it is how the two come to disagree.
+ */
+async function readIdentityMirror(params: {
+  organizationId: string
+  connectionId: string
+  appFieldKey: string
+  recordId: RecordId
+}): Promise<string | undefined> {
+  const { organizationId, connectionId, appFieldKey, recordId } = params
+
+  const byRecord = await getRecordIdentitiesForRecords(organizationId, [recordId])
+  const rows = byRecord.get(recordId) ?? []
+
+  const match = rows.find(
+    (row) =>
+      row.source === QUICKBOOKS_SOURCE &&
+      row.connectionId === connectionId &&
+      row.appFieldKey === appFieldKey
+  )
+  if (!match?.externalId) return undefined
+
+  logger.debug('Resolved a QuickBooks id from the RecordIdentity mirror, not the cell', {
+    organizationId,
+    entityInstanceId: parseRecordId(recordId).entityInstanceId,
+    appFieldKey,
+  })
+  return match.externalId
 }
 
 /**

--- a/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
+++ b/packages/lib/src/money/quickbooks/quickbooks-accounting-provider.ts
@@ -12,9 +12,17 @@
 // `counterpartyId` (brief 13 §1.1) - and it writes back whatever provider id
 // comes out. This file owns four things the core cannot: turning an account
 // into a QuickBooks account id, turning a counterparty into a QuickBooks
-// `Customer` or `Vendor` id (`resolveCounterparties`, beside
+// `Customer` or `Vendor` id (`resolveOrCreateCounterparties`, beside
 // `resolveMappedAccounts`), QuickBooks' `DocNumber`, and QuickBooks'
 // `requestid`.
+//
+// 🛑 Since task 23 the counterparty hop CREATES the customer when there is not
+// one, rather than refusing. It has to: QuickBooks will not accept an A/R line
+// without a `Customer`, and nothing else in production has written
+// `qboCustomerId` since the invoice mirror took its only writer with it in
+// #2100. That made every receivable entry permanently unexportable. The create
+// is bounded to contacts that actually carry a receivable, and the whole
+// argument is in `upsert-customer.ts` and task 23 §1.
 //
 // Registered from the APP layer via `registerAccountingProvider`, never imported
 // by `packages/lib` itself. That direction is decision P1: the ledger is ours
@@ -104,6 +112,7 @@ import {
 import { quickbooksAccountType } from './account-types'
 import { readQuickbooksIdField } from './identity-field'
 import { type QuickbooksToolContext, resolveQuickbooksContext } from './invoke-quickbooks-tool'
+import { readQuickbooksCustomerFields, upsertQuickbooksCustomer } from './upsert-customer'
 
 const logger = createScopedLogger('quickbooks-accounting-provider')
 
@@ -439,8 +448,28 @@ async function resolveMappedAccounts(
 
 /**
  * Resolve every counterparty a receivable or payable line names to a
- * QuickBooks `entity` reference, and refuse a receivable or payable line that
- * carries none at all (brief 13 §1.3, §1.4).
+ * QuickBooks `entity` reference, **creating the customer when there is not one
+ * yet**, and refuse a line that carries no counterparty at all (brief 13 §1.3,
+ * §1.4; task 23 §1).
+ *
+ * 🛑 **This WRITES, which is why the name says so.** It was a pure resolver
+ * until task 23: it read `qboCustomerId` and refused when the cell was empty,
+ * and since the only thing that ever wrote that cell (`sync-invoice.ts`) was
+ * deleted with the invoice mirror in #2100, the cell was empty for every org
+ * and every receivable entry was permanently blocked.
+ *
+ * Creating the customer HERE, rather than from a contact hook or a button, is
+ * task 23 §1's decision and rests on two things. It is bounded - only a contact
+ * that actually appears on a receivable line reaches QuickBooks, where a hook
+ * would push an entire address book into somebody's customer list. And it is
+ * not really a side effect - the export already posts a journal entry, and
+ * QuickBooks cannot accept the A/R line at all without a `Customer`, so the
+ * customer is a prerequisite of the entry rather than an extra act.
+ *
+ * ⚠️ Customers only. The `company` -> `Vendor` twin needs a `qboVendorId` field
+ * that does not exist yet, so a payable line still refuses exactly as before
+ * (task 23 §4.9). Mirror this once a vendor bill actually posts; do not build
+ * it blind.
  *
  * 🛑 **No provider id above the seam (P2).** A posting line carries OUR
  * `counterpartyType` / `counterpartyId` - a `contact` or `company` instance
@@ -453,14 +482,16 @@ async function resolveMappedAccounts(
  *
  * ⚠️ Every failure is collected, never thrown on the first - fixing an export
  * one refused line at a time is how a close slips a day (13 §1.3), and it is
- * the same rule `resolveMappedAccounts` follows at `:305-307`.
+ * the same rule `resolveMappedAccounts` follows at `:305-307`. That now covers
+ * the upsert's own refusals too: one contact that cannot be resolved must not
+ * hide the other nine.
  *
  * Which line needs a counterparty is read from the CHART, not from a
  * hardcoded role list: `subtype: 'accounts_receivable' | 'accounts_payable'`
  * on `ourChart` (task 13 §3, pulled forward), so a manual journal entry coded
  * to a receivable by hand is caught exactly like a builder's own A/R line.
  */
-async function resolveCounterparties(
+async function resolveOrCreateCounterparties(
   ctx: QuickbooksToolContext,
   input: PostEntryInput,
   ourChart: readonly ChartAccountRow[]
@@ -483,8 +514,14 @@ async function resolveCounterparties(
   const resolved = new Map<string, QuickbooksEntity>()
   const unsynced = new Set<string>()
 
+  // Collected here and merged into `problems` below, so an upsert refusal reads
+  // in the same register as a missing counterparty rather than aborting the run.
+  const upsertRefusals = new Map<string, string>()
+
   for (const { type, id } of distinct.values()) {
     const isCustomer = type === 'customer'
+    const key = counterpartyKey(type, id)
+
     const externalId = await readQuickbooksIdField({
       organizationId: ctx.organizationId,
       installationId: ctx.installationId,
@@ -493,11 +530,39 @@ async function resolveCounterparties(
       recordId: toRecordId(isCustomer ? 'contact' : 'company', id),
       handler,
     })
-    const key = counterpartyKey(type, id)
     if (externalId) {
       resolved.set(key, { type: isCustomer ? 'Customer' : 'Vendor', id: externalId })
-    } else {
+      continue
+    }
+
+    // A company has no `qboVendorId` field to write, so there is nothing to
+    // create into. It refuses below exactly as it did before task 23.
+    if (!isCustomer) {
       unsynced.add(key)
+      continue
+    }
+
+    try {
+      const contactFields = await readQuickbooksCustomerFields(ctx.organizationId, id)
+      const customerId = await upsertQuickbooksCustomer(ctx, {
+        organizationId: ctx.organizationId,
+        contactInstanceId: id,
+        contactFields,
+        handler,
+      })
+      resolved.set(key, { type: 'Customer', id: customerId })
+    } catch (error) {
+      // The upsert's refusals already name the contact and the remedy
+      // (`upsert-customer.ts`), so they are carried through verbatim. Anything
+      // else is a transport or Intuit failure and is reported as itself.
+      upsertRefusals.set(key, errorMessage(error))
+      unsynced.add(key)
+      logger.warn('Could not resolve or create a QuickBooks customer for a receivable line', {
+        organizationId: ctx.organizationId,
+        contactInstanceId: id,
+        docNumber: input.docNumber,
+        error: errorMessage(error),
+      })
     }
   }
 
@@ -520,10 +585,19 @@ async function resolveCounterparties(
       )
       continue
     }
-    if (unsynced.has(counterpartyKey(line.counterpartyType, line.counterpartyId))) {
+    const key = counterpartyKey(line.counterpartyType, line.counterpartyId)
+    if (unsynced.has(key)) {
+      // 🛑 The upsert's own sentence wins when there is one. It names the
+      // contact and what to do; the generic "has not been synced yet" below
+      // implies a sync is pending somewhere, which since task 23 is never true -
+      // the sync is this function, and it has already tried and refused.
+      const refusal = upsertRefusals.get(key)
       problems.add(
-        `${input.docNumber} posts to ${label}, and QuickBooks cannot accept a ${kind} line ` +
-          `without a ${qbNoun}. The ${ourNoun} on this line has not been synced to QuickBooks yet.`
+        refusal
+          ? `${input.docNumber} posts to ${label}. ${refusal}`
+          : `${input.docNumber} posts to ${label}, and QuickBooks cannot accept a ${kind} line ` +
+              `without a ${qbNoun}. The ${ourNoun} on this line has no ${qbNoun} in QuickBooks ` +
+              'and auxx cannot create one for it.'
       )
     }
   }
@@ -994,7 +1068,7 @@ export class QuickbooksAccountingProvider implements AccountingProvider {
           })
         )
       }
-      const counterparties = await resolveCounterparties(ctx, input, ourChart.value)
+      const counterparties = await resolveOrCreateCounterparties(ctx, input, ourChart.value)
       if (counterparties.isErr()) {
         return err(
           new ProviderPostError(counterparties.error.message, {

--- a/packages/lib/src/money/quickbooks/upsert-customer.ts
+++ b/packages/lib/src/money/quickbooks/upsert-customer.ts
@@ -1,35 +1,130 @@
 // packages/lib/src/money/quickbooks/upsert-customer.ts
 
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '@auxx/types/resource'
+import { and, eq, inArray } from 'drizzle-orm'
+import { UnprocessableEntityError } from '../../errors'
 import type { UnifiedCrudHandler } from '../../resources/crud'
+import { CONTACT_FIELDS } from '../../resources/registry/resources/contact-fields'
 import { readQuickbooksIdField, writeQuickbooksIdField } from './identity-field'
 import type { QuickbooksToolContext } from './invoke-quickbooks-tool'
 
+const logger = createScopedLogger('quickbooks-upsert-customer')
+
 const QBO_CUSTOMER_ID_FIELD_KEY = 'qboCustomerId'
+
+/**
+ * Intuit's fault code for a `DisplayName` that is already taken.
+ * `create_quickbooks_customer`'s own tool description names it.
+ */
+const DUPLICATE_NAME_FAULT = '6240'
+
+/** How many characters of the contact id the last-resort label carries. */
+const ID_SUFFIX_LENGTH = 6
+
+/**
+ * The `CustomField.systemAttribute` values a customer is built from.
+ *
+ * These, not the registry field KEYS: see {@link readQuickbooksCustomerFields}
+ * for why the difference is load-bearing.
+ *
+ * 🛑 Read off the registry rather than spelled here, so a rename cannot leave
+ * four string literals behind pointing at attributes no field carries any more.
+ * That failure would be silent: the join returns nothing, every contact looks
+ * nameless, and every receivable refuses its own export.
+ */
+const CONTACT_FIRST_NAME = CONTACT_FIELDS.firstName?.systemAttribute ?? 'first_name'
+const CONTACT_LAST_NAME = CONTACT_FIELDS.lastName?.systemAttribute ?? 'last_name'
+const CONTACT_PRIMARY_EMAIL = CONTACT_FIELDS.primaryEmail?.systemAttribute ?? 'primary_email'
+const CONTACT_COMPANY = CONTACT_FIELDS.company?.systemAttribute ?? 'contact_company'
+
+/** The forensic mark auxx writes on a customer it created. See {@link customerStamp}. */
+export function customerStamp(contactInstanceId: string): string {
+  return `auxx:contact:${contactInstanceId}`
+}
+
+/** The contact facts a customer is built from. All optional; none is guaranteed. */
+export interface QuickbooksCustomerFields {
+  firstName?: string
+  lastName?: string
+  primaryEmail?: string
+  /** The contact's company NAME, already resolved. Only used by label rung 3. */
+  companyName?: string
+}
 
 export interface UpsertQuickbooksCustomerInput {
   organizationId: string
   contactInstanceId: string
-  contactFields: {
-    firstName?: string
-    lastName?: string
-    primaryEmail?: string
-  }
+  contactFields: QuickbooksCustomerFields
   handler: UnifiedCrudHandler
 }
 
+/** One QuickBooks customer, as the find/create tools hand it back. */
+interface ToolCustomer {
+  customerId: string
+  displayName?: string
+  email?: string | null
+  notes?: string | null
+  active?: boolean
+}
+
+/** What the decision table in {@link classifyNameMatch} concluded. */
+type NameMatchVerdict = 'adopt' | 'different-person' | 'unknowable'
+
+/** Case- and whitespace-insensitive compare, so ' Jane@Example.com ' matches. */
+function norm(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase()
+}
+
 /**
- * Find-or-create the QuickBooks `Customer` mapped to an Auxx contact (money plan
- * 37e-quickbooks-invoice-sync.md §3 step 2, decision D4). Resolution order:
+ * Find-or-create the QuickBooks `Customer` for one auxx contact, and write the
+ * id back.
  *
- * 1. Stored `qboCustomerId` id-map field on the contact — the fast, idempotent path.
- * 2. `find_quickbooks_customer` by the contact's exact primary email — avoids the category's
- *    #1 pain (Jobber: duplicate customers from name matching); only attempted when the
- *    contact has an email.
- * 3. `create_quickbooks_customer`.
+ * Called from the EXPORT, by `resolveOrCreateCounterparties`, at the moment a
+ * receivable line needs a customer (plans/accounting/tasks/23 section 1).
+ * QuickBooks cannot accept an A/R line without one, so this is a prerequisite
+ * of the entry rather than a side effect of it.
  *
- * The resolved id is always written back (field + `RecordIdentity` mirror), even when found
- * rather than created, so step 1 short-circuits on the next sync.
+ * ── The ladder ──────────────────────────────────────────────────────────────
+ *
+ *   1. the stored `qboCustomerId` (cell, or its `RecordIdentity` mirror)
+ *   2. find by exact email
+ *   3. find by exact display name
+ *   4. create, and on Intuit's 6240 duplicate-name fault, decide (never adopt)
+ *
+ * Each layer covers a window the next cannot, and every layer that resolves an
+ * id writes it back before returning - a resolve that does not persist is a
+ * resolve that will run again.
+ *
+ * ── 🛑 Identity is the EMAIL. The name is only a label. ──────────────────────
+ *
+ * The one sentence that keeps someone from "fixing" one half of this by
+ * breaking the other:
+ *
+ *   - **Same email, two contacts** resolve to ONE customer. They are one person
+ *     and their A/R should aggregate.
+ *   - **Same name, different emails** resolve to TWO customers. They are two
+ *     people, and the collision is in the LABEL.
+ *
+ * So a label collision is resolved by CHANGING THE LABEL, never by merging the
+ * records. `John Smith` twice in an address book is not an edge case, it is
+ * Tuesday, and adopting the first Smith for the second would merge two people's
+ * receivables under one customer. That balances, the aging still foots, and
+ * nothing downstream can detect it - the same failure class
+ * `suggest-account-identities.ts` refuses to risk on accounts.
+ *
+ * ⚠️ **Renames are deliberately NOT chased.** Once layer 1 has an id it
+ * short-circuits forever, so a contact renamed in auxx keeps its old
+ * QuickBooks `DisplayName` and the two drift. That is consistent with frozen
+ * attribution, and a rename that rewrote history in somebody's books would be
+ * worse than a stale name. The drift is not a bug; do not file it as one.
+ *
+ * @throws {UnprocessableEntityError} when no customer can be resolved safely -
+ *   the contact has nothing to build a name from, or a same-named customer
+ *   cannot be told apart from a stranger. The caller collects these rather than
+ *   failing on the first, because fixing an export one refused post at a time is
+ *   how a close slips a day.
  */
 export async function upsertQuickbooksCustomer(
   ctx: QuickbooksToolContext,
@@ -38,6 +133,7 @@ export async function upsertQuickbooksCustomer(
   const { organizationId, contactInstanceId, contactFields, handler } = input
   const contactRecordId = toRecordId('contact', contactInstanceId)
 
+  // ── Layer 1: the stored id ────────────────────────────────────────────────
   const stored = await readQuickbooksIdField({
     organizationId,
     installationId: ctx.installationId,
@@ -49,44 +145,404 @@ export async function upsertQuickbooksCustomer(
   if (stored) return stored
 
   const email = contactFields.primaryEmail?.trim() || undefined
-  const displayName =
-    [contactFields.firstName, contactFields.lastName].filter(Boolean).join(' ').trim() || undefined
-
-  let qboCustomerId: string | undefined
-
-  if (email) {
-    const found = await ctx.callTool('find_quickbooks_customer', { email })
-    if (found?.found && found.customer?.customerId) {
-      qboCustomerId = String(found.customer.customerId)
-    }
+  const labels = buildDisplayNames(contactInstanceId, contactFields)
+  if (labels.length === 0) {
+    throw new UnprocessableEntityError(
+      `The contact on this line (${contactInstanceId}) has no name and no email, so no QuickBooks customer can be created for it. Give the contact a name or an email address.`,
+      { organizationId, contactInstanceId }
+    )
   }
 
-  if (!qboCustomerId) {
-    if (!displayName) {
-      throw new Error(
-        `Cannot create a QuickBooks customer for contact ${contactInstanceId} — it has no name ` +
-          'or email.'
-      )
-    }
-    const created = await ctx.callTool('create_quickbooks_customer', {
-      displayName,
-      ...(contactFields.firstName ? { givenName: contactFields.firstName } : {}),
-      ...(contactFields.lastName ? { familyName: contactFields.lastName } : {}),
-      ...(email ? { email } : {}),
+  const write = async (customerId: string): Promise<string> => {
+    await writeQuickbooksIdField({
+      organizationId,
+      installationId: ctx.installationId,
+      connectionId: ctx.connectionId,
+      appFieldKey: QBO_CUSTOMER_ID_FIELD_KEY,
+      entityType: 'contact',
+      entityInstanceId: contactInstanceId,
+      externalId: customerId,
+      userId: ctx.userId,
     })
-    qboCustomerId = String(created.customerId)
+    return customerId
   }
 
-  await writeQuickbooksIdField({
-    organizationId,
-    installationId: ctx.installationId,
-    connectionId: ctx.connectionId,
-    appFieldKey: QBO_CUSTOMER_ID_FIELD_KEY,
-    entityType: 'contact',
-    entityInstanceId: contactInstanceId,
-    externalId: qboCustomerId,
-    userId: ctx.userId,
-  })
+  // ── Layer 2: find by email ────────────────────────────────────────────────
+  //
+  // The strongest evidence there is, and the only one that means "same person"
+  // on its own. Two auxx contacts sharing an email land on one customer here,
+  // which is the accepted outcome (task 23 section 4.3).
+  if (email) {
+    const found = await findCustomer(ctx, { email })
+    if (found) {
+      assertUsable(found, organizationId, contactInstanceId)
+      logger.debug('Resolved a QuickBooks customer by email', {
+        organizationId,
+        contactInstanceId,
+        customerId: found.customerId,
+      })
+      return write(found.customerId)
+    }
+  }
 
-  return qboCustomerId
+  // ── Layers 3 and 4: walk the label ladder ─────────────────────────────────
+  //
+  // Each rung is tried in full - look, then create - before the next is
+  // considered, and a rung is only abandoned when the name it wants belongs to
+  // somebody else.
+  for (const [index, displayName] of labels.entries()) {
+    const isLastRung = index === labels.length - 1
+
+    // Layer 3. A name match is NOT proof, so it goes through the same decision
+    // table the 6240 recovery uses. This arm used to be absent entirely, which
+    // meant an emailless contact created a customer on every single attempt.
+    const existing = await findCustomer(ctx, { displayName })
+    if (existing) {
+      const verdict = classifyNameMatch(existing, { email, contactInstanceId })
+      if (verdict === 'adopt') {
+        assertUsable(existing, organizationId, contactInstanceId)
+        return write(existing.customerId)
+      }
+      if (verdict === 'unknowable') {
+        throw sameNameRefusal(existing, displayName, organizationId, contactInstanceId)
+      }
+      // 'different-person': the label is taken by somebody else. Relabel.
+      if (isLastRung) throw exhaustedRefusal(displayName, organizationId, contactInstanceId)
+      continue
+    }
+
+    // Layer 4. Create, and treat 6240 as a question rather than an answer.
+    try {
+      const created = await createCustomer(ctx, displayName, contactInstanceId, contactFields)
+      logger.debug('Created a QuickBooks customer', {
+        organizationId,
+        contactInstanceId,
+        customerId: created.customerId,
+        displayName,
+      })
+      return write(created.customerId)
+    } catch (error) {
+      if (!isDuplicateNameFault(error)) throw error
+
+      // 🛑 Two different things produce 6240 and the fault alone cannot tell
+      // them apart: OUR OWN RACE (a concurrent export of the same contact
+      // created it a moment ago) and A COLLISION (a different person with the
+      // same name). Re-query and adopt the winner is right for the first and
+      // catastrophic for the second. Ask who it is.
+      const winner = await findCustomer(ctx, { displayName })
+      if (!winner) {
+        // The name was taken when we posted and free when we looked. Nothing
+        // stable to reason about, so try the next label rather than guess.
+        if (isLastRung) throw error
+        continue
+      }
+
+      const verdict = classifyNameMatch(winner, { email, contactInstanceId })
+      if (verdict === 'adopt') {
+        assertUsable(winner, organizationId, contactInstanceId)
+        logger.debug('Recovered from a 6240 duplicate-name fault', {
+          organizationId,
+          contactInstanceId,
+          customerId: winner.customerId,
+        })
+        return write(winner.customerId)
+      }
+      if (verdict === 'unknowable') {
+        throw sameNameRefusal(winner, displayName, organizationId, contactInstanceId)
+      }
+      if (isLastRung) throw exhaustedRefusal(displayName, organizationId, contactInstanceId)
+    }
+  }
+
+  throw exhaustedRefusal(labels[labels.length - 1] ?? '', organizationId, contactInstanceId)
+}
+
+/**
+ * Is the customer found under our name actually ours?
+ *
+ * The decision table from task 23 section 2.4. Read it as four rows, because
+ * every one of them is a different real situation:
+ *
+ * | what we see | what it is | verdict |
+ * | --- | --- | --- |
+ * | its email equals ours | the same person | `adopt` |
+ * | its notes carry our stamp | our own race | `adopt` |
+ * | it has an email, and it is not ours | a different person | `different-person` |
+ * | no email, no stamp | unknowable | `unknowable` |
+ *
+ * 🛑 The last row is a REFUSAL and must stay one. A customer the firm typed in
+ * by hand, with a common name and no email, cannot be told apart from a
+ * stranger by anything we hold - and guessing there is the entire problem this
+ * function exists to avoid.
+ *
+ * ⚠️ The stamp arm only works because auxx stamps on CREATE ONLY (task 23
+ * section 3, MK's Q2). An absent stamp therefore means "not ours", never "not
+ * checked". If stamping is ever extended to customers we merely FOUND, this
+ * table has to be revisited in the same change or the second row starts lying.
+ */
+function classifyNameMatch(
+  found: ToolCustomer,
+  ours: { email?: string; contactInstanceId: string }
+): NameMatchVerdict {
+  const theirEmail = norm(found.email)
+  const ourEmail = norm(ours.email)
+
+  if (theirEmail && ourEmail && theirEmail === ourEmail) return 'adopt'
+  if (found.notes?.includes(customerStamp(ours.contactInstanceId))) return 'adopt'
+
+  // An email that is not ours is positive evidence of a different person. That
+  // includes the case where we have none: we cannot claim a record that carries
+  // somebody else's address.
+  if (theirEmail) return 'different-person'
+
+  return 'unknowable'
+}
+
+/**
+ * Every `DisplayName` this contact could take, best first.
+ *
+ * The label is what the firm reads on the A/R aging, on statements and in every
+ * report, so it has to stay human before it stays unique:
+ *
+ *   1. `First Last`
+ *   2. collided and there is an email  -> `First Last (email)`
+ *   3. collided and there is not       -> `First Last (Company)`
+ *   4. collided and neither            -> `First Last (a1b2c3)`
+ *
+ * With no name at all the email stands alone as the label; with neither the
+ * list is EMPTY and the caller refuses.
+ *
+ * 🛑 **Disambiguate on collision, do not pre-disambiguate everything.** Stamping
+ * `(jane@acme.com)` onto every customer forever, to pre-empt a clash most names
+ * never have, makes every report the accountant reads worse in order to solve a
+ * minority case.
+ *
+ * ⚠️ **Every rung is a pure function of the CONTACT, never of a counter.**
+ * `John Smith 2` would be unstable - which Smith is `2` depends on who exported
+ * first - so the name would not be reproducible and the find-by-name arm would
+ * go looking for a string only one particular ordering could have produced.
+ *
+ * Order-dependence survives anyway and is fine: the first Smith to export takes
+ * the plain name and the second carries a suffix, which is not reproducible from
+ * the contact alone. It does not need to be. Once either is created its id is
+ * stored and layer 1 short-circuits forever, so the worst case is one extra
+ * round trip through 6240 on a first attempt. That is a cost, not a bug.
+ */
+function buildDisplayNames(contactInstanceId: string, fields: QuickbooksCustomerFields): string[] {
+  const name = [fields.firstName, fields.lastName]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(' ')
+    .trim()
+  const email = fields.primaryEmail?.trim()
+  const company = fields.companyName?.trim()
+
+  const base = name || email
+  if (!base) return []
+
+  const labels = [base]
+
+  // Rung 2 or 3, never both: the email is the better discriminator when it
+  // exists, and a customer carrying both would just be noisier.
+  if (email && base !== email) labels.push(`${base} (${email})`)
+  else if (company) labels.push(`${base} (${company})`)
+
+  // Rung 4, the backstop that guarantees this terminates. Contact ids are
+  // unique, so a label carrying one cannot collide with another contact's.
+  labels.push(`${base} (${contactInstanceId.slice(-ID_SUFFIX_LENGTH)})`)
+
+  return labels
+}
+
+/** One `find_quickbooks_customer` call. Null when nothing matched. */
+async function findCustomer(
+  ctx: QuickbooksToolContext,
+  by: { email: string } | { displayName: string }
+): Promise<ToolCustomer | null> {
+  const result = await ctx.callTool('find_quickbooks_customer', by)
+  if (!result?.found || !result.customer?.customerId) return null
+  return { ...result.customer, customerId: String(result.customer.customerId) }
+}
+
+/**
+ * One `create_quickbooks_customer` call, carrying the forensic stamp.
+ *
+ * 🛑 The stamp goes on CREATE ONLY. We never touch the `Notes` of a customer the
+ * firm owns, which is what lets {@link classifyNameMatch} read an absent stamp
+ * as "not ours".
+ *
+ * ⚠️ `Notes` is not filterable in QQL, so nothing may ever resolve a customer BY
+ * this value - the same argument `postEntry` makes about `PrivateNote`, which is
+ * why `DocNumber` and not the note carries the journal lookup. It is read off a
+ * record already found another way.
+ */
+async function createCustomer(
+  ctx: QuickbooksToolContext,
+  displayName: string,
+  contactInstanceId: string,
+  fields: QuickbooksCustomerFields
+): Promise<ToolCustomer> {
+  const created = await ctx.callTool('create_quickbooks_customer', {
+    displayName,
+    ...(fields.firstName ? { givenName: fields.firstName } : {}),
+    ...(fields.lastName ? { familyName: fields.lastName } : {}),
+    ...(fields.companyName ? { companyName: fields.companyName } : {}),
+    ...(fields.primaryEmail ? { email: fields.primaryEmail } : {}),
+    notes: customerStamp(contactInstanceId),
+  })
+  return { ...created, customerId: String(created.customerId) }
+}
+
+/**
+ * Refuse a customer that cannot receive a posting.
+ *
+ * QuickBooks does not hard-delete a `Customer`, it sets `Active: false`, and a
+ * journal entry naming an inactive one is rejected. Catch it here, where the
+ * message can name the customer, rather than letting Intuit reject the whole
+ * entry with its own wording.
+ *
+ * 🛑 We do NOT reactivate it. That is an edit to their books nobody asked for.
+ *
+ * ⚠️ This checks customers resolved on THIS pass only. The layer-1 fast path
+ * deliberately does not re-fetch a stored customer to check it, because that
+ * would spend a round trip on every resolve to catch a state that Intuit
+ * reports anyway when the entry is posted.
+ */
+function assertUsable(
+  customer: ToolCustomer,
+  organizationId: string,
+  contactInstanceId: string
+): void {
+  if (customer.active === false) {
+    throw new UnprocessableEntityError(
+      `The QuickBooks customer '${customer.displayName ?? customer.customerId}' has been made inactive, and QuickBooks will not accept a receivable line for an inactive customer. Reactivate it in QuickBooks, then retry the export.`,
+      { organizationId, contactInstanceId, customerId: customer.customerId }
+    )
+  }
+}
+
+/** The section 2.4 row-four refusal: a same-named customer we cannot identify. */
+function sameNameRefusal(
+  found: ToolCustomer,
+  displayName: string,
+  organizationId: string,
+  contactInstanceId: string
+): UnprocessableEntityError {
+  return new UnprocessableEntityError(
+    `QuickBooks already has a customer called '${displayName}' (id ${found.customerId}) with no email address and no mark from auxx, so it cannot be told apart from the contact on this line. Add an email to one of them, or link them by hand, and retry the export.`,
+    { organizationId, contactInstanceId, customerId: found.customerId }
+  )
+}
+
+/** Every label the contact could take is spoken for. Vanishingly rare, real. */
+function exhaustedRefusal(
+  displayName: string,
+  organizationId: string,
+  contactInstanceId: string
+): UnprocessableEntityError {
+  return new UnprocessableEntityError(
+    `Every name auxx could give this contact in QuickBooks is already taken by a different customer, including '${displayName}'. Rename the conflicting customer in QuickBooks, then retry the export.`,
+    { organizationId, contactInstanceId }
+  )
+}
+
+/** Does this failure carry Intuit's duplicate-`DisplayName` fault? */
+function isDuplicateNameFault(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    message.includes(DUPLICATE_NAME_FAULT) ||
+    /duplicate name|name supplied already exists|must be unique/i.test(message)
+  )
+}
+
+/**
+ * The four contact facts a customer is built from, read in one go.
+ *
+ * Lives here rather than in the adapter because the shape it produces is this
+ * module's input, and a caller assembling it by hand would be a second place
+ * that has to know which fields matter.
+ *
+ * 🛑 **Resolved by `systemAttribute`, NOT by the registry key.** A field's
+ * registry `id` (`firstName`) is a brand cast over a plain string, but
+ * `FieldValue.fieldId` holds the org's own generated `CustomField` id
+ * (`pfofjb1056shi8x5lwm88nry`), and the two are unrelated. Asking for the
+ * registry key returns NOTHING, which would make every contact look nameless
+ * and refuse its own export. Verified against real rows on 2026-09-11; the
+ * registry declares `first_name`, `last_name`, `primary_email` and
+ * `contact_company` as the system attributes to join on.
+ *
+ * Reads `FieldValue` directly rather than through a `UnifiedCrudHandler` for the
+ * reason `account-map.ts` gives beside its own direct read: this is one question
+ * about one record, and the handler's per-record path would resolve a definition
+ * and a field set to answer it.
+ *
+ * `company` is a RELATIONSHIP (`contact_company`, has_many reverse), not a text
+ * column, so the name costs one more lookup. It feeds label rung 3 only, and
+ * rung 3 only fires on a name collision when there is no email, so every failure
+ * there degrades to rung 4 and nothing is lost. Hence the soft failure.
+ */
+export async function readQuickbooksCustomerFields(
+  organizationId: string,
+  contactInstanceId: string
+): Promise<QuickbooksCustomerFields> {
+  const rows = await database
+    .select({
+      systemAttribute: schema.CustomField.systemAttribute,
+      valueText: schema.FieldValue.valueText,
+      relatedEntityId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .innerJoin(schema.CustomField, eq(schema.CustomField.id, schema.FieldValue.fieldId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.entityId, contactInstanceId),
+        inArray(schema.CustomField.systemAttribute, [
+          CONTACT_FIRST_NAME,
+          CONTACT_LAST_NAME,
+          CONTACT_PRIMARY_EMAIL,
+          CONTACT_COMPANY,
+        ])
+      )
+    )
+
+  const text = (attribute: string): string | undefined =>
+    rows.find((row) => row.systemAttribute === attribute)?.valueText?.trim() || undefined
+
+  const fields: QuickbooksCustomerFields = {
+    firstName: text(CONTACT_FIRST_NAME),
+    lastName: text(CONTACT_LAST_NAME),
+    primaryEmail: text(CONTACT_PRIMARY_EMAIL),
+  }
+
+  const companyId = rows.find((row) => row.systemAttribute === CONTACT_COMPANY)?.relatedEntityId
+  if (companyId) {
+    const companyName = await readCompanyName(organizationId, companyId)
+    if (companyName) fields.companyName = companyName
+  }
+
+  return fields
+}
+
+/** The display name of the company a contact is linked to. Soft-fails. */
+async function readCompanyName(
+  organizationId: string,
+  companyInstanceId: string
+): Promise<string | undefined> {
+  try {
+    const row = await database.query.EntityInstance.findFirst({
+      where: and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.id, companyInstanceId)
+      ),
+      columns: { displayName: true },
+    })
+    return row?.displayName?.trim() || undefined
+  } catch (error) {
+    logger.debug('Could not read the contact company name for the label ladder', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
 }


### PR DESCRIPTION
Pairs with **auxxai-apps#77** (the `notes` field on the customer tools). Plan: `plans/accounting/tasks/23`.

## Why

`resolveCounterparties` refused every A/R entry whose contact had no `qboCustomerId` — and **nothing in production ever wrote that field**. `upsertQuickbooksCustomer`'s only caller was `sync-invoice.ts`, deleted with the invoice mirror in #2100. Brief 14's DECIDED block said in writing *"Keep `upsert-customer.ts` and `qboCustomerId`"*; it was kept and never re-wired.

So every receivable was permanently blocked, for every org. The message even read *"the contact on this line has not been synced to QuickBooks yet"* — implying a sync that did not exist.

## Where the sync runs

**In the export, in the adapter, at the moment a line needs a customer.** Not a contact hook, not a job, not a button.

- **Bounded.** Only a contact that actually carries a receivable reaches QuickBooks. A contact hook would push the whole address book — every ticket sender, every lead — into somebody's customer list.
- **Not really a side effect.** QuickBooks cannot accept the A/R line *at all* without a Customer, so creating one is part of posting the entry rather than something the export decided to do.
- **Automatic.** Retry export is the whole recovery story.

This deliberately differs from the chart push, which asks first. An account changes the shape of every report the firm runs; a customer is a name on a receivable QuickBooks demands.

## 🛑 The part not to simplify

Four idempotency layers: stored id → find by email → find by display name → recovery from Intuit's **6240** duplicate-name fault.

That last one is **not** "re-query and adopt the winner". Two different things produce 6240 and the fault cannot tell them apart:

- our own concurrent-export race, and
- **a different person who happens to share a name.**

Adopting merges two people's receivables under one customer. It balances, the aging foots, nothing downstream detects it. So 6240 goes through a decision table keyed on the email and on the `auxx:contact:<id>` stamp in `Notes`:

| Found customer | Verdict |
| --- | --- |
| same email | adopt |
| carries our stamp | adopt (our race) |
| different email | different person → relabel and retry |
| no email, no stamp | **refuse**, naming both |

That is also what makes create-only stamping a *correctness* decision rather than a courtesy: an absent stamp has to mean "not ours", never "not checked".

## The rule underneath

**The email is the identity; the name is only a label.** Two contacts sharing an email are one customer (their A/R should aggregate). Two contacts sharing a name are two customers, and the collision is in the label — so you change the label, never merge the records.

`DisplayName` stays plain `First Last`, disambiguated only on a real collision: email → company → a slice of the contact id. Every rung is a pure function of the contact, never a counter, so the name stays reproducible and find-by-name cannot go hunting for a string only one ordering would have produced.

## Two things the build found that the plan had wrong

1. **`FieldValue.fieldId` is the org's generated `CustomField.id`, not the registry key.** `toFieldId` is a brand cast over a plain string, so the two are unrelated values that both typecheck — and a read by `'firstName'` returns **zero rows silently**. Every contact would have looked nameless and every receivable refused with nothing pointing at the cause. Fields now resolve by `systemAttribute`, derived from `CONTACT_FIELDS` so a rename can't leave a stale literal, with a test asserting the registry still declares them.
2. **`RecordIdentity` already survives an instance delete** — neither `deleteEntityInstance` nor `sweepEntityFieldValues` touches it. So the fallback read is the entire deleted-contact fix and the delete path is untouched.

## Testing

19 new tests in `upsert-customer.test.ts` plus 3 on the adapter. The one that matters is **`🛑 row 3 — TWO John Smiths get TWO customers, never one`**: that is the test that would have caught the plan's own first draft.

1,543 `money` + `postings` tests pass. Both typecheck ratchets clean.

**Driven on DemoOrg1** against the live sandbox: all 15 credit memos exported, $40,106.56, fifteen contacts → fifteen distinct customers with zero duplicate display names, and the customer rides the A/R line in QuickBooks (`entityType: "Customer", entityId: "59"`).

## Known, not in scope

`failureReason` is not cleared on a successful export, so an `exported` row still carries its last refusal text. Noted in the handoff; separate fix.

https://claude.ai/code/session_014EqKqpcGc61XzboLkwJMP5