### PR TITLE
feat(money): fulfillment/fulfillment_line entities, shared stock-movement writer (wave 1)

### DIFF
--- a/apps/web/src/components/returns/hooks/use-salvage-tree.test.ts
+++ b/apps/web/src/components/returns/hooks/use-salvage-tree.test.ts
@@ -1,0 +1,85 @@
+// apps/web/src/components/returns/hooks/use-salvage-tree.test.ts
+
+// The two pure helpers behind §6.6's invariants. Both are what the CARD reads
+// to decide whether to offer an affordance, so a wrong answer here is a wrong
+// affordance, not a wrong number — which is why they are tested apart from the
+// React they are used in.
+
+import { describe, expect, it } from 'vitest'
+import type { SalvageNode } from '../types'
+import { canSplitNode, decidedDescendantCount, MIN_SPLITTABLE_QUANTITY } from './use-salvage-tree'
+
+function node(partial: Partial<SalvageNode> & Pick<SalvageNode, 'key'>): SalvageNode {
+  return {
+    partId: `part-${partial.key}`,
+    partName: `Part ${partial.key}`,
+    partNumber: null,
+    depth: 0,
+    quantity: 1,
+    status: 'undecided',
+    salvagePercent: 100,
+    hasChildren: false,
+    materialized: false,
+    children: null,
+    ...partial,
+  }
+}
+
+describe('canSplitNode', () => {
+  it('refuses a row with nothing to divide', () => {
+    expect(canSplitNode(node({ key: 'a', quantity: 0 }))).toBe(false)
+    expect(canSplitNode(node({ key: 'a', quantity: 1 }))).toBe(false)
+  })
+
+  it('allows a row carrying at least two units', () => {
+    expect(canSplitNode(node({ key: 'a', quantity: MIN_SPLITTABLE_QUANTITY }))).toBe(true)
+    expect(canSplitNode(node({ key: 'a', quantity: 4 }))).toBe(true)
+  })
+})
+
+describe('decidedDescendantCount', () => {
+  it('is zero for an unexpanded branch, because nothing is in memory to count', () => {
+    expect(decidedDescendantCount(node({ key: 'root', hasChildren: true, children: null }))).toBe(0)
+  })
+
+  it('ignores a node with no row — undecided by absence', () => {
+    const root = node({
+      key: 'root',
+      hasChildren: true,
+      children: [node({ key: 'a', materialized: false, status: 'undecided' })],
+    })
+    expect(decidedDescendantCount(root)).toBe(0)
+  })
+
+  it('ignores a materialized row that is still undecided', () => {
+    const root = node({
+      key: 'root',
+      hasChildren: true,
+      children: [node({ key: 'a', materialized: true, status: 'undecided' })],
+    })
+    expect(decidedDescendantCount(root)).toBe(0)
+  })
+
+  it('counts decided rows at every depth, and never the node itself', () => {
+    const root = node({
+      key: 'root',
+      materialized: true,
+      status: 'damaged',
+      hasChildren: true,
+      children: [
+        node({
+          key: 'a',
+          materialized: true,
+          status: 'good',
+          hasChildren: true,
+          children: [
+            node({ key: 'a1', materialized: true, status: 'scrap' }),
+            node({ key: 'a2', materialized: true, status: 'undecided' }),
+          ],
+        }),
+        node({ key: 'b', materialized: true, status: 'missing' }),
+      ],
+    })
+    expect(decidedDescendantCount(root)).toBe(3)
+  })
+})

--- a/apps/web/src/components/returns/hooks/use-salvage-tree.ts
+++ b/apps/web/src/components/returns/hooks/use-salvage-tree.ts
@@ -1,0 +1,138 @@
+// apps/web/src/components/returns/hooks/use-salvage-tree.ts
+'use client'
+
+// Local (never persisted) state for the salvage tree: which rows are open, and
+// which are still fetching their children.
+//
+// 🛑 Expansion is LOCAL and lazy, per plans/money/tasks/54-returns.md §6.6:
+// "Do not explode the whole BOM into `return_part_line` rows when the return
+// line is created." Depth 20 times two lifts is an unbounded row count for a
+// checklist the warehouse may only open two levels of. A node's children are
+// asked for on FIRST expand and cached by the caller from then on; every later
+// open/close of that row is pure client state and costs nothing.
+//
+// Everything here is derived from the node tree the card is handed. The hook
+// owns no copy of the data, so a refetch that changes quantities or statuses
+// cannot go stale against it.
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useMemo, useState } from 'react'
+import type { SalvageNode } from '../types'
+
+/** A row can only be split when it has more than one unit to divide. */
+export const MIN_SPLITTABLE_QUANTITY = 2
+
+/**
+ * How deep the indent is allowed to go, in levels.
+ *
+ * 🛑 `MAX_BOM_DEPTH` is 20 and `GridTreeRow`'s step is 1.5rem, so an uncapped
+ * indent would push 30rem of padding into a first column that is ~8rem wide on
+ * a drawer and narrower on a phone. Past this depth rows stop stepping in; the
+ * connector line stops with them, so the two never disagree.
+ */
+export const MAX_INDENT_DEPTH = 6
+
+/** True when this row has units to divide and is not already covered from above. */
+export function canSplitNode(node: SalvageNode): boolean {
+  return node.quantity >= MIN_SPLITTABLE_QUANTITY
+}
+
+/**
+ * Descendants of this node that a person has already ruled on.
+ *
+ * Best effort by construction: only LOADED children are in memory, so a row
+ * sitting behind an unexpanded branch cannot be counted. It is used to warn
+ * before a `good` supersedes work, never to decide anything.
+ */
+export function decidedDescendantCount(node: SalvageNode): number {
+  let count = 0
+  for (const child of node.children ?? []) {
+    if (child.materialized && child.status !== 'undecided') count += 1
+    count += decidedDescendantCount(child)
+  }
+  return count
+}
+
+export interface SalvageTreeState {
+  /** Is this row showing its children? */
+  isExpanded: (key: string) => boolean
+  /** Is this row waiting on its children to be materialized? */
+  isExpanding: (key: string) => boolean
+  /** Open a closed row (fetching on first open) or close an open one. */
+  toggle: (node: SalvageNode) => void
+  /** Force a row closed — what a `good` does to the branch it just covered. */
+  collapse: (key: string) => void
+}
+
+export interface UseSalvageTreeOptions {
+  /**
+   * Materialize a node's children. Called at most once per node: the resolved
+   * children are expected back on the node tree, after which open/close is
+   * local. A rejection leaves the row closed and raises an error toast.
+   */
+  onExpand: (node: SalvageNode) => void | Promise<void>
+}
+
+/** Expansion state for one salvage tree. */
+export function useSalvageTree({ onExpand }: UseSalvageTreeOptions): SalvageTreeState {
+  const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<string>>(() => new Set())
+  const [expandingKeys, setExpandingKeys] = useState<ReadonlySet<string>>(() => new Set())
+
+  const collapse = useCallback((key: string) => {
+    setExpandedKeys((current) => {
+      if (!current.has(key)) return current
+      const next = new Set(current)
+      next.delete(key)
+      return next
+    })
+  }, [])
+
+  const toggle = useCallback(
+    (node: SalvageNode) => {
+      const { key } = node
+      if (expandedKeys.has(key)) {
+        collapse(key)
+        return
+      }
+      // Already loaded (this session or a previous open) — nothing to fetch.
+      if (node.children !== null) {
+        setExpandedKeys((current) => new Set(current).add(key))
+        return
+      }
+      if (expandingKeys.has(key)) return
+
+      setExpandingKeys((current) => new Set(current).add(key))
+      // `onExpand` may be sync; `Promise.resolve` makes both shapes take the
+      // same path, so a synchronous caller still lands in the same cleanup.
+      Promise.resolve(onExpand(node))
+        .then(() => {
+          setExpandedKeys((current) => new Set(current).add(key))
+        })
+        .catch((error: unknown) => {
+          toastError({
+            title: 'Error loading components',
+            description:
+              error instanceof Error ? error.message : `Could not load ${node.partName}.`,
+          })
+        })
+        .finally(() => {
+          setExpandingKeys((current) => {
+            const next = new Set(current)
+            next.delete(key)
+            return next
+          })
+        })
+    },
+    [collapse, expandedKeys, expandingKeys, onExpand]
+  )
+
+  return useMemo(
+    () => ({
+      isExpanded: (key: string) => expandedKeys.has(key),
+      isExpanding: (key: string) => expandingKeys.has(key),
+      toggle,
+      collapse,
+    }),
+    [collapse, expandedKeys, expandingKeys, toggle]
+  )
+}

--- a/apps/web/src/components/returns/types.ts
+++ b/apps/web/src/components/returns/types.ts
@@ -1,0 +1,78 @@
+// apps/web/src/components/returns/types.ts
+
+// The salvage tree's wire shape (plans/money/tasks/54-returns.md §6.6).
+//
+// 🛑 TEMPORARY HOME. This is declared here only because the `return`,
+// `return_line` and `return_part_line` definitions do not exist yet and
+// `@auxx/lib/returns/client` therefore does not exist either. Wave 2 moves this
+// file's contents there verbatim and rewires the three importers below it; the
+// SHAPE is fixed and must not drift, because the lib side is being written
+// against the identical declaration.
+//
+// A node is NOT the same thing as a `return_part_line` row. The tree the user
+// sees is `loadSubpartGraph`'s in-memory BOM map; a row exists only for a node
+// somebody actually touched (`materialized`). §6.6: "a node with no row is
+// `undecided` by absence", which is what keeps the table small and the salvage
+// writer's input honest.
+
+import type { SelectOptionColor } from '@auxx/types/custom-field'
+
+/** The five conditions a returned component can be in. §3.6. */
+export type SalvageStatus = 'good' | 'damaged' | 'scrap' | 'missing' | 'undecided'
+
+/** One node of the BOM tree hanging off a return line. */
+export interface SalvageNode {
+  /**
+   * Stable identity for this node in THIS tree, unique across the whole tree.
+   *
+   * Not a part id and not a record id: the split button (§6.6) puts two
+   * siblings on the same part under the same parent, so a part id cannot key a
+   * row. Treat it as opaque.
+   */
+  key: string
+  partId: string
+  partName: string
+  partNumber: string | null
+  /** 0-based depth below the return line. Drives the indent. */
+  depth: number
+  /** Prefilled as BOM quantity times the return line's quantity. §6.6. */
+  quantity: number
+  status: SalvageStatus
+  /** 0 < pct <= 100. Only meaningful on a `good` node, which is the only kind that posts. §6.4. */
+  salvagePercent: number
+  /** The BOM says this part has subparts, so the row can be drilled into. */
+  hasChildren: boolean
+  /** A `return_part_line` row exists for this node. `false` means undecided by absence. */
+  materialized: boolean
+  /** `null` means NOT YET EXPANDED — children are materialized on first expand, never up front. */
+  children: SalvageNode[] | null
+}
+
+/**
+ * Status options in the order the warehouse works through them, shaped as
+ * `FieldOptions['options']` so `FieldInputAdapter` renders the same coloured
+ * badge select every other enum in the product gets.
+ */
+export const SALVAGE_STATUS_OPTIONS: Array<{
+  value: SalvageStatus
+  label: string
+  color: SelectOptionColor
+}> = [
+  { value: 'undecided', label: 'Undecided', color: 'gray' },
+  { value: 'good', label: 'Good', color: 'green' },
+  { value: 'damaged', label: 'Damaged', color: 'amber' },
+  { value: 'scrap', label: 'Scrap', color: 'red' },
+  { value: 'missing', label: 'Missing', color: 'orange' },
+]
+
+/** Narrow an unknown select value back to a {@link SalvageStatus}. */
+export function toSalvageStatus(value: unknown): SalvageStatus | null {
+  return SALVAGE_STATUS_OPTIONS.some((option) => option.value === value)
+    ? (value as SalvageStatus)
+    : null
+}
+
+/** Label for a status, for tooltips and confirm copy. */
+export function salvageStatusLabel(status: SalvageStatus): string {
+  return SALVAGE_STATUS_OPTIONS.find((option) => option.value === status)?.label ?? 'Undecided'
+}

--- a/apps/web/src/components/returns/ui/return-salvage-card.tsx
+++ b/apps/web/src/components/returns/ui/return-salvage-card.tsx
@@ -1,0 +1,193 @@
+// apps/web/src/components/returns/ui/return-salvage-card.tsx
+'use client'
+
+// The salvage tree (plans/money/tasks/54-returns.md §6.6): the checklist the
+// warehouse works down when a returned lift is torn down on the dock.
+//
+// 🛑 THIS IS A `CardBlock`, NOT A `RecordsBlock`, and §4.1's table is why.
+// `RecordsBlockConfig` carries source, `statusAttr`, `emptyLabel` and
+// `visibleLimit` and NOTHING else: it renders a read-only list with a status
+// badge it DISPLAYS. This surface needs a number input per row, a status
+// SELECTOR, a split button, lazy child expansion and the parent-implies-children
+// rule, none of which is expressible in config — and `actionsComponent` does not
+// change that, it is a section-level slot, not per-row controls.
+//
+// 🛑 PRESENTATIONAL ONLY, ON PURPOSE. Every byte comes in as a prop and every
+// write goes out as a callback: the `return` / `return_line` /
+// `return_part_line` definitions do not exist yet, so there is no router to
+// call and nothing here may invent one. See the wiring note at the bottom of
+// this comment block.
+//
+// WIRING (wave 2, not this wave): the drawer registry takes a
+// `ComponentType<DrawerTabProps>`, and this component is not one. The one-liner
+// is a sibling container that reads `recordId`, runs the salvage query and the
+// four mutations, and renders this. Register THAT under `'return:salvage'` in
+// `DRAWER_TAB_CARD_COMPONENTS` (the `tabCards` registry — NOT
+// `DRAWER_TAB_COMPONENTS`, which is the whole-tab one), and declare the card in
+// the `return` drawer config's `tabCards`. `drawer-card-parity.test.ts` only
+// asserts declared -> registered, so registering ahead of the declaration is
+// safe; declaring ahead of the component renders nothing, silently.
+
+import { EmptySection } from '@auxx/ui/components/section'
+import { Wrench } from 'lucide-react'
+import { useCallback } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
+import { decidedDescendantCount, useSalvageTree } from '../hooks/use-salvage-tree'
+import type { SalvageNode, SalvageStatus } from '../types'
+import { SALVAGE_COLS, SalvageTreeRow } from './salvage-tree-row'
+
+export interface ReturnSalvageCardProps {
+  /**
+   * The top level of the tree: the return line's own parts. §6.6 —
+   * "Create the top level only, and materialize a node's children on first
+   * expand." A node whose `children` is `null` has never been opened.
+   */
+  nodes: SalvageNode[]
+  /** The top level is still loading. Child loading is the row's own spinner. */
+  isLoading?: boolean
+  /**
+   * Materialize this node's children, resolving once they are on the tree.
+   * Called at most once per node; a rejection raises an error toast and leaves
+   * the row closed.
+   */
+  onExpand: (node: SalvageNode) => void | Promise<void>
+  /** Quantity is prefilled as BOM quantity times the return line's quantity, then edited here. */
+  onChangeQuantity: (node: SalvageNode, quantity: number) => void
+  /**
+   * Write a node's condition. A node with no row is `undecided` by absence, so
+   * the first non-`undecided` write on an unmaterialized node is what creates
+   * its `return_part_line`.
+   */
+  onChangeStatus: (node: SalvageNode, status: SalvageStatus) => void
+  /**
+   * Divide this row into two siblings whose quantities sum to the row's
+   * current quantity — for when the units diverge and one has to be drilled
+   * into. Only offered when `quantity >= 2`, which is what keeps §6.6's second
+   * invariant ("a parent's quantity bounds the sum of its children's") true by
+   * construction on this side.
+   */
+  onSplit: (node: SalvageNode) => void
+  /** No write access, or a return past the point of being edited. */
+  readOnly?: boolean
+}
+
+/**
+ * A multi-level condition checklist over a returned lift's bill of materials.
+ *
+ * A lift is built from subassemblies which have their own subassemblies and the
+ * tree can be deep, so nothing is rendered that has not been asked for: the
+ * card is handed the top level and asks for a node's children the first time
+ * somebody opens it.
+ */
+export function ReturnSalvageCard({
+  nodes,
+  isLoading = false,
+  onExpand,
+  onChangeQuantity,
+  onChangeStatus,
+  onSplit,
+  readOnly = false,
+}: ReturnSalvageCardProps) {
+  const tree = useSalvageTree({ onExpand })
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  /**
+   * A `good` answers for the whole branch beneath it, so selecting one closes
+   * that branch rather than leaving a subtree on screen whose controls no
+   * longer decide anything (§6.6: do not make the user check every descendant).
+   *
+   * When rows below it already carry a decision, that decision is about to stop
+   * counting — one recovery, not two — so it is confirmed first. Best effort by
+   * construction: only LOADED descendants can be counted, and a branch nobody
+   * has opened in this session holds no rows in memory to warn about.
+   */
+  const changeStatus = useCallback(
+    (node: SalvageNode, status: SalvageStatus) => {
+      if (status !== 'good') {
+        onChangeStatus(node, status)
+        return
+      }
+
+      const superseded = decidedDescendantCount(node)
+      const apply = () => {
+        onChangeStatus(node, 'good')
+        tree.collapse(node.key)
+      }
+
+      if (superseded === 0) {
+        apply()
+        return
+      }
+
+      void confirm({
+        title: 'Mark the whole subassembly good?',
+        description: `${superseded} component${superseded === 1 ? '' : 's'} below ${node.partName} already ${superseded === 1 ? 'has' : 'have'} a condition. A good subassembly is recovered whole, so those rows stop counting.`,
+        confirmText: 'Mark good',
+        cancelText: 'Cancel',
+        destructive: true,
+      }).then((confirmed) => {
+        if (confirmed) apply()
+      })
+    },
+    [confirm, onChangeStatus, tree]
+  )
+
+  if (isLoading) return <EmptySection loading />
+
+  if (nodes.length === 0) {
+    return (
+      <EmptySection
+        icon={<Wrench className='size-5' />}
+        title='Nothing to inspect'
+        description='This return line has no bill of materials, so there are no components to salvage.'
+      />
+    )
+  }
+
+  return (
+    <div className='space-y-2'>
+      {/* Header and rows share ONE bordered frame (the `line-builder.tsx` shape)
+          so the grid reads as a single table rather than a stack of loose rows.
+          The header uses the same `SALVAGE_COLS` template and the same `gap-x-2`
+          as the rows — never a second copy of either, which is how a header
+          drifts off its columns. */}
+      <div className='rounded-lg border border-primary-200/50 dark:border-[#1e2227]'>
+        <div
+          className='grid gap-x-2 rounded-t-lg border-primary-200/50 border-b bg-primary-50 px-1 py-2 text-muted-foreground text-sm dark:border-[#1e2227] dark:bg-background'
+          style={{ gridTemplateColumns: SALVAGE_COLS }}>
+          <div className='truncate pl-2'>Component</div>
+          <div className='px-2 text-right'>Qty</div>
+          <div className='px-2'>Condition</div>
+          <div />
+        </div>
+
+        {/* `py-1` and never `p-1`: `GridTreeRow` carries its own `px-1`, and a
+            second horizontal inset here would shift every row's flexible first
+            column off the header's. */}
+        <div className='flex flex-col gap-0.5 py-1'>
+          {nodes.map((node) => (
+            <SalvageTreeRow
+              key={node.key}
+              node={node}
+              tree={tree}
+              impliedGood={false}
+              readOnly={readOnly}
+              onChangeQuantity={onChangeQuantity}
+              onChangeStatus={changeStatus}
+              onSplit={onSplit}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* The absence rule, said out loud. A row nobody touches never becomes a
+          `return_part_line`, and the salvage writer only ever sees real rows. */}
+      <p className='px-1 text-muted-foreground text-xs'>
+        Components you do not touch stay undecided and are not restocked. A subassembly marked good
+        is recovered whole, so there is no need to open it.
+      </p>
+
+      <ConfirmDialog />
+    </div>
+  )
+}

--- a/apps/web/src/components/returns/ui/salvage-tree-row.tsx
+++ b/apps/web/src/components/returns/ui/salvage-tree-row.tsx
@@ -1,0 +1,250 @@
+// apps/web/src/components/returns/ui/salvage-tree-row.tsx
+'use client'
+
+// One node of the salvage tree, and its children (plans/money/tasks/54-returns.md §6.6).
+//
+// The row carries a NUMBER INPUT and a STATUS BADGE SELECTOR and nothing else,
+// which is the owner's spec verbatim: "we don't want all these fields for each
+// row, it would be just one status and the qty. All the photos, notes etc would
+// be on the return item itself" (§3.6). The only other affordance is the split
+// button, and it is on the row because splitting is a property of the row.
+//
+// 🛑 `GridTreeRow`, not `TreeRow`. This tree goes 20 levels deep (`MAX_BOM_DEPTH`)
+// and `TreeRow`'s indent shifts the WHOLE row, so the quantity box and the status
+// badge would walk 1.5rem to the right per level and fall off a phone by level
+// four. `GridTreeRow` puts the indent inside the first cell only, so every
+// control stays at a fixed x at every depth — which is exactly the case the
+// design guide (§7) says to use it for. Both come out of
+// `@auxx/ui/components/tree-row` and both carry `group/tree-row`, so
+// `TreeRowButton` is valid inside either.
+
+import { FieldType } from '@auxx/database/enums'
+import { Badge } from '@auxx/ui/components/badge'
+import { Spinner } from '@auxx/ui/components/spinner'
+import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Boxes, Package, Plus } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { Tooltip } from '~/components/global/tooltip'
+import {
+  canSplitNode,
+  MAX_INDENT_DEPTH,
+  MIN_SPLITTABLE_QUANTITY,
+  type SalvageTreeState,
+} from '../hooks/use-salvage-tree'
+import {
+  SALVAGE_STATUS_OPTIONS,
+  type SalvageNode,
+  type SalvageStatus,
+  toSalvageStatus,
+} from '../types'
+
+/**
+ * Shared `grid-template-columns` for the header and every row, at every depth
+ * (the `OPENING_STOCK_COLS` idiom).
+ *
+ * 🛑 ONE template is what makes the tree a table. Columns: part (fills and
+ * truncates, and absorbs the indent) | quantity | status | split. The bounds
+ * are container-driven, so the middle columns shrink toward a floor on a phone
+ * instead of pushing the row wider than the card.
+ */
+export const SALVAGE_COLS =
+  'minmax(6rem, 1fr) minmax(3.5rem, 4.5rem) minmax(6.5rem, 8.5rem) 1.75rem'
+
+export interface SalvageTreeRowProps {
+  node: SalvageNode
+  tree: SalvageTreeState
+  /**
+   * An ancestor is already `good`, so this row is covered by it and decides
+   * nothing. §6.6 invariant 1: only the highest `good` node in a branch
+   * produces a movement.
+   */
+  impliedGood: boolean
+  /** Nothing on this card can be edited (no write access, a settled return). */
+  readOnly: boolean
+  onChangeQuantity: (node: SalvageNode, quantity: number) => void
+  /** Already wrapped by the card: confirms a superseding `good` and collapses the branch. */
+  onChangeStatus: (node: SalvageNode, status: SalvageStatus) => void
+  onSplit: (node: SalvageNode) => void
+}
+
+export function SalvageTreeRow({
+  node,
+  tree,
+  impliedGood,
+  readOnly,
+  onChangeQuantity,
+  onChangeStatus,
+  onSplit,
+}: SalvageTreeRowProps) {
+  const expanded = tree.isExpanded(node.key)
+  const expanding = tree.isExpanding(node.key)
+  const loaded = node.children !== null
+
+  // A `good` node has already answered for everything beneath it, so drilling
+  // into it would materialize rows that decide nothing. The chevron stays only
+  // when the children are already in memory, so a person can still audit what
+  // they just covered without paying for a fetch.
+  const coveredFromHere = impliedGood || node.status === 'good'
+  const expandable = node.hasChildren && !expanding && (!coveredFromHere || loaded)
+
+  const disabled = readOnly || impliedGood
+
+  return (
+    <GridTreeRow
+      columns={SALVAGE_COLS}
+      // `gap-x-2` keeps the two bordered cells (quantity, status) off each
+      // other — flush borders read as one merged control, and padding inside a
+      // bordered box cannot fix that. The header row carries the same gap.
+      rowClassName={cn('gap-x-2 rounded-md hover:bg-primary-100/60', impliedGood && 'opacity-60')}
+      // Capped: see MAX_INDENT_DEPTH. The connector line reads the same value,
+      // so the line and the indent cannot disagree.
+      depth={Math.min(node.depth, MAX_INDENT_DEPTH)}
+      expandable={expandable}
+      chevronOnHover
+      isOpen={expanded && loaded}
+      onToggleOpen={expandable ? () => tree.toggle(node) : undefined}
+      icon={
+        expanding ? (
+          <Spinner className='size-4 text-muted-foreground' />
+        ) : node.hasChildren ? (
+          <Boxes className='size-4 text-muted-foreground' />
+        ) : (
+          <Package className='size-4 text-muted-foreground' />
+        )
+      }
+      title={
+        <span className='flex min-w-0 items-center gap-1.5'>
+          <span className='min-w-0 truncate text-sm'>{node.partName}</span>
+          {node.partNumber && (
+            <span className='shrink-0 text-muted-foreground text-xs tabular-nums'>
+              {node.partNumber}
+            </span>
+          )}
+          {/* Only a `good` row posts a movement, so the salvage percentage is
+              the one place it means anything. Read-only here: it is a policy on
+              the return line, not a per-row control (§6.4). */}
+          {node.status === 'good' && !impliedGood && node.salvagePercent !== 100 && (
+            <Tooltip content={`Valued at ${node.salvagePercent}% of this part's standard cost.`}>
+              <span className='shrink-0 text-muted-foreground text-xs tabular-nums'>
+                {node.salvagePercent}%
+              </span>
+            </Tooltip>
+          )}
+        </span>
+      }
+      cells={[
+        impliedGood ? (
+          <span
+            key='quantity'
+            className='w-full pr-1.5 text-right text-muted-foreground text-sm tabular-nums'>
+            {node.quantity}
+          </span>
+        ) : (
+          <QuantityCell key='quantity'>
+            <FieldInputAdapter
+              fieldType={FieldType.NUMBER}
+              value={node.quantity}
+              onChange={(value) => onChangeQuantity(node, toQuantity(value))}
+              placeholder='0'
+              disabled={readOnly}
+            />
+          </QuantityCell>
+        ),
+
+        <div key='status' className='flex w-full min-w-0 items-center'>
+          {impliedGood ? (
+            <Tooltip content='Covered by a subassembly above that is marked good. Only the highest good node in a branch is recovered.'>
+              <Badge variant='green' size='sm' className='shrink-0'>
+                Good, implied
+              </Badge>
+            </Tooltip>
+          ) : (
+            <FieldInputAdapter
+              fieldType={FieldType.SINGLE_SELECT}
+              fieldOptions={{ options: SALVAGE_STATUS_OPTIONS }}
+              triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+              value={node.status}
+              onChange={(value) => {
+                const next = toSalvageStatus(value)
+                if (next) onChangeStatus(node, next)
+              }}
+              placeholder='Undecided'
+              disabled={disabled}
+            />
+          )}
+        </div>,
+
+        // 🛑 `persistent`. A `TreeRowButton` is hover-revealed by default, and
+        // the split is not a secondary action here — it is how the warehouse
+        // records that four units of one subassembly did not all survive. There
+        // is no hover on the phone the dock actually uses.
+        <div key='split' className='flex w-full items-center justify-center'>
+          {!disabled && (
+            <Tooltip
+              content={
+                canSplitNode(node)
+                  ? 'Split into two rows, so one part of this quantity can be judged separately.'
+                  : `Needs at least ${MIN_SPLITTABLE_QUANTITY} units to split.`
+              }>
+              {/* The span keeps the tooltip alive over a disabled button. */}
+              <span className='inline-flex'>
+                <TreeRowButton
+                  persistent
+                  aria-label={`Split ${node.partName}`}
+                  disabled={!canSplitNode(node)}
+                  className='disabled:cursor-not-allowed disabled:opacity-40'
+                  onClick={() => onSplit(node)}>
+                  <Plus />
+                </TreeRowButton>
+              </span>
+            </Tooltip>
+          )}
+        </div>,
+      ]}>
+      {node.children?.map((child) => (
+        <SalvageTreeRow
+          key={child.key}
+          node={child}
+          tree={tree}
+          impliedGood={coveredFromHere}
+          readOnly={readOnly}
+          onChangeQuantity={onChangeQuantity}
+          onChangeStatus={onChangeStatus}
+          onSplit={onSplit}
+        />
+      ))}
+    </GridTreeRow>
+  )
+}
+
+/** A quantity the input can round-trip: never negative, never NaN. */
+function toQuantity(value: unknown): number {
+  const next = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(next) && next > 0 ? next : 0
+}
+
+/**
+ * The bordered 28px box that stops an editable cell reading as loose text —
+ * the `opening-stock-list.tsx` / `receive-purchase-order-dialog.tsx` recipe.
+ *
+ * ⚠️ THE CELL CARRIES THE BORDER, never the input: the field inside is
+ * chromeless on purpose (`border-0 bg-transparent!` in `node-inputs`), and
+ * `FieldInputAdapter` takes no `className`, so every class below has to be
+ * pushed onto it from out here. The increment arrows are hidden because nobody
+ * counting a pallet presses one and the pair costs 24px of a fixed column.
+ */
+function QuantityCell({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className={cn(
+        'flex h-7 w-full shrink-0 items-center rounded-md border border-primary-200 ring-1 ring-transparent transition-colors focus-within:bg-muted/60 focus-within:ring-ring/30 hover:bg-muted/60',
+        '[&_[data-slot=input-group]]:h-full [&_[data-slot=input-group]]:min-h-0',
+        '[&_input]:tabular-nums [&_input]:text-right',
+        '[&_div:has(>button[aria-label=Increment])]:hidden'
+      )}>
+      {children}
+    </div>
+  )
+}

--- a/docs/app-fields-and-entities-guide.md
+++ b/docs/app-fields-and-entities-guide.md
@@ -198,26 +198,34 @@ Each field carries:
 
 ### `targetEntity` kinds
 
-`EntityRefKind` (`packages/sdk/src/root/tools/types.ts`), re-verified 2026-09-10, is today:
+`EntityRefKind` (`packages/sdk/src/root/tools/types.ts`), re-verified 2026-09-11, is today:
 
 ```
 contact · company · ticket · article · thread · order · invoice · line_item ·
 catalog_item · part · product · build · purchase_order · vendor_bill ·
 gl_account · credit_memo · credit_memo_line · credit_memo_application ·
-tax_line · shipment · parcel
+tax_line · shipment · parcel · fulfillment · fulfillment_line
 ```
 
 `line_item` landed as the apps plan's Phase 1 item 3.10 (the Shopify brief's line columns, §5
 there); this guide's worked examples in §5 already use it. The four credit-memo and tax kinds
-arrived with entity migration 136, and `shipment` / `parcel` with 149.
+arrived with entity migration 136, `shipment` / `parcel` with 149, and `fulfillment` /
+`fulfillment_line` with 153 (`plans/money/tasks/55-shipment-lines.md`).
 
-**Seven of those kinds are `isVisible: false`** and were admitted anyway: `line_item`,
-`credit_memo_line`, `tax_line`, `credit_memo_application`, `shipment` and `parcel`. That is not a
-loophole in the narrowness rule below, it is the rule's actual shape. The union's own doc comment
-records that the first three were admitted **precisely so a channel connector could address them**,
-and the same argument admitted the last two: a parcel is one physical box with one tracking number,
-which is the fact a support agent needs, and no single app owns it. See
-`plans/apps/shipstation/shared-shipment-entities-proposal.md` §2.
+**Eight of those kinds are `isVisible: false`** and were admitted anyway: `line_item`,
+`credit_memo_line`, `tax_line`, `credit_memo_application`, `shipment`, `parcel`, `fulfillment` and
+`fulfillment_line`. That is not a loophole in the narrowness rule below, it is the rule's actual
+shape. The union's own doc comment records that the first three were admitted **precisely so a
+channel connector could address them**, and the same argument admitted the rest: a parcel is one
+physical box with one tracking number, which is the fact a support agent needs, and no single app
+owns it; a `fulfillment_line` is which units of an order line went out in one dispatch, which
+Shopify supplies per fulfillment and the connector currently discards. See
+`plans/apps/shipstation/shared-shipment-entities-proposal.md` §2 and
+`plans/money/tasks/55-shipment-lines.md` §1.
+
+⚠️ This paragraph read "Seven" while naming six kinds before `fulfillment` was added. The count was
+already off by one against its own list; `gl_account` is also `isVisible: false` but is treated
+separately below as the deliberate exception, so it is not counted here.
 
 What matters for admission is not visibility, it is whether a migration has seeded the kind into
 EXISTING orgs. A kind that lives only in `SYSTEM_ENTITIES` reaches new orgs and nothing else.

--- a/docs/inventory-costing-architecture-guide.md
+++ b/docs/inventory-costing-architecture-guide.md
@@ -1349,6 +1349,17 @@ JSON log joined to `GlPosting`; `plan.ts` is pure; `run.ts` never throws). Facts
   plan, so a `zero-value` shipment does not hold a month open.
 - The inventory relief of a shipment (a `sale` movement) is **still not built**; nothing
   in the tree writes that kind. Brief 50.
+  ⤵️ **2026-09-11: the design changed and so did its prerequisite.** Relief is one `sale` movement
+  per **`fulfillment_line`** for `quantity - quantity_relieved` - the exact sell-side mirror of
+  `purchase_order_line -> receive movement -> quantity_received` - written automatically on the
+  quiet lane with one post-commit `batchRecalculateQoH`, and **frozen at the part's ledger-derived
+  average**, never at `part_standard_cost` (which drifts permanently, because a standard-cost roll
+  never posts its revaluation delta). 🛑 It is BLOCKED on brief 55: `order_fulfillments` is being
+  retyped from the JSON cell described below into a has_many of `fulfillment` / `fulfillment_line`,
+  because the Shopify connector currently discards the per-dispatch grain it already receives.
+  **Everything in §9 about `order_fulfillments` being a JSON log describes the tree as it stands
+  today and is scheduled to become wrong.** See `plans/money/tasks/55-shipment-lines.md` and
+  decisions `D21` / `D22` / `D23`.
 
 ## 10. Write Lanes & the Silent Ledger Write
 

--- a/packages/lib/src/builds/complete-build.ts
+++ b/packages/lib/src/builds/complete-build.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/builds/complete-build.ts
 
 /**
- * `completeBuild` — the ONLY function in this module that writes a stock
+ * `completeBuild` - the ONLY function in this module that writes a stock
  * movement, and the one heavy write in the whole directory.
  *
  * plans/products/build/01-build-plan.md section 3.4, README B2/B4/B7/B8.
@@ -15,7 +15,7 @@
  *
  * That pair is the event the system could not record before this file existed,
  * and it is why margin was unavailable: not because parts had no cost, but
- * because nothing ever wrote a cost DOWN. `part_cost` is a live mirror — a
+ * because nothing ever wrote a cost DOWN. `part_cost` is a live mirror - a
  * vendor raising the motor price in March silently restates January's COGS.
  * Every number this function writes is read from `part_standard_cost`, frozen
  * onto an append-only row, and never recomputed.
@@ -28,7 +28,7 @@
  *    recalc therefore runs {@link recalculateAfterCommit}, after the
  *    transaction returns, never inside it.
  * 2. **The write lane.** One quiet session, decided in `write-lane.ts` and
- *    nowhere else. Read that file before changing it — `skipEvents: true` closes
+ *    nowhere else. Read that file before changing it - `skipEvents: true` closes
  *    only one of the two dispatch doors.
  * 3. **Batch the recalc.** Quantity on hand is a full re-SUM per part on every
  *    movement write; a build writing 51 movements would make that 51x worse in a
@@ -62,6 +62,7 @@ import {
   StockMovementType,
 } from '../resources/registry/enum-values'
 import { type RecordId, toRecordId } from '../resources/resource-id'
+import { type StockMovementInput, writeStockMovements } from '../stock-movements'
 import { BUILD_STATUS_BYPASS } from './build-mutations'
 import {
   assertBuildStatus,
@@ -94,10 +95,10 @@ const logger = createScopedLogger('builds:complete')
  * The order of the steps is the contract:
  *
  * 1. Re-read the build `FOR UPDATE` and refuse unless it is `planned` or
- *    `in_progress`. **B8 — one completion per build.** The lock is what makes
+ *    `in_progress`. **B8 - one completion per build.** The lock is what makes
  *    that a rule rather than a race; a run finished in tranches is a second
  *    build.
- * 2. Resolve components with `loadDirectSubparts` — **direct only** (B4).
+ * 2. Resolve components with `loadDirectSubparts` - **direct only** (B4).
  * 3. Value every line at its `part_standard_cost`. **If any component has none,
  *    abort with `UnprocessableEntityError` naming the parts.** Never post a zero
  *    cost: a zero-cost consume row understates COGS, drags every downstream
@@ -214,7 +215,7 @@ async function writeCompletion(
     args
   const txDb = tx as unknown as Database
 
-  // Step 1. The lock IS B8's enforcement — see `lockBuild`.
+  // Step 1. The lock IS B8's enforcement - see `lockBuild`.
   const build = await lockBuild(tx, organizationId, ctx, input.buildId)
   assertBuildStatus(
     build,
@@ -259,7 +260,7 @@ async function writeCompletion(
   // 🛑 The SAME function the completion form runs to preview these five numbers
   // (`client.ts`). The form has to show the variance before the write, because a
   // completion is irreversible except by a reversing build (B6) and refuses a
-  // second attempt (B8) — and a preview computed by a second implementation is
+  // second attempt (B8) - and a preview computed by a second implementation is
   // only accidentally the number that gets stored.
   const { materialCost, laborCost, overheadCost, producedValue, varianceAmount } =
     summarizeBuildCompletion({
@@ -273,78 +274,109 @@ async function writeCompletion(
     })
 
   const producedKinds = await readPartKinds(txDb, organizationId, [build.partId])
+  // The one construction site for the quiet lane. See `write-lane.ts`.
+  const buildSession = buildWriteSession()
   const crud = new UnifiedCrudHandler(organizationId, userId, txDb, undefined, {
-    // The one construction site for the quiet lane. See `write-lane.ts`.
-    session: buildWriteSession(),
+    session: buildSession,
     // 🛑 Step 6 writes `build_status: 'completed'`, which
     // `field-hooks/pre/build-status-guard.ts` refuses on a manual write. Without this the
     // wall built to protect the ledger would refuse the only function that writes it.
-    // ⚠️ The movement `create`s below share this handler and so inherit the set; that is
-    // safe only because it names `build_status` alone and `stock_movement` has no such
+    // ⚠️ `stock-movements.writeStockMovements` below is handed the same session and the
+    // same `bypassFieldGuards` set (the shared `movementLane` object), and that is safe
+    // only because it names `build_status` alone and `stock_movement` has no such
     // attribute.
     bypassFieldGuards: BUILD_STATUS_BYPASS,
   })
+  const movementLane = {
+    kind: 'quiet' as const,
+    session: buildSession,
+    bypassFieldGuards: BUILD_STATUS_BYPASS,
+  }
+  const movementCtxArgs = {
+    db: txDb,
+    organizationId,
+    userId,
+    movementDefId: movementCtx.movementDefId,
+    partDefId: movementCtx.partDefId,
+    lane: movementLane,
+    // The SAME handler `crud.update` below writes `build_status` through -
+    // `build-event.test.ts` pins exactly one quiet-lane `UnifiedCrudHandler`
+    // construction per completion. See `StockMovementsCtx.handler`.
+    handler: crud,
+  }
 
   const buildRecordId = toRecordId(ctx.buildDefId, build.buildId)
-  const movementIds: string[] = []
 
-  // Step 4: one `build_consume` per component, at the NEGATED quantity.
-  for (const line of plan.components) {
-    const values: Record<string, unknown> = {
-      stock_movement_part: toRecordId(movementCtx.partDefId, line.partId),
-      stock_movement_type: StockMovementType.BUILD_CONSUME,
-      stock_movement_quantity: -line.quantityConsumed,
-      // See the file header, trap 4. Never true on a build row.
-      stock_movement_adjust_subparts: false,
-      stock_movement_build: buildRecordId,
-      stock_movement_unit_cost: line.unitCost,
-      // Negated from the POSITIVE extended cost the plan computed, so the row
-      // and `materialCost` cannot disagree by a rounding step. Deriving it from
-      // `round(unitCost x -consumed)` instead would differ on a half-cent tail,
-      // because `Math.round` breaks ties toward positive infinity.
-      stock_movement_extended_cost: -(line.extendedCost ?? 0),
-      stock_movement_gl_account: line.glAccount,
-      stock_movement_cost_basis: StockMovementCostBasis.STANDARD,
-      stock_movement_occurred_at: completedAt.toISOString(),
-    }
+  // Step 4: one `build_consume` per component, at the NEGATED quantity, through
+  // the shared `stock-movements.writeStockMovements`
+  // (plans/money/tasks/50-batch-inventory-relief.md §2).
+  const consumeInputs: StockMovementInput[] = plan.components.map((line) => ({
+    partInstanceId: line.partId,
+    type: StockMovementType.BUILD_CONSUME,
+    quantity: -line.quantityConsumed,
+    // Non-null by construction: `assertPlanIsPostable` refuses a plan carrying
+    // any component with no standard cost before this point is ever reached.
+    unitCost: line.unitCost as number,
+    // Negated from the POSITIVE extended cost the plan computed, so the row
+    // and `materialCost` cannot disagree by a rounding step. Deriving it from
+    // `round(unitCost x -consumed)` instead would differ on a half-cent tail,
+    // because `Math.round` breaks ties toward positive infinity - the ONE
+    // documented `extendedCost` override (50 §2.2).
+    extendedCost: -(line.extendedCost ?? 0),
+    glAccount: line.glAccount,
+    costBasis: StockMovementCostBasis.STANDARD,
+    occurredAt: completedAt,
     // NULL is the OFF-BOM marker and is written as an absence, not a zero: a
     // stamped `0` would claim the bill of materials calls for none of this
     // component, which is a different and false statement.
-    if (line.qtyPerUnit != null) values.stock_movement_qty_per_unit = line.qtyPerUnit
+    qtyPerUnit: line.qtyPerUnit,
+    links: { buildId: buildRecordId },
+  }))
 
-    const created = await crud.create(movementCtx.movementDefId, values)
-    movementIds.push(created.instance.id)
-  }
+  const consumeWritten = await writeStockMovements(movementCtxArgs, consumeInputs)
+  if (consumeWritten.isErr()) throw consumeWritten.error
 
   // Step 5: the single `build_produce`.
   //
   // ⚠️ The account is resolved from the produced part's OWN `part_kind`, not
-  // hard-coded to 1330. Section 3.4 names 1330 because the case it describes is
-  // a finished good, and for a finished good this resolves to exactly that. A
-  // SUBASSEMBLY build stamped 1330 would put raw-materials stock into Finished
-  // Goods, contradicting the part-kind account map that receiving already uses
-  // (products/01 section 4) and overstating 1330 on every subassembly run.
-  const produceValues: Record<string, unknown> = {
-    stock_movement_part: toRecordId(movementCtx.partDefId, build.partId),
-    stock_movement_type: StockMovementType.BUILD_PRODUCE,
-    // 🛑 `quantityProduced`, never `unitsStarted`. B7: scrapped units consume
-    // material and produce NO movement. Their cost falls out in
-    // `varianceAmount` instead of being absorbed into the survivors, because
-    // absorbing it would give the same variant a different unit cost on every
-    // run and destroy the point of a standard.
-    stock_movement_quantity: quantityProduced,
-    stock_movement_adjust_subparts: false,
-    stock_movement_build: buildRecordId,
-    stock_movement_unit_cost: producedUnitCost,
-    stock_movement_extended_cost: producedValue,
-    stock_movement_gl_account: resolveInventoryRoleForPartKind(
-      producedKinds.get(build.partId) ?? null
-    ),
-    stock_movement_cost_basis: StockMovementCostBasis.STANDARD,
-    stock_movement_occurred_at: completedAt.toISOString(),
-  }
-  const produce = await crud.create(movementCtx.movementDefId, produceValues)
-  movementIds.push(produce.instance.id)
+  // hard-coded to 1330, and - load-bearing for
+  // `complete-build-transaction.int.test.ts` - resolved HERE, after every
+  // consume row above has already been written. Section 3.4 names 1330
+  // because the case it describes is a finished good, and for a finished good
+  // this resolves to exactly that. A SUBASSEMBLY build stamped 1330 would put
+  // raw-materials stock into Finished Goods, contradicting the part-kind
+  // account map that receiving already uses (products/01 section 4) and
+  // overstating 1330 on every subassembly run.
+  const produceGlAccount = resolveInventoryRoleForPartKind(producedKinds.get(build.partId) ?? null)
+
+  const produceInputs: StockMovementInput[] = [
+    {
+      partInstanceId: build.partId,
+      type: StockMovementType.BUILD_PRODUCE,
+      // 🛑 `quantityProduced`, never `unitsStarted`. B7: scrapped units consume
+      // material and produce NO movement. Their cost falls out in
+      // `varianceAmount` instead of being absorbed into the survivors, because
+      // absorbing it would give the same variant a different unit cost on
+      // every run and destroy the point of a standard.
+      quantity: quantityProduced,
+      unitCost: producedUnitCost,
+      extendedCost: producedValue,
+      glAccount: produceGlAccount,
+      costBasis: StockMovementCostBasis.STANDARD,
+      occurredAt: completedAt,
+      links: { buildId: buildRecordId },
+    },
+  ]
+
+  const produceWritten = await writeStockMovements(movementCtxArgs, produceInputs)
+  if (produceWritten.isErr()) throw produceWritten.error
+
+  // Consumes first then the single produce - `CompleteBuildResult.movementIds`
+  // documents that order.
+  const movementIds = [
+    ...consumeWritten.value.records.map((record) => record.movementId),
+    ...produceWritten.value.records.map((record) => record.movementId),
+  ]
 
   // Step 6.
   const buildValues: Record<string, unknown> = {
@@ -376,7 +408,16 @@ async function writeCompletion(
       producedValue,
       varianceAmount,
       movementIds,
-      recalculatedPartIds: [build.partId, ...plan.components.map((line) => line.partId)],
+      // §2.4 item 3: RETURNED by every `writeStockMovements` call, not
+      // re-derived - the quiet lane's recalc obligation is then structural
+      // rather than something this file has to remember to keep in sync with
+      // what was actually written.
+      recalculatedPartIds: [
+        ...new Set([
+          ...consumeWritten.value.affectedPartIds,
+          ...produceWritten.value.affectedPartIds,
+        ]),
+      ],
     },
   }
 }
@@ -400,7 +441,7 @@ export async function recalculateAfterCommit(
  * 🛑 **Never post a zero cost.** `readStandardCost` omits a part that has never
  * been rolled rather than defaulting it, precisely so this check can exist: a
  * missing standard is a refusal, not a zero. The two failure modes it prevents
- * are the same failure seen from either end — an unvalued consume row
+ * are the same failure seen from either end - an unvalued consume row
  * understates COGS forever, and an unvalued produce row creates inventory at
  * nothing.
  */

--- a/packages/lib/src/builds/reverse-build.ts
+++ b/packages/lib/src/builds/reverse-build.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/builds/reverse-build.ts
 
 /**
- * `reverseBuild` — the inverse of {@link completeBuild}.
+ * `reverseBuild` - the inverse of {@link completeBuild}.
  *
  * plans/products/build/01-build-plan.md section 3.4, README B6.
  *
@@ -14,7 +14,7 @@
  *
  * ## Why this does not reuse `receiving/reverse-movement.ts`
  *
- * That function exists, it is good, and it is the wrong shape here — four ways,
+ * That function exists, it is good, and it is the wrong shape here - four ways,
  * each of which would be a silent defect rather than a compile error:
  *
  * 1. **It re-types the row.** Its `REVERSAL_TYPE_BY_ORIGINAL` map deliberately
@@ -27,17 +27,18 @@
  * 2. **It cannot set `stock_movement_build`.** The reversing rows would be
  *    orphaned from the reversing build, `build_movements` would be empty, and
  *    a second reversal would have nothing to read back.
- * 3. **It does not copy `qty_per_unit`**, so the as-built BOM snapshot — the
- *    whole point of that column — is lost on the negation.
+ * 3. **It does not copy `qty_per_unit`**, so the as-built BOM snapshot - the
+ *    whole point of that column - is lost on the negation.
  * 4. **It is one movement, on the inline lane, outside any transaction.** A
  *    51-row build would become 51 independently-refusable operations and 51 full
  *    quantity-on-hand re-SUMs, and a failure half way through would leave a
  *    ledger that is neither the build nor its reversal.
  *
- * What IS reused is its two refusals, verbatim in spirit — a build is reversed
- * at most once, and a reversal is never itself reversed — plus
- * `computeExtendedCost`, so a reversal is identical in magnitude to the run it
- * undoes. Every reversing movement also points its
+ * What IS reused is its two refusals, verbatim in spirit - a build is reversed
+ * at most once, and a reversal is never itself reversed - plus the shared
+ * `stock-movements.writeStockMovements` (plans/money/tasks/50-batch-inventory-relief.md
+ * §2), whose `computeExtendedCost` fallback is what keeps a reversal identical
+ * in magnitude to the run it undoes. Every reversing movement also points its
  * `stock_movement_reverses_movement` at the row it negates, which is what makes
  * `reverseMovement`'s own already-reversed guard refuse to correct a movement
  * that this function has already undone.
@@ -50,10 +51,10 @@ import type { Database, Transaction } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Result } from 'neverthrow'
 import { BadRequestError, ConflictError, UnprocessableEntityError } from '../errors'
-import { computeExtendedCost } from '../receiving/client'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { BuildStatus, StockMovementCostBasis } from '../resources/registry/enum-values'
 import { toRecordId } from '../resources/resource-id'
+import { type StockMovementInput, writeStockMovements } from '../stock-movements'
 import { BUILD_STATUS_BYPASS, requireDefId } from './build-mutations'
 import {
   assertBuildStatus,
@@ -79,18 +80,18 @@ const logger = createScopedLogger('builds:reverse')
  * The order of the steps is the contract:
  *
  * 1. Re-read the original `FOR UPDATE`; refuse unless it is `completed`. A
- *    `planned` build has written nothing (B2) — cancel it instead.
+ *    `planned` build has written nothing (B2) - cancel it instead.
  * 2. Refuse a build that is ALREADY reversed (`ConflictError`). A second
  *    reversal would double the negation, and because every roll-up downstream
  *    re-SUMs rather than increments, the wrong number would look exactly as
  *    authoritative as the right one.
  * 3. Refuse to reverse a reversal (`BadRequestError`). The correction of an
- *    over-correction is a fresh build, not a chain of undos — a chain makes "is
+ *    over-correction is a fresh build, not a chain of undos - a chain makes "is
  *    this build live?" a graph walk instead of a lookup.
  * 4. Write ONE new build plus one negated movement per original movement, in a
  *    single transaction, carrying the originals' frozen costs verbatim.
  *
- * Then, after the commit, one batched quantity-on-hand recalculation — the same
+ * Then, after the commit, one batched quantity-on-hand recalculation - the same
  * rule, and the same reason, as `completeBuild`.
  */
 export async function reverseBuild(
@@ -120,7 +121,7 @@ export async function reverseBuild(
       )
 
       await recalculateAfterCommit(organizationId, result.recalculatedPartIds)
-      // Two frames, two defs — a reversal writes on BOTH.
+      // Two frames, two defs - a reversal writes on BOTH.
       //
       // The movements, so the reversing build's own ledger renders. And the
       // `build` ROW, which `completeBuild` never has to announce because its row
@@ -190,12 +191,13 @@ async function writeReversal(
   }
 
   // Step 4.
+  // The same quiet lane the completion takes, for the same reasons - see
+  // `write-lane.ts` and `complete-build.ts`'s header.
+  const reversalSession = buildWriteSession()
   const crud = new UnifiedCrudHandler(organizationId, userId, txDb, undefined, {
-    // The same quiet lane the completion takes, for the same reasons — see
-    // `write-lane.ts` and `complete-build.ts`'s header.
-    session: buildWriteSession(),
+    session: reversalSession,
     // 🛑 The reversing build is CREATED at `completed` (there is no planned reversal), and
-    // the field pre-hook chain has no `operation === 'create'` exemption — a create carrying
+    // the field pre-hook chain has no `operation === 'create'` exemption - a create carrying
     // a guarded value is refused exactly like an update. Without this, B6's only correction
     // for a posted run stops working.
     bypassFieldGuards: BUILD_STATUS_BYPASS,
@@ -211,52 +213,68 @@ async function writeReversal(
   )
   const reversalRecordId = toRecordId(ctx.buildDefId, reversalBuild.instance.id)
 
-  const movementIds: string[] = []
-  for (const movement of movements) {
+  // One negated `stock_movement` per original, through the shared
+  // `stock-movements.writeStockMovements`
+  // (plans/money/tasks/50-batch-inventory-relief.md §2). No live,
+  // order-dependent computation runs between rows here (unlike
+  // `complete-build.ts`'s produce row), so the whole batch goes through in one
+  // call.
+  const movementInputs: StockMovementInput[] = movements.map((movement) => {
     const quantity = -movement.quantity
-    const values: Record<string, unknown> = {
-      stock_movement_part: toRecordId(movementCtx.partDefId, movement.partId),
+    return {
+      partInstanceId: movement.partId,
       // 🛑 The TYPE is carried verbatim. A negated `build_consume` is still the
       // consume leg of a build; re-labelling it would break the pairing that
       // makes `SUM` over `build_consume` mean "material issued to production".
-      stock_movement_type: movement.type,
-      stock_movement_quantity: quantity,
-      // The build does its own explosion on the way out and on the way back.
-      stock_movement_adjust_subparts: false,
-      stock_movement_build: reversalRecordId,
+      type: movement.type,
+      quantity,
       // 🛑 The ORIGINAL's frozen cost, never today's. A reversal valued at the
       // current standard nets a build and its undo to a non-zero amount of
       // inventory value out of nothing.
-      stock_movement_unit_cost: movement.unitCost,
-      stock_movement_extended_cost:
-        movement.extendedCost != null
-          ? -movement.extendedCost
-          : computeExtendedCost(movement.unitCost, quantity),
-      // Points at the row it negates, so `reverseMovement`'s already-reversed
-      // guard refuses to correct a movement this build has already undone.
-      stock_movement_reverses_movement: toRecordId(movementCtx.movementDefId, movement.movementId),
-      stock_movement_occurred_at: occurredAt.toISOString(),
+      unitCost: movement.unitCost,
+      extendedCost: movement.extendedCost != null ? -movement.extendedCost : undefined,
+      // The basis follows the cost: a row carrying the original's frozen
+      // `standard` cost is still a `standard`, and re-deciding it here would
+      // let a reversal disagree with the movement it is a copy of.
+      costBasis: movement.costBasis ?? StockMovementCostBasis.STANDARD,
+      glAccount: movement.glAccount ?? undefined,
+      occurredAt,
+      // Copied, not recomputed. The as-built snapshot describes the run that
+      // happened, and the reversal describes the same run.
+      qtyPerUnit: movement.qtyPerUnit,
+      reason: input.reason,
+      links: {
+        buildId: reversalRecordId,
+        // Points at the row it negates, so `reverseMovement`'s already-reversed
+        // guard refuses to correct a movement this build has already undone.
+        reversesMovementId: movement.movementId,
+      },
     }
-    // The basis follows the cost: a row carrying the original's frozen
-    // `standard` cost is still a `standard`, and re-deciding it here would let a
-    // reversal disagree with the movement it is a copy of.
-    values.stock_movement_cost_basis = movement.costBasis ?? StockMovementCostBasis.STANDARD
-    if (movement.glAccount) values.stock_movement_gl_account = movement.glAccount
-    // Copied, not recomputed. The as-built snapshot describes the run that
-    // happened, and the reversal describes the same run.
-    if (movement.qtyPerUnit != null) values.stock_movement_qty_per_unit = movement.qtyPerUnit
-    if (input.reason) values.stock_movement_reason = input.reason
+  })
 
-    const created = await crud.create(movementCtx.movementDefId, values)
-    movementIds.push(created.instance.id)
-  }
+  const written = await writeStockMovements(
+    {
+      db: txDb,
+      organizationId,
+      userId,
+      movementDefId: movementCtx.movementDefId,
+      partDefId: movementCtx.partDefId,
+      lane: { kind: 'quiet', session: reversalSession, bypassFieldGuards: BUILD_STATUS_BYPASS },
+      // The SAME handler the reversal `build` row was created through -
+      // `build-event.test.ts` pins exactly one bypass-carrying
+      // `UnifiedCrudHandler` construction per reversal.
+      handler: crud,
+    },
+    movementInputs
+  )
+  if (written.isErr()) throw written.error
 
   return {
     buildId: reversalBuild.instance.id,
     recordId: reversalRecordId,
     reversalOfBuildId: original.buildId,
-    movementIds,
-    recalculatedPartIds: [...new Set(movements.map((movement) => movement.partId))],
+    movementIds: written.value.records.map((record) => record.movementId),
+    recalculatedPartIds: written.value.affectedPartIds,
   }
 }
 
@@ -264,15 +282,15 @@ async function writeReversal(
  * The reversing build's own row.
  *
  * Every quantity and every cost is the original's, negated. It lands
- * `completed` because it IS complete the moment it is written — there is no
- * planned reversal — and its `completedAt` is the reversal's accounting date,
+ * `completed` because it IS complete the moment it is written - there is no
+ * planned reversal - and its `completedAt` is the reversal's accounting date,
  * not the original's, so the correction falls in the period it was made rather
  * than reopening the period being corrected.
  *
  * Negating the quantities as well as the costs is what makes any report that
  * sums build output over a range net to zero across the pair. A reversal with a
  * positive `quantityProduced` would double-count production while its movements
- * cancelled out — two answers to "how many did we build", both from our own
+ * cancelled out - two answers to "how many did we build", both from our own
  * data.
  */
 function reversalBuildValues(

--- a/packages/lib/src/data-migrations/migrations/153-fulfillment-lines.test.ts
+++ b/packages/lib/src/data-migrations/migrations/153-fulfillment-lines.test.ts
@@ -1,0 +1,240 @@
+// packages/lib/src/data-migrations/migrations/153-fulfillment-lines.test.ts
+//
+// Migration 153 is the richest shape in this directory: two new defs (149's
+// shape) PLUS a field that changes TYPE under the same name (152's shape,
+// but the old row has to be found and dropped first rather than merely
+// added to). What actually goes wrong here:
+//
+//  - `order_fulfillments` keeps its systemAttribute, so `ensureCustomFields`'s
+//    own existence check (keyed on entityDefinitionId + systemAttribute)
+//    would see the OLD JSON row and skip creating the new RELATIONSHIP one
+//    entirely, silently leaving the field the wrong type forever;
+//  - the drop has to be gated on the stored `type`, or a re-run after this
+//    migration already applied would delete the NEW field it just created;
+//  - every has_many/belongs_to pair has to actually resolve - an unlinked
+//    inverse is worse than a missing field (135's lesson);
+//  - `fulfillment.shipment` is the one relationship in this migration that
+//    is DELIBERATELY never linked, and the assertion list must not choke on
+//    it;
+//  - a new entity type is a hand-edit across several files, and a type
+//    present in one registry and missing from its sibling silently seeds a
+//    zero-field def (149's own test pins this same checklist).
+
+import { ENTITY_DEFINITION_TYPES } from '@auxx/types/resource'
+import { SYSTEM_ATTRIBUTES } from '@auxx/types/system-attribute'
+import { describe, expect, it } from 'vitest'
+import { FulfillmentStatus } from '../../resources/registry/enum-values'
+import { RESOURCE_FIELD_REGISTRY } from '../../resources/registry/field-registry'
+import { FULFILLMENT_FIELDS } from '../../resources/registry/resources/fulfillment-fields'
+import { FULFILLMENT_LINE_FIELDS } from '../../resources/registry/resources/fulfillment-line-fields'
+import { LINE_ITEM_FIELDS } from '../../resources/registry/resources/line-item-fields'
+import { ORDER_FIELDS } from '../../resources/registry/resources/order-fields'
+import { STOCK_MOVEMENT_FIELDS } from '../../resources/registry/resources/stock-movement-fields'
+import { DISPLAY_FIELD_CONFIG, SYSTEM_ENTITIES } from '../../seed/entity-seeder/constants'
+import { FIELD_REGISTRY } from '../../seed/entity-seeder/create-fields'
+import { ALL_DATA_MIGRATIONS, PER_ORG_MIGRATIONS } from '../registry'
+import { migration153FulfillmentLines } from './153-fulfillment-lines'
+
+const MIGRATION_ID = '153-fulfillment-lines'
+
+describe('migration 153 registration', () => {
+  it('is registered exactly once, with a unique id', () => {
+    const ids = PER_ORG_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('is the only migration claiming the number 153', () => {
+    const numbers = ALL_DATA_MIGRATIONS.map((m) => m.id.split('-')[0])
+    expect(numbers.filter((n) => n === '153')).toHaveLength(1)
+  })
+
+  it('exports the migration it registers', () => {
+    expect(PER_ORG_MIGRATIONS).toContain(migration153FulfillmentLines)
+  })
+
+  it('reaches the shared data-migration registry without an entry of its own, sorted by id', () => {
+    const ids = ALL_DATA_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === MIGRATION_ID)).toHaveLength(1)
+    expect([...ids]).toEqual([...ids].sort((a, b) => a.localeCompare(b)))
+  })
+})
+
+describe.each([
+  ['fulfillment', 'fulfillments', FULFILLMENT_FIELDS],
+  ['fulfillment_line', 'fulfillment-lines', FULFILLMENT_LINE_FIELDS],
+] as const)('%s is registered everywhere a hidden def has to be', (type, apiSlug, fields) => {
+  it('is an EntityDefinitionType, so a <type>:<id> RecordId canonicalizes', () => {
+    expect(ENTITY_DEFINITION_TYPES).toContain(type)
+  })
+
+  it('resolves the SAME field map in both registries used by the two seeders', () => {
+    // Object identity: `createAllFields` iterates FIELD_REGISTRY while
+    // `createEntityDefinitions` iterates SYSTEM_ENTITIES, so a type in the
+    // second and not the first lands on a new org as a definition with ZERO
+    // fields, and UnifiedCrudHandler silently drops every value.
+    expect(RESOURCE_FIELD_REGISTRY[type]).toBe(fields)
+    expect(FIELD_REGISTRY[type]).toBe(fields)
+  })
+
+  it('is a HIDDEN SYSTEM_ENTITIES entry - no sidebar group, and no route folder', () => {
+    const entity = SYSTEM_ENTITIES.find((e) => e.entityType === type)
+    expect(entity).toBeDefined()
+    expect(entity?.apiSlug).toBe(apiSlug)
+    expect(entity?.isVisible).toBe(false)
+  })
+
+  it('every field carries a systemAttribute in the shared union, and every sort order is distinct', () => {
+    const orders: string[] = []
+    for (const field of Object.values(fields)) {
+      expect(SYSTEM_ATTRIBUTES).toContain(field.systemAttribute)
+      if (typeof field.systemSortOrder === 'string') orders.push(field.systemSortOrder)
+    }
+    expect(new Set(orders).size).toBe(orders.length)
+  })
+
+  it('displays as fields that exist on the def', () => {
+    const config = DISPLAY_FIELD_CONFIG[type]
+    expect(config).toBeDefined()
+    expect(fields[config!.primaryDisplayField]).toBeDefined()
+    expect(fields[config!.secondaryDisplayField!]).toBeDefined()
+  })
+})
+
+describe('order_fulfillments keeps its name and changes type', () => {
+  it('is a RELATIONSHIP has_many now, never JSON', () => {
+    expect(ORDER_FIELDS.fulfillments?.systemAttribute).toBe('order_fulfillments')
+    expect(ORDER_FIELDS.fulfillments?.fieldType).toBe('RELATIONSHIP')
+    expect(ORDER_FIELDS.fulfillments?.type).not.toBe('json')
+    expect(ORDER_FIELDS.fulfillments?.relationship).toMatchObject({
+      inverseResourceFieldId: 'fulfillment:order',
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    })
+  })
+
+  it('points fulfillment.order at the inverse order.fulfillments declares, with no onDelete', () => {
+    // A belongs_to never declares onDelete - the has_many side above owns
+    // that answer, and the engine reads the STORED value copied from there.
+    expect(FULFILLMENT_FIELDS.order?.relationship?.inverseResourceFieldId).toBe(
+      'order:fulfillments'
+    )
+    expect(FULFILLMENT_FIELDS.order?.relationship?.relationshipType).toBe('belongs_to')
+    expect(FULFILLMENT_FIELDS.order?.relationship?.onDelete).toBeUndefined()
+    expect(FULFILLMENT_FIELDS.order?.nullable).toBe(false)
+  })
+})
+
+describe('the relationship edges this migration must link', () => {
+  it('cascades fulfillment.lines into fulfillment_line, and links the inverse', () => {
+    expect(FULFILLMENT_FIELDS.lines?.relationship).toMatchObject({
+      inverseResourceFieldId: 'fulfillment_line:fulfillment',
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    })
+    expect(FULFILLMENT_LINE_FIELDS.fulfillment?.relationship?.inverseResourceFieldId).toBe(
+      'fulfillment:lines'
+    )
+    expect(FULFILLMENT_LINE_FIELDS.fulfillment?.relationship?.onDelete).toBeUndefined()
+  })
+
+  it('unlinks line_item.fulfillmentLines rather than cascading', () => {
+    // Mirrors line_item.creditMemoLines exactly - deleting a line item must
+    // not delete the fulfillment lines that already shipped it.
+    expect(LINE_ITEM_FIELDS.fulfillmentLines?.relationship).toMatchObject({
+      inverseResourceFieldId: 'fulfillment_line:lineItem',
+      relationshipType: 'has_many',
+      onDelete: 'unlink',
+      isInverse: true,
+    })
+    expect(FULFILLMENT_LINE_FIELDS.lineItem?.relationship?.inverseResourceFieldId).toBe(
+      'line_item:fulfillmentLines'
+    )
+  })
+
+  it('mirrors purchase_order_line.stockMovements for the sell side', () => {
+    expect(FULFILLMENT_LINE_FIELDS.stockMovements?.relationship).toMatchObject({
+      inverseResourceFieldId: 'stock_movement:fulfillmentLine',
+      relationshipType: 'has_many',
+      isInverse: true,
+    })
+    expect(STOCK_MOVEMENT_FIELDS.fulfillmentLine?.relationship?.inverseResourceFieldId).toBe(
+      'fulfillment_line:stockMovements'
+    )
+    expect(STOCK_MOVEMENT_FIELDS.fulfillmentLine?.relationship?.onDelete).toBeUndefined()
+    expect(STOCK_MOVEMENT_FIELDS.fulfillmentLine?.nullable).toBe(true)
+    expect(STOCK_MOVEMENT_FIELDS.fulfillmentLine?.capabilities).toMatchObject({
+      filterable: true,
+      updatable: false,
+    })
+  })
+
+  it('leaves fulfillment.shipment with no relationshipConfig and no resolvable inverse', () => {
+    // Deliberately one-sided (brief §2.2): no field on `shipment` points back,
+    // so this must never appear in a "must be linked" assertion list.
+    expect(FULFILLMENT_FIELDS.shipment?.relationship?.relationshipType).toBe('belongs_to')
+    expect(FULFILLMENT_FIELDS.shipment?.relationship?.inverseResourceFieldId).toBeNull()
+    expect(FULFILLMENT_FIELDS.shipment?.relationship?.onDelete).toBeUndefined()
+    expect(FULFILLMENT_FIELDS.shipment?.relationshipConfig).toBeUndefined()
+    expect(FULFILLMENT_FIELDS.shipment?.nullable).toBe(true)
+  })
+})
+
+describe('fulfillment_gl_posting is TEXT, exactly the credit_memo_gl_posting precedent', () => {
+  it('is TEXT and NOT a relationship', () => {
+    expect(FULFILLMENT_FIELDS.glPosting?.fieldType).toBe('TEXT')
+    expect(FULFILLMENT_FIELDS.glPosting?.type).toBe('string')
+    expect(FULFILLMENT_FIELDS.glPosting?.relationship).toBeUndefined()
+    expect(FULFILLMENT_FIELDS.glPosting?.relationshipConfig).toBeUndefined()
+  })
+
+  it('says in its own description why it is not a relationship', () => {
+    expect(FULFILLMENT_FIELDS.glPosting?.description ?? '').toMatch(/RELATIONSHIP/)
+    expect(FULFILLMENT_FIELDS.glPosting?.description ?? '').toMatch(/EntityDefinition/)
+  })
+
+  it('is nullable, because the poster stamps it after the fact', () => {
+    expect(FULFILLMENT_FIELDS.glPosting?.nullable).toBe(true)
+  })
+})
+
+describe('FulfillmentStatus mirrors Shopify exactly, all six values', () => {
+  it('carries all six lifecycle values, pending included', () => {
+    const values = FulfillmentStatus.values.map((v) => v.value)
+    expect(values).toEqual(['pending', 'open', 'success', 'cancelled', 'error', 'failure'])
+  })
+
+  it('binds fulfillment.status to the preset enum', () => {
+    expect(FULFILLMENT_FIELDS.status?.fieldType).toBe('SINGLE_SELECT')
+    expect(FULFILLMENT_FIELDS.status?.options?.options).toEqual(FulfillmentStatus.values)
+    expect(FULFILLMENT_FIELDS.status?.nullable).toBe(false)
+  })
+
+  it('gives every value a label and a colour', () => {
+    for (const item of FulfillmentStatus.values) {
+      expect(item.label).toBeTruthy()
+      expect(item.color).toBeTruthy()
+    }
+  })
+})
+
+describe('fulfillment_line carries no part, no date and no money', () => {
+  it('has exactly the four business fields the brief allows', () => {
+    const businessKeys = Object.keys(FULFILLMENT_LINE_FIELDS).filter(
+      (k) => !['id', 'createdAt', 'updatedAt', 'createdBy'].includes(k)
+    )
+    expect(new Set(businessKeys)).toEqual(
+      new Set(['fulfillment', 'lineItem', 'quantity', 'quantityRelieved', 'stockMovements'])
+    )
+  })
+
+  it('makes quantityRelieved a computed, never-written roll-up', () => {
+    expect(FULFILLMENT_LINE_FIELDS.quantityRelieved?.capabilities).toMatchObject({
+      creatable: false,
+      updatable: false,
+      computed: true,
+    })
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/153-fulfillment-lines.ts
+++ b/packages/lib/src/data-migrations/migrations/153-fulfillment-lines.ts
@@ -1,0 +1,388 @@
+// packages/lib/src/data-migrations/migrations/153-fulfillment-lines.ts
+
+import { type Database, schema } from '@auxx/database'
+import { FieldType } from '@auxx/database/enums'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import { getOrgCache } from '../../cache'
+import type { ResourceField } from '../../resources/registry/field-types'
+import { FULFILLMENT_FIELDS } from '../../resources/registry/resources/fulfillment-fields'
+import { FULFILLMENT_LINE_FIELDS } from '../../resources/registry/resources/fulfillment-line-fields'
+import { LINE_ITEM_FIELDS } from '../../resources/registry/resources/line-item-fields'
+import { ORDER_FIELDS } from '../../resources/registry/resources/order-fields'
+import { STOCK_MOVEMENT_FIELDS } from '../../resources/registry/resources/stock-movement-fields'
+import {
+  ensureCustomFields,
+  ensureEntityDefinitions,
+  linkDisplayFields,
+  linkNewRelationships,
+  loadExistingState,
+} from '../../seed/entity-helpers'
+import { SYSTEM_ENTITIES } from '../../seed/entity-seeder/constants'
+import type { PerOrgMigration, PerOrgMigrationResult } from '../per-org'
+
+const logger = createScopedLogger('entity-migrations:153')
+
+/** What {@link ensureCustomFields} returns, keyed `<entityType>:<field id>`. */
+type EnsuredFieldMap = Awaited<ReturnType<typeof ensureCustomFields>>
+
+/** The two defs this migration creates. Both hidden, both with no route folder. */
+const NEW_ENTITY_TYPES = ['fulfillment', 'fulfillment_line'] as const
+
+/** The registry field map for each new def. */
+const NEW_DEF_FIELDS: Record<string, Record<string, ResourceField>> = {
+  fulfillment: FULFILLMENT_FIELDS,
+  fulfillment_line: FULFILLMENT_LINE_FIELDS,
+}
+
+const ORDER_FULFILLMENTS_ATTRIBUTE = 'order_fulfillments'
+
+/**
+ * Every relationship half this migration must LINK, paired with the inverse it
+ * points at.
+ *
+ * Checked explicitly after {@link linkNewRelationships} rather than trusted,
+ * because that helper only logs a DEBUG line when it cannot resolve an inverse
+ * - the 135 lesson, restated by 136 and by 149's own copy of this list. An
+ * UNLINKED relationship is worse than a missing one: the field exists so
+ * writes are accepted, but with no inverse the other side reads empty and
+ * every consumer silently sees nothing.
+ *
+ * 🛑 `fulfillment:shipment` is DELIBERATELY ABSENT from this list. Per the
+ * brief's §2.2, that edge is a one-sided, opportunistic pointer with no
+ * inverse field on `shipment` at all - see `fulfillment-fields.ts`'s docblock
+ * on that field for why it is safe to leave unresolved forever.
+ */
+const RELATIONSHIP_PAIRS: readonly { owning: string; inverse: string }[] = [
+  { owning: `fulfillment:${FULFILLMENT_FIELDS.order?.id}`, inverse: 'order:fulfillments' },
+  { owning: `order:${ORDER_FIELDS.fulfillments?.id}`, inverse: 'fulfillment:order' },
+  {
+    owning: `fulfillment:${FULFILLMENT_FIELDS.lines?.id}`,
+    inverse: 'fulfillment_line:fulfillment',
+  },
+  {
+    owning: `fulfillment_line:${FULFILLMENT_LINE_FIELDS.fulfillment?.id}`,
+    inverse: 'fulfillment:lines',
+  },
+  {
+    owning: `fulfillment_line:${FULFILLMENT_LINE_FIELDS.lineItem?.id}`,
+    inverse: 'line_item:fulfillmentLines',
+  },
+  {
+    owning: `line_item:${LINE_ITEM_FIELDS.fulfillmentLines?.id}`,
+    inverse: 'fulfillment_line:lineItem',
+  },
+  {
+    owning: `fulfillment_line:${FULFILLMENT_LINE_FIELDS.stockMovements?.id}`,
+    inverse: 'stock_movement:fulfillmentLine',
+  },
+  {
+    owning: `stock_movement:${STOCK_MOVEMENT_FIELDS.fulfillmentLine?.id}`,
+    inverse: 'fulfillment_line:stockMovements',
+  },
+]
+
+/**
+ * A new def and a new field are invisible to every read path that serves them
+ * until the org's caches are dropped. `perOrgMigration` does this after the
+ * whole batch, but `up()` can also be called directly.
+ */
+const CACHE_KEYS = ['entityDefs', 'entityDefSlugs', 'customFields', 'resources'] as const
+
+/** What migration 153 reports on top of the shared counters. */
+export interface Migration153Result extends PerOrgMigrationResult {
+  /** Whether the OLD `order_fulfillments` JSON field was found and dropped. */
+  oldFulfillmentsFieldDropped: boolean
+}
+
+/**
+ * Migration 153: the `fulfillment` and `fulfillment_line` defs, their fields,
+ * and `order_fulfillments` reborn as a RELATIONSHIP under the same name
+ * (`plans/money/tasks/55-shipment-lines.md`).
+ *
+ * ## Why this migration is the whole point
+ *
+ * `ensureEntityDefinitions` / `ensureCustomFields` are plain inserts that skip
+ * whatever an org already holds, so `SYSTEM_ENTITIES` and `FIELD_REGISTRY`
+ * alone reach FRESH orgs and nothing else. This is what reaches the ones that
+ * already exist.
+ *
+ * ## The JSON field is DROPPED, not migrated in place
+ *
+ * `order_fulfillments` KEEPS ITS NAME (the owner's call, brief header) but
+ * changes type from JSON to RELATIONSHIP has_many. `ensureCustomFields` keys
+ * its "does this field already exist" check on
+ * `(entityDefinitionId, systemAttribute)` - the same key the OLD field
+ * occupies - so simply calling it would see the old row and skip creating the
+ * new shape entirely. This migration therefore finds and DELETES the old
+ * `CustomField` row FIRST, whenever its stored `type` is not already
+ * `RELATIONSHIP` (idempotency: a re-run after this migration already applied
+ * finds the new shape and leaves it alone).
+ *
+ * `FieldValue.fieldId -> CustomField.id` is ON DELETE CASCADE (verified
+ * against the live schema), so deleting the `CustomField` row takes every
+ * value with it. This migration does NOT delete `FieldValue` rows itself -
+ * doing so would be redundant with the cascade and is explicitly the brief's
+ * instruction.
+ *
+ * 🛑 This is a genuine DATA LOSS step, by design (brief §4.3, owner
+ * 2026-09-11: *"our quickbooks connection is a sandbox... we can reset our
+ * whole accounting right now if needed to"*). The runbook this migration
+ * assumes is: reset accounting on any org with posted fulfillment GL entries,
+ * THEN run this migration, THEN re-run the Shopify connector. This migration
+ * does not reset accounting itself and does not check for posted entries -
+ * that is an operational precondition, not something a schema migration can
+ * safely decide on an org's behalf.
+ *
+ * ## What it adds
+ *
+ * - **`fulfillment`** - one dispatch of goods, everything the JSON entry
+ *   carried, because revenue posts from it now.
+ * - **`fulfillment_line`** - one `(fulfillment, line_item)` tuple: units of one
+ *   order line that went out in one dispatch.
+ * - **`order.fulfillments`** - `order_fulfillments` reborn as a has_many, the
+ *   inverse of `fulfillment.order`.
+ * - **`line_item.fulfillmentLines`** - the has_many inverse of
+ *   `fulfillment_line.lineItem` - "where did this line's units go".
+ * - **`stock_movement.fulfillmentLine`** - the belongs_to that carries all of
+ *   task 50's inventory-relief netting, mirroring
+ *   `stock_movement.purchaseOrderLine`.
+ *
+ * ## Both new defs are HIDDEN
+ *
+ * `isVisible: false` in `SYSTEM_ENTITIES`, read from directly here rather than
+ * restated (the 146/149 pattern, so the two halves cannot disagree). No route
+ * folder was authored, so the list page is absent by omission, not by
+ * declaration.
+ *
+ * ## No writers yet
+ *
+ * This lands with nothing writing to either def. The connector and
+ * `money.fulfillOrder` changes are separate work; this migration is the
+ * registry contract they build against.
+ *
+ * ## Ordering
+ *
+ * MUST sort after 107 (`order`), the def whose absence marks an org that has
+ * not been seeded from the current registry at all. An org short of it, or of
+ * `line_item` / `stock_movement`, is a SKIP, not a failure - the seeder
+ * creates all of this together from the registry.
+ *
+ * Idempotent: `ensureEntityDefinitions` and `ensureCustomFields` are
+ * INSERT-only and skip whatever the org already holds, `linkNewRelationships`
+ * only writes an inverse that is currently unset, and the old-field drop is
+ * gated on the stored `type` still being JSON.
+ */
+export const migration153FulfillmentLines: PerOrgMigration = {
+  id: '153-fulfillment-lines',
+  description:
+    'Adds the hidden fulfillment and fulfillment_line defs with their fields, drops the old ' +
+    'order_fulfillments JSON field and recreates it under the same name as a RELATIONSHIP ' +
+    'has_many, and adds the line_item / stock_movement inverses - so revenue posts from ' +
+    'records instead of a collapsed JSON log (plans/money/tasks/55-shipment-lines.md)',
+
+  async up(db: Database, organizationId: string): Promise<Migration153Result> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    let existing = await loadExistingState(db, organizationId)
+
+    // Absent rather than failed: an org short of any of these three has not
+    // been seeded from the current registry at all, and the seeder creates
+    // everything below together from it.
+    const orderDef = existing.entityDefs.get('order')
+    const lineItemDef = existing.entityDefs.get('line_item')
+    const stockMovementDef = existing.entityDefs.get('stock_movement')
+    if (!orderDef || !lineItemDef || !stockMovementDef) {
+      return { ...state, alreadyUpToDate: true, oldFulfillmentsFieldDropped: false }
+    }
+
+    const oldFulfillmentsFieldDropped = await dropStaleJsonFulfillmentsField(
+      db,
+      organizationId,
+      orderDef.id
+    )
+    if (oldFulfillmentsFieldDropped) {
+      // The row `existing.fields` cached for this key is gone; drop it from
+      // the in-memory copy too so `ensureCustomFields` below creates the new
+      // shape instead of treating the deleted row as still current.
+      existing = await loadExistingState(db, organizationId)
+    }
+
+    const entityDefIds = await ensureEntityDefinitions(
+      db,
+      organizationId,
+      SYSTEM_ENTITIES.filter((e) => (NEW_ENTITY_TYPES as readonly string[]).includes(e.entityType)),
+      existing,
+      state
+    )
+    entityDefIds.set('order', orderDef.id)
+    entityDefIds.set('line_item', lineItemDef.id)
+    entityDefIds.set('stock_movement', stockMovementDef.id)
+
+    // 🛑 ONE field map spanning both new defs AND the three widened existing
+    // ones. `linkNewRelationships` resolves an inverse out of this map by
+    // `<entityType>:<field id>`, so linking the halves of a pair in separate
+    // calls would leave each unable to see the other and skip the pair with
+    // nothing louder than a debug line (the 135 lesson, restated by 136 and
+    // 149).
+    const fieldMap: EnsuredFieldMap = new Map()
+
+    for (const entityType of NEW_ENTITY_TYPES) {
+      const defId = entityDefIds.get(entityType)
+      if (!defId) continue
+      const created = await ensureCustomFields(
+        db,
+        organizationId,
+        entityType,
+        defId,
+        NEW_DEF_FIELDS[entityType]!,
+        existing,
+        state
+      )
+      for (const [key, value] of created) fieldMap.set(key, value)
+    }
+
+    const orderFulfillments = ORDER_FIELDS.fulfillments
+    const lineItemFulfillmentLines = LINE_ITEM_FIELDS.fulfillmentLines
+    const stockMovementFulfillmentLine = STOCK_MOVEMENT_FIELDS.fulfillmentLine
+    if (!orderFulfillments || !lineItemFulfillmentLines || !stockMovementFulfillmentLine) {
+      throw new Error(
+        'registry is missing one of order.fulfillments / line_item.fulfillmentLines / ' +
+          'stock_movement.fulfillmentLine (migration 153)'
+      )
+    }
+
+    const widenedOrder = await ensureCustomFields(
+      db,
+      organizationId,
+      'order',
+      orderDef.id,
+      { fulfillments: orderFulfillments },
+      existing,
+      state
+    )
+    for (const [key, value] of widenedOrder) fieldMap.set(key, value)
+
+    const widenedLineItem = await ensureCustomFields(
+      db,
+      organizationId,
+      'line_item',
+      lineItemDef.id,
+      { fulfillmentLines: lineItemFulfillmentLines },
+      existing,
+      state
+    )
+    for (const [key, value] of widenedLineItem) fieldMap.set(key, value)
+
+    const widenedStockMovement = await ensureCustomFields(
+      db,
+      organizationId,
+      'stock_movement',
+      stockMovementDef.id,
+      { fulfillmentLine: stockMovementFulfillmentLine },
+      existing,
+      state
+    )
+    for (const [key, value] of widenedStockMovement) fieldMap.set(key, value)
+
+    await linkNewRelationships(db, fieldMap, entityDefIds, state)
+    await assertInversesLinked(db, fieldMap)
+
+    await linkDisplayFields(db, [...NEW_ENTITY_TYPES], entityDefIds, fieldMap)
+
+    const changed =
+      state.entityDefsCreated > 0 ||
+      state.fieldsCreated > 0 ||
+      state.relationshipsLinked > 0 ||
+      oldFulfillmentsFieldDropped
+
+    if (changed) {
+      // `order_fulfillments` changing shape means a stale `customFields` cache
+      // entry would keep resolving the OLD (JSON) definition, which is worse
+      // than a missing one: every write would target a field id that no
+      // longer exists.
+      await getOrgCache().invalidateAndRecompute(organizationId, [...CACHE_KEYS])
+      logger.info('Migration 153 applied', {
+        organizationId,
+        ...state,
+        oldFulfillmentsFieldDropped,
+      })
+    }
+
+    return { ...state, alreadyUpToDate: !changed, oldFulfillmentsFieldDropped }
+  },
+}
+
+/**
+ * Delete the OLD `order_fulfillments` `CustomField` row, if it is still the
+ * JSON shape entity migration 125 created. Returns whether a row was dropped.
+ *
+ * Gated on the stored `type` rather than mere presence, so a re-run after
+ * this migration already replaced the field with the RELATIONSHIP shape
+ * leaves it alone - the whole point of the gate is to never delete the NEW
+ * field this same migration created.
+ *
+ * `FieldValue.fieldId -> CustomField.id` is ON DELETE CASCADE, so every value
+ * under the old field is dropped with it. No `FieldValue` delete is issued
+ * here - the brief is explicit that this migration must not write one.
+ */
+async function dropStaleJsonFulfillmentsField(
+  db: Database,
+  organizationId: string,
+  orderDefId: string
+): Promise<boolean> {
+  const [existingField] = await db
+    .select({ id: schema.CustomField.id, type: schema.CustomField.type })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.entityDefinitionId, orderDefId),
+        eq(schema.CustomField.systemAttribute, ORDER_FULFILLMENTS_ATTRIBUTE)
+      )
+    )
+    .limit(1)
+
+  if (!existingField || existingField.type === FieldType.RELATIONSHIP) return false
+
+  await db.delete(schema.CustomField).where(eq(schema.CustomField.id, existingField.id))
+  logger.info('Dropped stale JSON order_fulfillments field', {
+    organizationId,
+    fieldId: existingField.id,
+    previousType: existingField.type,
+  })
+  return true
+}
+
+/**
+ * Fail loudly when a relationship half was created but never linked.
+ *
+ * `linkNewRelationships` skips an unresolvable inverse with a debug line,
+ * which on this migration would mean, for example, a `fulfillment_line` that
+ * accepts stock-movement writes nobody can read back through
+ * `stockMovements`, silently breaking task 50's netting. `fulfillment.shipment`
+ * is deliberately NOT checked here - see {@link RELATIONSHIP_PAIRS}.
+ */
+async function assertInversesLinked(
+  db: Database,
+  fieldMap: Map<string, { id: string }>
+): Promise<void> {
+  for (const { owning, inverse } of RELATIONSHIP_PAIRS) {
+    const field = fieldMap.get(owning)
+    if (!field) {
+      throw new Error(`migration 153 could not resolve the field ${owning}`)
+    }
+    const row = await db.query.CustomField.findFirst({
+      where: eq(schema.CustomField.id, field.id),
+      columns: { options: true },
+    })
+    const inverseId = (row?.options as { relationship?: { inverseResourceFieldId?: string } })
+      ?.relationship?.inverseResourceFieldId
+    if (!inverseId) {
+      throw new Error(
+        `migration 153 created ${owning} but could not link it to ${inverse} - the inverse half ` +
+          'is missing, and an unlinked relationship writes rows the other side cannot see'
+      )
+    }
+  }
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -10,6 +10,7 @@ import { migration149ShipmentParcel } from './migrations/149-shipment-parcel'
 import { migration150StripLegacyAddressComponents } from './migrations/150-strip-legacy-address-components'
 import { migration151ShipmentLabelCostAndDocument } from './migrations/151-shipment-label-cost-and-document'
 import { migration152CreditMemoGlPosting } from './migrations/152-credit-memo-gl-posting'
+import { migration153FulfillmentLines } from './migrations/153-fulfillment-lines'
 import { type PerOrgMigration, perOrgMigration } from './per-org'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
@@ -74,6 +75,10 @@ export const PER_ORG_MIGRATIONS: PerOrgMigration[] = [
   // Recomputes a stored column from its own source with the current algorithm:
   // the backfill shape.
   migration147BackfillBankMatchKeys,
+  // Drops a field of one type and recreates it under the SAME name as another
+  // type, alongside two new defs and three widened existing ones: the
+  // type-change shape (plans/money/tasks/55-shipment-lines.md).
+  migration153FulfillmentLines,
 ]
 
 /**

--- a/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
+++ b/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
@@ -1,5 +1,16 @@
 // packages/lib/src/field-hooks/post/bom-movement-triggers.ts
 
+// 🛑 Deliberately NOT routed through `stock-movements.writeStockMovements`
+// (plans/money/tasks/50-batch-inventory-relief.md §2.5), unlike the six
+// writers that module extracts (`receive-stock.ts`, `adjust-stock.ts`,
+// `reverse-movement.ts`, `bulk-opening-stock.ts`, `complete-build.ts`,
+// `reverse-build.ts`). This hook runs INSIDE a post-create hook fired by
+// `UnifiedCrudHandler.create` itself, so routing its child inserts back
+// through `UnifiedCrudHandler` (or the shared writer, which is built on it)
+// would re-enter the trigger it lives in. It keeps its own raw
+// `EntityInstance` + `FieldValue` batch inserts below for that reason, not by
+// oversight.
+
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { TypedFieldValueInput } from '@auxx/types'
@@ -38,7 +49,7 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
   const adjustSubparts = values.stock_movement_adjust_subparts
   if (!adjustSubparts) return
 
-  // If this movement has a parent, it's a child — skip (safety guard)
+  // If this movement has a parent, it's a child - skip (safety guard)
   if (values.stock_movement_parent_movement) return
 
   // Resolve the affected part
@@ -60,18 +71,18 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
 
   // Check if this part has subparts at all
   if (!subpartGraph.has(partInstanceId)) {
-    // No subparts — clear the flag so recalculatePartQoH includes this movement
+    // No subparts - clear the flag so recalculatePartQoH includes this movement
     await clearAdjustSubpartsFlag(organizationId, entityInstanceId)
     return
   }
 
-  // Flatten to descendant targets (in-memory). The root is excluded — the
+  // Flatten to descendant targets (in-memory). The root is excluded - the
   // user-submitted parent movement itself counts as the root's deduction.
   const targets = getDeductionTargets(partInstanceId, quantity, subpartGraph)
 
   if (targets.length === 0) {
     logger.warn('BOM explosion produced no descendant targets', { partInstanceId })
-    // Parent movement is the root's deduction — clear flag and recalc root.
+    // Parent movement is the root's deduction - clear flag and recalc root.
     await clearAdjustSubpartsFlag(organizationId, entityInstanceId)
     await batchRecalculateQoH(organizationId, [partInstanceId])
     return
@@ -169,7 +180,7 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
 
     // Convert each typed value to a FieldValue insert row.
     // These are single-value fields (one row per (entityId, fieldId)),
-    // so the sortKey is purely positional — always the canonical first key.
+    // so the sortKey is purely positional - always the canonical first key.
     for (const { field, value } of typedValues) {
       fieldValueRows.push(
         buildFieldValueRow({

--- a/packages/lib/src/receiving/adjust-stock.ts
+++ b/packages/lib/src/receiving/adjust-stock.ts
@@ -1,14 +1,14 @@
 // packages/lib/src/receiving/adjust-stock.ts
 
 /**
- * The hand-keyed count correction — the THIRD movement writer
+ * The hand-keyed count correction - the THIRD movement writer
  * (plans/purchasing/05-receiving-cost-and-corrections.md section 1.5).
  *
  * Receiving was designed around two doors, both of which go through
  * `receiveStock` and its zero-cost guard. The Adjust Stock popover was a third,
  * and it went through the generic `record.create` instead: `type: 'adjust'`, a
  * quantity, and nothing else. No `unit_cost`, no `extended_cost`, no
- * `gl_account`, no `cost_basis`, and no guard — so a positive adjustment added
+ * `gl_account`, no `cost_basis`, and no guard - so a positive adjustment added
  * stock valued at nothing, which understates COGS and drags the part's average
  * cost toward zero.
  *
@@ -16,7 +16,7 @@
  * "because it looks like data", and claims the rule "generalises to every
  * movement writer". This file is what makes that claim true.
  *
- * Nothing else happens here — quantity on hand is maintained by the existing
+ * Nothing else happens here - quantity on hand is maintained by the existing
  * `mfg-stock-movements-created` rule (`recalculatePartQoH` in
  * `field-hooks/post/inventory-triggers.ts`), and a second writer for it would
  * give the same number two owners.
@@ -30,10 +30,9 @@ import type { Database } from '@auxx/database'
 import type { Result } from 'neverthrow'
 import { getCachedEntityDefId, requireCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../errors'
-import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { StockMovementCostBasis, StockMovementType } from '../resources/registry/enum-values'
-import { toRecordId } from '../resources/resource-id'
-import { computeExtendedCost, resolveInventoryRoleForPartKind, roundMinorUnits } from './client'
+import { writeStockMovements } from '../stock-movements'
+import { resolveInventoryRoleForPartKind, roundMinorUnits } from './client'
 import { assertCostFieldsMaterialized } from './cost-fields'
 import { guard } from './guard'
 import { readPartKind, readPartStandardCost } from './receipt-queries'
@@ -53,7 +52,7 @@ interface AdjustmentCost {
  * The order of the steps is the contract, not an implementation detail:
  *
  * 1. `quantity` is a finite, non-zero number, or `BadRequestError`.
- * 2. Resolve the part's STANDARD cost — in both directions — or
+ * 2. Resolve the part's STANDARD cost - in both directions - or
  *    `UnprocessableEntityError` naming the part. Nothing is written when this
  *    fails.
  * 3. Write one movement, `type: 'adjust'`, `cost_basis: standard`, with
@@ -65,12 +64,12 @@ interface AdjustmentCost {
  *
  * - A **positive** adjustment used to demand a user-entered `unitCost` and
  *   stamp `cost_basis: actual`. But an adjustment has no supplier row, no
- *   purchase order and no packing slip — there is no ACTUAL to record. What the
+ *   purchase order and no packing slip - there is no ACTUAL to record. What the
  *   found units are worth is what the system says a unit of that part is worth,
  *   which is `part_standard_cost`. Asking a person to type it invited a
  *   different answer every time and made the ledger's valuation depend on who
  *   was counting.
- * - A **negative** adjustment used to stamp NO cost at all — no `unit_cost`, no
+ * - A **negative** adjustment used to stamp NO cost at all - no `unit_cost`, no
  *   `extended_cost`, no `gl_account`. That is the worse of the two: a shrinkage
  *   carrying no cost is invisible to every period total that sums the ledger,
  *   so the L1 month-end assertion absorbs it into the COGS plug. `G12` exists
@@ -78,15 +77,15 @@ interface AdjustmentCost {
  *   valueless row cannot be separated from anything.
  *
  * 🛑 **A part with no standard cost fails CLOSED, naming the part.** It must not
- * fall back to `part_cost` — that is live replacement cost, rewritten on every
+ * fall back to `part_cost` - that is live replacement cost, rewritten on every
  * vendor-price change, and it must never value a movement (architecture guide
- * section 11, rule 2) — and it must not write zero, which is the exact defect
+ * section 11, rule 2) - and it must not write zero, which is the exact defect
  * `receiveStock` refuses. Roll standard cost for the part first.
  *
  * ⚠️ **This is a write-path change on an append-only ledger.** Every field on
  * `stock_movement` is `updatable: false`, so movements written before this
- * carry the old costing — a positive `adjust` at a hand-typed `actual` cost, a
- * negative one at no cost at all — and they CANNOT be back-filled. That is the
+ * carry the old costing - a positive `adjust` at a hand-typed `actual` cost, a
+ * negative one at no cost at all - and they CANNOT be back-filled. That is the
  * price of the append-only rule, and reversing them would change quantities
  * that are correct. Read a period that spans the change knowing the earlier
  * rows are shaped differently.
@@ -128,13 +127,13 @@ export async function adjustStock(
  * `Number.isFinite` is checked as well as the sign for the same reason
  * `assertReceivableQuantity` checks it: `NaN !== 0` is true, and an `Infinity`
  * quantity multiplies into an `extendedCost` of `Infinity` that `Math.round`
- * happily preserves — a value the `doublePrecision` column accepts and every
+ * happily preserves - a value the `doublePrecision` column accepts and every
  * later `SUM` is then poisoned by.
  *
  * Zero is refused rather than silently ignored. An adjustment of zero is a row
  * in an append-only ledger that corrects nothing, and a caller that sent one is
  * either mis-wired or asking a question ("set to the count it already has") the
- * answer to which is "nothing to do" — which the caller, not the ledger, should
+ * answer to which is "nothing to do" - which the caller, not the ledger, should
  * record.
  */
 function assertAdjustableQuantity(quantity: number): void {
@@ -152,7 +151,7 @@ function assertAdjustableQuantity(quantity: number): void {
  * Step 2: read the part's frozen standard cost, or refuse naming the part.
  *
  * Rounding is applied BEFORE the positivity check so a sub-half-cent standard
- * cost is rejected here rather than stored as a zero the ledger cannot explain —
+ * cost is rejected here rather than stored as a zero the ledger cannot explain -
  * the same ordering `resolveReceiptPrice` uses, and for the same reason.
  *
  * Runs for a REMOVAL as well as an addition, which is why the cost-field
@@ -178,7 +177,7 @@ async function resolveAdjustmentCost(
 
   if (standardCost == null || !Number.isFinite(standardCost)) {
     throw new UnprocessableEntityError(
-      `Cannot adjust ${partLabel}: it has no standard cost. An adjustment is valued at the part's standard cost, and there is nothing else it may honestly be valued at — the live part cost is a replacement price that changes with every vendor quote. Roll standard cost for this part first.`,
+      `Cannot adjust ${partLabel}: it has no standard cost. An adjustment is valued at the part's standard cost, and there is nothing else it may honestly be valued at - the live part cost is a replacement price that changes with every vendor quote. Roll standard cost for this part first.`,
       { partId }
     )
   }
@@ -201,30 +200,29 @@ interface WriteAdjustMovementArgs {
   movementDefId: string
   partDefId: string
   input: AdjustStockInput
-  /** Never null — `G12` values a removal exactly as it values an addition. */
+  /** Never null - `G12` values a removal exactly as it values an addition. */
   cost: AdjustmentCost
   occurredAt: Date
 }
 
 /**
- * Step 3: write the one movement.
- *
- * Values are keyed by `systemAttribute` and go through `UnifiedCrudHandler`
- * rather than a hand-built `EntityInstance` + `FieldValue` insert — the same
- * mechanism `writeReceiveMovement` and `writeReversal` use, and what makes the
- * post-commit triggers (QoH recalculation, timeline, realtime) fire at all. A
- * direct insert writes rows the rest of the system never hears about, which is
- * precisely how the popover this replaces got away with writing no cost.
+ * Step 3: write the one movement, through the shared
+ * `stock-movements/writeStockMovements` (plans/money/tasks/50-batch-inventory-relief.md
+ * §2) - the same writer `writeReceiveMovement` and `writeReversal` go through,
+ * and what makes the post-commit triggers (QoH recalculation, timeline,
+ * realtime) fire at all. A direct insert writes rows the rest of the system
+ * never hears about, which is precisely how the popover this replaces got
+ * away with writing no cost.
  *
  * Every cost field is stamped unconditionally: `resolveAdjustmentCost` has
  * already refused the write if the part has no standard cost, so there is no
  * branch here in which one is missing.
  *
- * 🛑 **`adjustSubparts: false` is load-bearing, not a default.**
+ * 🛑 **`adjustSubparts` is never set here, which is what keeps it `false`.**
  * `explodeBomMovement` inherits the parent movement's type AND its sign, so an
  * adjustment with the flag set would cascade the correction through the bill of
  * materials: "add 10" of a finished good would increase every component's stock
- * as well, so the assembly and the parts it consumed both go up — the opposite
+ * as well, so the assembly and the parts it consumed both go up - the opposite
  * of what building one does. An adjustment is a count correction and must never
  * cascade; explosion belongs to a movement that knows its own direction
  * (plans/products/11-costing-and-stock-improvements.md section 5.3).
@@ -237,42 +235,39 @@ async function writeAdjustMovement(
 ): Promise<MovementRecord> {
   const { movementDefId, partDefId, input, cost, occurredAt } = args
   const quantity = input.quantity
-  // Signed like `quantity`, so a removal's extended cost is NEGATIVE and a
-  // period total that sums the ledger nets correctly without a sign convention
-  // living anywhere else.
-  const extendedCost = computeExtendedCost(cost.unitCost, quantity)
 
-  const values: Record<string, unknown> = {
-    stock_movement_part: toRecordId(partDefId, input.partId),
-    stock_movement_type: StockMovementType.ADJUST,
-    stock_movement_quantity: quantity,
-    // See the JSDoc above. Never true on an adjustment.
-    stock_movement_adjust_subparts: false,
-    stock_movement_occurred_at: occurredAt.toISOString(),
-    // `standard`, not `actual`: this is the part's frozen `part_standard_cost`,
-    // read by the server. An adjustment has no supplier and no invoice, so there
-    // is no ACTUAL for it to record (`G12`).
-    stock_movement_cost_basis: StockMovementCostBasis.STANDARD,
-    stock_movement_unit_cost: cost.unitCost,
-    stock_movement_extended_cost: extendedCost,
-    stock_movement_gl_account: cost.glAccount,
-  }
-
-  if (input.reason) values.stock_movement_reason = input.reason
-  if (input.reference) values.stock_movement_reference = input.reference
-
-  const crud = new UnifiedCrudHandler(organizationId, userId, db)
-  const created = await crud.create(movementDefId, values)
+  const written = await writeStockMovements(
+    { db, organizationId, userId, movementDefId, partDefId, lane: { kind: 'plain' } },
+    [
+      {
+        partInstanceId: input.partId,
+        type: StockMovementType.ADJUST,
+        quantity,
+        unitCost: cost.unitCost,
+        // `standard`, not `actual`: this is the part's frozen
+        // `part_standard_cost`, read by the server. An adjustment has no
+        // supplier and no invoice, so there is no ACTUAL for it to record
+        // (`G12`).
+        costBasis: StockMovementCostBasis.STANDARD,
+        glAccount: cost.glAccount,
+        occurredAt,
+        reason: input.reason,
+        reference: input.reference,
+      },
+    ]
+  )
+  if (written.isErr()) throw written.error
+  const record = written.value.records[0]!
 
   return {
-    movementId: created.instance.id,
-    recordId: toRecordId(movementDefId, created.instance.id),
+    movementId: record.movementId,
+    recordId: record.recordId,
     partInstanceId: input.partId,
     quantity,
     unitCost: cost.unitCost,
-    extendedCost,
+    extendedCost: record.extendedCost,
     // An adjustment has no supplier and no purchase order: it is a count
-    // correction, not a purchase. Nothing here is withheld — there is nothing
+    // correction, not a purchase. Nothing here is withheld - there is nothing
     // to state.
     vendorUnitPrice: null,
     vendorPartId: null,

--- a/packages/lib/src/receiving/bulk-opening-stock.ts
+++ b/packages/lib/src/receiving/bulk-opening-stock.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/receiving/bulk-opening-stock.ts
 
 /**
- * `bulkOpenStockBalance` — the opening balance for a whole org, in one pass.
+ * `bulkOpenStockBalance` - the opening balance for a whole org, in one pass.
  *
  * plans/money/tasks/52-parts-costing-page.md §5.
  *
@@ -10,7 +10,7 @@
  * that each one is asked of the whole set at once:
  *
  * 1. `quantity > 0` and `unitCost > 0` at `RATE_DECIMALS`, or the ENTRY is
- *    refused — never the run.
+ *    refused - never the run.
  * 2. 🛑 A part that already has ANY `stock_movement` is EXCLUDED, not an error.
  *    Opening is once, and this guard is what stops the page becoming a back
  *    door into hand-valuing an adjustment.
@@ -26,8 +26,8 @@
  *
  * The discipline `money/fulfillment-posting/run.ts` and `executeBackfill` keep:
  * per-part isolation, and a summary that names what did not happen and why.
- * Only a WHOLE-RUN precondition — no `part` definition, no `stock_movement`
- * definition, cost fields not materialised — comes back as an `err`, because
+ * Only a WHOLE-RUN precondition - no `part` definition, no `stock_movement`
+ * definition, cost fields not materialised - comes back as an `err`, because
  * none of those is about a part and all of them refuse every entry identically.
  *
  * ## Quantity on hand
@@ -35,19 +35,19 @@
  * ✅ This writes on the ORDINARY lane, so `mfg-stock-movements-created` fires
  * per movement and `recalculatePartQoH` (its second action) is what updates
  * `part_quantity_on_hand`. HANDOFF rule 5 does NOT apply and the caller must
- * NOT call `batchRecalculateQoH` — quantity on hand has exactly one owner, and
+ * NOT call `batchRecalculateQoH` - quantity on hand has exactly one owner, and
  * a second writer here would give the same number two.
  *
  * ⚠️ `explodeBomMovement` (the rule's FIRST action) is a no-op on every row:
  * it guards on `stock_movement_adjust_subparts` as its third statement, before
  * any query, and step 4 writes `false` on every one. `recalculatePurchaseOrderLineReceived`
- * (its third) is a no-op too — an opening balance carries no purchase order line.
+ * (its third) is a no-op too - an opening balance carries no purchase order line.
  *
  * ## 🛑 `ensureStandardCost` takes ONE cost for the whole array
  *
  * `ensure-standard-cost.ts:143` calls `previousStandardCost == null` THE ONE
  * RULE: it writes only where `part_standard_cost IS NULL` and never overwrites.
- * So the caller's cost is not a per-part map — it is one number applied to every
+ * So the caller's cost is not a per-part map - it is one number applied to every
  * part named in that call. Entries are therefore grouped by DISTINCT unit cost
  * and the function is called once per group.
  *
@@ -55,7 +55,7 @@
  * is a documented no-op, and a movement stamped `cost_basis: standard` would
  * then carry a cost the standard disagrees with. The sequence (roll first,
  * default the cost column to the standard) is the fix; what this file adds is
- * the post-condition the single-part door already has — the part's standard is
+ * the post-condition the single-part door already has - the part's standard is
  * RE-READ after step 3, and a part left holding `null`, `0` or a negative is
  * dropped to `failed` rather than given a movement nothing downstream can value.
  *
@@ -78,7 +78,8 @@ import {
   StockMovementType,
 } from '../resources/registry/enum-values'
 import { type RecordId, toRecordId } from '../resources/resource-id'
-import { computeExtendedCost, resolveInventoryRoleForPartKind } from './client'
+import { buildStockMovementValues } from '../stock-movements'
+import { resolveInventoryRoleForPartKind } from './client'
 import { assertCostFieldsMaterialized } from './cost-fields'
 import { guard } from './guard'
 import type {
@@ -204,7 +205,7 @@ export async function bulkOpenStockBalance(
 }
 
 /**
- * Set `part_kind` on many parts at once — the confirm that must precede the run.
+ * Set `part_kind` on many parts at once - the confirm that must precede the run.
  *
  * 🛑 **The kind decides the account, and the account is frozen onto an
  * `updatable: false` movement** (§6.3). A part opened as `component` that was a
@@ -219,13 +220,13 @@ export async function bulkOpenStockBalance(
  * `subassembly` only and never to `finished_good`, for exactly this reason.
  *
  * Goes through `UnifiedCrudHandler.bulkSetFieldValue`, which fans out through
- * `setBulkValues` — so the field hooks, the realtime frames and the uniqueness
+ * `setBulkValues` - so the field hooks, the realtime frames and the uniqueness
  * gates all behave as they do on a single edit.
  *
  * 🛑 **The kind is validated HERE, not only in the router's input schema.**
  * `part_kind` is a SINGLE_SELECT and an unrecognised value would store as an
  * `optionId` nothing maps, which `resolveInventoryRoleForPartKind` then reads as
- * the default — silently posting a finished good to Raw Materials. A router
+ * the default - silently posting a finished good to Raw Materials. A router
  * schema protects one door; this protects the worker, the seeder and every
  * later caller too.
  *
@@ -344,7 +345,7 @@ function refuseOpeningQuantity(quantity: number): string | null {
  * 🛑 **A fractional input is NOT rounded down into a legal value.** A receipt
  * derives its cost from supplier terms and rounds the result; an opening balance
  * is typed, by a person looking at what was paid, so a value finer than
- * `stock_movement_unit_cost` can hold (`RATE_DECIMALS` — five major-unit places)
+ * `stock_movement_unit_cost` can hold (`RATE_DECIMALS` - five major-unit places)
  * means the caller is working in the wrong units, and silently rounding it would
  * freeze that mistake onto an append-only row forever.
  *
@@ -366,7 +367,7 @@ function refuseOpeningUnitCost(unitCost: number): string | null {
  * Remove every accepted part the verdict names, recording why.
  *
  * One helper for all four drop points so a part can never leave `accepted`
- * without a row in the summary explaining it — the property that makes
+ * without a row in the summary explaining it - the property that makes
  * `opened + excluded + failed` account for every entry.
  */
 function dropWhere(
@@ -447,7 +448,7 @@ async function readParts(
  *
  * ⚠️ Read-then-write with no DB constraint behind it. There is no uniqueness a
  * `FieldValue` row can express, so two runs racing at the same instant would
- * both pass — the same window the single-part door has, and the reason §6.2 says
+ * both pass - the same window the single-part door has, and the reason §6.2 says
  * this read must happen INSIDE the run rather than being taken from the
  * candidate list the page was rendered from.
  *
@@ -505,7 +506,7 @@ async function readPartsWithMovements(
  *
  * 🛑 `ensureStandardCost` takes `partIds: string[]` but ONE `source.unitCost`,
  * so a single call over mixed costs would freeze the first group's number onto
- * every part in the run. Grouping is not an optimisation — it is the only way to
+ * every part in the run. Grouping is not an optimisation - it is the only way to
  * call it correctly with more than one cost in play.
  *
  * A group that errs fails only its own parts. `ensureStandardCost` is documented
@@ -613,6 +614,15 @@ interface WriteInitialMovementsArgs {
  * `bulkCreate` reports failures BY INDEX and returns the successes in order, so
  * the two are re-paired by walking the input positions and consuming `created`
  * as the non-failed ones go past.
+ *
+ * 🛑 **Not `writeStockMovements`.** This is the one writer whose cardinality is
+ * `bulkCreate` with per-INDEX failure tolerance - a bad part must not lose the
+ * other 494 - which `stock-movements/write-movements.ts` does not attempt to
+ * unify (plans/money/tasks/50-batch-inventory-relief.md §2.2 does not name
+ * cardinality as a shared axis). It DOES share
+ * `stock-movements/buildStockMovementValues` for the nine keys and the sign
+ * convention, so the `adjustSubparts: false` default has one definition
+ * regardless of which of the six writers reaches it.
  */
 async function writeInitialMovements(
   db: Database,
@@ -623,29 +633,26 @@ async function writeInitialMovements(
   const { movementDefId, partDefId, occurredAt, entries, kindByPartId, failed } = args
   if (entries.length === 0) return []
 
-  const occurredAtIso = occurredAt.toISOString()
   const planned = entries.map((entry) => {
     const glAccount = resolveInventoryRoleForPartKind(kindByPartId.get(entry.partId))
-    const extendedCost = computeExtendedCost(entry.unitCost, entry.quantity)
-    return { entry, glAccount, extendedCost }
+    const values = buildStockMovementValues({
+      partRecordId: toRecordId(partDefId, entry.partId),
+      type: StockMovementType.INITIAL,
+      quantity: entry.quantity,
+      unitCost: entry.unitCost,
+      // `standard`, not `actual`. There is no vendor row, no purchase order and
+      // no packing slip behind an opening balance, and step 3 has just made
+      // this cost BE the part's standard, so `standard` is the honest
+      // description of it.
+      costBasis: StockMovementCostBasis.STANDARD,
+      glAccount,
+      // One date for the whole run: an opening balance is one event, on one date.
+      occurredAt,
+    })
+    return { entry, glAccount, extendedCost: values.stock_movement_extended_cost as number, values }
   })
 
-  const items: Record<string, unknown>[] = planned.map(({ entry, glAccount, extendedCost }) => ({
-    stock_movement_part: toRecordId(partDefId, entry.partId),
-    stock_movement_type: StockMovementType.INITIAL,
-    stock_movement_quantity: entry.quantity,
-    // See the JSDoc above. Never true on an opening balance.
-    stock_movement_adjust_subparts: false,
-    // One date for the whole run: an opening balance is one event, on one date.
-    stock_movement_occurred_at: occurredAtIso,
-    // `standard`, not `actual`. There is no vendor row, no purchase order and no
-    // packing slip behind an opening balance, and step 3 has just made this cost
-    // BE the part's standard, so `standard` is the honest description of it.
-    stock_movement_cost_basis: StockMovementCostBasis.STANDARD,
-    stock_movement_unit_cost: entry.unitCost,
-    stock_movement_extended_cost: extendedCost,
-    stock_movement_gl_account: glAccount,
-  }))
+  const items: Record<string, unknown>[] = planned.map(({ values }) => values)
 
   const crud = new UnifiedCrudHandler(organizationId, userId, db)
   const { created, errors } = await crud.bulkCreate(movementDefId, items)

--- a/packages/lib/src/receiving/receive-stock.ts
+++ b/packages/lib/src/receiving/receive-stock.ts
@@ -4,7 +4,7 @@
  * The single-line receipt write (plans/purchasing/01-build-plan.md section 3.2).
  *
  * One receipt is one `stock_movement` row: `type: 'receive'`, a positive
- * quantity, and a frozen landed cost. Nothing else happens here — quantity on
+ * quantity, and a frozen landed cost. Nothing else happens here - quantity on
  * hand is maintained by the existing `mfg-stock-movements-created` rule
  * (`recalculatePartQoH` in `field-hooks/post/inventory-triggers.ts`), and adding
  * a second writer for it would give the same number two owners.
@@ -19,10 +19,8 @@ import type { Result } from 'neverthrow'
 import { ensureStandardCost } from '../builds/ensure-standard-cost'
 import { getCachedEntityDefId, requireCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError, UnprocessableEntityError } from '../errors'
-import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
-import { toRecordId } from '../resources/resource-id'
+import { writeStockMovements } from '../stock-movements'
 import {
-  computeExtendedCost,
   computeReceiptLandedCost,
   type ReceiptCostInputs,
   resolveInventoryRoleForPartKind,
@@ -43,7 +41,7 @@ const logger = createScopedLogger('receiving')
  * 1. `quantity > 0`, or `BadRequestError`. A negative receipt is a vendor return
  *    and has to carry the ORIGINAL receipt's cost, so it cannot be expressed
  *    here without silently valuing the return at today's price.
- * 2. Resolve the price. See {@link resolveReceiptPrice} — the base is the price
+ * 2. Resolve the price. See {@link resolveReceiptPrice} - the base is the price
  *    the caller sent, and the supplier row contributes only the landed adders.
  * 3. Round both money values ONCE, at the point of storage.
  * 4. Give the part a standard cost if, and only if, it has none. See
@@ -56,7 +54,7 @@ const logger = createScopedLogger('receiving')
  * than a missing one because it looks like data: it sums into the inventory
  * balance as nothing, it makes the part's average cost collapse toward zero, and
  * nothing downstream can tell it apart from a genuinely free sample. The rule
- * generalises to every movement writer — stamp a cost, or write something
+ * generalises to every movement writer - stamp a cost, or write something
  * explicitly and permanently non-postable; there is no third state.
  */
 export async function receiveStock(
@@ -102,7 +100,7 @@ export async function receiveStock(
  *
  * `Number.isFinite` is checked as well as the sign because `NaN > 0` is false but
  * so is `NaN <= 0`, and an `Infinity` quantity would multiply into an
- * `extendedCost` of `Infinity` that `Math.round` happily preserves — a value the
+ * `extendedCost` of `Infinity` that `Math.round` happily preserves - a value the
  * `doublePrecision` column accepts and every later `SUM` is then poisoned by.
  */
 function assertReceivableQuantity(quantity: number): void {
@@ -133,8 +131,8 @@ interface ResolvedPrice {
  *    {@link import('./receive-purchase-order').receivePurchaseOrder} reads the
  *    purchase order line's agreed price server-side and passes the resolved cost
  *    down. No vendor terms are applied on top of it.
- * 2. **A supplied `vendorUnitPrice` is the BASE**, and the `vendor_part` row —
- *    when one is named — contributes ONLY the adders (freight, tariff, other).
+ * 2. **A supplied `vendorUnitPrice` is the BASE**, and the `vendor_part` row -
+ *    when one is named - contributes ONLY the adders (freight, tariff, other).
  * 3. **`vendorPartId` alone** prices the whole receipt from the supplier row:
  *    its `unitPrice` is the base and its adders sit on top.
  * 4. Otherwise there is no price at all, and the receipt is refused.
@@ -143,7 +141,7 @@ interface ResolvedPrice {
  * form shows the supplier's terms and lets the person keying the receipt replace
  * the price with what the packing slip in front of them actually says. Reading
  * `vendor_part.unitPrice` as the base after that would value the stock from the
- * number the user just *replaced* — and because every field on `stock_movement`
+ * number the user just *replaced* - and because every field on `stock_movement`
  * is `updatable: false`, the wrong cost is frozen forever with nothing thrown.
  * `apps/web/src/components/manufacturing/parts/receipt-input.ts` documents that
  * hazard, and compensated for it client-side by sending a pre-computed
@@ -292,23 +290,21 @@ async function setFirstStandardCostFromReceipt(
 }
 
 /**
- * Step 5: write the one movement.
+ * Step 5: write the one movement, through the shared
+ * `stock-movements/writeStockMovements` (plans/money/tasks/50-batch-inventory-relief.md
+ * §2). That is what makes the post-commit triggers (QoH, timeline, realtime)
+ * fire at all - a direct insert writes rows the rest of the system never
+ * hears about - and it is also what resolves `vendorPartId` /
+ * `purchaseOrderLineId` into links, refusing with `UnprocessableEntityError`
+ * when this org has no such definition yet.
  *
- * Values are keyed by `systemAttribute` and go through `UnifiedCrudHandler`
- * rather than a hand-built `EntityInstance` + `FieldValue` insert. That is the
- * same mechanism `data-connectors/inventory-bridge-linking.ts` uses to create
- * movements, and it is what makes the post-commit triggers (QoH, timeline,
- * realtime) fire at all — a direct insert writes rows the rest of the system
- * never hears about.
- *
- * 🛑 **`adjustSubparts: false` is load-bearing, not a default.**
+ * 🛑 **`adjustSubparts` is never set here, which is what keeps it `false`.**
  * `explodeBomMovement` inherits the parent movement's type AND its sign, so a
  * receipt with the flag set would create a `receive` movement for every
- * descendant in the BOM — receiving 10 motors would ADD 10 of every screw,
+ * descendant in the BOM - receiving 10 motors would ADD 10 of every screw,
  * bracket and wire harness inside them. Receiving 10 motors adds 10 motors and
  * consumes nothing: a purchase brings a finished item through the door, it does
- * not manufacture its own components. `baselineSeed` in
- * `inventory-bridge-linking.ts` sets it false for the identical reason.
+ * not manufacture its own components.
  */
 async function writeReceiveMovement(
   db: Database,
@@ -318,69 +314,46 @@ async function writeReceiveMovement(
 ): Promise<MovementRecord> {
   const { movementDefId, partDefId, input, unitCost, vendorUnitPrice, glAccount, occurredAt } = args
   const quantity = input.quantity
-  const extendedCost = computeExtendedCost(unitCost, quantity)
 
-  const values: Record<string, unknown> = {
-    stock_movement_part: toRecordId(partDefId, input.partId),
-    stock_movement_type: 'receive',
-    stock_movement_quantity: quantity,
-    // See the JSDoc above. Never true on a receipt.
-    stock_movement_adjust_subparts: false,
-    // A receipt is the first writer of `actual`: this cost is what was paid,
-    // not what the standard cost roll-up expects it to have been.
-    stock_movement_cost_basis: 'actual',
-    stock_movement_unit_cost: unitCost,
-    stock_movement_extended_cost: extendedCost,
-    stock_movement_gl_account: glAccount,
-    stock_movement_occurred_at: occurredAt.toISOString(),
-  }
-
-  if (vendorUnitPrice != null) values.stock_movement_vendor_unit_price = vendorUnitPrice
-  if (input.reference) values.stock_movement_reference = input.reference
-  if (input.reason) values.stock_movement_reason = input.reason
-
-  if (input.vendorPartId) {
-    const vendorPartDefId = await requireDefId(organizationId, 'vendor_part')
-    values.stock_movement_vendor_part = toRecordId(vendorPartDefId, input.vendorPartId)
-  }
-
-  if (input.purchaseOrderLineId) {
-    const lineDefId = await requireDefId(organizationId, 'purchase_order_line')
-    values.stock_movement_purchase_order_line = toRecordId(lineDefId, input.purchaseOrderLineId)
-  }
-
-  const crud = new UnifiedCrudHandler(organizationId, userId, db)
-  const created = await crud.create(movementDefId, values)
+  const written = await writeStockMovements(
+    { db, organizationId, userId, movementDefId, partDefId, lane: { kind: 'plain' } },
+    [
+      {
+        partInstanceId: input.partId,
+        type: 'receive',
+        quantity,
+        unitCost,
+        // A receipt is the first writer of `actual`: this cost is what was
+        // paid, not what the standard cost roll-up expects it to have been.
+        costBasis: 'actual',
+        glAccount,
+        occurredAt,
+        vendorUnitPrice: vendorUnitPrice ?? undefined,
+        reference: input.reference,
+        reason: input.reason,
+        links: {
+          vendorPartId: input.vendorPartId,
+          purchaseOrderLineId: input.purchaseOrderLineId,
+        },
+      },
+    ]
+  )
+  if (written.isErr()) throw written.error
+  const record = written.value.records[0]!
 
   return {
-    movementId: created.instance.id,
-    recordId: toRecordId(movementDefId, created.instance.id),
+    movementId: record.movementId,
+    recordId: record.recordId,
     partInstanceId: input.partId,
     quantity,
     unitCost,
-    extendedCost,
+    extendedCost: record.extendedCost,
     vendorUnitPrice,
     vendorPartId: input.vendorPartId ?? null,
     glAccount,
     occurredAt,
     purchaseOrderLineId: input.purchaseOrderLineId ?? null,
   }
-}
-
-/**
- * Resolve a def id the caller's input already committed us to, as an
- * `UnprocessableEntityError` rather than the bare `Error` the cache helper
- * throws — "you referenced a purchase order line and this org has no purchase
- * orders yet" is a 422 the UI can act on, not a 500.
- */
-async function requireDefId(organizationId: string, entityType: string): Promise<string> {
-  const defId = await getCachedEntityDefId(organizationId, entityType)
-  if (!defId) {
-    throw new UnprocessableEntityError(
-      `This organization has no ${entityType} entity definition yet`
-    )
-  }
-  return defId
 }
 
 /** Unwrap a neverthrow `Result` back into the imperative style `guard()` expects. */

--- a/packages/lib/src/receiving/reverse-movement.ts
+++ b/packages/lib/src/receiving/reverse-movement.ts
@@ -7,11 +7,11 @@
  * Until this existed there was no way to undo a receipt at all: the ledger is
  * append-only by construction, `receiveStock` refuses a non-positive quantity by
  * design ("A negative receipt is a vendor return"), and Adjust Stock writes no
- * `purchase_order_line` — so using it to fix a keying mistake moves the part's
+ * `purchase_order_line` - so using it to fix a keying mistake moves the part's
  * on-hand count and leaves `purchase_order_line_quantity_received` permanently
  * wrong.
  *
- * A reversal is therefore a NEW, opposite row, never an edit — which is what
+ * A reversal is therefore a NEW, opposite row, never an edit - which is what
  * `stock_movement_reverses_movement` was built for in entity migration 108 and
  * never wired up. The roll-up needs no change: it re-SUMs every movement
  * pointing at the line, so the negative row decrements `quantityReceived` for
@@ -26,10 +26,8 @@ import { and, eq, inArray, isNull } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { getCachedEntityDefId, getOrgCache } from '../cache'
 import { BadRequestError, ConflictError, NotFoundError, UnprocessableEntityError } from '../errors'
-import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { StockMovementType } from '../resources/registry/enum-values'
-import { toRecordId } from '../resources/resource-id'
-import { computeExtendedCost } from './client'
+import { writeStockMovements } from '../stock-movements'
 import { guard } from './guard'
 import type { MovementRecord } from './types'
 
@@ -38,7 +36,7 @@ export interface ReverseMovementInput {
   /** `EntityInstance.id` of the `stock_movement` being undone. */
   movementId: string
   /**
-   * Free text stamped onto the reversal only. The original is never touched —
+   * Free text stamped onto the reversal only. The original is never touched -
    * every field on `stock_movement` is `updatable: false`, which is the only
    * reason a cost frozen onto a movement can be trusted years later.
    */
@@ -49,7 +47,7 @@ export interface ReverseMovementInput {
  * Every attribute the reversal reads off the original.
  *
  * All of them are treated as optional below because they are only materialised
- * once entity migration 108 has run for the org — but the four the write cannot
+ * once entity migration 108 has run for the org - but the four the write cannot
  * be expressed without are asserted explicitly.
  */
 const REVERSAL_ATTRIBUTES = [
@@ -73,9 +71,9 @@ type ReversalFields = Record<ReversalAttribute, { id: string } | null>
 /**
  * What the reversal row is TYPED as, per the type of the row it undoes.
  *
- * The sign is what the arithmetic runs on — `recalculatePartQoH` and the
+ * The sign is what the arithmetic runs on - `recalculatePartQoH` and the
  * purchase-order roll-up both plain-`SUM` `stock_movement_quantity` with no
- * regard for the type — so this map is a LABEL, chosen to describe the direction
+ * regard for the type - so this map is a LABEL, chosen to describe the direction
  * the goods actually moved:
  *
  * - `receive` -> `return_out`: the goods go back out the door. This is the case
@@ -128,7 +126,7 @@ interface OriginalMovement {
  *    because the roll-up re-SUMs rather than increments, the wrong number would
  *    look exactly as authoritative as the right one.
  * 3. Refuse to reverse a reversal, with `BadRequestError`. The correction of an
- *    over-correction is a fresh receipt or adjustment, not a chain of undos —
+ *    over-correction is a fresh receipt or adjustment, not a chain of undos -
  *    a chain makes "is this movement live?" a graph walk instead of a lookup.
  * 4. Write ONE new movement: the negated quantity, the ORIGINAL's frozen unit
  *    cost verbatim, and the original's `purchaseOrderLine`, `glAccount`,
@@ -138,19 +136,19 @@ interface OriginalMovement {
  * froze, whatever today's supplier terms say. A reversal valued at the current
  * price nets a receipt and its undo to a non-zero amount of inventory value out
  * of nothing, which is the exact costing bug this subsystem exists to avoid.
- * `extendedCost` IS recomputed — from that same frozen unit cost against the
- * negated quantity — so it stays signed like the quantity and the subledger
+ * `extendedCost` IS recomputed - from that same frozen unit cost against the
+ * negated quantity - so it stays signed like the quantity and the subledger
  * still sums to the inventory balance.
  *
  * ⚠️ **Only a COSTED movement can be reversed here.** A movement with no frozen
- * `unitCost` (a pre-migration row, or a hand-keyed stock adjustment — see
+ * `unitCost` (a pre-migration row, or a hand-keyed stock adjustment - see
  * section 1.5 of the plan) has no cost to preserve, and writing its negation at
  * zero would be the thing `receive-stock.ts` refuses: a row that looks like data
  * and values inventory at nothing. Those are corrected with a second adjustment;
  * they carry no `purchaseOrderLine` either, so no roll-up is left wrong by that.
  *
- * ⚠️ Step 2 is a read-then-write check, not a database constraint — there is no
- * unique index available on a `FieldValue` relationship — so two reversals
+ * ⚠️ Step 2 is a read-then-write check, not a database constraint - there is no
+ * unique index available on a `FieldValue` relationship - so two reversals
  * issued concurrently for the same movement could both pass it. The window is a
  * single request and the surface is one row action, so this is accepted rather
  * than serialised.
@@ -288,7 +286,7 @@ async function readOriginalMovement(
   }
   if (unitCost == null || !Number.isFinite(unitCost) || unitCost <= 0 || !glAccount) {
     // See the JSDoc on `reverseMovement`: an uncosted movement has no frozen
-    // cost to carry, and the alternative — a reversal valued at zero — is worse
+    // cost to carry, and the alternative - a reversal valued at zero - is worse
     // than no row at all. `receiveStock` is the only writer of `unitCost` and it
     // stamps `glAccount` in the same breath, so the two travel together.
     throw new UnprocessableEntityError(
@@ -314,7 +312,7 @@ async function readOriginalMovement(
  * Step 2: does a live movement already point its `reversesMovement` at this one?
  *
  * Joins `EntityInstance` so an archived reversal does not block a legitimate
- * second attempt — an archived row contributes nothing to either roll-up, so
+ * second attempt - an archived row contributes nothing to either roll-up, so
  * treating it as a standing reversal would leave the mistake uncorrectable.
  */
 async function hasReversal(
@@ -355,21 +353,28 @@ interface WriteReversalArgs {
 }
 
 /**
- * Step 4: write the one opposite movement.
- *
- * Values are keyed by `systemAttribute` and go through `UnifiedCrudHandler`, the
- * same mechanism `writeReceiveMovement` uses and for the same reason: a direct
- * `EntityInstance` + `FieldValue` insert writes rows the post-commit triggers
- * (QoH recalculation, the purchase-order roll-up, timeline, realtime) never hear
- * about — and the roll-up firing is the entire point of copying the
+ * Step 4: write the one opposite movement, through the shared
+ * `stock-movements/writeStockMovements` (plans/money/tasks/50-batch-inventory-relief.md
+ * §2) - the same writer `writeReceiveMovement` uses and for the same reason: a
+ * direct `EntityInstance` + `FieldValue` insert writes rows the post-commit
+ * triggers (QoH recalculation, the purchase-order roll-up, timeline, realtime)
+ * never hear about - and the roll-up firing is the entire point of copying the
  * `purchaseOrderLine` across.
  *
- * 🛑 **`adjustSubparts: false` is load-bearing, not a default.**
+ * `partDefId` is resolved here rather than threaded in, since this is the
+ * only step of `reverseMovement` that needs it.
+ *
+ * 🛑 **`adjustSubparts` is never set here, which is what keeps it `false`.**
  * `explodeBomMovement` inherits the parent movement's type AND its sign, so a
  * reversal with the flag set would explode the negation across every descendant
- * in the BOM — undoing one receipt of 10 motors would also move 10 of every
+ * in the BOM - undoing one receipt of 10 motors would also move 10 of every
  * screw inside them. Undoing a purchase moves the purchased item and nothing
  * else, exactly as the receipt it undoes did.
+ *
+ * `extendedCost` is left to the shared writer to compute from
+ * `computeExtendedCost(unitCost, quantity)` - never negated from a stored
+ * total, so a reversal stays identical in magnitude to the receipt it undoes
+ * without depending on a number the original may never have carried.
  */
 async function writeReversal(
   db: Database,
@@ -379,60 +384,49 @@ async function writeReversal(
 ): Promise<MovementRecord> {
   const { movementDefId, originalMovementId, original, reason, occurredAt } = args
 
-  const partDefId = await requireDefId(organizationId, 'part')
+  const partDefId = await getPartDefId(organizationId)
   const quantity = -original.quantity
   const unitCost = original.unitCost
-  // Recomputed rather than negated from the stored total: `computeExtendedCost`
-  // rounds AFTER multiplying, so deriving it here keeps a reversal identical in
-  // magnitude to the receipt it undoes without depending on a stored number the
-  // original may never have carried.
-  const extendedCost = computeExtendedCost(unitCost, quantity)
 
-  const values: Record<string, unknown> = {
-    stock_movement_part: toRecordId(partDefId, original.partId),
-    stock_movement_type: reversalTypeFor(original.type),
-    stock_movement_quantity: quantity,
-    // See the JSDoc above. Never true on a reversal.
-    stock_movement_adjust_subparts: false,
-    stock_movement_unit_cost: unitCost,
-    stock_movement_extended_cost: extendedCost,
-    stock_movement_gl_account: original.glAccount,
-    stock_movement_occurred_at: occurredAt.toISOString(),
-    stock_movement_reverses_movement: toRecordId(movementDefId, originalMovementId),
-  }
-
-  // The basis follows the cost. A row carrying the original's frozen `actual`
-  // cost is still an `actual`, and re-deciding it here would let a reversal
-  // disagree with the movement it is a copy of.
-  if (original.costBasis) values.stock_movement_cost_basis = original.costBasis
-  if (original.vendorUnitPrice != null) {
-    values.stock_movement_vendor_unit_price = original.vendorUnitPrice
-  }
-  if (reason) values.stock_movement_reason = reason
-
-  if (original.vendorPartId) {
-    const vendorPartDefId = await requireDefId(organizationId, 'vendor_part')
-    values.stock_movement_vendor_part = toRecordId(vendorPartDefId, original.vendorPartId)
-  }
-
-  if (original.purchaseOrderLineId) {
-    // The copy that makes `purchase_order_line_quantity_received` roll back for
-    // free: the roll-up re-SUMs every movement pointing at the line, so the
-    // negative quantity decrements it with no change to the roll-up itself.
-    const lineDefId = await requireDefId(organizationId, 'purchase_order_line')
-    values.stock_movement_purchase_order_line = toRecordId(lineDefId, original.purchaseOrderLineId)
-  }
-
-  const crud = new UnifiedCrudHandler(organizationId, userId, db)
-  const created = await crud.create(movementDefId, values)
+  const written = await writeStockMovements(
+    { db, organizationId, userId, movementDefId, partDefId, lane: { kind: 'plain' } },
+    [
+      {
+        partInstanceId: original.partId,
+        type: reversalTypeFor(original.type),
+        quantity,
+        unitCost,
+        // The basis follows the cost. A row carrying the original's frozen
+        // `actual` cost is still an `actual`, and re-deciding it here would
+        // let a reversal disagree with the movement it is a copy of. Omitted
+        // entirely (not defaulted) when the original never carried one.
+        costBasis: original.costBasis ?? undefined,
+        glAccount: original.glAccount,
+        occurredAt,
+        vendorUnitPrice: original.vendorUnitPrice ?? undefined,
+        reason,
+        links: {
+          reversesMovementId: originalMovementId,
+          vendorPartId: original.vendorPartId ?? undefined,
+          // The copy that makes `purchase_order_line_quantity_received` roll
+          // back for free: the roll-up re-SUMs every movement pointing at the
+          // line, so the negative quantity decrements it with no change to
+          // the roll-up itself.
+          purchaseOrderLineId: original.purchaseOrderLineId ?? undefined,
+        },
+      },
+    ]
+  )
+  if (written.isErr()) throw written.error
+  const record = written.value.records[0]!
 
   return {
-    movementId: created.instance.id,
-    recordId: toRecordId(movementDefId, created.instance.id),
+    movementId: record.movementId,
+    recordId: record.recordId,
     partInstanceId: original.partId,
     quantity,
     unitCost,
-    extendedCost,
+    extendedCost: record.extendedCost,
     vendorUnitPrice: original.vendorUnitPrice,
     vendorPartId: original.vendorPartId,
     glAccount: original.glAccount,
@@ -447,17 +441,13 @@ function reversalTypeFor(originalType: string): string {
 }
 
 /**
- * Resolve a def id the ORIGINAL movement already committed us to, as an
- * `UnprocessableEntityError` rather than the bare `Error` the cache helper
- * throws — "the movement you are undoing names a purchase order line and this
- * org has no purchase orders" is a 422 the UI can act on, not a 500.
+ * Resolve the org's `part` def id, as an `UnprocessableEntityError` rather
+ * than the bare `Error` the cache helper throws.
  */
-async function requireDefId(organizationId: string, entityType: string): Promise<string> {
-  const defId = await getCachedEntityDefId(organizationId, entityType)
+async function getPartDefId(organizationId: string): Promise<string> {
+  const defId = await getCachedEntityDefId(organizationId, 'part')
   if (!defId) {
-    throw new UnprocessableEntityError(
-      `This organization has no ${entityType} entity definition yet`
-    )
+    throw new UnprocessableEntityError('This organization has no part entity definition yet')
   }
   return defId
 }

--- a/packages/lib/src/resources/registry/__tests__/system-entity-behavior.test.ts
+++ b/packages/lib/src/resources/registry/__tests__/system-entity-behavior.test.ts
@@ -41,7 +41,7 @@ describe('the shipped behavior map is exactly the curated set', () => {
   // One settled array, no provisional half — forces every new def to be an
   // explicit decision in review. Modeled on
   // ai-entity-visibility.test.ts:236.
-  it('SYSTEM_ENTITY_BEHAVIOR keys are exactly the 34 defs that differ from DEFAULTS', () => {
+  it('SYSTEM_ENTITY_BEHAVIOR keys are exactly the 36 defs that differ from DEFAULTS', () => {
     expect(Object.keys(SYSTEM_ENTITY_BEHAVIOR).sort()).toEqual([
       'article',
       'bank_account',
@@ -53,6 +53,8 @@ describe('the shipped behavior map is exactly the curated set', () => {
       'credit_memo_application',
       'credit_memo_line',
       'entity_group',
+      'fulfillment',
+      'fulfillment_line',
       'gl_account',
       'inbox',
       'journal_entry',

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -1038,6 +1038,45 @@ export const ParcelTrackingStatus = {
  * `partially_delivered` and the problem box stays invisible until somebody opens
  * the shipment.
  */
+/**
+ * Fulfillment Status - Shopify's own per-dispatch lifecycle
+ * `plans/money/tasks/55-shipment-lines.md` §3. Deliberately mirrors Shopify's
+ * vocabulary exactly (unlike {@link OrderFulfillmentStatus}, which is auxx's
+ * own aggregate over the order): the connector passes `f.status` straight
+ * through with no mapping, and `success` is a Shopify-ism, not an auxx word
+ * choice.
+ *
+ * 🛑 All six values, not five - the brief's §3 table omitted `pending`. Source
+ * of truth: `RawFulfillment`'s own docblock in the Shopify connector
+ * (`shopify.connector.server.ts`, the `status` field) reads `Lifecycle:
+ * pending | open | success | cancelled | error | failure`. This is a
+ * SINGLE_SELECT, and a written value with no matching option is not loudly
+ * refused in this codebase - it lands as an `optionId` no read path resolves,
+ * silently. Missing `pending` here would mean every fulfillment Shopify has
+ * not yet started working reads as no status at all rather than erroring.
+ *
+ * `cancelled` is a RECORD with this value, never an absence - the connector
+ * emits cancelled fulfillments rather than dropping them, and inventory
+ * relief nets against the row (task 50).
+ */
+export const FulfillmentStatus = {
+  PENDING: 'pending',
+  OPEN: 'open',
+  SUCCESS: 'success',
+  CANCELLED: 'cancelled',
+  ERROR: 'error',
+  FAILURE: 'failure',
+
+  values: [
+    { value: 'pending', label: 'Pending', color: 'gray' },
+    { value: 'open', label: 'Open', color: 'blue' },
+    { value: 'success', label: 'Success', color: 'green' },
+    { value: 'cancelled', label: 'Cancelled', color: 'gray' },
+    { value: 'error', label: 'Error', color: 'amber' },
+    { value: 'failure', label: 'Failure', color: 'red' },
+  ] satisfies FieldOptionItem[],
+} as const
+
 export const ShipmentStatus = {
   LABEL_CREATED: 'label_created',
   PICKED_UP: 'picked_up',

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -18,6 +18,8 @@ import { CREDIT_MEMO_APPLICATION_FIELDS } from './resources/credit-memo-applicat
 import { CREDIT_MEMO_FIELDS } from './resources/credit-memo-fields'
 import { CREDIT_MEMO_LINE_FIELDS } from './resources/credit-memo-line-fields'
 import { DATASET_FIELDS } from './resources/dataset-fields'
+import { FULFILLMENT_FIELDS } from './resources/fulfillment-fields'
+import { FULFILLMENT_LINE_FIELDS } from './resources/fulfillment-line-fields'
 import { GL_ACCOUNT_FIELDS } from './resources/gl-account-fields'
 import { INBOX_FIELDS } from './resources/inbox-fields'
 import { INVOICE_FIELDS } from './resources/invoice-fields'
@@ -180,6 +182,12 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   // contribute status (shared-shipment-entities-proposal.md). Entity migration 149.
   shipment: SHIPMENT_FIELDS,
   parcel: PARCEL_FIELDS,
+  // Hidden, sales-channel fact: one dispatch and its per-line-item tuples,
+  // replacing the `order_fulfillments` JSON array so revenue posts from
+  // records instead of a collapsed min/max/sum (plans/money/tasks/55). Entity
+  // migration 153.
+  fulfillment: FULFILLMENT_FIELDS,
+  fulfillment_line: FULFILLMENT_LINE_FIELDS,
 }
 
 /**

--- a/packages/lib/src/resources/registry/resources/fulfillment-fields.ts
+++ b/packages/lib/src/resources/registry/resources/fulfillment-fields.ts
@@ -1,0 +1,591 @@
+// packages/lib/src/resources/registry/resources/fulfillment-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import { FulfillmentStatus } from '../enum-values'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Fulfillment resource
+ * (`plans/money/tasks/55-shipment-lines.md` §3).
+ *
+ * ## What this replaces
+ *
+ * One dispatch of goods as the sales channel describes it - the record form of
+ * what used to be one entry in the `order_fulfillments` JSON array. Entity
+ * migration 153 drops that JSON field and recreates it under the SAME name as
+ * a has_many pointing here, because Shopify sends per-fulfillment line
+ * quantities and dates for every merchant and the old field threw them away
+ * (§1 of the brief). Revenue now posts from these records, not from a
+ * collapsed min/max/sum over them.
+ *
+ * `isVisible: false`, no route folder - the same hiding `credit_memo_line` and
+ * `parcel` get, for the same reason: nobody creates one by hand, and there is
+ * no list page to 404.
+ *
+ * ## Why not the `shipment` entity
+ *
+ * `shipment` / `parcel` are the LOGISTICS fact (which boxes, which carrier,
+ * where are they), written by ShipStation and the carrier apps, and they exist
+ * only when a label was bought through a connected provider. `fulfillment` /
+ * `fulfillment_line` are the SALES-CHANNEL fact (which order lines went out,
+ * how many, when), written by any channel and by `money.fulfillOrder`, and
+ * they exist ALWAYS - a fulfillment marked complete in the Shopify admin with
+ * no label bought still has to post revenue. The two meet only on the
+ * nullable {@link shipment} edge (§2.2 of the brief); nothing in relief or
+ * posting may read it.
+ *
+ * ⚠️ `RawFulfillment.location_id` exists on the Shopify payload and is
+ * deliberately NOT mapped here - auxx has no locations today. It is the field
+ * a future multi-location on-hand would need, recorded here as an omission
+ * rather than forgotten.
+ */
+export const FULFILLMENT_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique fulfillment identifier',
+  },
+
+  /** The order this fulfillment shipped against. The owning side of `order_fulfillments`. */
+  order: {
+    id: toFieldId('order'),
+    key: 'order',
+    label: 'Order',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'fulfillment_order',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'order:fulfillments' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'order',
+      relationshipType: 'belongs_to',
+      inverseName: 'Fulfillments',
+      inverseSystemAttribute: 'order_fulfillments',
+    },
+    description: 'The order this fulfillment shipped against',
+  },
+
+  /**
+   * 1-based within the order, in ship-date order. The revenue poster's
+   * document numbers key on it, the same role `bank_deposit_number` /
+   * `payout_number` play for their own postings - see §5's open question on
+   * where this gets computed (the projection, mirroring where `shipment_count`
+   * is derived today).
+   */
+  sequence: {
+    id: toFieldId('sequence'),
+    key: 'sequence',
+    label: 'Sequence',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'fulfillment_sequence',
+    systemSortOrder: 'a2',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description: "1-based within the order, ship-date order. The poster's doc numbers key on it",
+  },
+
+  /**
+   * Shopify's fulfillment `created_at`. 🛑 Never `updated_at`, which moves on
+   * every tracking scan and would silently re-date revenue already posted.
+   */
+  shippedAt: {
+    id: toFieldId('shippedAt'),
+    key: 'shippedAt',
+    label: 'Shipped At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'fulfillment_shipped_at',
+    systemSortOrder: 'a3',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      "THE accounting date. Shopify's fulfillment created_at - never updated_at, which moves " +
+      'on every tracking scan',
+  },
+
+  /** Shopify's own fulfillment lifecycle. See {@link FulfillmentStatus} for the values. */
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'fulfillment_status',
+    systemSortOrder: 'a4',
+    nullable: false,
+    options: { options: [...FulfillmentStatus.values] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      "Shopify's own fulfillment lifecycle. 🛑 A cancelled fulfillment is a record with this " +
+      'set to cancelled, never an absence - a vanished record is indistinguishable from one ' +
+      'never seen, and inventory relief nets against it',
+  },
+
+  /**
+   * When a relief reversal is written, on a cancelled fulfillment. NOT
+   * {@link shippedAt} - that is the dispatch date, and reversing relief at the
+   * dispatch date rather than the cancellation date would misdate the
+   * reversal's own accounting period.
+   */
+  cancelledAt: {
+    id: toFieldId('cancelledAt'),
+    key: 'cancelledAt',
+    label: 'Cancelled At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'fulfillment_cancelled_at',
+    systemSortOrder: 'a5',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'The date a relief reversal is written at, on a cancelled fulfillment. shippedAt is ' +
+      'the wrong one - it is the dispatch date, not the cancellation date',
+  },
+
+  /**
+   * ### A display field is not optional
+   *
+   * `computeDisplayValue` reads a field on the ROW and has no fallback - the
+   * shipment proposal learned this the expensive way when `shipment_number`
+   * was empty on 135 of 135 rows and every one rendered nameless. This is
+   * nullable in the type because Shopify's own field can be absent on an
+   * older API version, but the connector projects it (Shopify's `name`, e.g.
+   * `#1001.1`) and the native door (`money.fulfillOrder`) synthesises one when
+   * there is nothing to project, so in practice it is always there to read.
+   */
+  name: {
+    id: toFieldId('name'),
+    key: 'name',
+    label: 'Name',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'fulfillment_name',
+    systemSortOrder: 'a6',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      "The display field. Shopify's own name (#1001.1) when supplied; the native door " +
+      'synthesises one otherwise. Nullable in the type only - never actually absent',
+  },
+
+  trackingNumber: {
+    id: toFieldId('trackingNumber'),
+    key: 'trackingNumber',
+    label: 'Tracking Number',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'fulfillment_tracking_number',
+    systemSortOrder: 'a7',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'The channel-supplied tracking number, if any - a fulfillment marked complete with no ' +
+      'label bought carries none. This is the opportunistic match key for the nullable ' +
+      '{@link shipment} edge; nothing in relief or posting may read it (§2.2)',
+  },
+
+  trackingCompany: {
+    id: toFieldId('trackingCompany'),
+    key: 'trackingCompany',
+    label: 'Tracking Company',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'fulfillment_tracking_company',
+    systemSortOrder: 'a8',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+  },
+
+  trackingUrl: {
+    id: toFieldId('trackingUrl'),
+    key: 'trackingUrl',
+    label: 'Tracking URL',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'fulfillment_tracking_url',
+    systemSortOrder: 'a9',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+  },
+
+  /** The goods amount this fulfillment recognised, in integer minor units. Was `subtotalMinor`. */
+  subtotal: {
+    id: toFieldId('subtotal'),
+    key: 'subtotal',
+    label: 'Subtotal',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'fulfillment_subtotal',
+    systemSortOrder: 'aA',
+    nullable: false,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Integer minor units. The goods amount this fulfillment recognised - was subtotalMinor',
+  },
+
+  /** Subtotal plus the freight this fulfillment recognised. Was `totalMinor`. */
+  total: {
+    id: toFieldId('total'),
+    key: 'total',
+    label: 'Total',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'fulfillment_total',
+    systemSortOrder: 'aB',
+    nullable: false,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Integer minor units. Subtotal plus the freight this fulfillment recognised - was totalMinor',
+  },
+
+  /**
+   * Whether freight was recognised on THIS fulfillment. Freight is recognised
+   * once, on the first dispatch of an order - every later fulfillment of the
+   * same order carries `false` here even though it has its own {@link subtotal}.
+   */
+  shippingRecognised: {
+    id: toFieldId('shippingRecognised'),
+    key: 'shippingRecognised',
+    label: 'Shipping Recognised',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'fulfillment_shipping_recognised',
+    systemSortOrder: 'aC',
+    nullable: false,
+    defaultValue: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Whether freight was recognised on THIS fulfillment - freight is recognised once, on ' +
+      'the first dispatch of an order, so a later fulfillment of the same order carries ' +
+      'false here even though it has its own subtotal',
+  },
+
+  /**
+   * 🛑 The posting this fulfillment became. TEXT and not a RELATIONSHIP,
+   * exactly the precedent `credit_memo_gl_posting` set
+   * (`credit-memo-fields.ts`): `GlPosting` is a Drizzle table with no
+   * `EntityDefinition` to point at - the `gl_posting` `EntityRefKind` was
+   * removed on 2026-08-28 for that reason, and `payout_gl_posting_id` /
+   * `credit_memo_gl_posting` are the precedent. `readUnpostedShipments`'s
+   * idempotency guard becomes a `fulfillment_gl_posting IS NULL` predicate over
+   * these records instead of the JSON array's `glPostingId IS NULL` filter.
+   */
+  glPosting: {
+    id: toFieldId('glPosting'),
+    key: 'glPosting',
+    label: 'GL Posting',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'fulfillment_gl_posting',
+    systemSortOrder: 'aD',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'The posting this fulfillment became. TEXT and not a RELATIONSHIP because GlPosting is ' +
+      'a Drizzle table with no EntityDefinition to point at - the gl_posting EntityRefKind ' +
+      'was removed on 2026-08-28 for that reason, and credit_memo_gl_posting / ' +
+      'payout_gl_posting_id are the precedent',
+  },
+
+  docNumber: {
+    id: toFieldId('docNumber'),
+    key: 'docNumber',
+    label: 'Doc Number',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'fulfillment_doc_number',
+    systemSortOrder: 'aE',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+  },
+
+  recordedAt: {
+    id: toFieldId('recordedAt'),
+    key: 'recordedAt',
+    label: 'Recorded At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'fulfillment_recorded_at',
+    systemSortOrder: 'aF',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'When auxx recorded this fulfillment, distinct from shippedAt (the accounting date)',
+  },
+
+  /** The lines: one record per (fulfillment, line item) tuple this dispatch carried. */
+  lines: {
+    id: toFieldId('lines'),
+    key: 'lines',
+    label: 'Lines',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'fulfillment_lines',
+    systemSortOrder: 'aG',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'fulfillment_line:fulfillment' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    },
+    description: 'The per-line-item tuples this dispatch carried - one record per shipped line',
+  },
+
+  /**
+   * ### The nullable, opportunistic join to the logistics fact (brief §2.2)
+   *
+   * Filled when a fulfillment's tracking number matches a
+   * `parcel_tracking_number`; empty otherwise, which is the ordinary case
+   * today (a ShipStation label is bought for only some dispatches). 🛑
+   * **Nothing in this brief or in inventory relief may read it** - the moment
+   * either does, the shipment proposal's unsolved order-linking problem (its
+   * §7) becomes a blocker for the books. It is a support convenience only.
+   *
+   * 🛑 **Deliberately one-sided, per the brief's explicit "nothing new on
+   * `shipment` or `parcel`".** Every other belongs_to field in this registry
+   * pairs with a has_many inverse so `linkNewRelationships` can resolve
+   * `inverseResourceFieldId` to a real `CustomField`; this one has none to
+   * resolve to; `relationship.inverseResourceFieldId` stays `null` forever,
+   * by construction, and `relationshipConfig` is omitted so neither the
+   * per-org seeder's Pass 3 nor a migration's linker ever logs a spurious
+   * "inverse not found" warning trying to find one. The field still stores
+   * and reads correctly: a `RELATIONSHIP` value's target entity type is
+   * carried per-row on `FieldValue.relatedEntityDefinitionId`, not derived
+   * from the field's own inverse pairing, so an unresolved inverse costs this
+   * edge exactly two things and nothing else - reverse traversal from
+   * `shipment` (there is no field to traverse from) and a declared
+   * `onDelete` (the registry's own rule is that a `belongs_to` side never
+   * declares one; the has_many side does, and there is no has_many side
+   * here). A `shipment` deleted out from under a live pointer here is left
+   * unlinked rather than cascaded - acceptable exactly because §2.2 says
+   * nothing may depend on this edge.
+   */
+  shipment: {
+    id: toFieldId('shipment'),
+    key: 'shipment',
+    label: 'Shipment',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'fulfillment_shipment',
+    systemSortOrder: 'aH',
+    nullable: true,
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: null,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    description:
+      'The dispatch this maps to on the logistics side, filled opportunistically by ' +
+      'matching tracking numbers. Nullable, one-sided - no field on shipment points back ' +
+      '(brief §2.2), and nothing in relief or posting may read it',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the fulfillment is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the fulfillment is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/fulfillment-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/fulfillment-line-fields.ts
@@ -1,0 +1,251 @@
+// packages/lib/src/resources/registry/resources/fulfillment-line-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Fulfillment Line resource
+ * (`plans/money/tasks/55-shipment-lines.md` §3).
+ *
+ * One record per `(fulfillment, line_item)` tuple: units of ONE order line
+ * that went out in ONE dispatch. Hidden (`isVisible: false`), no route
+ * folder, managed entirely from the parent `fulfillment` - the same treatment
+ * `credit_memo_line` and `purchase_order_line` get.
+ *
+ * Deliberately carries no part, no date, and no money. The part is reached
+ * through `line_item_part`, the date through the parent fulfillment's
+ * `fulfillment_shipped_at`, and the money never existed per line in the old
+ * JSON log either - each would be a second copy that can go stale.
+ *
+ * The identity Shopify supplies for the connector to bind on is
+ * `${fulfillmentId}:${lineItemId}` - REST gives no id of its own for a
+ * fulfillment line, but both halves here are real Shopify ids (stronger than
+ * the tax-line precedent, which synthesises from a title because a Shopify
+ * tax line carries no id at all). That identity is a connector-side concern
+ * (§5 of the brief) and is not a field on this def.
+ */
+export const FULFILLMENT_LINE_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique fulfillment line identifier',
+  },
+
+  /** The dispatch this line belongs to. The owning side of `fulfillment_lines`. */
+  fulfillment: {
+    id: toFieldId('fulfillment'),
+    key: 'fulfillment',
+    label: 'Fulfillment',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'fulfillment_line_fulfillment',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'fulfillment:lines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'fulfillment',
+      relationshipType: 'belongs_to',
+      inverseName: 'Lines',
+      inverseSystemAttribute: 'fulfillment_lines',
+    },
+    description: 'The dispatch this line belongs to',
+  },
+
+  /**
+   * The order line these units shipped against. Bound from Shopify's
+   * `line_item_id` on the connector path - the line item already exists as
+   * its own record from the order fan-out, so this LINKS rather than mints
+   * (the connector's `reference` link mode, §5 of the brief).
+   */
+  lineItem: {
+    id: toFieldId('lineItem'),
+    key: 'lineItem',
+    label: 'Line Item',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'fulfillment_line_line_item',
+    systemSortOrder: 'a2',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'line_item:fulfillmentLines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'line_item',
+      relationshipType: 'belongs_to',
+      inverseName: 'Fulfillment Lines',
+      inverseSystemAttribute: 'line_item_fulfillment_lines',
+    },
+    description:
+      'The order line these units shipped against - links to the existing line item record ' +
+      'rather than minting one',
+  },
+
+  /** Units of the line shipped in THIS dispatch - not the line's total, not cumulative. */
+  quantity: {
+    id: toFieldId('quantity'),
+    key: 'quantity',
+    label: 'Quantity',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'fulfillment_line_quantity',
+    systemSortOrder: 'a3',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Units of the line item shipped in THIS dispatch only - never cumulative',
+  },
+
+  /**
+   * 🔑 The exact mirror of `purchase_order_line_quantity_received`: re-SUMmed
+   * whole by a post-hook over `stock_movement_fulfillment_line`, never
+   * incremented in place, with `field-hooks/post/purchase-order-line-rollups.ts`
+   * as the template (plans/money/tasks/50-batch-inventory-relief.md). The
+   * subledger is the truth and a hand-maintained copy of it diverges silently -
+   * same reason `part_quantity_on_hand` is computed rather than typed.
+   */
+  quantityRelieved: {
+    id: toFieldId('quantityRelieved'),
+    key: 'quantityRelieved',
+    label: 'Qty Relieved',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'fulfillment_line_quantity_relieved',
+    systemSortOrder: 'a4',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Re-SUMmed whole from stock_movement_fulfillment_line by a post-hook, never ' +
+      'incremented - the same shape as purchase_order_line_quantity_received and for the ' +
+      'same reason: the subledger is the truth',
+  },
+
+  // Reverse relationship: stockMovements (from stock_movement.fulfillmentLine).
+  // The sell-side mirror of `purchase_order_line.stockMovements` - what
+  // `quantityRelieved` re-sums over, and all of task 50's netting.
+  stockMovements: {
+    id: toFieldId('stockMovements'),
+    key: 'stockMovements',
+    label: 'Stock Movements',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'fulfillment_line_stock_movements',
+    systemSortOrder: 'a5',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'stock_movement:fulfillmentLine' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    },
+    description: 'The stock movements that relieved this line - what quantityRelieved re-sums over',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the fulfillment line is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the fulfillment line is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -376,6 +376,38 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     description: 'Credit memo lines that returned, cancelled or credited part of this line',
   },
 
+  // Reverse relationship: fulfillment lines that shipped part of this line
+  // (plans/money/tasks/55-shipment-lines.md §3) - "where did this line's units
+  // go". Same reasoning as `creditMemoLines` directly above: the counterpart
+  // of the owning `fulfillment_line_line_item`, declared so the edge is not
+  // left unlinked (the trap entity migration 135 asserts against).
+  fulfillmentLines: {
+    id: toFieldId('fulfillmentLines'),
+    key: 'fulfillmentLines',
+    label: 'Fulfillment Lines',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'line_item_fulfillment_lines',
+    systemSortOrder: 'a7c',
+    showInPanel: false,
+    showInDialogs: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'fulfillment_line:lineItem' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'unlink',
+      isInverse: true,
+    },
+    description: "Fulfillment lines that shipped part of this line - where this line's units went",
+  },
+
   optional: {
     id: toFieldId('optional'),
     key: 'optional',

--- a/packages/lib/src/resources/registry/resources/order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/order-fields.ts
@@ -689,8 +689,8 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
   },
 
   /**
-   * The shipment log: one entry per fulfillment `money.fulfillOrder` recorded
-   * (plans/accounting/HANDOFF.md slot 2G, tasks/01 §5).
+   * The shipment records: one `fulfillment` per dispatch `money.fulfillOrder`
+   * (or a channel connector) creates (plans/money/tasks/55-shipment-lines.md).
    *
    * 🛑 **This is the ONLY thing that makes "how much of this line is still to
    * ship" answerable.** `order_fulfillment_status` says `partial` and cannot
@@ -699,45 +699,48 @@ export const ORDER_FIELDS: Record<string, ResourceField> = {
    * line the first one already shipped and re-recognise its revenue - an entry
    * that balances and overstates the P&L with nothing to detect it.
    *
-   * JSON on the order rather than a `fulfillment` entity, following
-   * `journal_entry_lines` (`postings/journal-entries/client.ts`) exactly: a
-   * shipment has no independent identity, nothing links to it, and the
-   * normalised accounting copy already lives in `GlPostingLine`. A child entity
-   * would add an EntityInstance and several FieldValues per shipment for rows
-   * nobody addresses.
+   * 🔑 **Same name, new type.** Entity migration 153 DROPS the old JSON field
+   * of this exact name and recreates it as a RELATIONSHIP has_many, the
+   * inverse of `fulfillment_order`. The JSON choice was reasoned from two
+   * premises this migration invalidates: "a shipment has no independent
+   * identity" (Shopify assigns every fulfillment an id) and "nothing links to
+   * it" (`stock_movement` now does, via `stock_movement_fulfillment_line` -
+   * that link is the whole of task 50's inventory-relief netting). Revenue
+   * posts from these records now, not from a collapsed min/max/sum over a
+   * JSON array - see `fulfillment-fields.ts` for what replaced it.
    *
-   * ⚠️ The value is an OBJECT wrapping the array (`{ fulfillments: [...] }`),
-   * never the bare array - a `FieldValue` write treats a top-level array as a
-   * MULTI-VALUE write and this field is single-value, which
-   * `UnifiedCrudHandler.setFieldValues` logs and SWALLOWS. See
-   * `money/orders/client.ts`.
-   *
-   * `creatable: false`: a shipment is recorded by fulfilling, never by typing
-   * one into a create form.
+   * `cascade`, unlike `shipments` below: a fulfillment is fanned out of THIS
+   * order's own dispatch history and has no life without it, the same reason
+   * `creditMemos` cascades and `shipments` (ShipStation's own record) does
+   * not.
    */
   fulfillments: {
     id: toFieldId('fulfillments'),
     key: 'fulfillments',
     label: 'Fulfillments',
-    type: BaseType.JSON,
-    fieldType: FieldType.JSON,
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'order_fulfillments',
     systemSortOrder: 'aK1',
-    nullable: true,
-    showInPanel: false,
+    showInPanel: false, // has_many inverse; surfaced from the fulfillment side
     showInDialogs: false,
-    showInTable: false,
     capabilities: {
-      filterable: false,
+      filterable: true,
       sortable: false,
-      creatable: false,
+      creatable: true,
       updatable: true,
       configurable: false,
     },
+    relationship: {
+      inverseResourceFieldId: 'fulfillment:order' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    },
     description:
-      'One entry per shipment - sequence, date, the quantity shipped per line, and the GL ' +
-      'posting it produced. Appended by money.fulfillOrder, never edited',
+      'The dispatch records for this order - one per fulfillment, replacing the old JSON ' +
+      'shipment log under the same name (entity migration 153)',
   },
 
   /**

--- a/packages/lib/src/resources/registry/resources/return-fields.ts
+++ b/packages/lib/src/resources/registry/resources/return-fields.ts
@@ -1,0 +1,947 @@
+// packages/lib/src/resources/registry/resources/return-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import type { ResourceField } from '../field-types'
+
+/**
+ * The PHYSICAL lifecycle of a return (plans/money/tasks/54-returns.md §3.3).
+ *
+ * ```
+ * requested -> approved -> in_transit -> received -> inspected -> closed
+ *                    \-> declined          \-> cancelled
+ * ```
+ *
+ * An emailed or phoned return enters at `requested`. A dock surprise enters at
+ * `received` with {@link RETURN_FIELDS.contact} null. One line, two entry
+ * points. Transitions are enforced by `lifecycle-status-guard.ts`, the same way
+ * `build` and `purchase_order` do it.
+ *
+ * 🛑 There is deliberately NO `resolved` value and no money value of any kind.
+ * An earlier draft had `resolved` between `inspected` and `closed` and it was
+ * wrong: the refund routinely completes before the warehouse restocks, so on
+ * the day the money clears the return is neither `resolved` (nothing was
+ * inspected) nor merely `received` (that understates it). Goods and money are
+ * two axes, and crushing them into one enum is the mistake `VendorBillStatus`
+ * already stands as the cautionary tale for.
+ *
+ * Money is DERIVED, never stored as a status: {@link RETURN_FIELDS.creditedAmount}
+ * rolls up the linked credit memos, and "credited but not inspected" (memos
+ * present while status is below `inspected`) is a one-line derivation the UI
+ * surfaces as a badge. It is never blocked - there are good commercial reasons
+ * to refund fast, and the system's job is to say what was given up, not to
+ * refuse the decision.
+ */
+export const RETURN_STATUS_OPTIONS = [
+  { label: 'Requested', value: 'requested', color: 'gray' },
+  { label: 'Approved', value: 'approved', color: 'blue' },
+  { label: 'In Transit', value: 'in_transit', color: 'indigo' },
+  { label: 'Received', value: 'received', color: 'teal' },
+  { label: 'Inspected', value: 'inspected', color: 'amber' },
+  { label: 'Closed', value: 'closed', color: 'green' },
+  { label: 'Declined', value: 'declined', color: 'red' },
+  { label: 'Cancelled', value: 'cancelled', color: 'gray' },
+] as const
+
+/**
+ * How the return reached us (plans/money/tasks/54-returns.md §3.4).
+ *
+ * 🛑 A CLOSED `SINGLE_SELECT`, and that is a deliberate asymmetry with
+ * {@link RETURN_REASON_SEED_OPTIONS}, which is TAGS. A return has exactly ONE
+ * origin; TAGS is multi-value and would permit a return that arrived by both
+ * email and dock. Single-value-with-user-extension does not exist as a field
+ * type in this system: a `SINGLE_SELECT` marked `configurable: true` is
+ * editable only from the admin settings screen, never inline by the agent
+ * taking the call.
+ *
+ * ⚠️ `ensureCustomFields` never updates an existing field's options, so these
+ * values reach an org exactly ONCE, at creation. Adding one later needs its own
+ * entity migration. This binds hardest here, because the set is closed.
+ */
+export const RETURN_ORIGIN_OPTIONS = [
+  { label: 'Email', value: 'email', color: 'blue' },
+  { label: 'Phone', value: 'phone', color: 'purple' },
+  { label: 'Dock', value: 'dock', color: 'amber' },
+  { label: 'Web', value: 'web', color: 'teal' },
+] as const
+
+/**
+ * Why the goods came back (plans/money/tasks/54-returns.md §3.4). TAGS: ours,
+ * seeded, and user-extensible inline.
+ *
+ * The vocabulary is auxx's rather than any provider's. Shopify's `ReturnReason`
+ * is an apparel enum (`COLOR`, `SIZE_TOO_LARGE`, `STYLE`, `UNWANTED`, ...) with
+ * **no value for "the customer damaged it during installation"**, which is the
+ * exact fact a chargeback rebuttal turns on. `arrived_damaged` (carrier or our
+ * packing) and `damaged_by_customer` (theirs) are the two the business actually
+ * fights about, and no external system distinguishes them.
+ *
+ * No `other` value is seeded: with TAGS, "other" is just typing the real
+ * answer.
+ *
+ * ⚠️ Same one-shot rule as {@link RETURN_ORIGIN_OPTIONS}. `ensureCustomFields`
+ * never rewrites an existing field's options, so these seeds land once per org
+ * at creation and a later addition needs its own entity migration. TAGS is also
+ * multi-value, so a return may legitimately carry two reasons (wrong item AND
+ * damaged); that is accepted, and it is precisely why `origin` is not TAGS.
+ */
+export const RETURN_REASON_SEED_OPTIONS = [
+  { label: 'Not needed', value: 'not_needed', color: 'gray' },
+  { label: 'Ordered wrong', value: 'ordered_wrong', color: 'blue' },
+  { label: 'Arrived damaged', value: 'arrived_damaged', color: 'orange' },
+  { label: 'Damaged by customer', value: 'damaged_by_customer', color: 'red' },
+  { label: 'Defective', value: 'defective', color: 'amber' },
+  { label: 'Wrong item', value: 'wrong_item', color: 'purple' },
+  { label: 'Warranty', value: 'warranty', color: 'teal' },
+] as const
+
+/**
+ * Field definitions for the Return resource
+ * (plans/money/tasks/54-returns.md §3.1, §3.2, §3.3, §3.4, §3.7).
+ *
+ * ## What a return is
+ *
+ * ONE shipment back: one customer, one conversation. Its returned sold lines
+ * are `return_line` records, and the teardown checklist under each of those is
+ * `return_part_line`. Three grains, on purpose: this level is the logistics and
+ * money envelope, the middle level is the commercial fact and the evidence
+ * anchor, and the bottom level is the only thing that moves inventory.
+ *
+ * ## Visible, with a route folder, unlike `shipment` and `parcel`
+ *
+ * Warehouse staff create these BY HAND - returns do not arrive through the
+ * sales channel - so the list page and the create dialog are the entire point.
+ * `return` ships `isVisible: true` with a route folder at `app/returns/`.
+ * `return_line` and `return_part_line` stay hidden, like `credit_memo_line`.
+ *
+ * ## The money is linked, never created here
+ *
+ * The refund is issued at the channel and lands as a `credit_memo` with
+ * `source: channel`. A return LINKS to existing memos through
+ * {@link RETURN_FIELDS.creditMemos} and never creates one; the FK is on the
+ * memo because the memo is created first on the channel path. Nothing here ever
+ * writes to a channel-sourced memo: its fields are connector-managed and the
+ * next sync re-delivers every refund.
+ *
+ * Money amounts are integer MINOR UNITS.
+ */
+export const RETURN_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique return identifier',
+  },
+
+  // `RMA-` series through `keepOrAllocateRecordNumber`, wired exactly as `CM-`
+  // is on `credit_memo`: `creatable: false` and `updatable: false`, so the hook
+  // is the ONLY writer and the number is stable for the record's life. Nothing
+  // external supplies a number here, so in practice the hook always allocates.
+  number: {
+    id: toFieldId('number'),
+    key: 'number',
+    label: 'Number',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'return_number',
+    systemSortOrder: 'a1',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false, // hook-generated, prefix RMA - the hook is the ONLY writer
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Auto-generated return number, RMA-0001 off the return sequence scope',
+  },
+
+  /**
+   * Where the goods physically are. See {@link RETURN_STATUS_OPTIONS} for the
+   * transitions and for why there is no `resolved` and no money value.
+   */
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'return_status',
+    systemSortOrder: 'a2',
+    nullable: false,
+    options: { options: [...RETURN_STATUS_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select status',
+    defaultValue: 'requested',
+    description:
+      'The PHYSICAL lifecycle only: where the goods are. Money is never a status here - it ' +
+      'is derived from the linked credit memos. A dock surprise enters at received with no ' +
+      'contact; an emailed or phoned return enters at requested',
+  },
+
+  /**
+   * How the return reached us. Closed set, one value. See
+   * {@link RETURN_ORIGIN_OPTIONS} for why this is a `SINGLE_SELECT` while
+   * {@link reason} is TAGS.
+   */
+  origin: {
+    id: toFieldId('origin'),
+    key: 'origin',
+    label: 'Origin',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'return_origin',
+    systemSortOrder: 'a3',
+    nullable: true,
+    options: { options: [...RETURN_ORIGIN_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select origin',
+    description:
+      'How the return reached us: email, phone, dock or web. A CLOSED single select, not ' +
+      'tags - a return has exactly one origin, and a multi-value field would permit one that ' +
+      'arrived by both email and dock',
+  },
+
+  /**
+   * Why the goods came back. Seeded and user-extensible. See
+   * {@link RETURN_REASON_SEED_OPTIONS} for the seed set, why it is ours rather
+   * than any provider's, and why the seeds are one-shot per org.
+   */
+  reason: {
+    id: toFieldId('reason'),
+    key: 'reason',
+    label: 'Reason',
+    type: BaseType.TAGS,
+    fieldType: FieldType.TAGS,
+    isSystem: true,
+    systemAttribute: 'return_reason',
+    systemSortOrder: 'a4',
+    nullable: true,
+    options: { options: [...RETURN_REASON_SEED_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Add reasons',
+    description:
+      'Why the goods came back. TAGS, seeded but extensible inline by the agent taking the ' +
+      'call. Multi-value on purpose: wrong item AND damaged is a real answer. The seed ' +
+      'values reach an org once, at creation - adding one later needs its own migration',
+  },
+
+  /**
+   * 🛑 NULLABLE, and that is LOAD-BEARING (§3.2).
+   *
+   * Every other document in this system requires a party: `credit_memo.contact`
+   * is `nullable: false, required: true`. A return cannot be. About 15% of
+   * Auxx-Lift's returns are an unannounced pallet on the dock with no RMA, no
+   * email and no call, and the record has to exist BEFORE anyone knows whose it
+   * is. The warehouse photographs the label, types the sender into
+   * {@link senderNameRaw}, and identification happens later.
+   *
+   * "Unidentified" is therefore DERIVED from `contact IS NULL`, never a status
+   * value: identification and lifecycle are different axes, and the dock queue
+   * is a saved view over this null rather than an enum member. Do not add one.
+   */
+  contact: {
+    id: toFieldId('contact'),
+    key: 'contact',
+    label: 'Contact',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_contact',
+    systemSortOrder: 'a5',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'contact:returns' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'contact',
+      relationshipType: 'belongs_to',
+      inverseName: 'Returns',
+      inverseSystemAttribute: 'contact_returns',
+    },
+    description:
+      'The customer returning the goods. NULLABLE by design: a pallet arrives on the dock ' +
+      'with no notice and the record exists before anyone knows whose it is. Unidentified is ' +
+      'derived from this being null, never a status value',
+  },
+
+  /**
+   * The order the goods were sold on. Nullable for the same reason
+   * {@link contact} is: a dock surprise has no order until somebody matches the
+   * shipping label.
+   */
+  order: {
+    id: toFieldId('order'),
+    key: 'order',
+    label: 'Order',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_order',
+    systemSortOrder: 'a6',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'order:returns' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'order',
+      relationshipType: 'belongs_to',
+      inverseName: 'Returns',
+      inverseSystemAttribute: 'order_returns',
+    },
+    description:
+      'The order the returned goods were sold on - nullable, because a dock surprise has no ' +
+      'order until the label is matched. Also what suggests which credit memos to link',
+  },
+
+  /**
+   * The conversation. The ticket is the PRIMARY creation door for a return:
+   * returns arrive as email or as a call, both of which already become a ticket,
+   * and the return is created or linked from inside the ticket drawer rather
+   * than from a new button of its own.
+   */
+  ticket: {
+    id: toFieldId('ticket'),
+    key: 'ticket',
+    label: 'Ticket',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_ticket',
+    systemSortOrder: 'a7',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'ticket:returns' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'ticket',
+      relationshipType: 'belongs_to',
+      inverseName: 'Returns',
+      inverseSystemAttribute: 'ticket_returns',
+    },
+    description:
+      'The conversation this return came out of. The ticket drawer is the primary creation ' +
+      'door, so this is usually preset by the create-from-ticket flow',
+  },
+
+  requestedAt: {
+    id: toFieldId('requestedAt'),
+    key: 'requestedAt',
+    label: 'Requested',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'return_requested_at',
+    systemSortOrder: 'a8',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'When the customer asked to return. Null on a dock surprise, which never had a request',
+  },
+
+  receivedAt: {
+    id: toFieldId('receivedAt'),
+    key: 'receivedAt',
+    label: 'Received',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'return_received_at',
+    systemSortOrder: 'a9',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'When the goods physically arrived at the dock',
+  },
+
+  inspectedAt: {
+    id: toFieldId('inspectedAt'),
+    key: 'inspectedAt',
+    label: 'Inspected',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'return_inspected_at',
+    systemSortOrder: 'aA',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'When the warehouse finished inspecting. Routinely WEEKS after the refund cleared, ' +
+      'which is why money is not a status',
+  },
+
+  closedAt: {
+    id: toFieldId('closedAt'),
+    key: 'closedAt',
+    label: 'Closed',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'return_closed_at',
+    systemSortOrder: 'aB',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'When the return was closed out, with nothing further owed in either direction',
+  },
+
+  /**
+   * What the shipping label says, before anyone matches it to a contact. This
+   * plus {@link senderAddressRaw} and the label photo in {@link photos} is the
+   * whole of what the dock knows on a surprise pallet. No OCR in v1: the
+   * warehouse reads the label and types it.
+   */
+  senderNameRaw: {
+    id: toFieldId('senderNameRaw'),
+    key: 'senderNameRaw',
+    label: 'Sender Name (as labelled)',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'return_sender_name_raw',
+    systemSortOrder: 'aC',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter the name on the shipping label',
+    description:
+      'The sender exactly as the shipping label reads it, typed by the warehouse before any ' +
+      'contact is matched. Never overwritten once a contact is identified - it is evidence',
+  },
+
+  senderAddressRaw: {
+    id: toFieldId('senderAddressRaw'),
+    key: 'senderAddressRaw',
+    label: 'Sender Address (as labelled)',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'return_sender_address_raw',
+    systemSortOrder: 'aD',
+    showInTable: false,
+    nullable: true,
+    options: { multiline: true, rows: 3 },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter the address on the shipping label',
+    description: 'The return address exactly as the shipping label reads it',
+  },
+
+  inboundCarrier: {
+    id: toFieldId('inboundCarrier'),
+    key: 'inboundCarrier',
+    label: 'Inbound Carrier',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'return_inbound_carrier',
+    systemSortOrder: 'aE',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'fedex',
+    description:
+      'Who carried the goods back. Free text for the same reason `shipment_carrier` is: the ' +
+      'carrier list is account configuration, not a registry fact',
+  },
+
+  inboundTracking: {
+    id: toFieldId('inboundTracking'),
+    key: 'inboundTracking',
+    label: 'Inbound Tracking',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'return_inbound_tracking',
+    systemSortOrder: 'aF',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter tracking number',
+    description: 'The tracking number on the inbound leg, when there is one',
+  },
+
+  labelProvided: {
+    id: toFieldId('labelProvided'),
+    key: 'labelProvided',
+    label: 'Label Provided',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'return_label_provided',
+    systemSortOrder: 'aG',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Did we pay for the return label',
+  },
+
+  labelCost: {
+    id: toFieldId('labelCost'),
+    key: 'labelCost',
+    label: 'Label Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'return_label_cost',
+    systemSortOrder: 'aH',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'What the return label cost us, in integer MINOR UNITS (1654 is $16.54). Null when the ' +
+      'customer paid their own way back',
+  },
+
+  /**
+   * What the returned items were sold for, in integer minor units.
+   * TRANSCRIBED, never computed: recomputing it from the order lines would
+   * silently correct a discount, a price override or a partial line, and the
+   * whole point of this number is that it is what the customer was charged.
+   */
+  goodsValue: {
+    id: toFieldId('goodsValue'),
+    key: 'goodsValue',
+    label: 'Goods Value',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'return_goods_value',
+    systemSortOrder: 'aI',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'What the returned items were sold for, integer minor units. Transcribed, never ' +
+      'computed from the order lines',
+  },
+
+  /**
+   * What was actually credited, in integer minor units.
+   *
+   * DERIVED: rolled up from the credit memos linked through
+   * {@link creditMemos}, never typed by a person. `creatable: false` and
+   * `updatable: false` keep every human door shut, the same way the credit
+   * memo's own totals are protected.
+   */
+  creditedAmount: {
+    id: toFieldId('creditedAmount'),
+    key: 'creditedAmount',
+    label: 'Credited Amount',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'return_credited_amount',
+    systemSortOrder: 'aJ',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false, // rolled up from the linked memos - the roll-up is the only writer
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Rolled up from the linked credit memos, integer minor units. Derived, never typed. ' +
+      'Memos present while status is below inspected is the "credited but not inspected" ' +
+      'risk state, surfaced as a badge and deliberately never blocked',
+  },
+
+  /**
+   * `goodsValue - creditedAmount`, in integer minor units. DERIVED.
+   *
+   * 🛑 This has NO GL effect and no account role of its own (§5.2). When we
+   * refund $800 against $1,000 of goods, the memo IS $800 and the $200 was
+   * never credited, so there is nothing to post. An earlier design added a
+   * "damage deduction" LINE to the credit memo and was dropped: the memo is
+   * connector-managed, its total equals what the channel refunded by
+   * construction, and a line we add would be fought by the next sync.
+   *
+   * This is reporting and evidence. It is also already the column to sum if
+   * "how much did we eat on damage" is ever wanted annually.
+   */
+  withheldAmount: {
+    id: toFieldId('withheldAmount'),
+    key: 'withheldAmount',
+    label: 'Withheld Amount',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'return_withheld_amount',
+    systemSortOrder: 'aK',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false, // derived from goodsValue and creditedAmount
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Goods value minus credited amount, integer minor units. Derived, never typed, and it ' +
+      'has no GL effect at all: the money was simply never credited',
+  },
+
+  /**
+   * The sentence that goes in the chargeback rebuttal. Long-form on purpose:
+   * "the customer damaged the mast during installation, see the dated
+   * inspection photos" is what a card network reads, and it is the one piece of
+   * this record a human has to write.
+   */
+  withheldReason: {
+    id: toFieldId('withheldReason'),
+    key: 'withheldReason',
+    label: 'Withheld Reason',
+    type: BaseType.STRING,
+    fieldType: FieldType.RICH_TEXT,
+    isSystem: true,
+    systemAttribute: 'return_withheld_reason',
+    systemSortOrder: 'aL',
+    showInTable: false,
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Why the full amount was not credited',
+    description: 'Why the full amount was not credited - the sentence for the chargeback rebuttal',
+  },
+
+  /**
+   * The label, the pallet, the packaging, the carrier paperwork. Documents as
+   * well as images, because a dock surprise routinely arrives with a printed
+   * packing slip or a carrier exception form and those are evidence too.
+   */
+  photos: {
+    id: toFieldId('photos'),
+    key: 'photos',
+    label: 'Photos',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'return_photos',
+    systemSortOrder: 'aM',
+    nullable: true,
+    options: {
+      file: { allowMultiple: true, maxFiles: 25, allowedFileTypes: ['document', 'image'] },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'The shipping label, the pallet, the packaging and the carrier paperwork. Per-item ' +
+      'damage photos belong on the return line, not here',
+  },
+
+  /**
+   * The returned sold lines. One row per sold line PER CONDITION, so two lifts
+   * returned pristine and wrecked are two rows against the same `line_item`.
+   *
+   * `cascade` because a return line is an owned child: it has no meaning
+   * without its return. The has_many side declares the behavior; the
+   * `belongs_to` on `return_line` declares nothing.
+   */
+  lines: {
+    id: toFieldId('lines'),
+    key: 'lines',
+    label: 'Lines',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_lines',
+    systemSortOrder: 'aN',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'return_line:return' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    },
+    description:
+      'The returned sold lines - one per sold line per condition, each carrying its own ' +
+      'condition grade, liability verdict, photos and part tree',
+  },
+
+  /**
+   * The credit memos raised for this return. INVERSE: the FK is on the memo
+   * (`credit_memo.return`), because a return produces zero, one or several
+   * memos, a memo very often has no return at all (an allowance, a
+   * cancellation), and on the channel path the memo exists FIRST. That is the
+   * only direction that works.
+   *
+   * `unlink` rather than `cascade`: a credit memo is a posted accounting
+   * document with its own life, and deleting the return must never take one
+   * with it.
+   */
+  creditMemos: {
+    id: toFieldId('creditMemos'),
+    key: 'creditMemos',
+    label: 'Credit Memos',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_credit_memos',
+    systemSortOrder: 'aO',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'credit_memo:return' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'unlink',
+      isInverse: true,
+    },
+    description:
+      'The credit memos raised for this return. The return LINKS to memos and never creates ' +
+      'one; a channel-sourced memo is connector-managed and must never be written to',
+  },
+
+  /**
+   * The generated chargeback evidence pack, as a single FILE value - the
+   * documents registry `pointerAttr` pattern.
+   *
+   * `updatable: false` (and `creatable: false`) is what keeps every human door
+   * shut, exactly as on `credit_memo_pdf_asset`. Never make this user-writable:
+   * `ensureDocumentPdf` reads the pointer, loads that MediaAsset and appends a
+   * new VERSION whenever the content hash disagrees, and a file a person
+   * uploaded has no `contentHash` at all, so the comparison always fails and
+   * the next generation would silently republish their file as our pack.
+   */
+  evidencePackAsset: {
+    id: toFieldId('evidencePackAsset'),
+    key: 'evidencePackAsset',
+    label: 'Evidence Pack',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'return_evidence_pack_asset',
+    systemSortOrder: 'aP',
+    showInPanel: false,
+    nullable: true,
+    options: {
+      file: { allowMultiple: false, maxFiles: 1, allowedFileTypes: ['document'] },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+      hidden: true,
+    },
+    description: 'The generated chargeback evidence pack PDF - the generator is the only writer',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Automatically set when the return record is created in auxx. Never the date the goods ' +
+      'arrived - see receivedAt',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the return is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/return-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/return-line-fields.ts
@@ -1,0 +1,540 @@
+// packages/lib/src/resources/registry/resources/return-line-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import type { ResourceField } from '../field-types'
+
+/**
+ * What condition the returned units came back in
+ * (plans/money/tasks/54-returns.md §3.5).
+ *
+ * The grade is the INSPECTOR's verdict on the whole of this line, which is why
+ * divergent conditions are two `return_line` rows rather than one row with a
+ * hedged grade. It is deliberately about the goods, not about fault: fault is
+ * {@link RETURN_LINE_LIABILITY_OPTIONS}, and the two answers come apart all the
+ * time (a `damaged_scrap` unit can still be `no_fault`).
+ */
+export const RETURN_LINE_CONDITION_GRADE_OPTIONS = [
+  { label: 'New, sealed', value: 'new_sealed', color: 'green' },
+  { label: 'New, open box', value: 'new_open_box', color: 'teal' },
+  { label: 'Used, resalable', value: 'used_resalable', color: 'blue' },
+  { label: 'Damaged, repairable', value: 'damaged_repairable', color: 'amber' },
+  { label: 'Damaged, scrap', value: 'damaged_scrap', color: 'red' },
+] as const
+
+/**
+ * WHOSE fault the condition is (plans/money/tasks/54-returns.md §3.5).
+ *
+ * 🔑 This is the field the chargeback turns on, and no external system carries
+ * it. Shopify's `ReturnReason` has no value for "the customer damaged it during
+ * installation", which is the exact fact Auxx-Lift has to prove when a lift is
+ * wrecked on site, a full refund is demanded, refused, and a chargeback filed.
+ *
+ * `undetermined` is a real answer and the honest default before inspection.
+ * `no_fault` means nothing was wrong with the goods at all - an unwanted or
+ * mis-ordered item.
+ */
+export const RETURN_LINE_LIABILITY_OPTIONS = [
+  { label: 'Customer damage', value: 'customer_damage', color: 'red' },
+  { label: 'Shipping damage', value: 'shipping_damage', color: 'orange' },
+  { label: 'Manufacturing defect', value: 'manufacturing_defect', color: 'purple' },
+  { label: 'Wear and tear', value: 'wear_and_tear', color: 'amber' },
+  { label: 'No fault', value: 'no_fault', color: 'blue' },
+  { label: 'Undetermined', value: 'undetermined', color: 'gray' },
+] as const
+
+/**
+ * Field definitions for the Return Line resource
+ * (plans/money/tasks/54-returns.md §3.5, §3.7).
+ *
+ * ## The grain: one per SOLD LINE returned, PER CONDITION
+ *
+ * The customer buys 2 lifts, the channel carries ONE line item with quantity 2,
+ * and they send 1 or 2 back. Either way that is one `return_line` against that
+ * sold line carrying the returned {@link RETURN_LINE_FIELDS.quantity} - NOT one
+ * row per physical unit.
+ *
+ * The one thing that splits a line is DIVERGENT CONDITION. Two lifts back, one
+ * pristine and one wrecked, are two rows of quantity 1, each with its own
+ * grade, liability verdict, notes, photos and part tree. So several rows may
+ * point at the same `line_item`, exactly as `credit_memo_line` already does
+ * when one sold line is credited in pieces.
+ *
+ * ## This is the evidence anchor
+ *
+ * Everything a chargeback rebuttal reads hangs here: the condition, whose fault
+ * it was, the inspector, when they looked, and the timestamped photos.
+ * Inspection findings are FIELDS on this row rather than a separate
+ * `return_inspection` definition, by owner decision - a re-inspection
+ * overwrites. If side-by-side findings are ever needed that is a new
+ * definition, and nothing here blocks it.
+ *
+ * ## 🛑 The guard this needs, which is not a field
+ *
+ * Σ {@link RETURN_LINE_FIELDS.quantity} across every `return_line` pointing at
+ * a given `line_item`, across ALL returns, must not exceed what that line
+ * actually SHIPPED. Without it a customer can return three of two lifts and the
+ * salvage tree will happily restock parts for a unit that never left. The
+ * ceiling is Σ `fulfillment_line_quantity` over the line's fulfillment lines
+ * (excluding `cancelled` ones), falling back to sold quantity when the line has
+ * no fulfillment lines at all. It belongs in a pre-write hook, not in the UI.
+ *
+ * ⤵️ There is deliberately NO `fulfillmentLine` relationship here. The guard
+ * reads the fulfillment lines off the `line_item` and the evidence pack reaches
+ * the dispatch through the order, so nothing needs the return to name which
+ * dispatch a unit came back from, and an unused relationship goes stale.
+ */
+export const RETURN_LINE_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique return line identifier',
+  },
+
+  /** The return this line belongs to. The owning side of `return_lines`. */
+  return: {
+    id: toFieldId('return'),
+    key: 'return',
+    label: 'Return',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_line_return',
+    systemSortOrder: 'a1',
+    nullable: false,
+    required: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'return:lines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'return',
+      relationshipType: 'belongs_to',
+      inverseName: 'Lines',
+      inverseSystemAttribute: 'return_lines',
+    },
+    description: 'The return this line belongs to',
+  },
+
+  /**
+   * The sold line being returned. NULLABLE: a manually keyed return has no
+   * order at all, which is the ordinary case for a dock surprise, and the
+   * record has to exist before anyone matches it.
+   */
+  lineItem: {
+    id: toFieldId('lineItem'),
+    key: 'lineItem',
+    label: 'Line Item',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_line_line_item',
+    systemSortOrder: 'a2',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'line_item:returnLines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'line_item',
+      relationshipType: 'belongs_to',
+      inverseName: 'Return Lines',
+      inverseSystemAttribute: 'line_item_return_lines',
+    },
+    description:
+      'The sold line these units came off - nullable, because a manually keyed return may ' +
+      'have no order. Several return lines may point at one line item when the units came ' +
+      'back in different conditions',
+  },
+
+  /**
+   * What came back. Denormalized off the sold line so a return with no order
+   * still names a part, and it is the BOM ROOT the salvage tree is loaded from.
+   */
+  part: {
+    id: toFieldId('part'),
+    key: 'part',
+    label: 'Part',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_line_part',
+    systemSortOrder: 'a3',
+    nullable: false,
+    required: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'part:returnLines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'part',
+      relationshipType: 'belongs_to',
+      inverseName: 'Return Lines',
+      inverseSystemAttribute: 'part_return_lines',
+    },
+    description:
+      'What came back. Required and denormalized off the sold line, because a return with no ' +
+      'order still has to name a part - and this is the BOM root the salvage tree loads from',
+  },
+
+  /**
+   * Units returned on this line, bounded by what the sold line SHIPPED. See the
+   * module docblock for the cross-return guard, which is a pre-write hook
+   * rather than anything expressible here.
+   */
+  quantity: {
+    id: toFieldId('quantity'),
+    key: 'quantity',
+    label: 'Quantity',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'return_line_quantity',
+    systemSortOrder: 'a4',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    defaultValue: 1,
+    validation: { min: 0 },
+    description:
+      'Units returned on this line. Bounded across ALL returns by what the sold line shipped, ' +
+      'not by what it sold',
+  },
+
+  customerReason: {
+    id: toFieldId('customerReason'),
+    key: 'customerReason',
+    label: 'Customer Reason',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'return_line_customer_reason',
+    systemSortOrder: 'a5',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: "The customer's stated reason",
+    description:
+      "The customer's own words for why this came back, kept verbatim beside the return's " +
+      'normalized reason tags. Their claim is evidence; our classification is not',
+  },
+
+  customerNote: {
+    id: toFieldId('customerNote'),
+    key: 'customerNote',
+    label: 'Customer Note',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'return_line_customer_note',
+    systemSortOrder: 'a6',
+    showInTable: false,
+    nullable: true,
+    options: { multiline: true, rows: 3 },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Anything else the customer said',
+    description: 'Anything further the customer said about this line, in their words',
+  },
+
+  /**
+   * The inspector's verdict on the goods. See
+   * {@link RETURN_LINE_CONDITION_GRADE_OPTIONS}. Null until somebody inspects,
+   * which is routinely weeks after the refund cleared.
+   */
+  conditionGrade: {
+    id: toFieldId('conditionGrade'),
+    key: 'conditionGrade',
+    label: 'Condition Grade',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'return_line_condition_grade',
+    systemSortOrder: 'a7',
+    nullable: true,
+    options: { options: [...RETURN_LINE_CONDITION_GRADE_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select condition',
+    description:
+      'What condition the units came back in. One grade per line, which is why units that ' +
+      'came back differently are separate lines. Null until inspection',
+  },
+
+  /**
+   * Whose fault the condition is. See {@link RETURN_LINE_LIABILITY_OPTIONS}.
+   * Independent of {@link conditionGrade} on purpose: a scrapped unit can still
+   * be `no_fault`, and a pristine one can still be `customer_damage` on a part
+   * the customer already swapped out.
+   */
+  liability: {
+    id: toFieldId('liability'),
+    key: 'liability',
+    label: 'Liability',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'return_line_liability',
+    systemSortOrder: 'a8',
+    nullable: true,
+    options: { options: [...RETURN_LINE_LIABILITY_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select liability',
+    description:
+      'Whose fault the condition is - the fact a chargeback turns on, and one no sales ' +
+      'channel carries. Independent of the condition grade',
+  },
+
+  inspectionNotes: {
+    id: toFieldId('inspectionNotes'),
+    key: 'inspectionNotes',
+    label: 'Inspection Notes',
+    type: BaseType.STRING,
+    fieldType: FieldType.RICH_TEXT,
+    isSystem: true,
+    systemAttribute: 'return_line_inspection_notes',
+    systemSortOrder: 'a9',
+    showInTable: false,
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'What the inspection found',
+    description:
+      'What the inspection found. A re-inspection OVERWRITES this - findings are fields on ' +
+      'this row, not a separate inspection record',
+  },
+
+  inspectedBy: {
+    id: toFieldId('inspectedBy'),
+    key: 'inspectedBy',
+    label: 'Inspected By',
+    type: BaseType.ACTOR,
+    fieldType: FieldType.ACTOR,
+    isSystem: true,
+    systemAttribute: 'return_line_inspected_by',
+    systemSortOrder: 'aA',
+    dynamicOptionsKey: 'teamMembers',
+    nullable: true,
+    options: { actor: { target: 'user', multiple: false } },
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Who inspected these units. Named in the evidence pack',
+  },
+
+  inspectedAt: {
+    id: toFieldId('inspectedAt'),
+    key: 'inspectedAt',
+    label: 'Inspected At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'return_line_inspected_at',
+    systemSortOrder: 'aB',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'When these units were inspected. Per line rather than per return, because a pallet is ' +
+      'routinely opened one item at a time over several days',
+  },
+
+  /**
+   * The damage evidence. IMAGES ONLY, unlike the return's own photos: this is
+   * the timestamped proof of condition that a card network reads, and a PDF
+   * does not belong in it. If one component needs a photo it is photographed
+   * here, onto the parent line - `return_part_line` deliberately carries none.
+   */
+  photos: {
+    id: toFieldId('photos'),
+    key: 'photos',
+    label: 'Photos',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'return_line_photos',
+    systemSortOrder: 'aC',
+    nullable: true,
+    options: {
+      file: { allowMultiple: true, maxFiles: 25, allowedFileTypes: ['image'] },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Timestamped condition photos for these units. Every component photo lands here too - ' +
+      'the part lines carry no files of their own',
+  },
+
+  /**
+   * The teardown checklist: the BOM tree the warehouse works through.
+   *
+   * `cascade` because a part line is an owned child with no meaning away from
+   * its return line. The has_many side declares the behavior; the `belongs_to`
+   * on `return_part_line` declares nothing.
+   *
+   * ⚠️ Rows are materialized LAZILY, top level first and children on expand.
+   * Depth 20 times two lifts is an unbounded row count for a checklist somebody
+   * may only open two levels of, so a node with no row is `undecided` by
+   * absence and the salvage writer sees only rows a person actually touched.
+   */
+  partLines: {
+    id: toFieldId('partLines'),
+    key: 'partLines',
+    label: 'Part Lines',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_line_part_lines',
+    systemSortOrder: 'aD',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'return_part_line:returnLine' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    },
+    description:
+      'The teardown checklist under this line - the BOM tree, materialized lazily as the ' +
+      'warehouse works down it',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the return line is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the return line is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/return-part-line-fields.ts
+++ b/packages/lib/src/resources/registry/resources/return-part-line-fields.ts
@@ -1,0 +1,528 @@
+// packages/lib/src/resources/registry/resources/return-part-line-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import type { ResourceField } from '../field-types'
+
+/**
+ * The warehouse's disposition for one node of the teardown tree
+ * (plans/money/tasks/54-returns.md §3.6, §6.3).
+ *
+ * 🛑 Only `good` writes anything to the ledger, and only at the HIGHEST `good`
+ * node in each branch: marking a subassembly good and also marking its children
+ * good is ONE recovery, not two.
+ *
+ * Every other value writes NOTHING. A scrapped component was never in inventory
+ * to begin with - the lift was relieved at sale - so a `scrap` movement would
+ * be inventing a quantity in order to remove it. The decision is recorded on
+ * the row and stops there.
+ *
+ * `undecided` is also what a node with NO ROW means: rows are materialized
+ * lazily as the warehouse expands the tree, so absence is the default rather
+ * than an explicit row.
+ */
+export const RETURN_PART_LINE_STATUS_OPTIONS = [
+  { label: 'Good', value: 'good', color: 'green' },
+  { label: 'Damaged', value: 'damaged', color: 'amber' },
+  { label: 'Scrap', value: 'scrap', color: 'red' },
+  { label: 'Missing', value: 'missing', color: 'orange' },
+  { label: 'Undecided', value: 'undecided', color: 'gray' },
+] as const
+
+/**
+ * Field definitions for the Return Part Line resource
+ * (plans/money/tasks/54-returns.md §3.6, §6.3, §6.4, §6.6, §3.7).
+ *
+ * ## The BOM tree, and NOTHING else
+ *
+ * Deliberately minimal, by explicit owner decision: *"we don't want all these
+ * fields for each row, it would be just one status and the qty. All the photos,
+ * notes etc would be on the return item itself."* So there is no `photos`, no
+ * `notes`, no `liability` and no `inspector` here. If a specific component
+ * needs a photo, it is photographed onto the parent `return_line`.
+ *
+ * A lift is built from subassemblies which have their own subassemblies, and
+ * the tree can be deep. {@link RETURN_PART_LINE_FIELDS.parent} is
+ * SELF-REFERENTIAL and is what makes it a tree.
+ *
+ * ## Why restocking the CHECKED node is coherent
+ *
+ * `completeBuild` consumes ONE level: a subassembly is produced by its own
+ * build and carries its own on-hand balance. So a subassembly went DOWN when
+ * the lift was built, and recovering it from a return puts it back at the same
+ * level it left. An intact subassembly is worth a subassembly, not a bag of
+ * leaves, and the ledger stays coherent at every depth.
+ *
+ * ## Rows are materialized LAZILY
+ *
+ * 🛑 Do not explode the whole BOM into rows when the return line is created.
+ * Depth 20 times two lifts is an unbounded row count for a checklist the
+ * warehouse may only open two levels of. Create the top level only and
+ * materialize a node's children on first expand; the tree the user sees is
+ * `loadSubpartGraph`'s in-memory map. A node with no row is `undecided` by
+ * absence, and the salvage writer therefore sees only rows somebody touched.
+ *
+ * ## Cost is FROZEN on the row, not recomputed
+ *
+ * {@link RETURN_PART_LINE_FIELDS.salvagePercent} is the input and
+ * {@link RETURN_PART_LINE_FIELDS.unitCost} is the output, and BOTH are stored,
+ * always. `part_standard_cost` is re-rolled over time, so the percentage alone
+ * cannot reproduce the number a year from now. The movement freezes the output,
+ * and a correction is priced at what was frozen, never re-priced.
+ */
+export const RETURN_PART_LINE_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique return part line identifier',
+  },
+
+  /**
+   * The returned sold line this teardown belongs to. The owning side of
+   * `return_line_part_lines`. Set on every row in the tree, not only on the
+   * roots, so the whole checklist is one query.
+   */
+  returnLine: {
+    id: toFieldId('returnLine'),
+    key: 'returnLine',
+    label: 'Return Line',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_part_line_return_line',
+    systemSortOrder: 'a1',
+    nullable: false,
+    required: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'return_line:partLines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'return_line',
+      relationshipType: 'belongs_to',
+      inverseName: 'Part Lines',
+      inverseSystemAttribute: 'return_line_part_lines',
+    },
+    description:
+      'The returned sold line this teardown row belongs to. Carried on every row in the ' +
+      'tree, not only the roots, so the whole checklist loads in one query',
+  },
+
+  /**
+   * The node above this one. SELF-REFERENTIAL: this is the tree.
+   *
+   * Null on a top-level row (a direct subpart of the return line's part).
+   * `preventCircular` and `maxDepth` mirror the BOM loader's own
+   * `MAX_BOM_DEPTH = 20` guard; the relationship picker already excludes the
+   * record itself and its descendants from its own options.
+   */
+  parent: {
+    id: toFieldId('parent'),
+    key: 'parent',
+    label: 'Parent',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_part_line_parent',
+    systemSortOrder: 'a2',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'return_part_line:children' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+      constraints: {
+        preventCircular: true,
+        maxDepth: 20,
+      },
+    },
+    relationshipConfig: {
+      relatedEntityType: 'return_part_line',
+      relationshipType: 'belongs_to',
+      inverseName: 'Children',
+      inverseSystemAttribute: 'return_part_line_children',
+    },
+    description:
+      'The node above this one - self-referential, and this is what makes the teardown a ' +
+      'tree. Null on a top-level row. Depth is bounded at 20, matching MAX_BOM_DEPTH',
+  },
+
+  /**
+   * The nodes below this one. The self-referential inverse of {@link parent}.
+   *
+   * `cascade`: a child node has no meaning once its parent row is gone. The
+   * delete engine walking a cascade SELF-edge is the unusual case here and is
+   * worth a dedicated case in the relationship-on-delete coverage test.
+   */
+  children: {
+    id: toFieldId('children'),
+    key: 'children',
+    label: 'Children',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_part_line_children',
+    systemSortOrder: 'a2a',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'return_part_line:parent' as ResourceFieldId,
+      relationshipType: 'has_many',
+      onDelete: 'cascade',
+      isInverse: true,
+    },
+    description:
+      'The nodes below this one - self-referential. Cascade, because a child node is ' +
+      'meaningless without its parent row',
+  },
+
+  /** The component at this node of the tree. */
+  part: {
+    id: toFieldId('part'),
+    key: 'part',
+    label: 'Part',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_part_line_part',
+    systemSortOrder: 'a3',
+    nullable: false,
+    required: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'part:returnPartLines' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'part',
+      relationshipType: 'belongs_to',
+      inverseName: 'Return Part Lines',
+      inverseSystemAttribute: 'part_return_part_lines',
+    },
+    description: 'The component at this node of the teardown tree',
+  },
+
+  /**
+   * Units of this component at this node.
+   *
+   * Prefilled from the BOM as `bom quantity x the return line's quantity`: two
+   * lifts back, each carrying 2 of a subassembly, prefills 4. Editable, and
+   * splittable with the tree's plus button when the units diverge.
+   *
+   * ⚠️ A parent's quantity BOUNDS the sum of its children's. The split button
+   * creates siblings and must not create more units than the parent had; the
+   * writer enforces it.
+   */
+  quantity: {
+    id: toFieldId('quantity'),
+    key: 'quantity',
+    label: 'Quantity',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'return_part_line_quantity',
+    systemSortOrder: 'a4',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    defaultValue: 1,
+    validation: { min: 0 },
+    description:
+      "Units at this node. Prefilled as BOM quantity times the return line's quantity, then " +
+      "edited or split. A parent's quantity bounds the sum of its children's",
+  },
+
+  /**
+   * The warehouse's disposition. See {@link RETURN_PART_LINE_STATUS_OPTIONS}
+   * for which values move inventory (only `good`, and only at the highest
+   * `good` node in a branch) and why the rest write nothing.
+   */
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'return_part_line_status',
+    systemSortOrder: 'a5',
+    nullable: false,
+    options: { options: [...RETURN_PART_LINE_STATUS_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select status',
+    defaultValue: 'undecided',
+    description:
+      'What the warehouse decided about this node. Only good writes a movement, and only at ' +
+      'the highest good node in a branch - scrap and the rest record the decision and stop',
+  },
+
+  /**
+   * What this recovered unit is worth as a percentage of the part's standard
+   * cost. A recovered cylinder is not worth a new cylinder, and a stored
+   * percentage is the cheapest honest way to say so.
+   *
+   * 🛑 Standard cost, NOT the ledger average, by owner decision. An average
+   * basis would gate the salvage writer on data no org has: no org holds a
+   * single `initial` movement and builds are not backfilled, so most parts have
+   * no average at all. It is also a policy a person has to be able to defend -
+   * "60% of what this part is worth new" is a sentence a warehouse worker can
+   * say, and "60% of a blended average that moved three times this week" is
+   * not. Standard also remains the basis for `build_consume` and
+   * `build_produce`, so this is the consistent choice rather than the odd one.
+   *
+   * The writer refuses `pct <= 0` (a worthless part is `scrap`, which writes
+   * nothing at all, not a zero-cost movement) and `pct > 100` (salvage is never
+   * worth more than new). `validation` here is a UI hint, not the guard.
+   */
+  salvagePercent: {
+    id: toFieldId('salvagePercent'),
+    key: 'salvagePercent',
+    label: 'Salvage Percent',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'return_part_line_salvage_percent',
+    systemSortOrder: 'a6',
+    nullable: true,
+    options: { decimals: 0 },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    defaultValue: 100,
+    validation: { min: 0, max: 100 },
+    description:
+      "What this recovered unit is worth as a percentage of the part's STANDARD cost. The " +
+      'writer refuses 0 or less (that is scrap, which writes nothing) and more than 100',
+  },
+
+  /**
+   * `round(part_standard_cost x salvagePercent / 100)`, in integer minor units,
+   * FROZEN at the moment the salvage movement is written.
+   *
+   * Stored alongside {@link salvagePercent} rather than derived from it,
+   * because `part_standard_cost` is re-rolled over time and the percentage
+   * alone cannot reproduce this number later. `updatable: false`: this is the
+   * output the movement carries, and a correction reverses at the frozen amount
+   * rather than re-pricing.
+   *
+   * ⚠️ The writer refuses a part whose `part_standard_cost` is null OR ZERO,
+   * naming the part, rather than freezing $0 onto an append-only ledger. That
+   * refusal is deliberate asymmetry with sale relief, which warns and never
+   * refuses: a refused relief loses a shipment that really happened and cannot
+   * be re-derived, while a refused salvage loses nothing, because the
+   * disposition is already on this row and the movement can be written the
+   * moment somebody costs the part.
+   */
+  unitCost: {
+    id: toFieldId('unitCost'),
+    key: 'unitCost',
+    label: 'Unit Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'return_part_line_unit_cost',
+    systemSortOrder: 'a7',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true, // written once by the salvage writer, alongside the movement
+      updatable: false,
+      configurable: false,
+    },
+    description:
+      'Standard cost times the salvage percent, rounded once in integer MINOR UNITS and ' +
+      'frozen when the movement is written. A correction reverses at this amount, never at ' +
+      "today's standard",
+  },
+
+  /**
+   * Sibling order within one parent. A FRACTIONAL INDEX, hence TEXT rather than
+   * a number: the tree's split button inserts between existing siblings, and a
+   * lexicographic key does that without renumbering the rest.
+   */
+  sortOrder: {
+    id: toFieldId('sortOrder'),
+    key: 'sortOrder',
+    label: 'Sort Order',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'return_part_line_sort_order',
+    systemSortOrder: 'a8',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Sibling order within one parent. A fractional index, so the split button can insert ' +
+      'between two rows without renumbering anything',
+  },
+
+  /**
+   * The `return_in` movement this row produced, if it produced one. Set only on
+   * rows the salvage writer actually acted on, which is the highest `good` node
+   * in each branch and nothing else.
+   *
+   * One-sided on purpose: the `stock_movement` ledger is append-only and
+   * carries no field pointing back here. That also keeps this edge out of the
+   * ledger's own link set.
+   *
+   * 🛑 A salvage movement carries NO `stock_movement_fulfillment_line`, however
+   * tempting it is to record which dispatch a part came back from. That link is
+   * the whole of sale relief's netting, and a stray one is a single predicate
+   * away from reading as un-relief. If a salvage ever needs to name its
+   * dispatch, that is a field on `return_line` - never the movement's ledger
+   * link.
+   *
+   * ⚠️ `stock_movement_adjust_subparts` must also be FALSE on every salvage
+   * movement: the BOM trigger explodes any movement carrying that flag into
+   * child movements for every leaf, which would restock the subassembly AND its
+   * leaves, the same material twice on an append-only ledger. It would also
+   * make the row invisible to the on-hand SUM, which excludes flagged rows.
+   */
+  movement: {
+    id: toFieldId('movement'),
+    key: 'movement',
+    label: 'Movement',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'return_part_line_movement',
+    systemSortOrder: 'a9',
+    nullable: true,
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: null,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    description:
+      'The return_in movement this row produced, on the rows that produced one. Nullable and ' +
+      'ONE-SIDED: the append-only ledger carries no field pointing back here',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the return part line is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the return part line is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/resources/registry/resources/stock-movement-fields.ts
+++ b/packages/lib/src/resources/registry/resources/stock-movement-fields.ts
@@ -608,5 +608,41 @@ export const STOCK_MOVEMENT_FIELDS: Record<string, ResourceField> = {
     },
   },
 
+  // The sell-side twin of `purchaseOrderLine` above (plans/money/tasks/55
+  // §3, task 50's netting): a `sale`-type movement points at the
+  // `fulfillment_line` it relieved, and `fulfillment_line_quantity_relieved`
+  // re-SUMs over this edge. Nullable because not every movement is a sale
+  // relief (receipts, adjustments, builds carry no fulfillment line at all).
+  fulfillmentLine: {
+    id: toFieldId('fulfillmentLine'),
+    key: 'fulfillmentLine',
+    label: 'Fulfillment Line',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'stock_movement_fulfillment_line',
+    systemSortOrder: 'c2',
+    nullable: true,
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: false,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'fulfillment_line:stockMovements' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'fulfillment_line',
+      relationshipType: 'belongs_to',
+      inverseName: 'Stock Movements',
+      inverseSystemAttribute: 'fulfillment_line_stock_movements',
+    },
+  },
+
   createdBy: CREATED_BY_FIELD,
 }

--- a/packages/lib/src/resources/registry/system-entity-behavior.ts
+++ b/packages/lib/src/resources/registry/system-entity-behavior.ts
@@ -85,7 +85,7 @@ export const DEFAULTS: Omit<SystemEntityBehavior, 'creatable'> = {
 }
 
 /**
- * Per-`entityType` overrides for the 34 system defs that differ from
+ * Per-`entityType` overrides for the 36 system defs that differ from
  * {@link DEFAULTS}. The other 14 system defs (`contact`, `ticket`, `part`,
  * `company`, `product`, `order`, `quote`, `invoice`, `credit_memo`,
  * `purchase_order`, `vendor_bill`, `work_order`, `service_request`, `build`)
@@ -115,6 +115,25 @@ export const SYSTEM_ENTITY_BEHAVIOR: Record<string, Partial<SystemEntityBehavior
   credit_memo_line: {
     searchable: false,
     inPromptCatalog: false,
+    sidebar: 'never',
+  },
+  // The sales-channel fact behind `order_fulfillments` (plans/money/tasks/55).
+  // No route folder, unlike `shipment`/`parcel` below - `sidebar: 'never'`
+  // rather than `'off'` is what that difference requires: a def made visible
+  // with no route folder 404s its nav entry. `creatable` already derives
+  // false from `sidebar !== 'never'`; set explicitly for the same reason
+  // `parcel` does - a fulfillment is minted by a channel or by
+  // `money.fulfillOrder`, never typed into a create form.
+  fulfillment: {
+    searchable: false,
+    inPromptCatalog: false,
+    creatable: false,
+    sidebar: 'never',
+  },
+  fulfillment_line: {
+    searchable: false,
+    inPromptCatalog: false,
+    creatable: false,
     sidebar: 'never',
   },
   credit_memo_application: {

--- a/packages/lib/src/returns/__tests__/over-return-guard.test.ts
+++ b/packages/lib/src/returns/__tests__/over-return-guard.test.ts
@@ -1,0 +1,174 @@
+// packages/lib/src/returns/__tests__/over-return-guard.test.ts
+
+/**
+ * `returns/over-return-guard.ts` - plan section 3.5's ceiling.
+ *
+ * Plain arithmetic over plain arrays, so nothing is stubbed. Two cases carry
+ * the weight: the **edit** path, where a row must not count its own prior
+ * quantity against itself, and the **negative quantity**, which passes every
+ * ceiling comparison and would then restock parts for units that never left.
+ *
+ * The ceiling is an input throughout. These tests pass sold quantities today
+ * and will pass shipped quantities when task 55 lands, with no change here.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  checkOverReturn,
+  type ReturnedQuantityClaim,
+  remainingReturnableQuantity,
+  sumReturnedQuantity,
+} from '../over-return-guard'
+
+const LINE = 'line_item_1'
+
+function claims(...pairs: [string, number][]): ReturnedQuantityClaim[] {
+  return pairs.map(([returnLineId, quantity]) => ({ returnLineId, quantity }))
+}
+
+function check(args: {
+  ceiling: number
+  existing?: ReturnedQuantityClaim[]
+  quantity: number
+  returnLineId?: string | null
+}) {
+  return checkOverReturn({
+    lineItemId: LINE,
+    ceiling: args.ceiling,
+    existing: args.existing ?? [],
+    candidate: { returnLineId: args.returnLineId, quantity: args.quantity },
+  })
+}
+
+describe('sumReturnedQuantity', () => {
+  it('is zero for no claims', () => {
+    expect(sumReturnedQuantity([])).toBe(0)
+  })
+
+  it('sums every claim', () => {
+    expect(sumReturnedQuantity(claims(['a', 1], ['b', 2], ['c', 3]))).toBe(6)
+  })
+
+  it('excludes one row by id, for the edit path', () => {
+    expect(sumReturnedQuantity(claims(['a', 1], ['b', 2]), 'b')).toBe(1)
+  })
+
+  it('ignores an exclusion id that is not present', () => {
+    expect(sumReturnedQuantity(claims(['a', 1]), 'zz')).toBe(1)
+  })
+})
+
+describe('remainingReturnableQuantity', () => {
+  it('is the ceiling when nothing has come back', () => {
+    expect(remainingReturnableQuantity({ lineItemId: LINE, ceiling: 5, existing: [] })).toBe(5)
+  })
+
+  it('subtracts what is already claimed', () => {
+    expect(
+      remainingReturnableQuantity({ lineItemId: LINE, ceiling: 5, existing: claims(['a', 2]) })
+    ).toBe(3)
+  })
+
+  it('excludes the row being edited', () => {
+    expect(
+      remainingReturnableQuantity({
+        lineItemId: LINE,
+        ceiling: 5,
+        existing: claims(['a', 2]),
+        candidate: { returnLineId: 'a' },
+      })
+    ).toBe(5)
+  })
+
+  it('never goes negative on an already over-returned line', () => {
+    expect(
+      remainingReturnableQuantity({ lineItemId: LINE, ceiling: 2, existing: claims(['a', 5]) })
+    ).toBe(0)
+  })
+})
+
+describe('checkOverReturn', () => {
+  it('accepts a first return of the whole line', () => {
+    expect(check({ ceiling: 2, quantity: 2 }).isOk()).toBe(true)
+  })
+
+  it('accepts a partial return', () => {
+    expect(check({ ceiling: 2, quantity: 1 }).isOk()).toBe(true)
+  })
+
+  it('refuses more than the line ever let out', () => {
+    const result = check({ ceiling: 2, quantity: 3 })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.reason).toBe('over_return')
+      expect(result.error.statusCode).toBe(422)
+    }
+  })
+
+  it('sums across every return pointing at the line, not just this one', () => {
+    // Two lifts sold, one already returned on RMA-1, one on RMA-2, and a
+    // third would be a unit that never shipped.
+    expect(check({ ceiling: 2, existing: claims(['a', 1]), quantity: 1 }).isOk()).toBe(true)
+    const result = check({ ceiling: 2, existing: claims(['a', 1], ['b', 1]), quantity: 1 })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error).toMatchObject({
+        lineItemId: LINE,
+        ceiling: 2,
+        alreadyReturned: 2,
+        requested: 1,
+      })
+    }
+  })
+
+  it('refuses divergent condition rows that together exceed the line', () => {
+    // The grain is one row per sold line PER CONDITION, so several rows share
+    // one line_item and only the sum is bounded.
+    const existing = claims(['pristine', 1], ['wrecked', 1])
+    expect(check({ ceiling: 3, existing, quantity: 1 }).isOk()).toBe(true)
+    expect(check({ ceiling: 2, existing, quantity: 1 }).isErr()).toBe(true)
+  })
+
+  it('does not count an edited row against itself', () => {
+    // Saving a row of 2 unchanged must not read as 4 against a line of 2.
+    const existing = claims(['r1', 2])
+    expect(check({ ceiling: 2, existing, quantity: 2, returnLineId: 'r1' }).isOk()).toBe(true)
+  })
+
+  it('still bounds an edit that raises the quantity', () => {
+    const result = check({
+      ceiling: 2,
+      existing: claims(['r1', 2]),
+      quantity: 3,
+      returnLineId: 'r1',
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error).toMatchObject({ alreadyReturned: 0, requested: 3 })
+  })
+
+  it('refuses everything against a line that shipped nothing', () => {
+    // The ceiling a shipped bound produces for an unfulfilled line.
+    expect(check({ ceiling: 0, quantity: 1 }).isErr()).toBe(true)
+  })
+
+  it('refuses a quantity of zero or below, which no ceiling would catch', () => {
+    for (const quantity of [0, -1, -100]) {
+      const result = check({ ceiling: 2, quantity })
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) expect(result.error.reason).toBe('invalid_return_quantity')
+    }
+  })
+
+  it('refuses a non-finite quantity', () => {
+    expect(check({ ceiling: 2, quantity: Number.NaN }).isErr()).toBe(true)
+    expect(check({ ceiling: 2, quantity: Number.POSITIVE_INFINITY }).isErr()).toBe(true)
+  })
+
+  it('accepts a fractional quantity that fits, since a return line is a NUMBER field', () => {
+    expect(check({ ceiling: 2, quantity: 0.5 }).isOk()).toBe(true)
+  })
+
+  it('never throws', () => {
+    expect(() => check({ ceiling: Number.NaN, quantity: 1 })).not.toThrow()
+  })
+})

--- a/packages/lib/src/returns/__tests__/salvage-cost.test.ts
+++ b/packages/lib/src/returns/__tests__/salvage-cost.test.ts
@@ -1,0 +1,152 @@
+// packages/lib/src/returns/__tests__/salvage-cost.test.ts
+
+/**
+ * `returns/salvage-cost.ts` - plan section 6.4's arithmetic.
+ *
+ * Pure numbers in, pure numbers out, so there is nothing to stub. The cases
+ * that matter are the boundaries (0, 100, 101) and the zero standard cost,
+ * which is the one that gets through a guard written as `== null` and freezes
+ * $0 onto a ledger nothing can restate.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  computeSalvageUnitCost,
+  isUsableSalvagePercent,
+  isUsableStandardCost,
+} from '../salvage-cost'
+import { MissingStandardCostError } from '../salvage-errors'
+
+/** $201.00 as the minor units a `part_standard_cost` is stored in. */
+const STANDARD = 20100
+
+function unitCost(standardCost: number | null | undefined, salvagePercent: number) {
+  return computeSalvageUnitCost({
+    partId: 'p1',
+    partName: 'Hydraulic cylinder',
+    standardCost,
+    salvagePercent,
+  })
+}
+
+describe('isUsableStandardCost', () => {
+  it('accepts a positive cost', () => {
+    expect(isUsableStandardCost(1)).toBe(true)
+    expect(isUsableStandardCost(0.001)).toBe(true)
+  })
+
+  it('rejects null, undefined, zero, negatives and non-finite values', () => {
+    expect(isUsableStandardCost(null)).toBe(false)
+    expect(isUsableStandardCost(undefined)).toBe(false)
+    expect(isUsableStandardCost(0)).toBe(false)
+    expect(isUsableStandardCost(-1)).toBe(false)
+    expect(isUsableStandardCost(Number.NaN)).toBe(false)
+    expect(isUsableStandardCost(Number.POSITIVE_INFINITY)).toBe(false)
+  })
+})
+
+describe('isUsableSalvagePercent', () => {
+  it('accepts the open-closed range (0, 100]', () => {
+    expect(isUsableSalvagePercent(0.5)).toBe(true)
+    expect(isUsableSalvagePercent(60)).toBe(true)
+    expect(isUsableSalvagePercent(100)).toBe(true)
+  })
+
+  it('rejects 0, negatives, anything past 100, and non-finite values', () => {
+    expect(isUsableSalvagePercent(0)).toBe(false)
+    expect(isUsableSalvagePercent(-10)).toBe(false)
+    expect(isUsableSalvagePercent(100.01)).toBe(false)
+    expect(isUsableSalvagePercent(101)).toBe(false)
+    expect(isUsableSalvagePercent(Number.NaN)).toBe(false)
+    expect(isUsableSalvagePercent(Number.POSITIVE_INFINITY)).toBe(false)
+  })
+})
+
+describe('computeSalvageUnitCost', () => {
+  it('takes the percentage of the standard cost', () => {
+    const result = unitCost(STANDARD, 60)
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value).toBe(12060)
+  })
+
+  it('returns the standard cost unchanged at 100 percent', () => {
+    const result = unitCost(STANDARD, 100)
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value).toBe(STANDARD)
+  })
+
+  it('keeps fractional cents rather than collapsing a rate to whole cents', () => {
+    // A 1.594-cent fastener recovered at 50% is worth 0.797 cents, not 1.
+    const result = unitCost(1.594, 50)
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value).toBeCloseTo(0.797, 5)
+  })
+
+  it('rounds once, to a RATE precision', () => {
+    const result = unitCost(1, 33.3333)
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value).toBe(0.333)
+  })
+
+  it('refuses a percentage of zero: a worthless part is scrap, which writes nothing', () => {
+    const result = unitCost(STANDARD, 0)
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.reason).toBe('salvage_percent_out_of_range')
+      expect(result.error.statusCode).toBe(422)
+    }
+  })
+
+  it('refuses a negative percentage', () => {
+    const result = unitCost(STANDARD, -20)
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('refuses a percentage past 100: salvage is never worth more than new', () => {
+    const result = unitCost(STANDARD, 101)
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.reason).toBe('salvage_percent_out_of_range')
+      expect(result.error.message).toContain('Hydraulic cylinder')
+    }
+  })
+
+  it('refuses a null standard cost, naming the part', () => {
+    const result = unitCost(null, 60)
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.reason).toBe('missing_standard_cost')
+      expect(result.error.message).toContain('Hydraulic cylinder')
+      expect(result.error).toBeInstanceOf(MissingStandardCostError)
+      if (result.error instanceof MissingStandardCostError) {
+        expect(result.error.standardCost).toBeNull()
+      }
+    }
+  })
+
+  it('refuses a standard cost of exactly zero', () => {
+    const result = unitCost(0, 60)
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.reason).toBe('missing_standard_cost')
+      if (result.error instanceof MissingStandardCostError) {
+        expect(result.error.standardCost).toBe(0)
+      }
+    }
+  })
+
+  it('refuses an undefined and a negative standard cost', () => {
+    expect(unitCost(undefined, 60).isErr()).toBe(true)
+    expect(unitCost(-100, 60).isErr()).toBe(true)
+  })
+
+  it('refuses the percentage first when both inputs are bad', () => {
+    const result = unitCost(null, 0)
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.reason).toBe('salvage_percent_out_of_range')
+  })
+
+  it('never throws', () => {
+    expect(() => unitCost(Number.NaN, Number.NaN)).not.toThrow()
+  })
+})

--- a/packages/lib/src/returns/__tests__/salvage-invariants.test.ts
+++ b/packages/lib/src/returns/__tests__/salvage-invariants.test.ts
@@ -1,0 +1,444 @@
+// packages/lib/src/returns/__tests__/salvage-invariants.test.ts
+
+/**
+ * `returns/salvage-invariants.ts` - plan section 6.6's three rules.
+ *
+ * **No doubles.** The trees under test are built by the real
+ * `buildSalvageTree` from real BOM maps and real row arrays, so a change that
+ * breaks the builder's contract breaks these too, which is the point.
+ *
+ * The traps each get their own case: a `good` node nested under a `good` one,
+ * a split that invents a unit, sixteen bolts legitimately under four masts
+ * (the reading of invariant 2 that would refuse every real tree), a standard
+ * cost of exactly zero, and an uncosted part that is shadowed and therefore
+ * never salvaged at all.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  checkNoNestedGoodNodes,
+  checkSalvageQuantityBounds,
+  checkSalvageStandardCosts,
+  checkSalvageTree,
+  findMissingStandardCosts,
+  findQuantityAllowanceBreaches,
+  findShadowedGoodNodes,
+  selectSalvageMovementNodes,
+} from '../salvage-invariants'
+import { buildSalvageTree } from '../salvage-tree'
+import {
+  DEFAULT_SALVAGE_PERCENT,
+  type MaterializedSalvageRow,
+  ROOT_SALVAGE_KEY,
+  type SalvageNode,
+  type SalvageStatus,
+  type SubpartGraph,
+} from '../types'
+
+function graphOf(edges: Record<string, [string, number][]>): SubpartGraph {
+  return new Map(
+    Object.entries(edges).map(([parent, children]) => [
+      parent,
+      children.map(([childId, qty]) => ({ childId, qty })),
+    ])
+  )
+}
+
+function row(
+  id: string,
+  partId: string,
+  over: Partial<MaterializedSalvageRow> = {}
+): MaterializedSalvageRow {
+  return {
+    id,
+    partId,
+    parentId: null,
+    quantity: 1,
+    status: 'undecided' as SalvageStatus,
+    salvagePercent: DEFAULT_SALVAGE_PERCENT,
+    ...over,
+  }
+}
+
+function build(
+  graph: SubpartGraph,
+  rows: MaterializedSalvageRow[],
+  returnLineQuantity = 1
+): SalvageNode[] {
+  return buildSalvageTree({
+    graph,
+    rootPartId: 'lift',
+    returnLineQuantity,
+    rows,
+    parts: new Map([
+      ['mast', { name: 'Mast', number: 'P-1' }],
+      ['cylinder', { name: 'Cylinder', number: 'P-2' }],
+      ['bolt', { name: 'Bolt', number: 'P-3' }],
+    ]),
+  })
+}
+
+/** lift -> 1 mast -> 2 cylinders -> 4 bolts. */
+const DEEP = graphOf({
+  lift: [['mast', 1]],
+  mast: [['cylinder', 2]],
+  cylinder: [['bolt', 4]],
+})
+
+// ============= Invariant 1: one recovery per branch =============
+
+describe('selectSalvageMovementNodes', () => {
+  it('selects nothing when nothing is good', () => {
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'damaged' })])
+    expect(selectSalvageMovementNodes(roots)).toEqual([])
+  })
+
+  it('selects a good top-level node', () => {
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'good' })])
+    expect(selectSalvageMovementNodes(roots).map((n) => n.key)).toEqual(['r1'])
+  })
+
+  it('selects the HIGHEST good node and not its good children', () => {
+    const roots = build(DEEP, [
+      row('r1', 'mast', { status: 'good' }),
+      row('r2', 'cylinder', { parentId: 'r1', status: 'good', quantity: 2 }),
+    ])
+    expect(selectSalvageMovementNodes(roots).map((n) => n.key)).toEqual(['r1'])
+  })
+
+  it('stops at the first good node even when a lower one is also good', () => {
+    // good -> damaged -> good: only the top one recovers, its whole subtree
+    // came back into inventory with it.
+    const roots = build(DEEP, [
+      row('r1', 'mast', { status: 'good' }),
+      row('r2', 'cylinder', { parentId: 'r1', status: 'damaged', quantity: 2 }),
+      row('r3', 'bolt', { parentId: 'r2', status: 'good', quantity: 8 }),
+    ])
+    expect(selectSalvageMovementNodes(roots).map((n) => n.key)).toEqual(['r1'])
+  })
+
+  it('descends through a damaged parent to a good child', () => {
+    const roots = build(DEEP, [
+      row('r1', 'mast', { status: 'damaged' }),
+      row('r2', 'cylinder', { parentId: 'r1', status: 'good', quantity: 2 }),
+    ])
+    expect(selectSalvageMovementNodes(roots).map((n) => n.key)).toEqual(['r2'])
+  })
+
+  it('selects every good sibling', () => {
+    const graph = graphOf({
+      lift: [
+        ['mast', 1],
+        ['cylinder', 1],
+      ],
+    })
+    const roots = build(graph, [
+      row('r1', 'mast', { status: 'good' }),
+      row('r2', 'cylinder', { status: 'good' }),
+    ])
+    expect(selectSalvageMovementNodes(roots).map((n) => n.key)).toEqual(['r1', 'r2'])
+  })
+
+  it('treats an unexpanded node as a leaf', () => {
+    // The cylinder under the damaged mast has no row, so there is nothing
+    // beneath it to recover.
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'damaged' })])
+    expect(roots[0]?.children?.[0]?.children).toBeNull()
+    expect(selectSalvageMovementNodes(roots)).toEqual([])
+  })
+})
+
+describe('findShadowedGoodNodes', () => {
+  it('finds nothing in a tree with no nesting', () => {
+    const roots = build(DEEP, [
+      row('r1', 'mast', { status: 'good' }),
+      row('r2', 'cylinder', { parentId: 'r1', status: 'damaged', quantity: 2 }),
+    ])
+    expect(findShadowedGoodNodes(roots)).toEqual([])
+    expect(checkNoNestedGoodNodes(roots).isOk()).toBe(true)
+  })
+
+  it('pairs a nested good node with the good ancestor that shadows it', () => {
+    const roots = build(DEEP, [
+      row('r1', 'mast', { status: 'good' }),
+      row('r2', 'cylinder', { parentId: 'r1', status: 'good', quantity: 2 }),
+    ])
+    const shadowed = findShadowedGoodNodes(roots)
+    expect(shadowed).toHaveLength(1)
+    expect(shadowed[0]?.node.key).toBe('r2')
+    expect(shadowed[0]?.ancestor.key).toBe('r1')
+  })
+
+  it('reports the highest good ancestor for every level of a triple nesting', () => {
+    const roots = build(DEEP, [
+      row('r1', 'mast', { status: 'good' }),
+      row('r2', 'cylinder', { parentId: 'r1', status: 'good', quantity: 2 }),
+      row('r3', 'bolt', { parentId: 'r2', status: 'good', quantity: 8 }),
+    ])
+    const shadowed = findShadowedGoodNodes(roots)
+    expect(shadowed.map((s) => [s.node.key, s.ancestor.key])).toEqual([
+      ['r2', 'r1'],
+      ['r3', 'r1'],
+    ])
+  })
+
+  it('refuses, naming the part, when asked to', () => {
+    const roots = build(DEEP, [
+      row('r1', 'mast', { status: 'good' }),
+      row('r2', 'cylinder', { parentId: 'r1', status: 'good', quantity: 2 }),
+    ])
+    const result = checkNoNestedGoodNodes(roots)
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.reason).toBe('nested_good_node')
+      expect(result.error.partName).toBe('Cylinder')
+      expect(result.error.statusCode).toBe(422)
+      expect(result.error.message).toContain('Cylinder')
+    }
+  })
+})
+
+// ============= Invariant 2: a parent's quantity bounds its children =============
+
+describe('findQuantityAllowanceBreaches', () => {
+  const bounds = (roots: SalvageNode[], graph: SubpartGraph, returnLineQuantity = 1) => ({
+    roots,
+    graph,
+    rootPartId: 'lift',
+    returnLineQuantity,
+  })
+
+  it('accepts the ordinary tree, where children far outnumber their parent', () => {
+    // 4 masts, each holding 4 bolts, is 16 bolts under a parent of 4. A naive
+    // "sum(children) <= parent.quantity" reading would refuse this, and it
+    // would refuse every real BOM.
+    const graph = graphOf({ lift: [['mast', 4]], mast: [['bolt', 4]] })
+    const roots = build(graph, [row('r1', 'mast', { quantity: 4 })])
+    expect(roots[0]?.children?.[0]?.quantity).toBe(16)
+    expect(findQuantityAllowanceBreaches(bounds(roots, graph))).toEqual([])
+  })
+
+  it('accepts a split that adds up to exactly the allowance', () => {
+    const graph = graphOf({ lift: [['mast', 4]] })
+    const roots = build(graph, [
+      row('r1', 'mast', { quantity: 3, status: 'good', sortOrder: 'a' }),
+      row('r2', 'mast', { quantity: 1, status: 'scrap', sortOrder: 'b' }),
+    ])
+    expect(findQuantityAllowanceBreaches(bounds(roots, graph))).toEqual([])
+  })
+
+  it('refuses a split that invents a unit', () => {
+    const graph = graphOf({ lift: [['mast', 4]] })
+    const roots = build(graph, [
+      row('r1', 'mast', { quantity: 3, sortOrder: 'a' }),
+      row('r2', 'mast', { quantity: 2, sortOrder: 'b' }),
+    ])
+    const breaches = findQuantityAllowanceBreaches(bounds(roots, graph))
+    expect(breaches).toHaveLength(1)
+    expect(breaches[0]).toMatchObject({
+      reason: 'quantity_exceeds_allowance',
+      parentKey: ROOT_SALVAGE_KEY,
+      partId: 'mast',
+      partName: 'Mast',
+      allowed: 4,
+      total: 5,
+    })
+  })
+
+  it('scales the top-level allowance by the return line quantity', () => {
+    const graph = graphOf({ lift: [['mast', 2]] })
+    // Two lifts back, so 4 masts are allowed and 5 are not.
+    const four = build(graph, [row('r1', 'mast', { quantity: 4 })], 2)
+    expect(findQuantityAllowanceBreaches(bounds(four, graph, 2))).toEqual([])
+    const five = build(graph, [row('r1', 'mast', { quantity: 5 })], 2)
+    expect(findQuantityAllowanceBreaches(bounds(five, graph, 2))).toHaveLength(1)
+  })
+
+  it('bounds a split deeper in the tree against its own parent', () => {
+    const graph = graphOf({ lift: [['mast', 1]], mast: [['cylinder', 2]] })
+    const roots = build(graph, [
+      row('r1', 'mast', { quantity: 1 }),
+      row('r2', 'cylinder', { parentId: 'r1', quantity: 2, sortOrder: 'a' }),
+      row('r3', 'cylinder', { parentId: 'r1', quantity: 1, sortOrder: 'b' }),
+    ])
+    const breaches = findQuantityAllowanceBreaches(bounds(roots, graph))
+    expect(breaches).toHaveLength(1)
+    expect(breaches[0]).toMatchObject({ parentKey: 'r1', allowed: 2, total: 3 })
+  })
+
+  it('skips a part with no BOM edge under its parent rather than refusing it', () => {
+    // The BOM was edited after the row was written: there is no allowance to
+    // compare against, and inventing one would refuse a recorded decision.
+    const graph = graphOf({ lift: [['mast', 1]] })
+    const roots = build(graph, [row('r9', 'retired', { quantity: 99 })])
+    expect(findQuantityAllowanceBreaches(bounds(roots, graph))).toEqual([])
+  })
+
+  it('reports every breach but refuses on the first', () => {
+    const graph = graphOf({
+      lift: [
+        ['mast', 1],
+        ['cylinder', 1],
+      ],
+    })
+    const roots = build(graph, [
+      row('r1', 'mast', { quantity: 2 }),
+      row('r2', 'cylinder', { quantity: 3 }),
+    ])
+    expect(findQuantityAllowanceBreaches(bounds(roots, graph))).toHaveLength(2)
+    const result = checkSalvageQuantityBounds(bounds(roots, graph))
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.partId).toBe('mast')
+  })
+
+  it('accepts an empty tree', () => {
+    expect(findQuantityAllowanceBreaches(bounds([], new Map()))).toEqual([])
+  })
+})
+
+// ============= Invariant 3: a salvaged part must be costed =============
+
+describe('findMissingStandardCosts', () => {
+  const costs = (entries: [string, number | null | undefined][]) =>
+    new Map<string, number | null | undefined>(entries)
+
+  it('accepts a costed good node', () => {
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'good' })])
+    expect(findMissingStandardCosts({ roots, standardCosts: costs([['mast', 12345]]) })).toEqual([])
+  })
+
+  it('refuses a good node whose part has no cost at all, naming the part', () => {
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'good' })])
+    const missing = findMissingStandardCosts({ roots, standardCosts: new Map() })
+    expect(missing).toHaveLength(1)
+    expect(missing[0]).toMatchObject({
+      reason: 'missing_standard_cost',
+      partId: 'mast',
+      partName: 'Mast',
+      standardCost: null,
+    })
+    expect(missing[0]?.message).toContain('Mast')
+  })
+
+  it('refuses a standard cost of exactly zero', () => {
+    // The trap: a zero passes every guard that tests `== null`, and freezes
+    // $0 onto an append-only ledger.
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'good' })])
+    const missing = findMissingStandardCosts({ roots, standardCosts: costs([['mast', 0]]) })
+    expect(missing).toHaveLength(1)
+    expect(missing[0]?.standardCost).toBe(0)
+  })
+
+  it('refuses an explicit null and a negative cost', () => {
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'good' })])
+    expect(
+      findMissingStandardCosts({ roots, standardCosts: costs([['mast', null]]) })
+    ).toHaveLength(1)
+    expect(findMissingStandardCosts({ roots, standardCosts: costs([['mast', -5]]) })).toHaveLength(
+      1
+    )
+  })
+
+  it('ignores an uncosted part that is not good', () => {
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'damaged' })])
+    expect(findMissingStandardCosts({ roots, standardCosts: new Map() })).toEqual([])
+  })
+
+  it('ignores an uncosted good node that is shadowed by a good ancestor', () => {
+    // It produces no movement, so its cost is nobody's problem.
+    const roots = build(DEEP, [
+      row('r1', 'mast', { status: 'good' }),
+      row('r2', 'cylinder', { parentId: 'r1', status: 'good', quantity: 2 }),
+    ])
+    const missing = findMissingStandardCosts({ roots, standardCosts: costs([['mast', 900]]) })
+    expect(missing).toEqual([])
+  })
+
+  it('reports one error per part, not one per row', () => {
+    const graph = graphOf({ lift: [['mast', 4]] })
+    const roots = build(graph, [
+      row('r1', 'mast', { quantity: 2, status: 'good', sortOrder: 'a' }),
+      row('r2', 'mast', { quantity: 2, status: 'good', sortOrder: 'b' }),
+    ])
+    expect(findMissingStandardCosts({ roots, standardCosts: new Map() })).toHaveLength(1)
+  })
+
+  it('refuses through checkSalvageStandardCosts with a 422', () => {
+    const roots = build(DEEP, [row('r1', 'mast', { status: 'good' })])
+    const result = checkSalvageStandardCosts({ roots, standardCosts: new Map() })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.statusCode).toBe(422)
+  })
+})
+
+// ============= All three together =============
+
+describe('checkSalvageTree', () => {
+  const graph = graphOf({ lift: [['mast', 4]], mast: [['cylinder', 2]] })
+
+  it('returns the nodes that would move stock', () => {
+    const roots = build(graph, [
+      row('r1', 'mast', { quantity: 3, status: 'good', sortOrder: 'a' }),
+      row('r2', 'mast', { quantity: 1, status: 'scrap', sortOrder: 'b' }),
+    ])
+    const result = checkSalvageTree({
+      roots,
+      graph,
+      rootPartId: 'lift',
+      returnLineQuantity: 1,
+      standardCosts: new Map([['mast', 5000]]),
+    })
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value.map((n) => n.key)).toEqual(['r1'])
+  })
+
+  it('refuses on the quantity bound before it looks at costs', () => {
+    const roots = build(graph, [
+      row('r1', 'mast', { quantity: 3, status: 'good', sortOrder: 'a' }),
+      row('r2', 'mast', { quantity: 3, status: 'good', sortOrder: 'b' }),
+    ])
+    const result = checkSalvageTree({
+      roots,
+      graph,
+      rootPartId: 'lift',
+      returnLineQuantity: 1,
+      standardCosts: new Map(),
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.reason).toBe('quantity_exceeds_allowance')
+  })
+
+  it('selects past a nested good node by default, and refuses when asked', () => {
+    const roots = build(graph, [
+      row('r1', 'mast', { quantity: 4, status: 'good' }),
+      row('r2', 'cylinder', { parentId: 'r1', quantity: 8, status: 'good' }),
+    ])
+    const base = {
+      roots,
+      graph,
+      rootPartId: 'lift',
+      returnLineQuantity: 1,
+      standardCosts: new Map([['mast', 5000]]),
+    }
+    const lenient = checkSalvageTree(base)
+    expect(lenient.isOk()).toBe(true)
+    if (lenient.isOk()) expect(lenient.value.map((n) => n.key)).toEqual(['r1'])
+
+    const strict = checkSalvageTree({ ...base, refuseNestedGood: true })
+    expect(strict.isErr()).toBe(true)
+    if (strict.isErr()) expect(strict.error.reason).toBe('nested_good_node')
+  })
+
+  it('accepts a tree where nothing is good and therefore nothing moves', () => {
+    const roots = build(graph, [row('r1', 'mast', { quantity: 4, status: 'missing' })])
+    const result = checkSalvageTree({
+      roots,
+      graph,
+      rootPartId: 'lift',
+      returnLineQuantity: 1,
+      standardCosts: new Map(),
+    })
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) expect(result.value).toEqual([])
+  })
+})

--- a/packages/lib/src/returns/__tests__/salvage-tree.test.ts
+++ b/packages/lib/src/returns/__tests__/salvage-tree.test.ts
@@ -1,0 +1,424 @@
+// packages/lib/src/returns/__tests__/salvage-tree.test.ts
+
+/**
+ * `returns/salvage-tree.ts` - the lazy BOM view tree.
+ *
+ * **No doubles of any kind.** Every function under test takes plain data and
+ * returns plain data, so the inputs here are real `Map`s and real row arrays,
+ * built by the four helpers below. The interesting cases are the pathological
+ * ones and they get most of the file: a cycle, a self-edge, a BOM deeper than
+ * the cap, a part used in two branches, a split, and a row whose part is no
+ * longer in the BOM at all.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { bomQuantity, buildSalvageTree, findSalvageNode, flattenSalvageTree } from '../salvage-tree'
+import {
+  DEFAULT_SALVAGE_PERCENT,
+  MAX_SALVAGE_DEPTH,
+  type MaterializedSalvageRow,
+  ROOT_SALVAGE_KEY,
+  type SalvageNode,
+  type SalvagePartInfo,
+  type SubpartGraph,
+} from '../types'
+
+/** `{ parent: [[child, qty], ...] }` as the adjacency map `loadSubpartGraph` returns. */
+function graphOf(edges: Record<string, [string, number][]>): SubpartGraph {
+  return new Map(
+    Object.entries(edges).map(([parent, children]) => [
+      parent,
+      children.map(([childId, qty]) => ({ childId, qty })),
+    ])
+  )
+}
+
+/** A `return_part_line` row, top level and undecided unless overridden. */
+function row(
+  over: Partial<MaterializedSalvageRow> & Pick<MaterializedSalvageRow, 'id' | 'partId'>
+): MaterializedSalvageRow {
+  return {
+    parentId: null,
+    quantity: 1,
+    status: 'undecided',
+    salvagePercent: DEFAULT_SALVAGE_PERCENT,
+    ...over,
+  }
+}
+
+/** Part labels for every id named. */
+function partsOf(...ids: string[]): Map<string, SalvagePartInfo> {
+  return new Map(ids.map((id) => [id, { name: id.toUpperCase(), number: `P-${id}` }]))
+}
+
+/** `buildSalvageTree` with a one-lift return unless overridden. */
+function tree(over: {
+  graph: SubpartGraph
+  rootPartId?: string
+  returnLineQuantity?: number
+  rows?: MaterializedSalvageRow[]
+  parts?: Map<string, SalvagePartInfo>
+}): SalvageNode[] {
+  return buildSalvageTree({
+    graph: over.graph,
+    rootPartId: over.rootPartId ?? 'lift',
+    returnLineQuantity: over.returnLineQuantity ?? 1,
+    rows: over.rows ?? [],
+    parts: over.parts ?? new Map(),
+  })
+}
+
+// ============= bomQuantity =============
+
+describe('bomQuantity', () => {
+  it('returns the edge quantity', () => {
+    expect(bomQuantity(graphOf({ lift: [['mast', 2]] }), 'lift', 'mast')).toBe(2)
+  })
+
+  it('returns null for a part that is not a child of the parent', () => {
+    expect(bomQuantity(graphOf({ lift: [['mast', 2]] }), 'lift', 'bolt')).toBeNull()
+  })
+
+  it('returns null for a parent with no edges at all', () => {
+    expect(bomQuantity(new Map(), 'lift', 'mast')).toBeNull()
+  })
+
+  it('sums parallel edges rather than taking the first', () => {
+    const graph = graphOf({
+      lift: [
+        ['bolt', 3],
+        ['bolt', 4],
+      ],
+    })
+    expect(bomQuantity(graph, 'lift', 'bolt')).toBe(7)
+  })
+})
+
+// ============= The empty and trivial cases =============
+
+describe('buildSalvageTree, nothing to show', () => {
+  it('returns no nodes for a part with an empty BOM', () => {
+    expect(tree({ graph: new Map() })).toEqual([])
+  })
+
+  it('returns no nodes when the graph describes other parts only', () => {
+    expect(tree({ graph: graphOf({ other: [['bolt', 1]] }) })).toEqual([])
+  })
+
+  it('emits a row whose part is not in the BOM at all rather than dropping it', () => {
+    const nodes = tree({
+      graph: new Map(),
+      rows: [row({ id: 'r1', partId: 'ghost', quantity: 2, status: 'good' })],
+    })
+    expect(nodes.map((n) => n.key)).toEqual(['r1'])
+    expect(nodes[0]?.status).toBe('good')
+  })
+})
+
+// ============= The prefill rule =============
+
+describe('the prefill rule', () => {
+  it('prefills the top level at BOM quantity times the return line quantity', () => {
+    // Two lifts back, each carrying 2 of the subassembly: the row says 4.
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 2]] }),
+      returnLineQuantity: 2,
+    })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.quantity).toBe(4)
+  })
+
+  it('compounds down the tree: a child prefills from its parent quantity', () => {
+    // 2 lifts x 2 masts = 4 masts; each mast holds 3 bolts, so 12 bolts.
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 2]], mast: [['bolt', 3]] }),
+      returnLineQuantity: 2,
+      rows: [row({ id: 'r1', partId: 'mast', quantity: 4 })],
+    })
+    expect(nodes[0]?.children?.[0]?.quantity).toBe(12)
+  })
+
+  it('prefills children from the EDITED parent quantity, not the BOM one', () => {
+    // The warehouse found only 3 of the 4 masts: 3 x 3 = 9 bolts, not 12.
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 2]], mast: [['bolt', 3]] }),
+      returnLineQuantity: 2,
+      rows: [row({ id: 'r1', partId: 'mast', quantity: 3 })],
+    })
+    expect(nodes[0]?.children?.[0]?.quantity).toBe(9)
+  })
+
+  it('sums parallel BOM edges into one prefilled row', () => {
+    const nodes = tree({
+      graph: graphOf({
+        lift: [
+          ['bolt', 3],
+          ['bolt', 4],
+        ],
+      }),
+      returnLineQuantity: 2,
+    })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.quantity).toBe(14)
+  })
+})
+
+// ============= The laziness rule =============
+
+describe('the laziness rule', () => {
+  const deepGraph = graphOf({
+    lift: [['mast', 1]],
+    mast: [['cylinder', 2]],
+    cylinder: [['seal', 4]],
+  })
+
+  it('shows the top level only when nothing is materialized', () => {
+    const nodes = tree({ graph: deepGraph })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.children).toBeNull()
+    expect(nodes[0]?.hasChildren).toBe(true)
+  })
+
+  it('marks an unmaterialized node undecided by absence, at the default percent', () => {
+    const node = tree({ graph: deepGraph })[0]
+    expect(node?.materialized).toBe(false)
+    expect(node?.status).toBe('undecided')
+    expect(node?.salvagePercent).toBe(DEFAULT_SALVAGE_PERCENT)
+  })
+
+  it('keys an unmaterialized top-level node off the synthetic root key', () => {
+    expect(tree({ graph: deepGraph })[0]?.key).toBe(`bom:${ROOT_SALVAGE_KEY}:mast`)
+  })
+
+  it('keys an unmaterialized child off its materialized parent row id', () => {
+    const nodes = tree({ graph: deepGraph, rows: [row({ id: 'r1', partId: 'mast' })] })
+    expect(nodes[0]?.children?.[0]?.key).toBe('bom:r1:cylinder')
+  })
+
+  it('expands exactly one level past a materialized node', () => {
+    const nodes = tree({ graph: deepGraph, rows: [row({ id: 'r1', partId: 'mast' })] })
+    const cylinder = nodes[0]?.children?.[0]
+    expect(cylinder?.partId).toBe('cylinder')
+    // The seal under it is NOT present: nobody has touched the cylinder.
+    expect(cylinder?.children).toBeNull()
+    expect(cylinder?.hasChildren).toBe(true)
+  })
+
+  it('expands every level that has a row, and no further', () => {
+    const nodes = tree({
+      graph: deepGraph,
+      rows: [
+        row({ id: 'r1', partId: 'mast' }),
+        row({ id: 'r2', partId: 'cylinder', parentId: 'r1', quantity: 2 }),
+      ],
+    })
+    const seal = nodes[0]?.children?.[0]?.children?.[0]
+    expect(seal?.partId).toBe('seal')
+    expect(seal?.children).toBeNull()
+    // A leaf part offers no expander.
+    expect(seal?.hasChildren).toBe(false)
+  })
+
+  it('gives a materialized leaf an empty child list, not a null one', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['bolt', 1]] }),
+      rows: [row({ id: 'r1', partId: 'bolt' })],
+    })
+    expect(nodes[0]?.children).toEqual([])
+    expect(nodes[0]?.hasChildren).toBe(false)
+  })
+})
+
+// ============= Materialized rows =============
+
+describe('materialized rows', () => {
+  it('takes quantity, status and percent from the row, and keys on its id', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 2]] }),
+      returnLineQuantity: 5,
+      rows: [row({ id: 'r1', partId: 'mast', quantity: 7, status: 'good', salvagePercent: 60 })],
+    })
+    expect(nodes[0]).toMatchObject({
+      key: 'r1',
+      quantity: 7,
+      status: 'good',
+      salvagePercent: 60,
+      materialized: true,
+      depth: 0,
+    })
+  })
+
+  it('replaces the synthetic node for that part rather than showing both', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 2]] }),
+      rows: [row({ id: 'r1', partId: 'mast' })],
+    })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.key).toBe('r1')
+  })
+
+  it('shows both halves of a split, ordered by sortOrder', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 4]] }),
+      rows: [
+        row({ id: 'rb', partId: 'mast', quantity: 1, status: 'scrap', sortOrder: 'b' }),
+        row({ id: 'ra', partId: 'mast', quantity: 3, status: 'good', sortOrder: 'a' }),
+      ],
+    })
+    expect(nodes.map((n) => n.key)).toEqual(['ra', 'rb'])
+    expect(nodes.map((n) => n.quantity)).toEqual([3, 1])
+  })
+
+  it('falls back to the row id when sortOrder is missing, so order is total', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 4]] }),
+      rows: [
+        row({ id: 'r2', partId: 'mast', quantity: 1 }),
+        row({ id: 'r1', partId: 'mast', quantity: 3 }),
+      ],
+    })
+    expect(nodes.map((n) => n.key)).toEqual(['r1', 'r2'])
+  })
+
+  it('emits a row whose part left the parent BOM after the row was written, last', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 1]] }),
+      rows: [row({ id: 'r9', partId: 'retired', status: 'damaged' })],
+    })
+    expect(nodes.map((n) => n.partId)).toEqual(['mast', 'retired'])
+    expect(nodes[1]?.materialized).toBe(true)
+  })
+})
+
+// ============= Labels =============
+
+describe('part labels', () => {
+  it('carries the name and number from the parts map', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['mast', 1]] }),
+      parts: partsOf('mast'),
+    })
+    expect(nodes[0]?.partName).toBe('MAST')
+    expect(nodes[0]?.partNumber).toBe('P-mast')
+  })
+
+  it('names an unknown part by its id rather than rendering blank', () => {
+    const nodes = tree({ graph: graphOf({ lift: [['mast', 1]] }) })
+    expect(nodes[0]?.partName).toBe('mast')
+    expect(nodes[0]?.partNumber).toBeNull()
+  })
+})
+
+// ============= Cycles and the depth cap =============
+
+describe('cycles', () => {
+  it('terminates on a two-part cycle and stops at the repeat', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['a', 1]], a: [['b', 1]], b: [['a', 1]] }),
+      rows: [
+        row({ id: 'r1', partId: 'a' }),
+        row({ id: 'r2', partId: 'b', parentId: 'r1' }),
+        row({ id: 'r3', partId: 'a', parentId: 'r2' }),
+      ],
+    })
+    const repeat = nodes[0]?.children?.[0]?.children?.[0]
+    expect(repeat?.partId).toBe('a')
+    expect(repeat?.children).toEqual([])
+    expect(repeat?.hasChildren).toBe(false)
+  })
+
+  it('terminates on a self-edge, showing the repeat once and unexpandable', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['a', 1]], a: [['a', 2]] }),
+      rows: [row({ id: 'r1', partId: 'a' })],
+    })
+    const repeat = nodes[0]?.children?.[0]
+    expect(repeat?.partId).toBe('a')
+    expect(repeat?.hasChildren).toBe(false)
+    expect(nodes[0]?.children).toHaveLength(1)
+  })
+
+  it('treats the returned part itself as on the path', () => {
+    const nodes = tree({
+      graph: graphOf({ lift: [['a', 1]], a: [['lift', 1]] }),
+      rows: [row({ id: 'r1', partId: 'a' })],
+    })
+    expect(nodes[0]?.children?.[0]?.partId).toBe('lift')
+    expect(nodes[0]?.children?.[0]?.hasChildren).toBe(false)
+  })
+
+  it('shows a part used in two branches twice, because they are graded separately', () => {
+    const nodes = tree({
+      graph: graphOf({
+        lift: [
+          ['mast', 1],
+          ['base', 1],
+        ],
+        mast: [['bolt', 4]],
+        base: [['bolt', 6]],
+      }),
+      rows: [row({ id: 'r1', partId: 'mast' }), row({ id: 'r2', partId: 'base' })],
+    })
+    const bolts = flattenSalvageTree(nodes).filter((n) => n.partId === 'bolt')
+    expect(bolts).toHaveLength(2)
+    expect(bolts.map((b) => b.quantity)).toEqual([4, 6])
+    expect(new Set(bolts.map((b) => b.key)).size).toBe(2)
+  })
+})
+
+describe('the depth cap', () => {
+  /** `p0 -> p1 -> ... -> p{length}`, one of each. */
+  function chainGraph(length: number): SubpartGraph {
+    return graphOf(
+      Object.fromEntries(
+        Array.from({ length }, (_, i) => [`p${i}`, [[`p${i + 1}`, 1]] as [string, number][]])
+      )
+    )
+  }
+
+  it('stops at MAX_SALVAGE_DEPTH even when every level has a row', () => {
+    const depth = MAX_SALVAGE_DEPTH + 5
+    const rows = Array.from({ length: depth }, (_, i) =>
+      row({ id: `r${i}`, partId: `p${i + 1}`, parentId: i === 0 ? null : `r${i - 1}` })
+    )
+    const nodes = buildSalvageTree({
+      graph: chainGraph(depth + 1),
+      rootPartId: 'p0',
+      returnLineQuantity: 1,
+      rows,
+      parts: new Map(),
+    })
+
+    const flat = flattenSalvageTree(nodes)
+    expect(flat).toHaveLength(MAX_SALVAGE_DEPTH)
+    expect(Math.max(...flat.map((n) => n.depth))).toBe(MAX_SALVAGE_DEPTH - 1)
+    const deepest = flat[flat.length - 1]
+    expect(deepest?.children).toEqual([])
+    expect(deepest?.hasChildren).toBe(false)
+  })
+})
+
+// ============= Traversal helpers =============
+
+describe('flattenSalvageTree and findSalvageNode', () => {
+  const nodes = tree({
+    graph: graphOf({ lift: [['mast', 1]], mast: [['bolt', 2]] }),
+    rows: [row({ id: 'r1', partId: 'mast' })],
+  })
+
+  it('lists parents before children', () => {
+    expect(flattenSalvageTree(nodes).map((n) => n.partId)).toEqual(['mast', 'bolt'])
+  })
+
+  it('finds a node by key at any depth', () => {
+    expect(findSalvageNode(nodes, 'bom:r1:bolt')?.partId).toBe('bolt')
+  })
+
+  it('returns undefined for a key that is not in the tree', () => {
+    expect(findSalvageNode(nodes, 'nope')).toBeUndefined()
+  })
+
+  it('is empty for an empty forest', () => {
+    expect(flattenSalvageTree([])).toEqual([])
+  })
+})

--- a/packages/lib/src/returns/client.ts
+++ b/packages/lib/src/returns/client.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/returns/client.ts
+
+/**
+ * Client-safe surface of the returns module: the salvage tree's type contract,
+ * its vocabulary, and every pure function over it.
+ *
+ * Everything re-exported here is plain arithmetic and graph work over plain
+ * data - no `@auxx/database`, no queue, no cache - so the salvage tree card and
+ * the return create dialog can import it directly. The server barrel
+ * (`index.ts`) re-exports the same names.
+ *
+ * No `'use client'` directive: server code imports this file too, and the
+ * directive would turn every export into a client-reference proxy there
+ * (`docs/lib-module-guide.md` section 7).
+ */
+
+export {
+  checkOverReturn,
+  type OverReturnCheckInput,
+  type ReturnedQuantityClaim,
+  remainingReturnableQuantity,
+  sumReturnedQuantity,
+} from './over-return-guard'
+export {
+  computeSalvageUnitCost,
+  isUsableSalvagePercent,
+  isUsableStandardCost,
+  type SalvageUnitCostInput,
+} from './salvage-cost'
+export {
+  InvalidReturnQuantityError,
+  MissingStandardCostError,
+  NestedGoodSalvageNodeError,
+  OverReturnError,
+  SalvagePercentOutOfRangeError,
+  SalvageQuantityExceedsAllowanceError,
+  type SalvageRefusal,
+  type SalvageRefusalReason,
+} from './salvage-errors'
+export {
+  checkNoNestedGoodNodes,
+  checkSalvageQuantityBounds,
+  checkSalvageStandardCosts,
+  checkSalvageTree,
+  findMissingStandardCosts,
+  findQuantityAllowanceBreaches,
+  findShadowedGoodNodes,
+  type SalvageQuantityBoundsInput,
+  type SalvageStandardCostInput,
+  type SalvageTreeCheckInput,
+  selectSalvageMovementNodes,
+} from './salvage-invariants'
+export {
+  type BuildSalvageTreeInput,
+  bomQuantity,
+  buildSalvageTree,
+  findSalvageNode,
+  flattenSalvageTree,
+} from './salvage-tree'
+export {
+  DEFAULT_SALVAGE_PERCENT,
+  MAX_SALVAGE_DEPTH,
+  type MaterializedSalvageRow,
+  ROOT_SALVAGE_KEY,
+  SALVAGE_STATUSES,
+  type SalvageNode,
+  type SalvagePartInfo,
+  type SalvageStatus,
+  type SubpartEdge,
+  type SubpartGraph,
+} from './types'

--- a/packages/lib/src/returns/index.ts
+++ b/packages/lib/src/returns/index.ts
@@ -1,0 +1,66 @@
+// packages/lib/src/returns/index.ts
+
+/**
+ * Server entry point for the returns module.
+ *
+ * Everything in it is currently pure - the salvage tree, the three invariants,
+ * the valuation and the over-return guard - so this barrel and `client.ts`
+ * carry the same names. The gated salvage writer (plan section 6.3, step 7)
+ * and the return queries land here, not in `client.ts`.
+ */
+
+export {
+  checkOverReturn,
+  type OverReturnCheckInput,
+  type ReturnedQuantityClaim,
+  remainingReturnableQuantity,
+  sumReturnedQuantity,
+} from './over-return-guard'
+export {
+  computeSalvageUnitCost,
+  isUsableSalvagePercent,
+  isUsableStandardCost,
+  type SalvageUnitCostInput,
+} from './salvage-cost'
+export {
+  InvalidReturnQuantityError,
+  MissingStandardCostError,
+  NestedGoodSalvageNodeError,
+  OverReturnError,
+  SalvagePercentOutOfRangeError,
+  SalvageQuantityExceedsAllowanceError,
+  type SalvageRefusal,
+  type SalvageRefusalReason,
+} from './salvage-errors'
+export {
+  checkNoNestedGoodNodes,
+  checkSalvageQuantityBounds,
+  checkSalvageStandardCosts,
+  checkSalvageTree,
+  findMissingStandardCosts,
+  findQuantityAllowanceBreaches,
+  findShadowedGoodNodes,
+  type SalvageQuantityBoundsInput,
+  type SalvageStandardCostInput,
+  type SalvageTreeCheckInput,
+  selectSalvageMovementNodes,
+} from './salvage-invariants'
+export {
+  type BuildSalvageTreeInput,
+  bomQuantity,
+  buildSalvageTree,
+  findSalvageNode,
+  flattenSalvageTree,
+} from './salvage-tree'
+export {
+  DEFAULT_SALVAGE_PERCENT,
+  MAX_SALVAGE_DEPTH,
+  type MaterializedSalvageRow,
+  ROOT_SALVAGE_KEY,
+  SALVAGE_STATUSES,
+  type SalvageNode,
+  type SalvagePartInfo,
+  type SalvageStatus,
+  type SubpartEdge,
+  type SubpartGraph,
+} from './types'

--- a/packages/lib/src/returns/over-return-guard.ts
+++ b/packages/lib/src/returns/over-return-guard.ts
@@ -1,0 +1,125 @@
+// packages/lib/src/returns/over-return-guard.ts
+
+/**
+ * Plan section 3.5's guard: **a sold line cannot have more come back than went
+ * out**, summed across every `return_line` pointing at it, across every return.
+ *
+ * Several `return_line` rows may point at one `line_item` - the grain is one
+ * row per sold line **per condition**, so two lifts back, one pristine and one
+ * wrecked, is two rows of quantity 1. That is what makes a per-row check
+ * useless and this cross-return sum necessary: without it a customer can
+ * return three of two lifts, and the salvage tree would happily restock parts
+ * for a unit that never shipped.
+ *
+ * 🛑 **The ceiling is an INPUT, not something this function derives.** Today it
+ * is the line's **sold** quantity, which is the documented fallback. When task
+ * 55 lands, `fulfillment_line` gives a per-dispatch **shipped** quantity and
+ * the correct ceiling becomes the sum of that line's fulfillment-line
+ * quantities, excluding dispatches whose status is cancelled - a line ordered
+ * 5 and shipped 2 can have at most 2 come back, where the sold ceiling would
+ * wave through 5. The caller swaps the number; nothing in this file changes,
+ * and it stays testable without either table existing.
+ *
+ * ⚠️ Sold quantity remains the ceiling for any line with no fulfillment lines
+ * at all - every line predating 55's re-sync, and every manually keyed return
+ * with no order. The guard tightens where the data exists and never gets
+ * looser than the old rule where it does not.
+ */
+
+import { err, ok, type Result } from 'neverthrow'
+import { InvalidReturnQuantityError, OverReturnError } from './salvage-errors'
+
+/** One existing `return_line`'s claim on a sold line. */
+export interface ReturnedQuantityClaim {
+  /** The `return_line` id, so an update can exclude its own prior row. */
+  returnLineId: string
+  quantity: number
+}
+
+/** Everything {@link checkOverReturn} needs. No database, no derivation. */
+export interface OverReturnCheckInput {
+  lineItemId: string
+  /**
+   * The most units that may ever come back against this line.
+   *
+   * Sold quantity today; the shipped quantity once task 55 lands. See the file
+   * header - this function never computes it.
+   */
+  ceiling: number
+  /**
+   * Every `return_line` already pointing at this `line_item`, **across all
+   * returns**, not just the one being edited.
+   */
+  existing: readonly ReturnedQuantityClaim[]
+  /**
+   * The row being written. `returnLineId` is set when this is an edit of an
+   * existing row, and that row is then excluded from the sum - otherwise
+   * saving a row of 2 unchanged would count its own 2 twice and refuse itself.
+   */
+  candidate: { returnLineId?: string | null; quantity: number }
+}
+
+/**
+ * Units already claimed against the line, optionally ignoring one row.
+ *
+ * Exported because the create dialog wants the number to show, not just the
+ * verdict.
+ */
+export function sumReturnedQuantity(
+  existing: readonly ReturnedQuantityClaim[],
+  excludeReturnLineId?: string | null
+): number {
+  let total = 0
+  for (const claim of existing) {
+    if (excludeReturnLineId && claim.returnLineId === excludeReturnLineId) continue
+    total += claim.quantity
+  }
+  return total
+}
+
+/**
+ * How many more units the line can still take back. Never negative, so a line
+ * that is already over-returned reads as 0 rather than as credit.
+ */
+export function remainingReturnableQuantity(
+  input: Omit<OverReturnCheckInput, 'candidate'> & {
+    candidate?: { returnLineId?: string | null }
+  }
+): number {
+  const already = sumReturnedQuantity(input.existing, input.candidate?.returnLineId)
+  return Math.max(0, input.ceiling - already)
+}
+
+/**
+ * Refuse a return line that would bring back more than the line let out.
+ *
+ * Belongs in a pre-write hook, not in the UI: several returns can point at one
+ * sold line and no single screen sees them all.
+ *
+ * A non-positive or non-finite candidate quantity refuses separately. It would
+ * otherwise pass every ceiling comparison and then restock parts for units
+ * that never shipped, which is the exact failure the ceiling exists to
+ * prevent, arriving through the door the ceiling does not watch.
+ */
+export function checkOverReturn(
+  input: OverReturnCheckInput
+): Result<void, OverReturnError | InvalidReturnQuantityError> {
+  const requested = input.candidate.quantity
+  if (!Number.isFinite(requested) || requested <= 0) {
+    return err(new InvalidReturnQuantityError({ quantity: requested }))
+  }
+
+  const alreadyReturned = sumReturnedQuantity(input.existing, input.candidate.returnLineId)
+  if (alreadyReturned + requested > input.ceiling) {
+    return err(
+      new OverReturnError({
+        lineItemId: input.lineItemId,
+        ceiling: input.ceiling,
+        alreadyReturned,
+        requested,
+      })
+    )
+  }
+
+  return ok(undefined)
+}

--- a/packages/lib/src/returns/salvage-cost.ts
+++ b/packages/lib/src/returns/salvage-cost.ts
@@ -1,0 +1,102 @@
+// packages/lib/src/returns/salvage-cost.ts
+
+/**
+ * Plan section 6.4's arithmetic, and nothing else: what one salvaged unit is
+ * worth, given the part's standard cost and the percentage the warehouse set.
+ *
+ * ```
+ * unitCost = round(part_standard_cost * salvagePercent / 100)
+ * ```
+ *
+ * **Standard, not the ledger average, and that is a decision rather than an
+ * oversight.** Task 50 prices relief at the part's ledger-derived average and
+ * argues against standard; salvage keeps standard anyway, for reasons plan
+ * section 6.4 sets out in full. The one that matters here: no org holds a
+ * single `initial` movement and builds are not backfilled, so most parts have
+ * `V = 0, Q = 0` and **no average exists** - an average basis would refuse or
+ * fall back on most rows the day it shipped. There is deliberately no
+ * ledger-average read in this file, and adding one would drag opening stock and
+ * backfilled builds in as gates on the salvage writer.
+ *
+ * Rounding happens **once, here**. The extended cost stays `computeExtendedCost`'s
+ * job (`receiving/client.ts`), which rounds the product and not the factors.
+ */
+
+import { RATE_DECIMALS, roundMinor } from '@auxx/utils/currency'
+import { err, ok, type Result } from 'neverthrow'
+import { MissingStandardCostError, SalvagePercentOutOfRangeError } from './salvage-errors'
+
+/** One salvage valuation. All amounts are minor units. */
+export interface SalvageUnitCostInput {
+  partId: string
+  partName: string
+  /** `part_standard_cost`, in minor units. Null, zero and negative all refuse. */
+  standardCost: number | null | undefined
+  /** `return_part_line.salvagePercent`. Must be greater than 0 and at most 100. */
+  salvagePercent: number
+}
+
+/**
+ * Is this a `part_standard_cost` a movement may be valued at?
+ *
+ * 🛑 Zero is not a standard. Task 26 fixed the roll, but the handoff records 83
+ * parts already rolled to `0`, and a zero passes every guard that tests
+ * `== null` - which is how a $0 unit cost gets frozen onto an append-only
+ * ledger where nothing can restate it.
+ */
+export function isUsableStandardCost(cost: number | null | undefined): cost is number {
+  return typeof cost === 'number' && Number.isFinite(cost) && cost > 0
+}
+
+/** Is this a `salvagePercent` the writer accepts? `0 < pct <= 100`. */
+export function isUsableSalvagePercent(pct: number): boolean {
+  return Number.isFinite(pct) && pct > 0 && pct <= 100
+}
+
+/**
+ * The unit cost to freeze onto a salvage `return_in` movement.
+ *
+ * Three guards, all refusals rather than corrections (plan section 6.4):
+ *
+ * 1. `pct <= 0` refuses. A worthless part is `scrap`, and scrap writes **no
+ *    movement at all** (section 6.3) - not a zero-cost one.
+ * 2. `pct > 100` refuses. Salvage is never worth more than new.
+ * 3. A null, zero or negative standard cost refuses, **naming the part**.
+ *
+ * Refusing costs nothing here, which is why this diverges from task 50 section
+ * 4.2's relief writer, which warns and never refuses: a refused relief loses a
+ * shipment that really happened and cannot be re-derived, while a refused
+ * salvage loses nothing, because the disposition is already on the
+ * `return_part_line` and the movement can be written the moment somebody costs
+ * the part. Two writers, two answers. Do not harmonise them.
+ *
+ * The result is rounded to a RATE's precision (`RATE_DECIMALS`), the same as
+ * every other per-each cost stamped on a movement - a standard cost may itself
+ * carry fractional cents, and collapsing a salvage to whole cents would make a
+ * 60% recovery of a 1.5-cent fastener cost a whole cent.
+ */
+export function computeSalvageUnitCost(
+  input: SalvageUnitCostInput
+): Result<number, MissingStandardCostError | SalvagePercentOutOfRangeError> {
+  if (!isUsableSalvagePercent(input.salvagePercent)) {
+    return err(
+      new SalvagePercentOutOfRangeError({
+        partId: input.partId,
+        partName: input.partName,
+        salvagePercent: input.salvagePercent,
+      })
+    )
+  }
+  if (!isUsableStandardCost(input.standardCost)) {
+    return err(
+      new MissingStandardCostError({
+        partId: input.partId,
+        partName: input.partName,
+        standardCost: input.standardCost ?? null,
+      })
+    )
+  }
+
+  // The one rounding in the whole salvage valuation.
+  return ok(roundMinor((input.standardCost * input.salvagePercent) / 100, RATE_DECIMALS))
+}

--- a/packages/lib/src/returns/salvage-errors.ts
+++ b/packages/lib/src/returns/salvage-errors.ts
@@ -1,0 +1,197 @@
+// packages/lib/src/returns/salvage-errors.ts
+
+/**
+ * The refusals the returns logic can produce, as `AuxxError` subclasses.
+ *
+ * Every one of them is a **typed refusal returned in a `neverthrow` `err()`**,
+ * never thrown: the caller is a pre-write hook or the gated salvage writer
+ * (plan section 6.3, step 7), both of which have to report which part or which
+ * row was refused rather than fail the whole batch opaquely. Each class
+ * therefore carries the identifying fields as real properties, because
+ * `AuxxErrorDetails` only admits strings.
+ *
+ * All of them are 422s: they are validation failures on data a person typed,
+ * not authorization or existence problems. `apps/web`'s `auxxErrorMiddleware`
+ * maps them without anything further.
+ */
+
+import { UnprocessableEntityError } from '../errors'
+
+/** Discriminant carried by every refusal below. */
+export type SalvageRefusalReason =
+  | 'nested_good_node'
+  | 'quantity_exceeds_allowance'
+  | 'missing_standard_cost'
+  | 'salvage_percent_out_of_range'
+  | 'over_return'
+  | 'invalid_return_quantity'
+
+/**
+ * A `good` node that sits under another `good` node.
+ *
+ * Plan section 6.6 invariant 1. This is normally resolved by **selection**
+ * rather than refusal - {@link selectSalvageMovementNodes} stops at the highest
+ * `good` node, so the shadowed one simply produces no movement - and this error
+ * exists for the surfaces that would rather tell the user than silently ignore
+ * half of what they ticked.
+ */
+export class NestedGoodSalvageNodeError extends UnprocessableEntityError {
+  readonly reason = 'nested_good_node' as const
+  readonly nodeKey: string
+  readonly ancestorKey: string
+  readonly partName: string
+
+  constructor(params: { nodeKey: string; ancestorKey: string; partName: string }) {
+    super(
+      `${params.partName} is marked good underneath another part that is already marked good. ` +
+        'Only the highest good node in a branch is recovered.',
+      { nodeKey: params.nodeKey, ancestorKey: params.ancestorKey, partName: params.partName }
+    )
+    this.nodeKey = params.nodeKey
+    this.ancestorKey = params.ancestorKey
+    this.partName = params.partName
+  }
+}
+
+/**
+ * Sibling rows for one part add up to more units than the parent can hold.
+ *
+ * Plan section 6.6 invariant 2. The allowance is the BOM quantity of that part
+ * under the parent times the parent's own quantity, so the split button can
+ * divide four units any way it likes and cannot invent a fifth.
+ */
+export class SalvageQuantityExceedsAllowanceError extends UnprocessableEntityError {
+  readonly reason = 'quantity_exceeds_allowance' as const
+  readonly parentKey: string
+  readonly partId: string
+  readonly partName: string
+  readonly allowed: number
+  readonly total: number
+
+  constructor(params: {
+    parentKey: string
+    partId: string
+    partName: string
+    allowed: number
+    total: number
+  }) {
+    super(
+      `${params.partName}: ${params.total} units split under one parent that holds only ` +
+        `${params.allowed}.`,
+      { parentKey: params.parentKey, partId: params.partId, partName: params.partName }
+    )
+    this.parentKey = params.parentKey
+    this.partId = params.partId
+    this.partName = params.partName
+    this.allowed = params.allowed
+    this.total = params.total
+  }
+}
+
+/**
+ * A part that would be salvaged has no usable `part_standard_cost`.
+ *
+ * Plan sections 6.4 and 6.5. A zero passes every guard that tests `== null`,
+ * and the handoff records 83 parts already rolled to `0`, so zero is refused
+ * alongside null. The refusal **names the part**, because the fix is to cost
+ * that part and press the button again - nothing is lost by refusing, since the
+ * disposition is already recorded on the `return_part_line` row.
+ */
+export class MissingStandardCostError extends UnprocessableEntityError {
+  readonly reason = 'missing_standard_cost' as const
+  readonly partId: string
+  readonly partName: string
+  readonly standardCost: number | null
+
+  constructor(params: { partId: string; partName: string; standardCost: number | null }) {
+    super(
+      `${params.partName} has no standard cost, so it cannot be salvaged. ` +
+        'Set a standard cost for the part and salvage it again.',
+      { partId: params.partId, partName: params.partName }
+    )
+    this.partId = params.partId
+    this.partName = params.partName
+    this.standardCost = params.standardCost
+  }
+}
+
+/**
+ * `salvagePercent` outside `0 < pct <= 100` (plan section 6.4, guards 1 and 2).
+ *
+ * At or below zero the part is worthless, and a worthless part is `scrap`,
+ * which writes no movement at all - not a zero-cost one. Above 100 the salvage
+ * would be worth more than a new part.
+ */
+export class SalvagePercentOutOfRangeError extends UnprocessableEntityError {
+  readonly reason = 'salvage_percent_out_of_range' as const
+  readonly partId: string
+  readonly partName: string
+  readonly salvagePercent: number
+
+  constructor(params: { partId: string; partName: string; salvagePercent: number }) {
+    super(
+      `${params.partName}: a salvage percentage of ${params.salvagePercent} is outside the ` +
+        'permitted range (greater than 0, at most 100).',
+      { partId: params.partId, partName: params.partName }
+    )
+    this.partId = params.partId
+    this.partName = params.partName
+    this.salvagePercent = params.salvagePercent
+  }
+}
+
+/**
+ * More units would come back against a sold line than ever left (plan section 3.5).
+ */
+export class OverReturnError extends UnprocessableEntityError {
+  readonly reason = 'over_return' as const
+  readonly lineItemId: string
+  readonly ceiling: number
+  readonly alreadyReturned: number
+  readonly requested: number
+
+  constructor(params: {
+    lineItemId: string
+    ceiling: number
+    alreadyReturned: number
+    requested: number
+  }) {
+    super(
+      `Returning ${params.requested} would bring back ` +
+        `${params.alreadyReturned + params.requested} units against a line of ` +
+        `${params.ceiling}.`,
+      { lineItemId: params.lineItemId }
+    )
+    this.lineItemId = params.lineItemId
+    this.ceiling = params.ceiling
+    this.alreadyReturned = params.alreadyReturned
+    this.requested = params.requested
+  }
+}
+
+/**
+ * A returned quantity that is not a positive finite number.
+ *
+ * Separate from {@link OverReturnError} because a negative quantity passes any
+ * ceiling comparison and would then restock parts for units that never shipped
+ * - the exact failure the ceiling exists to prevent, arriving through the door
+ * the ceiling does not watch.
+ */
+export class InvalidReturnQuantityError extends UnprocessableEntityError {
+  readonly reason = 'invalid_return_quantity' as const
+  readonly quantity: number
+
+  constructor(params: { quantity: number }) {
+    super(`A returned quantity must be a positive number, got ${params.quantity}.`, {})
+    this.quantity = params.quantity
+  }
+}
+
+/** Every refusal this module can return. */
+export type SalvageRefusal =
+  | NestedGoodSalvageNodeError
+  | SalvageQuantityExceedsAllowanceError
+  | MissingStandardCostError
+  | SalvagePercentOutOfRangeError
+  | OverReturnError
+  | InvalidReturnQuantityError

--- a/packages/lib/src/returns/salvage-invariants.ts
+++ b/packages/lib/src/returns/salvage-invariants.ts
@@ -1,0 +1,277 @@
+// packages/lib/src/returns/salvage-invariants.ts
+
+/**
+ * Plan section 6.6's three invariants, as pure functions over a built tree.
+ *
+ * 1. **Only the highest `good` node in a branch produces a movement.** Walk
+ *    down, stop at the first `good`. A `good` node under a `good` ancestor is
+ *    one recovery, not two - the subassembly went into inventory whole, and
+ *    restocking its children as well would put the same material back twice on
+ *    an append-only ledger. This is the same one-level property
+ *    `bom/subpart-graph.ts` documents for builds, which is why restocking the
+ *    node the warehouse checked is coherent at every depth.
+ * 2. **A parent's quantity bounds its children.** The split button divides a
+ *    row; it must not invent units.
+ * 3. **A `good` row whose part has no usable standard cost refuses**, naming
+ *    the part.
+ *
+ * Every check returns a typed refusal in a `neverthrow` `err()` and throws
+ * nothing, so the gated salvage writer (step 7) can report which part stopped
+ * it without abandoning the rest of the return.
+ */
+
+import { err, ok, type Result } from 'neverthrow'
+import { isUsableStandardCost } from './salvage-cost'
+import {
+  MissingStandardCostError,
+  NestedGoodSalvageNodeError,
+  SalvageQuantityExceedsAllowanceError,
+} from './salvage-errors'
+import { bomQuantity } from './salvage-tree'
+import { ROOT_SALVAGE_KEY, type SalvageNode, type SubpartGraph } from './types'
+
+// ─── Invariant 1: one recovery per branch ───────────────────────────
+
+/**
+ * The nodes that would produce a `return_in` movement.
+ *
+ * Walk down from each root and stop at the first `good` node: it is included
+ * and its subtree is not searched. Anything else is descended into, because a
+ * `damaged` subassembly may still contain a `good` bolt worth recovering.
+ *
+ * An unexpanded node (`children === null`) is a leaf as far as this walk is
+ * concerned - by the laziness rule it has no rows beneath it, so there is
+ * nothing under it to recover.
+ */
+export function selectSalvageMovementNodes(roots: readonly SalvageNode[]): SalvageNode[] {
+  const out: SalvageNode[] = []
+  const walk = (nodes: readonly SalvageNode[]) => {
+    for (const node of nodes) {
+      if (node.status === 'good') {
+        out.push(node)
+        continue
+      }
+      if (node.children) walk(node.children)
+    }
+  }
+  walk(roots)
+  return out
+}
+
+/**
+ * The `good` nodes that sit beneath another `good` node, paired with the
+ * ancestor that shadows them.
+ *
+ * These are **not** an error by themselves: {@link selectSalvageMovementNodes}
+ * already ignores them, which is the plan's "one recovery, not two". The list
+ * exists so a surface can grey them out or explain why ticking them changed
+ * nothing.
+ */
+export function findShadowedGoodNodes(
+  roots: readonly SalvageNode[]
+): { node: SalvageNode; ancestor: SalvageNode }[] {
+  const out: { node: SalvageNode; ancestor: SalvageNode }[] = []
+  const walk = (nodes: readonly SalvageNode[], goodAncestor: SalvageNode | null) => {
+    for (const node of nodes) {
+      if (goodAncestor && node.status === 'good') out.push({ node, ancestor: goodAncestor })
+      // The ancestor reported is the HIGHEST good one, not the nearest: that is
+      // the node that actually produces the movement, so it is the one whose
+      // recovery explains why this row changed nothing.
+      const nextAncestor = node.status === 'good' ? (goodAncestor ?? node) : goodAncestor
+      if (node.children) walk(node.children, nextAncestor)
+    }
+  }
+  walk(roots, null)
+  return out
+}
+
+/**
+ * Refuse a tree that marks a `good` node under a `good` ancestor.
+ *
+ * Advisory: the salvage writer does not need it, because selection already
+ * resolves the ambiguity. A surface that would rather tell the user than
+ * silently drop half of what they ticked calls this first.
+ */
+export function checkNoNestedGoodNodes(
+  roots: readonly SalvageNode[]
+): Result<void, NestedGoodSalvageNodeError> {
+  const shadowed = findShadowedGoodNodes(roots)
+  const first = shadowed[0]
+  if (!first) return ok(undefined)
+  return err(
+    new NestedGoodSalvageNodeError({
+      nodeKey: first.node.key,
+      ancestorKey: first.ancestor.key,
+      partName: first.node.partName,
+    })
+  )
+}
+
+// ─── Invariant 2: a parent's quantity bounds its children ───────────
+
+/** What {@link findQuantityAllowanceBreaches} needs to know the allowances. */
+export interface SalvageQuantityBoundsInput {
+  roots: readonly SalvageNode[]
+  graph: SubpartGraph
+  /** `return_line.part`, the BOM root. */
+  rootPartId: string
+  /** `return_line.quantity`, the top level's parent quantity. */
+  returnLineQuantity: number
+}
+
+/**
+ * Every place where sibling rows for one part add up to more than the parent
+ * holds.
+ *
+ * ⚠️ **The bound is per part, against the BOM allowance** - not
+ * `sum(children.quantity) <= parent.quantity`, which would refuse every real
+ * tree, since a subassembly of 4 legitimately contains 16 bolts. The plan's
+ * sentence is about the **split** button: splitting a row of 4 may produce
+ * rows of 3 and 1, never 3 and 2. So the allowance for part `C` under parent
+ * `P` is `bomQuantity(P.part, C) * P.quantity`, and the rows for `C` under `P`
+ * must sum to no more than that.
+ *
+ * A part with no BOM edge under its parent - the BOM was edited after the row
+ * was written - has no allowance to compare against and is skipped rather than
+ * refused: the number to bound it by does not exist, and inventing one would
+ * refuse a decision somebody already recorded.
+ */
+export function findQuantityAllowanceBreaches(
+  input: SalvageQuantityBoundsInput
+): SalvageQuantityExceedsAllowanceError[] {
+  const out: SalvageQuantityExceedsAllowanceError[] = []
+
+  const checkLevel = (
+    siblings: readonly SalvageNode[],
+    parentKey: string,
+    parentPartId: string,
+    parentQuantity: number
+  ) => {
+    const totals = new Map<string, { total: number; name: string }>()
+    for (const node of siblings) {
+      const entry = totals.get(node.partId) ?? { total: 0, name: node.partName }
+      entry.total += node.quantity
+      totals.set(node.partId, entry)
+    }
+
+    for (const [partId, entry] of totals) {
+      const perParent = bomQuantity(input.graph, parentPartId, partId)
+      if (perParent === null) continue
+      const allowed = perParent * parentQuantity
+      if (entry.total > allowed) {
+        out.push(
+          new SalvageQuantityExceedsAllowanceError({
+            parentKey,
+            partId,
+            partName: entry.name,
+            allowed,
+            total: entry.total,
+          })
+        )
+      }
+    }
+
+    for (const node of siblings) {
+      if (node.children) checkLevel(node.children, node.key, node.partId, node.quantity)
+    }
+  }
+
+  checkLevel(input.roots, ROOT_SALVAGE_KEY, input.rootPartId, input.returnLineQuantity)
+  return out
+}
+
+/** {@link findQuantityAllowanceBreaches}, as a refusal on the first breach. */
+export function checkSalvageQuantityBounds(
+  input: SalvageQuantityBoundsInput
+): Result<void, SalvageQuantityExceedsAllowanceError> {
+  const breach = findQuantityAllowanceBreaches(input)[0]
+  return breach ? err(breach) : ok(undefined)
+}
+
+// ─── Invariant 3: a salvaged part must be costed ────────────────────
+
+/** What {@link findMissingStandardCosts} needs. Costs are minor units. */
+export interface SalvageStandardCostInput {
+  roots: readonly SalvageNode[]
+  /** `part_standard_cost` per part id. A part absent from the map reads as null. */
+  standardCosts: ReadonlyMap<string, number | null | undefined>
+}
+
+/**
+ * Every part that would be salvaged and has no usable `part_standard_cost`.
+ *
+ * Runs over {@link selectSalvageMovementNodes}'s output, not the whole tree: a
+ * `damaged` or `undecided` part writes no movement, so its cost is nobody's
+ * problem. One entry per part, even when several rows salvage it, because the
+ * fix is one edit to that part.
+ */
+export function findMissingStandardCosts(
+  input: SalvageStandardCostInput
+): MissingStandardCostError[] {
+  const out: MissingStandardCostError[] = []
+  const reported = new Set<string>()
+
+  for (const node of selectSalvageMovementNodes(input.roots)) {
+    if (reported.has(node.partId)) continue
+    const cost = input.standardCosts.get(node.partId)
+    if (isUsableStandardCost(cost)) continue
+    reported.add(node.partId)
+    out.push(
+      new MissingStandardCostError({
+        partId: node.partId,
+        partName: node.partName,
+        standardCost: cost ?? null,
+      })
+    )
+  }
+
+  return out
+}
+
+/** {@link findMissingStandardCosts}, as a refusal on the first uncosted part. */
+export function checkSalvageStandardCosts(
+  input: SalvageStandardCostInput
+): Result<void, MissingStandardCostError> {
+  const missing = findMissingStandardCosts(input)[0]
+  return missing ? err(missing) : ok(undefined)
+}
+
+// ─── All three, in the order the writer wants them ──────────────────
+
+/** {@link checkSalvageTree}'s input: both invariants that need outside data. */
+export interface SalvageTreeCheckInput
+  extends SalvageQuantityBoundsInput,
+    SalvageStandardCostInput {
+  /**
+   * Refuse a `good` node nested under another instead of quietly selecting the
+   * higher one. Off by default, matching the plan: nesting is resolved by
+   * selection, not refusal.
+   */
+  refuseNestedGood?: boolean
+}
+
+/**
+ * Apply all three invariants and return the nodes that would move stock.
+ *
+ * This is the single entry point the gated salvage writer (step 7) is meant to
+ * call, so the three checks cannot be applied in different combinations by
+ * different callers. It writes nothing and reads no database: the caller
+ * supplies the standard costs and, on success, turns each returned node into
+ * one `return_in` through the shared `writeStockMovements`.
+ */
+export function checkSalvageTree(
+  input: SalvageTreeCheckInput
+): Result<
+  SalvageNode[],
+  NestedGoodSalvageNodeError | SalvageQuantityExceedsAllowanceError | MissingStandardCostError
+> {
+  if (input.refuseNestedGood) {
+    const nested = checkNoNestedGoodNodes(input.roots)
+    if (nested.isErr()) return err(nested.error)
+  }
+  const bounds = checkSalvageQuantityBounds(input)
+  if (bounds.isErr()) return err(bounds.error)
+  const costs = checkSalvageStandardCosts(input)
+  if (costs.isErr()) return err(costs.error)
+  return ok(selectSalvageMovementNodes(input.roots))
+}

--- a/packages/lib/src/returns/salvage-tree.ts
+++ b/packages/lib/src/returns/salvage-tree.ts
@@ -1,0 +1,274 @@
+// packages/lib/src/returns/salvage-tree.ts
+
+/**
+ * The salvage tree as **pure graph work**: BOM edges plus whatever
+ * `return_part_line` rows exist, in, view tree out, with no database anywhere.
+ *
+ * The warehouse works a returned lift by walking its BOM and grading each
+ * subassembly (plan section 6.6). Two properties of that walk are what this
+ * file exists to get right, and neither is expressible in the query that loads
+ * the data:
+ *
+ * 1. **Laziness.** A BOM is up to {@link MAX_SALVAGE_DEPTH} deep and nobody
+ *    opens all of it, so rows are materialized on first touch. Only the top
+ *    level, plus the children of nodes that already have a row, are present. A
+ *    node with no row is `undecided` **by absence**, which keeps
+ *    `return_part_line` small and makes the salvage writer's input exactly "the
+ *    rows somebody actually touched".
+ * 2. **Compounding prefill.** A node's prefilled quantity is its BOM quantity
+ *    times its parent's quantity, and the top level's parent is the return line
+ *    itself. Two lifts returned, each carrying 2 of a subassembly, prefills
+ *    that row at 4; a bolt used 3 times in that subassembly prefills at 12.
+ *
+ * Cycles and the depth cap are handled the way `bom/subpart-graph.ts` handles
+ * them - a visited set and a hard depth limit - with one deliberate difference
+ * recorded on {@link buildSalvageTree}.
+ */
+
+import {
+  DEFAULT_SALVAGE_PERCENT,
+  MAX_SALVAGE_DEPTH,
+  type MaterializedSalvageRow,
+  ROOT_SALVAGE_KEY,
+  type SalvageNode,
+  type SalvagePartInfo,
+  type SubpartEdge,
+  type SubpartGraph,
+} from './types'
+
+/** Everything {@link buildSalvageTree} needs. All of it is plain data. */
+export interface BuildSalvageTreeInput {
+  /** `loadSubpartGraph(organizationId, rootPartId)`'s adjacency map. */
+  graph: SubpartGraph
+  /** `return_line.part` - the returned finished good, and the BOM root. */
+  rootPartId: string
+  /** `return_line.quantity` - how many of the finished good came back. */
+  returnLineQuantity: number
+  /** Every `return_part_line` row for this return line. Order does not matter. */
+  rows: readonly MaterializedSalvageRow[]
+  /** Part labels. A part missing from the map is named by its id, never blank. */
+  parts: ReadonlyMap<string, SalvagePartInfo>
+}
+
+/**
+ * Assemble the view tree for one return line.
+ *
+ * The returned finished good is **not** a node: it does not come back as
+ * itself (plan section 6.1), so the roots are its direct subassemblies and
+ * their synthetic parent key is {@link ROOT_SALVAGE_KEY}.
+ *
+ * Ordering within a parent is BOM edge order, and the rows for one part sort
+ * among themselves by `sortOrder` then `id`, so a split's two halves keep a
+ * stable position. Rows whose part is no longer in the parent's BOM - the BOM
+ * was edited after the row was written - are emitted last rather than dropped,
+ * because a recorded disposition must never vanish from the screen.
+ *
+ * 🛑 **The cycle guard is path-scoped, not global.** `getDeductionTargets` in
+ * `bom/subpart-graph.ts` shares one visited set across siblings, which is right
+ * for a flatten that consolidates quantities and wrong for a view: a part used
+ * in two different subassemblies is two rows the warehouse grades separately.
+ * A part that reappears **on its own path** is emitted once and not descended
+ * into, so the tree stays finite and shows `hasChildren: false` there rather
+ * than an expander that re-enters the loop.
+ */
+export function buildSalvageTree(input: BuildSalvageTreeInput): SalvageNode[] {
+  const byParent = groupRowsByParent(input.rows)
+
+  return buildLevel({
+    input,
+    byParent,
+    parentKey: ROOT_SALVAGE_KEY,
+    parentRowId: null,
+    parentPartId: input.rootPartId,
+    parentQuantity: input.returnLineQuantity,
+    depth: 0,
+    path: new Set<string>([input.rootPartId]),
+  })
+}
+
+/** Every node in the tree, parents before children. */
+export function flattenSalvageTree(roots: readonly SalvageNode[]): SalvageNode[] {
+  const out: SalvageNode[] = []
+  const walk = (nodes: readonly SalvageNode[]) => {
+    for (const node of nodes) {
+      out.push(node)
+      if (node.children) walk(node.children)
+    }
+  }
+  walk(roots)
+  return out
+}
+
+/** The node with `key`, or undefined. Convenience over {@link flattenSalvageTree}. */
+export function findSalvageNode(
+  roots: readonly SalvageNode[],
+  key: string
+): SalvageNode | undefined {
+  return flattenSalvageTree(roots).find((node) => node.key === key)
+}
+
+/**
+ * The BOM quantity of `childPartId` directly under `parentPartId`, or null when
+ * there is no such edge.
+ *
+ * Parallel edges are summed: two `subpart` rows joining the same pair mean the
+ * parent uses that many, and taking the first would silently halve the prefill.
+ */
+export function bomQuantity(
+  graph: SubpartGraph,
+  parentPartId: string,
+  childPartId: string
+): number | null {
+  const edges = graph.get(parentPartId)
+  if (!edges) return null
+  let total = 0
+  let found = false
+  for (const edge of edges) {
+    if (edge.childId !== childPartId) continue
+    found = true
+    total += edge.qty
+  }
+  return found ? total : null
+}
+
+// ─── internals ──────────────────────────────────────────────────────
+
+/** `parentRowId` (null at the top level) -> the rows under it. */
+function groupRowsByParent(
+  rows: readonly MaterializedSalvageRow[]
+): Map<string | null, MaterializedSalvageRow[]> {
+  const byParent = new Map<string | null, MaterializedSalvageRow[]>()
+  for (const row of rows) {
+    const bucket = byParent.get(row.parentId) ?? []
+    bucket.push(row)
+    byParent.set(row.parentId, bucket)
+  }
+  return byParent
+}
+
+/** Sibling order: `sortOrder` when both have one, then `id`, so it is total. */
+function compareRows(a: MaterializedSalvageRow, b: MaterializedSalvageRow): number {
+  const aOrder = a.sortOrder ?? ''
+  const bOrder = b.sortOrder ?? ''
+  if (aOrder !== bOrder) return aOrder < bOrder ? -1 : 1
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
+interface LevelContext {
+  input: BuildSalvageTreeInput
+  byParent: Map<string | null, MaterializedSalvageRow[]>
+  parentKey: string
+  parentRowId: string | null
+  parentPartId: string
+  parentQuantity: number
+  depth: number
+  /** Part ids on the path from the BOM root to this level, for the cycle guard. */
+  path: ReadonlySet<string>
+}
+
+function buildLevel(ctx: LevelContext): SalvageNode[] {
+  if (ctx.depth >= MAX_SALVAGE_DEPTH) return []
+
+  const edges = ctx.input.graph.get(ctx.parentPartId) ?? []
+  const rows = [...(ctx.byParent.get(ctx.parentRowId) ?? [])].sort(compareRows)
+
+  const nodes: SalvageNode[] = []
+  const placedRowIds = new Set<string>()
+  const seenEdgeParts = new Set<string>()
+
+  for (const edge of edges) {
+    if (seenEdgeParts.has(edge.childId)) continue
+    seenEdgeParts.add(edge.childId)
+
+    const edgeQty = bomQuantity(ctx.input.graph, ctx.parentPartId, edge.childId) ?? edge.qty
+    const matching = rows.filter((row) => row.partId === edge.childId)
+
+    if (matching.length === 0) {
+      nodes.push(makeSyntheticNode(ctx, edge, edgeQty))
+      continue
+    }
+    for (const row of matching) {
+      placedRowIds.add(row.id)
+      nodes.push(makeMaterializedNode(ctx, row))
+    }
+  }
+
+  // Rows whose part is no longer a child of this parent in the BOM. The
+  // disposition was recorded against a graph that has since changed; showing
+  // it last beats dropping it.
+  for (const row of rows) {
+    if (placedRowIds.has(row.id)) continue
+    nodes.push(makeMaterializedNode(ctx, row))
+  }
+
+  return nodes
+}
+
+function makeSyntheticNode(ctx: LevelContext, edge: SubpartEdge, edgeQty: number): SalvageNode {
+  const info = ctx.input.parts.get(edge.childId)
+  const cyclic = ctx.path.has(edge.childId)
+  return {
+    key: `bom:${ctx.parentKey}:${edge.childId}`,
+    partId: edge.childId,
+    partName: info?.name ?? edge.childId,
+    partNumber: info?.number ?? null,
+    depth: ctx.depth,
+    quantity: edgeQty * ctx.parentQuantity,
+    status: 'undecided',
+    salvagePercent: DEFAULT_SALVAGE_PERCENT,
+    hasChildren: hasChildren(ctx, edge.childId, null, cyclic),
+    materialized: false,
+    // Not expanded: an unmaterialized node's children are loaded on first
+    // touch, which is the whole of the laziness rule.
+    children: null,
+  }
+}
+
+function makeMaterializedNode(ctx: LevelContext, row: MaterializedSalvageRow): SalvageNode {
+  const info = ctx.input.parts.get(row.partId)
+  const cyclic = ctx.path.has(row.partId)
+  const children = cyclic
+    ? []
+    : buildLevel({
+        ...ctx,
+        parentKey: row.id,
+        parentRowId: row.id,
+        parentPartId: row.partId,
+        parentQuantity: row.quantity,
+        depth: ctx.depth + 1,
+        path: new Set([...ctx.path, row.partId]),
+      })
+
+  return {
+    key: row.id,
+    partId: row.partId,
+    partName: info?.name ?? row.partId,
+    partNumber: info?.number ?? null,
+    depth: ctx.depth,
+    quantity: row.quantity,
+    status: row.status,
+    salvagePercent: row.salvagePercent,
+    hasChildren: hasChildren(ctx, row.partId, children, cyclic),
+    materialized: true,
+    children,
+  }
+}
+
+/**
+ * Whether the UI should offer an expander.
+ *
+ * False on a cycle and at the depth cap even when the BOM says otherwise:
+ * expanding there yields nothing, and an expander that opens onto an empty list
+ * reads as a loading bug.
+ */
+function hasChildren(
+  ctx: LevelContext,
+  partId: string,
+  builtChildren: SalvageNode[] | null,
+  cyclic: boolean
+): boolean {
+  if (cyclic) return false
+  if (ctx.depth + 1 >= MAX_SALVAGE_DEPTH) return false
+  if (builtChildren && builtChildren.length > 0) return true
+  return (ctx.input.graph.get(partId)?.length ?? 0) > 0
+}

--- a/packages/lib/src/returns/types.ts
+++ b/packages/lib/src/returns/types.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/returns/types.ts
+
+/**
+ * The shapes the returns salvage logic is written against.
+ *
+ * Nothing here imports anything: `client.ts` re-exports this file for the
+ * browser, every pure module below imports it, and keeping the declarations in
+ * their own file is what stops `client.ts -> salvage-tree.ts -> client.ts` from
+ * becoming a real import cycle.
+ *
+ * See `plans/money/tasks/54-returns.md` sections 3.5, 3.6, 6.3, 6.4 and 6.6.
+ */
+
+/**
+ * `return_part_line.status` (plan section 3.6).
+ *
+ * `undecided` is also what a node with **no row at all** reads as: the tree is
+ * materialized lazily, so absence is the default rather than a stored value
+ * (plan section 6.6, "Materialize rows lazily, not on create").
+ */
+export type SalvageStatus = 'good' | 'damaged' | 'scrap' | 'missing' | 'undecided'
+
+/** Every `SalvageStatus`, for exhaustive UI selectors and validation. */
+export const SALVAGE_STATUSES = [
+  'good',
+  'damaged',
+  'scrap',
+  'missing',
+  'undecided',
+] as const satisfies readonly SalvageStatus[]
+
+/** `return_part_line.salvagePercent` when nobody has said otherwise (plan section 6.4). */
+export const DEFAULT_SALVAGE_PERCENT = 100
+
+/**
+ * The synthetic parent key the top level of the tree hangs off.
+ *
+ * The returned part itself is **not** a node: a returned lift does not come
+ * back as a lift (plan section 6.1), so the tree starts at its direct
+ * subassemblies and they need a stable parent key for {@link SalvageNode.key}'s
+ * `bom:${parentKey}:${partId}` form.
+ */
+export const ROOT_SALVAGE_KEY = 'root'
+
+/**
+ * Depth the walk refuses to go past, mirroring `MAX_BOM_DEPTH` in
+ * `bom/subpart-graph.ts`.
+ *
+ * Duplicated rather than imported on purpose: `subpart-graph.ts` imports
+ * `@auxx/database`, and this file has to stay loadable in a browser bundle.
+ * The two numbers describe the same guard and must move together.
+ */
+export const MAX_SALVAGE_DEPTH = 20
+
+/** One BOM edge, exactly as `loadSubpartGraph` returns it in its adjacency map. */
+export interface SubpartEdge {
+  childId: string
+  qty: number
+}
+
+/** `loadSubpartGraph`'s return shape: `parentPartId -> child edges`. */
+export type SubpartGraph = ReadonlyMap<string, readonly SubpartEdge[]>
+
+/** What the tree needs to label a part. Anything else belongs to the query, not here. */
+export interface SalvagePartInfo {
+  name: string
+  number: string | null
+}
+
+/**
+ * A `return_part_line` row that actually exists.
+ *
+ * `parentId` is the parent **row's** id, not a part id, and is null for a row
+ * at the top level of a return line's tree. Several rows may share a
+ * `(parentId, partId)` pair: that is the split button (plan section 6.6), one
+ * row per disposition.
+ */
+export interface MaterializedSalvageRow {
+  id: string
+  parentId: string | null
+  partId: string
+  quantity: number
+  status: SalvageStatus
+  salvagePercent: number
+  /** Fractional index. Ties and nulls fall back to `id` so the order is total. */
+  sortOrder?: string | null
+}
+
+/**
+ * One row of the salvage tree the warehouse works through.
+ *
+ * 🛑 This shape is a contract other surfaces are built against. `children:
+ * null` means "not expanded yet", which is different from `[]` ("expanded, no
+ * children"), and `materialized: false` means no `return_part_line` row exists,
+ * which is what makes `status: 'undecided'` true by absence.
+ */
+export interface SalvageNode {
+  /** `return_part_line` id, or `bom:${parentKey}:${partId}` when not yet materialized. */
+  key: string
+  partId: string
+  partName: string
+  partNumber: string | null
+  depth: number
+  /** Prefilled BOM qty x the parent's quantity, editable once materialized. */
+  quantity: number
+  status: SalvageStatus
+  /** Default {@link DEFAULT_SALVAGE_PERCENT}. */
+  salvagePercent: number
+  hasChildren: boolean
+  /** Does a `return_part_line` row exist. */
+  materialized: boolean
+  /** `null` means not yet expanded. */
+  children: SalvageNode[] | null
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -612,6 +612,41 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     color: 'amber',
     isVisible: false, // Internal entity, managed from the order
   },
+  {
+    // One dispatch of goods, as the sales channel describes it
+    // (plans/money/tasks/55-shipment-lines.md §3). Replaces the
+    // `order_fulfillments` JSON array - the field keeps its name and becomes a
+    // has_many pointing here, because Shopify sends per-fulfillment line
+    // quantities and dates that the JSON collapse threw away. Revenue now
+    // posts from these records. Entity migration 153.
+    //
+    // `isVisible: false`, no route folder: nobody creates one by hand, it is
+    // minted by a channel or by `money.fulfillOrder`.
+    //
+    // 🛑 This line reaches FRESH orgs only. `ensureEntityDefinitions` is a
+    // plain insert that skips an org already holding the def, so existing
+    // orgs are reached by migration 153.
+    entityType: 'fulfillment',
+    apiSlug: 'fulfillments',
+    singular: 'Fulfillment',
+    plural: 'Fulfillments',
+    icon: 'package-check',
+    color: 'blue',
+    isVisible: false,
+  },
+  {
+    // One `(fulfillment, line_item)` tuple: units of one order line that went
+    // out in one dispatch (55 §3). Same hiding and same insert-only caveat as
+    // `fulfillment` above - managed entirely from the parent, like
+    // `credit_memo_line` / `purchase_order_line`.
+    entityType: 'fulfillment_line',
+    apiSlug: 'fulfillment-lines',
+    singular: 'Fulfillment Line',
+    plural: 'Fulfillment Lines',
+    icon: 'list',
+    color: 'blue',
+    isVisible: false,
+  },
 ]
 
 /**
@@ -879,6 +914,22 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
   bank_rule: {
     primaryDisplayField: 'name',
     secondaryDisplayField: 'matchValue',
+  },
+  // `name` is nullable in the type (Shopify can omit it on an older API
+  // version) but the connector projects it and the native door synthesises
+  // one otherwise, so in practice it is always there - same reasoning as
+  // `shipment`'s tracking-number choice just above. `shippedAt` is
+  // `nullable: false`, which is what makes it a safe secondary.
+  fulfillment: {
+    primaryDisplayField: 'name',
+    secondaryDisplayField: 'shippedAt',
+  },
+  // The line item is the thing a person actually wants to see ("which line
+  // did these units come from"); `quantity` disambiguates two lines of the
+  // same fulfillment. Mirrors `subpart`'s relation-primary pattern just above.
+  fulfillment_line: {
+    primaryDisplayField: 'lineItem',
+    secondaryDisplayField: 'quantity',
   },
 }
 

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -17,6 +17,8 @@ import { CONTACT_FIELDS } from '../../resources/registry/resources/contact-field
 import { CREDIT_MEMO_APPLICATION_FIELDS } from '../../resources/registry/resources/credit-memo-application-fields'
 import { CREDIT_MEMO_FIELDS } from '../../resources/registry/resources/credit-memo-fields'
 import { CREDIT_MEMO_LINE_FIELDS } from '../../resources/registry/resources/credit-memo-line-fields'
+import { FULFILLMENT_FIELDS } from '../../resources/registry/resources/fulfillment-fields'
+import { FULFILLMENT_LINE_FIELDS } from '../../resources/registry/resources/fulfillment-line-fields'
 import { GL_ACCOUNT_FIELDS } from '../../resources/registry/resources/gl-account-fields'
 import { INBOX_FIELDS } from '../../resources/registry/resources/inbox-fields'
 import { INVOICE_FIELDS } from '../../resources/registry/resources/invoice-fields'
@@ -117,6 +119,10 @@ export const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   // with only a logged warning. `bank_rule` shipped that way and nothing failed.
   shipment: SHIPMENT_FIELDS,
   parcel: PARCEL_FIELDS,
+  // The sales-channel fact behind `order_fulfillments` (plans/money/tasks/55).
+  // Same warning as directly above: missing here means a zero-field def.
+  fulfillment: FULFILLMENT_FIELDS,
+  fulfillment_line: FULFILLMENT_LINE_FIELDS,
 }
 
 /**

--- a/packages/lib/src/stock-movements/guard.ts
+++ b/packages/lib/src/stock-movements/guard.ts
@@ -1,0 +1,33 @@
+// packages/lib/src/stock-movements/guard.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError } from '../errors'
+
+const logger = createScopedLogger('stock-movements')
+
+/**
+ * Run an imperative helper body that may `throw` an {@link AuxxError} for
+ * known business-rule failures, and convert the outcome into a neverthrow
+ * `Result`.
+ *
+ * Copied from `snippets/guard.ts` per `docs/lib-module-guide.md` §3 and
+ * `receiving/guard.ts` - small enough that duplicating it beats a shared
+ * abstraction, and duplicating it is what lets this module bind its own
+ * `createScopedLogger` scope.
+ */
+export async function guard<T>(
+  fn: () => Promise<T>,
+  logMessage: string,
+  meta: Record<string, unknown> = {}
+): Promise<Result<T, AuxxError>> {
+  try {
+    return ok(await fn())
+  } catch (error) {
+    if (error instanceof AuxxError) {
+      return err(error)
+    }
+    logger.error(logMessage, { error, ...meta })
+    return err(new AuxxError('Internal error'))
+  }
+}

--- a/packages/lib/src/stock-movements/index.ts
+++ b/packages/lib/src/stock-movements/index.ts
@@ -1,0 +1,13 @@
+// packages/lib/src/stock-movements/index.ts
+
+export type {
+  StockMovementInput,
+  StockMovementLinks,
+  StockMovementsCtx,
+  StockMovementsLane,
+  WriteStockMovementsResult,
+  WrittenStockMovement,
+} from './types'
+export type { ResolvedStockMovementLinks, StockMovementValueFields } from './values'
+export { buildStockMovementValues } from './values'
+export { writeStockMovements } from './write-movements'

--- a/packages/lib/src/stock-movements/types.ts
+++ b/packages/lib/src/stock-movements/types.ts
@@ -1,0 +1,175 @@
+// packages/lib/src/stock-movements/types.ts
+
+/**
+ * Input and output shapes for the shared `stock_movement` writer.
+ *
+ * plans/money/tasks/50-batch-inventory-relief.md §2.3 gives this contract
+ * verbatim, with two additive deviations, both required to make the
+ * extraction a zero-behaviour-change refactor of the five existing callers
+ * (§2.6: "if a test needs editing, the refactor changed behaviour and is
+ * wrong") rather than a literal transcription of the brief:
+ *
+ * 1. **`vendorUnitPrice` on the input.** The brief's contract has no slot for
+ *    it, but `receive-stock.ts` stamps `stock_movement_vendor_unit_price` - a
+ *    plain scalar, three-way-match provenance - distinct from the
+ *    `vendorPartId` RELATIONSHIP in `links`. Every other caller leaves it
+ *    undefined.
+ * 2. **`costBasis` and `glAccount` are optional, not required.** The brief
+ *    types both as required strings. `reverse-movement.ts` omits `costBasis`
+ *    entirely when the original movement never carried one (a pre-migration
+ *    row), and `reverse-build.ts` omits `glAccount` the same way. Making
+ *    either required here would force every caller to invent a value where
+ *    the current code deliberately writes no key at all.
+ */
+
+import type { Database } from '@auxx/database'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
+import type { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import type { WriteSession } from '../resources/crud/write-origin'
+
+/**
+ * The typed links a `stock_movement` may carry, per §2.4 item 4: one
+ * definition, so a reversal (or any other writer) copies the whole set
+ * instead of a hand-listed subset.
+ *
+ * Every value is a BARE `EntityInstance.id` - never a pre-built `RecordId` -
+ * except where a caller already holds a `RecordId` (a `defId:id` string) for
+ * one, which is accepted as-is so a caller that already resolved its own def
+ * id (a build's own context, for instance) is not made to resolve it twice.
+ */
+export interface StockMovementLinks {
+  vendorPartId?: string
+  purchaseOrderLineId?: string
+  buildId?: string
+  reversesMovementId?: string
+  parentMovementId?: string
+  fulfillmentLineId?: string
+}
+
+/** One `stock_movement` row to write. §2.3, plus the two deviations above. */
+export interface StockMovementInput {
+  /** `EntityInstance.id` of the `part` this movement is against. */
+  partInstanceId: string
+  /** A `StockMovementType` value. */
+  type: string
+  /** SIGNED. The sign convention lives here and nowhere else. */
+  quantity: number
+  /** Minor units, at `RATE_DECIMALS`. */
+  unitCost: number
+  /** A `StockMovementCostBasis` value. Omit only to omit the key entirely (see above). */
+  costBasis?: string
+  /** An inventory ROLE (`resolveInventoryRoleForPartKind`), never a code. Omit only to omit the key (see above). */
+  glAccount?: string
+  occurredAt: Date
+  /**
+   * Override for `computeExtendedCost(unitCost, quantity)`, for a caller that
+   * already has the signed amount and must not risk a rounding-tiebreak
+   * disagreement by recomputing it - `complete-build.ts`'s negated
+   * `build_consume` row is the case this exists for (§2.2).
+   */
+  extendedCost?: number
+  /**
+   * Opt-IN, and it must carry a `reason`. `false` (the default you get by
+   * saying nothing) is what every one of the six existing callers writes,
+   * always - §2.4 item 1.
+   */
+  adjustSubparts?: true
+  reason?: string
+  reference?: string
+  links?: StockMovementLinks
+  /** The as-built BOM snapshot. `null`/absent is the OFF-BOM marker - never write a 0. */
+  qtyPerUnit?: number | null
+  /**
+   * Not part of the brief's contract - see the file header, deviation 1.
+   * Three-way-match provenance, `receive-stock.ts` only.
+   */
+  vendorUnitPrice?: number
+}
+
+/** One `stock_movement` this call wrote, back to the caller. */
+export interface WrittenStockMovement {
+  movementId: string
+  /** `<entityDefinitionId>:<instanceId>`. */
+  recordId: string
+  partInstanceId: string
+  quantity: number
+  unitCost: number
+  extendedCost: number
+  glAccount: string | null
+  occurredAt: Date
+}
+
+/** What a `writeStockMovements` call did. */
+export interface WriteStockMovementsResult {
+  /** In the same order as the `inputs` array. */
+  records: WrittenStockMovement[]
+  /**
+   * Distinct `partInstanceId`s across every input. The quiet lane's caller
+   * MUST pass this to `batchRecalculateQoH` after its transaction commits -
+   * §2.4 item 3 is what makes that a structural fact instead of a comment.
+   */
+  affectedPartIds: string[]
+}
+
+/**
+ * Which write lane the movements land on (§2.2 - "must be a parameter and
+ * not a branch"):
+ *
+ * - `'plain'`: the ordinary interactive lane. `mfg-stock-movements-created`
+ *   fires per row and `recalculatePartQoH` updates quantity on hand. Used by
+ *   `receive-stock.ts`, `adjust-stock.ts` and `reverse-movement.ts`.
+ * - `'quiet'`: `txDb` + a `quietSession` + the post-commit recalc obligation
+ *   (`affectedPartIds` above). Used by `complete-build.ts` and
+ *   `reverse-build.ts`, both inside `db.transaction()`.
+ */
+export type StockMovementsLane =
+  | { kind: 'plain' }
+  | {
+      kind: 'quiet'
+      session: WriteSession
+      /**
+       * Builds-only (§2.2): the guard `stock_movement` has no attribute of its
+       * own, so forwarding a build's `bypassFieldGuards` here is inert for
+       * every field this module writes and exists only so the ONE
+       * `UnifiedCrudHandler` a caller might otherwise need per write stays a
+       * single construction site. See `complete-build.ts`'s note on
+       * `bypassFieldGuards`, reproduced verbatim there.
+       */
+      bypassFieldGuards?: ReadonlySet<SystemAttribute>
+    }
+
+/**
+ * `db | tx, organizationId, userId, lane` (50 §2.3), plus the two def ids
+ * every one of the six existing callers already resolves for its own
+ * pre-checks before it ever reaches a write. Passing them in here (rather
+ * than re-resolving inside this module) avoids a second cache round trip and
+ * keeps each caller's own "this organization has no X definition" refusal -
+ * worded and timed exactly as it is today - outside this module entirely.
+ */
+export interface StockMovementsCtx {
+  /** A pool connection for the `'plain'` lane, `tx as unknown as Database` for `'quiet'`. */
+  db: Database
+  organizationId: string
+  userId: string
+  /** `EntityInstance.id` of the org's `stock_movement` entity definition. */
+  movementDefId: string
+  /** `EntityInstance.id` of the org's `part` entity definition. */
+  partDefId: string
+  lane: StockMovementsLane
+  /**
+   * A `UnifiedCrudHandler` this call MUST write through, instead of
+   * constructing its own.
+   *
+   * A caller that makes several `writeStockMovements` calls inside one
+   * quiet-lane write (`complete-build.ts` splits consume from produce so the
+   * produce row's GL account can be resolved after every consume row has
+   * landed) must still route every movement through the SAME handler it
+   * updates its own row with - `build-event.test.ts` pins "one handler
+   * construction per quiet-lane completion" as the proof `bypassFieldGuards`
+   * cannot silently disarm a guard on an attribute nobody meant to bypass.
+   * Omit it and this function constructs its own, exactly as a
+   * single-movement writer (`receive-stock.ts`, `adjust-stock.ts`,
+   * `reverse-movement.ts`) already does.
+   */
+  handler?: UnifiedCrudHandler
+}

--- a/packages/lib/src/stock-movements/values.ts
+++ b/packages/lib/src/stock-movements/values.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/stock-movements/values.ts
+
+/**
+ * The values bag every `stock_movement` writer hands to `UnifiedCrudHandler`.
+ *
+ * 🛑 **The nine keys, in one place.** 50 §2.1: "`stock_movement_adjust_subparts:
+ * false` is written in six separate files, each with its own hand-written
+ * paragraph explaining why." This is that paragraph, once, and the function
+ * every one of the six callers now goes through to get there - the atomic
+ * writers via `write-movements.ts`, `bulk-opening-stock.ts` directly (its
+ * `bulkCreate` cardinality is not part of this module's contract - see §2.2,
+ * which does not name cardinality as a shared axis).
+ */
+
+import { computeExtendedCost } from '../receiving/client'
+import type { RecordId } from '../resources/resource-id'
+
+/** Already-resolved link targets, keyed the way the movement stores them. */
+export interface ResolvedStockMovementLinks {
+  vendorPart?: RecordId
+  purchaseOrderLine?: RecordId
+  build?: RecordId
+  reversesMovement?: RecordId
+  parentMovement?: RecordId
+  fulfillmentLine?: RecordId
+}
+
+/** Everything `buildStockMovementValues` needs, with every link already a `RecordId`. */
+export interface StockMovementValueFields {
+  partRecordId: RecordId
+  type: string
+  quantity: number
+  unitCost: number
+  /** Omit to omit `stock_movement_cost_basis` entirely - see `types.ts`'s header. */
+  costBasis?: string
+  /** Omit to omit `stock_movement_gl_account` entirely - see `types.ts`'s header. */
+  glAccount?: string
+  occurredAt: Date
+  /** Override for `computeExtendedCost(unitCost, quantity)`. See `StockMovementInput.extendedCost`. */
+  extendedCost?: number
+  adjustSubparts?: true
+  reason?: string
+  reference?: string
+  qtyPerUnit?: number | null
+  vendorUnitPrice?: number
+  links?: ResolvedStockMovementLinks
+}
+
+/**
+ * Build the values bag for one `stock_movement` create.
+ *
+ * 🛑 **`stock_movement_adjust_subparts` is ALWAYS present and is `true` only
+ * when the caller explicitly opted in.** `explodeBomMovement` inherits the
+ * parent movement's type AND its sign, so a `true` on the wrong writer
+ * cascades a receipt, an adjustment, a build leg or a reversal through the
+ * bill of materials - six separate defects this default exists to close at
+ * once (50 §2.1, §2.4 item 1).
+ *
+ * **The sign convention has one owner.** `extendedCost` is
+ * `computeExtendedCost(unitCost, quantity)` unless the caller supplies its
+ * own - the one documented override `complete-build.ts`'s negated
+ * `build_consume` row needs, because deriving it from
+ * `round(unitCost x -consumed)` instead can differ from
+ * `-round(unitCost x consumed)` on a half-cent tail (`Math.round` breaks ties
+ * toward positive infinity). §2.2, §2.4 item 2.
+ */
+export function buildStockMovementValues(
+  fields: StockMovementValueFields
+): Record<string, unknown> {
+  const {
+    partRecordId,
+    type,
+    quantity,
+    unitCost,
+    costBasis,
+    glAccount,
+    occurredAt,
+    extendedCost,
+    adjustSubparts,
+    reason,
+    reference,
+    qtyPerUnit,
+    vendorUnitPrice,
+    links,
+  } = fields
+
+  const values: Record<string, unknown> = {
+    stock_movement_part: partRecordId,
+    stock_movement_type: type,
+    stock_movement_quantity: quantity,
+    stock_movement_adjust_subparts: adjustSubparts === true,
+    stock_movement_unit_cost: unitCost,
+    stock_movement_extended_cost: extendedCost ?? computeExtendedCost(unitCost, quantity),
+    stock_movement_occurred_at: occurredAt.toISOString(),
+  }
+
+  if (costBasis !== undefined) values.stock_movement_cost_basis = costBasis
+  if (glAccount !== undefined) values.stock_movement_gl_account = glAccount
+  if (reason) values.stock_movement_reason = reason
+  if (reference) values.stock_movement_reference = reference
+  if (vendorUnitPrice != null) values.stock_movement_vendor_unit_price = vendorUnitPrice
+  // NULL is the off-BOM marker and is written as an absence, not a zero.
+  if (qtyPerUnit != null) values.stock_movement_qty_per_unit = qtyPerUnit
+
+  if (links?.vendorPart) values.stock_movement_vendor_part = links.vendorPart
+  if (links?.purchaseOrderLine) values.stock_movement_purchase_order_line = links.purchaseOrderLine
+  if (links?.build) values.stock_movement_build = links.build
+  if (links?.reversesMovement) values.stock_movement_reverses_movement = links.reversesMovement
+  if (links?.parentMovement) values.stock_movement_parent_movement = links.parentMovement
+  if (links?.fulfillmentLine) values.stock_movement_fulfillment_line = links.fulfillmentLine
+
+  return values
+}

--- a/packages/lib/src/stock-movements/write-movements.ts
+++ b/packages/lib/src/stock-movements/write-movements.ts
@@ -1,0 +1,227 @@
+// packages/lib/src/stock-movements/write-movements.ts
+
+/**
+ * `writeStockMovements` - the ONE writer behind `receive-stock.ts`,
+ * `adjust-stock.ts`, `reverse-movement.ts`, `complete-build.ts` and
+ * `reverse-build.ts` (plans/money/tasks/50-batch-inventory-relief.md §2).
+ *
+ * `bulk-opening-stock.ts` is the sixth caller and deliberately does NOT go
+ * through this function: its cardinality is `UnifiedCrudHandler.bulkCreate`
+ * with per-INDEX failure tolerance (one bad part must not lose the other
+ * 494), which §2.2 does not name as a shared axis. It still shares
+ * `buildStockMovementValues` (`values.ts`) for the nine keys and the sign
+ * convention, so the ONE rule six files used to restate by hand
+ * (`adjustSubparts` defaults false) has one definition regardless.
+ *
+ * ## What is a parameter here, never a branch (§2.2)
+ *
+ * - **The lane** - `ctx.lane`. `'plain'` constructs
+ *   `new UnifiedCrudHandler(organizationId, userId, db)` exactly as
+ *   `receive-stock.ts` / `adjust-stock.ts` / `reverse-movement.ts` do today
+ *   (no session override, no `bypassFieldGuards`). `'quiet'` adds the
+ *   session and the builds-only `bypassFieldGuards` - see `types.ts`.
+ * - **`bypassFieldGuards`** rides on the quiet lane only, and is inert here:
+ *   `stock_movement` has no attribute it would ever bypass. It is threaded
+ *   through purely so `complete-build.ts` and `reverse-build.ts` do not need
+ *   a second `UnifiedCrudHandler` construction site for their movement
+ *   writes.
+ * - **The typed links** - resolved here, once, from bare
+ *   `EntityInstance.id`s. §2.4 item 4: a reversal (or any future writer)
+ *   copies the WHOLE link set rather than a hand-listed subset, because
+ *   there is exactly one place that knows how to turn a link into a
+ *   `RecordId`.
+ * - **`extendedCost`** - computed here from `computeExtendedCost`, unless
+ *   the caller supplies the override (`values.ts`).
+ *
+ * `affectedPartIds` comes back from every call (§2.4 item 3): the quiet
+ * lane's caller passes it to `batchRecalculateQoH` after its transaction
+ * commits, and the set is a fact about what was WRITTEN, not something the
+ * caller re-derives and could get out of sync.
+ */
+
+import type { Result } from 'neverthrow'
+import { getCachedEntityDefId } from '../cache'
+import { UnprocessableEntityError } from '../errors'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import { isRecordId, type RecordId, toRecordId } from '../resources/resource-id'
+import { guard } from './guard'
+import type {
+  StockMovementInput,
+  StockMovementLinks,
+  StockMovementsCtx,
+  WriteStockMovementsResult,
+  WrittenStockMovement,
+} from './types'
+import { buildStockMovementValues, type ResolvedStockMovementLinks } from './values'
+
+/** The entity type a bare link id resolves against, for every link but the two that point at a `stock_movement` itself. */
+const LINK_ENTITY_TYPES = {
+  vendorPartId: 'vendor_part',
+  purchaseOrderLineId: 'purchase_order_line',
+  buildId: 'build',
+  fulfillmentLineId: 'fulfillment_line',
+} as const
+
+/**
+ * Resolve one bare link id to a `RecordId`, or pass an already-built
+ * `RecordId` through unchanged - a caller that already resolved its OWN def
+ * id (a build's own field context, for instance) is not made to resolve it
+ * twice, and cannot disagree with itself by doing so.
+ *
+ * Throws `UnprocessableEntityError` naming the entity type when the org has
+ * no such definition - the exact refusal `receive-stock.ts` and
+ * `reverse-movement.ts` each hand-rolled as their own `requireDefId` before
+ * this extraction.
+ */
+async function resolveLinkId(
+  organizationId: string,
+  entityType: string,
+  value: string
+): Promise<RecordId> {
+  if (isRecordId(value)) return value
+  const defId = await getCachedEntityDefId(organizationId, entityType)
+  if (!defId) {
+    throw new UnprocessableEntityError(
+      `This organization has no ${entityType} entity definition yet`
+    )
+  }
+  return toRecordId(defId, value)
+}
+
+/**
+ * `reversesMovementId` / `parentMovementId` point at a `stock_movement`
+ * itself - the def id this call is ALREADY writing against, so no second
+ * cache lookup is needed or made.
+ */
+function resolveMovementLinkId(movementDefId: string, value: string): RecordId {
+  return isRecordId(value) ? value : toRecordId(movementDefId, value)
+}
+
+async function resolveLinks(
+  ctx: StockMovementsCtx,
+  links: StockMovementLinks | undefined
+): Promise<ResolvedStockMovementLinks | undefined> {
+  if (!links) return undefined
+  const resolved: ResolvedStockMovementLinks = {}
+
+  if (links.vendorPartId) {
+    resolved.vendorPart = await resolveLinkId(
+      ctx.organizationId,
+      LINK_ENTITY_TYPES.vendorPartId,
+      links.vendorPartId
+    )
+  }
+  if (links.purchaseOrderLineId) {
+    resolved.purchaseOrderLine = await resolveLinkId(
+      ctx.organizationId,
+      LINK_ENTITY_TYPES.purchaseOrderLineId,
+      links.purchaseOrderLineId
+    )
+  }
+  if (links.buildId) {
+    resolved.build = await resolveLinkId(
+      ctx.organizationId,
+      LINK_ENTITY_TYPES.buildId,
+      links.buildId
+    )
+  }
+  if (links.fulfillmentLineId) {
+    resolved.fulfillmentLine = await resolveLinkId(
+      ctx.organizationId,
+      LINK_ENTITY_TYPES.fulfillmentLineId,
+      links.fulfillmentLineId
+    )
+  }
+  if (links.reversesMovementId) {
+    resolved.reversesMovement = resolveMovementLinkId(ctx.movementDefId, links.reversesMovementId)
+  }
+  if (links.parentMovementId) {
+    resolved.parentMovement = resolveMovementLinkId(ctx.movementDefId, links.parentMovementId)
+  }
+
+  return resolved
+}
+
+/**
+ * The one `UnifiedCrudHandler` every input in this call writes through -
+ * `ctx.handler` when the caller supplied one (see its doc comment), else a
+ * fresh construction from the lane.
+ */
+function buildHandler(ctx: StockMovementsCtx): UnifiedCrudHandler {
+  if (ctx.handler) return ctx.handler
+  if (ctx.lane.kind === 'quiet') {
+    return new UnifiedCrudHandler(ctx.organizationId, ctx.userId, ctx.db, undefined, {
+      session: ctx.lane.session,
+      bypassFieldGuards: ctx.lane.bypassFieldGuards,
+    })
+  }
+  return new UnifiedCrudHandler(ctx.organizationId, ctx.userId, ctx.db)
+}
+
+/**
+ * Write one or more `stock_movement` rows, atomically in the sense that every
+ * write shares one `UnifiedCrudHandler` and the caller decides the
+ * transaction boundary (§2's "no lane changes" - this function never opens
+ * its own transaction). A create that throws partway through propagates as
+ * `Err` and leaves whatever the caller's own transaction (if any) rolls back.
+ *
+ * Call it once per row for a single-movement writer (`receive-stock.ts`,
+ * `adjust-stock.ts`, `reverse-movement.ts`), once with the whole batch for a
+ * writer whose rows carry no live, order-dependent computation between them
+ * (`reverse-build.ts`), or split across calls when a value genuinely can only
+ * be known after an earlier write has landed (`complete-build.ts`'s produce
+ * row, whose GL account is resolved after every consume row is written -
+ * see that file's own comment for why the split is load-bearing there).
+ */
+export async function writeStockMovements(
+  ctx: StockMovementsCtx,
+  inputs: StockMovementInput[]
+): Promise<Result<WriteStockMovementsResult, Error>> {
+  return guard(
+    async () => {
+      const crud = buildHandler(ctx)
+      const records: WrittenStockMovement[] = []
+      const affectedPartIds = new Set<string>()
+
+      for (const input of inputs) {
+        const links = await resolveLinks(ctx, input.links)
+        const partRecordId = toRecordId(ctx.partDefId, input.partInstanceId)
+
+        const values = buildStockMovementValues({
+          partRecordId,
+          type: input.type,
+          quantity: input.quantity,
+          unitCost: input.unitCost,
+          costBasis: input.costBasis,
+          glAccount: input.glAccount,
+          occurredAt: input.occurredAt,
+          extendedCost: input.extendedCost,
+          adjustSubparts: input.adjustSubparts,
+          reason: input.reason,
+          reference: input.reference,
+          qtyPerUnit: input.qtyPerUnit,
+          vendorUnitPrice: input.vendorUnitPrice,
+          links,
+        })
+
+        const created = await crud.create(ctx.movementDefId, values)
+
+        records.push({
+          movementId: created.instance.id,
+          recordId: toRecordId(ctx.movementDefId, created.instance.id),
+          partInstanceId: input.partInstanceId,
+          quantity: input.quantity,
+          unitCost: input.unitCost,
+          extendedCost: values.stock_movement_extended_cost as number,
+          glAccount: input.glAccount ?? null,
+          occurredAt: input.occurredAt,
+        })
+        affectedPartIds.add(input.partInstanceId)
+      }
+
+      return { records, affectedPartIds: [...affectedPartIds] }
+    },
+    'Failed to write stock movements',
+    { organizationId: ctx.organizationId, count: inputs.length }
+  )
+}

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -149,6 +149,28 @@ export interface ToolActionContext {
  * inverse into EXISTING orgs, so these are not union entries that no org
  * resolves. Nothing WRITES to either yet - the ShipStation connector comes
  * next - but the defs resolve, which is what `provisionAppField` needs.
+ *
+ * `fulfillment` and `fulfillment_line` were ADDED 2026-09-11
+ * (plans/money/tasks/55-shipment-lines.md §3, §5). They follow `credit_memo_line`
+ * and `tax_line`'s precedent exactly: both are `isVisible: false`, they render
+ * inside their parent order, and they are admitted PRECISELY so a channel
+ * connector can address them. The Shopify connector holds every
+ * `(fulfillment.id, created_at, line_item_id, quantity)` tuple and today
+ * collapses them to a per-line min/max date and a sum; these two kinds are what
+ * let it stop doing that.
+ *
+ * `fulfillment_line` also repeats `tax_line`'s synthetic-key situation for the
+ * same reason: the REST `fulfillment.line_items[]` rows ship no id of their
+ * own, so identity is `${fulfillmentId}:${lineItemId}` - both halves real
+ * Shopify ids, which is a stronger key than the tax line's
+ * `${orderId}:${title}`.
+ *
+ * They satisfy the standing condition: entity migration `153` seeds both defs,
+ * their fields, and the retyped `order_fulfillments` inverse into EXISTING
+ * orgs, so these are not union entries that no org resolves. ⚠️ Note `153`
+ * DROPS the JSON `order_fulfillments` field and recreates it as a has_many to
+ * `fulfillment` - the attribute keeps its name and changes type, which is an
+ * owner decision recorded in 55's header, not an accident.
  */
 export type EntityRefKind =
   | 'contact'
@@ -172,6 +194,8 @@ export type EntityRefKind =
   | 'tax_line'
   | 'shipment'
   | 'parcel'
+  | 'fulfillment'
+  | 'fulfillment_line'
 
 /**
  * Per-tool configuration. See plans/kopilot/apps/README.md §4.2.

--- a/packages/types/resource/utils.ts
+++ b/packages/types/resource/utils.ts
@@ -186,6 +186,11 @@ export const ENTITY_DEFINITION_TYPES = [
   // RecordId canonicalizes to the org's def CUID like every other entry here.
   'shipment',
   'parcel',
+  // plans/money/tasks/55-shipment-lines.md. EntityInstance-backed, so a
+  // `fulfillment:<id>` / `fulfillment_line:<id>` relationship RecordId
+  // canonicalizes to the org's def CUID like every other entry here.
+  'fulfillment',
+  'fulfillment_line',
 ] as const
 
 /** Type for system entity types stored in EntityDefinition */

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -362,6 +362,7 @@ export const SYSTEM_ATTRIBUTES = [
   'line_item_part', // stamped from the line's catalog item, not hand-set (08 §6.2)
   'line_item_photos', // scouting/line-level photos (plan 37b §1)
   'line_item_credit_memo_lines', // inverse of credit_memo_line_line_item (accounting/10 §2.2)
+  'line_item_fulfillment_lines', // inverse of fulfillment_line_line_item (plans/money/tasks/55)
 
   // ─── Catalog Item fields ────────────────────────────────────────
   'catalog_item_name',
@@ -481,13 +482,15 @@ export const SYSTEM_ATTRIBUTES = [
   'order_tax_lines', // inverse of tax_line_order
   'order_credit_memos', // inverse of credit_memo_order (accounting/10 §2.1)
   'order_work_orders', // inverse of work_order_order
-  // Added by migration 125 (plans/accounting/HANDOFF.md slot 2G). The
-  // shipment log `money.fulfillOrder` appends to, and the ONLY thing that
-  // makes "how much of this line is still to ship" answerable. JSON on the
-  // order rather than a `fulfillment` entity for the reason
-  // `journal_entry_lines` is JSON: a shipment has no independent identity,
-  // nothing links to it, and the accounting copy is already normalised in
-  // `GlPostingLine`.
+  // Added by migration 125 as a JSON array (plans/accounting/HANDOFF.md slot
+  // 2G). 🛑 Entity migration 153 (plans/money/tasks/55) DROPS that JSON field
+  // and recreates the SAME systemAttribute as a RELATIONSHIP has_many to the
+  // new `fulfillment` entity - the owner's call was to keep the name and
+  // change the type, so a `fulfillment_order` belongs_to is now the inverse
+  // rather than a raw JSON cell. The premises behind the original JSON choice
+  // (no independent identity, nothing links to it) are exactly what this
+  // migration invalidates: Shopify assigns every fulfillment an id, and
+  // `stock_movement` now links to a `fulfillment_line`.
   'order_fulfillments',
   // Added by entity migration 149. Inverse of `shipment_order`
   // (plans/apps/shipstation/shared-shipment-entities-proposal.md §6). One
@@ -593,6 +596,9 @@ export const SYSTEM_ATTRIBUTES = [
   'stock_movement_purchase_order_line',
   'stock_movement_reverses_movement', // NOT parentMovement — that means BOM explosion
   'stock_movement_reversed_by_movements',
+  // Nullable, updatable: false, filterable: true - all of task 50's netting
+  // (plans/money/tasks/55). Mirrors stock_movement_purchase_order_line.
+  'stock_movement_fulfillment_line',
   'vendor_part_stock_movements', // inverse of stock_movement_vendor_part
 
   // ─── Purchase order ─────────────────────────────────────────────
@@ -1143,6 +1149,40 @@ export const SYSTEM_ATTRIBUTES = [
   'parcel_delivered_at',
   'parcel_received_by', // signature name, when the carrier reports one
   'parcel_shipment', // inverse of shipment_parcels
+
+  // ─── Fulfillment and fulfillment line (plans/money/tasks/55) ────
+  // Replaces `order_fulfillments` as a JSON array with real records, so
+  // revenue posts from a row instead of a collapsed min/max/sum. Both hidden
+  // (`isVisible: false`), no route folder. Entity migration 153.
+  'fulfillment_order', // owning side; inverse of order_fulfillments (same name, new type)
+  'fulfillment_sequence', // 1-based within the order, ship-date order
+  'fulfillment_shipped_at', // THE accounting date; never Shopify's updated_at
+  'fulfillment_status', // open | success | cancelled | error | failure, mirrors Shopify
+  'fulfillment_cancelled_at', // when a relief reversal is written; not shippedAt
+  'fulfillment_name', // the display field; nullable in type, never absent in practice
+  'fulfillment_tracking_number',
+  'fulfillment_tracking_company',
+  'fulfillment_tracking_url',
+  'fulfillment_subtotal', // integer minor units; was subtotalMinor
+  'fulfillment_total', // integer minor units; was totalMinor
+  'fulfillment_shipping_recognised', // freight recognised once, on the first dispatch
+  // TEXT, not a RELATIONSHIP - GlPosting is a Drizzle table with no
+  // EntityDefinition to point at. credit_memo_gl_posting is the precedent.
+  'fulfillment_gl_posting',
+  'fulfillment_doc_number',
+  'fulfillment_recorded_at',
+  'fulfillment_lines', // inverse of fulfillment_line_fulfillment, has_many, onDelete cascade
+  // Nullable, one-sided belongs_to the logistics fact (brief §2.2) - opportunistic
+  // tracking-number match, no field on shipment points back, and nothing in
+  // relief or posting may read it.
+  'fulfillment_shipment',
+  'fulfillment_line_fulfillment', // owning side; inverse of fulfillment_lines
+  'fulfillment_line_line_item', // owning side; inverse of line_item_fulfillment_lines
+  'fulfillment_line_quantity', // units shipped in THIS dispatch, never cumulative
+  // COMPUTED, re-SUMmed over stock_movement_fulfillment_line - the exact
+  // mirror of purchase_order_line_quantity_received.
+  'fulfillment_line_quantity_relieved',
+  'fulfillment_line_stock_movements', // inverse of stock_movement_fulfillment_line
 ] as const
 
 /** Union type of all valid system attribute identifiers */


### PR DESCRIPTION
Wave 1 of [brief 55](plans/money/tasks/55-shipment-lines.md) and [brief 50](plans/money/tasks/50-batch-inventory-relief.md). **Not a working feature yet** - see "What is NOT here".

## Why

`completeBuild` adds units to finished goods and nothing takes them out when they ship. `StockMovementType.SALE` appears exactly once in `packages/lib/src`, as the reversal target of a movement nobody produces. Because quantity on hand is a full re-SUM of the movement ledger, **on-hand is inflated by every unit ever sold, today.** That is an operations defect, not only an accounting one.

Relief needs to know which units of a line went out when. Chasing that found the real blocker: the Shopify connector already receives per-fulfillment line quantities and dates for every merchant, and `deriveFulfillments` collapses them to a per-line min/max date and a sum. `shipment_count` is literally a counter of the tuples being discarded.

The consequence is not cosmetic. For a merchant who ships a line in installments - 10 units of a made-to-order item, shipped as they come off the line - `derive-log.ts` holds out **the whole order**, so no log is written, no revenue posts and no inventory is relieved, **silently** (`heldOut` is a log counter no screen reads). The hold-out is load-bearing: remove it and the log pairs the *first* dispatch date with the *cumulative* quantity, recognising 5 units dated Sep 1 for a line that shipped 1 on Sep 1 and 4 on Sep 20.

## What is here

**`101e7ad47` - `fulfillment` / `fulfillment_line` entities, entity migration 153**

`order_fulfillments` keeps its name and changes type: the JSON cell on `order` is dropped and recreated as a has_many. The field's own docblock justified JSON with *"a shipment has no independent identity, nothing links to it"* - both clauses are now false, since Shopify assigns every fulfillment an id and `stock_movement_fulfillment_line` links to the line.

`FulfillmentStatus` carries six values, not the five the brief originally specified: `pending` is in Shopify's lifecycle and the connector passes `status` through unmapped. A SINGLE_SELECT write with no matching option is not loudly refused here, so a missing member would have been silent.

The registration surface is eleven files. Two fail silently if missed: `packages/types/resource/utils.ts` (RecordId canonicalization) and `seed/entity-seeder/create-fields.ts`, a **second** `FIELD_REGISTRY` the fresh-org seeder iterates - a missing entry there seeds a zero-field def on every new org.

**`c58a2afa0` - one shared `stock_movement` writer**

Pure extraction, no behaviour change, prerequisite of adding a seventh movement kind. `stock_movement_adjust_subparts: false` was written in six separate files, each with its own paragraph explaining why, and each right about a different failure. It now defaults to false, with `true` an opt-in carrying a reason. The sign convention has one owner, and the post-commit recalc obligation is returned as `affectedPartIds` rather than remembered.

Acceptance bar was that every existing test pass **unedited**: 926 tests across 47 files, zero test files touched. Four documented deviations from the plan's contract, one of which (`costBasis`/`glAccount` made optional) is logged as an open question in brief 50.

**`acf8ccb52` - SDK `EntityRefKind`**

Both kinds admitted on the precedent the union already records for `credit_memo_line` and `tax_line`. Note for the next person adding a kind: the apps repo links this package by path and consumes built `lib/`, so a source edit does not reach a connector until `pnpm --filter @auxx/sdk build`; and `removeComments: true` means the union's reasoning never reaches app authors, so `docs/app-fields-and-entities-guide.md` §3 (which transcribes it by hand) had to be updated too.

**`90e13c48e` - returns work from brief 54, NOT part of this change**

Someone else's uncommitted work, preserved because it was sitting untracked in a shared tree after that agent stopped. Incomplete and unwired. See the caveat below.

## What is NOT here

**Every reader in `money/` and `events/` still uses the JSON path.** `derive-log.ts` still derives, `parseFulfillments` still exists, `fulfillOrder` still writes JSON, pass 6 still calls `deriveFulfillmentLog`. Brief 55 §6 is untouched, and it is the largest and riskiest piece.

Brief 50 has only its extraction: no `relieveFulfillmentLines`, no `quantity_relieved` roll-up hook, no ledger-average read, no backfill dialog.

## Do not apply migration 153 yet

There is no interim state where both representations work, and **no automated signal tells you that you are in one.** Measured after this branch: the ratchet reports no new errors from the retype and `vitest run src/money src/events` passes 1228 tests. Field access is untyped at the boundary and the money tests mock the field layer, so neither can see the registry moved.

The failure mode is runtime and silent: the pass would write `{ fulfillments: [...] }` into a relationship field, and `setFieldValues` **logs and swallows** a mis-shaped write, so revenue would post from an empty log and report success.

The §6 worklist is therefore the grep - 40 non-test references across 14 files - and nothing else will produce it.

Also owed before any re-sync, per 55 §4: reset accounting first. On dev, 26 `fulfillment` GlPostings all carry a `providerEntryId`. Production must be checked separately.

## Known red

The returns commit introduces **4 typecheck-ratchet failures**, all in `return-fields.ts` / `return-line-fields.ts` / `return-part-line-fields.ts`: they declare ~50 `systemAttribute` strings never added to the union, because that agent stopped before wiring them. Pre-existing, not caused by committing them. Accepted for now by the owner. The other three commits are clean - the ratchet read 27/27 immediately before that commit, and the returns tests pass (101).

## Verification

- `typecheck-ratchet --package lib`: clean for the three fulfillment commits; 4 new locations from the returns commit only
- `vitest run src/receiving src/builds src/bom src/returns src/resources/registry src/data-migrations`: **1484 passing**
- `vitest run src/money src/events`: **1228 passing**
- Shopify connector (separate repo, `auxxai-apps`, not in this PR): 20 tests passing

https://claude.ai/code/session_01QrDpYX6rVuQyN7gQQNDvnb
