### PR TITLE
fix(accounting): say why Lock is refused, and give the ledger drawers one shape

### DIFF
--- a/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/journal/journal-entry-drawer.tsx
@@ -31,13 +31,6 @@ import { JournalEntryAttachment } from './journal-entry-attachment'
 import { JournalLines, JournalLinesTotals } from './journal-lines'
 import { firstDayOfPeriod, nextOpenPeriodAfter, periodKeyForEntryDate } from './period-helpers'
 
-/**
- * Cancels the scroll content's `p-3` so `Section` sits FLUSH with the drawer.
- * `Section` draws its own `p-3` and a full-width `border-b`, a divider meant
- * to run edge to edge (see `bank-account-editor.tsx`'s own copy of this).
- */
-const SECTION_BLEED = '-mx-3'
-
 interface JournalEntryDrawerProps {
   /** The record id, or `null` while `isNew` and the empty draft has not landed yet. */
   journalEntryId: string | null
@@ -239,9 +232,16 @@ export function JournalEntryDrawer({
           </div>
         ) : (
           <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
-            <div className='flex flex-col gap-3 p-3'>
+            {/* 🛑 No padding and no gap, deliberately - see the same note in
+                `posting-drawer.tsx`. `Section` draws its own `p-3 pb-4` and a
+                full-width `border-b`, so sections stack FLUSH and that border is
+                the divider. This wrapper used to carry `gap-3 p-3`, which is
+                why the Lines section had grown a `-mx-3` bleed to claw itself
+                back out to the edge; the bleed is deleted with it. Anything
+                that is NOT a Section carries its own padding below. */}
+            <div className='flex flex-col'>
               {!isEditable && (
-                <Alert variant='neutral'>
+                <Alert variant='neutral' className='mx-3 mt-3 w-auto'>
                   <AlertDescription>
                     This entry is {draft.status} and can no longer be edited here.
                   </AlertDescription>
@@ -258,84 +258,92 @@ export function JournalEntryDrawer({
                 </Alert>
               )}
 
-              <FieldPanel
-                orientation='responsive'
-                breakpoint='md'
-                resizeId='journal-entry-form'
-                defaultLabelWidth={110}
-                className='p-0'>
-                <FieldPanelRow
-                  title={isTemplate ? 'Starts' : 'Date'}
-                  type={BaseType.DATE}
-                  showIcon
-                  isRequired
-                  description={
-                    isTemplate
-                      ? 'The first occurrence. The schedule expands from here, and every generated entry takes its own occurrence date.'
-                      : undefined
-                  }>
-                  <FieldInputAdapter
-                    fieldType={FieldType.DATE}
-                    value={draft.date ? `${draft.date}T00:00:00.000Z` : null}
-                    onChange={(value) => {
-                      const iso = value as string | null
-                      if (iso) draft.setDate(iso.slice(0, 10))
-                    }}
-                    disabled={!isEditable}
-                  />
-                </FieldPanelRow>
-
-                {/* A template belongs to no period: it posts nothing, and each
-                    occurrence it generates lands in its own month. */}
-                {!isTemplate && (
+              {/* ⚠️ NOT wrapped in a `Section`. `FieldPanel` draws its own
+                  `rounded-2xl border` card, so a Section around it nests two
+                  boxes - and the record drawer's own Details block, the thing
+                  this screen is matching, is a Section over PLAIN rows
+                  (`fields-block.tsx` renders `EntityFields`), never a card in a
+                  card. The panel keeps its chrome and carries the padding the
+                  scroll wrapper no longer has. */}
+              <div className='p-3'>
+                <FieldPanel
+                  orientation='responsive'
+                  breakpoint='md'
+                  resizeId='journal-entry-form'
+                  defaultLabelWidth={110}
+                  className='p-0'>
                   <FieldPanelRow
-                    title='Period'
-                    type={BaseType.STRING}
+                    title={isTemplate ? 'Starts' : 'Date'}
+                    type={BaseType.DATE}
                     showIcon
-                    description='The calendar month of the date above. Changing the date can move it.'>
-                    <div className='flex h-8 items-center'>
-                      <Badge variant='outline' size='sm'>
-                        {entryPeriodKey ? formatPeriodLabel(entryPeriodKey) : 'Unknown'}
-                      </Badge>
-                    </div>
-                  </FieldPanelRow>
-                )}
-
-                <FieldPanelRow title='Memo' type={BaseType.STRING} showIcon>
-                  <FieldInputAdapter
-                    fieldType={FieldType.TEXT}
-                    value={draft.memo}
-                    onChange={(value) => draft.setMemo((value as string | null) ?? '')}
-                    placeholder='What this entry is for'
-                    disabled={!isEditable}
-                  />
-                </FieldPanelRow>
-
-                <FieldPanelRow
-                  title='Attachment'
-                  type={BaseType.FILE}
-                  showIcon
-                  description="The evidence behind the entry - the accountant's memo, a statement, a photo of the paper">
-                  {attachmentField && journalEntryId ? (
-                    <JournalEntryAttachment
-                      recordId={journalEntryId as RecordId}
-                      field={attachmentField}
+                    isRequired
+                    description={
+                      isTemplate
+                        ? 'The first occurrence. The schedule expands from here, and every generated entry takes its own occurrence date.'
+                        : undefined
+                    }>
+                    <FieldInputAdapter
+                      fieldType={FieldType.DATE}
+                      value={draft.date ? `${draft.date}T00:00:00.000Z` : null}
+                      onChange={(value) => {
+                        const iso = value as string | null
+                        if (iso) draft.setDate(iso.slice(0, 10))
+                      }}
+                      disabled={!isEditable}
                     />
-                  ) : (
-                    <span className='flex h-8 items-center text-muted-foreground text-sm'>
-                      {attachmentField
-                        ? 'Type a date, memo or line first - a file needs an entry to hang on'
-                        : 'Not available on this organization yet'}
-                    </span>
+                  </FieldPanelRow>
+
+                  {/* A template belongs to no period: it posts nothing, and each
+                    occurrence it generates lands in its own month. */}
+                  {!isTemplate && (
+                    <FieldPanelRow
+                      title='Period'
+                      type={BaseType.STRING}
+                      showIcon
+                      description='The calendar month of the date above. Changing the date can move it.'>
+                      <div className='flex h-8 items-center'>
+                        <Badge variant='outline' size='sm'>
+                          {entryPeriodKey ? formatPeriodLabel(entryPeriodKey) : 'Unknown'}
+                        </Badge>
+                      </div>
+                    </FieldPanelRow>
                   )}
-                </FieldPanelRow>
-              </FieldPanel>
+
+                  <FieldPanelRow title='Memo' type={BaseType.STRING} showIcon>
+                    <FieldInputAdapter
+                      fieldType={FieldType.TEXT}
+                      value={draft.memo}
+                      onChange={(value) => draft.setMemo((value as string | null) ?? '')}
+                      placeholder='What this entry is for'
+                      disabled={!isEditable}
+                    />
+                  </FieldPanelRow>
+
+                  <FieldPanelRow
+                    title='Attachment'
+                    type={BaseType.FILE}
+                    showIcon
+                    description="The evidence behind the entry - the accountant's memo, a statement, a photo of the paper">
+                    {attachmentField && journalEntryId ? (
+                      <JournalEntryAttachment
+                        recordId={journalEntryId as RecordId}
+                        field={attachmentField}
+                      />
+                    ) : (
+                      <span className='flex h-8 items-center text-muted-foreground text-sm'>
+                        {attachmentField
+                          ? 'Type a date, memo or line first - a file needs an entry to hang on'
+                          : 'Not available on this organization yet'}
+                      </span>
+                    )}
+                  </FieldPanelRow>
+                </FieldPanel>
+              </div>
 
               <Section
                 title='Lines'
                 icon={<BookOpenCheck className='size-4' />}
-                collapsible={false}
-                className={SECTION_BLEED}>
+                collapsible={false}>
                 <div className='flex flex-col gap-3'>
                   <JournalLines
                     rows={draft.lines}
@@ -348,7 +356,9 @@ export function JournalEntryDrawer({
               </Section>
 
               {blockers.length > 0 && (
-                <EntryBlockers blockers={blockers} onPostToNextPeriod={postToNextOpenPeriod} />
+                <div className='p-3'>
+                  <EntryBlockers blockers={blockers} onPostToNextPeriod={postToNextOpenPeriod} />
+                </div>
               )}
             </div>
           </ScrollArea>

--- a/apps/web/src/components/accounting/ui/ledger/__tests__/lock-refusal-reason.test.ts
+++ b/apps/web/src/components/accounting/ui/ledger/__tests__/lock-refusal-reason.test.ts
@@ -1,0 +1,84 @@
+// apps/web/src/components/accounting/ui/ledger/__tests__/lock-refusal-reason.test.ts
+//
+// Why the Lock button is refused, and what it tells the operator to do about it.
+//
+// 🛑 This is about the SENTENCE, not the gate. The gate itself was always
+// correct; what it carried was no reason at all, and the only nearby copy
+// described the state ("Open. The entry can still be reversed and re-entered")
+// while naming no remedy and implying an entry that may not exist.
+//
+// The case that matters is `nothing_to_close`. Such a month has no month-end
+// entry to post and never will, so the postable month's remedy - "post it, then
+// lock" - sends the operator to a control that reads "There is nothing to post"
+// and is itself disabled. A wrong remedy is worse than silence, which is the
+// whole reason the two branches exist.
+
+import { describe, expect, it } from 'vitest'
+import { lockRefusalReason } from '../format'
+
+const OPEN = {
+  periodLabel: 'January 2026',
+  isPostedPeriod: false,
+  justPosted: false,
+  isNothingToClose: false,
+}
+
+describe('lockRefusalReason', () => {
+  it('offers Lock on a posted month', () => {
+    expect(lockRefusalReason({ ...OPEN, isPostedPeriod: true })).toBeNull()
+  })
+
+  /**
+   * `justPosted` is why Lock works immediately after posting, before the period
+   * query has refetched and moved `state` off `'open'`. Dropping it would make
+   * the button dead until a reload.
+   */
+  it('offers Lock right after a post in this session, before the query catches up', () => {
+    expect(lockRefusalReason({ ...OPEN, justPosted: true })).toBeNull()
+  })
+
+  it('refuses an open month and names the remedy', () => {
+    const reason = lockRefusalReason(OPEN)
+    expect(reason).toContain('January 2026')
+    expect(reason).toContain('no month-end entry yet')
+    // The remedy, which is the half the old copy was missing entirely.
+    expect(reason).toContain('Post it under Entries above')
+  })
+
+  /**
+   * 🛑 The defect this function was extracted for. A month showing $1.3m of
+   * posted fulfillment still refuses to lock, because only `month_end_inventory`
+   * rows count - so the sentence has to say that the other entries do not close
+   * the month, or the operator reads the button as broken.
+   */
+  it('says that the other entries this month do not close it', () => {
+    expect(lockRefusalReason(OPEN)).toContain('do not close it')
+  })
+
+  describe('a nothing_to_close month', () => {
+    const nothing = { ...OPEN, isNothingToClose: true }
+
+    it('explains that there is nothing to post, rather than asking for a post', () => {
+      const reason = lockRefusalReason(nothing)
+      expect(reason).toContain('Nothing moved in January 2026')
+      expect(reason).toContain('Move to the next month')
+    })
+
+    /**
+     * The actual regression guard. `Post it under Entries above` points at a
+     * button that reads "There is nothing to post" and is disabled, so this
+     * month must never be given that remedy.
+     */
+    it('never tells the operator to post an entry that cannot be built', () => {
+      expect(lockRefusalReason(nothing)).not.toContain('Post it')
+    })
+
+    it('still yields to a posted month', () => {
+      expect(lockRefusalReason({ ...nothing, isPostedPeriod: true })).toBeNull()
+    })
+  })
+
+  it('carries whatever period label it is given', () => {
+    expect(lockRefusalReason({ ...OPEN, periodLabel: 'March 2027' })).toContain('March 2027')
+  })
+})

--- a/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
@@ -1,26 +1,11 @@
-// apps/web/src/components/accounting/ui/ledger/entry-journal.tsx
-
-'use client'
-
 import type { PostingDetailLine, ResolvedPostingLine } from '@auxx/lib/postings/client'
 import { toRecordId } from '@auxx/lib/resources/client'
-import { Alert } from '@auxx/ui/components/alert'
-import { Button } from '@auxx/ui/components/button'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableFooter,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@auxx/ui/components/table'
-import { cn } from '@auxx/ui/lib/utils'
-import { CheckCircle2, Search, TriangleAlert } from 'lucide-react'
-import { Tooltip } from '~/components/global/tooltip'
+import type { ReactNode } from 'react'
 import { useResource } from '~/components/resources'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
-import { AccountLabel, formatAccountLabel } from '../account-label'
+import { formatAccountLabel } from '../account-label'
+import type { StatementColumn, StatementRow } from '../reports/statement-table'
+import { StatementTable } from '../reports/statement-table'
 import { formatMinor } from './format'
 
 interface EntryJournalProps {
@@ -39,17 +24,69 @@ interface EntryJournalProps {
  * flush left, credits indented beneath them, a totals row, and an explicit
  * balanced verdict.
  *
+ * 🛑 Rendered through {@link StatementTable}, NOT a `<table>` of its own. This
+ * was the last hand-rolled money table in the subsystem - `ui-plan.md`'s own
+ * survey named it by line number ("every subtotal footer in the app is
+ * hand-rolled (`entry-journal.tsx:100-110`)") - and §4.1's argument applies to
+ * it exactly: a statement rendering as shadcn's bare `Table` sits in the same
+ * drawer as the framed `TreeRow` lists everything else uses and reads as a
+ * different product. The verdict strip below the table was always modelled on
+ * this file; `StatementVerdict` is that idea, so it comes back here as a prop
+ * rather than as a second `Alert`.
+ *
  * 🛑 No number on this table is ever signed. `direction` is the only carrier of
  * sign in the whole postings module and `amount` is always positive, so a
  * signed rendering would be inventing a second, disagreeing convention, and a
  * bookkeeper handed a two-column table of signed numbers is being asked to do
- * the conversion in their head (13-accounting-ui.md §5.2).
+ * the conversion in their head (13-accounting-ui.md §5.2). Neither column
+ * declares `signed`, which is what keeps `formatSignedMinor` away from them.
  *
  * ⚠️ The balanced verdict is stated rather than implied. `buildEntry` refuses to
  * return an unbalanced entry, so in practice this always reads "Balanced", but
  * a screen that shows totals and leaves the reader to compare them is asking for
  * the one mental step this section exists to remove.
  */
+/**
+ * Drops the `secondary` slot onto a SECOND LINE, under the account name.
+ *
+ * 🛑 Why this shape and not a wider column. A journal line carries an account
+ * name AND an identifying memo ("Sales Tax Payable" / "2026-01 - sales tax,
+ * Stephens County Tax"), and in a docked drawer the two do not fit on one line.
+ * Sharing the line costs one of them: `TREE_SECONDARY_NOTRUNCATE` makes the
+ * secondary `shrink-0` while the title is `truncate`, so the account name gives
+ * up ALL of its width first and renders as `S...`. Capping the memo instead
+ * just moved the loss onto the memo, whose distinguishing part is its tail.
+ * Two lines is the only arrangement where neither is sacrificed - which is what
+ * the hand-rolled table this replaced was doing with a `<p>` under the account.
+ *
+ * The indent is `LeadingIcon`'s `size-7` plus the title's `px-1` (2rem), plus
+ * `--statement-label-indent` - the reserved code track and its gap, which
+ * `StatementTable` measures over the whole statement and publishes for exactly
+ * this. Without that second term the memo lines up under the CODE, so on a row
+ * whose account has no code (`Product Revenue`, `Sales Tax Payable`) the name
+ * is pushed right past the empty track while the memo stays left, and the two
+ * lines disagree. It resolves to `0px` when no row has a code at all, because
+ * `AccountLabel` then renders neither the track nor the gap.
+ */
+const TWO_LINE_ROW = [
+  // The title's `py-1.5` is vertical rhythm for a ONE-line row. With the memo
+  // directly beneath it, the bottom half of that padding becomes a gap between
+  // two halves of the same label, so the pair reads as two rows rather than one.
+  '[&>div:first-child>[data-slot=tree-row-title]]:pb-0',
+  // The label cluster is a nowrap flex row by default; let it break.
+  '[&>div:first-child]:flex-wrap',
+  // A whole line of its own, aligned under the title.
+  '[&>div:first-child>[data-slot=tree-row-secondary]]:basis-full',
+  '[&>div:first-child>[data-slot=tree-row-secondary]]:ms-0',
+  '[&>div:first-child>[data-slot=tree-row-secondary]]:ps-[calc(2rem+var(--statement-label-indent,0px))]',
+  '[&>div:first-child>[data-slot=tree-row-secondary]]:pb-1',
+].join(' ')
+
+const COLUMNS: StatementColumn[] = [
+  { key: 'debit', label: 'Debit', align: 'right' },
+  { key: 'credit', label: 'Credit', align: 'right' },
+]
+
 export function EntryJournal({ lines, currencyCode, onDrillDown }: EntryJournalProps) {
   // Resolved once for the whole table: brief 13 §1's counterparty is either a
   // `contact` (customer) or a `company` (vendor) instance, and the def id is
@@ -69,89 +106,105 @@ export function EntryJournal({ lines, currencyCode, onDrillDown }: EntryJournalP
   const balanced = totalDebit === totalCredit
   const difference = Math.abs(totalDebit - totalCredit)
 
-  return (
-    <div className='flex flex-col gap-3'>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Account</TableHead>
-            <TableHead className='w-32 text-right'>Debit</TableHead>
-            <TableHead className='w-32 text-right'>Credit</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {[...debits, ...credits].map((line) => (
-            <TableRow key={`${line.direction}-${line.glAccountId}-${line.sortOrder}`}>
-              <TableCell className={cn('align-top', line.direction === 'credit' && 'ps-8')}>
-                <div className='flex items-center gap-2'>
-                  <AccountLabel
-                    account={{ code: line.accountCode, name: line.accountName ?? '' }}
-                  />
-                  {onDrillDown && (
-                    <Tooltip content='What is behind this number'>
-                      <Button
-                        variant='ghost'
-                        size='icon-xs'
-                        aria-label={`What is behind account ${formatAccountLabel({ code: line.accountCode, name: line.accountName ?? '' })}`}
-                        onClick={() =>
-                          onDrillDown({
-                            glAccountId: line.glAccountId,
-                            accountCode: line.accountCode,
-                            accountName: line.accountName,
-                          })
-                        }>
-                        <Search />
-                      </Button>
-                    </Tooltip>
-                  )}
-                </div>
-                {line.memo && <p className='mt-0.5 text-muted-foreground text-xs'>{line.memo}</p>}
-                {line.counterpartyType &&
-                  line.counterpartyId &&
-                  (() => {
-                    const defId =
-                      line.counterpartyType === 'customer'
-                        ? contactResource?.id
-                        : companyResource?.id
-                    if (!defId) return null
-                    return (
-                      <div className='mt-0.5'>
-                        <RecordBadge recordId={toRecordId(defId, line.counterpartyId)} size='sm' />
-                      </div>
-                    )
-                  })()}
-              </TableCell>
-              <TableCell className='text-right font-mono tabular-nums align-top'>
-                {line.direction === 'debit' ? formatMinor(line.amount, currencyCode) : null}
-              </TableCell>
-              <TableCell className='text-right font-mono tabular-nums align-top'>
-                {line.direction === 'credit' ? formatMinor(line.amount, currencyCode) : null}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-        <TableFooter>
-          <TableRow>
-            <TableCell>Totals</TableCell>
-            <TableCell className='text-right font-mono tabular-nums'>
-              {formatMinor(totalDebit, currencyCode)}
-            </TableCell>
-            <TableCell className='text-right font-mono tabular-nums'>
-              {formatMinor(totalCredit, currencyCode)}
-            </TableCell>
-          </TableRow>
-        </TableFooter>
-      </Table>
+  function counterpartyBadge(line: ResolvedPostingLine): ReactNode {
+    if (!line.counterpartyType || !line.counterpartyId) return undefined
+    const defId = line.counterpartyType === 'customer' ? contactResource?.id : companyResource?.id
+    if (!defId) return undefined
+    return <RecordBadge recordId={toRecordId(defId, line.counterpartyId)} size='sm' />
+  }
 
-      <Alert variant={balanced ? 'success' : 'destructive'}>
-        {balanced ? <CheckCircle2 /> : <TriangleAlert />}
-        <span>
-          {balanced
-            ? 'Balanced. Debits equal credits.'
-            : `Out of balance by ${formatMinor(difference, currencyCode)}.`}
-        </span>
-      </Alert>
-    </div>
+  /**
+   * The memo and the counterparty, in `TreeRow`'s VISIBLE `secondary` slot.
+   *
+   * 🛑 Deliberately NOT `meta.note`, which is the slot lib's own report rows
+   * use. `note` renders as `TooltipExplanation` - a `?` you have to hover - and
+   * on a journal entry the memo is IDENTIFYING rather than supplementary: a
+   * fulfillment entry carries fifteen lines all labelled `Sales Tax Payable`,
+   * and the memo ("sales tax, Stephens County Tax") is the only thing that
+   * tells them apart. Hidden behind a hover, the table reads as fifteen
+   * duplicate rows with different amounts. The old hand-rolled table printed it
+   * under the account name for exactly this reason.
+   */
+  function lineSecondary(line: ResolvedPostingLine): ReactNode {
+    const counterparty = counterpartyBadge(line)
+    if (!line.memo && !counterparty) return undefined
+    return (
+      <span className='flex min-w-0 items-center gap-2'>
+        {/* No width cap: {@link TWO_LINE_ROW} gives this slot a line of its
+            own, so the memo and the account name no longer compete. `truncate`
+            still guards the pathological case at the row edge. */}
+        {line.memo && <span className='truncate text-muted-foreground text-xs'>{line.memo}</span>}
+        {counterparty}
+      </span>
+    )
+  }
+
+  /**
+   * One line.
+   *
+   * `depth` IS the accountant's indent - 0 for a debit, 1 for a credit. A
+   * depth-1 row with no children takes `TreeRow`'s padding and nothing else:
+   * the connector line is drawn only for a row that actually has children
+   * (`BaseTreeRow`), so this borrows the indent without implying a parent.
+   */
+  function lineRow(line: ResolvedPostingLine, depth: 0 | 1): StatementRow {
+    return {
+      id: `${line.direction}-${line.glAccountId}-${line.sortOrder}`,
+      // The fallback for a line whose `accountName` snapshot is empty;
+      // `StatementTable` prefers `meta.accountName` and renders `AccountLabel`.
+      label: formatAccountLabel({ code: line.accountCode, name: line.accountName ?? '' }),
+      depth,
+      kind: 'line',
+      values: line.direction === 'debit' ? [line.amount, null] : [null, line.amount],
+      meta: {
+        glAccountId: line.glAccountId,
+        accountCode: line.accountCode,
+        accountName: line.accountName,
+        badge: lineSecondary(line),
+      },
+    }
+  }
+
+  const rows: StatementRow[] = [
+    ...debits.map((line) => lineRow(line, 0)),
+    ...credits.map((line) => lineRow(line, 1)),
+    {
+      id: 'totals',
+      label: 'Totals',
+      depth: 0,
+      kind: 'total',
+      values: [totalDebit, totalCredit],
+    },
+  ]
+
+  return (
+    <StatementTable
+      columns={COLUMNS}
+      rows={rows}
+      currency={currencyCode}
+      rowClassName={TWO_LINE_ROW}
+      verdict={{
+        label: balanced
+          ? 'Balanced. Debits equal credits.'
+          : `Out of balance by ${formatMinor(difference, currencyCode)}.`,
+        ok: balanced,
+      }}
+      // The whole row drills, the idiom every other `StatementTable` consumer
+      // uses (`trial-balance.tsx`), replacing the per-row magnifier button. The
+      // `glAccountId` guard is what keeps the Totals row inert.
+      onRowClick={
+        onDrillDown
+          ? (row) =>
+              row.meta?.glAccountId
+                ? onDrillDown({
+                    glAccountId: row.meta.glAccountId,
+                    accountCode: row.meta.accountCode ?? null,
+                    accountName: row.meta.accountName,
+                  })
+                : undefined
+          : undefined
+      }
+    />
   )
 }
 

--- a/apps/web/src/components/accounting/ui/ledger/format.ts
+++ b/apps/web/src/components/accounting/ui/ledger/format.ts
@@ -103,3 +103,38 @@ export function formatAuditTimestamp(iso: string, timeZone: string): string {
     timeZone,
   }).format(date)
 }
+
+/**
+ * Why Lock is refused for a month, or `null` when it is offered.
+ *
+ * 🛑 A month stays `open` until a MONTH-END entry is posted into it, and
+ * `listClosePeriods` counts ONLY `month_end_inventory` rows
+ * (`postings/close-periods.ts`). Every other posting in the month - the
+ * fulfillment days, credit memos, manual entries - leaves it open however much
+ * money they moved. So a month showing $1.3m of posted fulfillment can still
+ * refuse to lock, and with no reason on screen that reads as a broken button
+ * rather than an unmet precondition.
+ *
+ * ⚠️ The two refusals need DIFFERENT sentences, and giving the second one the
+ * first one's remedy is worse than saying nothing. A `nothing_to_close` month
+ * has no month-end entry to post and never will - the Post control above it
+ * reads "There is nothing to post" and is itself disabled - so "post it, then
+ * lock" points at a dead button. That was the first draft of this copy, and
+ * only opening the screen caught it.
+ */
+export function lockRefusalReason(params: {
+  periodLabel: string
+  /** `ClosePeriod.state !== 'open'`. */
+  isPostedPeriod: boolean
+  /** A post that landed in this session, before the period query has caught up. */
+  justPosted: boolean
+  /** The preview refused with `nothing_to_close`. */
+  isNothingToClose: boolean
+}): string | null {
+  const { periodLabel, isPostedPeriod, justPosted, isNothingToClose } = params
+  if (isPostedPeriod || justPosted) return null
+  if (isNothingToClose) {
+    return `Nothing moved in ${periodLabel}, so there is no month-end entry to post and locking is gated on one. Move to the next month.`
+  }
+  return `${periodLabel} has no month-end entry yet. Post it under Entries above, then lock the month. The other entries this month do not close it.`
+}

--- a/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/ledger-page.tsx
@@ -11,6 +11,7 @@ import { Section } from '@auxx/ui/components/section'
 import { Separator } from '@auxx/ui/components/separator'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import {
   ArrowLeftRight,
   BookOpenCheck,
@@ -52,7 +53,7 @@ import { type CountAdjustmentRow, CountEvidenceSection } from './count-evidence-
 import { EntryBlockers, type LedgerBlocker } from './entry-blockers'
 import { EntryJournal, journalLinesFromDetail } from './entry-journal'
 import { EntryRollForward } from './entry-roll-forward'
-import { formatPeriodLabel } from './format'
+import { formatPeriodLabel, lockRefusalReason } from './format'
 import { type LateArrivalRow, LateArrivalsSection } from './late-arrivals-section'
 import { LedgerToolbar } from './ledger-toolbar'
 import { PostResultCallout } from './post-result-callout'
@@ -198,6 +199,20 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
   const isSoftRefusal = blockers.every((blocker) =>
     (NON_FAILURE_REFUSALS as readonly string[]).includes(blocker.status)
   )
+
+  // Why Lock is refused, or `null` when it is offered. The reasoning, and the
+  // trap of giving a `nothing_to_close` month the postable month's remedy, are
+  // in `lockRefusalReason`'s own header. It is rendered as VISIBLE copy and not
+  // only in the button's tooltip: a refusal an operator has to hover to
+  // discover is the puzzle 13-accounting-ui.md §5.2 is about, and the line it
+  // replaces ("Open. The entry can still be reversed and re-entered") described
+  // the state and named no remedy at all.
+  const lockBlockedReason = lockRefusalReason({
+    periodLabel,
+    isPostedPeriod,
+    justPosted: actions.justPosted,
+    isNothingToClose: blockers.some((blocker) => blocker.status === 'nothing_to_close'),
+  })
   const lines = isPostedPeriod
     ? postedDetail
       ? journalLinesFromDetail(postedDetail.lines)
@@ -614,17 +629,34 @@ export function LedgerPage({ periodKey }: LedgerPageProps) {
                     <div className='flex flex-wrap items-center gap-3'>
                       {canControlLedger ? (
                         <>
-                          <Button
-                            variant={isLocked ? 'outline' : 'default'}
-                            disabled={!isPostedPeriod && !actions.justPosted}
-                            onClick={() => void handleToggleLock()}>
-                            {isLocked ? <LockOpen /> : <Lock />}
-                            {isLocked ? `Unlock ${periodLabel}` : `Lock ${periodLabel}`}
-                          </Button>
+                          {lockBlockedReason ? (
+                            /* 🛑 The `span` is load-bearing. `SimpleTooltip`
+                               clones its child with pointer handlers, and a
+                               DISABLED button fires no pointer events - so
+                               without a wrapper the tooltip never opens and the
+                               reason is unreachable, which is the bug this is
+                               fixing rather than a style choice. */
+                            <SimpleTooltip content={lockBlockedReason}>
+                              <span className='inline-flex'>
+                                <Button disabled>
+                                  <Lock />
+                                  {`Lock ${periodLabel}`}
+                                </Button>
+                              </span>
+                            </SimpleTooltip>
+                          ) : (
+                            <Button
+                              variant={isLocked ? 'outline' : 'default'}
+                              onClick={() => void handleToggleLock()}>
+                              {isLocked ? <LockOpen /> : <Lock />}
+                              {isLocked ? `Unlock ${periodLabel}` : `Lock ${periodLabel}`}
+                            </Button>
+                          )}
                           <span className='text-sm text-muted-foreground'>
                             {isLocked
                               ? 'Locked. Nothing can post into this month until it is unlocked, and unlocking asks first.'
-                              : 'Open. The entry can still be reversed and re-entered.'}
+                              : (lockBlockedReason ??
+                                'Open. The entry can still be reversed and re-entered.')}
                           </span>
                         </>
                       ) : (

--- a/apps/web/src/components/accounting/ui/ledger/posting-drawer.tsx
+++ b/apps/web/src/components/accounting/ui/ledger/posting-drawer.tsx
@@ -13,7 +13,7 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Textarea } from '@auxx/ui/components/textarea'
-import { BookOpenCheck, Layers, Undo2 } from 'lucide-react'
+import { BookOpenCheck, Info, Layers, Undo2 } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '~/trpc/react'
 import { EntryJournal, journalLinesFromDetail } from './entry-journal'
@@ -138,33 +138,46 @@ export function PostingDrawer({
           </div>
         ) : (
           <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
-            <div className='flex flex-col gap-2 p-3'>
-              <div className='flex flex-col gap-1 rounded-lg border bg-muted/30 p-3 text-sm'>
-                <div className='flex justify-between gap-4'>
-                  <span className='text-muted-foreground'>Period</span>
-                  <span>{formatPeriodLabel(detail.periodKey)}</span>
-                </div>
-                <div className='flex justify-between gap-4'>
-                  <span className='text-muted-foreground'>Posted</span>
-                  <span>
-                    {detail.postedAt
-                      ? formatAuditTimestamp(detail.postedAt, bookTimeZone)
-                      : 'Not in the books yet'}
-                  </span>
-                </div>
-                {isReversal && (
+            {/* 🛑 No padding and no gap on this wrapper, deliberately. `Section`
+                draws its own `p-3 pb-4` AND a full-width `border-b`, so stacking
+                sections FLUSH is what makes that border read as the divider
+                between them - the same shape the record drawer's blocks have.
+                A padded, gapped wrapper detaches every divider from the drawer
+                edge and floats the blocks, which is what this used to do; the
+                journal entry drawer had even grown a `-mx-3` bleed to claw one
+                Section back out to the edge. Put padding on a non-Section child
+                instead, never here. */}
+            <div className='flex flex-col'>
+              <Section title='Details' icon={<Info className='size-4' />} collapsible={false}>
+                <dl className='flex flex-col gap-1 text-sm'>
                   <div className='flex justify-between gap-4'>
-                    <span className='shrink-0 text-muted-foreground'>Reverses</span>
-                    <Button
-                      variant='link'
-                      size='sm'
-                      className='h-auto p-0'
-                      onClick={() => detail.reversesId && onSelectPosting(detail.reversesId)}>
-                      <span className='font-mono text-xs'>{detail.reversesId}</span>
-                    </Button>
+                    <dt className='text-muted-foreground'>Period</dt>
+                    <dd>{formatPeriodLabel(detail.periodKey)}</dd>
                   </div>
-                )}
-              </div>
+                  <div className='flex justify-between gap-4'>
+                    <dt className='text-muted-foreground'>Posted</dt>
+                    <dd>
+                      {detail.postedAt
+                        ? formatAuditTimestamp(detail.postedAt, bookTimeZone)
+                        : 'Not in the books yet'}
+                    </dd>
+                  </div>
+                  {isReversal && (
+                    <div className='flex justify-between gap-4'>
+                      <dt className='shrink-0 text-muted-foreground'>Reverses</dt>
+                      <dd>
+                        <Button
+                          variant='link'
+                          size='sm'
+                          className='h-auto p-0'
+                          onClick={() => detail.reversesId && onSelectPosting(detail.reversesId)}>
+                          <span className='font-mono text-xs'>{detail.reversesId}</span>
+                        </Button>
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </Section>
 
               <Section
                 title='Journal entry'
@@ -191,7 +204,7 @@ export function PostingDrawer({
                 </Section>
               )}
 
-              <div className='px-1'>
+              <div className='border-b p-3'>
                 <PostResultCallout
                   result={providerResultFromDetail(detail)}
                   providerLabel={providerLabel}

--- a/apps/web/src/components/accounting/ui/reports/statement-table.tsx
+++ b/apps/web/src/components/accounting/ui/reports/statement-table.tsx
@@ -11,7 +11,7 @@ import { EmptySection } from '@auxx/ui/components/section'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { CheckCircle2, Landmark, Search, TriangleAlert } from 'lucide-react'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { useMemo, useState } from 'react'
 import { AccountLabel } from '../account-label'
 import { accountMatchesSearch } from '../account-label-format'
@@ -101,6 +101,19 @@ export interface StatementTableProps {
    */
   expandAllByDefault?: boolean
   className?: string
+  /**
+   * Extra classes on EVERY row's line, appended after {@link ROW_KIND_CLASS}.
+   *
+   * For a consumer that needs a different row SHAPE, not different content -
+   * `entry-journal.tsx` uses it to wrap the `secondary` slot onto a second line,
+   * because a journal line's memo is identifying text rather than a badge and
+   * cannot share one line with the account name in a docked drawer.
+   *
+   * 🛑 Not a styling hook for colours or spacing. The `kind` classes ARE the
+   * information design of a statement (section > line > subtotal > total) and a
+   * consumer overriding them makes a balance sheet unreadable.
+   */
+  rowClassName?: string
 }
 
 /** Only a `line` row's cells ever accept `CurrencyInput` edits or a click-through. */
@@ -147,6 +160,7 @@ export function StatementTable({
   labelHeading = 'Account',
   expandAllByDefault = false,
   className,
+  rowClassName,
 }: StatementTableProps) {
   const [search, setSearch] = useState('')
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
@@ -197,7 +211,25 @@ export function StatementTable({
   }
 
   return (
-    <div className={cn('flex flex-col gap-3', className)}>
+    <div
+      className={cn('flex flex-col gap-3', className)}
+      style={
+        {
+          /**
+           * How far a row's account NAME sits from the label's left edge:
+           * `AccountLabel`'s reserved `${codeWidthCh}ch` code track plus its
+           * own `gap-1.5`. Published as a variable because the track is
+           * MEASURED here, from the whole statement, and a consumer that wants
+           * to line something else up under the name cannot recompute it
+           * without duplicating `maxAccountCodeLength`.
+           *
+           * `0px` when no row has a code: `AccountLabel` then renders neither
+           * the track nor the gap, so the name starts flush and any offset
+           * would be wrong rather than merely unnecessary.
+           */
+          '--statement-label-indent': codeWidthCh > 0 ? `calc(${codeWidthCh}ch + 0.375rem)` : '0px',
+        } as CSSProperties
+      }>
       <div className='rounded-lg border border-primary-200/50 dark:border-[#1e2227]'>
         {/*
           ⚠️ `top-[var(--statement-sticky-top,0px)]` and NOT `top-0`. The reports
@@ -256,6 +288,7 @@ export function StatementTable({
                 onToggleOpen={toggleOpen}
                 onCellChange={onCellChange}
                 onRowClick={onRowClick}
+                rowClassName={rowClassName}
               />
             ))
           )}
@@ -303,6 +336,8 @@ interface StatementTableRowProps {
   onToggleOpen: (rowId: string) => void
   onCellChange?: (rowId: string, colKey: string, minor: number | null) => void
   onRowClick?: (row: StatementRow) => void
+  /** Appended after the row's `kind` class. See `StatementTableProps`. */
+  rowClassName?: string
 }
 
 /**
@@ -325,6 +360,7 @@ function StatementTableRow({
   onToggleOpen,
   onCellChange,
   onRowClick,
+  rowClassName,
 }: StatementTableRowProps) {
   const editable = mode === 'edit' && EDITABLE_KINDS.has(row.kind)
   const clickable = !!onRowClick && row.kind !== 'section'
@@ -386,7 +422,7 @@ function StatementTableRow({
       }
       secondary={row.meta?.badge}
       description={row.meta?.note}
-      rowClassName={ROW_KIND_CLASS[row.kind]}
+      rowClassName={cn(ROW_KIND_CLASS[row.kind], rowClassName)}
       actions={
         <div className='flex items-center'>
           {columns.map((column, index) => {
@@ -438,6 +474,7 @@ function StatementTableRow({
               onToggleOpen={onToggleOpen}
               onCellChange={onCellChange}
               onRowClick={onRowClick}
+              rowClassName={rowClassName}
             />
           ))
         : undefined}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -688,12 +688,6 @@
       "import": "./dist/geo/index.mjs",
       "default": "./src/geo/index.ts"
     },
-    "./geocoding": {
-      "types": "./src/geocoding/index.ts",
-      "source": "./src/geocoding/index.ts",
-      "import": "./dist/geocoding/index.mjs",
-      "default": "./src/geocoding/index.ts"
-    },
     "./getting-started": {
       "types": "./src/getting-started/index.ts",
       "source": "./src/getting-started/index.ts",

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -306,6 +306,10 @@ export function TreeRow({
 
   const titleNode = (
     <span
+      // Named for the same reason `tree-row-secondary` is: a consumer that
+      // needs to reshape the label from the outside (a two-line row, say) has
+      // no other way to reach this span.
+      data-slot='tree-row-title'
       className={cn(
         'truncate px-1 py-1.5 text-foreground text-sm',
         secondaryFill && 'shrink-0',


### PR DESCRIPTION
Four things, all found by **opening the screens**, not by reading the diff.

## 1. The Lock button was disabled with no reason anywhere on the page

A month stays `open` until a **month-end** entry is posted, and `listClosePeriods` counts only `month_end_inventory` rows. So a month showing $1.3m of posted fulfillment still refuses to lock, and with nothing on screen that reads as a broken button rather than an unmet precondition. The only nearby copy — *"Open. The entry can still be reversed and re-entered"* — described the state, named no remedy, and implied an entry that may not exist.

The reason is now **visible copy**, not only a tooltip (a refusal you have to hover to discover is the puzzle 13-accounting-ui.md §5.2 is about).

**Driving it caught my own first draft being wrong.** It told a `nothing_to_close` month to *"post it under Entries above, then lock"* — pointing at a control that reads **"There is nothing to post"** and is itself disabled. A wrong remedy is worse than silence, so there are two branches. Extracted as `lockRefusalReason` in `format.ts` so it's testable without standing up the 900-line page (8 tests, including a guard that a `nothing_to_close` month is never told to post).

## 2. Both ledger drawers now have the record drawer's shape

They wrapped their bodies in `gap-2 p-3` / `gap-3 p-3`. `Section` draws its own `p-3 pb-4` **and a full-width `border-b`** — that border *is* the divider, so sections must stack flush for it to reach the drawer edge. A padded, gapped wrapper detaches every divider and floats the blocks.

`journal-entry-drawer` had grown a `SECTION_BLEED = '-mx-3'` const specifically to claw one Section back out to the edge against that padding — the codebase already knew this was wrong. **The hack is deleted along with the padding that caused it.** The posting drawer's hand-rolled `rounded-lg border bg-muted/30` facts card becomes a `Section` like everything else. Padding moved onto the non-Section children.

## 3. `EntryJournal` renders through `StatementTable`

It was the last hand-rolled money table in the subsystem — ui-plan's own survey names it by line number (*"every subtotal footer in the app is hand-rolled (`entry-journal.tsx:100-110`)"*). §4.1's argument applies to it exactly: a statement rendering as shadcn's bare `Table` sits in the same drawer as three framed `TreeRow` lists and reads as a different product.

Debits at `depth: 0`, credits at `depth: 1` for the accountant's indent, a `kind: 'total'` row, and the verdict as `StatementVerdict` — which was always *modelled* on this file, so it comes home as a prop rather than a second `Alert`. Drill-down is whole-row click guarded on `meta.glAccountId`, the `trial-balance.tsx` idiom, which keeps the Totals row inert.

Both documented arguments survive: **no number is ever signed** (neither column declares `signed`), and the verdict is **stated rather than implied**.

## 4. Three opt-in additions the migration needed

- **`StatementTable.rowClassName`** — appended after the `kind` class, threaded to nested children. The eleven other consumers pass nothing, so `cn(kind, undefined)` leaves them byte-identical. Documented as a hook for row *shape*, with a guard note that it must not override the `kind` classes, since section > line > subtotal > total *is* the information design of a statement.
- **`--statement-label-indent`** — the reserved code track plus `AccountLabel`'s gap. A variable because the track is **measured** over the whole statement; a consumer can't recompute it without duplicating `maxAccountCodeLength`, and a duplicate would drift. Without it the memo aligns under the **code**, so on a row whose account has no code the name is pushed right past the empty track while the memo stays left. Resolves to `0px` when no row has a code, since `AccountLabel` then renders neither track nor gap.
- **`data-slot='tree-row-title'`** on `TreeRow` — same reason `tree-row-secondary` has one: a consumer reshaping the label from outside has no other way to reach that span. Purely additive, nothing was using the name.

### Why the memo needed all three

It can't go in `meta.note`, which renders as a hover-only `?`: a fulfillment entry carries **fifteen lines all labelled `Sales Tax Payable`**, and the memo is the only thing that tells the jurisdictions apart.

Sharing one line costs one of them. `TREE_SECONDARY_NOTRUNCATE` makes the secondary `shrink-0` so badge pills aren't clipped, while the title is `truncate` — so the account name surrenders **all** its width first and renders as `S...`. Capping the memo just moved the loss onto the memo, whose distinguishing part is its tail. Two lines is the only arrangement where neither is sacrificed — which is what the table this replaces was doing with a `<p>` under the account name.

## `packages/lib/package.json`

Drops the `./geocoding` subpath. **Not hand-edited:** the exports block is generated by `scripts/generate-exports.ts` from *actual consumer imports*, nothing in the repo imports `@auxx/lib/geocoding`, and `pnpm -F @auxx/lib check:exports` runs in CI against the committed file. Verified with `--check`: *"exports up to date (287 entries)"*. `src/geocoding/` is untouched and its export returns the moment something imports it.

## Verification

- web ratchet **0/0**; `packages/ui` **3 files / 56 tests**; accounting suite **13 files / 133 tests**, plus **8 new**
- Biome clean; `check:exports` green
- **Driven on DemoOrg1**: both drawers, the credit-memo and fulfillment entry shapes, the Lock refusal on a `nothing_to_close` month, and the totals/verdict read back from the live DOM ($1,327,272.40 both sides, "Balanced")

https://claude.ai/code/session_01L6vTrHkJHWLTJcRgTRzaYf
