### PR TITLE
fix(accounting): one answer to "did the ledger take it", and the wizard stops crying wolf

### DIFF
--- a/apps/web/src/components/accounting/hooks/use-journal-entry-draft.ts
+++ b/apps/web/src/components/accounting/hooks/use-journal-entry-draft.ts
@@ -3,6 +3,7 @@
 'use client'
 
 import type { EntryPreview, PostResult, PostResultStatus } from '@auxx/lib/postings/client'
+import { didLedgerAccept } from '@auxx/lib/postings/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
@@ -11,16 +12,6 @@ import {
   linesFromDraftRows,
 } from '~/components/accounting/ui/journal/journal-lines'
 import { api } from '~/trpc/react'
-
-/** Same set `use-ledger-entry-actions.ts` uses: a `GlPosting` row now exists. */
-const POSTED_STATUSES = new Set<PostResultStatus>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_exported',
-])
 
 export interface UseJournalEntryDraftOptions {
   /** The record id once it exists server-side; `null` only before that. */
@@ -345,7 +336,7 @@ export function useJournalEntryDraft({
               onSuccess: (result) => {
                 setIsPostFlowPending(false)
                 setPostResult(result)
-                if (POSTED_STATUSES.has(result.status) && result.glPostingId) {
+                if (didLedgerAccept(result) && result.glPostingId) {
                   setStatus('posted')
                   setGlPostingId(result.glPostingId)
                   void utils.ledger.listPostings.invalidate()

--- a/apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
+++ b/apps/web/src/components/accounting/hooks/use-ledger-entry-actions.ts
@@ -3,35 +3,10 @@
 'use client'
 
 import type { EntryPreview, PostResult, PostResultStatus } from '@auxx/lib/postings/client'
+import { didLedgerAccept } from '@auxx/lib/postings/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '~/trpc/react'
-
-/**
- * The statuses that mean a `GlPosting` row now exists for the month.
- *
- * 🛑 Six of them, not one. `not_connected`, `disabled` and `not_exported` are
- * first-class successes under decision `P1` - the entry is built, balanced and
- * persisted identically, there is simply nowhere to push it - and
- * `already_posted` and `healed` are converged re-runs. Treating any of the six
- * as a failure is the single most common way this screen could be got wrong.
- *
- * `not_exported` is the newest and the narrowest: the posting TYPE routes to
- * `'none'`, so it never pushes whatever the org has connected. It reaches this
- * screen through a reversal, which inherits its original's posting type.
- *
- * Everything else (`period_closed`, `account_unmapped`, `unbalanced`,
- * `nothing_to_close`, `setup_incomplete`, `error`) wrote nothing, and all six
- * arrive as an ordinary result the callout renders. Only `error` is a fault.
- */
-const POSTED_STATUSES = new Set<PostResultStatus>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_exported',
-])
 
 interface UseLedgerEntryActionsOptions {
   periodKey: string
@@ -165,7 +140,7 @@ export function useLedgerEntryActions({
         // rendered by the callout. Nothing in this branch is an error.
         onSuccess: (result) => {
           setPostResult(result)
-          if (POSTED_STATUSES.has(result.status)) {
+          if (didLedgerAccept(result)) {
             setJustPosted(true)
             refreshBooks()
           }
@@ -185,7 +160,7 @@ export function useLedgerEntryActions({
         {
           onSuccess: (result) => {
             setPostResult(result)
-            if (POSTED_STATUSES.has(result.status)) {
+            if (didLedgerAccept(result)) {
               setJustPosted(false)
               requestedRef.current = null
               refreshBooks()

--- a/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
+import { didLedgerAccept } from '@auxx/lib/postings/client'
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
@@ -36,18 +37,6 @@ import { firstDayOfPeriod, nextOpenPeriodAfter, periodKeyForEntryDate } from './
  * to run edge to edge (see `bank-account-editor.tsx`'s own copy of this).
  */
 const SECTION_BLEED = '-mx-3'
-
-// `not_exported` is here for the opening entry and its reversal: both are
-// `journal_entry` records whose posting type routes to `'none'`, so they never
-// push and always land on it. The set means "a GlPosting row now exists".
-const POSTED_STATUSES = new Set([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_exported',
-])
 
 interface JournalEntryDrawerProps {
   /** The record id, or `null` while `isNew` and the empty draft has not landed yet. */
@@ -159,7 +148,7 @@ export function JournalEntryDrawer({
   }
   if (draft.preview?.blockedBy) {
     blockers.push(draft.preview.blockedBy)
-  } else if (draft.postResult && !POSTED_STATUSES.has(draft.postResult.status)) {
+  } else if (draft.postResult && !didLedgerAccept(draft.postResult)) {
     blockers.push({
       status: draft.postResult.status,
       error: draft.postResult.error ?? 'The post was refused.',

--- a/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-blockers.tsx
@@ -157,6 +157,19 @@ const REMEDIES: Partial<Record<LedgerBlockerStatus, BlockerRemedy>> = {
     guidance:
       'This is not a blocker. The entry is built, balanced and persisted identically with no provider at all.',
   },
+  // 🛑 The third member of the "nothing was pushed, and that is correct" family,
+  // and the one that was missing. `REMEDIES` is `Partial`, so an unlisted status
+  // silently takes `FALLBACK` - which is `failure`-toned and titled "The entry
+  // could not be built". A `'none'`-routed entry (`opening_balance`,
+  // `provider_sync`) rendered THAT over an entry that had posted perfectly.
+  // Neutral, like its two siblings above, and for the same reason.
+  not_exported: {
+    tone: 'neutral',
+    icon: Ban,
+    title: 'This entry is never exported',
+    guidance:
+      'Not a blocker and not a setting. This kind of entry is never pushed to the accounting system, whatever the organization has connected - an opening balance, or an entry that came FROM the provider and must not be handed back at it. It is built, balanced and persisted here.',
+  },
   // ── HANDOFF slot 1B: the two statuses added by 1A's `inventory_role_refused`
   // / `account_invalid` (types.ts, already present per 0B/9a) ────────────────
   inventory_role_refused: {

--- a/apps/web/src/components/accounting/ui/setup-wizard/wizard-done-page.tsx
+++ b/apps/web/src/components/accounting/ui/setup-wizard/wizard-done-page.tsx
@@ -2,7 +2,11 @@
 'use client'
 
 import type { PostResultStatus } from '@auxx/lib/postings/client'
-import { resolveSetupReadiness, SETUP_READINESS_SETTING_KEYS } from '@auxx/lib/postings/client'
+import {
+  didLedgerAccept,
+  resolveSetupReadiness,
+  SETUP_READINESS_SETTING_KEYS,
+} from '@auxx/lib/postings/client'
 import type { SettingKey } from '@auxx/lib/settings/client'
 import { Button } from '@auxx/ui/components/button'
 import { AlertTriangle, Check, PartyPopper } from 'lucide-react'
@@ -130,7 +134,17 @@ export function WizardDonePage({ onFinish }: WizardDonePageProps) {
       const result = await post.mutateAsync({})
       // `postEntry` never throws: a closed period, an account that has left the
       // chart and a provider refusal all arrive as a status the card renders.
-      if (result.status !== 'posted' && result.status !== 'already_posted') {
+      //
+      // 🛑 This MUST be `didLedgerAccept`, not `posted || already_posted`. The
+      // opening entry is `opening_balance`, which `EXPORT_ROUTE_BY_POSTING_TYPE`
+      // routes to `'none'`, so a perfectly good one comes back `not_exported` -
+      // and `EntryBlockers` has no remedy for it, so it fell through to
+      // `FALLBACK` and rendered the red "The entry could not be built" box over
+      // an entry that had posted. Before brief 22 §5 the same entry came back
+      // `not_connected` and rendered "No accounting system is connected" at an
+      // org with QuickBooks connected, which is the bug §5 was written about;
+      // fixing the status moved the lie rather than removing it.
+      if (!didLedgerAccept(result)) {
         setBlockers([
           {
             status: result.status as PostResultStatus,

--- a/apps/web/src/components/money/ui/invoice/write-off-dialog.tsx
+++ b/apps/web/src/components/money/ui/invoice/write-off-dialog.tsx
@@ -9,6 +9,7 @@
 // can be overridden to any expense account in the chart.
 
 import { FieldType } from '@auxx/database/enums'
+import { didLedgerAccept } from '@auxx/lib/postings/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -33,8 +34,6 @@ import { api } from '~/trpc/react'
 
 /** The one role a write-off's debit leg defaults to. See `build-write-off-entry.ts`. */
 const BAD_DEBT_EXPENSE_ROLE = 'bad_debt_expense'
-
-const POSTED_STATUSES = new Set(['posted', 'already_posted', 'not_connected', 'disabled'])
 
 interface WriteOffDialogProps {
   open: boolean
@@ -136,7 +135,7 @@ export function WriteOffDialog({
         reason: reason.trim(),
         expenseGlAccountId: expenseGlAccountId ?? undefined,
       })
-      if (!POSTED_STATUSES.has(result.status)) {
+      if (!didLedgerAccept(result)) {
         // A refusal `postEntry` returns rather than throws (a period locked
         // between preview and submit, say): the invoice was left untouched.
         toastError({

--- a/apps/web/src/components/money/ui/order/fulfill-order-dialog.tsx
+++ b/apps/web/src/components/money/ui/order/fulfill-order-dialog.tsx
@@ -27,6 +27,7 @@
 // task. Only an unexpected mutation failure gets `toastError`.
 
 import { FieldType } from '@auxx/database/enums'
+import { didLedgerAccept } from '@auxx/lib/postings/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -156,7 +157,7 @@ export function FulfillOrderDialog({
       // arrives here as a status, and the shipment has already been rolled back,
       // so the dialog stays open with the refusal on it rather than closing over
       // a fulfillment that did not happen.
-      if (!ACCEPTED_POST_STATUSES.has(result.post.status)) {
+      if (!didLedgerAccept(result.post)) {
         await utils.money.previewFulfillment.invalidate({ orderId })
         return
       }
@@ -176,7 +177,7 @@ export function FulfillOrderDialog({
     if (preview.data?.blockedBy) rows.push(preview.data.blockedBy)
     // A refusal returned by the mutation - the ledger would not take the entry
     // and the shipment was rolled back.
-    if (fulfill.data && !ACCEPTED_POST_STATUSES.has(fulfill.data.post.status)) {
+    if (fulfill.data && !didLedgerAccept(fulfill.data.post)) {
       rows.push({
         status: fulfill.data.post.status,
         error: fulfill.data.post.error ?? 'The ledger refused this fulfillment.',
@@ -323,21 +324,6 @@ export function FulfillOrderDialog({
     </Dialog>
   )
 }
-
-/**
- * The `postEntry` statuses that mean the ledger took the shipment.
- *
- * `not_connected` and `disabled` are successes: an org with no accounting system
- * connected is a first-class case, not a degraded one - the entry is built,
- * balanced and persisted, it is simply never pushed.
- */
-const ACCEPTED_POST_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-])
 
 /** `YYYY-MM-DD` for today, in the browser's own zone. */
 function todayKey(): string {

--- a/apps/web/src/server/api/routers/banking-review.ts
+++ b/apps/web/src/server/api/routers/banking-review.ts
@@ -32,6 +32,7 @@ import {
   undoReview,
 } from '@auxx/lib/banking/review'
 import { PermissionKey } from '@auxx/lib/permissions'
+import { didLedgerAccept, type PostResultStatus } from '@auxx/lib/postings/client'
 import { z } from 'zod'
 import { createTRPCRouter, permissionProcedure } from '~/server/api/trpc'
 
@@ -353,12 +354,15 @@ function toBulkOutcome(
   result: {
     isErr: () => boolean
     error?: Error
-    value?: { post: { status: string; error?: string } | null }
+    value?: { post: { status: PostResultStatus; error?: string } | null }
   }
 ): BulkOutcome {
   if (result.isErr()) return { id, ok: false, message: result.error?.message }
   const post = result.value?.post
-  if (post && post.status !== 'posted' && post.status !== 'already_posted') {
+  // ⚠️ Was `posted || already_posted`, which reported a bulk FAILURE for an org
+  // with no provider connected - the entry was built and persisted, and the row
+  // said it had not been. `didLedgerAccept` is the one answer to that question.
+  if (post && !didLedgerAccept(post)) {
     return { id, ok: false, status: post.status, message: post.error }
   }
   return { id, ok: true, status: post?.status }

--- a/packages/lib/src/banking/review/__tests__/writes.test.ts
+++ b/packages/lib/src/banking/review/__tests__/writes.test.ts
@@ -1009,7 +1009,11 @@ describe('🛑 bank_account_has_posted - the write-once removal gate', () => {
 
   it('is NOT stamped when the ledger refused the post', async () => {
     row()
-    h.postEntry.mockResolvedValue({ status: 'period_locked', error: 'September is closed' })
+    // `period_closed` is the real status; this stub said `period_locked` for a
+    // long time, which is not a member of `PostResultStatus` at all. It passed
+    // either way against a `Set<string>`, and it is what caught `didLedgerAccept`
+    // failing OPEN on an unknown status - see `postings/__tests__/ledger-accepted.test.ts`.
+    h.postEntry.mockResolvedValue({ status: 'period_closed', error: 'September is closed' })
     await codeTransaction(db, {
       organizationId: ORG,
       actorUserId: ACTOR,

--- a/packages/lib/src/banking/review/client.ts
+++ b/packages/lib/src/banking/review/client.ts
@@ -14,6 +14,7 @@
  * poster.
  */
 
+import type { PostResultStatus } from '../../postings/types'
 import { daysBetween } from '../client'
 
 /** What a human has decided about a line. Mirrors `BANK_TRANSACTION_REVIEW_STATUS_OPTIONS`. */
@@ -562,8 +563,21 @@ function closestFirst<T extends { id: string; postedAt: string | null }>(
 /** What a treatment write answers with. */
 export interface ReviewOutcome {
   transaction: BankTransactionRow
-  /** The ledger's answer, or null for the treatments that post nothing (B5). */
-  post: { status: string; error?: string; docNumber?: string; glPostingId?: string } | null
+  /**
+   * The ledger's answer, or null for the treatments that post nothing (B5).
+   *
+   * ⚠️ `status` is the real union, not `string`. It was `string`, and that is
+   * half of why "did the ledger take it?" could be got wrong in silence: a
+   * caller comparing it against a literal that is not a member of the union
+   * typechecks fine and is false forever. Narrowing it here is what makes
+   * `didLedgerAccept` usable on this shape at all.
+   */
+  post: {
+    status: PostResultStatus
+    error?: string
+    docNumber?: string
+    glPostingId?: string
+  } | null
   /** Anything worth saying that is not a refusal - the unmatched transfer leg. */
   warnings: string[]
 }

--- a/packages/lib/src/banking/review/writes.ts
+++ b/packages/lib/src/banking/review/writes.ts
@@ -39,6 +39,7 @@ import { and, eq, isNull } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { BadRequestError, ConflictError, UnprocessableEntityError } from '../../errors'
 import { clearBankDeposit } from '../../money/bank-deposits'
+import { didLedgerAccept } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { postEntry } from '../../postings/post-entry'
 import { reverseEntry } from '../../postings/reverse-entry'
@@ -75,26 +76,6 @@ interface ActorParams {
   actorUserId: string
   transactionId: string
 }
-
-/**
- * The statuses that mean the LEDGER took the entry.
- *
- * 🛑 Since the export split this is the only question a caller here may ask. A
- * refused push returns `posted` with `exportStatus: 'failed'`, so it lands in
- * this set on purpose: the entry is in the books and the document that produced
- * it must stand. Adding an `exportStatus` check to any of these call sites
- * reintroduces the defect - see plans/accounting/export-state-split.md.
- *
- * `not_connected` and `disabled` are in for the older reason: an org with no
- * accounting system is a first-class case, not a degraded one (decision P1).
- */
-const ACCEPTED_POST_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-])
 
 // ── Match ───────────────────────────────────────────────────────────────────
 
@@ -285,7 +266,7 @@ export async function codeTransaction(
         memo: memo ?? line.description ?? `Bank line ${line.externalId ?? transactionId}`,
       })
 
-      if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+      if (!didLedgerAccept(post)) {
         logger.warn('A coded bank line was refused by the ledger', {
           organizationId,
           transactionId,
@@ -514,7 +495,7 @@ export async function transferTransaction(
         memo: memo ?? `Transfer between bank accounts`,
       })
 
-      if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+      if (!didLedgerAccept(post)) {
         return {
           transaction: line,
           post: toPostSummary(post),
@@ -802,7 +783,7 @@ export async function undoReview(
             lock,
             memo: memo ?? `Undo bank review ${line.externalId ?? transactionId}`,
           })
-          if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+          if (!didLedgerAccept(post)) {
             // 🛑 Nothing is unlinked when the reversal was refused. A line back
             // in the queue with a live posting behind it would be coded twice.
             return {

--- a/packages/lib/src/money/bank-deposits/writes.ts
+++ b/packages/lib/src/money/bank-deposits/writes.ts
@@ -48,6 +48,7 @@ import { BadRequestError, ConflictError, UnprocessableEntityError } from '../../
 import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import { ACCOUNT_ROLES, buildEntry } from '../../postings/build-entry'
 import { loadChartAccountsById } from '../../postings/chart-accounts'
+import { isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { LEDGER_CURRENCY, postEntry } from '../../postings/post-entry'
 import type { PostResult } from '../../postings/types'
@@ -75,36 +76,6 @@ import type {
 } from './types'
 
 const logger = createScopedLogger('bank-deposits')
-
-/**
- * The `postEntry` statuses that mean the ledger accepted the deposit.
- *
- * `not_connected` and `disabled` are in the set on purpose: an org with no
- * accounting system connected is a first-class case, not a degraded one
- * (decision P1). The entry is built, balanced and persisted the same way; it is
- * simply never pushed.
- *
- * 🛑 Since the export split, a REFUSED PUSH also lands in this set: `postEntry`
- * returns `posted` with `exportStatus: 'failed'`, because the entry is in the
- * books. That is deliberate and it is the whole fix. This used to be the one
- * path in the codebase that undid a good document because a third party
- * declined a copy of it - the deposit was archived and its payments released
- * while its ledger row sat `failed` and holding the period claim. What reaches
- * `rollbackDeposit` now is only a PRE-CLAIM refusal, which wrote no row at all.
- * See plans/accounting/export-state-split.md.
- */
-const ACCEPTED_POST_STATUSES = new Set([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  // The org has never turned accounting on (task 17 §3). The deposit itself is
-  // real - grouping payments and banking them happens whether or not the org
-  // ever enables the ledger - so this is a success like `not_connected`, not a
-  // refusal to roll back.
-  'not_enabled',
-])
 
 /** `YYYY-MM-DD`, and nothing else. A posting's date is a contract, not a hint. */
 function assertIsoDate(value: string, label: string): void {
@@ -368,7 +339,7 @@ export async function createBankDeposit(
         })
       }
 
-      if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+      if (!isExpectedPostOutcome(post)) {
         await rollbackDeposit(db, organizationId, actorUserId, deposit)
         logger.warn('Bank deposit rolled back - the LEDGER refused the entry', {
           organizationId,

--- a/packages/lib/src/money/credit-memos/writes.ts
+++ b/packages/lib/src/money/credit-memos/writes.ts
@@ -26,6 +26,7 @@ import {
   CREDIT_MEMO_SOURCE_TYPE,
   type CreditMemoSettlement as CreditMemoSettlementLeg,
 } from '../../postings/build-credit-memo-entry'
+import { isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { listPostingsForSource } from '../../postings/list-postings'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { periodKeyForDate } from '../../postings/periods'
@@ -52,29 +53,6 @@ import {
   sumSucceededCreditMemoRefunds,
 } from './reads'
 import { CREDIT_MEMO_STATUS_BYPASS, settleCreditMemo } from './settle'
-
-/**
- * The statuses that mean the LEDGER took the entry. The same set
- * `postInvoiceIssuance` accepts, for the same reasons: a refused EXPORT still
- * returns `posted`, and an org with no accounting system is a first-class case.
- *
- * `not_enabled` is in for the newest reason: an org that has never turned the
- * accounting module on is a first-class case too (task 17 section 3). In
- * practice {@link issueCreditMemo} never reaches this set with `not_enabled` -
- * it short-circuits before the ledger is ever asked - but the value is here so
- * this set stays the complete list decision P1 and task 17 promise.
- */
-const ACCEPTED_POST_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_enabled',
-])
-
-/** The statuses that mean a reversal landed. Same set as `reverseInvoiceIssuance`. */
-const ACCEPTED_REVERSAL_STATUSES = ACCEPTED_POST_STATUSES
 
 const CALENDAR_DAY = /^\d{4}-\d{2}-\d{2}$/
 
@@ -654,7 +632,7 @@ export async function issueCreditMemo(
   } else {
     post = { status: 'not_enabled' }
   }
-  if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+  if (!isExpectedPostOutcome(post)) {
     throw new BadRequestError(
       `This credit memo could not be posted to the general ledger` +
         `${post.error ? `: ${post.error}` : ` (${post.status})`}`,
@@ -759,7 +737,7 @@ export async function voidCreditMemo(db: Database, input: CreditMemoLifecycleInp
         lock,
         memo: `Reversal of ${posting.docNumber} - credit memo ${memo.number} voided`,
       })
-      if (!ACCEPTED_REVERSAL_STATUSES.has(result.status)) {
+      if (!isExpectedPostOutcome(result)) {
         throw new BadRequestError(
           `This credit memo has a general ledger entry (${posting.docNumber}) that could not be ` +
             `reversed${result.error ? `: ${result.error}` : ` (${result.status})`}. Voiding it ` +

--- a/packages/lib/src/money/fulfillment-posting/run.ts
+++ b/packages/lib/src/money/fulfillment-posting/run.ts
@@ -51,6 +51,7 @@ import type { Result } from 'neverthrow'
 import { getOrgCache } from '../../cache'
 import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import { buildFulfillmentBatchEntry } from '../../postings/build-fulfillment-batch-entry'
+import { isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { postEntry } from '../../postings/post-entry'
 import {
@@ -70,28 +71,6 @@ import type {
 } from './types'
 
 const logger = createScopedLogger('money-fulfillment-posting')
-
-/**
- * The `postEntry` statuses that mean the LEDGER took the entry.
- *
- * The same set `money/orders/fulfill.ts` uses, minus `already_posted`: see the
- * file header. `not_connected` and `disabled` stay in, because an org with no
- * accounting provider connected is a first-class case (decision P1) - the entry
- * is built, balanced and persisted identically and simply never pushed, so its
- * shipments are posted and must be stamped.
- *
- * `not_enabled` is in for completeness (task 17 section 3): in practice this
- * run never reaches {@link executeGroup} for an org that has never turned
- * accounting on - {@link runFulfillmentPosting} checks it once, before the
- * plan is even read.
- */
-const POSTED_STATUSES = new Set<string>([
-  'posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_enabled',
-])
 
 /** One progress line per this many groups, so a long run is observable. */
 const PROGRESS_EVERY = 10
@@ -364,7 +343,10 @@ async function executeGroup(
     memo: request.memo ?? `Fulfillments shipped ${group.groupKey}`,
   })
 
-  if (post.status === 'already_posted' || !POSTED_STATUSES.has(post.status)) {
+  // 🛑 `already_posted` is excluded DELIBERATELY and is the one place this
+  // differs from a plain acceptance check: the claim was made by some other
+  // run, so this run must not stamp shipments onto numbers it did not compute.
+  if (post.status === 'already_posted' || !isExpectedPostOutcome(post)) {
     summary.skipped.push({
       groupKey: group.groupKey,
       status: post.status,

--- a/packages/lib/src/money/invoices/post-invoice.ts
+++ b/packages/lib/src/money/invoices/post-invoice.ts
@@ -37,6 +37,7 @@ import {
   INVOICE_ISSUED_POSTING_TYPE,
   INVOICE_SOURCE_TYPE,
 } from '../../postings/build-invoice-entry'
+import { didLedgerAccept, isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { listPostingsForSource } from '../../postings/list-postings'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { periodKeyForDate } from '../../postings/periods'
@@ -47,45 +48,6 @@ import type { PostResult } from '../../postings/types'
 import { getOrganizationSetting } from '../../settings/settings-service'
 
 const logger = createScopedLogger('money-invoice-ledger')
-
-/**
- * The statuses that mean the LEDGER took the entry.
- *
- * 🛑 Since the export split this is the only question a caller here may ask. A
- * refused push returns `posted` with `exportStatus: 'failed'`, so it lands in
- * this set on purpose: the entry is in the books and the document that produced
- * it must stand. Adding an `exportStatus` check to any of these call sites
- * reintroduces the defect - see plans/accounting/export-state-split.md.
- *
- * `not_connected` and `disabled` are in for the older reason: an org with no
- * accounting system is a first-class case, not a degraded one (decision P1).
- *
- * `not_enabled` is in for the newest reason: an org that has never turned the
- * accounting module on is a first-class case too (task 17 section 3).
- */
-const ACCEPTED_POST_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_enabled',
-])
-
-/**
- * The statuses that mean a reversal landed, or had nothing to do.
- *
- * The same set `reversePaymentPostings` uses, and for the same reason: a
- * provider that is not connected or is switched off still leaves OUR ledger
- * correct, which is the half a void has to protect.
- */
-const ACCEPTED_REVERSAL_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-])
 
 const INVOICE_ATTRIBUTES = [
   'invoice_number',
@@ -257,7 +219,7 @@ export async function postInvoiceIssuance(
       memo: `Invoice ${invoice.number} issued`,
     })
 
-    if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+    if (!isExpectedPostOutcome(post)) {
       // 🛑 Recorded, never swallowed. A refusal AFTER the claim writes a
       // `pending`/`failed` `GlPosting` row, which `listFailedExports` reads,
       // so it surfaces on the close console on its own. A refusal BEFORE the
@@ -385,7 +347,7 @@ export async function reverseInvoiceIssuance(
       lock,
       memo: memo ?? `Reversal of ${posting.docNumber} - invoice voided`,
     })
-    if (!ACCEPTED_REVERSAL_STATUSES.has(result.status)) {
+    if (!didLedgerAccept(result)) {
       logger.warn('An invoice issuance entry could not be reversed', {
         organizationId,
         invoiceId,

--- a/packages/lib/src/money/invoices/write-off.ts
+++ b/packages/lib/src/money/invoices/write-off.ts
@@ -28,6 +28,7 @@ import {
   buildWriteOffEntry,
   WRITE_OFF_SOURCE_TYPE,
 } from '../../postings/build-write-off-entry'
+import { isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { periodKeyForDate } from '../../postings/periods'
 import { LEDGER_CURRENCY, postEntry, previewEntry } from '../../postings/post-entry'
@@ -501,13 +502,11 @@ export async function writeOffInvoice(
     })
   }
 
-  const posted =
-    result.status === 'posted' ||
-    result.status === 'already_posted' ||
-    result.status === 'not_connected' ||
-    result.status === 'disabled' ||
-    result.status === 'not_enabled'
-  if (!posted) return result
+  // ⚠️ This list used to be written out here and was missing `healed` AND
+  // `not_exported` - a write-off on a healed claim, or on any posting type that
+  // ever routes to `'none'`, returned before stamping the invoice. The shared
+  // predicate carries both.
+  if (!isExpectedPostOutcome(result)) return result
 
   const remainingBalanceMinor = invoice.outstandingMinor - amount
 

--- a/packages/lib/src/money/orders/fulfill.ts
+++ b/packages/lib/src/money/orders/fulfill.ts
@@ -47,6 +47,7 @@ import {
   computeShipmentTotals,
   type ShipmentTotals,
 } from '../../postings/build-fulfillment-entry'
+import { isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { LEDGER_CURRENCY, postEntry, previewEntry } from '../../postings/post-entry'
 import type { EntryPreview, PostResult } from '../../postings/types'
@@ -69,27 +70,6 @@ import {
 } from './reads'
 
 const logger = createScopedLogger('money-orders')
-
-/**
- * The `postEntry` statuses that mean the ledger accepted the shipment.
- *
- * `not_connected` and `disabled` are in the set on purpose: an org with no
- * accounting system connected is a first-class case, not a degraded one
- * (decision P1). The entry is built, balanced and persisted the same way; it is
- * simply never pushed.
- *
- * `not_enabled` is in for the newest reason: an org that has never turned the
- * accounting module on is a first-class case too, and a shipment must never be
- * rolled back for it (task 17 section 3).
- */
-const ACCEPTED_POST_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_enabled',
-])
 
 /** One line, and how much of it the caller says went out. */
 export interface FulfillOrderLine {
@@ -456,7 +436,7 @@ export async function fulfillOrder(
         post = { status: 'not_enabled' }
       }
 
-      if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+      if (!isExpectedPostOutcome(post)) {
         await rollbackFulfillment(db, organizationId, actorUserId, order, order.nextSequence)
         logger.warn('Fulfillment rolled back - the ledger refused the entry', {
           organizationId,

--- a/packages/lib/src/money/payments/ledger.ts
+++ b/packages/lib/src/money/payments/ledger.ts
@@ -13,6 +13,7 @@ import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from '.
 import { FieldValueService } from '../../field-values/field-value-service'
 import { readFieldScalars } from '../../field-values/read-field-scalars'
 import { extractRelationshipRecordIds } from '../../field-values/relationship-field'
+import { didLedgerAccept } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { reverseEntry } from '../../postings/reverse-entry'
 import { UnifiedCrudHandler } from '../../resources/crud'
@@ -900,21 +901,6 @@ export async function recordManualRefund(
 }
 
 /**
- * The `reverseEntry` statuses that mean the general ledger took the reversal.
- *
- * `not_connected` and `disabled` are successes for the same reason they are in
- * `post-transaction.ts`: an org with no accounting system connected is a
- * first-class case, and the entry is still built, balanced and persisted.
- */
-const ACCEPTED_REVERSAL_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-])
-
-/**
  * Back every general-ledger entry this payment produced out of the books, before
  * the row that produced them is deleted.
  *
@@ -975,7 +961,7 @@ async function reversePaymentPostings(
       lock,
       memo: `Reversal of ${posting.docNumber} - payment ${transactionId} deleted`,
     })
-    if (!ACCEPTED_REVERSAL_STATUSES.has(result.status)) {
+    if (!didLedgerAccept(result)) {
       throw new ConflictError(
         `Payment ${transactionId} posted general ledger entry ${posting.docNumber}, and that ` +
           `entry could not be reversed (${result.status}${result.error ? `: ${result.error}` : ''}). ` +

--- a/packages/lib/src/money/payments/post-deposit-application.ts
+++ b/packages/lib/src/money/payments/post-deposit-application.ts
@@ -57,6 +57,7 @@ import {
   depositApplicationPeriodKey,
 } from '../../postings/build-deposit-application-entry'
 import { ACCOUNT_ROLES } from '../../postings/build-entry'
+import { isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { periodKeyForDate } from '../../postings/periods'
 import { postEntry } from '../../postings/post-entry'
@@ -65,30 +66,6 @@ import type { PostResult } from '../../postings/types'
 import { getOrganizationSetting } from '../../settings/settings-service'
 
 const logger = createScopedLogger('money-payments-ledger')
-
-/**
- * The statuses that mean the LEDGER took the entry.
- *
- * 🛑 Since the export split this is the only question a caller here may ask. A
- * refused push returns `posted` with `exportStatus: 'failed'`, so it lands in
- * this set on purpose: the entry is in the books and the document that produced
- * it must stand. Adding an `exportStatus` check to any of these call sites
- * reintroduces the defect - see plans/accounting/export-state-split.md.
- *
- * `not_connected` and `disabled` are in for the older reason: an org with no
- * accounting system is a first-class case, not a degraded one (decision P1).
- *
- * `not_enabled` is in for the newest reason: an org that has never turned the
- * accounting module on is a first-class case too (task 17 section 3).
- */
-const ACCEPTED_POST_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_enabled',
-])
 
 /**
  * The `GlPosting` statuses whose lines count as having reached the books.
@@ -280,7 +257,7 @@ export async function postDepositApplications(
       })
       results.push(post)
 
-      if (ACCEPTED_POST_STATUSES.has(post.status)) {
+      if (isExpectedPostOutcome(post)) {
         heldMinor -= amountMinor
       } else {
         logger.warn('A customer deposit application was not posted to the ledger', {

--- a/packages/lib/src/money/payments/post-transaction.ts
+++ b/packages/lib/src/money/payments/post-transaction.ts
@@ -55,6 +55,7 @@ import {
   PAYMENT_SOURCE_TYPE,
   paymentPeriodKey,
 } from '../../postings/build-payment-entry'
+import { isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { LEDGER_CURRENCY, postEntry } from '../../postings/post-entry'
 import { readPostingLineSourceIds } from '../../postings/read-posting'
@@ -71,30 +72,6 @@ const logger = createScopedLogger('money-payments-ledger')
  * per route.
  */
 export const PAYMENT_POSTING_TYPE: PostingType = 'payment'
-
-/**
- * The statuses that mean the LEDGER took the entry.
- *
- * 🛑 Since the export split this is the only question a caller here may ask. A
- * refused push returns `posted` with `exportStatus: 'failed'`, so it lands in
- * this set on purpose: the entry is in the books and the document that produced
- * it must stand. Adding an `exportStatus` check to any of these call sites
- * reintroduces the defect - see plans/accounting/export-state-split.md.
- *
- * `not_connected` and `disabled` are in for the older reason: an org with no
- * accounting system is a first-class case, not a degraded one (decision P1).
- *
- * `not_enabled` is in for the newest reason: an org that has never turned the
- * accounting module on is a first-class case too (task 17 section 3).
- */
-const ACCEPTED_POST_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_enabled',
-])
 
 /**
  * The transaction statuses that move money and therefore reach the ledger.
@@ -422,7 +399,7 @@ export async function postPaymentTransaction(
       }
     }
 
-    if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+    if (!isExpectedPostOutcome(post)) {
       // 🛑 Recorded, never swallowed. `postEntry` writes a `pending`/`failed`
       // `GlPosting` row once the claim succeeded, which is what
       // `listFailedExports` reads - so a refusal AFTER the claim surfaces on

--- a/packages/lib/src/money/payouts/sync.ts
+++ b/packages/lib/src/money/payouts/sync.ts
@@ -51,6 +51,7 @@ import type Stripe from 'stripe'
 import { UnprocessableEntityError } from '../../errors'
 import { isAccountingEnabled } from '../../postings/accounting-enabled'
 import { ACCOUNT_ROLES } from '../../postings/build-entry'
+import { didLedgerAccept } from '../../postings/ledger-accepted'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { payoutAccountUnmappedResult, postPayoutEntry } from '../../postings/post-payout-entry'
 import { reverseEntry } from '../../postings/reverse-entry'
@@ -268,7 +269,13 @@ async function ingestOne(
     })
   }
 
-  if (post.status !== 'posted' && post.status !== 'already_posted') {
+  // ⚠️ Widened from `posted || already_posted` by the shared predicate. An org
+  // with no provider connected, or one whose provider switch is off, still has a
+  // real, balanced, persisted entry - refusing there left the payout un-`paid`
+  // and its `glPostingId` unstamped over a ledger that held the entry.
+  // `not_enabled` is unreachable here: the sync returns early for an org that
+  // never turned accounting on.
+  if (!didLedgerAccept(post)) {
     return {
       created,
       posted: false,
@@ -462,7 +469,7 @@ export async function reverseFailedPayout(
         memo: `Payout ${record.number ?? gatewayPayoutId} failed - reversing the settlement`,
       })
 
-      if (reversal.status !== 'posted' && reversal.status !== 'already_posted') {
+      if (!didLedgerAccept(reversal)) {
         // 🛑 The record is NOT flipped to `reversed` when the reversal did not
         // land. A row saying reversed over a posting that is still `posted`
         // would hide a real overstatement of cash behind a status nobody

--- a/packages/lib/src/postings/__tests__/ledger-accepted.test.ts
+++ b/packages/lib/src/postings/__tests__/ledger-accepted.test.ts
@@ -1,0 +1,110 @@
+// packages/lib/src/postings/__tests__/ledger-accepted.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { didLedgerAccept, isExpectedPostOutcome } from '../ledger-accepted'
+import type { PostResultStatus } from '../types'
+
+/**
+ * Every member of `PostResultStatus`, written out by hand ON PURPOSE.
+ *
+ * 🛑 This list is the tripwire. `didLedgerAccept`'s `never` makes the SOURCE
+ * fail to compile when a status is added, but a `default: return false` slipped
+ * in later would silence that - so the test asserts the classification of a
+ * closed list rather than iterating a union it cannot see at runtime. Adding a
+ * status to `types.ts` and not to this file leaves the new value unasserted;
+ * `covers every PostResultStatus` below is what catches that.
+ */
+const ACCEPTED: readonly PostResultStatus[] = [
+  'posted',
+  'already_posted',
+  'healed',
+  'not_connected',
+  'disabled',
+  'not_exported',
+]
+
+const REFUSED: readonly PostResultStatus[] = [
+  'period_closed',
+  'account_unmapped',
+  'unbalanced',
+  'nothing_to_close',
+  'setup_incomplete',
+  'not_enabled',
+  'inventory_role_refused',
+  'account_invalid',
+  'revenue_incomplete',
+  'error',
+]
+
+describe('didLedgerAccept', () => {
+  it.each(ACCEPTED)('accepts %s - an entry exists', (status) => {
+    expect(didLedgerAccept({ status })).toBe(true)
+  })
+
+  it.each(REFUSED)('refuses %s - nothing was written', (status) => {
+    expect(didLedgerAccept({ status })).toBe(false)
+  })
+
+  /**
+   * The defect this whole module exists for. `opening_balance` and
+   * `provider_sync` route to `'none'`, so every entry on those paths lands on
+   * `not_exported` - and the hand-written arrays it replaced did not carry it,
+   * which made `provider-sync`'s sync record nothing while reporting success.
+   */
+  it('accepts not_exported, which is what the old hand-written arrays missed', () => {
+    expect(didLedgerAccept({ status: 'not_exported' })).toBe(true)
+  })
+
+  /**
+   * 🛑 The one that reads like a mistake and is not. `not_enabled` means the
+   * module was never turned on: nothing built, nothing claimed. It is ordinary,
+   * but it is not the ledger accepting anything.
+   */
+  it('refuses not_enabled, because nothing was built', () => {
+    expect(didLedgerAccept({ status: 'not_enabled' })).toBe(false)
+    expect(isExpectedPostOutcome({ status: 'not_enabled' })).toBe(true)
+  })
+
+  /**
+   * 🛑 The dangerous direction, and a bug this predicate actually shipped with
+   * for one test run. `default: return exhaustive` hands back the arriving
+   * string, and every non-empty string is truthy - so an unrecognised status
+   * read as "the ledger took it". Caught by `banking/review`'s own test, which
+   * stubs `period_locked` (a near-miss for the real `period_closed`).
+   *
+   * Typecheck cannot reach this: the cast is what a stale bundle, a JSON wire
+   * hop, or a test double does at runtime.
+   */
+  it('fails CLOSED on a status outside the union', () => {
+    const bogus = { status: 'period_locked' as PostResultStatus }
+    expect(didLedgerAccept(bogus)).toBe(false)
+    expect(isExpectedPostOutcome(bogus)).toBe(false)
+    expect(didLedgerAccept({ status: '' as PostResultStatus })).toBe(false)
+  })
+
+  it('covers every PostResultStatus exactly once', () => {
+    const all = [...ACCEPTED, ...REFUSED]
+    expect(new Set(all).size).toBe(all.length)
+    // Mirrors the union in `types.ts`. If this number moves, a status was added
+    // and both this file and `didLedgerAccept`'s switch need the new member.
+    expect(all).toHaveLength(16)
+  })
+})
+
+describe('isExpectedPostOutcome', () => {
+  it.each(ACCEPTED)('is true for %s', (status) => {
+    expect(isExpectedPostOutcome({ status })).toBe(true)
+  })
+
+  it.each(REFUSED.filter((s) => s !== 'not_enabled'))('is false for %s', (status) => {
+    expect(isExpectedPostOutcome({ status })).toBe(false)
+  })
+
+  it('differs from didLedgerAccept on exactly one status', () => {
+    const all = [...ACCEPTED, ...REFUSED]
+    const differ = all.filter(
+      (s) => didLedgerAccept({ status: s }) !== isExpectedPostOutcome({ status: s })
+    )
+    expect(differ).toEqual(['not_enabled'])
+  })
+})

--- a/packages/lib/src/postings/client.ts
+++ b/packages/lib/src/postings/client.ts
@@ -211,6 +211,7 @@ export {
   type ListJournalEntriesFilters,
   type PostingSummary,
 } from './journal-entries/client'
+export { didLedgerAccept, isExpectedPostOutcome } from './ledger-accepted'
 // ── plans/accounting/tasks/19: opening balances from the provider, pure half ──
 // PURE. No database, no io - see opening-fill-plan.ts's own header.
 export {

--- a/packages/lib/src/postings/index.ts
+++ b/packages/lib/src/postings/index.ts
@@ -246,6 +246,7 @@ export {
   type UpdateJournalEntryInput,
   updateJournalEntry,
 } from './journal-entries'
+export { didLedgerAccept, isExpectedPostOutcome } from './ledger-accepted'
 export { listPostings, listPostingsForSource } from './list-postings'
 export {
   FINALIZED_SETUP_STATE,

--- a/packages/lib/src/postings/journal-entries/writes.ts
+++ b/packages/lib/src/postings/journal-entries/writes.ts
@@ -30,6 +30,7 @@ import {
   MANUAL_ENTRY_SOURCE_TYPE,
   type ManualPostingType,
 } from '../build-manual-entry'
+import { didLedgerAccept } from '../ledger-accepted'
 import { resolvePeriodLock } from '../period-lock'
 import { postEntry, previewEntry } from '../post-entry'
 import { readPostingLineSourceIds } from '../read-posting'
@@ -406,18 +407,14 @@ export async function reverseJournalEntry(
       // Only a reversal that reached the ledger changes what this record says.
       // `already_posted` counts: it means the reversal was already there, which
       // is a converged re-run and not a failure.
-      const landed =
-        result.status === 'posted' ||
-        result.status === 'already_posted' ||
-        result.status === 'healed' ||
-        result.status === 'not_connected' ||
-        result.status === 'disabled' ||
-        // A reversal inherits the original's posting type (`reverse-entry.ts`),
-        // so reversing the opening entry - a `journal_entry` record of kind
-        // `opening_balance`, posted, with a `glPostingId`, and nothing here
-        // refuses it - produces a `'none'`-routed reversal. Without this the
-        // ledger would hold the reversal while the record still read `posted`.
-        result.status === 'not_exported'
+      //
+      // ⚠️ A reversal inherits the original's posting type (`reverse-entry.ts`),
+      // so reversing the opening entry - a `journal_entry` record of kind
+      // `opening_balance` - produces a `'none'`-routed reversal that lands on
+      // `not_exported`. The hand-written list this replaced had to be taught
+      // that by hand, and was, one release late; `didLedgerAccept` is exhaustive
+      // over the union, so the next `'none'` route cannot slip past it.
+      const landed = didLedgerAccept(result)
 
       if (landed) {
         const crud = new UnifiedCrudHandler(organizationId, userId, db)

--- a/packages/lib/src/postings/ledger-accepted.ts
+++ b/packages/lib/src/postings/ledger-accepted.ts
@@ -1,0 +1,100 @@
+// packages/lib/src/postings/ledger-accepted.ts
+
+import type { PostResultStatus } from './types'
+
+/**
+ * Did the LEDGER take the entry?
+ *
+ * 🛑 This is the ONE answer to "did the ledger take it?". Before it there were
+ * ~12 hand-written arrays of status strings across `money/*`, `banking/*`,
+ * `postings/*` and the web hooks, each spelling the set out again. Adding
+ * `not_exported` in brief 22 §5 silently broke two of them - `provider-sync`'s
+ * `isPosted` (the whole inbound sync would have recorded nothing WHILE
+ * REPORTING SUCCESS) and `journal-entries`' `landed` - and **typecheck could
+ * not see either**, because both were `status === '…'` inside a boolean. Only
+ * the four reachable that day were fixed; this exists so a fifth cannot happen.
+ *
+ * 🛑 Reads `status`, never `exportStatus`. A caller deciding whether the books
+ * hold the entry and reading the export's outcome instead is the exact defect
+ * `plans/accounting/export-state-split.md` closed: a provider refusal still
+ * leaves a real, balanced, persisted entry in OUR ledger, because the
+ * accounting system is an exporter and auxx.ai is the system of record
+ * (decision P1).
+ *
+ * ⚠️ The `switch` is deliberate and the `never` at the bottom is the point. A
+ * new `PostResultStatus` fails to compile here until somebody classifies it,
+ * which is the protection the old arrays could not give: `new Set<string>([…])`
+ * accepts any string, so a missing member was invisible until a screen lied.
+ * Do not replace it with a `Set` membership test, however tidy.
+ */
+export function didLedgerAccept(result: { status: PostResultStatus }): boolean {
+  switch (result.status) {
+    // An entry exists, balanced and persisted, and these five say so directly.
+    case 'posted':
+    // The claim was already held - a converged re-run, a SUCCESS, never a fault.
+    case 'already_posted':
+    case 'healed':
+    // No provider, or the provider's switch is off. The entry is built and
+    // persisted identically and simply never pushed (decision P1).
+    case 'not_connected':
+    case 'disabled':
+    // The posting TYPE routes to `'none'` whatever the org has connected -
+    // `opening_balance` and `provider_sync` today. It pushed nothing BY DESIGN,
+    // so an export is not merely absent, it is never coming.
+    case 'not_exported':
+      return true
+
+    // Every one of these wrote NOTHING. A caller that treats them as accepted
+    // records a ledger fact that does not exist.
+    case 'period_closed':
+    case 'account_unmapped':
+    case 'unbalanced':
+    case 'nothing_to_close':
+    case 'setup_incomplete':
+    case 'inventory_role_refused':
+    case 'account_invalid':
+    case 'revenue_incomplete':
+    case 'error':
+    // 🛑 NOT accepted, and this is the one that reads like a mistake. The
+    // accounting module has never been turned on, so nothing was built, nothing
+    // claimed, nothing logged (task 17 §3). It is a first-class SILENT case,
+    // but it is not the ledger accepting anything - callers that must not warn
+    // about it want {@link isExpectedPostOutcome}, which says so by name.
+    case 'not_enabled':
+      return false
+
+    // 🛑 FAILS CLOSED, and the `void` is why this is not `return exhaustive`.
+    //
+    // The assignment to `never` is the COMPILE-time guard and must stay. But
+    // returning it hands back whatever string actually arrived, and every
+    // non-empty string is truthy - so an unrecognised status would read as "the
+    // ledger took it", which is the one direction this predicate may never fail
+    // in. A runtime value outside the union is reachable in ways typecheck does
+    // not cover: a stale bundle, a status crossing a wire as JSON, a test double
+    // returning a near-miss (`period_locked` for `period_closed` - a real one,
+    // in `banking/review/__tests__/writes.test.ts`, which is what caught this).
+    default: {
+      const exhaustive: never = result.status
+      void exhaustive
+      return false
+    }
+  }
+}
+
+/**
+ * Is this a normal outcome that needs no warning?
+ *
+ * {@link didLedgerAccept}, plus `not_enabled`: an org that never turned the
+ * accounting module on is as ordinary as one with no provider connected, and
+ * the business action - issuing the invoice, banking the deposit, shipping the
+ * order - is real and must not be rolled back or logged as a failure for it
+ * (task 17 §3).
+ *
+ * 🛑 Use this for "should I warn / roll back", and {@link didLedgerAccept} for
+ * "does a `GlPosting` row exist". They differ on exactly one status and
+ * conflating them is how `not_enabled` ended up inside sets named
+ * `ACCEPTED_POST_STATUSES` that were also asked whether the books hold an entry.
+ */
+export function isExpectedPostOutcome(result: { status: PostResultStatus }): boolean {
+  return didLedgerAccept(result) || result.status === 'not_enabled'
+}

--- a/packages/lib/src/postings/provider-sync/writes.ts
+++ b/packages/lib/src/postings/provider-sync/writes.ts
@@ -18,6 +18,7 @@ import { and, eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { UnprocessableEntityError } from '../../errors'
 import { buildEntry } from '../build-entry'
+import { didLedgerAccept } from '../ledger-accepted'
 import type { PeriodLock } from '../periods'
 import { postEntry } from '../post-entry'
 import { reverseEntry } from '../reverse-entry'
@@ -250,17 +251,13 @@ async function stampProvenance(
  * `plans/accounting/export-state-split.md` closed.
  */
 function isPosted(result: PostResult): result is PostResult & { glPostingId: string } {
-  return (
-    (result.status === 'posted' ||
-      result.status === 'already_posted' ||
-      result.status === 'healed' ||
-      result.status === 'not_connected' ||
-      result.status === 'disabled' ||
-      // 🛑 The status EVERY entry on this path now gets. `provider_sync` is one
-      // of the two `'none'` routes in `EXPORT_ROUTE_BY_POSTING_TYPE` - that is
-      // this module's loop guard - so a synced entry never pushes and always
-      // lands here. Omitting it would make the sync record nothing at all.
-      result.status === 'not_exported') &&
-    Boolean(result.glPostingId)
-  )
+  // 🛑 `not_exported` is the status EVERY entry on this path gets, and the
+  // reason this predicate is shared rather than spelled out here. `provider_sync`
+  // is one of the two `'none'` routes in `EXPORT_ROUTE_BY_POSTING_TYPE` - this
+  // module's own loop guard - so a synced entry never pushes and always lands on
+  // it. When `not_exported` was added, the hand-written list this replaced did
+  // not gain it, and the whole inbound sync would have recorded NOTHING while
+  // reporting success. `didLedgerAccept` cannot miss a status: it fails to
+  // compile until every member of the union is classified.
+  return didLedgerAccept(result) && Boolean(result.glPostingId)
 }

--- a/packages/lib/src/purchasing/expense-bill/writes.ts
+++ b/packages/lib/src/purchasing/expense-bill/writes.ts
@@ -43,6 +43,7 @@ import {
   EXPENSE_BILL_POSTING_TYPE,
   EXPENSE_BILL_SOURCE_TYPE,
 } from '../../postings/build-expense-bill-entry'
+import { isExpectedPostOutcome } from '../../postings/ledger-accepted'
 import { listPostingsForSource } from '../../postings/list-postings'
 import { resolvePeriodLock } from '../../postings/period-lock'
 import { periodKeyForDate } from '../../postings/periods'
@@ -59,26 +60,6 @@ import {
 } from './reads'
 
 const logger = createScopedLogger('purchasing:expense-bill')
-
-/**
- * The statuses that mean the LEDGER took the entry. The same set
- * `postInvoiceIssuance` and `issueCreditMemo` accept, for the same reasons: a
- * refused EXPORT still returns `posted` (see
- * `plans/accounting/export-state-split.md`), an org with no accounting system is
- * a first-class case (decision P1), and an org that never enabled the module is
- * another (task 17 §3).
- */
-const ACCEPTED_POST_STATUSES = new Set<string>([
-  'posted',
-  'already_posted',
-  'healed',
-  'not_connected',
-  'disabled',
-  'not_enabled',
-])
-
-/** The statuses that mean a reversal landed. Same set as `reverseInvoiceIssuance`. */
-const ACCEPTED_REVERSAL_STATUSES = ACCEPTED_POST_STATUSES
 
 /**
  * The bill statuses a Post action may start from.
@@ -311,7 +292,7 @@ export async function postExpenseBill(
     post = { status: 'not_enabled' }
   }
 
-  if (!ACCEPTED_POST_STATUSES.has(post.status)) {
+  if (!isExpectedPostOutcome(post)) {
     throw new BadRequestError(
       'This vendor bill could not be posted to the general ledger' +
         `${post.error ? `: ${post.error}` : ` (${post.status})`}`,
@@ -419,7 +400,7 @@ export async function voidExpenseBill(db: Database, input: VoidExpenseBillInput)
           memo ??
           `Reversal of ${posting.docNumber} - bill ${bill.number || bill.internalNumber} voided`,
       })
-      if (!ACCEPTED_REVERSAL_STATUSES.has(result.status)) {
+      if (!isExpectedPostOutcome(result)) {
         throw new BadRequestError(
           `This vendor bill has a general ledger entry (${posting.docNumber}) that could not be ` +
             `reversed${result.error ? `: ${result.error}` : ` (${result.status})`}. Voiding it ` +


### PR DESCRIPTION
Closes brief `22` §3 row 5, which #2119 deliberately left out to keep its diff to the defect.

## The problem

"Did the ledger take it?" was answered by **~12 hand-written arrays of status strings** across `money/*`, `banking/*`, `postings/*` and the web hooks. Each spelled the set out again, and every one was a `new Set<string>([...])`, which accepts any string.

So when #2119 added `not_exported`, the sets that missed it just kept returning `false`. No type error, no failing test, a screen quietly lying. Two broke that way and were patched by hand at the time. This replaces the pattern rather than patching a third.

## The fix

`packages/lib/src/postings/ledger-accepted.ts` is the single predicate. It is a `switch` with `const exhaustive: never = result.status`, **not a `Set`**, so a new `PostResultStatus` fails to compile until somebody classifies it.

Verified by mutation, not by the tests going green:

```
src/postings/ledger-accepted.ts(67,13): error TS2322:
Type '"mutation_probe_status"' is not assignable to type 'never'.
```

**Two predicates, because the old sets conflated two questions:**

| | means | set |
|---|---|---|
| `didLedgerAccept(result)` | a `GlPosting` row exists | the six `PostEntryStatus` values |
| `isExpectedPostOutcome(result)` | normal outcome, do not warn or roll back | those **plus `not_enabled`** |

`not_enabled` is why there are two. It had been sitting inside sets *named* `ACCEPTED_POST_STATUSES` that were also asked whether the books hold an entry, and it means nothing was built at all. Of the twelve sites, eight wanted the wider question and four the narrower one.

## Two defects this found that were not on the list

**1. The setup wizard rendered the red "The entry could not be built" over a perfectly good opening entry.**

`wizard-done-page.tsx` asked `posted || already_posted`. The opening entry is `opening_balance`, routed to `'none'`, so #2119 changed what it returns from `not_connected` to `not_exported` — and `EntryBlockers`' `REMEDIES` map is `Partial` with no `not_exported` key, so it fell straight through to `FALLBACK`, which is `tone: 'failure'`.

Before #2119 that same page told a QuickBooks-connected org it had no accounting system, which is the bug brief `22` §5 was written about. **Fixing the status moved the lie rather than removing it**, and nobody saw it because the wizard's last page was never re-driven after #2119. Fixed both ways: the page uses the predicate, and `not_exported` gets its own neutral remedy beside `not_connected` and `disabled`.

**2. The predicate itself failed OPEN at first.**

`default: return exhaustive` hands back the arriving string, and every non-empty string is truthy, so an unrecognised status read as *"the ledger took it"* — the one direction this may never fail in. Caught by `banking/review`'s own test, whose stub returns `period_locked`, **not a member of the union at all**, a typo that passed for as long as the check was a `Set<string>`. Now `void exhaustive; return false`, with a regression test, and the stub says `period_closed`.

## Three more corrected in passing

- **`payouts/sync.ts`** asked `posted || already_posted`, so any provider-less org left the payout un-`paid` with its `glPostingId` unstamped over a ledger that held the entry. (`not_enabled` is unreachable there; the sync returns early for an accounting-off org.)
- **`money/invoices/write-off.ts`** was missing `healed` **and** `not_exported`.
- **`banking-review.ts`'s `toBulkOutcome`** reported a bulk failure for the same reason. Its `ReviewOutcome.post.status` was typed `string`, which is the other half of why this family is invisible to typecheck. Now the real union.

## Deliberately left alone

Single-status `=== 'already_posted'` checks in five files. "Was this a converged re-run?" is a genuinely different question, and `fulfillment-posting/run.ts` excludes it **on purpose**: the claim belongs to another run, so this one must not stamp shipments onto numbers it did not compute.

## Verification

- lib typecheck ratchet **27/27, unchanged**; web ratchet **0/0**
- Biome clean
- `vitest run src/postings src/money src/banking src/purchasing` = **167 files, 3060 tests, all passing**, plus **36 new** in `postings/__tests__/ledger-accepted.test.ts`
- Exhaustiveness guard proven by mutation (above), then reverted

⚠️ **Not driven in a browser.** This touches the last page of the setup wizard, the write-off dialog, the fulfill dialog and the bulk banking actions. The wizard bug above is exactly what happens when a status change ships on green tests, so the drive in the handoff's §1 applies to this PR too.

https://claude.ai/code/session_01L6vTrHkJHWLTJcRgTRzaYf
