### PR TITLE
fix(worker): run pending migrations in-process, not through the queue

### DIFF
--- a/apps/worker/src/boot/run-pending-migrations.test.ts
+++ b/apps/worker/src/boot/run-pending-migrations.test.ts
@@ -1,0 +1,81 @@
+// apps/worker/src/boot/run-pending-migrations.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runPendingDataMigrations = vi.fn()
+const info = vi.fn()
+const error = vi.fn()
+
+vi.mock('@auxx/lib/data-migrations', () => ({
+  runPendingDataMigrations: (...args: unknown[]) => runPendingDataMigrations(...args),
+}))
+vi.mock('@auxx/database', () => ({ database: { marker: 'db' } }))
+vi.mock('@auxx/config/client', () => ({
+  getAppVersion: () => ({ version: '0.1.235', sha: 'abc1234', buildTime: null }),
+}))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info, error, warn: vi.fn(), debug: vi.fn() }),
+}))
+
+const { runPendingMigrationsInProcess } = await import('./run-pending-migrations')
+
+/** Let the floating promise inside the function settle. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('runPendingMigrationsInProcess', () => {
+  beforeEach(() => {
+    runPendingDataMigrations.mockReset()
+    info.mockReset()
+    error.mockReset()
+  })
+
+  it('runs the migrations in this process rather than enqueueing a job', async () => {
+    runPendingDataMigrations.mockResolvedValue({ applied: ['151-x'], skipped: [] })
+
+    runPendingMigrationsInProcess()
+    await settle()
+
+    // The point of the whole fix: the runner is CALLED here, with this process's
+    // database handle. A queue dispatch could be answered by the outgoing build.
+    expect(runPendingDataMigrations).toHaveBeenCalledWith({ marker: 'db' })
+  })
+
+  it('does not block the caller', () => {
+    // Boot must not await a long backfill, or a slow migration trips the healthcheck
+    // timeout and fails the deploy.
+    runPendingDataMigrations.mockReturnValue(new Promise(() => {}))
+
+    expect(runPendingMigrationsInProcess()).toBeUndefined()
+  })
+
+  it('stamps the build on both log lines', async () => {
+    runPendingDataMigrations.mockResolvedValue({ applied: [], skipped: ['001-x'] })
+
+    runPendingMigrationsInProcess()
+    await settle()
+
+    // `applied: []` is indistinguishable from a correct no-op unless the log says
+    // which build produced it — that is what the 2026-09-11 incident lacked.
+    for (const call of info.mock.calls) {
+      expect(call[1]).toMatchObject({ build: { version: '0.1.235', sha: 'abc1234' } })
+    }
+    expect(info).toHaveBeenCalledWith(
+      'Boot data-migrations run finished',
+      expect.objectContaining({ summary: { applied: [], skipped: ['001-x'] } })
+    )
+  })
+
+  it('logs a rejection instead of leaving it unhandled', async () => {
+    runPendingDataMigrations.mockRejectedValue(new Error('advisory lock exploded'))
+
+    runPendingMigrationsInProcess()
+    await settle()
+
+    // Nothing awaits the promise, so a missing catch is both invisible AND fatal:
+    // an unhandled rejection takes the worker process down.
+    expect(error).toHaveBeenCalledWith(
+      'Boot data-migrations run failed',
+      expect.objectContaining({ error: 'advisory lock exploded' })
+    )
+  })
+})

--- a/apps/worker/src/boot/run-pending-migrations.ts
+++ b/apps/worker/src/boot/run-pending-migrations.ts
@@ -1,0 +1,52 @@
+// apps/worker/src/boot/run-pending-migrations.ts
+
+import { getAppVersion } from '@auxx/config/client'
+import { database } from '@auxx/database'
+import { runPendingDataMigrations } from '@auxx/lib/data-migrations'
+import { createScopedLogger } from '@auxx/logger'
+
+const logger = createScopedLogger('data-migrations-boot')
+
+/**
+ * Apply pending data migrations IN THIS PROCESS, deliberately not via the queue.
+ *
+ * A rolling deploy runs two builds against one Redis, and BullMQ has no notion of
+ * which build should handle a message. Worse, the boot enqueue used to sit inside
+ * `setupSchedules()` — which runs before `startWorkers()` attaches any consumer and
+ * before the healthcheck binds, so the outgoing container had not even been signalled
+ * to drain and was the ONLY possible consumer. It was not a race the new container
+ * could lose; it was one it could never enter.
+ *
+ * On 2026-09-11 the outgoing 0.1.234 worker answered 0.1.235's boot, found nothing
+ * pending against its own older registry, reported `applied: []` as SUCCESS, and
+ * `removeOnComplete` erased the job. Thirteen migrations stayed pending until a human
+ * noticed.
+ *
+ * Calling the runner here makes the code that applies the migrations and the code that
+ * ships them the same artifact, so the question cannot be decided by timing at all.
+ * `runPendingDataMigrations` takes a Postgres advisory lock, so replicas and the
+ * superadmin panel still dedupe against each other.
+ *
+ * Fire-and-forget on purpose: boot must not block on a long backfill, or a slow
+ * migration trips Railway's healthcheck timeout and fails the deploy. The hourly
+ * `dataMigrationsJob` scheduler is the safety net for a process that dies mid-run.
+ */
+export function runPendingMigrationsInProcess(): void {
+  // `build` is the whole diagnosis when this goes wrong. A run that applies nothing is
+  // indistinguishable from a correct no-op unless the log says which build produced it.
+  const build = getAppVersion()
+  logger.info('Applying pending data migrations in-process', { build })
+
+  void runPendingDataMigrations(database)
+    .then((summary) => {
+      logger.info('Boot data-migrations run finished', { summary, build })
+    })
+    .catch((error: unknown) => {
+      // Nothing awaits this promise, so without the catch a failure is invisible —
+      // and an unhandled rejection would take the worker down with it.
+      logger.error('Boot data-migrations run failed', {
+        error: error instanceof Error ? error.message : String(error),
+        build,
+      })
+    })
+}

--- a/apps/worker/src/server.ts
+++ b/apps/worker/src/server.ts
@@ -13,6 +13,7 @@ import { serve } from '@hono/node-server'
 import type { Worker } from 'bullmq'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import { runPendingMigrationsInProcess } from './boot/run-pending-migrations'
 import { type InboundEmailPoller, startInboundEmailPoller } from './inbound-email'
 import { devInboundEmailRoutes } from './inbound-email/dev-inbound-email'
 /**
@@ -44,6 +45,10 @@ async function initializeApp() {
   // Assign the result to the outer scope variable
   workersInstance = await startWorkers()
   console.log('Workers started.')
+
+  // AFTER the workers are up, so a migration that enqueues follow-up work has a
+  // consumer, and never before — see `runPendingMigrationsInProcess`.
+  runPendingMigrationsInProcess()
 
   inboundEmailPoller = startInboundEmailPoller()
   console.log(`Inbound email poller ${inboundEmailPoller ? 'started' : 'disabled'}.`)

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -2,7 +2,6 @@ import { constants } from '@auxx/config'
 import { database } from '@auxx/database'
 import { isSelfHosted } from '@auxx/deployment'
 import { reconcileConnectorSchedulers } from '@auxx/lib/data-connectors'
-import { enqueueDataMigrationsRun } from '@auxx/lib/jobs'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
 import { reconcileSourceSchedulers } from '@auxx/lib/knowledge-sources'
 import { startAiAgentWorker } from './worker-definitions/ai-agent-worker'
@@ -1254,11 +1253,19 @@ export async function setupSchedules() {
   await reconcileConnectorSchedulers(database)
 
   // ── Data Migrations ──────────────────────────────────────────
-  // Enqueue a one-shot pending-data-migrations run at boot (NOT a repeatable
-  // scheduler). Boot never blocks on it; exactly-once across replicas/services is
-  // enforced by the advisory lock + ledger inside the runner. Replaces the local
-  // "Run Entity Migrations" button habit in dev too.
-  await enqueueDataMigrationsRun()
+  // Hourly safety net, NOT the primary trigger. The primary trigger is the
+  // in-process call in `server.ts` right after this process's workers start —
+  // see `runPendingMigrationsInProcess` there for why it may not be a queue job.
+  //
+  // This scheduler catches what that call cannot: a container that died mid-run,
+  // a boot that raced a Redis outage, or a panel click delivered to a draining
+  // container. An idle tick is one advisory-lock acquire plus one SELECT over the
+  // ledger, so the cadence is free.
+  await maintenanceQueue.upsertJobScheduler(
+    'dataMigrationsJob',
+    { pattern: '0 * * * *' },
+    { data: {}, opts: { attempts: 1, priority: 5 } }
+  )
 }
 
 //   // Every 10 minutes

--- a/packages/lib/src/jobs/maintenance/data-migrations-job.ts
+++ b/packages/lib/src/jobs/maintenance/data-migrations-job.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/jobs/maintenance/data-migrations-job.ts
 
+import { getAppVersion } from '@auxx/config/client'
 import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { RunSummary } from '../../data-migrations'
@@ -12,24 +13,43 @@ const logger = createScopedLogger('data-migrations-job')
 const DATA_MIGRATIONS_JOB_ID = 'data-migrations-run'
 
 /**
- * Maintenance job that applies all pending data migrations. Enqueued at worker boot
- * and from the superadmin panel; exactly-once is enforced by the advisory lock + ledger
- * inside the runner, not by the queue. `attempts: 1` — a failed migration is recorded
- * and re-run is a deliberate action, never an auto-retry.
+ * Maintenance job that applies all pending data migrations. Two callers: the hourly
+ * scheduler registered in `setupSchedules`, and the superadmin panel. Exactly-once is
+ * enforced by the advisory lock + ledger inside the runner, not by the queue.
+ * `attempts: 1` — a failed migration is recorded and re-run is a deliberate action,
+ * never an auto-retry.
+ *
+ * ⚠️ This is the SAFETY NET, not the primary trigger. A queue is the wrong delivery
+ * mechanism for "apply the migrations this build ships": during a rolling deploy two
+ * builds consume one Redis, and the outgoing one will happily run this against its own
+ * older registry and report `applied: []` as success. The primary trigger is the
+ * in-process call in `apps/worker/src/server.ts` for exactly that reason.
  */
 export async function dataMigrationsJob(
   ctx: JobContext
 ): Promise<RunSummary | { skipped: 'lock-held' }> {
-  logger.info('Running pending data migrations', { jobId: ctx.jobId })
+  // `build` is the whole diagnosis when this goes wrong. A run that applies nothing
+  // is indistinguishable from a correct no-op UNLESS you can see which build produced
+  // it: on 2026-09-11 the outgoing 0.1.234 container answered for 0.1.235's boot and
+  // reported `applied: []` as success, and nothing in the logs said so.
+  const build = getAppVersion()
+  logger.info('Running pending data migrations', { jobId: ctx.jobId, build })
   const summary = await runPendingDataMigrations(db)
-  logger.info('Data migrations job finished', { summary, jobId: ctx.jobId })
+  logger.info('Data migrations job finished', { summary, jobId: ctx.jobId, build })
   return summary
 }
 
 /**
- * Enqueue a data-migrations run on the maintenance queue. `removeOnComplete`/`removeOnFail`
- * drop the job as soon as it settles so a fresh run can always be enqueued later, while
- * the fixed jobId coalesces repeat enqueues during a queued/active run.
+ * Enqueue a data-migrations run on the maintenance queue, for the superadmin panel.
+ *
+ * The fixed jobId coalesces repeat clicks during a queued/active run, and
+ * `removeOnComplete`/`removeOnFail` drop the job the moment it settles so the next
+ * click can enqueue again. Those two settings are a pair: BullMQ treats `add` with an
+ * existing jobId as a no-op, so RETAINING a completed job under this fixed id would
+ * make the panel button work exactly once and then silently do nothing forever.
+ *
+ * That is also why the audit trail lives in the log line (which names the build that
+ * ran it) and in the `DataMigration` ledger, not in a retained job.
  */
 export async function enqueueDataMigrationsRun(): Promise<void> {
   const { getQueue } = await import('../queues')


### PR DESCRIPTION
Follow-up to #2132. Fixes the bug that started all of this: on every release, the migration run enqueued by the **new** worker at boot is executed by the **outgoing** container, against the old code.

## Why it happens

A rolling deploy runs two builds against one Redis, and BullMQ has no notion of which build should handle a message. The boot enqueue sat inside `setupSchedules()` (`workers/index.ts`), which runs **before** `startWorkers()` attaches any consumer and **before** the healthcheck binds — so at the moment of the `add`, the new process had zero consumers and Railway had not even signalled the old container to drain.

It was not a race the new build could lose. It was one it could never enter.

On 2026-09-11 the outgoing `0.1.234` worker answered `0.1.235`'s boot, found nothing pending against its own older registry, reported `applied: []` as **success**, and `removeOnComplete` erased the job. Thirteen migrations stayed pending until someone noticed and pressed the panel button.

## The fix

**Primary trigger: in-process.** `apps/worker/src/boot/run-pending-migrations.ts` calls `runPendingDataMigrations(database)` directly, after this process's workers are up. The code that applies the migrations and the code that ships them become the same artifact, so timing cannot decide it. The advisory lock inside the runner still dedupes replicas and the panel against each other.

Fire-and-forget on purpose: boot must not block on a backfill, or a slow migration trips Railway's `healthcheckTimeout: 120` and fails the deploy. With a `.catch()`, because an unhandled rejection on a floating promise would take the worker down.

**Safety net: hourly scheduler.** The boot `queue.add` becomes `upsertJobScheduler('dataMigrationsJob', { pattern: '0 * * * *' })`, alongside its ~70 neighbours. This catches what the in-process call cannot: a container that died mid-run, a boot that raced a Redis outage, a panel click delivered to a draining container. An idle tick is one advisory-lock acquire plus one `SELECT` over the ledger — measured at ~5ms against 169 rows, and the registry is 10 entries now.

**Evidence: stamp the build.** Both run paths log `getAppVersion()`. `applied: []` is indistinguishable from a correct no-op unless the line says which build produced it, which is exactly what the incident could not be diagnosed from.

## What was deliberately not changed

I had `removeOnComplete: true` → `{ count: 50 }` in an earlier draft and backed it out. Retaining a completed job under the fixed `data-migrations-run` jobId would make the panel button work **once** and then silently do nothing forever, because BullMQ treats `add` with an existing jobId as a no-op. Those two settings are a pair, and the existing comment ("coalesce while one run is queued/active") depends on it.

Also rejected: a version stamp on the job data with re-enqueue on mismatch. Its only unique coverage is a superadmin clicking "run migrations" during a rolling-deploy window, and it needs a delay tuned to drain time plus a bounded retry counter to avoid looping.

## Frequency note

Dev restarts on every file save (`tsx --watch`), so this runs often. That is unchanged from before: `removeOnComplete: true` meant the fixed-jobId coalescing never applied across restarts, so each one already enqueued and ran. The in-process call is marginally cheaper — no Redis round-trip, no job record.

## Verification

- `apps/worker` typecheck clean (0 errors), `lib: no new type errors (27/27 baseline)`
- biome clean
- worker suite 17/17, `src/jobs` + `src/data-migrations` 218/218
- 4 new tests covering: the runner is called in-process with this process's db handle; the caller is not blocked; the build is stamped on both log lines; a rejection is logged rather than left unhandled

https://claude.ai/code/session_013eV9U2zNmtFtz84Q9SJsUX
