### PR TITLE
fix(apps): tell an app its settings changed, and stop guessing which installation

### DIFF
--- a/apps/web/src/components/apps/ui/app-settings.tsx
+++ b/apps/web/src/components/apps/ui/app-settings.tsx
@@ -11,6 +11,7 @@ import {
 } from '@auxx/ui/components/empty'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { SlidersHorizontal } from 'lucide-react'
+import { useOptionalMessageClient } from '~/components/apps/runtime/hooks/use-optional-message-client'
 import { api } from '~/trpc/react'
 import { SettingsFormRenderer } from './settings-form-renderer'
 
@@ -34,9 +35,35 @@ export default function AppSettings({
   currentSettings,
   schema,
 }: AppSettingsProps) {
+  // The app's runtime iframe, if one is already up. Pooled per installation in
+  // `AppStore`, so it commonly outlives the page the user is on.
+  const { messageClient } = useOptionalMessageClient({
+    appId: app?.app?.id,
+    appInstallationId: app?.installation?.id,
+  })
+
   const saveSettings = api.apps.saveSettings.useMutation({
     onSuccess: () => {
       toastSuccess({ title: 'Settings saved successfully' })
+
+      // Tell the app its settings moved, so anything it derived from them can be
+      // re-read. The app runtime iframe is long-lived and pooled per
+      // installation, so module state inside an app survives navigation around
+      // the host: without this an app caching anything settings-derived serves a
+      // stale answer until a full page reload. That shipped once already, as a
+      // workflow panel still offering read-only operations after writes were
+      // enabled.
+      //
+      // Fire-and-forget on purpose. No iframe running means nothing to
+      // invalidate, because the app will read settings fresh when it next
+      // starts, and a failed notification must never fail a save that already
+      // committed.
+      void messageClient
+        ?.sendRequest('host-event', {
+          name: 'settings-changed',
+          payload: { installationType },
+        })
+        .catch(() => {})
     },
     onError: (error) => {
       toastError({

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.test.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.test.tsx
@@ -124,3 +124,80 @@ describe('AddressInput fieldType branching', () => {
     expect(structProps).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * The options tests above all render with an EMPTY value, which is how a real
+ * bug shipped green: `parseAddressValue` rebuilds the struct from scratch on
+ * every render, and it listed only the original six keys. `name` and
+ * `residential` were therefore deleted on the render following any edit.
+ *
+ * It presented to the user as "the residential picker will not move off
+ * unknown" rather than as data loss, because the select falls back to
+ * `'unknown'` when the key is missing. Nothing about it was visible to a
+ * typecheck, and no options test could have caught it.
+ */
+describe('the stored value survives the round trip', () => {
+  function renderWithValue(value: Record<string, unknown>, inputMode = 'structured') {
+    const { fieldOptions } = mapFieldToVarEditorProps({ type: 'address', inputMode })
+    const specificProps = getSpecificPropsForType(BaseType.ADDRESS, { fieldOptions })
+    const onChange = vi.fn()
+    const view = render(
+      <AddressInput
+        inputs={{ _value: value }}
+        errors={{}}
+        onChange={onChange}
+        onError={vi.fn()}
+        name='_value'
+        {...specificProps}
+      />
+    )
+    return { onChange, view, specificProps }
+  }
+
+  it('carries name and residential into the structured editor', () => {
+    renderWithValue({ street1: '1 Example St', name: 'Jane Roe', residential: 'yes' })
+
+    const { value } = structProps.mock.calls[0]![0] as { value: Record<string, unknown> }
+    expect(value.name).toBe('Jane Roe')
+    expect(value.residential).toBe('yes')
+    expect(value.street1).toBe('1 Example St')
+  })
+
+  it('carries them into the single-input editor too', () => {
+    renderWithValue({ city: 'Austin', name: 'Jane Roe', residential: 'no' }, 'single')
+
+    const { value } = singleProps.mock.calls[0]![0] as { value: Record<string, unknown> }
+    expect(value.name).toBe('Jane Roe')
+    expect(value.residential).toBe('no')
+  })
+
+  it('keeps residential across a re-render, which is the bug that shipped', () => {
+    const { onChange, view, specificProps } = renderWithValue({ street1: '1 Example St' })
+
+    // What the child does when the picker moves off "unknown".
+    const stored = { street1: '1 Example St', residential: 'yes' }
+    onChange('_value', stored)
+
+    view.rerender(
+      <AddressInput
+        inputs={{ _value: stored }}
+        errors={{}}
+        onChange={onChange}
+        onError={vi.fn()}
+        name='_value'
+        {...specificProps}
+      />
+    )
+
+    const last = structProps.mock.calls.at(-1)![0] as { value: Record<string, unknown> }
+    expect(last.value.residential).toBe('yes')
+  })
+
+  it('treats an unrecognised residential as unanswered, never as commercial', () => {
+    // `'no'` suppresses a carrier surcharge, so a junk value must not become one.
+    renderWithValue({ street1: '1 Example St', residential: 'Residential' })
+
+    const { value } = structProps.mock.calls[0]![0] as { value: Record<string, unknown> }
+    expect(value.residential).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/address-input.tsx
@@ -31,22 +31,49 @@ interface AddressInputProps extends NodeInputProps {
   fieldType?: string
 }
 
+/** The residential indicator's three real states. Anything else is not an answer. */
+const RESIDENTIAL_VALUES = new Set(['unknown', 'yes', 'no'])
+
 /**
- * Parse raw value to AddressStruct
+ * Parse raw value to AddressStruct.
+ *
+ * 🛑 Every key the struct carries must be listed here. This rebuilds the object
+ * from scratch on EVERY render, so a key that is missing is not merely absent
+ * from the parse, it is actively deleted from the value the editor round-trips:
+ * the child writes it, `onChange` stores it, the next render strips it, and the
+ * control snaps back to its default. `name` and `residential` were dropped that
+ * way, which presented as a residential picker that could not be moved off
+ * "unknown" rather than as anything that looked like data loss.
+ *
+ * `street2` is the reason the six are spread rather than defaulted to `''`
+ * individually: the child components treat `undefined` and `''` alike, but the
+ * enum cannot, so `residential` is validated instead of coerced. An unrecognised
+ * stored value becomes `undefined` (ask again), never `'no'` (a commercial
+ * claim that suppresses a carrier surcharge).
  */
 function parseAddressValue(value: unknown): AddressStruct {
   const initial = (typeof value === 'object' && value !== null ? value : {}) as Record<
     string,
-    string
+    unknown
   >
+  const residential = initial.residential
   return {
-    street1: initial.street1 ?? '',
-    street2: initial.street2 ?? '',
-    city: initial.city ?? '',
-    state: initial.state ?? '',
-    zipCode: initial.zipCode ?? '',
-    country: initial.country ?? '',
+    street1: asText(initial.street1),
+    street2: asText(initial.street2),
+    city: asText(initial.city),
+    state: asText(initial.state),
+    zipCode: asText(initial.zipCode),
+    country: asText(initial.country),
+    name: asText(initial.name),
+    residential:
+      typeof residential === 'string' && RESIDENTIAL_VALUES.has(residential)
+        ? (residential as AddressStruct['residential'])
+        : undefined,
   }
+}
+
+function asText(value: unknown): string {
+  return typeof value === 'string' ? value : ''
 }
 
 /**

--- a/packages/lib/src/apps/get-app-details.ts
+++ b/packages/lib/src/apps/get-app-details.ts
@@ -152,8 +152,28 @@ export async function getAppWithInstallationStatus(
     orderBy: (d, { desc }) => [desc(d.createdAt)],
   })
 
-  // Query installation status
-  const installation = await db.query.AppInstallation.findFirst({
+  // Query installation status.
+  //
+  // 🛑 `findMany` + an explicit pick, NOT `findFirst`. An org can hold TWO live
+  // installations of one app at once — `auxx dev` / `pnpm sync-dev` creates a
+  // `development` one and `auxx version create --publish` a `production` one —
+  // and an unordered `findFirst` returns whichever row the database happens to
+  // hand back. That is not merely arbitrary, it is unstable: the same org could
+  // get a different answer between two queries.
+  //
+  // It matters because callers act on `installation.installationType`. The app
+  // settings page saves to it, so with both installations present an admin
+  // could toggle a setting, see it saved, and watch the running app ignore it,
+  // because the save landed on the other installation. That is what happened on
+  // 2026-09-11.
+  //
+  // `production` wins because that is what actually RUNS. The workflow layer
+  // already encodes the same preference in four places
+  // (`app-workflow-node.tsx`, `app-workflow-panel.tsx`, and twice in
+  // `workflow-block-registry.tsx`): production first, any installation as the
+  // fallback. This makes the read path agree with the execution path instead of
+  // silently disagreeing with it.
+  const installations = await db.query.AppInstallation.findMany({
     where: (inst, { and, eq, isNull }) =>
       and(
         eq(inst.organizationId, organizationId),
@@ -161,6 +181,8 @@ export async function getAppWithInstallationStatus(
         isNull(inst.uninstalledAt)
       ),
   })
+  const installation =
+    installations.find((inst) => inst.installationType === 'production') ?? installations[0]
 
   // Access check
   const hasDevDeployments = deployments.some(

--- a/packages/sdk/src/client/host-events.ts
+++ b/packages/sdk/src/client/host-events.ts
@@ -1,0 +1,70 @@
+// packages/sdk/src/client/host-events.ts
+
+import { EventBroker } from '../runtime/event-broker.js'
+
+/**
+ * Notifications the host pushes INTO an app, as opposed to the requests the
+ * host makes of it (`render-component`, `execute-workflow-block`, and the rest
+ * of the internal protocol).
+ *
+ * ## Why the wire is generic and the exports are not
+ *
+ * All of this travels over ONE message type, `host-event`, carrying
+ * `{ name, payload }`. Adding a second kind of notification later is a new
+ * `name` and a new narrow export here; it is not a new wire type, and it needs
+ * no change on the host.
+ *
+ * What is deliberately NOT exported is a raw `onHostEvent(name, cb)`. Every
+ * public API in this SDK is a purpose-built wrapper (`useRecord`, `useWorkflow`,
+ * `toasts`) and `Host` itself is internal, so no app has ever named an internal
+ * message string. Exposing one would mean apps could subscribe to
+ * `render-workflow-panel` or `cleanup-node-render`, and that we could not rename
+ * an internal message without breaking installed apps. Narrowing a published
+ * API later is impossible; widening this one is a one-line addition.
+ */
+
+/** The payload of a `settings-changed` notification. */
+export interface SettingsChangedEvent {
+  /** Which installation's settings moved. An app may have both. */
+  installationType: 'development' | 'production'
+}
+
+const brokers = new Map<string, EventBroker<any>>()
+
+function brokerFor(name: string): EventBroker<any> {
+  const existing = brokers.get(name)
+  if (existing) return existing
+  const created = new EventBroker<any>()
+  brokers.set(name, created)
+  return created
+}
+
+/**
+ * INTERNAL. Called by the platform runtime when a `host-event` arrives; not
+ * exported from `@auxx/sdk/client`.
+ */
+export function dispatchHostEvent(name: string, payload: unknown): void {
+  brokers.get(name)?.trigger(payload)
+}
+
+/**
+ * Subscribe to this app's settings being saved. Returns an unsubscribe function.
+ *
+ * The reason this exists: the app runtime iframe is long-lived and pooled per
+ * installation (`AppStore._messageClients`), so module state inside an app
+ * survives navigation around the host. An app that caches anything derived from
+ * its settings will therefore serve a stale answer until a full page reload.
+ * That is not hypothetical; it shipped, as a workflow panel that kept offering
+ * read-only operations after an admin had enabled writes.
+ *
+ * Treat it as a cache-invalidation signal, not as a source of truth: it tells
+ * you settings changed, not what they now are. Re-read them.
+ *
+ * @example
+ * ```typescript
+ * useEffect(() => onSettingsChanged(() => { cached = null; refetch() }), [])
+ * ```
+ */
+export function onSettingsChanged(callback: (event: SettingsChangedEvent) => void): () => void {
+  return brokerFor('settings-changed').addListener(callback)
+}

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -16,6 +16,10 @@ export * from './dialogs.js'
 export * from './forms/index.js'
 // Hooks
 export * from './hooks/index.js'
+export type { SettingsChangedEvent } from './host-events.js'
+// Host notifications. Only `onSettingsChanged` is public: `dispatchHostEvent`
+// is the runtime's entry point and must not become app-facing surface.
+export { onSettingsChanged } from './host-events.js'
 export * from './navigation.js'
 export * from './record-actions.js'
 export * from './toasts.js'

--- a/packages/sdk/src/runtime/index.ts
+++ b/packages/sdk/src/runtime/index.ts
@@ -35,6 +35,7 @@
  */
 
 import React from 'react'
+import { dispatchHostEvent } from '../client/host-events.js'
 import * as ClientSDK from '../client/index.js'
 import * as RootSDK from '../root/index.js'
 import { ExtensionInitError, ExtensionLoadError } from '../shared/errors.js'
@@ -465,6 +466,20 @@ async function main() {
  * @see eventBus - Event handler lookup and invocation
  */
 function setupHostHandlers() {
+  /**
+   * Host notifications pushed INTO the app. One wire type carries all of them;
+   * `dispatchHostEvent` fans out to whichever narrow subscriber API the app
+   * used. See `client/host-events.ts` for why the wire is generic and the
+   * exported surface is not.
+   *
+   * Returns `{ received: true }` rather than nothing so the host can tell a
+   * delivered notification from a runtime that predates this handler.
+   */
+  Host.onRequest('host-event', async ({ name, payload }: { name: string; payload?: unknown }) => {
+    dispatchHostEvent(name, payload)
+    return { received: true }
+  })
+
   // Handle component render requests
   Host.onRequest('render-component', async ({ id }: { id: string }) => {
     try {


### PR DESCRIPTION
Three platform bugs found by exercising the ShipStation block in a browser after #2128. **Two are latent for every app**, not just that one. Pairs with [auxxai-apps#79](https://github.com/Auxx-Ai/auxxai-apps/pull/79).

## 1. An app never learned its settings changed

`AppStore._messageClients` pools one hidden iframe per installation on `document.body`, torn down only by `message-client-wrapper`. So **an app's module state survives navigation around the host**. An admin enabling a setting and walking back to the workflow saw the old value until a full page reload, because the app had cached it and nothing could tell it otherwise.

Adds a host-to-app notification: one generic `host-event` wire carrying `{ name, payload }`, fanned out through an `EventBroker`, with exactly one public export — `onSettingsChanged`.

**A raw `onHostEvent(name, cb)` was considered and rejected.** `Host` is deliberately internal here, and no public API in this SDK names a wire string — every one is a purpose-built wrapper (`useRecord`, `useWorkflow`, `toasts`). Exposing a generic subscriber would let apps subscribe to `render-workflow-panel` or `cleanup-node-render`, and would freeze all 13 internal message names as public contract. Adding `onConnectionChanged` later is a one-line export over the same wire with no host change. Narrowing a published API later is not possible.

## 2. The settings page edited an arbitrary installation

```ts
// before
const installation = await db.query.AppInstallation.findFirst({
  where: and(orgId, appId, isNull(uninstalledAt)),   // no orderBy, no type filter
})
```

An org can hold **two** live installations of one app — `pnpm sync-dev` creates `development`, `auxx version create --publish` creates `production`. This returned whichever row the database handed back: not merely arbitrary, but unstable between queries.

Callers act on `installation.installationType`, and the settings page saves to it. With both present an admin could toggle a setting, watch it save, and watch the running app ignore it — because the write landed on the other installation. That happened on a live org today, and it convincingly masqueraded as bug 1.

The workflow layer already had a deterministic answer in **four** places (`app-workflow-node.tsx`, `app-workflow-panel.tsx`, `workflow-block-registry.tsx` ×2): production first, any as fallback, because production is what runs. The read path now agrees with the execution path instead of silently disagreeing.

## 3. `AddressStruct`'s two newest keys were deleted on every render

`parseAddressValue` in the workflow `AddressInput` rebuilds the struct from scratch and still listed only the original six keys, so `name` and `residential` were stripped on the render following any edit: the child wrote the value, the store kept it, the next render threw it away.

It presented as **"the residential picker will not move off unknown"** rather than as anything resembling data loss.

The seven existing tests passed throughout, because every one rendered with `inputs={{ _value: {} }}` — they covered the *options* path and never the *value* path. Four tests now cover the round trip, **mutation-checked**: reverting the fix fails 3 of 11.

An unrecognised stored `residential` now resolves to `undefined`, never `'no'`. `no` is a commercial claim that suppresses a carrier surcharge and must not be guessed.

## ⚠️ For anyone changing SDK client exports

`pnpm build` in the SDK does **not** rebuild the runtime bundle apps load. `@auxx/sdk/client` is externalised at app build time to the `AUXX_CLIENT_EXTENSION_SDK` global, which lives in `platform.<hash>.js`. A new export therefore typechecks, builds and tests green, then fails in the browser with `is not a function` — tearing down the panel a frame after it renders.

Run `pnpm --filter @auxx/api build:platform-runtime`, which builds into `apps/api/public/app-runtime/` **and** rewrites `index.html`'s hash. `apps/api/Dockerfile` already runs it, so deployed environments regenerate it — which is why the tracked `index.html` is deliberately **not** in this PR.

## Verification

| Check | Result |
| --- | --- |
| `typecheck-ratchet --package web` | 0 new errors |
| `typecheck-ratchet --package lib` | no new errors from these files |
| sdk vitest | 93 passed |
| address-input | 11 passed, mutation-checked |

Bugs 1 and 3 were also confirmed fixed in a live browser session.

## Reviewer notes

- The production-first preference now lives in **five** places and can drift. Giving it one home is owed, but the four web call sites work off a React array and this one is a Drizzle query, so it is not a clean extraction as written.
- A settings UI that names the installation it is editing — or refuses to guess when both exist — is the real fix for bug 2. This PR only stops the silent disagreement.
- `onSettingsChanged` is implemented but **not yet proven end to end**: the first attempt to test it toggled the other installation, which is how bug 2 surfaced.

https://claude.ai/code/session_01RSECMTQcECNELCG4fgmiAd
