### PR TITLE
refactor(ui): one Alert for accounting's 30 hand-rolled callouts

### DIFF
--- a/apps/web/src/components/accounting/ui/banking/import/bank-import-batches.tsx
+++ b/apps/web/src/components/accounting/ui/banking/import/bank-import-batches.tsx
@@ -14,6 +14,7 @@
 // that says what to do next.
 
 import type { BankImportBatch, ReverseImportRefusal } from '@auxx/lib/banking'
+import { Alert, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
@@ -88,10 +89,10 @@ export function BankImportBatches({ bankAccountId, currencyCode }: BankImportBat
       <ConfirmDialog />
 
       {refusals.length > 0 && (
-        <div className='mb-3 rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950/40'>
-          <p className='font-medium text-sm'>
+        <Alert variant='warning' className='mb-3'>
+          <AlertTitle>
             {refusals.length} line{refusals.length === 1 ? ' was' : 's were'} kept
-          </p>
+          </AlertTitle>
           <ul className='mt-2 flex flex-col gap-1'>
             {refusals.map((refusal) => (
               <li key={refusal.id} className='text-muted-foreground text-xs'>
@@ -106,7 +107,7 @@ export function BankImportBatches({ bankAccountId, currencyCode }: BankImportBat
               </li>
             ))}
           </ul>
-        </div>
+        </Alert>
       )}
 
       {!batches.isPending && rows.length === 0 ? (

--- a/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/review-drawer.tsx
@@ -8,6 +8,7 @@ import {
   REVIEW_STATUS_LABELS,
 } from '@auxx/lib/banking/review/client'
 import { isRecordId } from '@auxx/lib/resources/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
@@ -222,27 +223,25 @@ export function ReviewDrawer({
                     transaction, so nothing may be coded or matched against it -
                     and if it already posted, that posting has to come out. */}
                   {line.bankStatus === 'void' && (
-                    <div className='flex items-start gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4'>
-                      <Ban className='mt-0.5 size-5 shrink-0 text-destructive' />
-                      <div className='flex min-w-0 flex-1 flex-col gap-1'>
-                        <span className='font-medium'>The bank voided this line</span>
-                        <p className='text-muted-foreground text-xs'>
-                          No money moved, so it cannot be coded or matched. The row is kept as the
-                          record that the bank showed it and withdrew it.
-                        </p>
-                      </div>
+                    <Alert variant='destructive'>
+                      <Ban />
+                      <AlertTitle>The bank voided this line</AlertTitle>
+                      <AlertDescription className='text-xs'>
+                        No money moved, so it cannot be coded or matched. The row is kept as the
+                        record that the bank showed it and withdrew it.
+                      </AlertDescription>
                       {line.glPostingId && (
                         <Button
                           variant='outline'
                           size='sm'
-                          className='shrink-0'
+                          className='mt-2 justify-self-start'
                           loading={undo.isPending}
                           onClick={() => undo.mutate({ id: line.id })}>
                           <Undo2 />
                           Reverse posting
                         </Button>
                       )}
-                    </div>
+                    </Alert>
                   )}
 
                   {settled ? (

--- a/apps/web/src/components/accounting/ui/banking/review/transfer-panel.tsx
+++ b/apps/web/src/components/accounting/ui/banking/review/transfer-panel.tsx
@@ -5,6 +5,7 @@
 import { FieldType } from '@auxx/database/enums'
 import type { BankTransactionRow } from '@auxx/lib/banking/review/client'
 import type { PostResultStatus } from '@auxx/lib/postings/client'
+import { Alert } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { TriangleAlert } from 'lucide-react'
 import { useState } from 'react'
@@ -106,12 +107,10 @@ export function TransferPanel({ line, onDone }: TransferPanelProps) {
       </FieldPanel>
 
       {warnings.map((warning) => (
-        <div
-          key={warning}
-          className='flex items-start gap-2 rounded-lg border border-border bg-muted/40 p-3 text-sm'>
-          <TriangleAlert className='mt-0.5 size-4 shrink-0 text-muted-foreground' />
+        <Alert key={warning} variant='neutral'>
+          <TriangleAlert />
           <span>{warning}</span>
-        </div>
+        </Alert>
       ))}
 
       <EntryBlockers blockers={blockers} />

--- a/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
@@ -251,20 +252,21 @@ export function JournalEntryDrawer({
           <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
             <div className='flex flex-col gap-3 p-3'>
               {!isEditable && (
-                <div className='flex items-center justify-between gap-3 rounded-lg border bg-muted/40 p-3 text-sm'>
-                  <span className='text-muted-foreground'>
+                <Alert variant='neutral'>
+                  <AlertDescription>
                     This entry is {draft.status} and can no longer be edited here.
-                  </span>
+                  </AlertDescription>
                   {draft.glPostingId && (
                     <Button
                       variant='outline'
                       size='sm'
+                      className='mt-2 justify-self-start'
                       onClick={() => draft.glPostingId && onOpenPosting(draft.glPostingId)}>
                       <ExternalLink />
                       View posting
                     </Button>
                   )}
-                </div>
+                </Alert>
               )}
 
               <FieldPanel

--- a/apps/web/src/components/accounting/ui/journal/journal-lines.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-lines.tsx
@@ -4,6 +4,7 @@
 
 import type { ChartAccountRow, CounterpartyType, JournalEntryLine } from '@auxx/lib/postings/client'
 import { parseRecordId, toRecordId } from '@auxx/lib/resources/client'
+import { Alert } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
@@ -783,24 +784,14 @@ export function JournalLinesTotals({
           </span>
         </span>
       </div>
-      <div
-        className={cn(
-          'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm',
-          totals.balanced
-            ? 'border-green-500/40 text-green-700 dark:text-green-400'
-            : 'border-destructive/50 text-destructive'
-        )}>
-        {totals.balanced ? (
-          <CheckCircle2 className='size-4' />
-        ) : (
-          <TriangleAlert className='size-4' />
-        )}
+      <Alert variant={totals.balanced ? 'success' : 'destructive'}>
+        {totals.balanced ? <CheckCircle2 /> : <TriangleAlert />}
         <span>
           {totals.balanced
             ? 'Balanced. Debits equal credits.'
             : `Out of balance by ${formatMinor(totals.differenceMinor, currencyCode)}.`}
         </span>
-      </div>
+      </Alert>
     </div>
   )
 }

--- a/apps/web/src/components/accounting/ui/ledger/books-health.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/books-health.tsx
@@ -7,6 +7,7 @@ import type {
   DuplicateMovementFinding,
   FailedExport,
 } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
@@ -164,24 +165,14 @@ export function FailedExportsBanner({ exports: owed }: FailedExportsBannerProps)
   const pending = owed.filter((row) => row.exportStatus === 'pending')
 
   return (
-    <div
-      className={cn(
-        'flex flex-col gap-3 rounded-xl border p-4',
-        failed.length > 0 ? 'border-amber-500/40 bg-amber-500/5' : 'border-border bg-muted/40'
-      )}>
-      <div className='flex items-center gap-2'>
-        {failed.length > 0 ? (
-          <CircleAlert className='size-4 text-amber-600' />
-        ) : (
-          <Loader className='size-4 text-muted-foreground' />
-        )}
-        <span className='font-medium'>
-          {owed.length} {owed.length === 1 ? 'entry is' : 'entries are'} in your books but not in
-          the accounting system
-        </span>
-      </div>
+    <Alert variant={failed.length > 0 ? 'warning' : 'neutral'}>
+      {failed.length > 0 ? <CircleAlert /> : <Loader />}
+      <AlertTitle className='flex-wrap'>
+        {owed.length} {owed.length === 1 ? 'entry is' : 'entries are'} in your books but not in the
+        accounting system
+      </AlertTitle>
 
-      <div className='flex flex-col gap-2'>
+      <div className='mt-2 flex flex-col gap-2'>
         {[...failed, ...pending].map((row) => (
           <div
             key={row.glPostingId}
@@ -220,7 +211,7 @@ export function FailedExportsBanner({ exports: owed }: FailedExportsBannerProps)
           </div>
         ))}
       </div>
-    </div>
+    </Alert>
   )
 }
 
@@ -269,28 +260,22 @@ export function DuplicateMovementsCard({
       {findings.map((finding) => {
         const key = `${finding.glAccountId}-${finding.amountMinor}-${finding.direction}-${finding.entries[0]?.glPostingId ?? ''}`
         return (
-          <div
-            key={key}
-            className='flex flex-col gap-3 rounded-xl border border-amber-500/40 bg-amber-500/5 p-4'>
-            <div className='flex items-start gap-2'>
-              <TriangleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
-              <div className='flex min-w-0 flex-col gap-1'>
-                <span className='flex flex-wrap items-baseline gap-1 font-medium'>
-                  Possible duplicate
-                  <span className='text-muted-foreground'>-</span>
-                  <AccountLabel
-                    account={{ code: finding.accountCode, name: finding.accountName }}
-                    density='compact'
-                  />
-                </span>
-                <p className='text-sm text-muted-foreground'>
-                  {finding.entries.length} entries move this account by{' '}
-                  {formatMinor(finding.amountMinor, currencyCode)} from different sources.
-                </p>
-              </div>
-            </div>
+          <Alert key={key} variant='warning'>
+            <TriangleAlert />
+            <AlertTitle className='flex-wrap items-baseline'>
+              Possible duplicate
+              <span className='opacity-70'>-</span>
+              <AccountLabel
+                account={{ code: finding.accountCode, name: finding.accountName }}
+                density='compact'
+              />
+            </AlertTitle>
+            <AlertDescription>
+              {finding.entries.length} entries move this account by{' '}
+              {formatMinor(finding.amountMinor, currencyCode)} from different sources.
+            </AlertDescription>
 
-            <div className='flex flex-col gap-1.5'>
+            <div className='mt-2 flex flex-col gap-1.5'>
               {finding.entries.map((entry) => (
                 <button
                   key={entry.glPostingId}
@@ -308,10 +293,10 @@ export function DuplicateMovementsCard({
               ))}
             </div>
 
-            <p className='text-xs text-muted-foreground'>
+            <AlertDescription className='text-xs'>
               Nothing was changed. Reverse one, or delete it in QuickBooks.
-            </p>
-          </div>
+            </AlertDescription>
+          </Alert>
         )
       })}
 

--- a/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
@@ -3,8 +3,8 @@
 'use client'
 
 import type { PostResultStatus } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
-import { cn } from '@auxx/ui/lib/utils'
 import {
   Ban,
   CircleSlash,
@@ -261,14 +261,9 @@ const FALLBACK: BlockerRemedy = {
 }
 
 /** Neutral reads like the rest of the page; only a fault gets the destructive box. */
-const TONE_CLASS: Record<BlockerRemedy['tone'], string> = {
-  neutral: 'border-border bg-muted/40',
-  failure: 'border-destructive/40 bg-destructive/5',
-}
-
-const TONE_ICON_CLASS: Record<BlockerRemedy['tone'], string> = {
-  neutral: 'text-muted-foreground',
-  failure: 'text-destructive',
+const TONE_VARIANT: Record<BlockerRemedy['tone'], 'neutral' | 'destructive'> = {
+  neutral: 'neutral',
+  failure: 'destructive',
 }
 
 interface EntryBlockersProps {
@@ -310,47 +305,52 @@ export function EntryBlockers({
       {blockers.map((blocker) => {
         const remedy = REMEDIES[blocker.status] ?? FALLBACK
         const Icon = remedy.icon
+        const hasAction =
+          (!!remedy.href && !!remedy.actionLabel) ||
+          (remedy.action === 'unlock' && !!onReviewLock) ||
+          (blocker.status === 'period_closed' && !!onPostToNextPeriod) ||
+          (remedy.action === 'next-period' && !!onNextPeriod)
         return (
-          <div
-            key={`${blocker.status}-${blocker.error}`}
-            className={cn(
-              'flex flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-start',
-              TONE_CLASS[remedy.tone]
-            )}>
-            <Icon className={cn('mt-0.5 size-5 shrink-0', TONE_ICON_CLASS[remedy.tone])} />
-            <div className='flex min-w-0 flex-1 flex-col gap-1.5'>
-              <div className='flex flex-wrap items-center gap-2'>
-                <span className='font-medium'>{remedy.title}</span>
-                <span className='font-mono text-xs text-muted-foreground'>{blocker.status}</span>
+          <Alert key={`${blocker.status}-${blocker.error}`} variant={TONE_VARIANT[remedy.tone]}>
+            <Icon />
+            <AlertTitle className='flex-wrap'>
+              {remedy.title}
+              <span className='font-mono text-xs opacity-70'>{blocker.status}</span>
+            </AlertTitle>
+            {/* The server's own text, verbatim: on `account_unmapped` it names
+                every offending role, and on an uncosted movement it names the
+                row. Paraphrasing it here would throw away the only part that
+                identifies what to go and fix. */}
+            <p className='text-sm'>{blocker.error}</p>
+            <AlertDescription className='text-xs'>{remedy.guidance}</AlertDescription>
+            {/* One row, not one grid row each: `period_closed` offers BOTH
+                "review the lock" and "post to the next open period", and as
+                separate Alert children they would stack down the card. */}
+            {hasAction && (
+              <div className='mt-2 flex flex-wrap gap-2'>
+                {remedy.href && remedy.actionLabel && (
+                  <Button asChild variant='outline' size='sm'>
+                    <Link href={remedy.href}>{remedy.actionLabel}</Link>
+                  </Button>
+                )}
+                {remedy.action === 'unlock' && onReviewLock && (
+                  <Button variant='outline' size='sm' onClick={onReviewLock}>
+                    {remedy.actionLabel}
+                  </Button>
+                )}
+                {blocker.status === 'period_closed' && onPostToNextPeriod && (
+                  <Button variant='outline' size='sm' onClick={onPostToNextPeriod}>
+                    Post to the next open period
+                  </Button>
+                )}
+                {remedy.action === 'next-period' && onNextPeriod && (
+                  <Button variant='outline' size='sm' onClick={onNextPeriod}>
+                    {remedy.actionLabel}
+                  </Button>
+                )}
               </div>
-              {/* The server's own text, verbatim: on `account_unmapped` it names
-                  every offending role, and on an uncosted movement it names the
-                  row. Paraphrasing it here would throw away the only part that
-                  identifies what to go and fix. */}
-              <p className='text-sm'>{blocker.error}</p>
-              <p className='text-xs text-muted-foreground'>{remedy.guidance}</p>
-            </div>
-            {remedy.href && remedy.actionLabel && (
-              <Button asChild variant='outline' size='sm' className='shrink-0'>
-                <Link href={remedy.href}>{remedy.actionLabel}</Link>
-              </Button>
             )}
-            {remedy.action === 'unlock' && onReviewLock && (
-              <Button variant='outline' size='sm' className='shrink-0' onClick={onReviewLock}>
-                {remedy.actionLabel}
-              </Button>
-            )}
-            {blocker.status === 'period_closed' && onPostToNextPeriod && (
-              <Button variant='outline' size='sm' className='shrink-0' onClick={onPostToNextPeriod}>
-                Post to the next open period
-              </Button>
-            )}
-            {remedy.action === 'next-period' && onNextPeriod && (
-              <Button variant='outline' size='sm' className='shrink-0' onClick={onNextPeriod}>
-                {remedy.actionLabel}
-              </Button>
-            )}
-          </div>
+          </Alert>
         )
       })}
     </div>

--- a/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
@@ -4,6 +4,7 @@
 
 import type { PostingDetailLine, ResolvedPostingLine } from '@auxx/lib/postings/client'
 import { toRecordId } from '@auxx/lib/resources/client'
+import { Alert } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import {
   Table,
@@ -142,20 +143,14 @@ export function EntryJournal({ lines, currencyCode, onDrillDown }: EntryJournalP
         </TableFooter>
       </Table>
 
-      <div
-        className={cn(
-          'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm',
-          balanced
-            ? 'border-green-500/40 text-green-700 dark:text-green-400'
-            : 'border-destructive/50 text-destructive'
-        )}>
-        {balanced ? <CheckCircle2 className='size-4' /> : <TriangleAlert className='size-4' />}
+      <Alert variant={balanced ? 'success' : 'destructive'}>
+        {balanced ? <CheckCircle2 /> : <TriangleAlert />}
         <span>
           {balanced
             ? 'Balanced. Debits equal credits.'
             : `Out of balance by ${formatMinor(difference, currencyCode)}.`}
         </span>
-      </div>
+      </Alert>
     </div>
   )
 }

--- a/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { type AccountRole, NON_FAILURE_REFUSALS } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { MainPageContent } from '@auxx/ui/components/main-page'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
@@ -409,17 +410,15 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
                   cutoff is still ahead of the wall clock, or one whose period
                   read failed, could not raise an entry at all. */}
               {!activePeriodKey && (
-                <div className='flex items-start gap-3 rounded-xl border bg-muted/40 p-4'>
-                  <CalendarCheck2 className='mt-0.5 size-5 shrink-0 text-muted-foreground' />
-                  <div className='flex flex-col gap-1'>
-                    <span className='font-medium'>No month is open for closing yet</span>
-                    <p className='text-sm text-muted-foreground'>
-                      The first closable month is the one after the accounting cutoff. Nothing on or
-                      before the cutoff belongs to this system. A journal entry can still be raised
-                      below; it posts into whichever month its own date falls in.
-                    </p>
-                  </div>
-                </div>
+                <Alert variant='neutral'>
+                  <CalendarCheck2 />
+                  <AlertTitle>No month is open for closing yet</AlertTitle>
+                  <AlertDescription>
+                    The first closable month is the one after the accounting cutoff. Nothing on or
+                    before the cutoff belongs to this system. A journal entry can still be raised
+                    below; it posts into whichever month its own date falls in.
+                  </AlertDescription>
+                </Alert>
               )}
 
               {(failedExportsQuery.data?.length ?? 0) > 0 && (
@@ -427,16 +426,14 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
               )}
 
               {!!activePeriodKey && !period.hasOpenPeriod && (
-                <div className='flex items-start gap-3 rounded-xl border bg-muted/40 p-4'>
-                  <CalendarCheck2 className='mt-0.5 size-5 shrink-0 text-muted-foreground' />
-                  <div className='flex flex-col gap-1'>
-                    <span className='font-medium'>Nothing to close</span>
-                    <p className='text-sm text-muted-foreground'>
-                      Every month from the cutoff forward has been posted. {periodLabel} is the most
-                      recent, and it is shown below.
-                    </p>
-                  </div>
-                </div>
+                <Alert variant='neutral'>
+                  <CalendarCheck2 />
+                  <AlertTitle>Nothing to close</AlertTitle>
+                  <AlertDescription>
+                    Every month from the cutoff forward has been posted. {periodLabel} is the most
+                    recent, and it is shown below.
+                  </AlertDescription>
+                </Alert>
               )}
 
               {!!activePeriodKey && (

--- a/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/post-result-callout.tsx
@@ -3,8 +3,8 @@
 'use client'
 
 import type { PostResult, PostResultStatus } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
-import { cn } from '@auxx/ui/lib/utils'
 import { CheckCircle2, CircleSlash, ExternalLink, PlugZap, TriangleAlert } from 'lucide-react'
 import type { ComponentType } from 'react'
 
@@ -195,16 +195,16 @@ const OUTCOMES: Record<PostResultStatus, OutcomeCopy> = {
   },
 }
 
-const TONE_CLASS: Record<OutcomeCopy['tone'], string> = {
-  success: 'border-green-500/40 bg-green-500/5',
-  neutral: 'border-border bg-muted/40',
-  failure: 'border-destructive/40 bg-destructive/5',
-}
-
-const TONE_ICON_CLASS: Record<OutcomeCopy['tone'], string> = {
-  success: 'text-green-600 dark:text-green-400',
-  neutral: 'text-muted-foreground',
-  failure: 'text-destructive',
+/**
+ * The tones map onto shared `Alert` variants rather than a local set of border
+ * and text classes, so a posted entry reads as the same kind of object as every
+ * other callout in the app. The variant carries the border, the wash and the
+ * icon color; nothing here restates them.
+ */
+const TONE_VARIANT: Record<OutcomeCopy['tone'], 'success' | 'neutral' | 'destructive'> = {
+  success: 'success',
+  neutral: 'neutral',
+  failure: 'destructive',
 }
 
 interface PostResultCalloutProps {
@@ -251,35 +251,29 @@ export function PostResultCallout({
     : null
 
   return (
-    <div
-      className={cn(
-        'flex flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-start',
-        TONE_CLASS[copy.tone]
-      )}>
-      <Icon className={cn('mt-0.5 size-5 shrink-0', TONE_ICON_CLASS[copy.tone])} />
-      <div className='flex min-w-0 flex-1 flex-col gap-1'>
-        <div className='flex flex-wrap items-center gap-2'>
-          <span className='font-medium'>{copy.title}</span>
-          {result.docNumber && (
-            <span className='font-mono text-xs text-muted-foreground'>{result.docNumber}</span>
-          )}
-        </div>
-        <p className='text-sm text-muted-foreground'>{copy.detail}</p>
-        {result.error && <p className='text-sm'>{result.error}</p>}
-        {result.retryable && (
-          <p className='text-xs text-muted-foreground'>
-            This was a transport failure, so it is worth trying again.
-          </p>
+    <Alert variant={TONE_VARIANT[copy.tone]}>
+      <Icon />
+      <AlertTitle className='flex-wrap'>
+        {copy.title}
+        {result.docNumber && (
+          <span className='font-mono text-xs opacity-70'>{result.docNumber}</span>
         )}
-      </div>
+      </AlertTitle>
+      <AlertDescription>{copy.detail}</AlertDescription>
+      {result.error && <p className='text-sm'>{result.error}</p>}
+      {result.retryable && (
+        <AlertDescription className='text-xs'>
+          This was a transport failure, so it is worth trying again.
+        </AlertDescription>
+      )}
       {entryUrl && (
-        <Button asChild variant='outline' size='sm' className='shrink-0'>
+        <Button asChild variant='outline' size='sm' className='mt-2 justify-self-start'>
           <a href={entryUrl} target='_blank' rel='noreferrer'>
             <ExternalLink />
             Open in {providerLabel}
           </a>
         </Button>
       )}
-    </div>
+    </Alert>
   )
 }

--- a/apps/web/src/components/accounting/ui/ledger/revision-strip.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/revision-strip.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import type { PostingDetail } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { cn } from '@auxx/ui/lib/utils'
@@ -71,15 +72,13 @@ export function RevisionStrip({
   if (!entries || entries.length < 2) return null
 
   return (
-    <div className='flex flex-col gap-2 rounded-xl border bg-muted/30 p-3'>
-      <div className='flex items-center gap-2 text-xs text-muted-foreground'>
-        <History className='size-3.5' />
-        <span>
-          This month was posted more than once. The effective entry is the newest revision; the
-          earlier ones are kept and reversed, never edited.
-        </span>
-      </div>
-      <div className='flex flex-wrap gap-1.5'>
+    <Alert variant='neutral'>
+      <History />
+      <AlertDescription className='text-xs'>
+        This month was posted more than once. The effective entry is the newest revision; the
+        earlier ones are kept and reversed, never edited.
+      </AlertDescription>
+      <div className='mt-2 flex flex-wrap gap-1.5'>
         {entries.map((entry) => (
           <Button
             key={entry.glPostingId}
@@ -104,6 +103,6 @@ export function RevisionStrip({
           </Button>
         ))}
       </div>
-    </div>
+    </Alert>
   )
 }

--- a/apps/web/src/components/accounting/ui/provider-agreement/provider-agreement-table.tsx
+++ b/apps/web/src/components/accounting/ui/provider-agreement/provider-agreement-table.tsx
@@ -18,6 +18,7 @@
 // (§5 to §7), not a statement learning to read a provider.
 
 import type { ProviderAgreement, ProviderAgreementStatus } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import type { BadgeProps } from '@auxx/ui/components/badge'
 import { Badge } from '@auxx/ui/components/badge'
 import { EmptySection } from '@auxx/ui/components/section'
@@ -179,27 +180,21 @@ export function ProviderAgreementTable({
         somebody hunting through the table below for which three.
       */}
       {onlyTheirs.length > 0 && (
-        <div className='flex flex-col gap-2 rounded-xl border border-amber-500/40 bg-amber-500/5 p-4'>
-          <div className='flex items-start gap-2'>
-            <TriangleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
-            <div className='flex min-w-0 flex-col gap-1'>
-              <span className='font-medium'>
-                {onlyTheirs.length === 1
-                  ? 'One account carries a balance only in QuickBooks'
-                  : `${onlyTheirs.length} accounts carry a balance only in QuickBooks`}
-              </span>
-              <p className='text-muted-foreground text-sm'>
-                {onlyTheirs
-                  .map((row) => rowLabel(row.accountName, row.providerAccountId))
-                  .join(', ')}
-                . No account in this chart is mapped to {onlyTheirs.length === 1 ? 'it' : 'them'},
-                so whatever put the balance there was authored in {providerLabel} and this ledger
-                has never seen it. Either the account is simply unmapped, or the work behind it has
-                no counterpart here. Nothing was changed.
-              </p>
-            </div>
-          </div>
-        </div>
+        <Alert variant='warning'>
+          <TriangleAlert />
+          <AlertTitle className='flex-wrap'>
+            {onlyTheirs.length === 1
+              ? 'One account carries a balance only in QuickBooks'
+              : `${onlyTheirs.length} accounts carry a balance only in QuickBooks`}
+          </AlertTitle>
+          <AlertDescription>
+            {onlyTheirs.map((row) => rowLabel(row.accountName, row.providerAccountId)).join(', ')}.
+            No account in this chart is mapped to {onlyTheirs.length === 1 ? 'it' : 'them'}, so
+            whatever put the balance there was authored in {providerLabel} and this ledger has never
+            seen it. Either the account is simply unmapped, or the work behind it has no counterpart
+            here. Nothing was changed.
+          </AlertDescription>
+        </Alert>
       )}
 
       {providerCurrency !== currency && (

--- a/apps/web/src/components/accounting/ui/provider-sync/provider-sync-report.tsx
+++ b/apps/web/src/components/accounting/ui/provider-sync/provider-sync-report.tsx
@@ -26,6 +26,7 @@
 // here names a transaction on the accountant's side; a toast would take that
 // away three seconds later.
 
+import { Alert, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { cn } from '@auxx/ui/lib/utils'
 import { CircleAlert, Coins, Lock, Scale, TriangleAlert } from 'lucide-react'
@@ -94,6 +95,12 @@ export function readSyncedThrough(
   return outcome.syncedThrough < outcome.to ? 'short' : 'complete'
 }
 
+const TONE_VARIANT: Record<'neutral' | 'warn' | 'alarm', 'neutral' | 'warning' | 'destructive'> = {
+  neutral: 'neutral',
+  warn: 'warning',
+  alarm: 'destructive',
+}
+
 /** A bordered block in the section's own vocabulary. `alarm` is only for a fault. */
 function ReportCard({
   tone,
@@ -107,19 +114,13 @@ function ReportCard({
   children: ReactNode
 }) {
   return (
-    <div
-      className={cn(
-        'flex flex-col gap-2 rounded-xl border p-4',
-        tone === 'neutral' && 'border-border bg-muted/40',
-        tone === 'warn' && 'border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-400',
-        tone === 'alarm' && 'border-destructive/40 bg-destructive/5'
-      )}>
-      <div className='flex items-center gap-2'>
-        <span className={cn('shrink-0', tone === 'alarm' && 'text-destructive')}>{icon}</span>
-        <span className='font-medium text-sm'>{title}</span>
-      </div>
+    <Alert variant={TONE_VARIANT[tone]}>
+      {/* A direct child, not nested in the title: the gutter column is opened by
+          `has-[>svg]`, which only sees the Alert's own children. */}
+      {icon}
+      <AlertTitle>{title}</AlertTitle>
       {children}
-    </div>
+    </Alert>
   )
 }
 

--- a/apps/web/src/components/accounting/ui/reports/completeness-banner.tsx
+++ b/apps/web/src/components/accounting/ui/reports/completeness-banner.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { Alert, AlertTitle } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { Info } from 'lucide-react'
 import Link from 'next/link'
@@ -34,12 +35,10 @@ export function CompletenessBanner({ asOf }: CompletenessBannerProps) {
   if (items.length === 0) return null
 
   return (
-    <div className='flex flex-col gap-3 rounded-xl border border-border bg-muted/40 p-4'>
-      <div className='flex items-center gap-2'>
-        <Info className='size-4 text-muted-foreground' />
-        <span className='text-sm font-medium'>Not included in this report</span>
-      </div>
-      <ul className='flex flex-col gap-1.5'>
+    <Alert variant='neutral'>
+      <Info />
+      <AlertTitle>Not included in this report</AlertTitle>
+      <ul className='mt-2 flex flex-col gap-1.5'>
         {items.map((item) => (
           <li key={item.id} className='flex flex-wrap items-center justify-between gap-3 text-sm'>
             <span className='text-muted-foreground'>{item.label}</span>
@@ -49,6 +48,6 @@ export function CompletenessBanner({ asOf }: CompletenessBannerProps) {
           </li>
         ))}
       </ul>
-    </div>
+    </Alert>
   )
 }

--- a/apps/web/src/components/accounting/ui/reports/general-ledger.tsx
+++ b/apps/web/src/components/accounting/ui/reports/general-ledger.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { GENERAL_LEDGER_COLUMNS, toCsvRows } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -243,22 +244,20 @@ function buildTxnDateIndex(
  */
 function TruncatedBanner({ maxLines }: { maxLines?: number }) {
   return (
-    <div className='flex items-start gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4'>
-      <TriangleAlert className='mt-0.5 size-5 shrink-0 text-destructive' />
-      <div className='flex flex-col gap-1'>
-        <span className='font-medium'>{TRUNCATED_HEADLINE}</span>
-        <p className='text-sm'>
-          This range is bigger than one read can return
-          {maxLines ? `, so it stopped at ${maxLines.toLocaleString('en-US')} lines` : ''}. The
-          accounts and figures below are only part of the ledger, and they will not tie to the trial
-          balance for the same range.{' '}
-          <span className='font-medium'>Narrow the range - a month at a time always fits.</span>
-        </p>
-        <p className='text-muted-foreground text-sm'>
-          The CSV and the PDF are still available and carry this same warning as their first row,
-          but neither one is a ledger you can file against until the range fits.
-        </p>
-      </div>
-    </div>
+    <Alert variant='destructive'>
+      <TriangleAlert />
+      <AlertTitle>{TRUNCATED_HEADLINE}</AlertTitle>
+      <p className='text-sm'>
+        This range is bigger than one read can return
+        {maxLines ? `, so it stopped at ${maxLines.toLocaleString('en-US')} lines` : ''}. The
+        accounts and figures below are only part of the ledger, and they will not tie to the trial
+        balance for the same range.{' '}
+        <span className='font-medium'>Narrow the range - a month at a time always fits.</span>
+      </p>
+      <AlertDescription>
+        The CSV and the PDF are still available and carry this same warning as their first row, but
+        neither one is a ledger you can file against until the range fits.
+      </AlertDescription>
+    </Alert>
   )
 }

--- a/apps/web/src/components/accounting/ui/reports/provider-sync-marker.tsx
+++ b/apps/web/src/components/accounting/ui/reports/provider-sync-marker.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import { describeProviderSyncCoverage } from '@auxx/lib/postings/client'
-import { cn } from '@auxx/ui/lib/utils'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { CloudOff, RefreshCw, TriangleAlert } from 'lucide-react'
 import { api } from '~/trpc/react'
 
@@ -72,16 +72,10 @@ export function ProviderSyncMarker({ through }: ProviderSyncMarkerProps) {
   const Icon = reading.coverage === 'never_synced' ? CloudOff : TriangleAlert
 
   return (
-    <div
-      className={cn(
-        'flex flex-col gap-1 rounded-xl border border-amber-500/40 bg-amber-500/5 p-4',
-        'text-amber-700 dark:text-amber-400'
-      )}>
-      <div className='flex items-center gap-2'>
-        <Icon className='size-4' />
-        <span className='text-sm font-medium'>{reading.headline}</span>
-      </div>
-      {reading.detail && <p className='pl-6 text-sm text-muted-foreground'>{reading.detail}</p>}
-    </div>
+    <Alert variant='warning'>
+      <Icon />
+      <AlertTitle>{reading.headline}</AlertTitle>
+      {reading.detail && <AlertDescription>{reading.detail}</AlertDescription>}
+    </Alert>
   )
 }

--- a/apps/web/src/components/accounting/ui/reports/report-error-card.tsx
+++ b/apps/web/src/components/accounting/ui/reports/report-error-card.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { TriangleAlert } from 'lucide-react'
 
 /**
@@ -13,12 +14,10 @@ import { TriangleAlert } from 'lucide-react'
  */
 export function ReportErrorCard({ message }: { message: string }) {
   return (
-    <div className='flex items-start gap-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4'>
-      <TriangleAlert className='mt-0.5 size-5 shrink-0 text-destructive' />
-      <div className='flex flex-col gap-1'>
-        <span className='font-medium'>This report could not be built</span>
-        <p className='text-sm'>{message}</p>
-      </div>
-    </div>
+    <Alert variant='destructive'>
+      <TriangleAlert />
+      <AlertTitle>This report could not be built</AlertTitle>
+      <AlertDescription>{message}</AlertDescription>
+    </Alert>
   )
 }

--- a/apps/web/src/components/accounting/ui/reports/statement-table.tsx
+++ b/apps/web/src/components/accounting/ui/reports/statement-table.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import type { RecordId } from '@auxx/types/resource'
+import { Alert } from '@auxx/ui/components/alert'
 import { CurrencyInput, CurrencyInputField } from '@auxx/ui/components/input-currency'
 import { InputGroup } from '@auxx/ui/components/input-group'
 import { InputSearch } from '@auxx/ui/components/input-search'
@@ -277,19 +278,13 @@ export function StatementTable({
       )}
 
       {verdict && !query && (
-        <div
-          className={cn(
-            'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm',
-            verdict.ok
-              ? 'border-green-500/40 text-green-700 dark:text-green-400'
-              : 'border-destructive/50 text-destructive'
-          )}>
-          {verdict.ok ? <CheckCircle2 className='size-4' /> : <TriangleAlert className='size-4' />}
+        <Alert variant={verdict.ok ? 'success' : 'destructive'}>
+          {verdict.ok ? <CheckCircle2 /> : <TriangleAlert />}
           <span>
             {verdict.label}
             {verdict.detail ? ` ${verdict.detail}` : ''}
           </span>
-        </div>
+        </Alert>
       )}
     </div>
   )

--- a/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/account-map-list.tsx
@@ -48,6 +48,7 @@
 // the refusal.
 
 import { isMappableTo } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Combobox } from '@auxx/ui/components/combobox'
@@ -128,10 +129,10 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
 
   if (accountMap.isError) {
     return (
-      <div className='rounded-xl border border-destructive/40 bg-destructive/5 p-3'>
-        <p className='font-medium text-sm'>Could not read the account map</p>
-        <p className='text-muted-foreground text-xs'>{accountMap.error.message}</p>
-      </div>
+      <Alert variant='destructive'>
+        <AlertTitle>Could not read the account map</AlertTitle>
+        <AlertDescription>{accountMap.error.message}</AlertDescription>
+      </Alert>
     )
   }
 
@@ -184,22 +185,18 @@ export function AccountMapList({ compact = false }: AccountMapListProps) {
       </div>
 
       {broken.length > 0 && (
-        <div className='flex items-start gap-2 rounded-xl border border-destructive/40 bg-destructive/5 p-3'>
-          <TriangleAlert className='mt-0.5 size-4 shrink-0 text-destructive' />
-          <div className='min-w-0'>
-            <p className='font-medium text-sm'>
-              {broken.length} mapping{broken.length === 1 ? '' : 's'} no longer valid
-            </p>
-            <p className='text-muted-foreground text-xs'>
-              {broken.join(', ')}{' '}
-              {broken.length === 1
-                ? 'points at an account that has'
-                : 'point at accounts that have'}{' '}
-              been removed, deactivated or moved to a different section. Every close refuses until{' '}
-              {broken.length === 1 ? 'it is' : 'they are'} re-mapped.
-            </p>
-          </div>
-        </div>
+        <Alert variant='destructive'>
+          <TriangleAlert />
+          <AlertTitle>
+            {broken.length} mapping{broken.length === 1 ? '' : 's'} no longer valid
+          </AlertTitle>
+          <AlertDescription>
+            {broken.join(', ')}{' '}
+            {broken.length === 1 ? 'points at an account that has' : 'point at accounts that have'}{' '}
+            been removed, deactivated or moved to a different section. Every close refuses until{' '}
+            {broken.length === 1 ? 'it is' : 'they are'} re-mapped.
+          </AlertDescription>
+        </Alert>
       )}
 
       {visible.length === 0 ? (

--- a/apps/web/src/components/accounting/ui/settings/bank-account-connect-dialog.tsx
+++ b/apps/web/src/components/accounting/ui/settings/bank-account-connect-dialog.tsx
@@ -21,6 +21,7 @@
 // browser POSTs the result back itself.
 
 import type { BankConnectionStart } from '@auxx/lib/banking/client'
+import { Alert } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -178,20 +179,20 @@ export function BankAccountConnectDialog({
           {phase === 'saving' && <p className='text-muted-foreground'>Setting up the feed…</p>}
 
           {phase === 'empty' && (
-            <div className='flex items-start gap-2 rounded-lg border border-border bg-muted/40 p-3'>
-              <Building2 className='mt-0.5 size-4 shrink-0 text-muted-foreground' />
+            <Alert variant='neutral'>
+              <Building2 />
               <span>
                 No accounts were linked. Nothing was changed. Try again, or add the account by hand
                 and import statements into it.
               </span>
-            </div>
+            </Alert>
           )}
 
           {phase === 'error' && message && (
-            <div className='flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/5 p-3'>
-              <TriangleAlert className='mt-0.5 size-4 shrink-0 text-destructive' />
+            <Alert variant='destructive'>
+              <TriangleAlert />
               <span>{message}</span>
-            </div>
+            </Alert>
           )}
         </div>
 

--- a/apps/web/src/components/accounting/ui/settings/chart-list.tsx
+++ b/apps/web/src/components/accounting/ui/settings/chart-list.tsx
@@ -30,6 +30,7 @@
 // `map.isError`, and with no provider connected at all.
 
 import type { AccountRole, ChartAccountRow, GlAccountTypeValue } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { ButtonSwitch } from '@auxx/ui/components/button-switch'
@@ -310,22 +311,20 @@ export function ChartList({
           close to refuse on exactly these - so it leads the tab rather than
           waiting to be found by selecting the right row. */}
       {map.broken.length > 0 && (
-        <div className='flex items-start gap-2 rounded-xl border border-destructive/40 bg-destructive/5 p-3'>
-          <TriangleAlert className='mt-0.5 size-4 shrink-0 text-destructive' />
-          <div className='min-w-0'>
-            <p className='font-medium text-sm'>
-              {map.broken.length} link{map.broken.length === 1 ? '' : 's'} no longer valid
-            </p>
-            <p className='text-muted-foreground text-xs'>
-              {map.broken.join(', ')}{' '}
-              {map.broken.length === 1
-                ? 'points at an account that has'
-                : 'point at accounts that have'}{' '}
-              been removed, deactivated or moved to a different section. Every close refuses until{' '}
-              {map.broken.length === 1 ? 'it is' : 'they are'} re-linked.
-            </p>
-          </div>
-        </div>
+        <Alert variant='destructive'>
+          <TriangleAlert />
+          <AlertTitle>
+            {map.broken.length} link{map.broken.length === 1 ? '' : 's'} no longer valid
+          </AlertTitle>
+          <AlertDescription>
+            {map.broken.join(', ')}{' '}
+            {map.broken.length === 1
+              ? 'points at an account that has'
+              : 'point at accounts that have'}{' '}
+            been removed, deactivated or moved to a different section. Every close refuses until{' '}
+            {map.broken.length === 1 ? 'it is' : 'they are'} re-linked.
+          </AlertDescription>
+        </Alert>
       )}
 
       {isLoading ? (

--- a/apps/web/src/components/accounting/ui/settings/recurring-template-schedule-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/recurring-template-schedule-editor.tsx
@@ -12,6 +12,7 @@
 // off, and the drawer defers its create to the first edit.
 
 import { describeRecurrence, type RecurrencePattern } from '@auxx/lib/recurrence/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { EmptySection, Section } from '@auxx/ui/components/section'
@@ -173,26 +174,24 @@ export function RecurringTemplateScheduleEditor({
           entry still OWED, not one skipped. The sweep is holding its cursor on
           that occurrence, so nothing is lost while they decide. */}
       {held && (
-        <div className='mt-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50/60 p-3 text-sm dark:border-amber-900 dark:bg-amber-950/30'>
-          <TriangleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
-          <div className='flex flex-col gap-1'>
-            <span className='font-medium'>
-              Waiting on {formatPeriodLabel(held.month)}, which is closed
-            </span>
-            <span className='text-muted-foreground text-xs'>
-              The entry for {held.occurrenceDate} and everything after it is still owed. Reopen the
-              period in Accounting settings and the next sweep generates them; nothing is lost in
-              the meantime.
-            </span>
-          </div>
-        </div>
+        <Alert variant='warning' className='mt-3'>
+          <TriangleAlert />
+          <AlertTitle>Waiting on {formatPeriodLabel(held.month)}, which is closed</AlertTitle>
+          <AlertDescription>
+            The entry for {held.occurrenceDate} and everything after it is still owed. Reopen the
+            period in Accounting settings and the next sweep generates them; nothing is lost in the
+            meantime.
+          </AlertDescription>
+        </Alert>
       )}
 
       {!held && due > 0 && (
-        <div className='mt-3 rounded-lg border bg-muted/40 p-3 text-muted-foreground text-sm'>
-          {due} {due === 1 ? 'entry is' : 'entries are'} due and will be generated on the next
-          nightly sweep.
-        </div>
+        <Alert variant='neutral' className='mt-3'>
+          <AlertDescription>
+            {due} {due === 1 ? 'entry is' : 'entries are'} due and will be generated on the next
+            nightly sweep.
+          </AlertDescription>
+        </Alert>
       )}
     </div>
   )

--- a/apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
+++ b/apps/web/src/components/accounting/ui/settings/role-map-editor.tsx
@@ -23,6 +23,7 @@ import {
   ROLE_ACCOUNT_TYPES,
   type RoleAssignmentRow,
 } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
@@ -146,31 +147,31 @@ export function RoleMapEditor({
       {/* ⚠️ Chosen, then the account vanished. Not the same as unmapped, and the
           only state where a `confirmed` role still refuses a close. */}
       {state !== 'unmapped' && state !== 'unused' && !assignment?.account && (
-        <div className='space-y-1 rounded-xl border border-destructive/40 bg-destructive/5 p-3'>
-          <p className='font-medium text-sm'>The account this role names is gone</p>
-          <p className='text-muted-foreground text-xs'>
+        <Alert variant='destructive'>
+          <AlertTitle>The account this role names is gone</AlertTitle>
+          <AlertDescription>
             It has been archived or deleted since the mapping was made, and a role assignment
             deliberately carries no foreign key. Pick another account below - a close refuses on
             this until you do.
-          </p>
-        </div>
+          </AlertDescription>
+        </Alert>
       )}
 
       {state === 'suggested' && (
-        <div className='space-y-1 rounded-xl border border-amber-500/30 bg-amber-500/5 p-3'>
-          <p className='font-medium text-sm'>Why this was suggested</p>
-          <p className='text-muted-foreground text-xs'>
+        <Alert variant='warning'>
+          <AlertTitle>Why this was suggested</AlertTitle>
+          <AlertDescription>
             The account number and the statement type both match what the seeded default chart
             assigns to this role, and no one has repointed it. That is a guess, not a decision.
             Confirm it by picking it below, so a close is not resting on an assumption nobody made.
-          </p>
-        </div>
+          </AlertDescription>
+        </Alert>
       )}
 
       {isDefaultUnused && state !== 'unused' && (
-        <div className='space-y-1 rounded-xl border p-3'>
-          <p className='font-medium text-sm'>Nothing emits this role today</p>
-          <p className='text-muted-foreground text-xs'>
+        <Alert variant='neutral'>
+          <AlertTitle>Nothing emits this role today</AlertTitle>
+          <AlertDescription>
             {role === 'ppv'
               ? 'Purchase price variance is a report, not a posting. Nothing accumulates in 5090 ' +
                 'during the year, so no builder ever emits this role.'
@@ -178,26 +179,25 @@ export function RoleMapEditor({
                 'to finished goods and never to work in process, so no movement can reach it.'}{' '}
             Marking it unused is the expected choice. A map that demanded every role would block
             every preview on two roles nothing can post to.
-          </p>
-        </div>
+          </AlertDescription>
+        </Alert>
       )}
 
       {state === 'unused' ? (
-        <div className='space-y-2 rounded-xl border p-3'>
-          <p className='text-muted-foreground text-sm'>
-            This role is excused. Previews will not ask for it.
-          </p>
+        <Alert variant='neutral'>
+          <AlertDescription>This role is excused. Previews will not ask for it.</AlertDescription>
           {canControl && (
             <Button
               variant='outline'
               size='sm'
               loading={pending}
+              className='mt-2 justify-self-start'
               onClick={() => onToggleUnused(role)}>
               <RotateCcw />
               Mark used again
             </Button>
           )}
-        </div>
+        </Alert>
       ) : !canControl ? (
         <div className='rounded-xl border p-3'>
           <p className='text-muted-foreground text-xs'>Posts to</p>

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-accounts-page.tsx
@@ -9,6 +9,7 @@ import {
   type ChartPackKey,
   type RoleAssignmentState,
 } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
@@ -223,10 +224,10 @@ export function WizardAccountsPage() {
       {roleMap.isPending || chart.isPending ? (
         <EmptySection loading />
       ) : roleMap.isError ? (
-        <div className='rounded-xl border border-destructive/40 bg-destructive/5 p-3'>
-          <p className='font-medium text-sm'>Could not read the account map</p>
-          <p className='text-muted-foreground text-xs'>{roleMap.error.message}</p>
-        </div>
+        <Alert variant='destructive'>
+          <AlertTitle>Could not read the account map</AlertTitle>
+          <AlertDescription>{roleMap.error.message}</AlertDescription>
+        </Alert>
       ) : (
         <>
           <div className='flex flex-wrap items-center gap-2'>

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-opening-tb-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-opening-tb-page.tsx
@@ -8,6 +8,7 @@ import {
   readSettingMinorUnits,
   summariseOpeningTrialBalance,
 } from '@auxx/lib/postings/client'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { AlertTriangle } from 'lucide-react'
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react'
@@ -311,14 +312,9 @@ function VerdictStrip({
 }) {
   const verdict = openingVerdict(debitMinor, creditMinor, rowCount, currency)
   return (
-    <div
-      className={
-        verdict.ok
-          ? 'flex flex-col gap-0.5 rounded-lg border border-green-500/40 bg-background px-3 py-2 text-green-700 text-sm dark:text-green-400'
-          : 'flex flex-col gap-0.5 rounded-lg border border-destructive/50 bg-background px-3 py-2 text-destructive text-sm'
-      }>
-      <span className='font-medium'>{verdict.label}</span>
-      {verdict.detail && <span className='text-muted-foreground text-xs'>{verdict.detail}</span>}
-    </div>
+    <Alert variant={verdict.ok ? 'success' : 'destructive'} className='bg-background'>
+      <AlertTitle>{verdict.label}</AlertTitle>
+      {verdict.detail && <AlertDescription className='text-xs'>{verdict.detail}</AlertDescription>}
+    </Alert>
   )
 }

--- a/packages/ui/src/components/alert.tsx
+++ b/packages/ui/src/components/alert.tsx
@@ -1,22 +1,43 @@
+// packages/ui/src/components/alert.tsx
+
 import { cn } from '@auxx/ui/lib/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 import type { LucideIcon } from 'lucide-react'
 import type * as React from 'react'
 
+/**
+ * Two columns: the icon, then everything else.
+ *
+ * The icon is a real grid item rather than an absolutely-positioned one, so an
+ * Alert can hold a title, a description AND an action without the action being
+ * dragged into the icon's gutter. `[&>*:not(svg)]:col-start-2` is what keeps a
+ * bare `<div>`, `<span>` or `<Button>` child landing in the content column
+ * without every call site having to say so.
+ *
+ * Content sits at the same x as before the grid (12px padding + 16px icon +
+ * 12px gap = 40px, previously 12px padding + 28px `pl-7`); the icon itself
+ * moves 4px left, onto the padding edge it always should have been on.
+ */
 const alertVariants = cva(
-  'relative w-full items-center rounded-2xl border px-3 py-2 text-sm [&>svg]:absolute [&>svg]:size-4 [&>svg]:left-4 [&>svg]:text-foreground [&>svg~*]:pl-7',
+  'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-2xl border px-3 py-2 text-sm has-[>svg]:grid-cols-[1rem_1fr] has-[>svg]:gap-x-3 [&>*:not(svg)]:col-start-2 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-foreground',
   {
     variants: {
+      // Every tone carries a faint wash of its own color so a destructive and
+      // a warning Alert read as the same kind of object. Only `outline` and
+      // `translucent` opt out, because both exist to sit on a surface that
+      // already has one.
       variant: {
         default: 'bg-background text-foreground',
+        neutral: 'bg-muted/40 text-foreground [&>svg]:text-muted-foreground',
         outline: ' text-muted-foreground hover:bg-muted transition-colors duration-200',
         destructive:
-          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+          'border-destructive/50 bg-destructive/5 text-destructive dark:border-destructive [&>svg]:text-destructive',
         warning:
           'border-yellow-500/50 bg-yellow-50 dark:bg-yellow-950/20 text-yellow-700 dark:text-yellow-500 [&>svg]:text-yellow-600 dark:[&>svg]:text-yellow-500',
-        success: 'border-green-500/50 text-green-500 dark:border-green-500 [&>svg]:text-green-500',
+        success:
+          'border-green-500/50 bg-green-500/5 text-green-700 dark:border-green-500 dark:text-green-400 [&>svg]:text-green-600 dark:[&>svg]:text-green-400',
         good: 'border-good-500/50 bg-good-50 text-good-500 dark:border-good-500 [&>svg]:text-good-500',
-        blue: 'border-blue-500/50 text-blue-500 dark:border-blue-500 [&>svg]:text-blue-500',
+        blue: 'border-blue-500/50 bg-blue-500/5 text-blue-500 dark:border-blue-500 [&>svg]:text-blue-500',
         comparison:
           'border-comparison-200 bg-comparison-100 dark:bg-black/20 text-comparison-500 [&>svg]:text-comparison-500',
         bad: 'border-bad-200 bg-bad-50 dark:bg-black/20 text-bad-500 [&>svg]:text-bad-500',
@@ -39,13 +60,17 @@ const Alert = ({
 const AlertTitle = ({ className, ...props }: React.ComponentProps<'div'>) => (
   <h5
     className={cn(
-      'mb-1 font-medium leading-none tracking-tight flex items-center gap-2 [&>svg]:size-4',
+      'font-medium leading-none tracking-tight flex items-center gap-2 [&>svg]:size-4',
       className
     )}
     {...props}
   />
 )
 
+/**
+ * The body. Inherits the variant's color and drops to 70% so a tone reads as
+ * one block rather than a colored heading with unrelated grey text under it.
+ */
 const AlertDescription = ({ className, ...props }: React.ComponentProps<'div'>) => (
   <div className={cn('text-sm [&_p]:leading-relaxed opacity-70', className)} {...props} />
 )


### PR DESCRIPTION
## Why

Accounting had been building its own callouts. 30 bordered `<div>`s across 25 files, each restating a border colour, a background wash and an icon tint, while exactly one file in the whole subtree imported `Alert`. Three had grown their own tone -> class tables, and two of those were the *same* table under the *same* names (`TONE_CLASS` / `TONE_ICON_CLASS` in both `post-result-callout.tsx` and `entry-blockers.tsx`).

## What changed in `Alert`

`Alert` could not absorb these as it stood. The base was not a flex or grid container at all: it positioned the icon with `[&>svg]:absolute [&>svg]:left-4` and shoved every following sibling over with `[&>svg~*]:pl-7`, so an action button could not sit anywhere but in the icon's gutter.

- **Layout.** The base is now a two-column grid. `[&>*:not(svg)]:col-start-2` keeps the bare `<div>`, `<span>` and `<Button>` children that **37 existing call sites already pass** landing in the content column without each opting in. Content x is unchanged (12px padding + 16px icon + 12px gap = 40px, previously 12px + `pl-7`); the icon moves 4px left onto the padding edge `left-4` never matched.
- **Tones.** `destructive`, `success` and `blue` carried no background while `warning`, `good`, `bad`, `accent` and `comparison` did, which is most of why these never read as one family. All tinted now, plus a `neutral` variant for the `bg-muted/40` case accounting kept hand-rolling.

## Deliberate normalisations

- Detail text moves from `text-xs text-muted-foreground` to `AlertDescription` (`text-sm`, tone-inherited at 70%), matching the other 72 `Alert` sites rather than accounting's local habit.
- Right-aligned actions now sit below the text.
- `success` text goes `green-500` -> `green-700 dark:green-400`; 500 fails contrast on a light background, and 700 is what the accounting code had already chosen independently.
- `AlertTitle` drops `mb-1` in favour of the base's `gap-y-0.5`, tightening title/description by 2px.

## Two sharp edges handled

- **`wizard-opening-tb-page.tsx`'s `VerdictStrip` keeps an explicit `bg-background`.** It renders inside `sticky bottom-0`, so the opaque background is what stops the scrolling trial balance showing through it, and the new variant washes are translucent. This is the one place the tinted-background change would have actively broken something.
- **`EntryBlockers` groups its actions into one flex row** rather than one `Alert` child each. `period_closed` offers both "review the lock" and "post to the next open period", and as separate grid rows they stacked down the card with doubled margins.

## Verification

- `pnpm --filter @auxx/web typecheck` exits 0, no `error TS`.
- Biome clean across all 138 touched/adjacent files.
- Confirmed Tailwind 4 actually compiles the new arbitrary variants rather than dropping them (`:has(>svg)` -> `grid-template-columns: 1rem 1fr`; `&>*:not(svg)` -> `grid-column-start: 2`), and that `:has()` specificity (0,1,1) beats the base `grid-cols-[0_1fr]` (0,1,0).
- Rendered the four most at-risk **existing** compositions in a browser (icon+description, icon+title+description+ul, no-icon, `AlertIcon`+wrapper) plus the converted shapes. The no-icon case correctly collapses its gutter to zero.
- Spot-checked the real ledger page and JE drawer against the dev DB.

## Not in scope

- `books-health.tsx:62` stays as it is: a discrepancy list row, not a callout.
- `AlertIcon` (the 32px boxed variant, 4 sites) still renders *above* its content rather than beside it, because the base was never actually `flex` despite carrying `items-center`. Identical before and after, so pre-existing rather than a regression, but probably not what those pages intend.
- The balance verdict is now three `<Alert>` call sites (`journal-lines`, `entry-journal`, `statement-table`) plus `VerdictStrip` as a fourth spelling. Consistent, but still four copies of one idea.
- `Alert`'s `rounded-2xl` is visibly larger than the `rounded-lg`/`rounded-xl` accounting uses around it. Making accounting uniform with the app has made `Alert` non-uniform within accounting; left alone because changing it touches all 72 call sites.

https://claude.ai/code/session_018AtRa2DR5XkdTjg2fjrPUC
