### PR TITLE
feat(accounting): bulk issue drafts from the credit memo posting dialog

### DIFF
--- a/apps/web/src/components/money/ui/batch-posting/batch-posting-dialog.tsx
+++ b/apps/web/src/components/money/ui/batch-posting/batch-posting-dialog.tsx
@@ -87,9 +87,10 @@ interface BatchPostingDialogProps<
   Plan extends BatchPostingPlanShape<Exclusion>,
   Summary extends BatchPostingSummaryShape,
   Exclusion,
+  Options,
 > {
   /** 🛑 A module constant. See the file header. */
-  source: BatchPostingSource<Plan, Summary, Exclusion>
+  source: BatchPostingSource<Plan, Summary, Exclusion, Options>
   open: boolean
   onOpenChange: (open: boolean) => void
   onCompleted?: () => void
@@ -99,9 +100,18 @@ export function BatchPostingDialog<
   Plan extends BatchPostingPlanShape<Exclusion>,
   Summary extends BatchPostingSummaryShape,
   Exclusion,
->({ source, open, onOpenChange, onCompleted }: BatchPostingDialogProps<Plan, Summary, Exclusion>) {
+  Options = undefined,
+>({
+  source,
+  open,
+  onOpenChange,
+  onCompleted,
+}: BatchPostingDialogProps<Plan, Summary, Exclusion, Options>) {
   const [page, setPage] = useState<'plan' | 'result'>('plan')
   const [grouping, setGrouping] = useState<BatchPostingGrouping>(source.defaultGrouping)
+  // The source's own extra request state (§5.5's third axis). `undefined` for a
+  // source that declares no options slot, which is every field it ever sees.
+  const [options, setOptions] = useState<Options>(() => source.options?.defaultValue as Options)
   const [monthRange, setMonthRange] = useState<MonthRangeValue | null>(null)
   const [dayRange, setDayRange] = useState<InclusiveDayRange>(() => ({
     from: startOfLastMonthDayKey(),
@@ -122,8 +132,11 @@ export function BatchPostingDialog<
     setGrouping(source.defaultGrouping)
     setMonthRange(null)
     setDayRange({ from: startOfLastMonthDayKey(), to: todayDayKey() })
+    // 🛑 The options reset with it. An option that changes what the run WRITES
+    // is opt-in on every open, never inherited from the last time.
+    setOptions(source.options?.defaultValue as Options)
     setResult(null)
-  }, [open, source.defaultGrouping])
+  }, [open, source.defaultGrouping, source.options])
 
   // Derived rather than seeded: the period list is a query, so the month a
   // `useState` initialiser could name would be a month nothing had loaded yet.
@@ -145,7 +158,12 @@ export function BatchPostingDialog<
     return dayRangeToWire(dayRange.from, dayRange.to)
   }, [grouping, effectiveMonthRange, dayRange])
 
-  const preview = source.usePreview({ range, grouping, enabled: open && page === 'plan' })
+  const preview = source.usePreview({
+    range,
+    grouping,
+    options,
+    enabled: open && page === 'plan',
+  })
   const runner = source.useRunner()
 
   const plan = preview.plan
@@ -173,7 +191,7 @@ export function BatchPostingDialog<
   const handleRun = async () => {
     if (!plan || !range || plan.footer.postings === 0) return
     try {
-      const summary = await runner.run({ range, grouping })
+      const summary = await runner.run({ range, grouping, options })
       setResult(summary)
       setPage('result')
       onCompleted?.()
@@ -188,6 +206,12 @@ export function BatchPostingDialog<
   const stale = preview.isFetching
   const canRun =
     !!plan && !!range && plan.footer.postings > 0 && !refusal && !stale && !runner.isPending
+
+  // The source's own sentences about its option: why the plan is empty when the
+  // answer is the option being off, and what the run will do beyond posting.
+  // Both null for a source that declares no options slot.
+  const emptyPlanHint = plan ? (source.options?.emptyPlanHint?.(plan, options) ?? null) : null
+  const footerWarning = plan ? (source.options?.footerWarning?.(plan, options) ?? null) : null
 
   return (
     <Dialog open={open} onOpenChange={(next) => !runner.isPending && onOpenChange(next)}>
@@ -254,6 +278,15 @@ export function BatchPostingDialog<
                         disabled={runner.isPending}
                       />
                     </FieldPanelRow>
+
+                    {/* The source's own extra request field, if it has one
+                        (§5.5's third axis). A direct child of the panel, so the
+                        last-row border rule still sees it. */}
+                    {source.options?.render({
+                      value: options,
+                      onChange: setOptions,
+                      disabled: runner.isPending,
+                    })}
                   </FieldPanel>
 
                   {/* A refusal is a card, not a toast (ground rule 9): the book
@@ -279,9 +312,16 @@ export function BatchPostingDialog<
                           : 'flex flex-col gap-4 transition-opacity'
                       }>
                       {plan.groups.length === 0 ? (
-                        <p className='rounded-md border border-dashed px-3 py-6 text-center text-muted-foreground text-sm'>
-                          {source.emptyPlanNote}
-                        </p>
+                        <div className='flex flex-col gap-2'>
+                          <p className='rounded-md border border-dashed px-3 py-6 text-center text-muted-foreground text-sm'>
+                            {source.emptyPlanNote}
+                          </p>
+                          {/* 🛑 When the reason there is nothing to post is an
+                              option that is switched off, say THAT. An empty
+                              plan over a backlog of excluded documents is how
+                              somebody concludes the feature is broken. */}
+                          {emptyPlanHint && <Note tone='warning'>{emptyPlanHint}</Note>}
+                        </div>
                       ) : (
                         source.renderPlanTable({ plan, currencyCode, gatewayNames })
                       )}
@@ -309,52 +349,63 @@ export function BatchPostingDialog<
                   from 613 postings to 62 to 2 as the frequency changes is how
                   the tradeoff becomes visible instead of a constant nobody
                   sees. */}
-              <div className='flex shrink-0 flex-wrap items-center justify-between gap-2 border-t px-4 py-2.5'>
-                <p className='text-muted-foreground text-sm tabular-nums'>
-                  {plan ? (
-                    <>
-                      <strong className='font-medium text-foreground'>
-                        {plan.footer.postings}
-                      </strong>{' '}
-                      {plan.footer.postings === 1 ? 'posting' : 'postings'}
-                      {source.footerCounts(plan).map((count) => (
-                        <Fragment key={count.plural}>
-                          {' · '}
-                          <strong className='font-medium text-foreground'>{count.value}</strong>{' '}
-                          {count.value === 1 ? count.singular : count.plural}
-                        </Fragment>
-                      ))}
-                      {' · '}
-                      <strong className='font-medium text-foreground'>
-                        {formatMinor(plan.footer.totalMinor, currencyCode)}
-                      </strong>
-                    </>
-                  ) : (
-                    'No preview yet'
-                  )}
-                </p>
+              <div className='shrink-0 border-t'>
+                {/* 🛑 Above the counts, not in the scroll area: an option that
+                    WRITES to every document in the plan says so where the
+                    button is, which is the last thing read before it. */}
+                {footerWarning && (
+                  <p className='flex items-start gap-1.5 border-b bg-amber-50/60 px-4 py-2 text-sm dark:bg-amber-950/30'>
+                    <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+                    <span>{footerWarning}</span>
+                  </p>
+                )}
+                <div className='flex flex-wrap items-center justify-between gap-2 px-4 py-2.5'>
+                  <p className='text-muted-foreground text-sm tabular-nums'>
+                    {plan ? (
+                      <>
+                        <strong className='font-medium text-foreground'>
+                          {plan.footer.postings}
+                        </strong>{' '}
+                        {plan.footer.postings === 1 ? 'posting' : 'postings'}
+                        {source.footerCounts(plan).map((count) => (
+                          <Fragment key={count.plural}>
+                            {' · '}
+                            <strong className='font-medium text-foreground'>{count.value}</strong>{' '}
+                            {count.value === 1 ? count.singular : count.plural}
+                          </Fragment>
+                        ))}
+                        {' · '}
+                        <strong className='font-medium text-foreground'>
+                          {formatMinor(plan.footer.totalMinor, currencyCode)}
+                        </strong>
+                      </>
+                    ) : (
+                      'No preview yet'
+                    )}
+                  </p>
 
-                <div className='flex items-center gap-2'>
-                  <Button
-                    type='button'
-                    variant='ghost'
-                    size='sm'
-                    onClick={() => onOpenChange(false)}
-                    disabled={runner.isPending}>
-                    Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-                  </Button>
-                  <Button
-                    variant='outline'
-                    size='sm'
-                    onClick={handleRun}
-                    loading={runner.isPending}
-                    loadingText={source.runningLabel}
-                    disabled={!canRun}
-                    data-dialog-submit>
-                    Post {plan?.footer.postings ?? 0}{' '}
-                    {plan?.footer.postings === 1 ? 'entry' : 'entries'}{' '}
-                    <KbdSubmit variant='outline' size='sm' />
-                  </Button>
+                  <div className='flex items-center gap-2'>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='sm'
+                      onClick={() => onOpenChange(false)}
+                      disabled={runner.isPending}>
+                      Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+                    </Button>
+                    <Button
+                      variant='outline'
+                      size='sm'
+                      onClick={handleRun}
+                      loading={runner.isPending}
+                      loadingText={source.runningLabel}
+                      disabled={!canRun}
+                      data-dialog-submit>
+                      Post {plan?.footer.postings ?? 0}{' '}
+                      {plan?.footer.postings === 1 ? 'entry' : 'entries'}{' '}
+                      <KbdSubmit variant='outline' size='sm' />
+                    </Button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -367,6 +418,7 @@ export function BatchPostingDialog<
                 result ? source.membersPosted(result) : { value: 0, singular: '', plural: '' }
               }
               postedRows={result ? source.postedRows(result) : []}
+              optionNote={result ? (source.options?.resultNote?.(result) ?? null) : null}
               excludedNoun={source.excludedNoun}
               onBack={() => setPage('plan')}
               onClose={() => onOpenChange(false)}

--- a/apps/web/src/components/money/ui/batch-posting/batch-posting-result.tsx
+++ b/apps/web/src/components/money/ui/batch-posting/batch-posting-result.tsx
@@ -17,6 +17,7 @@ import { Button } from '@auxx/ui/components/button'
 import { KbdSubmit } from '@auxx/ui/components/kbd'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { TriangleAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { countLabel } from './count-label'
 import type { BatchPostingCount, BatchPostingPostedRow, BatchPostingSummaryShape } from './types'
 
@@ -28,6 +29,14 @@ interface BatchPostingResultProps<Summary extends BatchPostingSummaryShape> {
   /** What the posted entries covered, in this source's nouns. */
   membersPosted: BatchPostingCount
   postedRows: ReadonlyArray<BatchPostingPostedRow>
+  /**
+   * What this source's option did, from `BatchPostingOptionsSlot.resultNote`.
+   *
+   * Rendered directly under the posted entries and ABOVE skipped and failed: an
+   * option that writes to documents (issuing a draft) leaves work behind when it
+   * refuses, and the bottom of a list of 62 groups is where that gets lost.
+   */
+  optionNote?: ReactNode
   excludedNoun: { singular: string; plural: string }
   onBack: () => void
   onClose: () => void
@@ -37,6 +46,7 @@ export function BatchPostingResult<Summary extends BatchPostingSummaryShape>({
   result,
   membersPosted,
   postedRows,
+  optionNote,
   excludedNoun,
   onBack,
   onClose,
@@ -68,6 +78,8 @@ export function BatchPostingResult<Summary extends BatchPostingSummaryShape>({
               {posted > ROWS_SHOWN && <li>and {posted - ROWS_SHOWN} more</li>}
             </ul>
           )}
+
+          {optionNote}
 
           {skipped > 0 && (
             <div>

--- a/apps/web/src/components/money/ui/batch-posting/index.ts
+++ b/apps/web/src/components/money/ui/batch-posting/index.ts
@@ -8,6 +8,8 @@ export type {
   BatchPostingCount,
   BatchPostingExclusionRow,
   BatchPostingGrouping,
+  BatchPostingOptionsProps,
+  BatchPostingOptionsSlot,
   BatchPostingPlanShape,
   BatchPostingPostedRow,
   BatchPostingPreview,

--- a/apps/web/src/components/money/ui/batch-posting/types.ts
+++ b/apps/web/src/components/money/ui/batch-posting/types.ts
@@ -16,6 +16,25 @@
  * range control, the refusal card, the exclusions table, the footer layout, the
  * result page, the gateway-name lookup (both sources render a routed clearing
  * account) and the currency.
+ *
+ * ## The third axis: OPTIONS
+ *
+ * §5.5's two axes held until a source needed an extra REQUEST FIELD. The credit
+ * memo poster's `issueDrafts` is one: channel memos are ingested as `draft`, so
+ * a dialog that can only post already-issued memos previews an empty plan over
+ * the whole backlog and posts nothing.
+ *
+ * So a source may declare one {@link BatchPostingOptionsSlot}: a value of its
+ * own shape, the control that sets it, and the three sentences that explain it -
+ * the empty state's pointer at it, the footer's warning about what it will do,
+ * and what the result page says it did. The frame holds the value in state,
+ * resets it on every open, and threads it into `usePreview` and `run`.
+ *
+ * 🛑 **It is not a form engine, and adding a fourth axis needs the same
+ * argument this one had.** The frame never reads INTO the value, never validates
+ * it and never renders a control from a schema: the source renders its own
+ * control and owns its own shape. A source that declares no slot behaves exactly
+ * as it did before the slot existed.
  */
 
 import type { BatchPostingGrouping } from '@auxx/lib/money/client'
@@ -75,9 +94,15 @@ export interface BatchPostingExclusionRow {
   detail: string
 }
 
-export interface BatchPostingPreviewInput {
+export interface BatchPostingPreviewInput<Options = undefined> {
   range: BatchPostingWireRange | null
   grouping: BatchPostingGrouping
+  /**
+   * This source's own extra request state, or `undefined` when it declares no
+   * {@link BatchPostingOptionsSlot}. The preview takes it because the plan the
+   * dialog renders has to be the plan the run would execute (§6.4).
+   */
+  options: Options
   enabled: boolean
 }
 
@@ -97,9 +122,62 @@ export interface BatchPostingPreview<Plan> {
 }
 
 /** What the frame needs back from the source's run mutation. */
-export interface BatchPostingRunner<Summary> {
-  run: (input: { range: BatchPostingWireRange; grouping: BatchPostingGrouping }) => Promise<Summary>
+export interface BatchPostingRunner<Summary, Options = undefined> {
+  run: (input: {
+    range: BatchPostingWireRange
+    grouping: BatchPostingGrouping
+    /** The same value the preview was taken with. See {@link BatchPostingOptionsSlot}. */
+    options: Options
+  }) => Promise<Summary>
   isPending: boolean
+}
+
+/** What the frame hands a source's own controls. */
+export interface BatchPostingOptionsProps<Options> {
+  value: Options
+  onChange: (next: Options) => void
+  /** True while the run is in flight. */
+  disabled: boolean
+}
+
+/**
+ * A source's own extra request state, and everything that explains it.
+ *
+ * 🛑 One slot per source, one value, and the source renders its own control.
+ * See the header of this file for why this axis exists and what it is not.
+ */
+export interface BatchPostingOptionsSlot<Options, Plan, Summary> {
+  /**
+   * What a freshly opened dialog starts with.
+   *
+   * Re-read on every open, like the range and the frequency: an option that
+   * changes what the run WRITES is opt-in every time, never remembered from a
+   * dialog somebody abandoned.
+   */
+  defaultValue: Options
+  /**
+   * The control. Rendered as a direct child of the dialog's `FieldPanel`, under
+   * the range row, so a `FieldPanelRow` is what belongs here.
+   */
+  render: (props: BatchPostingOptionsProps<Options>) => ReactNode
+  /**
+   * Why the plan is empty, when the answer is this option being off.
+   *
+   * 🛑 Rendered beside `emptyPlanNote` whenever the plan has no groups. Without
+   * it the one screen that could explain a backlog of excluded documents says
+   * only "nothing to post", which is how somebody concludes the feature is
+   * broken.
+   */
+  emptyPlanHint?: (plan: Plan, value: Options) => ReactNode | null
+  /**
+   * What this run will do BEYOND posting, said in the footer.
+   *
+   * The footer is the last thing read before the button, so an option that
+   * writes to documents says so there and not only in the control's caption.
+   */
+  footerWarning?: (plan: Plan, value: Options) => ReactNode | null
+  /** What the option actually did, on the result page. */
+  resultNote?: (summary: Summary) => ReactNode | null
 }
 
 export interface BatchPostingTableProps<Plan> {
@@ -116,6 +194,7 @@ export interface BatchPostingSource<
   Plan extends BatchPostingPlanShape<Exclusion>,
   Summary extends BatchPostingSummaryShape,
   Exclusion,
+  Options = undefined,
 > {
   /** `'fulfillment' | 'credit_memo'`. Identity only. */
   sourceKey: string
@@ -139,10 +218,15 @@ export interface BatchPostingSource<
   runningLabel: string
   /** What an empty plan says, in this source's nouns. */
   emptyPlanNote: string
+  /**
+   * This source's own extra request field and its control (the third axis, see
+   * the header). Absent means the dialog is exactly what it was without it.
+   */
+  options?: BatchPostingOptionsSlot<Options, Plan, Summary>
   /** The preview query. 🛑 A HOOK - see the header of `batch-posting-dialog.tsx`. */
-  usePreview: (input: BatchPostingPreviewInput) => BatchPostingPreview<Plan>
+  usePreview: (input: BatchPostingPreviewInput<Options>) => BatchPostingPreview<Plan>
   /** The run mutation, including its own cache invalidation. 🛑 Also a HOOK. */
-  useRunner: () => BatchPostingRunner<Summary>
+  useRunner: () => BatchPostingRunner<Summary, Options>
   /** The plan table. Its COLUMNS are one of the two per-source halves (§5.5). */
   renderPlanTable: (props: BatchPostingTableProps<Plan>) => ReactNode
   /** The other half: what the footer counts, after the posting count. */

--- a/apps/web/src/components/money/ui/credit-memo-posting/credit-memo-source.tsx
+++ b/apps/web/src/components/money/ui/credit-memo-posting/credit-memo-source.tsx
@@ -22,6 +22,15 @@
 // A credit memo credits the books on the day it was issued, so the window is on
 // `issuedAt` and never on the order's date or the refund's. Both ends are
 // inclusive on the screen and half-open on the wire (25 §6.1).
+//
+// ## The one OPTION: issue drafts
+//
+// The third axis of the descriptor, and the source that made it exist. Channel
+// credit memos are INGESTED as `draft` - every one of DemoOrg1's 1,061 is - and
+// nothing bulk-issues them, so a dialog that only posts already-issued memos
+// previews an empty plan over the entire backlog. The switch is off by default
+// because issuing writes to hundreds of documents, and the empty state points
+// straight at it because an unexplained empty plan reads as a broken feature.
 
 import type {
   CreditMemoPostingExclusion,
@@ -30,15 +39,32 @@ import type {
   CreditMemoPostingRunSummary,
 } from '@auxx/lib/money/client'
 import { BATCH_POSTING_GROUPINGS } from '@auxx/lib/money/client'
+import { Switch } from '@auxx/ui/components/switch'
 import { keepPreviousData } from '@tanstack/react-query'
+import { TriangleAlert } from 'lucide-react'
+import { FieldPanelRow } from '~/components/global/forms/field-panel'
 import type {
   BatchPostingPreview,
   BatchPostingPreviewInput,
   BatchPostingRunner,
   BatchPostingSource,
 } from '~/components/money/ui/batch-posting'
+import { BaseType } from '~/components/workflow/types'
 import { api } from '~/trpc/react'
 import { CreditMemoPlanTable } from './credit-memo-plan-table'
+
+/**
+ * This source's extra request state.
+ *
+ * One field, and it is a WRITE: `issueDrafts` flips every `draft` memo the plan
+ * covers to `issued` before the entry is posted.
+ */
+export interface CreditMemoPostingOptions {
+  issueDrafts: boolean
+}
+
+/** How many rows of the failed-to-issue list are printed before it collapses. */
+const ISSUE_FAILURE_ROWS_SHOWN = 12
 
 /**
  * What each exclusion reason says on the row.
@@ -47,7 +73,7 @@ import { CreditMemoPlanTable } from './credit-memo-plan-table'
  * evidence. Both are needed: "before the accounting cutoff" explains nothing
  * without the cutoff, and `2026-06` explains nothing on its own.
  *
- * 🛑 A total `Record` over the closed union, so a seventh reason stops THIS file
+ * 🛑 A total `Record` over the closed union, so an eighth reason stops THIS file
  * compiling rather than rendering as a raw slug in the shared table.
  *
  * ⚠️ `gateway-ambiguous` and `test-gateway` are deliberately absent, and the
@@ -73,10 +99,15 @@ const EXCLUSION_COPY: Record<CreditMemoPostingExclusionReason, { label: string; 
       detail:
         'What is not refunded is credited to that customer in accounts receivable, and a receivable line that names nobody cannot be exported. Put the customer on the memo and it posts with the next run.',
     },
+    'missing-number': {
+      label: 'No credit memo number',
+      detail:
+        'The entry keys its document number on the memo number, so a memo without one cannot be told apart from any other memo in the period it posts into. Give it a number and it posts with the next run.',
+    },
     'not-issued': {
       label: 'Not issued',
       detail:
-        'A draft or voided memo is not a document the ledger has an opinion about. Issue it and it joins the next run.',
+        'A draft or voided memo is not a document the ledger has an opinion about. Turn on Issue drafts above to issue the drafts as part of this run; a voided memo never posts.',
     },
     'zero-value': {
       label: 'Nothing to credit',
@@ -96,10 +127,19 @@ const EXCLUSION_COPY: Record<CreditMemoPostingExclusionReason, { label: string; 
 function useCreditMemoPreview({
   range,
   grouping,
+  options,
   enabled,
-}: BatchPostingPreviewInput): BatchPostingPreview<CreditMemoPostingPlan> {
+}: BatchPostingPreviewInput<CreditMemoPostingOptions>): BatchPostingPreview<CreditMemoPostingPlan> {
   const query = api.money.previewCreditMemoPosting.useQuery(
-    { from: range?.from ?? '', to: range?.to ?? '', grouping },
+    {
+      from: range?.from ?? '',
+      to: range?.to ?? '',
+      grouping,
+      // 🛑 On the PREVIEW too, not only on the run: the plan the dialog shows has
+      // to be the plan the run executes, and with the flag on the server side
+      // only, the footer would read 0 postings for a run that posts 62.
+      issueDrafts: options.issueDrafts,
+    },
     {
       enabled: enabled && !!range,
       retry: false,
@@ -118,21 +158,26 @@ function useCreditMemoPreview({
 }
 
 /** The run mutation, plus the caches only this source's run invalidates. */
-function useCreditMemoRunner(): BatchPostingRunner<CreditMemoPostingRunSummary> {
+function useCreditMemoRunner(): BatchPostingRunner<
+  CreditMemoPostingRunSummary,
+  CreditMemoPostingOptions
+> {
   const utils = api.useUtils()
   const postCreditMemos = api.money.runCreditMemoPosting.useMutation()
 
   return {
     isPending: postCreditMemos.isPending,
-    run: async ({ range, grouping }) => {
+    run: async ({ range, grouping, options }) => {
       const summary = await postCreditMemos.mutateAsync({
         from: range.from,
         to: range.to,
         grouping,
+        issueDrafts: options.issueDrafts,
       })
       // The run writes `GlPosting` rows and stamps every memo behind them, and
       // nothing on the ledger page or a memo's ledger card learns about either on
-      // its own.
+      // its own. With `issueDrafts` it also flips the memos' own status, so the
+      // credit memo list is stale too.
       await Promise.all([
         utils.ledger.invalidate(),
         utils.money.creditMemoPostings.invalidate(),
@@ -143,10 +188,24 @@ function useCreditMemoRunner(): BatchPostingRunner<CreditMemoPostingRunSummary> 
   }
 }
 
+/**
+ * How many of the memos this plan excluded are DRAFTS.
+ *
+ * `not-issued` covers `draft` and `void` alike, and only the drafts are what the
+ * switch would rescue. The exclusion's own `detail` is the memo's status
+ * verbatim (`plan.ts`), which is what makes the two tellable apart here.
+ */
+function countExcludedDrafts(plan: CreditMemoPostingPlan): number {
+  return plan.exclusions.filter(
+    (exclusion) => exclusion.reason === 'not-issued' && exclusion.detail === 'draft'
+  ).length
+}
+
 export const CREDIT_MEMO_POSTING_SOURCE: BatchPostingSource<
   CreditMemoPostingPlan,
   CreditMemoPostingRunSummary,
-  CreditMemoPostingExclusion
+  CreditMemoPostingExclusion,
+  CreditMemoPostingOptions
 > = {
   sourceKey: 'credit_memo',
   title: 'Post credit memos',
@@ -163,6 +222,99 @@ export const CREDIT_MEMO_POSTING_SOURCE: BatchPostingSource<
   runningLabel: 'Posting...',
   emptyPlanNote:
     'Nothing to post in this range. Every credit memo in it either already carries a live posting or is listed below with the reason it does not.',
+  options: {
+    // 🛑 OFF. It changes document state for potentially hundreds of records in
+    // one press, so it is opt-in every time the dialog opens.
+    defaultValue: { issueDrafts: false },
+    render: ({ value, onChange, disabled }) => (
+      <FieldPanelRow
+        title='Issue drafts'
+        type={BaseType.BOOLEAN}
+        showIcon
+        description='Only drafts. A voided memo is never issued and never posts.'>
+        <div className='flex items-start gap-2.5 py-1.5 pe-2'>
+          <Switch
+            checked={value.issueDrafts}
+            onCheckedChange={(issueDrafts) => onChange({ issueDrafts })}
+            disabled={disabled}
+            className='mt-0.5 shrink-0'
+            aria-label='Issue drafts'
+          />
+          <span className='text-muted-foreground text-xs'>
+            Draft memos in this range are issued as part of the run, then posted into the same
+            entry. Left off, they are listed below as not issued and nothing happens to them.
+          </span>
+        </div>
+      </FieldPanelRow>
+    ),
+    // 🛑 The empty plan over a backlog of drafts. Channel memos arrive as
+    // drafts, so this is the FIRST thing most orgs see in this dialog, and
+    // "nothing to post" on its own is how somebody decides it is broken.
+    emptyPlanHint: (plan, value) => {
+      if (value.issueDrafts) return null
+      const drafts = countExcludedDrafts(plan)
+      if (drafts === 0) return null
+      return (
+        <>
+          <strong className='font-medium'>{drafts}</strong>{' '}
+          {drafts === 1
+            ? 'credit memo in this range is still a draft'
+            : 'credit memos in this range are still drafts'}
+          . Turn on <strong className='font-medium'>Issue drafts</strong> above to issue and post
+          them.
+        </>
+      )
+    },
+    // Issuing is a write to every one of them, and the footer is the last thing
+    // read before the button.
+    footerWarning: (plan) => {
+      if (plan.footer.drafts === 0) return null
+      return (
+        <>
+          <strong className='font-medium'>{plan.footer.drafts}</strong> of {plan.footer.memos}{' '}
+          {plan.footer.memos === 1 ? 'memo' : 'memos'} will be issued, then posted. Issuing is a
+          write to each one, and the entries can only be corrected by reversing them.
+        </>
+      )
+    },
+    resultNote: (summary) => {
+      const { count, failed } = summary.issued
+      if (count === 0 && failed.length === 0) return null
+      return (
+        <div>
+          {count > 0 && (
+            <p>
+              <strong className='font-medium'>{count}</strong> draft{' '}
+              {count === 1 ? 'memo was' : 'memos were'} issued by this run.
+            </p>
+          )}
+          {failed.length > 0 && (
+            <>
+              {/* Not buried under the posted list: a memo that refused to issue
+                  is a document somebody has to open. */}
+              <p className='mt-1 flex items-start gap-1.5'>
+                <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+                <span>
+                  {failed.length} {failed.length === 1 ? 'memo' : 'memos'} could not be issued.{' '}
+                  {failed.length === 1 ? 'It is' : 'They are'} still a draft and posted nothing.
+                </span>
+              </p>
+              <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
+                {failed.slice(0, ISSUE_FAILURE_ROWS_SHOWN).map((row) => (
+                  <li key={row.creditMemoId}>
+                    {row.number}: {row.reason}
+                  </li>
+                ))}
+                {failed.length > ISSUE_FAILURE_ROWS_SHOWN && (
+                  <li>and {failed.length - ISSUE_FAILURE_ROWS_SHOWN} more</li>
+                )}
+              </ul>
+            </>
+          )}
+        </div>
+      )
+    },
+  },
   usePreview: useCreditMemoPreview,
   useRunner: useCreditMemoRunner,
   renderPlanTable: ({ plan, currencyCode, gatewayNames }) => (

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -233,6 +233,18 @@ const creditMemoPostingShape = {
   from: z.iso.date(),
   to: z.iso.date(),
   grouping: z.enum(CREDIT_MEMO_POSTING_GROUPING_VALUES),
+  /**
+   * Issue the `draft` memos in the range as part of the run instead of excluding
+   * them as `not-issued`.
+   *
+   * 🛑 On the PREVIEW as well as the run, and required on both rather than
+   * defaulted: channel memos are ingested as `draft`, so this flag decides
+   * whether a plan covers the whole backlog or nothing at all, and a preview
+   * taken without it would name a footer the run does not honour. A default
+   * would let a caller that never heard of the flag get the other answer
+   * silently.
+   */
+  issueDrafts: z.boolean(),
 }
 
 export const moneyRouter = createTRPCRouter({
@@ -959,6 +971,7 @@ export const moneyRouter = createTRPCRouter({
         organizationId: ctx.session.organizationId,
         range: { from: input.from, to: input.to },
         grouping: input.grouping,
+        issueDrafts: input.issueDrafts,
       })
       if (result.isErr()) throw result.error
       return result.value
@@ -972,6 +985,11 @@ export const moneyRouter = createTRPCRouter({
    * declined (`already_posted`, a locked period) and a group that failed are both
    * arms of the summary, so the result page can say which of the months landed
    * instead of reporting the whole run as an error.
+   *
+   * ⚠️ With `issueDrafts` this also writes to the MEMOS - every draft it covers
+   * is issued before the entry is posted - which is why `summary.issued` is its
+   * own arm: a memo can be issued and still fail to post, and a draft that
+   * refuses to issue is a document somebody has to open.
    */
   runCreditMemoPosting: permissionProcedure(PermissionKey.ledgerPost)
     .input(z.object({ ...creditMemoPostingShape, memo: z.string().max(4000).optional() }))
@@ -981,6 +999,7 @@ export const moneyRouter = createTRPCRouter({
         actorUserId: ctx.session.userId,
         range: { from: input.from, to: input.to },
         grouping: input.grouping,
+        issueDrafts: input.issueDrafts,
         memo: input.memo,
       })
     }),

--- a/packages/lib/src/money/credit-memo-posting/__tests__/plan.test.ts
+++ b/packages/lib/src/money/credit-memo-posting/__tests__/plan.test.ts
@@ -57,6 +57,7 @@ function plan(
     lockedThroughMonth: null,
     ledgerCurrency: 'USD',
     timeZone: 'America/Los_Angeles',
+    issueDrafts: false,
     ...overrides,
   })
 }
@@ -253,6 +254,145 @@ describe('the exclusion priority order', () => {
   })
 })
 
+// 🛑 Channel memos are INGESTED as `draft` - all 1,061 of DemoOrg1's - so a
+// planner that always excludes a draft excludes the entire backlog and posts
+// nothing. §7's `not-issued` was written as though somebody had already issued
+// them one at a time, and nothing bulk-issues.
+describe('issueDrafts', () => {
+  it('plans a draft as a member instead of excluding it', () => {
+    const result = plan([memo({ status: 'draft' })], { issueDrafts: true })
+
+    expect(result.exclusions).toEqual([])
+    expect(result.groups[0]?.memos.map((m) => m.number)).toEqual(['CM-0001'])
+  })
+
+  it('counts the planned drafts in the footer, so the dialog can say so', () => {
+    const result = plan(
+      [
+        memo({ creditMemoId: 'a', number: 'CM-0001', status: 'draft' }),
+        memo({ creditMemoId: 'b', number: 'CM-0002', status: 'issued', contactId: 'ct_2' }),
+        memo({ creditMemoId: 'c', number: 'CM-0003', status: 'settled', contactId: 'ct_3' }),
+      ],
+      { issueDrafts: true }
+    )
+
+    expect(result.footer.memos).toBe(3)
+    expect(result.footer.drafts).toBe(1)
+  })
+
+  // A draft the plan EXCLUDED is not a document state this run changes.
+  it('does not count an excluded draft as one it will issue', () => {
+    const result = plan([memo({ status: 'draft', currency: 'EUR' })], { issueDrafts: true })
+
+    expect(result.footer.drafts).toBe(0)
+    expect(result.exclusions[0]?.reason).toBe('foreign-currency')
+  })
+
+  it('reports zero drafts when the flag is off, whatever is in the range', () => {
+    const result = plan([memo({ status: 'draft' })])
+
+    expect(result.footer.drafts).toBe(0)
+    expect(result.footer.memos).toBe(0)
+  })
+
+  // 🛑 `draft` and nothing else. A void memo is never resurrected.
+  it('still excludes a void memo as not-issued', () => {
+    const result = plan([memo({ status: 'void' })], { issueDrafts: true })
+
+    expect(result.groups).toEqual([])
+    expect(result.exclusions[0]).toMatchObject({ reason: 'not-issued', detail: 'void' })
+  })
+
+  // Fail CLOSED: an option id nobody has taught this module about is not a
+  // draft, so `issueDrafts` does not make it postable either.
+  it('still excludes an unknown status as not-issued', () => {
+    const result = plan([memo({ status: 'pending_review' })], { issueDrafts: true })
+
+    expect(result.exclusions[0]).toMatchObject({ reason: 'not-issued', detail: 'pending_review' })
+  })
+
+  it('leaves the plan exactly as it was when the flag is off', () => {
+    const memos = [
+      memo({ creditMemoId: 'a', number: 'CM-0001', status: 'draft' }),
+      memo({ creditMemoId: 'b', number: 'CM-0002', status: 'issued', contactId: 'ct_2' }),
+    ]
+
+    const result = plan(memos)
+
+    expect(result.groups[0]?.memos.map((m) => m.number)).toEqual(['CM-0002'])
+    expect(result.exclusions).toEqual([
+      {
+        creditMemoId: 'a',
+        number: 'CM-0001',
+        issuedAt: '2026-01-14',
+        reason: 'not-issued',
+        detail: 'draft',
+      },
+    ])
+  })
+
+  // 🛑 `run.ts` issues a planned draft through `resolveIssue`, which refuses
+  // without a contact or a number, so the planner must not promise one.
+  describe('the refusals resolveIssue would apply', () => {
+    it('excludes a draft with no contact as missing-contact', () => {
+      const result = plan([memo({ status: 'draft', contactId: null })], { issueDrafts: true })
+
+      expect(result.exclusions[0]?.reason).toBe('missing-contact')
+    })
+
+    it('excludes a draft with no number as missing-number', () => {
+      const result = plan([memo({ status: 'draft', number: '' })], { issueDrafts: true })
+
+      expect(result.exclusions[0]).toMatchObject({
+        reason: 'missing-number',
+        detail: 'credit_memo_number is empty',
+      })
+    })
+
+    it('excludes a draft whose number is blank as missing-number', () => {
+      const result = plan([memo({ status: 'draft', number: '   ' })], { issueDrafts: true })
+
+      expect(result.exclusions[0]?.reason).toBe('missing-number')
+    })
+
+    it('reports missing-contact before missing-number, as resolveIssue does', () => {
+      const result = plan([memo({ status: 'draft', contactId: null, number: '' })], {
+        issueDrafts: true,
+      })
+
+      expect(result.exclusions).toHaveLength(1)
+      expect(result.exclusions[0]?.reason).toBe('missing-contact')
+    })
+
+    it('excludes a draft that credits nothing as zero-value', () => {
+      const result = plan(
+        [
+          memo({
+            status: 'draft',
+            subtotalMinor: 0,
+            taxTotalMinor: 0,
+            totalMinor: 0,
+            amountRefundedMinor: 0,
+          }),
+        ],
+        { issueDrafts: true }
+      )
+
+      expect(result.exclusions[0]?.reason).toBe('zero-value')
+    })
+
+    // ⚠️ Only a memo this run would ISSUE. A batch entry keys its document
+    // number on the PERIOD, so an already-issued memo with an unallocated
+    // number posts inside one perfectly well.
+    it('posts an already-issued memo with no number rather than refusing it', () => {
+      const result = plan([memo({ status: 'issued', number: '' })], { issueDrafts: true })
+
+      expect(result.exclusions).toEqual([])
+      expect(result.groups).toHaveLength(1)
+    })
+  })
+})
+
 // §7 and `types.ts`: a sale can be refused and re-run, a refund cannot, because
 // the money has already moved.
 describe('the reasons that deliberately do not exist', () => {
@@ -433,6 +573,7 @@ describe('the footer', () => {
       postings: 2,
       memos: 2,
       contacts: 2,
+      drafts: 0,
       excluded: 1,
       totalMinor: 20_000,
     })

--- a/packages/lib/src/money/credit-memo-posting/__tests__/run.test.ts
+++ b/packages/lib/src/money/credit-memo-posting/__tests__/run.test.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/money/credit-memo-posting/__tests__/run.test.ts
 //
-// The four properties the run exists to hold:
+// The five properties the run exists to hold:
 //
 //  1. **The attempt counter.** A month key claims the month once, and a memo
 //     issued late into an already-posted January - or a January that was
@@ -13,6 +13,11 @@
 //  3. **Never throws**, and a group that posted but could not stamp is reported
 //     in BOTH `posted` and `failed` (§4.4).
 //  4. **§8's warning is a warning**, never a refusal.
+//  5. **It bulk ISSUES** (§7). Channel memos are ingested as `draft`, so a run
+//     that only posts already-issued memos posts nothing at all. Every draft is
+//     flipped through `issueCreditMemo(..., { post: false })` - ONE entry for
+//     the group, never one per memo - and a member that refuses is dropped from
+//     the group rather than summarised into an entry that says it was credited.
 //
 // `plan.ts` and the pure builders run FOR REAL; only the database, the poster
 // and the stamp are doubles.
@@ -36,13 +41,42 @@ const h = vi.hoisted(() => ({
     docNumber?: string
     error?: string
   },
-  postCalls: [] as Array<{ periodKey: string; txnDate: string; memo?: string }>,
+  postCalls: [] as Array<{
+    periodKey: string
+    txnDate: string
+    memo?: string
+    /** The entry's own lines, so a test can assert what a group actually claims. */
+    lines: Array<{ direction: string; amount: number }>
+  }>,
   stamps: [] as Array<{ creditMemoId: string; values: unknown }>,
   stampThrowsFor: null as string | null,
   systemUserId: 'usr_system',
   isAccountingEnabled: vi.fn(async () => true),
   readMemoCalls: 0,
   readSettingsCalls: 0,
+  /** Every `issueCreditMemo` call, with the options it carried. */
+  issues: [] as Array<{ creditMemoId: string; userId: string; issuedAt?: string; post?: boolean }>,
+  /** Credit memo ids whose issue refuses. */
+  issueThrowsFor: new Set<string>(),
+}))
+
+vi.mock('../../credit-memos/writes', () => ({
+  issueCreditMemo: async (
+    _db: unknown,
+    input: { userId: string; creditMemoInstanceId: string; issuedAt?: string },
+    options: { post?: boolean } = {}
+  ) => {
+    if (h.issueThrowsFor.has(input.creditMemoInstanceId)) {
+      throw new Error(`credit memo ${input.creditMemoInstanceId} has no lines`)
+    }
+    h.issues.push({
+      creditMemoId: input.creditMemoInstanceId,
+      userId: input.userId,
+      ...(input.issuedAt !== undefined ? { issuedAt: input.issuedAt } : {}),
+      ...(options.post !== undefined ? { post: options.post } : {}),
+    })
+    return { postingId: null, docNumber: null, status: 'issued' as const }
+  },
 }))
 
 vi.mock('../../../postings/accounting-enabled', () => ({
@@ -91,12 +125,20 @@ vi.mock('../../../postings/post-entry', () => ({
   LEDGER_CURRENCY: 'USD',
   postEntry: async (
     _db: unknown,
-    options: { entry: { periodKey: string; txnDate: string }; memo?: string }
+    options: {
+      entry: {
+        periodKey: string
+        txnDate: string
+        lines: Array<{ direction: string; amount: number }>
+      }
+      memo?: string
+    }
   ) => {
     h.postCalls.push({
       periodKey: options.entry.periodKey,
       txnDate: options.entry.txnDate,
       memo: options.memo,
+      lines: options.entry.lines,
     })
     return h.post
   },
@@ -164,6 +206,7 @@ const REQUEST = {
   actorUserId: 'usr_1',
   range: { from: '2026-01-01', to: '2026-02-01' },
   grouping: 'month',
+  issueDrafts: false,
 } as const
 
 beforeEach(() => {
@@ -186,7 +229,25 @@ beforeEach(() => {
   h.isAccountingEnabled.mockResolvedValue(true)
   h.readMemoCalls = 0
   h.readSettingsCalls = 0
+  h.issues = []
+  h.issueThrowsFor = new Set()
 })
+
+/** What one posted entry debits in total, integer minor units. */
+function debits(call: number): number {
+  return (h.postCalls[call]?.lines ?? [])
+    .filter((line) => line.direction === 'debit')
+    .reduce((total, line) => total + line.amount, 0)
+}
+
+/** An empty summary, as every "nothing happened" assertion spells it. */
+const EMPTY_SUMMARY = {
+  posted: [],
+  skipped: [],
+  failed: [],
+  issued: { count: 0, failed: [] },
+  exclusions: [],
+}
 
 // task 17 §3: checked ONCE per org, before the settings read and the netting
 // read - this run has no use for either when the org has never turned
@@ -197,7 +258,7 @@ describe('accounting not enabled', () => {
 
     const summary = await runCreditMemoPosting(stubDb(), REQUEST)
 
-    expect(summary).toEqual({ posted: [], skipped: [], failed: [], exclusions: [] })
+    expect(summary).toEqual(EMPTY_SUMMARY)
     expect(h.readSettingsCalls).toBe(0)
     expect(h.readMemoCalls).toBe(0)
     expect(h.postCalls).toEqual([])
@@ -267,7 +328,7 @@ describe('the refusals', () => {
 
     const summary = await runCreditMemoPosting(stubDb(), REQUEST)
 
-    expect(summary).toEqual({ posted: [], skipped: [], failed: [], exclusions: [] })
+    expect(summary).toEqual(EMPTY_SUMMARY)
     expect(h.postCalls).toEqual([])
   })
 })
@@ -368,6 +429,173 @@ describe('posting and stamping', () => {
         detail: 'draft',
       },
     ])
+  })
+})
+
+// 🛑 §7. Channel memos are INGESTED as `draft`, so without this the dialog
+// excludes the whole backlog and posts nothing.
+describe('bulk issuing', () => {
+  const ISSUING = { ...REQUEST, issueDrafts: true } as const
+
+  const drafts = [
+    memo({ creditMemoId: 'a', number: 'CM-0001', status: 'draft' }),
+    memo({ creditMemoId: 'b', number: 'CM-0002', status: 'draft', contactId: 'ct_2' }),
+    memo({ creditMemoId: 'c', number: 'CM-0003', status: 'draft', contactId: 'ct_3' }),
+  ]
+
+  // 🛑 THE property this whole feature exists for. Issuing each memo through
+  // the ordinary door would post 1,061 single-memo entries.
+  it('issues every draft in the group and then posts ONE entry for all of them', async () => {
+    h.memos = drafts
+
+    const summary = await runCreditMemoPosting(stubDb(), ISSUING)
+
+    expect(h.issues.map((issue) => issue.creditMemoId)).toEqual(['a', 'b', 'c'])
+    expect(h.postCalls).toHaveLength(1)
+    expect(summary.posted).toEqual([
+      { groupKey: '2026-01', postingId: 'gl_1', docNumber: 'AUXX-CRM-202601', memos: 3 },
+    ])
+  })
+
+  // ⚠️ No posting id exists at issue time, so the memo is stamped afterwards
+  // with the GROUP's posting - never inside `issueCreditMemo`.
+  it('issues with post: false, and stamps the batch posting id afterwards', async () => {
+    h.memos = drafts
+
+    await runCreditMemoPosting(stubDb(), ISSUING)
+
+    expect(h.issues.every((issue) => issue.post === false)).toBe(true)
+    expect(h.stamps.map((stamp) => stamp.creditMemoId)).toEqual(['a', 'b', 'c'])
+    expect(h.stamps[0]?.values).toEqual([{ fieldId: 'credit_memo_gl_posting', value: 'gl_1' }])
+  })
+
+  it('counts what actually flipped', async () => {
+    h.memos = [...drafts, memo({ creditMemoId: 'd', number: 'CM-0004', status: 'issued' })]
+
+    const summary = await runCreditMemoPosting(stubDb(), ISSUING)
+
+    expect(summary.issued).toEqual({ count: 3, failed: [] })
+    expect(h.issues.map((issue) => issue.creditMemoId)).toEqual(['a', 'b', 'c'])
+  })
+
+  // 🛑 The memo's own refund date, so a January backlog issued in September
+  // stays in January instead of being dated by the clock.
+  it('pins each memo to its own issue date and groups it by that date', async () => {
+    h.memos = [memo({ creditMemoId: 'a', number: 'CM-0001', status: 'draft' })]
+
+    await runCreditMemoPosting(stubDb(), ISSUING)
+
+    expect(h.issues[0]?.issuedAt).toBe('2026-01-14')
+    expect(h.postCalls[0]?.periodKey).toBe('2026-01')
+    expect(h.postCalls[0]?.txnDate).toBe('2026-01-14')
+  })
+
+  it('attributes the issues of an actorless run to the organization system user', async () => {
+    h.memos = drafts
+
+    await runCreditMemoPosting(stubDb(), { ...ISSUING, actorUserId: null })
+
+    expect(h.issues.every((issue) => issue.userId === 'usr_system')).toBe(true)
+  })
+
+  it('issues nothing at all when the flag is off, and excludes the drafts', async () => {
+    h.memos = drafts
+
+    const summary = await runCreditMemoPosting(stubDb(), REQUEST)
+
+    expect(h.issues).toEqual([])
+    expect(h.postCalls).toEqual([])
+    expect(summary.issued).toEqual({ count: 0, failed: [] })
+    expect(summary.exclusions.map((e) => e.reason)).toEqual([
+      'not-issued',
+      'not-issued',
+      'not-issued',
+    ])
+  })
+
+  // 🛑 A void memo is never resurrected.
+  it('never issues a void memo', async () => {
+    h.memos = [memo({ creditMemoId: 'v', number: 'CM-0009', status: 'void' })]
+
+    const summary = await runCreditMemoPosting(stubDb(), ISSUING)
+
+    expect(h.issues).toEqual([])
+    expect(h.postCalls).toEqual([])
+    expect(summary.exclusions[0]).toMatchObject({ reason: 'not-issued', detail: 'void' })
+  })
+
+  it('writes nothing on a preview, however many drafts it plans', async () => {
+    h.memos = drafts
+
+    const preview = (await previewCreditMemoPosting(stubDb(), ISSUING))._unsafeUnwrap()
+
+    expect(preview.plan.footer.memos).toBe(3)
+    expect(preview.plan.footer.drafts).toBe(3)
+    expect(h.issues).toEqual([])
+    expect(h.postCalls).toEqual([])
+    expect(h.stamps).toEqual([])
+  })
+
+  describe('a member that refuses to issue', () => {
+    // 🛑 It must not be summarised into an entry that says it was credited, and
+    // the group's totals have to describe the members that are left.
+    it('drops out, and the rest post with corrected totals', async () => {
+      h.memos = drafts
+      h.issueThrowsFor = new Set(['b'])
+
+      const summary = await runCreditMemoPosting(stubDb(), ISSUING)
+
+      expect(summary.issued.count).toBe(2)
+      expect(summary.issued.failed).toEqual([
+        { creditMemoId: 'b', number: 'CM-0002', reason: 'credit memo b has no lines' },
+      ])
+      expect(summary.posted).toEqual([
+        { groupKey: '2026-01', postingId: 'gl_1', docNumber: 'AUXX-CRM-202601', memos: 2 },
+      ])
+      // The dropped memo is neither stamped nor summarised.
+      expect(h.stamps.map((stamp) => stamp.creditMemoId)).toEqual(['a', 'c'])
+      // 🛑 $200, not $300: an entry that still claimed the dropped memo's $100
+      // would credit a refund that never happened, and it would balance.
+      expect(debits(0)).toBe(20_000)
+    })
+
+    it('is not an entry-level failure: the group still posts', async () => {
+      h.memos = drafts
+      h.issueThrowsFor = new Set(['a'])
+
+      const summary = await runCreditMemoPosting(stubDb(), ISSUING)
+
+      expect(summary.failed).toEqual([])
+      expect(h.postCalls).toHaveLength(1)
+    })
+
+    // 🛑 Nothing to post, and nothing went wrong with the ledger.
+    it('yields a SKIP, not a failure, when every member refuses', async () => {
+      h.memos = drafts
+      h.issueThrowsFor = new Set(['a', 'b', 'c'])
+
+      const summary = await runCreditMemoPosting(stubDb(), ISSUING)
+
+      expect(h.postCalls).toEqual([])
+      expect(summary.posted).toEqual([])
+      expect(summary.failed).toEqual([])
+      expect(summary.skipped[0]).toMatchObject({ groupKey: '2026-01', status: 'no_members' })
+      expect(summary.issued).toMatchObject({ count: 0 })
+      expect(summary.issued.failed).toHaveLength(3)
+    })
+
+    it('loses only its own group, never the run', async () => {
+      h.memos = [
+        memo({ creditMemoId: 'a', number: 'CM-0001', status: 'draft', issuedAt: '2026-01-14' }),
+        memo({ creditMemoId: 'b', number: 'CM-0002', status: 'draft', issuedAt: '2026-01-15' }),
+      ]
+      h.issueThrowsFor = new Set(['a'])
+
+      const summary = await runCreditMemoPosting(stubDb(), { ...ISSUING, grouping: 'day' })
+
+      expect(summary.posted.map((row) => row.groupKey)).toEqual(['2026-01-15'])
+      expect(summary.skipped[0]?.groupKey).toBe('2026-01-14')
+    })
   })
 })
 

--- a/packages/lib/src/money/credit-memo-posting/plan.ts
+++ b/packages/lib/src/money/credit-memo-posting/plan.ts
@@ -20,9 +20,10 @@
  * A memo is excluded ONCE, for the FIRST reason that applies, and the reasons
  * are ordered by which remedy the person has to reach for:
  *
- * 1. `not-issued` - a `draft` or `void` memo posts nothing, ever. Issue it or
- *    leave it. It is an exclusion rather than a silent filter so the footer's
- *    "1,047 of 1,061" has a reason attached to the gap (§7).
+ * 1. `not-issued` - a `void` memo posts nothing, ever, and so does a `draft`
+ *    unless {@link CreditMemoPostingPlanInput.issueDrafts} is set. It is an
+ *    exclusion rather than a silent filter so the footer's "1,047 of 1,061" has
+ *    a reason attached to the gap (§7).
  * 2. `before-cutoff` - covered by the opening balance; nothing to do, ever.
  * 3. `locked-period` - reopen the month, or leave it.
  * 4. `foreign-currency` - the books are kept in one currency.
@@ -30,13 +31,30 @@
  *    `accounts_receivable`-subtype line carrying no counterparty BEFORE the
  *    push, so inside a period entry one such memo would fail the export of
  *    every memo in the month (`types.ts`).
- * 6. `zero-value` - a memo that credits nothing, or whose amounts the shared
+ * 6. `missing-number` - fix the record, and only ever for a memo this run would
+ *    ISSUE. See {@link CreditMemoPostingPlanInput.issueDrafts} below.
+ * 7. `zero-value` - a memo that credits nothing, or whose amounts the shared
  *    arithmetic refuses to compute.
  *
  * Reporting a memo as `zero-value` when it is really in a closed period sends
  * somebody to look at the document instead of at the period, so the order of
  * these `if`s IS the contract. Every row carries the value that proves its
  * reason in `detail`, which is 44 §7.2b's rule.
+ *
+ * ## 🛑 A planned draft must pass the refusals `resolveIssue` would apply
+ *
+ * With `issueDrafts`, `run.ts` issues each `draft` member through
+ * `issueCreditMemo(..., { post: false })` BEFORE it builds the group's entry, so
+ * a draft the single-memo door would refuse is not a member this planner may
+ * promise. The three refusals `resolveIssue` makes that the netting read already
+ * carries the data for are checked here, in its own order (contact, then number,
+ * then a non-positive total - the last one is `computeCreditMemoAmounts`'s and
+ * therefore already applies to every memo): a `missing-number` draft is refused
+ * because the SINGLE-memo entry keys its document number on the memo number, and
+ * finding that out one memo at a time during the run would drop it from a group
+ * whose entry had already been dimensioned. The refusals this planner CANNOT
+ * make - an empty line set, a channel memo with no refund date - are the run's,
+ * and land in `CreditMemoPostingRunSummary.issued.failed`.
  *
  * 🛑 **`gateway-ambiguous` and `test-gateway` deliberately do not exist here**
  * (§7, and `types.ts` says it at length). A sale can be refused and re-run; a
@@ -121,10 +139,16 @@ export function planCreditMemoPosting(
   const byGroupKey = new Map<string, PlannedCreditMemo[]>()
 
   for (const memo of [...input.memos].sort(compareMemos)) {
-    // 🛑 FIRST. A draft or a void memo is not a document the ledger has any
-    // opinion about, so reporting it as `before-cutoff` or `zero-value` would
-    // send somebody to the period or to the lines when the answer is "issue it".
-    if (memo.status !== 'issued' && memo.status !== 'settled') {
+    // Whether THIS run would flip the memo to `issued` on its way to the entry.
+    // ⚠️ `draft` and nothing else: a `void` memo is never resurrected, and an
+    // option id nobody has taught this module about is not a draft either.
+    const issuing = input.issueDrafts && memo.status === 'draft'
+
+    // 🛑 FIRST. A memo the run will not issue and that is not already issued is
+    // not a document the ledger has any opinion about, so reporting it as
+    // `before-cutoff` or `zero-value` would send somebody to the period or to
+    // the lines when the answer is "issue it".
+    if (!issuing && memo.status !== 'issued' && memo.status !== 'settled') {
       exclusions.push(exclude(memo, 'not-issued', memo.status))
       continue
     }
@@ -147,6 +171,15 @@ export function planCreditMemoPosting(
     }
     if (!memo.contactId) {
       exclusions.push(exclude(memo, 'missing-contact', 'credit_memo_contact is empty'))
+      continue
+    }
+    // 🛑 Only for a memo this run would ISSUE, and that asymmetry is deliberate.
+    // A BATCH entry keys its document number on the period, so an already-issued
+    // memo with an unallocated number posts perfectly well inside one; the
+    // SINGLE-memo entry `resolveIssue` refuses without a number does not, and
+    // `run.ts` issues every draft through that door before it builds the group.
+    if (issuing && memo.number.trim().length === 0) {
+      exclusions.push(exclude(memo, 'missing-number', 'credit_memo_number is empty'))
       continue
     }
 
@@ -180,12 +213,16 @@ export function planCreditMemoPosting(
 
   const groups = [...byGroupKey.entries()]
     .sort(([a], [b]) => compareStrings(a, b))
-    .map(([groupKey, memos]) => toGroup(groupKey, memos))
+    .map(([groupKey, memos]) => collapseCreditMemoGroup(groupKey, memos))
 
   const contacts = new Set<string>()
+  let drafts = 0
   for (const group of groups) {
     for (const memo of group.memos) {
       if (memo.contactId) contacts.add(memo.contactId)
+      // Counted off the PLANNED members, never off the input: a draft the plan
+      // excluded is not a document state this run changes.
+      if (memo.status === 'draft') drafts += 1
     }
   }
 
@@ -202,6 +239,7 @@ export function planCreditMemoPosting(
       // `Σ group.contactCount`: that one counts the A/R lines an entry will
       // carry, and a fully refunded channel memo produces none.
       contacts: contacts.size,
+      drafts,
       excluded: exclusions.length,
       totalMinor: groups.reduce((total, group) => total + group.totals.totalMinor, 0),
     },
@@ -222,8 +260,21 @@ export function groupKeyFor(issuedAt: string, grouping: CreditMemoPostingGroupin
   return issuedAt
 }
 
-/** Collapse one bucket of memos into the posting it becomes. */
-function toGroup(groupKey: string, memos: PlannedCreditMemo[]): CreditMemoPostingGroup {
+/**
+ * Collapse one bucket of memos into the posting it becomes.
+ *
+ * 🛑 Exported for `run.ts`, which RE-collapses a group after a `draft` member
+ * failed to issue and had to be dropped from it. Every number an entry carries -
+ * the totals, the A/R line count, the transaction date - is derived here from
+ * the members alone, so rebuilding the group through this same function is what
+ * keeps a dropped member out of an entry that would otherwise still claim its
+ * amounts. A second copy of this arithmetic in the runner would be free to
+ * disagree with the plan the dialog showed.
+ */
+export function collapseCreditMemoGroup(
+  groupKey: string,
+  memos: PlannedCreditMemo[]
+): CreditMemoPostingGroup {
   let subtotalMinor = 0
   let taxTotalMinor = 0
   let totalMinor = 0

--- a/packages/lib/src/money/credit-memo-posting/reads.ts
+++ b/packages/lib/src/money/credit-memo-posting/reads.ts
@@ -617,6 +617,11 @@ export async function countUnpostedCreditMemos(
       const plan = planCreditMemoPosting({
         memos: memos.value,
         grouping: 'day',
+        // ⚠️ The close ISSUES nothing, so a draft is `not-issued` here whatever
+        // the dialog is set to. It is deliberately not close-blocking either
+        // (`CLOSE_BLOCKING_EXCLUSION_REASONS`): `countUnissuedChannelCreditMemos`
+        // already refuses a close over an unissued channel draft.
+        issueDrafts: false,
         cutoffPeriod: settings.value.cutoffPeriod,
         lockedThroughMonth: settings.value.lockedThroughMonth,
         ledgerCurrency: settings.value.ledgerCurrency,

--- a/packages/lib/src/money/credit-memo-posting/run.ts
+++ b/packages/lib/src/money/credit-memo-posting/run.ts
@@ -11,6 +11,20 @@
  * again - and deliberately so, because the two doors are one dialog and one
  * worker away from being the same feature (§5).
  *
+ * ## 🛑 It ISSUES the drafts, and issue-then-post is not atomic either
+ *
+ * Channel memos are ingested as `draft`, so with `issueDrafts` every `draft`
+ * member of a group is flipped through `issueCreditMemo(..., { post: false })`
+ * BEFORE the group's entry is built. `post: false` is what makes that a batch
+ * rather than 1,061 single-memo entries, and it is why no stamp is written
+ * there: the memo is stamped below with the GROUP's posting id.
+ *
+ * A memo issued here that the group then fails to post is an ordinary unposted
+ * memo - the next netting read offers it again, the next run posts it, and
+ * nothing is double-booked, because a stamp is the only thing that says posted.
+ * That is the acceptable half of the non-atomicity; the unstamped half below is
+ * the one that needs a person.
+ *
  * ## 🛑 It is NOT atomic, and the summary is what says so
  *
  * A group is `postEntry` followed by N stamps, and those are separate
@@ -36,10 +50,10 @@
  *
  * ## 🛑 Never throws
  *
- * Three layers: every STAMP inside its own `try` so one memo's lock contention
- * does not lose the rest of the group; every GROUP inside its own `try` so one
- * refused build does not lose the run; and the whole body inside one final `try`
- * so a caller always gets a summary.
+ * Four layers: every ISSUE and every STAMP inside its own `try` so one memo's
+ * refusal or lock contention does not lose the rest of the group; every GROUP
+ * inside its own `try` so one refused build does not lose the run; and the whole
+ * body inside one final `try` so a caller always gets a summary.
  *
  * No permission checks. The router asserts `ledgerPost`
  * (`docs/lib-module-guide.md` §6).
@@ -63,9 +77,10 @@ import {
   OPENING_BASELINE_SETTING_KEYS,
 } from '../../postings/setup-readiness'
 import { getOrganizationSetting } from '../../settings/settings-service'
+import { issueCreditMemo } from '../credit-memos/writes'
 import { countUnpostedShipments } from '../fulfillment-posting/reads'
 import { guard } from './guard'
-import { planCreditMemoPosting } from './plan'
+import { collapseCreditMemoGroup, planCreditMemoPosting } from './plan'
 import {
   readCreditMemoPostingSettings,
   readCreditMemoSettlementAccounts,
@@ -111,10 +126,17 @@ export interface CreditMemoPostingPreview {
   refusal: string | null
 }
 
-/** What a preview is asked for: no actor, because nothing is written. */
+/**
+ * What a preview is asked for: no actor, because nothing is written.
+ *
+ * ⚠️ `issueDrafts` belongs here even though a preview issues nothing: it decides
+ * whether a `draft` is a PLANNED member or a `not-issued` exclusion, so a
+ * preview that guessed it would show a different plan from the run it precedes.
+ * `footer.drafts` is how the dialog says how many memos the button will issue.
+ */
 export type CreditMemoPostingPreviewInput = Pick<
   CreditMemoPostingRequest,
-  'organizationId' | 'range' | 'grouping'
+  'organizationId' | 'range' | 'grouping' | 'issueDrafts'
 >
 
 /**
@@ -122,6 +144,10 @@ export type CreditMemoPostingPreviewInput = Pick<
  *
  * Runs the same reads and the same pure plan {@link runCreditMemoPosting} runs,
  * so what the dialog shows is what the run would freeze.
+ *
+ * 🛑 Writes NOTHING, `issueDrafts` or not. It plans the drafts as members and
+ * counts them in `footer.drafts`; flipping them is {@link runCreditMemoPosting}'s
+ * alone.
  */
 export async function previewCreditMemoPosting(
   db: Database,
@@ -154,6 +180,7 @@ export async function runCreditMemoPosting(
     posted: [],
     skipped: [],
     failed: [],
+    issued: { count: 0, failed: [] },
     exclusions: [],
   }
 
@@ -223,6 +250,8 @@ export async function runCreditMemoPosting(
       posted: summary.posted.length,
       skipped: summary.skipped.length,
       failed: summary.failed.length,
+      issued: summary.issued.count,
+      unissuable: summary.issued.failed.length,
       excluded: summary.exclusions.length,
     })
     return summary
@@ -287,6 +316,7 @@ async function prepare(db: Database, request: CreditMemoPostingPreviewInput): Pr
     settlementAccounts: accountsResult.value,
     unpostedShipments,
     grouping,
+    issueDrafts: request.issueDrafts,
     cutoffPeriod: settings.cutoffPeriod,
     lockedThroughMonth: settings.lockedThroughMonth,
     ledgerCurrency: settings.ledgerCurrency,
@@ -438,7 +468,85 @@ async function creditMemoStampWriter(
   }
 }
 
-/** Build, post and stamp one group. Throws only what the group layer records. */
+/**
+ * Flip every `draft` member of a group to `issued`, WITHOUT posting a thing.
+ *
+ * 🛑 `{ post: false }` is the whole point (brief 25 §7, `credit-memos/writes.ts`).
+ * Issuing through the ordinary door with the ledger attached would mint one
+ * single-memo entry per memo - 1,061 of them on DemoOrg1's backlog - which is
+ * exactly what the batch poster exists to prevent. No stamp is written there
+ * either; {@link executeGroup} stamps the survivors with the GROUP's posting id.
+ *
+ * 🛑 **One memo's refusal must not lose the group**, so every issue sits in its
+ * own `try` - the same discipline the stamps below have. A memo that refuses is
+ * DROPPED from the group rather than left in it: a member that is still a draft
+ * would otherwise be summarised into an entry that says it was credited, and
+ * then stamped as posted. The group is re-collapsed through
+ * {@link collapseCreditMemoGroup} so its totals, its A/R line count and its
+ * transaction date describe the members that are actually left.
+ *
+ * ⚠️ **Issue-then-post is NOT atomic, and that is acceptable.** A memo issued
+ * here whose group then fails to post is an ordinary unposted memo: it carries
+ * no stamp, so the next netting read offers it again and the next run posts it.
+ * Nothing is double-booked, because the stamp is the only thing that says
+ * posted. Compare the stamp failure below, which is the outcome that does need a
+ * person.
+ *
+ * @returns the group as it should now be built, or the same object untouched.
+ */
+async function issueGroupDrafts(
+  db: Database,
+  request: CreditMemoPostingRequest,
+  context: { group: CreditMemoPostingGroup; actorUserId: string },
+  summary: CreditMemoPostingRunSummary
+): Promise<CreditMemoPostingGroup> {
+  const { organizationId } = request
+  const { group, actorUserId } = context
+  if (!request.issueDrafts) return group
+
+  const dropped = new Set<string>()
+  for (const memo of group.memos) {
+    if (memo.status !== 'draft') continue
+    try {
+      await issueCreditMemo(
+        db,
+        {
+          organizationId,
+          userId: actorUserId,
+          creditMemoInstanceId: memo.creditMemoId,
+          // 🛑 The memo's OWN date, pinned rather than defaulted. It is the date
+          // the plan grouped on, so a January backlog issued in September stays
+          // in January instead of being dated by the clock.
+          issuedAt: memo.issuedAt,
+        },
+        { post: false }
+      )
+      summary.issued.count += 1
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      dropped.add(memo.creditMemoId)
+      summary.issued.failed.push({
+        creditMemoId: memo.creditMemoId,
+        number: memo.number,
+        reason,
+      })
+      logger.error('A draft credit memo could not be issued; dropping it from its group', {
+        organizationId,
+        groupKey: group.groupKey,
+        creditMemoId: memo.creditMemoId,
+        reason,
+      })
+    }
+  }
+
+  if (dropped.size === 0) return group
+  return collapseCreditMemoGroup(
+    group.groupKey,
+    group.memos.filter((memo) => !dropped.has(memo.creditMemoId))
+  )
+}
+
+/** Issue, build, post and stamp one group. Throws only what the group layer records. */
 async function executeGroup(
   db: Database,
   request: CreditMemoPostingRequest,
@@ -451,7 +559,24 @@ async function executeGroup(
   summary: CreditMemoPostingRunSummary
 ): Promise<void> {
   const { organizationId } = request
-  const { group, ledgerCurrency, actorUserId, stamp } = context
+  const { ledgerCurrency, actorUserId, stamp } = context
+
+  // 🛑 BEFORE the attempt count and the build, so the entry is dimensioned on
+  // the members that actually issued.
+  const group = await issueGroupDrafts(db, request, context, summary)
+  if (group.memos.length === 0) {
+    // Every member refused. Nothing was posted and nothing needs to be: the
+    // refusals are already in `summary.issued.failed`, which is where a person
+    // looks, and a group with no members is a skip rather than a failure.
+    summary.skipped.push({
+      groupKey: group.groupKey,
+      status: 'no_members',
+      reason:
+        `Every credit memo in ${group.groupKey} failed to issue, so there was nothing to post. ` +
+        'See the issue failures for the reason on each one.',
+    })
+    return
+  }
 
   // 🛑 The attempt is counted BEFORE the build, off the ledger itself. A month
   // key claims the month once, and a memo issued late into an already-posted

--- a/packages/lib/src/money/credit-memo-posting/types.ts
+++ b/packages/lib/src/money/credit-memo-posting/types.ts
@@ -46,12 +46,14 @@ export type CreditMemoPostingExclusionReason =
   | BatchPostingExclusionReason
   | 'not-issued'
   | 'missing-contact'
+  | 'missing-number'
 
 export const CREDIT_MEMO_POSTING_EXCLUSION_REASONS: readonly CreditMemoPostingExclusionReason[] = [
   'before-cutoff',
   'locked-period',
   'foreign-currency',
   'missing-contact',
+  'missing-number',
   'not-issued',
   'zero-value',
 ]
@@ -188,6 +190,26 @@ export interface CreditMemoPostingPlanInput {
   ledgerCurrency: string
   /** `accounting.bookTimeZone`. Carried, never applied: `issuedAt` is already a calendar day. */
   timeZone: string
+  /**
+   * Issue the `draft` memos in the range as part of the run, instead of
+   * excluding them as `not-issued`.
+   *
+   * 🛑 **Without this the dialog cannot do the job it exists for.** Channel
+   * memos are ingested as `draft` - all 1,061 of DemoOrg1's are - so a planner
+   * that treats `draft` as an exclusion excludes the entire backlog and posts
+   * nothing. §7's `not-issued` was written as though somebody had already
+   * issued them one at a time, and nothing bulk-issues.
+   *
+   * ⚠️ Only `draft` is affected. A `void` memo is still `not-issued` and is
+   * never resurrected.
+   *
+   * The grouping is safe under this flag because a channel memo keeps its OWN
+   * refund date: `resolveIssue` takes `input.issuedAt ?? memo.issuedAt` and
+   * REFUSES a channel memo that carries neither, rather than dating it with the
+   * clock. So issuing a January backlog in September still groups it into
+   * January.
+   */
+  issueDrafts: boolean
 }
 
 /** What the dialog renders and what the run executes. */
@@ -199,6 +221,14 @@ export interface CreditMemoPostingPlan {
     postings: number
     memos: number
     contacts: number
+    /**
+     * How many of `memos` are still `draft` and will be ISSUED by this run.
+     *
+     * Always present so the footer can say so before anybody presses the
+     * button: issuing changes document state for every one of them, and on the
+     * opening backlog it is the whole count.
+     */
+    drafts: number
     excluded: number
     totalMinor: number
   }
@@ -218,6 +248,8 @@ export interface CreditMemoPostingRequest {
   /** Half-open on `issuedAt`: `from <= issuedAt < to`, both `YYYY-MM-DD`. */
   range: { from: string; to: string }
   grouping: CreditMemoPostingGrouping
+  /** See {@link CreditMemoPostingPlanInput.issueDrafts}. */
+  issueDrafts: boolean
   memo?: string
 }
 
@@ -228,6 +260,15 @@ export interface CreditMemoPostingRunSummary {
   skipped: Array<{ groupKey: string; status: string; reason: string }>
   /** Groups that wrote nothing because something threw. Never re-thrown. */
   failed: Array<{ groupKey: string; reason: string }>
+  /**
+   * Memos this run flipped from `draft` to `issued`, and the ones it could not.
+   *
+   * Separate from `posted` because they are different facts with different
+   * remedies: a memo can be issued and then fail to post (it is then a normal
+   * unposted memo the next run picks up), and a draft that REFUSES to issue is
+   * a document problem somebody has to open.
+   */
+  issued: { count: number; failed: Array<{ creditMemoId: string; number: string; reason: string }> }
   exclusions: CreditMemoPostingExclusion[]
 }
 

--- a/packages/lib/src/money/credit-memos/__tests__/writes.test.ts
+++ b/packages/lib/src/money/credit-memos/__tests__/writes.test.ts
@@ -261,6 +261,105 @@ describe('accounting enabled', () => {
   })
 })
 
+// ─── Brief 25 §7: issuing WITHOUT posting, for the batch poster ─────────────
+//
+// 🛑 Channel memos are ingested as `draft`, so the bulk poster has to bulk
+// issue - and issuing 1,061 of them through the ledger would mint 1,061
+// single-memo entries, which is the exact thing batching exists to prevent.
+describe('post: false', () => {
+  const issue = (options?: { post?: boolean }) =>
+    issueCreditMemo(
+      db,
+      { organizationId: ORG, userId: USER, creditMemoInstanceId: MEMO_ID },
+      options
+    )
+
+  it('builds nothing, locks nothing and posts nothing, with accounting ENABLED', async () => {
+    h.isAccountingEnabled.mockResolvedValue(true)
+
+    const result = await issue({ post: false })
+
+    expect(h.buildCreditMemoEntry).not.toHaveBeenCalled()
+    expect(h.resolvePeriodLock).not.toHaveBeenCalled()
+    expect(h.postEntry).not.toHaveBeenCalled()
+    // The read that exists only to decide the builder's `reverseRevenue`.
+    expect(h.orderHadFulfillmentBefore).not.toHaveBeenCalled()
+    expect(result.postingId).toBeNull()
+    expect(result.docNumber).toBeNull()
+  })
+
+  it('does everything else, in the same order', async () => {
+    await issue({ post: false })
+
+    expect(h.recomputeTotals).toHaveBeenCalledTimes(1)
+    const write = h.setValuesForEntity.mock.calls[0]![0]
+    expect(write.values).toContainEqual({ fieldId: 'credit_memo_status', value: 'issued' })
+    expect(h.settleCreditMemo).toHaveBeenCalledTimes(1)
+  })
+
+  // ⚠️ There is no posting id to stamp. The batch run stamps the memo with the
+  // GROUP's posting id afterwards, and stamping anything here would claim the
+  // memo is posted when the entry has not been built yet.
+  it('writes NO stamp', async () => {
+    await issue({ post: false })
+
+    const write = h.setValuesForEntity.mock.calls[0]![0]
+    expect(
+      (write.values as Array<{ fieldId: string }>).some(
+        (v) => v.fieldId === 'credit_memo_gl_posting'
+      )
+    ).toBe(false)
+  })
+
+  it('writes the resolved issue date when it differs from the stored one', async () => {
+    h.memo.issuedAt = null
+
+    await issueCreditMemo(
+      db,
+      {
+        organizationId: ORG,
+        userId: USER,
+        creditMemoInstanceId: MEMO_ID,
+        issuedAt: '2026-01-14',
+      },
+      { post: false }
+    )
+
+    const write = h.setValuesForEntity.mock.calls[0]![0]
+    expect(write.values).toContainEqual({
+      fieldId: 'credit_memo_issued_at',
+      value: '2026-01-14T12:00:00.000Z',
+    })
+  })
+
+  it('applies the same refusals: a memo with no number does not issue', async () => {
+    h.memo.number = ''
+
+    await expect(issue({ post: false })).rejects.toThrow('has no number yet')
+    expect(h.setValuesForEntity).not.toHaveBeenCalled()
+  })
+
+  it('skips the accounting-enabled read entirely, because nothing can use it', async () => {
+    await issue({ post: false })
+
+    expect(h.isAccountingEnabled).not.toHaveBeenCalled()
+  })
+
+  // Every existing call site passes no options at all.
+  it('defaults to posting', async () => {
+    const result = await issue()
+
+    expect(h.postEntry).toHaveBeenCalledTimes(1)
+    expect(result.postingId).toBe('gl_1')
+  })
+
+  it('posts when asked explicitly', async () => {
+    await issue({ post: true })
+
+    expect(h.postEntry).toHaveBeenCalledTimes(1)
+  })
+})
+
 // ─── Brief 25 §2.1: a batched member is not voided in place ─────────────────
 
 describe('voidCreditMemo, memo inside a batched entry', () => {

--- a/packages/lib/src/money/credit-memos/writes.ts
+++ b/packages/lib/src/money/credit-memos/writes.ts
@@ -627,12 +627,32 @@ export async function previewIssueCreditMemo(
  * reason: a locked period, an unmapped role. Nothing has been written at that
  * point, so the memo stays a draft. The claim is keyed on the memo number, so a
  * retry converges to `already_posted` and still flips the status.
+ *
+ * @param options.post Post the issue entry. Defaults to `true`, which is every
+ *   door a person presses.
+ *
+ *   🛑 **`false` is the BULK door** (`money/credit-memo-posting/run.ts`, brief
+ *   25 §7). Channel memos are INGESTED as `draft` - all 1,061 of DemoOrg1's -
+ *   so bulk posting has to bulk issue, and issuing through here with the ledger
+ *   attached would mint 1,061 single-memo entries, which is the exact thing the
+ *   batch poster exists to prevent. With `false` the entry is neither built nor
+ *   posted and the period lock is never resolved; everything that makes the
+ *   memo a document still happens, in the same order - the totals, the status,
+ *   the date, the settlement. The accounting-disabled branch below is the
+ *   existing proof that this shape works.
+ *
+ *   ⚠️ There is no posting id in that case, so **no stamp is written**. The
+ *   batch run stamps the memo with its GROUP's posting id afterwards, and a
+ *   memo issued here that the run then fails to post is an ordinary unposted
+ *   memo the next netting read picks up.
  */
 export async function issueCreditMemo(
   db: Database,
-  input: IssueCreditMemoInput
+  input: IssueCreditMemoInput,
+  options: { post?: boolean } = {}
 ): Promise<IssueCreditMemoResult> {
   const { organizationId, userId, creditMemoInstanceId } = input
+  const shouldPost = options.post ?? true
 
   // The mirrors first, so what is stored is what posts. `resolveIssue` sums the
   // lines itself, and the builder asserts `total = subtotal + tax`, so a stale
@@ -650,7 +670,11 @@ export async function issueCreditMemo(
   // `resolveIssue` so it skips the read and the build that exist only to post
   // an entry (task 17 section 3) - a credit memo issues on an org that has
   // never turned accounting on exactly as it would on one that has.
-  const accountingEnabled = await isAccountingEnabled(db, organizationId)
+  //
+  // A caller that asked not to post takes the same road and does not even make
+  // the settings read: nothing downstream of it can change the answer, and over
+  // a 1,061-memo backlog it is 1,061 identical reads.
+  const accountingEnabled = shouldPost && (await isAccountingEnabled(db, organizationId))
   const { memo, issuedAt, built } = await resolveIssue(db, input, { buildEntry: accountingEnabled })
 
   let post: PostResult
@@ -664,6 +688,9 @@ export async function issueCreditMemo(
       memo: `Credit memo ${memo.number} issued`,
     })
   } else {
+    // Nothing was asked of the ledger, either because the org keeps no books or
+    // because the caller is posting the entry itself. Both carry no posting id,
+    // so neither writes a stamp below.
     post = { status: 'not_enabled' }
   }
   if (!isExpectedPostOutcome(post)) {


### PR DESCRIPTION
Follow-up to #2140, fixing the gap that made it useless for the job it was built for.

## The problem

Channel credit memos are **ingested as `draft`**, so on DemoOrg1 all **1,061** of them are drafts. #2140's planner treated `draft` as a `not-issued` exclusion, which means the bulk dialog excluded the entire backlog and posted nothing.

Brief 25 §7 was written as though somebody had already issued them one at a time. Nobody has, and nothing bulk-issues: the only route today is `packages/lib/scripts/issue-channel-credit-memos.ts`, a script that takes ids on the command line and posts an entry per memo.

> MK: *"all the credit memos come in as draft. we want to issue them in the bulk dialog. that is the whole point so we can bulk issue them."*

## Issuing must not post

`issueCreditMemo` takes `options: { post?: boolean }`, defaulting to `true` so every existing call site is unchanged. With `false` it neither builds nor posts an entry and never resolves the period lock, but everything that makes the memo a document still happens in the same order: totals, status, date, settlement. The accounting-disabled branch was already exactly this shape.

It writes **no stamp** in that mode, because the batch run stamps the memo with its **group's** posting id afterwards. Without this, bulk issuing through the existing door would mint 1,061 single-memo entries, which is the precise thing the batch poster exists to prevent. A test asserts `postEntry` is called **once** for a whole group of drafts.

## The grouping survives it

The obvious fear: issuing a January backlog in September dates it September and collapses everything into one wrong month.

It does not. `resolveIssue` takes `input.issuedAt ?? memo.issuedAt` and, for a channel memo carrying neither, **refuses** rather than reaching for the clock ("the channel's own date is the accounting date, never ingest time and never today"). A test pins a January draft issued in September to `periodKey: '2026-01'`.

## Issue-then-post is deliberately not atomic

A memo issued but not posted is an ordinary unposted memo, which is exactly what the netting read looks for, so the next run picks it up.

A memo that **refuses** to issue is dropped from its group, because it must never be summarised into an entry claiming it was credited, and lands in `summary.issued.failed`. The group's totals, A/R line count and `txnDate` are recomputed by re-running the planner's own `collapseCreditMemoGroup`, so the runner holds no second copy of the arithmetic that could disagree with the plan the dialog showed. A test asserts the surviving entry debits 20,000 rather than 30,000 after a drop.

`void` is never resurrected, and an unknown status still fails closed.

## New exclusion: `missing-number`

A draft with no number cannot be issued, because the single-memo entry keys its document number on it. Checked **only** for a memo this run would issue, since a batch entry keys on the period instead.

## The UI

A `<Switch>`, **off by default** because it writes to every draft in range. But an empty plan over a 1,061-draft backlog is indistinguishable from a broken feature, so:

- the **empty state** names the count and points at the switch
- the **footer** says how many memos will be issued, and renders inside the sticky bar so it cannot be scrolled away from Post
- the **result page** reports what was issued and lists what refused

The descriptor gains an options slot, a deliberate third axis beside columns and nouns. The frame holds the value and threads it through; it never reads into it. The fulfillment source declares none and is unchanged.

**No new permission:** `credit-memo.issue` is already `ledgerPost`, which is what `runCreditMemoPosting` asserts.

## Verification

| Gate | Result |
|---|---|
| `packages/lib` full suite | **18,497 passing, 0 failing** |
| `src/money` + `src/postings` | 2,579 passing |
| `apps/web` money UI | 121 passing |
| Typecheck ratchets | lib 27/27 baseline, web 0/0 |
| Biome | clean |

New tests: plan 36 → 49, run 28 → 40, credit-memos writes 22 → 30.

## Before merge

Unchanged from #2140: **migration 152 still has not been run anywhere**, and the January drive on DemoOrg1 is still owed. This PR is what makes that drive possible at all.

⚠️ The ordering trap matters more now that one action both issues and posts: `reverseRevenue` is decided from the shipment log, not from whether the fulfillment was posted, so **post the fulfillments first**. The dialog already carries that warning from §8, and it is the same warning the existing script's header gives.

https://claude.ai/code/session_01GuJ494QCELkP7ahfCza2JA
