### PR TITLE
refactor(web): put the builds backfill dialog on the shared batch frame

### DIFF
--- a/apps/web/src/components/manufacturing/builds/backfill-dialog.tsx
+++ b/apps/web/src/components/manufacturing/builds/backfill-dialog.tsx
@@ -28,6 +28,25 @@
 // The footer moving from 94 builds to 20 to 217 as the control changes IS the
 // feature (§7.2). It makes the tradeoff visible instead of baked into a constant
 // nobody can see.
+//
+// ## Its chrome is the shared batch-dialog chrome, and only its chrome
+//
+// This screen is the PROGENITOR of the shape `money/ui/batch-posting/` later
+// extracted a frame from (25 §5). It now wears that frame's shell, footer,
+// result page, note card, panel and enum row, so the three dialogs cannot drift
+// apart cosmetically any more.
+//
+// 🛑 **It is deliberately NOT a `BatchPostingSource`.** The descriptor is a
+// contract as much as a shape, and this dialog answers none of it: the range is
+// two `Date`s bounded by the build cutoff rather than a half-open day-key
+// window, the groupings are five and are filtered live by the *Create as*
+// answer beside them, the exclusions table counts quantities rather than listing
+// documents by date, the preflight and its consent checkbox have no analogue,
+// and the result reports builds raised and left in progress rather than entries
+// posted. Registering it would mean a pluggable range, a dynamic grouping list,
+// an overridable exclusions block, an overridable result page and a
+// source-supplied run predicate — five slots that exactly one source would ever
+// set, which is the failure mode 25 §5.2 names by hand.
 
 import { FieldType } from '@auxx/database/enums'
 import {
@@ -38,17 +57,24 @@ import {
 } from '@auxx/lib/builds/client'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
-import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
-import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { keepPreviousData } from '@tanstack/react-query'
 import { TriangleAlert } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { FieldPanelRow } from '~/components/global/forms/field-panel'
+import {
+  BatchDialogNote,
+  BatchDialogPanel,
+  BatchEnumRow,
+  BatchPlanSection,
+  BatchPlanSkeleton,
+} from '~/components/money/ui/batch-posting/batch-dialog-parts'
+import {
+  BatchDialogFooter,
+  BatchDialogResultPage,
+  BatchDialogShell,
+} from '~/components/money/ui/batch-posting/batch-dialog-shell'
 import { useResourceProperty } from '~/components/resources'
 import { BaseType } from '~/components/workflow/types'
 import { api } from '~/trpc/react'
@@ -64,7 +90,7 @@ const GROUPING_LABELS: Record<BackfillGrouping, string> = {
   range: 'One build for the whole range',
 }
 
-const STATUS_OPTIONS = [
+const STATUS_OPTIONS: readonly { value: BackfillStatus; label: string }[] = [
   { value: 'planned', label: 'Planned — work still to do' },
   { value: 'completed', label: 'Completed — this already happened' },
 ]
@@ -186,220 +212,160 @@ export function BackfillDialog({ open, onOpenChange, onCompleted }: BackfillDial
     !runBackfill.isPending
 
   return (
-    <Dialog open={open} onOpenChange={(next) => !runBackfill.isPending && onOpenChange(next)}>
-      <DialogContent size='content' position='tc' innerClassName='p-0'>
-        <DialogNav
-          title='Backfill builds'
-          description='Create builds for demand that has been ordered and never built.'
-          crumbs={[
-            {
-              label: 'Backfill builds',
-              onClick: page === 'result' ? () => setPage('plan') : undefined,
-            },
-            ...(page === 'result' ? [{ label: 'Result' }] : []),
-          ]}
-        />
+    <BatchDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      busy={runBackfill.isPending}
+      title='Backfill builds'
+      description='Create builds for demand that has been ordered and never built.'
+      page={page}
+      onBackToPlan={() => setPage('plan')}
+      planBody={
+        <>
+          <BatchDialogPanel resizeId='backfill-builds'>
+            <FieldPanelRow
+              title='From'
+              type={BaseType.DATE}
+              showIcon
+              isRequired
+              description='On the date the order was placed'>
+              <FieldInputAdapter
+                fieldType={FieldType.DATE}
+                value={from}
+                onChange={(val) => setFrom((val as string) ?? from)}
+                disabled={runBackfill.isPending}
+              />
+            </FieldPanelRow>
 
-        <DialogNavPages value={page}>
-          <DialogNavPage value='plan' size='3xl'>
-            <div className='flex flex-col'>
-              <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
-                <div className='flex flex-col gap-4 p-4'>
-                  <FieldPanel
-                    className='p-0'
-                    orientation='responsive'
-                    breakpoint='md'
-                    resizeId='backfill-builds'
-                    defaultLabelWidth={180}>
-                    <FieldPanelRow
-                      title='From'
-                      type={BaseType.DATE}
-                      showIcon
-                      isRequired
-                      description='On the date the order was placed'>
-                      <FieldInputAdapter
-                        fieldType={FieldType.DATE}
-                        value={from}
-                        onChange={(val) => setFrom((val as string) ?? from)}
-                        disabled={runBackfill.isPending}
-                      />
-                    </FieldPanelRow>
+            <FieldPanelRow
+              title='To'
+              type={BaseType.DATE}
+              showIcon
+              isRequired
+              description={
+                cutoff
+                  ? `Bounded by the build cutoff, ${formatDate(cutoff)}`
+                  : 'Exclusive — the day itself is not included'
+              }>
+              <FieldInputAdapter
+                fieldType={FieldType.DATE}
+                value={to}
+                onChange={(val) => setTo((val as string) ?? to)}
+                disabled={runBackfill.isPending}
+              />
+            </FieldPanelRow>
 
-                    <FieldPanelRow
-                      title='To'
-                      type={BaseType.DATE}
-                      showIcon
-                      isRequired
-                      description={
-                        cutoff
-                          ? `Bounded by the build cutoff, ${formatDate(cutoff)}`
-                          : 'Exclusive — the day itself is not included'
-                      }>
-                      <FieldInputAdapter
-                        fieldType={FieldType.DATE}
-                        value={to}
-                        onChange={(val) => setTo((val as string) ?? to)}
-                        disabled={runBackfill.isPending}
-                      />
-                    </FieldPanelRow>
-
-                    <FieldPanelRow
-                      title='Group into'
-                      type={BaseType.ENUM}
-                      showIcon
-                      isRequired
-                      description='How much demand one build covers'>
-                      <FieldInputAdapter
-                        fieldType={FieldType.SINGLE_SELECT}
-                        fieldOptions={{ options: groupingOptions }}
-                        value={grouping}
-                        onChange={(val) =>
-                          setGrouping(((val as string[])[0] as BackfillGrouping) ?? 'month')
-                        }
-                        disabled={runBackfill.isPending}
-                      />
-                    </FieldPanelRow>
-
-                    <FieldPanelRow
-                      title='Create as'
-                      type={BaseType.ENUM}
-                      showIcon
-                      isRequired
-                      description='Is this history, or is it work to do?'>
-                      <FieldInputAdapter
-                        fieldType={FieldType.SINGLE_SELECT}
-                        fieldOptions={{ options: STATUS_OPTIONS }}
-                        value={status}
-                        onChange={(val) => {
-                          setStatus(((val as string[])[0] as BackfillStatus) ?? 'planned')
-                          setAcknowledged(false)
-                        }}
-                        disabled={runBackfill.isPending}
-                      />
-                    </FieldPanelRow>
-                  </FieldPanel>
-
-                  {rangeGroupingBarred && (
-                    <Note>
-                      One build for the whole range is not available here: this range spans more
-                      than one month, and a completed build's date decides which month-end entry
-                      reflects it.
-                    </Note>
-                  )}
-
-                  {refusal && <Note tone='warning'>{refusal}</Note>}
-
-                  {refusal && cutoff && toDate.getTime() > cutoff.getTime() && (
-                    <div>
-                      <Button
-                        variant='outline'
-                        size='sm'
-                        onClick={() => setTo(new Date(cutoff).toISOString())}>
-                        Use the cutoff date
-                      </Button>
-                    </div>
-                  )}
-
-                  {preview.error && !refusal && <Note tone='warning'>{preview.error.message}</Note>}
-
-                  {preview.isPending && !plan && <PlanSkeleton />}
-
-                  {plan && (
-                    <div
-                      className={
-                        stale
-                          ? 'flex flex-col gap-4 opacity-60 transition-opacity'
-                          : 'flex flex-col gap-4 transition-opacity'
-                      }>
-                      <BackfillPeriodStrip
-                        plan={plan}
-                        selected={periodFilter}
-                        onSelect={setPeriodFilter}
-                      />
-
-                      <BackfillPlanTable
-                        plan={plan}
-                        partNames={data?.partNames ?? {}}
-                        periodFilter={periodFilter}
-                      />
-
-                      <BackfillExclusions
-                        exclusions={plan.excluded}
-                        partNames={data?.partNames ?? {}}
-                      />
-
-                      {preflight && (
-                        <CompletionPreflight
-                          buildCount={preflight.buildCount}
-                          movementCount={preflight.movementCount}
-                          unpricedParts={preflight.unpricedParts}
-                          negatives={negatives}
-                          acknowledged={acknowledged}
-                          onAcknowledge={setAcknowledged}
-                          disabled={runBackfill.isPending}
-                        />
-                      )}
-                    </div>
-                  )}
-                </div>
-              </ScrollArea>
-
-              {/* 🛑 The footer is the feature, not decoration. Watching it go
-                  from 94 builds to 20 to 217 as the grouping changes is how the
-                  tradeoff becomes visible instead of a constant nobody sees. */}
-              <div className='flex shrink-0 flex-wrap items-center justify-between gap-2 border-t px-4 py-2.5'>
-                <p className='text-muted-foreground text-sm tabular-nums'>
-                  {plan ? (
-                    <>
-                      <strong className='font-medium text-foreground'>{plan.parts.length}</strong>{' '}
-                      {plan.parts.length === 1 ? 'part' : 'parts'} ·{' '}
-                      <strong className='font-medium text-foreground'>{plan.buildCount}</strong>{' '}
-                      {plan.buildCount === 1 ? 'build' : 'builds'} ·{' '}
-                      <strong className='font-medium text-foreground'>
-                        {formatQuantity(plan.unitCount)}
-                      </strong>{' '}
-                      {plan.unitCount === 1 ? 'unit' : 'units'}
-                    </>
-                  ) : (
-                    'No preview yet'
-                  )}
-                </p>
-
-                <div className='flex items-center gap-2'>
-                  <Button
-                    type='button'
-                    variant='ghost'
-                    size='sm'
-                    onClick={() => onOpenChange(false)}
-                    disabled={runBackfill.isPending}>
-                    Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-                  </Button>
-                  <Button
-                    variant='outline'
-                    size='sm'
-                    onClick={handleRun}
-                    loading={runBackfill.isPending}
-                    loadingText='Creating builds...'
-                    disabled={!canRun}
-                    data-dialog-submit>
-                    {status === 'completed' ? 'Create and post' : 'Create builds'}{' '}
-                    <KbdSubmit variant='outline' size='sm' />
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </DialogNavPage>
-
-          <DialogNavPage value='result' size='3xl'>
-            <BackfillResult
-              result={result}
-              onClose={() => onOpenChange(false)}
-              onBack={() => setPage('plan')}
+            <BatchEnumRow
+              title='Group into'
+              description='How much demand one build covers'
+              options={groupingOptions}
+              value={grouping}
+              onChange={setGrouping}
+              fallback='month'
+              disabled={runBackfill.isPending}
             />
-          </DialogNavPage>
-        </DialogNavPages>
-      </DialogContent>
-    </Dialog>
+
+            <BatchEnumRow
+              title='Create as'
+              description='Is this history, or is it work to do?'
+              options={STATUS_OPTIONS}
+              value={status}
+              onChange={(next) => {
+                setStatus(next)
+                setAcknowledged(false)
+              }}
+              fallback='planned'
+              disabled={runBackfill.isPending}
+            />
+          </BatchDialogPanel>
+
+          {rangeGroupingBarred && (
+            <BatchDialogNote>
+              One build for the whole range is not available here: this range spans more than one
+              month, and a completed build's date decides which month-end entry reflects it.
+            </BatchDialogNote>
+          )}
+
+          {refusal && <BatchDialogNote tone='warning'>{refusal}</BatchDialogNote>}
+
+          {refusal && cutoff && toDate.getTime() > cutoff.getTime() && (
+            <div>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => setTo(new Date(cutoff).toISOString())}>
+                Use the cutoff date
+              </Button>
+            </div>
+          )}
+
+          {preview.error && !refusal && (
+            <BatchDialogNote tone='warning'>{preview.error.message}</BatchDialogNote>
+          )}
+
+          {preview.isPending && !plan && <BatchPlanSkeleton />}
+
+          {plan && (
+            <BatchPlanSection stale={stale}>
+              <BackfillPeriodStrip plan={plan} selected={periodFilter} onSelect={setPeriodFilter} />
+
+              <BackfillPlanTable
+                plan={plan}
+                partNames={data?.partNames ?? {}}
+                periodFilter={periodFilter}
+              />
+
+              <BackfillExclusions exclusions={plan.excluded} partNames={data?.partNames ?? {}} />
+
+              {preflight && (
+                <CompletionPreflight
+                  buildCount={preflight.buildCount}
+                  movementCount={preflight.movementCount}
+                  unpricedParts={preflight.unpricedParts}
+                  negatives={negatives}
+                  acknowledged={acknowledged}
+                  onAcknowledge={setAcknowledged}
+                  disabled={runBackfill.isPending}
+                />
+              )}
+            </BatchPlanSection>
+          )}
+        </>
+      }
+      planFooter={
+        <BatchDialogFooter
+          counts={
+            plan ? (
+              <>
+                <strong className='font-medium text-foreground'>{plan.parts.length}</strong>{' '}
+                {plan.parts.length === 1 ? 'part' : 'parts'} ·{' '}
+                <strong className='font-medium text-foreground'>{plan.buildCount}</strong>{' '}
+                {plan.buildCount === 1 ? 'build' : 'builds'} ·{' '}
+                <strong className='font-medium text-foreground'>
+                  {formatQuantity(plan.unitCount)}
+                </strong>{' '}
+                {plan.unitCount === 1 ? 'unit' : 'units'}
+              </>
+            ) : (
+              'No preview yet'
+            )
+          }
+          onCancel={() => onOpenChange(false)}
+          onSubmit={handleRun}
+          submitLabel={status === 'completed' ? 'Create and post' : 'Create builds'}
+          loading={runBackfill.isPending}
+          loadingText='Creating builds...'
+          disabled={!canRun}
+        />
+      }
+      result={
+        <BackfillResult
+          result={result}
+          onClose={() => onOpenChange(false)}
+          onBack={() => setPage('plan')}
+        />
+      }
+    />
   )
 }
 
@@ -524,89 +490,50 @@ function BackfillResult({
   const failed = result.failed.length
 
   return (
-    <div className='flex flex-col'>
-      <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
-        <div className='flex flex-col gap-3 p-4 text-sm'>
-          <p>
-            <strong className='font-medium'>{created}</strong>{' '}
-            {created === 1 ? 'build was' : 'builds were'} created.
+    <BatchDialogResultPage onBack={onBack} onClose={onClose}>
+      <p>
+        <strong className='font-medium'>{created}</strong>{' '}
+        {created === 1 ? 'build was' : 'builds were'} created.
+      </p>
+
+      {left > 0 && (
+        <div>
+          <p className='flex items-start gap-1.5'>
+            <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+            <span>
+              {left} of them could not be completed and {left === 1 ? 'is' : 'are'} sitting in
+              progress. They exist — do not run the backfill again for them.
+            </span>
           </p>
-
-          {left > 0 && (
-            <div>
-              <p className='flex items-start gap-1.5'>
-                <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
-                <span>
-                  {left} of them could not be completed and {left === 1 ? 'is' : 'are'} sitting in
-                  progress. They exist — do not run the backfill again for them.
-                </span>
-              </p>
-              <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
-                {result.leftInProgress.slice(0, 12).map((row) => (
-                  <li key={row.buildId}>{row.reason}</li>
-                ))}
-                {left > 12 && <li>and {left - 12} more</li>}
-              </ul>
-            </div>
-          )}
-
-          {failed > 0 && (
-            <div>
-              <p>
-                {failed} {failed === 1 ? 'bucket' : 'buckets'} produced nothing at all.
-              </p>
-              <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
-                {result.failed.slice(0, 12).map((row) => (
-                  <li key={row.bucketId}>
-                    {row.periodKey}: {row.reason}
-                  </li>
-                ))}
-                {failed > 12 && <li>and {failed - 12} more</li>}
-              </ul>
-            </div>
-          )}
+          <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
+            {result.leftInProgress.slice(0, 12).map((row) => (
+              <li key={row.buildId}>{row.reason}</li>
+            ))}
+            {left > 12 && <li>and {left - 12} more</li>}
+          </ul>
         </div>
-      </ScrollArea>
+      )}
 
-      <div className='flex shrink-0 items-center justify-end gap-2 border-t px-4 py-2.5'>
-        <Button type='button' variant='ghost' size='sm' onClick={onBack}>
-          Back to the preview
-        </Button>
-        <Button variant='outline' size='sm' onClick={onClose} data-dialog-submit>
-          Done <KbdSubmit variant='outline' size='sm' />
-        </Button>
-      </div>
-    </div>
+      {failed > 0 && (
+        <div>
+          <p>
+            {failed} {failed === 1 ? 'bucket' : 'buckets'} produced nothing at all.
+          </p>
+          <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
+            {result.failed.slice(0, 12).map((row) => (
+              <li key={row.bucketId}>
+                {row.periodKey}: {row.reason}
+              </li>
+            ))}
+            {failed > 12 && <li>and {failed - 12} more</li>}
+          </ul>
+        </div>
+      )}
+    </BatchDialogResultPage>
   )
 }
 
 // ─── Small pieces ────────────────────────────────────────────────────────
-
-function Note({ children, tone }: { children: React.ReactNode; tone?: 'warning' }) {
-  return (
-    <p
-      className={
-        tone === 'warning'
-          ? 'flex items-start gap-1.5 rounded-md border border-amber-300 bg-amber-50/60 px-3 py-2 text-sm dark:border-amber-900 dark:bg-amber-950/30'
-          : 'rounded-md border bg-muted/40 px-3 py-2 text-muted-foreground text-sm'
-      }>
-      {tone === 'warning' && (
-        <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
-      )}
-      <span>{children}</span>
-    </p>
-  )
-}
-
-function PlanSkeleton() {
-  return (
-    <div className='flex flex-col gap-2'>
-      <Skeleton className='h-9 w-full' />
-      <Skeleton className='h-9 w-full' />
-      <Skeleton className='h-9 w-full' />
-    </div>
-  )
-}
 
 /** January 1 of the current year — the range the cutover actually asks for. */
 function startOfYear(): Date {

--- a/apps/web/src/components/money/ui/batch-posting/batch-dialog-parts.tsx
+++ b/apps/web/src/components/money/ui/batch-posting/batch-dialog-parts.tsx
@@ -1,0 +1,150 @@
+// apps/web/src/components/money/ui/batch-posting/batch-dialog-parts.tsx
+'use client'
+
+// The small pieces every batch dialog repeats: the note card, the loading
+// placeholder, the stale-plan wrapper, the field panel's settings and the enum
+// row that every one of these screens asks its questions with.
+//
+// Each of these was duplicated verbatim across `backfill-dialog.tsx` and
+// `batch-posting-dialog.tsx`. See `batch-dialog-shell.tsx`'s header for where
+// the sharing stops and why.
+
+import { FieldType } from '@auxx/database/enums'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { TriangleAlert } from 'lucide-react'
+import { type ReactNode, useMemo } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+
+/**
+ * A sentence the screen keeps.
+ *
+ * 🛑 A refusal is a card and never a toast (ground rule 9): the book time zone
+ * being unset, or a range that runs past the build cutoff, is a task with an
+ * address, and a sentence that disappears cannot carry one.
+ */
+export function BatchDialogNote({ children, tone }: { children: ReactNode; tone?: 'warning' }) {
+  return (
+    <p
+      className={
+        tone === 'warning'
+          ? 'flex items-start gap-1.5 rounded-md border border-amber-300 bg-amber-50/60 px-3 py-2 text-sm dark:border-amber-900 dark:bg-amber-950/30'
+          : 'rounded-md border bg-muted/40 px-3 py-2 text-muted-foreground text-sm'
+      }>
+      {tone === 'warning' && (
+        <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+      )}
+      <span>{children}</span>
+    </p>
+  )
+}
+
+/** Three rows, while the first preview is in flight and there is nothing to keep. */
+export function BatchPlanSkeleton() {
+  return (
+    <div className='flex flex-col gap-2'>
+      <Skeleton className='h-9 w-full' />
+      <Skeleton className='h-9 w-full' />
+      <Skeleton className='h-9 w-full' />
+    </div>
+  )
+}
+
+/**
+ * The plan, dimmed while a refetch is in flight over a kept previous one.
+ *
+ * Dimmed rather than blanked: this is the screen whose whole point is watching
+ * the numbers move, and clearing the table on every change reads as "the
+ * numbers just went away".
+ */
+export function BatchPlanSection({ stale, children }: { stale: boolean; children: ReactNode }) {
+  return (
+    <div
+      className={
+        stale
+          ? 'flex flex-col gap-4 opacity-60 transition-opacity'
+          : 'flex flex-col gap-4 transition-opacity'
+      }>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * The question panel at the top of the preview page.
+ *
+ * One set of settings so the three dialogs' label columns line up and resize
+ * together per screen; `resizeId` is what keeps them independent per dialog.
+ */
+export function BatchDialogPanel({
+  resizeId,
+  children,
+}: {
+  resizeId: string
+  children: ReactNode
+}) {
+  return (
+    <FieldPanel
+      className='p-0'
+      orientation='responsive'
+      breakpoint='md'
+      resizeId={resizeId}
+      defaultLabelWidth={180}>
+      {children}
+    </FieldPanel>
+  )
+}
+
+interface BatchEnumRowProps<Value extends string> {
+  title: string
+  description: string
+  options: readonly { value: Value; label: string }[]
+  value: Value
+  onChange: (value: Value) => void
+  /**
+   * What a cleared select falls back to.
+   *
+   * 🛑 Required rather than defaulted: these answers decide what the run writes,
+   * so "whatever the first option happens to be" is not a safe guess to make in
+   * a shared component.
+   */
+  fallback: Value
+  disabled?: boolean
+}
+
+/**
+ * One single-select question, generic over the answer.
+ *
+ * Generic over `Value` rather than typed to a grouping union, because the three
+ * dialogs ask four of these between them and only one of the four is a
+ * grouping.
+ */
+export function BatchEnumRow<Value extends string>({
+  title,
+  description,
+  options,
+  value,
+  onChange,
+  fallback,
+  disabled,
+}: BatchEnumRowProps<Value>) {
+  // `FieldOptions.options` is a mutable array of widened `{ value: string }`, so
+  // a readonly list of the narrow union cannot be handed over as-is.
+  const selectOptions = useMemo(
+    () => options.map((option) => ({ value: option.value as string, label: option.label })),
+    [options]
+  )
+
+  return (
+    <FieldPanelRow title={title} type={BaseType.ENUM} showIcon isRequired description={description}>
+      <FieldInputAdapter
+        fieldType={FieldType.SINGLE_SELECT}
+        fieldOptions={{ options: selectOptions }}
+        value={value}
+        onChange={(next) => onChange(((next as string[])[0] as Value) ?? fallback)}
+        disabled={disabled}
+      />
+    </FieldPanelRow>
+  )
+}

--- a/apps/web/src/components/money/ui/batch-posting/batch-dialog-shell.tsx
+++ b/apps/web/src/components/money/ui/batch-posting/batch-dialog-shell.tsx
@@ -1,0 +1,217 @@
+// apps/web/src/components/money/ui/batch-posting/batch-dialog-shell.tsx
+'use client'
+
+// The CHROME every batch dialog wears: the two-page shell, the footer bar and
+// the result page's scroll-and-actions wrapper.
+//
+// (plans/accounting/tasks/25-batch-posting-and-credit-memos.md §5.1 - *"the
+// whole dialog"* - and §5.2's warning about where that stops.)
+//
+// ## Why this is separate from `BatchPostingSource`
+//
+// Three dialogs have this shape: `manufacturing/builds/backfill-dialog.tsx`
+// (the progenitor), and the two posting sources that copied it. Only the latter
+// two share a *contract* - same wire range, same grouping vocabulary, same
+// `posted / skipped / failed / exclusions` summary - so only they can be one
+// descriptor-driven dialog.
+//
+// The builds backfill shares none of that: its range is two `Date`s bounded by
+// the auto-build cutoff, its groupings are five and are filtered by another
+// answer on the same screen, its exclusions table counts quantities rather than
+// listing documents by date, and its result reports builds raised and left in
+// progress rather than entries posted. Pushing it through the descriptor would
+// mean a pluggable range, a dynamic grouping list, an overridable exclusions
+// block, an overridable result page and a source-supplied run predicate - five
+// slots, four of which exactly one source would ever set. §5.2 names that
+// failure mode by hand.
+//
+// 🛑 **So what is shared here is the chrome and nothing else.** Everything below
+// is markup that was byte-for-byte identical in all three files. If a prop shows
+// up here that only one caller passes a meaningful value for, it belongs in that
+// caller instead.
+
+import { Button } from '@auxx/ui/components/button'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { TriangleAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+/** Which of the two pages a batch dialog is showing. */
+export type BatchDialogPage = 'plan' | 'result'
+
+interface BatchDialogShellProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /**
+   * True while the run is in flight.
+   *
+   * 🛑 It closes the dialog's own escape hatch, not just the buttons: a run is
+   * non-atomic, so dismissing mid-flight would lose the only report of what it
+   * managed to write.
+   */
+  busy: boolean
+  /** Also the first crumb. */
+  title: string
+  description: string
+  page: BatchDialogPage
+  /** Makes the first crumb a jump back, but only from the result page. */
+  onBackToPlan: () => void
+  /** The preview page's rows, notes and tables. Wrapped in the scroller here. */
+  planBody: ReactNode
+  /** A {@link BatchDialogFooter}, pinned under the scroller. */
+  planFooter: ReactNode
+  /** The result page, which owns its own scroller - see {@link BatchDialogResultPage}. */
+  result: ReactNode
+}
+
+/**
+ * Dialog, breadcrumb header, and the plan/result page pair.
+ *
+ * Both pages declare `3xl`, so the card keeps its width across the transition
+ * instead of springing between two sizes on a screen that is mostly a table.
+ */
+export function BatchDialogShell({
+  open,
+  onOpenChange,
+  busy,
+  title,
+  description,
+  page,
+  onBackToPlan,
+  planBody,
+  planFooter,
+  result,
+}: BatchDialogShellProps) {
+  return (
+    <Dialog open={open} onOpenChange={(next) => !busy && onOpenChange(next)}>
+      <DialogContent size='content' position='tc' innerClassName='p-0'>
+        <DialogNav
+          title={title}
+          description={description}
+          crumbs={[
+            { label: title, onClick: page === 'result' ? onBackToPlan : undefined },
+            ...(page === 'result' ? [{ label: 'Result' }] : []),
+          ]}
+        />
+
+        <DialogNavPages value={page}>
+          <DialogNavPage value='plan' size='3xl'>
+            <div className='flex flex-col'>
+              <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
+                <div className='flex flex-col gap-4 p-4'>{planBody}</div>
+              </ScrollArea>
+              {planFooter}
+            </div>
+          </DialogNavPage>
+
+          <DialogNavPage value='result' size='3xl'>
+            {result}
+          </DialogNavPage>
+        </DialogNavPages>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface BatchDialogFooterProps {
+  /**
+   * What this run will do BEYOND the counts, said above them.
+   *
+   * The footer is the last thing read before the button, so an option that
+   * writes to documents says so here and not only in its own caption.
+   */
+  warning?: ReactNode
+  /**
+   * The count line, in this dialog's nouns. Callers pass `'No preview yet'` when
+   * there is no plan.
+   */
+  counts: ReactNode
+  onCancel: () => void
+  onSubmit: () => void
+  submitLabel: ReactNode
+  loading: boolean
+  loadingText: string
+  disabled: boolean
+}
+
+/**
+ * The pinned footer.
+ *
+ * 🛑 **It is the feature, not decoration.** Watching the counts go from 613 to
+ * 62 to 2 as the frequency changes is how the tradeoff becomes visible instead
+ * of baked into a constant nobody can see (49 §2.3 item 2, 44 §7.2).
+ */
+export function BatchDialogFooter({
+  warning,
+  counts,
+  onCancel,
+  onSubmit,
+  submitLabel,
+  loading,
+  loadingText,
+  disabled,
+}: BatchDialogFooterProps) {
+  return (
+    <div className='shrink-0 border-t'>
+      {warning && (
+        <p className='flex items-start gap-1.5 border-b bg-amber-50/60 px-4 py-2 text-sm dark:bg-amber-950/30'>
+          <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+          <span>{warning}</span>
+        </p>
+      )}
+      <div className='flex flex-wrap items-center justify-between gap-2 px-4 py-2.5'>
+        <p className='text-muted-foreground text-sm tabular-nums'>{counts}</p>
+
+        <div className='flex items-center gap-2'>
+          <Button type='button' variant='ghost' size='sm' onClick={onCancel} disabled={loading}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={onSubmit}
+            loading={loading}
+            loadingText={loadingText}
+            disabled={disabled}
+            data-dialog-submit>
+            {submitLabel} <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface BatchDialogResultPageProps {
+  children: ReactNode
+  onBack: () => void
+  onClose: () => void
+}
+
+/**
+ * The result page's scroller and its two actions.
+ *
+ * "Back to the preview" rather than a close-only page: the preview is still the
+ * answer to *"what did it leave behind?"*, and a run that skipped or refused
+ * part of its plan is read there, not here.
+ */
+export function BatchDialogResultPage({ children, onBack, onClose }: BatchDialogResultPageProps) {
+  return (
+    <div className='flex flex-col'>
+      <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
+        <div className='flex flex-col gap-3 p-4 text-sm'>{children}</div>
+      </ScrollArea>
+
+      <div className='flex shrink-0 items-center justify-end gap-2 border-t px-4 py-2.5'>
+        <Button type='button' variant='ghost' size='sm' onClick={onBack}>
+          Back to the preview
+        </Button>
+        <Button variant='outline' size='sm' onClick={onClose} data-dialog-submit>
+          Done <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/money/ui/batch-posting/batch-posting-dialog.tsx
+++ b/apps/web/src/components/money/ui/batch-posting/batch-posting-dialog.tsx
@@ -36,23 +36,22 @@
 // that changes identity between renders, or building one inside a component,
 // breaks the rules of hooks. Every registration is a `const` at module scope.
 
-import { FieldType } from '@auxx/database/enums'
-import { Button } from '@auxx/ui/components/button'
-import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
-import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import type { MonthRangeValue } from '@auxx/ui/components/month-range-picker'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
-import { TriangleAlert } from 'lucide-react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { formatMinor } from '~/components/accounting/ui/ledger/format'
-import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
+import {
+  BatchDialogNote,
+  BatchDialogPanel,
+  BatchEnumRow,
+  BatchPlanSection,
+  BatchPlanSkeleton,
+} from './batch-dialog-parts'
+import { BatchDialogFooter, BatchDialogShell } from './batch-dialog-shell'
 import { BatchPostingExclusions } from './batch-posting-exclusions'
 import { BatchPostingResult } from './batch-posting-result'
 import { BatchRangeControl, type InclusiveDayRange } from './batch-range-control'
@@ -214,246 +213,157 @@ export function BatchPostingDialog<
   const footerWarning = plan ? (source.options?.footerWarning?.(plan, options) ?? null) : null
 
   return (
-    <Dialog open={open} onOpenChange={(next) => !runner.isPending && onOpenChange(next)}>
-      <DialogContent size='content' position='tc' innerClassName='p-0'>
-        <DialogNav
-          title={source.title}
-          description={source.description}
-          crumbs={[
-            {
-              label: source.title,
-              onClick: page === 'result' ? () => setPage('plan') : undefined,
-            },
-            ...(page === 'result' ? [{ label: 'Result' }] : []),
-          ]}
-        />
-
-        <DialogNavPages value={page}>
-          <DialogNavPage value='plan' size='3xl'>
-            <div className='flex flex-col'>
-              <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
-                <div className='flex flex-col gap-4 p-4'>
-                  <FieldPanel
-                    className='p-0'
-                    orientation='responsive'
-                    breakpoint='md'
-                    resizeId='batch-posting'
-                    defaultLabelWidth={180}>
-                    {/* 🛑 Frequency FIRST (§6.2). The range control below is
-                        chosen by this answer. */}
-                    <FieldPanelRow
-                      title='Frequency'
-                      type={BaseType.ENUM}
-                      showIcon
-                      isRequired
-                      description={source.groupingDescription}>
-                      <FieldInputAdapter
-                        fieldType={FieldType.SINGLE_SELECT}
-                        fieldOptions={{ options: groupingOptions }}
-                        value={grouping}
-                        onChange={(value) =>
-                          setGrouping(
-                            ((value as string[])[0] as BatchPostingGrouping) ??
-                              source.defaultGrouping
-                          )
-                        }
-                        disabled={runner.isPending}
-                      />
-                    </FieldPanelRow>
-
-                    <FieldPanelRow
-                      title={grouping === 'month' ? 'Months' : 'Dates'}
-                      type={BaseType.DATE}
-                      showIcon
-                      isRequired
-                      description={source.rangeDescription}>
-                      <BatchRangeControl
-                        grouping={grouping}
-                        monthRange={effectiveMonthRange}
-                        onMonthRange={setMonthRange}
-                        dayRange={dayRange}
-                        onDayRange={setDayRange}
-                        months={months}
-                        monthsLoading={monthsLoading}
-                        disabled={runner.isPending}
-                      />
-                    </FieldPanelRow>
-
-                    {/* The source's own extra request field, if it has one
-                        (§5.5's third axis). A direct child of the panel, so the
-                        last-row border rule still sees it. */}
-                    {source.options?.render({
-                      value: options,
-                      onChange: setOptions,
-                      disabled: runner.isPending,
-                    })}
-                  </FieldPanel>
-
-                  {/* A refusal is a card, not a toast (ground rule 9): the book
-                      time zone being unset is a settings task with an address,
-                      and a sentence that disappears cannot carry one. */}
-                  {refusal && <Note tone='warning'>{refusal}</Note>}
-
-                  {preview.errorMessage && !refusal && (
-                    <Note tone='warning'>{preview.errorMessage}</Note>
-                  )}
-
-                  {/* `range` null means there is nothing to preview yet (the
-                      periods are still loading, or there are none). The control
-                      above already says so; a skeleton here would imply a
-                      request that was never made. */}
-                  {range && preview.isPending && !plan && <PlanSkeleton />}
-
-                  {plan && (
-                    <div
-                      className={
-                        stale
-                          ? 'flex flex-col gap-4 opacity-60 transition-opacity'
-                          : 'flex flex-col gap-4 transition-opacity'
-                      }>
-                      {plan.groups.length === 0 ? (
-                        <div className='flex flex-col gap-2'>
-                          <p className='rounded-md border border-dashed px-3 py-6 text-center text-muted-foreground text-sm'>
-                            {source.emptyPlanNote}
-                          </p>
-                          {/* 🛑 When the reason there is nothing to post is an
-                              option that is switched off, say THAT. An empty
-                              plan over a backlog of excluded documents is how
-                              somebody concludes the feature is broken. */}
-                          {emptyPlanHint && <Note tone='warning'>{emptyPlanHint}</Note>}
-                        </div>
-                      ) : (
-                        source.renderPlanTable({ plan, currencyCode, gatewayNames })
-                      )}
-
-                      <BatchPostingExclusions
-                        rows={plan.exclusions.map(source.exclusionRow)}
-                        columns={source.exclusionColumns}
-                        copy={source.exclusionCopy}
-                      />
-
-                      {plan.footer.postings > 0 && (
-                        <Note>
-                          Posting writes {plan.footer.postings}{' '}
-                          {plan.footer.postings === 1 ? 'entry' : 'entries'} onto an append-only
-                          ledger. They can only be corrected by reversing them, never by editing
-                          them.
-                        </Note>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </ScrollArea>
-
-              {/* 🛑 The footer is the feature, not decoration. Watching it go
-                  from 613 postings to 62 to 2 as the frequency changes is how
-                  the tradeoff becomes visible instead of a constant nobody
-                  sees. */}
-              <div className='shrink-0 border-t'>
-                {/* 🛑 Above the counts, not in the scroll area: an option that
-                    WRITES to every document in the plan says so where the
-                    button is, which is the last thing read before it. */}
-                {footerWarning && (
-                  <p className='flex items-start gap-1.5 border-b bg-amber-50/60 px-4 py-2 text-sm dark:bg-amber-950/30'>
-                    <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
-                    <span>{footerWarning}</span>
-                  </p>
-                )}
-                <div className='flex flex-wrap items-center justify-between gap-2 px-4 py-2.5'>
-                  <p className='text-muted-foreground text-sm tabular-nums'>
-                    {plan ? (
-                      <>
-                        <strong className='font-medium text-foreground'>
-                          {plan.footer.postings}
-                        </strong>{' '}
-                        {plan.footer.postings === 1 ? 'posting' : 'postings'}
-                        {source.footerCounts(plan).map((count) => (
-                          <Fragment key={count.plural}>
-                            {' · '}
-                            <strong className='font-medium text-foreground'>{count.value}</strong>{' '}
-                            {count.value === 1 ? count.singular : count.plural}
-                          </Fragment>
-                        ))}
-                        {' · '}
-                        <strong className='font-medium text-foreground'>
-                          {formatMinor(plan.footer.totalMinor, currencyCode)}
-                        </strong>
-                      </>
-                    ) : (
-                      'No preview yet'
-                    )}
-                  </p>
-
-                  <div className='flex items-center gap-2'>
-                    <Button
-                      type='button'
-                      variant='ghost'
-                      size='sm'
-                      onClick={() => onOpenChange(false)}
-                      disabled={runner.isPending}>
-                      Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-                    </Button>
-                    <Button
-                      variant='outline'
-                      size='sm'
-                      onClick={handleRun}
-                      loading={runner.isPending}
-                      loadingText={source.runningLabel}
-                      disabled={!canRun}
-                      data-dialog-submit>
-                      Post {plan?.footer.postings ?? 0}{' '}
-                      {plan?.footer.postings === 1 ? 'entry' : 'entries'}{' '}
-                      <KbdSubmit variant='outline' size='sm' />
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </DialogNavPage>
-
-          <DialogNavPage value='result' size='3xl'>
-            <BatchPostingResult
-              result={result}
-              membersPosted={
-                result ? source.membersPosted(result) : { value: 0, singular: '', plural: '' }
-              }
-              postedRows={result ? source.postedRows(result) : []}
-              optionNote={result ? (source.options?.resultNote?.(result) ?? null) : null}
-              excludedNoun={source.excludedNoun}
-              onBack={() => setPage('plan')}
-              onClose={() => onOpenChange(false)}
+    <BatchDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      busy={runner.isPending}
+      title={source.title}
+      description={source.description}
+      page={page}
+      onBackToPlan={() => setPage('plan')}
+      planBody={
+        <>
+          <BatchDialogPanel resizeId='batch-posting'>
+            {/* 🛑 Frequency FIRST (§6.2). The range control below is chosen by
+                this answer. */}
+            <BatchEnumRow
+              title='Frequency'
+              description={source.groupingDescription}
+              options={groupingOptions}
+              value={grouping}
+              onChange={setGrouping}
+              fallback={source.defaultGrouping}
+              disabled={runner.isPending}
             />
-          </DialogNavPage>
-        </DialogNavPages>
-      </DialogContent>
-    </Dialog>
-  )
-}
 
-// ─── Small pieces ─────────────────────────────────────────────────────────
+            <FieldPanelRow
+              title={grouping === 'month' ? 'Months' : 'Dates'}
+              type={BaseType.DATE}
+              showIcon
+              isRequired
+              description={source.rangeDescription}>
+              <BatchRangeControl
+                grouping={grouping}
+                monthRange={effectiveMonthRange}
+                onMonthRange={setMonthRange}
+                dayRange={dayRange}
+                onDayRange={setDayRange}
+                months={months}
+                monthsLoading={monthsLoading}
+                disabled={runner.isPending}
+              />
+            </FieldPanelRow>
 
-function Note({ children, tone }: { children: React.ReactNode; tone?: 'warning' }) {
-  return (
-    <p
-      className={
-        tone === 'warning'
-          ? 'flex items-start gap-1.5 rounded-md border border-amber-300 bg-amber-50/60 px-3 py-2 text-sm dark:border-amber-900 dark:bg-amber-950/30'
-          : 'rounded-md border bg-muted/40 px-3 py-2 text-muted-foreground text-sm'
-      }>
-      {tone === 'warning' && (
-        <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
-      )}
-      <span>{children}</span>
-    </p>
-  )
-}
+            {/* The source's own extra request field, if it has one (§5.5's
+                third axis). A direct child of the panel, so the last-row
+                border rule still sees it. */}
+            {source.options?.render({
+              value: options,
+              onChange: setOptions,
+              disabled: runner.isPending,
+            })}
+          </BatchDialogPanel>
 
-function PlanSkeleton() {
-  return (
-    <div className='flex flex-col gap-2'>
-      <Skeleton className='h-9 w-full' />
-      <Skeleton className='h-9 w-full' />
-      <Skeleton className='h-9 w-full' />
-    </div>
+          {/* A refusal is a card, not a toast (ground rule 9): the book time
+              zone being unset is a settings task with an address, and a
+              sentence that disappears cannot carry one. */}
+          {refusal && <BatchDialogNote tone='warning'>{refusal}</BatchDialogNote>}
+
+          {preview.errorMessage && !refusal && (
+            <BatchDialogNote tone='warning'>{preview.errorMessage}</BatchDialogNote>
+          )}
+
+          {/* `range` null means there is nothing to preview yet (the periods
+              are still loading, or there are none). The control above already
+              says so; a skeleton here would imply a request that was never
+              made. */}
+          {range && preview.isPending && !plan && <BatchPlanSkeleton />}
+
+          {plan && (
+            <BatchPlanSection stale={stale}>
+              {plan.groups.length === 0 ? (
+                <div className='flex flex-col gap-2'>
+                  <p className='rounded-md border border-dashed px-3 py-6 text-center text-muted-foreground text-sm'>
+                    {source.emptyPlanNote}
+                  </p>
+                  {/* 🛑 When the reason there is nothing to post is an option
+                      that is switched off, say THAT. An empty plan over a
+                      backlog of excluded documents is how somebody concludes
+                      the feature is broken. */}
+                  {emptyPlanHint && (
+                    <BatchDialogNote tone='warning'>{emptyPlanHint}</BatchDialogNote>
+                  )}
+                </div>
+              ) : (
+                source.renderPlanTable({ plan, currencyCode, gatewayNames })
+              )}
+
+              <BatchPostingExclusions
+                rows={plan.exclusions.map(source.exclusionRow)}
+                columns={source.exclusionColumns}
+                copy={source.exclusionCopy}
+              />
+
+              {plan.footer.postings > 0 && (
+                <BatchDialogNote>
+                  Posting writes {plan.footer.postings}{' '}
+                  {plan.footer.postings === 1 ? 'entry' : 'entries'} onto an append-only ledger.
+                  They can only be corrected by reversing them, never by editing them.
+                </BatchDialogNote>
+              )}
+            </BatchPlanSection>
+          )}
+        </>
+      }
+      planFooter={
+        <BatchDialogFooter
+          warning={footerWarning}
+          counts={
+            plan ? (
+              <>
+                <strong className='font-medium text-foreground'>{plan.footer.postings}</strong>{' '}
+                {plan.footer.postings === 1 ? 'posting' : 'postings'}
+                {source.footerCounts(plan).map((count) => (
+                  <Fragment key={count.plural}>
+                    {' · '}
+                    <strong className='font-medium text-foreground'>{count.value}</strong>{' '}
+                    {count.value === 1 ? count.singular : count.plural}
+                  </Fragment>
+                ))}
+                {' · '}
+                <strong className='font-medium text-foreground'>
+                  {formatMinor(plan.footer.totalMinor, currencyCode)}
+                </strong>
+              </>
+            ) : (
+              'No preview yet'
+            )
+          }
+          onCancel={() => onOpenChange(false)}
+          onSubmit={handleRun}
+          submitLabel={
+            <>
+              Post {plan?.footer.postings ?? 0} {plan?.footer.postings === 1 ? 'entry' : 'entries'}
+            </>
+          }
+          loading={runner.isPending}
+          loadingText={source.runningLabel}
+          disabled={!canRun}
+        />
+      }
+      result={
+        <BatchPostingResult
+          result={result}
+          membersPosted={
+            result ? source.membersPosted(result) : { value: 0, singular: '', plural: '' }
+          }
+          postedRows={result ? source.postedRows(result) : []}
+          optionNote={result ? (source.options?.resultNote?.(result) ?? null) : null}
+          excludedNoun={source.excludedNoun}
+          onBack={() => setPage('plan')}
+          onClose={() => onOpenChange(false)}
+        />
+      }
+    />
   )
 }

--- a/apps/web/src/components/money/ui/batch-posting/batch-posting-result.tsx
+++ b/apps/web/src/components/money/ui/batch-posting/batch-posting-result.tsx
@@ -13,11 +13,9 @@
  * Shared across sources. Only the nouns come from the descriptor.
  */
 
-import { Button } from '@auxx/ui/components/button'
-import { KbdSubmit } from '@auxx/ui/components/kbd'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { TriangleAlert } from 'lucide-react'
 import type { ReactNode } from 'react'
+import { BatchDialogResultPage } from './batch-dialog-shell'
 import { countLabel } from './count-label'
 import type { BatchPostingCount, BatchPostingPostedRow, BatchPostingSummaryShape } from './types'
 
@@ -59,83 +57,69 @@ export function BatchPostingResult<Summary extends BatchPostingSummaryShape>({
   const excluded = result.exclusions.length
 
   return (
-    <div className='flex flex-col'>
-      <ScrollArea viewportClassName='max-h-[70vh]' allowScrollChaining>
-        <div className='flex flex-col gap-3 p-4 text-sm'>
+    <BatchDialogResultPage onBack={onBack} onClose={onClose}>
+      <p>
+        <strong className='font-medium'>{posted}</strong>{' '}
+        {posted === 1 ? 'entry was' : 'entries were'} posted, covering {countLabel(membersPosted)}.
+      </p>
+
+      {posted > 0 && (
+        <ul className='ps-4 text-muted-foreground text-xs tabular-nums'>
+          {postedRows.slice(0, ROWS_SHOWN).map((row) => (
+            <li key={row.groupKey}>
+              <span className='font-mono'>{row.docNumber}</span> · {row.groupKey} · {row.note}
+            </li>
+          ))}
+          {posted > ROWS_SHOWN && <li>and {posted - ROWS_SHOWN} more</li>}
+        </ul>
+      )}
+
+      {optionNote}
+
+      {skipped > 0 && (
+        <div>
           <p>
-            <strong className='font-medium'>{posted}</strong>{' '}
-            {posted === 1 ? 'entry was' : 'entries were'} posted, covering{' '}
-            {countLabel(membersPosted)}.
+            {skipped} {skipped === 1 ? 'group was' : 'groups were'} skipped. Nothing was written for{' '}
+            {skipped === 1 ? 'it' : 'them'}, and nothing is wrong.
           </p>
-
-          {posted > 0 && (
-            <ul className='ps-4 text-muted-foreground text-xs tabular-nums'>
-              {postedRows.slice(0, ROWS_SHOWN).map((row) => (
-                <li key={row.groupKey}>
-                  <span className='font-mono'>{row.docNumber}</span> · {row.groupKey} · {row.note}
-                </li>
-              ))}
-              {posted > ROWS_SHOWN && <li>and {posted - ROWS_SHOWN} more</li>}
-            </ul>
-          )}
-
-          {optionNote}
-
-          {skipped > 0 && (
-            <div>
-              <p>
-                {skipped} {skipped === 1 ? 'group was' : 'groups were'} skipped. Nothing was written
-                for {skipped === 1 ? 'it' : 'them'}, and nothing is wrong.
-              </p>
-              <ul className='mt-1 ps-4 text-muted-foreground text-xs'>
-                {result.skipped.slice(0, ROWS_SHOWN).map((row) => (
-                  <li key={row.groupKey}>
-                    {row.groupKey}: {row.status}, {row.reason}
-                  </li>
-                ))}
-                {skipped > ROWS_SHOWN && <li>and {skipped - ROWS_SHOWN} more</li>}
-              </ul>
-            </div>
-          )}
-
-          {failed > 0 && (
-            <div>
-              <p className='flex items-start gap-1.5'>
-                <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
-                <span>
-                  {failed} {failed === 1 ? 'group' : 'groups'} wrote nothing at all. They stay
-                  unposted and come back in the next preview.
-                </span>
-              </p>
-              <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
-                {result.failed.slice(0, ROWS_SHOWN).map((row) => (
-                  <li key={row.groupKey}>
-                    {row.groupKey}: {row.reason}
-                  </li>
-                ))}
-                {failed > ROWS_SHOWN && <li>and {failed - ROWS_SHOWN} more</li>}
-              </ul>
-            </div>
-          )}
-
-          {excluded > 0 && (
-            <p className='text-muted-foreground text-xs'>
-              {excluded}{' '}
-              {excluded === 1 ? `${excludedNoun.singular} was` : `${excludedNoun.plural} were`}{' '}
-              excluded from this run. They are listed with their reasons on the preview.
-            </p>
-          )}
+          <ul className='mt-1 ps-4 text-muted-foreground text-xs'>
+            {result.skipped.slice(0, ROWS_SHOWN).map((row) => (
+              <li key={row.groupKey}>
+                {row.groupKey}: {row.status}, {row.reason}
+              </li>
+            ))}
+            {skipped > ROWS_SHOWN && <li>and {skipped - ROWS_SHOWN} more</li>}
+          </ul>
         </div>
-      </ScrollArea>
+      )}
 
-      <div className='flex shrink-0 items-center justify-end gap-2 border-t px-4 py-2.5'>
-        <Button type='button' variant='ghost' size='sm' onClick={onBack}>
-          Back to the preview
-        </Button>
-        <Button variant='outline' size='sm' onClick={onClose} data-dialog-submit>
-          Done <KbdSubmit variant='outline' size='sm' />
-        </Button>
-      </div>
-    </div>
+      {failed > 0 && (
+        <div>
+          <p className='flex items-start gap-1.5'>
+            <TriangleAlert className='mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500' />
+            <span>
+              {failed} {failed === 1 ? 'group' : 'groups'} wrote nothing at all. They stay unposted
+              and come back in the next preview.
+            </span>
+          </p>
+          <ul className='mt-1 ps-6 text-muted-foreground text-xs'>
+            {result.failed.slice(0, ROWS_SHOWN).map((row) => (
+              <li key={row.groupKey}>
+                {row.groupKey}: {row.reason}
+              </li>
+            ))}
+            {failed > ROWS_SHOWN && <li>and {failed - ROWS_SHOWN} more</li>}
+          </ul>
+        </div>
+      )}
+
+      {excluded > 0 && (
+        <p className='text-muted-foreground text-xs'>
+          {excluded}{' '}
+          {excluded === 1 ? `${excludedNoun.singular} was` : `${excludedNoun.plural} were`} excluded
+          from this run. They are listed with their reasons on the preview.
+        </p>
+      )}
+    </BatchDialogResultPage>
   )
 }

--- a/apps/web/src/components/money/ui/batch-posting/index.ts
+++ b/apps/web/src/components/money/ui/batch-posting/index.ts
@@ -1,5 +1,14 @@
 // apps/web/src/components/money/ui/batch-posting/index.ts
 
+export {
+  BatchDialogNote,
+  BatchDialogPanel,
+  BatchEnumRow,
+  BatchPlanSection,
+  BatchPlanSkeleton,
+} from './batch-dialog-parts'
+export type { BatchDialogPage } from './batch-dialog-shell'
+export { BatchDialogFooter, BatchDialogResultPage, BatchDialogShell } from './batch-dialog-shell'
 export { BatchPostingDialog } from './batch-posting-dialog'
 export { BatchPostingExclusions } from './batch-posting-exclusions'
 export { BatchPostingResult } from './batch-posting-result'

--- a/apps/web/src/components/money/ui/batch-posting/types.ts
+++ b/apps/web/src/components/money/ui/batch-posting/types.ts
@@ -35,6 +35,16 @@
  * it and never renders a control from a schema: the source renders its own
  * control and owns its own shape. A source that declares no slot behaves exactly
  * as it did before the slot existed.
+ *
+ * ## The third instance is chrome-only, on purpose
+ *
+ * `manufacturing/builds/backfill-dialog.tsx` is where this shape came from, and
+ * it is NOT a registration here. It shares the chrome in `batch-dialog-shell.tsx`
+ * and `batch-dialog-parts.tsx` and nothing else, because it answers none of this
+ * descriptor's contract - not the wire range, not the grouping vocabulary, not
+ * the exclusion row, not the run summary. That file's header lists the five
+ * slots registering it would have cost. Read it before widening anything below
+ * for a fourth caller.
  */
 
 import type { BatchPostingGrouping } from '@auxx/lib/money/client'


### PR DESCRIPTION
`post-fulfillments-dialog.tsx`'s own header says it was *"copied structurally from `manufacturing/builds/backfill-dialog.tsx`, which is the house shape for preview a batch, then run it"*.

So **builds is the progenitor of this shape**, and #2140 extracted a frame from the *copy* while leaving the *original* sitting on its own duplicate implementation. That is the worst of both worlds: a frame claiming to be the house shape while the house it came from does not use it. Brief 25 §5 named three instances; the build converged two.

## It is chrome-only, on purpose

Builds now wears the frame's chrome. It is deliberately **not** a `BatchPostingSource`, and the descriptor did not move: no generic grouping parameter, no pluggable range, no new slots, no optional fields. `fulfillment-posting/` and `credit-memo-posting/` are untouched, so the frame's public surface did not move either.

Registering builds would have needed **five** widenings, and exactly one caller would ever set four of them:

| | the frame | builds |
|---|---|---|
| range | half-open `YYYY-MM-DD` window it owns state for | two `Date`s, `to` defaulting to now **with a time of day**, bounded above by `inventory.autoBuildEnabledAt`, dynamic caption, "Use the cutoff date" button under the refusal |
| groupings | a static list | computed from **another answer on the same screen** (`rangeGroupingBarred`), plus a reset effect |
| exclusions | `title / dayKey / reason / detail` | Part / Reason / Ordered / Built / On hand, keyed by part, **no date** |
| run gate | always enabled | an acknowledgement `Checkbox` living **inside the preflight card**, not the settings panel |
| result | posted / skipped / failed with doc numbers and group keys | created / left in progress / failed, none of those |

The exclusions row is the one that settles it: mapping builds' table onto the frame's row shape **loses three quantity columns**, which is a behaviour change and therefore off the table. Add a footer with no postings lead and no money total and there is nothing of the frame's own rendering left to share.

This is §5.2's guardrail applied to the frame itself: a pile of optional slots only one caller uses is the same failure as a generic builder.

## What was extracted

- **`batch-dialog-shell.tsx`** — the Dialog, the `DialogNav` crumbs, the plan/result `DialogNavPage` pair, the scroller, the footer container and the result page scaffolding.
- **`batch-dialog-parts.tsx`** — `Note` and `PlanSkeleton`, which were **byte-for-byte duplicates** in both dialogs, plus the stale-opacity wrapper, the settings panel, and an enum row.

The genericity landed on the **enum row**, not the descriptor: the three dialogs ask four such questions and only one of them is a grouping, which is the tell that grouping was never the right thing to parameterise. It takes an explicit `fallback` because the three call sites fall back differently (`source.defaultGrouping`, `'month'`, `'planned'`) and a shared default would have silently changed one of them.

`backfill-dialog.tsx`: 627 → 554.

## Verification

- `typecheck-ratchet --package web` → **no new type errors (0 total, baseline 0)**
- `vitest run src/components` → 258/259 files, **2,699/2,700 tests pass**. The one failure is `manufacturing/parts/receipt-input.test.ts`, which fails on clean `HEAD` too and is recorded in the plan.
- `range.test.ts` → 18/18, file unmodified
- Biome clean

## Scope

Pure web-layer refactor. **No behaviour change in any of the three dialogs**, and nothing under `packages/lib` is touched — the builds lib side, its router, and its plan/exclusion/summary types are all unchanged.

⚠️ None of the three dialogs has component tests, so this needs a smoke test of all three: Post fulfillments, Post credit memos, and Backfill builds (including the cutoff refusal and the acknowledgement gate).

https://claude.ai/code/session_01GuJ494QCELkP7ahfCza2JA
