### PR TITLE
feat(workflow): an address type for app workflow fields, and two more keys on AddressStruct

### DIFF
--- a/apps/web/src/components/custom-fields/ui/address-component-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/address-component-editor.tsx
@@ -11,32 +11,62 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 
-/** Available address component definitions */
+/**
+ * Available address component definitions, in render order.
+ *
+ * `name` and `residential` are opt-in additions
+ * (plans/apps/shipstation/shipstation-workflow-expansion-plan.md §5) — they are deliberately
+ * NOT in {@link DEFAULT_ADDRESS_COMPONENTS}, so an existing field keeps its current shape
+ * until an admin checks them.
+ */
 const ADDRESS_COMPONENTS = [
+  { id: 'name', label: 'Name' },
   { id: 'street1', label: 'Street Address' },
   { id: 'street2', label: 'Apartment/Suite' },
   { id: 'city', label: 'City' },
   { id: 'state', label: 'State/Province' },
   { id: 'zipCode', label: 'ZIP/Postal Code' },
   { id: 'country', label: 'Country' },
+  { id: 'residential', label: 'Residential' },
 ]
 
-/** Default address components (all enabled) */
+/** Default address components — the original six, all enabled. */
 const DEFAULT_ADDRESS_COMPONENTS = ['street1', 'street2', 'city', 'state', 'zipCode', 'country']
 
 /**
- * Parse stored field options into editor state.
- * Extracts address components from options.addressComponents.
+ * A component id no editor has ever produced.
+ *
+ * Five registry address fields (order/work_order/service_request/purchase_order/company) ship
+ * `addressComponents: ['street', 'city', 'state', 'country']` — written before the editor's id
+ * set existed, so it names `street` rather than `street1` and omits `street2`/`zipCode`
+ * entirely. Nothing read the option until now, so those literals were inert. Honoring them
+ * literally would delete the ZIP line from every order, work order and company address in
+ * every org, which no admin ever asked for, so a list carrying this id is treated as
+ * un-configured and falls back to the defaults. The editor cannot emit `street`, so this can
+ * never swallow a real admin choice.
+ */
+const LEGACY_UNCONFIGURED_ID = 'street'
+
+/**
+ * Parse stored field options into editor state, and the single source of truth for which
+ * sub-fields the three renderers show (`AddressStructFields`, `AddressSingleFields`,
+ * `DisplayAddressStruct`).
+ *
+ * Returns {@link DEFAULT_ADDRESS_COMPONENTS} when the option is absent, empty, or a
+ * pre-editor registry literal (see {@link LEGACY_UNCONFIGURED_ID}).
  */
 export function parseAddressComponents(fieldOptions?: FieldOptions): string[] {
-  if (
+  const stored =
     fieldOptions &&
     'addressComponents' in fieldOptions &&
     Array.isArray(fieldOptions.addressComponents)
-  ) {
-    return fieldOptions.addressComponents
+      ? fieldOptions.addressComponents
+      : undefined
+
+  if (!stored || stored.length === 0 || stored.includes(LEGACY_UNCONFIGURED_ID)) {
+    return [...DEFAULT_ADDRESS_COMPONENTS]
   }
-  return [...DEFAULT_ADDRESS_COMPONENTS]
+  return stored
 }
 
 /**

--- a/apps/web/src/components/fields/displays/display-address.tsx
+++ b/apps/web/src/components/fields/displays/display-address.tsx
@@ -1,7 +1,14 @@
+// apps/web/src/components/fields/displays/display-address.tsx
+
 import { type AddressStructValue, formatAddress } from '@auxx/utils/address'
+import { useMemo } from 'react'
+import { parseAddressComponents } from '~/components/custom-fields/ui/address-component-editor'
 import { useSettings } from '~/hooks/use-settings'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
+
+/** The postal components `formatAddress` renders, in the order it renders them. */
+const POSTAL_COMPONENTS = ['street1', 'street2', 'city', 'state', 'zipCode', 'country'] as const
 
 /**
  * DisplayAddress component
@@ -18,13 +25,31 @@ export function DisplayAddress() {
 }
 
 /**
+ * Drops the components the field's `addressComponents` option turns off, so the rendered line
+ * matches what the editor shows. `residential` is an indicator rather than a line of the
+ * address, so it never reaches the formatter.
+ */
+function pickComponents(
+  address: Partial<AddressStructValue>,
+  components: Set<string>
+): Partial<AddressStructValue> {
+  const picked: Partial<AddressStructValue> = {}
+  for (const key of POSTAL_COMPONENTS) {
+    if (components.has(key) && address[key] !== undefined) picked[key] = address[key]
+  }
+  if (components.has('name') && address.name !== undefined) picked.name = address.name
+  return picked
+}
+
+/**
  * DisplayAddressStruct component
  * Renders a structured address from a JSON string or object via the shared canonical
  * formatter (plans/address-field/01-single-input-address-field.md decision #10). The
- * org's business-address country is omitted from the rendered line when it matches.
+ * org's business-address country is omitted from the rendered line when it matches, and the
+ * field's `addressComponents` option decides which components are rendered at all.
  */
 export function DisplayAddressStruct() {
-  const { value } = useFieldContext()
+  const { field, value } = useFieldContext()
   let address: Partial<AddressStructValue> = {}
   if (typeof value === 'string') {
     try {
@@ -39,7 +64,15 @@ export function DisplayAddressStruct() {
   const { getSetting } = useSettings({})
   const business = getSetting('documents.business') as { address?: { country?: string } } | null
   const domesticCountry = business?.address?.country
-  const formattedAddress = formatAddress(address, { domesticCountry })
+
+  const components = useMemo(
+    () => new Set(parseAddressComponents(field?.options)),
+    [field?.options]
+  )
+  const formattedAddress = formatAddress(pickComponents(address, components), {
+    domesticCountry,
+    include: components.has('name') ? ['name'] : undefined,
+  })
 
   return (
     <DisplayWrapper copyValue={formattedAddress || null}>

--- a/apps/web/src/components/fields/inputs/__tests__/address-components.test.tsx
+++ b/apps/web/src/components/fields/inputs/__tests__/address-components.test.tsx
@@ -1,0 +1,112 @@
+// apps/web/src/components/fields/inputs/__tests__/address-components.test.tsx
+//
+// `addressComponents` was fully declared - field-options schema, tRPC router, app-deployment
+// schema, `defineField`, and a complete checkbox editor - and read by NOTHING. An admin could
+// uncheck "Apartment/Suite", save, and every renderer still drew all six inputs
+// (plans/apps/shipstation/shipstation-workflow-expansion-plan.md §5). These tests pin the
+// wiring in both directions: the option now hides a sub-field, and an absent option still
+// renders exactly the six an existing field has always shown.
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { parseAddressComponents } from '~/components/custom-fields/ui/address-component-editor'
+import { type AddressStruct, AddressStructFields } from '../address-struct-input-field'
+
+const EMPTY: AddressStruct = {
+  street1: '',
+  street2: '',
+  city: '',
+  state: '',
+  zipCode: '',
+  country: '',
+}
+
+const ALL_SIX_PLACEHOLDERS = [
+  'Street address',
+  'Apartment, suite, etc. (optional)',
+  'City',
+  'State',
+  'ZIP Code',
+]
+
+function renderFields(components?: string[]) {
+  return render(<AddressStructFields value={EMPTY} onChange={vi.fn()} components={components} />)
+}
+
+describe('parseAddressComponents', () => {
+  it('returns the original six when the option is absent', () => {
+    expect(parseAddressComponents()).toEqual([
+      'street1',
+      'street2',
+      'city',
+      'state',
+      'zipCode',
+      'country',
+    ])
+  })
+
+  it('returns the stored list verbatim when an admin configured one', () => {
+    expect(parseAddressComponents({ addressComponents: ['street1', 'city'] })).toEqual([
+      'street1',
+      'city',
+    ])
+  })
+
+  it('carries the opt-in name and residential ids through', () => {
+    expect(
+      parseAddressComponents({ addressComponents: ['name', 'street1', 'residential'] })
+    ).toEqual(['name', 'street1', 'residential'])
+  })
+
+  // Five registry address fields ship `['street', 'city', 'state', 'country']` - written
+  // before the editor's id set existed, naming `street` rather than `street1` and omitting
+  // `street2`/`zipCode`. Honoring that literally would delete the ZIP line from every order,
+  // work order and company address in every org.
+  it('treats a pre-editor registry literal as un-configured', () => {
+    expect(
+      parseAddressComponents({ addressComponents: ['street', 'city', 'state', 'country'] })
+    ).toEqual(['street1', 'street2', 'city', 'state', 'zipCode', 'country'])
+  })
+
+  it('treats an empty list as un-configured rather than rendering nothing', () => {
+    expect(parseAddressComponents({ addressComponents: [] })).toHaveLength(6)
+  })
+})
+
+describe('AddressStructFields honors addressComponents', () => {
+  it('renders the original six, and neither opt-in key, with no components prop', () => {
+    renderFields()
+    for (const placeholder of ALL_SIX_PLACEHOLDERS) {
+      expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument()
+    }
+    expect(screen.getByText('Country')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Name')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Residential')).not.toBeInTheDocument()
+  })
+
+  it('hides a sub-field the option leaves out', () => {
+    renderFields(['street1', 'city', 'state', 'zipCode', 'country'])
+    expect(
+      screen.queryByPlaceholderText('Apartment, suite, etc. (optional)')
+    ).not.toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Street address')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('ZIP Code')).toBeInTheDocument()
+  })
+
+  it('renders the name input and the three-way residential select when opted in', () => {
+    renderFields(['name', 'street1', 'city', 'state', 'zipCode', 'country', 'residential'])
+    expect(screen.getByPlaceholderText('Name')).toBeInTheDocument()
+    // A select, not a checkbox: `unknown` is a real, distinct state.
+    expect(screen.getByLabelText('Residential')).toBeInTheDocument()
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('renders only what is asked for', () => {
+    renderFields(['name', 'street1'])
+    expect(screen.getByPlaceholderText('Name')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Street address')).toBeInTheDocument()
+    for (const placeholder of ['City', 'State', 'ZIP Code']) {
+      expect(screen.queryByPlaceholderText(placeholder)).not.toBeInTheDocument()
+    }
+  })
+})

--- a/apps/web/src/components/fields/inputs/address-single-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/address-single-input-field.tsx
@@ -2,12 +2,20 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
+import { Input } from '@auxx/ui/components/input'
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
 } from '@auxx/ui/components/input-group'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
 import { cn } from '@auxx/ui/lib/utils'
 import {
   type AddressParseCandidate,
@@ -17,6 +25,7 @@ import {
 } from '@auxx/utils/address'
 import { Maximize2, Minimize2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { parseAddressComponents } from '~/components/custom-fields/ui/address-component-editor'
 import { useDebouncedValue } from '~/hooks/use-debounced-value'
 import { useFieldNavigationOptional } from '../field-navigation-context'
 import { usePropertyContext } from '../property-provider'
@@ -55,6 +64,8 @@ function normalizeStructValue(value: unknown): AddressStructValue {
     state: v.state ?? '',
     zipCode: v.zipCode ?? '',
     country: v.country ?? '',
+    name: v.name,
+    residential: v.residential,
     raw: v.raw,
     lat: v.lat,
     lng: v.lng,
@@ -70,7 +81,9 @@ function hasVisibleChange(a: AddressStructValue, b: AddressStructValue): boolean
     a.city !== b.city ||
     a.state !== b.state ||
     a.zipCode !== b.zipCode ||
-    a.country !== b.country
+    a.country !== b.country ||
+    (a.name || '') !== (b.name || '') ||
+    a.residential !== b.residential
   )
 }
 
@@ -82,6 +95,8 @@ function toAddressStruct(v: Partial<AddressStructValue>): AddressStruct {
     state: v.state ?? '',
     zipCode: v.zipCode ?? '',
     country: v.country ?? '',
+    name: v.name ?? '',
+    residential: v.residential,
   }
 }
 
@@ -118,6 +133,12 @@ interface AddressSingleFieldsProps {
   autoFocus?: boolean
   className?: string
   inputVariant?: 'default' | 'transparent'
+  /**
+   * Sub-fields to render, from the field's `addressComponents` option
+   * (see `parseAddressComponents`). Omitted ⇒ the default six, so a caller with no field
+   * options renders exactly as before.
+   */
+  components?: string[]
 }
 
 /**
@@ -132,6 +153,9 @@ interface AddressSingleFieldsProps {
  *   two views: compact single line ⇄ the existing `AddressStructFields` detail view
  *   (pre-filled from the top candidate, for corrections without retyping). In the detail
  *   view the same button sits inside the street-address input and collapses back.
+ * - `name`/`residential`, when the field enables them, render as their own controls around
+ *   the single line rather than inside it: the line's text is round-tripped through
+ *   `parseAddress`, and a recipient name in it would be parsed as a street.
  */
 export function AddressSingleFields({
   value,
@@ -142,8 +166,10 @@ export function AddressSingleFields({
   autoFocus,
   className,
   inputVariant,
+  components,
 }: AddressSingleFieldsProps) {
   const structValue = useMemo(() => normalizeStructValue(value), [value])
+  const shown = useMemo(() => new Set(components ?? parseAddressComponents()), [components])
 
   const [mode, setMode] = useState<'idle' | 'editing'>('idle')
   const [text, setText] = useState('')
@@ -178,13 +204,18 @@ export function AddressSingleFields({
     return () => nav?.setPopoverCapturing(false)
   }, [candidates.length, nav])
 
+  // `name`/`residential` are carried over from the committed value: the parser cannot produce
+  // them (they are not in the typed line), so spreading the candidate alone would silently
+  // clear a recipient name every time a postal line is re-accepted.
   const buildAccepted = useCallback(
     (candidate: AddressParseCandidate, rawText: string): AddressStructWithSource => ({
       ...candidate.struct,
+      name: structValue.name,
+      residential: structValue.residential,
       raw: candidate.confidence < LOW_CONFIDENCE_THRESHOLD ? rawText : undefined,
       _source: 'single',
     }),
-    []
+    [structValue.name, structValue.residential]
   )
 
   const revertToIdle = useCallback(() => {
@@ -257,7 +288,11 @@ export function AddressSingleFields({
 
   const openDetails = useCallback(() => {
     const candidate = candidates[0]
-    const seed = candidate?.struct ?? structValue
+    // A candidate carries only the postal line, so the committed `name`/`residential` are
+    // merged back in rather than dropped when the detail view opens over a parse.
+    const seed: Partial<AddressStructValue> = candidate
+      ? { ...candidate.struct, name: structValue.name, residential: structValue.residential }
+      : structValue
     const draft = toAddressStruct({ ...seed, country: seed.country || defaultCountry })
     setDetailsDraft(draft)
     // Typed-but-unaccepted text seeded this draft — propagate it immediately so toggling
@@ -288,10 +323,20 @@ export function AddressSingleFields({
         state: next.state,
         zipCode: next.zipCode,
         country: next.country,
+        name: next.name || undefined,
+        residential: next.residential,
         _source: 'structured',
       })
     },
     [onDraftChange]
+  )
+
+  /** Edits `name`/`residential` without touching the postal line the single input owns. */
+  const handleSidecarChange = useCallback(
+    (patch: Pick<AddressStructValue, 'name' | 'residential'>) => {
+      onDraftChange({ ...structValue, ...patch, _source: 'structured' })
+    },
+    [onDraftChange, structValue]
   )
 
   const handleKeyDown = useCallback(
@@ -346,6 +391,19 @@ export function AddressSingleFields({
 
   return (
     <div className={cn('flex flex-col gap-1', className)}>
+      {/* `name`/`residential` sit outside the parsed line; in the detail view
+          `AddressStructFields` renders them instead, so they are not doubled. */}
+      {!detailsOpen && shown.has('name') && (
+        <Input
+          size='sm'
+          variant={inputVariant}
+          placeholder='Name'
+          value={structValue.name ?? ''}
+          onChange={(e) => handleSidecarChange({ name: e.target.value })}
+          disabled={disabled}
+        />
+      )}
+
       {!detailsOpen && (
         <InputGroup
           size='sm'
@@ -391,6 +449,27 @@ export function AddressSingleFields({
         </div>
       )}
 
+      {!detailsOpen && shown.has('residential') && (
+        <Select
+          value={structValue.residential ?? 'unknown'}
+          onValueChange={(v) =>
+            handleSidecarChange({ residential: v as AddressStructValue['residential'] })
+          }
+          disabled={disabled}>
+          <SelectTrigger
+            size='sm'
+            variant={inputVariant === 'transparent' ? 'transparent' : 'default'}
+            aria-label='Residential'>
+            <SelectValue placeholder='Residential' />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='unknown'>Unknown</SelectItem>
+            <SelectItem value='yes'>Residential</SelectItem>
+            <SelectItem value='no'>Commercial</SelectItem>
+          </SelectContent>
+        </Select>
+      )}
+
       {detailsOpen && (
         <AddressStructFields
           value={detailsDraft}
@@ -398,6 +477,7 @@ export function AddressSingleFields({
           disabled={disabled}
           inputVariant={inputVariant}
           className='flex flex-col gap-2'
+          components={components}
           autoFocus
           street1Addon={detailsToggleButton}
         />
@@ -416,10 +496,11 @@ export function AddressSingleFields({
  *   fire-and-forget on popover close via `onBeforeClose`, same as the structured editor.
  */
 export function AddressSingleInputField() {
-  const { value, commitValue, commitValueAndClose, onBeforeClose } = usePropertyContext()
+  const { field, value, commitValue, commitValueAndClose, onBeforeClose } = usePropertyContext()
   const initial = useMemo(() => normalizeStructValue(value), [value])
   const [pending, setPending] = useState<AddressStructValue>(initial)
   const defaultCountry = useOrgBusinessCountry()
+  const components = useMemo(() => parseAddressComponents(field?.options), [field?.options])
 
   const handleAccept = useCallback(
     (next: AddressStructWithSource) => {
@@ -448,6 +529,7 @@ export function AddressSingleInputField() {
       defaultCountry={defaultCountry}
       onAccept={handleAccept}
       onDraftChange={handleDraftChange}
+      components={components}
       autoFocus
       className='w-[350px] p-2'
     />

--- a/apps/web/src/components/fields/inputs/address-struct-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/address-struct-input-field.tsx
@@ -1,16 +1,28 @@
 'use client'
 
+// apps/web/src/components/fields/inputs/address-struct-input-field.tsx
+'use client'
+
 import { CountrySelect } from '@auxx/ui/components/country-select'
 import { Input } from '@auxx/ui/components/input'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@auxx/ui/components/input-group'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
 import { cn } from '@auxx/ui/lib/utils'
-// apps/web/src/components/fields/inputs/address-struct-input-field.tsx
-import { type ReactNode, useCallback, useEffect, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
+import { parseAddressComponents } from '~/components/custom-fields/ui/address-component-editor'
 import { usePropertyContext } from '../property-provider'
 
 /**
  * AddressStruct interface - structured address data
- * Matches ADDRESS_COMPONENTS: street1, street2, city, state, zipCode, country
+ * Matches ADDRESS_COMPONENTS: name, street1, street2, city, state, zipCode, country,
+ * residential. `name`/`residential` are opt-in per field via `addressComponents`, so they
+ * are optional here and every existing caller keeps compiling unchanged.
  */
 export interface AddressStruct {
   street1: string
@@ -19,7 +31,16 @@ export interface AddressStruct {
   state: string
   zipCode: string
   country: string
+  name?: string
+  residential?: 'unknown' | 'yes' | 'no'
 }
+
+/** The residential indicator's three real states — `unknown` is not "empty". */
+const RESIDENTIAL_OPTIONS: { value: 'unknown' | 'yes' | 'no'; label: string }[] = [
+  { value: 'unknown', label: 'Unknown' },
+  { value: 'yes', label: 'Residential' },
+  { value: 'no', label: 'Commercial' },
+]
 
 /**
  * Props for the shared AddressStructFields component
@@ -43,6 +64,12 @@ interface AddressStructFieldsProps {
    * street line rather than floating above the fields.
    */
   street1Addon?: ReactNode
+  /**
+   * Sub-fields to render, from the field's `addressComponents` option
+   * (see `parseAddressComponents`). Omitted ⇒ the default six, so a caller that has no field
+   * options renders exactly as before.
+   */
+  components?: string[]
 }
 
 /**
@@ -57,102 +84,178 @@ export function AddressStructFields({
   className = 'flex w-[350px] flex-col gap-2 p-2',
   inputVariant,
   street1Addon,
+  components,
 }: AddressStructFieldsProps) {
-  /** Handle field change */
+  /** Handle a text sub-field change. `residential` is an enum, so it has its own handler. */
   const handleFieldChange = useCallback(
-    (fieldName: keyof AddressStruct, fieldValue: string) => {
+    (fieldName: Exclude<keyof AddressStruct, 'residential'>, fieldValue: string) => {
       onChange({ ...value, [fieldName]: fieldValue })
     },
     [value, onChange]
   )
+
+  const handleResidentialChange = useCallback(
+    (next: string) => {
+      onChange({ ...value, residential: next as AddressStruct['residential'] })
+    },
+    [value, onChange]
+  )
+
+  const shown = useMemo(() => new Set(components ?? parseAddressComponents()), [components])
+
+  // The street line owns `autoFocus` and the expand/collapse addon; when it is hidden they
+  // move to whichever field renders first, so the popover still lands on an input and the
+  // toggle never disappears.
+  const firstVisible = ['name', 'street1', 'street2', 'city', 'state', 'zipCode'].find((id) =>
+    shown.has(id)
+  )
+
   return (
     <div className={className}>
+      {shown.has('name') && (
+        <Input
+          size='sm'
+          variant={inputVariant}
+          placeholder='Name'
+          value={value.name ?? ''}
+          onChange={(e) => handleFieldChange('name', e.target.value)}
+          disabled={disabled}
+          autoFocus={autoFocus && firstVisible === 'name'}
+        />
+      )}
+
       {/* Street Address - full width; with an addon it becomes an InputGroup so the addon
           button sits inside the input's right edge */}
-      {street1Addon ? (
-        <InputGroup
-          size='sm'
-          className={cn(
-            inputVariant === 'transparent' && 'border-transparent bg-transparent shadow-none'
-          )}>
-          <InputGroupInput
+      {shown.has('street1') &&
+        (street1Addon ? (
+          <InputGroup
+            size='sm'
+            className={cn(
+              inputVariant === 'transparent' && 'border-transparent bg-transparent shadow-none'
+            )}>
+            <InputGroupInput
+              placeholder='Street address'
+              value={value.street1}
+              onChange={(e) => handleFieldChange('street1', e.target.value)}
+              disabled={disabled}
+              autoFocus={autoFocus && firstVisible === 'street1'}
+            />
+            <InputGroupAddon align='inline-end'>{street1Addon}</InputGroupAddon>
+          </InputGroup>
+        ) : (
+          <Input
+            size='sm'
+            variant={inputVariant}
             placeholder='Street address'
             value={value.street1}
             onChange={(e) => handleFieldChange('street1', e.target.value)}
             disabled={disabled}
-            autoFocus={autoFocus}
+            autoFocus={autoFocus && firstVisible === 'street1'}
           />
-          <InputGroupAddon align='inline-end'>{street1Addon}</InputGroupAddon>
-        </InputGroup>
-      ) : (
-        <Input
-          size='sm'
-          variant={inputVariant}
-          placeholder='Street address'
-          value={value.street1}
-          onChange={(e) => handleFieldChange('street1', e.target.value)}
-          disabled={disabled}
-          autoFocus={autoFocus}
-        />
+        ))}
+
+      {/* The toggle addon lives in the street line; with the street hidden it would vanish
+          with it, so render it on its own row instead. */}
+      {!shown.has('street1') && street1Addon && (
+        <div className='flex justify-end'>{street1Addon}</div>
       )}
 
       {/* Apartment/Suite - full width */}
-      <Input
-        size='sm'
-        variant={inputVariant}
-        placeholder='Apartment, suite, etc. (optional)'
-        value={value.street2}
-        onChange={(e) => handleFieldChange('street2', e.target.value)}
-        disabled={disabled}
-      />
+      {shown.has('street2') && (
+        <Input
+          size='sm'
+          variant={inputVariant}
+          placeholder='Apartment, suite, etc. (optional)'
+          value={value.street2}
+          onChange={(e) => handleFieldChange('street2', e.target.value)}
+          disabled={disabled}
+          autoFocus={autoFocus && firstVisible === 'street2'}
+        />
+      )}
 
-      {/* City and State - side by side */}
-      <div className='flex gap-2'>
-        <Input
-          size='sm'
-          variant={inputVariant}
-          className='min-w-0 flex-1'
-          placeholder='City'
-          value={value.city}
-          onChange={(e) => handleFieldChange('city', e.target.value)}
-          disabled={disabled}
-        />
-        <Input
-          size='sm'
-          variant={inputVariant}
-          className='w-24'
-          placeholder='State'
-          value={value.state}
-          onChange={(e) => handleFieldChange('state', e.target.value)}
-          disabled={disabled}
-        />
-      </div>
-
-      {/* ZIP Code and Country - side by side */}
-      <div className='flex gap-2'>
-        <Input
-          size='sm'
-          variant={inputVariant}
-          className='w-24'
-          placeholder='ZIP Code'
-          value={value.zipCode}
-          onChange={(e) => handleFieldChange('zipCode', e.target.value)}
-          disabled={disabled}
-        />
-        <div className='min-w-0 flex-1'>
-          {/* Shared picker: full ISO 3166-1 list, flag on the left, blue selected check.
-              Rows are indexed by country name, so "United" finds both United States and
-              United Kingdom — the previous Combobox indexed the alpha-2 code alone. */}
-          <CountrySelect
-            value={value.country}
-            onChange={(code) => handleFieldChange('country', code)}
-            disabled={disabled}
-            placeholder='Country'
-            variant={inputVariant === 'transparent' ? 'transparent' : 'default'}
-            size='sm'
-          />
+      {/* City and State - side by side; either alone takes the full row */}
+      {(shown.has('city') || shown.has('state')) && (
+        <div className='flex gap-2'>
+          {shown.has('city') && (
+            <Input
+              size='sm'
+              variant={inputVariant}
+              className='min-w-0 flex-1'
+              placeholder='City'
+              value={value.city}
+              onChange={(e) => handleFieldChange('city', e.target.value)}
+              disabled={disabled}
+              autoFocus={autoFocus && firstVisible === 'city'}
+            />
+          )}
+          {shown.has('state') && (
+            <Input
+              size='sm'
+              variant={inputVariant}
+              className={shown.has('city') ? 'w-24' : 'min-w-0 flex-1'}
+              placeholder='State'
+              value={value.state}
+              onChange={(e) => handleFieldChange('state', e.target.value)}
+              disabled={disabled}
+              autoFocus={autoFocus && firstVisible === 'state'}
+            />
+          )}
         </div>
-      </div>
+      )}
+
+      {/* ZIP Code and Country - side by side; either alone takes the full row */}
+      {(shown.has('zipCode') || shown.has('country')) && (
+        <div className='flex gap-2'>
+          {shown.has('zipCode') && (
+            <Input
+              size='sm'
+              variant={inputVariant}
+              className={shown.has('country') ? 'w-24' : 'min-w-0 flex-1'}
+              placeholder='ZIP Code'
+              value={value.zipCode}
+              onChange={(e) => handleFieldChange('zipCode', e.target.value)}
+              disabled={disabled}
+              autoFocus={autoFocus && firstVisible === 'zipCode'}
+            />
+          )}
+          {shown.has('country') && (
+            <div className='min-w-0 flex-1'>
+              {/* Shared picker: full ISO 3166-1 list, flag on the left, blue selected check.
+                  Rows are indexed by country name, so "United" finds both United States and
+                  United Kingdom — the previous Combobox indexed the alpha-2 code alone. */}
+              <CountrySelect
+                value={value.country}
+                onChange={(code) => handleFieldChange('country', code)}
+                disabled={disabled}
+                placeholder='Country'
+                variant={inputVariant === 'transparent' ? 'transparent' : 'default'}
+                size='sm'
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {shown.has('residential') && (
+        <Select
+          value={value.residential ?? 'unknown'}
+          onValueChange={handleResidentialChange}
+          disabled={disabled}>
+          <SelectTrigger
+            size='sm'
+            variant={inputVariant === 'transparent' ? 'transparent' : 'default'}
+            aria-label='Residential'>
+            <SelectValue placeholder='Residential' />
+          </SelectTrigger>
+          <SelectContent>
+            {RESIDENTIAL_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
     </div>
   )
 }
@@ -172,11 +275,14 @@ function parseAddressValue(value: unknown): AddressStruct {
     state: initial.state ?? '',
     zipCode: initial.zipCode ?? '',
     country: initial.country ?? '',
+    name: initial.name ?? '',
+    residential: (initial.residential as AddressStruct['residential']) ?? undefined,
   }
 }
 
 /**
- * Shallow compare two AddressStruct objects
+ * Shallow compare two AddressStruct objects. `name`/`residential` are compared too — without
+ * them, editing only the recipient line never reports a change and the commit is dropped.
  */
 function hasAddressChanged(a: AddressStruct, b: AddressStruct): boolean {
   return (
@@ -185,7 +291,9 @@ function hasAddressChanged(a: AddressStruct, b: AddressStruct): boolean {
     a.city !== b.city ||
     a.state !== b.state ||
     a.zipCode !== b.zipCode ||
-    a.country !== b.country
+    a.country !== b.country ||
+    (a.name ?? '') !== (b.name ?? '') ||
+    a.residential !== b.residential
   )
 }
 
@@ -199,10 +307,11 @@ function hasAddressChanged(a: AddressStruct, b: AddressStruct): boolean {
  * - Does NOT capture arrow keys (allows row navigation)
  */
 export function AddressStructInputField() {
-  const { value, commitValue, onBeforeClose } = usePropertyContext()
+  const { field, value, commitValue, onBeforeClose } = usePropertyContext()
 
   const initialAddress = parseAddressValue(value)
   const [fields, setFields] = useState<AddressStruct>(initialAddress)
+  const components = useMemo(() => parseAddressComponents(field?.options), [field?.options])
 
   // Register save handler for popover close - fire-and-forget. `_source: 'structured'` marks
   // this as an authoritative structured-editor commit (decision #11 in
@@ -221,5 +330,7 @@ export function AddressStructInputField() {
     }
   }, [onBeforeClose, fields, initialAddress, commitValue])
 
-  return <AddressStructFields value={fields} onChange={setFields} autoFocus />
+  return (
+    <AddressStructFields value={fields} onChange={setFields} components={components} autoFocus />
+  )
 }

--- a/apps/web/src/components/workflow/apps/primitives/inputs/var-input.tsx
+++ b/apps/web/src/components/workflow/apps/primitives/inputs/var-input.tsx
@@ -72,6 +72,12 @@ export const VarInputInternal = ({
   const resolvedCanAdd = schemaField?.canAdd
   const resolvedCanManage = schemaField?.canManage
 
+  // Resolve address props from schema. Without these an app's declared
+  // `Workflow.address({ addressComponents, inputMode })` reaches the editor stripped, which is
+  // the silent-no-op this whole path exists to avoid.
+  const resolvedAddressComponents = schemaField?.addressComponents
+  const resolvedInputMode = schemaField?.inputMode
+
   const { varType, mode, allowConstant, allowedTypes, fieldOptions } = mapFieldToVarEditorProps({
     type: resolvedType,
     format: resolvedFormat,
@@ -83,6 +89,8 @@ export const VarInputInternal = ({
     multi: resolvedMulti,
     canAdd: resolvedCanAdd,
     canManage: resolvedCanManage,
+    addressComponents: resolvedAddressComponents,
+    inputMode: resolvedInputMode,
   })
 
   // Dot-path access for nested fields

--- a/apps/web/src/components/workflow/apps/workflow-block-loader.ts
+++ b/apps/web/src/components/workflow/apps/workflow-block-loader.ts
@@ -70,6 +70,8 @@ function catalogFieldToBlockField(name: string, fieldJson: any): WorkflowBlockFi
     multi: metadata.multi,
     canAdd: metadata.canAdd,
     canManage: metadata.canManage,
+    addressComponents: metadata.addressComponents,
+    inputMode: metadata.inputMode,
     _fieldKind: 'input',
   }
 

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.test.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.test.tsx
@@ -1,0 +1,126 @@
+// apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.test.tsx
+
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BaseType } from '~/components/workflow/types'
+import { getSpecificPropsForType } from '~/components/workflow/ui/input-editor/get-input-component'
+import { mapFieldToVarEditorProps } from '~/components/workflow/utils/field-to-var-editor'
+
+/**
+ * These tests walk the real chain an app's `Workflow.address()` field takes:
+ *
+ *   mapFieldToVarEditorProps -> getSpecificPropsForType -> AddressInput -> Address*Fields
+ *
+ * Every link is a real function; only the two leaf field components and the org-country
+ * hook are doubled, so the assertion is genuinely "the options reached the renderer".
+ * A typecheck cannot catch a break anywhere in this chain, which is the whole point.
+ */
+
+const singleProps = vi.fn()
+const structProps = vi.fn()
+
+vi.mock('~/components/fields/inputs/address-single-input-field', () => ({
+  AddressSingleFields: (props: Record<string, unknown>) => {
+    singleProps(props)
+    return <div data-testid='single-fields' />
+  },
+}))
+
+vi.mock('~/components/fields/inputs/address-struct-input-field', () => ({
+  AddressStructFields: (props: Record<string, unknown>) => {
+    structProps(props)
+    return <div data-testid='struct-fields' />
+  },
+}))
+
+vi.mock('~/components/fields/inputs/use-org-business-country', () => ({
+  useOrgBusinessCountry: () => 'US',
+}))
+
+const { AddressInput } = await import('./address-input')
+
+/** Render AddressInput the way ConstantInputAdapter does, from an SDK field declaration. */
+function renderFromSchemaField(field: {
+  addressComponents?: string[]
+  inputMode?: string
+  fieldType?: string
+}) {
+  const { varType, fieldOptions } = mapFieldToVarEditorProps({
+    type: 'address',
+    addressComponents: field.addressComponents,
+    inputMode: field.inputMode,
+  })
+  expect(varType).toBe(BaseType.ADDRESS)
+
+  const specificProps = getSpecificPropsForType(varType, { fieldOptions })
+
+  render(
+    <AddressInput
+      inputs={{ _value: {} }}
+      errors={{}}
+      onChange={vi.fn()}
+      onError={vi.fn()}
+      name='_value'
+      fieldType={field.fieldType}
+      {...specificProps}
+    />
+  )
+}
+
+beforeEach(() => {
+  singleProps.mockClear()
+  structProps.mockClear()
+})
+
+describe('Workflow.address options reach the rendered component', () => {
+  it('delivers addressComponents all the way to the field component', () => {
+    renderFromSchemaField({ addressComponents: ['street1', 'city'] })
+
+    expect(singleProps).toHaveBeenCalledTimes(1)
+    expect(singleProps.mock.calls[0][0].components).toEqual(['street1', 'city'])
+  })
+
+  it('delivers addressComponents in structured mode too', () => {
+    renderFromSchemaField({ addressComponents: ['street1', 'city'], inputMode: 'structured' })
+
+    expect(structProps).toHaveBeenCalledTimes(1)
+    expect(structProps.mock.calls[0][0].components).toEqual(['street1', 'city'])
+  })
+
+  it('resolves an absent inputMode to the single paste-and-parse editor', () => {
+    renderFromSchemaField({})
+
+    expect(singleProps).toHaveBeenCalledTimes(1)
+    expect(structProps).not.toHaveBeenCalled()
+  })
+
+  it('renders the structured editor when inputMode is structured', () => {
+    renderFromSchemaField({ inputMode: 'structured' })
+
+    expect(structProps).toHaveBeenCalledTimes(1)
+    expect(singleProps).not.toHaveBeenCalled()
+  })
+
+  it('leaves components undefined when the field declares no addressComponents', () => {
+    renderFromSchemaField({})
+
+    expect(singleProps.mock.calls[0][0].components).toBeUndefined()
+  })
+})
+
+describe('AddressInput fieldType branching', () => {
+  it('keeps legacy plain-text ADDRESS on the structured fields regardless of inputMode', () => {
+    // Decision #9: legacy ADDRESS must not be flipped to single mode by this change.
+    renderFromSchemaField({ fieldType: 'ADDRESS' })
+
+    expect(structProps).toHaveBeenCalledTimes(1)
+    expect(singleProps).not.toHaveBeenCalled()
+  })
+
+  it('honours inputMode for a real ADDRESS_STRUCT field', () => {
+    renderFromSchemaField({ fieldType: 'ADDRESS_STRUCT' })
+
+    expect(singleProps).toHaveBeenCalledTimes(1)
+    expect(structProps).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.tsx
@@ -22,11 +22,12 @@ interface AddressInputProps extends NodeInputProps {
   name: string
   /** Placeholder text */
   placeholder?: string
-  /** Field-specific options (used for address inputVariant / inputMode) */
+  /** Field-specific options (address inputVariant / inputMode / addressComponents) */
   fieldOptions?: FieldOptions
   /** The underlying FieldType — `ADDRESS_STRUCT` branches on `fieldOptions.inputMode`
    *  (decision #4); legacy `ADDRESS` (plain text) stays on the structured fields, untouched
-   *  (decision #9). Absent (e.g. the workflow variable/constant editor) also stays untouched. */
+   *  (decision #9). Absent is the workflow variable/constant editor, which has no `FieldType`
+   *  at all and branches on `inputMode` like `ADDRESS_STRUCT` does. */
   fieldType?: string
 }
 
@@ -83,7 +84,13 @@ export const AddressInput = createNodeInput<AddressInputProps>(
       [name, onChange, onError]
     )
 
-    const isSingleMode = isAddressStruct && fieldOptions?.inputMode !== 'structured'
+    // Who gets to honour `inputMode`: real `ADDRESS_STRUCT` fields, and the workflow
+    // variable/constant editor, which carries no `FieldType` at all. Legacy plain-text
+    // `ADDRESS` is deliberately excluded and stays on the structured fields (decision #9).
+    const honoursInputMode = fieldType === undefined || isAddressStruct
+
+    // Absent resolves to 'single', matching `parseAddressInputMode`.
+    const isSingleMode = honoursInputMode && fieldOptions?.inputMode !== 'structured'
 
     if (isSingleMode) {
       return (
@@ -95,6 +102,7 @@ export const AddressInput = createNodeInput<AddressInputProps>(
           disabled={isLoading}
           className='flex w-full flex-col gap-1 pe-2 py-1'
           inputVariant={fieldOptions?.address?.inputVariant}
+          components={fieldOptions?.addressComponents}
         />
       )
     }
@@ -106,6 +114,7 @@ export const AddressInput = createNodeInput<AddressInputProps>(
         disabled={isLoading}
         className='flex w-full flex-col gap-1 pe-2 py-1'
         inputVariant={fieldOptions?.address?.inputVariant}
+        components={fieldOptions?.addressComponents}
       />
     )
   }

--- a/apps/web/src/components/workflow/types/block-types.ts
+++ b/apps/web/src/components/workflow/types/block-types.ts
@@ -165,6 +165,17 @@ export interface WorkflowBlockField {
   canManage?: boolean
 
   // ========================================
+  // Address Fields
+  // ========================================
+
+  /** Address sub-fields to render (for `address` fields). All of them when absent. */
+  addressComponents?: readonly string[]
+
+  /** How an `address` field is edited. Anything other than 'structured', absent included,
+   *  resolves to 'single' — see `parseAddressInputMode`. */
+  inputMode?: 'single' | 'structured'
+
+  // ========================================
   // Nested Structures
   // ========================================
 

--- a/apps/web/src/components/workflow/ui/input-editor/get-input-component.ts
+++ b/apps/web/src/components/workflow/ui/input-editor/get-input-component.ts
@@ -113,6 +113,12 @@ export interface FieldOptions {
   selectVariant?: 'transparent' | 'outline'
   /** For ENUM/SELECT type — show loading skeleton while options are being fetched */
   loading?: boolean
+  /** For ADDRESS type — which address components the editor shows (all when omitted).
+   *  Mutable to match `AddressStructFields`/`AddressSingleFields`' `components` prop and
+   *  `@auxx/lib`'s own `FieldOptions.addressComponents`. */
+  addressComponents?: string[]
+  /** For ADDRESS type — 'single' paste-and-parse line vs one input per component */
+  inputMode?: 'single' | 'structured'
   /** For NUMBER type */
   number?: {
     min?: number
@@ -204,7 +210,15 @@ export function getSpecificPropsForType(
     }
 
     case BaseType.ADDRESS:
-      return {}
+      // A narrow projection, not the raw `fieldOptions`: `AddressInput` already declares a
+      // `fieldOptions` prop and reads exactly these two keys off it. Widening the adapter to
+      // spread raw options for every type would be a much bigger contract change.
+      return {
+        fieldOptions: {
+          addressComponents: fieldOptions?.addressComponents,
+          inputMode: fieldOptions?.inputMode,
+        },
+      }
 
     case BaseType.ARRAY:
       if (fieldOptions?.multiSelect) {

--- a/apps/web/src/components/workflow/utils/field-to-var-editor.test.ts
+++ b/apps/web/src/components/workflow/utils/field-to-var-editor.test.ts
@@ -1,0 +1,66 @@
+// apps/web/src/components/workflow/utils/field-to-var-editor.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { BaseType, VAR_MODE } from '~/components/workflow/types'
+import { mapFieldToVarEditorProps, mapFieldType } from './field-to-var-editor'
+
+describe('mapFieldToVarEditorProps — address', () => {
+  it('resolves type "address" to the ADDRESS render path, not the STRING fallback', () => {
+    const result = mapFieldToVarEditorProps({ type: 'address' })
+
+    expect(result.varType).toBe(BaseType.ADDRESS)
+    expect(result.mode).toBe(VAR_MODE.PICKER)
+    // The trap: without the case above, the default arm returns STRING/RICH and an app
+    // shipping Workflow.address() silently renders a plain text box.
+    expect(result.varType).not.toBe(BaseType.STRING)
+    expect(result.mode).not.toBe(VAR_MODE.RICH)
+  })
+
+  it('passes addressComponents and inputMode through in fieldOptions', () => {
+    const result = mapFieldToVarEditorProps({
+      type: 'address',
+      addressComponents: ['street1', 'city', 'country'],
+      inputMode: 'structured',
+    })
+
+    expect(result.fieldOptions?.addressComponents).toEqual(['street1', 'city', 'country'])
+    expect(result.fieldOptions?.inputMode).toBe('structured')
+  })
+
+  it('resolves an absent inputMode to single, matching parseAddressInputMode', () => {
+    const result = mapFieldToVarEditorProps({ type: 'address' })
+
+    expect(result.fieldOptions?.inputMode).toBe('single')
+    expect(result.fieldOptions?.addressComponents).toBeUndefined()
+  })
+
+  it('normalizes an unknown inputMode to single', () => {
+    const result = mapFieldToVarEditorProps({ type: 'address', inputMode: 'nonsense' })
+
+    expect(result.fieldOptions?.inputMode).toBe('single')
+  })
+
+  it('honours acceptsVariables: false by disallowing constant-mode toggling', () => {
+    expect(
+      mapFieldToVarEditorProps({ type: 'address', acceptsVariables: false }).allowConstant
+    ).toBe(false)
+    expect(
+      mapFieldToVarEditorProps({ type: 'address', acceptsVariables: true }).allowConstant
+    ).toBe(true)
+  })
+
+  it('maps an "address" entry in variableTypes to BaseType.ADDRESS', () => {
+    const result = mapFieldToVarEditorProps({
+      type: 'address',
+      variableTypes: ['address', 'string'],
+    })
+
+    expect(result.allowedTypes).toEqual([BaseType.ADDRESS, BaseType.STRING])
+  })
+})
+
+describe('mapFieldType — address', () => {
+  it('returns BaseType.ADDRESS for the type icon', () => {
+    expect(mapFieldType('address')).toBe(BaseType.ADDRESS)
+  })
+})

--- a/apps/web/src/components/workflow/utils/field-to-var-editor.ts
+++ b/apps/web/src/components/workflow/utils/field-to-var-editor.ts
@@ -40,6 +40,9 @@ function normalizeOption(opt: string | { label: string; value: string }): {
  * @param params.options - Enum options for select fields
  * @param params.acceptsVariables - Whether the field accepts variable references
  * @param params.variableTypes - Allowed variable types for filtering
+ * @param params.addressComponents - Address sub-fields to show, for address fields
+ * @param params.inputMode - Address edit mode for address fields; anything other than
+ *   'structured' (absent included) resolves to 'single'
  */
 export function mapFieldToVarEditorProps(params: {
   type: string
@@ -52,6 +55,8 @@ export function mapFieldToVarEditorProps(params: {
   multi?: boolean
   canAdd?: boolean
   canManage?: boolean
+  addressComponents?: readonly string[]
+  inputMode?: string
 }): VarEditorMappedProps {
   const { type, format, options, acceptsVariables, variableTypes, variant, loading } = params
 
@@ -177,6 +182,22 @@ export function mapFieldToVarEditorProps(params: {
       }
     }
 
+    case 'address':
+      return {
+        varType: BaseType.ADDRESS,
+        mode: VAR_MODE.PICKER,
+        allowConstant,
+        allowedTypes,
+        fieldOptions: {
+          // Copied, not aliased: the SDK schema hands us a `readonly` array and the
+          // address components prop downstream is mutable.
+          addressComponents: params.addressComponents ? [...params.addressComponents] : undefined,
+          // Matches `parseAddressInputMode`: anything other than 'structured',
+          // absent included, resolves to 'single' (the paste-and-parse editor).
+          inputMode: params.inputMode === 'structured' ? 'structured' : 'single',
+        },
+      }
+
     case 'array': {
       if (options && options.length > 0) {
         const normalizedOptions = (options as any[]).map(normalizeOption)
@@ -253,6 +274,8 @@ export function mapFieldType(type?: string, format?: string): BaseType {
       return BaseType.ENUM
     case 'array':
       return BaseType.ARRAY
+    case 'address':
+      return BaseType.ADDRESS
     case 'object':
     case 'struct':
       return BaseType.OBJECT
@@ -278,6 +301,7 @@ function mapStringToBaseType(typeStr: string): BaseType | null {
     url: BaseType.URL,
     phone: BaseType.PHONE,
     currency: BaseType.CURRENCY,
+    address: BaseType.ADDRESS,
     file: BaseType.FILE,
     json: BaseType.JSON,
     any: BaseType.ANY,

--- a/packages/lib/src/custom-fields/types.ts
+++ b/packages/lib/src/custom-fields/types.ts
@@ -189,7 +189,13 @@ export type CustomFieldRecord = CustomField
 
 /**
  * AddressStruct interface
- * Structured address data matching ADDRESS_COMPONENTS in address-component-editor.tsx
+ * Structured address data matching ADDRESS_COMPONENTS in address-component-editor.tsx.
+ *
+ * `name` and `residential` are opt-in per field (they are NOT in
+ * `DEFAULT_ADDRESS_COMPONENTS`) and must be mirrored on `AddressStructValue`
+ * (`packages/utils/src/address.ts`) and on `addressStructJson`
+ * (`packages/lib/src/field-values/field-value-validator.ts`) — that schema is closed, so a
+ * key missing there is dropped before it reaches storage.
  */
 export interface AddressStruct {
   street1: string
@@ -198,6 +204,10 @@ export interface AddressStruct {
   state: string
   zipCode: string
   country: string
+  /** Recipient line — a person, or the company where there is no contact person. */
+  name?: string
+  /** Carrier residential indicator; `'unknown'` is a real, distinct state. */
+  residential?: 'unknown' | 'yes' | 'no'
 }
 
 /**

--- a/packages/lib/src/field-values/__tests__/address-struct-keys.test.ts
+++ b/packages/lib/src/field-values/__tests__/address-struct-keys.test.ts
@@ -1,0 +1,154 @@
+// packages/lib/src/field-values/__tests__/address-struct-keys.test.ts
+
+import type { FieldType } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { jsonConverter } from '../converters/json'
+import type { FieldValueContext } from '../field-value-helpers'
+import { validateAndConvertValue } from '../field-value-helpers'
+import { FieldValueValidator, fieldValueSchemas } from '../field-value-validator'
+
+/**
+ * `addressStructJson` is a CLOSED zod object, deliberately not `.passthrough()`: a key that is
+ * not listed is dropped silently, before the value ever reaches storage or the post-write hook.
+ * `name` and `residential`
+ * (plans/apps/shipstation/shipstation-workflow-expansion-plan.md §4) are therefore only real
+ * once they are in that schema — the failure mode this file guards is invisible at runtime.
+ */
+
+const ADDRESS_STRUCT = 'ADDRESS_STRUCT' as FieldType
+
+const field = {
+  id: 'field_address',
+  type: ADDRESS_STRUCT,
+  options: undefined,
+} as unknown as Parameters<typeof validateAndConvertValue>[3]
+
+const ctx = { validator: new FieldValueValidator() } as unknown as FieldValueContext
+
+/** Full write path for a scalar JSON field: validate + convert, then read back out. */
+async function roundTrip(value: unknown): Promise<Record<string, unknown> | null> {
+  const typed = await validateAndConvertValue(ctx, value, ADDRESS_STRUCT, field)
+  return jsonConverter.toRawValue(typed) as Record<string, unknown> | null
+}
+
+describe('addressStructJson carries name and residential', () => {
+  it('round-trips a struct carrying both new keys', async () => {
+    const struct = {
+      street1: '123 Main St',
+      street2: 'Apt 4',
+      city: 'Austin',
+      state: 'TX',
+      zipCode: '78701',
+      country: 'US',
+      name: 'Jane Smith',
+      residential: 'yes',
+    }
+
+    await expect(roundTrip(struct)).resolves.toEqual(struct)
+  })
+
+  it('round-trips name and residential alongside the geocode enrichment keys', async () => {
+    const struct = {
+      street1: '123 Main St',
+      city: 'Austin',
+      state: 'TX',
+      zipCode: '78701',
+      country: 'US',
+      name: 'Acme Corp',
+      residential: 'no',
+      lat: 30.2672,
+      lng: -97.7431,
+      geocodedAt: '2026-09-11T00:00:00.000Z',
+    }
+
+    await expect(roundTrip(struct)).resolves.toEqual(struct)
+  })
+
+  it('accepts all three residential states and rejects anything else', () => {
+    for (const residential of ['unknown', 'yes', 'no']) {
+      const parsed = fieldValueSchemas.addressStructJson.safeParse({
+        street1: '1 Foo St',
+        residential,
+      })
+      expect(parsed.success).toBe(true)
+      expect(parsed.success && parsed.data.residential).toBe(residential)
+    }
+
+    expect(
+      fieldValueSchemas.addressStructJson.safeParse({ street1: '1 Foo St', residential: true })
+        .success
+    ).toBe(false)
+    expect(
+      fieldValueSchemas.addressStructJson.safeParse({
+        street1: '1 Foo St',
+        residential: 'RESIDENTIAL',
+      }).success
+    ).toBe(false)
+  })
+
+  it('a name alone satisfies the refine; a residential indicator alone does not', () => {
+    expect(fieldValueSchemas.addressStructJson.safeParse({ name: 'Jane Smith' }).success).toBe(true)
+    expect(fieldValueSchemas.addressStructJson.safeParse({ residential: 'yes' }).success).toBe(
+      false
+    )
+  })
+
+  it('is still closed — an unlisted key is dropped, not stored', async () => {
+    const stored = await roundTrip({
+      street1: '1 Foo St',
+      company: 'Acme Corp',
+      phone: '+15125551234',
+    })
+    expect(stored).toEqual({ street1: '1 Foo St' })
+  })
+})
+
+describe('backward compatibility: structs written before the new keys existed', () => {
+  const LEGACY_SHAPES: { label: string; struct: Record<string, unknown> }[] = [
+    {
+      label: 'the original six',
+      struct: {
+        street1: '123 Main St',
+        street2: 'Apt 4',
+        city: 'Austin',
+        state: 'TX',
+        zipCode: '78701',
+        country: 'US',
+      },
+    },
+    { label: 'street only', struct: { street1: '1 Foo St' } },
+    { label: 'country only', struct: { country: 'DE' } },
+    {
+      label: 'with raw and a completed geocode',
+      struct: {
+        street1: 'Musterstraße 1',
+        city: 'Berlin',
+        zipCode: '12345',
+        country: 'DE',
+        raw: 'Musterstrasse 1 12345 Berlin',
+        lat: 52.52,
+        lng: 13.405,
+        geocodedAt: '2026-01-01T00:00:00.000Z',
+      },
+    },
+  ]
+
+  it.each(LEGACY_SHAPES)('validates and round-trips unchanged — $label', async ({ struct }) => {
+    expect(fieldValueSchemas.addressStructJson.safeParse(struct).success).toBe(true)
+    await expect(roundTrip(struct)).resolves.toEqual(struct)
+  })
+
+  it('an empty struct is still rejected', () => {
+    expect(fieldValueSchemas.addressStructJson.safeParse({}).success).toBe(false)
+  })
+
+  it('strips the transient _source marker path unchanged (still accepted)', () => {
+    const parsed = fieldValueSchemas.addressStructJson.safeParse({
+      street1: '1 Foo St',
+      name: 'Jane Smith',
+      _source: 'structured',
+    })
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && parsed.data._source).toBe('structured')
+  })
+})

--- a/packages/lib/src/field-values/field-value-validator.ts
+++ b/packages/lib/src/field-values/field-value-validator.ts
@@ -168,7 +168,12 @@ export const fieldValueSchemas = {
   // enrichment, `_source` is a transient write-time marker the geocoder normalize hook reads and
   // always strips on write-back — all five MUST stay in this schema (not `.passthrough()`, to
   // keep the shape closed) or they're silently dropped here before the value ever reaches
-  // storage or the post-write hook.
+  // storage or the post-write hook. `name`/`residential`
+  // (plans/apps/shipstation/shipstation-workflow-expansion-plan.md §4) are here for the same
+  // reason: a key that is not listed vanishes with no error.
+  //
+  // Every key is `.optional()`, so a struct written before `name`/`residential` existed keeps
+  // validating unchanged.
   addressStructJson: z
     .object({
       street1: z.string().optional(),
@@ -177,15 +182,21 @@ export const fieldValueSchemas = {
       state: z.string().optional(),
       zipCode: z.string().optional(),
       country: z.string().optional(),
+      name: z.string().optional(),
+      residential: z.enum(['unknown', 'yes', 'no']).optional(),
       raw: z.string().optional(),
       lat: z.number().optional(),
       lng: z.number().optional(),
       geocodedAt: z.string().optional(),
       _source: z.enum(['single', 'structured']).optional(),
     })
-    .refine((v) => v.street1 || v.street2 || v.city || v.state || v.zipCode || v.country, {
-      message: 'ADDRESS_STRUCT requires at least one address field',
-    }),
+    // `name` counts as content (it is typed by a user and would otherwise be silently
+    // rejected on a name-only write); `residential` does not — an indicator on its own is
+    // not an address.
+    .refine(
+      (v) => v.street1 || v.street2 || v.city || v.state || v.zipCode || v.country || v.name,
+      { message: 'ADDRESS_STRUCT requires at least one address field' }
+    ),
 
   // FILE JSON: { ref, caption?, internal? } — one file reference per FieldValue row
   // ("asset:id" or "file:id"). `caption`/`internal` are additive (plans/dispatch/

--- a/packages/sdk/__tests__/workflow-address-node.test.ts
+++ b/packages/sdk/__tests__/workflow-address-node.test.ts
@@ -1,0 +1,70 @@
+// packages/sdk/__tests__/workflow-address-node.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { Workflow, WorkflowAddressNode } from '../src/root/workflow'
+
+describe('Workflow.address', () => {
+  it('creates a WorkflowAddressNode with type "address"', () => {
+    const field = Workflow.address({ label: 'Ship To' })
+
+    expect(field).toBeInstanceOf(WorkflowAddressNode)
+    expect(field.type).toBe('address')
+  })
+
+  it('serializes the shared metadata', () => {
+    const json = Workflow.address({
+      label: 'Ship To',
+      description: 'Where the parcel goes',
+      required: true,
+      acceptsVariables: true,
+    }).toJSON()
+
+    expect(json.type).toBe('address')
+    expect(json.acceptsVariables).toBe(true)
+    expect(json._metadata?.label).toBe('Ship To')
+    expect(json._metadata?.description).toBe('Where the parcel goes')
+    expect(json._metadata?.required).toBe(true)
+  })
+
+  it('serializes addressComponents and inputMode into metadata', () => {
+    const json = Workflow.address({
+      label: 'Ship From',
+      addressComponents: ['street1', 'city', 'country'],
+      inputMode: 'single',
+    }).toJSON()
+
+    expect(json._metadata?.addressComponents).toEqual(['street1', 'city', 'country'])
+    expect(json._metadata?.inputMode).toBe('single')
+  })
+
+  it('omits addressComponents and inputMode when not given', () => {
+    const json = Workflow.address({ label: 'Ship From' }).toJSON()
+
+    expect(json._metadata?.addressComponents).toBeUndefined()
+    expect(json._metadata?.inputMode).toBeUndefined()
+  })
+
+  it('optional() returns a new node carrying the original options', () => {
+    const field = Workflow.address({ label: 'Ship To', inputMode: 'structured' })
+    const optionalField = field.optional()
+
+    expect(optionalField).not.toBe(field)
+    expect(optionalField.isOptional).toBe(true)
+    expect(field.isOptional).toBe(false)
+    expect(optionalField.toJSON()._metadata?.inputMode).toBe('structured')
+  })
+
+  it('passes values through serialize and deserialize unchanged', () => {
+    const field = Workflow.address()
+    const value = {
+      street1: '1 Main St',
+      city: 'Austin',
+      state: 'TX',
+      zipCode: '78701',
+      country: 'US',
+    }
+
+    expect(field.serialize(value)).toEqual(value)
+    expect(field.deserialize(value)).toEqual(value)
+  })
+})

--- a/packages/sdk/src/root/fields/define-field.ts
+++ b/packages/sdk/src/root/fields/define-field.ts
@@ -80,8 +80,19 @@ interface ScalarFieldDecl extends BaseFieldDecl {
 /** Address field — `addressComponents` is optional, everything else forbidden. */
 interface AddressStructFieldDecl extends BaseFieldDecl {
   readonly type: 'ADDRESS_STRUCT'
-  /** Sub-field set surfaced on the field, e.g. `['street', 'city', 'state', 'country']`.
-   *  The synced/set value must be shaped `{ street1, street2, city, state, zipCode, country }`. */
+  /**
+   * Sub-field set surfaced on the field. Valid ids are exactly the struct's keys:
+   * `name`, `street1`, `street2`, `city`, `state`, `zipCode`, `country`, `residential`.
+   * Omit it for the default six (`street1`, `street2`, `city`, `state`, `zipCode`,
+   * `country`) — `name` and `residential` are opt-in.
+   *
+   * An id outside that set is ignored by the renderers, so `'street'` (which no editor has
+   * ever produced) hides nothing; it marks the whole list as un-configured.
+   *
+   * The synced/set value is shaped
+   * `{ street1, street2, city, state, zipCode, country, name?, residential? }`, where
+   * `residential` is `'unknown' | 'yes' | 'no'`.
+   */
   readonly addressComponents?: readonly string[]
   readonly options?: never
   readonly relationship?: never

--- a/packages/sdk/src/root/workflow/index.ts
+++ b/packages/sdk/src/root/workflow/index.ts
@@ -15,6 +15,8 @@ export type { SelectOption } from '../schema/select-node.js'
 
 // Import input field classes (needed for type utilities below)
 import {
+  WorkflowAddressNode,
+  type WorkflowAddressValue,
   WorkflowArrayNode,
   WorkflowBooleanNode,
   WorkflowCurrencyNode,
@@ -30,6 +32,7 @@ import {
 
 // Export input field types
 export type {
+  AddressInputOptions,
   ArrayInputOptions,
   BooleanInputOptions,
   CurrencyInputOptions,
@@ -40,6 +43,8 @@ export type {
   SelectInputOptions,
   StringInputOptions,
   StructInputOptions,
+  WorkflowAddressInputMode,
+  WorkflowAddressValue,
   WorkflowFileData,
   WorkflowStringFormat,
 } from './input-nodes.js'
@@ -56,6 +61,7 @@ export {
   WorkflowCurrencyNode,
   WorkflowSecretNode,
   WorkflowFileNode,
+  WorkflowAddressNode,
 }
 
 // Re-export StringFormat from schema for backwards compatibility
@@ -64,6 +70,7 @@ import type { StringFormat } from '../schema/index.js'
 import { AuxxRuleReference, auxxRule, WorkflowAuxxRuleNode } from './auxx-rule-node.js'
 // Import input factories (not exported directly - only via Workflow namespace)
 import {
+  address,
   array,
   boolean,
   currency,
@@ -140,6 +147,7 @@ export const Workflow = {
   currency,
   secret,
   file,
+  address,
 } as const
 
 // Export StringFormat type for use in workflow definitions
@@ -163,6 +171,7 @@ export type WorkflowNode =
   | WorkflowCurrencyNode
   | WorkflowSecretNode
   | WorkflowFileNode
+  | WorkflowAddressNode
   | WorkflowAuxxRuleNode
 
 /**
@@ -182,21 +191,23 @@ export type InferFieldType<T> = T extends WorkflowStringNode
             ? string
             : T extends WorkflowFileNode
               ? WorkflowFileData | WorkflowFileData[]
-              : T extends WorkflowSelectNode<infer TOptions>
-                ? TOptions extends readonly (infer U)[]
-                  ? U extends string
-                    ? U
-                    : U extends { value: infer V }
-                      ? V
-                      : string
-                  : string
-                : T extends WorkflowArrayNode<infer TItem>
-                  ? InferFieldType<TItem>[]
-                  : T extends WorkflowStructNode<infer TFields>
-                    ? { [K in keyof TFields]: InferFieldType<TFields[K]> }
-                    : T extends WorkflowFieldNode<any, infer TValue, any>
-                      ? TValue
-                      : never
+              : T extends WorkflowAddressNode
+                ? WorkflowAddressValue
+                : T extends WorkflowSelectNode<infer TOptions>
+                  ? TOptions extends readonly (infer U)[]
+                    ? U extends string
+                      ? U
+                      : U extends { value: infer V }
+                        ? V
+                        : string
+                    : string
+                  : T extends WorkflowArrayNode<infer TItem>
+                    ? InferFieldType<TItem>[]
+                    : T extends WorkflowStructNode<infer TFields>
+                      ? { [K in keyof TFields]: InferFieldType<TFields[K]> }
+                      : T extends WorkflowFieldNode<any, infer TValue, any>
+                        ? TValue
+                        : never
 
 /**
  * Infer the input type from a workflow schema

--- a/packages/sdk/src/root/workflow/input-nodes.ts
+++ b/packages/sdk/src/root/workflow/input-nodes.ts
@@ -354,6 +354,49 @@ export interface FileInputOptions
 }
 
 /**
+ * How an address field is edited in the workflow panel.
+ *
+ * - `single`: one paste-and-parse line (the platform default when this is absent)
+ * - `structured`: one input per address component
+ */
+export type WorkflowAddressInputMode = 'single' | 'structured'
+
+/**
+ * The value an address input field produces.
+ *
+ * Structurally identical to the platform's canonical address struct. Typed here rather than
+ * imported because the SDK must not depend on `@auxx/lib`.
+ */
+export interface WorkflowAddressValue {
+  street1: string
+  street2?: string
+  city: string
+  state: string
+  zipCode: string
+  country: string
+  /** Contact or company name printed on the address line */
+  name?: string
+  /** Residential delivery indicator, drives carrier surcharges */
+  residential?: 'unknown' | 'yes' | 'no'
+}
+
+/**
+ * Options for address input fields
+ */
+export interface AddressInputOptions extends BaseWorkflowFieldOptions<WorkflowAddressValue> {
+  /**
+   * Which address components the panel shows. Omit to show all of them.
+   * Values are keys of {@link WorkflowAddressValue}, e.g. `['street1', 'city', 'country']`.
+   */
+  addressComponents?: readonly string[]
+  /**
+   * How the field is edited. Leave absent to take the platform default: the host resolves
+   * anything other than `'structured'`, absent included, to `'single'`.
+   */
+  inputMode?: WorkflowAddressInputMode
+}
+
+/**
  * Structured file data in workflow context
  */
 export interface WorkflowFileData {
@@ -453,6 +496,35 @@ export class WorkflowFileNode extends WorkflowFieldNode<
     if (this._options.maxFiles !== undefined) base._metadata.maxFiles = this._options.maxFiles
     if (this._options.allowedFileTypes)
       base._metadata.allowedFileTypes = this._options.allowedFileTypes
+    return base
+  }
+}
+
+/**
+ * Address input field node
+ *
+ * Resolves to the platform's existing address render path, so the panel gets the real
+ * address editor rather than a plain text box.
+ */
+export class WorkflowAddressNode extends WorkflowFieldNode<
+  'address',
+  WorkflowAddressValue,
+  AddressInputOptions
+> {
+  get type(): 'address' {
+    return 'address'
+  }
+
+  optional(): WorkflowAddressNode {
+    return new WorkflowAddressNode({ ...this._options, isOptional: true })
+  }
+
+  toJSON() {
+    const base = super.toJSON()
+    if (!base._metadata) base._metadata = {}
+    if (this._options.addressComponents)
+      base._metadata.addressComponents = this._options.addressComponents as string[]
+    if (this._options.inputMode) base._metadata.inputMode = this._options.inputMode
     return base
   }
 }
@@ -671,4 +743,24 @@ export function secret(options?: SecretInputOptions): WorkflowSecretNode {
  */
 export function file(options?: FileInputOptions): WorkflowFileNode {
   return new WorkflowFileNode(options)
+}
+
+/**
+ * Create an address input field
+ *
+ * One field per address, rather than a pile of flat string inputs.
+ *
+ * @example
+ * ```typescript
+ * Workflow.address({
+ *   label: 'Ship To',
+ *   required: true,
+ *   acceptsVariables: true,
+ *   inputMode: 'structured',
+ *   addressComponents: ['name', 'street1', 'street2', 'city', 'state', 'zipCode', 'country'],
+ * })
+ * ```
+ */
+export function address(options?: AddressInputOptions): WorkflowAddressNode {
+  return new WorkflowAddressNode(options)
 }

--- a/packages/sdk/src/runtime/workflow.ts
+++ b/packages/sdk/src/runtime/workflow.ts
@@ -235,6 +235,10 @@ function serializeFields(
       canAdd: metadata.canAdd,
       canManage: metadata.canManage,
 
+      // Address
+      addressComponents: metadata.addressComponents,
+      inputMode: metadata.inputMode,
+
       // Debug marker
       _fieldKind: kind,
     }
@@ -343,6 +347,10 @@ function serializeFieldsFromJSON(
       multi: metadata.multi,
       canAdd: metadata.canAdd,
       canManage: metadata.canManage,
+
+      // Address
+      addressComponents: metadata.addressComponents,
+      inputMode: metadata.inputMode,
       _fieldKind: kind,
     }
 
@@ -395,6 +403,11 @@ function serializeNestedField(fieldJson: any, kind: 'input' | 'output'): any {
     multi: metadata.multi,
     canAdd: metadata.canAdd,
     canManage: metadata.canManage,
+
+    // Address
+    addressComponents: metadata.addressComponents,
+    inputMode: metadata.inputMode,
+
     _fieldKind: kind,
   }
 

--- a/packages/utils/src/__tests__/address.test.ts
+++ b/packages/utils/src/__tests__/address.test.ts
@@ -134,6 +134,127 @@ describe('formatAddressForGeocode', () => {
       '123 Main St, Austin, US'
     )
   })
+
+  // A person's name in a MapTiler query degrades the result, and `residential` is not a place.
+  // See plans/apps/shipstation/shipstation-workflow-expansion-plan.md §4.
+  it('never includes name or residential', () => {
+    expect(
+      formatAddressForGeocode({
+        name: 'Jane Smith',
+        street1: '123 Main St',
+        city: 'Austin',
+        state: 'TX',
+        zipCode: '78701',
+        country: 'US',
+        residential: 'yes',
+      })
+    ).toBe('123 Main St, Austin, TX, 78701, US')
+  })
+})
+
+// plans/apps/shipstation/shipstation-workflow-expansion-plan.md §4: `name` and `residential`
+// are additive keys, and `formatAddress`'s DEFAULT output must stay byte-identical because it
+// renders in dispatch notifications, digests, the route planner, timeline chips and the field
+// display.
+describe('formatAddress — name/residential are opt-in only', () => {
+  const FIXTURES: { label: string; address: Partial<AddressStructValue>; expected: string }[] = [
+    {
+      label: 'US with unit',
+      address: {
+        street1: '123 Main St',
+        street2: 'Apt 4',
+        city: 'Austin',
+        state: 'TX',
+        zipCode: '78701',
+        country: 'US',
+      },
+      expected: '123 Main St, Apt 4, Austin, TX 78701, United States',
+    },
+    {
+      label: 'DE profile',
+      address: { street1: 'Musterstraße 1', city: 'Berlin', zipCode: '12345', country: 'DE' },
+      expected: 'Musterstraße 1, 12345 Berlin, Germany',
+    },
+    {
+      label: 'UK, no state',
+      address: {
+        street1: '10 Downing Street',
+        city: 'London',
+        state: '',
+        zipCode: 'SW1A 2AA',
+        country: 'GB',
+      },
+      expected: '10 Downing Street, London, SW1A 2AA, United Kingdom',
+    },
+    {
+      label: 'street only',
+      address: { street1: '1 Foo St' },
+      expected: '1 Foo St',
+    },
+  ]
+
+  it.each(FIXTURES)('default output is unchanged by name/residential — $label', ({
+    address,
+    expected,
+  }) => {
+    expect(formatAddress(address)).toBe(expected)
+    expect(formatAddress({ ...address, name: 'Jane Smith', residential: 'yes' })).toBe(expected)
+    expect(formatAddress({ ...address, name: 'Acme Corp', residential: 'no' })).toBe(expected)
+  })
+
+  it('default output is unchanged with domesticCountry and country overrides too', () => {
+    const a: Partial<AddressStructValue> = {
+      street1: '123 Main St',
+      city: 'Austin',
+      state: 'TX',
+      zipCode: '78701',
+      country: 'US',
+    }
+    const withExtras = { ...a, name: 'Jane Smith', residential: 'unknown' as const }
+    for (const opts of [
+      { domesticCountry: 'US' },
+      { domesticCountry: 'GB' },
+      { country: 'code' as const },
+      { country: 'omit' as const },
+      { country: 'name' as const },
+    ]) {
+      expect(formatAddress(withExtras, opts)).toBe(formatAddress(a, opts))
+    }
+  })
+
+  it("include: ['name'] prepends the recipient line", () => {
+    expect(
+      formatAddress(
+        {
+          name: 'Jane Smith',
+          street1: '123 Main St',
+          city: 'Austin',
+          state: 'TX',
+          zipCode: '78701',
+          country: 'US',
+        },
+        { domesticCountry: 'US', include: ['name'] }
+      )
+    ).toBe('Jane Smith, 123 Main St, Austin, TX 78701')
+  })
+
+  it("include: ['name'] on an address with no name adds no empty segment", () => {
+    expect(
+      formatAddress(
+        { street1: '123 Main St', city: 'Austin', state: 'TX', zipCode: '78701', country: 'US' },
+        { domesticCountry: 'US', include: ['name'] }
+      )
+    ).toBe('123 Main St, Austin, TX 78701')
+  })
+
+  it('residential never renders, even when name is included', () => {
+    expect(
+      formatAddress(
+        { street1: '1 Foo St', residential: 'yes' },
+        { country: 'omit', include: ['name'] }
+      )
+    ).toBe('1 Foo St')
+  })
 })
 
 describe('parseAddress — US fixtures', () => {

--- a/packages/utils/src/address.ts
+++ b/packages/utils/src/address.ts
@@ -13,6 +13,19 @@ export interface AddressStructValue {
   state: string
   zipCode: string
   country: string // ISO alpha-2
+  /**
+   * Recipient line — a person, or the company where there is no contact person. Opt-in per
+   * field via `addressComponents` and never part of the geocoder query
+   * (plans/apps/shipstation/shipstation-workflow-expansion-plan.md §4). Converters must
+   * PICK a person or a company, never concatenate: a merged "Acme Corp - Jane Smith" cannot
+   * be split back out.
+   */
+  name?: string
+  /**
+   * Carrier residential indicator. `'unknown'` is a real, distinct state (it is what
+   * `POST /v2/addresses/validate` resolves), so it is never collapsed to a boolean.
+   */
+  residential?: 'unknown' | 'yes' | 'no'
   raw?: string
   lat?: number
   lng?: number
@@ -242,10 +255,19 @@ function countryNameFor(codeOrName: string): string {
  * `opts.country: 'name' | 'code' | 'omit'` overrides that behavior. Profile-aware ordering:
  * DE renders `"Straße Nr, PLZ Stadt"` (zip before city, no state). Returns `''` when every
  * part is empty — callers can `|| null`.
+ *
+ * `opts.include` is strictly opt-in and the ONLY way to render a key outside the six postal
+ * components. The default output is byte-identical to what dispatch notifications, digests,
+ * the route planner, timeline chips and the field display already send, so it must stay that
+ * way; `include: ['name']` prepends the recipient line for callers that want it.
  */
 export function formatAddress(
   a: Partial<AddressStructValue>,
-  opts?: { domesticCountry?: string; country?: 'name' | 'code' | 'omit' }
+  opts?: {
+    domesticCountry?: string
+    country?: 'name' | 'code' | 'omit'
+    include?: readonly 'name'[]
+  }
 ): string {
   const street1 = (a.street1 ?? '').trim()
   const street2 = (a.street2 ?? '').trim()
@@ -255,12 +277,14 @@ export function formatAddress(
   const countryCode = (a.country ?? '').trim()
   const isDE = countryCode.toUpperCase() === 'DE'
 
+  const nameLine = opts?.include?.includes('name') ? (a.name ?? '').trim() : ''
+
   const segments = isDE
     ? [street1, street2, [zipCode, city].filter(Boolean).join(' ')]
     : [street1, street2, city, [state, zipCode].filter(Boolean).join(' ')]
 
   const countryText = resolveCountryDisplay(countryCode, opts)
-  const parts = [...segments, countryText].filter((p) => p.trim().length > 0)
+  const parts = [nameLine, ...segments, countryText].filter((p) => p.trim().length > 0)
   return parts.length > 0 ? parts.join(', ') : ''
 }
 
@@ -280,7 +304,12 @@ function resolveCountryDisplay(
   return countryNameFor(countryCode)
 }
 
-/** Flat comma-join of all components — geocoder input, NOT a display formatter. */
+/**
+ * Flat comma-join of the six postal components — geocoder input, NOT a display formatter.
+ *
+ * `name` and `residential` are deliberately excluded and must stay excluded: a person's name
+ * in a MapTiler query degrades the result, and `residential` is not a place.
+ */
 export function formatAddressForGeocode(a: Partial<AddressStructValue>): string {
   return [a.street1, a.street2, a.city, a.state, a.zipCode, a.country]
     .map((p) => (p ?? '').trim())


### PR DESCRIPTION
Step 0 of the ShipStation workflow expansion. **The ShipStation app PR ([auxxai-apps](https://github.com/Auxx-Ai/auxxai-apps)) depends on this one** — it uses `Workflow.address()` for ship-to and ship-from.

## Why

The platform already had an address type end to end: `BaseType.ADDRESS` in the engine, a real `AddressInput` with paste-parse and geocoder normalisation, and native workflow nodes reaching it. The app SDK was the only layer without one, so an app that wanted a ship-to address had to flatten it into six string inputs.

## Three changes

### 1. `Workflow.address()` in the SDK

A `WorkflowAddressNode` plus the mapper cases resolving it to the existing render path.

Getting the field's *options* to the component turned out to be a **six link chain**, four links of which were silently dropping `addressComponents` and `inputMode`:

| Link | Was |
| --- | --- |
| `workflow-block-loader.ts` | flattens `_metadata`, copies `multi`/`canAdd`/`canManage`, not these |
| `packages/sdk/src/runtime/workflow.ts` (iframe twin, 3 sites) | same omission |
| `WorkflowBlockField` | no such keys |
| `var-input.tsx` | never read them off the schema |
| `getSpecificPropsForType(ADDRESS)` | returned `{}` |
| `AddressInput` | gated single mode on a `fieldType` the workflow editor never passes |

Fixing only the last three would still have failed, because the loader had already discarded the values before anything looked for them.

⚠️ **`mapFieldToVarEditorProps` ends in a `default:` returning `BaseType.STRING`.** An app using `Workflow.address()` against a web build without the mapper case renders a plain text box **and no error**. The SDK and web halves have to ship together, and a green typecheck is not evidence either way.

### 2. Two optional keys on `AddressStruct`: `name` and `residential`

Carriers require both, a geocoder cannot tell you the second, and it drives a real surcharge. Deliberately **not** `phone`, `email` or `company` — contact data belongs next to the address, not inside it.

The closed `addressStructJson` schema is the load-bearing part: it is not `.passthrough()`, and its own comment warns keys outside it are dropped before reaching storage or the post-write hook, so both keys had to be added there or they would vanish with no error.

Three places deliberately stay at the original six keys:
- `formatAddressForGeocode` — a name in a geocoder query degrades the result
- `ADDRESS_COMPONENT_KEYS` in the normalize hook — a name in the idempotence hash would re-geocode on every rename
- `mergeAddress` — cannot reach them

`formatAddress` gains an opt-in `include` rather than changing shape, because its default output renders in dispatch notifications, digests, the route planner and timeline chips. A test pins the default byte-identical.

### 3. `addressComponents` now actually works

It has been declared, stored, validated, carried into deployments and editable in a checkbox UI for months **with no renderer reading it**. An admin could untick "Apartment/Suite" and nothing happened.

🛑 **Honoring it naively would have been a regression, not a fix.** Five registry fields already ship a stored value, all the same literal:

```
options: { addressComponents: ['street', 'city', 'state', 'country'] }
```

`{order,work-order,purchase-order,service-request,company}-fields.ts`. That predates the editor's id set: it says `street` where the real id is `street1`, and omits `street2` and `zipCode` entirely. Turning the option on literally would have **dropped the street and ZIP lines from every order, work order, purchase order, service request and company address in every org** — silently, and on read, so no write would look wrong.

The resolver now treats a list containing `street` as un-configured and falls back to the defaults, so those five behave exactly as before. **Correcting the literals needs an entity migration stamp and is still owed; until then this guard is load-bearing and must not be removed as dead defensive code.**

The general lesson: an option no renderer reads has never been validated by use, so stored values for it are unconstrained. Grep for what is already stored before honoring a dormant option. "Absent means default" is only a safety argument when absent is actually the common case.

## Verification

| Check | Result |
| --- | --- |
| `typecheck-ratchet --package web` | 0 new errors |
| sdk vitest | 93 passed |
| utils address | 50 passed |
| lib field-values / custom-fields / geocoding | 578 passed |
| web fields | 151 passed |

The two pass-through fixes were **mutation-tested**: reverting either one fails 3 of 7 tests, so they are not vacuously green.

## Reviewer notes

- Legacy plain-text `ADDRESS` is untouched, per decision #9 of `plans/address-field/01-single-input-address-field.md`. `AddressInput` gates on `fieldType === undefined || isAddressStruct`, and `undefined` means the workflow editor and nothing else.
- This reverses **decision #1** of that plan ("AddressStruct stays canonical, unchanged keys"). Decisions #6/#7 already bent it by adding `raw`/`lat`/`lng`/`geocodedAt`. That plan should get a dated pointer here.
- `packages/sdk/src/runtime/workflow.ts` is the iframe twin of `workflow-block-loader.ts`; they must change together or a field option works in one host and vanishes in the other.

https://claude.ai/code/session_01RSECMTQcECNELCG4fgmiAd
