### PR TITLE
feat(shipstation): transit status, Shopify order linking, cost and label PDF

### DIFF
--- a/apps/api/src/routes/__tests__/deployments.test.ts
+++ b/apps/api/src/routes/__tests__/deployments.test.ts
@@ -9,6 +9,10 @@ const TARGET_ORG_ID = 'org_target'
 const mockVerifyOrgMembership = vi.fn()
 const mockOnCacheEvent = vi.fn()
 const mockInstallationInsert = vi.fn()
+// Installation lifecycle, observable so the one-live-row invariant can be asserted.
+const mockInstallationFindFirst = vi.fn()
+const mockInstallationUpdate = vi.fn()
+const mockInstallationDelete = vi.fn()
 
 // Auth/scope middleware are replaced with pass-throughs: this test covers the
 // route's own organization check, not token validation.
@@ -33,6 +37,8 @@ vi.mock('../../middleware/scope', () => ({
 vi.mock('drizzle-orm', () => ({
   and: (...args: unknown[]) => ({ _and: args }),
   eq: (a: unknown, b: unknown) => ({ _eq: [a, b] }),
+  isNull: (a: unknown) => ({ _isNull: a }),
+  isNotNull: (a: unknown) => ({ _isNotNull: a }),
 }))
 
 vi.mock('@auxx/database', () => {
@@ -43,7 +49,12 @@ vi.mock('@auxx/database', () => {
   const deployment = { id: 'deployment_1', version: null, status: 'active' }
 
   const tx = {
-    delete: () => ({ where: async () => undefined }),
+    delete: () => ({
+      where: async (predicate: unknown) => {
+        mockInstallationDelete(predicate)
+        return undefined
+      },
+    }),
     insert: () =>
       ({
         values: (values: unknown) => {
@@ -53,9 +64,16 @@ vi.mock('@auxx/database', () => {
           })
         },
       }) as any,
-    update: () => ({ set: () => ({ where: async () => undefined }) }),
+    update: () => ({
+      set: (values: unknown) => ({
+        where: async () => {
+          mockInstallationUpdate(values)
+          return undefined
+        },
+      }),
+    }),
     query: {
-      AppInstallation: { findFirst: async () => undefined },
+      AppInstallation: { findFirst: (...args: unknown[]) => mockInstallationFindFirst(...args) },
     },
   }
 
@@ -121,6 +139,8 @@ const DEV_BODY = {
 describe('POST /:appId/deployments — development target organization', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: nothing installed. Individual tests override.
+    mockInstallationFindFirst.mockResolvedValue(undefined)
   })
 
   it('rejects a caller who is not a member of the target organization with 403', async () => {
@@ -178,5 +198,81 @@ describe('POST /:appId/deployments — development target organization', () => {
 
     expect(res.status).toBe(500)
     expect(mockInstallationInsert).not.toHaveBeenCalled()
+  })
+  // Regression, migration 0376 + PR #2130. That PR replaced the unique over
+  // (appId, organizationId, installationType) with a PARTIAL unique over
+  // (appId, organizationId) WHERE `uninstalledAt IS NULL`, and updated `installApp`
+  // to repoint the single live row. This route was missed: it looked the installation
+  // up scoped to 'development', so it could not see a live PRODUCTION row, concluded
+  // nothing was installed, and INSERTed - which the index rejects with an unhandled
+  // constraint error that reaches the CLI as a bare 500. The effect was that
+  // `auxx dev --once` failed for every app already installed from a publish.
+  it('repoints a live PRODUCTION installation instead of inserting a second row', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(ok({ organizationId: TARGET_ORG_ID }))
+    mockInstallationFindFirst.mockResolvedValueOnce({
+      id: 'install_prod',
+      installationType: 'production',
+      currentDeploymentId: 'deployment_published',
+      uninstalledAt: null,
+    })
+
+    const res = await postDevDeployment(DEV_BODY)
+
+    expect(res.status).toBe(200)
+    // The row is repointed AND restamped: it is a production install being switched
+    // to a dev deployment, so leaving the type alone would misreport what runs.
+    expect(mockInstallationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationType: 'development',
+        currentDeploymentId: 'deployment_1',
+      })
+    )
+    // The whole point: no second live row.
+    expect(mockInstallationInsert).not.toHaveBeenCalledWith(
+      expect.objectContaining({ installationType: 'development' })
+    )
+  })
+
+  it('reactivates a soft-deleted installation rather than deleting and re-inserting', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(ok({ organizationId: TARGET_ORG_ID }))
+    // First lookup (live) finds nothing; second (soft-deleted) finds the old row.
+    mockInstallationFindFirst.mockResolvedValueOnce(undefined).mockResolvedValueOnce({
+      id: 'install_old',
+      installationType: 'production',
+      currentDeploymentId: 'deployment_published',
+      uninstalledAt: new Date('2026-09-11T19:03:46Z'),
+    })
+
+    const res = await postDevDeployment(DEV_BODY)
+
+    expect(res.status).toBe(200)
+    // Reactivated in place: a soft-deleted installation keeps its AppSetting and
+    // Credential rows, and every other table references its id.
+    expect(mockInstallationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uninstalledAt: null,
+        installationType: 'development',
+        currentDeploymentId: 'deployment_1',
+      })
+    )
+    expect(mockInstallationInsert).not.toHaveBeenCalledWith(
+      expect.objectContaining({ installationType: 'development' })
+    )
+  })
+
+  it('inserts only when the org has no installation of the app at all', async () => {
+    mockVerifyOrgMembership.mockResolvedValue(ok({ organizationId: TARGET_ORG_ID }))
+    mockInstallationFindFirst.mockResolvedValue(undefined)
+
+    const res = await postDevDeployment(DEV_BODY)
+
+    expect(res.status).toBe(200)
+    expect(mockInstallationInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installationType: 'development',
+        currentDeploymentId: 'deployment_1',
+      })
+    )
+    expect(mockInstallationUpdate).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/src/routes/deployments.ts
+++ b/apps/api/src/routes/deployments.ts
@@ -9,7 +9,7 @@ import { calculateNextVersion } from '@auxx/services/app-versions'
 import { verifyAppAccess } from '@auxx/services/developer-accounts'
 import { verifyOrgMembership } from '@auxx/services/organization-members'
 import { stableStringify } from '@auxx/utils/json'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNotNull, isNull } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { type ErrorStatusCode, errorResponse } from '../lib/response'
 import { authMiddleware } from '../middleware/auth'
@@ -235,31 +235,77 @@ deployments.post('/:appId/deployments', requireScope(['developer', 'apps:write']
         throw new Error('Failed to create deployment')
       }
 
-      // 3. Update or create installation
-      const existing = await tx.query.AppInstallation.findFirst({
+      // 3. Repoint, reactivate, or create the ONE live installation.
+      //
+      // 🛑 Do NOT filter this lookup by `installationType`. Migration 0376 replaced
+      // the unique over (appId, organizationId, installationType) with a PARTIAL
+      // unique over (appId, organizationId) WHERE `uninstalledAt IS NULL`, so an org
+      // may hold exactly one live installation of an app whatever its type. A lookup
+      // scoped to 'development' cannot see a live PRODUCTION row, concludes nothing is
+      // installed, and inserts - which the index rejects with an unhandled constraint
+      // error, surfacing to the CLI as a bare 500. That made `auxx dev --once` fail for
+      // every app already installed from a publish, which is exactly when you want to
+      // dev-deploy: to test a change before publishing it.
+      //
+      // `installationType` is mutable by design now (0376's comment says so), so
+      // switching an app between a published and a development deployment is a
+      // REPOINT of the single row. This mirrors `installApp` in
+      // `@auxx/lib/apps/installations/install-app.ts`, which was updated for the new
+      // invariant while this route was missed.
+      const liveInstallation = await tx.query.AppInstallation.findFirst({
         where: and(
           eq(schema.AppInstallation.appId, appId),
           eq(schema.AppInstallation.organizationId, targetOrganizationId),
-          eq(schema.AppInstallation.installationType, 'development')
+          isNull(schema.AppInstallation.uninstalledAt)
         ),
       })
 
-      if (existing && !existing.uninstalledAt) {
+      if (liveInstallation) {
+        // Stamped, not assumed: the live row may be a production install being
+        // switched to this dev deployment.
         await tx
           .update(schema.AppInstallation)
-          .set({ currentDeploymentId: deployment.id, updatedAt: new Date() })
-          .where(eq(schema.AppInstallation.id, existing.id))
+          .set({
+            installationType: 'development',
+            currentDeploymentId: deployment.id,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.AppInstallation.id, liveInstallation.id))
       } else {
-        if (existing?.uninstalledAt) {
-          await tx.delete(schema.AppInstallation).where(eq(schema.AppInstallation.id, existing.id))
-        }
-        await tx.insert(schema.AppInstallation).values({
-          appId,
-          organizationId: targetOrganizationId,
-          installationType: 'development',
-          currentDeploymentId: deployment.id,
-          installedAt: new Date(),
+        // Nothing live. Reactivate the most recently uninstalled row rather than
+        // DELETEing it and inserting a fresh one: a soft-deleted installation keeps
+        // its AppSetting and Credential rows, which `uninstallApp` preserves on
+        // purpose, and a hard delete discards them along with the id every other
+        // table references.
+        const softDeleted = await tx.query.AppInstallation.findFirst({
+          where: and(
+            eq(schema.AppInstallation.appId, appId),
+            eq(schema.AppInstallation.organizationId, targetOrganizationId),
+            isNotNull(schema.AppInstallation.uninstalledAt)
+          ),
+          orderBy: (installations, { desc }) => [desc(installations.uninstalledAt)],
         })
+
+        if (softDeleted) {
+          await tx
+            .update(schema.AppInstallation)
+            .set({
+              uninstalledAt: null,
+              installationType: 'development',
+              currentDeploymentId: deployment.id,
+              installedAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .where(eq(schema.AppInstallation.id, softDeleted.id))
+        } else {
+          await tx.insert(schema.AppInstallation).values({
+            appId,
+            organizationId: targetOrganizationId,
+            installationType: 'development',
+            currentDeploymentId: deployment.id,
+            installedAt: new Date(),
+          })
+        }
       }
 
       return deployment

--- a/packages/lib/scripts/probe-shipstation-fulfillments.ts
+++ b/packages/lib/scripts/probe-shipstation-fulfillments.ts
@@ -1,0 +1,123 @@
+// packages/lib/scripts/probe-shipstation-fulfillments.ts
+// Probe: GET /v2/fulfillments.
+//
+// Two open questions this settles:
+//
+//  1. ORDER LINKAGE. `order_source_id` is a documented filter on this endpoint, and a
+//     "fulfillment" is the Shopify-side concept. If a fulfillment row carries an order id
+//     or an order-source marker, it beats parsing `external_shipment_id` (which is the only
+//     route found so far, and whose format is inferred rather than provider-stated).
+//
+//  2. DELTA CAPABILITY. Expansion plan §2 claims this endpoint "sorts by `modified_at`".
+//     The documented query surface the owner pasted shows `sort_by=created_at` plus
+//     `create_date_start` / `create_date_end` and `ship_date_start` / `ship_date_end`, with
+//     no modified-date filter. If `modified_at` is not a legal sort, the plan's claim is
+//     wrong and this endpoint has the same created-at-floor-only constraint that forced the
+//     two-cursor design on labels. Both are probed explicitly below.
+//
+// Probed UNFILTERED: the pasted URL's placeholder values (`ship_to_name=string`) would
+// return an empty set and prove nothing.
+//
+// Read-only. GET only.
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { revealSecrets } from '@auxx/credentials/store'
+
+const CREDENTIAL_ID = process.env.SS_CREDENTIAL_ID ?? 't3f9k1su4vwto30g2bi0qbpl'
+const ORG_ID = process.env.SS_ORG_ID ?? 'abgwpa1l81reht2zmwrcihfu'
+const PAGE_SIZE = Number(process.env.SS_PAGE_SIZE ?? 50)
+const OUT = process.env.SS_OUT ?? 'plans/apps/shipstation/probe-2026-09-11-fulfillments-raw.json'
+
+const BASE = 'https://api.shipstation.com'
+
+function nonEmpty(v: unknown): boolean {
+  if (v === null || v === undefined || v === '') return false
+  if (Array.isArray(v)) return v.length > 0
+  if (typeof v === 'object') return Object.keys(v as object).length > 0
+  return true
+}
+
+async function get(apiKey: string, path: string) {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { 'api-key': apiKey, accept: 'application/json' },
+    redirect: 'error',
+  })
+  const text = await res.text()
+  return { status: res.status, ok: res.ok, text }
+}
+
+async function main() {
+  const revealed = await revealSecrets<Record<string, unknown>>(CREDENTIAL_ID, ORG_ID)
+  if (revealed.isErr()) throw new Error(`credential read failed: ${revealed.error.code}`)
+  const sec = revealed.value.secrets
+  const apiKey = (sec.apiKey ?? sec.api_key ?? sec.secret ?? sec.token) as string | undefined
+  if (!apiKey) throw new Error(`no apiKey in secrets; keys = ${Object.keys(sec)}`)
+
+  // Q2 first, cheaply: is `modified_at` a legal sort_by, or only `created_at`?
+  const sortProbes: Record<string, { status: number; body: string }> = {}
+  for (const sortBy of ['created_at', 'modified_at', 'ship_date', 'not_a_field']) {
+    const r = await get(apiKey, `/v2/fulfillments?page_size=1&sort_by=${sortBy}&sort_dir=desc`)
+    sortProbes[sortBy] = { status: r.status, body: r.text.slice(0, 500) }
+    console.log(
+      `sort_by=${sortBy.padEnd(12)} -> ${r.status}  ${r.text.slice(0, 220).replace(/\s+/g, ' ')}`
+    )
+  }
+
+  const main = await get(
+    apiKey,
+    `/v2/fulfillments?page_size=${PAGE_SIZE}&sort_by=created_at&sort_dir=desc`
+  )
+  console.log(`\nGET /v2/fulfillments (page_size=${PAGE_SIZE}) -> ${main.status}`)
+
+  const parsed = main.ok ? JSON.parse(main.text) : null
+  mkdirSync(dirname(OUT), { recursive: true })
+  writeFileSync(
+    OUT,
+    JSON.stringify(
+      {
+        probedAt: new Date().toISOString(),
+        sortProbes,
+        status: main.status,
+        result: parsed ?? main.text.slice(0, 2000),
+      },
+      null,
+      2
+    )
+  )
+  console.log(`written to ${OUT}`)
+
+  if (!parsed) {
+    console.log(`\nbody: ${main.text.slice(0, 600)}`)
+    return
+  }
+
+  const body = parsed as Record<string, unknown>
+  const rows = (body.fulfillments ?? []) as Record<string, unknown>[]
+  console.log(`\nenvelope keys: ${Object.keys(body).join(', ')}`)
+  console.log(`total: ${String(body.total)}   returned: ${rows.length}`)
+  if (rows.length === 0) return
+
+  const keys = new Set<string>()
+  for (const r of rows) for (const k of Object.keys(r)) keys.add(k)
+
+  console.log('\n=== fulfillment field coverage ===')
+  const cov = [...keys].map((k) => ({
+    n: rows.filter((r) => nonEmpty(r[k])).length,
+    k,
+    ex: JSON.stringify(rows.find((r) => nonEmpty(r[k]))?.[k] ?? null).slice(0, 66),
+  }))
+  for (const c of cov.sort((a, b) => b.n - a.n || a.k.localeCompare(b.k))) {
+    console.log(`${String(c.n).padStart(3)}/${rows.length}  ${c.k.padEnd(28)} ${c.ex}`)
+  }
+
+  console.log('\n=== first row, in full ===')
+  console.log(JSON.stringify(rows[0], null, 2).slice(0, 2500))
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/packages/lib/scripts/probe-shipstation-label-fields.ts
+++ b/packages/lib/scripts/probe-shipstation-label-fields.ts
@@ -1,0 +1,90 @@
+// packages/lib/scripts/probe-shipstation-label-fields.ts
+// Probe: which money / document fields does a LABEL actually populate?
+//
+// The shipments probe (probe-2026-09-11-shipments-raw.json) showed `amount_paid`,
+// `shipping_paid` and `tax_paid` present on every shipment but all ZERO, and
+// `retail_rate` null on all 50. So the cost the merchant actually paid is not on the
+// shipment. This checks the label, which is where `shipment_cost` / `insurance_cost` /
+// `label_download` are documented to live.
+//
+// Read-only. GET /v2/labels only.
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { revealSecrets } from '@auxx/credentials/store'
+
+const CREDENTIAL_ID = process.env.SS_CREDENTIAL_ID ?? 't3f9k1su4vwto30g2bi0qbpl'
+const ORG_ID = process.env.SS_ORG_ID ?? 'abgwpa1l81reht2zmwrcihfu'
+const PAGE_SIZE = Number(process.env.SS_PAGE_SIZE ?? 50)
+const OUT = process.env.SS_OUT ?? 'probe-labels-raw.json'
+
+function nonEmpty(v: unknown): boolean {
+  if (v === null || v === undefined || v === '') return false
+  if (Array.isArray(v)) return v.length > 0
+  if (typeof v === 'object') return Object.keys(v as object).length > 0
+  return true
+}
+
+async function main() {
+  const revealed = await revealSecrets<Record<string, unknown>>(CREDENTIAL_ID, ORG_ID)
+  if (revealed.isErr()) throw new Error(`credential read failed: ${revealed.error.code}`)
+  const sec = revealed.value.secrets
+  const apiKey = (sec.apiKey ?? sec.api_key ?? sec.secret ?? sec.token) as string | undefined
+  if (!apiKey) throw new Error(`no apiKey in secrets; keys = ${Object.keys(sec)}`)
+
+  const url = `https://api.shipstation.com/v2/labels?page_size=${PAGE_SIZE}&sort_by=created_at&sort_dir=desc`
+  const res = await fetch(url, {
+    headers: { 'api-key': apiKey, accept: 'application/json' },
+    redirect: 'error',
+  })
+  if (!res.ok) throw new Error(`GET /v2/labels -> ${res.status} ${await res.text()}`)
+
+  const raw = await res.text()
+  mkdirSync(dirname(OUT), { recursive: true })
+  writeFileSync(OUT, JSON.stringify(JSON.parse(raw), null, 2))
+  console.log(`raw response written to ${OUT} (${raw.length} bytes)\n`)
+
+  const body = JSON.parse(raw) as { labels?: Record<string, unknown>[]; total?: number }
+  const labels = body.labels ?? []
+  console.log(`total reported: ${body.total}   returned: ${labels.length}\n`)
+
+  const keys = new Set<string>()
+  for (const l of labels) for (const k of Object.keys(l)) keys.add(k)
+
+  console.log('=== label field coverage ===')
+  const rows = [...keys].map((k) => {
+    const n = labels.filter((l) => nonEmpty(l[k])).length
+    const ex = labels.find((l) => nonEmpty(l[k]))?.[k]
+    return { n, k, ex: JSON.stringify(ex ?? null)?.slice(0, 70) ?? '' }
+  })
+  for (const r of rows.sort((a, b) => b.n - a.n || a.k.localeCompare(b.k))) {
+    console.log(`${String(r.n).padStart(3)}/${labels.length}  ${r.k.padEnd(30)} ${r.ex}`)
+  }
+
+  // The money + document question, spelled out.
+  console.log('\n=== the fields asked about ===')
+  for (const k of [
+    'shipment_cost',
+    'insurance_cost',
+    'requested_comparison_amount',
+    'insurance_claim',
+    'label_download',
+    'form_download',
+    'paperless_download',
+    'display_scheme',
+    'charge_event',
+  ]) {
+    const n = labels.filter((l) => nonEmpty(l[k])).length
+    const ex = labels.find((l) => nonEmpty(l[k]))?.[k]
+    console.log(
+      `  ${k.padEnd(30)} ${String(n).padStart(3)}/${labels.length}  ${JSON.stringify(ex ?? null)}`
+    )
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/packages/lib/scripts/probe-shipstation-purchase-orders.ts
+++ b/packages/lib/scripts/probe-shipstation-purchase-orders.ts
@@ -1,0 +1,85 @@
+// packages/lib/scripts/probe-shipstation-purchase-orders.ts
+// Probe: List purchase orders.
+//
+// Expectation-setting: this account 404s on `/v2/sales_orders`, `/v2/sales_orders/stores`,
+// `/v2/stores` and `/v1/stores` (expansion plan, live-testing section), so the inventory /
+// purchasing suite may not be enabled here either. A 404 is a RESULT, not a failure, and is
+// recorded as such rather than thrown.
+//
+// The expansion plan's decision 2 put this whole suite out of scope ("Auxx owns stock; two
+// systems of record is not a trade worth making"). This probe is evidence gathering, not a
+// reversal of that.
+//
+// Read-only. GET only.
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { revealSecrets } from '@auxx/credentials/store'
+
+const CREDENTIAL_ID = process.env.SS_CREDENTIAL_ID ?? 't3f9k1su4vwto30g2bi0qbpl'
+const ORG_ID = process.env.SS_ORG_ID ?? 'abgwpa1l81reht2zmwrcihfu'
+const PAGE_SIZE = Number(process.env.SS_PAGE_SIZE ?? 50)
+const OUT = process.env.SS_OUT ?? 'plans/apps/shipstation/probe-2026-09-11-purchase-orders-raw.json'
+
+/** Candidate paths, most likely first. The V2 spec names are not verified on this account. */
+const CANDIDATES = [
+  `/v2/purchase_orders?page_size=${PAGE_SIZE}`,
+  `/v2/inventory/purchase_orders?page_size=${PAGE_SIZE}`,
+  `/v2/purchase-orders?page_size=${PAGE_SIZE}`,
+]
+
+async function main() {
+  const revealed = await revealSecrets<Record<string, unknown>>(CREDENTIAL_ID, ORG_ID)
+  if (revealed.isErr()) throw new Error(`credential read failed: ${revealed.error.code}`)
+  const sec = revealed.value.secrets
+  const apiKey = (sec.apiKey ?? sec.api_key ?? sec.secret ?? sec.token) as string | undefined
+  if (!apiKey) throw new Error(`no apiKey in secrets; keys = ${Object.keys(sec)}`)
+
+  const attempts: { path: string; status: number; bodyPreview: string }[] = []
+  let winner: { path: string; json: unknown } | null = null
+
+  for (const path of CANDIDATES) {
+    const res = await fetch(`https://api.shipstation.com${path}`, {
+      headers: { 'api-key': apiKey, accept: 'application/json' },
+      redirect: 'error',
+    })
+    const text = await res.text()
+    attempts.push({ path, status: res.status, bodyPreview: text.slice(0, 400) })
+    console.log(`GET ${path} -> ${res.status}`)
+    if (res.ok) {
+      winner = { path, json: JSON.parse(text) }
+      break
+    }
+  }
+
+  mkdirSync(dirname(OUT), { recursive: true })
+  writeFileSync(
+    OUT,
+    JSON.stringify(
+      { probedAt: new Date().toISOString(), attempts, result: winner?.json ?? null },
+      null,
+      2
+    )
+  )
+  console.log(`\nwritten to ${OUT}`)
+
+  if (!winner) {
+    console.log('\n=== NO PURCHASE ORDER ENDPOINT REACHABLE ON THIS ACCOUNT ===')
+    for (const a of attempts) console.log(`  ${a.status}  ${a.path}\n       ${a.bodyPreview}\n`)
+    return
+  }
+
+  const body = winner.json as Record<string, unknown>
+  const rows = (body.purchase_orders ?? body.items ?? []) as Record<string, unknown>[]
+  console.log(`\nendpoint: ${winner.path}`)
+  console.log(`envelope keys: ${Object.keys(body).join(', ')}`)
+  console.log(`rows returned: ${rows.length}`)
+  if (rows[0]) console.log(`\nfirst row keys:\n  ${Object.keys(rows[0]).sort().join('\n  ')}`)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/packages/lib/scripts/probe-shipstation-shipment-items.ts
+++ b/packages/lib/scripts/probe-shipstation-shipment-items.ts
@@ -1,0 +1,152 @@
+// packages/lib/scripts/probe-shipstation-shipment-items.ts
+// Probe: does `shipments[].items[]` carry an order-linking key the LABEL stream lacks?
+//
+// The 2026-09-10 probe recorded the SHIPMENT's own `external_order_id` as null and the
+// item's `external_order_item_id`, but never sampled the item's own `external_order_id`
+// or `order_source_code`. Those two decide whether the Shopify order resolver can key on
+// a provider-stated id + channel instead of parsing `external_shipment_id`.
+//
+// Read-only. GET /v2/shipments only.
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { revealSecrets } from '@auxx/credentials/store'
+
+const CREDENTIAL_ID = process.env.SS_CREDENTIAL_ID ?? 't3f9k1su4vwto30g2bi0qbpl'
+const ORG_ID = process.env.SS_ORG_ID ?? 'abgwpa1l81reht2zmwrcihfu'
+const PAGE_SIZE = Number(process.env.SS_PAGE_SIZE ?? 50)
+const OUT = process.env.SS_OUT ?? 'probe-shipments-raw.json'
+
+interface ShipmentItem {
+  sales_order_id?: string | null
+  sales_order_item_id?: string | null
+  external_order_id?: string | null
+  external_order_item_id?: string | null
+  order_source_code?: string | null
+  item_id?: string | null
+  sku?: string | null
+  quantity?: number | null
+}
+
+interface Shipment {
+  shipment_id: string
+  shipment_number?: string | null
+  store_id?: string | null
+  external_shipment_id?: string | null
+  external_order_id?: string | null
+  shipment_status?: string | null
+  items?: ShipmentItem[]
+}
+
+async function main() {
+  const revealed = await revealSecrets<Record<string, unknown>>(CREDENTIAL_ID, ORG_ID)
+  if (revealed.isErr()) throw new Error(`credential read failed: ${revealed.error.code}`)
+  const s = revealed.value.secrets
+  const apiKey = (s.apiKey ?? s.api_key ?? s.secret ?? s.token) as string | undefined
+  if (!apiKey) throw new Error(`no apiKey in secrets; keys = ${Object.keys(s)}`)
+
+  const url = `https://api.shipstation.com/v2/shipments?page_size=${PAGE_SIZE}&sort_by=modified_at&sort_dir=desc`
+  const res = await fetch(url, {
+    headers: { 'api-key': apiKey, accept: 'application/json' },
+    redirect: 'error',
+  })
+  if (!res.ok) throw new Error(`GET /v2/shipments -> ${res.status} ${await res.text()}`)
+
+  const raw = await res.text()
+  mkdirSync(dirname(OUT), { recursive: true })
+  writeFileSync(OUT, JSON.stringify(JSON.parse(raw), null, 2))
+  console.log(`raw response written to ${OUT} (${raw.length} bytes)`)
+
+  const body = JSON.parse(raw) as { shipments?: Shipment[]; total?: number }
+  const shipments = body.shipments ?? []
+  console.log(`\ntotal reported: ${body.total}   returned: ${shipments.length}\n`)
+
+  // Coverage across the page, per field, at BOTH levels.
+  const tally = {
+    shipments: shipments.length,
+    withItems: 0,
+    items: 0,
+    shipment_external_order_id: 0,
+    shipment_external_shipment_id: 0,
+    item_external_order_id: 0,
+    item_external_order_item_id: 0,
+    item_sales_order_id: 0,
+    item_order_source_code: 0,
+    item_item_id: 0,
+  }
+  const sourceCodes = new Map<string, number>()
+  const samples: string[] = []
+
+  for (const s of shipments) {
+    if (s.external_order_id) tally.shipment_external_order_id += 1
+    if (s.external_shipment_id) tally.shipment_external_shipment_id += 1
+    const items = s.items ?? []
+    if (items.length > 0) tally.withItems += 1
+    for (const it of items) {
+      tally.items += 1
+      if (it.external_order_id) tally.item_external_order_id += 1
+      if (it.external_order_item_id) tally.item_external_order_item_id += 1
+      if (it.sales_order_id) tally.item_sales_order_id += 1
+      if (it.item_id) tally.item_item_id += 1
+      if (it.order_source_code) {
+        tally.item_order_source_code += 1
+        sourceCodes.set(it.order_source_code, (sourceCodes.get(it.order_source_code) ?? 0) + 1)
+      }
+    }
+    if (samples.length < 6 && items[0]) {
+      const it = items[0]
+      samples.push(
+        [
+          `  shipment ${s.shipment_id}  number=${s.shipment_number ?? 'null'}`,
+          `    external_shipment_id : ${s.external_shipment_id ?? 'null'}`,
+          `    shipment.external_order_id : ${s.external_order_id ?? 'null'}`,
+          `    item.external_order_id     : ${it.external_order_id ?? 'null'}`,
+          `    item.external_order_item_id: ${it.external_order_item_id ?? 'null'}`,
+          `    item.sales_order_id        : ${it.sales_order_id ?? 'null'}`,
+          `    item.order_source_code     : ${it.order_source_code ?? 'null'}`,
+          `    item.item_id               : ${it.item_id ?? 'null'}  sku=${it.sku ?? 'null'}`,
+        ].join('\n')
+      )
+    }
+  }
+
+  console.log('=== coverage ===')
+  for (const [k, v] of Object.entries(tally)) console.log(`  ${k.padEnd(32)} ${v}`)
+
+  console.log('\n=== order_source_code values ===')
+  if (sourceCodes.size === 0) console.log('  (none returned)')
+  for (const [code, n] of sourceCodes) console.log(`  ${code}: ${n}`)
+
+  console.log('\n=== samples ===')
+  console.log(samples.join('\n\n'))
+
+  // THE question: does item.external_order_id equal the first component of
+  // external_shipment_id? If so the resolver can read a provider-stated id instead of
+  // splitting a string whose format is merchant-specific.
+  let agree = 0
+  let disagree = 0
+  let untestable = 0
+  for (const s of shipments) {
+    const first = (s.external_shipment_id ?? '').split('-')[0]
+    const itemOrderId = (s.items ?? []).find((i) => i.external_order_id)?.external_order_id
+    if (!first || !itemOrderId) {
+      untestable += 1
+      continue
+    }
+    if (first === itemOrderId) agree += 1
+    else {
+      disagree += 1
+      if (disagree <= 3) console.log(`\n  DISAGREE ${s.shipment_id}: ${first} vs ${itemOrderId}`)
+    }
+  }
+  console.log(
+    `\n=== external_shipment_id[0] vs item.external_order_id ===\n  agree=${agree} disagree=${disagree} untestable=${untestable}`
+  )
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -29,6 +29,7 @@ import type { SliceResult, SyncRunCounters, SyncSliceCtx, SyncSource } from '../
 import { runAsyncExportSlice } from './async-export'
 import { flattenConnectionMeta } from './connection-meta'
 import { runConnectorSlice } from './connector-slice-loop'
+import { resolveCrossConnectorLinks } from './cross-connector-links'
 import { listBackfillRunIds, reconcileManagedMarkers, reconcileOrphans } from './reconciliation'
 import { newRecordFailureTally } from './record-failure-tally'
 import { resolveRelationships } from './relationship-pass'
@@ -381,6 +382,7 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     const syncCtx = await this.buildCtx(counters, allMappings)
 
     await resolveRelationships(syncCtx, { stage: 'park' })
+    await this.resolveCrossConnectorLinks(syncCtx)
     await this.emitRecordsInvalidated(syncCtx.touchedDefs)
 
     // Fold the pass's warnings the way the finalize folds its own (no checkpoint key,
@@ -401,6 +403,28 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
       dataConnectorId: this.deps.connector.id,
       runId: this.deps.run.id,
     })
+  }
+
+  /**
+   * Cross-connector record linking, run in the same slot as the relationship two-pass.
+   *
+   * Separate from it because the two-pass resolves targets by
+   * `(dataConnectorId, def, externalId)` and so can only see records THIS connector
+   * created; these links resolve through `RecordIdentity` instead. Additive,
+   * self-deferring and stateless, so a target that is not synced yet costs nothing and
+   * lands on a later run.
+   *
+   * A failure here NEVER fails the run: an order link is a nicety, and losing it must
+   * not turn a clean sync into a failed one.
+   */
+  private async resolveCrossConnectorLinks(syncCtx: SyncCtx): Promise<void> {
+    const result = await resolveCrossConnectorLinks(syncCtx)
+    if (result.isErr()) {
+      logger.warn('cross-connector link pass failed — continuing finalize', {
+        sourceId: this.id,
+        error: result.error.message,
+      })
+    }
   }
 
   /**
@@ -460,6 +484,7 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     const syncCtx = await this.buildCtx(counters, allMappings)
 
     await resolveRelationships(syncCtx)
+    await this.resolveCrossConnectorLinks(syncCtx)
     // reconcileOrphans self-skips non-snapshot streams, so it's a no-op for steady. A
     // snapshot stream's crawl may have spanned several runs (parked at the ingest
     // ceiling, resumed from its cursor on the next trigger), so "seen this backfill"

--- a/packages/lib/src/data-connectors/connector-webhook.test.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.test.ts
@@ -21,6 +21,7 @@ const {
   fetchFn,
   deleteWhere,
   resolveRelationships,
+  resolveCrossConnectorLinks,
   foldRunManifest,
   publishSyncRecordsChanged,
 } = vi.hoisted(() => {
@@ -46,6 +47,10 @@ const {
     fetchFn: vi.fn(),
     deleteWhere: vi.fn(),
     resolveRelationships: vi.fn(),
+    // Faked for the same reason as `resolveRelationships`: the real module reaches the
+    // org cache, whose provider graph touches Drizzle column refs at import time.
+    // `isErr` is all the caller reads.
+    resolveCrossConnectorLinks: vi.fn(async (..._a: unknown[]) => ({ isErr: () => false })),
     // Both are called with the real arity (`(db, runId, fragment)` /
     // `(db, args)`) — declare a rest param so the pass-through mock factory
     // below can forward whatever it receives.
@@ -80,6 +85,9 @@ vi.mock('./reconciliation', () => ({
 }))
 vi.mock('./relationship-pass', () => ({
   resolveRelationships: (...a: unknown[]) => resolveRelationships(...a),
+}))
+vi.mock('./cross-connector-links', () => ({
+  resolveCrossConnectorLinks: (...a: unknown[]) => resolveCrossConnectorLinks(...a),
 }))
 vi.mock('./service', () => ({
   loadConnector: (...a: unknown[]) => loadConnector(...a),

--- a/packages/lib/src/data-connectors/connector-webhook.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.ts
@@ -21,6 +21,7 @@ import { flattenConnectionMeta } from './connection-meta'
 import { prepareConnectorFetch } from './connector-runtime'
 import { ConnectorRateLimitError } from './connectors'
 import { isConnectorCheckpoint } from './connectors/types'
+import { resolveCrossConnectorLinks } from './cross-connector-links'
 import { publishConnectorSync } from './realtime'
 import { archiveExternalId } from './reconciliation'
 import { newRecordFailureTally } from './record-failure-tally'
@@ -146,6 +147,16 @@ export async function runWebhookSteeredRun(
     // connector-wide, so it's safe on a partial run and also clears edges stranded by
     // earlier deliveries. Without it, webhook-steered connectors never form relationships.
     await resolveRelationships(ctx)
+    // Cross-connector links (`RecordIdentity`-resolved, so build-order and
+    // connector-order independent) are safe on a partial run for the same three
+    // reasons, and hold no retry state at all. A failure must not fail the delivery.
+    const links = await resolveCrossConnectorLinks(ctx)
+    if (links.isErr()) {
+      logger.warn('cross-connector link pass failed — continuing webhook finalize', {
+        connectorId,
+        error: links.error.message,
+      })
+    }
 
     // Close the run PARTIAL — it observed a single steered record, so the connector
     // finalize must NOT reconcile orphans (that would archive the rest of the collection).

--- a/packages/lib/src/data-connectors/cross-connector-links/__tests__/dispatch.test.ts
+++ b/packages/lib/src/data-connectors/cross-connector-links/__tests__/dispatch.test.ts
@@ -1,0 +1,46 @@
+// packages/lib/src/data-connectors/cross-connector-links/__tests__/dispatch.test.ts
+// The engine's door: only a ShipStation connector may run the ShipStation pass. Every
+// other connector must not reach a single query, because this hook sits in the hot
+// finalize path of every sync in the product.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSyncCtx } from '../../__test-helpers'
+import type { SyncCtx } from '../../sinks/types'
+
+const h = vi.hoisted(() => ({ shipstation: vi.fn() }))
+
+vi.mock('../shipstation-order-link', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../shipstation-order-link')>()),
+  resolveShipStationOrderLinks: h.shipstation,
+}))
+
+import { ok } from 'neverthrow'
+import { resolveCrossConnectorLinks } from '../index'
+
+const ctx = (type: string): SyncCtx =>
+  makeSyncCtx({ connector: { id: 'dc1', type } as unknown as SyncCtx['connector'] })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.shipstation.mockResolvedValue(ok({ examined: 3, linked: 3 }))
+})
+
+describe('resolveCrossConnectorLinks', () => {
+  it('runs the order link pass for a ShipStation connector', async () => {
+    const result = await resolveCrossConnectorLinks(ctx('app:shipstation'))
+
+    expect(h.shipstation).toHaveBeenCalledTimes(1)
+    expect(result._unsafeUnwrap()).toMatchObject({ linked: 3 })
+  })
+
+  it.each([
+    'app:shopify',
+    'app:quickbooks',
+    'generic_rest',
+  ])('does nothing for a %s connector', async (type) => {
+    const result = await resolveCrossConnectorLinks(ctx(type))
+
+    expect(h.shipstation).not.toHaveBeenCalled()
+    expect(result._unsafeUnwrap()).toMatchObject({ examined: 0, linked: 0 })
+  })
+})

--- a/packages/lib/src/data-connectors/cross-connector-links/__tests__/shipstation-order-link.test.ts
+++ b/packages/lib/src/data-connectors/cross-connector-links/__tests__/shipstation-order-link.test.ts
@@ -1,0 +1,287 @@
+// packages/lib/src/data-connectors/cross-connector-links/__tests__/shipstation-order-link.test.ts
+// The ShipStation -> Shopify order link pass, with `./queries` mocked (Drizzle column
+// refs are undefined under vitest), so only the decision logic runs.
+//
+// The point of this pass is that a WRONG FORMAT GUESS PRODUCES ZERO LINKS, NEVER WRONG
+// LINKS, so most cases below assert that nothing was written: a UUID never reaches a
+// lookup, an unmatched id writes nothing and logs no warning, a too-short prefix is
+// refused, and a second run over an already-correct edge is a no-op.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSyncCtx } from '../../__test-helpers'
+import type { SyncCtx } from '../../sinks/types'
+
+const h = vi.hoisted(() => ({
+  resolveFields: vi.fn(),
+  listBindings: vi.fn(),
+  readExternalIds: vi.fn(),
+  findOrders: vi.fn(),
+  readTargets: vi.fn(),
+  // Params mirror `UnifiedCrudHandler.update` so `mock.calls[n]` destructures as the
+  // real tuple instead of an empty one.
+  update: vi.fn(
+    async (
+      _recordId: string,
+      _values: Record<string, unknown>,
+      _modes?: Record<string, 'set' | 'add' | 'remove'>,
+      _options?: Record<string, unknown>
+    ) => ({})
+  ),
+}))
+
+vi.mock('../queries', () => ({
+  SHIPMENT_ORDER_ATTRIBUTE: 'shipment_order',
+  resolveShipmentOrderLinkFields: h.resolveFields,
+  listShipmentBindings: h.listBindings,
+  readExternalShipmentIds: h.readExternalIds,
+  findShopifyOrderInstances: h.findOrders,
+  readCurrentOrderTargets: h.readTargets,
+}))
+
+import {
+  parseShopifyOrderIdFromExternalShipmentId,
+  resolveShipStationOrderLinks,
+} from '../shipstation-order-link'
+
+const ORG = 'org_1'
+const SHIPMENT_DEF = 'def_shipment'
+const ORDER_DEF = 'def_order'
+const EXT_FIELD = 'fld_external_shipment_id'
+const ORDER_FIELD = 'fld_shipment_order'
+const SHIPMENT = 'inst_shipment_1'
+const ORDER = 'inst_order_1'
+
+/** The verified real-data shape: `<shopifyOrderId>-<unknown>`. */
+const NUMERIC_PAIR = '7475907559600-8667090518192'
+const SHOPIFY_ORDER_ID = '7475907559600'
+/** A real value from the reference account, from a different order source. */
+const UUID_SHAPED = '029dca61-7961-cd09-5338-3cecd1784ede'
+
+function ctx(): SyncCtx {
+  return makeSyncCtx({
+    orgId: ORG,
+    connector: { id: 'dc1', type: 'app:shipstation' } as unknown as SyncCtx['connector'],
+    relationshipCrud: { update: h.update } as unknown as SyncCtx['relationshipCrud'],
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.resolveFields.mockResolvedValue({
+    shipmentDefId: SHIPMENT_DEF,
+    orderDefId: ORDER_DEF,
+    externalShipmentIdFieldId: EXT_FIELD,
+    orderFieldId: ORDER_FIELD,
+  })
+  h.listBindings.mockResolvedValue([{ entityInstanceId: SHIPMENT, pinnedFields: [] }])
+  h.readExternalIds.mockResolvedValue(new Map([[SHIPMENT, NUMERIC_PAIR]]))
+  h.findOrders.mockResolvedValue(new Map([[SHOPIFY_ORDER_ID, ORDER]]))
+  h.readTargets.mockResolvedValue(new Map<string, string>())
+  h.update.mockResolvedValue({})
+})
+
+describe('parseShopifyOrderIdFromExternalShipmentId', () => {
+  it('takes the first component of a numeric pair', () => {
+    expect(parseShopifyOrderIdFromExternalShipmentId(NUMERIC_PAIR)).toBe(SHOPIFY_ORDER_ID)
+  })
+
+  it('refuses a UUID', () => {
+    expect(parseShopifyOrderIdFromExternalShipmentId(UUID_SHAPED)).toBeNull()
+  })
+
+  it('refuses a numeric first component that is too short', () => {
+    expect(parseShopifyOrderIdFromExternalShipmentId('1234567-8667090518192')).toBeNull()
+  })
+
+  it('refuses a bare id with no second component', () => {
+    // Real value on the reference account. It DOES match a stored order, and is
+    // refused anyway: one unverified shape is not evidence for a second one.
+    expect(parseShopifyOrderIdFromExternalShipmentId('7439103557808')).toBeNull()
+  })
+
+  it('refuses a non-numeric second component, and never reads it', () => {
+    expect(parseShopifyOrderIdFromExternalShipmentId('7475907559600-abc')).toBeNull()
+  })
+
+  it('refuses a third component', () => {
+    expect(parseShopifyOrderIdFromExternalShipmentId('7475907559600-866709-1')).toBeNull()
+  })
+
+  it('refuses empty and missing values', () => {
+    expect(parseShopifyOrderIdFromExternalShipmentId('')).toBeNull()
+    expect(parseShopifyOrderIdFromExternalShipmentId(null)).toBeNull()
+    expect(parseShopifyOrderIdFromExternalShipmentId(undefined)).toBeNull()
+  })
+})
+
+describe('resolveShipStationOrderLinks — the matching case', () => {
+  it('links a numeric pair whose first component matches a stored Shopify order', async () => {
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toMatchObject({ examined: 1, linked: 1, unmatched: 0 })
+    expect(h.update).toHaveBeenCalledTimes(1)
+    const [recordId, values] = h.update.mock.calls[0]!
+    expect(recordId).toBe(`${SHIPMENT_DEF}:${SHIPMENT}`)
+    expect(values).toEqual({ shipment_order: `${ORDER_DEF}:${ORDER}` })
+  })
+
+  it('looks the order up by the FIRST component only', async () => {
+    await resolveShipStationOrderLinks(ctx())
+    expect(h.findOrders).toHaveBeenCalledWith(expect.anything(), ORG, ORDER_DEF, [SHOPIFY_ORDER_ID])
+  })
+
+  it('marks the shipment def touched so the grid refetches', async () => {
+    const c = ctx()
+    await resolveShipStationOrderLinks(c)
+    expect([...c.touchedDefs]).toEqual([SHIPMENT_DEF])
+  })
+})
+
+describe('resolveShipStationOrderLinks — no match is silent', () => {
+  it('writes nothing when the order is not synced yet', async () => {
+    h.findOrders.mockResolvedValue(new Map())
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toMatchObject({ examined: 1, unmatched: 1, linked: 0 })
+    expect(h.update).not.toHaveBeenCalled()
+  })
+
+  it('leaves no retry state behind — a later run re-derives and links', async () => {
+    h.findOrders.mockResolvedValue(new Map())
+    await resolveShipStationOrderLinks(ctx())
+
+    // The Shopify delta lands; nothing about the shipment changed.
+    h.findOrders.mockResolvedValue(new Map([[SHOPIFY_ORDER_ID, ORDER]]))
+    const second = await resolveShipStationOrderLinks(ctx())
+
+    expect(second._unsafeUnwrap()).toMatchObject({ linked: 1, unmatched: 0 })
+    expect(h.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes nothing when the id is ambiguous across two Shopify connections', async () => {
+    h.findOrders.mockResolvedValue(new Map([[SHOPIFY_ORDER_ID, null]]))
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ unmatched: 1, linked: 0 })
+    expect(h.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveShipStationOrderLinks — the shape gate', () => {
+  it('skips a UUID without ever attempting a lookup', async () => {
+    h.readExternalIds.mockResolvedValue(new Map([[SHIPMENT, UUID_SHAPED]]))
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ examined: 1, skippedShape: 1, linked: 0 })
+    expect(h.findOrders).not.toHaveBeenCalled()
+    expect(h.update).not.toHaveBeenCalled()
+  })
+
+  it('skips a first component that is numeric but too short', async () => {
+    h.readExternalIds.mockResolvedValue(new Map([[SHIPMENT, '1234567-8667090518192']]))
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ skippedShape: 1, linked: 0 })
+    expect(h.findOrders).not.toHaveBeenCalled()
+  })
+
+  it('counts a shipment with no stored external id separately, and skips it', async () => {
+    h.readExternalIds.mockResolvedValue(new Map())
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ missingExternalId: 1, skippedShape: 0 })
+    expect(h.findOrders).not.toHaveBeenCalled()
+  })
+
+  it('still links the qualifying siblings of a skipped value', async () => {
+    h.listBindings.mockResolvedValue([
+      { entityInstanceId: 'inst_uuid', pinnedFields: [] },
+      { entityInstanceId: SHIPMENT, pinnedFields: [] },
+    ])
+    h.readExternalIds.mockResolvedValue(
+      new Map([
+        ['inst_uuid', UUID_SHAPED],
+        [SHIPMENT, NUMERIC_PAIR],
+      ])
+    )
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ examined: 2, skippedShape: 1, linked: 1 })
+    expect(h.update).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('resolveShipStationOrderLinks — idempotency', () => {
+  it('writes nothing when the edge already points at the right order', async () => {
+    h.readTargets.mockResolvedValue(new Map([[`${SHIPMENT}::${ORDER_FIELD}`, ORDER]]))
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ alreadyLinked: 1, linked: 0 })
+    expect(h.update).not.toHaveBeenCalled()
+  })
+
+  it('does not touch the def when every edge is already correct', async () => {
+    h.readTargets.mockResolvedValue(new Map([[`${SHIPMENT}::${ORDER_FIELD}`, ORDER]]))
+
+    const c = ctx()
+    await resolveShipStationOrderLinks(c)
+
+    expect([...c.touchedDefs]).toEqual([])
+  })
+
+  it('rewrites an edge pointing at the WRONG order', async () => {
+    h.readTargets.mockResolvedValue(new Map([[`${SHIPMENT}::${ORDER_FIELD}`, 'inst_order_other']]))
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ linked: 1, alreadyLinked: 0 })
+    expect(h.update).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('resolveShipStationOrderLinks — guards', () => {
+  it('leaves a field the user paused alone', async () => {
+    h.listBindings.mockResolvedValue([{ entityInstanceId: SHIPMENT, pinnedFields: [ORDER_FIELD] }])
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result._unsafeUnwrap()).toMatchObject({ pinned: 1, linked: 0 })
+    expect(h.update).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the org has no shipment def, field or order def', async () => {
+    h.resolveFields.mockResolvedValue(null)
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toMatchObject({ examined: 0, linked: 0 })
+    expect(h.listBindings).not.toHaveBeenCalled()
+  })
+
+  it('counts a failed write without throwing, so a later run retries it', async () => {
+    h.update.mockRejectedValue(new Error('boom'))
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toMatchObject({ failed: 1, linked: 0 })
+  })
+
+  it('returns err rather than throwing when a read blows up', async () => {
+    h.listBindings.mockRejectedValue(new Error('db down'))
+
+    const result = await resolveShipStationOrderLinks(ctx())
+
+    expect(result.isErr()).toBe(true)
+  })
+})

--- a/packages/lib/src/data-connectors/cross-connector-links/index.ts
+++ b/packages/lib/src/data-connectors/cross-connector-links/index.ts
@@ -1,0 +1,65 @@
+// packages/lib/src/data-connectors/cross-connector-links/index.ts
+// The engine's single door to cross-connector record linking.
+//
+// A connector's own two-pass (`relationship-pass.ts`) resolves edges by
+// `(dataConnectorId, def, externalId)` and so can only ever see records THIS
+// connector created. The few links that must cross that fence resolve through
+// `RecordIdentity` instead, and they live here.
+//
+// The dispatch is deliberately a `switch` on `connector.type` rather than a
+// registry: there is exactly one such link today (ShipStation shipment -> Shopify
+// order), and its rules are specific enough — a provider-specific id format,
+// inferred from one merchant — that generalising them would mean inventing
+// configuration nobody has asked for. What the seam DOES buy is that the engine's
+// finalize path never names an app.
+
+import { ok, type Result } from 'neverthrow'
+import type { SyncCtx } from '../sinks/types'
+import {
+  resolveShipStationOrderLinks,
+  SHIPSTATION_CONNECTOR_TYPE,
+  type ShipStationOrderLinkSummary,
+} from './shipstation-order-link'
+
+/** What a cross-connector link pass did, or all-zeroes when none applied. */
+export type CrossConnectorLinkSummary = ShipStationOrderLinkSummary
+
+const NONE: CrossConnectorLinkSummary = {
+  examined: 0,
+  missingExternalId: 0,
+  skippedShape: 0,
+  unmatched: 0,
+  linked: 0,
+  alreadyLinked: 0,
+  pinned: 0,
+  failed: 0,
+}
+
+/**
+ * Run whichever cross-connector link pass this connector has, if any.
+ *
+ * Called alongside `resolveRelationships` at the connector finalize, at a park, and
+ * after a webhook-steered fetch — all three for the same reason: the pass is
+ * additive, self-deferring and connector-wide, so it is safe on a partial run and a
+ * target that is not synced yet simply resolves on a later run.
+ *
+ * Holds no retry state, so calling it more often is free. Never throws; the `err`
+ * arm is for the caller to log, never to fail the run on.
+ */
+export async function resolveCrossConnectorLinks(
+  ctx: SyncCtx
+): Promise<Result<CrossConnectorLinkSummary, Error>> {
+  switch (ctx.connector.type) {
+    case SHIPSTATION_CONNECTOR_TYPE:
+      return resolveShipStationOrderLinks(ctx)
+    default:
+      return ok(NONE)
+  }
+}
+
+export {
+  parseShopifyOrderIdFromExternalShipmentId,
+  resolveShipStationOrderLinks,
+  SHIPSTATION_CONNECTOR_TYPE,
+  type ShipStationOrderLinkSummary,
+} from './shipstation-order-link'

--- a/packages/lib/src/data-connectors/cross-connector-links/queries.ts
+++ b/packages/lib/src/data-connectors/cross-connector-links/queries.ts
@@ -1,0 +1,224 @@
+// packages/lib/src/data-connectors/cross-connector-links/queries.ts
+// Every read the ShipStation -> Shopify order link pass makes, in one file so the
+// decision logic in `shipstation-order-link.ts` stays pure enough to unit-test
+// without a database (Drizzle column refs are undefined under vitest).
+//
+// All four reads are BULK and bounded: the pass never issues a query per shipment.
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { getCachedCustomFields, getCachedEntityDefId } from '../../cache'
+import { readRelationshipTargets } from '../service'
+
+/** `entityType` of the registry defs this pass bridges. */
+const SHIPMENT_ENTITY_TYPE = 'shipment'
+const ORDER_ENTITY_TYPE = 'order'
+
+/** The ShipStation app field carrying the raw `external_shipment_id`. */
+const EXTERNAL_SHIPMENT_ID_APP_FIELD = 'externalShipmentId'
+
+/** The `systemAttribute` of the relationship this pass populates. */
+export const SHIPMENT_ORDER_ATTRIBUTE = 'shipment_order'
+
+/** `RecordIdentity.source` / `.appFieldKey` the Shopify connector writes an order under. */
+const SHOPIFY_SOURCE = 'shopify'
+const SHOPIFY_ORDER_ID_APP_FIELD = 'shopifyOrderId'
+
+/** Max ids per `IN (...)`, matching `readRelationshipTargets`. */
+const CHUNK = 500
+
+/** The four org-scoped ids the pass needs before it can read anything else. */
+export interface ShipmentOrderLinkFields {
+  shipmentDefId: string
+  orderDefId: string
+  /** `CustomField.id` of the shipment's `externalShipmentId` app field. */
+  externalShipmentIdFieldId: string
+  /** `CustomField.id` of `shipment_order`. */
+  orderFieldId: string
+}
+
+/** One live shipment binding of the connector being synced. */
+export interface ShipmentBinding {
+  entityInstanceId: string
+  /** Concrete `CustomField.id`s the user PAUSED on this record (plan 40). */
+  pinnedFields: string[]
+}
+
+function chunk<T>(items: T[], size = CHUNK): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size))
+  return out
+}
+
+/**
+ * Resolve the shipment/order defs and the two fields from the org cache.
+ *
+ * Returns `null` when any of them is missing, which is the whole "this org is not
+ * shaped for the link" exit: an org without the shipment registry def, without the
+ * ShipStation app field, or on a catalog old enough to predate `shipment_order`
+ * simply does no work. Never an error — a missing def is not a failure of the sync.
+ */
+export async function resolveShipmentOrderLinkFields(
+  orgId: string
+): Promise<ShipmentOrderLinkFields | null> {
+  const [shipmentDefId, orderDefId] = await Promise.all([
+    getCachedEntityDefId(orgId, SHIPMENT_ENTITY_TYPE),
+    getCachedEntityDefId(orgId, ORDER_ENTITY_TYPE),
+  ])
+  if (!shipmentDefId || !orderDefId) return null
+
+  const shipmentFields = await getCachedCustomFields(orgId, shipmentDefId)
+  const externalIdField = shipmentFields.find(
+    (f) => f.appFieldKey === EXTERNAL_SHIPMENT_ID_APP_FIELD
+  )
+  const orderField = shipmentFields.find((f) => f.systemAttribute === SHIPMENT_ORDER_ATTRIBUTE)
+  if (!externalIdField || !orderField) return null
+
+  return {
+    shipmentDefId,
+    orderDefId,
+    externalShipmentIdFieldId: externalIdField.id,
+    orderFieldId: orderField.id,
+  }
+}
+
+/**
+ * Live, bound shipment records of ONE connector.
+ *
+ * Scoped to the connector rather than to the def so a second ShipStation
+ * connection in the same org resolves only its own shipments, and archived
+ * bindings are skipped (their record is gone upstream; re-linking it is noise).
+ * Backed by the `(dataConnectorId, entityDefinitionId, externalId)` index prefix.
+ */
+export async function listShipmentBindings(
+  db: Database,
+  dataConnectorId: string,
+  shipmentDefId: string
+): Promise<ShipmentBinding[]> {
+  const rows = await db
+    .select({
+      entityInstanceId: schema.DataConnectorItem.entityInstanceId,
+      pinnedFields: schema.DataConnectorItem.pinnedFields,
+    })
+    .from(schema.DataConnectorItem)
+    .where(
+      and(
+        eq(schema.DataConnectorItem.dataConnectorId, dataConnectorId),
+        eq(schema.DataConnectorItem.entityDefinitionId, shipmentDefId),
+        isNull(schema.DataConnectorItem.archivedAt)
+      )
+    )
+
+  const out: ShipmentBinding[] = []
+  for (const row of rows) {
+    if (!row.entityInstanceId) continue
+    out.push({ entityInstanceId: row.entityInstanceId, pinnedFields: row.pinnedFields ?? [] })
+  }
+  return out
+}
+
+/**
+ * Raw `external_shipment_id` per shipment instance.
+ *
+ * Read from `FieldValue` rather than from the connector item because the value is
+ * an ordinary app-field cell, not part of the binding. A shipment with no value is
+ * simply absent from the map.
+ *
+ * @returns `entityInstanceId` -> the raw, unparsed provider string
+ */
+export async function readExternalShipmentIds(
+  db: Database,
+  organizationId: string,
+  fieldId: string,
+  entityInstanceIds: string[]
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>()
+  for (const ids of chunk(entityInstanceIds)) {
+    const rows = await db
+      .select({
+        entityId: schema.FieldValue.entityId,
+        valueText: schema.FieldValue.valueText,
+      })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.organizationId, organizationId),
+          eq(schema.FieldValue.fieldId, fieldId),
+          inArray(schema.FieldValue.entityId, ids)
+        )
+      )
+    for (const row of rows) {
+      if (row.valueText && !out.has(row.entityId)) out.set(row.entityId, row.valueText)
+    }
+  }
+  return out
+}
+
+/**
+ * Reverse-resolve Shopify order ids to the order records this org already stores,
+ * through `RecordIdentity` (the write-through index the Shopify connector mirrors
+ * every identity cell into) rather than through `DataConnectorItem` — which is what
+ * makes this CROSS-connector at all. `findItemByDef` filters `dataConnectorId` with
+ * hard equality, so the connector-scoped path can never see a Shopify-created order.
+ *
+ * `connectionId` is deliberately NOT filtered: the ShipStation side carries no usable
+ * channel signal (`order_source_code` is null on every shipment), so the pass cannot
+ * know which store an id came from. An id that resolves to two different records
+ * across two Shopify connections is mapped to `null` — AMBIGUOUS, treated by the
+ * caller exactly like "not found", so a two-store org gets no link rather than a
+ * coin-flip link.
+ *
+ * @returns `externalId` -> order `entityInstanceId`, or `null` when ambiguous
+ */
+export async function findShopifyOrderInstances(
+  db: Database,
+  organizationId: string,
+  orderDefId: string,
+  externalIds: string[]
+): Promise<Map<string, string | null>> {
+  const out = new Map<string, string | null>()
+  for (const ids of chunk(externalIds)) {
+    const rows = await db
+      .select({
+        externalId: schema.RecordIdentity.externalId,
+        entityInstanceId: schema.RecordIdentity.entityInstanceId,
+      })
+      .from(schema.RecordIdentity)
+      .where(
+        and(
+          eq(schema.RecordIdentity.organizationId, organizationId),
+          eq(schema.RecordIdentity.entityDefinitionId, orderDefId),
+          eq(schema.RecordIdentity.source, SHOPIFY_SOURCE),
+          eq(schema.RecordIdentity.appFieldKey, SHOPIFY_ORDER_ID_APP_FIELD),
+          inArray(schema.RecordIdentity.externalId, ids)
+        )
+      )
+    for (const row of rows) {
+      const seen = out.get(row.externalId)
+      if (seen === undefined) out.set(row.externalId, row.entityInstanceId)
+      else if (seen !== row.entityInstanceId) out.set(row.externalId, null)
+    }
+  }
+  return out
+}
+
+/**
+ * Current `shipment_order` targets, for the idempotency guard. Thin wrapper over
+ * the two-pass's own reader so both passes answer "is this edge already right?"
+ * from identical rules (exactly one non-null target, or absent).
+ *
+ * @returns `${entityInstanceId}::${orderFieldId}` -> current target instance id
+ */
+export async function readCurrentOrderTargets(
+  db: Database,
+  organizationId: string,
+  orderFieldId: string,
+  entityInstanceIds: string[]
+): Promise<Map<string, string>> {
+  return readRelationshipTargets(
+    db,
+    organizationId,
+    entityInstanceIds.map((entityInstanceId) => ({ entityInstanceId, fieldId: orderFieldId }))
+  )
+}

--- a/packages/lib/src/data-connectors/cross-connector-links/shipstation-order-link.ts
+++ b/packages/lib/src/data-connectors/cross-connector-links/shipstation-order-link.ts
@@ -1,0 +1,276 @@
+// packages/lib/src/data-connectors/cross-connector-links/shipstation-order-link.ts
+// Link a ShipStation shipment to the Shopify order it was created from
+// (plans/apps/shipstation/shipstation-status-and-linking-plan.md §4).
+//
+// WHY THIS IS NOT A CONNECTOR MAPPING (§4.4, verified in `service.ts`):
+// `linkMode: 'reference'` cannot cross connectors. `findItemByDef` filters
+// `dataConnectorId` with hard equality, so a ShipStation reference to a
+// Shopify-created order resolves nothing, lands back on `stillPending`, and is
+// retried every run forever. `shipment_order` is therefore declared on the def and
+// bound by nothing. This pass fills it from the OTHER side of the fence:
+// `RecordIdentity`, the org-wide, connector-agnostic identity index.
+//
+// THE JOIN, AND WHY IT IS SAFE TO INFER:
+// `external_shipment_id` is populated 135/135 on the reference account and shaped
+// `<shopifyOrderId>-<unknown>`, e.g. `7475907559600-8667090518192`. Only the FIRST
+// component is verified; the suffix matches 0 of 135 Shopify order ids and its
+// semantics are unknown, so this pass never parses it.
+//
+// The format is INFERRED from one merchant, one order source, one carrier. It is not
+// provider-stated: `order_source_code` is null on every shipment and every shipment
+// item, so we cannot ask the API which channel a shipment came from, and the shape is
+// not even uniform inside one merchant (9 of 135 values are UUIDs from a different
+// order source). Every rule below exists so a WRONG FORMAT GUESS PRODUCES ZERO LINKS,
+// NEVER WRONG LINKS:
+//
+//   - attempt only on `^[0-9]{8,}-[0-9]+$`; a UUID, a bare id, or anything else is
+//     skipped without a lookup
+//   - link only on EXACT string equality to a stored Shopify order id
+//   - no match means no link, SILENTLY: not an error, not a warning, and above all
+//     not a pending edge that retries forever. A merchant on a different shape gets
+//     nulls, which is the status quo
+//   - an id resolving to two records across two Shopify connections is AMBIGUOUS and
+//     links nothing
+//   - never a fuzzy match, a nearest match, or a match on order NUMBER. Order numbers
+//     are merchant-customizable (prefixes, suffixes, custom sequences); order ids are
+//     opaque global integers with no merchant control. That distinction is the entire
+//     reason this is safe
+//   - never a match on TRACKING NUMBER, anywhere (see the connector's own comments)
+//
+// NOT-YET-SYNCED IS THE NORMAL CASE, NOT AN ERROR. A sync can park partway (the 9,000
+// record ingest ceiling), and ShipStation ships faster than the Shopify delta lands:
+// on the reference account 8 of the 125 qualifying shipments name an order id larger
+// than the largest order synced. Those simply do not link this run. The pass holds NO
+// retry state of any kind — it re-derives everything from `external_shipment_id`,
+// which is stored raw — so a later run picks them up for free and nothing accumulates.
+//
+// IDEMPOTENCY, the same fix `relationship-pass.ts` needed: the pass re-examines every
+// shipment on every run, so without a guard it would DELETE+INSERT an identical
+// `FieldValue` row and fire the whole `entity:field:updated` fan-out (timeline entry,
+// activity touch, record rules) for each, every 15 minutes. The fix suppresses the
+// WRITE, not the event: one bulk pre-read of the current targets, and an edge already
+// pointing at the right order is left alone. A genuine link still fires everything it
+// fires today.
+
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError } from '../../errors'
+import { toRecordId } from '../../resources/resource-id'
+import type { SyncCtx } from '../sinks/types'
+import {
+  findShopifyOrderInstances,
+  listShipmentBindings,
+  readCurrentOrderTargets,
+  readExternalShipmentIds,
+  resolveShipmentOrderLinkFields,
+  SHIPMENT_ORDER_ATTRIBUTE,
+} from './queries'
+
+const logger = createScopedLogger('data-connector-shipstation-order-link')
+
+/**
+ * `DataConnector.type` of a ShipStation connector. The dispatch gates on this, so
+ * no other connector ever runs this pass.
+ */
+export const SHIPSTATION_CONNECTOR_TYPE = 'app:shipstation'
+
+/**
+ * The ONLY accepted shape. Anchored at both ends, so a UUID
+ * (`029dca61-7961-cd09-...`), a bare id (`7439103557808`) and a three-part value all
+ * fail it. The `{8,}` floor rejects a short numeric prefix that could collide with an
+ * unrelated integer; real Shopify order ids are 13 digits today.
+ */
+const EXTERNAL_SHIPMENT_ID_PATTERN = /^([0-9]{8,})-[0-9]+$/
+
+/** What one pass did. Every counter is a shipment, and they sum to `examined`. */
+export interface ShipStationOrderLinkSummary {
+  /** Live shipment bindings of this connector that the pass looked at. */
+  examined: number
+  /** No `external_shipment_id` stored at all. */
+  missingExternalId: number
+  /** Stored, but not numeric-pair shaped (UUIDs, bare ids): skipped without a lookup. */
+  skippedShape: number
+  /**
+   * Parsed to a plausible order id that this org does not store, or that is ambiguous
+   * across two Shopify connections. Left null, silently — usually an order the Shopify
+   * connector has not synced yet, which resolves on a later run at no cost.
+   */
+  unmatched: number
+  /** Edges written this pass. */
+  linked: number
+  /** Edges already pointing at the right order: no write, no event, no `touchedDefs`. */
+  alreadyLinked: number
+  /** The user PAUSED `shipment_order` on this record (plan 40), so it is left alone. */
+  pinned: number
+  /** The relationship write threw. No state is kept; the next run simply retries. */
+  failed: number
+}
+
+const EMPTY: ShipStationOrderLinkSummary = {
+  examined: 0,
+  missingExternalId: 0,
+  skippedShape: 0,
+  unmatched: 0,
+  linked: 0,
+  alreadyLinked: 0,
+  pinned: 0,
+  failed: 0,
+}
+
+/**
+ * Extract the Shopify order id from a raw `external_shipment_id`.
+ *
+ * Pure, and the single place the format guess lives. Returns `null` for anything that
+ * is not exactly `<8+ digits>-<digits>` — which is what turns "we guessed the shape
+ * wrong" into "we linked nothing" instead of "we linked wrongly". The second component
+ * is matched only so the shape can be asserted; its value is never read.
+ */
+export function parseShopifyOrderIdFromExternalShipmentId(
+  raw: string | null | undefined
+): string | null {
+  if (!raw) return null
+  return EXTERNAL_SHIPMENT_ID_PATTERN.exec(raw)?.[1] ?? null
+}
+
+/**
+ * Resolve `shipment_order` for every live shipment of a ShipStation connector.
+ *
+ * Runs at the connector finalize, at a park, and after a webhook-steered fetch. Safe
+ * on a partial run for the same reasons the relationship pass is: it is additive,
+ * self-deferring and connector-wide.
+ *
+ * Never throws — an order link is a nicety, and a failure here must not turn a clean
+ * sync into a failed one. Callers log the `err` and carry on.
+ */
+export async function resolveShipStationOrderLinks(
+  ctx: SyncCtx
+): Promise<Result<ShipStationOrderLinkSummary, Error>> {
+  try {
+    return ok(await runPass(ctx))
+  } catch (error) {
+    logger.warn('shipstation order link pass failed — links left untouched', {
+      connectorId: ctx.connector.id,
+      runId: ctx.runId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return err(error instanceof AuxxError ? error : new AuxxError('ShipStation order link failed'))
+  }
+}
+
+async function runPass(ctx: SyncCtx): Promise<ShipStationOrderLinkSummary> {
+  const fields = await resolveShipmentOrderLinkFields(ctx.orgId)
+  if (!fields) return EMPTY
+
+  const bindings = await listShipmentBindings(ctx.db, ctx.connector.id, fields.shipmentDefId)
+  if (bindings.length === 0) return EMPTY
+
+  const summary: ShipStationOrderLinkSummary = { ...EMPTY, examined: bindings.length }
+
+  // One record can carry two bindings (two mappings onto one instance), so pins union.
+  const pinnedByInstance = new Map<string, Set<string>>()
+  for (const binding of bindings) {
+    let pins = pinnedByInstance.get(binding.entityInstanceId)
+    if (!pins) {
+      pins = new Set<string>()
+      pinnedByInstance.set(binding.entityInstanceId, pins)
+    }
+    for (const fieldId of binding.pinnedFields) pins.add(fieldId)
+  }
+  const instanceIds = [...pinnedByInstance.keys()]
+
+  const rawById = await readExternalShipmentIds(
+    ctx.db,
+    ctx.orgId,
+    fields.externalShipmentIdFieldId,
+    instanceIds
+  )
+
+  // PARSE + SHAPE GATE. Everything that does not qualify is counted and dropped here,
+  // before any lookup, so a merchant on a different shape costs one regex per row.
+  const candidates = new Map<string, string>()
+  for (const instanceId of instanceIds) {
+    const raw = rawById.get(instanceId)
+    if (!raw) {
+      summary.missingExternalId += 1
+      continue
+    }
+    const orderExternalId = parseShopifyOrderIdFromExternalShipmentId(raw)
+    if (!orderExternalId) {
+      summary.skippedShape += 1
+      continue
+    }
+    candidates.set(instanceId, orderExternalId)
+  }
+  if (candidates.size === 0) return summary
+
+  const orderInstances = await findShopifyOrderInstances(ctx.db, ctx.orgId, fields.orderDefId, [
+    ...new Set(candidates.values()),
+  ])
+
+  // EXACT EQUALITY ONLY. `undefined` (no such order yet) and `null` (ambiguous across
+  // two Shopify connections) are both "no link", and both are silent.
+  const resolved = new Map<string, string>()
+  for (const [instanceId, orderExternalId] of candidates) {
+    const orderInstanceId = orderInstances.get(orderExternalId)
+    if (!orderInstanceId) {
+      summary.unmatched += 1
+      continue
+    }
+    resolved.set(instanceId, orderInstanceId)
+  }
+  if (resolved.size === 0) return summary
+
+  const currentTargets = await readCurrentOrderTargets(ctx.db, ctx.orgId, fields.orderFieldId, [
+    ...resolved.keys(),
+  ])
+
+  let firstWriteError: string | undefined
+  for (const [instanceId, orderInstanceId] of resolved) {
+    // PAUSED on this record (plan 40 D4): the user re-pointed the order by hand, so
+    // the connector may not touch it. Not a warning — it is the user's choice.
+    if (pinnedByInstance.get(instanceId)?.has(fields.orderFieldId)) {
+      summary.pinned += 1
+      continue
+    }
+
+    // IDEMPOTENCY GUARD. Deliberately does NOT `touchedDefs.add(...)`: nothing changed
+    // on this def from this pass, so it must not force a `records:invalidated` refetch.
+    if (currentTargets.get(`${instanceId}::${fields.orderFieldId}`) === orderInstanceId) {
+      summary.alreadyLinked += 1
+      continue
+    }
+
+    try {
+      // Through `relationshipCrud`, not `crud`: `crud` runs under the run's silent
+      // `sync` session, and a genuine new link must keep firing `entity:field:updated`,
+      // the activity touch and record rules.
+      await ctx.relationshipCrud.update(
+        toRecordId(fields.shipmentDefId, instanceId),
+        { [SHIPMENT_ORDER_ATTRIBUTE]: toRecordId(fields.orderDefId, orderInstanceId) },
+        undefined,
+        {}
+      )
+      ctx.touchedDefs.add(fields.shipmentDefId)
+      summary.linked += 1
+    } catch (error) {
+      summary.failed += 1
+      firstWriteError ??= error instanceof Error ? error.message : String(error)
+    }
+  }
+
+  if (summary.failed > 0) {
+    logger.warn('shipstation order links failed to write — retried on the next run', {
+      connectorId: ctx.connector.id,
+      runId: ctx.runId,
+      failed: summary.failed,
+      error: firstWriteError,
+    })
+  }
+
+  logger.info('shipstation order link pass done', {
+    connectorId: ctx.connector.id,
+    runId: ctx.runId,
+    ...summary,
+  })
+  return summary
+}

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -108,6 +108,15 @@ export {
   isConnectorCheckpoint,
   PermanentSteerError,
 } from './connectors'
+// Cross-connector record linking (shipstation-status-and-linking-plan §4): the links
+// the connector-scoped two-pass structurally cannot resolve.
+export {
+  type CrossConnectorLinkSummary,
+  parseShopifyOrderIdFromExternalShipmentId,
+  resolveCrossConnectorLinks,
+  resolveShipStationOrderLinks,
+  type ShipStationOrderLinkSummary,
+} from './cross-connector-links'
 export type {
   BackfillSliceJobData,
   DataConnectorSyncJobData,

--- a/packages/lib/src/data-migrations/migrations/151-shipment-label-cost-and-document.test.ts
+++ b/packages/lib/src/data-migrations/migrations/151-shipment-label-cost-and-document.test.ts
@@ -1,0 +1,285 @@
+// packages/lib/src/data-migrations/migrations/151-shipment-label-cost-and-document.test.ts
+//
+// Migration 151 is four INSERTs over a def that already exists, so the write is
+// not what silently goes wrong. What does:
+//
+//  - the id is a permanent ledger key in a space shared with the whole-database
+//    shape, and a reused one is skipped by every database that ran the old
+//    migration, with no error;
+//  - the migration names its four fields by KEY, so a registry rename with no
+//    rename here provisions fewer fields than it claims to. The migration
+//    throws on that, and this pins the keys so the throw is never the first
+//    anyone hears of it;
+//  - CURRENCY is an INTEGER MINOR-UNIT amount. The provider sends a decimal, so
+//    a field declared as NUMBER, or a key without the `Minor` suffix that says
+//    what the integer means, is how $16.54 silently becomes 16 cents;
+//  - a sort order colliding with an existing shipment field would reorder the
+//    panel rather than append to it.
+
+import { SYSTEM_ATTRIBUTES } from '@auxx/types/system-attribute'
+import { describe, expect, it, vi } from 'vitest'
+import type { ResourceField } from '../../resources/registry/field-types'
+
+// `getOrgCache` is a Redis round trip nothing here backs, and
+// `entity-helpers` is the database. Both stubbed for the same reason 150's
+// test stubs the cache: `up()` is being driven for its DECISIONS.
+const invalidateAndRecompute = vi.fn(async () => {})
+vi.mock('../../cache', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getOrgCache: () => ({ invalidateAndRecompute }),
+}))
+
+/** Entity types the stubbed `loadExistingState` reports the org as holding. */
+let existingDefs: string[] = ['shipment']
+/** Field keys the stubbed `ensureCustomFields` reports as already present. */
+let existingFieldKeys: string[] = []
+/** Every `ensureCustomFields` call this run made, for the assertions below. */
+const ensureCalls: { entityType: string; defId: string; fieldKeys: string[] }[] = []
+
+// Spread the original: `registry.ts` also imports 149, which needs
+// `ensureEntityDefinitions`, `linkNewRelationships` and `linkDisplayFields` to
+// exist as named exports at import time.
+vi.mock('../../seed/entity-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  loadExistingState: async () => ({
+    entityDefs: new Map(
+      existingDefs.map((type) => [type, { id: `def_${type}`, entityType: type }])
+    ),
+    fields: new Map(),
+  }),
+  ensureCustomFields: async (
+    _db: unknown,
+    _organizationId: string,
+    entityType: string,
+    defId: string,
+    fields: Record<string, ResourceField>,
+    _existing: unknown,
+    state: { fieldsCreated: number }
+  ) => {
+    const fieldKeys = Object.keys(fields)
+    ensureCalls.push({ entityType, defId, fieldKeys })
+    for (const key of fieldKeys) {
+      if (!existingFieldKeys.includes(key)) state.fieldsCreated++
+    }
+    return new Map()
+  },
+}))
+
+const { migration151ShipmentLabelCostAndDocument } = await import(
+  './151-shipment-label-cost-and-document'
+)
+const { ALL_DATA_MIGRATIONS, PER_ORG_MIGRATIONS } = await import('../registry')
+const { SHIPMENT_FIELDS } = await import('../../resources/registry/resources/shipment-fields')
+
+const MIGRATION_ID = '151-shipment-label-cost-and-document'
+const ORG = 'org_1'
+const DB = {} as never
+
+/** The four keys this migration exists to provision, with their attributes. */
+const NEW_FIELDS = [
+  ['costMinor', 'shipment_cost'],
+  ['insuranceCostMinor', 'shipment_insurance_cost'],
+  ['insuranceClaim', 'shipment_insurance_claim'],
+  ['labelUrl', 'shipment_label_url'],
+] as const
+
+function resetStubs() {
+  existingDefs = ['shipment']
+  existingFieldKeys = []
+  ensureCalls.length = 0
+  invalidateAndRecompute.mockClear()
+}
+
+describe('migration 151 registration', () => {
+  it('is registered exactly once, with the id the module exports', () => {
+    const ids = PER_ORG_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect(migration151ShipmentLabelCostAndDocument.id).toBe(MIGRATION_ID)
+  })
+
+  it('is the only migration claiming the number 151', () => {
+    const numbers = ALL_DATA_MIGRATIONS.map((m) => m.id.split('-')[0])
+    expect(numbers.filter((n) => n === '151')).toHaveLength(1)
+    expect(new Set(numbers).size).toBe(numbers.length)
+  })
+
+  it('reaches the shared registry without an entry of its own, sorted after 149', () => {
+    // `buildRegistry` spreads `PER_ORG_MIGRATIONS.map(perOrgMigration)`, so
+    // registering there is the whole job - a hand-written entry would be a
+    // duplicate id that `assertUniqueMigrationIds` throws on at module load.
+    const ids = ALL_DATA_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    // 149 created the def this widens; the registry's own id sort is what
+    // guarantees the order.
+    expect(ids.indexOf(MIGRATION_ID)).toBeGreaterThan(ids.indexOf('149-shipment-parcel'))
+    expect([...ids]).toEqual([...ids].sort((a, b) => a.localeCompare(b)))
+  })
+})
+
+describe('what the migration provisions exists in the registry', () => {
+  it.each(NEW_FIELDS)('%s is a shipment field carrying %s', (key, attribute) => {
+    const field = SHIPMENT_FIELDS[key]
+    expect(field).toBeDefined()
+    expect(field?.key).toBe(key)
+    expect(field?.systemAttribute).toBe(attribute)
+    expect(field?.isSystem).toBe(true)
+  })
+
+  it.each(NEW_FIELDS)('%s declares a systemAttribute in the shared union', (key) => {
+    expect(SYSTEM_ATTRIBUTES).toContain(SHIPMENT_FIELDS[key]?.systemAttribute)
+  })
+
+  it.each(NEW_FIELDS)('%s is nullable, because only a live label supplies one', (key) => {
+    // Every one is label-level and the shipment can outlive its label: a fully
+    // voided shipment has no live label at all, so a value is never guaranteed.
+    expect(SHIPMENT_FIELDS[key]?.nullable).toBe(true)
+  })
+})
+
+describe('the money fields say they are integer minor units', () => {
+  // `field-value-helpers.ts`: CURRENCY is NUMBER's shape exactly, an integer
+  // minor-unit amount. ShipStation sends `{"currency":"usd","amount":16.54}`
+  // and the mapping layer has no transform hook, so the connector multiplies.
+  // Declaring these NUMBER, or naming them without `Minor`, is how the decimal
+  // gets written through and $16.54 becomes 16 cents.
+  const MONEY_KEYS = ['costMinor', 'insuranceCostMinor'] as const
+
+  it.each(MONEY_KEYS)('%s is CURRENCY, not NUMBER', (key) => {
+    expect(SHIPMENT_FIELDS[key]?.fieldType).toBe('CURRENCY')
+    expect(SHIPMENT_FIELDS[key]?.type).toBe('currency')
+  })
+
+  it.each(MONEY_KEYS)('%s keeps the Minor suffix that says what the integer is', (key) => {
+    expect(key.endsWith('Minor')).toBe(true)
+  })
+
+  it.each(MONEY_KEYS)('%s declares the two-decimal USD denomination, like totalMinor', (key) => {
+    // A value never carries its own denomination on the read path: the render
+    // site resolves it from these options. All observed data is US domestic.
+    expect(SHIPMENT_FIELDS[key]?.options).toMatchObject({
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    })
+  })
+})
+
+describe('the document and claim fields', () => {
+  it('stores the label as a URL rather than a file reference', () => {
+    // Owner decision: a plain link, not a fetched `MediaAsset`. The href is
+    // unauthenticated, so a link in the UI works with no proxying.
+    expect(SHIPMENT_FIELDS.labelUrl?.fieldType).toBe('URL')
+    expect(SHIPMENT_FIELDS.labelUrl?.type).toBe('url')
+  })
+
+  it('warns in its own description that the label URL is a bearer secret', () => {
+    // The one fact about this column that cannot be recovered by reading its
+    // type: anyone holding the string fetches a document carrying a customer's
+    // name and address, so it must never be exported, logged or handed onward.
+    const description = SHIPMENT_FIELDS.labelUrl?.description ?? ''
+    expect(description).toMatch(/BEARER SECRET/)
+    expect(description).toMatch(/unauthenticated/i)
+  })
+
+  it('keeps the insurance claim TEXT, with its unknown shape recorded', () => {
+    // Owner decision 2026-09-11, forward-looking: null on all 50 probed labels
+    // because nothing on the account is insured, so the wire shape is unknown
+    // and the connector must emit only a string.
+    expect(SHIPMENT_FIELDS.insuranceClaim?.fieldType).toBe('TEXT')
+    expect(SHIPMENT_FIELDS.insuranceClaim?.description ?? '').toMatch(/UNKNOWN|unknown/)
+  })
+})
+
+describe('the sort orders append rather than reshuffle', () => {
+  it('gives every shipment field a distinct sort order', () => {
+    const orders = Object.values(SHIPMENT_FIELDS)
+      .map((f) => f.systemSortOrder)
+      .filter((s): s is string => typeof s === 'string')
+    expect(new Set(orders).size).toBe(orders.length)
+  })
+
+  it('sorts all four after every field that already existed', () => {
+    const newKeys = NEW_FIELDS.map(([key]) => key) as string[]
+    const previous = Object.entries(SHIPMENT_FIELDS)
+      .filter(([key]) => !newKeys.includes(key))
+      // `createdAt` / `updatedAt` / `createdBy` are the trailing common block.
+      .filter(([key]) => !['createdAt', 'updatedAt', 'createdBy'].includes(key))
+      .map(([, field]) => field.systemSortOrder ?? '')
+    const added = newKeys.map((key) => SHIPMENT_FIELDS[key]?.systemSortOrder ?? '')
+
+    for (const order of added) {
+      for (const existing of previous) {
+        expect(order > existing).toBe(true)
+      }
+      // ...and still ahead of the common trailing block, so the panel keeps
+      // Created / Updated / Created By last.
+      expect(order < (SHIPMENT_FIELDS.createdAt?.systemSortOrder ?? 'b0')).toBe(true)
+      expect(order < (SHIPMENT_FIELDS.createdBy?.systemSortOrder ?? 'az')).toBe(true)
+    }
+  })
+})
+
+describe('migration 151 up()', () => {
+  it('skips an org that never got the shipment def, touching nothing', async () => {
+    resetStubs()
+    existingDefs = ['order']
+
+    const result = await migration151ShipmentLabelCostAndDocument.up(DB, ORG)
+
+    expect(result.alreadyUpToDate).toBe(true)
+    expect(result.fieldsCreated).toBe(0)
+    expect(ensureCalls).toHaveLength(0)
+    expect(invalidateAndRecompute).not.toHaveBeenCalled()
+  })
+
+  it('provisions exactly the four fields onto the shipment def', async () => {
+    resetStubs()
+
+    const result = await migration151ShipmentLabelCostAndDocument.up(DB, ORG)
+
+    expect(ensureCalls).toHaveLength(1)
+    expect(ensureCalls[0]?.entityType).toBe('shipment')
+    expect(ensureCalls[0]?.defId).toBe('def_shipment')
+    expect(ensureCalls[0]?.fieldKeys).toEqual([
+      'costMinor',
+      'insuranceCostMinor',
+      'insuranceClaim',
+      'labelUrl',
+    ])
+    expect(result.fieldsCreated).toBe(4)
+    expect(result.alreadyUpToDate).toBe(false)
+    expect(result.entityDefsCreated).toBe(0)
+  })
+
+  it('flushes the field caches, because a stale one drops every write', async () => {
+    resetStubs()
+
+    await migration151ShipmentLabelCostAndDocument.up(DB, ORG)
+
+    expect(invalidateAndRecompute).toHaveBeenCalledWith(ORG, ['customFields', 'resources'])
+  })
+
+  it('is idempotent: a re-run writes nothing and flushes nothing', async () => {
+    resetStubs()
+    existingFieldKeys = ['costMinor', 'insuranceCostMinor', 'insuranceClaim', 'labelUrl']
+
+    const result = await migration151ShipmentLabelCostAndDocument.up(DB, ORG)
+
+    expect(result.fieldsCreated).toBe(0)
+    expect(result.alreadyUpToDate).toBe(true)
+    expect(invalidateAndRecompute).not.toHaveBeenCalled()
+  })
+
+  it('is self-sufficient: a partly-applied org gets only what it is missing', async () => {
+    // The ledger retries a batch from the top, so an org that took two fields
+    // before a later org failed must complete rather than duplicate.
+    resetStubs()
+    existingFieldKeys = ['costMinor', 'insuranceCostMinor']
+
+    const result = await migration151ShipmentLabelCostAndDocument.up(DB, ORG)
+
+    expect(result.fieldsCreated).toBe(2)
+    expect(result.alreadyUpToDate).toBe(false)
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/151-shipment-label-cost-and-document.ts
+++ b/packages/lib/src/data-migrations/migrations/151-shipment-label-cost-and-document.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/data-migrations/migrations/151-shipment-label-cost-and-document.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getOrgCache } from '../../cache'
+import type { ResourceField } from '../../resources/registry/field-types'
+import { SHIPMENT_FIELDS } from '../../resources/registry/resources/shipment-fields'
+import { ensureCustomFields, loadExistingState } from '../../seed/entity-helpers'
+import type { PerOrgMigration, PerOrgMigrationResult } from '../per-org'
+
+const logger = createScopedLogger('entity-migrations:151')
+
+const SHIPMENT_ENTITY_TYPE = 'shipment'
+
+/**
+ * The registry keys this migration provisions, in panel order.
+ *
+ * Named as KEYS and resolved out of `SHIPMENT_FIELDS` below, rather than
+ * restated as literals here, so the stored field can never disagree with the
+ * one a fresh org is seeded with. The keys themselves are checked, because a
+ * rename in the registry with no rename here would otherwise create three
+ * fields while claiming four and say nothing.
+ */
+const NEW_FIELD_KEYS = ['costMinor', 'insuranceCostMinor', 'insuranceClaim', 'labelUrl'] as const
+
+/** A new field is invisible to every read path that serves it until these drop. */
+const CACHE_KEYS = ['customFields', 'resources'] as const
+
+/**
+ * Migration 151: `shipment` learns what the label COST and where the PDF is
+ * (`plans/apps/shipstation/shipstation-status-and-linking-plan.md` §7).
+ *
+ * ## Why a migration and not just the registry edit
+ *
+ * `EntityDefinition` and `CustomField` rows are seeded per org from the resource
+ * registry, and `ensureCustomFields` is INSERT-only, so a registry edit reaches
+ * FRESH orgs and nothing else. Every org that already took migration 149's
+ * `shipment` def needs this to see the four new fields at all: without them the
+ * connector's mapping resolves no target and drops the value with a log line.
+ *
+ * ## What it adds
+ *
+ * - **`shipment_cost`** and **`shipment_insurance_cost`**, both CURRENCY, which
+ *   is an INTEGER MINOR-UNIT amount. The provider sends a decimal
+ *   (`{"currency":"usd","amount":16.54}`) and the mapping layer has no transform
+ *   hook, so the connector server multiplies before it emits. Writing the
+ *   decimal through unconverted would store 16 cents for a $16.54 label.
+ * - **`shipment_insurance_claim`**, TEXT, forward-looking: null on all 50 probed
+ *   labels because nothing on this account is insured, so its wire shape is
+ *   still unknown.
+ * - **`shipment_label_url`**, URL, the printable PDF of the live label. The
+ *   value is a CAPABILITY URL: it fetches unauthenticated and carries a
+ *   customer's name and address, so it is a bearer secret wherever it is read.
+ *
+ * All four are nullable and all four are label-level, so only the live
+ * (non-voided) label's values ever arrive. That is correct rather than lossy:
+ * voiding refunds the label.
+ *
+ * ## No backfill, and there is nothing to backfill
+ *
+ * Nothing has ever written these, because the fields did not exist. Null
+ * everywhere is the correct starting state, and the values arrive on the next
+ * sync after the connector's phase-2 mapping ships.
+ *
+ * ## Ordering
+ *
+ * MUST sort after 149, which creates the `shipment` def. An org short of it is a
+ * SKIP rather than a failure: the seeder creates the def and all of these fields
+ * together from the registry.
+ *
+ * Idempotent: `ensureCustomFields` is INSERT-only and skips whatever the org
+ * already holds, so a re-run writes nothing and reports `alreadyUpToDate`. Safe
+ * to re-apply with `packages/lib/scripts/run-entity-migration.ts --id
+ * 151-shipment-label-cost-and-document`.
+ */
+export const migration151ShipmentLabelCostAndDocument: PerOrgMigration = {
+  id: '151-shipment-label-cost-and-document',
+  description:
+    'Adds the label cost, insurance cost, insurance claim and label PDF URL fields to the ' +
+    'shipment def - both amounts in integer minor units because the provider sends decimals, ' +
+    'and the URL is a bearer secret (shipstation-status-and-linking-plan.md §7)',
+
+  async up(db: Database, organizationId: string): Promise<PerOrgMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const shipmentDef = existing.entityDefs.get(SHIPMENT_ENTITY_TYPE)
+    if (!shipmentDef) {
+      // The org never got migration 149's `shipment` def. A fresh install brings
+      // the def and these four fields along together from the registry.
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    const fields: Record<string, ResourceField> = {}
+    for (const key of NEW_FIELD_KEYS) {
+      const field = SHIPMENT_FIELDS[key]
+      if (!field) {
+        throw new Error(`shipment-fields registry is missing the key "${key}" (migration 151)`)
+      }
+      fields[key] = field
+    }
+
+    await ensureCustomFields(
+      db,
+      organizationId,
+      SHIPMENT_ENTITY_TYPE,
+      shipmentDef.id,
+      fields,
+      existing,
+      state
+    )
+
+    const changed = state.fieldsCreated > 0
+
+    if (changed) {
+      // `ensureCustomFields` bypasses the org cache and `UnifiedCrudHandler`
+      // resolves a field's shape from it, so a stale entry would keep dropping
+      // every write to these four. `perOrgMigration` flushes after the whole
+      // batch, but `up()` is also called directly by
+      // `scripts/run-entity-migration.ts`, so do it here too (as 148 does).
+      await getOrgCache().invalidateAndRecompute(organizationId, [...CACHE_KEYS])
+      logger.info('Migration 151 applied', {
+        organizationId,
+        fieldsCreated: state.fieldsCreated,
+      })
+    }
+
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -8,6 +8,7 @@ import { migration147BackfillBankMatchKeys } from './migrations/147-backfill-ban
 import { migration148RecurringJournalEntries } from './migrations/148-recurring-journal-entries'
 import { migration149ShipmentParcel } from './migrations/149-shipment-parcel'
 import { migration150StripLegacyAddressComponents } from './migrations/150-strip-legacy-address-components'
+import { migration151ShipmentLabelCostAndDocument } from './migrations/151-shipment-label-cost-and-document'
 import { type PerOrgMigration, perOrgMigration } from './per-org'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
@@ -61,6 +62,9 @@ export const PER_ORG_MIGRATIONS: PerOrgMigration[] = [
   migration149ShipmentParcel,
   // Mutates `CustomField.options` on fields that already exist: the cleanup shape.
   migration150StripLegacyAddressComponents,
+  // Adds four fields to the `shipment` def 149 created: label cost, insurance cost,
+  // insurance claim and the label PDF URL.
+  migration151ShipmentLabelCostAndDocument,
   // Recomputes a stored column from its own source with the current algorithm:
   // the backfill shape.
   migration147BackfillBankMatchKeys,

--- a/packages/lib/src/resources/registry/resources/shipment-fields.ts
+++ b/packages/lib/src/resources/registry/resources/shipment-fields.ts
@@ -395,6 +395,151 @@ export const SHIPMENT_FIELDS: Record<string, ResourceField> = {
       'matched.',
   },
 
+  /**
+   * What the merchant paid the carrier for this label.
+   *
+   * ## Integer minor units, and why the connector does the multiplying
+   *
+   * `field-value-helpers.ts` is explicit that CURRENCY is NUMBER's shape
+   * exactly: an integer minor-unit amount. ShipStation sends a DECIMAL
+   * (`{"currency":"usd","amount":16.54}`), so writing it through unconverted
+   * stores 12 cents for a $12.34 label. The mapping layer has no transform
+   * hook, so the connector server must emit the already-multiplied integer.
+   * That is what the `Minor` suffix on the key is for, the same signal
+   * `bank_deposit_total`'s `totalMinor` carries.
+   */
+  costMinor: {
+    id: toFieldId('costMinor'),
+    key: 'costMinor',
+    label: 'Shipping Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'shipment_cost',
+    systemSortOrder: 'a9',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'What the merchant paid for this label, in INTEGER MINOR UNITS (1654 is $16.54). The ' +
+      'provider sends a decimal amount with its own currency, so the connector multiplies ' +
+      'before it emits: the mapping layer has no transform hook to do it later. Populated on ' +
+      'all 50 labels in the 2026-09-11 probe. Defaults to USD because every shipment observed ' +
+      'is US domestic. Only the LIVE (non-voided) label reaches this field, which is correct, ' +
+      'because voiding refunds the label and the reprint is what was actually paid for.',
+  },
+
+  insuranceCostMinor: {
+    id: toFieldId('insuranceCostMinor'),
+    key: 'insuranceCostMinor',
+    label: 'Insurance Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'shipment_insurance_cost',
+    systemSortOrder: 'aA',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'What insuring this shipment cost, integer minor units, converted by the connector for ' +
+      'the same reason as the shipping cost. The provider supplied it on all 50 labels in the ' +
+      '2026-09-11 probe and the amount was 0 on every one: this merchant does not insure. A ' +
+      'zero here is therefore a real reading rather than a missing value. Live label only.',
+  },
+
+  insuranceClaim: {
+    id: toFieldId('insuranceClaim'),
+    key: 'insuranceClaim',
+    label: 'Insurance Claim',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'shipment_insurance_claim',
+    systemSortOrder: 'aB',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Any insurance claim the provider reports against this label. FORWARD-LOOKING, added by ' +
+      'owner decision on 2026-09-11 rather than because a value was seen: it was null on all ' +
+      '50 probed labels, which follows from the insurance cost being 0 everywhere, since ' +
+      'nothing uninsured can be claimed. The wire shape is consequently UNKNOWN, so the ' +
+      'connector writes this only when the provider sends a string. If a later label returns a ' +
+      'structure, whoever finds it picks the one scalar that belongs in a text column and ' +
+      'records which, instead of serializing the whole object into the field.',
+  },
+
+  /**
+   * The printable PDF of this shipment's live label.
+   *
+   * ## A bearer secret, stored as plain text
+   *
+   * Verified 2026-09-11: the href is on the provider's public API host and an
+   * UNAUTHENTICATED GET returns `200 application/pdf`, so a plain link in the UI
+   * works with no proxying. The flip side is that the opaque path segment is the
+   * ONLY thing protecting a document carrying a customer's name and address.
+   * Anyone holding the string can fetch the label. Treat the column the way a
+   * token is treated: never in an export, a log line, a webhook payload, or
+   * anything an agent can read out to a third party.
+   *
+   * Stored as a URL rather than fetched into a `MediaAsset` by owner decision.
+   * Expiry is unmeasured, so if these eventually 404 the column becomes dead
+   * strings, which is the argument for revisiting that decision.
+   */
+  labelUrl: {
+    id: toFieldId('labelUrl'),
+    key: 'labelUrl',
+    label: 'Label PDF',
+    type: BaseType.URL,
+    fieldType: FieldType.URL,
+    isSystem: true,
+    systemAttribute: 'shipment_label_url',
+    systemSortOrder: 'aC',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      "The PDF of the label a person would actually print, read off the provider's " +
+      '`label_download` object (which also carries png and zpl). Present on all 50 labels in ' +
+      'the 2026-09-11 probe. BEARER SECRET: the URL fetches unauthenticated and the document ' +
+      "carries the customer's name and address, so it must never be exported, logged, or " +
+      'handed to a third party. Live label only, so a void and reprint replaces this and the ' +
+      'superseded PDF becomes unreachable. Expiry is unmeasured.',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -1099,6 +1099,18 @@ export const SYSTEM_ATTRIBUTES = [
   'shipment_parcel_count',
   'shipment_parcels', // inverse of parcel_shipment, has_many, onDelete cascade
   'shipment_order', // inverse of order_shipments
+  // Label-level money and documents, added by entity migration 151
+  // (plans/apps/shipstation/shipstation-status-and-linking-plan.md §7). Both
+  // amounts are CURRENCY, which is an INTEGER MINOR-UNIT amount; the provider
+  // sends a decimal and the connector multiplies, because the mapping layer has
+  // no transform hook. Only the live (non-voided) label's values arrive, since
+  // voiding refunds the label.
+  'shipment_cost',
+  'shipment_insurance_cost',
+  'shipment_insurance_claim',
+  // A capability URL: it fetches unauthenticated and carries the customer's
+  // name and address, so treat the value as a bearer secret.
+  'shipment_label_url',
 
   // Parcel. `parcel_tracking_number` is the cross-app match key: the carrier
   // apps find the box by it, so it is treated as unique (§8b).


### PR DESCRIPTION
Every shipment read `label_created` while ShipStation reported half the boxes delivered, nothing connected a box to the order it came from, and cost, insurance and the label PDF were never read off the wire.

Plan: `plans/apps/shipstation/shipstation-status-and-linking-plan.md` (untracked). Pairs with **Auxx-Ai/auxxai-apps** `feat/shipstation-status-and-fields`, which must merge and publish for any of this to have a writer.

## Measured on dev, after a full backfill

| field | before | after |
| --- | ---: | ---: |
| `shipment_status` = `label_created` | 158 | **4** |
| `shipment_status` = `in_transit` | 0 | **81** |
| `shipment_status` = `delivered` | 0 | **73** |
| `shipment_number` | 0 | 159 |
| `storeId` | 0 | 159 |
| `shipment_cost` / `insurance_cost` / `label_url` | 0 | 158 each |
| **`shipment_order`** | **0** | **122** |

852 fetched, 75 created, 728 updated, 0 failed, 51.8s.

All 122 order links verified against the source: **122 correct, 0 wrong.** Every one of the 43 unlinked shipments is accounted for: 20 are Shopify ids newer than the newest synced order (they link on a later finalize), 16 are UUID-shaped from a different order source, 2 are bare-numeric and refused on purpose, 5 carry no `external_shipment_id`.

## What is here

**Four `shipment` registry fields + entity migration 151.** Cost and insurance are `CURRENCY`, which is integer **minor** units; the connector converts, because the mapping layer has no transform hook. Verified: 0 non-integer rows, min `1518`, max `129451`.

**A cross-connector link resolver** (`data-connectors/cross-connector-links/`), hooked into the three places `resolveRelationships` already runs. The connector-scoped two-pass structurally cannot do this job: `findItemByDef` filters `dataConnectorId` with hard equality, so a ShipStation reference to a Shopify-created order resolves nothing and retries forever. This resolves through `RecordIdentity` instead.

**An `apps/api` regression fix**, second commit. Unrelated to ShipStation but included because it blocked testing this: `auxx dev --once` returned a bare 500 for any app already installed from a publish. See below.

## The order format is INFERRED, and the resolver is built around that

`order_source_code` is null on all 50 probed shipments and all 50 shipment items, so the API offers **no channel signal to gate on**. The only thing identifying a Shopify-sourced shipment is the shape of `external_shipment_id`, and that shape is not universal even inside one merchant.

So the resolver fails to **zero** links rather than to wrong ones: anchored shape gate, exact id equality only, silent on no match, no retry state persisted, second component never parsed, and ambiguity across two Shopify connections maps to null rather than coin-flipping. A merchant whose ShipStation writes a different shape simply gets nulls, which is the status quo.

Matching on order **number** was considered and rejected: order numbers are merchant-customizable (prefixes, suffixes, custom sequences), order ids are opaque global integers.

## The `apps/api` fix

Migration 0376 (#2130, same day) replaced the unique over `(appId, organizationId, installationType)` with a partial unique over `(appId, organizationId) WHERE uninstalledAt IS NULL`, and updated `installApp` to repoint the single live row. `apps/api` had **zero files** in that commit, and this route still looked the installation up scoped to `'development'` — so it could not see the live PRODUCTION row holding the only permitted slot, concluded nothing was installed, and inserted. The index rejected it, unhandled, and Hono returned a bare 500.

It also hard-`DELETE`d soft-deleted installations, which discards the `AppSetting` and `Credential` rows `uninstallApp` preserves on purpose.

## Verification

- `data-connectors` 774 tests, `data-migrations` 144, `resources/registry` 257, `apps/api` deployments 7 (was 4)
- `typecheck-ratchet --package lib`: no new type errors (27 total, baseline 27)
- Both halves of the API fix mutation-checked: restoring the type filter fails the repoint test, restoring delete-and-insert fails the reactivate test
- The deploy that previously 500'd now succeeds, and the installation is switched in place rather than duplicated

## Known gap, read before accepting a catalog

Under the incremental catalog `shipment_status` **freezes**. The label stream's two cursors are creations and voids; a `tracking_status` change is neither, so a label crawled while `in_transit` is never re-read. `/v2/labels` has no modified-time filter and returns no modified time, so no third sweep can be written.

Today's 73 `delivered` are correct because this was a full backfill. They will not grow until a `/v2/tracking` stream exists (phase 4 in the plan). A frozen `in_transit` on a delivered shipment is worse than the `label_created` it replaces, so that stream is now the thing keeping this honest, not an optional extra.

Probe scripts are included so every "documented but null" finding is reproducible. Four fields that exist in the OpenAPI spec are null in practice on this account.

https://claude.ai/code/session_01GoSAFjR7nNqL6BU3fJHyM6
